### PR TITLE
Update `make gpg` instructions in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ To build a package:
 ```bash
 $ make shell
 $ studio enter
-$ make gpg
+$ (cd plans; make gpg)
 $ build plans/redis
 ```
 


### PR DESCRIPTION
After the Makefile clean change, there is no longer a `gpg` target in
the root Makefile. Consequently the `make gpg` needs to be run from the
`plans/` subdirectory. As this is a stand-in for a more correct future
behavior a slightly worse user experience here is not a terrible loss.
