### PR TITLE
Require less broad OAuth scopes

### DIFF
--- a/components/builder-protocol/src/net.rs
+++ b/components/builder-protocol/src/net.rs
@@ -50,7 +50,7 @@ impl error::Error for NetError {
             ErrCode::ENTITY_CONFLICT => "Entity already exists in datastore.",
             ErrCode::ZMQ => "Network error.",
             ErrCode::DATA_STORE => "Database error.",
-            ErrCode::AUTH_SCOPE => "Additional authorization scope required for action.",
+            ErrCode::AUTH_SCOPE => "Additional authorization scope(s) required for action.",
         }
     }
 }

--- a/components/builder-web/app/util.ts
+++ b/components/builder-web/app/util.ts
@@ -18,12 +18,18 @@ import config from "./config";
 import {Project} from "./records/Project";
 import {AppStore} from "./AppStore";
 
+// These OAuth scopes are required for a user to be authenticated. If this list is updated, then
+// the back-end also needs to be updated in `components/net/src/oauth/github.rs`. Both the
+// front-end app and back-end app should have identical requirements to make things easier for
+// our users and less cumbersome for us to message out.
+const AUTH_SCOPES = ["user:email", "read:org"];
+
 // Create a GitHub login URL
 export function createGitHubLoginUrl(state) {
     const params = {
         client_id: config["github_client_id"],
         redirect_uri: `${window.location.protocol}//${window.location.host}`,
-        scope: "user,read:org",
+        scope: AUTH_SCOPES.join(","),
         state
     };
     const urlPrefix = "https://github.com/login/oauth/authorize";

--- a/components/hab/src/command/cli.rs
+++ b/components/hab/src/command/cli.rs
@@ -82,8 +82,8 @@ pub mod setup {
                       public depot, doing so allows you to collaborate with the Habitat \
                       community. In addition, it is how you can perform continuous deployment \
                       with Habitat."));
-        try!(ui.para("The depot uses GitHub authentication with an access token with the \
-                      user scope (https://help.github.\
+        try!(ui.para("The depot uses GitHub authentication by personal access token with the \
+                      user:email and read:org scopes (https://help.github.\
                       com/articles/creating-an-access-token-for-command-line-use/)."));
         try!(ui.para("If you would like to share your packages on the depot, please enter your \
                       GitHub access token. Otherwise, just enter No."));

--- a/components/net/src/error.rs
+++ b/components/net/src/error.rs
@@ -35,7 +35,6 @@ pub enum Error {
     MaxHops,
     Net(net::NetError),
     HTTP(hyper::status::StatusCode),
-    MissingScope(String),
     Protobuf(protobuf::ProtobufError),
     RequiredConfigField(&'static str),
     Sys,
@@ -54,7 +53,6 @@ impl fmt::Display for Error {
             Error::MaxHops => format!("Received a message containing too many network hops"),
             Error::Net(ref e) => format!("{}", e),
             Error::HTTP(ref e) => format!("{}", e),
-            Error::MissingScope(ref e) => format!("Missing GitHub permission: {}", e),
             Error::Protobuf(ref e) => format!("{}", e),
             Error::RequiredConfigField(ref e) => {
                 format!("Missing required field in configuration, {}", e)
@@ -76,7 +74,6 @@ impl error::Error for Error {
             Error::JsonDecode(ref err) => err.description(),
             Error::MaxHops => "Received a message containing too many network hops",
             Error::Net(ref err) => err.description(),
-            Error::MissingScope(_) => "Missing GitHub authorization scope.",
             Error::Protobuf(ref err) => err.description(),
             Error::RequiredConfigField(_) => "Missing required field in configuration.",
             Error::Sys => "Internal system error",

--- a/www/source/docs/share-packages-overview.html.md
+++ b/www/source/docs/share-packages-overview.html.md
@@ -26,7 +26,7 @@ You can create your own origin in the depot or be invited to join an existing on
 
 ## Setting up hab to authenticate to the depot
 
-Because the depot uses GitHub to authenticate, you must generate a [GitHub access token](https://help.github.com/articles/creating-an-access-token-for-command-line-use/) for use with the `hab` command-line utility. The only rights the GitHub personal authorization token needs at present is `user` since it is used for authentication and to determine features based on team membership.
+Because the depot uses GitHub to authenticate, you must generate a [GitHub access token](https://help.github.com/articles/creating-an-access-token-for-command-line-use/) for use with the `hab` command-line utility. The GitHub personal access token needs the `user:email` and `read:org` scopes. Habitat uses this for authentication and to determine features based on team membership.
 
 Once you have this token, you can set the `HAB_AUTH_TOKEN` [environment variable](/docs/reference/environment-vars/) to this value, so that any commands requiring authentication will use it.
 

--- a/www/source/tutorials/getting-started/linux/setup-environment.html.md.erb
+++ b/www/source/tutorials/getting-started/linux/setup-environment.html.md.erb
@@ -22,7 +22,7 @@ The `hab` command-line interface (CLI) tool downloads its other components when 
 
     <%= partial "/shared/setup_environment_script_step" %>
 
-    > Note: The only rights the GitHub personal authorization token needs at present is `user` since it is used for authentication and to determine features based on team membership. Also, you can opt-out of providing usage data at a later point in time by re-running the `hab setup` subcommand and typing `No` when asked if you want to provide usage data.
+    > Note: The GitHub personal access token needs the `user:email` and `read:org` scopes. Habitat uses this for authentication and to determine features based on team membership. Also, you can opt-out of providing usage data at a later point in time by re-running the `hab setup` subcommand and typing `No` when asked if you want to provide usage data.
 
 That's it. You're all set up and ready to create your first package. The first step in that process is to create a plan.
 

--- a/www/source/tutorials/getting-started/mac/setup-environment.html.md.erb
+++ b/www/source/tutorials/getting-started/mac/setup-environment.html.md.erb
@@ -27,7 +27,7 @@ The `hab` command-line interface (CLI) tool downloads its other components when 
 
    <%= partial "/shared/setup_environment_script_step" %>
 
-   > Note: The only rights the GitHub personal authorization token needs at present is `user` since it is used for authentication and to determine features based on team membership. Also, you can opt-out of providing usage data at a later point in time by re-running the `hab setup` subcommand and typing `No` when asked if you want to provide usage data.
+   > Note: The GitHub personal access token needs the `user:email` and `read:org` scopes. Habitat uses this for authentication and to determine features based on team membership. Also, you can opt-out of providing usage data at a later point in time by re-running the `hab setup` subcommand and typing `No` when asked if you want to provide usage data.
 
 That's it. You're all set up and ready to create your first package. The first step in that process is to create a plan.
 


### PR DESCRIPTION
Previously we required the `user:email` scope on the API and
`user:email`/`read:org` on the front-end application. When feature flags
were added we needed the ability to read which GitHub teams a user was a
part of in order to determine which features flags to grant the user.

To accomplish this we began requiring the full `user` scope on the
back-end which is one way to grant permissions to read a user's teams,
but it also requires the user to allow us full read/write to their user
profile.

This change ensures the front-end and the back-end both require the same
OAuth scopes and removes the requirement for full access to the `user`
scope. We once again only require `user:email` and `read:org`

![gif-keyboard-13473140267849866289](https://cloud.githubusercontent.com/assets/54036/18895407/3ecee068-84ce-11e6-9f78-950f78815b4b.gif)
