### PR TITLE
Use a consistent template for Rust component Plans.

### DIFF
--- a/components/builder-api/habitat/plan.sh
+++ b/components/builder-api/habitat/plan.sh
@@ -2,15 +2,43 @@ pkg_name=hab-builder-api
 pkg_origin=core
 pkg_version=0.8.0
 pkg_maintainer="Jamie Winsor <reset@chef.io>"
-pkg_license=('apachev2')
+pkg_license=('Apache-2.0')
 pkg_source=nosuchfile.tar.gz
 pkg_bin_dirs=(bin)
 pkg_deps=(core/glibc core/openssl core/coreutils core/gcc-libs core/zeromq core/libsodium core/libarchive)
-pkg_build_deps=(core/protobuf core/protobuf-rust core/coreutils core/cacerts core/cargo-nightly
-                core/rust core/gcc core/pkg-config core/node core/phantomjs)
+pkg_build_deps=(core/protobuf core/protobuf-rust core/coreutils core/cacerts core/cargo-nightly core/rust core/gcc core/pkg-config core/node core/phantomjs)
 pkg_expose=(9636)
-srv_bin="bldr-api"
-pkg_svc_run="bin/$srv_bin start -c ${pkg_svc_path}/config.toml"
+bin="bldr-api"
+pkg_svc_run="bin/$bin start -c ${pkg_svc_path}/config.toml"
+
+do_prepare() {
+  rm -Rdf $HAB_CACHE_SRC_PATH/ui-$pkg_name-$pkg_version
+  cp -ra $PLAN_CONTEXT/../../builder-web $HAB_CACHE_SRC_PATH/ui-$pkg_name-$pkg_version
+  rm -Rdf $HAB_CACHE_SRC_PATH/ui-$pkg_name-$pkg_version/node_modules
+
+  # Can be either `--release` or `--debug` to determine cargo build strategy
+  build_type="--debug"
+  build_line "Building artifacts with \`${build_type#--}' mode"
+
+  export rustc_target="x86_64-unknown-linux-gnu"
+  build_line "Setting rustc_target=$rustc_target"
+
+  # Used by the `build.rs` program to set the version of the binaries
+  export PLAN_VERSION="${pkg_version}/${pkg_release}"
+  build_line "Setting PLAN_VERSION=$PLAN_VERSION"
+
+  # Used by Cargo to use a pristine, isolated directory for all compilation
+  export CARGO_TARGET_DIR="$HAB_CACHE_SRC_PATH/$pkg_dirname"
+  build_line "Setting CARGO_TARGET_DIR=$CARGO_TARGET_DIR"
+
+  export LIBARCHIVE_LIB_DIR=$(pkg_path_for libarchive)/lib
+  export LIBARCHIVE_INCLUDE_DIR=$(pkg_path_for libarchive)/include
+  export OPENSSL_LIB_DIR=$(pkg_path_for openssl)/lib
+  export OPENSSL_INCLUDE_DIR=$(pkg_path_for openssl)/include
+  export PROTOBUF_PREFIX=$(pkg_path_for protobuf)
+  export SODIUM_LIB_DIR=$(pkg_path_for libsodium)/lib
+  export LIBZMQ_PREFIX=$(pkg_path_for zeromq)
+}
 
 do_build() {
   pushd $HAB_CACHE_SRC_PATH/ui-$pkg_name-$pkg_version > /dev/null
@@ -24,38 +52,25 @@ do_build() {
   npm run dist
   popd > /dev/null
 
-  # Used by the `build.rs` program to set the version of the binaries
-  export PLAN_VERSION="${pkg_version}/${pkg_release}"
-  build_line "Setting PLAN_VERSION=$PLAN_VERSION"
-
-  # Used by Cargo to fetch registries/crates/etc.
-  export SSL_CERT_FILE=$(pkg_path_for cacerts)/ssl/cert.pem
-  build_line "Setting SSL_CERT_FILE=$SSL_CERT_FILE"
-
-  export rustc_target="debug"
-  build_line "Setting rustc_target=$rustc_target"
-
-  export LIBARCHIVE_LIB_DIR=$(pkg_path_for libarchive)/lib
-  export LIBARCHIVE_INCLUDE_DIR=$(pkg_path_for libarchive)/include
-  export OPENSSL_LIB_DIR=$(pkg_path_for openssl)/lib
-  export OPENSSL_INCLUDE_DIR=$(pkg_path_for openssl)/include
-  export PROTOBUF_PREFIX=$(pkg_path_for protobuf)
-  export SODIUM_LIB_DIR=$(pkg_path_for libsodium)/lib
-  export LIBZMQ_PREFIX=$(pkg_path_for zeromq)
-
   pushd $PLAN_CONTEXT/.. > /dev/null
-  cargo clean --target=$rustc_target --verbose
-  cargo build \
-    -j $(nproc) \
-    --verbose
+  cargo build ${build_type#--debug} --target=$rustc_target --verbose
   popd > /dev/null
 }
 
 do_install() {
   cp -vR $HAB_CACHE_SRC_PATH/ui-$pkg_name-$pkg_version/dist $pkg_prefix/static
-  install -v -D $PLAN_CONTEXT/../../../target/$rustc_target/$srv_bin $pkg_prefix/bin/$srv_bin
+
+  install -v -D $CARGO_TARGET_DIR/$rustc_target/${build_type#--}/$bin \
+    $pkg_prefix/bin/$bin
 }
 
+do_strip() {
+  if [[ "$build_type" != "--debug" ]]; then
+    do_default_strip
+  fi
+}
+
+# Turn the remaining default phases into no-ops
 do_download() {
   return 0
 }
@@ -66,10 +81,4 @@ do_verify() {
 
 do_unpack() {
   return 0
-}
-
-do_prepare() {
-  rm -Rdf $HAB_CACHE_SRC_PATH/ui-$pkg_name-$pkg_version
-  cp -ra $PLAN_CONTEXT/../../builder-web $HAB_CACHE_SRC_PATH/ui-$pkg_name-$pkg_version
-  rm -Rdf $HAB_CACHE_SRC_PATH/ui-$pkg_name-$pkg_version/node_modules
 }

--- a/components/builder-router/habitat/plan.sh
+++ b/components/builder-router/habitat/plan.sh
@@ -2,27 +2,30 @@ pkg_name=hab-builder-router
 pkg_origin=core
 pkg_version=0.8.0
 pkg_maintainer="Jamie Winsor <reset@chef.io>"
-pkg_license=('apachev2')
+pkg_license=('Apache-2.0')
 pkg_source=nosuchfile.tar.gz
 pkg_bin_dirs=(bin)
 pkg_deps=(core/glibc core/openssl core/gcc-libs core/zeromq core/libsodium core/libarchive)
-pkg_build_deps=(core/protobuf core/protobuf-rust core/coreutils core/cacerts core/cargo-nightly
-                core/rust core/gcc core/pkg-config)
+pkg_build_deps=(core/protobuf core/protobuf-rust core/coreutils core/cacerts core/cargo-nightly core/rust core/gcc core/pkg-config)
 pkg_expose=(5562 5563)
-srv_bin="bldr-router"
-pkg_svc_run="bin/$srv_bin start -c ${pkg_svc_path}/config.toml"
+bin="bldr-router"
+pkg_svc_run="bin/$bin start -c ${pkg_svc_path}/config.toml"
 
-do_build() {
+do_prepare() {
+  # Can be either `--release` or `--debug` to determine cargo build strategy
+  build_type="--debug"
+  build_line "Building artifacts with \`${build_type#--}' mode"
+
+  export rustc_target="x86_64-unknown-linux-gnu"
+  build_line "Setting rustc_target=$rustc_target"
+
   # Used by the `build.rs` program to set the version of the binaries
   export PLAN_VERSION="${pkg_version}/${pkg_release}"
   build_line "Setting PLAN_VERSION=$PLAN_VERSION"
 
-  # Used by Cargo to fetch registries/crates/etc.
-  export SSL_CERT_FILE=$(pkg_path_for cacerts)/ssl/cert.pem
-  build_line "Setting SSL_CERT_FILE=$SSL_CERT_FILE"
-
-  export rustc_target="debug"
-  build_line "Setting rustc_target=$rustc_target"
+  # Used by Cargo to use a pristine, isolated directory for all compilation
+  export CARGO_TARGET_DIR="$HAB_CACHE_SRC_PATH/$pkg_dirname"
+  build_line "Setting CARGO_TARGET_DIR=$CARGO_TARGET_DIR"
 
   export LIBARCHIVE_LIB_DIR=$(pkg_path_for libarchive)/lib
   export LIBARCHIVE_INCLUDE_DIR=$(pkg_path_for libarchive)/include
@@ -31,19 +34,26 @@ do_build() {
   export PROTOBUF_PREFIX=$(pkg_path_for protobuf)
   export SODIUM_LIB_DIR=$(pkg_path_for libsodium)/lib
   export LIBZMQ_PREFIX=$(pkg_path_for zeromq)
+}
 
+do_build() {
   pushd $PLAN_CONTEXT/.. > /dev/null
-  cargo clean --target=$rustc_target --verbose
-  cargo build \
-    -j $(nproc) \
-    --verbose
+  cargo build ${build_type#--debug} --target=$rustc_target --verbose
   popd > /dev/null
 }
 
 do_install() {
-  install -v -D $PLAN_CONTEXT/../../../target/$rustc_target/$srv_bin $pkg_prefix/bin/$srv_bin
+  install -v -D $CARGO_TARGET_DIR/$rustc_target/${build_type#--}/$bin \
+    $pkg_prefix/bin/$bin
 }
 
+do_strip() {
+  if [[ "$build_type" != "--debug" ]]; then
+    do_default_strip
+  fi
+}
+
+# Turn the remaining default phases into no-ops
 do_download() {
   return 0
 }
@@ -53,9 +63,5 @@ do_verify() {
 }
 
 do_unpack() {
-  return 0
-}
-
-do_prepare() {
   return 0
 }

--- a/components/builder-sessionsrv/habitat/plan.sh
+++ b/components/builder-sessionsrv/habitat/plan.sh
@@ -2,26 +2,29 @@ pkg_name=hab-builder-sessionsrv
 pkg_origin=core
 pkg_version=0.8.0
 pkg_maintainer="Jamie Winsor <reset@chef.io>"
-pkg_license=('apachev2')
+pkg_license=('Apache-2.0')
 pkg_source=nosuchfile.tar.gz
 pkg_bin_dirs=(bin)
 pkg_deps=(core/glibc core/openssl core/gcc-libs core/zeromq core/libsodium core/libarchive)
-pkg_build_deps=(core/protobuf core/protobuf-rust core/coreutils core/cacerts core/cargo-nightly
-                core/rust core/gcc core/pkg-config)
-srv_bin="bldr-session-srv"
-pkg_svc_run="bin/$srv_bin start -c ${pkg_svc_path}/config.toml"
+pkg_build_deps=(core/protobuf core/protobuf-rust core/coreutils core/cacerts core/cargo-nightly core/rust core/gcc core/pkg-config)
+bin="bldr-session-srv"
+pkg_svc_run="bin/$bin start -c ${pkg_svc_path}/config.toml"
 
-do_build() {
+do_prepare() {
+  # Can be either `--release` or `--debug` to determine cargo build strategy
+  build_type="--debug"
+  build_line "Building artifacts with \`${build_type#--}' mode"
+
+  export rustc_target="x86_64-unknown-linux-gnu"
+  build_line "Setting rustc_target=$rustc_target"
+
   # Used by the `build.rs` program to set the version of the binaries
   export PLAN_VERSION="${pkg_version}/${pkg_release}"
   build_line "Setting PLAN_VERSION=$PLAN_VERSION"
 
-  # Used by Cargo to fetch registries/crates/etc.
-  export SSL_CERT_FILE=$(pkg_path_for cacerts)/ssl/cert.pem
-  build_line "Setting SSL_CERT_FILE=$SSL_CERT_FILE"
-
-  export rustc_target="debug"
-  build_line "Setting rustc_target=$rustc_target"
+  # Used by Cargo to use a pristine, isolated directory for all compilation
+  export CARGO_TARGET_DIR="$HAB_CACHE_SRC_PATH/$pkg_dirname"
+  build_line "Setting CARGO_TARGET_DIR=$CARGO_TARGET_DIR"
 
   export LIBARCHIVE_LIB_DIR=$(pkg_path_for libarchive)/lib
   export LIBARCHIVE_INCLUDE_DIR=$(pkg_path_for libarchive)/include
@@ -30,19 +33,26 @@ do_build() {
   export PROTOBUF_PREFIX=$(pkg_path_for protobuf)
   export SODIUM_LIB_DIR=$(pkg_path_for libsodium)/lib
   export LIBZMQ_PREFIX=$(pkg_path_for zeromq)
+}
 
+do_build() {
   pushd $PLAN_CONTEXT/.. > /dev/null
-  cargo clean --target=$rustc_target --verbose
-  cargo build \
-    -j $(nproc) \
-    --verbose
+  cargo build ${build_type#--debug} --target=$rustc_target --verbose
   popd > /dev/null
 }
 
 do_install() {
-  install -v -D $PLAN_CONTEXT/../../../target/$rustc_target/$srv_bin $pkg_prefix/bin/$srv_bin
+  install -v -D $CARGO_TARGET_DIR/$rustc_target/${build_type#--}/$bin \
+    $pkg_prefix/bin/$bin
 }
 
+do_strip() {
+  if [[ "$build_type" != "--debug" ]]; then
+    do_default_strip
+  fi
+}
+
+# Turn the remaining default phases into no-ops
 do_download() {
   return 0
 }
@@ -52,9 +62,5 @@ do_verify() {
 }
 
 do_unpack() {
-  return 0
-}
-
-do_prepare() {
   return 0
 }

--- a/components/builder-vault/habitat/plan.sh
+++ b/components/builder-vault/habitat/plan.sh
@@ -2,26 +2,29 @@ pkg_name=hab-builder-vault
 pkg_origin=core
 pkg_version=0.8.0
 pkg_maintainer="Jamie Winsor <reset@chef.io>"
-pkg_license=('apachev2')
+pkg_license=('Apache-2.0')
 pkg_source=nosuchfile.tar.gz
 pkg_bin_dirs=(bin)
 pkg_deps=(core/glibc core/openssl core/gcc-libs core/zeromq core/libsodium core/libarchive)
-pkg_build_deps=(core/protobuf core/protobuf-rust core/coreutils core/cacerts core/cargo-nightly
-                core/rust core/gcc core/pkg-config)
-srv_bin="bldr-vault"
-pkg_svc_run="bin/$srv_bin start -c ${pkg_svc_path}/config.toml"
+pkg_build_deps=(core/protobuf core/protobuf-rust core/coreutils core/cacerts core/cargo-nightly core/rust core/gcc core/pkg-config)
+bin="bldr-vault"
+pkg_svc_run="bin/$bin start -c ${pkg_svc_path}/config.toml"
 
-do_build() {
+do_prepare() {
+  # Can be either `--release` or `--debug` to determine cargo build strategy
+  build_type="--debug"
+  build_line "Building artifacts with \`${build_type#--}' mode"
+
+  export rustc_target="x86_64-unknown-linux-gnu"
+  build_line "Setting rustc_target=$rustc_target"
+
   # Used by the `build.rs` program to set the version of the binaries
   export PLAN_VERSION="${pkg_version}/${pkg_release}"
   build_line "Setting PLAN_VERSION=$PLAN_VERSION"
 
-  # Used by Cargo to fetch registries/crates/etc.
-  export SSL_CERT_FILE=$(pkg_path_for cacerts)/ssl/cert.pem
-  build_line "Setting SSL_CERT_FILE=$SSL_CERT_FILE"
-
-  export rustc_target="debug"
-  build_line "Setting rustc_target=$rustc_target"
+  # Used by Cargo to use a pristine, isolated directory for all compilation
+  export CARGO_TARGET_DIR="$HAB_CACHE_SRC_PATH/$pkg_dirname"
+  build_line "Setting CARGO_TARGET_DIR=$CARGO_TARGET_DIR"
 
   export LIBARCHIVE_LIB_DIR=$(pkg_path_for libarchive)/lib
   export LIBARCHIVE_INCLUDE_DIR=$(pkg_path_for libarchive)/include
@@ -30,19 +33,26 @@ do_build() {
   export PROTOBUF_PREFIX=$(pkg_path_for protobuf)
   export SODIUM_LIB_DIR=$(pkg_path_for libsodium)/lib
   export LIBZMQ_PREFIX=$(pkg_path_for zeromq)
+}
 
+do_build() {
   pushd $PLAN_CONTEXT/.. > /dev/null
-  cargo clean --target=$rustc_target --verbose
-  cargo build \
-    -j $(nproc) \
-    --verbose
+  cargo build ${build_type#--debug} --target=$rustc_target --verbose
   popd > /dev/null
 }
 
 do_install() {
-  install -v -D $PLAN_CONTEXT/../../../target/$rustc_target/$srv_bin $pkg_prefix/bin/$srv_bin
+  install -v -D $CARGO_TARGET_DIR/$rustc_target/${build_type#--}/$bin \
+    $pkg_prefix/bin/$bin
 }
 
+do_strip() {
+  if [[ "$build_type" != "--debug" ]]; then
+    do_default_strip
+  fi
+}
+
+# Turn the remaining default phases into no-ops
 do_download() {
   return 0
 }
@@ -52,9 +62,5 @@ do_verify() {
 }
 
 do_unpack() {
-  return 0
-}
-
-do_prepare() {
   return 0
 }

--- a/components/builder-worker/habitat/plan.sh
+++ b/components/builder-worker/habitat/plan.sh
@@ -2,26 +2,29 @@ pkg_name=hab-builder-worker
 pkg_origin=core
 pkg_version=0.8.0
 pkg_maintainer="Jamie Winsor <reset@chef.io>"
-pkg_license=('apachev2')
+pkg_license=('Apache-2.0')
 pkg_source=nosuchfile.tar.gz
 pkg_bin_dirs=(bin)
 pkg_deps=(core/glibc core/openssl core/gcc-libs core/zeromq core/libsodium core/libarchive)
-pkg_build_deps=(core/protobuf core/protobuf-rust core/coreutils core/cacerts core/cargo-nightly
-                core/rust core/gcc core/pkg-config)
-srv_bin="bldr-worker"
-pkg_svc_run="bin/$srv_bin start -c ${pkg_svc_path}/config.toml"
+pkg_build_deps=(core/protobuf core/protobuf-rust core/coreutils core/cacerts core/cargo-nightly core/rust core/gcc core/pkg-config)
+bin="bldr-worker"
+pkg_svc_run="bin/$bin start -c ${pkg_svc_path}/config.toml"
 
-do_build() {
+do_prepare() {
+  # Can be either `--release` or `--debug` to determine cargo build strategy
+  build_type="--debug"
+  build_line "Building artifacts with \`${build_type#--}' mode"
+
+  export rustc_target="x86_64-unknown-linux-gnu"
+  build_line "Setting rustc_target=$rustc_target"
+
   # Used by the `build.rs` program to set the version of the binaries
   export PLAN_VERSION="${pkg_version}/${pkg_release}"
   build_line "Setting PLAN_VERSION=$PLAN_VERSION"
 
-  # Used by Cargo to fetch registries/crates/etc.
-  export SSL_CERT_FILE=$(pkg_path_for cacerts)/ssl/cert.pem
-  build_line "Setting SSL_CERT_FILE=$SSL_CERT_FILE"
-
-  export rustc_target="debug"
-  build_line "Setting rustc_target=$rustc_target"
+  # Used by Cargo to use a pristine, isolated directory for all compilation
+  export CARGO_TARGET_DIR="$HAB_CACHE_SRC_PATH/$pkg_dirname"
+  build_line "Setting CARGO_TARGET_DIR=$CARGO_TARGET_DIR"
 
   export LIBARCHIVE_LIB_DIR=$(pkg_path_for libarchive)/lib
   export LIBARCHIVE_INCLUDE_DIR=$(pkg_path_for libarchive)/include
@@ -30,19 +33,26 @@ do_build() {
   export PROTOBUF_PREFIX=$(pkg_path_for protobuf)
   export SODIUM_LIB_DIR=$(pkg_path_for libsodium)/lib
   export LIBZMQ_PREFIX=$(pkg_path_for zeromq)
+}
 
+do_build() {
   pushd $PLAN_CONTEXT/.. > /dev/null
-  cargo clean --target=$rustc_target --verbose
-  cargo build \
-    -j $(nproc) \
-    --verbose
+  cargo build ${build_type#--debug} --target=$rustc_target --verbose
   popd > /dev/null
 }
 
 do_install() {
-  install -v -D $PLAN_CONTEXT/../../../target/$rustc_target/$srv_bin $pkg_prefix/bin/$srv_bin
+  install -v -D $CARGO_TARGET_DIR/$rustc_target/${build_type#--}/$bin \
+    $pkg_prefix/bin/$bin
 }
 
+do_strip() {
+  if [[ "$build_type" != "--debug" ]]; then
+    do_default_strip
+  fi
+}
+
+# Turn the remaining default phases into no-ops
 do_download() {
   return 0
 }
@@ -52,9 +62,5 @@ do_verify() {
 }
 
 do_unpack() {
-  return 0
-}
-
-do_prepare() {
   return 0
 }

--- a/components/depot/habitat/plan.sh
+++ b/components/depot/habitat/plan.sh
@@ -2,25 +2,29 @@ pkg_name=hab-depot
 pkg_origin=core
 pkg_version=0.8.0
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_license=('apachev2')
+pkg_license=('Apache-2.0')
 pkg_source=nosuchfile.tar.gz
 pkg_deps=(core/glibc core/gcc-libs core/libarchive core/libsodium core/openssl core/zeromq)
 pkg_build_deps=(core/coreutils core/cacerts core/cargo-nightly core/rust core/gcc core/pkg-config)
 pkg_bin_dirs=(bin)
-srv_bin="hab-depot"
-pkg_svc_run="bin/$srv_bin start -c ${pkg_svc_path}/config.toml"
+bin="$pkg_name"
+pkg_svc_run="bin/$bin start -c ${pkg_svc_path}/config.toml"
 
 do_prepare() {
+  # Can be either `--release` or `--debug` to determine cargo build strategy
+  build_type="--release"
+  build_line "Building artifacts with \`${build_type#--}' mode"
+
+  export rustc_target="x86_64-unknown-linux-gnu"
+  build_line "Setting rustc_target=$rustc_target"
+
   # Used by the `build.rs` program to set the version of the binaries
   export PLAN_VERSION="${pkg_version}/${pkg_release}"
   build_line "Setting PLAN_VERSION=$PLAN_VERSION"
 
-  # Used by Cargo to fetch registries/crates/etc.
-  export SSL_CERT_FILE=$(pkg_path_for cacerts)/ssl/cert.pem
-  build_line "Setting SSL_CERT_FILE=$SSL_CERT_FILE"
-
-  export rustc_target="x86_64-unknown-linux-gnu"
-  build_line "Setting rustc_target=$rustc_target"
+  # Used by Cargo to use a pristine, isolated directory for all compilation
+  export CARGO_TARGET_DIR="$HAB_CACHE_SRC_PATH/$pkg_dirname"
+  build_line "Setting CARGO_TARGET_DIR=$CARGO_TARGET_DIR"
 
   export LIBARCHIVE_LIB_DIR=$(pkg_path_for libarchive)/lib
   export LIBARCHIVE_INCLUDE_DIR=$(pkg_path_for libarchive)/include
@@ -31,23 +35,23 @@ do_prepare() {
 }
 
 do_build() {
-  pushd $PLAN_CONTEXT > /dev/null
-  cargo clean --target=$rustc_target --verbose
-  cargo build \
-    -j $(nproc) \
-    --target=$rustc_target \
-    --verbose
+  pushd $PLAN_CONTEXT/.. > /dev/null
+  cargo build ${build_type#--debug} --target=$rustc_target --verbose
   popd > /dev/null
 }
 
 do_install() {
-  install -v -D $PLAN_CONTEXT/../../../target/$rustc_target/$srv_bin $pkg_prefix/bin/$srv_bin
+  install -v -D $CARGO_TARGET_DIR/$rustc_target/${build_type#--}/$bin \
+    $pkg_prefix/bin/$bin
 }
 
 do_strip() {
-  return 0
+  if [[ "$build_type" != "--debug" ]]; then
+    do_default_strip
+  fi
 }
 
+# Turn the remaining default phases into no-ops
 do_download() {
   return 0
 }

--- a/components/director/habitat/plan.sh
+++ b/components/director/habitat/plan.sh
@@ -2,26 +2,30 @@ pkg_name=hab-director
 pkg_origin=core
 pkg_version=0.8.0
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_license=('apachev2')
+pkg_license=('Apache-2.0')
 pkg_source=nosuchfile.tar.gz
 pkg_deps=(core/glibc core/gcc-libs core/libarchive core/libsodium core/openssl)
 pkg_build_deps=(core/coreutils core/cacerts core/cargo-nightly core/rust core/gcc)
 pkg_bin_dirs=(bin)
-srv_bin="hab-director"
-pkg_svc_run="bin/$srv_bin start -c ${pkg_svc_path}/config.toml"
+bin="hab-director"
+pkg_svc_run="bin/$bin start -c ${pkg_svc_path}/config.toml"
 pkg_svc_user=root
 
 do_prepare() {
+  # Can be either `--release` or `--debug` to determine cargo build strategy
+  build_type="--release"
+  build_line "Building artifacts with \`${build_type#--}' mode"
+
+  export rustc_target="x86_64-unknown-linux-gnu"
+  build_line "Setting rustc_target=$rustc_target"
+
   # Used by the `build.rs` program to set the version of the binaries
   export PLAN_VERSION="${pkg_version}/${pkg_release}"
   build_line "Setting PLAN_VERSION=$PLAN_VERSION"
 
-  # Used by Cargo to fetch registries/crates/etc.
-  export SSL_CERT_FILE=$(pkg_path_for cacerts)/ssl/cert.pem
-  build_line "Setting SSL_CERT_FILE=$SSL_CERT_FILE"
-
-  export rustc_target="x86_64-unknown-linux-gnu"
-  build_line "Setting rustc_target=$rustc_target"
+  # Used by Cargo to use a pristine, isolated directory for all compilation
+  export CARGO_TARGET_DIR="$HAB_CACHE_SRC_PATH/$pkg_dirname"
+  build_line "Setting CARGO_TARGET_DIR=$CARGO_TARGET_DIR"
 
   export LIBARCHIVE_LIB_DIR=$(pkg_path_for libarchive)/lib
   export LIBARCHIVE_INCLUDE_DIR=$(pkg_path_for libarchive)/include
@@ -32,22 +36,22 @@ do_prepare() {
 
 do_build() {
   pushd $PLAN_CONTEXT > /dev/null
-  cargo clean --target=$rustc_target --verbose
-  cargo build \
-    -j $(nproc) \
-    --target=$rustc_target \
-    --verbose
+  cargo build ${build_type#--debug} --target=$rustc_target --verbose
   popd > /dev/null
 }
 
 do_install() {
-  install -v -D $PLAN_CONTEXT/../../../target/$rustc_target/$srv_bin $pkg_prefix/bin/$srv_bin
+  install -v -D $CARGO_TARGET_DIR/$rustc_target/${build_type#--}/$bin \
+    $pkg_prefix/bin/$bin
 }
 
 do_strip() {
-  return 0
+  if [[ "$build_type" != "--debug" ]]; then
+    do_default_strip
+  fi
 }
 
+# Turn the remaining default phases into no-ops
 do_download() {
   return 0
 }

--- a/components/hab/dynamic/plan.sh
+++ b/components/hab/dynamic/plan.sh
@@ -6,7 +6,7 @@ pkg_deps=(
   core/glibc core/zlib core/xz core/bzip2 core/libarchive
   core/openssl core/libsodium core/gcc-libs
 )
-pkg_build_deps=(core/coreutils core/cacerts core/rust core/gcc)
+pkg_build_deps=(core/coreutils core/cargo-nightly core/rust core/gcc)
 pkg_bin_dirs=(bin)
 
 do_begin() {

--- a/components/sup/plan.sh
+++ b/components/sup/plan.sh
@@ -1,5 +1,5 @@
 pkg_name=hab-sup
-pkg_distname=$pkg_name
+_pkg_distname=$pkg_name
 pkg_origin=core
 pkg_version=0.8.0
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
@@ -9,27 +9,25 @@ pkg_deps=(
   core/busybox-static
   core/glibc core/gcc-libs core/libarchive core/libsodium core/openssl
 )
-pkg_build_deps=(core/coreutils core/cacerts core/rust core/gcc)
+pkg_build_deps=(core/coreutils core/cacerts core/cargo-nightly core/rust core/gcc)
 pkg_bin_dirs=(bin)
 
-program=$pkg_name
+bin=$_pkg_distname
 
 _common_prepare() {
   do_default_prepare
+
+  # Can be either `--release` or `--debug` to determine cargo build strategy
+  build_type="--release"
+  build_line "Building artifacts with \`${build_type#--}' mode"
 
   # Used by the `build.rs` program to set the version of the binaries
   export PLAN_VERSION="${pkg_version}/${pkg_release}"
   build_line "Setting PLAN_VERSION=$PLAN_VERSION"
 
-  # Used by Cargo to fetch registries/crates/etc.
-  export SSL_CERT_FILE=$(pkg_path_for cacerts)/ssl/cert.pem
-  build_line "Setting SSL_CERT_FILE=$SSL_CERT_FILE"
-
-  # Used to find libgcc_s.so.1 when compiling `build.rs` in dependencies. Since
-  # this used only at build time, we will use the version found in the gcc
-  # package proper--it won't find its way into the final binaries.
-  export LD_LIBRARY_PATH=$(pkg_path_for gcc)/lib
-  build_line "Setting LD_LIBRARY_PATH=$LD_LIBRARY_PATH"
+  # Used by Cargo to use a pristine, isolated directory for all compilation
+  export CARGO_TARGET_DIR="$HAB_CACHE_SRC_PATH/$pkg_dirname"
+  build_line "Setting CARGO_TARGET_DIR=$CARGO_TARGET_DIR"
 }
 
 do_prepare() {
@@ -47,22 +45,19 @@ do_prepare() {
 
 do_build() {
   pushd $PLAN_CONTEXT > /dev/null
-  cargo clean --target=$rustc_target --verbose
-  cargo build \
-    -j $(nproc) \
-    --target=$rustc_target \
-    --release \
-    --verbose
+  cargo build ${build_type#--debug} --target=$rustc_target --verbose
   popd > /dev/null
 }
 
 do_install() {
-  install -v -D $PLAN_CONTEXT/target/$rustc_target/release/$program \
-    $pkg_prefix/bin/$program
+  install -v -D $CARGO_TARGET_DIR/$rustc_target/${build_type#--}/$bin \
+    $pkg_prefix/bin/$bin
 }
 
 do_strip() {
-  strip $pkg_prefix/bin/$program
+  if [[ "$build_type" != "--debug" ]]; then
+    do_default_strip
+  fi
 }
 
 # Turn the remaining default phases into no-ops

--- a/components/sup/static/plan.sh
+++ b/components/sup/static/plan.sh
@@ -6,7 +6,7 @@ pkg_deps=(core/busybox-static)
 pkg_build_deps=(
   core/musl core/zlib-musl core/xz-musl core/bzip2-musl core/libarchive-musl
   core/openssl-musl core/libsodium-musl
-  core/coreutils core/cacerts core/rust core/gcc
+  core/coreutils core/cacerts core/cargo-nightly core/rust core/gcc
 )
 
 do_begin() {
@@ -34,4 +34,10 @@ do_prepare() {
   export OPENSSL_STATIC=true
   export SODIUM_LIB_DIR=$(pkg_path_for libsodium-musl)/lib
   export SODIUM_STATIC=true
+
+  # Used to find libgcc_s.so.1 when compiling `build.rs` in dependencies. Since
+  # this used only at build time, we will use the version found in the gcc
+  # package proper--it won't find its way into the final binaries.
+  export LD_LIBRARY_PATH=$(pkg_path_for gcc)/lib
+  build_line "Setting LD_LIBRARY_PATH=$LD_LIBRARY_PATH"
 }


### PR DESCRIPTION
Note that the Plan updates rely on published packages from habitat-sh/core-plans#132