### PR TITLE
Move DataStore ownership from dispatcher/worker to server

### DIFF
--- a/components/builder-api/Cargo.lock
+++ b/components/builder-api/Cargo.lock
@@ -163,6 +163,7 @@ dependencies = [
  "env_logger 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat_builder_protocol 0.7.0",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "r2d2 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "r2d2_redis 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/builder-dbcache/Cargo.lock
+++ b/components/builder-dbcache/Cargo.lock
@@ -5,6 +5,7 @@ dependencies = [
  "env_logger 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat_builder_protocol 0.7.0",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "r2d2 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "r2d2_redis 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -151,6 +152,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "memchr"
 version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num_cpus"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/builder-dbcache/Cargo.toml
+++ b/components/builder-dbcache/Cargo.toml
@@ -7,6 +7,7 @@ description = "Habitat-Builder Database Access Library"
 [dependencies]
 env_logger = "*"
 log = "*"
+num_cpus = "*"
 protobuf = "*"
 r2d2 = "*"
 r2d2_redis = "*"

--- a/components/builder-dbcache/src/config.rs
+++ b/components/builder-dbcache/src/config.rs
@@ -12,20 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-extern crate habitat_builder_protocol as protocol;
-#[macro_use]
-extern crate log;
-extern crate num_cpus;
-extern crate protobuf;
-extern crate r2d2;
-extern crate r2d2_redis;
-extern crate redis;
-extern crate rustc_serialize;
-extern crate time;
+use std::net;
 
-pub mod config;
-pub mod data_store;
-pub mod error;
+use num_cpus;
 
-pub use self::data_store::{ConnectionPool, Bucket, BasicSet, ExpiringSet, InstaSet, IndexSet};
-pub use self::error::{Error, Result};
+pub trait DataStoreCfg {
+    fn default_connection_retry_ms() -> u64 {
+        5_000
+    }
+
+    fn default_pool_size() -> u32 {
+        (num_cpus::get() * 8) as u32
+    }
+
+    fn connection_retry_ms(&self) -> u64;
+    fn datastore_addr(&self) -> &net::SocketAddrV4;
+    fn pool_size(&self) -> u32;
+}

--- a/components/builder-jobsrv/Cargo.lock
+++ b/components/builder-jobsrv/Cargo.lock
@@ -116,6 +116,7 @@ dependencies = [
  "env_logger 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat_builder_protocol 0.7.0",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "r2d2 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "r2d2_redis 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/builder-jobsrv/src/config.rs
+++ b/components/builder-jobsrv/src/config.rs
@@ -16,6 +16,7 @@
 
 use std::net;
 
+use dbcache::config::DataStoreCfg;
 use hab_core::config::{ConfigFile, ParseInto};
 use hab_net::config::{DispatcherCfg, RouteAddrs, Shards};
 use protocol::sharding::{ShardId, SHARD_COUNT};
@@ -33,10 +34,14 @@ pub struct Config {
     pub worker_heartbeat_addr: net::SocketAddrV4,
     /// Net dddress to the persistent datastore.
     pub datastore_addr: net::SocketAddrV4,
-    /// List of shard identifiers serviced by the running service.
-    pub shards: Vec<ShardId>,
+    /// Connection retry timeout in milliseconds for datastore.
+    pub datastore_retry_ms: u64,
+    /// Number of database connections to start in pool.
+    pub pool_size: u32,
     /// Router's hearbeat port to connect to.
     pub heartbeat_port: u16,
+    /// List of shard identifiers serviced by the running service.
+    pub shards: Vec<ShardId>,
     /// Number of threads to process queued messages.
     pub worker_threads: usize,
 }
@@ -48,6 +53,8 @@ impl Default for Config {
             worker_command_addr: net::SocketAddrV4::new(net::Ipv4Addr::new(0, 0, 0, 0), 5566),
             worker_heartbeat_addr: net::SocketAddrV4::new(net::Ipv4Addr::new(0, 0, 0, 0), 5567),
             datastore_addr: net::SocketAddrV4::new(net::Ipv4Addr::new(127, 0, 0, 1), 6379),
+            datastore_retry_ms: Self::default_connection_retry_ms(),
+            pool_size: Self::default_pool_size(),
             shards: (0..SHARD_COUNT).collect(),
             heartbeat_port: 5563,
             worker_threads: Self::default_worker_count(),
@@ -64,9 +71,26 @@ impl ConfigFile for Config {
         try!(toml.parse_into("cfg.worker_command_addr", &mut cfg.worker_command_addr));
         try!(toml.parse_into("cfg.worker_heartbeat_addr", &mut cfg.worker_heartbeat_addr));
         try!(toml.parse_into("cfg.datastore_addr", &mut cfg.datastore_addr));
-        try!(toml.parse_into("cfg.shards", &mut cfg.shards));
+        try!(toml.parse_into("cfg.datastore_retry_ms", &mut cfg.datastore_retry_ms));
+        try!(toml.parse_into("cfg.pool_size", &mut cfg.pool_size));
         try!(toml.parse_into("cfg.heartbeat_port", &mut cfg.heartbeat_port));
+        try!(toml.parse_into("cfg.shards", &mut cfg.shards));
+        try!(toml.parse_into("cfg.worker_threads", &mut cfg.worker_threads));
         Ok(cfg)
+    }
+}
+
+impl DataStoreCfg for Config {
+    fn datastore_addr(&self) -> &net::SocketAddrV4 {
+        &self.datastore_addr
+    }
+
+    fn connection_retry_ms(&self) -> u64 {
+        self.datastore_retry_ms
+    }
+
+    fn pool_size(&self) -> u32 {
+        self.pool_size
     }
 }
 

--- a/components/builder-jobsrv/src/server/handlers.rs
+++ b/components/builder-jobsrv/src/server/handlers.rs
@@ -31,7 +31,7 @@ pub fn job_create(req: &mut Envelope,
     job.set_state(proto::JobState::default());
     state.datastore().jobs.write(&mut job).unwrap();
     state.datastore().job_queue.enqueue(&job).unwrap();
-    try!(state.work_manager.notify_work());
+    try!(state.worker_mgr().notify_work());
     try!(req.reply_complete(sock, &job));
     Ok(())
 }

--- a/components/builder-jobsrv/src/server/worker_manager.rs
+++ b/components/builder-jobsrv/src/server/worker_manager.rs
@@ -1,0 +1,247 @@
+// Copyright (c) 2016 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::{mpsc, Arc, RwLock};
+use std::time::{Duration, Instant};
+use std::thread::{self, JoinHandle};
+
+use dbcache::InstaSet;
+use linked_hash_map::LinkedHashMap;
+use hab_net::config::ToAddrString;
+use hab_net::server::{Service, ZMQ_CONTEXT};
+use protobuf::{parse_from_bytes, Message};
+use protocol::jobsrv;
+use zmq;
+
+use config::Config;
+use data_store::DataStore;
+use error::Result;
+
+const WORKER_MGR_ADDR: &'static str = "inproc://work-manager";
+const WORKER_TIMEOUT_MS: u64 = 33_000;
+
+pub struct WorkerMgrClient {
+    socket: zmq::Socket,
+}
+
+impl WorkerMgrClient {
+    pub fn connect(&mut self) -> Result<()> {
+        try!(self.socket.connect(WORKER_MGR_ADDR));
+        Ok(())
+    }
+
+    pub fn notify_work(&mut self) -> Result<()> {
+        try!(self.socket.send(&[1], 0));
+        Ok(())
+    }
+}
+
+impl Default for WorkerMgrClient {
+    fn default() -> WorkerMgrClient {
+        let socket = (**ZMQ_CONTEXT).as_mut().socket(zmq::DEALER).unwrap();
+        socket.set_sndhwm(1).unwrap();
+        socket.set_linger(0).unwrap();
+        socket.set_immediate(true).unwrap();
+        WorkerMgrClient { socket: socket }
+    }
+}
+
+pub struct WorkerMgr {
+    config: Arc<RwLock<Config>>,
+    datastore: Arc<Box<DataStore>>,
+    hb_sock: zmq::Socket,
+    rq_sock: zmq::Socket,
+    work_mgr_sock: zmq::Socket,
+    msg: zmq::Message,
+    workers: LinkedHashMap<String, Instant>,
+}
+
+impl WorkerMgr {
+    pub fn new(config: Arc<RwLock<Config>>, datastore: Arc<Box<DataStore>>) -> Result<Self> {
+        let hb_sock = try!((**ZMQ_CONTEXT).as_mut().socket(zmq::SUB));
+        let rq_sock = try!((**ZMQ_CONTEXT).as_mut().socket(zmq::ROUTER));
+        let work_mgr_sock = try!((**ZMQ_CONTEXT).as_mut().socket(zmq::DEALER));
+        try!(rq_sock.set_router_mandatory(true));
+        try!(hb_sock.set_subscribe(&[]));
+        try!(work_mgr_sock.set_rcvhwm(1));
+        try!(work_mgr_sock.set_linger(0));
+        try!(work_mgr_sock.set_immediate(true));
+        let msg = try!(zmq::Message::new());
+        Ok(WorkerMgr {
+            config: config,
+            datastore: datastore,
+            hb_sock: hb_sock,
+            rq_sock: rq_sock,
+            work_mgr_sock: work_mgr_sock,
+            msg: msg,
+            workers: LinkedHashMap::new(),
+        })
+    }
+
+    pub fn start(cfg: Arc<RwLock<Config>>, ds: Arc<Box<DataStore>>) -> Result<JoinHandle<()>> {
+        let (tx, rx) = mpsc::sync_channel(1);
+        let handle = thread::Builder::new()
+            .name("worker-manager".to_string())
+            .spawn(move || {
+                let mut manager = Self::new(cfg, ds).unwrap();
+                manager.run(tx).unwrap();
+            })
+            .unwrap();
+        match rx.recv() {
+            Ok(()) => Ok(handle),
+            Err(e) => panic!("worker-manager thread startup error, err={}", e),
+        }
+    }
+
+    fn run(&mut self, rz: mpsc::SyncSender<()>) -> Result<()> {
+        try!(self.work_mgr_sock.bind(WORKER_MGR_ADDR));
+        {
+            let cfg = self.config.read().unwrap();
+            println!("Listening for commands on {}",
+                     cfg.worker_command_addr.to_addr_string());
+            try!(self.rq_sock.bind(&cfg.worker_command_addr.to_addr_string()));
+            println!("Listening for heartbeats on {}",
+                     cfg.worker_heartbeat_addr.to_addr_string());
+            try!(self.hb_sock.bind(&cfg.worker_heartbeat_addr.to_addr_string()));
+        }
+        let mut hb_sock = false;
+        let mut rq_sock = false;
+        let mut work_mgr_sock = false;
+        rz.send(()).unwrap();
+        loop {
+            {
+                let timeout = self.poll_timeout();
+                let mut items = [self.hb_sock.as_poll_item(1),
+                                 self.rq_sock.as_poll_item(1),
+                                 self.work_mgr_sock.as_poll_item(1)];
+                // Poll until timeout or message is received. Checking for the zmq::POLLIN flag on
+                // a poll item's revents will let you know if you have received a message or not
+                // on that socket.
+                try!(zmq::poll(&mut items, timeout));
+                if (items[0].get_revents() & zmq::POLLIN) > 0 {
+                    hb_sock = true;
+                }
+                if (items[1].get_revents() & zmq::POLLIN) > 0 {
+                    rq_sock = true;
+                }
+                if (items[2].get_revents() & zmq::POLLIN) > 0 {
+                    work_mgr_sock = true;
+                }
+            }
+            if hb_sock {
+                try!(self.process_heartbeat());
+                hb_sock = false;
+            }
+            self.expire_workers();
+            if rq_sock {
+                try!(self.process_job_status());
+                rq_sock = false;
+            }
+            if work_mgr_sock {
+                try!(self.distribute_work());
+            }
+        }
+        Ok(())
+    }
+
+    fn poll_timeout(&self) -> i64 {
+        if let Some((_, expiry)) = self.workers.front() {
+            let timeout = *expiry - Instant::now();
+            (timeout.as_secs() as i64 * 1000) + (timeout.subsec_nanos() as i64 / 1000 / 1000)
+        } else {
+            -1
+        }
+    }
+
+    fn distribute_work(&mut self) -> Result<()> {
+        loop {
+            let job = match self.datastore.job_queue.peek() {
+                Ok(Some(job)) => job,
+                Ok(None) => break,
+                Err(e) => return Err(e),
+            };
+            match self.workers.pop_front() {
+                Some((worker, _)) => {
+                    debug!("sending work, worker={:?}, job={:?}", worker, job);
+                    if self.rq_sock.send_str(&worker, zmq::SNDMORE).is_err() {
+                        debug!("failed to send, worker went away, worker={:?}", worker);
+                        continue;
+                    }
+                    if self.rq_sock.send(&[], zmq::SNDMORE).is_err() {
+                        debug!("failed to send, worker went away, worker={:?}", worker);
+                        continue;
+                    }
+                    if self.rq_sock.send(&job.write_to_bytes().unwrap(), 0).is_err() {
+                        debug!("failed to send, worker went away, worker={:?}", worker);
+                        continue;
+                    }
+                    // JW TODO: Wait for response back to ensure we can dequeue this. If state
+                    // returned is not processing then we move onto next worker and assume this
+                    // worker is no longer valid. Put work back on queue.
+                    try!(self.datastore.job_queue.dequeue());
+                    // Consume the to-do work notification if the queue is empty.
+                    if try!(self.datastore.job_queue.peek()).is_none() {
+                        try!(self.work_mgr_sock.recv(&mut self.msg, 0));
+                    }
+                    break;
+                }
+                None => break,
+            }
+        }
+        Ok(())
+    }
+
+    fn expire_workers(&mut self) {
+        let now = Instant::now();
+        loop {
+            if let Some((_, expiry)) = self.workers.front() {
+                if expiry >= &now {
+                    break;
+                }
+            } else {
+                break;
+            }
+            let worker = self.workers.pop_front();
+            debug!("expiring worker due to inactivity, worker={:?}", worker);
+        }
+    }
+
+    fn process_heartbeat(&mut self) -> Result<()> {
+        try!(self.hb_sock.recv(&mut self.msg, 0));
+        let heartbeat: jobsrv::Heartbeat = try!(parse_from_bytes(&self.msg));
+        debug!("heartbeat={:?}", heartbeat);
+        match heartbeat.get_state() {
+            jobsrv::WorkerState::Ready => {
+                let now = Instant::now();
+                let expiry = now + Duration::from_millis(WORKER_TIMEOUT_MS);
+                self.workers.insert(heartbeat.get_endpoint().to_string(), expiry);
+            }
+            jobsrv::WorkerState::Busy => {
+                self.workers.remove(heartbeat.get_endpoint());
+            }
+        }
+        Ok(())
+    }
+
+    fn process_job_status(&mut self) -> Result<()> {
+        // Pop message delimiter
+        try!(self.rq_sock.recv(&mut self.msg, 0));
+        // Pop message body
+        try!(self.rq_sock.recv(&mut self.msg, 0));
+        let job: jobsrv::Job = try!(parse_from_bytes(&self.msg));
+        debug!("job_status={:?}", job);
+        try!(self.datastore.jobs.update(&job));
+        Ok(())
+    }
+}

--- a/components/builder-router/Cargo.lock
+++ b/components/builder-router/Cargo.lock
@@ -112,6 +112,7 @@ dependencies = [
  "env_logger 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat_builder_protocol 0.7.0",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "r2d2 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "r2d2_redis 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/builder-router/src/server.rs
+++ b/components/builder-router/src/server.rs
@@ -75,7 +75,6 @@ impl<'a> Server<'a> {
         loop {
             match self.state {
                 SocketState::Ready => {
-                    println!("socket ready");
                     if self.envelope.max_hops() {
                         // We should force the sender to disconnect, they have a problem.
                         self.state = SocketState::Cleaning;

--- a/components/builder-sessionsrv/Cargo.lock
+++ b/components/builder-sessionsrv/Cargo.lock
@@ -117,6 +117,7 @@ dependencies = [
  "env_logger 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat_builder_protocol 0.7.0",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "r2d2 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "r2d2_redis 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/builder-sessionsrv/src/config.rs
+++ b/components/builder-sessionsrv/src/config.rs
@@ -15,6 +15,7 @@
 
 use std::net;
 
+use dbcache::config::DataStoreCfg;
 use hab_core::config::{ConfigFile, ParseInto};
 use hab_net::config::{DispatcherCfg, RouteAddrs, Shards};
 use protocol::sharding::{ShardId, SHARD_COUNT};
@@ -28,6 +29,10 @@ pub struct Config {
     pub routers: Vec<net::SocketAddrV4>,
     /// Net dddress to the persistent datastore.
     pub datastore_addr: net::SocketAddrV4,
+    /// Connection retry timeout in milliseconds for datastore.
+    pub datastore_retry_ms: u64,
+    /// Number of database connections to start in pool.
+    pub pool_size: u32,
     /// Router's hearbeat port to connect to.
     pub heartbeat_port: u16,
     /// List of shard identifiers serviced by the running service.
@@ -41,6 +46,8 @@ impl Default for Config {
         Config {
             routers: vec![net::SocketAddrV4::new(net::Ipv4Addr::new(127, 0, 0, 1), 5562)],
             datastore_addr: net::SocketAddrV4::new(net::Ipv4Addr::new(127, 0, 0, 1), 6379),
+            datastore_retry_ms: Self::default_connection_retry_ms(),
+            pool_size: Self::default_pool_size(),
             heartbeat_port: 5563,
             shards: (0..SHARD_COUNT).collect(),
             worker_threads: Self::default_worker_count(),
@@ -55,10 +62,26 @@ impl ConfigFile for Config {
         let mut cfg = Config::default();
         try!(toml.parse_into("cfg.routers", &mut cfg.routers));
         try!(toml.parse_into("cfg.datastore_addr", &mut cfg.datastore_addr));
+        try!(toml.parse_into("cfg.datastore_retry_ms", &mut cfg.datastore_retry_ms));
+        try!(toml.parse_into("cfg.pool_size", &mut cfg.pool_size));
         try!(toml.parse_into("cfg.heartbeat_port", &mut cfg.heartbeat_port));
         try!(toml.parse_into("cfg.shards", &mut cfg.shards));
         try!(toml.parse_into("cfg.worker_threads", &mut cfg.worker_threads));
         Ok(cfg)
+    }
+}
+
+impl DataStoreCfg for Config {
+    fn datastore_addr(&self) -> &net::SocketAddrV4 {
+        &self.datastore_addr
+    }
+
+    fn connection_retry_ms(&self) -> u64 {
+        self.datastore_retry_ms
+    }
+
+    fn pool_size(&self) -> u32 {
+        self.pool_size
     }
 }
 

--- a/components/builder-vault/Cargo.lock
+++ b/components/builder-vault/Cargo.lock
@@ -115,6 +115,7 @@ dependencies = [
  "env_logger 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat_builder_protocol 0.7.0",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "r2d2 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "r2d2_redis 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/builder-vault/src/server/mod.rs
+++ b/components/builder-vault/src/server/mod.rs
@@ -16,13 +16,13 @@ pub mod handlers;
 
 use std::ops::Deref;
 use std::sync::{Arc, RwLock};
-use std::time::Duration;
-use std::thread;
 
 use protocol::net;
 use zmq;
 
-use hab_net::{Application, Dispatcher, Supervisor};
+use dbcache::data_store::Pool;
+use hab_net::{Application, Supervisor};
+use hab_net::dispatcher::prelude::*;
 use hab_net::server::{Envelope, NetIdent, RouteConn, Service, ZMQ_CONTEXT};
 
 use config::Config;
@@ -31,19 +31,35 @@ use error::{Error, Result};
 
 const BE_LISTEN_ADDR: &'static str = "inproc://backend";
 
+#[derive(Clone)]
 pub struct ServerState {
-    datastore: DataStore,
+    datastore: Arc<Box<DataStore>>,
+}
+
+impl ServerState {
+    pub fn new(datastore: DataStore) -> Self {
+        ServerState {
+            datastore: Arc::new(Box::new(datastore)),
+        }
+    }
+}
+
+impl DispatcherState for ServerState {
+    fn is_initialized(&self) -> bool {
+        true
+    }
 }
 
 pub struct Worker {
+    #[allow(dead_code)]
     config: Arc<RwLock<Config>>,
-    state: Option<ServerState>,
 }
 
 impl Dispatcher for Worker {
-    type State = ServerState;
     type Config = Config;
     type Error = Error;
+    type InitState = ServerState;
+    type State = ServerState;
 
     fn message_queue() -> &'static str {
         BE_LISTEN_ADDR
@@ -74,38 +90,11 @@ impl Dispatcher for Worker {
     }
 
     fn new(config: Arc<RwLock<Config>>) -> Self {
-        Worker {
-            config: config,
-            state: None,
-        }
+        Worker { config: config }
     }
 
     fn context(&mut self) -> &mut zmq::Context {
         (**ZMQ_CONTEXT).as_mut()
-    }
-
-    fn init(&mut self) -> Result<()> {
-        loop {
-            let result = {
-                let cfg = self.config.read().unwrap();
-                DataStore::open(cfg.deref())
-            };
-            match result {
-                Ok(datastore) => {
-                    self.state = Some(ServerState { datastore: datastore });
-                    break;
-                }
-                Err(e) => {
-                    error!("{}", e);
-                    thread::sleep(Duration::from_millis(5000));
-                }
-            }
-        }
-        Ok(())
-    }
-
-    fn state(&mut self) -> &mut ServerState {
-        self.state.as_mut().unwrap()
     }
 }
 
@@ -144,8 +133,13 @@ impl Application for Server {
 
     fn run(&mut self) -> Result<()> {
         try!(self.be_sock.bind(BE_LISTEN_ADDR));
+        let datastore = {
+            let cfg = self.config.read().unwrap();
+            DataStore::start(cfg.deref())
+        };
         let cfg = self.config.clone();
-        let sup: Supervisor<Worker> = Supervisor::new(cfg);
+        let init_state = ServerState::new(datastore);
+        let sup: Supervisor<Worker> = Supervisor::new(cfg, init_state);
         try!(sup.start());
         try!(self.connect());
         try!(zmq::proxy(&mut self.router.socket, &mut self.be_sock));

--- a/components/core/src/config.rs
+++ b/components/core/src/config.rs
@@ -181,6 +181,36 @@ impl ParseInto<u16> for toml::Value {
     }
 }
 
+impl ParseInto<u32> for toml::Value {
+    fn parse_into(&self, field: &'static str, out: &mut u32) -> Result<bool> {
+        if let Some(val) = self.lookup(field) {
+            if let Some(v) = val.as_integer() {
+                *out = v as u32;
+                Ok(true)
+            } else {
+                Err(Error::ConfigInvalidString(field))
+            }
+        } else {
+            Ok(false)
+        }
+    }
+}
+
+impl ParseInto<u64> for toml::Value {
+    fn parse_into(&self, field: &'static str, out: &mut u64) -> Result<bool> {
+        if let Some(val) = self.lookup(field) {
+            if let Some(v) = val.as_integer() {
+                *out = v as u64;
+                Ok(true)
+            } else {
+                Err(Error::ConfigInvalidString(field))
+            }
+        } else {
+            Ok(false)
+        }
+    }
+}
+
 impl ParseInto<Vec<u16>> for toml::Value {
     fn parse_into(&self, field: &'static str, out: &mut Vec<u16>) -> Result<bool> {
         if let Some(val) = self.lookup(field) {
@@ -212,6 +242,29 @@ impl ParseInto<Vec<u32>> for toml::Value {
                 for int in v.iter() {
                     if let Some(i) = int.as_integer() {
                         buf.push(i as u32);
+                    } else {
+                        return Err(Error::ConfigInvalidArray(field));
+                    }
+                }
+                *out = buf;
+                Ok(true)
+            } else {
+                Err(Error::ConfigInvalidArray(field))
+            }
+        } else {
+            Ok(false)
+        }
+    }
+}
+
+impl ParseInto<Vec<u64>> for toml::Value {
+    fn parse_into(&self, field: &'static str, out: &mut Vec<u64>) -> Result<bool> {
+        if let Some(val) = self.lookup(field) {
+            if let Some(v) = val.as_slice() {
+                let mut buf = vec![];
+                for int in v.iter() {
+                    if let Some(i) = int.as_integer() {
+                        buf.push(i as u64);
                     } else {
                         return Err(Error::ConfigInvalidArray(field));
                     }

--- a/components/net/src/dispatcher/prelude.rs
+++ b/components/net/src/dispatcher/prelude.rs
@@ -12,20 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-extern crate habitat_builder_protocol as protocol;
-#[macro_use]
-extern crate log;
-extern crate num_cpus;
-extern crate protobuf;
-extern crate r2d2;
-extern crate r2d2_redis;
-extern crate redis;
-extern crate rustc_serialize;
-extern crate time;
-
-pub mod config;
-pub mod data_store;
-pub mod error;
-
-pub use self::data_store::{ConnectionPool, Bucket, BasicSet, ExpiringSet, InstaSet, IndexSet};
-pub use self::error::{Error, Result};
+pub use super::{Dispatcher, DispatcherState, MessageHandler};

--- a/components/net/src/lib.rs
+++ b/components/net/src/lib.rs
@@ -36,7 +36,6 @@ pub mod supervisor;
 
 use std::process::Command;
 
-pub use self::dispatcher::Dispatcher;
 pub use self::error::{Error, Result};
 pub use self::server::{Application, ServerReg};
 pub use self::supervisor::Supervisor;


### PR DESCRIPTION
DataStore connections are no longer allocated per worker and on the stack

* Allocate the connection manager to the heap
* Pass initial state to dispatcher
  * State is shared and must implement clone. This state is cloned for each worker ensuring that
    new workers are always started with the latest configuration
  * This contains a reference to the heap allocated DataStore for builder services
  * Initial state is converted into actual state and passed by reference from main loop on each
    call to dispatch a message
* Add DataStoreCfg trait for reading datastore connection info from server config file
  * DataStore specific options can now be tweaked via exposing functions on this trait. See
    the included functions for details
* Re-arrange Dispatcher components in net crate
  * Add `hab_net::dispatcher::prelude` module which allows developers to easily glob the common
    dispatcher components into their module

Signed-off-by: Jamie Winsor <jamie@vialstudios.com>

![gif-keyboard-15982393327634948593](https://cloud.githubusercontent.com/assets/54036/16245367/5a995fb4-37b5-11e6-850d-e40d45f0c98c.gif)
