### PR TITLE
set pkg_derivation for all packages to 'chef'

### DIFF
--- a/packages/bldr/Bldrfile
+++ b/packages/bldr/Bldrfile
@@ -1,4 +1,5 @@
 pkg_name=bldr
+pkg_derivation=chef
 pkg_version=0.0.1
 pkg_license=('Apache2')
 pkg_source=http://download.redis.io/releases/${pkg_name}-${pkg_version}.tar.bz2

--- a/packages/busybox/Bldrfile
+++ b/packages/busybox/Bldrfile
@@ -1,4 +1,5 @@
 pkg_name=busybox
+pkg_derivation=chef
 pkg_version=1.23.2
 pkg_license=('GPLv2')
 pkg_source=http://www.busybox.net/downloads/${pkg_name}-${pkg_version}.tar.bz2

--- a/packages/bzip2/Bldrfile
+++ b/packages/bzip2/Bldrfile
@@ -1,4 +1,5 @@
 pkg_name=bzip2
+pkg_derivation=chef
 pkg_version=1.0.6
 pkg_license=('bzip2')
 pkg_source=http://www.bzip.org/1.0.6/bzip2-1.0.6.tar.gz

--- a/packages/cacerts/Bldrfile
+++ b/packages/cacerts/Bldrfile
@@ -1,4 +1,5 @@
 pkg_name=cacerts
+pkg_derivation=chef
 pkg_version=
 pkg_license=('MPL1.1 GPLv2.0 LGPLv2.1')
 pkg_source=http://curl.haxx.se/ca/cacert.pem

--- a/packages/glibc/Bldrfile
+++ b/packages/glibc/Bldrfile
@@ -1,4 +1,5 @@
 pkg_name=glibc
+pkg_derivation=chef
 pkg_version=2.19
 pkg_license=('GPLv2' 'LGPLv2.1')
 pkg_source=http://ftp.gnu.org/gnu/libc/${pkg_name}-${pkg_version}.tar.bz2

--- a/packages/gnupg/Bldrfile
+++ b/packages/gnupg/Bldrfile
@@ -1,4 +1,5 @@
 pkg_name=gnupg
+pkg_derivation=chef
 pkg_version=1.4.19
 pkg_license=('GPLv3')
 pkg_source=https://gnupg.org/ftp/gcrypt/gnupg/${pkg_name}-${pkg_version}.tar.bz2

--- a/packages/haproxy/Bldrfile
+++ b/packages/haproxy/Bldrfile
@@ -2,6 +2,7 @@
 # vi: set ft=sh :
 
 pkg_name=haproxy
+pkg_derivation=chef
 pkg_version=1.5.12
 pkg_license=('BSD')
 pkg_maintainer="Adam Jacob <adam@chef.io>"

--- a/packages/libaio/Bldrfile
+++ b/packages/libaio/Bldrfile
@@ -1,4 +1,5 @@
 pkg_name=libaio
+pkg_derivation=chef
 pkg_version=0.3.109
 pkg_license=('LGPL')
 pkg_maintainer="Jamie Winsor <reset@chef.io>"

--- a/packages/libedit/Bldrfile
+++ b/packages/libedit/Bldrfile
@@ -1,4 +1,5 @@
 pkg_name=libedit
+pkg_derivation=chef
 pkg_version=3.1.20150325
 pkg_license=('bsd')
 pkg_source=http://thrysoee.dk/editline/libedit-20150325-3.1.tar.gz

--- a/packages/libgcc/Bldrfile
+++ b/packages/libgcc/Bldrfile
@@ -1,4 +1,5 @@
 pkg_name=libgcc
+pkg_derivation=chef
 pkg_version=4.9.1
 pkg_license=('LGPLv2.1')
 pkg_source=http://ftp.gnu.org/gnu/libc/${pkg_name}-${pkg_version}.tar.bz2

--- a/packages/libltdl/Bldrfile
+++ b/packages/libltdl/Bldrfile
@@ -1,4 +1,5 @@
 pkg_name=lib32-libltdl
+pkg_derivation=chef
 pkg_version=2.4.6
 pkg_license=('GPL')
 pkg_maintainer="Jamie Winsor <reset@chef.io>"

--- a/packages/libstdc++/Bldrfile
+++ b/packages/libstdc++/Bldrfile
@@ -1,4 +1,5 @@
 pkg_name=libstdc++
