### PR TITLE
Adding next step links to marketing articles and fixing footer text

### DIFF
--- a/www/source/about/habitat-and-modern-app.html.slim
+++ b/www/source/about/habitat-and-modern-app.html.slim
@@ -209,3 +209,9 @@ table
         the Habitat package was built. This provides easy integration with
         existing monitoring systems such as Nagios or Sensu, or even with
         entities external to Habitat, such as load balancers.
+
+<hr>
+<ul class="main-content--button-nav">
+  <li><a href="/about/habitat-and-workload-placement" class="button cta">Next - Habitat and Workload Placement</a></li>
+  <li><a href="/about/why-package-automation-with-app">Back - Why Package the App and Its Automation Together?</a></li>
+</ul>

--- a/www/source/about/habitat-and-workload-placement.html.slim
+++ b/www/source/about/habitat-and-workload-placement.html.slim
@@ -126,3 +126,8 @@ p <strong>The workload is the unit of deployment, not the image format</strong>.
 p <strong>All runtime environments are good</strong>. We at Habitat love these runtime
   environments and we want to make sure that Habitat applications can run in all of them.
   Over time, we'll have more and more integrations that will make this easier.
+
+<hr>
+<ul class="main-content--button-nav">
+  <li><a href="/about/habitat-and-modern-app">Back - Habitat and the Modern Application</a></li>
+</ul>

--- a/www/source/about/habitat-genesis.html.slim
+++ b/www/source/about/habitat-genesis.html.slim
@@ -11,7 +11,7 @@ p Chef is an automation company. Ever since it was founded in 2008, we've been
   automation products should address multiple domains and provide a holistic
   view of the environment. Consequently, any company that uses Chef can
   accelerate their velocity and deliver their own digital products quickly and
-  reliably. 
+  reliably.
 
 p Over the years, what we mean by automation has evolved, and its scope has
   widened. We've seen Chef transform from a configuration management platform
@@ -34,7 +34,7 @@ p Companies today have an extensive digital presence, backed by numerous custom
   services rather than a single, monolithic component. This trend toward
   increasingly sophisticated application topologies with complex dependency
   relationships shows no signs of slowing down. It's the source of the
-  complexity crisis in modern application management. 
+  complexity crisis in modern application management.
 
 h2 The complexity crisis in modern application management
 
@@ -64,7 +64,7 @@ p Instead, we should first define what it means for a modern application to be
   end up being under the control of the application itself. The application can
   control how it should respond to dynamic changes in its environment by
   policy, how it should behave when deployed under different topologies, and
-  even how it should control its dependencies. In other words, we get Habitat. 
+  even how it should control its dependencies. In other words, we get Habitat.
 
 h2 Enter Habitat
 
@@ -77,7 +77,7 @@ p Habitat is a new open-source project created by Chef and spearheaded by its
   and to react to changes in that environment. Habitat allows the application
   to be independent of any particular infrastructure environment, such as
   containers or PaaS, and to present a well-defined interface to the outside
-  world that makes commonplace tasks such as monitoring easy to do. 
+  world that makes commonplace tasks such as monitoring easy to do.
 
 p Habitat speaks directly to the problem of complexity <em>and</em>
   high-velocity development. It handles the management tasks that deflect teams
@@ -112,7 +112,7 @@ p Habitat packages can run, unmodified, across a wide variety of runtime
   systems such as Pivotal Cloud Foundry. Independence from the environment is
   important because it lets application developers defer choices about the
   infrastructure until very late in the development cycle, rather than making
-  them early on and letting them dictate the design of the application. 
+  them early on and letting them dictate the design of the application.
 
 h2 Get started today
 
@@ -127,19 +127,9 @@ p Are you ready to solve your company's complexity crisis? Do you want to spend
   up and running quickly.  Habitat is an open source project, and your
   suggestions and contributions are incredibly important. You can find the
   GitHub repo #{link_to 'here', 'https://github.com/habitat-sh/habitat'}. Join
-  us! 
+  us!
 
-h2 For further reading
-
-p Here's a list of additional articles that give you some insight into the
-  philosophy that shaped Habitat's design.
-
-ul
-  li =link_to 'What is a Modern Application?',
-      '/about/what-is-modern-app.html'
-  li =link_to 'Why Package the App and Its Automation Together?',
-      '/about/why-package-automation-with-app.html'
-  li =link_to 'Habitat and the Modern Application',
-      '/about/habitat-and-modern-app.html'
-  li =link_to 'Habitat and Workload Placement',
-      '/about/habitat-and-workload-placement.html'
+<hr>
+<ul class="main-content--button-nav">
+  <li><a href="/about/what-is-modern-app" class="button cta">Next - Why Package the App and Its Automation Together?</a></li>
+</ul>

--- a/www/source/about/what-is-modern-app.html.slim
+++ b/www/source/about/what-is-modern-app.html.slim
@@ -176,3 +176,9 @@ p Habitat provides much of the standard "plumbing" that developers need for
   Instead, developers can spend their time actually writing applications and
   let value to the business guide their design choices. With Habitat, the
   application comes first.
+
+<hr>
+<ul class="main-content--button-nav">
+  <li><a href="/about/why-package-automation-with-app" class="button cta">Next - Why Package the App and Its Automation Together?</a></li>
+  <li><a href="/about/habitat-genesis">Back - The Genesis of Habitat</a></li>
+</ul>

--- a/www/source/about/why-package-automation-with-app.html.slim
+++ b/www/source/about/why-package-automation-with-app.html.slim
@@ -154,3 +154,9 @@ p Packaging automation with the application makes the environment simpler to
   discovery capabilities are built in. Entities can coordinate with each other
   to deploy according to some defined policy rather than relying on a central
   orchestrator that forces entities, one at a time, to abide by that policy.
+
+<hr>
+<ul class="main-content--button-nav">
+  <li><a href="/about/habitat-and-modern-app" class="button cta">Next - Habitat and the Modern Application</a></li>
+  <li><a href="/about/what-is-modern-app">Back - What is a Modern Application?</a></li>
+</ul>

--- a/www/source/layouts/_footer.slim
+++ b/www/source/layouts/_footer.slim
@@ -48,7 +48,7 @@ footer#main-footer class="#{layout_class}"
               li
                 h4 More
               li.footer--sitemap--link
-                a href="/about" About
+                a href="/about" Why Habitat
               li.footer--sitemap--link
                 a href="/community" Community
 


### PR DESCRIPTION
- Added Next and back links to longform artiticles
- Changed footer "About" link text to "Why Habitat"
- Removed extraneous links at bottom of habitat-genesis topic

Signed-off-by: David Wrede dwrede@chef.io
