### PR TITLE
Use new sentinel testing branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 branches:
   only:
   - master
-  - auto
+  - /^sentinel.+$/
   - /^test_development-.*$/
 env:
   global:
@@ -168,4 +168,9 @@ matrix:
     install: "(cd www && bundle install)"
     script: ./support/ci/deploy_website.sh
 notifications:
-  webhooks: http://old-bots.habitat.sh:54856/travis
+  webhooks:
+    urls:
+      - http://bots.habitat.sh:4567/travis
+    on_success: always
+    on_failure: always
+    on_start: always


### PR DESCRIPTION
The sentinel doesn't use 'auto' like homu did; instead, it creates
branches called 'sentinel/ORG/REPO/PR', which it uses to do the
integration test. It also deletes these branches for you.

This commit makes that functionality actually run in travis.

Signed-off-by: Adam Jacob <adam@chef.io>