### PR TITLE
Remove pinning on a specific version of coreutils

### DIFF
--- a/plans/node/plan.sh
+++ b/plans/node/plan.sh
@@ -8,7 +8,7 @@ pkg_source=https://nodejs.org/dist/v${pkg_version}/${pkg_name}-v${pkg_version}.t
 # pkg_version is node-4.2.6 (without the v). This tweak makes build happy
 pkg_dirname=node-v${pkg_version}
 pkg_shasum=ea5e357db8817052b17496d607c719d809ed1383e8fcf7c8ffc5214e705aefdd
-pkg_deps=(core/glibc core/gcc-libs core/coreutils/8.24/20160223204924)
+pkg_deps=(core/glibc core/gcc-libs core/coreutils)
 pkg_build_deps=(core/python2 core/gcc core/make)
 pkg_lib_dirs=(lib)
 pkg_include_dirs=(include)


### PR DESCRIPTION
@jtimberman I'm gonna assume this was an error, unless there was a particular reason for the pinning I'm missing?
