### PR TITLE
[hab] Read user's keys when running `hab pkg build` with `sudo`.

### DIFF
--- a/components/core/src/os/users/linux.rs
+++ b/components/core/src/os/users/linux.rs
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::path::PathBuf;
+
 use linux_users;
+use linux_users::os::unix::UserExt;
 
 pub fn get_uid_by_name(owner: &str) -> Option<u32> {
     linux_users::get_user_by_name(owner).map(|u| u.uid())
@@ -24,4 +27,8 @@ pub fn get_gid_by_name(group: &str) -> Option<u32> {
 
 pub fn get_effective_uid() -> u32 {
     linux_users::get_effective_uid()
+}
+
+pub fn get_home_for_user(username: &str) -> Option<PathBuf> {
+    linux_users::get_user_by_name(username).map(|u| PathBuf::from(u.home_dir()))
 }

--- a/components/core/src/os/users/mod.rs
+++ b/components/core/src/os/users/mod.rs
@@ -16,10 +16,10 @@
 mod windows;
 
 #[cfg(windows)]
-pub use self::windows::{get_uid_by_name, get_gid_by_name, get_effective_uid};
+pub use self::windows::{get_uid_by_name, get_gid_by_name, get_effective_uid, get_home_for_user};
 
 #[cfg(not(windows))]
 pub mod linux;
 
 #[cfg(not(windows))]
-pub use self::linux::{get_uid_by_name, get_gid_by_name, get_effective_uid};
+pub use self::linux::{get_uid_by_name, get_gid_by_name, get_effective_uid, get_home_for_user};

--- a/components/core/src/os/users/windows.rs
+++ b/components/core/src/os/users/windows.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::path::PathBuf;
+
 pub fn get_uid_by_name(owner: &str) -> Option<u32> {
     unimplemented!();
 }
@@ -21,5 +23,9 @@ pub fn get_gid_by_name(group: &str) -> Option<u32> {
 }
 
 pub fn get_effective_uid() -> u32 {
+    unimplemented!();
+}
+
+pub fn get_home_for_user(username: &str) -> Option<PathBuf> {
     unimplemented!();
 }

--- a/components/hab/src/config.rs
+++ b/components/hab/src/config.rs
@@ -18,7 +18,9 @@ use std::io::Write;
 use std::path::PathBuf;
 
 use hcore::config::{ConfigFile, ParseInto};
+use hcore::env as henv;
 use hcore::fs::{am_i_root, FS_ROOT_PATH};
+use hcore::os::users;
 use toml;
 
 use error::{Error, Result};
@@ -26,18 +28,15 @@ use error::{Error, Result};
 const CLI_CONFIG_PATH: &'static str = "hab/etc/cli.toml";
 
 pub fn load() -> Result<Config> {
-    let cli_config_path = cli_config_path();
-    if cli_config_path.exists() {
-        debug!("Loading CLI config from {}", cli_config_path.display());
-        Ok(try!(Config::from_file(&cli_config_path)))
-    } else {
-        debug!("No CLI config found, loading defaults");
-        Ok(Config::default())
-    }
+    common_load(false)
+}
+
+pub fn load_with_sudo_user() -> Result<Config> {
+    common_load(true)
 }
 
 pub fn save(config: &Config) -> Result<()> {
-    let config_path = cli_config_path();
+    let config_path = cli_config_path(false);
     let parent_path = match config_path.parent() {
         Some(p) => p,
         None => return Err(Error::FileNotFound(config_path.to_string_lossy().into_owned())),
@@ -50,16 +49,36 @@ pub fn save(config: &Config) -> Result<()> {
     Ok(())
 }
 
-fn cli_config_path() -> PathBuf {
+fn common_load(use_sudo_user: bool) -> Result<Config> {
+    let cli_config_path = cli_config_path(use_sudo_user);
+    if cli_config_path.exists() {
+        debug!("Loading CLI config from {}", cli_config_path.display());
+        Ok(try!(Config::from_file(&cli_config_path)))
+    } else {
+        debug!("No CLI config found, loading defaults");
+        Ok(Config::default())
+    }
+}
+
+fn cli_config_path(use_sudo_user: bool) -> PathBuf {
     match am_i_root() {
-        true => PathBuf::from(FS_ROOT_PATH).join(CLI_CONFIG_PATH),
-        _ => {
-            match env::home_dir() {
-                Some(home) => home.join(format!(".{}", CLI_CONFIG_PATH)),
-                None => PathBuf::from(FS_ROOT_PATH).join(CLI_CONFIG_PATH),
+        true => {
+            if use_sudo_user {
+                if let Some(sudo_user) = henv::sudo_user() {
+                    if let Some(home) = users::get_home_for_user(&sudo_user) {
+                        return home.join(format!(".{}", CLI_CONFIG_PATH));
+                    }
+                }
+            }
+        }
+        false => {
+            if let Some(home) = env::home_dir() {
+                return home.join(format!(".{}", CLI_CONFIG_PATH));
             }
         }
     }
+
+    PathBuf::from(FS_ROOT_PATH).join(CLI_CONFIG_PATH)
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, RustcEncodable)]

--- a/components/studio/libexec/hab-studio-type-bare.sh
+++ b/components/studio/libexec/hab-studio-type-bare.sh
@@ -104,7 +104,7 @@ EOT
 }
 
 _hab() {
-  $bb env FS_ROOT=$HAB_STUDIO_ROOT $hab $*
+  $bb env FS_ROOT=$HAB_STUDIO_ROOT HAB_CACHE_KEY_PATH= $hab $*
 }
 
 _pkgpath_for() {

--- a/components/studio/libexec/hab-studio-type-baseimage.sh
+++ b/components/studio/libexec/hab-studio-type-baseimage.sh
@@ -129,7 +129,7 @@ EOT
 }
 
 _hab() {
-  $bb env FS_ROOT=$HAB_STUDIO_ROOT $hab $*
+  $bb env FS_ROOT=$HAB_STUDIO_ROOT HAB_CACHE_KEY_PATH= $hab $*
 }
 
 _pkgpath_for() {

--- a/components/studio/libexec/hab-studio-type-default.sh
+++ b/components/studio/libexec/hab-studio-type-default.sh
@@ -97,7 +97,7 @@ PROFILE
 }
 
 _hab() {
-  $bb env FS_ROOT=$HAB_STUDIO_ROOT $hab $*
+  $bb env FS_ROOT=$HAB_STUDIO_ROOT HAB_CACHE_KEY_PATH= $hab $*
 }
 
 _pkgpath_for() {

--- a/components/studio/libexec/hab-studio-type-stage1.sh
+++ b/components/studio/libexec/hab-studio-type-stage1.sh
@@ -91,5 +91,5 @@ PROFILE
 }
 
 _hab() {
-  $bb env FS_ROOT=$HAB_STUDIO_ROOT $hab $*
+  $bb env FS_ROOT=$HAB_STUDIO_ROOT HAB_CACHE_KEY_PATH= $hab $*
 }


### PR DESCRIPTION
This change affects the behavior specfically of all `hab studio *` and
`hab pkg build` calls when the command is invoked using the `sudo`
command.

Our ideal workflow for a Habitat user on their workstation is to only
require elevated privileges when necessary (and perhaps over time even
trim this list down!). So, one should be able to create keys, run the
setup, etc. without root privileges.

Prior to the change, the issue was that the underlying Habitat Studio
software needed elevated privileges to run `chroot`, bind mount file
systems, etc. which implies that a non-root user may call
`sudo hab pkg build ...`. With the existing logic, this required that
origin keys be set up and installed in the root location under
`/hab/cache/keys`. There was also an implication for the user's config
file.

The behavior in this change will do the followin extra steps for the
Studio-related subcommands **only**:

* If the pre-exiting `$HAB_CACHE_KEY_PATH` environment variable is
  present, use that as the key cache location. This preserves all
  previous behavior and is the end-user's "trump card".
* If the `$SUDO_USER` environment variable is present, then determine
  path to the non-root user's key cache (i.e. `~/.hab/cache/keys`).
* If the value of `$SUDO_USER` is `root`, then the root user has used
  the `sudo` command and we will consider this as no different than a
  straight call from the root user. In this case, use the root location
  for the key cache.
* If the non-root user's home directory cannot be determined, fall back
* to the root location for the key cache.
* If we are in fact the root user, use the root location for key cache
  and proceed as before.
* If all other above conditions aren't met, then we are a non-root user
  that did not invoke the command under `sudo` and is therefore destined
  to fail. A future feature change will detect this case and early-exit
  with a warning to the end user. This "detect-and-fail" logic should
  become a natural default for any Habitat tooling.

To reproduce and test this feature, you can use the devshell environment by
running `make shell` in the root of the project. In the devshell, compile
`hab`, build a new `core/hab-studio` package to install,  and set up a
non-root user:

```
> cd /src/components/hab
> cargo build
> cd /src
> hab pkg build components/studio
> echo hab install \
        ./results/$(source ./results/last_build.env; echo $pkg_artifact)
> useradd -m -s /bin/bash -G sudo jdoe
> echo jdoe:1234 | chpasswd
> su - jdoe
```

Next, run `hab setup` to generate a user origin key and user config
file, all hosted under `~jdoe/.hab`:

```
> /src/target/debug/hab setup

Habitat CLI Setup
=================

  Welcome to hab setup. Let's get started.

Set up a default origin

  Every package in Habitat belongs to an origin, which indicates the
  person or organization responsible for maintaining that package. Each
  origin also has a key used to cryptographically sign packages in that
  origin.

  Selecting a default origin tells package building operations such as
  'hab pkg build' what key should be used to sign the packages produced.
  If you do not set a default origin now, you will have to tell package
  building commands each time what origin to use.

  For more information on origins and how they are used in building
  packages, please consult the docs at
  https://www.habitat.sh/docs/create-packages-build/

Set up a default origin? [Yes/no/quit]

  Enter the name of your origin. If you plan to publish your packages
  publicly, we recommend that you select one that is not already in use on
  the Habitat build service found at https://app.habitat.sh/.

Default origin name: [default: jdoe]

Create origin key pair

  It doesn't look like you have a signing key for the origin `jdoe'.
  Without it, you won't be able to build new packages successfully.

  You can either create a new signing key now, or, if you are building
  packages for an origin that already exists, ask the owner to give you
  the signing key.

  For more information on the use of origin keys, please consult the
  documentation at https://www.habitat.sh/docs/concepts-keys/#origin-keys

Create an origin key for `jdoe'? [Yes/no/quit]
» Generating origin key for jdoe
★ Generated origin key pair jdoe-20160921154605.

GitHub Access Token

  While you can build and run Habitat packages without sharing them on the
  public depot, doing so allows you to collaborate with the Habitat
  community. In addition, it is how you can perform continuous deployment
  with Habitat.

  The depot uses GitHub authentication with an access token with the
  user:email scope
  (https://help.github.com/articles/creating-an-access-token-for-command-line-use/).

  If you would like to share your packages on the depot, please enter your
  GitHub access token. Otherwise, just enter No.

  For more information on sharing packages on the depot, please read the
  documentation at https://www.habitat.sh/docs/share-packages-overview/

Set up a default GitHub access token? [Yes/no/quit] no
  Okay, maybe another time.

Analytics

  The `hab` command-line tool will optionally send anonymous usage data to
  Habitat's Google Analytics account. This is a strictly opt-in activity
  and no tracking will occur unless you respond affirmatively to the
  question below.

  We collect this data to help improve Habitat's user experience. For
  example, we would like to know the category of tasks users are
  performing, and which ones they are having trouble with (e.g. mistyping
  command line arguments).

  To see what kinds of data are sent and how they are anonymized, please
  read more about our analytics here:
  https://www.habitat.sh/docs/about-analytics/

Enable analytics? [Yes/no/quit]
» Opting in to analytics
Ω Creating /home/jdoe/.hab/cache/analytics/OPTED_IN
★ Analytics opted in, thank you!

CLI Setup Complete

  That's all for now. Thanks for using Habitat!
```

Finally, build the `core/hab-plan-build` package as the `jdoe` user,
using jdoe's origin key. Note that you'll need to be in the `/src`
directory to have the correct Studio context:

```
> cd /src

> sudo /src/target/debug/hab pkg build components/plan-build
[sudo] password for jdoe:
   hab-studio: Destroying Studio at /hab/studios/src (default)
   hab-studio: Creating Studio at /hab/studios/src (default)
   hab-studio: Importing jdoe secret origin key
» Importing origin key from standard input
★ Imported secret origin key jdoe-20160921155616.
» Installing core/hab-backline
↓ Downloading core/hab-backline/0.9.3/20160916192451
...

> ls ./results/jdoe-*.hart
./results/jdoe-hab-plan-build-0.10.0-dev-20160921155723-x86_64-linux.hart

> sudo /src/target/debug/hab studio rm
   hab-studio: Destroying Studio at /hab/studios/src (default)
```

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>