### PR TITLE
remove runit from supervisor

### DIFF
--- a/components/bldr/src/error.rs
+++ b/components/bldr/src/error.rs
@@ -121,7 +121,7 @@ pub enum ErrorKind {
     PackageIdentMismatch(String, String),
     RemotePackageNotFound(package::PackageIdent),
     MustacheMergeOnlyMaps,
-    SupervisorSignalFailed,
+    SignalFailed,
     StringFromUtf8Error(string::FromUtf8Error),
     StrFromUtf8Error(str::Utf8Error),
     SupervisorDied,
@@ -145,6 +145,7 @@ pub enum ErrorKind {
     JsonEncode(json::EncoderError),
     JsonDecode(json::DecoderError),
     InitialPeers,
+    InvalidPidFile,
 }
 
 /// Our result type alias, for easy coding.
@@ -217,7 +218,7 @@ impl fmt::Display for BldrError {
                 }
             }
             ErrorKind::MustacheMergeOnlyMaps => format!("Can only merge two Mustache::Data::Maps"),
-            ErrorKind::SupervisorSignalFailed => format!("Failed to send a signal to the process supervisor"),
+            ErrorKind::SignalFailed => format!("Failed to send a signal to the child process"),
             ErrorKind::StringFromUtf8Error(ref e) => format!("{}", e),
             ErrorKind::StrFromUtf8Error(ref e) => format!("{}", e),
             ErrorKind::SupervisorDied => format!("The supervisor died"),
@@ -252,6 +253,8 @@ impl fmt::Display for BldrError {
             ErrorKind::JsonEncode(ref e) => format!("JSON encoding error: {}", e),
             ErrorKind::JsonDecode(ref e) => format!("JSON decoding error: {}", e),
             ErrorKind::InitialPeers => format!("Failed to contact initial peers"),
+            ErrorKind::InvalidPidFile => format!("Invalid child process PID file"),
+
         };
         let cstring = Red.bold().paint(content).to_string();
         let mut so = StructuredOutput::new("bldr",
@@ -300,7 +303,7 @@ impl Error for BldrError {
             ErrorKind::PackageIdentMismatch(_, _) => "Expected a package identity but received another",
             ErrorKind::RemotePackageNotFound(_) => "Cannot find a package in any sources",
             ErrorKind::MustacheMergeOnlyMaps => "Can only merge two Mustache::Data::Maps",
-            ErrorKind::SupervisorSignalFailed => "Failed to send a signal to the process supervisor",
+            ErrorKind::SignalFailed => "Failed to send a signal to the child process",
             ErrorKind::StringFromUtf8Error(_) => "Failed to convert a string from a Vec<u8> as UTF-8",
             ErrorKind::StrFromUtf8Error(_) => "Failed to convert a str from a &[u8] as UTF-8",
             ErrorKind::SupervisorDied => "The supervisor died",
@@ -324,6 +327,7 @@ impl Error for BldrError {
             ErrorKind::JsonEncode(_) => "JSON encoding error",
             ErrorKind::JsonDecode(_) => "JSON decoding error: {:?}",
             ErrorKind::InitialPeers => "Failed to contact initial peers",
+            ErrorKind::InvalidPidFile => "Invalid child process PID file",
         }
     }
 }

--- a/components/bldr/src/sidecar.rs
+++ b/components/bldr/src/sidecar.rs
@@ -269,7 +269,7 @@ fn config(lock: &Arc<RwLock<Package>>, _req: &mut Request) -> IronResult<Respons
 /// * Fails if the supervisor cannot return the status.
 fn status(lock: &Arc<RwLock<Package>>, _req: &mut Request) -> IronResult<Response> {
     let package = lock.read().unwrap();
-    let output = try!(package.status());
+    let output = try!(package.status_via_pidfile());
     Ok(Response::with((status::Ok, output)))
 }
 

--- a/components/bldr/src/topology/leader.rs
+++ b/components/bldr/src/topology/leader.rs
@@ -4,13 +4,12 @@
 // this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
 // is made available under an open source license such as the Apache 2.0 License.
 
-use topology::{self, standalone, State, Worker};
+use topology::{self, standalone, State, Worker, stop};
 use state_machine::StateMachine;
 use error::{BldrResult, BldrError};
 use package::Package;
 use config::Config;
 use census::MIN_QUORUM;
-use package::Signal;
 use gossip::server;
 
 static LOGKEY: &'static str = "TL";
@@ -125,9 +124,10 @@ fn state_check_for_election(worker: &mut Worker) -> BldrResult<(State, u64)> {
             }
             outputln!("Stopping the service to ensure there is only one master");
             {
-                let package = worker.package.write().unwrap();
-                if let Err(e) = package.signal(Signal::Stop) {
-                    outputln!("{}", e);
+                if worker.child_info.is_some() {
+                    if let Err(e) = stop(worker.child_info.as_ref().unwrap().pid) {
+                        outputln!("{}", e);
+                    }
                 }
             }
         } else {


### PR DESCRIPTION
This PR removes the use of runit as a process supervisor.

Note, a separate PR will remove references to runit in plans + packaging scripts.

Processes are started via the `/opt/bldr/srvc/<package>/run` script instead of via `runsv`. Additionally, the child PID is stored in `/opt/bldr/srvc/<package>/PID`. The PIDfile allows code outside of the worker (specifically, the sidecar) to send signals and check status of a package without knowing it's pid. The tradeoff here is that you have to open and read the PIDfile. Note that the worker doesn't need to check the pidfile on every iteration of `topology::run_internal`, as the pid is stashed in the worker state.

The `topology::run_internal` loop changes slightly, as we have to restart a child if we detect a failure instead of letting runit do that for us.

Signals are passed _through_ bldr via the `kill` syscall. The two exceptions are `SIGINT` and `SIGTERM`, which when caught, kill the child (permanently) and exit the supervisor. Note, the child could still directly receive `SIGINT` or `SIGTERM`, in which case, it will exit and be restarted by the supervisor.

The create time of the PIDfile is used to determine uptime for a child outside the scope of the worker, instead of creating a second file to store this timestamp. Status is mainly called from the sidecar, which doesn't have access to the worker state, thus the use of the PIDfile create time. It's a simple but effective hack.

Note: there are 2 test failures that appear to be unrelated to this PR (they fail on master as well):

```
test output::tests::format_verbose ... FAILED
test output::tests::format_verbose_color ... FAILED
```

---

TODO: 
- [x] wait for child during supervisor shutdown, then kill -9 after a timeout
- [ ] test pkg upgrade restarts
- [ ] test gossip change restarts
