### PR TITLE
Update documentation references for user scope

### DIFF
--- a/components/hab/src/command/cli.rs
+++ b/components/hab/src/command/cli.rs
@@ -83,7 +83,7 @@ pub mod setup {
                       community. In addition, it is how you can perform continuous deployment \
                       with Habitat."));
         try!(ui.para("The depot uses GitHub authentication with an access token with the \
-                      user:email scope (https://help.github.\
+                      user scope (https://help.github.\
                       com/articles/creating-an-access-token-for-command-line-use/)."));
         try!(ui.para("If you would like to share your packages on the depot, please enter your \
                       GitHub access token. Otherwise, just enter No."));

--- a/www/source/docs/share-packages-overview.html.md
+++ b/www/source/docs/share-packages-overview.html.md
@@ -26,7 +26,7 @@ You can create your own origin in the depot or be invited to join an existing on
 
 ## Setting up hab to authenticate to the depot
 
-Because the depot uses GitHub to authenticate, you must generate a [GitHub access token](https://help.github.com/articles/creating-an-access-token-for-command-line-use/) for use with the `hab` command-line utility. The only rights this token needs at present is `user:email` since it is only used for authentication.
+Because the depot uses GitHub to authenticate, you must generate a [GitHub access token](https://help.github.com/articles/creating-an-access-token-for-command-line-use/) for use with the `hab` command-line utility. The only rights the GitHub personal authorization token needs at present is `user` since it is used for authentication and to determine features based on team membership.
 
 Once you have this token, you can set the `HAB_AUTH_TOKEN` [environment variable](/docs/reference/environment-vars/) to this value, so that any commands requiring authentication will use it.
 

--- a/www/source/tutorials/getting-started/linux/setup-environment.html.md.erb
+++ b/www/source/tutorials/getting-started/linux/setup-environment.html.md.erb
@@ -22,7 +22,7 @@ The `hab` command-line interface (CLI) tool downloads its other components when 
 
     <%= partial "/shared/setup_environment_script_step" %>
 
-    > Note: The only rights the GitHub personal authorization token needs at present is `user:email` since it is only used for authentication. Also, you can opt-out of providing usage data at a later point in time by re-running the `hab setup` subcommand and typing `No` when asked if you want to provide usage data.
+    > Note: The only rights the GitHub personal authorization token needs at present is `user` since it is used for authentication and to determine features based on team membership. Also, you can opt-out of providing usage data at a later point in time by re-running the `hab setup` subcommand and typing `No` when asked if you want to provide usage data.
 
 That's it. You're all set up and ready to create your first package. The first step in that process is to create a plan.
 

--- a/www/source/tutorials/getting-started/mac/setup-environment.html.md.erb
+++ b/www/source/tutorials/getting-started/mac/setup-environment.html.md.erb
@@ -27,7 +27,7 @@ The `hab` command-line interface (CLI) tool downloads its other components when 
 
    <%= partial "/shared/setup_environment_script_step" %>
 
-   > Note: The only rights the GitHub personal authorization token needs at present is `user:email` since it is only used for authentication. Also, you can opt-out of providing usage data at a later point in time by re-running the `hab setup` subcommand and typing `No` when asked if you want to provide usage data.
+   > Note: The only rights the GitHub personal authorization token needs at present is `user` since it is used for authentication and to determine features based on team membership. Also, you can opt-out of providing usage data at a later point in time by re-running the `hab setup` subcommand and typing `No` when asked if you want to provide usage data.
 
 That's it. You're all set up and ready to create your first package. The first step in that process is to create a plan.
 


### PR DESCRIPTION
We need the `user` scope for the OAuth token, not just `user:email`.

Signed-off-by: jtimberman <joshua@chef.io>