### PR TITLE
update license header to more accurate licensing state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "bldr"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "ansi_term 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "docopt 0.6.78 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/bldr/census.rs
+++ b/src/bldr/census.rs
@@ -1,19 +1,8 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// Copyright:: Copyright (c) 2015 Chef Software, Inc.
-// License:: Apache License, Version 2.0
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
 
 //! The Census is the core of our service discovery mechanism. It keeps track of every supervisor
 //! in our group, and handles reading, writing, and serializing it with the discovery backend
@@ -255,11 +244,12 @@ impl GenServer for CensusEntryActor {
                       -> HandleResult<Self::T> {
         match self.write_to_discovery(state) {
             Ok(_) => HandleResult::NoReply(Some(ENTRY_TIMEOUT_MS)),
-            Err(e) =>
+            Err(e) => {
                 return HandleResult::Stop(StopReason::Fatal(format!("Census Entry Actor caught \
                                                                      unexpected error: {:?}",
                                                                     e)),
-                                          None),
+                                          None)
+            }
         }
     }
 
@@ -271,9 +261,7 @@ impl GenServer for CensusEntryActor {
                    state: &mut Self::S)
                    -> HandleResult<Self::T> {
         match message {
-            Message::Stop => {
-                HandleResult::Stop(StopReason::Normal, Some(Message::Ok))
-            }
+            Message::Stop => HandleResult::Stop(StopReason::Normal, Some(Message::Ok)),
             Message::Write(etcdwrite) => {
                 mem::replace(state, etcdwrite);
                 match self.write_to_discovery(state) {
@@ -282,9 +270,11 @@ impl GenServer for CensusEntryActor {
                 }
                 HandleResult::Reply(Message::Ok, Some(ENTRY_TIMEOUT_MS))
             }
-            Message::Ok => HandleResult::Stop(StopReason::Fatal(format!("You don't send me Ok! \
-                                                                         I send YOU Ok!")),
-                                              Some(Message::Ok)),
+            Message::Ok => {
+                HandleResult::Stop(StopReason::Fatal(format!("You don't send me Ok! I send YOU \
+                                                              Ok!")),
+                                   Some(Message::Ok))
+            }
         }
     }
 }
@@ -524,9 +514,7 @@ impl Census {
                                                      Some(lce)
                                                  }
                                              }
-                                             None => {
-                                                 Some(rce)
-                                             }
+                                             None => Some(rce),
                                          }
                                      })
                                      .unwrap();
@@ -673,11 +661,12 @@ impl GenServer for CensusActor {
                     state.census_string = None;
                 }
                 Err(TryRecvError::Empty) => {}
-                Err(e) =>
+                Err(e) => {
                     return HandleResult::Stop(StopReason::Fatal(format!("Census Actor caught \
                                                                          unexpected error: {:?}",
                                                                         e)),
-                                              None),
+                                              None)
+                }
             }
         }
         HandleResult::NoReply(Some(CENSUS_TIMEOUT_MS))
@@ -699,18 +688,17 @@ impl GenServer for CensusActor {
                     state.census_string = None;
                 }
                 Err(TryRecvError::Empty) => {}
-                Err(e) =>
+                Err(e) => {
                     return HandleResult::Stop(StopReason::Fatal(format!("Census Actor caught \
                                                                          unexpected error: {:?}",
                                                                         e)),
-                                              Some(CensusMessage::Ok)),
+                                              Some(CensusMessage::Ok))
+                }
             }
         }
 
         match message {
-            CensusMessage::Stop => {
-                HandleResult::Stop(StopReason::Normal, Some(CensusMessage::Ok))
-            }
+            CensusMessage::Stop => HandleResult::Stop(StopReason::Normal, Some(CensusMessage::Ok)),
             CensusMessage::Census => {
                 match state.census_string {
                     Some(ref toml_string) => {
@@ -723,14 +711,16 @@ impl GenServer for CensusActor {
                     }
                 }
             }
-            CensusMessage::Ok =>
+            CensusMessage::Ok => {
                 HandleResult::Stop(StopReason::Fatal(format!("You don't send me Ok! I send YOU \
                                                               Ok!")),
-                                   Some(CensusMessage::Ok)),
-            CensusMessage::CensusToml(_) =>
+                                   Some(CensusMessage::Ok))
+            }
+            CensusMessage::CensusToml(_) => {
                 HandleResult::Stop(StopReason::Fatal(format!("You don't send me CensusToml(_)! \
                                                               I send YOU CensusToml(_)!")),
-                                   Some(CensusMessage::Ok)),
+                                   Some(CensusMessage::Ok))
+            }
         }
     }
 }

