### PR TITLE
[bldr] cleanup warnings

### DIFF
--- a/src/bldr/gossip/client.rs
+++ b/src/bldr/gossip/client.rs
@@ -24,13 +24,12 @@ use msgpack::{Encoder, Decoder};
 use rustc_serialize::{Encodable, Decodable};
 use utp::UtpSocket;
 
-use std::thread;
 use std::net::ToSocketAddrs;
 
 use error::BldrResult;
 use gossip::message::{BUFFER_SIZE, Message};
 
-static LOGKEY: &'static str = "GC";
+//static LOGKEY: &'static str = "GC";
 
 /// A Gossip Client.
 pub struct Client {

--- a/src/bldr/gossip/server.rs
+++ b/src/bldr/gossip/server.rs
@@ -23,17 +23,14 @@ use std::net::SocketAddr;
 use std::thread;
 use std::net;
 
-use msgpack::Decoder;
-use rustc_serialize::Decodable;
 use utp::{UtpListener, UtpSocket};
-use wonder::actor;
 use wonder::actor::{GenServer, ActorSender, HandleResult, InitResult, StopReason};
 
 use gossip::client::Client;
-use gossip::message::{BUFFER_SIZE, Message};
+use gossip::message::Message;
 use error::{BldrResult, BldrError};
 
-static LOGKEY: &'static str = "GS";
+//static LOGKEY: &'static str = "GS";
 
 /// A gossip server
 pub struct Server {
@@ -77,7 +74,7 @@ impl Server {
 /// * We fail to receive a message
 /// * We fail to decode the message into a gossip::Message
 /// * We fail to transmit a response (depending on the message)
-fn receive(mut socket: UtpSocket, src: net::SocketAddr) -> BldrResult<Message> {
+fn receive(socket: UtpSocket, src: net::SocketAddr) -> BldrResult<Message> {
     let mut client = Client::from_socket(socket);
     let msg = try!(client.recv_message());
 
@@ -127,7 +124,7 @@ impl GenServer for ServerActor {
                    message: Self::T,
                    _caller: &ActorSender<Self::T>,
                    _me: &ActorSender<Self::T>,
-                   state: &mut Self::S)
+                   _state: &mut Self::S)
                    -> HandleResult<Self::T> {
         match message {
             ServerActorMessage::Stop => {

--- a/src/bldr/package/archive.rs
+++ b/src/bldr/package/archive.rs
@@ -15,11 +15,8 @@
 //
 
 use std::fmt;
-use std::fs::File;
 use std::io::{Seek, SeekFrom};
-use std::mem;
 use std::path::PathBuf;
-use std::process::Command;
 use std::str;
 
 use libarchive::writer;
@@ -28,7 +25,6 @@ use libarchive::archive::{Entry, ReadFilter, ReadFormat};
 use regex::Regex;
 
 use error::{BldrResult, BldrError, ErrorKind};
-use fs::GPG_CACHE;
 use package::Package;
 use util::gpg;
 
@@ -186,7 +182,7 @@ impl PackageArchive {
                 }
             }
             Ok(None) => Err(bldr_error!(ErrorKind::MetaFileMalformed)),
-            Err(e) => Err(bldr_error!(ErrorKind::MetaFileMalformed)),
+            Err(_) => Err(bldr_error!(ErrorKind::MetaFileMalformed)),
         }
     }
 }


### PR DESCRIPTION
- unused LOGKEYs remain, but commented out
- `cargo build` shouldn't display any warnings
