### PR TITLE
[http-client] Fix issue where ssl cache needs to be relative to FS_ROOT.

### DIFF
--- a/components/http-client/src/lib.rs
+++ b/components/http-client/src/lib.rs
@@ -105,7 +105,7 @@ mod ssl {
         } else {
             let cached_certs = cache_ssl_path(fs_root_path).join("cert.pem");
             if !cached_certs.exists() {
-                try!(fs::create_dir_all(cache_ssl_path(None)));
+                try!(fs::create_dir_all(cache_ssl_path(fs_root_path)));
                 debug!("Creating cached cacert.pem at: {}", cached_certs.display());
                 let mut file = try!(File::create(&cached_certs));
                 try!(file.write_all(CACERT_PEM.as_bytes()));


### PR DESCRIPTION
The issue show up when `hab-studio` uses `hab` to install packages. The Studio code set an `$FS_ROOT` to prefix the Studio instance root, and so the ssl cache directory would be something like `/hab/studios/src/hab/cache/ssl`.

![gif-keyboard-10483376611533089928](https://cloud.githubusercontent.com/assets/261548/15801160/876bd5b8-2a49-11e6-9adf-bc1121ea9891.gif)
