### PR TITLE
honor pkg_svc_user/pkg_svc_group (rebased)

### DIFF
--- a/components/core/src/crypto/keys/box_key_pair.rs
+++ b/components/core/src/crypto/keys/box_key_pair.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::io::BufRead;
 use std::path::{Path, PathBuf};
 use std::str;
 

--- a/components/core/src/error.rs
+++ b/components/core/src/error.rs
@@ -69,7 +69,7 @@ pub enum Error {
     /// When an error occurs parsing an integer.
     ParseIntError(num::ParseIntError),
     /// Occurs when setting ownership or permissions on a file or directory fails.
-    PermissionFailed,
+    PermissionFailed(String),
     /// When an error occurs parsing or compiling a regular expression.
     RegexParse(regex::Error),
     /// When an error occurs converting a `String` from a UTF-8 byte vector.
@@ -135,7 +135,7 @@ impl fmt::Display for Error {
                 }
             }
             Error::ParseIntError(ref e) => format!("{}", e),
-            Error::PermissionFailed => format!("Failed to set permissions"),
+            Error::PermissionFailed(ref e) => format!("{}", e),
             Error::RegexParse(ref e) => format!("{}", e),
             Error::StringFromUtf8Error(ref e) => format!("{}", e),
             Error::UnameFailed(ref e) => format!("{}", e),
