### PR TITLE
Update the homu webhook to hit the IP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -170,4 +170,4 @@ notifications:
     on_failure: always
     on_success: change
     secure: FjTKlrpHSKlUktFSf9W6ANmxWujelaN4bPRletBXkNwmZYwpqN1YC4lFwS16X0J6kNyvHGRva018YsUMtwI/FXtHH3YliyxCivmEoeAlZa+jMdy16pmBGhxo+mPC92SnHt1DhXfQUTstWw3h+Lq2F2MfwrB8k+nVBFJjfrF8HY0=
-  webhooks: http://willem.habitat.sh:54856/travis
+  webhooks: http://52.37.151.35:54856/travis


### PR DESCRIPTION
So we don't break when we swtich. Old willem can be old homu, until we
move it all to heroku.

![gif-keyboard-8414425535106328846](https://cloud.githubusercontent.com/assets/4304/15989282/e19fefb8-3027-11e6-9c08-e9973d58c16a.gif)

Signed-off-by: Adam Jacob adam@chef.io
