### PR TITLE
initial commit of builder project

### DIFF
--- a/components/builder-api/Cargo.lock
+++ b/components/builder-api/Cargo.lock
@@ -1,0 +1,488 @@
+[root]
+name = "habitat_builder_api"
+version = "0.1.0"
+dependencies = [
+ "clap 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "habitat_builder_protocol 0.1.0",
+ "habitat_net 0.1.0",
+ "iron 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "router 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "urlencoded 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zmq 0.7.0 (git+https://github.com/reset/rust-zmq.git?branch=build-rs)",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ansi_term"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "bitflags"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "bodyparser"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "iron 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "persistent 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "plugin 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "clap"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ansi_term 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vec_map 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "conduit-mime-types"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rustc-serialize 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "cookie"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.58 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "error"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "traitobject 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "habitat_builder_protocol"
+version = "0.1.0"
+dependencies = [
+ "bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "habitat_net"
+version = "0.1.0"
+dependencies = [
+ "bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zmq 0.7.0 (git+https://github.com/reset/rust-zmq.git?branch=build-rs)",
+]
+
+[[package]]
+name = "hpack"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "httparse"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "hyper"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cookie 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "httparse 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mime 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solicit 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "traitobject 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicase 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "iron"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "conduit-mime-types 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "error 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "modifier 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "plugin 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typemap 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "kernel32-sys"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "language-tags"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "lazy_static"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "libc"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "log"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "matches"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "memchr"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "mime"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "modifier"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "num"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "num_cpus"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "persistent"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "iron 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "plugin 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "plugin"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "typemap 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "protobuf"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rand"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "route-recognizer"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "router"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "iron 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "route-recognizer 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rustc-serialize"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rustc_version"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "semver"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde_json"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "solicit"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "hpack 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "strsim"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "time"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "traitobject"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "traitobject"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "typeable"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "typemap"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unsafe-any 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "unicase"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "unicode-bidi"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unsafe-any"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "traitobject 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "url"
+version = "0.2.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "url"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-bidi 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-normalization 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "urlencoded"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bodyparser 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iron 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "plugin 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 0.2.38 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "utf8-ranges"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "uuid"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "vec_map"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "zmq"
+version = "0.7.0"
+source = "git+https://github.com/reset/rust-zmq.git?branch=build-rs#edacfbffb8d966a8b5ac1c98eb3a7e29378fa78c"
+dependencies = [
+ "libc 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zmq-sys 0.7.0 (git+https://github.com/reset/rust-zmq.git?branch=build-rs)",
+]
+
+[[package]]
+name = "zmq-sys"
+version = "0.7.0"
+source = "git+https://github.com/reset/rust-zmq.git?branch=build-rs#edacfbffb8d966a8b5ac1c98eb3a7e29378fa78c"
+dependencies = [
+ "libc 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+

--- a/components/builder-api/Cargo.toml
+++ b/components/builder-api/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "habitat_builder_api"
+version = "0.1.0"
+authors = ["Adam Jacob <adam@chef.io>", "Jamie Winsor <reset@chef.io>", "Fletcher Nichol <fnichol@chef.io>", "Joshua Timberman <joshua@chef.io>", "Dave Parfitt <dparfitt@chef.io>"]
+description = "Habitat-Builder HTTP API gateway"
+
+[[bin]]
+name = "bldr-api"
+doc = false
+
+[dependencies]
+env_logger = "*"
+iron = "*"
+log = "*"
+protobuf = "*"
+router = "*"
+rustc-serialize = "*"
+urlencoded = "*"
+
+[dependencies.clap]
+version = "*"
+features = [ "suggestions", "color", "unstable" ]
+
+[dependencies.zmq]
+# git = "https://github.com/erickt/rust-zmq.git"
+git = "https://github.com/reset/rust-zmq.git"
+branch = "build-rs"
+
+[dependencies.habitat_builder_protocol]
+path = "../builder-protocol"
+
+[dependencies.habitat_net]
+path = "../net"

--- a/components/builder-api/README.md
+++ b/components/builder-api/README.md
@@ -1,0 +1,3 @@
+# builder-api
+
+Habitat-Builder HTTP API gateway

--- a/components/builder-api/src/config.rs
+++ b/components/builder-api/src/config.rs
@@ -1,0 +1,38 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
+//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
+
+use std::net;
+
+pub struct Config {
+    pub http_addr: net::SocketAddrV4,
+    sessionsrv_addr: net::SocketAddrV4,
+}
+
+impl Config {
+    pub fn new() -> Self {
+        Config::default()
+    }
+
+    pub fn sessionsrv_addr(&self) -> String {
+        format!("tcp://{}:{}",
+                self.sessionsrv_addr.ip(),
+                self.sessionsrv_addr.port())
+    }
+
+    pub fn set_port(&mut self, port: u16) -> &mut Self {
+        self.http_addr = net::SocketAddrV4::new(*self.http_addr.ip(), port);
+        self
+    }
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Config {
+            http_addr: net::SocketAddrV4::new(net::Ipv4Addr::new(0, 0, 0, 0), 9636),
+            sessionsrv_addr: net::SocketAddrV4::new(net::Ipv4Addr::new(127, 0, 0, 1), 5560),
+        }
+    }
+}

--- a/components/builder-api/src/error.rs
+++ b/components/builder-api/src/error.rs
@@ -1,0 +1,33 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
+//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
+
+use std::io;
+use std::result;
+
+use protobuf;
+use zmq;
+
+#[derive(Debug)]
+pub enum Error {
+    BadPort(String),
+    IO(io::Error),
+    Protobuf(protobuf::ProtobufError),
+    Zmq(zmq::Error),
+}
+
+pub type Result<T> = result::Result<T, Error>;
+
+impl From<protobuf::ProtobufError> for Error {
+    fn from(err: protobuf::ProtobufError) -> Error {
+        Error::Protobuf(err)
+    }
+}
+
+impl From<zmq::Error> for Error {
+    fn from(err: zmq::Error) -> Error {
+        Error::Zmq(err)
+    }
+}

--- a/components/builder-api/src/http.rs
+++ b/components/builder-api/src/http.rs
@@ -1,0 +1,85 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
+//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
+
+use std::sync::{Arc, Mutex};
+use std::thread;
+
+use iron::prelude::*;
+use iron::{headers, status, AfterMiddleware};
+use protobuf::{self, Message};
+use protocol::sessionsrv::{AuthToken, GitHubAuth};
+use protocol::net::NetError;
+use router::Router;
+use rustc_serialize::json::{self, ToJson};
+use zmq;
+
+use config::Config;
+use error::Result;
+
+struct Cors;
+
+impl AfterMiddleware for Cors {
+    fn after(&self, _req: &mut Request, mut res: Response) -> IronResult<Response> {
+        res.headers.set(headers::AccessControlAllowOrigin::Any);
+        Ok(res)
+    }
+}
+
+pub fn run(config: Arc<Config>, context: Arc<Mutex<zmq::Context>>) -> Result<()> {
+    let ctx1 = context.clone();
+    let router = router!(
+        get "/authenticate/:code" => move |r: &mut Request| authenticate(r, &ctx1)
+    );
+    let mut chain = Chain::new(router);
+    chain.link_after(Cors);
+    thread::Builder::new().name("http-srv".to_string()).spawn(move || {
+        let mut xmitter = context.lock().unwrap().socket(zmq::PAIR).unwrap();
+        xmitter.connect("inproc://rz-http").unwrap();
+        let server = Iron::new(chain).http(config.http_addr).unwrap();
+        xmitter.send(&[], 0).unwrap();
+    });
+    Ok(())
+}
+
+fn authenticate(req: &mut Request, ctx: &Arc<Mutex<zmq::Context>>) -> IronResult<Response> {
+    let params = req.extensions.get::<Router>().unwrap();
+    let code = match params.find("code") {
+        Some(code) => code.to_string(),
+        _ => return Ok(Response::with(status::BadRequest)),
+    };
+    let mut xmitter = {
+        ctx.lock().unwrap().socket(zmq::REQ).unwrap()
+    };
+    xmitter.connect("inproc://login-queue").unwrap();
+    let mut request = GitHubAuth::new();
+    request.set_code(code.to_string());
+    xmitter.send_str("LOGIN", zmq::SNDMORE).unwrap();
+    xmitter.send(&request.write_to_bytes().unwrap(), 0).unwrap();
+
+    match xmitter.recv_msg(0) {
+        Ok(rep) => {
+            match rep.as_str() {
+                Some("AuthToken") => {
+                    let msg = xmitter.recv_msg(0).unwrap();
+                    let token: AuthToken = protobuf::parse_from_bytes(&msg).unwrap();
+                    let encoded = json::encode(&token.to_json()).unwrap();
+                    Ok(Response::with((status::Ok, encoded)))
+                }
+                Some("NetError") => {
+                    let msg = xmitter.recv_msg(0).unwrap();
+                    let err: NetError = protobuf::parse_from_bytes(&msg).unwrap();
+                    let encoded = json::encode(&err.to_json()).unwrap();
+                    Ok(Response::with((status::Ok, encoded)))
+                }
+                _ => Ok(Response::with(status::InternalServerError)),
+            }
+        }
+        Err(e) => {
+            println!("{:?}", e);
+            Ok(Response::with(status::ServiceUnavailable))
+        }
+    }
+}

--- a/components/builder-api/src/lib.rs
+++ b/components/builder-api/src/lib.rs
@@ -1,0 +1,26 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
+//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
+
+extern crate habitat_net as hab_net;
+extern crate habitat_builder_protocol as protocol;
+extern crate iron;
+#[macro_use]
+extern crate log;
+extern crate protobuf;
+#[macro_use]
+extern crate router;
+extern crate rustc_serialize;
+extern crate urlencoded;
+extern crate zmq;
+
+pub mod config;
+pub mod error;
+pub mod http;
+pub mod login_queue;
+pub mod server;
+
+pub use self::config::Config;
+pub use self::error::{Error, Result};

--- a/components/builder-api/src/login_queue.rs
+++ b/components/builder-api/src/login_queue.rs
@@ -1,0 +1,57 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
+//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
+
+use std::sync::{Arc, Mutex};
+use std::thread;
+
+use zmq;
+
+use config::Config;
+use error::Result;
+
+pub struct Server {
+    config: Arc<Config>,
+    ctx: Arc<Mutex<zmq::Context>>,
+    fe_sock: zmq::Socket,
+    be_sock: zmq::Socket,
+    rz_sock: zmq::Socket,
+}
+
+impl Server {
+    fn new(config: Arc<Config>, ctx: Arc<Mutex<zmq::Context>>) -> Self {
+        let (fe, be, rz) = {
+            let mut ctx = ctx.lock().unwrap();
+            let fe = ctx.socket(zmq::ROUTER).unwrap();
+            let be = ctx.socket(zmq::DEALER).unwrap();
+            let rz = ctx.socket(zmq::PAIR).unwrap();
+            (fe, be, rz)
+        };
+        Server {
+            config: config,
+            ctx: ctx,
+            fe_sock: fe,
+            be_sock: be,
+            rz_sock: rz,
+        }
+    }
+
+    pub fn run(config: Arc<Config>, ctx: Arc<Mutex<zmq::Context>>) -> Result<()> {
+        thread::Builder::new().name("login-queue-conn".to_string()).spawn(move || {
+            let mut conn = Self::new(config, ctx);
+            conn.start();
+        });
+        Ok(())
+    }
+
+    fn start(&mut self) -> Result<()> {
+        try!(self.fe_sock.bind("inproc://login-queue"));
+        try!(self.be_sock.connect(&self.config.sessionsrv_addr()));
+        try!(self.rz_sock.connect("inproc://rz-login-queue"));
+        try!(self.rz_sock.send(&[], 0));
+        try!(zmq::proxy(&mut self.fe_sock, &mut self.be_sock));
+        Ok(())
+    }
+}

--- a/components/builder-api/src/main.rs
+++ b/components/builder-api/src/main.rs
@@ -1,0 +1,72 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
+//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
+
+#[macro_use]
+extern crate clap;
+extern crate env_logger;
+extern crate habitat_builder_api as api;
+#[macro_use]
+extern crate log;
+
+use std::process;
+use std::str::FromStr;
+
+use api::{Config, Error, Result};
+
+const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+
+fn main() {
+    env_logger::init().unwrap();
+    let matches = app().get_matches();
+    debug!("CLI matches: {:?}", matches);
+    let config = match config_from_args(&matches) {
+        Ok(result) => result,
+        Err(e) => return exit_with(e, 1),
+    };
+    match start(config) {
+        Ok(_) => std::process::exit(0),
+        Err(e) => exit_with(e, 1),
+    }
+}
+
+fn app<'a, 'b>() -> clap::App<'a, 'b> {
+    clap_app!(BuilderApi =>
+        (version: VERSION)
+        (about: "Manage a Habitat builder-api")
+        (@setting VersionlessSubcommands)
+        (@setting SubcommandRequiredElseHelp)
+        (@subcommand start =>
+            (about: "Run a Habitat builder-api")
+            (@arg port: --port +takes_value "Listen port. [default: 9632]")
+        )
+    )
+}
+
+fn config_from_args(matches: &clap::ArgMatches) -> Result<Config> {
+    let cmd = matches.subcommand_name().unwrap();
+    let args = matches.subcommand_matches(cmd).unwrap();
+    let mut config = Config::new();
+    if let Some(port) = args.value_of("port") {
+        if u16::from_str(port).map(|p| config.set_port(p)).is_err() {
+            return Err(Error::BadPort(port.to_string()));
+        }
+    }
+    Ok(config)
+}
+
+fn exit_with(err: Error, code: i32) {
+    println!("{:?}", err);
+    process::exit(code)
+}
+
+/// Starts the builder-api server.
+///
+/// # Failures
+///
+/// * Fails if the depot server fails to start - canot bind to the port, etc.
+fn start(config: Config) -> Result<()> {
+    api::server::run(config)
+}

--- a/components/builder-api/src/server.rs
+++ b/components/builder-api/src/server.rs
@@ -1,0 +1,85 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
+//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
+
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::Duration;
+
+use zmq;
+
+use hab_net::Conn;
+use protobuf::{self, Message};
+use protocol::{jobsrv, sessionsrv};
+
+use config::Config;
+use error::Result;
+use login_queue;
+use http;
+
+pub struct Server {
+    pub config: Arc<Config>,
+    context: Arc<Mutex<zmq::Context>>,
+}
+
+impl Server {
+    pub fn new(config: Config) -> Result<Self> {
+        let mut ctx = zmq::Context::new();
+        Ok(Server {
+            config: Arc::new(config),
+            context: Arc::new(Mutex::new(ctx)),
+        })
+    }
+
+    pub fn run(&mut self) -> Result<()> {
+        try!(self.start_conn());
+        try!(self.start_http());
+
+        loop {
+            thread::sleep(Duration::from_millis(5000));
+        }
+        Ok(())
+    }
+
+    fn start_conn(&mut self) -> Result<()> {
+        let mut receiver = {
+            let mut receiver = try!(self.context.lock().unwrap().socket(zmq::PAIR));
+            try!(receiver.bind("inproc://rz-login-queue"));
+            receiver
+        };
+        let cfg1 = self.config.clone();
+        let ctx1 = self.context.clone();
+        try!(login_queue::Server::run(cfg1, ctx1));
+        try!(receiver.recv_msg(0).map(|msg| {
+            match msg.as_str() {
+                Some(_) => println!("LoginQ conn ready"),
+                _ => panic!("error starting LoginQ conn"),
+            }
+        }));
+        Ok(())
+    }
+
+    fn start_http(&mut self) -> Result<()> {
+        let mut receiver = {
+            let mut receiver = try!(self.context.lock().unwrap().socket(zmq::PAIR));
+            try!(receiver.bind("inproc://rz-http"));
+            receiver
+        };
+        let cfg1 = self.config.clone();
+        let ctx1 = self.context.clone();
+        try!(http::run(cfg1, ctx1));
+        try!(receiver.recv_msg(0).map(|msg| {
+            match msg.as_str() {
+                Some(_) => println!("Builder API listening on {}", &self.config.http_addr),
+                _ => panic!("error starting http-srv"),
+            }
+        }));
+        Ok(())
+    }
+}
+
+pub fn run(config: Config) -> Result<()> {
+    try!(Server::new(config)).run()
+}

--- a/components/builder-jobsrv/Cargo.lock
+++ b/components/builder-jobsrv/Cargo.lock
@@ -1,0 +1,162 @@
+[root]
+name = "habitat_builder_jobsrv"
+version = "0.1.0"
+dependencies = [
+ "clap 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "habitat_builder_protocol 0.1.0",
+ "habitat_net 0.1.0",
+ "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zmq 0.7.0 (git+https://github.com/reset/rust-zmq.git?branch=build-rs)",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ansi_term"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "bitflags"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "bitflags"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "clap"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ansi_term 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vec_map 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.58 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "habitat_builder_protocol"
+version = "0.1.0"
+dependencies = [
+ "bitflags 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "habitat_net"
+version = "0.1.0"
+dependencies = [
+ "bitflags 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zmq 0.7.0 (git+https://github.com/reset/rust-zmq.git?branch=build-rs)",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "log"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "memchr"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "protobuf"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "regex"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rustc-serialize"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "strsim"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "utf8-ranges"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "vec_map"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "zmq"
+version = "0.7.0"
+source = "git+https://github.com/reset/rust-zmq.git?branch=build-rs#edacfbffb8d966a8b5ac1c98eb3a7e29378fa78c"
+dependencies = [
+ "libc 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zmq-sys 0.7.0 (git+https://github.com/reset/rust-zmq.git?branch=build-rs)",
+]
+
+[[package]]
+name = "zmq-sys"
+version = "0.7.0"
+source = "git+https://github.com/reset/rust-zmq.git?branch=build-rs#edacfbffb8d966a8b5ac1c98eb3a7e29378fa78c"
+dependencies = [
+ "libc 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+

--- a/components/builder-jobsrv/Cargo.toml
+++ b/components/builder-jobsrv/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "habitat_builder_jobsrv"
+version = "0.1.0"
+authors = ["Adam Jacob <adam@chef.io>", "Jamie Winsor <reset@chef.io>", "Fletcher Nichol <fnichol@chef.io>", "Joshua Timberman <joshua@chef.io>", "Dave Parfitt <dparfitt@chef.io>"]
+description = "Habitat-Builder Job Server"
+
+[[bin]]
+name = "bldr-job-srv"
+doc = false
+
+[dependencies]
+env_logger = "*"
+log = "*"
+protobuf = "*"
+
+[dependencies.clap]
+version = "*"
+features = [ "suggestions", "color", "unstable" ]
+
+[dependencies.zmq]
+# git = "https://github.com/erickt/rust-zmq.git"
+git = "https://github.com/reset/rust-zmq.git"
+branch = "build-rs"
+
+[dependencies.habitat_builder_protocol]
+path = "../builder-protocol"
+
+[dependencies.habitat_net]
+path = "../net"

--- a/components/builder-jobsrv/README.md
+++ b/components/builder-jobsrv/README.md
@@ -1,0 +1,3 @@
+# builder-jobsrv
+
+Collects job requests and distributes to workers

--- a/components/builder-jobsrv/src/config.rs
+++ b/components/builder-jobsrv/src/config.rs
@@ -1,0 +1,27 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
+//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
+
+use std::net;
+
+pub struct Config {
+    pub port: u16,
+    pub listen_addr: net::Ipv4Addr,
+}
+
+impl Config {
+    pub fn new() -> Self {
+        Config::default()
+    }
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Config {
+            port: 9636,
+            listen_addr: net::Ipv4Addr::new(0, 0, 0, 0),
+        }
+    }
+}

--- a/components/builder-jobsrv/src/error.rs
+++ b/components/builder-jobsrv/src/error.rs
@@ -1,0 +1,39 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
+//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
+
+use std::io;
+use std::result;
+
+use protobuf;
+use zmq;
+
+#[derive(Debug)]
+pub enum Error {
+    BadPort(String),
+    IO(io::Error),
+    Protobuf(protobuf::ProtobufError),
+    Zmq(zmq::Error),
+}
+
+pub type Result<T> = result::Result<T, Error>;
+
+impl From<io::Error> for Error {
+    fn from(err: io::Error) -> Error {
+        Error::IO(err)
+    }
+}
+
+impl From<protobuf::ProtobufError> for Error {
+    fn from(err: protobuf::ProtobufError) -> Error {
+        Error::Protobuf(err)
+    }
+}
+
+impl From<zmq::Error> for Error {
+    fn from(err: zmq::Error) -> Error {
+        Error::Zmq(err)
+    }
+}

--- a/components/builder-jobsrv/src/lib.rs
+++ b/components/builder-jobsrv/src/lib.rs
@@ -1,0 +1,16 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
+//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
+
+extern crate habitat_builder_protocol as protocol;
+extern crate protobuf;
+extern crate zmq;
+
+pub mod config;
+pub mod error;
+pub mod server;
+
+pub use self::config::Config;
+pub use self::error::{Error, Result};

--- a/components/builder-jobsrv/src/main.rs
+++ b/components/builder-jobsrv/src/main.rs
@@ -1,0 +1,77 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
+//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
+
+#[macro_use]
+extern crate clap;
+extern crate env_logger;
+extern crate habitat_builder_jobsrv as jobsrv;
+#[macro_use]
+extern crate log;
+
+use std::process;
+use std::str::FromStr;
+
+use jobsrv::{Config, Error, Result};
+
+const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+
+fn main() {
+    env_logger::init().unwrap();
+    let matches = app().get_matches();
+    debug!("CLI matches: {:?}", matches);
+    let config = match config_from_args(&matches) {
+        Ok(result) => result,
+        Err(e) => return exit_with(e, 1),
+    };
+    match start(config) {
+        Ok(_) => std::process::exit(0),
+        Err(e) => exit_with(e, 1),
+    }
+}
+
+fn app<'a, 'b>() -> clap::App<'a, 'b> {
+    clap_app!(BuilderJobSrv =>
+        (version: VERSION)
+        (about: "Manage a Habitat Builder job server")
+        (@setting VersionlessSubcommands)
+        (@setting SubcommandRequiredElseHelp)
+        (@subcommand start =>
+            (about: "Run a Habitat Builder job server")
+            (@arg port: --port +takes_value "Listen port. [default: 9637]")
+        )
+    )
+}
+
+fn config_from_args(matches: &clap::ArgMatches) -> Result<Config> {
+    let cmd = matches.subcommand_name().unwrap();
+    let args = matches.subcommand_matches(cmd).unwrap();
+    let mut config = Config::new();
+    if let Some(port) = args.value_of("port") {
+        if let Some(port) = u16::from_str(port).ok() {
+            config.port = port;
+        } else {
+            return Err(Error::BadPort(port.to_string()));
+        }
+    }
+    Ok(config)
+}
+
+fn exit_with(err: Error, code: i32) {
+    println!("{:?}", err);
+    process::exit(code)
+}
+
+/// Starts the builder-jobsrv server.
+///
+/// # Failures
+///
+/// * Fails if the depot server fails to start - canot bind to the port, etc.
+fn start(config: Config) -> Result<()> {
+    println!("Depot listening on {}:{}",
+             &config.listen_addr,
+             &config.port);
+    jobsrv::server::run(config)
+}

--- a/components/builder-jobsrv/src/server.rs
+++ b/components/builder-jobsrv/src/server.rs
@@ -1,0 +1,64 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
+//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
+
+use std::thread;
+
+use protobuf::{parse_from_bytes, Message};
+use protocol::jobsrv;
+use zmq;
+
+use config::Config;
+use error::Result;
+
+pub struct Server {
+    pub config: Config,
+    ctx: zmq::Context,
+}
+
+impl Server {
+    pub fn new(config: Config) -> Self {
+        Server {
+            config: config,
+            ctx: zmq::Context::new(),
+        }
+    }
+
+    pub fn reconfigure(config: Config) -> Result<()> {
+        Ok(())
+    }
+
+    pub fn run(&mut self) -> Result<()> {
+        // build request socket?
+        let mut socket = try!(self.ctx.socket(zmq::REP));
+        try!(socket.bind("tcp://127.0.0.1:9636"));
+        let thread = try!(thread::Builder::new()
+                              .name("server".to_string())
+                              .spawn(move || Self::recv_loop(&mut socket)));
+        thread.join().unwrap();
+        Ok(())
+    }
+
+    fn recv_loop(socket: &mut zmq::Socket) -> Result<()> {
+        let mut msg = try!(zmq::Message::new());
+        loop {
+            try!(socket.recv(&mut msg, 0));
+            try!(Self::dispatch(socket, &msg));
+        }
+    }
+
+    fn dispatch(socket: &mut zmq::Socket, msg: &zmq::Message) -> Result<()> {
+        let mut request: jobsrv::JobCreate = try!(parse_from_bytes(&msg));
+        println!("Received {:?}", request);
+        let mut job: jobsrv::Job = jobsrv::Job::new();
+        job.set_id("fakeid".to_string());
+        try!(socket.send(&job.write_to_bytes().unwrap(), 0));
+        Ok(())
+    }
+}
+
+pub fn run(config: Config) -> Result<()> {
+    Server::new(config).run()
+}

--- a/components/builder-protocol/Cargo.lock
+++ b/components/builder-protocol/Cargo.lock
@@ -1,0 +1,30 @@
+[root]
+name = "habitat_builder_protocol"
+version = "0.1.0"
+dependencies = [
+ "bitflags 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "bitflags"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "protobuf"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rustc-serialize"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+

--- a/components/builder-protocol/Cargo.toml
+++ b/components/builder-protocol/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "habitat_builder_protocol"
+version = "0.1.0"
+authors = ["Adam Jacob <adam@chef.io>", "Jamie Winsor <reset@chef.io>", "Fletcher Nichol <fnichol@chef.io>", "Joshua Timberman <joshua@chef.io>", "Dave Parfitt <dparfitt@chef.io>"]
+description = "Habitat-Builder Network Server Protocol"
+build = "build.rs"
+
+[dependencies]
+bitflags = "*"
+protobuf = "*"
+rustc-serialize = "*"
+
+[build-dependencies]
+pkg-config = "0.3"

--- a/components/builder-protocol/README.md
+++ b/components/builder-protocol/README.md
@@ -1,0 +1,3 @@
+# builder-protocol
+
+Definitions for network protocol messages and serialization implementations for builder servers

--- a/components/builder-protocol/build.rs
+++ b/components/builder-protocol/build.rs
@@ -1,0 +1,44 @@
+extern crate pkg_config;
+
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+fn main() {
+    let prefix = match env::var("PROTOBUF_PREFIX").ok() {
+        Some(prefix) => prefix,
+        None => {
+            match pkg_config::get_variable("protobuf", "prefix") {
+                Ok(prefix) => prefix,
+                Err(msg) => panic!("Unable to locate protobuf, err={:?}", msg),
+            }
+        }
+    };
+
+    let out_dir = r"src/message";
+    let cmd = Command::new(format!("{}/bin/protoc", prefix))
+                  .arg("--rust_out")
+                  .arg(out_dir)
+                  .args(&protocol_files())
+                  .output();
+    match cmd {
+        Ok(out) => {
+            if !out.status.success() {
+                panic!("{:?}", out)
+            }
+        }
+        Err(e) => panic!("{}", e),
+    }
+}
+
+fn protocol_files() -> Vec<PathBuf> {
+    let mut files = vec![];
+    for entry in fs::read_dir("protocols").unwrap() {
+        let file = entry.unwrap();
+        if file.metadata().unwrap().is_file() {
+            files.push(file.path());
+        }
+    }
+    files
+}

--- a/components/builder-protocol/protocols/jobsrv.proto
+++ b/components/builder-protocol/protocols/jobsrv.proto
@@ -1,0 +1,11 @@
+import "protocols/sessionsrv.proto";
+
+package jobsrv;
+
+message Job {
+    required string id = 1;
+}
+
+message JobCreate {
+  required sessionsrv.AuthToken token = 1;
+}

--- a/components/builder-protocol/protocols/net.proto
+++ b/components/builder-protocol/protocols/net.proto
@@ -1,0 +1,13 @@
+package net;
+
+enum ErrCode {
+  BUG = 0;
+  TIMEOUT = 1;
+  REMOTE_REJECTED = 2;
+  BAD_REMOTE_REPLY = 3;
+}
+
+message NetError {
+    required ErrCode code = 1;
+    required string msg = 2;
+}

--- a/components/builder-protocol/protocols/sessionsrv.proto
+++ b/components/builder-protocol/protocols/sessionsrv.proto
@@ -1,0 +1,9 @@
+package sessionsrv;
+
+message GitHubAuth {
+  required string code = 1;
+}
+
+message AuthToken {
+  required string token = 1;
+}

--- a/components/builder-protocol/src/jobsrv.rs
+++ b/components/builder-protocol/src/jobsrv.rs
@@ -1,0 +1,7 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
+//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
+
+pub use message::jobsrv::*;

--- a/components/builder-protocol/src/lib.rs
+++ b/components/builder-protocol/src/lib.rs
@@ -1,0 +1,15 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
+//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
+
+#[macro_use]
+extern crate bitflags;
+extern crate protobuf;
+extern crate rustc_serialize;
+
+pub mod jobsrv;
+pub mod net;
+pub mod sessionsrv;
+mod message;

--- a/components/builder-protocol/src/message/jobsrv.rs
+++ b/components/builder-protocol/src/message/jobsrv.rs
@@ -1,0 +1,425 @@
+// This file is generated. Do not edit
+// @generated
+
+#![allow(dead_code)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+#![allow(non_upper_case_globals)]
+#![allow(unused_imports)]
+
+use protobuf::Message as Message_imported_for_functions;
+use protobuf::ProtobufEnum as ProtobufEnum_imported_for_functions;
+
+#[derive(Clone,Default)]
+pub struct Job {
+    // message fields
+    id: ::protobuf::SingularField<::std::string::String>,
+    // special fields
+    unknown_fields: ::protobuf::UnknownFields,
+    cached_size: ::std::cell::Cell<u32>,
+}
+
+// see codegen.rs for the explanation why impl Sync explicitly
+unsafe impl ::std::marker::Sync for Job {}
+
+impl Job {
+    pub fn new() -> Job {
+        ::std::default::Default::default()
+    }
+
+    pub fn default_instance() -> &'static Job {
+        static mut instance: ::protobuf::lazy::Lazy<Job> = ::protobuf::lazy::Lazy {
+            lock: ::protobuf::lazy::ONCE_INIT,
+            ptr: 0 as *const Job,
+        };
+        unsafe {
+            instance.get(|| {
+                Job {
+                    id: ::protobuf::SingularField::none(),
+                    unknown_fields: ::protobuf::UnknownFields::new(),
+                    cached_size: ::std::cell::Cell::new(0),
+                }
+            })
+        }
+    }
+
+    // required string id = 1;
+
+    pub fn clear_id(&mut self) {
+        self.id.clear();
+    }
+
+    pub fn has_id(&self) -> bool {
+        self.id.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_id(&mut self, v: ::std::string::String) {
+        self.id = ::protobuf::SingularField::some(v);
+    }
+
+    // Mutable pointer to the field.
+    // If field is not initialized, it is initialized with default value first.
+    pub fn mut_id<'a>(&'a mut self) -> &'a mut ::std::string::String {
+        if self.id.is_none() {
+            self.id.set_default();
+        };
+        self.id.as_mut().unwrap()
+    }
+
+    // Take field
+    pub fn take_id(&mut self) -> ::std::string::String {
+        self.id.take().unwrap_or_else(|| ::std::string::String::new())
+    }
+
+    pub fn get_id<'a>(&'a self) -> &'a str {
+        match self.id.as_ref() {
+            Some(v) => &v,
+            None => "",
+        }
+    }
+}
+
+impl ::protobuf::Message for Job {
+    fn is_initialized(&self) -> bool {
+        if self.id.is_none() {
+            return false;
+        };
+        true
+    }
+
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+        while !try!(is.eof()) {
+            let (field_number, wire_type) = try!(is.read_tag_unpack());
+            match field_number {
+                1 => {
+                    try!(::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.id));
+                },
+                _ => {
+                    try!(::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields()));
+                },
+            };
+        }
+        ::std::result::Result::Ok(())
+    }
+
+    // Compute sizes of nested messages
+    #[allow(unused_variables)]
+    fn compute_size(&self) -> u32 {
+        let mut my_size = 0;
+        for value in self.id.iter() {
+            my_size += ::protobuf::rt::string_size(1, &value);
+        };
+        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
+        self.cached_size.set(my_size);
+        my_size
+    }
+
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+        if let Some(v) = self.id.as_ref() {
+            try!(os.write_string(1, &v));
+        };
+        try!(os.write_unknown_fields(self.get_unknown_fields()));
+        ::std::result::Result::Ok(())
+    }
+
+    fn get_cached_size(&self) -> u32 {
+        self.cached_size.get()
+    }
+
+    fn get_unknown_fields<'s>(&'s self) -> &'s ::protobuf::UnknownFields {
+        &self.unknown_fields
+    }
+
+    fn mut_unknown_fields<'s>(&'s mut self) -> &'s mut ::protobuf::UnknownFields {
+        &mut self.unknown_fields
+    }
+
+    fn type_id(&self) -> ::std::any::TypeId {
+        ::std::any::TypeId::of::<Job>()
+    }
+
+    fn as_any(&self) -> &::std::any::Any {
+        self as &::std::any::Any
+    }
+
+    fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
+        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+    }
+}
+
+impl ::protobuf::MessageStatic for Job {
+    fn new() -> Job {
+        Job::new()
+    }
+
+    fn descriptor_static(_: ::std::option::Option<Job>) -> &'static ::protobuf::reflect::MessageDescriptor {
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
+            lock: ::protobuf::lazy::ONCE_INIT,
+            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+        };
+        unsafe {
+            descriptor.get(|| {
+                let mut fields = ::std::vec::Vec::new();
+                fields.push(::protobuf::reflect::accessor::make_singular_string_accessor(
+                    "id",
+                    Job::has_id,
+                    Job::get_id,
+                ));
+                ::protobuf::reflect::MessageDescriptor::new::<Job>(
+                    "Job",
+                    fields,
+                    file_descriptor_proto()
+                )
+            })
+        }
+    }
+}
+
+impl ::protobuf::Clear for Job {
+    fn clear(&mut self) {
+        self.clear_id();
+        self.unknown_fields.clear();
+    }
+}
+
+impl ::std::cmp::PartialEq for Job {
+    fn eq(&self, other: &Job) -> bool {
+        self.id == other.id &&
+        self.unknown_fields == other.unknown_fields
+    }
+}
+
+impl ::std::fmt::Debug for Job {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        ::protobuf::text_format::fmt(self, f)
+    }
+}
+
+#[derive(Clone,Default)]
+pub struct JobCreate {
+    // message fields
+    token: ::protobuf::SingularPtrField<super::sessionsrv::AuthToken>,
+    // special fields
+    unknown_fields: ::protobuf::UnknownFields,
+    cached_size: ::std::cell::Cell<u32>,
+}
+
+// see codegen.rs for the explanation why impl Sync explicitly
+unsafe impl ::std::marker::Sync for JobCreate {}
+
+impl JobCreate {
+    pub fn new() -> JobCreate {
+        ::std::default::Default::default()
+    }
+
+    pub fn default_instance() -> &'static JobCreate {
+        static mut instance: ::protobuf::lazy::Lazy<JobCreate> = ::protobuf::lazy::Lazy {
+            lock: ::protobuf::lazy::ONCE_INIT,
+            ptr: 0 as *const JobCreate,
+        };
+        unsafe {
+            instance.get(|| {
+                JobCreate {
+                    token: ::protobuf::SingularPtrField::none(),
+                    unknown_fields: ::protobuf::UnknownFields::new(),
+                    cached_size: ::std::cell::Cell::new(0),
+                }
+            })
+        }
+    }
+
+    // required .sessionsrv.AuthToken token = 1;
+
+    pub fn clear_token(&mut self) {
+        self.token.clear();
+    }
+
+    pub fn has_token(&self) -> bool {
+        self.token.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_token(&mut self, v: super::sessionsrv::AuthToken) {
+        self.token = ::protobuf::SingularPtrField::some(v);
+    }
+
+    // Mutable pointer to the field.
+    // If field is not initialized, it is initialized with default value first.
+    pub fn mut_token<'a>(&'a mut self) -> &'a mut super::sessionsrv::AuthToken {
+        if self.token.is_none() {
+            self.token.set_default();
+        };
+        self.token.as_mut().unwrap()
+    }
+
+    // Take field
+    pub fn take_token(&mut self) -> super::sessionsrv::AuthToken {
+        self.token.take().unwrap_or_else(|| super::sessionsrv::AuthToken::new())
+    }
+
+    pub fn get_token<'a>(&'a self) -> &'a super::sessionsrv::AuthToken {
+        self.token.as_ref().unwrap_or_else(|| super::sessionsrv::AuthToken::default_instance())
+    }
+}
+
+impl ::protobuf::Message for JobCreate {
+    fn is_initialized(&self) -> bool {
+        if self.token.is_none() {
+            return false;
+        };
+        true
+    }
+
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+        while !try!(is.eof()) {
+            let (field_number, wire_type) = try!(is.read_tag_unpack());
+            match field_number {
+                1 => {
+                    try!(::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.token));
+                },
+                _ => {
+                    try!(::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields()));
+                },
+            };
+        }
+        ::std::result::Result::Ok(())
+    }
+
+    // Compute sizes of nested messages
+    #[allow(unused_variables)]
+    fn compute_size(&self) -> u32 {
+        let mut my_size = 0;
+        for value in self.token.iter() {
+            let len = value.compute_size();
+            my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
+        };
+        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
+        self.cached_size.set(my_size);
+        my_size
+    }
+
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+        if let Some(v) = self.token.as_ref() {
+            try!(os.write_tag(1, ::protobuf::wire_format::WireTypeLengthDelimited));
+            try!(os.write_raw_varint32(v.get_cached_size()));
+            try!(v.write_to_with_cached_sizes(os));
+        };
+        try!(os.write_unknown_fields(self.get_unknown_fields()));
+        ::std::result::Result::Ok(())
+    }
+
+    fn get_cached_size(&self) -> u32 {
+        self.cached_size.get()
+    }
+
+    fn get_unknown_fields<'s>(&'s self) -> &'s ::protobuf::UnknownFields {
+        &self.unknown_fields
+    }
+
+    fn mut_unknown_fields<'s>(&'s mut self) -> &'s mut ::protobuf::UnknownFields {
+        &mut self.unknown_fields
+    }
+
+    fn type_id(&self) -> ::std::any::TypeId {
+        ::std::any::TypeId::of::<JobCreate>()
+    }
+
+    fn as_any(&self) -> &::std::any::Any {
+        self as &::std::any::Any
+    }
+
+    fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
+        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+    }
+}
+
+impl ::protobuf::MessageStatic for JobCreate {
+    fn new() -> JobCreate {
+        JobCreate::new()
+    }
+
+    fn descriptor_static(_: ::std::option::Option<JobCreate>) -> &'static ::protobuf::reflect::MessageDescriptor {
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
+            lock: ::protobuf::lazy::ONCE_INIT,
+            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+        };
+        unsafe {
+            descriptor.get(|| {
+                let mut fields = ::std::vec::Vec::new();
+                fields.push(::protobuf::reflect::accessor::make_singular_message_accessor(
+                    "token",
+                    JobCreate::has_token,
+                    JobCreate::get_token,
+                ));
+                ::protobuf::reflect::MessageDescriptor::new::<JobCreate>(
+                    "JobCreate",
+                    fields,
+                    file_descriptor_proto()
+                )
+            })
+        }
+    }
+}
+
+impl ::protobuf::Clear for JobCreate {
+    fn clear(&mut self) {
+        self.clear_token();
+        self.unknown_fields.clear();
+    }
+}
+
+impl ::std::cmp::PartialEq for JobCreate {
+    fn eq(&self, other: &JobCreate) -> bool {
+        self.token == other.token &&
+        self.unknown_fields == other.unknown_fields
+    }
+}
+
+impl ::std::fmt::Debug for JobCreate {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        ::protobuf::text_format::fmt(self, f)
+    }
+}
+
+static file_descriptor_proto_data: &'static [u8] = &[
+    0x0a, 0x16, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x63, 0x6f, 0x6c, 0x73, 0x2f, 0x6a, 0x6f, 0x62, 0x73,
+    0x72, 0x76, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x12, 0x06, 0x6a, 0x6f, 0x62, 0x73, 0x72, 0x76,
+    0x1a, 0x1a, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x63, 0x6f, 0x6c, 0x73, 0x2f, 0x73, 0x65, 0x73, 0x73,
+    0x69, 0x6f, 0x6e, 0x73, 0x72, 0x76, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x22, 0x11, 0x0a, 0x03,
+    0x4a, 0x6f, 0x62, 0x12, 0x0a, 0x0a, 0x02, 0x69, 0x64, 0x18, 0x01, 0x20, 0x02, 0x28, 0x09, 0x22,
+    0x31, 0x0a, 0x09, 0x4a, 0x6f, 0x62, 0x43, 0x72, 0x65, 0x61, 0x74, 0x65, 0x12, 0x24, 0x0a, 0x05,
+    0x74, 0x6f, 0x6b, 0x65, 0x6e, 0x18, 0x01, 0x20, 0x02, 0x28, 0x0b, 0x32, 0x15, 0x2e, 0x73, 0x65,
+    0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73, 0x72, 0x76, 0x2e, 0x41, 0x75, 0x74, 0x68, 0x54, 0x6f, 0x6b,
+    0x65, 0x6e, 0x4a, 0xd7, 0x01, 0x0a, 0x06, 0x12, 0x04, 0x00, 0x00, 0x0a, 0x01, 0x0a, 0x09, 0x0a,
+    0x02, 0x03, 0x00, 0x12, 0x03, 0x00, 0x07, 0x23, 0x0a, 0x08, 0x0a, 0x01, 0x02, 0x12, 0x03, 0x02,
+    0x08, 0x0e, 0x0a, 0x0a, 0x0a, 0x02, 0x04, 0x00, 0x12, 0x04, 0x04, 0x00, 0x06, 0x01, 0x0a, 0x0a,
+    0x0a, 0x03, 0x04, 0x00, 0x01, 0x12, 0x03, 0x04, 0x08, 0x0b, 0x0a, 0x0b, 0x0a, 0x04, 0x04, 0x00,
+    0x02, 0x00, 0x12, 0x03, 0x05, 0x04, 0x1b, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x00, 0x02, 0x00, 0x04,
+    0x12, 0x03, 0x05, 0x04, 0x0c, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x00, 0x02, 0x00, 0x05, 0x12, 0x03,
+    0x05, 0x0d, 0x13, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x00, 0x02, 0x00, 0x01, 0x12, 0x03, 0x05, 0x14,
+    0x16, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x00, 0x02, 0x00, 0x03, 0x12, 0x03, 0x05, 0x19, 0x1a, 0x0a,
+    0x0a, 0x0a, 0x02, 0x04, 0x01, 0x12, 0x04, 0x08, 0x00, 0x0a, 0x01, 0x0a, 0x0a, 0x0a, 0x03, 0x04,
+    0x01, 0x01, 0x12, 0x03, 0x08, 0x08, 0x11, 0x0a, 0x0b, 0x0a, 0x04, 0x04, 0x01, 0x02, 0x00, 0x12,
+    0x03, 0x09, 0x02, 0x2a, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x01, 0x02, 0x00, 0x04, 0x12, 0x03, 0x09,
+    0x02, 0x0a, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x01, 0x02, 0x00, 0x06, 0x12, 0x03, 0x09, 0x0b, 0x1f,
+    0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x01, 0x02, 0x00, 0x01, 0x12, 0x03, 0x09, 0x20, 0x25, 0x0a, 0x0c,
+    0x0a, 0x05, 0x04, 0x01, 0x02, 0x00, 0x03, 0x12, 0x03, 0x09, 0x28, 0x29,
+];
+
+static mut file_descriptor_proto_lazy: ::protobuf::lazy::Lazy<::protobuf::descriptor::FileDescriptorProto> = ::protobuf::lazy::Lazy {
+    lock: ::protobuf::lazy::ONCE_INIT,
+    ptr: 0 as *const ::protobuf::descriptor::FileDescriptorProto,
+};
+
+fn parse_descriptor_proto() -> ::protobuf::descriptor::FileDescriptorProto {
+    ::protobuf::parse_from_bytes(file_descriptor_proto_data).unwrap()
+}
+
+pub fn file_descriptor_proto() -> &'static ::protobuf::descriptor::FileDescriptorProto {
+    unsafe {
+        file_descriptor_proto_lazy.get(|| {
+            parse_descriptor_proto()
+        })
+    }
+}

