### PR TITLE
[bldr-build] Support transitive (not directly declared) dependencies.

### DIFF
--- a/plans/bldr-build
+++ b/plans/bldr-build
@@ -542,6 +542,64 @@ _resolve_dependency() {
   fi
 }
 
+# **Internal** Returns (on stdout) the `TDEPS` file contents of another locally
+# installed package which contain the set of all direct and transitive run
+# dependencies. An empty set could be returned as whitespace and/or newlines.
+# The lack of a `TDEPS` file in the desired package will be considered an
+# unset, or empty set.
+#
+# ```
+# _get_tdeps_for /opt/bldr/pkgs/chef/a/4.2.2/20160113044458
+# # /opt/bldr/pkgs/chef/dep-b/1.2.3/20160113033619
+# # /opt/bldr/pkgs/chef/dep-c/5.0.1/20160113033507
+# # /opt/bldr/pkgs/chef/dep-d/2.0.0/20160113033539
+# # /opt/bldr/pkgs/chef/dep-e/10.0.1/20160113033453
+# # /opt/bldr/pkgs/chef/dep-f/4.2.2/20160113033338
+# # /opt/bldr/pkgs/chef/dep-g/4.2.2/20160113033319
+# ```
+#
+# Will return 0 in any case and the contents of `TDEPS` if the file exists.
+_get_tdeps_for() {
+  local pkg_path="$1"
+  if [[ -f "$pkg_path/TDEPS" ]]; then
+    cat $pkg_path/TDEPS
+  else
+    # No file, meaning an empty set
+    echo
+  fi
+  return 0
+}
+
+# **Internal** Appends an entry to the given array only if the entry is not
+# already present and returns the resulting array back on stdout. In so doing,
+# this function mimicks a set when adding new entries. Note that any array can
+# be passed in, including ones that already contain duplicate entries.
+#
+# ```
+# arr=(a b c)
+# arr=($(_return_or_append_to_set "b" "${arr[@]}"))
+# echo ${arr[@]}
+# # a b c
+# arr=($(_return_or_append_to_set "z" "${arr[@]}"))
+# echo ${arr[@]}
+# # a b c z
+# ```
+#
+# Will return 0 in any case.
+_return_or_append_to_set() {
+  local e
+  local appended_set
+  for e in "${@:2}"; do
+    if [[ "$e" == "$1" ]]; then
+      echo "${@:2}"
+      return 0
+    fi
+  done
+  appended_set=("${@:2}" "$1")
+  echo "${appended_set[@]}"
+  return 0
+}
+
 # **Internal** Prints the source file, line number, and lines of context around
 # the current debugging session context. Used by `attach()` and should not be
 # used externally.
@@ -676,8 +734,8 @@ trim() {
   echo "$var"
 }
 
-# Returns the path for the desired build or runtime package dependency on
-# stdout from the resolved dependency set.
+# Returns the path for the desired build or runtime direct package dependency
+# on stdout from the resolved dependency set.
 #
 # ```
 # pkg_all_deps_resolved=(
@@ -950,14 +1008,36 @@ do_default_begin() {
   return 0
 }
 
-# **Internal** Walk each item in `$pkg_build_deps` and $pkg_deps`, and for each
+# **Internal** Determines suitable package identifiers for each build and
+# run dependency and populates several package-related arrays for use
+# throughout this program.
+#
+# Walk each item in `$pkg_build_deps` and $pkg_deps`, and for each
 # item determine the absolute path to a suitable package release (which will be
