### PR TITLE
set a two hour timeout for making the world

### DIFF
--- a/.delivery/cookbooks/bldr/recipes/functional.rb
+++ b/.delivery/cookbooks/bldr/recipes/functional.rb
@@ -25,6 +25,8 @@ ssh_key = data_bag_item('delivery-secrets', 'chef-bldr-acceptance')['github']
 
 execute 'make clean package functional force=true' do
   cwd node['delivery']['workspace']['repo']
+  # set a two hour time out because this makes the world
+  timeout 7200
   environment(
     'GITHUB_DEPLOY_KEY' => ssh_key,
     'DELIVERY_GIT_SHASUM' => node['delivery']['change']['sha'],


### PR DESCRIPTION
The default timeout for execute resources is an hour. Let's make it two hours. This may need to increase as the world becomes larger.
