### PR TITLE
Remove SAP HANA from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,10 +3,6 @@ target
 .delivery/cli.toml
 .tags*
 log/
-plans/hana/SAP*
-plans/hana/sapcar.exe
-plans/hana/*.exe
-plans/hana/*.rar
 plans/log/
 plans/tmp/
 results/


### PR DESCRIPTION
We do not need to `.gitignore` this any longer because we don't have HANA in the plans tree.
