### PR TITLE
[plan-build] Escape upper and lower tr classes

### DIFF
--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -324,9 +324,9 @@ INITIAL_PATH="$PATH"
 # The value of `pwd` on initial start of this program
 INITIAL_PWD="$(pwd)"
 # The target architecture this plan will be built for
-pkg_arch=$(uname -m | tr [[:upper:]] [[:lower:]])
+pkg_arch=$(uname -m | tr '[:upper:]' '[:lower:]')
 # The target system (i.e. operating system variant) this plan will be built for
-pkg_sys=$(uname -s | tr [[:upper:]] [[:lower:]])
+pkg_sys=$(uname -s | tr '[:upper:]' '[:lower:]')
 # The full target tuple this plan will be built for
 pkg_target="${pkg_arch}-${pkg_sys}"
 # The package's origin (i.e. acme)


### PR DESCRIPTION
Before this commit, the arguments to the changed tr commands were being
interpreted by the shell as file globs and only passed onto `tr` if the
glob failed.  If a file in the current working directory matched the
glob, a user's build would either fail with the following confusing
error message:

    [53][default:/src:1]# build /src/R
    tr: misaligned [:upper:] and/or [:lower:] construct

in the case of the first [:upper:] glob matching or, in the case of the
[:lower:] glob matching, silently save the pkg_arch and pkg_sys with any
upper case characters translated to the single character that the shell
glob matched to.

The debug output shows the command that bash is ultimately running
post-glob:

    ++ tr R '[[:lower:]]'
    tr: misaligned [:upper:] and/or [:lower:] construct
    + pkg_arch=

In this example the R folder has matched the first glob and thus the tr
command is invalid and fails with an error.

This likely hasn't been hit in the common case since it requires that
you have a file or directory with single character name in your current
directory.

In addition to escaping the tr argument with single quotes to avoid
shell globbing, I've also removed the double brackets per the usage in
the tr manual page.

Signed-off-by: Steven Danna <steve@chef.io>