### PR TITLE
[core] Set mtime on files while unpacking archive

### DIFF
--- a/components/core/src/package/archive.rs
+++ b/components/core/src/package/archive.rs
@@ -20,7 +20,7 @@ use std::str::{self, FromStr};
 
 use libarchive::writer;
 use libarchive::reader::{self, Reader};
-use libarchive::archive::{Entry, ReadFilter, ReadFormat};
+use libarchive::archive::{Entry, ReadFilter, ReadFormat, ExtractOption, ExtractOptions};
 use regex::Regex;
 
 use error::{Error, Result};
@@ -186,6 +186,9 @@ impl PackageArchive {
         try!(builder.support_filter(ReadFilter::Xz));
         let mut reader = try!(builder.open_stream(tar_reader));
         let writer = writer::Disk::new();
+        let mut extract_options = ExtractOptions::new();
+        extract_options.add(ExtractOption::Time);
+        try!(writer.set_options(&extract_options));
         try!(writer.set_standard_lookup());
         try!(writer.write(&mut reader, Some(root.to_string_lossy().as_ref())));
         try!(writer.close());


### PR DESCRIPTION
By default libarchive ignores the time data in the archive when
unpacking files. This means that the mtime of the files on disk after
install are all set to the time of install. This causes problems with
packages like guile which look at the mtime of its compiled assets to
determine if it needs to recompile them at startup.

Signed-off-by: Steven Danna <steve@chef.io>