### PR TITLE
Ensure `unzip` declares its bin dir

### DIFF
--- a/plans/unzip/plan.sh
+++ b/plans/unzip/plan.sh
@@ -9,6 +9,7 @@ pkg_shasum=036d96991646d0449ed0aa952e4fbe21b476ce994abc276e49d30e686708bd37
 pkg_dirname=unzip60
 pkg_deps=(core/glibc core/bzip2)
 pkg_build_deps=(core/make core/gcc)
+pkg_bin_dirs=(bin)
 
 do_build() {
   DEFINES='-DACORN_FTYPE_NFS -DWILD_STOP_AT_DIR -DLARGE_FILE_SUPPORT \


### PR DESCRIPTION
Without this change the binaries that ship in the package will not be available on `PATH`.
