### PR TITLE
[hab] Update `hab rumor inject` to `hab config apply`.

### DIFF
--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -14,9 +14,9 @@ use url::Url;
 const VERSION: &'static str = env!("CARGO_PKG_VERSION");
 
 pub fn get() -> App<'static, 'static> {
-    let alias_inject = sub_rumor_inject()
-                           .about("Alias for 'rumor inject'")
-                           .setting(AppSettings::Hidden);
+    let alias_apply = sub_config_apply()
+                          .about("Alias for 'config apply'")
+                          .setting(AppSettings::Hidden);
     let alias_install = sub_package_install()
                             .about("Alias for 'pkg install'")
                             .setting(AppSettings::Hidden);
@@ -57,6 +57,11 @@ pub fn get() -> App<'static, 'static> {
                  "A path to any local file")
             )
 
+        )
+        (@subcommand config =>
+            (about: "Commands relating to Habitat runtime config")
+            (@setting ArgRequiredElseHelp)
+            (subcommand: sub_config_apply())
         )
         (@subcommand origin =>
             (about: "Commands relating to Habitat origin keys")
@@ -100,20 +105,15 @@ pub fn get() -> App<'static, 'static> {
             (@setting ArgRequiredElseHelp)
             (subcommand: sub_package_install())
         )
-        (@subcommand rumor =>
-            (about: "Commands relating to Habitat rumors")
-            (@setting ArgRequiredElseHelp)
-            (subcommand: sub_rumor_inject())
-        )
         (@subcommand sup =>
             (about: "Commands relating to the Habitat Supervisor")
         )
 
-        (subcommand: alias_inject)
+        (subcommand: alias_apply)
         (subcommand: alias_install)
         (subcommand: alias_start())
         (after_help: "ALIASES:\
-             \n    inject      Alias for: 'rumor inject'\
+             \n    apply       Alias for: 'config apply'\
              \n    install     Alias for: 'pkg install'\
              \n    start       Alias for: 'sup start'\
              \n"
@@ -132,9 +132,9 @@ fn sub_package_install() -> App<'static, 'static> {
 }
 
 #[cfg_attr(rustfmt, rustfmt_skip)]
-fn sub_rumor_inject() -> App<'static, 'static> {
-    clap_app!(@subcommand inject =>
-        (about: "Injects a configuration or configuration file into a group of Habitat Supervisors")
+fn sub_config_apply() -> App<'static, 'static> {
+    clap_app!(@subcommand apply =>
+        (about: "Applies a configuration to a group of Habitat Supervisors")
         (@arg PEERS: -p --peers +takes_value
          "A comma-delimited list of one or more Habitat Supervisor peers to infect (default: 127.0.0.1:9634)")
         (@arg SERVICE_GROUP: +required

--- a/components/hab/src/command/config/apply.rs
+++ b/components/hab/src/command/config/apply.rs
@@ -27,14 +27,14 @@ pub fn start(peers: &Vec<String>,
             try!(ConfigFile::from_body(sg, "config.toml".to_string(), body, number))
         }
     };
-    println!("Injecting {} into {}", &file, &sg1);
+    println!("Applying configuration {} to {}", &file, &sg1);
     let rumor = hab_gossip::Rumor::config_file(file);
 
     let mut list = hab_gossip::RumorList::new();
     list.add_rumor(rumor);
 
     try!(initial_peers(&peers, &list));
-    println!("Finished injecting");
+    println!("Finished applying configuration");
     Ok(())
 }
 
@@ -60,7 +60,7 @@ fn initial_peers(peer_listeners: &Vec<String>, rumor_list: &hab_gossip::RumorLis
 fn try_peers(peer_listeners: &Vec<String>, rumor_list: &hab_gossip::RumorList) -> bool {
     let mut initialized = false;
     for to in peer_listeners {
-        println!("Joining gossip peer at {}", to);
+        println!("Joining peer: {}", to);
         let mut c = match hab_gossip::Client::new(&to[..]) {
             Ok(c) => c,
             Err(e) => {
@@ -71,7 +71,7 @@ fn try_peers(peer_listeners: &Vec<String>, rumor_list: &hab_gossip::RumorList) -
         };
 
         match c.inject(rumor_list.clone()) {
-            Ok(_) => println!("Rumors injected at {}", to),
+            Ok(_) => println!("Configuration applied to: {}", to),
             Err(e) => {
                 println!("Failed to ping {:?}: {:?}", to, e);
                 continue;

--- a/components/hab/src/command/config/mod.rs
+++ b/components/hab/src/command/config/mod.rs
@@ -5,4 +5,4 @@
 // the Software until such time that the Software is made available under an
 // open source license such as the Apache 2.0 License.
 
-pub mod inject;
+pub mod apply;

--- a/components/hab/src/command/mod.rs
+++ b/components/hab/src/command/mod.rs
@@ -6,4 +6,4 @@
 // open source license such as the Apache 2.0 License.
 
 pub mod artifact;
-pub mod rumor;
+pub mod config;


### PR DESCRIPTION
This change also renames the subcommand alias `inject` to `apply`.

```
> hab --help
hab 0.4.0

Authors: The Habitat Maintainers <humans@habitat.sh>

"A Habitat is the natural environment for your services" - Alan Turing

USAGE:
    hab [FLAGS] [SUBCOMMAND]

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

SUBCOMMANDS:
    artifact    Commands relating to Habitat artifacts
    config      Commands relating to Habitat runtime config
    help        Prints this message or the help message of the given subcommand(s)
    origin      Commands relating to Habitat origin keys
    pkg         Commands relating to Habitat packages
    service     Commands relating to Habitat services
    sup         Commands relating to the Habitat Supervisor
    user        Commands relating to Habitat users

ALIASES:
    apply       Alias for: 'config apply'
    install     Alias for: 'pkg install'
    start       Alias for: 'sup start'

> hab config --help
hab-config
Commands relating to Habitat runtime config

USAGE:
    hab config [FLAGS] [SUBCOMMAND]

FLAGS:
    -h, --help    Prints help information

SUBCOMMANDS:
    apply    Applies a configuration to a group of Habitat Supervisors
    help     Prints this message or the help message of the given subcommand(s)

> hab apply --help
hab-apply
Alias for 'config apply'

USAGE:
    hab apply [FLAGS] [OPTIONS] <SERVICE_GROUP> <VERSION_NUMBER> [ARGS]

FLAGS:
    -h, --help    Prints help information

OPTIONS:
    -p, --peers <PEERS>    A comma-delimited list of one or more Habitat Supervisor peers to infect (default: 127.0.0.1:9634)

ARGS:
    <SERVICE_GROUP>     Target service group for this injection (ex: redis.default)
    <VERSION_NUMBER>    A version number (integer) for this configuration (ex: 42)
    [FILE]              Path to local file on disk (ex: /tmp/config.toml, default: <stdin>)

> hab apply --help
hab-apply
Alias for 'config apply'

USAGE:
    hab apply [FLAGS] [OPTIONS] <SERVICE_GROUP> <VERSION_NUMBER> [ARGS]

FLAGS:
    -h, --help    Prints help information

OPTIONS:
    -p, --peers <PEERS>    A comma-delimited list of one or more Habitat Supervisor peers to infect (default: 127.0.0.1:9634)

ARGS:
    <SERVICE_GROUP>     Target service group for this injection (ex: redis.default)
    <VERSION_NUMBER>    A version number (integer) for this configuration (ex: 42)
    [FILE]              Path to local file on disk (ex: /tmp/config.toml, default: <stdin>)
```
