### PR TITLE
Document use of exec in run hooks

### DIFF
--- a/www/source/docs/reference/plan-syntax.html.md
+++ b/www/source/docs/reference/plan-syntax.html.md
@@ -345,6 +345,29 @@ run
   - When a package is updated, after the `init` hook has been called.
   - When the package config changes, after the `init` hook has been called, but before a `reconfigure` hook is called.
 
+  You can use this hook in place of `$pkg_svc_run` when you need more complex behavior such as setting environment variables or command options that are based on dynamic configuration.
+
+  Services run using this hook should do two things:
+
+  - Redirect stderr to stdout (e.g. with `exec 2>&1` at the start of the hook)
+  - Call the command to execute with `exec <command> <options>` rather than running the command directly. This ensures the command is executed in the same process and that the service will restart correctly on configuration changes.
+
+  A run hook can use the following as a template:
+
+  ~~~ bash
+  #!/bin/sh
+
+  # redirect stderr
+  exec 2>&1
+
+  # Set some environment variables
+  export MY_ENVIRONMENT_VARIABLE=1
+  export MY_OTHER_ENVIRONMENT_VARIABLE=2
+
+  # Run the command
+  exec my_command --option {{cfg.option}} --option2 {{cfg.option2}}
+  ~~~
+
 ***
 
 ## Runtime configuration settings

--- a/www/source/docs/reference/plan-syntax.html.md
+++ b/www/source/docs/reference/plan-syntax.html.md
@@ -135,7 +135,7 @@ pkg_svc_run
   pkg_svc_run="bin/haproxy -f $pkg_svc_config_path/haproxy.conf"
   ~~~
 
-> Note: You should use a [run hook](#plan-hooks) instead if you have complex start up behavior.
+> Note: You should use a [run hook](#hooks) instead if you have complex start up behavior.
 
 pkg_expose
 : Optional. An array of ports this service exposes when you create a Docker image from your package.
@@ -146,7 +146,7 @@ pkg_expose
 
 
 pkg_interpreters
-: Optional. An array of interpreters used in [shebang](https://en.wikipedia.org/wiki/Shebang_(Unix)) lines for scripts. Specify the subdirectory where the binary is relative to the package, for example, `bin/bash` or `libexec/neverland`, since binaries can be located in directories besides `bin`. This list of interpreters will be written to the metadata INTERPRETERS file, located inside a package, with their fully-qualified path.  Then these can be used with the fix_interpreter function. For more information on declaring shebangs in Habitat, see [Plan hooks](#plan-hooks), and for more information on the fix_interpreter function, see [Plan utility functions](#plan-utility-functions).
+: Optional. An array of interpreters used in [shebang](https://en.wikipedia.org/wiki/Shebang_(Unix)) lines for scripts. Specify the subdirectory where the binary is relative to the package, for example, `bin/bash` or `libexec/neverland`, since binaries can be located in directories besides `bin`. This list of interpreters will be written to the metadata INTERPRETERS file, located inside a package, with their fully-qualified path.  Then these can be used with the fix_interpreter function. For more information on declaring shebangs in Habitat, see [Plan hooks](#hooks), and for more information on the fix_interpreter function, see [Plan utility functions](#plan-utility-functions).
 
   ~~~
   pkg_interpreters=(bin/bash)


### PR DESCRIPTION
This change documents how you need to use exec in run hooks to avoid bad behavior, as well as providing a simple example and suggestions on when you would want to use a run hook instead of `$pkg_svc_run`. Let me know if the reasons to use a run hook are incorrect and you could do those using `$pkg_svc_run` instead.

I also fixed a couple of links pointing to the hooks section.

This fixes #989 