### PR TITLE
attempt to download signing keys upon artifact installation, new origin keys Depot API

### DIFF
--- a/components/core/src/crypto.rs
+++ b/components/core/src/crypto.rs
@@ -15,9 +15,12 @@
 //! - All public keys, certificates, and signatures are to be referred to as **public**.
 //! - All secret or private keys are to be referred to as **secret**.
 //! - All symmetric encryption keys are to be referred to as **secret**.
-//! - The word `key` by itself does not indicate whether it is **public** or **secret**. The only
-//! exception is if the word `key` appears as part of a file suffix, where it is then considered as
-//! a **secret key** file.
+//! - In general, the word `key` by itself does not indicate something as
+//! **public** or **secret**. The exceptions to this rule are as follows:
+//!     - if the word key appears in a URL, then we are referring to a public key to
+//!       conform to other API's that offer similar public key downloading functionality.
+//!     - the word `key` appears as part of a file suffix, where it is then considered as
+//!       a **secret key** file.
 //! - Referring to keys (by example):
 //!     - A key name: `habitat`
 //!     - A key rev: `201603312016`
@@ -313,7 +316,8 @@ pub type SigKeyPair = KeyPair<SigPublicKey, SigSecretKey>;
 pub type BoxKeyPair = KeyPair<BoxPublicKey, BoxSecretKey>;
 pub type SymKey = KeyPair<(), SymSecretKey>;
 
