### PR TITLE
Correct footer typo.

### DIFF
--- a/www/source/layouts/_footer.slim
+++ b/www/source/layouts/_footer.slim
@@ -2,7 +2,7 @@ footer#main-footer
   .row
     .columns.medium-12
       .footer--cta
-        h2.footer--cta-heading See how it works in less than 10 mintues.
+        h2.footer--cta-heading See how it works in less than 10 minutes.
         a.footer--cta-button href="/try" Try the Demo
         p.footer--cta-subtext
           | Take a quick, interactive tour of Habitat features
@@ -39,7 +39,7 @@ footer#main-footer
               li.footer--sitemap--link
                 a href="https://app.habitat.sh/#/sign-in" Log In
               li.footer--sitemap--link
-                a href="https://app.habitat.sh/#pkgs/core" Official Packages
+                a href="https://app.habitat.sh/#/pkgs/core" Official Packages
 
           .columns.medium-3.small-6
             ul.no-bullet
@@ -57,7 +57,7 @@ footer#main-footer
               li.footer--sitemap--link
                 a href="/legal/licensing" Licensing
               li.footer--sitemap--link
-                a href="/legal/terms&amp;conditions" Terms &amp; Conditions
+                a href="/legal/terms-and-conditions" Terms &amp; Conditions
               li.footer--sitemap--link
                 a href="/legal/privacy-policy" Privacy Policy
         .row


### PR DESCRIPTION
I also corrected one incorrect link to the official packages, as well as not using an ampersand in the filename of the yet-to-be-written T&C page.
