### PR TITLE
Adding docker build support to studios

### DIFF
--- a/plans/bldr-build
+++ b/plans/bldr-build
@@ -692,9 +692,10 @@ _determine_pkg_installer() {
   elif [ -n "${BLDR_BIN:-}" ]; then
     BLDR_BIN=$BLDR_BIN
     build_line "Using set BLDR_BIN=$BLDR_BIN for dependency installs"
-  elif _pkg_for_bldr_install=$(_latest_installed_package "chef/bldr"); then
-    BLDR_BIN="$_pkg_for_bldr_install/bin/bldr"
-    build_line "Using chef/bldr for dependency installs"
+## We are bypassing bldr for now, while we get the system stable, then we come back
+#  elif _pkg_for_bldr_install=$(_latest_installed_package "chef/bldr"); then
+#    BLDR_BIN="$_pkg_for_bldr_install/bin/bldr"
+#    build_line "Using chef/bldr for dependency installs"
   elif _pkg_for_bldr_install=$(_latest_installed_package "chef/bpm"); then
     BLDR_BIN="$_pkg_for_bldr_install/bin/bpm"
     build_line "Using chef/bpm for dependency installs"

--- a/plans/bldr-studio/bin/dockerize
+++ b/plans/bldr-studio/bin/dockerize
@@ -1,0 +1,141 @@
+#!/bin/sh
+#
+# # Usage
+#
+# ```
+# $ dockerize [PKG ...]
+# ```
+#
+# # Synopsis
+#
+# Create a docker container from a set of bldr packages.
+#
+# # License and Copyright
+#
+# ```
+# Copyright: Copyright (c) 2016 Chef Software, Inc.
+# License: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ```
+
+# Fail if there are any unset variables and whenever a command returns a
+# non-zero exit code.
+set -eu
+
+# If the variable `$DEBUG` is set, then print the shell commands as we execute.
+if [ -n "${DEBUG:-}" ]; then
+  set -x
+  export DEBUG
+fi
+
+# ## Help
+
+# **Internal** Prints help
+print_help() {
+  printf -- "$program $version
+
+$author
+
+Dockerize - make docker containers from bldr packages
+
+USAGE:
+  $program [PKG ..]
+"
+}
+
+find_system_commands() {
+  if $(mktemp --version 2>&1 | grep -q 'GNU coreutils'); then
+    _mktemp_cmd=$(command -v mktemp)
+  else
+    if $(/bin/mktemp --version 2>&1 | grep -q 'GNU coreutils'); then
+      _mktemp_cmd=/bin/mktemp
+    else
+      exit_with "We require GNU mktemp to build docker images; aborting" 1
+    fi
+  fi
+}
+
+# Wraps `dockerfile` to ensure that a Docker image build is being executed in a
+# clean directory with native filesystem permissions which is outside the
+# source code tree.
+build_docker_image() {
+  DOCKER_CONTEXT="$($_mktemp_cmd -t -d "bldr-dockerize-XXXX")"
+  pushd $DOCKER_CONTEXT > /dev/null
+  docker_image $@
+  popd > /dev/null
+  rm -rf "$DOCKER_CONTEXT"
+}
+
+pkg_path_for() {
+  local dep="$1"
+  find $BLDR_ROOT/pkgs -mindepth 4 -maxdepth 4 -type d | grep $dep
+}
+
+package_name_for() {
+  local pkg="$1"
+  echo $(echo $pkg | cut -d "/" -f 2)
+}
+
+package_exposes() {
+  local pkg="$1"
+  local expose_file=$(find $DOCKER_CONTEXT/rootfs/$BLDR_ROOT/pkgs/$pkg -name EXPOSES)
+  if [ -f "$expose_file" ]; then
+    cat $expose_file
+  fi
+}
+
+package_version_tag() {
+  local pkg="$1"
+  local ident_file=$(find $DOCKER_CONTEXT/rootfs/$BLDR_ROOT/pkgs/$pkg -name IDENT)
+  cat $ident_file | awk 'BEGIN { FS = "/" }; { print $1 "/" $2 ":" $3 "-" $4 }'
+}
+
+package_latest_tag() {
+  local pkg="$1"
+  local ident_file=$(find $DOCKER_CONTEXT/rootfs/$BLDR_ROOT/pkgs/$pkg -name IDENT)
+  cat $ident_file | awk 'BEGIN { FS = "/" }; { print $1 "/" $2 ":latest" }'
+}
+
+docker_image() {
+  env PKGS="$@" NO_MOUNT=1 studio -r $DOCKER_CONTEXT/rootfs -t baseimage new
+  local pkg_name=$(package_name_for $1)
+  local version_tag=$(package_version_tag $1)
+  local latest_tag=$(package_latest_tag $1)
+  cat <<EOT > $DOCKER_CONTEXT/Dockerfile
+FROM scratch
+ENV $(cat $DOCKER_CONTEXT/rootfs/init.sh | grep PATH)
+WORKDIR /
+ADD rootfs /
+VOLUME $BLDR_ROOT/srvc/${pkg_name}/data $BLDR_ROOT/srvc/${pkg_name}/config
+EXPOSE 9631 $(package_exposes $1)
+ENTRYPOINT ["/init.sh"]
+CMD ["start", "$1"]
+EOT
+  local docker="$(pkg_path_for chef/docker)/bin/docker"
+  $docker build --force-rm --no-cache -t $version_tag .
+  $docker tag $version_tag $latest_tag
+}
+
+# The current version of Bldr Studio
+version='@version@'
+# The author of this program
+author='@author@'
+# The short version of the program name which is used in logging output
+program=$(basename $0)
+BLDR_ROOT="/opt/bldr"
+
+/opt/bldr/bin/bpm install chef/docker
+find_system_commands
+build_docker_image $@
+

--- a/plans/bldr-studio/bin/studio
+++ b/plans/bldr-studio/bin/studio
@@ -70,7 +70,7 @@ OPTIONS:
     -r <STUDIO_ROOT>  Sets a Studio root (default: /opt/studio)
     -s <SRC_PATH>     Sets the source path (default: \$PWD)
     -t <STUDIO_TYPE>  Sets a Studio type when creating (default: bldr)
-                      Valid types: [bldr bldr-slim busybox stage1]
+                      Valid types: [baseimage bldr bldr-slim busybox stage1]
 
 SUBCOMMANDS:
     build     Build using a Studio
@@ -136,7 +136,7 @@ new_studio() {
       # Set the default/unset type
       STUDIO_TYPE=bldr
       ;;
-    bldr-slim|busybox|stage1)
+    bldr-slim|busybox|stage1|baseimage)
       # Confirmed valid types
       ;;
     *)
