### PR TITLE
[hab] Add lightweight analytics to `hab` CLI which is defaulted to opt-out.

### DIFF
--- a/components/builder-api/Cargo.lock
+++ b/components/builder-api/Cargo.lock
@@ -105,6 +105,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "error"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -164,8 +174,10 @@ dependencies = [
 name = "habitat_core"
 version = "0.6.0"
 dependencies = [
+ "errno 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libarchive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsodium-sys 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.71 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/builder-dbcache/Cargo.lock
+++ b/components/builder-dbcache/Cargo.lock
@@ -41,6 +41,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "habitat_builder_protocol"
 version = "0.6.0"
 dependencies = [
@@ -57,8 +67,10 @@ dependencies = [
 name = "habitat_core"
 version = "0.6.0"
 dependencies = [
+ "errno 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libarchive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsodium-sys 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.71 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/builder-jobsrv/Cargo.lock
+++ b/components/builder-jobsrv/Cargo.lock
@@ -71,6 +71,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -107,8 +117,10 @@ dependencies = [
 name = "habitat_core"
 version = "0.6.0"
 dependencies = [
+ "errno 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libarchive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsodium-sys 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.71 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/builder-protocol/Cargo.lock
+++ b/components/builder-protocol/Cargo.lock
@@ -30,11 +30,23 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "errno"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "habitat_core"
 version = "0.6.0"
 dependencies = [
+ "errno 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libarchive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsodium-sys 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.71 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/builder-sessionsrv/Cargo.lock
+++ b/components/builder-sessionsrv/Cargo.lock
@@ -83,6 +83,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -133,8 +143,10 @@ dependencies = [
 name = "habitat_core"
 version = "0.6.0"
 dependencies = [
+ "errno 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libarchive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsodium-sys 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.71 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/builder-vault/Cargo.lock
+++ b/components/builder-vault/Cargo.lock
@@ -70,6 +70,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -106,8 +116,10 @@ dependencies = [
 name = "habitat_core"
 version = "0.6.0"
 dependencies = [
+ "errno 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libarchive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsodium-sys 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.71 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/builder-worker/Cargo.lock
+++ b/components/builder-worker/Cargo.lock
@@ -64,6 +64,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -85,8 +95,10 @@ dependencies = [
 name = "habitat_core"
 version = "0.6.0"
 dependencies = [
+ "errno 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libarchive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsodium-sys 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.71 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/common/Cargo.lock
+++ b/components/common/Cargo.lock
@@ -56,6 +56,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "gcc"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -85,8 +95,10 @@ dependencies = [
 name = "habitat_core"
 version = "0.6.0"
 dependencies = [
+ "errno 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libarchive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsodium-sys 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.69 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/core/Cargo.lock
+++ b/components/core/Cargo.lock
@@ -2,9 +2,11 @@
 name = "habitat_core"
 version = "0.6.0"
 dependencies = [
+ "errno 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libarchive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsodium-sys 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.71 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -32,6 +34,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "errno"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/components/core/Cargo.toml
+++ b/components/core/Cargo.toml
@@ -4,8 +4,10 @@ version = "0.6.0"
 authors = ["Adam Jacob <adam@chef.io>", "Jamie Winsor <reset@chef.io>", "Fletcher Nichol <fnichol@chef.io>", "Joshua Timberman <joshua@chef.io>", "Dave Parfitt <dparfitt@chef.io>"]
 
 [dependencies]
+errno = "*"
 lazy_static = "*"
 libarchive = "*"
+libc = "*"
 log = "*"
 regex = "*"
 rustc-serialize = "*"

--- a/components/core/src/error.rs
+++ b/components/core/src/error.rs
@@ -70,6 +70,8 @@ pub enum Error {
     RegexParse(regex::Error),
     /// When an error occurs converting a `String` from a UTF-8 byte vector.
     StringFromUtf8Error(string::FromUtf8Error),
+    /// Occurs when a `uname` libc call returns an error.
+    UnameFailed(String),
     /// When an error occurs attempting to interpret a sequence of u8 as a string.
     Utf8Error(str::Utf8Error),
     /// When an error occurs attempting to parse a string into a URL.
@@ -135,6 +137,7 @@ impl fmt::Display for Error {
             Error::PermissionFailed => format!("Failed to set permissions"),
             Error::RegexParse(ref e) => format!("{}", e),
             Error::StringFromUtf8Error(ref e) => format!("{}", e),
+            Error::UnameFailed(ref e) => format!("{}", e),
             Error::Utf8Error(ref e) => format!("{}", e),
             Error::UrlParseError(ref e) => format!("{}", e),
         };
@@ -180,6 +183,7 @@ impl error::Error for Error {
             Error::PermissionFailed => "Failed to set permissions",
             Error::RegexParse(_) => "Failed to parse a regular expression",
             Error::StringFromUtf8Error(_) => "Failed to convert a string from a Vec<u8> as UTF-8",
+            Error::UnameFailed(_) => "uname failed",
             Error::Utf8Error(_) => "Failed to interpret a sequence of bytes as a string",
             Error::UrlParseError(ref err) => err.description(),
         }

--- a/components/core/src/lib.rs
+++ b/components/core/src/lib.rs
@@ -5,10 +5,12 @@
 // the Software until such time that the Software is made available under an
 // open source license such as the Apache 2.0 License.
 
+extern crate errno;
 #[cfg(test)]
 extern crate hyper;
 #[macro_use]
 extern crate lazy_static;
+extern crate libc;
 extern crate libarchive;
 #[macro_use]
 extern crate log;

--- a/components/core/src/util/sys.rs
+++ b/components/core/src/util/sys.rs
@@ -5,8 +5,14 @@
 // the Software until such time that the Software is made available under an
 // open source license such as the Apache 2.0 License.
 
-use error::{Error, Result};
+use std::ffi::CStr;
+use std::mem;
 use std::process::Command;
+
+use errno::errno;
+use libc;
+
+use error::{Error, Result};
 
 pub fn ip(path: Option<&str>) -> Result<String> {
     debug!("Shelling out to determine IP address");
@@ -30,4 +36,34 @@ pub fn ip(path: Option<&str>) -> Result<String> {
             Err(Error::NoOutboundAddr)
         }
     }
+}
+
+#[derive(Debug)]
+pub struct Uname {
+    pub sys_name: String,
+    pub node_name: String,
+    pub release: String,
+    pub version: String,
+    pub machine: String,
+}
+
+pub fn uname() -> Result<Uname> {
+    unsafe { uname_libc() }
+}
+
+unsafe fn uname_libc() -> Result<Uname> {
+    let mut utsname: libc::utsname = mem::uninitialized();
+    let rv = libc::uname(&mut utsname);
+    if rv < 0 {
+        let errno = errno();
+        let code = errno.0 as i32;
+        return Err(Error::UnameFailed(format!("Error {} when calling uname: {}", code, errno)));
+    }
+    Ok(Uname {
+        sys_name: CStr::from_ptr(utsname.sysname.as_ptr()).to_string_lossy().into_owned(),
+        node_name: CStr::from_ptr(utsname.nodename.as_ptr()).to_string_lossy().into_owned(),
+        release: CStr::from_ptr(utsname.release.as_ptr()).to_string_lossy().into_owned(),
+        version: CStr::from_ptr(utsname.version.as_ptr()).to_string_lossy().into_owned(),
+        machine: CStr::from_ptr(utsname.machine.as_ptr()).to_string_lossy().into_owned(),
+    })
 }

--- a/components/depot-client/Cargo.lock
+++ b/components/depot-client/Cargo.lock
@@ -49,6 +49,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "gcc"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -79,8 +89,10 @@ dependencies = [
 name = "habitat_core"
 version = "0.6.0"
 dependencies = [
+ "errno 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libarchive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsodium-sys 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.71 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/depot/Cargo.lock
+++ b/components/depot/Cargo.lock
@@ -26,6 +26,7 @@ dependencies = [
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicase 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "urlencoded 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -114,6 +115,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "error"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -168,8 +179,10 @@ dependencies = [
 name = "habitat_core"
 version = "0.6.0"
 dependencies = [
+ "errno 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libarchive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsodium-sys 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.71 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/director/Cargo.lock
+++ b/components/director/Cargo.lock
@@ -100,6 +100,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "error"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -155,8 +165,10 @@ dependencies = [
 name = "habitat_core"
 version = "0.6.0"
 dependencies = [
+ "errno 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libarchive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsodium-sys 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.69 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/hab/Cargo.lock
+++ b/components/hab/Cargo.lock
@@ -8,6 +8,7 @@ dependencies = [
  "habitat_common 0.6.0",
  "habitat_core 0.6.0",
  "habitat_depot_client 0.6.0",
+ "habitat_http_client 0.6.0",
  "hyper 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -86,6 +87,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "gcc"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -132,8 +143,10 @@ dependencies = [
 name = "habitat_core"
 version = "0.6.0"
 dependencies = [
+ "errno 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libarchive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsodium-sys 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.69 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/hab/Cargo.toml
+++ b/components/hab/Cargo.toml
@@ -17,7 +17,6 @@ rustc-serialize = "*"
 # Temporary depdency for gossip/rumor injection code duplication.
 temp_utp = "*"
 url = "*"
-# Temporary depdency for gossip/rumor injection code duplication.
 uuid = "0.1"
 
 [dependencies.clap]
@@ -32,6 +31,9 @@ path = "../common"
 
 [dependencies.habitat_depot_client]
 path = "../depot-client"
+
+[dependencies.habitat_http_client]
+path = "../http-client"
 
 [features]
 functional = []

--- a/components/hab/src/analytics.rs
+++ b/components/hab/src/analytics.rs
@@ -1,0 +1,590 @@
+// Copyright:: Copyright (c) 2015-2016 The Habitat Maintainers
+//
+// The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.
+// and the party accessing this file ("Licensee") apply to Licensee's use of
+// the Software until such time that the Software is made available under an
+// open source license such as the Apache 2.0 License.
+
+//! hab command line interface analytics module.
+//!
+//! The `hab` command-line tool will optionally send anonymous usage data to Habitat's Google
+//! Analytics account. This is a strictly opt-in activity and no tracking will occur unless you
+//! respond affirmatively to the question during `hab setup`. If you do not use `hab setup`, no
+//! data will ever be sent.
+//!
+//! We collect this data to help improve Habitat's user experience: for example, to know what tasks
+//! users are performing, and which ones they are having trouble with (e.g. mistyping command line
+//! arguments).
+//!
+//! By _anonymous_ we mean that all identifying information about you is removed before we send the
+//! data. This includes the removal of any information about what packages you are building, or
+//! what origins you are using. For example, if you were building the package `yourname/yourapp`,
+//! and you typed `hab pkg build -k yourkey yourname/yourapp`, the fact that you were performing
+//! the `pkg build` operation would be transmitted. Neither the name of the specific package you
+//! are building, nor the fact that you are using the `yourkey` key to sign that package would be
+//! transmitted.
+//!
+//! Please do not hesitate to [contact us](mailto:support@habitat.sh) if you have questions or
+//! concerns about the use of Google Analytics within the Habitat product.
+//!
+//! Note that this module is highly documented, even inside functions with the intent of guiding a
+//! user through the implementation who may not necessarily be familiar with Rust code. Given the
+//! "must-not-impact-the-user" nature of this code, it tends to be much more explicit than regular,
+//! idomatic Rust code. But at least you can see a lot of `match` expressions in action :)
+//!
+//! # Subcommand Invocations
+//!
+//! The following is a complete list of all pre-selected commands which are reported:
+//!
+//! * `apply`
+//! * `artifact upload`
+//! * `config apply`
+//! * `file upload`
+//! * `origin key generate`
+//! * `pkg build`
+//! * `ring key generate`
+//! * `service key generate`
+//! * `studio build`
+//! * `studio enter`
+//! * `user key generate`
+//!
+//! # Subcommands Which Attempt Submission of Events
+//!
+//! The only time events will be sent to the Google Analytics API is when certain subcommands are
+//! invoked which require network access. These subcommands are:
+//!
+//! * `apply`
+//! * `artifact upload`
+//! * `config apply`
+//! * `file upload`
+//! * `install`
+//! * `origin key upload`
+//! * `pkg install`
+//!
+//! For all other subcommands, even those which report events, the event payload is saved to a
+//! cached file under the analytics cache directory (`/hab/cache/analytics` for a root user and
+//! `$HOME/.hab/cache/analytics` for a non-root user).
+//!
+//! # Event Data Breakdown
+//!
+//! For each event that is reported, a set of information is bundled into the payload. Here is a
+//! breakdown of each key/value entry:
+//!
+//! ## `v=1`
+//!
+//! The [Protocol
+//! Version](https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#v)
+//! which is currently only ever the integer value of `1`.
+//!
+//! ## `tid=UA-XXXXXXX-X`
+//!
+//! The [Tracking
+//! ID](https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#tid)
+//! which represents this product and is currently hard coded as `"UA-6369228-7"`.
+//!
+//! ## `cid=f673faaf-6ba1-4e60-b819-e2d51e4ad6f1`
+//!
+//! The [Client
+//! ID](https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#cid)
+//! which is a randomly generated [UUID
+//! v4](https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_.28random.29) and
+//! written into the system or user's analytics cache (`/hab/cache/analytics/CLIENT_ID` when the
+//! program is invoked as the root user and `$HOME/.hab/analytics/CLIENT_ID` when invoked by a
+//! non-root user). This is not intended to track individual users or systems, but rather show
+//! patterns of usage in aggregate. For example: "In general, users who generally start with `hab
+//! studio enter` tend to migrate to using `hab pkg build` over time".
+//!
+//! ## `t=event`
+//!
+//! The [Hit
+//! Type](https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#t).
+//! This value is hard coded as `"event"` as it is a required Google Analtyics field for all Hit
+//! Events.
+//!
+//! ## `aip=1`
+//!
+//! Enables [Anonymize
+//! IP](https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#aip).
+//! This entry ensures that the sender's IP address will not be captured and will be anonymized.
+//! The value is hard coded as the integer `1`.
+//!
+//! ## `an=hab`
+//!
+//! The [Application
+//! Name](https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#an)
+//! of the program sending the event. For this program the value is currently hard coded as
+//! `"hab"`.
+//!
+//! ## `av=0.6.0%2F20160604180457`
+//!
+//! The [Application
+//! Version](https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#av)
+//! of the program sending the event. This version string will be the same value as reported when
+//! asking for the program's version on the command line. Note that this field may contain
+//! characters that must be percent encoded.
+//!
+//! ## `ds=cli--hab`
+//!
+//! The [Data
+//! Source](https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#ds)
+//! which represents the program which generated the event data. For this program the value is
+//! currently hardcoded as `"cli--hab"`.
+//!
+//! ## `ec=invoke`
+//!
+//! The [Event
+//! Category](https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#ec)
+//! which corresponds to the type of event being sent. Currently there are only 2 possible values:
+//! `"invoke"` for subcommand invocations and `"clierror"` for CLI errors.
+//!
+//! ## `ea=hab--pkg--build`
+//!
+//! The [Event
+//! Action](https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#ea)
+//! which breaks down differently depending on the type of event. For subcommand invocations (where
+//! `"ec=invoke"`), the value is the subcommand invoked with no further arguments, options, or
+//! flags. Any spaces are replaced with a doubledash, as in: `"hab--studio--enter"` or
+//! `"hab--artifact--upload"`. For CLI errors (where `"ec=clierror"`), the value is the type of CLI
+//! error followed by a double dash and terminated with the subcommand which was invoked (also
+//! containing no further arguments, options, or flags). As before any spaces in the subcommand are
+//! replaced with a double dash, as in: `"InvalidSubcommand--hab-whoops"`.
+//!
+//! # User-Agent HTTP Header
+//!
+//! A user agent string is also included in the HTTP/POST to the Google Analytics API it is of the
+//! form:
+//!
+//! ```text
+//! <PRODUCT>/<VERSION> (<TARGET>; <KERNEL_RELEASE>)
+//! ```
+//!
+//! where:
+//!
+//! * `<PRODUCT>`: is the provided product name. For this program the value is currently hard coded
+//!   as `"hab"`.
+//! * `<VERSION>`: is the provided version string which may also include a release number. This is
+//!   the same version obtained when running the help or version subcommands.
+//! * `<TARGET>`: is the machine architecture and the kernel separated by a dash in lower case.
+//! * `<KERNEL_RELEASE>`: is the kernel release string from `uname`.
+//!
+//! For example:
+//!
+//! ```text
+//! hab/0.6.0/20160606153031 (x86_64-darwin; 14.5.0)
+//! ```
+
+use std::env;
+use std::fs::{self, File};
+use std::io::{Read, Write};
+use std::path::Path;
+use std::time::{UNIX_EPOCH, SystemTime};
+
+use clap;
+use hcore;
+use http_client;
+use url::percent_encoding::{utf8_percent_encode, PATH_SEGMENT_ENCODE_SET};
+use uuid::Uuid;
+
+/// The Google Analytics [Tracking
+/// ID](https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#tid)
+/// which represents this product.
+const GOOGLE_ANALYTICS_ID: &'static str = "UA-6369228-7";
+/// The Google Analytics [URL
+/// endpoint](https://developers.google.com/analytics/devguides/collection/protocol/v1/reference#endpoint).
+const GOOGLE_ANALYTICS_URL: &'static str = "https://www.google-analytics.com/collect";
+/// The product name for this application.
+const PRODUCT: &'static str = "hab";
+/// A representation of the source of the analytics data.
+const DATA_SOURCE: &'static str = "cli--hab";
+/// The filename containing a randomly generated [Client
+/// ID](https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#cid).
+const CLIENT_ID_METAFILE: &'static str = "CLIENT_ID";
+/// The filename which represents a program which has opted in to analytics
+const OPTED_IN_METAFILE: &'static str = "OPTED_IN";
+/// The filename which represents a program which has explicitly opted out to analytics. Note that
+/// the default is opted out.
+const OPTED_OUT_METAFILE: &'static str = "OPTED_OUT";
+
+/// Different kinds of analytic events.
+enum Event {
+    /// Occurs when a CLI error occurs, such as when a required argument is missing, an invalid
+    /// subcommand is invoked, etc.
+    CliError,
+    /// Occurs when a pre-selected subcommand will be invoked, representing a user's intention to
+    /// use this subcommand.
+    Subcommand,
+}
+
+/// Selects a known pre-selected of subcommands and reports on the event of their invocation with
+/// no environment, arguments, or paramters being captured.
+///
+/// The set of pre-selected subcommands help the project and the maintainers better confirm
+/// workflow hypotheses, have feel for adoption of subsystems, and generally have a sense about
+/// what is important to users in aggregate.
+pub fn instrument_subcommand() {
+    // If analytics are not enabled, return early, we're done.
+    if !analytics_enabled() {
+        return;
+    }
+
+    // Get the first 3 program arguments after the program name argument in order to determine the
+    // subcommand which will be invoked. If there aren't that many program arguments, a default of
+    // an emppty string slice is used.
+    let mut args = env::args();
+    let arg1 = args.nth(1).unwrap_or_default();
+    let arg2 = args.next().unwrap_or_default();
+    let arg3 = args.next().unwrap_or_default();
+
+    // Use a pattern match against a tuple of the first 3 program arguments, or as many as are
+    // relevant.
+    match (arg1.as_str(), arg2.as_str(), arg3.as_str()) {
+        // Match against any pre-selected subcommands that are 1 level deep and ignore any
+        // potential arguments, options, or flags to that subcommand--these extras will not be
+        // reported.
+        ("apply", _, _) => record_event(Event::Subcommand, &format!("{}--{}", PRODUCT, arg1)),
+        // Match against any pre-selected subcommands that are 2 levels deep and ignore any
+        // potential arguments, options, or flags to that subcommand--these extras will not be
+        // reported.
+        ("artifact", "upload", _) |
+        ("config", "apply", _) |
+        ("file", "upload", _) |
+        ("pkg", "build", _) |
+        ("studio", "build", _) |
+        ("studio", "enter", _) => {
+            record_event(Event::Subcommand,
+                         &format!("{}--{}--{}", PRODUCT, arg1, arg2))
+        }
+        // Match against any pre-selected subcommands that are 3 levels deep. Since there are no
+        // more postional matches left, we ignore all further arguments, options, or flags to that
+        // subcommand.
+        ("origin", "key", "generate") |
+        ("ring", "key", "generate") |
+        ("service", "key", "generate") |
+        ("user", "key", "generate") => {
+            record_event(Event::Subcommand,
+                         &format!("{}--{}--{}--{}", PRODUCT, arg1, arg2, arg3))
+        }
+        // If the subcommand to be invoked doesn't match any of the above arms, then it has not
+        // been pre-selected and we can return early, all done.
+        _ => (),
+    };
+
+    // If the subcommand to be invoked makes network calls, then attempt to send any pending events
+    if should_send() {
+        send_pending();
+    }
+}
+
+/// Determines the type of CLI error and reports on the occurance of an error given the subcommand
+/// which was invoked with no environment, arguments, or parameters being captured.
+///
+/// The generic error types tied to the subcommand attempted help the project and the maintainers
+/// to better understand common stumbling blocks, under-documented subcommands, and confirm user
+/// experience hypotheses.
+pub fn instrument_clap_error(err: &clap::Error) {
+    // If analytics are not enabled, return early, we're done.
+    if !analytics_enabled() {
+        return;
+    }
+
+    // Get the first 3 program arguments after the program name in order to determine the
+    // subcommand which was invoked leading to the CLI error. If there aren't that many program
+    // arguments, a default of an empty string slice is used.
+    let mut args = env::args();
+    let arg1 = args.nth(1).unwrap_or_default();
+    let arg2 = args.next().unwrap_or_default();
+    let arg3 = args.next().unwrap_or_default();
+
+    // Use a pattern match against the first program argument.
+    match arg1.as_str() {
+        // Match against subcommands which are 2 levels deep.
+        "artifact" | "config" | "file" | "pkg" => {
+            record_event(Event::CliError,
+                         &format!("{:?}--{}--{}--{}", err.kind, PRODUCT, arg1, arg2))
+        }
+        // Match against subcommands which are 3 levels deep.
+        "origin" | "ring" | "service" | "user" => {
+            record_event(Event::CliError,
+                         &format!("{:?}--{}--{}--{}--{}", err.kind, PRODUCT, arg1, arg2, arg3))
+        }
+        // Match against subcommands which are 1 levels deep or anything else remaining. This match
+        // arm appears last because it "slurps" up all remaining cases with `_`.
+        "apply" | "install" | _ => {
+            record_event(Event::CliError,
+                         &format!("{:?}--{}--{}", err.kind, PRODUCT, arg1))
+        }
+    }
+}
+
+/// Returns true if analytics are enabled and false otherwise.
+fn analytics_enabled() -> bool {
+    // Get the path to the analytics cache directory.
+    let cache_dir = hcore::fs::cache_analytics_path(None);
+
+    if cache_dir.join(OPTED_OUT_METAFILE).exists() {
+        // If an explicit opt-out file exists, the return false
+        false
+    } else if cache_dir.join(OPTED_IN_METAFILE).exists() {
+        // If an opt-in file exists, return true
+        true
+    } else {
+        // In all other cases, return false which enforces the default opt-out behavior
+        false
+    }
+}
+
+/// Creates a representation of the analytic event and sends it to the Google Analytics API.
+fn record_event(kind: Event, action: &str) {
+    // Determine a suitable category value given the type of event we are capturing. We are using
+    // pattern matching over a type which means that the Rust compiler will guarentee that no enum
+    // types are missing in the future.
+    let category = match kind {
+        Event::CliError => "clierror",
+        Event::Subcommand => "invoke",
+    };
+    // Craft the Google Analytics payload body which resembles a URL query string, even requiring
+    // all values to be percent encoded. For more details about the payload data format see:
+    // https://developers.google.com/analytics/devguides/collection/protocol/v1/reference#payload
+    //
+    // For more details about the chosen variables, values, and their meanings, see the above
+    // module documentation.
+    let event = format!("v=1&tid={}&cid={}&t=event&aip=1&an={}&av={}&ds={}&ec={}&ea={}",
+                        utf8_percent_encode(GOOGLE_ANALYTICS_ID, PATH_SEGMENT_ENCODE_SET),
+                        utf8_percent_encode(&client_id(), PATH_SEGMENT_ENCODE_SET),
+                        utf8_percent_encode(PRODUCT, PATH_SEGMENT_ENCODE_SET),
+                        utf8_percent_encode(super::VERSION, PATH_SEGMENT_ENCODE_SET),
+                        utf8_percent_encode(DATA_SOURCE, PATH_SEGMENT_ENCODE_SET),
+                        utf8_percent_encode(category, PATH_SEGMENT_ENCODE_SET),
+                        utf8_percent_encode(action, PATH_SEGMENT_ENCODE_SET));
+    debug!("Event: {}", event);
+    // Save the event to disk--there might not be enough time to hit the network
+    save_event(&event);
+}
+
+/// Determines whether or not to send an event now or save it for later.
+///
+/// If the subcommand to be invoked requires network access then this is a reasonable time to
+/// attempt submitting events, otherwise we should honor the spirit of the subcommand and not hit
+/// the network if it is an "offline" operation.
+fn should_send() -> bool {
+    let mut args = env::args();
+
+    // Use a pattern match against a tuple of the first 3 program arguments after the program name
+    // in order to determine whether or not the subcommand to be invoked is going to hit the
+    // network. If it will, return true and otherwise return false.
+    match (args.nth(1).unwrap_or_default().as_str(),
+           args.next().unwrap_or_default().as_str(),
+           args.next().unwrap_or_default().as_str()) {
+        ("apply", _, _) |
+        ("artifact", "upload", _) |
+        ("config", "apply", _) |
+        ("file", "upload", _) |
+        ("install", _, _) |
+        ("origin", "key", "upload") |
+        ("pkg", "install", _) => true,
+        _ => false,
+    }
+}
+
+/// Sends the event to Google Analytics via an HTTP/POST.
+///
+/// This function returns true if the event was sent and false if an error occured along the way.
+/// The presence of a `false` return value is enough to assume that we want to save this event to
+/// disk for later retry.
+fn send_event(payload: &str) -> bool {
+    // Create a new Hyper HTTP client, using a helper from the `habitat_http_client` crate. This
+    // function is reponsible for setting up the SSL context, finding suitable SSL root certificate
+    // files, etc. The `None` references are for more advanced use cases which is the Rust way of
+    // saying: "I'm giving you nothing for this value, as opposed to something".
+    //
+    // The `new_hyper_client` function returns a `Result` structure which can either be `Ok`, or
+    // can contain an error (`Err`). The `Ok` pattern matching arm will return the actual
+    // "unwraped" client from the expresssion and setting the client variable binding. The `Err`
+    // matching arm is when something (or anything) goes wrong. In this case we absolutely do not
+    // want to crash, panic this thread, or otherwise impact the real operation potentially running
+    // concurrently. So, the strategy here is to report and early return.
+    let client = match http_client::new_hyper_client(None, None) {
+        Ok(c) => c,
+        Err(e) => {
+            debug!("Error create HTTP client: {}", e);
+            return false;
+        }
+    };
+    // Build up an HTTP/POST request to the Google Analytics API endpoint with the event payload as
+    // the body of the request. The `mut` keyword means that we can mutate the contents of this
+    // variable binding.
+    let mut request = client.post(GOOGLE_ANALYTICS_URL).body(payload);
+    // Generate a "User-Agent" header for this request, using a helper function from the
+    // `habitat_http_client` crate. This function also returns a `Result`, but we only care if the
+    // function returns us a successful `UserAgent` struct, hence the "if let" Rust pattern
+    // matching structure.
+    if let Ok(ua) = http_client::user_agent(PRODUCT, super::VERSION) {
+        request = request.header(ua);
+    }
+    // Send the request on the wire. As before we will unwrap the successful operation or report
+    // and early return if anything goes wrong.
+    let response = match request.send() {
+        Ok(r) => r,
+        Err(e) => {
+            debug!("Error posting payload to {}: {}", GOOGLE_ANALYTICS_URL, e);
+            return false;
+        }
+    };
+    // Report if the posting was successful or not successful.
+    if response.status.is_success() {
+        debug!("Event posted successfully: {}",
+               response.status.canonical_reason().unwrap_or_default());
+        true
+    } else {
+        debug!("Response indicated not successful: {}",
+               response.status.canonical_reason().unwrap_or_default());
+        false
+    }
+}
+
+/// Save the event to a timestamped file under the analytics cache directory.
+///
+/// A later execution of this program may batch up pending events and attempt to submit them.
+fn save_event(payload: &str) {
+    // Compute a timestamp as number of seconds and nanoseconds since the Unix epoch.
+    let (secs, subsec_nanos) = match SystemTime::now().duration_since(UNIX_EPOCH) {
+        Ok(duration) => (duration.as_secs(), duration.subsec_nanos()),
+        Err(e) => {
+            debug!("Cannot generate system time: {}", e);
+            return;
+        }
+    };
+    // Determine the parent directory for the cached event file.
+    let cache_dir = hcore::fs::cache_analytics_path(None);
+    // Determine the full path to the cached event file.
+    let cached_event = cache_dir.join(format!("event-{}.{}.txt", secs, subsec_nanos));
+    // Write the file with the payload contents to disk.
+    write_file(&cache_dir, &cached_event, payload);
+}
+
+/// Attempts to send any pending events on disk in the analytics cache.
+fn send_pending() {
+    // Determine the path to the analytics cache directory.
+    let cache_dir = hcore::fs::cache_analytics_path(None);
+    // Get an iterator to all file and directory entries under the cache directory. If an error
+    // occurs, report and return early.
+    let entries = match cache_dir.read_dir() {
+        Ok(rd) => rd,
+        Err(e) => {
+            debug!("Cannot read directory entries in {}: {}",
+                   cache_dir.display(),
+                   e);
+            return;
+        }
+    };
+    // Iterate over each directory entry.
+    for entry in entries {
+        // Ensure that the directory entry is readable and if not, proceed to the next entry.
+        let entry = match entry {
+            Ok(e) => e,
+            Err(e) => {
+                debug!("Error reading directory entry: {}", e);
+                continue;
+            }
+        };
+        // Get the entry's metadata and if there are any errors, proceed to the next entry.
+        let metadata = match entry.metadata() {
+            Ok(md) => md,
+            Err(e) => {
+                debug!("Error reading entry metadata: {}", e);
+                continue;
+            }
+        };
+        // If the directory entry is a file and the base file name starts with `event-`, then this
+        // is a cached event. Otherwise proceed to the next entry.
+        if metadata.is_file() &&
+           entry.file_name().to_string_lossy().as_ref().starts_with("event-") {
+            let file_path = entry.path();
+            // Send the event, but if not successful report and proceed to the next entry.
+            if send_event(&read_file(&file_path)) {
+                // If the event was successfully sent, then remove the cached file. If there is an
+                // error removing the file, report and proceed to the next entry.
+                if let Err(e) = fs::remove_file(&file_path) {
+                    debug!("Error removing {}: {}", file_path.display(), e);
+                    continue;
+                }
+            } else {
+                debug!("Error sending pending event, keeping for a retry next attempt");
+                continue;
+            }
+        }
+    }
+}
+
+/// Returns a previous randomly generated [Client
+/// ID](https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#cid) or
+/// creates, saves, and return a new Client ID.
+fn client_id() -> String {
+    // Get a path to the location containing a file with the randomly generated Client ID, using a
+    // helper function from the `habitat_core` crate. The `None` tells the function that there is
+    // no custom file system root prefix path.
+    let metadir = hcore::fs::cache_analytics_path(None);
+    // Get the path to the metadata file.
+    let metafile = metadir.join(CLIENT_ID_METAFILE);
+    if metafile.exists() {
+        // Return the contents of the file which is the Client ID
+        read_file(&metafile)
+    } else {
+        // Generate a new, random UUID for the Client ID.
+        let uuid = Uuid::new_v4().to_hyphenated_string();
+        write_file(&metadir, &metafile, &uuid);
+        // Finally, return the Client ID String
+        uuid
+    }
+}
+
+/// Reads a file from disk and returns its contents as an owned String.
+fn read_file(file_path: &Path) -> String {
+    // Set up a mutable heap-allocated buffer to read into from the file.
+    let mut content = String::new();
+    // If the file exists, then open it to get a file handle for reading. As before, this could
+    // fail so we will unwrap and use the success and report and early return on any failure.
+    // As this function is guarenting that a String will be returned, and given that we can't
+    // open the file with our answer (we hope), then we'll return an empty String.
+    let mut file = match File::open(file_path) {
+        Ok(f) => f,
+        Err(e) => {
+            debug!("Error opening file {}: {}", file_path.display(), e);
+            return content;
+        }
+    };
+    // Read the file contents into the above mutable String buffer. This "if let" construct
+    // will only report and early return if a failure is returned in the `Result`.
+    if let Err(e) = file.read_to_string(&mut content) {
+        debug!("Error reading file {}: {}", file_path.display(), e);
+        return content;
+    }
+    // Finally, return the content as a String.
+    content
+}
+
+/// Writes the content to a file while also ensuring that the parent directory exists.
+fn write_file(parent_dir: &Path, file_path: &Path, content: &str) {
+    debug!("Creating directory {}", parent_dir.display());
+    // Create the parent directory of the file to ensure that it exists. If an error
+    // is returned during directory creation, we'll report the error and return.
+    if let Err(e) = fs::create_dir_all(parent_dir) {
+        debug!("Error creating directory {}: {}", parent_dir.display(), e);
+        return;
+    };
+    // Create an empty file and return a file handle for writing. Same error handling logic as
+    // above.
+    let mut file = match File::create(&file_path) {
+        Ok(f) => f,
+        Err(e) => {
+            debug!("Error creating file {}: {}", file_path.display(), e);
+            return;
+        }
+    };
+    debug!("Creating file {}", file_path.display());
+    // Write out the content to the file. Same error handling logic as above.
+    if let Err(e) = file.write_all(content.as_bytes()) {
+        debug!("Error writing to file {}: {}", file_path.display(), e);
+        return;
+    }
+}

--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -14,8 +14,6 @@ use clap::{App, AppSettings, Arg};
 use url::Url;
 use hcore::crypto::keys::PairType;
 
-const VERSION: &'static str = include_str!(concat!(env!("OUT_DIR"), "/VERSION"));
-
 pub fn get() -> App<'static, 'static> {
     let alias_apply = sub_config_apply()
         .about("Alias for 'config apply'")
@@ -29,7 +27,7 @@ pub fn get() -> App<'static, 'static> {
 
     clap_app!(hab =>
         (about: "\"A Habitat is the natural environment for your services\" - Alan Turing")
-        (version: VERSION)
+        (version: super::VERSION)
         (author: "\nAuthors: The Habitat Maintainers <humans@habitat.sh>\n")
         (@setting VersionlessSubcommands)
         (@setting ArgRequiredElseHelp)

--- a/components/http-client/Cargo.lock
+++ b/components/http-client/Cargo.lock
@@ -33,6 +33,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "gcc"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -50,8 +60,10 @@ dependencies = [
 name = "habitat_core"
 version = "0.6.0"
 dependencies = [
+ "errno 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libarchive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsodium-sys 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.71 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/net/Cargo.lock
+++ b/components/net/Cargo.lock
@@ -30,6 +30,16 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "errno"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -51,8 +61,10 @@ dependencies = [
 name = "habitat_core"
 version = "0.6.0"
 dependencies = [
+ "errno 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libarchive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsodium-sys 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.71 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/sup/Cargo.lock
+++ b/components/sup/Cargo.lock
@@ -117,6 +117,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "error"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -172,8 +182,10 @@ dependencies = [
 name = "habitat_core"
 version = "0.6.0"
 dependencies = [
+ "errno 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libarchive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsodium-sys 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.69 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
The `hab` command-line tool will optionally send anonymous usage data to Habitat's Google Analytics account. This is a strictly opt-in activity and no tracking will occur unless you respond affirmatively to the question during `hab setup`. If you do not use `hab setup`, no data will ever be sent.

We collect this data to help improve Habitat's user experience: for example, to know what tasks users are performing, and which ones they are having trouble with (e.g. mistyping command line arguments).

By _anonymous_ we mean that all identifying information about you is removed before we send the data. This includes the removal of any information about what packages you are building, or what origins you are using. For example, if you were building the package `yourname/yourapp`, and you typed `hab pkg build -k yourkey yourname/yourapp`, the fact that you were performing the `pkg build` operation would be transmitted. Neither the name of the specific package you are building, nor the fact that you are using the `yourkey` key to sign that package would be transmitted.

Please do not hesitate to [contact us](mailto:support@habitat.sh) if you have questions or concerns about the use of Google Analytics within the Habitat product.

Note that this module is highly documented, even inside functions with the intent of guiding a user through the implementation who may not necessarily be familiar with Rust code. Given the "must-not-impact-the-user" nature of this code, it tends to be much more explicit than regular, idiomatic Rust code. But at least you can see a lot of `match` expressions in action :)
# Subcommand Invocations

The following is a complete list of all pre-selected commands which are reported:
- `apply`
- `artifact upload`
- `config apply`
- `file upload`
- `origin key generate`
- `pkg build`
- `ring key generate`
- `service key generate`
- `studio build`
- `studio enter`
- `user key generate`
# Subcommands Which Attempt Submission of Events

The only time events will be sent to the Google Analytics API is when certain subcommands are invoked which require network access. These subcommands are:
- `apply`
- `artifact upload`
- `config apply`
- `file upload`
- `install`
- `origin key upload`
- `pkg install`

For all other subcommands, even those which report events, the event payload is saved to a cached file under the analytics cache directory (`/hab/cache/analytics` for a root user and `$HOME/.hab/cache/analytics` for a non-root user).
# Event Data Breakdown

For each event that is reported, a set of information is bundled into the payload. Here is a breakdown of each key/value entry:
## `v=1`

The [Protocol Version](https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#v) which is currently only ever the integer value of `1`.
## `tid=UA-XXXXXXX-X`

The [Track ID](https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#tid)
which represents this product and is currently hard coded as `"UA-6369228-7"`.
## `cid=f673faaf-6ba1-4e60-b819-e2d51e4ad6f1`

The [Client ID](https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#cid)
which is a randomly generated [UUID v4](https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_.28random.29) and written into the system or user's analytics cache (`/hab/cache/analytics/CLIENT_ID` when the program is invoked as the root user and `$HOME/.hab/analytics/CLIENT_ID` when invoked by a non-root user). This is not intended to track individual users or systems, but rather show patterns of usage in aggregate. For example: "In general, users who generally start with `hab studio enter` tend to migrate to using `hab pkg build` over time".
## `t=event`

The [Hit Type](https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#t). This value is hard coded as `"event"` as it is a required Google Analtyics field for all Hit Events.
## `aip=1`

Enables [Anonymize IP](https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#aip). This entry ensures that the sender's IP address will not be captured and will be anonymized.  The value is hard coded as the integer `1`.
## `an=hab`

The [Application Name](https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#an) of the program sending the event. For this program the value is currently hard coded as `"hab"`.
## `av=0.6.0%2F20160604180457`

The [Application Version](https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#av) of the program sending the event. This version string will be the same value as reported when asking for the program's version on the command line. Note that this field may contain characters that must be percent encoded.
## `ds=cli--hab`

The [Data Source](https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#ds) which represents the program which generated the event data. For this program the value is currently hardcoded as `"cli--hab"`.
## `ec=invoke`

The [Event Category](https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#ec) which corresponds to the type of event being sent. Currently there are only 2 possible values: `"invoke"` for subcommand invocations and `"clierror"` for CLI errors.
## `ea=hab--pkg--build`

The [Event Action](https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#ea) which breaks down differently depending on the type of event. For subcommand invocations (where `"ec=invoke"`), the value is the subcommand invoked with no further arguments, options, or flags. Any spaces are replaced with a doubledash, as in: `"hab--studio--enter"` or `"hab--artifact--upload"`. For CLI errors (where `"ec=clierror"`), the value is the type of CLI error followed by a double dash and terminated with the subcommand which was invoked (also containing no further arguments, options, or flags). As before any spaces in the subcommand are replaced with a double dash, as in: `"InvalidSubcommand--hab-whoops"`.
# User-Agent HTTP Header

A user agent string is also included in the HTTP/POST to the Google Analytics API it is of the form:

``` text
<PRODUCT>/<VERSION> (<TARGET>; <KERNEL_RELEASE>)
```

where:
- `<PRODUCT>`: is the provided product name. For this program the value is currently hard coded as `"hab"`.
- `<VERSION>`: is the provided version string which may also include a release number. This is the same version obtained when running the help or version subcommands.
- `<TARGET>`: is the machine architecture and the kernel separated by a dash in lower case.
- `<KERNEL_RELEASE>`: is the kernel release string from `uname`.

For example:

``` text
hab/0.6.0/20160606153031 (x86_64-darwin; 14.5.0)
```
