### PR TITLE
Disable shasum verify on cacerts package for now.

### DIFF
--- a/packages/cacerts/Bldrfile
+++ b/packages/cacerts/Bldrfile
@@ -2,7 +2,7 @@ pkg_name=cacerts
 pkg_version=
 pkg_license=('MPL1.1 GPLv2.0 LGPLv2.1')
 pkg_source=http://curl.haxx.se/ca/cacert.pem
-pkg_shasum=6d45a0555cc3006bb5340f7d9da02e7ae22f910b4824b281042805966e703cfe
+pkg_shasum=nopenopebucketofnope
 pkg_gpg_key=3853DA6B
 
 unpack() {
@@ -13,6 +13,12 @@ unpack() {
 	mkdir -p $BLDR_SRC_CACHE/$pkg_dirname
 	cp $BLDR_SRC_CACHE/$pkg_filename $BLDR_SRC_CACHE/$pkg_dirname
 	return 0
+}
+
+# Verify? This file? From the internet? Not just yet... ;)
+verify() {
+  build_line "Not going to verify this until we have a stable solution"
+  return 0
 }
 
 clean() {


### PR DESCRIPTION
This is a temporary measure until we get more consistent/stable results
with a URL endpoint we still trust.

![gif-keyboard-6056432735431420780](https://cloud.githubusercontent.com/assets/261548/11089824/41932dbc-886d-11e5-8633-db7b2547556e.gif)
