### PR TITLE
rename CLI flags to remove "gossip"

### DIFF
--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -113,15 +113,15 @@ fn config_from_args(args: &ArgMatches, subcommand: &str, sub_args: &ArgMatches) 
                                            .to_string_lossy()
                                            .as_ref())
                             .to_string());
-    config.set_gossip_listen(sub_args.value_of("gossip-listen")
+    config.set_gossip_listen(sub_args.value_of("listen-peer")
                                      .unwrap_or(DEFAULT_GOSSIP_LISTEN)
                                      .to_string());
-    let gossip_peers = match sub_args.values_of("gossip-peer") {
+    let gossip_peers = match sub_args.values_of("peer") {
         Some(gp) => gp.map(|s| s.to_string()).collect(),
         None => vec![],
     };
     config.set_gossip_peer(gossip_peers);
-    if sub_args.value_of("gossip-permanent").is_some() {
+    if sub_args.value_of("permanent-peer").is_some() {
         config.set_gossip_permanent(true);
     }
     if let Some(sg) = sub_args.value_of("service-group") {
@@ -194,19 +194,19 @@ fn main() {
                                  .value_name("watch")
                                  .multiple(true)
                                  .help("One or more service groups to watch for updates"))
-                        .arg(Arg::with_name("gossip-peer")
-                                 .long("gossip-peer")
+                        .arg(Arg::with_name("peer")
+                                 .long("peer")
                                  .value_name("ip:port")
                                  .multiple(true)
-                                 .help("The listen string of an initial gossip peer"))
-                        .arg(Arg::with_name("gossip-listen")
-                                 .long("gossip-listen")
+                                 .help("The listen address of an initial peer"))
+                        .arg(Arg::with_name("listen-peer")
+                                 .long("listen-peer")
                                  .value_name("ip:port")
-                                 .help("The listen string for gossip [default: 0.0.0.0:9634]"))
-                        .arg(Arg::with_name("gossip-permanant")
+                                 .help("The listen address [default: 0.0.0.0:9634]"))
+                        .arg(Arg::with_name("permanent-peer")
                                  .short("I")
-                                 .long("gossip-permanent")
-                                 .help("If this service is a permanent gossip peer"));
+                                 .long("permanent-peer")
+                                 .help("If this service is a permanent peer"));
     let sub_sh = SubCommand::with_name("sh").about("Start an interactive shell");
     let sub_config = SubCommand::with_name("config")
                          .about("Print the default.toml for a given package")

--- a/components/sup/tests/util/docker.rs
+++ b/components/sup/tests/util/docker.rs
@@ -72,7 +72,7 @@ pub fn run_with_peer(image: &str, peer: &str) -> Docker {
                  image,
                  "start",
                  image,
-                 &format!("--gossip-peer={}", peer),
+                 &format!("--peer={}", peer),
                  &format!("--group={}", thread::current().name().unwrap_or("main"))])
 }
 
@@ -83,9 +83,9 @@ pub fn run_with_peer_permanent(image: &str, peer: &str) -> Docker {
                  image,
                  "start",
                  image,
-                 &format!("--gossip-peer={}", peer),
+                 &format!("--peer={}", peer),
                  &format!("--group={}", thread::current().name().unwrap_or("main")),
-                 &format!("--gossip-permanent")])
+                 &format!("--permanent-peer")])
 }
 
 pub fn run_with_permanent(image: &str) -> Docker {
@@ -96,7 +96,7 @@ pub fn run_with_permanent(image: &str) -> Docker {
                  "start",
                  image,
                  &format!("--group={}", thread::current().name().unwrap_or("main")),
-                 &format!("--gossip-permanent")])
+                 &format!("--permanent-peer")])
 }
 
 pub fn run_with_peer_topology(image: &str, peer: &str, topology: &str) -> Docker {
@@ -107,7 +107,7 @@ pub fn run_with_peer_topology(image: &str, peer: &str, topology: &str) -> Docker
                  "start",
                  image,
                  &format!("--topology={}", topology),
-                 &format!("--gossip-peer={}", peer),
+                 &format!("--peer={}", peer),
                  &format!("--group={}", thread::current().name().unwrap_or("main"))])
 }
 
@@ -119,9 +119,9 @@ pub fn run_with_peer_permanent_topology(image: &str, peer: &str, topology: &str)
                  "start",
                  image,
                  &format!("--topology={}", topology),
-                 &format!("--gossip-peer={}", peer),
+                 &format!("--peer={}", peer),
                  &format!("--group={}", thread::current().name().unwrap_or("main")),
-                 &format!("--gossip-permanent")])
+                 &format!("--permanent-peer")])
 }
 
 pub fn run_with_permanent_topology(image: &str, topology: &str) -> Docker {
@@ -133,7 +133,7 @@ pub fn run_with_permanent_topology(image: &str, topology: &str) -> Docker {
                  image,
                  &format!("--topology={}", topology),
                  &format!("--group={}", thread::current().name().unwrap_or("main")),
-                 &format!("--gossip-permanent")])
+                 &format!("--permanent-peer")])
 }
 
 


### PR DESCRIPTION
`--gossip-peer` becomes `--peer`
`--gossip-permanent` becomes `--permanent-peer`
`--gossip-listener` becomes `--listen-peer`
- I can't start anything right now because of package craziness.

```
root@6d04a94e47b6:/src/components/sup# ./target/debug/hab-sup start --help
hab-sup-start
Start a Habitat-supervised service from a package

USAGE:
    hab-sup start [FLAGS] [OPTIONS] <package>

FLAGS:
    -h, --help              Prints help information
        --no-color          Turn ANSI color off :(
    -I, --permanent-peer    If this service is a permanent peer
    -v                      Verbose output; shows line numbers

OPTIONS:
        --group <group>            The service group; shared config and topology [default: default].
        --listen-peer <ip:port>    The listen string [default: 0.0.0.0:9634]
        --peer <ip:port>...        The listen string of an initial peer
    -s, --strategy <strategy>      The update strategy; [default: none]. [values: none, at-once]
    -t, --topology <topology>      Service topology
    -u, --url <url>                Use the specified package depot url
        --watch <watch>...         One or more service groups to watch for updates

ARGS:
    <package>    Name of package to start
```