--- a/src/bldr/command/configure.rs
+++ b/src/bldr/command/configure.rs
@@ -1,19 +1,8 @@
-//
 // Copyright:: Copyright (c) 2015 Chef Software, Inc.
-// License:: Apache License, Version 2.0
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
 
 //! Prints the configuration options for a service. Actually the `config` command.
 //!

--- a/src/bldr/command/install.rs
+++ b/src/bldr/command/install.rs
@@ -1,19 +1,8 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// Copyright:: Copyright (c) 2015 Chef Software, Inc.
-// License:: Apache License, Version 2.0
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
 
 //! Installs a bldr package from a [repo](../repo).
 //!

--- a/src/bldr/command/key.rs
+++ b/src/bldr/command/key.rs
@@ -1,19 +1,8 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// Copyright:: Copyright (c) 2015 Chef Software, Inc.
-// License:: Apache License, Version 2.0
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
 
 //! Installs a gpg key from a [repo](../repo) or a local file.
 //!

--- a/src/bldr/command/key_upload.rs
+++ b/src/bldr/command/key_upload.rs
@@ -1,19 +1,8 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// Copyright:: Copyright (c) 2015 Chef Software, Inc.
-// License:: Apache License, Version 2.0
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
 
 //! Uploads a gpg key to a [repo](../repo).
 //!
@@ -70,8 +59,9 @@ pub fn key(config: &Config) -> BldrResult<()> {
                         outputln!("Uploading {}.asc", config.key());
                         try!(repo::client::put_key(url, cached));
                     }
