### PR TITLE
Update copyright notice to reference Habitat.

### DIFF
--- a/components/common/src/command/mod.rs
+++ b/components/common/src/command/mod.rs
@@ -1,7 +1,8 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 pub mod package;

--- a/components/common/src/command/package/install.rs
+++ b/components/common/src/command/package/install.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 //! Installs a bldr package from a [depot](../depot).
 //!

--- a/components/common/src/command/package/mod.rs
+++ b/components/common/src/command/package/mod.rs
@@ -1,7 +1,8 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 pub mod install;

--- a/components/common/src/config_file.rs
+++ b/components/common/src/config_file.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 use std::collections::HashMap;
 use std::fmt;

--- a/components/common/src/error.rs
+++ b/components/common/src/error.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 use std::error;
 use std::io;

--- a/components/common/src/lib.rs
+++ b/components/common/src/lib.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 extern crate habitat_core as hcore;
 extern crate habitat_depot_core as depot_core;

--- a/components/core/src/error.rs
+++ b/components/core/src/error.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 use std::error;
 use std::io;

--- a/components/core/src/fs.rs
+++ b/components/core/src/fs.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 pub const PACKAGE_HOME: &'static str = "/opt/bldr/pkgs";
 pub const SERVICE_HOME: &'static str = "/opt/bldr/svc";

--- a/components/core/src/gpg.rs
+++ b/components/core/src/gpg.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 use std::fs::{self, File};
 use std::io;

--- a/components/core/src/lib.rs
+++ b/components/core/src/lib.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 extern crate crypto;
 extern crate gpgme;

--- a/components/core/src/package/archive.rs
+++ b/components/core/src/package/archive.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 use std::collections::HashMap;
 use std::fs::File;

--- a/components/core/src/package/ident.rs
+++ b/components/core/src/package/ident.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 use std::cmp::{Ordering, PartialOrd};
 use std::fmt;

--- a/components/core/src/package/install.rs
+++ b/components/core/src/package/install.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 use std::cmp::{Ordering, PartialOrd};
 use std::env;

--- a/components/core/src/package/mod.rs
+++ b/components/core/src/package/mod.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 pub mod archive;
 pub mod ident;

--- a/components/core/src/service.rs
+++ b/components/core/src/service.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 use std::fmt;
 use std::result;

--- a/components/core/src/url.rs
+++ b/components/core/src/url.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 /// Default Depot URL
 pub const DEFAULT_DEPOT_URL: &'static str = "http://52.37.151.35:9632";

--- a/components/core/src/util/mod.rs
+++ b/components/core/src/util/mod.rs
@@ -1,7 +1,8 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 pub mod perm;

--- a/components/core/src/util/perm.rs
+++ b/components/core/src/util/perm.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 use std::process::Command;
 

--- a/components/depot-client/src/error.rs
+++ b/components/depot-client/src/error.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 use std::error;
 use std::io;

--- a/components/depot-client/src/lib.rs
+++ b/components/depot-client/src/lib.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 extern crate habitat_core as hcore;
 extern crate habitat_depot_core as depot_core;

--- a/components/depot-core/src/data_object.rs
+++ b/components/depot-core/src/data_object.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 use std::fmt;
 use std::result;

--- a/components/depot-core/src/lib.rs
+++ b/components/depot-core/src/lib.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 extern crate habitat_core as hcore;
 #[macro_use]

--- a/components/depot/src/config.rs
+++ b/components/depot/src/config.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 use std::net;
 

--- a/components/depot/src/data_store.rs
+++ b/components/depot/src/data_store.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 use std::any::Any;
 use std::ffi::{CStr, CString};

--- a/components/depot/src/doctor.rs
+++ b/components/depot/src/doctor.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 use std::fs;
 use std::io;

--- a/components/depot/src/error.rs
+++ b/components/depot/src/error.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 use std::error;
 use std::ffi;

--- a/components/depot/src/lib.rs
+++ b/components/depot/src/lib.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 extern crate habitat_core as hcore;
 extern crate habitat_depot_core as depot_core;

--- a/components/depot/src/main.rs
+++ b/components/depot/src/main.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 extern crate habitat_core as hcore;
 extern crate habitat_depot as depot;

--- a/components/depot/src/server.rs
+++ b/components/depot/src/server.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 use std::fs::{self, File};
 use std::io::{Read, Write, BufWriter};

--- a/components/depot/tests/server.rs
+++ b/components/depot/tests/server.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 extern crate regex;
 extern crate time;

--- a/components/depot/tests/support/command.rs
+++ b/components/depot/tests/support/command.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 use std::io::prelude::*;
 use std::io;

