### PR TITLE
change location of temporary bldr-repo

### DIFF
--- a/plans/Makefile
+++ b/plans/Makefile
@@ -1,5 +1,5 @@
 PKGS := glibc libgcc zlib cacerts busybox patchelf libgpg-error libassuan gnupg gpgme openssl runit bldr redis ncurses libedit bzip2 pcre nginx haproxy libaio libltdl libxml2 numactl perl
-REPO := http://ec2-52-10-238-149.us-west-2.compute.amazonaws.com
+REPO := http://159.203.235.47
 
 bldr: gpg
 	@for pkg in glibc libgcc zlib cacerts busybox patchelf libgpg-error libassuan gnupg gpgme openssl runit bldr; do \

--- a/plans/bldr-build
+++ b/plans/bldr-build
@@ -273,7 +273,7 @@ BLDR_PKG_CACHE=$BLDR_ROOT/cache/pkgs
 # The first argument to the script is a bldr context directory, containing a Plan
 BLDR_CONTEXT=${1:-.}
 # The default bldr package repository from where to download dependencies
-BLDR_REPO=http://ec2-52-10-238-149.us-west-2.compute.amazonaws.com
+BLDR_REPO=http://159.203.235.47
 # The default derivation is `bldr`
 pkg_derivation=""
 # Each release is a timestamp - `YYYYMMDDhhmmss`


### PR DESCRIPTION
Our previous instance was destroyed - this will point us to our new temp location
