### PR TITLE
Fix package specification for cmake

### DIFF
--- a/docs/BUILDING_WINDOWS.md
+++ b/docs/BUILDING_WINDOWS.md
@@ -20,7 +20,7 @@ choco install vcredist2013
 choco install visualcppbuildtools --version 14.0.25123
 
 # several cmake based builds
-choco install cmake
+choco install cmake.portable
 
 ## a few more pre-reqs for the OpenSSL builds
 choco install StrawberryPerl


### PR DESCRIPTION
the `cmake` package doesn't put the command line on PATH, but `cmake.portable` does.

Signed-off-by: Steven Murawski <steven.murawski@gmail.com>