### PR TITLE
Changes to make origins work with the web app

### DIFF
--- a/components/builder-api/Cargo.lock
+++ b/components/builder-api/Cargo.lock
@@ -2,6 +2,7 @@
 name = "habitat_builder_api"
 version = "0.1.0"
 dependencies = [
+ "bodyparser 0.3.0 (git+https://github.com/iron/body-parser.git)",
  "clap 2.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat_builder_protocol 0.1.0",
@@ -14,6 +15,7 @@ dependencies = [
  "router 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicase 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "urlencoded 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zmq 0.7.0 (git+https://github.com/reset/rust-zmq.git?branch=build-rs)",
 ]
@@ -40,6 +42,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "bitflags"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "bodyparser"
+version = "0.3.0"
+source = "git+https://github.com/iron/body-parser.git#6d214973beeb9f886d3c9926dc592d12b18a8749"
+dependencies = [
+ "iron 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "persistent 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "plugin 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "bodyparser"

--- a/components/builder-api/Cargo.toml
+++ b/components/builder-api/Cargo.toml
@@ -18,7 +18,12 @@ redis = "*"
 router = "*"
 rustc-serialize = "*"
 toml = "*"
+unicase = "*"
 urlencoded = "*"
+
+[dependencies.bodyparser]
+
+git = "https://github.com/iron/body-parser.git"
 
 [dependencies.clap]
 version = "*"

--- a/components/builder-api/src/lib.rs
+++ b/components/builder-api/src/lib.rs
@@ -16,6 +16,7 @@ extern crate redis;
 extern crate router;
 extern crate rustc_serialize;
 extern crate toml;
+extern crate unicase;
 extern crate urlencoded;
 extern crate zmq;
 

--- a/web/app/BuilderApiClient.ts
+++ b/web/app/BuilderApiClient.ts
@@ -1,0 +1,29 @@
+// Copyright:: Copyright (c) 2015-2016 The Habitat Maintainers
+//
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
+
+import "whatwg-fetch";
+import config from "./config";
+
+export class BuilderApiClient {
+    private urlPrefix: string = config["builder_url"];
+
+    constructor(private token: string) { }
+
+    public createOrigin(origin) {
+        return new Promise((resolve, reject) => {
+            fetch(`${this.urlPrefix}/origins`, {
+                body: JSON.stringify(origin),
+                headers: {
+                    "Authorization": `Bearer ${this.token}`,
+                },
+                method: "POST",
+            }).then(response => {
+                resolve(response.json());
+            }).catch(error => reject(error));
+        });
+    }
+}

--- a/web/app/actions/origins.ts
+++ b/web/app/actions/origins.ts
@@ -8,6 +8,7 @@
 import {addNotification, SUCCESS, DANGER} from "./notifications";
 import {requestRoute} from "./router";
 import * as api from "../builderApi";
+import {BuilderApiClient} from "../BuilderApiClient";
 
 export const POPULATE_MY_ORIGINS = "POPULATE_MY_ORIGINS";
 export const SET_CURRENT_ORIGIN = "SET_CURRENT_ORIGIN";
@@ -15,11 +16,11 @@ export const SET_CURRENT_ORIGIN_CREATING_FLAG =
     "SET_CURRENT_ORIGIN_CREATING_FLAG";
 export const TOGGLE_ORIGIN_PICKER = "TOGGLE_ORIGIN_PICKER";
 
-export function createOrigin(origin, isFirstOrigin = false) {
+export function createOrigin(origin, token, isFirstOrigin = false) {
     return dispatch => {
         dispatch(setCurrentOriginCreatingFlag(true));
 
-        api.createOrigin(origin).then(origin => {
+        new BuilderApiClient(token).createOrigin(origin).then(origin => {
             if (isFirstOrigin || origin["default"]) {
                 dispatch(setCurrentOrigin(origin));
             }

--- a/web/app/builderApi.ts
+++ b/web/app/builderApi.ts
@@ -10,19 +10,6 @@ import config from "./config";
 
 const urlPrefix = config["builder_url"] || "";
 
-export function createOrigin(origin) {
-    return new Promise((resolve, reject) => {
-        // FIXME: Remove this when we have a real api
-        resolve(origin);
-        fetch(`${urlPrefix}/origins`, {
-            body: JSON.stringify(origin),
-            method: "POST",
-        }).then(response => {
-            resolve(response.json());
-        }).catch(error => reject(error));
-    });
-}
-
 export function createProject(project) {
     return new Promise((resolve, reject) => {
         // FIXME: Remove this when we have a real api
@@ -38,8 +25,6 @@ export function createProject(project) {
 
 export function deleteOrigin(origin) {
     return new Promise((resolve, reject) => {
-        // FIXME: Remove this when we have a real api
-        resolve(origin);
         fetch(`${urlPrefix}/origins/${origin["name"]}`, {
             method: "DELETE",
         }).then(response => {
@@ -59,9 +44,6 @@ export function getMyOrigins() {
 export function isOriginAvailable(name) {
     return new Promise((resolve, reject) => {
         fetch(`${urlPrefix}/origins/${name}`).then(response => {
-            // FIXME: FAKE!
-            if (name === "smith") { resolve(true); }
-
             // Getting a 200 means it exists and is already taken.
             if (response.status === 200) {
                 reject(false);
@@ -70,9 +52,6 @@ export function isOriginAvailable(name) {
                 resolve(true);
             }
         }).catch(error => {
-            // FIXME: FAKE!
-            if (name === "smith") { resolve(true); }
-
             // This happens when there is a network error. We'll say that it is
             // not available.
             reject(false);

--- a/web/app/initialState.ts
+++ b/web/app/initialState.ts
@@ -74,8 +74,7 @@ export default Record({
         current: Record({
             name: "smith",
         })(),
-     //   mine: List(),
-        mine: List([{ name: "smith", default: true }, { name: "core", default: false }, { name: "oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo", default: false }]),
+        mine: List(),
         ui: Record({
             current: Record({
                 creating: false,

--- a/web/app/origin-create-page/OriginCreatePageComponent.ts
+++ b/web/app/origin-create-page/OriginCreatePageComponent.ts
@@ -6,7 +6,7 @@
 // open source license such as the Apache 2.0 License.
 
 import {Control, ControlGroup, FormBuilder, Validators} from "angular2/common";
-import {Component, OnInit} from "angular2/core";
+import {AfterViewInit, Component, OnInit} from "angular2/core";
 import {Observable} from "rxjs";
 import {AppStore} from "../AppStore";
 import {AsyncValidator} from "../AsyncValidator";
@@ -75,15 +75,13 @@ import {requireSignIn} from "../util";
     </div>`
 })
 
-export class OriginCreatePageComponent implements OnInit {
+export class OriginCreatePageComponent implements AfterViewInit, OnInit {
     private form: ControlGroup;
     private maxLength = 255;
     private name: Control;
     private pattern = "^[a-z0-9\-_]+$";
 
     constructor(private formBuilder: FormBuilder, private store: AppStore) {
-        requireSignIn(this);
-
         this.form = formBuilder.group({
             default: new Control(this.isFirstOrigin),
         });
@@ -99,16 +97,23 @@ export class OriginCreatePageComponent implements OnInit {
 
     get username() { return this.store.getState().users.current.username; }
 
-
-    ngOnInit() {
+    ngAfterViewInit() {
         // Attempt to validate when the page loads.
         if (this.isFirstOrigin) {
-            this.name.markAsDirty();
+            setTimeout(() => this.form.controls["name"].markAsDirty(), 1000);
         }
     }
 
+    ngOnInit() {
+        requireSignIn(this);
+    }
+
     private createOrigin(origin) {
-        this.store.dispatch(createOrigin(origin, this.isFirstOrigin));
+        this.store.dispatch(createOrigin(
+            origin,
+            this.store.getState().gitHub.authToken,
+            this.isFirstOrigin
+        ));
         return false;
     }
 }

--- a/web/app/origins-page/OriginsPageComponent.ts
+++ b/web/app/origins-page/OriginsPageComponent.ts
@@ -23,35 +23,47 @@ import {requireSignIn} from "../util";
                [routerLink]="['OriginCreate']">Add Origin</a>
         </div>
         <div class="page-body">
-            <ul class="hab-origins-list">
-                <li *ngFor="#origin of origins">
-                    <a class="hab-item-list hab-no-select"
-                       [class.active]="origin.name === currentOrigin.name">
-                        <div class="hab-item-list--title">
-                            <h3>{{origin.name}}</h3>
-                        </div>
-                        <div class="button hab-item-list--controls">
+            <div *ngIf="origins.size === 0">
+                <div class="hero">
+                    <h3>You don't currently have any origins, let's add one now.</h3>
+                    <p>
+                        <a class="button cta" [routerLink]='["OriginCreate"]'>
+                            Add Origin
+                        </a>
+                    </p>
+                </div>
+            </div>
+            <div *ngIf="origins.size > 0">
+                <ul class="hab-origins-list">
+                    <li *ngFor="#origin of origins">
+                        <a class="hab-item-list hab-no-select"
+                        [class.active]="origin.name === currentOrigin.name">
+                            <div class="hab-item-list--title">
+                                <h3>{{origin.name}}</h3>
+                            </div>
+                            <div class="button hab-item-list--controls">
+                                <button
+                                class="confirm hab-origins-list--default"
+                                (click)="setCurrentOrigin(origin)"
+                                [disabled]="origin.name === currentOrigin.name">
+                                    <span *ngIf="origin.name === currentOrigin.name">
+                                        <i class="octicon octicon-star"></i> Default
+                                    </span>
+                                    <span *ngIf="origin.name !== currentOrigin.name">
+                                        Set as Default
+                                    </span>
+                            </button>
                             <button
-                               class="confirm hab-origins-list--default"
-                               (click)="setCurrentOrigin(origin)"
-                               [disabled]="origin.name === currentOrigin.name">
-                                <span *ngIf="origin.name === currentOrigin.name">
-                                    <i class="octicon octicon-star"></i> Default
-                                </span>
-                                <span *ngIf="origin.name !== currentOrigin.name">
-                                    Set as Default
-                                </span>
-                        </button>
-                        <button
-                            class="danger hab-origins-list--delete"
-                            (click)="deleteOrigin(origin)"
-                            [disabled]="origin.name === currentOrigin.name">
-                            <i class="octicon octicon-trashcan"></i> Delete
-                        </button>
-                        </div>
-                    </a>
-                </li>
-            </ul>
+                                class="danger hab-origins-list--delete"
+                                (click)="deleteOrigin(origin)"
+                                [disabled]="origin.name === currentOrigin.name">
+                                <i class="octicon octicon-trashcan"></i> Delete
+                            </button>
+                            </div>
+                        </a>
+                    </li>
+                </ul>
+            </div>
         </div>
     </div>`,
 })


### PR DESCRIPTION
- Include `Access-Control-Allow-Headers` so CORS POST requests can work
- To create an origin `POST /origins` with a JSON body instead of `POST
  /origins/name`
- Make GET requests to /origins/name return a 404 if it's not found
- Creating an origin gives a 201 instead of a 200 response
- Create a BuilderApi class in the web app that takes the auth token
  in the constructor and makes authenticated requests
- Remove fake origin related data and responses in the web app
- Fix bug on origin create form validation
- Show a message when no origins are present
