### PR TITLE
Update to latest ZeroMQ crate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,17 @@
 branches:
   only:
-  - master
-  - /^sentinel.+$/
-  - /^test_development-.*$/
+    - master
+    - /^sentinel.+$/
+    - /^test_development-.*$/
 env:
   global:
-  - PATH=$HOME/bin:$HOME/.cargo/bin:$PATH
+    - PATH=$HOME/bin:$HOME/.cargo/bin:$PATH
 matrix:
   include:
   - language: ruby
     rvm: 2.3.1
     env:
-    - AFFECTED_DIRS="components/hab|components/sup"
+      - AFFECTED_DIRS="components/hab|components/sup"
     sudo: required
     addons:
       apt:
@@ -26,164 +26,167 @@ matrix:
       directories:
       - /root/travis_bootstrap
     before_install:
-    - ./support/ci/fast_pass.sh || exit 0
+      - ./support/ci/fast_pass.sh || exit 0
     script:
-    - sudo ./support/ci/specs.sh
+      - sudo ./support/ci/specs.sh
   - language: rust
     env:
-    - COMPONENTS=bin LIBSODIUM=$HOME/pkgs/libsodium/1.0.8 LIBARCHIVE=$HOME/pkgs/libarchive/3.2.0 PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$LIBARCHIVE/lib/pkgconfig:$LIBSODIUM/lib/pkgconfig" LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$LIBARCHIVE/lib:$LIBSODIUM/lib"
-    - AFFECTED_DIRS="components/director|components/hab|components/sup"
+      - COMPONENTS=bin LIBSODIUM_PREFIX=$HOME/pkgs/libsodium/1.0.8 LIBARCHIVE_PREFIX=$HOME/pkgs/libarchive/3.2.0 LIBZMQ_PREFIX=$HOME/pkgs/zeromq/4.1.4 PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$LIBARCHIVE_PREFIX/lib/pkgconfig:$LIBSODIUM_PREFIX/lib/pkgconfig:$LIBZMQ_PREFIX/lib/pkgconfig" LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$LIBARCHIVE_PREFIX/lib:$LIBSODIUM_PREFIX/lib:$LIBZMQ_PREFIX/lib" LIBRARY_PATH="$LIBRARY_PATH:$LIBZMQ_PREFIX/lib"
+      - AFFECTED_DIRS="components/director|components/hab|components/sup"
     rust: stable
     sudo: false
     addons:
       apt:
         sources:
-        - kalakris-cmake
+          - kalakris-cmake
         packages:
-        - build-essential
-        - ca-certificates
-        - cmake
-        - curl
-        - libbz2-dev
-        - liblzma-dev
-        - libprotobuf-dev
-        - libssl-dev
-        - libzmq3-dev
-        - pkg-config
+          - build-essential
+          - ca-certificates
+          - cmake
+          - curl
+          - libbz2-dev
+          - liblzma-dev
+          - libprotobuf-dev
+          - libssl-dev
+          - pkg-config
     cache:
       apt: true
       cargo: true
       directories:
-      - "$HOME/rust"
-      - "$HOME/pkgs"
-      - target
+        - "$HOME/rust"
+        - "$HOME/pkgs"
+        - "$HOME/.cargo"
+        - target
     before_install:
-    - ./support/ci/fast_pass.sh || exit 0
-    - ./support/ci/compile_libsodium.sh
-    - ./support/ci/compile_libarchive.sh
-    - ./support/ci/install_rustfmt.sh
-    - ./support/ci/install_cargo.sh
+      - ./support/ci/fast_pass.sh || exit 0
+      - ./support/ci/compile_libsodium.sh
+      - ./support/ci/compile_libarchive.sh
+      - ./support/ci/compile_zmq.sh
+      - ./support/ci/install_rustfmt.sh
+      - ./support/ci/install_cargo.sh
     script:
-    - ./support/ci/rust_tests.sh
-    - ./support/ci/lint.sh
+      - ./support/ci/rust_tests.sh
+      - ./support/ci/lint.sh
   - language: rust
     env:
-    - COMPONENTS=lib LIBSODIUM=$HOME/pkgs/libsodium/1.0.8 LIBARCHIVE=$HOME/pkgs/libarchive/3.2.0 PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$LIBARCHIVE/lib/pkgconfig:$LIBSODIUM/lib/pkgconfig" LD_LIBRARY_PATH="LD_LIBRARY_PATH:$LIBARCHIVE/lib:$LIBSODIUM/lib"
-    - AFFECTED_DIRS="components/builder-dbcache|components/builder-protocol|components/common|components/core|components/builder-depot-client|components/http-client|components/net"
+      - COMPONENTS=lib LIBSODIUM_PREFIX=$HOME/pkgs/libsodium/1.0.8 LIBARCHIVE_PREFIX=$HOME/pkgs/libarchive/3.2.0 LIBZMQ_PREFIX=$HOME/pkgs/zeromq/4.1.4 PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$LIBARCHIVE_PREFIX/lib/pkgconfig:$LIBSODIUM_PREFIX/lib/pkgconfig:$LIBZMQ_PREFIX/lib/pkgconfig" LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$LIBARCHIVE_PREFIX/lib:$LIBSODIUM_PREFIX/lib:$LIBZMQ_PREFIX/lib" LIBRARY_PATH="$LIBRARY_PATH:$LIBZMQ_PREFIX/lib"
+      - AFFECTED_DIRS="components/builder-dbcache|components/builder-protocol|components/common|components/core|components/builder-depot-client|components/http-client|components/net"
     rust: stable
     sudo: false
     addons:
       apt:
         sources:
