### PR TITLE
public/secret key upload w/ auth

### DIFF
--- a/components/builder-api/src/http/handlers.rs
+++ b/components/builder-api/src/http/handlers.rs
@@ -277,7 +277,7 @@ pub fn job_show(req: &mut Request, ctx: &Arc<Mutex<zmq::Context>>) -> IronResult
 /// Endpoint for determining availability of builder-api components.
 ///
 /// Returns a status 200 on success. Any non-200 responses are an outage or a partial outage.
-pub fn status(req: &mut Request) -> IronResult<Response> {
+pub fn status(_req: &mut Request) -> IronResult<Response> {
     Ok(Response::with(status::Ok))
 }
 

--- a/components/core/src/crypto/mod.rs
+++ b/components/core/src/crypto/mod.rs
@@ -225,37 +225,37 @@ use env as henv;
 use fs::cache_key_path;
 
 /// The suffix on the end of a public sig/box file
-static PUBLIC_KEY_SUFFIX: &'static str = "pub";
+pub static PUBLIC_KEY_SUFFIX: &'static str = "pub";
 
 /// The suffix on the end of a public sig file
-static SECRET_SIG_KEY_SUFFIX: &'static str = "sig.key";
+pub static SECRET_SIG_KEY_SUFFIX: &'static str = "sig.key";
 
 /// The suffix on the end of a secret box file
-static SECRET_BOX_KEY_SUFFIX: &'static str = "box.key";
+pub static SECRET_BOX_KEY_SUFFIX: &'static str = "box.key";
 
 /// The suffix on the end of a secret symmetric key file
-static SECRET_SYM_KEY_SUFFIX: &'static str = "sym.key";
+pub static SECRET_SYM_KEY_SUFFIX: &'static str = "sym.key";
 
 /// The hashing function we're using during sign/verify
 /// See also: https://download.libsodium.org/doc/hashing/generic_hashing.html
-static SIG_HASH_TYPE: &'static str = "BLAKE2b";
+pub static SIG_HASH_TYPE: &'static str = "BLAKE2b";
 
 /// This environment variable allows you to override the fs::CACHE_KEY_PATH
 /// at runtime. This is useful for testing.
-static CACHE_KEY_PATH_ENV_VAR: &'static str = "HAB_CACHE_KEY_PATH";
+pub static CACHE_KEY_PATH_ENV_VAR: &'static str = "HAB_CACHE_KEY_PATH";
 
 /// Create secret key files with these permissions
 static PUBLIC_KEY_PERMISSIONS: &'static str = "0400";
 static SECRET_KEY_PERMISSIONS: &'static str = "0400";
 
-static HART_FORMAT_VERSION: &'static str = "HART-1";
-static BOX_FORMAT_VERSION: &'static str = "BOX-1";
+pub static HART_FORMAT_VERSION: &'static str = "HART-1";
+pub static BOX_FORMAT_VERSION: &'static str = "BOX-1";
 
-const PUBLIC_SIG_KEY_VERSION: &'static str = "SIG-PUB-1";
-const SECRET_SIG_KEY_VERSION: &'static str = "SIG-SEC-1";
-const PUBLIC_BOX_KEY_VERSION: &'static str = "BOX-PUB-1";
-const SECRET_BOX_KEY_VERSION: &'static str = "BOX-SEC-1";
-const SECRET_SYM_KEY_VERSION: &'static str = "SYM-SEC-1";
+pub const PUBLIC_SIG_KEY_VERSION: &'static str = "SIG-PUB-1";
+pub const SECRET_SIG_KEY_VERSION: &'static str = "SIG-SEC-1";
+pub const PUBLIC_BOX_KEY_VERSION: &'static str = "BOX-PUB-1";
+pub const SECRET_BOX_KEY_VERSION: &'static str = "BOX-SEC-1";
+pub const SECRET_SYM_KEY_VERSION: &'static str = "SYM-SEC-1";
 
 pub use self::keys::box_key_pair::BoxKeyPair;
 pub use self::keys::sym_key::SymKey;

--- a/components/depot/src/server.rs
+++ b/components/depot/src/server.rs
@@ -649,7 +649,7 @@ fn upload_origin_secret_key(depot: &Depot, req: &mut Request) -> IronResult<Resp
 
     let mut conn = Broker::connect(&depot.context).unwrap();
     conn.route(&request).unwrap();
-    Ok(Response::with(status::Ok))
+    Ok(Response::with(status::Created))
 }
 
 fn upload_package(depot: &Depot, req: &mut Request) -> IronResult<Response> {

--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -138,10 +138,20 @@ pub fn get() -> App<'static, 'static> {
                         (aliases: &["i", "im", "imp", "impo", "impor"])
                  )
                  (@subcommand upload =>
-                        (about: "Upload a public origin key to the depot")
+                        (@group upload =>
+                            (@attributes +required)
+                            (@arg ORIGIN: +required "The origin name")
+                            (@arg PUBLIC_FILE: --pubfile +takes_value {file_exists}
+                                    "Path to a local public origin key file on disk")
+                        )
+                        (about: "Upload origin keys to the depot")
                         (aliases: &["u", "up", "upl", "uplo", "uploa"])
-                        (@arg FILE: +required {file_exists}
-                         "Path to a local public origin key file on disk")
+                         (@arg WITH_SECRET: -s --secret
+                            conflicts_with[PUBLIC_FILE]
+                            "Upload secret key in addition to the public key")
+                        (@arg SECRET_FILE: --secfile +takes_value {file_exists}
+                            conflicts_with[ORIGIN]
+                            "Path to a local secret origin key file on disk")
                         (@arg DEPOT_URL: -u --url +takes_value {valid_url}
                          "Use a specific Depot URL")
                         (@arg AUTH_TOKEN: -z --auth +takes_value

--- a/components/hab/src/command/origin.rs
+++ b/components/hab/src/command/origin.rs
@@ -6,6 +6,44 @@
 // open source license such as the Apache 2.0 License.
 
 pub mod key {
+
+    use std::fs::File;
+    use std::io::{BufRead, BufReader};
+    use std::path::Path;
+
+    use error::{Error, Result};
+    use hcore;
+
+    // shared between origin::key::upload and origin::key::upload_latest
+    fn get_name_with_rev(keyfile: &Path, expected_vsn: &str) -> Result<String> {
+        let f = try!(File::open(&keyfile));
+        let f = BufReader::new(f);
+        let mut lines = f.lines();
+        let _ = match lines.next() {
+            Some(val) => {
+                let val = try!(val);
+                if &val != expected_vsn {
+                    let msg = format!("Unsupported version: {}", &val);
+                    return Err(Error::HabitatCore(hcore::Error::CryptoError(msg)));
+                }
+                ()
+            }
+            None => {
+                let msg = "Corrupt key file, can't read file version".to_string();
+                return Err(Error::HabitatCore(hcore::Error::CryptoError(msg)));
+            }
+        };
+        let name_with_rev = match lines.next() {
+            Some(val) => try!(val),
+            None => {
+                let msg = "Corrupt key file, can't read name with rev".to_string();
+                return Err(Error::HabitatCore(hcore::Error::CryptoError(msg)));
+            }
+        };
+        Ok(name_with_rev)
+    }
+
+
     pub mod download {
         use std::path::Path;
 
@@ -141,60 +179,193 @@ pub mod key {
     }
 
     pub mod upload {
-        use std::fs::File;
-        use std::io::{BufRead, BufReader};
         use std::path::Path;
 
         use ansi_term::Colour::{Blue, Green, Yellow};
+        use hyper::status::StatusCode::{Forbidden, Unauthorized};
+
         use common::command::ProgressBar;
-        use depot_client::Client;
-        use hcore;
+        use depot_client::{self, Client};
+        use hcore::crypto::{PUBLIC_SIG_KEY_VERSION, SECRET_SIG_KEY_VERSION};
         use hcore::crypto::keys::parse_name_with_rev;
+        use super::get_name_with_rev;
 
         use error::{Error, Result};
 
-        pub fn start(depot: &str, token: &str, keyfile: &Path) -> Result<()> {
+        pub fn start(depot: &str,
+                     token: &str,
+                     public_keyfile: &Path,
+                     secret_keyfile: Option<&Path>)
+                     -> Result<()> {
+            let depot_client = try!(Client::new(depot, None));
             println!("{}",
                      Yellow.bold()
-                         .paint(format!("» Uploading public origin key {}", keyfile.display())));
-            let name_with_rev = {
-                let f = try!(File::open(&keyfile));
-                let f = BufReader::new(f);
-                let mut lines = f.lines();
-                let _ = match lines.next() {
-                    Some(val) => {
-                        let val = try!(val);
-                        if &val != "SIG-PUB-1" {
-                            let msg = format!("Unsupported version: {}", &val);
-                            return Err(Error::HabitatCore(hcore::Error::CryptoError(msg)));
-                        }
-                        ()
-                    }
-                    None => {
-                        let msg = "Corrupt key file, can't read file version".to_string();
-                        return Err(Error::HabitatCore(hcore::Error::CryptoError(msg)));
-                    }
-                };
-                match lines.next() {
-                    Some(val) => try!(val),
-                    None => {
-                        let msg = "Corrupt key file, can't read name with rev".to_string();
-                        return Err(Error::HabitatCore(hcore::Error::CryptoError(msg)));
-                    }
-                }
-            };
+                         .paint(format!("» Uploading public origin key {}",
+                                        public_keyfile.display())));
+
+            let name_with_rev = try!(get_name_with_rev(&public_keyfile, PUBLIC_SIG_KEY_VERSION));
             let (name, rev) = try!(parse_name_with_rev(&name_with_rev));
             println!("{} {}",
                      Green.bold().paint("↑ Uploading"),
-                     keyfile.display());
-            let depot_client = try!(Client::new(depot, None));
+                     public_keyfile.display());
             let mut progress = ProgressBar::default();
-            try!(depot_client.put_origin_key(&name, &rev, keyfile, token, Some(&mut progress)));
-            println!("{} {}", Green.bold().paint("✓ Uploaded"), &name_with_rev);
+
+            match depot_client.put_origin_key(&name,
+                                              &rev,
+                                              public_keyfile,
+                                              token,
+                                              Some(&mut progress)) {
+                Ok(()) => {
+                    println!("{} {}", Green.bold().paint("✓ Uploaded"), &name_with_rev);
+                }
+                Err(e @ depot_client::Error::HTTP(Forbidden)) |
+                Err(e @ depot_client::Error::HTTP(Unauthorized)) => {
+                    return Err(Error::from(e));
+                }
+
+                Err(e @ depot_client::Error::HTTP(_)) => {
+                    debug!("Error uploading public key {}", e);
+                    println!("{} {}",
+                             Yellow.bold()
+                                 .paint("✓ Public key revision already exists in the depot"),
+                             &name_with_rev);
+                }
+                Err(e) => {
+                    return Err(Error::DepotClient(e));
+                }
+            };
+
             println!("{}",
                      Blue.paint(format!("★ Upload of public origin key {} complete.",
                                         &name_with_rev)));
+            if let Some(secret_keyfile) = secret_keyfile {
+                let name_with_rev = try!(get_name_with_rev(&secret_keyfile,
+                                                           SECRET_SIG_KEY_VERSION));
+                let (name, rev) = try!(parse_name_with_rev(&name_with_rev));
+                println!("{} {}",
+                         Green.bold().paint("↑ Uploading"),
+                         secret_keyfile.display());
+                let mut progress = ProgressBar::default();
+                match depot_client.put_origin_secret_key(&name,
+                                                         &rev,
+                                                         secret_keyfile,
+                                                         token,
+                                                         Some(&mut progress)) {
+                    Ok(()) => {
+
+                        println!("{} {}", Green.bold().paint("✓ Uploaded"), &name_with_rev);
+                        println!("{}",
+                                 Blue.paint(format!("★ Upload of secret origin key {} complete.",
+                                                    &name_with_rev)));
+                    }
+                    Err(e) => {
+                        return Err(Error::DepotClient(e));
+                    }
+                };
+            }
+
             Ok(())
         }
     }
+
+
+
+
+
+    pub mod upload_latest {
+        use std::path::Path;
+
+        use ansi_term::Colour::{Blue, Green, Yellow};
+        use hyper::status::StatusCode::{Forbidden, Unauthorized};
+
+        use common::command::ProgressBar;
+        use depot_client::{self, Client};
+        use error::{Error, Result};
+        use hcore::crypto::keys::parse_name_with_rev;
+        use hcore::crypto::{PUBLIC_SIG_KEY_VERSION, SECRET_SIG_KEY_VERSION, SigKeyPair};
+        use super::get_name_with_rev;
+
+        pub fn start(depot: &str,
+                     token: &str,
+                     origin: &str,
+                     with_secret: bool,
+                     cache: &Path)
+                     -> Result<()> {
+            let depot_client = try!(Client::new(depot, None));
+            let latest = try!(SigKeyPair::get_latest_pair_for(origin, cache));
+            let public_keyfile = try!(SigKeyPair::get_public_key_path(&latest.name_with_rev(),
+                                                                      cache));
+
+            let name_with_rev = try!(get_name_with_rev(&public_keyfile, PUBLIC_SIG_KEY_VERSION));
+
+            let (name, rev) = try!(parse_name_with_rev(&name_with_rev));
+
+
+            println!("{} {}",
+                     Green.bold().paint("↑ Uploading public key"),
+                     public_keyfile.display());
+            let mut progress = ProgressBar::default();
+
+
+
+            match depot_client.put_origin_key(&name, &rev, &public_keyfile, token, Some(&mut progress)) {
+                Ok(()) => {
+                    println!("{} {}", Green.bold().paint("✓ Uploaded"), &name_with_rev);
+                }
+                Err(e @ depot_client::Error::HTTP(Forbidden)) |
+                Err(e @ depot_client::Error::HTTP(Unauthorized)) => {
+                    return Err(Error::from(e));
+                }
+                Err(e @ depot_client::Error::HTTP(_)) => {
+                    debug!("Error uploading public key {}", e);
+                    println!("{} {}",
+                             Yellow.bold()
+                                 .paint("✓ Public key revision already exists in the depot"),
+                             &name_with_rev);
+                }
+                Err(e) => {
+                    return Err(Error::DepotClient(e));
+                }
+            };
+
+            println!("{}",
+                     Blue.paint(format!("★ Upload of public origin key {} complete.",
+                                        &name_with_rev)));
+
+            if with_secret {
+                let secret_keyfile = try!(SigKeyPair::get_secret_key_path(&latest.name_with_rev(),
+                                                                          cache));
+
+                // we already have this value, but get_name_with_rev will also
+                // check the SECRET_SIG_KEY_VERSION
+                let name_with_rev = try!(get_name_with_rev(&secret_keyfile,
+                                                           SECRET_SIG_KEY_VERSION));
+                println!("{} {}",
+                         Green.bold().paint("↑ Uploading secret key"),
+                         secret_keyfile.display());
+                let mut progress = ProgressBar::default();
+                match depot_client.put_origin_secret_key(&name,
+                                                         &rev,
+                                                         &secret_keyfile,
+                                                         token,
+                                                         Some(&mut progress)) {
+                    Ok(()) => {
+
+                        println!("{} {}", Green.bold().paint("✓ Uploaded"), &name_with_rev);
+                        println!("{}",
+                                 Blue.paint(format!("★ Upload of secret origin key {} complete.",
+                                                    &name_with_rev)));
+                    }
+                    Err(e) => {
+                        return Err(Error::DepotClient(e));
+                    }
+                }
+            }
+            Ok(())
+        }
+    }
+
+
+
+
 }

--- a/components/hab/src/command/pkg.rs
+++ b/components/hab/src/command/pkg.rs
@@ -173,7 +173,7 @@ pub mod export {
         use error::{Error, Result};
         use hcore::crypto::default_cache_key_path;
         use hcore::fs::{cache_artifact_path, FS_ROOT_PATH};
-        use hcore::package::{PackageIdent, PackageInstall, Identifiable};
+        use hcore::package::{PackageIdent, PackageInstall};
         use hcore::url::default_depot_url;
         use std::ffi::OsString;
         use std::path::Path;


### PR DESCRIPTION
This PR allows a user to upload public and secret keys to a depot. You MUST have Github Personal Access Token setup for use on the command line. In the Github UI, click "Edit Profile" and then setup a new token with `user:email` scoping. Copy/paste the return value somewhere safe.

```
export HAB_AUTH_TOKEN="xyz" # also, -z or --auth
# upload the latest public key
hab origin key upload core

# upload the latest public AND secret keys
hab origin key upload core -s
```

or

```
export HAB_AUTH_TOKEN="xyz"
# upload a public key by filename
hab origin key upload --pubfile /hab/cache/keys/core-20160423193745.pub 

# upload a public AND secret key by filename
hab origin key upload --pubfile /hab/cache/keys/core-20160423193745.pub --secfile /hab/cache/keys/core-20160423193745.sig.key
```

---

```
root@e6ea30d736fe:/src/components/hab# ./target/debug/hab origin key upload --help
hab-origin-key-upload
Upload origin keys to the depot

USAGE:
    hab origin key upload [FLAGS] [OPTIONS] <ORIGIN|--pubfile <PUBLIC_FILE>>

FLAGS:
    -s, --secret     Upload secret key in addition to the public key
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
    -z, --auth <AUTH_TOKEN>        Authentication token for the Depot
    -u, --url <DEPOT_URL>          Use a specific Depot URL
        --pubfile <PUBLIC_FILE>    Path to a local public origin key file on disk
        --secfile <SECRET_FILE>    Path to a local secret origin key file on disk

ARGS:
    <ORIGIN>    The origin name
```
