### PR TITLE
[hab] Add initial support for building a Mac `hab` binary.

### DIFF
--- a/components/hab/mac/README.md
+++ b/components/hab/mac/README.md
@@ -1,0 +1,24 @@
+# Building a hab Mac Binary
+
+As Habitat currently does not have first class support for the Mac platform, a pragmatic approach has been taken to build a `hab` binary for Mac OS X. A wrapper script called `mac-build.sh` attempts to install any missing pre-requisites before invoking the `hab-plan-build.sh` program with a custom `PATH`. Currently, the following are required on the Mac system performing the build:
+
+* Xcode CLI tools
+* Homebrew
+* `coreutils`, `gnu-tar`, and `wget` Homebrew packages
+* Rust
+
+A final prerequisite of a `hab` binary itself is required by `hab-plan-build.sh` to sign the resulting Habitat artifact. This can be most easily accomplished by either bringing in an older build of `hab` or compiling it out of the source tree and placing the result somewhere in the `PATH` to be picked up by the build program. As we are using the build program, a secret origin key is also required in the Mac's key cache under `/hab/cache/keys`.
+
+## Usage
+
+```sh
+sudo ./mac-build.sh
+```
+
+Assuming success, this will produce a local `./results` directory with the artifact.
+
+Alternatively, as `mac-build.sh` is a wrapper around the build program, it can be just as easily invoked from the root of the source tree with:
+
+```sh
+sudo ./components/src/hab/mac/mac-build components/src/hab/mac
+```

--- a/components/hab/mac/homebrew/hab-libarchive.rb
+++ b/components/hab/mac/homebrew/hab-libarchive.rb
@@ -1,0 +1,42 @@
+# Forked from https://raw.githubusercontent.com/Homebrew/homebrew-core/master/Formula/libarchive.rb
+# On 2016-05-25
+
+class HabLibarchive < Formula
+  desc "Multi-format archive and compression library"
+  homepage "http://www.libarchive.org"
+  url "http://www.libarchive.org/downloads/libarchive-3.2.0.tar.gz"
+  mirror "https://github.com/libarchive/libarchive/archive/v3.2.0.tar.gz"
+  sha256 "7bce45fd71ff01dc20d19edd78322d4965583d81b8bed8e26cacb65d6f5baa87"
+
+  keg_only :provided_by_osx
+
+  depends_on "xz" => :recommended
+  depends_on "lz4" => :optional
+  depends_on "lzop" => :optional
+
+  def install
+    system "./configure",
+           "--prefix=#{prefix}",
+           "--without-lzo2",    # Use lzop binary instead of lzo2 due to GPL
+           "--without-nettle",  # xar hashing option but GPLv3
+           "--without-xml2",    # xar hashing option but tricky dependencies
+           "--without-openssl", # mtree hashing now possible without OpenSSL
+           "--with-expat",      # best xar hashing option
+           "--with-libiconv-prefix=/usr/local/opt/hab-libiconv",
+           "--enable-shared=no"
+
+    system "make", "install"
+
+    # Just as apple does it.
+    ln_s bin/"bsdtar", bin/"tar"
+    ln_s bin/"bsdcpio", bin/"cpio"
+    ln_s man1/"bsdtar.1", man1/"tar.1"
+    ln_s man1/"bsdcpio.1", man1/"cpio.1"
+  end
+
+  test do
+    (testpath/"test").write("test")
+    system bin/"bsdtar", "-czvf", "test.tar.gz", "test"
+    assert_match /test/, shell_output("#{bin}/bsdtar -xOzf test.tar.gz")
+  end
+end

