### PR TITLE
[core] add quickcheck and ServiceGroup parsing property

### DIFF
--- a/components/core/Cargo.lock
+++ b/components/core/Cargo.lock
@@ -9,6 +9,7 @@ dependencies = [
  "libc 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsodium-sys 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quickcheck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "sodiumoxide 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -34,6 +35,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.71 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -178,6 +188,16 @@ dependencies = [
 name = "pkg-config"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "quickcheck"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "env_logger 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "rand"

--- a/components/core/Cargo.toml
+++ b/components/core/Cargo.toml
@@ -24,6 +24,7 @@ time = "*"
 
 [dev-dependencies]
 tempdir = "*"
+quickcheck = "*"
 
 [dev-dependencies.hyper]
 version = "*"

--- a/components/core/src/lib.rs
+++ b/components/core/src/lib.rs
@@ -26,6 +26,9 @@ extern crate rustc_serialize;
 extern crate sodiumoxide;
 extern crate libsodium_sys;
 #[cfg(test)]
+#[macro_use]
+extern crate quickcheck;
+#[cfg(test)]
 extern crate tempdir;
 extern crate time;
 extern crate toml;


### PR DESCRIPTION
Hi!

Now that the [Rust implementation of QuickCheck](https://github.com/BurntSushi/quickcheck) (aka "QC") doesn't require a [nightly Rust build](https://users.rust-lang.org/t/quickcheck-has-a-macro-on-rust-stable/6636), I'm including it in Habitat core. 

The first property that I've included generates service, group, and an optional organization to pass into `ServiceGroup::from_str()`. While testing, I found several bugs with the current regex we're using.

If you'd like to see some of the crazy Strings that QC generates,
run the test:

	cargo test -- prop_service_group_from_str --nocapture
	# some of the output may mess up tmux etc
