### PR TITLE
Add ability to recursively install dependencies of a package

### DIFF
--- a/plans/Makefile
+++ b/plans/Makefile
@@ -1,30 +1,23 @@
+PKGS := glibc libgcc zlib cacerts busybox gnupg openssl runit bldr redis ncurses libedit bzip2 pcre nginx haproxy libaio libltdl libxml2 numactl perl
+REPO := http://ec2-52-10-238-149.us-west-2.compute.amazonaws.com
+
 world: gpg
-	./bldr-build glibc
-	./bldr-build libgcc
-	./bldr-build zlib
-	./bldr-build cacerts
-	./bldr-build busybox
-	./bldr-build gnupg
-	./bldr-build openssl
-	./bldr-build runit
-	./bldr-build bldr
-	./bldr-build redis
-	./bldr-build ncurses
-	./bldr-build libedit
-	./bldr-build bzip2
-	./bldr-build pcre
-	./bldr-build nginx
-	./bldr-build haproxy
-	./bldr-build libaio
-	./bldr-build libltdl
-	./bldr-build libxml2
-	./bldr-build numactl
-	./bldr-build perl
+	@for pkg in $(PKGS); do \
+		./bldr-build $$pkg; \
+	done
 	cp ./chef-public.gpg /opt/bldr/cache/keys/chef-public.asc
+
+publish:
+	cargo build --release
+	@for pkg in $(PKGS); do \
+		../target/release/bldr upload chef/$$pkg -u $(REPO); \
+	done
 
 gpg:
 	- gpg --import chef-public.gpg
 	- gpg --import chef-private.gpg
+	- gpg --homedir /opt/bldr/cache/gpg --import chef-public.gpg
+	- gpg --homedir /opt/bldr/cache/gpg --import chef-private.gpg
 
 clean:
 	rm -rf /opt/bldr/pkgs/*

--- a/plans/bldr-build
+++ b/plans/bldr-build
@@ -721,6 +721,8 @@ link_libraries() {
     echo $dep_pkg_name >> $pkg_path/DEPS
   done
 
+  echo "${pkg_derivation}/${pkg_name}/${pkg_version}/${pkg_rel}" >> $pkg_path/IDENT
+
   return 0
 }
 

--- a/src/bldr/config.rs
+++ b/src/bldr/config.rs
@@ -202,6 +202,23 @@ impl Config {
     pub fn repo_addr(&self) -> net::SocketAddrV4 {
         net::SocketAddrV4::new(self.listen_addr.0.clone(), self.port.0.clone())
     }
+
+    pub fn package_id(&self) -> String {
+        if self.version.is_some() && self.release.is_some() {
+            format!("{}/{}/{}/{}",
+                    &self.deriv,
+                    &self.package,
+                    self.version.as_ref().unwrap(),
+                    self.release.as_ref().unwrap())
+        } else if self.version.is_some() {
+            format!("{}/{}/{}",
+                    self.deriv,
+                    self.package,
+                    self.version.as_ref().unwrap())
+        } else {
+            format!("{}/{}", self.deriv, self.package)
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -246,23 +246,22 @@ fn configure(config: &Config) -> BldrResult<()> {
 /// Install a package
 #[allow(dead_code)]
 fn install(config: &Config) -> BldrResult<()> {
-    outputln!("Installing {}", Yellow.bold().paint(config.package()));
-    let pkg_file = try!(install::from_url(&config.url().as_ref().unwrap(),
-                                          config.deriv(),
-                                          config.package(),
-                                          config.version(),
-                                          config.release()));
-    try!(install::verify(config.package(), &pkg_file));
-    try!(install::unpack(config.package(), &pkg_file));
+    outputln!("Installing {}", Yellow.bold().paint(&config.package_id()));
+    try!(install::from_url(&config.url().as_ref().unwrap(),
+                           config.deriv(),
+                           config.package(),
+                           config.version().clone(),
+                           config.release().clone()));
     Ok(())
 }
 
 /// Start a service
 #[allow(dead_code)]
 fn start(config: &Config) -> BldrResult<()> {
-    outputln!("Starting {}", Yellow.bold().paint(config.package()));
+    outputln!("Starting {}", Yellow.bold().paint(&config.package_id()));
     try!(start::package(config));
-    outputln!("Finished with {}", Yellow.bold().paint(config.package()));
+    outputln!("Finished with {}",
+              Yellow.bold().paint(&config.package_id()));
     Ok(())
 }
 
@@ -272,7 +271,8 @@ fn repo(config: &Config) -> BldrResult<()> {
     outputln!("Starting Bldr Repository at {}",
               Yellow.bold().paint(config.path()));
     try!(repo::start(&config));
-    outputln!("Finished with {}", Yellow.bold().paint(config.package()));
+    outputln!("Finished with {}",
+              Yellow.bold().paint(&config.package_id()));
     Ok(())
 }
 
@@ -282,7 +282,8 @@ fn upload(config: &Config) -> BldrResult<()> {
     outputln!("Upload Bldr Package {}",
               Yellow.bold().paint(config.package()));
     try!(upload::package(&config));
-    outputln!("Finished with {}", Yellow.bold().paint(config.package()));
+    outputln!("Finished with {}",
+              Yellow.bold().paint(&config.package_id()));
     Ok(())
 }
 

--- a/tests/fixtures/bldr_build/plan.sh
+++ b/tests/fixtures/bldr_build/plan.sh
@@ -31,4 +31,3 @@ install() {
   chmod 755 $pkg_path/bin/*
 	return 0
 }
-


### PR DESCRIPTION
![screen shot 2015-11-25 at 12 22 22 am](https://cloud.githubusercontent.com/assets/54036/11391884/a7fe1862-930a-11e5-9192-55a8f22b0b16.png)

The main primary improvement in this PR is the addition of recursive dependency installation on package install.

Additional improvements/changes:
- added `IDENT` file to generated metadata files output from bldr-build
- general improvements to output for install command
- differentiate between a package definition (`Package`) and the downloaded artifact by creating the `PackageArchive` struct and moving related functions as member and class functions
