### PR TITLE
Do not cache index.html or habitat.conf.js

### DIFF
--- a/plans/nginx-builder-api/config/nginx.conf
+++ b/plans/nginx-builder-api/config/nginx.conf
@@ -73,20 +73,30 @@ http {
         break;
     }
 
-  	location ~* ^/v1/depot/.*/latest$ {
-  	   add_header Cache-Control "private, no-cache, no-store";
-  	   proxy_pass http://localhost:9636;
-  	}
+    location /index.html {
+      add_header Cache-Control "private, no-cache, no-store";
+      break;
+    }
 
-  	location /v1/depot {
+    location /habitat.conf.js {
+      add_header Cache-Control "private, no-cache, no-store";
+      break;
+    }
+
+    location ~* ^/v1/depot/.*/latest$ {
+       add_header Cache-Control "private, no-cache, no-store";
+       proxy_pass http://localhost:9636;
+    }
+
+    location /v1/depot {
        client_max_body_size 1024m;
-  	   proxy_cache my_cache;
-  	   proxy_pass http://localhost:9636;
-  	}
+       proxy_cache my_cache;
+       proxy_pass http://localhost:9636;
+    }
 
-  	location /v1 {
-  	   add_header Cache-Control "private, no-cache, no-store";
-  	   proxy_pass http://localhost:9636;
+    location /v1 {
+       add_header Cache-Control "private, no-cache, no-store";
+       proxy_pass http://localhost:9636;
     }
   }
 }


### PR DESCRIPTION
This will keep index.html and habitat.conf.js from being cached.

Signed-off-by: Adam Jacob <adam@chef.io>