--- a/components/builder-protocol/src/message/mod.rs
+++ b/components/builder-protocol/src/message/mod.rs
@@ -1,0 +1,9 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
+//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
+
+pub mod jobsrv;
+pub mod net;
+pub mod sessionsrv;

--- a/components/builder-protocol/src/message/net.rs
+++ b/components/builder-protocol/src/message/net.rs
@@ -1,0 +1,343 @@
+// This file is generated. Do not edit
+// @generated
+
+#![allow(dead_code)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+#![allow(non_upper_case_globals)]
+#![allow(unused_imports)]
+
+use protobuf::Message as Message_imported_for_functions;
+use protobuf::ProtobufEnum as ProtobufEnum_imported_for_functions;
+
+#[derive(Clone,Default)]
+pub struct NetError {
+    // message fields
+    code: ::std::option::Option<ErrCode>,
+    msg: ::protobuf::SingularField<::std::string::String>,
+    // special fields
+    unknown_fields: ::protobuf::UnknownFields,
+    cached_size: ::std::cell::Cell<u32>,
+}
+
+// see codegen.rs for the explanation why impl Sync explicitly
+unsafe impl ::std::marker::Sync for NetError {}
+
+impl NetError {
+    pub fn new() -> NetError {
+        ::std::default::Default::default()
+    }
+
+    pub fn default_instance() -> &'static NetError {
+        static mut instance: ::protobuf::lazy::Lazy<NetError> = ::protobuf::lazy::Lazy {
+            lock: ::protobuf::lazy::ONCE_INIT,
+            ptr: 0 as *const NetError,
+        };
+        unsafe {
+            instance.get(|| {
+                NetError {
+                    code: ::std::option::Option::None,
+                    msg: ::protobuf::SingularField::none(),
+                    unknown_fields: ::protobuf::UnknownFields::new(),
+                    cached_size: ::std::cell::Cell::new(0),
+                }
+            })
+        }
+    }
+
+    // required .net.ErrCode code = 1;
+
+    pub fn clear_code(&mut self) {
+        self.code = ::std::option::Option::None;
+    }
+
+    pub fn has_code(&self) -> bool {
+        self.code.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_code(&mut self, v: ErrCode) {
+        self.code = ::std::option::Option::Some(v);
+    }
+
+    pub fn get_code<'a>(&self) -> ErrCode {
+        self.code.unwrap_or(ErrCode::BUG)
+    }
+
+    // required string msg = 2;
+
+    pub fn clear_msg(&mut self) {
+        self.msg.clear();
+    }
+
+    pub fn has_msg(&self) -> bool {
+        self.msg.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_msg(&mut self, v: ::std::string::String) {
+        self.msg = ::protobuf::SingularField::some(v);
+    }
+
+    // Mutable pointer to the field.
+    // If field is not initialized, it is initialized with default value first.
+    pub fn mut_msg<'a>(&'a mut self) -> &'a mut ::std::string::String {
+        if self.msg.is_none() {
+            self.msg.set_default();
+        };
+        self.msg.as_mut().unwrap()
+    }
+
+    // Take field
+    pub fn take_msg(&mut self) -> ::std::string::String {
+        self.msg.take().unwrap_or_else(|| ::std::string::String::new())
+    }
+
+    pub fn get_msg<'a>(&'a self) -> &'a str {
+        match self.msg.as_ref() {
+            Some(v) => &v,
+            None => "",
+        }
+    }
+}
+
+impl ::protobuf::Message for NetError {
+    fn is_initialized(&self) -> bool {
+        if self.code.is_none() {
+            return false;
+        };
+        if self.msg.is_none() {
+            return false;
+        };
+        true
+    }
+
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+        while !try!(is.eof()) {
+            let (field_number, wire_type) = try!(is.read_tag_unpack());
+            match field_number {
+                1 => {
+                    if wire_type != ::protobuf::wire_format::WireTypeVarint {
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                    };
+                    let tmp = try!(is.read_enum());
+                    self.code = ::std::option::Option::Some(tmp);
+                },
+                2 => {
+                    try!(::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.msg));
+                },
+                _ => {
+                    try!(::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields()));
+                },
+            };
+        }
+        ::std::result::Result::Ok(())
+    }
+
+    // Compute sizes of nested messages
+    #[allow(unused_variables)]
+    fn compute_size(&self) -> u32 {
+        let mut my_size = 0;
+        for value in self.code.iter() {
+            my_size += ::protobuf::rt::enum_size(1, *value);
+        };
+        for value in self.msg.iter() {
+            my_size += ::protobuf::rt::string_size(2, &value);
+        };
+        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
+        self.cached_size.set(my_size);
+        my_size
+    }
+
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+        if let Some(v) = self.code {
+            try!(os.write_enum(1, v.value()));
+        };
+        if let Some(v) = self.msg.as_ref() {
+            try!(os.write_string(2, &v));
+        };
+        try!(os.write_unknown_fields(self.get_unknown_fields()));
+        ::std::result::Result::Ok(())
+    }
+
+    fn get_cached_size(&self) -> u32 {
+        self.cached_size.get()
+    }
+
+    fn get_unknown_fields<'s>(&'s self) -> &'s ::protobuf::UnknownFields {
+        &self.unknown_fields
+    }
+
+    fn mut_unknown_fields<'s>(&'s mut self) -> &'s mut ::protobuf::UnknownFields {
+        &mut self.unknown_fields
+    }
+
+    fn type_id(&self) -> ::std::any::TypeId {
+        ::std::any::TypeId::of::<NetError>()
+    }
+
+    fn as_any(&self) -> &::std::any::Any {
+        self as &::std::any::Any
+    }
+
+    fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
+        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+    }
+}
+
+impl ::protobuf::MessageStatic for NetError {
+    fn new() -> NetError {
+        NetError::new()
+    }
+
+    fn descriptor_static(_: ::std::option::Option<NetError>) -> &'static ::protobuf::reflect::MessageDescriptor {
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
+            lock: ::protobuf::lazy::ONCE_INIT,
+            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+        };
+        unsafe {
+            descriptor.get(|| {
+                let mut fields = ::std::vec::Vec::new();
+                fields.push(::protobuf::reflect::accessor::make_singular_enum_accessor(
+                    "code",
+                    NetError::has_code,
+                    NetError::get_code,
+                ));
+                fields.push(::protobuf::reflect::accessor::make_singular_string_accessor(
+                    "msg",
+                    NetError::has_msg,
+                    NetError::get_msg,
+                ));
+                ::protobuf::reflect::MessageDescriptor::new::<NetError>(
+                    "NetError",
+                    fields,
+                    file_descriptor_proto()
+                )
+            })
+        }
+    }
+}
+
+impl ::protobuf::Clear for NetError {
+    fn clear(&mut self) {
+        self.clear_code();
+        self.clear_msg();
+        self.unknown_fields.clear();
+    }
+}
+
+impl ::std::cmp::PartialEq for NetError {
+    fn eq(&self, other: &NetError) -> bool {
+        self.code == other.code &&
+        self.msg == other.msg &&
+        self.unknown_fields == other.unknown_fields
+    }
+}
+
+impl ::std::fmt::Debug for NetError {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        ::protobuf::text_format::fmt(self, f)
+    }
+}
+
+#[derive(Clone,PartialEq,Eq,Debug,Hash)]
+pub enum ErrCode {
+    BUG = 0,
+    TIMEOUT = 1,
+    REMOTE_REJECTED = 2,
+    BAD_REMOTE_REPLY = 3,
+}
+
+impl ::protobuf::ProtobufEnum for ErrCode {
+    fn value(&self) -> i32 {
+        *self as i32
+    }
+
+    fn from_i32(value: i32) -> ::std::option::Option<ErrCode> {
+        match value {
+            0 => ::std::option::Option::Some(ErrCode::BUG),
+            1 => ::std::option::Option::Some(ErrCode::TIMEOUT),
+            2 => ::std::option::Option::Some(ErrCode::REMOTE_REJECTED),
+            3 => ::std::option::Option::Some(ErrCode::BAD_REMOTE_REPLY),
+            _ => ::std::option::Option::None
+        }
+    }
+
+    fn values() -> &'static [Self] {
+        static values: &'static [ErrCode] = &[
+            ErrCode::BUG,
+            ErrCode::TIMEOUT,
+            ErrCode::REMOTE_REJECTED,
+            ErrCode::BAD_REMOTE_REPLY,
+        ];
+        values
+    }
+
+    fn enum_descriptor_static(_: Option<ErrCode>) -> &'static ::protobuf::reflect::EnumDescriptor {
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> = ::protobuf::lazy::Lazy {
+            lock: ::protobuf::lazy::ONCE_INIT,
+            ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
+        };
+        unsafe {
+            descriptor.get(|| {
+                ::protobuf::reflect::EnumDescriptor::new("ErrCode", file_descriptor_proto())
+            })
+        }
+    }
+}
+
+impl ::std::marker::Copy for ErrCode {
+}
+
+static file_descriptor_proto_data: &'static [u8] = &[
+    0x0a, 0x13, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x63, 0x6f, 0x6c, 0x73, 0x2f, 0x6e, 0x65, 0x74, 0x2e,
+    0x70, 0x72, 0x6f, 0x74, 0x6f, 0x12, 0x03, 0x6e, 0x65, 0x74, 0x22, 0x33, 0x0a, 0x08, 0x4e, 0x65,
+    0x74, 0x45, 0x72, 0x72, 0x6f, 0x72, 0x12, 0x1a, 0x0a, 0x04, 0x63, 0x6f, 0x64, 0x65, 0x18, 0x01,
+    0x20, 0x02, 0x28, 0x0e, 0x32, 0x0c, 0x2e, 0x6e, 0x65, 0x74, 0x2e, 0x45, 0x72, 0x72, 0x43, 0x6f,
+    0x64, 0x65, 0x12, 0x0b, 0x0a, 0x03, 0x6d, 0x73, 0x67, 0x18, 0x02, 0x20, 0x02, 0x28, 0x09, 0x2a,
+    0x4a, 0x0a, 0x07, 0x45, 0x72, 0x72, 0x43, 0x6f, 0x64, 0x65, 0x12, 0x07, 0x0a, 0x03, 0x42, 0x55,
+    0x47, 0x10, 0x00, 0x12, 0x0b, 0x0a, 0x07, 0x54, 0x49, 0x4d, 0x45, 0x4f, 0x55, 0x54, 0x10, 0x01,
+    0x12, 0x13, 0x0a, 0x0f, 0x52, 0x45, 0x4d, 0x4f, 0x54, 0x45, 0x5f, 0x52, 0x45, 0x4a, 0x45, 0x43,
+    0x54, 0x45, 0x44, 0x10, 0x02, 0x12, 0x14, 0x0a, 0x10, 0x42, 0x41, 0x44, 0x5f, 0x52, 0x45, 0x4d,
+    0x4f, 0x54, 0x45, 0x5f, 0x52, 0x45, 0x50, 0x4c, 0x59, 0x10, 0x03, 0x4a, 0xf0, 0x02, 0x0a, 0x06,
+    0x12, 0x04, 0x00, 0x00, 0x0c, 0x01, 0x0a, 0x08, 0x0a, 0x01, 0x02, 0x12, 0x03, 0x00, 0x08, 0x0b,
+    0x0a, 0x0a, 0x0a, 0x02, 0x05, 0x00, 0x12, 0x04, 0x02, 0x00, 0x07, 0x01, 0x0a, 0x0a, 0x0a, 0x03,
+    0x05, 0x00, 0x01, 0x12, 0x03, 0x02, 0x05, 0x0c, 0x0a, 0x0b, 0x0a, 0x04, 0x05, 0x00, 0x02, 0x00,
+    0x12, 0x03, 0x03, 0x02, 0x0a, 0x0a, 0x0c, 0x0a, 0x05, 0x05, 0x00, 0x02, 0x00, 0x01, 0x12, 0x03,
+    0x03, 0x02, 0x05, 0x0a, 0x0c, 0x0a, 0x05, 0x05, 0x00, 0x02, 0x00, 0x02, 0x12, 0x03, 0x03, 0x08,
+    0x09, 0x0a, 0x0b, 0x0a, 0x04, 0x05, 0x00, 0x02, 0x01, 0x12, 0x03, 0x04, 0x02, 0x0e, 0x0a, 0x0c,
+    0x0a, 0x05, 0x05, 0x00, 0x02, 0x01, 0x01, 0x12, 0x03, 0x04, 0x02, 0x09, 0x0a, 0x0c, 0x0a, 0x05,
+    0x05, 0x00, 0x02, 0x01, 0x02, 0x12, 0x03, 0x04, 0x0c, 0x0d, 0x0a, 0x0b, 0x0a, 0x04, 0x05, 0x00,
+    0x02, 0x02, 0x12, 0x03, 0x05, 0x02, 0x16, 0x0a, 0x0c, 0x0a, 0x05, 0x05, 0x00, 0x02, 0x02, 0x01,
+    0x12, 0x03, 0x05, 0x02, 0x11, 0x0a, 0x0c, 0x0a, 0x05, 0x05, 0x00, 0x02, 0x02, 0x02, 0x12, 0x03,
+    0x05, 0x14, 0x15, 0x0a, 0x0b, 0x0a, 0x04, 0x05, 0x00, 0x02, 0x03, 0x12, 0x03, 0x06, 0x02, 0x17,
+    0x0a, 0x0c, 0x0a, 0x05, 0x05, 0x00, 0x02, 0x03, 0x01, 0x12, 0x03, 0x06, 0x02, 0x12, 0x0a, 0x0c,
+    0x0a, 0x05, 0x05, 0x00, 0x02, 0x03, 0x02, 0x12, 0x03, 0x06, 0x15, 0x16, 0x0a, 0x0a, 0x0a, 0x02,
+    0x04, 0x00, 0x12, 0x04, 0x09, 0x00, 0x0c, 0x01, 0x0a, 0x0a, 0x0a, 0x03, 0x04, 0x00, 0x01, 0x12,
+    0x03, 0x09, 0x08, 0x10, 0x0a, 0x0b, 0x0a, 0x04, 0x04, 0x00, 0x02, 0x00, 0x12, 0x03, 0x0a, 0x04,
+    0x1e, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x00, 0x02, 0x00, 0x04, 0x12, 0x03, 0x0a, 0x04, 0x0c, 0x0a,
+    0x0c, 0x0a, 0x05, 0x04, 0x00, 0x02, 0x00, 0x06, 0x12, 0x03, 0x0a, 0x0d, 0x14, 0x0a, 0x0c, 0x0a,
+    0x05, 0x04, 0x00, 0x02, 0x00, 0x01, 0x12, 0x03, 0x0a, 0x15, 0x19, 0x0a, 0x0c, 0x0a, 0x05, 0x04,
+    0x00, 0x02, 0x00, 0x03, 0x12, 0x03, 0x0a, 0x1c, 0x1d, 0x0a, 0x0b, 0x0a, 0x04, 0x04, 0x00, 0x02,
+    0x01, 0x12, 0x03, 0x0b, 0x04, 0x1c, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x00, 0x02, 0x01, 0x04, 0x12,
+    0x03, 0x0b, 0x04, 0x0c, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x00, 0x02, 0x01, 0x05, 0x12, 0x03, 0x0b,
+    0x0d, 0x13, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x00, 0x02, 0x01, 0x01, 0x12, 0x03, 0x0b, 0x14, 0x17,
+    0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x00, 0x02, 0x01, 0x03, 0x12, 0x03, 0x0b, 0x1a, 0x1b,
+];
+
+static mut file_descriptor_proto_lazy: ::protobuf::lazy::Lazy<::protobuf::descriptor::FileDescriptorProto> = ::protobuf::lazy::Lazy {
+    lock: ::protobuf::lazy::ONCE_INIT,
+    ptr: 0 as *const ::protobuf::descriptor::FileDescriptorProto,
+};
+
+fn parse_descriptor_proto() -> ::protobuf::descriptor::FileDescriptorProto {
+    ::protobuf::parse_from_bytes(file_descriptor_proto_data).unwrap()
+}
+
+pub fn file_descriptor_proto() -> &'static ::protobuf::descriptor::FileDescriptorProto {
+    unsafe {
+        file_descriptor_proto_lazy.get(|| {
+            parse_descriptor_proto()
+        })
+    }
+}

