### PR TITLE
Rename 'views' to 'channels'

### DIFF
--- a/components/builder-depot/doc/api.raml
+++ b/components/builder-depot/doc/api.raml
@@ -104,16 +104,16 @@ baseUri: http://api.samplehost.com
                 200:
                 400:
                 500:
-/views:
+/channels:
   get:
-    description: List all views
+    description: List all channels
     responses:
       200:
         body:
           application/json:
             example: |
               {}
-  /{view}:
+  /{channelId}:
     /pkgs:
       /{origin}:
         get:

--- a/components/builder-depot/src/server.rs
+++ b/components/builder-depot/src/server.rs
@@ -1018,7 +1018,7 @@ fn list_packages(depot: &Depot, req: &mut Request) -> IronResult<Response> {
     }
 }
 
-fn list_views(depot: &Depot, _req: &mut Request) -> IronResult<Response> {
+fn list_channels(depot: &Depot, _req: &mut Request) -> IronResult<Response> {
     let views = try!(depot.datastore.views.all());
     let body = json::encode(&views).unwrap();
 
@@ -1296,9 +1296,40 @@ pub fn router(depot: Arc<Depot>) -> Result<Chain> {
     let depot25 = depot.clone();
     let depot26 = depot.clone();
     let depot27 = depot.clone();
+    let depot28 = depot.clone();
+    let depot29 = depot.clone();
+    let depot30 = depot.clone();
+    let depot31 = depot.clone();
+    let depot32 = depot.clone();
+    let depot33 = depot.clone();
+    let depot34 = depot.clone();
+    let depot35 = depot.clone();
 
     let router = router!(
-        get "/views" => move |r: &mut Request| list_views(&depot1, r),
+        get "/channels" => move |r: &mut Request| list_channels(&depot28, r),
+        get "/channels/:view/pkgs/:origin" => move |r: &mut Request| list_packages(&depot29, r),
+        get "/channels/:view/pkgs/:origin/:pkg" => {
+            move |r: &mut Request| list_packages(&depot30, r)
+        },
+        get "/channels/:view/pkgs/:origin/:pkg/latest" => {
+            move |r: &mut Request| show_package(&depot31, r)
+        },
+        get "/channels/:view/pkgs/:origin/:pkg/:version" => {
+            move |r: &mut Request| list_packages(&depot32, r)
+        },
+        get "/channels/:view/pkgs/:origin/:pkg/:version/latest" => {
+            move |r: &mut Request| show_package(&depot33, r)
+        },
+        get "/channels/:view/pkgs/:origin/:pkg/:version/:release" => {
+            move |r: &mut Request| show_package(&depot34, r)
+        },
+        post "/channels/:view/pkgs/:origin/:pkg/:version/:release/promote" => {
+            move |r: &mut Request| promote_package(&depot35, r)
+        },
+
+        // JW: `views` is a deprecated term and now an alias for `channels`. These routes should be
+        // removed at a later date.
+        get "/views" => move |r: &mut Request| list_channels(&depot1, r),
         get "/views/:view/pkgs/:origin" => move |r: &mut Request| list_packages(&depot2, r),
         get "/views/:view/pkgs/:origin/:pkg" => move |r: &mut Request| list_packages(&depot3, r),
         get "/views/:view/pkgs/:origin/:pkg/latest" => {

--- a/www/source/docs/continuous-deployment-overview.html.md
+++ b/www/source/docs/continuous-deployment-overview.html.md
@@ -16,7 +16,7 @@ As described in our article, [Why Package the App and Automation Together?](/abo
 
 ## Implementation
 
-Continuous deployment with Habitat uses two major features: materialized views in the depot, and update strategies. We will illustrate the end-to-end flow by using the principles and nomenclature of [Chef Automate](https://www.chef.io/automate/).
+Continuous deployment with Habitat uses two major features: materialized channels in the depot, and update strategies. We will illustrate the end-to-end flow by using the principles and nomenclature of [Chef Automate](https://www.chef.io/automate/).
 
 We provide several components to help you implement continuous deployment with Chef Automate and Habitat:
 
@@ -40,14 +40,14 @@ At the end of the Publish phase, Chef Automate stores Habitat-specific informati
 
 Each of these phases runs per environment (acceptance, union, rehearsal, delivered).
 
-| Provision | Updates the materialized view in the depot for the application in the indicated environment with the metadata saved at the end of the pre-artifact stages. This will trigger supervisors in that environment to update the Habitat package in concordance with their configured update strategy, if any. |
+| Provision | Updates the materialized channel in the depot for the application in the indicated environment with the metadata saved at the end of the pre-artifact stages. This will trigger supervisors in that environment to update the Habitat package in concordance with their configured update strategy, if any. |
 | Deploy | No default action. Intended to be overridden by the user if desired. |
 | Smoke | No default action. Intended to be overridden by the user if desired. |
 | Functional | No default action. Intended to be overridden by the user if desired. |
 
 ### Supervisor Configuration
 
-In order to enable automatic deployment in each environment during the provision stage, you should [configure the supervisor](/docs/run-packages-update-strategy/) to use a named view as its depot URL, and set its update strategy. By convention, it's best to name the depot view the same as the service group name.
+In order to enable automatic deployment in each environment during the provision stage, you should [configure the supervisor](/docs/run-packages-update-strategy/) to use a named channel as its depot URL, and set its update strategy. By convention, it's best to name the depot channel the same as the service group name.
 
 <hr>
 <ul class="main-content--link-nav">

--- a/www/source/docs/run-packages-update-strategy.html.md
+++ b/www/source/docs/run-packages-update-strategy.html.md
@@ -16,24 +16,24 @@ To start a supervisor with the auto-update strategy, pass the `--strategy` argum
 
        hab start yourorigin/yourapp --strategy at-once --url https://willem.habitat.sh/v1/depot
 
-## Configuring an Update Strategy with a Depot View
+## Configuring an Update Strategy with a Depot Channel
 
-A _view_ in a depot is a point-in-time snapshot of the state of the depot. In point of fact, it is a [materialized view](https://en.wikipedia.org/wiki/Materialized_view) of the depot, starting with the specific `origin/package/version/release` quad, and encapsulating all of the transitive dependencies of that quad. This is very useful for continuous deployment purposes:
+A _channel_ in a depot is a point-in-time snapshot of the state of the depot. In point of fact, it is a [materialized channel](https://en.wikipedia.org/wiki/Materialized_channel) of the depot, starting with the specific `origin/package/version/release` quad, and encapsulating all of the transitive dependencies of that quad. This is very useful for continuous deployment purposes:
 
-* By convention, you name the view in the depot after the name of your service group (e.g. `myapp.production`)
+* By convention, you name the channel in the depot after the name of your service group (e.g. `myapp.production`)
 * You deliver new versions of `myapp` as Habitat packages to the depot
-* When you are ready to roll out a new version of the application, you update the view corresponding to the intended environment
+* When you are ready to roll out a new version of the application, you update the channel corresponding to the intended environment
 * The supervisors in that service group, configured with an appropriate update strategy, update their underlying Habitat package, optionally coordinating with one another, and restart the service.
 
-Configuring the supervisors'  update strategy URL to point to a view ensures that new versions of the application do not get deployed until the view is updated, thereby preventing unstable versions from reaching environments for which they are not intended.
+Configuring the supervisors'  update strategy URL to point to a channel ensures that new versions of the application do not get deployed until the channel is updated, thereby preventing unstable versions from reaching environments for which they are not intended.
 
-To start a supervisor with a strategy and pointing to a view, modify slightly the URL to the depot:
+To start a supervisor with a strategy and pointing to a channel, modify slightly the URL to the depot:
 
-       hab start yourorigin/yourapp --strategy at-once --url https://yourdepot.example.com/v1/depot/views/yourview
+       hab start yourorigin/yourapp --strategy at-once --url https://yourdepot.example.com/v1/depot/channels/yourchannel
 
-`yourview` represents the view you have created in the depot.
+`yourchannel` represents the channel you have created in the depot.
 
-_At the moment, the `hab` command-line tool lacks the ability to create and manage views. To use views, you must run your own depot server and use the internal depot maintenance tool to manage views_.
+_At the moment, the `hab` command-line tool lacks the ability to create and manage channels. To use channels, you must run your own depot server and use the internal depot maintenance tool to manage channels_.
 
 <hr>
 <ul class="main-content--link-nav">

--- a/www/source/docs/share-packages-overview.html.md
+++ b/www/source/docs/share-packages-overview.html.md
@@ -50,13 +50,13 @@ You can instruct the supervisor to download and run packages from a depot by usi
 
 If the supervisor does not have the `core/postgresql` package in its local cache, it will contact the public depot, retrieve the latest version and the public key for the `core` origin, verify the cryptographic integrity of the package, and then start it.
 
-You may also supply a `--url` argument to the `hab start` command to instruct the supervisor to use either a different depot, or a materialized view in that depot for the purposes of continuous deployment:
+You may also supply a `--url` argument to the `hab start` command to instruct the supervisor to use either a different depot, or a materialized channel in that depot for the purposes of continuous deployment:
 
        hab start core/postgresql --url http://mydepot.example.com/v1/depot
 
 or
 
-       hab start core/postgresql --url http://mydepot.example.com/v1/depot/views/myview
+       hab start core/postgresql --url http://mydepot.example.com/v1/depot/channels/mychannel
 
 <hr>
 <ul class="main-content--link-nav">


### PR DESCRIPTION
* Depot API endpoints renamed from `/views` to `/channels`
* `/views` endpoints remain as an alias
* Update docs to reflect naming changes

Signed-off-by: Jamie Winsor <jamie@vialstudios.com>