### PR TITLE
Reduce the complexity of the root Makefile.

### DIFF
--- a/.delivery/cookbooks/bldr/recipes/functional.rb
+++ b/.delivery/cookbooks/bldr/recipes/functional.rb
@@ -30,7 +30,7 @@ makelog = ::File.join(Chef::Config[:file_cache_path],
 # otherwise :)
 Chef::Log.warn("`make` will log output to #{makelog}")
 
-execute "make clean package functional force=true 2>&1 | tee #{makelog}" do
+execute "make clean functional force=true 2>&1 | tee #{makelog}" do
   cwd node['delivery']['workspace']['repo']
   # set a two hour time out because this compiles :allthethings:
   timeout 7200

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,35 +1,35 @@
 FROM ubuntu:latest
-MAINTAINER Adam Jacob <adam@chef.io>
-
-ENV TRIPLE x86_64-unknown-linux-gnu
+MAINTAINER The Bldr Maintainers <bldr@chef.io>
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    dh-autoreconf \
     build-essential \
-    patchutils \
     ca-certificates \
     curl \
+    dh-autoreconf \
     file \
     gawk \
     gdb \
     gnupg \
+    libarchive-dev \
+    libclang-dev \
     libncurses5-dev \
     libncursesw5-dev \
+    libgpgme11-dev \
     libssl-dev \
     libssl-doc \
     man \
+    m4 \
     npm \
+    patchutils \
+    pkg-config \
     rsync \
     wget \
-    m4 \
-    pkg-config \
-    libgpgme11-dev \
-    libarchive-dev \
-    libclang-dev \
   && rm -rf /var/lib/apt/lists/*
 
-ENV SHELL /bin/bash
 ENV CARGO_HOME /bldr-cargo-cache
+
+ARG BLDR_REPO
+ENV BLDR_REPO ${BLDR_REPO:-}
 
 RUN curl -s https://static.rust-lang.org/rustup.sh | sh -s -- -y && rustc -V
 RUN curl -sSL https://get.docker.io | sh && docker -v

--- a/Makefile
+++ b/Makefile
@@ -1,101 +1,60 @@
-build_args :=
-run_args :=
-ifneq (${docker_http_proxy},)
-	_http_proxy := http_proxy="${docker_http_proxy}"
-	build_args := $(build_args) --build-arg $(_http_proxy)
-	run_args := $(run_args) -e $(_http_proxy)
+build_args := --build-arg BLDR_REPO=$(BLDR_REPO)
+run_args := -e BLDR_REPO=$(BLDR_REPO)
+ifneq (${http_proxy},)
+	build_args := $(build_args) --build-arg http_proxy="${http_proxy}"
+	run_args := $(run_args) -e http_proxy="${http_proxy}"
 endif
-ifneq (${docker_https_proxy},)
-	_https_proxy := https_proxy="${docker_https_proxy}"
-	build_args := $(build_args) --build-arg $(_https_proxy)
-	run_args := $(run_args) -e $(_https_proxy)
+ifneq (${https_proxy},)
+	build_args := $(build_args) --build-arg https_proxy="${https_proxy}"
+	run_args := $(run_args) -e https_proxy="${https_proxy}"
 endif
 
-run := docker-compose run --rm $(run_args)
-IMAGE := chef/bldr
-VOLUMES := installed cache_pkgs cache_src cache_keys cargo
-CLEAN_VOLUMES := clean-installed clean-cache_pkgs clean-cache_src clean-cache_keys clean-cargo
-NO_CACHE := false
+docker_cmd := env http_proxy= https_proxy= docker
+compose_cmd := env http_proxy= https_proxy= docker-compose
+run := $(compose_cmd) run --rm $(run_args)
+dimage := bldr/devshell
 
-.PHONY: image test run shell pkg-shell clean bldr-base clean-package package volumes clean-volumes all
+.PHONY: build shell docs-serve test unit functional clean image docs
 
-all: package
+build: image
+	$(run) shell cargo build
 
-package: image
-ifeq ($(GITHUB_DEPLOY_KEY),)
-	$(run) package sh -c '(cd /src/plans && make bldr-deps bldr-webui)'
-else
-	$(run) package sh -c "chmod +x /usr/local/bin/ssh_wrapper.sh /usr/local/bin/git_src_checkout.sh; GITHUB_DEPLOY_KEY=\"$${GITHUB_DEPLOY_KEY}\" DELIVERY_GIT_SHASUM=${DELIVERY_GIT_SHASUM} /bin/bash /usr/local/bin/git_src_checkout.sh && (cd /src/plans && make bldr-deps bldr-webui)"
-endif
+shell: image
+	$(run) shell
 
-clean-package: image
-	$(run) package sh -c 'rm -rf /opt/bldr/cache/pkgs/* /opt/bldr/pkgs/*'
-
-volumes: $(VOLUMES)
-
-$(VOLUMES):
-	docker-compose up -d $@
-
-clean-volumes: $(CLEAN_VOLUMES)
-
-$(CLEAN_VOLUMES):
-	docker-compose rm -f `echo $@ | sed 's/^clean-//'`
-
-image:
-	if [ -n "${force}" -o -z "`docker images -q $(IMAGE)`" ]; then docker build $(build_args) -t $(IMAGE) --no-cache=${NO_CACHE} .; fi
+docs-serve: docs
+	@echo "==> View the docs at:\n\n        http://`\
+		echo ${DOCKER_HOST} | sed -e 's|^tcp://||' -e 's|:[0-9]\{1,\}$$||'`:9633/\n\n"
+	$(run) -p 9633:9633 shell sh -c 'set -e; cd ./target/doc; python -m SimpleHTTPServer 9633;'
 
 test: image
-	$(run) package cargo test
+	$(run) shell cargo test
 
 unit: image
-	$(run) package cargo test --lib
+	$(run) shell cargo test --lib
 
 functional: image
-	$(run) package cargo test --test functional
+	$(run) shell cargo test --test functional
 
-cargo-clean: image
-	$(run) package cargo clean
+clean:
+	rm -rf target/debug target/release
+	$(compose_cmd) stop
+	$(compose_cmd) rm -f -v
+	$(docker_cmd) rmi $(dimage) || true
+	($(docker_cmd) images -q -f dangling=true | xargs $(docker_cmd) rmi -f) || true
+
+image:
+	if [ -n "${force}" -o -z "`$(docker_cmd) images -q $(dimage)`" ]; then \
+		$(docker_cmd) build $(build_args) -t $(dimage) .; \
+	fi
 
 docs: image
-	$(run) package sh -c 'set -ex; \
+	$(run) shell sh -c 'set -ex; \
 		cargo doc; \
 		rustdoc --crate-name bldr README.md -o ./target/doc/bldr; \
 		docco -e .sh -o target/doc/bldr/bldr-build plans/bldr-build; \
 		cp -r images ./target/doc/bldr; \
 		echo "<meta http-equiv=refresh content=0;url=bldr/index.html>" > target/doc/index.html;'
 
-doc-serve: image
-	@echo "==> View the docs at:\n\n        http://`\
-		echo ${DOCKER_HOST} | sed -e 's|^tcp://||' -e 's|:[0-9]\{1,\}$$||'`:9633/\n\n"
-	$(run) -p 9633:9633 package sh -c 'set -e; cd ./target/doc; python -m SimpleHTTPServer 9633;'
-
-repo-serve: image
-	$(run) --service-ports repo cargo run -- repo
-
-shell: image
-	$(run) package bash
-
+# Alias to `make shell` for the "old fingers" crowd
 pkg-shell: shell
-
-bldr-base: package
-
-clean:
-	docker-compose kill
-	docker-compose rm -f -v
-	(docker images -q -f dangling=true | xargs docker rmi -f) || true
-
-gpg:
-	mkdir -p /opt/bldr/cache/gpg
-	- gpg --import /src/plans/chef-public.gpg
-	- gpg --import /src/plans/chef-private.gpg
-	- gpg --homedir /opt/bldr/cache/gpg --import /src/plans/chef-public.gpg
-	- gpg --homedir /opt/bldr/cache/gpg --import /src/plans/chef-private.gpg
-
-redis:
-	$(run) bldr cargo run -- start chef/redis
-
-publish:
-	for x in `docker images | egrep '^bldr/base' | awk '{print $2}'`; do \
-		docker tag -f bldr/base:$x quay.io/bldr/base:$x ; \
-	done
-	docker push quay.io/bldr/base

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ install it, and you're done!
 
 Run `make docs` to build the internal documentation for bldr.
 
-Run `make doc-serve` to run a small web server that exposes the documentation on port `9633`. You can then
+Run `make docs-serve` to run a small web server that exposes the documentation on port `9633`. You can then
 read the docs at `http://<DOCKER_HOST>:9633/` (with working JavaScript-based search).
 
 ## Writing new features

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,5 @@
-bldr:
-  image: chef/bldr
-  privileged: true
-  volumes:
-    - .:/src
-    - /var/run/docker.sock:/var/run/docker.sock
-  volumes_from:
-    - cache_keys
-    - cargo
-  links:
-    - repo
-
-package:
-  image: chef/bldr
+shell:
+  image: bldr/devshell
   privileged: true
   volumes:
     - .:/src
@@ -21,47 +9,17 @@ package:
     - cache_keys
     - cargo
 
-repo:
-  image: chef/bldr
-  privileged: true
-  ports:
-    - "9632:9632"
-  environment:
-    DOCKER_CERT_PATH: "/docker-certs"
-    DOCKER_TLS_VERIFY: 1
-  volumes:
-    - .:/src
-    - "~/.docker/machine/certs:/docker-certs"
-  volumes_from:
-    - installed
-    - cargo
-
-base:
-  image: bldr
-
 cache_src:
   image: tianon/true
   command: /true
   volumes:
     - /opt/bldr/cache/src
 
-cache_pkgs:
-  image: tianon/true
-  command: /true
-  volumes:
-    - /opt/bldr/cache/pkgs
-
 cache_keys:
   image: tianon/true
   command: /true
   volumes:
     - /opt/bldr/cache/keys
-
-installed:
-  image: tianon/true
-  command: /true
-  volumes:
-    - /opt/bldr/pkgs
 
 cargo:
   image: tianon/true


### PR DESCRIPTION
This change puts our root Makefile, Dockerfile, and docker-compose.yml
on a diet. Only what is purely required is specified and any older
targets are purged.

The biggest change is that the default `make` target is not `make build`
which creates the Docker development image and compiles the supervisor
Rust project.

Additionally, `make doc-serve` has been renamed to `make docs-serve`.
