### PR TITLE
[merged] [plan-build] Fix file discovery in do_default_strip

### DIFF
--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -2051,7 +2051,7 @@ do_strip() {
 # Default implementation for the `do_strip()` phase.
 do_default_strip() {
   build_line "Stripping unneeded symbols from binaries and libraries"
-  find $pkg_prefix -type f -perm u+w -print0 2> /dev/null \
+  find $pkg_prefix -type f -perm -u+w -print0 2> /dev/null \
     | while read -rd '' f; do
       case "$(file -bi "$f")" in
         *application/x-executable*) strip --strip-all "$f";;


### PR DESCRIPTION
The previous invocation of find passed the `-perm` argument `u+w` which
would only match files whose mode was exactly 0200. Because of this,
almost no packages were shipping stripped executables. Changing this to
`-u+w` will find any files where the mode has the user write bit set.

Fixes #1066

Signed-off-by: Steven Danna <steve@chef.io>