### PR TITLE
[hab] Fix missing artifact cache directory using `FS_ROOT` env var.

### DIFF
--- a/components/common/src/command/package/install.rs
+++ b/components/common/src/command/package/install.rs
@@ -247,6 +247,7 @@ impl<'a> InstallTask<'a> {
                 return Err(Error::HabitatCore(hcore::Error::InvalidPackageIdent(ident.to_string())))
             }
         };
+        try!(fs::create_dir_all(self.cache_artifact_path));
         try!(fs::copy(artifact_path, self.cache_artifact_path.join(name)));
         Ok(())
     }


### PR DESCRIPTION
![gif-keyboard-7173616939916329311](https://cloud.githubusercontent.com/assets/261548/18884101/46d593d6-84a3-11e6-98a4-e308ac0c6810.gif)
