### PR TITLE
[hab] Add `hab studio` subcommand.

### DIFF
--- a/components/core/src/url.rs
+++ b/components/core/src/url.rs
@@ -5,8 +5,17 @@
 // the Software until such time that the Software is made available under an
 // open source license such as the Apache 2.0 License.
 
+use env as henv;
+
 /// Default Depot URL
 pub const DEFAULT_DEPOT_URL: &'static str = "http://willem.habitat.sh:9636/v1/depot";
 
 /// Default Depot URL environment variable
 pub const DEPOT_URL_ENVVAR: &'static str = "HAB_DEPOT_URL";
+
+pub fn default_depot_url() -> String {
+    match henv::var(DEPOT_URL_ENVVAR) {
+        Ok(val) => val,
+        Err(_) => DEFAULT_DEPOT_URL.to_string(),
+    }
+}

--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -197,6 +197,10 @@ pub fn get() -> App<'static, 'static> {
                  )
             )
         )
+        (@subcommand studio =>
+            (about: "Commands relating to Habitat Studios")
+            (aliases: &["stu", "stud", "studi"])
+        )
         (@subcommand sup =>
             (about: "Commands relating to the Habitat Supervisor")
         )

--- a/components/hab/src/exec.rs
+++ b/components/hab/src/exec.rs
@@ -12,11 +12,12 @@ use std::os::unix::ffi::OsStringExt;
 use std::path::{Path, PathBuf};
 use std::ptr;
 
+use ansi_term::Colour::Cyan;
 use common;
 use hcore;
 use hcore::fs::cache_artifact_path;
 use hcore::package::{PackageIdent, PackageInstall};
-use hcore::url::DEFAULT_DEPOT_URL;
+use hcore::url::default_depot_url;
 
 use error::{Error, Result};
 
@@ -75,8 +76,10 @@ pub fn command_from_pkg(command: &str,
             }
         }
         Err(hcore::Error::PackageNotFound(_)) => {
-            println!("Package for {} not found, installing from depot", &ident);
-            try!(common::command::package::install::from_url(DEFAULT_DEPOT_URL,
+            println!("{}",
+                     Cyan.bold()
+                         .paint(format!("∵ Package for {} not found, installing", &ident)));
+            try!(common::command::package::install::from_url(&default_depot_url(),
                                                              ident,
                                                              fs_root_path,
                                                              &cache_artifact_path(None),

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -56,6 +56,10 @@ const SUP_CMD: &'static str = "hab-sup";
 const SUP_CMD_ENVVAR: &'static str = "HAB_SUP_BINARY";
 const SUP_PACKAGE_IDENT: &'static str = "core/hab-sup";
 
+const STUDIO_CMD: &'static str = "hab-studio";
+const STUDIO_CMD_ENVVAR: &'static str = "HAB_STUDIO_BINARY";
+const STUDIO_PACKAGE_IDENT: &'static str = "core/hab-studio";
+
 /// you can skip the --origin CLI param if you specify this env var
 const HABITAT_ORIGIN_ENVVAR: &'static str = "HAB_ORIGIN";
 
@@ -449,6 +453,27 @@ fn exec_subcommand_if_called() -> Result<()> {
                         init();
                         let ident = try!(PackageIdent::from_str(SUP_PACKAGE_IDENT));
                         try!(exec::command_from_pkg(SUP_CMD,
+                                                    &ident,
+                                                    &default_cache_key_path(None),
+                                                    0))
+                    }
+                };
+
+                if let Some(cmd) = find_command(command.to_string_lossy().as_ref()) {
+                    try!(exec::exec_command(cmd, env::args_os().skip(skip_n).collect()));
+                } else {
+                    return Err(Error::ExecCommandNotFound(command.to_string_lossy().into_owned()));
+                }
+            }
+            "studio" | "stu" | "stud" | "studi" => {
+                let skip_n = 2;
+
+                let command = match henv::var(STUDIO_CMD_ENVVAR) {
+                    Ok(command) => PathBuf::from(command),
+                    Err(_) => {
+                        init();
+                        let ident = try!(PackageIdent::from_str(STUDIO_PACKAGE_IDENT));
+                        try!(exec::command_from_pkg(STUDIO_CMD,
                                                     &ident,
                                                     &default_cache_key_path(None),
                                                     0))


### PR DESCRIPTION
This change introduces a new top-level subcommand noun: `studio`. The
implementation logic is virtually identical to the `hab sup` subcommand,
meaning that the `core/hab-studio` package is installed if not present
and then directly invoked via an `exec(1)` syscall.

``` sh
> hab
hab 0.5.0

Authors: The Habitat Maintainers <humans@habitat.sh>

"A Habitat is the natural environment for your services" - Alan Turing

USAGE:
    hab [FLAGS] [SUBCOMMAND]

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

SUBCOMMANDS:
    artifact    Commands relating to Habitat artifacts
    config      Commands relating to Habitat runtime config
    file        Commands relating to Habitat files
    help        Prints this message or the help of the given subcommand(s)
    origin      Commands relating to Habitat origin keys
    pkg         Commands relating to Habitat packages
    ring        Commands relating to Habitat rings
    service     Commands relating to Habitat services
    studio      Commands relating to Habitat Studios
    sup         Commands relating to the Habitat Supervisor
    user        Commands relating to Habitat users
ALIASES:
    apply       Alias for: 'config apply'
    install     Alias for: 'pkg install'
    start       Alias for: 'sup start'

> hab studio -t busybox enter
∵ Package for core/hab-studio not found, installing
» Installing core/hab-studio
↓ Downloading core/hab-studio/0.5.0/20160524185743
    2.52 MB / 2.52 MB / [==================] 100.00 % 49.32 MB/s
✓ Installed core/hab-studio/0.5.0/20160524185743
★ Install of core/hab-studio complete with 1 packages installed.
   hab-studio: Creating Studio at /hab/studios/src (busybox)
   hab-studio: Entering Studio at /hab/studios/src (busybox)

[#][busybox:/src:0]# exit

> hab stu rm
   hab-studio: Destroying Studio at /hab/studios/src (busybox)
```

![gif-keyboard-15351413531070600140](https://cloud.githubusercontent.com/assets/261548/15584519/29769d66-2338-11e6-99a7-07d0ad9675dd.gif)
