### PR TITLE
Remove organization from director configurations

### DIFF
--- a/terraform/templates/gateway-director.toml
+++ b/terraform/templates/gateway-director.toml
@@ -1,5 +1,5 @@
-[cfg.services.core.redis.${env}.habitat]
+[cfg.services.core.redis.${env}]
 start = "--permanent-peer --peer ${peer_ip}:9000"
 
-[cfg.services.core.hab-builder-api.${env}.habitat]
+[cfg.services.core.hab-builder-api.${env}]
 start = "--permanent-peer --bind database:redis.${env},router:hab-builder-router.${env} --peer ${peer_ip}:9000"

--- a/terraform/templates/router-director.toml
+++ b/terraform/templates/router-director.toml
@@ -1,2 +1,2 @@
-[cfg.services.core.hab-builder-router.${env}.habitat]
+[cfg.services.core.hab-builder-router.${env}]
 start = "--permanent-peer"

--- a/terraform/templates/services-director.toml
+++ b/terraform/templates/services-director.toml
@@ -1,11 +1,11 @@
-[cfg.services.core.redis.${env}.habitat]
+[cfg.services.core.redis.${env}]
 start = "--permanent-peer --peer ${peer_ip}:9000"
 
-[cfg.services.core.hab-builder-jobsrv.${env}.habitat]
+[cfg.services.core.hab-builder-jobsrv.${env}]
 start = "--permanent-peer --bind database:redis.${env},router:hab-builder-router.${env} --peer ${peer_ip}:9000"
 
-[cfg.services.core.hab-builder-sessionsrv.${env}.habitat]
+[cfg.services.core.hab-builder-sessionsrv.${env}]
 start = "--permanent-peer --bind database:redis.${env},router:hab-builder-router.${env} --peer ${peer_ip}:9000"
 
-[cfg.services.core.hab-builder-vault.${env}.habitat]
+[cfg.services.core.hab-builder-vault.${env}]
 start = "--permanent-peer --bind database:redis.${env},router:hab-builder-router.${env} --peer ${peer_ip}:9000"

--- a/terraform/templates/worker-director.toml
+++ b/terraform/templates/worker-director.toml
@@ -1,2 +1,2 @@
-[cfg.services.core.hab-builder-worker.${env}.habitat]
+[cfg.services.core.hab-builder-worker.${env}]
 start = "--permanent-peer --bind jobsrv:hab-builder-jobsrv.${env} --peer ${peer_ip}:9000"


### PR DESCRIPTION
Gossip information doesn't seem to be shared between supervisors when an organization is specified

Signed-off-by: Jamie Winsor jamie@vialstudios.com
