### PR TITLE
Homepage: Add "Watch the Video" CTA button to homepage sub-hero

### DIFF
--- a/www/source/index.html.slim
+++ b/www/source/index.html.slim
@@ -57,6 +57,8 @@ section.sub-hero
             p
               | Run fast, run smart with Habitat. Habitat apps are immutable
                 and atomically deployed, with self-organizing peer relationships.
+        p
+          a.sub-hero--button.button href="/about/announcement/" Watch the Video
         img.sub-hero--graphic src="/images/graphics/subhero-watermark.png" alt=""
 
 section.main-section.first

--- a/www/source/stylesheets/_home.scss
+++ b/www/source/stylesheets/_home.scss
@@ -221,6 +221,14 @@ $sub-hero-skew: 5deg;
   }
 }
 
+.sub-hero--button {
+  margin: rem-calc(40) 0 rem-calc(-35);
+
+  @include small-home {
+    margin: rem-calc(20) 0 0 6%;
+  }
+}
+
 // Main section
 .main-section {
   padding: rem-calc(120) 0;


### PR DESCRIPTION
CTA directs users to the webcast announcement recording located
at /about/announcement.

Signed-off-by: Maggie Walker <magwalk@gmail.com>

![screen shot 2016-06-15 at 12 17 07 pm](https://cloud.githubusercontent.com/assets/7217000/16094021/1cfa6d7c-32f3-11e6-96da-ed3456a6d36a.png)
