### PR TITLE
[bldr-build] Add chroot-based build environments.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,11 +2,14 @@
 target
 .delivery/cli.toml
 .tags*
+/bldr_cache_pkgs/
 bldr-base/bldr-base.tar.bz2
 plans/**/*-cache
-plans/**/Dockerfile
 plans/hana/SAP*
 plans/hana/sapcar.exe
 plans/hana/*.exe
 plans/hana/*.rar
+plans/logs/
+plans/support/chroot/lfs-tools/
 opt/
+.vagrant/

--- a/plans/support/chroot/Dockerfile
+++ b/plans/support/chroot/Dockerfile
@@ -1,0 +1,18 @@
+FROM alpine
+MAINTAINER The Bldr Maintainers <bldr@chef.io>
+
+RUN apk add --update \
+    make \
+    sudo \
+  && rm -rf /var/cache/apk/*
+
+COPY Makefile /tmp-plans/
+COPY lfs-tools /tmp-plans/lfs-tools
+COPY scripts /tmp-plans/scripts
+
+ENV CHROOT /mnt/chroot
+ENV PLANS /plans
+
+RUN cd /tmp-plans \
+  && make metal NO_MOUNT=true \
+  && rm -rf /tmp-plans

--- a/plans/support/chroot/Makefile
+++ b/plans/support/chroot/Makefile
@@ -1,0 +1,82 @@
+build_args :=
+run_args :=
+ifneq (${docker_http_proxy},)
+	_http_proxy := http_proxy="${docker_http_proxy}"
+	build_args := $(build_args) --build-arg $(_http_proxy)
+	run_args := $(run_args) -e $(_http_proxy)
+endif
+ifneq (${docker_https_proxy},)
+	_https_proxy := https_proxy="${docker_https_proxy}"
+	build_args := $(build_args) --build-arg $(_https_proxy)
+	run_args := $(run_args) -e $(_https_proxy)
+endif
+
+ifneq (${CHROOT},)
+	CHROOT := ${CHROOT}
+else
+	CHROOT := /mnt/chroot
+endif
+ifneq (${PLANS},)
+	PLANS := ${PLANS}
+else
+	PLANS := `pwd`/../..
+endif
+
+IMAGE := chroot_build
+TOOLS := lfs-tools/lfs-tools-20151209232702.tar.xz
+TOOLS_EXTRA := lfs-tools/lfs-tools-extras-20151202003003.tar.xz
+TARS := $(TOOLS) $(TOOLS_EXTRA)
+
+image:
+	if [ -n "${force}" -o -z "`docker images -q $(IMAGE)`" ]; then \
+		make $(TARS); \
+		docker build $(build_args) -t $(IMAGE):layers .; \
+		id=`docker run -d $(IMAGE):layers sh`; \
+		echo "==> Flattening $(IMAGE):layers to $(IMAGE):squash..."; \
+		docker export $$id \
+			| docker import -m "Squashed from $(IMAGE):layers" - $(IMAGE):squash; \
+		docker rm -f $$id; \
+		docker rmi -f $(IMAGE):layers; \
+		docker build $(build_args) -t $(IMAGE) docker-final; \
+		docker rmi -f $(IMAGE):squash; \
+	fi
+
+shell: image
+	docker-compose run --rm $(run_args) build
+
+clean-data:
+	docker-compose rm -f -v data
+
+vm:
+	make $(TARS)
+	time (vagrant up)
+
+vm-shell: vm
+	vagrant ssh
+
+vm-destroy:
+	vagrant destroy -f
+
+metal: ensure-linux
+	make $(TARS)
+	sudo -i env CHROOT=$(CHROOT) PLANS=$(PLANS) NO_MOUNT=${NO_MOUNT} \
+		TOOLS=`pwd`/$(TOOLS) TOOLS_EXTRA=`pwd`/$(TOOLS_EXTRA) \
+		`pwd`/scripts/create_chroot.sh
+
+metal-shell: metal
+	sudo -i env CHROOT=$(CHROOT) `pwd`/scripts/enter_chroot.sh
+
+metal-destroy: ensure-linux
+	sudo -i env CHROOT=$(CHROOT) `pwd`/scripts/umount_filesystems.sh
+	sudo -i rm -rfv $(CHROOT)
+
+$(TARS):
+	mkdir -pv `dirname $@`
+	http_proxy=${docker_http_proxy} curl -L -o "$@" \
+		"http://s3-us-west-2.amazonaws.com/fnichol-lfs-tools/`basename $@`"
+
+ensure-linux:
+	@if [ `uname -s` != "Linux" ]; then \
+		echo ">>> Only for running on Linux systems, aborting"; \
+		exit 1; \
+	fi

--- a/plans/support/chroot/Vagrantfile
+++ b/plans/support/chroot/Vagrantfile
@@ -1,0 +1,27 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+cache_dir = "../../../bldr_cache_pkgs"
+
+FileUtils.mkdir_p(File.join(File.dirname(__FILE__), cache_dir))
+
+Vagrant.configure(2) do |config|
+  config.vm.box = "bento/ubuntu-15.04"
+
+  config.vm.provider "virtualbox" do |vb|
+    vb.memory = "4096"
+    vb.cpus = 2
+  end
+
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+  config.vm.synced_folder "../..", "/plans"
+  config.vm.synced_folder cache_dir, "/mnt/chroot/opt/bldr/cache/pkgs"
+
+  config.vm.provision "shell", inline: <<-SHELL
+    cat <<-EOF | tee /home/vagrant/.bash_profile
+    if [ -n "\\${PS1}" -o "\\$-" = "*i*" ]; then
+      set -eux; cd /plans/support/chroot; exec make metal-shell;
+    fi
+EOF
+  SHELL
+end

--- a/plans/support/chroot/bin/capture.sh
+++ b/plans/support/chroot/bin/capture.sh
@@ -1,0 +1,88 @@
+#
+# # Usage
+#
+# ```
+# $ capture.sh <SESSION_NAME>
+# ```
+#
+# # Synopsis
+#
+# `capture.sh` provides an easy way to start logging a terminal session in
+# order to capture a full session transctipt. It is designed to execute in a
+# minimal chrooted build environment, and therefore only yields a minimal
+# set of environment variables. At the end of the session, simply type `exit`
+# and you are returned to the previous session context.
+#
+# # License and Copyright
+#
+# ```
+# Copyright: Copyright (c) 2015 Chef Software, Inc.
+# License: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ```
+#
+#
+
+# # Main program
+
+# Fail if there are any unset variables and whenever a command returns a
+# non-zero exit code.
+set -eu
+
+# If the variable `$DEBUG` is set, then print the shell commands as we execute.
+if [ -n "${DEBUG:-}" ]; then
+  set -x
+fi
+
+# The name of session, used for file naming and prompt decoration
+name="$1"
+# Determine the path to the `env(1)` command
+env_cmd="`command -v env`"
+# The directory that will hold all the session log files
+log_dir="/plans/logs"
+
+# Determine which path to `bash(1)` we should use--if the stage1 `/tools`
+# version is present, use this, and otherwise assume that `/bin/bash` is
+# correct and exists.
+if [ -x /tools/bin/bash ]; then
+  bash_cmd="/tools/bin/bash"
+else
+  bash_cmd="/bin/bash"
+fi
+
+# Build the base environment variable set to be passed into `script(1)`. We
+# propagate the `$PATH` of our caller, but set `$HOME` explictly. If either
+# `$http_proxy` or `$https_proxy` environment variables are present, pass
+# these along as well.
+env="HOME=/root TERM=$TERM PATH=$PATH"
+if [ -n "${http_proxy:-}" ]; then
+  env="$env http_proxy=$http_proxy"
+fi
+if [ -n "${https_proxy:-}" ]; then
+  env="$env https_proxy=$https_proxy"
+fi
+
+# The final command that will be passed to `script(1)`
+command="$env_cmd -i $env 'PS1=[chroot:$name] \u:\w\$ ' $bash_cmd --login +h"
+# The current timestamp, in UTC--the only true time
+timestamp="`date -u +%Y%m%d%H%M%S`"
+
+# Display the final setup and execution for the user
+set -x
+
+# Create the log directory, if not present
+mkdir -pv "$log_dir"
+
+# Finally, become the `script(1)` process
+exec script -c "$command" "$log_dir/${name}.${timestamp}.log"

--- a/plans/support/chroot/docker-compose.yml
+++ b/plans/support/chroot/docker-compose.yml
@@ -1,0 +1,13 @@
+build:
+  image: chroot_build
+  privileged: true
+  volumes:
+    - ../../../plans:/plans
+  volumes_from:
+    - data
+
+data:
+  image: tianon/true
+  command: /true
+  volumes:
+    - /mnt/chroot/opt/bldr

--- a/plans/support/chroot/docker-final/Dockerfile
+++ b/plans/support/chroot/docker-final/Dockerfile
@@ -1,0 +1,9 @@
+FROM chroot_build:squash
+MAINTAINER The Bldr Maintainers <bldr@chef.io>
+
+ENV CHROOT /mnt/chroot
+ENV PLANS /plans
+ENV PATH $PATH:$PLANS/support/chroot/scripts
+
+WORKDIR /plans/support/chroot
+CMD ["make", "metal-shell"]

--- a/plans/support/chroot/scripts/create_chroot.sh
+++ b/plans/support/chroot/scripts/create_chroot.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env sh
+#
+# # Usage
+#
+# ```
+# $ create_chroot.sh
+# ```
+#
+# # Synopsis
+#
+# `create_chroot.sh` will created a self-contained, minimal environment in
+# which we can develop, build, and package software that is free from any
+# upstream operating system distribution. This program invokes several other
+# programs in the hopes that the sub-components could be used independently.
+#
+# # Environment Variables
+#
+# There are several important enviroment variables that are required for
+# this program and some that are optional:
+#
+# * `$CHROOT` (**Required**): The root directory of the chroot filesystem
+# * `$PLANS` (**Required**): The directory containing the bldr Plan files
+# * `$TOOLS` (*Optional*): The path to a `.tar.xz` file containing a minimal
+#    "stage1" build toolchain which will be extracted into the chroot's
+#    `/tools` directory
+# * `$TOOLS_EXTRA` (*Optional*): The path to a `.tar.xz` file containing a
+#    small number of ancillary programs required for the `bldr-build` program
+# * `$DEBUG` (*Optional*): If set, the program will output the shell commands
+#    as they are being executed
+#
+# # License and Copyright
+#
+# ```
+# Copyright: Copyright (c) 2015 Chef Software, Inc.
+# License: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ```
+#
+#
+
+# # Main program
+
+# Fail if there are any unset variables and whenever a command returns a
+# non-zero exit code.
+set -eu
+
+# If the variable `$DEBUG` is set, then print the shell commands as we execute.
+if [ -n "${DEBUG:-}" ]; then
+  set -x
+fi
+
+# The path to the tools tarball, or empty if not set
+tools="${TOOLS:-}"
+# The path to the ancillary tools tarball, or empty if not set
+tools_extra="${TOOLS_EXTRA:-}"
+
+echo "==> Setting up CHROOT=$CHROOT"
+echo "==> Mounting /plans from PLANS=$PLANS"
+if [ -n "$tools" ]; then
+  echo "==> Using /tools from $tools"
+fi
+if [ -n "$tools_extra" ]; then
+  echo "==> Adding more content into /tools from $tools_extra"
+fi
+
+# Mount virtual filesystems and create the root directory structure
+`dirname $0`/mount_filesystems.sh
+`dirname $0`/create_directories.sh
+
+# If `$tools` is set and the `/tools` directory doesn't appear to have been
+# previously extracted, then extract! Finally, create some symlinks from
+# the `/tools` programs into the root filesystem. This is done to satisfy
+# tools such as `make(1)` which expect `/bin/sh` to exist--sad panda faces...
+if [ -n "$tools" -a ! -x $CHROOT/tools/bin/bash ]; then
+  echo "==> Extracting $tools into $CHROOT"
+  xzcat $tools | tar xf - -C $CHROOT
+  `dirname $0`/create_tools_symlinks.sh
+fi
+
+# If `$tools_extra` is set, then extract the tarball
+if [ -n "$tools_extra" ]; then
+  echo "==> Extracting $tools_extra into $CHROOT"
+  xzcat $tools_extra | tar xf - -C $CHROOT
+fi
+
+# If `/plans` has not yet been mounted into the chroot filesystem, then do
+# so--unless `$NO_MOUNT` has been set. The `$NO_MOUNT` variable is used
+# by tooling such as `docker build` when permissions may not allow such a
+# command to be executed. Note that we're bind-mounting the plans directory
+# into the chroot, meaning it can be somewhere else on the filesystem.
+if [ -z "${NO_MOUNT:-}" ] && ! mount | grep -q "on $CHROOT/plans type"; then
+  echo "==> Mounting $PLANS as /plans"
+  mkdir -pv $CHROOT/plans
+  mount -v --bind -o ro $PLANS $CHROOT/plans
+fi
+
+# Copy minimal networking and DNS resolution configuration files into the
+# chroot filesystem so that commands such as `wget(1)` will work
+for f in /etc/hosts /etc/resolv.conf; do
+  mkdir -pv `dirname $f`
+  cp -v $f $CHROOT$f
+done
+
+echo "==> Finished creating CHROOT"
+
+# Exit cleanly, thanks for playing
+exit 0

--- a/plans/support/chroot/scripts/create_directories.sh
+++ b/plans/support/chroot/scripts/create_directories.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env sh
+#
+# # Usage
+#
+# ```
+# $ create_directories.sh
+# ```
+#
+# # Synopsis
+#
+# `create_directories.sh` creates a base filesystem layout for the chroot
+# environment.
+#
+# # Environment Variables
+#
+# There are several enviroment variables that are used with this program:
+#
+# * `$CHROOT` (*Optional*): The root directory of the chroot filesystem. If
+#    you are running this program outside of a chrooted environment, you
+#    must provide this variable.
+# * `$DEBUG` (*Optional*): If set, the program will output the shell commands
+#    as they are being executed
+#
+# # License and Copyright
+#
+# ```
+# Copyright: Copyright (c) 2015 Chef Software, Inc.
+# License: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ```
+#
+#
+
+# # Main program
+
+# Fail if there are any unset variables and whenever a command returns a
+# non-zero exit code.
+set -eu
+
+# If the variable `$DEBUG` is set, then print the shell commands as we execute.
+if [ -n "${DEBUG:-}" ]; then
+  set -x
+fi
+
+# If `$CHROOT` is set, it will be prefixed before every directory path, and
+# otherwise the directories will be absolute paths in the current environment
+root="${CHROOT:-}"
+
+mkdir -pv $root/bin
+mkdir -pv $root/boot
+mkdir -pv $root/etc/opt
+mkdir -pv $root/etc/sysconfig
+mkdir -pv $root/home
+mkdir -pv $root/lib/firmware
+mkdir -pv $root/mnt
+mkdir -pv $root/opt
+
+mkdir -pv $root/media/floppy
+mkdir -pv $root/media/cdrom
+mkdir -pv $root/sbin
+mkdir -pv $root/srv
+mkdir -pv $root/var
+
+install -dv -m 0750 $root/root
+install -dv -m 1777 $root/tmp $root/var/tmp
+
+mkdir -pv $root/usr/bin
+mkdir -pv $root/usr/include
+mkdir -pv $root/usr/lib
+mkdir -pv $root/usr/sbin
+mkdir -pv $root/usr/src
+mkdir -pv $root/usr/local/bin
+mkdir -pv $root/usr/local/include
+mkdir -pv $root/usr/local/lib
+mkdir -pv $root/usr/local/sbin
+mkdir -pv $root/usr/local/src
+
+mkdir -pv $root/usr/share/color
+mkdir -pv $root/usr/share/dict
+mkdir -pv $root/usr/share/doc
+mkdir -pv $root/usr/share/info
+mkdir -pv $root/usr/share/locale
+mkdir -pv $root/usr/share/man
+mkdir -pv $root/usr/local/share/color
+mkdir -pv $root/usr/local/share/dict
+mkdir -pv $root/usr/local/share/doc
+mkdir -pv $root/usr/local/share/info
+mkdir -pv $root/usr/local/share/locale
+mkdir -pv $root/usr/local/share/man
+
+mkdir -pv $root/usr/share/misc
+mkdir -pv $root/usr/share/terminfo
+mkdir -pv $root/usr/share/zoneinfo
+mkdir -pv $root/usr/local/share/misc
+mkdir -pv $root/usr/local/share/terminfo
+mkdir -pv $root/usr/local/share/zoneinfo
+
+mkdir -pv $root/usr/libexec
+
+mkdir -pv $root/usr/share/man/man1
+mkdir -pv $root/usr/share/man/man2
+mkdir -pv $root/usr/share/man/man3
+mkdir -pv $root/usr/share/man/man4
+mkdir -pv $root/usr/share/man/man5
+mkdir -pv $root/usr/share/man/man6
+mkdir -pv $root/usr/share/man/man7
+mkdir -pv $root/usr/share/man/man8
+mkdir -pv $root/usr/local/share/man/man1
+mkdir -pv $root/usr/local/share/man/man2
+mkdir -pv $root/usr/local/share/man/man3
+mkdir -pv $root/usr/local/share/man/man4
+mkdir -pv $root/usr/local/share/man/man5
+mkdir -pv $root/usr/local/share/man/man6
+mkdir -pv $root/usr/local/share/man/man7
+mkdir -pv $root/usr/local/share/man/man8
+
+# If the system is 64-bit, a few symlinks will be required
+case $(uname -m) in
+x86_64)
+  ln -sfv lib $root/lib64
+  ln -sfv lib $root/usr/lib64
+  ln -sfv lib $root/usr/local/lib64
+  ;;
+esac
+
+mkdir -pv $root/var/log
+mkdir -pv $root/var/mail
+mkdir -pv $root/var/spool
+
+ln -sfv /run $root/var/run
+ln -sfv /run/lock $root/var/lock
+
+mkdir -pv $root/var/opt
+mkdir -pv $root/var/cache
+mkdir -pv $root/var/lib/color
+mkdir -pv $root/var/lib/misc
+mkdir -pv $root/var/lib/locate
+mkdir -pv $root/var/local
+
+# So long, thank for all the fish!
+exit 0

--- a/plans/support/chroot/scripts/create_tools_symlinks.sh
+++ b/plans/support/chroot/scripts/create_tools_symlinks.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env sh
+#
+# # Usage
+#
+# ```
+# $ create_tools_symlinks.sh
+# ```
+#
+# # Synopsis
+#
+# `create_tools_symlinks.sh` creates symlinks from the minimal toolchain
+# installed under `/tools` into the root of the chroot environment. This is
+# done to satisfy tools such as `make(1)` which expect `/bin/sh` to exist.
+#
+# # Environment Variables
+#
+# There are several enviroment variables that are used with this program:
+#
+# * `$CHROOT` (*Optional*): The root directory of the chroot filesystem. If
+#    you are running this program outside of a chrooted environment, you
+#    must provide this variable.
+# * `$DEBUG` (*Optional*): If set, the program will output the shell commands
+#    as they are being executed
+#
+# # License and Copyright
+#
+# ```
+# Copyright: Copyright (c) 2015 Chef Software, Inc.
+# License: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ```
+#
+#
+
+# # Main program
+
+# Fail if there are any unset variables and whenever a command returns a
+# non-zero exit code.
+set -eu
+
+# If the variable `$DEBUG` is set, then print the shell commands as we execute.
+if [ -n "${DEBUG:-}" ]; then
+  set -x
+fi
+
+# If `$CHROOT` is set, it will be prefixed before every path, and otherwise
+# the paths will be absolute paths in the current environment
+root="${CHROOT:-}"
+
+# If the `/tools` software isn't present, there is no need continuing, so
+# we'll bail instead!
+if [ ! -d "$root/tools" ]; then
+  echo ">>> No directory $root/tools present, quitting"
+  exit 1
+fi
+
+ln -sfv /tools/bin/bash $root/bin
+ln -sfv /tools/bin/cat $root/bin
+ln -sfv /tools/bin/echo $root/bin
+ln -sfv /tools/bin/pwd $root/bin
+ln -sfv /tools/bin/stty $root/bin
+
+ln -sfv /tools/bin/perl $root/usr/bin
+ln -sfv /tools/lib/libgcc_s.so $root/usr/lib
+ln -sfv /tools/lib/libgcc_s.so.1 $root/usr/lib
+ln -sfv /tools/lib/libstdc++.so $root/usr/lib
+ln -sfv /tools/lib/libstdc++.so.6 $root/usr/lib
+sed 's/tools/usr/' $root/tools/lib/libstdc++.la > $root/usr/lib/libstdc++.la
+ln -sfv bash $root/bin/sh
+
+ln -sfv /proc/self/mounts $root/etc/mtab
+
+touch $root/var/log/btmp
+touch $root/var/log/lastlog
+touch $root/var/log/wtmp
+chgrp -v 13 $root/var/log/lastlog
+chmod -v 664 $root/var/log/lastlog
+chmod -v 600 $root/var/log/btmp
+
+# If `/etc/passwd` is not present, create a minimal version to satisfy
+# some software when being built
+if [ ! -f "$root/etc/passwd" ]; then
+  echo "> Creating minimal /etc/passwd"
+  cat > $root/etc/passwd << "EOF"
+root:x:0:0:root:/root:/bin/bash
+bin:x:1:1:bin:/dev/null:/bin/false
+daemon:x:6:6:Daemon User:/dev/null:/bin/false
+messagebus:x:18:18:D-Bus Message Daemon User:/var/run/dbus:/bin/false
+nobody:x:99:99:Unprivileged User:/dev/null:/bin/false
+EOF
+fi
+
+# If `/etc/group` is not present, create a minimal version to satisfy
+# some software when being built
+if [ ! -f "$root/etc/group" ]; then
+  echo "> Creating minimal /etc/group"
+  cat > $root/etc/group << "EOF"
+root:x:0:
+bin:x:1:daemon
+sys:x:2:
+kmem:x:3:
+tape:x:4:
+tty:x:5:
+daemon:x:6:
+floppy:x:7:
+disk:x:8:
+lp:x:9:
+dialout:x:10:
+audio:x:11:
+video:x:12:
+utmp:x:13:
+usb:x:14:
+cdrom:x:15:
+adm:x:16:
+messagebus:x:18:
+systemd-journal:x:23:
+input:x:24:
+mail:x:34:
+nogroup:x:99:
+users:x:999:
+EOF
+fi
+
+# That's all folks!
+exit 0

--- a/plans/support/chroot/scripts/enter_chroot.sh
+++ b/plans/support/chroot/scripts/enter_chroot.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env sh
+#
+# # Usage
+#
+# ```
+# $ enter_chroot.sh [<COMMAND> [<ARG>...]]
+# ```
+#
+# # Synopsis
+#
+# `enter_chroot.sh`
+#
+# # Environment Variables
+#
+# There are several enviroment variables that are used with this program:
+#
+# * `$CHROOT` (**Required**): The root directory of the chroot filesystem
+# * `$DEBUG` (*Optional*): If set, the program will output the shell commands
+#    as they are being executed
+#
+# # License and Copyright
+#
+# ```
+# Copyright: Copyright (c) 2015 Chef Software, Inc.
+# License: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ```
+#
+#
+
+# # Main program
+
+# Fail if there are any unset variables and whenever a command returns a
+# non-zero exit code.
+set -eu
+
+# If the variable `$DEBUG` is set, then print the shell commands as we execute.
+if [ -n "${DEBUG:-}" ]; then
+  set -x
+fi
+
+# Determine which path to `env(1)` we should use--if the stage1 `/tools`
+# version is present, use this, and otherwise assume that `/usr/bin/env` is
+# correct and exists.
+if [ -x "$CHROOT/tools/bin/env" ]; then
+  env_cmd="/tools/bin/env"
+else
+  env_cmd="/usr/bin/env"
+fi
+
+# Determine which path to `bash(1)` we should use--if the stage1 `/tools`
+# version is present, use this, and otherwise assume that `/bin/bash` is
+# correct and exists.
+if [ -x "$CHROOT/tools/bin/bash" ]; then
+  bash_cmd="/tools/bin/bash"
+else
+  bash_cmd="/bin/bash"
+fi
+
+# Build a minimal `$PATH` for use inside the chroot environment.
+path="/bin:/usr/bin:/sbin:/usr/sbin"
+# `/tools/bin` is added, but at the end of `$PATH` to that any other version
+# of a command will be found first
+if [ -d "$CHROOT/tools/bin" ]; then
+  path="${path}:/tools/bin"
+fi
+# The `bin/` directory of the chroot support files is added at the very
+# end of the `$PATH` to make programs such as `capture.sh` available
+if [ -d "$CHROOT/plans/support/chroot/bin" ]; then
+  path="${path}:/plans/support/chroot/bin"
+fi
+
+# Determine the command to run inside the chroot environment. If no arguments
+# to this program are provided then a `bash(1)` will be run. Otherwise the
+# provided command will be executed instead.
+if [ -z "${*:-}" ]; then
+  cmd="$bash_cmd --login +h"
+else
+  cmd="$*"
+fi
+
+# Build the base environment variable set to be passed into `script(1)`. We
+# propagate the `$PATH` of our caller, but set `$HOME` explictly. If either
+# `$http_proxy` or `$https_proxy` environment variables are present, pass
+# these along as well.
+env="HOME=/root TERM=$TERM PATH=$path"
+if [ -n "${http_proxy:-}" ]; then
+  env="$env http_proxy=$http_proxy"
+fi
+if [ -n "${https_proxy:-}" ]; then
+  env="$env https_proxy=$https_proxy"
+fi
+
+echo "==> Entering CHROOT"
+echo
+
+# Display the final setup and execution for the user
+set -x
+
+# Finally, become the `chroot(8)` process
+exec chroot "$CHROOT" "$env_cmd" -i $env 'PS1=[chroot] \u:\w\$ ' $cmd

--- a/plans/support/chroot/scripts/mount_filesystems.sh
+++ b/plans/support/chroot/scripts/mount_filesystems.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env sh
+#
+# # Usage
+#
+# ```
+# $ mount_filesystems.sh
+# ```
+#
+# # Synopsis
+#
+# `mount_filesystems.sh` mounts several filesystems into the chroot environment
+#
+# # Environment Variables
+#
+# There are several enviroment variables that are used with this program:
+#
+# * `$CHROOT` (**Required**): The root directory of the chroot filesystem
+# * `$DEBUG` (*Optional*): If set, the program will output the shell commands
+#    as they are being executed
+#
+# # License and Copyright
+#
+# ```
+# Copyright: Copyright (c) 2015 Chef Software, Inc.
+# License: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ```
+#
+#
+
+# # Main program
+
+# Fail if there are any unset variables and whenever a command returns a
+# non-zero exit code.
+set -eu
+
+# If the variable `$DEBUG` is set, then print the shell commands as we execute.
+if [ -n "${DEBUG:-}" ]; then
+  set -x
+fi
+
+mkdir -pv $CHROOT/dev
+mkdir -pv $CHROOT/proc
+mkdir -pv $CHROOT/sys
+mkdir -pv $CHROOT/run
+
+# Make  a `/dev/console` device, if it doesn't exist
+if [ ! -c $CHROOT/dev/console ]; then
+  mknod -m 600 $CHROOT/dev/console c 5 1
+fi
+# Make  a `/dev/null` device, if it doesn't exist
+if [ ! -c $CHROOT/dev/null ]; then
+  mknod -m 666 $CHROOT/dev/null c 1 3
+fi
+
+# Unless `$NO_MOUNT` is set, mount filesystems such as `/dev`, `/proc`, and
+# company. If the mount already exists, skip it to be all idempotent and nerdy
+# like that
+if [ -z "${NO_MOUNT:-}" ]; then
+  if ! mount | grep -q "on $CHROOT/dev type"; then
+    mount -v --bind /dev $CHROOT/dev
+  fi
+
+  if ! mount | grep -q "on $CHROOT/dev/pts type"; then
+    mount -vt devpts devpts $CHROOT/dev/pts -o gid=5,mode=620
+  fi
+  if ! mount | grep -q "on $CHROOT/proc type"; then
+    mount -vt proc proc $CHROOT/proc
+  fi
+  if ! mount | grep -q "on $CHROOT/sys type"; then
+    mount -vt sysfs sysfs $CHROOT/sys
+  fi
+  if ! mount | grep -q "on $CHROOT/run type"; then
+    mount -vt tmpfs tmpfs $CHROOT/run
+  fi
+
+  if [ -h $CHROOT/dev/shm ]; then
+    mkdir -pv $CHROOT/`readlink $CHROOT/dev/shm`
+  fi
+fi
+
+# To be continued? Nope!
+exit 0

--- a/plans/support/chroot/scripts/umount_filesystems.sh
+++ b/plans/support/chroot/scripts/umount_filesystems.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env sh
+#
+# # Usage
+#
+# ```
+# $ umount_filesystems.sh
+# ```
+#
+# # Synopsis
+#
+# `umount_filesystems.sh` unmounts filesystems from the chroot environment
+#
+# # Environment Variables
+#
+# There are several enviroment variables that are used with this program:
+#
+# * `$CHROOT` (**Required**): The root directory of the chroot filesystem
+# * `$DEBUG` (*Optional*): If set, the program will output the shell commands
+#    as they are being executed
+#
+# # License and Copyright
+#
+# ```
+# Copyright: Copyright (c) 2015 Chef Software, Inc.
+# License: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ```
+#
+#
+
+# # Main program
+
+# Fail if there are any unset variables and whenever a command returns a
+# non-zero exit code.
+set -eu
+
+# If the variable `$DEBUG` is set, then print the shell commands as we execute.
+if [ -n "${DEBUG:-}" ]; then
+  set -x
+fi
+
+# Unmount filesystems that were set up in `mount_filesystems.sh`, but only
+# if they are currently mounted. You know, so you can run this all day long,
+# like, for fun and stuff.
+
+if mount | grep -q "on $CHROOT/plans type"; then
+  umount -v -l $CHROOT/plans
+fi
+
+if mount | grep -q "on $CHROOT/run type"; then
+  umount -v $CHROOT/run
+fi
+
+if mount | grep -q "on $CHROOT/sys type"; then
+  umount -v $CHROOT/sys
+fi
+
+if mount | grep -q "on $CHROOT/proc type"; then
+  umount -v $CHROOT/proc
+fi
+
+if mount | grep -q "on $CHROOT/dev/pts type"; then
+  umount -v $CHROOT/dev/pts
+fi
+
+if  mount | grep -q "on $CHROOT/dev type"; then
+  umount -v -l $CHROOT/dev
+fi
+
+# Next time, on Batman and Friends...
+exit 0


### PR DESCRIPTION
# chroot Environments

This change introduces 3 new environments for developing bldr Plans and
producing packages. In order to guarentee there is no accidental
contamination of library linking from a base operating system, we can
build our software in a sandboxed environment thanks to the `chroot(8)`
command.

Lower level software components (think: glibc, binutils, etc.) are much
more sensitive to the environment in which they are built, and as a
result do not always behave correctly when built in a cgroup/namespaced
environment which Docker provides us. As a hedge to the pure container
world, 2 additional build environments are available for use:
- A Vagrant-based virtual machine, backed by VirtualBox and a known-good
  Bento box (Vagrant base box)
- A "bare metal" environment which can be used on physical servers, or
  other virtual machine instances such as Amazon's EC2 or Microsoft's
  Azure cloud
# Unified User Experience

All 3 options (Docker container, Vagrant virtual machine, bare metal)
have the same setup and user flow--the only difference is the `make`
target name.
## Docker

**Note:** The usual bldr/Docker environment setup is assumed here, see
the main project's README.md for more details.

To start a shell session:

```
$ cd plans/support/chroot
$ make shell
```

To only create the base image (`make shell` automatically calls this):

```
$ cd plans/support/chroot
$ make image
```

To clean up the data container:

```
$ cd plans/support/chroot
$ make clean-data
```
## Vagrant

**Note:** An installation of Vagrant and VirtualBox will be required for
this solution to be used. The Bento box will be downloaded automatically
from Atlas on first boot, and this may take a short while initially.

To start a shell session:

```
$ cd plans/support/chroot
$ make vm-shell
```

To only create the base vm (`make vm-shell` automatically calls this):

```
$ cd plans/support/chroot
$ make vm
```

To destroy the vm:

```
$ cd plans/support/chroot
$ make vm-destroy
```
## Bare Metal

**Note:** The only real requirements for this solution are a Linux-based
distribution, and the `sudo(1)`, `make(1)`, and `chroot(8)` commands in
the `$PATH`.

To start a shell session:

```
$ cd plans/support/chroot
$ make metal-shell
```

To only create the base chroot (`make metal-shell` automatically calls
this):

```
$ cd plans/support/chroot
$ make metal
```

To destroy the chroot:

```
$ cd plans/support/chroot
$ make metal-destroy
```
