### PR TITLE
Make JS compilation faster

### DIFF
--- a/components/builder-web/bin/dist
+++ b/components/builder-web/bin/dist
@@ -1,5 +1,8 @@
 #!/bin/sh
-set -x
+set -ex
+
+NODE_ENV=production
+export NODE_ENV
 
 npm run clean
 rm -rf dist/*

--- a/components/builder-web/npm-shrinkwrap.json
+++ b/components/builder-web/npm-shrinkwrap.json
@@ -1,10 +1,10 @@
 {
   "name": "habitat",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "dependencies": {
     "angular2": {
       "version": "2.0.0-beta.15",
-      "from": "angular2@2.0.0-beta.15",
+      "from": "https://registry.npmjs.org/angular2/-/angular2-2.0.0-beta.15.tgz",
       "resolved": "https://registry.npmjs.org/angular2/-/angular2-2.0.0-beta.15.tgz"
     },
     "ansi_up": {
@@ -17,9 +17,283 @@
       "from": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.1.tgz"
     },
+    "awesome-typescript-loader": {
+      "version": "0.17.0",
+      "from": "awesome-typescript-loader@*",
+      "resolved": "https://registry.npmjs.org/awesome-typescript-loader/-/awesome-typescript-loader-0.17.0.tgz",
+      "dependencies": {
+        "babel-polyfill": {
+          "version": "6.8.0",
+          "from": "babel-polyfill@>=6.1.19 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.8.0.tgz",
+          "dependencies": {
+            "core-js": {
+              "version": "2.4.0",
+              "from": "core-js@>=2.1.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.0.tgz"
+            },
+            "babel-regenerator-runtime": {
+              "version": "6.5.0",
+              "from": "babel-regenerator-runtime@>=6.3.13 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-regenerator-runtime/-/babel-regenerator-runtime-6.5.0.tgz"
+            },
+            "babel-runtime": {
+              "version": "6.6.1",
+              "from": "babel-runtime@>=6.0.0 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.6.1.tgz"
+            }
+          }
+        },
+        "colors": {
+          "version": "1.1.2",
+          "from": "colors@>=1.1.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz"
+        },
+        "enhanced-resolve": {
+          "version": "0.9.1",
+          "from": "enhanced-resolve@>=0.9.1 <0.10.0",
+          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz",
+          "dependencies": {
+            "tapable": {
+              "version": "0.1.10",
+              "from": "tapable@>=0.1.8 <0.2.0",
+              "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz"
+            },
+            "memory-fs": {
+              "version": "0.2.0",
+              "from": "memory-fs@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz"
+            },
+            "graceful-fs": {
+              "version": "4.1.4",
+              "from": "graceful-fs@>=4.1.2 <5.0.0",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz"
+            }
+          }
+        },
+        "es6-promisify": {
+          "version": "3.0.0",
+          "from": "es6-promisify@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-3.0.0.tgz"
+        },
+        "loader-utils": {
+          "version": "0.2.15",
+          "from": "loader-utils@>=0.2.6 <0.3.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.15.tgz",
+          "dependencies": {
+            "big.js": {
+              "version": "3.1.3",
+              "from": "big.js@>=3.1.3 <4.0.0",
+              "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
+            },
+            "emojis-list": {
+              "version": "2.0.1",
+              "from": "emojis-list@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.0.1.tgz"
+            },
+            "json5": {
+              "version": "0.5.0",
+              "from": "json5@>=0.5.0 <0.6.0",
+              "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.0.tgz"
+            },
+            "object-assign": {
+              "version": "4.1.0",
+              "from": "object-assign@>=4.0.1 <5.0.0",
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
+            }
+          }
+        },
+        "lodash": {
+          "version": "3.10.1",
+          "from": "lodash@>=3.10.1 <4.0.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+        },
+        "object-assign": {
+          "version": "2.1.1",
+          "from": "object-assign@>=2.1.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
+        },
+        "parse-json": {
+          "version": "2.2.0",
+          "from": "parse-json@>=2.2.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+          "dependencies": {
+            "error-ex": {
+              "version": "1.3.0",
+              "from": "error-ex@>=1.2.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
+              "dependencies": {
+                "is-arrayish": {
+                  "version": "0.2.1",
+                  "from": "is-arrayish@>=0.2.1 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "source-map-support": {
+          "version": "0.4.0",
+          "from": "source-map-support@>=0.4.0 <0.5.0",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.0.tgz",
+          "dependencies": {
+            "source-map": {
+              "version": "0.1.32",
+              "from": "source-map@0.1.32",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
+              "dependencies": {
+                "amdefine": {
+                  "version": "1.0.0",
+                  "from": "amdefine@>=0.0.4",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "from": "strip-bom@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "dependencies": {
+            "is-utf8": {
+              "version": "0.2.1",
+              "from": "is-utf8@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
+            }
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "from": "strip-json-comments@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz"
+        },
+        "tsconfig": {
+          "version": "2.2.0",
+          "from": "tsconfig@>=2.1.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/tsconfig/-/tsconfig-2.2.0.tgz",
+          "dependencies": {
+            "array-uniq": {
+              "version": "1.0.2",
+              "from": "array-uniq@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
+            },
+            "globby": {
+              "version": "4.0.0",
+              "from": "globby@>=4.0.0 <5.0.0",
+              "resolved": "https://registry.npmjs.org/globby/-/globby-4.0.0.tgz",
+              "dependencies": {
+                "array-union": {
+                  "version": "1.0.1",
+                  "from": "array-union@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz"
+                },
+                "arrify": {
+                  "version": "1.0.1",
+                  "from": "arrify@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
+                },
+                "glob": {
+                  "version": "6.0.4",
+                  "from": "glob@>=6.0.1 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "from": "inflight@>=1.0.4 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "minimatch": {
+                      "version": "3.0.0",
+                      "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.4",
+                          "from": "brace-expansion@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.4.tgz",
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.4.1",
+                              "from": "balanced-match@>=0.4.1 <0.5.0",
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.1.tgz"
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "from": "concat-map@0.0.1",
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.3.3",
+                      "from": "once@>=1.3.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "path-is-absolute": {
+                      "version": "1.0.0",
+                      "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                    }
+                  }
+                },
+                "object-assign": {
+                  "version": "4.1.0",
+                  "from": "object-assign@>=4.0.1 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
+                },
+                "pify": {
+                  "version": "2.3.0",
+                  "from": "pify@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
+                }
+              }
+            },
+            "pinkie-promise": {
+              "version": "2.0.1",
+              "from": "pinkie-promise@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+              "dependencies": {
+                "pinkie": {
+                  "version": "2.0.4",
+                  "from": "pinkie@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+                }
+              }
+            },
+            "xtend": {
+              "version": "4.0.1",
+              "from": "xtend@>=4.0.0 <5.0.0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+            }
+          }
+        }
+      }
+    },
     "blueimp-md5": {
       "version": "2.3.0",
-      "from": "blueimp-md5@*",
+      "from": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.3.0.tgz",
       "resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.3.0.tgz"
     },
     "bourbon": {
@@ -146,7 +420,7 @@
     },
     "es6-shim": {
       "version": "0.35.0",
-      "from": "es6-shim@0.35.0",
+      "from": "https://registry.npmjs.org/es6-shim/-/es6-shim-0.35.0.tgz",
       "resolved": "https://registry.npmjs.org/es6-shim/-/es6-shim-0.35.0.tgz"
     },
     "immutable": {
@@ -156,104 +430,104 @@
     },
     "jsdom": {
       "version": "8.4.0",
-      "from": "jsdom@*",
+      "from": "https://registry.npmjs.org/jsdom/-/jsdom-8.4.0.tgz",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-8.4.0.tgz",
       "dependencies": {
         "abab": {
           "version": "1.0.3",
-          "from": "abab@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/abab/-/abab-1.0.3.tgz",
           "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.3.tgz"
         },
         "acorn": {
           "version": "2.7.0",
-          "from": "acorn@>=2.4.0 <3.0.0",
+          "from": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz"
         },
         "acorn-globals": {
           "version": "1.0.9",
-          "from": "acorn-globals@>=1.0.4 <2.0.0",
+          "from": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.9.tgz",
           "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.9.tgz"
         },
         "array-equal": {
           "version": "1.0.0",
-          "from": "array-equal@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz"
         },
         "cssom": {
           "version": "0.3.1",
-          "from": "cssom@>=0.3.0 <0.4.0",
+          "from": "https://registry.npmjs.org/cssom/-/cssom-0.3.1.tgz",
           "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.1.tgz"
         },
         "cssstyle": {
           "version": "0.2.34",
-          "from": "cssstyle@>=0.2.34 <0.3.0",
+          "from": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.34.tgz",
           "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.34.tgz"
         },
         "escodegen": {
           "version": "1.8.0",
-          "from": "escodegen@>=1.6.1 <2.0.0",
+          "from": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.0.tgz",
           "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.0.tgz",
           "dependencies": {
             "estraverse": {
               "version": "1.9.3",
-              "from": "estraverse@>=1.9.1 <2.0.0",
+              "from": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
               "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
             },
             "esutils": {
               "version": "2.0.2",
-              "from": "esutils@>=2.0.2 <3.0.0",
+              "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
               "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
             },
             "esprima": {
               "version": "2.7.2",
-              "from": "esprima@>=2.7.1 <3.0.0",
+              "from": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
             },
             "optionator": {
               "version": "0.8.1",
-              "from": "optionator@>=0.8.1 <0.9.0",
+              "from": "https://registry.npmjs.org/optionator/-/optionator-0.8.1.tgz",
               "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.1.tgz",
               "dependencies": {
                 "prelude-ls": {
                   "version": "1.1.2",
-                  "from": "prelude-ls@>=1.1.2 <1.2.0",
+                  "from": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
                 },
                 "deep-is": {
                   "version": "0.1.3",
-                  "from": "deep-is@>=0.1.3 <0.2.0",
+                  "from": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
                   "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
                 },
                 "wordwrap": {
                   "version": "1.0.0",
-                  "from": "wordwrap@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
                 },
                 "type-check": {
                   "version": "0.3.2",
-                  "from": "type-check@>=0.3.2 <0.4.0",
+                  "from": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
                   "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
                 },
                 "levn": {
                   "version": "0.3.0",
-                  "from": "levn@>=0.3.0 <0.4.0",
+                  "from": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz"
                 },
                 "fast-levenshtein": {
                   "version": "1.1.3",
-                  "from": "fast-levenshtein@>=1.1.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.1.3.tgz",
                   "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.1.3.tgz"
                 }
               }
             },
             "source-map": {
               "version": "0.2.0",
-              "from": "source-map@>=0.2.0 <0.3.0",
+              "from": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
               "dependencies": {
                 "amdefine": {
                   "version": "1.0.0",
-                  "from": "amdefine@>=0.0.4",
+                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                 }
               }
@@ -262,42 +536,42 @@
         },
         "nwmatcher": {
           "version": "1.3.7",
-          "from": "nwmatcher@>=1.3.7 <2.0.0",
+          "from": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.3.7.tgz",
           "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.3.7.tgz"
         },
         "parse5": {
           "version": "1.5.1",
-          "from": "parse5@>=1.5.1 <2.0.0",
+          "from": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz",
           "resolved": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz"
         },
         "request": {
           "version": "2.72.0",
-          "from": "request@>=2.55.0 <3.0.0",
+          "from": "https://registry.npmjs.org/request/-/request-2.72.0.tgz",
           "resolved": "https://registry.npmjs.org/request/-/request-2.72.0.tgz",
           "dependencies": {
             "aws-sign2": {
               "version": "0.6.0",
-              "from": "aws-sign2@>=0.6.0 <0.7.0",
+              "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
               "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
             },
             "aws4": {
               "version": "1.3.2",
-              "from": "aws4@>=1.2.1 <2.0.0",
+              "from": "https://registry.npmjs.org/aws4/-/aws4-1.3.2.tgz",
               "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.3.2.tgz",
               "dependencies": {
                 "lru-cache": {
                   "version": "4.0.1",
-                  "from": "lru-cache@>=4.0.0 <5.0.0",
+                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.1.tgz",
                   "dependencies": {
                     "pseudomap": {
                       "version": "1.0.2",
-                      "from": "pseudomap@>=1.0.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz"
                     },
                     "yallist": {
                       "version": "2.0.0",
-                      "from": "yallist@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz"
                     }
                   }
@@ -306,42 +580,42 @@
             },
             "bl": {
               "version": "1.1.2",
-              "from": "bl@>=1.1.2 <1.2.0",
+              "from": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
               "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "2.0.6",
-                  "from": "readable-stream@>=2.0.5 <2.1.0",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "isarray": {
                       "version": "1.0.0",
-                      "from": "isarray@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                     },
                     "process-nextick-args": {
                       "version": "1.0.6",
-                      "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                      "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
                       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "util-deprecate": {
                       "version": "1.0.2",
-                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                      "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                     }
                   }
@@ -350,148 +624,148 @@
             },
             "caseless": {
               "version": "0.11.0",
-              "from": "caseless@>=0.11.0 <0.12.0",
+              "from": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
               "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
             },
             "combined-stream": {
               "version": "1.0.5",
-              "from": "combined-stream@>=1.0.5 <1.1.0",
+              "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
               "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
               "dependencies": {
                 "delayed-stream": {
                   "version": "1.0.0",
-                  "from": "delayed-stream@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
                 }
               }
             },
             "extend": {
               "version": "3.0.0",
-              "from": "extend@>=3.0.0 <3.1.0",
+              "from": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
             },
             "forever-agent": {
               "version": "0.6.1",
-              "from": "forever-agent@>=0.6.1 <0.7.0",
+              "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
               "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
             },
             "form-data": {
               "version": "1.0.0-rc4",
-              "from": "form-data@>=1.0.0-rc3 <1.1.0",
+              "from": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz",
               "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz",
               "dependencies": {
                 "async": {
                   "version": "1.5.2",
-                  "from": "async@>=1.5.2 <2.0.0",
+                  "from": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
                   "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
                 }
               }
             },
             "har-validator": {
               "version": "2.0.6",
-              "from": "har-validator@>=2.0.6 <2.1.0",
+              "from": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
               "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
               "dependencies": {
                 "chalk": {
                   "version": "1.1.3",
-                  "from": "chalk@>=1.1.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                   "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                   "dependencies": {
                     "ansi-styles": {
                       "version": "2.2.1",
-                      "from": "ansi-styles@>=2.2.1 <3.0.0",
+                      "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
                       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                     },
                     "escape-string-regexp": {
                       "version": "1.0.5",
-                      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                      "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
                       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                     },
                     "has-ansi": {
                       "version": "2.0.0",
-                      "from": "has-ansi@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                       "dependencies": {
                         "ansi-regex": {
                           "version": "2.0.0",
-                          "from": "ansi-regex@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                         }
                       }
                     },
                     "strip-ansi": {
                       "version": "3.0.1",
-                      "from": "strip-ansi@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                       "dependencies": {
                         "ansi-regex": {
                           "version": "2.0.0",
-                          "from": "ansi-regex@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                         }
                       }
                     },
                     "supports-color": {
                       "version": "2.0.0",
-                      "from": "supports-color@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                     }
                   }
                 },
                 "commander": {
                   "version": "2.9.0",
-                  "from": "commander@>=2.9.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
                   "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
                   "dependencies": {
                     "graceful-readlink": {
                       "version": "1.0.1",
-                      "from": "graceful-readlink@>=1.0.0",
+                      "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                     }
                   }
                 },
                 "is-my-json-valid": {
                   "version": "2.13.1",
-                  "from": "is-my-json-valid@>=2.12.4 <3.0.0",
+                  "from": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
                   "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
                   "dependencies": {
                     "generate-function": {
                       "version": "2.0.0",
-                      "from": "generate-function@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                     },
                     "generate-object-property": {
                       "version": "1.2.0",
-                      "from": "generate-object-property@>=1.1.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                       "dependencies": {
                         "is-property": {
                           "version": "1.0.2",
-                          "from": "is-property@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                         }
                       }
                     },
                     "jsonpointer": {
                       "version": "2.0.0",
-                      "from": "jsonpointer@2.0.0",
+                      "from": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
                     },
                     "xtend": {
                       "version": "4.0.1",
-                      "from": "xtend@>=4.0.0 <5.0.0",
+                      "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                     }
                   }
                 },
                 "pinkie-promise": {
                   "version": "2.0.1",
-                  "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                   "dependencies": {
                     "pinkie": {
                       "version": "2.0.4",
-                      "from": "pinkie@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                     }
                   }
@@ -500,106 +774,106 @@
             },
             "hawk": {
               "version": "3.1.3",
-              "from": "hawk@>=3.1.3 <3.2.0",
+              "from": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
               "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
               "dependencies": {
                 "hoek": {
                   "version": "2.16.3",
-                  "from": "hoek@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
                   "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
                 },
                 "boom": {
                   "version": "2.10.1",
-                  "from": "boom@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
                   "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
                 },
                 "cryptiles": {
                   "version": "2.0.5",
-                  "from": "cryptiles@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
                   "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
                 },
                 "sntp": {
                   "version": "1.0.9",
-                  "from": "sntp@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
                   "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
                 }
               }
             },
             "http-signature": {
               "version": "1.1.1",
-              "from": "http-signature@>=1.1.0 <1.2.0",
+              "from": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
               "dependencies": {
                 "assert-plus": {
                   "version": "0.2.0",
-                  "from": "assert-plus@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
                 },
                 "jsprim": {
                   "version": "1.2.2",
-                  "from": "jsprim@>=1.2.2 <2.0.0",
+                  "from": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz",
                   "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz",
                   "dependencies": {
                     "extsprintf": {
                       "version": "1.0.2",
-                      "from": "extsprintf@1.0.2",
+                      "from": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
                     },
                     "json-schema": {
                       "version": "0.2.2",
-                      "from": "json-schema@0.2.2",
+                      "from": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz",
                       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
                     },
                     "verror": {
                       "version": "1.3.6",
-                      "from": "verror@1.3.6",
+                      "from": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
                       "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
                     }
                   }
                 },
                 "sshpk": {
                   "version": "1.8.2",
-                  "from": "sshpk@>=1.7.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/sshpk/-/sshpk-1.8.2.tgz",
                   "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.8.2.tgz",
                   "dependencies": {
                     "asn1": {
                       "version": "0.2.3",
-                      "from": "asn1@>=0.2.3 <0.3.0",
+                      "from": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
                       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
                     },
                     "assert-plus": {
                       "version": "1.0.0",
-                      "from": "assert-plus@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
                     },
                     "dashdash": {
                       "version": "1.13.1",
-                      "from": "dashdash@>=1.12.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/dashdash/-/dashdash-1.13.1.tgz",
                       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.13.1.tgz"
                     },
                     "getpass": {
                       "version": "0.1.5",
-                      "from": "getpass@>=0.1.1 <0.2.0",
+                      "from": "https://registry.npmjs.org/getpass/-/getpass-0.1.5.tgz",
                       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.5.tgz"
                     },
                     "jsbn": {
                       "version": "0.1.0",
-                      "from": "jsbn@>=0.1.0 <0.2.0",
+                      "from": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
                     },
                     "tweetnacl": {
                       "version": "0.13.3",
-                      "from": "tweetnacl@>=0.13.0 <0.14.0",
+                      "from": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz",
                       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz"
                     },
                     "jodid25519": {
                       "version": "1.0.2",
-                      "from": "jodid25519@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
                     },
                     "ecc-jsbn": {
                       "version": "0.1.1",
-                      "from": "ecc-jsbn@>=0.1.1 <0.2.0",
+                      "from": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
                     }
                   }
@@ -608,88 +882,88 @@
             },
             "is-typedarray": {
               "version": "1.0.0",
-              "from": "is-typedarray@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
             },
             "isstream": {
               "version": "0.1.2",
-              "from": "isstream@>=0.1.2 <0.2.0",
+              "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
               "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
             },
             "json-stringify-safe": {
               "version": "5.0.1",
-              "from": "json-stringify-safe@>=5.0.1 <5.1.0",
+              "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
               "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
             },
             "mime-types": {
               "version": "2.1.10",
-              "from": "mime-types@>=2.1.7 <2.2.0",
+              "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz",
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz",
               "dependencies": {
                 "mime-db": {
                   "version": "1.22.0",
-                  "from": "mime-db@>=1.22.0 <1.23.0",
+                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz",
                   "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz"
                 }
               }
             },
             "oauth-sign": {
               "version": "0.8.1",
-              "from": "oauth-sign@>=0.8.1 <0.9.0",
+              "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.1.tgz",
               "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.1.tgz"
             },
             "qs": {
               "version": "6.1.0",
-              "from": "qs@>=6.1.0 <6.2.0",
+              "from": "https://registry.npmjs.org/qs/-/qs-6.1.0.tgz",
               "resolved": "https://registry.npmjs.org/qs/-/qs-6.1.0.tgz"
             },
             "stringstream": {
               "version": "0.0.5",
-              "from": "stringstream@>=0.0.4 <0.1.0",
+              "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
               "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
             },
             "tunnel-agent": {
               "version": "0.4.2",
-              "from": "tunnel-agent@>=0.4.1 <0.5.0",
+              "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz",
               "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
             }
           }
         },
         "sax": {
           "version": "1.2.1",
-          "from": "sax@>=1.1.4 <2.0.0",
+          "from": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
           "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz"
         },
         "symbol-tree": {
           "version": "3.1.4",
-          "from": "symbol-tree@>=3.1.0 <4.0.0",
+          "from": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.1.4.tgz",
           "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.1.4.tgz"
         },
         "tough-cookie": {
           "version": "2.2.2",
-          "from": "tough-cookie@>=2.2.0 <3.0.0",
+          "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz",
           "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz"
         },
         "webidl-conversions": {
           "version": "3.0.1",
-          "from": "webidl-conversions@>=3.0.1 <4.0.0",
+          "from": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
           "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz"
         },
         "whatwg-url": {
           "version": "2.0.1",
-          "from": "whatwg-url@>=2.0.1 <3.0.0",
+          "from": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-2.0.1.tgz",
           "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-2.0.1.tgz",
           "dependencies": {
             "tr46": {
               "version": "0.0.3",
-              "from": "tr46@>=0.0.3 <0.1.0",
+              "from": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
               "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz"
             }
           }
         },
         "xml-name-validator": {
           "version": "2.0.1",
-          "from": "xml-name-validator@>=2.0.1 <3.0.0",
+          "from": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
           "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz"
         }
       }
@@ -1358,21 +1632,6 @@
                   "from": "ini@~1.3.0",
                   "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
                 },
-                "is-my-json-valid": {
-                  "version": "2.12.3",
-                  "from": "is-my-json-valid@^2.12.3",
-                  "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.3.tgz"
-                },
-                "is-property": {
-                  "version": "1.0.2",
-                  "from": "is-property@^1.0.0",
-                  "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
-                },
-                "is-typedarray": {
-                  "version": "1.0.0",
-                  "from": "is-typedarray@~1.0.0",
-                  "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
-                },
                 "isarray": {
                   "version": "0.0.1",
                   "from": "isarray@0.0.1",
@@ -1383,10 +1642,25 @@
                   "from": "isstream@~0.1.2",
                   "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
                 },
+                "is-property": {
+                  "version": "1.0.2",
+                  "from": "is-property@^1.0.0",
+                  "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+                },
+                "is-my-json-valid": {
+                  "version": "2.12.3",
+                  "from": "is-my-json-valid@^2.12.3",
+                  "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.3.tgz"
+                },
                 "jodid25519": {
                   "version": "1.0.2",
                   "from": "jodid25519@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
+                },
+                "is-typedarray": {
+                  "version": "1.0.0",
+                  "from": "is-typedarray@~1.0.0",
+                  "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
                 },
                 "jsbn": {
                   "version": "0.1.0",
@@ -1533,11 +1807,6 @@
                   "from": "stringstream@~0.0.4",
                   "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
                 },
-                "strip-ansi": {
-                  "version": "3.0.0",
-                  "from": "strip-ansi@^3.0.0",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
-                },
                 "strip-json-comments": {
                   "version": "1.0.4",
                   "from": "strip-json-comments@~1.0.4",
@@ -1552,6 +1821,11 @@
                   "version": "2.2.1",
                   "from": "tar@~2.2.0",
                   "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz"
+                },
+                "strip-ansi": {
+                  "version": "3.0.0",
+                  "from": "strip-ansi@^3.0.0",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
                 },
                 "tough-cookie": {
                   "version": "2.2.1",
@@ -4490,15 +4764,15 @@
                           "from": "http-signature@~1.1.0",
                           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.0.tgz"
                         },
-                        "inherits": {
-                          "version": "2.0.1",
-                          "from": "inherits@*",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                        },
                         "ini": {
                           "version": "1.3.4",
                           "from": "ini@~1.3.0",
                           "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@*",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         },
                         "is-my-json-valid": {
                           "version": "2.12.3",
@@ -4565,15 +4839,15 @@
                           "from": "lodash._createpadding@^3.0.0",
                           "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz"
                         },
-                        "lodash.pad": {
-                          "version": "3.1.1",
-                          "from": "lodash.pad@^3.0.0",
-                          "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-3.1.1.tgz"
-                        },
                         "lodash.padleft": {
                           "version": "3.1.1",
                           "from": "lodash.padleft@^3.0.0",
                           "resolved": "https://registry.npmjs.org/lodash.padleft/-/lodash.padleft-3.1.1.tgz"
+                        },
+                        "lodash.pad": {
+                          "version": "3.1.1",
+                          "from": "lodash.pad@^3.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-3.1.1.tgz"
                         },
                         "lodash.padright": {
                           "version": "3.1.1",
@@ -4675,15 +4949,15 @@
                           "from": "stringstream@~0.0.4",
                           "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
                         },
-                        "strip-json-comments": {
-                          "version": "1.0.4",
-                          "from": "strip-json-comments@~1.0.4",
-                          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
-                        },
                         "strip-ansi": {
                           "version": "3.0.0",
                           "from": "strip-ansi@^3.0.0",
                           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
+                        },
+                        "strip-json-comments": {
+                          "version": "1.0.4",
+                          "from": "strip-json-comments@~1.0.4",
+                          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
                         },
                         "supports-color": {
                           "version": "2.0.0",
@@ -4695,15 +4969,15 @@
                           "from": "tar@~2.2.0",
                           "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz"
                         },
-                        "tunnel-agent": {
-                          "version": "0.4.2",
-                          "from": "tunnel-agent@~0.4.1",
-                          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
-                        },
                         "tough-cookie": {
                           "version": "2.2.1",
                           "from": "tough-cookie@~2.2.0",
                           "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
+                        },
+                        "tunnel-agent": {
+                          "version": "0.4.2",
+                          "from": "tunnel-agent@~0.4.1",
+                          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
                         },
                         "tweetnacl": {
                           "version": "0.13.2",
@@ -5609,15 +5883,15 @@
                       "from": "qs@~5.2.0",
                       "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
                     },
-                    "readable-stream": {
-                      "version": "1.1.13",
-                      "from": "readable-stream@^1.1.13",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz"
-                    },
                     "request": {
                       "version": "2.67.0",
                       "from": "request@2.x",
                       "resolved": "https://registry.npmjs.org/request/-/request-2.67.0.tgz"
+                    },
+                    "readable-stream": {
+                      "version": "1.1.13",
+                      "from": "readable-stream@^1.1.13",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz"
                     },
                     "semver": {
                       "version": "5.1.0",
@@ -7825,7 +8099,7 @@
     },
     "marked": {
       "version": "0.3.5",
-      "from": "marked@*",
+      "from": "https://registry.npmjs.org/marked/-/marked-0.3.5.tgz",
       "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.5.tgz"
     },
     "mocha": {
@@ -9115,11 +9389,6 @@
                 }
               }
             },
-            "node-uuid": {
-              "version": "1.4.7",
-              "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
-              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
-            },
             "qs": {
               "version": "5.2.0",
               "from": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz",
@@ -9485,7 +9754,7 @@
     },
     "node-uuid": {
       "version": "1.4.7",
-      "from": "node-uuid@*",
+      "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
       "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
     },
     "normalize-scss": {
@@ -9507,12 +9776,12 @@
     },
     "parse-link-header": {
       "version": "0.4.1",
-      "from": "parse-link-header@*",
+      "from": "https://registry.npmjs.org/parse-link-header/-/parse-link-header-0.4.1.tgz",
       "resolved": "https://registry.npmjs.org/parse-link-header/-/parse-link-header-0.4.1.tgz",
       "dependencies": {
         "xtend": {
           "version": "4.0.1",
-          "from": "xtend@>=4.0.0 <4.1.0",
+          "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
         }
       }
@@ -9745,11 +10014,6 @@
                   "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.21.0.tgz"
                 }
               }
-            },
-            "node-uuid": {
-              "version": "1.4.7",
-              "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
-              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
             },
             "qs": {
               "version": "5.2.0",
@@ -10149,11 +10413,6 @@
                   "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.21.0.tgz"
                 }
               }
-            },
-            "node-uuid": {
-              "version": "1.4.7",
-              "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
-              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
             },
             "qs": {
               "version": "5.2.0",
@@ -10729,7 +10988,7 @@
     },
     "redux-reset": {
       "version": "0.1.3",
-      "from": "redux-reset@*",
+      "from": "https://registry.npmjs.org/redux-reset/-/redux-reset-0.1.3.tgz",
       "resolved": "https://registry.npmjs.org/redux-reset/-/redux-reset-0.1.3.tgz"
     },
     "redux-thunk": {
@@ -10744,7 +11003,7 @@
     },
     "rxjs": {
       "version": "5.0.0-beta.2",
-      "from": "rxjs@5.0.0-beta.2",
+      "from": "https://registry.npmjs.org/rxjs/-/rxjs-5.0.0-beta.2.tgz",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.0.0-beta.2.tgz"
     },
     "sass-lint": {
@@ -12230,72 +12489,6 @@
           "version": "1.1.2",
           "from": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
           "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz"
-        }
-      }
-    },
-    "ts-loader": {
-      "version": "0.8.0",
-      "from": "https://registry.npmjs.org/ts-loader/-/ts-loader-0.8.0.tgz",
-      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-0.8.0.tgz",
-      "dependencies": {
-        "arrify": {
-          "version": "1.0.1",
-          "from": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
-        },
-        "colors": {
-          "version": "1.1.2",
-          "from": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz"
-        },
-        "enhanced-resolve": {
-          "version": "0.9.1",
-          "from": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz",
-          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz",
-          "dependencies": {
-            "tapable": {
-              "version": "0.1.10",
-              "from": "https://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz",
-              "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz"
-            },
-            "memory-fs": {
-              "version": "0.2.0",
-              "from": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz"
-            },
-            "graceful-fs": {
-              "version": "4.1.2",
-              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
-            }
-          }
-        },
-        "loader-utils": {
-          "version": "0.2.12",
-          "from": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
-          "dependencies": {
-            "big.js": {
-              "version": "3.1.3",
-              "from": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
-              "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
-            },
-            "json5": {
-              "version": "0.4.0",
-              "from": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
-              "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
-            }
-          }
-        },
-        "object-assign": {
-          "version": "2.1.1",
-          "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
-        },
-        "semver": {
-          "version": "5.1.0",
-          "from": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
         }
       }
     },
@@ -15629,35 +15822,35 @@
                       "from": "chalk@^1.1.1",
                       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz"
                     },
-                    "combined-stream": {
-                      "version": "1.0.5",
-                      "from": "combined-stream@~1.0.5",
-                      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
-                    },
                     "commander": {
                       "version": "2.9.0",
                       "from": "commander@^2.9.0",
                       "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
                     },
-                    "core-util-is": {
-                      "version": "1.0.2",
-                      "from": "core-util-is@~1.0.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                    "combined-stream": {
+                      "version": "1.0.5",
+                      "from": "combined-stream@~1.0.5",
+                      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
                     },
                     "cryptiles": {
                       "version": "2.0.5",
                       "from": "cryptiles@2.x.x",
                       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
                     },
-                    "debug": {
-                      "version": "0.7.4",
-                      "from": "debug@~0.7.2",
-                      "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "from": "core-util-is@~1.0.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "dashdash": {
                       "version": "1.10.1",
                       "from": "dashdash@>=1.10.1 <2.0.0",
                       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.10.1.tgz"
+                    },
+                    "debug": {
+                      "version": "0.7.4",
+                      "from": "debug@~0.7.2",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
                     },
                     "deep-extend": {
                       "version": "0.4.0",
@@ -15679,15 +15872,15 @@
                       "from": "ecc-jsbn@>=0.0.1 <1.0.0",
                       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
                     },
-                    "escape-string-regexp": {
-                      "version": "1.0.3",
-                      "from": "escape-string-regexp@^1.0.2",
-                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
-                    },
                     "extend": {
                       "version": "3.0.0",
                       "from": "extend@~3.0.0",
                       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+                    },
+                    "escape-string-regexp": {
+                      "version": "1.0.3",
+                      "from": "escape-string-regexp@^1.0.2",
+                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
                     },
                     "extsprintf": {
                       "version": "1.0.2",
@@ -16248,7 +16441,7 @@
     },
     "zone.js": {
       "version": "0.6.12",
-      "from": "zone.js@>=0.6.10 <0.7.0",
+      "from": "zone.js@0.6.12",
       "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.6.12.tgz"
     }
   }

--- a/components/builder-web/package.json
+++ b/components/builder-web/package.json
@@ -59,6 +59,7 @@
   },
   "devDependencies": {
     "assertion-error": "^1.0.1",
+    "awesome-typescript-loader": "^0.17.0",
     "chai-as-promised": "^5.2.0",
     "concurrently": "^1.0.0",
     "deep-eql": "^0.1.3",
@@ -79,7 +80,6 @@
     "protractor": "^3.1.0",
     "sass-lint": "^1.4.0",
     "sinon": "^1.17.3",
-    "ts-loader": "^0.8.0",
     "ts-node": "^0.5.5",
     "tslint": "^3.2.2",
     "tslint-loader": "^2.1.0",

--- a/components/builder-web/webpack.conf.js
+++ b/components/builder-web/webpack.conf.js
@@ -1,4 +1,27 @@
+"use strict";
+
 const webpack = require("webpack");
+const isProduction = process.env.NODE_ENV == "production";
+
+// Set up compression to only happen if NODE_ENV = production
+let loaders = [
+    { test: /\.ts$/, loader: "awesome-typescript-loader" },
+];
+let plugins = [];
+
+if (isProduction) {
+    loaders.push({ test: "app.js", loader: "uglify" });
+    plugins.push(
+        new webpack.optimize.UglifyJsPlugin({
+            compress: {
+                drop_debugger: false,
+                warnings: false,
+            },
+            mangle: false,
+            sourceMap: true,
+        })
+    )
+}
 
 module.exports = {
     devtool: "source-map",
@@ -13,22 +36,10 @@ module.exports = {
         preLoaders: [
             { test: /\.ts$/, loader: "tslint" },
         ],
-        loaders: [
-            { test: /\.ts$/, loader: "ts-loader" },
-            { test: "app.js", loader: "uglify" },
-        ],
+        loaders: loaders,
         noParse: [/angular2\/bundles\/.+/],
     },
-    plugins: [
-        new webpack.optimize.UglifyJsPlugin({
-            compress: {
-                drop_debugger: false,
-                warnings: false,
-            },
-            mangle: false,
-            sourceMap: true,
-        }),
-    ],
+    plugins: plugins,
     stats: {
         chunks: false,
     },


### PR DESCRIPTION
- When we're running in dev (with `npm start` or `npm run build-js`),
  turn off compression of JS. If `NODE_ENV=production` is set (which we
  now do in `npm run dist`), compress the JS. This takes down
  compilation from about 27s to 13s on my machine.
- Use `awesome-ts-loader` instead of `ts-loader` (note the lack of
  `awesome` in the name of what we were using), which uses incremental
  compilation, that takes the build time down from 13s to about 4s
  in development

![gif-keyboard-16348563388765342585](https://cloud.githubusercontent.com/assets/9912/15261998/445e0e7e-1925-11e6-8be2-89f138678a2e.gif)

Signed-off-by: Nathan L Smith smith@chef.io
