### PR TITLE
[bldr-build] Delay creating `$pkg_path` until `_build_environment()`.

### DIFF
--- a/plans/bldr-build
+++ b/plans/bldr-build
@@ -1272,6 +1272,9 @@ _build_environment() {
     fi
   done
 
+  # Create the `$pkg_path`
+  mkdir -p $pkg_path
+
   # Set PREFIX for maximum default software build support
   export PREFIX=$pkg_path
   build_line "Setting PATH=$PATH"
@@ -1854,9 +1857,6 @@ pkg_srvc_config="$BLDR_ROOT/srvc/$pkg_name/config"
 if pkg_for_bldr=$(_latest_package "chef/bldr"); then
   BLDR_BIN="$pkg_for_bldr/bin/bldr"
 fi
-
-# Create the `$pkg_path`
-mkdir -p $pkg_path
 
 # Run `do_begin`
 build_line "Bldr setup"


### PR DESCRIPTION
This change should not impact any existing Plans, unless they are doing
borderline bad things.

Prior to this change the `$pkg_path` (i.e. the full path to the
extracted package on disk, such as
`/opt/bldr/pkgs/acme/software/1.2.3/201501020304`) was created almost at
the start of the Plan execution, even before the `do_begin()` phase.
This change delays creation until after dependencies are resolved and
present, the software has been downloaded, verified, and extracted.

The benefit is that any failures of the Plan before this point would not
end up with an empty `$pkg_path` directory on disk. This also helps
Plans that determine some of their metadata later than at start.