-        - kalakris-cmake
+          - kalakris-cmake
         packages:
-        - build-essential
-        - ca-certificates
-        - cmake
-        - curl
-        - libbz2-dev
-        - liblzma-dev
-        - libprotobuf-dev
-        - libssl-dev
-        - libzmq3-dev
-        - pkg-config
+          - build-essential
+          - ca-certificates
+          - cmake
+          - curl
+          - libbz2-dev
+          - liblzma-dev
+          - libprotobuf-dev
+          - libssl-dev
+          - pkg-config
     cache:
       apt: true
       cargo: true
       directories:
-      - "$HOME/rust"
-      - "$HOME/pkgs"
-      - target
+        - "$HOME/rust"
+        - "$HOME/pkgs"
+        - "$HOME/.cargo"
+        - target
     before_install:
-    - ./support/ci/fast_pass.sh || exit 0
-    - ./support/ci/compile_libsodium.sh
-    - ./support/ci/compile_libarchive.sh
-    - ./support/ci/install_rustfmt.sh
-    - ./support/ci/install_cargo.sh
+      - ./support/ci/fast_pass.sh || exit 0
+      - ./support/ci/compile_libsodium.sh
+      - ./support/ci/compile_libarchive.sh
+      - ./support/ci/compile_zmq.sh
+      - ./support/ci/install_rustfmt.sh
+      - ./support/ci/install_cargo.sh
     script:
-    - ./support/ci/rust_tests.sh
-    - ./support/ci/lint.sh
+      - ./support/ci/rust_tests.sh
+      - ./support/ci/lint.sh
   - language: rust
     env:
-    - COMPONENTS=srv LIBSODIUM=$HOME/pkgs/libsodium/1.0.8 LIBARCHIVE=$HOME/pkgs/libarchive/3.2.0 PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$LIBARCHIVE/lib/pkgconfig:$LIBSODIUM/lib/pkgconfig" LD_LIBRARY_PATH="LD_LIBRARY_PATH:$LIBARCHIVE/lib:$LIBSODIUM/lib"
-    - AFFECTED_DIRS="components/builder-api|components/builder-admin|components/builder-jobsrv|components/builder-sessionsrv|components/builder-vault|components/builder-worker|components/builder-depot"
+      - COMPONENTS=srv LIBSODIUM_PREFIX=$HOME/pkgs/libsodium/1.0.8 LIBARCHIVE_PREFIX=$HOME/pkgs/libarchive/3.2.0 LIBZMQ_PREFIX=$HOME/pkgs/zeromq/4.1.4 PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$LIBARCHIVE_PREFIX/lib/pkgconfig:$LIBSODIUM_PREFIX/lib/pkgconfig:$LIBZMQ_PREFIX/lib/pkgconfig" LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$LIBARCHIVE_PREFIX/lib:$LIBSODIUM_PREFIX/lib:$LIBZMQ_PREFIX/lib" LIBRARY_PATH="$LIBRARY_PATH:$LIBZMQ_PREFIX/lib"
+      - AFFECTED_DIRS="components/builder-api|components/builder-admin|components/builder-jobsrv|components/builder-sessionsrv|components/builder-vault|components/builder-worker|components/builder-depot"
     rust: stable
     sudo: false
     addons:
       apt:
         sources:
-        - kalakris-cmake
+          - kalakris-cmake
         packages:
-        - build-essential
-        - ca-certificates
-        - cmake
-        - curl
-        - libbz2-dev
-        - liblzma-dev
-        - libprotobuf-dev
-        - libssl-dev
-        - libzmq3-dev
-        - pkg-config
+          - build-essential
+          - ca-certificates
+          - cmake
+          - curl
+          - libbz2-dev
+          - liblzma-dev
+          - libprotobuf-dev
+          - libssl-dev
+          - pkg-config
     cache:
       apt: true
       cargo: true
       directories:
-      - "$HOME/rust"
-      - "$HOME/pkgs"
-      - target
+        - "$HOME/rust"
+        - "$HOME/pkgs"
+        - "$HOME/.cargo"
+        - target
     before_install:
