### PR TITLE
Include ensurepip in configure for core/python2

### DIFF
--- a/plans/python2/plan.sh
+++ b/plans/python2/plan.sh
@@ -19,6 +19,7 @@ do_prepare() {
 
 do_build() {
     ./configure --prefix=${pkg_prefix} \
-                --enable-shared
+                --enable-shared \
+                --with-ensurepip
     make
 }


### PR DESCRIPTION
Builds the `pip` binaries.

Signed-off-by: Samuel Cassiba <s@cassiba.com>