### PR TITLE
Lets write out if we have any census that changes

### DIFF
--- a/components/sup/src/census.rs
+++ b/components/sup/src/census.rs
@@ -732,7 +732,8 @@ impl CensusList {
         }
     }
 
-    pub fn process(&mut self, remote_ce: CensusEntry) -> bool {
+    pub fn process(&mut self, mut remote_ce: CensusEntry) -> bool {
+        remote_ce.needs_write = Some(true);
         if let Some(mut current_ce) = self.get_mut(&remote_ce.id, &remote_ce.service_group()) {
             return current_ce.update_via(remote_ce);
         }
@@ -744,6 +745,15 @@ impl CensusList {
         for (_sg, mut census) in self.censuses.iter_mut() {
             census.written();
         }
+    }
+
+    pub fn needs_write(&self) -> bool {
+        for (_sg, census) in self.censuses.iter() {
+            if census.needs_write() {
+                return true;
+            }
+        }
+        return false;
     }
 }
 

--- a/components/sup/src/topology/mod.rs
+++ b/components/sup/src/topology/mod.rs
@@ -486,7 +486,7 @@ fn run_internal<'a>(sm: &mut StateMachine<State, Worker<'a>, BldrError>,
             let (write_census, in_event, write_rumor, me_clone) = {
                 let cl = worker.census_list.read().unwrap();
                 let census = cl.local_census();
-                (census.needs_write(),
+                (cl.needs_write(),
                  census.in_event,
                  census.me().needs_write(),
                  census.me().clone())


### PR DESCRIPTION
![gif-keyboard-1102394896176064410](https://cloud.githubusercontent.com/assets/4304/14335896/bcf83884-fc13-11e5-8126-8c530214cbb1.gif)

Currently, we only update the svc configuration if _this supervisors_
census changes. We really want to do that if any census has changed.
