### PR TITLE
Static directory permissions

### DIFF
--- a/components/builder-api/habitat/hooks/init
+++ b/components/builder-api/habitat/hooks/init
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-ln -sf {{pkg.path}}/static {{pkg.svc_path}}
-rm -df {{pkg.svc_static_path}}/habitat.conf.js
+cp -a {{pkg.path}}/static/* {{pkg.svc_static_path}}
+rm -f {{pkg.svc_static_path}}/habitat.conf.js
 ln -sf {{pkg.svc_config_path}}/habitat.conf.js {{pkg.svc_static_path}}/habitat.conf.js

--- a/components/sup/src/package/mod.rs
+++ b/components/sup/src/package/mod.rs
@@ -188,6 +188,9 @@ impl Package {
         try!(Self::create_dir_all(self.pkg_install.svc_var_path()));
         try!(util::perm::set_owner(self.pkg_install.svc_var_path(), &user, &group));
         try!(util::perm::set_permissions(self.pkg_install.svc_var_path(), 0o700));
+        try!(Self::create_dir_all(self.pkg_install.svc_static_path()));
+        try!(util::perm::set_owner(self.pkg_install.svc_static_path(), &user, &group));
+        try!(util::perm::set_permissions(self.pkg_install.svc_static_path(), 0o700));
         // TODO: Not 100% if this directory is still needed, but for the moment it's still here -
         // FIN
         try!(Self::create_dir_all(self.pkg_install.svc_path().join("toml")));


### PR DESCRIPTION
This commit adds the static directory to the default directory
structure of services in /hab/svc and it ensures the ownership is set
consistently to avoid permissions errors.

We also need the static directory copied in the api application
instead of linked because the parent (/hab/svc/hab-builder-api) will
be owned by root, which creates a permissions issue for the init hook
to continue running and set up the habitat.conf.js config file.

Signed-off-by: jtimberman <joshua@chef.io>

This pull request requires the changes in #1240 