--- a/components/depot/tests/support/docker.rs
+++ b/components/depot/tests/support/docker.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 //! Start a docker container, store the instance id
 //! Get the logs

--- a/components/depot/tests/support/mod.rs
+++ b/components/depot/tests/support/mod.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 pub mod setup;
 pub mod path;

--- a/components/depot/tests/support/path.rs
+++ b/components/depot/tests/support/path.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 use std::env;
 use std::path::PathBuf;

--- a/components/depot/tests/support/setup.rs
+++ b/components/depot/tests/support/setup.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 use std::sync::{Once, ONCE_INIT};
 

--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 use std::path::Path;
 use std::result;

--- a/components/hab/src/command/archive/mod.rs
+++ b/components/hab/src/command/archive/mod.rs
@@ -1,7 +1,8 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 pub mod upload;

--- a/components/hab/src/command/archive/upload.rs
+++ b/components/hab/src/command/archive/upload.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 //! Uploads a package to a [Depot](../depot).
 //!

--- a/components/hab/src/command/mod.rs
+++ b/components/hab/src/command/mod.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 pub mod archive;
 pub mod rumor;

--- a/components/hab/src/command/rumor/inject.rs
+++ b/components/hab/src/command/rumor/inject.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 use std::path::Path;
 use std::io::{self, Read};

--- a/components/hab/src/command/rumor/mod.rs
+++ b/components/hab/src/command/rumor/mod.rs
@@ -1,7 +1,8 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 pub mod inject;

--- a/components/hab/src/error.rs
+++ b/components/hab/src/error.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 use std::error;
 use std::ffi;

--- a/components/hab/src/exec.rs
+++ b/components/hab/src/exec.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 extern crate libc;
 

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 extern crate habitat_core as hcore;
 extern crate habitat_common as common;

--- a/components/sup/src/census.rs
+++ b/components/sup/src/census.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 //! The Census is the core of our service discovery mechanism. It keeps track of every supervisor
 //! in our group, and handles reading, writing, and serializing it with the discovery backend

--- a/components/sup/src/command/configure.rs
+++ b/components/sup/src/command/configure.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 //! Prints the configuration options for a service. Actually the `config` command.
 //!

--- a/components/sup/src/command/key.rs
+++ b/components/sup/src/command/key.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 use std::fs;
 use std::path::Path;

--- a/components/sup/src/command/mod.rs
+++ b/components/sup/src/command/mod.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 //! The CLI commands.
 //!

--- a/components/sup/src/command/start.rs
+++ b/components/sup/src/command/start.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 //! Starts a service from an installed bldr package.
 //!

--- a/components/sup/src/config.rs
+++ b/components/sup/src/config.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 //! Configuration for bldr.
 //!

--- a/components/sup/src/discovery/etcd.rs
+++ b/components/sup/src/discovery/etcd.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 //! Etcd backend for service discovery.
 //!

--- a/components/sup/src/discovery/mod.rs
+++ b/components/sup/src/discovery/mod.rs
@@ -1,7 +1,8 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 pub mod etcd;

--- a/components/sup/src/election.rs
+++ b/components/sup/src/election.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 //! The election sub-protocol.
 //!

--- a/components/sup/src/error.rs
+++ b/components/sup/src/error.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 //! Error handling for Bldr.
 //!

--- a/components/sup/src/gossip/client.rs
+++ b/components/sup/src/gossip/client.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 //! The Gossip Client.
 //!

--- a/components/sup/src/gossip/detector.rs
+++ b/components/sup/src/gossip/detector.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 //! The failure detector.
 //!

--- a/components/sup/src/gossip/lamport_clock.rs
+++ b/components/sup/src/gossip/lamport_clock.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 //! This is an implementation of a [lamport
 //! clock](https://en.wikipedia.org/wiki/Lamport_timestamps), which we use to track incarnations.

--- a/components/sup/src/gossip/member.rs
+++ b/components/sup/src/gossip/member.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 //! The membership system.
 //!

--- a/components/sup/src/gossip/mod.rs
+++ b/components/sup/src/gossip/mod.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 //! The gossip infrastructure.
 //!

--- a/components/sup/src/gossip/rumor.rs
+++ b/components/sup/src/gossip/rumor.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 //! The rumor system.
 //!

--- a/components/sup/src/gossip/server.rs
+++ b/components/sup/src/gossip/server.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 //! The Gossip Server.
 //!

--- a/components/sup/src/health_check.rs
+++ b/components/sup/src/health_check.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 use std::fmt::{self, Display, Formatter};
 