-                    Err(_) =>
-                        return Err(bldr_error!(ErrorKind::KeyNotFound(config.key().to_string()))),
+                    Err(_) => {
+                        return Err(bldr_error!(ErrorKind::KeyNotFound(config.key().to_string())))
+                    }
                 }
             } else {
                 return Err(bldr_error!(ErrorKind::FileNotFound(config.key().to_string())));

--- a/src/bldr/command/mod.rs
+++ b/src/bldr/command/mod.rs
@@ -1,19 +1,8 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// Copyright:: Copyright (c) 2015 Chef Software, Inc.
-// License:: Apache License, Version 2.0
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
 
 //! The CLI commands.
 //!

--- a/src/bldr/command/repo.rs
+++ b/src/bldr/command/repo.rs
@@ -1,19 +1,8 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// Copyright:: Copyright (c) 2015 Chef Software, Inc.
-// License:: Apache License, Version 2.0
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
 
 //! Runs a bldr package repository.
 //!

--- a/src/bldr/command/start.rs
+++ b/src/bldr/command/start.rs
@@ -1,19 +1,8 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// Copyright:: Copyright (c) 2015 Chef Software, Inc.
-// License:: Apache License, Version 2.0
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
 
 //! Starts a service from an installed bldr package.
 //!

--- a/src/bldr/command/upload.rs
+++ b/src/bldr/command/upload.rs
@@ -1,19 +1,8 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// Copyright:: Copyright (c) 2015 Chef Software, Inc.
-// License:: Apache License, Version 2.0
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
 
 //! Uploads a package to a [repository](../repo).
 //!

--- a/src/bldr/config.rs
+++ b/src/bldr/config.rs
@@ -1,19 +1,8 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// Copyright:: Copyright (c) 2015 Chef Software, Inc.
-// License:: Apache License, Version 2.0
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
 
 //! Configuration for bldr.
 //!

--- a/src/bldr/discovery/etcd.rs
+++ b/src/bldr/discovery/etcd.rs
@@ -1,19 +1,8 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// Copyright:: Copyright (c) 2015 Chef Software, Inc.
-// License:: Apache License, Version 2.0
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
 
 //! Etcd backend for service discovery.
 //!
@@ -173,12 +162,14 @@ pub fn watch(key: &str,
              watcher_tx: Sender<Option<String>>,
              watcher_rx: Receiver<bool>) {
     match enabled() {
-        Some(_) => watch_thread(key,
-                                reconnect_interval,
-                                wait,
-                                recursive,
-                                watcher_tx,
-                                watcher_rx),
+        Some(_) => {
+            watch_thread(key,
+                         reconnect_interval,
+                         wait,
+                         recursive,
+                         watcher_tx,
+                         watcher_rx)
+        }
         None => {
             debug!("Etcd not enabled; starting mock thread");
             watch_mock_thread(key, reconnect_interval, watcher_tx, watcher_rx);

--- a/src/bldr/discovery/mod.rs
+++ b/src/bldr/discovery/mod.rs
@@ -1,18 +1,7 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// Copyright:: Copyright (c) 2015 Chef Software, Inc.
-// License:: Apache License, Version 2.0
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
 
 pub mod etcd;

--- a/src/bldr/error.rs
+++ b/src/bldr/error.rs
@@ -1,18 +1,8 @@
-// Copyright:: Copyright (c) 2015 Chef Software, Inc.
-// License:: Apache License, Version 2.0
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
 
 //! Error handling for Bldr.
 //!

--- a/src/bldr/fs.rs
+++ b/src/bldr/fs.rs
@@ -1,19 +1,8 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// Copyright:: Copyright (c) 2015 Chef Software, Inc.
-// License:: Apache License, Version 2.0
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
 
 pub const PACKAGE_HOME: &'static str = "/opt/bldr/pkgs";
 pub const SERVICE_HOME: &'static str = "/opt/bldr/srvc";

--- a/src/bldr/gossip/client.rs
+++ b/src/bldr/gossip/client.rs
@@ -1,19 +1,8 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// Copyright:: Copyright (c) 2015 Chef Software, Inc.
-// License:: Apache License, Version 2.0
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
 
 //! The Gossip Client.
 //!
@@ -63,9 +52,7 @@ impl Client {
         try!(self.send_message(Message::Ping));
         let msg = try!(self.recv_message());
         match msg {
-            Message::Pong => {
-                debug!("Gossip is alive - Ping successful")
-            }
+            Message::Pong => debug!("Gossip is alive - Ping successful"),
             _ => unreachable!(),
         }
         Ok(())

--- a/src/bldr/gossip/lamport_clock.rs
+++ b/src/bldr/gossip/lamport_clock.rs
@@ -1,19 +1,8 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// Copyright:: Copyright (c) 2015 Chef Software, Inc.
-// License:: Apache License, Version 2.0
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
 
 //! This is an implementation of a [lamport
 //! clock](https://en.wikipedia.org/wiki/Lamport_timestamps), which we use to provide ordering in

--- a/src/bldr/gossip/message.rs
+++ b/src/bldr/gossip/message.rs
@@ -1,19 +1,8 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// Copyright:: Copyright (c) 2015 Chef Software, Inc.
-// License:: Apache License, Version 2.0
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
 
 pub const BUFFER_SIZE: usize = 4096;
 

--- a/src/bldr/gossip/mod.rs
+++ b/src/bldr/gossip/mod.rs
@@ -1,19 +1,8 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// Copyright:: Copyright (c) 2015 Chef Software, Inc.
-// License:: Apache License, Version 2.0
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
 
 //! The gossip infrastructure.
 

--- a/src/bldr/gossip/server.rs
+++ b/src/bldr/gossip/server.rs
@@ -1,19 +1,8 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// Copyright:: Copyright (c) 2015 Chef Software, Inc.
-// License:: Apache License, Version 2.0
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
 
 //! The Gossip Server.
 //!
@@ -133,10 +122,11 @@ impl GenServer for ServerActor {
             ServerActorMessage::Stop => {
                 HandleResult::Stop(StopReason::Normal, Some(ServerActorMessage::Ok))
             }
-            ServerActorMessage::Ok =>
+            ServerActorMessage::Ok => {
                 HandleResult::Stop(StopReason::Fatal(format!("You don't send me Ok! I send YOU \
                                                               Ok!")),
-                                   Some(ServerActorMessage::Ok)),
+                                   Some(ServerActorMessage::Ok))
+            }
         }
     }
 }

--- a/src/bldr/health_check.rs
+++ b/src/bldr/health_check.rs
@@ -1,19 +1,8 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// Copyright:: Copyright (c) 2015 Chef Software, Inc.
-// License:: Apache License, Version 2.0
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
 
 use std::fmt::{self, Display, Formatter};
 

--- a/src/bldr/lib.rs
+++ b/src/bldr/lib.rs
@@ -1,19 +1,8 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// Copyright:: Copyright (c) 2015 Chef Software, Inc.
-// License:: Apache License, Version 2.0
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
 
 //! Bldr helps you build, manage, and run applications - on bare metal, in the cloud, and in
 //! containers. You can [read more about it, including setup instructions, in the README](README.html).

--- a/src/bldr/output.rs
+++ b/src/bldr/output.rs
@@ -1,19 +1,8 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// Copyright:: Copyright (c) 2015 Chef Software, Inc.
-// License:: Apache License, Version 2.0
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
 
 //! Formats user-visible output for Bldr.
 //!

--- a/src/bldr/package/archive.rs
+++ b/src/bldr/package/archive.rs
@@ -1,18 +1,8 @@
-// Copyright:: Copyright (c) 2015 Chef Software, Inc.
-// License:: Apache License, Version 2.0
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
 
 use std::fmt;
 use std::io::{Seek, SeekFrom};

--- a/src/bldr/package/hooks.rs
+++ b/src/bldr/package/hooks.rs
@@ -1,18 +1,8 @@
-// Copyright:: Copyright (c) 2015 Chef Software, Inc.
-// License:: Apache License, Version 2.0
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
 
 use std::fmt;
 use std::fs::{self, OpenOptions};

--- a/src/bldr/package/mod.rs
+++ b/src/bldr/package/mod.rs
@@ -1,19 +1,8 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// Copyright:: Copyright (c) 2015 Chef Software, Inc.
-// License:: Apache License, Version 2.0
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
 
 pub mod archive;
 pub mod hooks;

--- a/src/bldr/package/updater.rs
+++ b/src/bldr/package/updater.rs
@@ -1,19 +1,8 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// Copyright:: Copyright (c) 2015 Chef Software, Inc.
-// License:: Apache License, Version 2.0
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
 
 use std::sync::{Arc, RwLock};
 

--- a/src/bldr/repo/client.rs
+++ b/src/bldr/repo/client.rs
@@ -1,18 +1,8 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// Copyright:: Copyright (c) 2015 Chef Software, Inc.
-// License:: Apache License, Version 2.0
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
 
 use std::io::{Read, Write, BufWriter};
 use std::fs::{self, File};
@@ -64,11 +54,12 @@ pub fn fetch_package_exact(repo: &str,
             let path = PathBuf::from(file);
             Ok(PackageArchive::new(path))
         }
-        Err(BldrError{ err: ErrorKind::HTTP(StatusCode::NotFound), ..}) =>
+        Err(BldrError{ err: ErrorKind::HTTP(StatusCode::NotFound), ..}) => {
             Err(bldr_error!(ErrorKind::RemotePackageNotFound(package.derivation.clone(),
                                                              package.name.clone(),
                                                              Some(package.version.clone()),
-                                                             Some(package.release.clone())))),
+                                                             Some(package.release.clone()))))
+        }
         Err(e) => Err(e),
     }
 }
