### PR TITLE
files in a packages config directory are logged upon parse failure

### DIFF
--- a/components/sup/src/service_config.rs
+++ b/components/sup/src/service_config.rs
@@ -167,7 +167,10 @@ impl ServiceConfig {
         for config in config_files.iter() {
             let path = pi.installed_path().join("config").join(config);
             debug!("Config template {} at {:?}", config, &path);
-            try!(handlebars.register_template_file(config, &path));
+            if let Err(e) = handlebars.register_template_file(config, &path) {
+                outputln!("Error parsing config template file {}: {}", path.to_string_lossy(), e);
+                return Err(sup_error!(Error::HandlebarsTemplateFileError(e)))
+            }
         }
 
         let final_data = convert::toml_to_json(final_toml);


### PR DESCRIPTION
If an editor leaves a backup/swap file in the `./config` dir of a plan, the supervisor will fail to start with:
```
hab-sup(ER)[src/error.rs:322:8]: IOError(Error { repr: Custom(Custom { kind: InvalidData, error: StringError("stream did not contain valid UTF-8") }) })
```
This PR displays the config file that failed to parse. 

See also: https://github.com/habitat-sh/habitat/issues/1120

![1__tmux](https://cloud.githubusercontent.com/assets/58244/17751065/6bdb80bc-6493-11e6-8746-2cf05bc44978.png)
