### PR TITLE
[hab/common] allow arbitrary filenames to apply gossip.toml config

### DIFF
--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -195,6 +195,7 @@ fn sub_config_apply() -> App<'static, 'static> {
          "A version number (positive integer) for this configuration (ex: 42)")
         (@arg FILE: {file_exists_or_stdin}
          "Path to local file on disk (ex: /tmp/config.toml, default: <stdin>)")
+        (@arg AS_GOSSIP: --gossip "Apply config as gossip.toml")
     )
 }
 

--- a/components/hab/src/command/config/apply.rs
+++ b/components/hab/src/command/config/apply.rs
@@ -19,11 +19,12 @@ pub fn start(peers: &Vec<String>,
              ring_key: Option<SymKey>,
              sg: ServiceGroup,
              number: u64,
-             file_path: Option<&Path>)
+             file_path: Option<&Path>,
+             as_gossip: bool)
              -> Result<()> {
     let sg1 = sg.clone();
     let file = match file_path {
-        Some(p) => try!(GossipFile::from_file(sg, p, number)),
+        Some(p) => try!(GossipFile::from_file(sg, p, number, as_gossip)),
         None => {
             let mut body = vec![0; 1024];
             try!(io::stdin().read_to_end(&mut body));

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -214,7 +214,8 @@ fn sub_config_apply(m: &ArgMatches) -> Result<()> {
         Some(p) => Some(Path::new(p)),
     };
 
-    try!(command::config::apply::start(&peers, ring_key, sg, number, file_path));
+    let as_gossip = m.is_present("AS_GOSSIP");
+    try!(command::config::apply::start(&peers, ring_key, sg, number, file_path, as_gossip));
     Ok(())
 }
 


### PR DESCRIPTION
This PR allows [a user to apply gossip.toml data with an arbitrary filename](https://chefio.atlassian.net/browse/BLDR-160).

For example, uploading `foo.toml` below with `--gossip` results in `/hab/svc/redis/gossip.toml` written with the contents of `foo.toml`:

```
    ./target/debug/hab config apply redis.default 1 foo.toml  --gossip
```

Without `--gossip`, the result is a `/hab/svc/redis/files/foo.toml` file:

```
    ./target/debug/hab config apply redis.default 1 foo.toml 
```

would appreciate a once-over from @fnichol 
