### PR TITLE
URL escape the dollar signs in download URLs

### DIFF
--- a/www/source/docs/get-habitat.html.md
+++ b/www/source/docs/get-habitat.html.md
@@ -13,14 +13,14 @@ If you intend to build Habitat packages on your Mac, you will also need to insta
 _Habitat for Mac requires a 64-bit processor running Mac OS X version 10.9+._
 
 
-<a class="button" href="https://api.bintray.com/content/habitat/stable/darwin/x86_64/hab-$latest-x86_64-darwin.zip?bt_package=hab-x86_64-darwin">Download Habitat for Mac OS X</a>
+<a class="button" href="https://api.bintray.com/content/habitat/stable/darwin/x86_64/hab-%24latest-x86_64-darwin.zip?bt_package=hab-x86_64-darwin">Download Habitat for Mac OS X</a>
 <a class="button secondary" href="https://www.docker.com/products/docker-toolbox">Download Docker Toolbox</a>
 
 ### For Linux
 To start using Habitat on Linux, download the following binary.  
 _Habitat for Linux requires a 64-bit processor with a kernel greater than 2.6.32._
 
-<a class="button" href="https://api.bintray.com/content/habitat/stable/linux/x86_64/hab-$latest-x86_64-linux.tar.gz?bt_package=hab-x86_64-linux">Download Habitat for Linux</a>
+<a class="button" href="https://api.bintray.com/content/habitat/stable/linux/x86_64/hab-%24latest-x86_64-linux.tar.gz?bt_package=hab-x86_64-linux">Download Habitat for Linux</a>
 
 ### For Windows
 Habitat currently runs on Mac and Linux operating systems only. Windows support is coming soon.


### PR DESCRIPTION
This is so that bash doesn't think they are variables when copy/pasting

Signed-off-by: Jonathan Morley <morley.jonathan@gmail.com>