### PR TITLE
Fix missing app module

### DIFF
--- a/components/builder-web/package.json
+++ b/components/builder-web/package.json
@@ -14,7 +14,7 @@
     "build-js-watch": "npm run build-js -- --watch",
     "clean": "concurrent \"npm run clean-js\" \"npm run clean-css\"",
     "clean-css": "rm -fv assets/app.css assets/app.css.map",
-    "clean-js": "rm -fv assets/app.js assets/app.js.map app**/*.js app**/*.js.map",
+    "clean-js": "rm -fv assets/app.js assets/app.js.map",
     "dist": "bin/dist",
     "format-js": "tsfmt --replace app**/*.ts",
     "lint": "concurrent \"npm run lint-css\" \"npm run lint-js\"",


### PR DESCRIPTION
`npm run dist` was running `npm run clean-js` which deletes app/**.js,
but recently we added a couple .js files and we were deleting them when
we built that app so that wasn't cool.

![gif-keyboard-11729207848908114176](https://cloud.githubusercontent.com/assets/9912/15938687/ddf7521a-2e39-11e6-92c3-dd20d5f062a0.gif)
