### PR TITLE
Clean the middleman build before building

### DIFF
--- a/www/Makefile
+++ b/www/Makefile
@@ -1,6 +1,9 @@
-build:
+build: clean
 	bundle exec middleman build
 .PHONY: build
+
+clean:
+	rm -Rdf build
 
 sync: export AWS_BUCKET=habitat-www
 sync: export AWS_DEFAULT_REGION=us-west-2


### PR DESCRIPTION
This addresses the weirdness we noticed late last week after deploying the site. A few pages were not generated and the s3 sync deleted them resulting in a few unwanted 404s. There's likely a bug in Middleman's logic for determining what is new/changed which we can side step by just deleting the output directory before building