### PR TITLE
Changes `--peers` to `--peer`

### DIFF
--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -18,13 +18,13 @@ const VERSION: &'static str = include_str!(concat!(env!("OUT_DIR"), "/VERSION"))
 
 pub fn get() -> App<'static, 'static> {
     let alias_apply = sub_config_apply()
-                          .about("Alias for 'config apply'")
-                          .aliases(&["ap", "app", "appl"])
-                          .setting(AppSettings::Hidden);
+        .about("Alias for 'config apply'")
+        .aliases(&["ap", "app", "appl"])
+        .setting(AppSettings::Hidden);
     let alias_install = sub_package_install()
-                            .about("Alias for 'pkg install'")
-                            .aliases(&["i", "in", "ins", "inst", "insta", "instal"])
-                            .setting(AppSettings::Hidden);
+        .about("Alias for 'pkg install'")
+        .aliases(&["i", "in", "ins", "inst", "insta", "instal"])
+        .setting(AppSettings::Hidden);
     let alias_start = alias_start().aliases(&["st", "sta", "star"]);
 
     clap_app!(hab =>
@@ -91,7 +91,7 @@ pub fn get() -> App<'static, 'static> {
                    "A version number (positive integer) for this configuration (ex: 42)")
                 (@arg ORG: --org +takes_value "Name of service organization")
                 (@arg USER: +takes_value)
-                (@arg PEERS: -p --peers +takes_value
+                (@arg PEER: -p --peer +takes_value
                  "A comma-delimited list of one or more Habitat Supervisor peers to infect \
                  (default: 127.0.0.1:9634)")
                 (@arg RING: -r --ring +takes_value
@@ -265,7 +265,7 @@ fn sub_package_install() -> App<'static, 'static> {
 fn sub_config_apply() -> App<'static, 'static> {
     clap_app!(@subcommand apply =>
         (about: "Applies a configuration to a group of Habitat Supervisors")
-        (@arg PEERS: -p --peers +takes_value
+        (@arg PEER: -p --peer +takes_value
          "A comma-delimited list of one or more Habitat Supervisor peers to infect \
          (default: 127.0.0.1:9634)")
         (@arg RING: -r --ring +takes_value

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -210,7 +210,7 @@ fn sub_config_apply(m: &ArgMatches) -> Result<()> {
     let fs_root = henv::var(FS_ROOT_ENVVAR).unwrap_or(FS_ROOT_PATH.to_string());
     let fs_root_path = Some(Path::new(&fs_root));
     let default_ip = try!(ip());
-    let peers_str = m.value_of("PEERS").unwrap_or(&default_ip);
+    let peers_str = m.value_of("PEER").unwrap_or(&default_ip);
     let mut peers: Vec<String> = peers_str.split(",").map(|p| p.into()).collect();
     for p in peers.iter_mut() {
         if p.find(':').is_none() {
@@ -239,7 +239,7 @@ fn sub_file_upload(m: &ArgMatches) -> Result<()> {
     let fs_root = henv::var(FS_ROOT_ENVVAR).unwrap_or(FS_ROOT_PATH.to_string());
     let fs_root_path = Some(Path::new(&fs_root));
     let default_ip = try!(ip());
-    let peers_str = m.value_of("PEERS").unwrap_or(&default_ip);
+    let peers_str = m.value_of("PEER").unwrap_or(&default_ip);
     let mut peers: Vec<String> = peers_str.split(",").map(|p| p.into()).collect();
     for p in peers.iter_mut() {
         if p.find(':').is_none() {

--- a/www/source/javascripts/try.js
+++ b/www/source/javascripts/try.js
@@ -204,7 +204,7 @@
             // hab inject (alias)
             } else if (args[0] === "config") {
               // inject the gossip.toml into the group
-              if (args.join(" ") === "config apply redis.default 1 /tmp/gossip.toml --peers 172.17.0.4") {
+              if (args.join(" ") === "config apply redis.default 1 /tmp/gossip.toml --peer 172.17.0.4") {
                 getResponse("hab-config-apply").then(function (txt) {
                     inStudio = true;
                     callback(format(txt));

--- a/www/source/try/5.html.slim
+++ b/www/source/try/5.html.slim
@@ -23,7 +23,7 @@ p
     the TCP backlog issue.
 
 code
-  | hab config apply redis.default 1 /tmp/gossip.toml --peers 172.17.0.4
+  | hab config apply redis.default 1 /tmp/gossip.toml --peer 172.17.0.4
 
 .window-buttons
   ul

--- a/www/source/try/responses/hab-config-apply-help.txt
+++ b/www/source/try/responses/hab-config-apply-help.txt
@@ -1,4 +1,4 @@
 The config apply parameters were not correct. Please check spelling and re-try.
 
 The command to apply the gossip.toml file is:
-   [1;33mhab config apply redis.default 1 /tmp/gossip.toml --peers 172.17.0.4
+   [1;33mhab config apply redis.default 1 /tmp/gossip.toml --peer 172.17.0.4


### PR DESCRIPTION
![gif-keyboard-15202406663733194968](https://cloud.githubusercontent.com/assets/4304/15610367/b8b6c8d8-23d9-11e6-8826-e5838bca4980.gif)

The `hab` binary used the flag `--peers`, while the sup uses the flag
`--peer`. This change makes it `--peer` everywhere.

We're all peer again.

Signed-off-by: Adam Jacob adam@chef.io
