### PR TITLE
[plans] Update redis plan to work in Studio.

### DIFF
--- a/plans/redis/plan.sh
+++ b/plans/redis/plan.sh
@@ -1,17 +1,18 @@
 pkg_name=redis
 pkg_derivation=chef
 pkg_version=3.0.7
-pkg_license=('BSD')
-pkg_maintainer="Adam Jacob <adam@chef.io>"
+pkg_license=('bsd')
+pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
 pkg_source=http://download.redis.io/releases/${pkg_name}-${pkg_version}.tar.gz
 pkg_shasum=b2a791c4ea3bb7268795c45c6321ea5abcc24457178373e6a6e3be6372737f23
-pkg_gpg_key=3853DA6B
-pkg_binary_path=(bin)
 pkg_deps=(chef/glibc)
+pkg_build_deps=(chef/coreutils chef/diffutils chef/patch chef/make chef/gcc)
+pkg_binary_path=(bin)
 pkg_service_run="bin/redis-server /opt/bldr/srvc/redis/config/redis.config"
 pkg_docker_build="auto"
 pkg_expose=(6379)
+pkg_gpg_key=3853DA6B
 
 do_build() {
-	make
+  make
 }


### PR DESCRIPTION
Note that presently, `bldr-build` won't complete as we're still adding back Docker image creation. The Bldr package does go to completion however:

