### PR TITLE
Add plan for the which command

### DIFF
--- a/plans/which/plan.sh
+++ b/plans/which/plan.sh
@@ -1,0 +1,11 @@
+pkg_origin=core
+pkg_name=which
+pkg_version=2.21
+pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
+pkg_license=('GPL-3.0')
+pkg_source=http://ftp.gnu.org/gnu/which/which-2.21.tar.gz
+pkg_shasum=f4a245b94124b377d8b49646bf421f9155d36aa7614b6ebf83705d3ffc76eaad
+pkg_deps=()
+pkg_build_deps=(core/make core/gcc)
+pkg_bin_dirs=(bin)
+


### PR DESCRIPTION
Adds a new plan for the `which` command.

Signed-off-by: Kevin J. Dickerson kevin.dickerson@loom.technology
