### PR TITLE
[plans] Correctly set dynamic linker for foundational Plans.

### DIFF
--- a/plans/binutils/ld-wrapper.sh
+++ b/plans/binutils/ld-wrapper.sh
@@ -42,10 +42,11 @@ set -e
 params=("$@")
 
 # Create an empty array for extra arguments.
-extra=()
+before=()
+after=()
 
 # Add the dynamic linker.
-extra+=("-dynamic-linker @dynamic_linker@")
+before+=("-dynamic-linker @dynamic_linker@")
 
 # Add `-rpath` switches.
 #
@@ -53,7 +54,7 @@ extra+=("-dynamic-linker @dynamic_linker@")
 # http://mywiki.wooledge.org/BashFAQ/024
 while read path; do
   if [ -n "$path" ]; then
-    extra+=("-rpath $path")
+    after+=("-rpath $path")
   fi
 done < <(echo $LD_RUN_PATH | tr : '\n')
 
@@ -63,11 +64,15 @@ if [ -n "$DEBUG" ]; then
   for i in "${params[@]}"; do
     echo "  $i" >&2
   done
-  echo "extra flags to @program@:" >&2
-  for i in ${extra[@]}; do
+  echo "before flags to @program@:" >&2
+  for i in ${before[@]}; do
+    echo "  $i" >&2
+  done
+  echo "after flags to @program@:" >&2
+  for i in ${after[@]}; do
     echo "  $i" >&2
   done
 fi
 
 # Become the underlying real program
-exec @program@ "${params[@]}" ${extra[@]}
+exec @program@ ${before[@]} "${params[@]}" ${after[@]}