```
Script started on Wed Feb 17 16:35:01 2016
[1][bldr:/src:0]$ build redis
   bpm: Using: chef/build/0.4.0/20160216061501
   bpm: Setting: PATH=/opt/bldr/pkgs/chef/build/0.4.0/20160216061501/bin:/opt/bldr/pkgs/chef/bash/4.3.42/20160216055239/bin:/opt/bldr/pkgs/chef/binutils/2.25.1/20160216044353/bin:/opt/bldr/pkgs/chef/bzip2/1.0.6/20160216054725/bin:/opt/bldr/pkgs/chef/coreutils/8.24/20160216055015/bin:/opt/bldr/pkgs/chef/file/5.24/20160216044345/bin:/opt/bldr/pkgs/chef/findutils/4.4.2/20160216055905/bin:/opt/bldr/pkgs/chef/gawk/4.1.3/20160216055358/bin:/opt/bldr/pkgs/chef/gnupg/1.4.20/20160216061033/bin:/opt/bldr/pkgs/chef/grep/2.22/20160216055208/bin:/opt/bldr/pkgs/chef/gzip/1.6/20160216060141/bin:/opt/bldr/pkgs/chef/sed/4.2.2/20160216054856/bin:/opt/bldr/pkgs/chef/tar/1.28/20160216055322/bin:/opt/bldr/pkgs/chef/wget/1.16.3/20160216061001/bin:/opt/bldr/pkgs/chef/xz/5.2.2/20160216055924/bin:/opt/bldr/pkgs/chef/acl/2.2.52/20160216054845/bin:/opt/bldr/pkgs/chef/attr/2.4.47/20160216054838/bin:/opt/bldr/pkgs/chef/bash/4.3.42/20160216055239/bin:/opt/bldr/pkgs/chef/binutils/2.25.1/20160216044353/bin:/opt/bldr/pkgs/chef/bzip2/1.0.6/20160216054725/bin:/opt/bldr/pkgs/chef/coreutils/8.24/20160216055015/bin:/opt/bldr/pkgs/chef/file/5.24/20160216044345/bin:/opt/bldr/pkgs/chef/findutils/4.4.2/20160216055905/bin:/opt/bldr/pkgs/chef/gawk/4.1.3/20160216055358/bin:/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/bin:/opt/bldr/pkgs/chef/gnupg/1.4.20/20160216061033/bin:/opt/bldr/pkgs/chef/grep/2.22/20160216055208/bin:/opt/bldr/pkgs/chef/gzip/1.6/20160216060141/bin:/opt/bldr/pkgs/chef/less/481/20160216055611/bin:/opt/bldr/pkgs/chef/libcap/2.24/20160216054855/bin:/opt/bldr/pkgs/chef/libidn/1.32/20160216060600/bin:/opt/bldr/pkgs/chef/ncurses/6.0/20160216054755/bin:/opt/bldr/pkgs/chef/openssl/1.0.2f/20160216060624/bin:/opt/bldr/pkgs/chef/pcre/8.38/20160216055153/bin:/opt/bldr/pkgs/chef/sed/4.2.2/20160216054856/bin:/opt/bldr/pkgs/chef/tar/1.28/20160216055322/bin:/opt/bldr/pkgs/chef/wget/1.16.3/20160216061001/bin:/opt/bldr/pkgs/chef/xz/5.2.2/20160216055924/bin
   bpm: Running: 'build redis'
Loading /src/redis/plan.sh
   redis: Plan loaded
   redis: Bldr setup
   redis: WARN No installed packages of 'chef/bldr' were found
   redis: Using chef/bpm for dependency installs
   redis: Resolving dependencies
   redis: Resolved build dependency 'chef/coreutils' to /opt/bldr/pkgs/chef/coreutils/8.24/20160216055015
   redis: Resolved build dependency 'chef/diffutils' to /opt/bldr/pkgs/chef/diffutils/3.3/20160216055834
   redis: Resolved build dependency 'chef/patch' to /opt/bldr/pkgs/chef/patch/2.7.5/20160216060201
   redis: Resolved build dependency 'chef/make' to /opt/bldr/pkgs/chef/make/4.1/20160216060154
   redis: Resolved build dependency 'chef/gcc' to /opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623
   redis: Resolved dependency 'chef/glibc' to /opt/bldr/pkgs/chef/glibc/2.22/20160216043612
   redis: Setting PATH=/opt/bldr/pkgs/chef/redis/3.0.7/20160217163505/bin:/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/bin:/opt/bldr/pkgs/chef/coreutils/8.24/20160216055015/bin:/opt/bldr/pkgs/chef/diffutils/3.3/20160216055834/bin:/opt/bldr/pkgs/chef/patch/2.7.5/20160216060201/bin:/opt/bldr/pkgs/chef/make/4.1/20160216060154/bin:/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/bin:/opt/bldr/pkgs/chef/build/0.4.0/20160216061501/bin:/opt/bldr/pkgs/chef/bash/4.3.42/20160216055239/bin:/opt/bldr/pkgs/chef/binutils/2.25.1/20160216044353/bin:/opt/bldr/pkgs/chef/bzip2/1.0.6/20160216054725/bin:/opt/bldr/pkgs/chef/coreutils/8.24/20160216055015/bin:/opt/bldr/pkgs/chef/file/5.24/20160216044345/bin:/opt/bldr/pkgs/chef/findutils/4.4.2/20160216055905/bin:/opt/bldr/pkgs/chef/gawk/4.1.3/20160216055358/bin:/opt/bldr/pkgs/chef/gnupg/1.4.20/20160216061033/bin:/opt/bldr/pkgs/chef/grep/2.22/20160216055208/bin:/opt/bldr/pkgs/chef/gzip/1.6/20160216060141/bin:/opt/bldr/pkgs/chef/sed/4.2.2/20160216054856/bin:/opt/bldr/pkgs/chef/tar/1.28/20160216055322/bin:/opt/bldr/pkgs/chef/wget/1.16.3/20160216061001/bin:/opt/bldr/pkgs/chef/xz/5.2.2/20160216055924/bin:/opt/bldr/pkgs/chef/acl/2.2.52/20160216054845/bin:/opt/bldr/pkgs/chef/attr/2.4.47/20160216054838/bin:/opt/bldr/pkgs/chef/bash/4.3.42/20160216055239/bin:/opt/bldr/pkgs/chef/binutils/2.25.1/20160216044353/bin:/opt/bldr/pkgs/chef/bzip2/1.0.6/20160216054725/bin:/opt/bldr/pkgs/chef/coreutils/8.24/20160216055015/bin:/opt/bldr/pkgs/chef/file/5.24/20160216044345/bin:/opt/bldr/pkgs/chef/findutils/4.4.2/20160216055905/bin:/opt/bldr/pkgs/chef/gawk/4.1.3/20160216055358/bin:/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/bin:/opt/bldr/pkgs/chef/gnupg/1.4.20/20160216061033/bin:/opt/bldr/pkgs/chef/grep/2.22/20160216055208/bin:/opt/bldr/pkgs/chef/gzip/1.6/20160216060141/bin:/opt/bldr/pkgs/chef/less/481/20160216055611/bin:/opt/bldr/pkgs/chef/libcap/2.24/20160216054855/bin:/opt/bldr/pkgs/chef/libidn/1.32/20160216060600/bin:/opt/bldr/pkgs/chef/ncurses/6.0/20160216054755/bin:/opt/bldr/pkgs/chef/openssl/1.0.2f/20160216060624/bin:/opt/bldr/pkgs/chef/pcre/8.38/20160216055153/bin:/opt/bldr/pkgs/chef/sed/4.2.2/20160216054856/bin:/opt/bldr/pkgs/chef/tar/1.28/20160216055322/bin:/opt/bldr/pkgs/chef/wget/1.16.3/20160216061001/bin:/opt/bldr/pkgs/chef/xz/5.2.2/20160216055924/bin
   redis: Found previous file 'redis-3.0.7.tar.gz', attempting to re-use
   redis: Verifying redis-3.0.7.tar.gz
   redis: Checksum verified for redis-3.0.7.tar.gz
   redis: Using cached and verified 'redis-3.0.7.tar.gz'
   redis: Verifying redis-3.0.7.tar.gz
   redis: Checksum verified for redis-3.0.7.tar.gz
   redis: Clean the cache
   redis: Unpacking redis-3.0.7.tar.gz
   redis: Setting build environment
   redis: Setting PREFIX=/opt/bldr/pkgs/chef/redis/3.0.7/20160217163505
   redis: Setting LD_RUN_PATH=/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/lib
   redis: Setting CFLAGS=-I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include
   redis: Setting LDFLAGS=-L/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/lib -L/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/lib
   redis: Preparing to build
   redis: Building
cd src && make all
make[1]: Entering directory '/opt/bldr/cache/src/redis-3.0.7/src'
rm -rf redis-server redis-sentinel redis-cli redis-benchmark redis-check-dump redis-check-aof *.o *.gcda *.gcno *.gcov redis.info lcov-html
(cd ../deps && make distclean)
make[2]: Entering directory '/opt/bldr/cache/src/redis-3.0.7/deps'
(cd hiredis && make clean) > /dev/null || true
(cd linenoise && make clean) > /dev/null || true
(cd lua && make clean) > /dev/null || true
(cd jemalloc && [ -f Makefile ] && make distclean) > /dev/null || true
(rm -f .make-*)
make[2]: Leaving directory '/opt/bldr/cache/src/redis-3.0.7/deps'
(rm -f .make-*)
echo STD=-std=c99 -pedantic >> .make-settings
echo WARN=-Wall -W >> .make-settings
echo OPT=-O2 >> .make-settings
echo MALLOC=jemalloc >> .make-settings
echo CFLAGS=-I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include >> .make-settings
echo LDFLAGS=-L/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/lib -L/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/lib >> .make-settings
echo REDIS_CFLAGS= >> .make-settings
echo REDIS_LDFLAGS= >> .make-settings
echo PREV_FINAL_CFLAGS=-std=c99 -pedantic -Wall -W -O2 -g -ggdb -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include  -I../deps/hiredis -I../deps/linenoise -I../deps/lua/src -DUSE_JEMALLOC -I../deps/jemalloc/include >> .make-settings
echo PREV_FINAL_LDFLAGS=-L/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/lib -L/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/lib  -g -ggdb -rdynamic >> .make-settings
(cd ../deps && make hiredis linenoise lua jemalloc)
make[2]: Entering directory '/opt/bldr/cache/src/redis-3.0.7/deps'
(cd hiredis && make clean) > /dev/null || true
(cd linenoise && make clean) > /dev/null || true
(cd lua && make clean) > /dev/null || true
(cd jemalloc && [ -f Makefile ] && make distclean) > /dev/null || true
(rm -f .make-*)
(echo "-I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include" > .make-cflags)
(echo "-L/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/lib -L/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/lib" > .make-ldflags)
MAKE hiredis
cd hiredis && make static
make[3]: Entering directory '/opt/bldr/cache/src/redis-3.0.7/deps/hiredis'
cc -std=c99 -pedantic -c -O3 -fPIC -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include -Wall -W -Wstrict-prototypes -Wwrite-strings -g -ggdb  net.c
In file included from /opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include/sys/types.h:25:0,
                 from net.c:34:
/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include/features.h:148:3: warning: #warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE" [-Wcpp]
 # warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE"
   ^
cc -std=c99 -pedantic -c -O3 -fPIC -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include -Wall -W -Wstrict-prototypes -Wwrite-strings -g -ggdb  hiredis.c
In file included from /opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include/string.h:25:0,
                 from hiredis.c:33:
/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include/features.h:148:3: warning: #warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE" [-Wcpp]
 # warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE"
   ^
cc -std=c99 -pedantic -c -O3 -fPIC -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include -Wall -W -Wstrict-prototypes -Wwrite-strings -g -ggdb  sds.c
cc -std=c99 -pedantic -c -O3 -fPIC -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include -Wall -W -Wstrict-prototypes -Wwrite-strings -g -ggdb  async.c
In file included from /opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include/stdlib.h:24:0,
                 from async.c:33:
/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include/features.h:148:3: warning: #warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE" [-Wcpp]
 # warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE"
   ^
ar rcs libhiredis.a net.o hiredis.o sds.o async.o
make[3]: Leaving directory '/opt/bldr/cache/src/redis-3.0.7/deps/hiredis'
MAKE linenoise
cd linenoise && make
make[3]: Entering directory '/opt/bldr/cache/src/redis-3.0.7/deps/linenoise'
cc  -Wall -Os -g -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include -c linenoise.c
make[3]: Leaving directory '/opt/bldr/cache/src/redis-3.0.7/deps/linenoise'
MAKE lua
cd lua/src && make all CFLAGS="-O2 -Wall -DLUA_ANSI -DENABLE_CJSON_GLOBAL -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include" MYLDFLAGS="-L/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/lib -L/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/lib" AR="ar rcu"
make[3]: Entering directory '/opt/bldr/cache/src/redis-3.0.7/deps/lua/src'
cc -O2 -Wall -DLUA_ANSI -DENABLE_CJSON_GLOBAL -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include   -c -o lapi.o lapi.c
cc -O2 -Wall -DLUA_ANSI -DENABLE_CJSON_GLOBAL -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include   -c -o lcode.o lcode.c
cc -O2 -Wall -DLUA_ANSI -DENABLE_CJSON_GLOBAL -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include   -c -o ldebug.o ldebug.c
cc -O2 -Wall -DLUA_ANSI -DENABLE_CJSON_GLOBAL -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include   -c -o ldo.o ldo.c
ldo.c: In function 'f_parser':
ldo.c:496:7: warning: unused variable 'c' [-Wunused-variable]
   int c = luaZ_lookahead(p->z);
       ^
cc -O2 -Wall -DLUA_ANSI -DENABLE_CJSON_GLOBAL -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include   -c -o ldump.o ldump.c
cc -O2 -Wall -DLUA_ANSI -DENABLE_CJSON_GLOBAL -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include   -c -o lfunc.o lfunc.c
cc -O2 -Wall -DLUA_ANSI -DENABLE_CJSON_GLOBAL -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include   -c -o lgc.o lgc.c
cc -O2 -Wall -DLUA_ANSI -DENABLE_CJSON_GLOBAL -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include   -c -o llex.o llex.c
cc -O2 -Wall -DLUA_ANSI -DENABLE_CJSON_GLOBAL -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include   -c -o lmem.o lmem.c
cc -O2 -Wall -DLUA_ANSI -DENABLE_CJSON_GLOBAL -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include   -c -o lobject.o lobject.c
cc -O2 -Wall -DLUA_ANSI -DENABLE_CJSON_GLOBAL -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include   -c -o lopcodes.o lopcodes.c
cc -O2 -Wall -DLUA_ANSI -DENABLE_CJSON_GLOBAL -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include   -c -o lparser.o lparser.c
cc -O2 -Wall -DLUA_ANSI -DENABLE_CJSON_GLOBAL -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include   -c -o lstate.o lstate.c
cc -O2 -Wall -DLUA_ANSI -DENABLE_CJSON_GLOBAL -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include   -c -o lstring.o lstring.c
cc -O2 -Wall -DLUA_ANSI -DENABLE_CJSON_GLOBAL -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include   -c -o ltable.o ltable.c
cc -O2 -Wall -DLUA_ANSI -DENABLE_CJSON_GLOBAL -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include   -c -o ltm.o ltm.c
cc -O2 -Wall -DLUA_ANSI -DENABLE_CJSON_GLOBAL -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include   -c -o lundump.o lundump.c
cc -O2 -Wall -DLUA_ANSI -DENABLE_CJSON_GLOBAL -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include   -c -o lvm.o lvm.c
cc -O2 -Wall -DLUA_ANSI -DENABLE_CJSON_GLOBAL -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include   -c -o lzio.o lzio.c
cc -O2 -Wall -DLUA_ANSI -DENABLE_CJSON_GLOBAL -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include   -c -o strbuf.o strbuf.c
cc -O2 -Wall -DLUA_ANSI -DENABLE_CJSON_GLOBAL -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include   -c -o fpconv.o fpconv.c
cc -O2 -Wall -DLUA_ANSI -DENABLE_CJSON_GLOBAL -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include   -c -o lauxlib.o lauxlib.c
cc -O2 -Wall -DLUA_ANSI -DENABLE_CJSON_GLOBAL -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include   -c -o lbaselib.o lbaselib.c
cc -O2 -Wall -DLUA_ANSI -DENABLE_CJSON_GLOBAL -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include   -c -o ldblib.o ldblib.c
cc -O2 -Wall -DLUA_ANSI -DENABLE_CJSON_GLOBAL -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include   -c -o liolib.o liolib.c
cc -O2 -Wall -DLUA_ANSI -DENABLE_CJSON_GLOBAL -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include   -c -o lmathlib.o lmathlib.c
cc -O2 -Wall -DLUA_ANSI -DENABLE_CJSON_GLOBAL -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include   -c -o loslib.o loslib.c
cc -O2 -Wall -DLUA_ANSI -DENABLE_CJSON_GLOBAL -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include   -c -o ltablib.o ltablib.c
cc -O2 -Wall -DLUA_ANSI -DENABLE_CJSON_GLOBAL -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include   -c -o lstrlib.o lstrlib.c
cc -O2 -Wall -DLUA_ANSI -DENABLE_CJSON_GLOBAL -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include   -c -o loadlib.o loadlib.c
cc -O2 -Wall -DLUA_ANSI -DENABLE_CJSON_GLOBAL -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include   -c -o linit.o linit.c
cc -O2 -Wall -DLUA_ANSI -DENABLE_CJSON_GLOBAL -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include   -c -o lua_cjson.o lua_cjson.c
cc -O2 -Wall -DLUA_ANSI -DENABLE_CJSON_GLOBAL -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include   -c -o lua_struct.o lua_struct.c
cc -O2 -Wall -DLUA_ANSI -DENABLE_CJSON_GLOBAL -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include   -c -o lua_cmsgpack.o lua_cmsgpack.c
cc -O2 -Wall -DLUA_ANSI -DENABLE_CJSON_GLOBAL -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include   -c -o lua_bit.o lua_bit.c
ar rcu liblua.a lapi.o lcode.o ldebug.o ldo.o ldump.o lfunc.o lgc.o llex.o lmem.o lobject.o lopcodes.o lparser.o lstate.o lstring.o ltable.o ltm.o lundump.o lvm.o lzio.o strbuf.o fpconv.o lauxlib.o lbaselib.o ldblib.o liolib.o lmathlib.o loslib.o ltablib.o lstrlib.o loadlib.o linit.o lua_cjson.o lua_struct.o lua_cmsgpack.o lua_bit.o  # DLL needs all object files
ar: `u' modifier ignored since `D' is the default (see `U')
ranlib liblua.a
cc -O2 -Wall -DLUA_ANSI -DENABLE_CJSON_GLOBAL -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include   -c -o lua.o lua.c
cc -o lua -L/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/lib -L/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/lib lua.o liblua.a -lm 
liblua.a(loslib.o): In function `os_tmpname':
loslib.c:(.text+0x27c): warning: the use of `tmpnam' is dangerous, better use `mkstemp'
cc -O2 -Wall -DLUA_ANSI -DENABLE_CJSON_GLOBAL -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include   -c -o luac.o luac.c
cc -O2 -Wall -DLUA_ANSI -DENABLE_CJSON_GLOBAL -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include   -c -o print.o print.c
cc -o luac -L/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/lib -L/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/lib luac.o print.o liblua.a -lm 
make[3]: Leaving directory '/opt/bldr/cache/src/redis-3.0.7/deps/lua/src'
MAKE jemalloc
cd jemalloc && ./configure --with-jemalloc-prefix=je_ --enable-cc-silence CFLAGS="-std=gnu99 -Wall -pipe -g3 -O3 -funroll-loops -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include" LDFLAGS="-L/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/lib -L/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/lib"
checking for xsltproc... false
checking for gcc... gcc
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables... 
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether we are using the GNU C compiler... yes
checking whether gcc accepts -g... yes
checking for gcc option to accept ISO C89... none needed
checking how to run the C preprocessor... gcc -E
checking for grep that handles long lines and -e... /opt/bldr/pkgs/chef/grep/2.22/20160216055208/bin/grep
checking for egrep... /opt/bldr/pkgs/chef/grep/2.22/20160216055208/bin/grep -E
checking for ANSI C header files... yes
checking for sys/types.h... yes
checking for sys/stat.h... yes
checking for stdlib.h... yes
checking for string.h... yes
checking for memory.h... yes
checking for strings.h... yes
checking for inttypes.h... yes
checking for stdint.h... yes
checking for unistd.h... yes
checking whether byte ordering is bigendian... no
checking size of void *... 8
checking size of int... 4
checking size of long... 8
checking size of intmax_t... 8
checking build system type... x86_64-unknown-linux-gnu
checking host system type... x86_64-unknown-linux-gnu
checking whether pause instruction is compilable... yes
checking whether SSE2 intrinsics is compilable... yes
checking for ar... ar
checking whether __attribute__ syntax is compilable... yes
checking whether compiler supports -fvisibility=hidden... yes
checking whether compiler supports -Werror... yes
checking whether tls_model attribute is compilable... no
checking for a BSD-compatible install... /opt/bldr/pkgs/chef/coreutils/8.24/20160216055015/bin/install -c
checking for ranlib... ranlib
checking for ld... /opt/bldr/pkgs/chef/binutils/2.25.1/20160216044353/bin/ld
checking for autoconf... false
checking for memalign... yes
checking for valloc... yes
checking configured backtracing method... N/A
checking for sbrk... yes
checking whether utrace(2) is compilable... no
checking whether valgrind is compilable... no
checking STATIC_PAGE_SHIFT... 12
checking pthread.h usability... yes
checking pthread.h presence... yes
checking for pthread.h... yes
checking for pthread_create in -lpthread... yes
checking for _malloc_thread_cleanup... no
checking for _pthread_mutex_init_calloc_cb... no
checking for TLS... yes
checking whether a program using ffsl is compilable... yes
checking whether atomic(9) is compilable... no
checking whether Darwin OSAtomic*() is compilable... no
checking whether to force 32-bit __sync_{add,sub}_and_fetch()... no
checking whether to force 64-bit __sync_{add,sub}_and_fetch()... no
checking whether Darwin OSSpin*() is compilable... no
checking for stdbool.h that conforms to C99... yes
checking for _Bool... yes
configure: creating ./config.status
config.status: creating Makefile
config.status: creating doc/html.xsl
config.status: creating doc/manpages.xsl
config.status: creating doc/jemalloc.xml
config.status: creating include/jemalloc/jemalloc_macros.h
config.status: creating include/jemalloc/jemalloc_protos.h
config.status: creating include/jemalloc/internal/jemalloc_internal.h
config.status: creating test/test.sh
config.status: creating test/include/test/jemalloc_test.h
config.status: creating config.stamp
config.status: creating bin/jemalloc.sh
config.status: creating include/jemalloc/jemalloc_defs.h
config.status: creating include/jemalloc/internal/jemalloc_internal_defs.h
config.status: creating test/include/test/jemalloc_test_defs.h
config.status: executing include/jemalloc/internal/private_namespace.h commands
config.status: executing include/jemalloc/internal/private_unnamespace.h commands
config.status: executing include/jemalloc/internal/public_symbols.txt commands
config.status: executing include/jemalloc/internal/public_namespace.h commands
config.status: executing include/jemalloc/internal/public_unnamespace.h commands
config.status: executing include/jemalloc/internal/size_classes.h commands
config.status: executing include/jemalloc/jemalloc_protos_jet.h commands
config.status: executing include/jemalloc/jemalloc_rename.h commands
config.status: executing include/jemalloc/jemalloc_mangle.h commands
config.status: executing include/jemalloc/jemalloc_mangle_jet.h commands
config.status: executing include/jemalloc/jemalloc.h commands
===============================================================================
jemalloc version   : 3.6.0-0-g46c0af68bd248b04df75e4f92d5fb804c3d75340
library revision   : 1

CC                 : gcc
CPPFLAGS           :  -D_GNU_SOURCE -D_REENTRANT
CFLAGS             : -std=gnu99 -Wall -pipe -g3 -O3 -funroll-loops -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include -fvisibility=hidden
LDFLAGS            : -L/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/lib -L/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/lib
EXTRA_LDFLAGS      : 
LIBS               :  -lpthread
RPATH_EXTRA        : 

XSLTPROC           : false
XSLROOT            : 

PREFIX             : /usr/local
BINDIR             : /usr/local/bin
INCLUDEDIR         : /usr/local/include
LIBDIR             : /usr/local/lib
DATADIR            : /usr/local/share
MANDIR             : /usr/local/share/man

srcroot            : 
abs_srcroot        : /opt/bldr/cache/src/redis-3.0.7/deps/jemalloc/
objroot            : 
abs_objroot        : /opt/bldr/cache/src/redis-3.0.7/deps/jemalloc/

JEMALLOC_PREFIX    : je_
JEMALLOC_PRIVATE_NAMESPACE
                   : je_
install_suffix     : 
autogen            : 0
experimental       : 1
cc-silence         : 1
debug              : 0
code-coverage      : 0
stats              : 1
prof               : 0
prof-libunwind     : 0
prof-libgcc        : 0
prof-gcc           : 0
tcache             : 1
fill               : 1
utrace             : 0
valgrind           : 0
xmalloc            : 0
mremap             : 0
munmap             : 0
dss                : 0
lazy_lock          : 0
tls                : 1
===============================================================================
cd jemalloc && make CFLAGS="-std=gnu99 -Wall -pipe -g3 -O3 -funroll-loops -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include" LDFLAGS="-L/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/lib -L/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/lib" lib/libjemalloc.a
make[3]: Entering directory '/opt/bldr/cache/src/redis-3.0.7/deps/jemalloc'
gcc -std=gnu99 -Wall -pipe -g3 -O3 -funroll-loops -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include -c -D_GNU_SOURCE -D_REENTRANT -Iinclude -Iinclude -o src/jemalloc.o src/jemalloc.c
gcc -std=gnu99 -Wall -pipe -g3 -O3 -funroll-loops -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include -c -D_GNU_SOURCE -D_REENTRANT -Iinclude -Iinclude -o src/arena.o src/arena.c
gcc -std=gnu99 -Wall -pipe -g3 -O3 -funroll-loops -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include -c -D_GNU_SOURCE -D_REENTRANT -Iinclude -Iinclude -o src/atomic.o src/atomic.c
gcc -std=gnu99 -Wall -pipe -g3 -O3 -funroll-loops -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include -c -D_GNU_SOURCE -D_REENTRANT -Iinclude -Iinclude -o src/base.o src/base.c
gcc -std=gnu99 -Wall -pipe -g3 -O3 -funroll-loops -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include -c -D_GNU_SOURCE -D_REENTRANT -Iinclude -Iinclude -o src/bitmap.o src/bitmap.c
gcc -std=gnu99 -Wall -pipe -g3 -O3 -funroll-loops -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include -c -D_GNU_SOURCE -D_REENTRANT -Iinclude -Iinclude -o src/chunk.o src/chunk.c
gcc -std=gnu99 -Wall -pipe -g3 -O3 -funroll-loops -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include -c -D_GNU_SOURCE -D_REENTRANT -Iinclude -Iinclude -o src/chunk_dss.o src/chunk_dss.c
gcc -std=gnu99 -Wall -pipe -g3 -O3 -funroll-loops -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include -c -D_GNU_SOURCE -D_REENTRANT -Iinclude -Iinclude -o src/chunk_mmap.o src/chunk_mmap.c
gcc -std=gnu99 -Wall -pipe -g3 -O3 -funroll-loops -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include -c -D_GNU_SOURCE -D_REENTRANT -Iinclude -Iinclude -o src/ckh.o src/ckh.c
gcc -std=gnu99 -Wall -pipe -g3 -O3 -funroll-loops -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include -c -D_GNU_SOURCE -D_REENTRANT -Iinclude -Iinclude -o src/ctl.o src/ctl.c
gcc -std=gnu99 -Wall -pipe -g3 -O3 -funroll-loops -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include -c -D_GNU_SOURCE -D_REENTRANT -Iinclude -Iinclude -o src/extent.o src/extent.c
gcc -std=gnu99 -Wall -pipe -g3 -O3 -funroll-loops -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include -c -D_GNU_SOURCE -D_REENTRANT -Iinclude -Iinclude -o src/hash.o src/hash.c
gcc -std=gnu99 -Wall -pipe -g3 -O3 -funroll-loops -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include -c -D_GNU_SOURCE -D_REENTRANT -Iinclude -Iinclude -o src/huge.o src/huge.c
gcc -std=gnu99 -Wall -pipe -g3 -O3 -funroll-loops -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include -c -D_GNU_SOURCE -D_REENTRANT -Iinclude -Iinclude -o src/mb.o src/mb.c
gcc -std=gnu99 -Wall -pipe -g3 -O3 -funroll-loops -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include -c -D_GNU_SOURCE -D_REENTRANT -Iinclude -Iinclude -o src/mutex.o src/mutex.c
gcc -std=gnu99 -Wall -pipe -g3 -O3 -funroll-loops -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include -c -D_GNU_SOURCE -D_REENTRANT -Iinclude -Iinclude -o src/prof.o src/prof.c
gcc -std=gnu99 -Wall -pipe -g3 -O3 -funroll-loops -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include -c -D_GNU_SOURCE -D_REENTRANT -Iinclude -Iinclude -o src/quarantine.o src/quarantine.c
gcc -std=gnu99 -Wall -pipe -g3 -O3 -funroll-loops -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include -c -D_GNU_SOURCE -D_REENTRANT -Iinclude -Iinclude -o src/rtree.o src/rtree.c
gcc -std=gnu99 -Wall -pipe -g3 -O3 -funroll-loops -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include -c -D_GNU_SOURCE -D_REENTRANT -Iinclude -Iinclude -o src/stats.o src/stats.c
gcc -std=gnu99 -Wall -pipe -g3 -O3 -funroll-loops -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include -c -D_GNU_SOURCE -D_REENTRANT -Iinclude -Iinclude -o src/tcache.o src/tcache.c
gcc -std=gnu99 -Wall -pipe -g3 -O3 -funroll-loops -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include -c -D_GNU_SOURCE -D_REENTRANT -Iinclude -Iinclude -o src/util.o src/util.c
gcc -std=gnu99 -Wall -pipe -g3 -O3 -funroll-loops -I/opt/bldr/pkgs/chef/glibc/2.22/20160216043612/include -I/opt/bldr/pkgs/chef/make/4.1/20160216060154/include -I/opt/bldr/pkgs/chef/gcc/5.2.0/20160216044623/include -c -D_GNU_SOURCE -D_REENTRANT -Iinclude -Iinclude -o src/tsd.o src/tsd.c
ar crus lib/libjemalloc.a src/jemalloc.o src/arena.o src/atomic.o src/base.o src/bitmap.o src/chunk.o src/chunk_dss.o src/chunk_mmap.o src/ckh.o src/ctl.o src/extent.o src/hash.o src/huge.o src/mb.o src/mutex.o src/prof.o src/quarantine.o src/rtree.o src/stats.o src/tcache.o src/util.o src/tsd.o
ar: `u' modifier ignored since `D' is the default (see `U')
make[3]: Leaving directory '/opt/bldr/cache/src/redis-3.0.7/deps/jemalloc'
make[2]: Leaving directory '/opt/bldr/cache/src/redis-3.0.7/deps'
    CC adlist.o
    CC ae.o
    CC anet.o
    CC dict.o
    CC redis.o
    CC sds.o
    CC zmalloc.o
    CC lzf_c.o
    CC lzf_d.o
    CC pqsort.o
    CC zipmap.o
    CC sha1.o
    CC ziplist.o
    CC release.o
    CC networking.o
    CC util.o
    CC object.o
    CC db.o