-    - ./support/ci/fast_pass.sh || exit 0
-    - ./support/ci/compile_libsodium.sh
-    - ./support/ci/compile_libarchive.sh
-    - ./support/ci/install_rustfmt.sh
-    - ./support/ci/install_cargo.sh
+      - ./support/ci/fast_pass.sh || exit 0
+      - ./support/ci/compile_libsodium.sh
+      - ./support/ci/compile_libarchive.sh
+      - ./support/ci/compile_zmq.sh
+      - ./support/ci/install_rustfmt.sh
+      - ./support/ci/install_cargo.sh
     script:
-    - ./support/ci/rust_tests.sh
-    - ./support/ci/lint.sh
+      - ./support/ci/rust_tests.sh
+      - ./support/ci/lint.sh
   - language: node_js
     node_js: 4.4.3
     sudo: required
     env:
-    - CXX=g++-4.8
-    - AFFECTED_DIRS="components/builder-web"
+      - CXX=g++-4.8
+      - AFFECTED_DIRS="components/builder-web"
     addons:
       apt:
         sources:
-        - ubuntu-toolchain-r-test
+          - ubuntu-toolchain-r-test
         packages:
-        - g++-4.8
-        - wget
+          - g++-4.8
+          - wget
     cache:
       apt: true
       directories:
-      - components/builder-web/node_modules
-      - components/builder-web/typings
+        - components/builder-web/node_modules
+        - components/builder-web/typings
     before_install:
-    - ./support/ci/fast_pass.sh || exit 0
-    - npm config set spin=false
+      - ./support/ci/fast_pass.sh || exit 0
+      - npm config set spin=false
     install:
-    - "(cd components/builder-web && npm install)"
+      - "(cd components/builder-web && npm install)"
     script:
-    - "(cd components/builder-web && npm run travis)"
-    - sudo -E bash -c "./support/ci/build_builder_web.sh"
+      - "(cd components/builder-web && npm run travis)"
+      - sudo -E bash -c "./support/ci/build_builder_web.sh"
   - language: ruby
     rvm: 2.3.1
     sudo: false
     cache:
       bundle: true
       directories:
-      - www/build
+        - www/build
     env:
