### PR TITLE
Remove locking on zmq::Context

### DIFF
--- a/components/builder-api/src/http/mod.rs
+++ b/components/builder-api/src/http/mod.rs
@@ -9,11 +9,12 @@
 
 pub mod handlers;
 
-use std::sync::{mpsc, Arc, Mutex};
+use std::sync::{mpsc, Arc};
 use std::thread::{self, JoinHandle};
 
 use depot;
 use hab_net::oauth::github::GitHubClient;
+use hab_net::routing::BrokerContext;
 use iron::prelude::*;
 use iron::AfterMiddleware;
 use iron::headers;
@@ -21,14 +22,13 @@ use iron::method::Method;
 use mount::Mount;
 use staticfile::Static;
 use unicase::UniCase;
-use zmq;
 
 use config::Config;
 use error::Result;
 use self::handlers::*;
 
 /// Create a new `iron::Chain` containing a Router and it's required middleware
-pub fn router(config: Arc<Config>, context: Arc<Mutex<zmq::Context>>) -> Result<Chain> {
+pub fn router(config: Arc<Config>, context: Arc<BrokerContext>) -> Result<Chain> {
     let github = GitHubClient::new(&*config);
     let ctx1 = context.clone();
     let ctx2 = context.clone();
@@ -65,7 +65,7 @@ pub fn router(config: Arc<Config>, context: Arc<Mutex<zmq::Context>>) -> Result<
 /// # Panics
 ///
 /// * Listener crashed during startup
-pub fn run(config: Arc<Config>, context: Arc<Mutex<zmq::Context>>) -> Result<JoinHandle<()>> {
+pub fn run(config: Arc<Config>, context: Arc<BrokerContext>) -> Result<JoinHandle<()>> {
     let (tx, rx) = mpsc::sync_channel(1);
 
     let addr = config.http_addr.clone();

--- a/components/builder-api/src/server.rs
+++ b/components/builder-api/src/server.rs
@@ -7,12 +7,11 @@
 
 //! Contains core functionality for the Application's main server.
 
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use hab_net::config::RouteAddrs;
-use hab_net::routing::Broker;
+use hab_net::routing::{Broker, BrokerContext};
 use hab_net::server::NetIdent;
-use zmq;
 
 use config::Config;
 use error::Result;
@@ -21,16 +20,15 @@ use http;
 /// The main server for the Builder-API application. This should be run on the main thread.
 pub struct Server {
     pub config: Arc<Config>,
-    context: Arc<Mutex<zmq::Context>>,
+    ctx: Arc<BrokerContext>,
 }
 
 impl Server {
     /// Create a new `Server`
     pub fn new(config: Config) -> Self {
-        let ctx = zmq::Context::new();
         Server {
             config: Arc::new(config),
-            context: Arc::new(Mutex::new(ctx)),
+            ctx: Arc::new(BrokerContext::new()),
         }
     }
 
@@ -42,8 +40,8 @@ impl Server {
     /// * HTTP server could not start
     pub fn run(&mut self) -> Result<()> {
         let cfg1 = self.config.clone();
-        let ctx1 = self.context.clone();
-        let ctx2 = self.context.clone();
+        let ctx1 = self.ctx.clone();
+        let ctx2 = self.ctx.clone();
         let broker = Broker::run(Self::net_ident(), ctx1, self.config.route_addrs());
         let http = try!(http::run(cfg1, ctx2));
 

--- a/components/depot/src/lib.rs
+++ b/components/depot/src/lib.rs
@@ -45,7 +45,7 @@ pub mod server;
 pub use self::config::Config;
 pub use self::error::{Error, Result};
 
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -56,16 +56,17 @@ use data_store::DataStore;
 
 use hab_net::oauth::github::GitHubClient;
 use hab_net::server::NetIdent;
+use hab_net::routing::BrokerContext;
 
 pub struct Depot {
     pub config: Config,
     pub datastore: DataStore,
-    context: Arc<Mutex<zmq::Context>>,
+    pub context: Arc<BrokerContext>,
     github: GitHubClient,
 }
 
 impl Depot {
-    pub fn new(config: Config, ctx: Arc<Mutex<zmq::Context>>) -> Result<Arc<Depot>> {
+    pub fn new(config: Config, ctx: Arc<BrokerContext>) -> Result<Arc<Depot>> {
         let datastore = try!(DataStore::open(&config));
         let github = GitHubClient::new(&config);
         Ok(Arc::new(Depot {

--- a/components/depot/src/main.rs
+++ b/components/depot/src/main.rs
@@ -19,10 +19,12 @@ extern crate zmq;
 use std::net;
 use std::process;
 use std::str::FromStr;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
+
+use hab_core::config::ConfigFile;
+use hab_net::routing::BrokerContext;
 
 use depot::{server, Config, Error, Result};
-use hab_core::config::ConfigFile;
 
 const VERSION: &'static str = include_str!(concat!(env!("OUT_DIR"), "/VERSION"));
 const CFG_DEFAULT_PATH: &'static str = "/hab/svc/hab-depot/config.toml";
@@ -141,7 +143,7 @@ fn start(config: Config) -> Result<()> {
 /// * The database cannot be read
 /// * A write transaction cannot be acquired
 pub fn repair(config: Config) -> Result<()> {
-    let ctx = Arc::new(Mutex::new(zmq::Context::new()));
+    let ctx = Arc::new(BrokerContext::new());
     let depot = try!(depot::Depot::new(config, ctx));
     let report = try!(depot::doctor::repair(&depot));
     println!("Report: {:?}", &report);
@@ -155,7 +157,7 @@ pub fn repair(config: Config) -> Result<()> {
 /// * The database cannot be read
 /// * A write transaction cannot be acquired.
 fn view_create(view: &str, config: Config) -> Result<()> {
-    let ctx = Arc::new(Mutex::new(zmq::Context::new()));
+    let ctx = Arc::new(BrokerContext::new());
     let depot = try!(depot::Depot::new(config, ctx));
     try!(depot.datastore.views.write(&view));
     Ok(())
@@ -168,7 +170,7 @@ fn view_create(view: &str, config: Config) -> Result<()> {
 /// * The database cannot be read
 /// * A read transaction cannot be acquired.
 fn view_list(config: Config) -> Result<()> {
-    let ctx = Arc::new(Mutex::new(zmq::Context::new()));
+    let ctx = Arc::new(BrokerContext::new());
     let depot = try!(depot::Depot::new(config, ctx));
     let views = try!(depot.datastore.views.all());
     if views.is_empty() {


### PR DESCRIPTION
- zmq::Context is sync/send and can be mutably referenced safely in an UnsafeCell

![gif-keyboard-14486096608910197905](https://cloud.githubusercontent.com/assets/54036/16028321/155056ba-3193-11e6-8791-b72754bdfe5c.gif)

Signed-off-by: Jamie Winsor jamie@vialstudios.com