db.c: In function 'scanGenericCommand':
db.c:559:22: warning: 'patlen' may be used uninitialized in this function [-Wmaybe-uninitialized]
                 if (!stringmatchlen(pat, patlen, buf, len, 0)) filter = 1;
                      ^
db.c:559:22: warning: 'pat' may be used uninitialized in this function [-Wmaybe-uninitialized]
    CC replication.o
    CC rdb.o
    CC t_string.o
    CC t_list.o
    CC t_set.o
    CC t_zset.o
    CC t_hash.o
    CC config.o
    CC aof.o
    CC pubsub.o
    CC multi.o
    CC debug.o
    CC sort.o
    CC intset.o
    CC syncio.o
    CC cluster.o
    CC crc16.o
    CC endianconv.o
    CC slowlog.o
    CC scripting.o
    CC bio.o
    CC rio.o
    CC rand.o
    CC memtest.o
    CC crc64.o
    CC bitops.o
    CC sentinel.o
    CC notify.o
    CC setproctitle.o
    CC blocked.o
    CC hyperloglog.o
    CC latency.o
    CC sparkline.o
    LINK redis-server
    INSTALL redis-sentinel
    CC redis-cli.o
    LINK redis-cli
    CC redis-benchmark.o
    LINK redis-benchmark
    CC redis-check-dump.o
    LINK redis-check-dump
    CC redis-check-aof.o
    LINK redis-check-aof

