### PR TITLE
rename repo to view

### DIFF
--- a/components/depot/src/data_store.rs
+++ b/components/depot/src/data_store.rs
@@ -1449,7 +1449,7 @@ impl Drop for PkgIndex {
     }
 }
 
-/// Contains a mapping of repository names and the packages found within that repository.
+/// Contains a mapping of view names and the packages found within that view.
 ///
 /// This is how packages will be "promoted" between environments without duplicating data on disk.
 pub struct ViewDatabase {

--- a/components/sup/src/lib.rs
+++ b/components/sup/src/lib.rs
@@ -31,8 +31,6 @@
 //!
 //! * [The bldr Command Line Reference](command)
 //! * [The bldr Sidecar; http interface to promises](sidecar)
-//! * [The bldr Depot; http based package repository](depot)
-//!
 
 extern crate habitat_core as hcore;
 extern crate habitat_common as common;


### PR DESCRIPTION
Simple busy work task to standardize all references of "repo" or "repos" in the depot to "view" and "views"

![gif-keyboard-9657620863860048427](https://cloud.githubusercontent.com/assets/54036/14399360/cf393e9c-fda0-11e5-9905-585cee2b74b2.gif)
