### PR TITLE
Add Standard output and error formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,6 @@ plans/**/*-cache
 plans/**/Dockerfile
 plans/hana/SAP*
 plans/hana/sapcar.exe
+plans/hana/*.exe
+plans/hana/*.rar
 opt/

--- a/src/bldr/command/install.rs
+++ b/src/bldr/command/install.rs
@@ -60,9 +60,11 @@ use std::process::Command;
 use std::fs;
 
 use fs::{PACKAGE_CACHE, GPG_CACHE};
-use error::{BldrResult, BldrError};
+use error::{BldrResult, ErrorKind};
 use util::gpg;
 use repo;
+
+static LOGKEY: &'static str = "CI";
 
 /// Given a package name and a base url, downloads the package
 /// to `/opt/bldr/cache/pkgs`. Returns the filename in the cache as a String
@@ -106,10 +108,10 @@ pub fn unpack(package: &str, file: &str) -> BldrResult<()> {
                                        file))
                           .output());
     match output.status.success() {
-        true => println!("   {}: Installed", package),
+        true => outputln!("Installed {}", package),
         false => {
-            println!("   {}: Failed to install", package);
-            return Err(BldrError::UnpackFailed);
+            outputln!("Failed to install {}", package);
+            return Err(bldr_error!(ErrorKind::UnpackFailed));
         }
     }
     Ok(())

--- a/src/bldr/command/key_upload.rs
+++ b/src/bldr/command/key_upload.rs
@@ -37,8 +37,10 @@ use std::path::Path;
 
 use fs::KEY_CACHE;
 use config::Config;
-use error::{BldrError, BldrResult};
+use error::{BldrResult, ErrorKind};
 use repo;
+
+static LOGKEY: &'static str = "KU";
 
 /// Upload a key to a repository.
 ///
@@ -56,7 +58,7 @@ pub fn key(config: &Config) -> BldrResult<()> {
 
     match fs::metadata(path) {
         Ok(_) => {
-            println!("   {}: uploading {}", url, config.key());
+            outputln!("Uploading {}", config.key());
             try!(repo::client::put_key(url, path));
         }
         Err(_) => {
@@ -65,16 +67,17 @@ pub fn key(config: &Config) -> BldrResult<()> {
                 let cached = Path::new(&file);
                 match fs::metadata(&cached) {
                     Ok(_) => {
-                        println!("   {}: uploading {}.asc", url, config.key());
+                        outputln!("Uploading {}.asc", config.key());
                         try!(repo::client::put_key(url, cached));
                     }
-                    Err(_) => return Err(BldrError::KeyNotFound(config.key().to_string())),
+                    Err(_) =>
+                        return Err(bldr_error!(ErrorKind::KeyNotFound(config.key().to_string()))),
                 }
             } else {
-                return Err(BldrError::FileNotFound(config.key().to_string()));
+                return Err(bldr_error!(ErrorKind::FileNotFound(config.key().to_string())));
             }
         }
     }
-    println!("   {}: complete", config.key());
+    outputln!("Complete");
     Ok(())
 }

--- a/src/bldr/command/repo.rs
+++ b/src/bldr/command/repo.rs
@@ -39,12 +39,14 @@ use config::Config;
 use error::BldrResult;
 use repo;
 
+static LOGKEY: &'static str = "CR";
+
 /// Starts the repository.
 ///
 /// # Failures
 ///
 /// * Fails if the repository fails to start - canot bind to the port, etc.
 pub fn start(config: &Config) -> BldrResult<()> {
-    println!("Repo listening on {:?}", config.repo_addr());
+    outputln!("Repo listening on {:?}", config.repo_addr());
     repo::run(&config)
 }

--- a/src/bldr/command/upload.rs
+++ b/src/bldr/command/upload.rs
@@ -37,6 +37,8 @@ use config::Config;
 use pkg::Package;
 use repo;
 
+static LOGKEY: &'static str = "CU";
+
 /// Upload a package to a repository.
 ///
 /// Find the latest package, then read it from the cache, and upload to the repository.
@@ -49,10 +51,8 @@ use repo;
 pub fn package(config: &Config) -> BldrResult<()> {
     let url = config.url().as_ref().unwrap();
     let package = try!(Package::latest(config.deriv(), config.package(), None, None));
-    println!("   {}: Uploading from {}",
-             &package,
-             package.cache_file().to_string_lossy());
+    outputln!("Uploading from {}", package.cache_file().to_string_lossy());
     try!(repo::client::put_package(url, &package));
-    println!("   {}: complete", config.package());
+    outputln!("Complete");
     Ok(())
 }

--- a/src/bldr/lib.rs
+++ b/src/bldr/lib.rs
@@ -43,8 +43,10 @@
 //! * [The bldr Repo; http based package repository](repo)
 //!
 
-#[macro_use] extern crate hyper;
-#[macro_use] extern crate log;
+#[macro_use]
+extern crate hyper;
+#[macro_use]
+extern crate log;
 extern crate tempdir;
 extern crate mustache;
 extern crate rustc_serialize;
@@ -55,11 +57,202 @@ extern crate libc;
 extern crate url;
 extern crate fnv;
 extern crate iron;
-#[macro_use] extern crate router;
+#[macro_use]
+extern crate router;
 extern crate time;
 extern crate wonder;
 extern crate uuid;
 
+#[macro_export]
+/// Creates a new BldrError, embedding the current file name, line number, column, and module path.
+macro_rules! bldr_error {
+    ($p: expr) => {
+        {
+            use $crate::error::BldrError;
+            BldrError::new($p, LOGKEY, file!(), line!(), column!())
+        }
+    }
+}
+
+#[macro_export]
+/// Works the same as the print! macro, but uses our StructuredOutput formatter.
+macro_rules! output {
+    ($content: expr) => {
+        {
+            use $crate::output::StructuredOutput;
+            let so = StructuredOutput::new("bldr",
+                                           LOGKEY,
+                                           line!(),
+                                           file!(),
+                                           column!(),
+                                           $content);
+            print!("{}", so);
+        }
+    };
+    (P: $preamble: expr, $content: expr) => {
+        {
+            use $crate::output::StructuredOutput;
+            let so = StructuredOutput::new($preamble,
+                                           LOGKEY,
+                                           line!(),
+                                           file!(),
+                                           column!(),
+                                           $content);
+            print!("{}", so);
+        }
+    };
+    ($content: expr, $($arg:tt)*) => {
+        {
+            use $crate::output::StructuredOutput;
+            let content = format!($content, $($arg)*);
+            let so = StructuredOutput::new("bldr",
+                                           LOGKEY,
+                                           line!(),
+                                           file!(),
+                                           column!(),
+                                           &content);
+            print!("{}", so);
+        }
+    };
+    (P: $preamble: expr, $content: expr, $($arg:tt)*) => {
+        {
+            use $crate::output::StructuredOutput;
+            let content = format!($content, $($arg)*);
+            let so = StructuredOutput::new($preamble,
+                                           LOGKEY,
+                                           line!(),
+                                           file!(),
+                                           column!(),
+                                           &content);
+            print!("{}", so);
+        }
+    };
+}
+
+#[macro_export]
+/// Works the same as println!, but uses our structured output formatter.
+macro_rules! outputln {
+    ($content: expr) => {
+        {
+            use $crate::output::StructuredOutput;
+            let so = StructuredOutput::new("bldr",
+                                           LOGKEY,
+                                           line!(),
+                                           file!(),
+                                           column!(),
+                                           $content);
+            println!("{}", so);
+        }
+    };
+    (P: $preamble:expr, $content: expr) => {
+        {
+            use $crate::output::StructuredOutput;
+            let so = StructuredOutput::new($preamble,
+                                           LOGKEY,
+                                           line!(),
+                                           file!(),
+                                           column!(),
+                                           $content);
+            println!("{}", so);
+        }
+    };
+    ($content: expr, $($arg:tt)*) => {
+        {
+            use $crate::output::StructuredOutput;
+            let content = format!($content, $($arg)*);
+            let so = StructuredOutput::new("bldr",
+                                           LOGKEY,
+                                           line!(),
+                                           file!(),
+                                           column!(),
+                                           &content);
+            println!("{}", so);
+        }
+    };
+    (P: $preamble: expr, $content: expr, $($arg:tt)*) => {
+        {
+            use $crate::output::StructuredOutput;
+            let content = format!($content, $($arg)*);
+            let so = StructuredOutput::new($preamble,
+                                           LOGKEY,
+                                           line!(),
+                                           file!(),
+                                           column!(),
+                                           &content);
+            println!("{}", so);
+        }
+    }
+}
+
+#[macro_export]
+/// Works the same as format!, but uses our structured output formatter.
+macro_rules! output_format {
+    ($content: expr) => {
+        {
+            use $crate::output::StructuredOutput;
+            let so = StructuredOutput::new("bldr",
+                                           LOGKEY,
+                                           line!(),
+                                           file!(),
+                                           column!(),
+                                           $content);
+            format!("{}", so)
+        }
+    };
+    (P: $preamble:expr, $content: expr) => {
+        {
+            use $crate::output::StructuredOutput;
+            let so = StructuredOutput::new($preamble,
+                                           LOGKEY,
+                                           line!(),
+                                           file!(),
+                                           column!(),
+                                           $content);
+            format!("{}", so)
+        }
+    };
+    (P: $preamble:expr, L: $logkey:expr) => {
+        {
+            use $crate::output::StructuredOutput;
+            let so = StructuredOutput::new($preamble,
+                                           $logkey,
+                                           line!(),
+                                           file!(),
+                                           column!(),
+                                           "");
+            format!("{}", so)
+        }
+    };
+
+    ($content: expr, $($arg:tt)*) => {
+        {
+            use $crate::output::StructuredOutput;
+            let content = format!($content, $($arg)*);
+            let so = StructuredOutput::new("bldr",
+                                           LOGKEY,
+                                           line!(),
+                                           file!(),
+                                           column!(),
+                                           &content);
+            format!("{}", so)
+        }
+    };
+    (P: $preamble: expr, $content: expr, $($arg:tt)*) => {
+        {
+            use $crate::output::StructuredOutput;
+            let content = format!($content, $($arg)*);
+            let so = StructuredOutput::new($preamble,
+                                           LOGKEY,
+                                           line!(),
+                                           file!(),
+                                           column!(),
+                                           &content);
+            format!("{}", so)
+        }
+    }
+}
+
+pub mod output;
 pub mod error;
 pub mod command;
 pub mod util;

--- a/src/bldr/output.rs
+++ b/src/bldr/output.rs
@@ -1,0 +1,209 @@
+//
+// Copyright:: Copyright (c) 2015 Chef Software, Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//! Formats user-visible output for Bldr.
+//!
+//! Most of this module is used via the `output!`, `outputln!`, and `output_format!` macros. They
+//! create a `StructuredOutput` struct, which includes the line number, file name, and column it
+//! was called on. Additionally, it uses a standard constant called `LOGKEY` as a short hint as to
+//! where the output was generated within bldr. Also supported is a `preamble`, which is used to
+//! denote when output comes from a running service rather than bldr itself.
+//!
+//! The `StructuredOutput` struct supports two global options - verbosity and coloring. If verbose
+//! is turned on, then every line printed is annotated with its preamble, logkey, and precise
+//! location. Without verbose, it prints simply the preamble and logkey. Coloring does what it says
+//! on the tin :)
+
+use std::sync::atomic::{AtomicBool, Ordering, ATOMIC_BOOL_INIT};
+use std::fmt;
+
+use ansi_term::Colour::{White, Cyan, Green};
+
+static mut VERBOSE: AtomicBool = ATOMIC_BOOL_INIT;
+// I am sorry this isn't named the other way; I can't get an atomic initializer that defaults to
+// true. Them's the breaks.
+static mut NO_COLOR: AtomicBool = ATOMIC_BOOL_INIT;
+
+/// True if verbose output is on.
+pub fn is_verbose() -> bool {
+    unsafe { VERBOSE.load(Ordering::Relaxed) }
+}
+
+/// Turn verbose output on or off.
+pub fn set_verbose(booly: bool) {
+    unsafe {
+        VERBOSE.store(booly, Ordering::Relaxed);
+    }
+}
+
+/// True if color is enabled
+pub fn is_color() -> bool {
+    unsafe {
+        if NO_COLOR.load(Ordering::Relaxed) {
+            false
+        } else {
+            true
+        }
+    }
+}
+
+/// Set to true if you want color to turn off.
+pub fn set_no_color(booly: bool) {
+    unsafe {
+        NO_COLOR.store(booly, Ordering::Relaxed);
+    }
+}
+
+/// Adds structure to printed output. Stores a preamble, a logkey, line, file, column, and content
+/// to print.
+pub struct StructuredOutput<'a> {
+    preamble: &'a str,
+    logkey: &'static str,
+    line: u32,
+    file: &'static str,
+    column: u32,
+    content: &'a str,
+    pub verbose: Option<bool>,
+    pub color: Option<bool>,
+}
+
+impl<'a> StructuredOutput<'a> {
+    /// Return a new StructuredOutput struct.
+    pub fn new(preamble: &'a str,
+               logkey: &'static str,
+               line: u32,
+               file: &'static str,
+               column: u32,
+               content: &'a str)
+               -> StructuredOutput<'a> {
+        StructuredOutput {
+            preamble: preamble,
+            logkey: logkey,
+            line: line,
+            file: file,
+            column: column,
+            content: content,
+            verbose: None,
+            color: None,
+        }
+    }
+}
+
+// If we ever want to create multiple output formats in the future, we would do it here -
+// essentially create a flag we check to see what output you want, then call a different formatting
+// function. Viola!
+impl<'a> fmt::Display for StructuredOutput<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let verbose = self.verbose.unwrap_or(is_verbose());
+        let color = self.color.unwrap_or(is_color());
+        let preamble_color = match self.preamble {
+            "bldr" => Cyan,
+            _ => Green,
+        };
+        if verbose {
+            if color {
+                write!(f,
+                       "{}({})[{}]: {}",
+                       preamble_color.paint(self.preamble),
+                       White.bold().paint(self.logkey),
+                       White.underline()
+                            .paint(&format!("{}:{}:{}", self.file, self.line, self.column)),
+                       self.content)
+            } else {
+                write!(f,
+                       "{}({})[{}:{}:{}]: {}",
+                       self.preamble,
+                       self.logkey,
+                       self.file,
+                       self.line,
+                       self.column,
+                       self.content)
+            }
+        } else {
+            if color {
+                write!(f,
+                       "{}({}): {}",
+                       preamble_color.paint(self.preamble),
+                       White.bold().paint(self.logkey),
+                       self.content)
+            } else {
+                write!(f, "{}({}): {}", self.preamble, self.logkey, self.content)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::StructuredOutput;
+    use ansi_term::Colour::{White, Cyan};
+
+    static LOGKEY: &'static str = "SOT";
+
+    fn so<'a>(preamble: &'a str, content: &'a str) -> StructuredOutput<'a> {
+        StructuredOutput::new(preamble, LOGKEY, 1, file!(), 2, content)
+    }
+
+    #[test]
+    fn new() {
+        let so = so("bldr", "opeth is amazing");
+        assert_eq!(so.logkey, "SOT");
+        assert_eq!(so.preamble, "bldr");
+        assert_eq!(so.content, "opeth is amazing");
+    }
+
+    #[test]
+    fn format() {
+        let mut so = so("bldr", "opeth is amazing");
+        so.verbose = Some(false);
+        so.color = Some(false);
+        assert_eq!(format!("{}", so), "bldr(SOT): opeth is amazing");
+    }
+
+    #[test]
+    fn format_color() {
+        let mut so = so("bldr", "opeth is amazing");
+        so.verbose = Some(false);
+        so.color = Some(true);
+        assert_eq!(format!("{}", so),
+                   format!("{}({}): opeth is amazing",
+                           Cyan.paint("bldr"),
+                           White.bold().paint("SOT")));
+    }
+
+    #[test]
+    fn format_verbose() {
+        let mut so = so("bldr", "opeth is amazing");
+        so.verbose = Some(true);
+        so.color = Some(false);
+        assert_eq!(format!("{}", so),
+                   "bldr(SOT)[src/bldr/output.rs:1:2]: opeth is amazing");
+    }
+
+    #[test]
+    fn format_verbose_color() {
+        let mut so = so("bldr", "opeth is amazing");
+        so.verbose = Some(true);
+        so.color = Some(true);
+        assert_eq!(format!("{}", so),
+                   format!("{}({})[{}]: opeth is amazing",
+                   Cyan.paint("bldr"),
+                   White.bold().paint("SOT"),
+                   White.underline().paint("src/bldr/output.rs:1:2"),
+                   ));
+    }
+}

--- a/src/bldr/topology/leader.rs
+++ b/src/bldr/topology/leader.rs
@@ -21,6 +21,8 @@ use error::{BldrResult, BldrError};
 use pkg::Package;
 use config::Config;
 
+static LOGKEY: &'static str = "TL";
+
 pub fn run(package: Package, config: &Config) -> BldrResult<()> {
     let mut worker = try!(Worker::new(package, String::from("leader"), config));
     let mut sm: StateMachine<State, Worker, BldrError> = StateMachine::new(State::Init);
@@ -46,8 +48,7 @@ fn state_init(worker: &mut Worker) -> BldrResult<(State, u32)> {
 }
 
 fn state_restore_dataset(worker: &mut Worker) -> BldrResult<(State, u32)> {
-    println!("   {}: Restoring the dataset from a peer",
-             worker.preamble());
+    outputln!("Restoring the dataset from a peer");
     let ce = try!(worker.census.me_mut());
     ce.data_init(Some(true));
     Ok((State::DetermineViability, 0))

--- a/src/bldr/util/gpg.rs
+++ b/src/bldr/util/gpg.rs
@@ -19,8 +19,10 @@ use std::process::Command;
 use std::fs;
 
 use fs::GPG_CACHE;
-use error::{BldrResult, BldrError};
+use error::{BldrResult, ErrorKind};
 use util::perm;
+
+static LOGKEY: &'static str = "GP";
 
 fn gpg_cmd() -> Command {
     let mut command = Command::new("gpg");
@@ -37,13 +39,13 @@ pub fn import(status: &str, keyfile: &str) -> BldrResult<()> {
                           .arg(keyfile)
                           .output());
     match output.status.success() {
-        true => println!("   {}: GPG key imported", status),
+        true => outputln!("{} GPG key imported", status),
         false => {
-            println!("   {}: GPG import failed:\n{}\n{}",
-                     status,
-                     String::from_utf8_lossy(&output.stdout),
-                     String::from_utf8_lossy(&output.stderr));
-            return Err(BldrError::GPGImportFailed);
+            outputln!("{} GPG import failed:\n{}\n{}",
+                      status,
+                      String::from_utf8_lossy(&output.stdout),
+                      String::from_utf8_lossy(&output.stderr));
+            return Err(bldr_error!(ErrorKind::GPGImportFailed));
         }
     }
     Ok(())
@@ -55,10 +57,10 @@ pub fn verify(status: &str, file: &str) -> BldrResult<()> {
                           .arg(file)
                           .output());
     match output.status.success() {
-        true => println!("   {}: GPG signature verified", status),
+        true => outputln!("{} GPG signature verified", status),
         false => {
-            println!("   {}: GPG signature failed", status);
-            return Err(BldrError::GPGVerifyFailed);
+            outputln!("{} GPG signature failed", status);
+            return Err(bldr_error!(ErrorKind::GPGVerifyFailed));
         }
     }
     Ok(())

--- a/src/bldr/util/perm.rs
+++ b/src/bldr/util/perm.rs
@@ -15,8 +15,10 @@
 // limitations under the License.
 //
 
-use error::{BldrResult, BldrError};
+use error::{BldrResult, ErrorKind};
 use std::process::Command;
+
+static LOGKEY: &'static str = "UP";
 
 pub fn set_owner(path: &str, owner: &str) -> BldrResult<()> {
     let output = try!(Command::new("chown")
@@ -26,7 +28,7 @@ pub fn set_owner(path: &str, owner: &str) -> BldrResult<()> {
     match output.status.success() {
         true => Ok(()),
         false => {
-            Err(BldrError::PermissionFailed)
+            Err(bldr_error!(ErrorKind::PermissionFailed))
         }
     }
 }
@@ -42,7 +44,7 @@ pub fn set_permissions(path: &str, perm: &str) -> BldrResult<()> {
     match output.status.success() {
         true => Ok(()),
         false => {
-            Err(BldrError::PermissionFailed)
+            Err(bldr_error!(ErrorKind::PermissionFailed))
         }
     }
 }

--- a/src/bldr/util/signals.rs
+++ b/src/bldr/util/signals.rs
@@ -27,7 +27,9 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering, ATOMIC_USIZE_INIT, AT
 use wonder::actor;
 use wonder::actor::{ActorSender, HandleResult, InitResult, StopReason};
 
-use error::{BldrResult, BldrError};
+use error::{BldrResult, BldrError, ErrorKind};
+
+static LOGKEY: &'static str = "US";
 
 const TIMEOUT_MS: u64 = 30;
 static INIT: Once = ONCE_INIT;
@@ -99,7 +101,7 @@ impl actor::GenServer for SignalNotifier {
                 SIGNAL.store(0 as usize, Ordering::SeqCst);
             });
             if ALIVE.compare_and_swap(false, true, Ordering::Relaxed) {
-                return Err(BldrError::SignalNotifierStarted);
+                return Err(bldr_error!(ErrorKind::SignalNotifierStarted));
             }
         }
         Ok(Some(TIMEOUT_MS))

--- a/src/bldr/util/sys.rs
+++ b/src/bldr/util/sys.rs
@@ -15,8 +15,10 @@
 // limitations under the License.
 //
 
-use error::{BldrResult, BldrError};
+use error::{BldrResult, ErrorKind};
 use std::process::Command;
+
+static LOGKEY: &'static str = "US";
 
 pub fn ip() -> BldrResult<String> {
     debug!("Shelling out to determine IP address");
@@ -34,7 +36,7 @@ pub fn ip() -> BldrResult<String> {
             debug!("IP address command returned: OUT: {} ERR: {}",
                    String::from_utf8_lossy(&output.stdout),
                    String::from_utf8_lossy(&output.stderr));
-            Err(BldrError::IPFailed)
+            Err(bldr_error!(ErrorKind::IPFailed))
         }
     }
 }
@@ -56,7 +58,7 @@ pub fn hostname() -> BldrResult<String> {
             debug!("Hostname address command returned: OUT: {} ERR: {}",
                    String::from_utf8_lossy(&output.stdout),
                    String::from_utf8_lossy(&output.stderr));
-            Err(BldrError::IPFailed)
+            Err(bldr_error!(ErrorKind::IPFailed))
         }
     }
 }

--- a/tests/bldr/repo.rs
+++ b/tests/bldr/repo.rs
@@ -35,8 +35,8 @@ fn upload_a_package_and_then_install_it() {
     upload.wait_with_output();
     assert_cmd_exit_code!(upload, [0]);
     assert_regex!(upload.stdout(), r"Upload Bldr Package (.+)");
-    assert_regex!(upload.stdout(), r"simple_service: uploading (.+)");
-    assert_regex!(upload.stdout(), r"simple_service: complete");
+    assert_regex!(upload.stdout(), r"Uploading (.+)");
+    assert_regex!(upload.stdout(), r"Complete");
     let mut install = command::bldr(&["install",
                                       "test/simple_service",
                                       "-u",


### PR DESCRIPTION
- Creates a new output module, that handles colorizing and pretty output
- Adds the output!, outputln!, and output_format! macros, that work like
  print!, println!, and format!, but use the output module.
- Adds the LOGKEY constant, for tracking where messages come from within
  bldr.
- Adds a 'verbose' flag to every command, that adds the file name, line
  number, and column where the output statement was called.
- Moves our errors into a BldrError struct, which tracks the file, line,
  and column where the error was created.
- Adds a bldr_error! macro, which takes the renamed "ErrorKind" enum as
  an argument, and creates a new BldrError instead.
- Prints all errors as if the "verbose" flag was always on - the side
  effect is that all errors (except those driven by the From trait)
  include the file name and line number they were created from.
- Updates every user-visible print! and println! statement to use
  output! and outputln!
- Updates every occurence of BldrError to use the bldr_error! macro
  instead
