### PR TITLE
build bldr-web in a studio

### DIFF
--- a/plans/bldr-web/hooks/init
+++ b/plans/bldr-web/hooks/init
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 mkdir -p /opt/bldr/srvc/nginx/var
 path_to_bldr_web="/opt/bldr/pkgs/{{bldr.origin}}/{{bldr.name}}/{{bldr.version}}/{{bldr.release}}"
 

--- a/plans/bldr-web/hooks/run
+++ b/plans/bldr-web/hooks/run
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 path_to_nginx=`cat /opt/bldr/pkgs/{{bldr.origin}}/{{bldr.name}}/{{bldr.version}}/{{bldr.release}}/DEPS | grep nginx`
 exec 2>&1

--- a/plans/bldr-web/plan.sh
+++ b/plans/bldr-web/plan.sh
@@ -6,7 +6,8 @@ pkg_license=('Apache2')
 pkg_filename=${pkg_name}-${pkg_version}.tar.bz2
 pkg_gpg_key=3853DA6B
 pkg_deps=(chef/glibc chef/bldr chef/pcre chef/nginx)
-pkg_build_deps=(chef/node chef/coreutils chef/phantomjs)
+pkg_build_deps=(chef/node chef/coreutils chef/phantomjs chef/python2
+                chef/make chef/gcc chef/gcc-libs)
 pkg_lib_dirs=(lib)
 pkg_include_dirs=(include)
 pkg_expose=(80 443)
@@ -21,9 +22,14 @@ do_begin() {
 }
 
 do_build() {
-    npm install
-    fix_interpreter "${BLDR_SRC_CACHE}/${pkg_name}-${pkg_version}/node_modules/.bin/*" chef/coreutils bin/env
-    npm run dist
+  npm install
+
+  for b in ${BLDR_SRC_CACHE}/${pkg_name}-${pkg_version}/node_modules/.bin/*; do
+    fix_interpreter $(readlink -f -n $b) chef/coreutils bin/env
+  done
+
+  npm run postinstall
+  npm run dist
 }
 
 do_install() {

--- a/web/package.json
+++ b/web/package.json
@@ -24,7 +24,7 @@
     "lint-js-watch": "watch 'npm run lint-js'",
     "help": "cat README.md",
     "repl": "cd app && tsun",
-    "postinstall": "typings install",
+    "postinstall": "typings install --no-insight",
     "start": "concurrent \"npm run build-css-watch\" \"npm run build-js-watch\" \"npm run test-unit -- --no-single-run\" \"npm run lint-css-watch\" \"lite-server\"",
     "test": "npm run test-unit && npm run test-e2e",
     "test-watch": "concurrent \"npm run test-unit-watch\" \"npm run test-e2e-watch\"",


### PR DESCRIPTION
This commit introduces changes that allow bldr-web to be built in a
studio:
- Add build deps for installing and building npm modules
- Change the interpreter in the source files, not the symlinks, for the
  node module binaries
- Skip the prompt for phone-home statistics for the typings npm module
- Use sh, not bash, for hooks because busybox doesn't have a bash
