### PR TITLE
Disables banner

### DIFF
--- a/www/source/layouts/_nav.slim
+++ b/www/source/layouts/_nav.slim
@@ -1,5 +1,6 @@
 #main-nav class="#{layout_class}"
-  = partial "layouts/message"
+  / Uncomment to enable the global message
+  / = partial "layouts/message"
   .main-nav--container.clearfix
     .main-nav--logo
       a href="/"


### PR DESCRIPTION
This removes the banner from the top of the page since we have already
had the webinar. Instead of removing the code, we leave the partial and
a comment with how to turn it back on for future instances where we
would want to display a message at the top of the page.

Signed-off-by: Christopher Webber <cwebber@chef.io>