### PR TITLE
WIP Add ruby client library

### DIFF
--- a/components/ruby-client/.gitignore
+++ b/components/ruby-client/.gitignore
@@ -1,0 +1,9 @@
+/.bundle/
+/.yardoc
+/Gemfile.lock
+/_yardoc/
+/coverage/
+/doc/
+/pkg/
+/spec/reports/
+/tmp/

--- a/components/ruby-client/.rspec
+++ b/components/ruby-client/.rspec
@@ -1,0 +1,2 @@
+--format documentation
+--color

--- a/components/ruby-client/Gemfile
+++ b/components/ruby-client/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gemspec

--- a/components/ruby-client/README.md
+++ b/components/ruby-client/README.md
@@ -1,0 +1,38 @@
+# Habitat::Client
+
+This is the Ruby client library for Habitat.
+
+## Installation
+
+Add this line to your application's Gemfile:
+
+```ruby
+gem 'habitat-client'
+```
+
+And then execute:
+
+    $ bundle
+
+Or install it yourself as:
+
+    $ gem install habitat-client
+
+## Usage
+
+```ruby
+# Create an instance object
+hc = Habitat::Client.new
+
+# Create the instance with a specific Habitat Depot
+hc = Habitat::Client.new('http://localhost:9632')
+
+# Upload a Habitat Artifact
+hc.put_package('core-pandas-0.0.1-20160425190407.hart')
+
+# Show a package
+hc.show_package('core/pandas')
+
+# Promote a package to the `stable` view
+hc.promote_package('core/pandas', 'stable')
+```

--- a/components/ruby-client/Rakefile
+++ b/components/ruby-client/Rakefile
@@ -1,0 +1,6 @@
+require 'bundler/gem_tasks'
+require 'rspec/core/rake_task'
+
+RSpec::Core::RakeTask.new(:spec)
+
+task :default => :spec

--- a/components/ruby-client/habitat-client.gemspec
+++ b/components/ruby-client/habitat-client.gemspec
@@ -1,0 +1,28 @@
+# coding: utf-8
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'habitat/client/version'
+
+Gem::Specification.new do |spec|
+  spec.name          = 'habitat-client'
+  spec.version       = Habitat::Client::VERSION
+  spec.authors       = ['Joshua Timberman']
+  spec.email         = ['humans@habitat.sh']
+
+  spec.summary       = %q{Habitat Depot Client Library}
+  spec.homepage      = 'https://www.habitat.sh'
+
+  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.require_paths = ['lib']
+
+  spec.add_dependency 'rbnacl', '~> 3.3'
+  spec.add_dependency 'faraday', '~> 0.9.0'
+  spec.add_dependency 'mixlib-shellout', '~> 2.2'
+
+  spec.add_development_dependency 'pry'
+  spec.add_development_dependency 'pry-coolline'
+  spec.add_development_dependency 'bundler', '~> 1.11'
+  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rspec', '~> 3.0'
+end

