### PR TITLE
Don't redirect to /pkgs every time; fix layout

### DIFF
--- a/web/app/actions/gitHub.ts
+++ b/web/app/actions/gitHub.ts
@@ -21,6 +21,7 @@ export const SET_GITHUB_AUTH_STATE = "SET_GITHUB_AUTH_STATE";
 export const SET_SELECTED_GITHUB_ORG = "SET_SELECTED_GITHUB_ORG";
 
 export function authenticateWithGitHub(token = undefined) {
+    const wasInitializedWithToken = !!token;
     token = token || sessionStorage.getItem("gitHubAuthToken");
 
     return dispatch => {
@@ -40,7 +41,11 @@ export function authenticateWithGitHub(token = undefined) {
                 dispatch(setCurrentOrigin({ name: data["login"]}));
                 dispatch(populateGitHubUserData(data));
                 dispatch(attemptSignIn(data["login"]));
-                dispatch(goHome());
+
+                // If we started off with a token, that means we're in the
+                // process of signing in and should be redirected home. If not,
+                // it means we don't need to redirect
+                if (wasInitializedWithToken) { dispatch(goHome()); }
             });
         }
     };

--- a/web/app/side-nav/_side-nav.scss
+++ b/web/app/side-nav/_side-nav.scss
@@ -5,7 +5,7 @@
 // the Software until such time that the Software is made available under an
 // open source license such as the Apache 2.0 License.
 
-i.hab-side-nav {
+.hab-side-nav {
   @include span-columns(2);
 
   .switcher {


### PR DESCRIPTION
This was happening because we were asking to `goHome()` whenever sign-in
happened, even when it wasn't supposed to.

I also inserted a stray `i` (thanks, Vim) when fixing the copyright messages,
which messed up the layout. This has been removed.