--- a/components/hab/mac/homebrew/hab-libiconv.rb
+++ b/components/hab/mac/homebrew/hab-libiconv.rb
@@ -1,0 +1,60 @@
+# Forked from https://raw.githubusercontent.com/Homebrew/homebrew-dupes/master/libiconv.rb
+# On 2016-05-25
+#
+class HabLibiconv < Formula
+  desc "Conversion library"
+  homepage "https://www.gnu.org/software/libiconv/"
+  url "http://ftpmirror.gnu.org/libiconv/libiconv-1.14.tar.gz"
+  mirror "https://ftp.gnu.org/gnu/libiconv/libiconv-1.14.tar.gz"
+  sha256 "72b24ded17d687193c3366d0ebe7cde1e6b18f0df8c55438ac95be39e8a30613"
+
+  bottle do
+    sha256 "64d8a9383ba42ba3e41422bb8548ebc8f296f67fdda6e6d6a324f990b03c6db0" => :el_capitan
+    sha256 "a0d9ff36269bc908fde4a039d2083152202055a2e053b6582ad2c9063c85ebc2" => :yosemite
+    sha256 "456a816a94427c963fa3cb90257830aa33268f22443cf5a8a4cf1be3e3ed3bb9" => :mavericks
+  end
+
+  keg_only :provided_by_osx
+
+  option :universal
+
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/patches/9be2793af/libiconv/patch-Makefile.devel"
+    sha256 "ad9b6da1a82fc4de27d6f7086a3382993a0b16153bc8e8a23d7b5f9334ca0a42"
+  end
+
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/patches/9be2793af/libiconv/patch-utf8mac.diff"
+    sha256 "e8128732f22f63b5c656659786d2cf76f1450008f36bcf541285268c66cabeab"
+  end
+
+  patch :DATA
+
+  def install
+    ENV.universal_binary if build.universal?
+    ENV.j1
+
+    system "./configure", "--disable-debug",
+                          "--disable-dependency-tracking",
+                          "--prefix=#{prefix}",
+                          "--enable-extra-encodings",
+                          "--enable-static"
+    system "make", "-f", "Makefile.devel", "CFLAGS=#{ENV.cflags}", "CC=#{ENV.cc}"
+    system "make", "install"
+  end
+end
+
+
+__END__
+diff --git a/lib/flags.h b/lib/flags.h
+index d7cda21..4cabcac 100644
+--- a/lib/flags.h
++++ b/lib/flags.h
+@@ -14,6 +14,7 @@
+ 
+ #define ei_ascii_oflags (0)
+ #define ei_utf8_oflags (HAVE_ACCENTS | HAVE_QUOTATION_MARKS | HAVE_HANGUL_JAMO)
++#define ei_utf8mac_oflags (HAVE_ACCENTS | HAVE_QUOTATION_MARKS | HAVE_HANGUL_JAMO)
+ #define ei_ucs2_oflags (HAVE_ACCENTS | HAVE_QUOTATION_MARKS | HAVE_HANGUL_JAMO)
+ #define ei_ucs2be_oflags (HAVE_ACCENTS | HAVE_QUOTATION_MARKS | HAVE_HANGUL_JAMO)
+ #define ei_ucs2le_oflags (HAVE_ACCENTS | HAVE_QUOTATION_MARKS | HAVE_HANGUL_JAMO)

--- a/components/hab/mac/mac-build.sh
+++ b/components/hab/mac/mac-build.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+# Fail if there are any unset variables and whenever a command returns a
+# non-zero exit code.
+set -eu
+
+# If the variable `$DEBUG` is set, then print the shell commands as we execute.
+if [ -n "${DEBUG:-}" ]; then
+  set -x
+  export DEBUG
+fi
+
+info() {
+  case "${TERM:-}" in
+    *term | xterm-* | rxvt | screen | screen-*)
+      printf -- "   \033[1;33m$(basename $0): \033[1;37m$1\033[0m\n"
+      ;;
+    *)
+      printf -- "   $(basename $0): $1\n"
+      ;;
+  esac
+  return 0
+}
+
+install_if_missing() {
+  local pkg="$1"
+  if [[ -n "${2:-}" ]]; then
+    local formula="$2"
+  else
+    local formula="$pkg"
+  fi
+
+  if [[ $(brew list --versions $pkg | wc -l) -eq 0 ]]; then
+    info "Installing missing Homebrew package $formula"
+    sudo -u $SUDO_USER brew install $formula
+  fi
+}
+
+if (( $EUID != 0 )); then
+  info "Please run as root (with \`sudo $0 $*\`)"
+  exit 1
+fi
+
+if ! pkgutil --pkgs=com.apple.pkg.CLTools_Executables >/dev/null; then
+  info "Xcode CLI tools missing, attempting to install"
+  # Implementation graciously borrowed and modified from the build-essential
+  # Chef cookbook which has been graciously borrowed and modified from Tim
+  # Sutton's osx-vm-templates project.
+  #
+  # Source: https://github.com/chef-cookbooks/build-essential/blob/a4f9621020e930a0e4fa0ccb5b7957dbef8ab347/libraries/xcode_command_line_tools.rb#L182-L188
+  # Source: https://github.com/timsutton/osx-vm-templates/blob/b001475df54a9808d3d56d06e71b8fa3001fff42/scripts/xcode-cli-tools.sh
+  touch /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress
+  PROD=$(softwareupdate -l | grep "\*.*Command Line" | head -n 1 | awk -F"*" '{print $2}' | sed -e 's/^ *//' | tr -d '\n')
+  softwareupdate -i "$PROD" -v
+  rm -f /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress
+fi
+
+if ! command -v brew >/dev/null; then
+  info "Homebrew missing, attempting to install"
+  sudo -u $SUDO_USER /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+fi
+
+# Homebrew pacakges required to run `hab-plan-build.sh
+install_if_missing coreutils
+install_if_missing gnu-tar
+install_if_missing wget
+
+# Homebrew packages required to build `hab`
+install_if_missing zlib homebrew/dupes/zlib
+install_if_missing xz
+install_if_missing bzip2 homebrew/dupes/bzip2
+install_if_missing expat
+install_if_missing openssl
+install_if_missing libsodium
+install_if_missing hab-libiconv $(dirname $0)/homebrew/hab-libiconv.rb
+install_if_missing hab-libarchive $(dirname $0)/homebrew/hab-libarchive.rb
+
+if ! command -v rustc >/dev/null; then
+  info "Rust missing, attempting to install"
+  curl -s https://static.rust-lang.org/rustup.sh | sh -s -- -y
+fi
+
+info "Updating PATH to include GNU toolchain from HomeBrew"
+gnu_path="$(brew --prefix coreutils)/libexec/gnubin"
+gnu_path="$gnu_path:$(brew --prefix gnu-tar)/libexec/gnubin"
+export PATH="$gnu_path:$PATH"
+info "Setting PATH=$PATH"
+
+program="$(dirname $0)/../../plan-build/bin/hab-plan-build.sh"
+info "Executing: $program $*"
+echo
+exec $program $*

