### PR TITLE
Always render run script with chpst

### DIFF
--- a/components/builder-admin/habitat/plan.sh
+++ b/components/builder-admin/habitat/plan.sh
@@ -8,7 +8,7 @@ pkg_bin_dirs=(bin)
 pkg_deps=(core/glibc core/openssl core/gcc-libs core/zeromq core/libsodium core/libarchive)
 pkg_build_deps=(core/protobuf core/protobuf-rust core/coreutils core/cacerts core/cargo-nightly core/rust core/gcc core/pkg-config)
 bin="bldr-admin"
-pkg_svc_run="bin/$bin start -c ${pkg_svc_path}/config.toml"
+pkg_svc_run="$bin start -c ${pkg_svc_path}/config.toml"
 
 do_prepare() {
   # Can be either `--release` or `--debug` to determine cargo build strategy

--- a/components/builder-api-proxy/hooks/run
+++ b/components/builder-api-proxy/hooks/run
@@ -1,4 +1,0 @@
-#!/bin/sh
-#
-exec 2>&1
-exec hab pkg exec core/nginx nginx -c {{pkg.svc_path}}/config/nginx.conf

--- a/components/builder-api-proxy/plan.sh
+++ b/components/builder-api-proxy/plan.sh
@@ -1,11 +1,17 @@
 pkg_origin=core
 pkg_name=builder-api-proxy
 pkg_description="HTTP Proxy service fronting the Habitat Builder API service"
-pkg_version=0.1.0
+pkg_version=$(cat "${PLAN_CONTEXT}/../../VERSION")
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh"
 pkg_source=nosuchfile.tar.xz
-pkg_license=("apache2")
-pkg_deps=(core/nginx core/curl)
+pkg_license=("Apache-2.0")
+
+# we depend on a specific version of nginx until we can build this
+# with a released version of hab that fixes the dependency version
+# sorting bug: https://github.com/habitat-sh/habitat/pull/1221
+pkg_deps=(core/nginx/1.10.1 core/curl)
+pkg_svc_run="nginx -c ${pkg_svc_config_path}/nginx.conf"
+# nginx is configured to drop privileges to hab:hab
 pkg_svc_user="root"
 pkg_svc_group="root"
 

--- a/components/builder-api/habitat/plan.sh
+++ b/components/builder-api/habitat/plan.sh
@@ -9,9 +9,7 @@ pkg_deps=(core/glibc core/openssl core/coreutils core/gcc-libs core/zeromq core/
 pkg_build_deps=(core/protobuf core/protobuf-rust core/coreutils core/cacerts core/cargo-nightly core/rust core/gcc core/pkg-config core/node core/phantomjs)
 pkg_expose=(9636)
 bin="bldr-api"
-pkg_svc_run="bin/$bin start -c ${pkg_svc_path}/config.toml"
-pkg_svc_user="root"
-pkg_svc_group="root"
+pkg_svc_run="$bin start -c ${pkg_svc_path}/config.toml"
 
 do_prepare() {
   rm -Rdf $HAB_CACHE_SRC_PATH/ui-$pkg_name-$pkg_version

--- a/components/builder-depot/habitat/plan.sh
+++ b/components/builder-depot/habitat/plan.sh
@@ -8,7 +8,7 @@ pkg_deps=(core/glibc core/gcc-libs core/libarchive core/libsodium core/openssl c
 pkg_build_deps=(core/coreutils core/cacerts core/cargo-nightly core/rust core/gcc core/pkg-config)
 pkg_bin_dirs=(bin)
 bin="$pkg_name"
-pkg_svc_run="bin/$bin start -c ${pkg_svc_path}/config.toml"
+pkg_svc_run="$bin start -c ${pkg_svc_path}/config.toml"
 
 do_prepare() {
   # Can be either `--release` or `--debug` to determine cargo build strategy

--- a/components/builder-jobsrv/habitat/plan.sh
+++ b/components/builder-jobsrv/habitat/plan.sh
@@ -9,7 +9,7 @@ pkg_deps=(core/glibc core/openssl core/gcc-libs core/zeromq core/libsodium core/
 pkg_build_deps=(core/protobuf core/protobuf-rust core/coreutils core/cacerts core/cargo-nightly core/rust core/gcc core/pkg-config)
 pkg_expose=(5566 5567)
 bin="bldr-job-srv"
-pkg_svc_run="bin/$bin start -c ${pkg_svc_path}/config.toml"
+pkg_svc_run="$bin start -c ${pkg_svc_path}/config.toml"
 
 do_prepare() {
   # Can be either `--release` or `--debug` to determine cargo build strategy

--- a/components/builder-router/habitat/plan.sh
+++ b/components/builder-router/habitat/plan.sh
@@ -9,7 +9,7 @@ pkg_deps=(core/glibc core/openssl core/gcc-libs core/zeromq core/libsodium core/
 pkg_build_deps=(core/protobuf core/protobuf-rust core/coreutils core/cacerts core/cargo-nightly core/rust core/gcc core/pkg-config)
 pkg_expose=(5562 5563)
 bin="bldr-router"
-pkg_svc_run="bin/$bin start -c ${pkg_svc_path}/config.toml"
+pkg_svc_run="$bin start -c ${pkg_svc_path}/config.toml"
 
 do_prepare() {
   # Can be either `--release` or `--debug` to determine cargo build strategy

--- a/components/builder-sessionsrv/habitat/plan.sh
+++ b/components/builder-sessionsrv/habitat/plan.sh
@@ -8,7 +8,7 @@ pkg_bin_dirs=(bin)
 pkg_deps=(core/glibc core/openssl core/gcc-libs core/zeromq core/libsodium core/libarchive)
 pkg_build_deps=(core/protobuf core/protobuf-rust core/coreutils core/cacerts core/cargo-nightly core/rust core/gcc core/pkg-config)
 bin="bldr-session-srv"
-pkg_svc_run="bin/$bin start -c ${pkg_svc_path}/config.toml"
+pkg_svc_run="$bin start -c ${pkg_svc_path}/config.toml"
 
 do_prepare() {
   # Can be either `--release` or `--debug` to determine cargo build strategy

--- a/components/builder-vault/habitat/plan.sh
+++ b/components/builder-vault/habitat/plan.sh
@@ -8,7 +8,7 @@ pkg_bin_dirs=(bin)
 pkg_deps=(core/glibc core/openssl core/gcc-libs core/zeromq core/libsodium core/libarchive)
 pkg_build_deps=(core/protobuf core/protobuf-rust core/coreutils core/cacerts core/cargo-nightly core/rust core/gcc core/pkg-config)
 bin="bldr-vault"
-pkg_svc_run="bin/$bin start -c ${pkg_svc_path}/config.toml"
+pkg_svc_run="$bin start -c ${pkg_svc_path}/config.toml"
 
 do_prepare() {
   # Can be either `--release` or `--debug` to determine cargo build strategy

--- a/components/builder-worker/habitat/plan.sh
+++ b/components/builder-worker/habitat/plan.sh
@@ -8,7 +8,7 @@ pkg_bin_dirs=(bin)
 pkg_deps=(core/glibc core/openssl core/gcc-libs core/zeromq core/libsodium core/libarchive)
 pkg_build_deps=(core/protobuf core/protobuf-rust core/coreutils core/cacerts core/cargo-nightly core/rust core/gcc core/pkg-config)
 bin="bldr-worker"
-pkg_svc_run="bin/$bin start -c ${pkg_svc_path}/config.toml"
+pkg_svc_run="$bin start -c ${pkg_svc_path}/config.toml"
 
 do_prepare() {
   # Can be either `--release` or `--debug` to determine cargo build strategy

--- a/components/director/habitat/plan.sh
+++ b/components/director/habitat/plan.sh
@@ -8,8 +8,8 @@ pkg_deps=(core/glibc core/gcc-libs core/libarchive core/libsodium core/openssl)
 pkg_build_deps=(core/coreutils core/cacerts core/cargo-nightly core/rust core/gcc)
 pkg_bin_dirs=(bin)
 bin="hab-director"
-pkg_svc_run="bin/$bin start -c ${pkg_svc_path}/config.toml"
-pkg_svc_user=root
+pkg_svc_run="$bin start -c ${pkg_svc_path}/config.toml"
+pkg_svc_user="root"
 
 do_prepare() {
   # Can be either `--release` or `--debug` to determine cargo build strategy

--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -1993,11 +1993,14 @@ do_default_build_config() {
   return 0
 }
 
-# Write out the `$pkg_prefix/run` file. If a file named `hooks/run` exists, we
-# skip this step. Otherwise, we look for `$pkg_svc_run`, and use that.
+# Write out the `$pkg_prefix/run` file. If a file named `hooks/run`
+# exists, we skip this step. Otherwise, we look for `$pkg_svc_run`,
+# and use that. We assume that the binary used in the `$pkg_svc_run`
+# command is set in the $PATH.
 #
-# If the `$pkg_svc_user` is set to a value that is not `root`, we change
-# the service to be run under that user before we start it.
+# This will write a `run` script that uses `chpst` to run the command
+# as the `$pkg_svc_user` and `$pkg_svc_group`. These are `hab` by
+# default.
 #
 # Delegates most of the implementation to the `do_default_build_server()`
 # function.
@@ -2009,32 +2012,27 @@ do_build_service() {
 # Default implementation of the `do_build_service()` phase.
 do_default_build_service() {
   build_line "Writing service management scripts"
-  if [[ -f "$PLAN_CONTEXT/hooks/run" ]]; then
+  if [[ -f "${PLAN_CONTEXT}/hooks/run" ]]; then
+    build_line "Using run hook ${PLAN_CONTEXT}/hooks/run"
     return 0
   else
     if [[ -n "${pkg_svc_run}" ]]; then
-      if [[ -n "$pkg_svc_user" && "${pkg_svc_user}" != "root" ]]; then
-        cat <<EOT >> $pkg_prefix/run
+      # We use chpst to ensure that the script works outside `hab-sup`
+      # for debugging purposes, or under a `hab-director`.
+      build_line "Writing ${pkg_prefix}/run script to run ${pkg_svc_run} as ${pkg_svc_user}:${pkg_svc_group}"
+      cat <<EOT >> $pkg_prefix/run
 #!/bin/sh
 cd $pkg_svc_path
 
 if [ "\$(whoami)" = "root" ]; then
   exec chpst \\
-    -U ${pkg_svc_user}:$pkg_svc_group \\
-    -u ${pkg_svc_user}:$pkg_svc_group \\
-    $pkg_prefix/$pkg_svc_run 2>&1
+    -U ${pkg_svc_user}:${pkg_svc_group} \\
+    -u ${pkg_svc_user}:${pkg_svc_group} \\
+    ${pkg_svc_run} 2>&1
 else
-  exec $pkg_prefix/$pkg_svc_run 2>&1
+  exec ${pkg_svc_run} 2>&1
 fi
 EOT
-      else
-        cat <<EOT >> $pkg_prefix/run
-#!/bin/sh
-cd $pkg_svc_path
-
-exec $pkg_prefix/$pkg_svc_run 2>&1
-EOT
-      fi
     fi
   fi
   return 0

--- a/www/source/docs/create-plans.html.md.erb
+++ b/www/source/docs/create-plans.html.md.erb
@@ -153,7 +153,7 @@ pkg_build_deps=(core/patch core/make core/gcc)
 pkg_bin_dirs=(bin)
 pkg_lib_dirs=(lib)
 pkg_expose=(80 443)
-pkg_svc_run="bin/httpd -DFOREGROUND -f $pkg_svc_config_path/httpd.conf"
+pkg_svc_run="httpd -DFOREGROUND -f $pkg_svc_config_path/httpd.conf"
 pkg_svc_user="root"
 
 do_build() {


### PR DESCRIPTION
This commit makes two primary changes to the build script:

- The run script generated from pkg_svc_run in the plan will always
  render with chpst set to run with pkg_svc_user and pkg_svc_group
- The generated run script no longer prefixes the pkg_svc_run command
  with "$pkg_prefix"

These changes are necessary to ensure that the sane default for built
packages does the right thing for the most cases. We assume that the
binary used in the pkg_svc_run will be in a bin dir defined in the plan
so it ends up in the PATH.

Additionally, we need some other changes:

- Update plans to reflect this change in the various components' plans
- The proxy package can now use pkg_svc_run instead of having its own
  run hook

Signed-off-by: jtimberman <joshua@chef.io>