### PR TITLE
[hab,sup] Add formatted output & input methods to `UI`.

### DIFF
--- a/components/hab/src/command/cli.rs
+++ b/components/hab/src/command/cli.rs
@@ -13,11 +13,8 @@
 // limitations under the License.
 
 pub mod setup {
-    use std::io::{self, Write};
     use std::path::Path;
-    use std::process;
 
-    use ansi_term::Colour::{Cyan, Green, White};
     use common::ui::UI;
     use hcore::crypto::SigKeyPair;
     use hcore::env;
@@ -27,103 +24,106 @@ pub mod setup {
     use config;
     use error::Result;
 
-    // @TODO fin: Move `title`, `para`, etc into UI
     pub fn start(ui: &mut UI, cache_path: &Path, analytics_path: &Path) -> Result<()> {
         let mut generated_origin = false;
 
-        println!("");
-        title("Habitat CLI Setup");
-        para("Welcome to hab setup. Let's get started.");
+        try!(ui.br());
+        try!(ui.title("Habitat CLI Setup"));
+        try!(ui.para("Welcome to hab setup. Let's get started."));
 
-        heading("Set up a default origin");
-        para("Every package in Habitat belongs to an origin, which indicates the person or \
-              organization responsible for maintaining that package. Each origin also has \
-              a key used to cryptographically sign packages in that origin.");
-        para("Selecting a default origin tells package building operations such as 'hab pkg \
-              build' what key should be used to sign the packages produced. If you do not \
-              set a default origin now, you will have to tell package building commands each \
-              time what origin to use.");
-        para("For more information on origins and how they are used in building packages, \
-              please consult the docs at https://www.habitat.sh/docs/create-packages-build/");
-        if try!(ask_default_origin()) {
-            println!("");
-            para("Enter the name of your origin. If you plan to publish your packages publicly, \
-                  we recommend that you select one that is not already in use on the Habitat \
-                  build service found at https://app.habitat.sh/.");
-            let origin = try!(prompt_origin());
+        try!(ui.heading("Set up a default origin"));
+        try!(ui.para("Every package in Habitat belongs to an origin, which indicates the person or \
+                   organization responsible for maintaining that package. Each origin also has \
+                   a key used to cryptographically sign packages in that origin."));
+        try!(ui.para("Selecting a default origin tells package building operations such as 'hab \
+                      pkg build' what key should be used to sign the packages produced. If you \
+                      do not set a default origin now, you will have to tell package building \
+                      commands each time what origin to use."));
+        try!(ui.para("For more information on origins and how they are used in building packages, \
+                   please consult the docs at https://www.habitat.sh/docs/create-packages-build/"));
+        if try!(ask_default_origin(ui)) {
+            try!(ui.br());
+            try!(ui.para("Enter the name of your origin. If you plan to publish your packages \
+                          publicly, we recommend that you select one that is not already in use \
+                          on the Habitat build service found at https://app.habitat.sh/."));
+            let origin = try!(prompt_origin(ui));
             try!(write_cli_config_origin(&origin));
-            println!("");
+            try!(ui.br());
             if is_origin_in_cache(&origin, cache_path) {
-                para(&format!("You already have an origin key for {} created and installed. \
-                              Great work!",
-                              &origin));
+                try!(ui.para(&format!("You already have an origin key for {} created and \
+                                       installed. Great work!",
+                                      &origin)));
             } else {
-                heading("Create origin key pair");
-                para(&format!("It doesn't look like you have a signing key for the origin `{}'. \
-                               Without it, you won't be able to build new packages successfully.",
-                              &origin));
-                para("You can either create a new signing key now, or, if you are building \
-                      packages for an origin that already exists, ask the owner to give you the \
-                      signing key.");
-                para("For more information on the use of origin keys, please consult the \
-                      documentation at https://www.habitat.sh/docs/concepts-keys/#origin-keys");
-                if try!(ask_create_origin(&origin)) {
+                try!(ui.heading("Create origin key pair"));
+                try!(ui.para(&format!("It doesn't look like you have a signing key for the origin \
+                                    `{}'. Without it, you won't be able to build new packages \
+                                    successfully.",
+                                   &origin)));
+                try!(ui.para("You can either create a new signing key now, or, if you are building \
+                           packages for an origin that already exists, ask the owner to give \
+                           you the signing key."));
+                try!(ui.para("For more information on the use of origin keys, please consult \
+                              the documentation at \
+                              https://www.habitat.sh/docs/concepts-keys/#origin-keys"));
+                if try!(ask_create_origin(ui, &origin)) {
                     try!(create_origin(ui, &origin, cache_path));
                     generated_origin = true;
                 } else {
-                    para(&format!("You might want to create an origin key later with: `hab \
-                                  origin key generate {}'",
-                                  &origin));
+                    try!(ui.para(&format!("You might want to create an origin key later with: \
+                                           `hab origin key generate {}'",
+                                          &origin)));
                 }
             }
         } else {
-            para("Okay, maybe another time.");
+            try!(ui.para("Okay, maybe another time."));
         }
-        heading("GitHub Access Token");
-        para("While you can build and run Habitat packages without sharing them on the public \
-              depot, doing so allows you to collaborate with the Habitat community. In addition, \
-              it is how you can perform continuous deployment with Habitat.");
-        para("The depot uses GitHub authentication with an access token with the user:email \
-              scope (https://help.github.\
-              com/articles/creating-an-access-token-for-command-line-use/).");
-        para("If you would like to share your packages on the depot, please enter your GitHub \
-              access token. Otherwise, just enter No.");
-        para("For more information on sharing packages on the depot, please read the \
-              documentation at https://www.habitat.sh/docs/share-packages-overview/");
-        if try!(ask_default_auth_token()) {
-            println!("");
-            para("Enter your GitHub access token.");
-            let auth_token = try!(prompt_auth_token());
+        try!(ui.heading("GitHub Access Token"));
+        try!(ui.para("While you can build and run Habitat packages without sharing them on the \
+                      public depot, doing so allows you to collaborate with the Habitat \
+                      community. In addition, it is how you can perform continuous deployment \
+                      with Habitat."));
+        try!(ui.para("The depot uses GitHub authentication with an access token with the \
+                      user:email scope (https://help.github.\
+                      com/articles/creating-an-access-token-for-command-line-use/)."));
+        try!(ui.para("If you would like to share your packages on the depot, please enter your \
+                      GitHub access token. Otherwise, just enter No."));
+        try!(ui.para("For more information on sharing packages on the depot, please read the \
+              documentation at https://www.habitat.sh/docs/share-packages-overview/"));
+        if try!(ask_default_auth_token(ui)) {
+            try!(ui.br());
+            try!(ui.para("Enter your GitHub access token."));
+            let auth_token = try!(prompt_auth_token(ui));
             try!(write_cli_config_auth_token(&auth_token));
         } else {
-            para("Okay, maybe another time.");
+            try!(ui.para("Okay, maybe another time."));
         }
-        heading("Analytics");
-        para("The `hab` command-line tool will optionally send anonymous usage data to Habitat's \
-             Google Analytics account. This is a strictly opt-in activity and no tracking will \
-             occur unless you respond affirmatively to the question below.");
-        para("We collect this data to help improve Habitat's user experience. For example, we \
-              would like to know the category of tasks users are performing, and which ones they \
-              are having trouble with (e.g. mistyping command line arguments).");
-        para("To see what kinds of data are sent and how they are anonymized, please read more \
-             about our analytics here: https://www.habitat.sh/docs/about-analytics/");
-        if try!(ask_enable_analytics(analytics_path)) {
-            try!(opt_in_analytics(analytics_path, generated_origin));
+        try!(ui.heading("Analytics"));
+        try!(ui.para("The `hab` command-line tool will optionally send anonymous usage data to \
+                   Habitat's Google Analytics account. This is a strictly opt-in activity and \
+                   no tracking will occur unless you respond affirmatively to the question \
+                   below."));
+        try!(ui.para("We collect this data to help improve Habitat's user experience. For example, \
+                   we would like to know the category of tasks users are performing, and which \
+                   ones they are having trouble with (e.g. mistyping command line arguments)."));
+        try!(ui.para("To see what kinds of data are sent and how they are anonymized, please read \
+                   more about our analytics here: https://www.habitat.sh/docs/about-analytics/"));
+        if try!(ask_enable_analytics(ui, analytics_path)) {
+            try!(opt_in_analytics(ui, analytics_path, generated_origin));
         } else {
-            try!(opt_out_analytics(analytics_path));
+            try!(opt_out_analytics(ui, analytics_path));
         }
-        heading("CLI Setup Complete");
-        para("That's all for now. Thanks for using Habitat!");
+        try!(ui.heading("CLI Setup Complete"));
+        try!(ui.para("That's all for now. Thanks for using Habitat!"));
         Ok(())
     }
 
-    fn ask_default_origin() -> Result<bool> {
-        prompt_yes_no("Set up a default origin?", Some(true))
+    fn ask_default_origin(ui: &mut UI) -> Result<bool> {
+        Ok(try!(ui.prompt_yes_no("Set up a default origin?", Some(true))))
     }
 
-    fn ask_create_origin(origin: &str) -> Result<bool> {
-        prompt_yes_no(&format!("Create an origin key for `{}'?", origin),
-                      Some(true))
+    fn ask_create_origin(ui: &mut UI, origin: &str) -> Result<bool> {
+        Ok(try!(ui.prompt_yes_no(&format!("Create an origin key for `{}'?", origin),
+                                 Some(true))))
     }
 
     fn write_cli_config_origin(origin: &str) -> Result<()> {
@@ -152,158 +152,58 @@ pub mod setup {
 
     fn create_origin(ui: &mut UI, origin: &str, cache_path: &Path) -> Result<()> {
         let result = command::origin::key::generate::start(ui, &origin, cache_path);
-        println!("");
+        try!(ui.br());
         result
     }
 
-    fn prompt_origin() -> Result<String> {
+    fn prompt_origin(ui: &mut UI) -> Result<String> {
         let config = try!(config::load());
         let default = match config.origin {
             Some(o) => {
-                para(&format!("You already have a default origin set up as `{}', but feel free \
-                               to change it if you wish.",
-                              &o));
+                try!(ui.para(&format!("You already have a default origin set up as `{}', but feel \
+                                    free to change it if you wish.",
+                                   &o)));
                 Some(o)
             }
             None => env::var("USER").ok(),
         };
-        prompt_ask("Default origin name", default.as_ref().map(|x| &**x))
+        Ok(try!(ui.prompt_ask("Default origin name", default.as_ref().map(|x| &**x))))
     }
 
-    fn ask_default_auth_token() -> Result<bool> {
-        prompt_yes_no("Set up a default GitHub access token?", Some(true))
+    fn ask_default_auth_token(ui: &mut UI) -> Result<bool> {
+        Ok(try!(ui.prompt_yes_no("Set up a default GitHub access token?", Some(true))))
     }
 
-    fn prompt_auth_token() -> Result<String> {
+    fn prompt_auth_token(ui: &mut UI) -> Result<String> {
         let config = try!(config::load());
         let default = match config.auth_token {
             Some(o) => {
-                para("You already have a default auth token set up, but feel free to change it \
-                      if you wish.");
+                try!(ui.para("You already have a default auth token set up, but feel free to \
+                              change it if you wish."));
                 Some(o)
             }
             None => None,
         };
-        prompt_ask("GitHub access token", default.as_ref().map(|x| &**x))
+        Ok(try!(ui.prompt_ask("GitHub access token", default.as_ref().map(|x| &**x))))
     }
 
-    fn ask_enable_analytics(analytics_path: &Path) -> Result<bool> {
+    fn ask_enable_analytics(ui: &mut UI, analytics_path: &Path) -> Result<bool> {
         let default = match analytics::is_opted_in(analytics_path) {
             Some(val) => Some(val),
             None => Some(true),
         };
-        prompt_yes_no("Enable analytics?", default)
+        Ok(try!(ui.prompt_yes_no("Enable analytics?", default)))
     }
 
-    fn opt_in_analytics(analytics_path: &Path, generated_origin: bool) -> Result<()> {
+    fn opt_in_analytics(ui: &mut UI, analytics_path: &Path, generated_origin: bool) -> Result<()> {
         let result = analytics::opt_in(analytics_path, generated_origin);
-        println!("");
+        try!(ui.br());
         result
     }
 
-    fn opt_out_analytics(analytics_path: &Path) -> Result<()> {
+    fn opt_out_analytics(ui: &mut UI, analytics_path: &Path) -> Result<()> {
         let result = analytics::opt_out(analytics_path);
-        println!("");
+        try!(ui.br());
         result
-    }
-
-    fn title(text: &str) {
-        println!("{}", Green.bold().paint(text));
-        println!("{}\n",
-                 Green.bold().paint(format!("{:=<width$}", "", width = text.chars().count())));
-    }
-
-    fn heading(text: &str) {
-        println!("{}\n", Green.bold().paint(text));
-    }
-
-    fn para(text: &str) {
-        print_wrapped(text, 75, 2)
-    }
-
-    fn print_wrapped(text: &str, wrap_width: usize, left_indent: usize) {
-        for line in text.split("\n\n") {
-            let mut buffer = String::new();
-            let mut width = 0;
-            for word in line.split_whitespace() {
-                let wl = word.chars().count();
-                if (width + wl + 1) > (wrap_width - left_indent) {
-                    println!("{:<width$}{}", " ", buffer, width = left_indent);
-                    buffer.clear();
-                    width = 0;
-                }
-                width = width + wl + 1;
-                buffer.push_str(word);
-                buffer.push(' ');
-            }
-            if !buffer.is_empty() {
-                println!("{:<width$}{}", " ", buffer, width = left_indent);
-            }
-            println!("");
-        }
-    }
-
-    fn prompt_yes_no(question: &str, default: Option<bool>) -> Result<bool> {
-        let choice = match default {
-            Some(yes) => {
-                if yes {
-                    format!("{}{}{}",
-                            White.paint("["),
-                            White.bold().paint("Yes"),
-                            White.paint("/no/quit]"))
-                } else {
-                    format!("{}{}{}",
-                            White.paint("[yes/"),
-                            White.bold().paint("No"),
-                            White.paint("/quit]"))
-                }
-            }
-            None => format!("{}", White.paint("[yes/no/quit]")),
-        };
-        loop {
-            try!(io::stdout().flush());
-            print!("{} {} ", Cyan.paint(question), choice);
-            try!(io::stdout().flush());
-            let mut response = String::new();
-            try!(io::stdin().read_line(&mut response));
-            match response.trim().chars().next().unwrap_or('\n') {
-                'y' | 'Y' => return Ok(true),
-                'n' | 'N' => return Ok(false),
-                'q' | 'Q' => process::exit(0),
-                '\n' => {
-                    match default {
-                        Some(default) => return Ok(default),
-                        None => continue,
-                    }
-                }
-                _ => continue,
-            }
-        }
-    }
-
-    fn prompt_ask(question: &str, default: Option<&str>) -> Result<String> {
-        let choice = match default {
-            Some(d) => {
-                format!(" {}{}{}",
-                        White.paint("[default: "),
-                        White.bold().paint(d),
-                        White.paint("]"))
-            }
-            None => "".to_string(),
-        };
-        loop {
-            try!(io::stdout().flush());
-            print!("{}{} ", Cyan.paint(format!("{}:", question)), choice);
-            try!(io::stdout().flush());
-            let mut response = String::new();
-            try!(io::stdin().read_line(&mut response));
-            if response.trim().is_empty() {
-                match default {
-                    Some(d) => return Ok(d.to_string()),
-                    None => continue,
-                }
-            }
-            return Ok(response.trim().to_string());
-        }
     }
 }


### PR DESCRIPTION
This change adds several text formatting methods to the `UI` struct
which originally came from the `hab setup` code. The method names are
loosely based on the their HTML equivalents:

* `UI#title()` - A colored title with equals underlining with trailing
  blank line
* `UI#heading()` - A colored title with trailing blank line
* `UI#para()` - A paragraph of text that is re-flowed to fit in a
  standard 80-character wide terminal. The text is also left indented
  and has trailing blank line
* `UI#br()` - A blank line to the same stdout stream as the other
  content functions above

Additionally, several user-facing input methods have been added:

* `UI#prompt_yes_no()` - Asks the user a yes/no question with an
  optional default value which returns their answer
* `UI#prompt_ask()` - Asks the user a question with an optional default
  value which is returned as a string
