### PR TITLE
Virtualbox must die

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ by having a convention cover it. When we do need to configure things, we set san
 ## Setup
 
 1. [Install Docker Toolbox](http://docs.docker.com/mac/step_one/)
+1. [Install VMWare Fusion](https://www.vmware.com/products/fusion)
+1. Delete the default docker-machine image: `docker-machine rm default`
+1. Create a new one with vmware fusion: `docker-machine create -d vmwarefusion --vmwarefusion-memory-size 4096 --vmwarefusion-cpu-count 2 --vmwarefusion-disk-size 40960 default`. Feel free to increase the number of CPUs, Ram, or Disk space as needed. (Adam used 4 cpu, 8gb of ram)
 1. Consider adding `eval "$(docker-machine env default)"` to your shell initialization
 1. Checkout the source by running `git clone git@github.com:chef/bldr.git; cd bldr`
 1. Run `make`


### PR DESCRIPTION
Sadly, Virtualbox and Docker have some pretty nasty bugs, in particular
with sharing of data from the home directory through to a container. You
can literally have one process get the data that was present when the
container was booted, while another process sees the data that is
current. In the same shell.

[It makes you want to crawl into a hole and hide - the bug is 5 years
old](https://www.virtualbox.org/ticket/9069) - we can safely assume they
are not going to fix it.

![WHY](http://gif.co/trcp.gif)
