### PR TITLE
[bldr-build] `attach()` function, a la `binding.pry` for debugging.

### DIFF
--- a/plans/bldr-build
+++ b/plans/bldr-build
@@ -441,6 +441,118 @@ latest_package() {
   esac
 }
 
+# Attach to an interactive debugging session which lets the user check the state
+# of variables, call arbitrary functions, turn on higher levels of logging
+# (with `set -x`), or whatever else is useful.
+#
+# Usage: simply add `attach` in a `plan.sh` file and a debugging session will
+# spawn, similar to:
+#
+# ```
+# ### Attaching to debugging session
+#
+# From: /plans/glibc/plan.sh @ line 66 :
+#
+#     56:
+#     57:   # Modify the ldd rewrite script to remove lib64 and libx32 from RTLDLIST
+#     58:   sed -i '/RTLDLIST/d' sysdeps/unix/sysv/linux/*/ldd-rewrite.sed
+#     59:
+#     60:   rm -rf ../${pkg_name}-build
+#     61:   mkdir ../${pkg_name}-build
+#     62:   pushd ../${pkg_name}-build > /dev/null
+#     63:     # Configure Glibc to install its libraries into `$pkg_prefix/lib`
+#     64:     echo "libc_cv_slibdir=$pkg_prefix/lib" >> config.cache
+#     65:
+#  => 66:     attach
+#     67:
+#     68:     ../$pkg_dirname/configure \
+#     69:       --prefix=$pkg_prefix \
+#     70:       --libdir=$pkg_prefix/lib \
+#     71:       --libexecdir=$pkg_prefix/lib/glibc \
+#     72:       --enable-obsolete-rpc \
+#     73:       --disable-profile \
+#     74:       --enable-kernel=2.6.32 \
+#     75:       --cache-file=config.cache
+#     76:     make
+#
+# [1] glibc(build)>
+# ```
+attach() {
+  printf "\n### Attaching to debugging session\n"
+  local cmd=""
+  local fname="${FUNCNAME[1]}"
+  local replno=1
+  # Print out our current code context (source file, line number, etc.)
+  __attach_whereami
+  # Loop through input, REPL-style until either `"exit"` or `"quit"` is found
+  while [ "$cmd" != "exit" -a "$cmd" != "quit" ]; do
+    read -p "[$replno] ${pkg_name}($fname)> " cmd
+    case "$cmd" in
+      vars) (set -o posix; set);;
+      whereami*|\@*)
+        __attach_whereami "$(echo $cmd \
+          | awk '{if (NF == 2) print $2; else print "10"}')"
+        ;;
+      exit|quit) ;;
+      exit-program|quit-program) exit $?;;
+      help)
+        printf "
+Help
+  help          Show a list of command or information about a specific command.
+
+Context
+  whereami      Show the code surrounding the current context
+                (add a number to increase the lines of context).
+
+Environment
+  vars          Prints all the environment variables that are currently in scope.
+
+Navigating
+  exit          Pop to the previous context.
+  exit-program  End the $0 program.
+
+Aliases
+  @             Alias for \`whereami\`.
+  quit          Alias for \`exit\`.
+  quit-program  Alias for \`exit-program\`.
+
+"
+        ;;
+      *) eval $cmd;;
+    esac
+    # Increment our REPL command line count, cause that's helpful
+    replno=$((${replno}+1))
+  done
+  printf "\n### Leaving debugging session\n\n"
+  return 0
+}
+
+# **Internal** Prints the source file, line number, and lines of context around
+# the current debugging session context. Used by `attach()` and should not be
+# used externally.
+#
+# ```
+# __attach_whereami    # => defaults to 10 lines of context around the current line
+# __attach_whereami 2  # => shows 2 lines of context around the current line
+# ```
+__attach_whereami() {
+  local context=${1:-10}
+  local lnum="${BASH_LINENO[1]}"
+  local src="${BASH_SOURCE[2]}"
+  # If we are printing this program, use the absolute path version
+  if [ "$src" = "$0" ]; then
+    src="$BLDR_BUILD"
+  fi
+  echo
+  echo "From: $src @ line $lnum :"
+  echo
+  awk '{printf "%d: %s\n", NR, $0}' "$src" \
+    | sed -e "$((${lnum}-${context})),$((${lnum}+${context}))!d" \
+      -e 's,^,    ,g' \
+    | sed -e "$((${context}+1))s/^   / =>/"
+  echo
+}
+
 # Return the absolute path for a path, which might be absolute or relative.
 #
 # ```sh
