### PR TITLE
[plans] add bldr-web plan

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,9 @@ all: package
 
 package: image
 ifeq ($(GITHUB_DEPLOY_KEY),)
-	$(run) package sh -c '(cd /src/plans && make bldr-deps)'
+	$(run) package sh -c '(cd /src/plans && make bldr-deps bldr-webui)'
 else
-	$(run) package sh -c "chmod +x /usr/local/bin/ssh_wrapper.sh /usr/local/bin/git_src_checkout.sh; GITHUB_DEPLOY_KEY=\"$${GITHUB_DEPLOY_KEY}\" DELIVERY_GIT_SHASUM=${DELIVERY_GIT_SHASUM} /bin/bash /usr/local/bin/git_src_checkout.sh && (cd /src/plans && make bldr-deps)"
+	$(run) package sh -c "chmod +x /usr/local/bin/ssh_wrapper.sh /usr/local/bin/git_src_checkout.sh; GITHUB_DEPLOY_KEY=\"$${GITHUB_DEPLOY_KEY}\" DELIVERY_GIT_SHASUM=${DELIVERY_GIT_SHASUM} /bin/bash /usr/local/bin/git_src_checkout.sh && (cd /src/plans && make bldr-deps bldr-webui)"
 endif
 
 clean-package: image

--- a/plans/Makefile
+++ b/plans/Makefile
@@ -1,8 +1,9 @@
 BLDR_PKGS := glibc libgcc patchelf zlib xz bzip2 cacerts busybox libgpg-error libassuan gnupg gpgme openssl libarchive runit rngd bldr
-PKGS := $(BLDR_PKGS) redis ncurses libedit pcre nginx haproxy libaio libltdl libxml2 numactl perl erlang libyaml libiconv libtool libffi ruby
+BLDR_WEB_PKGS := node ncurses libedit pcre nginx bldr-web
+PKGS := $(BLDR_PKGS) $(BLDR_WEB_PKGS) redis haproxy libaio libltdl libxml2 numactl perl erlang libyaml libiconv libtool libffi ruby
 REPO := http://159.203.235.47
 
-.PHONY: bldr-deps world publish gpg clean baseimage_root $(PKGS) $(addprefix publish-,$(PKGS)) new-plan
+.PHONY: bldr-deps bldr-webui world publish gpg clean baseimage_root $(PKGS) $(addprefix publish-,$(PKGS)) new-plan
 
 new-plan:
 	mkdir -p $(plan)
@@ -12,6 +13,8 @@ world: gpg $(PKGS)
 	cp ./chef-public.gpg /opt/bldr/cache/keys/chef-public.asc
 
 bldr-deps: gpg $(BLDR_PKGS)
+
+bldr-webui: gpg $(BLDR_WEB_PKGS)
 
 publish:
 	cargo build --release

--- a/plans/bldr-build
+++ b/plans/bldr-build
@@ -178,6 +178,7 @@
 # * `$pkg_srvc_data`: Service data; `/opt/bldr/srvc/$pkg_name/data`
 # * `$pkg_srvc_var`: Variable state; `/opt/bldr/srvc/$pkg_name/var`
 # * `$pkg_srvc_config`: Configuration; `/opt/bldr/srvc/$pkg_name/config`
+# * `$pkg_srvc_static`: Static data; `/opt/bldr/srvc/$pkg_name/static`
 # * `$BLDR_SRC_CACHE`: The path to all the package sources
 # * `$BLDR_PKG_CACHE`: The path to all generated packages
 # * `$CFLAGS`: C compiler options
@@ -1893,6 +1894,7 @@ pkg_srvc="$BLDR_ROOT/srvc/$pkg_name"
 pkg_srvc_data="$BLDR_ROOT/srvc/$pkg_name/data"
 pkg_srvc_var="$BLDR_ROOT/srvc/$pkg_name/var"
 pkg_srvc_config="$BLDR_ROOT/srvc/$pkg_name/config"
+pkg_srvc_static="$BLDR_ROOT/srvc/$pkg_name/static"
 
 # The default location for the bldr binary to use
 if pkg_for_bldr=$(_latest_package "chef/bldr"); then

