### PR TITLE
Update JDK8 to patch all binaries instead of just the java binary

### DIFF
--- a/plans/jdk8/plan.sh
+++ b/plans/jdk8/plan.sh
@@ -8,7 +8,7 @@ pkg_filename=jdk-${pkg_version}-linux-x64.tar.gz
 pkg_license=('Oracle Binary Code License Agreement for the Java SE Platform Products and JavaFX')
 pkg_description=('Oracle Java Development Kit. This package is made available to you to allow you to run your applications as provided in and subject to the terms of the Oracle Binary Code License Agreement for the Java SE Platform Products and JavaFX, found at http://www.oracle.com/technetwork/java/javase/terms/license/index.html')
 pkg_deps=(core/glibc)
-pkg_build_deps=(core/patchelf)
+pkg_build_deps=(core/patchelf core/file)
 pkg_bin_dirs=(bin jre/bin)
 pkg_lib_dirs=(lib)
 pkg_include_dirs=(include)
@@ -64,7 +64,8 @@ do_install() {
   build_line "Setting rpath for '${pkg_prefix}/bin/java' to '$LD_RUN_PATH'"
 
   export LD_RUN_PATH=$LD_RUN_PATH:$pkg_prefix/lib/amd64/jli
-  patchelf --interpreter "$(pkg_path_for glibc)/lib/ld-linux-x86-64.so.2" \
-           --set-rpath ${LD_RUN_PATH} \
-           ${pkg_prefix}/bin/java
+
+  find $pkg_prefix/bin -type f -executable \
+    -exec sh -c "file -i '{}' | grep -q 'x-executable; charset=binary'" \; \
+    -exec patchelf --interpreter "$(pkg_path_for glibc)/lib/ld-linux-x86-64.so.2" --set-rpath ${LD_RUN_PATH} {} \;
 }


### PR DESCRIPTION
Signed-off-by: Elliott Davis edavis@chef.io
