### PR TITLE
Add additional configurable options for builder-api server

### DIFF
--- a/components/builder-api/habitat/default.toml
+++ b/components/builder-api/habitat/default.toml
@@ -3,6 +3,10 @@ router_addrs = [
   "127.0.0.1:5562"
 ]
 
+[github]
+client_id = ""
+client_secret = ""
+
 [depot]
 path = "/hab/svc/hab-depot/data"
 datastore_addr = "127.0.0.1:6397"

--- a/components/builder-api/src/config.rs
+++ b/components/builder-api/src/config.rs
@@ -15,6 +15,16 @@ use toml;
 
 use error::{Error, Result};
 
+/// URL to GitHub API endpoint
+const GITHUB_URL: &'static str = "https://api.github.com";
+// Default Client ID for providing a default value in development environments only. This is
+// associated to Jamie Winsor's GitHub account and is configured to re-direct and point to a local
+// builder-api.
+const DEV_GITHUB_CLIENT_ID: &'static str = "e98d2a94787be9af9c00";
+// Default Client Secret for development purposes only. See the `DEV_GITHUB_CLIENT_ID` for
+// additional comments.
+const DEV_GITHUB_CLIENT_SECRET: &'static str = "e5ff94188e3cf01d42f3e2bcbbe4faabe11c71ba";
+
 #[derive(Debug)]
 pub struct Config {
     /// Public listening net address for HTTP requests
@@ -23,6 +33,12 @@ pub struct Config {
     pub depot: depot::Config,
     /// List of net addresses for routing servers to connect to
     pub routers: Vec<net::SocketAddrV4>,
+    /// URL to GitHub API
+    pub github_url: String,
+    /// Client identifier used for GitHub API requests
+    pub github_client_id: String,
+    /// Client secret used for GitHub API requests
+    pub github_client_secret: String,
 }
 
 impl Config {
@@ -39,6 +55,9 @@ impl Default for Config {
             http_addr: net::SocketAddrV4::new(net::Ipv4Addr::new(0, 0, 0, 0), 9636),
             routers: vec![net::SocketAddrV4::new(net::Ipv4Addr::new(127, 0, 0, 1), 5562)],
             depot: depot::Config::default(),
+            github_url: GITHUB_URL.to_string(),
+            github_client_id: DEV_GITHUB_CLIENT_ID.to_string(),
+            github_client_secret: DEV_GITHUB_CLIENT_SECRET.to_string(),
         }
     }
 }
@@ -52,6 +71,13 @@ impl ConfigFile for Config {
         try!(toml.parse_into("cfg.router_addrs", &mut cfg.routers));
         try!(toml.parse_into("cfg.depot.path", &mut cfg.depot.path));
         try!(toml.parse_into("cfg.depot.datastore_addr", &mut cfg.depot.datastore_addr));
+        try!(toml.parse_into("cfg.github.url", &mut cfg.github_url));
+        if !try!(toml.parse_into("cfg.github.client_id", &mut cfg.github_client_id)) {
+            return Err(Error::RequiredConfigField("github.client_id"));
+        }
+        if !try!(toml.parse_into("cfg.github.client_secret", &mut cfg.github_client_secret)) {
+            return Err(Error::RequiredConfigField("github.client_secret"));
+        }
         Ok(cfg)
     }
 }

--- a/components/builder-api/src/error.rs
+++ b/components/builder-api/src/error.rs
@@ -30,6 +30,7 @@ pub enum Error {
     JsonDecode(json::DecoderError),
     MissingScope(String),
     Protobuf(protobuf::ProtobufError),
+    RequiredConfigField(&'static str),
     Zmq(zmq::Error),
 }
 
@@ -48,6 +49,9 @@ impl fmt::Display for Error {
             Error::JsonDecode(ref e) => format!("JSON decoding error, {}", e),
             Error::MissingScope(ref e) => format!("Missing GitHub permission: {}", e),
             Error::Protobuf(ref e) => format!("{}", e),
+            Error::RequiredConfigField(ref e) => {
+                format!("Missing required field in configuration, {}", e)
+            }
             Error::Zmq(ref e) => format!("{}", e),
         };
         write!(f, "{}", msg)
@@ -67,6 +71,7 @@ impl error::Error for Error {
             Error::JsonDecode(ref err) => err.description(),
             Error::MissingScope(_) => "Missing GitHub authorization scope.",
             Error::Protobuf(ref err) => err.description(),
+            Error::RequiredConfigField(_) => "Missing required field in configuration.",
             Error::Zmq(ref err) => err.description(),
         }
     }

