### PR TITLE
Removing nodejs-tutorial-app plan

### DIFF
--- a/plans/nodejs-tutorial-app/config/config.json
+++ b/plans/nodejs-tutorial-app/config/config.json
@@ -1,4 +1,0 @@
-{
-	"message": "{{cfg.message}}",
-	"port": "{{cfg.port}}"
-}

--- a/plans/nodejs-tutorial-app/default.toml
+++ b/plans/nodejs-tutorial-app/default.toml
@@ -1,7 +1,0 @@
-# Default values that can be updated.
-
-# Message of the Day
-message = "Hello, World!"
-
-# The port number that is listening for requests.
-port = 8080

--- a/plans/nodejs-tutorial-app/hooks/init
+++ b/plans/nodejs-tutorial-app/hooks/init
@@ -1,5 +1,0 @@
-#!/bin/sh
-#
-ln -s {{pkg.path}}/package.json {{pkg.svc_path}}
-ln -s {{pkg.path}}/server.js {{pkg.svc_path}}
-ln -s {{pkg.path}}/node_modules {{pkg.svc_path}}

--- a/plans/nodejs-tutorial-app/hooks/run
+++ b/plans/nodejs-tutorial-app/hooks/run
@@ -1,4 +1,0 @@
-#!/bin/sh
-#
-cd {{pkg.svc_path}}
-npm start


### PR DESCRIPTION
- Not really a "core" plan, so moving it plan over to habitat-examples-plans repo for customers to use as a reference.

Signed-off-by: David Wrede dwrede@chef.io
