### PR TITLE
Removes announcement banner

### DIFF
--- a/www/source/layouts/_nav.slim
+++ b/www/source/layouts/_nav.slim
@@ -1,5 +1,4 @@
 #main-nav class="#{layout_class}"
-  = partial "layouts/message"
   .main-nav--container.clearfix
     .main-nav--logo
       a href="/"


### PR DESCRIPTION
Now that the live stream/announcement is over, bignews is redirecting to habitat... so we can officially remove the banner.

Signed-off-by: Ryan Keairns <rkeairns@chef.io>