### PR TITLE
add a short flag for --topology

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -222,6 +222,7 @@ fn main() {
                         .arg(arg_url())
                         .arg(arg_group())
                         .arg(Arg::with_name("topology")
+                                 .short("t")
                                  .long("topology")
                                  .value_name("topology")
                                  .help("Service topology"))


### PR DESCRIPTION
I missed this during the docopt => conversion, and the examples from README use `-t`.

![gif-keyboard-904980064655141781](https://cloud.githubusercontent.com/assets/58244/12918886/9bba9e40-cf0f-11e5-9668-06bf7f42afd7.gif)
