### PR TITLE
Correct pkg_include_dirs for core/libffi

### DIFF
--- a/plans/libffi/plan.sh
+++ b/plans/libffi/plan.sh
@@ -9,7 +9,7 @@ pkg_shasum=d06ebb8e1d9a22d19e38d63fdb83954253f39bedc5d46232a05645685722ca37
 pkg_deps=(core/glibc core/libtool)
 pkg_build_deps=(core/coreutils core/make core/gcc)
 pkg_lib_dirs=(lib)
-pkg_include_dirs=(include)
+pkg_include_dirs=(lib/${pkg_name}-${pkg_version}/include)
 
 do_build() {
     ./configure --prefix=${pkg_prefix} --disable-multi-os-directory


### PR DESCRIPTION
Signed-off-by: Samuel Cassiba <s@cassiba.com>