### PR TITLE
bldr upload now uploads dependencies

### DIFF
--- a/components/bldr/src/package/mod.rs
+++ b/components/bldr/src/package/mod.rs
@@ -76,6 +76,18 @@ impl PackageIdent {
         }
     }
 
+    pub fn archive_name(&self) -> Option<String> {
+        if self.fully_qualified() {
+            Some(format!("{}-{}-{}-{}.bldr",
+                         self.origin,
+                         self.name,
+                         self.version.as_ref().unwrap(),
+                         self.release.as_ref().unwrap()))
+        } else {
+            None
+        }
+    }
+
     pub fn fully_qualified(&self) -> bool {
         self.version.is_some() && self.release.is_some()
     }


### PR DESCRIPTION
![gif-keyboard-4295078047944762463](https://cloud.githubusercontent.com/assets/4304/13830018/7304a8b2-eb87-11e5-8c42-cc3b8ab4e504.gif)

This fixes bldr upload to now correctly deal with dependencies.
- If a dependency doesn't exist in the depot, we check for an archive in
  the same directory as the archive you specified on the command line,
  and upload it
- If everything is present, it doesn't upload anything
