### PR TITLE
Impove error handling for origins

### DIFF
--- a/components/builder-web/app/BuilderApiClient.ts
+++ b/components/builder-web/app/BuilderApiClient.ts
@@ -86,7 +86,11 @@ export class BuilderApiClient {
                 headers: this.headers,
             }).then(response => {
                 response.json().then(data => {
-                    resolve(data["origins"]);
+                    if (response.ok) {
+                        resolve(data["origins"]);
+                    } else {
+                        reject(new Error(response.statusText));
+                    }
                 });
             }).catch(error => reject(error));
         });

--- a/components/builder-web/app/origins-page/OriginsPageComponent.ts
+++ b/components/builder-web/app/origins-page/OriginsPageComponent.ts
@@ -34,7 +34,7 @@ import {requireSignIn} from "../util";
             <p *ngIf="ui.errorMessage">
                 Failed to load origins: {{ui.errorMessage}}
             </p>
-            <div *ngIf="origins.size === 0">
+            <div *ngIf="origins.size === 0 && !ui.errorMessage">
                 <div class="hero">
                     <h3>You don't currently have any origins. Let's add one now.</h3>
                     <p>


### PR DESCRIPTION
* Show an error message when origins fail to load
* Do not show the call to create a new origin when there's an error
* If we get a 401 from GitHub, notify the user and sign out

Fixes #894.

![gif-keyboard-17666572379971342815](https://cloud.githubusercontent.com/assets/9912/16203275/18f63d9c-36df-11e6-8743-4ab125f7c0db.gif)