### PR TITLE
bldr-build and studio improvements

### DIFF
--- a/plans/bldr-build
+++ b/plans/bldr-build
@@ -1879,7 +1879,7 @@ $(cat $PLAN_CONTEXT/plan.sh)
 
 Files
 -----
-$(find $pkg_path -type f | $_sort_cmd | xargs $_shasum_cmd)
+$(find $pkg_path -type f -print0 | $_sort_cmd | xargs -0 $_shasum_cmd)
 EOT
   return 0
 }

--- a/plans/bldr-studio/bin/studio
+++ b/plans/bldr-studio/bin/studio
@@ -332,15 +332,8 @@ EOF
   # Invoke the type's implementation
   finish_setup
 
-  # Add a useful command prompt
-  case "${TERM:-}" in
-  *term | xterm-* | rxvt | screen | screen-*)
-    prompt='\[\e[0;32m\][\[\e[0;36m\]\#\[\e[0;32m\]]['$studio_type':\[\e[0;35m\]\w\[\e[0;32m\]:\e[1;37m\$?\[\e[0;32m\]]\$\[\e[0m\]\040 '
-    ;;
-  *)
-    prompt='[\#]['$studio_type':\w:\$?]\$\040 '
-    ;;
-  esac
+  # This prompt tells us what kind of studio we're in!
+  prompt='[\#]['$studio_type':\w:\$?]\$\040 '
   studio_enter_environment="$studio_enter_environment PS1=$prompt"
 
   # Add a Studio configuration file at the root of the filesystem


### PR DESCRIPTION
When writing the SHA256 checksums to the manifest, files that have
spaces in the names are not escaped/quoted, so errors will get
displayed and those files will not be included in the manifest. Adding
the `-print0` option to find, along with the `-0` option to xargs
resolves this problem.

We love colorized prompts. However, in most of our default terminal
settings the escape codes cause weird behavior that prevents the
terminal from displaying really long commands. For now, let's just
have a simple prompt with no color.