--- a/plans/binutils/plan.sh
+++ b/plans/binutils/plan.sh
@@ -15,15 +15,9 @@ pkg_gpg_key=3853DA6B
 do_prepare() {
   _verify_tty
 
-  glibc="$(pkg_path_for glibc)"
-
-  # TODO: For the wrapper scripts to function correctly, we need the full
-  # path to bash. Until a bash plan is created, we're going to wing this...
-  bash=/bin/bash
-
-  # TODO: We need a more clever way to calculate/determine the path to ld-*.so
-  dynamic_linker="${glibc}/lib/ld-linux-x86-64.so.2"
-
+  # Add explicit linker instructions as the binutils we are using may have its
+  # own dynamic linker defaults.
+  dynamic_linker="$(pkg_path_for glibc)/lib/ld-linux-x86-64.so.2"
   LDFLAGS="$LDFLAGS -Wl,-rpath=${LD_RUN_PATH},--enable-new-dtags"
   LDFLAGS="$LDFLAGS -Wl,--dynamic-linker=$dynamic_linker"
   export LDFLAGS
@@ -33,6 +27,10 @@ do_prepare() {
   # on our /tools install.
   export CFLAGS="$CFLAGS -static-libgcc"
   build_line "Updating CFLAGS=$CFLAGS"
+
+  # TODO: For the wrapper scripts to function correctly, we need the full
+  # path to bash. Until a bash plan is created, we're going to wing this...
+  bash=/bin/bash
 
   # Make `--enable-new-dtags` the default so that the linker sets `RUNPATH`
   # instead of `RPATH` in ELF binaries. This is important as `RPATH` is

--- a/plans/file/plan.sh
+++ b/plans/file/plan.sh
@@ -15,9 +15,13 @@ pkg_gpg_key=3853DA6B
 do_prepare() {
   do_default_prepare
 
-  # TODO: We need a more clever way to calculate/determine the path to ld-*.so
+  # Add explicit linker instructions as the binutils we are using may have its
+  # own dynamic linker defaults. This is necessary because this Plan is built
+  # before the `chef/binutils` Plan which will set the new `chef/glibc` dynamic
+  # linker for all later Plans.
+  dynamic_linker="$(pkg_path_for glibc)/lib/ld-linux-x86-64.so.2"
   LDFLAGS="$LDFLAGS -Wl,-rpath=${LD_RUN_PATH},--enable-new-dtags"
-  LDFLAGS="$LDFLAGS -Wl,--dynamic-linker=$(pkg_path_for glibc)/lib/ld-2.22.so"
+  LDFLAGS="$LDFLAGS -Wl,--dynamic-linker=$dynamic_linker"
   export LDFLAGS
   build_line "Updating LDFLAGS=$LDFLAGS"
 }

--- a/plans/gcc/plan.sh
+++ b/plans/gcc/plan.sh
@@ -18,13 +18,9 @@ do_prepare() {
   binutils="$(pkg_path_for binutils)"
   headers="$glibc/include"
 
-  # TODO: For the wrapper scripts to function correctly, we need the full
-  # path to bash. Until a bash plan is created, we're going to wing this...
-  bash=/bin/bash
-
-  # TODO: We need a more clever way to calculate/determine the path to ld-*.so
-  dynamic_linker="${glibc}/lib/ld-linux-x86-64.so.2"
-
+  # Add explicit linker instructions as the binutils we are using may have its
+  # own dynamic linker defaults.
+  dynamic_linker="$(pkg_path_for glibc)/lib/ld-linux-x86-64.so.2"
   LDFLAGS="$LDFLAGS -Wl,-rpath=${LD_RUN_PATH},--enable-new-dtags"
   LDFLAGS="$LDFLAGS -Wl,--dynamic-linker=$dynamic_linker"
   build_line "Updating LDFLAGS=$LDFLAGS"
@@ -52,6 +48,10 @@ do_prepare() {
   # Ensure gcc can find the shared libs for zlib
   export LIBRARY_PATH="$(pkg_path_for zlib)/lib"
   build_line "Setting LIBRARY_PATH=$LIBRARY_PATH"
+
+  # TODO: For the wrapper scripts to function correctly, we need the full
+  # path to bash. Until a bash plan is created, we're going to wing this...
+  bash=/bin/bash
 
   # Tell gcc not to look under the default `/lib/` and `/usr/lib/` directories
   # for libraries

--- a/plans/zlib/plan.sh
+++ b/plans/zlib/plan.sh
@@ -12,9 +12,15 @@ pkg_include_dirs=(include)
 pkg_gpg_key=3853DA6B
 
 do_prepare() {
-  # TODO: We need a more clever way to calculate/determine the path to ld-*.so
+  do_default_prepare
+
+  # Add explicit linker instructions as the binutils we are using may have its
+  # own dynamic linker defaults. This is necessary because this Plan is built
+  # before the `chef/binutils` Plan which will set the new `chef/glibc` dynamic
+  # linker for all later Plans.
+  dynamic_linker="$(pkg_path_for glibc)/lib/ld-linux-x86-64.so.2"
   LDFLAGS="$LDFLAGS -Wl,-rpath=${LD_RUN_PATH},--enable-new-dtags"
-  LDFLAGS="$LDFLAGS -Wl,--dynamic-linker=$(pkg_path_for glibc)/lib/ld-2.22.so"
+  LDFLAGS="$LDFLAGS -Wl,--dynamic-linker=$dynamic_linker"
   export LDFLAGS
   build_line "Updating LDFLAGS=$LDFLAGS"
 }


### PR DESCRIPTION
This change fixes the following problem:
- A `chef/binutils` & `chef/gcc`, both built with `chef/glibc` version "a.b.c"
- Build a new version of `chef/glibc` (x.y.z) using the above software
- The dynamic linker entry for `chef/glibc` x.y.z binaries is the one from
  `chef/glibc` a.b.c
- When `chef/glibc` x.y.z is installed in a new Studio, its binaries fail as
  they need the dynamic linker from `chef/glibc` a.b.c

The main underlying cause of this issue was the `ld-wrapper.sh` script in the
`chef/binutils` Plan. It was incorrectly adding the `-dynamic-linker` option
after the passed arguments to the `ld` binary, meaning that its own dynamic
linker was set last and thus always chosen, even when a `-W1,dynamic-linker`
entry was added to a Plan's `LDCONFIG` environment variable. The main fix in
this change is that the default dynamic linker is added before the passed
arugments and allows us to override the default with a customer dynamic linker.
Now the fixed behavior is:
- A `chef/binutils` & `chef/gcc`, both built with `chef/glibc` version "a.b.c"
- Build a new version of `chef/glibc` (x.y.z) using the above software
- The dynamic linker entry for `chef/glibc` x.y.z binaries is the one from
  itself--x.y.z
- Any Plans built between `chef/glibc` and `chef/gcc` with custom
  `-W1,dynamic-linker` setting in `LDFLAGS` gets honored and not ignored
