### PR TITLE
Updated docs to reflect GH auth support in cli setup

### DIFF
--- a/www/source/docs/create-plans.html.md.erb
+++ b/www/source/docs/create-plans.html.md.erb
@@ -49,7 +49,7 @@ To create a plan, do the following:
 
 2. All plans must have a `plan.sh` at the root of the plan context. This file will be used by the hab-plan-build command to build your package, so create a plan.sh file in your plan context and open it.
 
-       touch plan.sh && $EDITOR plan.sh
+       $EDITOR plan.sh
 
 3. Copy the following template into plan.sh. You can use it as a skeleton template when writing new plans.
 

--- a/www/source/docs/share-packages-overview.html.md
+++ b/www/source/docs/share-packages-overview.html.md
@@ -18,7 +18,7 @@ We will use the public depot provided by the Habitat project for this section. H
 
 ## Creating an account in the depot
 
-The depot software presently only supports GitHub authentication. For the public depot, you visit https://app.habitat.sh/ in your browser and sign up for an account, allowing it to use GitHub for authorization.
+The depot software presently only supports GitHub authentication. For the public depot, visit https://app.habitat.sh/ in your browser and sign up for an account. Allow it to use GitHub for authorization.
 
 ## Creating an origin or joining an existing origin
 

--- a/www/source/shared/_setup_environment.html.md.erb
+++ b/www/source/shared/_setup_environment.html.md.erb
@@ -19,6 +19,6 @@ The `hab` command-line interface (CLI) tool downloads its other components when 
        docker-machine start
        eval "$(docker-machine env machinename)"
 
-5. Follow the instructions in the setup script. Create a new origin and a set of origin keys. If you would like to provide anonymous data on your usage of the `hab` CLI, please type in `Yes` or hit Enter. For information on the type of data we gather and how we intend to use it, see [Analytics in Habitat](/docs/about-analytics).
+5. Follow the instructions in the setup script. Create a new origin and a set of origin keys. Optionally, you can provide a [GitHub personal authorization token](https://help.github.com/articles/creating-an-access-token-for-command-line-use/) for the `hab` CLI to use to upload packages to the public depot and share them with the Habitat community. You can also provide anonymous data on your usage of the `hab` CLI. For information on the type of data we gather and how we intend to use it, see [Analytics in Habitat](/docs/about-analytics).
 
-   > Note: You can also opt-out of providing usage data at a later point in time by re-running the `hab setup` subcommand and typing `No` when asked if you want to provide usage data.
+   > Note: The only rights the GitHub personal authorization token needs at present is `user.email` since it is only used for authentication. Also, you can opt-out of providing usage data at a later point in time by re-running the `hab setup` subcommand and typing `No` when asked if you want to provide usage data.

--- a/www/source/tutorials/getting-started-overview.html.md
+++ b/www/source/tutorials/getting-started-overview.html.md
@@ -14,7 +14,7 @@ As a first step in understanding Habitat, this tutorial will show you how to cre
 This tutorial currently supports Linux and Mac OS X as host operating systems. Before starting this tutorial, you need to have the following:
 
 *   The `hab` command-line interface tool. See [Get Habitat](/docs/get-habitat) if you don't already have this installed on your machine.
-{::comment}*    An active GitHub account is recommended. If you don't already have an account, [sign up](https://github.com/) for one now. Note: This is only required if you want to use the build service to build your packages. {:/comment}
+*    An active GitHub account is recommended. If you don't already have an account, [sign up](https://github.com/) for one now. Note: This is required to upload and share your packages with others in the Habitat community.
 *   Your favorite text editor.
 *   Open egress on TCP port 9636. This is needed to upload and download packages from the public depot.
 *   If you are running Mac OS X on your host machine, then you need [Docker Toolbox](https://www.docker.com/products/docker-toolbox) installed. The toolbox also installs Oracle VM VirtualBox, which will run and manage the Linux VM where the Docker daemon resides. Make sure you have a Docker VM running before proceeding through the tutorial.


### PR DESCRIPTION
- Updated docs to reflect Github auth support in `hab setup`.
- Misc copyedit in shared-packages topic.

Don't merge until #801 goes in.

Signed-off-by: David Wrede dwrede@chef.io
