### PR TITLE
[sup] Fix Supervisor CLI compilation.

### DIFF
--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -153,7 +153,9 @@ fn config_from_args(args: &ArgMatches, subcommand: &str, sub_args: &ArgMatches) 
         None => {
             match henv::var(RING_KEY_ENVVAR) {
                 Ok(val) => {
-                    Some(try!(SymKey::write_file_from_str(&val, &default_cache_key_path(None))))
+                    let (key, _) = try!(SymKey::write_file_from_str(&val,
+                                                                    &default_cache_key_path(None)));
+                    Some(key)
                 }
                 Err(_) => {
                     match henv::var(RING_ENVVAR) {


### PR DESCRIPTION
As we're not explicitly building our binaries to test, this compile error snuck through. I feel pretty bad about it.

![gif-keyboard-4071984813988632882](https://cloud.githubusercontent.com/assets/261548/15382127/d0949332-1d43-11e6-889e-5c8b6ac1d864.gif)