Hint: It's a good idea to run 'make test' ;)

make[1]: Leaving directory '/opt/bldr/cache/src/redis-3.0.7/src'
   redis: Installing
mkdir: created directory '/opt/bldr/pkgs/chef/redis/3.0.7/20160217163505'
cd src && make install
make[1]: Entering directory '/opt/bldr/cache/src/redis-3.0.7/src'

Hint: It's a good idea to run 'make test' ;)

    INSTALL install
    INSTALL install
    INSTALL install
    INSTALL install
    INSTALL install
make[1]: Leaving directory '/opt/bldr/cache/src/redis-3.0.7/src'
   redis: Building package metadata
   redis: Writing configuration
   redis: Writing service management scripts
   redis: WARN No installed packages of 'chef/busybox' were found
   redis: WARN No installed packages of 'chef/busybox' were found
   redis: Stripping binaries
   redis: Creating manifest
   redis: Generating package
/opt/bldr/pkgs/chef/tar/1.28/20160216055322/bin/tar: Removing leading `/' from member names
   redis: Creating Docker images
/opt/bldr/pkgs/chef/build/0.4.0/20160216061501/bin/build: line 1755: rsync: command not found
Cleaning up Docker context /tmp/bldr--src-redis-Eatq
   redis: Build time: 1m27s
   redis: Exiting on error
[2][bldr:/src:127]$ exit
logout

Script done on Wed Feb 17 16:37:23 2016
```
