### PR TITLE
Update Admin, API, and Depot route definitions with names

### DIFF
--- a/components/builder-admin/src/http/mod.rs
+++ b/components/builder-admin/src/http/mod.rs
@@ -50,7 +50,7 @@ pub fn router(config: Arc<Config>) -> Result<Chain> {
         edit_feature_teams: post "/features/:id/teams" => {
             XHandler::new(feature_grant).before(admin.clone())
         },
-        delete_feature_team: "/features/:feature/teams/:id" => {
+        delete_feature_team: delete "/features/:feature/teams/:id" => {
             XHandler::new(feature_revoke).before(admin.clone())
         }
     );

--- a/components/builder-admin/src/http/mod.rs
+++ b/components/builder-admin/src/http/mod.rs
@@ -40,13 +40,17 @@ const HTTP_THREAD_COUNT: usize = 128;
 pub fn router(config: Arc<Config>) -> Result<Chain> {
     let admin = Authenticated::new(&*config).require(privilege::ADMIN);
     let router = router!(
-        get "/status" => status,
-        post "/search" => XHandler::new(search).before(admin.clone()),
-        get "/accounts/:id" => XHandler::new(account_show).before(admin.clone()),
-        get "/features" => XHandler::new(features_list).before(admin.clone()),
-        get "/features/:id/teams" => XHandler::new(feature_grants_list).before(admin.clone()),
-        post "/features/:id/teams" => XHandler::new(feature_grant).before(admin.clone()),
-        delete "/features/:feature/teams/:id" => {
+        status: get "/status" => status,
+        search: post "/search" => XHandler::new(search).before(admin.clone()),
+        account: get "/accounts/:id" => XHandler::new(account_show).before(admin.clone()),
+        features: get "/features" => XHandler::new(features_list).before(admin.clone()),
+        feature_teams: get "/features/:id/teams" => {
+            XHandler::new(feature_grants_list).before(admin.clone())
+        },
+        edit_feature_teams: post "/features/:id/teams" => {
+            XHandler::new(feature_grant).before(admin.clone())
+        },
+        delete_feature_team: "/features/:feature/teams/:id" => {
             XHandler::new(feature_revoke).before(admin.clone())
         }
     );


### PR DESCRIPTION
In https://github.com/habitat-sh/habitat/commit/fb2402e00c3f57822851ade4167210c0e7fe1bd4 we bumped our dependency on `iron-router` which requires a name field when declaring routes for use with `url_for()`.

We're not using the new named route functionality just yet (though, I'm happy it's arrived!) so these names may change int he future but this will get us compiling.