### PR TITLE
Add support for `http_proxy` & `https_proxy`.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ cargo-volume-clean:
 	if [ -n "`$(container_with) name=bldr-cargo-cache`" ]; then docker rm bldr-cargo-cache; fi
 
 container:
-	docker build -t chef/bldr --no-cache=${NO_CACHE} .
+	docker build --build-arg http_proxy=${http_proxy} --build-arg https_proxy=${https_proxy} -t chef/bldr --no-cache=${NO_CACHE} .
 
 test:
 	docker-compose run package cargo test
@@ -86,7 +86,7 @@ base-shell:
 	docker-compose run base
 
 clean:
-	docker rm $(docker ps -q -f status=exited)
+	docker rm $(docker ps -a -q -f status=exited)
 	docker images -q -f dangling=true | xargs docker rmi
 
 redis:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,9 @@ bldr:
     - "bldr-cargo-cache"
     - "bldr-keys-cache"
     - "bldr-installed-cache"
+  environment:
+    - http_proxy=$http_proxy
+    - https_proxy=$https_proxy
   links:
     - etcd
 
@@ -23,11 +26,17 @@ package:
     - "bldr-keys-cache"
     - "bldr-src-cache"
     - "bldr-installed-cache"
+  environment:
+    - http_proxy=$http_proxy
+    - https_proxy=$https_proxy
   links:
     - etcd
 
 base:
   image: bldr
+  environment:
+    - http_proxy=$http_proxy
+    - https_proxy=$https_proxy
   links:
     - etcd
 


### PR DESCRIPTION
This change transmits the lowercase HTTP proxy environment variables
into the following places:
- In `docker build` in the Makefile (using the new `--build-arg` flag in
  Docker 1.9)
- In `docker-compose.yml` by adding `envrionment` blocks.

In both cases, if one or neither of the variables are set, empty values
are passed in and nothing should happen.
