### PR TITLE
bump r2d2_redis dependency

### DIFF
--- a/components/builder-api/Cargo.lock
+++ b/components/builder-api/Cargo.lock
@@ -149,7 +149,7 @@ dependencies = [
  "env_logger 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "r2d2 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "r2d2_redis 0.2.0 (git+https://github.com/chef/r2d2-redis.git?branch=update-r2d2)",
+ "r2d2_redis 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "redis 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -200,7 +200,7 @@ dependencies = [
  "mount 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "r2d2 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "r2d2_redis 0.2.0 (git+https://github.com/chef/r2d2-redis.git?branch=update-r2d2)",
+ "r2d2_redis 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "redis 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.69 (registry+https://github.com/rust-lang/crates.io-index)",
  "router 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -550,8 +550,8 @@ dependencies = [
 
 [[package]]
 name = "r2d2_redis"
-version = "0.2.0"
-source = "git+https://github.com/chef/r2d2-redis.git?branch=update-r2d2#a137d2496e9720a6b1080dcb5cf49a101c2d8e7d"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "r2d2 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "redis 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/builder-dbcache/Cargo.lock
+++ b/components/builder-dbcache/Cargo.lock
@@ -5,7 +5,7 @@ dependencies = [
  "env_logger 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "r2d2 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "r2d2_redis 0.2.0 (git+https://github.com/chef/r2d2-redis.git?branch=update-r2d2)",
+ "r2d2_redis 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "redis 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -75,8 +75,8 @@ dependencies = [
 
 [[package]]
 name = "r2d2_redis"
-version = "0.2.0"
-source = "git+https://github.com/chef/r2d2-redis.git?branch=update-r2d2#a137d2496e9720a6b1080dcb5cf49a101c2d8e7d"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "r2d2 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "redis 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/builder-dbcache/Cargo.toml
+++ b/components/builder-dbcache/Cargo.toml
@@ -8,10 +8,7 @@ description = "Habitat-Builder Database Access Library"
 env_logger = "*"
 log = "*"
 r2d2 = "*"
+r2d2_redis = "*"
 redis = "*"
 rustc-serialize = "*"
 time = "*"
-
-[dependencies.r2d2_redis]
-git = "https://github.com/chef/r2d2-redis.git"
-branch = "update-r2d2"

--- a/components/builder-jobsrv/Cargo.lock
+++ b/components/builder-jobsrv/Cargo.lock
@@ -71,7 +71,7 @@ dependencies = [
  "env_logger 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "r2d2 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "r2d2_redis 0.2.0 (git+https://github.com/chef/r2d2-redis.git?branch=update-r2d2)",
+ "r2d2_redis 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "redis 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -206,8 +206,8 @@ dependencies = [
 
 [[package]]
 name = "r2d2_redis"
-version = "0.2.0"
-source = "git+https://github.com/chef/r2d2-redis.git?branch=update-r2d2#a137d2496e9720a6b1080dcb5cf49a101c2d8e7d"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "r2d2 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "redis 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/builder-sessionsrv/Cargo.lock
+++ b/components/builder-sessionsrv/Cargo.lock
@@ -12,7 +12,7 @@ dependencies = [
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "r2d2 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "r2d2_redis 0.2.0 (git+https://github.com/chef/r2d2-redis.git?branch=update-r2d2)",
+ "r2d2_redis 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "redis 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -106,7 +106,7 @@ dependencies = [
  "env_logger 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "r2d2 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "r2d2_redis 0.2.0 (git+https://github.com/chef/r2d2-redis.git?branch=update-r2d2)",
+ "r2d2_redis 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "redis 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -356,8 +356,8 @@ dependencies = [
 
 [[package]]
 name = "r2d2_redis"
-version = "0.2.0"
-source = "git+https://github.com/chef/r2d2-redis.git?branch=update-r2d2#a137d2496e9720a6b1080dcb5cf49a101c2d8e7d"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "r2d2 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "redis 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/builder-sessionsrv/Cargo.toml
+++ b/components/builder-sessionsrv/Cargo.toml
@@ -15,6 +15,7 @@ hyper = "*"
 log = "*"
 protobuf = "*"
 r2d2 = "*"
+r2d2_redis = "*"
 redis = "*"
 rustc-serialize = "*"
 time = "*"
@@ -23,10 +24,6 @@ toml = "*"
 [dependencies.clap]
 version = "*"
 features = [ "suggestions", "color", "unstable" ]
-
-[dependencies.r2d2_redis]
-git = "https://github.com/chef/r2d2-redis.git"
-branch = "update-r2d2"
 
 [dependencies.zmq]
 # git = "https://github.com/erickt/rust-zmq.git"

--- a/components/builder-vault/Cargo.lock
+++ b/components/builder-vault/Cargo.lock
@@ -11,7 +11,7 @@ dependencies = [
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "r2d2 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "r2d2_redis 0.2.0 (git+https://github.com/chef/r2d2-redis.git?branch=update-r2d2)",
+ "r2d2_redis 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "redis 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -75,7 +75,7 @@ dependencies = [
  "env_logger 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "r2d2 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "r2d2_redis 0.2.0 (git+https://github.com/chef/r2d2-redis.git?branch=update-r2d2)",
+ "r2d2_redis 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "redis 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -210,8 +210,8 @@ dependencies = [
 
 [[package]]
 name = "r2d2_redis"
-version = "0.2.0"
-source = "git+https://github.com/chef/r2d2-redis.git?branch=update-r2d2#a137d2496e9720a6b1080dcb5cf49a101c2d8e7d"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "r2d2 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "redis 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/builder-vault/Cargo.toml
+++ b/components/builder-vault/Cargo.toml
@@ -14,6 +14,7 @@ env_logger = "*"
 log = "*"
 protobuf = "*"
 r2d2 = "*"
+r2d2_redis = "*"
 redis = "*"
 rustc-serialize = "*"
 toml = "*"
@@ -21,10 +22,6 @@ toml = "*"
 [dependencies.clap]
 version = "*"
 features = [ "suggestions", "color", "unstable" ]
-
-[dependencies.r2d2_redis]
-git = "https://github.com/chef/r2d2-redis.git"
-branch = "update-r2d2"
 
 [dependencies.zmq]
 # git = "https://github.com/erickt/rust-zmq.git"

--- a/components/depot/Cargo.lock
+++ b/components/depot/Cargo.lock
@@ -17,7 +17,7 @@ dependencies = [
  "mount 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "r2d2 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "r2d2_redis 0.2.0 (git+https://github.com/chef/r2d2-redis.git?branch=update-r2d2)",
+ "r2d2_redis 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "redis 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.69 (registry+https://github.com/rust-lang/crates.io-index)",
  "router 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -146,7 +146,7 @@ dependencies = [
  "env_logger 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "r2d2 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "r2d2_redis 0.2.0 (git+https://github.com/chef/r2d2-redis.git?branch=update-r2d2)",
+ "r2d2_redis 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "redis 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -492,8 +492,8 @@ dependencies = [
 
 [[package]]
 name = "r2d2_redis"
-version = "0.2.0"
-source = "git+https://github.com/chef/r2d2-redis.git?branch=update-r2d2#a137d2496e9720a6b1080dcb5cf49a101c2d8e7d"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "r2d2 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "redis 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/depot/Cargo.toml
+++ b/components/depot/Cargo.toml
@@ -20,6 +20,7 @@ log = "*"
 mount = "*"
 openssl = "*"
 r2d2 = "*"
+r2d2_redis = "*"
 redis = "*"
 regex = "*"
 router = "*"
@@ -33,10 +34,6 @@ walkdir = "*"
 [dependencies.clap]
 version = "*"
 features = [ "suggestions", "color", "unstable" ]
-
-[dependencies.r2d2_redis]
-git = "https://github.com/chef/r2d2-redis.git"
-branch = "update-r2d2"
 
 [dependencies.habitat_builder_dbcache]
 path = "../builder-dbcache"


### PR DESCRIPTION
My changes were merged upstream into r2d2_redis so we can switch back to using the crate instead of our branch on Github

https://github.com/sorccu/r2d2-redis/pull/7
