### PR TITLE
[hab] Support `FS_ROOT` environment variable.

### DIFF
--- a/components/common/src/gossip_file.rs
+++ b/components/common/src/gossip_file.rs
@@ -214,7 +214,7 @@ impl GossipFile {
                     // this write will fail.
                     println!("Attempting to decrypt {}", &self.file_name);
                     let decrypted_bytes = try!(BoxKeyPair::decrypt(&self.body,
-                                                                   &default_cache_key_path()));
+                                                                   &default_cache_key_path(None)));
                     println!("Successfully decrypted {}", &self.file_name);
                     try!(new_file.write_all(&decrypted_bytes));
                 } else {

--- a/components/core/src/crypto/mod.rs
+++ b/components/core/src/crypto/mod.rs
@@ -217,12 +217,12 @@
 //! <symkey_base64>
 //! ```
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use sodiumoxide::init as nacl_init;
 
 use env as henv;
-use fs::CACHE_KEY_PATH;
+use fs::cache_key_path;
 
 /// The suffix on the end of a public sig/box file
 static PUBLIC_KEY_SUFFIX: &'static str = "pub";
@@ -265,8 +265,11 @@ pub mod artifact;
 pub mod hash;
 pub mod keys;
 
-pub fn default_cache_key_path() -> PathBuf {
-    PathBuf::from(henv::var(CACHE_KEY_PATH_ENV_VAR).unwrap_or(CACHE_KEY_PATH.to_string()))
+pub fn default_cache_key_path(fs_root_path: Option<&Path>) -> PathBuf {
+    match henv::var(CACHE_KEY_PATH_ENV_VAR) {
+        Ok(val) => PathBuf::from(val),
+        Err(_) => cache_key_path(fs_root_path),
+    }
 }
 
 pub fn init() {

--- a/components/core/src/fs.rs
+++ b/components/core/src/fs.rs
@@ -6,25 +6,52 @@
 // open source license such as the Apache 2.0 License.
 
 use std::env;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use env as henv;
 
-pub const ROOT_PATH: &'static str = "/hab";
+/// The default filesystem root path
+pub const FS_ROOT_PATH: &'static str = "/";
+/// The default root path of the Habitat filesytem
+pub const ROOT_PATH: &'static str = "hab";
 /// The default download root path for package artifacts, used on package installation
-pub const CACHE_ARTIFACT_PATH: &'static str = "/hab/cache/artifacts";
+pub const CACHE_ARTIFACT_PATH: &'static str = "hab/cache/artifacts";
 /// The default path where cryptographic keys are stored
-pub const CACHE_KEY_PATH: &'static str = "/hab/cache/keys";
+pub const CACHE_KEY_PATH: &'static str = "hab/cache/keys";
 /// The default path where source artifacts are downloaded, extracted, & compiled
-pub const CACHE_SRC_PATH: &'static str = "/hab/cache/src";
+pub const CACHE_SRC_PATH: &'static str = "hab/cache/src";
 /// The root path containing all locally installed packages
-pub const PKG_PATH: &'static str = "/hab/pkgs";
+pub const PKG_PATH: &'static str = "hab/pkgs";
 /// The root path containing all runtime service directories and files
-const SVC_PATH: &'static str = "/hab/svc";
+const SVC_PATH: &'static str = "hab/svc";
+
+/// Returns the path to the artifacts cache, optionally taking a custom filesystem root.
+pub fn cache_artifact_path(fs_root_path: Option<&Path>) -> PathBuf {
+    match fs_root_path {
+        Some(fs_root_path) => Path::new(fs_root_path).join(CACHE_ARTIFACT_PATH),
+        None => Path::new(FS_ROOT_PATH).join(CACHE_ARTIFACT_PATH),
+    }
+}
+
+/// Returns the path to the keys cache, optionally taking a custom filesystem root.
+pub fn cache_key_path(fs_root_path: Option<&Path>) -> PathBuf {
+    match fs_root_path {
+        Some(fs_root_path) => Path::new(fs_root_path).join(CACHE_KEY_PATH),
+        None => Path::new(FS_ROOT_PATH).join(CACHE_KEY_PATH),
+    }
+}
+
+/// Returns the path to the src cache, optionally taking a custom filesystem root.
+pub fn cache_src_path(fs_root_path: Option<&Path>) -> PathBuf {
+    match fs_root_path {
+        Some(fs_root_path) => Path::new(fs_root_path).join(CACHE_SRC_PATH),
+        None => Path::new(FS_ROOT_PATH).join(CACHE_SRC_PATH),
+    }
+}
 
 /// Returns the root path for a given service's configuration, files, and data.
 pub fn svc_path(service_name: &str) -> PathBuf {
-    PathBuf::from(SVC_PATH).join(service_name)
+    Path::new("/").join(SVC_PATH).join(service_name)
 }
 
 /// Returns the path to a given service's configuration.

--- a/components/core/src/package/archive.rs
+++ b/components/core/src/package/archive.rs
@@ -169,7 +169,8 @@ impl PackageArchive {
     /// # Failures
     ///
     /// * If the package cannot be unpacked
-    pub fn unpack(&self) -> Result<()> {
+    pub fn unpack(&self, fs_root_path: Option<&Path>) -> Result<()> {
+        let root = fs_root_path.unwrap_or(Path::new("/"));
         let tar_reader = try!(artifact::get_archive_reader(&self.path));
         let mut builder = reader::Builder::new();
         try!(builder.support_format(ReadFormat::All));
@@ -177,7 +178,7 @@ impl PackageArchive {
         let mut reader = try!(builder.open_stream(tar_reader));
         let writer = writer::Disk::new();
         try!(writer.set_standard_lookup());
-        try!(writer.write(&mut reader, Some("/")));
+        try!(writer.write(&mut reader, Some(root.to_string_lossy().as_ref())));
         try!(writer.close());
         Ok(())
     }

--- a/components/hab/src/exec.rs
+++ b/components/hab/src/exec.rs
@@ -14,6 +14,7 @@ use std::ptr;
 
 use common;
 use hcore;
+use hcore::fs::cache_artifact_path;
 use hcore::package::{PackageIdent, PackageInstall};
 use hcore::url::DEFAULT_DEPOT_URL;
 
@@ -76,6 +77,8 @@ pub fn command_from_pkg(command: &str,
             println!("Package for {} not found, installing from depot", &ident);
             try!(common::command::package::install::from_url(DEFAULT_DEPOT_URL,
                                                              ident,
+                                                             Path::new("/"),
+                                                             &cache_artifact_path(None),
                                                              cache_key_path));
             command_from_pkg(&command, &ident, &cache_key_path, retry + 1)
         }

--- a/components/sup/src/gossip/server.rs
+++ b/components/sup/src/gossip/server.rs
@@ -101,7 +101,7 @@ impl Server {
         let census_list = CensusList::new(Census::new(ce.clone()));
 
         let ring_key = match ring_name_with_rev {
-            Some(rnwr) => Some(SymKey::get_pair_for(&rnwr, &default_cache_key_path()).unwrap()),
+            Some(rnwr) => Some(SymKey::get_pair_for(&rnwr, &default_cache_key_path(None)).unwrap()),
             None => None,
         };
 

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -133,8 +133,8 @@ fn config_from_args(args: &ArgMatches, subcommand: &str, sub_args: &ArgMatches) 
     config.set_gossip_listen_ip(gossip_ip);
     config.set_gossip_listen_port(gossip_port);
     config.set_sidecar_listen(sub_args.value_of("listen-sidecar")
-                                     .unwrap_or(DEFAULT_SIDECAR_LISTEN_IP_PORT)
-                                     .to_string());
+                                      .unwrap_or(DEFAULT_SIDECAR_LISTEN_IP_PORT)
+                                      .to_string());
     let gossip_peers = match sub_args.values_of("peer") {
         Some(gp) => gp.map(|s| s.to_string()).collect(),
         None => vec![],
@@ -151,14 +151,17 @@ fn config_from_args(args: &ArgMatches, subcommand: &str, sub_args: &ArgMatches) 
     }
     config.set_version_number(value_t!(sub_args, "version-number", u64).unwrap_or(0));
     let ring = match sub_args.value_of("ring") {
-        Some(val) => Some(try!(SymKey::get_latest_pair_for(&val, &default_cache_key_path()))),
+        Some(val) => Some(try!(SymKey::get_latest_pair_for(&val, &default_cache_key_path(None)))),
         None => {
             match henv::var(RING_KEY_ENVVAR) {
-                Ok(val) => Some(try!(SymKey::write_file_from_str(&val, &default_cache_key_path()))),
+                Ok(val) => {
+                    Some(try!(SymKey::write_file_from_str(&val, &default_cache_key_path(None))))
+                }
                 Err(_) => {
                     match henv::var(RING_ENVVAR) {
                         Ok(val) => {
-                            Some(try!(SymKey::get_latest_pair_for(&val, &default_cache_key_path())))
+                            Some(try!(SymKey::get_latest_pair_for(&val,
+                                                                  &default_cache_key_path(None))))
                         }
                         Err(_) => None,
                     }

--- a/components/sup/src/service_config.rs
+++ b/components/sup/src/service_config.rs
@@ -578,8 +578,9 @@ mod test {
     fn gen_pkg() -> Package {
         let pkg_install = PackageInstall::new_from_parts(
             PackageIdent::from_str("neurosis/sovereign/2000/20160222201258").unwrap(),
-            PathBuf::from("/fakeo/here"),
-            PathBuf::from("/fakeo"));
+            PathBuf::from("/"),
+            PathBuf::from("/fakeo"),
+            PathBuf::from("/fakeo/here"));
         Package {
             origin: String::from("neurosis"),
             name: String::from("sovereign"),

--- a/components/sup/tests/bldr_build/mod.rs
+++ b/components/sup/tests/bldr_build/mod.rs
@@ -22,14 +22,14 @@ fn builds_a_service() {
     assert_cmd_exit_code!(simple_service, [0]);
     assert_regex!(simple_service.stdout(), r"Loading /.*/plan.sh");
     assert_regex!(simple_service.stdout(),
-                  &format!(r"{}/bldr_build-0.0.1", fs::CACHE_SRC_PATH));
+                  &format!(r"{}/bldr_build-0.0.1", fs::cache_src_path(None)));
     assert_regex!(simple_service.stdout(),
-                  &format!(r"{}/test/bldr_build/0.0.1/\d{{14}}", fs::PKG_PATH));
+                  &format!(r"/{}/test/bldr_build/0.0.1/\d{{14}}", fs::PKG_PATH));
     assert_regex!(simple_service.stdout(),
                   &format!(r"{}/test-bldr_build-0.0.1-\d{{14}}.bldr",
-                           fs::CACHE_ARTIFACT_PATH));
+                           fs::cache_artifact_path(None)));
     let pkg_re = Regex::new(&format!(r"({}/test-bldr_build-0.0.1-\d{{14}}.bldr)",
-                                     fs::CACHE_ARTIFACT_PATH))
+                                     fs::cache_artifact_path(None)))
                      .unwrap();
     let caps = pkg_re.captures(simple_service.stdout()).unwrap();
     if let Some(pkg_path) = caps.at(1) {


### PR DESCRIPTION
This change lays the groundwork for replacing `hab-bpm`, namely in its
role setting up Studios. When using the `hab` binary on installation, if
an `$FS_ROOT` environment variable is set, this will effectively replace
the default `/` path, which allows a user or some automation to install
into a mounted filesystem or subdirectory that will become the root of a
filesystem for Habitat.

For example, here we install `core/redis`, its dependencies, any
downloaded public origin keys, and downloaded artifacts under a
`/tmp/newfs` filesystem root:

```
> ls -l /tmp/newfs
ls: cannot access /tmp/newfs: No such file or directory

> env FS_ROOT=/tmp/newfs ./target/debug/hab install core/redis
» Installing core/redis
↓ Downloading core/glibc/2.22/20160427193532
    16.21 MB / 16.21 MB \ [=================================] 100.00 % 30.25 MB/s
↓ Downloading core-20160423193745 public origin key
    75 B / 75 B | [========================================] 100.00 % 358.35 KB/s
☑ Cached core-20160423193745 public origin key
✓ Installed core/glibc/2.22/20160427193532
↓ Downloading core/linux-headers/4.3/20160427193435
    798.63 KB / 798.63 KB / [===============================] 100.00 % 88.11 MB/s
✓ Installed core/linux-headers/4.3/20160427193435
↓ Downloading core/redis/3.0.7/20160427222845
    1.46 MB / 1.46 MB | [===================================] 100.00 % 80.88 MB/s
✓ Installed core/redis/3.0.7/20160427222845
★ Install of core/redis complete with 3 packages installed.

> ls -l /tmp/newfs/
total 4
drwxr-xr-x 4 root root 4096 May 17 05:44 hab

> ls -l /tmp/newfs/hab/cache/keys/
total 4
-rw-r--r-- 1 root root 75 May 17 05:44 core-20160423193745.pub

> ls -l /tmp/newfs/hab/cache/artifacts/
total 18900
-rw-r--r-- 1 root root 17001749 May 17 05:44 core-glibc-2.22-20160427193532-x86_64-linux.hart
-rw-r--r-- 1 root root   817797 May 17 05:44 core-linux-headers-4.3-20160427193435-x86_64-linux.hart
-rw-r--r-- 1 root root  1530761 May 17 05:44 core-redis-3.0.7-20160427222845-x86_64-linux.hart

> ls -l /tmp/newfs/hab/pkgs/core/
total 12
drwxr-xr-x 3 root root 4096 May 17 05:44 glibc
drwxr-xr-x 3 root root 4096 May 17 05:44 linux-headers
drwxr-xr-x 3 root root 4096 May 17 05:44 redis
```

Signed-off-by: Fletcher Nichol fnichol@nichol.ca
