### PR TITLE
Prettier error formatting upon error exit from supervisor

### DIFF
--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -338,7 +338,7 @@ fn main() {
 /// Exit with an error message and the right status code
 #[allow(dead_code)]
 fn exit_with(e: SupError, code: i32) {
-    println!("{:?}", e);
+    println!("{}", e.to_string());
     process::exit(code)
 }
 


### PR DESCRIPTION
Previously supervisor errors looked like this: 
SupError { err: HandlebarsTemplateFileError(TemplateError(UnexpectedClosingBraces(5, 44))), logkey: "ER", file: "src/error.rs", line: 300, column: 8 }

Now they look like this: 
hab-sup(ER)[src/error.rs:288:8]: Cannot find a release of package in any sources: cargo/foo

Signed-off-by: kmacgugan kmacgugan@chef.io