--- a/components/builder-protocol/src/message/sessionsrv.rs
+++ b/components/builder-protocol/src/message/sessionsrv.rs
@@ -1,0 +1,422 @@
+// This file is generated. Do not edit
+// @generated
+
+#![allow(dead_code)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+#![allow(non_upper_case_globals)]
+#![allow(unused_imports)]
+
+use protobuf::Message as Message_imported_for_functions;
+use protobuf::ProtobufEnum as ProtobufEnum_imported_for_functions;
+
+#[derive(Clone,Default)]
+pub struct GitHubAuth {
+    // message fields
+    code: ::protobuf::SingularField<::std::string::String>,
+    // special fields
+    unknown_fields: ::protobuf::UnknownFields,
+    cached_size: ::std::cell::Cell<u32>,
+}
+
+// see codegen.rs for the explanation why impl Sync explicitly
+unsafe impl ::std::marker::Sync for GitHubAuth {}
+
+impl GitHubAuth {
+    pub fn new() -> GitHubAuth {
+        ::std::default::Default::default()
+    }
+
+    pub fn default_instance() -> &'static GitHubAuth {
+        static mut instance: ::protobuf::lazy::Lazy<GitHubAuth> = ::protobuf::lazy::Lazy {
+            lock: ::protobuf::lazy::ONCE_INIT,
+            ptr: 0 as *const GitHubAuth,
+        };
+        unsafe {
+            instance.get(|| {
+                GitHubAuth {
+                    code: ::protobuf::SingularField::none(),
+                    unknown_fields: ::protobuf::UnknownFields::new(),
+                    cached_size: ::std::cell::Cell::new(0),
+                }
+            })
+        }
+    }
+
+    // required string code = 1;
+
+    pub fn clear_code(&mut self) {
+        self.code.clear();
+    }
+
+    pub fn has_code(&self) -> bool {
+        self.code.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_code(&mut self, v: ::std::string::String) {
+        self.code = ::protobuf::SingularField::some(v);
+    }
+
+    // Mutable pointer to the field.
+    // If field is not initialized, it is initialized with default value first.
+    pub fn mut_code<'a>(&'a mut self) -> &'a mut ::std::string::String {
+        if self.code.is_none() {
+            self.code.set_default();
+        };
+        self.code.as_mut().unwrap()
+    }
+
+    // Take field
+    pub fn take_code(&mut self) -> ::std::string::String {
+        self.code.take().unwrap_or_else(|| ::std::string::String::new())
+    }
+
+    pub fn get_code<'a>(&'a self) -> &'a str {
+        match self.code.as_ref() {
+            Some(v) => &v,
+            None => "",
+        }
+    }
+}
+
+impl ::protobuf::Message for GitHubAuth {
+    fn is_initialized(&self) -> bool {
+        if self.code.is_none() {
+            return false;
+        };
+        true
+    }
+
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+        while !try!(is.eof()) {
+            let (field_number, wire_type) = try!(is.read_tag_unpack());
+            match field_number {
+                1 => {
+                    try!(::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.code));
+                },
+                _ => {
+                    try!(::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields()));
+                },
+            };
+        }
+        ::std::result::Result::Ok(())
+    }
+
+    // Compute sizes of nested messages
+    #[allow(unused_variables)]
+    fn compute_size(&self) -> u32 {
+        let mut my_size = 0;
+        for value in self.code.iter() {
+            my_size += ::protobuf::rt::string_size(1, &value);
+        };
+        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
+        self.cached_size.set(my_size);
+        my_size
+    }
+
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+        if let Some(v) = self.code.as_ref() {
+            try!(os.write_string(1, &v));
+        };
+        try!(os.write_unknown_fields(self.get_unknown_fields()));
+        ::std::result::Result::Ok(())
+    }
+
+    fn get_cached_size(&self) -> u32 {
+        self.cached_size.get()
+    }
+
+    fn get_unknown_fields<'s>(&'s self) -> &'s ::protobuf::UnknownFields {
+        &self.unknown_fields
+    }
+
+    fn mut_unknown_fields<'s>(&'s mut self) -> &'s mut ::protobuf::UnknownFields {
+        &mut self.unknown_fields
+    }
+
+    fn type_id(&self) -> ::std::any::TypeId {
+        ::std::any::TypeId::of::<GitHubAuth>()
+    }
+
+    fn as_any(&self) -> &::std::any::Any {
+        self as &::std::any::Any
+    }
+
+    fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
+        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+    }
+}
+
+impl ::protobuf::MessageStatic for GitHubAuth {
+    fn new() -> GitHubAuth {
+        GitHubAuth::new()
+    }
+
+    fn descriptor_static(_: ::std::option::Option<GitHubAuth>) -> &'static ::protobuf::reflect::MessageDescriptor {
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
+            lock: ::protobuf::lazy::ONCE_INIT,
+            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+        };
+        unsafe {
+            descriptor.get(|| {
+                let mut fields = ::std::vec::Vec::new();
+                fields.push(::protobuf::reflect::accessor::make_singular_string_accessor(
+                    "code",
+                    GitHubAuth::has_code,
+                    GitHubAuth::get_code,
+                ));
+                ::protobuf::reflect::MessageDescriptor::new::<GitHubAuth>(
+                    "GitHubAuth",
+                    fields,
+                    file_descriptor_proto()
+                )
+            })
+        }
+    }
+}
+
+impl ::protobuf::Clear for GitHubAuth {
+    fn clear(&mut self) {
+        self.clear_code();
+        self.unknown_fields.clear();
+    }
+}
+
+impl ::std::cmp::PartialEq for GitHubAuth {
+    fn eq(&self, other: &GitHubAuth) -> bool {
+        self.code == other.code &&
+        self.unknown_fields == other.unknown_fields
+    }
+}
+
+impl ::std::fmt::Debug for GitHubAuth {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        ::protobuf::text_format::fmt(self, f)
+    }
+}
+
+#[derive(Clone,Default)]
+pub struct AuthToken {
+    // message fields
+    token: ::protobuf::SingularField<::std::string::String>,
+    // special fields
+    unknown_fields: ::protobuf::UnknownFields,
+    cached_size: ::std::cell::Cell<u32>,
+}
+
+// see codegen.rs for the explanation why impl Sync explicitly
+unsafe impl ::std::marker::Sync for AuthToken {}
+
+impl AuthToken {
+    pub fn new() -> AuthToken {
+        ::std::default::Default::default()
+    }
+
+    pub fn default_instance() -> &'static AuthToken {
+        static mut instance: ::protobuf::lazy::Lazy<AuthToken> = ::protobuf::lazy::Lazy {
+            lock: ::protobuf::lazy::ONCE_INIT,
+            ptr: 0 as *const AuthToken,
+        };
+        unsafe {
+            instance.get(|| {
+                AuthToken {
+                    token: ::protobuf::SingularField::none(),
+                    unknown_fields: ::protobuf::UnknownFields::new(),
+                    cached_size: ::std::cell::Cell::new(0),
+                }
+            })
+        }
+    }
+
+    // required string token = 1;
+
+    pub fn clear_token(&mut self) {
+        self.token.clear();
+    }
+
+    pub fn has_token(&self) -> bool {
+        self.token.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_token(&mut self, v: ::std::string::String) {
+        self.token = ::protobuf::SingularField::some(v);
+    }
+
+    // Mutable pointer to the field.
+    // If field is not initialized, it is initialized with default value first.
+    pub fn mut_token<'a>(&'a mut self) -> &'a mut ::std::string::String {
+        if self.token.is_none() {
+            self.token.set_default();
+        };
+        self.token.as_mut().unwrap()
+    }
+
+    // Take field
+    pub fn take_token(&mut self) -> ::std::string::String {
+        self.token.take().unwrap_or_else(|| ::std::string::String::new())
+    }
+
+    pub fn get_token<'a>(&'a self) -> &'a str {
+        match self.token.as_ref() {
+            Some(v) => &v,
+            None => "",
+        }
+    }
+}
+
+impl ::protobuf::Message for AuthToken {
+    fn is_initialized(&self) -> bool {
+        if self.token.is_none() {
+            return false;
+        };
+        true
+    }
+
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+        while !try!(is.eof()) {
+            let (field_number, wire_type) = try!(is.read_tag_unpack());
+            match field_number {
+                1 => {
+                    try!(::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.token));
+                },
+                _ => {
+                    try!(::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields()));
+                },
+            };
+        }
+        ::std::result::Result::Ok(())
+    }
+
+    // Compute sizes of nested messages
+    #[allow(unused_variables)]
+    fn compute_size(&self) -> u32 {
+        let mut my_size = 0;
+        for value in self.token.iter() {
+            my_size += ::protobuf::rt::string_size(1, &value);
+        };
+        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
+        self.cached_size.set(my_size);
+        my_size
+    }
+
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+        if let Some(v) = self.token.as_ref() {
+            try!(os.write_string(1, &v));
+        };
+        try!(os.write_unknown_fields(self.get_unknown_fields()));
+        ::std::result::Result::Ok(())
+    }
+
+    fn get_cached_size(&self) -> u32 {
+        self.cached_size.get()
+    }
+
+    fn get_unknown_fields<'s>(&'s self) -> &'s ::protobuf::UnknownFields {
+        &self.unknown_fields
+    }
+
+    fn mut_unknown_fields<'s>(&'s mut self) -> &'s mut ::protobuf::UnknownFields {
+        &mut self.unknown_fields
+    }
+
+    fn type_id(&self) -> ::std::any::TypeId {
+        ::std::any::TypeId::of::<AuthToken>()
+    }
+
+    fn as_any(&self) -> &::std::any::Any {
+        self as &::std::any::Any
+    }
+
+    fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
+        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+    }
+}
+
+impl ::protobuf::MessageStatic for AuthToken {
+    fn new() -> AuthToken {
+        AuthToken::new()
+    }
+
+    fn descriptor_static(_: ::std::option::Option<AuthToken>) -> &'static ::protobuf::reflect::MessageDescriptor {
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
+            lock: ::protobuf::lazy::ONCE_INIT,
+            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+        };
+        unsafe {
+            descriptor.get(|| {
+                let mut fields = ::std::vec::Vec::new();
+                fields.push(::protobuf::reflect::accessor::make_singular_string_accessor(
+                    "token",
+                    AuthToken::has_token,
+                    AuthToken::get_token,
+                ));
+                ::protobuf::reflect::MessageDescriptor::new::<AuthToken>(
+                    "AuthToken",
+                    fields,
+                    file_descriptor_proto()
+                )
+            })
+        }
+    }
+}
+
+impl ::protobuf::Clear for AuthToken {
+    fn clear(&mut self) {
+        self.clear_token();
+        self.unknown_fields.clear();
+    }
+}
+
+impl ::std::cmp::PartialEq for AuthToken {
+    fn eq(&self, other: &AuthToken) -> bool {
+        self.token == other.token &&
+        self.unknown_fields == other.unknown_fields
+    }
+}
+
+impl ::std::fmt::Debug for AuthToken {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        ::protobuf::text_format::fmt(self, f)
+    }
+}
+
+static file_descriptor_proto_data: &'static [u8] = &[
+    0x0a, 0x1a, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x63, 0x6f, 0x6c, 0x73, 0x2f, 0x73, 0x65, 0x73, 0x73,
+    0x69, 0x6f, 0x6e, 0x73, 0x72, 0x76, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x12, 0x0a, 0x73, 0x65,
+    0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73, 0x72, 0x76, 0x22, 0x1a, 0x0a, 0x0a, 0x47, 0x69, 0x74, 0x48,
+    0x75, 0x62, 0x41, 0x75, 0x74, 0x68, 0x12, 0x0c, 0x0a, 0x04, 0x63, 0x6f, 0x64, 0x65, 0x18, 0x01,
+    0x20, 0x02, 0x28, 0x09, 0x22, 0x1a, 0x0a, 0x09, 0x41, 0x75, 0x74, 0x68, 0x54, 0x6f, 0x6b, 0x65,
+    0x6e, 0x12, 0x0d, 0x0a, 0x05, 0x74, 0x6f, 0x6b, 0x65, 0x6e, 0x18, 0x01, 0x20, 0x02, 0x28, 0x09,
+    0x4a, 0xcc, 0x01, 0x0a, 0x06, 0x12, 0x04, 0x00, 0x00, 0x08, 0x01, 0x0a, 0x08, 0x0a, 0x01, 0x02,
+    0x12, 0x03, 0x00, 0x08, 0x12, 0x0a, 0x0a, 0x0a, 0x02, 0x04, 0x00, 0x12, 0x04, 0x02, 0x00, 0x04,
+    0x01, 0x0a, 0x0a, 0x0a, 0x03, 0x04, 0x00, 0x01, 0x12, 0x03, 0x02, 0x08, 0x12, 0x0a, 0x0b, 0x0a,
+    0x04, 0x04, 0x00, 0x02, 0x00, 0x12, 0x03, 0x03, 0x02, 0x1b, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x00,
+    0x02, 0x00, 0x04, 0x12, 0x03, 0x03, 0x02, 0x0a, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x00, 0x02, 0x00,
+    0x05, 0x12, 0x03, 0x03, 0x0b, 0x11, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x00, 0x02, 0x00, 0x01, 0x12,
+    0x03, 0x03, 0x12, 0x16, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x00, 0x02, 0x00, 0x03, 0x12, 0x03, 0x03,
+    0x19, 0x1a, 0x0a, 0x0a, 0x0a, 0x02, 0x04, 0x01, 0x12, 0x04, 0x06, 0x00, 0x08, 0x01, 0x0a, 0x0a,
+    0x0a, 0x03, 0x04, 0x01, 0x01, 0x12, 0x03, 0x06, 0x08, 0x11, 0x0a, 0x0b, 0x0a, 0x04, 0x04, 0x01,
+    0x02, 0x00, 0x12, 0x03, 0x07, 0x02, 0x1c, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x01, 0x02, 0x00, 0x04,
+    0x12, 0x03, 0x07, 0x02, 0x0a, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x01, 0x02, 0x00, 0x05, 0x12, 0x03,
+    0x07, 0x0b, 0x11, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x01, 0x02, 0x00, 0x01, 0x12, 0x03, 0x07, 0x12,
+    0x17, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x01, 0x02, 0x00, 0x03, 0x12, 0x03, 0x07, 0x1a, 0x1b,
+];
+
+static mut file_descriptor_proto_lazy: ::protobuf::lazy::Lazy<::protobuf::descriptor::FileDescriptorProto> = ::protobuf::lazy::Lazy {
+    lock: ::protobuf::lazy::ONCE_INIT,
+    ptr: 0 as *const ::protobuf::descriptor::FileDescriptorProto,
+};
+
+fn parse_descriptor_proto() -> ::protobuf::descriptor::FileDescriptorProto {
+    ::protobuf::parse_from_bytes(file_descriptor_proto_data).unwrap()
+}
+
+pub fn file_descriptor_proto() -> &'static ::protobuf::descriptor::FileDescriptorProto {
+    unsafe {
+        file_descriptor_proto_lazy.get(|| {
+            parse_descriptor_proto()
+        })
+    }
+}

