### PR TITLE
Stub out uname and effective_uid to make hab run

### DIFF
--- a/components/core/src/os/system/windows.rs
+++ b/components/core/src/os/system/windows.rs
@@ -14,15 +14,22 @@
 
 use error::Result;
 
+// We can probably pull this from Win32_OperatingSystem
 #[derive(Debug)]
 pub struct Uname {
-    pub sys_name: String,
-    pub node_name: String,
-    pub release: String,
-    pub version: String,
-    pub machine: String,
+    pub sys_name: String, // static - Windows
+    pub node_name: String, // __SERVER
+    pub release: String, // Version
+    pub version: String, // Caption
+    pub machine: String, // OSArchitecture - but converted to standard x86_64 or i386
 }
 
 pub fn uname() -> Result<Uname> {
-    unimplemented!();
+    Ok(Uname{
+        sys_name: String::from("Windows"),
+        node_name: String::from("CHEF-WIN10"),
+        release: String::from("10.0.14915"),
+        version: String::from("Microsoft Windows 10 Enterprise Insider Preview"),
+        machine: String::from("x86_64"),
+    })
 }

--- a/components/core/src/os/users/windows.rs
+++ b/components/core/src/os/users/windows.rs
@@ -21,5 +21,5 @@ pub fn get_gid_by_name(group: &str) -> Option<u32> {
 }
 
 pub fn get_effective_uid() -> u32 {
-    unimplemented!();
+    0u32
 }


### PR DESCRIPTION
This gets us a basic `hab` command.  `hab setup` and `hab install` minimally work.

We are just stubbing out the basic uname info that we'd expect from a windows box and pretending to be root.