### PR TITLE
Fixes race condition on initial leader start

### DIFF
--- a/src/bldr/topology/leader.rs
+++ b/src/bldr/topology/leader.rs
@@ -98,6 +98,11 @@ fn state_in_election(worker: &mut Worker) -> BldrResult<(State, u32)> {
         }
     }
 
+    if let Some(leader_ce) = worker.census.get_leader() {
+        println!("   {}: {} has already been elected; becoming a follower", preamble, leader_ce.candidate_string());
+        return Ok((State::BecomeFollower, 0));
+    }
+
     match worker.census.voting_finished() {
         Some(winner) => {
             let me = try!(worker.census.me());


### PR DESCRIPTION
When the leader topology starts, it's possible that one of the
supervisors completes an entire election cycle all by itself. This
should make it so we go ahead and prefer them if that occurs.

The symptom here was a stalled initial election.
