### PR TITLE
Add search/auto-complete for packages

### DIFF
--- a/components/builder-api/Cargo.lock
+++ b/components/builder-api/Cargo.lock
@@ -182,7 +182,6 @@ name = "habitat_depot"
 version = "0.6.0"
 dependencies = [
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "bodyparser 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat_builder_dbcache 0.6.0",


### PR DESCRIPTION
Add `/v1/depot/pkgs/search/{:query}` endpoint which behaves like listing packages but returns packages which auto-complete based on the given query parameter. Use the Content-Range, Next-Range, and Range headers to get additional results if the result set is larger than 50.

All four parts of a package identifiers will be included in the search so you can attempt to auto-complete any of the following:
- Origin
- Name
- Version
- Release

![gif-keyboard-6806528374463512454](https://cloud.githubusercontent.com/assets/54036/15796487/3f70c188-29b3-11e6-9dc2-a44885af5224.gif)

Signed-off-by: Jamie Winsor jamie@vialstudios.com
