### PR TITLE
[acceptance] double royale with cheese instance

### DIFF
--- a/.delivery/cookbooks/bldr/recipes/functional.rb
+++ b/.delivery/cookbooks/bldr/recipes/functional.rb
@@ -23,9 +23,16 @@ docker_machine_config = BldrDockerMachine.load_config
 
 ssh_key = data_bag_item('delivery-secrets', 'chef-bldr-acceptance')['github']
 
-execute 'make clean package functional force=true' do
+makelog = ::File.join(Chef::Config[:file_cache_path],
+                      'make-functional.out')
+
+# warn level because we use doc formatter and this won't be displayed
+# otherwise :)
+Chef::Log.warn("`make` will log output to #{makelog}")
+
+execute "make clean package functional force=true 2>&1 | tee #{makelog}" do
   cwd node['delivery']['workspace']['repo']
-  # set a two hour time out because this makes the world
+  # set a two hour time out because this compiles :allthethings:
   timeout 7200
   environment(
     'GITHUB_DEPLOY_KEY' => ssh_key,

--- a/.delivery/cookbooks/bldr/recipes/provision.rb
+++ b/.delivery/cookbooks/bldr/recipes/provision.rb
@@ -23,7 +23,7 @@ execute 'bldr-docker-machine' do
     docker-machine create -d amazonec2 \
       --amazonec2-vpc-id vpc-2229ff47 \
       --amazonec2-region us-west-2 \
-      --amazonec2-instance-type m3.medium \
+      --amazonec2-instance-type c3.xlarge \
       --amazonec2-private-address-only \
       bldr-docker-machine
   EOH

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,6 @@ NO_CACHE := false
 
 all: package
 
-
-
 package: image
 ifeq ($(GITHUB_DEPLOY_KEY),)
 	$(run) package sh -c '(cd /src/plans && make bldr-deps)'


### PR DESCRIPTION
The build times take way too long on an m3.medium, and we run out of disk space fast. Let's embiggen this to a metric instance.

Also write the output from make to a file in the repo dir because we're losing output from mixlib/shellout for some reason.
