### PR TITLE
re-add test attribute

### DIFF
--- a/tests/bldr/key.rs
+++ b/tests/bldr/key.rs
@@ -52,6 +52,7 @@ fn gpg_test_setup() -> String {
     gpg_cache
 }
 
+#[test]
 fn kt_generate_service_key() {
     // also tests list-keys
     let gpg_cache = gpg_test_setup();


### PR DESCRIPTION
I think this got nuked during rebase.

![gif-keyboard-17342814363504328500](https://cloud.githubusercontent.com/assets/58244/12664395/301476a4-c5fd-11e5-9101-b2b77149c310.gif)
