### PR TITLE
[devshell] Use rustup in Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,14 +33,9 @@ ENV PATH $PATH:$CARGO_HOME/bin:/root/.cargo/bin
 ARG HAB_DEPOT_URL
 ENV HAB_DEPOT_URL ${HAB_DEPOT_URL:-}
 
-RUN curl -s https://static.rust-lang.org/rustup.sh | sh -s -- -y \
-  && RUST_VERSION=$(rustc -V | cut -d ' ' -f 2) \
-  && URL=http://static.rust-lang.org/dist/rust-std-${RUST_VERSION}-x86_64-unknown-linux-musl.tar.gz \
-  && mkdir -p /prep/rust-std-musl \
-  && (cd /prep && curl -LO $URL) \
-  && tar xf /prep/$(basename $URL) -C /prep/rust-std-musl --strip-components=1 \
-  && (cd /prep/rust-std-musl && ./install.sh --prefix=$(rustc --print sysroot)) \
-  && rm -rf /prep \
+RUN curl -sSf https://sh.rustup.rs \
+    | env -u CARGO_HOME sh -s -- -y --no-modify-path --default-toolchain stable \
+  && env -u CARGO_HOME rustup target add x86_64-unknown-linux-musl \
   && rustc -V
 RUN URL=https://static.rust-lang.org/cargo-dist/cargo-nightly-x86_64-unknown-linux-gnu.tar.gz \
   && mkdir -p /prep/cargo \

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -26,7 +26,10 @@ apt-get update && apt-get install -y --no-install-recommends \
     sudo \
     wget
 
-curl -sSf https://static.rust-lang.org/rustup.sh | sh
+curl -sSf https://sh.rustup.rs \
+    | sh -s -- -y --default-toolchain stable \
+  && rustup target add x86_64-unknown-linux-musl \
+  && rustc -V
 wget -nv https://static.rust-lang.org/cargo-dist/cargo-nightly-x86_64-unknown-linux-gnu.tar.gz && \
   tar -xzf cargo-nightly-x86_64-unknown-linux-gnu.tar.gz && \
   sudo cargo-nightly-x86_64-unknown-linux-gnu/install.sh &&
@@ -85,7 +88,10 @@ git clone git://github.com/zeromq/libzmq.git
 git clone https://github.com/zeromq/czmq.git
 (cd czmq && ./autogen.sh && ./configure && make install && ldconfig)
 
-curl -sSf https://static.rust-lang.org/rustup.sh | sh
+curl -sSf https://sh.rustup.rs \
+    | sh -s -- -y --default-toolchain stable \
+  && rustup target add x86_64-unknown-linux-musl \
+  && rustc -V
 wget -nv https://static.rust-lang.org/cargo-dist/cargo-nightly-x86_64-unknown-linux-gnu.tar.gz && \
   tar -xzf cargo-nightly-x86_64-unknown-linux-gnu.tar.gz && \
   sudo cargo-nightly-x86_64-unknown-linux-gnu/install.sh &&
@@ -123,7 +129,10 @@ git clone https://github.com/jedisct1/libsodium.git
 (cd libsodium && ./autogen.sh && ./configure && make && make install)
 
 # Install Rust
-curl -sSf https://static.rust-lang.org/rustup.sh | sh
+curl -sSf https://sh.rustup.rs \
+    | sh -s -- -y --default-toolchain stable \
+  && rustup target add x86_64-unknown-linux-musl \
+  && rustc -V
 wget -nv https://static.rust-lang.org/cargo-dist/cargo-nightly-x86_64-unknown-linux-gnu.tar.gz && \
   tar -xzf cargo-nightly-x86_64-unknown-linux-gnu.tar.gz && \
   sudo cargo-nightly-x86_64-unknown-linux-gnu/install.sh &&


### PR DESCRIPTION
This change "aggressively upgrades" us to use the new Rustup tooling
rather than the currently stable rustup.sh installer. Upon the release
of the next stable Rust, we should be able to drop the requirement of a
newer nightly Cargo installation further reducing the line count.

![gif-keyboard-4040447348298661739](https://cloud.githubusercontent.com/assets/261548/18620118/66e31670-7dc9-11e6-9377-dd7f87f1de6a.gif)
