### PR TITLE
Only build the "auto" branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 branches:
   only:
-  - master
   - auto
 env:
   global:


### PR DESCRIPTION
The Homu readme (https://github.com/barosl/homu,
https://github.com/servo/homu), says to do `only: -auto` in .travis.yml,
but we have master and auto.

This probably will make it so we don't do that extra build on master.

![gif-keyboard-4269918751022729145](https://cloud.githubusercontent.com/assets/9912/16218205/6f480eda-3740-11e6-8290-faff758211af.gif)
