### PR TITLE
Simulate log streaming

### DIFF
--- a/web/app/AppStore.ts
+++ b/web/app/AppStore.ts
@@ -15,7 +15,7 @@ const finalCreateStore = compose(
     // actions to make async calls.
     applyMiddleware(thunk),
     // Enable dev tools if the extension is installed.
-    window["devToolsExtension"] ? window["devToolsExtension"]() : (f) => { f; }
+    window["devToolsExtension"] ? window["devToolsExtension"]() : (f) => f
 )(createStore);
 const appStore = finalCreateStore(rootReducer);
 

--- a/web/app/packages-page/PackagesPageComponent.ts
+++ b/web/app/packages-page/PackagesPageComponent.ts
@@ -39,7 +39,7 @@ import {filterPackagesBy, requestRoute} from "../actions";
                     {{package.version}}
                     /
                     {{package.release}}
-          
+
                     <span class="stars" *ngIf="package.starCount">{{package.starCount}}</span>
                 </a>
             </li>

--- a/web/app/rootReducer.test.ts
+++ b/web/app/rootReducer.test.ts
@@ -12,7 +12,7 @@ describe("rootReducer", () => {
                 const action = {
                     type: SET_CURRENT_PACKAGE, payload: { name: "test" }
                 };
-                chai.expect(rootReducer(state, action).get("currentPackage"))
+                expect(rootReducer(state, action).get("currentPackage"))
                     .to.equal(null);
             });
         });
@@ -25,7 +25,7 @@ describe("rootReducer", () => {
                 const action = {
                     type: SET_CURRENT_PACKAGE, payload: { name: "test" }
                 };
-                chai.expect(rootReducer(state, action).get("currentPackage")
+                expect(rootReducer(state, action).get("currentPackage")
                     .dependencies).to.deep.equal([]);
             });
         });
@@ -38,7 +38,7 @@ describe("rootReducer", () => {
                 const action = {
                     type: SET_CURRENT_PACKAGE, payload: { name: "test" }
                 };
-                chai.expect(rootReducer(state, action).get("currentPackage")
+                expect(rootReducer(state, action).get("currentPackage")
                     .buildDependencies).to.deep.equal([]);
             });
         });

