### PR TITLE
Updates to Travis for website deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -135,9 +135,6 @@ matrix:
     script:
     - "(cd components/builder-web && npm run travis)"
     - sudo -E bash -c "./support/ci/build_builder_web.sh"
-    #after_success:
-    #- "hart=$(source ./results/last_build.env && echo $pkg_artifact)"
-    #- "if [ -n \"$hart\" ]; then hab pkg upload ./results/$hart; fi"
   - language: ruby
     rvm: 2.3.1
     sudo: false
@@ -148,32 +145,15 @@ matrix:
     env:
     - AWS_BUCKET=habitat-www
     - AWS_DEFAULT_REGION=us-west-2
-    - AWS_ACCESS_KEY_ID=AKIAIDANMMC5VSMGERSQ
+    - AWS_ACCESS_KEY_ID=AKIAIE3PM7VKCMUX7TIA
     # AWS_SECRET_ACCESS_KEY
-    - secure: "dwqNcne26b9MIGhO+t5//nTALVvL1XAHf2SS590Wqh8V3MA9eboalCTPB/8o8N3E0nNwW3EIKSjsecp+AAziEXBSQtJhMzHBQIMhmfLVPvpxZniN6jg+oZwlhj+AkUMz5f95lgwmowHSchQJmJZDKTth/7L+Z3KgD7yVFiJKhWA="
+    - secure: "QadoE7tZXlUoLcgqlQsJOb0B5CjW/pOz/geBe3ObzYJ0vs60JztT1ySbz0LSqiUWXJyWL+RroBcoauzILUBjN5uszFaxZQ80J5GL+bwhlLaK/PpIf/37HCXmEQ0yzJyGWMKsr0Mp6d2DXUC2XNqf1InmygEwGbgFZFzMvdZ2KB981EfxxzZNsQhxak/WFUjvvJ9m95OfSGerb8swvpIH0zIg0MG3Gmj+xPCI+4eSLOYa+xLkDIjBngEPKZ0Uvfg32fB6k47XktFRpOkoS6ecDxPF7fjqjVRF+j7Y9MkH+FvSOohF48u5klqYZA7SMAbGO5n4xRkDkA2Wn3XH8jnOkt307OGm2zvTRSa3QowaJgnHRfSsGy5+ql6J3w7Ap0jqCGWwqV3qldkyC7rblz3oRHhyB52xm283T4ptDuIN29UNn+zWOgk3sSKIO3jmShNc/x7l+DoTTuMz72hw1gd3YTrCJ651pTPDXjkCb5Yn7Gt4SxKPUENL+USHohHD69WuhruFawdgctFh1WhFLr2vTvqh1eHxU5oyXV4PJwXuG2wIqnGwjaAYoRph58r28GE8YX487MlLKpGL8xXOaEdcQaADRQVihE5QW9XOt/E3DWFA+Ntt+U0SsegY1HHT/lkA29U3inXV1Nvt6P1+AKz8AuYT4QndZSMI8K9YOUlcP8E="
     # FASTLY_API_KEY
-    - secure: gdbeNjLU9smyegb7nNIwqi6oghu2TwQ9u0l0+BtqIUO6y3O/J9orkCGkWhwtaRkOtLVVakduC0qCCZDD24f/2aZoPN4XhHeNL6oDnq9TngKqi4/sOYRUQ5TB8xL+ja3H6Gx9bB1FhpohuMlfTbCnO3lLWP0Oj4btbcsfsYe8ytM=
+    - secure: "t3dUI5oNwsB1gSP3DIwwxnY7z/NigMm4XgMrQuiU5xda4sL67JQ/sU8j00I3B9TnfA1fekMBzMOKES+F7SI1y+b6K7q+SOI4mgcNqRcQKJans6o6XuBVT9Tp8om7izxOgp0lVLuHxv4OVEhmhORTCWjk/jW1M45oG5oAYOvATsbQ/gZiVCKMrb8bSSpl6eSn5YqIvJiqDW707O2wUDJsdiS4bXTIVUtai+hCeIckitrrFWWkDNWnP0/OnFb3F2ka3lFRwfuUH8UQ6oqT4YcumngIMbIvBSCOBOenGagvrhpcX2m0cVDNY/sE6iv9c2HBSlEK6vaYAbkfX6mpNseruPPq7xv5HGBhj6wlkCHpML1xse7qbCTgzKUlIfkAQQljmUH7c/mN1i9YucoMtgJxRqZCiuoO/hNILcAoQFv14NvqUNOgGeYqHzi3RSxMeQxs3uLA1l0AZpLR6aPNOM9XZyVxhFw55htS5yY52rvXVz4TR1JF22RZesT8V/WpQoPSP1d4bmVVIqa83piqQJ65cMQ0YyhQWRLtWIipvKlztnwpSV/J2LjXzbZm4J//0ArCNx0wNggrkyL7xBpmgbLgRCgid9SUlIX1HPisdJkL/z7lmz9s05ppATiipy/PduaqCZ/Lpq4wMZ8S2ILLPbNtYx8EOPGjLspPnXbpHB4z73A="
     # FASTLY_SERVICE_KEY
