### PR TITLE
Add back files missing in ruby library

### DIFF
--- a/components/ruby-client/.gitignore
+++ b/components/ruby-client/.gitignore
@@ -1,0 +1,9 @@
+/.bundle/
+/.yardoc
+/Gemfile.lock
+/_yardoc/
+/coverage/
+/doc/
+/pkg/
+/spec/reports/
+/tmp/

--- a/components/ruby-client/.rspec
+++ b/components/ruby-client/.rspec
@@ -1,0 +1,2 @@
+--format documentation
+--color

--- a/components/ruby-client/Gemfile
+++ b/components/ruby-client/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gemspec

--- a/components/ruby-client/README.md
+++ b/components/ruby-client/README.md
@@ -1,0 +1,38 @@
+# Habitat::Client
+
+This is the Ruby client library for Habitat.
+
+## Installation
+
+Add this line to your application's Gemfile:
+
+```ruby
+gem 'habitat-client'
+```
+
+And then execute:
+
+    $ bundle
+
+Or install it yourself as:
+
+    $ gem install habitat-client
+
+## Usage
+
+```ruby
+# Create an instance object
+hc = Habitat::Client.new
+
+# Create the instance with a specific Habitat Depot
+hc = Habitat::Client.new('http://localhost:9636/v1/depot')
+
+# Upload a Habitat Artifact
+hc.put_package('core-pandas-0.0.1-20160425190407.hart')
+
+# Show a package
+hc.show_package('core/pandas')
+
+# Promote a package to the `stable` view
+hc.promote_package('core/pandas', 'stable')
+```

--- a/components/ruby-client/habitat-client.gemspec
+++ b/components/ruby-client/habitat-client.gemspec
@@ -11,7 +11,6 @@ Gem::Specification.new do |spec|
 
   spec.summary       = 'Habitat Depot Client Library'
   spec.homepage      = 'https://www.habitat.sh'
-  spec.license       = 'Apache-2.0'
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }

--- a/components/ruby-client/lib/habitat/client.rb
+++ b/components/ruby-client/lib/habitat/client.rb
@@ -43,10 +43,10 @@ module Habitat
     # === Examples
     #
     #    hc = Habitat::Client.new
-    #    hc = Habitat::Client.new('https://depot.habitat.sh')
+    #    hc = Habitat::Client.new('https://habitat-depot.example.com')
     #    hc.connection.get('/pkgs')
 
-    def initialize(depot = 'http://willem.habitat.sh:9636/v1/depot')
+    def initialize(depot = 'https://willem.habitat.sh/v1/depot')
       @depot = depot
       @connection = Faraday.new(url: @depot) do |f|
         f.request :multipart

