### PR TITLE
Native Docker for Mac is now released.

### DIFF
--- a/www/source/docs/get-habitat.html.md
+++ b/www/source/docs/get-habitat.html.md
@@ -9,12 +9,12 @@ To get started with Habitat, you only need to download the `hab` command-line in
 
 ### For Mac
 To start using Habitat on Mac OS X, download the following binary.  
-If you intend to build Habitat packages on your Mac, you will also need to install the [Docker Toolbox](https://www.docker.com/products/docker-toolbox).  
+If you intend to build Habitat packages on your Mac, you will also need to install [Docker for Mac](https://www.docker.com/products/docker#/mac).  
 _Habitat for Mac requires a 64-bit processor running Mac OS X version 10.9+._
 
 
 <a class="button" href="https://api.bintray.com/content/habitat/stable/darwin/x86_64/hab-%24latest-x86_64-darwin.zip?bt_package=hab-x86_64-darwin">Download Habitat for Mac OS X</a>
-<a class="button secondary" href="https://www.docker.com/products/docker-toolbox">Download Docker Toolbox</a>
+<a class="button secondary" href="https://www.docker.com/products/docker#/mac">Download Docker for Mac</a>
 
 ### For Linux
 To start using Habitat on Linux, download the following binary.  


### PR DESCRIPTION
We should point people at it rather than the Docker Toolbox (the landing page at Docker will redirect them if they have an older Mac and cannot use Docker for Mac).