+pkg_derivation=chef
 pkg_version=5.2.1
 pkg_license=('GPLv2' 'LGPLv2.1')
 pkg_source=http://ftp.gnu.org/gnu/libc/${pkg_name}-${pkg_version}.tar.bz2

--- a/packages/libxml2/Bldrfile
+++ b/packages/libxml2/Bldrfile
@@ -1,4 +1,5 @@
 pkg_name=libxml2
+pkg_derivation=chef
 pkg_version=2.9.2
 pkg_license=('MIT')
 pkg_maintainer="Jamie Winsor <reset@chef.io>"

--- a/packages/ncurses/Bldrfile
+++ b/packages/ncurses/Bldrfile
@@ -2,6 +2,7 @@
 # vi: set ft=sh :
 
 pkg_name=ncurses
+pkg_derivation=chef
 pkg_version=5.9
 pkg_license=('ncurses')
 pkg_source=http://ftp.gnu.org/gnu/ncurses/ncurses-5.9.tar.gz

--- a/packages/nginx/Bldrfile
+++ b/packages/nginx/Bldrfile
@@ -2,6 +2,7 @@
 # vi: set ft=sh :
 
 pkg_name=nginx
+pkg_derivation=chef
 pkg_version=1.8.0
 pkg_maintainer="Adam Jacob <adam@chef.io>"
 pkg_license=('bsd')

--- a/packages/numactl/Bldrfile
+++ b/packages/numactl/Bldrfile
@@ -1,4 +1,5 @@
 pkg_name=numactl
+pkg_derivation=chef
 pkg_version=2.0.10
 pkg_license=('GPLv2', 'LGPL2.1')
 pkg_source=https://github.com/${pkg_name}/${pkg_name}/archive/v${pkg_version}.tar.gz

--- a/packages/openssl/Bldrfile
+++ b/packages/openssl/Bldrfile
@@ -1,4 +1,5 @@
 pkg_name=openssl
+pkg_derivation=chef
 pkg_version=1.0.2d
 pkg_license=('BSD')
 pkg_source=https://www.openssl.org/source/openssl-1.0.2d.tar.gz

--- a/packages/pcre/Bldrfile
+++ b/packages/pcre/Bldrfile
@@ -1,4 +1,5 @@
 pkg_name=pcre
+pkg_derivation=chef
 pkg_version=8.37
 pkg_license=('bsd')
 pkg_source=https://ftp.csx.cam.ac.uk/pub/software/programming/${pkg_name}/${pkg_name}-${pkg_version}.tar.bz2

--- a/packages/perl/Bldrfile
+++ b/packages/perl/Bldrfile
@@ -1,4 +1,5 @@
 pkg_name=perl
+pkg_derivation=chef
 pkg_version=5.22.0
 pkg_license=('GPL' 'PerlArtistic')
 pkg_maintainer="Jamie Winsor <reset@chef.io>"

--- a/packages/redis/Bldrfile
+++ b/packages/redis/Bldrfile
@@ -1,4 +1,5 @@
 pkg_name=redis
+pkg_derivation=chef
 pkg_version=3.0.1
 pkg_license=('BSD')
 pkg_maintainer="Adam Jacob <adam@chef.io>"

--- a/packages/runit/Bldrfile
+++ b/packages/runit/Bldrfile
@@ -1,4 +1,5 @@
 pkg_name=runit
+pkg_derivation=chef
 pkg_version=2.1.2
 pkg_license=('BSD')
 pkg_source=http://smarden.org/runit/runit-2.1.2.tar.gz

--- a/packages/zlib/Bldrfile
+++ b/packages/zlib/Bldrfile
@@ -1,4 +1,5 @@
 pkg_name=zlib
+pkg_derivation=chef
 pkg_version=1.2.8
 pkg_license=('zlib')
 pkg_source=http://downloads.sourceforge.net/project/libpng/$pkg_name/${pkg_version}/${pkg_name}-${pkg_version}.tar.gz


### PR DESCRIPTION
When we have a hosted repository in AWS and we are no longer building our package world within this repository we should move the Bldrfile from the bldr package to the root of this project and move the contents of the packages directory into a github repository (perhaps chef/bldr-packages?).

Because of this I have set pkg_derivation for all packages in our repository to 'chef'.
