### PR TITLE
[bldr] encryption/decryption

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,6 +17,7 @@ dependencies = [
  "rmp 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rmp-serialize 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "router 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rpassword 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -211,6 +212,15 @@ dependencies = [
  "plugin 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "typemap 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "kernel32-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -456,6 +466,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rpassword"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termios 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rustc-serialize"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -501,6 +522,14 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rand 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "termios"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ uuid = "*"
 utp = "*"
 rmp = "*"
 rmp-serialize = "*"
+rpassword = "*"
 
 [dependencies.wonder]
 path = "./vendor/wonder"

--- a/src/bldr/command/key.rs
+++ b/src/bldr/command/key.rs
@@ -13,12 +13,17 @@ use util::gpg;
 use regex::Regex;
 use ansi_term::Colour::{Yellow, Red};
 use time::strptime;
-
+use rpassword::read_password;
+use package::Package;
+use std::process::{Command, Stdio, Child};
 use repo;
 
-static LOGKEY: &'static str = "KU";
+static LOGKEY: &'static str = "KU"; // "key utils"
 static USER_KEY_COMMENT: &'static str = "bldr user key";
 static SERVICE_KEY_COMMENT: &'static str = "bldr service key";
+// "bldr managed keys" all start with a prefix
+static BLDR_KEY_PREFIX: &'static str = "bldr_";
+static BLDR_EMAIL_SUFFIX: &'static str = "@bldr";
 
 /// Uploads a gpg key to a [repo](../repo).
 ///
@@ -39,7 +44,7 @@ static SERVICE_KEY_COMMENT: &'static str = "bldr service key";
 /// Will upload the `chef-public` key from the local key cache to the repo url.
 ///
 /// ```bash
-/// $ bldr upload-key /tmp/chef-public -u http://localhost:9633
+/// $ bldr upload-key --infile /tmp/chef-public -u http://localhost:9633
 /// ```
 ///
 /// Will upload the key at `/tmp/chef-public.asc` to the repo url.
@@ -75,11 +80,10 @@ pub fn upload(config: &Config) -> BldrResult<()> {
     Ok(())
 }
 
-/// Installs a gpg key from a [repo](../repo) or a local file.
-/// If `config.url()` is empty, we assume the value
-/// of `config.key()` is a path to the key. Otherwise, we download the
-/// key from the repo at `config.url()`, drop it in `/opt/bldr/cache/keys`,
-/// and then import it into GPG.
+/// Imports a gpg key from a [repo](../repo) or a local file.
+/// If `config.infile() is not empty, we try to load from a file.
+/// Otherwise, we load the key `config.key()` from `config.url()`,
+/// drop it in `/opt/bldr/cache/keys`, and then import it into GPG.
 ///
 /// # Failures
 ///
@@ -90,33 +94,130 @@ pub fn upload(config: &Config) -> BldrResult<()> {
 /// # Examples
 ///
 /// ```bash
-/// $ bldr install-key chef-public -u http://localhost:9633
+/// $ bldr import-key chef-public -u http://localhost:9633
 /// ```
 ///
 /// Will download the `chef-public` gpg key from the specified repo.
 ///
 /// ```bash
-/// $ bldr install-key /tmp/chef-public.asc
+/// $ bldr import-key --infile /tmp/chef-public.asc
 /// ```
 ///
 /// Will install the key found in `/tmp/chef-public.asc`.
 ///
-pub fn install(config: &Config) -> BldrResult<()> {
-    match *config.url() {
-        Some(ref url) => {
-            if url.is_empty() {
-                try!(gpg::import(&config.key()));
-            }
+pub fn import(config: &Config) -> BldrResult<()> {
+    match *config.infile() {
+        Some(ref infile) => {
+            try!(gpg::import(infile));
+        }
+        None => {
             try!(fs::create_dir_all(KEY_CACHE));
-            let filename = try!(repo::client::fetch_key(url, &config.key(), KEY_CACHE));
+            // docopt requires -u to be set, so we should be safe to unwrap here
+            let url = config.url().as_ref().unwrap();
+            let filename = try!(repo::client::fetch_key(&url, &config.key(), KEY_CACHE));
             try!(gpg::import(&filename));
         }
-        None => try!(gpg::import(&config.key())),
     }
+    outputln!("Successfully imported key(s)");
     Ok(())
 }
 
+/// Exports a public user or service key to a local file.
+/// When importing a service key, if the group is not specified
+/// it defaults to `default`.
+///
+/// # Examples
+/// ```bash
+/// $ bldr export-key --user foo --outfile /tmp/foo.pubkey
+/// ```
+///
+/// ```bash
+/// $ bldr export-key --service redis --outfile /tmp/redis.pubkey
+/// ```
+///
+/// ```bash
+/// $ bldr export-key --service redis --group dev --outfile /tmp/redis.pubkey
+/// ```
+///
+pub fn export(config: &Config) -> BldrResult<()> {
+    // it's either a service key or a user key,
+    // docopt will fail if you don't specify one or the other
+    let keyname = if config.service_key().is_some() {
+        gen_service_key_name(&config.service_key().as_ref().unwrap(), config.group())
+    } else {
+        gen_user_key_name(&config.user_key().as_ref().unwrap())
+    };
+    let outfile = config.outfile().as_ref().unwrap();
+    try!(gpg::export(&keyname, &outfile));
+    outputln!("Successfully exported key {} to {}",
+              Yellow.bold().paint(keyname),
+              Yellow.bold().paint(outfile as &str));
+    Ok(())
+}
 
+/// Encrypt and sign a file.
+/// Valid user and service keys must be specified.
+/// The user and service are both specified as recipients in the encrypted message.
+/// The user key is used to sign the encrypted message.
+/// If a password is not specified for the user key with the `--password` flag,
+/// bldr will display an interactive prompt.
+pub fn encrypt_and_sign(config: &Config) -> BldrResult<()> {
+    // these values are required per docopt, so they really *shouldn't* be empty
+    let userkey = config.user_key().as_ref().unwrap();
+    let servicekey = config.service_key().as_ref().unwrap();
+
+    let infile = config.infile().as_ref().unwrap();
+    let outfile = config.outfile().as_ref().unwrap();
+
+    outputln!("Attempting to encrypt {}, sending output to {}",
+              Yellow.bold().paint(infile as &str),
+              Yellow.bold().paint(outfile as &str));
+
+    // prepend BLDR_KEY_PREFIX to the key name, these are the bldr keys
+    let full_userkey = gen_user_key_name(&userkey);
+    let full_servicekey = gen_service_key_name(&servicekey, config.group());
+    let password = match config.password().clone() {
+        Some(p) => p,
+        None => {
+            println!("Please enter the key password for {}:", userkey);
+            let password = try!(read_password());
+            debug!("The password is: '{}'", password);
+            password
+        }
+    };
+
+    debug!("User key: {}", full_userkey);
+    debug!("Service key: {}", full_servicekey);
+    debug!("Input file: {}", infile);
+    debug!("Output file: {}", outfile);
+
+    try!(gpg::encrypt_and_sign(&full_userkey,
+                               &password,
+                               &full_servicekey,
+                               &infile,
+                               &outfile));
+
+    outputln!("Successfully wrote encrypted output to {}",
+              Yellow.bold().paint(outfile as &str));
+    Ok(())
+}
+
+/// Decrypt a file
+/// The private key of the service must reside in the current GPG cache.
+/// The public key of the user must reside in the current GPG cache to
+/// verify the signature.
+pub fn decrypt_and_verify(config: &Config) -> BldrResult<()> {
+    let infile = config.infile().as_ref().unwrap();
+    let outfile = config.outfile().as_ref().unwrap();
+    let msg = format!("Attempting to decrypt {}, sending output to {}",
+                      infile as &str,
+                      outfile as &str);
+    outputln!("{}", Yellow.bold().paint(msg));
+    try!(gpg::decrypt_and_verify(&infile, &outfile));
+    outputln!("Successfully wrote decrypted output to {}",
+              Yellow.bold().paint(outfile as &str));
+    Ok(())
+}
 
 /// list ALL keys in gpg
 pub fn list(_config: &Config) -> BldrResult<()> {
@@ -156,7 +257,7 @@ pub fn list(_config: &Config) -> BldrResult<()> {
 
 /// ensure parameters are correct before generating
 /// gpg "xml-ish" parameter string
-fn check_params(params: gpg::KeygenParams) -> BldrResult<()> {
+fn check_params(params: &gpg::KeygenParams) -> BldrResult<()> {
     // must be at least 5 characters
     if params.keyname.len() < 5 {
         return Err(bldr_error!(ErrorKind::InvalidKeyParameter("key name must be at least 5 \
@@ -175,35 +276,95 @@ fn check_params(params: gpg::KeygenParams) -> BldrResult<()> {
 }
 
 /// generate a service key name in the form of
-/// `bldr: keyname.group`
+/// `bldr_keyname.group`. If a service key is already in the
+/// form BLDR_KEY_PREFIX.+, then just return it
 fn gen_service_key_name(keyname: &str, group: &str) -> String {
-    format!("bldr: {}.{}", keyname, group)
+    let re = String::from(BLDR_KEY_PREFIX) + ".+";
+    let regex = Regex::new(&re).unwrap();
+    if regex.is_match(keyname) {
+        // it's already in normalized form
+        keyname.to_string()
+    } else {
+        format!("{}{}.{}", BLDR_KEY_PREFIX, keyname, group)
+    }
 }
 
 /// generate a service key email address in the form of
 /// `keyname.group@bldr`
 fn gen_service_key_email(keyname: &str, group: &str) -> String {
-    format!("{}.{}@bldr", keyname, group)
+    format!("{}.{}{}", keyname, group, BLDR_EMAIL_SUFFIX)
 }
 
 /// generate a user key name in the form of
-/// `bldr: keyname`
+/// `bldr_keyname`. If a user key is already in the
+/// form BLDR_KEY_PREFIX.+, then just return it
+
 fn gen_user_key_name(keyname: &str) -> String {
-    format!("bldr: {}", keyname)
+    let re = String::from(BLDR_KEY_PREFIX) + ".+";
+    let regex = Regex::new(&re).unwrap();
+    if regex.is_match(keyname) {
+        // it's already in normalized form
+        keyname.to_string()
+    } else {
+        format!("{}{}", BLDR_KEY_PREFIX, keyname)
+    }
+}
+
+/// Used to kill the rngd process in the event of an error
+struct DroppableChildProcess {
+    child: Child,
+}
+
+impl Drop for DroppableChildProcess {
+    fn drop(&mut self) {
+        debug!("Killing rngd");
+        let _ = self.child.kill();
+        debug!("Waiting for rngd to die");
+        let _ = self.child.wait();
+        ()
+    }
+}
+
+
+/// run rngd in the background to generate entropy while generating keys.
+/// The process is killed when it goes out of scope via `DroppableChildProcess`.
+fn run_rngd() -> BldrResult<DroppableChildProcess> {
+    debug!("Spawning rngd in the background");
+    let res = try!(Package::load("chef", "rngd", None, None, None));
+    let rngdpath = res.join_path("sbin/rngd");
+    debug!("RNGD path = {}", rngdpath);
+    let child = Command::new(rngdpath)
+                    .arg("-f")
+                    .arg("-r")
+                    .arg("/dev/urandom")
+                    .stdout(Stdio::null())
+                    .stderr(Stdio::null())
+                    .spawn()
+                    .unwrap_or_else(|e| panic!("failed to execute child: {}", e));
+    let droppable = DroppableChildProcess { child: child };
+    Ok(droppable)
 }
 
 /// generate a user key in gpg
 /// A user key requires a password and valid email address
 /// If the user key already exists in gpg, it will not be created.
 pub fn generate_user_key(config: &Config) -> BldrResult<()> {
-    let comment = USER_KEY_COMMENT.to_string();
-    let email = config.email().clone().unwrap();
-    let kn = gen_user_key_name(config.key());
-    let mut params = gpg::KeygenParams::new(kn, email, comment);
-    params.passphrase = config.password().clone();
-    params.expire_days = config.expire_days().unwrap_or(0);
-    try!(check_params(params.clone()));
-    try!(gpg::generate(params));
+    let _child = try!(run_rngd());
+    let email = config.email().as_ref().unwrap();
+    let keyname = gen_user_key_name(config.key());
+
+    let fingerprint = {
+        let mut params = gpg::KeygenParams::new(&keyname, &email, USER_KEY_COMMENT);
+        params.passphrase = config.password().as_ref();
+        params.expire_days = config.expire_days().unwrap_or(0);
+        try!(check_params(&params));
+        try!(gpg::generate(&params))
+    };
+
+    outputln!("Successfully generated user key {}",
+              Yellow.bold().paint(keyname));
+
+    outputln!("Fingerprint: {}", Yellow.bold().paint(fingerprint));
     Ok(())
 }
 
@@ -212,23 +373,29 @@ pub fn generate_user_key(config: &Config) -> BldrResult<()> {
 /// A service key has an email address automatically generated, in
 /// the form: `service.group@bldr`
 pub fn generate_service_key(config: &Config) -> BldrResult<()> {
-    let comment = SERVICE_KEY_COMMENT.to_string();
+    let _child = try!(run_rngd());
+    let comment = SERVICE_KEY_COMMENT;
     let kn = gen_service_key_name(config.key(), config.group());
     let ke = gen_service_key_email(config.key(), config.group());
-    let mut params = gpg::KeygenParams::new(kn, ke, comment);
-    params.passphrase = None;
-    params.expire_days = config.expire_days().unwrap_or(0);
-    try!(check_params(params.clone()));
-    try!(gpg::generate(params));
+    let fingerprint = {
+        let mut params = gpg::KeygenParams::new(&kn, &ke, comment);
+        params.passphrase = None;
+        params.expire_days = config.expire_days().unwrap_or(0);
+        try!(check_params(&params));
+        try!(gpg::generate(&params))
+    };
+
+    outputln!("Successfully generated service key {}",
+              Yellow.bold().paint(kn));
+    outputln!("Fingerprint: {}", Yellow.bold().paint(fingerprint));
     Ok(())
 }
-
 
 #[test]
 fn gen_key_check_params_test() {
     fn fail_if_err(keyname: &str, email: &str) {
-        let params = gpg::KeygenParams::new(keyname.to_string(), email.to_string(), "".to_string());
-        let results = check_params(params);
+        let params = gpg::KeygenParams::new(keyname, email, "");
+        let results = check_params(&params);
         match results {
             Ok(_) => assert!(true),
             Err(_) => assert!(false),
@@ -236,8 +403,8 @@ fn gen_key_check_params_test() {
     }
 
     fn fail_if_ok(keyname: &str, email: &str) {
-        let params = gpg::KeygenParams::new(keyname.to_string(), email.to_string(), "".to_string());
-        let results = check_params(params);
+        let params = gpg::KeygenParams::new(keyname, email, "");
+        let results = check_params(&params);
         match results {
             Ok(_) => assert!(false),
             Err(_) => assert!(true),
@@ -264,12 +431,24 @@ fn gen_service_key_email_test() {
 
 #[test]
 fn gen_service_key_name_test() {
-    assert_eq!("bldr: foobar.default",
+    assert_eq!("bldr_foobar.default",
                gen_service_key_name("foobar", "default"));
 }
 
 #[test]
+fn gen_service_key_name_test_normalized() {
+    assert_eq!("bldr_foobar.default",
+               gen_service_key_name("bldr_foobar.default", "default"));
+}
+
+#[test]
 fn gen_user_key_name_test() {
-    assert_eq!("bldr: foobar", gen_user_key_name("foobar"));
+    assert_eq!("bldr_foobar", gen_user_key_name("foobar"));
+
+}
+
+#[test]
+fn gen_user_key_name_test_normalized() {
+    assert_eq!("bldr_foobar", gen_user_key_name("bldr_foobar"));
 
 }

--- a/src/bldr/config.rs
+++ b/src/bldr/config.rs
@@ -23,11 +23,15 @@ pub enum Command {
     Install,
     Config,
     Start,
-    InstallKey,
-    UploadKey,
+    ImportKey,
+    ExportKey,
+    UploadRepoKey,
+    DownloadRepoKey,
     GenerateUserKey,
     GenerateServiceKey,
     ListKeys,
+    Encrypt,
+    Decrypt,
     Shell,
     Repo,
     Upload,
@@ -42,7 +46,7 @@ impl Default for Command {
 }
 
 /// Holds our configuration options.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct Config {
     command: Command,
     package: String,
@@ -61,6 +65,10 @@ pub struct Config {
     listen_addr: repo::ListenAddr,
     port: repo::ListenPort,
     gossip_listen: String,
+    userkey: Option<String>,
+    servicekey: Option<String>,
+    infile: Option<String>,
+    outfile: Option<String>,
 }
 
 impl Config {
@@ -111,6 +119,50 @@ impl Config {
     /// Return the email address
     pub fn email(&self) -> &Option<String> {
         &self.email
+    }
+
+    /// Set the user key
+    pub fn set_user_key(&mut self, userkey: String) -> &mut Config {
+        self.userkey = Some(userkey);
+        self
+    }
+
+    /// Return the user key
+    pub fn user_key(&self) -> &Option<String> {
+        &self.userkey
+    }
+
+    /// Set the service key
+    pub fn set_service_key(&mut self, set_servicekey: String) -> &mut Config {
+        self.servicekey = Some(set_servicekey);
+        self
+    }
+
+    /// Return the service key
+    pub fn service_key(&self) -> &Option<String> {
+        &self.servicekey
+    }
+
+    /// Set the input file to encrypt/decrypt
+    pub fn set_infile(&mut self, infile: String) -> &mut Config {
+        self.infile = Some(infile);
+        self
+    }
+
+    /// Return the input file to encrypt/decrypt
+    pub fn infile(&self) -> &Option<String> {
+        &self.infile
+    }
+
+    /// Set the input file to encrypt/decrypt
+    pub fn set_outfile(&mut self, outfile: String) -> &mut Config {
+        self.outfile = Some(outfile);
+        self
+    }
+
+    /// Return the input file to encrypt/decrypt
+    pub fn outfile(&self) -> &Option<String> {
+        &self.outfile
     }
 
     /// Set the package name

--- a/src/bldr/error.rs
+++ b/src/bldr/error.rs
@@ -255,7 +255,7 @@ impl fmt::Display for BldrError {
             }
             ErrorKind::MsgpackDecode(ref e) => format!("Msgpack decoding error: {:?}", e),
             ErrorKind::MsgpackEncode(ref e) => format!("Msgpack encoding error: {:?}", e),
-            ErrorKind::InvalidKeyParameter(ref e) => format!("Invalid parameter for key generation: {:?}", e),
+            ErrorKind::InvalidKeyParameter(ref e) => format!("Invalid key parameter: {:?}", e),
         };
         let cstring = Red.bold().paint(content).to_string();
         let mut so = StructuredOutput::new("bldr",

--- a/src/bldr/lib.rs
+++ b/src/bldr/lib.rs
@@ -56,6 +56,7 @@ extern crate uuid;
 extern crate utp;
 extern crate rmp;
 extern crate rmp_serialize as msgpack;
+extern crate rpassword;
 
 #[macro_export]
 /// Creates a new BldrError, embedding the current file name, line number, column, and module path.

--- a/src/bldr/repo/mod.rs
+++ b/src/bldr/repo/mod.rs
@@ -99,7 +99,9 @@ impl Repo {
     }
 }
 
+#[derive(Debug)]
 pub struct ListenAddr(pub net::Ipv4Addr);
+#[derive(Debug)]
 pub struct ListenPort(pub u16);
 
 impl Default for ListenAddr {

--- a/src/bldr/util/gpg.rs
+++ b/src/bldr/util/gpg.rs
@@ -5,16 +5,17 @@
 // is made available under an open source license such as the Apache 2.0 License.
 
 use std::fs::{self, File};
+use std::io;
+use std::io::Write;
+use std::env;
 use gpgme;
 use gpgme::ops;
-
 use fs::GPG_CACHE;
 use error::{BldrResult, BldrError, ErrorKind};
 use util::perm;
-use ansi_term::Colour::Blue;
 
 static LOGKEY: &'static str = "KEY";
-
+static BLDR_GPG_CACHE_ENV_VAR: &'static str = "BLDR_GPG_CACHE";
 
 static DEFAULT_KEY_TYPE: &'static str = "RSA";
 const DEFAULT_KEY_LENGTH: u16 = 2048;
@@ -22,22 +23,24 @@ const DEFAULT_KEY_LENGTH: u16 = 2048;
 static DEFAULT_SUBKEY_TYPE: &'static str = "RSA";
 const DEFAULT_SUBKEY_LENGTH: u16 = 2048;
 
-#[derive(Clone)]
-pub struct KeygenParams {
-    pub keyname: String,
-    pub email: String,
-    pub comment: String,
+static CACHE_DIR_PERMS: &'static str = "0700";
+
+#[derive(Clone, Debug)]
+pub struct KeygenParams<'a> {
+    pub keyname: &'a str,
+    pub email: &'a str,
+    pub comment: &'a str,
     pub expire_days: u16,
-    pub passphrase: Option<String>,
+    pub passphrase: Option<&'a String>,
     pub key_type: String,
     pub key_length: u16,
     pub subkey_type: String,
     pub subkey_length: u16,
 }
 
-impl KeygenParams {
-    /// Create a default `KeygenParams`
-    pub fn new(keyname: String, email: String, comment: String) -> KeygenParams {
+impl<'a> KeygenParams<'a> {
+    /// Create a `KeygenParams` with several values defaulted
+    pub fn new(keyname: &'a str, email: &'a str, comment: &'a str) -> KeygenParams<'a> {
         KeygenParams {
             keyname: keyname,
             email: email,
@@ -52,15 +55,15 @@ impl KeygenParams {
     }
 
     #[cfg_attr(rustfmt, rustfmt_skip)]
-    pub fn to_gpg_params_string(self) -> String {
-        let ptext = match self.passphrase {
+    pub fn to_gpg_params_string(&self) -> String {
+        let ptext = match self.passphrase.as_ref() {
             Some(p) => format!("Passphrase: {}", p),
             None => "".to_string(),
         };
 
     // NOTE: you can't pass Passphrase: with an empty string
     // so don't pass the string at all if a value doesn't exist
-        let s = format!("
+        format!("
                 <GnupgKeyParms format=\"internal\">
                     Key-Type: {key_type}
                     Key-Length: {key_length}
@@ -72,35 +75,56 @@ impl KeygenParams {
                     Expire-Date: {expire_date}
                     {passphrase_text}
                 </GnupgKeyParms>\n",
-                        key_type = self.key_type,
-                        key_length = self.key_length,
-                        subkey_type = self.subkey_type,
-                        subkey_length = self.subkey_length,
-                        name_real = self.keyname,
-                        name_comment = self.comment,
-                        name_email = self.email.clone(),
-                        expire_date = self.expire_days,
-                        passphrase_text = ptext);
-        s
+                key_type = self.key_type,
+                key_length = self.key_length,
+                subkey_type = self.subkey_type,
+                subkey_length = self.subkey_length,
+                name_real = self.keyname,
+                name_comment = self.comment,
+                name_email = self.email,
+                expire_date = self.expire_days,
+                passphrase_text = ptext)
     }
 }
 
+/// Use either the hardcoded bldr GPG path
+/// or use the value from BLDR_GPG_CACHE_ENV_VAR
+fn gpg_cache_dir() -> String {
+    let gpgcache = match env::var(BLDR_GPG_CACHE_ENV_VAR) {
+        Ok(val) => String::from(val),
+        Err(_) => String::from(GPG_CACHE),
+    };
+    debug!("GPG cache = {}", gpgcache);
+    gpgcache
+}
+
+/// Initialize the gpgme context w/ OpenPGP protocol and
+/// GPG cache directory (which may come from an env var)
 fn init_ctx() -> BldrResult<gpgme::Context> {
     let mut ctx = try!(gpgme::create_context());
-    try!(ctx.set_engine_info(gpgme::PROTOCOL_OPENPGP, None, Some(String::from(GPG_CACHE))));
+    try!(ctx.set_engine_info(gpgme::PROTOCOL_OPENPGP, None, Some(gpg_cache_dir())));
     Ok(ctx)
+}
+
+/// Create the GPG cache directory if it doesn't exist
+/// Set the permissions on the directory so the user has r/w/x only
+fn ensure_gpg_dir() -> BldrResult<()> {
+    try!(fs::create_dir_all(gpg_cache_dir()));
+    try!(perm::set_permissions(&gpg_cache_dir(), CACHE_DIR_PERMS));
+    Ok(())
 }
 
 pub fn decrypt<'a>(file: &str) -> BldrResult<gpgme::Data<'a>> {
     let mut ctx = try!(init_ctx());
+    try!(ensure_gpg_dir());
     let mut signature = {
         let f = match File::open(&file) {
             Ok(f) => f,
-            Err(_) => return Err(bldr_error!(ErrorKind::FileNotFound(String::from(file)))),
+            Err(e) => return Err(BldrError::from(e)),
         };
         match gpgme::Data::from_seekable_reader(f) {
             Ok(data) => data,
-            Err(_) => return Err(bldr_error!(ErrorKind::FileNotFound(String::from(file)))),
+            Err(wrapped_error) => return Err(BldrError::from(wrapped_error.error())),
         }
     };
     let mut out = try!(gpgme::Data::new());
@@ -108,19 +132,198 @@ pub fn decrypt<'a>(file: &str) -> BldrResult<gpgme::Data<'a>> {
     Ok(out)
 }
 
+/// encrypt and sign a file
+/// Encrypt uses a service public key and a user public key as recipients,
+/// message signing uses a **user** *private* key.
+pub fn encrypt_and_sign(userkey: &str,
+                        password: &str,
+                        servicekey: &str,
+                        infile: &str,
+                        outfile: &str)
+                        -> BldrResult<()> {
+    let mut ctx = try!(init_ctx());
+
+    let mut infiledata = {
+        let f = match File::open(&infile) {
+            Ok(f) => f,
+            Err(e) => return Err(BldrError::from(e)),
+        };
+        match gpgme::Data::from_seekable_reader(f) {
+            Ok(data) => data,
+            Err(wrapped_error) => return Err(BldrError::from(wrapped_error.error())),
+
+        }
+    };
+
+    debug!("Loading keys");
+    let ukey = try!(find_key(userkey));
+    //let ukey2 = try!(find_key(userkey));
+    let skey = try!(find_key(servicekey));
+
+    if let None = ukey {
+        return Err(bldr_error!(ErrorKind::InvalidKeyParameter(String::from("User key not found"))));
+    }
+    /*
+    if let None = ukey2 {
+        return Err(bldr_error!(ErrorKind::InvalidKeyParameter(String::from("User key not found"))));
+    }
+    */
+    if let None = skey {
+        return Err(bldr_error!(ErrorKind::InvalidKeyParameter(String::from("Service key not \
+                                                                            found"))));
+    }
+
+    let ukey = ukey.unwrap();
+    //let ukey2 = ukey2.unwrap();
+    let skey = skey.unwrap();
+
+    let recipients = vec![skey, ukey];
+    debug!("Keys loaded");
+
+    // generate text output, including BEGIN GPG MESSAGE / ENG GPG MESSAGE
+    ctx.set_armor(true);
+
+    // ensure we don't pick up any stragglers
+    ctx.clear_signers();
+
+    // user signs this key for a service
+    try!(ctx.add_signer(&recipients[1]));
+
+    // move the password to the heap for the closure below
+    let p = password.to_string();
+
+    // NOTE: with_passphase_cb will probably change it's parameter types
+    // in a future version of rust-gpgme
+    let mut guard = ctx.with_passphrase_cb(move |_: Option<&str>,
+                                                 _: Option<&str>,
+                                                 _,
+                                                 out: &mut io::Write| {
+        debug!("Using password '{}'", p.clone());
+        try!(out.write_all(p.as_bytes()));
+        Ok(())
+    });
+
+    // store the encrypted output here
+    let mut output = try!(gpgme::Data::new());
+
+    // NOTE: ENCRYPT_ALWAYS_TRUST is being used below,
+    // This assumes that any key in your GPG keystore is trusted.
+    // see also: https://www.gnupg.org/gph/en/manual/x334.html
+    try!(guard.encrypt_and_sign(&recipients,
+                                ops::ENCRYPT_ALWAYS_TRUST,
+                                &mut infiledata,
+                                &mut output));
+    try!(write_output(outfile, output));
+    Ok(())
+}
+
+/// Decrypt uses a service private key and a user public key to verify an encrypted message.
+///	A service OR a user should be able to decrypt bldr-encrypted a message.
+pub fn decrypt_and_verify(infile: &str, outfile: &str) -> BldrResult<()> {
+    let mut ctx = try!(init_ctx());
+    let mut infiledata = {
+        let f = match File::open(&infile) {
+            Ok(f) => f,
+            Err(e) => return Err(BldrError::from(e)),
+        };
+        match gpgme::Data::from_seekable_reader(f) {
+            Ok(data) => data,
+            Err(wrapped_error) => return Err(BldrError::from(wrapped_error.error())),
+        }
+    };
+    let mut output = try!(gpgme::Data::new());
+
+    match ctx.decrypt_and_verify(&mut infiledata, &mut output) {
+        Ok((decrypt_result, verify_result)) => {
+            debug!("Wrong key usage? {}", decrypt_result.wrong_key_usage());
+            debug!("unsupported_algorithm? {:?}",
+                   decrypt_result.unsupported_algorithm());
+            debug!("recipients? {:?}", decrypt_result.recipients());
+            debug!("filename? {:?}", decrypt_result.filename());
+            debug!("signatures? {:?}", verify_result.signatures());
+            debug!("filename? {:?}", verify_result.filename());
+        }
+        Err(e) => return Err(BldrError::from(e)),
+    };
+
+    try!(write_output(outfile, output));
+    Ok(())
+}
+
+/// Keep me, I'm useful for troubleshooting key import errors.
+fn debug_import_result(result: ops::ImportResult) {
+    for i in result.imports() {
+        debug!("Fingerprint: {}", i.fingerprint().unwrap_or("none"));
+        debug!("Error: {:?}", i.result().err());
+        let status = i.status();
+        if status.contains(ops::IMPORT_NEW) {
+            debug!("NEW");
+        }
+        if status.contains(ops::IMPORT_SECRET) {
+            debug!("SECRET");
+        }
+        if status.contains(ops::IMPORT_SIG) {
+            debug!("SIG");
+        }
+        if status.contains(ops::IMPORT_SUBKEY) {
+            debug!("SUBKEY");
+        }
+        if status.contains(ops::IMPORT_UID) {
+            debug!("UID");
+        }
+    }
+
+    debug!("Considered: {}", result.considered());
+    debug!("Imported: {}", result.imported());
+    debug!("Imported RSA: {}", result.imported_rsa());
+    debug!("Not imported: {}", result.not_imported());
+    debug!("Unchanged: {}", result.unchanged());
+
+    debug!("No user id: {}", result.no_user_id());
+
+    debug!("New user ids: {}", result.new_user_ids());
+    debug!("New subkeys: {}", result.new_subkeys());
+    debug!("New signatures: {}", result.new_signatures());
+    debug!("New revocations: {}", result.new_revocations());
+
+    debug!("Secret read: {}", result.secret_read());
+    debug!("Secret imported: {}", result.secret_imported());
+    debug!("Secret unchanged: {}", result.secret_unchanged());
+}
+
+/// Import a public key into the GPG cache
 pub fn import(keyfile: &str) -> BldrResult<()> {
-    try!(fs::create_dir_all(GPG_CACHE));
-    try!(perm::set_permissions(GPG_CACHE, "0700"));
+    try!(ensure_gpg_dir());
     let mut ctx = try!(init_ctx());
     let mut data = try!(gpgme::Data::load(&keyfile));
-    try!(data.set_encoding(gpgme::data::ENCODING_URL));
+    ctx.set_protocol(gpgme::PROTOCOL_OPENPGP).unwrap();
     match ctx.import(&mut data) {
-        Ok(_) => {
-            outputln!("{} GPG key imported", keyfile);
+        Ok(result) => {
+            debug_import_result(result);
             Ok(())
         }
         Err(e) => Err(BldrError::from(e)),
     }
+}
+
+/// Export a public key from the GPG cache.
+pub fn export(key: &str, outfile: &str) -> BldrResult<()> {
+    let mut ctx = try!(init_ctx());
+    let key_search = try!(find_key(&key));
+    if let None = key_search {
+        return Err(bldr_error!(ErrorKind::InvalidKeyParameter(String::from("Key not found"))));
+    }
+    let k = key_search.unwrap();
+    let keys = vec![k];
+    let mode = ops::ExportMode::empty();
+    let mut output = gpgme::Data::new().unwrap();
+    ctx.set_armor(true);
+    if let Err(e) = ctx.export_keys(&keys, mode, Some(&mut output)) {
+        return Err(BldrError::from(e));
+    };
+
+    try!(write_output(outfile, output));
+    Ok(())
 }
 
 pub fn verify<'a>(file: &str) -> BldrResult<gpgme::Data<'a>> {
@@ -133,7 +336,7 @@ pub fn verify<'a>(file: &str) -> BldrResult<gpgme::Data<'a>> {
         };
         match gpgme::Data::from_seekable_reader(f) {
             Ok(data) => data,
-            Err(_) => return Err(bldr_error!(ErrorKind::FileNotFound(String::from(file)))),
+            Err(wrapped_error) => return Err(BldrError::from(wrapped_error.error())),
         }
     };
 
@@ -144,12 +347,15 @@ pub fn verify<'a>(file: &str) -> BldrResult<gpgme::Data<'a>> {
     }
 }
 
-pub fn generate(params: KeygenParams) -> BldrResult<()> {
-    try!(fs::create_dir_all(GPG_CACHE));
-    try!(perm::set_permissions(GPG_CACHE, "0700"));
+/// Generate a key with the given params. It must not already exist
+/// in the GPG cache.
+/// `RUST_LOG=bldr=debug` is your friend for this one, as the `ctx.generate_key`
+/// function takes an ugly xml-ish string.
+pub fn generate(params: &KeygenParams) -> BldrResult<String> {
+    try!(ensure_gpg_dir());
 
-    let exists = try!(key_exists(&params.keyname));
-    if exists == true {
+    let k = try!(find_key(&params.keyname));
+    if k.is_some() {
         return Err(bldr_error!(ErrorKind::InvalidKeyParameter(String::from("Key already exists"))));
     }
 
@@ -158,59 +364,75 @@ pub fn generate(params: KeygenParams) -> BldrResult<()> {
     debug!("{}", s);
     // GnuPG does not support public and secret, they should be NULL.
     // https://www.gnupg.org/documentation/manuals/gpgme/Generating-Keys.html#Generating-Keys
-    match ctx.generate_key(s.clone(), None, None) {
+    match ctx.generate_key(s, None, None) {
         Ok(key_gen_result) => {
-            outputln!("Fingerprint: {}", Blue.bold().paint(key_gen_result.fingerprint().unwrap()));
-            Ok(())
+            match key_gen_result.fingerprint() {
+                Some(fp) => return Ok(fp.to_string()),
+                // Not sure why this would happen, but here it is!
+                None => Ok("No fingerprint".to_string()),
+            }
         }
-        Err(e) => {
-            outputln!("Error generating key {}", e);
-            Err(BldrError::from(e))
-        }
+        Err(e) => Err(BldrError::from(e)),
     }
 }
 
-pub fn key_exists(keyname: &str) -> BldrResult<bool> {
-    try!(fs::create_dir_all(GPG_CACHE));
-    try!(perm::set_permissions(GPG_CACHE, "0700"));
-
+/// Return the **first** key that contains the `keyname` **first** in it's list of users
+pub fn find_key(keyname: &str) -> BldrResult<Option<gpgme::keys::Key>> {
+    try!(ensure_gpg_dir());
     let mut ctx = try!(init_ctx());
     let mode = ops::KeyListMode::empty();
     ctx.set_key_list_mode(mode).unwrap();
-    let searchexp = vec![keyname];
-    // pull this out into it's own value,
-    // otherwise ctx doesn't live long enough
-    let keymatch = ctx.find_keys(searchexp);
-    match keymatch {
-        Ok(keys) => {
-            if keys.count() > 0 {
-                Ok(true)
-            } else {
-                Ok(false)
+    let mut keys = try!(ctx.keys());
+    // irritatingly nested
+    for key in keys.by_ref().filter_map(Result::ok) {
+        match key.user_ids().enumerate().next() {
+            Some((_, user)) => {
+                if let Some(n) = user.name() {
+                    if n == keyname {
+                        return Ok(Some(key.clone()));
+                    }
+                }
             }
-        }
-        Err(e) => {
-            Err(BldrError::from(e))
+            None => {}
         }
     }
+    Ok(None)
 }
 
+/// query all keys in the gpg cache and return a vec
+/// with a copy of each
 pub fn list() -> BldrResult<Vec<gpgme::keys::Key>> {
-    try!(fs::create_dir_all(GPG_CACHE));
-    try!(perm::set_permissions(GPG_CACHE, "0700"));
+    try!(ensure_gpg_dir());
     let mut ctx = try!(init_ctx());
 
     // https://www.gnupg.org/documentation/manuals/gpgme/Key-Listing-Mode.html#Key-Listing-Mode
-    let mode = ops::KeyListMode::empty();
-
+    let mut mode = ops::KeyListMode::empty();
+    // this is the default mode, but specify it anyways to be explicit
+    mode.insert(ops::KEY_LIST_MODE_LOCAL);
     ctx.set_key_list_mode(mode).unwrap();
 
     let mut allkeys = Vec::new();
     // get ALL keys
     let mut keys = ctx.keys().unwrap();
-
     for key in keys.by_ref().filter_map(Result::ok) {
         allkeys.push(key.clone());
     }
     Ok(allkeys)
+}
+
+/// write the output from a gpgme::Data object to a file
+fn write_output(outfile: &str, output: gpgme::Data) -> BldrResult<()> {
+    match output.into_string() {
+        Ok(o) => {
+            let mut f = try!(File::create(outfile));
+            try!(f.write_all(o.as_bytes()));
+        }
+        Err(e) => {
+            match e {
+                Some(utf8_error) => return Err(BldrError::from(utf8_error)),
+                None => panic!("File output error: {:?}", e),
+            }
+        }
+    }
+    Ok(())
 }

--- a/tests/bldr/key.rs
+++ b/tests/bldr/key.rs
@@ -4,18 +4,28 @@
 // this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
 // is made available under an open source license such as the Apache 2.0 License.
 
+extern crate uuid;
 use setup;
 use util::{self, command, docker};
+use uuid::Uuid;
+use std::env;
 
+/// kt_ = "key test"
 
-#[test]
-fn upload_a_key_and_install_it() {
+/// run all gpg tests in their own cache so they
+/// don't leave test certs behind etc
+fn gen_test_gpg_cache() -> String {
+    format!("/tmp/{}", Uuid::new_v4().to_simple_string())
+}
 
+#[ignore]
+#[test] // TODO
+fn kt_upload_a_key_and_install_it() {
     setup::gpg_import();
     setup::simple_service();
     let d = docker::repo("test/simple_service");
     let ipaddress = d.ipaddress();
-    let mut upload = command::bldr(&["upload-key",
+    let mut upload = command::bldr(&["upload-repo-key",
                                      &util::path::fixture_as_string("chef-public.gpg"),
                                      "-u",
                                      &format!("http://{}:9632", ipaddress)])
@@ -23,7 +33,8 @@ fn upload_a_key_and_install_it() {
     upload.wait_with_output();
     assert_cmd_exit_code!(upload, [0]);
     assert_regex!(upload.stdout(), r"Upload Bldr key (.+)");
-    let mut install = command::bldr(&["install-key",
+    let mut install = command::bldr(&["import-key",
+                                      "--infile",
                                       "chef-public.gpg",
                                       "-u",
                                       &format!("http://{}:9632", ipaddress)])
@@ -33,69 +44,22 @@ fn upload_a_key_and_install_it() {
 }
 
 
-#[test]
-fn generate_service_key() {
-    // also tests list-keys
-    extern crate uuid;
-    use uuid::Uuid;
-
-    setup::gpg_import();
-    let test_uuid = Uuid::new_v4().to_simple_string();
-    let mut generate = command::bldr(&["generate-service-key", &test_uuid]).unwrap();
-
-    generate.wait_with_output();
-    assert_cmd_exit_code!(generate, [0]);
-    assert_regex!(generate.stdout(), r".*Fingerprint.*");
-
-    // check to see if the key is in the output
-    let mut listkeys = command::bldr(&["list-keys"]).unwrap();
-    listkeys.wait_with_output();
-
-    let re_string = format!(".*{}.*", test_uuid);
-    assert_cmd_exit_code!(listkeys, [0]);
-    assert_regex!(listkeys.stdout(), &re_string);
-
+fn gpg_test_setup() -> String {
+    let gpg_cache = gen_test_gpg_cache();
+    setup::gpg_import_with_gpg_cache(&gpg_cache);
+    // leaving this in as it may be useful in future testing
+    // env::set_var("BLDR_GPG_CACHE", &gpg_cache);
+    gpg_cache
 }
 
 #[test]
-fn generate_service_key_with_expiration() {
+fn kt_generate_service_key() {
     // also tests list-keys
-    extern crate uuid;
-    use uuid::Uuid;
+    let gpg_cache = gpg_test_setup();
 
-    setup::gpg_import();
     let test_uuid = Uuid::new_v4().to_simple_string();
-    let mut generate = command::bldr(&["generate-service-key",
-                                       &test_uuid,
-                                       "--expire-days=10"]).unwrap();
-
-    generate.wait_with_output();
-    assert_cmd_exit_code!(generate, [0]);
-    assert_regex!(generate.stdout(), r".*Fingerprint.*");
-
-    // check to see if the key is in the output
-    let mut listkeys = command::bldr(&["list-keys"]).unwrap();
-    listkeys.wait_with_output();
-
-    let re_string = format!(".*{}.*", test_uuid);
-    assert_cmd_exit_code!(listkeys, [0]);
-    assert_regex!(listkeys.stdout(), &re_string);
-}
-
-
-
-#[test]
-fn generate_user_key() {
-    // also tests list-keys
-    extern crate uuid;
-    use uuid::Uuid;
-
-    setup::gpg_import();
-    let test_uuid = Uuid::new_v4().to_simple_string();
-    let mut generate = command::bldr(&["generate-user-key",
-                                       &test_uuid,
-                                       "password",
-                                       "email@bldrtest"])
+    let mut generate = command::bldr_with_test_gpg_cache(&["generate-service-key", &test_uuid],
+                                                         &gpg_cache)
                            .unwrap();
 
     generate.wait_with_output();
@@ -103,7 +67,99 @@ fn generate_user_key() {
     assert_regex!(generate.stdout(), r".*Fingerprint.*");
 
     // check to see if the key is in the output
-    let mut listkeys = command::bldr(&["list-keys"]).unwrap();
+    let mut listkeys = command::bldr_with_test_gpg_cache(&["list-keys"], &gpg_cache).unwrap();
+    listkeys.wait_with_output();
+
+    let re_string = format!(".*{}.*", test_uuid);
+    assert_cmd_exit_code!(listkeys, [0]);
+    assert_regex!(listkeys.stdout(), &re_string);
+}
+
+
+#[test]
+fn kt_generate_service_key_with_bldr_prefix() {
+    // also tests list-keys
+    let gpg_cache = gpg_test_setup();
+
+    let test_uuid = Uuid::new_v4().to_simple_string();
+    let test_uuid_with_prefix = "bldr_".to_string() + &test_uuid;
+
+    let mut generate = command::bldr_with_test_gpg_cache(&["generate-service-key", &test_uuid],
+                                                         &gpg_cache)
+                           .unwrap();
+
+    generate.wait_with_output();
+    assert_cmd_exit_code!(generate, [0]);
+
+    {
+        let re = format!(".*{}.*", test_uuid_with_prefix);
+        println!("Looking for \n{}\n", re);
+        assert_regex!(generate.stdout(), &re);
+    }
+
+    {
+        let re = format!(".*Successfully generated service key.*");
+        println!("Looking for \n{}\n", re);
+        assert_regex!(generate.stdout(), &re);
+    }
+
+
+
+    // check to see if the key is in the output
+    let mut listkeys = command::bldr_with_test_gpg_cache(&["list-keys"], &gpg_cache).unwrap();
+    listkeys.wait_with_output();
+
+    let re_string = format!(".*{}.*", test_uuid);
+    assert_cmd_exit_code!(listkeys, [0]);
+    assert_regex!(listkeys.stdout(), &re_string);
+}
+
+
+
+#[test]
+fn kt_generate_service_key_with_group() {
+
+    // pass in --group as "foobar123"
+    // also tests list-keys
+    let gpg_cache = gpg_test_setup();
+
+    let test_uuid = Uuid::new_v4().to_simple_string();
+    let mut generate = command::bldr_with_test_gpg_cache(&["generate-service-key",
+                                                           &test_uuid,
+                                                           "--group=foobar123"],
+                                                         &gpg_cache)
+                           .unwrap();
+
+    generate.wait_with_output();
+    assert_cmd_exit_code!(generate, [0]);
+    assert_regex!(generate.stdout(), r".*Fingerprint.*");
+
+    // check to see if the key is in the output
+    let mut listkeys = command::bldr_with_test_gpg_cache(&["list-keys"], &gpg_cache).unwrap();
+    listkeys.wait_with_output();
+    let re_string = format!(".*{}\\.foobar123.*", test_uuid);
+    assert_cmd_exit_code!(listkeys, [0]);
+    assert_regex!(listkeys.stdout(), &re_string);
+}
+
+
+#[test]
+fn kt_generate_service_key_with_expiration() {
+    // also tests list-keys
+    let gpg_cache = gpg_test_setup();
+    let test_uuid = Uuid::new_v4().to_simple_string();
+    let mut generate = command::bldr_with_test_gpg_cache(&["generate-service-key",
+                                                           &test_uuid,
+                                                           "--expire-days=10"],
+                                                         &gpg_cache)
+                           .unwrap();
+
+    generate.wait_with_output();
+    assert_cmd_exit_code!(generate, [0]);
+    assert_regex!(generate.stdout(), r".*Fingerprint.*");
+
+    // check to see if the key is in the output
+    let mut listkeys = command::bldr_with_test_gpg_cache(&["list-keys"], &gpg_cache).unwrap();
     listkeys.wait_with_output();
 
     let re_string = format!(".*{}.*", test_uuid);
@@ -112,18 +168,15 @@ fn generate_user_key() {
 }
 
 #[test]
-fn generate_user_key_with_expiration() {
+fn kt_generate_service_key_with_expiration_and_group() {
     // also tests list-keys
-    extern crate uuid;
-    use uuid::Uuid;
-
-    setup::gpg_import();
+    let gpg_cache = gpg_test_setup();
     let test_uuid = Uuid::new_v4().to_simple_string();
-    let mut generate = command::bldr(&["generate-user-key",
-                                       &test_uuid,
-                                       "password",
-                                       "email@bldrtest",
-                                       "--expire-days=10"])
+    let mut generate = command::bldr_with_test_gpg_cache(&["generate-service-key",
+                                                           &test_uuid,
+                                                           "--expire-days=10",
+                                                           "--group=foobar123"],
+                                                         &gpg_cache)
                            .unwrap();
 
     generate.wait_with_output();
@@ -131,10 +184,263 @@ fn generate_user_key_with_expiration() {
     assert_regex!(generate.stdout(), r".*Fingerprint.*");
 
     // check to see if the key is in the output
-    let mut listkeys = command::bldr(&["list-keys"]).unwrap();
+    let mut listkeys = command::bldr_with_test_gpg_cache(&["list-keys"], &gpg_cache).unwrap();
+    listkeys.wait_with_output();
+
+    let re_string = format!(".*{}\\.foobar123.*", test_uuid);
+    assert_cmd_exit_code!(listkeys, [0]);
+    assert_regex!(listkeys.stdout(), &re_string);
+}
+
+
+
+#[test]
+fn kt_generate_user_key() {
+    // also tests list-keys
+    let gpg_cache = gpg_test_setup();
+    let test_uuid = Uuid::new_v4().to_simple_string();
+    let mut generate = command::bldr_with_test_gpg_cache(&["generate-user-key",
+                                                           &test_uuid,
+                                                           "password",
+                                                           "email@bldrtest"],
+                                                         &gpg_cache)
+                           .unwrap();
+
+    generate.wait_with_output();
+    assert_cmd_exit_code!(generate, [0]);
+    assert_regex!(generate.stdout(), r".*Fingerprint.*");
+
+    // check to see if the key is in the output
+    let mut listkeys = command::bldr_with_test_gpg_cache(&["list-keys"], &gpg_cache).unwrap();
     listkeys.wait_with_output();
 
     let re_string = format!(".*{}.*", test_uuid);
     assert_cmd_exit_code!(listkeys, [0]);
     assert_regex!(listkeys.stdout(), &re_string);
+}
+
+#[test]
+fn kt_generate_user_key_with_expiration() {
+    // also tests list-keys
+    let gpg_cache = gpg_test_setup();
+    let test_uuid = Uuid::new_v4().to_simple_string();
+    let mut generate = command::bldr_with_test_gpg_cache(&["generate-user-key",
+                                                           &test_uuid,
+                                                           "password",
+                                                           "email@bldrtest",
+                                                           "--expire-days=10"],
+                                                         &gpg_cache)
+                           .unwrap();
+
+    generate.wait_with_output();
+    assert_cmd_exit_code!(generate, [0]);
+    assert_regex!(generate.stdout(), r".*Fingerprint.*");
+
+    // check to see if the key is in the output
+    let mut listkeys = command::bldr_with_test_gpg_cache(&["list-keys"], &gpg_cache).unwrap();
+    listkeys.wait_with_output();
+
+    let re_string = format!(".*{}.*", test_uuid);
+    assert_cmd_exit_code!(listkeys, [0]);
+    assert_regex!(listkeys.stdout(), &re_string);
+}
+
+#[test]
+fn kt_generate_user_key_with_bldr_prefix() {
+    // also tests list-keys
+    let gpg_cache = gpg_test_setup();
+    let test_uuid = Uuid::new_v4().to_simple_string();
+    let test_uuid_with_prefix = "bldr_".to_string() + &test_uuid;
+    let mut generate = command::bldr_with_test_gpg_cache(&["generate-user-key",
+                                                           &test_uuid_with_prefix,
+                                                           "password",
+                                                           "email@bldrtest",
+                                                           "--expire-days=10"],
+                                                         &gpg_cache)
+                           .unwrap();
+
+    generate.wait_with_output();
+    assert_cmd_exit_code!(generate, [0]);
+    {
+        let re = format!(".*{}.*", test_uuid_with_prefix);
+        println!("Looking for \n{}\n", re);
+        assert_regex!(generate.stdout(), &re);
+    }
+
+    {
+        let re = format!(".*Successfully generated user key.*");
+        println!("Looking for \n{}\n", re);
+        assert_regex!(generate.stdout(), &re);
+    }
+
+
+    // check to see if the key is in the output
+    let mut listkeys = command::bldr_with_test_gpg_cache(&["list-keys"], &gpg_cache).unwrap();
+    listkeys.wait_with_output();
+
+    let re_string = format!(".*{}.*", test_uuid);
+    assert_cmd_exit_code!(listkeys, [0]);
+    assert_regex!(listkeys.stdout(), &re_string);
+}
+
+
+fn mk_tmp_filename() -> String {
+    format!("/tmp/{}", Uuid::new_v4().to_simple_string())
+}
+
+
+
+#[test]
+fn kt_find_key() {
+    use bldr_lib::util::gpg;
+    let cache_dir = gen_test_gpg_cache();
+    // let cache_dir = "/opt/bldr/cache/gpg/";
+    {
+        // generate a test user
+        let mut generate_user = command::bldr_with_test_gpg_cache(&["generate-user-key",
+                                                                    "a",
+                                                                    "password",
+                                                                    "email@bldrtest",
+                                                                    "--expire-days=10"],
+                                                                  &cache_dir)
+                                    .unwrap();
+        generate_user.wait_with_output();
+        println!("{}", generate_user.stdout());
+        assert_cmd_exit_code!(generate_user, [0]);
+        assert_regex!(generate_user.stdout(), r".*Fingerprint.*");
+    }
+
+    {
+        // generate a test user
+        let mut generate_user = command::bldr_with_test_gpg_cache(&["generate-user-key",
+                                                                    "aa",
+                                                                    "password",
+                                                                    "email@bldrtest",
+                                                                    "--expire-days=10"],
+                                                                  &cache_dir)
+                                    .unwrap();
+        generate_user.wait_with_output();
+        println!("{}", generate_user.stdout());
+        assert_cmd_exit_code!(generate_user, [0]);
+        assert_regex!(generate_user.stdout(), r".*Fingerprint.*");
+    }
+
+    env::set_var("BLDR_GPG_CACHE", cache_dir);
+    match gpg::find_key("bldr_a") {
+        Ok(result) => {
+            let r = result.unwrap();
+            assert_eq!(1, r.user_ids().count());
+            let (_, user) = r.user_ids().enumerate().next().unwrap();
+            let name = user.name().unwrap();
+            assert_eq!("bldr_a", name);
+        }
+        Err(e) => panic!("FAIL {:?}", e),
+    };
+
+
+    match gpg::find_key("bldr_aa") {
+        Ok(result) => {
+            let r = result.unwrap();
+            assert_eq!(1, r.user_ids().count());
+            let (_, user) = r.user_ids().enumerate().next().unwrap();
+            let name = user.name().unwrap();
+            assert_eq!("bldr_aa", name);
+        }
+        Err(e) => panic!("FAIL {:?}", e),
+    };
+
+    match gpg::find_key("aaa") {
+        Ok(Some(_)) => assert!(false),
+        Ok(None) => assert!(true),
+        Err(_) => assert!(false),
+    };
+    env::remove_var("BLDR_GPG_CACHE");
+}
+
+#[test]
+fn kt_end_to_end() {
+    // test all encryption functions with the default group
+    test_gpg(None);
+}
+
+#[test]
+fn kt_end_to_end_with_group() {
+    // test all encryption functions with a group
+    test_gpg(Some("testgroup"));
+}
+
+fn test_gpg(group: Option<&str>) {
+    use std::io::prelude::*;
+    use std::fs::File;
+    use key_utils::*;
+    let file_to_encrypt = mk_tmp_filename();
+    let encrypted_file = mk_tmp_filename();
+    let decrypted_file = mk_tmp_filename();
+
+    let exported_user_key = mk_tmp_filename();
+    let exported_service_key = mk_tmp_filename();
+
+    println!("Plaintext file to encrypt: {}", file_to_encrypt);
+    println!("Encrypted output: {}", encrypted_file);
+    println!("Decrypted output: {}", decrypted_file);
+    println!("Exported user key: {}", exported_user_key);
+    println!("Exported service key: {}", exported_service_key);
+
+    let mut f = File::create(file_to_encrypt.clone()).unwrap();
+    let _res = f.write_all(b"Top secret data!\nTop secret data!!\n");
+
+    let gpg_cache_a = gen_test_gpg_cache();
+    let gpg_cache_b = gen_test_gpg_cache();
+    println!("GPG CACHE A = {}", gpg_cache_a);
+    println!("GPG CACHE B = {}", gpg_cache_b);
+
+    // make a user and a service in the default group
+    let (ua, sa) = make_user_and_service(&gpg_cache_a, group);
+    let (_ub, sb) = make_user_and_service(&gpg_cache_b, group);
+
+    // encrypt something that only GPG Cache A can decrypt
+    encrypt(&ua,
+            &sa,
+            &file_to_encrypt,
+            &encrypted_file,
+            &gpg_cache_a,
+            group);
+
+    // we can decrypt a message that we own all keys for
+    decrypt(&encrypted_file, &decrypted_file, &gpg_cache_a, 0);
+
+
+    // Can gpg_cache_b read the message, even though it's not
+    // the recipient? This should fail (return code 1), we
+    // encrypted as user ua, but we need sa's private key to
+    // decrypt (or ua's public key to verify)
+    decrypt(&encrypted_file, &decrypted_file, &gpg_cache_b, 1);
+
+    // export the service key from the B cache
+    export_service_key(&sb, &exported_service_key, &gpg_cache_b, group);
+
+    // export the user key from the A cache
+    export_user_key(&ua, &exported_user_key, &gpg_cache_a);
+
+    import(&exported_user_key, &gpg_cache_b);
+    let search_for_user = format!(".*{}.*", ua);
+    // do a list-keys and search for the user that was imported
+    list_keys(&gpg_cache_b, &search_for_user);
+
+    import(&exported_service_key, &gpg_cache_a);
+    let search_for_service = format!(".*{}.*", sb);
+    // do a list-leys and search for the service that was imported
+    list_keys(&gpg_cache_a, &search_for_service);
+
+    // encrypt a new message, this time using service B's public key
+    // which we have imported
+    encrypt(&ua,
+            &sb,
+            &file_to_encrypt,
+            &encrypted_file,
+            &gpg_cache_a,
+            group);
+
+    // returns 0 :-)
+    decrypt(&encrypted_file, &decrypted_file, &gpg_cache_b, 0);
 }


### PR DESCRIPTION
This PR implements or enhances all of these commands*:

```
bldr generate-user-key <key> <password> <email> [--expire-days=<expire_days>] [-vn]
bldr generate-service-key <key> [--expire-days=<expire_days>] [--group=<group>] [-vn]
bldr encrypt --user <userkey> --service <servicekey> --infile <infile> --outfile <outfile> [--password <password>] [--group=<group>] [-vn]
bldr decrypt --infile <infile> --outfile <outfile> [-vn]
bldr import-key (--infile <infile> | <key> --u <url>) [-vn]
bldr export-key (--user <userkey> | --service <servicekey>) --outfile <outfile> [--group=<group>] [-vn]
bldr download-repo-key <key> [-vn]
bldr upload-repo-key <key> -u <url> [-vn]
bldr list-keys [-vn]
```
- with the exception of download/upload, which have been renamed for clarity.

**Notes**:
- Encrypt uses a **service** _public_ key and a **user** _public_ key as recipients, message signing uses a **user** _private_ key.
  - Key trust is not implemented, and encryption uses the `ENCRYPT_ALWAYS_TRUST` [flag](https://www.gnupg.org/documentation/manuals/gpgme/Encrypting-a-Plaintext.html#Encrypting-a-Plaintext).
- Decrypt uses a **service** _private_ key and a **user** _public_ key to verify an encrypted message.
  - a service **OR** a user should be able to decrypt a message.
- If `--password` isn't specified to `encrypt`, then an echoless password prompt appears. We can talk about other ways to obtain a password in another PR (`~/.bldr/config`?)
- `import-key` and `export-key` only do public key IO, we can't export private keys.
- Key input/output functions have been refactored to take `--infile` and `--outfile`.
- rngd is started/stopped on demand to generate entropy for key generation
- `download-repo-key` / `upload-repo-key` need to be readdressed in a separate PR.
- Keys are generated with a `bldr_` prefix to distinguish them from any other key that is imported/exported into the GPG cache. Additionally, GPG has a 4 character minimum on key names, so having a common bldr prefix allows keys with >= 1 character. (Really, I just wanted to have a key named `foo`). ~~TODO: The only wrinkle here is that specifying a name on the CLI for a key should work with both normalized + non-normalized names (unless there are keys with normalized + non-normalized names that are the same).~~
- bldr will honor the `BLDR_GPG_CACHE` environment variable to point at a different GPG cache. This is primarily used for testing encrypt/decrypt/import/export.
- New dependency: [rpassword](https://github.com/conradkleinespel/rustastic-password) (MIT license) for echoless password entry

**TODO**:
- [x] implement colorized output
- [x] gpg module shouldn't display any output
- [x] ~~test Decrypt as user~~ Not possible, I need to be able to export private keys
- [x] list keys test
- [x] test service group params 
- [x] test user export
- [x] find_key should be an exact match
- [x] find_key should do an exact match using the _first_ name on a key
- [x] key tests need to be multi-GPG_CACHE aware so they don't litter the main gpg cache
- [x] normalize key names (did the user enter `bldr_foo` or `foo`?)
- [x] clone wars
## 

![skitch](https://cloud.githubusercontent.com/assets/58244/12597302/74eadae0-c452-11e5-9ba4-28526d7197b9.png)

![skitch-1](https://cloud.githubusercontent.com/assets/58244/12597310/7c2fe836-c452-11e5-9e26-3b31c8b6c6d3.png)
