### PR TITLE
[hab] Support multiple args on `pkg install` & `artifact upload`.

### DIFF
--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -42,8 +42,8 @@ pub fn get() -> App<'static, 'static> {
                 (aliases: &["u", "up", "upl", "uplo", "uploa"])
                 (@arg DEPOT_URL: -u --url +takes_value {valid_url}
                  "Use a specific Depot URL")
-                (@arg ARTIFACT: +required {file_exists}
-                 "A path to a Habitat artifact \
+                (@arg ARTIFACT: +required +multiple {file_exists}
+                 "One or more paths to a Habitat artifact \
                  (ex: /home/acme-redis-3.0.7-21120102031201-x86_64-linux.hart)")
             )
             (@subcommand sign =>
@@ -255,9 +255,9 @@ fn sub_package_install() -> App<'static, 'static> {
     clap_app!(@subcommand install =>
         (about: "Installs a Habitat package from a Depot or locally from a Habitat artifact")
         (@arg DEPOT_URL: -u --url +takes_value {valid_url} "Use a specific Depot URL")
-        (@arg PKG_IDENT_OR_ARTIFACT: +required "A Habitat package identifier (ex: acme/redis) \
-         or path to a Habitat artifact \
-         (ex: /home/acme-redis-3.0.7-21120102031201-x86_64-linux.hart)")
+        (@arg PKG_IDENT_OR_ARTIFACT: +required +multiple
+         "One or more Habitat package identifiers (ex: acme/redis) and/or paths to a \
+         Habitat artifact (ex: /home/acme-redis-3.0.7-21120102031201-x86_64-linux.hart)")
     )
 }
 

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -192,9 +192,12 @@ fn sub_artifact_sign(m: &ArgMatches) -> Result<()> {
 fn sub_artifact_upload(m: &ArgMatches) -> Result<()> {
     let env_or_default = henv::var(DEPOT_URL_ENVVAR).unwrap_or(DEFAULT_DEPOT_URL.to_string());
     let url = m.value_of("DEPOT_URL").unwrap_or(&env_or_default);
-    let artifact_path = m.value_of("ARTIFACT").unwrap();
+    let artifact_paths = m.values_of("ARTIFACT").unwrap();
 
-    command::artifact::upload::start(&url, &artifact_path)
+    for artifact_path in artifact_paths {
+        try!(command::artifact::upload::start(&url, &artifact_path));
+    }
+    Ok(())
 }
 
 fn sub_artifact_verify(m: &ArgMatches) -> Result<()> {
@@ -361,14 +364,16 @@ fn sub_pkg_install(m: &ArgMatches) -> Result<()> {
     let fs_root_path = Some(Path::new(&fs_root));
     let env_or_default = henv::var(DEPOT_URL_ENVVAR).unwrap_or(DEFAULT_DEPOT_URL.to_string());
     let url = m.value_of("DEPOT_URL").unwrap_or(&env_or_default);
-    let ident_or_artifact = m.value_of("PKG_IDENT_OR_ARTIFACT").unwrap();
+    let ident_or_artifacts = m.values_of("PKG_IDENT_OR_ARTIFACT").unwrap();
     init();
 
-    try!(common::command::package::install::start(url,
-                                                  ident_or_artifact,
-                                                  Path::new(&fs_root),
-                                                  &cache_artifact_path(fs_root_path),
-                                                  &default_cache_key_path(fs_root_path)));
+    for ident_or_artifact in ident_or_artifacts {
+        try!(common::command::package::install::start(url,
+                                                      ident_or_artifact,
+                                                      Path::new(&fs_root),
+                                                      &cache_artifact_path(fs_root_path),
+                                                      &default_cache_key_path(fs_root_path)));
+    }
     Ok(())
 }
 

--- a/components/studio/build-docker-image.sh
+++ b/components/studio/build-docker-image.sh
@@ -48,9 +48,7 @@ trap 'rm -rf $tmp_root; exit $?' INT TERM EXIT
 
 export FS_ROOT="$tmp_root/rootfs"
 
-for hart_or_ident in "$@"; do
-  hab pkg install $hart_or_ident
-done
+hab pkg install $*
 if ! hab pkg path core/hab-static >/dev/null 2>&1; then
   >&2 echo "   $(basename $0): WARN core/hab-static must be installed, aborting"
   exit 1


### PR DESCRIPTION
This feature is in line with the behavior of other package managers, that is:

> As a user, I want to install multiple packages with one command line invocation like `apt-get install redis-server git-core sudo`.

With this change, multiple arguments are accepted on the `hab pkg install` and `hab artifact upload` subcommands. Remembering that it is (in general) your shell that unrolls file globs before passing the
argments to the process, we can now have highly desirable workflows such as:

```
hab pkg install ./results/*.hart
hab artifact upload ./results/*.hart
```

The `pkg install` subcommand in particular treats each argument as an artifact-or-pkg-ident, meaning you can mix and match local arifacts with published packages, as in:

```
hab pkg install ./results/*.hart core/hab-sup
```

![gif-keyboard-8519441934611072433](https://cloud.githubusercontent.com/assets/261548/15611952/013854cc-23ea-11e6-9daf-9e3d1f30a178.gif)
