### PR TITLE
[travis] Use a gcc/g++-based compiler for node native compilation.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -112,16 +112,13 @@ matrix:
   - language: node_js
     node_js: 4.2.6
     sudo: required
-    compiler: clang-3.6
     env:
-    - CXX=clang-3.6
+    - CXX=g++-4.8
     addons:
       apt:
         sources:
-        - llvm-toolchain-precise-3.6
         - ubuntu-toolchain-r-test
         packages:
-        - clang-3.6
         - g++-4.8
         - wget
     cache:


### PR DESCRIPTION
This change is to work around the LLVM apt site going offline (source: http://lists.llvm.org/pipermail/llvm-dev/2016-May/100303.html) which caused the Travis builds to all fail (source: https://github.com/travis-ci/apt-source-whitelist/issues/279). We'll use the gcc/g++ alternative toolchain from the [docs](https://docs.travis-ci.com/user/languages/javascript-with-nodejs#Node.js-v4-%28or-io.js-v3%29-compiler-requirements).