-enum KeyType {
+#[derive(PartialEq, Eq)]
+pub enum KeyType {
     Sig,
     Box,
     Sym,
@@ -332,9 +336,82 @@ fn env_var_or_default(env_var: &str, default: &str) -> String {
 /// Return the canonical location for nacl keys
 /// This value can be overridden via CACHE_KEY_PATH_ENV_VAR,
 /// which is useful for testing
-fn nacl_key_dir() -> String {
+pub fn nacl_key_dir() -> String {
     env_var_or_default(CACHE_KEY_PATH_ENV_VAR, CACHE_KEY_PATH)
 }
+
+/// takes a Path to a key, and returns the origin and revision in a tuple
+/// ex: /src/foo/core-xyz-20160423193745.pub yields ("core", "20160423193745")
+/// TODO DP: this should be in a crypto::utils package
+pub fn parse_origin_key_filename<P: AsRef<Path>>(keyfile: P) -> Result<(String, String)> {
+    let stem = match keyfile.as_ref().file_stem().and_then(|s| s.to_str()) {
+        Some(s) => s,
+        None => return Err(Error::CryptoError("Can't parse key filename".to_string()))
+    };
+
+    parse_origin_key_name(stem)
+}
+
+/// takes a string in the form origin-revision and returns a
+/// tuple in the form (origin, revision)
+pub fn parse_origin_key_name(origin_rev: &str) -> Result<(String, String)> {
+    let mut chunks: Vec<&str> = origin_rev.split("-").collect();
+    if chunks.len() < 2 {
+        return Err(Error::CryptoError("Invalid origin key name".to_string()))
+    }
+    let rev = match chunks.pop() {
+        Some(r) => r,
+        None => return Err(Error::CryptoError("Invalid origin key revision".to_string()))
+    };
+    let origin = chunks.join("-").trim().to_owned();
+    Ok((origin, rev.trim().to_owned()))
+}
+
+#[test]
+fn test_parse_origin_key_name() {
+    assert!(parse_origin_key_name("foo").is_ok() == false);
+    match parse_origin_key_name("foo-20160423193745\n") {
+        Ok((origin, rev)) => {
+            assert!(origin == "foo");
+            assert!(rev == "20160423193745");
+        }
+        Err(_) => panic!("Fail!")
+    };
+
+
+    match parse_origin_key_name("foo-bar-baz-20160423193745") {
+        Ok((origin, rev)) => {
+            assert!(origin == "foo-bar-baz");
+            assert!(rev == "20160423193745");
+        }
+        Err(_) => panic!("Fail!")
+    };
+}
+
+#[test]
+fn test_parse_origin_key_filename() {
+    if parse_origin_key_filename(Path::new("/tmp/foo.pub")).is_ok() {
+        panic!("Shouldn't match")
+    };
+
+
+    match parse_origin_key_filename(Path::new("/tmp/core-20160423193745.pub")) {
+        Ok((origin, rev)) => {
+            assert!(origin == "core");
+            assert!(rev == "20160423193745");
+        }
+        Err(_) => panic!("Bad filename")
+    };
+
+    match parse_origin_key_filename(Path::new("/tmp/multi-dash-origin-20160423193745.pub")) {
+        Ok((origin, rev)) => {
+            assert!(origin == "multi-dash-origin");
+            assert!(rev == "20160423193745");
+        }
+        Err(_) => panic!("Bad filename")
+    };
+}
+
 
 /// A Context makes crypto operations available centered on a given
 /// key cache directory.
@@ -444,6 +521,23 @@ impl Context {
             return Err(Error::CryptoError("Can't end of header".to_string()));
         }
         Ok(reader)
+    }
+
+    /// opens up a .hart file and returns the name of the (key, revision)
+    /// of the signer
+    pub fn get_artifact_signer<P: AsRef<Path>>(&self, infilename: P) -> Result<(String, String)> {
+        let f = try!(File::open(infilename));
+        let mut your_format_version = String::new();
+        let mut your_key_name = String::new();
+        let mut reader = BufReader::new(f);
+        if try!(reader.read_line(&mut your_format_version)) <= 0 {
+            return Err(Error::CryptoError("Can't read format version".to_string()));
+        }
+        if try!(reader.read_line(&mut your_key_name)) <= 0 {
+            return Err(Error::CryptoError("Can't read keyname".to_string()));
+        }
+        let origin_rev_pair = try!(parse_origin_key_name(&your_key_name));
+        Ok(origin_rev_pair)
     }
 
     /// verify the crypto signature of a .hart file

--- a/components/depot-client/src/error.rs
+++ b/components/depot-client/src/error.rs
@@ -22,6 +22,7 @@ pub enum Error {
     IO(io::Error),
     NoFilePart,
     NoXFilename,
+    RemoteOriginKeyNotFound(String),
     RemotePackageNotFound(package::PackageIdent),
     WriteSyncFailed,
 }
@@ -40,6 +41,7 @@ impl fmt::Display for Error {
                          not have one")
             }
             Error::NoXFilename => format!("Invalid download from a Depot - missing X-Filename header"),
+            Error::RemoteOriginKeyNotFound(ref e) => format!("{}", e),
             Error::RemotePackageNotFound(ref pkg) => {
                 if pkg.fully_qualified() {
                     format!("Cannot find package in any sources: {}", pkg)
@@ -62,6 +64,7 @@ impl error::Error for Error {
             Error::IO(ref err) => err.description(),
             Error::NoFilePart => "An invalid path was passed - we needed a filename, and this path does not have one",
             Error::NoXFilename => "Invalid download from a Depot - missing X-Filename header",
+            Error::RemoteOriginKeyNotFound(_) => "Remote origin key not found",
             Error::RemotePackageNotFound(_) => "Cannot find a package in any sources",
             Error::WriteSyncFailed => "Could not write to destination; bytes written was 0 on a non-0 buffer",
         }

--- a/components/depot-core/src/data_object.rs
+++ b/components/depot-core/src/data_object.rs
@@ -218,3 +218,34 @@ impl AsRef<package::PackageIdent> for Package {
         self.ident.as_ref()
     }
 }
+
+
+#[derive(RustcEncodable, RustcDecodable, Eq, PartialEq, Debug, Clone)]
+pub struct OriginKeyIdent {
+    pub origin: String,
+    pub revision: String,
+    pub location: String,
+}
+
+impl OriginKeyIdent {
+    pub fn new(origin: String, revision: String, location: String) -> OriginKeyIdent {
+        OriginKeyIdent {
+            origin: origin,
+            revision: revision,
+            location: location,
+        }
+    }
+}
+
+impl fmt::Display for OriginKeyIdent {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}-{}", self.origin, self.revision)
+    }
+}
+
+impl AsRef<OriginKeyIdent> for OriginKeyIdent {
+    fn as_ref(&self) -> &OriginKeyIdent {
+        self
+    }
+}
+

--- a/components/depot-core/src/lib.rs
+++ b/components/depot-core/src/lib.rs
@@ -13,5 +13,15 @@ extern crate rustc_serialize;
 
 pub mod data_object;
 
+use hyper::header::{Headers, ContentDisposition, DispositionType, DispositionParam, Charset};
+
 header! { (XFileName, "X-Filename") => [String] }
 header! { (ETag, "ETag") => [String] }
+
+/// convenience function for setting Content-Disposition
+pub fn set_disposition(headers: &mut Headers, filename: String, charset: Charset) -> () {
+    headers.set(ContentDisposition {
+        disposition: DispositionType::Attachment,
+        parameters: vec![DispositionParam::Filename( charset, None, filename.into_bytes())],
+    });
+}

--- a/components/depot/doc/api.raml
+++ b/components/depot/doc/api.raml
@@ -1,0 +1,167 @@
+#%RAML 1.0
+title: Depot API
+version: v1
+baseUri: http://api.samplehost.com
+# in alphabetical order
+/origins:
+  /{origin}:
+    /keys:
+      get:
+        description: Return a list of key revisions for an organization.
+        responses:
+          200:
+            body:
+              application/json:
+                example: |
+                  [
+                    {
+                      "origin": "core",
+                      "revision": "20160423193732",
+                      "location": "/origins/core/keys/20160423193732"
+                    },
+                    {
+                      "origin": "core",
+                      "revision": "20160423193733",
+                      "location": "/origins/core/keys/20160423193733"
+                    }
+                  ]
+      /{revision}:
+          get:
+            description: Get a key revision for a specific origin
+            responses:
+              200:
+                body:
+                  text/plain:
+                    example: |
+                      SIG-PUB-1
+                      core-20160423193745
+
+                      Jpmj1gD9oTFCgz3wSLltt/QB6RTmNRWoUTe+xhDTIHc=
+          post:
+            description: Upload a new key revision for an origin
+            body:
+              text/plain:
+                example: |
+                  SIG-PUB-1
+                  core-20160423193745
+
+                  Jpmj1gD9oTFCgz3wSLltt/QB6RTmNRWoUTe+xhDTIHc=
+
+/pkgs:
+  /{origin}:
+    get:
+      description: List packages for an origin
+      responses:
+        200:
+        400:
+        404:
+        500:
+    /{pkg}:
+      description: TODO
+      get:
+        description: TODO
+        responses:
+          200:
+          400:
+          404:
+          500:
+      /latest:
+        get:
+          description: TODO
+          responses:
+            200:
+            404:
+            500:
+      /{version}:
+        get:
+          description: TODO
+          responses:
+            200:
+            400:
+            404:
+            500:
+        /latest:
+          get:
+            responses:
+              200:
+              404:
+              500:
+        /{release}:
+          get:
+            responses:
+              200:
+              404:
+              500:
+          post:
+            responses:
+              200:
+              400:
+              422:
+              409:
+          /download:
+            get:
+              responses:
+                200:
+                400:
+                500:
+/views:
+  get:
+    description: List all views
+    responses:
+      200:
+        body:
+          application/json:
+            example: |
+              {}
+  /{view}:
+    /pkgs:
+      /{origin}:
+        get:
+          description: List packages for an origin
+          responses:
+            200:
+              description: Return a list of packages for an origin
+            400:
+              description: Origin not supplied
+            404:
+              description: Origin does not exist
+            500:
+              description: Datastore error
+        /{pkg}:
+          get:
+            description: TODO
+            responses:
+              200:
+                description: Return a list of packages for an origin
+              400:
+                description: Origin not supplied
+              404:
+                description: Origin does not exist
+              500:
+                description: Datastore error
+          /latest:
+            get:
+              responses:
+                200:
+                404:
+                500:
+          /{version}:
+            get:
+            /latest:
+              get:
+                responses:
+                  200:
+                  404:
+                  500:
+            /{release}:
+              get:
+                responses:
+                  200:
+                  404:
+                  500:
+              /promote:
+                post:
+                  responses:
+                    200:
+                    404:
+                    500:

--- a/components/depot/src/lib.rs
+++ b/components/depot/src/lib.rs
@@ -92,8 +92,16 @@ impl Depot {
                           ident.release.as_ref().unwrap()))
     }
 
