### PR TITLE
[hab-director] per-service environment variables

### DIFF
--- a/components/director/src/error.rs
+++ b/components/director/src/error.rs
@@ -35,7 +35,7 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let msg = match *self {
             Error::AddrParseError(ref e) => format!("Can't parse IP address {}", e),
-            Error::DirectorError(ref e) => format!("Director error {}", e),
+            Error::DirectorError(ref e) => format!("Director error: {}", e),
             Error::HabitatCore(ref e) => format!("{}", e),
             Error::IO(ref e) => format!("{}", e),
             Error::NoServices => "No services specified in configuration".to_string(),

--- a/components/director/src/lib.rs
+++ b/components/director/src/lib.rs
@@ -33,6 +33,7 @@ pub mod controller;
 pub use self::config::Config;
 pub use self::error::{Error, Result};
 
+use std::collections::HashMap;
 use std::fmt;
 use std::result;
 use std::str::FromStr;
@@ -49,6 +50,7 @@ pub struct ServiceDef {
     pub ident: PackageIdent,
     pub service_group: ServiceGroup,
     pub cli_args: Option<String>,
+    pub env: HashMap<String, String>,
 }
 
 impl ServiceDef {
@@ -57,6 +59,7 @@ impl ServiceDef {
             ident: ident,
             service_group: service_group,
             cli_args: None,
+            env: HashMap::new(),
         }
     }
 }

--- a/components/director/src/main.rs
+++ b/components/director/src/main.rs
@@ -102,6 +102,17 @@
 //!
 //! [cfg.services.core.rngd.foo.someorg]
 //! start = "--permanent-peer --foo=bar"
+//!
+//! Environment variables can be specified for each service in a TOML
+//! table. Only TOML string values are supported as environment variables.
+//!
+//! ```
+//! [cfg.services.core.someservice.somegroup.someorg]
+//! start = "--permanent-peer"
+//! [cfg.services.core.someservice.somegroup.someorg.env]
+//! JAVA_HOME="/hab/pkgs/core/jdk/foo"
+//! CLASSPATH="/hab/pkgs/core/bar/jars"
+//!
 //! ```
 //! ### Signal handling
 //!

--- a/www/source/docs/run-packages-director.html.md
+++ b/www/source/docs/run-packages-director.html.md
@@ -35,6 +35,31 @@ the service table definition:
 
 > Note:  CLI arguments specified in config.toml are split on whitespace.
 
+
+Services can provide environment variables in the form of a TOML table which follows the following format:
+
+	[services.<origin>.<name>.<group>.<organization>.env]
+	ENV1="some value"
+	ENV2="some other value" 
+
+> Note: Environment variables MUST be specified as valid TOML strings. 
+
+For example:
+
+	# Specify custom JAVA_HOME and CLASSPATH environment variables
+	[services.core.java_app.somegroup.someorg]
+	start = "--permanent-peer"
+	[services.core.java_app.somegroup.someorg.env]
+	JAVA_HOME="/some/path/"
+	CLASSPATH="/some/classpath/foo.jar"
+	
+	[services.core.rngd.foo.someorg]
+	start = "--permanent-peer --foo=bar"
+	JAVA_HOME="/a/different/path/"
+	# we don't specify CLASSPATH here, so it won't be set for core/rngd
+
+> Note: We current don't support global environment variables.
+
 ## Using the director
 When run in a supervisor, the director can be started using the `hab start` command.
 


### PR DESCRIPTION
Services can provide environment variables in the form of a TOML table which follows the following format:

```
[services.<origin>.<name>.<group>.<organization>.env]
ENV1="some value"
ENV2="some other value" 
```

> Note: Environment variables MUST be specified as valid TOML strings.

For example:

```
# Specify custom JAVA_HOME and CLASSPATH environment variables
[services.core.java_app.somegroup.someorg]
start = "--permanent-peer"
[services.core.java_app.somegroup.someorg.env]
JAVA_HOME="/some/path/"
CLASSPATH="/some/classpath/foo.jar"
   
[services.core.rngd.foo.someorg]
start = "--permanent-peer --foo=bar"
JAVA_HOME="/a/different/path/"
# we don't specify CLASSPATH here, so it won't be set for core/rngd
```

> Note: We current don't support "global" environment variables that are shared between services. This is definitely doable, but not in this PR.

for you @smith 🍰 