### PR TITLE
[hab] Add an optional arg to install.sh to specify a version of hab.

### DIFF
--- a/components/hab/install.sh
+++ b/components/hab/install.sh
@@ -50,6 +50,9 @@ sha256sum -c "$sha_file"
 zcat "$archive" | tar x -C "$workdir"
 # Directory containing the binary
 archive_dir="$(echo $archive | sed 's/.tar.gz$//')"
-# Install latest hab release using the extracted version and add/update symlink
-"$archive_dir/hab" install core/hab
-"$archive_dir/hab" pkg binlink core/hab hab
+# Install the latest release unless a specific version was provided
+ident="core/hab"
+if [ -n "${1:-}" ]; then ident="$ident/$1"; fi
+# Install hab release using the extracted version and add/update symlink
+"$archive_dir/hab" install "$ident"
+"$archive_dir/hab" pkg binlink "$ident" hab


### PR DESCRIPTION
This is an optional/opt-in change to the `install.sh` script which helps
consumers specify a version (i.e. `install.sh 0.8.0`) or a release (i.e.
`install.sh 0.8.0/20160729175817`) to be installed. Note that the
version installed will originate from the Depot and not the Bintray
repo--the `hab` provided by the Bintray repo is only used to install the
target version of `hab`. The more you know...

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>