### PR TITLE
Some more doc and tutorial updates

### DIFF
--- a/www/source/tutorials/getting-started-configure-plan.html.md
+++ b/www/source/tutorials/getting-started-configure-plan.html.md
@@ -3,21 +3,15 @@ title: Add configuration to your plan
 ---
 
 # Add configuration to your plan
-When you create a plan, you may optionally define which configuration settings can be overridden through the use of a templatized [Handlebars.js](https:handlebars.js.com) version of the native application configuration file. Default settings are then specified in and updated from a corresponding [TOML](https://github.com/toml-lang/toml) file.  
+When you create a plan, you may optionally define which configuration settings can be overridden. Those configuration settings are specific to the native application or service, but you may use a [handlebars](http://handlebarsjs.com/)-based version of the native application configuration file and then update the settings in a corresponding [TOML](https://github.com/toml-lang/toml) file.
 
 In this tutorial, the archive for our Node.js app already has a configuration file called `config.json` that populates a message and specifies a listening port for the http server. We will use that file as a template for the settings that can be overridden at start up or while our service is running.
 
 1. In your `plans/mytutorialapp` directory, create a new directory named `config` and add a new file to it named `config.json` to match the name of the configuration file that `server.js` references.
 
-<<<<<<< 6c575f356f1325ae615a539697c29d5076af4ce8
        [9][default:/src/plans/mytutorialapp/hooks:0]# cd /src/plans/mytutorialapp
        [10][default:/src/plans/mytutorialapp:0]# mkdir -p config
        [11][default:/src/plans/mytutorialapp:0]# touch config/config.json
-=======
-       [9][default:/src/plans/mytutorialapp/hooks:0]$cd /src/plans/mytutorialapp
-       [10][default:/src/plans/mytutorialapp:0]$mkdir -p config
-       [11][default:/src/plans/mytutorialapp:0]$touch config/config.json
->>>>>>> Account for a pre-existing `config` directory.
 
 
 2. Open `config/config.json` in your text editor.
@@ -45,12 +39,7 @@ As we said, a TOML file is associated with your configuration file and specifies
 
 1. If you are not in the `/src/plans/mytutorialapp` directory, change directories to it and create a file named `default.toml`.
 
-<<<<<<< d15dc7e27d44af0f3e8351b58ce9ff8eee9f9e55
        [12][default:/src/plans/mytutorialapp:0]# touch default.toml
-=======
-       [12][default:/src/plans/mytutorialapp:0]$cd /src/plans/mytutorialapp
-       [12][default:/src/plans/mytutorialapp:0]$touch default.toml
->>>>>>> Ensure the proper location on the filesystem.
 
 2. Open `default.toml` in your text editor and add the default values.
 


### PR DESCRIPTION
- Valid software license should be used in the example docs
- Clarify the tutorial description about what happens when you build the package
- Make the tutorial steps less error-prone
- Update some grammar
- Mention handlebars instead of mustache 
