### PR TITLE
Add support for Marathon (Mesos) applications

### DIFF
--- a/components/pkg-mesosize/bin/hab-pkg-mesosize.sh
+++ b/components/pkg-mesosize/bin/hab-pkg-mesosize.sh
@@ -1,0 +1,193 @@
+#!/bin/bash
+#
+# # Usage
+#
+# ```
+# $ hab-pkg-mesosize [PKG ...]
+# ```
+#
+# # Synopsis
+#
+# Create a Mesos application from a set of Habitat packages.
+#
+# # License and Copyright
+#
+# ```
+# Copyright: Copyright (c) 2016 Chef Software, Inc.
+# License: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ```
+
+# defaults for the application
+: ${CPU:="0.5"}
+: ${DISK:="0"}
+: ${INSTANCES:="1"}
+: ${MEM:="256"}
+: ${PKG:="unknown"}
+
+# Fail if there are any unset variables and whenever a command returns a
+# non-zero exit code.
+set -eu
+
+# If the variable `$DEBUG` is set, then print the shell commands as we execute.
+if [ -n "${DEBUG:-}" ]; then
+  set -x
+  export DEBUG
+fi
+
+# ## Help
+
+# **Internal** Prints help
+print_help() {
+  printf -- "$program $version
+
+$author
+
+Habitat Package Mesosize - Create a Mesos application from a set of Habitat packages
+
+USAGE:
+  $program [FLAGS] [OPTIONS] <PKG_IDENT>
+
+FLAGS:
+    --help           Prints help information
+
+OPTIONS:
+    --cpu=N          CPUs for the application (float, .5 is default)
+    --disk=N         Disk Space for the application (0 is default)
+    --instances=N    Number of application instances to launch (1 is default)
+    --mem=N          Memory for the application (MB, 256 is default)
+
+ARGS:
+    <PKG_IDENT>      Habitat package identifier (ex: acme/redis)
+"
+}
+
+# **Internal** Exit the program with an error message and a status code.
+#
+# ```sh
+# exit_with "Something bad went down" 55
+# ```
+exit_with() {
+  case "${TERM:-}" in
+    *term | xterm-* | rxvt | screen | screen-*)
+      printf -- "\033[1;31mERROR: \033[1;37m$1\033[0m\n"
+      ;;
+    *)
+      printf -- "ERROR: $1\n"
+      ;;
+  esac
+  exit $2
+}
+
+find_system_commands() {
+  if $(mktemp --version 2>&1 | grep -q 'GNU coreutils'); then
+    _mktemp_cmd=$(command -v mktemp)
+  else
+    if $(/bin/mktemp --version 2>&1 | grep -q 'GNU coreutils'); then
+      _mktemp_cmd=/bin/mktemp
+    else
+      exit_with "We require GNU mktemp to build Mesos applications; aborting" 1
+    fi
+  fi
+}
+
+# parse the CLI flags and options
+parse_options() {
+  for i in "$@"
+  do
+    case $i in
+      --help)
+        print_help
+        exit
+        ;;
+      --cpu=*)
+        CPU="${i#*=}"
+        shift
+        ;;
+      --disk=*)
+        DISK="${i#*=}"
+        shift
+        ;;
+      --instances=*)
+        INSTANCES="${i#*=}"
+        shift
+        ;;
+      --mem=*)
+        MEM="${i#*=}"
+        shift
+        ;;
+      *)
+        PKG=${i}
+        ;;
+    esac
+  done
+  if [ "$PKG" == "unknown" ]; then
+    print_help
+    exit_with "You must specify one or more Habitat packages to Mesosize." 1
+  fi
+}
+
+# Create a hab studio baseimage and populate it with the application
+build_tarball_image() {
+  TARBALL_CONTEXT="$($_mktemp_cmd -t -d "${program}-XXXX")"
+  pushd $TARBALL_CONTEXT > /dev/null
+  env PKGS="$PKG" NO_MOUNT=1 hab studio -r $TARBALL_CONTEXT -t bare new
+  echo $PKG > $TARBALL_CONTEXT/.hab_pkg
+  popd > /dev/null
+  tar -czpf $(package_name_with_version $PKG).tgz -C $TARBALL_CONTEXT ./
+}
+
+package_name_with_version() {
+  local ident_file=$(find $TARBALL_CONTEXT/$HAB_ROOT_PATH/pkgs/$PKG -name IDENT)
+  cat $ident_file | awk 'BEGIN { FS = "/" }; { print $1 "-" $2 "-" $3 "-" $4 }'
+}
+
+# https://mesosphere.github.io/marathon/docs/application-basics.html
+create_application_definition() {
+  echo "
+  {
+   \"id\": \"$PKG\",
+   \"cmd\": \"/bin/id -u hab &>/dev/null || /sbin/useradd hab; /bin/chown -R hab:hab *; mount -t proc proc proc/; mount -t sysfs sys sys/;mount -o bind /dev dev/; /usr/sbin/chroot . ./init.sh start $PKG\",
+   \"cpus\": $CPU,
+   \"disk\": $DISK,
+   \"mem\": $MEM,
+   \"instances\": $INSTANCES,
+   \"uris\": [ \"URL_TO_$(package_name_with_version $PKG).tgz\" ]
+  }
+"
+  # what about exposing ports?
+  }
+
+# The root of the filesystem. If the program is running on a seperate
+# filesystem or chroot environment, this environment variable may need to be
+# set.
+: ${FS_ROOT:=}
+# The root path of the Habitat file system. If the `$HAB_ROOT_PATH` environment
+# variable is set, this value is overridden, otherwise it is set to its default
+: ${HAB_ROOT_PATH:=$FS_ROOT/hab}
+
+# The current version of Habitat Studio
+version='@version@'
+# The author of this program
+author='@author@'
+# The short version of the program name which is used in logging output
+program=$(basename $0)
+
+find_system_commands
+
+parse_options $@
+build_tarball_image
+# publish the tarball somewhere? upload_tarball_to_artifact_store?
+create_application_definition
+rm -rf $TARBALL_CONTEXT

