### PR TITLE
Allow starting of initializer topology by command line

### DIFF
--- a/opt/bldr/pkgs/test/simple_service/0.0.1/20151116161429/MANIFEST
+++ b/opt/bldr/pkgs/test/simple_service/0.0.1/20151116161429/MANIFEST
@@ -1,0 +1,65 @@
+test simple_service
+=========================
+
+Maintainer: Adam Jacob <adam@chef.io>
+Version: 0.0.1
+Release: 20151116161429
+License: Apache2 
+Source: [http://example.com/releases/simple_service-0.0.1.tar.bz2](http://example.com/releases/simple_service-0.0.1.tar.bz2)
+SHA: abdbfdee83945bbe0a17e67219346427b655db90dee3410fbd40f1b5e3493242
+Path: /opt/bldr/pkgs/test/simple_service/0.0.1/20151116161429
+Dependencies:  
+
+Plan
+========
+
+Flags
+-----
+
+CFLAGS: 
+LDFLAGS: 
+LD_RUN_PATH: 
+
+```bash
+pkg_name=simple_service
+pkg_derivation=test
+pkg_version=0.0.1
+pkg_license=('Apache2')
+pkg_maintainer="Adam Jacob <adam@chef.io>"
+pkg_source=http://example.com/releases/${pkg_name}-${pkg_version}.tar.bz2
+pkg_filename=${pkg_name}-${pkg_version}.tar.bz2
+pkg_shasum=0e21be5d7c5e6ab6adcbed257619897db59be9e1ded7ef6fd1582d0cdb5e5bb7
+pkg_gpg_key=3853DA6B
+pkg_binary_path=(bin)
+pkg_deps=()
+pkg_service_run="bin/simple_service"
+pkg_docker_build="auto"
+
+bldr_begin() {
+	tar -cjvf $BLDR_SRC_CACHE/${pkg_name}-${pkg_version}.tar.bz2 --exclude 'plans' --exclude '.git' --exclude '.gitignore' --exclude 'target' --transform "s,^\.,simple_service-0.0.1," .
+	pkg_shasum=$(trim $(sha256sum /opt/bldr/cache/src/simple_service-0.0.1.tar.bz2 | cut -d " " -f 1))
+}
+
+download() {
+	return 0
+}
+
+build() {
+	return 0
+}
+
+install() {
+	cp -r $BLDR_SRC_CACHE/$pkg_dirname/bin $pkg_prefix
+	chmod 755 $pkg_path/bin
+  chmod 755 $pkg_path/bin/*
+	return 0
+}
+```
+
+Files
+-----
+92d6c7a5658a23395614fd0d41d42c71ffeb5b78498c0a7f102bfa880c594777  /opt/bldr/pkgs/test/simple_service/0.0.1/20151116161429/PATH
+ac4fecf6d3f7edbb1fdfc225fd28a6f93f723b5203c65a3b661926d7a4e2d472  /opt/bldr/pkgs/test/simple_service/0.0.1/20151116161429/config/simple.conf
+08c7bfdd956b6e93401f983084628975526c532854830f69e1afa34bea8db80f  /opt/bldr/pkgs/test/simple_service/0.0.1/20151116161429/default.toml
+812f2681a47bb8a5756c2654a58893b816d9252b1b7380cffae495c8d97d6d10  /opt/bldr/pkgs/test/simple_service/0.0.1/20151116161429/run
+a39f5195f796fecd405a3aba99778d56053cacc48b28d98e3b28b9bc225e055a  /opt/bldr/pkgs/test/simple_service/0.0.1/20151116161429/bin/simple_service

--- a/opt/bldr/pkgs/test/simple_service/0.0.1/20151116161429/PATH
+++ b/opt/bldr/pkgs/test/simple_service/0.0.1/20151116161429/PATH
@@ -1,0 +1,1 @@
+/opt/bldr/pkgs/test/simple_service/0.0.1/20151116161429/bin

--- a/opt/bldr/pkgs/test/simple_service/0.0.1/20151116161429/bin/simple_service
+++ b/opt/bldr/pkgs/test/simple_service/0.0.1/20151116161429/bin/simple_service
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+EXIT_NOW=0
+
+set_exit_now() {
+  EXIT_NOW=1
+}
+
+trap "set_exit_now" INT TERM HUP
+echo Shipping out to Boston
+echo "### Configuration file ###"
+cat /opt/bldr/srvc/simple_service/config/simple.conf
+echo "### End of configuration file ###"
+echo "### Running toml data ###"
+cat /opt/bldr/srvc/simple_service/config.toml
+echo "### End running toml data ###"
+
+while [ 1 ]; do
+  if [ $EXIT_NOW = 1 ]; then
+     echo "Exiting on signal"
+     exit 0
+  fi
+  sleep 1
+done
+

--- a/opt/bldr/pkgs/test/simple_service/0.0.1/20151116161429/config/simple.conf
+++ b/opt/bldr/pkgs/test/simple_service/0.0.1/20151116161429/config/simple.conf
@@ -1,0 +1,3 @@
+### Configuration ###
+setting: {{setting}}
+### End Configuration ###

--- a/opt/bldr/pkgs/test/simple_service/0.0.1/20151116161429/default.toml
+++ b/opt/bldr/pkgs/test/simple_service/0.0.1/20151116161429/default.toml
@@ -1,0 +1,1 @@
+setting = "true"

--- a/opt/bldr/pkgs/test/simple_service/0.0.1/20151116161429/run
+++ b/opt/bldr/pkgs/test/simple_service/0.0.1/20151116161429/run
@@ -1,0 +1,11 @@
+#!/opt/bldr/pkgs/chef/busybox/1.23.2/20151116135232/bin/sh
+cd /opt/bldr/srvc/simple_service
+
+if [ "$(whoami)" = "root" ]; then
+  exec /opt/bldr/pkgs/chef/busybox/1.23.2/20151116135232/bin/chpst \
+    -U bldr:bldr \
+    -u bldr:bldr \
+    /opt/bldr/pkgs/test/simple_service/0.0.1/20151116161429/bin/simple_service 2>&1
+else
+  exec /opt/bldr/pkgs/test/simple_service/0.0.1/20151116161429/bin/simple_service 2>&1
+fi

--- a/src/bldr/command/start.rs
+++ b/src/bldr/command/start.rs
@@ -58,10 +58,10 @@
 //! See the [documentation on topologies](../topology) for a deeper discussion of how they function.
 //!
 
-use error::{BldrResult, BldrError};
+use error::BldrResult;
 use config::Config;
 use pkg::Package;
-use topology;
+use topology::{self, Topology};
 
 /// Creates a [Package](../../pkg/struct.Package.html), then passes it to the run method of the
 /// selected [topology](../../topology).
@@ -73,12 +73,10 @@ use topology;
 /// * Fails if an unknown topology was specified on the command line
 pub fn package(config: &Config) -> BldrResult<()> {
     let package = try!(Package::latest(config.package(), None));
-    match config.topology() {
-        "standalone" => try!(topology::standalone::run(package, config)),
-        "leader" => try!(topology::leader::run(package, config)),
-        t => {
-            return Err(BldrError::UnknownTopology(String::from(t)))
-        }
+    match *config.topology() {
+        Topology::Standalone => try!(topology::standalone::run(package, config)),
+        Topology::Leader => try!(topology::leader::run(package, config)),
+        Topology::Initializer => try!(topology::initializer::run(package, config)),
     }
     Ok(())
 }

--- a/src/bldr/config.rs
+++ b/src/bldr/config.rs
@@ -23,6 +23,8 @@
 //!
 //! See the [Config](struct.Config.html) struct for the specific options available.
 
+use topology::Topology;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 /// An enum with the various CLI commands. Used to keep track of what command was called.
 pub enum Command {
@@ -50,7 +52,7 @@ pub struct Config {
     command: Command,
     package: String,
     url: String,
-    topology: String,
+    topology: Topology,
     group: String,
     path: String,
     deriv: String,
@@ -177,13 +179,13 @@ impl Config {
     }
 
     /// Set the topology
-    pub fn set_topology(&mut self, topology: String) -> &mut Config {
+    pub fn set_topology(&mut self, topology: Topology) -> &mut Config {
         self.topology = topology;
         self
     }
 
     /// Return the topology
-    pub fn topology(&self) -> &str {
+    pub fn topology(&self) -> &Topology {
         &self.topology
     }
 }
@@ -191,11 +193,12 @@ impl Config {
 #[cfg(test)]
 mod tests {
     use super::{Config, Command};
+    use topology::Topology;
 
     #[test]
     fn new() {
         let c = Config::new();
-        assert_eq!(c.topology(), String::new());
+        assert_eq!(*c.topology(), Topology::Standalone);
     }
 
     #[test]
@@ -236,7 +239,7 @@ mod tests {
     #[test]
     fn topology() {
         let mut c = Config::new();
-        c.set_topology(String::from("leader"));
-        assert_eq!(c.topology(), "leader");
+        c.set_topology(Topology::Leader);
+        assert_eq!(*c.topology(), Topology::Leader);
     }
 }

--- a/src/bldr/topology/mod.rs
+++ b/src/bldr/topology/mod.rs
@@ -108,6 +108,19 @@ pub fn WTERMSIG(status: c_int) -> c_int {
     status & 0x7f
 }
 
+#[derive(PartialEq, Eq, Debug)]
+pub enum Topology {
+    Standalone,
+    Leader,
+    Initializer,
+}
+
+impl Default for Topology {
+    fn default() -> Topology {
+        Topology::Standalone
+    }
+}
+
 /// Viable states for the topologies. Not every topology will implement every state.
 #[derive(PartialEq, Eq, Hash, Debug, Clone, Copy)]
 pub enum State {

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,7 @@ use std::ptr;
 use bldr::config::{Command, Config};
 use bldr::error::{BldrResult, BldrError};
 use bldr::command::*;
+use bldr::topology::Topology;
 
 /// The version number
 #[allow(dead_code)]
@@ -82,19 +83,34 @@ struct Args {
     flag_version: String,
     flag_release: String,
     flag_url: String,
-    flag_topology: String,
+    flag_topology: Option<String>,
     flag_group: String,
     flag_watch: Vec<String>
 }
 
 /// Creates a [Config](config/struct.Config.html) from the [Args](/Args)
 /// struct.
-fn config_from_args(args: &Args, command: Command) -> Config {
+fn config_from_args(args: &Args, command: Command) -> BldrResult<Config> {
     let mut config = Config::new();
     config.set_command(command);
     config.set_package(args.arg_package.clone());
     config.set_url(args.flag_url.clone());
-    config.set_topology(args.flag_topology.clone());
+
+    if let Some(ref topology) = args.flag_topology {
+        match topology.as_ref() {
+            "standalone" => {
+                config.set_topology(Topology::Standalone);
+            },
+            "leader" => {
+                config.set_topology(Topology::Leader);
+            },
+            "initializer" => {
+                config.set_topology(Topology::Initializer);
+            },
+            t => return Err(BldrError::UnknownTopology(String::from(t))),
+        }
+    }
+
     config.set_group(args.flag_group.clone());
     config.set_watch(args.flag_watch.clone());
     config.set_path(args.flag_path.clone());
@@ -102,7 +118,7 @@ fn config_from_args(args: &Args, command: Command) -> Config {
     config.set_deriv(args.flag_deriv.clone());
     config.set_release(args.flag_release.clone());
     config.set_key(args.arg_key.clone());
-    config
+    Ok(config)
 }
 
 /// The primary loop for bldr.
@@ -121,40 +137,58 @@ fn main() {
     debug!("Docopt Args: {:?}", args);
     let result = match args {
         Args{cmd_install: true, ..} => {
-            let config = config_from_args(&args, Command::Install);
-            install(&config)
+            match config_from_args(&args, Command::Install) {
+                Ok(config) => install(&config),
+                Err(e) => Err(e),
+            }
         },
         Args{cmd_start: true, ..} => {
-            let config = config_from_args(&args, Command::Start);
-            start(&config)
+            match config_from_args(&args, Command::Start) {
+                Ok(config) => start(&config),
+                Err(e) => Err(e),
+            }
         },
         Args{cmd_key: true, ..} => {
-            let config = config_from_args(&args, Command::Key);
-            key(&config)
+            match config_from_args(&args, Command::Key) {
+                Ok(config) => key(&config),
+                Err(e) => Err(e),
+            }
         },
         Args{cmd_key_upload: true, ..} => {
-            let config = config_from_args(&args, Command::KeyUpload);
-            key_upload(&config)
+            match config_from_args(&args, Command::KeyUpload) {
+                Ok(config) => key_upload(&config),
+                Err(e) => Err(e),
+            }
         },
         Args{cmd_sh: true, ..} => {
-            let config = config_from_args(&args, Command::Shell);
-            shell(&config)
+            match config_from_args(&args, Command::Shell) {
+                Ok(config) => shell(&config),
+                Err(e) => Err(e),
+            }
         },
         Args{cmd_bash: true, ..} => {
-            let config = config_from_args(&args, Command::Shell);
-            shell(&config)
+            match config_from_args(&args, Command::Shell) {
+                Ok(config) => shell(&config),
+                Err(e) => Err(e),
+            }
         },
         Args{cmd_repo: true, ..} => {
-            let config = config_from_args(&args, Command::Repo);
-            repo(&config)
+            match config_from_args(&args, Command::Repo) {
+                Ok(config) => repo(&config),
+                Err(e) => Err(e),
+            }
         },
         Args{cmd_upload: true, ..} => {
-            let config = config_from_args(&args, Command::Upload);
-            upload(&config)
+            match config_from_args(&args, Command::Upload) {
+                Ok(config) => upload(&config),
+                Err(e) => Err(e),
+            }
         },
         Args{cmd_config: true, ..} => {
-            let config = config_from_args(&args, Command::Configuration);
-            configure(&config)
+            match config_from_args(&args, Command::Configuration) {
+                Ok(config) => configure(&config),
+                Err(e) => Err(e),
+            }
         },
         _ => Err(BldrError::CommandNotImplemented),
     };


### PR DESCRIPTION
I accidentally forgot to hook the topology up to the command line

![gif-keyboard-17116232656264430006](https://cloud.githubusercontent.com/assets/54036/11186939/07a78628-8c39-11e5-9666-722e86336b91.gif)
