### PR TITLE
set socket send/recv timeout for brokers in builder-api

### DIFF
--- a/components/builder-api/Cargo.lock
+++ b/components/builder-api/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
  "toml 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "urlencoded 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zmq 0.7.0 (git+https://github.com/reset/rust-zmq.git?branch=build-rs)",
+ "zmq 0.7.0 (git+https://github.com/reset/rust-zmq.git?branch=habitat)",
 ]
 
 [[package]]
@@ -221,7 +221,7 @@ version = "0.1.0"
 dependencies = [
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "zmq 0.7.0 (git+https://github.com/reset/rust-zmq.git?branch=build-rs)",
+ "zmq 0.7.0 (git+https://github.com/reset/rust-zmq.git?branch=habitat)",
 ]
 
 [[package]]
@@ -820,17 +820,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "zmq"
 version = "0.7.0"
-source = "git+https://github.com/reset/rust-zmq.git?branch=build-rs#edacfbffb8d966a8b5ac1c98eb3a7e29378fa78c"
+source = "git+https://github.com/reset/rust-zmq.git?branch=habitat#a72dbba780614273f2fab5e2a95dfa26b3f28ea8"
 dependencies = [
  "libc 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "zmq-sys 0.7.0 (git+https://github.com/reset/rust-zmq.git?branch=build-rs)",
+ "zmq-sys 0.7.0 (git+https://github.com/reset/rust-zmq.git?branch=habitat)",
 ]
 
 [[package]]
 name = "zmq-sys"
 version = "0.7.0"
-source = "git+https://github.com/reset/rust-zmq.git?branch=build-rs#edacfbffb8d966a8b5ac1c98eb3a7e29378fa78c"
+source = "git+https://github.com/reset/rust-zmq.git?branch=habitat#a72dbba780614273f2fab5e2a95dfa26b3f28ea8"
 dependencies = [
  "libc 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/builder-api/Cargo.toml
+++ b/components/builder-api/Cargo.toml
@@ -33,7 +33,7 @@ features = [ "suggestions", "color", "unstable" ]
 [dependencies.zmq]
 # git = "https://github.com/erickt/rust-zmq.git"
 git = "https://github.com/reset/rust-zmq.git"
-branch = "build-rs"
+branch = "habitat"
 
 [dependencies.habitat_core]
 path = "../core"

--- a/components/builder-api/src/broker.rs
+++ b/components/builder-api/src/broker.rs
@@ -14,6 +14,8 @@ use error::Result;
 
 pub const SESSION_LISTEN_ADDR: &'static str = "inproc://sessionsrv-broker";
 pub const VAULT_LISTEN_ADDR: &'static str = "inproc://vault-broker";
+pub const RECV_TIMEOUT_MS: i32 = 5000;
+pub const SEND_TIMEOUT_MS: i32 = 5000;
 
 pub struct SessionSrv {
     config: Arc<Config>,
@@ -41,6 +43,8 @@ impl SessionSrv {
 
     pub fn connect(ctx: &Arc<Mutex<zmq::Context>>) -> Result<zmq::Socket> {
         let mut socket = ctx.lock().unwrap().socket(zmq::REQ).unwrap();
+        socket.set_rcvtimeo(RECV_TIMEOUT_MS).unwrap();
+        socket.set_sndtimeo(SEND_TIMEOUT_MS).unwrap();
         socket.connect(SESSION_LISTEN_ADDR).unwrap();
         Ok(socket)
     }
@@ -96,6 +100,8 @@ impl VaultSrv {
 
     pub fn connect(ctx: &Arc<Mutex<zmq::Context>>) -> Result<zmq::Socket> {
         let mut socket = ctx.lock().unwrap().socket(zmq::REQ).unwrap();
+        socket.set_rcvtimeo(RECV_TIMEOUT_MS).unwrap();
+        socket.set_sndtimeo(SEND_TIMEOUT_MS).unwrap();
         socket.connect(VAULT_LISTEN_ADDR).unwrap();
         Ok(socket)
     }

--- a/components/builder-jobsrv/Cargo.toml
+++ b/components/builder-jobsrv/Cargo.toml
@@ -22,7 +22,7 @@ features = [ "suggestions", "color", "unstable" ]
 [dependencies.zmq]
 # git = "https://github.com/erickt/rust-zmq.git"
 git = "https://github.com/reset/rust-zmq.git"
-branch = "build-rs"
+branch = "habitat"
 
 [dependencies.habitat_core]
 path = "../core"

--- a/components/builder-sessionsrv/Cargo.toml
+++ b/components/builder-sessionsrv/Cargo.toml
@@ -31,7 +31,7 @@ branch = "update-r2d2"
 [dependencies.zmq]
 # git = "https://github.com/erickt/rust-zmq.git"
 git = "https://github.com/reset/rust-zmq.git"
-branch = "build-rs"
+branch = "habitat"
 
 [dependencies.habitat_core]
 path = "../core"

--- a/components/builder-vault/Cargo.toml
+++ b/components/builder-vault/Cargo.toml
@@ -29,7 +29,7 @@ branch = "update-r2d2"
 [dependencies.zmq]
 # git = "https://github.com/erickt/rust-zmq.git"
 git = "https://github.com/reset/rust-zmq.git"
-branch = "build-rs"
+branch = "habitat"
 
 [dependencies.habitat_core]
 path = "../core"

--- a/components/builder-worker/Cargo.toml
+++ b/components/builder-worker/Cargo.toml
@@ -22,7 +22,7 @@ features = [ "suggestions", "color", "unstable" ]
 [dependencies.zmq]
 # git = "https://github.com/erickt/rust-zmq.git"
 git = "https://github.com/reset/rust-zmq.git"
-branch = "build-rs"
+branch = "habitat"
 
 [dependencies.habitat_core]
 path = "../core"

--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -10,4 +10,4 @@ protobuf = "*"
 [dependencies.zmq]
 # git = "https://github.com/erickt/rust-zmq.git"
 git = "https://github.com/reset/rust-zmq.git"
-branch = "build-rs"
+branch = "habitat"


### PR DESCRIPTION
Default socket timeout is `-1` which is "infinite". We definitely don't want an infinite timeout for anything in the http api (or probably anywhere).

![gif-keyboard-1797359787960175918](https://cloud.githubusercontent.com/assets/54036/14972440/dcf7ffb6-1090-11e6-990c-292b8d8c2cf2.gif)
