### PR TITLE
[hab] Automatically installs `hab-sup` if missing when invoked.

### DIFF
--- a/components/hab/src/command/rumor/inject.rs
+++ b/components/hab/src/command/rumor/inject.rs
@@ -17,6 +17,7 @@ pub fn start(peers: &Vec<String>,
              number: u64,
              file_path: Option<&Path>)
              -> Result<()> {
+    let sg1 = sg.clone();
     let file = match file_path {
         Some(p) => try!(ConfigFile::from_file(sg, p, number)),
         None => {
@@ -25,14 +26,14 @@ pub fn start(peers: &Vec<String>,
             try!(ConfigFile::from_body(sg, "config.toml".to_string(), body, number))
         }
     };
-    println!("Injecting {} into {}", &file, &sg);
+    println!("Injecting {} into {}", &file, &sg1);
     let rumor = hab_gossip::Rumor::config_file(file);
 
     let mut list = hab_gossip::RumorList::new();
     list.add_rumor(rumor);
 
     try!(initial_peers(&peers, &list));
-    outputln!("Finished injecting");
+    println!("Finished injecting");
     Ok(())
 }
 

--- a/components/hab/src/exec.rs
+++ b/components/hab/src/exec.rs
@@ -12,8 +12,20 @@ use std::os::unix::ffi::OsStringExt;
 use std::path::PathBuf;
 use std::ptr;
 
-use error::Result;
+use common;
+use hcore;
+use hcore::package::{PackageIdent, PackageInstall};
+use hcore::url::DEFAULT_DEPOT_URL;
 
+use error::{Error, Result};
+
+const MAX_RETRIES: u8 = 4;
+
+/// Returns the absolute path for a given command, if it exists, by searching the `PATH`
+/// environment variable.
+///
+/// If the command represents an absolute path, then the `PATH` seaching will not be performed. If
+/// no absolute path can be found for the command, then `None` is returned.
 pub fn find_command(command: &str) -> Option<PathBuf> {
     // If the command path is absolute and a file exists, then use that.
     let candidate = PathBuf::from(command);
@@ -37,6 +49,13 @@ pub fn find_command(command: &str) -> Option<PathBuf> {
     }
 }
 
+/// Makes an `execv(3)` system call to become a new program.
+///
+/// Note that if successful, this function will not return.
+///
+/// # Failures
+///
+/// * Command and/or command arguments cannot be converted into `CString`
 pub fn exec_command(command: PathBuf, args: Vec<OsString>) -> Result<()> {
     let prog = try!(CString::new(command.into_os_string().into_vec()));
     let mut argv: Vec<*const i8> = Vec::with_capacity(args.len() + 2);
@@ -52,4 +71,53 @@ pub fn exec_command(command: PathBuf, args: Vec<OsString>) -> Result<()> {
         libc::execv(prog.as_ptr(), argv.as_mut_ptr());
     }
     Ok(())
+}
+
+/// Returns the absolute path to the given command from the given package identifier.
+///
+/// If the package is not locally installed, the package will be installed before recomputing.
+/// There are a maximum number of times a re-installation will be attempted before returning an
+/// error.
+///
+/// # Failures
+///
+/// * If the package is installed but the command cannot be found in the package
+/// * If an error occurs when loading the local package from disk
+/// * If the maximum number of installation retries has been exceeded
+pub fn command_from_pkg(command: &str, ident: &PackageIdent, retry: u8) -> Result<PathBuf> {
+    if retry > MAX_RETRIES {
+        return Err(Error::ExecCommandNotFound(command.to_string()));
+    }
+
+    match PackageInstall::load(ident, None) {
+        Ok(pi) => {
+            match try!(find_command_in_pkg(&command, &pi)) {
+                Some(cmd) => Ok(cmd),
+                None => return Err(Error::ExecCommandNotFound(command.to_string())),
+            }
+        }
+        Err(hcore::Error::PackageNotFound(_)) => {
+            println!("Package for {} not found, installing from depot", &ident);
+            try!(common::command::package::install::from_url(DEFAULT_DEPOT_URL, ident));
+            command_from_pkg(&command, &ident, retry + 1)
+        }
+        Err(e) => return Err(Error::from(e)),
+    }
+}
+
+/// Returns the absolute path to the given command from a given package installation.
+///
+/// If the command is not found, then `None` is returned.
+///
+/// # Failures
+///
+/// * The path entries metadata cannot be loaded
+fn find_command_in_pkg(command: &str, pkg_install: &PackageInstall) -> Result<Option<PathBuf>> {
+    for path in try!(pkg_install.paths()) {
+        let candidate = path.join(command);
+        if candidate.is_file() {
+            return Ok(Some(candidate));
+        }
+    }
+    Ok(None)
 }


### PR DESCRIPTION
This change lays the groundwork for some future subcommands that need
some simlar behavior. With this change, the `hab` binary performs the
following checks if `hab sup` or `hab start` is invoked:
- If an environment variable `HABITAT_SUP_BINARY` is present, exec this
  value as the `hap-sup` program
- Otherwise, see if a Supervisor package (currently `chef/hap-sup`) is
  locally installed. Use it if installed and if not download the latest
  version and use that.

Ignoring the particulars of the current UI output, here is a sample run
of `hab start chef/redis` without either `chef/redis` or `chef/hap-sup`
being locally installed:

``````
> hab start chef/redis
Package for chef/hab-sup not found, installing from depot
Installing chef/hab-sup
Package chef/bzip2/1.0.6/20160310204954 already installed
Package chef/cacerts/2016.01.20/20160310211035 already installed
Package chef/gcc-libs/5.2.0/20160310204947 already installed
Package chef/glibc/2.22/20160310192356 already installed
Package chef/gpgme/1.6.0/20160310223048 already installed
Package chef/libarchive/3.1.2/20160310222903 already installed
Package chef/libassuan/2.4.2/20160310223025 already installed
Package chef/libgpg-error/1.20/20160310222812 already installed
Package chef/linux-headers/4.3/20160310192326 already installed
Package chef/openssl/1.0.2f/20160310211038 already installed
Package chef/rngd/5/20160310222754 already installed
Package chef/xz/5.2.2/20160310210257 already installed
Package chef/zlib/1.2.8/20160310193228 already installed
hab-sup 5358751/5358751
Installed chef/hab-sup/0.4.0/20160405170211
bldr(MN): Starting chef/redis
bldr(CS): chef/redis is not installed
bldr(CS): Searching for chef/redis in remote http://52.37.151.35:9632
Installing chef/redis
Package chef/glibc/2.22/20160310192356 already installed
Package chef/linux-headers/4.3/20160310192326 already installed
redis 927215/927215
Installed chef/redis/3.0.7/20160405144915
bldr(GS): Supervisor 172.17.0.2: 705a56b8-5f5f-4b93-b874-60d917e6bafb
bldr(GS): Census redis.default: c5bd9595-3f2d-4530-84ba-66712b147534
bldr(GS): Starting inbound gossip listener
bldr(GS): Starting outbound gossip distributor
bldr(GS): Starting gossip failure detector
bldr(CN): Starting census health adjuster
bldr(SC): Updated redis.config
redis(TS): Starting
redis(SO):                 _._
redis(O):            _.-``__ ''-._
redis(O):       _.-``    `.  `_.  ''-._           Redis 3.0.7 (00000000/0) 64 bit
redis(O):   .-`` .-```.  ```\/    _.,_ ''-._
redis(O):  (    '      ,       .-`  | `,    )     Running in standalone mode
redis(O):  |`-._`-...-` __...-.``-._|'` _.-'|     Port: 6379
redis(O):  |    `-._   `._    /     _.-'    |     PID: 31704
redis(O):   `-._    `-._  `-./  _.-'    _.-'
redis(O):  |`-._`-._    `-.__.-'    _.-'_.-'|
redis(O):  |    `-._`-._        _.-'_.-'    |           http://redis.io
redis(O):   `-._    `-._`-.__.-'_.-'    _.-'
redis(O):  |`-._`-._    `-.__.-'    _.-'_.-'|
redis(O):  |    `-._`-._        _.-'_.-'    |
redis(O):   `-._    `-._`-.__.-'_.-'    _.-'
redis(O):       `-._    `-.__.-'    _.-'
redis(O):           `-._        _.-'
redis(O):               `-.__.-'
redis(O):
redis(O): 31704:M 05 Apr 22:22:50.253 # WARNING: The TCP backlog setting of 511 cannot be enforced because /proc/sys/net/core/somaxconn is set to the lower value of 128.
redis(O): 31704:M 05 Apr 22:22:50.253 # Server started, Redis version 3.0.7
redis(O): 31704:M 05 Apr 22:22:50.253 # WARNING overcommit_memory is set to 0! Background save may fail under low memory condition. To fix this issue add 'vm.overcommit_memory = 1' to /etc/sysctl.conf and then reboot or run the command 'sysctl vm.overcommit_memory=1' for this to take effect.
redis(O): 31704:M 05 Apr 22:22:50.253 # WARNING you have Transparent Huge Pages (THP) support enabled in your kernel. This will create latency and memory usage issues with Redis. To fix this issue run the command 'echo never > /sys/kernel/mm/transparent_hugepage/enabled' as root, and add it to your /etc/rc.local in order to retain the setting after a reboot. Redis must be restarted after THP is disabled.
redis(O): 31704:M 05 Apr 22:22:50.253 * DB loaded from disk: 0.000 seconds
redis(O): 31704:M 05 Apr 22:22:50.253 * The server is now ready to accept connections on port 6379
^Credis(O): 31704:signal-handler (1459894970) Received SIGINT scheduling shutdown...
redis(O): 31704:signal-handler (1459894970) Received SIGTERM scheduling shutdown...
redis(O): 31704:M 05 Apr 22:22:50.859 # User requested shutdown...
redis(O): 31704:M 05 Apr 22:22:50.859 * Saving the final RDB snapshot before exiting.
redis(O): 31704:M 05 Apr 22:22:50.861 * DB saved on disk
redis(O): 31704:M 05 Apr 22:22:50.861 # Redis is now ready to exit, bye bye...
bldr(TP): Waiting for supervisor to finish
bldr(TP): Supervisor has finished
bldr(MN): Finished with chef/redis
``````
