### PR TITLE
require derivation when starting/installing package

### DIFF
--- a/src/bldr/command/configure.rs
+++ b/src/bldr/command/configure.rs
@@ -40,7 +40,7 @@ use pkg::Package;
 /// * If the default.toml does not exist, or cannot be read
 /// * If we can't read the file into a string
 pub fn display(config: &Config) -> BldrResult<()> {
-    let package = try!(Package::latest(config.package(), None));
+    let package = try!(Package::latest(config.deriv(), config.package(), None));
     let mut file = try!(File::open(package.join_path("default.toml")));
     let mut s = String::new();
     try!(file.read_to_string(&mut s));

--- a/src/bldr/command/install.rs
+++ b/src/bldr/command/install.rs
@@ -68,9 +68,9 @@ use std::fs;
 ///
 /// * Fails if it cannot create `/opt/bldr/cache/pkgs`
 /// * Fails if it cannot download the package from the upstream
-pub fn from_url(package: &str, url: &str) -> BldrResult<String> {
+pub fn from_url(package: &str, deriv: &str, url: &str) -> BldrResult<String> {
     try!(fs::create_dir_all("/opt/bldr/cache/pkgs"));
-    let filename = try!(http::download_package(package, url, "/opt/bldr/cache/pkgs"));
+    let filename = try!(http::download_package(package, deriv, url, "/opt/bldr/cache/pkgs"));
     Ok(filename)
 }
 

--- a/src/bldr/command/start.rs
+++ b/src/bldr/command/start.rs
@@ -72,7 +72,7 @@ use topology::{self, Topology};
 /// * Fails if the `run` method for the topology fails
 /// * Fails if an unknown topology was specified on the command line
 pub fn package(config: &Config) -> BldrResult<()> {
-    let package = try!(Package::latest(config.package(), None));
+    let package = try!(Package::latest(config.deriv(), config.package(), None));
     match *config.topology() {
         Topology::Standalone => try!(topology::standalone::run(package, config)),
         Topology::Leader => try!(topology::leader::run(package, config)),

--- a/src/bldr/command/upload.rs
+++ b/src/bldr/command/upload.rs
@@ -30,6 +30,7 @@
 //! This should be extended to cover uploading specific packages, and finding them by ways more
 //! complex than just latest version.
 //!
+
 use error::BldrResult;
 use config::Config;
 use std::fs::File;
@@ -47,7 +48,7 @@ use util::http;
 /// * Fails if the package doesn't have a `.bldr` file in the cache
 /// * Fails if it cannot upload the file
 pub fn package(config: &Config) -> BldrResult<()> {
-    let package = try!(Package::latest(config.package(), None));
+    let package = try!(Package::latest(config.deriv(), config.package(), None));
     println!("   {}: uploading {}", config.package(), package.cache_file().to_string_lossy());
     let mut file = try!(File::open(package.cache_file()));
     try!(http::upload(&format!("{}/pkgs/{}/{}/{}/{}", config.url(), package.derivation, package.name, package.version, package.release), &mut file));

--- a/src/bldr/error.rs
+++ b/src/bldr/error.rs
@@ -72,6 +72,7 @@ pub enum BldrError {
     ActorError(actor::ActorError),
     CensusNotFound(String),
     UuidParseError(uuid::ParseError),
+    InvalidPackageIdent(String),
 }
 
 pub type BldrResult<T> = result::Result<T, BldrError>;
@@ -123,6 +124,7 @@ impl fmt::Display for BldrError {
             BldrError::ActorError(ref err) => write!(f, "Actor returned error: {:?}", err),
             BldrError::CensusNotFound(ref s) => write!(f, "Census entry not found: {:?}", s),
             BldrError::UuidParseError(ref e) => write!(f, "Uuid Parse Error: {:?}", e),
+            BldrError::InvalidPackageIdent(ref e) => write!(f, "Invalid package identifier: {:?}. A valid identifier is in the form derivation/name (example: chef/redis)", e),
         }
     }
 }
@@ -167,6 +169,7 @@ impl Error for BldrError {
             BldrError::ActorError(_) => "A running actor responded with an error",
             BldrError::CensusNotFound(_) => "A census entry does not exist",
             BldrError::UuidParseError(_) => "Uuid Parse Error",
+            BldrError::InvalidPackageIdent(_) => "Package identifiers must be in derivation/name format (example: chef/redis)",
         }
     }
 }

--- a/src/bldr/pkg.rs
+++ b/src/bldr/pkg.rs
@@ -212,10 +212,10 @@ impl Package {
         }
     }
 