--- a/components/ruby-client/spec/fixtures/depot_cassettes/player.yml
+++ b/components/ruby-client/spec/fixtures/depot_cassettes/player.yml
@@ -1,0 +1,44 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:9632/pkgs/core/pandas/latest
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Etag:
+      - NHRwHYyGrDdDCLnwRW0Rs9owOVo51Wv28z6HncFEtNs=
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - text/plain
+      Date:
+      - Wed, 20 Apr 2016 16:01:23 GMT
+      Content-Length:
+      - '2037'
+    body:
+      encoding: UTF-8
+      string: '{"ident":{"origin":"core","name":"pandas","version":"0.0.1","release":"20160419213120"},"manifest":"core
+        pandas\n=========================\n\nMaintainer: The Habitat Maintainers <humans@habitat.sh>\nVersion:
+        0.0.1\nRelease: 20160419213120\nLicense:  \nSource: [http://example.com/pandas-0.0.1.tar.xz](http://example.com/pandas-0.0.1.tar.xz)\nSHA:
+        sha256sum\nPath: /hab/pkgs/core/pandas/0.0.1/20160419213120\nBuild Dependencies:  \nDependencies:  \nInterpreters  \n\nPlan\n========\n\nBuild
+        Flags\n-----------\n\nCFLAGS: \nLDFLAGS: \nLD_RUN_PATH: /hab/pkgs/core/pandas/0.0.1/20160419213120/lib\n\n```bash\npkg_origin=core\npkg_name=pandas\npkg_version=0.0.1\npkg_maintainer=\"The
+        Habitat Maintainers <humans@habitat.sh>\"\npkg_license=()\npkg_source=http://example.com/${pkg_name}-${pkg_version}.tar.xz\npkg_shasum=sha256sum\n#pkg_deps=(chef/glibc)\n#pkg_build_deps=(chef/coreutils)\npkg_bin_dirs=(bin)\npkg_include_dirs=(include)\npkg_lib_dirs=(lib)\npkg_gpg_key=3853DA6B\n\ndo_begin()
+        {\n  return 0\n}\n\ndo_unpack() {\n  return 0\n}\n\ndo_download() {\n  return
+        0\n}\n\ndo_verify() {\n  return 0\n}\n\ndo_install() {\n  return 0\n}\n\ndo_build()
+        {\n  return 0\n}\n\ndo_prepare() {\n  return 0\n}\n```\n\nFiles\n-----\n949ee43a4372733130115580d1e038f463b22262355a53bb7afd80c7cf4cdabc  /hab/pkgs/core/pandas/0.0.1/20160419213120/CFLAGS\n5fe0fd5101905208fe49d640f03f2b0c8e07d80fe0231b7f7d0a64e1937bc8b0  /hab/pkgs/core/pandas/0.0.1/20160419213120/IDENT\ne25c2c5ae4ffde1e34b86ec59528c5ef236c1ce46e65d0a0856ac961b454b04d  /hab/pkgs/core/pandas/0.0.1/20160419213120/INTERPRETERS\nbc4890f7e35204aa2281554198a8773c124c9d6687b13d1ed4c9f37a25e3c58d  /hab/pkgs/core/pandas/0.0.1/20160419213120/LDFLAGS\n580ba95e5045d82ca4df124f2d59ca4af088d614548c5ca5062a6291c2717fe2  /hab/pkgs/core/pandas/0.0.1/20160419213120/LD_RUN_PATH\nd3698dc4c61fe457fdef9ab38997873de852b7c5c2da610e2fb4474d4253773d  /hab/pkgs/core/pandas/0.0.1/20160419213120/PATH","deps":[],"tdeps":[],"exposes":[],"config":null,"checksum":"NHRwHYyGrDdDCLnwRW0Rs9owOVo51Wv28z6HncFEtNs="}'
+    http_version: 
+  recorded_at: Wed, 20 Apr 2016 16:01:23 GMT
+recorded_with: VCR 3.0.1

--- a/components/ruby-client/spec/habitat/client/version_spec.rb
+++ b/components/ruby-client/spec/habitat/client/version_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+describe 'Habitat::Client::VERSION' do
+  it 'has a version number' do
+    expect(Habitat::Client::VERSION).not_to be nil
+  end
+end

--- a/components/ruby-client/spec/habitat/client_spec.rb
+++ b/components/ruby-client/spec/habitat/client_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+
+describe Habitat::Client do
+  let(:hc) { Habitat::Client.new }
+  let(:hc_custom_depot) { Habitat::Client.new('http://localhost:9636') }
+
+  it 'includes the Habitat module in Hab' do
+    expect(hc).to be_a(Hab::Client)
+  end
+
+  it 'has a default depot' do
+    expect(hc.depot).to eq 'https://willem.habitat.sh/v1/depot'
+  end
+
+  it 'can set custom depot' do
+    expect(hc_custom_depot.depot).to eq 'http://localhost:9636'
+  end
+
+  it 'sets a connection up with Faraday' do
+    expect(hc.connection).to be_a(Faraday::Connection)
+  end
+
+  it 'raises when using unimplemented methods' do
+    expect { hc.fetch_key('empty') }.to raise_exception RuntimeError
+    expect { hc.put_key('empty', 'file.key') }.to raise_exception RuntimeError
+  end
+end
+
+describe Habitat::PackageIdent do
+  it 'sets version to latest if unspecified' do
+    hpi = Habitat::PackageIdent.new('core', 'rspec')
+    expect(hpi.version).to eq 'latest'
+  end
+
+  it 'sets release to latest if unspecified' do
+    hpi = Habitat::PackageIdent.new('core', 'rspec', '3.4.4')
+    expect(hpi.release).to eq 'latest'
+  end
+
+  describe '#to_s' do
+    it 'ends in latest with no version specified' do
+      hpi = Habitat::PackageIdent.new('core', 'rspec')
+      expect(hpi.to_s).to match('core/rspec/latest')
+    end
+
+    it 'ends in latest with version, but no release specified' do
+      hpi = Habitat::PackageIdent.new('core', 'rspec', '3.4.4')
+      expect(hpi.to_s).to match('core/rspec/3.4.4/latest')
+    end
+
+    it 'is fully qualified with all parts specified' do
+      hpi = Habitat::PackageIdent.new('core', 'rspec', '3.4.4', '201604181646')
+      expect(hpi.to_s).to match('core/rspec/3.4.4/201604181646')
+    end
+  end
+end

--- a/components/ruby-client/spec/spec_helper.rb
+++ b/components/ruby-client/spec/spec_helper.rb
@@ -1,0 +1,3 @@
+$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+require 'habitat/client'
+require 'habitat/client/version'


### PR DESCRIPTION
Some of the files required for the ruby library went missing between the branches and pull requests that happened recently. This commit restores those missing files.
