### PR TITLE
Fix NGINX Config

### DIFF
--- a/plans/nginx/config/nginx.conf
+++ b/plans/nginx/config/nginx.conf
@@ -1,19 +1,19 @@
-worker_processes  {{worker_processes}};
+worker_processes  {{cfg.worker_processes}};
 daemon off;
 
 events {
-    worker_connections  {{worker_connections}};
+    worker_connections  {{cfg.events.worker_connections}};
 }
 
 http {
     include        mime.types;
     default_type   application/octet-stream;
 
-    sendfile       {{sendfile}};
-    tcp_nopush     {{tcp_nopush}};
-    tcp_nodelay    {{tcp_nodelay}};
+    sendfile       {{cfg.http.sendfile}};
+    tcp_nopush     {{cfg.http.tcp_nopush}};
+    tcp_nodelay    {{cfg.http.tcp_nodelay}};
 
-    keepalive_timeout  {{keepalive_timeout}};
+    keepalive_timeout  {{cfg.http.keepalive_timeout}};
 
     gzip  on;
     gzip_vary on;

--- a/plans/nginx/default.toml
+++ b/plans/nginx/default.toml
@@ -1,15 +1,27 @@
-# NGINX Tunables
+ #    #   ####      #    #    #  #    #
+ ##   #  #    #     #    ##   #   #  #
+ # #  #  #          #    # #  #    ##
+ #  # #  #  ###     #    #  # #    ##
+ #   ##  #    #     #    #   ##   #  #
+ #    #   ####      #    #    #  #    #
+ # For help with NGINX Config Tuning, 
+ # refer to: http://nginx.org/en/docs/http/ngx_http_core_module.html
 
-#
-# For help with NGINX Config Tuning, refer to: http://nginx.org/en/docs/http/ngx_http_core_module.html
-#
 
+#### General Configuration
 # worker_processes: Number of NGINX processes. Default = 1
 worker_processes = 4
 
+
+
+#### Events Context Configuration
+[events]
 # worker_connections: Connections per Worker Process.  Default = 1024
 worker_connections = 1024
 
+
+#### HTTP Context Configuration
+[http]
 # http.sendfile: Enable (on) or disable (off) Sendfile Support.  Default = on
 sendfile = "on"
 


### PR DESCRIPTION
NGINX builds were unusable due to missing configuration in the default.toml, this is fixed.  Dockerized builds of chef/nginx now work beautifully.
