### PR TITLE
[hab,hab-sup] Fix progress bar/newline rendering issue.

### DIFF
--- a/components/depot-client/src/lib.rs
+++ b/components/depot-client/src/lib.rs
@@ -49,6 +49,7 @@ header! { (ETag, "ETag") => [String] }
 
 pub trait DisplayProgress: Write {
     fn size(&mut self, size: u64);
+    fn finish(&mut self);
 }
 
 pub struct Client {


### PR DESCRIPTION
This change addresses an issue where a download/upload progress bar
doesn't print a newline character once complete and thus appends the
next line to itself. This is observed when resizing terminal windows,
copying command line output, and occasionally when a command is
executing in a non-interactive shell.

Our progress bar implementation uses the `pbr` crate and gets combined
into a broadcast writer or tee reader before calling `io::copy` on an
IO stream. Rather than include extra external calls once the copy is
completed, the progress is also kept inside the `ProgressBar` struct.
The last call to `write()` will cause a newline to be printed to the
`stdout` stream and then the stream will be flushed before proceeding.

It may be possible to add further smarts to the upstream library, but
this fix resolves the rendering issues in the meantime. Additional
changes to the command line's UI behavior are coming shortly which may
further tweak this implementation.

![gif-keyboard-18445042107409089205](https://cloud.githubusercontent.com/assets/261548/17418241/b8881590-5a54-11e6-90e8-69dfd7597683.gif)
