### PR TITLE
[plans] Add a simple, sample Rails app

### DIFF
--- a/plans/radiant/hooks/init
+++ b/plans/radiant/hooks/init
@@ -1,0 +1,31 @@
+#!/bin/sh
+export RADIANT_HOME="{{pkg.path}}"
+export RADIANT_DATA="{{pkg.svc_path}}/data"
+
+echo "Removing previous version deployed at ${RADIANT_DATA}"
+rm -rf ${RADIANT_DATA}*
+
+echo "Deploying new version from ${RADIANT_HOME} to ${RADIANT_DATA}"
+cp -a ${RADIANT_HOME}/dist ${RADIANT_DATA}
+
+# echo "Linking radiant.conf"
+# ln -s {{pkg.svc_path}}/config/radiant.conf ${RADIANT_DATA}/dist/config/radiant.conf
+
+export GEM_HOME="${RADIANT_DATA}/dist/vendor/bundle"
+export GEM_PATH="$(bpm pkgpath chef/bundler)"
+export LD_LIBRARY_PATH="$(bpm pkgpath chef/gcc-libs)/lib"
+export PATH="$PATH:${RADIANT_DATA}/dist/bin"
+export RAILS_ENV="production"
+
+# mkdir -p ${RADIANT_DATA}/dist/log
+# touch ${RADIANT_DATA}/dist/log/production.log
+
+chown -R bldr:bldr ${RADIANT_DATA}/dist
+cd ${RADIANT_DATA}/dist
+
+exec 2>&1
+
+if [[ ! -f ${RADIANT_DATA}/.migrations_complete ]]; then
+  echo "Running 'rake db:create db:migrate' in ${PWD}"
+  exec chpst -u bldr bin/rake db:create db:migrate && touch $RADIANT_DATA/.migrations_complete
+fi

--- a/plans/radiant/hooks/run
+++ b/plans/radiant/hooks/run
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+export RADIANT_DATA="{{pkg.svc_path}}/data"
+export GEM_HOME="${RADIANT_DATA}/dist/vendor/bundle/ruby/2.3.0"
+export GEM_PATH="$(bpm pkgpath chef/ruby)/lib/ruby/gems/2.3.0:$(bpm pkgpath chef/bundler):$GEM_HOME"
+export LD_LIBRARY_PATH="$(bpm pkgpath chef/gcc-libs)/lib"
+export PATH="$PATH:${RADIANT_DATA}/dist/bin"
+export RAILS_ENV="production"
+
+cd $RADIANT_DATA/dist
+
+exec 2>&1
+exec chpst -u bldr ./bin/rails server

