### PR TITLE
Add missing word in documentation

### DIFF
--- a/www/source/docs/contribute-help-build.html.md
+++ b/www/source/docs/contribute-help-build.html.md
@@ -38,4 +38,4 @@ While Habitat has initial support for Mesos and Kubernetes, we're working on sup
 
 ## Scalability and Load Testing
 
-The Habitat supervisor and its [communication protocols](/docs/internals-supervisor) have been designed to be very scalable. Our belief is that supervisor rings of thousands or even tens of thousands of nodes are possible, but we have not yet engaged in formal verification. If you are a distributed systems expert interested in testing scalability, we'd for you to try it and to share your results with us.
+The Habitat supervisor and its [communication protocols](/docs/internals-supervisor) have been designed to be very scalable. Our belief is that supervisor rings of thousands or even tens of thousands of nodes are possible, but we have not yet engaged in formal verification. If you are a distributed systems expert interested in testing scalability, we'd love for you to try it and to share your results with us.


### PR DESCRIPTION
This adds a missing word to the contribution documentation. I'd be happy to change it if you'd prefer different wording.  

Signed-off-by: Scott Macfarlane <macfarlane.scott@gmail.com>