@@ -271,6 +271,9 @@ new_studio() {
   $bb chmod $v 664 $STUDIO_ROOT/var/log/lastlog
   $bb chmod $v 600 $STUDIO_ROOT/var/log/btmp
 
+  # Load the appropriate type strategy to complete the setup
+  . $libexec_path/bldr-studio-type-${STUDIO_TYPE}.sh
+
   # If `/etc/passwd` is not present, create a minimal version to satisfy
   # some software when being built
   if [ ! -f "$STUDIO_ROOT/etc/passwd" ]; then
@@ -319,8 +322,12 @@ users:x:999:
 EOF
   fi
 
-  # Load the appropriate type strategy to complete the setup
-  . $libexec_path/bldr-studio-type-${STUDIO_TYPE}.sh
+  # Copy minimal networking and DNS resolution configuration files into the
+  # Studio filesystem so that commands such as `wget(1)` will work
+  for f in /etc/hosts /etc/resolv.conf; do
+    $bb mkdir -p $v $($bb dirname $f)
+    $bb cp $v $f $STUDIO_ROOT$f
+  done
 
   # Invoke the type's implementation
   finish_setup
@@ -393,13 +400,6 @@ cd /src
 
 PROFILE
   fi
-
-  # Copy minimal networking and DNS resolution configuration files into the
-  # Studio filesystem so that commands such as `wget(1)` will work
-  for f in /etc/hosts /etc/resolv.conf; do
-    $bb mkdir -p $v $($bb dirname $f)
-    $bb cp $v $f $STUDIO_ROOT$f
-  done
 
   $bb mkdir -p $v $STUDIO_ROOT/src
   # Mount the `$SRC_PATH` under `/src` in the Studio, unless either `$NO_MOUNT`
@@ -687,7 +687,6 @@ set_libexec_path() {
   libexec_path="$($bb dirname $p)/libexec"
   return 0
 }
-
 
 # # Main Flow
 

--- a/plans/bldr-studio/libexec/bldr-studio-type-baseimage.sh
+++ b/plans/bldr-studio/libexec/bldr-studio-type-baseimage.sh
@@ -1,0 +1,135 @@
+studio_type="baseimage"
+studio_path="/opt/bldr/bin"
+studio_enter_environment=
+studio_build_environment=
+studio_build_command="/opt/bldr/bin/build"
+studio_run_environment=
+
+bldr_pkgs="chef/bpm chef/bldr chef/busybox-static"
+PKGS="$PKGS"
+
+finish_setup() {
+  if [ -x "$STUDIO_ROOT/opt/bldr/bin/bpm" ]; then
+    return 0
+  fi
+
+  for embed in $PKGS; do
+    if [ -d "/opt/bldr/pkgs/$embed" ]; then
+      echo "> Using local package for $embed"
+      embed_path=$(_outside_pkgpath_for $embed)
+      $bb mkdir -p $STUDIO_ROOT/$embed_path
+      $bb cp -ra $embed_path/* $STUDIO_ROOT/$embed_path
+      for tdep in $($bb cat $embed_path/TDEPS); do
+        echo "> Using local package for $tdep via $embed"
+        $bb mkdir -p $STUDIO_ROOT/opt/bldr/pkgs/$tdep
+        $bb cp -ra /opt/bldr/pkgs/$tdep/* $STUDIO_ROOT/opt/bldr/pkgs/$tdep
+      done
+    else
+      _bpm install $embed
+    fi
+  done
+
+  for pkg in $bldr_pkgs; do
+    _bpm install $pkg
+  done
+
+  local bpm_path=$(_pkgpath_for chef/bpm)
+  local bldr_path=$(_pkgpath_for chef/bldr)
+  local busybox_path=$(_pkgpath_for chef/busybox-static)
+
+  local full_path="/opt/bldr/bin"
+  for path_pkg in $PKGS chef/bldr chef/busybox-static; do
+    local path_file="$STUDIO_ROOT/$(_pkgpath_for $path_pkg)/PATH"
+    if [ -f "$path_file" ]; then
+      full_path="$full_path:$($bb cat $path_file)"
+    fi
+
+    local tdeps_file="$STUDIO_ROOT/$(_pkgpath_for $path_pkg)/TDEPS"
+    if [ -f "$tdeps_file" ]; then
+      for tdep in $($bb cat $tdeps_file); do
+        local tdep_path_file="$STUDIO_ROOT/$(_pkgpath_for $tdep)/PATH"
+        if [ -f "$tdep_path_file" ]; then
+          full_path="$full_path:$($bb cat $tdep_path_file)"
+        fi
+      done
+    fi
+  done
+
+  studio_path="$full_path"
+  studio_enter_command="${busybox_path}/bin/sh --login"
+
+  $bb mkdir -p $v $STUDIO_ROOT/opt/bldr/bin
+
+  # Put `bpm` on the default `$PATH` and ensure that it gets a sane shell and
+  # initial `busybox` (sane being its own vendored version)
+  $bb cat <<EOF > $STUDIO_ROOT/opt/bldr/bin/bpm
+#!$busybox_path/bin/sh
+exec $bpm_path/bin/bpm \$*
+EOF
+  $bb chmod $v 755 $STUDIO_ROOT/opt/bldr/bin/bpm
+  $bb ln -s $v $busybox_path/bin/sh $STUDIO_ROOT/bin/bash
+  $bb ln -s $v $busybox_path/bin/sh $STUDIO_ROOT/bin/sh
+  $bb ln -s $v $bldr_path/bin/bldr $STUDIO_ROOT/opt/bldr/bin/bldr
+
+  # Set the login shell for any relevant user to be `/bin/bash`
+  $bb sed -e "s,/bin/sh,$busybox_path/bin/bash,g" -i $STUDIO_ROOT/etc/passwd
+
+  $bb cat <<PROFILE > $STUDIO_ROOT/etc/profile
+# Add bpm to the default \$PATH at the front so any wrapping scripts will
+# be found and called first
+export PATH=$full_path:\$PATH
+
+# Colorize grep/egrep/fgrep by default
+alias grep='grep --color=auto'
+alias egrep='egrep --color=auto'
+alias fgrep='fgrep --color=auto'
+
+PROFILE
+
+  $bb cat <<EOT > $STUDIO_ROOT/etc/resolv.conf
+nameserver 8.8.8.8
+nameserver 8.8.4.4
+EOT
+
+  $bb cat <<EOT > $STUDIO_ROOT/etc/nsswitch.conf
+passwd:     files
+group:      files
+shadow:     files
+
+hosts:      files dns
+networks:   files
+
+rpc:        files
+services:   files
+EOT
+  echo bldr:x:42:42:root:/:/bin/sh >> $STUDIO_ROOT/etc/passwd
+  echo bldr:x:42:bldr >> $STUDIO_ROOT/etc/group
+  for X in null ptmx random stdin stdout stderr tty urandom zero
+  do
+      $bb cp -a /dev/$X $STUDIO_ROOT/dev
+  done
+
+  $bb cat <<EOT > $STUDIO_ROOT/init.sh
+#!$busybox_path/bin/sh
+export PATH=$full_path
+exec $bldr_path/bin/bldr "\$@"
+EOT
+  $bb chmod a+x $STUDIO_ROOT/init.sh
+
+  $bb rm $STUDIO_ROOT/opt/bldr/cache/pkgs/*
+
+  studio_env_command="$busybox_path/bin/env"
+}
+
+_bpm() {
+  $bb env BUSYBOX=$bb FS_ROOT=$STUDIO_ROOT $bb sh $bpm $*
+}
+
+_pkgpath_for() {
+  _bpm pkgpath $1 | $bb sed -e "s,^$STUDIO_ROOT,,g"
+}
+
+_outside_pkgpath_for() {
+  $bb env BUSYBOX=$bb $bb sh $bpm pkgpath $1
+}
+

--- a/plans/bldr-studio/libexec/bldr-studio-type-bldr-slim.sh
+++ b/plans/bldr-studio/libexec/bldr-studio-type-bldr-slim.sh
@@ -6,7 +6,7 @@ studio_build_environment=
 studio_build_command="/opt/bldr/bin/build"
 studio_run_environment=
 
-bldr_pkgs="chef/bpm chef/build"
+bldr_pkgs="chef/bpm chef/build chef/bldr-studio"
 
 finish_setup() {
   if [ -x "$STUDIO_ROOT/opt/bldr/bin/bpm" ]; then
@@ -42,6 +42,22 @@ EOF
 exec /opt/bldr/bin/bpm exec chef/build build \$*
 EOF
   $bb chmod $v 755 $STUDIO_ROOT/opt/bldr/bin/build
+
+  # Create a wrapper to dockerize
+  $bb cat <<EOF > $STUDIO_ROOT/opt/bldr/bin/dockerize
+#!$bpm_path/libexec/busybox sh
+cmd=\$(find /opt/bldr/pkgs/chef/bldr-studio -name dockerize)
+exec \$cmd \$*
+EOF
+  $bb chmod $v 755 $STUDIO_ROOT/opt/bldr/bin/dockerize
+
+  # Create a wrapper to studio
+  $bb cat <<EOF > $STUDIO_ROOT/opt/bldr/bin/studio
+#!$bpm_path/libexec/busybox sh
+cmd=\$(find /opt/bldr/pkgs/chef/bldr-studio -name studio)
+exec \$cmd \$*
+EOF
+  $bb chmod $v 755 $STUDIO_ROOT/opt/bldr/bin/studio
 
   $bb ln -s $v $bash_path/bin/bash $STUDIO_ROOT/bin/bash
   $bb ln -s $v bash $STUDIO_ROOT/bin/sh

--- a/plans/bldr-studio/libexec/bldr-studio-type-bldr.sh
+++ b/plans/bldr-studio/libexec/bldr-studio-type-bldr.sh
@@ -3,4 +3,4 @@
 studio_type="bldr"
 studio_enter_command="/opt/bldr/bin/bpm exec chef/backline bash --login +h"
 
-bldr_pkgs="chef/bpm chef/backline"
+bldr_pkgs="chef/bpm chef/backline chef/bldr-studio"

--- a/plans/bldr-studio/plan.sh
+++ b/plans/bldr-studio/plan.sh
@@ -11,6 +11,7 @@ pkg_gpg_key=3853DA6B
 
 do_build() {
   cp -v $PLAN_CONTEXT/bin/studio studio
+  cp -v $PLAN_CONTEXT/bin/dockerize dockerize
   cp -v $PLAN_CONTEXT/libexec/bldr-studio-type-*.sh .
 
   # Embed the release version and author information of the program.
@@ -18,10 +19,16 @@ do_build() {
     -e "s,@author@,$pkg_maintainer,g" \
     -e "s,@version@,$pkg_version/$pkg_rel,g" \
     -i studio
+
+  sed \
+    -e "s,@author@,$pkg_maintainer,g" \
+    -e "s,@version@,$pkg_version/$pkg_rel,g" \
+    -i dockerize
 }
 
 do_install() {
   install -v -D studio $pkg_path/bin/studio
+  install -v -D dockerize $pkg_path/bin/dockerize
   for f in `ls bldr-studio-type-*.sh`; do
     install -v -D $f $pkg_path/libexec/$f
   done

--- a/plans/bldr/plan.sh
+++ b/plans/bldr/plan.sh
@@ -43,7 +43,11 @@ do_install() {
 }
 
 do_docker_image() {
-  ./mkimage.sh
-  docker build -t "bldr/base:${pkg_version}-${pkg_rel}" .
-  docker tag -f bldr/base:${pkg_version}-${pkg_rel} bldr/base:latest
+  return 0
 }
+
+# do_docker_image() {
+#   ./mkimage.sh
+#   docker build -t "bldr/base:${pkg_version}-${pkg_rel}" .
+#   docker tag -f bldr/base:${pkg_version}-${pkg_rel} bldr/base:latest
+# }

--- a/plans/redis/plan.sh
+++ b/plans/redis/plan.sh
@@ -7,9 +7,9 @@ pkg_source=http://download.redis.io/releases/${pkg_name}-${pkg_version}.tar.gz
 pkg_shasum=b2a791c4ea3bb7268795c45c6321ea5abcc24457178373e6a6e3be6372737f23
 pkg_gpg_key=3853DA6B
 pkg_binary_path=(bin)
+pkg_build_deps=(chef/make chef/gcc)
 pkg_deps=(chef/glibc)
 pkg_service_run="bin/redis-server /opt/bldr/srvc/redis/config/redis.config"
-pkg_docker_build="auto"
 pkg_expose=(6379)
 
 do_build() {

--- a/plans/support/cheap-upload.sh
+++ b/plans/support/cheap-upload.sh
@@ -1,4 +1,5 @@
 set -eu
+BLDR_REPO=${BLDR_REPO:-"http://52.11.158.96:32768"}
 if [ -n "${DEBUG:-}" ]; then set -x; fi
 
 pkg_file="$1"


### PR DESCRIPTION
![gif-keyboard-3439039113249482715](https://cloud.githubusercontent.com/assets/4304/13138384/c6fd89be-d5db-11e5-8498-10cc953e2e3f.gif)
- Adds a new 'baseimage' studio type, for making a docker base image
  from a package
- A 'dockerize' command that does the needful of building your studio, then running `docker build`.
- Supports building arbitrary docker containers from arbitrary package
  lists

The new path for getting a docker container is something like:

``` bash
$ studio enter
$ build plan/redis
$ dockerize chef/redis
```

You can also just dockerize any-old package in the depot. Works as long
as you have a docker socket handy.

Next up is figuring out why we have some strange behavior coming out of
bldr-build, and removing the docker features from it entirely. Yay
smaller tools!
