### PR TITLE
Make Slack URL be http instead of https

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Habitat
 
 [![Build Status](https://travis-ci.org/habitat-sh/habitat.svg?branch=master)](https://travis-ci.org/habitat-sh/habitat)
-[![Slack](http://slack.habitat.sh/badge.svg)](https://slack.habitat.sh/)
+[![Slack](http://slack.habitat.sh/badge.svg)](http://slack.habitat.sh/)
 
 Want to try Habitat? [Get started here](https://www.habitat.sh/try/).
 


### PR DESCRIPTION
Because it's an Heroku app and you get a cert error if you hit it at
https.
