### PR TITLE
[sup] Set appropriate `PATH` for `sh` & `bash` subcommands.

### DIFF
--- a/components/sup/src/command/mod.rs
+++ b/components/sup/src/command/mod.rs
@@ -13,3 +13,4 @@
 
 pub mod start;
 pub mod configure;
+pub mod shell;

--- a/components/sup/src/command/shell.rs
+++ b/components/sup/src/command/shell.rs
@@ -1,0 +1,65 @@
+// Copyright:: Copyright (c) 2015-2016 The Habitat Maintainers
+//
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
+
+use std::env;
+use std::ffi::CString;
+use std::ptr;
+
+use hcore::env as henv;
+use hcore::fs::find_command;
+use libc;
+
+use error::{Error, Result};
+use util::path::busybox_paths;
+
+/// Our output key
+static LOGKEY: &'static str = "SH";
+
+/// Start a bash shell
+pub fn bash() -> Result<()> {
+    try!(set_path());
+    outputln!("Starting your bashlike shell; enjoy!");
+    exec_shell("bash")
+}
+
+/// Start a sh shell
+pub fn sh() -> Result<()> {
+    try!(set_path());
+    outputln!("Starting your bourne shell; enjoy!");
+    exec_shell("sh")
+}
+
+fn set_path() -> Result<()> {
+    let mut paths = String::new();
+    for path in try!(busybox_paths()).iter() {
+        if !paths.is_empty() {
+            paths.push(':');
+        }
+        paths.push_str(&path.to_string_lossy());
+    }
+    if let Some(val) = henv::var_os("PATH") {
+        paths.push(':');
+        paths.push_str(&val.to_string_lossy());
+    }
+    debug!("Setting the PATH to {}", &paths);
+    env::set_var("PATH", &paths);
+    Ok(())
+}
+
+fn exec_shell(cmd: &str) -> Result<()> {
+    let cmd_path = match find_command(cmd) {
+        Some(p) => p,
+        None => return Err(sup_error!(Error::ExecCommandNotFound(cmd.to_string()))),
+    };
+    let c_cmd = try!(CString::new(cmd_path.to_string_lossy().into_owned()));
+    let mut argv = [c_cmd.as_ptr(), ptr::null()];
+    debug!("Exec {:?}", &cmd_path.display());
+    unsafe {
+        libc::execvp(c_cmd.as_ptr(), argv.as_mut_ptr());
+    }
+    Ok(())
+}