--- a/components/hab/mac/plan.sh
+++ b/components/hab/mac/plan.sh
@@ -1,0 +1,43 @@
+source ../plan.sh
+
+pkg_name=hab
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+# There is no true equivalent here (yet), so dependency arrarys will be empty.
+pkg_deps=()
+pkg_build_deps=()
+
+nproc() {
+  sysctl -n hw.ncpu
+}
+
+do_begin() {
+  # Set the parent directory as the "root" of this plan.
+  PLAN_CONTEXT="$(abspath ..)"
+}
+
+do_prepare() {
+  # Used by the `build.rs` program to set the version of the binaries
+  export PLAN_VERSION="${pkg_version}/${pkg_release}"
+  build_line "Setting PLAN_VERSION=$PLAN_VERSION"
+
+  export rustc_target="x86_64-apple-darwin"
+  build_line "Setting rustc_target=$rustc_target"
+
+  formulas="$PLAN_CONTEXT/mac/homebrew"
+
+  la_ldflags="-L$(brew --prefix zlib)/lib -lz"
+  la_ldflags="$la_ldflags -L$(brew --prefix xz)/lib -llzma"
+  la_ldflags="$la_ldflags -L$(brew --prefix bzip2)/lib -lbz2"
+  la_ldflags="$la_ldflags -L$(brew --prefix expat)/lib -lexpat"
+  la_ldflags="$la_ldflags -L$(brew --prefix "$formulas"/hab-libiconv.rb)/lib -liconv"
+
+  export LIBARCHIVE_LIB_DIR=$(brew --prefix "$formulas"/hab-libarchive.rb)/lib
+  export LIBARCHIVE_INCLUDE_DIR=$(brew --prefix "$formulas"/hab-libarchive.rb)/include
+  export LIBARCHIVE_LDFLAGS="$la_ldflags"
+  export LIBARCHIVE_STATIC=true
+  export OPENSSL_LIB_DIR=$(brew --prefix openssl)/lib
+  export OPENSSL_INCLUDE_DIR=$(brew --prefix openssl)/include
+  export OPENSSL_STATIC=true
+  export SODIUM_LIB_DIR=$(brew --prefix libsodium)/lib
+  export SODIUM_STATIC=true
+}


### PR DESCRIPTION
This work is a result of a short research spike which looked into what a
`hab` binary for the Mac would look like. After finally having success
building the binary with the desired characteristics, I noted that our
build program--normally running inside a Studio--would be great at
capturing the build process. The change introduces a `mac/` subdirectory
under the hab component containing all necessary build details including
a script called `mac-build.sh` that wraps the main build program,
ensuring that all build dependencies are met before starting. Again, as
we don't have the benefit of a proper Mac build environment, we are
relying on Homebrew packages for the external linking libraries.

![gif-keyboard-3487017035671629812](https://cloud.githubusercontent.com/assets/261548/15578499/ee9d7990-231d-11e6-8b07-18824115f97a.gif)
