### PR TITLE
enable all ports for caching

### DIFF
--- a/plans/polipo/config/polipo.config
+++ b/plans/polipo/config/polipo.config
@@ -1,3 +1,4 @@
+allowedPorts = {{cfg.allowedPorts}}
 cacheIsShared = {{cfg.cacheIsShared}}
 chunkHighMark = {{cfg.chunkHighMark}}
 disableIndexing = {{cfg.disableIndexing}}
@@ -10,3 +11,4 @@ objectHighMark = {{cfg.objectHighMark}}
 proxyAddress = "{{cfg.proxyAddress}}"
 proxyPort = {{cfg.port}}
 serverExpireTime = {{cfg.serverExpireTime}}
+tunnelAllowedPorts = {{cfg.tunnelAllowedPorts}}

--- a/plans/polipo/default.toml
+++ b/plans/polipo/default.toml
@@ -1,4 +1,6 @@
 # https://www.irif.univ-paris-diderot.fr/~jch//software/polipo/manual/
+# enable all ports
+allowedPorts = "1-65535"
 # share caching between all users, possibly unsafe
 cacheIsShared = "false"
 # 4X the default
@@ -19,3 +21,5 @@ proxyAddress = "::0"
 port = 8123
 # duration to keep server data
 serverExpireTime = "7d"
+# enable all ports
+tunnelAllowedPorts = "1-65535"


### PR DESCRIPTION
From the Polipo documentation, "Set this variable to ‘1-65535’ if your clients (and the web pages they consult!) are fully trusted."
