### PR TITLE
replace docopt with clap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,7 +3,7 @@ name = "bldr"
 version = "0.3.0"
 dependencies = [
  "ansi_term 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "docopt 0.6.78 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "gpgme 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -61,6 +61,22 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "bitflags"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "clap"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ansi_term 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vec_map 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "conduit-mime-types"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -77,16 +93,6 @@ dependencies = [
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "docopt"
-version = "0.6.78"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "regex 0.1.48 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "strsim 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -491,7 +497,7 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -628,6 +634,11 @@ dependencies = [
  "rand 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "vec_map"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ doc = false
 name = "functional"
 
 [dependencies]
-docopt = "*"
 rustc-serialize = "*"
 log = "*"
 env_logger = "*"
@@ -47,6 +46,9 @@ branch = "fallback_on_missing_extension"
 
 [dependencies.libarchive]
 path = "./vendor/libarchive-rust"
+
+[dependencies.clap]
+features = [ "suggestions", "color" ]
 
 [profile.release]
 lto = true

--- a/src/bldr/command/key.rs
+++ b/src/bldr/command/key.rs
@@ -351,7 +351,9 @@ fn run_rngd() -> BldrResult<DroppableChildProcess> {
 pub fn generate_user_key(config: &Config) -> BldrResult<()> {
     let _child = try!(run_rngd());
     let email = config.email().as_ref().unwrap();
-    let keyname = gen_user_key_name(config.key());
+    // clap requires user_key to be specified for generate
+    let user_key = config.user_key().as_ref().unwrap();
+    let keyname = gen_user_key_name(user_key);
 
     let fingerprint = {
         let mut params = gpg::KeygenParams::new(&keyname, &email, USER_KEY_COMMENT);
@@ -375,8 +377,10 @@ pub fn generate_user_key(config: &Config) -> BldrResult<()> {
 pub fn generate_service_key(config: &Config) -> BldrResult<()> {
     let _child = try!(run_rngd());
     let comment = SERVICE_KEY_COMMENT;
-    let kn = gen_service_key_name(config.key(), config.group());
-    let ke = gen_service_key_email(config.key(), config.group());
+    // clap requires service_key to be specified
+    let service_key = config.service_key().as_ref().unwrap();
+    let kn = gen_service_key_name(service_key, config.group());
+    let ke = gen_service_key_email(service_key, config.group());
     let fingerprint = {
         let mut params = gpg::KeygenParams::new(&kn, &ke, comment);
         params.passphrase = None;

--- a/src/bldr/config.rs
+++ b/src/bldr/config.rs
@@ -13,10 +13,13 @@
 //! See the [Config](struct.Config.html) struct for the specific options available.
 
 use std::net;
-
 use gossip::server::GOSSIP_DEFAULT_PORT;
 use topology::Topology;
 use repo;
+use std::str::FromStr;
+use error::{BldrResult, BldrError, ErrorKind};
+
+static LOGKEY: &'static str = "CFG";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 /// An enum with the various CLI commands. Used to keep track of what command was called.
@@ -37,6 +40,32 @@ pub enum Command {
     Repo,
     Upload,
     Configuration,
+}
+
+
+impl FromStr for Command {
+    type Err = BldrError;
+    fn from_str(s: &str) -> Result<Command, BldrError> {
+        match s {
+        "bash" => Ok(Command::Shell),
+        "config" => Ok(Command::Config),
+        "decrypt" => Ok(Command::Decrypt),
+        "depot" => Ok(Command::Repo),
+        "download-depot-key" => Ok(Command::DownloadRepoKey),
+        "encrypt" => Ok(Command::Encrypt),
+        "export-key" => Ok(Command::ExportKey),
+        "generate-service-key" => Ok(Command::GenerateServiceKey),
+        "generate-user-key" => Ok(Command::GenerateUserKey),
+        "import-key" => Ok(Command::ImportKey),
+        "install" => Ok(Command::Install),
+        "list-keys" => Ok(Command::ListKeys),
+        "sh" => Ok(Command::Shell),
+        "start" => Ok(Command::Start),
+        "upload-depot-key" => Ok(Command::UploadRepoKey),
+        "upload" => Ok(Command::Upload),
+            _ => Err(bldr_error!(ErrorKind::CommandNotImplemented))
+        }
+    }
 }
 
 // We provide a default command primarily so the Config struct can have sane defaults.

--- a/tests/bldr/key.rs
+++ b/tests/bldr/key.rs
@@ -58,7 +58,8 @@ fn kt_generate_service_key() {
     let gpg_cache = gpg_test_setup();
 
     let test_uuid = Uuid::new_v4().to_simple_string();
-    let mut generate = command::bldr_with_test_gpg_cache(&["generate-service-key", &test_uuid],
+    let mut generate = command::bldr_with_test_gpg_cache(&["generate-service-key",
+                                                           &test_uuid],
                                                          &gpg_cache)
                            .unwrap();
 
@@ -84,7 +85,8 @@ fn kt_generate_service_key_with_bldr_prefix() {
     let test_uuid = Uuid::new_v4().to_simple_string();
     let test_uuid_with_prefix = "bldr_".to_string() + &test_uuid;
 
-    let mut generate = command::bldr_with_test_gpg_cache(&["generate-service-key", &test_uuid],
+    let mut generate = command::bldr_with_test_gpg_cache(&["generate-service-key",
+                                                           &test_uuid],
                                                          &gpg_cache)
                            .unwrap();
 
@@ -199,8 +201,11 @@ fn kt_generate_user_key() {
     let gpg_cache = gpg_test_setup();
     let test_uuid = Uuid::new_v4().to_simple_string();
     let mut generate = command::bldr_with_test_gpg_cache(&["generate-user-key",
+                                                           "--user",
                                                            &test_uuid,
+                                                           "--password",
                                                            "password",
+                                                           "--email",
                                                            "email@bldrtest"],
                                                          &gpg_cache)
                            .unwrap();
@@ -224,8 +229,11 @@ fn kt_generate_user_key_with_expiration() {
     let gpg_cache = gpg_test_setup();
     let test_uuid = Uuid::new_v4().to_simple_string();
     let mut generate = command::bldr_with_test_gpg_cache(&["generate-user-key",
+                                                           "--user",
                                                            &test_uuid,
+                                                           "--password",
                                                            "password",
+                                                           "--email",
                                                            "email@bldrtest",
                                                            "--expire-days=10"],
                                                          &gpg_cache)
@@ -251,8 +259,11 @@ fn kt_generate_user_key_with_bldr_prefix() {
     let test_uuid = Uuid::new_v4().to_simple_string();
     let test_uuid_with_prefix = "bldr_".to_string() + &test_uuid;
     let mut generate = command::bldr_with_test_gpg_cache(&["generate-user-key",
+                                                           "--user",
                                                            &test_uuid_with_prefix,
+                                                           "--password",
                                                            "password",
+                                                           "--email",
                                                            "email@bldrtest",
                                                            "--expire-days=10"],
                                                          &gpg_cache)
@@ -297,8 +308,11 @@ fn kt_find_key() {
     {
         // generate a test user
         let mut generate_user = command::bldr_with_test_gpg_cache(&["generate-user-key",
+                                                                    "--user",
                                                                     "a",
+                                                                    "--password",
                                                                     "password",
+                                                                    "--email",
                                                                     "email@bldrtest",
                                                                     "--expire-days=10"],
                                                                   &cache_dir)
@@ -312,8 +326,11 @@ fn kt_find_key() {
     {
         // generate a test user
         let mut generate_user = command::bldr_with_test_gpg_cache(&["generate-user-key",
+                                                                    "--user",
                                                                     "aa",
+                                                                    "--password",
                                                                     "password",
+                                                                    "--email",
                                                                     "email@bldrtest",
                                                                     "--expire-days=10"],
                                                                   &cache_dir)

--- a/tests/functional.rs
+++ b/tests/functional.rs
@@ -28,8 +28,7 @@ mod setup {
         ONCE.call_once(|| {
             let mut gpg = match util::command::run("gpg",
                                                    &["--import",
-                                                   &util::path::fixture_as_string("chef-pri\
-                                                                                  vate.gpg")]) {
+                                                   &util::path::fixture_as_string("chef-private.gpg")]) {
                                                        Ok(cmd) => cmd,
                                                        Err(e) => panic!("{:?}", e),
         };
@@ -47,8 +46,7 @@ mod setup {
             let mut gpg =
                 match util::command::run_with_env("gpg",
                                                   &["--import",
-                                                  &util::path::fixture_as_string("chef-priv\
-                                                                                 ate.gpg")],
+                                                  &util::path::fixture_as_string("chef-private.gpg")],
                                                                                  &env) {
                     Ok(cmd) => cmd,
                     Err(e) => panic!("{:?}", e),
@@ -63,19 +61,19 @@ mod setup {
         ONCE.call_once(|| {
             let tempdir = TempDir::new("simple_service").unwrap();
             let mut copy_cmd = Command::new("cp")
-                .arg("-r")
-                .arg(util::path::fixture("simple_service"))
-                .arg(tempdir.path().to_str().unwrap())
-                .spawn()
-                .unwrap();
+                                   .arg("-r")
+                                   .arg(util::path::fixture("simple_service"))
+                                   .arg(tempdir.path().to_str().unwrap())
+                                   .spawn()
+                                   .unwrap();
             copy_cmd.wait().unwrap();
 
-            let mut simple_service = match util::command::bldr_build(tempdir.path()
-                                                                            .join("simple_serv\
-                                                                                   ice")) {
-                Ok(cmd) => cmd,
-                Err(e) => panic!("{:?}", e),
-            };
+            let mut simple_service =
+                match util::command::bldr_build(tempdir.path()
+                                                       .join("simple_service")) {
+                    Ok(cmd) => cmd,
+                    Err(e) => panic!("{:?}", e),
+                };
             simple_service.wait_with_output();
             if !simple_service.status.unwrap().success() {
                 panic!("Failed to build simple service: stdout: {:?}\nstderr: {:?}",
@@ -97,12 +95,12 @@ mod setup {
                                    .unwrap();
             copy_cmd.wait().unwrap();
 
-            let mut simple_service = match util::command::bldr_build(tempdir.path()
-                                                                            .join("simple_serv\
-                                                                                   ice_gossip")) {
-                Ok(cmd) => cmd,
-                Err(e) => panic!("{:?}", e),
-            };
+            let mut simple_service =
+                match util::command::bldr_build(tempdir.path()
+                                                       .join("simple_service_gossip")) {
+                    Ok(cmd) => cmd,
+                    Err(e) => panic!("{:?}", e),
+                };
             simple_service.wait_with_output();
             if !simple_service.status.unwrap().success() {
                 panic!("Failed to build simple service for gossip: stdout: {:?}\nstderr: {:?}",
@@ -142,9 +140,7 @@ mod setup {
         static ONCE: Once = ONCE_INIT;
         ONCE.call_once(|| {
             let mut cmd = match util::command::bldr(&["key",
-                                                    &util::path::fixture_as_string("chef-pu\
-                                                                                   blic.as\
-                                                                                      c")]) {
+                                                    &util::path::fixture_as_string("chef-public.asc")]) {
                                                         Ok(cmd) => cmd,
                                                         Err(e) => panic!("{:?}", e),
         };
@@ -249,21 +245,21 @@ mod key_utils {
         let mut export = match group {
             Some(g) => {
                 command::bldr_with_test_gpg_cache(&["export-key",
-                                                  "--service",
-                                                  &key,
-                                                  "--outfile",
-                                                  &outfile,
-                                                  "--group",
-                                                  &g],
+                                                    "--service",
+                                                    &key,
+                                                    "--outfile",
+                                                    &outfile,
+                                                    "--group",
+                                                    &g],
                                                   &cache)
                     .unwrap()
             }
             None => {
                 command::bldr_with_test_gpg_cache(&["export-key",
-                                                  "--service",
-                                                  &key,
-                                                  "--outfile",
-                                                  &outfile],
+                                                    "--service",
+                                                    &key,
+                                                    "--outfile",
+                                                    &outfile],
                                                   &cache)
                     .unwrap()
             }
@@ -276,12 +272,12 @@ mod key_utils {
 
     pub fn export_user_key(key: &str, outfile: &str, cache: &str) {
         let mut export = command::bldr_with_test_gpg_cache(&["export-key",
-                                                           "--user",
-                                                           &key,
-                                                           "--outfile",
-                                                           &outfile],
+                                                             "--user",
+                                                             &key,
+                                                             "--outfile",
+                                                             &outfile],
                                                            &cache)
-            .unwrap();
+                             .unwrap();
         export.wait_with_output();
         assert_cmd_exit_code!(export, [0]);
         println!("{}", export.stdout());
@@ -289,10 +285,10 @@ mod key_utils {
 
     pub fn import(exported_user_key: &str, cache: &str) {
         let mut import = command::bldr_with_test_gpg_cache(&["import-key",
-                                                           "--infile",
-                                                           &exported_user_key],
+                                                             "--infile",
+                                                             &exported_user_key],
                                                            &cache)
-            .unwrap();
+                             .unwrap();
         import.wait_with_output();
         assert_cmd_exit_code!(import, [0]);
         println!("{}", import.stdout());
@@ -308,33 +304,33 @@ mod key_utils {
         let mut encrypt = match group {
             Some(g) => {
                 command::bldr_with_test_gpg_cache(&["encrypt",
-                                                  "--user",
-                                                  &user,
-                                                  "--service",
-                                                  &service,
-                                                  "--infile",
-                                                  &file_to_encrypt,
-                                                  "--outfile",
-                                                  &encrypted_file,
-                                                  "--password",
-                                                  "password",
-                                                  "--group",
-                                                  g],
+                                                    "--user",
+                                                    &user,
+                                                    "--service",
+                                                    &service,
+                                                    "--infile",
+                                                    &file_to_encrypt,
+                                                    "--outfile",
+                                                    &encrypted_file,
+                                                    "--password",
+                                                    "password",
+                                                    "--group",
+                                                    g],
                                                   &cache)
                     .unwrap()
             }
             None => {
                 command::bldr_with_test_gpg_cache(&["encrypt",
-                                                  "--user",
-                                                  &user,
-                                                  "--service",
-                                                  &service,
-                                                  "--infile",
-                                                  &file_to_encrypt,
-                                                  "--outfile",
-                                                  &encrypted_file,
-                                                  "--password",
-                                                  "password"],
+                                                    "--user",
+                                                    &user,
+                                                    "--service",
+                                                    &service,
+                                                    "--infile",
+                                                    &file_to_encrypt,
+                                                    "--outfile",
+                                                    &encrypted_file,
+                                                    "--password",
+                                                    "password"],
                                                   &cache)
                     .unwrap()
             }
@@ -350,12 +346,12 @@ mod key_utils {
     pub fn decrypt(encrypted_file: &str, decrypted_file: &str, cache: &str, expected_status: i32) {
         // try to decrypt a file that's not meant for me
         let mut decrypt = command::bldr_with_test_gpg_cache(&["decrypt",
-                                                            "--infile",
-                                                            &encrypted_file,
-                                                            "--outfile",
-                                                            &decrypted_file],
+                                                              "--infile",
+                                                              &encrypted_file,
+                                                              "--outfile",
+                                                              &decrypted_file],
                                                             &cache)
-            .unwrap();
+                              .unwrap();
         decrypt.wait_with_output();
         println!("{}", decrypt.stdout());
         assert_cmd_exit_code!(decrypt, [expected_status]);
@@ -375,12 +371,15 @@ mod key_utils {
 
         // generate a test user
         let mut generate_user = command::bldr_with_test_gpg_cache(&["generate-user-key",
-                                                                  &user_uuid,
-                                                                  "password",
-                                                                  "email@bldrtest",
-                                                                  "--expire-days=10"],
+                                                                    "--user",
+                                                                    &user_uuid,
+                                                                    "--password",
+                                                                    "password",
+                                                                    "--email",
+                                                                    "email@bldrtest",
+                                                                    "--expire-days=10"],
                                                                   cache_dir)
-            .unwrap();
+                                    .unwrap();
         generate_user.wait_with_output();
         println!("{}", generate_user.stdout());
         assert_cmd_exit_code!(generate_user, [0]);
@@ -389,14 +388,15 @@ mod key_utils {
         let mut generate_service = match group {
             Some(g) => {
                 command::bldr_with_test_gpg_cache(&["generate-service-key",
-                                                  &service_uuid,
-                                                  "--group",
-                                                  &g],
+                                                    &service_uuid,
+                                                    "--group",
+                                                    &g],
                                                   cache_dir)
                     .unwrap()
             }
             None => {
-                command::bldr_with_test_gpg_cache(&["generate-service-key", &service_uuid],
+                command::bldr_with_test_gpg_cache(&["generate-service-key",
+                                                    &service_uuid],
                                                   cache_dir)
                     .unwrap()
             }

--- a/tests/util/command.rs
+++ b/tests/util/command.rs
@@ -115,6 +115,22 @@ pub fn command_with_env(cmd: &str, args: &[&str], env: Option<&HashMap<&str, &st
              cmd,
              args,
              env);
+
+    let envstr = match env {
+        Some(es) => {
+            let mut s = String::new();
+            for (k, v) in es {
+                s.push_str(&format!("{}={} ", k, v));
+            }
+            s
+        }
+        None => "".to_string(),
+    };
+
+    let argsstr = args.join(" ");
+    // copy and paste commands to run in your terminal. You're welcome.
+    println!(">>>>\n\t\t {} {} {}\n<<<<", envstr, cmd, argsstr);
+
     let mut command = Command::new(cmd);
     command.args(args);
     command.stdin(Stdio::null());


### PR DESCRIPTION
- `repo` has been replaced with `depot` where it's visible to a user
- `Command` structs can be obtained via `FromStr`
- [This](https://github.com/chef/bldr/blob/996fba30381064bbe57d7222993f507b3e262174/src/main.rs#L223-L310) has been replaced with a simple match on subcommand that returns a `Handler` fn pointer. This allows for the removal of repetitive code shared between every command.
- default cli values are explicitly stored as constants (`DEFAULT_GOSSIP_LISTEN` etc)
- The monster clap setup function chain is too long for rustfmt. It's been manually formatted and is now ignored by rustfmt.

Note: explicit casting to `Handler` is [required *](https://users.rust-lang.org/t/can-i-create-an-array-of-functions-and-pass-that-to-another-method/1263):

```
...
"config" => Some(configure as Handler)
...
```
