### PR TITLE
[hab] add `hab pkg provides` command

### DIFF
--- a/components/hab/Cargo.lock
+++ b/components/hab/Cargo.lock
@@ -19,6 +19,7 @@ dependencies = [
  "toml 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "walkdir 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -709,6 +710,15 @@ dependencies = [
 name = "vec_map"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "walkdir"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "winapi"

--- a/components/hab/Cargo.toml
+++ b/components/hab/Cargo.toml
@@ -18,6 +18,7 @@ temp_utp = "*"
 toml = "*"
 url = "*"
 uuid = "0.1"
+walkdir = "*"
 
 [dependencies.clap]
 version = "*"

--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -170,6 +170,13 @@ pub fn get() -> App<'static, 'static> {
                 (@arg PKG_IDENT: +required +takes_value
                     "A package identifier (ex: core/redis, core/busybox-static/1.42.2)")
             )
+            (@subcommand provides =>
+                (about: "Search installed Habitat packages for a given file")
+                (@arg FILE: +required +takes_value
+                    "File name to find")
+                (@arg FULL_RELEASES: -r "Show fully qualified package names (ex: core/busybox-static/1.24.2/20160708162350)")
+                (@arg FULL_PATHS: -p "Show full path to file")
+            )
             (@subcommand sign =>
                 (about: "Signs an archive with an origin key, generating a Habitat Artifact")
                 (aliases: &["s", "si", "sig"])

--- a/components/hab/src/command/pkg.rs
+++ b/components/hab/src/command/pkg.rs
@@ -311,11 +311,14 @@ pub mod provides {
         // the location of installed packages
         let pkg_root = fs_root_path.join(PKG_PATH);
 
+        let mut found_any = false;
+
         // recursively walk the directories in pkg_root looking for matches
         for entry in WalkDir::new(pkg_root).into_iter().filter_map(|e| e.ok()) {
             if let Some(f) = entry.path().file_name().and_then(|f| f.to_str()) {
 
                 if filename == f {
+                    found_any = true;
                     let mut comps = entry.path().components();
 
                     // skip prefix_count segments of the path
@@ -351,7 +354,11 @@ pub mod provides {
         for entry in &found {
             println!("{}", entry);
         }
-        Ok(())
+        if found_any {
+            Ok(())
+        } else {
+            Err(Error::ProvidesError(filename.to_string()))
+        }
     }
 }
 

--- a/components/hab/src/command/pkg.rs
+++ b/components/hab/src/command/pkg.rs
@@ -290,6 +290,71 @@ pub mod path {
     }
 }
 
+pub mod provides {
+    use std::collections::HashSet;
+    use std::path::Path;
+
+    use walkdir::WalkDir;
+
+    use error::{Error, Result};
+    use hcore::fs::PKG_PATH;
+
+    pub fn start(filename: &str,
+                 fs_root_path: &Path,
+                 full_releases: bool,
+                 full_path: bool)
+                 -> Result<()> {
+        let mut found = HashSet::new();
+        // count the # of directories in the path to the package dir
+        // ex: /hab/pkg == 2
+        let prefix_count = Path::new(PKG_PATH).components().count();
+        // the location of installed packages
+        let pkg_root = fs_root_path.join(PKG_PATH);
+
+        // recursively walk the directories in pkg_root looking for matches
+        for entry in WalkDir::new(pkg_root).into_iter().filter_map(|e| e.ok()) {
+            if let Some(f) = entry.path().file_name().and_then(|f| f.to_str()) {
+
+                if filename == f {
+                    let mut comps = entry.path().components();
+
+                    // skip prefix_count segments of the path
+                    let _ = try!(comps.nth(prefix_count).ok_or(Error::FileNotFound(f.to_string())));
+
+                    let segments = if full_releases {
+                        // take all 4 segments of the path
+                        // ex: core/busybox-static/1.24.2/20160708162350
+                        comps.take(4)
+                    } else {
+                        // only take 2 segments of the path
+                        // ex: core/busybox-static
+                        comps.take(2)
+                    };
+
+                    let mapped_segs: Vec<String> =
+                        segments.map(|c| c.as_os_str().to_string_lossy().into_owned()).collect();
+                    let pkg_name = mapped_segs.join("/");
+
+                    // if we show the full path, then don't bother stuffing
+                    // the result into the found HashSet, as we want to
+                    // print out each path we find.
+                    if full_path {
+                        println!("{}: {}", &pkg_name, &entry.path().to_string_lossy());
+                    } else {
+                        found.insert(pkg_name);
+                    }
+                }
+            }
+        }
+        // if we're not using full_path, then using a set will filter out
+        // duplicates. This shows the filtered set of matches
+        for entry in &found {
+            println!("{}", entry);
+        }
+        Ok(())
+    }
+}
+
 pub mod sign {
     use std::path::Path;
 

--- a/components/hab/src/error.rs
+++ b/components/hab/src/error.rs
@@ -40,6 +40,7 @@ pub enum Error {
     IO(io::Error),
     PackageArchiveMalformed(String),
     PathPrefixError(path::StripPrefixError),
+    ProvidesError(String),
     SubcommandNotSupported(String),
     UnsupportedExportFormat(String),
 }
@@ -68,6 +69,7 @@ impl fmt::Display for Error {
                         e)
             }
             Error::PathPrefixError(ref err) => format!("{}", err),
+            Error::ProvidesError(ref err) => format!("Can't find {}", err),
             Error::SubcommandNotSupported(ref e) => {
                 format!("Subcommand `{}' not supported on this operating system", e)
             }
@@ -96,6 +98,7 @@ impl error::Error for Error {
                 "Package archive was unreadable or had unexpected contents"
             }
             Error::PathPrefixError(ref err) => err.description(),
+            Error::ProvidesError(_) => "Can't find a package that provides the given search parameter",
             Error::SubcommandNotSupported(_) => "Subcommand not supported on this operating system",
             Error::UnsupportedExportFormat(_) => "Unsupported export format",
         }

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -32,6 +32,7 @@ extern crate url;
 // Temporary depdency for gossip/rumor injection code duplication.
 extern crate utp;
 extern crate uuid;
+extern crate walkdir;
 
 mod analytics;
 mod cli;
@@ -146,6 +147,7 @@ fn start() -> Result<()> {
                 ("hash", Some(m)) => try!(sub_pkg_hash(m)),
                 ("install", Some(m)) => try!(sub_pkg_install(m)),
                 ("path", Some(m)) => try!(sub_pkg_path(m)),
+                ("provides", Some(m)) => try!(sub_pkg_provides(m)),
                 ("sign", Some(m)) => try!(sub_pkg_sign(m)),
                 ("upload", Some(m)) => try!(sub_pkg_upload(m)),
                 ("verify", Some(m)) => try!(sub_pkg_verify(m)),
@@ -446,6 +448,18 @@ fn sub_pkg_path(m: &ArgMatches) -> Result<()> {
     let ident = try!(PackageIdent::from_str(m.value_of("PKG_IDENT").unwrap()));
 
     command::pkg::path::start(&ident, &fs_root_path)
+}
+
+fn sub_pkg_provides(m: &ArgMatches) -> Result<()> {
+    let fs_root = henv::var(FS_ROOT_ENVVAR).unwrap_or(FS_ROOT_PATH.to_string());
+    let fs_root_path = Path::new(&fs_root);
+    // FILE is requied, should be safe to unwrap
+    let filename = m.value_of("FILE").unwrap();
+
+    let full_releases = m.is_present("FULL_RELEASES");
+    let full_paths = m.is_present("FULL_PATHS");
+
+    command::pkg::provides::start(&filename, &fs_root_path, full_releases, full_paths)
 }
 
 fn sub_pkg_sign(m: &ArgMatches) -> Result<()> {

--- a/www/source/docs/reference/habitat-cli.html.md
+++ b/www/source/docs/reference/habitat-cli.html.md
@@ -22,6 +22,7 @@ The commands and sub-commands for the Habitat CLI (`hab`) are listed below.
 - [hab pkg hash](#hab-pkg-hash)
 - [hab pkg install](#hab-pkg-install)
 - [hab pkg path](#hab-pkg-path)
+- [hab pkg provides](#hab-pkg-provides)
 - [hab pkg sign](#hab-pkg-sign)
 - [hab pkg upload](#hab-pkg-upload)
 - [hab pkg verify](#hab-pkg-verify)
@@ -354,6 +355,24 @@ Prints the path to a specific installed release of a package
 **ARGS**
 
     <PKG_IDENT>    A package identifier (ex: core/redis, core/busybox-static/1.42.2)
+
+<h2 id="hab-pkg-provides" class="anchor">hab pkg provides</h2>
+Search installed Habitat packages for a given file.
+
+**USAGE**
+
+    hab pkg provides [FLAGS] <FILE>
+
+**FLAGS**
+
+    -p               Show full path to file
+    -r               Show fully qualified package names (ex: core/busybox-static/1.24.2/20160708162350)
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+**ARGS**
+
+    <FILE>    File name to find
 
 <h2 id="hab-pkg-sign" class="anchor">hab pkg sign</h2>
 Signs an archive with an origin key, generating a Habitat Artifact


### PR DESCRIPTION
This PR implements the `hab pkg provides` subcommand, which gives us a _platform independent_ way to search **installed** Habitat packages for a given file.

Current flags are:

`-r` shows fully qualified package names
`-p` show full path to a found file

Here's some sample output searching for a binary, a header file, and a .so:

```
$ hab pkg provides bash
core/busybox-static
$ hab pkg provides -r bash
core/busybox-static/1.24.2/20160708162350
$ hab pkg provides -p bash
core/busybox-static: /hab/pkgs/core/busybox-static/1.24.2/20160708162350/bin/bash
$ hab pkg provides -rp bash
core/busybox-static/1.24.2/20160708162350: /hab/pkgs/core/busybox-static/1.24.2/20160708162350/bin/bash


$ hab pkg provides stdlib.h
core/glibc
$ hab pkg provides -r stdlib.h
core/glibc/2.22/20160612063629
$ hab pkg provides -p stdlib.h
core/glibc: /hab/pkgs/core/glibc/2.22/20160612063629/include/stdlib.h
core/glibc: /hab/pkgs/core/glibc/2.22/20160612063629/include/bits/stdlib.h
$ hab pkg provides -rp stdlib.h
core/glibc/2.22/20160612063629: /hab/pkgs/core/glibc/2.22/20160612063629/include/stdlib.h
core/glibc/2.22/20160612063629: /hab/pkgs/core/glibc/2.22/20160612063629/include/bits/stdlib.h

$ hab pkg provides -p libstdc++.so.6
core/gcc-libs: /hab/pkgs/core/gcc-libs/5.2.0/20160612075020/lib/libstdc++.so.6
```

cc @stevendanna 