### PR TITLE
[WIP] Ensure the hab versions inside and outside of a studio match

### DIFF
--- a/components/bintray-publish/bin/publish-studio.sh
+++ b/components/bintray-publish/bin/publish-studio.sh
@@ -153,6 +153,8 @@ _main() {
 
   info "Pushing ${docker_image}:$docker_image_version"
   docker push "${docker_image}:$docker_image_version"
+  info "Pushing ${docker_image}:$docker_image_short_version tag for $docker_image_version"
+  docker push "${docker_image}:$docker_image_short_version"
   info "Pushing latest tag for $docker_image_version"
   docker push "${docker_image}:latest"
 

--- a/components/hab/src/command/studio.rs
+++ b/components/hab/src/command/studio.rs
@@ -111,6 +111,7 @@ mod inner {
     use hcore::env as henv;
     use hcore::fs::{CACHE_KEY_PATH, find_command};
 
+    use VERSION;
     use error::{Error, Result};
     use exec;
 
@@ -122,7 +123,8 @@ mod inner {
 
     pub fn start(_ui: &mut UI, args: Vec<OsString>) -> Result<()> {
         let docker = henv::var(DOCKER_CMD_ENVVAR).unwrap_or(DOCKER_CMD.to_string());
-        let image = henv::var(DOCKER_IMAGE_ENVVAR).unwrap_or(DOCKER_IMAGE.to_string());
+        let image = henv::var(DOCKER_IMAGE_ENVVAR)
+            .unwrap_or(format!("{}:{}", DOCKER_IMAGE, VERSION));
 
         let cmd = match find_command(&docker) {
             Some(cmd) => cmd,

--- a/components/studio/build-docker-image.sh
+++ b/components/studio/build-docker-image.sh
@@ -82,6 +82,7 @@ info "Purging container hab cache"
 rm -rf $FS_ROOT/hab/cache
 
 ident="$(hab pkg path core/hab-studio | rev | cut -d '/' -f 1-4 | rev)"
+short_version=$(echo $ident | awk -F/ '{print $3}')
 version=$(echo $ident | awk -F/ '{print $3 "-" $4}')
 
 cat <<EOF > $tmp_root/Dockerfile
@@ -100,9 +101,13 @@ docker build --no-cache -t ${IMAGE_NAME}:$version .
 info "Tagging latest image to ${IMAGE_NAME}:$version"
 docker tag ${IMAGE_NAME}:$version ${IMAGE_NAME}:latest
 
+info "Tagging latest image to ${IMAGE_NAME}:$short_version"
+docker tag ${IMAGE_NAME}:$version ${IMAGE_NAME}:$short_version
+
 cat <<-EOF > "$start_dir/results/last_image.env"
 docker_image=$IMAGE_NAME
 docker_image_version=$version
+docker_image_short_version=$short_version
 EOF
 
 info


### PR DESCRIPTION
This work is part of resolving https://github.com/habitat-sh/habitat/issues/1167

As this stands right now, instead of providing a separate `hab studio update` command, we add an additional tag to the studio docker image when we publish it to our docker registry.  The additional tag is the short version of hab, e.g. `0.9.0`.

Then, when running `hab studio enter`, we specify that the version of the studio image we want is the same as the version of hab that ran `hab studio enter`.  Docker will take care of downloading the appropriate image if necessary, which means manually running `docker pull` is no longer needed.

I've manually verified that the modifications to the `hab` command work (pulling the correct docker image version) against a local docker registry, but I haven't tested the modifications to the bintray publishing process, as I'm not sure how to do that.

At this point, I'm interested in feedback if this is a good direction to go in vs having another command to type.  To me, it feels simpler and should just Do The Right Thing™.

Thoughts?

Signed-off-by: Josh Black <raskchanky@gmail.com>