### PR TITLE
fix nested parsing functionality in ParseInto trait

### DIFF
--- a/components/builder-api/src/config.rs
+++ b/components/builder-api/src/config.rs
@@ -52,7 +52,7 @@ impl Default for Config {
 impl ConfigFile for Config {
     type Error = Error;
 
-    fn from_toml(toml: toml::Table) -> Result<Self> {
+    fn from_toml(toml: toml::Value) -> Result<Self> {
         let mut cfg = Config::default();
         try!(toml.parse_into("cfg.http_addr", &mut cfg.http_addr));
         try!(toml.parse_into("cfg.sessionsrv_addr", &mut cfg.sessionsrv_addr));

--- a/components/builder-jobsrv/Cargo.lock
+++ b/components/builder-jobsrv/Cargo.lock
@@ -11,7 +11,7 @@ dependencies = [
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "zmq 0.7.0 (git+https://github.com/reset/rust-zmq.git?branch=build-rs)",
+ "zmq 0.7.0 (git+https://github.com/reset/rust-zmq.git?branch=habitat)",
 ]
 
 [[package]]
@@ -108,7 +108,7 @@ version = "0.1.0"
 dependencies = [
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "zmq 0.7.0 (git+https://github.com/reset/rust-zmq.git?branch=build-rs)",
+ "zmq 0.7.0 (git+https://github.com/reset/rust-zmq.git?branch=habitat)",
 ]
 
 [[package]]
@@ -361,17 +361,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "zmq"
 version = "0.7.0"
-source = "git+https://github.com/reset/rust-zmq.git?branch=build-rs#edacfbffb8d966a8b5ac1c98eb3a7e29378fa78c"
+source = "git+https://github.com/reset/rust-zmq.git?branch=habitat#ee474416e7e40c0c1f81897c13a7aa3155c6f387"
 dependencies = [
  "libc 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "zmq-sys 0.7.0 (git+https://github.com/reset/rust-zmq.git?branch=build-rs)",
+ "zmq-sys 0.7.0 (git+https://github.com/reset/rust-zmq.git?branch=habitat)",
 ]
 
 [[package]]
 name = "zmq-sys"
 version = "0.7.0"
-source = "git+https://github.com/reset/rust-zmq.git?branch=build-rs#edacfbffb8d966a8b5ac1c98eb3a7e29378fa78c"
+source = "git+https://github.com/reset/rust-zmq.git?branch=habitat#ee474416e7e40c0c1f81897c13a7aa3155c6f387"
 dependencies = [
  "libc 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/builder-jobsrv/src/config.rs
+++ b/components/builder-jobsrv/src/config.rs
@@ -31,7 +31,7 @@ impl Default for Config {
 impl ConfigFile for Config {
     type Error = Error;
 
-    fn from_toml(toml: toml::Table) -> Result<Self> {
+    fn from_toml(toml: toml::Value) -> Result<Self> {
         let mut cfg = Config::default();
         try!(toml.parse_into("cfg.listen_addr", &mut cfg.listen_addr));
         Ok(cfg)

--- a/components/builder-sessionsrv/src/config.rs
+++ b/components/builder-sessionsrv/src/config.rs
@@ -44,7 +44,7 @@ impl Default for Config {
 impl ConfigFile for Config {
     type Error = Error;
 
-    fn from_toml(toml: toml::Table) -> Result<Self> {
+    fn from_toml(toml: toml::Value) -> Result<Self> {
         let mut cfg = Config::default();
         try!(toml.parse_into("cfg.listen_addr", &mut cfg.listen_addr));
         try!(toml.parse_into("cfg.datastore_addr", &mut cfg.datastore_addr));

--- a/components/builder-vault/src/config.rs
+++ b/components/builder-vault/src/config.rs
@@ -44,7 +44,7 @@ impl Default for Config {
 impl ConfigFile for Config {
     type Error = Error;
 
-    fn from_toml(toml: toml::Table) -> Result<Self> {
+    fn from_toml(toml: toml::Value) -> Result<Self> {
         let mut cfg = Config::default();
         try!(toml.parse_into("cfg.listen_addr", &mut cfg.listen_addr));
         try!(toml.parse_into("cfg.datastore_addr", &mut cfg.datastore_addr));

--- a/components/builder-worker/Cargo.lock
+++ b/components/builder-worker/Cargo.lock
@@ -10,7 +10,7 @@ dependencies = [
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "zmq 0.7.0 (git+https://github.com/reset/rust-zmq.git?branch=build-rs)",
+ "zmq 0.7.0 (git+https://github.com/reset/rust-zmq.git?branch=habitat)",
 ]
 
 [[package]]
@@ -89,7 +89,7 @@ version = "0.1.0"
 dependencies = [
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "zmq 0.7.0 (git+https://github.com/reset/rust-zmq.git?branch=build-rs)",
+ "zmq 0.7.0 (git+https://github.com/reset/rust-zmq.git?branch=habitat)",
 ]
 
 [[package]]
@@ -261,17 +261,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "zmq"
 version = "0.7.0"
-source = "git+https://github.com/reset/rust-zmq.git?branch=build-rs#edacfbffb8d966a8b5ac1c98eb3a7e29378fa78c"
+source = "git+https://github.com/reset/rust-zmq.git?branch=habitat#ee474416e7e40c0c1f81897c13a7aa3155c6f387"
 dependencies = [
  "libc 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "zmq-sys 0.7.0 (git+https://github.com/reset/rust-zmq.git?branch=build-rs)",
+ "zmq-sys 0.7.0 (git+https://github.com/reset/rust-zmq.git?branch=habitat)",
 ]
 
 [[package]]
 name = "zmq-sys"
 version = "0.7.0"
-source = "git+https://github.com/reset/rust-zmq.git?branch=build-rs#edacfbffb8d966a8b5ac1c98eb3a7e29378fa78c"
+source = "git+https://github.com/reset/rust-zmq.git?branch=habitat#ee474416e7e40c0c1f81897c13a7aa3155c6f387"
 dependencies = [
  "libc 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/builder-worker/src/config.rs
+++ b/components/builder-worker/src/config.rs
@@ -32,7 +32,7 @@ impl Default for Config {
 impl ConfigFile for Config {
     type Error = Error;
 
-    fn from_toml(toml: toml::Table) -> Result<Self> {
+    fn from_toml(toml: toml::Value) -> Result<Self> {
         let mut cfg = Config::default();
         try!(toml.parse_into("cfg.jobsrv_addr", &mut cfg.jobsrv_addr));
         Ok(cfg)

--- a/components/core/src/error.rs
+++ b/components/core/src/error.rs
@@ -15,7 +15,6 @@ use std::string;
 
 use libarchive;
 use regex;
-use toml;
 
 use package;
 
@@ -32,12 +31,14 @@ pub enum Error {
     ConfigFileIO(io::Error),
     /// Parsing error while reading a configuratino file.
     ConfigFileSyntax(String),
+    /// Expected a valid array of values for configuration field value.
+    ConfigInvalidArray(&'static str),
     /// Expected a valid Ipv4 network address for configuration field value.
-    ConfigInvalidIpv4Addr(&'static str, toml::Value),
+    ConfigInvalidIpv4Addr(&'static str),
     /// Expected a valid SocketAddrV4 address pair for configuration field value.
-    ConfigInvalidSocketAddrV4(&'static str, toml::Value),
+    ConfigInvalidSocketAddrV4(&'static str),
     /// Expected a string for configuration field value.
-    ConfigInvalidString(&'static str, toml::Value),
+    ConfigInvalidString(&'static str),
     /// Crypto library error
     CryptoError(String),
     /// Occurs when a file that should exist does not or could not be read.
@@ -81,18 +82,19 @@ impl fmt::Display for Error {
                 format!("Syntax errors while parsing TOML configuration file:\n\n{}",
                         e)
             }
-            Error::ConfigInvalidIpv4Addr(ref f, ref v) => {
-                format!("Invalid Ipv4 address in config, field={}, value={}. (example: \"127.0.0.0\")",
-                        f,
-                        v)
+            Error::ConfigInvalidArray(ref f) => {
+                format!("Invalid array of values in config, field={}", f)
             }
-            Error::ConfigInvalidSocketAddrV4(ref f, ref v) => {
-                format!("Invalid Ipv4 network address pair in config, field={}, value={}. (example: \"127.0.0.0:8080\")",
-                        f,
-                        v)
+            Error::ConfigInvalidIpv4Addr(ref f) => {
+                format!("Invalid Ipv4 address in config, field={}. (example: \"127.0.0.0\")",
+                        f)
             }
-            Error::ConfigInvalidString(ref f, ref v) => {
-                format!("Invalid string value in config, field={}, value={}", f, v)
+            Error::ConfigInvalidSocketAddrV4(ref f) => {
+                format!("Invalid Ipv4 network address pair in config, field={}. (example: \"127.0.0.0:8080\")",
+                        f)
+            }
+            Error::ConfigInvalidString(ref f) => {
+                format!("Invalid string value in config, field={}.", f)
             }
             Error::CryptoError(ref e) => format!("Crypto error: {}", e),
             Error::FileNotFound(ref e) => format!("File not found at: {}", e),
@@ -136,9 +138,10 @@ impl error::Error for Error {
             Error::BadKeyPath(_) => "An absolute path to a file on disk is required",
             Error::ConfigFileIO(_) => "Unable to read the raw contents of a configuration file",
             Error::ConfigFileSyntax(_) => "Error parsing contents of configuration file",
-            Error::ConfigInvalidIpv4Addr(_, _) => "Invalid Ipv4 network address encountered while parsing a configuration file",
-            Error::ConfigInvalidSocketAddrV4(_, _) => "Invalid Ipv4 network address pair encountered while parsing a configuration file",
-            Error::ConfigInvalidString(_, _) => "Invalid string value encountered while parsing a configuration file",
+            Error::ConfigInvalidArray(_) => "Invalid array of values encountered while parsing a configuration file",
+            Error::ConfigInvalidIpv4Addr(_) => "Invalid Ipv4 network address encountered while parsing a configuration file",
+            Error::ConfigInvalidSocketAddrV4(_) => "Invalid Ipv4 network address pair encountered while parsing a configuration file",
+            Error::ConfigInvalidString(_) => "Invalid string value encountered while parsing a configuration file",
             Error::CryptoError(_) => "Crypto error",
             Error::FileNotFound(_) => "File not found",
             Error::InvalidPackageIdent(_) => "Package identifiers must be in origin/name format (example: acme/redis)",

--- a/components/depot/src/config.rs
+++ b/components/depot/src/config.rs
@@ -23,7 +23,7 @@ pub struct Config {
 impl ConfigFile for Config {
     type Error = Error;
 
-    fn from_toml(toml: toml::Table) -> Result<Self> {
+    fn from_toml(toml: toml::Value) -> Result<Self> {
         let mut cfg = Config::default();
         try!(toml.parse_into("path", &mut cfg.path));
         try!(toml.parse_into("bind_addr", &mut cfg.listen_addr));


### PR DESCRIPTION
Previously the dotted path identifier was being ignored, this fixes that. Oops!

![gif-keyboard-9335362411976946580](https://cloud.githubusercontent.com/assets/54036/15193249/b52c2254-1771-11e6-8a7a-92d76977df01.gif)