--- a/components/sup/src/lib.rs
+++ b/components/sup/src/lib.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 //! Bldr helps you build, manage, and run applications - on bare metal, in the cloud, and in
 //! containers. You can [read more about it, including setup instructions, in the README](README.html).

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 #[macro_use]
 extern crate habitat_sup as sup;

--- a/components/sup/src/output.rs
+++ b/components/sup/src/output.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 //! Formats user-visible output for Bldr.
 //!

--- a/components/sup/src/package/hooks.rs
+++ b/components/sup/src/package/hooks.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 use std::fmt;
 use std::fs::{self, OpenOptions};

--- a/components/sup/src/package/mod.rs
+++ b/components/sup/src/package/mod.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 pub mod hooks;
 pub mod updater;

--- a/components/sup/src/package/updater.rs
+++ b/components/sup/src/package/updater.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 use std::sync::{Arc, RwLock};
 

--- a/components/sup/src/service_config.rs
+++ b/components/sup/src/service_config.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 /// Collect all the configuration data that is exposed to users, and render it.
 

--- a/components/sup/src/sidecar.rs
+++ b/components/sup/src/sidecar.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 //! The http sidecar for bldr services. Provides an interface to verifying and validating
 //! promises.

--- a/components/sup/src/state_machine.rs
+++ b/components/sup/src/state_machine.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 //! A generic state machine.
 

--- a/components/sup/src/topology/initializer.rs
+++ b/components/sup/src/topology/initializer.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 //! This is the building block of complicated topologies which require a leader. It is
 //! used when a single member of your cluster should perform additional applications

--- a/components/sup/src/topology/leader.rs
+++ b/components/sup/src/topology/leader.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 use topology::{self, standalone, State, Worker, stop};
 use state_machine::StateMachine;

--- a/components/sup/src/topology/mod.rs
+++ b/components/sup/src/topology/mod.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 //! The service topologies.
 //!

--- a/components/sup/src/topology/standalone.rs
+++ b/components/sup/src/topology/standalone.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 //! This is the default topology. It's most useful for applications that stand alone, or that don't
 //! share state between one another.

--- a/components/sup/src/user_config.rs
+++ b/components/sup/src/user_config.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 //! Manages runtime configuration provided by the users through a GenServer.
 //!

--- a/components/sup/src/util/convert.rs
+++ b/components/sup/src/util/convert.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 use std::collections::{BTreeMap, HashMap};
 

--- a/components/sup/src/util/mod.rs
+++ b/components/sup/src/util/mod.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 pub mod convert;
 pub mod sys;

--- a/components/sup/src/util/signals.rs
+++ b/components/sup/src/util/signals.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 //! Traps and notifies UNIX signals.
 //!

--- a/components/sup/src/util/sys.rs
+++ b/components/sup/src/util/sys.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 use error::{BldrResult, ErrorKind};
 use std::process::Command;

--- a/components/sup/tests/bldr/gossip.rs
+++ b/components/sup/tests/bldr/gossip.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 use setup;
 use util::supervisor::Supervisor;

--- a/components/sup/tests/bldr/key.rs
+++ b/components/sup/tests/bldr/key.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 extern crate uuid;
 use setup;

--- a/components/sup/tests/bldr/mod.rs
+++ b/components/sup/tests/bldr/mod.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 pub mod start;
 pub mod key;

--- a/components/sup/tests/bldr/start.rs
+++ b/components/sup/tests/bldr/start.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 use util::{self, docker};
 use setup;

--- a/components/sup/tests/bldr/topology/leader.rs
+++ b/components/sup/tests/bldr/topology/leader.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 use setup;
 use util::supervisor::Supervisor;

--- a/components/sup/tests/bldr/topology/mod.rs
+++ b/components/sup/tests/bldr/topology/mod.rs
@@ -1,7 +1,8 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 pub mod leader;

--- a/components/sup/tests/bldr_build/mod.rs
+++ b/components/sup/tests/bldr_build/mod.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 use regex::Regex;
 

--- a/components/sup/tests/functional.rs
+++ b/components/sup/tests/functional.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 extern crate regex;
 extern crate tempdir;

--- a/components/sup/tests/util/command.rs
+++ b/components/sup/tests/util/command.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 use std::io::prelude::*;
 use std::io;

--- a/components/sup/tests/util/discovery.rs
+++ b/components/sup/tests/util/discovery.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 use hyper::header::ContentType;
 use hyper::client::Client;

--- a/components/sup/tests/util/docker.rs
+++ b/components/sup/tests/util/docker.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 //! Start a docker container, store the instance id
 //! Get the logs

