### PR TITLE
Convert the Rails sample to use binding.

### DIFF
--- a/plans/ruby-rails-sample/config/database.yml
+++ b/plans/ruby-rails-sample/config/database.yml
@@ -8,8 +8,8 @@ production:
   database: {{cfg.database_name}}
   username: {{cfg.database_username}}
   password: {{cfg.database_password}}
-{{#cfg.database_discover}}
-{{#svc.named.postgresql.default.members}}  host: {{ip}}{{/svc.named.postgresql.default.members}}
-{{/cfg.database_discover}}
-{{^cfg.database_discover}}  host: {{cfg.database_host}}{{/cfg.database_discover}}
+{{#bind.has_database}}
+{{#bind.database.members}}  host: {{ip}}{{/bind.database.members}}
+{{/bind.has_database}}
+{{^bind.has_database}}  host: {{cfg.database_host}}{{/bind.has_database}}
   port: {{cfg.database_port}}

--- a/plans/ruby-rails-sample/default.toml
+++ b/plans/ruby-rails-sample/default.toml
@@ -9,15 +9,11 @@ database_username = "ruby-rails-sample"
 # servers running in the wild.
 database_password = ""
 
-# If this is false, then we use the value of database_host in the
-# database.yml, otherwise we're going to attempt to find the IP for
-# the postgresql server in the "postgresql.default" service group
-# (hard coded for now, :sadpanda:)
-database_discover = true
-
-# A "safe" fallback is using localhost - we recommend this only be
-# used for testing purposes, and instead run a postgresql service that
-# can be discovered using gossip
+# Normally you should use named service binding to bind the "database"
+# name to the database service group, and this app will connect to the
+# leader of that service group. If you do not use binding, this app
+# will fall back to using the database host specified here (localhost).
+# We recommend that this only be used for testing purposes.
 database_host = "localhost"
 
 # It's highly unlikely anyone would want to change this from the


### PR DESCRIPTION
This commit changes the Ruby on Rails sample app to use named service binding as in PR #455, so that the service group name need not be `postgresql.default`. You start up the supervisor now with `--bind database:foo.bar` where `foo.bar` is the name of your actual PostgreSQL service group.
