### PR TITLE
[hab] Promote a `hab setup` alias for `hab cli setup`.

### DIFF
--- a/components/hab/src/analytics.rs
+++ b/components/hab/src/analytics.rs
@@ -45,6 +45,7 @@
 //! * `pkg build`
 //! * `ring key generate`
 //! * `service key generate`
+//! * `setup`
 //! * `studio build`
 //! * `studio enter`
 //! * `user key generate`
@@ -62,6 +63,7 @@
 //! * `install`
 //! * `origin key upload`
 //! * `pkg install`
+//! * `setup`
 //!
 //! For all other subcommands, even those which report events, the event payload is saved to a
 //! cached file under the analytics cache directory (`/hab/cache/analytics` for a root user and
@@ -314,7 +316,7 @@ pub fn instrument_clap_error(err: &clap::Error) {
         }
         // Match against subcommands which are 1 levels deep or anything else remaining. This match
         // arm appears last because it "slurps" up all remaining cases with `_`.
-        "apply" | "install" | _ => {
+        "apply" | "install" | "setup" | _ => {
             record_event(Event::CliError,
                          &format!("{:?}--{}--{}", err.kind, PRODUCT, arg1))
         }

--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -23,6 +23,9 @@ pub fn get() -> App<'static, 'static> {
         .about("Alias for 'pkg install'")
         .aliases(&["i", "in", "ins", "inst", "insta", "instal"])
         .setting(AppSettings::Hidden);
+    let alias_setup = sub_cli_setup()
+        .about("Alias for 'cli setup'")
+        .aliases(&["set", "setu"]);
     let alias_start = alias_start().aliases(&["st", "sta", "star"]);
 
     clap_app!(hab =>
@@ -253,11 +256,13 @@ pub fn get() -> App<'static, 'static> {
         )
         (subcommand: alias_apply)
         (subcommand: alias_install)
+        (subcommand: alias_setup)
         (subcommand: alias_start)
-        (after_help: "ALIASES:\
-            \n    apply       Alias for: 'config apply'\
-            \n    install     Alias for: 'pkg install'\
-            \n    start       Alias for: 'sup start'\
+        (after_help: "\nALIASES:\
+            \n    apply      Alias for: 'config apply'\
+            \n    install    Alias for: 'pkg install'\
+            \n    setup      Alias for: 'cli setup'\
+            \n    start      Alias for: 'sup start'\
             \n"
         )
     )

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -168,6 +168,7 @@ fn start() -> Result<()> {
                 _ => unreachable!(),
             }
         }
+        ("setup", Some(_)) => try!(sub_cli_setup()),
         ("user", Some(matches)) => {
             match matches.subcommand() {
                 ("key", Some(m)) => {


### PR DESCRIPTION
![gif-keyboard-15634223486332435522](https://cloud.githubusercontent.com/assets/261548/15988074/4fdc32e8-3000-11e6-81de-c655740b69d7.gif)
