### PR TITLE
Request full user scope on web login

### DIFF
--- a/components/builder-web/app/util.ts
+++ b/components/builder-web/app/util.ts
@@ -23,7 +23,7 @@ export function createGitHubLoginUrl(state) {
     const params = {
         client_id: config["github_client_id"],
         redirect_uri: `${window.location.protocol}//${window.location.host}`,
-        scope: "user:email,read:org",
+        scope: "user,read:org",
         state
     };
     const urlPrefix = "https://github.com/login/oauth/authorize";


### PR DESCRIPTION
We now require the full `user` scope but I missed this last bit which ensures the web app gets the appropriate scope!

![gif-keyboard-6052135904664803074](https://cloud.githubusercontent.com/assets/54036/18890124/ddfc6292-84b4-11e6-8fc1-60a6d6c4427c.gif)