### PR TITLE
[dockerize] take advantage of docker layers

### DIFF
--- a/components/pkg-dockerize/bin/hab-pkg-dockerize.sh
+++ b/components/pkg-dockerize/bin/hab-pkg-dockerize.sh
@@ -160,6 +160,7 @@ build_docker_image() {
   local ident_file="$(hab pkg path $PKG)/IDENT"
   if [[ ! -f "$ident_file" ]]; then
     hab pkg install $PKG # try to install it
+    ident_file="$(hab pkg path $PKG)/IDENT"
   fi
 
   if [[ -n "$DOCKER_REGISTRY_URL" ]]; then

--- a/components/pkg-dockerize/plan.sh
+++ b/components/pkg-dockerize/plan.sh
@@ -4,7 +4,7 @@ pkg_version=$(cat "$PLAN_CONTEXT/../../VERSION")
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_source=nosuchfile.tar.gz
-pkg_deps=(core/coreutils core/findutils core/gawk core/grep core/bash core/docker core/hab-studio)
+pkg_deps=(core/coreutils core/findutils core/gawk core/grep core/bash core/docker core/hab core/hab-studio)
 pkg_build_deps=()
 pkg_bin_dirs=(bin)
 


### PR DESCRIPTION
This modifies the docker exporter to take advantage of layering. The current implementation creates an image consisting of a single layer with all the dependencies and packages installed. Instead, we create two images:
- A base image which includes only runtime dependencies
- Named as `origin/pkg_base:<hash>` where hash is computed from the names (idents) of the runtime deps
- Also tagged as `origin/habitat_export_base:<hash>` to allow re-use across packages which share the same set of dependencies. For instance, we have many apps which will only depend on `core/tomcat8`.
- A "runtime" image which installs the final package(s) and uses previous image as the base (`FROM origin/pkg_base:<hash>`)

This gives much better reuse of layers and totally avoids re-building the base image between app builds. Final images:

```
REPOSITORY                                  TAG                    IMAGE ID            CREATED             SIZE
chetan/foobar                               0.1.0-20160826204445   c3b2ed108437        5 seconds ago        177.8 MB
chetan/foobar                               latest                 c3b2ed108437        5 seconds ago        177.8 MB
chetan/habitat_export_base                  dadf80f42a2a2028       7921e8c8aac2        16 minutes ago       159.8 MB
chetan/foobar_base                          dadf80f42a2a2028       7921e8c8aac2        16 minutes ago       159.8 MB
```
