### PR TITLE
check for generated run file/symlink before re-linking

### DIFF
--- a/src/bldr/pkg.rs
+++ b/src/bldr/pkg.rs
@@ -448,7 +448,10 @@ impl Package {
         } else {
             let run = self.join_path(RUN_FILENAME);
             try!(util::perm::set_permissions(&run, "0755"));
-            try!(fs::remove_file(&srvc_run));
+            match fs::metadata(&srvc_run) {
+                Ok(_) => try!(fs::remove_file(&srvc_run)),
+                Err(_) => {}
+            }
             try!(unix::fs::symlink(&run, &srvc_run));
         }
         Ok(())


### PR DESCRIPTION
oops
![gif-keyboard-6814065619759090294](https://cloud.githubusercontent.com/assets/54036/11306499/16a4ef7c-8f67-11e5-91c6-0acc97c63c0b.gif)
