### PR TITLE
Just enough code to make the core crate tests pass

### DIFF
--- a/components/core/src/os/filesystem/windows.rs
+++ b/components/core/src/os/filesystem/windows.rs
@@ -13,11 +13,19 @@
 // limitations under the License.
 
 use libc::{c_int, c_char};
+use std::ffi::CStr;
+use std::path::Path;
 
 pub fn chown(r_path: *const c_char, uid: u32, gid: u32) -> c_int {
     unimplemented!();
 }
 
 pub fn chmod(r_path: *const c_char, mode: u32) -> c_int {
-    unimplemented!();
+    unsafe {
+        let path = CStr::from_ptr(r_path).to_str().unwrap();
+        match Path::new(path).exists() {
+            false => 1,
+            true => 0
+        } 
+    }
 }


### PR DESCRIPTION
This stubs out the chmod functionality and if the file exits, we've assume rights.

We'll have to circle back later and fill it back in.

Also, the windows build currently requires dynamic libraries for libarchive and zlib (which the build script accounts for).

ref: #1192 

Signed-off-by: Steven Murawski <steven.murawski@gmail.com>