### PR TITLE
Add `friends_only` feature flag

### DIFF
--- a/components/builder-web/app/boot.ts
+++ b/components/builder-web/app/boot.ts
@@ -25,7 +25,8 @@ if (config["environment"] === "production") {
     enableProdMode();
 
     // Don't load if we're on habitat.sh and the "friends" cookie is not set
-    if (window.location.host.endsWith("habitat.sh") &&
+    if (config["friends_only"] &&
+        window.location.host.endsWith("habitat.sh") &&
         !document.cookie.includes("habitat_is_not_bldr")) {
         goingToBoot = false;
     }

--- a/components/builder-web/habitat/config/habitat.conf.js
+++ b/components/builder-web/habitat/config/habitat.conf.js
@@ -3,6 +3,7 @@ habitatConfig({
     community_url: "{{cfg.community_url}}",
     docs_url: "{{cfg.docs_url}}",
     environment: "{{cfg.environment}}",
+    friends_only: {{cfg.friends_only}},
     github_client_id: "{{cfg.github_client_id}}",
     source_code_url: "{{cfg.source_code_url}}",
     tutorials_url: "{{cfg.tutorials_url}}",

--- a/components/builder-web/habitat/default.toml
+++ b/components/builder-web/habitat/default.toml
@@ -11,6 +11,10 @@ docs_url = "https://www.habitat.sh/docs"
 # production mode
 environment = "production"
 
+# If `friends_only` is `true`, you use the pre-launch friends.habitat.sh to
+# access the site.
+friends_only = true
+
 # The URL for Habitat's source code
 # GitHub Client ID for OAuth2
 github_client_id = ""

--- a/terraform/config/habitat-builder-web.toml
+++ b/terraform/config/habitat-builder-web.toml
@@ -1,2 +1,3 @@
 habitat_api_url = "https://habitat-api-1022630102.us-west-2.elb.amazonaws.com/v1"
 github_client_id = "e98d2a94787be9af9c00"
+friends_only = true


### PR DESCRIPTION
Make it so setting `friends_only = false` will turn off the
friends.habitat.sh checking.

![gif-keyboard-9115676299696095521](https://cloud.githubusercontent.com/assets/9912/15907960/de41b1c6-2d84-11e6-8a4f-657330f47ade.gif)
