### PR TITLE
Experimental: Use Docker even on Linux to start studios

### DIFF
--- a/components/hab/src/command/studio.rs
+++ b/components/hab/src/command/studio.rs
@@ -13,44 +13,6 @@ pub fn start(args: Vec<OsString>) -> Result<()> {
     inner::start(args)
 }
 
-#[cfg(target_os = "linux")]
-mod inner {
-    use std::ffi::OsString;
-    use std::path::PathBuf;
-    use std::str::FromStr;
-
-    use hcore::crypto::{init, default_cache_key_path};
-    use hcore::env as henv;
-    use hcore::fs::find_command;
-    use hcore::package::PackageIdent;
-
-    use error::{Error, Result};
-    use exec;
-
-    const STUDIO_CMD: &'static str = "hab-studio";
-    const STUDIO_CMD_ENVVAR: &'static str = "HAB_STUDIO_BINARY";
-    const STUDIO_PACKAGE_IDENT: &'static str = "core/hab-studio";
-
-    pub fn start(args: Vec<OsString>) -> Result<()> {
-        let command = match henv::var(STUDIO_CMD_ENVVAR) {
-            Ok(command) => PathBuf::from(command),
-            Err(_) => {
-                init();
-                let ident = try!(PackageIdent::from_str(STUDIO_PACKAGE_IDENT));
-                try!(exec::command_from_pkg(STUDIO_CMD, &ident, &default_cache_key_path(None), 0))
-            }
-        };
-
-        if let Some(cmd) = find_command(command.to_string_lossy().as_ref()) {
-            try!(exec::exec_command(cmd, args));
-        } else {
-            return Err(Error::ExecCommandNotFound(command.to_string_lossy().into_owned()));
-        }
-        Ok(())
-    }
-}
-
-#[cfg(not(target_os = "linux"))]
 mod inner {
     use std::env;
     use std::ffi::OsString;


### PR DESCRIPTION
This is a PR for discussion i.e.so that I understand the full implications of doing this.

Right now the static `hab` binary performs differently on OS X versus Linux. This causes problems for people who use Linux as a workstation, because they basically need to be `root` in order to use the static Hab binary just to `hab studio enter`, as it's going to try and make `/hab` on the user's workstation, install `core/hab-studio` from the depot in there, and then start it.

What I propose in this PR is that the static `hab` binary use Docker under the hood as well for parity with Mac OS X. What we need to discuss are the implications for things like our build system.
