### PR TITLE
Make Authenticated middleware self contained

### DIFF
--- a/components/net/src/oauth/github.rs
+++ b/components/net/src/oauth/github.rs
@@ -28,6 +28,7 @@ use error::{Error, Result};
 
 const USER_AGENT: &'static str = "Habitat-Builder";
 
+#[derive(Clone)]
 pub struct GitHubClient {
     pub url: String,
     pub client_id: String,


### PR DESCRIPTION
* Authenticated middleware made less brittle by falling
  back to initializing a new BrokerConn if the RouteBroker middleware
  does not appear in the middleware chain before the Authenticated
  middleware.
* Authenticated middleware now owns it's own copy of GitHubClient

Signed-off-by: Jamie Winsor <jamie@vialstudios.com>