### PR TITLE
Remove the Waffle badge as we aren't currently using it.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![Build Status](https://api.travis-ci.org/habitat-sh/habitat.svg?branch=master)](https://travis-ci.org/habitat-sh/habitat)
 [![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/ttt9p6r4q6fcipwb/branch/master?svg=true)](https://ci.appveyor.com/project/habitat/habitat/branch/master)
 [![Slack](http://slack.habitat.sh/badge.svg)](http://slack.habitat.sh/)
-[![Stories in Ready](https://badge.waffle.io/habitat-sh/habitat.png?label=ready&title=Ready)](https://waffle.io/habitat-sh/habitat)
 
 Want to try Habitat? [Get started here](https://www.habitat.sh/try/).
 


### PR DESCRIPTION
I removed the Waffle badge because we currently aren't using it. When @eeyun decides what he'd like to use as the OSS project management tool, he can add a badge back in.