### PR TITLE
upgrade OpenSSL to 1.0.2f

### DIFF
--- a/plans/openssl/plan.sh
+++ b/plans/openssl/plan.sh
@@ -1,9 +1,9 @@
 pkg_name=openssl
 pkg_derivation=chef
-pkg_version=1.0.2e
+pkg_version=1.0.2f
 pkg_license=('BSD')
-pkg_source=https://www.openssl.org/source/openssl-1.0.2e.tar.gz
-pkg_shasum=e23ccafdb75cfcde782da0151731aa2185195ac745eea3846133f2e05c0e0bff
+pkg_source=https://www.openssl.org/source/openssl-1.0.2f.tar.gz
+pkg_shasum=932b4ee4def2b434f85435d9e3e19ca8ba99ce9a065a61524b429a9d5e9b2e9c
 pkg_gpg_key=3853DA6B
 pkg_deps=(chef/glibc chef/zlib chef/cacerts)
 pkg_binary_path=(bin)


### PR DESCRIPTION
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-0701
