### PR TITLE
Adds optimizely snippet to head

### DIFF
--- a/www/source/layouts/layout.slim
+++ b/www/source/layouts/layout.slim
@@ -6,6 +6,8 @@ html prefix="og: http://ogp.me/ns#"
     meta content="width=device-width,initial-scale=1.0,minimum-scale=1.0,maximum-scale=1.0,user-scalable=no" name="viewport"
     meta name="description" content=current_page.data.description
 
+    script src="https://cdn.optimizely.com/js/6807120590.js"
+
     - current_page.data.title ||= "Habitat"
     - canonical_url = "https://www.habitat.sh"
     - social_image = "#{canonical_url}/images/habitat-social.jpg"


### PR DESCRIPTION
Going to test some copy changes.

Note: 
A previous attempt at adding Optimizely through Google Tag Manager caused issues since that lodges the script into the body. I've added it directly into the head here (not using GTM) and everything looks 👌 locally.