### PR TITLE
hab-static is no more, "hab pkg export mesos" works again

### DIFF
--- a/components/pkg-mesosize/plan.sh
+++ b/components/pkg-mesosize/plan.sh
@@ -4,7 +4,7 @@ pkg_version=0.1.0
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_source=nosuchfile.tar.gz
-pkg_deps=(core/coreutils core/findutils core/gawk core/grep core/bash core/tar core/gzip core/hab-static core/hab-studio)
+pkg_deps=(core/coreutils core/findutils core/gawk core/grep core/bash core/tar core/gzip core/hab)
 pkg_build_deps=()
 pkg_bin_dirs=(bin)
 

--- a/components/studio/libexec/hab-studio-type-bare.sh
+++ b/components/studio/libexec/hab-studio-type-bare.sh
@@ -6,7 +6,7 @@ studio_build_command=
 studio_run_environment=
 studio_run_command=
 
-base_pkgs="core/hab-static core/hab-sup"
+base_pkgs="core/hab core/hab-sup"
 : ${PKGS:=}
 
 run_user="hab"
@@ -37,7 +37,7 @@ finish_setup() {
     _hab install $pkg
   done
 
-  local hab_path=$(_pkgpath_for core/hab-static)
+  local hab_path=$(_pkgpath_for core/hab)
   local sup_path=$(_pkgpath_for core/hab-sup)
   local busybox_path=$(_pkgpath_for core/busybox-static)
 
@@ -70,7 +70,7 @@ finish_setup() {
   $bb mkdir -p $v $HAB_STUDIO_ROOT$HAB_ROOT_PATH/bin
 
   # Put `hab` on the default `$PATH`
-  _hab pkg binlink --dest $HAB_ROOT_PATH/bin core/hab-static hab
+  _hab pkg binlink --dest $HAB_ROOT_PATH/bin core/hab hab
 
   # Create `/bin/{sh,bash}` for software that hardcodes these shells
   _hab pkg binlink core/busybox-static bash


### PR DESCRIPTION
Looks like this was overlooked when hab-static was removed.