### PR TITLE
Fetch projects using the API

### DIFF
--- a/components/builder-web/app/BuilderApiClient.ts
+++ b/components/builder-web/app/BuilderApiClient.ts
@@ -84,6 +84,29 @@ export class BuilderApiClient {
         });
     }
 
+    public getProject(projectId) {
+        return new Promise((resolve, reject) => {
+            fetch(`${this.urlPrefix}/projects/${projectId}`, {
+                method: "GET",
+                headers: this.headers
+            }).then(response => {
+                if (response.ok) {
+                    resolve(response.json());
+                } else {
+                    reject(new Error(response.statusText));
+                }
+            }).catch(error => reject(error));
+        });
+    }
+
+    public getProjects() {
+        return new Promise((resolve, reject) => {
+            // TODO make the real API call here once the endpoint exists
+            // for now, just pretend it succeeded and there were no results
+            resolve([]);
+        });
+    }
+
     public getMyOriginInvitations() {
         return new Promise((resolve, reject) => {
             fetch(`${this.urlPrefix}/user/invitations`, {

--- a/components/builder-web/app/actions/projects.ts
+++ b/components/builder-web/app/actions/projects.ts
@@ -36,12 +36,12 @@ export const SET_PROJECTS = "SET_PROJECTS";
 export function addProject(project: Object, token: string) {
     return dispatch => {
         new BuilderApiClient(token).createProject(project).then(response => {
+            dispatch(requestRoute(["Projects"]));
             dispatch(addNotification({
                 title: "Project created",
-                body: `Created ${project["name"]}.`,
+                body: `Created ${response["id"]}.`,
                 type: SUCCESS,
             }));
-            console.log(response);
         }).catch(error => {
             dispatch(addNotification({
                 title: "Failed to Create project",
@@ -88,32 +88,33 @@ function fetchBuildLog(pkg, builds) {
     };
 }
 
-export function fetchProject(params) {
+export function fetchProject(id: string, token: string) {
     return dispatch => {
-        fakeApi.get(`projects/${params["origin"]}/${params["name"]}.json`).then(response => {
+        new BuilderApiClient(token).getProject(id).then(response => {
             dispatch(
-                setCurrentProject(
-                    Object.assign({
-                        ui: { exists: true, loading: false }
-                    }, response)
-                )
+              setCurrentProject(
+                Object.assign({
+                  ui: { exists: true, loading: false }
+                }, response)
+              )
             );
         }).catch(error => {
-            dispatch(setCurrentProject({
-                ui: { exists: false, loading: false }
+            dispatch(addNotification({
+                title: "Failed to fetch project",
+                body: error.message,
+                type: DANGER,
             }));
         });
     };
 }
 
-export function fetchProjects() {
+export function fetchProjects(token: string) {
     return dispatch => {
-        fakeApi.get("projects.json").then(response => {
+        new BuilderApiClient(token).getProjects().then(response => {
             dispatch(setProjects(response));
         });
     };
 }
-
 
 function finishBuildStream(build) {
     return {

--- a/components/builder-web/app/initialState.ts
+++ b/components/builder-web/app/initialState.ts
@@ -132,8 +132,8 @@ export default Record({
         added: List(),
         all: List(),
         current: Record({
-            origin: undefined,
-            name: undefined,
+            id: undefined,
+            plan_path: undefined,
             description: undefined,
             latestBuild: undefined,
             sourceUrl: undefined,

--- a/components/builder-web/app/project-page/ProjectPageComponent.ts
+++ b/components/builder-web/app/project-page/ProjectPageComponent.ts
@@ -31,11 +31,10 @@ import {friendlyTime, requireSignIn} from "../util";
         </div>
         <div *ngIf="project.ui.exists">
             <header class="page-title">
-                <h2>{{project.origin}} / {{project.name}}</h2>
+                <h2>{{project.id}}</h2>
                 <h4 *ngIf="project.latestBuild">
                     <a [routerLink]="['Package', {
-                        origin: project.origin,
-                        name: project.name,
+                        id: project.id,
                         version: project.latestBuild.version,
                         release: project.latestBuild.release
                     }]">
@@ -62,7 +61,7 @@ import {friendlyTime, requireSignIn} from "../util";
                                 <li>
                                     <h4>Build Command</h4>
                                     <div class="build-command">
-                                        hab install {{project.origin}}/{{project.name}}
+                                        hab install {{project.id}}
                                         <a (click)="false" href="#">⎘</a>
                                     </div>
                                 </li>
@@ -95,7 +94,7 @@ import {friendlyTime, requireSignIn} from "../util";
                                 <li>
                                     <h4>Build Command</h4>
                                     <div class="build-command">
-                                        hab install {{project.origin}}/{{project.name}}
+                                        hab install {{project.id}}
                                         <a (click)="false" href="#">⎘</a>
                                     </div>
                                 </li>
@@ -133,9 +132,19 @@ export class ProjectPageComponent implements OnInit {
         return this.store.getState().projects.current;
     }
 
+    get token() {
+        return this.store.getState().gitHub.authToken;
+    }
+
+    get id() {
+        return `${this.routeParams.params["origin"]}/${this.routeParams.params["name"]}`;
+    }
+
     ngOnInit() {
-        this.store.dispatch(fetchProject(this.routeParams.params));
-        this.store.dispatch(fetchBuilds(this.routeParams.params));
+        this.store.dispatch(fetchProject(this.id, this.token));
+        // leaving this commented out on purpose as a reminder to make it work
+        // again once the API returns build information
+        // this.store.dispatch(fetchBuilds(this.routeParams.params));
     }
 
     private friendlyTime(t) { return friendlyTime(t); }

--- a/components/builder-web/app/projects-page/ProjectsPageComponent.ts
+++ b/components/builder-web/app/projects-page/ProjectsPageComponent.ts
@@ -29,8 +29,7 @@ import {requireSignIn} from "../util";
         <div class="page-body">
             <ul class="hab-projects-list">
                 <li *ngIf="projects.size === 0">
-                    You do not have any Projects yet. Why not
-                    <a [routerLink]="['ProjectCreate']">create one</a>?
+                    You do not have any Projects yet.
                 </li>
                 <li *ngFor="#project of projects">
                     <a [routerLink]="['Project', { origin: project.origin, name: project.name }]" class="hab-item-list" href="#">
@@ -47,11 +46,15 @@ export class ProjectsPageComponent implements OnInit {
         requireSignIn(this);
     }
 
+    get token() {
+        return this.store.getState().gitHub.authToken;
+    }
+
     get projects() {
         return this.store.getState().projects.all;
     }
 
     ngOnInit() {
-        this.store.dispatch(fetchProjects());
+        this.store.dispatch(fetchProjects(this.token));
     }
 }


### PR DESCRIPTION
This makes `/projects/foo/bar` actually fetch the `foo/bar` project via the API and display it.  The display page is light on details because right now the API is only returning the id (`foo/bar` in this case) and the `plan_path`.

I also removed the canned data that shows up at `/projects` because it's misleading, now that project creation and fetching of individual projects actually works.  One would expect there to be a list of legit projects there to choose from, and going to a fake one will error when it tries to fetch the fake one from the server.

Instead, since the server doesn't support listing of projects yet, I'm just pretending like it made the API call and there weren't any projects on the server.  This is slightly confusing though, because after creating a project, you're redirected to a page that says you don't have any projects yet.  Right now, you have to manually construct the URL yourself to see the detail of the project.

![gif-keyboard-10458544534437627401](https://cloud.githubusercontent.com/assets/947/17409635/f2a7a39c-5a24-11e6-9d67-c8aff7f5c888.gif)
