### PR TITLE
ignore habitat secret key files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ plans/hana/*.rar
 plans/log/
 plans/tmp/
 .vagrant/
+*.sig.key
+*.box.key
+*.sym.key


### PR DESCRIPTION
Just a safety measure so we don't accidentally add any secret Habitat keys to the repo.

Key suffixes defined here: https://github.com/habitat-sh/habitat/blob/master/components/core/src/crypto.rs#L223-L230
