### PR TITLE
Refactor Makefile and docker-compose.yml to be more idempotent & quick.

### DIFF
--- a/.delivery/cookbooks/bldr/recipes/functional.rb
+++ b/.delivery/cookbooks/bldr/recipes/functional.rb
@@ -1,6 +1,6 @@
 workspace = node['delivery']['workspace']['repo']
 
-execute 'make volume-clean all' do
+execute 'make clean all' do
   cwd workspace
 end
 

--- a/.delivery/cookbooks/bldr/recipes/lint.rb
+++ b/.delivery/cookbooks/bldr/recipes/lint.rb
@@ -18,7 +18,7 @@
 
 workspace = node['delivery']['workspace']['repo']
 
-execute 'make volume-clean volumes container' do
+execute 'make clean container' do
   cwd workspace
 end
 

--- a/.delivery/cookbooks/bldr/recipes/unit.rb
+++ b/.delivery/cookbooks/bldr/recipes/unit.rb
@@ -18,7 +18,7 @@
 
 workspace = node['delivery']['workspace']['repo']
 
-execute 'make volume-clean volumes container' do
+execute 'make clean container' do
   cwd workspace
 end
 

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,9 @@
 .delivery
+.git
+demo
+images
+packages
+src
+target
+tests
+vendor

--- a/README.md
+++ b/README.md
@@ -88,12 +88,13 @@ by having a convention cover it. When we do need to configure things, we set san
 
 1. [Install Docker Toolbox](http://docs.docker.com/mac/step_one/)
 1. Consider adding `eval "$(docker-machine env default)"` to your shell initialization
-1. [Install Stable Rust](https://www.rust-lang.org/install.html) `curl -sSf https://static.rust-lang.org/rustup.sh | sh`
 1. Checkout the source by running `git clone git@github.com:chef/bldr.git; cd bldr`
 1. Run `make`
 1. Run `make test`
 
 Everything should come up green. Congratulations - you have a working Bldr development environment.
+
+**Optional:** This project compiles and runs inside Docker containers so while installing the Rust language isn't strictly necessary, you might want a local copy of Rust on your workstation (some editors' language support require an installed version). To [install stable Rust](https://www.rust-lang.org/install.html), run: `curl -sSf https://static.rust-lang.org/rustup.sh | sh`
 
 **Optional:** This project currently uses GitHub integration wtih Delivery so
 while the delivery-cli tool is not strictly necessary to initiate reviews, it

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,12 +5,9 @@ bldr:
     - .:/src
     - /var/run/docker.sock:/var/run/docker.sock
   volumes_from:
-    - "bldr-cargo-cache"
-    - "bldr-keys-cache"
-    - "bldr-installed-cache"
-  environment:
-    - http_proxy=$http_proxy
-    - https_proxy=$https_proxy
+    - installed
+    - cache_keys
+    - cargo
   links:
     - etcd
 
@@ -21,22 +18,16 @@ package:
     - .:/src
     - /var/run/docker.sock:/var/run/docker.sock
   volumes_from:
-    - "bldr-cargo-cache"
-    - "bldr-pkg-cache"
-    - "bldr-keys-cache"
-    - "bldr-src-cache"
-    - "bldr-installed-cache"
-  environment:
-    - http_proxy=$http_proxy
-    - https_proxy=$https_proxy
+    - installed
+    - cache_src
+    - cache_pkgs
+    - cache_keys
+    - cargo
   links:
     - etcd
 
 base:
   image: bldr
-  environment:
-    - http_proxy=$http_proxy
-    - https_proxy=$https_proxy
   links:
     - etcd
 
@@ -47,3 +38,33 @@ etcd:
     - "4001:4001"
     - "7001:7001"
   command: "-cors='*' -listen-client-urls='http://0.0.0.0:2379,http://0.0.0.0:4001' -advertise-client-urls='http://0.0.0.0:2379,http://0.0.0.0:4001'"
+
+cache_src:
+  image: tianon/true
+  command: /true
+  volumes:
+    - /opt/bldr/cache/src
+
+cache_pkgs:
+  image: tianon/true
+  command: /true
+  volumes:
+    - /opt/bldr/cache/pkgs
+
+cache_keys:
+  image: tianon/true
+  command: /true
+  volumes:
+    - /opt/bldr/cache/keys
+
+installed:
+  image: tianon/true
+  command: /true
+  volumes:
+    - /opt/bldr/pkgs
+
+cargo:
+  image: tianon/true
+  command: /true
+  volumes:
+    - /bldr-cargo-cache


### PR DESCRIPTION
There are several updates and changes to clean things up:
- This change uses 2 environment variables: `docker_http_proxy` and
  `docker_https_proxy` to set `http_proxy` and `https_proxy` respectively
  for use in Docker instances and for `docker build` commands. Using the
  regular environment variables will cause the `docker` binary to run
  through the proxy if a `tcp://` connection is being used, often leading
  to connection problems.
- The `--rm` flag is passed into most `docker-compose run` commands which
  should keep the Docker host a little tidier over time.
- The data volumes are now completely described in the
  `docker-compose.yml` meaning that the package container will
  automatically create the volumes before starting.
- The documentation server is now executing inside a Docker container,
  removing the dependency on Ruby on the workstation.
- The root `.dockerignore` file includes most of the subdirectories,
  leading to a quicker `docker build` command.
- The duplication of Makefile targets for the data volumes has been DRY'd
  up a little.

![gif-keyboard-13961059849074692912](https://cloud.githubusercontent.com/assets/261548/11120035/c598bdb2-894d-11e5-8956-f9b979765316.gif)
