### PR TITLE
[plan] Add diffutils to the backline plan.

### DIFF
--- a/plans/backline/plan.sh
+++ b/plans/backline/plan.sh
@@ -9,6 +9,7 @@ pkg_gpg_key=3853DA6B
 
 pkg_deps=(
   chef/build
+  chef/diffutils
   chef/less
   chef/make
   chef/mg


### PR DESCRIPTION
The backline Plan provides the interactive environment for our default
Studio type and having `diff` on PATH is really helpful. The driving
desire for this additon was in the creation of a patch file, which is
usually produced with some combination of
`diff -ur <ORIG_DIR> <CHANGED_DIR>`.