--- a/web/app/rootReducer.ts
+++ b/web/app/rootReducer.ts
@@ -16,6 +16,21 @@ export function rootReducer(state = initialState, action) {
 
     switch (action.type) {
 
+        // When we're simulating streaming and adding to a build log
+        case actionTypes.APPEND_TO_BUILD_LOG:
+            p = Object.assign({}, state.get("currentPackage"));
+            const id = action.payload.buildId;
+            p.buildLogs[id] = (p.buildLogs[id] || "") + action.payload.text + "\n";
+            return state.set("currentPackage", p);
+
+        // Set a build to successful when its log is done streaming
+        case actionTypes.FINISH_BUILD_STREAM:
+            p = state.get("currentPackage");
+            const index = p.builds.findIndex(x => x.id === action.payload.buildId);
+            p.builds[index].status = "success";
+            p.builds[index].duration = action.payload.duration;
+            return state.set("currentPackage", p);
+
         case actionTypes.POPULATE_BUILD_LOG:
             p = state.get("currentPackage");
 

--- a/web/app/tests-entry.ts
+++ b/web/app/tests-entry.ts
@@ -1,2 +1,7 @@
+// Expose chai.expect globally for tests
+declare var expect: Function;
+expect = chai.expect;
+
+// Load all tests
 let testContext = (<{ context?: Function }>require).context("./", true, /\.test\.ts/);
 testContext.keys().forEach(testContext);

--- a/web/app/util.test.ts
+++ b/web/app/util.test.ts
@@ -4,7 +4,7 @@ describe("util", () => {
     describe("packageString", () => {
         describe("with a fully qualified identifier", () => {
             it("returns the string", () => {
-                chai.expect(util.packageString({
+                expect(util.packageString({
                     derivation: "testderiv",
                     name: "testname",
                     version: "1.0.0",
@@ -16,7 +16,7 @@ describe("util", () => {
 
         describe("with a missing parts", () => {
             it("returns the partial string", () => {
-                chai.expect(util.packageString({
+                expect(util.packageString({
                     derivation: "testderiv",
                     name: "testname",
                 })

--- a/web/fixtures/log/chef/openssl/4.txt
+++ b/web/fixtures/log/chef/openssl/4.txt
@@ -1,0 +1,207 @@
+Loading /src/plans/openssl/plan.sh
+   [1;36mopenssl: [1;37mPlan loaded[0m
+../bldr-build: line 527: --version-sort: command not found
+   [1;36mopenssl: [1;33mWARN [1;37mCould not find a suitable installed package for 'chef/bldr'[0m
+   [1;36mopenssl: [1;37mBldr setup[0m
+   [1;36mopenssl: [1;37mResolving dependencies[0m
+   [1;36mopenssl: [1;37mResolved dependency 'chef/glibc' to /opt/bldr/pkgs/chef/glibc/2.19/20160204174948[0m
+   [1;36mopenssl: [1;37mResolved dependency 'chef/zlib' to /opt/bldr/pkgs/chef/zlib/1.2.8/20160204174955[0m
+   [1;36mopenssl: [1;37mResolved dependency 'chef/cacerts' to /opt/bldr/pkgs/chef/cacerts/2016.02.04/20160204175039[0m
+   [1;36mopenssl: [1;37mSetting PATH=/opt/bldr/pkgs/chef/openssl/1.0.2f/20160204195444/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin[0m
+   [1;36mopenssl: [1;37mDownloading 'https://www.openssl.org/source/openssl-1.0.2f.tar.gz' to 'openssl-1.0.2f.tar.gz'[0m
+--2016-02-04 19:54:44--  https://www.openssl.org/source/openssl-1.0.2f.tar.gz
+Resolving www.openssl.org (www.openssl.org)... 194.97.150.234, 2001:608:c00:180::1:ea
+Connecting to www.openssl.org (www.openssl.org)|194.97.150.234|:443... connected.
+HTTP request sent, awaiting response... 200 OK
+Length: 5258384 (5.0M) [application/x-gzip]
+Saving to: 'openssl-1.0.2f.tar.gz'
+
+     0K .......... .......... .......... .......... ..........  0%  173K 29s
+    50K .......... .......... .......... .......... ..........  1%  360K 22s
+   100K .......... .......... .......... .......... ..........  2% 3.64M 15s
+   150K .......... .......... .......... .......... ..........  3%  440K 14s
+   200K .......... .......... .......... .......... ..........  4% 2.27M 11s
+   250K .......... .......... .......... .......... ..........  5% 5.76M 9s
+   300K .......... .......... .......... .......... ..........  6%  391K 10s
+   350K .......... .......... .......... .......... ..........  7% 5.63M 9s
+   400K .......... .......... .......... .......... ..........  8%  329K 9s
+   450K .......... .......... .......... .......... ..........  9% 6.54M 8s
+   500K .......... .......... .......... .......... .......... 10% 6.66M 7s
+   550K .......... .......... .......... .......... .......... 11% 7.01M 7s
+   600K .......... .......... .......... .......... .......... 12% 6.46M 6s
+   650K .......... .......... .......... .......... .......... 13%  439K 6s
+   700K .......... .......... .......... .......... .......... 14% 5.62M 6s
+   750K .......... .......... .......... .......... .......... 15%  332K 6s
+   800K .......... .......... .......... .......... .......... 16%  405K 7s
+   850K .......... .......... .......... .......... .......... 17% 4.68M 6s
+   900K .......... .......... .......... .......... .......... 18% 6.22M 6s
+   950K .......... .......... .......... .......... .......... 19% 6.46M 5s
+  1000K .......... .......... .......... .......... .......... 20% 6.67M 5s
+  1050K .......... .......... .......... .......... .......... 21%  437K 5s
+  1100K .......... .......... .......... .......... .......... 22% 5.39M 5s
+  1150K .......... .......... .......... .......... .......... 23% 5.63M 5s
+  1200K .......... .......... .......... .......... .......... 24%  413K 5s
+  1250K .......... .......... .......... .......... .......... 25% 6.04M 5s
+  1300K .......... .......... .......... .......... .......... 26% 4.98M 4s
+  1350K .......... .......... .......... .......... .......... 27%  413K 5s
+  1400K .......... .......... .......... .......... .......... 28% 4.26M 4s
+  1450K .......... .......... .......... .......... .......... 29% 4.86M 4s
+  1500K .......... .......... .......... .......... .......... 30% 6.49M 4s
+  1550K .......... .......... .......... .......... .......... 31%  410K 4s
+  1600K .......... .......... .......... .......... .......... 32% 4.99M 4s
+  1650K .......... .......... .......... .......... .......... 33% 5.69M 4s
+  1700K .......... .......... .......... .......... .......... 34%  411K 4s
+  1750K .......... .......... .......... .......... .......... 35% 4.14M 4s
+  1800K .......... .......... .......... .......... .......... 36% 5.44M 4s
+  1850K .......... .......... .......... .......... .......... 36%  468K 4s
+  1900K .......... .......... .......... .......... .......... 37% 2.09M 4s
+  1950K .......... .......... .......... .......... .......... 38% 5.17M 3s
+  2000K .......... .......... .......... .......... .......... 39%  466K 3s
+  2050K .......... .......... .......... .......... .......... 40% 2.36M 3s
+  2100K .......... .......... .......... .......... .......... 41% 4.40M 3s
+  2150K .......... .......... .......... .......... .......... 42% 5.29M 3s
+  2200K .......... .......... .......... .......... .......... 43%  435K 3s
+  2250K .......... .......... .......... .......... .......... 44% 3.72M 3s
+  2300K .......... .......... .......... .......... .......... 45% 3.94M 3s
+  2350K .......... .......... .......... .......... .......... 46%  190K 3s
+  2400K .......... .......... .......... .......... .......... 47% 5.36M 3s
+  2450K .......... .......... .......... .......... .......... 48% 6.57M 3s
+  2500K .......... .......... .......... .......... .......... 49% 6.53M 3s
+  2550K .......... .......... .......... .......... .......... 50% 6.71M 3s
+  2600K .......... .......... .......... .......... .......... 51%  464K 3s
+  2650K .......... .......... .......... .......... .......... 52% 2.71M 3s
+  2700K .......... .......... .......... .......... .......... 53% 4.65M 3s
+  2750K .......... .......... .......... .......... .......... 54%  408K 3s
+  2800K .......... .......... .......... .......... .......... 55% 2.78M 2s
+  2850K .......... .......... .......... .......... .......... 56%  424K 2s
+  2900K .......... .......... .......... .......... .......... 57% 3.21M 2s
+  2950K .......... .......... .......... .......... .......... 58% 3.11M 2s
+  3000K .......... .......... .......... .......... .......... 59%  430K 2s
+  3050K .......... .......... .......... .......... .......... 60% 3.00M 2s
+  3100K .......... .......... .......... .......... .......... 61% 2.66M 2s
+  3150K .......... .......... .......... .......... .......... 62%  425K 2s
+  3200K .......... .......... .......... .......... .......... 63% 2.42M 2s
+  3250K .......... .......... .......... .......... .......... 64%  463K 2s
+  3300K .......... .......... .......... .......... .......... 65% 2.75M 2s
+  3350K .......... .......... .......... .......... .......... 66% 2.24M 2s
+  3400K .......... .......... .......... .......... .......... 67%  470K 2s
+  3450K .......... .......... .......... .......... .......... 68% 2.85M 2s
+  3500K .......... .......... .......... .......... .......... 69% 2.00M 2s
+  3550K .......... .......... .......... .......... .......... 70%  457K 2s
+  3600K .......... .......... .......... .......... .......... 71% 2.28M 2s
+  3650K .......... .......... .......... .......... .......... 72%  467K 2s
+  3700K .......... .......... .......... .......... .......... 73% 2.22M 1s
+  3750K .......... .......... .......... .......... .......... 73% 2.54M 1s
+  3800K .......... .......... .......... .......... .......... 74%  480K 1s
+  3850K .......... .......... .......... .......... .......... 75% 2.30M 1s
+  3900K .......... .......... .......... .......... .......... 76% 2.46M 1s
+  3950K .......... .......... .......... .......... .......... 77%  478K 1s
+  4000K .......... .......... .......... .......... .......... 78% 2.29M 1s
+  4050K .......... .......... .......... .......... .......... 79% 2.20M 1s
+  4100K .......... .......... .......... .......... .......... 80%  496K 1s
+  4150K .......... .......... .......... .......... .......... 81% 2.44M 1s
+  4200K .......... .......... .......... .......... .......... 82% 2.01M 1s
+  4250K .......... .......... .......... .......... .......... 83%  490K 1s
+  4300K .......... .......... .......... .......... .......... 84% 2.61M 1s
+  4350K .......... .......... .......... .......... .......... 85% 2.75M 1s
+  4400K .......... .......... .......... .......... .......... 86%  447K 1s
+  4450K .......... .......... .......... .......... .......... 87% 2.88M 1s
+  4500K .......... .......... .......... .......... .......... 88% 2.74M 1s
+  4550K .......... .......... .......... .......... .......... 89%  484K 1s
+  4600K .......... .......... .......... .......... .......... 90% 2.04M 1s
+  4650K .......... .......... .......... .......... .......... 91% 2.89M 0s
+  4700K .......... .......... .......... .......... .......... 92%  484K 0s
+  4750K .......... .......... .......... .......... .......... 93% 2.23M 0s
+  4800K .......... .......... .......... .......... .......... 94% 2.18M 0s
+  4850K .......... .......... .......... .......... .......... 95%  479K 0s
+  4900K .......... .......... .......... .......... .......... 96% 2.76M 0s
+  4950K .......... .......... .......... .......... .......... 97% 2.92M 0s
+  5000K .......... .......... .......... .......... .......... 98%  475K 0s
+  5050K .......... .......... .......... .......... .......... 99% 2.18M 0s
+  5100K .......... .......... .......... .....                100% 5.29M=5.3s
+
+2016-02-04 19:54:51 (962 KB/s) - 'openssl-1.0.2f.tar.gz' saved [5258384/5258384]
+
+   [1;36mopenssl: [1;37mDownloaded 'openssl-1.0.2f.tar.gz'[0m
+   [1;36mopenssl: [1;37mVerifying openssl-1.0.2f.tar.gz[0m
+   [1;36mopenssl: [1;37mChecksum verified for openssl-1.0.2f.tar.gz[0m
+   [1;36mopenssl: [1;37mClean the cache[0m
+   [1;36mopenssl: [1;37mUnpacking openssl-1.0.2f.tar.gz[0m
+   [1;36mopenssl: [1;37mSetting build environment[0m
+   [1;36mopenssl: [1;37mSetting PREFIX=/opt/bldr/pkgs/chef/openssl/1.0.2f/20160204195444[0m
+   [1;36mopenssl: [1;37mSetting
+
+
+
+
+
+...snip...
+
+
+
+
+
+
+installing libcrypto.a
+installing libssl.a
+installing libcrypto.so.1.0.0
+installing libssl.so.1.0.0
+make[1]: Entering directory `/opt/bldr/pkgs/chef/openssl/1.0.2f/20160204195444/lib'
+make[2]: Entering directory `/opt/bldr/pkgs/chef/openssl/1.0.2f/20160204195444/lib'
+make[2]: Leaving directory `/opt/bldr/pkgs/chef/openssl/1.0.2f/20160204195444/lib'
+make[2]: Entering directory `/opt/bldr/pkgs/chef/openssl/1.0.2f/20160204195444/lib'
+make[2]: Leaving directory `/opt/bldr/pkgs/chef/openssl/1.0.2f/20160204195444/lib'
+make[1]: Leaving directory `/opt/bldr/pkgs/chef/openssl/1.0.2f/20160204195444/lib'
+OpenSSL shared libraries have been installed in:
+  /opt/bldr/pkgs/chef/openssl/1.0.2f/20160204195444
+
+If this directory is not in a standard system path for dynamic/shared
+libraries, then you will have problems linking and executing
+applications that use OpenSSL libraries UNLESS:
+
+* you link with static (archive) libraries.  If you are truly
+  paranoid about security, you should use static libraries.
+* you use the GNU libtool code during linking
+  (http://www.gnu.org/software/libtool/libtool.html)
+* you use pkg-config during linking (this requires that
+  PKG_CONFIG_PATH includes the path to the OpenSSL shared
+  library directory), and make use of -R or -rpath.
+  (http://www.freedesktop.org/software/pkgconfig/)
+* you specify the system-wide link path via a command such
+  as crle(1) on Solaris systems.
+* you add the OpenSSL shared library directory to /etc/ld.so.conf
+  and run ldconfig(8) on Linux systems.
+* you define the LD_LIBRARY_PATH, LIBPATH, SHLIB_PATH (HP),
+  DYLD_LIBRARY_PATH (MacOS X) or PATH (Cygwin and DJGPP)
+  environment variable and add the OpenSSL shared library
+  directory to it.
+
+One common tool to check the dynamic dependencies of an executable
+or dynamic library is ldd(1) on most UNIX systems.
+
+See any operating system documentation and manpages about shared
+libraries for your version of UNIX.  The following manpages may be
+helpful: ld(1), ld.so(1), ld.so.1(1) [Solaris], dld.sl(1) [HP],
+ldd(1), crle(1) [Solaris], pldd(1) [Solaris], ldconfig(8) [Linux],
+chatr(1) [HP].
+cp libcrypto.pc /opt/bldr/pkgs/chef/openssl/1.0.2f/20160204195444/lib/pkgconfig
+chmod 644 /opt/bldr/pkgs/chef/openssl/1.0.2f/20160204195444/lib/pkgconfig/libcrypto.pc
+cp libssl.pc /opt/bldr/pkgs/chef/openssl/1.0.2f/20160204195444/lib/pkgconfig
+chmod 644 /opt/bldr/pkgs/chef/openssl/1.0.2f/20160204195444/lib/pkgconfig/libssl.pc
+cp openssl.pc /opt/bldr/pkgs/chef/openssl/1.0.2f/20160204195444/lib/pkgconfig
+chmod 644 /opt/bldr/pkgs/chef/openssl/1.0.2f/20160204195444/lib/pkgconfig/openssl.pc
+   [1;36mopenssl: [1;37mBuilding package metadata[0m
+   [1;36mopenssl: [1;37mWriting configuration[0m
+   [1;36mopenssl: [1;37mWriting service management scripts[0m
+   [1;36mopenssl: [1;37mStripping binaries[0m
+   [1;36mopenssl: [1;37mCreating manifest[0m
+   [1;36mopenssl: [1;37mGenerating package[0m
+/bin/tar: Removing leading `/' from member names
+   [1;36mopenssl: [1;37mBldr cleanup[0m
+   [1;36mopenssl: [1;37mCache: /opt/bldr/cache/src/openssl-1.0.2f[0m
+   [1;36mopenssl: [1;37mInstalled: /opt/bldr/pkgs/chef/openssl/1.0.2f/20160204195444[0m
+   [1;36mopenssl: [1;37mPackage: /opt/bldr/cache/pkgs/chef-openssl-1.0.2f-20160204195444.bldr[0m
+   [1;36mopenssl: [1;37m[0m
+   [1;36mopenssl: [1;37mI love it when a plan.sh comes together.[0m
+   [1;36mopenssl: [1;37m[0m
+   [1;36mopenssl: [1;37mBuild time: 2m51s[0m

--- a/web/fixtures/log/chef/openssl/builds.json
+++ b/web/fixtures/log/chef/openssl/builds.json
@@ -1,4 +1,12 @@
-[
+[    {
+        "id": 4,
+        "status": "running",
+        "gitCommit": "118096d",
+        "gitCommitUrl": "https://github.com/chef/bldr/commit/118096d73755a185c5b8cde0a92701c401f6ff12",
+        "startTime": "2016-02-01T19:49:00Z",
+        "author": "Nathan Smith <smith@chef.io>",
+        "version": "1.0.2f"
+    },
     {
         "id": 3,
         "status": "queued",


### PR DESCRIPTION
When on chef/openssl, you should now see logs streaming away, and turn
green when done.

Also  expose
`expect` as a global in tests.

![gif-keyboard-1135205658224944734](https://cloud.githubusercontent.com/assets/9912/12926289/5985d0d0-cf28-11e5-939e-68cb742312a5.gif)
