### PR TITLE
add a --gossip flag to config apply to upload gossip.toml data

### DIFF
--- a/components/common/src/gossip_file.rs
+++ b/components/common/src/gossip_file.rs
@@ -25,11 +25,24 @@ use error::{Error, Result};
 
 const IDEMPOTENCY_INTERVAL_MINUTES: i64 = 5;
 
+const GOSSIP_TOML: &'static str = "gossip.toml";
+
+/// Determines if this GossipFile payload is gossip.toml or a
+/// "regular" file. Does not include the notion of encryption.
+#[derive(Clone, Debug, PartialEq, Eq, RustcDecodable, RustcEncodable)]
+pub enum GossipFileType {
+    /// This file will be rendered as gossip.toml
+    GossipToml,
+    /// This file will be rendered using GossipFile.file_name
+    File,
+}
+
 /// The gossip file struct.
 #[derive(Clone, Debug, Eq, RustcDecodable, RustcEncodable)]
 pub struct GossipFile {
     pub service_group: ServiceGroup,
     pub file_name: String,
+    pub file_type: GossipFileType,
     body: Vec<u8>,
     checksum: String,
     version_number: u64,
@@ -40,7 +53,8 @@ pub struct GossipFile {
 impl GossipFile {
     pub fn from_file<P: AsRef<Path>>(service_group: ServiceGroup,
                                      file_path: P,
-                                     version_number: u64)
+                                     version_number: u64,
+                                     as_gossip: bool)
                                      -> Result<GossipFile> {
         let path = file_path.as_ref();
         for part in path.components() {
@@ -57,9 +71,19 @@ impl GossipFile {
         let file_name = try!(path.file_name().ok_or(Error::FileNameError));
         let checksum = openssl_hash::hash(openssl_hash::Type::SHA256, &body);
 
+        let (file_type, file_name) = if as_gossip {
+            // override the filename so users don't have to know the file
+            // is named gossip.toml internally
+            (GossipFileType::GossipToml, GOSSIP_TOML.to_string())
+        } else {
+            (GossipFileType::File, file_name.to_string_lossy().to_string())
+        };
+
+
         let cf = GossipFile {
             service_group: service_group,
-            file_name: file_name.to_string_lossy().to_string(),
+            file_name: file_name,
+            file_type: file_type,
             body: body,
             checksum: checksum.as_slice().to_hex(),
             version_number: version_number,
@@ -94,6 +118,7 @@ impl GossipFile {
         let cf = GossipFile {
             service_group: try!(ServiceGroup::from_str(&service_pair.name)),
             file_name: file_name.to_string_lossy().to_string(),
+            file_type: GossipFileType::File, // Doesn't allow an encrypted gossip.toml
             body: encrypted_body,
             checksum: checksum.as_slice().to_hex(),
             version_number: version_number,
@@ -111,9 +136,16 @@ impl GossipFile {
                      -> Result<GossipFile> {
         let checksum = openssl_hash::hash(openssl_hash::Type::SHA256, &body);
 
+        let file_type = if file_name == GOSSIP_TOML {
+            GossipFileType::GossipToml
+        } else {
+            GossipFileType::File
+        };
+
         let cf = GossipFile {
             service_group: service_group,
             file_name: file_name,
+            file_type: file_type,
             body: body,
             checksum: checksum.as_slice().to_hex(),
             version_number: version_number,
@@ -153,7 +185,7 @@ impl GossipFile {
     }
 
     pub fn on_disk_path(&self) -> PathBuf {
-        if &self.file_name == "gossip.toml" {
+        if self.file_type == GossipFileType::GossipToml {
             fs::svc_path(&self.service_group.service).join(&self.file_name)
         } else {
             fs::svc_files_path(&self.service_group.service).join(&self.file_name)
@@ -378,7 +410,7 @@ impl GossipFileList {
             if needs_file_updated == false && written == true {
                 needs_file_updated = true;
             }
-            if gf.file_name == "gossip.toml" {
+            if gf.file_type == GossipFileType::GossipToml {
                 needs_reconfigure = true;
             }
         }
@@ -416,7 +448,7 @@ mod test {
 
     use hcore::crypto::BoxKeyPair;
     use hcore::service::ServiceGroup;
-    use gossip_file::{GossipFile, FileWriteRetry};
+    use gossip_file::{GossipFile, FileWriteRetry, GossipFileType};
 
     fn fixture(name: &str) -> PathBuf {
         env::current_exe()
@@ -436,7 +468,7 @@ mod test {
     fn new_from_file() {
         let cf = GossipFile::from_file(ServiceGroup::from_str("petty.gunslingers").unwrap(),
                                        fixture("foo.bar").as_path(),
-                                       2)
+                                       2, false)
                      .unwrap();
         assert_eq!(cf.service_group,
                    ServiceGroup::from_str("petty.gunslingers").unwrap());
@@ -444,7 +476,24 @@ mod test {
         assert_eq!(cf.checksum,
                    "f34fe622a8fe7565fc15be3ce8bc43d7e32a0dd744ebef509fa0bdb130c0ac31");
         assert_eq!(cf.version_number, 2);
+        assert_eq!(cf.file_type, GossipFileType::File);
     }
+
+
+    #[test]
+    fn new_from_file_as_gossip() {
+        let cf = GossipFile::from_file(ServiceGroup::from_str("petty.gunslingers").unwrap(),
+                                       fixture("foo.bar").as_path(),
+                                       2, true)
+                     .unwrap();
+        assert_eq!(cf.service_group,
+                   ServiceGroup::from_str("petty.gunslingers").unwrap());
+        assert_eq!(cf.file_name, "gossip.toml");
+        assert_eq!(cf.checksum,
+                   "f34fe622a8fe7565fc15be3ce8bc43d7e32a0dd744ebef509fa0bdb130c0ac31");
+        assert_eq!(cf.version_number, 2);
+        assert_eq!(cf.file_type, GossipFileType::GossipToml);
+      }
 
     #[test]
     fn new_from_file_encrypt() {
@@ -466,7 +515,7 @@ mod test {
         assert_eq!(gf.checksum,
                    "f34fe622a8fe7565fc15be3ce8bc43d7e32a0dd744ebef509fa0bdb130c0ac31");
         assert_eq!(gf.version_number, 1);
-
+        assert_eq!(gf.file_type, GossipFileType::File);
         let val_bytes = BoxKeyPair::decrypt(&gf.body, cache.path()).unwrap();
         let decrypted = String::from_utf8(val_bytes).unwrap();
 

--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -195,6 +195,7 @@ fn sub_config_apply() -> App<'static, 'static> {
          "A version number (positive integer) for this configuration (ex: 42)")
         (@arg FILE: {file_exists_or_stdin}
          "Path to local file on disk (ex: /tmp/config.toml, default: <stdin>)")
+        (@arg AS_GOSSIP: --gossip "Apply config as gossip.toml")
     )
 }
 

--- a/components/hab/src/command/config.rs
+++ b/components/hab/src/command/config.rs
@@ -20,11 +20,12 @@ pub mod apply {
                  ring_key: Option<&SymKey>,
                  sg: &ServiceGroup,
                  number: u64,
-                 file_path: Option<&Path>)
+                 file_path: Option<&Path>,
+                 as_gossip: bool)
                  -> Result<()> {
         let sg1 = sg.clone();
         let file = match file_path {
-            Some(p) => try!(GossipFile::from_file(sg.clone(), p, number)),
+            Some(p) => try!(GossipFile::from_file(sg.clone(), p, number, as_gossip)),
             None => {
                 let mut body = vec![0; 1024];
                 try!(io::stdin().read_to_end(&mut body));

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -209,8 +209,8 @@ fn sub_config_apply(m: &ArgMatches) -> Result<()> {
         None => None,
     };
     let sg = try!(ServiceGroup::from_str(m.value_of("SERVICE_GROUP").unwrap()));
-
-    command::config::apply::start(&peers, ring_key.as_ref(), &sg, number, file_path)
+    let as_gossip = m.is_present("AS_GOSSIP");
+    command::config::apply::start(&peers, ring_key.as_ref(), &sg, number, file_path, as_gossip)
 }
 
 fn sub_file_upload(m: &ArgMatches) -> Result<()> {


### PR DESCRIPTION
This PR allows [a user to apply gossip.toml data with an arbitrary filename](https://chefio.atlassian.net/browse/BLDR-160).

For example, uploading `foo.toml` below with `--gossip` results in `/hab/svc/redis/gossip.toml` written with the contents of `foo.toml`:

```
    ./target/debug/hab config apply redis.default 1 foo.toml  --gossip
```

Without `--gossip`, the result is a `/hab/svc/redis/files/foo.toml` file:

```
    ./target/debug/hab config apply redis.default 1 foo.toml 
```

would appreciate a once-over from @fnichol 

(rebased and pulled over from this dead PR: https://github.com/habitat-sh/habitat/pull/501)

Signed-off-by: Dave Parfitt dparfitt@chef.io
