### PR TITLE
Allow version and release in command line package identifier

### DIFF
--- a/src/bldr/command/configure.rs
+++ b/src/bldr/command/configure.rs
@@ -40,7 +40,7 @@ use pkg::Package;
 /// * If the default.toml does not exist, or cannot be read
 /// * If we can't read the file into a string
 pub fn display(config: &Config) -> BldrResult<()> {
-    let package = try!(Package::latest(config.deriv(), config.package(), None));
+    let package = try!(Package::latest(config.deriv(), config.package(), None, None));
     let mut file = try!(File::open(package.join_path("default.toml")));
     let mut s = String::new();
     try!(file.read_to_string(&mut s));

--- a/src/bldr/command/install.rs
+++ b/src/bldr/command/install.rs
@@ -71,9 +71,14 @@ use repo;
 ///
 /// * Fails if it cannot create `/opt/bldr/cache/pkgs`
 /// * Fails if it cannot download the package from the upstream
-pub fn latest_from_url(deriv: &str, package: &str, url: &str) -> BldrResult<String> {
+pub fn from_url(url: &str,
+                deriv: &str,
+                package: &str,
+                version: &Option<String>,
+                release: &Option<String>)
+                -> BldrResult<String> {
     try!(fs::create_dir_all(PACKAGE_CACHE));
-    repo::client::fetch_package_latest(url, deriv, package, PACKAGE_CACHE)
+    repo::client::fetch_package(url, deriv, package, version, release, PACKAGE_CACHE)
 }
 
 /// Given a package name and a path to a file as an `&str`, verify

--- a/src/bldr/command/upload.rs
+++ b/src/bldr/command/upload.rs
@@ -48,7 +48,7 @@ use repo;
 /// * Fails if it cannot upload the file
 pub fn package(config: &Config) -> BldrResult<()> {
     let url = config.url().as_ref().unwrap();
-    let package = try!(Package::latest(config.deriv(), config.package(), None));
+    let package = try!(Package::latest(config.deriv(), config.package(), None, None));
     println!("   {}: Uploading from {}",
              &package,
              package.cache_file().to_string_lossy());

--- a/src/bldr/config.rs
+++ b/src/bldr/config.rs
@@ -59,8 +59,8 @@ pub struct Config {
     group: String,
     path: String,
     deriv: String,
-    version: String,
-    release: String,
+    version: Option<String>,
+    release: Option<String>,
     watch: Vec<String>,
     key: String,
     listen_addr: repo::ListenAddr,
@@ -119,23 +119,23 @@ impl Config {
 
     /// Set the version
     pub fn set_version(&mut self, version: String) -> &mut Config {
-        self.version = version;
+        self.version = Some(version);
         self
     }
 
     /// Return the version
-    pub fn version(&self) -> &str {
+    pub fn version(&self) -> &Option<String> {
         &self.version
     }
 
     /// Set the release
     pub fn set_release(&mut self, release: String) -> &mut Config {
-        self.release = release;
+        self.release = Some(release);
         self
     }
 
     /// Return the release
-    pub fn release(&self) -> &str {
+    pub fn release(&self) -> &Option<String> {
         &self.release
     }
 

--- a/src/bldr/lib.rs
+++ b/src/bldr/lib.rs
@@ -55,7 +55,7 @@ extern crate libc;
 extern crate url;
 extern crate fnv;
 extern crate iron;
-extern crate router;
+#[macro_use] extern crate router;
 extern crate time;
 extern crate wonder;
 extern crate uuid;

--- a/src/bldr/topology/standalone.rs
+++ b/src/bldr/topology/standalone.rs
@@ -71,7 +71,7 @@ pub fn state_initializing(worker: &mut Worker) -> BldrResult<(State, u32)> {
 pub fn state_starting(worker: &mut Worker) -> BldrResult<(State, u32)> {
     println!("   {}: Starting", worker.preamble());
     let package = worker.package_name.clone();
-    let runit_pkg = try!(Package::latest("chef", "runit", None));
+    let runit_pkg = try!(Package::latest("chef", "runit", None, None));
     let mut child = try!(Command::new(runit_pkg.join_path("bin/runsv"))
                              .arg(&format!("/opt/bldr/srvc/{}", worker.package_name))
                              .stdin(Stdio::null())


### PR DESCRIPTION
This PR will allow you to more grainularly specify a package to install, upload, or run.

Prior to this PR the package identifier on the command line accepted only a derivation and name: `bldr install chef/redis`. With the functionality in this PR you can now perform `bldr install chef/redis/1.2.3` or `bldr install chef/redis/1.2.3/20151119125912`.

![gif-keyboard-17439286568811385463](https://cloud.githubusercontent.com/assets/54036/11298058/52944388-8f31-11e5-87b2-5c4d1ccaa7c5.gif)
