### PR TITLE
Cleaning up a panic at exit

### DIFF
--- a/src/bldr/topology/mod.rs
+++ b/src/bldr/topology/mod.rs
@@ -381,6 +381,7 @@ fn run_internal<'a>(sm: &mut StateMachine<State, Worker<'a>, BldrError>, worker:
         // Next state!
         try!(sm.next(worker));
     }
-    try!(SignalNotifier::stop(&handler));
+    // Guess what? We don't seem to suffer from just shutting this shit down.
+    // try!(SignalNotifier::stop(&handler));
     Ok(())
 }

--- a/src/bldr/util/signals.rs
+++ b/src/bldr/util/signals.rs
@@ -51,6 +51,7 @@ unsafe extern fn handle_signal(signal: u32) {
 pub enum Message {
     Signal(Signal),
     Stop,
+    Ok,
 }
 
 /// `i32` representation of each Unix Signal of interest.
@@ -106,8 +107,8 @@ impl actor::GenServer for SignalNotifier {
 
     fn handle_call(&self, message: Self::T, _: &ActorSender<Self::T>, _: &ActorSender<Self::T>, _: &mut Self::S) -> HandleResult<Self::T> {
         match message {
-            Message::Stop => HandleResult::Stop(StopReason::Normal, None),
-            msg => HandleResult::Stop(StopReason::Fatal(format!("unexpected call message: {:?}", msg)), None),
+            Message::Stop => HandleResult::Stop(StopReason::Normal, Some(Message::Ok)),
+            msg => HandleResult::Stop(StopReason::Fatal(format!("unexpected call message: {:?}", msg)), Some(Message::Ok)),
         }
     }
 


### PR DESCRIPTION
I'm pretty sure we should be stopping all our actors before we exit,
just out of kindness (and hidden race conditions). But, I'm not sure
what went wrong, and this trades a race condition for a certain constant
panic. Lets fix it in post :)

Love,
Adam
