### PR TITLE
if reconfigure hook exists, don't send SIGTERM

### DIFF
--- a/components/sup/src/topology/mod.rs
+++ b/components/sup/src/topology/mod.rs
@@ -331,10 +331,12 @@ fn run_internal<'a>(sm: &mut StateMachine<State, Worker<'a>, SupError>,
                         // Write the configuration, and restart if needed
                         if try!(service_config.write(&package)) {
                             try!(package.copy_run(&service_config));
-                            try!(package.reconfigure(&service_config));
                             outputln!("Restarting because the service config was updated via the \
                                        census");
-                            restart_process = true;
+                            let has_reconfigure = try!(package.reconfigure(&service_config));
+                            if !has_reconfigure {
+                                restart_process = true;
+                            }
                         }
                     }
                 }
@@ -374,8 +376,8 @@ fn run_internal<'a>(sm: &mut StateMachine<State, Worker<'a>, SupError>,
                 service_config.cfg(&package);
                 if try!(service_config.write(&package)) {
                     try!(package.copy_run(&service_config));
-                    let existed = try!(package.reconfigure(&service_config));
-                    if !existed {
+                    let has_reconfigure = try!(package.reconfigure(&service_config));
+                    if !has_reconfigure {
                         restart_process = true;
                     }
                 }


### PR DESCRIPTION
There already is a comment saying that this could do with some refactoring; for now only trying to fix the bug that @jamesc reported.

Fixes #987.

Signed-off-by: Stephan Renatus <srenatus@chef.io>