--- a/components/pkg-mesosize/plan.sh
+++ b/components/pkg-mesosize/plan.sh
@@ -1,0 +1,45 @@
+pkg_name=hab-pkg-mesosize
+pkg_origin=core
+pkg_version=0.1.0
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=('Apache-2.0')
+pkg_source=nosuchfile.tar.gz
+pkg_deps=(core/coreutils core/findutils core/gawk core/grep core/bash core/tar core/gzip core/hab-static core/hab-studio)
+pkg_build_deps=()
+pkg_bin_dirs=(bin)
+
+program=$pkg_name
+
+do_build() {
+  cp -v $PLAN_CONTEXT/bin/${program}.sh ${program}
+
+  # Use the bash from our dependency list as the shebang. Also, embed the
+  # release version of the program.
+  sed \
+    -e "s,#!/bin/bash$,#!$(pkg_path_for bash)/bin/bash," \
+    -e "s,@author@,$pkg_maintainer,g" \
+    -e "s,@version@,$pkg_version/$pkg_release,g" \
+    -i $program
+}
+
+do_install() {
+  install -v -D $program $pkg_prefix/bin/$program
+}
+
+# Turn the remaining default phases into no-ops
+
+do_download() {
+  return 0
+}
+
+do_verify() {
+  return 0
+}
+
+do_unpack() {
+  return 0
+}
+
+do_prepare() {
+  return 0
+}

