### PR TITLE
polipo caching performance improvements

### DIFF
--- a/plans/polipo/config/polipo.config
+++ b/plans/polipo/config/polipo.config
@@ -1,13 +1,10 @@
-disableIndexing = false
-disableServersList = false
+cacheIsShared = {{cfg.cacheIsShared}}
+chunkHighMark = {{cfg.chunkHighMark}}
+disableIndexing = {{cfg.disableIndexing}}
+disableServersList = {{cfg.disableServersList}}
 diskCacheRoot = "{{pkg.svc_path}}/cache/"
-dnsNameServer = "8.8.8.8"
-proxyAddress = "::0"
+dnsNameServer = "{{cfg.dnsNameServer}}"
+localDocumentRoot = "{{pkg.svc_path}}/www/"
+objectHighMark = {{cfg.objectHighMark}}
+proxyAddress = "{{cfg.proxyAddress}}"
 proxyPort = {{cfg.port}}
-
-# share caching between all users, possibly unsafe
-cacheIsShared = false
-
-# 8X the defaults
-chunkHighMark = 201326592
-objectHighMark = 16384

--- a/plans/polipo/default.toml
+++ b/plans/polipo/default.toml
@@ -1,2 +1,17 @@
+# https://www.irif.univ-paris-diderot.fr/~jch//software/polipo/manual/
+# share caching between all users, possibly unsafe
+cacheIsShared = "false"
+# 4X the default
+chunkHighMark = 100663296
+# show the list of packages
+disableIndexing = "false"
+# show the list of servers
+disableServersList = "false"
+# Override DNS
+dnsNameServer = "8.8.8.8"
+# 4X the default
+objectHighMark = 8192
+# allows anyone access
+proxyAddress = "::0"
 # The port number that is listening for requests.
-port=8123
+port = 8123

--- a/plans/polipo/hooks/init
+++ b/plans/polipo/hooks/init
@@ -2,3 +2,4 @@
 #
 
 mkdir {{pkg.svc_path}}/cache/
+mkdir {{pkg.svc_path}}/www/


### PR DESCRIPTION
I thought habitat was not passing the http_proxy environment variable everywhere, turned out polipo was just very conservatively configured. This configuration uses more memory and is more liberal with sharing content between machines. Since Habitat is potentially using multiple machines (containers) as build environments are created/destroyed this makes for much more efficient caching.
https://www.irif.univ-paris-diderot.fr/~jch//software/polipo/polipo.html#index-cacheIsShared
