### PR TITLE
Remove writing out of the origin key from travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -100,7 +100,6 @@ matrix:
     - sudo apt-get update
     - sudo apt-get -y install docker iproute2 libsodium-dev libzmq-dev
     - command -v protoc-gen-rust || cargo install protobuf
-    - openssl aes-256-cbc -K $encrypted_c4f852370b68_key -iv $encrypted_c4f852370b68_iv -in core-20160423193745.sig.key.enc -out core-20160423193745.sig.key -d
     script:
     - ./support/ci.sh
     - sudo -E bash -c "./support/publish.sh"


### PR DESCRIPTION
This was supposed to be removed when the same line was added to
support/publish.sh. Remove the line from .travis.yml and pull requests
from forks should be able to pass tests.

My bad.

![tumblr_n4ci6hspxn1qicrz8o1_250](https://cloud.githubusercontent.com/assets/9912/15381940/f63cb2d0-1d49-11e6-9c27-87812d53d32b.gif)
