### PR TITLE
refactor `pkg` module into `package` module and submodule friends

### DIFF
--- a/src/bldr/census.rs
+++ b/src/bldr/census.rs
@@ -45,7 +45,7 @@ use config::Config;
 use error::{BldrResult, BldrError, ErrorKind};
 use discovery::etcd::{self, EtcdWrite};
 use util;
-use pkg::Package;
+use package::Package;
 
 static LOGKEY: &'static str = "CN";
 

--- a/src/bldr/command/configure.rs
+++ b/src/bldr/command/configure.rs
@@ -30,7 +30,7 @@ use std::fs::File;
 
 use error::BldrResult;
 use config::Config;
-use pkg::Package;
+use package::Package;
 
 /// Print the default.toml for a given package.
 ///

--- a/src/bldr/command/install.rs
+++ b/src/bldr/command/install.rs
@@ -60,7 +60,7 @@ use std::fs;
 
 use fs::PACKAGE_CACHE;
 use error::BldrResult;
-use pkg::Package;
+use package::Package;
 use repo;
 
 static LOGKEY: &'static str = "CI";

--- a/src/bldr/command/start.rs
+++ b/src/bldr/command/start.rs
@@ -64,7 +64,7 @@ use ansi_term::Colour::Yellow;
 use fs::PACKAGE_CACHE;
 use error::{BldrResult, ErrorKind};
 use config::Config;
-use pkg::Package;
+use package::Package;
 use topology::{self, Topology};
 use command::install;
 use repo;

--- a/src/bldr/command/upload.rs
+++ b/src/bldr/command/upload.rs
@@ -34,7 +34,7 @@
 use error::BldrResult;
 use config::Config;
 
-use pkg::Package;
+use package::Package;
 use repo;
 
 static LOGKEY: &'static str = "CU";

--- a/src/bldr/error.rs
+++ b/src/bldr/error.rs
@@ -56,7 +56,7 @@ use hyper;
 use toml;
 use mustache;
 use regex;
-use pkg;
+use package;
 use output::StructuredOutput;
 
 static LOGKEY: &'static str = "ER";