@@ -113,11 +104,12 @@ pub fn fetch_package(repo: &str,
             let path = PathBuf::from(file);
             Ok(PackageArchive::new(path))
         }
-        Err(BldrError { err: ErrorKind::HTTP(StatusCode::NotFound), ..}) =>
+        Err(BldrError { err: ErrorKind::HTTP(StatusCode::NotFound), ..}) => {
             Err(bldr_error!(ErrorKind::RemotePackageNotFound(derivation.to_string(),
                                                              package.to_string(),
                                                              version.clone(),
-                                                             release.clone()))),
+                                                             release.clone())))
+        }
         Err(e) => Err(e),
     }
 }

--- a/src/bldr/repo/mod.rs
+++ b/src/bldr/repo/mod.rs
@@ -1,18 +1,8 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// Copyright:: Copyright (c) 2015 Chef Software, Inc.
-// License:: Apache License, Version 2.0
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
 
 pub mod client;
 

--- a/src/bldr/service_config.rs
+++ b/src/bldr/service_config.rs
@@ -1,19 +1,8 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// Copyright:: Copyright (c) 2015 Chef Software, Inc.
-// License:: Apache License, Version 2.0
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
 
 //! Stores the configuration data for the service, and manages binding that data to any
 //! configuration files we need to render.

--- a/src/bldr/sidecar.rs
+++ b/src/bldr/sidecar.rs
@@ -1,19 +1,8 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// Copyright:: Copyright (c) 2015 Chef Software, Inc.
-// License:: Apache License, Version 2.0
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
 
 //! The http sidecar for bldr services. Provides an interface to verifying and validating
 //! promises.
@@ -105,8 +94,9 @@ impl GenServer for Sidecar {
 
         match Iron::new(router).http(LISTEN_ADDR) {
             Ok(_) => HandleResult::NoReply(None),
-            Err(_) =>
-                HandleResult::Stop(StopReason::Fatal("couldn't start router".to_string()), None),
+            Err(_) => {
+                HandleResult::Stop(StopReason::Fatal("couldn't start router".to_string()), None)
+            }
         }
     }
 }

