### PR TITLE
Use wget-static for bpm

### DIFF
--- a/plans/bpm/bin/bpm.sh
+++ b/plans/bpm/bin/bpm.sh
@@ -522,7 +522,7 @@ latest_remote_package() {
       ;;
     "2"|"1")
       local result="$(\
-        $bb env -u http_proxy $bb wget "$BLDR_REPO/pkgs/$1" -O- -q | \
+        $bb env -u http_proxy $wget "$BLDR_REPO/pkgs/$1" -O- -q | \
         $jq -r 'last | .origin + "/" + .name + "/" + .version + "/" + .release')"
       if [ -n "$result" ]; then
         echo $result
@@ -632,7 +632,7 @@ install_package() {
     trap '$bb rm -f $pkg_filename; exit $?' INT TERM EXIT
 
     info "Downloading $($bb basename $pkg_filename)"
-    $bb wget $pkg_source -O $pkg_filename $wui
+    $wget $pkg_source -O $pkg_filename $wui
 
     info "Unpacking $($bb basename $pkg_filename)"
     local gpg_cmd="$gpg --homedir $BLDR_GPG_CACHE --decrypt $pkg_filename"
@@ -802,6 +802,8 @@ cu="$libexec_path/coreutils"
 gpg="$libexec_path/gpg"
 # Absolute path to the `jq` command
 jq="$libexec_path/jq"
+# Absolute path to the `wget` command
+wget="$libexec_path/wget"
 # The current version of this program
 version='@version@'
 # The author of this program

--- a/plans/bpm/plan.sh
+++ b/plans/bpm/plan.sh
@@ -5,7 +5,9 @@ pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
 pkg_license=('apachev2')
 pkg_source=nosuchfile.tar.gz
 pkg_deps=()
-pkg_build_deps=(chef/coreutils chef/tar chef/xz chef/wget chef/busybox-static chef/coreutils-static chef/gnupg-static chef/jq-static)
+pkg_build_deps=(chef/coreutils chef/tar chef/xz chef/wget chef/busybox-static
+                chef/coreutils-static chef/gnupg-static chef/jq-static
+                chef/wget-static)
 pkg_binary_path=(bin)
 pkg_gpg_key=3853DA6B
 
@@ -38,6 +40,9 @@ do_install() {
 
   install -v -D $(pkg_path_for jq-static)/bin/jq \
     $pkg_path/libexec/jq
+
+  install -v -D $(pkg_path_for wget-static)/bin/wget \
+    $pkg_path/libexec/wget
 }
 
 do_end() {


### PR DESCRIPTION
The `wget` included with busybox exits 0 when the download fails, and it
doesn't have any retry logic. This embeds wget-static and uses that
instead.
