### PR TITLE
Rename `container` target to `image`.

### DIFF
--- a/.delivery/cookbooks/bldr/recipes/functional.rb
+++ b/.delivery/cookbooks/bldr/recipes/functional.rb
@@ -1,11 +1,21 @@
-workspace = node['delivery']['workspace']['repo']
+#
+# Cookbook Name:: bldr
+# Recipe:: functional
+#
+# Copyright 2015 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-execute 'make clean all force=true' do
-  cwd workspace
-end
-
-execute "docker ps -a -f 'name=bldr-*'"
-
-execute 'make functional' do
-  cwd workspace
+execute 'make clean packages functional force=true' do
+  cwd node['delivery']['workspace']['repo']
 end

--- a/.delivery/cookbooks/bldr/recipes/lint.rb
+++ b/.delivery/cookbooks/bldr/recipes/lint.rb
@@ -16,14 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-workspace = node['delivery']['workspace']['repo']
-
-execute 'make clean container force=true' do
-  cwd workspace
-end
-
-execute "docker ps -a -f 'name=bldr-*'"
-
-execute 'make docs' do
-  cwd workspace
+execute 'make clean docs force=true' do
+  cwd node['delivery']['workspace']['repo']
 end

--- a/.delivery/cookbooks/bldr/recipes/unit.rb
+++ b/.delivery/cookbooks/bldr/recipes/unit.rb
@@ -16,14 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-workspace = node['delivery']['workspace']['repo']
-
-execute 'make clean container force=true' do
-  cwd workspace
-end
-
-execute "docker ps -a -f 'name=bldr-*'"
-
-execute 'make unit' do
-  cwd workspace
+execute 'make clean unit force=true' do
+  cwd node['delivery']['workspace']['repo']
 end


### PR DESCRIPTION
This is closer to Docker's terminology. Now that the image target
is a pre-requisite of `unit`, `test`, `functional`, etc., we can drop
the explicit calls to the `image` target in the Delivery recipes.
