### PR TITLE
build deps in a post studio world

### DIFF
--- a/plans/diffutils/plan.sh
+++ b/plans/diffutils/plan.sh
@@ -6,7 +6,7 @@ pkg_license=('gplv3+')
 pkg_source=http://ftp.gnu.org/gnu/$pkg_name/${pkg_name}-${pkg_version}.tar.xz
 pkg_shasum=a25e89a8ab65fded1731e4186be1bb25cda967834b6df973599cdcd5abdfc19c
 pkg_deps=(chef/glibc)
-pkg_build_deps=(chef/coreutils chef/diffutils chef/patch chef/make chef/gcc chef/sed)
+pkg_build_deps=(chef/coreutils chef/patch chef/make chef/gcc chef/sed)
 pkg_binary_path=(bin)
 pkg_gpg_key=3853DA6B
 

--- a/plans/libedit/plan.sh
+++ b/plans/libedit/plan.sh
@@ -7,6 +7,7 @@ pkg_dirname=${pkg_name}-20150325-3.1
 pkg_shasum=c88a5e4af83c5f40dda8455886ac98923a9c33125699742603a88a0253fcc8c5
 pkg_gpg_key=3853DA6B
 pkg_deps=(chef/glibc chef/ncurses)
+pkg_build_deps=(chef/gcc chef/make chef/coreutils)
 pkg_lib_dirs=(lib)
 pkg_include_dirs=(include)
 

--- a/plans/nginx/plan.sh
+++ b/plans/nginx/plan.sh
@@ -7,12 +7,12 @@ pkg_source=http://nginx.org/download/nginx-1.8.0.tar.gz
 pkg_shasum=23cca1239990c818d8f6da118320c4979aadf5386deda691b1b7c2c96b9df3d5
 pkg_gpg_key=3853DA6B
 pkg_deps=(chef/glibc chef/libedit chef/ncurses chef/zlib chef/bzip2 chef/openssl chef/pcre)
+pkg_build_deps=(chef/gcc chef/make chef/coreutils)
 pkg_lib_dirs=(lib)
 pkg_binary_path=(sbin)
 pkg_include_dirs=(include)
 pkg_service_run="sbin/nginx"
 pkg_service_user="root"
-pkg_docker_build="auto"
 pkg_expose=(80 443)
 
 do_build() {

--- a/plans/patch/plan.sh
+++ b/plans/patch/plan.sh
@@ -6,7 +6,7 @@ pkg_license=('gplv3+')
 pkg_source=http://ftp.gnu.org/gnu/$pkg_name/${pkg_name}-${pkg_version}.tar.xz
 pkg_shasum=fd95153655d6b95567e623843a0e77b81612d502ecf78a489a4aed7867caa299
 pkg_deps=(chef/glibc chef/attr)
-pkg_build_deps=(chef/coreutils chef/diffutils chef/patch chef/make chef/gcc chef/sed)
+pkg_build_deps=(chef/coreutils chef/diffutils chef/make chef/gcc chef/sed)
 pkg_binary_path=(bin)
 pkg_gpg_key=3853DA6B
 


### PR DESCRIPTION
This commit adjusts the build deps for a few plans that didn't have binaries after we switched to studio for builds.
