### PR TITLE
[plans] Add a ruby plan

### DIFF
--- a/plans/Makefile
+++ b/plans/Makefile
@@ -1,5 +1,5 @@
 BLDR_PKGS := glibc libgcc patchelf zlib cacerts busybox libgpg-error libassuan gnupg gpgme openssl runit bldr
-PKGS := $(BLDR_PKGS) redis ncurses libedit bzip2 pcre nginx haproxy libaio libltdl libxml2 numactl perl
+PKGS := $(BLDR_PKGS) redis ncurses libedit bzip2 pcre nginx haproxy libaio libltdl libxml2 numactl perl erlang libyaml libiconv libtool libffi ruby
 REPO := http://159.203.235.47
 
 .PHONY: bldr-deps world publish gpg clean baseimage_root $(PKGS) $(addprefix publish-,$(PKGS)) new-plan

--- a/plans/libffi/plan.sh
+++ b/plans/libffi/plan.sh
@@ -1,0 +1,17 @@
+pkg_name=libffi
+pkg_version=3.2.1
+pkg_derivation=chef
+pkg_license=('mit')
+pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
+pkg_source=ftp://sourceware.org/pub/${pkg_name}/${pkg_name}-${pkg_version}.tar.gz
+pkg_filename=${pkg_name}-${pkg_version}.tar.gz
+pkg_shasum=d06ebb8e1d9a22d19e38d63fdb83954253f39bedc5d46232a05645685722ca37
+pkg_gpg_key=3853DA6B
+pkg_deps=(chef/glibc chef/libtool)
+pkg_lib_dirs=(lib)
+pkg_include_dirs=(include)
+
+do_build() {
+    ./configure --prefix=${pkg_prefix} --disable-multi-os-directory
+    make
+}

