### PR TITLE
revert bucket name change from travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -153,7 +153,7 @@ matrix:
       - www/build
     env:
     - AFFECTED_DIRS="www"
-    - AWS_BUCKET=habitat-www-monolith
+    - AWS_BUCKET=habitat-www
     - AWS_DEFAULT_REGION=us-west-2
     - AWS_ACCESS_KEY_ID=AKIAIE3PM7VKCMUX7TIA
     # AWS_SECRET_ACCESS_KEY


### PR DESCRIPTION
This will revert a change we made earlier this week which was grouped with the re-naming of AWS artifacts to allow for additional logical environments to be setup. We aren't going to be re-running Terraform on the monolith environment so the bucket is not/will not be created.

This will need to be updated again at a later date when monolith is destroyed in favor of live

Signed-off-by: Jamie Winsor <jamie@vialstudios.com>