### PR TITLE
The shasum for cacerts.pem changed which caused 'make' to fail

### DIFF
--- a/packages/cacerts/Bldrfile
+++ b/packages/cacerts/Bldrfile
@@ -3,7 +3,7 @@ pkg_version=
 pkg_license=('MPL1.1 GPLv2.0 LGPLv2.1')
 pkg_source=http://curl.haxx.se/ca/cacert.pem
 pkg_filename=cacert.pem
-pkg_shasum=6d45a0555cc3006bb5340f7d9da02e7ae22f910b4824b281042805966e703cfe
+pkg_shasum=8b9352512e928e59b4fd6e1bcd7ba77a5313f6ae9348657ed88dac4498ee0e43
 pkg_gpg_key=3853DA6B
 
 unpack() {


### PR DESCRIPTION
Closes #17
