### PR TITLE
You can't use these variables in hooks

### DIFF
--- a/www/source/docs/plan-syntax.html.md
+++ b/www/source/docs/plan-syntax.html.md
@@ -160,7 +160,7 @@ pkg_svc_group
 ***
 
 ## Variables
-The following variables can be used in your plan and hook scripts to help get binaries and libraries to build and install in the correct locations in your package.
+The following variables can be used in your plans to help get binaries and libraries to build and install in the correct locations in your package.
 
 $pkg_prefix
 : This variable is the absolute path for your package.


### PR DESCRIPTION
Only in plans. Hooks require you to use ``{{pkg.prefix}}` instead of
`$pkg_prefix`.