--- a/components/studio/libexec/hab-studio-type-bare.sh
+++ b/components/studio/libexec/hab-studio-type-bare.sh
@@ -1,0 +1,116 @@
+studio_type="bare"
+studio_path="$HAB_ROOT_PATH/bin"
+studio_enter_environment=
+studio_build_environment=
+studio_build_command=
+studio_run_environment=
+studio_run_command=
+
+base_pkgs="core/hab-static core/hab-sup"
+: ${PKGS:=}
+
+run_user="hab"
+run_group="$run_user"
+
+finish_setup() {
+  if [ -h "$HAB_STUDIO_ROOT$HAB_ROOT_PATH/bin/hab" ]; then
+    return 0
+  fi
+
+  for embed in $PKGS; do
+    if [ -d "$HAB_PKG_PATH/$embed" ]; then
+      echo "> Using local package for $embed"
+      embed_path=$(_outside_pkgpath_for $embed)
+      $bb mkdir -p $HAB_STUDIO_ROOT/$embed_path
+      $bb cp -ra $embed_path/* $HAB_STUDIO_ROOT/$embed_path
+      for tdep in $($bb cat $embed_path/TDEPS); do
+        echo "> Using local package for $tdep via $embed"
+        $bb mkdir -p $HAB_STUDIO_ROOT$HAB_PKG_PATH/$tdep
+        $bb cp -ra $HAB_PKG_PATH/$tdep/* $HAB_STUDIO_ROOT$HAB_PKG_PATH/$tdep
+      done
+    else
+      _hab install $embed
+    fi
+  done
+
+  for pkg in $base_pkgs; do
+    _hab install $pkg
+  done
+
+  local hab_path=$(_pkgpath_for core/hab-static)
+  local sup_path=$(_pkgpath_for core/hab-sup)
+  local busybox_path=$(_pkgpath_for core/busybox-static)
+
+  local full_path=""
+  for path_pkg in $PKGS core/hab-sup core/busybox-static; do
+    local path_file="$HAB_STUDIO_ROOT/$(_pkgpath_for $path_pkg)/PATH"
+    if [ -f "$path_file" ]; then
+      if [ -z "$full_path" ]; then
+        full_path="$($bb cat $path_file)"
+      else
+        full_path="$full_path:$($bb cat $path_file)"
+      fi
+    fi
+
+    local tdeps_file="$HAB_STUDIO_ROOT/$(_pkgpath_for $path_pkg)/TDEPS"
+    if [ -f "$tdeps_file" ]; then
+      for tdep in $($bb cat $tdeps_file); do
+        local tdep_path_file="$HAB_STUDIO_ROOT/$(_pkgpath_for $tdep)/PATH"
+        if [ -f "$tdep_path_file" ]; then
+          full_path="$full_path:$($bb cat $tdep_path_file)"
+        fi
+      done
+    fi
+  done
+  full_path="$full_path:$HAB_ROOT_PATH/bin"
+
+  studio_path="$full_path"
+  studio_enter_command="${busybox_path}/bin/sh --login"
+
+  $bb mkdir -p $v $HAB_STUDIO_ROOT$HAB_ROOT_PATH/bin
+
+  # Put `hab` on the default `$PATH`
+  _hab pkg binlink --dest $HAB_ROOT_PATH/bin core/hab-static hab
+
+  # Create `/bin/{sh,bash}` for software that hardcodes these shells
+  _hab pkg binlink core/busybox-static bash
+  _hab pkg binlink core/busybox-static sh
+
+  # Set the login shell for any relevant user to be `/bin/bash`
+  $bb sed -e "s,/bin/sh,$busybox_path/bin/bash,g" -i $HAB_STUDIO_ROOT/etc/passwd
+
+  echo "${run_user}:x:42:42:root:/:/bin/sh" >> $HAB_STUDIO_ROOT/etc/passwd
+  echo "${run_group}:x:42:${run_user}" >> $HAB_STUDIO_ROOT/etc/group
+
+  local sup="$HAB_ROOT_PATH/bin/hab sup"
+  $bb touch $HAB_STUDIO_ROOT/.hab_pkg
+  $bb cat <<EOT > $HAB_STUDIO_ROOT/init.sh
+#!$busybox_path/bin/sh
+export PATH=$full_path
+case \$1 in
+  -h|--help|help|-V|--version) exec $sup "\$@";;
+  -*) exec $sup start \$(cat /.hab_pkg) "\$@";;
+  *) exec $sup "\$@";;
+esac
+EOT
+  $bb chmod a+x $HAB_STUDIO_ROOT/init.sh
+
+  $bb rm -f $HAB_STUDIO_ROOT$HAB_CACHE_ARTIFACT_PATH/*
+
+  # remove the unnecessary supporting filesystem
+  $bb rm -rf $HAB_STUDIO_ROOT/home $HAB_STUDIO_ROOT/lib $HAB_STUDIO_ROOT/lib64 $HAB_STUDIO_ROOT/mnt $HAB_STUDIO_ROOT/opt $HAB_STUDIO_ROOT/root $HAB_STUDIO_ROOT/run $HAB_STUDIO_ROOT/sbin $HAB_STUDIO_ROOT/src $HAB_STUDIO_ROOT/usr
+
+  studio_env_command="$busybox_path/bin/env"
+}
+
+_hab() {
+  $bb env FS_ROOT=$HAB_STUDIO_ROOT $hab $*
+}
+
+_pkgpath_for() {
+  _hab pkg path $1 | $bb sed -e "s,^$HAB_STUDIO_ROOT,,g"
+}
+
+_outside_pkgpath_for() {
+  $hab pkg path $1
+}


### PR DESCRIPTION
Mesos can use docker but the native format is a filesystem sandbox with cgroups and namespaces. hab-pkg-mesosize creates a mostly empty hab-studio and packages it into a tarball. hab-pkg-mesosize provides the JSON syntax for loading the application into Marathon via the UI, documentation to be provided in a separate PR. The tarball still needs an accessible URL, that may be done manually or investigated in a later PR for pushing it into Mesos' artifact store. Networking is not addressed in the current format either.
