### PR TITLE
initial metadata store implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,14 +3,18 @@ name = "bldr"
 version = "0.4.0"
 dependencies = [
  "ansi_term 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bincode 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "gpgme 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "iron 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "libarchive 0.1.0",
  "libc 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lmdb-sys 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "mustache 0.6.1 (git+https://github.com/adamhjk/rust-mustache?branch=fallback_on_missing_extension)",
  "rand 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -51,6 +55,17 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "bincode"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "bitflags"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -58,6 +73,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "bitflags"
 version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "byteorder"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -275,6 +295,16 @@ version = "2.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "pnacl-build-helper 1.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "lmdb-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "gcc 0.3.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,16 @@ doc = false
 name = "functional"
 
 [dependencies]
+bincode = "*"
+bitflags = "*"
 rustc-serialize = "*"
 log = "*"
 env_logger = "*"
 ansi_term = "*"
 gpgme = "*"
 hyper = "*"
+lazy_static = "*"
+lmdb-sys = "*"
 tempdir = "*"
 toml = "*"
 regex = "*"

--- a/src/bldr/command/configure.rs
+++ b/src/bldr/command/configure.rs
@@ -1,4 +1,4 @@
-// Copyright:: Copyright (c) 2015 Chef Software, Inc.
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
 // The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
 // this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
@@ -29,11 +29,7 @@ use package::Package;
 /// * If the default.toml does not exist, or cannot be read
 /// * If we can't read the file into a string
 pub fn display(config: &Config) -> BldrResult<()> {
-    let package = try!(Package::load(config.deriv(),
-                                     config.package(),
-                                     config.version().clone(),
-                                     config.release().clone(),
-                                     None));
+    let package = try!(Package::load(config.package(), None));
     let mut file = try!(File::open(package.join_path("default.toml")));
     let mut s = String::new();
     try!(file.read_to_string(&mut s));

--- a/src/bldr/command/repo.rs
+++ b/src/bldr/command/repo.rs
@@ -25,17 +25,78 @@
 //! Does the same, but the data is stored in `/tmp/whatever`.
 
 use config::Config;
-use error::BldrResult;
-use repo;
+use error::{BldrError, BldrResult, ErrorKind};
+use repo::{self, data_object};
+use repo::data_store::{self, Cursor, Database, Transaction};
 
 static LOGKEY: &'static str = "CR";
 
-/// Starts the repository.
+/// Create a repository with the given name in the database.
 ///
 /// # Failures
 ///
-/// * Fails if the repository fails to start - canot bind to the port, etc.
+/// * The database cannot be read
+/// * A write transaction cannot be acquired.
+pub fn create_repository(name: &str, config: &Config) -> BldrResult<()> {
+    let repo = try!(repo::Repo::new(String::from(config.path())));
+    let txn = try!(repo.datastore.views.txn_rw());
+    let object = data_object::View::new(name);
+    try!(repo.datastore.views.write(&txn, &object));
+    Ok(())
+}
+
+/// List all repositories in the database.
+///
+/// # Failures
+///
+/// * The database cannot be read
+/// * A read transaction cannot be acquired.
+pub fn list_repositories(config: &Config) -> BldrResult<()> {
+    let repo = try!(repo::Repo::new(String::from(config.path())));
+    let mut views: Vec<data_object::View> = vec![];
+    let txn = try!(repo.datastore.views.txn_ro());
+    let mut cursor = try!(txn.cursor_ro());
+    match cursor.first() {
+        Err(BldrError {err: ErrorKind::MdbError(data_store::MdbError::NotFound), ..}) => {
+            outputln!("No repositories. Create one with `bldr repo-create`.");
+            return Ok(());
+        }
+        Err(e) => return Err(e),
+        Ok(value) => views.push(value),
+    }
+    loop {
+        match cursor.next() {
+            Ok((_, value)) => views.push(value),
+            Err(_) => break,
+        }
+    }
+    outputln!("Listing {} repositories", views.len());
+    for view in views.iter() {
+        outputln!("     {}", view);
+    }
+    Ok(())
+}
+
+/// Starts the depot server.
+///
+/// # Failures
+///
+/// * Fails if the depot server fails to start - canot bind to the port, etc.
 pub fn start(config: &Config) -> BldrResult<()> {
     outputln!("Repo listening on {:?}", config.repo_addr());
     repo::run(&config)
+}
+
+/// Analyzes the integrity of the depot's metadata by comparing the metadata with the packages
+/// on disk. If a package is found on disk that is not present in the metadata it is added to the
+/// metadata and if an entry in the metadata doesn't have a matching package archive on disk the
+/// entry is dropped from the database.
+///
+/// # Failures
+///
+/// * The database cannot be read
+/// * A write transaction cannot be acquired
+pub fn repair(config: &Config) -> BldrResult<()> {
+    outputln!("Repairing repo at {:?}", config.path());
+    repo::repair(&config)
 }

--- a/src/bldr/lib.rs
+++ b/src/bldr/lib.rs
@@ -32,6 +32,9 @@
 //! * [The bldr Repo; http based package repository](repo)
 //!
 
+extern crate bincode;
+#[macro_use]
+extern crate bitflags;
 #[macro_use]
 extern crate hyper;
 #[macro_use]
@@ -42,12 +45,15 @@ extern crate rustc_serialize;
 extern crate toml;
 extern crate ansi_term;
 extern crate gpgme;
+#[macro_use]
+extern crate lazy_static;
 extern crate libarchive;
 extern crate regex;
 extern crate libc;
 extern crate url;
 extern crate fnv;
 extern crate iron;
+extern crate lmdb_sys;
 #[macro_use]
 extern crate router;
 extern crate time;

--- a/src/bldr/package/archive.rs
+++ b/src/bldr/package/archive.rs
@@ -7,7 +7,7 @@
 use std::fmt;
 use std::io::{Seek, SeekFrom};
 use std::path::PathBuf;
-use std::str;
+use std::str::{self, FromStr};
 
 use libarchive::writer;
 use libarchive::reader::{self, Reader};
@@ -15,7 +15,7 @@ use libarchive::archive::{Entry, ReadFilter, ReadFormat};
 use regex::Regex;
 
 use error::{BldrResult, BldrError, ErrorKind};
-use package::Package;
+use package::PackageIdent;
 use util::gpg;
 
 static LOGKEY: &'static str = "PA";
@@ -23,7 +23,9 @@ static LOGKEY: &'static str = "PA";
 #[derive(Debug)]
 pub enum MetaFile {
     CFlags,
+    Config,
     Deps,
+    TDeps,
     Exposes,
     Ident,
     LdRunPath,
@@ -36,7 +38,9 @@ impl fmt::Display for MetaFile {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let id = match *self {
             MetaFile::CFlags => "CFLAGS",
+            MetaFile::Config => "default.toml",
             MetaFile::Deps => "DEPS",
+            MetaFile::TDeps => "TDEPS",
             MetaFile::Exposes => "EXPOSES",
             MetaFile::Ident => "IDENT",
             MetaFile::LdRunPath => "LD_RUN_PATH",
@@ -58,49 +62,88 @@ impl PackageArchive {
         PackageArchive { path: path }
     }
 
-    /// A package struct representing the contents of this archive.
-    ///
-    /// # Failures
-    ///
-    /// * If an `IDENT` metafile is not found in the archive
-    /// * If the archive cannot be read
-    /// * If the archive cannot be verified
-    pub fn package(&self) -> BldrResult<Package> {
-        let body = try!(self.read_metadata(MetaFile::Ident));
-        let mut package = try!(Package::from_ident(&body));
-        match self.deps() {
-            Ok(Some(deps)) => {
-                for dep in deps {
-                    package.add_dep(dep);
-                }
-            }
-            Ok(None) => {}
-            Err(e) => return Err(e),
+    pub fn cflags(&self) -> BldrResult<Option<String>> {
+        match self.read_metadata(MetaFile::CFlags) {
+            Ok(data) => Ok(Some(data)),
+            Err(BldrError{err: ErrorKind::MetaFileNotFound(_), ..}) => Ok(None),
+            Err(e) => Err(e),
         }
-        Ok(package)
     }
 
-    /// List of package structs representing the package dependencies for this archive.
+    pub fn config(&self) -> BldrResult<Option<String>> {
+        match self.read_metadata(MetaFile::Config) {
+            Ok(data) => Ok(Some(data)),
+            Err(BldrError{err: ErrorKind::MetaFileNotFound(_), ..}) => Ok(None),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Returns a list of package identifiers representing the runtime package dependencies for
+    /// this archive.
     ///
     /// # Failures
     ///
     /// * If a `DEPS` metafile is not found in the archive
     /// * If the archive cannot be read
     /// * If the archive cannot be verified
-    pub fn deps(&self) -> BldrResult<Option<Vec<Package>>> {
-        match self.read_metadata(MetaFile::Deps) {
-            Ok(body) => {
-                let dep_strs: Vec<&str> = body.split("\n").collect();
-                let mut deps = vec![];
-                for dep in &dep_strs {
-                    match Package::from_ident(&dep) {
-                        Ok(package) => deps.push(package),
-                        Err(_) => continue,
-                    }
-                }
-                Ok(Some(deps))
+    pub fn deps(&self) -> BldrResult<Vec<PackageIdent>> {
+        self.read_deps(MetaFile::Deps)
+    }
+
+    /// Returns a list of package identifiers representing the transitive runtime package
+    /// dependencies for this archive.
+    ///
+    /// # Failures
+    ///
+    /// * If a `TDEPS` metafile is not found in the archive
+    /// * If the archive cannot be read
+    /// * If the archive cannot be verified
+    pub fn tdeps(&self) -> BldrResult<Vec<PackageIdent>> {
+        self.read_deps(MetaFile::TDeps)
+    }
+
+    pub fn exposes(&self) -> BldrResult<Vec<u16>> {
+        match self.read_metadata(MetaFile::Exposes) {
+            Ok(data) => {
+                let ports: Vec<u16> = data.split(" ")
+                                          .filter_map(|port| port.parse::<u16>().ok())
+                                          .collect();
+                Ok(ports)
             }
+            Err(BldrError{err: ErrorKind::MetaFileNotFound(_), ..}) => Ok(vec![]),
+            Err(e) => Err(e),
+        }
+    }
+
+    pub fn ident(&self) -> BldrResult<PackageIdent> {
+        let data = try!(self.read_metadata(MetaFile::Ident));
+        PackageIdent::from_str(&data)
+    }
+
+    pub fn ld_run_path(&self) -> BldrResult<Option<String>> {
+        match self.read_metadata(MetaFile::LdRunPath) {
+            Ok(data) => Ok(Some(data)),
             Err(BldrError{err: ErrorKind::MetaFileNotFound(_), ..}) => Ok(None),
+            Err(e) => Err(e),
+        }
+    }
+
+    pub fn ldflags(&self) -> BldrResult<Option<String>> {
+        match self.read_metadata(MetaFile::LdFlags) {
+            Ok(data) => Ok(Some(data)),
+            Err(BldrError {err: ErrorKind::MetaFileNotFound(_), ..}) => Ok(None),
+            Err(e) => Err(e),
+        }
+    }
+
+    pub fn manifest(&self) -> BldrResult<String> {
+        self.read_metadata(MetaFile::Manifest)
+    }
+
+    pub fn path(&self) -> BldrResult<Option<String>> {
+        match self.read_metadata(MetaFile::Path) {
+            Ok(data) => Ok(Some(data)),
+            Err(BldrError {err: ErrorKind::MetaFileNotFound(_), ..}) => Ok(None),
             Err(e) => Err(e),
         }
     }
@@ -129,7 +172,7 @@ impl PackageArchive {
     /// # Failures
     ///
     /// * If the package cannot be unpacked via gpg
-    pub fn unpack(&self) -> BldrResult<Package> {
+    pub fn unpack(&self) -> BldrResult<()> {
         let file = self.path.to_str().unwrap().to_string();
         let mut out = try!(gpg::verify(&file));
         try!(out.seek(SeekFrom::Start(0)));
@@ -141,7 +184,29 @@ impl PackageArchive {
         try!(writer.set_standard_lookup());
         try!(writer.write(&mut reader, Some("/")));
         try!(writer.close());
-        self.package()
+        Ok(())
+    }
+
+    fn read_deps(&self, file: MetaFile) -> BldrResult<Vec<PackageIdent>> {
+        let mut deps: Vec<PackageIdent> = vec![];
+        match self.read_metadata(file) {
+            Ok(body) => {
+                let ids: Vec<String> = body.split("\n").map(|d| d.to_string()).collect();
+                for id in &ids {
+                    let package = try!(PackageIdent::from_str(id));
+                    if !package.fully_qualified() {
+                        // JW TODO: use a more appropriate erorr to describe the invalid
+                        // user input here. (user because a package was generated by a user
+                        // and read into program)
+                        return Err(bldr_error!(ErrorKind::InvalidPackageIdent(package.to_string())));
+                    }
+                    deps.push(package);
+                }
+                Ok(deps)
+            }
+            Err(BldrError{err: ErrorKind::MetaFileNotFound(_), ..}) => Ok(deps),
+            Err(e) => Err(e),
+        }
     }
 
     fn read_metadata(&self, file: MetaFile) -> BldrResult<String> {
@@ -167,7 +232,7 @@ impl PackageArchive {
         match reader.read_block() {
             Ok(Some(bytes)) => {
                 match str::from_utf8(bytes) {
-                    Ok(content) => Ok(content.to_string()),
+                    Ok(content) => Ok(content.trim().to_string()),
                     Err(_) => Err(bldr_error!(ErrorKind::MetaFileMalformed)),
                 }
             }

--- a/src/bldr/repo/data_object.rs
+++ b/src/bldr/repo/data_object.rs
@@ -1,0 +1,197 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
+//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
+
+use std::collections::HashSet;
+use std::fmt;
+use std::str::FromStr;
+
+use rustc_serialize::{Encoder, Decoder, Encodable, Decodable};
+
+use error::{BldrResult, ErrorKind};
+use package;
+use super::data_store::ToMdbValue;
+
+static LOGKEY: &'static str = "DO";
+
+pub trait DataObject : Encodable + Decodable {
+    type Key: ToMdbValue + fmt::Display;
+    fn ident(&self) -> &Self::Key;
+}
+
+#[repr(C)]
+#[derive(PartialEq, Debug, Clone)]
+pub struct PackageIdent(String);
+
+impl PackageIdent {
+    pub fn new(ident: String) -> Self {
+        PackageIdent(ident)
+    }
+
+    pub fn deriv_idx(&self) -> String {
+        format!("{}", self.parts()[0])
+    }
+
+    pub fn name_idx(&self) -> String {
+        let vec: Vec<&str> = self.parts();
+        format!("{}/{}", vec[0], vec[1])
+    }
+
+    pub fn version_idx(&self) -> String {
+        let vec: Vec<&str> = self.parts();
+        format!("{}/{}/{}", vec[0], vec[1], vec[2])
+    }
+
+    pub fn parts(&self) -> Vec<&str> {
+        self.0.split("/").collect()
+    }
+}
+
+impl fmt::Display for PackageIdent {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl Encodable for PackageIdent {
+    fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {
+        let p = self.parts();
+        try!(s.emit_struct("PackageIdent", p.len(), |s| {
+            try!(s.emit_struct_field("derivation", 0, |s| p[0].encode(s)));
+            try!(s.emit_struct_field("name", 1, |s| p[1].encode(s)));
+            if p.len() > 2 {
+                try!(s.emit_struct_field("version", 2, |s| p[2].encode(s)));
+            }
+            if p.len() > 3 {
+                try!(s.emit_struct_field("release", 3, |s| p[3].encode(s)));
+            }
+            Ok(())
+        }));
+        Ok(())
+    }
+}
+
+impl Decodable for PackageIdent {
+    fn decode<D: Decoder>(d: &mut D) -> Result<Self, D::Error> {
+        d.read_struct("PackageIdent", 4, |d| {
+            let derivation: String = try!(d.read_struct_field("derivation", 0, |d| Decodable::decode(d)));
+            let name: String = try!(d.read_struct_field("name", 1, |d| Decodable::decode(d)));
+            let version: String = try!(d.read_struct_field("version", 2, |d| Decodable::decode(d)));
+            let release: String = try!(d.read_struct_field("release", 3, |d| Decodable::decode(d)));
+            Ok(PackageIdent::new(format!("{}/{}/{}/{}", derivation, name, version, release)))
+        })
+    }
+}
+
+impl DataObject for PackageIdent {
+    type Key = String;
+
+    fn ident<'a>(&'a self) -> &'a String {
+        &self.0
+    }
+}
+
+impl Into<package::PackageIdent> for PackageIdent {
+    fn into(self) -> package::PackageIdent {
+        FromStr::from_str(&self.0).unwrap()
+    }
+}
+
+#[repr(C)]
+#[derive(RustcEncodable, RustcDecodable, PartialEq, Debug)]
+pub struct View {
+    pub ident: String,
+    pub packages: HashSet<<Package as DataObject>::Key>,
+}
+
+impl View {
+    pub fn new(name: &str) -> Self {
+        View {
+            ident: String::from(name),
+            packages: HashSet::new(),
+        }
+    }
+
+    pub fn add_package(&mut self, package: <Package as DataObject>::Key) -> &mut Self {
+        self.packages.insert(package);
+        self
+    }
+}
+
+impl DataObject for View {
+    type Key = String;
+
+    fn ident<'a>(&'a self) -> &'a String {
+        &self.ident
+    }
+}
+
+impl fmt::Display for View {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.ident)
+    }
+}
+
+#[repr(C)]
+#[derive(RustcEncodable, RustcDecodable, PartialEq, Debug)]
+pub struct Package {
+    pub ident: PackageIdent,
+    pub manifest: String,
+    pub deps: Vec<PackageIdent>,
+    pub tdeps: Vec<PackageIdent>,
+    pub exposes: Vec<u16>,
+    pub config: Option<String>,
+    pub views: HashSet<<View as DataObject>::Key>,
+}
+
+impl Package {
+    pub fn from_archive(archive: &package::PackageArchive) -> BldrResult<Self> {
+        let ident = match archive.ident() {
+            Ok(value) => {
+                if !value.fully_qualified() {
+                    return Err(bldr_error!(ErrorKind::InvalidPackageIdent(value.to_string())));
+                }
+                PackageIdent::new(value.to_string())
+            }
+            Err(e) => return Err(e),
+        };
+        Ok(Package {
+            ident: ident,
+            manifest: try!(archive.manifest()),
+            deps: try!(archive.deps()).iter().map(|d| PackageIdent::new(d.to_string())).collect(),
+            tdeps: try!(archive.tdeps()).iter().map(|d| PackageIdent::new(d.to_string())).collect(),
+            exposes: try!(archive.exposes()),
+            config: try!(archive.config()),
+            views: HashSet::new(),
+        })
+    }
+
+    pub fn add_view(&mut self, view: <View as DataObject>::Key) -> &mut Self {
+        self.views.insert(view);
+        self
+    }
+}
+
+impl Into<package::Package> for Package {
+    fn into(self) -> package::Package {
+        let ident = self.ident.parts();
+        package::Package {
+            derivation: ident[0].to_string(),
+            name: ident[1].to_string(),
+            version: ident[2].to_string(),
+            release: ident[3].to_string(),
+            deps: self.deps.into_iter().map(|d| d.into()).collect(),
+            tdeps: self.tdeps.into_iter().map(|d| d.into()).collect(),
+        }
+    }
+}
+
+impl DataObject for Package {
+    type Key = String;
+
+    fn ident<'a>(&'a self) -> &'a String {
+        &self.ident.0
+    }
+}

--- a/src/bldr/repo/data_store.rs
+++ b/src/bldr/repo/data_store.rs
@@ -1,0 +1,1470 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
+//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
+
+use std::any::Any;
+use std::ffi::{CStr, CString};
+use std::fmt;
+use std::fs;
+use std::marker::PhantomData;
+use std::mem;
+use std::path::Path;
+use std::ptr;
+use std::slice;
+use std::sync::{Arc, Mutex};
+
+use bincode::{self, SizeLimit};
+use bincode::rustc_serialize::{encode, decode};
+use libc::{c_void, c_int, c_uint, mode_t, size_t};
+use lmdb_sys;
+use rustc_serialize::{Encodable, Decodable};
+
+use error::{BldrResult, ErrorKind};
+use super::data_object::{self, DataObject};
+use package::PackageIdent;
+
+static LOGKEY: &'static str = "DS";
+
+lazy_static! {
+    static ref OPEN_LOCK: Mutex<()> = Mutex::new(());
+}
+
+bitflags! {
+    flags EnvFlags: c_uint {
+        const ENV_NO_SYNC = lmdb_sys::MDB_NOSYNC,
+        const ENV_NO_META_SYNC = lmdb_sys::MDB_NOMETASYNC,
+        const ENV_MAP_ASYNC = lmdb_sys::MDB_MAPASYNC,
+        const ENV_NO_MEM_INIT = lmdb_sys::MDB_NOMEMINIT,
+    }
+}
+
+bitflags! {
+    flags EnvCreateFlags: c_uint {
+        const ENV_CREATE_FIXED_MAP = lmdb_sys::MDB_FIXEDMAP,
+        const ENV_CREATE_NO_SUB_DIR = lmdb_sys::MDB_NOSUBDIR,
+        const ENV_CREATE_READ_ONLY = lmdb_sys::MDB_RDONLY,
+        const ENV_CREATE_WRITE_MAP = lmdb_sys::MDB_WRITEMAP,
+        const ENV_CREATE_NO_META_SYNC = lmdb_sys::MDB_NOMETASYNC,
+        const ENV_CREATE_NO_SYNC = lmdb_sys::MDB_NOSYNC,
+        const ENV_CREATE_MAP_ASYNC = lmdb_sys::MDB_MAPASYNC,
+        const ENV_CREATE_NO_TLS = lmdb_sys::MDB_NOTLS,
+        const ENV_CREATE_NO_LOCK = lmdb_sys::MDB_NOLOCK,
+        const ENV_CREATE_NO_READ_AHEAD = lmdb_sys::MDB_NORDAHEAD,
+        const ENV_CREATE_NO_MEM_INIT = lmdb_sys::MDB_NOMEMINIT,
+    }
+}
+
+bitflags! {
+    flags DatabaseFlags: c_uint {
+        const DB_REVERSE_KEY = lmdb_sys::MDB_REVERSEKEY,
+        const DB_ALLOW_DUPS = lmdb_sys::MDB_DUPSORT,
+        const DB_INTEGER_KEY = lmdb_sys::MDB_INTEGERKEY,
+        const DB_DUPS_FIXED = lmdb_sys::MDB_DUPFIXED,
+        const DB_ALLOW_INT_DUPS = lmdb_sys::MDB_INTEGERDUP,
+        const DB_REVERSE_DUPS = lmdb_sys::MDB_REVERSEDUP,
+        const DB_CREATE = lmdb_sys::MDB_CREATE,
+    }
+}
+
+bitflags! {
+    flags WriteFlags: c_uint {
+        const CURRENT = lmdb_sys::MDB_CURRENT,
+        const NO_DUP_DATA = lmdb_sys::MDB_NODUPDATA,
+        const NO_OVERWRITE = lmdb_sys::MDB_NOOVERWRITE,
+        const RESERVE = lmdb_sys::MDB_RESERVE,
+        const APPEND = lmdb_sys::MDB_APPEND,
+        const APPEND_DUP = lmdb_sys::MDB_APPENDDUP,
+        const MULTIPLE = lmdb_sys::MDB_MULTIPLE,
+    }
+}
+
+/// Name of the package database
+pub const PACKAGE_DB: &'static str = "packages";
+/// Name of the package index database
+pub const PACKAGE_INDEX: &'static str = "package-index";
+/// Name of the views database
+pub const VIEW_DB: &'static str = "views";
+/// Value for how many databases can be opened within a DataStore's environment. Increase this
+/// count for each new database added and decrease this count if databases are removed from the
+/// DataStore.
+pub const MAX_DBS: u32 = 3;
+
+macro_rules! try_mdb {
+    ($e: expr) => (match $e {
+        lmdb_sys::MDB_SUCCESS => (),
+        _ => return Err(bldr_error!(ErrorKind::MdbError(MdbError::from($e))))
+    })
+}
+
+macro_rules! handle_mdb {
+    ($e: expr) => (match $e {
+        lmdb_sys::MDB_SUCCESS => Ok(()),
+        _ => Err(bldr_error!(ErrorKind::MdbError(MdbError::from($e))))
+    })
+}
+
+macro_rules! assert_txn_state_eq {
+    ($cur:expr, $exp:expr) => (
+        {
+            let c = $cur.clone();
+            let e = $exp;
+            if c == e {
+                ()
+            } else {
+                return Err(bldr_error!(ErrorKind::MdbError(MdbError::StateError(c, e))))
+            }
+        }
+    )
+}
+
+#[derive(Debug)]
+pub enum MdbError {
+    /// The specified DBI was changed unexpectedly
+    BadDbi,
+    /// Invalid reuse of reader locktable slot
+    BadRslot,
+    /// Transaction must abort, has a child, or is invalid
+    BadTxn,
+    /// Unsupported size of key/database name/data or wrong DUPFIXED size
+    BadValSize,
+    /// Unable to decode data from database
+    DecodingError(bincode::rustc_serialize::DecodingError),
+    /// Unable to encode data into database
+    EncodingError(bincode::rustc_serialize::EncodingError),
+    /// Key/Data pair not found
+    NotFound,
+    /// Key/Data pair already exists
+    KeyExists,
+    /// Cursor stack too deep (internal error)
+    CursorFull,
+    /// Environment maxdbs reached
+    DbsFull,
+    /// Operation and database incompatible or database type has changed. This can mean:
+    ///
+    /// * Operation expects an the database to have the `DB_ALLOW_DUPS`/`DB_DUPS_FIXED` flag set
+    /// * Opening a named database when the unamed database has the `DB_ALLOW_DUPS`/`DB_INTEGER_KEY`
+    ///   flag set
+    /// * Accessing a data record as a database or vice versa
+    /// * The database was dropped and recreated with different flags
+    Incompatible,
+    /// File is not a valid LMDB file
+    Invalid,
+    /// Environment mapsize reached
+    MapFull,
+    /// Database contents grew beyond environment mapsize
+    MapResized,
+    /// Page has not enough space (internal error)
+    PageFull,
+    /// Requested page not found (usually indicates data corruption)
+    PageNotFound,
+    /// Environment maxreaders reached
+    ReadersFull,
+    /// Located page was wrong type
+    Corrupted,
+    /// Update of meta page failed or environment encountered a fatal error
+    Panic,
+    /// Too many TLS keys in use (Windows only)
+    TLSFull,
+    /// Trasnaction has too many dirty pages
+    TxnFull,
+    /// Transaction was in an unexpected state at time of execution
+    StateError(TxnState, TxnState),
+    /// Catch all for undefined error codes
+    Undefined(c_int, String),
+    /// Environment version mismatch
+    VersionMismatch,
+}
+
+impl fmt::Display for MdbError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl From<c_int> for MdbError {
+    fn from(code: c_int) -> MdbError {
+        match code {
+            lmdb_sys::MDB_BAD_DBI => MdbError::BadDbi,
+            lmdb_sys::MDB_BAD_RSLOT => MdbError::BadRslot,
+            lmdb_sys::MDB_BAD_TXN => MdbError::BadTxn,
+            lmdb_sys::MDB_BAD_VALSIZE => MdbError::BadValSize,
+            lmdb_sys::MDB_NOTFOUND => MdbError::NotFound,
+            lmdb_sys::MDB_KEYEXIST => MdbError::KeyExists,
+            lmdb_sys::MDB_CURSOR_FULL => MdbError::CursorFull,
+            lmdb_sys::MDB_DBS_FULL => MdbError::DbsFull,
+            lmdb_sys::MDB_INCOMPATIBLE => MdbError::Incompatible,
+            lmdb_sys::MDB_INVALID => MdbError::Invalid,
+            lmdb_sys::MDB_MAP_FULL => MdbError::MapFull,
+            lmdb_sys::MDB_MAP_RESIZED => MdbError::MapResized,
+            lmdb_sys::MDB_PAGE_FULL => MdbError::PageFull,
+            lmdb_sys::MDB_PAGE_NOTFOUND => MdbError::PageNotFound,
+            lmdb_sys::MDB_READERS_FULL => MdbError::ReadersFull,
+            lmdb_sys::MDB_CORRUPTED => MdbError::Corrupted,
+            lmdb_sys::MDB_PANIC => MdbError::Panic,
+            lmdb_sys::MDB_TLS_FULL => MdbError::TLSFull,
+            lmdb_sys::MDB_TXN_FULL => MdbError::TxnFull,
+            lmdb_sys::MDB_VERSION_MISMATCH => MdbError::VersionMismatch,
+            _ => {
+                let msg = unsafe {
+                    String::from_utf8(CStr::from_ptr(lmdb_sys::mdb_strerror(code))
+                                          .to_bytes()
+                                          .to_vec())
+                        .unwrap()
+                };
+                MdbError::Undefined(code, msg)
+            }
+        }
+    }
+}
+
+impl From<bincode::rustc_serialize::DecodingError> for MdbError {
+    fn from(value: bincode::rustc_serialize::DecodingError) -> MdbError {
+        MdbError::DecodingError(value)
+    }
+}
+
+impl From<bincode::rustc_serialize::EncodingError> for MdbError {
+    fn from(value: bincode::rustc_serialize::EncodingError) -> MdbError {
+        MdbError::EncodingError(value)
+    }
+}
+
+fn create_txn(env: &Environment,
+              flags: c_uint,
+              parent: Option<&mut lmdb_sys::MDB_txn>)
+              -> BldrResult<*mut lmdb_sys::MDB_txn> {
+    let mut handle: *mut lmdb_sys::MDB_txn = ptr::null_mut();
+    let parent = if parent.is_some() {
+        parent.unwrap() as *mut lmdb_sys::MDB_txn
+    } else {
+        ptr::null_mut() as *mut lmdb_sys::MDB_txn
+    };
+    unsafe {
+        try_mdb!(lmdb_sys::mdb_txn_begin(env.handle, parent, flags, &mut handle));
+    }
+    Ok(handle)
+}
+
+fn cursor_get<'a, K, D>(cursor: *mut lmdb_sys::MDB_cursor,
+                        key: Option<&K>,
+                        value: Option<&D>,
+                        op: CursorOp)
+                        -> BldrResult<(Option<&'a K>, D)>
+    where K: ToMdbValue,
+          D: Encodable + Decodable
+{
+    unsafe {
+        let mut kval = if key.is_some() {
+            key.unwrap().to_mdb_value()
+        } else {
+            val_for::<K>(None)
+        };
+        let mut dval = encoded_val_for::<D>(value);
+        let key_ptr = kval.mv_data;
+        try_mdb!(lmdb_sys::mdb_cursor_get(cursor, &mut kval, &mut dval, op as u32));
+        let kout = if key_ptr != kval.mv_data {
+            let kout: &K = &*(kval.mv_data as *const K);
+            Some(kout)
+        } else {
+            None
+        };
+        let bytes: &[u8] = slice::from_raw_parts(dval.mv_data as *const u8, dval.mv_size);
+        match decode(bytes) {
+            Ok(dout) => Ok((kout, dout)),
+            Err(e) => Err(bldr_error!(ErrorKind::MdbError(MdbError::from(e)))),
+        }
+    }
+}
+
+unsafe fn val_for<T>(data: Option<&T>) -> lmdb_sys::MDB_val {
+    match data {
+        Some(d) => {
+            lmdb_sys::MDB_val {
+                mv_data: d as *const T as *mut c_void,
+                mv_size: mem::size_of::<T>() as size_t,
+            }
+        }
+        None => {
+            lmdb_sys::MDB_val {
+                mv_data: ptr::null_mut(),
+                mv_size: 0,
+            }
+        }
+    }
+}
+
+unsafe fn encoded_val_for<T: Encodable>(data: Option<&T>) -> lmdb_sys::MDB_val {
+    match data {
+        Some(d) => {
+            // JW TODO: this should be set to the max size the database allows. Infinite is fine
+            // for now.
+            let mut encoded: Vec<u8> = encode(d, SizeLimit::Infinite).unwrap();
+            let bytes: &mut [u8] = &mut encoded[..];
+            lmdb_sys::MDB_val {
+                mv_data: bytes.as_ptr() as *mut c_void,
+                mv_size: bytes.len() as size_t,
+            }
+        }
+        None => {
+            lmdb_sys::MDB_val {
+                mv_data: ptr::null_mut() as *mut c_void,
+                mv_size: 0,
+            }
+        }
+    }
+}
+
+pub unsafe trait ToMdbValue {
+    fn to_mdb_value(&self) -> lmdb_sys::MDB_val;
+}
+
+unsafe impl ToMdbValue for String {
+    fn to_mdb_value(&self) -> lmdb_sys::MDB_val {
+        let t: &str = self;
+        lmdb_sys::MDB_val {
+            mv_data: t.as_ptr() as *mut c_void,
+            mv_size: t.len(),
+        }
+    }
+}
+
+pub struct DataStore {
+    pub packages: PkgDatabase,
+    pub views: ViewDatabase,
+    #[allow(dead_code)]
+    env: Arc<Environment>,
+}
+
+impl DataStore {
+    /// Instantiates a new LMDB backed datastore.
+    ///
+    /// # Failures
+    ///
+    /// * Cannot read/write to the given path
+    /// * Cannot obtain a lock to create the environment
+    /// * Could not create the environment or any of it's databases
+    pub fn open(path: &Path) -> BldrResult<Self> {
+        let mut flags = EnvCreateFlags::empty();
+        flags.toggle(ENV_CREATE_NO_SUB_DIR);
+        match path.parent() {
+            Some(root) => try!(fs::create_dir_all(root)),
+            None => return Err(bldr_error!(ErrorKind::DbInvalidPath)),
+        }
+        let env = try!(Environment::new().max_databases(MAX_DBS).flags(flags).open(&path, 0o744));
+        let env1 = Arc::new(env);
+        let env2 = env1.clone();
+        let env3 = env1.clone();
+        let pkg_database = try!(PkgDatabase::new().create(env2));
+        let view_database = try!(ViewDatabase::new().create(env3));
+        Ok(DataStore {
+            env: env1,
+            packages: pkg_database,
+            views: view_database,
+        })
+    }
+
+    /// Truncates every database in the datastore.
+    ///
+    /// # Failures
+    ///
+    /// * If a read-write transaction could not be acquired for any of the databases in the
+    ///   datastore
+    pub fn clear(&self) -> BldrResult<()> {
+        let txn = try!(self.packages.txn_rw());
+        try!(self.packages.clear(&txn));
+        try!(txn.commit());
+        let txn = try!(self.views.txn_rw());
+        try!(self.views.clear(&txn));
+        txn.commit()
+    }
+}
+
+pub struct EnvironmentBuilder {
+    flags: EnvCreateFlags,
+    map_size: Option<u64>,
+    max_databases: Option<u32>,
+    max_readers: Option<u32>,
+}
+
+impl EnvironmentBuilder {
+    /// Set environment flags.
+    pub fn flags(mut self, flags: EnvCreateFlags) -> Self {
+        // JW TODO: don't let people set flags themselves, the lmdb API is hostile and requires
+        // that you have knowledge of what flags are and are not allowed to be mixed. Instead expose
+        // setters that return a result when setting flags that may or may not be compatible with
+        // the current state of the environment being built
+        self.flags = flags;
+        self
+    }
+
+    /// Set the maximum number of named databases for the environment.
+    ///
+    /// This function is only needed if multiple databases will be used in the environment. Simpler
+    /// applications that use the environment as a single unnamed database can ignore this option.
+    pub fn max_databases(mut self, count: u32) -> Self {
+        self.max_databases = Some(count);
+        self
+    }
+
+    /// Set the maximum number of threads/reader slots for the environment.
+    ///
+    /// This defines the number of slots in the lock table that is used to track readers in the
+    /// environment. The default is 126. Starting a read-only transaction normally ties a lock table
+    /// slot to the current thread untilt he environment closes or the thread exists. If the
+    /// `ENV_CREATE_NO_TLS` flag is set, starting a new transaction instead ties the slot to the
+    /// transaction until it, or the environment, is destroyed.
+    pub fn max_readers(mut self, count: u32) -> Self {
+        self.max_readers = Some(count);
+        self
+    }
+
+    /// Set the size of the memory map to use for this environment.
+    ///
+    /// The size should be a multiple of the OS page size. The default is 10485760 bytes. The size
+    /// of the memory map is also the maximum size of the database. The value should be chosen
+    /// as large as possible to accomodate future growth of the database.
+    pub fn map_size(mut self, size: u64) -> Self {
+        self.map_size = Some(size);
+        self
+    }
+
+    /// Create/open the database
+    pub fn open(self, path: &Path, permissions: u32) -> BldrResult<Environment> {
+        let handle: *mut lmdb_sys::MDB_env = ptr::null_mut();
+        unsafe {
+            try_mdb!(lmdb_sys::mdb_env_create(mem::transmute(&handle)));
+        }
+
+        if let Some(map_size) = self.map_size {
+            unsafe {
+                try_mdb!(lmdb_sys::mdb_env_set_mapsize(handle, map_size as usize));
+            }
+        }
+
+        if let Some(count) = self.max_databases {
+            unsafe { try_mdb!(lmdb_sys::mdb_env_set_maxdbs(handle, count)) }
+        }
+
+        if let Some(count) = self.max_readers {
+            unsafe { try_mdb!(lmdb_sys::mdb_env_set_maxreaders(handle, count)) }
+        }
+
+        // JW TODO: if read only flag is set, lets return a read only environment.
+
+        unsafe {
+            let path_str = try!(path.to_str().ok_or(bldr_error!(ErrorKind::DbInvalidPath)));
+            let path_ptr = try!(CString::new(path_str)
+                                    .map_err(|_| bldr_error!(ErrorKind::DbInvalidPath)))
+                               .as_ptr();
+
+            match lmdb_sys::mdb_env_open(handle,
+                                         path_ptr,
+                                         self.flags.bits(),
+                                         permissions as mode_t) {
+                lmdb_sys::MDB_SUCCESS => Ok(Environment { handle: handle }),
+                code => {
+                    lmdb_sys::mdb_env_close(handle);
+                    Err(bldr_error!(ErrorKind::MdbError(MdbError::from(code))))
+                }
+            }
+        }
+    }
+}
+
+impl Default for EnvironmentBuilder {
+    fn default() -> EnvironmentBuilder {
+        EnvironmentBuilder {
+            flags: EnvCreateFlags::empty(),
+            max_databases: None,
+            max_readers: None,
+            map_size: None,
+        }
+    }
+}
+
+pub struct Environment {
+    handle: *mut lmdb_sys::MDB_env,
+}
+
+impl Environment {
+    pub fn new() -> EnvironmentBuilder {
+        EnvironmentBuilder::default()
+    }
+}
+
+impl Drop for Environment {
+    fn drop(&mut self) {
+        if self.handle != ptr::null_mut() {
+            unsafe { lmdb_sys::mdb_env_close(self.handle) }
+        }
+    }
+}
+
+unsafe impl Send for Environment {}
+unsafe impl Sync for Environment {}
+
+pub enum Txn {
+    Read,
+    ReadWrite,
+}
+
+#[derive(PartialEq, Debug, Eq, Copy, Clone)]
+pub enum TxnState {
+    Normal,
+    Released,
+    Invalid,
+}
+
+impl Default for TxnState {
+    fn default() -> TxnState {
+        TxnState::Normal
+    }
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+#[allow(dead_code)]
+/// Cursor Get operations
+///
+/// This is the set of all operations for retrieving data using a cursor.
+enum CursorOp {
+    /// Position at the first key/data item
+    First = lmdb_sys::MDB_FIRST as isize,
+    /// Position at the first data item of current key. Valid only if the database has the
+    /// `DB_ALLOW_DUPS` flag set
+    FirstDup = lmdb_sys::MDB_FIRST_DUP as isize,
+    /// Position at key/data pair. Valid only if the database has the `DB_ALLOW_DUPS` flag set
+    GetBoth = lmdb_sys::MDB_GET_BOTH as isize,
+    /// Position at key, nearest data. Valid only if the database has the `DB_ALLOW_DUPS` flag set
+    GetBothRange = lmdb_sys::MDB_GET_BOTH_RANGE as isize,
+    /// Return the key and data at the cursor's current position
+    GetCurrent = lmdb_sys::MDB_GET_CURRENT as isize,
+    /// Return the key and up to a page of duplicate data items from the cursor's current position.
+    /// Move the cursor to prepare for `NextMultiple` cursor operation. Valid only if the database
+    /// has the `DB_DUPS_FIXED` flag set
+    GetMultiple = lmdb_sys::MDB_GET_MULTIPLE as isize,
+    /// Position the cursor at the last key and data item
+    Last = lmdb_sys::MDB_LAST as isize,
+    /// Position the cursor at the last data item of the current key. Valid only if the database has
+    /// the `DB_ALLOW_DUPS` flag set
+    LastDup = lmdb_sys::MDB_LAST_DUP as isize,
+    /// Position at the next data item
+    Next = lmdb_sys::MDB_NEXT as isize,
+    /// Position at the next data item of the current key. Valid only if the database has the
+    /// `DB_ALLOW_DUPS` flag set
+    NextDup = lmdb_sys::MDB_NEXT_DUP as isize,
+    /// Return key and up to a page of duplicate data items from next cursor position. Move cursor
+    /// to prepare for `NextMultiple` cursor operation. Valid only if the database has the
+    /// `DB_DUPS_FIXED` flag set
+    NextMultiple = lmdb_sys::MDB_NEXT_MULTIPLE as isize,
+    /// Position at first data item of next key
+    NextNoDup = lmdb_sys::MDB_NEXT_NODUP as isize,
+    /// Position at previous data item
+    Prev = lmdb_sys::MDB_PREV as isize,
+    /// Position at previous data item of current key. Valid only if the database has the
+    /// `DB_ALLOW_DUPS` flag set
+    PrevDup = lmdb_sys::MDB_PREV_DUP as isize,
+    /// Position at the last data item of previous key
+    PrevNoDup = lmdb_sys::MDB_PREV_NODUP as isize,
+    /// Position at the specified key
+    Set = lmdb_sys::MDB_SET as isize,
+    /// Position at the specified key and return the key and it's data
+    SetKey = lmdb_sys::MDB_SET_KEY as isize,
+    /// Position at first key greater than or equal to the specified key
+    SetRange = lmdb_sys::MDB_SET_RANGE as isize,
+}
+
+/// Common behaviour for cursors
+pub trait Cursor<'a, 'd, D: 'a + 'd + Database, T: Transaction<'a, D>> {
+    /// Returns a raw pointer to the cursor's handle.
+    fn handle(&self) -> *mut lmdb_sys::MDB_cursor;
+
+    /// Returns a raw pointer to the cursor's transaction handle.
+    fn txn(&self) -> &'a mut lmdb_sys::MDB_txn;
+
+    /// Returns a reference to the current state of the cursor's transaction.
+    fn state(&self) -> &TxnState;
+
+    /// Returns the cursor's database handle.
+    fn database(&self) -> lmdb_sys::MDB_dbi;
+
+    /// Return count of duplicates for current key.
+    ///
+    /// This call is only valid on databases that support sorted duplicate items by the
+    /// `DB_ALLOW_DUPS` flag.
+    fn dup_count(&self) -> BldrResult<u64> {
+        assert_txn_state_eq!(self.state(), TxnState::Normal);
+        let mut count: size_t = 0;
+        unsafe {
+            try_mdb!(lmdb_sys::mdb_cursor_count(self.handle(), &mut count));
+        }
+        Ok(count as u64)
+    }
+
+    /// Position cursor at the first key/data item and return the data for the item.
+    fn first(&mut self) -> BldrResult<D::Object> {
+        assert_txn_state_eq!(self.state(), TxnState::Normal);
+        match cursor_get::<<D::Object as DataObject>::Key, D::Object>(self.handle(),
+                                                                      None,
+                                                                      None,
+                                                                      CursorOp::First) {
+            Ok((_, value)) => Ok(value),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Position the cursor at the first data item of the current key.
+    ///
+    /// This call is only valid on databases that support sorted duplicate items by the
+    /// `DB_ALLOW_DUPS` flag.
+    fn first_dup(&mut self) -> BldrResult<D::Object> {
+        assert_txn_state_eq!(self.state(), TxnState::Normal);
+        match cursor_get::<<D::Object as DataObject>::Key, D::Object>(self.handle(),
+                                                                      None,
+                                                                      None,
+                                                                      CursorOp::FirstDup) {
+            Ok((_, value)) => Ok(value),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Position the cursor at the last key/data item and return the data for that item.
+    fn last(&mut self) -> BldrResult<D::Object> {
+        assert_txn_state_eq!(self.state(), TxnState::Normal);
+        match cursor_get::<<D::Object as DataObject>::Key, D::Object>(self.handle(),
+                                                                      None,
+                                                                      None,
+                                                                      CursorOp::Last) {
+            Ok((_, value)) => Ok(value),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Position the cursor at the last data item of the current key.
+    ///
+    /// This call is only valid on databases that support sorted duplicate items by the
+    /// `DB_ALLOW_DUPS` flag.
+    fn last_dup(&mut self) -> BldrResult<D::Object> {
+        assert_txn_state_eq!(self.state(), TxnState::Normal);
+        match cursor_get::<<D::Object as DataObject>::Key, D::Object>(self.handle(),
+                                                                      None,
+                                                                      None,
+                                                                      CursorOp::LastDup) {
+            Ok((_, value)) => Ok(value),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Position the cursor at the next data item.
+    fn next(&mut self) -> BldrResult<(&'a <D::Object as DataObject>::Key, D::Object)> {
+        assert_txn_state_eq!(self.state(), TxnState::Normal);
+        match cursor_get::<<D::Object as DataObject>::Key, D::Object>(self.handle(),
+                                                                      None,
+                                                                      None,
+                                                                      CursorOp::Next) {
+            Ok((Some(key), value)) => Ok((key, value)),
+            Ok(_) => unreachable!(),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Position the cursor at the next data item of the current key.
+    ///
+    /// This call is only valid on databases taht support sorted duplicate items by the
+    /// `DB_ALLOW_DUPS` flag.
+    fn next_dup(&mut self) -> BldrResult<(&'a <D::Object as DataObject>::Key, D::Object)> {
+        assert_txn_state_eq!(self.state(), TxnState::Normal);
+        match cursor_get::<<D::Object as DataObject>::Key, D::Object>(self.handle(),
+                                                                      None,
+                                                                      None,
+                                                                      CursorOp::NextDup) {
+            Ok((Some(key), value)) => Ok((key, value)),
+            Ok(_) => unreachable!(),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Position the cursor at the specified key and return the key and data.
+    fn set_key(&mut self,
+               key: &<D::Object as DataObject>::Key)
+               -> BldrResult<(&'d <D::Object as DataObject>::Key, D::Object)> {
+        assert_txn_state_eq!(self.state(), TxnState::Normal);
+        match cursor_get::<<D::Object as DataObject>::Key, D::Object>(self.handle(),
+                                                                      Some(key),
+                                                                      None,
+                                                                      CursorOp::SetKey) {
+            Ok((Some(key), value)) => Ok((key, value)),
+            Ok(_) => unreachable!(),
+            Err(e) => Err(e),
+        }
+    }
+}
+
+/// Read-only cursor
+pub struct RoCursor<'a, D: 'a + Database, T: 'a + Transaction<'a, D>> {
+    txn: &'a T,
+    cursor: *mut lmdb_sys::MDB_cursor,
+    _marker: PhantomData<D>,
+}
+
+impl<'a, D, T> RoCursor<'a, D, T>
+    where D: Database,
+          T: Transaction<'a, D>
+{
+    fn open(txn: &'a T) -> BldrResult<Self> {
+        assert_txn_state_eq!(txn.state(), TxnState::Normal);
+        let mut cursor: *mut lmdb_sys::MDB_cursor = ptr::null_mut();
+        unsafe {
+            try_mdb!(lmdb_sys::mdb_cursor_open(txn.handle(), txn.database().handle(), &mut cursor));
+        }
+        Ok(RoCursor {
+            txn: txn,
+            cursor: cursor,
+            _marker: PhantomData,
+        })
+    }
+}
+
+impl<'a, 'b, D, T> Cursor<'a, 'b, D, T> for RoCursor<'a, D, T>
+    where D: 'a + 'b + Database,
+          T: 'a + Transaction<'a, D>
+{
+    fn handle(&self) -> *mut lmdb_sys::MDB_cursor {
+        self.cursor
+    }
+
+    fn txn(&self) -> &'a mut lmdb_sys::MDB_txn {
+        self.txn.handle()
+    }
+
+    fn database(&self) -> lmdb_sys::MDB_dbi {
+        self.txn.database().handle()
+    }
+
+    fn state(&self) -> &TxnState {
+        self.txn.state()
+    }
+}
+
+impl<'a, D, T> Drop for RoCursor<'a, D, T>
+    where D: Database,
+          T: Transaction<'a, D>
+{
+    fn drop(&mut self) {
+        unsafe { lmdb_sys::mdb_cursor_close(self.cursor) }
+    }
+}
+
+/// Read-write cursor
+pub struct RwCursor<'a, D: 'a + Database> {
+    txn: &'a RwTransaction<'a, D>,
+    cursor: *mut lmdb_sys::MDB_cursor,
+    _marker: PhantomData<D>,
+}
+
+impl<'a, D: Database> RwCursor<'a, D> {
+    fn open(txn: &'a RwTransaction<D>) -> BldrResult<Self> {
+        assert_txn_state_eq!(txn.state(), TxnState::Normal);
+        let mut cursor: *mut lmdb_sys::MDB_cursor = ptr::null_mut();
+        unsafe {
+            try_mdb!(lmdb_sys::mdb_cursor_open(txn.handle(), txn.database().handle(), &mut cursor));
+        }
+        Ok(RwCursor {
+            txn: txn,
+            cursor: cursor,
+            _marker: PhantomData,
+        })
+    }
+}
+
+impl<'a, 'b, D, T> Cursor<'a, 'b, D, T> for RwCursor<'a, D>
+    where D: 'a + 'b + Database,
+          T: 'a + Transaction<'a, D>
+{
+    fn handle(&self) -> *mut lmdb_sys::MDB_cursor {
+        self.cursor
+    }
+
+    fn txn(&self) -> &'a mut lmdb_sys::MDB_txn {
+        self.txn.handle()
+    }
+
+    fn database(&self) -> lmdb_sys::MDB_dbi {
+        self.txn.database().handle()
+    }
+
+    fn state(&self) -> &TxnState {
+        self.txn.state()
+    }
+}
+
+impl<'a, D: Database> Drop for RwCursor<'a, D> {
+    fn drop(&mut self) {
+        unsafe { lmdb_sys::mdb_cursor_close(self.cursor) }
+    }
+}
+
+pub struct DatabaseBuilder<T: Database> {
+    pub name: Option<String>,
+    pub flags: DatabaseFlags,
+    txn_flags: c_uint,
+    _marker: PhantomData<T>,
+}
+
+impl<T: Database> DatabaseBuilder<T> {
+    /// Create a new database
+    pub fn create(mut self, env: Arc<Environment>) -> BldrResult<T> {
+        self.flags = self.flags | DB_CREATE;
+        let handle = try!(self.open_database(&env));
+        T::open(env, handle)
+    }
+
+    /// Open an existing database
+    pub fn open(mut self, env: Arc<Environment>) -> BldrResult<T> {
+        self.flags = self.flags - DB_CREATE;
+        let handle = try!(self.open_database(&env));
+        T::open(env, handle)
+    }
+
+    /// Configures the database to be a named database
+    pub fn named(&mut self, name: String) -> &mut Self {
+        self.name = Some(name);
+        self
+    }
+
+    /// Set database flags
+    pub fn flags(&mut self, flags: DatabaseFlags) -> &mut Self {
+        self.flags = flags;
+        self
+    }
+
+    /// Set the database to be read-only
+    pub fn readonly(&mut self) -> &mut Self {
+        self.txn_flags = lmdb_sys::MDB_RDONLY;
+        self
+    }
+
+    /// Set the database to be writeable
+    pub fn writable(&mut self) -> &mut Self {
+        self.txn_flags = 0;
+        self
+    }
+
+    fn open_database(&self, env: &Environment) -> BldrResult<lmdb_sys::MDB_dbi> {
+        match OPEN_LOCK.lock() {
+            Ok(_) => {
+                let name_ptr = if self.name.is_some() {
+                    try!(CString::new(self.name.as_ref().unwrap().as_bytes())).as_ptr()
+                } else {
+                    ptr::null()
+                };
+                let mut handle: lmdb_sys::MDB_dbi = 0;
+                let txn = try!(create_txn(env, self.txn_flags, None));
+                unsafe {
+                    match handle_mdb!(lmdb_sys::mdb_dbi_open(txn,
+                                                             name_ptr,
+                                                             self.flags.bits(),
+                                                             &mut handle)) {
+                        Ok(()) => {
+                            try_mdb!(lmdb_sys::mdb_txn_commit(txn));
+                            Ok(handle)
+                        }
+                        Err(e) => {
+                            lmdb_sys::mdb_txn_abort(txn);
+                            return Err(e);
+                        }
+                    }
+                }
+            }
+            Err(e) => panic!("Internal data access error: {:?}", e),
+        }
+    }
+}
+
+/// Common behaviour for databases
+pub trait Database : Sized {
+    type Object: DataObject + Any;
+
+    /// Drop all entries from the database
+    fn clear<'a, T: Transaction<'a, Self>>(&'a self, txn: &'a T) -> BldrResult<()> {
+        txn.clear()
+    }
+
+    /// Write an object into the database
+    fn write<'a>(&self, txn: &'a RwTransaction<'a, Self>, object: &Self::Object) -> BldrResult<()> {
+        txn.put(object.ident(), object)
+    }
+
+    /// Open the database
+    fn open(env: Arc<Environment>, handle: lmdb_sys::MDB_dbi) -> BldrResult<Self>;
+
+    /// Returns a reference to the database's environment
+    fn env(&self) -> &Environment;
+
+    /// Returns the database handle
+    fn handle(&self) -> lmdb_sys::MDB_dbi;
+
+    /// Begin a read-only transaction
+    fn txn_ro<'b>(&'b self) -> BldrResult<RoTransaction<'b, Self>> {
+        RoTransaction::begin(self)
+    }
+
+    /// Begin a read-write transaction
+    fn txn_rw<'b>(&'b self) -> BldrResult<RwTransaction<'b, Self>> {
+        RwTransaction::begin(self)
+    }
+}
+
+/// Common behaviour for transactions
+pub trait Transaction<'a, D: 'a + Database> : Sized {
+    /// Begin a transaction
+    fn begin(database: &'a D) -> BldrResult<Self>;
+
+    /// Abandon all the operations of the transaction instead of saving them.
+    fn abort(self) -> ();
+
+    /// Commit all the operations of a transaction into the database.
+    fn commit(self) -> BldrResult<()>;
+
+    /// Return a reference to the transaction's database
+    fn database(&self) -> &'a D;
+
+    /// Return a reference of the transaction's handle
+    fn handle(&self) -> &mut lmdb_sys::MDB_txn;
+
+    /// Return a reference of the transaction's current state
+    fn state(&self) -> &TxnState;
+
+    /// Returns a read-only cursor
+    fn cursor_ro(&'a self) -> BldrResult<RoCursor<'a, D, Self>> {
+        RoCursor::open(self)
+    }
+
+    /// Begins a read-only nested transaction within the current transaction into the given
+    /// database.
+    fn new_child<D2: Database>(&'a self, database: &'a D2) -> BldrResult<RoTransaction<'a, D2>> {
+        let handle = try!(create_txn(database.env(), lmdb_sys::MDB_RDONLY, Some(self.handle())));
+        Ok(RoTransaction {
+            database: database,
+            parent: Some(self.handle()),
+            handle: handle,
+            state: TxnState::default(),
+        })
+    }
+
+    /// Begins a read-write nested transaction within the current transaction into the given
+    /// database.
+    fn new_child_rw<D2: Database>(&'a self, database: &'a D2) -> BldrResult<RwTransaction<'a, D2>> {
+        let handle = try!(create_txn(database.env(), 0, Some(self.handle())));
+        Ok(RwTransaction {
+            database: database,
+            parent: Some(self.handle()),
+            handle: handle,
+            state: TxnState::default(),
+        })
+    }
+
+    /// Clear all data in the database.
+    fn clear(&self) -> BldrResult<()> {
+        assert_txn_state_eq!(self.state(), TxnState::Normal);
+        unsafe {
+            try_mdb!(lmdb_sys::mdb_drop(self.handle(), self.database().handle(), 0));
+        }
+        Ok(())
+    }
+
+    /// Return a value from the database.
+    fn get(&self, k: &<D::Object as DataObject>::Key) -> BldrResult<D::Object> {
+        assert_txn_state_eq!(self.state(), TxnState::Normal);
+        unsafe {
+            let mut key = k.to_mdb_value();
+            let mut data = encoded_val_for::<()>(None);
+            try_mdb!(lmdb_sys::mdb_get(self.handle() as *mut lmdb_sys::MDB_txn,
+                                       self.database().handle(),
+                                       &mut key,
+                                       &mut data));
+            let bytes: &[u8] = slice::from_raw_parts(data.mv_data as *const u8, data.mv_size);
+            match decode(bytes) {
+                Ok(value) => Ok(value),
+                Err(e) => Err(bldr_error!(ErrorKind::MdbError(MdbError::from(e)))),
+            }
+        }
+    }
+}
+
+pub struct RoTransaction<'a, D: 'a + Database> {
+    database: &'a D,
+    #[allow(dead_code)]
+    parent: Option<&'a mut lmdb_sys::MDB_txn>,
+    handle: *mut lmdb_sys::MDB_txn,
+    state: TxnState,
+}
+
+impl<'a, D: Database> RoTransaction<'a, D> {
+    /// Like `abort()`, but doesn't consume the transaction, keeping it alive for later use.
+    #[allow(dead_code)]
+    fn reset(&mut self) {
+        if *self.state() != TxnState::Normal {
+            return ();
+        }
+        unsafe {
+            lmdb_sys::mdb_txn_reset(self.handle());
+        }
+        self.state = TxnState::Released;
+    }
+
+    /// Acquires a new reader lock for a transaction that had been previously released by `renew()`.
+    #[allow(dead_code)]
+    fn renew(&mut self) -> BldrResult<()> {
+        assert_txn_state_eq!(self.state(), TxnState::Released);
+        unsafe {
+            try_mdb!(lmdb_sys::mdb_txn_renew(self.handle()));
+        }
+        self.state = TxnState::Normal;
+        Ok(())
+    }
+}
+
+impl<'a, D: 'a + Database> Transaction<'a, D> for RoTransaction<'a, D> {
+    fn begin(database: &'a D) -> BldrResult<Self> {
+        let handle = try!(create_txn(database.env(), lmdb_sys::MDB_RDONLY, None));
+        Ok(RoTransaction {
+            database: database,
+            parent: None,
+            handle: handle,
+            state: TxnState::default(),
+        })
+    }
+
+    fn abort(self) {
+        if *self.state() != TxnState::Normal {
+            return ();
+        }
+        unsafe {
+            lmdb_sys::mdb_txn_abort(self.handle());
+        }
+    }
+
+    fn commit(mut self) -> BldrResult<()> {
+        assert_txn_state_eq!(self.state(), TxnState::Normal);
+        unsafe {
+            try_mdb!(lmdb_sys::mdb_txn_commit(self.handle()));
+        }
+        self.state = TxnState::Released;
+        Ok(())
+    }
+
+    fn database(&self) -> &'a D {
+        self.database
+    }
+
+    fn handle(&self) -> &mut lmdb_sys::MDB_txn {
+        unsafe { &mut *self.handle }
+    }
+
+    fn state(&self) -> &TxnState {
+        &self.state
+    }
+}
+
+impl<'a, D: 'a + Database> Drop for RoTransaction<'a, D> {
+    fn drop(&mut self) {
+        if self.state == TxnState::Normal {
+            unsafe {
+                lmdb_sys::mdb_txn_commit(self.handle);
+            }
+            self.state = TxnState::Released;
+        }
+    }
+}
+
+pub struct RwTransaction<'a, D: 'a + Database> {
+    database: &'a D,
+    #[allow(dead_code)]
+    parent: Option<&'a mut lmdb_sys::MDB_txn>,
+    handle: *mut lmdb_sys::MDB_txn,
+    state: TxnState,
+}
+
+impl<'a, D: Database> RwTransaction<'a, D> {
+    /// Returns a read-write cursor
+    pub fn cursor_rw(&'a self) -> BldrResult<RwCursor<'a, D>> {
+        RwCursor::open(self)
+    }
+
+    /// Write a key/value into the database.
+    ///
+    /// The default behaviour is to enter a new key/data pair, replacing any previously existing
+    /// key if duplicates are not allowed, or adding a new duplicate data item if duplicates are
+    /// allowed.
+    ///
+    /// Duplicates can be allowed by setting the `DB_ALLOW_DUPS` flag on the database.
+    fn put(&self, key: &<D::Object as DataObject>::Key, value: &D::Object) -> BldrResult<()> {
+        assert_txn_state_eq!(self.state(), TxnState::Normal);
+        // JW TODO: these flags represent different types of "writes" and are dependent upon the
+        // flags used to open the database. This would mean that this `put` function is the
+        // foundation for writing data into the database and functions like `write`, `update`, and
+        // `append` are the public API hanging off of the database itself.
+        let flags = 0;
+        unsafe {
+            let mut kval = key.to_mdb_value();
+            let mut dval = encoded_val_for::<D::Object>(Some(value));
+            try_mdb!(lmdb_sys::mdb_put(self.handle,
+                                       self.database.handle(),
+                                       &mut kval,
+                                       &mut dval,
+                                       flags));
+        }
+        Ok(())
+    }
+
+    /// Delete items from the database.
+    ///
+    /// If the database does not support duplicate data items the value argument is ignored. If
+    /// the database supports duplicate data items and the value argument is `None`, all of the
+    /// duplicate data items for the key are deleted. Otherwise, if the data option is present only
+    /// the matching data item will be deleted.
+    ///
+    /// # Failures
+    ///
+    /// * MdbError::NotFound if the specified key/data pair is not in the database
+    #[allow(dead_code)]
+    fn delete(&self,
+              key: &<D::Object as DataObject>::Key,
+              value: Option<&D::Object>)
+              -> BldrResult<()> {
+        unsafe {
+            let mut kval = key.to_mdb_value();
+            let dval: *mut lmdb_sys::MDB_val = {
+                if value.is_some() {
+                    &mut encoded_val_for::<D::Object>(value)
+                } else {
+                    ptr::null_mut()
+                }
+            };
+            try_mdb!(lmdb_sys::mdb_del(self.handle, self.database.handle(), &mut kval, dval));
+        }
+        Ok(())
+    }
+}
+
+impl<'a, D: 'a + Database> Transaction<'a, D> for RwTransaction<'a, D> {
+    fn begin(database: &'a D) -> BldrResult<Self> {
+        let handle = try!(create_txn(database.env(), 0, None));
+        Ok(RwTransaction {
+            database: database,
+            parent: None,
+            handle: handle,
+            state: TxnState::default(),
+        })
+    }
+
+    fn abort(self) {
+        if *self.state() != TxnState::Normal {
+            return ();
+        }
+        unsafe {
+            lmdb_sys::mdb_txn_abort(self.handle());
+        }
+    }
+
+    fn commit(mut self) -> BldrResult<()> {
+        assert_txn_state_eq!(self.state(), TxnState::Normal);
+        unsafe {
+            try_mdb!(lmdb_sys::mdb_txn_commit(self.handle()));
+        }
+        self.state = TxnState::Invalid;
+        Ok(())
+    }
+
+    fn database(&self) -> &'a D {
+        self.database
+    }
+
+    fn handle(&self) -> &mut lmdb_sys::MDB_txn {
+        unsafe { &mut *self.handle }
+    }
+
+    fn state(&self) -> &TxnState {
+        &self.state
+    }
+}
+
+impl<'a, D: 'a + Database> Drop for RwTransaction<'a, D> {
+    fn drop(&mut self) {
+        if self.state == TxnState::Normal {
+            unsafe {
+                lmdb_sys::mdb_txn_commit(self.handle);
+            }
+            self.state = TxnState::Invalid;
+        }
+    }
+}
+
+/// Contains metadata entries for each package known by the Depot
+pub struct PkgDatabase {
+    pub index: PkgIndex,
+    env: Arc<Environment>,
+    handle: lmdb_sys::MDB_dbi,
+}
+
+impl PkgDatabase {
+    pub fn new() -> DatabaseBuilder<Self> {
+        DatabaseBuilder::default()
+    }
+}
+
+impl Database for PkgDatabase {
+    type Object = data_object::Package;
+
+    fn open(env: Arc<Environment>, handle: lmdb_sys::MDB_dbi) -> BldrResult<Self> {
+        let env2 = env.clone();
+        let index = try!(PkgIndex::new().create(env2));
+        Ok(PkgDatabase {
+            env: env,
+            handle: handle,
+            index: index,
+        })
+    }
+
+    fn clear<'a, T: Transaction<'a, Self>>(&'a self, txn: &'a T) -> BldrResult<()> {
+        try!(txn.clear());
+        let nested = try!(txn.new_child_rw(&self.index));
+        try!(self.index.clear(&nested));
+        try!(nested.commit());
+        Ok(())
+    }
+
+    fn write<'a>(&self, txn: &RwTransaction<'a, Self>, object: &Self::Object) -> BldrResult<()> {
+        try!(txn.put(object.ident(), object));
+        let nested = try!(txn.new_child_rw(&self.index));
+        try!(self.index.write(&nested, &object.ident));
+        try!(nested.commit());
+        Ok(())
+    }
+
+    fn env(&self) -> &Environment {
+        &self.env
+    }
+
+    fn handle(&self) -> lmdb_sys::MDB_dbi {
+        self.handle
+    }
+}
+
+impl Default for DatabaseBuilder<PkgDatabase> {
+    fn default() -> DatabaseBuilder<PkgDatabase> {
+        DatabaseBuilder {
+            name: Some(PACKAGE_DB.to_string()),
+            flags: DatabaseFlags::empty(),
+            txn_flags: 0,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl Drop for PkgDatabase {
+    fn drop(&mut self) {
+        unsafe { lmdb_sys::mdb_dbi_close(self.env.handle, self.handle()) }
+    }
+}
+
+/// Contains an index of package identifiers to easily find the latest version/release of a
+/// specified package.
+pub struct PkgIndex {
+    env: Arc<Environment>,
+    handle: lmdb_sys::MDB_dbi,
+}
+
+impl PkgIndex {
+    pub fn new() -> DatabaseBuilder<Self> {
+        DatabaseBuilder::default()
+    }
+}
+
+impl Database for PkgIndex {
+    type Object = data_object::PackageIdent;
+
+    fn open(env: Arc<Environment>, handle: lmdb_sys::MDB_dbi) -> BldrResult<Self> {
+        Ok(PkgIndex {
+            env: env,
+            handle: handle,
+        })
+    }
+
+    fn env(&self) -> &Environment {
+        &self.env
+    }
+
+    fn handle(&self) -> lmdb_sys::MDB_dbi {
+        self.handle
+    }
+
+    fn write<'a>(&self, txn: &RwTransaction<'a, Self>, object: &Self::Object) -> BldrResult<()> {
+        try!(txn.put(&object.deriv_idx(), object));
+        try!(txn.put(&object.name_idx(), object));
+        txn.put(&object.version_idx(), object)
+    }
+}
+
+impl Default for DatabaseBuilder<PkgIndex> {
+    fn default() -> DatabaseBuilder<PkgIndex> {
+        let mut flags = DatabaseFlags::empty();
+        flags.toggle(DB_ALLOW_DUPS);
+        DatabaseBuilder {
+            name: Some(PACKAGE_INDEX.to_string()),
+            flags: flags,
+            txn_flags: 0,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl Drop for PkgIndex {
+    fn drop(&mut self) {
+        unsafe { lmdb_sys::mdb_dbi_close(self.env.handle, self.handle()) }
+    }
+}
+
+/// Contains a mapping of repository names and the packages found within that repository.
+///
+/// This is how packages will be "promoted" between environments without duplicating data on disk.
+pub struct ViewDatabase {
+    env: Arc<Environment>,
+    handle: lmdb_sys::MDB_dbi,
+}
+
+impl ViewDatabase {
+    pub fn new() -> DatabaseBuilder<Self> {
+        DatabaseBuilder::default()
+    }
+}
+
+impl Database for ViewDatabase {
+    type Object = data_object::View;
+
+    fn open(env: Arc<Environment>, handle: lmdb_sys::MDB_dbi) -> BldrResult<Self> {
+        Ok(ViewDatabase {
+            env: env,
+            handle: handle,
+        })
+    }
+
+    fn env(&self) -> &Environment {
+        &self.env
+    }
+
+    fn handle(&self) -> lmdb_sys::MDB_dbi {
+        self.handle
+    }
+}
+
+impl Default for DatabaseBuilder<ViewDatabase> {
+    fn default() -> DatabaseBuilder<ViewDatabase> {
+        DatabaseBuilder {
+            name: Some(VIEW_DB.to_string()),
+            flags: DatabaseFlags::empty(),
+            txn_flags: 0,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl Drop for ViewDatabase {
+    fn drop(&mut self) {
+        unsafe { lmdb_sys::mdb_dbi_close(self.env.handle, self.handle()) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+    use std::collections::HashSet;
+    use super::*;
+    use super::super::data_object::*;
+    use error::{BldrError, ErrorKind};
+
+    // JW TODO: This test is ignored while I track down a bug preventing multiple transactions
+    // being opened from different threads.
+    #[test]
+    #[ignore]
+    fn read_write_composite_data_object() {
+        let ds = open_datastore();
+        let key: String = "chef/redis/3.0.1/1234".to_string();
+        {
+            let pkg = Package {
+                ident: PackageIdent::new(key.clone()),
+                manifest: "my-manifest".to_string(),
+                deps: vec![],
+                tdeps: vec![],
+                exposes: vec![],
+                config: Some("configuration".to_string()),
+                views: HashSet::new(),
+            };
+            let txn = ds.packages.txn_rw().unwrap();
+            txn.put(&pkg.ident(), &pkg).unwrap();
+            txn.commit().unwrap();
+        }
+        let txn = ds.packages.txn_ro().unwrap();
+        let saved = txn.get(&"chef/redis/3.0.1/1234".to_string()).unwrap();
+        txn.abort();
+        assert_eq!(saved.ident(), "chef/redis/3.0.1/1234");
+        assert_eq!(saved.manifest, "my-manifest");
+        assert_eq!(saved.config, Some("configuration".to_string()));
+    }
+
+    // JW TODO: This test is ignored while I track down a bug preventing multiple transactions
+    // being opened from different threads.
+    #[test]
+    #[ignore]
+    fn transaction_read_write() {
+        let ds = open_datastore();
+        {
+            let mut view = View::new("my-view");
+            view.add_package("my-package".to_string());
+            let txn = ds.views.txn_rw().unwrap();
+            txn.put(view.ident(), &view).unwrap();
+            txn.commit().unwrap();
+        };
+        let txn = ds.views.txn_ro().unwrap();
+        let saved = txn.get(&"my-view".to_string()).unwrap();
+        txn.abort();
+        assert_eq!(saved.ident(), "my-view");
+        assert_eq!(saved.packages.len(), 1);
+    }
+
+    // JW TODO: This test is ignored while I track down a bug preventing multiple transactions
+    // being opened from different threads.
+    #[test]
+    #[ignore]
+    fn transaction_delete() {
+        let ds = open_datastore();
+        {
+            let mut view = View::new("my-view");
+            view.add_package("my-package".to_string());
+            let txn = ds.views.txn_rw().unwrap();
+            txn.put(view.ident(), &view).unwrap();
+            txn.commit().unwrap();
+        };
+        let txn = ds.views.txn_rw().unwrap();
+        txn.delete(&"my-view".to_string(), None).unwrap();
+        match txn.get(&"my-view".to_string()) {
+            Err(BldrError { err: ErrorKind::MdbError(MdbError::NotFound), .. }) => {
+                txn.abort();
+                assert!(true)
+            }
+            _ => {
+                txn.abort();
+                assert!(false)
+            }
+        }
+    }
+
+    fn open_datastore() -> DataStore {
+        let ds = DataStore::open(Path::new("/opt/bldr/test")).unwrap();
+        ds.clear().unwrap();
+        ds
+    }
+}

--- a/src/bldr/repo/mod.rs
+++ b/src/bldr/repo/mod.rs
@@ -5,12 +5,14 @@
 // is made available under an open source license such as the Apache 2.0 License.
 
 pub mod client;
+pub mod data_object;
+pub mod data_store;
 
 use iron::prelude::*;
 use iron::status;
 use iron::request::Body;
 use iron::headers;
-use router::Router;
+use router::{Params, Router};
 use rustc_serialize::json;
 
 use std::net;
@@ -19,71 +21,50 @@ use std::fs::{self, File};
 use std::io::{Read, Write, BufWriter};
 use std::path::{Path, PathBuf};
 
-use error::{BldrResult, ErrorKind};
+use error::{BldrError, BldrResult, ErrorKind};
 use config::Config;
-
-use package::{Package, PackageArchive};
+use self::data_store::{Cursor, DataStore, Database, Transaction};
+use self::data_object::DataObject;
+use package::{self, Package, PackageArchive};
 
 static LOGKEY: &'static str = "RE";
 
 header! { (XFileName, "X-Filename") => [String] }
 
-struct Repo {
+pub struct Repo {
     pub path: String,
+    pub datastore: DataStore,
 }
 
 impl Repo {
-    fn new(path: &str) -> BldrResult<Arc<Repo>> {
-        Ok(Arc::new(Repo { path: String::from(path) }))
+    pub fn new(path: String) -> BldrResult<Arc<Repo>> {
+        let dbpath = Path::new(&path).join("datastore");
+        let datastore = try!(DataStore::open(dbpath.as_path()));
+        Ok(Arc::new(Repo {
+            path: path,
+            datastore: datastore,
+        }))
     }
 
     // Return a PackageArchive representing the given package. None is returned if the repository
     // doesn't have an archive for the given package.
-    fn archive(&self,
-               derivation: &str,
-               name: &str,
-               version: &str,
-               release: &str)
-               -> Option<PackageArchive> {
-        let file = self.archive_path(derivation, name, version, release);
+    fn archive(&self, ident: &package::PackageIdent) -> Option<PackageArchive> {
+        let file = self.archive_path(&ident);
         match fs::metadata(&file) {
             Ok(_) => Some(PackageArchive::new(file)),
             Err(_) => None,
         }
     }
 
-    // Return a PackageArchive representing the latest release available for the given package
-    // derivation, name, and version (optional).
-    //
-    // If a version is specified the latest release of that version will be returned, if it is
-    // omitted the latest release of the latest version is returned.
-    fn archive_latest(&self,
-                      derivation: &str,
-                      name: &str,
-                      version: Option<&str>)
-                      -> Option<PackageArchive> {
-        match Package::load(derivation,
-                            name,
-                            version.map(String::from),
-                            None,
-                            Some(self.packages_path().to_str().unwrap())) {
-            Ok(package) => self.archive(&package.derivation,
-                                        &package.name,
-                                        &package.version,
-                                        &package.release),
-            Err(_) => None,
-        }
-    }
-
     // Return a formatted string representing the filename of an archive for the given package
     // identifier pieces.
-    fn archive_path(&self, derivation: &str, name: &str, version: &str, release: &str) -> PathBuf {
+    fn archive_path(&self, ident: &package::PackageIdent) -> PathBuf {
         self.packages_path()
-            .join(derivation)
-            .join(name)
-            .join(version)
-            .join(release)
-            .join(format!("{}-{}-{}-{}.bldr", &derivation, &name, &version, &release))
+            .join(&ident.derivation)
+            .join(&ident.name)
+            .join(ident.version.as_ref().unwrap())
+            .join(ident.release.as_ref().unwrap())
+            .join(format!("{}-{}-{}-{}.bldr", &ident.derivation, &ident.name, ident.version.as_ref().unwrap(), ident.release.as_ref().unwrap()))
     }
 
     fn key_path(&self, name: &str) -> PathBuf {
@@ -113,6 +94,30 @@ impl Default for ListenAddr {
 impl Default for ListenPort {
     fn default() -> Self {
         ListenPort(9632)
+    }
+}
+
+impl<'a> Into<package::PackageIdent> for &'a Params {
+    fn into(self) -> package::PackageIdent {
+        package::PackageIdent::new(self.find("deriv").unwrap(), self.find("pkg").unwrap(), self.find("version"), self.find("release"))
+    }
+}
+
+impl<'a> Into<data_object::PackageIdent> for &'a Params {
+    fn into(self) -> data_object::PackageIdent {
+        let deriv = self.find("deriv").unwrap();
+        let name = self.find("pkg");
+        let version = self.find("version");
+        let release = self.find("release");
+        if release.is_some() && version.is_some() && name.is_some() {
+            data_object::PackageIdent::new(format!("{}/{}/{}/{}", deriv, name.unwrap(), version.unwrap(), release.unwrap()))
+        } else if version.is_some() && name.is_some() {
+            data_object::PackageIdent::new(format!("{}/{}/{}", deriv, name.unwrap(), version.unwrap()))
+        } else if name.is_some() {
+            data_object::PackageIdent::new(format!("{}/{}", deriv, name.unwrap()))
+        } else {
+            data_object::PackageIdent::new(deriv.to_string())
+        }
     }
 }
 
@@ -165,31 +170,54 @@ fn upload_key(repo: &Repo, req: &mut Request) -> IronResult<Response> {
 
 fn upload_package(repo: &Repo, req: &mut Request) -> IronResult<Response> {
     outputln!("Upload {:?}", req);
-    let rext = req.extensions.get::<Router>().unwrap();
+    let ident: package::PackageIdent = {
+        let params = req.extensions.get::<Router>().unwrap();
+        params.into()
+    };
 
-    let deriv = rext.find("deriv").unwrap();
-    let pkg = rext.find("pkg").unwrap();
-    let version = rext.find("version").unwrap();
-    let release = rext.find("release").unwrap();
+    if !ident.fully_qualified() {
+        return Ok(Response::with((status::BadRequest)));
+    }
 
-    let filename = repo.archive_path(deriv, pkg, version, release);
+    let txn = try!(repo.datastore.packages.txn_rw());
+    if let Ok(_) = txn.get(&ident.to_string()) {
+        if let Some(_) = repo.archive(&ident) {
+            return Ok(Response::with((status::Conflict)));
+        } else {
+            // This should never happen. Writing the package to disk and recording it's existence
+            // in the metadata is a transactional operation and one cannot exist without the other.
+            //
+            // JW TODO: write the depot repair tool and wire it into the `bldr-depot repair` command
+            panic!("Inconsistent package metadata! Exit and run `bldr-depot repair` to fix data integrity.");
+        }
+    }
+
+    let filename = repo.archive_path(&ident);
     try!(write_file(&filename, &mut req.body));
+    let archive = PackageArchive::new(filename);
+    let object = match data_object::Package::from_archive(&archive) {
+        Ok(object) => object,
+        Err(_) => return Ok(Response::with(status::UnprocessableEntity)),
+    };
+    if ident.satisfies(&object.ident.clone().into()) {
+        // JW TODO: handle failure here?
+        try!(repo.datastore.packages.write(&txn, &object));
+        try!(txn.commit());
 
-    let mut response = Response::with((status::Created,
-                                       format!("/pkgs/{}/{}/{}/{}/download",
-                                               deriv,
-                                               pkg,
-                                               version,
-                                               release)));
-    let mut base_url = req.url.clone();
-    base_url.path = vec![String::from("pkgs"),
-                         String::from(deriv),
-                         String::from(pkg),
-                         String::from(version),
-                         String::from(release),
-                         String::from("download")];
-    response.headers.set(headers::Location(format!("{}", base_url)));
-    Ok(response)
+        let mut response = Response::with((status::Created, format!("/pkgs/{}/download", object.ident)));
+        let mut base_url = req.url.clone();
+        let parts: Vec<&str> = object.ident.parts();
+        base_url.path = vec![String::from("pkgs"),
+                             parts[0].to_string(),
+                             parts[1].to_string(),
+                             parts[2].to_string(),
+                             parts[3].to_string(),
+                             String::from("download")];
+        response.headers.set(headers::Location(format!("{}", base_url)));
+        Ok(response)
+    } else {
+        Ok(Response::with(status::UnprocessableEntity))
+    }
 }
 
 fn download_key(repo: &Repo, req: &mut Request) -> IronResult<Response> {
@@ -213,76 +241,140 @@ fn download_key(repo: &Repo, req: &mut Request) -> IronResult<Response> {
 
 fn download_package(repo: &Repo, req: &mut Request) -> IronResult<Response> {
     outputln!("Download {:?}", req);
-    let rext = req.extensions.get::<Router>().unwrap();
+    let params = req.extensions.get::<Router>().unwrap();
+    // JW TODO: check for repo param
+    let ident: data_object::PackageIdent = params.into();
 
-    let deriv = match rext.find("deriv") {
-        Some(deriv) => deriv,
-        None => return Ok(Response::with(status::BadRequest)),
-    };
-    let pkg = match rext.find("pkg") {
-        Some(pkg) => pkg,
-        None => return Ok(Response::with(status::BadRequest)),
-    };
-    let param_ver = rext.find("version");
-    let param_rel = rext.find("release");
-
-    let archive = if param_ver.is_some() && param_rel.is_some() {
-        match repo.archive(&deriv,
-                           &pkg,
-                           param_ver.as_ref().unwrap(),
-                           param_rel.as_ref().unwrap()) {
-            Some(archive) => archive,
-            None => return Ok(Response::with(status::NotFound)),
+    let result = if ident.parts().len() == 4 {
+        let txn = try!(repo.datastore.packages.txn_ro());
+        match txn.get(&ident.to_string()) {
+            Ok(package) => {
+                let value: package::PackageIdent = package.ident.into();
+                Ok(value)
+            },
+            Err(e) => Err(e)
         }
     } else {
-        match repo.archive_latest(&deriv, &pkg, param_ver) {
-            Some(archive) => archive,
-            None => return Ok(Response::with(status::NotFound)),
+        // JW TODO: fix scoping of cursor/transactions and refactor this
+        let r = {
+            let idx = try!(repo.datastore.packages.index.txn_ro());
+            let mut cursor = try!(idx.cursor_ro());
+            if let Some(e) = cursor.set_key(&ident.to_string()).err() {
+                Err(e)
+            } else {
+                cursor.last_dup()
+            }
+        };
+        match r {
+            Ok(v) => {
+                let txn = try!(repo.datastore.packages.txn_ro());
+                let value: package::PackageIdent = try!(txn.get(&v.ident())).ident.into();
+                Ok(value)
+            },
+            Err(e) => Err(BldrError::from(e))
         }
     };
 
-    match fs::metadata(&archive.path) {
-        Ok(_) => {
-            let mut response = Response::with((status::Ok, archive.path.clone()));
-            response.headers.set(XFileName(archive.file_name()));
-            Ok(response)
-        }
-        Err(_) => {
-            Ok(Response::with(status::NotFound))
-        }
+    match result {
+        Ok(ident) => {
+            if let Some(archive) = repo.archive(&ident) {
+                match fs::metadata(&archive.path) {
+                    Ok(_) => {
+                        let mut response = Response::with((status::Ok, archive.path.clone()));
+                        response.headers.set(XFileName(archive.file_name()));
+                        Ok(response)
+                    }
+                    Err(_) => Ok(Response::with(status::NotFound)),
+                }
+            } else {
+                // This should never happen. Writing the package to disk and recording it's existence
+                // in the metadata is a transactional operation and one cannot exist without the other.
+                //
+                // JW TODO: write the depot repair tool and wire it into the `bldr-depot repair` command
+                panic!("Inconsistent package metadata! Exit and run `bldr-depot repair` to fix data integrity.");
+            }
+        },
+        Err(BldrError { err: ErrorKind::MdbError(data_store::MdbError::NotFound), ..}) => Ok(Response::with((status::NotFound))),
+        Err(_) => unreachable!("unknown error"),
+    }
+}
+
+fn list_packages(repo: &Repo, req: &mut Request) -> IronResult<Response> {
+    let params = req.extensions.get::<Router>().unwrap();
+    let ident: data_object::PackageIdent = params.into();
+    let mut packages: Vec<package::PackageIdent> = vec![];
+
+    let txn = try!(repo.datastore.packages.index.txn_ro());
+    let mut cursor = try!(txn.cursor_ro());
+    let result = match cursor.set_key(ident.ident()) {
+        Ok((_, value)) => {
+            packages.push(value.into());
+            loop {
+                match cursor.next_dup() {
+                    Ok((_, value)) => packages.push(value.into()),
+                    Err(_) => break
+                }
+            }
+            Ok(())
+        },
+        Err(e) => Err(BldrError::from(e))
+    };
+
+    match result {
+        Ok(()) => {
+            let body = json::encode(&packages).unwrap();
+            Ok(Response::with((status::Ok, body)))
+        },
+        Err(BldrError { err: ErrorKind::MdbError(data_store::MdbError::NotFound), ..}) => Ok(Response::with((status::NotFound))),
+        Err(_) => unreachable!("unknown error"),
     }
 }
 
 fn show_package(repo: &Repo, req: &mut Request) -> IronResult<Response> {
-    let rext = req.extensions.get::<Router>().unwrap();
-    let package = rext.find("pkg").unwrap();
-    let deriv = rext.find("deriv").unwrap();
-    let version = rext.find("version");
-    let release = rext.find("release");
+    let params = req.extensions.get::<Router>().unwrap();
+    let ident: package::PackageIdent = params.into();
 
-    let archive = if version.is_some() && release.is_some() {
-        match repo.archive(&deriv,
-                           &package,
-                           version.as_ref().unwrap(),
-                           release.as_ref().unwrap()) {
-            Some(archive) => archive,
-            None => return Ok(Response::with(status::NotFound)),
-        }
+    let result = if ident.fully_qualified() {
+        let txn = try!(repo.datastore.packages.txn_ro());
+        txn.get(&ident.to_string())
     } else {
-        match repo.archive_latest(&deriv, &package, version) {
-            Some(archive) => archive,
-            None => return Ok(Response::with(status::NotFound)),
+        let r = {
+            let idx = try!(repo.datastore.packages.index.txn_ro());
+            let mut cursor = try!(idx.cursor_ro());
+            if let Some(e) = cursor.set_key(&ident.to_string()).err() {
+                Err(e)
+            } else {
+                cursor.last_dup()
+            }
+        };
+        match r {
+            Ok(v) => {
+                let txn = try!(repo.datastore.packages.txn_ro());
+                txn.get(&v.ident())
+            },
+            Err(e) => Err(e)
         }
     };
+    match result {
+        Ok(data) => {
+            // JW TODO: re-enable proper json encoding when I have a plan for proper decoding
+            // let body = json::encode(&data.to_json()).unwrap();
+            let body = json::encode(&data).unwrap();
+            Ok(Response::with((status::Ok, body)))
+        },
+        Err(BldrError { err: ErrorKind::MdbError(data_store::MdbError::NotFound), ..}) => Ok(Response::with((status::NotFound))),
+        Err(e) => unreachable!("unknown error: {:?}", e),
+    }
+}
 
-    let package = try!(archive.package());
-    let body = json::encode(&package).unwrap();
-    Ok(Response::with((status::Ok, body)))
+pub fn repair(config: &Config) -> BldrResult<()> {
+    let repo = try!(Repo::new(String::from(config.path())));
+    repo.datastore.clear()
 }
 
 pub fn run(config: &Config) -> BldrResult<()> {
-    let repo = try!(Repo::new(config.path()));
-    let repo2 = repo.clone();
+    let repo = try!(Repo::new(String::from(config.path())));
+    // let repo2 = repo.clone();
     let repo3 = repo.clone();
     let repo4 = repo.clone();
     let repo5 = repo.clone();
@@ -290,17 +382,33 @@ pub fn run(config: &Config) -> BldrResult<()> {
     let repo7 = repo.clone();
     let repo8 = repo.clone();
     let repo9 = repo.clone();
+    let repo10 = repo.clone();
+    let repo11 = repo.clone();
+    let repo12 = repo.clone();
+    let repo13 = repo.clone();
+    let repo14 = repo.clone();
+    let repo15 = repo.clone();
+    let repo16 = repo.clone();
+    let repo17 = repo.clone();
     let router = router!(
-        post "/pkgs/:deriv/:pkg/:version/:release" => move |r: &mut Request| upload_package(&repo, r),
-        get "/pkgs/:deriv/:pkg/:version/:release/download" => move |r: &mut Request| download_package(&repo2, r),
-        get "/pkgs/:deriv/:pkg/:version/download" => move |r: &mut Request| download_package(&repo3, r),
-        get "/pkgs/:deriv/:pkg/download" => move |r: &mut Request| download_package(&repo4, r),
-        get "/pkgs/:deriv/:pkg/:version/:release" => move |r: &mut Request| show_package(&repo5, r),
-        get "/pkgs/:deriv/:pkg/:version" => move |r: &mut Request| show_package(&repo6, r),
-        get "/pkgs/:deriv/:pkg" => move |r: &mut Request| show_package(&repo7, r),
+        // JW TODO: update list/show/download function to cover scoping rules of these routes repos
+        get "/pkgs/:deriv/:pkg/:version" => move |r: &mut Request| list_packages(&repo3, r),
+        get "/pkgs/:deriv/:pkg" => move |r: &mut Request| list_packages(&repo4, r),
+        get "/pkgs/:deriv/:pkg/latest" => move |r: &mut Request| show_package(&repo5, r),
+        get "/pkgs/:deriv/:pkg/:version/:release/download" => move |r: &mut Request| download_package(&repo6, r),
+        get "/pkgs/:deriv/:pkg/:version/download" => move |r: &mut Request| download_package(&repo7, r),
+        get "/pkgs/:deriv/:pkg/download" => move |r: &mut Request| download_package(&repo8, r),
 
-        post "/keys/:key" => move |r: &mut Request| upload_key(&repo8, r),
-        get "/keys/:key" => move |r: &mut Request| download_key(&repo9, r)
+        post "/pkgs/:deriv/:pkg/:version/:release" => move |r: &mut Request| upload_package(&repo9, r),
+        get "/pkgs/:deriv/:pkg/:version/latest" => move |r: &mut Request| show_package(&repo10, r),
+        get "/pkgs/:deriv/:pkg/:version/:release" => move |r: &mut Request| show_package(&repo11, r),
+        get "/pkgs/:deriv/:pkg/latest" => move |r: &mut Request| show_package(&repo12, r),
+        get "/pkgs/:deriv/:pkg/:version" => move |r: &mut Request| list_packages(&repo13, r),
+        get "/pkgs/:deriv/:pkg" => move |r: &mut Request| list_packages(&repo14, r),
+        get "/pkgs/:deriv" => move |r: &mut Request| list_packages(&repo15, r),
+
+        post "/keys/:key" => move |r: &mut Request| upload_key(&repo16, r),
+        get "/keys/:key" => move |r: &mut Request| download_key(&repo17, r)
     );
     Iron::new(router).http(config.repo_addr()).unwrap();
     Ok(())

--- a/src/bldr/topology/standalone.rs
+++ b/src/bldr/topology/standalone.rs
@@ -20,7 +20,7 @@ use std::io::prelude::*;
 
 use fs::SERVICE_HOME;
 use error::{BldrResult, BldrError, ErrorKind};
-use package::Package;
+use package::{Package, PackageIdent};
 use state_machine::StateMachine;
 use topology::{self, State, Worker};
 use config::Config;
@@ -63,7 +63,7 @@ pub fn state_initializing(worker: &mut Worker) -> BldrResult<(State, u64)> {
 pub fn state_starting(worker: &mut Worker) -> BldrResult<(State, u64)> {
     outputln!(P: &worker.package_name, "Starting");
     let package = worker.package_name.clone();
-    let runit_pkg = try!(Package::load("chef", "runit", None, None, None));
+    let runit_pkg = try!(Package::load(&PackageIdent::new("chef", "runit", None, None), None));
     let mut child = try!(Command::new(runit_pkg.join_path("bin/runsv"))
                              .arg(&format!("{}/{}", SERVICE_HOME, worker.package_name))
                              .stdin(Stdio::null())


### PR DESCRIPTION
This is the first pass at adding a metadata storage to the Depot server
- Repo server stores metadata in [lmdb](http://symas.com/mdb/), an embedded in-memory database
- Added `PackageIdent` struct which encapsulates functionality which was sprinkled throughout modules in the codebase for working with package identifiers. This struct is passed as an argument to many functions which previously took either four `&str`s or two `&str`s and two `Option<&str>`s
- Added `DataStore` struct which encapsulates the lmdb environment and all databases
- Added `PkgDatabase` which is populated from reading the metadata files of package archives
- Added `PkgIndex` which is a special database that allows sorted duplicate data to form an index. This database can be queried to find the latest version of a package using a cursor.
- Added `ViewDatabase` which contains the names of repositories and the packages which are a part of them. This allows us to segregate particular packages to only being available in certain environments while not duplicating data on disk for the actual package archive.
- Added `data_store` and `data_object` modules which contain an abstraction on top of the FFI layer of lmdb
- Add new command line option `depot-repair`
- Add new command line option `repo-create`
- Add new command line option `repo-list`
- Uploading a package which already exists on the depot will no longer result in a forced upload
- Moved package archive specific functions to `package::archive` module from `package`
## Known Issues
- Starting multiple transactions from different threads is not currently working. Additional child transactions can be started, but not root transactions. This behaviour should be possible within LMDB.
- Cursor functions don't return useable values for keys, but the data of the current item is good to read and available
