### PR TITLE
Update for Terraform 0.7

### DIFF
--- a/terraform/builder-gateways.tf
+++ b/terraform/builder-gateways.tf
@@ -47,7 +47,7 @@ resource "aws_instance" "builder_api" {
       "sudo mv /home/ubuntu/hab-director.service /etc/systemd/system/hab-director.service",
       "sudo mkdir -p /hab/etc/director",
       "cat <<BODY > /tmp/director-config.toml",
-      "${template_file.gateway_director.rendered}",
+      "${data.template_file.gateway_director.rendered}",
       "BODY",
       "sudo mv /tmp/director-config.toml /hab/etc/director/config.toml",
       "sudo systemctl daemon-reload",
@@ -64,7 +64,7 @@ resource "aws_instance" "builder_api" {
   }
 }
 
-resource "template_file" "gateway_director" {
+data "template_file" "gateway_director" {
   template = "${file("${path.module}/templates/gateway-director.toml")}"
 
   vars {

--- a/terraform/builder-monolith.tf
+++ b/terraform/builder-monolith.tf
@@ -51,7 +51,7 @@ resource "aws_instance" "monolith" {
       "sudo mv /home/ubuntu/hab-director.service /etc/systemd/system/hab-director.service",
       "sudo mkdir -p /hab/etc/director",
       "cat <<BODY > /tmp/director-config.toml",
-      "${template_file.monolith_director.rendered}",
+      "${data.template_file.monolith_director.rendered}",
       "BODY",
       "sudo mv /tmp/director-config.toml /hab/etc/director/config.toml",
       "sudo systemctl daemon-reload",
@@ -68,7 +68,7 @@ resource "aws_instance" "monolith" {
   }
 }
 
-resource "template_file" "monolith_director" {
+data "template_file" "monolith_director" {
   template = "${file("${path.module}/templates/monolith-director.toml")}"
 
   vars {

--- a/terraform/builder-routers.tf
+++ b/terraform/builder-routers.tf
@@ -34,7 +34,7 @@ resource "aws_instance" "router" {
       "sudo mv /home/ubuntu/hab-director.service /etc/systemd/system/hab-director.service",
       "sudo mkdir -p /hab/etc/director",
       "cat <<BODY > /tmp/director-config.toml",
-      "${template_file.router_director.rendered}",
+      "${data.template_file.router_director.rendered}",
       "BODY",
       "sudo mv /tmp/director-config.toml /hab/etc/director/config.toml",
       "sudo systemctl daemon-reload",
@@ -51,7 +51,7 @@ resource "aws_instance" "router" {
   }
 }
 
-resource "template_file" "router_director" {
+data "template_file" "router_director" {
   template = "${file("${path.module}/templates/router-director.toml")}"
 
   vars {

--- a/terraform/builder-services.tf
+++ b/terraform/builder-services.tf
@@ -47,7 +47,7 @@ resource "aws_instance" "services" {
       "sudo mv /home/ubuntu/hab-director.service /etc/systemd/system/hab-director.service",
       "sudo mkdir -p /hab/etc/director",
       "cat <<BODY > /tmp/director-config.toml",
-      "${template_file.services_director.rendered}",
+      "${data.template_file.services_director.rendered}",
       "BODY",
       "sudo mv /tmp/director-config.toml /hab/etc/director/config.toml",
       "sudo systemctl daemon-reload",
@@ -64,7 +64,7 @@ resource "aws_instance" "services" {
   }
 }
 
-resource "template_file" "services_director" {
+data "template_file" "services_director" {
   template = "${file("${path.module}/templates/services-director.toml")}"
 
   vars {

--- a/terraform/builder-workers.tf
+++ b/terraform/builder-workers.tf
@@ -35,7 +35,7 @@ resource "aws_instance" "jobsrv_workers" {
       "sudo mv /home/ubuntu/hab-director.service /etc/systemd/system/hab-director.service",
       "sudo mkdir -p /hab/etc/director",
       "cat <<BODY > /tmp/director-config.toml",
-      "${template_file.worker_director.rendered}",
+      "${data.template_file.worker_director.rendered}",
       "BODY",
       "sudo mv /tmp/director-config.toml /hab/etc/director/config.toml",
       "sudo systemctl daemon-reload",
@@ -52,7 +52,7 @@ resource "aws_instance" "jobsrv_workers" {
   }
 }
 
-resource "template_file" "worker_director" {
+data "template_file" "worker_director" {
   template = "${file("${path.module}/templates/worker-director.toml")}"
 
   vars {


### PR DESCRIPTION
These changes are necessary for the Terraform 0.7 release

* Terraform 0.7 [Release notes](https://www.hashicorp.com/blog/terraform-0-7.html)
* Terraform 0.7 [Upgrade guide](https://www.terraform.io/upgrade-guides/0-7.html)