### PR TITLE
[devshell] Prevent the `protobuf` crate binary from being mount-masked.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   && rm -rf /var/lib/apt/lists/*
 
 ENV CARGO_HOME /cargo-cache
-ENV PATH /cargo-cache/bin:$PATH
+ENV PATH $PATH:$CARGO_HOME/bin:/root/.cargo/bin
 
 ARG HAB_DEPOT_URL
 ENV HAB_DEPOT_URL ${HAB_DEPOT_URL:-}
@@ -35,7 +35,7 @@ RUN ln -snf /usr/bin/nodejs /usr/bin/node && npm install -g docco && echo "docco
 
 RUN (adduser --system hab || true) && (addgroup --system hab || true)
 
-RUN cargo install protobuf
+RUN env -u CARGO_HOME cargo install protobuf && rm -rf /root/.cargo/registry
 
 COPY .delivery/scripts/ssh_wrapper.sh /usr/local/bin
 COPY .delivery/scripts/git_src_checkout.sh /usr/local/bin


### PR DESCRIPTION
This change fixes an issue we had in the devshell when trying to build
all components. The `cargo install protobuf` command in the Dockerfile
honors the `$CARGO_HOME` environment variable override (as it should),
but that directory get overlay-mounted whenever a container is started
up which means that our lovingly compiled binaries get masked over.

Instead, we'll install this crate into the default location (under
root's home) and add that path to the environment's `$PATH`.

Signed-off-by: Fletcher Nichol fnichol@nichol.ca
