### PR TITLE
Repair `make serve-docs` in root Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,10 @@ ifneq ($(IN_DOCKER),)
 	dimage := bldr/devshell
 	docker_cmd := env http_proxy= https_proxy= docker
 	compose_cmd := env http_proxy= https_proxy= docker-compose
-	run := $(compose_cmd) run --rm $(run_args) shell
+	common_run := $(compose_cmd) run --rm $(run_args)
+	run := $(common_run) shell
 	docs_host := ${DOCKER_HOST}
-	docs_run := $(run) -p 9633:9633
+	docs_run := $(common_run) -p 9633:9633 shell
 else
 	run :=
 	docs_host := 127.0.0.1


### PR DESCRIPTION
This change fixes an argument ordering of `docker-compose` that left
the `make serve-docs` target nonfunctional.

![gif-keyboard-7499486133460680767](https://cloud.githubusercontent.com/assets/261548/14124180/6aa0beba-f5c1-11e5-9d30-d76bd50e362a.gif)
