### PR TITLE
[http-client] Add missing colon on Host header when connecting to proxy.

### DIFF
--- a/components/http-client/src/net.rs
+++ b/components/http-client/src/net.rs
@@ -58,7 +58,7 @@ impl<S: SslClient> NetworkConnector for ProxyHttpsConnector<S> {
                 // We can't yet use hyper directly and therefore use the underlying http parsing
                 // library to establish the connection and parse the response. This implementation
                 // is largely based on hyper's internal proxy tunneling code.
-                let mut connect_msg = format!("{method} {host}:{port} {version}\r\nHost \
+                let mut connect_msg = format!("{method} {host}:{port} {version}\r\nHost: \
                                                {host}:{port}\r\n",
                                               method = Method::Connect,
                                               version = HttpVersion::Http11,


### PR DESCRIPTION
When a tunneling proxy connection is established, a client makes a
request to the proxy with something like the following:

```
CONNECT willem.habitat.sh:443 HTTP/1.1
Host: willem.habitat.sh:443
Proxy-Authorization: Basic amRvZTpzYXNzYWZyYXNz
```

The HTTP verb in this case is `CONNECT` and what follows are HTTP
headers, namely the `Host` and optionally the `Proxy-Authorization`
headers.

This change adds a missing colon to the `Host` header which causes some
proxy servers to correctly fail with an invalid request (i.e. an
HTTP/400).

Special thanks to the heroic efforts of @hiucimon who lent his effort,
time, and was able to diagnose this on a proper network setup.

Closes #1180

![gif-keyboard-7161155796445724375](https://cloud.githubusercontent.com/assets/261548/18102481/eb9b6328-6eaf-11e6-8bd1-b5e069ec0c2e.gif)