@@ -108,7 +108,7 @@ pub enum ErrorKind {
     UnpackFailed,
     TomlParser(Vec<toml::ParserError>),
     MustacheEncoderError(mustache::encoder::Error),
-    MetaFileNotFound(pkg::MetaFile),
+    MetaFileNotFound(package::MetaFile),
     PermissionFailed,
     BadVersion,
     RegexParse(regex::Error),
@@ -129,7 +129,7 @@ pub enum ErrorKind {
     UnknownTopology(String),
     NoConfiguration,
     HealthCheck(String),
-    HookFailed(pkg::HookType, i32, String),
+    HookFailed(package::HookType, i32, String),
     TryRecvError(mpsc::TryRecvError),
     BadWatch(String),
     NoXFilename,

--- a/src/bldr/lib.rs
+++ b/src/bldr/lib.rs
@@ -256,7 +256,7 @@ pub mod output;
 pub mod error;
 pub mod command;
 pub mod util;
-pub mod pkg;
+pub mod package;
 pub mod discovery;
 pub mod topology;
 pub mod state_machine;

--- a/src/bldr/package/archive.rs
+++ b/src/bldr/package/archive.rs
@@ -1,0 +1,173 @@
+//
+// Copyright:: Copyright (c) 2015 Chef Software, Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use std::fmt;
+use std::path::PathBuf;
+use std::process::Command;
+
+use regex::Regex;
+
+use error::{BldrResult, BldrError, ErrorKind};
+use fs::GPG_CACHE;
+use package::Package;
+use util::gpg;
+
+static LOGKEY: &'static str = "PA";
+
+#[derive(Debug)]
+pub enum MetaFile {
+    CFlags,
+    Deps,
+    Exposes,
+    Ident,
+    LdRunPath,
+    LdFlags,
+    Manifest,
+    Path,
+}
+
+impl fmt::Display for MetaFile {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let id = match *self {
+            MetaFile::CFlags => "CFLAGS",
+            MetaFile::Deps => "DEPS",
+            MetaFile::Exposes => "EXPOSES",
+            MetaFile::Ident => "IDENT",
+            MetaFile::LdRunPath => "LD_RUN_PATH",
+            MetaFile::LdFlags => "LDFLAGS",
+            MetaFile::Manifest => "MANIFEST",
+            MetaFile::Path => "PATH",
+        };
+        write!(f, "{}", id)
+    }
+}
+
+#[derive(Debug)]
+pub struct PackageArchive {
+    pub path: PathBuf,
+}
+
+impl PackageArchive {
+    pub fn new(path: PathBuf) -> Self {
+        PackageArchive { path: path }
+    }
+
+    /// A package struct representing the contents of this archive.
+    ///
+    /// # Failures
+    ///
+    /// * If an `IDENT` metafile is not found in the archive
+    /// * If the archive cannot be read
+    /// * If the archive cannot be verified
+    pub fn package(&self) -> BldrResult<Package> {
+        let body = try!(self.read_metadata(MetaFile::Ident));
+        let mut package = try!(Package::from_ident(&body));
+        match self.deps() {
+            Ok(Some(deps)) => {
+                for dep in deps {
+                    package.add_dep(dep);
+                }
+            }
+            Ok(None) => {}
+            Err(e) => return Err(e),
+        }
+        Ok(package)
+    }
+
+    /// List of package structs representing the package dependencies for this archive.
+    ///
+    /// # Failures
+    ///
+    /// * If a `DEPS` metafile is not found in the archive
+    /// * If the archive cannot be read
+    /// * If the archive cannot be verified
+    pub fn deps(&self) -> BldrResult<Option<Vec<Package>>> {
+        match self.read_metadata(MetaFile::Deps) {
+            Ok(body) => {
+                let dep_strs: Vec<&str> = body.split("\n").collect();
+                let mut deps = vec![];
+                for dep in &dep_strs {
+                    match Package::from_ident(&dep) {
+                        Ok(package) => deps.push(package),
+                        Err(_) => continue,
+                    }
+                }
+                Ok(Some(deps))
+            }
+            Err(BldrError{err: ErrorKind::MetaFileNotFound(_), ..}) => Ok(None),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// A plain string representation of the archive's file name.
+    pub fn file_name(&self) -> String {
+        self.path.file_name().unwrap().to_string_lossy().into_owned()
+    }
+
+    /// Given a package name and a path to a file as an `&str`, verify
+    /// the files gpg signature.
+    ///
+    /// # Failures
+    ///
+    /// * Fails if it cannot verify the GPG signature for any reason
+    pub fn verify(&self) -> BldrResult<()> {
+        gpg::verify(self.path.to_str().unwrap())
+    }
+
+    /// Given a package name and a path to a file as an `&str`, unpack
+    /// the package.
+    ///
+    /// # Failures
+    ///
+    /// * If the package cannot be unpacked via gpg
+    pub fn unpack(&self) -> BldrResult<Package> {
+        let output = try!(Command::new("sh")
+                              .arg("-c")
+                              .arg(format!("gpg --homedir {} --decrypt {} | tar -C / -x",
+                                           GPG_CACHE,
+                                           self.path.to_str().unwrap()))
+                              .output());
+        match output.status.success() {
+            true => self.package(),
+            false => Err(bldr_error!(ErrorKind::UnpackFailed)),
+        }
+    }
+
+    fn read_metadata(&self, file: MetaFile) -> BldrResult<String> {
+        let output = try!(Command::new("sh")
+                              .arg("-c")
+                              .arg(format!("gpg --homedir {} --decrypt {} | tar xO --wildcards \
+                                            --no-anchored {}",
+                                           GPG_CACHE,
+                                           self.path.to_string_lossy(),
+                                           file))
+                              .output());
+        match output.status.success() {
+            true => {
+                Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+            }
+            false => {
+                let re = Regex::new(&format!("{}: Not found in archive", file)).unwrap();
+                if re.is_match(&String::from_utf8_lossy(&output.stderr)) {
+                    Err(bldr_error!(ErrorKind::MetaFileNotFound(file)))
+                } else {
+                    Err(bldr_error!(ErrorKind::ArchiveReadFailed(String::from_utf8_lossy(&output.stderr).into_owned())))
+                }
+            }
+        }
+    }
+}

--- a/src/bldr/package/hooks.rs
+++ b/src/bldr/package/hooks.rs
@@ -1,0 +1,161 @@
+//
+// Copyright:: Copyright (c) 2015 Chef Software, Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use std::fmt;
+use std::fs::{self, OpenOptions};
+use std::io::prelude::*;
+use std::os::unix::fs::OpenOptionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{self, Command};
+
+use mustache;
+
+use error::{BldrResult, ErrorKind};
+use package::Package;
+use service_config::ServiceConfig;
+use util::convert;
+
+static LOGKEY: &'static str = "PH";
+
+#[derive(Debug, Clone)]
+pub enum HookType {
+    HealthCheck,
+    Reconfigure,
+    Run,
+    Init,
+}
+
+impl fmt::Display for HookType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            &HookType::Init => write!(f, "init"),
+            &HookType::HealthCheck => write!(f, "health_check"),
+            &HookType::Reconfigure => write!(f, "reconfigure"),
+            &HookType::Run => write!(f, "run"),
+        }
+    }
+}
+
+pub struct Hook {
+    pub htype: HookType,
+    pub template: PathBuf,
+    pub path: PathBuf,
+}
+
+impl Hook {
+    pub fn new(htype: HookType, template: PathBuf, path: PathBuf) -> Self {
+        Hook {
+            htype: htype,
+            template: template,
+            path: path,
+        }
+    }
+
+    pub fn run(&self, context: Option<&ServiceConfig>) -> BldrResult<String> {
+        try!(self.compile(context));
+        match Command::new(&self.path).output() {
+            Ok(result) => {
+                let output = Self::format_output(&result);
+                match result.status.code() {
+                    Some(0) => Ok(output),
+                    Some(code) =>
+                        Err(bldr_error!(ErrorKind::HookFailed(self.htype.clone(), code, output))),
+                    None => Err(bldr_error!(ErrorKind::HookFailed(self.htype.clone(), -1, output))),
+                }
+            }
+            Err(_) => {
+                let err = format!("couldn't run hook: {}", &self.path.to_string_lossy());
+                Err(bldr_error!(ErrorKind::HookFailed(self.htype.clone(), -1, err)))
+            }
+        }
+    }
+
+    pub fn compile(&self, context: Option<&ServiceConfig>) -> BldrResult<()> {
+        if let Some(ctx) = context {
+            let template = try!(mustache::compile_path(&self.template));
+            let mut out = Vec::new();
+            let toml = try!(ctx.compile_toml());
+            let data = convert::toml_table_to_mustache(toml);
+            template.render_data(&mut out, &data);
+            let data = try!(String::from_utf8(out));
+            let mut file = try!(OpenOptions::new()
+                                    .write(true)
+                                    .truncate(true)
+                                    .create(true)
+                                    .read(true)
+                                    .mode(0o770)
+                                    .open(&self.path));
+            try!(write!(&mut file, "{}", data));
+            Ok(())
+        } else {
+            try!(fs::copy(&self.template, &self.path));
+            Ok(())
+        }
+    }
+
+    fn format_output(output: &process::Output) -> String {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        format!("{}\n{}", stdout, stderr)
+    }
+}
+
+pub struct HookTable<'a> {
+    pub package: &'a Package,
+    pub init_hook: Option<Hook>,
+    pub health_check_hook: Option<Hook>,
+    pub reconfigure_hook: Option<Hook>,
+    pub run_hook: Option<Hook>,
+}
+
+impl<'a> HookTable<'a> {
+    pub fn new(package: &'a Package) -> Self {
+        HookTable {
+            package: package,
+            init_hook: None,
+            health_check_hook: None,
+            reconfigure_hook: None,
+            run_hook: None,
+        }
+    }
+
+    pub fn load_hooks(&mut self) -> &mut Self {
+        let hook_path = self.package.join_path("hooks");
+        let path = Path::new(&hook_path);
+        match fs::metadata(path) {
+            Ok(meta) => {
+                if meta.is_dir() {
+                    self.init_hook = self.load_hook(HookType::Init);
+                    self.reconfigure_hook = self.load_hook(HookType::Reconfigure);
+                    self.health_check_hook = self.load_hook(HookType::HealthCheck);
+                    self.run_hook = self.load_hook(HookType::Run);
+                }
+            }
+            Err(_) => {}
+        }
+        self
+    }
+
+    fn load_hook(&self, hook_type: HookType) -> Option<Hook> {
+        let template = self.package.hook_template_path(&hook_type);
+        let concrete = self.package.hook_path(&hook_type);
+        match fs::metadata(&template) {
+            Ok(_) => Some(Hook::new(hook_type, template, concrete)),
+            Err(_) => None,
+        }
+    }
+}

