### PR TITLE
Corrected some copy errors in Try Habitat

### DIFF
--- a/www/source/try/3.html.slim
+++ b/www/source/try/3.html.slim
@@ -8,7 +8,7 @@ h2.page-body--title Configure the Service Through Environment Variables
 p
   | In the first step, we started up the Redis service and, as you might have noticed, there was
     a warning about the TCP backlog setting. Next, the supervisor informed us
-    that many settings - including the TCP backlog - are configurable.
+    that many settings&mdash;including the TCP backlog&mdash;are configurable.
 
 p
   | With Habitat, there are a couple of ways to make config changes to your service.

--- a/www/source/try/5.html.slim
+++ b/www/source/try/5.html.slim
@@ -11,7 +11,7 @@ p
     out to all of your nodes.
 p
   | Imagine, for a moment, if you could simply apply the change in a single command
-    with each node picking it up automatically... imagine no more! The Habitat
+    with each node picking it up automatically&hellip; imagine no more! The Habitat
     supervisor has it under control so that you can quickly update the entire group.
 p
   | Before we dive into the topic of setting up groups, let's presume
@@ -19,7 +19,7 @@ p
     database instances.
 p
   | Note that the TCP backlog warning is present in the two sample running nodes.
-    Now, go ahead and apply the updated config.toml file by uploading it one of the
+    Now, go ahead and apply the updated config.toml file by uploading it to one of the
     nodes in our service group. Then watch the magic happen as the peers discover
     and apply the change, clearing the TCP backlog issue.
 

--- a/www/source/try/index.html.slim
+++ b/www/source/try/index.html.slim
@@ -14,7 +14,7 @@ p
     download and run existing packages to create services.
 
 p
-  | After staring a service, we'll demonstrate how easy Habitat makes it to inject config changes
+  | After starting a service, we'll demonstrate how easy Habitat makes it to inject config changes
     to a single service and, lastly, how you can automatically cluster the infrastructure
     and apply a change to any number of services regardless of where they are running
     (in containers, VMs, or on bare metal).


### PR DESCRIPTION
Inserted missing letters and words, replaced some characters with HTML
entities. Sorry, after seeing "staring a service" I just couldn't stop myself.

Signed-off-by: Trevor Bramble tbramble@chef.io
