### PR TITLE
fix erroneous error output when uploading packages

### DIFF
--- a/src/bldr/command/upload.rs
+++ b/src/bldr/command/upload.rs
@@ -50,10 +50,11 @@ pub fn package(config: &Config) -> BldrResult<()> {
             return Err(bldr_error!(ErrorKind::PackageArchiveMalformed(format!("{}",
                                                                           package.cache_file().to_string_lossy()))));
         }
-        Err(e) => {
+        Err(e @ BldrError{err: ErrorKind::HTTP(_), ..}) => {
             outputln!("Unexpected response from remote");
             return Err(e);
         }
+        Err(e) => return Err(e),
     }
     outputln!("Complete");
     Ok(())


### PR DESCRIPTION
The console will only contain output about an unexpected response from remote if the remote returned an unexpected response and not for all errors

![gif-keyboard-17464746098120913283](https://cloud.githubusercontent.com/assets/54036/13686507/e546da56-e6ca-11e5-8260-6146fa8fcf95.gif)