--- a/components/sup/tests/util/mod.rs
+++ b/components/sup/tests/util/mod.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 pub mod path;
 pub mod command;

--- a/components/sup/tests/util/path.rs
+++ b/components/sup/tests/util/path.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 use std::env;
 use std::path::PathBuf;

--- a/components/sup/tests/util/supervisor.rs
+++ b/components/sup/tests/util/supervisor.rs
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 use std::thread;
 use time::{SteadyTime, Duration};

--- a/web/app/AppStore.ts
+++ b/web/app/AppStore.ts
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 import {Injectable} from "angular2/core";
 import {applyMiddleware, compose, createStore} from "redux";

--- a/web/app/app.scss
+++ b/web/app/app.scss
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 @import "bourbon";
 @import "base/base";

--- a/web/app/boot.ts
+++ b/web/app/boot.ts
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 ///<reference path="../node_modules/angular2/typings/browser.d.ts"/>
 ///<reference path='../node_modules/immutable/dist/immutable.d.ts'/>

--- a/web/app/config.ts
+++ b/web/app/config.ts
@@ -1,7 +1,8 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 export default window["Habitat"]["config"];

--- a/web/app/header/user-nav/_user-nav.scss
+++ b/web/app/header/user-nav/_user-nav.scss
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 
 .hab-header nav {

--- a/web/app/home-page/HomePageComponent.ts
+++ b/web/app/home-page/HomePageComponent.ts
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 import {Component} from "angular2/core";
 import {Router} from "angular2/router";

--- a/web/app/home-page/_home-page.scss
+++ b/web/app/home-page/_home-page.scss
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 .hab-hero {
   @include outer-container;

--- a/web/app/package-page/_package-page.scss
+++ b/web/app/package-page/_package-page.scss
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 .hab-package {
   .hab-spinner {

--- a/web/app/packages-page/PackagesPageComponent.ts
+++ b/web/app/packages-page/PackagesPageComponent.ts
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 import {Component, OnInit} from "angular2/core";
 import {RouteParams, RouterLink} from "angular2/router";

--- a/web/app/packages-page/_packages-page.scss
+++ b/web/app/packages-page/_packages-page.scss
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 .hab-packages {
   .hab-spinner {

--- a/web/app/sign-in-page/_sign-in-page.scss
+++ b/web/app/sign-in-page/_sign-in-page.scss
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 .hab-sign-in {
   @include span-columns(6);

--- a/web/app/sign-up-form/SignUpFormComponent.ts
+++ b/web/app/sign-up-form/SignUpFormComponent.ts
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 import {AppStore} from "../AppStore";
 import {Component} from "angular2/core";

--- a/web/app/sign-up-form/_sign-up-form.scss
+++ b/web/app/sign-up-form/_sign-up-form.scss
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 .hab-sign-up-form {
   @include span-columns(6);

--- a/web/stylesheets/_item-list.scss
+++ b/web/stylesheets/_item-list.scss
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 // For lists of things like packages or projects
 .hab-item-list {

--- a/web/stylesheets/base/_base.scss
+++ b/web/stylesheets/base/_base.scss
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 @import "normalize";
 

--- a/web/stylesheets/base/_buttons.scss
+++ b/web/stylesheets/base/_buttons.scss
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 #{$all-buttons}, a.button {
   appearance: none;

--- a/web/stylesheets/base/_forms.scss
+++ b/web/stylesheets/base/_forms.scss
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 fieldset {
   background-color: transparent;

--- a/web/stylesheets/base/_grid-settings.scss
+++ b/web/stylesheets/base/_grid-settings.scss
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 @import "neat-helpers"; // or "../neat/neat-helpers" when not in Rails
 

--- a/web/stylesheets/base/_lists.scss
+++ b/web/stylesheets/base/_lists.scss
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 ul,
 ol {

--- a/web/stylesheets/base/_tables.scss
+++ b/web/stylesheets/base/_tables.scss
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 table {
   border-collapse: collapse;

--- a/web/stylesheets/base/_typography.scss
+++ b/web/stylesheets/base/_typography.scss
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 html {
   overflow-y: scroll;

--- a/web/stylesheets/base/_variables.scss
+++ b/web/stylesheets/base/_variables.scss
@@ -1,8 +1,9 @@
 // Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
 
 // Typography
 $base-font-family: "Titillium Web", $helvetica;


### PR DESCRIPTION
This change also wraps the notice to 80 character as the updated name
would push a line over the current 100 character word wrap. Why 80? I
like it?
