### PR TITLE
[hab] Make the `install.sh` script more portable with BusyBox userland.

### DIFF
--- a/components/hab/install.sh
+++ b/components/hab/install.sh
@@ -47,7 +47,7 @@ fi
 sha256sum -c "$sha_file"
 
 # Extract the archive into a temporary directory
-tar xf "$archive" -C "$workdir"
+zcat "$archive" | tar x -C "$workdir"
 # Directory containing the binary
 archive_dir="$(echo $archive | sed 's/.tar.gz$//')"
 # Install latest hab release using the extracted version and add/update symlink


### PR DESCRIPTION
This change aims to make the gzip'd tarball extraction more portable in
non-GNU userlands by first using `zcat` and then piping the stream to
`tar` for extraction. This change allows for a better out-of-the-box
experience in minimal distributions such as the BusyBox Docker image,
Alpine Linux, etc.

Thanks to @bscott for debugging with me!