### PR TITLE
Implement searching in the web app

### DIFF
--- a/components/builder-web/app/AppComponent.ts
+++ b/components/builder-web/app/AppComponent.ts
@@ -113,6 +113,11 @@ import {authenticateWithGitHub, loadSessionState, removeNotification,
         component: PackagesPageComponent,
     },
     {
+        path: "/pkgs/search/:query",
+        name: "PackagesSearch",
+        component: PackagesPageComponent,
+    },
+    {
         path: "/pkgs/:origin/:name/:version/:release",
         name: "Package",
         component: PackagePageComponent

--- a/components/builder-web/app/PackageBreadcrumbsComponent.ts
+++ b/components/builder-web/app/PackageBreadcrumbsComponent.ts
@@ -14,9 +14,6 @@ import {RouterLink} from "angular2/router";
     selector: "package-breadcrumbs",
     template: `
     <span class="hab-package-breadcrumbs">
-        <span *ngIf="showAll">All Packages</span>
-        <span *ngIf="params.filter === 'mine'">My Packages</span>
-        <a *ngIf="!ident.origin && !params.filter && !showAll" [routerLink]="['Packages']">*</a>
         <a [routerLink]="['PackagesForOrigin',
             { origin: ident.origin }]">
             {{ident.origin}}
@@ -43,14 +40,9 @@ import {RouterLink} from "angular2/router";
 })
 
 export class PackageBreadcrumbsComponent {
-    private ident;
     private params;
 
     constructor() {
         this.params = this.params || {};
-    }
-
-    get showAll() {
-        return Object.keys(this.ident).length === 0;
     }
 }

--- a/components/builder-web/app/actions/index.ts
+++ b/components/builder-web/app/actions/index.ts
@@ -49,6 +49,8 @@ export const CLEAR_PACKAGES = packageActions.CLEAR_PACKAGES;
 export const POPULATE_EXPLORE = packageActions.POPULATE_EXPLORE;
 export const SET_CURRENT_PACKAGE = packageActions.SET_CURRENT_PACKAGE;
 export const SET_PACKAGES_NEXT_RANGE = packageActions.SET_PACKAGES_NEXT_RANGE;
+export const SET_PACKAGES_SEARCH_QUERY =
+    packageActions.SET_PACKAGES_SEARCH_QUERY;
 export const SET_PACKAGES_TOTAL_COUNT = packageActions.SET_PACKAGES_TOTAL_COUNT;
 
 export const SET_VISIBLE_PACKAGES = packageActions.SET_VISIBLE_PACKAGES;
@@ -104,6 +106,7 @@ export const fetchPackage = packageActions.fetchPackage;
 export const filterPackagesBy = packageActions.filterPackagesBy;
 export const populateExplore = packageActions.populateExplore;
 export const setCurrentPackage = packageActions.setCurrentPackage;
+export const setPackagesSearchQuery = packageActions.setPackagesSearchQuery;
 export const setVisiblePackages = packageActions.setVisiblePackages;
 
 export const addProject = projectActions.addProject;

--- a/components/builder-web/app/actions/packages.ts
+++ b/components/builder-web/app/actions/packages.ts
@@ -12,6 +12,7 @@ export const CLEAR_PACKAGES = "CLEAR_PACKAGES";
 export const POPULATE_EXPLORE = "POPULATE_EXPLORE";
 export const SET_CURRENT_PACKAGE = "SET_CURRENT_PACKAGE";
 export const SET_PACKAGES_NEXT_RANGE = "SET_PACKAGES_NEXT_RANGE";
+export const SET_PACKAGES_SEARCH_QUERY = "SET_PACKAGES_SEARCH_QUERY";
 export const SET_PACKAGES_TOTAL_COUNT = "SET_PACKAGES_TOTAL_COUNT";
 export const SET_VISIBLE_PACKAGES = "SET_VISIBLE_PACKAGES";
 
@@ -34,17 +35,21 @@ export function fetchPackage(pkg) {
     return dispatch => {
         dispatch(clearPackages());
         depotApi.get(pkg.ident).then(response => {
-            dispatch(setCurrentPackage(response));
+            dispatch(setCurrentPackage(response["results"]));
         }).catch(error => {
             dispatch(setCurrentPackage(undefined, error));
         });
     };
 }
 
-export function filterPackagesBy(params, nextRange: number = 0) {
+export function filterPackagesBy(params, query: string, nextRange: number = 0) {
     return dispatch => {
         if (nextRange === 0) {
             dispatch(clearPackages());
+        }
+
+        if (query) {
+            params = { query };
         }
 
         depotApi.get(params, nextRange).then(response => {
@@ -75,6 +80,13 @@ export function setCurrentPackage(pkg, error = undefined) {
 function setPackagesNextRange(payload: number) {
     return {
         type: SET_PACKAGES_NEXT_RANGE,
+        payload,
+    };
+}
+
+export function setPackagesSearchQuery(payload: string) {
+    return {
+        type: SET_PACKAGES_SEARCH_QUERY,
         payload,
     };
 }

--- a/components/builder-web/app/depotApi.ts
+++ b/components/builder-web/app/depotApi.ts
@@ -11,9 +11,13 @@ import {packageString} from "./util";
 
 const urlPrefix = config["habitat_api_url"] || "";
 
-export function get(ident, nextRange: number = 0) {
+export function get(params, nextRange: number = 0) {
+    const url = `${urlPrefix}/depot/pkgs/` +
+        ("query" in params ? `search/${params["query"]}`
+                           : packageString(params));
+
     return new Promise((resolve, reject) => {
-        fetch(`${urlPrefix}/depot/pkgs/${packageString(ident)}`, {
+        fetch(url, {
             headers: { "Range": nextRange.toString() }
         }).then(response => {
             // Fail the promise if an error happens.
@@ -25,7 +29,10 @@ export function get(ident, nextRange: number = 0) {
                 reject(new Error(response.statusText));
             }
 
-            const totalCount = parseInt(response.headers.get("Content-Range").split("=")[1], 10);
+            const totalCount = parseInt(
+                (response.headers.get("Content-Range") || "").split("=")[1],
+                10
+            );
             const nextRange = parseInt(response.headers.get("Next-Range"), 10);
 
             const headers = response.headers;

--- a/components/builder-web/app/initialState.ts
+++ b/components/builder-web/app/initialState.ts
@@ -86,6 +86,7 @@ export default Record({
         explore: List(),
         visible: List(),
         nextRange: 0,
+        searchQuery: "",
         totalCount: 0,
         ui: Record({
             current: Record({

--- a/components/builder-web/app/reducers/packages.ts
+++ b/components/builder-web/app/reducers/packages.ts
@@ -45,6 +45,9 @@ export default function packages(state = initialState["packages"], action) {
         case actionTypes.SET_PACKAGES_NEXT_RANGE:
             return state.set("nextRange", action.payload);
 
+        case actionTypes.SET_PACKAGES_SEARCH_QUERY:
+            return state.set("searchQuery", action.payload);
+
         case actionTypes.SET_PACKAGES_TOTAL_COUNT:
             return state.set("totalCount", action.payload);
 


### PR DESCRIPTION
- There's a search box in package list pages that will search if you type
  in it.
- Going to /pkgs/search/:query also does what you would expect.
- Fix the bug related to the new range header stuff that was stopping
  single package pages from displaying.
- Fix the bug where my math about pagination was slightly off because of a
  `<=` rather than a `<`.
- When no packages are found, it now says "No packages found" instead
  of "Failed to load packages."

_IMPORTANT NOTE_: Packages that are on an existing depot _will not_ show
up in search results unless the are re-uploaded or somehow redis gets
told to index them.

![tumblr_o7qhym5yj41qmob6ro1_400](https://cloud.githubusercontent.com/assets/9912/15810706/e638e752-2b66-11e6-8350-4c7b0a19199a.gif)
