### PR TITLE
Add ConfigFile trait for reading TOML configuration files

### DIFF
--- a/components/core/Cargo.lock
+++ b/components/core/Cargo.lock
@@ -10,6 +10,7 @@ dependencies = [
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "sodiumoxide 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -129,6 +130,14 @@ dependencies = [
  "kernel32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "toml"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/components/core/Cargo.toml
+++ b/components/core/Cargo.toml
@@ -9,6 +9,7 @@ libarchive = "*"
 log = "*"
 regex = "*"
 rustc-serialize = "*"
+toml = "*"
 
 ### !!NOTE!! sodiumoxide and libsodium-sys are using an override, via the
 ### .cargo/config file. When https://github.com/dnaq/sodiumoxide/pull/103
@@ -16,5 +17,3 @@ rustc-serialize = "*"
 sodiumoxide = "*"
 libsodium-sys = "*"
 time = "*"
-
-

--- a/components/core/src/config.rs
+++ b/components/core/src/config.rs
@@ -1,0 +1,55 @@
+// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
+//
+// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
+// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
+// is made available under an open source license such as the Apache 2.0 License.
+
+use std;
+use std::fs::File;
+use std::io::Read;
+use std::path::Path;
+
+use toml;
+
+use error::Error;
+
+pub trait ConfigFile: Sized {
+    type Error: std::error::Error + From<Error>;
+
+    fn from_file<T: AsRef<Path>>(filepath: T) -> Result<Self, Self::Error> {
+        let mut file = match File::open(filepath.as_ref()) {
+            Ok(f) => f,
+            Err(e) => return Err(Self::Error::from(Error::ConfigFileIO(e))),
+        };
+        let mut raw = String::new();
+        match file.read_to_string(&mut raw) {
+            Ok(_) => (),
+            Err(e) => return Err(Self::Error::from(Error::ConfigFileIO(e))),
+        }
+        let mut parser = toml::Parser::new(&raw);
+        match parser.parse() {
+            Some(toml) => Self::from_toml(toml),
+            None => {
+                let msg = format_errors(&parser);
+                Err(Self::Error::from(Error::ConfigFileSyntax(msg)))
+            }
+        }
+    }
+
+    fn from_toml(toml: toml::Table) -> Result<Self, Self::Error>;
+}
+
+fn format_errors(parser: &toml::Parser) -> String {
+    let mut msg = String::new();
+    for err in &parser.errors {
+        let (loline, locol) = parser.to_linecol(err.lo);
+        let (hiline, hicol) = parser.to_linecol(err.hi);
+        msg.push_str(&format!("\t{}:{}-{}:{} error: {}\n",
+                              loline,
+                              locol,
+                              hiline,
+                              hicol,
+                              err.desc));
+    }
+    msg
+}

--- a/components/core/src/error.rs
+++ b/components/core/src/error.rs
@@ -26,6 +26,10 @@ pub enum Error {
     ArchiveError(libarchive::error::ArchiveError),
     /// An invalid path to a keyfile was given.
     BadKeyPath(String),
+    /// Error reading raw contents of configuration file.
+    ConfigFileIO(io::Error),
+    /// Parsing error while reading a configuratino file.
+    ConfigFileSyntax(String),
     /// Crypto library error
     CryptoError(String),
     /// Occurs when a file that should exist does not or could not be read.
@@ -60,6 +64,11 @@ impl fmt::Display for Error {
             Error::ArchiveError(ref err) => format!("{}", err),
             Error::BadKeyPath(ref e) => {
                 format!("Invalid keypath: {}. Specify an absolute path to a file on disk.",
+                        e)
+            }
+            Error::ConfigFileIO(ref e) => format!("Error reading configuration file: {}", e),
+            Error::ConfigFileSyntax(ref e) => {
+                format!("Syntax errors while parsing TOML configuration file:\n\n{}",
                         e)
             }
             Error::CryptoError(ref e) => format!("Crypto error: {}", e),
@@ -101,6 +110,8 @@ impl error::Error for Error {
         match *self {
             Error::ArchiveError(ref err) => err.description(),
             Error::BadKeyPath(_) => "An absolute path to a file on disk is required",
+            Error::ConfigFileIO(_) => "Unable to read the raw contents of a configuration file",
+            Error::ConfigFileSyntax(_) => "Error parsing contents of configuration file",
             Error::CryptoError(_) => "Crypto error",
             Error::FileNotFound(_) => "File not found",
             Error::InvalidPackageIdent(_) => "Package identifiers must be in origin/name format (example: acme/redis)",

--- a/components/core/src/lib.rs
+++ b/components/core/src/lib.rs
@@ -15,9 +15,11 @@ extern crate rustc_serialize;
 extern crate sodiumoxide;
 extern crate libsodium_sys;
 extern crate time;
+extern crate toml;
 
 pub use self::error::{Error, Result};
 
+pub mod config;
 pub mod env;
 pub mod error;
 pub mod fs;

--- a/components/depot/Cargo.lock
+++ b/components/depot/Cargo.lock
@@ -158,6 +158,7 @@ dependencies = [
  "rustc-serialize 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "sodiumoxide 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/components/depot/src/config.rs
+++ b/components/depot/src/config.rs
@@ -5,12 +5,10 @@
 // the Software until such time that the Software is made available under an
 // open source license such as the Apache 2.0 License.
 
-use std::fs::File;
-use std::io::Read;
 use std::net;
-use std::path::Path;
 use std::str::FromStr;
 
+use hcore::config::ConfigFile;
 use redis;
 use toml;
 
@@ -26,47 +24,23 @@ pub struct Config {
 }
 
 impl Config {
-    pub fn from_file<T: AsRef<Path>>(filepath: T) -> Result<Self> {
-        // don't try, use our own error about config not found
-        let mut file = try!(File::open(filepath.as_ref()));
-        let mut raw = String::new();
-        // don't try, use our own error about invalid config syntax
-        try!(file.read_to_string(&mut raw));
-        let mut parser = toml::Parser::new(&raw);
-        match parser.parse() {
-            Some(toml) => Ok(Config::from(toml)),
-            None => {
-                let mut msg = String::new();
-                for err in &parser.errors {
-                    let (loline, locol) = parser.to_linecol(err.lo);
-                    let (hiline, hicol) = parser.to_linecol(err.hi);
-                    msg.push_str(&format!("\t{}:{}-{}:{} error: {}\n",
-                                          loline,
-                                          locol,
-                                          hiline,
-                                          hicol,
-                                          err.desc));
-                }
-                Err(Error::ConfigFileSyntax(msg))
-            }
-        }
-    }
-
     pub fn depot_addr(&self) -> net::SocketAddrV4 {
         net::SocketAddrV4::new(self.listen_addr.0.clone(), self.port.0.clone())
     }
 }
 
-impl From<toml::Table> for Config {
-    fn from(table: toml::Table) -> Self {
+impl ConfigFile for Config {
+    type Error = Error;
+
+    fn from_toml(toml: toml::Table) -> Result<Self> {
         let mut cfg = Config::default();
-        if let Some(value) = table.get("path") {
+        if let Some(value) = toml.get("path") {
             match value {
                 &toml::Value::String(ref path) => cfg.path = path.clone(),
                 _ => panic!("JW TODO: handle this error"),
             }
         }
-        if let Some(value) = table.get("bind_addr") {
+        if let Some(value) = toml.get("bind_addr") {
             match value {
                 &toml::Value::String(ref addr_str) => {
                     // JW TODO: handle this
@@ -76,14 +50,14 @@ impl From<toml::Table> for Config {
                 _ => panic!("JW TODO: handle this error"),
             }
         }
-        if let Some(value) = table.get("port") {
+        if let Some(value) = toml.get("port") {
             match value {
                 &toml::Value::Integer(port) => cfg.port = ListenPort(port as u16),
                 _ => panic!("JW TODO: handle this error"),
             }
         }
-        if table.contains_key("datastore_addr") || table.contains_key("datastore_port") {
-            let ip = match table.get("datastore_addr") {
+        if toml.contains_key("datastore_addr") || toml.contains_key("datastore_port") {
+            let ip = match toml.get("datastore_addr") {
                 Some(&toml::Value::String(ref addr_str)) => {
                     // JW TODO: handle this error
                     net::Ipv4Addr::from_str(addr_str).unwrap()
@@ -91,14 +65,14 @@ impl From<toml::Table> for Config {
                 Some(_) => panic!("JW TODO: handle this error"),
                 None => net::Ipv4Addr::new(127, 0, 0, 1),
             };
-            let port = match table.get("datastore_port") {
+            let port = match toml.get("datastore_port") {
                 Some(&toml::Value::Integer(port)) => port as u16,
                 Some(_) => panic!("handle"),
                 None => 6379,
             };
             cfg.datastore_addr = net::SocketAddrV4::new(ip, port);
         }
-        cfg
+        Ok(cfg)
     }
 }
 

--- a/components/depot/src/error.rs
+++ b/components/depot/src/error.rs
@@ -19,7 +19,6 @@ use redis;
 #[derive(Debug)]
 pub enum Error {
     BadPort(String),
-    ConfigFileSyntax(String),
     DataStore(dbcache::Error),
     HabitatCore(hcore::Error),
     HTTP(hyper::status::StatusCode),
@@ -38,10 +37,6 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let msg = match *self {
             Error::BadPort(ref e) => format!("{} is an invalid port. Valid range 1-65535.", e),
-            Error::ConfigFileSyntax(ref e) => {
-                format!("Syntax errors while parsing TOML configuration file:\n\n{}",
-                        e)
-            }
             Error::DataStore(ref e) => format!("DataStore error, {}", e),
             Error::HabitatCore(ref e) => format!("{}", e),
             Error::HTTP(ref e) => format!("{}", e),
@@ -74,7 +69,6 @@ impl error::Error for Error {
     fn description(&self) -> &str {
         match *self {
             Error::BadPort(_) => "Received an invalid port or a number outside of the valid range.",
-            Error::ConfigFileSyntax(_) => "Error parsing contents of configuration file",
             Error::DataStore(ref err) => err.description(),
             Error::HabitatCore(ref err) => err.description(),
             Error::HTTP(_) => "Received an HTTP error",

--- a/components/depot/src/main.rs
+++ b/components/depot/src/main.rs
@@ -18,6 +18,7 @@ use std::process;
 use std::str::FromStr;
 
 use depot::{server, Config, Error, Result};
+use hcore::config::ConfigFile;
 
 const VERSION: &'static str = include_str!(concat!(env!("OUT_DIR"), "/VERSION"));
 const CFG_DEFAULT_PATH: &'static str = "/hab/svc/hab-depot/config/server.cfg.toml";


### PR DESCRIPTION
This fixes some of the error messages in reading the configuration file so we don't just get generic OS messages spit out to the command line. This is in core because all of our servers which read toml configuration from file could benefit here.

![gif-keyboard-8353021732604858511](https://cloud.githubusercontent.com/assets/54036/14804267/96890c7a-0b16-11e6-87c0-2a03983ae0c1.gif)
