### PR TITLE
Fix tests failing due to missing `pkg_derivation` in fixtures.

### DIFF
--- a/tests/bldr_build/mod.rs
+++ b/tests/bldr_build/mod.rs
@@ -44,9 +44,9 @@ fn builds_a_service() {
     assert_cmd_exit_code!(simple_service, [0]);
     assert_regex!(simple_service.stdout(), r"Loading /.*/Bldrfile");
     assert_regex!(simple_service.stdout(), r"bldr_build: Cache: /opt/bldr/cache/src/bldr_build-0.0.1");
-    assert_regex!(simple_service.stdout(), r"bldr_build: Installed: /opt/bldr/pkgs/bldr/bldr_build/0.0.1/\d{14}");
-    assert_regex!(simple_service.stdout(), r"bldr_build: Package: /opt/bldr/cache/pkgs/bldr-bldr_build-0.0.1-\d{14}.bldr");
-    let pkg_re = Regex::new(r"bldr_build: Package: (/opt/bldr/cache/pkgs/bldr-bldr_build-0.0.1-\d{14}.bldr)").unwrap();
+    assert_regex!(simple_service.stdout(), r"bldr_build: Installed: /opt/bldr/pkgs/test/bldr_build/0.0.1/\d{14}");
+    assert_regex!(simple_service.stdout(), r"bldr_build: Package: /opt/bldr/cache/pkgs/test-bldr_build-0.0.1-\d{14}.bldr");
+    let pkg_re = Regex::new(r"bldr_build: Package: (/opt/bldr/cache/pkgs/test-bldr_build-0.0.1-\d{14}.bldr)").unwrap();
     let caps = pkg_re.captures(simple_service.stdout()).unwrap();
     if let Some(pkg_path) = caps.at(1) {
         assert_file_exists!(pkg_path);

--- a/tests/fixtures/bldr_build/Bldrfile
+++ b/tests/fixtures/bldr_build/Bldrfile
@@ -1,4 +1,5 @@
 pkg_name=bldr_build
+pkg_derivation=test
 pkg_version=0.0.1
 pkg_license=('Apache2')
 pkg_maintainer="Adam Jacob <adam@chef.io>"

--- a/tests/fixtures/simple_service/Bldrfile
+++ b/tests/fixtures/simple_service/Bldrfile
@@ -1,4 +1,5 @@
 pkg_name=simple_service
+pkg_derivation=test
 pkg_version=0.0.1
 pkg_license=('Apache2')
 pkg_maintainer="Adam Jacob <adam@chef.io>"


### PR DESCRIPTION
pkg_derivation is now explicit and required, which required updating the
test output.

tsk tsk to not running `make test`

![animated](https://cloud.githubusercontent.com/assets/261548/11125377/e7ab6f0a-8969-11e5-9a5c-78ff9b311d33.gif)
