### PR TITLE
Allow pasting in try habitat

### DIFF
--- a/www/source/javascripts/try.js
+++ b/www/source/javascripts/try.js
@@ -388,4 +388,11 @@ $("#mobile-keyboard-trigger").click(function() {
         $(".window-node").hide();
         $("#" + targetID).show();
     });
+
+    // Hack to allow pasting.
+    // See https://github.com/sdether/josh.js/issues/28
+    $("#shell-panel").pastableNonInputable();
+    $("#shell-panel").on("pasteText", function (event, data) {
+        shell.addText(data.text);
+    });
 }());


### PR DESCRIPTION
This took some ugly hacks, and the cursor doesn't move to the end when
you paste, but I think people would be turned off by not being able to
paste.

We can turn this off when we produce "Try Habitat the Hard Way"

![gif-keyboard-2193518170989423815](https://cloud.githubusercontent.com/assets/9912/15989035/4ab763a4-302e-11e6-9fd0-1fbc384673d7.gif)