-    - secure: GoX6A9uqZ7avilS62w+Noju1ntmqK45C98apBrVnym0tDON3W7kJ5sUJiq6x3+oFOxn0QlaOX1Mku5GyesDE+NbGm4YlLLcucTv2gi9iab5HJsxhHNsLgyMWBPCj25n2qcaCQE0g7naRSThnpRFFV+U6wbqLBods0jKbL95yrPY=
+    - secure: "SFcY62bzpxUVD6ZDE23KudYX5gCt9fuH8QE2wAE+Pu4LPj9SKQyOwpbx3Aej2EzPk14RNA2HKXr3jY+rGdSpNrSyTmbf2IMOolVjIDSoT2xD5E+hAARfuurjHH8l9Bwb8KRiPG3oxcM85oXU6kd882SN5CsM3jY65vj94I/SMZYpUB7KSUQP8ji7hoE1eVeXQWi2AM+fjPFwWG1BhiP16j7SyAaDCAI+jDAeTplrdg10pxIKv7ef1wOHahyGlORdxubAilQW+dZuubMjl2qgPem8FQRmYSLJNEAvj663QYZf1XfH1fDYavW7J0l9vj4E8BwXUAdYn20JPwR6HSI/XsJrpxEc/PEt/2HqhTPAnxVwKQkXEgbKxCamPDIwBANwhjOdetY9dR8w9W4rsJ7wT7WQw40chlFO1gU8Ct4dIlCYogtTBxRdrCObTWRkGlsEH2XNxt4lE4xoE79njlQqNj/Wq0FeyljLPIaK90E1C9O0Q5Li1LaiIQTxyaoivLGELXrsysvkRwEOOCGiFt6w8P1LDEqoKz7Z5tu7+dbh3c31KCgPsgo150/Q4+plnq6+GoY+3ejWac7qf+q1dbp5Gx4lNPBKKuUylhx7TYUlpAp3hLcoA3fs245eYbbv1+fJ1SLIFGYNTHzRRmbB1bZaHQeHl8dMNuMh4JVDexAuCXc="
     install: "(cd www && bundle install)"
     script: "(cd www && ./bin/middleman build)"
     after_script: ./support/ci/deploy_website.sh
-    deploy:
-      provider: s3
-      access_key_id: AKIAJD2LEPZPVODPFLIQ
-      secret_access_key:
-        secure: U1oAoekCDu6Qa94sANnJH9dfa6g0E9GpvDPwnE6Kv2/d8uprXapWtLvVJ8rnrB/4fLgDntqgMpZYbmETbsCkfnX1olxlch6J06Tel/xJPX//mPG7v3ZEYcpyKAfdI1X9je9jP23ijkEnFMtkjlJ/JDOd9nHqsbECeeUY3U8ZiUk=
-      bucket: habitat-web-www
-      local-dir: www/build
-      skip_cleanup: true
-      acl: public_read
-      on:
-        repo: habitat-sh/habitat
-    after_deploy:
-    - "./support/purge_website.sh"
 notifications:
-  slack:
-    on_failure: always
-    on_success: change
-    secure: FjTKlrpHSKlUktFSf9W6ANmxWujelaN4bPRletBXkNwmZYwpqN1YC4lFwS16X0J6kNyvHGRva018YsUMtwI/FXtHH3YliyxCivmEoeAlZa+jMdy16pmBGhxo+mPC92SnHt1DhXfQUTstWw3h+Lq2F2MfwrB8k+nVBFJjfrF8HY0=
   webhooks: http://52.37.151.35:54856/travis

--- a/support/purge_website.sh
+++ b/support/purge_website.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-set -e
-
-curl -H "Fastly-Key: ${FASTLY_API_KEY}" -X POST "https://api.fastly.com/service/${FASTLY_SERVICE_KEY}/purge_all"

--- a/terraform/www.tf
+++ b/terraform/www.tf
@@ -58,6 +58,14 @@ resource "aws_s3_bucket" "www" {
       },
       "Resource": "arn:aws:s3:::${var.www_bucket_name}",
       "Action": "s3:*"
+    },
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::${var.aws_account_id}:user/${aws_iam_user.www.name}"
+      },
+      "Resource": "arn:aws:s3:::${var.www_bucket_name}/*",
+      "Action": "s3:*"
     }
   ]
 }

--- a/www/config.rb
+++ b/www/config.rb
@@ -62,6 +62,7 @@ activate :autoprefixer
 activate :directory_indexes
 
 activate :s3_sync do |s3_sync|
+  s3_sync.path_style = false
   s3_sync.region = ENV["AWS_DEFAULT_REGION"]
 end
 


### PR DESCRIPTION
* We've switched from pro to non-pro travis, so all of the secure keys
  have been regenerated
* Update the bucket policy to add the thing that was causing the deploy
  to the new bucket on the habitat org to fail
* Remove the slack notification, because it's disabled anyway (Homu
  posts notifications to Slack instead)
* Set `path_style = false` in the s3_sync; `true` is only needed if you
  have special characters in your bucket name; we don't
* Remove the Travis deploy for the bucket on the CIA account (currently
  the active website.)

Deploying to the new bucket will not work until the terraform change to
the bucket policy is applied.

This makes it so the website is not deployed to the bucket it's being
served from now, so the Fastly service will need to be pointed at the
new bucket once the deploy succeeds.

![gif-keyboard-10398425249175422067](https://cloud.githubusercontent.com/assets/9912/16142386/adc5d28e-3419-11e6-9528-28f58d0072e7.gif)
