### PR TITLE
Resolves race condition with waitpid(0)

### DIFF
--- a/src/bldr/discovery/mod.rs
+++ b/src/bldr/discovery/mod.rs
@@ -231,7 +231,7 @@ impl DiscoveryWatcher {
     // Stop the watch. Sends the signal to the backend thread to stop itself cleanly.
     fn stop(&mut self) {
         let tx = self.tx.as_ref().unwrap();
-        tx.send(true).unwrap();
+        let _result = tx.send(true);
     }
 
     // Check for a response from a watch.
@@ -367,7 +367,7 @@ impl DiscoveryWriter {
     // Sends the appropriate signal to the writer thread.
     fn stop(&mut self) {
         let tx = self.tx.as_ref().unwrap();
-        tx.send(true).unwrap();
+        let _result = tx.send(true);
     }
 
     // Check for a response to a write.

--- a/src/bldr/pkg.rs
+++ b/src/bldr/pkg.rs
@@ -354,7 +354,10 @@ impl Package {
         let res = self.signal(Signal::Status);
         match res {
             Ok(_) => return true,
-            Err(_) => return false,
+            Err(e) => {
+                debug!("Supervisor not running?: {:?}", e);
+                return false
+            },
         }
     }
 

--- a/src/bldr/sidecar.rs
+++ b/src/bldr/sidecar.rs
@@ -48,7 +48,7 @@ fn health(sidecar: &Sidecar, _req: &mut Request) -> IronResult<Response> {
 
 pub fn run(pkg: &str) -> BldrResult<()> {
     let pkg_name = String::from(pkg);
-    thread::spawn(move || -> BldrResult<()> {
+    try!(thread::Builder::new().name(String::from("sidecar")).spawn(move || -> BldrResult<()> {
         // The sidecar is in an Arc. The clones are
         // creating instances to share, and when they all go away, we'll
         // reap the instance. Turns out they won't really ever go away,
@@ -65,7 +65,7 @@ pub fn run(pkg: &str) -> BldrResult<()> {
 
         Iron::new(router).http("0.0.0.0:9631").unwrap();
         Ok(())
-    });
+    }));
     Ok(())
 }
 

--- a/src/bldr/topology/leader.rs
+++ b/src/bldr/topology/leader.rs
@@ -284,10 +284,10 @@ fn state_leader(worker: &mut Worker) -> BldrResult<(State, u32)> {
         try!(worker.package.configure());
         try!(standalone::state_starting(worker));
         let watch_package = worker.package.clone();
-        let configuration_thread = thread::spawn(move || -> BldrResult<()> {
+        let configuration_thread = try!(thread::Builder::new().name(String::from("configuration")).spawn(move || -> BldrResult<()> {
             try!(watch_package.watch_configuration());
             Ok(())
-        });
+        }));
         worker.configuration_thread = Some(configuration_thread);
     }
 
@@ -315,10 +315,10 @@ fn state_follower(worker: &mut Worker) -> BldrResult<(State, u32)> {
         try!(worker.package.configure());
         try!(standalone::state_starting(worker));
         let watch_package = worker.package.clone();
-        let configuration_thread = thread::spawn(move || -> BldrResult<()> {
+        let configuration_thread = try!(thread::Builder::new().name(String::from("configuration")).spawn(move || -> BldrResult<()> {
             try!(watch_package.watch_configuration());
             Ok(())
-        });
+        }));
         worker.configuration_thread = Some(configuration_thread);
     }
     Ok((State::Follower, 0))

--- a/src/bldr/topology/mod.rs
+++ b/src/bldr/topology/mod.rs
@@ -246,7 +246,7 @@ fn run_internal<'a>(sm: &mut StateMachine<State, Worker<'a>, BldrError>, worker:
                 unsafe {
                     let mut status: c_int = 0;
                     let supervisor_pid = worker.supervisor_id.unwrap() as pid_t;
-                    match waitpid(0 as pid_t, &mut status, 1 as c_int) {
+                    match waitpid(supervisor_pid, &mut status, 1 as c_int) {
                         0 => {}, // Nothing returned,
                         pid if pid == supervisor_pid => {
                             if WIFEXITED(status) {
@@ -265,12 +265,12 @@ fn run_internal<'a>(sm: &mut StateMachine<State, Worker<'a>, BldrError>, worker:
                         pid => {
                             if WIFEXITED(status) {
                                 let exit_code = WEXITSTATUS(status);
-                                println!("   {}: Process {} died with exit code {}", worker.preamble(), pid, exit_code);
+                                debug!("   {}: Process {} died with exit code {}", worker.preamble(), pid, exit_code);
                             } else if WIFSIGNALED(status) {
                                 let exit_signal = WTERMSIG(status);
-                                println!("   {}: Process {} terminated with signal {}", worker.preamble(), pid, exit_signal);
+                                debug!("   {}: Process {} terminated with signal {}", worker.preamble(), pid, exit_signal);
                             } else {
-                                println!("   {}: Process {} died, but I don't know how.", worker.preamble(), pid);
+                                debug!("   {}: Process {} died, but I don't know how.", worker.preamble(), pid);
                             }
                         }
                     }

--- a/src/bldr/util/signals.rs
+++ b/src/bldr/util/signals.rs
@@ -104,9 +104,9 @@ impl SignalNotifier {
     pub fn start() -> SignalNotifier {
         let (otx, orx): (Sender<Signal>, Receiver<Signal>) = mpsc::channel();
         let (itx, irx) = mpsc::channel();
-        let handle = thread::spawn(move || {
+        let handle = thread::Builder::new().name(String::from("signal_handler")).spawn(move || {
             SignalNotifier::init(otx, irx)
-        });
+        }).unwrap();
         SignalNotifier::new(itx, orx, handle)
     }
 


### PR DESCRIPTION
Bldr has multiple threads going at once. The main thread is running an
event loop that includes a call to `waitpid(0)`, which means wait for
every any child that exits. In a seperate thread, most commonly the
`configuration` thread that watches for filesystem change events for
service reconfiguration, we then execute commands and call rusts
`output()` function. This function calls `waitpid(PID)`, which then
races with the main thread - if the main thread reaps the child before
`output()` can reach it, the thread rust spawns to read the output
panics.

Debugging this required dropping in to `rust-gdb` and doing fun thread
gymnastics. As a side-effect, I've moved all of our calls to
`thread::spawn` to use the `thread::Builder` interface, and set a custom
name per-thread - so you at least have a chance to understand precisely
what thread was the issue.

If anyone needs to do this in the future, you can debug thread panics
with:

``` bash
  $ gdb
  > rbreak rust_panic
  # stuff happens
  > info threads
```

Will get you the goods. Good luck, thread hunters!

Love,
Adam
