### PR TITLE
Set the pkg user/group for builder-api-proxy

### DIFF
--- a/components/builder-api-proxy/config/nginx.conf
+++ b/components/builder-api-proxy/config/nginx.conf
@@ -1,3 +1,4 @@
+user hab hab;
 daemon off;
 pid {{pkg.svc_var_path}}/pid;
 
@@ -56,7 +57,7 @@ http {
   add_header "X-UA-Compatible" "IE=Edge";
   add_header Strict-Transport-Security "max-age=31536000; includeSubDomains;";
 
-  proxy_cache_path {{pkg.svc_path_path}}/cache levels=1:2 keys_zone=my_cache:10m max_size=10g inactive=60m use_temp_path=off;
+  proxy_cache_path {{pkg.svc_var_path}}/cache levels=1:2 keys_zone=my_cache:10m max_size=10g inactive=60m use_temp_path=off;
 
   server {
     index index.html;

--- a/components/builder-api-proxy/plan.sh
+++ b/components/builder-api-proxy/plan.sh
@@ -6,6 +6,8 @@ pkg_maintainer="The Habitat Maintainers <humans@habitat.sh"
 pkg_source=nosuchfile.tar.xz
 pkg_license=("apache2")
 pkg_deps=(core/nginx core/curl)
+pkg_svc_user="root"
+pkg_svc_group="root"
 
 do_begin() {
   return 0


### PR DESCRIPTION
With the change in #1050, we need to start nginx in builder-api-proxy as root, and then drop privileges to hab/hab.

We also need to put the cache in the right place.

Signed-off-by: jtimberman <joshua@chef.io>