### PR TITLE
Copy no_proxy settings to studio

### DIFF
--- a/components/studio/bin/hab-studio.sh
+++ b/components/studio/bin/hab-studio.sh
@@ -869,6 +869,9 @@ chroot_env() {
   if [ -n "${https_proxy:-}" ]; then
     env="$env https_proxy=$https_proxy"
   fi
+  if [ -n "${no_proxy:-}" ]; then
+    env="$env no_proxy=$no_proxy"
+  fi
 
   echo "$env"
   return 0
@@ -888,6 +891,9 @@ report_env_vars() {
   fi
   if [ -n "${https_proxy:-}" ]; then
     info "Exported: https_proxy=$https_proxy"
+  fi
+  if [ -n "${no_proxy:-}" ]; then
+    info "Exported: no_proxy=$no_proxy"
   fi
 }
 


### PR DESCRIPTION
Just like the http and https proxy settings, this also copies no_proxy env var to the hab studio if it's been set.