--- a/components/ruby-client/lib/habitat/client.rb
+++ b/components/ruby-client/lib/habitat/client.rb
@@ -1,0 +1,305 @@
+require_relative 'client/version'
+require_relative 'exceptions'
+require 'faraday'
+require 'json'
+
+module Habitat
+
+  # Habitat Client
+  #
+  # This class is an API client to the Habitat Depot. It uses Faraday
+  # under the covers to give us a nice HTTP interface.
+
+  class Client
+    attr_reader :depot, :connection
+
+    # Creates the Habitat client connection object. The public
+    # interface should be used for the common interactions with the
+    # API, but more complex operations can be done using the
+    # +connection+ attribute through Faraday.
+    #
+    # === Attributes
+    #
+    # * +depot+ - URL to the Habitat Depot, defaults to the public service run by the Habitat organization
+    # * +connection+ - A Faraday object representing the HTTP connection
+    #
+    # === Examples
+    #
+    #    hc = Habitat::Client.new
+    #    hc = Habitat::Client.new('https://depot.habitat.sh')
+    #    hc.connection.get('/pkgs')
+
+    def initialize(depot = 'http://willem.habitat.sh:9632')
+      @depot = depot
+      @connection = Faraday.new(url: @depot) do |f|
+        f.request :multipart
+        f.request :url_encoded
+        f.adapter :net_http
+      end
+    end
+
+    # Downloads the specified key. By default, it will download to the
+    # current directory as a file named by the +X-Filename+ HTTP
+    # header.
+    def fetch_key(key, path = '.')
+      raise 'Downloading keys is not yet implemented'
+    end
+
+    # Uploads the specified key from the given path location.
+    def put_key(key, path)
+      raise 'Uploading keys is not yet implemented'
+    end
+
+    # Downloads the specified package. It will default to the latest
+    # version if not specified, or the latest release of a version if
+    # the release is not specified.
+    #
+    # The file will be downloaded to the current directory as a file
+    # named by the +X-Filename+ HTTP header.
+    #
+    # === Arguments
+    #
+    # * +pkg+ - A package string, like +core/zlib+
+    def fetch_package(pkg, path = '.')
+      download(fetch_package_path(pkg), path)
+    end
+
+    # Show details about the specified package using a package
+    # identifier string. If the version or release are not specified,
+    # +latest+ is assumed.
+    #
+    # === Examples
+    #
+    #    hc = Habitat::Client.new
+    #    hc.show_package('core/zlib')
+    #    hc.show_package('core/zlib/1.2.8')
+    #    hc.show_package('core/zlib/1.2.8/20160222155343')
+    def show_package(pkg)
+      JSON.parse(@connection.get(show_package_path(pkg)).body)
+    end
+
+    # Uploads a package from the specified filepath.
+    #
+    # === Arguments
+    #
+    # * +file+ - The file to upload
+    #
+    # === Examples
+    def put_package(file)
+      upload(upload_package_path(file), file)
+    end
+
+    # Promotes a package to the specified view, for example
+    # +core/zlib+ to +staging+ or +production+
+    #
+    # === Examples
+    #
+    #    hc = Habitat::Client.new
+    #    hc.promote_package('core/pandas/0.0.1/20160419213120', 'staging')
+    def promote_package(pkg, view)
+      promote(promote_artifact_path(pkg, view))
+    end
+
+    private
+    # Returns the PackageIdent as a string with the version and/or
+    # release qualified if not specified. For example, if +pkg+ is
+    # +'core/zlib'+, it will return +'core/zlib/latest'+.
+    def package_ident(pkg)
+      PackageIdent.new(*pkg.split('/')).to_s
+    end
+
+    # If the PackageIdent has four parts, it's fully qualified.
+    def fully_qualified?(pkg)
+      parts = package_ident(pkg).split('/')
+      return parts.count == 4 && parts.last != 'latest'
+    end
+
+    # Returns a URL path for retrieving the PackageIdent specified.
+    def show_package_path(pkg)
+      ['pkgs', package_ident(pkg)].join('/')
+    end
+
+    # Returns a URL path for retrieving the PackageIdent specified
+    # using the download path.
+    def fetch_package_path(pkg)
+      resolved_path = resolve_latest(package_ident(pkg))
+      ['pkgs', resolved_path, 'download'].join('/')
+    end
+
+    # Returns a URL path for retrieving the specified key
+    def fetch_key_path(key)
+      ['keys', key].join('/')
+    end
+
+    # Returns a URL path for uploading the specified package artifact
+    def upload_package_path(path)
+      ['pkgs', derive_pkgid_from_file(path)].join('/')
+    end
+
+    # Resolves the latest version of the package returned by +show_package+
+    def resolve_latest(pkg)
+      latest = show_package(pkg)
+      ['origin', 'name', 'version', 'release'].map {|i| latest['ident'][i] }.join('/')
+    end
+
+    def validate_pkg_path!(pkg)
+      if ! fully_qualified?(pkg)
+        raise <<-EOH.gsub(/^\s+/, '')
+          You must specify a fully qualified package path, such as:
+
+              core/pandas/0.0.1/20160419213120
+
+          You specified `#{pkg}' in `#{caller_locations(1,1)[0].label}'
+        EOH
+      end
+    end
+
+    # Opens a Habitat Artifact and reads the IDENT metadata to get the
+    # fully qualified package identifier.
+    def derive_pkgid_from_file(file)
+      require 'mixlib/shellout'
+      tail_n = 'tail -n +6'
+      xzcat = 'xzcat --decompress'
+      tar_toc = 'tar -tf -'
+      tar_stdout = 'tar -xOf -'
+      subcommand = "#{tail_n} #{file} | #{xzcat} | #{tar_toc} | grep '/IDENT$'"
+      command = "#{tail_n} #{file} | #{xzcat} | #{tar_stdout} $(#{subcommand})"
+      pkgid = Mixlib::ShellOut.new(command)
+      begin
+        pkgid.run_command.stdout.chomp
+      rescue
+        raise "Could not derive a version from #{file}, aborting!"
+      end
+    end
+
+    # Returns a hex encoded blake2b hash from the given data.
+    def blake2b_checksum(data, size = 32)
+      require 'rbnacl'
+      require 'digest'
+      Digest.hexencode(RbNaCl::Hash.blake2b(data, digest_size: size)).chomp
+    end
+
+    # Returns the URL path for promoting an artifact
+    def promote_artifact_path(pkg, view)
+      validate_pkg_path!(pkg)
+      ['views', view, 'pkgs', pkg, 'promote'].join('/')
+    end
+
+    def promote(url)
+      response = @connection.post(url)
+      if response.status == 200
+        return true
+      else
+        return "Depot server returned #{response.status} for promote request"
+      end
+    end
+
+    # Downloads the file from the depot.
+    def download(url, path = '.')
+      response = @connection.get(url)
+      if response.status == 200
+        ::File.open(
+          ::File.join(
+            path,
+            response.headers['x-filename']
+          ), 'wb') do |fp|
+          fp.write(response.body)
+        end
+      else
+        raise Habitat::DownloadError, "Depot server returned #{response.status} for download request"
+      end
+    end
+
+    # Uploads a file to the depot.
+    #
+    # === Attributes
+    # * +url+ - the URL path on the depot server
+    # * +path+ - the file path to upload
+    def upload(url, path)
+      payload = {file: Faraday::UploadIO.new(path, 'application/octet-stream')}
+      response = @connection.post do |req|
+        req.url url
+        req.params['checksum'] = blake2b_checksum(IO.read(path))
+        req.body = payload
+      end
+
+      if response.status == 200
+        return true
+      else
+        raise Habitat::UploadError, "Depot server returned #{response.status} for upload of '#{path}'"
+      end
+    end
+
+  end
+
+  # Habitat Package Ident
+  #
+  # This class builds a Habitat Package Identifier object using the
+  # four components of a Habitat package: origin, package name (pkg),
+  # version, and release. It subclasses +Struct+ with arguments that
+  # have default values - 'latest' for +version+ and +release+. It
+  # also implements a method to return the package identifier as a +/+
+  # separated string for use in the Habitat Depot API
+
+  class PackageIdent < Struct.new(:origin, :pkg, :version, :release)
+
+    # Creates the package identifier using the origin and package
+    # name. Optionally will also use the version and release, or sets
+    # them to latest if not specified.
+    #
+    # === Attributes
+    #
+    # * +origin+ - The package origin
+    # * +pkg+ - The package name
+    # * +version+ - The version of the package
+    # * +release+ - The timestamp release of the package
+    #
+    # === Examples
+    #
+    # Use the latest core/zlib package:
+    #
+    #    Habitat::PackageIdent.new('core', 'zlib')
+    #
+    # Use version 1.2.8 of the core/zlib package:
+    #
+    #    Habitat::PackageIdent.new('core', 'zlib', '1.2.8')
+    #
+    # Use a specific release of version 1.2.8 of the core/zlib
+    # package:
+    #
+    #     Habitat::PackageIdent.new('core', 'zlib', '1.2.8', '20160222155343')
+    #
+    # Pass an array as an argument:
+    #
+    #    Habitat::PackageIdent.new(*['core', 'zlib'])
+    #
+    # For example, from a +#split+ string:
+    #
+    #    Habitat::PackageIdent.new(*'core/zlib'.split('/'))
+
+    def initialize(origin, pkg, version = 'latest', release = 'latest'); super end
+
+    # Returns a string from a +Habitat::PackageIdent+ object separated by
+    # +/+ (forward slash).
+    #
+    # === Examples
+    #
+    #     zlib = Habitat::PackageIdent.new('core', 'zlib')
+    #     zlib.to_s #=> "core/zlib/latest"
+
+    def to_s
+      if self[:version] == 'latest'
+        parts = [self[:origin], self[:pkg], self[:version]]
+      else
+        parts = [self[:origin], self[:pkg], self[:version], self[:release]]
+      end
+      parts.join('/')
+    end
+  end
+end
+
+
+# So users don't have to remember +Habitat+ vs +Hab+
+module Hab
+  include Habitat
+end

