### PR TITLE
[core] Update crypto module documentation, suitable for rustdocs.

### DIFF
--- a/components/core/src/crypto.rs
+++ b/components/core/src/crypto.rs
@@ -1,8 +1,219 @@
-// Copyright:: Copyright (c) 2015-2016 Chef Software, Inc.
+// Copyright:: Copyright (c) 2015-2016 The Habitat Maintainers
 //
-// The terms of the Evaluation Agreement (Bldr) between Chef Software Inc. and the party accessing
-// this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
-// is made available under an open source license such as the Apache 2.0 License.
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
+
+//! Habitat core encryption and cryptography.
+//!
+//! This module uses [libsodium](https://github.com/jedisct1/libsodium) and its Rust counterpart
+//! [sodiumoxide](https://github.com/dnaq/sodiumoxide) for cryptographic operations.
+//!
+//! # Concepts and terminology:
+//!
+//! - All public keys, certificates, and signatures are to be referred to as **public**.
+//! - All secret or private keys are to be referred to as **secret**.
+//! - All symmetric encryption keys are to be referred to as **secret**.
+//! - The word `key` by itself does not indicate whether it is **public** or **secret**. The only
+//! exception is if the word `key` appears as part of a file suffix, where it is then considered as
+//! a **secret key** file.
+//! - Referring to keys (by example):
+//!     - A key name: `habitat`
+//!     - A key rev: `201603312016`
+//!     - A key name with rev: `habitat-201603312016`
+//!     - A key file: `habitat-201603312016.pub`
+//!     - A key path or fully qualified key path: `/foo/bar/habitat-201603312016.pub`
+//! - An **Origin** refers to build-time operations, including signing and verifification of a
+//! Habitat artifact.
+//! - An **Organization** or **Org** refers to run-time operations such as deploying a package
+//! signed in a different origin into your own organization. This is abbreviated as "org" in
+//! user-facing command line parameters and internal variable names.
+//! - To distinguish between **Org** and **Origin**, the following might help: Habitat packages
+//! come from an **Origin** and run in an **Organization**.
+//! - A **Ring** is the full set of Supervisors that communicate with each other.
+//! - A **Signing key**, also known as a **sig** key, is used to sign and verify Habitat artifacts.
+//! The file contains a `sig.key` file suffix. Note that sig keys are not compatible with box keys.
+//! - A **Box key** is used for encryption and decryption of arbitrary data. The file contains a
+//! `.box.key` file suffix. Note that box keys are not compatible with sig keys.
+//! - A **Sym key** is used for symmetric encryption, meaning that a shared secret is used to
+//! encrypt a message into a ciphertext and that same secret is used later to decryt the ciphertext
+//! into the original message.
+//! - A **Ring key** is a **sym** key used when sending messages between the Supervisors to prevent
+//! a third party from intercepting the traffic.
+//! - **Key revisions** - There can exist several keys for any given user, service, ring, or origin
+//! via different revision numbers. Revision numbers appear following the key name and are in the
+//! format `{year}{month}{day}{hour24}{minute}{second}`. For all user-facing cryptographic
+//! operations (such as sign, verify, encrypt, decrypt, etc.), the latest key is tried first, and
+//! upon failure, the keys will be tred in reverse chronological order until success or there are
+//! no more keys.
+//!
+//! ***TODO: key revisions are generated as part of a filename, but only the most recent key is
+//! used during crypto operations.***
+//!
+//! # Key file naming
+//!
+//! ## Origin key
+//!
+//! ```text
+//! <origin_name>-<revision>.pub
+//! <origin_name>-<revision>.sig.key
+//! ```
+//!
+//! Example origin key file names ("sig" keys):
+//!
+//! ```text
+//! habitat-201603312016.pub
+//! habitat-201603312016.sig.key
+//! your_company-201604021516.pub
+//! your_company-201604021516.sig.key
+//! ```
+//!
+//! ## User key
+//!
+//! ```text
+//! <user_name>-<revision>.pub
+//! <user_name>-<revision>.box.key
+//! ```
+//!
+//! Example user keys ("box" keys)
+//!
+//! ```text
+//! dave-201603312016.pub
+//! some_user-201603312016.pub
+//! ```
+//!
+//! ## Service key
+//!
+//! ```text
+//! <service_name>.<group>@<organization>-<revision>.pub
+//! <service_name>.<group>@<organization>-<revision>.box.key
+//! ```
+//!
+//! Example Service keys:
+//!
+//! ```text
+//! redis.default@habitat-201603312016.pub
+//! ```
+//!
+//! ## Ring key
+//!
+//! ```text
+//! <ring_name>-<revision>.sym.key
+//! ```
+//!
+//! Example Ring keys:
+//!
+//! ```text
+//! staging-201603312016.sym.key
+//! ```
+//!
+//! # File fomats
+//!
+//! ## Habitat artifacts
+//!
+//! A signed Habitat artifact (a file with the extention `.hart`) has 5 plaintext lines followed by
+//! a binary blob of data, which is an unsigned, compressed tarfile. The lines are as follows:
+//!
+//! 1. The artifact format version
+//! 1. The name with revision of the origin key which was used to sign the artifact
+//! 1. The hashing algorithm used, which at present is only `BLAKE2b`, but may expand in the future
+//! 1. A Base64 *signed* value of the binary blob's Base64 file hash
+//! 1. The last line is left empty, meaning that 2 newline characters (`\n`) separate the header
+//!    from the payload
+//!
+//! The remainder of the file is a compressed tarball of the contents to be extracted on disk. At
+//! present, the tarball is compressed using `xz` but is considered an implementation detail. Also
+//! note unlike the format of keys, the compressed tarball is **not** Base64 encoded--it is the
+//! compressed tarball itself.
+//!
+//! Note that the BLAKE2b hash functions use a digest length of 32 bytes (256 bits!). More details
+//! about the hashing strategy can be found in the [libsodium hashing
+//! documentation](https://download.libsodium.org/doc/hashing/generic_hashing.html).
+//!
+//! Signing uses a secret origin key, while verifying uses the public origin key. Thus, it it safe
+//! to distribute public origin keys.
+//!
+//! Example header:
+//!
+//! ```text
+//! HART-1
+//! habitat-20160405144945
+//! BLAKE2b
+//! signed BLAKE2b signature
+//!
+//! <binary-blob>
+//! ```
+//!
+//! Due to the simple, line-driven structure of the header it's possible to examine the contents of
+//! a Habitat artifact using standard Unix tooling:
+//!
+//! ```text
+//! $ head -4 /path/to/acme-glibc-2.22-20160310192356-x86_64-linux.hart
+//! HART-1
+//! habitat-20160405144945
+//! BLAKE2b
+//! abc123...
+//! ```
+//!
+//! Note that the `abc123` would be a Base64 string in a real file.
+//!
+//! It's also possible to extract a plain compressed tarball from a signed Habitat artifact using
+//! the `tail(1)` Unix command:
+//!
+//! ```text
+//! tail -n +6 /tmp/somefile.hart > somefile.tar.xz
+//! ```
+//!
+//! The above command starts streaming the file to standard out at line 6, skipping the first 5
+//! plaintext lines.
+//!
+//! If the Habitat artifact needs to be extracted on disk without verifying its integrity or
+//! authenticity, this can be accomplised with:
+//!
+//! ```text
+//! tail -n +6 /tmp/somefile.hart | xzcat | tar x -C /
+//! ```
+//!
+//! **Caution!** Working with Habitat artifacts in this manner this is not normally recommended and
+//! is **not** a supported workflow for working with Habitat artifacts--they are signed for very
+//! important reasons.
+//!
+//! ## Encrypted payloads
+//!
+//! The first 4 lines of an encrypted payload are as follows:
+//!
+//! 1. The encrypted format version
+//! 1. The key name, including revision of the source user
+//! 1. The key name, including revision of the recipient service
+//! 1. A nonce, in Bas64 format.
+//! 1. The encrypted message in Bas64 format.
+//!
+//! ```text
+//! BOX-1
+//! signing key name
+//! recipient key name
+//! nonce_base64
+//!
+//! <ciphertext_base64>
+//! ```
+//!
+//! ## Ring keys
+//!
+//! There are 3 lines, that is 3 parts that are separtated by a newline character `\n`. They are as
+//! follows:
+//!
+//! 1. Encrypted format version
+//! 1. The ring key name, including revision
+//! 1. The key itself, which is Bas64-encoded
+//!
+//! ```text
+//! SYM-1
+//! staging-20160405144945
+//!
+//! <symkey_base64>
+//! ```
+
 use std::ptr;
 use std::collections::HashSet;
 use std::fs;