--- a/components/builder-api/src/http/handlers.rs
+++ b/components/builder-api/src/http/handlers.rs
@@ -24,7 +24,7 @@ use rustc_serialize::json::{self, ToJson};
 use zmq;
 
 use error::Error;
-use oauth::github;
+use oauth::github::GitHubClient;
 
 pub fn authenticate(req: &mut Request,
                     ctx: &Arc<Mutex<zmq::Context>>)
@@ -59,15 +59,18 @@ pub fn authenticate(req: &mut Request,
     }
 }
 
-pub fn session_create(req: &mut Request, ctx: &Arc<Mutex<zmq::Context>>) -> IronResult<Response> {
+pub fn session_create(req: &mut Request,
+                      github: &GitHubClient,
+                      ctx: &Arc<Mutex<zmq::Context>>)
+                      -> IronResult<Response> {
     let params = req.extensions.get::<Router>().unwrap();
     let code = match params.find("code") {
         Some(code) => code,
         _ => return Ok(Response::with(status::BadRequest)),
     };
-    match github::authenticate(code) {
+    match github.authenticate(code) {
         Ok(token) => {
-            match github::user(&token) {
+            match github.user(&token) {
                 Ok(user) => {
                     let mut conn = Broker::connect(&ctx).unwrap();
                     let mut request = SessionCreate::new();

--- a/components/builder-api/src/http/mod.rs
+++ b/components/builder-api/src/http/mod.rs
@@ -22,16 +22,18 @@ use zmq;
 use config::Config;
 use error::Result;
 use self::handlers::*;
+use oauth::github::GitHubClient;
 
 /// Create a new `iron::Chain` containing a Router and it's required middleware
-pub fn router(context: Arc<Mutex<zmq::Context>>) -> Result<Chain> {
+pub fn router(config: Arc<Config>, context: Arc<Mutex<zmq::Context>>) -> Result<Chain> {
+    let github = GitHubClient::new(&*config);
     let ctx1 = context.clone();
     let ctx2 = context.clone();
     let ctx3 = context.clone();
     let ctx4 = context.clone();
     let ctx5 = context.clone();
     let router = router!(
-        get "/authenticate/:code" => move |r: &mut Request| session_create(r, &ctx1),
+        get "/authenticate/:code" => move |r: &mut Request| session_create(r, &github, &ctx1),
 
         post "/origins" => move |r: &mut Request| origin_create(r, &ctx2),
         get "/origins/:origin" => move |r: &mut Request| origin_show(r, &ctx3),
@@ -57,14 +59,15 @@ pub fn router(context: Arc<Mutex<zmq::Context>>) -> Result<Chain> {
 /// * Listener crashed during startup
 pub fn run(config: Arc<Config>, context: Arc<Mutex<zmq::Context>>) -> Result<JoinHandle<()>> {
     let (tx, rx) = mpsc::sync_channel(1);
+    let addr = config.http_addr.clone();
     let depot = try!(depot::server::router(config.depot.clone()));
-    let chain = try!(router(context));
+    let chain = try!(router(config, context));
     let mut mount = Mount::new();
     mount.mount("/v1", chain).mount("/v1/depot", depot);
     let handle = thread::Builder::new()
         .name("http-srv".to_string())
         .spawn(move || {
-            let _server = Iron::new(mount).http(config.http_addr).unwrap();
+            let _server = Iron::new(mount).http(addr).unwrap();
             tx.send(()).unwrap();
         })
         .unwrap();

--- a/components/builder-api/src/oauth/github.rs
+++ b/components/builder-api/src/oauth/github.rs
@@ -13,14 +13,66 @@ use hyper::mime::{Mime, TopLevel, SubLevel};
 use protocol::sessionsrv;
 use rustc_serialize::json;
 
+use config::Config;
 use error::{Error, Result};
 
-// JW TODO: do not hardcode these. Make available through configuration file.
-const GH_CLIENT_ID: &'static str = "e98d2a94787be9af9c00";
-const GH_CLIENT_SECRET: &'static str = "e5ff94188e3cf01d42f3e2bcbbe4faabe11c71ba";
 const USER_AGENT: &'static str = "Habitat-Builder";
 
-static GH_URL: &'static str = "https://api.github.com";
+pub struct GitHubClient {
+    pub url: String,
+    pub client_id: String,
+    pub client_secret: String,
+}
+
+impl GitHubClient {
+    pub fn new(config: &Config) -> Self {
+        GitHubClient {
+            url: config.github_url.clone(),
+            client_id: config.github_client_id.clone(),
+            client_secret: config.github_client_secret.clone(),
+        }
+    }
+
+    pub fn authenticate(&self, code: &str) -> Result<String> {
+        let url =
+            Url::parse(&format!("https://github.\
+                                 com/login/oauth/access_token?client_id={}&client_secret={}&code={}",
+                                self.client_id,
+                                self.client_secret,
+                                code))
+                .unwrap();
+        let mut rep = try!(http_post(url));
+        if rep.status.is_success() {
+            let mut encoded = String::new();
+            try!(rep.read_to_string(&mut encoded));
+            match json::decode(&encoded) {
+                Ok(msg @ AuthOk { .. }) => {
+                    let scope = "user:email".to_string();
+                    if msg.has_scope(&scope) {
+                        Ok(msg.access_token)
+                    } else {
+                        Err(Error::MissingScope(scope))
+                    }
+                }
+                Err(_) => {
+                    let err: AuthErr = try!(json::decode(&encoded));
+                    Err(Error::from(err))
+                }
+            }
+        } else {
+            Err(Error::HTTP(rep.status))
+        }
+    }
+
+    pub fn user(&self, token: &str) -> Result<User> {
+        let url = Url::parse(&format!("{}/user", self.url)).unwrap();
+        let mut rep = try!(http_get(url, token));
+        let mut body = String::new();
+        try!(rep.read_to_string(&mut body));
+        let user: User = json::decode(&body).unwrap();
+        Ok(user)
+    }
+}
 
 #[derive(Debug, RustcEncodable, RustcDecodable)]
 pub struct User {
@@ -105,46 +157,6 @@ impl fmt::Display for AuthErr {
 pub enum AuthResp {
     AuthOk,
     AuthErr,
-}
-
-pub fn authenticate(code: &str) -> Result<String> {
-    let url =
-        Url::parse(&format!("https://github.\
-                             com/login/oauth/access_token?client_id={}&client_secret={}&code={}",
-                            GH_CLIENT_ID,
-                            GH_CLIENT_SECRET,
-                            code))
-            .unwrap();
-    let mut rep = try!(http_post(url));
-    if rep.status.is_success() {
-        let mut encoded = String::new();
-        try!(rep.read_to_string(&mut encoded));
-        match json::decode(&encoded) {
-            Ok(msg @ AuthOk { .. }) => {
-                let scope = "user:email".to_string();
-                if msg.has_scope(&scope) {
-                    Ok(msg.access_token)
-                } else {
-                    Err(Error::MissingScope(scope))
-                }
-            }
-            Err(_) => {
-                let err: AuthErr = try!(json::decode(&encoded));
-                Err(Error::from(err))
-            }
-        }
-    } else {
-        Err(Error::HTTP(rep.status))
-    }
-}
-
-pub fn user(token: &str) -> Result<User> {
-    let url = Url::parse(&format!("{}/user", GH_URL)).unwrap();
-    let mut rep = try!(http_get(url, token));
-    let mut body = String::new();
-    try!(rep.read_to_string(&mut body));
-    let user: User = json::decode(&body).unwrap();
-    Ok(user)
 }
 
 fn http_get(url: Url, token: &str) -> Result<hyper::client::response::Response> {


### PR DESCRIPTION
- Added `github.client_id` as a configurable field to builder-api server
- Added `github.client_secret` as a configurable field to builder-api server
- Added `github.url` as a configurable field to builder-api server
- All OAuth calls will now use the values of these fields

![gif-keyboard-3494451331950561715](https://cloud.githubusercontent.com/assets/54036/15765740/dabcdf54-28ec-11e6-860c-9d4cd2fc9064.gif)

Signed-off-by: Jamie Winsor jamie@vialstudios.com