-    - AFFECTED_DIRS="www"
-    - AWS_BUCKET=habitat-www
-    - AWS_DEFAULT_REGION=us-west-2
-    - AWS_ACCESS_KEY_ID=AKIAIE3PM7VKCMUX7TIA
-    # AWS_SECRET_ACCESS_KEY
-    - secure: "QadoE7tZXlUoLcgqlQsJOb0B5CjW/pOz/geBe3ObzYJ0vs60JztT1ySbz0LSqiUWXJyWL+RroBcoauzILUBjN5uszFaxZQ80J5GL+bwhlLaK/PpIf/37HCXmEQ0yzJyGWMKsr0Mp6d2DXUC2XNqf1InmygEwGbgFZFzMvdZ2KB981EfxxzZNsQhxak/WFUjvvJ9m95OfSGerb8swvpIH0zIg0MG3Gmj+xPCI+4eSLOYa+xLkDIjBngEPKZ0Uvfg32fB6k47XktFRpOkoS6ecDxPF7fjqjVRF+j7Y9MkH+FvSOohF48u5klqYZA7SMAbGO5n4xRkDkA2Wn3XH8jnOkt307OGm2zvTRSa3QowaJgnHRfSsGy5+ql6J3w7Ap0jqCGWwqV3qldkyC7rblz3oRHhyB52xm283T4ptDuIN29UNn+zWOgk3sSKIO3jmShNc/x7l+DoTTuMz72hw1gd3YTrCJ651pTPDXjkCb5Yn7Gt4SxKPUENL+USHohHD69WuhruFawdgctFh1WhFLr2vTvqh1eHxU5oyXV4PJwXuG2wIqnGwjaAYoRph58r28GE8YX487MlLKpGL8xXOaEdcQaADRQVihE5QW9XOt/E3DWFA+Ntt+U0SsegY1HHT/lkA29U3inXV1Nvt6P1+AKz8AuYT4QndZSMI8K9YOUlcP8E="
-    # FASTLY_API_KEY
-    - secure: "t3dUI5oNwsB1gSP3DIwwxnY7z/NigMm4XgMrQuiU5xda4sL67JQ/sU8j00I3B9TnfA1fekMBzMOKES+F7SI1y+b6K7q+SOI4mgcNqRcQKJans6o6XuBVT9Tp8om7izxOgp0lVLuHxv4OVEhmhORTCWjk/jW1M45oG5oAYOvATsbQ/gZiVCKMrb8bSSpl6eSn5YqIvJiqDW707O2wUDJsdiS4bXTIVUtai+hCeIckitrrFWWkDNWnP0/OnFb3F2ka3lFRwfuUH8UQ6oqT4YcumngIMbIvBSCOBOenGagvrhpcX2m0cVDNY/sE6iv9c2HBSlEK6vaYAbkfX6mpNseruPPq7xv5HGBhj6wlkCHpML1xse7qbCTgzKUlIfkAQQljmUH7c/mN1i9YucoMtgJxRqZCiuoO/hNILcAoQFv14NvqUNOgGeYqHzi3RSxMeQxs3uLA1l0AZpLR6aPNOM9XZyVxhFw55htS5yY52rvXVz4TR1JF22RZesT8V/WpQoPSP1d4bmVVIqa83piqQJ65cMQ0YyhQWRLtWIipvKlztnwpSV/J2LjXzbZm4J//0ArCNx0wNggrkyL7xBpmgbLgRCgid9SUlIX1HPisdJkL/z7lmz9s05ppATiipy/PduaqCZ/Lpq4wMZ8S2ILLPbNtYx8EOPGjLspPnXbpHB4z73A="
-    # FASTLY_SERVICE_KEY
-    - secure: "SFcY62bzpxUVD6ZDE23KudYX5gCt9fuH8QE2wAE+Pu4LPj9SKQyOwpbx3Aej2EzPk14RNA2HKXr3jY+rGdSpNrSyTmbf2IMOolVjIDSoT2xD5E+hAARfuurjHH8l9Bwb8KRiPG3oxcM85oXU6kd882SN5CsM3jY65vj94I/SMZYpUB7KSUQP8ji7hoE1eVeXQWi2AM+fjPFwWG1BhiP16j7SyAaDCAI+jDAeTplrdg10pxIKv7ef1wOHahyGlORdxubAilQW+dZuubMjl2qgPem8FQRmYSLJNEAvj663QYZf1XfH1fDYavW7J0l9vj4E8BwXUAdYn20JPwR6HSI/XsJrpxEc/PEt/2HqhTPAnxVwKQkXEgbKxCamPDIwBANwhjOdetY9dR8w9W4rsJ7wT7WQw40chlFO1gU8Ct4dIlCYogtTBxRdrCObTWRkGlsEH2XNxt4lE4xoE79njlQqNj/Wq0FeyljLPIaK90E1C9O0Q5Li1LaiIQTxyaoivLGELXrsysvkRwEOOCGiFt6w8P1LDEqoKz7Z5tu7+dbh3c31KCgPsgo150/Q4+plnq6+GoY+3ejWac7qf+q1dbp5Gx4lNPBKKuUylhx7TYUlpAp3hLcoA3fs245eYbbv1+fJ1SLIFGYNTHzRRmbB1bZaHQeHl8dMNuMh4JVDexAuCXc="
+      - AFFECTED_DIRS="www"
+      - AWS_BUCKET=habitat-www
+      - AWS_DEFAULT_REGION=us-west-2
+      - AWS_ACCESS_KEY_ID=AKIAIE3PM7VKCMUX7TIA
+      # AWS_SECRET_ACCESS_KEY
+      - secure: "QadoE7tZXlUoLcgqlQsJOb0B5CjW/pOz/geBe3ObzYJ0vs60JztT1ySbz0LSqiUWXJyWL+RroBcoauzILUBjN5uszFaxZQ80J5GL+bwhlLaK/PpIf/37HCXmEQ0yzJyGWMKsr0Mp6d2DXUC2XNqf1InmygEwGbgFZFzMvdZ2KB981EfxxzZNsQhxak/WFUjvvJ9m95OfSGerb8swvpIH0zIg0MG3Gmj+xPCI+4eSLOYa+xLkDIjBngEPKZ0Uvfg32fB6k47XktFRpOkoS6ecDxPF7fjqjVRF+j7Y9MkH+FvSOohF48u5klqYZA7SMAbGO5n4xRkDkA2Wn3XH8jnOkt307OGm2zvTRSa3QowaJgnHRfSsGy5+ql6J3w7Ap0jqCGWwqV3qldkyC7rblz3oRHhyB52xm283T4ptDuIN29UNn+zWOgk3sSKIO3jmShNc/x7l+DoTTuMz72hw1gd3YTrCJ651pTPDXjkCb5Yn7Gt4SxKPUENL+USHohHD69WuhruFawdgctFh1WhFLr2vTvqh1eHxU5oyXV4PJwXuG2wIqnGwjaAYoRph58r28GE8YX487MlLKpGL8xXOaEdcQaADRQVihE5QW9XOt/E3DWFA+Ntt+U0SsegY1HHT/lkA29U3inXV1Nvt6P1+AKz8AuYT4QndZSMI8K9YOUlcP8E="
+      # FASTLY_API_KEY
+      - secure: "t3dUI5oNwsB1gSP3DIwwxnY7z/NigMm4XgMrQuiU5xda4sL67JQ/sU8j00I3B9TnfA1fekMBzMOKES+F7SI1y+b6K7q+SOI4mgcNqRcQKJans6o6XuBVT9Tp8om7izxOgp0lVLuHxv4OVEhmhORTCWjk/jW1M45oG5oAYOvATsbQ/gZiVCKMrb8bSSpl6eSn5YqIvJiqDW707O2wUDJsdiS4bXTIVUtai+hCeIckitrrFWWkDNWnP0/OnFb3F2ka3lFRwfuUH8UQ6oqT4YcumngIMbIvBSCOBOenGagvrhpcX2m0cVDNY/sE6iv9c2HBSlEK6vaYAbkfX6mpNseruPPq7xv5HGBhj6wlkCHpML1xse7qbCTgzKUlIfkAQQljmUH7c/mN1i9YucoMtgJxRqZCiuoO/hNILcAoQFv14NvqUNOgGeYqHzi3RSxMeQxs3uLA1l0AZpLR6aPNOM9XZyVxhFw55htS5yY52rvXVz4TR1JF22RZesT8V/WpQoPSP1d4bmVVIqa83piqQJ65cMQ0YyhQWRLtWIipvKlztnwpSV/J2LjXzbZm4J//0ArCNx0wNggrkyL7xBpmgbLgRCgid9SUlIX1HPisdJkL/z7lmz9s05ppATiipy/PduaqCZ/Lpq4wMZ8S2ILLPbNtYx8EOPGjLspPnXbpHB4z73A="
+      # FASTLY_SERVICE_KEY
+      - secure: "SFcY62bzpxUVD6ZDE23KudYX5gCt9fuH8QE2wAE+Pu4LPj9SKQyOwpbx3Aej2EzPk14RNA2HKXr3jY+rGdSpNrSyTmbf2IMOolVjIDSoT2xD5E+hAARfuurjHH8l9Bwb8KRiPG3oxcM85oXU6kd882SN5CsM3jY65vj94I/SMZYpUB7KSUQP8ji7hoE1eVeXQWi2AM+fjPFwWG1BhiP16j7SyAaDCAI+jDAeTplrdg10pxIKv7ef1wOHahyGlORdxubAilQW+dZuubMjl2qgPem8FQRmYSLJNEAvj663QYZf1XfH1fDYavW7J0l9vj4E8BwXUAdYn20JPwR6HSI/XsJrpxEc/PEt/2HqhTPAnxVwKQkXEgbKxCamPDIwBANwhjOdetY9dR8w9W4rsJ7wT7WQw40chlFO1gU8Ct4dIlCYogtTBxRdrCObTWRkGlsEH2XNxt4lE4xoE79njlQqNj/Wq0FeyljLPIaK90E1C9O0Q5Li1LaiIQTxyaoivLGELXrsysvkRwEOOCGiFt6w8P1LDEqoKz7Z5tu7+dbh3c31KCgPsgo150/Q4+plnq6+GoY+3ejWac7qf+q1dbp5Gx4lNPBKKuUylhx7TYUlpAp3hLcoA3fs245eYbbv1+fJ1SLIFGYNTHzRRmbB1bZaHQeHl8dMNuMh4JVDexAuCXc="
     before_install: ./support/ci/fast_pass.sh || exit 0
     install: "(cd www && bundle install)"
     script: ./support/ci/deploy_website.sh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,7 +230,7 @@ dependencies = [
  "toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "urlencoded 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "zmq 0.7.0 (git+https://github.com/reset/rust-zmq.git?branch=habitat)",
+ "zmq 0.8.0 (git+https://github.com/erickt/rust-zmq.git)",
 ]
 
 [[package]]
