### PR TITLE
[plan] De-optimize gmp plan.

### DIFF
--- a/plans/gmp/plan.sh
+++ b/plans/gmp/plan.sh
@@ -20,7 +20,9 @@ do_prepare() {
 }
 
 do_build() {
-  ./configure --prefix=$pkg_prefix
+  ./configure \
+    --prefix=$pkg_prefix \
+    --build=x86_64-unknown-linux-gnu
   make -j$(nproc)
 }
 


### PR DESCRIPTION
It turns out that GMP self-optimizes itself by default in its `./configure`
script. This change sets an explicit `--build` configure option which enables
the generic C optimizations (i.e., nothing).

> "In general, if you want a library that runs as fast as possible, you should
> configure GMP for the exact CPU type your system uses. However, this may mean
> the binaries won’t run on older members of the family, and might run slower
> on other members, older or newer. _The best idea is always to build GMP for
> the exact machine type you intend to run it on_.”

Source: https://gmplib.org/manual/Build-Options.html
