### PR TITLE
Fix GitHub auth

### DIFF
--- a/components/builder-web/app/AppComponent.ts
+++ b/components/builder-web/app/AppComponent.ts
@@ -24,8 +24,9 @@ import {SCMReposPageComponent} from "./scm-repos-page/SCMReposPageComponent";
 import {SideNavComponent} from "./side-nav/SideNavComponent";
 import {SignInPageComponent} from "./sign-in-page/SignInPageComponent";
 import {authenticateWithGitHub, fetchMyOrigins, loadSessionState,
-    removeNotification, routeChange, setCurrentOrigin, signOut,
-    toggleOriginPicker, toggleUserNavMenu} from "./actions/index";
+    removeNotification, requestGitHubAuthToken, routeChange, setCurrentOrigin,
+    setGitHubAuthState, signOut, toggleOriginPicker, toggleUserNavMenu}
+    from "./actions/index";
 
 @Component({
     directives: [HeaderComponent, NotificationsComponent, RouterOutlet, SideNavComponent],
@@ -215,8 +216,19 @@ export class AppComponent implements OnInit {
     get user() { return this.state.users.current; }
 
     ngOnInit() {
+        // Populate the GitHub authstate (used to get a token) in SessionStorage
+        // either with what's there already, or with a new UUID.
+        this.store.dispatch(setGitHubAuthState());
+
         // Load up the session state from sessionStorage when we load the page
         this.store.dispatch(loadSessionState(sessionStorage));
+
+        // Request an auth token from GitHub. This doesn't do anything if the
+        // "code" and "state" query parameters are not present.
+        this.store.dispatch(requestGitHubAuthToken(
+            window.location.search,
+            this.store.getState().gitHub.authState
+        ));
 
         // When the page loads attempt to authenticate with GitHub. If there
         // is no token stored in session storage, this won't do anything.

--- a/components/builder-web/app/actions/gitHub.ts
+++ b/components/builder-web/app/actions/gitHub.ts
@@ -162,10 +162,12 @@ export function removeSessionStorage() {
     };
 }
 
-export function requestGitHubAuthToken(params = {}, stateKey = "") {
+export function requestGitHubAuthToken(params, stateKey = "") {
+    params = new URLSearchParams(params.slice(1));
+
     return dispatch => {
-        if (params["code"] && params["state"] === stateKey) {
-            fetch(`${gitHubTokenAuthUrl}/${params["code"]}`).then(response => {
+        if (params.has("code") && params.get("state") === stateKey) {
+            fetch(`${gitHubTokenAuthUrl}/${params.get("code")}`).then(response => {
                 return response.json();
             }).catch(error => {
                 console.error(error);

--- a/components/builder-web/app/actions/origins.ts
+++ b/components/builder-web/app/actions/origins.ts
@@ -67,7 +67,6 @@ export function deleteOrigin(origin) {
 export function fetchMyOrigins() {
     return dispatch => {
         api.getMyOrigins().then(origins => {
-            console.log(origins);
             dispatch(populateMyOrigins(origins));
         });
     };

--- a/components/builder-web/app/sign-in-page/SignInPageComponent.ts
+++ b/components/builder-web/app/sign-in-page/SignInPageComponent.ts
@@ -8,8 +8,7 @@
 import {Component, OnInit} from "angular2/core";
 import {RouteParams, RouterLink} from "angular2/router";
 import {AppStore} from "../AppStore";
-import {requestGitHubAuthToken, setGitHubAuthState, signOut} from
-    "../actions/index";
+import {setGitHubAuthState, signOut} from "../actions/index";
 import config from "../config";
 import {createGitHubLoginUrl, icon} from "../util";
 
@@ -95,17 +94,15 @@ export class SignInPageComponent implements OnInit {
 
     get sourceCodeUrl() { return config["source_code_url"]; }
 
-    ngOnInit() {
-        this.store.dispatch(setGitHubAuthState());
-        this.store.dispatch(requestGitHubAuthToken(
-            this.routeParams.params,
-            this.store.getState().gitHub.authState
-        ));
-    }
-
     private icon(name) { return icon(name); }
 
     private signOut() {
         this.store.dispatch(signOut());
+    }
+
+    public ngOnInit() {
+        // Populate the GitHub authstate (used to get a token) in SessionStorage
+        // either with what's there already, or with a new UUID.
+        this.store.dispatch(setGitHubAuthState());
     }
 }


### PR DESCRIPTION
GitHub auth was not working due to the way redirect urls were working.
Make it so we check for an auth code and state on every page load, but
only attempt auth when necessary.

![giphy](https://cloud.githubusercontent.com/assets/9912/15197786/01938840-1799-11e6-8a24-4c9586c29a10.gif)
