### PR TITLE
add logical environment scope to resources without it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -153,7 +153,7 @@ matrix:
       - www/build
     env:
     - AFFECTED_DIRS="www"
-    - AWS_BUCKET=habitat-www
+    - AWS_BUCKET=habitat-www-monolith
     - AWS_DEFAULT_REGION=us-west-2
     - AWS_ACCESS_KEY_ID=AKIAIE3PM7VKCMUX7TIA
     # AWS_SECRET_ACCESS_KEY

--- a/terraform/builder-gateways.tf
+++ b/terraform/builder-gateways.tf
@@ -146,7 +146,7 @@ resource "aws_security_group" "builder_api" {
 }
 
 resource "aws_elb" "builder_api" {
-    name            = "builder-api"
+    name            = "builder-api-${var.env}"
     security_groups = ["${aws_security_group.builder_api_elb.id}"]
     subnets         = ["${var.public_subnet_id}"]
     instances       = ["${aws_instance.monolith.*.id}"]

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,7 @@
+output "www_bucket_name" {
+    value = "${aws_s3_bucket.www.id}"
+}
+
+output "www_user" {
+    value = "${aws_iam_user.www.name}"
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -77,13 +77,3 @@ variable "connection_agent" {
 variable "connection_private_key" {
     description = "File path to AWS keypair private key"
 }
-
-variable "www_bucket_name" {
-    description = "Name of the bucket where the website gets deployed"
-    default = "habitat-www"
-}
-
-variable "www_user" {
-    description = "Name of the user who can deploy the website"
-    default = "www"
-}

--- a/terraform/www.tf
+++ b/terraform/www.tf
@@ -1,9 +1,9 @@
 resource "aws_iam_user" "www" {
-  name = "${var.www_user}"
+  name = "www-${var.env}"
 }
 
 resource "aws_iam_user_policy" "www" {
-  name = "${var.www_user}"
+  name = "www-${var.env}"
   user = "${aws_iam_user.www.name}"
 
   policy = <<EOF
@@ -30,7 +30,7 @@ EOF
 }
 
 resource "aws_s3_bucket" "www" {
-  bucket = "${var.www_bucket_name}"
+  bucket = "habitat-www-${var.env}"
   acl    = "public-read"
 
   website {
@@ -48,7 +48,7 @@ resource "aws_s3_bucket" "www" {
           "*"
         ]
       },
-      "Resource": "arn:aws:s3:::${var.www_bucket_name}/*",
+      "Resource": "arn:aws:s3:::habitat-www-${var.env}/*",
       "Action": "s3:GetObject"
     },
     {
@@ -56,7 +56,7 @@ resource "aws_s3_bucket" "www" {
       "Principal": {
         "AWS": "arn:aws:iam::${var.aws_account_id}:user/${aws_iam_user.www.name}"
       },
-      "Resource": "arn:aws:s3:::${var.www_bucket_name}",
+      "Resource": "arn:aws:s3:::habitat-www-${var.env}",
       "Action": "s3:*"
     },
     {
@@ -64,7 +64,7 @@ resource "aws_s3_bucket" "www" {
       "Principal": {
         "AWS": "arn:aws:iam::${var.aws_account_id}:user/${aws_iam_user.www.name}"
       },
-      "Resource": "arn:aws:s3:::${var.www_bucket_name}/*",
+      "Resource": "arn:aws:s3:::habitat-www-${var.env}/*",
       "Action": "s3:*"
     }
   ]


### PR DESCRIPTION
This adds the logical environment scoping to a few resources which were missing it. I will run Terraform on the live environment to bring it inline once this is merged.

![gif-keyboard-6671091646682989744](https://cloud.githubusercontent.com/assets/54036/16392271/f0c4c8f8-3c5f-11e6-90fa-512c4671978e.gif)

Signed-off-by: Jamie Winsor <jamie@vialstudios.com>