### PR TITLE
support removing empty cache directories

### DIFF
--- a/components/studio/libexec/hab-studio-type-baseimage.sh
+++ b/components/studio/libexec/hab-studio-type-baseimage.sh
@@ -127,7 +127,7 @@ esac
 EOT
   $bb chmod a+x $HAB_STUDIO_ROOT/init.sh
 
-  $bb rm $HAB_STUDIO_ROOT$HAB_CACHE_ARTIFACT_PATH/*
+  $bb rm -f $HAB_STUDIO_ROOT$HAB_CACHE_ARTIFACT_PATH/*
 
   studio_env_command="$busybox_path/bin/env"
 }


### PR DESCRIPTION
"rm $HAB_STUDIO_ROOT$HAB_CACHE_ARTIFACT_PATH/*" with an empty directory fails the script. 