@@ -32,190 +243,6 @@ use env as henv;
 use error::{Error, Result};
 use fs::CACHE_KEY_PATH;
 use util::perm;
-
-/// Habitat uses [libsodium](https://github.com/jedisct1/libsodium) and it's Rust
-/// counterpart [sodiumoxide](https://github.com/dnaq/sodiumoxide) for
-/// cryptographic operations.
-///
-/// ### Concepts and terminology:
-/// - All public keys/certificates/signatures will be referred to as **public**.
-/// - All secret or private keys will be referred to as **secret**.
-/// - All symmetric encryption keys will be referred to as **secret**.
-/// - The word `key` by itself does not indicate **public** or **secret**. The only
-/// exception is if the word key appears as part of a file suffix, where it is then
-/// considered the **secret key** file.
-/// - Referring to keys (by example):
-/// 	- key name: habitat
-/// 	- key rev: 201603312016
-/// 	- key name with rev: habitat-201603312016
-/// 	- key file: habitat-201603312016.pub
-/// 	- key path / fully qualified key path: /foo/bar/habitat-201603312016.pub
-/// - **Origin** -  refers to build-time operations, including signing and
-/// verifification of an artifact.
-/// - **Organization** / **Org** - refers to run-time operations that can happen in Habitat,
-/// such as deploying a package signed in a different origin into your own organization.
-/// Abbreviated as "org" in CLI params and variable names.
-/// - **Org vs Origin** - Habitat packages come from an origin and run in an organization
-/// - **Ring** - The full set of Supervisors that communicate with each other.
-/// - **Signing keys** - aka **sig** keys. These are used to sign and verify
-/// packages. Contains a `sig.key` file suffix. Sig keys are NOT compatible with
-/// box keys.
-/// - **Box keys** - used for encryption/decryption of arbitrary data. Contains a
-/// `.box.key` file suffix. Box keys are NOT compatible with sig keys.
-/// - **Sym keys** - used for symmetric encryption, meaning that a shared secret is used to encrypt
-/// a message into a cyphertext and that same secret is used later to decryt the cyphertext into
-/// the original message.
-/// - **Ring key** - A Sym key used when sending messages between the Supervisors to prevent a
-/// third party from intercepting the traffic.
-/// - **Key revisions** - Habitat can use several keys for any given user, service,
-/// or origin via different revision numbers. Revision numbers appear following the
-/// key name and are in the format
-/// `{year}{month}{day}{hour24}{minute}{second}`. For all user-facing cryptographic
-/// operations (sign/verify/encrypt/decrypt), the latest key is tried first, and
-/// upon failure, Habitat will try keys in reverse chronological order until
-/// success or there are no more keys. ***TODO: key revisions are generated as part
-/// of a filename, but only the most recent key is used during crypto operations.***
-///
-
-/// ### Key name format
-///
-/// - Origin key
-///
-/// ```text
-/// <origin_name>-<revision>.pub
-/// <origin_name>-<revision>.sig.key
-/// ```
-///
-/// - User key
-///
-/// ```text
-/// <user_name>-<revision>.pub
-/// <user_name>-<revision>.box.key
-/// ```
-///
-/// - Service key
-///
-/// ```text
-/// <service_name>.<group>@<organization>-<revision>.pub
-/// <service_name>.<group>@<organization>-<revision>.box.key
-/// ```
-///
-/// - Ring key
-///
-/// ```text
-/// <ring_name>-<revision>.sym.key
-/// ```
-///
-/// Example origin key file names ("sig" keys):
-///
-/// ```text
-/// habitat-201603312016.pub
-/// habitat-201603312016.sig.key
-/// your_company-201604021516.pub
-/// your_company-201604021516.sig.key
-/// ```
-///
-/// Example user keys ("box" keys)
-///
-/// ```text
-/// dave-201603312016.pub
-/// some_user-201603312016.pub
-/// ```
-///
-/// Example Service keys:
-///
-/// ```text
-/// redis.default@habitat-201603312016.pub
-/// ```
-///
-/// Example Ring keys:
-///
-/// ```text
-/// staging-201603312016.sym.key
-/// ```
-///
-///
-/// ### Habitat signed artifact format
-///
-/// A signed `.hart` artifact has 3 plaintext lines followed by a binary blob
-/// of data, which is the unsigned tarfile.
-///
-/// - The first plaintext line is the version of the artifact format
-/// - The second plaintext line is the name of the origin signing key that was used
-/// to sign this artifact.
-/// - The third plaintext line is the hashing algorithm used, which will be
-/// `BLAKE2b` unless our use of crypto is expanded some time in the future.
-/// - Our BLAKE2b hash functions use a digest length of 32 bytes (256 bits!).
-/// information from the binary data
-/// - The fourth plaintext line is a base64 *signed* value of the binary blob's
-/// base64 file hash. Signing uses a secret origin key, while verifying uses the
-/// public origin key. Thus, it it safe to distribute public origin keys.
-/// - The fifth line is left empty, meaning that 2 newline characters separate the header
-///
-/// Example header:
-/// ```text
-/// HART-1
-/// habitat-20160405144945
-/// BLAKE2b
-/// signed BLAKE2b signature
-///
-/// <binary-blob>
-/// ```
-///
-/// https://download.libsodium.org/doc/hashing/generic_hashing.html
-///
-/// It's possible to examine the contents of a `.hart` file from a Linux shell:
-///
-/// ```text
-/// $ head -4 /path/to/acme-glibc-2.22-20160310192356-x86_64-linux.hart
-/// HART-1
-/// habitat-20160405144945
-/// BLAKE2b
-/// w4yC7/QADdC+NfH/wgN5u4K94nMieb1TxTVzbSfpMwRQ4k+YwhLs1nDXSIbSC8jHdF/7/LqLWtgPvGDmoKIvBDI0aGpIcGdlNDJhMDBnQ3lsMVVFM0JvRlZGSHhXcnBuWWF0/// SllXTXo1ZDg9
-/// # Note that this is an example signature only
-/// ```
-///
-/// It is also possible to extract a plain tarball from a signed `.hart` artifact using the following command:
-///
-/// ```text
-/// tail -n +6 /tmp/somefile.hart > somefile.tar
-/// # start at line 6, skipping the first 5 plaintext lines.
-/// ```
-///
-/// ### Habitat encrypted payload format
-///
-/// The first 4 lines of an encrypted payload are as follows:
-///
-/// 0. encrypted format version #, the current version is `0.1.0`
-/// 1. The key name, including revision of the source user
-/// 2. The key name, including revision of the recipient service
-/// 3. A nonce, in base64 format.
-/// 4. The encrypted message in base64 format.
-///
-/// ```text
-/// BOX-1
-/// signing key name
-/// recipient key name
-/// nonce_base64
-///
-/// <ciphertext_base64>
-/// ```
-///
-/// ### Habitat Ring key format
-///
-/// There are 3 lines, that is 3 parts that are separtated by a newline character `\n`. They are as
-/// follows:
-///
-/// 0. Encrypted format version #, the current version is `1`
-/// 1. The ring key name, including revision
-/// 2. The key itself, which is base64-encoded
-///
-/// ```text
-/// SYM-1
-/// staging-20160405144945
-///
-/// <symkey_base64>
-/// ```
 
 /// The suffix on the end of a public sig/box file
 static PUB_KEY_SUFFIX: &'static str = "pub";
