### PR TITLE
Recurse into subdirectories inside config.

### DIFF
--- a/components/sup/Cargo.toml
+++ b/components/sup/Cargo.toml
@@ -37,6 +37,7 @@ lazy_static = "*"
 handlebars = "*"
 wonder = "*"
 users = "*"
+walkdir = "*"
 
 [dependencies.habitat_core]
 path = "../core"

--- a/components/sup/src/lib.rs
+++ b/components/sup/src/lib.rs
@@ -66,6 +66,7 @@ extern crate threadpool;
 extern crate openssl;
 #[macro_use]
 extern crate lazy_static;
+extern crate walkdir;
 
 #[macro_export]
 /// Creates a new SupError, embedding the current file name, line number, column, and module path.

--- a/components/sup/src/service_config.rs
+++ b/components/sup/src/service_config.rs
@@ -17,7 +17,8 @@
 use std::ascii::AsciiExt;
 use std::collections::HashMap;
 use std::env;
-use std::fs::File;
+use std::fs::{File, create_dir_all};
+use std::path::Path;
 use std::io::prelude::*;
 
 use ansi_term::Colour::Purple;
@@ -194,6 +195,9 @@ impl ServiceConfig {
                 debug!("Configuration {} does not exist; restarting", filename);
                 outputln!("Updated {}", Purple.bold().paint(config));
                 self.config_hash.insert(filename.clone(), file_hash);
+                if let Some(parent_path) = Path::new(&filename).parent() {
+                    try!(create_dir_all(parent_path));
+                }
                 let mut config_file = try!(File::create(&filename));
                 try!(config_file.write_all(&template_data.into_bytes()));
                 should_restart = true

--- a/test/fixtures/service_with_nested_config/bin/service_with_nested_config
+++ b/test/fixtures/service_with_nested_config/bin/service_with_nested_config
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+EXIT_NOW=0
+
+set_exit_now() {
+  EXIT_NOW=1
+}
+
+trap "set_exit_now" INT TERM HUP
+echo Starting service_with_nested_config
+echo "### Base level configuration file ###"
+cat /hab/svc/service_with_nested_config/config/base_level.conf
+echo "### Second level configuration file ###"
+cat /hab/svc/service_with_nested_config/config/subdir/one_deep.conf
+echo "### Third level configuration file ###"
+cat /hab/svc/service_with_nested_config/config/subdir/nextdir/two_deep.conf
+
+while [ 1 ]; do
+  if [ $EXIT_NOW = 1 ]; then
+     echo "Exiting on signal"
+     exit 0
+  fi
+  sleep 1
+done

--- a/test/fixtures/service_with_nested_config/config/base_level.conf
+++ b/test/fixtures/service_with_nested_config/config/base_level.conf
@@ -1,0 +1,1 @@
+config_setting = {{cfg.foo}}

--- a/test/fixtures/service_with_nested_config/config/subdir/nextdir/two_deep.conf
+++ b/test/fixtures/service_with_nested_config/config/subdir/nextdir/two_deep.conf
@@ -1,0 +1,2 @@
+config_setting = {{cfg.foo}}
+special_setting = {{cfg.bar}}

--- a/test/fixtures/service_with_nested_config/config/subdir/one_deep.conf
+++ b/test/fixtures/service_with_nested_config/config/subdir/one_deep.conf
@@ -1,0 +1,1 @@
+config_setting = {{cfg.foo}}

--- a/test/fixtures/service_with_nested_config/default.toml
+++ b/test/fixtures/service_with_nested_config/default.toml
@@ -1,0 +1,2 @@
+foo = 'fighters'
+bar = 'cheers'

--- a/test/fixtures/service_with_nested_config/hooks/run
+++ b/test/fixtures/service_with_nested_config/hooks/run
@@ -1,0 +1,3 @@
+cp -r {{pkg.path}}/bin {{pkg.svc_path}}
+cd {{pkg.svc_path}}
+exec ./bin/service_with_nested_config

--- a/test/fixtures/service_with_nested_config/plan.sh
+++ b/test/fixtures/service_with_nested_config/plan.sh
@@ -1,0 +1,39 @@
+pkg_name=service_with_nested_config
+pkg_origin=hab_test
+pkg_version=0.0.1
+pkg_license=('Apache2')
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_source=nosuchfile.tar.gz
+pkg_bin_dirs=(bin)
+pkg_deps=()
+pkg_svc_user=root
+pkg_svc_group=root
+
+do_download() {
+  return 0
+}
+
+do_verify() {
+  return 0
+}
+
+do_unpack() {
+  return 0
+}
+
+do_prepare() {
+  return 0
+}
+
+do_build() {
+  return 0
+}
+
+do_install() {
+  mkdir -p $pkg_prefix/bin
+  cp -r $PLAN_CONTEXT/bin $pkg_prefix
+  # this is outside of the chroot, so it won't work
+  #cp -r /src/components/sup/target/debug/hab-sup $pkg_prefix/bin
+  chmod 755 $pkg_prefix/bin
+  chmod 755 $pkg_prefix/bin/*
+}

--- a/test/spec/nested_config.rb
+++ b/test/spec/nested_config.rb
@@ -1,0 +1,88 @@
+# it's safest to use `require_relative` with `spec_helper`, 
+# as different modes of running the tests have different require 
+# behaviors. We can't fully rely on a `.rspec` file.
+require_relative 'spec_helper'
+
+describe "Nested Config" do
+    before(:all) do
+        ctx.common_setup()
+    end
+
+    after(:all) do
+        ctx.common_teardown()
+    end
+
+     # This method lets us prevent cleanup of the test environment
+     # in the event of a test failure.
+    # You don't need this if you want the test environment to 
+    # cleanup all generated test directories and keys even
+    # if your tests fail.
+    after(:each) do |example|
+        if example.exception
+            puts "Detected failed examples, keeping environment"
+            ctx.cleanup = false
+        end
+    end
+
+    context "package functionality" do
+        it "should build, install, start and render configs for service_with_nested_config" do
+            ctx.register_dir "result"
+
+            # Build the package
+            result = ctx.cmd_expect("studio build fixtures/service_with_nested_config",
+                                    "I love it when a plan.sh comes together",
+                                    :timeout_seconds => 60)
+            expect(result.exited?).to be true
+            expect(result.exitstatus).to eq 0
+
+            last_build_info = HabTesting::Utils::parse_last_build()
+
+            expect(last_build_info["pkg_origin"]).to eq ctx.hab_origin
+
+            hart = Pathname.new("results").join(last_build_info["pkg_artifact"])
+            expect(File.exist?(hart)).to be true
+
+            # install package
+            result = ctx.cmd_expect("pkg install ./results/#{last_build_info["pkg_artifact"]}",
+                                    "Install of #{ctx.hab_origin}/service_with_nested_config/0.0.1/#{last_build_info["pkg_release"]} complete",
+                                    :kill_when_found => false)
+            
+            # verify install completed
+            expect(result.exited?).to be true
+            expect(result.exitstatus).to eq 0
+
+            install_path = Pathname.new(ctx.hab_pkg_path).join(
+                ctx.hab_origin,
+                last_build_info["pkg_name"],
+                last_build_info["pkg_version"],
+                last_build_info["pkg_release"]
+            )
+
+            # check installed config files
+            expect(File.exist?("#{install_path}/config/base_level.conf")).to be true
+            expect(File.exist?("#{install_path}/config/subdir")).to be true
+            expect(File.exist?("#{install_path}/config/subdir/one_deep.conf")).to be true
+            expect(File.exist?("#{install_path}/config/subdir/nextdir")).to be true
+            expect(File.exist?("#{install_path}/config/subdir/nextdir/two_deep.conf")).to be true
+
+            # register output directory
+            svc_path = Pathname.new(ctx.hab_svc_path).join("service_with_nested_config")
+            ctx.register_dir svc_path
+
+            # switch to sup binary
+            ctx.hab_bin = ctx.hab_sup_bin
+            # start the service
+            result = ctx.cmd_expect("start #{ctx.hab_origin}/service_with_nested_config",
+                                    "Starting service_with_nested_config",
+                                    :kill_when_found => true)
+
+            # check running config files
+            expect(File.exist?(svc_path)).to be true
+            expect(File.exist?("#{svc_path}/config/base_level.conf")).to be true
+            expect(File.exist?("#{svc_path}/config/subdir")).to be true
+            expect(File.exist?("#{svc_path}/config/subdir/one_deep.conf")).to be true
+            expect(File.exist?("#{svc_path}/config/subdir/nextdir")).to be true
+            expect(File.exist?("#{svc_path}/config/subdir/nextdir/two_deep.conf")).to be true
+        end
+    end
+end

--- a/test/test.sh
+++ b/test/test.sh
@@ -21,7 +21,7 @@ set -e
 
 # The list of all specs to run after basic and env tests are run.
 # WITHOUT .rb suffix.
-all_specs=(crypto)
+all_specs=(crypto nested_config)
 
 # sadly, this is NOT a banner of a cat. But, with a pull request,
 # YOU could make it so.


### PR DESCRIPTION
Potential fix for #1116.

Currently the supervisor blows up when there is a directory inside a packages config directory.  This change adds the ability for the supervisor to recreate any subdirectories and render the config files in them.

Signed-off-by: Nolan Davidson ndavidson@chef.io
