### PR TITLE
Iterate on plans with --config-from

### DIFF
--- a/components/sup/src/config.rs
+++ b/components/sup/src/config.rs
@@ -139,12 +139,24 @@ pub struct Config {
     version_number: u64,
     organization: Option<String>,
     ring: Option<String>,
+    config_from: Option<String>,
 }
 
 impl Config {
     /// Create a default `Config`
     pub fn new() -> Config {
         Config::default()
+    }
+
+    /// Set the config file from directory
+    pub fn set_config_from(&mut self, config_from: Option<String>) -> &mut Config {
+        self.config_from = config_from;
+        self
+    }
+
+    /// Return the config file from directory
+    pub fn config_from(&self) -> Option<&String> {
+        self.config_from.as_ref()
     }
 
     /// Set the archive

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -69,6 +69,9 @@ fn config_from_args(subcommand: &str, sub_args: &ArgMatches) -> Result<()> {
     let mut config = Config::new();
     let command = try!(Command::from_str(subcommand));
     config.set_command(command);
+    if let Some(ref config_from) = sub_args.value_of("config-from") {
+        config.set_config_from(Some(config_from.to_string()));
+    }
     if let Some(ref strategy) = sub_args.value_of("strategy") {
         config.set_update_strategy(UpdateStrategy::from_str(strategy));
     }
@@ -277,6 +280,11 @@ fn main() {
         .arg(arg_group())
         .arg(arg_org())
         .arg(arg_strategy())
+        .arg(Arg::with_name("config-from")
+            .short("C")
+            .long("config-from")
+            .value_name("config-from")
+            .help("Use package config from this path, rather than the package itself"))
         .arg(Arg::with_name("topology")
             .short("t")
             .long("topology")

--- a/components/sup/src/package/hooks.rs
+++ b/components/sup/src/package/hooks.rs
@@ -205,7 +205,7 @@ impl<'a> HookTable<'a> {
     }
 
     pub fn load_hooks(&mut self) -> &mut Self {
-        let path = &self.package.path().join("hooks");
+        let path = &self.package.config_from().join("hooks");
         match fs::metadata(path) {
             Ok(meta) => {
                 if meta.is_dir() {

--- a/components/sup/src/service_config.rs
+++ b/components/sup/src/service_config.rs
@@ -161,8 +161,8 @@ impl ServiceConfig {
         // more explicit... in a minute, we render all the config files anyway.
         let config_files = try!(pkg.config_files());
         for config in config_files.iter() {
-            let path = pi.installed_path().join("config").join(config);
-            debug!("Config template {} at {:?}", config, &path);
+            let path = pkg.config_from().join("config").join(config);
+            debug!("Config template {} from {:?}", config, &path);
             if let Err(e) = handlebars.register_template_file(config, &path) {
                 outputln!("Error parsing config template file {}: {}",
                           path.to_string_lossy(),
@@ -363,7 +363,7 @@ impl Cfg {
 
     fn load_default(&mut self, pkg: &Package) -> Result<()> {
         // Default
-        let mut file = match File::open(pkg.path().join("default.toml")) {
+        let mut file = match File::open(pkg.config_from().join("default.toml")) {
             Ok(file) => file,
             Err(e) => {
                 debug!("Failed to open default.toml: {}", e);

--- a/www/source/docs/reference/plan-syntax.html.md
+++ b/www/source/docs/reference/plan-syntax.html.md
@@ -14,6 +14,7 @@ This syntax guide is divided into six parts:
 - [Hooks](#hooks)
 - [Runtime configuration settings](#runtime-configuration-settings)
 - [Utility functions](#utility-functions)
+- [Iterative development](#iterative-development)
 
 ## Basic settings
 The following settings are defined at the beginning of your plan. They specify basic information about your plan such as name, version, and dependencies.
@@ -539,3 +540,22 @@ exit_with "Something bad happened" 55
 
 trim()
 : Trims leading and trailing whitespace characters from a bash variable.
+
+***
+
+## Iterative Development
+To assist in creating new packages, or modifying existing ones, the supervisor
+has an option to allow you to use the configuration directly from a specific
+directory, rather than the one it includes in the compiled artifact. This can
+significantly shorten the cycle time when working on configuration and hooks.
+
+First, build the plan as you normally would. Second, when you start the
+supervisor, pass the name of the directory with your plan inside it:
+
+```
+$ hab start core/redis --config-from /src
+```
+
+This would take the configuration and hooks from /src, rather than from the
+package you have previously built. When the configuration is as you want it,
+do a final rebuild of the package.


### PR DESCRIPTION
![gif-keyboard-9626797244353975288](https://cloud.githubusercontent.com/assets/4304/18616999/901e86d0-7d7b-11e6-8371-927771cc026d.gif)

This commit enables the `--config-from` option to the supervisor. It
allows you to pass the directory where your habitat plan lives, and when
you run the supervisor, it will use the configuration it finds there
rather than the configuration in the package.

While this violates a bunch of useful properties in production, it's
very useful for plan creation. Here is an example:

```bash
$ build redis
[.. hab builds stuff ..]
$ hab start core/redis
[ .. redis starts ..]
```

At this point, you might realize a hook is wrong, or a configuration
value isn't set. Currently, testing this would either require you to
edit the installed path in `/hab/pkgs`, or recompile all of redis. With
this option, you can instead say:

```bash
$ hab start core/redis --config-from /src
```

And edit the configuration file in place, test to your hearts content,
and then issue one final build when you're sure eveything works.

In future work, it would be cool to include some file watching logic, to
automatically reload the service when your configuration changes. For
now, though, this works great, and it doesn't take any new dependencies.

Signed-off-by: Adam Jacob <adam@chef.io>