### PR TITLE
Fix Travis CI badge.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Habitat
 
-[![Build Status](https://travis-ci.org/habitat-sh/habitat.svg?branch=master)](https://travis-ci.org/habitat-sh/habitat)
+[![Build Status](https://api.travis-ci.org/habitat-sh/habitat.svg?branch=master)](https://travis-ci.org/habitat-sh/habitat)
 [![Slack](http://slack.habitat.sh/badge.svg)](http://slack.habitat.sh/)
 
 Want to try Habitat? [Get started here](https://www.habitat.sh/try/).


### PR DESCRIPTION
I don't know if it's that GitHub's image caching doesn't know how to handle redirects or what, but the badge doesn't seem to show up unless we use the redirect target URL.