### PR TITLE
Create a plan for proxying builder-api

### DIFF
--- a/plans/nginx-builder-api/config/mime.types
+++ b/plans/nginx-builder-api/config/mime.types
@@ -1,0 +1,89 @@
+
+types {
+    text/html                             html htm shtml;
+    text/css                              css;
+    text/xml                              xml;
+    image/gif                             gif;
+    image/jpeg                            jpeg jpg;
+    application/javascript                js;
+    application/atom+xml                  atom;
+    application/rss+xml                   rss;
+
+    text/mathml                           mml;
+    text/plain                            txt;
+    text/vnd.sun.j2me.app-descriptor      jad;
+    text/vnd.wap.wml                      wml;
+    text/x-component                      htc;
+
+    image/png                             png;
+    image/tiff                            tif tiff;
+    image/vnd.wap.wbmp                    wbmp;
+    image/x-icon                          ico;
+    image/x-jng                           jng;
+    image/x-ms-bmp                        bmp;
+    image/svg+xml                         svg svgz;
+    image/webp                            webp;
+
+    application/font-woff                 woff;
+    application/java-archive              jar war ear;
+    application/json                      json;
+    application/mac-binhex40              hqx;
+    application/msword                    doc;
+    application/pdf                       pdf;
+    application/postscript                ps eps ai;
+    application/rtf                       rtf;
+    application/vnd.apple.mpegurl         m3u8;
+    application/vnd.ms-excel              xls;
+    application/vnd.ms-fontobject         eot;
+    application/vnd.ms-powerpoint         ppt;
+    application/vnd.wap.wmlc              wmlc;
+    application/vnd.google-earth.kml+xml  kml;
+    application/vnd.google-earth.kmz      kmz;
+    application/x-7z-compressed           7z;
+    application/x-cocoa                   cco;
+    application/x-java-archive-diff       jardiff;
+    application/x-java-jnlp-file          jnlp;
+    application/x-makeself                run;
+    application/x-perl                    pl pm;
+    application/x-pilot                   prc pdb;
+    application/x-rar-compressed          rar;
+    application/x-redhat-package-manager  rpm;
+    application/x-sea                     sea;
+    application/x-shockwave-flash         swf;
+    application/x-stuffit                 sit;
+    application/x-tcl                     tcl tk;
+    application/x-x509-ca-cert            der pem crt;
+    application/x-xpinstall               xpi;
+    application/xhtml+xml                 xhtml;
+    application/xspf+xml                  xspf;
+    application/zip                       zip;
+
+    application/octet-stream              bin exe dll;
+    application/octet-stream              deb;
+    application/octet-stream              dmg;
+    application/octet-stream              iso img;
+    application/octet-stream              msi msp msm;
+
+    application/vnd.openxmlformats-officedocument.wordprocessingml.document    docx;
+    application/vnd.openxmlformats-officedocument.spreadsheetml.sheet          xlsx;
+    application/vnd.openxmlformats-officedocument.presentationml.presentation  pptx;
+
+    audio/midi                            mid midi kar;
+    audio/mpeg                            mp3;
+    audio/ogg                             ogg;
+    audio/x-m4a                           m4a;
+    audio/x-realaudio                     ra;
+
+    video/3gpp                            3gpp 3gp;
+    video/mp2t                            ts;
+    video/mp4                             mp4;
+    video/mpeg                            mpeg mpg;
+    video/quicktime                       mov;
+    video/webm                            webm;
+    video/x-flv                           flv;
+    video/x-m4v                           m4v;
+    video/x-mng                           mng;
+    video/x-ms-asf                        asx asf;
+    video/x-ms-wmv                        wmv;
+    video/x-msvideo                       avi;
+}

