### PR TITLE
Revert back to typed headers in HTTP gateways

### DIFF
--- a/components/net/src/http/headers.rs
+++ b/components/net/src/http/headers.rs
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub use super::headers::*;
-pub use super::middleware::*;
-pub use super::rendering::{render_json, render_net_error};
+header! { (CacheControl, "Cache-Control") => [String] }
+header! { (ContentDisposition, "Content-Disposition") => [String] }
+header! { (ContentRange, "Content-Range") => [String] }
+header! { (NextRange, "Next-Range") => [isize] }
+header! { (XContentRange, "X-Content-Range") => [String] }
+header! { (XFileName, "X-Filename") => [String] }
+header! { (ETag, "ETag") => [String] }

--- a/components/net/src/http/mod.rs
+++ b/components/net/src/http/mod.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 pub mod controller;
+pub mod headers;
 pub mod middleware;
 pub mod rendering;
 

--- a/components/net/src/lib.rs
+++ b/components/net/src/lib.rs
@@ -16,6 +16,7 @@
 extern crate bitflags;
 extern crate fnv;
 extern crate habitat_builder_protocol as protocol;
+#[macro_use]
 extern crate hyper;
 extern crate iron;
 #[macro_use]


### PR DESCRIPTION
We swapped to setting headers with raw values during a transitionary
period in the Iron/Hyper crates which introduced conflicting versions
of the crates in our project. Now that Iron has rolled forward to the
latest version of Hyper, we can swap back to typed headers.

![gif-keyboard-17295432275068976275](https://cloud.githubusercontent.com/assets/54036/18495409/82ecd6bc-79d2-11e6-86d9-7f66e019e7fa.gif)
