### PR TITLE
[sup,core] Set optional PATH when shelling out for ip & hostname.

### DIFF
--- a/components/core/src/util/sys.rs
+++ b/components/core/src/util/sys.rs
@@ -8,12 +8,15 @@
 use error::{Error, Result};
 use std::process::Command;
 
-pub fn ip() -> Result<String> {
+pub fn ip(path: Option<&str>) -> Result<String> {
     debug!("Shelling out to determine IP address");
-    let output = try!(Command::new("sh")
-        .arg("-c")
-        .arg("ip route get 8.8.8.8 | awk '{printf \"%s\", $NF; exit}'")
-        .output());
+    let mut cmd = Command::new("sh");
+    cmd.arg("-c").arg("ip route get 8.8.8.8 | awk '{printf \"%s\", $NF; exit}'");
+    if let Some(path) = path {
+        cmd.env("PATH", path);
+        debug!("Setting shell out PATH={}", path);
+    }
+    let output = try!(cmd.output());
     match output.status.success() {
         true => {
             debug!("IP address is {}", String::from_utf8_lossy(&output.stdout));

--- a/components/director/Cargo.lock
+++ b/components/director/Cargo.lock
@@ -122,13 +122,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "habitat_builder_protocol"
+version = "0.6.0"
+dependencies = [
+ "bitflags 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "habitat_core 0.6.0",
+ "pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redis 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "habitat_common"
 version = "0.6.0"
 dependencies = [
  "ansi_term 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "habitat_builder_protocol 0.6.0",
  "habitat_core 0.6.0",
  "habitat_depot_client 0.6.0",
- "habitat_depot_core 0.6.0",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.7.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "pbr 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -160,24 +173,14 @@ name = "habitat_depot_client"
 version = "0.6.0"
 dependencies = [
  "broadcast 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "habitat_builder_protocol 0.6.0",
  "habitat_core 0.6.0",
- "habitat_depot_core 0.6.0",
  "hyper 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "pbr 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "tee 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "habitat_depot_core"
-version = "0.6.0"
-dependencies = [
- "habitat_core 0.6.0",
- "hyper 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "redis 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -190,7 +193,6 @@ dependencies = [
  "habitat_common 0.6.0",
  "habitat_core 0.6.0",
  "habitat_depot_client 0.6.0",
- "habitat_depot_core 0.6.0",
  "handlebars 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "iron 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -565,6 +567,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "tempdir 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "protobuf"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "quick-error"

--- a/components/director/src/controller.rs
+++ b/components/director/src/controller.rs
@@ -57,7 +57,7 @@ impl Controller {
         let mut next_gossip_port = FIRST_GOSSIP_PORT;
         let mut next_http_port = FIRST_HTTP_PORT;
 
-        let default_ip = try!(ip());
+        let default_ip = try!(ip(None));
         let listen_ip = try!(Ipv4Addr::from_str(&default_ip));
 
 
@@ -249,7 +249,7 @@ mod tests {
         controller.create_children().unwrap();
         assert_eq!(3, controller.children.as_ref().unwrap().len());
 
-        let test_ip = ip().unwrap();
+        let test_ip = ip(None).unwrap();
         {
 
             let child = &controller.children.as_ref().unwrap()[0];

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -47,7 +47,6 @@ use hcore::crypto::keys::PairType;
 use hcore::fs::{cache_artifact_path, FS_ROOT_PATH};
 use hcore::service::ServiceGroup;
 use hcore::package::PackageIdent;
-use hcore::util::sys::ip;
 use hcore::url::{DEFAULT_DEPOT_URL, DEPOT_URL_ENVVAR};
 
 use gossip::hab_gossip;
@@ -213,8 +212,7 @@ fn sub_artifact_verify(m: &ArgMatches) -> Result<()> {
 fn sub_config_apply(m: &ArgMatches) -> Result<()> {
     let fs_root = henv::var(FS_ROOT_ENVVAR).unwrap_or(FS_ROOT_PATH.to_string());
     let fs_root_path = Some(Path::new(&fs_root));
-    let default_ip = try!(ip());
-    let peers_str = m.value_of("PEER").unwrap_or(&default_ip);
+    let peers_str = m.value_of("PEER").unwrap_or("127.0.0.1");
     let mut peers: Vec<String> = peers_str.split(",").map(|p| p.into()).collect();
     for p in peers.iter_mut() {
         if p.find(':').is_none() {
@@ -242,8 +240,7 @@ fn sub_config_apply(m: &ArgMatches) -> Result<()> {
 fn sub_file_upload(m: &ArgMatches) -> Result<()> {
     let fs_root = henv::var(FS_ROOT_ENVVAR).unwrap_or(FS_ROOT_PATH.to_string());
     let fs_root_path = Some(Path::new(&fs_root));
-    let default_ip = try!(ip());
-    let peers_str = m.value_of("PEER").unwrap_or(&default_ip);
+    let peers_str = m.value_of("PEER").unwrap_or("127.0.0.1");
     let mut peers: Vec<String> = peers_str.split(",").map(|p| p.into()).collect();
     for p in peers.iter_mut() {
         if p.find(':').is_none() {

--- a/components/sup/src/census.rs
+++ b/components/sup/src/census.rs
@@ -78,8 +78,8 @@ impl CensusEntry {
         CensusEntry {
             id: Uuid::new_v4(),
             member_id: member_id,
-            hostname: util::sys::hostname().unwrap_or(String::from("unknown")),
-            ip: util::sys::ip().unwrap_or(String::from("127.0.0.1")),
+            hostname: util::sys::hostname(None).unwrap_or(String::from("unknown")),
+            ip: util::sys::ip(None).unwrap_or(String::from("127.0.0.1")),
             suitability: 0,
             port: None,
             exposes: None,

--- a/components/sup/src/gossip/server.rs
+++ b/components/sup/src/gossip/server.rs
@@ -82,7 +82,7 @@ impl Server {
                port: Option<String>)
                -> Server {
 
-        let hostname = util::sys::hostname().unwrap_or(String::from("unknown"));
+        let hostname = util::sys::hostname(None).unwrap_or(String::from("unknown"));
         let listen = format!("{}:{}", listen_ip, listen_port);
         let peer_listen = listen.clone();
         let peer_listen2 = peer_listen.clone();

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -35,6 +35,7 @@ use sup::error::{Error, Result, SupError};
 use sup::command::*;
 use sup::topology::Topology;
 use sup::util::parse_ip_port_with_defaults;
+use sup::util::path::busybox_paths;
 use sup::util::sys::ip;
 
 /// Our output key
@@ -122,7 +123,14 @@ fn config_from_args(args: &ArgMatches, subcommand: &str, sub_args: &ArgMatches) 
             .as_ref())
         .to_string());
 
-    let default_gossip_ip = try!(ip());
+    let mut env_path = String::new();
+    for path in try!(busybox_paths()) {
+        if env_path.len() > 0 {
+            env_path.push(':');
+        }
+        env_path.push_str(path.to_string_lossy().as_ref());
+    }
+    let default_gossip_ip = try!(ip(Some(&env_path)));
     let (gossip_ip, gossip_port) = try!(parse_ip_port_with_defaults(
                                         sub_args.value_of("listen-peer"),
                                         &default_gossip_ip,

--- a/components/sup/src/service_config.rs
+++ b/components/sup/src/service_config.rs
@@ -538,7 +538,7 @@ pub struct Sys {
 
 impl Sys {
     fn new(config: &Config) -> Sys {
-        let ip = match util::sys::ip() {
+        let ip = match util::sys::ip(None) {
             Ok(ip) => ip,
             Err(e) => {
                 outputln!("IP Address lookup failed; using fallback of 127.0.0.1 ({})",
@@ -546,7 +546,7 @@ impl Sys {
                 String::from("127.0.0.1")
             }
         };
-        let hostname = match util::sys::hostname() {
+        let hostname = match util::sys::hostname(None) {
             Ok(ip) => ip,
             Err(e) => {
                 outputln!("Hostname lookup failed; using fallback of localhost ({})",


### PR DESCRIPTION
This fixes an issue we are seeing in the Supervisor when the default
bind address is being determined. In minimal environments (such as in a
Studio, in a Docker container, etc) the `ip` and `hostname` commands may
not be found in the `PATH` passed to `hap-sup` on start. The supervisor
does have a runtime dependency on `core/busybox-static` and that
package's `PATH` is added to the process' `PATH` just before the
supervised service is started. The issue here was that the command line
parsing/default logic happens way before the service package is
installed and started.

In an effort to keep things reasonably generic (as these are `util::sys`
functions), the `ip()` and `hostname()` functions optionally take a
`PATH` value as a `&str` which, if present, is set as the spawned
command's `PATH`. We set a `PATH` for the command line parsing call by
using the already-present `busybox_paths()` utility function, and we use
the existing `PATH` of the process for all other calls as they happen
after the `PATH`-setting logic has executed in `command::start`.

For example, running the following in the devshell will ensure that the
Ubuntu `iproute2` package's `/sbin/ip` and `/bin/ip` will _not_ be found
or used:

```
> rm -f /sbin/ip /bin/ip

> hash -r

> command -v ip || echo 'all gone'
all gone

> env RUST_LOG=err,habitat_core::util::sys=debug hab-sup start core/redis
DEBUG:habitat_core::util::sys: Shelling out to determine IP address
DEBUG:habitat_core::util::sys: Setting shell out PATH=/hab/pkgs/core/busybox-static/1.24.2/20160427212720/bin
DEBUG:habitat_core::util::sys: IP address is 172.17.0.2
hab-sup(MN): Starting core/redis
DEBUG:habitat_core::util::sys: Shelling out to determine IP address
DEBUG:habitat_core::util::sys: IP address is 172.17.0.2
hab-sup(GS): Supervisor 172.17.0.2: 5e09deec-3a9b-4ccc-8a1f-d7c2d9f70266
hab-sup(GS): Census redis.default: da58e70a-53a6-4419-a627-ee1d3b6e78d7
hab-sup(GS): Starting inbound gossip listener
hab-sup(GS): Starting outbound gossip distributor
hab-sup(GS): Starting gossip failure detector
hab-sup(CN): Starting census health adjuster
DEBUG:habitat_core::util::sys: Shelling out to determine IP address
DEBUG:habitat_core::util::sys: IP address is 172.17.0.2
hab-sup(SC): Updated redis.config
hab-sup(TP): Restarting because the service config was updated via the census
redis(SV): Starting
-- snip --
```

![gif-keyboard-1592210085816581818](https://cloud.githubusercontent.com/assets/261548/15729857/19cf0ef6-2825-11e6-8763-a649587afbf7.gif)
