### PR TITLE
nav and formatting fixes to build and run packages

### DIFF
--- a/www/data/docs_sidebar.json
+++ b/www/data/docs_sidebar.json
@@ -87,8 +87,8 @@
           ]
         },
         {
-          "title": "Run services",
-          "link": "/docs/run-services/"
+          "title": "Run packages",
+          "link": "/docs/run-packages-overview/"
         }
       ]
     },

--- a/www/source/docs/run-packages-overview.html.md
+++ b/www/source/docs/run-packages-overview.html.md
@@ -20,15 +20,15 @@ You can create a Docker container for any package by performing the following st
 1. Create an interactive studio in any directory with the `hab studio enter` command.
 2. Install the Docker exporter:
 
-      hab pkg install core/hab-pkg-dockerize
+       hab pkg install core/hab-pkg-dockerize
 
 3. Install the Habitat package you want to create a Docker container from, for example:
 
-      hab pkg install yourorigin/yourpackage
+       hab pkg install yourorigin/yourpackage
 
 4. Run the Docker exporter on the package. (`hab pkg exec` sets the correct paths needed to find all the exporter's dependencies.)
 
-      hab pkg exec core/hab-pkg-dockerize hab-pkg-dockerize yourorigin/yourpackage
+       hab pkg exec core/hab-pkg-dockerize hab-pkg-dockerize yourorigin/yourpackage
 
 5. You can now exit the studio. The new Docker image exists on your computer and can be examined with `docker images` or run with `docker run`.
 
@@ -39,19 +39,19 @@ You can create an Application Container Image (ACI) for any package by performin
 1. Create an interactive studio in any directory with the `hab studio enter` command.
 2. Install the ACI exporter:
 
-      hab pkg install core/hab-pkg-aci
+       hab pkg install core/hab-pkg-aci
 
 3. Install the Habitat package you want to create a Docker container from, for example:
 
-      hab pkg install yourorigin/yourpackage
+       hab pkg install yourorigin/yourpackage
 
 4. Run the ACI exporter on the package.
 
-      hab pkg exec core/hab-pkg-aci hab-pkg-aci yourorigin/yourpackage
+       hab pkg exec core/hab-pkg-aci hab-pkg-aci yourorigin/yourpackage
 
 5. Note that this will create unsigned ACI images. If you wish to sign your ACI with default options, pass `SIGN=true`:
 
-      SIGN=true hab pkg exec core/hab-pkg-aci hab-pkg-aci yourorigin/yourpackage
+       SIGN=true hab pkg exec core/hab-pkg-aci hab-pkg-aci yourorigin/yourpackage
 
 6. The `.aci` can now be moved to any runtime capable of running ACIs (e.g. rkt on CoreOS) for execution.
 


### PR DESCRIPTION
- Fix incorrect sidebar link to current version of running packages
- Fix missing space; without the space the CLI formatting is wrong.
