### PR TITLE
Remove a leading space from the config file output

### DIFF
--- a/components/builder-web/app/package-page/PackagePageComponent.ts
+++ b/components/builder-web/app/package-page/PackagePageComponent.ts
@@ -66,7 +66,7 @@ import {fetchPackage} from "../actions/index";
                 </div>
                 <div class="hab-package-config" *ngIf="package.config">
                     <h3>Configuration</h3>
-                    <pre> {{package.config}}</pre>
+                    <pre>{{package.config}}</pre>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
I noticed it; it bothered me; I deleted it.

![gif-keyboard-9537344439311157416](https://cloud.githubusercontent.com/assets/9912/16991751/4b706d02-4e62-11e6-9609-0c353a1fd071.gif)
