### PR TITLE
[hab/mac] Update go-live Docker Studio image to the Bintray repo.

### DIFF
--- a/components/hab/src/command/studio.rs
+++ b/components/hab/src/command/studio.rs
@@ -79,7 +79,7 @@ mod inner {
     const DOCKER_CMD: &'static str = "docker";
     const DOCKER_CMD_ENVVAR: &'static str = "HAB_DOCKER_BINARY";
 
-    const DOCKER_IMAGE: &'static str = "habitat/studio";
+    const DOCKER_IMAGE: &'static str = "habitat-docker-registry.bintray.io/studio";
     const DOCKER_IMAGE_ENVVAR: &'static str = "HAB_DOCKER_STUDIO_IMAGE";
 
     pub fn start(args: Vec<OsString>) -> Result<()> {


### PR DESCRIPTION
This change updates the default Docker to:

  habitat-docker-registry.bintray.io/studio

The default value can still be overridden by setting the
`HAB_DOCKER_STUDIO_IMAGE` environment variable.

![gif-keyboard-15810608306039675544](https://cloud.githubusercontent.com/assets/261548/15988955/a2aad968-3021-11e6-899d-95b4f1c2b8c8.gif)
