### PR TITLE
Add dependencies to Dockerfile for building builder components

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,11 +9,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     gdb \
     iproute2 \
     libarchive-dev \
+    libprotobuf-dev \
     libsodium-dev \
     libssl-dev \
+    libczmq-dev \
     man \
     npm \
     pkg-config \
+    protobuf-compiler \
     sudo \
     tmux \
     vim \
@@ -21,6 +24,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   && rm -rf /var/lib/apt/lists/*
 
 ENV CARGO_HOME /cargo-cache
+ENV PATH /cargo-cache/bin:$PATH
 
 ARG HAB_DEPOT_URL
 ENV HAB_DEPOT_URL ${HAB_DEPOT_URL:-}
@@ -30,6 +34,8 @@ RUN curl -sSL https://get.docker.io | sh && docker -v
 RUN ln -snf /usr/bin/nodejs /usr/bin/node && npm install -g docco && echo "docco `docco -V`"
 
 RUN (adduser --system hab || true) && (addgroup --system hab || true)
+
+RUN cargo install protobuf
 
 COPY .delivery/scripts/ssh_wrapper.sh /usr/local/bin
 COPY .delivery/scripts/git_src_checkout.sh /usr/local/bin


### PR DESCRIPTION
This adds the protobuf compiler, library, and rust extension along with libzmq for building all of the `builder-*` crates

![gif-keyboard-9008690620347671677](https://cloud.githubusercontent.com/assets/54036/14796780/f4ca290a-0ae3-11e6-9ae3-db1f78e79c88.gif)
