### PR TITLE
Fixed sidebar styling for line-wrapped entries

### DIFF
--- a/www/data/about_sidebar.yml
+++ b/www/data/about_sidebar.yml
@@ -3,12 +3,12 @@ sidebar_links:
 - title: About
   links:
   - title: The Genesis of Habitat
-    link:  /about/habitat-genesis.html
+    link:  "/about/habitat-genesis/"
   - title: What is a Modern Application?
-    link:  /about/what-is-modern-app.html
+    link:  "/about/what-is-modern-app/"
   - title: Why Package the App and Its Automation Together?
-    link:  /about/why-package-automation-with-app.html
+    link:  "/about/why-package-automation-with-app/"
   - title: Habitat and the Modern Application
-    link:  /about/habitat-and-modern-app.html
+    link:  "/about/habitat-and-modern-app/"
   - title: Habitat and Workload Placement
-    link:  /about/habitat-and-workload-placement.html
+    link:  "/about/habitat-and-workload-placement/"

--- a/www/data/docs_sidebar.yml
+++ b/www/data/docs_sidebar.yml
@@ -3,9 +3,9 @@ sidebar_links:
 - title: Getting Started
   links:
   - title: Overview
-    link: "/docs/overview"
+    link: "/docs/overview/"
   - title: Get Habitat
-    link: "/docs/get-habitat"
+    link: "/docs/get-habitat/"
   - title: Tutorials
     link: "/tutorials/"
   - title: Concepts

--- a/www/data/tutorials_sidebar.yml
+++ b/www/data/tutorials_sidebar.yml
@@ -16,7 +16,7 @@ sidebar_links:
     - title: Add hooks to your plan
       link: "/tutorials/getting-started-add-hooks/"
     - title: Add configuration to your plan
-      link: "/tutorials/getting-started-configure-plan"
+      link: "/tutorials/getting-started-configure-plan/"
     - title: Process your build
       link: "/tutorials/getting-started-process-build/"
     - title: Next steps
@@ -24,4 +24,4 @@ sidebar_links:
 - title: Quick Links
   links:
   - title: Habitat docs
-    link: "/docs"
+    link: "/docs/"

--- a/www/source/stylesheets/_layout.scss
+++ b/www/source/stylesheets/_layout.scss
@@ -90,9 +90,10 @@ body.has-sidebar {
 }
 
 .main-sidebar--list--item {
-    display: block;
-    line-height: rem-calc(32);
-    padding-left: 0;
+  display: block;
+  line-height: 1.2;
+  margin-bottom: rem-calc(13);
+  padding-left: 0;
 }
 
 .main-content__has-sidebar {


### PR DESCRIPTION
Also modified "about" sidebar links so they're properly matched by the
active page identifier, and added missing quotes, slashes to make all
the entries super matchy-matchy.

Signed-off-by: Trevor Bramble tbramble@chef.io
