### PR TITLE
Fix default nav behavior

### DIFF
--- a/www/source/javascripts/nav.js
+++ b/www/source/javascripts/nav.js
@@ -1,5 +1,5 @@
 const navBreakpoint = 710;
-const $mainNav = $('#main-nav:not(.has-sidebar)');
+const $mainNav = $('#main-nav');
 const $navLinks = $('.main-nav--links');
 const $navToggle = $('.main-nav--toggle');
 const currentPagePath = location.pathname;
@@ -8,13 +8,15 @@ const stickyBreakpoint = 120;
 const stickyVisibleBreakpoint = 160;
 
 var toggleStickyNav = function() {
-  if ($(window).width() > navBreakpoint) {
-    $mainNav.toggleClass('is-sticky', $(window).scrollTop() > stickyBreakpoint);
-    $mainNav.toggleClass('is-visible', $(window).scrollTop() > stickyVisibleBreakpoint);
-    $('#content-outer').toggleClass('has-sticky-nav', $(window).scrollTop() > stickyBreakpoint);
-  } else {
-    $mainNav.removeClass('is-visible');
-    $mainNav.toggleClass('is-sticky', $(window).scrollTop() > 0);
+  if ($mainNav.is(":not(.has-sidebar)")) {
+    if ($(window).width() > navBreakpoint) {
+      $mainNav.toggleClass('is-sticky', $(window).scrollTop() > stickyBreakpoint);
+      $mainNav.toggleClass('is-visible', $(window).scrollTop() > stickyVisibleBreakpoint);
+      $('#content-outer').toggleClass('has-sticky-nav', $(window).scrollTop() > stickyBreakpoint);
+    } else {
+      $mainNav.removeClass('is-visible');
+      $mainNav.toggleClass('is-sticky', $(window).scrollTop() > 0);
+    }
   }
 };
 


### PR DESCRIPTION
Fixes some buggy behavior that was caused by changing the $mainNav
definition to :not(.has-sidebar). Instead removes the has-sidebar
pages in the logic of the sticky function.
