### PR TITLE
Remove `/dev/console` from bldr package image creation.

### DIFF
--- a/packages/bldr/mkimage.sh
+++ b/packages/bldr/mkimage.sh
@@ -89,7 +89,7 @@ ln -sf $RUNIT_ROOT/bin/svlogd bin/svlogd
 ln -sf $RUNIT_ROOT/bin/utmpset bin/utmpset
 
 cp /lib/x86_64-linux-gnu/ld-linux-x86-64.so.2 lib
-for X in console null ptmx random stdin stdout stderr tty urandom zero
+for X in null ptmx random stdin stdout stderr tty urandom zero
 do
     cp -a /dev/$X dev
 done


### PR DESCRIPTION
In the CD pipeline the `/dev/console` does not exist in the container
building the bldr package image. This was determined by running:

```
docker exec 872f177f61f4 ls -l /dev/
```

at runtime to confirm its absence.

Running full clean builds locally yielded a clean passing functional
suite.
