### PR TITLE
[delivery] Only fully rebuild devshell image once a day.

### DIFF
--- a/.delivery/cookbooks/bldr/recipes/lint.rb
+++ b/.delivery/cookbooks/bldr/recipes/lint.rb
@@ -16,7 +16,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-execute 'make distclean docs force=true' do
+execute 'make distclean' do
+  cwd node['delivery']['workspace']['repo']
+  environment(
+    'IN_DOCKER' => 'true'
+  )
+  not_if { BldrDocker.fresh_image?("bldr/devshell:latest") }
+end
+
+execute 'make docs refresh=true' do
   cwd node['delivery']['workspace']['repo']
   environment(
     'IN_DOCKER' => 'true'

--- a/.delivery/cookbooks/bldr/recipes/unit.rb
+++ b/.delivery/cookbooks/bldr/recipes/unit.rb
@@ -16,7 +16,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-execute 'make distclean unit force=true' do
+execute 'make distclean' do
+  cwd node['delivery']['workspace']['repo']
+  environment(
+    'IN_DOCKER' => 'true'
+  )
+  not_if { BldrDocker.fresh_image?("bldr/devshell:latest") }
+end
+
+execute 'make unit refresh=true' do
   cwd node['delivery']['workspace']['repo']
   environment(
     'IN_DOCKER' => 'true'

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ distclean: ## fully cleans up project tree and any associated Docker images and 
 	($(docker_cmd) images -q -f dangling=true | xargs $(docker_cmd) rmi -f) || true
 
 image: ## create an image
-	if [ -n "${force}" -o -z "`$(docker_cmd) images -q $(dimage)`" ]; then \
+	if [ -n "${force}" -o -n "${refresh}" -o -z "`$(docker_cmd) images -q $(dimage)`" ]; then \
 		if [ -n "${force}" ]; then \
 		  $(docker_cmd) build --no-cache $(build_args) -t $(dimage) .; \
 		else \


### PR DESCRIPTION
This change makes our "devshell" Docker image rebuilding much less
aggressive when running in Delivery. Prior to this change, the devshell
Docker image was removed completely and then rebuilt from scratch for
every `unit`, `lint`, and `functional` execution. While this made the
image as fresh as possible, there is a fair amount of wasted and waiting
time on every execution.

With this change, the "devshell" image is fully rebuilt if the existing
one is older than 24 hours. Otherwise, `refresh=true` is passed to the
Makefile targets which runs the phase with through a `docker build`
first, relying on previous image cache layers. This means that if a
change involves updates to the Dockerfile, then the "devshell" image
will be refreshed on the first execution.
