### PR TITLE
Reverse order of installed output statement

### DIFF
--- a/components/common/src/command/package/install.rs
+++ b/components/common/src/command/package/install.rs
@@ -168,8 +168,8 @@ fn install_from_depot(url: &str,
             } else {
                 println!("{} {} which satisfies {}",
                          Green.paint("→ Using"),
-                         given_ident,
-                         ident.as_ref());
+                         ident.as_ref(),
+                         given_ident);
             }
         }
         Err(_) => {


### PR DESCRIPTION
When installing dependencies, reading the language doesn't make a ton of sense.

Before:
```
→ Using core/which/2.21/20160612155441
→ Using core/zlib/1.2.8/20160612064520
→ Using miketheman/custompkg which satisfies miketheman/custompkg/0.1.0/20160617171833
```

After:
```
→ Using core/which/2.21/20160612155441
→ Using core/zlib/1.2.8/20160612064520
→ Using miketheman/custompkg/0.1.0/20160617171833 which satisfies miketheman/custompkg
```