### PR TITLE
Not found pages and improve loading

### DIFF
--- a/web/app/SpinnerComponent.ts
+++ b/web/app/SpinnerComponent.ts
@@ -1,0 +1,12 @@
+import {Component} from "angular2/core";
+
+@Component({
+    inputs: ["isSpinning", "onClick"],
+    selector: "hab-spinner",
+    template: `
+    <span (click)="onClick()" [class.spinning]="isSpinning"
+        class="hab-spinner"></span>
+    `
+})
+
+export class SpinnerComponent { }

--- a/web/app/actions/index.ts
+++ b/web/app/actions/index.ts
@@ -30,6 +30,7 @@ export const PERFORM_ORG_MEMBER_SEARCH = orgActions.PERFORM_ORG_MEMBER_SEARCH;
 export const POPULATE_ORG = orgActions.POPULATE_ORG;
 export const TOGGLE_MEMBER_ACTION_MENU = orgActions.TOGGLE_MEMBER_ACTION_MENU;
 
+export const CLEAR_PACKAGES = packageActions.CLEAR_PACKAGES;
 export const POPULATE_EXPLORE = packageActions.POPULATE_EXPLORE;
 export const SET_CURRENT_PACKAGE = packageActions.SET_CURRENT_PACKAGE;
 export const SET_VISIBLE_PACKAGES = packageActions.SET_VISIBLE_PACKAGES;

--- a/web/app/actions/packages.ts
+++ b/web/app/actions/packages.ts
@@ -7,9 +7,16 @@
 import * as depotApi from "../depotApi";
 import * as fakeApi from "../fakeApi";
 
+export const CLEAR_PACKAGES = "CLEAR_PACKAGES";
 export const POPULATE_EXPLORE = "POPULATE_EXPLORE";
 export const SET_CURRENT_PACKAGE = "SET_CURRENT_PACKAGE";
 export const SET_VISIBLE_PACKAGES = "SET_VISIBLE_PACKAGES";
