### PR TITLE
Make the service groups be full-grown keys in Svc

### DIFF
--- a/components/sup/src/service_config.rs
+++ b/components/sup/src/service_config.rs
@@ -167,9 +167,15 @@ impl Svc {
         let mut top = service_entry(cl.local_census());
         let mut all: Vec<toml::Value> = Vec::new();
         let mut named = toml::Table::new();
-        for (sg, c) in cl.iter() {
+        for (_sg, c) in cl.iter() {
             all.push(toml::Value::Table(service_entry(c)));
-            named.insert(sg.clone(), toml::Value::Table(service_entry(c)));
+            let mut group = if named.contains_key(&c.service) {
+                named.get(&c.service).unwrap().as_table().unwrap().clone()
+            } else {
+                toml::Table::new()
+            };
+            group.insert(c.group.clone(), toml::Value::Table(service_entry(c)));
+            named.insert(c.service.clone(), toml::Value::Table(group));
         }
         top.insert("all".to_string(), toml::Value::Array(all));
         top.insert("named".to_string(), toml::Value::Table(named));


### PR DESCRIPTION
![gif-keyboard-188527673609329009](https://cloud.githubusercontent.com/assets/4304/14327994/a432444a-fbe9-11e5-8168-6c9d1fd2585a.gif)

When using the `svc` tree in the config.toml, the service group itself
was the primary key for the `named` tree. This was causing problems - it
wasn't possible to descend far enough. This turns it into the correct
hierarchy.
