### PR TITLE
[plan] Upgrade to libarchive 3.2.0.

### DIFF
--- a/plans/libarchive/plan.sh
+++ b/plans/libarchive/plan.sh
@@ -1,11 +1,11 @@
 pkg_name=libarchive
 pkg_distname=$pkg_name
 pkg_origin=core
-pkg_version=3.1.2
+pkg_version=3.2.0
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('BSD')
 pkg_source=http://www.libarchive.org/downloads/${pkg_distname}-${pkg_version}.tar.gz
-pkg_shasum=eb87eacd8fe49e8d90c8fdc189813023ccc319c5e752b01fb6ad0cc7b2c53d5e
+pkg_shasum=7bce45fd71ff01dc20d19edd78322d4965583d81b8bed8e26cacb65d6f5baa87
 pkg_dirname=${pkg_distname}-${pkg_version}
 pkg_deps=(core/glibc core/openssl core/zlib core/bzip2 core/xz)
 pkg_build_deps=(core/gcc core/coreutils core/make)


### PR DESCRIPTION
This happily resolves some tar extraction issues noted with our
`core/hab-static` binary. Yay new releases!

![gif-keyboard-3119031285793965661](https://cloud.githubusercontent.com/assets/261548/15311021/b612234e-1bb3-11e6-9291-ffdf0cff9588.gif)
