### PR TITLE
[hab-studio] fix key export/import err handling upon studio enter

### DIFF
--- a/components/studio/libexec/hab-studio-type-stage1.sh
+++ b/components/studio/libexec/hab-studio-type-stage1.sh
@@ -19,7 +19,28 @@ finish_setup() {
       # will use the outside cache key path, whereas the `_hab` function has
       # the `$FS_ROOT` set for the inside of the Studio. We're copying from
       # the outside in, using `hab` twice. I love my job.
-      $hab origin key export --type secret $key | _hab origin key import
+
+      # if we don't set +e here, then the subshell exits upon
+      # error without any output
+      set +e
+      key_text=$($hab origin key export --type secret $key)
+      # capture the result now before calling other commands
+      # that will overwrite the result
+      local result=$?
+      # reenable exit upon error
+      set -e
+
+      # NOTE: quotes MUST appear around ${key_text} to preserve
+      # newlines in the hab export output
+      if [ $result -eq 0 ]; then
+        echo "${key_text}" | _hab origin key import
+      else
+        echo "Error exporting $key key"
+        # key_text will contain an error message
+        echo "${key_text}"
+        exit 1
+      fi
+
     done
   fi
 


### PR DESCRIPTION
This PR improves error handling during studio creation, particularly when exporting a key from the host to the studio chroot.

Before this PR, when entering a studio with a key that doesn't exist in the cache, the error is reported as an "Unsupported key version". This is because the exported key _error message_ is piped to the `hab origin key import` command, which doesn't recognize the error message as a valid key :-(

Here's what starting a studio without an existing key currently looks like:

```
make shell

root@d42c540f6ae3:/src# export HAB_ORIGIN=kittens
root@d42c540f6ae3:/src# hab studio enter
∵ Package for core/hab-studio not found, installing
» Installing core/hab-studio
	... # removed for brevity
   hab-studio: Creating Studio at /hab/studios/src (default)
   hab-studio: Importing kittens secret origin key
» Importing origin key from standard input
✗✗✗
✗✗✗ Crypto error: Unsupported key version: ✗✗✗
✗✗✗
```

This PR catches errors when calling `hab origin key export`, and exits while displaying the export error message:

### Examples: 

These examples reflect the changes from this PR.

Starting a studio with a key that _DOES NOT_ exist in your key cache:

```
[core] hab_dev:root:/src$ export HAB_ORIGIN=myorigin
[myorigin] hab_dev:root:/src$ hab studio enter
   hab-studio: Creating Studio at /hab/studios/src (default)
   hab-studio: Importing myorigin secret origin key
Error exporting myorigin key
✗✗✗
✗✗✗ Crypto error: No revisions found for myorigin sig key
✗✗✗
```

Starting a studio with a key that _DOES_ exist in your key cache:

```
[metadave] hab_dev:root:/src$ hab studio enter
   hab-studio: Creating Studio at /hab/studios/src (default)
   hab-studio: Importing metadave secret origin key
» Importing origin key from standard input
★ Imported secret origin key metadave-20160620150805.
» Installing core/hab-backline
...
# yay!
```


-- 
To test this change out for yourself:

```
make shell
# NOTE: this isn't the real core key, unless you upload it ;-)
#       Core maintainers: PLEASE be careful here
hab origin key generate core
# NOTE: if you are a core maintainer, you MUST remove this key after testing

export HAB_ORIGIN=core
cd /src/components/studio && rm -rf ./results && hab studio build .
hab pkg install ./results/core*.hart

cd /src
export HAB_ORIGIN=foobar123
hab studio enter
```

This PR also affects the `stage1` studio type. 
To test:

```
# use the test instructions above, while changing the last line to:
hab studio -t stage1 enter
```

You'll see the following output for keys that don't exist:

```
root@70a2c39c65d0:/src# hab studio -t stage1 enter
   hab-studio: Creating Studio at /hab/studios/src (stage1)
   hab-studio: Importing foobar123 secret origin key
Error exporting foobar123 key
✗✗✗
✗✗✗ Crypto error: No revisions found for foobar123 sig key
✗✗✗
```

---
Note: my prompt is different inside the devshell, I'm using this to display my current `HAB_ORIGIN`:

	export PS1="[\$HAB_ORIGIN] hab_dev:\u:\w\$ "

