### PR TITLE
Expose X-Content-Range header

### DIFF
--- a/components/depot/src/server.rs
+++ b/components/depot/src/server.rs
@@ -1259,7 +1259,8 @@ impl AfterMiddleware for Cors {
         res.headers.set(headers::AccessControlAllowOrigin::Any);
         res.headers
             .set(headers::AccessControlExposeHeaders(vec![UniCase("content-range".to_owned()),
-                                                          UniCase("next-range".to_owned())]));
+                                                          UniCase("next-range".to_owned()),
+                                                          UniCase("x-content-range".to_owned())]));
         res.headers
             .set(headers::AccessControlAllowHeaders(vec![UniCase("authorization".to_owned()),
                                                          UniCase("range".to_owned())]));


### PR DESCRIPTION
We were setting the X-Content-Range header, but not exposing it via my
old nemesis, `Access-Control-Expose-Headers`. This makes it so the
header is exposed and the client can see and use it.

![gif-keyboard-13179685337719961950](https://cloud.githubusercontent.com/assets/9912/16397032/96ede238-3c87-11e6-84b7-d77e9a5379a3.gif)
