### PR TITLE
[builder-web] Minor UI bug fixes

### DIFF
--- a/components/builder-web/app/AppComponent.ts
+++ b/components/builder-web/app/AppComponent.ts
@@ -33,8 +33,8 @@ import {SCMReposPageComponent} from "./scm-repos-page/SCMReposPageComponent";
 import {SideNavComponent} from "./side-nav/SideNavComponent";
 import {SignInPageComponent} from "./sign-in-page/SignInPageComponent";
 import {authenticateWithGitHub, loadSessionState, removeNotification,
-    requestGitHubAuthToken, routeChange, setGitHubAuthState, signOut,
-    toggleUserNavMenu} from "./actions/index";
+    requestGitHubAuthToken, routeChange, setGitHubAuthState,
+    setPackagesSearchQuery, signOut, toggleUserNavMenu} from "./actions/index";
 
 @Component({
     directives: [FooterComponent, HeaderComponent, NotificationsComponent,
@@ -175,6 +175,8 @@ export class AppComponent implements OnInit {
             // Don't show the side nav on the Sign In screen
             this.hideNav = value.indexOf("sign-in") !== -1;
             store.dispatch(routeChange(value));
+            // Clear the package search when the route changes
+            store.dispatch(setPackagesSearchQuery(""));
         });
 
         // Listen for changes on the state.

--- a/components/builder-web/app/package-page/PackagePageComponent.ts
+++ b/components/builder-web/app/package-page/PackagePageComponent.ts
@@ -35,7 +35,7 @@ import {fetchPackage} from "../actions/index";
         <hab-spinner [isSpinning]="ui.loading" [onClick]="spinnerFetchPackage">
         </hab-spinner>
     </div>
-    <div class="page-body has-sidebar">
+    <div *ngIf="!ui.loading" class="page-body has-sidebar">
         <div class="page-body--main">
             <div *ngIf="!ui.exists && !ui.loading">
                 <p>


### PR DESCRIPTION
* Clear the search query on navigation, to prevent it from being
  pre-filled when navigating back to the package list from an individual
  package
* Don't show content on the individual package page until loading is
  complete, to prevent a flash of empty dependencies

![gif-keyboard-12802901446766841825](https://cloud.githubusercontent.com/assets/9912/16273756/7a66d764-3868-11e6-8760-bbb1356a0fd6.gif)