--- a/src/bldr/state_machine.rs
+++ b/src/bldr/state_machine.rs
@@ -1,19 +1,8 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// Copyright:: Copyright (c) 2015 Chef Software, Inc.
-// License:: Apache License, Version 2.0
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
 
 //! A generic state machine.
 

--- a/src/bldr/topology/initializer.rs
+++ b/src/bldr/topology/initializer.rs
@@ -1,26 +1,16 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// Copyright:: Copyright (c) 2015 Chef Software, Inc.
-// License:: Apache License, Version 2.0
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
-// This is the building block of complicated topologies which require a leader. It is
-// used when a single member of your cluster should perform additional applications
-// level initialization and/or if the other members of your cluster need to perform
-// additional initialization steps.
-//
-// We guarantee that the leader will perform it's initialization sequence before the
-// followers attempt to run thier initialization sequences.
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
+
+//! This is the building block of complicated topologies which require a leader. It is
+//! used when a single member of your cluster should perform additional applications
+//! level initialization and/or if the other members of your cluster need to perform
+//! additional initialization steps.
+//!
+//! We guarantee that the leader will perform it's initialization sequence before the
+//! followers attempt to run thier initialization sequences.
 
 use config::Config;
 use error::{BldrResult, BldrError};

--- a/src/bldr/topology/leader.rs
+++ b/src/bldr/topology/leader.rs
@@ -1,19 +1,8 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// Copyright:: Copyright (c) 2015 Chef Software, Inc.
-// License:: Apache License, Version 2.0
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
 
 use topology::{self, initializer, State, Worker};
 use state_machine::StateMachine;

--- a/src/bldr/topology/mod.rs
+++ b/src/bldr/topology/mod.rs
@@ -1,19 +1,8 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// Copyright:: Copyright (c) 2015 Chef Software, Inc.
-// License:: Apache License, Version 2.0
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
 
 //! The service topologies.
 //!

--- a/src/bldr/topology/standalone.rs
+++ b/src/bldr/topology/standalone.rs
@@ -1,19 +1,8 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// Copyright:: Copyright (c) 2015 Chef Software, Inc.
-// License:: Apache License, Version 2.0
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
 
 //! This is the default topology. It's most useful for applications that stand alone, or that don't
 //! share state between one another.

--- a/src/bldr/user_config.rs
+++ b/src/bldr/user_config.rs
@@ -1,19 +1,8 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// Copyright:: Copyright (c) 2015 Chef Software, Inc.
-// License:: Apache License, Version 2.0
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
 
 //! Manages runtime configuration provided by the users through a GenServer.
 //!
@@ -115,11 +104,12 @@ impl GenServer for UserActor {
                     state.config_string = None;
                 }
                 Err(TryRecvError::Empty) => {}
-                Err(e) =>
+                Err(e) => {
                     return HandleResult::Stop(StopReason::Fatal(format!("User Actor caught \
                                                                          unexpected error: {:?}",
                                                                         e)),
-                                              None),
+                                              None)
+                }
             }
         }
         HandleResult::NoReply(Some(TIMEOUT_MS))
@@ -141,36 +131,36 @@ impl GenServer for UserActor {
                     state.config_string = None;
                 }
                 Err(TryRecvError::Empty) => {}
-                Err(e) =>
+                Err(e) => {
                     return HandleResult::Stop(StopReason::Fatal(format!("User Actor caught \
                                                                          unexpected error: {:?}",
                                                                         e)),
-                                              Some(Message::Ok)),
+                                              Some(Message::Ok))
+                }
             }
         }
 
         match message {
-            Message::Stop => {
-                HandleResult::Stop(StopReason::Normal, Some(Message::Ok))
-            }
+            Message::Stop => HandleResult::Stop(StopReason::Normal, Some(Message::Ok)),
             Message::Config => {
                 match state.config_string {
                     Some(ref toml_string) => {
                         HandleResult::Reply(Message::ConfigToml(Some(toml_string.clone())),
                                             Some(TIMEOUT_MS))
                     }
-                    None => {
-                        HandleResult::Reply(Message::ConfigToml(None), Some(TIMEOUT_MS))
-                    }
+                    None => HandleResult::Reply(Message::ConfigToml(None), Some(TIMEOUT_MS)),
                 }
             }
-            Message::Ok => HandleResult::Stop(StopReason::Fatal(format!("You don't send me Ok! \
-                                                                         I send YOU Ok!")),
-                                              Some(Message::Ok)),
-            Message::ConfigToml(_) =>
+            Message::Ok => {
+                HandleResult::Stop(StopReason::Fatal(format!("You don't send me Ok! I send YOU \
+                                                              Ok!")),
+                                   Some(Message::Ok))
+            }
+            Message::ConfigToml(_) => {
                 HandleResult::Stop(StopReason::Fatal(format!("You don't send me CensusToml(_)! \
                                                               I send YOU CensusToml(_)!")),
-                                   Some(Message::Ok)),
+                                   Some(Message::Ok))
+            }
         }
     }
 }

