### PR TITLE
don't compile libarchive with support for lzo

### DIFF
--- a/plans/libarchive/plan.sh
+++ b/plans/libarchive/plan.sh
@@ -14,6 +14,7 @@ do_build() {
   build/autogen.sh
   ./configure \
     --prefix=$pkg_prefix \
-    --without-xml2
+    --without-xml2 \
+    --without-lzo2
   make
 }


### PR DESCRIPTION
This will take care of linking to `lzo`, which is licensed under GPL2

![screen shot 2016-01-12 at 10 17 08 pm](https://cloud.githubusercontent.com/assets/54036/12286578/3ca65e3a-b97a-11e5-83bf-19f2651e00be.png)

![gif-keyboard-15528504773020626699](https://cloud.githubusercontent.com/assets/54036/12286594/537415ee-b97a-11e5-971f-771a7dd49650.gif)