-    fn key_path(&self, name: &str) -> PathBuf {
-        self.keys_path().join(format!("{}.asc", name))
+    fn key_path(&self, key: &str, rev: &str) -> PathBuf {
+        let mut digest = Sha256::new();
+        let mut output = [0; 64];
+        let key_with_rev = format!("{}-{}.pub", key, rev);
+        digest.input_str(&key_with_rev.to_string());
+        digest.result(&mut output);
+        self.keys_path()
+            .join(format!("{:x}", output[0]))
+            .join(format!("{:x}", output[1]))
+            .join(format!("{}-{}.pub", key, rev))
     }
 
     fn keys_path(&self) -> PathBuf {

--- a/components/depot/tests/support/setup.rs
+++ b/components/depot/tests/support/setup.rs
@@ -9,7 +9,7 @@ use std::sync::{Once, ONCE_INIT};
 use std::env;
 
 pub fn origin_setup() {
-    env::set_var("HABITAT_KEY_CACHE", super::path::key_cache());
+    env::set_var("HAB_CACHE_KEY_PATH", super::path::key_cache());
 }
 
 pub fn simple_service() {
@@ -29,15 +29,7 @@ pub fn simple_service() {
 }
 
 pub fn key_install() {
-    static ONCE: Once = ONCE_INIT;
-    ONCE.call_once(|| {
-        let mut cmd = match super::command::sup(&["key",
-                                                &super::path::fixture_as_string("chef-public.asc")]) {
-                                                    Ok(cmd) => cmd,
-                                                    Err(e) => panic!("{:?}", e),
-    };
-    cmd.wait_with_output();
-    });
+    // TODO DP: is there a relatively static pub key I can use?
 }
 
 fn dockerize(ident_str: &str) {

--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -91,6 +91,19 @@ pub fn get() -> App<'static, 'static> {
                         (about: "Generates a Habitat origin key")
                         (@arg ORIGIN: "The origin name")
                  )
+                 (@subcommand download =>
+                        (about: "Download origin key(s) to HAB_CACHE_KEY_PATH")
+                        (@arg ORIGIN: +required "The origin name")
+                        (@arg REVISION: "The key revision")
+                        (@arg DEPOT_URL: -u --url +takes_value {valid_url}
+                         "Use a specific Depot URL")
+                 )
+                 (@subcommand upload =>
+                        (about: "Upload a public origin key to the depot")
+                        (@arg FILE: +required {file_exists} "Path to a local public origin key file on disk")
+                        (@arg DEPOT_URL: -u --url +takes_value {valid_url}
+                         "Use a specific Depot URL")
+                 )
             )
         )
         (@subcommand service =>

--- a/components/hab/src/command/artifact/crypto.rs
+++ b/components/hab/src/command/artifact/crypto.rs
@@ -4,8 +4,33 @@
 // this file ("Licensee") apply to Licensee's use of the Software until such time that the Software
 // is made available under an open source license such as the Apache 2.0 License.
 
+use std::path::{Path};
+
+use depot_client;
 use error::{Error, Result};
 use hcore::crypto;
+
+
+pub fn download_origin_keys(depot: &str, origin: &str, revision: Option<&str>) -> Result<()> {
+    let outdir = crypto::nacl_key_dir();
+    match revision {
+        Some(rev) => {
+            try!(depot_client::get_origin_key(depot, origin, rev, &outdir));
+        }
+        None => {
+             try!(depot_client::get_origin_keys(depot, origin, &outdir));
+        }
+    };
+    println!("Successfully downloaded origin key(s)");
+    Ok(())
+}
+
+pub fn upload_origin_key(depot: &str, keyfile: &Path) -> Result<()> {
+    let (origin, revision) = try!(crypto::parse_origin_key_filename(keyfile));
+    try!(depot_client::post_origin_key(depot, &origin, &revision, keyfile));
+    println!("Successfully uploaded origin key");
+    Ok(())
+}
 
 pub fn generate_origin_key(origin: &str) -> Result<()> {
     let crypto_ctx = crypto::Context::default();

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -96,7 +96,9 @@ fn run_hab() -> Result<()> {
             match matches.subcommand() {
                 ("key", Some(m)) => {
                     match m.subcommand() {
+                        ("download", Some(sc)) => try!(sub_origin_key_download(sc)),
                         ("generate", Some(sc)) => try!(sub_origin_key_generate(sc)),
+                        ("upload", Some(sc)) => try!(sub_origin_key_upload(sc)),
                         _ => unreachable!(),
                     }
                 }
@@ -265,9 +267,27 @@ fn sub_file_upload(m: &ArgMatches) -> Result<()> {
     Ok(())
 }
 
+fn sub_origin_key_download(m: &ArgMatches) -> Result<()> {
+    let origin = m.value_of("ORIGIN").unwrap();
+    let revision = m.value_of("REVISION");
+    let env_or_default = henv::var(DEPOT_URL_ENVVAR).unwrap_or(DEFAULT_DEPOT_URL.to_string());
+    let url = m.value_of("DEPOT_URL").unwrap_or(&env_or_default);
+    try!(command::artifact::crypto::download_origin_keys(&url, &origin, revision));
+    Ok(())
+}
+
 fn sub_origin_key_generate(m: &ArgMatches) -> Result<()> {
     let origin = try!(origin_param_or_env(&m));
     try!(command::artifact::crypto::generate_origin_key(&origin));
+    Ok(())
+}
+
+fn sub_origin_key_upload(m: &ArgMatches) -> Result<()> {
+    let env_or_default = henv::var(DEPOT_URL_ENVVAR).unwrap_or(DEFAULT_DEPOT_URL.to_string());
+    let url = m.value_of("DEPOT_URL").unwrap_or(&env_or_default);
+    // required field
+    let keyfile = Path::new(m.value_of("FILE").unwrap());
+    try!(command::artifact::crypto::upload_origin_key(url, &keyfile));
     Ok(())
 }
 


### PR DESCRIPTION
# Overview

Upon artifact install, check to see if we have the signing origin key for an artifact in our local key cache (`HAB_CACHE_KEY_PATH`). If not, try to download it from the origin and continue with artifact verification. Initially, I had implemented package install to download _all_ keys for an origin. Upon discussion with the team, we decided it would be best for the depot to download a single key at a time, since we have the exact key w/ revision in the .hart header.

This PR adds 4 new routes to the depot API for uploading/download origin keys. Origin keys are stored in a hashed file structure on disk, and metadata is stored as a Redis set with `origin_keys` as the prefix. For example, `origin_keys:core` is a set of all keys for the `core` origin. Redis-backed storage for keys buys us the ability to list all keys for a given origin.
## New `hab` commands:
- `hab origin key upload /path/to/some_origin.pub`
  - upload an origin key by filename.
  - Upload will not overwrite an existing key.
- `hab origin key download some_origin`
  - this command downloads all public keys for a specific origin into the `HAB_CACHE_KEY_PATH` directory.
- `hab origin key download some_origin revision`
  - this command downloads a single public key w/ revision into the `HAB_CACHE_KEY_PATH` directory.
## Depot API

The new routes in the Depot API are as follows:
#### List all keys

GET `/origins/:origin/keys`

Return a list of all keys for an origin in the following format:

Example response:

```
[
    {
      "origin": "core",
      "revision": "20160423193732",
      "location": "/origins/core/keys/20160423193732"
    },
    {
      "origin": "core",
      "revision": "20160423193733",
      "location": "/origins/core/keys/20160423193733"
    }
]
```
#### Get a specific origin key by revision
- GET `/origins/:origin/keys/:revision`

Returns a plain-text origin public key:

Example response:

```
SIG-PUB-1
core-20160423193745

Jpmj1gD9oTFCgz3wSLltt/QB6RTmNRWoUTe+xhDTIHc=
```
### Get the newest key revision for an origin
- GET `/origins/:origin/keys/latest`

Returns a plain-text origin public key:

Example response:

```
SIG-PUB-1
core-20160423193745

Jpmj1gD9oTFCgz3wSLltt/QB6RTmNRWoUTe+xhDTIHc=
```
#### Upload a new origin key with revision
- POST `/origins/:origin/keys/:revision`
## RAML

This PR includes an initial implementation of RAML for the new `/origins` key routes. The rest of the routes are marked as TODO. I'd love for this to help test and document our API's in the future.
## Misc Notes
- set Content-Disposition for package + key download
- removed GPG key installation from test setup
- The crypto module is getting huge and probably deserves a refactor soon. 

Sadly, this PR is light on testing. We'll need to get some integration test stuff together soonish. Perhaps a testing spike is in order across the board.
