### PR TITLE
Support wider range of service group string parsing.

### DIFF
--- a/components/core/src/service.rs
+++ b/components/core/src/service.rs
@@ -13,6 +13,11 @@ use regex::Regex;
 
 use error::Error;
 
+lazy_static! {
+    static ref FROM_STR_RE: Regex =
+        Regex::new(r"\A(?P<service>[^.]+)\.(?P<group>[^.@]+)(@(?P<organization>.+))?\z").unwrap();
+}
+
 #[derive(Clone, Debug, Eq, Hash, PartialEq, RustcDecodable, RustcEncodable)]
 pub struct ServiceGroup {
     pub service: String,
@@ -21,7 +26,10 @@ pub struct ServiceGroup {
 }
 
 impl ServiceGroup {
-    pub fn new<T: Into<String>>(service: T, group: T, organization: Option<String>) -> Self {
+    pub fn new<S1, S2>(service: S1, group: S2, organization: Option<String>) -> Self
+        where S1: Into<String>,
+              S2: Into<String>
+    {
         ServiceGroup {
             service: service.into(),
             group: group.into(),
@@ -43,44 +51,102 @@ impl FromStr for ServiceGroup {
     type Err = Error;
 
     fn from_str(value: &str) -> result::Result<Self, Self::Err> {
-        let regex = Regex::new(r"^([A-Za-z_0-9]+)\.([A-Za-z_0-9]+)(@([A-Za-z_0-9]+))?$").unwrap();
-        let caps = match regex.captures(value) {
+        let caps = match FROM_STR_RE.captures(value) {
             Some(c) => c,
             None => return Err(Error::InvalidServiceGroup(value.to_string())),
         };
-        let name = match caps.at(1) {
-            Some(n) => n,
+        let service = match caps.name("service") {
+            Some(s) => s.to_string(),
             None => return Err(Error::InvalidServiceGroup(value.to_string())),
         };
-
-        let group = match caps.at(2) {
-            Some(n) => n,
+        let group = match caps.name("group") {
+            Some(g) => g.to_string(),
             None => return Err(Error::InvalidServiceGroup(value.to_string())),
         };
-
-        // you can't specify a key with an "@", but without an org
-        // ex: "foo.bar@"
-        if value.ends_with('@') {
-            return Err(Error::InvalidServiceGroup(value.to_string()));
+        let organization = match caps.name("organization") {
+            Some(o) => Some(o.to_string()),
+            None => None,
         };
 
-        Ok(ServiceGroup::new(name, group, caps.at(4).map(|s| s.to_string())))
+        Ok(ServiceGroup::new(service, group, organization))
     }
 }
 
-#[test]
-fn service_groups_with_org() {
-    let x = ServiceGroup::from_str("foo.bar").unwrap();
-    assert!(x.service == "foo".to_string());
-    assert!(x.group == "bar".to_string());
-    assert!(x.organization.is_none());
+#[cfg(test)]
+mod test {
+    use std::str::FromStr;
 
-    let y = ServiceGroup::from_str("foo.bar@baz").unwrap();
-    assert!(y.service == "foo".to_string());
-    assert!(y.group == "bar".to_string());
-    assert!(y.organization.unwrap() == "baz");
+    use super::ServiceGroup;
 
-    assert!(ServiceGroup::from_str("foo.bar@").is_err());
-    assert!(ServiceGroup::from_str("f.oo.bar@baz").is_err());
-    assert!(ServiceGroup::from_str("foo@baz").is_err());
+    #[test]
+    fn service_group_fields() {
+        let sg = ServiceGroup {
+            service: "kayla".to_string(),
+            group: "album".to_string(),
+            organization: Some("flying_colors".to_string()),
+        };
+        assert_eq!(sg.service, "kayla");
+        assert_eq!(sg.group, "album");
+        assert_eq!(sg.organization, Some("flying_colors".to_string()));
+    }
+
+    #[test]
+    fn fmt_without_organization() {
+        let sg = ServiceGroup::new("kayla", "album", None);
+        assert_eq!(&sg.to_string(), "kayla.album");
+
+        let sg = ServiceGroup::new("blue-ocean", "album-track", None);
+        assert_eq!(&sg.to_string(), "blue-ocean.album-track");
+    }
+
+    #[test]
+    fn fmt_with_organization() {
+        let sg = ServiceGroup::new("kayla", "album", Some("flying_colors".to_string()));
+        assert_eq!(&sg.to_string(), "kayla.album@flying_colors");
+
+        let sg = ServiceGroup::new("blue-ocean", "album-track", Some("f-l_y".to_string()));
+        assert_eq!(&sg.to_string(), "blue-ocean.album-track@f-l_y");
+    }
+
+    #[test]
+    fn from_str_without_organization() {
+        let expected = ServiceGroup::new("kayla", "album", None);
+        let actual = ServiceGroup::from_str("kayla.album").unwrap();
+        assert_eq!(expected, actual);
+
+        let expected = ServiceGroup::new("blue-ocean", "track-from_album", None);
+        let actual = ServiceGroup::from_str("blue-ocean.track-from_album").unwrap();
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn from_str_with_organization() {
+        let expected = ServiceGroup::new("kayla", "album", Some("flying_colors".to_string()));
+        let actual = ServiceGroup::from_str("kayla.album@flying_colors").unwrap();
+        assert_eq!(expected, actual);
+
+        let expected = ServiceGroup::new("blue-ocean",
+                                         "track-from_album",
+                                         Some("f-l_y".to_string()));
+        let actual = ServiceGroup::from_str("blue-ocean.track-from_album@f-l_y").unwrap();
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    #[should_panic(expected = "not.allowed@")]
+    fn from_str_ending_with_at() {
+        ServiceGroup::from_str("not.allowed@").unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "only.one.period@allowed")]
+    fn from_str_too_many_periods() {
+        ServiceGroup::from_str("only.one.period@allowed").unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "oh-noes")]
+    fn from_str_not_enough_periods() {
+        ServiceGroup::from_str("oh-noes").unwrap();
+    }
 }


### PR DESCRIPTION
This change fixes the service group string parsing logic to accept more
values that are legal and useful.

In working on a new feature, I spun up a Depot/Redis combination in
Docker containers which gave me the following service groups in my ring:
- `redis.default`
- `hab-depot.default`

When attempting to apply config for the Depot service I was surprised to
get the following failure:

```
echo 'datastore_addr = “172.17.0.2”’ | hab apply --peers 172.17.0.2 hab-depot.default 1
Invalid service group: "hab-depot.default". A valid service group string is in the form service.group (example: redis.production)
```

After reworking the code that parses these service group strings, we see
the following glory:

```
echo 'datastore_addr = "172.17.0.2"' | hab apply --peers 172.17.0.2 hab-depot.default 1
» Applying configuration
↑ Applying configuration for hab-depot.default into ring via ["172.17.0.2:9634"]
Joining peer: 172.17.0.2:9634
Configuration applied to: 172.17.0.2:9634
★ Applied configuration.
```

Yes!

![gif-keyboard-9008690620347671677](https://cloud.githubusercontent.com/assets/261548/15367015/504d0e84-1ce4-11e6-9507-3f7f0fb38de6.gif)
