### PR TITLE
Communicate over unix domain socket for "Docker in Docker" contexts.

### DIFF
--- a/.delivery/cookbooks/bldr/.kitchen.yml
+++ b/.delivery/cookbooks/bldr/.kitchen.yml
@@ -10,6 +10,8 @@ provisioner:
     delivery:
       workspace:
         repo: /workspace
+    delivery_builder:
+      build_user: root
 
 platforms:
   - name: ubuntu-15.04

--- a/.delivery/cookbooks/bldr/recipes/default.rb
+++ b/.delivery/cookbooks/bldr/recipes/default.rb
@@ -26,15 +26,11 @@ compose_url = "https://github.com/docker/compose/releases/download/#{compose_ver
 include_recipe 'build-essential'
 
 docker_service 'default' do
-  host 'tcp://0.0.0.0:2376'
+  host 'unix:///var/run/docker.sock'
   action [:create, :start]
 end
 
-execute 'docker info' do
-  environment({
-    'DOCKER_HOST' => "tcp://#{node['ipaddress']}:2376"
-  })
-end
+execute 'docker info'
 
 remote_file '/usr/bin/docker-compose' do
   source compose_url
@@ -44,3 +40,9 @@ remote_file '/usr/bin/docker-compose' do
 end
 
 execute 'docker-compose version'
+
+# add build user to the docker group to access the domain socket
+group 'docker' do
+  append true
+  members Array(node['delivery_builder']['build_user'])
+end

--- a/.delivery/cookbooks/bldr/recipes/functional.rb
+++ b/.delivery/cookbooks/bldr/recipes/functional.rb
@@ -1,16 +1,11 @@
-env = { 'DOCKER_HOST' => "tcp://#{node['ipaddress']}:2376" }
 workspace = node['delivery']['workspace']['repo']
 
 execute 'make volume-clean all' do
   cwd workspace
-  environment env
 end
 
-execute "docker ps -a -f 'name=bldr-*'" do
-  environment env
-end
+execute "docker ps -a -f 'name=bldr-*'"
 
 execute 'make functional' do
   cwd workspace
-  environment env
 end

--- a/.delivery/cookbooks/bldr/recipes/unit.rb
+++ b/.delivery/cookbooks/bldr/recipes/unit.rb
@@ -16,19 +16,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-env = { 'DOCKER_HOST' => "tcp://#{node['ipaddress']}:2376" }
 workspace = node['delivery']['workspace']['repo']
 
 execute 'make volume-clean volumes container' do
   cwd workspace
-  environment env
 end
 
-execute "docker ps -a -f 'name=bldr-*'" do
-  environment env
-end
+execute "docker ps -a -f 'name=bldr-*'"
 
 execute 'make unit' do
   cwd workspace
-  environment env
 end

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+.delivery

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ package-clean:
 	docker-compose run package bash -c 'rm -rf /opt/bldr/pkgs/*'
 
 packages: package-clean
-	docker-compose run -e DOCKER_HOST=${DOCKER_HOST} package bash -c 'cd /src/packages; make world'
+	docker-compose run package bash -c 'cd /src/packages; make world'
 
 volume-clean: pkg-cache-volume-clean key-cache-volume-clean cargo-volume-clean installed-cache-volume-clean src-cache-volume-clean
 
@@ -52,20 +52,20 @@ container:
 	docker build -t chef/bldr --no-cache=${NO_CACHE} .
 
 test:
-	docker-compose run -e DOCKER_HOST=${DOCKER_HOST} package cargo test
+	docker-compose run package cargo test
 
 unit:
-	docker-compose run -e DOCKER_HOST=${DOCKER_HOST} package cargo test --lib
+	docker-compose run package cargo test --lib
 
 functional:
-	docker-compose run -e DOCKER_HOST=${DOCKER_HOST} package cargo test --test functional
+	docker-compose run package cargo test --test functional
 
 cargo-clean:
-	docker-compose run -e DOCKER_HOST=${DOCKER_HOST} package cargo clean
+	docker-compose run package cargo clean
 
 docs:
-	docker-compose run -e DOCKER_HOST=${DOCKER_HOST} package cargo doc
-	docker-compose run -e DOCKER_HOST=${DOCKER_HOST} package rustdoc --crate-name bldr README.md -o ./target/doc/bldr
+	docker-compose run package cargo doc
+	docker-compose run package rustdoc --crate-name bldr README.md -o ./target/doc/bldr
 	docco -e .sh -o target/doc/bldr/bldr-build packages/bldr-build
 	cp -r images ./target/doc/bldr
 	echo '<meta http-equiv=refresh content=0;url=bldr/index.html>' > target/doc/index.html
@@ -78,7 +78,7 @@ shell:
 	docker-compose run bldr bash
 
 pkg-shell:
-	docker-compose run -e DOCKER_HOST=${DOCKER_HOST} package bash
+	docker-compose run package bash
 
 bldr-base: packages
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,9 @@
 bldr:
   image: chef/bldr
   privileged: true
-  environment:
-    DOCKER_CERT_PATH: "/docker-certs"
-    DOCKER_TLS_VERIFY: 1
   volumes:
     - .:/src
-    - "~/.docker/machine/certs:/docker-certs"
+    - /var/run/docker.sock:/var/run/docker.sock
   volumes_from:
     - "bldr-cargo-cache"
     - "bldr-keys-cache"
@@ -17,12 +14,9 @@ bldr:
 package:
   image: chef/bldr
   privileged: true
-  environment:
-    DOCKER_CERT_PATH: "/docker-certs"
-    DOCKER_TLS_VERIFY: 1
   volumes:
     - .:/src
-    - "~/.docker/machine/certs:/docker-certs"
+    - /var/run/docker.sock:/var/run/docker.sock
   volumes_from:
     - "bldr-cargo-cache"
     - "bldr-pkg-cache"

--- a/packages/bldr/Bldrfile
+++ b/packages/bldr/Bldrfile
@@ -10,7 +10,7 @@ pkg_deps=(glibc libgcc busybox openssl runit)
 
 bldr_begin() {
 	pushd ../../
-	tar -cjvf $BLDR_SRC_CACHE/${pkg_name}-${pkg_version}.tar.bz2 --exclude 'packages' --exclude '.git' --exclude '.gitignore' --exclude 'target' --transform "s,^\.,bldr-0.0.1," .
+	tar -cjvf $BLDR_SRC_CACHE/${pkg_name}-${pkg_version}.tar.bz2 --exclude 'packages' --exclude '.git' --exclude '.gitignore' --exclude 'target' --exclude '.delivery' --transform "s,^\.,bldr-0.0.1," .
 	popd
 	pkg_shasum=$(trim $(sha256sum /opt/bldr/cache/src/bldr-0.0.1.tar.bz2 | cut -d " " -f 1))
 }


### PR DESCRIPTION
The primary trick here is to bind-mount the default Docker socket
(`/var/run/docker.sock`) into the container that needs to run other
`docker` commands. Because the `-v` flag is concerned with paths local
to the system running the Docker engine and not your workstation this
should be more than safe and frees the project to not be as tightly
coupled to the implemenation of docker-machine.
