### PR TITLE
Allow the demo scripts to use an arbitrarily named Docker Machine.

### DIFF
--- a/demo/etcd-clean.sh
+++ b/demo/etcd-clean.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 
-#etcd_ipaddress=$(docker inspect $(docker ps | grep etcd | cut -d " " -f 1)  | jq -r '.[0].NetworkSettings.IPAddress')
-etcd_ipaddress=$(docker-machine ip default)
+etcd_ipaddress=$(docker-machine ip ${DOCKER_MACHINE_NAME:-default})
 curl -X DELETE http://$etcd_ipaddress:4001/v2/keys/bldr?recursive=true

--- a/demo/etcd-load.sh
+++ b/demo/etcd-load.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-etcd_ipaddress=$(docker-machine ip default)
+etcd_ipaddress=$(docker-machine ip ${DOCKER_MACHINE_NAME:-default})
 foo=$(cat $1); curl -L http://$etcd_ipaddress:4001/v2/keys/bldr/redis/default/config -XPUT -d value="${foo}"


### PR DESCRIPTION
For those users who don't wish to use their "default" Docker Machine for
this demo, now you have a way out--via setting a `DOCKER_MACHINE_NAME`
environment variable.

> "Thanks!"
>     - Fletcher
