### PR TITLE
Use #each to iterate over an array of tables via toml

### DIFF
--- a/plans/redis/config/redis.config
+++ b/plans/redis/config/redis.config
@@ -154,9 +154,9 @@ databases {{cfg.databases}}
 #   like in the following example:
 #
 #   save ""
-{{#with cfg.save}}
+{{#each cfg.save}}
 save {{sec}} {{keys}}
-{{/with}}
+{{~/each}}
 
 # By default Redis will stop accepting writes if RDB snapshots are enabled
 # (at least one save point) and the latest background save failed.
@@ -962,4 +962,3 @@ hz 10
 # in order to commit the file to the disk more incrementally and avoid
 # big latency spikes.
 aof-rewrite-incremental-fsync yes
-


### PR DESCRIPTION
Using `#with` results in incorrect config output.

**Incorrect**

```
#   It is also possible to remove all the previously configured save
#   points by adding a save directive with a single empty string argument
#   like in the following example:
#
#   save ""
```

**Correct**

```
#   It is also possible to remove all the previously configured save
#   points by adding a save directive with a single empty string argument
#   like in the following example:
#
#   save ""
save 900 1
save 300 10
save 60 10000
```

**TOML snippet**

```
[[save]]
sec = 900
keys = 1

[[save]]
sec = 300
keys = 10

[[save]]
sec = 60
keys = 10000
```

Signed-off-by: Kevin J. Dickerson kevin.dickerson@loom.technology
