### PR TITLE
[acceptance] Sharing secret through environment

### DIFF
--- a/.delivery/cookbooks/bldr/recipes/functional.rb
+++ b/.delivery/cookbooks/bldr/recipes/functional.rb
@@ -21,9 +21,14 @@ load_delivery_chef_config
 machine_dir = BldrDockerMachine.dbuild_machine_dir
 docker_machine_config = BldrDockerMachine.load_config
 
+ssh_key = data_bag_item('delivery-secrets', 'bldr-chef-acceptance')['github']
+
 execute 'make clean package functional force=true' do
   cwd node['delivery']['workspace']['repo']
   environment(
+    'GITHUB_DEPLOY_KEY' => ssh_key,
+    'DELIVERY_GIT_SHASUM' => node['delivery']['change']['sha'],
+    'GIT_SSH' => "#{node['delivery']['workspace']['repo']}/ssh_wrapper.sh",
     'DOCKER_TLS_VERIFY' => '1',
     'DOCKER_CERT_PATH' => machine_dir,
     'DOCKER_HOST' => "tcp://#{BldrDockerMachine.machine_ip}:2376",

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,5 +38,7 @@ RUN ln -snf /usr/bin/nodejs /usr/bin/node && npm install -g docco && echo "docco
 RUN adduser --system bldr
 RUN addgroup --system bldr
 
+COPY ssh_wrapper.sh /usr/local/bin/ssh_wrapper.sh
+
 WORKDIR /src
 CMD ["bash"]

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,20 @@ NO_CACHE := false
 
 all: package
 
+atest:
+ifeq ($(GITHUB_DEPLOY_KEY),)
+	@echo "nothing to see here"
+else
+	@echo "$$GITHUB_DEPLOY_KEY"
+	@echo "SHASUM: $(DELIVERY_GIT_SHASUM)"
+endif
+
 package: image
+ifeq ($(GITHUB_DEPLOY_KEY),)
 	$(run) package sh -c 'cd /src/plans; make world'
+else
+	$(run) package sh -c "mkdir -p ~/.ssh; echo \"$${GITHUB_DEPLOY_KEY}\" > ~/.ssh/id_rsa_bldr_github; chmod 0600 ~/.ssh/id_rsa_bldr_github; chmod +x /usr/local/bin/ssh_wrapper.sh; (cd / && GIT_SSH=/usr/local/bin/ssh_wrapper.sh git clone git@github.com:chef/bldr.git /src) && git checkout $(DELIVERY_GIT_SHASUM) && cd /src/plans; make world; ls -la /src /usr/local/bin"
+endif
 
 clean-package: image
 	$(run) package sh -c 'rm -rf /opt/bldr/cache/pkgs/* /opt/bldr/pkgs/*'

--- a/ssh_wrapper.sh
+++ b/ssh_wrapper.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+/usr/bin/env ssh -o "StrictHostKeyChecking=no" -i ~/.ssh/id_rsa_bldr_github $1 $2


### PR DESCRIPTION
We need to inject the secret - an SSH key - into the Docker container so that we can clone the private bldr repository. We don't have it available with the volumes directive in docker-compose.yml because we can't do a shared folder over to the EC2 node.

This is accomplished by injecting the SSH into the environment that make executes in during the functional phase. We then check for the environment variable in the make target, and execute appropriately - if we have a GITHUB_DEPLOY_KEY we hope for the best that we have the DELIVERY_GIT_SHASUM and can use the GIT_SSH too.

We also needed an SSH wrapper script, which gets copied over to the target docker container, so that we can use this deploy key, and not get prompted for the GitHub SSH host key.
