### PR TITLE
Work around a rust perf regression

### DIFF
--- a/plans/bldr/plan.sh
+++ b/plans/bldr/plan.sh
@@ -19,7 +19,7 @@ do_begin() {
 	gpg --homedir /opt/bldr/cache/gpg --import chef-private.gpg || true
 	pushd ../../
 	tar -cjvf $BLDR_SRC_CACHE/${pkg_name}-${pkg_version}.tar.bz2 \
-		--exclude 'plans' --exclude 'bldr-plan' --exclude 'demo' --exclude 'images' \
+		--exclude 'plans' --exclude 'bldr-plan' --exclude 'demo' --exclude 'images' --exclude 'web' \
 		--exclude '.git' --exclude '.gitignore' --exclude 'target' --exclude '.delivery' \
 		--transform "s,^\.,bldr-$pkg_version," .
 	popd
@@ -41,15 +41,15 @@ do_build() {
       GPG_ERROR_CONFIG=$(pkg_path_for chef/libgpg-error)/bin/gpg-error-config \
       LIBARCHIVE_LIB_DIR=$(pkg_path_for chef/libarchive)/lib \
       LIBARCHIVE_INCLUDE_DIR=$(pkg_path_for chef/libarchive)/include \
-      cargo build --release
+      cargo build
   # Make double-sure our binary is completely pure (no accidental linking leaks
   # outside `/opt/bldr/pkgs`)
-  patchelf --set-rpath "$LD_RUN_PATH" target/release/bldr
+  patchelf --set-rpath "$LD_RUN_PATH" target/debug/bldr
 }
 
 do_install() {
 	mkdir -p $pkg_path/bin
-	cp target/release/bldr $pkg_path/bin
+	cp target/debug/bldr $pkg_path/bin
 	# if [[ -f "$BLDR_BIN" ]]; then
 	# 	$BLDR_BIN key chef-public -u $BLDR_REPO
 	# 	$BLDR_BIN install chef/cacerts -u $BLDR_REPO


### PR DESCRIPTION
![gif-keyboard-7265911640631772084](https://cloud.githubusercontent.com/assets/4304/12703642/f4a77ef2-c7fc-11e5-8e57-5b81bf7705cb.gif)

The rust compiler has a performance regression where it is no longer
re-using it's cache for complex type boundaries. The side effect is our
release builds can take up to 20+ minutes to complete.

While the same regression exists in debug mode, it's far less damaging.
So this PR has us shipping debug builds for now. This wouldn't be a
choice if we were in production anyplace - it would cause a universal
performance regression for every bldr customer. Since we aren't, this is
the easiest way out, while we wait for rust 1.7.

Love,
Adam
