### PR TITLE
Stream output from running hooks

### DIFF
--- a/src/bldr/topology/standalone.rs
+++ b/src/bldr/topology/standalone.rs
@@ -102,8 +102,7 @@ pub fn state_starting(worker: &mut Worker) -> BldrResult<(State, u32)> {
                                  }
                                  _ => {
                                      // Write the buffer to the BufWriter on the Heap
-                                     let buf_vec = buf[0..len].to_vec();
-                                     let buf_string = String::from_utf8(buf_vec).unwrap();
+                                     let buf_string = String::from_utf8_lossy(&buf[0 .. len]);
                                      line.push_str(&buf_string);
                                      if line.contains("\n") {
                                          print!("{}", line);


### PR DESCRIPTION
This change is taken from our work on the multi-hana branch from week two at SAP in Germany. This change is still in the multi-hana branch but I'm submitting it here to ensure it gets into the codebase.

Additionally this fixes an output streaming bug in standalone topology.

@adamhjk can you check my usage of `output_format!` here? I'm not 100% sure if I'm using it correctly!
