### PR TITLE
install declared transitive dependencies on package installation

### DIFF
--- a/src/bldr/package/mod.rs
+++ b/src/bldr/package/mod.rs
@@ -125,6 +125,12 @@ impl fmt::Display for PackageIdent {
     }
 }
 
+impl AsRef<PackageIdent> for PackageIdent {
+    fn as_ref(&self) -> &PackageIdent {
+        self
+    }
+}
+
 impl From<Package> for PackageIdent {
     fn from(value: Package) -> PackageIdent {
         PackageIdent::new(value.origin, value.name, Some(value.version), Some(value.release))
@@ -920,7 +926,7 @@ impl PartialOrd for Package {
 
 #[cfg(test)]
 mod tests {
-    use super::{Package, PackageIdent, split_version, version_sort};
+    use super::{PackageIdent, split_version, version_sort};
     use std::cmp::Ordering;
     use std::cmp::PartialOrd;
 


### PR DESCRIPTION
This is a small performance improvement and a "do the right thing" change to our package installation process. We will now leverage the declared TDEPS (transitive dependencies) instead of dynamically discovering it.

Previously we were discovering transitive dependencies by downloading a package, checking it's DEPs file, and then ensuring we didn't get into a cyclical install loop.

I've also fixed a small bug in the router by re-ordering the routes.

![gif-keyboard-17861947114191544080](https://cloud.githubusercontent.com/assets/54036/13367787/fdcf170e-dc99-11e5-8d82-2973247a2e96.gif)