-    pub fn latest(pkg: &str, opt_path: Option<&str>) -> BldrResult<Package> {
+    pub fn latest(deriv: &str, pkg: &str, opt_path: Option<&str>) -> BldrResult<Package> {
         let path = opt_path.unwrap_or("/opt/bldr/pkgs");
         let pl = try!(Self::package_list(path));
-        let latest: Option<Package> = pl.iter().filter(|&p| p.name == pkg)
+        let latest: Option<Package> = pl.iter().filter(|&p| p.name == pkg && p.derivation == deriv)
             .fold(None, |winner, b| {
                 match winner {
                     Some(a) => {
@@ -233,7 +233,7 @@ impl Package {
     }
 
     pub fn signal(&self, signal: Signal) -> BldrResult<String> {
-        let runit_pkg = try!(Self::latest("runit", None));
+        let runit_pkg = try!(Self::latest("runit", "chef", None));
         let signal_arg = match signal {
             Signal::Status => "status",
             Signal::Up => "up",

--- a/src/bldr/repo.rs
+++ b/src/bldr/repo.rs
@@ -133,12 +133,10 @@ fn download_latest(repo: &Repo, req: &mut Request) -> IronResult<Response> {
     println!("Download Latest {:?}", req);
     let rext = req.extensions.get::<Router>().unwrap();
 
-    let _deriv = rext.find("deriv").unwrap();
+    let deriv = rext.find("deriv").unwrap();
     let pkg = rext.find("pkg").unwrap();
 
-    // Hahaha - you thought deriv would work. Not so much.
-    let package = try!(Package::latest(pkg, Some(&format!("{}/pkgs", &repo.path))));
-    println!("{:?}", package);
+    let package = try!(Package::latest(deriv, pkg, Some(&format!("{}/pkgs", &repo.path))));
 
     let path = Path::new(&repo.path).join(format!("pkgs/{}/{}/{}/{}", &package.derivation, &package.name, &package.version, &package.release));
     let short_filename = format!("{}-{}-{}-{}.bldr", &package.derivation, &package.name, &package.version, &package.release);

--- a/src/bldr/topology/standalone.rs
+++ b/src/bldr/topology/standalone.rs
@@ -70,7 +70,7 @@ pub fn state_initializing(worker: &mut Worker) -> BldrResult<(State, u32)> {
 pub fn state_starting(worker: &mut Worker) -> BldrResult<(State, u32)> {
     println!("   {}: Starting", worker.preamble());
     let package = worker.package_name.clone();
-    let runit_pkg = try!(Package::latest("runit", None));
+    let runit_pkg = try!(Package::latest("chef", "runit", None));
     let mut child = try!(
         Command::new(runit_pkg.join_path("bin/runsv"))
         .arg(&format!("/opt/bldr/srvc/{}", worker.package_name))

--- a/src/bldr/util/http.rs
+++ b/src/bldr/util/http.rs
@@ -32,8 +32,8 @@ pub fn upload(url: &str, file: &mut File) -> BldrResult<()> {
     Ok(())
 }
 
-pub fn download_package(package: &str, base_url: &str, path: &str) -> BldrResult<String> {
-    let url = format!("{}/pkgs/bldr/{}/download", base_url, package);
+pub fn download_package(package: &str, deriv: &str, base_url: &str, path: &str) -> BldrResult<String> {
+    let url = format!("{}/pkgs/{}/{}/download", base_url, deriv, package);
     download(package, &url, path)
 }
 

--- a/tests/bldr/repo.rs
+++ b/tests/bldr/repo.rs
@@ -27,13 +27,13 @@ fn upload_a_package_and_then_install_it() {
     let d = docker::repo("test/simple_service");
     let ipaddress = d.ipaddress();
 
-    let mut upload = command::bldr(&["upload", "simple_service", "-u", &format!("http://{}:9632", ipaddress)]).unwrap();
+    let mut upload = command::bldr(&["upload", "test/simple_service", "-u", &format!("http://{}:9632", ipaddress)]).unwrap();
     upload.wait_with_output();
     assert_cmd_exit_code!(upload, [0]);
     assert_regex!(upload.stdout(), r"Upload Bldr Package (.+)");
     assert_regex!(upload.stdout(), r"simple_service: uploading (.+)");
     assert_regex!(upload.stdout(), r"simple_service: complete");
-    let mut install = command::bldr(&["install", "simple_service", "-u", &format!("http://{}:9632", ipaddress)]).unwrap();
+    let mut install = command::bldr(&["install", "test/simple_service", "-u", &format!("http://{}:9632", ipaddress)]).unwrap();
     install.wait_with_output();
     assert_cmd_exit_code!(install, [0]);
 }

--- a/tests/bldr/start.rs
+++ b/tests/bldr/start.rs
@@ -111,4 +111,3 @@ fn leader_with_discovery() {
         assert_docker_log_count!(1, "Starting my term as leader", [ d1, d2 ]);
     }
 }
-

--- a/tests/util/docker.rs
+++ b/tests/util/docker.rs
@@ -40,15 +40,15 @@ pub fn run_with_env(image: &str, env: &str) -> Docker {
 }
 
 pub fn run_with_etcd(image: &str) -> Docker {
-    docker_cmd(&["run", "-d", "--link=bldr_etcd_1:etcd", "-e=BLDR_CONFIG_ETCD=http://etcd:4001", image, "start", "simple_service", &format!("--group={}", thread::current().name().unwrap_or("main"))])
+    docker_cmd(&["run", "-d", "--link=bldr_etcd_1:etcd", "-e=BLDR_CONFIG_ETCD=http://etcd:4001", image, "start", "test/simple_service", &format!("--group={}", thread::current().name().unwrap_or("main"))])
 }
 
 pub fn run_with_etcd_watch(image: &str, watch: &str) -> Docker {
-    docker_cmd(&["run", "-d", "--link=bldr_etcd_1:etcd", "-e=BLDR_CONFIG_ETCD=http://etcd:4001", image, "start", "simple_service", &format!("--group={}", thread::current().name().unwrap_or("main")), &format!("--watch={}", watch)])
+    docker_cmd(&["run", "-d", "--link=bldr_etcd_1:etcd", "-e=BLDR_CONFIG_ETCD=http://etcd:4001", image, "start", "test/simple_service", &format!("--group={}", thread::current().name().unwrap_or("main")), &format!("--watch={}", watch)])
 }
 
 pub fn run_with_etcd_topology(image: &str, topology: &str) -> Docker {
-    docker_cmd(&["run", "-d", "--link=bldr_etcd_1:etcd", "-e=BLDR_CONFIG_ETCD=http://etcd:4001", image, "start", "simple_service", &format!("--group={}", thread::current().name().unwrap_or("main")), &format!("--topology={}", topology)])
+    docker_cmd(&["run", "-d", "--link=bldr_etcd_1:etcd", "-e=BLDR_CONFIG_ETCD=http://etcd:4001", image, "start", "test/simple_service", &format!("--group={}", thread::current().name().unwrap_or("main")), &format!("--topology={}", topology)])
 }
 
 impl Docker {


### PR DESCRIPTION
With this change it will be a requirement to fully qualify packages when identifying them in all commands on the command line. You will now need to run `bldr start chef/redis` and `bldr start redis` will no longer function.

This change will allow us as developers to provide a much more simplistic approach to allowing multiple derivations on the same node and also make it less error prone for users.

For example: A bldr user has two "preferred" derivations. One is their organization and Chef is the fallback. If we are consuming the redis package from the Chef repository and we have no redis package in ours, then unning the `bldr start redis` command will download and install Chef's Redis package. However, a day later when another employee decides to upload a Redis package into your organization's repository then the command which you ran a few days prior may not work as expected or at all.

This change will make sure that users are always running exactly what they expect.
