### PR TITLE
configure rustfmt to not split strings at the end of a

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+format_strings = false


### PR DESCRIPTION
line