+
+function clearPackages() {
+    return {
+        type: CLEAR_PACKAGES,
+    };
+}
 
 // Fetch the explore endpoint
 export function fetchExplore() {
@@ -22,8 +29,11 @@ export function fetchExplore() {
 
 export function fetchPackage(pkg) {
     return dispatch => {
+        dispatch(clearPackages());
         depotApi.get(pkg.ident).then(response => {
             dispatch(setCurrentPackage(response));
+        }).catch(error => {
+            dispatch(setCurrentPackage(undefined, error));
         });
     };
 }
@@ -31,8 +41,11 @@ export function fetchPackage(pkg) {
 export function filterPackagesBy(params) {
     return dispatch => {
         if ("origin" in params) {
+            dispatch(clearPackages());
             depotApi.get(params).then(response => {
                 dispatch(setVisiblePackages(response));
+            }).catch(error => {
+                dispatch(setVisiblePackages(undefined, error));
             });
         } else {
             fakeApi.get("packages.json").then(response => {
@@ -49,16 +62,18 @@ export function populateExplore(data) {
     };
 }
 
-export function setCurrentPackage(pkg) {
+export function setCurrentPackage(pkg, error = undefined) {
     return {
         type: SET_CURRENT_PACKAGE,
         payload: pkg,
+        error: error,
     };
 }
 
-export function setVisiblePackages(params) {
+export function setVisiblePackages(params, error = undefined) {
     return {
         type: SET_VISIBLE_PACKAGES,
         payload: params,
+        error: error,
     };
 }

--- a/web/app/app.scss
+++ b/web/app/app.scss
@@ -10,6 +10,7 @@
 
 @import "drop-down";
 @import "item-list";
+@import "spinner";
 @import "tabs";
 
 @import "explore-page/explore-page";

--- a/web/app/depotApi.ts
+++ b/web/app/depotApi.ts
@@ -6,14 +6,18 @@ const urlPrefix = config["depotUrl"] || "";
 
 // Get the JSON from a url from the fixtures directory.
 export function get(ident) {
-    return fetch(`${urlPrefix}/pkgs/${packageString(ident)}`).then(response => {
-        const url = response.url;
+    return new Promise((resolve, reject) => {
+        fetch(`${urlPrefix}/pkgs/${packageString(ident)}`).then(response => {
+            // Fail the promise if an error happens.
+            //
+            // If we're hitting the fake api, the 4xx response will show up
+            // here, but if we're hitting the real depot, it will show up in the
+            // catch below.
+            if (response.status >= 400) {
+                reject(new Error(response.statusText));
+            }
 
-        // Fail the promise if an error happens.
-        if (response.status >= 400) {
-            return Promise.reject(new Error(response.statusText));
-        }
-
-        return response.json();
+            resolve(response.json());
+        }).catch(error => reject(error));
     });
 };

--- a/web/app/initialState.ts
+++ b/web/app/initialState.ts
@@ -57,6 +57,18 @@ export default Record({
         current: undefined,
         explore: List(),
         visible: List(),
+        ui: Record({
+            current: Record({
+                errorMessage: undefined,
+                exists: false,
+                loading: true,
+            })(),
+            visible: Record({
+                errorMessage: undefined,
+                exists: false,
+                loading: true,
+            })(),
+        })(),
     })(),
     projects: Record({
         // This is a temporary hack that lets us add projects, and gets

--- a/web/app/package-page/_package-page.scss
+++ b/web/app/package-page/_package-page.scss
@@ -5,6 +5,10 @@
 // is made available under an open source license such as the Apache 2.0 License.
 
 .hab-package {
+  .hab-spinner {
+      float: right;
+  }
+
   &-info {
     @include outer-container;
     margin-bottom: $base-spacing;

--- a/web/app/packages-page/PackagesPageComponent.ts
+++ b/web/app/packages-page/PackagesPageComponent.ts
@@ -8,22 +8,31 @@ import {Component, OnInit} from "angular2/core";
 import {RouteParams, RouterLink} from "angular2/router";
 import {AppStore} from "../AppStore";
 import {PackageBreadcrumbsComponent} from "../PackageBreadcrumbsComponent";
+import {SpinnerComponent} from "../SpinnerComponent";
 import {filterPackagesBy, requestRoute} from "../actions/index";
 
 @Component({
-    directives: [PackageBreadcrumbsComponent, RouterLink],
+    directives: [PackageBreadcrumbsComponent, RouterLink, SpinnerComponent],
     template: `
     <div class="hab-packages">
         <h2>
+            <hab-spinner [isSpinning]="ui.loading" [onClick]="spinnerFetchPackages">
+            </hab-spinner>
             <package-breadcrumbs [ident]="routeParams.params"
                 [params]="routeParams.params">
             </package-breadcrumbs>
         </h2>
         <hr>
-        <ul class="hab-packages-plan-list">
-            <li *ngIf="packages.size === 0">
-                No packages found. Here's how to create one: &hellip;
-            </li>
+        <div *ngIf="(!ui.exists || packages.size === 0) && !ui.loading">
+            <p>
+                Failed to load packages.
+                <span *ngIf="ui.errorMessage">
+                    Error: {{ui.errorMessage}}
+                </span>
+            </p>
+        </div>
+        <ul *ngIf="ui.exists && !ui.loading" class="hab-packages-plan-list">
+
             <li class="hab-packages-package" *ngFor="#package of packages">
                 <a [routerLink]="['Package', { origin: package.origin,
                                                name: package.name,
@@ -45,17 +54,29 @@ import {filterPackagesBy, requestRoute} from "../actions/index";
 })
 
 export class PackagesPageComponent implements OnInit {
-    constructor(private store: AppStore, private routeParams: RouteParams) { }
+    private spinnerFetchPackages: Function;
+
+    constructor(private store: AppStore, private routeParams: RouteParams) {
+        this.spinnerFetchPackages = this.fetchPackages.bind(this);
+    }
 
     get packages() {
         return this.store.getState().packages.visible;
     }
 
-    ngOnInit() {
+    get ui() {
+        return this.store.getState().packages.ui.visible;
+    }
+
+    public ngOnInit() {
         if (!this.store.getState().user.isSignedIn) {
             this.store.dispatch(requestRoute(["Home"]));
         }
 
+        this.fetchPackages();
+    }
+
+    private fetchPackages() {
         this.store.dispatch(filterPackagesBy(this.routeParams.params));
     }
 }

--- a/web/app/packages-page/_packages-page.scss
+++ b/web/app/packages-page/_packages-page.scss
@@ -5,6 +5,10 @@
 // is made available under an open source license such as the Apache 2.0 License.
 
 .hab-packages {
+  .hab-spinner {
+    float: right;
+  }
+
   &-plan-list {
     li a {
       @extend .hab-item-list;

--- a/web/app/reducers/packages.ts
+++ b/web/app/reducers/packages.ts
@@ -12,16 +12,46 @@ import {fromJS, List, Record} from "immutable";
 
 export default function packages(state = initialState["packages"], action) {
     switch (action.type) {
+        case actionTypes.CLEAR_PACKAGES:
+            return state.set("current", Package()).
+                set("visible", List()).
+                setIn(["ui", "current", "loading"], true).
+                setIn(["ui", "current", "exists"], false).
+                setIn(["ui", "visible", "loading"], true).
+                setIn(["ui", "visible", "exists"], false);
+
         case actionTypes.POPULATE_EXPLORE:
             return state.setIn(["explore"], List(action.payload));
 
         case actionTypes.SET_CURRENT_PACKAGE:
-            let p = Object.assign({}, action.payload);
-            p.manifest = marked(p.manifest);
-            return state.set("current", Package(p));
+            if (action.error) {
+                return state.set("current", Package()).
+                    setIn(["ui", "current", "errorMessage"],
+                    action.error.message).
+                    setIn(["ui", "current", "loading"], false).
+                    setIn(["ui", "current", "exists"], false);
+            } else {
+                let p = Object.assign({}, action.payload);
+                p.manifest = marked(p.manifest);
+                return state.set("current", Package(p)).
+                    setIn(["ui", "current", "errorMessage"], undefined).
+                    setIn(["ui", "current", "exists"], true).
+                    setIn(["ui", "current", "loading"], false);
+            }
 
         case actionTypes.SET_VISIBLE_PACKAGES:
-            return state.set("visible", List(action.payload));
+            if (action.error) {
+                return state.set("visible", List()).
+                    setIn(["ui", "visible", "errorMessage"],
+                    action.error.message).
+                    setIn(["ui", "visible", "exists"], false).
+                    setIn(["ui", "visible", "loading"], false);
+            } else {
+                return state.set("visible", List(action.payload)).
+                    setIn(["ui", "visible", "errorMessage"], undefined).
+                    setIn(["ui", "visible", "exists"], true).
+                    setIn(["ui", "visible", "loading"], false);
+            }
 
         default:
             return state;

--- a/web/stylesheets/_spinner.scss
+++ b/web/stylesheets/_spinner.scss
@@ -1,0 +1,30 @@
+.hab-spinner {
+  background-image: hab-icon("sync");
+  background-position: 50% 50%;
+  background-repeat: no-repeat;
+  background-size: 50%;
+
+  height: 32px;
+  width: 32px;
+
+  &:hover {
+    cursor: pointer;
+  }
+
+  &.spinning {
+    animation-duration: 1s;
+    animation-iteration-count: infinite;
+    animation-name: spinner-rotate;
+    animation-timing-function: linear;
+  }
+
+  @keyframes spinner-rotate {
+    from {
+      transform: rotate(0deg);
+    }
+
+    to {
+      transform: rotate(360deg);
+    }
+  }
+}


### PR DESCRIPTION
- Going to http://localhost:3000/#/pkgs/chef should load the packages
  for chef
- Changing the URL bar to http://localhost:3000/#/pkgs/x and pressing
  enter should show a not found page
- Going to
  http://localhost:3000/#/pkgs/chef/discourse/1.4.5/20160315221848
  should not show a momentary partially loaded package
- Going to http://localhost:3000/#/pkgs/chef/discourse/1.4.5/x should
  not show a momentarily loaded package, and should show a not found
  page

Also dig the spinner.

![image](http://www.funnymeme.com/wp-content/uploads/2014/03/Funny-gifs-the-sound-of-music-machine-guns.gif)
