### PR TITLE
fix package specificity in upload/configure commands

### DIFF
--- a/src/bldr/command/configure.rs
+++ b/src/bldr/command/configure.rs
@@ -40,7 +40,11 @@ use package::Package;
 /// * If the default.toml does not exist, or cannot be read
 /// * If we can't read the file into a string
 pub fn display(config: &Config) -> BldrResult<()> {
-    let package = try!(Package::latest(config.deriv(), config.package(), None, None));
+    let package = try!(Package::load(config.deriv(),
+                                     config.package(),
+                                     config.version().clone(),
+                                     config.release().clone(),
+                                     None));
     let mut file = try!(File::open(package.join_path("default.toml")));
     let mut s = String::new();
     try!(file.read_to_string(&mut s));

--- a/src/bldr/command/start.rs
+++ b/src/bldr/command/start.rs
@@ -80,7 +80,7 @@ static LOGKEY: &'static str = "CS";
 /// * Fails if the `run` method for the topology fails
 /// * Fails if an unknown topology was specified on the command line
 pub fn package(config: &Config) -> BldrResult<()> {
-    match Package::latest(config.deriv(), config.package(), None, None) {
+    match Package::load(config.deriv(), config.package(), None, None, None) {
         Ok(mut package) => {
             if let Some(ref url) = *config.url() {
                 outputln!("Checking remote for newer versions...");
@@ -120,6 +120,7 @@ pub fn package(config: &Config) -> BldrResult<()> {
                 None => {
                     Err(bldr_error!(ErrorKind::PackageNotFound(config.deriv().to_string(),
                                                                config.package().to_string(),
+                                                               config.release().clone(),
                                                                config.release().clone())))
                 }
             }

--- a/src/bldr/command/upload.rs
+++ b/src/bldr/command/upload.rs
@@ -39,9 +39,8 @@ use repo;
 
 static LOGKEY: &'static str = "CU";
 
-/// Upload a package to a repository.
-///
-/// Find the latest package, then read it from the cache, and upload to the repository.
+/// Upload a package from the cache to a repository. The latest version/release of the package
+/// will be uploaded if not specified.
 ///
 /// # Failures
 ///
@@ -50,7 +49,11 @@ static LOGKEY: &'static str = "CU";
 /// * Fails if it cannot upload the file
 pub fn package(config: &Config) -> BldrResult<()> {
     let url = config.url().as_ref().unwrap();
-    let package = try!(Package::latest(config.deriv(), config.package(), None, None));
+    let package = try!(Package::load(config.deriv(),
+                                     config.package(),
+                                     config.version().clone(),
+                                     config.release().clone(),
+                                     None));
     outputln!("Uploading from {}", package.cache_file().to_string_lossy());
     try!(repo::client::put_package(url, &package));
     outputln!("Complete");

--- a/src/bldr/error.rs
+++ b/src/bldr/error.rs
@@ -117,7 +117,7 @@ pub enum ErrorKind {
     FileNotFound(String),
     KeyNotFound(String),
     PackageLoad(String),
-    PackageNotFound(String, String, Option<String>),
+    PackageNotFound(String, String, Option<String>, Option<String>),
     RemotePackageNotFound(String, String, Option<String>, Option<String>),
     MustacheMergeOnlyMaps,
     SupervisorSignalFailed,
@@ -181,12 +181,18 @@ impl fmt::Display for BldrError {
             ErrorKind::FileNotFound(ref e) => format!("File not found at: {}", e),
             ErrorKind::KeyNotFound(ref e) => format!("Key not found in key cache: {}", e),
             ErrorKind::PackageLoad(ref e) => format!("Unable to load package from: {}", e),
-            ErrorKind::PackageNotFound(ref d, ref n, ref r) => {
-                if r.is_some() {
+            ErrorKind::PackageNotFound(ref d, ref n, ref v, ref r) => {
+                if v.is_some() && r.is_some() {
+                    format!("Cannot find package: {}/{}/{}/{}",
+                            d,
+                            n,
+                            v.as_ref().unwrap(),
+                            r.as_ref().unwrap())
+                } else if v.is_some() {
                     format!("Cannot find a release of package: {}/{}/{}",
                             d,
                             n,
-                            r.as_ref().unwrap())
+                            v.as_ref().unwrap())
                 } else {
                     format!("Cannot find a release of package: {}/{}", d, n)
                 }
@@ -276,7 +282,7 @@ impl Error for BldrError {
             ErrorKind::FileNotFound(_) => "File not found",
             ErrorKind::KeyNotFound(_) => "Key not found in key cache",
             ErrorKind::PackageLoad(_) => "Unable to load package from path",
-            ErrorKind::PackageNotFound(_, _, _) => "Cannot find a package",
+            ErrorKind::PackageNotFound(_, _, _, _) => "Cannot find a package",
             ErrorKind::RemotePackageNotFound(_, _, _, _) => "Cannot find a package in any sources",
             ErrorKind::MustacheMergeOnlyMaps => "Can only merge two Mustache::Data::Maps",
             ErrorKind::SupervisorSignalFailed =>

--- a/src/bldr/repo/mod.rs
+++ b/src/bldr/repo/mod.rs
@@ -72,10 +72,11 @@ impl Repo {
                       name: &str,
                       version: Option<&str>)
                       -> Option<PackageArchive> {
-        match Package::latest(derivation,
-                              name,
-                              version,
-                              Some(self.packages_path().to_str().unwrap())) {
+        match Package::load(derivation,
+                            name,
+                            version.map(String::from),
+                            None,
+                            Some(self.packages_path().to_str().unwrap())) {
             Ok(package) => self.archive(&package.derivation,
                                         &package.name,
                                         &package.version,

--- a/src/bldr/topology/standalone.rs
+++ b/src/bldr/topology/standalone.rs
@@ -74,7 +74,7 @@ pub fn state_initializing(worker: &mut Worker) -> BldrResult<(State, u32)> {
 pub fn state_starting(worker: &mut Worker) -> BldrResult<(State, u32)> {
     outputln!(P: &worker.package_name, "Starting");
     let package = worker.package_name.clone();
-    let runit_pkg = try!(Package::latest("chef", "runit", None, None));
+    let runit_pkg = try!(Package::load("chef", "runit", None, None, None));
     let mut child = try!(Command::new(runit_pkg.join_path("bin/runsv"))
                              .arg(&format!("{}/{}", SERVICE_HOME, worker.package_name))
                              .stdin(Stdio::null())


### PR DESCRIPTION
Fixes always retrieving latest package in upload/configure command when a version and release, or version is specified

![gif-keyboard-8236809678737006729](https://cloud.githubusercontent.com/assets/54036/11643436/bc33bd26-9cf8-11e5-9763-8972371a8569.gif)
