### PR TITLE
Set the SSL_CERT_FILE for the director

### DIFF
--- a/terraform/files/hab-director.service
+++ b/terraform/files/hab-director.service
@@ -2,6 +2,7 @@
 Description=Habitat Director
 
 [Service]
+ExecStartPre=/bin/bash -c "/bin/systemctl set-environment SSL_CERT_FILE=$(hab pkg path core/cacerts)/ssl/cert.pem"
 ExecStart=/bin/hab-director start -c /hab/etc/director/config.toml
 
 [Install]


### PR DESCRIPTION
We need to set the SSL_CERT_FILE in the environment in order for the
processes started by the director to know where to find it, so that
HTTPS requests can have the SSL certificates verified. This change was
done manually on "live." When we set up the "acceptance" environment,
the Sign In process was throwing a 500 that looks like this:

ERROR:habitat_builder_api::http::handlers: github authentication, err=HyperError(Ssl(OpenSslErrors([UnknownError { library: "SSLroutines", function: "ssl3_get_server_certificate", reason: "certificate verify failed" }])))

This isn't because we are using a self-signed certifcate on acceptance
though, it's because the application couldn't verify GitHub's
certificate because it didn't know about the CA certs.

This change will hardcode the release-specific cert.pem, so if that
changes, it will probably fail on startup in the future.

Signed-off-by: jtimberman <joshua@chef.io>