### PR TITLE
Fix node plan, add python plans

### DIFF
--- a/plans/node/plan.sh
+++ b/plans/node/plan.sh
@@ -2,14 +2,23 @@ pkg_name=node
 pkg_derivation=chef
 pkg_version=4.2.6
 pkg_license=('MIT')
-pkg_maintainer="Dave Parfitt <dparfitt@chef.io>"
+pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
 pkg_source=https://nodejs.org/dist/v${pkg_version}/${pkg_name}-v${pkg_version}.tar.gz
 # the archive contains a 'v' version # prefix, but the default value of
 # pkg_version is node-4.2.6 (without the v). This tweak makes bldr-build happy
 pkg_dirname=node-v${pkg_version}
 pkg_shasum=ea5e357db8817052b17496d607c719d809ed1383e8fcf7c8ffc5214e705aefdd
 pkg_gpg_key=3853DA6B
-pkg_deps=(chef/glibc)
+pkg_deps=(chef/glibc chef/gcc-libs)
+pkg_build_deps=(chef/python2 chef/gcc chef/make chef/coreutils)
 pkg_lib_dirs=(lib)
 pkg_include_dirs=(include)
 pkg_binary_path=(bin)
+pkg_interpreters=(bin/node)
+
+do_build() {
+    fix_interpreter configure chef/coreutils bin/env
+
+    # use --without-snapshot, because https://github.com/nodejs/node/issues/4212
+    ./configure --prefix=${pkg_prefix} --without-snapshot && make && make install
+}

--- a/plans/python/plan.sh
+++ b/plans/python/plan.sh
@@ -1,0 +1,21 @@
+pkg_name=python
+pkg_version=3.5.1
+pkg_derivation=chef
+pkg_license=('python')
+pkg_dirname=Python-${pkg_version}
+pkg_source=https://www.python.org/ftp/python/${pkg_version}/${pkg_dirname}.tgz
+pkg_filename=${pkg_dirname}.tgz
+pkg_shasum=687e067d9f391da645423c7eda8205bae9d35edc0c76ef5218dcbe4cc770d0d7
+pkg_gpg_key=3853DA6B
+pkg_deps=(chef/glibc chef/gcc-libs chef/coreutils chef/make chef/ncurses chef/zlib chef/readline chef/openssl chef/bzip2)
+pkg_build_deps=(chef/linux-headers chef/gcc)
+pkg_lib_dirs=(lib)
+pkg_binary_path=(bin)
+pkg_include_dirs=(include Include)
+pkg_interpreters=(bin/python bin/python3 bin/python3.5)
+
+do_build() {
+    ./configure --prefix=${pkg_prefix} \
+                --enable-shared
+    make
+}

--- a/plans/python2/plan.sh
+++ b/plans/python2/plan.sh
@@ -1,0 +1,21 @@
+pkg_name=python2
+pkg_version=2.7.11
+pkg_derivation=chef
+pkg_license=('python')
+pkg_dirname=Python-${pkg_version}
+pkg_source=https://www.python.org/ftp/python/${pkg_version}/${pkg_dirname}.tgz
+pkg_filename=${pkg_dirname}.tgz
+pkg_shasum=82929b96fd6afc8da838b149107078c02fa1744b7e60999a8babbc0d3fa86fc6
+pkg_gpg_key=3853DA6B
+pkg_deps=(chef/glibc chef/gcc-libs chef/coreutils chef/make chef/ncurses chef/zlib chef/readline chef/openssl chef/bzip2)
+pkg_build_deps=(chef/linux-headers chef/gcc)
+pkg_lib_dirs=(lib)
+pkg_binary_path=(bin)
+pkg_include_dirs=(include Include)
+pkg_interpreters=(bin/python bin/python2 bin/python2.7)
+
+do_build() {
+    ./configure --prefix=${pkg_prefix} \
+                --enable-shared
+    make
+}


### PR DESCRIPTION
In our studio build environment, we don't have /usr/bin/env, which the configure script for node hardcodes. We use the fix_interpreter function in bldr-build to fix this. 

Node's build requires python, which we also don't have in our studio build environment, so we need to depend on it. Which means we need a plan for it. Node mentions 2.6 or 2.7 on their site, which will be the python2 package. Because the build is basically the same between python 2 and 3, the python plan is also added which will default to 3.
