### PR TITLE
add sidecar + gossip ip/port to config.toml sys table

### DIFF
--- a/components/sup/src/config.rs
+++ b/components/sup/src/config.rs
@@ -89,7 +89,8 @@ pub struct Config {
     expire_days: Option<u16>,
     gossip_listen_ip: String,
     gossip_listen_port: u16,
-    sidecar_listen: String,
+    sidecar_listen_ip: String,
+    sidecar_listen_port: u16,
     userkey: Option<String>,
     servicekey: Option<String>,
     infile: Option<String>,
@@ -291,12 +292,21 @@ impl Config {
         self
     }
 
-    pub fn sidecar_listen(&self) -> &str {
-        &self.sidecar_listen
+    pub fn sidecar_listen_ip(&self) -> &str {
+        &self.sidecar_listen_ip
     }
 
-    pub fn set_sidecar_listen(&mut self, sl: String) -> &mut Config {
-        self.sidecar_listen = sl;
+    pub fn set_sidecar_listen_ip(&mut self, ip: String) -> &mut Config {
+        self.sidecar_listen_ip = ip;
+        self
+    }
+
+    pub fn sidecar_listen_port(&self) -> u16 {
+        self.sidecar_listen_port
+    }
+
+    pub fn set_sidecar_listen_port(&mut self, port: u16) -> &mut Config {
+        self.sidecar_listen_port = port;
         self
     }
 

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -45,7 +45,9 @@ const VERSION: &'static str = include_str!(concat!(env!("OUT_DIR"), "/VERSION"))
 
 /// CLI defaults
 static DEFAULT_GROUP: &'static str = "default";
-static DEFAULT_SIDECAR_LISTEN_IP_PORT: &'static str = "0.0.0.0:9631";
+
+static DEFAULT_SIDECAR_LISTEN_IP: &'static str = "0.0.0.0";
+static DEFAULT_SIDECAR_LISTEN_PORT: u16 = 9631;
 
 const DEFAULT_GOSSIP_LISTEN_PORT: u16 = 9634;
 
@@ -127,12 +129,21 @@ fn config_from_args(args: &ArgMatches, subcommand: &str, sub_args: &ArgMatches) 
                                         DEFAULT_GOSSIP_LISTEN_PORT));
 
     debug!("Gossip IP = {}", &gossip_ip);
-    debug!("Gossip Port = {}", &gossip_port);
+    debug!("Gossip port = {}", &gossip_port);
     config.set_gossip_listen_ip(gossip_ip);
     config.set_gossip_listen_port(gossip_port);
-    config.set_sidecar_listen(sub_args.value_of("listen-sidecar")
-                                      .unwrap_or(DEFAULT_SIDECAR_LISTEN_IP_PORT)
-                                      .to_string());
+
+    let (sidecar_ip, sidecar_port) = try!(parse_ip_port_with_defaults(
+                                            sub_args.value_of("listen-sidecar"),
+                                            DEFAULT_SIDECAR_LISTEN_IP,
+                                            DEFAULT_SIDECAR_LISTEN_PORT));
+
+    debug!("Sidecar IP = {}", &sidecar_ip);
+    debug!("Sidecar port = {}", &sidecar_port);
+
+    config.set_sidecar_listen_ip(sidecar_ip);
+    config.set_sidecar_listen_port(sidecar_port);
+
     let gossip_peers = match sub_args.values_of("peer") {
         Some(gp) => gp.map(|s| s.to_string()).collect(),
         None => vec![],


### PR DESCRIPTION
This PR adds gossip + sidecar IP and port info to the `sys` table:

```
cat /hab/svc/redis/config.toml
...
[sys]
gossip_ip = "172.17.0.5"
gossip_port = 9634
hostname = "7628605811ba"
ip = "172.17.0.5"
sidecar_ip = "0.0.0.0"
sidecar_port = 9631
```

Note that `ip` can be different that `gossip_ip` if you have multiple IP's on a node and choose which one you want gossip to listen to.
