### PR TITLE
Add Apache Maven 3 plan

### DIFF
--- a/plans/maven/README.md
+++ b/plans/maven/README.md
@@ -1,0 +1,20 @@
+# Apache Maven 3
+
+See [https://maven.apache.org/index.html](https://maven.apache.org/index.html) for more information.
+
+
+To use this plan, you'll need to set the `JAVA_HOME` and pay attention to the location of `M2_HOME` during packaging.
+
+```
+export M2_HOME=/foo/bar/baz
+
+# Ant requires JAVA_HOME to be set, and can be set via:
+export JAVA_HOME=$(hab pkg path core/jdk8)
+```
+
+
+To use `mvn` in the Habitat dev shell:
+
+```
+hab pkg binlink core/maven mvn
+```

--- a/plans/maven/plan.sh
+++ b/plans/maven/plan.sh
@@ -1,0 +1,23 @@
+pkg_origin=core
+pkg_name=maven
+pkg_version=3.3.9
+pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
+pkg_license=('Apache-2.0')
+pkg_source=http://apache.cs.utah.edu/maven/maven-3/${pkg_version}/source/apache-maven-${pkg_version}-src.tar.gz
+pkg_shasum=9150475f509b23518e67a220a9d3a821648ab27550f4ece4d07b92b1fc5611bc
+pkg_deps=(core/jdk8)
+pkg_build_deps=(core/jdk8 core/ant)
+pkg_bin_dirs=(bin)
+pkg_include_dirs=(include)
+pkg_lib_dirs=(lib)
+
+do_build() {
+  export JAVA_HOME=$(hab pkg path core/jdk8)
+  pushd $HAB_CACHE_SRC_PATH/apache-maven-$pkg_version
+  ant -Dmaven.home="${pkg_prefix}"
+}
+
+
+do_install() {
+  return 0
+}


### PR DESCRIPTION
This plan depends on `core/ant`, which is included in https://github.com/habitat-sh/habitat/pull/919.