### PR TITLE
Fix the missing port and exposes functionality

### DIFF
--- a/components/bldr/src/census.rs
+++ b/components/bldr/src/census.rs
@@ -726,9 +726,7 @@ impl CensusList {
                    service_group: &str)
                    -> Option<&mut CensusEntry> {
         match self.censuses.get_mut(service_group) {
-            Some(mut census) => {
-                census.get_mut(census_entry_id)
-            }
+            Some(mut census) => census.get_mut(census_entry_id),
             None => None,
         }
     }
@@ -746,7 +744,6 @@ impl CensusList {
             census.written();
         }
     }
-
 }
 
 impl Deref for CensusList {

--- a/components/bldr/src/gossip/server.rs
+++ b/components/bldr/src/gossip/server.rs
@@ -62,7 +62,13 @@ pub struct Server {
 impl Server {
     /// Creates a new Server. Creates our own entry in the census and membership lists, and writes
     /// a rumor that this server is alive.
-    pub fn new(listen: String, permanent: bool, service: String, group: String) -> Server {
+    pub fn new(listen: String,
+               permanent: bool,
+               service: String,
+               group: String,
+               exposes: Option<Vec<String>>,
+               port: Option<String>)
+               -> Server {
         let hostname = util::sys::hostname().unwrap_or(String::from("unknown"));
         let ip = util::sys::ip().unwrap_or(String::from("127.0.0.1"));
 
@@ -71,7 +77,9 @@ impl Server {
         let member = Member::new(hostname, ip, peer_listen2, permanent);
 
         let service_group = format!("{}.{}", service, group);
-        let ce = CensusEntry::new(service, group, member.id.clone());
+        let mut ce = CensusEntry::new(service, group, member.id.clone());
+        ce.exposes = exposes;
+        ce.port = port;
         let my_id = member.id.clone();
         let leader_id = member.id.clone();
         outputln!("Supervisor {}", member);


### PR DESCRIPTION
![gif-keyboard-3494451331950561715](https://cloud.githubusercontent.com/assets/4304/13764907/b4ea735a-ea11-11e5-87b4-81591c306d5d.gif)

The "port" and "exposes" data was missing from the census with the
latest refactor. This commit puts it back.
