### PR TITLE
[devshell] Persist /hab/etc & /hab/cache/artifacts across sessions.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,13 +4,13 @@
 .gitignore
 components
 !components/hab/install.sh
-demo
 images
 log
 plans
 results
 support
 !support/devshell_profile.sh
+terraform
 tmp
 vendor
 www

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,15 +5,16 @@ shell:
     - .:/src
     - /var/run/docker.sock:/var/run/docker.sock
   volumes_from:
-    - cache_src
+    - cache_artifacts
     - cache_keys
     - cargo
+    - etc
 
-cache_src:
+cache_artifacts:
   image: tianon/true
   command: /true
   volumes:
-    - /hab/cache/src
+    - /hab/cache/artifacts
 
 cache_keys:
   image: tianon/true
@@ -26,3 +27,9 @@ cargo:
   command: /true
   volumes:
     - /cargo-cache
+
+etc:
+  image: tianon/true
+  command: /true
+  volumes:
+    - /hab/etc


### PR DESCRIPTION
Saving the etc directory across sessions will allow us to save the
`cli.toml` settings such as default origin name and github access token.

Additionally the artifacts cache is persisted for future cache sharing
ideas...

Signed-off-by: Fletcher Nichol fnichol@nichol.ca
