### PR TITLE
Quote no_proxy correctly

### DIFF
--- a/components/studio/bin/hab-studio.sh
+++ b/components/studio/bin/hab-studio.sh
@@ -870,7 +870,12 @@ chroot_env() {
     env="$env https_proxy=$https_proxy"
   fi
   if [ -n "${no_proxy:-}" ]; then
-    env="$env no_proxy=$no_proxy"
+    # If you pass whitespace here, bash will loose its mind when we do expansion
+    # in the exec later on. To spare you, and me, and everyone else, we go ahead
+    # and take care of that little whitespace problem for you.
+    #
+    # Thanks, Docker, for passing unneccessary spaces. You're a peach.
+    env="$env no_proxy=$(echo $no_proxy | $bb sed 's/, /,/g')"
   fi
 
   echo "$env"


### PR DESCRIPTION


Docker for Mac 1.12.0-a build 11213 and above have started automatically
setting `no_proxy` for the local docker networks.

```bash
no_proxy="*.local, 169.254/16, 192.168.99/24"
```

In `hab-studio`, we use that variable when we build up the list of
environment variables to pass to `env` before we exec the chroot. The
issue is quoting - the whitespace in the value causes the call to env
to see the parts as a new set of environment variables. While you would
think you could work around that by just making some judicious use of
`"` or `'` everywhere, you would be wrong - bash somehow knows, deep in
its dark soul, that we're being naughty.

The final answer was to do what all good shell scripts do. Throw up your
hands in anger and just use sed.

```bash
env="$env no_proxy=$(echo $no_proxy | $bb sed 's/, /,/g')"
```

Because it turns out the whitespace is totally un-needed in the
`no_proxy` value.

![I Fixed It](https://cloud.githubusercontent.com/assets/4304/17715074/6ba0e718-63b7-11e6-8029-8a51dfa585e9.gif)

Signed-off-by: Adam Jacob <adam@chef.io>