### PR TITLE
Remove "sidecar" jargon and refer to it as the supervisor's HTTP API.

### DIFF
--- a/www/source/docs/concepts-communication.html.md
+++ b/www/source/docs/concepts-communication.html.md
@@ -44,9 +44,9 @@ Think of each supervisor in the system as a *census entry*; taken together, they
 
 An example is leader election; it's handled here by having a consistent (and simple) algorithm for selecting a leader deterministically for the group. We rely on the eventual consistency of every supervisors census entry to elect a new leader in a reasonable amount of time.
 
-## Sidecar
+## Supervisor HTTP API
 
-The Habitat sidecar is an http service that exposes cluster metadata, statistics, and general diagnostic information useful for monitoring and support in the form of a JSON document. The sidecar also keeps the latest result from any `health_check` hooks that are run as part of a service group.
+The Habitat supervisor provides a HTTP API to expose cluster metadata, statistics, and general diagnostic information useful for monitoring and support in the form of a JSON document. The API also keeps the latest result from any `health_check` hooks that are run as part of a service group.
 
 <hr>
 <ul class="main-content--link-nav">

--- a/www/source/docs/concepts-overview.html.md
+++ b/www/source/docs/concepts-overview.html.md
@@ -3,7 +3,7 @@ title: Concepts overview
 ---
 
 # Concepts
-Habitat is comprised of binaries, a sidecar to report package status, a depot, a communication model for disseminating rumors through a gossip ring, and many other components.
+Habitat is comprised of plan and build system, a supervisor, an HTTP interface on that supervisor to report package status, a depot, a communication model for disseminating rumors through a supervisor ring, and many other components.
 
 This section will delve into each of these major components to give you a better idea of what they are, what they do, and how they work together.
 

--- a/www/source/docs/plan-syntax.html.md
+++ b/www/source/docs/plan-syntax.html.md
@@ -259,7 +259,7 @@ file_updated
 
 health_check
 : File location: `<plan>/hooks/health_check`
-: This hook is run when the Habitat sidecar receives a request at `/health`.
+: This hook is run when the Habitat HTTP API receives a request at `/health`.
 
   The `health_check` script must return a valid exit code from the list below.
 


### PR DESCRIPTION
A few other copy edits here and there.
