### PR TITLE
Fixes for builder-web deploy

### DIFF
--- a/components/builder-web/habitat/config/habitat.conf.js
+++ b/components/builder-web/habitat/config/habitat.conf.js
@@ -3,7 +3,7 @@ habitatConfig({
     community_url: "{{cfg.community_url}}",
     depot_url: "{{cfg.depot_url}}",
     docs_url: "{{cfg.docs_url}}",
-    environment: "{{cfg.docs_url}}",
+    environment: "{{cfg.environment}}",
     github_client_id: "{{cfg.github_client_id}}",
     github_token_auth_url: "{{cfg.github_token_auth_url}}",
     source_code_url: "{{cfg.source_code_url}}",

--- a/components/builder-web/habitat/config/nginx.conf
+++ b/components/builder-web/habitat/config/nginx.conf
@@ -163,8 +163,8 @@ http {
 
         # Any request that did not originally come in to the ELB
         # over HTTPS gets redirected.
-        if ($http_x_forwarded_proto != "https") {
-          rewrite ^(.*)$ https://$server_name$1 permanent;
+        if ($http_x_forwarded_proto = "http") {
+          rewrite ^(.*)$ https://$host$1 permanent;
         }
 
         location ~* ^/favicon.ico/ {


### PR DESCRIPTION
- Make it so nginx redirects to the http hostname, not localhost
- Fix typo in habitat.conf.js template

![giphy](https://cloud.githubusercontent.com/assets/9912/15410504/bf0ec8c0-1ddf-11e6-89f9-67038ec00982.gif)
