### PR TITLE
[hab/mac] Prompt for core origin key when performing a Mac hab release.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -191,13 +191,16 @@ target component.
 
 # How-To: Build Mac Components
 
-1. Turn on and enter virtual machine
+1. Ensure no pre-exiting old virtual machine, then turn on and enter the system
 
 	```
 	$ cd ~/code/habitat/components/hab/mac
+	$ vagrant destroy
 	$ vagrant up
 	$ vagrant ssh
 	```
+
+1. Have the secret core origin key ready for pasting into the terminal. The `mac-build.sh` script will interactively prompt for pasting the key contents if no core origin key is installed on the VM.
 
 1. Build Hab for Mac
 

--- a/components/hab/mac/install.sh
+++ b/components/hab/mac/install.sh
@@ -21,8 +21,8 @@ trap 'rm -rf $workdir; exit $?' INT TERM EXIT
 rm -rf "$workdir"
 mkdir -p "$workdir"
 cd "$workdir"
-wget $hab_url -O $workdir/hab-latest.zip
-wget $sha_url -O $workdir/hab-latest.zip.sha256sum
+curl -sL $hab_url > $workdir/hab-latest.zip
+curl -sL $sha_url > $workdir/hab-latest.zip.sha256sum
 
 # Set the target file name for the slim archive
 archive="$workdir/$(cat hab-latest.zip.sha256sum | cut -d ' ' -f 3)"
@@ -37,8 +37,8 @@ if command -v gpg >/dev/null; then
   sha_sig_file="${archive}.sha256sum.asc"
   key_url="https://bintray.com/user/downloadSubjectPublicKey?username=habitat"
   key_file="$workdir/habitat.asc"
-  wget "$sha_sig_url" -O "$sha_sig_file"
-  wget "$key_url" -O "$key_file"
+  curl -sL "$sha_sig_url" > "$sha_sig_file"
+  curl -sL "$key_url" > "$key_file"
   gpg --no-permission-warning --dearmor "$key_file"
   gpg --no-permission-warning --keyring "${key_file}.gpg" --verify "$sha_sig_file"
 fi

--- a/components/hab/mac/mac-build.sh
+++ b/components/hab/mac/mac-build.sh
@@ -41,6 +41,25 @@ if (( $EUID != 0 )); then
   exit 1
 fi
 
+if [[ ! -f /bin/hab ]]; then
+  info "Habitat CLI missing, attempting to install latest release"
+  sh $(dirname $0)/install.sh
+fi
+
+while true; do
+  if [[ $(ls -1 /hab/cache/keys/core-*.sig.key 2> /dev/null | wc -l) -gt 0 ]]; then
+    break
+  else
+    info "System is missing core origin signing key"
+    info "You will be prompted to paste in the secret key now."
+    info "After pasting, type Ctrl-D to send EOF"
+    info ""
+    info "Paste your key now:"
+    info ""
+    hab origin key import
+  fi
+done
+
 if ! pkgutil --pkgs=com.apple.pkg.CLTools_Executables >/dev/null; then
   info "Xcode CLI tools missing, attempting to install"
   # Implementation graciously borrowed and modified from the build-essential
@@ -93,11 +112,6 @@ if [[ ! -f "$cargo_bin" ]] || [[ $($cargo_bin --version | cut -d ' ' -f 2) < "0.
   ./install.sh --prefix=/opt/cargo
   popd > /dev/null
   rm -rf "$cargo_workdir"
-fi
-
-if [[ ! -f /bin/hab ]]; then
-  info "Habitat CLI missing, attempting to install latest release"
-  sh $(dirname $0)/install.sh
 fi
 
 info "Updating PATH to include GNU toolchain from HomeBrew and custom Cargo"


### PR DESCRIPTION
This change alters the ordering of the `mac-build.sh` script to prompt
the user for a core origin signing key as soon as possible in the
process. As a consequence, a `wget` command is no longer present for the
mac `install.sh` program and therefore `curl` is used instead (Homebrew
installs the `wget` command whereas `curl` is available on stock Mac
installations).

![gif-keyboard-4148750678897312232](https://cloud.githubusercontent.com/assets/261548/18640359/04d8c4ca-7e55-11e6-8559-59c40313ca24.gif)
