### PR TITLE
Attach an EBS volume to the monolith

### DIFF
--- a/terraform/builder-monolith.tf
+++ b/terraform/builder-monolith.tf
@@ -20,6 +20,22 @@ resource "aws_instance" "monolith" {
         agent       = "${var.connection_agent}"
     }
 
+    ebs_block_device {
+        device_name = "/dev/xvdf"
+        volume_size = 1500
+        volume_type = "gp2"
+    }
+
+    provisioner "remote-exec" {
+        inline = [
+            "sudo mkfs.ext4 /dev/xvdf",
+            "sudo mount /dev/xvdf /mnt",
+            "echo '/dev/xvdf /hab     ext4   defaults 0 0' | sudo tee -a /etc/fstab",
+            "sudo mkdir -p /mnt/hab",
+            "sudo ln -s /mnt/hab /hab"
+        ]
+    }
+
     # JW TODO: Bake AMIs with updated habitat on them instead of bootstrapping
     provisioner "remote-exec" {
         script = "${path.module}/scripts/bootstrap.sh"


### PR DESCRIPTION
In the incident postmortem from 2016-06-23 it was identified that we
need to attach an EBS volume. ~~During instance creation we need to use
1 TB even though 1.5 TB was used when we remediated the issue, because
anything larger than 1 TB was causing instance creation to fail with
terraform apply.~~ We'll use gp2 as the type so we can get moar iops and 1.5TB size.

Signed-off-by: jtimberman <joshua@chef.io>