### PR TITLE
upload signing keys when uploading packages

### DIFF
--- a/components/hab/src/command/cli.rs
+++ b/components/hab/src/command/cli.rs
@@ -23,7 +23,7 @@ pub mod setup {
 
     use analytics;
     use command;
-    use config::{self, Config};
+    use config;
     use error::Result;
 
     pub fn start(cache_path: &Path, analytics_path: &Path) -> Result<()> {


### PR DESCRIPTION
Attempt to upload an artifacts signing key during `hab pkg upload`. If the key already exists, we just make a note and move on with the upload. This is cheaper than requesting a list of all public origin keys from the depot and iterating through them.

![1__tmux](https://cloud.githubusercontent.com/assets/58244/16162648/ae803b9a-34a2-11e6-9149-1e3209efcad7.png)

addresses https://github.com/habitat-sh/habitat/issues/895