--- a/src/bldr/util/convert.rs
+++ b/src/bldr/util/convert.rs
@@ -1,19 +1,8 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// Copyright:: Copyright (c) 2015 Chef Software, Inc.
-// License:: Apache License, Version 2.0
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
 
 use std::collections::{BTreeMap, HashMap};
 

--- a/src/bldr/util/gpg.rs
+++ b/src/bldr/util/gpg.rs
@@ -1,18 +1,8 @@
-// Copyright:: Copyright (c) 2015 Chef Software, Inc.
-// License:: Apache License, Version 2.0
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
 
 use std::fs::{self, File};
 

--- a/src/bldr/util/mod.rs
+++ b/src/bldr/util/mod.rs
@@ -1,19 +1,8 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// Copyright:: Copyright (c) 2015 Chef Software, Inc.
-// License:: Apache License, Version 2.0
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
 
 pub mod convert;
 pub mod gpg;

--- a/src/bldr/util/perm.rs
+++ b/src/bldr/util/perm.rs
@@ -1,19 +1,8 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// Copyright:: Copyright (c) 2015 Chef Software, Inc.
-// License:: Apache License, Version 2.0
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
 
 use error::{BldrResult, ErrorKind};
 use std::process::Command;
@@ -27,9 +16,7 @@ pub fn set_owner(path: &str, owner: &str) -> BldrResult<()> {
                           .output());
     match output.status.success() {
         true => Ok(()),
-        false => {
-            Err(bldr_error!(ErrorKind::PermissionFailed))
-        }
+        false => Err(bldr_error!(ErrorKind::PermissionFailed)),
     }
 }
 
@@ -43,8 +30,6 @@ pub fn set_permissions(path: &str, perm: &str) -> BldrResult<()> {
                           .output());
     match output.status.success() {
         true => Ok(()),
-        false => {
-            Err(bldr_error!(ErrorKind::PermissionFailed))
-        }
+        false => Err(bldr_error!(ErrorKind::PermissionFailed)),
     }
 }

--- a/src/bldr/util/signals.rs
+++ b/src/bldr/util/signals.rs
@@ -1,19 +1,8 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// Copyright:: Copyright (c) 2015 Chef Software, Inc.
-// License:: Apache License, Version 2.0
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
 
 //! Traps and notifies UNIX signals.
 //!
@@ -40,7 +29,7 @@ static mut CAUGHT: AtomicBool = ATOMIC_BOOL_INIT;
 static mut SIGNAL: AtomicUsize = ATOMIC_USIZE_INIT;
 
 // Functions from POSIX libc.
