### PR TITLE
fixes for node, add phantomjs

### DIFF
--- a/plans/bldr-web/plan.sh
+++ b/plans/bldr-web/plan.sh
@@ -3,32 +3,31 @@ pkg_version=0.4.0
 pkg_origin=chef
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
 pkg_license=('Apache2')
-pkg_source=http://example.com/${pkg_name}-${pkg_version}.tar.bz2
 pkg_filename=${pkg_name}-${pkg_version}.tar.bz2
-pkg_shasum=01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
 pkg_gpg_key=3853DA6B
 pkg_deps=(chef/glibc chef/bldr chef/pcre chef/nginx)
-pkg_build_deps=(chef/node)
+pkg_build_deps=(chef/node chef/coreutils chef/phantomjs)
 pkg_lib_dirs=(lib)
 pkg_include_dirs=(include)
-pkg_docker_build="auto"
 pkg_expose=(80 443)
 
 do_begin() {
     pushd ../../
+    mkdir -p $BLDR_SRC_CACHE
     tar -cjvf $BLDR_SRC_CACHE/${pkg_name}-${pkg_version}.tar.bz2 \
-		    --transform "s,^\./web,bldr-web-$pkg_version," ./web
+		    --transform "s,^\./web,bldr-web-${pkg_version}," ./web
     popd
     pkg_shasum=$(trim $(sha256sum /opt/bldr/cache/src/${pkg_filename} | cut -d " " -f 1))
 }
 
 do_build() {
     npm install
+    fix_interpreter "${BLDR_SRC_CACHE}/${pkg_name}-${pkg_version}/node_modules/.bin/*" chef/coreutils bin/env
     npm run dist
 }
 
 do_install() {
-    cp -R dist ${pkg_path}/dist
+    cp -vR dist ${pkg_path}/dist
 }
 
 do_verify() {

--- a/plans/curl/plan.sh
+++ b/plans/curl/plan.sh
@@ -1,0 +1,33 @@
+pkg_name=curl
+pkg_version=7.47.1
+pkg_origin=chef
+pkg_license=('curl')
+pkg_source=https://curl.haxx.se/download/${pkg_name}-${pkg_version}.tar.gz
+pkg_filename=${pkg_name}-${pkg_version}.tar.gz
+pkg_shasum=4e9d85028e754048887505a73638bf9b254c39582a191f43c95fe7de8e4d8005
+pkg_gpg_key=3853DA6B
+pkg_deps=(chef/glibc chef/openssl chef/zlib)
+pkg_build_deps=(chef/gcc chef/make chef/coreutils chef/perl)
+pkg_lib_dirs=(lib)
+pkg_include_dirs=(include)
+pkg_binary_path=(bin)
+
+do_build() {
+    fix_interpreter scripts/zsh.pl chef/perl bin/perl
+    ./configure --prefix=${pkg_prefix} \
+                --with-ssl=$(pkg_path_for chef/openssl) \
+                --with-zlib=$(pkg_path_for chef/zlib) \
+                --disable-manual \
+                --disable-ldap \
+                --disable-ldaps \
+                --disable-rtsp \
+                --enable-proxy \
+                --enable-optimize \
+                --disable-dependency-tracking \
+                --enable-ipv6 \
+                --without-libidn \
+                --without-gnutls \
+                --without-librtmp
+    make
+    make install
+}

--- a/plans/fontconfig/plan.sh
+++ b/plans/fontconfig/plan.sh
@@ -1,0 +1,39 @@
+pkg_name=fontconfig
+pkg_version=2.11.94
+pkg_origin=chef
+pkg_license=('fontconfig')
+pkg_source=https://www.freedesktop.org/software/fontconfig/release/${pkg_name}-${pkg_version}.tar.bz2
+pkg_filename=${pkg_name}-${pkg_version}.tar.bz2
+pkg_shasum=d763c024df434146f3352448bc1f4554f390c8a48340cef7aa9cc44716a159df
+pkg_gpg_key=3853DA6B
+pkg_deps=(chef/glibc)
+pkg_build_deps=(chef/gcc chef/make chef/coreutils chef/python
+                chef/pkg-config chef/freetype chef/expat
+                chef/diffutils chef/libtool chef/m4 chef/automake
+                chef/autoconf chef/file)
+pkg_lib_dirs=(lib)
+pkg_include_dirs=(include)
+
+do_prepare() {
+  # Borrowing this pro tip from ArchLinux!
+  # https://projects.archlinux.org/svntogit/packages.git/tree/trunk/PKGBUILD?h=packages/fontconfig#n34
+  # this seems to run libtoolize though...
+  autoreconf -fi
+
+  _file_path="$(pkg_path_for chef/file)/bin/file"
+  _uname_path="$(pkg_path_for chef/coreutils)/bin/uname"
+
+  sed -e "s#/usr/bin/file#${_file_path}#g" -i configure
+  sed -e "s#/usr/bin/uname#${_uname_path}#g" -i configure
+}
+
+do_build() {
+  export PKG_CONFIG_PATH="$(pkg_path_for chef/freetype)/lib/pkgconfig:$(pkg_path_for chef/expat)/lib/pkgconfig"
+
+  ./configure --sysconfdir=${pkg_prefix}/etc \
+              --prefix=${pkg_prefix} \
+              --disable-static \
+              --mandir=${pkg_prefix}/man
+  make
+  make install
+}

--- a/plans/freetype/plan.sh
+++ b/plans/freetype/plan.sh
@@ -1,0 +1,12 @@
+pkg_name=freetype
+pkg_version=2.6.3
+pkg_origin=chef
+pkg_license=('FreeType')
+pkg_source=http://download.savannah.gnu.org/releases/freetype/${pkg_name}-${pkg_version}.tar.bz2
+pkg_filename=${pkg_name}-${pkg_version}.tar.gz
+pkg_shasum=371e707aa522acf5b15ce93f11183c725b8ed1ee8546d7b3af549863045863a2
+pkg_gpg_key=3853DA6B
+pkg_deps=(chef/glibc chef/libpng)
+pkg_build_deps=(chef/gcc chef/make chef/coreutils)
+pkg_lib_dirs=(lib)
+pkg_include_dirs=(include)

--- a/plans/libpng/plan.sh
+++ b/plans/libpng/plan.sh
@@ -1,0 +1,25 @@
+pkg_name=libpng
+pkg_version=1.6.21
+pkg_origin=chef
+pkg_license=('libpng')
+pkg_source=http://download.sourceforge.net/${pkg_name}/${pkg_name}-${pkg_version}.tar.gz
+pkg_filename=${pkg_name}-${pkg_version}.tar.gz
+pkg_shasum=b36a3c124622c8e1647f360424371394284f4c6c4b384593e478666c59ff42d3
+pkg_gpg_key=3853DA6B
+pkg_deps=(chef/glibc chef/zlib)
+pkg_build_deps=(chef/gcc chef/make chef/coreutils chef/diffutils
+                chef/autoconf chef/automake)
+pkg_lib_dirs=(lib)
+pkg_include_dirs=(include)
+
+do_build() {
+  _zlib_dir=$(pkg_path_for chef/zlib)
+
+  export CPPFLAGS="${CPPFLAGS} ${CFLAGS}"
+  ./configure --prefix=${pkg_prefix} \
+              --host=x86_64-unknown-linux-gnu \
+              --build=x86_64-unknown-linux-gnu \
+              --disable-static \
+              --with-zlib-prefix=${_zlib_dir} \ &&
+  make && make install
+}

--- a/plans/node/plan.sh
+++ b/plans/node/plan.sh
@@ -9,16 +9,20 @@ pkg_source=https://nodejs.org/dist/v${pkg_version}/${pkg_name}-v${pkg_version}.t
 pkg_dirname=node-v${pkg_version}
 pkg_shasum=ea5e357db8817052b17496d607c719d809ed1383e8fcf7c8ffc5214e705aefdd
 pkg_gpg_key=3853DA6B
-pkg_deps=(chef/glibc chef/gcc-libs)
-pkg_build_deps=(chef/python2 chef/gcc chef/make chef/coreutils)
+pkg_deps=(chef/glibc chef/gcc-libs chef/coreutils/8.24/20160223204924)
+pkg_build_deps=(chef/python2 chef/gcc chef/make)
 pkg_lib_dirs=(lib)
 pkg_include_dirs=(include)
 pkg_binary_path=(bin)
 pkg_interpreters=(bin/node)
 
 do_build() {
-    fix_interpreter configure chef/coreutils bin/env
+  # Node ships a lot of scripts that hardcode `/usr/bin/env`, so we
+  # need to fix that everywhere.
+  for target in `find . -type f -exec grep -l '^\#\!/usr/bin/env' {} \;`; do
+    fix_interpreter ${target} chef/coreutils bin/env
+  done
 
-    # use --without-snapshot, because https://github.com/nodejs/node/issues/4212
-    ./configure --prefix=${pkg_prefix} --without-snapshot && make && make install
+  # use --without-snapshot, because https://github.com/nodejs/node/issues/4212
+  ./configure --prefix=${pkg_prefix} --without-snapshot && make && make install
 }

--- a/plans/phantomjs/plan.sh
+++ b/plans/phantomjs/plan.sh
@@ -1,0 +1,65 @@
+pkg_name=phantomjs
+pkg_version=2.1.1
+pkg_origin=chef
+pkg_license=('bsd')
+pkg_source=https://bitbucket.org/ariya/phantomjs/downloads/${pkg_name}-${pkg_version}-linux-x86_64.tar.bz2
+pkg_filename=${pkg_name}-${pkg_version}-linux-x86_64.tar.bz2
+pkg_dirname=${pkg_name}-${pkg_version}-linux-x86_64
+pkg_shasum=86dd9a4bf4aee45f1a84c9f61cf1947c1d6dce9b9e8d2a907105da7852460d2f
+pkg_gpg_key=3853DA6B
+
+# Ensure we depend on all the libraries that the prebuilt phantomjs
+# links against here:
+pkg_deps=(chef/glibc chef/freetype chef/fontconfig chef/patchelf
+          chef/zlib chef/libpng chef/expat chef/gcc-libs)
+
+# We need curl instead of wget because wget doesn't work for
+# downloading from bitbucket URLs. Sometimes.
+pkg_build_deps=(chef/curl chef/cacerts)
+
+pkg_binary_path=(bin)
+
+do_download() {
+  # downloading from bitbucket with wget results in a 403.
+  # So then we implement our own `do_download` with `curl`.
+  pushd $BLDR_SRC_CACHE > /dev/null
+  if [[ -f $pkg_filename ]]; then
+    build_line "Found previous file '${pkg_filename}', attempting to re-use"
+    if verify_file $pkg_filename $pkg_shasum; then
+      build_line "Using cached and verified '${pkg_filename}'"
+      return 0
+    else
+      build_line "Clearing previous '${pkg_filename}' and re-attempting download"
+      rm -fv $pkg_filename
+    fi
+  fi
+
+  build_line "Downloading '${pkg_source}' to '${pkg_filename}' with curl"
+  curl -L -O $pkg_source --cacert $(pkg_path_for chef/cacerts)/ssl/cert.pem
+  build_line "Downloaded '${pkg_filename}'";
+  popd > /dev/null
+}
+
+do_build () {
+  # We don't need to build because phantomjs is a prebuilt binary!
+  return 0
+}
+
+do_strip() {
+  # Because we're a) using a prebuilt binary, and b) running
+  # patchelf against it, strip will remove "commonly the strings
+  # that represent the names associated with symbol table entries"
+  # https://refspecs.linuxfoundation.org/LSB_3.0.0/LSB-PDA/LSB-PDA/specialsections.html
+  return 0
+}
+
+do_install() {
+  cp -vR * ${pkg_path}
+
+  build_line "Setting interpreter for '${pkg_prefix}/bin/phantomjs' '$(pkg_path_for chef/glibc)/lib/ld-linux-x86-64.so.2'"
+  build_line "Setting rpath for '${pkg_prefix}/bin/phantomjs' to '$LD_RUN_PATH'"
+
+  patchelf --interpreter "$(pkg_path_for chef/glibc)/lib/ld-linux-x86-64.so.2" \
+           --set-rpath ${LD_RUN_PATH} \
+           ${pkg_prefix}/bin/phantomjs
+}


### PR DESCRIPTION
These changes go together because they're to help support building bldr-web (which has some fixes in this commit, too).
- Add a phantomjs plan. This also brings in the dependencies: curl, fontconfig, freetype, libpng
- Fix the interpreters in scripts that ship with node.js
- Specify a particular coreutils version because we'll use it via fix_interpreter
