### PR TITLE
[plans] Fix the bldr Plan and several dependent ones.

### DIFF
--- a/plans/bldr/plan.sh
+++ b/plans/bldr/plan.sh
@@ -1,12 +1,33 @@
 pkg_name=bldr
 pkg_derivation=chef
 pkg_version=0.4.0
-pkg_license=('Apache2')
+pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
+pkg_license=('apachev2')
 pkg_source=nosuchfile.tar.gz
-pkg_gpg_key=3853DA6B
 pkg_binary_path=(bin)
-pkg_build_deps=(chef/coreutils chef/tar chef/patchelf chef/cacerts chef/rust chef/gcc)
-pkg_deps=(chef/openssl chef/runit chef/gpgme chef/libarchive chef/libgpg-error)
+pkg_deps=(chef/glibc chef/openssl chef/gcc-libs chef/gpgme chef/libarchive chef/libgpg-error chef/runit chef/rngd)
+pkg_build_deps=(chef/coreutils chef/cacerts chef/rust chef/gcc)
+pkg_gpg_key=3853DA6B
+
+do_build() {
+  pushd $PLAN_CONTEXT > /dev/null
+  cargo clean
+  env OPENSSL_LIB_DIR=$(pkg_path_for chef/openssl)/lib \
+      OPENSSL_INCLUDE_DIR=$(pkg_path_for chef/openssl)/include \
+      GPGME_CONFIG=$(pkg_path_for chef/gpgme)/bin/gpgme-config \
+      GPG_ERROR_CONFIG=$(pkg_path_for chef/libgpg-error)/bin/gpg-error-config \
+      LIBARCHIVE_LIB_DIR=$(pkg_path_for chef/libarchive)/lib \
+      LIBARCHIVE_INCLUDE_DIR=$(pkg_path_for chef/libarchive)/include \
+      SSL_CERT_FILE=$(pkg_path_for chef/cacerts)/ssl/cert.pem \
+      cargo build --verbose
+  popd > /dev/null
+}
+
+do_install() {
+  install -v -D $PLAN_CONTEXT/../../target/debug/bldr $pkg_path/bin/bldr
+}
+
+# Turn the remaining default phases into no-ops
 
 do_download() {
   return 0
@@ -23,31 +44,3 @@ do_unpack() {
 do_prepare() {
   return 0
 }
-
-do_build() {
-  pushd $PLAN_CONTEXT
-  cargo clean
-  env OPENSSL_LIB_DIR=$(pkg_path_for chef/openssl)/lib \
-      OPENSSL_INCLUDE_DIR=$(pkg_path_for chef/openssl)/include \
-      GPGME_CONFIG=$(pkg_path_for chef/gpgme)/bin/gpgme-config \
-      GPG_ERROR_CONFIG=$(pkg_path_for chef/libgpg-error)/bin/gpg-error-config \
-      LIBARCHIVE_LIB_DIR=$(pkg_path_for chef/libarchive)/lib \
-      LIBARCHIVE_INCLUDE_DIR=$(pkg_path_for chef/libarchive)/include \
-      SSL_CERT_FILE=$(pkg_path_for chef/cacerts)/ssl/cert.pem \
-      cargo build --verbose
-}
-
-do_install() {
-  mkdir -p $pkg_path/bin
-  cp $PLAN_CONTEXT/../../target/debug/bldr $pkg_path/bin
-}
-
-do_docker_image() {
-  return 0
-}
-
-# do_docker_image() {
-#   ./mkimage.sh
-#   docker build -t "bldr/base:${pkg_version}-${pkg_rel}" .
-#   docker tag -f bldr/base:${pkg_version}-${pkg_rel} bldr/base:latest
-# }

--- a/plans/m4/plan.sh
+++ b/plans/m4/plan.sh
@@ -14,6 +14,12 @@ do_prepare() {
   # Force gcc to use our ld wrapper from binutils when calling `ld`
   CFLAGS="$CFLAGS -B$(pkg_path_for binutils)/bin/"
   build_line "Updating CFLAGS=$CFLAGS"
+
+  # Add explicit linker instructions as the binutils we are using may have its
+  # own dynamic linker defaults.
+  dynamic_linker="$(pkg_path_for glibc)/lib/ld-linux-x86-64.so.2"
+  LDFLAGS="$LDFLAGS -Wl,--dynamic-linker=$dynamic_linker"
+  build_line "Updating LDFLAGS=$LDFLAGS"
 }
 
 do_check() {

--- a/plans/rngd/plan.sh
+++ b/plans/rngd/plan.sh
@@ -1,19 +1,22 @@
 pkg_name=rngd
 pkg_derivation=chef
 pkg_version=5
-pkg_license=('GPLv2')
 pkg_maintainer="Dave Parfitt <dparfitt@chef.io>"
+pkg_license=('gplv2')
 pkg_source=http://http.debian.net/debian/pool/main/r/rng-tools/rng-tools_2-unofficial-mt.14.orig.tar.bz2
 pkg_shasum=a3791d566106873c361e19819f79c4fff44514cdf65c10f8a16e9ee3840f04ee
-pkg_gpg_key=3853DA6B
-pkg_binary_path=(bin)
 pkg_deps=(chef/glibc)
+pkg_build_deps=(chef/coreutils chef/autoconf chef/automake chef/make chef/gcc)
 # package has a _ but the extracted dir has a -
 pkg_dirname=rng-tools-2-unofficial-mt.14
+pkg_binary_path=(bin)
 pkg_service_run="sbin/rngd -f -r /dev/urandom"
 pkg_service_user=root
+pkg_gpg_key=3853DA6B
 
 do_build() {
-    ./autogen.sh && ./configure --prefix=$pkg_prefix  && make
+  ./autogen.sh
+  ./configure --prefix=$pkg_prefix
+  make
 }
 


### PR DESCRIPTION
This change attempts to more correctly build a `chef/bldr` package that
captures all the runtime dependencies which are required. In the process
of refreshing dependent Plans, several issues were encountered and so
included:
- The rngd plan lacked a `pkg_build_deps` entry and so was not able to
  successfully build in a Studio, so this was addressed
- The m4 plan was setting an old dynamic linker entry in the `bin/m4`
  entry and so had to be fixed
