### PR TITLE
[plan-build] Use `make -j` in default steps

### DIFF
--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -1760,7 +1760,7 @@ do_build() {
 # Default implementation for the `do_build()` phase.
 do_default_build() {
   ./configure --prefix=$pkg_prefix
-  make
+  make -j
 }
 
 # Will run post-compile tests and checks, provided 2 conditions are true:
@@ -1810,7 +1810,7 @@ do_install() {
 
 # Default implementation for the `do_install()` phase.
 do_default_install() {
-  make install
+  make -j install
 }
 
 # **Internal** Write out the package data to files:


### PR DESCRIPTION
The `make` man page says:

> If the -j option is given without an argument, make will not limit the
> number of jobs that can run simultaneously.

Using `make -j` by default makes it use all available cores and
noticeably speeds up build times.

Not sure if this is the correct thing to do, but if it is, let's merge
it!

![gif-keyboard-14521149750607829157](https://cloud.githubusercontent.com/assets/9912/16955413/1c2221a8-4d9a-11e6-8223-a75e2030cf96.gif)