--- a/components/builder-protocol/src/net.rs
+++ b/components/builder-protocol/src/net.rs
@@ -1,0 +1,34 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
+//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
+
+use std::collections::BTreeMap;
+
+use protobuf::core::ProtobufEnum;
+use rustc_serialize::json::{Json, ToJson};
+
+pub use message::net::*;
+
+pub fn err<M: Into<String>>(code: ErrCode, msg: M) -> NetError {
+    let mut err = NetError::new();
+    err.set_code(code);
+    err.set_msg(msg.into());
+    err
+}
+
+impl ToJson for ErrCode {
+    fn to_json(&self) -> Json {
+        Json::U64(self.value() as u64)
+    }
+}
+
+impl ToJson for NetError {
+    fn to_json(&self) -> Json {
+        let mut m = BTreeMap::new();
+        m.insert("code".to_string(), self.get_code().to_json());
+        m.insert("msg".to_string(), self.get_msg().to_json());
+        Json::Object(m)
+    }
+}

--- a/components/builder-protocol/src/sessionsrv.rs
+++ b/components/builder-protocol/src/sessionsrv.rs
@@ -1,0 +1,19 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
+//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
+
+use std::collections::BTreeMap;
+
+use rustc_serialize::json::{Json, ToJson};
+
+pub use message::sessionsrv::*;
+
+impl ToJson for AuthToken {
+    fn to_json(&self) -> Json {
+        let mut m = BTreeMap::new();
+        m.insert("token".to_string(), self.get_token().to_json());
+        Json::Object(m)
+    }
+}

