### PR TITLE
Adding package search from the CLI. Fixes #1159

### DIFF
--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -177,6 +177,11 @@ pub fn get() -> App<'static, 'static> {
                 (@arg FULL_RELEASES: -r "Show fully qualified package names (ex: core/busybox-static/1.24.2/20160708162350)")
                 (@arg FULL_PATHS: -p "Show full path to file")
             )
+            (@subcommand search =>
+                (about: "Search for a package on a Depot")
+                (@arg SEARCH_TERM: +required +takes_value "Search term")
+                (@arg DEPOT_URL: -u --url +takes_value {valid_url} "Use a specific Depot URL")
+            )
             (@subcommand sign =>
                 (about: "Signs an archive with an origin key, generating a Habitat Artifact")
                 (aliases: &["s", "si", "sig"])

--- a/components/hab/src/command/pkg.rs
+++ b/components/hab/src/command/pkg.rs
@@ -362,6 +362,33 @@ pub mod provides {
     }
 }
 
+pub mod search {
+    use error::Result;
+    use depot_client::Client;
+    use {PRODUCT, VERSION};
+
+    pub fn start(st: &str, url: &str) -> Result<()> {
+        let depot_client = try!(Client::new(url, PRODUCT, VERSION, None));
+        match depot_client.search_package(st.to_string()) {
+            Ok(packages) => {
+                match packages.len() {
+                    0 => { println!("No packages found that match '{}'", st); }
+                    _ => {
+                        for p in &packages {
+                            println!("{}/{}/{}/{}", p.origin, p.name, p.version.clone().unwrap(), p.release.clone().unwrap());
+                        }
+                        if packages.len() == 50 {
+                            println!("Search returned too many items, only showing the first 50");
+                        }
+                    }
+                }
+            },
+            Err(e) => println!("{}", e)
+        }
+        Ok(())
+    }
+}
+
 pub mod sign {
     use std::path::Path;
 

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -148,6 +148,7 @@ fn start() -> Result<()> {
                 ("install", Some(m)) => try!(sub_pkg_install(m)),
                 ("path", Some(m)) => try!(sub_pkg_path(m)),
                 ("provides", Some(m)) => try!(sub_pkg_provides(m)),
+                ("search", Some(m)) => try!(sub_pkg_search(m)),
                 ("sign", Some(m)) => try!(sub_pkg_sign(m)),
                 ("upload", Some(m)) => try!(sub_pkg_upload(m)),
                 ("verify", Some(m)) => try!(sub_pkg_verify(m)),
@@ -460,6 +461,13 @@ fn sub_pkg_provides(m: &ArgMatches) -> Result<()> {
     let full_paths = m.is_present("FULL_PATHS");
 
     command::pkg::provides::start(&filename, &fs_root_path, full_releases, full_paths)
+}
+
+fn sub_pkg_search(m: &ArgMatches) -> Result<()> {
+    let env_or_default = henv::var(DEPOT_URL_ENVVAR).unwrap_or(DEFAULT_DEPOT_URL.to_string());
+    let url = m.value_of("DEPOT_URL").unwrap_or(&env_or_default);
+    let search_term = m.value_of("SEARCH_TERM").unwrap();
+    command::pkg::search::start(&search_term, &url)
 }
 
 fn sub_pkg_sign(m: &ArgMatches) -> Result<()> {


### PR DESCRIPTION
Not sure about the output formatting.  Currently just prints out the full ident for all found packages.

I couldn't quite figure out the right incantation to get the depot API to return more than 50 results, so this just prints the first 50 and prints a message indicating more are avaiable.

Signed-off-by: Nolan Davidson <ndavidson@chef.io>