### PR TITLE
convert references of derivation to origin, project wide

### DIFF
--- a/plans/acl/plan.sh
+++ b/plans/acl/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=acl
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=2.2.52
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
 pkg_license=('lgpl')

--- a/plans/apr-util/plan.sh
+++ b/plans/apr-util/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=apr-util
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=1.5.4
 pkg_license=('Apache2')
 pkg_source=http://www.us.apache.org/dist/apr/${pkg_name}-${pkg_version}.tar.bz2

--- a/plans/apr/plan.sh
+++ b/plans/apr/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=apr
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=1.5.2
 pkg_license=('Apache2')
 pkg_source=http://www.us.apache.org/dist/apr/${pkg_name}-${pkg_version}.tar.bz2

--- a/plans/attr/plan.sh
+++ b/plans/attr/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=attr
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=2.4.47
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
 pkg_license=('gplv2+')

--- a/plans/autoconf/plan.sh
+++ b/plans/autoconf/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=autoconf
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=2.69
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
 pkg_license=('gplv2+')

--- a/plans/automake/plan.sh
+++ b/plans/automake/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=automake
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=1.15
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
 pkg_license=('gplv2+')

--- a/plans/backline/plan.sh
+++ b/plans/backline/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=backline
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=0.1.0
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
 pkg_license=('apachev2')

--- a/plans/bash/plan.sh
+++ b/plans/bash/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=bash
 pkg_distname=$pkg_name
-pkg_derivation=chef
+pkg_origin=chef
 _base_version=4.3
 pkg_version=${_base_version}.42
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"

--- a/plans/bc/plan.sh
+++ b/plans/bc/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=bc
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=1.06.95
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
 pkg_license=('gplv3+')

--- a/plans/binutils/plan.sh
+++ b/plans/binutils/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=binutils
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=2.25.1
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
 pkg_license=('gpl')

--- a/plans/bison/plan.sh
+++ b/plans/bison/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=bison
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=3.0.4
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
 pkg_license=('gplv3')

--- a/plans/bldr-build
+++ b/plans/bldr-build
@@ -149,13 +149,12 @@
 # pkg_expose=(80 443)
 # ```
 #
-# ### pkg_derivation
-# A string to use for the derivation. Defaults to bldr. The derivation is used
-# to denote a particular upstream of a package; when we resolve dependencies,
-# we consider a version of a package to be equal regardless of its derivation -
-# but you can specify what you prefer to use.
+# ### pkg_origin
+# A string to use for the origin. The origin is used to denote a particular upstream of a
+# package; when we resolve dependencies, we consider a version of a package to be equal
+# regardless of its origin - but you can specify what you prefer to use.
 # ```
-# pkg_derivation=bldr
+# pkg_origin=chef
 # ```
 #
 # ### pkg_interpreters
