### PR TITLE
Add step to BUILDING for sourcing cargo env to fix make error

### DIFF
--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -35,6 +35,7 @@ wget -nv https://static.rust-lang.org/cargo-dist/cargo-nightly-x86_64-unknown-li
   sudo cargo-nightly-x86_64-unknown-linux-gnu/install.sh &&
   rm -rf cargo-nightly-x86_64-unknown-linux-gnu \
     cargo-nightly-x86_64-unknown-linux-gnu.tar.gz
+source $HOME/.cargo/env
 (adduser --system hab || true) && (addgroup --system hab || true)
 ln -snf /usr/bin/nodejs /usr/bin/node && npm install -g docco && echo "docco `docco -V`"
 
@@ -97,6 +98,7 @@ wget -nv https://static.rust-lang.org/cargo-dist/cargo-nightly-x86_64-unknown-li
   sudo cargo-nightly-x86_64-unknown-linux-gnu/install.sh &&
   rm -rf cargo-nightly-x86_64-unknown-linux-gnu \
     cargo-nightly-x86_64-unknown-linux-gnu.tar.gz
+source $HOME/.cargo/env
 (adduser --system hab || true) && (addgroup --system hab || true)
 ln -snf /usr/bin/nodejs /usr/bin/node && npm install -g docco && echo "docco `docco -V`"
 
@@ -117,7 +119,7 @@ curl http://download.opensuse.org/repositories/home:/fengshuo:/zeromq/CentOS_Cen
 # Install common development tools
 yum groupinstall -y 'Development Tools'
 # install sudo as the Rust installation needs it
-yum install -y sudo libarchive-devel protobuf-devel openssl-devel zeromq-devel libczmq1-devel gpm-libs which
+yum install -y sudo libarchive-devel protobuf-devel openssl-devel zeromq-devel libczmq1-devel gpm-libs which wget
 
 # pkg-config will be able to find libsodium with the following:
 export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
@@ -138,6 +140,7 @@ wget -nv https://static.rust-lang.org/cargo-dist/cargo-nightly-x86_64-unknown-li
   sudo cargo-nightly-x86_64-unknown-linux-gnu/install.sh &&
   rm -rf cargo-nightly-x86_64-unknown-linux-gnu \
     cargo-nightly-x86_64-unknown-linux-gnu.tar.gz
+source $HOME/.cargo/env
 
 # Setup hab user and group
 useradd --system hab


### PR DESCRIPTION
Without sourcing, there's no rustc in the PATH:

    root@f28438e09c40:/# cd habitat && make
    sh -c 'cd components/director && cargo build'
        Updating registry `https://github.com/rust-lang/crates.io-index`
        Updating git repository `https://github.com/reset/rust-zmq.git`
        Updating git repository `https://github.com/habitat-sh/redis-rs`
        Updating git repository `https://github.com/habitat-sh/urlencoded.git`
        Updating git repository `https://github.com/habitat-sh/r2d2-redis.git`
    error: An unknown error occurred

    To learn more, run the command again with --verbose.
    Makefile:165: recipe for target 'build-director' failed
    make: *** [build-director] Error 101

    root@f28438e09c40:/habitat# cd components/director && cargo build --verbose
    error: Could not execute process `rustc -vV` (never executed)

    Caused by:
      No such file or directory (os error 2)

Sourcing solves that:

    root@f28438e09c40:/habitat# source $HOME/.cargo/env
    root@f28438e09c40:/habitat# make
    sh -c 'cd components/director && cargo build'
    warning: unused manifest key: package.workspace
        Updating registry `https://github.com/rust-lang/crates.io-index`
        Updating git repository `https://github.com/habitat-sh/redis-rs`
     Downloading log v0.3.6
     Downloading clap v2.13.0
     Downloading env_logger v0.3.5
     Downloading wonder v0.1.0
    ...

Also added wget to the list of packages to install for CentOS, otherwise
the wget for cargo-nightly doesn't work.

h/t to @eeyun for showing me the light.