### PR TITLE
Update demo script to use all uppercase env vars.

### DIFF
--- a/demo/demoscript.md
+++ b/demo/demoscript.md
@@ -60,7 +60,7 @@ Get a TOML output with all the configuration values.
 Run the container again overriding the configuration:
 
 ```
-docker run -e BLDR_redis='tcp-backlog = 128' -it quay.io/bldr/redis
+docker run -e BLDR_REDIS='tcp-backlog = 128' -it quay.io/bldr/redis
 ```
 
 See the message gone.


### PR DESCRIPTION
This changed during the service config refactor in 5c2f3237.
