### PR TITLE
Explicitly name bldr_etcd_1 container name in docker-compose.yml.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,7 @@ base:
     - etcd
 
 etcd:
+  container_name: bldr_etcd_1
   image: quay.io/coreos/etcd:latest
   ports:
     - "4001:4001"


### PR DESCRIPTION
As a developer, if I clone this project to directory who's name is _not_
named `bldr`, then docker-compose will choose a different name for the
etcd container. This is currently a problem as the functional tests
required an explicit `--link bldr_etcd_1` when running certain topology
tests. Rather than revist this too deeply at the moment, settting a
clear, consistent name for etcd seems like a reasonable approach.