--- a/plans/bldr-web/config/mime.types
+++ b/plans/bldr-web/config/mime.types
@@ -1,0 +1,89 @@
+
+types {
+    text/html                             html htm shtml;
+    text/css                              css;
+    text/xml                              xml;
+    image/gif                             gif;
+    image/jpeg                            jpeg jpg;
+    application/javascript                js;
+    application/atom+xml                  atom;
+    application/rss+xml                   rss;
+
+    text/mathml                           mml;
+    text/plain                            txt;
+    text/vnd.sun.j2me.app-descriptor      jad;
+    text/vnd.wap.wml                      wml;
+    text/x-component                      htc;
+
+    image/png                             png;
+    image/tiff                            tif tiff;
+    image/vnd.wap.wbmp                    wbmp;
+    image/x-icon                          ico;
+    image/x-jng                           jng;
+    image/x-ms-bmp                        bmp;
+    image/svg+xml                         svg svgz;
+    image/webp                            webp;
+
+    application/font-woff                 woff;
+    application/java-archive              jar war ear;
+    application/json                      json;
+    application/mac-binhex40              hqx;
+    application/msword                    doc;
+    application/pdf                       pdf;
+    application/postscript                ps eps ai;
+    application/rtf                       rtf;
+    application/vnd.apple.mpegurl         m3u8;
+    application/vnd.ms-excel              xls;
+    application/vnd.ms-fontobject         eot;
+    application/vnd.ms-powerpoint         ppt;
+    application/vnd.wap.wmlc              wmlc;
+    application/vnd.google-earth.kml+xml  kml;
+    application/vnd.google-earth.kmz      kmz;
+    application/x-7z-compressed           7z;
+    application/x-cocoa                   cco;
+    application/x-java-archive-diff       jardiff;
+    application/x-java-jnlp-file          jnlp;
+    application/x-makeself                run;
+    application/x-perl                    pl pm;
+    application/x-pilot                   prc pdb;
+    application/x-rar-compressed          rar;
+    application/x-redhat-package-manager  rpm;
+    application/x-sea                     sea;
+    application/x-shockwave-flash         swf;
+    application/x-stuffit                 sit;
+    application/x-tcl                     tcl tk;
+    application/x-x509-ca-cert            der pem crt;
+    application/x-xpinstall               xpi;
+    application/xhtml+xml                 xhtml;
+    application/xspf+xml                  xspf;
+    application/zip                       zip;
+
+    application/octet-stream              bin exe dll;
+    application/octet-stream              deb;
+    application/octet-stream              dmg;
+    application/octet-stream              iso img;
+    application/octet-stream              msi msp msm;
+
+    application/vnd.openxmlformats-officedocument.wordprocessingml.document    docx;
+    application/vnd.openxmlformats-officedocument.spreadsheetml.sheet          xlsx;
+    application/vnd.openxmlformats-officedocument.presentationml.presentation  pptx;
+
+    audio/midi                            mid midi kar;
+    audio/mpeg                            mp3;
+    audio/ogg                             ogg;
+    audio/x-m4a                           m4a;
+    audio/x-realaudio                     ra;
+
+    video/3gpp                            3gpp 3gp;
+    video/mp2t                            ts;
+    video/mp4                             mp4;
+    video/mpeg                            mpeg mpg;
+    video/quicktime                       mov;
+    video/webm                            webm;
+    video/x-flv                           flv;
+    video/x-m4v                           m4v;
+    video/x-mng                           mng;
+    video/x-ms-asf                        asx asf;
+    video/x-ms-wmv                        wmv;
+    video/x-msvideo                       avi;
+}

--- a/plans/bldr-web/config/nginx.conf
+++ b/plans/bldr-web/config/nginx.conf
@@ -1,0 +1,34 @@
+worker_processes  {{worker_processes}};
+daemon off;
+
+events {
+    worker_connections  {{events.worker_connections}};
+}
+
+http {
+    include        mime.types;
+    default_type   application/octet-stream;
+
+    sendfile       {{http.sendfile}};
+    tcp_nopush     {{http.tcp_nopush}};
+    tcp_nodelay    {{http.tcp_nodelay}};
+
+    keepalive_timeout  {{http.keepalive_timeout}};
+
+    gzip  on;
+    gzip_vary on;
+    gzip_min_length 10240;
+    gzip_proxied expired no-cache no-store private auth;
+    gzip_types text/plain text/css text/xml text/javascript application/x-javascript application/xml;
+    gzip_disable "MSIE [1-6]\.";
+
+    server {
+        listen       *:80;
+        server_name  localhost;
+
+        location / {
+            root   {{doc_root}};
+            index  index.html index.htm;
+        }
+    }
+}

--- a/plans/bldr-web/default.toml
+++ b/plans/bldr-web/default.toml
@@ -1,0 +1,11 @@
+doc_root = '/opt/bldr/srvc/bldr-web/static'
+worker_processes = 1
+
+[events]
+worker_connections = 2048
+
+[http]
+sendfile = 'off'
+tcp_nopush = 'off'
+tcp_nodelay = 'on'
+keepalive_timeout = '75s'

--- a/plans/bldr-web/hooks/init
+++ b/plans/bldr-web/hooks/init
@@ -1,0 +1,5 @@
+#!/bin/bash
+mkdir -p /opt/bldr/srvc/nginx/var
+path_to_bldr_web="/opt/bldr/pkgs/{{bldr.derivation}}/{{bldr.name}}/{{bldr.version}}/{{bldr.release}}"
+
+rm -rf /opt/bldr/srvc/bldr-web/static* && cp -r $path_to_bldr_web/dist /opt/bldr/srvc/bldr-web/static

