### PR TITLE
print_help if no arguments are provided.

### DIFF
--- a/components/pkg-aci/bin/hab-pkg-aci.sh
+++ b/components/pkg-aci/bin/hab-pkg-aci.sh
@@ -164,7 +164,10 @@ program=$(basename $0)
 find_system_commands
 
 if [ -z "$@" ]; then
-    exit_with "You must specify one or more Habitat packages to create an ACI from." 1
+  print_help
+  exit_with "You must specify one or more Habitat packages to create an ACI from." 1
+elif [ "$@" == "--help" ]; then
+  print_help
 else
-    build_aci $@
+  build_aci $@
 fi

--- a/components/pkg-dockerize/bin/hab-pkg-dockerize.sh
+++ b/components/pkg-dockerize/bin/hab-pkg-dockerize.sh
@@ -157,7 +157,10 @@ program=$(basename $0)
 find_system_commands
 
 if [ -z "$@" ]; then
-    exit_with "You must specify one or more Habitat packages to Dockerize." 1
+  print_help
+  exit_with "You must specify one or more Habitat packages to Dockerize." 1
+elif [ "$@" == "--help" ]; then
+  print_help
 else
-    build_docker_image $@
+  build_docker_image $@
 fi


### PR DESCRIPTION
print_help wasn't actually used with either command.