--- a/components/ruby-client/lib/habitat/client/version.rb
+++ b/components/ruby-client/lib/habitat/client/version.rb
@@ -1,0 +1,5 @@
+module Habitat
+  class Client
+    VERSION = '0.4.0'
+  end
+end

--- a/components/ruby-client/lib/habitat/exceptions.rb
+++ b/components/ruby-client/lib/habitat/exceptions.rb
@@ -1,0 +1,19 @@
+module Habitat
+  class PromotionError < StandardError
+    def initialize(msg = 'Promotion of package on Depot server failed')
+      super
+    end
+  end
+
+  class UploadError < StandardError
+    def initialize(msg = 'Upload of artifact to Depot server failed')
+      super
+    end
+  end
+
+  class DownloadError < StandardError
+    def initialize(msg = 'Download of artifact from Depot server failed')
+      super
+    end
+  end
+end

--- a/components/ruby-client/spec/fixtures/depot_cassettes/player.yml
+++ b/components/ruby-client/spec/fixtures/depot_cassettes/player.yml
@@ -1,0 +1,44 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:9632/pkgs/core/pandas/latest
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Etag:
+      - NHRwHYyGrDdDCLnwRW0Rs9owOVo51Wv28z6HncFEtNs=
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - text/plain
+      Date:
+      - Wed, 20 Apr 2016 16:01:23 GMT
+      Content-Length:
+      - '2037'
+    body:
+      encoding: UTF-8
+      string: '{"ident":{"origin":"core","name":"pandas","version":"0.0.1","release":"20160419213120"},"manifest":"core
+        pandas\n=========================\n\nMaintainer: The Habitat Maintainers <humans@habitat.sh>\nVersion:
+        0.0.1\nRelease: 20160419213120\nLicense:  \nSource: [http://example.com/pandas-0.0.1.tar.xz](http://example.com/pandas-0.0.1.tar.xz)\nSHA:
+        sha256sum\nPath: /hab/pkgs/core/pandas/0.0.1/20160419213120\nBuild Dependencies:  \nDependencies:  \nInterpreters  \n\nPlan\n========\n\nBuild
+        Flags\n-----------\n\nCFLAGS: \nLDFLAGS: \nLD_RUN_PATH: /hab/pkgs/core/pandas/0.0.1/20160419213120/lib\n\n```bash\npkg_origin=core\npkg_name=pandas\npkg_version=0.0.1\npkg_maintainer=\"The
+        Habitat Maintainers <humans@habitat.sh>\"\npkg_license=()\npkg_source=http://example.com/${pkg_name}-${pkg_version}.tar.xz\npkg_shasum=sha256sum\n#pkg_deps=(chef/glibc)\n#pkg_build_deps=(chef/coreutils)\npkg_bin_dirs=(bin)\npkg_include_dirs=(include)\npkg_lib_dirs=(lib)\npkg_gpg_key=3853DA6B\n\ndo_begin()
+        {\n  return 0\n}\n\ndo_unpack() {\n  return 0\n}\n\ndo_download() {\n  return
+        0\n}\n\ndo_verify() {\n  return 0\n}\n\ndo_install() {\n  return 0\n}\n\ndo_build()
+        {\n  return 0\n}\n\ndo_prepare() {\n  return 0\n}\n```\n\nFiles\n-----\n949ee43a4372733130115580d1e038f463b22262355a53bb7afd80c7cf4cdabc  /hab/pkgs/core/pandas/0.0.1/20160419213120/CFLAGS\n5fe0fd5101905208fe49d640f03f2b0c8e07d80fe0231b7f7d0a64e1937bc8b0  /hab/pkgs/core/pandas/0.0.1/20160419213120/IDENT\ne25c2c5ae4ffde1e34b86ec59528c5ef236c1ce46e65d0a0856ac961b454b04d  /hab/pkgs/core/pandas/0.0.1/20160419213120/INTERPRETERS\nbc4890f7e35204aa2281554198a8773c124c9d6687b13d1ed4c9f37a25e3c58d  /hab/pkgs/core/pandas/0.0.1/20160419213120/LDFLAGS\n580ba95e5045d82ca4df124f2d59ca4af088d614548c5ca5062a6291c2717fe2  /hab/pkgs/core/pandas/0.0.1/20160419213120/LD_RUN_PATH\nd3698dc4c61fe457fdef9ab38997873de852b7c5c2da610e2fb4474d4253773d  /hab/pkgs/core/pandas/0.0.1/20160419213120/PATH","deps":[],"tdeps":[],"exposes":[],"config":null,"checksum":"NHRwHYyGrDdDCLnwRW0Rs9owOVo51Wv28z6HncFEtNs="}'
+    http_version: 
+  recorded_at: Wed, 20 Apr 2016 16:01:23 GMT
+recorded_with: VCR 3.0.1

--- a/components/ruby-client/spec/habitat/client/version_spec.rb
+++ b/components/ruby-client/spec/habitat/client/version_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+describe 'Habitat::Client::VERSION' do
+  it 'has a version number' do
+    expect(Habitat::Client::VERSION).not_to be nil
+  end
+end

--- a/components/ruby-client/spec/habitat/client_spec.rb
+++ b/components/ruby-client/spec/habitat/client_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+
+describe Habitat::Client do
+  let(:hc) { Habitat::Client.new }
+  let(:hc_custom_depot) { Habitat::Client.new('http://localhost:9632') }
+
+  it 'includes the Habitat module in Hab' do
+    expect(hc).to be_a(Hab::Client)
+  end
+
+  it 'has a default depot' do
+    expect(hc.depot).to eq 'http://willem.habitat.sh:9632'
+  end
+
+  it 'can set custom depot' do
+    expect(hc_custom_depot.depot).to eq 'http://localhost:9632'
+  end
+
+  it 'sets a connection up with Faraday' do
+    expect(hc.connection).to be_a(Faraday::Connection)
+  end
+
+  it 'raises when using unimplemented methods' do
+    expect { hc.fetch_key('empty') }.to raise_exception RuntimeError
+    expect { hc.put_key('empty', 'file.key') }.to raise_exception RuntimeError
+  end
+end
+
+describe Habitat::PackageIdent do
+  it 'sets version to latest if unspecified' do
+    hpi = Habitat::PackageIdent.new('core', 'rspec')
+    expect(hpi.version).to eq 'latest'
+  end
+
+  it 'sets release to latest if unspecified' do
+    hpi = Habitat::PackageIdent.new('core', 'rspec', '3.4.4')
+    expect(hpi.release).to eq 'latest'
+  end
+
+  describe '#to_s' do
+    it 'ends in latest with no version specified' do
+      hpi = Habitat::PackageIdent.new('core', 'rspec')
+      expect(hpi.to_s).to match('core/rspec/latest')
+    end
+
+    it 'ends in latest with version, but no release specified' do
+      hpi = Habitat::PackageIdent.new('core', 'rspec', '3.4.4')
+      expect(hpi.to_s).to match('core/rspec/3.4.4/latest')
+    end
+
+    it 'is fully qualified with all parts specified' do
+      hpi = Habitat::PackageIdent.new('core', 'rspec', '3.4.4', '201604181646')
+      expect(hpi.to_s).to match('core/rspec/3.4.4/201604181646')
+    end
+  end
+end

--- a/components/ruby-client/spec/spec_helper.rb
+++ b/components/ruby-client/spec/spec_helper.rb
@@ -1,0 +1,3 @@
+$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+require 'habitat/client'
+require 'habitat/client/version'


### PR DESCRIPTION
I wanted to get this out for review and ideas.

Known Issues:

`put_package` results in `422` HTTP status code. This is because the checksum on the depot server's stored copy of the artifact is different. However, `hab artifact upload` seems to work fine. 

Incomplete spec coverage - we don't have mocked HTTP calls to do unit testing of the various GET/POST requests we can make.

We don't run `rspec` in CI. Local testing was done using ChefDK's Ruby, which is probably the right thing as that is what we'd have on Delivery build nodes where this is most likely to be used first.

No key download/upload capability yet.
