### PR TITLE
No longer need outbound port 9636 open to access public depot

### DIFF
--- a/www/source/tutorials/getting-started-overview.html.md
+++ b/www/source/tutorials/getting-started-overview.html.md
@@ -16,7 +16,6 @@ This tutorial currently supports Linux and Mac OS X as host operating systems. B
 *   The `hab` command-line interface tool. See [Get Habitat](/docs/get-habitat) if you don't already have this installed on your machine.
 *    An active GitHub account is recommended. If you don't already have an account, [sign up](https://github.com/) for one now. Note: This is required to upload and share your packages with others in the Habitat community.
 *   Your favorite text editor.
-*   Open egress on TCP port 9636. This is needed to upload and download packages from the public depot.
 *   If you are running Mac OS X on your host machine, then you need [Docker Toolbox](https://www.docker.com/products/docker-toolbox) installed. The toolbox also installs Oracle VM VirtualBox, which will run and manage the Linux VM where the Docker daemon resides. Make sure you have a Docker VM running before proceeding through the tutorial.
 *   If you are running a Linux distribution such as Ubuntu on your host machine, then you need to install the [Docker Engine](https://docs.docker.com/linux/) CLI tool.
 


### PR DESCRIPTION
- Removing note in Prerequisites that specified opening up outbound port 9636 on your local machine. 

That was the port used before the GA launch. Connections to the depot now happen over the standard HTTPS port 443.

Signed-off-by: David Wrede <dwrede@chef.io>