### PR TITLE
[hab-plan-build] filenames with whitespace(s) breaks FILES metafile generation

### DIFF
--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -1953,7 +1953,7 @@ _build_metadata() {
   build_line "Generating blake2b hashes of all files in the package"
   find $pkg_prefix -type f \
     | $_sort_cmd \
-    | while read file; do _b2sum $file; done > ${pkg_name}_blake2bsums
+    | while read file; do _b2sum "$file"; done > ${pkg_name}_blake2bsums
 
   build_line "Generating signed metadata FILES"
   $HAB_BIN pkg sign --origin $pkg_origin ${pkg_name}_blake2bsums $pkg_prefix/FILES
@@ -2163,7 +2163,9 @@ EOT
 # TODO: (jtimberman) If `hab pkg hash` itself starts to output
 # like `sha256sum` at some point, we'll need to update this function.
 _b2sum() {
-  echo -en "$($HAB_BIN pkg hash $1)  $1\n"
+  local filename="$1"
+  local hash_val=$(hab pkg hash "$filename")
+  echo -en "$hash_val  $filename\n"
 }
 
 # **Internal** Create the package artifact with `tar`/`hab pkg sign`


### PR DESCRIPTION
Fixes #1065