--- a/plans/nginx-builder-api/config/nginx.conf
+++ b/plans/nginx-builder-api/config/nginx.conf
@@ -1,0 +1,92 @@
+daemon off;
+pid {{pkg.svc_var_path}}/pid;
+
+worker_processes  {{cfg.worker_processes}};
+worker_rlimit_nofile {{cfg.worker_rlimit_nofile}};
+
+events {
+    worker_connections  {{cfg.events.worker_connections}};
+}
+
+http {
+  client_body_temp_path {{pkg.svc_var_path}}/nginx/client-body;
+  fastcgi_temp_path {{pkg.svc_var_path}}/nginx/fastcgi;
+  proxy_temp_path {{pkg.svc_var_path}}/nginx/proxy;
+  scgi_temp_path {{pkg.svc_var_path}}/nginx/scgi_temp_path;
+  uwsgi_temp_path {{pkg.svc_var_path}}/nginx/uwsgi;
+
+  include        mime.types;
+  default_type   application/octet-stream;
+
+  sendfile       {{cfg.http.sendfile}};
+  tcp_nopush     {{cfg.http.tcp_nopush}};
+  tcp_nodelay    {{cfg.http.tcp_nodelay}};
+
+  keepalive_timeout  {{cfg.http.keepalive_timeout}};
+
+  gzip  on;
+  gzip_vary on;
+  gzip_min_length 256;
+  gzip_proxied expired no-cache no-store private auth;
+  gzip_types
+    application/javascript
+    application/json
+    application/vnd.ms-fontobject
+    application/x-font-ttf
+    font/opentype
+    image/svg+xml
+    image/x-icon
+    text/css
+
+  gzip_disable "MSIE [1-6]\.";
+
+  open_file_cache max=1000 inactive=20s;
+  open_file_cache_valid 30s;
+  open_file_cache_min_uses 2;
+  open_file_cache_errors on;
+
+  spdy_keepalive_timeout 300s;
+  spdy_headers_comp 6;
+
+  add_header X-Frame-Options SAMEORIGIN;
+  add_header X-Content-Type-Options nosniff;
+  add_header X-XSS-Protection "1; mode=block";
+  add_header Alternate-Protocol  443:npn-spdy/3;
+
+  add_header "X-UA-Compatible" "IE=Edge";
+  add_header Strict-Transport-Security "max-age=31536000; includeSubDomains;";
+
+  proxy_cache_path {{pkg.svc_path_path}}/cache levels=1:2 keys_zone=my_cache:10m max_size=10g inactive=60m use_temp_path=off;
+
+  server {
+    index index.html;
+    listen       *:80;
+    server_name  localhost;
+    root /hab/svc/hab-builder-api/static;
+
+    if ($http_x_forwarded_proto = "http") {
+      rewrite ^(.*)$ https://$host$1 permanent;
+    }
+
+    location ~* ^/favicon.ico/ {
+        access_log off;
+        break;
+    }
+
+  	location ~* ^/v1/depot/.*/latest$ {
+  	   add_header Cache-Control "private, no-cache, no-store";
+  	   proxy_pass http://localhost:9636;
+  	}
+
+  	location /v1/depot {
+       client_max_body_size 1024m;
+  	   proxy_cache my_cache;
+  	   proxy_pass http://localhost:9636;
+  	}
+
+  	location /v1 {
+  	   add_header Cache-Control "private, no-cache, no-store";
+  	   proxy_pass http://localhost:9636;
+    }
+  }
+}

--- a/plans/nginx-builder-api/default.toml
+++ b/plans/nginx-builder-api/default.toml
@@ -1,0 +1,12 @@
+doc_root = '/hab/svc/hab-builder-api/static'
+worker_rlimit_nofile = 8192
+worker_processes = "auto"
+
+[events]
+worker_connections = 8000
+
+[http]
+sendfile = "on"
+tcp_nopush = "on"
+tcp_nodelay = "on"
+keepalive_timeout = "20s"

--- a/plans/nginx-builder-api/hooks/health_check
+++ b/plans/nginx-builder-api/hooks/health_check
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+set -x
+
+# default return code is 0
+rc=0
+
+hab pkg exec core/curl curl --head --fail --max-time 1 http://localhost
+
+case $? in
+  # Zero exit status means curl got back a 200 end everything is ok.
+  0)
+    rc=0 ;;
+  # Anything else is critical
+  *)
+    rc=2 ;;
+esac
+
+exit $rc

--- a/plans/nginx-builder-api/hooks/init
+++ b/plans/nginx-builder-api/hooks/init
@@ -1,0 +1,3 @@
+#!/bin/sh
+mkdir -p {{pkg.svc_var_path}}/nginx
+chown hab:hab {{pkg.svc_var_path}}

--- a/plans/nginx-builder-api/hooks/run
+++ b/plans/nginx-builder-api/hooks/run
@@ -1,0 +1,4 @@
+#!/bin/sh
+#
+exec 2>&1
+exec hab pkg exec core/nginx nginx -c {{pkg.svc_path}}/config/nginx.conf

--- a/plans/nginx-builder-api/plan.sh
+++ b/plans/nginx-builder-api/plan.sh
@@ -1,0 +1,36 @@
+pkg_origin=core
+pkg_name=nginx-builder-api
+pkg_description="This is nginx configuration used to run the habitat monolith's nginx LB"
+pkg_version=0.1.0
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh"
+pkg_source=nosuchfile.tar.xz
+pkg_license=("apache2")
+pkg_deps=(core/nginx core/curl)
+
+do_begin() {
+  return 0
+}
+
+do_build() {
+  return 0
+}
+
+do_download() {
+  return 0
+}
+
+do_install() {
+  return 0
+}
+
+do_prepare() {
+  return 0
+}
+
+do_unpack() {
+  return 0
+}
+
+do_verify() {
+  return 0
+}


### PR DESCRIPTION
This commit adds a plan and configuration for standing up nginx in front of the monolithic depot. It uses a slightly modified (as in,
it's a template) nginx.conf from the monolithic system, and should be added to the director configuration used to run the monolith. It will be refactored for discovery and all the goods at a future date.

Signed-off-by: jtimberman <joshua@chef.io>