### PR TITLE
don't use our email in the plan template

### DIFF
--- a/plans/plan-tmpl.sh
+++ b/plans/plan-tmpl.sh
@@ -1,8 +1,7 @@
-# Template plan.sh
 pkg_origin=core
 pkg_name=PACKAGE
 pkg_version=0.0.1
-pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_maintainer="You <humans@example.com>"
 pkg_license=()
 pkg_source=http://example.com/${pkg_name}-${pkg_version}.tar.xz
 pkg_shasum=sha256sum


### PR DESCRIPTION
- don't default a Chef email address as the maintainer on new plans 
- the comment `# Template plan.sh` shows up in new templates. ([it even shows up in the docs](https://www-acceptance.habitat.sh/tutorials/getting-started-create-plan/))
