### PR TITLE
Use a single API URL

### DIFF
--- a/components/builder-web/app/BuilderApiClient.ts
+++ b/components/builder-web/app/BuilderApiClient.ts
@@ -9,7 +9,7 @@ import "whatwg-fetch";
 import config from "./config";
 
 export class BuilderApiClient {
-    private urlPrefix: string = config["builder_url"];
+    private urlPrefix: string = config["habitat_api_url"];
 
     constructor(private token: string) { }
 

--- a/components/builder-web/app/actions/gitHub.ts
+++ b/components/builder-web/app/actions/gitHub.ts
@@ -14,7 +14,7 @@ import {DANGER} from "./notifications";
 
 const parseLinkHeader = require("parse-link-header");
 const uuid = require("node-uuid").v4;
-const gitHubTokenAuthUrl = config["github_token_auth_url"];
+const gitHubTokenAuthUrl = `${config["habitat_api_url"]}/authenticate`;
 
 export const LOAD_SESSION_STATE = "LOAD_SESSION_STATE";
 export const POPULATE_GITHUB_ORGS = "POPULATE_GITHUB_ORGS";

--- a/components/builder-web/app/builderApi.ts
+++ b/components/builder-web/app/builderApi.ts
@@ -8,7 +8,7 @@
 import "whatwg-fetch";
 import config from "./config";
 
-const urlPrefix = config["builder_url"] || "";
+const urlPrefix = config["habitat_api_url"] || "";
 
 export function createProject(project) {
     return new Promise((resolve, reject) => {

--- a/components/builder-web/app/depotApi.ts
+++ b/components/builder-web/app/depotApi.ts
@@ -9,11 +9,11 @@ import "whatwg-fetch";
 import config from "./config";
 import {packageString} from "./util";
 
-const urlPrefix = config["depot_url"] || "";
+const urlPrefix = config["habitat_api_url"] || "";
 
 export function get(ident) {
     return new Promise((resolve, reject) => {
-        fetch(`${urlPrefix}/pkgs/${packageString(ident)}`).then(response => {
+        fetch(`${urlPrefix}/depot/pkgs/${packageString(ident)}`).then(response => {
             // Fail the promise if an error happens.
             //
             // If we're hitting the fake api, the 4xx response will show up

--- a/components/builder-web/habitat.conf.sample.js
+++ b/components/builder-web/habitat.conf.sample.js
@@ -1,10 +1,8 @@
 habitatConfig({
-    // The URL for the builder service
-    builder_url: "",
+    // The URL for the Habitat API service (including the API version)
+    habitat_api_url: "",
     // The URL for community information
     community_url: "https://www.habitat.sh/community",
-    // The URL for the depot service
-    depot_url: "",
     // The URL for documentation
     docs_url: "https://www.habitat.sh/docs",
     // The environment in which we're running. If "production", enable
@@ -13,8 +11,6 @@ habitatConfig({
     // The URL for Habitat's source code
     // GitHub Client ID for OAuth2
     github_client_id: "",
-    // The URL used to get a GitHub token
-    github_token_auth_url: "",
     // The URL for the Habitat source code
     source_code_url: "https://github.com/habitat-sh/habitat",
     // The URL for tutorials

--- a/components/builder-web/habitat/config/habitat.conf.js
+++ b/components/builder-web/habitat/config/habitat.conf.js
@@ -1,11 +1,9 @@
 habitatConfig({
-    builder_url: "{{cfg.builder_url}}",
+    habitat_api_url: "{{cfg.habitat_api_url}}",
     community_url: "{{cfg.community_url}}",
-    depot_url: "{{cfg.depot_url}}",
     docs_url: "{{cfg.docs_url}}",
     environment: "{{cfg.environment}}",
     github_client_id: "{{cfg.github_client_id}}",
-    github_token_auth_url: "{{cfg.github_token_auth_url}}",
     source_code_url: "{{cfg.source_code_url}}",
     tutorials_url: "{{cfg.tutorials_url}}",
 });

--- a/components/builder-web/habitat/default.toml
+++ b/components/builder-web/habitat/default.toml
@@ -1,11 +1,8 @@
-# The URL for the builder service
-builder_url = ""
+# The URL for the Habitat API service (including the API version)
+habitat_api_url = ""
 
 # The URL for community information
 community_url = "https://www.habitat.sh/community"
-
-# The URL for the depot service
-depot_url = ""
 
 # The URL for documentation
 docs_url = "https://www.habitat.sh/docs"
@@ -17,9 +14,6 @@ environment = "production"
 # The URL for Habitat's source code
 # GitHub Client ID for OAuth2
 github_client_id = ""
-
-# The URL used to get a GitHub token
-github_token_auth_url = ""
 
 # The URL for the Habitat source code
 source_code_url = "https://github.com/habitat-sh/habitat"

--- a/terraform/config/habitat-builder-web.toml
+++ b/terraform/config/habitat-builder-web.toml
@@ -1,4 +1,2 @@
-builder_url = "https://habitat-api-1022630102.us-west-2.elb.amazonaws.com/v1"
-depot_url = "https://habitat-api-1022630102.us-west-2.elb.amazonaws.com/v1/depot"
+habitat_api_url = "https://habitat-api-1022630102.us-west-2.elb.amazonaws.com/v1"
 github_client_id = "e98d2a94787be9af9c00"
-github_token_auth_url = "https://habitat-api-1022630102.us-west-2.elb.amazonaws.com/v1/authenticate"


### PR DESCRIPTION
Replace `depot_url`, `builder_url`, and `github_auth_token_url` with
`habitat_api_url`.

Signed-off-by: Nathan L Smith smith@chef.io
