### PR TITLE
Copyedits to the Try Habitat experience.

### DIFF
--- a/www/source/try/5.html.slim
+++ b/www/source/try/5.html.slim
@@ -23,7 +23,7 @@ p
     the TCP backlog issue.
 
 code
-  | hab config apply redis.default 1 /tmp/gossip.toml --peer 172.17.0.4
+  | hab config apply redis.default 1 /tmp/config.toml --peer 172.17.0.4
 
 .window-buttons
   ul

--- a/www/source/try/responses/hab-sup-config-service.txt
+++ b/www/source/try/responses/hab-sup-config-service.txt
@@ -23,22 +23,25 @@ tcp-backlog = 511
 # bind = [] - listen on all interfaces
 bind = []
 
-unixsocket = false
-unixsocketperm = false
+# Listen on a unix socket
+# unixsocket = "/tmp/redis.sock"
+# unixsocketperm = 700
+
 timeout = 0
 tcp-keepalive = 0
 loglevel = "notice"
 logfile = "\"\""
-syslog-enabled = ["no"]
-syslog-ident = ["redis"]
-syslog-facility = ["local0"]
+# Uncomment to enable syslog
+# syslog-enabled = "yes"
+# syslog-ident = "redis"
+# syslog-facility = "local0"
 databases = 16
 stop-writes-on-bgsave-error = "yes"
 rbcompression = "yes"
 rbchecksum = "yes"
 dbfilename = "dump.rdb"
-slaveof = []
-masterauth = []
+
+# masterauth = ""
 slave-serve-stale-data = "yes"
 slave-read-only = "yes"
 repl-diskless-sync = "no"
@@ -46,12 +49,12 @@ repl-diskless-synx-delay = 5
 repl-ping-slave-period = 10
 repl-timeout = 60
 repl-disable-tcp-nodelay = "no"
-repl-backlog-size = ["1mb"]
-repl-backlog-ttl = ["3600"]
+repl-backlog-size = "1mb"
+repl-backlog-ttl = "3600"
 slave-priority = "100"
 min-slaves-to-write = false
 min-slaves-max-lag = false
-requirepass = []
+requirepass = ""
 
 [[save]]
 sec = 900
@@ -64,6 +67,7 @@ keys = 10
 [[save]]
 sec = 60
 keys = 10000
+
 
 [1;32mThere we go! Among other responsibilities, the supervisor can assist us with config settings.
 [1;33mScroll to the top of the output and note that the tcp-backlog is set to 511.


### PR DESCRIPTION
- The default.toml looks a little different now that we're using Handlebars to drive it, so update it. In particular, Habitat knows how to handle nulls, whereas before it didn't.
- The user doesn't need to write a file called "gossip.toml"; it can be anything they want, so let's call it "config.toml" instead, to hide the inside baseball of gossip.

Signed-off-by: Julian C. Dunn jdunn@chef.io
