### PR TITLE
[bpm] Update `hab-bpm install` to understand updated artifact format.

### DIFF
--- a/components/bpm/bin/hab-bpm.sh
+++ b/components/bpm/bin/hab-bpm.sh
@@ -635,7 +635,7 @@ install_package() {
     $wget $pkg_source -O $pkg_filename $wui
 
     info "Unpacking $($bb basename $pkg_filename)"
-    $bb tail -n +4 $pkg_filename | $bb xzcat | $bb tar x -C $FS_ROOT/
+    $bb tail -n +6 $pkg_filename | $bb xzcat | $bb tar x -C $FS_ROOT/
 
     # Clear the file download and extraction clean trap
     trap - INT TERM EXIT


### PR DESCRIPTION
Due the changes in #425, the header portion of a Habitat Artifact has
grown from the first 3 lines to 5 lines, the last of which is an empty
line. In order for the "cheap" (i.e. dirty, evil, not recommended)
install method that `hab-bpm` currently uses to work, we need to start
reading the tar archive starting on line 6 now, not 4.

Hm, the commit message is far longer than the fix. Funny how that works.
