### PR TITLE
[acceptance] Better logic for bldr src checkout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,9 @@ endif
 
 package: image
 ifeq ($(GITHUB_DEPLOY_KEY),)
-	$(run) package sh -c 'cd /src/plans; make world'
+	$(run) package sh -c '(cd /src/plans && make world)'
 else
-	$(run) package sh -c "mkdir -p ~/.ssh; echo \"$${GITHUB_DEPLOY_KEY}\" > ~/.ssh/id_rsa_bldr_github; chmod 0600 ~/.ssh/id_rsa_bldr_github; chmod +x /usr/local/bin/ssh_wrapper.sh; (cd / && GIT_SSH=/usr/local/bin/ssh_wrapper.sh git clone git@github.com:chef/bldr.git /src) && git checkout $(DELIVERY_GIT_SHASUM) && cd /src/plans; make world; ls -la /src /usr/local/bin"
+	$(run) package sh -c "mkdir -p ~/.ssh; echo \"$${GITHUB_DEPLOY_KEY}\" > ~/.ssh/id_rsa_bldr_github; chmod 0600 ~/.ssh/id_rsa_bldr_github; chmod +x /usr/local/bin/ssh_wrapper.sh; ([ ! -d /src/plans ] || (cd / && GIT_SSH=/usr/local/bin/ssh_wrapper.sh git clone git@github.com:chef/bldr.git /src)) && git checkout $(DELIVERY_GIT_SHASUM) && (cd /src/plans && make world)"
 endif
 
 clean-package: image


### PR DESCRIPTION
We want to check that if /src/plans doesn't exist, then cd to the root directory, clone the bldr repo to /src. If that succeeds, then check out the shasum for the delivery change, and if re on that commit, make all the plans. But do that in a subshell if we can cd into the plans directory.