@@ -1008,6 +1120,8 @@ done
 BLDR_BIN=$(latest_package "chef/bldr")/bin/bldr
 # Expand the context path to an absolute path
 BLDR_CONTEXT="$(abspath $BLDR_CONTEXT)"
+# Expand the path of this program to an absolute path
+BLDR_BUILD=$(abspath $0)
 
 # First we check if the provided path has a `plan.sh` in it. If not, we'll quickly bail.
 if [[ ! -f "$BLDR_CONTEXT/plan.sh" ]]; then


### PR DESCRIPTION
This feature adds a function called `attach()` for Plan authors when
working or debugging their plans. Simply add `attach` anywhere in the
`plan.sh` file and you will be dropped into a shell-like REPL with all
of `bldr-build`'s variables and functions in scope. For example:

```
[chroot:glibc] root:/plans$ ./bldr-build glibc
find: `/opt/bldr/pkgs/chef/bldr': No such file or directory
Loading /plans/glibc/plan.sh
   glibc: Plan loaded
   glibc: Downloading http://ftp.gnu.org/gnu/glibc/glibc-2.22.tar.xz
   glibc: Checksum verified
   glibc: Using cached glibc-2.22.tar.xz
   glibc: Verifying glibc-2.22.tar.xz
   glibc: Checksum verified
   glibc: Clean the cache
   glibc: Unpacking glibc-2.22.tar.xz
   glibc: Setting build environment
chef/linux-headers
   glibc: Setting PATH=/opt/bldr/pkgs/chef/glibc/2.22/20151214231223/sbin:/opt/bldr/pkgs/chef/glibc/2.22/20151214231223/bin:/bin:/usr/bin:/sbin:/usr/sbin:/tools/bin:/plans/support/chroot/bin
   glibc: Setting PREFIX=/opt/bldr/pkgs/chef/glibc/2.22/20151214231223
   glibc: Setting LD_RUN_PATH=/opt/bldr/pkgs/chef/glibc/2.22/20151214231223/lib
   glibc: Setting CFLAGS=-I/opt/bldr/pkgs/chef/linux-headers/4.3/20151211230237/include
   glibc: Setting LDFLAGS=
   glibc: Preparing to build
   glibc: Building
   glibc: Overriding LD_RUN_PATH=
   glibc: Overriding LDFLAGS=-L/usr/lib
   glibc: Adding LIBRARY_PATH=/usr/lib
patching file sunrpc/rpc_main.c
patching file elf/ldconfig.c
patching file elf/Makefile
patching file elf/rtld.c
patching file sysdeps/generic/dl-cache.h
   glibc: Our linker is will be: /opt/bldr/pkgs/chef/glibc/2.22/20151214231223/lib64/ld-linux-x86-64.so.2

### Attaching to debugging session

