### PR TITLE
[hab] Add `hab pkg export` subcommand

### DIFF
--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -208,8 +208,16 @@ pub fn get() -> App<'static, 'static> {
                    (aliases: &["p", "pa", "pat"])
                    (@arg PKG_IDENT: +required +takes_value
                     "A package identifier (ex: core/redis, core/busybox-static/1.42.2)")
-            )
-        )
+             )
+            (@subcommand export =>
+                   (about: "Exports the package to the specified format")
+                   (aliases: &["e", "ex", "exp"])
+                   (@arg FORMAT: +required +takes_value
+                    "The export format (ex: docker, aci)")
+                   (@arg PKG_IDENT: +required +takes_value
+                    "A package identifier (ex: core/redis, core/busybox-static/1.42.2)")
+             )
+         )
         (@subcommand ring =>
             (about: "Commands relating to Habitat rings")
             (aliases: &["r", "ri", "rin"])

--- a/components/hab/src/error.rs
+++ b/components/hab/src/error.rs
@@ -32,6 +32,7 @@ pub enum Error {
     PackageArchiveMalformed(String),
     PathPrefixError(path::StripPrefixError),
     SubcommandNotSupported(String),
+    UnsupportedExportFormat(String)
 }
 
 impl fmt::Display for Error {
@@ -59,7 +60,8 @@ impl fmt::Display for Error {
             Error::PathPrefixError(ref err) => format!("{}", err),
             Error::SubcommandNotSupported(ref e) => {
                 format!("Subcommand `{}' not supported on this operating system", e)
-            }
+            },
+            Error::UnsupportedExportFormat(ref e) => format!("Unsupported export format: {}", e)
         };
         write!(f, "{}", msg)
     }
@@ -84,6 +86,7 @@ impl error::Error for Error {
             }
             Error::PathPrefixError(ref err) => err.description(),
             Error::SubcommandNotSupported(_) => "Subcommand not supported on this operating system",
+            Error::UnsupportedExportFormat(_) => "Unsupported export format"
         }
     }
 }

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -9,6 +9,7 @@ extern crate habitat_core as hcore;
 extern crate habitat_common as common;
 extern crate habitat_depot_client as depot_client;
 extern crate habitat_http_client as http_client;
+
 extern crate ansi_term;
 #[macro_use]
 extern crate clap;
@@ -142,6 +143,7 @@ fn start() -> Result<()> {
                 ("exec", Some(m)) => try!(sub_pkg_exec(m, remaining_args)),
                 ("install", Some(m)) => try!(sub_pkg_install(m)),
                 ("path", Some(m)) => try!(sub_pkg_path(m)),
+                ("export", Some(m)) => try!(sub_pkg_export(m)),
                 _ => unreachable!(),
             }
         }
@@ -435,6 +437,13 @@ fn sub_pkg_path(m: &ArgMatches) -> Result<()> {
     let ident = try!(PackageIdent::from_str(m.value_of("PKG_IDENT").unwrap()));
 
     command::pkg::path::start(&ident, &fs_root_path)
+}
+
+fn sub_pkg_export(m: &ArgMatches) -> Result<()> {
+    let ident = try!(PackageIdent::from_str(m.value_of("PKG_IDENT").unwrap()));
+    let format = &m.value_of("FORMAT").unwrap();
+    let export_fmt = try!(command::pkg::export::format_for(&format));
+    command::pkg::export::start(&ident, &export_fmt)
 }
 
 fn sub_ring_key_export(m: &ArgMatches) -> Result<()> {


### PR DESCRIPTION
The `hab pkg export FORMAT PKG_IDENT` subcommand exports a pkg in the
specified format. Currently docker and aci are the only two supported
formats. The coresponding core packages will be installed on demand if
required (core/hab-pkg-dockerize and core/hab-pkg-aci).
