### PR TITLE
Some refactors to clean up the pkg module

### DIFF
--- a/src/bldr/command/configure.rs
+++ b/src/bldr/command/configure.rs
@@ -30,7 +30,7 @@ use std::fs::File;
 
 use error::BldrResult;
 use config::Config;
-use pkg;
+use pkg::Package;
 
 /// Print the default.toml for a given package.
 ///
@@ -40,7 +40,7 @@ use pkg;
 /// * If the default.toml does not exist, or cannot be read
 /// * If we can't read the file into a string
 pub fn display(config: &Config) -> BldrResult<()> {
-    let package = try!(pkg::latest(config.package(), None));
+    let package = try!(Package::latest(config.package(), None));
     let mut file = try!(File::open(package.join_path("default.toml")));
     let mut s = String::new();
     try!(file.read_to_string(&mut s));

--- a/src/bldr/command/start.rs
+++ b/src/bldr/command/start.rs
@@ -60,7 +60,7 @@
 
 use error::{BldrResult, BldrError};
 use config::Config;
-use pkg;
+use pkg::Package;
 use topology;
 
 /// Creates a [Package](../../pkg/struct.Package.html), then passes it to the run method of the
@@ -72,7 +72,7 @@ use topology;
 /// * Fails if the `run` method for the topology fails
 /// * Fails if an unknown topology was specified on the command line
 pub fn package(config: &Config) -> BldrResult<()> {
-    let package = try!(pkg::latest(config.package(), None));
+    let package = try!(Package::latest(config.package(), None));
     match config.topology() {
         "standalone" => try!(topology::standalone::run(package, config)),
         "leader" => try!(topology::leader::run(package, config)),

--- a/src/bldr/command/upload.rs
+++ b/src/bldr/command/upload.rs
@@ -34,7 +34,7 @@ use error::BldrResult;
 use config::Config;
 use std::fs::File;
 
-use pkg;
+use pkg::Package;
 use util::http;
 
 /// Upload a package to a repository.
@@ -47,7 +47,7 @@ use util::http;
 /// * Fails if the package doesn't have a `.bldr` file in the cache
 /// * Fails if it cannot upload the file
 pub fn package(config: &Config) -> BldrResult<()> {
-    let package = try!(pkg::latest(config.package(), None));
+    let package = try!(Package::latest(config.package(), None));
     println!("   {}: uploading {}", config.package(), package.cache_file().to_string_lossy());
     let mut file = try!(File::open(package.cache_file()));
     try!(http::upload(&format!("{}/pkgs/{}/{}/{}/{}", config.url(), package.derivation, package.name, package.version, package.release), &mut file));

--- a/src/bldr/repo.rs
+++ b/src/bldr/repo.rs
@@ -12,7 +12,7 @@ use std::path::{Path, PathBuf};
 use error::{BldrError, BldrResult};
 use config::Config;
 
-use pkg;
+use pkg::Package;
 use util::http::XFileName;
 
 struct Repo {
@@ -137,7 +137,7 @@ fn download_latest(repo: &Repo, req: &mut Request) -> IronResult<Response> {
     let pkg = rext.find("pkg").unwrap();
 
     // Hahaha - you thought deriv would work. Not so much.
-    let package = try!(pkg::latest(pkg, Some(&format!("{}/pkgs", &repo.path))));
+    let package = try!(Package::latest(pkg, Some(&format!("{}/pkgs", &repo.path))));
     println!("{:?}", package);
 
     let path = Path::new(&repo.path).join(format!("pkgs/{}/{}/{}/{}", &package.derivation, &package.name, &package.version, &package.release));

--- a/src/bldr/sidecar.rs
+++ b/src/bldr/sidecar.rs
@@ -32,7 +32,7 @@ use std::thread;
 
 use error::{BldrError, BldrResult};
 
-use pkg::{self, Package, Signal};
+use pkg::{Package, Signal};
 use health_check;
 
 /// The sidecar state
@@ -48,7 +48,7 @@ impl Sidecar {
     ///
     /// * If the package cannot be found
     fn new(pkg: &str) -> BldrResult<Arc<Sidecar>> {
-        let package = try!(pkg::latest(pkg, None));
+        let package = try!(Package::latest(pkg, None));
         Ok(Arc::new(Sidecar{package: package}))
     }
 }

--- a/src/bldr/topology/standalone.rs
+++ b/src/bldr/topology/standalone.rs
@@ -34,7 +34,6 @@ use std::thread;
 use error::{BldrResult, BldrError};
 use std::process::{Command, Stdio};
 use std::io::prelude::*;
-use pkg;
 use ansi_term::Colour::White;
 use pkg::Package;
 use state_machine::StateMachine;
@@ -77,7 +76,7 @@ pub fn state_configure(_worker: &mut Worker) -> Result<(State, u32), BldrError> 
 /// * If we cannot start the supervisor
 pub fn state_starting(worker: &mut Worker) -> Result<(State, u32), BldrError> {
     println!("   {}: Starting", worker.preamble());
-    let runit_pkg = try!(pkg::latest("runit", None));
+    let runit_pkg = try!(Package::latest("runit", None));
     let mut child = try!(
         Command::new(runit_pkg.join_path("bin/runsv"))
         .arg(&format!("/opt/bldr/srvc/{}", worker.package.name))


### PR DESCRIPTION
This would have been part of the BLDR-20 work but I'd rather separate it into a separate PR :smile: 
- move functions from pkg module space into Package impl
- is_dir is now stable - leverage in package_list function
