### PR TITLE
Support `http_proxy` & `no_proxy` environment variables for Depot calls.

### DIFF
--- a/components/builder-api/Cargo.lock
+++ b/components/builder-api/Cargo.lock
@@ -168,6 +168,7 @@ dependencies = [
  "sodiumoxide 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -252,6 +253,16 @@ dependencies = [
  "typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "idna"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-bidi 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-normalization 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -745,6 +756,15 @@ dependencies = [
  "unicode-bidi 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-normalization 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "url"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "idna 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/components/builder-sessionsrv/Cargo.lock
+++ b/components/builder-sessionsrv/Cargo.lock
@@ -130,6 +130,7 @@ dependencies = [
  "sodiumoxide 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -173,6 +174,16 @@ dependencies = [
  "typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "idna"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-bidi 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-normalization 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -500,6 +511,15 @@ dependencies = [
  "unicode-bidi 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-normalization 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "url"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "idna 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/components/builder-vault/Cargo.lock
+++ b/components/builder-vault/Cargo.lock
@@ -104,6 +104,7 @@ dependencies = [
  "sodiumoxide 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -113,6 +114,16 @@ dependencies = [
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "zmq 0.7.0 (git+https://github.com/reset/rust-zmq.git?branch=habitat)",
+]
+
+[[package]]
+name = "idna"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-bidi 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-normalization 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -320,6 +331,15 @@ dependencies = [
  "unicode-bidi 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-normalization 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "url"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "idna 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/components/common/Cargo.lock
+++ b/components/common/Cargo.lock
@@ -69,6 +69,7 @@ dependencies = [
  "sodiumoxide 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -77,9 +78,10 @@ version = "0.5.0"
 dependencies = [
  "habitat_core 0.5.0",
  "habitat_depot_core 0.5.0",
- "hyper 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -87,7 +89,7 @@ name = "habitat_depot_core"
 version = "0.5.0"
 dependencies = [
  "habitat_core 0.5.0",
- "hyper 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "redis 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -107,7 +109,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "hyper"
-version = "0.8.1"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cookie 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -123,7 +125,17 @@ dependencies = [
  "traitobject 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "idna"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-bidi 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-normalization 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -419,6 +431,15 @@ dependencies = [
  "unicode-bidi 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-normalization 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "url"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "idna 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/components/core/Cargo.lock
+++ b/components/core/Cargo.lock
@@ -13,6 +13,7 @@ dependencies = [
  "tempdir 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/components/core/Cargo.toml
+++ b/components/core/Cargo.toml
@@ -10,6 +10,7 @@ log = "*"
 regex = "*"
 rustc-serialize = "*"
 toml = "*"
+url = "*"
 
 ### !!NOTE!! sodiumoxide and libsodium-sys are using an override, via the
 ### .cargo/config file. When https://github.com/dnaq/sodiumoxide/pull/103

--- a/components/core/src/env.rs
+++ b/components/core/src/env.rs
@@ -9,6 +9,10 @@ use std;
 use std::env::VarError;
 use std::ffi::{OsStr, OsString};
 
+use extern_url;
+
+use error::{Error, Result};
+
 /// Fetches the environment variable `key` from the current process, but only it is not empty.
 ///
 /// This function augments the `std::env::var` function from the standard library, only by
@@ -68,5 +72,136 @@ pub fn var_os<K: AsRef<OsStr>>(key: K) -> std::option::Option<OsString> {
             }
         }
         None => None,
+    }
+}
+
+/// Returns a host/port tuple from the `http_proxy` environment variable, if it is set.
+///
+/// The value of `http_proxy` must be a parseable URL such as `http://proxy.company.com:8001/`
+/// otherwise a parsing error will be returned. If the port is not present, than the default port
+/// numbers of http/80 and https/443 will be returned. Currently user authentication is not
+/// supported. If the `http_proxy` environment variable is not set or is empty, then a `Result` of
+/// `None` will be returned.
+///
+/// References:
+///
+/// * https://www.gnu.org/software/wget/manual/html_node/Proxies.html
+/// * https://wiki.archlinux.org/index.php/proxy_settings
+/// * https://msdn.microsoft.com/en-us/library/hh272656(v=vs.120).aspx
+/// * http://www.cyberciti.biz/faq/linux-unix-set-proxy-environment-variable/
+///
+/// # Examples
+///
+/// Behavior when environment variable is set:
+///
+/// ```
+/// use std;
+/// use habitat_core::env;
+///
+/// std::env::set_var("http_proxy", "http://proxy.example.com:8001/");
+/// let (host, port) = env::http_proxy().unwrap().unwrap();
+///
+/// assert_eq!(&host, "proxy.example.com");
+/// assert_eq!(port, 8001);
+/// ```
+/// Behavior when environment variable is empty:
+///
+/// ```
+/// use std;
+/// use habitat_core::env;
+///
+/// std::env::set_var("http_proxy", "");
+///
+/// assert_eq!(env::http_proxy().unwrap(), None);
+/// ```
+///
+/// # Errors
+///
+/// * If the value of the `http_proxy` environment variable cannot be parsed as a URL
+/// * If the URL scheme is not a valid type (currently only supported schemes are http and https)
+/// * If the URL is missing a host/domain segement
+/// * If the URL is missing a port number and a default cannot be determined
+pub fn http_proxy() -> Result<Option<(String, u16)>> {
+    match self::var("http_proxy") {
+        Ok(url) => {
+            let url = try!(extern_url::Url::parse(&url));
+            match url.scheme() {
+                "http" | "https" => (),
+                scheme => {
+                    let msg = format!("Invalid scheme {} for {}", &scheme, &url);
+                    return Err(Error::InvalidProxyValue(msg));
+                }
+            };
+            let host = match url.host_str() {
+                Some(val) => val,
+                None => return Err(Error::UrlParseError(extern_url::ParseError::EmptyHost)),
+            };
+            let port = match url.port_or_known_default() {
+                Some(val) => val,
+                None => return Err(Error::UrlParseError(extern_url::ParseError::InvalidPort)),
+            };
+            Ok(Some((host.to_string(), port)))
+        }
+        _ => Ok(None),
+    }
+}
+
+/// Returns a host/port tuple from the `http_proxy` environment variable if it is set and the given
+/// domain name is not matched in the `no_proxy` environment variable domain extension set.
+///
+/// See the [`http_proxy()`] function for more details about the `http_proxy` environment variable
+/// parsing. This function honors the `no_proxy` environment variable which is assumed to be a
+/// comma separated set of domain extensions. If the given domain matches one of these extensions
+/// then no proxy information should be returned (i.e. a return of `Ok(None)`).
+///
+/// # Errors
+///
+/// * If [`http_proxy()`] was unsuccessful
+///
+/// [`http_proxy()`]: #method.http_proxy
+///
+/// # Examples
+///
+/// Behavior when domain matches extension set:
+///
+/// ```
+/// use std;
+/// use habitat_core::env;
+///
+/// std::env::set_var("http_proxy", "http://proxy.example.com:8001/");
+/// std::env::set_var("no_proxy", "localhost,127.0.0.1,localaddress,.localdomain.com");
+///
+/// assert_eq!(env::http_proxy_unless_domain_exempted("server.localdomain.com").unwrap(), None);
+/// ```
+///
+/// Behavior when domain does not match extension set:
+///
+/// ```
+/// use std;
+/// use habitat_core::env;
+///
+/// std::env::set_var("http_proxy", "http://proxy.example.com:8001/");
+/// std::env::set_var("no_proxy", "localhost,127.0.0.1,localaddress,.localdomain.com");
+/// let (host, port) = env::http_proxy_unless_domain_exempted("www.example.com").unwrap().unwrap();
+///
+/// assert_eq!(&host, "proxy.example.com");
+/// assert_eq!(port, 8001);
+/// ```
+///
+pub fn http_proxy_unless_domain_exempted(domain: &str) -> Result<Option<(String, u16)>> {
+    match self::var("no_proxy") {
+        Ok(domains) => {
+            for extension in domains.split(',') {
+                if domain.ends_with(extension) {
+                    debug!("Domain {} matches domain extension {} from no_proxy='{}'",
+                           &domain,
+                           &extension,
+                           &domains);
+                    return Ok(None);
+                }
+            }
+            http_proxy()
+        }
+        _ => http_proxy(),
     }
 }

--- a/components/core/src/lib.rs
+++ b/components/core/src/lib.rs
@@ -20,6 +20,7 @@ extern crate libsodium_sys;
 extern crate tempdir;
 extern crate time;
 extern crate toml;
+extern crate url as extern_url;
 
 pub use self::error::{Error, Result};
 

--- a/components/depot-client/Cargo.lock
+++ b/components/depot-client/Cargo.lock
@@ -4,9 +4,10 @@ version = "0.5.0"
 dependencies = [
  "habitat_core 0.5.0",
  "habitat_depot_core 0.5.0",
- "hyper 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -64,6 +65,7 @@ dependencies = [
  "sodiumoxide 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -71,7 +73,7 @@ name = "habitat_depot_core"
 version = "0.5.0"
 dependencies = [
  "habitat_core 0.5.0",
- "hyper 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "redis 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -91,7 +93,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "hyper"
-version = "0.8.0"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cookie 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -107,7 +109,17 @@ dependencies = [
  "traitobject 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "idna"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-bidi 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-normalization 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -400,6 +412,15 @@ dependencies = [
  "unicode-bidi 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-normalization 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "url"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "idna 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/components/depot-client/Cargo.toml
+++ b/components/depot-client/Cargo.toml
@@ -7,6 +7,7 @@ authors = ["Adam Jacob <adam@chef.io>", "Jamie Winsor <reset@chef.io>", "Fletche
 hyper = "*"
 log = "*"
 rustc-serialize = "*"
+url = "*"
 
 [dependencies.habitat_core]
 path = "../core"

--- a/components/depot-core/Cargo.lock
+++ b/components/depot-core/Cargo.lock
@@ -63,6 +63,7 @@ dependencies = [
  "sodiumoxide 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/components/depot/Cargo.lock
+++ b/components/depot/Cargo.lock
@@ -160,6 +160,7 @@ dependencies = [
  "sodiumoxide 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -204,6 +205,16 @@ dependencies = [
  "typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "idna"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-bidi 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-normalization 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -657,6 +668,15 @@ dependencies = [
  "unicode-bidi 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-normalization 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "url"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "idna 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/components/hab/Cargo.lock
+++ b/components/hab/Cargo.lock
@@ -7,7 +7,7 @@ dependencies = [
  "habitat_common 0.5.0",
  "habitat_core 0.5.0",
  "habitat_depot_client 0.5.0",
- "hyper 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.65 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -114,6 +114,7 @@ dependencies = [
  "sodiumoxide 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -122,9 +123,10 @@ version = "0.5.0"
 dependencies = [
  "habitat_core 0.5.0",
  "habitat_depot_core 0.5.0",
- "hyper 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -132,7 +134,7 @@ name = "habitat_depot_core"
 version = "0.5.0"
 dependencies = [
  "habitat_core 0.5.0",
- "hyper 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "redis 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -152,7 +154,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "hyper"
-version = "0.8.1"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cookie 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -168,7 +170,17 @@ dependencies = [
  "traitobject 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "idna"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-bidi 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-normalization 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -557,6 +569,15 @@ dependencies = [
  "unicode-bidi 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-normalization 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "url"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "idna 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/components/sup/Cargo.lock
+++ b/components/sup/Cargo.lock
@@ -9,7 +9,7 @@ dependencies = [
  "habitat_core 0.5.0",
  "habitat_depot_client 0.5.0",
  "habitat_depot_core 0.5.0",
- "hyper 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "iron 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -157,6 +157,7 @@ dependencies = [
  "sodiumoxide 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -165,9 +166,10 @@ version = "0.5.0"
 dependencies = [
  "habitat_core 0.5.0",
  "habitat_depot_core 0.5.0",
- "hyper 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -175,7 +177,7 @@ name = "habitat_depot_core"
 version = "0.5.0"
 dependencies = [
  "habitat_core 0.5.0",
- "hyper 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "redis 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -204,7 +206,6 @@ dependencies = [
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl 0.7.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "solicit 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -212,6 +213,37 @@ dependencies = [
  "typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "hyper"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cookie 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "httparse 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mime 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.7.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solicit 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "traitobject 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicase 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "idna"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-bidi 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-normalization 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -712,6 +744,15 @@ dependencies = [
  "unicode-bidi 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-normalization 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "url"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "idna 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]


### PR DESCRIPTION
This feature adds support for using the `http_proxy` and
`no_proxy` environment variables when interacting with a Depot via the
`depot-client` component which powers the `hab` CLI and the `hab-sup`
Supervisor.

The raw environment variable parsing and interpretation is maintained in
the `core` component, which is then used by the `depot-client` when
creating `hyper::Client` instances. If the Depot URL's host/domain part
matches an entry in the `no_proxy` comma-separated list of domain
extensions, a proxy will not be used. Note that at the moment the
behavior when calling SSL-wrapped Depot instances is undefined and not
tested (which will happen later when this is officially supported).

Signed-off-by: Fletcher Nichol fnichol@nichol.ca
