### PR TITLE
Improvements to make builder-web navigation more real

### DIFF
--- a/components/builder-web/app/AppComponent.ts
+++ b/components/builder-web/app/AppComponent.ts
@@ -23,10 +23,9 @@ import {RouteConfig, Router, RouterOutlet} from "angular2/router";
 import {SCMReposPageComponent} from "./scm-repos-page/SCMReposPageComponent";
 import {SideNavComponent} from "./side-nav/SideNavComponent";
 import {SignInPageComponent} from "./sign-in-page/SignInPageComponent";
-import {authenticateWithGitHub, fetchMyOrigins, loadSessionState,
-    removeNotification, requestGitHubAuthToken, routeChange, setCurrentOrigin,
-    setGitHubAuthState, signOut, toggleOriginPicker, toggleUserNavMenu}
-    from "./actions/index";
+import {authenticateWithGitHub, loadSessionState, removeNotification,
+    requestGitHubAuthToken, routeChange, setGitHubAuthState, signOut,
+    toggleUserNavMenu} from "./actions/index";
 
 @Component({
     directives: [HeaderComponent, NotificationsComponent, RouterOutlet, SideNavComponent],
@@ -45,14 +44,8 @@ import {authenticateWithGitHub, fetchMyOrigins, loadSessionState,
                     [toggleUserNavMenu]="toggleUserNavMenu"></hab-header>
     </div>
     <div class="hab-container">
-        <hab-side-nav [fetchMyOrigins]="fetchMyOrigins"
-                      [isOriginPickerOpen]="state.origins.ui.isPickerOpen"
-                      [isSignedIn]="user.isSignedIn"
-                      [myOrigins]="state.origins.mine"
-                      [origin]="origin"
+        <hab-side-nav [isSignedIn]="user.isSignedIn"
                       [route]="state.router.route"
-                      [setCurrentOrigin]="setCurrentOrigin"
-                      [toggleOriginPicker]="toggleOriginPicker"
                       *ngIf="!hideNav">
         </hab-side-nav>
         <section class="hab-main" [ngClass]="{centered: hideNav}">
@@ -67,7 +60,7 @@ import {authenticateWithGitHub, fetchMyOrigins, loadSessionState,
 @RouteConfig([
     {
         path: "/",
-        redirectTo: ["Packages"],
+        redirectTo: ["PackagesForOrigin", { origin: "core" }],
     },
     {
         path: "/explore",
@@ -152,11 +145,8 @@ import {authenticateWithGitHub, fetchMyOrigins, loadSessionState,
 ])
 
 export class AppComponent implements OnInit {
-    fetchMyOrigins: Function;
     removeNotification: Function;
-    setCurrentOrigin: Function;
     signOut: Function;
-    toggleOriginPicker: Function;
     toggleUserNavMenu: Function;
     hideNav: boolean;
 
@@ -177,28 +167,13 @@ export class AppComponent implements OnInit {
             if (requestedRoute) { router.navigate(requestedRoute); }
         });
 
-        this.fetchMyOrigins = function() {
-            this.store.dispatch(fetchMyOrigins());
-            return false;
-        }.bind(this);
-
         this.removeNotification = function(i) {
             this.store.dispatch(removeNotification(i));
             return false;
         }.bind(this);
 
-        this.setCurrentOrigin = function (origin) {
-            this.store.dispatch(setCurrentOrigin(origin));
-            return false;
-        }.bind(this);
-
         this.signOut = function() {
             this.store.dispatch(signOut());
-            return false;
-        }.bind(this);
-
-        this.toggleOriginPicker = function() {
-            this.store.dispatch(toggleOriginPicker());
             return false;
         }.bind(this);
 

--- a/components/builder-web/app/actions/gitHub.ts
+++ b/components/builder-web/app/actions/gitHub.ts
@@ -8,8 +8,8 @@
 import "whatwg-fetch";
 import {URLSearchParams} from "angular2/http";
 import config from "../config";
-import {attemptSignIn, addNotification, goHome, requestRoute, setCurrentOrigin,
-    setSigningInFlag, signOut} from "./index";
+import {attemptSignIn, addNotification, goHome, requestRoute, setSigningInFlag,
+    signOut} from "./index";
 import {DANGER} from "./notifications";
 
 const parseLinkHeader = require("parse-link-header");

--- a/components/builder-web/app/actions/router.ts
+++ b/components/builder-web/app/actions/router.ts
@@ -10,7 +10,7 @@ export const ROUTE_REQUESTED = "ROUTE_REQUESTED";
 
 export function goHome() {
     return dispatch => {
-        dispatch(requestRoute(["Packages"]));
+        dispatch(requestRoute(["PackagesForOrigin", { origin: "core" }]));
     };
 }
 

--- a/components/builder-web/app/header/HeaderComponent.ts
+++ b/components/builder-web/app/header/HeaderComponent.ts
@@ -20,7 +20,9 @@ import {UserNavComponent} from "./user-nav/UserNavComponent";
         <h1 class="logo">{{appName}}</h1>
         <nav>
             <ul>
-                <li><a [routerLink]="['Packages']">Packages</a></li>
+                <li><a [routerLink]="['PackagesForOrigin', { origin: 'core' }]">
+                    Packages
+                </a></li>
                 <li><a href="{{config['docs_url']}}">Docs</a></li>
                 <li><a href="{{config['tutorials_url']}}">Tutorials</a></li>
                 <li><a href="{{config['community_url']}}">Community</a></li>

--- a/components/builder-web/app/initialState.ts
+++ b/components/builder-web/app/initialState.ts
@@ -79,7 +79,6 @@ export default Record({
             current: Record({
                 creating: false,
             })(),
-            isPickerOpen: false,
         })(),
     })(),
     packages: Record({

--- a/components/builder-web/app/side-nav/SideNavComponent.ts
+++ b/components/builder-web/app/side-nav/SideNavComponent.ts
@@ -7,45 +7,27 @@
 
 import {Component, OnInit} from "angular2/core";
 import {RouterLink} from "angular2/router";
-import {OriginPickerComponent} from "./OriginPickerComponent";
 
 @Component({
-    directives: [OriginPickerComponent, RouterLink],
-    inputs: ["fetchMyOrigins", "isSignedIn", "isOriginPickerOpen", "myOrigins",
-        "origin", "route", "setCurrentOrigin", "toggleOriginPicker"],
+    directives: [RouterLink],
+    inputs: ["isSignedIn", "route"],
     selector: "hab-side-nav",
     template: `
     <nav class="hab-side-nav">
-        <hab-origin-picker [fetchMyOrigins]="fetchMyOrigins"
-                           [isSignedIn]="isSignedIn"
-                           [isOpen]="isOriginPickerOpen"
-                           [myOrigins]="myOrigins"
-                           [currentOrigin]="origin"
-                           [setCurrentOrigin]="setCurrentOrigin"
-                           [toggleOriginPicker]="toggleOriginPicker">
-        </hab-origin-picker>
-        <ul class="hab-side-nav--list" *ngIf="isSignedIn">
-            <li><a [class.active]='routeMatch("projects")'
-                   [routerLink]="['Projects']">Projects</a></li>
-        </ul>
-        <hr>
-        <h4>Public Packages</h4>
+        <h4>Dashboard</h4>
         <ul class="hab-side-nav--list">
-            <li><a [class.active]='routeMatch("explore")'
-                   [routerLink]="['Explore']">Explore</a></li>
-            <li><a [class.active]='routeMatch("pkgs$")'
-                   [routerLink]="['Packages']">All Packages</a></li>
-            <li *ngIf="isSignedIn">
-                <a [class.active]='routeMatch("pkgs.+filter=mine")'
-                   [routerLink]="['Packages', { filter: 'mine' }]">
-                    My Packages
-                </a>
-            </li>
-        </ul>
-        <h4 *ngIf="isSignedIn">Organizations</h4>
-        <ul class="hab-side-nav--list" *ngIf="isSignedIn">
-            <li><a [class.active]='routeMatch("orgs")'
-                   [routerLink]="['Organizations']">Manage Orgs</a></li>
+            <li *ngIf="isSignedIn"><a [class.active]='routeMatch("projects")'
+                   [routerLink]="['Projects']">Projects</a></li>
+            <li *ngIf="isSignedIn"><a
+                   [class.active]='routeMatch("origins")'
+                   [routerLink]="['Origins']">Origins</a></li>
+            <li *ngIf="isSignedIn"><a
+                   [class.active]='routeMatch("orgs")'
+                   [routerLink]="['Organizations']">Organizations</a></li>
+            <li><a [class.active]='routeMatch("pkgs\/core")'
+                   [routerLink]="['PackagesForOrigin', { origin: 'core' }]">
+                Public Packages
+            </a></li>
         </ul>
     </nav>`
 })

--- a/components/builder-web/app/side-nav/_side-nav.scss
+++ b/components/builder-web/app/side-nav/_side-nav.scss
@@ -7,7 +7,7 @@
 
 .hab-side-nav {
   @include span-columns(2);
-  padding-top: rem(65);
+  padding-top: $base-spacing;
   position: relative;
 
   .switcher {

--- a/components/builder-web/app/util.ts
+++ b/components/builder-web/app/util.ts
@@ -13,7 +13,7 @@ import config from "./config";
 export function createGitHubLoginUrl(state) {
     const params = {
         client_id: config["github_client_id"],
-        redirect_uri: `${window.location.protocol}//${window.location.host}${window.location.pathname}#/sign-in`,
+        redirect_uri: `${window.location.protocol}//${window.location.host}`,
         scope: "user:email,read:org",
         state
     };


### PR DESCRIPTION
Put the information presented to the user more in line with what the API
is currently capable of.
- Remove the "all packages" and "my packages" and just present "core"
- Remove the origin switcher
- Name the side nav items more consistently
- Make /pkgs/core the default route
- Redirect to / instead of /sign-in on sign in

![giphy](https://cloud.githubusercontent.com/assets/9912/15296423/f3ed29f6-1b5a-11e6-9adb-0344d4ccc440.gif)
