### PR TITLE
Fail travis build on failure to deploy website

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -164,7 +164,6 @@ matrix:
     - secure: "SFcY62bzpxUVD6ZDE23KudYX5gCt9fuH8QE2wAE+Pu4LPj9SKQyOwpbx3Aej2EzPk14RNA2HKXr3jY+rGdSpNrSyTmbf2IMOolVjIDSoT2xD5E+hAARfuurjHH8l9Bwb8KRiPG3oxcM85oXU6kd882SN5CsM3jY65vj94I/SMZYpUB7KSUQP8ji7hoE1eVeXQWi2AM+fjPFwWG1BhiP16j7SyAaDCAI+jDAeTplrdg10pxIKv7ef1wOHahyGlORdxubAilQW+dZuubMjl2qgPem8FQRmYSLJNEAvj663QYZf1XfH1fDYavW7J0l9vj4E8BwXUAdYn20JPwR6HSI/XsJrpxEc/PEt/2HqhTPAnxVwKQkXEgbKxCamPDIwBANwhjOdetY9dR8w9W4rsJ7wT7WQw40chlFO1gU8Ct4dIlCYogtTBxRdrCObTWRkGlsEH2XNxt4lE4xoE79njlQqNj/Wq0FeyljLPIaK90E1C9O0Q5Li1LaiIQTxyaoivLGELXrsysvkRwEOOCGiFt6w8P1LDEqoKz7Z5tu7+dbh3c31KCgPsgo150/Q4+plnq6+GoY+3ejWac7qf+q1dbp5Gx4lNPBKKuUylhx7TYUlpAp3hLcoA3fs245eYbbv1+fJ1SLIFGYNTHzRRmbB1bZaHQeHl8dMNuMh4JVDexAuCXc="
     before_install: ./support/ci/fast_pass.sh || exit 0
     install: "(cd www && bundle install)"
-    script: "(cd www && ./bin/middleman build)"
-    after_script: ./support/ci/deploy_website.sh
+    script: ./support/ci/deploy_website.sh
 notifications:
   webhooks: https://habitat-homu.herokuapp.com/travis

--- a/support/ci/deploy_website.sh
+++ b/support/ci/deploy_website.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 
+
 git log HEAD~1..HEAD | grep -q '!!! Temporary Commit !!!'
 is_tmp_commit=$?
+
+set -eu
+
+cd www
+./bin/middleman build
 
 # If we are not on a pull request, on the "auto" branch (which homu uses when
 # auto-merging master), and not on a temporary commit, then run the publish
@@ -9,7 +15,6 @@ is_tmp_commit=$?
 if [ "${TRAVIS_PULL_REQUEST}" = "false" ] &&
    [ "${TRAVIS_BRANCH}" = "auto" ] &&
    [[ $is_tmp_commit = 1 ]]; then
-  set -eux
-  cd www && ./bin/middleman s3_sync
+  ./bin/middleman s3_sync
   curl -H "Fastly-Key: ${FASTLY_API_KEY}" -X POST "https://api.fastly.com/service/${FASTLY_SERVICE_KEY}/purge_all"
 else echo "Not on master; skipping website deploy"; fi


### PR DESCRIPTION
On Travis, if your `after_script` fails (exits non-zero), the build
still gets to be green.

This makes it so the building of the website and the deploying (if we're
on the right branch) are all in the `script` instead, so if the deploy
fails, the Travis build goes red.

(This happened: https://travis-ci.org/habitat-sh/habitat/jobs/141353230.
It was because we made a change on S3, and the script failed, but we
weren't notified by a Travis failure, but by somebody noticing their
change had not been deployed.)

![gif-keyboard-11424010234139658987](https://cloud.githubusercontent.com/assets/9912/16535335/1214e1d8-3fac-11e6-86c8-b2f5cb9f3a0e.gif)


