### PR TITLE
[ci/lint] Update rustfmt version parsing logic.

### DIFF
--- a/support/ci/lint.sh
+++ b/support/ci/lint.sh
@@ -59,7 +59,7 @@ if ! command -v rustfmt >/dev/null; then
 fi
 
 info "Checking for version $rf_version of rustfmt"
-actual="$(rustfmt --version)"
+actual="$(rustfmt --version | cut -d ' ' -f 1)"
 if [[ "$actual" != "0.5.0" ]]; then
   exit_with "\`rustfmt' version $actual doesn't match expected: $rf_version" 2
 fi


### PR DESCRIPTION
This failure appears to be from an update is the output of `rustfmt --version` from 0.5.0 to 0.6.0.
