### PR TITLE
Adds LamportClocks

### DIFF
--- a/src/bldr/gossip/lamport_clock.rs
+++ b/src/bldr/gossip/lamport_clock.rs
@@ -1,0 +1,151 @@
+//
+// Copyright:: Copyright (c) 2015 Chef Software, Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//! This is an implementation of a [lamport
+//! clock](https://en.wikipedia.org/wiki/Lamport_timestamps), which we use to provide ordering in
+//! the gossip system.
+
+use std::cmp::Ordering;
+
+/// A struct representing a lamport clock; a simple unsigned 64 bit integer.
+#[derive(Debug, RustcDecodable, RustcEncodable, Clone)]
+pub struct LamportClock {
+    counter: u64,
+}
+
+impl LamportClock {
+    /// Create a new LamportClock; its counter is set to 0.
+    pub fn new() -> LamportClock {
+        LamportClock { counter: 0 }
+    }
+
+    /// Increment the clock.
+    pub fn increment(&mut self) {
+        self.counter += 1;
+    }
+
+    /// Set the clock based on a peer; if the peer is later than you, update the clock to refer to
+    /// its time.
+    pub fn set_by_peer_clock(&mut self, peer_clock: &LamportClock) {
+        let peer_counter: u64 = peer_clock.counter + 1;
+        if peer_counter > self.counter {
+            self.counter = peer_counter;
+        }
+    }
+
+    /// Return the current time.
+    pub fn time(&self) -> u64 {
+        self.counter.clone()
+    }
+}
+
+impl PartialEq for LamportClock {
+    fn eq(&self, other: &LamportClock) -> bool {
+        if self.counter == other.counter {
+            true
+        } else {
+            false
+        }
+    }
+}
+
+impl PartialOrd for LamportClock {
+    fn partial_cmp(&self, other: &LamportClock) -> Option<Ordering> {
+        let my_counter = self.counter;
+        let their_counter = other.counter;
+        if my_counter > their_counter {
+            Some(Ordering::Greater)
+        } else if my_counter < their_counter {
+            Some(Ordering::Less)
+        } else {
+            Some(Ordering::Equal)
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::LamportClock;
+    use std::thread::{self, JoinHandle};
+    use std::sync::{Arc, RwLock};
+
+    #[test]
+    fn lamport_clock_increment() {
+        let lc = Arc::new(RwLock::new(LamportClock::new()));
+
+        assert_eq!(lc.read().unwrap().time(), 0);
+
+        fn spawn_threads(lc: &Arc<RwLock<LamportClock>>) -> Vec<JoinHandle<()>> {
+            let mut children = Vec::new();
+            for _ in 0..10 {
+                let lc_clone = lc.clone();
+                let child = thread::spawn(move || {
+                    &lc_clone.write().unwrap().increment();
+                });
+                children.push(child);
+            }
+            children
+        }
+
+        let children = spawn_threads(&lc);
+
+        for child in children {
+            &child.join();
+        }
+
+        assert_eq!(lc.read().unwrap().time(), 10);
+    }
+
+    #[test]
+    fn lamport_clock_peer() {
+        let lc = Arc::new(RwLock::new(LamportClock::new()));
+
+        let peer = LamportClock { counter: 665 };
+
+        {
+            let mut lc_write = lc.write().unwrap();
+            lc_write.set_by_peer_clock(&peer);
+        }
+
+        assert_eq!(lc.read().unwrap().time(), 666);
+    }
+
+    #[test]
+    fn lamport_clock_peer_younger() {
+        let lc = Arc::new(RwLock::new(LamportClock { counter: 665 }));
+
+        let peer = LamportClock { counter: 1 };
+
+        {
+            let mut lc_write = lc.write().unwrap();
+            lc_write.set_by_peer_clock(&peer);
+        }
+
+        assert_eq!(lc.read().unwrap().time(), 665);
+    }
+
+    #[test]
+    fn lamport_clock_partialord() {
+        let olc = LamportClock { counter: 666 };
+        let ylc = LamportClock { counter: 555 };
+        let elc = LamportClock { counter: 666 };
+
+        assert!(olc > ylc);
+        assert!(ylc < olc);
+        assert!(olc == elc);
+    }
+}

--- a/src/bldr/gossip/mod.rs
+++ b/src/bldr/gossip/mod.rs
@@ -1,0 +1,20 @@
+//
+// Copyright:: Copyright (c) 2015 Chef Software, Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//! The gossip infrastructure.
+
+pub mod lamport_clock;

--- a/src/bldr/lib.rs
+++ b/src/bldr/lib.rs
@@ -270,6 +270,7 @@ pub mod user_config;
 pub mod service_config;
 pub mod watch_config;
 pub mod census;
+pub mod gossip;
 
 #[allow(dead_code)]
 const VERSION: &'static str = env!("CARGO_PKG_VERSION");


### PR DESCRIPTION
This adds a basic, working [lamport
clock](https://en.wikipedia.org/wiki/Lamport_timestamps). It simply
wraps up an integer, allows the clock to be incremented, and implements
order and equality traits.

This is a basic building block of our Gossip protocol.

![It is time](http://tmblr.co/Zh5BRq1T5HAtW)
