### PR TITLE
Rename `make pkg-shell` to `make shell`.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ VOLUMES := installed cache_pkgs cache_src cache_keys cargo
 CLEAN_VOLUMES := clean-installed clean-cache_pkgs clean-cache_src clean-cache_keys clean-cargo
 NO_CACHE := false
 
-.PHONY: image test run shell clean bldr-base clean-package package volumes clean-volumes all
+.PHONY: image test run shell pkg-shell clean bldr-base clean-package package volumes clean-volumes all
 
 all: package
 
@@ -73,15 +73,11 @@ repo-serve: image
 	$(run) --service-ports repo cargo run -- repo
 
 shell: image
-	$(run) bldr bash
-
-pkg-shell: image
 	$(run) package bash
 
-bldr-base: package
+pkg-shell: shell
 
-base-shell: image
-	$(run) base
+bldr-base: package
 
 clean:
 	docker-compose kill

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ read the docs at `http://<DOCKER_HOST>:9633/` (with working JavaScript-based sea
 ## Writing new features
 
 1. Start a new feature branch
-1. Open a terminal and run `make pkg-shell`
+1. Open a terminal and run `make shell`
 1. Build with `cargo build` or `cargo test`
 1. You can use `cargo run -- foobar` to pass options to the built binary
 1. Commit your change
@@ -236,7 +236,7 @@ This commit brings the development environment up to date in studio.
 To build a package:
 
 ```bash
-$ make pkg-shell
+$ make shell
 $ studio enter
 $ make gpg
 $ build plans/redis


### PR DESCRIPTION
This change also removes the pre-existing `make shell` and `make
base-shell` targets as they appear to not be in heavy use.
