### PR TITLE
add a `hab artifact hash <filename>` command

### DIFF
--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -51,6 +51,12 @@ pub fn get() -> App<'static, 'static> {
                 (@arg ARTIFACT: +required {file_exists}
                  "A path to a .hab artifact file (ex: /home/chef-redis-3.0.7-21120102031201.hab)")
             )
+            (@subcommand hash=>
+                (about: "Generate a BLAKE2b hash for a file")
+                (@arg SOURCE : +required {file_exists}
+                 "Any existing file")
+            )
+
         )
         (@subcommand origin =>
             (about: "Runs Habitat origin commands")

--- a/components/hab/src/command/artifact/crypto.rs
+++ b/components/hab/src/command/artifact/crypto.rs
@@ -7,6 +7,18 @@
 use error::{Error, Result};
 use hcore::crypto;
 
+pub fn generate_origin_key(origin_key: &str) -> Result<()> {
+    try!(crypto::generate_origin_sig_key(origin_key));
+    println!("Successfully generated {} origin key", origin_key);
+    Ok(())
+}
+
+pub fn hash(infile: &str) -> Result<()> {
+    let h = try!(crypto::hash_file(infile));
+    println!("{}", h);
+    Ok(())
+}
+
 pub fn sign(origin_key: &str, infile: &str, outfile: &str) -> Result<()> {
 
     let key_pairs = try!(crypto::read_sig_origin_keys(origin_key));
@@ -35,9 +47,3 @@ pub fn verify(infile: &str) -> Result<()> {
     Ok(())
 }
 
-
-pub fn generate_origin_key(origin_key: &str) -> Result<()> {
-    try!(crypto::generate_origin_sig_key(origin_key));
-    println!("Successfully generated {} origin key", origin_key);
-    Ok(())
-}

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -61,6 +61,7 @@ fn run_hab() -> Result<()> {
                 ("upload", Some(m)) => try!(sub_artifact_upload(m)),
                 ("sign", Some(m)) => try!(sub_artifact_sign(m)),
                 ("verify", Some(m)) => try!(sub_artifact_verify(m)),
+                ("hash", Some(m)) => try!(sub_artifact_hash(m)),
                 _ => unreachable!(),
             }
         }
@@ -94,17 +95,9 @@ fn run_hab() -> Result<()> {
     Ok(())
 }
 
-fn sub_artifact_upload(m: &ArgMatches) -> Result<()> {
-    let url = m.value_of("DEPOT_URL").unwrap_or(DEFAULT_DEPOT_URL);
-    let artifact_path = m.value_of("ARTIFACT").unwrap();
-
-    try!(command::artifact::upload::start(&url, &artifact_path));
-    Ok(())
-}
-
-fn sub_origin_key_generate(m: &ArgMatches) -> Result<()> {
-    let origin_key = m.value_of("ORIGIN").unwrap();
-    try!(command::artifact::crypto::generate_origin_key(&origin_key));
+fn sub_artifact_hash(m: &ArgMatches) -> Result<()> {
+    let source = m.value_of("SOURCE").unwrap();
+    try!(command::artifact::crypto::hash(&source));
     Ok(())
 }
 
@@ -125,9 +118,23 @@ fn sub_artifact_sign(m: &ArgMatches) -> Result<()> {
     Ok(())
 }
 
+fn sub_artifact_upload(m: &ArgMatches) -> Result<()> {
+    let url = m.value_of("DEPOT_URL").unwrap_or(DEFAULT_DEPOT_URL);
+    let artifact_path = m.value_of("ARTIFACT").unwrap();
+
+    try!(command::artifact::upload::start(&url, &artifact_path));
+    Ok(())
+}
+
 fn sub_artifact_verify(m: &ArgMatches) -> Result<()> {
     let infile = m.value_of("ARTIFACT").unwrap();
     try!(command::artifact::crypto::verify(&infile));
+    Ok(())
+}
+
+fn sub_origin_key_generate(m: &ArgMatches) -> Result<()> {
+    let origin_key = m.value_of("ORIGIN").unwrap();
+    try!(command::artifact::crypto::generate_origin_key(&origin_key));
     Ok(())
 }
 


### PR DESCRIPTION
- also: alphabetize artifact subcommands in main

```
root@5590f3906ba0:/src/components/hab# ./target/debug/hab artifact hash --help                                hab-artifact-hash
Generate a BLAKE2b hash for a file

USAGE:
    hab artifact hash [FLAGS] <SOURCE>

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

ARGS:
    <SOURCE>    Any existing file
```

```
root@5590f3906ba0:/src/components/hab# ./target/debug/hab artifact hash Cargo.toml
olh8WWxUtErXPkU/ALwQC6Rp7iLjOJA0Ty5AyyuuCsQ=
```