--- a/plans/radiant/plan.sh
+++ b/plans/radiant/plan.sh
@@ -1,0 +1,111 @@
+pkg_name=radiant
+pkg_version=2.0.0-alpha-jt
+
+pkg_origin=chef
+pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
+pkg_license=('mit')
+
+pkg_source=https://github.com/jtimberman/radiant/archive/${pkg_version}.tar.gz
+pkg_shasum=24e6527eec98df16f3857f3d0cdf630729b0b833117589c32b98b0078f1bea05
+
+pkg_gpg_key=3853DA6B
+pkg_deps=(
+  chef/bundler
+  chef/cacerts
+  chef/glibc
+  chef/libffi
+  chef/libxml2
+  chef/libxslt
+  chef/libyaml
+  chef/openssl
+  chef/postgresql
+  chef/ruby
+  chef/sqlite
+  chef/zlib
+)
+
+pkg_build_deps=(
+  chef/coreutils
+  chef/gcc
+  chef/make
+)
+
+pkg_lib_dirs=(lib)
+pkg_include_dirs=(include)
+pkg_expose=(80 443 3000)
+
+# do_download() {
+#   export GIT_SSL_CAINFO="$(pkg_path_for chef/cacerts)/ssl/certs/cacert.pem"
+#   git clone https://github.com/jtimberman/radiant
+#   pushd radiant
+#   git checkout $radiant_git_shasum
+#   popd
+#   tar -cjvf $BLDR_SRC_CACHE/${pkg_name}-${pkg_version}.tar.bz2 \
+#       --transform "s,^\./radiant,radiant-${pkg_version}," ./radiant \
+#       --exclude radiant/.git --exclude radiant/spec
+#   pkg_shasum=$(trim $(sha256sum $BLDR_SRC_CACHE/${pkg_filename} | cut -d " " -f 1))
+# }
+
+# The configure scripts for some RubyGems that build native extensions
+# use `/usr/bin` paths for commands. This is not going to work in a
+# studio where we don't have any of those commands. But we're kind of
+# stuck because the native extension is going to be built during
+# `bundle install`.
+#
+# We clean this link up in `do_install`.
+do_prepare() {
+  # build_line "Setting link for /usr/bin/file to chef/file"
+  # [[ ! -f /usr/bin/file ]] && ln -s $(pkg_path_for chef/file)/bin/file /usr/bin/file
+
+  build_line "Setting link for /usr/bin/env to chef/coreutils"
+  [[ ! -f /usr/bin/env ]] && ln -s $(pkg_path_for chef/coreutils)/bin/env /usr/bin/env
+  return 0
+}
+
+do_build() {
+  export CPPFLAGS="${CPPFLAGS} ${CFLAGS}"
+
+  local _bundler_dir=$(pkg_path_for chef/bundler)
+  local _libxml2_dir=$(pkg_path_for chef/libxml2)
+  local _libxslt_dir=$(pkg_path_for chef/libxslt)
+  local _postgresql_dir=$(pkg_path_for chef/postgresql)
+  local _pgconfig=$_postgresql_dir/bin/pg_config
+  local _sqlite_dir=$(pkg_path_for chef/sqlite)
+  local _zlib_dir=$(pkg_path_for chef/zlib)
+
+  export GEM_HOME=${pkg_path}/vendor/bundle
+  export GEM_PATH=${_bundler_dir}:${GEM_HOME}
+
+  # don't let bundler split up the nokogiri config string (it breaks
+  # the build), so specify it as an env var instead
+  export NOKOGIRI_CONFIG="--use-system-libraries --with-zlib-dir=${_zlib_dir} --with-xslt-dir=${_libxslt_dir} --with-xml2-include=${_libxml2_dir}/include/libxml2 --with-xml2-lib=${_libxml2_dir}/lib"
+  bundle config build.nokogiri '${NOKOGIRI_CONFIG}'
+  bundle config build.pg --with-pg-config=${_pgconfig}
+  bundle config build.sqlite3 --with-sqlite3-include=${_sqlite_dir}/include --with-sqlite3-lib=${_sqlite_dir}/lib
+
+  # We don't need mysql, so let's not even have it in the gemfile
+  sed -e 's/gem "mysql"/#removed mysql gem/' -i rails40.gemfile
+
+  bundle install --jobs 2 --retry 5 --path vendor/bundle \
+         --binstubs --gemfile=rails40.gemfile
+}
+
+do_install() {
+  cp -R . ${pkg_path}/dist
+
+  for binstub in ${pkg_path}/dist/bin/*; do
+    build_line "Setting shebang for ${binstub} to 'chef/ruby'"
+    [[ -f $binstub ]] && sed -e "s#/usr/bin/env ruby#$(pkg_path_for chef/ruby)/bin/ruby#" -i $binstub
+  done
+
+  # if [[ `readlink /usr/bin/file` = "$(pkg_path_for chef/file)/bin/file" ]]; then
+  #   build_line "Removing the symlink we created for '/usr/bin/file'"
+  #   rm /usr/bin/file
+  # fi
+
+  if [[ `readlink /usr/bin/env` = "$(pkg_path_for chef/coreutils)/bin/env" ]]; then
+    build_line "Removing the symlink we created for '/usr/bin/env'"
+    rm /usr/bin/env
+  fi
+
+}

--- a/plans/ruby-rails-sample/config/database.yml
+++ b/plans/ruby-rails-sample/config/database.yml
@@ -1,0 +1,12 @@
+default: &default
+  adapter: postgresql
+  encoding: unicode
+  pool: 5
+
+production:
+  <<: *default
+  database: {{cfg.database_name}}
+  username: {{cfg.database_username}}
+  password: {{cfg.database_password}}
+  host: {{cfg.database_host}}
+  port: {{cfg.database_port}}

--- a/plans/ruby-rails-sample/default.toml
+++ b/plans/ruby-rails-sample/default.toml
@@ -1,0 +1,7 @@
+database_name = "ruby-rails-sample_production"
+database_username = "ruby-rails-sample"
+database_password = ""
+database_host = "localhost"
+database_port = 5432
+rails_binding_ip = "0.0.0.0"
+rails_port = 3000

--- a/plans/ruby-rails-sample/hooks/init
+++ b/plans/ruby-rails-sample/hooks/init
@@ -1,0 +1,28 @@
+#!/bin/sh
+export RAILS_SAMPLE_HOME="{{pkg.path}}"
+export RAILS_SAMPLE_DATA="{{pkg.svc_path}}/data"
+
+echo "Removing previous version deployed at ${RAILS_SAMPLE_DATA}"
+rm -rf ${RAILS_SAMPLE_DATA}*
+
+echo "Deploying new version from ${RAILS_SAMPLE_HOME} to ${RAILS_SAMPLE_DATA}"
+cp -a ${RAILS_SAMPLE_HOME}/dist ${RAILS_SAMPLE_DATA}
+
+echo "Linking database.yml"
+ln -sf {{pkg.svc_path}}/config/database.yml ${RAILS_SAMPLE_DATA}/dist/config/database.yml
+
+export GEM_HOME="${RAILS_SAMPLE_DATA}/dist/vendor/bundle/ruby/2.3.0"
+export GEM_PATH="$(bpm pkgpath chef/ruby)/lib/ruby/gems/2.3.0:$(bpm pkgpath chef/bundler):$GEM_HOME"
+export LD_LIBRARY_PATH="$(bpm pkgpath chef/gcc-libs)/lib"
+export PATH="$PATH:${RAILS_SAMPLE_DATA}/dist/bin"
+export RAILS_ENV="production"
+
+chown -R bldr:bldr ${RAILS_SAMPLE_DATA}/dist
+cd ${RAILS_SAMPLE_DATA}/dist
+
+exec 2>&1
+
+if [[ ! -f ${RAILS_SAMPLE_DATA}/.migrations_complete ]]; then
+  echo "Running 'rake bootstrap' in ${PWD}"
+  exec chpst -u bldr bin/rake bootstrap && touch $RAILS_SAMPLE_DATA/.migrations_complete
+fi

--- a/plans/ruby-rails-sample/hooks/run
+++ b/plans/ruby-rails-sample/hooks/run
@@ -1,0 +1,12 @@
+#!/bin/sh
+export RAILS_SAMPLE_DATA="{{pkg.svc_path}}/data"
+export GEM_HOME="${RAILS_SAMPLE_DATA}/dist/vendor/bundle/ruby/2.3.0"
+export GEM_PATH="$(bpm pkgpath chef/ruby)/lib/ruby/gems/2.3.0:$(bpm pkgpath chef/bundler):$GEM_HOME"
+export LD_LIBRARY_PATH="$(bpm pkgpath chef/gcc-libs)/lib"
+export PATH="$PATH:${RAILS_SAMPLE_DATA}/dist/bin"
+export RAILS_ENV="production"
+
+cd $RAILS_SAMPLE_DATA/dist
+
+exec 2>&1
+exec chpst -u bldr ./bin/rails server -b {{cfg.rails_binding_ip}} -p {{cfg.rails_port}}

--- a/plans/ruby-rails-sample/plan.sh
+++ b/plans/ruby-rails-sample/plan.sh
@@ -1,0 +1,91 @@
+pkg_name=ruby-rails-sample
+pkg_version=0.0.1
+pkg_origin=chef
+pkg_maintainer="The Bldr Maintainers <bldr@chef.io>"
+pkg_license=('mit')
+pkg_source=https://github.com/jtimberman/ruby-rails-sample/archive/${pkg_version}.tar.gz
+pkg_shasum=a4a6daf4c2637d37800de9b083d22d79367cd00ee9702478cdaff72f7d97dd75
+pkg_gpg_key=3853DA6B
+
+pkg_deps=(
+  chef/bundler
+  chef/cacerts
+  chef/glibc
+  chef/libffi
+  chef/libxml2
+  chef/libxslt
+  chef/libyaml
+  chef/node
+  chef/openssl
+  chef/postgresql
+  chef/ruby
+  chef/zlib
+)
+
+pkg_build_deps=(
+  chef/coreutils
+  chef/gcc
+  chef/make
+)
+
+pkg_lib_dirs=(lib)
+pkg_include_dirs=(include)
+pkg_expose=(3000)
+
+# The configure scripts for some RubyGems that build native extensions
+# use `/usr/bin` paths for commands. This is not going to work in a
+# studio where we don't have any of those commands. But we're kind of
+# stuck because the native extension is going to be built during
+# `bundle install`.
+#
+# We clean this link up in `do_install`.
+do_prepare() {
+  build_line "Setting link for /usr/bin/env to chef/coreutils"
+  [[ ! -f /usr/bin/env ]] && ln -s $(pkg_path_for chef/coreutils)/bin/env /usr/bin/env
+  return 0
+}
+
+do_build() {
+  export CPPFLAGS="${CPPFLAGS} ${CFLAGS}"
+
+  local _bundler_dir=$(pkg_path_for chef/bundler)
+  local _libxml2_dir=$(pkg_path_for chef/libxml2)
+  local _libxslt_dir=$(pkg_path_for chef/libxslt)
+  local _postgresql_dir=$(pkg_path_for chef/postgresql)
+  local _pgconfig=$_postgresql_dir/bin/pg_config
+  local _zlib_dir=$(pkg_path_for chef/zlib)
+
+  export GEM_HOME=${pkg_path}/vendor/bundle
+  export GEM_PATH=${_bundler_dir}:${GEM_HOME}
+
+  # don't let bundler split up the nokogiri config string (it breaks
+  # the build), so specify it as an env var instead
+  export NOKOGIRI_CONFIG="--use-system-libraries --with-zlib-dir=${_zlib_dir} --with-xslt-dir=${_libxslt_dir} --with-xml2-include=${_libxml2_dir}/include/libxml2 --with-xml2-lib=${_libxml2_dir}/lib"
+  bundle config build.nokogiri '${NOKOGIRI_CONFIG}'
+  bundle config build.pg --with-pg-config=${_pgconfig}
+
+  # We need to add tzinfo-data to the Gemfile since we're not in an
+  # environment that has this from the OS
+  if [[ -z "`grep 'gem .*tzinfo-data.*' Gemfile`" ]]; then
+    echo 'gem "tzinfo-data"' >> Gemfile
+  fi
+
+  # Remove the specific ruby version, because our ruby is 2.3
+  sed -e 's/^ruby.*//' -i Gemfile
+
+  bundle install --jobs 2 --retry 5 --path vendor/bundle --binstubs
+}
+
+do_install() {
+  cp -R . ${pkg_path}/dist
+
+  for binstub in ${pkg_path}/dist/bin/*; do
+    build_line "Setting shebang for ${binstub} to 'chef/ruby'"
+    [[ -f $binstub ]] && sed -e "s#/usr/bin/env ruby#$(pkg_path_for chef/ruby)/bin/ruby#" -i $binstub
+  done
+
+  if [[ `readlink /usr/bin/env` = "$(pkg_path_for chef/coreutils)/bin/env" ]]; then
+    build_line "Removing the symlink we created for '/usr/bin/env'"
+    rm /usr/bin/env
+  fi
+}


### PR DESCRIPTION
This commit adds the Heroku sample Rails application. While this is a fairly trivial example, it showcases:
- Rails 4.2
- PostgreSQL connectivity
- Nokogiri installation :)

The application will connect to a configured database. That can be done with the following .toml:

``` toml
database_host = "habitat-rails.ckcupbc3wyhz.us-west-2.rds.amazonaws.com"
database_username = "habrails"
database_password = "habitat-rails-testing"
```

And a `docker run` like this:

```
% docker run -it -p 3000:3000 -e BLDR_RUBY-RAILS-SAMPLE="$(cat ~/tmp/ruby-rails-sample.toml)" --privileged chef/ruby-rails-sample
```
