### PR TITLE
[plans] python 3.5.2 (updated)

### DIFF
--- a/plans/python/plan.sh
+++ b/plans/python/plan.sh
@@ -1,11 +1,11 @@
 pkg_name=python
-pkg_version=3.5.1
+pkg_version=3.5.2
 pkg_origin=core
 pkg_license=('python')
 pkg_dirname=Python-${pkg_version}
 pkg_source=https://www.python.org/ftp/python/${pkg_version}/${pkg_dirname}.tgz
 pkg_filename=${pkg_dirname}.tgz
-pkg_shasum=687e067d9f391da645423c7eda8205bae9d35edc0c76ef5218dcbe4cc770d0d7
+pkg_shasum=1524b840e42cf3b909e8f8df67c1724012c7dc7f9d076d4feef2d3eff031e8a0
 pkg_deps=(core/glibc core/gcc-libs core/coreutils core/make core/ncurses core/zlib core/readline core/openssl core/bzip2)
 pkg_build_deps=(core/linux-headers core/gcc)
 pkg_lib_dirs=(lib)


### PR DESCRIPTION
Released 2016-06-26, includes security patches and much more.
See https://docs.python.org/3.5/whatsnew/changelog.html#python-3-5-2

Signed-off-by: Mike Fiedler <miketheman@gmail.com>