### PR TITLE
[hab/mac] Disable the `hab sup` subcommand on non-Linux binaries.

### DIFF
--- a/components/hab/src/command/sup.rs
+++ b/components/hab/src/command/sup.rs
@@ -6,34 +6,65 @@
 // open source license such as the Apache 2.0 License.
 
 use std::ffi::OsString;
-use std::path::PathBuf;
-use std::str::FromStr;
 
-use hcore::crypto::{init, default_cache_key_path};
-use hcore::env as henv;
-use hcore::fs::find_command;
-use hcore::package::PackageIdent;
-
-use error::{Error, Result};
-use exec;
-
-const SUP_CMD: &'static str = "hab-sup";
-const SUP_CMD_ENVVAR: &'static str = "HAB_SUP_BINARY";
-const SUP_PACKAGE_IDENT: &'static str = "core/hab-sup";
+use error::Result;
 
 pub fn start(args: Vec<OsString>) -> Result<()> {
-    let command = match henv::var(SUP_CMD_ENVVAR) {
-        Ok(command) => PathBuf::from(command),
-        Err(_) => {
-            init();
-            let ident = try!(PackageIdent::from_str(SUP_PACKAGE_IDENT));
-            try!(exec::command_from_pkg(SUP_CMD, &ident, &default_cache_key_path(None), 0))
-        }
-    };
+    inner::start(args)
+}
 
-    if let Some(cmd) = find_command(command.to_string_lossy().as_ref()) {
-        exec::exec_command(cmd, args)
-    } else {
-        Err(Error::ExecCommandNotFound(command.to_string_lossy().into_owned()))
+
+#[cfg(target_os = "linux")]
+mod inner {
+    use std::ffi::OsString;
+    use std::path::PathBuf;
+    use std::str::FromStr;
+
+    use hcore::crypto::{init, default_cache_key_path};
+    use hcore::env as henv;
+    use hcore::fs::find_command;
+    use hcore::package::PackageIdent;
+
+    use error::{Error, Result};
+    use exec;
+
+    const SUP_CMD: &'static str = "hab-sup";
+    const SUP_CMD_ENVVAR: &'static str = "HAB_SUP_BINARY";
+    const SUP_PACKAGE_IDENT: &'static str = "core/hab-sup";
+
+    pub fn start(args: Vec<OsString>) -> Result<()> {
+        let command = match henv::var(SUP_CMD_ENVVAR) {
+            Ok(command) => PathBuf::from(command),
+            Err(_) => {
+                init();
+                let ident = try!(PackageIdent::from_str(SUP_PACKAGE_IDENT));
+                try!(exec::command_from_pkg(SUP_CMD, &ident, &default_cache_key_path(None), 0))
+            }
+        };
+
+        if let Some(cmd) = find_command(command.to_string_lossy().as_ref()) {
+            exec::exec_command(cmd, args)
+        } else {
+            Err(Error::ExecCommandNotFound(command.to_string_lossy().into_owned()))
+        }
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+mod inner {
+    use std::env;
+    use std::ffi::OsString;
+
+    use ansi_term::Colour::Yellow;
+
+    use error::{Error, Result};
+
+    pub fn start(_args: Vec<OsString>) -> Result<()> {
+        let subcmd = env::args().nth(1).unwrap_or("<unknown>".to_string());
+        let msg = format!("∅ Launching a native Supervisor on this operating system is not yet \
+                           supported. Try running this command again on a 64-bit Linux \
+                           operating system.\n");
+        println!("{}", Yellow.bold().paint(msg));
+        Err(Error::SubcommandNotSupported(subcmd))
     }
 }

--- a/components/hab/src/error.rs
+++ b/components/hab/src/error.rs
@@ -31,6 +31,7 @@ pub enum Error {
     IO(io::Error),
     PackageArchiveMalformed(String),
     PathPrefixError(path::StripPrefixError),
+    SubcommandNotSupported(String),
 }
 
 impl fmt::Display for Error {
@@ -56,6 +57,9 @@ impl fmt::Display for Error {
                         e)
             }
             Error::PathPrefixError(ref err) => format!("{}", err),
+            Error::SubcommandNotSupported(ref e) => {
+                format!("Subcommand `{}' not supported on this operating system", e)
+            }
         };
         write!(f, "{}", msg)
     }
@@ -79,6 +83,7 @@ impl error::Error for Error {
                 "Package archive was unreadable or had unexpected contents"
             }
             Error::PathPrefixError(ref err) => err.description(),
+            Error::SubcommandNotSupported(_) => "Subcommand not supported on this operating system",
         }
     }
 }

--- a/components/hab/src/exec.rs
+++ b/components/hab/src/exec.rs
@@ -22,6 +22,7 @@ use hcore::url::default_depot_url;
 
 use error::{Error, Result};
 
+#[allow(dead_code)] // Currently only used on Linux platforms
 const MAX_RETRIES: u8 = 4;
 
 /// Makes an `execv(3)` system call to become a new program.
@@ -67,6 +68,7 @@ pub fn exec_command(command: PathBuf, args: Vec<OsString>) -> Result<()> {
 /// * If the package is installed but the command cannot be found in the package
 /// * If an error occurs when loading the local package from disk
 /// * If the maximum number of installation retries has been exceeded
+#[allow(dead_code)] // Currently only used on Linux platforms
 pub fn command_from_pkg(command: &str,
                         ident: &PackageIdent,
                         cache_key_path: &Path,


### PR DESCRIPTION
This change preserves the `hab sup` subcommand for all platforms, but disables its behavior if invokes from a non-Linux system. The hope is that if and when support is added to a new system target, we can relax this disabling logic.
