### PR TITLE
[studio] Add a `hab` user & group to default Studio type.

### DIFF
--- a/components/studio/libexec/hab-studio-type-default.sh
+++ b/components/studio/libexec/hab-studio-type-default.sh
@@ -9,6 +9,9 @@ studio_run_command="$HAB_ROOT_PATH/bin/hab pkg exec core/hab-backline bash -l"
 
 pkgs="core/hab-backline"
 
+run_user="hab"
+run_group="$run_user"
+
 finish_setup() {
   if [ -n "$HAB_ORIGIN_KEYS" ]; then
     for key in $(echo $HAB_ORIGIN_KEYS | $bb tr ',' ' '); do
@@ -66,6 +69,9 @@ alias egrep='egrep --color=auto'
 alias fgrep='fgrep --color=auto'
 
 PROFILE
+
+  echo "${run_user}:x:42:42:root:/:/bin/sh" >> $HAB_STUDIO_ROOT/etc/passwd
+  echo "${run_group}:x:42:${run_user}" >> $HAB_STUDIO_ROOT/etc/group
 
   studio_env_command="$coreutils_path/bin/env"
 }


### PR DESCRIPTION
This change coupled with #617 should allow a user to enter a default
Studio and immediately run:

```
hab start core/redis
```

without issues.

Neither the Supervisor nor the `hab` CLI is responsible for adding users
and/groups (at least at the moment) meaning that if a service package
uses a non-privileged user to run under, this could result in a failure.
Further work can be done to have the package announce its user
requirements and have the Supervisor at least detect-and-fail is a user
is not present (minimal solution) or attempt to add a user/group (a
delightful solution).
