### PR TITLE
Ignore file with generated blake2b hashes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ tmp/
 *.sig.key
 *.box.key
 *.sym.key
+*blake2b_hashes_list


### PR DESCRIPTION
In commit 122f1b0, we started generating the blake2b checksums of all files in a package to a file in the plan's directory. We should ignore this.

Signed-off-by: jtimberman joshua@chef.io
