### PR TITLE
Don't cache failed downloads

### DIFF
--- a/plans/bldr-build
+++ b/plans/bldr-build
@@ -873,9 +873,17 @@ do_download() {
     fi
   else
     pushd $BLDR_SRC_CACHE > /dev/null
-    $_wget_cmd $pkg_source -O $BLDR_SRC_CACHE/${pkg_filename}
-    popd > /dev/null
-    build_line "Downloaded";
+    # Download with wget. If wget encounters a >= 400 status, it still leaves
+    # behind an empty file. If there's an error, delete the empty file so we
+    # don't continue with an empty file.
+    $_wget_cmd $pkg_source -O $BLDR_SRC_CACHE/${pkg_filename} ||
+      rm -f $BLDR_SRC_CACHE/${pkg_filename}
+    if [ -f $BLDR_SRC_CACHE/${pkg_filename} ]; then
+      popd > /dev/null
+      build_line "Downloaded";
+    else
+      exit_with "Downloading $pkg_source failed" 1
+    fi
   fi
   return 0
 }


### PR DESCRIPTION
When `wget -O` hits a 404, it saves an empty file. This isn't what we
want, so remove the file if it gets put there and fail when we hit
errors.

![image](https://cloud.githubusercontent.com/assets/9912/12250262/4074fac0-b88b-11e5-9044-a665941386fa.png)
