### PR TITLE
Add `exec` to tutorial app run hook.

### DIFF
--- a/www/source/tutorials/getting-started-add-hooks.html.md
+++ b/www/source/tutorials/getting-started-add-hooks.html.md
@@ -38,7 +38,12 @@ Perform the following operations in the same directory where the `plan.sh` file 
        #!/bin/sh
        #
        cd {{pkg.svc_path}}
-       npm start
+
+       # `exec` makes it so the process that the Habitat supervisor uses is
+       # `npm start`, rather than the run hook itself. `2>&1` makes it so both
+       # standard output and standard error go to the standard output stream,
+       # so all the logs from the application go to the same place.
+       exec npm start 2>&1
 
 7. Save the `run` hook file.
 


### PR DESCRIPTION
Restarting doesn't work properly without it. See #989.

![gif-keyboard-11790824695907597446](https://cloud.githubusercontent.com/assets/9912/16534967/4e614184-3fa9-11e6-8e8a-7bcc394dcf39.gif)
