### PR TITLE
Add ability to configure Depot server from config file

### DIFF
--- a/components/depot/plan/config/nah.txt
+++ b/components/depot/plan/config/nah.txt
@@ -1,1 +1,0 @@
-placeholder until a second pass of https://github.com/chef/bldr/pull/159 is completed

--- a/components/depot/plan/config/server.cfg.toml
+++ b/components/depot/plan/config/server.cfg.toml
@@ -1,0 +1,7 @@
+path = "{{cfg.path}}"
+bind_addr = "{{cfg.bind_addr}}"
+port = {{cfg.port}}
+{{#svc.named.redis.default.members}}
+datastore_addr = "{{ip}}"
+datastore_port = {{port}}
+{{/svc.named.redis.default.members}}

--- a/components/depot/plan/default.toml
+++ b/components/depot/plan/default.toml
@@ -1,0 +1,5 @@
+path = "/hab/svc/hab-depot/data"
+bind_addr = "0.0.0.0"
+port = 9632
+datastore_addr = "127.0.0.1"
+datastore_port = 6379

--- a/components/depot/plan/plan.sh
+++ b/components/depot/plan/plan.sh
@@ -4,15 +4,11 @@ pkg_version=0.4.0
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('apachev2')
 pkg_source=nosuchfile.tar.gz
-pkg_deps=(
-  core/glibc core/gcc-libs core/libarchive core/libsodium core/openssl
-)
+pkg_deps=(core/glibc core/gcc-libs core/libarchive core/libsodium core/openssl)
 pkg_build_deps=(core/coreutils core/cacerts core/rust core/gcc)
 pkg_bin_dirs=(bin)
-
-program=$pkg_name
-
-pkg_service_run="bin/$program start"
+srv_bin="hab-depot"
+pkg_service_run="bin/$srv_bin start -c $pkg_svc_config_path/server.cfg.toml"
 
 do_prepare() {
   # Used by the `build.rs` program to set the version of the binaries
@@ -44,17 +40,14 @@ do_build() {
 }
 
 do_install() {
-  install -v -D $PLAN_CONTEXT/../target/$rustc_target/debug/$program \
-    $pkg_prefix/bin/$program
+  install -v -D $PLAN_CONTEXT/../target/$rustc_target/debug/$srv_bin \
+    $pkg_prefix/bin/$srv_bin
 }
 
 do_strip() {
   return 0
-  # for the moment, we'll skip stripping
-  # strip $pkg_prefix/bin/$program
 }
 
-# Turn the remaining default phases into no-ops
 do_download() {
   return 0
 }

--- a/components/depot/src/config.rs
+++ b/components/depot/src/config.rs
@@ -5,26 +5,100 @@
 // the Software until such time that the Software is made available under an
 // open source license such as the Apache 2.0 License.
 
+use std::fs::File;
+use std::io::Read;
 use std::net;
+use std::path::Path;
+use std::str::FromStr;
 
 use redis;
+use toml;
+
+use super::{ListenAddr, ListenPort};
+use error::{Error, Result};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Config {
     pub path: String,
-    pub listen_addr: super::ListenAddr,
-    pub port: super::ListenPort,
+    pub listen_addr: ListenAddr,
+    pub port: ListenPort,
     pub datastore_addr: net::SocketAddrV4,
 }
 
 impl Config {
-    /// Create a default `Config`
-    pub fn new() -> Config {
-        Config::default()
+    pub fn from_file<T: AsRef<Path>>(filepath: T) -> Result<Self> {
+        // don't try, use our own error about config not found
+        let mut file = try!(File::open(filepath.as_ref()));
+        let mut raw = String::new();
+        // don't try, use our own error about invalid config syntax
+        try!(file.read_to_string(&mut raw));
+        let mut parser = toml::Parser::new(&raw);
+        match parser.parse() {
+            Some(toml) => Ok(Config::from(toml)),
+            None => {
+                let mut msg = String::new();
+                for err in &parser.errors {
+                    let (loline, locol) = parser.to_linecol(err.lo);
+                    let (hiline, hicol) = parser.to_linecol(err.hi);
+                    msg.push_str(&format!("\t{}:{}-{}:{} error: {}\n",
+                                          loline,
+                                          locol,
+                                          hiline,
+                                          hicol,
+                                          err.desc));
+                }
+                Err(Error::ConfigFileSyntax(msg))
+            }
+        }
     }
 
     pub fn depot_addr(&self) -> net::SocketAddrV4 {
         net::SocketAddrV4::new(self.listen_addr.0.clone(), self.port.0.clone())
+    }
+}
+
+impl From<toml::Table> for Config {
+    fn from(table: toml::Table) -> Self {
+        let mut cfg = Config::default();
+        if let Some(value) = table.get("path") {
+            match value {
+                &toml::Value::String(ref path) => cfg.path = path.clone(),
+                _ => panic!("JW TODO: handle this error"),
+            }
+        }
+        if let Some(value) = table.get("bind_addr") {
+            match value {
+                &toml::Value::String(ref addr_str) => {
+                    // JW TODO: handle this
+                    let bind_addr = net::Ipv4Addr::from_str(addr_str).unwrap();
+                    cfg.listen_addr = ListenAddr(bind_addr)
+                }
+                _ => panic!("JW TODO: handle this error"),
+            }
+        }
+        if let Some(value) = table.get("port") {
+            match value {
+                &toml::Value::Integer(port) => cfg.port = ListenPort(port as u16),
+                _ => panic!("JW TODO: handle this error"),
+            }
+        }
+        if table.contains_key("datastore_addr") || table.contains_key("datastore_port") {
+            let ip = match table.get("datastore_addr") {
+                Some(&toml::Value::String(ref addr_str)) => {
+                    // JW TODO: handle this error
+                    net::Ipv4Addr::from_str(addr_str).unwrap()
+                }
+                Some(_) => panic!("JW TODO: handle this error"),
+                None => net::Ipv4Addr::new(127, 0, 0, 1),
+            };
+            let port = match table.get("datastore_port") {
+                Some(&toml::Value::Integer(port)) => port as u16,
+                Some(_) => panic!("handle"),
+                None => 6379,
+            };
+            cfg.datastore_addr = net::SocketAddrV4::new(ip, port);
+        }
+        cfg
     }
 }
 

--- a/components/depot/src/error.rs
+++ b/components/depot/src/error.rs
@@ -19,6 +19,7 @@ use redis;
 #[derive(Debug)]
 pub enum Error {
     BadPort(String),
+    ConfigFileSyntax(String),
     DataStore(dbcache::Error),
     HabitatCore(hcore::Error),
     HTTP(hyper::status::StatusCode),
@@ -37,6 +38,10 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let msg = match *self {
             Error::BadPort(ref e) => format!("{} is an invalid port. Valid range 1-65535.", e),
+            Error::ConfigFileSyntax(ref e) => {
+                format!("Syntax errors while parsing TOML configuration file:\n\n{}",
+                        e)
+            }
             Error::DataStore(ref e) => format!("DataStore error, {}", e),
             Error::HabitatCore(ref e) => format!("{}", e),
             Error::HTTP(ref e) => format!("{}", e),
@@ -69,6 +74,7 @@ impl error::Error for Error {
     fn description(&self) -> &str {
         match *self {
             Error::BadPort(_) => "Received an invalid port or a number outside of the valid range.",
+            Error::ConfigFileSyntax(_) => "Error parsing contents of configuration file",
             Error::DataStore(ref err) => err.description(),
             Error::HabitatCore(ref err) => err.description(),
             Error::HTTP(_) => "Received an HTTP error",

--- a/components/depot/src/lib.rs
+++ b/components/depot/src/lib.rs
@@ -26,6 +26,7 @@ extern crate redis;
 extern crate router;
 extern crate rustc_serialize;
 extern crate time;
+extern crate toml;
 extern crate urlencoded;
 extern crate walkdir;
 


### PR DESCRIPTION
This also updates the depot plan to write a configuration file to automatically discover redis from it's service group

![gif-keyboard-4794937593360299070](https://cloud.githubusercontent.com/assets/54036/14802414/7a0bf064-0b05-11e6-9049-43fb972e64ef.gif)