@@ -254,7 +281,12 @@ static SECRET_SYM_KEY_VERSION: &'static str = "SYM-SEC-1";
 
 const BUF_SIZE: usize = 1024;
 
-/// You can ask for both keys at once
+/// A pair key related key (public and secret) which have a name and revision.
+///
+/// Depending on the type of keypair, the public key may be empty or not apply, or one or both of
+/// the keys may not be present due to the loading context. For example, the act of verifying a
+/// signed message or artifact only requires the public key to be present, whereas the act of
+/// signing will require the secret key to be present.
 #[derive(Clone)]
 pub struct KeyPair<P, S> {
     /// The name of the key, ex: "habitat"
@@ -622,10 +654,9 @@ impl Context {
         }
     }
 
-
-    /// *********************************************
-    /// Key generation functions
-    /// *******************************************
+    // *******************************************
+    // Key generation functions
+    // *******************************************
 
     pub fn generate_origin_sig_key(&self, origin: &str) -> Result<String> {
         let revision = self.mk_revision_string();
@@ -804,9 +835,9 @@ impl Context {
         Ok(())
     }
 
-    /// *********************************************
-    /// Key reading functions
-    /// *******************************************
+    // *******************************************
+    // Key reading functions
+    // *******************************************
 
     /// Return a Vec of origin keys with a given name.
     /// The newest key is listed first in the Vec
@@ -884,7 +915,6 @@ impl Context {
         }
         Ok(keys)
     }
-
 
     pub fn get_sig_secret_key(&self, key_with_rev: &str) -> Result<SigSecretKey> {
         let bytes = try!(self.get_sig_secret_key_bytes(key_with_rev));
@@ -995,7 +1025,6 @@ impl Context {
             }
         }
     }
-
 
     /// If a key "belongs" to a filename revision, then add the full stem of the
     /// file (without path, without .suffix)


### PR DESCRIPTION
This change allows us to view the crypto code documentation via `cargo
doc`. Some of the section heading are moved around to keep similar
concepts together and for markdown formatting.

Signed-off-by: Fletcher Nichol fnichol@nichol.ca
