### PR TITLE
Adding check of `alive` status to haproxy.conf

### DIFF
--- a/plans/haproxy/config/haproxy.conf
+++ b/plans/haproxy/config/haproxy.conf
@@ -14,7 +14,9 @@ frontend http-in
 backend default
 {{#if bind.has_backend }}
 {{~#each bind.backend.members}}
+{{~#if alive }}
     server {{ip}} {{ip}}:{{port}}
+{{~/if}}
 {{~/each}}
 {{~else}}
 {{~#each cfg.server}}


### PR DESCRIPTION
The current implementation does not remove dead nodes from its config.  This causes timeouts if
backend nodes go away. It can also lead to config conflicts if new nodes come up with the same IP
as stale node entries.

This change allows nodes to be removed from haproxy when they are deemed no longer alive by the supervisor.

Signed-off-by: Nolan Davidson <ndavidson@chef.io>