### PR TITLE
Update haproxy plan

### DIFF
--- a/plans/haproxy/config/haproxy.conf
+++ b/plans/haproxy/config/haproxy.conf
@@ -1,24 +1,17 @@
-{{#watch}}
-defaults {{service-name}}_{{group-name}}
-{{#tcp-enable}}
-  mode tcp
-  timeout connect {{tcp.connect}}
-  timeout server {{tcp.server}}
-  timeout client {{tcp.client}}
-{{/tcp-enable}}
+global
+    maxconn {{cfg.maxconn}}
 
-frontend ft_{{service-name}}_{{group-name}}
- bind {{bind}}:{{census.leader.port}} name {{service-name}}_{{group-name}}
- default_backend bk_{{service-name}}_{{group-name}}
- option tcplog
- option logasap
- log global
+defaults
+    mode {{cfg.mode}}
+    timeout connect 5000ms
+    timeout client 50000ms
+    timeout server 50000ms
 
-backend bk_{{service-name}}_{{group-name}}
- option httpchk GET /health HTTP/1.1\r\nHost:\ bldr
- http-check expect rstring topology-leader\ =\ true
+frontend http-in
+    bind {{cfg.bind}}
+    default_backend default
 
- {{#census.members}}
- server {{hostname}} {{ip}}:{{port}} check port 9631 inter 1s
- {{/census.members}}
-{{/watch}}
+backend default
+{{~#each cfg.server}}
+    server {{name}} {{host_or_ip}}:{{port}}
+{{~/each}}

--- a/plans/haproxy/default.toml
+++ b/plans/haproxy/default.toml
@@ -1,6 +1,13 @@
-bind = '0.0.0.0'
-tcp-enable = true
-[tcp]
-connect = '4s'
-server = '30s'
-client = '30s'
+maxconn = 32
+mode = "http"
+bind = "*:80"
+
+[[server]]
+name = "first"
+host_or_ip = "172.17.0.3"
+port = "8000"
+
+[[server]]
+name = "second"
+host_or_ip = "172.17.0.4"
+port = "8000"

--- a/plans/haproxy/plan.sh
+++ b/plans/haproxy/plan.sh
@@ -1,30 +1,36 @@
-pkg_name=haproxy
 pkg_origin=core
-pkg_version=1.5.12
-pkg_license=('BSD')
-pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_source=http://www.haproxy.org/download/1.5/src/${pkg_name}-${pkg_version}.tar.gz
-pkg_shasum=6648dd7d6b958d83dd7101eab5792178212a66c884bec0ebcd8abc39df83bb78
+pkg_name=haproxy
+pkg_version=1.6.5
+pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
+pkg_license=('GPL-2.0', 'LGPL-2.1')
+pkg_source=http://www.haproxy.org/download/1.6/src/haproxy-1.6.5.tar.gz
+pkg_shasum=c4b3fb938874abbbbd52782087117cc2590263af78fdce86d64e4a11acfe85de
+pkg_service_run='bin/haproxy -f config/haproxy.conf -db'
+pkg_expose=(8080)
+pkg_deps=(core/zlib core/pcre core/openssl)
+pkg_build_deps=(
+  core/coreutils
+  core/gcc
+  core/pcre
+  core/make
+  core/openssl
+  core/zlib
+)
+
 pkg_bin_dirs=(bin)
-pkg_build_deps=(core/make core/gcc)
-pkg_deps=(core/glibc core/pcre core/openssl core/zlib)
-pkg_service_run="bin/haproxy -f $pkg_svc_config_path/haproxy.conf"
-pkg_docker_build="auto"
-pkg_expose=(80 443)
 
 do_build() {
   make USE_PCRE=1 \
-    USE_PCRE_JIT=1 \
-    CPU=x86_64 \
-    TARGET=linux2628 \
-    USE_OPENSSL=1 \
-    USE_ZLIB=1 \
-    ADDINC="$CFLAGS" \
-    ADDLIB="$LDFLAGS"
+       USE_PCRE_JIT=1 \
+       CPU=native \
+       TARGET=linux2628 \
+       USE_OPENSSL=1 \
+       USE_ZLIB=1 \
+       ADDINC="$CFLAGS" \
+       ADDLIB="$LDFLAGS"
 }
 
 do_install() {
   mkdir -p $pkg_prefix/bin
   cp haproxy $pkg_prefix/bin
 }
-


### PR DESCRIPTION
This PR updates the haproxy plan.
- Uses handlebars
- Updates license information
- Builds for native CPU
- Specifies two default servers in default configuration
