### PR TITLE
Revised tutorial setup steps

### DIFF
--- a/www/source/docs/create-packages-build.html.md
+++ b/www/source/docs/create-packages-build.html.md
@@ -26,7 +26,7 @@ When you enter the studio environment, your origin keys are not automatically sh
 * Set `HAB_ORIGIN_KEYS` to one or more key names, separated by commas like `export HAB_ORIGIN_KEYS=originname-internal,originname-test,originname`
 * Use the `-k` flag (short for “keys”) which accepts one or more key names separated by commas with `hab studio -k originname-internal,originname-test enter`
 
-The first way overrides the `HAB_ORIGIN` environment variable to import public and secret keys into the studio environment. This is useful if you want to not only build your package, but also you can use this to build your own versions of other packages, such as `originname/node` or `originname/glibc`.
+The first way overrides the `HAB_ORIGIN` environment variable to import public and secret keys into the studio environment and override any `pkg_origin` values in the packages that you build. This is useful if you want to not only build your package, but also you can use this to build your own versions of other packages, such as `originname/node` or `originname/glibc`.
 
 The second and third way import multiple secret keys that must match the origin names for the plans you intend to build.
 

--- a/www/source/shared/_setup_environment.html.md.erb
+++ b/www/source/shared/_setup_environment.html.md.erb
@@ -1,24 +1,23 @@
 The `hab` command-line interface (CLI) tool downloads its other components when it needs them, so setup for Habitat is centered on where you want the `hab` CLI installed and getting it integrated into your shell.
 
-1.  Open a terminal window. Change directory to the directory where you want to place the `hab` CLI. The following example creates a directory called `bin` and places it at the root of the home directory:
+1.  Open a terminal window. Change directory to the directory where you want to place the `hab` CLI and copy the `hab` CLI to that directory.
 
-        mkdir -p ~/bin && cd ~/bin
+        mkdir -p ~/bin
+        cp where/you/extracted/hab ~/bin
 
-2. Copy the `hab` CLI to that directory.
-
-3. Add the location for the `hab` CLI to your `PATH` environment variable.
+2. Add the location for the `hab` CLI to your `PATH` environment variable.
 
        export PATH=$PATH:~/bin
 
     To keep from typing this in for every terminal window you use, add the above statement to your shell profile.
 
-4. Open a terminal window and run `hab setup`. If your host machine is running Linux, the `hab` CLI must run as root, so we suggest running it as root through the `sudo` command.
+3. For Mac OS X, run `hab setup`. On Linux, run `sudo hab setup`.
 
-   If you're running on Mac OS X, make sure your docker-machine is running and your shell is connected to it first.
+   > Note: If you're running on Mac OS X, make sure your docker-machine is running and your shell is connected to it first.
 
        docker-machine start
        eval "$(docker-machine env machinename)"
 
-5. Follow the instructions in the setup script. Create a new origin and a set of origin keys. Optionally, you can provide a [GitHub personal authorization token](https://help.github.com/articles/creating-an-access-token-for-command-line-use/) for the `hab` CLI to use to upload packages to the public depot and share them with the Habitat community. You can also provide anonymous data on your usage of the `hab` CLI. For information on the type of data we gather and how we intend to use it, see [Analytics in Habitat](/docs/about-analytics).
+4. Follow the instructions in the setup script. Create a new origin and a set of origin keys. Optionally, you can provide a [GitHub personal authorization token](https://help.github.com/articles/creating-an-access-token-for-command-line-use/) for the `hab` CLI to use to upload packages to the public depot and share them with the Habitat community. You can also provide anonymous data on your usage of the `hab` CLI. For information on the type of data we gather and how we intend to use it, see [Analytics in Habitat](/docs/about-analytics).
 
    > Note: The only rights the GitHub personal authorization token needs at present is `user.email` since it is only used for authentication. Also, you can opt-out of providing usage data at a later point in time by re-running the `hab setup` subcommand and typing `No` when asked if you want to provide usage data.

--- a/www/source/tutorials/getting-started-create-plan.html.md.erb
+++ b/www/source/tutorials/getting-started-create-plan.html.md.erb
@@ -32,6 +32,7 @@ pkg_maintainer="Your Name <your email address>"
 pkg_license=()
 pkg_source=http://example.com/${pkg_name}-${pkg_version}.tar.xz
 pkg_shasum=sha256sum
+pkg_filename=${pkg_name}-${pkg_version}.tar.gz
 pkg_deps=()
 pkg_build_deps=()
 pkg_bin_dirs=(bin)

--- a/www/source/tutorials/getting-started-process-build.html.md
+++ b/www/source/tutorials/getting-started-process-build.html.md
@@ -13,10 +13,14 @@ For more information on how to natively run Habitat services or how to run servi
 
 To show the portability of Habitat, you will export and run a Habitat service from within a Docker container through the following steps:
 
-1. If you are not in the studio environment, change over to your plan directory and enter the studio.  (Remember to replace `myorigin` with the name of the origin key you created during `hab setup`. For the examples in this tutorial, it will be set to "myorigin")
+1. If you are not in the studio environment, change over to your plan directory and enter the studio.
 
         cd ~/plans/mytutorialapp
-        hab studio -k myorigin enter
+        hab studio enter
+
+    For Linux, run `sudo hab studio enter` instead.
+
+    > Note: When you created an origin key pair in `hab setup`, you were also asked if you wanted to setup a default origin. If you said yes, then the `HAB_ORIGIN` environment variable is overridden for you with the default origin name you created. This action will also import the secret origin key that matches the overridden origin name when you call `hab studio enter`.
 
 2. Build your mytutorialapp package.
 
@@ -24,11 +28,11 @@ To show the portability of Habitat, you will export and run a Habitat service fr
 
 3. Run `hab pkg export docker origin/packagename` with the origin and name of your package. These values are referenced in the pkg_origin and pkg_name settings of your plan, respectively.
 
-        [4][default:/src:0]# hab pkg export docker myorigin/mytutorialapp
+        [2][default:/src:0]# hab pkg export docker myorigin/mytutorialapp
 
     Habitat will proceed to unpack and install all necessary Habitat packages, including a Habitat supervisor, the mytutorialapp package, and all of its runtime dependencies. Then it will create an image using the Docker scratch image as the base and build up the rest of the image from there.
 
-4. Once that process has completed, run your Docker image inside a container or from any terminal window that has access to the Docker CLI on your host machine.
+4. Once that process has completed, exit out of the studio and run your Docker image inside a container or from any terminal window that has access to the Docker CLI on your host machine.
 
     > Note: We have to publish the Docker container port number to allow that container to be accessed by the host machine. Also, you may need to connect your shell to the Docker VM using `eval "$(docker-machine env default)"` if you are running Mac OS X.
 


### PR DESCRIPTION
- Revised and clarified when you need to run `sudo hab subcommand` in tutorial.

- Also included minor formatting updates.

Signed-off-by: David Wrede <dwrede@chef.io>