### PR TITLE
[core] Use 'Owner' and 'Permissions' during unpack

### DIFF
--- a/components/core/src/package/archive.rs
+++ b/components/core/src/package/archive.rs
@@ -188,6 +188,8 @@ impl PackageArchive {
         let writer = writer::Disk::new();
         let mut extract_options = ExtractOptions::new();
         extract_options.add(ExtractOption::Time);
+        extract_options.add(ExtractOption::Owner);
+        extract_options.add(ExtractOption::Permissions);
         try!(writer.set_options(&extract_options));
         try!(writer.set_standard_lookup());
         try!(writer.write(&mut reader, Some(root.to_string_lossy().as_ref())));


### PR DESCRIPTION
* Per the [libarchive-rust documentation](https://github.com/chef/libarchive-rust/blob/master/src/archive.rs#L201-L212), the `Permissions` option may be
  used to fully restore the original permissions. When used in
  combination with the `Owner` option, the original owner as well as the
  setuid/setgid bits should be properly set during installation.

I was unfortunately having some trouble getting my dev `make shell` to build a
test-setuid plan.sh with this, so would welcome an additional test.

References #1175, perhaps!

Signed-off-by: AJ Christensen <aj@junglistheavy.industries>