### PR TITLE
[core] Return Err in `PackageInstall::load` when pkg path not present.

### DIFF
--- a/components/core/src/package/install.rs
+++ b/components/core/src/package/install.rs
@@ -39,6 +39,9 @@ impl PackageInstall {
     pub fn load(ident: &PackageIdent, fs_root_path: Option<&Path>) -> Result<PackageInstall> {
         let fs_root_path = fs_root_path.unwrap_or(Path::new("/"));
         let package_root_path = fs_root_path.join(PKG_PATH);
+        if !package_root_path.exists() {
+            return Err(Error::PackageNotFound(ident.clone()));
+        }
         let pl = try!(Self::package_list(&package_root_path));
         if ident.fully_qualified() {
             if pl.iter().any(|ref p| p.satisfies(ident)) {


### PR DESCRIPTION
Checking for the `/hab/pkgs` directory hasn't been a concern until we
started producing a portable `hab` CLI binary which doesn't necessarily
run inside a Habitat package itself. The package install detection logic
was initially running under the assumption that it was a Supervisor and
hence properly installed as a Habitat package. Then our glibc/dynamic
version of `hab` had the same set of assumptions (i.e. that it was
running in a Habitat package, hence the parent directories would exist).

This fix performs an early return if the package root path does not
exist which is accurate: no Habitat packages will exist so there's no
more detection work to do!

Closes #736
