### PR TITLE
Fix some null errors with GitHub accounts

### DIFF
--- a/components/builder-api/src/http/handlers.rs
+++ b/components/builder-api/src/http/handlers.rs
@@ -77,7 +77,9 @@ pub fn session_create(req: &mut Request,
                     let mut request = SessionCreate::new();
                     request.set_token(token);
                     request.set_extern_id(user.id);
-                    request.set_email(user.email);
+                    if let Some(email) = user.email {
+                        request.set_email(email);
+                    }
                     request.set_name(user.login);
                     request.set_provider(OAuthProvider::GitHub);
                     conn.route(&request).unwrap();

--- a/components/depot/src/server.rs
+++ b/components/depot/src/server.rs
@@ -77,7 +77,9 @@ pub fn session_create(depot: &Depot, token: &str) -> result::Result<Session, Res
             let mut request = SessionCreate::new();
             request.set_token(token.to_string());
             request.set_extern_id(user.id);
-            request.set_email(user.email);
+            if let Some(email) = user.email {
+                request.set_email(email);
+            }
             request.set_name(user.login);
             request.set_provider(OAuthProvider::GitHub);
             conn.route(&request).unwrap();

--- a/components/net/src/oauth/github.rs
+++ b/components/net/src/oauth/github.rs
@@ -99,11 +99,11 @@ pub struct User {
     pub events_url: String,
     pub received_events_url: String,
     pub site_admin: bool,
-    pub name: String,
-    pub company: String,
-    pub blog: String,
-    pub location: String,
-    pub email: String,
+    pub name: Option<String>,
+    pub company: Option<String>,
+    pub blog: Option<String>,
+    pub location: Option<String>,
+    pub email: Option<String>,
     pub hireable: Option<bool>,
     pub bio: Option<String>,
     pub public_repos: u32,
@@ -118,7 +118,9 @@ impl From<User> for sessionsrv::Account {
     fn from(user: User) -> sessionsrv::Account {
         let mut account = sessionsrv::Account::new();
         account.set_name(user.login);
-        account.set_email(user.email);
+        if let Some(email) = user.email {
+            account.set_email(email);
+        }
         account
     }
 }


### PR DESCRIPTION
If a GitHub API response contained some null values we would panic. This
changes them to use `Option`s.

Note that we still fail on a null email due to a protobuf failure, but
this can be fixed separately.

![gif-keyboard-10829935538221768277](https://cloud.githubusercontent.com/assets/9912/15982870/50ed353e-2f5a-11e6-98ee-d577532b95af.gif)