--- a/plans/bldr-web/hooks/run
+++ b/plans/bldr-web/hooks/run
@@ -1,0 +1,5 @@
+#!/bin/bash
+#
+path_to_nginx=`cat /opt/bldr/pkgs/{{bldr.derivation}}/{{bldr.name}}/{{bldr.version}}/{{bldr.release}}/DEPS | grep nginx`
+exec 2>&1
+exec /opt/bldr/pkgs/$path_to_nginx/sbin/nginx -c /opt/bldr/srvc/bldr-web/config/nginx.conf

--- a/plans/bldr-web/plan.sh
+++ b/plans/bldr-web/plan.sh
@@ -1,0 +1,40 @@
+pkg_name=bldr-web
+pkg_version=0.4.0
+pkg_derivation=chef
+pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
+pkg_license=('Apache2')
+pkg_source=http://example.com/${pkg_name}-${pkg_version}.tar.bz2
+pkg_filename=${pkg_name}-${pkg_version}.tar.bz2
+pkg_shasum=01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+pkg_gpg_key=3853DA6B
+pkg_deps=(chef/glibc chef/bldr chef/pcre chef/nginx)
+pkg_build_deps=(chef/node)
+pkg_lib_dirs=(lib)
+pkg_include_dirs=(include)
+pkg_docker_build="auto"
+pkg_expose=(80 443)
+
+do_begin() {
+    pushd ../../
+    tar -cjvf $BLDR_SRC_CACHE/${pkg_name}-${pkg_version}.tar.bz2 \
+		    --transform "s,^\./web,bldr-web-$pkg_version," ./web
+    popd
+    pkg_shasum=$(trim $(sha256sum /opt/bldr/cache/src/${pkg_filename} | cut -d " " -f 1))
+}
+
+do_build() {
+    npm install
+    npm run dist
+}
+
+do_install() {
+    cp -R dist ${pkg_path}/dist
+}
+
+do_verify() {
+    return 0
+}
+
+do_download() {
+    return 0
+}

--- a/plans/node/plan.sh
+++ b/plans/node/plan.sh
@@ -1,14 +1,15 @@
 pkg_name=node
 pkg_derivation=chef
-pkg_version=4.2.4
+pkg_version=4.2.6
 pkg_license=('MIT')
 pkg_maintainer="Dave Parfitt <dparfitt@chef.io>"
 pkg_source=https://nodejs.org/dist/v${pkg_version}/${pkg_name}-v${pkg_version}.tar.gz
 # the archive contains a 'v' version # prefix, but the default value of
-# pkg_version is node-4.2.4 (without the v). This tweak makes bldr-build happy
+# pkg_version is node-4.2.6 (without the v). This tweak makes bldr-build happy
 pkg_dirname=node-v${pkg_version}
-pkg_shasum=4ee244ffede7328d9fa24c3024787e71225b7abaac49fe2b30e68b27460c10ec
+pkg_shasum=ea5e357db8817052b17496d607c719d809ed1383e8fcf7c8ffc5214e705aefdd
 pkg_gpg_key=3853DA6B
 pkg_deps=(chef/glibc)
 pkg_lib_dirs=(lib)
 pkg_include_dirs=(include)
+pkg_binary_path=(bin)


### PR DESCRIPTION
Crate a new bldr-web plan so we can build the webui app and be able to run it in acceptance. The app needs to be served over HTTP, so we use nginx as that already exists as a plan. Some particular things to note about this, because it's an app - in particular, node.js - we can reference for example purposes.

The toplevel Makefile adds `bldr-webui` to the package target's make command so that the webui gets built. This will be particularly important in acceptance where we're going to need to run the app.

In order to add this to plans/Makefile, we needed a new variable, `BLDR_WEB_PKGS`, which included the dependencies for bldr-web. It needs node to build, and then it needs nginx (and its dependencies) to run.

I also added a new variable for bldr-build, `pkg_srvc_static`. This will be where "static" content exists for the service, such as application files. In this case it's also the document root for the web server to use, but think like any other web-served application. This gets blown away and recreated in the `init` hook for now.

Speaking of hooks, we have two for this app, `run` and `init`. Because we want to use the nginx package to serve the application, we need to know where its binary is. The `run` hook uses the bldr configuration to locate this. Note that we want to have pkg metadata exposed to bldr at run time at some point (see Slack discussion from this evening). We also execute this with the nginx config from bldr-web. The init hook makes the `var` directory for nginx - since that's compiled into nginx directly. It also ensures that we're copying the static content built for the application, `dist`, to the `pkg_srvc_static` location.

The configuration file for nginx was copied directly over, and the various configuration options added to the `default.toml`.

Overall, this plan gets us much closer to having the webui able to run in acceptance, though that part isn't finished yet. It can be demonstrated in this form though. It will build a docker container, so that can be started up like this:

```
time make clean package force=true
docker run -p 80:80 -it chef/bldr-web
```

And then access it via the IP returned from:

```
docker-machine ip default
```

Or, on OS X:

```
open http://$(docker-machine ip default)
```
- Add a bldr-webui target in plans/Makefile
- Add new static configuration variable in plans/bldr-build
- Create plans/bldr-web, the app will be served by nginx
