### PR TITLE
[hab/mac] Ensure that `-R` is passed to `hab studio` on `pkg build`.

### DIFF
--- a/components/hab/src/command/pkg.rs
+++ b/components/hab/src/command/pkg.rs
@@ -88,7 +88,7 @@ pub mod build {
             args.push(keys.into());
         }
         args.push("build".into());
-        if cfg!(target_os = "linux") && reuse {
+        if cfg!(not(target_os = "linux")) || reuse {
             args.push("-R".into());
         }
         args.push(plan_context.into());


### PR DESCRIPTION
This fixes a logic bug where the reuse flag should be sent to the Studio
Docker container, as the Studio is already pristine. Otherwise, the
Studio is immediately removed and rebuilt on every `hab pkg build`
invocation.

![gif-keyboard-16009331927389997241](https://cloud.githubusercontent.com/assets/261548/15733896/03aa356a-2848-11e6-9a52-32d47ad0ef13.gif)
