### PR TITLE
Fix link to docs on origin members tab

### DIFF
--- a/components/builder-web/app/origin-page/OriginMembersTabComponent.ts
+++ b/components/builder-web/app/origin-page/OriginMembersTabComponent.ts
@@ -72,12 +72,14 @@ import {TabComponent} from "../TabComponent";
             </div>
             <div class="hab-origin--right">
                 <p>
-                    <em>Origin keys</em> ensure that only authorized users
-                    or (organizations) are able
-                    to push updates to packages in this origin.
+                    <em>Origin keys</em> ensure only authorized users (or
+                    organizations) are able to push updates to packages
+                    in this origin.
                 </p>
                 <p>
-                    Read the docs for more information on <a href="{{docsUrl}}/concepts-keys/">managing and using keys</a>.
+                    Read the docs for more information on
+                    <a href="{{docsUrl}}/concepts-keys/">
+                        managing and using keys</a>.
                 </p>
             </div>
         </div>
@@ -86,6 +88,7 @@ import {TabComponent} from "../TabComponent";
 })
 
 export class OriginMembersTabComponent implements OnInit {
+    @Input() docsUrl: string;
     @Input() errorMessage: string;
     @Input() invitations: List<Object>;
     @Input() members: List<Object>;

--- a/components/builder-web/app/origin-page/OriginPageComponent.ts
+++ b/components/builder-web/app/origin-page/OriginPageComponent.ts
@@ -119,6 +119,7 @@ import {requireSignIn} from "../util";
                 </div>
             </tab>
             <hab-origin-members-tab
+                [docsUrl]="docsUrl"
                 [errorMessage]="ui.userInviteErrorMessage"
                 [invitations]="invitations"
                 [members]="members"


### PR DESCRIPTION
We weren't passing the docs url into the members tab component, so it
was using an empty string, causing the clicker to go to the wrong
address.

![gif-keyboard-16376239957681259489](https://cloud.githubusercontent.com/assets/9912/16093392/924c2280-32f0-11e6-81b8-b6e9e1f67c1d.gif)