### PR TITLE
Mark updated nodes with "change applied" not "changed applied"

### DIFF
--- a/www/source/javascripts/try.js
+++ b/www/source/javascripts/try.js
@@ -220,7 +220,7 @@
                       //change button text to reflect resulting status
                       //show badge on window buttons
                       //show full updated cli output
-                      $(".node-status").html("changed applied").parent().addClass("updated");
+                      $(".node-status").html("change applied").parent().addClass("updated");
                       $(".button-badge, .full-output").show();
                     }
                 });


### PR DESCRIPTION
This updates the "tab" titles on Try page 5 to be "Service group node 1 - change applied" rather than "Service group node 1 - changed applied"