@@ -289,8 +288,8 @@ PLAN_CONTEXT=${1:-.}
 : ${BLDR_REPO:=http://52.11.158.96:32768}
 # The value of `$PATH` on initial start of this program
 BLDR_INITIAL_PATH="$PATH"
-# The default derivation is `bldr`
-pkg_derivation=""
+# The package's origin (i.e. chef)
+pkg_origin=""
 # Each release is a timestamp - `YYYYMMDDhhmmss`
 pkg_rel=$(date -u +%Y%m%d%H%M%S)
 # The default build deps setting - an empty array
@@ -535,7 +534,7 @@ _resolve_dependency() {
   local dep="$1"
   local dep_path
   if ! echo "$dep" | grep -q '\/' > /dev/null; then
-    warn "Derivation required for '$dep' in plan '$pkg_derivation/$pkg_name' (example: chef/$dep)"
+    warn "Origin required for '$dep' in plan '$pkg_origin/$pkg_name' (example: chef/$dep)"
     return 1
   fi
 
@@ -1616,7 +1615,7 @@ _build_metadata() {
     echo "$deps" > $pkg_path/TDEPS
   fi
 
-  echo "${pkg_derivation}/${pkg_name}/${pkg_version}/${pkg_rel}" >> $pkg_path/IDENT
+  echo "${pkg_origin}/${pkg_name}/${pkg_version}/${pkg_rel}" >> $pkg_path/IDENT
 
   return 0
 }
@@ -1713,7 +1712,7 @@ do_default_strip() {
 _build_manifest() {
 build_line "Creating manifest"
 cat <<-EOT >> $pkg_path/MANIFEST
-$pkg_derivation $pkg_name
+$pkg_origin $pkg_name
 =========================
 
 Maintainer: $pkg_maintainer
@@ -1756,7 +1755,7 @@ _generate_package() {
   $_tar_cmd -cf - "$pkg_path" | $_gpg_cmd \
     --set-filename x.tar \
     --local-user $pkg_gpg_key \
-    --output $BLDR_PKG_CACHE/${pkg_derivation}-${pkg_name}-${pkg_version}-${pkg_rel}.bldr\
+    --output $BLDR_PKG_CACHE/${pkg_origin}-${pkg_name}-${pkg_version}-${pkg_rel}.bldr\
     --sign
   return 0
 }
@@ -1818,9 +1817,9 @@ else
   exit_with "Failed to load Plan" $ret
 fi
 
-# `$pkg_derivation` is a required metadata key
-if [[ -z "${pkg_derivation}" ]]; then
-  exit_with "Failed to build. 'pkg_derivation' must be set." 1
+# `$pkg_origin` is a required metadata key
+if [[ -z "${pkg_origin}" ]]; then
+  exit_with "Failed to build. 'pkg_origin' must be set." 1
 fi
 
 # `$pkg_version` is a required metadata key
@@ -1847,12 +1846,12 @@ fi
 
 # Set `$pkg_path` if it is not already set by the `plan.sh`.
 if [[ -z "${pkg_path+xxx}" ]]; then
-  pkg_path=$BLDR_PKG_ROOT/${pkg_derivation}/${pkg_name}/${pkg_version}/${pkg_rel}
+  pkg_path=$BLDR_PKG_ROOT/${pkg_origin}/${pkg_name}/${pkg_version}/${pkg_rel}
 fi
 
 # Set `$pkg_prefix` if not already set by the `plan.sh`.
 if [[ -z "${pkg_prefix+xxx}" ]]; then
-  pkg_prefix=$BLDR_PKG_ROOT/${pkg_derivation}/${pkg_name}/${pkg_version}/${pkg_rel}
+  pkg_prefix=$BLDR_PKG_ROOT/${pkg_origin}/${pkg_name}/${pkg_version}/${pkg_rel}
 fi
 
 # Set $pkg_srvc variables.
@@ -1941,7 +1940,7 @@ do_end
 # Print the results
 build_line "Cache: $BLDR_SRC_CACHE/$pkg_dirname"
 build_line "Installed: $pkg_path"
-build_line "Package: $BLDR_PKG_CACHE/${pkg_derivation}-${pkg_name}-${pkg_version}-${pkg_rel}.bldr"
+build_line "Package: $BLDR_PKG_CACHE/${pkg_origin}-${pkg_name}-${pkg_version}-${pkg_rel}.bldr"
 
 # Exit cleanly
 build_line

--- a/plans/bldr-studio/plan.sh
+++ b/plans/bldr-studio/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=bldr-studio
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=0.1.0
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
 pkg_license=('apachev2')

--- a/plans/bldr-web/hooks/init
+++ b/plans/bldr-web/hooks/init
@@ -1,5 +1,5 @@
 #!/bin/bash
 mkdir -p /opt/bldr/srvc/nginx/var
-path_to_bldr_web="/opt/bldr/pkgs/{{bldr.derivation}}/{{bldr.name}}/{{bldr.version}}/{{bldr.release}}"
+path_to_bldr_web="/opt/bldr/pkgs/{{bldr.origin}}/{{bldr.name}}/{{bldr.version}}/{{bldr.release}}"
 
 rm -rf /opt/bldr/srvc/bldr-web/static* && cp -r $path_to_bldr_web/dist /opt/bldr/srvc/bldr-web/static

--- a/plans/bldr-web/hooks/run
+++ b/plans/bldr-web/hooks/run
@@ -1,5 +1,5 @@
 #!/bin/bash
 #
-path_to_nginx=`cat /opt/bldr/pkgs/{{bldr.derivation}}/{{bldr.name}}/{{bldr.version}}/{{bldr.release}}/DEPS | grep nginx`
+path_to_nginx=`cat /opt/bldr/pkgs/{{bldr.origin}}/{{bldr.name}}/{{bldr.version}}/{{bldr.release}}/DEPS | grep nginx`
 exec 2>&1
 exec /opt/bldr/pkgs/$path_to_nginx/sbin/nginx -c /opt/bldr/srvc/bldr-web/config/nginx.conf

--- a/plans/bldr-web/plan.sh
+++ b/plans/bldr-web/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=bldr-web
 pkg_version=0.4.0
-pkg_derivation=chef
+pkg_origin=chef
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
 pkg_license=('Apache2')
 pkg_source=http://example.com/${pkg_name}-${pkg_version}.tar.bz2

--- a/plans/bldr/plan.sh
+++ b/plans/bldr/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=bldr
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=0.4.0
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
 pkg_license=('apachev2')

--- a/plans/bootstrap-toolchain.sh
+++ b/plans/bootstrap-toolchain.sh
@@ -15,7 +15,7 @@ trap _on_exit 1 2 3 15 ERR
 : ${BUILD:=./bldr-build}
 BLDR_ROOT=/opt/bldr
 BLDR_PKG_ROOT="$BLDR_ROOT/pkgs"
-derivation=chef
+origin=chef
 
 build() {
   local plan="${1:-}"
@@ -25,14 +25,14 @@ build() {
     exit 0
   fi
   local db="tmp/${DB_PREFIX:-}bootstrap-toolchain.db"
-  local path="$BLDR_PKG_ROOT/$derivation/$plan"
+  local path="$BLDR_PKG_ROOT/$origin/$plan"
   local manifest
   local ident
   local cmd
   mkdir -p $(dirname $db)
   touch $db
 
-  if grep -q "^$derivation/$plan:$*$" $db > /dev/null; then
+  if grep -q "^$origin/$plan:$*$" $db > /dev/null; then
     if ident=$(find $path -name IDENT -type f 2>&1); then
       ident="$(echo $ident | tr ' ' '\n' | sort | tail -n 1)"
       if [ ! -f "$ident" ]; then
@@ -55,7 +55,7 @@ build() {
   echo "[$plan] Building with: $cmd"
   eval $cmd
   echo "[$plan] Recording build record in $db"
-  echo "$derivation/$plan:$*" >> $db
+  echo "$origin/$plan:$*" >> $db
 }
 
 cat <<_PLANS_ | while read plan; do build $plan; done

--- a/plans/bpm/bin/bpm.sh
+++ b/plans/bpm/bin/bpm.sh
@@ -523,7 +523,7 @@ latest_remote_package() {
     "2"|"1")
       local result="$(\
         $bb env -u http_proxy $bb wget "$BLDR_REPO/pkgs/$1" -O- -q | \
-        $jq -r '.derivation + "/" + .name + "/" + .version + "/" + .release')"
+        $jq -r '.origin + "/" + .name + "/" + .version + "/" + .release')"
       if [ -n "$result" ]; then
         echo $result
       else
@@ -596,7 +596,7 @@ latest_installed_package() {
 # given package identifier.
 #
 # Note that a fully qualified package identifier must be provided, that is
-# `<DERIVATION>/<NAME>/<VERSION>/<RELEASE>`.
+# `<ORIGIN>/<NAME>/<VERSION>/<RELEASE>`.
 #
 # ```sh
 # install_package chef/zlib/1.2.8/20160104212444
@@ -648,7 +648,7 @@ install_package() {
 # from a package repository, represented by the given package identifier.
 #
 # Note that a fully qualified package identifier must be provided, that is
-# `<DERIVATION>/<NAME>/<VERSION>/<RELEASE>`.
+# `<ORIGIN>/<NAME>/<VERSION>/<RELEASE>`.
 #
 # ```sh
 # install_package_tdeps chef/zlib/1.2.8/20160104212444

--- a/plans/bpm/plan.sh
+++ b/plans/bpm/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=bpm
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=0.1.0
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
 pkg_license=('apachev2')

--- a/plans/build/plan.sh
+++ b/plans/build/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=build
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=0.4.0
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
 pkg_license=('apachev2')

--- a/plans/busybox/plan.sh
+++ b/plans/busybox/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=busybox
 pkg_distname=$pkg_name
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=1.24.1
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
 pkg_license=('gplv2')

--- a/plans/bzip2/plan.sh
+++ b/plans/bzip2/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=bzip2
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=1.0.6
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
 pkg_license=('bzip2')

--- a/plans/cacerts/plan.sh
+++ b/plans/cacerts/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=cacerts
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=_set_from_downloaded_cacerts_file_
 pkg_license=('mplv1.1' 'gplV2' 'lgplv2.1')
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
@@ -48,6 +48,6 @@ update_pkg_version() {
   # Several metadata values get their defaults from the value of `$pkg_version`
   # so we must update these as well
   pkg_dirname=${pkg_name}-${pkg_version}
-  pkg_prefix=$BLDR_PKG_ROOT/${pkg_derivation}/${pkg_name}/${pkg_version}/${pkg_rel}
+  pkg_prefix=$BLDR_PKG_ROOT/${pkg_origin}/${pkg_name}/${pkg_version}/${pkg_rel}
   pkg_path=$pkg_prefix
 }

--- a/plans/check/plan.sh
+++ b/plans/check/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=check
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=0.10.0
 pkg_license=('lgplv2+')
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"

--- a/plans/clens/plan.sh
+++ b/plans/clens/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=clens
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=0.7.0
 pkg_license=('isc')
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"

--- a/plans/coreutils/plan.sh
+++ b/plans/coreutils/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=coreutils
 pkg_distname=$pkg_name
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=8.24
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
 pkg_license=('gplv3')

--- a/plans/db/plan.sh
+++ b/plans/db/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=db
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=5.3.28
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
 pkg_license=('custom')

--- a/plans/dejagnu/plan.sh
+++ b/plans/dejagnu/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=dejagnu
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=1.5.3
 pkg_license=('gplv2+')
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"

--- a/plans/diffutils/plan.sh
+++ b/plans/diffutils/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=diffutils
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=3.3
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
 pkg_license=('gplv3+')

--- a/plans/docker/plan.sh
+++ b/plans/docker/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=docker
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=1.10.1
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
 pkg_license=('Apache-2')

--- a/plans/erlang/plan.sh
+++ b/plans/erlang/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=erlang
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=18.2.1
 pkg_dirname=otp_src_${pkg_version}
 pkg_license=('erlang')

--- a/plans/expat/plan.sh
+++ b/plans/expat/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=expat
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=2.1.0
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
 pkg_license=('mit')

--- a/plans/expect/plan.sh
+++ b/plans/expect/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=expect
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=5.45
 pkg_license=('custom')
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"

--- a/plans/file/plan.sh
+++ b/plans/file/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=file
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=5.24
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
 pkg_license=('custom')

--- a/plans/findutils/plan.sh
+++ b/plans/findutils/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=findutils
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=4.4.2
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
 pkg_license=('gplv3+')

--- a/plans/flex/plan.sh
+++ b/plans/flex/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=flex
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=2.6.0
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
 pkg_license=('custom')

--- a/plans/gawk/plan.sh
+++ b/plans/gawk/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=gawk
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=4.1.3
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
 pkg_license=('gplv3+')

--- a/plans/gcc/plan.sh
+++ b/plans/gcc/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=gcc
 pkg_distname=$pkg_name
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=5.2.0
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
 pkg_license=('gpl')

--- a/plans/gdbm/plan.sh
+++ b/plans/gdbm/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=gdbm
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=1.11
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
 pkg_license=('gplv3+')

--- a/plans/gettext/plan.sh
+++ b/plans/gettext/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=gettext
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=0.19.6
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
 pkg_license=('gplv2+' 'lgpl2+')

--- a/plans/glibc/plan.sh
+++ b/plans/glibc/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=glibc
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=2.22
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
 pkg_license=('gplv2' 'lgplv2')

--- a/plans/gmp/plan.sh
+++ b/plans/gmp/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=gmp
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=6.1.0
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
 pkg_license=('gplv3')

--- a/plans/gnupg/plan.sh
+++ b/plans/gnupg/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=gnupg
 pkg_distname=$pkg_name
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=1.4.20
 pkg_license=('gplv3+')
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"

--- a/plans/gpgme/plan.sh
+++ b/plans/gpgme/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=gpgme
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=1.6.0
 pkg_license=('LGPL')
 pkg_source=https://www.gnupg.org/ftp/gcrypt/${pkg_name}/${pkg_name}-${pkg_version}.tar.bz2

--- a/plans/grep/plan.sh
+++ b/plans/grep/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=grep
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=2.22
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
 pkg_license=('gplv3+')

--- a/plans/gzip/plan.sh
+++ b/plans/gzip/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=gzip
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=1.6
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
 pkg_license=('gplv3+')

--- a/plans/hana/plan.sh
+++ b/plans/hana/plan.sh
@@ -1,4 +1,4 @@
-pkg_derivation=sap
+pkg_origin=sap
 pkg_name=hana
 pkg_version=100.102.01
 pkg_license=('SAP')

--- a/plans/haproxy/plan.sh
+++ b/plans/haproxy/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=haproxy
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=1.5.12
 pkg_license=('BSD')
 pkg_maintainer="Adam Jacob <adam@chef.io>"

--- a/plans/iana-etc/plan.sh
+++ b/plans/iana-etc/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=iana-etc
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=2.30
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
 pkg_license=('gplv3+')

--- a/plans/inetutils/plan.sh
+++ b/plans/inetutils/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=inetutils
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=1.9.4
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
 pkg_license=('gplv3+')

--- a/plans/iptables/plan.sh
+++ b/plans/iptables/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=iptables
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=1.6.0
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
 pkg_license=('gplv2')

--- a/plans/jq-static/plan.sh
+++ b/plans/jq-static/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=jq-static
 pkg_distname=jq
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=1.5
 pkg_license=('mit')
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"

--- a/plans/less/plan.sh
+++ b/plans/less/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=less
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=481
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
 pkg_license=('gplv3+')

--- a/plans/libaio/plan.sh
+++ b/plans/libaio/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=libaio
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=0.3.109
 pkg_license=('LGPL')
 pkg_maintainer="Jamie Winsor <reset@chef.io>"

--- a/plans/libarchive/plan.sh
+++ b/plans/libarchive/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=libarchive
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=3.1.2
 pkg_license=('BSD')
 pkg_source=http://www.libarchive.org/downloads/${pkg_name}-${pkg_version}.tar.gz

--- a/plans/libassuan/plan.sh
+++ b/plans/libassuan/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=libassuan
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=2.4.2
 pkg_license=('lgplv2+')
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"

--- a/plans/libbsd/plan.sh
+++ b/plans/libbsd/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=libbsd
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=0.8.1
 pkg_license=('custom')
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"

--- a/plans/libcap/plan.sh
+++ b/plans/libcap/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=libcap
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=2.24
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
 pkg_license=('gplv2')

--- a/plans/libedit/plan.sh
+++ b/plans/libedit/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=libedit
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=3.1.20150325
 pkg_license=('bsd')
 pkg_source=http://thrysoee.dk/editline/libedit-20150325-3.1.tar.gz

--- a/plans/libffi/plan.sh
+++ b/plans/libffi/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=libffi
 pkg_version=3.2.1
-pkg_derivation=chef
+pkg_origin=chef
 pkg_license=('mit')
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
 pkg_source=ftp://sourceware.org/pub/${pkg_name}/${pkg_name}-${pkg_version}.tar.gz

--- a/plans/libgcrypt/plan.sh
+++ b/plans/libgcrypt/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=libgcrypt
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=1.6.4
 pkg_license=('lgplv2+')
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"

--- a/plans/libgpg-error/plan.sh
+++ b/plans/libgpg-error/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=libgpg-error
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=1.20
 pkg_license=('lgplv2+')
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"

--- a/plans/libiconv/plan.sh
+++ b/plans/libiconv/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=libiconv
 pkg_version=1.14
-pkg_derivation=chef
+pkg_origin=chef
 pkg_license=('gplv2')
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
 pkg_source=http://ftp.gnu.org/pub/gnu/${pkg_name}/${pkg_name}-${pkg_version}.tar.gz

--- a/plans/libidn/plan.sh
+++ b/plans/libidn/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=libidn
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=1.32
 pkg_license=('lgplv2+')
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"

--- a/plans/libksba/plan.sh
+++ b/plans/libksba/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=libksba
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=1.3.3
 pkg_license=('lgplv3+')
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"

--- a/plans/libltdl/plan.sh
+++ b/plans/libltdl/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=libltdl
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=2.4.6
 pkg_license=('GPL')
 pkg_maintainer="Jamie Winsor <reset@chef.io>"

--- a/plans/libmpc/plan.sh
+++ b/plans/libmpc/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=libmpc
 pkg_distname=mpc
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=1.0.3
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
 pkg_license=('lgpl')

--- a/plans/libtool/plan.sh
+++ b/plans/libtool/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=libtool
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=2.4.6
 pkg_license=('gplv2+')
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"

--- a/plans/libxml2/plan.sh
+++ b/plans/libxml2/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=libxml2
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=2.9.2
 pkg_license=('MIT')
 pkg_maintainer="Jamie Winsor <reset@chef.io>"

--- a/plans/libyaml/plan.sh
+++ b/plans/libyaml/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=libyaml
 pkg_version=0.1.6
-pkg_derivation=chef
+pkg_origin=chef
 pkg_license=('mit')
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
 pkg_dirname=yaml-${pkg_version}

--- a/plans/linux-headers-musl/plan.sh
+++ b/plans/linux-headers-musl/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=linux-headers-musl
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=3.12.6-5
 pkg_license=('mit')
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"

--- a/plans/linux-headers/plan.sh
+++ b/plans/linux-headers/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=linux-headers
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=4.3
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
 pkg_license=('gplv2')

--- a/plans/linux-pam/plan.sh
+++ b/plans/linux-pam/plan.sh
@@ -1,4 +1,4 @@
-pkg_derivation=chef
+pkg_origin=chef
 pkg_name=linux-pam
 pkg_version=1.2.1
 pkg_license=('MIT', 'GPL')

--- a/plans/lzo/plan.sh
+++ b/plans/lzo/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=lzo
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=2.09
 pkg_license=('GPL')
 pkg_source=http://www.oberhumer.com/opensource/${pkg_name}/download/${pkg_name}-${pkg_version}.tar.gz

--- a/plans/m4/plan.sh
+++ b/plans/m4/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=m4
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=1.4.17
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
 pkg_license=('gplv3')

--- a/plans/make/plan.sh
+++ b/plans/make/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=make
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=4.1
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
 pkg_license=('gplv3+')

--- a/plans/man-pages/plan.sh
+++ b/plans/man-pages/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=man-pages
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=4.02
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
 pkg_license=('gplv2')

--- a/plans/mg/plan.sh
+++ b/plans/mg/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=mg
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=20160118
 pkg_license=('publicdomain')
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"

--- a/plans/mpfr/plan.sh
+++ b/plans/mpfr/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=mpfr
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=3.1.3
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
 pkg_license=('lgpl')

--- a/plans/musl/plan.sh
+++ b/plans/musl/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=musl
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=1.1.12
 pkg_license=('mit')
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"

--- a/plans/ncurses/plan.sh
+++ b/plans/ncurses/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=ncurses
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=6.0
 pkg_license=('ncurses')
 pkg_source=http://ftp.gnu.org/gnu/$pkg_name/${pkg_name}-${pkg_version}.tar.gz

--- a/plans/nginx/plan.sh
+++ b/plans/nginx/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=nginx
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=1.8.0
 pkg_maintainer="Adam Jacob <adam@chef.io>"
 pkg_license=('bsd')

--- a/plans/node/plan.sh
+++ b/plans/node/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=node
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=4.2.6
 pkg_license=('MIT')
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"

--- a/plans/npth/plan.sh
+++ b/plans/npth/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=npth
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=1.2
 pkg_license=('lgplv3+')
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"

--- a/plans/numactl/plan.sh
+++ b/plans/numactl/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=numactl
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=2.0.10
 pkg_license=('GPLv2', 'LGPL2.1')
 pkg_source=https://github.com/${pkg_name}/${pkg_name}/archive/v${pkg_version}.tar.gz

--- a/plans/openssl-0.9.8/plan.sh
+++ b/plans/openssl-0.9.8/plan.sh
@@ -1,4 +1,4 @@
-pkg_derivation=chef
+pkg_origin=chef
 pkg_name=openssl-0.9.8
 pkg_version=0.9.8zg
 pkg_license=('BSD')

--- a/plans/openssl/plan.sh
+++ b/plans/openssl/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=openssl
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=1.0.2f
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
 pkg_license=('bsd')

--- a/plans/patch/plan.sh
+++ b/plans/patch/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=patch
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=2.7.5
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
 pkg_license=('gplv3+')

--- a/plans/patchelf/plan.sh
+++ b/plans/patchelf/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=patchelf
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=0.8
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
 pkg_license=('gplv3')

--- a/plans/pcre/plan.sh
+++ b/plans/pcre/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=pcre
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=8.38
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
 pkg_license=('bsd')

--- a/plans/perl/plan.sh
+++ b/plans/perl/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=perl
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=5.22.1
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
 pkg_license=('gpl' 'perlartistic')

--- a/plans/pkg-config/plan.sh
+++ b/plans/pkg-config/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=pkg-config
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=0.29
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
 pkg_license=('gplv2+')

--- a/plans/plan-tmpl.sh
+++ b/plans/plan-tmpl.sh
@@ -1,7 +1,7 @@
 # Template plan.sh
 pkg_name=PACKAGE
 pkg_version=0.0.0
-pkg_derivation=chef
+pkg_origin=chef
 pkg_license=('PACKAGE')
 pkg_source=http://example.com/${pkg_name}-${pkg_version}.tar.gz
 pkg_filename=${pkg_name}-${pkg_version}.tar.gz

--- a/plans/procps-ng/plan.sh
+++ b/plans/procps-ng/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=procps-ng
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=3.3.11
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
 pkg_license=('gpl' 'lgpl')

--- a/plans/psmisc/plan.sh
+++ b/plans/psmisc/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=psmisc
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=22.21
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
 pkg_license=('gpl')

--- a/plans/python/plan.sh
+++ b/plans/python/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=python
 pkg_version=3.5.1
-pkg_derivation=chef
+pkg_origin=chef
 pkg_license=('python')
 pkg_dirname=Python-${pkg_version}
 pkg_source=https://www.python.org/ftp/python/${pkg_version}/${pkg_dirname}.tgz

--- a/plans/python2/plan.sh
+++ b/plans/python2/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=python2
 pkg_version=2.7.11
-pkg_derivation=chef
+pkg_origin=chef
 pkg_license=('python')
 pkg_dirname=Python-${pkg_version}
 pkg_source=https://www.python.org/ftp/python/${pkg_version}/${pkg_dirname}.tgz

--- a/plans/readline/plan.sh
+++ b/plans/readline/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=readline
-pkg_derivation=chef
+pkg_origin=chef
 _base_version=6.3
 pkg_version=${_base_version}.8
 pkg_license=('gplv3+')

--- a/plans/redis/plan.sh
+++ b/plans/redis/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=redis
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=3.0.7
 pkg_license=('BSD')
 pkg_maintainer="Adam Jacob <adam@chef.io>"

--- a/plans/rngd/plan.sh
+++ b/plans/rngd/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=rngd
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=5
 pkg_license=('gplv2')
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"

--- a/plans/ruby/plan.sh
+++ b/plans/ruby/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=ruby
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=2.3.0
 pkg_license=('ruby')
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"

--- a/plans/runit/plan.sh
+++ b/plans/runit/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=runit
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=2.1.2
 pkg_license=('BSD')
 pkg_source=http://smarden.org/runit/runit-2.1.2.tar.gz

--- a/plans/rust/plan.sh
+++ b/plans/rust/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=rust
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=1.6.0
 pkg_license=('Apache-2.0' 'MIT')
 pkg_source=https://static.rust-lang.org/dist/${pkg_name}-${pkg_version}-x86_64-unknown-linux-gnu.tar.gz

--- a/plans/sed/plan.sh
+++ b/plans/sed/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=sed
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=4.2.2
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
 pkg_license=('gplv3')

--- a/plans/shadow/plan.sh
+++ b/plans/shadow/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=shadow
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=4.2.1
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
 pkg_license=('bsd')

--- a/plans/tar/plan.sh
+++ b/plans/tar/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=tar
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=1.28
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
 pkg_license=('gplv3+')

--- a/plans/tcl/plan.sh
+++ b/plans/tcl/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=tcl
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=8.6.4
 pkg_license=('custom')
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"

--- a/plans/texinfo/plan.sh
+++ b/plans/texinfo/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=texinfo
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=6.0
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
 pkg_license=('gplv3+')

--- a/plans/tzdata/plan.sh
+++ b/plans/tzdata/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=tzdata
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=2015f
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
 pkg_license=('gpl')

--- a/plans/util-linux/plan.sh
+++ b/plans/util-linux/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=util-linux
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=2.27.1
 pkg_license=('GPLv2')
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"

--- a/plans/vim/plan.sh
+++ b/plans/vim/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=vim
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=7.4.1089
 pkg_license=('vim')
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"

--- a/plans/wget/plan.sh
+++ b/plans/wget/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=wget
 pkg_distname=$pkg_name
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=1.16.3
 pkg_license=('gplv3+')
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"

--- a/plans/xz/plan.sh
+++ b/plans/xz/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=xz
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=5.2.2
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
 pkg_license=('gpl2+' 'lgpl2+')

--- a/plans/zlib/plan.sh
+++ b/plans/zlib/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=zlib
-pkg_derivation=chef
+pkg_origin=chef
 pkg_version=1.2.8
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
 pkg_license=('zlib')

--- a/src/bldr/command/install.rs
+++ b/src/bldr/command/install.rs
@@ -18,7 +18,7 @@
 //! $ bldr install redis -u http://bldr.co:9633 -d adam
 //! ```
 //!
-//! Will do the same, but choose the `adam` derivation, rather than the default `bldr`.
+//! Will do the same, but choose the `adam` origin, rather than the default `bldr`.
 //!
 //! ```bash
 //! $ bldr install redis -u http://bldr.co:9633 -v 3.0.1
@@ -36,7 +36,7 @@
 //! $ bldr install redis -u http://bldr.co:9633 -d adam -v 3.0.1 -r 20150911204047
 //! ```
 //!
-//! The same as the last, but from the `adam` derivation as well.
+//! The same as the last, but from the `adam` origin as well.
 //!
 //! # Internals
 //!

--- a/src/bldr/error.rs
+++ b/src/bldr/error.rs
@@ -252,7 +252,7 @@ impl fmt::Display for BldrError {
             ErrorKind::UuidParseError(ref e) => format!("Uuid Parse Error: {:?}", e),
             ErrorKind::InvalidPackageIdent(ref e) => {
                 format!("Invalid package identifier: {:?}. A valid identifier is in the form \
-                         derivation/name (example: chef/redis)",
+                         origin/name (example: chef/redis)",
                         e)
             }
             ErrorKind::InvalidKeyParameter(ref e) => {
@@ -349,7 +349,7 @@ impl Error for BldrError {
             ErrorKind::CensusNotFound(_) => "A census entry does not exist",
             ErrorKind::UuidParseError(_) => "Uuid Parse Error",
             ErrorKind::InvalidPackageIdent(_) => {
-                "Package identifiers must be in derivation/name format (example: chef/redis)"
+                "Package identifiers must be in origin/name format (example: chef/redis)"
             }
             ErrorKind::InvalidKeyParameter(_) => "Key parameter error",
             ErrorKind::JsonEncode(_) => "JSON encoding error",

--- a/src/bldr/package/updater.rs
+++ b/src/bldr/package/updater.rs
@@ -86,7 +86,7 @@ impl GenServer for PackageUpdater {
         // JW TODO: Store and use the version if the package was started with a specific version.
         //          This will allow an operator to lock to a version and receive security updates
         //          in the form of release updates for a package.
-        let ident = PackageIdent::new(package.derivation.clone(), package.name.clone(), None, None);
+        let ident = PackageIdent::new(package.origin.clone(), package.name.clone(), None, None);
         match repo::client::show_package(&state.repo, &ident) {
             Ok(remote) => {
                 let latest: Package = remote.into();

--- a/src/bldr/repo/client.rs
+++ b/src/bldr/repo/client.rs
@@ -109,7 +109,7 @@ pub fn put_package(repo: &str, package: &Package) -> BldrResult<()> {
     let mut file = try!(File::open(package.cache_file()));
     let url = format!("{}/pkgs/{}/{}/{}/{}",
                       repo,
-                      package.derivation,
+                      package.origin,
                       package.name,
                       package.version,
                       package.release);

--- a/src/bldr/repo/data_object.rs
+++ b/src/bldr/repo/data_object.rs
@@ -30,7 +30,7 @@ impl PackageIdent {
         PackageIdent(ident)
     }
 
-    pub fn deriv_idx(&self) -> String {
+    pub fn origin_idx(&self) -> String {
         format!("{}", self.parts()[0])
     }
 
@@ -59,7 +59,7 @@ impl Encodable for PackageIdent {
     fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {
         let p = self.parts();
         try!(s.emit_struct("PackageIdent", p.len(), |s| {
-            try!(s.emit_struct_field("derivation", 0, |s| p[0].encode(s)));
+            try!(s.emit_struct_field("origin", 0, |s| p[0].encode(s)));
             try!(s.emit_struct_field("name", 1, |s| p[1].encode(s)));
             if p.len() > 2 {
                 try!(s.emit_struct_field("version", 2, |s| p[2].encode(s)));
@@ -76,11 +76,11 @@ impl Encodable for PackageIdent {
 impl Decodable for PackageIdent {
     fn decode<D: Decoder>(d: &mut D) -> Result<Self, D::Error> {
         d.read_struct("PackageIdent", 4, |d| {
-            let derivation: String = try!(d.read_struct_field("derivation", 0, |d| Decodable::decode(d)));
+            let origin: String = try!(d.read_struct_field("origin", 0, |d| Decodable::decode(d)));
             let name: String = try!(d.read_struct_field("name", 1, |d| Decodable::decode(d)));
             let version: String = try!(d.read_struct_field("version", 2, |d| Decodable::decode(d)));
             let release: String = try!(d.read_struct_field("release", 3, |d| Decodable::decode(d)));
-            Ok(PackageIdent::new(format!("{}/{}/{}/{}", derivation, name, version, release)))
+            Ok(PackageIdent::new(format!("{}/{}/{}/{}", origin, name, version, release)))
         })
     }
 }
@@ -178,7 +178,7 @@ impl Into<package::Package> for Package {
     fn into(self) -> package::Package {
         let ident = self.ident.parts();
         package::Package {
-            derivation: ident[0].to_string(),
+            origin: ident[0].to_string(),
             name: ident[1].to_string(),
             version: ident[2].to_string(),
             release: ident[3].to_string(),

--- a/src/bldr/repo/data_store.rs
+++ b/src/bldr/repo/data_store.rs
@@ -1303,7 +1303,7 @@ impl Database for PkgIndex {
     }
 
     fn write<'a>(&self, txn: &RwTransaction<'a, Self>, object: &Self::Object) -> BldrResult<()> {
-        try!(txn.put(&object.deriv_idx(), object));
+        try!(txn.put(&object.origin_idx(), object));
         try!(txn.put(&object.name_idx(), object));
         txn.put(&object.version_idx(), object)
     }

--- a/src/bldr/repo/mod.rs
+++ b/src/bldr/repo/mod.rs
@@ -60,11 +60,11 @@ impl Repo {
     // identifier pieces.
     fn archive_path(&self, ident: &package::PackageIdent) -> PathBuf {
         self.packages_path()
-            .join(&ident.derivation)
+            .join(&ident.origin)
             .join(&ident.name)
             .join(ident.version.as_ref().unwrap())
             .join(ident.release.as_ref().unwrap())
-            .join(format!("{}-{}-{}-{}.bldr", &ident.derivation, &ident.name, ident.version.as_ref().unwrap(), ident.release.as_ref().unwrap()))
+            .join(format!("{}-{}-{}-{}.bldr", &ident.origin, &ident.name, ident.version.as_ref().unwrap(), ident.release.as_ref().unwrap()))
     }
 
     fn key_path(&self, name: &str) -> PathBuf {
@@ -99,24 +99,24 @@ impl Default for ListenPort {
 
 impl<'a> Into<package::PackageIdent> for &'a Params {
     fn into(self) -> package::PackageIdent {
-        package::PackageIdent::new(self.find("deriv").unwrap(), self.find("pkg").unwrap(), self.find("version"), self.find("release"))
+        package::PackageIdent::new(self.find("origin").unwrap(), self.find("pkg").unwrap(), self.find("version"), self.find("release"))
     }
 }
 
 impl<'a> Into<data_object::PackageIdent> for &'a Params {
     fn into(self) -> data_object::PackageIdent {
-        let deriv = self.find("deriv").unwrap();
+        let origin = self.find("origin").unwrap();
         let name = self.find("pkg");
         let version = self.find("version");
         let release = self.find("release");
         if release.is_some() && version.is_some() && name.is_some() {
-            data_object::PackageIdent::new(format!("{}/{}/{}/{}", deriv, name.unwrap(), version.unwrap(), release.unwrap()))
+            data_object::PackageIdent::new(format!("{}/{}/{}/{}", origin, name.unwrap(), version.unwrap(), release.unwrap()))
         } else if version.is_some() && name.is_some() {
-            data_object::PackageIdent::new(format!("{}/{}/{}", deriv, name.unwrap(), version.unwrap()))
+            data_object::PackageIdent::new(format!("{}/{}/{}", origin, name.unwrap(), version.unwrap()))
         } else if name.is_some() {
-            data_object::PackageIdent::new(format!("{}/{}", deriv, name.unwrap()))
+            data_object::PackageIdent::new(format!("{}/{}", origin, name.unwrap()))
         } else {
-            data_object::PackageIdent::new(deriv.to_string())
+            data_object::PackageIdent::new(origin.to_string())
         }
     }
 }
@@ -392,20 +392,20 @@ pub fn run(config: &Config) -> BldrResult<()> {
     let repo17 = repo.clone();
     let router = router!(
         // JW TODO: update list/show/download function to cover scoping rules of these routes repos
-        get "/pkgs/:deriv/:pkg/:version" => move |r: &mut Request| list_packages(&repo3, r),
-        get "/pkgs/:deriv/:pkg" => move |r: &mut Request| list_packages(&repo4, r),
-        get "/pkgs/:deriv/:pkg/latest" => move |r: &mut Request| show_package(&repo5, r),
-        get "/pkgs/:deriv/:pkg/:version/:release/download" => move |r: &mut Request| download_package(&repo6, r),
-        get "/pkgs/:deriv/:pkg/:version/download" => move |r: &mut Request| download_package(&repo7, r),
-        get "/pkgs/:deriv/:pkg/download" => move |r: &mut Request| download_package(&repo8, r),
+        get "/pkgs/:origin/:pkg/:version" => move |r: &mut Request| list_packages(&repo3, r),
+        get "/pkgs/:origin/:pkg" => move |r: &mut Request| list_packages(&repo4, r),
+        get "/pkgs/:origin/:pkg/latest" => move |r: &mut Request| show_package(&repo5, r),
+        get "/pkgs/:origin/:pkg/:version/:release/download" => move |r: &mut Request| download_package(&repo6, r),
+        get "/pkgs/:origin/:pkg/:version/download" => move |r: &mut Request| download_package(&repo7, r),
+        get "/pkgs/:origin/:pkg/download" => move |r: &mut Request| download_package(&repo8, r),
 
-        post "/pkgs/:deriv/:pkg/:version/:release" => move |r: &mut Request| upload_package(&repo9, r),
-        get "/pkgs/:deriv/:pkg/:version/latest" => move |r: &mut Request| show_package(&repo10, r),
-        get "/pkgs/:deriv/:pkg/:version/:release" => move |r: &mut Request| show_package(&repo11, r),
-        get "/pkgs/:deriv/:pkg/latest" => move |r: &mut Request| show_package(&repo12, r),
-        get "/pkgs/:deriv/:pkg/:version" => move |r: &mut Request| list_packages(&repo13, r),
-        get "/pkgs/:deriv/:pkg" => move |r: &mut Request| list_packages(&repo14, r),
-        get "/pkgs/:deriv" => move |r: &mut Request| list_packages(&repo15, r),
+        post "/pkgs/:origin/:pkg/:version/:release" => move |r: &mut Request| upload_package(&repo9, r),
+        get "/pkgs/:origin/:pkg/:version/latest" => move |r: &mut Request| show_package(&repo10, r),
+        get "/pkgs/:origin/:pkg/:version/:release" => move |r: &mut Request| show_package(&repo11, r),
+        get "/pkgs/:origin/:pkg/latest" => move |r: &mut Request| show_package(&repo12, r),
+        get "/pkgs/:origin/:pkg/:version" => move |r: &mut Request| list_packages(&repo13, r),
+        get "/pkgs/:origin/:pkg" => move |r: &mut Request| list_packages(&repo14, r),
+        get "/pkgs/:origin" => move |r: &mut Request| list_packages(&repo15, r),
 
         post "/keys/:key" => move |r: &mut Request| upload_key(&repo16, r),
         get "/keys/:key" => move |r: &mut Request| download_key(&repo17, r)

--- a/src/bldr/service_config.rs
+++ b/src/bldr/service_config.rs
@@ -328,7 +328,7 @@ fn read_default_toml_file(pkg: &Package) -> BldrResult<String> {
 // Generates the toml for the bldr data from a package.
 fn bldr_data(pkg: &Package) -> String {
     let mut toml_string = String::from("[bldr]\n");
-    toml_string.push_str(&format!("derivation = \"{}\"", pkg.derivation));
+    toml_string.push_str(&format!("origin = \"{}\"", pkg.origin));
     toml_string.push_str(&format!("name = \"{}\"", pkg.name));
     toml_string.push_str(&format!("version = \"{}\"", pkg.version));
     toml_string.push_str(&format!("release = \"{}\"", pkg.release));

--- a/tests/fixtures/bldr_build/plan.sh
+++ b/tests/fixtures/bldr_build/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=bldr_build
-pkg_derivation=test
+pkg_origin=test
 pkg_version=0.0.1
 pkg_license=('Apache2')
 pkg_maintainer="Adam Jacob <adam@chef.io>"

--- a/tests/fixtures/simple_service/plan.sh
+++ b/tests/fixtures/simple_service/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=simple_service
-pkg_derivation=test
+pkg_origin=test
 pkg_version=0.0.1
 pkg_license=('Apache2')
 pkg_maintainer="Adam Jacob <adam@chef.io>"

--- a/tests/fixtures/simple_service_gossip/plan.sh
+++ b/tests/fixtures/simple_service_gossip/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=simple_service_gossip
-pkg_derivation=test
+pkg_origin=test
 pkg_version=0.0.1
 pkg_license=('Apache2')
 pkg_maintainer="Adam Jacob <adam@chef.io>"

--- a/tests/fixtures/simple_service_without_config/plan.sh
+++ b/tests/fixtures/simple_service_without_config/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=simple_service_without_config
-pkg_derivation=test
+pkg_origin=test
 pkg_version=0.0.1
 pkg_license=('Apache2')
 pkg_maintainer="Adam Jacob <adam@chef.io>"

--- a/web/app/project-create-page/ProjectCreatePageComponent.ts
+++ b/web/app/project-create-page/ProjectCreatePageComponent.ts
@@ -24,7 +24,7 @@ import {ControlGroup, FormBuilder, Validators} from "angular2/common";
                 <a href="#">(change)</a>
             </div>
             <div class="project-fields">
-                <div class="deriv">
+                <div class="origin">
                     <label for="origin">Project Origin</label>
                     <input ngControl="origin" disabled id="origin" name="origin">
                 </div>

--- a/web/app/project-create-page/_project-create-page.scss
+++ b/web/app/project-create-page/_project-create-page.scss
@@ -12,7 +12,7 @@
     @include omega;
     @include outer-container;
 
-    .deriv, .name {
+    .origin, .name {
       @include span-columns(6);
     }
 

--- a/web/app/util.test.ts
+++ b/web/app/util.test.ts
@@ -5,22 +5,22 @@ describe("util", () => {
         describe("with a fully qualified identifier", () => {
             it("returns the string", () => {
                 expect(util.packageString({
-                    origin: "testderiv",
+                    origin: "testorigin",
                     name: "testname",
                     version: "1.0.0",
                     release: "197001010000",
                 })
-                ).to.eq("testderiv/testname/1.0.0/197001010000");
+                ).to.eq("testorigin/testname/1.0.0/197001010000");
             });
         });
 
         describe("with a missing parts", () => {
             it("returns the partial string", () => {
                 expect(util.packageString({
-                    origin: "testderiv",
+                    origin: "testorigin",
                     name: "testname",
                 })
-                ).to.eq("testderiv/testname");
+                ).to.eq("testorigin/testname");
             });
         });
     });


### PR DESCRIPTION
This PR changes all references to a `derivation` or a `deriv` to an `origin`. This coincides with the discussion that we had earlier this week and is inline with changes that @smith made to the web app portion of Bldr.

![gif-keyboard-13662286169976537880](https://cloud.githubusercontent.com/assets/54036/13350009/58093212-dc32-11e5-85bc-97a234f61bde.gif)