@@ -179,7 +179,7 @@ impl error::Error for Error {
             Error::NoOutboundAddr => "Failed to discover the outbound IP address",
             Error::PackageNotFound(_) => "Cannot find a package",
             Error::ParseIntError(_) => "Failed to parse an integer from a string!",
-            Error::PermissionFailed => "Failed to set permissions",
+            Error::PermissionFailed(_) => "Failed to set permissions",
             Error::RegexParse(_) => "Failed to parse a regular expression",
             Error::StringFromUtf8Error(_) => "Failed to convert a string from a Vec<u8> as UTF-8",
             Error::UnameFailed(_) => "uname failed",

--- a/components/core/src/package/install.rs
+++ b/components/core/src/package/install.rs
@@ -223,6 +223,26 @@ impl PackageInstall {
         fs::svc_var_path(&self.ident.name)
     }
 
+    /// Returns the user that the package is specified to run as
+    /// or None if the package doesn't contain a SVC_USER Metafile
+    pub fn svc_user(&self) -> Result<Option<String>> {
+        match self.read_metafile(MetaFile::SvcUser) {
+            Ok(body) => Ok(Some(body)),
+            Err(Error::MetaFileNotFound(MetaFile::SvcUser)) => Ok(None),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Returns the group that the package is specified to run as
+    /// or None if the package doesn't contain a SVC_GROUP Metafile
+    pub fn svc_group(&self) -> Result<Option<String>> {
+        match self.read_metafile(MetaFile::SvcGroup) {
+            Ok(body) => Ok(Some(body)),
+            Err(Error::MetaFileNotFound(MetaFile::SvcGroup)) => Ok(None),
+            Err(e) => Err(e),
+        }
+    }
+
     /// Read the contents of a given metafile.
     ///
     /// # Failures

--- a/components/core/src/package/mod.rs
+++ b/components/core/src/package/mod.rs
@@ -34,6 +34,8 @@ pub enum MetaFile {
     LdFlags,
     Manifest,
     Path,
+    SvcUser,
+    SvcGroup,
 }
 
 impl fmt::Display for MetaFile {
@@ -49,6 +51,8 @@ impl fmt::Display for MetaFile {
             MetaFile::LdFlags => "LDFLAGS",
             MetaFile::Manifest => "MANIFEST",
             MetaFile::Path => "PATH",
+            MetaFile::SvcUser => "SVC_USER",
+            MetaFile::SvcGroup => "SVC_GROUP",
         };
         write!(f, "{}", id)
     }

--- a/components/core/src/util/perm.rs
+++ b/components/core/src/util/perm.rs
@@ -18,13 +18,43 @@ use std::path::Path;
 use error::{Error, Result};
 
 pub fn set_owner<T: AsRef<Path>, X: AsRef<str>>(path: T, owner: X) -> Result<()> {
+    debug!("Attempting to set owner of {:?} to {:?}",
+           &path.as_ref(),
+           &owner.as_ref());
     let output = try!(Command::new("chown")
         .arg(owner.as_ref())
         .arg(path.as_ref())
         .output());
     match output.status.success() {
         true => Ok(()),
-        false => Err(Error::PermissionFailed),
+        false => {
+            Err(Error::PermissionFailed(format!("Can't change owner of {:?} to {:?}",
+                                                &path.as_ref(),
+                                                &owner.as_ref())))
+        }
+    }
+}
+
+pub fn set_owner_and_group<T: AsRef<Path>, X: AsRef<str>>(path: T, owner: X, group: X) -> Result<()> {
+    debug!("Attempting to set owner of {:?} to {:?}:{:?}",
+           &path.as_ref(),
+           &owner.as_ref(),
+           &group.as_ref());
+    let user_and_group = format!("{}:{}", owner.as_ref(), group.as_ref());
+
+    let output = try!(Command::new("chown")
+        .arg(&user_and_group)
+        .arg(path.as_ref())
+        .output());
+    match output.status.success() {
+        true => Ok(()),
+        false => {
+            Err(Error::PermissionFailed(format!("Can't change owner of {:?} to {:?}:{:?}",
+                                                &path.as_ref(),
+                                                &owner.as_ref(),
+                                                &group.as_ref()
+                                                )))
+        }
     }
 }
 
@@ -32,12 +62,19 @@ pub fn set_owner<T: AsRef<Path>, X: AsRef<str>>(path: T, owner: X) -> Result<()>
 // platform abstraction. Until then, if we move to Windows or some
 // other platform, this code will need to become platform specific.
 pub fn set_permissions<T: AsRef<Path>, X: AsRef<str>>(path: T, perm: X) -> Result<()> {
+    debug!("Attempting to set permissions on {:?} to {:?}",
+           &path.as_ref(),
+           &perm.as_ref());
     let output = try!(Command::new("chmod")
         .arg(perm.as_ref())
         .arg(path.as_ref())
         .output());
     match output.status.success() {
         true => Ok(()),
-        false => Err(Error::PermissionFailed),
+        false => {
+            Err(Error::PermissionFailed(format!("Can't set permissions on {:?} to {:?}",
+                                                &path.as_ref(),
+                                                &perm.as_ref())))
+        }
     }
 }

--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -1915,6 +1915,9 @@ _build_metadata() {
   echo "${pkg_origin}/${pkg_name}/${pkg_version}/${pkg_release}" \
     >> $pkg_prefix/IDENT
 
+  echo "$pkg_svc_user" > $pkg_prefix/SVC_USER
+  echo "$pkg_svc_group" > $pkg_prefix/SVC_GROUP
+
   # Generate the blake2b hashes of all the files in the package. This
   # is not in the resulting MANIFEST because MANIFEST is included!
   pushd "$HAB_CACHE_SRC_PATH/$pkg_dirname" > /dev/null

--- a/components/sup/Cargo.lock
+++ b/components/sup/Cargo.lock
@@ -26,6 +26,7 @@ dependencies = [
  "toml 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "urlencoded 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "users 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "wonder 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/components/sup/Cargo.toml
+++ b/components/sup/Cargo.toml
@@ -36,6 +36,7 @@ openssl = "*"
 lazy_static = "*"
 handlebars = "*"
 wonder = "*"
+users = "*"
 
 [dependencies.habitat_core]
 path = "../core"

--- a/components/sup/src/error.rs
+++ b/components/sup/src/error.rs
@@ -127,6 +127,7 @@ pub enum Error {
     NulError(ffi::NulError),
     PackageArchiveMalformed(String),
     PackageNotFound(package::PackageIdent),
+    Permissions(String),
     RemotePackageNotFound(package::PackageIdent),
     SignalFailed,
     SignalNotifierStarted,
@@ -152,6 +153,7 @@ impl fmt::Display for SupError {
             Error::ExecCommandNotFound(ref c) => {
                 format!("`{}' was not found on the filesystem or in PATH", c)
             }
+            Error::Permissions(ref err) => format!("{}", err),
             Error::HabitatCommon(ref err) => format!("{}", err),
             Error::HabitatCore(ref err) => format!("{}", err),
             Error::HandlebarsTemplateFileError(ref err) => format!("{:?}", err),
@@ -275,6 +277,7 @@ impl error::Error for SupError {
                 "Package archive was unreadable or had unexpected contents"
             }
             Error::PackageNotFound(_) => "Cannot find a package",
+            Error::Permissions(_) => "File system permissions error",
             Error::RemotePackageNotFound(_) => "Cannot find a package in any sources",
             Error::SignalFailed => "Failed to send a signal to the child process",
             Error::SignalNotifierStarted => "Only one instance of a Signal Notifier may be running",

--- a/components/sup/src/gossip/rumor.rs
+++ b/components/sup/src/gossip/rumor.rs
@@ -21,7 +21,6 @@ use std::collections::HashMap;
 use std::ops::{Deref, DerefMut};
 
 use common::gossip_file::GossipFile;
-use rustc_serialize::Encodable;
 use uuid::Uuid;
 
 use census::CensusEntry;

--- a/components/sup/src/package/hooks.rs
+++ b/components/sup/src/package/hooks.rs
@@ -22,11 +22,14 @@ use std::process::{Command, Stdio};
 use handlebars::Handlebars;
 
 use error::{Error, Result};
+use hcore::util;
 use package::Package;
 use service_config::{ServiceConfig, never_escape_fn};
 use util::convert;
 use util::handlebars_helpers;
+use util::users as hab_users;
 
+pub const HOOK_PERMISSIONS: &'static str = "0755";
 static LOGKEY: &'static str = "PH";
 
 #[derive(Debug, Clone)]
@@ -55,24 +58,31 @@ pub struct Hook {
     pub htype: HookType,
     pub template: PathBuf,
     pub path: PathBuf,
+    pub user: String,
+    pub group: String,
 }
 
 impl Hook {
-    pub fn new(htype: HookType, template: PathBuf, path: PathBuf) -> Self {
+    pub fn new(htype: HookType,
+               template: PathBuf,
+               path: PathBuf,
+               user: String,
+               group: String)
+               -> Self {
         Hook {
             htype: htype,
             template: template,
             path: path,
+            user: user,
+            group: group,
         }
     }
 
     pub fn run(&self, context: Option<&ServiceConfig>) -> Result<String> {
         try!(self.compile(context));
-        let mut child = try!(Command::new(&self.path)
-            .stdin(Stdio::null())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn());
+        let mut cmd = Command::new(&self.path);
+        try!(self.run_platform(&mut cmd));
+        let mut child = try!(cmd.spawn());
         {
             let mut c_stdout = match child.stdout {
                 Some(ref mut s) => s,
@@ -114,7 +124,36 @@ impl Hook {
         }
     }
 
+    #[cfg(any(target_os="linux", target_os="macos"))]
+    fn run_platform(&self, cmd: &mut Command) -> Result<()> {
+        use std::os::unix::process::CommandExt;
+        let uid = hab_users::user_name_to_uid(&self.user);
+        let gid = hab_users::group_name_to_gid(&self.group);
+        if let None = uid {
+            panic!("Can't determine uid");
+        }
+
+        if let None = gid {
+            panic!("Can't determine gid");
+        }
+
+        let uid = uid.unwrap();
+        let gid = gid.unwrap();
+        cmd.stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .uid(uid)
+            .gid(gid);
+        Ok(())
+    }
+
+    #[cfg(target_os = "windows")]
+    fn run_platform(&self, cmd: &mut Command) -> Result<()> {
+        unimplemented!();
+    }
+
     pub fn compile(&self, context: Option<&ServiceConfig>) -> Result<()> {
+        let runas = format!("{}:{}", &self.user, &self.group);
         if let Some(ctx) = context {
             debug!("Rendering hook {:?}", self);
             let mut handlebars = Handlebars::new();
@@ -133,9 +172,13 @@ impl Hook {
                 .mode(0o770)
                 .open(&self.path));
             try!(write!(&mut file, "{}", data));
+            try!(util::perm::set_owner(&self.path, &runas));
+            try!(util::perm::set_permissions(&self.path, HOOK_PERMISSIONS));
             Ok(())
         } else {
             try!(fs::copy(&self.template, &self.path));
+            try!(util::perm::set_owner(&self.path, &runas));
+            try!(util::perm::set_permissions(&self.path, HOOK_PERMISSIONS));
             Ok(())
         }
     }
@@ -182,8 +225,11 @@ impl<'a> HookTable<'a> {
     fn load_hook(&self, hook_type: HookType) -> Option<Hook> {
         let template = self.package.hook_template_path(&hook_type);
         let concrete = self.package.hook_path(&hook_type);
+        let (user, group) = hab_users::get_user_and_group(&self.package.pkg_install)
+            .expect("Can't determine user:group");
+
         match fs::metadata(&template) {
-            Ok(_) => Some(Hook::new(hook_type, template, concrete)),
+            Ok(_) => Some(Hook::new(hook_type, template, concrete, user, group)),
             Err(_) => None,
         }
     }

--- a/components/sup/src/package/mod.rs
+++ b/components/sup/src/package/mod.rs
@@ -22,7 +22,6 @@ use std;
 use std::env;
 use std::fmt;
 use std::fs::File;
-use std::os::unix;
 use std::path::{Path, PathBuf};
 use std::string::ToString;
 use std::io::prelude::*;
@@ -30,12 +29,13 @@ use std::io::prelude::*;
 use hcore::package::{PackageIdent, PackageInstall};
 use hcore::util;
 
-use self::hooks::HookTable;
+use self::hooks::{HookTable, HOOK_PERMISSIONS};
 use error::{Error, Result, SupError};
 use health_check::{self, CheckResult};
 use service_config::ServiceConfig;
 use supervisor::Supervisor;
 use util::path::busybox_paths;
+use util::users as hab_users;
 
 static LOGKEY: &'static str = "PK";
 const INIT_FILENAME: &'static str = "init";
@@ -43,8 +43,6 @@ const HEALTHCHECK_FILENAME: &'static str = "health_check";
 const FILEUPDATED_FILENAME: &'static str = "file_updated";
 const RECONFIGURE_FILENAME: &'static str = "reconfigure";
 const RUN_FILENAME: &'static str = "run";
-const SERVICE_PATH_OWNER: &'static str = "hab";
-const SERVICE_PATH_GROUP: &'static str = "hab";
 
 #[derive(Debug, Clone)]
 pub struct Package {
@@ -151,24 +149,50 @@ impl Package {
         self.pkg_install.svc_path()
     }
 
+    /// this function wraps create_dir_all so we can give friendly error
+    /// messages to the user.
+    fn create_dir_all<P: AsRef<Path>>(path: P) -> Result<()> {
+        debug!("Creating dir with subdirs: {:?}", &path.as_ref());
+        if let Err(e) = std::fs::create_dir_all(&path) {
+            Err(sup_error!(Error::Permissions(format!("Can't create {:?}, {}", &path.as_ref(), e))))
+        } else {
+            Ok(())
+        }
+    }
+
     /// Create the service path for this package.
     pub fn create_svc_path(&self) -> Result<()> {
-        let runas = format!("{}:{}", SERVICE_PATH_OWNER, SERVICE_PATH_GROUP);
+        let (user, group) = try!(hab_users::get_user_and_group(&self.pkg_install));
+
+        let runas = format!("{}:{}", user, group);
         debug!("Creating svc paths");
-        try!(std::fs::create_dir_all(self.pkg_install.svc_config_path()));
-        try!(std::fs::create_dir_all(self.pkg_install.svc_data_path()));
+
+
+        if let Err(e) = Self::create_dir_all(self.pkg_install.svc_path()) {
+            outputln!("Can't create directory {}",
+                      &self.pkg_install.svc_path().to_str().unwrap());
+            outputln!("If this service is running as non-root, you'll need to create \
+                       {} and give the current user write access to it",
+                      self.pkg_install.svc_path().to_str().unwrap());
+            return Err(e);
+        }
+
+        try!(Self::create_dir_all(self.pkg_install.svc_config_path()));
+        try!(util::perm::set_owner(self.pkg_install.svc_config_path(), &runas));
+        try!(util::perm::set_permissions(self.pkg_install.svc_config_path(), "0700"));
+        try!(Self::create_dir_all(self.pkg_install.svc_data_path()));
         try!(util::perm::set_owner(self.pkg_install.svc_data_path(), &runas));
         try!(util::perm::set_permissions(self.pkg_install.svc_data_path(), "0700"));
-        try!(std::fs::create_dir_all(self.pkg_install.svc_files_path()));
+        try!(Self::create_dir_all(self.pkg_install.svc_files_path()));
         try!(util::perm::set_owner(self.pkg_install.svc_files_path(), &runas));
         try!(util::perm::set_permissions(self.pkg_install.svc_files_path(), "0700"));
-        try!(std::fs::create_dir_all(self.pkg_install.svc_hooks_path()));
-        try!(std::fs::create_dir_all(self.pkg_install.svc_var_path()));
+        try!(Self::create_dir_all(self.pkg_install.svc_hooks_path()));
+        try!(Self::create_dir_all(self.pkg_install.svc_var_path()));
         try!(util::perm::set_owner(self.pkg_install.svc_var_path(), &runas));
         try!(util::perm::set_permissions(self.pkg_install.svc_var_path(), "0700"));
         // TODO: Not 100% if this directory is still needed, but for the moment it's still here -
         // FIN
-        try!(std::fs::create_dir_all(self.pkg_install.svc_path().join("toml")));
+        try!(Self::create_dir_all(self.pkg_install.svc_path().join("toml")));
         try!(util::perm::set_permissions(self.pkg_install.svc_path().join("toml"), "0700"));
         Ok(())
     }
@@ -177,28 +201,20 @@ impl Package {
     pub fn copy_run(&self, context: &ServiceConfig) -> Result<()> {
         debug!("Copying the run file");
         let svc_run = self.pkg_install.svc_path().join(RUN_FILENAME);
+        debug!("svc_run = {}", &svc_run.to_str().unwrap());
         if let Some(hook) = self.hooks().run_hook {
+            debug!("Comiling hook");
             try!(hook.compile(Some(context)));
-            match std::fs::read_link(&svc_run) {
-                Ok(path) => {
-                    if path != hook.path {
-                        try!(util::perm::set_permissions(hook.path.to_str().unwrap(), "0755"));
-                        try!(std::fs::remove_file(&svc_run));
-                        try!(unix::fs::symlink(hook.path, &svc_run));
-                    }
-                }
-                Err(_) => try!(unix::fs::symlink(hook.path, &svc_run)),
-            }
+            try!(std::fs::copy(hook.path, &svc_run));
+            try!(util::perm::set_permissions(&svc_run.to_str().unwrap(), HOOK_PERMISSIONS));
         } else {
             let run = self.path().join(RUN_FILENAME);
             match std::fs::metadata(&run) {
                 Ok(_) => {
-                    try!(util::perm::set_permissions(&run, "0755"));
-                    match std::fs::metadata(&svc_run) {
-                        Ok(_) => try!(std::fs::remove_file(&svc_run)),
-                        Err(_) => {}
-                    }
-                    try!(unix::fs::symlink(&run, &svc_run));
+                    debug!("run file = {}", &run.to_str().unwrap());
+                    debug!("svc_run file = {}", &svc_run.to_str().unwrap());
+                    try!(std::fs::copy(&run, &svc_run));
+                    try!(util::perm::set_permissions(&svc_run, HOOK_PERMISSIONS));
                 }
                 Err(e) => {
                     outputln!("Error finding the run file: {}", e);

--- a/components/sup/src/service_config.rs
+++ b/components/sup/src/service_config.rs
@@ -23,7 +23,7 @@ use std::io::prelude::*;
 use ansi_term::Colour::Purple;
 use rustc_serialize::Encodable;
 use toml;
-use handlebars::{Handlebars, JsonRender};
+use handlebars::Handlebars;
 
 use common::gossip_file::GOSSIP_TOML;
 use census::{Census, CensusList};
@@ -31,10 +31,12 @@ use config::Config;
 use error::{Error, Result};
 use hcore::package::PackageInstall;
 use hcore::crypto;
+
 use package::Package;
 use util;
 use util::convert;
 use util::handlebars_helpers;
+use util::users as hab_users;
 use VERSION;
 
 static LOGKEY: &'static str = "SC";
@@ -473,6 +475,10 @@ pub struct Pkg {
     pub svc_files_path: String,
     pub svc_static_path: String,
     pub svc_var_path: String,
+    pub svc_user: Option<String>,
+    pub svc_group: Option<String>,
+    pub svc_user_default: String,
+    pub svc_group_default: String,
 }
 
 impl Pkg {
@@ -512,6 +518,18 @@ impl Pkg {
             Some(r) => r.clone(),
             None => "".to_string(),
         };
+
+        let (default_svc_user, default_svc_group) = match hab_users::get_user_and_group(&pkg_install) {
+            Ok((svc_user, svc_group)) => (svc_user, svc_group),
+            Err(_e) => {
+                // TODO
+                panic!("Can't get default service and user");
+            }
+        };
+
+        let svc_user = pkg_install.svc_user().unwrap_or(None);
+        let svc_group = pkg_install.svc_group().unwrap_or(None);
+
         Pkg {
             origin: ident.origin.clone(),
             name: ident.name.clone(),
@@ -527,6 +545,10 @@ impl Pkg {
             svc_files_path: pkg_install.svc_files_path().to_string_lossy().into_owned(),
             svc_static_path: pkg_install.svc_static_path().to_string_lossy().into_owned(),
             svc_var_path: pkg_install.svc_var_path().to_string_lossy().into_owned(),
+            svc_user: svc_user,
+            svc_group: svc_group,
+            svc_user_default: default_svc_user,
+            svc_group_default: default_svc_group,
         }
     }
 

--- a/components/sup/src/util/mod.rs
+++ b/components/sup/src/util/mod.rs
@@ -17,6 +17,7 @@ pub mod handlebars_helpers;
 pub mod path;
 pub mod sys;
 pub mod signals;
+pub mod users;
 
 use std::net::Ipv4Addr;
 use std::net::SocketAddrV4;

--- a/components/sup/src/util/users.rs
+++ b/components/sup/src/util/users.rs
@@ -1,0 +1,143 @@
+// Copyright (c) 2016 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(any(target_os="linux", target_os="macos"))]
+extern crate users;
+
+use error::{Result, Error};
+use hcore::package::PackageInstall;
+
+static LOGKEY: &'static str = "UR";
+
+const DEFAULT_USER: &'static str = "hab";
+const DEFAULT_GROUP: &'static str = "hab";
+
+/// This function checks to see if a custom SVC_USER and SVC_GROUP has
+/// been specified as part of the package metadata.
+/// If a pkg_svc_user and pkg_svc_group have been defined, check if:
+///     a) we are root
+///     b) we are the specified user:group
+///     c) fail otherwise
+/// If pkg_svc_user and pkg_svc_group have NOT been defined, return None.
+#[cfg(any(target_os="linux", target_os="macos"))]
+fn check_pkg_user_and_group(pkg_install: &PackageInstall) -> Result<Option<(String, String)>> {
+    let svc_user = try!(pkg_install.svc_user());
+    let svc_group = try!(pkg_install.svc_group());
+    match (svc_user, svc_group) {
+        (Some(user), Some(group)) => {
+            // a package has a SVC_USER and SVC_GROUP defined,
+            // these MUST exist in order to continue
+            debug!("SVC_USER = {}", &user);
+            debug!("SVC_GROUP = {}", &group);
+            if let None = users::get_user_by_name(&user) {
+                return Err(sup_error!(Error::Permissions(format!("Package requires user {} to \
+                                                                  exist, but it doesn't",
+                                                                 user))));
+            }
+            if let None = users::get_group_by_name(&group) {
+                return Err(sup_error!(Error::Permissions(format!("Package requires group {} \
+                                                                  to exist, but it doesn't",
+                                                                 group))));
+            }
+
+            let current_user = users::get_current_username();
+            let current_group = users::get_current_groupname();
+
+            if let None = current_user {
+                return Err(sup_error!(Error::Permissions("Can't determine current user"
+                    .to_string())));
+            }
+
+            if let None = current_group {
+                return Err(sup_error!(Error::Permissions("Can't determine current group"
+                    .to_string())));
+            }
+
+            let current_user = current_user.unwrap();
+            let current_group = current_group.unwrap();
+
+            if current_user == "root" {
+                Ok(Some((user, group)))
+            } else {
+                if current_user == user && current_group == group {
+                    // ok, sup is running as svc_user/svc_group already
+                    Ok(Some((user, group)))
+                } else {
+                    let msg = format!("Package must run as {}:{} or root", &user, &group);
+                    return Err(sup_error!(Error::Permissions(msg)));
+                }
+            }
+        }
+        _ => {
+            debug!("User/group not specified in package, running with default");
+            Ok(None)
+        }
+    }
+}
+
+/// checks to see if hab/hab exists, if not, fall back to
+/// current user/group. If that fails, then return an error.
+#[cfg(any(target_os="linux", target_os="macos"))]
+fn get_default_user_and_group() -> Result<(String, String)> {
+    let user = users::get_user_by_name(DEFAULT_USER);
+    let group = users::get_group_by_name(DEFAULT_GROUP);
+    match (user, group) {
+        (Some(user), Some(group)) => return Ok((user.name().to_string(), group.name().to_string())),
+        _ => {
+            debug!("hab:hab does NOT exist");
+            let user = users::get_current_username();
+            let group = users::get_current_groupname();
+            match (user, group) {
+                (Some(user), Some(group)) => {
+                    debug!("Running as {}/{}", user, group);
+                    return Ok((user, group));
+                }
+                _ => {
+                    return Err(sup_error!(Error::Permissions("Can't determine current user:group"
+                        .to_string())))
+                }
+            }
+        }
+    }
+}
+
+/// check and see if a user/group is specified in package metadata.
+/// if not, we'll try and use hab/hab.
+/// If hab/hab doesn't exist, try to use (current username, current group).
+/// If that doesn't work, then give up.
+#[cfg(any(target_os="linux", target_os="macos"))]
+pub fn get_user_and_group(pkg_install: &PackageInstall) -> Result<(String, String)> {
+    if let Some((user, group)) = try!(check_pkg_user_and_group(&pkg_install)) {
+        Ok((user, group))
+    } else {
+        let defaults = try!(get_default_user_and_group());
+        Ok(defaults)
+    }
+}
+
+#[cfg(any(target_os="linux", target_os="macos"))]
+pub fn user_name_to_uid(user: &str) -> Option<u32> {
+    users::get_user_by_name(user).map(|u| u.uid())
+}
+
+#[cfg(any(target_os="linux", target_os="macos"))]
+pub fn group_name_to_gid(group: &str) -> Option<u32> {
+    users::get_group_by_name(group).map(|g| g.gid())
+}
+
+#[cfg(target_os = "windows")]
+pub fn get_user_and_group(pkg_install: &PackageInstall) -> Result<(String, String)> {
+    unimplemented!();
+}
+

--- a/www/source/docs/reference/package-contents.html.md
+++ b/www/source/docs/reference/package-contents.html.md
@@ -7,22 +7,6 @@ During the build process, the hab-plan-build script creates several files that s
 
 Packages are installed in the `/hab/pkgs/` directory, and then further organized in subdirectories corresponding to fully-qualified package identifiers: `origin/name/version/release`. For more information on package identifiers, see [Packages](/docs/concepts-packages).
 
-
-## MANIFEST
-A file containing package information, such as checksum, maintainer, build variables, and other metadata specified in plan.sh as well as the contents of the plan.sh itself.
-
-## FILES
-List of all files in this package along with their blake2b checksums. The FILES file itself is signed using `hab pkg sign` to provide an assurance that its contents haven't been tampered with.
-
-## PATH
-An absolute path to the `bin` folder for the package. A fully-qualified package identifier is used, so version and release information is included in the path.
-
-## DEPS
-Runtime dependencies for your package. These dependencies are processed by Habitat and their corresponding environment variables (such as `PATH` and `LD_LIBRARY_PATH`) are added to the current environment.
-
-## TDEPS
-Fully-qualified package identifiers of any runtime dependencies that the runtime dependencies for your project depend on. This is essentially a flattened tree of dependencies all the way up to the root dependency (`linux-headers` in most cases).
-
 ## BUILD_DEPS
 Fully-qualified package identifiers of any build dependencies that your package depends on. These are listed in the root plan.sh file of your plan directory.
 
@@ -32,11 +16,11 @@ Fully-qualified package identifiers of any runtime dependencies that the build d
 ## CFLAGS
 Additional switches to be passed to the compiler when this package is used as a build dependency.
 
-## LDFLAGS
-Additional switches to be passed to the compiler when this package is used as a build dependency.
+## DEPS
+Runtime dependencies for your package. These dependencies are processed by Habitat and their corresponding environment variables (such as `PATH` and `LD_LIBRARY_PATH`) are added to the current environment.
 
-## LD_RUN_PATH
-Additional switches to be passed to the compiler when this package is used as a build dependency.
+## FILES
+List of all files in this package along with their blake2b checksums. The FILES file itself is signed using `hab pkg sign` to provide an assurance that its contents haven't been tampered with.
 
 ## IDENT
 The fully-qualified identifier for the package. The format is `origin/name/version/release`.
@@ -44,8 +28,29 @@ The fully-qualified identifier for the package. The format is `origin/name/versi
 ## INTERPRETERS
 If `pkg_interpreters` is specified in your plan.sh, then this file will be generated and contain a list of absolute paths to any interpreters that a package can provide. Code in a `plan.sh` may use the `fix_interpreter` function to replace hardcoded instances of interpreters, such as `/bin/env`. The location of interpreters in Habitat will be nested under `/hab/pkgs/`. For more information on interpreters, see the fix_interpreter description in [Utility functions](/docs/reference/plan-syntax#utility-functions).
 
+## LDFLAGS
+Additional switches to be passed to the compiler when this package is used as a build dependency.
+
+## LD_RUN_PATH
+Additional switches to be passed to the compiler when this package is used as a build dependency.
+
+## MANIFEST
+A file containing package information, such as checksum, maintainer, build variables, and other metadata specified in plan.sh as well as the contents of the plan.sh itself.
+
+## PATH
+An absolute path to the `bin` folder for the package. A fully-qualified package identifier is used, so version and release information is included in the path.
+
 ## TARGET
 The CPU architecture and platform for the package. The format is `architecture-platform`. For example, x86_64-linux.
+
+## TDEPS
+Fully-qualified package identifiers of any runtime dependencies that the runtime dependencies for your project depend on. This is essentially a flattened tree of dependencies all the way up to the root dependency (`linux-headers` in most cases).
+
+## SVC_GROUP
+The value of `pkg_svc_group` from a plan. The Habitat supervisor will try to start a service with this group if it exists.
+
+## SVC_USER
+The value of `pkg_svc_user` from a plan. The Habitat supervisor will try to start a service with this user if it exists.
 
 ## default.toml
 If you have defined a default.toml file in the root of your plan, then it will be included in the same relative location within the installed package directory. For more information on configuration and the default.toml file, see [Add configuration to plans](/docs/create-packages-configure/).

--- a/www/source/docs/reference/plan-syntax.html.md
+++ b/www/source/docs/reference/plan-syntax.html.md
@@ -396,8 +396,26 @@ svc_static_path
 svc_var_path
 : The location of any variable state data for the Habitat service.
 
+svc_user
+: The value of pkg_svc_user specified in a plan.
+
+svc_group
+: The value of pkg_svc_group specified in a plan.
+
+svc_user_default
+: The default user determined by the Habitat supervisor. `svc_user_default` will contain one of the following values, tested in order:
+- `svc_user` if specified in the plan
+- `hab` if the user exists
+- the current user id
+
+svc_group_default
+: The default group determined by the Habitat supervisor. `svc_group_default` will contain one of the following values, tested in order:
+- `svc_group` if specified in the plan
+- `hab` if the group exists
+- the effective group id
+
 ### cfg
-These are settings defined in your templatized configuration file. The values for those settings are pulled from the default.toml file included in your package.
+These are settings defined in your templatized configuration file. The values for those settings are pulled from the `default.toml` file included in your package. 
 
 ***
 

--- a/www/source/docs/run-packages-upload-files.html.md
+++ b/www/source/docs/run-packages-upload-files.html.md
@@ -11,7 +11,7 @@ To decrypt the file, the supervisor needs the service secret key and the user pu
 
 If a supervisor receives an encrypted file through a gossip rumor but is not the intended recipient, the file remains encrypted in memory. If the supervisor is the recipient and has the service secret key and the user public key, then the decrypted file will be written out to disk in the running service's directory (for example, /hab/svc/redis/files/foo). If a service is the recipient but does not have the appropriate keys to decrypt, the operation will be retried with an exponential backoff starting at one second, then doubling the time between retries (two seconds, four seconds, and so on). A max retry limit has not been set yet.
 
-> Note: Both the secret and public keys have their permissions set to allow the owners to read only (0400). Also, subdirectories on uploads are not supported. All files are uploaded to `/hab/svc/servicename/files`.
+> Note: Both the secret and public keys have their permissions set to allow the owners to read only (0400). Also, subdirectories on uploads are not supported. All files are uploaded to `/hab/svc/servicename/files`, and are owned by `$pkg_svc_user:$pkg_svc_group` if specified in a plan. Otherwise, the user and group defaults to `hab:hab`. Uploaded file permissions are set to `0770`.
 
 ## Usage
 Follow this basic flow to upload files into a service group.


### PR DESCRIPTION
Plans that specify pkg_svc_user and pkg_svc_group will have SVC_USER and
SVC_GROUP artifact metafiles created during build. The supervisor will
attempt to run the child service process as the given user/group.

- if SVC_USER and SVC_GROUP metafiles exist, the supervisor will verify the user
  and group specified within exists. If we are running as the specified
  user:group, the process will start without changing user:group. If we
  aren't running as the specified user:group, but are running as root,
  we exec the child process as SVC_USER:SVC_GROUP. If a pkg_svc_user and
  pkg_svc_group aren't specified, try running the service as hab:hab if
  that user:group exists, otherwise, fall back to the current uid:gid.
- we no longer symlink to hooks, they are copied to /hab/svc/foo/*. This
  is so we can chmod the run script as the user/group running the service.
- friendlier chmod/chown/mkdir errors that bubble up to the CLI
- Tracing added for chmod/chown/mkdir functions
- a RuntimeConfig struct is passed into Supervisor that specifies
  additional params used during child process exec.
- Supervisor provides a platform-dependent start_platform() function
  to allow for future expansion.
- **hooks are executed as `SVC_USER:SVC_GROUP` if they are specified, otherwise, they fall back to `hab:hab`, `current_uid:current_gid`, and finally panic.**
- Platform dependent users module, currently supports Linux (osx
untested but might just work)
- fixed a bug in `GossipFileList`/`GossipFile` where files wouldn't register that they've been written, making them write at every iteration
- `hab file upload`ed files are chown'd to `svc_user:svc_group`
- ~~postgres plan updated to run as `hab:hab`. `initdb` (in the `init` hook) requires a non-root user to run.~~
- permissions are tricky, please kick the tires with this branch on a few packages before considering a merge for this PR.

---

Staring without user `dparfitt`, which is specified in my local test `core/redis` package:

```
root@a4b6b938bc68:/src/components/sup# ./target/debug/hab-sup start core/redis
hab-sup(MN): Starting core/redis
hab-sup(USERS)[src/util/users.rs:41:27]: Package requires user dparfitt to exist, but it doesn't
```

Staring with user `dparfitt`, which is specified in my local test `core/redis` package:

```
root@a4b6b938bc68:/src/components/sup# ./target/debug/hab-sup start core/redis
hab-sup(MN): Starting core/redis
hab-sup(TP): Child process will run as user=dparfitt, group=dparfitt
```

Staring w/ `dparfitt:dparfitt`, but without write access to `/hab/svc/redis`:

```
hab-sup(PK): Can't create directory /hab/svc/redis
hab-sup(PK): If this service is running as non-root, you'll need to create /hab/svc/redis and give the current user write access to it
hab-sup(PK)[src/package/mod.rs:154:16]: Can't create "/hab/svc/redis", Permission denied (os error 13)
```

`/hab/svc/` file permissions for a running service that uses `hab:hab`:
```
root@3e8333673d2f:/src/components/sup# ls -latr /hab/svc/postgresql/
total 84
drwxr-xr-x  4 root root  4096 Jun 29 21:17 ..
drwx------  2 hab  hab   4096 Jun 29 21:17 files
drwx------  2 root root  4096 Jun 29 21:17 toml
-rw-r--r--  1 root root 46036 Jun 29 21:17 config.toml
-rwxr-xr-x  1 root root   195 Jun 29 21:17 run
drwxr-xr-x  2 root root  4096 Jun 29 21:17 hooks
drwx------  3 hab  hab   4096 Jun 29 21:17 config
drwx------  3 hab  hab   4096 Jun 29 21:17 var
drwx------ 19 hab  hab   4096 Jun 29 21:17 data
```

---

### File upload permissions

File permissions for uploaded file are the same as those specified in `pkg_svc_user`/`pkg_svc_group`.

If you want to try a simple file upload yourself, you can try the following:
   (note: you'll probably need a different value in `--peer 172.17.0.2:9634`)

```
hab user key generate someuser
hab service key generate redis.default someorg

/src/components/sup/target/debug/hab-sup start --org someorg core/redis &

date > foo.dat
hab file upload redis.default ./foo.dat 2 --peer 172.17.0.2:9634 --org someorg someuser

root@d6182a162160:/src/components/sup# ls -latr /hab/svc/redis/files/
total 12
drwxr-xr-x 8 root root 4096 Jul 15 20:55 ..
-rwxrwx--- 1 hab  hab    29 Jul 15 20:55 foo.dat
drwx------ 2 hab  hab  4096 Jul 15 20:55 .

root@d6182a162160:/src/components/sup# cat /hab/svc/redis/files/foo.dat
Fri Jul 15 20:55:44 UTC 2016
```
---

### Template params

There are new template vars accessible at runtime:

- `pkg.svc_user` - the value of `pkg_svc_user` specified in a plan
- `pkg.svc_group` - the value of `pkg_svc_group` specified in a plan

- `pkg.svc_user_default` - the default user determined by hab-sup via `fn hab_users::get_user_and_group()`
- `pkg.svc_group_default` - the default group determined by hab-sup via `fn hab_users::get_user_and_group()`

The logic in `hab_users::get_user_and_group()` is as follows:
- check and see if a user/group is specified in package metadata.
- if not, we'll try and use hab/hab.
- if hab/hab doesn't exist, try to use (current username, current group).
- If that doesn't work, then give up.

---

TODO:
- [x] NOTE: plans with chpst will fail if they don't specify pkg_svc_user/pkg_svc_group as root
- [x] should hab-plan-build ensure that pkg_svc_user/pkg_svc_group must be specified together or not at all?
  - hab-plan-build defaults them to `hab:hab`
- [x] `{{pkg.svc_user}}` and `{{pkg_svc_group}}` should be available in templates
- [x] Test `hab file upload` and check permissions