### PR TITLE
Fixed typo and updated continuous delivery doc

### DIFF
--- a/www/source/about/why-habitat.html.slim
+++ b/www/source/about/why-habitat.html.slim
@@ -32,7 +32,7 @@ p When we start from the
   Enterprise, we tend to build solutions that are too narrowly focused. Our
   software becomes an example of
   <a href="https://en.wikipedia.org/wiki/Conway%27s_law">Conway's Law</a> in action.
-  The deep silo-ing of responsibility present in most enterpries drives us to design
+  The deep silo-ing of responsibility present in most enterprises drives us to design
   software specifically for one silo or another: we build security software, or we
   build application deployment software, or we build configuration management software.
   If we endeavour to escape this trap by designing solutions that cut across the silos,

--- a/www/source/docs/continuous-deployment-overview.html.md
+++ b/www/source/docs/continuous-deployment-overview.html.md
@@ -16,14 +16,14 @@ As described in our article, [Why Package the App and Automation Together?](/abo
 
 ## Implementation
 
-Continuous deployment with Habitat uses two major features: materialized views in the depot, and update strategies. We will illustrate the end-to-end flow by using the principles and nomenclature of [Chef Delivery](https://www.chef.io/delivery/).
+Continuous deployment with Habitat uses two major features: materialized views in the depot, and update strategies. We will illustrate the end-to-end flow by using the principles and nomenclature of [Chef Automate](https://www.chef.io/automate/).
 
-We provide several components to help you implement continuous deployment with Chef Delivery and Habitat:
+We provide several components to help you implement continuous deployment with Chef Automate and Habitat:
 
 * A [build cookbook](https://github.com/chef-cookbooks/habitat-build) that can build Habitat projects, including performing lint and syntax checks
-* A [Ruby client library](https://rubygems.org/habitat-client) that you can use in your own Chef Delivery projects to programatically interact with a depot API to achieve the tasks here.
+* A [Ruby client library](https://rubygems.org/habitat-client) that you can use in your own Chef Automate projects to programatically interact with a depot API to achieve the tasks here.
 
-The build cookbook accomplishes the tasks described in the following table. It performs Habitat-specific operations for promoting an artifact through acceptance, union, rehearsal and delivered environments, and performs no actions in situations where the Delivery user should define actions specific to their application.
+The build cookbook accomplishes the tasks described in the following table. It performs Habitat-specific operations for promoting an artifact through acceptance, union, rehearsal and delivered environments, and performs no actions in situations where the Chef Automate user should define actions specific to their application.
 
 ### Pre-Artifact
 
@@ -34,7 +34,7 @@ The build cookbook accomplishes the tasks described in the following table. It p
 | Quality | No default action. Intended to be overriden by the user if desired. |
 | Publish | Builds the package with Habitat and uploads it to the configured Habitat depot. |
 
-At the end of the Publish phase, Chef Delivery stores Habitat-specific information about the package (origin, package name, version, and release) for use in the Post-Artifact stage.
+At the end of the Publish phase, Chef Automate stores Habitat-specific information about the package (origin, package name, version, and release) for use in the Post-Artifact stage.
 
 ### Post-Artifact
 


### PR DESCRIPTION
- Fixed typo in "Why Habitat" topic
- Updated Continuous Deployment topic to reflect Chef Delivery -> Chef Automate changes