### PR TITLE
Use `--listen-http` rather than `--listen-sidecar`

### DIFF
--- a/components/director/Cargo.lock
+++ b/components/director/Cargo.lock
@@ -191,12 +191,12 @@ dependencies = [
  "habitat_core 0.5.0",
  "habitat_depot_client 0.5.0",
  "habitat_depot_core 0.5.0",
+ "handlebars 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "iron 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "mustache 0.6.1 (git+https://github.com/adamhjk/rust-mustache?branch=fallback_on_missing_extension)",
  "openssl 0.7.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.69 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -211,6 +211,19 @@ dependencies = [
  "urlencoded 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "wonder 0.1.0",
+]
+
+[[package]]
+name = "handlebars"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "itertools 0.4.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quick-error 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.69 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -294,6 +307,11 @@ dependencies = [
  "typemap 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "itertools"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "kernel32-sys"
@@ -389,15 +407,6 @@ dependencies = [
 name = "modifier"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "mustache"
-version = "0.6.1"
-source = "git+https://github.com/adamhjk/rust-mustache?branch=fallback_on_missing_extension#ecc021d1ad0bc2f5832fd36a24dece8ff58e6a3a"
-dependencies = [
- "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "num"
@@ -556,6 +565,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "tempdir 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rand"

--- a/components/director/src/controller.rs
+++ b/components/director/src/controller.rs
@@ -27,7 +27,7 @@ use super::task::{Task, ExecContext, ExecParams};
 static MINIMUM_LOOP_TIME_MS: i64 = 200;
 static LOGKEY: &'static str = "CTRL";
 pub const FIRST_GOSSIP_PORT: u16 = 9000;
-pub const FIRST_SIDECAR_PORT: u16 = 8000;
+pub const FIRST_HTTP_PORT: u16 = 8000;
 
 pub struct Controller {
     pub config: Config,
@@ -51,11 +51,11 @@ impl Controller {
 
     /// iterate through the config ServiceDefs and create `Task`
     /// instances. A Controller contains "all the tasks", so
-    /// it calculate gossip_port + sidecar_port #s accordingly.
+    /// it calculate gossip_port + http_port #s accordingly.
     pub fn create_children(&mut self) -> Result<()> {
         let mut children = Vec::new();
         let mut next_gossip_port = FIRST_GOSSIP_PORT;
-        let mut next_sidecar_port = FIRST_SIDECAR_PORT;
+        let mut next_http_port = FIRST_HTTP_PORT;
 
         let default_ip = try!(ip());
         let listen_ip = try!(Ipv4Addr::from_str(&default_ip));
@@ -66,7 +66,7 @@ impl Controller {
         for sd in &self.config.service_defs {
             let exec_ctx = self.exec_ctx.clone();
             let exec_params = ExecParams::new(SocketAddrV4::new(listen_ip, next_gossip_port),
-                                              SocketAddrV4::new(listen_ip, next_sidecar_port),
+                                              SocketAddrV4::new(listen_ip, next_http_port),
                                               initial_peer);
 
             // after the first iteration, each child will connect to the previous
@@ -76,9 +76,9 @@ impl Controller {
             children.push(dc);
 
             // this will have to be more intelligent if we
-            // let users define gossip/sidecar ports
+            // let users define gossip/http ports
             next_gossip_port += 1;
-            next_sidecar_port += 1;
+            next_http_port += 1;
         }
         self.children = Some(children);
         Ok(())
@@ -260,7 +260,7 @@ mod tests {
                         "foo",
                         "--listen-peer",
                         format!("{}:9000", test_ip).as_str(),
-                        "--listen-sidecar",
+                        "--listen-http",
                         format!("{}:8000", test_ip).as_str(),
                         "--group",
                         "somegroup",
@@ -279,7 +279,7 @@ mod tests {
                         "--listen-peer",
                         // did we increment the port?
                         format!("{}:9001", test_ip).as_str(),
-                        "--listen-sidecar",
+                        "--listen-http",
                         // did we increment the port?
                         format!("{}:8001", test_ip).as_str(),
                         "--group",
@@ -301,7 +301,7 @@ mod tests {
                         "--listen-peer",
                         // did we increment the port?
                         format!("{}:9002", test_ip).as_str(),
-                        "--listen-sidecar",
+                        "--listen-http",
                         // did we increment the port?
                         format!("{}:8002", test_ip).as_str(),
                         "--group",

--- a/components/director/src/main.rs
+++ b/components/director/src/main.rs
@@ -21,7 +21,7 @@
 //!
 //! - `Controller`
 //! 	- A controller "has" and supervises many Tasks (children)
-//! 	- calculates gossip and sidecar port #'s for all children before starting.
+//! 	- calculates gossip and http port #'s for all children before starting.
 //! 	- runs in a tight loop to see if children are down and start/restarts them.
 //! 	- catches OS signals
 //!
@@ -35,7 +35,7 @@
 //!     - Config values for a `Task` that the `Controller` calculates during
 //!       startup. `ExecParams` currently includes:
 //!          - gossip_listen
-//!          - sidecar_listen
+//!          - http_listen
 //!          - Option<peer_ip_port>
 //!
 //! - `ServiceDef`
@@ -123,39 +123,39 @@
 //! - Each subsequent task that is created uses the previous tasks IP:port as
 //! a value for --peer.
 //! - Gossip port numbers are assigned starting with FIRST_GOSSIP_PORT (9000)
-//! - Sidecar port numbers are assigned starting with FIRST_SIDECAR_PORT (8000)
+//! - HTTP port numbers are assigned starting with FIRST_HTTP_PORT (8000)
 //! - If the hab-sup that's running the director is assigned ports other than
 //! the defaults (9634, 9631), there is a possibility that they could conflict
 //! with the automatically assigned port numbers of the child tasks.
 //! - The diagram below shows a hab-sup process running the director with it's
 //! default IP + port (changeable by the user). Each task that's started is
-//! assigned a new consecutive gossip + sidecar IP.
+//! assigned a new consecutive gossip + http IP.
 //!
 //!                 ┌────────────────────────────┐
 //!                 │     hab-sup (Director)     │
 //!              ┌─▶│       Gossip = 9634        │ * default ports
-//!              │  │       Sidecar = 9631       │
+//!              │  │       HTTP = 9631          │
 //!              │  └────────────────────────────┘
 //!              │
 //!         Peer │
 //!              │  ┌────────────────────────────┐
 //!              │  │Task 0                      │
 //!              └──│FIRST_GOSSIP_PORT (9000)    │◀─┐
-//!                 │FIRST_SIDECAR_PORT (8000)   │  │
+//!                 │FIRST_HTTP_PORT (8000)      │  │
 //!                 └────────────────────────────┘  │
 //!                                                 │
 //!                                                 │ Peer
 //!                 ┌────────────────────────────┐  │
 //!                 │Task 1                      │  │
 //!              ┌─▶│FIRST_GOSSIP_PORT+1 (9001)  │──┘
-//!              │  │FIRST_SIDECAR_PORT+1 (8001) │
+//!              │  │FIRST_HTTP_PORT+1 (8001)    │
 //!              │  └────────────────────────────┘
 //!              │
 //!         Peer │
 //!              │  ┌────────────────────────────┐
 //!              │  │Task 2                      │
 //!              └──│FIRST_GOSSIP_PORT+2 (9002)  │
-//!                 │FIRST_SIDECAR_PORT+2 (8002) │
+//!                 │FIRST_HTTP_PORT+2 (8002)    │
 //!                 └────────────────────────────┘
 //!
 

--- a/components/director/src/task.rs
+++ b/components/director/src/task.rs
@@ -149,7 +149,7 @@ impl Task {
         args.insert(1, self.service_def.ident.to_string());
         args.push("--listen-peer".to_string());
         args.push(self.exec_params.gossip_listen.to_string());
-        args.push("--listen-sidecar".to_string());
+        args.push("--listen-http".to_string());
         args.push(self.exec_params.sidecar_listen.to_string());
         args.push("--group".to_string());
         args.push(self.service_def.service_group.group.clone());
@@ -187,11 +187,11 @@ impl Task {
                       );
 
             let mut child = try!(Command::new(&self.exec_ctx.sup_path)
-                                     .args(&args)
-                                     .stdin(Stdio::null())
-                                     .stdout(Stdio::piped())
-                                     .stderr(Stdio::piped())
-                                     .spawn());
+                .args(&args)
+                .stdin(Stdio::null())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .spawn());
             self.pid = Some(child.id());
 
             outputln!("Started {} [gossip {}, http API: {}, peer: {}, pid: {}]",
@@ -199,16 +199,16 @@ impl Task {
                       &self.exec_params.gossip_listen,
                       &self.exec_params.sidecar_listen,
                       &self.exec_params
-                           .initial_peer
-                           .as_ref()
-                           .map_or("None".to_string(), |v| v.to_string()),
+                          .initial_peer
+                          .as_ref()
+                          .map_or("None".to_string(), |v| v.to_string()),
                       &child.id());
 
             try!(self.transition_to_started());
             let name = self.service_def.to_string();
             try!(thread::Builder::new()
-                     .name(String::from(name.clone()))
-                     .spawn(move || -> Result<()> { child_reader(&mut child, name) }));
+                .name(String::from(name.clone()))
+                .spawn(move || -> Result<()> { child_reader(&mut child, name) }));
             debug!("Spawned child reader");
 
         } else {
@@ -449,7 +449,7 @@ mod tests {
         Task::new(exec_ctx, exec_params, sd)
     }
 
-    /// parse args, inject listen-peer and listen-sidecar, no peer
+    /// parse args, inject listen-peer and listen-http, no peer
     #[test]
     fn cmd_args_parsing_no_peer() {
         let dc = get_test_dc();
@@ -462,7 +462,7 @@ mod tests {
                  "-foo=bar",
                  "--listen-peer",
                  "127.0.0.1:9000",
-                 "--listen-sidecar",
+                 "--listen-http",
                  "127.0.0.1:8000",
                  "--group",
                  "somegroup",
@@ -470,7 +470,7 @@ mod tests {
                  "someorg"]);
     }
 
-    /// parse args, inject listen-peer, listen-sidecar, peer
+    /// parse args, inject listen-peer, listen-http, peer
     #[test]
     fn cmd_args_parsing_peer() {
         let mut dc = get_test_dc();
@@ -486,7 +486,7 @@ mod tests {
                  "-foo=bar",
                  "--listen-peer",
                  "127.0.0.1:9000",
-                 "--listen-sidecar",
+                 "--listen-http",
                  "127.0.0.1:8000",
                  "--group",
                  "somegroup",

--- a/components/sup/src/config.rs
+++ b/components/sup/src/config.rs
@@ -89,8 +89,8 @@ pub struct Config {
     expire_days: Option<u16>,
     gossip_listen_ip: String,
     gossip_listen_port: u16,
-    sidecar_listen_ip: String,
-    sidecar_listen_port: u16,
+    http_listen_ip: String,
+    http_listen_port: u16,
     userkey: Option<String>,
     servicekey: Option<String>,
     infile: Option<String>,
@@ -292,21 +292,21 @@ impl Config {
         self
     }
 
-    pub fn sidecar_listen_ip(&self) -> &str {
-        &self.sidecar_listen_ip
+    pub fn http_listen_ip(&self) -> &str {
+        &self.http_listen_ip
     }
 
-    pub fn set_sidecar_listen_ip(&mut self, ip: String) -> &mut Config {
-        self.sidecar_listen_ip = ip;
+    pub fn set_http_listen_ip(&mut self, ip: String) -> &mut Config {
+        self.http_listen_ip = ip;
         self
     }
 
-    pub fn sidecar_listen_port(&self) -> u16 {
-        self.sidecar_listen_port
+    pub fn http_listen_port(&self) -> u16 {
+        self.http_listen_port
     }
 
-    pub fn set_sidecar_listen_port(&mut self, port: u16) -> &mut Config {
-        self.sidecar_listen_port = port;
+    pub fn set_http_listen_port(&mut self, port: u16) -> &mut Config {
+        self.http_listen_port = port;
         self
     }
 

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -46,8 +46,8 @@ const VERSION: &'static str = include_str!(concat!(env!("OUT_DIR"), "/VERSION"))
 /// CLI defaults
 static DEFAULT_GROUP: &'static str = "default";
 
-static DEFAULT_SIDECAR_LISTEN_IP: &'static str = "0.0.0.0";
-static DEFAULT_SIDECAR_LISTEN_PORT: u16 = 9631;
+static DEFAULT_HTTP_LISTEN_IP: &'static str = "0.0.0.0";
+static DEFAULT_HTTP_LISTEN_PORT: u16 = 9631;
 
 const DEFAULT_GOSSIP_LISTEN_PORT: u16 = 9634;
 
@@ -116,11 +116,11 @@ fn config_from_args(args: &ArgMatches, subcommand: &str, sub_args: &ArgMatches) 
     };
     config.set_bind(bindings);
     config.set_path(sub_args.value_of("path")
-                            .unwrap_or(fs::svc_path(sup::PROGRAM_NAME.as_str())
-                                           .join("data")
-                                           .to_string_lossy()
-                                           .as_ref())
-                            .to_string());
+        .unwrap_or(fs::svc_path(sup::PROGRAM_NAME.as_str())
+            .join("data")
+            .to_string_lossy()
+            .as_ref())
+        .to_string());
 
     let default_gossip_ip = try!(ip());
     let (gossip_ip, gossip_port) = try!(parse_ip_port_with_defaults(
@@ -134,15 +134,15 @@ fn config_from_args(args: &ArgMatches, subcommand: &str, sub_args: &ArgMatches) 
     config.set_gossip_listen_port(gossip_port);
 
     let (sidecar_ip, sidecar_port) = try!(parse_ip_port_with_defaults(
-                                            sub_args.value_of("listen-sidecar"),
-                                            DEFAULT_SIDECAR_LISTEN_IP,
-                                            DEFAULT_SIDECAR_LISTEN_PORT));
+                                            sub_args.value_of("listen-http"),
+                                            DEFAULT_HTTP_LISTEN_IP,
+                                            DEFAULT_HTTP_LISTEN_PORT));
 
-    debug!("Sidecar IP = {}", &sidecar_ip);
-    debug!("Sidecar port = {}", &sidecar_port);
+    debug!("HTTP IP = {}", &sidecar_ip);
+    debug!("HTTP port = {}", &sidecar_port);
 
-    config.set_sidecar_listen_ip(sidecar_ip);
-    config.set_sidecar_listen_port(sidecar_port);
+    config.set_http_listen_ip(sidecar_ip);
+    config.set_http_listen_port(sidecar_port);
 
     let gossip_peers = match sub_args.values_of("peer") {
         Some(gp) => gp.map(|s| s.to_string()).collect(),
@@ -241,75 +241,75 @@ fn main() {
     };
 
     let sub_start = SubCommand::with_name("start")
-                        .about("Start a Habitat-supervised service from a package")
-                        .aliases(&["st", "sta", "star"])
-                        .arg(Arg::with_name("package")
-                                 .index(1)
-                                 .required(true)
-                                 .help("Name of package to start"))
-                        .arg(arg_url())
-                        .arg(arg_group())
-                        .arg(arg_org())
-                        .arg(arg_strategy())
-                        .arg(Arg::with_name("topology")
-                                 .short("t")
-                                 .long("topology")
-                                 .value_name("topology")
-                                 .help("Service topology"))
-                        .arg(Arg::with_name("bind")
-                                 .long("bind")
-                                 .value_name("bind")
-                                 .multiple(true)
-                                 .help("One or more service groups to bind to a configuration"))
-                        .arg(Arg::with_name("ring")
-                                 .short("r")
-                                 .long("ring")
-                                 .value_name("ring")
-                                 .help("Ring key name"))
-                        .arg(Arg::with_name("peer")
-                                 .long("peer")
-                                 .value_name("ip:port")
-                                 .multiple(true)
-                                 .help("The listen address of an initial peer"))
-                        .arg(Arg::with_name("listen-peer")
-                                 .long("listen-peer")
-                                 .value_name("ip:port")
-                                 .help("The listen address [default: ip_with_default_route:9634]"))
-                        .arg(Arg::with_name("listen-sidecar")
-                                 .long("listen-sidecar")
-                                 .value_name("ip:port")
-                                 .help("The sidecar listen address [default: 0.0.0.0:9631]"))
-                        .arg(Arg::with_name("permanent-peer")
-                                 .short("I")
-                                 .long("permanent-peer")
-                                 .help("If this service is a permanent peer"));
+        .about("Start a Habitat-supervised service from a package")
+        .aliases(&["st", "sta", "star"])
+        .arg(Arg::with_name("package")
+            .index(1)
+            .required(true)
+            .help("Name of package to start"))
+        .arg(arg_url())
+        .arg(arg_group())
+        .arg(arg_org())
+        .arg(arg_strategy())
+        .arg(Arg::with_name("topology")
+            .short("t")
+            .long("topology")
+            .value_name("topology")
+            .help("Service topology"))
+        .arg(Arg::with_name("bind")
+            .long("bind")
+            .value_name("bind")
+            .multiple(true)
+            .help("One or more service groups to bind to a configuration"))
+        .arg(Arg::with_name("ring")
+            .short("r")
+            .long("ring")
+            .value_name("ring")
+            .help("Ring key name"))
+        .arg(Arg::with_name("peer")
+            .long("peer")
+            .value_name("ip:port")
+            .multiple(true)
+            .help("The listen address of an initial peer"))
+        .arg(Arg::with_name("listen-peer")
+            .long("listen-peer")
+            .value_name("ip:port")
+            .help("The listen address [default: ip_with_default_route:9634]"))
+        .arg(Arg::with_name("listen-http")
+            .long("listen-http")
+            .value_name("ip:port")
+            .help("The HTTP API listen address [default: 0.0.0.0:9631]"))
+        .arg(Arg::with_name("permanent-peer")
+            .short("I")
+            .long("permanent-peer")
+            .help("If this service is a permanent peer"));
     let sub_bash = SubCommand::with_name("bash")
-                       .about("Start an interactive shell (bash)")
-                       .aliases(&["b", "ba", "bas"]);
+        .about("Start an interactive shell (bash)")
+        .aliases(&["b", "ba", "bas"]);
     let sub_sh = SubCommand::with_name("sh").about("Start an interactive shell (sh)");
     let sub_config = SubCommand::with_name("config")
-                         .about("Print the default.toml for a given package")
-                         .aliases(&["c", "co", "con", "conf", "confi"])
-                         .arg(Arg::with_name("package")
-                                  .index(1)
-                                  .required(true)
-                                  .help("Name of package"));
+        .about("Print the default.toml for a given package")
+        .aliases(&["c", "co", "con", "conf", "confi"])
+        .arg(Arg::with_name("package")
+            .index(1)
+            .required(true)
+            .help("Name of package"));
     let args = App::new(sup::PROGRAM_NAME.as_str())
-                   .version(VERSION)
-                   .setting(AppSettings::VersionlessSubcommands)
-                   .setting(AppSettings::SubcommandRequiredElseHelp)
-                   .arg(Arg::with_name("verbose")
-                            .short("v")
-                            .global(true)
-                            .help("Verbose output; shows line numbers"))
-                   .arg(Arg::with_name("no-color")
-                            .long("no-color")
-                            .global(true)
-                            .help("Turn ANSI color off :("))
-                   .subcommand(sub_start)
-                   .subcommand(sub_bash)
-                   .subcommand(sub_sh)
-                   .subcommand(sub_config);
+        .version(VERSION)
+        .setting(AppSettings::VersionlessSubcommands)
+        .setting(AppSettings::SubcommandRequiredElseHelp)
+        .arg(Arg::with_name("verbose")
+            .short("v")
+            .global(true)
+            .help("Verbose output; shows line numbers"))
+        .arg(Arg::with_name("no-color")
+            .long("no-color")
+            .global(true)
+            .help("Turn ANSI color off :("))
+        .subcommand(sub_start)
+        .subcommand(sub_bash)
+        .subcommand(sub_sh)
+        .subcommand(sub_config);
     let matches = args.get_matches();
 
     debug!("clap matches {:?}", matches);

--- a/components/sup/src/service_config.rs
+++ b/components/sup/src/service_config.rs
@@ -559,8 +559,8 @@ impl Sys {
             hostname: hostname,
             gossip_ip: config.gossip_listen_ip().to_string(),
             gossip_port: config.gossip_listen_port(),
-            sidecar_ip: config.sidecar_listen_ip().to_string(),
-            sidecar_port: config.sidecar_listen_port(),
+            sidecar_ip: config.http_listen_ip().to_string(),
+            sidecar_port: config.http_listen_port(),
         }
     }
 

--- a/components/sup/src/topology/mod.rs
+++ b/components/sup/src/topology/mod.rs
@@ -170,8 +170,8 @@ impl<'a> Worker<'a> {
         let sidecar_el = gossip_server.election_list.clone();
         let sidecar_sup = supervisor.clone();
         let sidecar_listen = try!(SocketAddrV4::from_str(&format!("{}:{}",
-                                                                  &config.sidecar_listen_ip(),
-                                                                  config.sidecar_listen_port())));
+                                                                  &config.http_listen_ip(),
+                                                                  config.http_listen_port())));
         Ok(Worker {
             package: pkg_lock,
             package_name: package_name,


### PR DESCRIPTION
This PR updates the `--listen-sidecar` flag to be `--listen-http`. It
doesn't update all the internals to reflect it (since it's still the
"sidecar" module) - but I tried to change everywhere you reference the
configuration option.

It also is the first time the director has been updated post-handlebars
conversion, so it updated the Cargo.lock.

![gif-keyboard-8884018301051363787](https://cloud.githubusercontent.com/assets/4304/15611281/901cab54-23de-11e6-9252-db6bba499aa8.gif)

Signed-off-by: Adam Jacob adam@chef.io