-# on disk). These "resolved" paths will be added to respective parallel arrays
-# (`$pkg_deps_resolved` and `$pkg_build_deps_resolved`) as well as a combined
-# array `$pkg_all_deps_resolved`.
+# on disk). Then, several package-related arrays are created:
+#
+# * `$pkg_build_deps_resolved`: A pacakge-path array of all direct build
+#    dependencies, declared in `$pkg_build_deps`.
+# * `$pkg_build_tdeps_resolved`: A package-path array of all direct build
+#    depenedencies and the run depedencies for each direct build dependency.
+# * `$pkg_deps_resolved`: A package-path array of all direct run dependencies,
+#    declared in `$pkg_deps`.
+# * `$pkg_tdeps_resolved`:  A package-path array of all direct run depdencies
+#    and the run dependencies for each direct run dependency.
+# * `$pkg_all_deps_resolved`: A package-path array of all direct build and
+#    run depenencies, declared in `$pkg_build_deps` and `$pkg_deps`.
+# * `$pkg_all_tdeps_resolved`: An ordered package-path array of all direct
+#    build and run dependencies, and the run depenencies for each direct
+#    dependency. Further details below in the function.
 _resolve_dependencies() {
   build_line "Resolving dependencies"
   local resolved
+  local dep
+  local tdep
+  local tdeps
+
+  # Build `${pkg_build_deps_resolved[@]}` containing all resolved direct build
+  # dependencies.
   pkg_build_deps_resolved=()
   for dep in "${pkg_build_deps[@]}"; do
     if resolved="$(_resolve_dependency $dep)"; then
@@ -967,6 +1047,9 @@ _resolve_dependencies() {
       exit_with "Resolving '$dep' failed, should this be built first?" 1
     fi
   done
+
+  # Build `${pkg_deps_resolved[@]}` containing all resolved direct run
+  # dependencies.
   pkg_deps_resolved=()
   for dep in "${pkg_deps[@]}"; do
     if resolved="$(_resolve_dependency $dep)"; then
@@ -976,7 +1059,68 @@ _resolve_dependencies() {
       exit_with "Resolving '$dep' failed, should this be built first?" 1
     fi
   done
-  pkg_all_deps_resolved=("${pkg_build_deps_resolved[@]}" "${pkg_deps_resolved[@]}")
+
+  # Build `${pkg_build_tdeps_resolved[@]}` containing all the direct build
+  # dependencies, and the run dependencies for each direct build dependency.
+
+  # Copy all direct build dependencies into a new array
+  pkg_build_tdeps_resolved=("${pkg_build_deps_resolved[@]}")
+  # Append all non-direct (transitive) run dependencies for each direct build
+  # dependency. That's right, not a typo ;) This is how a `chef/gcc` build
+  # dependency could pull in `chef/binutils` for us, as an example. Any
+  # duplicate entries are dropped to produce a proper set.
+  for dep in "${pkg_build_deps_resolved[@]}"; do
+    tdeps=($(_get_tdeps_for $dep))
+    for tdep in "${tdeps[@]}"; do
+      tdep="$BLDR_PKG_ROOT/$tdep"
+      pkg_build_tdeps_resolved=(
+        $(_return_or_append_to_set "$tdep" "${pkg_build_tdeps_resolved[@]}")
+      )
+    done
+  done
+
+  # Build `${pkg_tdeps_resolved[@]}` containing all the direct run
+  # dependencies, and the run dependencies for each direct run dependency.
+
+  # Copy all direct dependencies into a new array
+  pkg_tdeps_resolved=("${pkg_deps_resolved[@]}")
+  # Append all non-direct (transitive) run dependencies for each direct run
+  # dependency. Any duplicate entries are dropped to produce a proper set.
+  for dep in "${pkg_deps_resolved[@]}"; do
+    tdeps=($(_get_tdeps_for $dep))
+    for tdep in "${tdeps[@]}"; do
+      tdep="$BLDR_PKG_ROOT/$tdep"
+      pkg_tdeps_resolved=(
+        $(_return_or_append_to_set "$tdep" "${pkg_tdeps_resolved[@]}")
+      )
+    done
+  done
+
+  # Build `${pkg_all_deps_resolved[@]}` containing all direct build and run
+  # dependencies. The build dependencies appear before the run dependencies.
+  pkg_all_deps_resolved=(
+    "${pkg_build_deps_resolved[@]}"
+    "${pkg_deps_resolved[@]}"
+  )
+
+  # Build an ordered set of all build and run dependencies (direct and
+  # transitive). The order is important as this gets used when setting the
+  # `$PATH` ordering in the build environment. To give priority to direct
+  # dependencies over transitive ones the order of packages is the following:
+  #
+  # 1. All direct build dependencies
+  # 1. All direct run dependencies
+  # 1. All unique transitive build dependencies that aren't already added
+  # 1. All unique transitive run dependencies that aren't already added
+  pkg_all_tdeps_resolved=(
+    "${pkg_build_deps_resolved[@]}"
+    "${pkg_deps_resolved[@]}"
+  )
+  for dep in "${pkg_build_tdeps_resolved[@]}" "${pkg_tdeps_resolved[@]}"; do
+    pkg_all_tdeps_resolved=(
+      $(_return_or_append_to_set "$tdep" "${pkg_all_tdeps_resolved[@]}")
+    )
+  done
 }
 
 # Download the software from `$pkg_source` and place it in
@@ -1045,6 +1189,13 @@ do_default_unpack() {
 # location.
 _build_environment() {
   build_line "Setting build environment"
+
+  # Build `$LD_RUN_PATH` containing each path in our own `${pkg_lib_dirs[@]}`
+  # array and then each direct run dependency's `LD_RUN_PATH` entry if one
+  # exists. This ensures that the resulting `RUNPATH` (like `RPATH`, but not
+  # overridable) entries only contain **direct** **runtime** paths. If a
+  # dependency's lib directory needs to be set in the resulting `RUNPATH`
+  # sections of an ELF binary, it must be a direct dependency, not transitive.
   local ld_run_path_part=""
   for lib in "${pkg_lib_dirs[@]}"; do
     if [[ -z $ld_run_path_part ]]; then
@@ -1054,14 +1205,6 @@ _build_environment() {
     fi
   done
   export LD_RUN_PATH=$ld_run_path_part
-  local path_part=""
-  for path in "${pkg_binary_path[@]}"; do
-    if [[ -z $path_part ]]; then
-      path_part="$pkg_path/$path"
-    else
-      path_part="$path_part:$pkg_path/$path"
-    fi
-  done
   for dep_path in "${pkg_deps_resolved[@]}"; do
     if [[ -f "$dep_path/LD_RUN_PATH" ]]; then
       local data=$(cat $dep_path/LD_RUN_PATH)
@@ -1073,6 +1216,41 @@ _build_environment() {
       fi
     fi
   done
+
+  # Build `$PATH` containing each path in our own `${pkg_binary_path[@]}`
+  # array, and then any dependency's `PATH` entry (direct or transitive) if one
+  # exists. The ordering of the path is specfic to
+  # `${pkg_all_tdeps_resolved[@]}` which is further explained in the
+  # `_resolve_dependencies()` function.
+  local path_part=""
+  for path in "${pkg_binary_path[@]}"; do
+    if [[ -z $path_part ]]; then
+      path_part="$pkg_path/$path"
+    else
+      path_part="$path_part:$pkg_path/$path"
+    fi
+  done
+  for dep_path in "${pkg_all_tdeps_resolved[@]}"; do
+    if [[ -f "$dep_path/PATH" ]]; then
+      local data=$(cat $dep_path/PATH)
+      local trimmed=$(trim $data)
+      if [[ -z $path_part ]]; then
+        path_part="$trimmed"
+      else
+        path_part="$path_part:$trimmed"
+      fi
+    fi
+  done
+  # Insert all the package PATH fragments before the default PATH to ensure
+  # Bldr package binaries are used before any userland/operating system binaries
+  if [[ -n $path_part ]]; then
+    export PATH="$path_part:$PATH"
+  fi
+
+  # Build `$CFLAGS` and `$LDFLAGS` containing any direct dependency's `CFLAGS`
+  # or `LDFLAGS` entries respectively (build or run). If the software to be
+  # built requires the path to headers or shared libraries, it must be a
+  # direct dependency, not transitive.
   for dep_path in "${pkg_all_deps_resolved[@]}"; do
     if [[ -f "$dep_path/CFLAGS" ]]; then
       local data=$(cat $dep_path/CFLAGS)
@@ -1092,21 +1270,8 @@ _build_environment() {
         export LDFLAGS="$trimmed"
       fi
     fi
-    if [[ -f "$dep_path/PATH" ]]; then
-      local data=$(cat $dep_path/PATH)
-      local trimmed=$(trim $data)
-      if [[ -z $path_part ]]; then
-        path_part="$trimmed"
-      else
-        path_part="$path_part:$trimmed"
-      fi
-    fi
   done
-  # Insert all the package PATH fragments before the default PATH to ensure
-  # Bldr package binaries are used before any userland/operating system binaries
-  if [[ -n $path_part ]]; then
-    export PATH="$path_part:$PATH"
-  fi
+
   # Set PREFIX for maximum default software build support
   export PREFIX=$pkg_path
   build_line "Setting PATH=$PATH"
@@ -1261,9 +1426,17 @@ _build_metadata() {
   if [[ -n "$deps" ]]; then
     echo "$deps" > $pkg_path/BUILD_DEPS
   fi
+  deps="$(printf '%s\n' "${pkg_build_tdeps_resolved[@]}" | cut -d "/" -f ${cutn}- | sort)"
+  if [[ -n "$deps" ]]; then
+    echo "$deps" > $pkg_path/BUILD_TDEPS
+  fi
   deps="$(printf '%s\n' "${pkg_deps_resolved[@]}" | cut -d "/" -f ${cutn}-)"
   if [[ -n "$deps" ]]; then
     echo "$deps" > $pkg_path/DEPS
+  fi
+  deps="$(printf '%s\n' "${pkg_tdeps_resolved[@]}" | cut -d "/" -f ${cutn}- | sort)"
+  if [[ -n "$deps" ]]; then
+    echo "$deps" > $pkg_path/TDEPS
   fi
 
   echo "${pkg_derivation}/${pkg_name}/${pkg_version}/${pkg_rel}" >> $pkg_path/IDENT


### PR DESCRIPTION
As a Plan author, I want to write a plan without having to fully express
the dependency tree for my software, so that I can easily write plans
without knowing all the dependencies down to glibc.

Prior to this change, the plan syntax requires you to fully express
dependencies, so for example, if a `chef/httpd` Plan depends on
`chef/apr-util` and `chef/apr-util` depends on `chef/apr`, you still
need to tell `chef/httpd` that it depends on `chef/apr`. In other words,
`bldr-build` did not support transitive dependencies. This feature adds
this support.
## New Metadata

This change introduces 2 new metadata files: `TDEPS` and `BUILD_TDEPS`.
The `T` in both of these names, refers to "transitive", that is,
non-direct dependencies that are not explicitly declared by a Plan
author.

The `TDEPS` file is formatted exactly similar to the `DEPS` metadata
file (package identifier entries, one per line). It is the unique set of
**all** other packages that need to be installed for the given package
to correctly function at runtime. To install a package in a fresh
environment the algorithm becomes simple: install yourself, then install
each entry in your `TDEPS` metadata. As the packages are immutable (the
internal files never change) and atomic (you never half-install a
package over one that is already is use), the installation order of the
`TDEPS` packages is irrelevant. This is why the entries are lexically
sorted to make the output more deterministic.

The `BUILD_TDEPS` serves the same purpose as `TDEPS`, but for the
`BUILD_TEPS` with one important difference: the `BUILD_TDEPS` entries
are **run** depenedencies of the direct **build** dependencies. Put
another way, it is the unique set of **all** other package that need to
be installed for the given package to correctly function at build time.

An example might be helpful. Imagine 4 Plans that have the following
relationships:

```
> head -n 4 app/plan.sh dep-x/plan.sh dep-y/plan.sh dep-z/plan.sh

==> app/plan.sh <==
pkg_name=app
pkg_derivation=chef
pkg_version=1.0.0
pkg_deps=(chef/dep-x chef/dep-z)

==> dep-x/plan.sh <==
pkg_name=dep-x
pkg_derivation=chef
pkg_version=2.0.0
pkg_deps=(chef/dep-y)

==> dep-y/plan.sh <==
pkg_name=dep-y
pkg_derivation=chef
pkg_version=3.0.0
pkg_deps=(chef/dep-z)

==> dep-z/plan.sh <==
pkg_name=dep-z
pkg_derivation=chef
pkg_version=4.0.0
pkg_deps=()
```

Once built (starting with Plans containing no packages and building
backwards to `chef/app`), the contents of the `DEPS` and `TDEPS` files
look like the following:

```
 # The use of head is only to get file banners, hence the large line arg
> head -n 500 /opt/bldr/pkgs/chef/{app,dep-{x,y,z}}/*/*/{DEPS,TDEPS}

==> /opt/bldr/pkgs/chef/app/1.0.0/20160113162220/DEPS <==
chef/dep-x/2.0.0/20160113162217
chef/dep-z/4.0.0/20160113162211

==> /opt/bldr/pkgs/chef/app/1.0.0/20160113162220/TDEPS <==
chef/dep-x/2.0.0/20160113162217
chef/dep-y/3.0.0/20160113162213
chef/dep-z/4.0.0/20160113162211

==> /opt/bldr/pkgs/chef/dep-x/2.0.0/20160113162217/DEPS <==
chef/dep-y/3.0.0/20160113162213

==> /opt/bldr/pkgs/chef/dep-x/2.0.0/20160113162217/TDEPS <==
chef/dep-y/3.0.0/20160113162213
chef/dep-z/4.0.0/20160113162211

==> /opt/bldr/pkgs/chef/dep-y/3.0.0/20160113162213/DEPS <==
chef/dep-z/4.0.0/20160113162211

==> /opt/bldr/pkgs/chef/dep-y/3.0.0/20160113162213/TDEPS <==
chef/dep-z/4.0.0/20160113162211

head: cannot open '/opt/bldr/pkgs/chef/dep-z/*/*/DEPS' for reading: No such file or directory
head: cannot open '/opt/bldr/pkgs/chef/dep-z/*/*/TDEPS' for reading: No such file or directory
```

Note that the `chef/dep-z` didn't have any dependencies, so its `DEPS`
and `TDEPS` metadata files were not created. This is the same as having
an empty file.

Finally, the reader should note that the `DEPS` and `BUILD_DEPS`
metadata files remain unchanged in their format, behavior, and semantics
(i.e.  meaning). They remain the suitably resolved package identifiers
of the packages declared by Plan authors in the `$pkg_deps` and
`$pkg_build_deps` arrays respectively.
## Build Environment Variables

The internal `_build_environment()` phase sets up various environment
variables that will be used to build a package from a Plan. The newly
introduced notion of transitive dependencies slightly changes the inputs
from which these variables are populated. In the interest of clarity,
here is the high level intent for each:
- `$LD_RUN_PATH`: Only present `LD_RUN_PATH` metadata entries from
  **direct** **run** dependencies are added. The paths in this variable
  become the `RUNPATH` entry in the resulting ELF binaries (commands
  under `bin/` and shared libraries), therefore it must be as small as
  possible and each path entry must be installed on disk before the
  resulting command or library is used.
- `$PATH`: All present `PATH` metadata entries from direct and
  transitive, build and run dependencies are added. If a useful command
  exists in the dependency chain, it will be availble for Plan authors
  without any further work. Please read the following section about
  `pkg_path_for()` for more detail.
- `$CFLAGS`: All present `CFLAGS` metadata entries from **direct** build
  and run dependencies are added. Transitive dependency entries are not
  added--if you need particular headers, then it sounds like you
  directly depend on that package, no?
- `$LDFLAGS`: All present `LDFLAGS` metadata entries from **direct**
  build and run dependencies are added. Transitive dependency entries
  are not added--if you need the path to particular shared libraries, you
  most certainly have a direct dependency requirement.
## Note for pkg_path_for()

The code for the `pkg_path_for()` helper function has not changed,
however there is now a subtle but important difference in its behavior.
The `pkg_path_for()` function will only return results for **direct**
build and run dependencies, and no transitive ones. The rationale is as
follows: as a Plan author, if you find yourself writing statements like:

```
do_build() {
  ./configure --prefix=$pkg_prefix \
    --with-libc=$(pkg_path_for chef/glibc)
}
```

then the implication is you directly depend on `chef/glibc`. Similarly,
if you need the path to to a command which will be used at runtime:

```
do_build() {
  make BASH_BINARY=$(pkg_path_for chef/bash)/bin/bash
}
```

then you also directly depend on `chef/bash`.

If you only require a command for build time--let's say Perl as a build
dependency--then make sure you declare it in your build dependencies and
the `perl` command will already be in `$PATH` when the Plan executes.