@@ -260,7 +260,7 @@ dependencies = [
  "staticfile 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zmq 0.7.0 (git+https://github.com/reset/rust-zmq.git?branch=habitat)",
+ "zmq 0.8.0 (git+https://github.com/erickt/rust-zmq.git)",
 ]
 
 [[package]]
@@ -295,7 +295,7 @@ dependencies = [
  "redis 0.7.0 (git+https://github.com/habitat-sh/redis-rs?branch=habitat)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "zmq 0.7.0 (git+https://github.com/reset/rust-zmq.git?branch=habitat)",
+ "zmq 0.8.0 (git+https://github.com/erickt/rust-zmq.git)",
 ]
 
 [[package]]
@@ -324,7 +324,7 @@ dependencies = [
  "protobuf 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "zmq 0.7.0 (git+https://github.com/reset/rust-zmq.git?branch=habitat)",
+ "zmq 0.8.0 (git+https://github.com/erickt/rust-zmq.git)",
 ]
 
 [[package]]
@@ -345,7 +345,7 @@ dependencies = [
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "zmq 0.7.0 (git+https://github.com/reset/rust-zmq.git?branch=habitat)",
+ "zmq 0.8.0 (git+https://github.com/erickt/rust-zmq.git)",
 ]
 
 [[package]]
@@ -363,7 +363,7 @@ dependencies = [
  "redis 0.7.0 (git+https://github.com/habitat-sh/redis-rs?branch=habitat)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "zmq 0.7.0 (git+https://github.com/reset/rust-zmq.git?branch=habitat)",
+ "zmq 0.8.0 (git+https://github.com/erickt/rust-zmq.git)",
 ]
 
 [[package]]
@@ -379,7 +379,7 @@ dependencies = [
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "zmq 0.7.0 (git+https://github.com/reset/rust-zmq.git?branch=habitat)",
+ "zmq 0.8.0 (git+https://github.com/erickt/rust-zmq.git)",
 ]
 
 [[package]]
@@ -463,7 +463,7 @@ dependencies = [
  "urlencoded 0.4.0 (git+https://github.com/habitat-sh/urlencoded.git?branch=habitat)",
  "uuid 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "zmq 0.7.0 (git+https://github.com/reset/rust-zmq.git?branch=habitat)",
+ "zmq 0.8.0 (git+https://github.com/erickt/rust-zmq.git)",
 ]
 
 [[package]]
@@ -534,7 +534,7 @@ dependencies = [
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zmq 0.7.0 (git+https://github.com/reset/rust-zmq.git?branch=habitat)",
+ "zmq 0.8.0 (git+https://github.com/erickt/rust-zmq.git)",
 ]
 
 [[package]]
@@ -1453,18 +1453,18 @@ dependencies = [
 
 [[package]]
 name = "zmq"
-version = "0.7.0"
-source = "git+https://github.com/reset/rust-zmq.git?branch=habitat#8023e3503a03cd4a04ea6b93de34bb4a09953d27"
+version = "0.8.0"
+source = "git+https://github.com/erickt/rust-zmq.git#5cd311a6127a7dd49920cc0a3f7f9501b155146c"
 dependencies = [
  "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "zmq-sys 0.7.0 (git+https://github.com/reset/rust-zmq.git?branch=habitat)",
+ "zmq-sys 0.8.0 (git+https://github.com/erickt/rust-zmq.git)",
 ]
 
 [[package]]
 name = "zmq-sys"
-version = "0.7.0"
-source = "git+https://github.com/reset/rust-zmq.git?branch=habitat#8023e3503a03cd4a04ea6b93de34bb4a09953d27"
+version = "0.8.0"
+source = "git+https://github.com/erickt/rust-zmq.git#5cd311a6127a7dd49920cc0a3f7f9501b155146c"
 dependencies = [
  "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1601,5 +1601,5 @@ dependencies = [
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 "checksum wonder 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "07666280a40a706383d9c32f5783c213ca4c9d745102d3f0c9916f5675aad563"
-"checksum zmq 0.7.0 (git+https://github.com/reset/rust-zmq.git?branch=habitat)" = "<none>"
-"checksum zmq-sys 0.7.0 (git+https://github.com/reset/rust-zmq.git?branch=habitat)" = "<none>"
+"checksum zmq 0.8.0 (git+https://github.com/erickt/rust-zmq.git)" = "<none>"
+"checksum zmq-sys 0.8.0 (git+https://github.com/erickt/rust-zmq.git)" = "<none>"

--- a/components/builder-admin/Cargo.toml
+++ b/components/builder-admin/Cargo.toml
@@ -34,8 +34,7 @@ version = "*"
 features = [ "suggestions", "color", "unstable" ]
 
 [dependencies.zmq]
-git = "https://github.com/reset/rust-zmq.git"
-branch = "habitat"
+git = "https://github.com/erickt/rust-zmq.git"
 
 [dependencies.habitat_core]
 path = "../core"

--- a/components/builder-admin/habitat/plan.sh
+++ b/components/builder-admin/habitat/plan.sh
@@ -37,6 +37,9 @@ do_prepare() {
 }
 
 do_build() {
+  export LIBRARY_PATH=$LIBZMQ_PREFIX/lib
+  build_line "Setting LIBRARY_PATH=$LIBRARY_PATH"
+
   pushd $PLAN_CONTEXT/.. > /dev/null
   cargo build ${build_type#--debug} --target=$rustc_target --verbose
   popd > /dev/null

--- a/components/builder-api/Cargo.toml
+++ b/components/builder-api/Cargo.toml
@@ -33,9 +33,7 @@ version = "*"
 features = [ "suggestions", "color", "unstable" ]
 
 [dependencies.zmq]
-# git = "https://github.com/erickt/rust-zmq.git"
-git = "https://github.com/reset/rust-zmq.git"
-branch = "habitat"
+git = "https://github.com/erickt/rust-zmq.git"
 
 [dependencies.habitat_core]
 path = "../core"

--- a/components/builder-api/habitat/plan.sh
+++ b/components/builder-api/habitat/plan.sh
@@ -43,6 +43,9 @@ do_prepare() {
 }
 
 do_build() {
+  export LIBRARY_PATH=$LIBZMQ_PREFIX/lib
+  build_line "Setting LIBRARY_PATH=$LIBRARY_PATH"
+
   pushd $HAB_CACHE_SRC_PATH/ui-$pkg_name-$pkg_version > /dev/null
   export HOME=$HAB_CACHE_SRC_PATH
   npm install

--- a/components/builder-depot/Cargo.toml
+++ b/components/builder-depot/Cargo.toml
@@ -64,9 +64,7 @@ git = "https://github.com/habitat-sh/urlencoded.git"
 branch = "habitat"
 
 [dependencies.zmq]
-# git = "https://github.com/erickt/rust-zmq.git"
-git = "https://github.com/reset/rust-zmq.git"
-branch = "habitat"
+git = "https://github.com/erickt/rust-zmq.git"
 
 [build-dependencies]
 serde_codegen = "*"

--- a/components/builder-depot/habitat/plan.sh
+++ b/components/builder-depot/habitat/plan.sh
@@ -35,6 +35,9 @@ do_prepare() {
 }
 
 do_build() {
+  export LIBRARY_PATH=$LIBZMQ_PREFIX/lib
+  build_line "Setting LIBRARY_PATH=$LIBRARY_PATH"
+
   pushd $PLAN_CONTEXT/.. > /dev/null
   cargo build ${build_type#--debug} --target=$rustc_target --verbose
   popd > /dev/null

--- a/components/builder-jobsrv/Cargo.toml
+++ b/components/builder-jobsrv/Cargo.toml
@@ -23,9 +23,7 @@ version = "*"
 features = [ "suggestions", "color", "unstable" ]
 
 [dependencies.zmq]
-# git = "https://github.com/erickt/rust-zmq.git"
-git = "https://github.com/reset/rust-zmq.git"
-branch = "habitat"
+git = "https://github.com/erickt/rust-zmq.git"
 
 [dependencies.habitat_core]
 path = "../core"

--- a/components/builder-jobsrv/habitat/plan.sh
+++ b/components/builder-jobsrv/habitat/plan.sh
@@ -38,6 +38,9 @@ do_prepare() {
 }
 
 do_build() {
+  export LIBRARY_PATH=$LIBZMQ_PREFIX/lib
+  build_line "Setting LIBRARY_PATH=$LIBRARY_PATH"
+
   pushd $PLAN_CONTEXT/.. > /dev/null
   cargo build ${build_type#--debug} --target=$rustc_target --verbose
   popd > /dev/null

--- a/components/builder-router/Cargo.toml
+++ b/components/builder-router/Cargo.toml
@@ -22,9 +22,7 @@ version = "*"
 features = [ "suggestions", "color", "unstable" ]
 
 [dependencies.zmq]
-# git = "https://github.com/erickt/rust-zmq.git"
-git = "https://github.com/reset/rust-zmq.git"
-branch = "habitat"
+git = "https://github.com/erickt/rust-zmq.git"
 
 [dependencies.habitat_builder_dbcache]
 path = "../builder-dbcache"

--- a/components/builder-router/habitat/plan.sh
+++ b/components/builder-router/habitat/plan.sh
@@ -38,6 +38,9 @@ do_prepare() {
 }
 
 do_build() {
+  export LIBRARY_PATH=$LIBZMQ_PREFIX/lib
+  build_line "Setting LIBRARY_PATH=$LIBRARY_PATH"
+
   pushd $PLAN_CONTEXT/.. > /dev/null
   cargo build ${build_type#--debug} --target=$rustc_target --verbose
   popd > /dev/null

--- a/components/builder-router/src/server.rs
+++ b/components/builder-router/src/server.rs
@@ -327,12 +327,6 @@ impl<'a> Application for Server<'a> {
     }
 }
 
-impl<'a> Drop for Server<'a> {
-    fn drop(&mut self) {
-        self.fe_sock.close().unwrap();
-    }
-}
-
 enum SocketState {
     Ready,
     Hops,

--- a/components/builder-sessionsrv/Cargo.toml
+++ b/components/builder-sessionsrv/Cargo.toml
@@ -25,9 +25,7 @@ version = "*"
 features = [ "suggestions", "color", "unstable" ]
 
 [dependencies.zmq]
-# git = "https://github.com/erickt/rust-zmq.git"
-git = "https://github.com/reset/rust-zmq.git"
-branch = "habitat"
+git = "https://github.com/erickt/rust-zmq.git"
 
 [dependencies.habitat_core]
 path = "../core"

--- a/components/builder-sessionsrv/habitat/plan.sh
+++ b/components/builder-sessionsrv/habitat/plan.sh
@@ -37,6 +37,9 @@ do_prepare() {
 }
 
 do_build() {
+  export LIBRARY_PATH=$LIBZMQ_PREFIX/lib
+  build_line "Setting LIBRARY_PATH=$LIBRARY_PATH"
+
   pushd $PLAN_CONTEXT/.. > /dev/null
   cargo build ${build_type#--debug} --target=$rustc_target --verbose
   popd > /dev/null

--- a/components/builder-vault/Cargo.toml
+++ b/components/builder-vault/Cargo.toml
@@ -22,9 +22,7 @@ version = "*"
 features = [ "suggestions", "color", "unstable" ]
 
 [dependencies.zmq]
-# git = "https://github.com/erickt/rust-zmq.git"
-git = "https://github.com/reset/rust-zmq.git"
-branch = "habitat"
+git = "https://github.com/erickt/rust-zmq.git"
 
 [dependencies.habitat_core]
 path = "../core"

--- a/components/builder-vault/habitat/plan.sh
+++ b/components/builder-vault/habitat/plan.sh
@@ -37,6 +37,9 @@ do_prepare() {
 }
 
 do_build() {
+  export LIBRARY_PATH=$LIBZMQ_PREFIX/lib
+  build_line "Setting LIBRARY_PATH=$LIBRARY_PATH"
+
   pushd $PLAN_CONTEXT/.. > /dev/null
   cargo build ${build_type#--debug} --target=$rustc_target --verbose
   popd > /dev/null

--- a/components/builder-worker/Cargo.toml
+++ b/components/builder-worker/Cargo.toml
@@ -22,9 +22,7 @@ version = "*"
 features = [ "suggestions", "color", "unstable" ]
 
 [dependencies.zmq]
-# git = "https://github.com/erickt/rust-zmq.git"
-git = "https://github.com/reset/rust-zmq.git"
-branch = "habitat"
+git = "https://github.com/erickt/rust-zmq.git"
 
 [dependencies.habitat_core]
 path = "../core"

--- a/components/builder-worker/habitat/plan.sh
+++ b/components/builder-worker/habitat/plan.sh
@@ -42,6 +42,9 @@ do_prepare() {
 }
 
 do_build() {
+  export LIBRARY_PATH=$LIBZMQ_PREFIX/lib
+  build_line "Setting LIBRARY_PATH=$LIBRARY_PATH"
+
   pushd $PLAN_CONTEXT/.. > /dev/null
   cargo build ${build_type#--debug} --target=$rustc_target --verbose
   popd > /dev/null

--- a/components/builder-worker/src/server.rs
+++ b/components/builder-worker/src/server.rs
@@ -137,12 +137,6 @@ impl Server {
 
 impl NetIdent for Server {}
 
-impl Drop for Server {
-    fn drop(&mut self) {
-        self.fe_sock.close().unwrap();
-    }
-}
-
 pub fn run(config: Config) -> Result<()> {
     try!(Server::new(config)).run()
 }

--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -20,9 +20,7 @@ time = "*"
 unicase = "*"
 
 [dependencies.zmq]
-# git = "https://github.com/erickt/rust-zmq.git"
-git = "https://github.com/reset/rust-zmq.git"
-branch = "habitat"
+git = "https://github.com/erickt/rust-zmq.git"
 
 [dependencies.habitat_builder_protocol]
 path = "../builder-protocol"

--- a/components/net/src/dispatcher/mod.rs
+++ b/components/net/src/dispatcher/mod.rs
@@ -99,7 +99,6 @@ pub trait Dispatcher: Sized + Send {
             }
             envelope.reset();
         }
-        try!(sock.close());
         Ok(())
     }
 }

--- a/components/net/src/server.rs
+++ b/components/net/src/server.rs
@@ -305,11 +305,6 @@ impl RouteConn {
         })
     }
 
-    pub fn close(&mut self) -> Result<()> {
-        try!(self.socket.close());
-        Ok(())
-    }
-
     pub fn connect(&mut self, addr: &str) -> Result<()> {
         try!(self.socket.connect(addr));
         Ok(())
@@ -332,11 +327,5 @@ impl RouteConn {
         let bytes = try!(req.write_to_bytes());
         try!(self.socket.send(&bytes, 0));
         Ok(())
-    }
-}
-
-impl Drop for RouteConn {
-    fn drop(&mut self) {
-        self.close().unwrap();
     }
 }

--- a/support/ci/compile_zmq.sh
+++ b/support/ci/compile_zmq.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -eu
+
+version=4.1.4
+nv=zeromq-$version
+source=http://download.zeromq.org/zeromq-$version.tar.gz
+prefix=$HOME/pkgs/zeromq/$version
+
+# If installed, exit early!
+if [ -d "$prefix" ]; then
+  echo "--> Detected $nv installed under $prefix, skipping compile"
+  exit 0
+fi
+
+echo "--> Compiling $nv"
+trap 'rm -rf /tmp/${nv}*; exit $?' INT TERM EXIT
+(cd /tmp && wget --no-check-certificate $source && tar xf /tmp/$(basename $source))
+cd /tmp/$nv
+./autogen.sh && ./configure --prefix=$prefix --with-libsodium
+make
+make install


### PR DESCRIPTION
* Swap off of my personal fork to the canonical repository. We have been
  granted commit access and will collaborate there from now on
* Remove explicit ZeroMQ socket closes - these are now automatically
  handled by the Socket's drop trait
* Update Builder component plans to find libzmq at build time
