### PR TITLE
[sup,depot] Fix `dockerize` in functional tests.

### DIFF
--- a/components/depot/tests/support/setup.rs
+++ b/components/depot/tests/support/setup.rs
@@ -44,14 +44,7 @@ pub fn simple_service() {
         if !simple_service.status.unwrap().success() {
             panic!("Failed to build simple service");
         }
-        let mut docker = match super::command::studio_run("dockerize", &["test/simple_service"]) {
-            Ok(cmd) => cmd,
-            Err(e) => panic!("{:?}", e),
-        };
-        docker.wait_with_output();
-        if !docker.status.unwrap().success() {
-            panic!("Failed to dockerize simple service");
-        }
+        dockerize("test/simple_service");
     });
 }
 
@@ -65,4 +58,28 @@ pub fn key_install() {
     };
     cmd.wait_with_output();
     });
+}
+
+fn dockerize(ident_str: &str) {
+    let mut install = match super::command::studio_run("hab-bpm",
+                                                       &["install", "chef/hab-pkg-dockerize"]) {
+        Ok(cmd) => cmd,
+        Err(e) => panic!("{:?}", e),
+    };
+    install.wait_with_output();
+    if !install.status.unwrap().success() {
+        panic!("Failed to install 'chef/hab-pkg-dockerize'");
+    }
+    let mut docker = match super::command::studio_run("hab-bpm",
+                                                      &["exec",
+                                                        "chef/hab-pkg-dockerize",
+                                                        "hab-pkg-dockerize",
+                                                        ident_str]) {
+        Ok(cmd) => cmd,
+        Err(e) => panic!("{:?}", e),
+    };
+    docker.wait_with_output();
+    if !docker.status.unwrap().success() {
+        panic!("Failed to dockerize simple service");
+    }
 }

--- a/components/sup/tests/functional.rs
+++ b/components/sup/tests/functional.rs
@@ -82,15 +82,7 @@ mod setup {
             if !simple_service.status.unwrap().success() {
                 panic!("Failed to build simple service");
             }
-            let mut docker = match util::command::studio_run("dockerize",
-                                                             &["test/simple_service"]) {
-                Ok(cmd) => cmd,
-                Err(e) => panic!("{:?}", e),
-            };
-            docker.wait_with_output();
-            if !docker.status.unwrap().success() {
-                panic!("Failed to dockerize simple service");
-            }
+            util::command::dockerize("test/simple_service");
         });
     }
 
@@ -105,14 +97,7 @@ mod setup {
             if !simple_service.status.unwrap().success() {
                 panic!("Failed to build simple service gossip");
             }
-            let mut docker = match util::command::studio_run("dockerize", &["test/simple_service_gossip"]) {
-                Ok(cmd) => cmd,
-                Err(e) => panic!("{:?}", e),
-            };
-            docker.wait_with_output();
-            if !docker.status.unwrap().success() {
-                panic!("Failed to dockerize simple service gossip");
-            }
+            util::command::dockerize("test/simple_service_gossip");
         });
     }
 
@@ -156,8 +141,6 @@ mod setup {
         cmd.wait_with_output();
         });
     }
-
-
 }
 
 

--- a/components/sup/tests/util/command.rs
+++ b/components/sup/tests/util/command.rs
@@ -201,6 +201,29 @@ pub fn studio_run(cmd: &str, args: &[&str]) -> CmdResult<Cmd> {
     spawn(command)
 }
 
+pub fn dockerize(ident_str: &str) {
+    let mut install = match studio_run("hab-bpm", &["install", "chef/hab-pkg-dockerize"]) {
+        Ok(cmd) => cmd,
+        Err(e) => panic!("{:?}", e),
+    };
+    install.wait_with_output();
+    if !install.status.unwrap().success() {
+        panic!("Failed to install 'chef/hab-pkg-dockerize'");
+    }
+    let mut docker = match studio_run("hab-bpm",
+                                      &["exec",
+                                        "chef/hab-pkg-dockerize",
+                                        "hab-pkg-dockerize",
+                                        ident_str]) {
+        Ok(cmd) => cmd,
+        Err(e) => panic!("{:?}", e),
+    };
+    docker.wait_with_output();
+    if !docker.status.unwrap().success() {
+        panic!("Failed to dockerize simple service");
+    }
+}
+
 pub fn run(cmd: &str, args: &[&str]) -> CmdResult<Cmd> {
     let command = command(cmd, args);
     spawn(command)


### PR DESCRIPTION
This change restores the `dockerize` functionality in the Depot and Supervisor components.
