### PR TITLE
Semver suggests 0.1.0 as the initial version

### DIFF
--- a/plans/plan-tmpl.sh
+++ b/plans/plan-tmpl.sh
@@ -1,6 +1,6 @@
 pkg_origin=core
 pkg_name=PACKAGE
-pkg_version=0.0.1
+pkg_version=0.1.0
 pkg_maintainer="You <humans@example.com>"
 pkg_license=()
 pkg_source=http://example.com/${pkg_name}-${pkg_version}.tar.xz


### PR DESCRIPTION
_The simplest thing to do is start your initial development release at 0.1.0 and then increment the minor version for each subsequent release._

Signed-off-by: Nathen Harvey nharvey@chef.io
