### PR TITLE
Add optional binding to haproxy config

### DIFF
--- a/plans/haproxy/config/haproxy.conf
+++ b/plans/haproxy/config/haproxy.conf
@@ -12,6 +12,12 @@ frontend http-in
     default_backend default
 
 backend default
+{{#if bind.has_backend }}
+{{~#each bind.backend.members}}
+    server {{ip}} {{ip}}:{{port}}
+{{~/each}}
+{{~else}}
 {{~#each cfg.server}}
     server {{name}} {{host_or_ip}}:{{port}}
 {{~/each}}
+{{~/if}}


### PR DESCRIPTION
Updated haproxy.conf to use a binding named backend if one is available.  If not, it falls back to the original config values.  This allows haproxy to automatically add all members of a service group as backends.

Signed-off-by: Nolan Davidson <ndavidson@chef.io>