--- a/components/builder-sessionsrv/Cargo.lock
+++ b/components/builder-sessionsrv/Cargo.lock
@@ -1,0 +1,468 @@
+[root]
+name = "habitat_builder_sessionsrv"
+version = "0.1.0"
+dependencies = [
+ "clap 2.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "habitat_builder_protocol 0.1.0",
+ "habitat_net 0.1.0",
+ "hyper 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redis 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zmq 0.7.0 (git+https://github.com/reset/rust-zmq.git?branch=build-rs)",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ansi_term"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "bitflags"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "bitflags"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "byteorder"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "clap"
+version = "2.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ansi_term 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vec_map 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "cookie"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "openssl 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.61 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "gcc"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "gdi32-sys"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "habitat_builder_protocol"
+version = "0.1.0"
+dependencies = [
+ "bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "habitat_net"
+version = "0.1.0"
+dependencies = [
+ "bitflags 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zmq 0.7.0 (git+https://github.com/reset/rust-zmq.git?branch=build-rs)",
+]
+
+[[package]]
+name = "hpack"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "httparse"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "hyper"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cookie 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "httparse 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mime 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solicit 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "traitobject 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicase 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "kernel32-sys"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "language-tags"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "lazy_static"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "libc"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "libressl-pnacl-sys"
+version = "2.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "pnacl-build-helper 1.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "log"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "matches"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "memchr"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "mempool"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "mime"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num_cpus"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "openssl"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc 0.3.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys-extras 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "gdi32-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libressl-pnacl-sys 2.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "user32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "openssl-sys-extras"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "gcc 0.3.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "pnacl-build-helper"
+version = "1.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "tempdir 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "protobuf"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rand"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "redis"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rustc-serialize 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha1 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex"
+version = "0.1.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mempool 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rustc-serialize"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rustc_version"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "semver"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "sha1"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "solicit"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "hpack 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "strsim"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "tempdir"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "time"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "traitobject"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "typeable"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicase"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "unicode-bidi"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "url"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-bidi 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-normalization 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "user32-sys"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "utf8-ranges"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "uuid"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "vec_map"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "zmq"
+version = "0.7.0"
+source = "git+https://github.com/reset/rust-zmq.git?branch=build-rs#edacfbffb8d966a8b5ac1c98eb3a7e29378fa78c"
+dependencies = [
+ "libc 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zmq-sys 0.7.0 (git+https://github.com/reset/rust-zmq.git?branch=build-rs)",
+]
+
+[[package]]
+name = "zmq-sys"
+version = "0.7.0"
+source = "git+https://github.com/reset/rust-zmq.git?branch=build-rs#edacfbffb8d966a8b5ac1c98eb3a7e29378fa78c"
+dependencies = [
+ "libc 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+

--- a/components/builder-sessionsrv/Cargo.toml
+++ b/components/builder-sessionsrv/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "habitat_builder_sessionsrv"
+version = "0.1.0"
+authors = ["Adam Jacob <adam@chef.io>", "Jamie Winsor <reset@chef.io>", "Fletcher Nichol <fnichol@chef.io>", "Joshua Timberman <joshua@chef.io>", "Dave Parfitt <dparfitt@chef.io>"]
+description = "Habitat-Builder Session Server"
+
+[[bin]]
+name = "bldr-session-srv"
+doc = false
+
+[dependencies]
+env_logger = "*"
+hyper = "*"
+log = "*"
+protobuf = "*"
+redis = "*"
+rustc-serialize = "*"
+
+[dependencies.clap]
+version = "*"
+features = [ "suggestions", "color", "unstable" ]
+
+[dependencies.zmq]
+# git = "https://github.com/erickt/rust-zmq.git"
+git = "https://github.com/reset/rust-zmq.git"
+branch = "build-rs"
+
+[dependencies.habitat_builder_protocol]
+path = "../builder-protocol"
+
+[dependencies.habitat_net]
+path = "../net"

--- a/components/builder-sessionsrv/README.md
+++ b/components/builder-sessionsrv/README.md
@@ -1,0 +1,3 @@
+# builder-sessionsrv
+
+Generates, validates, and invalidates authenticated sessions for builder clients

--- a/components/builder-sessionsrv/src/config.rs
+++ b/components/builder-sessionsrv/src/config.rs
@@ -1,0 +1,48 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
+//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
+
+use std::net;
+
+use redis;
+
+pub struct Config {
+    pub port: u16,
+    pub datastore_addr: net::SocketAddrV4,
+    pub worker_count: usize,
+    listen_addr: net::SocketAddrV4,
+}
+
+impl Config {
+    pub fn new() -> Self {
+        Config::default()
+    }
+
+    pub fn fe_addr(&self) -> String {
+        format!("tcp://{}:{}",
+                self.listen_addr.ip(),
+                self.listen_addr.port())
+    }
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Config {
+            port: 9636,
+            listen_addr: net::SocketAddrV4::new(net::Ipv4Addr::new(0, 0, 0, 0), 5560),
+            datastore_addr: net::SocketAddrV4::new(net::Ipv4Addr::new(127, 0, 0, 1), 6379),
+            worker_count: 8,
+        }
+    }
+}
+
+impl<'a> redis::IntoConnectionInfo for &'a Config {
+    fn into_connection_info(self) -> redis::RedisResult<redis::ConnectionInfo> {
+        format!("redis://{}:{}",
+                self.datastore_addr.ip(),
+                self.datastore_addr.port())
+            .into_connection_info()
+    }
+}

--- a/components/builder-sessionsrv/src/data_store.rs
+++ b/components/builder-sessionsrv/src/data_store.rs
@@ -1,0 +1,27 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
+//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
+
+use redis;
+
+use config::Config;
+use error::Result;
+
+pub struct DataStore {
+    conn: Option<redis::Connection>,
+}
+
+impl DataStore {
+    pub fn new() -> Self {
+        DataStore { conn: None }
+    }
+
+    pub fn open(&mut self, config: &Config) -> Result<()> {
+        let client = try!(redis::Client::open(config));
+        let conn = try!(client.get_connection());
+        self.conn = Some(conn);
+        Ok(())
+    }
+}

--- a/components/builder-sessionsrv/src/error.rs
+++ b/components/builder-sessionsrv/src/error.rs
@@ -1,0 +1,93 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
+//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
+
+use std::fmt;
+use std::io;
+use std::result;
+
+use hyper;
+use protobuf;
+use redis;
+use rustc_serialize::json;
+use zmq;
+
+use oauth;
+
+#[derive(Debug)]
+pub enum Error {
+    Auth(oauth::github::AuthErr),
+    BadPort(String),
+    DataStore(redis::RedisError),
+    HTTP(hyper::status::StatusCode),
+    HyperError(hyper::error::Error),
+    IO(io::Error),
+    JsonDecode(json::DecoderError),
+    MissingScope(String),
+    Protobuf(protobuf::ProtobufError),
+    Zmq(zmq::Error),
+}
+
+pub type Result<T> = result::Result<T, Error>;
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let msg = match *self {
+            Error::Auth(ref e) => format!("GitHub Authentication error, {}", e),
+            Error::BadPort(ref e) => format!("{} is an invalid port. Valid range 1-65535.", e),
+            Error::DataStore(ref e) => format!("DataStore error, {}", e),
+            Error::HTTP(ref e) => format!("{}", e),
+            Error::HyperError(ref e) => format!("{}", e),
+            Error::IO(ref e) => format!("{}", e),
+            Error::JsonDecode(ref e) => format!("JSON decoding error, {}", e),
+            Error::MissingScope(ref e) => format!("Missing GitHub permission: {}", e),
+            Error::Protobuf(ref e) => format!("{}", e),
+            Error::Zmq(ref e) => format!("{}", e),
+        };
+        write!(f, "{}", msg)
+    }
+}
+
+impl From<io::Error> for Error {
+    fn from(err: io::Error) -> Self {
+        Error::IO(err)
+    }
+}
+
+impl From<hyper::error::Error> for Error {
+    fn from(err: hyper::error::Error) -> Self {
+        Error::HyperError(err)
+    }
+}
+
+impl From<json::DecoderError> for Error {
+    fn from(err: json::DecoderError) -> Self {
+        Error::JsonDecode(err)
+    }
+}
+
+impl From<oauth::github::AuthErr> for Error {
+    fn from(err: oauth::github::AuthErr) -> Self {
+        Error::Auth(err)
+    }
+}
+
+impl From<protobuf::ProtobufError> for Error {
+    fn from(err: protobuf::ProtobufError) -> Self {
+        Error::Protobuf(err)
+    }
+}
+
+impl From<redis::RedisError> for Error {
+    fn from(err: redis::RedisError) -> Self {
+        Error::DataStore(err)
+    }
+}
+
+impl From<zmq::Error> for Error {
+    fn from(err: zmq::Error) -> Self {
+        Error::Zmq(err)
+    }
+}

