### PR TITLE
Adds banner announcement for bignews/live stream

### DIFF
--- a/www/source/layouts/_message.slim
+++ b/www/source/layouts/_message.slim
@@ -1,0 +1,2 @@
+#global_message
+  <a href="https://bignews.chef.io"><strong>Join us for a live announcement on June 14th at 8:30am PDT.</strong> Learn more.</a>

--- a/www/source/layouts/_nav.slim
+++ b/www/source/layouts/_nav.slim
@@ -1,4 +1,5 @@
 #main-nav class="#{layout_class}"
+  = partial "layouts/message"
   .main-nav--container.clearfix
     .main-nav--logo
       a href="/"

--- a/www/source/stylesheets/_global.scss
+++ b/www/source/stylesheets/_global.scss
@@ -11,6 +11,7 @@
 //  6. Images
 //  7. Callout Boxes
 //  8. Anchor Links
+//  9. Global Message
 
 
 // 1. Global
@@ -279,4 +280,19 @@ ol.lower-alpha {
   width: 0;
   height: 7em;
   margin-top: -7em;
+}
+
+// 9. Global Message
+// ---------
+
+#global_message {
+  background-color: $hab-green;
+  color: $white;
+  text-align: center;
+  padding: rem-calc(10) rem-calc(60);
+
+  a {
+    color: $white;
+    font-size: rem-calc(14);
+  }
 }


### PR DESCRIPTION
This adds a static banner message that points to http://bignews.chef.io
I'll open a second PR that removed the banner and have it ready for merge once the event ends.

After the video presentation finishes encoding (later in the day), we can open a 3rd PR that embed the video (which will be on YouTube) in the /about area of the site (perhaps as a new link in the left nav below Why Habitat? > Overview

<img width="1239" alt="screenshot 2016-06-13 11 52 53" src="https://cloud.githubusercontent.com/assets/446285/16019360/6b582046-315d-11e6-9a6d-df4cba960e2e.png">

Signed-off-by: Ryan Keairns rkeairns@chef.io
