### PR TITLE
add a start-web-dev Makefile target for front end devs

### DIFF
--- a/components/builder-api/builder_api.toml
+++ b/components/builder-api/builder_api.toml
@@ -1,0 +1,13 @@
+http_addr = "0.0.0.0:9636"
+router_addrs = ["127.0.0.1:5562"]
+
+[depot]
+datastore_addr = "0.0.0.0:6379"
+
+[github]
+url = "https://api.github.com"
+# these are public, stored in this file:
+# https://github.com/habitat-sh/habitat/blob/master/components/builder-api/src/config.rs#L28-L34
+# we're not divulging any secrets here
+client_id = "e98d2a94787be9af9c00"
+client_secret = "e5ff94188e3cf01d42f3e2bcbbe4faabe11c71ba"

--- a/components/builder-api/habitat/default.toml
+++ b/components/builder-api/habitat/default.toml
@@ -1,3 +1,14 @@
+http_addr = "0.0.0.0:9636"
+router_addrs = ["127.0.0.1:5562"]
+
+[depot]
+datastore_addr = "0.0.0.0:6379"
+
+[github]
+url = "https://api.github.com"
+client_id = "e98d2a94787be9af9c00"
+client_secret = "e5ff94188e3cf01d42f3e2bcbbe4faabe11c71ba"
+
 [ui]
 app_url          = "https://willem.habitat.sh/v1"
 community_url    = "https://www.habitat.sh/community"

--- a/components/builder-web/builder_web.toml
+++ b/components/builder-web/builder_web.toml
@@ -1,0 +1,5 @@
+[services.core.redis.dev]
+[services.core.hab-builder-router.dev]
+[services.core.hab-builder-sessionsrv.dev]
+[services.core.hab-builder-vault.dev]
+[services.core.hab-builder-api.dev]


### PR DESCRIPTION
This is for @ryankeairns et al

- From an OSX terminal:
```
make start-web-dev
```

- Update `components/builder-web/habitat.conf.js`, you'll need to get the IP of the running container (or docker-machine) and use it in the `habitat_api_url` value.

```
habitatConfig({
    habitat_api_url: "http://172.16.127.128:9636/v1",
    // the value below isn't secret, you can find it in the public habitat.sh repo.
    github_client_id: "e98d2a94787be9af9c00",
});
```

- In OSX:
```
cd components/builder-web
nvm use v4.2.6
npm install
npm start
```

---

Additionally, this PR automatically opens up port 9636 in a dev shell.