--- a/components/builder-sessionsrv/src/lib.rs
+++ b/components/builder-sessionsrv/src/lib.rs
@@ -1,0 +1,25 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
+//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
+
+extern crate habitat_net as hab_net;
+extern crate habitat_builder_protocol as protocol;
+extern crate hyper;
+#[macro_use]
+extern crate log;
+extern crate protobuf;
+extern crate redis;
+extern crate rustc_serialize;
+#[macro_use]
+extern crate zmq;
+
+pub mod config;
+pub mod data_store;
+pub mod error;
+pub mod oauth;
+pub mod server;
+
+pub use self::config::Config;
+pub use self::error::{Error, Result};

--- a/components/builder-sessionsrv/src/main.rs
+++ b/components/builder-sessionsrv/src/main.rs
@@ -1,0 +1,74 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
+//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
+
+#[macro_use]
+extern crate clap;
+extern crate env_logger;
+extern crate habitat_builder_sessionsrv as sessionsrv;
+#[macro_use]
+extern crate log;
+
+use std::process;
+use std::str::FromStr;
+
+use sessionsrv::{Config, Error, Result};
+
+const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+
+fn main() {
+    env_logger::init().unwrap();
+    let matches = app().get_matches();
+    debug!("CLI matches: {:?}", matches);
+    let config = match config_from_args(&matches) {
+        Ok(result) => result,
+        Err(e) => return exit_with(e, 1),
+    };
+    match start(config) {
+        Ok(_) => std::process::exit(0),
+        Err(e) => exit_with(e, 1),
+    }
+}
+
+fn app<'a, 'b>() -> clap::App<'a, 'b> {
+    clap_app!(BuilderSessionSrv =>
+        (version: VERSION)
+        (about: "Manage a Habitat-Builder session server")
+        (@setting VersionlessSubcommands)
+        (@setting SubcommandRequiredElseHelp)
+        (@subcommand start =>
+            (about: "Run a Habitat-Builder session server")
+            (@arg port: --port +takes_value "Listen port. [default: 9637]")
+        )
+    )
+}
+
+fn config_from_args(matches: &clap::ArgMatches) -> Result<Config> {
+    let cmd = matches.subcommand_name().unwrap();
+    let args = matches.subcommand_matches(cmd).unwrap();
+    let mut config = Config::new();
+    if let Some(port) = args.value_of("port") {
+        if let Some(port) = u16::from_str(port).ok() {
+            config.port = port;
+        } else {
+            return Err(Error::BadPort(port.to_string()));
+        }
+    }
+    Ok(config)
+}
+
+fn exit_with(err: Error, code: i32) {
+    println!("{:?}", err);
+    process::exit(code)
+}
+
+/// Starts the builder-sessionsrv server.
+///
+/// # Failures
+///
+/// * Fails if the depot server fails to start - canot bind to the port, etc.
+fn start(config: Config) -> Result<()> {
+    sessionsrv::server::run(config)
+}

--- a/components/builder-sessionsrv/src/oauth/github.rs
+++ b/components/builder-sessionsrv/src/oauth/github.rs
@@ -1,0 +1,85 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
+//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
+
+use std::fmt;
+use std::io::Read;
+
+use hyper;
+use hyper::header::{Accept, qitem};
+use hyper::mime::{Mime, TopLevel, SubLevel};
+use rustc_serialize::json;
+
+use error::{Error, Result};
+
+// JW TODO: do not hardcode these. Make available through configuration file.
+const GH_CLIENT_ID: &'static str = "e98d2a94787be9af9c00";
+const GH_CLIENT_SECRET: &'static str = "e5ff94188e3cf01d42f3e2bcbbe4faabe11c71ba";
+
+#[derive(RustcDecodable, RustcEncodable)]
+pub struct AuthOk {
+    pub access_token: String,
+    pub scope: String,
+    pub token_type: String,
+}
+
+impl AuthOk {
+    pub fn has_scope(&self, grant: &str) -> bool {
+        self.scope.split(",").collect::<Vec<&str>>().iter().any(|&p| p == grant)
+    }
+}
+
+#[derive(RustcDecodable, RustcEncodable, Debug)]
+pub struct AuthErr {
+    pub error: String,
+    pub error_description: String,
+    pub error_uri: String,
+}
+
+impl fmt::Display for AuthErr {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f,
+               "err={}, desc={}, uri={}",
+               self.error,
+               self.error_description,
+               self.error_uri)
+    }
+}
+
+#[derive(RustcDecodable, RustcEncodable)]
+pub enum AuthResp {
+    AuthOk,
+    AuthErr,
+}
+
+pub fn authenticate(code: &str) -> Result<String> {
+    let client = hyper::Client::new();
+    let url = hyper::Url::parse(&format!("https://github.com/login/oauth/access_token?client_id={}&client_secret={}&code={}", GH_CLIENT_ID, GH_CLIENT_SECRET, code)).unwrap();
+    let request = client.post(url)
+                        .header(Accept(vec![qitem(Mime(TopLevel::Application,
+                                                       SubLevel::Json,
+                                                       vec![]))]));
+    let mut response = try!(request.send());
+    if response.status.is_success() {
+        let mut encoded = String::new();
+        try!(response.read_to_string(&mut encoded));
+        match json::decode(&encoded) {
+            Ok(msg @ AuthOk {..}) => {
+                let scope = "user:email".to_string();
+                if msg.has_scope(&scope) {
+                    Ok(msg.access_token)
+                } else {
+                    Err(Error::MissingScope(scope))
+                }
+            }
+            Err(_) => {
+                let err: AuthErr = try!(json::decode(&encoded));
+                Err(Error::from(err))
+            }
+        }
+    } else {
+        Err(Error::HTTP(response.status))
+    }
+}

--- a/components/builder-sessionsrv/src/oauth/mod.rs
+++ b/components/builder-sessionsrv/src/oauth/mod.rs
@@ -1,0 +1,7 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
+//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
+
+pub mod github;

--- a/components/builder-sessionsrv/src/server.rs
+++ b/components/builder-sessionsrv/src/server.rs
@@ -1,0 +1,264 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
+//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
+
+use std::sync::{mpsc, Arc, Mutex};
+use std::time::Duration;
+use std::thread;
+
+use protobuf::{parse_from_bytes, Message};
+use protocol::net::{self, ErrCode};
+use protocol::sessionsrv::{AuthToken, GitHubAuth};
+use zmq;
+
+use config::Config;
+use data_store::DataStore;
+use error::{Error, Result};
+use oauth::github;
+
+const BE_LISTEN_ADDR: &'static str = "inproc://backend";
+
+pub struct Worker {
+    config: Arc<Mutex<Config>>,
+    sock: zmq::Socket,
+    datastore: DataStore,
+}
+
+impl Worker {
+    pub fn new(context: &mut zmq::Context, config: Arc<Mutex<Config>>) -> Result<Self> {
+        let sock = context.socket(zmq::DEALER).unwrap();
+        Ok(Worker {
+            config: config,
+            sock: sock,
+            datastore: DataStore::new(),
+        })
+    }
+
+    fn start(mut self, rz: mpsc::SyncSender<()>) -> Result<()> {
+        loop {
+            {
+                let cfg = self.config.lock().unwrap();
+                match self.datastore.open(&cfg) {
+                    Ok(()) => break,
+                    Err(e) => {
+                        error!("{}", e);
+                        thread::sleep(Duration::from_millis(5000));
+                    }
+                }
+            }
+        }
+        try!(self.sock.connect(BE_LISTEN_ADDR));
+        let mut msg = zmq::Message::new().unwrap();
+        rz.send(()).unwrap();
+        loop {
+            // JW TODO: abstract this out to be more developer friendly
+            // pop client ident
+            let ident = try!(self.sock.recv_msg(0));
+            // pop lq ident
+            let ident2 = try!(self.sock.recv_msg(0));
+            // pop request frame
+            try!(self.sock.recv(&mut msg, 0));
+            // pop message-id
+            try!(self.sock.recv(&mut msg, 0));
+            // send reply
+            //  -> client ident
+            //  -> lq ident
+            //  -> empty rep frame
+            //  -> actual message
+            self.sock.send_msg(ident, zmq::SNDMORE).unwrap();
+            self.sock.send_msg(ident2, zmq::SNDMORE).unwrap();
+            self.sock.send(&[], zmq::SNDMORE).unwrap();
+            match self.dispatch(&msg) {
+                Ok(()) => continue,
+                Err(e) => return Err(e),
+            }
+        }
+    }
+
+    fn dispatch(&mut self, msg: &zmq::Message) -> Result<()> {
+        match msg.as_str() {
+            Some("LOGIN") => {
+                let request = try!(self.sock.recv_msg(0));
+                let req: GitHubAuth = parse_from_bytes(&request).unwrap();
+                match github::authenticate(&req.get_code()) {
+                    Ok(token) => {
+                        let mut reply: AuthToken = AuthToken::new();
+                        reply.set_token(token);
+                        self.sock.send_str("AuthToken", zmq::SNDMORE).unwrap();
+                        self.sock.send(&reply.write_to_bytes().unwrap(), 0).unwrap();
+                    }
+                    Err(Error::Auth(e)) => {
+                        debug!("login failure: {:?}", e);
+                        let reply = net::err(ErrCode::REMOTE_REJECTED, e.error);
+                        self.sock.send_str("NetError", zmq::SNDMORE).unwrap();
+                        self.sock.send(&reply.write_to_bytes().unwrap(), 0).unwrap();
+                    }
+                    Err(e @ Error::JsonDecode(_)) => {
+                        debug!("login failure: {:?}", e);
+                        let reply = net::err(ErrCode::BAD_REMOTE_REPLY, "ss::auth:1");
+                        self.sock.send_str("NetError", zmq::SNDMORE).unwrap();
+                        self.sock.send(&reply.write_to_bytes().unwrap(), 0).unwrap();
+                    }
+                    Err(e) => {
+                        error!("unhandled login failure: {:?}", e);
+                        let reply = net::err(ErrCode::BUG, "ss::auth:0");
+                        self.sock.send_str("NetError", zmq::SNDMORE).unwrap();
+                        self.sock.send(&reply.write_to_bytes().unwrap(), 0).unwrap();
+                    }
+                }
+
+            }
+            _ => panic!("unexpected message: {:?}", msg.as_str()),
+        }
+        Ok(())
+    }
+}
+
+impl Drop for Worker {
+    fn drop(&mut self) {
+        self.sock.close().unwrap();
+    }
+}
+
+pub struct Server {
+    config: Arc<Mutex<Config>>,
+    ctx: Arc<Mutex<zmq::Context>>,
+    fe_sock: zmq::Socket,
+    be_sock: zmq::Socket,
+}
+
+impl Server {
+    pub fn new(config: Config) -> Self {
+        let mut ctx = zmq::Context::new();
+        let fe = ctx.socket(zmq::ROUTER).unwrap();
+        let be = ctx.socket(zmq::DEALER).unwrap();
+        Server {
+            config: Arc::new(Mutex::new(config)),
+            ctx: Arc::new(Mutex::new(ctx)),
+            fe_sock: fe,
+            be_sock: be,
+        }
+    }
+
+    pub fn reconfigure(&self, config: Config) -> Result<()> {
+        {
+            let mut cfg = self.config.lock().unwrap();
+            *cfg = config;
+        }
+        // obtain lock and replace our config
+        // notify datastore to refresh it's connection if it needs to
+        // notify sockets to reconnect if changes
+        Ok(())
+    }
+
+    pub fn run(&mut self) -> Result<()> {
+        {
+            let cfg = self.config.lock().unwrap();
+            try!(self.fe_sock.bind(&cfg.fe_addr()));
+            try!(self.be_sock.bind(BE_LISTEN_ADDR));
+            println!("Listening on ({})", cfg.fe_addr());
+        }
+
+        let ctx = self.ctx.clone();
+        let cfg = self.config.clone();
+        let sup = Supervisor::new(ctx, cfg);
+        try!(sup.start());
+        try!(zmq::proxy(&mut self.fe_sock, &mut self.be_sock));
+        Ok(())
+    }
+}
+
+impl Drop for Server {
+    fn drop(&mut self) {
+        self.fe_sock.close().unwrap();
+        self.be_sock.close().unwrap();
+    }
+}
+
+pub struct Supervisor {
+    context: Arc<Mutex<zmq::Context>>,
+    config: Arc<Mutex<Config>>,
+    workers: Vec<mpsc::Receiver<()>>,
+}
+
+impl Supervisor {
+    pub fn new(ctx: Arc<Mutex<zmq::Context>>, config: Arc<Mutex<Config>>) -> Self {
+        Supervisor {
+            context: ctx,
+            config: config,
+            workers: vec![],
+        }
+    }
+
+    pub fn start(mut self) -> Result<()> {
+        try!(self.init());
+        debug!("Supervisor ready");
+        self.run()
+    }
+
+    fn init(&mut self) -> Result<()> {
+        let count = {
+            self.config.lock().unwrap().worker_count
+        };
+        for _i in 0..count {
+            let rx = try!(self.spawn_worker());
+            self.workers.push(rx);
+        }
+        let mut success = 0;
+        while success != count {
+            match self.workers[success].recv() {
+                Ok(()) => {
+                    debug!("Worker {} ready", success);
+                    success += 1;
+                }
+                Err(_) => debug!("Worker {} failed to start", success),
+            }
+        }
+        Ok(())
+    }
+
+    fn run(mut self) -> Result<()> {
+        thread::spawn(move || {
+            loop {
+                let count = {
+                    self.config.lock().unwrap().worker_count
+                };
+                for i in 0..count {
+                    match self.workers[i].try_recv() {
+                        Err(mpsc::TryRecvError::Disconnected) => {
+                            println!("Worker {} restarting...", i);
+                            let rx = self.spawn_worker().unwrap();
+                            match rx.recv() {
+                                Ok(()) => self.workers[i] = rx,
+                                Err(_) => {
+                                    println!("Worker {} failed restart!", i);
+                                    self.workers.remove(i);
+                                }
+                            }
+                        }
+                        Ok(msg) => println!("Worker {} sent unexpected msg: {:?}", i, msg),
+                        Err(mpsc::TryRecvError::Empty) => continue,
+                    }
+                }
+                thread::sleep(Duration::from_millis(500));
+            }
+        });
+        Ok(())
+    }
+
+    fn spawn_worker(&self) -> Result<mpsc::Receiver<()>> {
+        let cfg = self.config.clone();
+        let (tx, rx) = mpsc::sync_channel(1);
+        let worker = try!(Worker::new(&mut self.context.lock().unwrap(), cfg));
+        thread::spawn(move || {
+            worker.start(tx).unwrap();
+        });
+        Ok(rx)
+    }
+}
+
+pub fn run(config: Config) -> Result<()> {
+    Server::new(config).run()
+}

