### PR TITLE
Isolated members find a way to ressurect

### DIFF
--- a/demo/gossip.txt
+++ b/demo/gossip.txt
@@ -1,0 +1,79 @@
+Four terminals
+pkg-shell each
+ifconfig in each
+
+Tab two
+Four terminals
+docker exec in each, mapping to the other tab
+ifconfig in each
+jq installed in each
+
+even network 4 and 6
+odd network 5 and 7
+
+Start 4
+env RUST_LOG=warn ./target/debug/bldr start chef/redis --gossip-permanent
+
+Start 5
+env RUST_LOG=warn ./target/debug/bldr start chef/redis --gossip-permanent --gossip-peer 172.17.0.4
+
+Start 6
+env RUST_LOG=warn ./target/debug/bldr start chef/redis --gossip-peer 172.17.0.4 --gossip-permanent
+
+Start 7
+env RUST_LOG=warn ./target/debug/bldr start chef/redis --gossip-peer 172.17.0.5 --gossip-permanent
+
+
+Show that they both saw each other as alive
+
+Show the gossip endpoint of the sidecar
+
+curl http://localhost:9631/gossip | jq .
+
+Show how we will show status
+
+curl http://localhost:9631/gossip | jq '.member_list.members | map({ip: .ip, health: .health})'
+
+Partition 4 from 5
+On 4
+iptables -A INPUT -s 172.17.0.5 -j DROP
+On 5
+iptables -A INPUT -s 172.17.0.4 -j DROP
+
+Show that.. they stay alive, because they can find a route to each other
+through 6 and 7
+
+Heal the partition
+On 4
+iptables -D INPUT -s 172.17.0.5 -j DROP
+On 5
+iptables -D INPUT -s 172.17.0.4 -j DROP
+
+
+
+Partition 4 and 6 from 5 and 7
+
+On 4 and 6
+iptables -A INPUT -s 172.17.0.5 -j DROP
+iptables -A INPUT -s 172.17.0.7 -j DROP
+
+On 5 and 7
+iptables -A INPUT -s 172.17.0.4 -j DROP
+iptables -A INPUT -s 172.17.0.6 -j DROP
+
+Show the status on both sides
+
+curl http://localhost:9631/gossip | jq '.member_list.members | map({ip: .ip, health: .health})'
+
+Describe the alzheimers problem
+
+Heal the partition
+
+On 4 + 6
+iptables -D INPUT -s 172.17.0.5 -j DROP
+iptables -D INPUT -s 172.17.0.7 -j DROP
+
+On 5 + 7
+iptables -D INPUT -s 172.17.0.4 -j DROP
+iptables -D INPUT -s 172.17.0.6 -j DROP
+

--- a/src/bldr/gossip/server.rs
+++ b/src/bldr/gossip/server.rs
@@ -435,8 +435,11 @@ pub fn outbound(my_peer: Peer,
             continue;
         }
 
-        // You can skip dead members, unless they are permanent
-        if member.health == Health::Confirmed && !member.permanent {
+        // You can skip dead members, unless they are permanent, or you are isolated
+        let isolated = {
+            member_list.read().unwrap().isolated(&my_peer.member_id)
+        };
+        if member.health == Health::Confirmed && !member.permanent && !isolated {
             continue;
         }
 


### PR DESCRIPTION
It's possible under many partitioning scenarios that a given node can
find itself completely isolated - it detects all the other members as
down, and it cannot reach another permanent member.

Since an entirely new supervisor always generates an entirely new ID, we
can tell the difference between a supervisor who was gone and came back,
and a supervisor that is new to the ring.

Therefore, if we get completely isolated, we want to get a little
aggressive about trying to find a peer who we can communicate our
alive-ness with. This commit makes it so that if you find yourself
completely isolated, you start sending pings again to all your Confirmed
dead peers.

After the first member responds, you stop treating confirmed dead
members as dead - assuming the rest of the gossip protocol will work out
for you who is actually alive, and who is actually dead.

Live Long and Prosper \//

![gif-keyboard-4738754057678504660](https://cloud.githubusercontent.com/assets/4304/12690433/519b93d4-c698-11e5-8333-afe329028221.gif)