-extern {
+extern "C" {
     fn signal(sig: u32, cb: unsafe extern "C" fn(u32)) -> unsafe extern "C" fn(u32);
 }
 
@@ -115,9 +104,10 @@ impl actor::GenServer for SignalNotifier {
                    -> HandleResult<Self::T> {
         match message {
             Message::Stop => HandleResult::Stop(StopReason::Normal, Some(Message::Ok)),
-            msg =>
+            msg => {
                 HandleResult::Stop(StopReason::Fatal(format!("unexpected call message: {:?}", msg)),
-                                   Some(Message::Ok)),
+                                   Some(Message::Ok))
+            }
         }
     }
 
@@ -129,20 +119,27 @@ impl actor::GenServer for SignalNotifier {
         unsafe {
             if CAUGHT.load(Ordering::SeqCst) {
                 match SIGNAL.load(Ordering::SeqCst) {
-                    signal if signal == Signal::SIGHUP as usize =>
-                        self::send_signal(tx, Signal::SIGHUP),
-                    signal if signal == Signal::SIGINT as usize =>
-                        self::send_signal(tx, Signal::SIGINT),
-                    signal if signal == Signal::SIGQUIT as usize =>
-                        self::send_signal(tx, Signal::SIGQUIT),
-                    signal if signal == Signal::SIGALRM as usize =>
-                        self::send_signal(tx, Signal::SIGALRM),
-                    signal if signal == Signal::SIGTERM as usize =>
-                        self::send_signal(tx, Signal::SIGTERM),
-                    signal if signal == Signal::SIGUSR1 as usize =>
-                        self::send_signal(tx, Signal::SIGUSR1),
-                    signal if signal == Signal::SIGUSR2 as usize =>
-                        self::send_signal(tx, Signal::SIGUSR2),
+                    signal if signal == Signal::SIGHUP as usize => {
+                        self::send_signal(tx, Signal::SIGHUP)
+                    }
+                    signal if signal == Signal::SIGINT as usize => {
+                        self::send_signal(tx, Signal::SIGINT)
+                    }
+                    signal if signal == Signal::SIGQUIT as usize => {
+                        self::send_signal(tx, Signal::SIGQUIT)
+                    }
+                    signal if signal == Signal::SIGALRM as usize => {
+                        self::send_signal(tx, Signal::SIGALRM)
+                    }
+                    signal if signal == Signal::SIGTERM as usize => {
+                        self::send_signal(tx, Signal::SIGTERM)
+                    }
+                    signal if signal == Signal::SIGUSR1 as usize => {
+                        self::send_signal(tx, Signal::SIGUSR1)
+                    }
+                    signal if signal == Signal::SIGUSR2 as usize => {
+                        self::send_signal(tx, Signal::SIGUSR2)
+                    }
                     signal => {
                         return HandleResult::Stop(StopReason::Fatal(format!("caught unexpected \
                                                                              signal: {}",

--- a/src/bldr/util/sys.rs
+++ b/src/bldr/util/sys.rs
@@ -1,19 +1,8 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// Copyright:: Copyright (c) 2015 Chef Software, Inc.
-// License:: Apache License, Version 2.0
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
 
 use error::{BldrResult, ErrorKind};
 use std::process::Command;

--- a/src/bldr/watch_config.rs
+++ b/src/bldr/watch_config.rs
@@ -1,19 +1,8 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// Copyright:: Copyright (c) 2015 Chef Software, Inc.
-// License:: Apache License, Version 2.0
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
 
 //! Handles 'watch' configuration events.
 //!
@@ -136,12 +125,8 @@ impl WatchActorState {
         for watch_member in config.watch().iter() {
             let watch_parts: Vec<&str> = watch_member.split('.').collect();
             let (service, group) = match watch_parts.len() {
-                1 => {
-                    (String::from(watch_parts[0]), String::from("default"))
-                }
-                2 => {
-                    (String::from(watch_parts[0]), String::from(watch_parts[1]))
-                }
+                1 => (String::from(watch_parts[0]), String::from("default")),
+                2 => (String::from(watch_parts[0]), String::from(watch_parts[1])),
                 _ => {
                     return Err(bldr_error!(ErrorKind::BadWatch(watch_member.clone())));
                 }
@@ -175,7 +160,6 @@ impl WatchActorState {
             }
         }
     }
-
 }
 
 impl GenServer for WatchActor {
@@ -210,9 +194,7 @@ impl GenServer for WatchActor {
         }
 
         match message {
-            Message::Stop => {
-                HandleResult::Stop(StopReason::Normal, Some(Message::Ok))
-            }
+            Message::Stop => HandleResult::Stop(StopReason::Normal, Some(Message::Ok)),
             Message::Config => {
                 let mut watch_toml: toml::Table = BTreeMap::new();
                 let mut watch_list: toml::Array = Vec::new();
@@ -272,13 +254,16 @@ impl GenServer for WatchActor {
                     HandleResult::Reply(Message::ConfigToml(None), Some(TIMEOUT_MS))
                 }
             }
-            Message::Ok => HandleResult::Stop(StopReason::Fatal(format!("You don't send me Ok! \
-                                                                         I send YOU Ok!")),
-                                              Some(Message::Ok)),
-            Message::ConfigToml(_) =>
+            Message::Ok => {
+                HandleResult::Stop(StopReason::Fatal(format!("You don't send me Ok! I send YOU \
+                                                              Ok!")),
+                                   Some(Message::Ok))
+            }
+            Message::ConfigToml(_) => {
                 HandleResult::Stop(StopReason::Fatal(format!("You don't send me CensusToml(_)! \
                                                               I send YOU CensusToml(_)!")),
-                                   Some(Message::Ok)),
+                                   Some(Message::Ok))
+            }
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,18 +1,8 @@
-// Copyright:: Copyright (c) 2015 Chef Software, Inc.
-// License:: Apache License, Version 2.0
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
 
 #[macro_use]
 extern crate bldr;

--- a/tests/bldr/gossip.rs
+++ b/tests/bldr/gossip.rs
@@ -1,19 +1,8 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// Copyright:: Copyright (c) 2015 Chef Software, Inc.
-// License:: Apache License, Version 2.0
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
 
 use setup;
 use util::docker;

--- a/tests/bldr/key.rs
+++ b/tests/bldr/key.rs
@@ -1,19 +1,8 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// Copyright:: Copyright (c) 2015 Chef Software, Inc.
-// License:: Apache License, Version 2.0
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
 
 use setup;
 use util::{self, command, docker};

--- a/tests/bldr/mod.rs
+++ b/tests/bldr/mod.rs
@@ -1,3 +1,9 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
+//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
+
 pub mod start;
 pub mod repo;
 pub mod key;

--- a/tests/bldr/repo.rs
+++ b/tests/bldr/repo.rs
@@ -1,19 +1,8 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// Copyright:: Copyright (c) 2015 Chef Software, Inc.
-// License:: Apache License, Version 2.0
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
 
 use setup;
 use util::{command, docker};

--- a/tests/bldr/start.rs
+++ b/tests/bldr/start.rs
@@ -1,19 +1,8 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// Copyright:: Copyright (c) 2015 Chef Software, Inc.
-// License:: Apache License, Version 2.0
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
 
 use util::{self, docker};
 use setup;

--- a/tests/bldr_build/mod.rs
+++ b/tests/bldr_build/mod.rs
@@ -1,19 +1,8 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// Copyright:: Copyright (c) 2015 Chef Software, Inc.
-// License:: Apache License, Version 2.0
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
 
 use std::process::Command;
 

--- a/tests/functional.rs
+++ b/tests/functional.rs
@@ -1,19 +1,8 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// Copyright:: Copyright (c) 2015 Chef Software, Inc.
-// License:: Apache License, Version 2.0
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
 
 extern crate regex;
 extern crate tempdir;

--- a/tests/util/command.rs
+++ b/tests/util/command.rs
@@ -1,19 +1,8 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// Copyright:: Copyright (c) 2015 Chef Software, Inc.
-// License:: Apache License, Version 2.0
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
 
 use std::io::prelude::*;
 use std::io;
@@ -39,8 +28,10 @@ impl Cmd {
             Some(ref mut child) => {
                 child.kill().unwrap_or_else(|x| panic!("{:?}", x));
             }
-            None => panic!("Cannot kill a child that does not exist - you have probably called \
-                            wait_with_output already"),
+            None => {
+                panic!("Cannot kill a child that does not exist - you have probably called \
+                        wait_with_output already")
+            }
         }
         self
     }

--- a/tests/util/discovery.rs
+++ b/tests/util/discovery.rs
@@ -1,19 +1,8 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// Copyright:: Copyright (c) 2015 Chef Software, Inc.
-// License:: Apache License, Version 2.0
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
 
 use hyper::header::ContentType;
 use hyper::client::Client;

--- a/tests/util/docker.rs
+++ b/tests/util/docker.rs
@@ -1,9 +1,14 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-//  Start a docker container, store the instance id
-//  Get the logs
-//  Stop the container
-//  Get the logs
-//  Remove the container on drop
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
+
+//! Start a docker container, store the instance id
+//! Get the logs
+//! Stop the container
+//! Get the logs
+//! Remove the container on drop
 
 use util::command;
 use time;

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -1,3 +1,9 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
+//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
+
 pub mod path;
 pub mod command;
 pub mod docker;

--- a/tests/util/path.rs
+++ b/tests/util/path.rs
@@ -1,19 +1,8 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// Copyright:: Copyright (c) 2015 Chef Software, Inc.
-// License:: Apache License, Version 2.0
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
 
 use std::env;
 use std::path::PathBuf;


### PR DESCRIPTION
This was at the request of Jen Dumas. We should keep this our license header until at the very least 4/20.

From @juliandunn

```
Hey team, I finalized all the legal paper with Jen Dumas, who says that we need to remove any Apache 2.0 headers from bldr source code until 4/20. Until that time, the following text should be used instead:

The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing this file ("Licensee") apply to Licensee's use of the Software until such time that the Software is made available under an open source license such as the Apache 2.0 License.
I will add an expedite chore to JIRA so this gets done asap. Thanks everyone.
```

@metadave I also went ahead and set the correct date as you pointed out ealrier this week ;)