--- a/components/builder-worker/Cargo.lock
+++ b/components/builder-worker/Cargo.lock
@@ -1,0 +1,155 @@
+[root]
+name = "habitat_builder_worker"
+version = "0.1.0"
+dependencies = [
+ "clap 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "habitat_builder_protocol 0.1.0",
+ "habitat_net 0.1.0",
+ "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ansi_term"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "bitflags"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "clap"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ansi_term 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vec_map 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.58 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "habitat_builder_protocol"
+version = "0.1.0"
+dependencies = [
+ "bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "habitat_net"
+version = "0.1.0"
+dependencies = [
+ "bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zmq 0.7.0 (git+https://github.com/reset/rust-zmq.git?branch=build-rs)",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "log"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "memchr"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "protobuf"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "regex"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rustc-serialize"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "strsim"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "utf8-ranges"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "vec_map"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "zmq"
+version = "0.7.0"
+source = "git+https://github.com/reset/rust-zmq.git?branch=build-rs#edacfbffb8d966a8b5ac1c98eb3a7e29378fa78c"
+dependencies = [
+ "libc 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zmq-sys 0.7.0 (git+https://github.com/reset/rust-zmq.git?branch=build-rs)",
+]
+
+[[package]]
+name = "zmq-sys"
+version = "0.7.0"
+source = "git+https://github.com/reset/rust-zmq.git?branch=build-rs#edacfbffb8d966a8b5ac1c98eb3a7e29378fa78c"
+dependencies = [
+ "libc 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+

--- a/components/builder-worker/Cargo.toml
+++ b/components/builder-worker/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "habitat_builder_worker"
+version = "0.1.0"
+authors = ["Adam Jacob <adam@chef.io>", "Jamie Winsor <reset@chef.io>", "Fletcher Nichol <fnichol@chef.io>", "Joshua Timberman <joshua@chef.io>", "Dave Parfitt <dparfitt@chef.io>"]
+description = "Habitat-Builder Worker"
+
+[[bin]]
+name = "bldr-worker"
+doc = false
+
+[dependencies]
+env_logger = "*"
+log = "*"
+
+[dependencies.clap]
+features = [ "suggestions", "color", "unstable" ]
+
+[dependencies.habitat_net]
+path = "../net"
+
+[dependencies.habitat_builder_protocol]
+path = "../builder-protocol"

--- a/components/builder-worker/README.md
+++ b/components/builder-worker/README.md
@@ -1,0 +1,3 @@
+# builder-worker
+
+Pulls jobs from (n) job servers and executes work

--- a/components/builder-worker/src/config.rs
+++ b/components/builder-worker/src/config.rs
@@ -1,0 +1,23 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
+//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
+
+use std::net;
+
+pub struct Config {
+    pub jobsrv_addr: net::SocketAddrV4,
+}
+
+impl Config {
+    pub fn new() -> Self {
+        Config::default()
+    }
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Config { jobsrv_addr: net::SocketAddrV4::new(net::Ipv4Addr::new(0, 0, 0, 0), 5560) }
+    }
+}

--- a/components/builder-worker/src/error.rs
+++ b/components/builder-worker/src/error.rs
@@ -1,0 +1,31 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
+//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
+
+use std::fmt;
+use std::io;
+use std::result;
+
+#[derive(Debug)]
+pub enum Error {
+    IO(io::Error),
+}
+
+pub type Result<T> = result::Result<T, Error>;
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let msg = match *self {
+            Error::IO(ref e) => format!("{}", e),
+        };
+        write!(f, "{}", msg)
+    }
+}
+
+impl From<io::Error> for Error {
+    fn from(err: io::Error) -> Self {
+        Error::IO(err)
+    }
+}

--- a/components/builder-worker/src/lib.rs
+++ b/components/builder-worker/src/lib.rs
@@ -1,0 +1,14 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
+//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
+
+extern crate habitat_net as hab_net;
+extern crate habitat_builder_protocol as protocol;
+
+pub mod config;
+pub mod error;
+
+pub use self::config::Config;
+pub use self::error::{Error, Result};

--- a/components/builder-worker/src/main.rs
+++ b/components/builder-worker/src/main.rs
@@ -1,0 +1,65 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
+//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
+
+#[macro_use]
+extern crate clap;
+extern crate env_logger;
+extern crate habitat_builder_worker as worker;
+#[macro_use]
+extern crate log;
+
+use std::process;
+
+use worker::{Config, Error, Result};
+
+const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+
+fn main() {
+    env_logger::init().unwrap();
+    let matches = app().get_matches();
+    debug!("CLI matches: {:?}", matches);
+    let config = match config_from_args(&matches) {
+        Ok(result) => result,
+        Err(e) => return exit_with(e, 1),
+    };
+    match start(config) {
+        Ok(_) => std::process::exit(0),
+        Err(e) => exit_with(e, 1),
+    }
+}
+
+fn app<'a, 'b>() -> clap::App<'a, 'b> {
+    clap_app!(BuilderWorker =>
+        (version: VERSION)
+        (about: "Manage a Habitat-Builder worker")
+        (@setting VersionlessSubcommands)
+        (@setting SubcommandRequiredElseHelp)
+        (@subcommand start =>
+            (about: "Run a Habitat-Builder worker")
+        )
+    )
+}
+
+fn config_from_args(matches: &clap::ArgMatches) -> Result<Config> {
+    let cmd = matches.subcommand_name().unwrap();
+    let args = matches.subcommand_matches(cmd).unwrap();
+    let mut config = Config::new();
+    Ok(config)
+}
+
+fn exit_with(err: Error, code: i32) {
+    println!("{:?}", err);
+    process::exit(code)
+}
+
+/// Starts the builder-worker.
+///
+/// # Failures
+///
+/// * Fails if the depot server fails to start - canot bind to the port, etc.
+fn start(config: Config) -> Result<()> {
+    Ok(())
+}

--- a/components/net/Cargo.lock
+++ b/components/net/Cargo.lock
@@ -1,0 +1,56 @@
+[root]
+name = "habitat_net"
+version = "0.1.0"
+dependencies = [
+ "bitflags 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zmq 0.7.0 (git+https://github.com/reset/rust-zmq.git?branch=build-rs)",
+]
+
+[[package]]
+name = "bitflags"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "libc"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "log"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "protobuf"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "zmq"
+version = "0.7.0"
+source = "git+https://github.com/reset/rust-zmq.git?branch=build-rs#edacfbffb8d966a8b5ac1c98eb3a7e29378fa78c"
+dependencies = [
+ "libc 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zmq-sys 0.7.0 (git+https://github.com/reset/rust-zmq.git?branch=build-rs)",
+]
+
+[[package]]
+name = "zmq-sys"
+version = "0.7.0"
+source = "git+https://github.com/reset/rust-zmq.git?branch=build-rs#edacfbffb8d966a8b5ac1c98eb3a7e29378fa78c"
+dependencies = [
+ "libc 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+

--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "habitat_net"
+version = "0.1.0"
+authors = ["Adam Jacob <adam@chef.io>", "Jamie Winsor <reset@chef.io>", "Fletcher Nichol <fnichol@chef.io>", "Joshua Timberman <joshua@chef.io>", "Dave Parfitt <dparfitt@chef.io>"]
+
+[dependencies]
+bitflags = "*"
+protobuf = "*"
+
+[dependencies.zmq]
+# git = "https://github.com/erickt/rust-zmq.git"
+git = "https://github.com/reset/rust-zmq.git"
+branch = "build-rs"

--- a/components/net/src/conn.rs
+++ b/components/net/src/conn.rs
@@ -1,0 +1,88 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
+//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
+
+use protobuf;
+use zmq;
+
+use message::Message;
+use error::Result;
+
+pub trait Conn<T: protobuf::Message> {
+    fn socket(&mut self) -> &mut zmq::Socket;
+
+    fn send(&mut self, msg: &Message<T>) -> Result<()> {
+        let bytes = try!(msg.as_bytes());
+        try!(self.socket().send(&bytes, 0));
+        Ok(())
+    }
+
+    fn send_txn(&mut self, msg: &Message<T>) -> Result<()> {
+        // add transaction bits transactional
+        // * generate transaction id
+        // * set transaction id flags
+        self.send(msg)
+    }
+
+    fn reply(&mut self, txn: u32, msg: &Message<T>) -> Result<()> {
+        // add transaction bits
+        // * set transaction id flag
+        // * set transaction partial flag
+        Ok(())
+    }
+
+    fn reply_complete(&mut self, txn: u32, msg: &Message<T>) -> Result<()> {
+        // add transaction bits
+        // * set transaction id flag
+        Ok(())
+    }
+}
+
+// pub struct Server {
+//     pub config: Config,
+//     ctx: zmq::Context,
+// }
+//
+// impl Server {
+//     pub fn new(config: Config) -> Self {
+//         Server {
+//             config: config,
+//             ctx: zmq::Context::new(),
+//         }
+//     }
+//
+//     pub fn reconfigure(config: Config) -> Result<()> {
+//         Ok(())
+//     }
+//
+//     pub fn run(&mut self) -> Result<()> {
+//         // build request socket?
+//         let mut socket = try!(self.ctx.socket(zmq::REP));
+//         try!(socket.bind("tcp://127.0.0.1:9636"));
+//         let thread = try!(thread::Builder::new()
+//                               .name("server".to_string())
+//                               .spawn(move || Self::recv_loop(&mut socket)));
+//         thread.join().unwrap();
+//         Ok(())
+//     }
+//
+//     fn recv_loop(socket: &mut zmq::Socket) -> Result<()> {
+//         let mut msg = try!(zmq::Message::new());
+//         loop {
+//             try!(socket.recv(&mut msg, 0));
+//             try!(Self::dispatch(socket, &msg));
+//         }
+//     }
+//
+//     fn dispatch(socket: &mut zmq::Socket, msg: &zmq::Message) -> Result<()> {
+//         let mut request: jobsrv::JobCreate = try!(parse_from_bytes(&msg));
+//         println!("Received {:?}", request);
+//         let mut job: jobsrv::Job = jobsrv::Job::new();
+//         job.set_id("fakeid".to_string());
+//         try!(socket.send(&job.write_to_bytes().unwrap(), 0));
+//         Ok(())
+//     }
+// }
+//

--- a/components/net/src/error.rs
+++ b/components/net/src/error.rs
@@ -1,0 +1,38 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
+//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
+
+use std::io;
+use std::result;
+
+use protobuf;
+use zmq;
+
+#[derive(Debug)]
+pub enum Error {
+    IO(io::Error),
+    Protobuf(protobuf::ProtobufError),
+    Zmq(zmq::Error),
+}
+
+pub type Result<T> = result::Result<T, Error>;
+
+impl From<io::Error> for Error {
+    fn from(err: io::Error) -> Error {
+        Error::IO(err)
+    }
+}
+
+impl From<protobuf::ProtobufError> for Error {
+    fn from(err: protobuf::ProtobufError) -> Error {
+        Error::Protobuf(err)
+    }
+}
+
+impl From<zmq::Error> for Error {
+    fn from(err: zmq::Error) -> Error {
+        Error::Zmq(err)
+    }
+}

--- a/components/net/src/lib.rs
+++ b/components/net/src/lib.rs
@@ -1,0 +1,19 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
+//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
+
+#[macro_use]
+extern crate bitflags;
+extern crate protobuf;
+extern crate zmq;
+
+pub mod conn;
+pub mod error;
+pub mod message;
+pub mod server;
+
+pub use self::conn::Conn;
+pub use self::error::{Error, Result};
+pub use self::message::Message;

--- a/components/net/src/message.rs
+++ b/components/net/src/message.rs
@@ -1,0 +1,81 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
+//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
+
+use protobuf;
+
+use error::Result;
+
+bitflags! {
+    flags TransactionFlags: u32 {
+        const TXN_RESPONSE = 0 << 31,
+        const TXN_PARTIAL = 0 << 30,
+        const TXN_ID = 0x3FFFFFFF,
+    }
+}
+
+pub struct Message<T> {
+    pub body: T,
+    flags: TransactionFlags,
+}
+
+impl<T: protobuf::Message> Message<T> {
+    pub fn new(body: T, txn: Option<u32>) -> Self {
+        let flags = if txn.is_some() {
+            match TransactionFlags::from_bits(txn.unwrap()) {
+                Some(bits) => bits,
+                None => panic!("invalid transaction id: {}", txn.unwrap()),
+            }
+        } else {
+            TransactionFlags::empty()
+        };
+        Message {
+            body: body,
+            flags: flags,
+        }
+    }
+
+    pub fn as_bytes(&self) -> Result<Vec<u8>> {
+        let bytes = try!(self.body.write_to_bytes());
+        Ok(bytes)
+    }
+
+    pub fn txn_id(&self) -> Option<u32> {
+        let id = self.flags & TXN_ID;
+        if id.bits > 0 {
+            Some(id.bits)
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_txn_id() {
+        let no_transaction = Message::new("body", None);
+        assert_eq!(no_transaction.txn_id(), None);
+
+        let transactional = Message::new("body", Some(1));
+        assert_eq!(transactional.txn_id(), Some(1));
+
+        let highbound = Message::new("body", Some(1073741823));
+        assert_eq!(highbound.txn_id(), Some(1073741823));
+    }
+
+    #[should_panic]
+    fn txn_id_overflow() {
+        let msg = Message::new("body", Some(1073741824));
+    }
+
+    #[test]
+    fn txn_is_response() {}
+
+    #[test]
+    fn txn_is_partial() {}
+}

--- a/components/net/src/server.rs
+++ b/components/net/src/server.rs
@@ -1,0 +1,38 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
+//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
+
+use zmq;
+
+use error::Result;
+
+pub struct Connector {
+    addr: String,
+    socket_type: zmq::SocketType,
+}
+
+impl Connector {
+    pub fn new(socket_type: zmq::SocketType, addr: &str) -> Self {
+        Connector {
+            addr: addr.to_string(),
+            socket_type: socket_type,
+        }
+    }
+}
+
+pub trait Proxy {
+    fn front_end(&self) -> &Connector;
+    fn back_end(&self) -> &Connector;
+
+    fn start(&self, ctx: &mut zmq::Context) -> Result<()> {
+        let mut fe = try!(ctx.socket(self.front_end().socket_type));
+        let mut be = try!(ctx.socket(self.back_end().socket_type));
+
+        try!(fe.bind(&self.front_end().addr));
+        try!(be.connect(&self.back_end().addr));
+        try!(zmq::proxy(&mut fe, &mut be));
+        Ok(())
+    }
+}

--- a/plans/hab-builder-api/config/app.cfg.toml
+++ b/plans/hab-builder-api/config/app.cfg.toml
@@ -1,0 +1,7 @@
+[http]
+ip = {{cfg.http.ip}}
+port = {{cfg.http.port}}
+
+[sessionsrv]
+ip = {{cfg.sessionsrv.ip}}
+port = {{cfg.sessionsrv.port}}

--- a/plans/hab-builder-api/default.toml
+++ b/plans/hab-builder-api/default.toml
@@ -1,0 +1,7 @@
+[http]
+ip = "127.0.0.1"
+port = 9636
+
+[sessionsrv]
+ip = "127.0.0.1"
+port = 5560

--- a/plans/hab-builder-api/plan.sh
+++ b/plans/hab-builder-api/plan.sh
@@ -1,0 +1,43 @@
+pkg_name=hab-builder-api
+pkg_origin=core
+pkg_version=0.4.0
+pkg_maintainer="Jamie Winsor <reset@chef.io>"
+pkg_license=('apachev2')
+pkg_source=nosuchfile.tar.gz
+pkg_bin_dirs=(bin)
+pkg_deps=(chef/glibc chef/openssl chef/gcc-libs core/zeromq)
+pkg_build_deps=(core/protobuf core/protobuf-rust chef/coreutils chef/cacerts chef/rust chef/gcc chef/pkg-config)
+pkg_service_run="bin/bldr-api ${pkg_svc}/config/app.cfg.toml"
+pkg_gpg_key=3853DA6B
+
+do_build() {
+  pushd $PLAN_CONTEXT/../../components/builder-api > /dev/null
+  cargo clean
+  env OPENSSL_LIB_DIR=$(pkg_path_for chef/openssl)/lib \
+      OPENSSL_INCLUDE_DIR=$(pkg_path_for chef/openssl)/include \
+      SSL_CERT_FILE=$(pkg_path_for chef/cacerts)/ssl/cert.pem \
+      PROTOBUF_PREFIX=$(pkg_path_for core/protobuf) \
+      LIBZMQ_PREFIX=$(pkg_path_for core/zeromq) \
+      cargo build -j$(nproc) --verbose
+  popd > /dev/null
+}
+
+do_install() {
+  install -v -D $PLAN_CONTEXT/../../components/builder-api/target/debug/bldr-api $pkg_prefix/bin/bldr-api
+}
+
+do_download() {
+  return 0
+}
+
+do_verify() {
+  return 0
+}
+
+do_unpack() {
+  return 0
+}
+
+do_prepare() {
+  return 0
+}

--- a/plans/hab-builder-jobsrv/config/app.cfg.toml
+++ b/plans/hab-builder-jobsrv/config/app.cfg.toml
@@ -1,0 +1,7 @@
+[http]
+ip = {{cfg.http.ip}}
+port = {{cfg.http.port}}
+
+[sessionsrv]
+ip = {{cfg.sessionsrv.ip}}
+port = {{cfg.sessionsrv.port}}

--- a/plans/hab-builder-jobsrv/default.toml
+++ b/plans/hab-builder-jobsrv/default.toml
@@ -1,0 +1,7 @@
+[http]
+ip = "127.0.0.1"
+port = 9636
+
+[sessionsrv]
+ip = "127.0.0.1"
+port = 5560

--- a/plans/hab-builder-jobsrv/plan.sh
+++ b/plans/hab-builder-jobsrv/plan.sh
@@ -1,0 +1,43 @@
+pkg_name=hab-builder-jobsrv
+pkg_origin=core
+pkg_version=0.4.0
+pkg_maintainer="Jamie Winsor <reset@chef.io>"
+pkg_license=('apachev2')
+pkg_source=nosuchfile.tar.gz
+pkg_bin_dirs=(bin)
+pkg_deps=(chef/glibc chef/openssl chef/gcc-libs core/zeromq)
+pkg_build_deps=(core/protobuf core/protobuf-rust chef/coreutils chef/cacerts chef/rust chef/gcc chef/pkg-config)
+pkg_service_run="bin/bldr-job-srv ${pkg_svc}/config/app.cfg.toml"
+pkg_gpg_key=3853DA6B
+
+do_build() {
+  pushd $PLAN_CONTEXT/../../components/builder-jobsrv > /dev/null
+  cargo clean
+  env OPENSSL_LIB_DIR=$(pkg_path_for chef/openssl)/lib \
+      OPENSSL_INCLUDE_DIR=$(pkg_path_for chef/openssl)/include \
+      SSL_CERT_FILE=$(pkg_path_for chef/cacerts)/ssl/cert.pem \
+      PROTOBUF_PREFIX=$(pkg_path_for core/protobuf) \
+      LIBZMQ_PREFIX=$(pkg_path_for core/zeromq) \
+      cargo build -j$(nproc) --verbose
+  popd > /dev/null
+}
+
+do_install() {
+  install -v -D $PLAN_CONTEXT/../../components/builder-jobsrv/target/debug/bldr-job-srv $pkg_prefix/bin/bldr-job-srv
+}
+
+do_download() {
+  return 0
+}
+
+do_verify() {
+  return 0
+}
+
+do_unpack() {
+  return 0
+}
+
+do_prepare() {
+  return 0
+}

--- a/plans/hab-builder-sessionsrv/config/app.cfg.toml
+++ b/plans/hab-builder-sessionsrv/config/app.cfg.toml
@@ -1,0 +1,7 @@
+[http]
+ip = {{cfg.http.ip}}
+port = {{cfg.http.port}}
+
+[sessionsrv]
+ip = {{cfg.sessionsrv.ip}}
+port = {{cfg.sessionsrv.port}}

--- a/plans/hab-builder-sessionsrv/default.toml
+++ b/plans/hab-builder-sessionsrv/default.toml
@@ -1,0 +1,7 @@
+[http]
+ip = "127.0.0.1"
+port = 9636
+
+[sessionsrv]
+ip = "127.0.0.1"
+port = 5560

--- a/plans/hab-builder-sessionsrv/plan.sh
+++ b/plans/hab-builder-sessionsrv/plan.sh
@@ -1,0 +1,43 @@
+pkg_name=hab-builder-sessionsrv
+pkg_origin=core
+pkg_version=0.4.0
+pkg_maintainer="Jamie Winsor <reset@chef.io>"
+pkg_license=('apachev2')
+pkg_source=nosuchfile.tar.gz
+pkg_bin_dirs=(bin)
+pkg_deps=(chef/glibc chef/openssl chef/gcc-libs core/zeromq)
+pkg_build_deps=(core/protobuf core/protobuf-rust chef/coreutils chef/cacerts chef/rust chef/gcc chef/pkg-config)
+pkg_service_run="bin/bldr-session-srv ${pkg_svc}/config/app.cfg.toml"
+pkg_gpg_key=3853DA6B
+
+do_build() {
+  pushd $PLAN_CONTEXT/../../components/builder-sessionsrv > /dev/null
+  cargo clean
+  env OPENSSL_LIB_DIR=$(pkg_path_for chef/openssl)/lib \
+      OPENSSL_INCLUDE_DIR=$(pkg_path_for chef/openssl)/include \
+      SSL_CERT_FILE=$(pkg_path_for chef/cacerts)/ssl/cert.pem \
+      PROTOBUF_PREFIX=$(pkg_path_for core/protobuf) \
+      LIBZMQ_PREFIX=$(pkg_path_for core/zeromq) \
+      cargo build -j$(nproc) --verbose
+  popd > /dev/null
+}
+
+do_install() {
+  install -v -D $PLAN_CONTEXT/../../components/builder-sessionsrv/target/debug/bldr-session-srv $pkg_prefix/bin/bldr-session-srv
+}
+
+do_download() {
+  return 0
+}
+
+do_verify() {
+  return 0
+}
+
+do_unpack() {
+  return 0
+}
+
+do_prepare() {
+  return 0
+}

--- a/plans/hab-builder-worker/config/app.cfg.toml
+++ b/plans/hab-builder-worker/config/app.cfg.toml
@@ -1,0 +1,7 @@
+[http]
+ip = {{cfg.http.ip}}
+port = {{cfg.http.port}}
+
+[sessionsrv]
+ip = {{cfg.sessionsrv.ip}}
+port = {{cfg.sessionsrv.port}}

--- a/plans/hab-builder-worker/default.toml
+++ b/plans/hab-builder-worker/default.toml
@@ -1,0 +1,7 @@
+[http]
+ip = "127.0.0.1"
+port = 9636
+
+[sessionsrv]
+ip = "127.0.0.1"
+port = 5560

--- a/plans/hab-builder-worker/plan.sh
+++ b/plans/hab-builder-worker/plan.sh
@@ -1,0 +1,43 @@
+pkg_name=hab-builder-worker
+pkg_origin=core
+pkg_version=0.4.0
+pkg_maintainer="Jamie Winsor <reset@chef.io>"
+pkg_license=('apachev2')
+pkg_source=nosuchfile.tar.gz
+pkg_bin_dirs=(bin)
+pkg_deps=(chef/glibc chef/openssl chef/gcc-libs core/zeromq)
+pkg_build_deps=(core/protobuf core/protobuf-rust chef/coreutils chef/cacerts chef/rust chef/gcc chef/pkg-config)
+pkg_service_run="bin/bldr-worker ${pkg_svc}/config/app.cfg.toml"
+pkg_gpg_key=3853DA6B
+
+do_build() {
+  pushd $PLAN_CONTEXT/../../components/builder-worker > /dev/null
+  cargo clean
+  env OPENSSL_LIB_DIR=$(pkg_path_for chef/openssl)/lib \
+      OPENSSL_INCLUDE_DIR=$(pkg_path_for chef/openssl)/include \
+      SSL_CERT_FILE=$(pkg_path_for chef/cacerts)/ssl/cert.pem \
+      PROTOBUF_PREFIX=$(pkg_path_for core/protobuf) \
+      LIBZMQ_PREFIX=$(pkg_path_for core/zeromq) \
+      cargo build -j$(nproc) --verbose
+  popd > /dev/null
+}
+
+do_install() {
+  install -v -D $PLAN_CONTEXT/../../components/builder-worker/target/debug/bldr-worker $pkg_prefix/bin/bldr-worker
+}
+
+do_download() {
+  return 0
+}
+
+do_verify() {
+  return 0
+}
+
+do_unpack() {
+  return 0
+}
+
+do_prepare() {
+  return 0
+}

--- a/plans/protobuf-rust/plan.sh
+++ b/plans/protobuf-rust/plan.sh
@@ -1,0 +1,35 @@
+pkg_name=protobuf-rust
+pkg_origin=core
+pkg_version=1.0.18
+pkg_license=('BSD')
+pkg_source=nosuchfile.tar.gz
+pkg_gpg_key=3853DA6B
+pkg_bin_dirs=(bin)
+pkg_deps=(chef/glibc chef/gcc)
+pkg_build_deps=(chef/rust chef/gcc chef/cacerts core/protobuf)
+
+do_build() {
+  env SSL_CERT_FILE=$(pkg_path_for chef/cacerts)/ssl/cert.pem \
+      PROTOBUF_PREFIX=$(pkg_path_for core/protobuf) \
+      cargo install protobuf --root $pkg_prefix --vers $pkg_version -j$(nproc) --verbose
+}
+
+do_install() {
+  return 0
+}
+
+do_download() {
+  return 0
+}
+
+do_verify() {
+  return 0
+}
+
+do_unpack() {
+  return 0
+}
+
+do_prepare() {
+  return 0
+}

--- a/plans/protobuf/plan.sh
+++ b/plans/protobuf/plan.sh
@@ -1,0 +1,12 @@
+pkg_name=protobuf
+pkg_origin=core
+pkg_version=2.6.1
+pkg_license=('BSD')
+pkg_source=https://github.com/google/${pkg_name}/releases/download/v${pkg_version}/${pkg_name}-${pkg_version}.tar.bz2
+pkg_shasum=ee445612d544d885ae240ffbcbf9267faa9f593b7b101f21d58beceb92661910
+pkg_gpg_key=3853DA6B
+pkg_deps=(chef/gcc chef/zlib)
+pkg_build_deps=(chef/make)
+pkg_bin_dirs=(bin)
+pkg_lib_dirs=(lib)
+pkg_include_dirs=(include)

--- a/plans/zeromq/plan.sh
+++ b/plans/zeromq/plan.sh
@@ -1,0 +1,20 @@
+pkg_name=zeromq
+pkg_origin=core
+pkg_version=4.1.4
+pkg_license=('LGPL')
+pkg_source=http://download.zeromq.org/${pkg_name}-${pkg_version}.tar.gz
+pkg_shasum=e99f44fde25c2e4cb84ce440f87ca7d3fe3271c2b8cfbc67d55e4de25e6fe378
+pkg_gpg_key=3853DA6B
+pkg_deps=(chef/glibc chef/gcc-libs chef/libsodium)
+pkg_build_deps=(chef/gcc chef/coreutils chef/make chef/pkg-config chef/patchelf)
+pkg_lib_dirs=(lib)
+pkg_include_dirs=(include)
+
+do_prepare() {
+  export PKG_CONFIG_PATH=$(pkg_path_for chef/libsodium)/lib/pkgconfig
+}
+
+do_install() {
+  do_default_install
+  find $pkg_prefix/lib -name *.so | xargs -I '%' patchelf --set-rpath "$LD_RUN_PATH" %
+}

--- a/web/app/actions/gitHub.ts
+++ b/web/app/actions/gitHub.ts
@@ -93,7 +93,7 @@ export function requestGitHubAuthToken(params = {}, stateKey = "") {
                 } else {
                     dispatch(addNotification({
                         title: "Authentication Failed",
-                        body: data["error"],
+                        body: `[err=${data["code"]}] ${data["msg"]}`,
                         type: DANGER,
                     }));
                 }


### PR DESCRIPTION
This is the foundational work for Habitat's Builder service. The current functionality centers around the ability to authentication through GitHub from the web project located at `$root/web` with Builder.

The web project sends an HTTP request to a running builder-api server which is connected to a session server. The HTTP API takes JSON from the web client and forms transactional requests to the session server over a binary protocol defined by `.proto` files in builder-protocol. The messages are sent over zeromq sockets and then serviced by a pool of supervised workers on the session server. Responses are routed back to the appropriate builder-api server and back to the correct requesting client.
- added net crate
- added builder-protocol crate
- added builder-api crate
- added builder-api habitat plan
- added builder-jobsrv crate
- added builder-jobsrv habitat plan
- added builder-sessionsrv crate
- added builder-jobsrv habitat plan
- added builder-worker crate
- added builder-jobsrv habitat plan

The `builder-jobsrv` and `builder-worker` crates can largely be ignored in this PR. They are place holders for future implementation.

![giphy-1](https://cloud.githubusercontent.com/assets/54036/14381699/274f7060-fd3d-11e5-924a-886e5b712ab7.gif)
