### PR TITLE
Move Core Plans Maintainers back to main MAINTAINERS.md

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -86,3 +86,22 @@ tutorials and reference materials.
 
 * [Ryan Keairns](https://github.com/ryankeairns)
 * [Brian Scott](https://github.com/bscott)
+
+### Core Plans
+
+The core Habitat plans are plans maintained by the Habitat core plans
+maintainers. The plans are located in the
+[habitat-sh/core-plans](https://github.com/habitat-sh/core-plans) repository.
+
+#### Lieutenant
+
+* [Adam Jacob](https://github.com/adamhjk)
+
+#### Maintainers
+
+* [Elliott Davis](https://github.com/elliott-davis)
+* [Fletcher Nichol](https://github.com/fnichol)
+* [Dave Parfitt](https://github.com/metadave)
+* [Nathan L Smith](https://github.com/smith)
+* [Joshua Timberman](https://github.com/jtimberman)
+* [Jamie Winsor](https://github.com/reset)


### PR DESCRIPTION
Feels like it would be better to have just one of these files.

![gif-keyboard-10564341984700588675](https://cloud.githubusercontent.com/assets/9912/17105267/22963cd4-524c-11e6-915e-fc7cbb9b2b06.gif)
