### PR TITLE
Open forums and slack in new tab

### DIFF
--- a/www/source/community.html.slim
+++ b/www/source/community.html.slim
@@ -12,8 +12,8 @@ section.hero.community
           | Habitat is an open source project created and supported
             by a passionate group of people. Our vision is grand — to bring automation
             to places previously unconsidered.
-        a.button.cta href="https://forums.habitat.sh/" Visit the Forums
-        a.button.cta href="http://slack.habitat.sh" Join us on Slack
+        a.button.cta href="https://forums.habitat.sh/" target="_blank" Visit the Forums
+        a.button.cta href="http://slack.habitat.sh" target="_blank" Join us on Slack
     .hero--graphic
       img[src="/images/graphics/hero-community.svg"
         onerror="this.src='/images/graphics/hero-community.png'" alt=""]
@@ -31,7 +31,7 @@ section.sub-hero.community
             p
               | Is something unclear or just feeling stuck? We're here
                 to help keep you moving.
-            a.button.outline href="https://forums.habitat.sh/" Ask a Question
+            a.button.outline href="https://forums.habitat.sh/" target="_blank" Ask a Question
 
           .sub-hero--blurb.columns.medium-4
             img.sub-hero--icon[src="/images/icons/subhero-results.svg"
@@ -40,7 +40,7 @@ section.sub-hero.community
             p
               | We rely on your feedback to improve Habitat and look
                 forward to hearing from you.
-            a.button.outline href="https://forums.habitat.sh/" Report an issue
+            a.button.outline href="https://forums.habitat.sh/" target="_blank" Report an issue
 
           .sub-hero--blurb.columns.medium-4
             img.sub-hero--icon[src="/images/icons/subhero-results.svg"


### PR DESCRIPTION
From the community page you can open the forums and slack - neither of which have a clear path back to the website. This change simply makes it so that those things open in a new tab which seems appropriate since they are external links to a Discourse instance and Slack, respectively.

We did not make the app link (Search Packages) open in a new tab since that feels more connected to the site, the app nav has links back to docs & tuts, and that once you get into the product you'll likely not return to the website home page very often.

Signed-off-by: Ryan Keairns <rkeairns@chef.io>