### PR TITLE
Convert supervisor config to global singleton

### DIFF
--- a/components/sup/src/command/configure.rs
+++ b/components/sup/src/command/configure.rs
@@ -26,7 +26,7 @@ use std::io::prelude::*;
 use std::fs::File;
 
 use error::Result;
-use config::Config;
+use config::gconfig;
 use package::Package;
 
 /// Print the default.toml for a given package.
@@ -36,8 +36,8 @@ use package::Package;
 /// * If the package cannot be found
 /// * If the default.toml does not exist, or cannot be read
 /// * If we can't read the file into a string
-pub fn display(config: &Config) -> Result<()> {
-    let package = try!(Package::load(config.package(), None));
+pub fn display() -> Result<()> {
+    let package = try!(Package::load(gconfig().package(), None));
     let mut file = try!(File::open(package.path().join("default.toml")));
     let mut s = String::new();
     try!(file.read_to_string(&mut s));

--- a/components/sup/src/command/start.rs
+++ b/components/sup/src/command/start.rs
@@ -69,7 +69,7 @@ use hcore::package::PackageIdent;
 
 use {PRODUCT, VERSION};
 use error::Result;
-use config::{Config, UpdateStrategy};
+use config::{gconfig, UpdateStrategy};
 use package::Package;
 use topology::{self, Topology};
 
@@ -83,17 +83,17 @@ static LOGKEY: &'static str = "CS";
 /// * Fails if it cannot find a package with the given name
 /// * Fails if the `run` method for the topology fails
 /// * Fails if an unknown topology was specified on the command line
-pub fn package(config: &Config) -> Result<()> {
+pub fn package() -> Result<()> {
     let mut ui = UI::default();
-    match Package::load(config.package(), None) {
+    match Package::load(gconfig().package(), None) {
         Ok(mut package) => {
-            let update_strategy = config.update_strategy();
+            let update_strategy = gconfig().update_strategy();
             match update_strategy {
                 UpdateStrategy::None => {}
                 _ => {
-                    let url = config.url();
+                    let url = gconfig().url();
                     outputln!("Checking Depot for newer versions...");
-                    // It is important to pass `config.package()` to `show_package()` instead
+                    // It is important to pass `gconfig().package()` to `show_package()` instead
                     // of the package identifier of the loaded package. This will ensure that
                     // if the operator starts a package while specifying a version number, they
                     // will only automaticaly receive release updates for the started package.
@@ -103,7 +103,7 @@ pub fn package(config: &Config) -> Result<()> {
                     // number, for the started  package.
                     let depot_client = try!(Client::new(url, PRODUCT, VERSION, None));
                     let latest_pkg_data =
-                        try!(depot_client.show_package((*config.package()).clone()));
+                        try!(depot_client.show_package((*gconfig().package()).clone()));
                     let latest_ident: PackageIdent = latest_pkg_data.get_ident().clone().into();
                     if &latest_ident > package.ident() {
                         outputln!("Downloading latest version from Depot: {}", latest_ident);
@@ -121,13 +121,13 @@ pub fn package(config: &Config) -> Result<()> {
                     };
                 }
             }
-            start_package(package, config)
+            start_package(package)
         }
         Err(_) => {
             outputln!("{} is not installed",
-                      Yellow.bold().paint(config.package().to_string()));
-            let url = config.url();
-            let new_pkg_data = match config.local_artifact() {
+                      Yellow.bold().paint(gconfig().package().to_string()));
+            let url = gconfig().url();
+            let new_pkg_data = match gconfig().local_artifact() {
                 Some(artifact) => {
                     try!(install::start(&mut ui,
                                         url,
@@ -140,11 +140,11 @@ pub fn package(config: &Config) -> Result<()> {
                 }
                 None => {
                     outputln!("Searching for {} in remote {}",
-                              Yellow.bold().paint(config.package().to_string()),
+                              Yellow.bold().paint(gconfig().package().to_string()),
                               url);
                     try!(install::start(&mut ui,
                                         url,
-                                        &config.package().to_string(),
+                                        &gconfig().package().to_string(),
                                         PRODUCT,
                                         VERSION,
                                         Path::new(FS_ROOT_PATH),
@@ -153,18 +153,18 @@ pub fn package(config: &Config) -> Result<()> {
                 }
             };
             let package = try!(Package::load(&new_pkg_data, None));
-            start_package(package, config)
+            start_package(package)
         }
     }
 }
 
-fn start_package(package: Package, config: &Config) -> Result<()> {
+fn start_package(package: Package) -> Result<()> {
     let run_path = try!(package.run_path());
     debug!("Setting the PATH to {}", run_path);
     env::set_var("PATH", &run_path);
-    match *config.topology() {
-        Topology::Standalone => topology::standalone::run(package, config),
-        Topology::Leader => topology::leader::run(package, config),
-        Topology::Initializer => topology::initializer::run(package, config),
+    match *gconfig().topology() {
+        Topology::Standalone => topology::standalone::run(package),
+        Topology::Leader => topology::leader::run(package),
+        Topology::Initializer => topology::initializer::run(package),
     }
 }

--- a/components/sup/src/topology/initializer.rs
+++ b/components/sup/src/topology/initializer.rs
@@ -20,7 +20,6 @@
 //! We guarantee that the leader will perform its initialization sequence before the
 //! followers attempt to run their initialization sequences.
 
-use config::Config;
 use error::{Result, SupError};
 use state_machine::StateMachine;
 use topology::{self, standalone, State, Worker};
@@ -34,8 +33,8 @@ enum InitGate {
     Done,
 }
 
-pub fn run(package: Package, config: &Config) -> Result<()> {
-    let mut worker = try!(Worker::new(package, String::from("initializer"), config));
+pub fn run(package: Package) -> Result<()> {
+    let mut worker = try!(Worker::new(package, String::from("initializer")));
     let mut sm: StateMachine<State, Worker, SupError> =
         StateMachine::new(State::DetermineViability);
     sm.add_dispatch(State::DetermineViability, state_determine_viability);

--- a/components/sup/src/topology/standalone.rs
+++ b/components/sup/src/topology/standalone.rs
@@ -26,14 +26,13 @@ use error::{Result, SupError};
 use package::Package;
 use state_machine::StateMachine;
 use topology::{self, State, Worker};
-use config::Config;
 
 /// Sets up the topology and calls run_internal.
 ///
 /// Add's the state transitions to the state machine, sets up the signal handlers, and runs the
 /// `topology::run_internal` function.
-pub fn run(package: Package, config: &Config) -> Result<()> {
-    let mut worker = try!(Worker::new(package, String::from("standalone"), config));
+pub fn run(package: Package) -> Result<()> {
+    let mut worker = try!(Worker::new(package, String::from("standalone")));
     let mut sm: StateMachine<State, Worker, SupError> = StateMachine::new(State::Initializing);
     sm.add_dispatch(State::Initializing, state_initializing);
     sm.add_dispatch(State::Starting, state_starting);

--- a/support/ci/install_rustfmt.sh
+++ b/support/ci/install_rustfmt.sh
@@ -10,5 +10,5 @@ if command -v rustfmt >/dev/null; then
   fi
 fi
 
-cargo uninstall rustfmt
+cargo uninstall rustfmt || true
 cargo install --vers $version rustfmt


### PR DESCRIPTION
This commit converts to using a global singleton for configuration,
rather than threading a reference to everything that needs configuration
data.

Since we need to populate our `Config` struct with data from `clap`, we
need to be able to modify it at runtime with an argument, rather than
simply use `lazy_static!`. This implementation stores the configuration
as a static pointer to a location on the heap via `Box`, and updates
the pointer via `mem::transmute` in a `gcache()` method. This method
is called early in `main` - right after we populate the configuration
struct, in fact.

Once `gcache()` has been called (one time only; subsequent calls will be
ignored), you can access the `Config` struct through the
`config::gconfig()` method.

This removes all the references to threading an `&Config` through the
code base, and replaces them with calls to `gconfig()`.

In particular, it cleans up the need for lifetimes in the topology and
worker code, which is a nice side effect.

![gif-keyboard-11431932797035670168](https://cloud.githubusercontent.com/assets/4304/18573582/b07412f0-7b92-11e6-82d8-6f37c4634166.gif)

Signed-off-by: Adam Jacob <adam@chef.io>