### PR TITLE
[bldr-build] Set `PATH` directly after resolving dependencies.

### DIFF
--- a/plans/bldr-build
+++ b/plans/bldr-build
@@ -351,13 +351,24 @@ _on_exit() {
     echo "Cleaning up Docker context $DOCKER_CONTEXT"
     rm -rf "$DOCKER_CONTEXT"
   fi
+  : ${pkg_name:=unknown}
+  elapsed=$SECONDS
+  elapsed=$(echo $elapsed | awk '{printf "%dm%ds", $1/60, $1%60}')
+  case "$TERM" in
+    *term | xterm-* | rxvt | screen | screen-*)
+      echo -e "   \033[1;36m${pkg_name}: \033[1;37mBuild time: $elapsed\033[0m"
+      ;;
+    *)
+      echo "   ${pkg_name}: Build time: $elapsed"
+      ;;
+  esac
   if [[ $exit_status -ne 0 ]]; then
     case "$TERM" in
       *term | xterm-* | rxvt | screen | screen-*)
-        echo -e "\033[1;31mExiting on error\033[0m"
+        echo -e "   \033[1;36m${pkg_name}: \033[1;31mExiting on error\033[0m"
         ;;
       *)
-        echo "Exiting on error"
+        echo "   ${pkg_name}: Exiting on error"
         ;;
     esac
   fi
@@ -1971,5 +1982,7 @@ build_line "Installed: $pkg_path"
 build_line "Package: $BLDR_PKG_CACHE/${pkg_derivation}-${pkg_name}-${pkg_version}-${pkg_rel}.bldr"
 
 # Exit cleanly
-build_line "$(basename $0) complete. I love it when a plan.sh comes together."
+build_line
+build_line "I love it when a plan.sh comes together."
+build_line
 _on_exit  0


### PR DESCRIPTION
## Set `PATH` directly after resolving dependencies.

This change changes the running order of operations in `bldr-build`
slightly to allow for more powerful "Plan upgrades" when setting up a
Plan execution to run with all of the right tools and libraries.

Prior to this change, the `PATH` was adjusted in the
`_build_environment()` phase which is after `do_download()`,
`do_verify()`, and `do_unpack()` have completed. If a Plan requires a
specific version of `wget` or perhaps a tool that can extract 7zip
archives, there is no way to install these these packages before they
are needed. This change sets the `PATH` after the `do_begin()` phase
(which is another oportunity to augment the `$pkg_deps` and
`$pkg_build_deps` arrays), and before `do_download()`.

Note that this affected the `_find_system_commands()` phase in that we
require a GNU version of the `sort` command for the `_latest_package()`
to function correctly. Consequently, an additional function,
`_find_initial_system_commands()`, was added to ensure that any initial
commands were present **before** (and in service of) the package
resolving phase.

---

Surprise! Bonus delighter!

![gif-keyboard-6163470006781291340](https://cloud.githubusercontent.com/assets/261548/12654990/eead5472-c5b3-11e5-91fc-c5e3ac318d6e.gif)
## Add build time in summary.

Not a large feature, but certainly a useful one--knowing how long a
build took in minutes and seconds. This turns out to be nightmarishly
hard to do in straight Shell/Bash without resorting to the `bc` command
for floating point math. Instead the simplest thing possible was used:
the `$SECONDS` environment variable present in every Bash shell, which
is the number of whole seconds since its process started. Combine this
with a bit of `awk` and we get something reminiscent of the "real" part
of the `time(1)` command. Not that this works even on build failure as
we are hooking into the `_on_exit()` trap function hook. Sweet, no?
