### PR TITLE
Correct syntax help in clap

### DIFF
--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -55,7 +55,7 @@ pub fn get() -> App<'static, 'static> {
                 (about: "Upload a file to the supervisor ring.")
                 (aliases: &["u", "up", "upl", "uplo", "uploa"])
                 (@arg SERVICE_GROUP: +required +takes_value {valid_service_group}
-                    "Target service group for this injection (ex: redis.default)")
+                    "Target service group (ex: redis.default)")
                 (@arg FILE: +required {file_exists} "Path to local file on disk")
                 (@arg VERSION_NUMBER: +required
                     "A version number (positive integer) for this configuration (ex: 42)")
@@ -227,7 +227,7 @@ pub fn get() -> App<'static, 'static> {
                 (@subcommand generate =>
                     (about: "Generates a Habitat service key")
                     (aliases: &["g", "ge", "gen", "gene", "gener", "genera", "generat"])
-                    (@arg SERVICE_GROUP: +required +takes_value {valid_service_group} "Target service group for this injection (ex: redis.default)")
+                    (@arg SERVICE_GROUP: +required +takes_value {valid_service_group} "Target service group (ex: redis.default)")
                     (@arg ORG: "The service organization")
                 )
             )
@@ -291,7 +291,7 @@ fn sub_config_apply() -> App<'static, 'static> {
         (@arg RING: -r --ring +takes_value
             "Ring key name, which will encrypt communication messages")
         (@arg SERVICE_GROUP: +required {valid_service_group}
-            "Target service group for this injection (ex: redis.default)")
+            "Target service group (ex: redis.default)")
         (@arg VERSION_NUMBER: +required
             "A version number (positive integer) for this configuration (ex: 42)")
         (@arg FILE: {file_exists_or_stdin}

--- a/www/source/docs/reference/habitat-cli.html.md
+++ b/www/source/docs/reference/habitat-cli.html.md
@@ -97,7 +97,7 @@ Applies configuration to a group of Habitat supervisors.
 
 **ARGS**
 
-    <SERVICE_GROUP>     Target service group for this injection (ex: redis.default)
+    <SERVICE_GROUP>     Target service group (ex: redis.default)
     <VERSION_NUMBER>    A version number (positive integer) for this configuration (ex: 42)
     <FILE>              Path to local file on disk (ex: /tmp/config.toml, default: <stdin>)
 
@@ -122,7 +122,7 @@ Upload a file to a supervisor ring.
 
 **ARGS**
 
-    <SERVICE_GROUP>     Target service group for this injection (ex: redis.default)
+    <SERVICE_GROUP>     Target service group (ex: redis.default)
     <FILE>              Path to local file on disk
     <VERSION_NUMBER>    A version number (positive integer) for this configuration (ex: 42)
     <USER>              Name of the user key
@@ -451,7 +451,7 @@ Generates a Habitat service key
 
 **ARGS**
 
-    <SERVICE_GROUP>    Target service group for this injection (ex: redis.default)
+    <SERVICE_GROUP>    Target service group (ex: redis.default)
     <ORG>              The service organization
 
 <h2 id="hab-studio" class="anchor">hab studio</h2>


### PR DESCRIPTION
- Make sure we don't show "hab setup" twice: once in the aliases list, once in the main commands.
- Wrap long lines that roll off the end of the syntax ref so you can actually read them all.
- Catch up on --org option added in PR #789.
