### PR TITLE
[bldr-build] Delighters for the week of January 19, 2016

### DIFF
--- a/plans/bldr-build
+++ b/plans/bldr-build
@@ -1340,6 +1340,34 @@ do_default_build() {
   make
 }
 
+# Will run post-compile tests and checks, provided 2 conditions are true:
+#
+# 1. A `do_check()` function has been declared. By default, no such function
+#    exists, so Plan author must add one explicitly--there is no reasonably
+#    good deault here.
+# 1. A `$DO_CHECK` environment variable is set to some non-empty value. As
+#    tests can dramatically inflate the build time of a Plan, this has been
+#    left as an opt-in option.
+#
+# Here's an example example of a vanilla Plan such as Sed:
+#
+# ```sh
+# pkg_name=sed
+# # other Plan metadata...
+#
+# do_check() {
+#   make check
+# }
+# ```
+do_check_wrapper() {
+  if [[ "$(type -t do_check)" = "function" && -n "$DO_CHECK" ]]; then
+    build_line "Running post-compile tests"
+    pushd "$BLDR_SRC_CACHE/$pkg_dirname" > /dev/null
+    do_check
+    popd > /dev/null
+  fi
+}
+
 # Identical to the `build_wrapper` function above; simply makes sure the
 # working directory for the install_files step is correct.
 do_install_wrapper() {
@@ -1861,6 +1889,9 @@ do_prepare_wrapper
 
 # Build the source
 do_build_wrapper
+
+# Check the source
+do_check_wrapper
 
 # Install the source
 do_install_wrapper


### PR DESCRIPTION
## Place run dependencies before build dependenices.

This affects the order that the `$PATH`, `$LDFLAGS`, and `$CFLAGS`
environment variables are set. Before this change, the build
dependencies were first with run dependencies second, but after building
more software this has proven to be a sub-optimal ordering.

For example, if `libgcc.so` was desired, then the version from
`chef/gcc` might be found first by a libtool-driven build before the
shared library from `chef/gcc-libs` was checked. This change allows the
`chef/gcc-libs` to **most likely** be found first.
## Add internal `_fix_libtool()` phase to purge sys paths.

A frequently repeating pattern has emerged with software that ships with
Libtool scripts (i.e. `ltmain.sh`): by default they search system paths
for common libraries under `/usr/lib`, `/lib`, etc. As we are striving
for total isolation from any host environment, it is beneficial to
eliminate this source of "system leak".

A default, internal phase to fix this whenever a Libtool script is found
seems reasonable and additionally eliminates more boilerplate in Plan
files.

Thanks to the NixOS/nixpkgs project for the rationale, explanation, and
basis for implementation!

See:
- https://github.com/NixOS/nixpkgs/blob/1a4ab04e298077185dd32d4594825b6e92f60a4e/pkgs/stdenv/generic/setup.sh#L615-L617
- https://github.com/NixOS/nixpkgs/blob/1a4ab04e298077185dd32d4594825b6e92f60a4e/pkgs/stdenv/generic/setup.sh#L628-L631
## Exit early if PGP signing key is not properly set up.

This change is in the spirit of Fail Fast to give Plan authors the
shortest possible feedback loop. Before this change, a Plan may
download, extract, build, install the software correctly only to fail at
the very end of the process because either the `$pkg_gpg_key` metadata
was not set or the private key was not loaded via `gpg --import
<KEY>.gpg`. Given the high cost (in wall clock time) of executing a
Plan, this easily leads to tears, frustration, and anger. At least for
this author.
## Add an optional `do_check()` phase for post-compile tests.

This new phase will run post-compile tests and checks, provided 2
conditions are true:
1. A `do_check()` function has been declared. By default, no such
   function exists, so Plan author must add one explicitly--there is no
   reasonably good deault here.
2. A `$DO_CHECK` environment variable is set to some non-empty value. As
   tests can dramatically inflate the build time of a Plan, this has been
   left as an opt-in option.

Here's an example example of a vanilla Plan such as Sed:

``` sh
pkg_name=sed
 # other Plan metadata...

do_check() {
  make check
}
```
