### PR TITLE
Send X-Content-Range headers with package lists

### DIFF
--- a/components/builder-web/app/depotApi.ts
+++ b/components/builder-web/app/depotApi.ts
@@ -37,7 +37,12 @@ export function get(params, nextRange: number = 0) {
             }
 
             const totalCount = parseInt(
-                (response.headers.get("Content-Range") || "").split("=")[1],
+                // The caching proxy (Fastly) may strip out the Content-Range
+                // header on responses, so attempt to use the X-Content-Range
+                // as well until this is fixed.
+                (response.headers.get("Content-Range") ||
+                 response.headers.get("X-Content-Range") ||
+                 "").split("=")[1],
                 10
             );
             const nextRange = parseInt(response.headers.get("Next-Range"), 10);

--- a/components/depot/src/server.rs
+++ b/components/depot/src/server.rs
@@ -955,7 +955,15 @@ fn list_packages(depot: &Depot, req: &mut Request) -> IronResult<Response> {
                     Response::with((status::Ok, body))
                 };
                 let range = vec![format!("{}..{}; count={}", offset, num, count).into_bytes()];
-                response.headers.set_raw("Content-Range", range);
+                response.headers.set_raw("Content-Range", range.clone());
+                // We set both of these because Fastly was stripping the
+                // Content-Range, so we use both until we can get that fixed.
+                response.headers.set_raw("X-Content-Range", range);
+
+                response.headers.set(ContentType(Mime(TopLevel::Application,
+                                                      SubLevel::Json,
+                                                      vec![(Attr::Charset, Value::Utf8)])));
+
                 dont_cache_response(&mut response);
                 Ok(response)
             }
@@ -981,7 +989,11 @@ fn list_packages(depot: &Depot, req: &mut Request) -> IronResult<Response> {
                     Response::with((status::Ok, body))
                 };
                 let range = vec![format!("{}..{}; count={}", offset, num, count).into_bytes()];
-                response.headers.set_raw("Content-Range", range);
+                response.headers.set_raw("Content-Range", range.clone());
+                // We set both of these because Fastly was stripping the
+                // Content-Range, so we use both until we can get that fixed.
+                response.headers.set_raw("X-Content-Range", range);
+
                 response.headers.set(ContentType(Mime(TopLevel::Application,
                                                       SubLevel::Json,
                                                       vec![(Attr::Charset, Value::Utf8)])));
@@ -1103,7 +1115,15 @@ fn search_packages(depot: &Depot, req: &mut Request) -> IronResult<Response> {
         Response::with((status::Ok, body))
     };
     let range = vec![format!("{}..{}", offset, num).into_bytes()];
-    response.headers.set_raw("Content-Range", range);
+    response.headers.set_raw("Content-Range", range.clone());
+    // We set both of these because Fastly was stripping the
+    // Content-Range, so we use both until we can get that fixed.
+    response.headers.set_raw("X-Content-Range", range);
+
+    response.headers.set(ContentType(Mime(TopLevel::Application,
+                                          SubLevel::Json,
+                                          vec![(Attr::Charset, Value::Utf8)])));
+
     dont_cache_response(&mut response);
     Ok(response)
 }


### PR DESCRIPTION
Since Fastly is currently stripping out the Content-Range headers, send
X-Content-Range as a fallback so we can use those, which should not get
stripped.

Also make the package list and search endpoints have `application/json;
charset=utf-8` content type instead of `text/plain`.

![gif-keyboard-4892917987816720926](https://cloud.githubusercontent.com/assets/9912/16102472/b7eec806-3324-11e6-96d6-d930a65f960d.gif)
