### PR TITLE
Fix bug with inclusion of whitespace in VERSION constant

### DIFF
--- a/components/build.rs
+++ b/components/build.rs
@@ -10,7 +10,7 @@ fn main() {
         _ => read_version(),
     };
     let mut f = File::create(Path::new(&env::var("OUT_DIR").unwrap()).join("VERSION")).unwrap();
-    f.write_all(version.as_bytes()).unwrap();
+    f.write_all(version.trim().as_bytes()).unwrap();
 }
 
 fn read_version() -> String {

--- a/components/builder-admin/build.rs
+++ b/components/builder-admin/build.rs
@@ -38,5 +38,5 @@ fn write_version_file() {
         _ => read_version(),
     };
     let mut f = File::create(Path::new(&env::var("OUT_DIR").unwrap()).join("VERSION")).unwrap();
-    f.write_all(version.as_bytes()).unwrap();
+    f.write_all(version.trim().as_bytes()).unwrap();
 }

--- a/components/builder-api/build.rs
+++ b/components/builder-api/build.rs
@@ -38,5 +38,5 @@ fn write_version_file() {
         _ => read_version(),
     };
     let mut f = File::create(Path::new(&env::var("OUT_DIR").unwrap()).join("VERSION")).unwrap();
-    f.write_all(version.as_bytes()).unwrap();
+    f.write_all(version.trim().as_bytes()).unwrap();
 }

--- a/components/builder-depot/build.rs
+++ b/components/builder-depot/build.rs
@@ -38,5 +38,5 @@ fn write_version_file() {
         _ => read_version(),
     };
     let mut f = File::create(Path::new(&env::var("OUT_DIR").unwrap()).join("VERSION")).unwrap();
-    f.write_all(version.as_bytes()).unwrap();
+    f.write_all(version.trim().as_bytes()).unwrap();
 }


### PR DESCRIPTION
The VERSION constant is inlined by including the contents of a VERSION
file which may or may not have newline characters or other whitespace
which can lead to issues when consuming the VERSION constant.

This will trim any whitespace before setting the constant.

(related to #1291)