### PR TITLE
skip rustfmt lint on generated protocol files

### DIFF
--- a/support/ci/lint.sh
+++ b/support/ci/lint.sh
@@ -85,6 +85,10 @@ fi
 eval "$cmd" | while read file; do
   case "${file##*.}" in
     rs)
+      if echo "$file" | grep -q "components/builder-protocol/src/message" >/dev/null; then
+        info "Skipping generated Rust code file $file"
+        break
+      fi
       info "Running rustfmt on $file"
       set +e
       output="$(rustfmt --skip-children --write-mode diff "$file" 2>&1)"


### PR DESCRIPTION
We need to skip generated protocol files because we don't want to ever mutate generated code

Signed-off-by: Jamie Winsor jamie@vialstudios.com