From: /plans/glibc/plan.sh @ line 66 :

    56:
    57:   # Modify the ldd rewrite script to remove lib64 and libx32 from RTLDLIST
    58:   sed -i '/RTLDLIST/d' sysdeps/unix/sysv/linux/*/ldd-rewrite.sed
    59:
    60:   rm -rf ../${pkg_name}-build
    61:   mkdir ../${pkg_name}-build
    62:   pushd ../${pkg_name}-build > /dev/null
    63:     # Configure Glibc to install its libraries into `$pkg_prefix/lib`
    64:     echo "libc_cv_slibdir=$pkg_prefix/lib" >> config.cache
    65:
 => 66:     attach
    67:
    68:     ../$pkg_dirname/configure \
    69:       --prefix=$pkg_prefix \
    70:       --libdir=$pkg_prefix/lib \
    71:       --libexecdir=$pkg_prefix/lib/glibc \
    72:       --enable-obsolete-rpc \
    73:       --disable-profile \
    74:       --enable-kernel=2.6.32 \
    75:       --cache-file=config.cache
    76:     make

[1] glibc(build)> echo $pkg_name
glibc
[2] glibc(build)> echo $pkg_build_deps
chef/linux-headers
[3] glibc(build)> vars
BASH=/bin/bash
BASHOPTS=cmdhist:complete_fullquote:extquote:force_fignore:hostcomplete:interactive_comments:progcomp:promptvars:sourcepath
BASH_ALIASES=()
BASH_ARGC=([0]="1")
BASH_ARGV=([0]="glibc")
BASH_CMDS=()
BASH_LINENO=([0]="66" [1]="784" [2]="1234" [3]="0")
BASH_SOURCE=([0]="./bldr-build" [1]="/plans/glibc/plan.sh" [2]="./bldr-build" [3]="./bldr-build")
BASH_VERSINFO=([0]="4" [1]="3" [2]="30" [3]="1" [4]="release" [5]="x86_64-unknown-linux-gnu")
BASH_VERSION='4.3.30(1)-release'
BLDR_BIN=/bin/bldr
BLDR_BUILD=/plans/bldr-build
BLDR_CONTEXT=/plans/glibc
BLDR_PKG_CACHE=/opt/bldr/cache/pkgs
BLDR_PKG_ROOT=/opt/bldr/pkgs
BLDR_REPO=http://ec2-52-10-238-149.us-west-2.compute.amazonaws.com
BLDR_ROOT=/opt/bldr
BLDR_SRC_CACHE=/opt/bldr/cache/src
BLDR_VERSION=0.0.1
CFLAGS=-I/opt/bldr/pkgs/chef/linux-headers/4.3/20151211230237/include
DIRSTACK=()
EUID=0
FUNCNAME=([0]="debug" [1]="build" [2]="build_wrapper" [3]="main")
GROUPS=()
HOME=/root
HOSTNAME=vagrant
HOSTTYPE=x86_64
IFS='
'
LDFLAGS=-L/usr/lib
LIBRARY_PATH=/usr/lib
MACHTYPE=x86_64-unknown-linux-gnu
OLDPWD=/opt/bldr/cache/src/glibc-2.22
OPTERR=1
OPTIND=2
OSTYPE=linux-gnu
PATH=/opt/bldr/pkgs/chef/glibc/2.22/20151214231223/sbin:/opt/bldr/pkgs/chef/glibc/2.22/20151214231223/bin:/bin:/usr/bin:/sbin:/usr/sbin:/tools/bin:/plans/support/chroot/bin
PIPESTATUS=([0]="0")
POSIXLY_CORRECT=y
PPID=9372
PREFIX=/opt/bldr/pkgs/chef/glibc/2.22/20151214231223
PS4='+ '
PWD=/opt/bldr/cache/src/glibc-build
SHELL=/bin/bash
SHELLOPTS=braceexpand:errexit:errtrace:hashall:interactive-comments:posix
SHLVL=2
TERM=screen-256color
UID=0
_=posix
checksum=([0]="eb731406903befef1d8f878a46be75ef862b9056ab0cde1626d08a7a05328948" [1]="/opt/bldr/cache/src/glibc-2.22.tar.xz")
cmd=vars
dep=chef/linux-headers
dep_deriv=chef
dep_path=/opt/bldr/pkgs/chef/linux-headers/4.3/20151211230237
dep_rest=linux-headers
fname=build
graceful_exit=true
ldflags_part=' -L/usr/lib'
lib=lib
opt='?'
path=bin
pkg_binary_path=([0]="sbin" [1]="bin")
pkg_build_deps=([0]="chef/linux-headers")
pkg_deps=()
pkg_derivation=chef
pkg_dirname=glibc-2.22
pkg_docker_build=false
pkg_docker_from=bldr/base
pkg_expose=()
pkg_filename=glibc-2.22.tar.xz
pkg_format=([0]="bldr")
pkg_gpg_key=3853DA6B
pkg_include_dirs=([0]="include")
pkg_lib_dirs=([0]="lib")
pkg_license=([0]="gplv2" [1]="lgplv2")
pkg_maintainer='The Bldr Maintainers <bldr@chef.io>'
pkg_name=glibc
pkg_path=/opt/bldr/pkgs/chef/glibc/2.22/20151214231223
pkg_prefix=/opt/bldr/pkgs/chef/glibc/2.22/20151214231223
pkg_rel=20151214231223
pkg_service_run=
pkg_service_user=bldr
pkg_shasum=eb731406903befef1d8f878a46be75ef862b9056ab0cde1626d08a7a05328948
pkg_source=http://ftp.gnu.org/gnu/glibc/glibc-2.22.tar.xz
pkg_srvc=/opt/bldr/srvc/glibc
pkg_srvc_config=/opt/bldr/srvc/glibc/config
pkg_srvc_data=/opt/bldr/srvc/glibc/data
pkg_srvc_var=/opt/bldr/srvc/glibc/var
pkg_version=2.22
replno=3
unpack_file=/opt/bldr/cache/src/glibc-2.22.tar.xz
[4] glibc(build)>
[5] glibc(build)>
[6] glibc(build)>
[7] glibc(build)>
[8] glibc(build)>
[9] glibc(build)> env
LDFLAGS=-L/usr/lib
TERM=screen-256color
LIBRARY_PATH=/usr/lib
OLDPWD=/opt/bldr/cache/src/glibc-2.22
PATH=/opt/bldr/pkgs/chef/glibc/2.22/20151214231223/sbin:/opt/bldr/pkgs/chef/glibc/2.22/20151214231223/bin:/bin:/usr/bin:/sbin:/usr/sbin:/tools/bin:/plans/support/chroot/bin
PWD=/opt/bldr/cache/src/glibc-build
HOME=/root
SHLVL=2
CFLAGS=-I/opt/bldr/pkgs/chef/linux-headers/4.3/20151211230237/include
PREFIX=/opt/bldr/pkgs/chef/glibc/2.22/20151214231223
_=/tools/bin/env
[10] glibc(build)>
[11] glibc(build)>
[12] glibc(build)>
[13] glibc(build)> exit

### Leaving debugging session

configure: loading cache config.cache
checking build system type... x86_64-unknown-linux-gnu
checking host system type... x86_64-unknown-linux-gnu
checking for gcc... gcc
checking for suffix of object files... o
checking whether we are using the GNU C compiler... yes
checking whether gcc accepts -g... yes
checking for readelf... readelf
checking for g++... g++
checking whether we are using the GNU C++ compiler... yes
checking whether g++ accepts -g... yes
checking whether g++ can link programs... yes
checking for sysdeps preconfigure fragments... aarch64 alpha arm hppa i386 m68k microblaze mips nacl nios2 powerpc s390 sh sparc tile x86_64 checking whether gcc compiles in -mx32 mode by default... no

configure: running configure fragment for add-on libidn
checking for assembler and linker STT_GNU_IFUNC support... yes
checking whether .text pseudo-op must be used... yes
checking sysdep dirs... sysdeps/unix/sysv/linux/x86_64/64 sysdeps/unix/sysv/linux/x86_64 sysdeps/unix/sysv/linux/x86 sysdeps/unix/sysv/linux/wordsize-64 sysdeps/x86_64/nptl sysdeps/unix/sysv/linux sysdeps/nptl sysdeps/pthread sysdeps/gnu sysdeps/unix/inet sysdeps/unix/sysv sysdeps/unix/x86_64 sysdeps/unix sysdeps/posix sysdeps/x86_64/64 sysdeps/x86_64/fpu/multiarch sysdeps/x86_64/fpu sysdeps/x86/fpu sysdeps/x86_64/multiarch sysdeps/x86_64 sysdeps/x86 sysdeps/ieee754/ldbl-96 sysdeps/ieee754/dbl-64/wordsize-64 sysdeps/ieee754/dbl-64 sysdeps/ieee754/flt-32 sysdeps/wordsize-64 sysdeps/ieee754 sysdeps/generic
checking for a BSD-compatible install... /tools/bin/install -c
checking whether ln -s works... yes
checking whether /tools/lib/gcc/x86_64-unknown-linux-gnu/5.2.0/../../../../x86_64-unknown-linux-gnu/bin/as is GNU as... yes
checking whether /tools/lib/gcc/x86_64-unknown-linux-gnu/5.2.0/../../../../x86_64-unknown-linux-gnu/bin/ld is GNU ld... yes
checking for /tools/lib/gcc/x86_64-unknown-linux-gnu/5.2.0/../../../../x86_64-unknown-linux-gnu/bin/as... /tools/lib/gcc/x86_64-unknown-linux-gnu/5.2.0/../../../../x86_64-unknown-linux-gnu/bin/as
checking version of /tools/lib/gcc/x86_64-unknown-linux-gnu/5.2.0/../../../../x86_64-unknown-linux-gnu/bin/as... 2.25.1, ok
checking for /tools/lib/gcc/x86_64-unknown-linux-gnu/5.2.0/../../../../x86_64-unknown-linux-gnu/bin/ld... /tools/lib/gcc/x86_64-unknown-linux-gnu/5.2.0/../../../../x86_64-unknown-linux-gnu/bin/ld
checking version of /tools/lib/gcc/x86_64-unknown-linux-gnu/5.2.0/../../../../x86_64-unknown-linux-gnu/bin/ld... 2.25.1, ok
checking for gnumake... no
^CMakefile:9: recipe for target 'all' failed
make: *** [all] Interrupt
Exiting on error
[chroot:glibc] root:/plans$
```