--- a/src/bldr/package/updater.rs
+++ b/src/bldr/package/updater.rs
@@ -1,0 +1,147 @@
+//
+// Copyright:: Copyright (c) 2015 Chef Software, Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use std::sync::{Arc, RwLock};
+
+use wonder;
+use wonder::actor::{GenServer, InitResult, HandleResult, ActorSender, ActorResult};
+
+use error::BldrError;
+use fs::PACKAGE_CACHE;
+use package::Package;
+use repo;
+
+const TIMEOUT_MS: u64 = 60_000;
+
+pub type PackageUpdaterActor = wonder::actor::Actor<UpdaterMessage>;
+
+pub struct PackageUpdater;
+
+impl PackageUpdater {
+    pub fn start(url: &str, package: Arc<RwLock<Package>>) -> PackageUpdaterActor {
+        let state = UpdaterState::new(url.to_string(), package);
+        wonder::actor::Builder::new(PackageUpdater)
+            .name("package-updater".to_string())
+            .start(state)
+            .unwrap()
+    }
+
+    /// Signal a package updater to transition it's status from `stopped` to `running`. An updater
+    /// has the `stopped` status after it has found and notified the main thread of an updated
+    /// package.
+    pub fn run(actor: &PackageUpdaterActor) -> ActorResult<()> {
+        actor.cast(UpdaterMessage::Run)
+    }
+}
+
+pub struct UpdaterState {
+    pub repo: String,
+    pub package: Arc<RwLock<Package>>,
+    pub status: UpdaterStatus,
+}
+
+impl UpdaterState {
+    pub fn new(repo: String, package: Arc<RwLock<Package>>) -> Self {
+        UpdaterState {
+            repo: repo,
+            package: package,
+            status: UpdaterStatus::Stopped,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum UpdaterMessage {
+    Ok,
+    Run,
+    Stop,
+    Update(Package),
+}
+
+pub enum UpdaterStatus {
+    Running,
+    Stopped,
+}
+
+impl GenServer for PackageUpdater {
+    type T = UpdaterMessage;
+    type S = UpdaterState;
+    type E = BldrError;
+
+    fn init(&self, _tx: &ActorSender<Self::T>, state: &mut Self::S) -> InitResult<Self::E> {
+        state.status = UpdaterStatus::Running;
+        Ok(Some(TIMEOUT_MS))
+    }
+
+    fn handle_timeout(&self,
+                      tx: &ActorSender<Self::T>,
+                      _me: &ActorSender<Self::T>,
+                      state: &mut Self::S)
+                      -> HandleResult<Self::T> {
+        let package = state.package.read().unwrap();
+        match repo::client::show_package(&state.repo,
+                                         &package.derivation,
+                                         &package.name,
+                                         None,
+                                         None) {
+            Ok(latest) => {
+                if latest > *package {
+                    match repo::client::fetch_package_exact(&state.repo, &latest, PACKAGE_CACHE) {
+                        Ok(archive) => {
+                            debug!("Updater downloaded new package to {:?}", archive);
+                            // JW TODO: actually handle verify and unpack results
+                            archive.verify().unwrap();
+                            archive.unpack().unwrap();
+                            state.status = UpdaterStatus::Stopped;
+                            let msg = wonder::actor::Message::Cast(UpdaterMessage::Update(latest));
+                            tx.send(msg).unwrap();
+                            HandleResult::NoReply(None)
+                        }
+                        Err(e) => {
+                            debug!("Failed to download package: {:?}", e);
+                            HandleResult::NoReply(Some(TIMEOUT_MS))
+                        }
+                    }
+                } else {
+                    debug!("Package found is not newer than ours");
+                    HandleResult::NoReply(Some(TIMEOUT_MS))
+                }
+            }
+            Err(e) => {
+                debug!("Updater failed to get latest package: {:?}", e);
+                HandleResult::NoReply(Some(TIMEOUT_MS))
+            }
+        }
+    }
+
+    fn handle_cast(&self,
+                   msg: Self::T,
+                   _tx: &ActorSender<Self::T>,
+                   _me: &ActorSender<Self::T>,
+                   state: &mut Self::S)
+                   -> HandleResult<Self::T> {
+        match msg {
+            UpdaterMessage::Run => HandleResult::NoReply(Some(TIMEOUT_MS)),
+            _ => {
+                match state.status {
+                    UpdaterStatus::Running => HandleResult::NoReply(Some(TIMEOUT_MS)),
+                    UpdaterStatus::Stopped => HandleResult::NoReply(None),
+                }
+            }
+        }
+    }
+}

--- a/src/bldr/repo/client.rs
+++ b/src/bldr/repo/client.rs
@@ -25,7 +25,7 @@ use rustc_serialize::json;
 
 use super::XFileName;
 use error::{BldrResult, BldrError, ErrorKind};
-use pkg::{Package, PackageArchive};
+use package::{Package, PackageArchive};
 
 static LOGKEY: &'static str = "RC";
 

--- a/src/bldr/repo/mod.rs
+++ b/src/bldr/repo/mod.rs
@@ -32,7 +32,7 @@ use std::path::{Path, PathBuf};
 use error::{BldrResult, ErrorKind};
 use config::Config;
 
-use pkg::{Package, PackageArchive};
+use package::{Package, PackageArchive};
 
 static LOGKEY: &'static str = "RE";
 

--- a/src/bldr/service_config.rs
+++ b/src/bldr/service_config.rs
@@ -38,7 +38,7 @@ use ansi_term::Colour::Purple;
 use util;
 use util::convert;
 use error::{BldrResult, ErrorKind};
-use pkg::Package;
+use package::Package;
 
 static LOGKEY: &'static str = "SC";
 

--- a/src/bldr/sidecar.rs
+++ b/src/bldr/sidecar.rs
@@ -34,7 +34,7 @@ use wonder::actor::{GenServer, InitResult, HandleResult, StopReason, ActorSender
 
 use error::BldrError;
 use health_check;
-use pkg::Package;
+use package::Package;
 use service_config::ServiceConfig;
 
 const GET_HEALTH: &'static str = "/health";

--- a/src/bldr/topology/initializer.rs
+++ b/src/bldr/topology/initializer.rs
@@ -26,7 +26,7 @@ use config::Config;
 use error::{BldrResult, BldrError};
 use state_machine::StateMachine;
 use topology::{self, standalone, State, Worker};
-use pkg::Package;
+use package::Package;
 
 static LOGKEY: &'static str = "TI";
 

--- a/src/bldr/topology/leader.rs
+++ b/src/bldr/topology/leader.rs
@@ -18,7 +18,7 @@
 use topology::{self, initializer, State, Worker};
 use state_machine::StateMachine;
 use error::{BldrResult, BldrError};
-use pkg::Package;
+use package::Package;
 use config::Config;
 
 static LOGKEY: &'static str = "TL";

--- a/src/bldr/topology/mod.rs
+++ b/src/bldr/topology/mod.rs
@@ -40,7 +40,7 @@ use wonder;
 
 use state_machine::StateMachine;
 use census;
-use pkg::{self, Package, PackageUpdaterActor, Signal};
+use package::{self, Package, PackageUpdaterActor, Signal};
 use util::signals;
 use util::signals::SignalNotifier;
 use error::{BldrResult, BldrError, ErrorKind};
@@ -218,7 +218,7 @@ impl<'a> Worker<'a> {
 
         if let Some(ref url) = *config.url() {
             let pkg_lock_2 = pkg_lock.clone();
-            pkg_updater = Some(pkg::PackageUpdater::start(url, pkg_lock_2));
+            pkg_updater = Some(package::PackageUpdater::start(url, pkg_lock_2));
         }
 
         Ok(Worker {
@@ -460,11 +460,11 @@ fn run_internal<'a>(sm: &mut StateMachine<State, Worker<'a>, BldrError>,
 
         if let Some(ref updater) = worker.pkg_updater {
             match updater.receiver.try_recv() {
-                Ok(wonder::actor::Message::Cast(pkg::UpdaterMessage::Update(package))) => {
+                Ok(wonder::actor::Message::Cast(package::UpdaterMessage::Update(package))) => {
                     debug!("Main loop received package update notification: {:?}",
                            &package);
                     try!(worker.update_package(package));
-                    try!(pkg::PackageUpdater::run(&updater));
+                    try!(package::PackageUpdater::run(&updater));
                 }
                 Ok(_) => {}
                 Err(TryRecvError::Empty) => {}

--- a/src/bldr/topology/standalone.rs
+++ b/src/bldr/topology/standalone.rs
@@ -31,7 +31,7 @@ use std::io::prelude::*;
 
 use fs::SERVICE_HOME;
 use error::{BldrResult, BldrError, ErrorKind};
-use pkg::Package;
+use package::Package;
 use state_machine::StateMachine;
 use topology::{self, State, Worker};
 use config::Config;


### PR DESCRIPTION
This is just a simple first step to making the package module more manageable. I've split the major components out into their own submodule and re-exported them from the package module to avoid changing the public interface. We can, and should, look at how to best clean up the interface we expose once things are more solidified.
