### PR TITLE
[acceptance] load delivery chef config

### DIFF
--- a/.delivery/cookbooks/bldr/recipes/functional.rb
+++ b/.delivery/cookbooks/bldr/recipes/functional.rb
@@ -16,12 +16,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-machine_dir = ::File.join(
-  Etc.getpwnam('dbuild').dir,
-  '.docker/machine/machines',
-  'bldr-docker-machine'
-)
+load_delivery_chef_config
 
+machine_dir = BldrDockerMachine.dbuild_machine_dir
 docker_machine_config = BldrDockerMachine.load_config
 
 execute 'make clean package functional force=true' do


### PR DESCRIPTION
We need to load the delivery chef config so the helpers return the
right things for the docker host
