### PR TITLE
Fix redirection on page load bug

### DIFF
--- a/web/app/AppComponent.ts
+++ b/web/app/AppComponent.ts
@@ -23,9 +23,9 @@ import {RouteConfig, Router, RouterOutlet} from "angular2/router";
 import {SCMReposPageComponent} from "./scm-repos-page/SCMReposPageComponent";
 import {SideNavComponent} from "./side-nav/SideNavComponent";
 import {SignInPageComponent} from "./sign-in-page/SignInPageComponent";
-import {authenticateWithGitHub, fetchMyOrigins, removeNotification, routeChange,
-    setCurrentOrigin, signOut, toggleOriginPicker, toggleUserNavMenu}
-    from "./actions/index";
+import {authenticateWithGitHub, fetchMyOrigins, loadSessionState,
+    removeNotification, routeChange, setCurrentOrigin, signOut,
+    toggleOriginPicker, toggleUserNavMenu} from "./actions/index";
 
 @Component({
     directives: [HeaderComponent, NotificationsComponent, RouterOutlet, SideNavComponent],
@@ -209,8 +209,13 @@ export class AppComponent implements OnInit {
     get user() { return this.state.users.current; }
 
     ngOnInit() {
+        // Load up the session state from sessionStorage when we load the page
+        this.store.dispatch(loadSessionState(sessionStorage));
+
         // When the page loads attempt to authenticate with GitHub. If there
         // is no token stored in session storage, this won't do anything.
-        this.store.dispatch(authenticateWithGitHub());
+        this.store.dispatch(
+            authenticateWithGitHub(this.state.gitHub.authToken)
+        );
     }
 }

--- a/web/app/actions/index.ts
+++ b/web/app/actions/index.ts
@@ -15,6 +15,7 @@ import * as routerActions from "./router";
 import * as usersActions from "./users";
 
 // Action types
+export const LOAD_SESSION_STATE = gitHubActions.LOAD_SESSION_STATE;
 export const POPULATE_GITHUB_ORGS = gitHubActions.POPULATE_GITHUB_ORGS;
 export const POPULATE_GITHUB_REPOS = gitHubActions.POPULATE_GITHUB_REPOS;
 export const POPULATE_GITHUB_USER_DATA = gitHubActions.POPULATE_GITHUB_USER_DATA;
@@ -25,6 +26,7 @@ export const SET_GITHUB_ORGS_LOADING_FLAG =
 export const SET_GITHUB_REPOS_LOADING_FLAG =
     gitHubActions.SET_GITHUB_REPOS_LOADING_FLAG;
 export const SET_GITHUB_AUTH_STATE = gitHubActions.SET_GITHUB_AUTH_STATE;
+export const SET_GITHUB_AUTH_TOKEN = gitHubActions.SET_GITHUB_AUTH_TOKEN;
 export const SET_SELECTED_GITHUB_ORG = gitHubActions.SET_SELECTED_GITHUB_ORG;
 
 export const ADD_NOTIFICATION = notificationActions.ADD_NOTIFICATION;
@@ -70,8 +72,10 @@ export const RESET = "RESET";
 export const authenticateWithGitHub = gitHubActions.authenticateWithGitHub;
 export const fetchGitHubOrgs = gitHubActions.fetchGitHubOrgs;
 export const fetchGitHubRepos = gitHubActions.fetchGitHubRepos;
+export const loadSessionState = gitHubActions.loadSessionState;
 export const onGitHubOrgSelect = gitHubActions.onGitHubOrgSelect;
 export const onGitHubRepoSelect = gitHubActions.onGitHubRepoSelect;
+export const removeSessionStorage = gitHubActions.removeSessionStorage;
 export const requestGitHubAuthToken = gitHubActions.requestGitHubAuthToken;
 export const setGitHubAuthState = gitHubActions.setGitHubAuthState;
 export const setSelectedGitHubOrg = gitHubActions.setSelectedGitHubOrg;

--- a/web/app/actions/users.ts
+++ b/web/app/actions/users.ts
@@ -5,7 +5,7 @@
 // the Software until such time that the Software is made available under an
 // open source license such as the Apache 2.0 License.
 
-import {requestRoute, resetAppState} from "./index";
+import {requestRoute, removeSessionStorage, resetAppState} from "./index";
 
 export const SET_SIGNING_IN_FLAG = "SET_SIGNING_IN_FLAG";
 export const SIGN_IN_ATTEMPT = "SIGN_IN_ATTEMPT";
@@ -32,9 +32,8 @@ export function toggleUserNavMenu() {
 }
 
 export function signOut() {
-    sessionStorage.removeItem("gitHubAuthToken");
-
     return dispatch => {
+        dispatch(removeSessionStorage());
         dispatch(resetAppState());
         dispatch(requestRoute(["SignIn"]));
     };

--- a/web/app/initialState.ts
+++ b/web/app/initialState.ts
@@ -14,6 +14,7 @@ export default Record({
     })(),
     gitHub: Record({
         authState: undefined,
+        authToken: undefined,
         orgs: List(),
         repos: List(),
         selectedOrg: undefined,

--- a/web/app/reducers/gitHub.ts
+++ b/web/app/reducers/gitHub.ts
@@ -11,6 +11,10 @@ import initialState from "../initialState";
 
 export default function gitHub(state = initialState["gitHub"], action) {
     switch (action.type) {
+        case actionTypes.LOAD_SESSION_STATE:
+            return state.set("authState", action.payload.gitHubAuthState).
+                set("authToken", action.payload.gitHubAuthToken);
+
         case actionTypes.POPULATE_GITHUB_ORGS:
             return state.set("orgs",
                 state.get("orgs").concat(fromJS(action.payload)).
@@ -31,6 +35,9 @@ export default function gitHub(state = initialState["gitHub"], action) {
 
         case actionTypes.SET_GITHUB_AUTH_STATE:
             return state.set("authState", action.payload);
+
+        case actionTypes.SET_GITHUB_AUTH_TOKEN:
+            return state.set("authToken", action.payload);
 
         case actionTypes.SET_GITHUB_ORGS_LOADING_FLAG:
             return state.setIn(["ui", "orgs", "loading"], action.payload);

--- a/web/app/sign-in-page/SignInPageComponent.ts
+++ b/web/app/sign-in-page/SignInPageComponent.ts
@@ -6,9 +6,9 @@
 // open source license such as the Apache 2.0 License.
 
 import {Component, OnInit} from "angular2/core";
-import {RouteParams, RouterLink, Router} from "angular2/router";
+import {RouteParams, RouterLink} from "angular2/router";
 import {AppStore} from "../AppStore";
-import {attemptSignIn, goHome, requestGitHubAuthToken, setGitHubAuthState} from
+import {requestGitHubAuthToken, setGitHubAuthState, signOut} from
     "../actions/index";
 import config from "../config";
 import {createGitHubLoginUrl, icon} from "../util";
@@ -23,15 +23,24 @@ import {createGitHubLoginUrl, icon} from "../util";
         <div class="main">
             <div class="button-area">
                 <hr>
-                <a [class.disabled]="isSigningIn"
+                <a [class.disabled]="isSigningIn || isSignedIn"
                    class="button" href="{{gitHubLoginUrl}}">
                     <i class="octicon octicon-mark-github"></i>
                     <span *ngIf="isSigningIn">
                         Signing In&hellip;
                     </span>
-                    <span *ngIf="!isSigningIn">
+                    <span *ngIf="!isSignedIn && !isSigningIn">
                         Sign In with GitHub
                     </span>
+                    <span *ngIf="isSignedIn && !isSigningIn">
+                        Signed In with GitHub
+                    </span>
+                </a>
+                <a *ngIf="isSignedIn"
+                   class="button secondary hab-sign-in--out"
+                   (click)="signOut()"
+                   href="#">
+                   Sign Out
                 </a>
                 <hr>
             </div>
@@ -76,6 +85,10 @@ export class SignInPageComponent implements OnInit {
         return createGitHubLoginUrl(this.store.getState().gitHub.authState);
     }
 
+    get isSignedIn() {
+        return this.store.getState().users.current.isSignedIn;
+    }
+
     get isSigningIn() {
         return this.store.getState().users.current.isSigningIn;
     }
@@ -83,16 +96,16 @@ export class SignInPageComponent implements OnInit {
     get sourceCodeUrl() { return config["source_code_url"]; }
 
     ngOnInit() {
-        if (this.store.getState().users.current.isSignedIn) {
-            this.store.dispatch(goHome());
-        } else {
-            this.store.dispatch(setGitHubAuthState());
-            this.store.dispatch(requestGitHubAuthToken(
-                this.routeParams.params,
-                this.store.getState().gitHub.authState
-            ));
-        }
+        this.store.dispatch(setGitHubAuthState());
+        this.store.dispatch(requestGitHubAuthToken(
+            this.routeParams.params,
+            this.store.getState().gitHub.authState
+        ));
     }
 
     private icon(name) { return icon(name); }
+
+    private signOut() {
+        this.store.dispatch(signOut());
+    }
 }

--- a/web/app/sign-in-page/_sign-in-page.scss
+++ b/web/app/sign-in-page/_sign-in-page.scss
@@ -5,11 +5,19 @@
 // the Software until such time that the Software is made available under an
 // open source license such as the Apache 2.0 License.
 
-.hab-sign-in .main {
-  @include span-columns(6);
-  @include shift(3);
+.hab-sign-in {
+  .main {
+    @include span-columns(6);
+    @include shift(3);
 
-  .button-area {
-    text-align: center;
+    .button-area {
+      text-align: center;
+    }
   }
+}
+
+a.hab-sign-in--out {
+  display: block;
+  margin: $small-spacing / 2 auto;
+  width: 49%;
 }

--- a/web/app/util.ts
+++ b/web/app/util.ts
@@ -58,15 +58,12 @@ export function packageString(o = {}) {
 export function requireSignIn(pageComponent) {
     const store = pageComponent.store;
     const state = store.getState();
-    const user = state.users.current;
-    const isSigningIn = user.isSigningIn;
-    const isSignedIn = user.isSignedIn;
+    const hasToken = !!state.gitHub.authToken;
     const currentOrigin = state.origins.current.name;
 
-    if (!isSigningIn ) {
-        if (!isSignedIn) { store.dispatch(requestRoute(["SignIn"])); }
-        if (isSignedIn && !currentOrigin) {
-            store.dispatch(requestRoute(["OriginCreate"]));
-        }
+    if (!hasToken) { store.dispatch(requestRoute(["SignIn"])); }
+
+    if (hasToken && !currentOrigin) {
+        store.dispatch(requestRoute(["OriginCreate"]));
     }
 }

--- a/web/stylesheets/base/_buttons.scss
+++ b/web/stylesheets/base/_buttons.scss
@@ -57,6 +57,15 @@
     }
   }
 
+  &.secondary {
+    background-color: $medium-gray;
+
+    &:focus,
+    &:hover {
+      background-color: shade($medium-gray, 20%);
+    }
+  }
+
   &.small {
     font-size: 50%;
   }


### PR DESCRIPTION
Make it so when you load the page, instead of checking for isSignedIn
(which will always be false on initial page load, since we're not
finished authenticating yet at that point), check for the presence of a
token in session storage.

Also simplify some of the token handling and put a sign out button on
the sign in page when signed in instead of insisting on redirecting away
from it.

![gif-keyboard-12569471633754029118](https://cloud.githubusercontent.com/assets/9912/14662278/3fd8909e-067a-11e6-9216-487f0b4a8323.gif)
