### PR TITLE
Dashes should be replaced with underscores

### DIFF
--- a/components/sup/src/service_config.rs
+++ b/components/sup/src/service_config.rs
@@ -350,7 +350,7 @@ impl Cfg {
     }
 
     fn load_environment(&mut self, pkg: &Package) -> BldrResult<()> {
-        let var_name = format!("BLDR_{}", pkg.name).to_ascii_uppercase();
+        let var_name = format!("BLDR_{}", pkg.name).to_ascii_uppercase().replace("-", "_");
         match env::var(&var_name) {
             Ok(config) => {
                 let mut toml_parser = toml::Parser::new(&config);


### PR DESCRIPTION
Dashes are not valid in environment variables. We allow them in the
names of packages, so this will simply replace them with underscores,
so shell things work as one would expect.
