### PR TITLE
match more explicitly when searching for metafiles

### DIFF
--- a/src/bldr/package/archive.rs
+++ b/src/bldr/package/archive.rs
@@ -226,7 +226,8 @@ impl PackageArchive {
         try!(builder.support_format(ReadFormat::All));
         try!(builder.support_filter(ReadFilter::All));
         let mut reader = try!(builder.open_stream(out));
-        let re = try!(Regex::new(&format!("/{}$", file)));
+        let re = try!(Regex::new(&format!(r"^opt/bldr/pkgs/([^/]+)/([^/]+)/([^/]+)/([^/]+)/{}$",
+                                          file)));
         loop {
             {
                 if let Some(entry) = reader.next_header() {


### PR DESCRIPTION
Files sharing the same name of our metafiles within the contents of a package could previously have fulfilled the match

![gif-keyboard-12878899955496040301](https://cloud.githubusercontent.com/assets/54036/13512806/c499849e-e151-11e5-9d7f-8f45ec5ce3f2.gif)
