### PR TITLE
Adding a build script for the Windows `hab` binary and AppVeyor Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Habitat
 
 [![Build Status](https://api.travis-ci.org/habitat-sh/habitat.svg?branch=master)](https://travis-ci.org/habitat-sh/habitat)
+[![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/ttt9p6r4q6fcipwb/branch/master?svg=true)](https://ci.appveyor.com/project/habitat/habitat/branch/master)
 [![Slack](http://slack.habitat.sh/badge.svg)](http://slack.habitat.sh/)
 [![Stories in Ready](https://badge.waffle.io/habitat-sh/habitat.png?label=ready&title=Ready)](https://waffle.io/habitat-sh/habitat)
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,27 @@
+
+image: Visual Studio 2015
+
+cache:
+    - c:\Program Files (x86)\Rust
+
+branches:
+  only:
+    - smurawski/master
+
+init:
+  - git config --global core.eol lf
+
+skip_tags: true
+
+clone_folder: c:\projects\habitat
+
+install:
+  - ps: ./components/hab/win/win-build.ps1
+  - rustc -V
+  - cargo -V
+
+build: false
+
+test_script:
+  - cd c:\projects\habitat\components\hab
+  - cargo build --verbose

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ cache:
 
 branches:
   only:
-    - smurawski/master
+    - master
 
 init:
   - git config --global core.eol lf

--- a/components/hab/win/README.md
+++ b/components/hab/win/README.md
@@ -1,0 +1,15 @@
+# Building a hab Windows Binary
+
+As Habitat currently does not have first class support for the Windows platform, a pragmatic approach has been taken to build a `hab` binary for Windows. A wrapper script called `win-build.ps1` attempts to install any missing pre-requisites and then building a `hab` binary. Currently, the following are required on the Mac system performing the build:
+
+* Chocolatey
+* Win32 builds of libarchive, libsodium, bzip2, zlib, xz, and openssl via a custom Chocolatey package 
+* vcredist2013 and visualcppbuildtools Chocolatey packages
+* Rust msvc nightly
+
+## Usage
+
+```powershell
+cd components/hab/win
+./win-build.ps1
+```

--- a/components/hab/win/win-build.ps1
+++ b/components/hab/win/win-build.ps1
@@ -1,0 +1,95 @@
+#!/usr/bin/env powershell
+
+#Requires -Version 5
+
+## Helper Functions
+function New-PathString([string]$StartingPath, [string]$Path) {
+    if (-not [string]::IsNullOrEmpty($path)) {
+        if (-not [string]::IsNullOrEmpty($StartingPath)) {
+            [string[]]$PathCollection = "$path;$StartingPath" -split ';'
+            $Path = ($PathCollection |
+              Select-Object -Unique | 
+              where {-not [string]::IsNullOrEmpty($_.trim())} | 
+              where {test-path "$_"}
+              ) -join ';'
+        }
+      $path
+    }
+}
+
+# Make sure that chocolatey is installed and up to date
+# (required for dependencies)
+if (-not (get-command choco -ErrorAction SilentlyContinue)) {
+    Write-Host "Installing Chocolatey"
+    Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1')) | out-null
+}
+else {
+    Write-Host "Making sure Chocolatey is current."
+    choco upgrade chocolatey --confirm | Out-Null
+}
+
+# We need the native library dependencies for `hab`
+# Until we have habitat packages on Windows, there is
+# a chocolatey package hosted in MyGet with the native 
+# dependencies built.
+choco install habitat_native_dependencies --confirm -s https://www.myget.org/F/habitat/api/v2  --allowemptychecksums
+
+# set a few reference variables for later
+$ChocolateyHabitatLibDir = "$env:ChocolateyInstall\lib\habitat_native_dependencies\builds\lib"
+$ChocolateyHabitatIncludeDir = "$env:ChocolateyInstall\lib\habitat_native_dependencies\builds\include"
+$ChocolateyHabitatBinDir = "$env:ChocolateyInstall\lib\habitat_native_dependencies\builds\bin"
+
+if (-not [bool]::Parse($env:APPVEYOR)) {
+    # We need the Visual C 2013 Runtime for the Win32 ABI Rust
+    choco install 'vcredist2013' --confirm --allowemptychecksum
+
+    # We need the Visual C++ tools to build Rust crates (provides a compiler and linker) 
+    choco install 'visualcppbuildtools' --version '14.0.25123' --confirm --allowemptychecksum
+}
+
+# Install Rust Nightly (since there aren't MSVC nightly cargo builds)
+if (get-command -Name rustup.exe -ErrorAction SilentlyContinue) {
+    rustup install nightly-x86_64-pc-windows-msvc
+    $cargo = 'rustup run nightly-x86_64-pc-windows-msvc cargo'
+}
+else {
+    $env:PATH = New-PathString -StartingPath $env:PATH -Path "C:\Program Files (x86)\Rust\bin"
+    if (-not (get-command rustc -ErrorAction SilentlyContinue)) {
+        write-host "installing rust"
+        Invoke-WebRequest -UseBasicParsing -Uri 'https://static.rust-lang.org/dist/rust-nightly-x86_64-pc-windows-msvc.exe' -OutFile './rust-nightly.exe'
+        start-process -filepath ./rust-nightly.exe -argumentlist  '/VERYSILENT', '/NORESTART', '/DIR="C:\Program Files (x86)\Rust"' -Wait
+        $env:PATH = New-PathString -StartingPath $env:PATH -Path "C:\Program Files (x86)\Rust\bin"
+        while (-not (get-command cargo -ErrorAction SilentlyContinue)) {
+            Write-Warning "`tWaiting for `cargo` to be available."
+            start-sleep -Seconds 1
+        }
+        
+    }
+    else {
+        # TODO: version checking logic and upgrades
+    }
+    $cargo = 'cargo'
+}
+
+# Set Environment Variables for the build
+$env:LIB                        = New-PathString -StartingPath $env:LIB     -Path $ChocolateyHabitatLibDir
+$env:INCLUDE                    = New-PathString -StartingPath $env:INCLUDE -Path $ChocolateyHabitatIncludeDir
+$env:PATH                       = New-PathString -StartingPath $env:PATH    -Path $ChocolateyHabitatBinDir
+$env:SODIUM_STATIC              = $true
+$env:SODIUM_LIB_DIR             = $ChocolateyHabitatLibDir
+$env:LIBARCHIVE_INCLUDE_DIR     = $ChocolateyHabitatIncludeDir
+$env:LIBARCHIVE_LIB_DIR         = $ChocolateyHabitatLibDir
+$env:OPENSSL_LIBS               = 'ssleay32:libeay32'
+$env:OPENSSL_LIB_DIR            = $ChocolateyHabitatLibDir
+$env:OPENSSL_INCLUDE_DIR        = $ChocolateyHabitatIncludeDir
+$env:OPENSSL_STATIC             = $true
+
+
+# Start the build
+if (-not [bool]::Parse($env:APPVEYOR)) {
+    Push-Location "$psscriptroot\.."
+    invoke-expression "$cargo clean"
+    Invoke-Expression "$cargo build" 
+    Pop-Location
+    exit $LASTEXITCODE
+}

--- a/components/hab/win/win-build.ps1
+++ b/components/hab/win/win-build.ps1
@@ -17,6 +17,10 @@ function New-PathString([string]$StartingPath, [string]$Path) {
     }
 }
 
+function Test-AppVeyor {
+    (test-path env:\APPVEYOR) -and (-not [bool]::Parse($env:APPVEYOR))
+} 
+
 # Make sure that chocolatey is installed and up to date
 # (required for dependencies)
 if (-not (get-command choco -ErrorAction SilentlyContinue)) {
@@ -39,7 +43,7 @@ $ChocolateyHabitatLibDir = "$env:ChocolateyInstall\lib\habitat_native_dependenci
 $ChocolateyHabitatIncludeDir = "$env:ChocolateyInstall\lib\habitat_native_dependencies\builds\include"
 $ChocolateyHabitatBinDir = "$env:ChocolateyInstall\lib\habitat_native_dependencies\builds\bin"
 
-if (-not [bool]::Parse($env:APPVEYOR)) {
+if (-not (Test-AppVeyor)) {
     # We need the Visual C 2013 Runtime for the Win32 ABI Rust
     choco install 'vcredist2013' --confirm --allowemptychecksum
 
@@ -86,7 +90,7 @@ $env:OPENSSL_STATIC             = $true
 
 
 # Start the build
-if (-not [bool]::Parse($env:APPVEYOR)) {
+if (-not (Test-AppVeyor)) {
     Push-Location "$psscriptroot\.."
     invoke-expression "$cargo clean"
     Invoke-Expression "$cargo build" 


### PR DESCRIPTION
- [X] `hab` Windows build script and README.md to `./components/hab/win/`
- [X] AppVeyor config and project setup
- [X] Build status added to main README.md