### PR TITLE
Change the URL for docs to www.habitat.sh/docs

### DIFF
--- a/components/builder-web/habitat.conf.sample.js
+++ b/components/builder-web/habitat.conf.sample.js
@@ -6,7 +6,7 @@ habitatConfig({
     // The URL for the depot service
     depot_url: "",
     // The URL for documentation
-    docs_url: "https://docs.habitat.sh",
+    docs_url: "https://www.habitat.sh/docs",
     // The environment in which we're running. If "production", enable
     // production mode
     environment: "production",

--- a/components/builder-web/habitat/default.toml
+++ b/components/builder-web/habitat/default.toml
@@ -8,7 +8,7 @@ community_url = "https://www.habitat.sh/community"
 depot_url = ""
 
 # The URL for documentation
-docs_url = "https://docs.habitat.sh"
+docs_url = "https://www.habitat.sh/docs"
 
 # The environment in which we're running. If "production", enable
 # production mode


### PR DESCRIPTION
![gif-keyboard-10961711213826893884](https://cloud.githubusercontent.com/assets/4304/15411457/fcd956bc-1dd4-11e6-8657-5d549d4ae365.gif)

This changes the docs url to http://www.habitat.sh/docs in the
builder-web.

Signed-off-by: Adam Jacob adam@chef.io
