### PR TITLE
Remove unconditional reference to sudo(8).

### DIFF
--- a/www/source/docs/create-packages-build.html.md
+++ b/www/source/docs/create-packages-build.html.md
@@ -13,8 +13,6 @@ As part of building a package, it needs to be signed with a secret origin key at
 
     hab origin key generate originname
 
-   > Note: If your host machine is Linux, you must run the `hab` CLI as root through the `sudo` command.
-
 The `hab-origin` subcommand will place originname-_timestamp_.sig.key and originname-_timestamp_.pub files (the origin key pair) in the `$HOME/.hab/cache/keys` directory. If you're creating origin keys in the studio container or you are running as root on a Linux machine, your keys will be stored in `/hab/cache/keys`.
 
 Because the secret key is used to sign your package, it should not be shared freely; however, if anyone wants to download and use your package, then they must have your public key (.pub) installed in their local `$HOME/.hab/cache/keys` or `/hab/cache/keys` directory. Public keys will be downloaded from the depot by the supervisor, if needed.


### PR DESCRIPTION
I could only find one applicable reference to the unconditional use of `sudo` in the docs. This can be removed now that we have fixed #1269