### PR TITLE
Update install location of `bldr` in fixture Plans.

### DIFF
--- a/components/bldr/tests/fixtures/bldr_build/plan.sh
+++ b/components/bldr/tests/fixtures/bldr_build/plan.sh
@@ -31,7 +31,7 @@ do_build() {
 
 do_install() {
   cp -r $PLAN_CONTEXT/bin $pkg_prefix
-  cp -r /src/target/debug/bldr $pkg_prefix/bin
+  cp -r /src/components/bldr/target/debug/bldr $pkg_prefix/bin
   chmod 755 $pkg_prefix/bin
   chmod 755 $pkg_prefix/bin/*
   return 0

--- a/components/bldr/tests/fixtures/simple_service/plan.sh
+++ b/components/bldr/tests/fixtures/simple_service/plan.sh
@@ -31,7 +31,7 @@ do_build() {
 
 do_install() {
   cp -r $PLAN_CONTEXT/bin $pkg_prefix
-  cp -r /src/target/debug/bldr $pkg_prefix/bin
+  cp -r /src/components/bldr/target/debug/bldr $pkg_prefix/bin
   chmod 755 $pkg_prefix/bin
   chmod 755 $pkg_prefix/bin/*
   return 0

--- a/components/bldr/tests/fixtures/simple_service_gossip/plan.sh
+++ b/components/bldr/tests/fixtures/simple_service_gossip/plan.sh
@@ -31,7 +31,7 @@ do_build() {
 
 do_install() {
   cp -r $PLAN_CONTEXT/bin $pkg_prefix
-  cp -r /src/target/debug/bldr $pkg_prefix/bin
+  cp -r /src/components/bldr/target/debug/bldr $pkg_prefix/bin
   chmod 755 $pkg_prefix/bin
   chmod 755 $pkg_prefix/bin/*
   return 0

--- a/components/bldr/tests/fixtures/simple_service_without_config/plan.sh
+++ b/components/bldr/tests/fixtures/simple_service_without_config/plan.sh
@@ -27,7 +27,7 @@ do_build() {
 }
 
 do_install() {
-  cp -r /src/target/debug/bldr $pkg_prefix/bin
+  cp -r /src/components/bldr/target/debug/bldr $pkg_prefix/bin
 	cp -r $BLDR_SRC_CACHE/$pkg_dirname/bin $pkg_prefix
 	chmod 755 $pkg_path/bin
     chmod 755 $pkg_path/bin/*


### PR DESCRIPTION
This change fixes the package builds of these fixture Plans.

**Note** that the functional suite still fails on the current "update by
default on start" upgrade strategy which is being worked on.
