### PR TITLE
builder-api should start as root/root

### DIFF
--- a/components/builder-api/habitat/plan.sh
+++ b/components/builder-api/habitat/plan.sh
@@ -10,6 +10,8 @@ pkg_build_deps=(core/protobuf core/protobuf-rust core/coreutils core/cacerts cor
 pkg_expose=(9636)
 bin="bldr-api"
 pkg_svc_run="bin/$bin start -c ${pkg_svc_path}/config.toml"
+pkg_svc_user="root"
+pkg_svc_group="root"
 
 do_prepare() {
   rm -Rdf $HAB_CACHE_SRC_PATH/ui-$pkg_name-$pkg_version


### PR DESCRIPTION
We drop privileges with chpst in the run script to hab/hab. This is so
the init hook will run properly.

Signed-off-by: jtimberman <joshua@chef.io>