### PR TITLE
[studio] Update the `habitat/studio` Docker image creation to not cache.

### DIFF
--- a/components/studio/build-docker-image.sh
+++ b/components/studio/build-docker-image.sh
@@ -75,5 +75,5 @@ RUN env NO_MOUNT=true hab studio new && rm -rf /hab/studios/src/hab/cache
 ENTRYPOINT ["/bin/hab", "studio"]
 EOF
 cd $tmp_root
-docker build -t habitat/studio:$version .
+docker build --no-cache -t habitat/studio:$version .
 docker tag habitat/studio:$version habitat/studio:latest


### PR DESCRIPTION
In this case, we don't want any prior layers--it's all new to us!

![gif-keyboard-10695819741392136439](https://cloud.githubusercontent.com/assets/261548/15682468/0ef2b4a2-271b-11e6-81e1-507cf525d5fb.gif)
