### PR TITLE
Fix `bldr start`'s update strategy

### DIFF
--- a/components/bldr/src/config.rs
+++ b/components/bldr/src/config.rs
@@ -41,6 +41,27 @@ pub enum Command {
     Upload,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UpdateStrategy {
+    None,
+    AtOnce,
+}
+
+impl UpdateStrategy {
+    pub fn from_str(strategy: &str) -> Self {
+        match strategy {
+            "none" => UpdateStrategy::None,
+            "at-once" => UpdateStrategy::AtOnce,
+            s => panic!("Invalid update strategy {}", s),
+        }
+    }
+}
+impl Default for UpdateStrategy {
+    fn default() -> UpdateStrategy {
+        UpdateStrategy::None
+    }
+}
+
 impl FromStr for Command {
     type Err = BldrError;
     fn from_str(s: &str) -> Result<Command, BldrError> {
@@ -94,6 +115,7 @@ pub struct Config {
     outfile: Option<String>,
     gossip_peer: Vec<String>,
     gossip_permanent: bool,
+    update_strategy: UpdateStrategy,
 }
 
 impl Config {
@@ -111,6 +133,16 @@ impl Config {
     /// Return the archive
     pub fn archive(&self) -> &str {
         &self.archive
+    }
+
+    pub fn set_update_strategy(&mut self, strat: UpdateStrategy) -> &mut Config {
+        self.update_strategy = strat;
+        self
+    }
+
+    /// Return the command we used
+    pub fn update_strategy(&self) -> UpdateStrategy {
+        self.update_strategy.clone()
     }
 
     /// Set the `Command` we used

--- a/components/bldr/src/main.rs
+++ b/components/bldr/src/main.rs
@@ -25,7 +25,7 @@ use ansi_term::Colour::Yellow;
 use core::package::PackageIdent;
 use clap::{App, AppSettings, Arg, ArgGroup, ArgMatches, SubCommand};
 
-use bldr::config::{Command, Config};
+use bldr::config::{Command, Config, UpdateStrategy};
 use bldr::error::{BldrResult, BldrError, ErrorKind};
 use bldr::command::*;
 use bldr::topology::Topology;
@@ -52,6 +52,9 @@ fn config_from_args(args: &ArgMatches,
     let mut config = Config::new();
     let command = try!(Command::from_str(subcommand));
     config.set_command(command);
+    if let Some(ref strategy) = sub_args.value_of("strategy") {
+        config.set_update_strategy(UpdateStrategy::from_str(strategy));
+    }
     if let Some(ref archive) = sub_args.value_of("archive") {
         config.set_archive(archive.to_string());
     }
@@ -164,6 +167,14 @@ fn main() {
             .takes_value(true)
             .help("Output filename")
     };
+    let arg_strategy = || {
+        Arg::with_name("strategy")
+            .long("strategy")
+            .short("s")
+            .takes_value(true)
+            .possible_values(&["none", "at-once"])
+            .help("The update strategy; [default: none].")
+    };
 
     let sub_install = SubCommand::with_name("install")
                           .about("Install a bldr package from a depot")
@@ -180,6 +191,7 @@ fn main() {
                                  .help("Name of package to start"))
                         .arg(arg_url())
                         .arg(arg_group())
+                        .arg(arg_strategy())
                         .arg(Arg::with_name("topology")
                                  .short("t")
                                  .long("topology")

--- a/components/depot/Cargo.lock
+++ b/components/depot/Cargo.lock
@@ -12,7 +12,7 @@ dependencies = [
  "hyper 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "iron 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "libarchive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libarchive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lmdb-sys 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -69,7 +69,7 @@ version = "0.4.0"
 dependencies = [
  "gpgme 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "libarchive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libarchive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-crypto 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -267,7 +267,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libarchive"
-version = "0.1.1"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libarchive3-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
![gif-keyboard-3157760903762571472](https://cloud.githubusercontent.com/assets/4304/13973199/8f07d888-f05d-11e5-9657-968bf7ef78b6.gif)

Right now, `bldr start` always checks to see if there is software to
download, and always tries to update to the latest version. This commit
adds a flag called `--strategy`, which defaults to `none`. This causes
the supervisor to:
1. Install the software if it is not already on disk
2. Never update the software

This removes many of the current crop of failure conditions. 

If you pass the flag `at-once`, then:
1. Install the software if it is not already on disk
2. Try and upgrade the software if it is already on disk and a new
   version is available
