### PR TITLE
Fix sign-in button and footer styles; add Google Analytics snippet

### DIFF
--- a/components/builder-web/app/app.scss
+++ b/components/builder-web/app/app.scss
@@ -56,7 +56,7 @@ body {
 .hab-container {
   @include outer-container;
   max-width: rem(1200);
-  min-height: 100%;
+  min-height: 70vh;
 }
 
 .hab-main {
@@ -64,7 +64,6 @@ body {
   background-color: $white;
   border-radius: 0 0 $global-radius $global-radius;
   height: 100%;
-  min-height: 75vh;
   position: relative;
   z-index: 50;
 
@@ -76,7 +75,6 @@ body {
     }
 
     @include span-columns(12);
-    min-height: inherit;
   }
 }
 
@@ -106,6 +104,7 @@ body {
 
 .page-body {
   padding: rem(30) rem(20);
+  min-height: 50vh;
 
   &.has-sidebar {
     @include outer-container;
@@ -116,6 +115,10 @@ body {
       margin-bottom: rem(15);
       text-align: center;
     }
+  }
+
+  .hab-sign-in & {
+    min-height: inherit;
   }
 }
 

--- a/components/builder-web/app/sign-in-page/SignInPageComponent.ts
+++ b/components/builder-web/app/sign-in-page/SignInPageComponent.ts
@@ -36,7 +36,7 @@ import {createGitHubLoginUrl, icon} from "../util";
                     </span>
                 </a>
                 <a *ngIf="isSignedIn"
-                   class="button secondary hab-sign-in--out"
+                   class="button hab-sign-in--out"
                    (click)="signOut()"
                    href="#">
                    Sign Out

--- a/components/builder-web/index.html
+++ b/components/builder-web/index.html
@@ -10,6 +10,15 @@
     <base href="/">
   </head>
   <body>
+    <!-- Google Tag Manager -->
+    <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-5VR24H"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-5VR24H');</script>
+    <!-- End Google Tag Manager -->
     <hab>
     <script>
         window.Habitat = { config: {} };


### PR DESCRIPTION
When logged in, the sign out button had mixed green and orange colors - this make sit all green again.
Also while on the sign-in page, the footer was floating above the bottom of the screen due to the short content... this pushes it down.

Unrelated, we needed to add the Google Tag Manager snippet (missed that earlier).

Signed-off-by: Ryan Keairns rkeairns@chef.io
