### PR TITLE
[ci/rustfmt] Uninstall then install rustfmt when upgrading.

### DIFF
--- a/support/ci/install_rustfmt.sh
+++ b/support/ci/install_rustfmt.sh
@@ -10,4 +10,5 @@ if command -v rustfmt >/dev/null; then
   fi
 fi
 
-cargo install --vers $version --force rustfmt
+cargo uninstall rustfmt
+cargo install --vers $version rustfmt


### PR DESCRIPTION
This change is necessary if using an older version of Cargo which does
not yet support the `--force` flag on `cargo install`.
