### PR TITLE
Makes upload take an archive, rather than an ident

### DIFF
--- a/src/bldr/config.rs
+++ b/src/bldr/config.rs
@@ -90,6 +90,7 @@ pub struct Config {
     topology: Topology,
     group: String,
     path: String,
+    archive: String,
     watch: Vec<String>,
     key: String,
     password: Option<String>,
@@ -110,6 +111,17 @@ impl Config {
     /// Create a default `Config`
     pub fn new() -> Config {
         Config::default()
+    }
+
+    /// Set the archive
+    pub fn set_archive(&mut self, archive: String) -> &mut Config {
+        self.archive = archive;
+        self
+    }
+
+    /// Return the archive
+    pub fn archive(&self) -> &str {
+        &self.archive
     }
 
     /// Set the `Command` we used

--- a/src/bldr/package/mod.rs
+++ b/src/bldr/package/mod.rs
@@ -331,8 +331,9 @@ impl Package {
                                                              match a.partial_cmp(&b) {
                                                                  Some(Ordering::Greater) => Some(a),
                                                                  Some(Ordering::Equal) => Some(a),
-                                                                 Some(Ordering::Less) =>
-                                                                     Some(b.clone()),
+                                                                 Some(Ordering::Less) => {
+                                                                     Some(b.clone())
+                                                                 }
                                                                  None => Some(a),
                                                              }
                                                          }


### PR DESCRIPTION
![gif-keyboard-7463363754354019810](https://cloud.githubusercontent.com/assets/4304/13693202/791a776a-e6fd-11e5-8753-c9d19c570dcb.gif)
- `bldr upload` now takes a path to an archive
- It also now uses a PackageArchive rather than Package
- A default depot URL is included now, making -u optional
