### PR TITLE
Rewrite README to be more developer-focused

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ by having a convention cover it. When we do need to configure things, we set san
 1. Consider adding `eval "$(docker-machine env default)"` to your shell initialization
 1. Checkout the source by running `git clone git@github.com:habitat-sh/habitat.git; cd habitat`
 1. Run `make`
-1. Run `make test`
+1. (Optional) Run `make test` if you want to run the tests. This will take a while.
 
 Everything should come up green. Congratulations - you have a working Habitat development environment.
 


### PR DESCRIPTION
This PR rewrites the README to be more developer-oriented, i.e. for folks who are hacking on the code itself. We put a preamble in it to point _users_ to the regular Habitat website and documentation.

I could use some help with what other links we feel we need to put in that preamble @davidwrede @ryankeairns.

Also, the Travis badge is broken because this isn't a public project yet. It will become a non-404 when we open it up.
