### PR TITLE
[plans] Use prefix on erlang

### DIFF
--- a/plans/erlang/plan.sh
+++ b/plans/erlang/plan.sh
@@ -13,16 +13,17 @@ pkg_lib_dirs=(lib)
 pkg_include_dirs=(include)
 
 do_build() {
-  ./configure --enable-threads \
-              --enable-smp-support \
-              --enable-kernel-poll \
-              --enable-threads \
-              --enable-smp-support \
-              --enable-kernel-poll \
-              --enable-dynamic-ssl-lib \
-              --enable-shared-zlib \
-              --enable-hipe \
-              --without-javac \
-              --disable-debug
-  make
+    ./configure --prefix=${pkg_prefix} \
+                --enable-threads \
+                --enable-smp-support \
+                --enable-kernel-poll \
+                --enable-threads \
+                --enable-smp-support \
+                --enable-kernel-poll \
+                --enable-dynamic-ssl-lib \
+                --enable-shared-zlib \
+                --enable-hipe \
+                --without-javac \
+                --disable-debug
+    make
 }


### PR DESCRIPTION
We should be using --prefix to ensure make install goes in the right
place.
