### PR TITLE
Add ability to define a reconfigure hook

### DIFF
--- a/src/bldr/error.rs
+++ b/src/bldr/error.rs
@@ -31,6 +31,7 @@ use hyper;
 use toml;
 use mustache;
 use regex;
+use pkg;
 
 #[derive(Debug)]
 pub enum BldrError {
@@ -62,6 +63,7 @@ pub enum BldrError {
     UnknownTopology(String),
     NoConfiguration,
     HealthCheck(String),
+    HookFailed(pkg::HookType, i32, String),
     TryRecvError(mpsc::TryRecvError),
     BadWatch(String),
     NoXFilename,
@@ -112,6 +114,7 @@ impl fmt::Display for BldrError {
             BldrError::UnknownTopology(ref t) => write!(f, "Unknown topology {}!", t),
             BldrError::NoConfiguration => write!(f, "No configuration data - cannot continue"),
             BldrError::HealthCheck(ref e) => write!(f, "Health Check failed: {}", e),
+            BldrError::HookFailed(ref t, ref e, ref o) => write!(f, "Hook failed to run: {}, {}, {}", t, e, o),
             BldrError::TryRecvError(ref err) => err.fmt(f),
             BldrError::BadWatch(ref e) => write!(f, "Bad watch format: {} is not valid", e),
             BldrError::NoXFilename => write!(f, "Invalid download from a repository - missing X-Filename header"),
@@ -155,6 +158,7 @@ impl Error for BldrError {
             BldrError::UnknownTopology(_) => "Unknown topology",
             BldrError::NoConfiguration => "No configuration data available",
             BldrError::HealthCheck(_) => "Health Check returned an unknown status code",
+            BldrError::HookFailed(_, _, _) => "Hook failed to run",
             BldrError::TryRecvError(_) => "A channel failed to recieve a response",
             BldrError::BadWatch(_) => "An invalid watch was specified",
             BldrError::NoXFilename => "Invalid download from a repository - missing X-Filename header",

--- a/src/bldr/topology/mod.rs
+++ b/src/bldr/topology/mod.rs
@@ -374,7 +374,7 @@ fn run_internal<'a>(sm: &mut StateMachine<State, Worker<'a>, BldrError>, worker:
         if !worker.census.in_event {
             // Write the configuration, and restart if needed
             if try!(worker.service_config.write(&worker.package)) {
-                try!(worker.package.signal(Signal::Restart));
+                try!(worker.package.reconfigure(&worker.service_config));
             }
         }
 

--- a/src/bldr/util/convert.rs
+++ b/src/bldr/util/convert.rs
@@ -1,0 +1,78 @@
+//
+// Copyright:: Copyright (c) 2015 Chef Software, Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use std::collections::{BTreeMap, HashMap};
+
+use toml;
+use mustache;
+
+// Translates a toml table to a mustache datastructure.
+pub fn toml_table_to_mustache(toml: BTreeMap<String, toml::Value>) -> mustache::Data {
+    let mut hashmap = HashMap::new();
+    for (key, value) in toml.iter() {
+        hashmap.insert(format!("{}", key), toml_to_mustache(value.clone()));
+    }
+    mustache::Data::Map(hashmap)
+}
+
+// Translates a given toml value to its mustache equivalent.
+pub fn toml_to_mustache(value: toml::Value) -> mustache::Data {
+    match value {
+        toml::Value::String(s) => mustache::Data::StrVal(format!("{}", s)),
+        toml::Value::Integer(i) => mustache::Data::StrVal(format!("{}", i)),
+        toml::Value::Float(i) => mustache::Data::StrVal(format!("{}", i)),
+        toml::Value::Boolean(b) => mustache::Data::Bool(b),
+        toml::Value::Datetime(s) => mustache::Data::StrVal(format!("{}", s)),
+        toml::Value::Array(a) => toml_vec_to_mustache(a),
+        toml::Value::Table(t) => toml_table_to_mustache(t),
+    }
+}
+
+// Translates toml vectors to mustache vectors.
+pub fn toml_vec_to_mustache(toml: Vec<toml::Value>) -> mustache::Data {
+    let mut mvec = vec![];
+    for x in toml.iter() {
+        mvec.push(toml_to_mustache(x.clone()))
+    }
+    mustache::Data::VecVal(mvec)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::toml_table_to_mustache;
+    use toml;
+    use mustache;
+
+    #[test]
+    fn toml_data_is_rendered_to_mustache() {
+        let toml = r#"
+                daemonize = "no"
+                slaveof = "127.0.0.1 6380"
+
+                [winks]
+                left = "yes"
+                right = "no"
+                wiggle = [ "snooze", "looze" ]
+            "#;
+        let toml_value = toml::Parser::new(toml).parse().unwrap();
+        let template = mustache::compile_str("hello {{daemonize}} for {{slaveof}} {{winks.right}} {{winks.left}} {{# winks.wiggle}} {{.}} {{/winks.wiggle}}");
+        let mut bytes = vec![];
+        let data = toml_table_to_mustache(toml_value);
+        template.render_data(&mut bytes, &data);
+        assert_eq!(String::from_utf8(bytes).unwrap(), "hello no for 127.0.0.1 6380 no yes  snooze  looze ".to_string());
+    }
+}

--- a/src/bldr/util/mod.rs
+++ b/src/bldr/util/mod.rs
@@ -15,6 +15,7 @@
 // limitations under the License.
 //
 
+pub mod convert;
 pub mod http;
 pub mod gpg;
 pub mod perm;


### PR DESCRIPTION
Hooks are defined as executable scripts within a package definition directory `hooks` next to a `Bldrfile`.

The default hook is perform the previous behaviour - to restart the service.
