### PR TITLE
append environment names to terraform resources

### DIFF
--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -1,6 +1,6 @@
 resource "aws_route53_record" "app" {
     zone_id = "${var.dns_zone_id}"
-    name    = "app"
+    name    = "app-${var.env}"
     type    = "CNAME"
     ttl     = "300"
     records = ["${aws_elb.builder_api.dns_name}"]
@@ -8,7 +8,7 @@ resource "aws_route53_record" "app" {
 
 resource "aws_route53_record" "willem" {
     zone_id = "${var.dns_zone_id}"
-    name    = "willem"
+    name    = "willem-${var.env}"
     type    = "CNAME"
     ttl     = "300"
     records = ["${aws_elb.builder_api.dns_name}"]


### PR DESCRIPTION
Append the environment to the name of the resources.

Signed-off-by: Christopher Webber cwebber@chef.io
