### PR TITLE
Removes slide down nav on docs, tutorials, why

### DIFF
--- a/www/source/javascripts/nav.js
+++ b/www/source/javascripts/nav.js
@@ -1,5 +1,5 @@
 const navBreakpoint = 710;
-const $mainNav = $('#main-nav');
+const $mainNav = $('#main-nav:not(.has-sidebar)');
 const $navLinks = $('.main-nav--links');
 const $navToggle = $('.main-nav--toggle');
 const currentPagePath = location.pathname;


### PR DESCRIPTION
Feedback has indicated that the slide down nav is interfering with the reading experience on docs and tutorials. The quickest fix was to remove the slide down feature on all pages that have a sidebar (/docs, /tutorial, /why-habitat). 

We'll keep it on the home page so that the main call-to-action is always present (especially to new users / people reading the home page).

Signed-off-by: Ryan Keairns rkeairns@chef.io
