### PR TITLE
glibc 2.23 and openssl 1.0.2g

### DIFF
--- a/plans/glibc/plan.sh
+++ b/plans/glibc/plan.sh
@@ -1,10 +1,10 @@
 pkg_name=glibc
 pkg_origin=chef
-pkg_version=2.22
+pkg_version=2.23
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
 pkg_license=('gplv2' 'lgplv2')
 pkg_source=http://ftp.gnu.org/gnu/$pkg_name/${pkg_name}-${pkg_version}.tar.xz
-pkg_shasum=eb731406903befef1d8f878a46be75ef862b9056ab0cde1626d08a7a05328948
+pkg_shasum=94efeb00e4603c8546209cefb3e1a50a5315c86fa9b078b6fad758e187ce13e9
 pkg_deps=(chef/linux-headers)
 pkg_build_deps=(chef/coreutils chef/diffutils chef/patch chef/make chef/gcc chef/sed chef/perl)
 pkg_binary_path=(bin)

--- a/plans/openssl/plan.sh
+++ b/plans/openssl/plan.sh
@@ -1,10 +1,10 @@
 pkg_name=openssl
 pkg_origin=chef
-pkg_version=1.0.2f
+pkg_version=1.0.2g
 pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
 pkg_license=('bsd')
 pkg_source=http://www.openssl.org/source/${pkg_name}-${pkg_version}.tar.gz
-pkg_shasum=932b4ee4def2b434f85435d9e3e19ca8ba99ce9a065a61524b429a9d5e9b2e9c
+pkg_shasum=b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33
 pkg_deps=(chef/glibc chef/zlib chef/cacerts)
 pkg_build_deps=(chef/coreutils chef/diffutils chef/patch chef/make chef/gcc chef/sed chef/grep chef/perl)
 pkg_binary_path=(bin)


### PR DESCRIPTION
Updates for the following security vulnerabilities:
https://www.sourceware.org/ml/libc-alpha/2016-02/msg00416.html
https://www.openssl.org/news/vulnerabilities.html#y2016

**_Don't merge yet!**_ This segfaults during build with glibc 2.23:

```
/bin/sh: line 1: 26992 Segmentation fault      LD_LIBRARY_PATH=$LIBPATH:$LD_LIBRARY_PATH ${SHAREDCMD} ${SHAREDFLAGS} -o $SHLIB$SHLIB_SOVER$SHLIB_SUFFIX $ALLSYMSFLAGS $SHOBJECTS $NOALLSYMSFLAGS $LIB
DEPS
Makefile.shared:169: recipe for target 'link_a.gnu' failed
make[4]: *** [link_a.gnu] Error 139
make[4]: Leaving directory '/opt/bldr/cache/src/openssl-1.0.2g'
Makefile:354: recipe for target 'do_linux-shared' failed
make[3]: *** [do_linux-shared] Error 2
make[3]: Leaving directory '/opt/bldr/cache/src/openssl-1.0.2g'
Makefile:307: recipe for target 'libcrypto.so.1.0.0' failed
make[2]: *** [libcrypto.so.1.0.0] Error 2
make[2]: Leaving directory '/opt/bldr/cache/src/openssl-1.0.2g'
Makefile:109: recipe for target 'shared' failed
make[1]: *** [shared] Error 2
make[1]: Leaving directory '/opt/bldr/cache/src/openssl-1.0.2g/crypto'
Makefile:284: recipe for target 'build_crypto' failed
make: *** [build_crypto] Error 1
```
