### PR TITLE
Restore functional test suite.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,11 +53,8 @@ unit: image ## run unit tests with cargo
 	$(run) shell cargo test --lib --manifest-path components/depot-client/Cargo.toml
 
 functional: image ## run the functional tests
-	$(run) shell cargo test --test functional --manifest-path components/core/Cargo.toml
 	$(run) shell cargo test --test functional --manifest-path components/bldr/Cargo.toml
-	$(run) shell cargo test --test functional --manifest-path components/depot-core/Cargo.toml
 	$(run) shell cargo test --test functional --manifest-path components/depot/Cargo.toml
-	$(run) shell cargo test --test functional --manifest-path components/depot-client/Cargo.toml
 
 clean: ## clean up our docker environment
 	rm -rf components/bldr/target/debug components/bldr/target/release

--- a/components/bldr/tests/bldr/mod.rs
+++ b/components/bldr/tests/bldr/mod.rs
@@ -5,7 +5,6 @@
 // is made available under an open source license such as the Apache 2.0 License.
 
 pub mod start;
-pub mod depot;
 pub mod key;
 pub mod gossip;
 pub mod topology;


### PR DESCRIPTION
This change removes an extra `use` line that was moved out under the
`bldr` component which causes the suite to not compile.

Additionally, the `make functional` Make target was repaired by removing
calls to `cargo test --test function` on components lacking a `tests/`
subdirectory. While this solution is not my first choice, it gets us
back to green without addressing the Makefile for the moment. In other
words, my eyes spot duplication ;)

**Note** that as is, our `make functional` _will_ fail. This needs to be addressed in another PR.
