### PR TITLE
write output from build to a file

### DIFF
--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -2167,6 +2167,13 @@ build_line "Source Cache: $HAB_CACHE_SRC_PATH/$pkg_dirname"
 build_line "Installed Path: $pkg_prefix"
 build_line "Artifact: $pkg_artifact"
 
+# Write results to a output file users can process, e.g., in CI
+cat <<-EOF > $HAB_CACHE_SRC_PATH/${pkg_origin}-${pkg_name}-build-output
+source-cache:$HAB_CACHE_SRC_PATH/$pkg_dirname
+installed-path:$pkg_prefix
+artifact:$pkg_artifact
+EOF
+
 # Exit cleanly
 build_line
 build_line "I love it when a plan.sh comes together."


### PR DESCRIPTION
It is desirable to have a simple machine parseable output file from a
build so that it can be consumed in CD/CI systems. We need the source
cache, the installed path, and the full path to the build artifact.

Signed-off-by: jtimberman joshua@chef.io