--- a/components/sup/src/config.rs
+++ b/components/sup/src/config.rs
@@ -28,7 +28,8 @@ static LOGKEY: &'static str = "CFG";
 pub enum Command {
     Config,
     Start,
-    Shell,
+    ShellBash,
+    ShellSh,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -57,7 +58,8 @@ impl FromStr for Command {
     fn from_str(s: &str) -> Result<Command, SupError> {
         match s {
             "config" => Ok(Command::Config),
-            "sh" => Ok(Command::Shell),
+            "bash" => Ok(Command::ShellBash),
+            "sh" => Ok(Command::ShellSh),
             "start" => Ok(Command::Start),
             _ => Err(sup_error!(Error::CommandNotImplemented)),
         }

--- a/components/sup/src/error.rs
+++ b/components/sup/src/error.rs
@@ -92,6 +92,7 @@ pub enum Error {
     CommandNotImplemented,
     DbInvalidPath,
     DepotClient(depot_client::Error),
+    ExecCommandNotFound(String),
     FileNotFound(String),
     HabitatCommon(common::Error),
     HabitatCore(hcore::Error),
@@ -137,6 +138,9 @@ impl fmt::Display for SupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let content = match self.err {
             Error::ActorError(ref err) => format!("Actor returned error: {:?}", err),
+            Error::ExecCommandNotFound(ref c) => {
+                format!("`{}' was not found on the filesystem or in PATH", c)
+            }
             Error::HabitatCommon(ref err) => format!("{}", err),
             Error::HabitatCore(ref err) => format!("{}", err),
             Error::CommandNotImplemented => format!("Command is not yet implemented!"),
@@ -221,6 +225,7 @@ impl error::Error for SupError {
     fn description(&self) -> &str {
         match self.err {
             Error::ActorError(_) => "A running actor responded with an error",
+            Error::ExecCommandNotFound(_) => "Exec command was not found on filesystem or in PATH",
             Error::HabitatCommon(ref err) => err.description(),
             Error::HabitatCore(ref err) => err.description(),
             Error::CommandNotImplemented => "Command is not yet implemented!",

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -17,9 +17,7 @@ extern crate libc;
 #[macro_use]
 extern crate clap;
 
-use std::ffi::CString;
 use std::process;
-use std::ptr;
 use std::result;
 use std::str::FromStr;
 
@@ -133,8 +131,8 @@ fn config_from_args(args: &ArgMatches, subcommand: &str, sub_args: &ArgMatches) 
     config.set_gossip_listen_ip(gossip_ip);
     config.set_gossip_listen_port(gossip_port);
     config.set_sidecar_listen(sub_args.value_of("listen-sidecar")
-                                     .unwrap_or(DEFAULT_SIDECAR_LISTEN_IP_PORT)
-                                     .to_string());
+                                      .unwrap_or(DEFAULT_SIDECAR_LISTEN_IP_PORT)
+                                      .to_string());
     let gossip_peers = match sub_args.values_of("peer") {
         Some(gp) => gp.map(|s| s.to_string()).collect(),
         None => vec![],
@@ -268,7 +266,8 @@ fn main() {
                                  .short("I")
                                  .long("permanent-peer")
                                  .help("If this service is a permanent peer"));
-    let sub_sh = SubCommand::with_name("sh").about("Start an interactive shell");
+    let sub_bash = SubCommand::with_name("bash").about("Start an interactive shell (bash)");
+    let sub_sh = SubCommand::with_name("sh").about("Start an interactive shell (sh)");
     let sub_config = SubCommand::with_name("config")
                          .about("Print the default.toml for a given package")
                          .arg(Arg::with_name("package")
@@ -288,6 +287,7 @@ fn main() {
                             .global(true)
                             .help("Turn ANSI color off :("))
                    .subcommand(sub_start)
+                   .subcommand(sub_bash)
                    .subcommand(sub_sh)
                    .subcommand(sub_config);
     let matches = args.get_matches();
@@ -303,7 +303,8 @@ fn main() {
     };
 
     let result = match config.command() {
-        Command::Shell => shell(&config),
+        Command::ShellBash => shell_bash(&config),
+        Command::ShellSh => shell_sh(&config),
         Command::Config => configure(&config),
         Command::Start => start(&config),
     };
@@ -321,18 +322,16 @@ fn exit_with(e: SupError, code: i32) {
     process::exit(code)
 }
 
-/// Start a shell
+/// Start a sh shell
 #[allow(dead_code)]
-fn shell(_config: &Config) -> Result<()> {
-    outputln!("Starting your shell; enjoy!");
-    let shell_arg = try!(CString::new("sh"));
-    let mut argv = [shell_arg.as_ptr(), ptr::null()];
-    // Yeah, you don't know any better.. but we aren't coming back from
-    // what happens next.
-    unsafe {
-        libc::execvp(shell_arg.as_ptr(), argv.as_mut_ptr());
-    }
-    Ok(())
+fn shell_sh(_config: &Config) -> Result<()> {
+    shell::sh()
+}
+
+/// Start a bash shell
+#[allow(dead_code)]
+fn shell_bash(_config: &Config) -> Result<()> {
+    shell::bash()
 }
 
 /// Show the configuration options for a service


### PR DESCRIPTION
This change re-introduces the `bash` subcommand which was mistakenly
removed (sorry y'all) and also sets an appropriate `PATH` environment
variable.

The logic is similar to the path-setting logic of the `start` subcommand
except in this case, there is no Supervisor or service to have on path.
Instead, we determine a suitable Busybox path and append any `PATH`
entries at the end. This should make the Docker-wrapped services more
ergonomic when using `docker exec` or similar tricks.

![gif-keyboard-8611699104379787096](https://cloud.githubusercontent.com/assets/261548/15329690/d4b9daa4-1c16-11e6-9df6-fe940bc885c3.gif)
