### PR TITLE
[pkg-dockerize] Split hab-pkg-dockerize out of `hab-studio`.

### DIFF
--- a/components/pkg-dockerize/bin/hab-pkg-dockerize.sh
+++ b/components/pkg-dockerize/bin/hab-pkg-dockerize.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # # Usage
 #
@@ -77,11 +77,6 @@ build_docker_image() {
   rm -rf "$DOCKER_CONTEXT"
 }
 
-pkg_path_for() {
-  local dep="$1"
-  find $BLDR_ROOT/pkgs -mindepth 4 -maxdepth 4 -type d | grep $dep
-}
-
 package_name_for() {
   local pkg="$1"
   echo $(echo $pkg | cut -d "/" -f 2)
@@ -123,9 +118,8 @@ EXPOSE 9631 $(package_exposes $1)
 ENTRYPOINT ["/init.sh"]
 CMD ["start", "$1"]
 EOT
-  local docker="$(pkg_path_for chef/docker)/bin/docker"
-  $docker build --force-rm --no-cache -t $version_tag .
-  $docker tag $version_tag $latest_tag
+  docker build --force-rm --no-cache -t $version_tag .
+  docker tag $version_tag $latest_tag
 }
 
 # The root of the bldr tree. If `BLDR_ROOT` is set, this value is overridden,
@@ -139,6 +133,5 @@ author='@author@'
 # The short version of the program name which is used in logging output
 program=$(basename $0)
 
-hab-bpm install chef/docker
 find_system_commands
 build_docker_image $@

--- a/components/pkg-dockerize/plan.sh
+++ b/components/pkg-dockerize/plan.sh
@@ -1,0 +1,46 @@
+pkg_name=hab-pkg-dockerize
+pkg_origin=chef
+pkg_version=0.1.0
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=('apachev2')
+pkg_source=nosuchfile.tar.gz
+pkg_deps=(chef/coreutils chef/findutils chef/gawk chef/grep chef/bash chef/docker chef/hab-studio)
+pkg_build_deps=()
+pkg_bin_dirs=(bin)
+pkg_gpg_key=3853DA6B
+
+program=$pkg_name
+
+do_build() {
+  cp -v $PLAN_CONTEXT/bin/${program}.sh ${program}
+
+  # Use the bash from our dependency list as the shebang. Also, embed the
+  # release version of the program.
+  sed \
+    -e "s,#!/bin/bash$,#!$(pkg_path_for bash)/bin/bash," \
+    -e "s,@author@,$pkg_maintainer,g" \
+    -e "s,@version@,$pkg_version/$pkg_rel,g" \
+    -i $program
+}
+
+do_install() {
+  install -v -D $program $pkg_prefix/bin/$program
+}
+
+# Turn the remaining default phases into no-ops
+
+do_download() {
+  return 0
+}
+
+do_verify() {
+  return 0
+}
+
+do_unpack() {
+  return 0
+}
+
+do_prepare() {
+  return 0
+}

--- a/components/studio/libexec/hab-studio-type-baseimage.sh
+++ b/components/studio/libexec/hab-studio-type-baseimage.sh
@@ -115,7 +115,7 @@ EOT
   echo "${run_group}:x:42:${run_user}" >> $STUDIO_ROOT/etc/group
 
   local sup=$sup_path/bin/hab-sup
-  touch $STUDIO_ROOT/.hab_pkg
+  $bb touch $STUDIO_ROOT/.hab_pkg
   $bb cat <<EOT > $STUDIO_ROOT/init.sh
 #!$busybox_path/bin/sh
 export PATH=$full_path

--- a/components/studio/libexec/hab-studio-type-default.sh
+++ b/components/studio/libexec/hab-studio-type-default.sh
@@ -44,13 +44,6 @@ exec $BLDR_ROOT/bin/hab-bpm exec chef/hab-plan-build hab-plan-build \$*
 EOF
   $bb chmod $v 755 $STUDIO_ROOT$BLDR_ROOT/bin/build
 
-  # Create a wrapper to dockerize
-  $bb cat <<EOF > $STUDIO_ROOT$BLDR_ROOT/bin/dockerize
-#!$bpm_path/libexec/busybox sh
-exec $BLDR_ROOT/bin/hab-bpm exec chef/hab-studio hab-pkg-dockerize \$*
-EOF
-  $bb chmod $v 755 $STUDIO_ROOT$BLDR_ROOT/bin/dockerize
-
   # Create a wrapper to studio
   $bb cat <<EOF > $STUDIO_ROOT$BLDR_ROOT/bin/studio
 #!$bpm_path/libexec/busybox sh

--- a/components/studio/plan.sh
+++ b/components/studio/plan.sh
@@ -11,7 +11,6 @@ pkg_gpg_key=3853DA6B
 
 do_build() {
   cp -v $PLAN_CONTEXT/bin/hab-studio.sh hab-studio
-  cp -v $PLAN_CONTEXT/bin/hab-pkg-dockerize.sh hab-pkg-dockerize
   cp -v $PLAN_CONTEXT/libexec/hab-studio-type-*.sh .
 
   # Embed the release version and author information of the program.
@@ -19,16 +18,10 @@ do_build() {
     -e "s,@author@,$pkg_maintainer,g" \
     -e "s,@version@,$pkg_version/$pkg_rel,g" \
     -i hab-studio
-
-  sed \
-    -e "s,@author@,$pkg_maintainer,g" \
-    -e "s,@version@,$pkg_version/$pkg_rel,g" \
-    -i hab-pkg-dockerize
 }
 
 do_install() {
   install -v -D hab-studio $pkg_prefix/bin/hab-studio
-  install -v -D hab-pkg-dockerize $pkg_prefix/bin/hab-pkg-dockerize
   for f in `ls hab-studio-type-*.sh`; do
     install -v -D $f $pkg_prefix/libexec/$f
   done


### PR DESCRIPTION
This program has its own dependencies, is only needed some of the time
and can ship in its own package. Additionally, this could end up being a
subcommand of `hab pkg` which could install-on-invoke.

Additionally this fixes an issue where the dockerize command did not execute properly due to missing BusyBox prefix'ing when calling commands.

Ultimately, I'm hoping the reasoning for this will be clear shortly, despite making the command an install away (i.e. `hab-bpm install chef/hab-pkg-dockerize`) and a crazy long (but correct) invocation (i.e. `hab-bpm exec chef/hab-pkg-dockerize hab-pkg-dockerize chef/redis`).