--- a/plans/libiconv/patches/libiconv-1.14_srclib_stdio.in.h-remove-gets-declarations.patch
+++ b/plans/libiconv/patches/libiconv-1.14_srclib_stdio.in.h-remove-gets-declarations.patch
@@ -1,0 +1,29 @@
+--- libiconv-1.14/srclib/stdio.in.h.orig  2014-07-02 01:49:41.484192961 +0000
++++ libiconv-1.14/srclib/stdio.in.h 2014-07-02 01:51:10.433127793 +0000
+@@ -679,26 +679,6 @@
+ # endif
+ #endif
+
+-#if @GNULIB_GETS@
+-# if @REPLACE_STDIO_READ_FUNCS@ && @GNULIB_STDIO_H_NONBLOCKING@
+-#  if !(defined __cplusplus && defined GNULIB_NAMESPACE)
+-#   undef gets
+-#   define gets rpl_gets
+-#  endif
+-_GL_FUNCDECL_RPL (gets, char *, (char *s) _GL_ARG_NONNULL ((1)));
+-_GL_CXXALIAS_RPL (gets, char *, (char *s));
+-# else
+-_GL_CXXALIAS_SYS (gets, char *, (char *s));
+-#  undef gets
+-# endif
+-_GL_CXXALIASWARN (gets);
+-/* It is very rare that the developer ever has full control of stdin,
+-   so any use of gets warrants an unconditional warning.  Assume it is
+-   always declared, since it is required by C89.  */
+-_GL_WARN_ON_USE (gets, "gets is a security hole - use fgets instead");
+-#endif
+-
+-
+ #if @GNULIB_OBSTACK_PRINTF@ || @GNULIB_OBSTACK_PRINTF_POSIX@
+ struct obstack;
+ /* Grow an obstack with formatted output.  Return the number of

--- a/plans/libiconv/plan.sh
+++ b/plans/libiconv/plan.sh
@@ -1,0 +1,18 @@
+pkg_name=libiconv
+pkg_version=1.14
+pkg_derivation=chef
+pkg_license=('gplv2')
+pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
+pkg_source=http://ftp.gnu.org/pub/gnu/${pkg_name}/${pkg_name}-${pkg_version}.tar.gz
+pkg_filename=${pkg_name}-${pkg_version}.tar.gz
+pkg_shasum=72b24ded17d687193c3366d0ebe7cde1e6b18f0df8c55438ac95be39e8a30613
+pkg_gpg_key=3853DA6B
+pkg_deps=(chef/glibc)
+pkg_lib_dirs=(lib)
+pkg_include_dirs=(include)
+
+do_build() {
+    patch -p1 -i $PLAN_CONTEXT/patches/libiconv-1.14_srclib_stdio.in.h-remove-gets-declarations.patch
+    ./configure --prefix=${pkg_prefix}
+    make
+}

--- a/plans/libtool/plan.sh
+++ b/plans/libtool/plan.sh
@@ -1,0 +1,12 @@
+pkg_name=libtool
+pkg_derivation=chef
+pkg_version=2.4.6
+pkg_license=('gplv2')
+pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
+pkg_source=http://ftp.gnu.org/gnu/${pkg_name}/${pkg_name}-${pkg_version}.tar.gz
+pkg_filename=${pkg_name}-${pkg_version}.tar.gz
+pkg_shasum=e3bd4d5d3d025a36c21dd6af7ea818a2afcd4dfc1ea5a17b39d7854bcd0c06e3
+pkg_gpg_key=3853DA6B
+pkg_deps=(chef/glibc)
+pkg_lib_dirs=(lib)
+pkg_include_dirs=(include)

--- a/plans/libyaml/plan.sh
+++ b/plans/libyaml/plan.sh
@@ -1,0 +1,13 @@
+pkg_name=libyaml
+pkg_version=0.1.6
+pkg_derivation=chef
+pkg_license=('mit')
+pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
+pkg_dirname=yaml-${pkg_version}
+pkg_source=http://pyyaml.org/download/${pkg_name}/yaml-${pkg_version}.tar.gz
+pkg_filename=yaml-${pkg_version}.tar.gz
+pkg_shasum=7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749
+pkg_gpg_key=3853DA6B
+pkg_deps=(chef/glibc)
+pkg_lib_dirs=(lib)
+pkg_include_dirs=(include)

--- a/plans/ruby/patches/ruby-2_1_3-no-mkmf.patch
+++ b/plans/ruby/patches/ruby-2_1_3-no-mkmf.patch
@@ -1,0 +1,22 @@
+diff --git a/lib/mkmf.rb b/lib/mkmf.rb
+index b408ed7..7a9c9fe 100644
+--- a/lib/mkmf.rb
++++ b/lib/mkmf.rb
+@@ -365,6 +365,17 @@ module MakeMakefile
+   end
+ 
+   def libpath_env
++    # Patch for aix
++    # Ideally applications should not need LIBPATH/LD_LIBRARY_PATH set
++    # and should rely on the embedded paths in binaries/shared objects
++    # For chef say on AIX we already build using -blibpath and
++    # LD_RUN_PATH, so the extensions built using chef embedded ruby
++    # (using rbconfig) should have correct paths set.
++    # Setting LIBPATH overrides the behaviour of programs invoked from
++    # chef built ruby, for example xlc ends up picking up libiconv built
++    # within chef embedded ruby libs instead of the one from /usr/lib
++    return {}
++
+     # used only if native compiling
+     if libpathenv = config_string("LIBPATHENV")
+       pathenv = ENV[libpathenv]

--- a/plans/ruby/plan.sh
+++ b/plans/ruby/plan.sh
@@ -1,0 +1,29 @@
+pkg_name=ruby
+pkg_derivation=chef
+pkg_version=2.3.0
+pkg_license=('ruby')
+pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
+pkg_source=https://cache.ruby-lang.org/pub/${pkg_name}/${pkg_name}-${pkg_version}.tar.gz
+pkg_filename=${pkg_name}-${pkg_version}.tar.gz
+pkg_shasum=ba5ba60e5f1aa21b4ef8e9bf35b9ddb57286cb546aac4b5a28c71f459467e507
+pkg_gpg_key=3853DA6B
+pkg_deps=(chef/glibc chef/ncurses chef/zlib chef/libedit chef/openssl
+          chef/libyaml chef/libiconv chef/libffi)
+pkg_lib_dirs=(lib)
+pkg_include_dirs=(include)
+
+do_build() {
+    CFLAGS="${CFLAGS} -O3 -g -pipe"
+    patch -p1 -i $PLAN_CONTEXT/patches/ruby-2_1_3-no-mkmf.patch
+
+    ./configure --prefix=${pkg_prefix} \
+                --with-out-ext=dbm \
+                --enable-shared \
+                --enable-libedit \
+                --disable-install-doc \
+                --without-gmp \
+                --without-gdbm \
+                --with-openssl-dir=$(_resolve_dependency chef/openssl) \
+                --with-libyaml-dir=$(_resolve_dependency chef/libyaml)
+    make
+}


### PR DESCRIPTION
This also adds dependencies for ruby:
- libffi
- libiconv
- libtool
- libyaml

We needed to add the patch ruby-2_1_3-no-mkmf to prevent errors in make install. We also needed to force the openssl and libyaml directories by using the _resolve_dependency function from bldr-build.
