### PR TITLE
Use #each instead of #with to accurately write toml array of tables

### DIFF
--- a/plans/redis/config/redis.config
+++ b/plans/redis/config/redis.config
@@ -62,9 +62,9 @@ tcp-backlog {{cfg.tcp-backlog}}
 #
 # bind 192.168.1.100 10.0.0.1
 # bind 127.0.0.1
-{{#if cfg.bind}}
+{{~#if cfg.bind}}
 bind {{cfg.bind}}
-{{/if}}
+{{~/if}}
 
 # Specify the path for the Unix socket that will be used to listen for
 # incoming connections. There is no default, so Redis will not listen
@@ -72,12 +72,12 @@ bind {{cfg.bind}}
 #
 # unixsocket /tmp/redis.sock
 # unixsocketperm 700
-{{#if cfg.unixsocket}}
+{{~#if cfg.unixsocket}}
 unixsocket {{cfg.unixsocket}}
-{{/if}}
-{{#if cfg.unixsocketperm}}
+{{~/if}}
+{{~#if cfg.unixsocketperm}}
 unixsocketperm {{cfg.unixsocketperm}}
-{{/if}}
+{{~/if}}
 
 # Close the connection after a client is idle for N seconds (0 to disable)
 timeout {{cfg.timeout}}
@@ -114,19 +114,19 @@ logfile {{{cfg.logfile}}}
 # To enable logging to the system logger, just set 'syslog-enabled' to yes,
 # and optionally update the other syslog parameters to suit your needs.
 
-{{#if cfg.syslog-enabled}}
+{{~#if cfg.syslog-enabled}}
 syslog-enabled {{cfg.syslog-enabled}}
-{{/if}}
+{{~/if}}
 
 # Specify the syslog identity.
-{{#if cfg.syslog-ident}}
+{{~#if cfg.syslog-ident}}
 syslog-ident {{cfg.syslog-ident}}
-{{/if}}
+{{~/if}}
 
 # Specify the syslog facility. Must be USER or between LOCAL0-LOCAL7.
-{{#if cfg.syslog-facility}}
+{{~#if cfg.syslog-facility}}
 syslog-facility {{cfg.syslog-facility}}
-{{/if}}
+{{~/if}}
 
 # Set the number of databases. The default database is DB 0, you can select
 # a different one on a per-connection basis using SELECT <dbid> where
@@ -154,9 +154,9 @@ databases {{cfg.databases}}
 #   like in the following example:
 #
 #   save ""
-{{#with cfg.save}}
+{{~#each cfg.save}}
 save {{sec}} {{keys}}
-{{/with}}
+{{~/each}}
 
 # By default Redis will stop accepting writes if RDB snapshots are enabled
 # (at least one save point) and the latest background save failed.
@@ -218,19 +218,19 @@ dir {{pkg.svc_data_path}}
 #    and resynchronize with them.
 #
 # slaveof <masterip> <masterport>
-{{#if svc.me.follower}}
-{{#with svc.leader}}
+{{~#if svc.me.follower}}
+{{~#each svc.leader}}
 slaveof {{ip}} {{port}}
-{{/with}}
-{{/if}}
+{{~/each}}
+{{~/if}}
 
 # If the master is password protected (using the "requirepass" configuration
 # directive below) it is possible to tell the slave to authenticate before
 # starting the replication synchronization process, otherwise the master will
 # refuse the slave request.
-{{#if cfg.masterauth}}
+{{~#if cfg.masterauth}}
 masterauth {{cfg.masterauth}}
-{{/if}}
+{{~/if}}
 
 # When a slave loses its connection with the master, or when the replication
 # is still in progress, the slave can act in two different ways:
@@ -349,7 +349,9 @@ repl-disable-tcp-nodelay {{cfg.repl-disable-tcp-nodelay}}
 #
 # The backlog is only allocated once there is at least a slave connected.
 #
-{{#if cfg.repl-backlog-size}}repl-backlog-size {{cfg.repl-backlog-size}} {{/if}}
+{{~#if cfg.repl-backlog-size}}
+repl-backlog-size {{cfg.repl-backlog-size}}
+{{~/if}}
 
 # After a master has no longer connected slaves for some time, the backlog
 # will be freed. The following option configures the amount of seconds that
@@ -358,7 +360,9 @@ repl-disable-tcp-nodelay {{cfg.repl-disable-tcp-nodelay}}
 #
 # A value of 0 means to never release the backlog.
 #
-{{#if cfg.repl-backlog-ttl}}repl-backlog-ttl {{cfg.repl-backlog-ttl}} {{/if}}
+{{~#if cfg.repl-backlog-ttl}}
+repl-backlog-ttl {{cfg.repl-backlog-ttl}}
+{{~/if}}
 
 # The slave priority is an integer number published by Redis in the INFO output.
 # It is used by Redis Sentinel in order to select a slave to promote into a
@@ -389,9 +393,13 @@ slave-priority {{cfg.slave-priority}}
 #
 # For example to require at least 3 slaves with a lag <= 10 seconds use:
 #
-{{#if cfg.min-slaves-to-write}} min-slaves-to-write {{cfg.min-slaves-to-write}} {{/if}}
+{{~#if cfg.min-slaves-to-write}}
+min-slaves-to-write {{cfg.min-slaves-to-write}}
+{{~/if}}
 
-{{#if cfg.min-slaves-max-lag}} min-slaves-max-lag {{cfg.min-slaves-max-lag}} {{/if}}
+{{~#if cfg.min-slaves-max-lag}}
+min-slaves-max-lag {{cfg.min-slaves-max-lag}}
+{{~/if}}
 
 #
 # Setting one or the other to 0 disables the feature.
@@ -412,9 +420,9 @@ slave-priority {{cfg.slave-priority}}
 # 150k passwords per second against a good box. This means that you should
 # use a very strong password otherwise it will be very easy to break.
 #
-{{#if cfg.requirepass}}
+{{~#if cfg.requirepass}}
 requirepass {{cfg.requirepass}}
-{{/if}}
+{{~/if}}
 
 # Command renaming.
 #
@@ -962,4 +970,3 @@ hz 10
 # in order to commit the file to the disk more incrementally and avoid
 # big latency spikes.
 aof-rewrite-incremental-fsync yes
-

--- a/plans/redis/default.toml
+++ b/plans/redis/default.toml
@@ -67,4 +67,3 @@ keys = 10
 [[save]]
 sec = 60
 keys = 10000
-

--- a/plans/redis/plan.sh
+++ b/plans/redis/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=redis
 pkg_origin=core
 pkg_version=3.0.7
-pkg_license=('BSD')
+pkg_license=('BSD-3-Clause')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=http://download.redis.io/releases/${pkg_name}-${pkg_version}.tar.gz
 pkg_shasum=b2a791c4ea3bb7268795c45c6321ea5abcc24457178373e6a6e3be6372737f23


### PR DESCRIPTION
- Corrects the output of the `redis` plan configuration template where there are arrays of tables. Pretty sure `#each` was intended rather than `#with`!
- Prefer the "remove whitespace" tilde (e.g. `{{~#if…` vs `{{#if…`).
- Removed whitespace end of TOML file.

**Incorrect**

```
#   It is also possible to remove all the previously configured save
#   points by adding a save directive with a single empty string argument
#   like in the following example:
#
#   save ""

save
```

**Correct**

```
#   It is also possible to remove all the previously configured save
#   points by adding a save directive with a single empty string argument
#   like in the following example:
#
#   save ""
save 900 1
save 300 10
save 60 10000
```

**TOML**

```
…
[[save]]
sec = 900
keys = 1

[[save]]
sec = 300
keys = 10

[[save]]
sec = 60
keys = 10000
```

Signed-off-by: Kevin J. Dickerson kevin.dickerson@loom.technology
