### PR TITLE
Adds trailing slash to fix search bug

### DIFF
--- a/www/source/layouts/sidebar.slim
+++ b/www/source/layouts/sidebar.slim
@@ -3,7 +3,7 @@
     .row
       .main-sidebar
           - if sidebar_layout == 'docs'
-            form.main-sidebar--search action="/docs/search" method="get"
+            form.main-sidebar--search action="/docs/search/" method="get"
               input type="text" placeholder="Search Documentation" name="q"
           ul.no-bullet
             - sidebar_data(sidebar_layout).each do |item|


### PR DESCRIPTION
Makes it so the search bar in the sidebar actually works! S3 was
adding a trailing slash which was breaking the functionality.
This adds the trailing slash to the form action so the search
query gets carried onto the search page.

Signed-off-by: Maggie Walker <magwalk@gmail.com>