### PR TITLE
bump locked libarchive crate

### DIFF
--- a/components/bldr/Cargo.lock
+++ b/components/bldr/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
  "hyper 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "iron 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "libarchive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libarchive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lmdb-sys 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -88,7 +88,7 @@ version = "0.4.0"
 dependencies = [
  "gpgme 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "libarchive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libarchive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-crypto 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -314,7 +314,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libarchive"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libarchive3-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/core/Cargo.lock
+++ b/components/core/Cargo.lock
@@ -4,7 +4,7 @@ version = "0.4.0"
 dependencies = [
  "gpgme 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "libarchive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libarchive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.57 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-crypto 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -74,7 +74,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libarchive"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libarchive3-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/depot-client/Cargo.lock
+++ b/components/depot-client/Cargo.lock
@@ -28,7 +28,7 @@ version = "0.4.0"
 dependencies = [
  "gpgme 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "libarchive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libarchive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-crypto 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -154,7 +154,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libarchive"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libarchive3-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/depot-core/Cargo.lock
+++ b/components/depot-core/Cargo.lock
@@ -28,7 +28,7 @@ version = "0.4.0"
 dependencies = [
  "gpgme 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "libarchive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libarchive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-crypto 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -143,7 +143,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libarchive"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libarchive3-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/depot/Cargo.lock
+++ b/components/depot/Cargo.lock
@@ -12,7 +12,7 @@ dependencies = [
  "hyper 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "iron 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "libarchive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libarchive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lmdb-sys 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -69,7 +69,7 @@ version = "0.4.0"
 dependencies = [
  "gpgme 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "libarchive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libarchive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-crypto 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -267,7 +267,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libarchive"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libarchive3-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
This will resolve extracting archives which contain hardlinks

![gif-keyboard-4804483223486697997](https://cloud.githubusercontent.com/assets/54036/13938364/61f8eb44-ef8a-11e5-97ac-9e4607101c43.gif)
