### PR TITLE
SWIM as an independent library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,33 +1,16 @@
 [root]
-name = "habitat_sup"
-version = "0.0.0"
+name = "habitat_swim"
+version = "0.1.0"
 dependencies = [
- "ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "clap 2.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "habitat_common 0.0.0",
  "habitat_core 0.0.0",
- "habitat_depot_client 0.0.0",
- "handlebars 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "iron 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.1.77 (registry+https://github.com/rust-lang/crates.io-index)",
- "router 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "temp_utp 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "threadpool 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "users 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "wonder 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -42,6 +25,14 @@ dependencies = [
 name = "ansi_term"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "aster"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "syntex_syntax 0.43.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "bitflags"
@@ -66,7 +57,7 @@ dependencies = [
  "iron 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "persistent 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "plugin 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.8.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.8.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -77,7 +68,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "clap"
-version = "2.13.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -114,7 +105,7 @@ dependencies = [
  "openssl 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -152,7 +143,7 @@ dependencies = [
 
 [[package]]
 name = "fnv"
-version = "1.0.5"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -177,7 +168,7 @@ dependencies = [
  "bitflags 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "libgit2-sys 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -185,7 +176,7 @@ name = "hab"
 version = "0.0.0"
 dependencies = [
  "ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "clap 2.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat_common 0.0.0",
  "habitat_core 0.0.0",
@@ -199,7 +190,7 @@ dependencies = [
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "temp_utp 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -209,7 +200,7 @@ name = "habitat_builder_admin"
 version = "0.0.0"
 dependencies = [
  "bodyparser 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "clap 2.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat_builder_protocol 0.0.0",
  "habitat_core 0.0.0",
@@ -223,8 +214,8 @@ dependencies = [
  "protobuf 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "router 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.8.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_codegen 0.8.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.8.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_codegen 0.8.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "staticfile 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -238,7 +229,7 @@ name = "habitat_builder_api"
 version = "0.0.0"
 dependencies = [
  "bodyparser 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "clap 2.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat_builder_protocol 0.0.0",
  "habitat_core 0.0.0",
@@ -254,8 +245,8 @@ dependencies = [
  "redis 0.7.0 (git+https://github.com/habitat-sh/redis-rs?branch=habitat)",
  "router 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.8.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_codegen 0.8.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.8.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_codegen 0.8.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "staticfile 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -283,7 +274,7 @@ dependencies = [
 name = "habitat_builder_jobsrv"
 version = "0.0.0"
 dependencies = [
- "clap 2.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat_builder_dbcache 0.0.0",
  "habitat_builder_protocol 0.0.0",
@@ -314,7 +305,7 @@ dependencies = [
 name = "habitat_builder_router"
 version = "0.0.0"
 dependencies = [
- "clap 2.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat_builder_dbcache 0.0.0",
  "habitat_builder_protocol 0.0.0",
@@ -332,7 +323,7 @@ name = "habitat_builder_sessionsrv"
 version = "0.0.0"
 dependencies = [
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "clap 2.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat_builder_dbcache 0.0.0",
  "habitat_builder_protocol 0.0.0",
@@ -352,7 +343,7 @@ dependencies = [
 name = "habitat_builder_vault"
 version = "0.0.0"
 dependencies = [
- "clap 2.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat_builder_dbcache 0.0.0",
  "habitat_builder_protocol 0.0.0",
@@ -370,7 +361,7 @@ dependencies = [
 name = "habitat_builder_worker"
 version = "0.0.0"
 dependencies = [
- "clap 2.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "git2 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat_builder_protocol 0.0.0",
@@ -422,8 +413,8 @@ dependencies = [
  "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "users 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "users 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -431,7 +422,7 @@ name = "habitat_depot"
 version = "0.0.0"
 dependencies = [
  "bodyparser 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "clap 2.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat_builder_dbcache 0.0.0",
  "habitat_builder_protocol 0.0.0",
@@ -454,13 +445,13 @@ dependencies = [
  "router 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.8.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_codegen 0.8.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.8.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_codegen 0.8.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "urlencoded 0.4.0 (git+https://github.com/habitat-sh/urlencoded.git?branch=habitat)",
  "uuid 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -480,7 +471,7 @@ dependencies = [
  "pbr 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "tee 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -488,7 +479,7 @@ name = "habitat_director"
 version = "0.0.0"
 dependencies = [
  "ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "clap 2.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat_common 0.0.0",
  "habitat_core 0.0.0",
@@ -514,7 +505,7 @@ dependencies = [
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -522,7 +513,7 @@ name = "habitat_net"
 version = "0.0.0"
 dependencies = [
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fnv 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat_builder_protocol 0.0.0",
  "hyper 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "iron 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -539,14 +530,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "habitat_sup"
+version = "0.0.0"
+dependencies = [
+ "ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "habitat_common 0.0.0",
+ "habitat_core 0.0.0",
+ "habitat_depot_client 0.0.0",
+ "handlebars 0.20.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iron 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.77 (registry+https://github.com/rust-lang/crates.io-index)",
+ "router 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "temp_utp 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "threadpool 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "users 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wonder 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "handlebars"
-version = "0.21.0"
+version = "0.20.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "pest 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.77 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -582,7 +606,7 @@ dependencies = [
  "traitobject 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -609,7 +633,7 @@ dependencies = [
  "num_cpus 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "plugin 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "typemap 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -764,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "num"
-version = "0.1.36"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-bigint 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -772,7 +796,7 @@ dependencies = [
  "num-integer 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-iter 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-rational 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -781,7 +805,7 @@ version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-integer 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -791,7 +815,7 @@ name = "num-complex"
 version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-traits 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -800,7 +824,7 @@ name = "num-integer"
 version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-traits 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -809,7 +833,7 @@ version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-integer 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -819,13 +843,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-bigint 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-integer 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.1.36"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -961,13 +985,28 @@ version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "quick-error"
-version = "1.1.0"
+name = "quasi"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "syntex_errors 0.43.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syntex_syntax 0.43.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
-name = "quote"
-version = "0.2.3"
+name = "quasi_codegen"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aster 0.26.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syntex 0.43.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syntex_errors 0.43.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syntex_syntax 0.43.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1001,7 +1040,7 @@ version = "0.7.0"
 source = "git+https://github.com/habitat-sh/redis-rs?branch=habitat#d87dcb6db739f879743b3d152090fb10138b1771"
 dependencies = [
  "sha1 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1033,7 +1072,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "iron 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "route-recognizer 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1078,27 +1117,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "0.8.11"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde_codegen"
-version = "0.8.11"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "quote 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_codegen_internals 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "syntex 0.44.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "syntex_syntax 0.44.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aster 0.26.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quasi 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quasi_codegen 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_codegen_internals 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syntex 0.43.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syntex_syntax 0.43.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_codegen_internals"
-version = "0.9.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "syn 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syntex_errors 0.43.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syntex_syntax 0.43.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1108,8 +1149,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dtoa 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.8.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.8.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1145,7 +1186,7 @@ dependencies = [
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mount 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1154,39 +1195,30 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "syn"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "quote 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "syntex"
-version = "0.44.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "syntex_errors 0.44.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "syntex_syntax 0.44.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syntex_errors 0.43.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syntex_syntax 0.43.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "syntex_errors"
-version = "0.44.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "syntex_pos 0.44.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syntex_pos 0.43.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "syntex_pos"
-version = "0.44.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1194,15 +1226,15 @@ dependencies = [
 
 [[package]]
 name = "syntex_syntax"
-version = "0.44.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "syntex_errors 0.44.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "syntex_pos 0.44.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syntex_errors 0.43.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syntex_pos 0.43.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1219,7 +1251,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "num 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1360,7 +1392,7 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "1.2.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "idna 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1375,7 +1407,7 @@ dependencies = [
  "bodyparser 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "iron 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "plugin 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1386,7 +1418,7 @@ dependencies = [
  "bodyparser 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "iron 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "plugin 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1400,7 +1432,7 @@ dependencies = [
 
 [[package]]
 name = "users"
-version = "0.5.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1474,12 +1506,13 @@ dependencies = [
 [metadata]
 "checksum aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ca972c2ea5f742bfce5687b9aef75506a764f61d37f8f649047846a9686ddb66"
 "checksum ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "23ac7c30002a5accbf7e8987d0632fa6de155b7c3d39d0067317a391e00a2ef6"
+"checksum aster 0.26.1 (registry+https://github.com/rust-lang/crates.io-index)" = "baa18cafee9499ac766e76117577b84efa98f43b81964cf167cd800b29176db3"
 "checksum bitflags 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2a6577517ecd0ee0934f48a7295a89aaef3e6dfafeac404f94c0b3448518ddfe"
 "checksum bitflags 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4f67931368edf3a9a51d29886d245f1c3db2f1ef0dcc9e35ff70341b78c10d23"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum bodyparser 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "07b171b407e583dc8f01011a713f20575a81ac60acecf3b8153012709aeb1fd6"
 "checksum broadcast 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fb214f702da3cc6aa1666520f40ea66f506644db5e1065be4bbc972f7ec3750b"
-"checksum clap 2.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2887ae5b606c1fa314b9238e25a8be3fa673378415c32efc5749464f3365ee9d"
+"checksum clap 2.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bbc90fa76af314f6e1d09fb3e739d145b25e0f8630a108ade30a3b58569b7b90"
 "checksum cmake 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "dfcf5bcece56ef953b8ea042509e9dcbdfe97820b7e20d86beb53df30ed94978"
 "checksum conduit-mime-types 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "95ca30253581af809925ef68c2641cc140d6183f43e12e0af4992d53768bd7b8"
 "checksum cookie 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0e3d6405328b6edb412158b3b7710e2634e23f3614b9bb1c412df7952489a626"
@@ -1487,11 +1520,11 @@ dependencies = [
 "checksum env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "15abd780e45b3ea4f76b4e9a26ff4843258dd8a3eed2775a0e7368c2e7936c2f"
 "checksum errno 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1e2b2decb0484e15560df3210cf0d78654bb0864b2c138977c07e377a1bae0e2"
 "checksum error 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "a6e606f14042bb87cc02ef6a14db6c90ab92ed6f62d87e69377bc759fd7987cc"
-"checksum fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6cc484842f1e2884faf56f529f960cc12ad8c71ce96cc7abba0a067c98fee344"
+"checksum fnv 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8e8af7b5408ab0c4910cad114c8f9eb454bf75df7afe8964307eeafb68a13a5e"
 "checksum gcc 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)" = "91ecd03771effb0c968fd6950b37e89476a578aaf1c70297d8e92b6516ec3312"
 "checksum gdi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0912515a8ff24ba900422ecda800b52f4016a56251922d397c576bf92c690518"
 "checksum git2 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "33a96eeef227403006cdb59ea6e05baad8cddde6b79abed753d96ccee136bad2"
-"checksum handlebars 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bab872a49fe1eb585e6c23c03f7a062528aafcbdba9456e6bb763b92c054abf2"
+"checksum handlebars 0.20.5 (registry+https://github.com/rust-lang/crates.io-index)" = "07f9c1d28bcfb97143c95ed0667141677b2b5675c7ba3d5b81459ad43b1073bd"
 "checksum hpack 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d2da7d3a34cf6406d9d700111b8eafafe9a251de41ae71d8052748259343b58"
 "checksum httparse 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "46534074dbb80b070d60a5cb8ecadd8963a00a438ae1a95268850a7ef73b67ae"
 "checksum hyper 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)" = "eb27e8a3e8f17ac43ffa41bbda9cf5ad3f9f13ef66fa4873409d4902310275f7"
@@ -1517,13 +1550,13 @@ dependencies = [
 "checksum mime 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b5c93a4bd787ddc6e7833c519b73a50883deb5863d76d9b71eb8216fb7f94e66"
 "checksum modifier 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "41f5c9112cb662acd3b204077e0de5bc66305fa8df65c8019d5adb10e9ab6e58"
 "checksum mount 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c518ef1edf5da3aa1cdd5160c08d1781995ccb74b5669c2315ce29fe6cf6c1f2"
-"checksum num 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "bde7c03b09e7c6a301ee81f6ddf66d7a28ec305699e3d3b056d2fc56470e3120"
+"checksum num 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "5a9699207fab8b02bd0e56f8f06fee3f26d640303130de548898b4c9704f6d01"
 "checksum num-bigint 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "88b14378471f7c2adc5262f05b4701ef53e8da376453a8d8fee48e51db745e49"
 "checksum num-complex 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "f0c78e054dd19c3fd03419ade63fa661e9c49bb890ce3beb4eee5b7baf93f92f"
 "checksum num-integer 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "fb24d9bfb3f222010df27995441ded1e954f8f69cd35021f6bef02ca9552fb92"
 "checksum num-iter 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "287a1c9969a847055e1122ec0ea7a5c5d6f72aad97934e131c83d5c08ab4e45c"
 "checksum num-rational 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "54ff603b8334a72fbb27fe66948aac0abaaa40231b3cecd189e76162f6f38aaf"
-"checksum num-traits 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "a16a42856a256b39c6d3484f097f6713e14feacd9bfb02290917904fae46c81c"
+"checksum num-traits 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "8359ea48994f253fa958b5b90b013728b06f54872e5a58bce39540fcdd0f2527"
 "checksum num_cpus 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "cee7e88156f3f9e19bdd598f8d6c9db7bf4078f99f8381f43a55b09648d1a6e3"
 "checksum num_cpus 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8890e6084723d57d0df8d2720b0d60c6ee67d6c93e7169630e4371e88765dcad"
 "checksum openssl 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)" = "c4117b6244aac42ed0150a6019b4d953d28247c5dd6ae6f46ae469b5f2318733"
@@ -1539,8 +1572,9 @@ dependencies = [
 "checksum plugin 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "1a6a0dc3910bc8db877ffed8e457763b317cf880df4ae19109b9f77d277cf6e0"
 "checksum pnacl-build-helper 1.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "61c9231d31aea845007443d62fcbb58bb6949ab9c18081ee1e09920e0cf1118b"
 "checksum protobuf 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)" = "6ec4c2fe04370298218a09ab53a534febf54c160c5554e4de987b6d73c916d5d"
+"checksum quasi 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f9b160391362abca7c0e30cead65872b01b03f8371dee7441e130601c9b4d173"
+"checksum quasi_codegen 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bcc10982c4b09697fb79d7725ea5e33ef2b1ff934fdddefa3e83d4f8c50b8d34"
 "checksum quick-error 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0aad603e8d7fb67da22dbdf1f4b826ce8829e406124109e73cf1b2454b93a71c"
-"checksum quote 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4c5cf478fe1006dbcc72567121d23dbdae5f1632386068c5c86ff4f645628504"
 "checksum r2d2 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a63c7dd6655b3165145c5c140e8548ba2176a263682c07aaead2fe79eedd97bc"
 "checksum r2d2_redis 0.4.0 (git+https://github.com/habitat-sh/r2d2-redis.git?branch=habitat)" = "<none>"
 "checksum rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "2791d88c6defac799c3f20d74f094ca33b9332612d9aef9078519c82e4fe04a5"
@@ -1555,20 +1589,19 @@ dependencies = [
 "checksum semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "d4f410fedcf71af0345d7607d246e7ad15faaadd49d240ee3b24e5dc21a820ac"
 "checksum sequence_trie 0.0.13 (registry+https://github.com/rust-lang/crates.io-index)" = "d5b4eb0f7d1ff9b9666d8b8ff543f3705dd464025269a5b0e1988ffa60ca1be8"
 "checksum serde 0.7.15 (registry+https://github.com/rust-lang/crates.io-index)" = "1b0e0732aa8ec4267f61815a396a942ba3525062e3bd5520aa8419927cfc0a92"
-"checksum serde 0.8.11 (registry+https://github.com/rust-lang/crates.io-index)" = "15db662ce4b837aac5731c52fe732d84a00f909763236289587cb7ca6985f6d8"
-"checksum serde_codegen 0.8.11 (registry+https://github.com/rust-lang/crates.io-index)" = "c3593f88d23a7e721e17fbf7fe01856d32b58e18ee1b4684f894e724e49bc160"
-"checksum serde_codegen_internals 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b7fb3bda24f9eee7446793d209f7edac5400f85f002bff1c3d59ec678c728c9e"
+"checksum serde 0.8.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8523fd515099dac5b5abd25b0b9f9709d40eedf03f72ca519903bf138a6577be"
+"checksum serde_codegen 0.8.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3c1b749326ac14ace12e5117d3e14a4509853ba0bea54c335d27dad66bd9fdfa"
+"checksum serde_codegen_internals 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8488640b7caaa438eb05c74466f9fa91a61bb4e4e7520f3c1cfcf77fb10bdb61"
 "checksum serde_json 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e5b3bb42fa42265df8a1822b3db2090bc8f9e17e8142599c76a5b854bc4e7b5b"
 "checksum sha1 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cc30b1e1e8c40c121ca33b86c23308a090d19974ef001b4bf6e61fd1a0fb095c"
 "checksum sodiumoxide 0.0.12 (registry+https://github.com/rust-lang/crates.io-index)" = "8d9da099120def269669aa349e0c3e97de4ab2c5cb9a54a765041651dd0055eb"
 "checksum solicit 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "172382bac9424588d7840732b250faeeef88942e37b6e35317dce98cafdd75b2"
 "checksum staticfile 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7638ee7543e08b10d13f9e6c4488534d47c2269b258bf76a6fb998bfd7f54937"
 "checksum strsim 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "50c069df92e4b01425a8bf3576d5d417943a6a7272fbabaf5bd80b1aaa76442e"
-"checksum syn 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b13c81b5c030f09cd7d6f11db2fd5f20cd92e967f49cc0033fcf31a1abe0cf70"
-"checksum syntex 0.44.0 (registry+https://github.com/rust-lang/crates.io-index)" = "84f37b94d7ee762bcac58741f73a95465cf87188c3b93f10df9245aff821b2b4"
-"checksum syntex_errors 0.44.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d0d95d2141ae79f312a01c6934d9984f9d7f5cfaf0c74aae5fbbc234a6dcb77a"
-"checksum syntex_pos 0.44.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3e2cbf0598c5970f2dca122a4e6f7e93bf42f2d0b2dd88c3ea112413152864df"
-"checksum syntex_syntax 0.44.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5e25a819be16cba4729d5d0a59d9559b463250e90419cd4cc67ac258c6397e55"
+"checksum syntex 0.43.0 (registry+https://github.com/rust-lang/crates.io-index)" = "64ecf1787b4b8b8d865a2a05b1d9429bc2abef50caebd4c6b53ecea805a05aa3"
+"checksum syntex_errors 0.43.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cad40c64b27f251ee286cf18e157e40fe3586bd1ad89e2318d336829e4f6bb41"
+"checksum syntex_pos 0.43.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6e56b7e73e8826c0bdd111da685becee1d42a42200139f72687242b6c0394247"
+"checksum syntex_syntax 0.43.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b1590efa9a3862c1f812abb205e16e15c81a36a6c22cdaa28962c2eb80f1453e"
 "checksum tee 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "37c12559dba7383625faaff75be24becf35bfc885044375bcab931111799a3da"
 "checksum temp_utp 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "36fdead2a3a40ad303ffc4012c59fbf962f5f6084f4d558c9c8859a0f9240884"
 "checksum tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "87974a6f5c1dfb344d733055601650059a3363de2a6104819293baff662132d6"
@@ -1590,11 +1623,11 @@ dependencies = [
 "checksum unicode-width 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2d6722facc10989f63ee0e20a83cd4e1714a9ae11529403ac7e0afd069abc39e"
 "checksum unicode-xid 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "36dff09cafb4ec7c8cf0023eb0b686cb6ce65499116a12201c9e11840ca01beb"
 "checksum unsafe-any 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b351086021ebc264aea3ab4f94d61d889d98e5e9ec2d985d993f50133537fd3a"
-"checksum url 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8527c62d9869a08325c38272b3f85668df22a65890c61a639d233dc0ed0b23a2"
+"checksum url 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "afe9ec54bc4db14bc8744b7fed060d785ac756791450959b2248443319d5b119"
 "checksum urlencoded 0.4.0 (git+https://github.com/habitat-sh/urlencoded.git?branch=habitat)" = "<none>"
 "checksum urlencoded 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5ddcf2d3a0beedb5cdf50cabc521ab76a994907877a1d91d996c251d42c70e2e"
 "checksum user32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4ef4711d107b21b410a3a974b1204d9accc8b10dad75d8324b5d755de1617d47"
-"checksum users 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7ae8fdf783cb9652109c99886459648feb92ecc749e6b8e7930f6decba74c7c"
+"checksum users 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d6d73ff26a6a57e6328f6e0b31738dfe27478e90ea828c3aba85a774d815c971"
 "checksum utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a1ca13c08c41c9c3e04224ed9ff80461d97e121589ff27c753a16cb10830ae0f"
 "checksum uuid 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1a9ff57156caf7e22f37baf3c9d8f6ce8194842c23419dafcb0716024514d162"
 "checksum vec_map 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cac5efe5cb0fa14ec2f84f83c701c562ee63f6dcc680861b21d65c682adfb05f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,5 @@ members = [
   "components/http-client",
   "components/net",
   "components/sup",
+  "components/swim",
 ]

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ else
 endif
 
 BIN = director hab sup
-LIB = builder-dbcache builder-protocol common core builder-depot-client http-client net
+LIB = builder-dbcache builder-protocol common core builder-depot-client http-client net swim
 SRV = builder-api builder-admin builder-depot builder-router builder-jobsrv builder-sessionsrv builder-vault builder-worker
 ALL = $(BIN) $(LIB) $(SRV)
 VERSION := $(shell cat VERSION)

--- a/components/swim/Cargo.toml
+++ b/components/swim/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "habitat_swim"
+version = "0.1.0"
+authors = ["Adam Jacob <adam@chef.io>"]
+build = "build.rs"
+workspace = "../../"
+
+[[bin]]
+name = "swim"
+doc = false
+
+[build-dependencies]
+pkg-config = "0.3"
+
+[dependencies]
+protobuf = "*"
+rustc-serialize = "*"
+rand = "*"
+log = "*"
+env_logger = "*"
+time = "*"
+
+[dependencies.uuid]
+version = "*"
+features = ["rustc-serialize", "v4"]
+
+[dependencies.habitat_core]
+path = "../core"
+
+[features]
+functional = []
+protocols = []
+

--- a/components/swim/bin/trace-sequence.rb
+++ b/components/swim/bin/trace-sequence.rb
@@ -1,0 +1,57 @@
+#!/usr/bin/env ruby
+# Copyright (c) 2016 Chef Software Inc. and/or applicable contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# cat *.swimtrace | sort | ruby ~/src/habitat/components/swim/bin/trace-sequence.rb >! sequence.txt | java -DPLANTUML_LIMIT_SIZE=81920 -Xmx1024m  -jar ~/Downloads/plantuml.jar -verbose sequence.txt
+
+output = [];
+actors = {};
+
+$stdin.each_line do |line|
+  line =~ /(.+)!\*!(.+)!\*!(.+)!\*!(.+)!\*!(.+)!\*!(.+)!\*!(.+)!\*!(.+)!\*!(.+)!\*!(.+)/
+  time_string = $1
+  module_path = $2
+  line = $3
+  server_name = $4
+  server_id = $5
+  listening = $6
+  thread_name = $7
+  msg_type = $8
+  to_addr = $9
+  payload = $10
+
+  actors[listening] = true;
+  case msg_type
+  when /^probe-marked-confirmed$/
+    output.push "\"#{listening}\" -[#red]-> \"#{to_addr}\" : #{msg_type}"
+  when /^probe-marked-suspect$/
+    output.push "\"#{listening}\" -[#orange]-> \"#{to_addr}\" : #{msg_type}"
+  when /^probe.+/
+    output.push "\"#{listening}\" -[#black]-> \"#{to_addr}\" : #{msg_type}"
+  when /.+ping$/
+    output.push "\"#{listening}\" -[#blue]-> \"#{to_addr}\" : #{msg_type}"
+  when /.+ack$/
+    output.push "\"#{listening}\" -[#green]-> \"#{to_addr}\" : #{msg_type}"
+  else
+    output.push "\"#{listening}\" -[#black]-> \"#{to_addr}\" : #{msg_type}"
+  end
+end
+output.push "@enduml"
+actors.keys.sort.reverse.each do |actor|
+  output.unshift "participant \"#{actor}\""
+end
+output.unshift "@startuml"
+
+puts output.join("\n")

--- a/components/swim/build.rs
+++ b/components/swim/build.rs
@@ -1,0 +1,55 @@
+extern crate pkg_config;
+
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+fn main() {
+    if env::var("CARGO_FEATURE_PROTOCOLS").is_ok() {
+        generate_protocols();
+    }
+}
+
+fn generate_protocols() {
+    let prefix = match env::var("PROTOBUF_PREFIX").ok() {
+        Some(prefix) => prefix,
+        None => {
+            match pkg_config::get_variable("protobuf", "prefix") {
+                Ok(prefix) => prefix,
+                Err(msg) => panic!("Unable to locate protobuf, err={:?}", msg),
+            }
+        }
+    };
+
+    let out_dir = r"src/message";
+    let cmd = Command::new(format!("{}/bin/protoc", prefix))
+        .arg("--rust_out")
+        .arg(out_dir)
+        .args(&protocol_files())
+        .output();
+    match cmd {
+        Ok(out) => {
+            if !out.status.success() {
+                panic!("{:?}", out)
+            }
+        }
+        Err(e) => panic!("{}", e),
+    }
+}
+
+fn protocol_files() -> Vec<PathBuf> {
+    let mut files = vec![];
+    for entry in fs::read_dir("protocols").unwrap() {
+        let file = entry.unwrap();
+        // skip vim temp files
+        if file.file_name().to_str().unwrap().starts_with(".") {
+            continue;
+        }
+        if file.metadata().unwrap().is_file() {
+            files.push(file.path());
+        }
+    }
+    files
+}
+

--- a/components/swim/protocols/swim.proto
+++ b/components/swim/protocols/swim.proto
@@ -1,0 +1,43 @@
+syntax = "proto2";
+
+message Member {
+  optional string id = 1;
+  optional uint64 incarnation = 2;
+  optional string address = 3;
+  optional bool persistent = 4 [default = false];
+}
+
+message Ping {
+  optional Member from = 1;
+  optional Member forward_to = 2;
+}
+
+message Ack {
+  optional Member from = 1;
+  optional Member forward_to = 2;
+}
+
+message PingReq {
+  optional Member from = 1;
+  optional Member target = 2;
+}
+
+message Membership {
+  enum Health { ALIVE = 1; SUSPECT = 2; CONFIRMED = 3; };
+
+  optional Member member = 1;
+  optional Health health = 2;
+}
+
+message Swim {
+  enum Type { PING = 1; ACK = 2; PINGREQ = 3; };
+
+  // Identifies which field is filled in.
+  required Type type = 1;
+
+  // Optional
+  optional Ping ping = 2;
+  optional Ack ack = 3;
+  optional PingReq pingreq = 4;
+  repeated Membership membership = 5;
+}

--- a/components/swim/src/error.rs
+++ b/components/swim/src/error.rs
@@ -1,0 +1,69 @@
+// Copyright (c) 2016 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use protobuf;
+
+use std::error;
+use std::fmt;
+use std::io;
+use std::result;
+
+pub type Result<T> = result::Result<T, Error>;
+
+#[derive(Debug)]
+pub enum Error {
+    BadMessage(String),
+    CannotBind(io::Error),
+    ProtobufError(protobuf::ProtobufError),
+    SocketSetReadTimeout(io::Error),
+    SocketSetWriteTimeout(io::Error),
+    ServerCloneError,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let msg = match *self {
+            Error::BadMessage(ref err) => format!("Bad Message: {:?}", err),
+            Error::CannotBind(ref err) => format!("Cannot bind to port: {:?}", err),
+            Error::ProtobufError(ref err) => format!("ProtoBuf Error: {}", err),
+            Error::SocketSetReadTimeout(ref err) => {
+                format!("Cannot set UDP socket read timeout: {}", err)
+            }
+            Error::SocketSetWriteTimeout(ref err) => {
+                format!("Cannot set UDP socket write timeout: {}", err)
+            },
+            Error::ServerCloneError => format!("Cannot clone the underlying UDP socket"),
+        };
+        write!(f, "{}", msg)
+    }
+}
+
+impl error::Error for Error {
+    fn description(&self) -> &str {
+        match *self {
+            Error::BadMessage(ref _err) => "Bad Protobuf Message; should be Ping/Ack/PingReq",
+            Error::CannotBind(ref _err) => "Cannot bind to port",
+            Error::ProtobufError(ref err) => err.description(),
+            Error::SocketSetReadTimeout(ref _err) => "Cannot set UDP socket read timeout",
+            Error::SocketSetWriteTimeout(ref _err) => "Cannot set UDP socket write timeout",
+            Error::ServerCloneError => "Cannot clone the underlying UDP socket",
+        }
+    }
+}
+
+impl From<protobuf::ProtobufError> for Error {
+    fn from(err: protobuf::ProtobufError) -> Error {
+        Error::ProtobufError(err)
+    }
+}

--- a/components/swim/src/lib.rs
+++ b/components/swim/src/lib.rs
@@ -1,0 +1,48 @@
+// Copyright (c) 2016 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! This is the [SWIM](https://www.cs.cornell.edu/~asdas/research/dsn02-swim.pdf) implementation for Habitat.
+//!
+//! It implements SWIM+Susp+Inf. It uses Newscast-style "heat" tracking to share membership rumors,
+//! while trying to keep UDP packet sizes below 512 bytes. It has the following changes:
+//!
+//! 1. It uses a single membership rumor with internal logic for applying the rumors state, rather
+//!    than sending differential event messages.
+//! 1. If an "Alive" membership rumor is recieved with a higher incarnation, it takes precedent
+//!    over "Confirmed" membership rumors.
+//! 1. Members can be marked "persistent", which means that they will always be taken through the
+//!    Probe cycle, regardless of their status. This allows networks to heal from partitions.
+//!
+//! The library consists of a single SWIM Server, which has three working threads:
+//!
+//! 1. An inbound thread, handling receipt of SWIM messages.
+//! 1. An outbound thread, which handles the Ping->PingReq cycle and protocol timing.
+//! 1. An expire thread, which handles timing out suspected members.
+//!
+//! Start exploring the code base by following the thread of execution in the `server` module.
+
+#[macro_use]
+extern crate log;
+extern crate protobuf;
+extern crate rand;
+extern crate time;
+extern crate uuid;
+
+#[macro_use]
+pub mod trace;
+mod error;
+pub mod member;
+mod message;
+pub mod server;
+pub mod rumor;

--- a/components/swim/src/main.rs
+++ b/components/swim/src/main.rs
@@ -1,0 +1,50 @@
+// Copyright (c) 2016 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+extern crate env_logger;
+#[macro_use]
+extern crate log;
+extern crate habitat_swim;
+
+use std::env;
+use std::thread;
+use std::time::Duration;
+use std::net::SocketAddr;
+
+use habitat_swim::{server, member, trace};
+
+fn main() {
+    env_logger::init().unwrap();
+    let mut args = env::args();
+    let _ = args.next();
+
+    let bind_to = args.next().unwrap();
+    println!("Binding to {}", bind_to);
+
+    let server = server::Server::new(&bind_to[..], member::Member::new(), trace::Trace::default())
+        .unwrap();
+    println!("Server ID: {}", server.member.read().unwrap().get_id());
+
+    server.start(server::outbound::Timing::default()).expect("Cannot start server");
+
+    let targets: Vec<String> = args.collect();
+    for target in &targets {
+        let addr: SocketAddr = target.parse().unwrap();
+        let member = member::Member::from(addr);
+        server::outbound::ping(&server, &member, addr, None);
+    }
+    loop {
+        thread::sleep(Duration::from_millis(1000));
+    }
+}

--- a/components/swim/src/member.rs
+++ b/components/swim/src/member.rs
@@ -1,0 +1,722 @@
+// Copyright (c) 2016 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Tracks membership. Contains both the `Member` struct and the `MemberList`.
+
+use std::collections::{hash_map, HashMap};
+use std::fmt;
+use std::iter::IntoIterator;
+use std::net::SocketAddr;
+use std::ops::{Deref, DerefMut};
+use std::sync::{Arc, RwLock};
+
+use uuid::Uuid;
+use rand::{thread_rng, Rng};
+use time::SteadyTime;
+
+use rumor::RumorKey;
+use message::swim::{Member as ProtoMember, Membership as ProtoMembership,
+                    Membership_Health as ProtoMembership_Health};
+
+/// How many nodes do we target when we need to run PingReq.
+const PINGREQ_TARGETS: usize = 5;
+
+/// The health of a node.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum Health {
+    Alive,
+    Suspect,
+    Confirmed,
+}
+
+/// Maps our internal health to the wire protocols health.
+impl From<ProtoMembership_Health> for Health {
+    fn from(pm_health: ProtoMembership_Health) -> Health {
+        match pm_health {
+            ProtoMembership_Health::ALIVE => Health::Alive,
+            ProtoMembership_Health::SUSPECT => Health::Suspect,
+            ProtoMembership_Health::CONFIRMED => Health::Confirmed,
+        }
+    }
+}
+
+impl From<Health> for ProtoMembership_Health {
+    fn from(pm_health: Health) -> ProtoMembership_Health {
+        match pm_health {
+            Health::Alive => ProtoMembership_Health::ALIVE,
+            Health::Suspect => ProtoMembership_Health::SUSPECT,
+            Health::Confirmed => ProtoMembership_Health::CONFIRMED,
+        }
+    }
+}
+
+impl<'a> From<&'a Health> for ProtoMembership_Health {
+    fn from(pm_health: &'a Health) -> ProtoMembership_Health {
+        match pm_health {
+            &Health::Alive => ProtoMembership_Health::ALIVE,
+            &Health::Suspect => ProtoMembership_Health::SUSPECT,
+            &Health::Confirmed => ProtoMembership_Health::CONFIRMED,
+        }
+    }
+}
+
+impl fmt::Display for Health {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            &Health::Alive => write!(f, "Alive"),
+            &Health::Suspect => write!(f, "Suspect"),
+            &Health::Confirmed => write!(f, "Confirmed"),
+        }
+    }
+}
+
+/// A member in the swim group. Passes most of its functionality along to the internal protobuf
+/// representation.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Member {
+    pub proto: ProtoMember,
+}
+
+impl Member {
+    /// Creates a new member with a unique UUID and an incarnation of zero.
+    pub fn new() -> Member {
+        let mut proto_member = ProtoMember::new();
+        proto_member.set_id(Uuid::new_v4().simple().to_string());
+        proto_member.set_incarnation(0);
+        Member { proto: proto_member }
+    }
+
+    /// Returns the socket address of this member.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if the address is un-parseable. In practice, it shouldn't be
+    /// un-parseable, since its set from the inbound socket directly.
+    pub fn socket_address(&self) -> SocketAddr {
+        match self.get_address().parse() {
+            Ok(addr) => addr,
+            Err(e) => {
+                panic!("Cannot parse member {:?} address: {}", self, e);
+            }
+        }
+    }
+}
+
+impl Deref for Member {
+    type Target = ProtoMember;
+
+    fn deref(&self) -> &ProtoMember {
+        &self.proto
+    }
+}
+
+impl DerefMut for Member {
+    fn deref_mut(&mut self) -> &mut ProtoMember {
+        &mut self.proto
+    }
+}
+
+impl From<ProtoMember> for Member {
+    fn from(member: ProtoMember) -> Member {
+        Member { proto: member }
+    }
+}
+
+impl<'a> From<&'a ProtoMember> for Member {
+    fn from(member: &'a ProtoMember) -> Member {
+        Member { proto: member.clone() }
+    }
+}
+
+impl From<SocketAddr> for Member {
+    fn from(socket: SocketAddr) -> Member {
+        let mut member = Member::new();
+        member.set_address(format!("{}", socket));
+        member
+    }
+}
+
+impl From<Member> for RumorKey {
+    fn from(member: Member) -> RumorKey {
+        RumorKey::new("member", member.get_id())
+    }
+}
+
+impl<'a> From<&'a Member> for RumorKey {
+    fn from(member: &'a Member) -> RumorKey {
+        RumorKey::new("member", member.get_id())
+    }
+}
+
+impl<'a> From<&'a &'a Member> for RumorKey {
+    fn from(member: &'a &'a Member) -> RumorKey {
+        RumorKey::new("member", member.get_id())
+    }
+}
+
+// This is a Uuid type turned to a string
+pub type UuidSimple = String;
+
+/// Tracks lists of members, their health, and how long they have been suspect.
+#[derive(Debug, Clone)]
+pub struct MemberList {
+    members: Arc<RwLock<HashMap<UuidSimple, Member>>>,
+    health: Arc<RwLock<HashMap<UuidSimple, Health>>>,
+    suspect: Arc<RwLock<HashMap<UuidSimple, SteadyTime>>>,
+}
+
+impl MemberList {
+    /// Creates a new, empty, MemberList.
+    pub fn new() -> MemberList {
+        MemberList {
+            members: Arc::new(RwLock::new(HashMap::new())),
+            health: Arc::new(RwLock::new(HashMap::new())),
+            suspect: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    /// Inserts a member into the member list with the given health.
+    pub fn insert(&self, member: Member, health: Health) -> bool {
+        let share_rumor: bool;
+        let mut start_suspicion: bool = false;
+        let mut stop_suspicion: bool = false;
+
+        // If we have an existing member record..
+        if let Some(current_member) = self.members
+            .read()
+            .expect("Member List read lock poisoned")
+            .get(member.get_id()) {
+            // If my incarnation is newer than the member we are being asked
+            // to insert, we want to prefer our member, health and all.
+            if current_member.get_incarnation() > member.get_incarnation() {
+                share_rumor = false;
+                // If the new rumor has a higher incarnation than our status, we want
+                // to prefer it.
+            } else if member.get_incarnation() > current_member.get_incarnation() {
+                share_rumor = true;
+            } else {
+                // We know we have a health if we have a record
+                let hl = self.health.read().expect("Health lock is poisoned");
+                let current_health = hl.get(current_member.get_id())
+                    .expect("No health for a membership record should be impossible; did you use \
+                             insert?");
+                // If curently healthy and the rumor is suspicion, then we are now suspicious.
+                if *current_health == Health::Alive && health == Health::Suspect {
+                    start_suspicion = true;
+                    share_rumor = true;
+                    // If currently healthy and the rumor is confirmation, then we are now confirmed
+                } else if *current_health == Health::Alive && health == Health::Confirmed {
+                    share_rumor = true;
+                    // If we are both alive, then nothing to see here.
+                } else if *current_health == Health::Alive && health == Health::Alive {
+                    share_rumor = false;
+                    // If currently suspicous and the rumor is alive, then we are still suspicious
+                } else if *current_health == Health::Suspect && health == Health::Alive {
+                    share_rumor = false;
+                    // If currently suspicous and the rumor is suspicion, then nothing to see here.
+                } else if *current_health == Health::Suspect && health == Health::Suspect {
+                    share_rumor = false;
+                    // If currently suspicious and the rumor is confirmation, then we are now confirmed
+                } else if *current_health == Health::Suspect && health == Health::Confirmed {
+                    stop_suspicion = true;
+                    share_rumor = true;
+                    // When we are currently confirmed, we stay that way until something with a
+                    // higher incarnation changes our mind.
+                } else {
+                    share_rumor = false;
+                }
+            }
+        } else {
+            share_rumor = true;
+        }
+
+        if share_rumor == true {
+            self.health
+                .write()
+                .expect("Health lock is poisoned")
+                .insert(String::from(member.get_id()), health);
+            if start_suspicion == true {
+                self.suspect
+                    .write()
+                    .expect("Suspect lock is poisoned")
+                    .insert(String::from(member.get_id()), SteadyTime::now());
+            }
+            if stop_suspicion == true {
+                self.suspect.write().expect("Suspect lock is poisoned").remove(member.get_id());
+            }
+            self.members
+                .write()
+                .expect("Member list lock is poisoned")
+                .insert(String::from(member.get_id()), member);
+        }
+        share_rumor
+    }
+
+    /// Returns the health of the member, if the member exists.
+    pub fn health_of(&self, member: &Member) -> Option<Health> {
+        match self.health.read().expect("Health lock is poisoned").get(member.get_id()) {
+            Some(health) => Some(health.clone()),
+            None => None,
+        }
+    }
+
+    /// Returns true if the members health is the same as `health`. False otherwise.
+    pub fn check_health_of(&self, member: &Member, health: Health) -> bool {
+        match self.health.read().expect("Health lock is poisoned").get(member.get_id()) {
+            Some(real_health) if *real_health == health => true,
+            Some(_) => false,
+            None => false,
+        }
+    }
+
+    /// Returns true if the member is alive, suspect, or persistent; used during the target
+    /// selection phase of the outbound thread.
+    pub fn member_alive_suspect_or_persistent(&self, member: &Member) -> bool {
+        if member.get_persistent() {
+            return true;
+        }
+        self.check_health_of(member, Health::Alive) || self.check_health_of(member, Health::Suspect)
+    }
+
+    /// Updates the health of a member without touching the member itself. Returns true if the
+    /// health changed, false otherwise.
+    pub fn insert_health_by_id(&self, member_id: &str, health: Health) -> bool {
+        if let Some(current_health) = self.health
+            .read()
+            .expect("Health read lock is poisoned")
+            .get(member_id) {
+            if *current_health == health {
+                return false;
+            }
+        }
+        if health == Health::Suspect {
+            let mut sl = self.suspect.write().expect("Suspect lock is poisoned");
+            sl.insert(String::from(member_id), SteadyTime::now());
+        }
+        self.health
+            .write()
+            .expect("Health write lock is poisoned")
+            .insert(String::from(member_id), health);
+        true
+    }
+
+    /// The same as `insert_health_by_id`, but takes a member rather than an id.
+    pub fn insert_health(&self, member: &Member, health: Health) -> bool {
+        self.insert_health_by_id(member.get_id(), health)
+    }
+
+    /// Returns a protobuf membership record for the given member id.
+    pub fn membership_for(&self, member_id: &str) -> ProtoMembership {
+        let mut pm = ProtoMembership::new();
+        let mhealth: ProtoMembership_Health =
+            self.health
+                .read()
+                .expect("Health lock is poisoned")
+                .get(member_id)
+                .expect("Should have membership before calling membership_for")
+                .into();
+        let ml = self.members.read().expect("Member list lock is poisoned");
+        let member = ml.get(member_id)
+            .expect("Should have membership before calling membership_for");
+        pm.set_health(mhealth);
+        pm.set_member(member.proto.clone());
+        pm
+    }
+
+    /// Returns the number of members.
+    pub fn len(&self) -> usize {
+        self.members.read().expect("Member list lock is poisoned").len()
+    }
+
+    /// A randomized list of members to check.
+    pub fn check_list(&self, exclude_id: &str) -> Vec<Member> {
+        let mut members: Vec<Member> = self.members
+            .read()
+            .expect("Member list lock is poisoned")
+            .values()
+            .filter(|v| v.get_id() != exclude_id)
+            .map(|v| v.clone())
+            .collect();
+        let mut rng = thread_rng();
+        rng.shuffle(&mut members);
+        members
+    }
+
+    /// Takes a function whose first argument is a member, and calls it for every pingreq target.
+    pub fn with_pingreq_targets<F>(&self,
+                                   sending_member: &Member,
+                                   target_member: &Member,
+                                   mut with_closure: F)
+                                   -> ()
+        where F: FnMut(&Member) -> ()
+    {
+        let ml = self.members.read().expect("Member list lock is poisoned");
+        let mut members: Vec<&Member> = ml.values().collect();
+        let mut rng = thread_rng();
+        rng.shuffle(&mut members);
+        for member in members.into_iter()
+            .filter(|m| {
+                m.get_id() != sending_member.get_id() && m.get_id() != target_member.get_id()
+            })
+            .take(PINGREQ_TARGETS) {
+            with_closure(member);
+        }
+    }
+
+    /// Takes a function whose argument is a `HashMap::Values` iterator, with the ID and Membership
+    /// entry.
+    pub fn with_member_iter<F>(&self, mut with_closure: F) -> ()
+        where F: FnMut(hash_map::Values<String, Member>) -> ()
+    {
+        with_closure(self.members.read().expect("Member list lock is poisoned").values());
+    }
+
+    /// Takes a function whose argument is a reference to the member list hashmap.
+    pub fn with_member_list<F>(&self, mut with_closure: F) -> ()
+        where F: FnMut(&HashMap<String, Member>) -> ()
+    {
+        with_closure(self.members.read().expect("Member list lock is poisoned").deref());
+    }
+
+    /// Calls a function whose argument is a reference to a membership entry matching the given ID.
+    pub fn with_member<F>(&self, member_id: &str, mut with_closure: F) -> ()
+        where F: FnMut(Option<&Member>) -> ()
+    {
+        let ml = self.members.read().expect("Member list lock poisoned");
+        let member = ml.get(member_id);
+        with_closure(member);
+    }
+
+    /// Iterates over the member list, calling the function for each member.
+    pub fn with_members<F>(&self, with_closure: F) -> ()
+        where F: Fn(&Member) -> ()
+    {
+        for member in self.members.read().expect("Member list lock is poisoned").values() {
+            with_closure(member);
+        }
+    }
+
+    /// Iterates over every suspected membership entry, calling the given closure.
+    pub fn with_suspects<F>(&self, mut with_closure: F) -> ()
+        where F: FnMut((&str, &SteadyTime)) -> ()
+    {
+        for (id, suspect) in self.suspect.read().expect("Suspect list lock is poisoned").iter() {
+            with_closure((id, suspect));
+        }
+    }
+
+    /// Expires a member from the suspect list.
+    pub fn expire(&self, member_id: &str) {
+        let mut suspects = self.suspect.write().expect("Suspect list lock is poisoned");
+        suspects.remove(member_id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    mod member {
+        use uuid::Uuid;
+        use message::swim;
+        use member::Member;
+
+        // Sets the uuid to simple, and the incarnation to zero.
+        #[test]
+        fn new() {
+            let member = Member::new();
+            assert_eq!(member.proto.get_id().len(), 32);
+            assert_eq!(member.proto.get_incarnation(), 0);
+        }
+
+        // Takes a member in from a protobuf
+        #[test]
+        fn new_from_proto() {
+            let mut proto = swim::Member::new();
+            let uuid = Uuid::new_v4();
+            proto.set_id(uuid.simple().to_string());
+            proto.set_incarnation(0);
+            let proto2 = proto.clone();
+            let member: Member = proto.into();
+            assert_eq!(proto2, member.proto);
+        }
+    }
+
+    mod member_list {
+        use member::{Member, MemberList, Health, PINGREQ_TARGETS};
+
+        fn populated_member_list(size: u64) -> MemberList {
+            let ml = MemberList::new();
+            for _x in 0..size {
+                let m = Member::new();
+                ml.insert(m, Health::Alive);
+            }
+            ml
+        }
+
+        #[test]
+        fn new() {
+            let ml = MemberList::new();
+            assert_eq!(ml.len(), 0);
+        }
+
+        #[test]
+        fn insert() {
+            let ml = populated_member_list(4);
+            assert_eq!(ml.len(), 4);
+        }
+
+        #[test]
+        fn check_list() {
+            let ml = populated_member_list(1000);
+            let list_a = ml.check_list("foo");
+            let list_b = ml.check_list("foo");
+            assert!(list_a != list_b);
+        }
+
+        #[test]
+        fn health_of() {
+            let ml = populated_member_list(1);
+            ml.with_members(|m| assert!(ml.check_health_of(m, Health::Alive)));
+        }
+
+        #[test]
+        fn pingreq_targets() {
+            let ml = populated_member_list(10);
+            ml.with_member_iter(|mut i| {
+                let from = i.nth(0).unwrap();
+                let target = i.nth(1).unwrap();
+                let mut counter: usize = 0;
+                ml.with_pingreq_targets(from, target, |_m| counter += 1);
+                assert_eq!(counter, PINGREQ_TARGETS);
+            });
+        }
+
+        #[test]
+        fn pingreq_targets_excludes_pinging_member() {
+            let ml = populated_member_list(3);
+            ml.with_member_iter(|mut i| {
+                let from = i.nth(0).unwrap();
+                let target = i.nth(1).unwrap();
+                let mut excluded_appears: bool = false;
+                ml.with_pingreq_targets(from, target, |m| if m.get_id() == from.get_id() {
+                    excluded_appears = true
+                });
+                assert_eq!(excluded_appears, false);
+            });
+        }
+
+        #[test]
+        fn pingreq_targets_excludes_target_member() {
+            let ml = populated_member_list(3);
+            ml.with_member_iter(|mut i| {
+                let from = i.nth(0).unwrap();
+                let target = i.nth(1).unwrap();
+                let mut excluded_appears: bool = false;
+                ml.with_pingreq_targets(from, target, |m| if m.get_id() == target.get_id() {
+                    excluded_appears = true
+                });
+                assert_eq!(excluded_appears, false);
+            });
+        }
+
+        #[test]
+        fn pingreq_targets_minimum_viable_pingreq_size_is_three() {
+            let ml = populated_member_list(3);
+            ml.with_member_iter(|mut i| {
+                let from = i.nth(0).unwrap();
+                let target = i.nth(1).unwrap();
+                let mut counter: isize = 0;
+                ml.with_pingreq_targets(from, target, |_m| counter += 1);
+                assert_eq!(counter, 1);
+            });
+        }
+
+        #[test]
+        fn insert_no_member() {
+            let ml = MemberList::new();
+            let member = Member::new();
+            let mcheck = member.clone();
+            assert_eq!(ml.insert(member, Health::Alive), true);
+            assert!(ml.check_health_of(&mcheck, Health::Alive));
+        }
+
+        #[test]
+        fn insert_existing_member_lower_incarnation() {
+            let ml = MemberList::new();
+            let member_one = Member::new();
+            let mcheck_one = member_one.clone();
+            let mut member_two = member_one.clone();
+            member_two.set_incarnation(1);
+            let mcheck_two = member_two.clone();
+
+            assert_eq!(ml.insert(member_one, Health::Alive), true);
+            assert!(ml.check_health_of(&mcheck_one, Health::Alive));
+
+            assert_eq!(ml.insert(member_two, Health::Alive), true);
+            ml.with_member(mcheck_two.get_id(),
+                           |m| assert_eq!(m.unwrap().get_incarnation(), 1));
+        }
+
+        #[test]
+        fn insert_existing_member_higher_incarnation() {
+            let ml = MemberList::new();
+            let mut member_one = Member::new();
+            let mcheck_one = member_one.clone();
+            let member_two = member_one.clone();
+            let mcheck_two = member_two.clone();
+
+            member_one.set_incarnation(1);
+
+            assert_eq!(ml.insert(member_one, Health::Alive), true);
+            assert!(ml.check_health_of(&mcheck_one, Health::Alive));
+
+            assert_eq!(ml.insert(member_two, Health::Alive), false);
+            ml.with_member(mcheck_two.get_id(),
+                           |m| assert_eq!(m.unwrap().get_incarnation(), 1));
+        }
+
+        #[test]
+        fn insert_equal_incarnation_current_alive_new_alive() {
+            let ml = MemberList::new();
+            let member_one = Member::new();
+            let mcheck_one = member_one.clone();
+            let member_two = member_one.clone();
+
+            assert_eq!(ml.insert(member_one, Health::Alive), true);
+            assert!(ml.check_health_of(&mcheck_one, Health::Alive));
+
+            assert_eq!(ml.insert(member_two, Health::Alive), false);
+        }
+
+        #[test]
+        fn insert_equal_incarnation_current_alive_new_suspect() {
+            let ml = MemberList::new();
+            let member_one = Member::new();
+            let mcheck_one = member_one.clone();
+            let member_two = member_one.clone();
+            let mcheck_two = member_two.clone();
+
+            assert_eq!(ml.insert(member_one, Health::Alive), true);
+            assert!(ml.check_health_of(&mcheck_one, Health::Alive));
+
+            assert_eq!(ml.insert(member_two, Health::Suspect), true);
+            assert!(ml.check_health_of(&mcheck_two, Health::Suspect));
+        }
+
+        #[test]
+        fn insert_equal_incarnation_current_alive_new_confirmed() {
+            let ml = MemberList::new();
+            let member_one = Member::new();
+            let mcheck_one = member_one.clone();
+            let member_two = member_one.clone();
+            let mcheck_two = member_two.clone();
+
+            assert_eq!(ml.insert(member_one, Health::Alive), true);
+            assert!(ml.check_health_of(&mcheck_one, Health::Alive));
+
+            assert_eq!(ml.insert(member_two, Health::Confirmed), true);
+            assert!(ml.check_health_of(&mcheck_two, Health::Confirmed));
+        }
+
+        #[test]
+        fn insert_equal_incarnation_current_suspect_new_alive() {
+            let ml = MemberList::new();
+            let member_one = Member::new();
+            let mcheck_one = member_one.clone();
+            let member_two = member_one.clone();
+            let mcheck_two = member_two.clone();
+
+            assert_eq!(ml.insert(member_one, Health::Suspect), true);
+            assert!(ml.check_health_of(&mcheck_one, Health::Suspect));
+
+            assert_eq!(ml.insert(member_two, Health::Alive), false);
+            assert!(ml.check_health_of(&mcheck_two, Health::Suspect));
+        }
+
+        #[test]
+        fn insert_equal_incarnation_current_suspect_new_suspect() {
+            let ml = MemberList::new();
+            let member_one = Member::new();
+            let mcheck_one = member_one.clone();
+            let member_two = member_one.clone();
+            let mcheck_two = member_two.clone();
+
+            assert_eq!(ml.insert(member_one, Health::Suspect), true);
+            assert!(ml.check_health_of(&mcheck_one, Health::Suspect));
+
+            assert_eq!(ml.insert(member_two, Health::Suspect), false);
+            assert!(ml.check_health_of(&mcheck_two, Health::Suspect));
+        }
+
+        #[test]
+        fn insert_equal_incarnation_current_suspect_new_confirmed() {
+            let ml = MemberList::new();
+            let member_one = Member::new();
+            let mcheck_one = member_one.clone();
+            let member_two = member_one.clone();
+            let mcheck_two = member_two.clone();
+
+            assert_eq!(ml.insert(member_one, Health::Suspect), true);
+            assert!(ml.check_health_of(&mcheck_one, Health::Suspect));
+
+            assert_eq!(ml.insert(member_two, Health::Confirmed), true);
+            assert!(ml.check_health_of(&mcheck_two, Health::Confirmed));
+        }
+
+        #[test]
+        fn insert_equal_incarnation_current_confirmed_new_alive() {
+            let ml = MemberList::new();
+            let member_one = Member::new();
+            let mcheck_one = member_one.clone();
+            let member_two = member_one.clone();
+            let mcheck_two = member_two.clone();
+
+            assert_eq!(ml.insert(member_one, Health::Confirmed), true);
+            assert!(ml.check_health_of(&mcheck_one, Health::Confirmed));
+
+            assert_eq!(ml.insert(member_two, Health::Alive), false);
+            assert!(ml.check_health_of(&mcheck_two, Health::Confirmed));
+        }
+
+        #[test]
+        fn insert_equal_incarnation_current_confirmed_new_suspect() {
+            let ml = MemberList::new();
+            let member_one = Member::new();
+            let mcheck_one = member_one.clone();
+            let member_two = member_one.clone();
+            let mcheck_two = member_two.clone();
+
+            assert_eq!(ml.insert(member_one, Health::Confirmed), true);
+            assert!(ml.check_health_of(&mcheck_one, Health::Confirmed));
+
+            assert_eq!(ml.insert(member_two, Health::Suspect), false);
+            assert!(ml.check_health_of(&mcheck_two, Health::Confirmed));
+        }
+
+        #[test]
+        fn insert_equal_incarnation_current_confirmed_new_confirmed() {
+            let ml = MemberList::new();
+            let member_one = Member::new();
+            let mcheck_one = member_one.clone();
+            let member_two = member_one.clone();
+            let mcheck_two = member_two.clone();
+
+            assert_eq!(ml.insert(member_one, Health::Confirmed), true);
+            assert!(ml.check_health_of(&mcheck_one, Health::Confirmed));
+
+            assert_eq!(ml.insert(member_two, Health::Confirmed), false);
+            assert!(ml.check_health_of(&mcheck_two, Health::Confirmed));
+        }
+
+    }
+}

--- a/components/swim/src/message/mod.rs
+++ b/components/swim/src/message/mod.rs
@@ -1,0 +1,15 @@
+// Copyright (c) 2016 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod swim;

--- a/components/swim/src/message/swim.rs
+++ b/components/swim/src/message/swim.rs
@@ -1,0 +1,1923 @@
+// This file is generated. Do not edit
+// @generated
+
+// https://github.com/Manishearth/rust-clippy/issues/702
+#![allow(unknown_lints)]
+#![allow(clippy)]
+
+#![cfg_attr(rustfmt, rustfmt_skip)]
+
+#![allow(box_pointers)]
+#![allow(dead_code)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+#![allow(non_upper_case_globals)]
+#![allow(trivial_casts)]
+#![allow(unsafe_code)]
+#![allow(unused_imports)]
+#![allow(unused_results)]
+
+use protobuf::Message as Message_imported_for_functions;
+use protobuf::ProtobufEnum as ProtobufEnum_imported_for_functions;
+
+#[derive(Clone,Default)]
+pub struct Member {
+    // message fields
+    id: ::protobuf::SingularField<::std::string::String>,
+    incarnation: ::std::option::Option<u64>,
+    address: ::protobuf::SingularField<::std::string::String>,
+    persistent: ::std::option::Option<bool>,
+    // special fields
+    unknown_fields: ::protobuf::UnknownFields,
+    cached_size: ::std::cell::Cell<u32>,
+}
+
+// see codegen.rs for the explanation why impl Sync explicitly
+unsafe impl ::std::marker::Sync for Member {}
+
+impl Member {
+    pub fn new() -> Member {
+        ::std::default::Default::default()
+    }
+
+    pub fn default_instance() -> &'static Member {
+        static mut instance: ::protobuf::lazy::Lazy<Member> = ::protobuf::lazy::Lazy {
+            lock: ::protobuf::lazy::ONCE_INIT,
+            ptr: 0 as *const Member,
+        };
+        unsafe {
+            instance.get(|| {
+                Member {
+                    id: ::protobuf::SingularField::none(),
+                    incarnation: ::std::option::Option::None,
+                    address: ::protobuf::SingularField::none(),
+                    persistent: ::std::option::Option::None,
+                    unknown_fields: ::protobuf::UnknownFields::new(),
+                    cached_size: ::std::cell::Cell::new(0),
+                }
+            })
+        }
+    }
+
+    // optional string id = 1;
+
+    pub fn clear_id(&mut self) {
+        self.id.clear();
+    }
+
+    pub fn has_id(&self) -> bool {
+        self.id.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_id(&mut self, v: ::std::string::String) {
+        self.id = ::protobuf::SingularField::some(v);
+    }
+
+    // Mutable pointer to the field.
+    // If field is not initialized, it is initialized with default value first.
+    pub fn mut_id(&mut self) -> &mut ::std::string::String {
+        if self.id.is_none() {
+            self.id.set_default();
+        };
+        self.id.as_mut().unwrap()
+    }
+
+    // Take field
+    pub fn take_id(&mut self) -> ::std::string::String {
+        self.id.take().unwrap_or_else(|| ::std::string::String::new())
+    }
+
+    pub fn get_id(&self) -> &str {
+        match self.id.as_ref() {
+            Some(v) => &v,
+            None => "",
+        }
+    }
+
+    // optional uint64 incarnation = 2;
+
+    pub fn clear_incarnation(&mut self) {
+        self.incarnation = ::std::option::Option::None;
+    }
+
+    pub fn has_incarnation(&self) -> bool {
+        self.incarnation.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_incarnation(&mut self, v: u64) {
+        self.incarnation = ::std::option::Option::Some(v);
+    }
+
+    pub fn get_incarnation(&self) -> u64 {
+        self.incarnation.unwrap_or(0)
+    }
+
+    // optional string address = 3;
+
+    pub fn clear_address(&mut self) {
+        self.address.clear();
+    }
+
+    pub fn has_address(&self) -> bool {
+        self.address.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_address(&mut self, v: ::std::string::String) {
+        self.address = ::protobuf::SingularField::some(v);
+    }
+
+    // Mutable pointer to the field.
+    // If field is not initialized, it is initialized with default value first.
+    pub fn mut_address(&mut self) -> &mut ::std::string::String {
+        if self.address.is_none() {
+            self.address.set_default();
+        };
+        self.address.as_mut().unwrap()
+    }
+
+    // Take field
+    pub fn take_address(&mut self) -> ::std::string::String {
+        self.address.take().unwrap_or_else(|| ::std::string::String::new())
+    }
+
+    pub fn get_address(&self) -> &str {
+        match self.address.as_ref() {
+            Some(v) => &v,
+            None => "",
+        }
+    }
+
+    // optional bool persistent = 4;
+
+    pub fn clear_persistent(&mut self) {
+        self.persistent = ::std::option::Option::None;
+    }
+
+    pub fn has_persistent(&self) -> bool {
+        self.persistent.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_persistent(&mut self, v: bool) {
+        self.persistent = ::std::option::Option::Some(v);
+    }
+
+    pub fn get_persistent(&self) -> bool {
+        self.persistent.unwrap_or(false)
+    }
+}
+
+impl ::protobuf::Message for Member {
+    fn is_initialized(&self) -> bool {
+        true
+    }
+
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+        while !try!(is.eof()) {
+            let (field_number, wire_type) = try!(is.read_tag_unpack());
+            match field_number {
+                1 => {
+                    try!(::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.id));
+                },
+                2 => {
+                    if wire_type != ::protobuf::wire_format::WireTypeVarint {
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                    };
+                    let tmp = try!(is.read_uint64());
+                    self.incarnation = ::std::option::Option::Some(tmp);
+                },
+                3 => {
+                    try!(::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.address));
+                },
+                4 => {
+                    if wire_type != ::protobuf::wire_format::WireTypeVarint {
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                    };
+                    let tmp = try!(is.read_bool());
+                    self.persistent = ::std::option::Option::Some(tmp);
+                },
+                _ => {
+                    try!(::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields()));
+                },
+            };
+        }
+        ::std::result::Result::Ok(())
+    }
+
+    // Compute sizes of nested messages
+    #[allow(unused_variables)]
+    fn compute_size(&self) -> u32 {
+        let mut my_size = 0;
+        for value in &self.id {
+            my_size += ::protobuf::rt::string_size(1, &value);
+        };
+        for value in &self.incarnation {
+            my_size += ::protobuf::rt::value_size(2, *value, ::protobuf::wire_format::WireTypeVarint);
+        };
+        for value in &self.address {
+            my_size += ::protobuf::rt::string_size(3, &value);
+        };
+        if self.persistent.is_some() {
+            my_size += 2;
+        };
+        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
+        self.cached_size.set(my_size);
+        my_size
+    }
+
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+        if let Some(v) = self.id.as_ref() {
+            try!(os.write_string(1, &v));
+        };
+        if let Some(v) = self.incarnation {
+            try!(os.write_uint64(2, v));
+        };
+        if let Some(v) = self.address.as_ref() {
+            try!(os.write_string(3, &v));
+        };
+        if let Some(v) = self.persistent {
+            try!(os.write_bool(4, v));
+        };
+        try!(os.write_unknown_fields(self.get_unknown_fields()));
+        ::std::result::Result::Ok(())
+    }
+
+    fn get_cached_size(&self) -> u32 {
+        self.cached_size.get()
+    }
+
+    fn get_unknown_fields(&self) -> &::protobuf::UnknownFields {
+        &self.unknown_fields
+    }
+
+    fn mut_unknown_fields(&mut self) -> &mut ::protobuf::UnknownFields {
+        &mut self.unknown_fields
+    }
+
+    fn type_id(&self) -> ::std::any::TypeId {
+        ::std::any::TypeId::of::<Member>()
+    }
+
+    fn as_any(&self) -> &::std::any::Any {
+        self as &::std::any::Any
+    }
+
+    fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
+        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+    }
+}
+
+impl ::protobuf::MessageStatic for Member {
+    fn new() -> Member {
+        Member::new()
+    }
+
+    fn descriptor_static(_: ::std::option::Option<Member>) -> &'static ::protobuf::reflect::MessageDescriptor {
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
+            lock: ::protobuf::lazy::ONCE_INIT,
+            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+        };
+        unsafe {
+            descriptor.get(|| {
+                let mut fields = ::std::vec::Vec::new();
+                fields.push(::protobuf::reflect::accessor::make_singular_string_accessor(
+                    "id",
+                    Member::has_id,
+                    Member::get_id,
+                ));
+                fields.push(::protobuf::reflect::accessor::make_singular_u64_accessor(
+                    "incarnation",
+                    Member::has_incarnation,
+                    Member::get_incarnation,
+                ));
+                fields.push(::protobuf::reflect::accessor::make_singular_string_accessor(
+                    "address",
+                    Member::has_address,
+                    Member::get_address,
+                ));
+                fields.push(::protobuf::reflect::accessor::make_singular_bool_accessor(
+                    "persistent",
+                    Member::has_persistent,
+                    Member::get_persistent,
+                ));
+                ::protobuf::reflect::MessageDescriptor::new::<Member>(
+                    "Member",
+                    fields,
+                    file_descriptor_proto()
+                )
+            })
+        }
+    }
+}
+
+impl ::protobuf::Clear for Member {
+    fn clear(&mut self) {
+        self.clear_id();
+        self.clear_incarnation();
+        self.clear_address();
+        self.clear_persistent();
+        self.unknown_fields.clear();
+    }
+}
+
+impl ::std::cmp::PartialEq for Member {
+    fn eq(&self, other: &Member) -> bool {
+        self.id == other.id &&
+        self.incarnation == other.incarnation &&
+        self.address == other.address &&
+        self.persistent == other.persistent &&
+        self.unknown_fields == other.unknown_fields
+    }
+}
+
+impl ::std::fmt::Debug for Member {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        ::protobuf::text_format::fmt(self, f)
+    }
+}
+
+#[derive(Clone,Default)]
+pub struct Ping {
+    // message fields
+    from: ::protobuf::SingularPtrField<Member>,
+    forward_to: ::protobuf::SingularPtrField<Member>,
+    // special fields
+    unknown_fields: ::protobuf::UnknownFields,
+    cached_size: ::std::cell::Cell<u32>,
+}
+
+// see codegen.rs for the explanation why impl Sync explicitly
+unsafe impl ::std::marker::Sync for Ping {}
+
+impl Ping {
+    pub fn new() -> Ping {
+        ::std::default::Default::default()
+    }
+
+    pub fn default_instance() -> &'static Ping {
+        static mut instance: ::protobuf::lazy::Lazy<Ping> = ::protobuf::lazy::Lazy {
+            lock: ::protobuf::lazy::ONCE_INIT,
+            ptr: 0 as *const Ping,
+        };
+        unsafe {
+            instance.get(|| {
+                Ping {
+                    from: ::protobuf::SingularPtrField::none(),
+                    forward_to: ::protobuf::SingularPtrField::none(),
+                    unknown_fields: ::protobuf::UnknownFields::new(),
+                    cached_size: ::std::cell::Cell::new(0),
+                }
+            })
+        }
+    }
+
+    // optional .Member from = 1;
+
+    pub fn clear_from(&mut self) {
+        self.from.clear();
+    }
+
+    pub fn has_from(&self) -> bool {
+        self.from.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_from(&mut self, v: Member) {
+        self.from = ::protobuf::SingularPtrField::some(v);
+    }
+
+    // Mutable pointer to the field.
+    // If field is not initialized, it is initialized with default value first.
+    pub fn mut_from(&mut self) -> &mut Member {
+        if self.from.is_none() {
+            self.from.set_default();
+        };
+        self.from.as_mut().unwrap()
+    }
+
+    // Take field
+    pub fn take_from(&mut self) -> Member {
+        self.from.take().unwrap_or_else(|| Member::new())
+    }
+
+    pub fn get_from(&self) -> &Member {
+        self.from.as_ref().unwrap_or_else(|| Member::default_instance())
+    }
+
+    // optional .Member forward_to = 2;
+
+    pub fn clear_forward_to(&mut self) {
+        self.forward_to.clear();
+    }
+
+    pub fn has_forward_to(&self) -> bool {
+        self.forward_to.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_forward_to(&mut self, v: Member) {
+        self.forward_to = ::protobuf::SingularPtrField::some(v);
+    }
+
+    // Mutable pointer to the field.
+    // If field is not initialized, it is initialized with default value first.
+    pub fn mut_forward_to(&mut self) -> &mut Member {
+        if self.forward_to.is_none() {
+            self.forward_to.set_default();
+        };
+        self.forward_to.as_mut().unwrap()
+    }
+
+    // Take field
+    pub fn take_forward_to(&mut self) -> Member {
+        self.forward_to.take().unwrap_or_else(|| Member::new())
+    }
+
+    pub fn get_forward_to(&self) -> &Member {
+        self.forward_to.as_ref().unwrap_or_else(|| Member::default_instance())
+    }
+}
+
+impl ::protobuf::Message for Ping {
+    fn is_initialized(&self) -> bool {
+        true
+    }
+
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+        while !try!(is.eof()) {
+            let (field_number, wire_type) = try!(is.read_tag_unpack());
+            match field_number {
+                1 => {
+                    try!(::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.from));
+                },
+                2 => {
+                    try!(::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.forward_to));
+                },
+                _ => {
+                    try!(::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields()));
+                },
+            };
+        }
+        ::std::result::Result::Ok(())
+    }
+
+    // Compute sizes of nested messages
+    #[allow(unused_variables)]
+    fn compute_size(&self) -> u32 {
+        let mut my_size = 0;
+        for value in &self.from {
+            let len = value.compute_size();
+            my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
+        };
+        for value in &self.forward_to {
+            let len = value.compute_size();
+            my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
+        };
+        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
+        self.cached_size.set(my_size);
+        my_size
+    }
+
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+        if let Some(v) = self.from.as_ref() {
+            try!(os.write_tag(1, ::protobuf::wire_format::WireTypeLengthDelimited));
+            try!(os.write_raw_varint32(v.get_cached_size()));
+            try!(v.write_to_with_cached_sizes(os));
+        };
+        if let Some(v) = self.forward_to.as_ref() {
+            try!(os.write_tag(2, ::protobuf::wire_format::WireTypeLengthDelimited));
+            try!(os.write_raw_varint32(v.get_cached_size()));
+            try!(v.write_to_with_cached_sizes(os));
+        };
+        try!(os.write_unknown_fields(self.get_unknown_fields()));
+        ::std::result::Result::Ok(())
+    }
+
+    fn get_cached_size(&self) -> u32 {
+        self.cached_size.get()
+    }
+
+    fn get_unknown_fields(&self) -> &::protobuf::UnknownFields {
+        &self.unknown_fields
+    }
+
+    fn mut_unknown_fields(&mut self) -> &mut ::protobuf::UnknownFields {
+        &mut self.unknown_fields
+    }
+
+    fn type_id(&self) -> ::std::any::TypeId {
+        ::std::any::TypeId::of::<Ping>()
+    }
+
+    fn as_any(&self) -> &::std::any::Any {
+        self as &::std::any::Any
+    }
+
+    fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
+        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+    }
+}
+
+impl ::protobuf::MessageStatic for Ping {
+    fn new() -> Ping {
+        Ping::new()
+    }
+
+    fn descriptor_static(_: ::std::option::Option<Ping>) -> &'static ::protobuf::reflect::MessageDescriptor {
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
+            lock: ::protobuf::lazy::ONCE_INIT,
+            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+        };
+        unsafe {
+            descriptor.get(|| {
+                let mut fields = ::std::vec::Vec::new();
+                fields.push(::protobuf::reflect::accessor::make_singular_message_accessor(
+                    "from",
+                    Ping::has_from,
+                    Ping::get_from,
+                ));
+                fields.push(::protobuf::reflect::accessor::make_singular_message_accessor(
+                    "forward_to",
+                    Ping::has_forward_to,
+                    Ping::get_forward_to,
+                ));
+                ::protobuf::reflect::MessageDescriptor::new::<Ping>(
+                    "Ping",
+                    fields,
+                    file_descriptor_proto()
+                )
+            })
+        }
+    }
+}
+
+impl ::protobuf::Clear for Ping {
+    fn clear(&mut self) {
+        self.clear_from();
+        self.clear_forward_to();
+        self.unknown_fields.clear();
+    }
+}
+
+impl ::std::cmp::PartialEq for Ping {
+    fn eq(&self, other: &Ping) -> bool {
+        self.from == other.from &&
+        self.forward_to == other.forward_to &&
+        self.unknown_fields == other.unknown_fields
+    }
+}
+
+impl ::std::fmt::Debug for Ping {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        ::protobuf::text_format::fmt(self, f)
+    }
+}
+
+#[derive(Clone,Default)]
+pub struct Ack {
+    // message fields
+    from: ::protobuf::SingularPtrField<Member>,
+    forward_to: ::protobuf::SingularPtrField<Member>,
+    // special fields
+    unknown_fields: ::protobuf::UnknownFields,
+    cached_size: ::std::cell::Cell<u32>,
+}
+
+// see codegen.rs for the explanation why impl Sync explicitly
+unsafe impl ::std::marker::Sync for Ack {}
+
+impl Ack {
+    pub fn new() -> Ack {
+        ::std::default::Default::default()
+    }
+
+    pub fn default_instance() -> &'static Ack {
+        static mut instance: ::protobuf::lazy::Lazy<Ack> = ::protobuf::lazy::Lazy {
+            lock: ::protobuf::lazy::ONCE_INIT,
+            ptr: 0 as *const Ack,
+        };
+        unsafe {
+            instance.get(|| {
+                Ack {
+                    from: ::protobuf::SingularPtrField::none(),
+                    forward_to: ::protobuf::SingularPtrField::none(),
+                    unknown_fields: ::protobuf::UnknownFields::new(),
+                    cached_size: ::std::cell::Cell::new(0),
+                }
+            })
+        }
+    }
+
+    // optional .Member from = 1;
+
+    pub fn clear_from(&mut self) {
+        self.from.clear();
+    }
+
+    pub fn has_from(&self) -> bool {
+        self.from.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_from(&mut self, v: Member) {
+        self.from = ::protobuf::SingularPtrField::some(v);
+    }
+
+    // Mutable pointer to the field.
+    // If field is not initialized, it is initialized with default value first.
+    pub fn mut_from(&mut self) -> &mut Member {
+        if self.from.is_none() {
+            self.from.set_default();
+        };
+        self.from.as_mut().unwrap()
+    }
+
+    // Take field
+    pub fn take_from(&mut self) -> Member {
+        self.from.take().unwrap_or_else(|| Member::new())
+    }
+
+    pub fn get_from(&self) -> &Member {
+        self.from.as_ref().unwrap_or_else(|| Member::default_instance())
+    }
+
+    // optional .Member forward_to = 2;
+
+    pub fn clear_forward_to(&mut self) {
+        self.forward_to.clear();
+    }
+
+    pub fn has_forward_to(&self) -> bool {
+        self.forward_to.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_forward_to(&mut self, v: Member) {
+        self.forward_to = ::protobuf::SingularPtrField::some(v);
+    }
+
+    // Mutable pointer to the field.
+    // If field is not initialized, it is initialized with default value first.
+    pub fn mut_forward_to(&mut self) -> &mut Member {
+        if self.forward_to.is_none() {
+            self.forward_to.set_default();
+        };
+        self.forward_to.as_mut().unwrap()
+    }
+
+    // Take field
+    pub fn take_forward_to(&mut self) -> Member {
+        self.forward_to.take().unwrap_or_else(|| Member::new())
+    }
+
+    pub fn get_forward_to(&self) -> &Member {
+        self.forward_to.as_ref().unwrap_or_else(|| Member::default_instance())
+    }
+}
+
+impl ::protobuf::Message for Ack {
+    fn is_initialized(&self) -> bool {
+        true
+    }
+
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+        while !try!(is.eof()) {
+            let (field_number, wire_type) = try!(is.read_tag_unpack());
+            match field_number {
+                1 => {
+                    try!(::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.from));
+                },
+                2 => {
+                    try!(::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.forward_to));
+                },
+                _ => {
+                    try!(::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields()));
+                },
+            };
+        }
+        ::std::result::Result::Ok(())
+    }
+
+    // Compute sizes of nested messages
+    #[allow(unused_variables)]
+    fn compute_size(&self) -> u32 {
+        let mut my_size = 0;
+        for value in &self.from {
+            let len = value.compute_size();
+            my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
+        };
+        for value in &self.forward_to {
+            let len = value.compute_size();
+            my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
+        };
+        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
+        self.cached_size.set(my_size);
+        my_size
+    }
+
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+        if let Some(v) = self.from.as_ref() {
+            try!(os.write_tag(1, ::protobuf::wire_format::WireTypeLengthDelimited));
+            try!(os.write_raw_varint32(v.get_cached_size()));
+            try!(v.write_to_with_cached_sizes(os));
+        };
+        if let Some(v) = self.forward_to.as_ref() {
+            try!(os.write_tag(2, ::protobuf::wire_format::WireTypeLengthDelimited));
+            try!(os.write_raw_varint32(v.get_cached_size()));
+            try!(v.write_to_with_cached_sizes(os));
+        };
+        try!(os.write_unknown_fields(self.get_unknown_fields()));
+        ::std::result::Result::Ok(())
+    }
+
+    fn get_cached_size(&self) -> u32 {
+        self.cached_size.get()
+    }
+
+    fn get_unknown_fields(&self) -> &::protobuf::UnknownFields {
+        &self.unknown_fields
+    }
+
+    fn mut_unknown_fields(&mut self) -> &mut ::protobuf::UnknownFields {
+        &mut self.unknown_fields
+    }
+
+    fn type_id(&self) -> ::std::any::TypeId {
+        ::std::any::TypeId::of::<Ack>()
+    }
+
+    fn as_any(&self) -> &::std::any::Any {
+        self as &::std::any::Any
+    }
+
+    fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
+        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+    }
+}
+
+impl ::protobuf::MessageStatic for Ack {
+    fn new() -> Ack {
+        Ack::new()
+    }
+
+    fn descriptor_static(_: ::std::option::Option<Ack>) -> &'static ::protobuf::reflect::MessageDescriptor {
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
+            lock: ::protobuf::lazy::ONCE_INIT,
+            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+        };
+        unsafe {
+            descriptor.get(|| {
+                let mut fields = ::std::vec::Vec::new();
+                fields.push(::protobuf::reflect::accessor::make_singular_message_accessor(
+                    "from",
+                    Ack::has_from,
+                    Ack::get_from,
+                ));
+                fields.push(::protobuf::reflect::accessor::make_singular_message_accessor(
+                    "forward_to",
+                    Ack::has_forward_to,
+                    Ack::get_forward_to,
+                ));
+                ::protobuf::reflect::MessageDescriptor::new::<Ack>(
+                    "Ack",
+                    fields,
+                    file_descriptor_proto()
+                )
+            })
+        }
+    }
+}
+
+impl ::protobuf::Clear for Ack {
+    fn clear(&mut self) {
+        self.clear_from();
+        self.clear_forward_to();
+        self.unknown_fields.clear();
+    }
+}
+
+impl ::std::cmp::PartialEq for Ack {
+    fn eq(&self, other: &Ack) -> bool {
+        self.from == other.from &&
+        self.forward_to == other.forward_to &&
+        self.unknown_fields == other.unknown_fields
+    }
+}
+
+impl ::std::fmt::Debug for Ack {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        ::protobuf::text_format::fmt(self, f)
+    }
+}
+
+#[derive(Clone,Default)]
+pub struct PingReq {
+    // message fields
+    from: ::protobuf::SingularPtrField<Member>,
+    target: ::protobuf::SingularPtrField<Member>,
+    // special fields
+    unknown_fields: ::protobuf::UnknownFields,
+    cached_size: ::std::cell::Cell<u32>,
+}
+
+// see codegen.rs for the explanation why impl Sync explicitly
+unsafe impl ::std::marker::Sync for PingReq {}
+
+impl PingReq {
+    pub fn new() -> PingReq {
+        ::std::default::Default::default()
+    }
+
+    pub fn default_instance() -> &'static PingReq {
+        static mut instance: ::protobuf::lazy::Lazy<PingReq> = ::protobuf::lazy::Lazy {
+            lock: ::protobuf::lazy::ONCE_INIT,
+            ptr: 0 as *const PingReq,
+        };
+        unsafe {
+            instance.get(|| {
+                PingReq {
+                    from: ::protobuf::SingularPtrField::none(),
+                    target: ::protobuf::SingularPtrField::none(),
+                    unknown_fields: ::protobuf::UnknownFields::new(),
+                    cached_size: ::std::cell::Cell::new(0),
+                }
+            })
+        }
+    }
+
+    // optional .Member from = 1;
+
+    pub fn clear_from(&mut self) {
+        self.from.clear();
+    }
+
+    pub fn has_from(&self) -> bool {
+        self.from.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_from(&mut self, v: Member) {
+        self.from = ::protobuf::SingularPtrField::some(v);
+    }
+
+    // Mutable pointer to the field.
+    // If field is not initialized, it is initialized with default value first.
+    pub fn mut_from(&mut self) -> &mut Member {
+        if self.from.is_none() {
+            self.from.set_default();
+        };
+        self.from.as_mut().unwrap()
+    }
+
+    // Take field
+    pub fn take_from(&mut self) -> Member {
+        self.from.take().unwrap_or_else(|| Member::new())
+    }
+
+    pub fn get_from(&self) -> &Member {
+        self.from.as_ref().unwrap_or_else(|| Member::default_instance())
+    }
+
+    // optional .Member target = 2;
+
+    pub fn clear_target(&mut self) {
+        self.target.clear();
+    }
+
+    pub fn has_target(&self) -> bool {
+        self.target.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_target(&mut self, v: Member) {
+        self.target = ::protobuf::SingularPtrField::some(v);
+    }
+
+    // Mutable pointer to the field.
+    // If field is not initialized, it is initialized with default value first.
+    pub fn mut_target(&mut self) -> &mut Member {
+        if self.target.is_none() {
+            self.target.set_default();
+        };
+        self.target.as_mut().unwrap()
+    }
+
+    // Take field
+    pub fn take_target(&mut self) -> Member {
+        self.target.take().unwrap_or_else(|| Member::new())
+    }
+
+    pub fn get_target(&self) -> &Member {
+        self.target.as_ref().unwrap_or_else(|| Member::default_instance())
+    }
+}
+
+impl ::protobuf::Message for PingReq {
+    fn is_initialized(&self) -> bool {
+        true
+    }
+
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+        while !try!(is.eof()) {
+            let (field_number, wire_type) = try!(is.read_tag_unpack());
+            match field_number {
+                1 => {
+                    try!(::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.from));
+                },
+                2 => {
+                    try!(::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.target));
+                },
+                _ => {
+                    try!(::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields()));
+                },
+            };
+        }
+        ::std::result::Result::Ok(())
+    }
+
+    // Compute sizes of nested messages
+    #[allow(unused_variables)]
+    fn compute_size(&self) -> u32 {
+        let mut my_size = 0;
+        for value in &self.from {
+            let len = value.compute_size();
+            my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
+        };
+        for value in &self.target {
+            let len = value.compute_size();
+            my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
+        };
+        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
+        self.cached_size.set(my_size);
+        my_size
+    }
+
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+        if let Some(v) = self.from.as_ref() {
+            try!(os.write_tag(1, ::protobuf::wire_format::WireTypeLengthDelimited));
+            try!(os.write_raw_varint32(v.get_cached_size()));
+            try!(v.write_to_with_cached_sizes(os));
+        };
+        if let Some(v) = self.target.as_ref() {
+            try!(os.write_tag(2, ::protobuf::wire_format::WireTypeLengthDelimited));
+            try!(os.write_raw_varint32(v.get_cached_size()));
+            try!(v.write_to_with_cached_sizes(os));
+        };
+        try!(os.write_unknown_fields(self.get_unknown_fields()));
+        ::std::result::Result::Ok(())
+    }
+
+    fn get_cached_size(&self) -> u32 {
+        self.cached_size.get()
+    }
+
+    fn get_unknown_fields(&self) -> &::protobuf::UnknownFields {
+        &self.unknown_fields
+    }
+
+    fn mut_unknown_fields(&mut self) -> &mut ::protobuf::UnknownFields {
+        &mut self.unknown_fields
+    }
+
+    fn type_id(&self) -> ::std::any::TypeId {
+        ::std::any::TypeId::of::<PingReq>()
+    }
+
+    fn as_any(&self) -> &::std::any::Any {
+        self as &::std::any::Any
+    }
+
+    fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
+        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+    }
+}
+
+impl ::protobuf::MessageStatic for PingReq {
+    fn new() -> PingReq {
+        PingReq::new()
+    }
+
+    fn descriptor_static(_: ::std::option::Option<PingReq>) -> &'static ::protobuf::reflect::MessageDescriptor {
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
+            lock: ::protobuf::lazy::ONCE_INIT,
+            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+        };
+        unsafe {
+            descriptor.get(|| {
+                let mut fields = ::std::vec::Vec::new();
+                fields.push(::protobuf::reflect::accessor::make_singular_message_accessor(
+                    "from",
+                    PingReq::has_from,
+                    PingReq::get_from,
+                ));
+                fields.push(::protobuf::reflect::accessor::make_singular_message_accessor(
+                    "target",
+                    PingReq::has_target,
+                    PingReq::get_target,
+                ));
+                ::protobuf::reflect::MessageDescriptor::new::<PingReq>(
+                    "PingReq",
+                    fields,
+                    file_descriptor_proto()
+                )
+            })
+        }
+    }
+}
+
+impl ::protobuf::Clear for PingReq {
+    fn clear(&mut self) {
+        self.clear_from();
+        self.clear_target();
+        self.unknown_fields.clear();
+    }
+}
+
+impl ::std::cmp::PartialEq for PingReq {
+    fn eq(&self, other: &PingReq) -> bool {
+        self.from == other.from &&
+        self.target == other.target &&
+        self.unknown_fields == other.unknown_fields
+    }
+}
+
+impl ::std::fmt::Debug for PingReq {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        ::protobuf::text_format::fmt(self, f)
+    }
+}
+
+#[derive(Clone,Default)]
+pub struct Membership {
+    // message fields
+    member: ::protobuf::SingularPtrField<Member>,
+    health: ::std::option::Option<Membership_Health>,
+    // special fields
+    unknown_fields: ::protobuf::UnknownFields,
+    cached_size: ::std::cell::Cell<u32>,
+}
+
+// see codegen.rs for the explanation why impl Sync explicitly
+unsafe impl ::std::marker::Sync for Membership {}
+
+impl Membership {
+    pub fn new() -> Membership {
+        ::std::default::Default::default()
+    }
+
+    pub fn default_instance() -> &'static Membership {
+        static mut instance: ::protobuf::lazy::Lazy<Membership> = ::protobuf::lazy::Lazy {
+            lock: ::protobuf::lazy::ONCE_INIT,
+            ptr: 0 as *const Membership,
+        };
+        unsafe {
+            instance.get(|| {
+                Membership {
+                    member: ::protobuf::SingularPtrField::none(),
+                    health: ::std::option::Option::None,
+                    unknown_fields: ::protobuf::UnknownFields::new(),
+                    cached_size: ::std::cell::Cell::new(0),
+                }
+            })
+        }
+    }
+
+    // optional .Member member = 1;
+
+    pub fn clear_member(&mut self) {
+        self.member.clear();
+    }
+
+    pub fn has_member(&self) -> bool {
+        self.member.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_member(&mut self, v: Member) {
+        self.member = ::protobuf::SingularPtrField::some(v);
+    }
+
+    // Mutable pointer to the field.
+    // If field is not initialized, it is initialized with default value first.
+    pub fn mut_member(&mut self) -> &mut Member {
+        if self.member.is_none() {
+            self.member.set_default();
+        };
+        self.member.as_mut().unwrap()
+    }
+
+    // Take field
+    pub fn take_member(&mut self) -> Member {
+        self.member.take().unwrap_or_else(|| Member::new())
+    }
+
+    pub fn get_member(&self) -> &Member {
+        self.member.as_ref().unwrap_or_else(|| Member::default_instance())
+    }
+
+    // optional .Membership.Health health = 2;
+
+    pub fn clear_health(&mut self) {
+        self.health = ::std::option::Option::None;
+    }
+
+    pub fn has_health(&self) -> bool {
+        self.health.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_health(&mut self, v: Membership_Health) {
+        self.health = ::std::option::Option::Some(v);
+    }
+
+    pub fn get_health(&self) -> Membership_Health {
+        self.health.unwrap_or(Membership_Health::ALIVE)
+    }
+}
+
+impl ::protobuf::Message for Membership {
+    fn is_initialized(&self) -> bool {
+        true
+    }
+
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+        while !try!(is.eof()) {
+            let (field_number, wire_type) = try!(is.read_tag_unpack());
+            match field_number {
+                1 => {
+                    try!(::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.member));
+                },
+                2 => {
+                    if wire_type != ::protobuf::wire_format::WireTypeVarint {
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                    };
+                    let tmp = try!(is.read_enum());
+                    self.health = ::std::option::Option::Some(tmp);
+                },
+                _ => {
+                    try!(::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields()));
+                },
+            };
+        }
+        ::std::result::Result::Ok(())
+    }
+
+    // Compute sizes of nested messages
+    #[allow(unused_variables)]
+    fn compute_size(&self) -> u32 {
+        let mut my_size = 0;
+        for value in &self.member {
+            let len = value.compute_size();
+            my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
+        };
+        for value in &self.health {
+            my_size += ::protobuf::rt::enum_size(2, *value);
+        };
+        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
+        self.cached_size.set(my_size);
+        my_size
+    }
+
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+        if let Some(v) = self.member.as_ref() {
+            try!(os.write_tag(1, ::protobuf::wire_format::WireTypeLengthDelimited));
+            try!(os.write_raw_varint32(v.get_cached_size()));
+            try!(v.write_to_with_cached_sizes(os));
+        };
+        if let Some(v) = self.health {
+            try!(os.write_enum(2, v.value()));
+        };
+        try!(os.write_unknown_fields(self.get_unknown_fields()));
+        ::std::result::Result::Ok(())
+    }
+
+    fn get_cached_size(&self) -> u32 {
+        self.cached_size.get()
+    }
+
+    fn get_unknown_fields(&self) -> &::protobuf::UnknownFields {
+        &self.unknown_fields
+    }
+
+    fn mut_unknown_fields(&mut self) -> &mut ::protobuf::UnknownFields {
+        &mut self.unknown_fields
+    }
+
+    fn type_id(&self) -> ::std::any::TypeId {
+        ::std::any::TypeId::of::<Membership>()
+    }
+
+    fn as_any(&self) -> &::std::any::Any {
+        self as &::std::any::Any
+    }
+
+    fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
+        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+    }
+}
+
+impl ::protobuf::MessageStatic for Membership {
+    fn new() -> Membership {
+        Membership::new()
+    }
+
+    fn descriptor_static(_: ::std::option::Option<Membership>) -> &'static ::protobuf::reflect::MessageDescriptor {
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
+            lock: ::protobuf::lazy::ONCE_INIT,
+            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+        };
+        unsafe {
+            descriptor.get(|| {
+                let mut fields = ::std::vec::Vec::new();
+                fields.push(::protobuf::reflect::accessor::make_singular_message_accessor(
+                    "member",
+                    Membership::has_member,
+                    Membership::get_member,
+                ));
+                fields.push(::protobuf::reflect::accessor::make_singular_enum_accessor(
+                    "health",
+                    Membership::has_health,
+                    Membership::get_health,
+                ));
+                ::protobuf::reflect::MessageDescriptor::new::<Membership>(
+                    "Membership",
+                    fields,
+                    file_descriptor_proto()
+                )
+            })
+        }
+    }
+}
+
+impl ::protobuf::Clear for Membership {
+    fn clear(&mut self) {
+        self.clear_member();
+        self.clear_health();
+        self.unknown_fields.clear();
+    }
+}
+
+impl ::std::cmp::PartialEq for Membership {
+    fn eq(&self, other: &Membership) -> bool {
+        self.member == other.member &&
+        self.health == other.health &&
+        self.unknown_fields == other.unknown_fields
+    }
+}
+
+impl ::std::fmt::Debug for Membership {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        ::protobuf::text_format::fmt(self, f)
+    }
+}
+
+#[derive(Clone,PartialEq,Eq,Debug,Hash)]
+pub enum Membership_Health {
+    ALIVE = 1,
+    SUSPECT = 2,
+    CONFIRMED = 3,
+}
+
+impl ::protobuf::ProtobufEnum for Membership_Health {
+    fn value(&self) -> i32 {
+        *self as i32
+    }
+
+    fn from_i32(value: i32) -> ::std::option::Option<Membership_Health> {
+        match value {
+            1 => ::std::option::Option::Some(Membership_Health::ALIVE),
+            2 => ::std::option::Option::Some(Membership_Health::SUSPECT),
+            3 => ::std::option::Option::Some(Membership_Health::CONFIRMED),
+            _ => ::std::option::Option::None
+        }
+    }
+
+    fn values() -> &'static [Self] {
+        static values: &'static [Membership_Health] = &[
+            Membership_Health::ALIVE,
+            Membership_Health::SUSPECT,
+            Membership_Health::CONFIRMED,
+        ];
+        values
+    }
+
+    fn enum_descriptor_static(_: Option<Membership_Health>) -> &'static ::protobuf::reflect::EnumDescriptor {
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> = ::protobuf::lazy::Lazy {
+            lock: ::protobuf::lazy::ONCE_INIT,
+            ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
+        };
+        unsafe {
+            descriptor.get(|| {
+                ::protobuf::reflect::EnumDescriptor::new("Membership_Health", file_descriptor_proto())
+            })
+        }
+    }
+}
+
+impl ::std::marker::Copy for Membership_Health {
+}
+
+#[derive(Clone,Default)]
+pub struct Swim {
+    // message fields
+    field_type: ::std::option::Option<Swim_Type>,
+    ping: ::protobuf::SingularPtrField<Ping>,
+    ack: ::protobuf::SingularPtrField<Ack>,
+    pingreq: ::protobuf::SingularPtrField<PingReq>,
+    membership: ::protobuf::RepeatedField<Membership>,
+    // special fields
+    unknown_fields: ::protobuf::UnknownFields,
+    cached_size: ::std::cell::Cell<u32>,
+}
+
+// see codegen.rs for the explanation why impl Sync explicitly
+unsafe impl ::std::marker::Sync for Swim {}
+
+impl Swim {
+    pub fn new() -> Swim {
+        ::std::default::Default::default()
+    }
+
+    pub fn default_instance() -> &'static Swim {
+        static mut instance: ::protobuf::lazy::Lazy<Swim> = ::protobuf::lazy::Lazy {
+            lock: ::protobuf::lazy::ONCE_INIT,
+            ptr: 0 as *const Swim,
+        };
+        unsafe {
+            instance.get(|| {
+                Swim {
+                    field_type: ::std::option::Option::None,
+                    ping: ::protobuf::SingularPtrField::none(),
+                    ack: ::protobuf::SingularPtrField::none(),
+                    pingreq: ::protobuf::SingularPtrField::none(),
+                    membership: ::protobuf::RepeatedField::new(),
+                    unknown_fields: ::protobuf::UnknownFields::new(),
+                    cached_size: ::std::cell::Cell::new(0),
+                }
+            })
+        }
+    }
+
+    // required .Swim.Type type = 1;
+
+    pub fn clear_field_type(&mut self) {
+        self.field_type = ::std::option::Option::None;
+    }
+
+    pub fn has_field_type(&self) -> bool {
+        self.field_type.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_field_type(&mut self, v: Swim_Type) {
+        self.field_type = ::std::option::Option::Some(v);
+    }
+
+    pub fn get_field_type(&self) -> Swim_Type {
+        self.field_type.unwrap_or(Swim_Type::PING)
+    }
+
+    // optional .Ping ping = 2;
+
+    pub fn clear_ping(&mut self) {
+        self.ping.clear();
+    }
+
+    pub fn has_ping(&self) -> bool {
+        self.ping.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_ping(&mut self, v: Ping) {
+        self.ping = ::protobuf::SingularPtrField::some(v);
+    }
+
+    // Mutable pointer to the field.
+    // If field is not initialized, it is initialized with default value first.
+    pub fn mut_ping(&mut self) -> &mut Ping {
+        if self.ping.is_none() {
+            self.ping.set_default();
+        };
+        self.ping.as_mut().unwrap()
+    }
+
+    // Take field
+    pub fn take_ping(&mut self) -> Ping {
+        self.ping.take().unwrap_or_else(|| Ping::new())
+    }
+
+    pub fn get_ping(&self) -> &Ping {
+        self.ping.as_ref().unwrap_or_else(|| Ping::default_instance())
+    }
+
+    // optional .Ack ack = 3;
+
+    pub fn clear_ack(&mut self) {
+        self.ack.clear();
+    }
+
+    pub fn has_ack(&self) -> bool {
+        self.ack.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_ack(&mut self, v: Ack) {
+        self.ack = ::protobuf::SingularPtrField::some(v);
+    }
+
+    // Mutable pointer to the field.
+    // If field is not initialized, it is initialized with default value first.
+    pub fn mut_ack(&mut self) -> &mut Ack {
+        if self.ack.is_none() {
+            self.ack.set_default();
+        };
+        self.ack.as_mut().unwrap()
+    }
+
+    // Take field
+    pub fn take_ack(&mut self) -> Ack {
+        self.ack.take().unwrap_or_else(|| Ack::new())
+    }
+
+    pub fn get_ack(&self) -> &Ack {
+        self.ack.as_ref().unwrap_or_else(|| Ack::default_instance())
+    }
+
+    // optional .PingReq pingreq = 4;
+
+    pub fn clear_pingreq(&mut self) {
+        self.pingreq.clear();
+    }
+
+    pub fn has_pingreq(&self) -> bool {
+        self.pingreq.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_pingreq(&mut self, v: PingReq) {
+        self.pingreq = ::protobuf::SingularPtrField::some(v);
+    }
+
+    // Mutable pointer to the field.
+    // If field is not initialized, it is initialized with default value first.
+    pub fn mut_pingreq(&mut self) -> &mut PingReq {
+        if self.pingreq.is_none() {
+            self.pingreq.set_default();
+        };
+        self.pingreq.as_mut().unwrap()
+    }
+
+    // Take field
+    pub fn take_pingreq(&mut self) -> PingReq {
+        self.pingreq.take().unwrap_or_else(|| PingReq::new())
+    }
+
+    pub fn get_pingreq(&self) -> &PingReq {
+        self.pingreq.as_ref().unwrap_or_else(|| PingReq::default_instance())
+    }
+
+    // repeated .Membership membership = 5;
+
+    pub fn clear_membership(&mut self) {
+        self.membership.clear();
+    }
+
+    // Param is passed by value, moved
+    pub fn set_membership(&mut self, v: ::protobuf::RepeatedField<Membership>) {
+        self.membership = v;
+    }
+
+    // Mutable pointer to the field.
+    pub fn mut_membership(&mut self) -> &mut ::protobuf::RepeatedField<Membership> {
+        &mut self.membership
+    }
+
+    // Take field
+    pub fn take_membership(&mut self) -> ::protobuf::RepeatedField<Membership> {
+        ::std::mem::replace(&mut self.membership, ::protobuf::RepeatedField::new())
+    }
+
+    pub fn get_membership(&self) -> &[Membership] {
+        &self.membership
+    }
+}
+
+impl ::protobuf::Message for Swim {
+    fn is_initialized(&self) -> bool {
+        if self.field_type.is_none() {
+            return false;
+        };
+        true
+    }
+
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+        while !try!(is.eof()) {
+            let (field_number, wire_type) = try!(is.read_tag_unpack());
+            match field_number {
+                1 => {
+                    if wire_type != ::protobuf::wire_format::WireTypeVarint {
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                    };
+                    let tmp = try!(is.read_enum());
+                    self.field_type = ::std::option::Option::Some(tmp);
+                },
+                2 => {
+                    try!(::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.ping));
+                },
+                3 => {
+                    try!(::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.ack));
+                },
+                4 => {
+                    try!(::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.pingreq));
+                },
+                5 => {
+                    try!(::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.membership));
+                },
+                _ => {
+                    try!(::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields()));
+                },
+            };
+        }
+        ::std::result::Result::Ok(())
+    }
+
+    // Compute sizes of nested messages
+    #[allow(unused_variables)]
+    fn compute_size(&self) -> u32 {
+        let mut my_size = 0;
+        for value in &self.field_type {
+            my_size += ::protobuf::rt::enum_size(1, *value);
+        };
+        for value in &self.ping {
+            let len = value.compute_size();
+            my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
+        };
+        for value in &self.ack {
+            let len = value.compute_size();
+            my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
+        };
+        for value in &self.pingreq {
+            let len = value.compute_size();
+            my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
+        };
+        for value in &self.membership {
+            let len = value.compute_size();
+            my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
+        };
+        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
+        self.cached_size.set(my_size);
+        my_size
+    }
+
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+        if let Some(v) = self.field_type {
+            try!(os.write_enum(1, v.value()));
+        };
+        if let Some(v) = self.ping.as_ref() {
+            try!(os.write_tag(2, ::protobuf::wire_format::WireTypeLengthDelimited));
+            try!(os.write_raw_varint32(v.get_cached_size()));
+            try!(v.write_to_with_cached_sizes(os));
+        };
+        if let Some(v) = self.ack.as_ref() {
+            try!(os.write_tag(3, ::protobuf::wire_format::WireTypeLengthDelimited));
+            try!(os.write_raw_varint32(v.get_cached_size()));
+            try!(v.write_to_with_cached_sizes(os));
+        };
+        if let Some(v) = self.pingreq.as_ref() {
+            try!(os.write_tag(4, ::protobuf::wire_format::WireTypeLengthDelimited));
+            try!(os.write_raw_varint32(v.get_cached_size()));
+            try!(v.write_to_with_cached_sizes(os));
+        };
+        for v in &self.membership {
+            try!(os.write_tag(5, ::protobuf::wire_format::WireTypeLengthDelimited));
+            try!(os.write_raw_varint32(v.get_cached_size()));
+            try!(v.write_to_with_cached_sizes(os));
+        };
+        try!(os.write_unknown_fields(self.get_unknown_fields()));
+        ::std::result::Result::Ok(())
+    }
+
+    fn get_cached_size(&self) -> u32 {
+        self.cached_size.get()
+    }
+
+    fn get_unknown_fields(&self) -> &::protobuf::UnknownFields {
+        &self.unknown_fields
+    }
+
+    fn mut_unknown_fields(&mut self) -> &mut ::protobuf::UnknownFields {
+        &mut self.unknown_fields
+    }
+
+    fn type_id(&self) -> ::std::any::TypeId {
+        ::std::any::TypeId::of::<Swim>()
+    }
+
+    fn as_any(&self) -> &::std::any::Any {
+        self as &::std::any::Any
+    }
+
+    fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
+        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+    }
+}
+
+impl ::protobuf::MessageStatic for Swim {
+    fn new() -> Swim {
+        Swim::new()
+    }
+
+    fn descriptor_static(_: ::std::option::Option<Swim>) -> &'static ::protobuf::reflect::MessageDescriptor {
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
+            lock: ::protobuf::lazy::ONCE_INIT,
+            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+        };
+        unsafe {
+            descriptor.get(|| {
+                let mut fields = ::std::vec::Vec::new();
+                fields.push(::protobuf::reflect::accessor::make_singular_enum_accessor(
+                    "type",
+                    Swim::has_field_type,
+                    Swim::get_field_type,
+                ));
+                fields.push(::protobuf::reflect::accessor::make_singular_message_accessor(
+                    "ping",
+                    Swim::has_ping,
+                    Swim::get_ping,
+                ));
+                fields.push(::protobuf::reflect::accessor::make_singular_message_accessor(
+                    "ack",
+                    Swim::has_ack,
+                    Swim::get_ack,
+                ));
+                fields.push(::protobuf::reflect::accessor::make_singular_message_accessor(
+                    "pingreq",
+                    Swim::has_pingreq,
+                    Swim::get_pingreq,
+                ));
+                fields.push(::protobuf::reflect::accessor::make_repeated_message_accessor(
+                    "membership",
+                    Swim::get_membership,
+                ));
+                ::protobuf::reflect::MessageDescriptor::new::<Swim>(
+                    "Swim",
+                    fields,
+                    file_descriptor_proto()
+                )
+            })
+        }
+    }
+}
+
+impl ::protobuf::Clear for Swim {
+    fn clear(&mut self) {
+        self.clear_field_type();
+        self.clear_ping();
+        self.clear_ack();
+        self.clear_pingreq();
+        self.clear_membership();
+        self.unknown_fields.clear();
+    }
+}
+
+impl ::std::cmp::PartialEq for Swim {
+    fn eq(&self, other: &Swim) -> bool {
+        self.field_type == other.field_type &&
+        self.ping == other.ping &&
+        self.ack == other.ack &&
+        self.pingreq == other.pingreq &&
+        self.membership == other.membership &&
+        self.unknown_fields == other.unknown_fields
+    }
+}
+
+impl ::std::fmt::Debug for Swim {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        ::protobuf::text_format::fmt(self, f)
+    }
+}
+
+#[derive(Clone,PartialEq,Eq,Debug,Hash)]
+pub enum Swim_Type {
+    PING = 1,
+    ACK = 2,
+    PINGREQ = 3,
+}
+
+impl ::protobuf::ProtobufEnum for Swim_Type {
+    fn value(&self) -> i32 {
+        *self as i32
+    }
+
+    fn from_i32(value: i32) -> ::std::option::Option<Swim_Type> {
+        match value {
+            1 => ::std::option::Option::Some(Swim_Type::PING),
+            2 => ::std::option::Option::Some(Swim_Type::ACK),
+            3 => ::std::option::Option::Some(Swim_Type::PINGREQ),
+            _ => ::std::option::Option::None
+        }
+    }
+
+    fn values() -> &'static [Self] {
+        static values: &'static [Swim_Type] = &[
+            Swim_Type::PING,
+            Swim_Type::ACK,
+            Swim_Type::PINGREQ,
+        ];
+        values
+    }
+
+    fn enum_descriptor_static(_: Option<Swim_Type>) -> &'static ::protobuf::reflect::EnumDescriptor {
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> = ::protobuf::lazy::Lazy {
+            lock: ::protobuf::lazy::ONCE_INIT,
+            ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
+        };
+        unsafe {
+            descriptor.get(|| {
+                ::protobuf::reflect::EnumDescriptor::new("Swim_Type", file_descriptor_proto())
+            })
+        }
+    }
+}
+
+impl ::std::marker::Copy for Swim_Type {
+}
+
+static file_descriptor_proto_data: &'static [u8] = &[
+    0x0a, 0x14, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x63, 0x6f, 0x6c, 0x73, 0x2f, 0x73, 0x77, 0x69, 0x6d,
+    0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x22, 0x7b, 0x0a, 0x06, 0x4d, 0x65, 0x6d, 0x62, 0x65, 0x72,
+    0x12, 0x0e, 0x0a, 0x02, 0x69, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x02, 0x69, 0x64,
+    0x12, 0x20, 0x0a, 0x0b, 0x69, 0x6e, 0x63, 0x61, 0x72, 0x6e, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x18,
+    0x02, 0x20, 0x01, 0x28, 0x04, 0x52, 0x0b, 0x69, 0x6e, 0x63, 0x61, 0x72, 0x6e, 0x61, 0x74, 0x69,
+    0x6f, 0x6e, 0x12, 0x18, 0x0a, 0x07, 0x61, 0x64, 0x64, 0x72, 0x65, 0x73, 0x73, 0x18, 0x03, 0x20,
+    0x01, 0x28, 0x09, 0x52, 0x07, 0x61, 0x64, 0x64, 0x72, 0x65, 0x73, 0x73, 0x12, 0x25, 0x0a, 0x0a,
+    0x70, 0x65, 0x72, 0x73, 0x69, 0x73, 0x74, 0x65, 0x6e, 0x74, 0x18, 0x04, 0x20, 0x01, 0x28, 0x08,
+    0x3a, 0x05, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x52, 0x0a, 0x70, 0x65, 0x72, 0x73, 0x69, 0x73, 0x74,
+    0x65, 0x6e, 0x74, 0x22, 0x4b, 0x0a, 0x04, 0x50, 0x69, 0x6e, 0x67, 0x12, 0x1b, 0x0a, 0x04, 0x66,
+    0x72, 0x6f, 0x6d, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x07, 0x2e, 0x4d, 0x65, 0x6d, 0x62,
+    0x65, 0x72, 0x52, 0x04, 0x66, 0x72, 0x6f, 0x6d, 0x12, 0x26, 0x0a, 0x0a, 0x66, 0x6f, 0x72, 0x77,
+    0x61, 0x72, 0x64, 0x5f, 0x74, 0x6f, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x07, 0x2e, 0x4d,
+    0x65, 0x6d, 0x62, 0x65, 0x72, 0x52, 0x09, 0x66, 0x6f, 0x72, 0x77, 0x61, 0x72, 0x64, 0x54, 0x6f,
+    0x22, 0x4a, 0x0a, 0x03, 0x41, 0x63, 0x6b, 0x12, 0x1b, 0x0a, 0x04, 0x66, 0x72, 0x6f, 0x6d, 0x18,
+    0x01, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x07, 0x2e, 0x4d, 0x65, 0x6d, 0x62, 0x65, 0x72, 0x52, 0x04,
+    0x66, 0x72, 0x6f, 0x6d, 0x12, 0x26, 0x0a, 0x0a, 0x66, 0x6f, 0x72, 0x77, 0x61, 0x72, 0x64, 0x5f,
+    0x74, 0x6f, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x07, 0x2e, 0x4d, 0x65, 0x6d, 0x62, 0x65,
+    0x72, 0x52, 0x09, 0x66, 0x6f, 0x72, 0x77, 0x61, 0x72, 0x64, 0x54, 0x6f, 0x22, 0x47, 0x0a, 0x07,
+    0x50, 0x69, 0x6e, 0x67, 0x52, 0x65, 0x71, 0x12, 0x1b, 0x0a, 0x04, 0x66, 0x72, 0x6f, 0x6d, 0x18,
+    0x01, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x07, 0x2e, 0x4d, 0x65, 0x6d, 0x62, 0x65, 0x72, 0x52, 0x04,
+    0x66, 0x72, 0x6f, 0x6d, 0x12, 0x1f, 0x0a, 0x06, 0x74, 0x61, 0x72, 0x67, 0x65, 0x74, 0x18, 0x02,
+    0x20, 0x01, 0x28, 0x0b, 0x32, 0x07, 0x2e, 0x4d, 0x65, 0x6d, 0x62, 0x65, 0x72, 0x52, 0x06, 0x74,
+    0x61, 0x72, 0x67, 0x65, 0x74, 0x22, 0x8a, 0x01, 0x0a, 0x0a, 0x4d, 0x65, 0x6d, 0x62, 0x65, 0x72,
+    0x73, 0x68, 0x69, 0x70, 0x12, 0x1f, 0x0a, 0x06, 0x6d, 0x65, 0x6d, 0x62, 0x65, 0x72, 0x18, 0x01,
+    0x20, 0x01, 0x28, 0x0b, 0x32, 0x07, 0x2e, 0x4d, 0x65, 0x6d, 0x62, 0x65, 0x72, 0x52, 0x06, 0x6d,
+    0x65, 0x6d, 0x62, 0x65, 0x72, 0x12, 0x2a, 0x0a, 0x06, 0x68, 0x65, 0x61, 0x6c, 0x74, 0x68, 0x18,
+    0x02, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x12, 0x2e, 0x4d, 0x65, 0x6d, 0x62, 0x65, 0x72, 0x73, 0x68,
+    0x69, 0x70, 0x2e, 0x48, 0x65, 0x61, 0x6c, 0x74, 0x68, 0x52, 0x06, 0x68, 0x65, 0x61, 0x6c, 0x74,
+    0x68, 0x22, 0x2f, 0x0a, 0x06, 0x48, 0x65, 0x61, 0x6c, 0x74, 0x68, 0x12, 0x09, 0x0a, 0x05, 0x41,
+    0x4c, 0x49, 0x56, 0x45, 0x10, 0x01, 0x12, 0x0b, 0x0a, 0x07, 0x53, 0x55, 0x53, 0x50, 0x45, 0x43,
+    0x54, 0x10, 0x02, 0x12, 0x0d, 0x0a, 0x09, 0x43, 0x4f, 0x4e, 0x46, 0x49, 0x52, 0x4d, 0x45, 0x44,
+    0x10, 0x03, 0x22, 0xd2, 0x01, 0x0a, 0x04, 0x53, 0x77, 0x69, 0x6d, 0x12, 0x1e, 0x0a, 0x04, 0x74,
+    0x79, 0x70, 0x65, 0x18, 0x01, 0x20, 0x02, 0x28, 0x0e, 0x32, 0x0a, 0x2e, 0x53, 0x77, 0x69, 0x6d,
+    0x2e, 0x54, 0x79, 0x70, 0x65, 0x52, 0x04, 0x74, 0x79, 0x70, 0x65, 0x12, 0x19, 0x0a, 0x04, 0x70,
+    0x69, 0x6e, 0x67, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x05, 0x2e, 0x50, 0x69, 0x6e, 0x67,
+    0x52, 0x04, 0x70, 0x69, 0x6e, 0x67, 0x12, 0x16, 0x0a, 0x03, 0x61, 0x63, 0x6b, 0x18, 0x03, 0x20,
+    0x01, 0x28, 0x0b, 0x32, 0x04, 0x2e, 0x41, 0x63, 0x6b, 0x52, 0x03, 0x61, 0x63, 0x6b, 0x12, 0x22,
+    0x0a, 0x07, 0x70, 0x69, 0x6e, 0x67, 0x72, 0x65, 0x71, 0x18, 0x04, 0x20, 0x01, 0x28, 0x0b, 0x32,
+    0x08, 0x2e, 0x50, 0x69, 0x6e, 0x67, 0x52, 0x65, 0x71, 0x52, 0x07, 0x70, 0x69, 0x6e, 0x67, 0x72,
+    0x65, 0x71, 0x12, 0x2b, 0x0a, 0x0a, 0x6d, 0x65, 0x6d, 0x62, 0x65, 0x72, 0x73, 0x68, 0x69, 0x70,
+    0x18, 0x05, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x0b, 0x2e, 0x4d, 0x65, 0x6d, 0x62, 0x65, 0x72, 0x73,
+    0x68, 0x69, 0x70, 0x52, 0x0a, 0x6d, 0x65, 0x6d, 0x62, 0x65, 0x72, 0x73, 0x68, 0x69, 0x70, 0x22,
+    0x26, 0x0a, 0x04, 0x54, 0x79, 0x70, 0x65, 0x12, 0x08, 0x0a, 0x04, 0x50, 0x49, 0x4e, 0x47, 0x10,
+    0x01, 0x12, 0x07, 0x0a, 0x03, 0x41, 0x43, 0x4b, 0x10, 0x02, 0x12, 0x0b, 0x0a, 0x07, 0x50, 0x49,
+    0x4e, 0x47, 0x52, 0x45, 0x51, 0x10, 0x03, 0x4a, 0xd7, 0x0d, 0x0a, 0x06, 0x12, 0x04, 0x00, 0x00,
+    0x2a, 0x01, 0x0a, 0x08, 0x0a, 0x01, 0x0c, 0x12, 0x03, 0x00, 0x00, 0x12, 0x0a, 0x0a, 0x0a, 0x02,
+    0x04, 0x00, 0x12, 0x04, 0x02, 0x00, 0x07, 0x01, 0x0a, 0x0a, 0x0a, 0x03, 0x04, 0x00, 0x01, 0x12,
+    0x03, 0x02, 0x08, 0x0e, 0x0a, 0x0b, 0x0a, 0x04, 0x04, 0x00, 0x02, 0x00, 0x12, 0x03, 0x03, 0x02,
+    0x19, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x00, 0x02, 0x00, 0x04, 0x12, 0x03, 0x03, 0x02, 0x0a, 0x0a,
+    0x0c, 0x0a, 0x05, 0x04, 0x00, 0x02, 0x00, 0x05, 0x12, 0x03, 0x03, 0x0b, 0x11, 0x0a, 0x0c, 0x0a,
+    0x05, 0x04, 0x00, 0x02, 0x00, 0x01, 0x12, 0x03, 0x03, 0x12, 0x14, 0x0a, 0x0c, 0x0a, 0x05, 0x04,
+    0x00, 0x02, 0x00, 0x03, 0x12, 0x03, 0x03, 0x17, 0x18, 0x0a, 0x0b, 0x0a, 0x04, 0x04, 0x00, 0x02,
+    0x01, 0x12, 0x03, 0x04, 0x02, 0x22, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x00, 0x02, 0x01, 0x04, 0x12,
+    0x03, 0x04, 0x02, 0x0a, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x00, 0x02, 0x01, 0x05, 0x12, 0x03, 0x04,
+    0x0b, 0x11, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x00, 0x02, 0x01, 0x01, 0x12, 0x03, 0x04, 0x12, 0x1d,
+    0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x00, 0x02, 0x01, 0x03, 0x12, 0x03, 0x04, 0x20, 0x21, 0x0a, 0x0b,
+    0x0a, 0x04, 0x04, 0x00, 0x02, 0x02, 0x12, 0x03, 0x05, 0x02, 0x1e, 0x0a, 0x0c, 0x0a, 0x05, 0x04,
+    0x00, 0x02, 0x02, 0x04, 0x12, 0x03, 0x05, 0x02, 0x0a, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x00, 0x02,
+    0x02, 0x05, 0x12, 0x03, 0x05, 0x0b, 0x11, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x00, 0x02, 0x02, 0x01,
+    0x12, 0x03, 0x05, 0x12, 0x19, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x00, 0x02, 0x02, 0x03, 0x12, 0x03,
+    0x05, 0x1c, 0x1d, 0x0a, 0x0b, 0x0a, 0x04, 0x04, 0x00, 0x02, 0x03, 0x12, 0x03, 0x06, 0x02, 0x31,
+    0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x00, 0x02, 0x03, 0x04, 0x12, 0x03, 0x06, 0x02, 0x0a, 0x0a, 0x0c,
+    0x0a, 0x05, 0x04, 0x00, 0x02, 0x03, 0x05, 0x12, 0x03, 0x06, 0x0b, 0x0f, 0x0a, 0x0c, 0x0a, 0x05,
+    0x04, 0x00, 0x02, 0x03, 0x01, 0x12, 0x03, 0x06, 0x10, 0x1a, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x00,
+    0x02, 0x03, 0x03, 0x12, 0x03, 0x06, 0x1d, 0x1e, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x00, 0x02, 0x03,
+    0x08, 0x12, 0x03, 0x06, 0x1f, 0x30, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x00, 0x02, 0x03, 0x07, 0x12,
+    0x03, 0x06, 0x2a, 0x2f, 0x0a, 0x0a, 0x0a, 0x02, 0x04, 0x01, 0x12, 0x04, 0x09, 0x00, 0x0c, 0x01,
+    0x0a, 0x0a, 0x0a, 0x03, 0x04, 0x01, 0x01, 0x12, 0x03, 0x09, 0x08, 0x0c, 0x0a, 0x0b, 0x0a, 0x04,
+    0x04, 0x01, 0x02, 0x00, 0x12, 0x03, 0x0a, 0x02, 0x1b, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x01, 0x02,
+    0x00, 0x04, 0x12, 0x03, 0x0a, 0x02, 0x0a, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x01, 0x02, 0x00, 0x06,
+    0x12, 0x03, 0x0a, 0x0b, 0x11, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x01, 0x02, 0x00, 0x01, 0x12, 0x03,
+    0x0a, 0x12, 0x16, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x01, 0x02, 0x00, 0x03, 0x12, 0x03, 0x0a, 0x19,
+    0x1a, 0x0a, 0x0b, 0x0a, 0x04, 0x04, 0x01, 0x02, 0x01, 0x12, 0x03, 0x0b, 0x02, 0x21, 0x0a, 0x0c,
+    0x0a, 0x05, 0x04, 0x01, 0x02, 0x01, 0x04, 0x12, 0x03, 0x0b, 0x02, 0x0a, 0x0a, 0x0c, 0x0a, 0x05,
+    0x04, 0x01, 0x02, 0x01, 0x06, 0x12, 0x03, 0x0b, 0x0b, 0x11, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x01,
+    0x02, 0x01, 0x01, 0x12, 0x03, 0x0b, 0x12, 0x1c, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x01, 0x02, 0x01,
+    0x03, 0x12, 0x03, 0x0b, 0x1f, 0x20, 0x0a, 0x0a, 0x0a, 0x02, 0x04, 0x02, 0x12, 0x04, 0x0e, 0x00,
+    0x11, 0x01, 0x0a, 0x0a, 0x0a, 0x03, 0x04, 0x02, 0x01, 0x12, 0x03, 0x0e, 0x08, 0x0b, 0x0a, 0x0b,
+    0x0a, 0x04, 0x04, 0x02, 0x02, 0x00, 0x12, 0x03, 0x0f, 0x02, 0x1b, 0x0a, 0x0c, 0x0a, 0x05, 0x04,
+    0x02, 0x02, 0x00, 0x04, 0x12, 0x03, 0x0f, 0x02, 0x0a, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x02, 0x02,
+    0x00, 0x06, 0x12, 0x03, 0x0f, 0x0b, 0x11, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x02, 0x02, 0x00, 0x01,
+    0x12, 0x03, 0x0f, 0x12, 0x16, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x02, 0x02, 0x00, 0x03, 0x12, 0x03,
+    0x0f, 0x19, 0x1a, 0x0a, 0x0b, 0x0a, 0x04, 0x04, 0x02, 0x02, 0x01, 0x12, 0x03, 0x10, 0x02, 0x21,
+    0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x02, 0x02, 0x01, 0x04, 0x12, 0x03, 0x10, 0x02, 0x0a, 0x0a, 0x0c,
+    0x0a, 0x05, 0x04, 0x02, 0x02, 0x01, 0x06, 0x12, 0x03, 0x10, 0x0b, 0x11, 0x0a, 0x0c, 0x0a, 0x05,
+    0x04, 0x02, 0x02, 0x01, 0x01, 0x12, 0x03, 0x10, 0x12, 0x1c, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x02,
+    0x02, 0x01, 0x03, 0x12, 0x03, 0x10, 0x1f, 0x20, 0x0a, 0x0a, 0x0a, 0x02, 0x04, 0x03, 0x12, 0x04,
+    0x13, 0x00, 0x16, 0x01, 0x0a, 0x0a, 0x0a, 0x03, 0x04, 0x03, 0x01, 0x12, 0x03, 0x13, 0x08, 0x0f,
+    0x0a, 0x0b, 0x0a, 0x04, 0x04, 0x03, 0x02, 0x00, 0x12, 0x03, 0x14, 0x02, 0x1b, 0x0a, 0x0c, 0x0a,
+    0x05, 0x04, 0x03, 0x02, 0x00, 0x04, 0x12, 0x03, 0x14, 0x02, 0x0a, 0x0a, 0x0c, 0x0a, 0x05, 0x04,
+    0x03, 0x02, 0x00, 0x06, 0x12, 0x03, 0x14, 0x0b, 0x11, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x03, 0x02,
+    0x00, 0x01, 0x12, 0x03, 0x14, 0x12, 0x16, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x03, 0x02, 0x00, 0x03,
+    0x12, 0x03, 0x14, 0x19, 0x1a, 0x0a, 0x0b, 0x0a, 0x04, 0x04, 0x03, 0x02, 0x01, 0x12, 0x03, 0x15,
+    0x02, 0x1d, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x03, 0x02, 0x01, 0x04, 0x12, 0x03, 0x15, 0x02, 0x0a,
+    0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x03, 0x02, 0x01, 0x06, 0x12, 0x03, 0x15, 0x0b, 0x11, 0x0a, 0x0c,
+    0x0a, 0x05, 0x04, 0x03, 0x02, 0x01, 0x01, 0x12, 0x03, 0x15, 0x12, 0x18, 0x0a, 0x0c, 0x0a, 0x05,
+    0x04, 0x03, 0x02, 0x01, 0x03, 0x12, 0x03, 0x15, 0x1b, 0x1c, 0x0a, 0x0a, 0x0a, 0x02, 0x04, 0x04,
+    0x12, 0x04, 0x18, 0x00, 0x1d, 0x01, 0x0a, 0x0a, 0x0a, 0x03, 0x04, 0x04, 0x01, 0x12, 0x03, 0x18,
+    0x08, 0x12, 0x0a, 0x0b, 0x0a, 0x04, 0x04, 0x04, 0x04, 0x00, 0x12, 0x03, 0x19, 0x02, 0x38, 0x0a,
+    0x0c, 0x0a, 0x05, 0x04, 0x04, 0x04, 0x00, 0x01, 0x12, 0x03, 0x19, 0x07, 0x0d, 0x0a, 0x0d, 0x0a,
+    0x06, 0x04, 0x04, 0x04, 0x00, 0x02, 0x00, 0x12, 0x03, 0x19, 0x10, 0x1a, 0x0a, 0x0e, 0x0a, 0x07,
+    0x04, 0x04, 0x04, 0x00, 0x02, 0x00, 0x01, 0x12, 0x03, 0x19, 0x10, 0x15, 0x0a, 0x0e, 0x0a, 0x07,
+    0x04, 0x04, 0x04, 0x00, 0x02, 0x00, 0x02, 0x12, 0x03, 0x19, 0x18, 0x19, 0x0a, 0x0d, 0x0a, 0x06,
+    0x04, 0x04, 0x04, 0x00, 0x02, 0x01, 0x12, 0x03, 0x19, 0x1b, 0x27, 0x0a, 0x0e, 0x0a, 0x07, 0x04,
+    0x04, 0x04, 0x00, 0x02, 0x01, 0x01, 0x12, 0x03, 0x19, 0x1b, 0x22, 0x0a, 0x0e, 0x0a, 0x07, 0x04,
+    0x04, 0x04, 0x00, 0x02, 0x01, 0x02, 0x12, 0x03, 0x19, 0x25, 0x26, 0x0a, 0x0d, 0x0a, 0x06, 0x04,
+    0x04, 0x04, 0x00, 0x02, 0x02, 0x12, 0x03, 0x19, 0x28, 0x36, 0x0a, 0x0e, 0x0a, 0x07, 0x04, 0x04,
+    0x04, 0x00, 0x02, 0x02, 0x01, 0x12, 0x03, 0x19, 0x28, 0x31, 0x0a, 0x0e, 0x0a, 0x07, 0x04, 0x04,
+    0x04, 0x00, 0x02, 0x02, 0x02, 0x12, 0x03, 0x19, 0x34, 0x35, 0x0a, 0x0b, 0x0a, 0x04, 0x04, 0x04,
+    0x02, 0x00, 0x12, 0x03, 0x1b, 0x02, 0x1d, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x04, 0x02, 0x00, 0x04,
+    0x12, 0x03, 0x1b, 0x02, 0x0a, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x04, 0x02, 0x00, 0x06, 0x12, 0x03,
+    0x1b, 0x0b, 0x11, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x04, 0x02, 0x00, 0x01, 0x12, 0x03, 0x1b, 0x12,
+    0x18, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x04, 0x02, 0x00, 0x03, 0x12, 0x03, 0x1b, 0x1b, 0x1c, 0x0a,
+    0x0b, 0x0a, 0x04, 0x04, 0x04, 0x02, 0x01, 0x12, 0x03, 0x1c, 0x02, 0x1d, 0x0a, 0x0c, 0x0a, 0x05,
+    0x04, 0x04, 0x02, 0x01, 0x04, 0x12, 0x03, 0x1c, 0x02, 0x0a, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x04,
+    0x02, 0x01, 0x06, 0x12, 0x03, 0x1c, 0x0b, 0x11, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x04, 0x02, 0x01,
+    0x01, 0x12, 0x03, 0x1c, 0x12, 0x18, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x04, 0x02, 0x01, 0x03, 0x12,
+    0x03, 0x1c, 0x1b, 0x1c, 0x0a, 0x0a, 0x0a, 0x02, 0x04, 0x05, 0x12, 0x04, 0x1f, 0x00, 0x2a, 0x01,
+    0x0a, 0x0a, 0x0a, 0x03, 0x04, 0x05, 0x01, 0x12, 0x03, 0x1f, 0x08, 0x0c, 0x0a, 0x0b, 0x0a, 0x04,
+    0x04, 0x05, 0x04, 0x00, 0x12, 0x03, 0x20, 0x02, 0x2f, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x05, 0x04,
+    0x00, 0x01, 0x12, 0x03, 0x20, 0x07, 0x0b, 0x0a, 0x0d, 0x0a, 0x06, 0x04, 0x05, 0x04, 0x00, 0x02,
+    0x00, 0x12, 0x03, 0x20, 0x0e, 0x17, 0x0a, 0x0e, 0x0a, 0x07, 0x04, 0x05, 0x04, 0x00, 0x02, 0x00,
+    0x01, 0x12, 0x03, 0x20, 0x0e, 0x12, 0x0a, 0x0e, 0x0a, 0x07, 0x04, 0x05, 0x04, 0x00, 0x02, 0x00,
+    0x02, 0x12, 0x03, 0x20, 0x15, 0x16, 0x0a, 0x0d, 0x0a, 0x06, 0x04, 0x05, 0x04, 0x00, 0x02, 0x01,
+    0x12, 0x03, 0x20, 0x18, 0x20, 0x0a, 0x0e, 0x0a, 0x07, 0x04, 0x05, 0x04, 0x00, 0x02, 0x01, 0x01,
+    0x12, 0x03, 0x20, 0x18, 0x1b, 0x0a, 0x0e, 0x0a, 0x07, 0x04, 0x05, 0x04, 0x00, 0x02, 0x01, 0x02,
+    0x12, 0x03, 0x20, 0x1e, 0x1f, 0x0a, 0x0d, 0x0a, 0x06, 0x04, 0x05, 0x04, 0x00, 0x02, 0x02, 0x12,
+    0x03, 0x20, 0x21, 0x2d, 0x0a, 0x0e, 0x0a, 0x07, 0x04, 0x05, 0x04, 0x00, 0x02, 0x02, 0x01, 0x12,
+    0x03, 0x20, 0x21, 0x28, 0x0a, 0x0e, 0x0a, 0x07, 0x04, 0x05, 0x04, 0x00, 0x02, 0x02, 0x02, 0x12,
+    0x03, 0x20, 0x2b, 0x2c, 0x0a, 0x33, 0x0a, 0x04, 0x04, 0x05, 0x02, 0x00, 0x12, 0x03, 0x23, 0x02,
+    0x19, 0x1a, 0x26, 0x20, 0x49, 0x64, 0x65, 0x6e, 0x74, 0x69, 0x66, 0x69, 0x65, 0x73, 0x20, 0x77,
+    0x68, 0x69, 0x63, 0x68, 0x20, 0x66, 0x69, 0x65, 0x6c, 0x64, 0x20, 0x69, 0x73, 0x20, 0x66, 0x69,
+    0x6c, 0x6c, 0x65, 0x64, 0x20, 0x69, 0x6e, 0x2e, 0x0a, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x05, 0x02,
+    0x00, 0x04, 0x12, 0x03, 0x23, 0x02, 0x0a, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x05, 0x02, 0x00, 0x06,
+    0x12, 0x03, 0x23, 0x0b, 0x0f, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x05, 0x02, 0x00, 0x01, 0x12, 0x03,
+    0x23, 0x10, 0x14, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x05, 0x02, 0x00, 0x03, 0x12, 0x03, 0x23, 0x17,
+    0x18, 0x0a, 0x17, 0x0a, 0x04, 0x04, 0x05, 0x02, 0x01, 0x12, 0x03, 0x26, 0x02, 0x19, 0x1a, 0x0a,
+    0x20, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x61, 0x6c, 0x0a, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x05,
+    0x02, 0x01, 0x04, 0x12, 0x03, 0x26, 0x02, 0x0a, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x05, 0x02, 0x01,
+    0x06, 0x12, 0x03, 0x26, 0x0b, 0x0f, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x05, 0x02, 0x01, 0x01, 0x12,
+    0x03, 0x26, 0x10, 0x14, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x05, 0x02, 0x01, 0x03, 0x12, 0x03, 0x26,
+    0x17, 0x18, 0x0a, 0x0b, 0x0a, 0x04, 0x04, 0x05, 0x02, 0x02, 0x12, 0x03, 0x27, 0x02, 0x17, 0x0a,
+    0x0c, 0x0a, 0x05, 0x04, 0x05, 0x02, 0x02, 0x04, 0x12, 0x03, 0x27, 0x02, 0x0a, 0x0a, 0x0c, 0x0a,
+    0x05, 0x04, 0x05, 0x02, 0x02, 0x06, 0x12, 0x03, 0x27, 0x0b, 0x0e, 0x0a, 0x0c, 0x0a, 0x05, 0x04,
+    0x05, 0x02, 0x02, 0x01, 0x12, 0x03, 0x27, 0x0f, 0x12, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x05, 0x02,
+    0x02, 0x03, 0x12, 0x03, 0x27, 0x15, 0x16, 0x0a, 0x0b, 0x0a, 0x04, 0x04, 0x05, 0x02, 0x03, 0x12,
+    0x03, 0x28, 0x02, 0x1f, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x05, 0x02, 0x03, 0x04, 0x12, 0x03, 0x28,
+    0x02, 0x0a, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x05, 0x02, 0x03, 0x06, 0x12, 0x03, 0x28, 0x0b, 0x12,
+    0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x05, 0x02, 0x03, 0x01, 0x12, 0x03, 0x28, 0x13, 0x1a, 0x0a, 0x0c,
+    0x0a, 0x05, 0x04, 0x05, 0x02, 0x03, 0x03, 0x12, 0x03, 0x28, 0x1d, 0x1e, 0x0a, 0x0b, 0x0a, 0x04,
+    0x04, 0x05, 0x02, 0x04, 0x12, 0x03, 0x29, 0x02, 0x25, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x05, 0x02,
+    0x04, 0x04, 0x12, 0x03, 0x29, 0x02, 0x0a, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x05, 0x02, 0x04, 0x06,
+    0x12, 0x03, 0x29, 0x0b, 0x15, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x05, 0x02, 0x04, 0x01, 0x12, 0x03,
+    0x29, 0x16, 0x20, 0x0a, 0x0c, 0x0a, 0x05, 0x04, 0x05, 0x02, 0x04, 0x03, 0x12, 0x03, 0x29, 0x23,
+    0x24,
+];
+
+static mut file_descriptor_proto_lazy: ::protobuf::lazy::Lazy<::protobuf::descriptor::FileDescriptorProto> = ::protobuf::lazy::Lazy {
+    lock: ::protobuf::lazy::ONCE_INIT,
+    ptr: 0 as *const ::protobuf::descriptor::FileDescriptorProto,
+};
+
+fn parse_descriptor_proto() -> ::protobuf::descriptor::FileDescriptorProto {
+    ::protobuf::parse_from_bytes(file_descriptor_proto_data).unwrap()
+}
+
+pub fn file_descriptor_proto() -> &'static ::protobuf::descriptor::FileDescriptorProto {
+    unsafe {
+        file_descriptor_proto_lazy.get(|| {
+            parse_descriptor_proto()
+        })
+    }
+}

--- a/components/swim/src/rumor.rs
+++ b/components/swim/src/rumor.rs
@@ -1,0 +1,297 @@
+// Copyright (c) 2016 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Tracks rumors for distribution.
+//!
+//! Each rumor is represented by a `RumorKey`, which has a unique key and a "kind", which
+//! represents what "kind" of rumor it is (for example, a "member").
+//!
+//! These keys are added to a RumorList, which tracks each rumors spread to each member it sends
+//! to. Each rumor is shared with every member `RUMOR_MAX` times.
+//!
+//! New rumors need to implement the `From` trait for `RumorKey`, and then can track the arrival of
+//! new rumors, and dispatch them according to thier `kind`.
+
+use std::collections::HashMap;
+use std::default::Default;
+use std::sync::{Arc, RwLock};
+
+use member::UuidSimple;
+
+/// The description of a `RumorKey`.
+#[derive(Clone, Debug, Hash, PartialEq, PartialOrd, Eq)]
+pub struct RumorKey {
+    pub kind: String,
+    pub key: UuidSimple,
+}
+
+impl RumorKey {
+    pub fn new<A: Into<String>, B: Into<String>>(kind: A, key: B) -> RumorKey {
+        RumorKey {
+            kind: kind.into(),
+            key: key.into(),
+        }
+    }
+}
+
+/// The number of times a rumor will be shared before it goes cold for that member.
+pub const RUMOR_MAX: usize = 2;
+
+/// The RumorList is a map of `RumorKey` entries to member ID's, whose value is the number of times
+/// we have shared this rumor with that member. The list is lazily populated when we ask for rumors
+/// to share for a given member.
+///
+/// When a rumor changes, we re-insert it into the `RumorList` - this automatically sets all the
+/// counters for every member, and starts the sharing cycle over again.
+#[derive(Debug, Clone)]
+pub struct RumorList {
+    rumor_list: Arc<RwLock<HashMap<RumorKey, HashMap<UuidSimple, usize>>>>,
+}
+
+impl Default for RumorList {
+    fn default() -> RumorList {
+        RumorList { rumor_list: Arc::new(RwLock::new(HashMap::new())) }
+    }
+}
+
+pub type RumorVec = Vec<(RumorKey, usize)>;
+
+impl RumorList {
+    /// Add/Update a rumor to the list.
+    pub fn insert<T: Into<RumorKey>>(&self, rumor: T) {
+        let rk: RumorKey = rumor.into();
+        let mut rumors = self.rumor_list.write().expect("Rumor Map lock poisoned");
+        rumors.insert(rk, HashMap::new());
+    }
+
+    /// Return a list of rumors, along with their current heat, sorted by heat. Lowest to highest.
+    /// So all the "0" rumors sort higher than the "2" rumors.
+    pub fn rumors(&self, id: &str) -> RumorVec {
+        let rumors = self.rumor_list.read().expect("Rumor map lock poisoned");
+        let mut rumor_vec: RumorVec = rumors.iter()
+            .map(|(rk, heat_map)| {
+                match heat_map.get(id) {
+                    Some(h) => (rk.clone(), h.clone()),
+                    None => (rk.clone(), 0),
+                }
+            })
+            .filter(|&(ref _rk, heat)| heat < RUMOR_MAX)
+            .collect();
+        rumor_vec.sort_by(|&(ref _a_rk, ref a_heat), &(ref _b_rk, ref b_heat)| b_heat.cmp(&a_heat));
+        rumor_vec
+    }
+
+    /// Take a certain amount of rumors.
+    pub fn take(&self, id: &str, amount: usize) -> RumorVec {
+        self.rumors(id).into_iter().take(amount).collect()
+    }
+
+    /// Take a certain amount of rumors of a given kind.
+    pub fn take_by_kind(&self, id: &str, amount: usize, kind: &str) -> RumorVec {
+        self.rumors(id)
+            .into_iter()
+            .filter(|&(ref rk, ref _heat)| rk.kind == kind)
+            .take(amount)
+            .collect()
+    }
+
+    /// Increment the heat for a given member for the list of rumors given.
+    pub fn update_heat(&self, id: &str, rumors: &RumorVec) {
+        if rumors.len() > 0 {
+            let mut rumor_map = self.rumor_list.write().expect("Rumor map lock poisoned");
+            for &(ref rk, ref _heat) in rumors {
+                if rumor_map.contains_key(&rk) {
+                    let mut heat_map = rumor_map.get_mut(&rk).unwrap();
+                    if heat_map.contains_key(id) {
+                        let mut heat = heat_map.get_mut(id).unwrap();
+                        *heat += 1;
+                    } else {
+                        heat_map.insert(String::from(id), 1);
+                    }
+                } else {
+                    debug!("Rumor does not exist in map; was probably deleted between retrieval \
+                            and sending");
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use uuid::Uuid;
+
+    use rumor::RumorKey;
+
+    pub struct FakeRumor {
+        pub id: Uuid,
+    }
+
+    impl Default for FakeRumor {
+        fn default() -> FakeRumor {
+            FakeRumor { id: Uuid::new_v4() }
+        }
+    }
+
+    impl<'a> From<&'a FakeRumor> for RumorKey {
+        fn from(rumor: &FakeRumor) -> RumorKey {
+            RumorKey {
+                kind: String::from("fake"),
+                key: rumor.id.simple().to_string(),
+            }
+        }
+    }
+
+    impl From<FakeRumor> for RumorKey {
+        fn from(rumor: FakeRumor) -> RumorKey {
+            RumorKey {
+                kind: String::from("fake"),
+                key: rumor.id.simple().to_string(),
+            }
+        }
+    }
+
+    pub struct TrumpRumor {
+        pub id: Uuid,
+    }
+
+    impl Default for TrumpRumor {
+        fn default() -> TrumpRumor {
+            TrumpRumor { id: Uuid::new_v4() }
+        }
+    }
+
+    impl<'a> From<&'a TrumpRumor> for RumorKey {
+        fn from(rumor: &TrumpRumor) -> RumorKey {
+            RumorKey {
+                kind: String::from("trump"),
+                key: rumor.id.simple().to_string(),
+            }
+        }
+    }
+
+    impl From<TrumpRumor> for RumorKey {
+        fn from(rumor: TrumpRumor) -> RumorKey {
+            RumorKey {
+                kind: String::from("trump"),
+                key: rumor.id.simple().to_string(),
+            }
+        }
+    }
+
+    mod rumor_list {
+        use super::{FakeRumor, TrumpRumor};
+        use rumor::{RumorList, RUMOR_MAX};
+
+        #[test]
+        fn insert() {
+            let rl = RumorList::default();
+            let rumor = FakeRumor::default();
+            rl.insert(&rumor);
+        }
+
+        #[test]
+        fn rumors() {
+            let rl = RumorList::default();
+            for _ in 0..100 {
+                let rumor = FakeRumor::default();
+                rl.insert(&rumor);
+            }
+            let rumors = rl.rumors(&String::from("fake"));
+            assert_eq!(rumors.len(), 100);
+        }
+
+        #[test]
+        fn take() {
+            let rl = RumorList::default();
+            for _ in 0..100 {
+                let rumor = FakeRumor::default();
+                rl.insert(&rumor);
+            }
+            let rumors = rl.take(&String::from("fake"), 5);
+            assert_eq!(rumors.len(), 5);
+        }
+
+        #[test]
+        fn take_by_kind() {
+            let rl = RumorList::default();
+            for _ in 0..100 {
+                let rumor = FakeRumor::default();
+                rl.insert(&rumor);
+            }
+            for _ in 0..100 {
+                let rumor = TrumpRumor::default();
+                rl.insert(&rumor);
+            }
+            let rumors = rl.take_by_kind(&String::from("fake"), 100, "trump");
+            assert_eq!(rumors.len(), 100);
+            assert_eq!(rumors.iter().all(|&(ref rk, ref _heat)| rk.kind == "trump"),
+                       true);
+        }
+
+        #[test]
+        fn update_heat() {
+            let rl = RumorList::default();
+            for _ in 0..10 {
+                let rumor = FakeRumor::default();
+                rl.insert(&rumor);
+            }
+            let rumors = rl.take(&String::from("fake"), 5);
+            rl.update_heat(&String::from("fake"), &rumors);
+            assert_eq!(rl.rumors(&String::from("fake"))
+                           .iter()
+                           .filter(|&&(ref _rk, ref heat)| *heat == 1)
+                           .count(),
+                       5);
+            assert_eq!(rl.rumors(&String::from("fake"))
+                           .iter()
+                           .filter(|&&(ref _rk, ref heat)| *heat == 0)
+                           .count(),
+                       5);
+
+        }
+
+        #[test]
+        fn update_heat_and_take_returns_colder_rumors() {
+            let rl = RumorList::default();
+            for _ in 0..10 {
+                let rumor = FakeRumor::default();
+                rl.insert(&rumor);
+            }
+            let updated_rumors = rl.take(&String::from("fake"), 5);
+            rl.update_heat(&String::from("fake"), &updated_rumors);
+            rl.take(&String::from("fake"), 5);
+            assert_eq!(rl.rumors(&String::from("fake"))
+                           .iter()
+                           .filter(|&&(ref _rk, ref heat)| *heat == 0)
+                           .count(),
+                       5);
+        }
+
+        #[test]
+        fn rumor_list_obeys_max_heat() {
+            let rl = RumorList::default();
+            for _ in 0..10 {
+                let rumor = FakeRumor::default();
+                rl.insert(&rumor);
+            }
+            let rumors = rl.take(&String::from("fake"), 5);
+            for _x in 0..RUMOR_MAX {
+                rl.update_heat(&String::from("fake"), &rumors);
+            }
+            assert_eq!(rl.rumors(&String::from("fake")).len(), 5);
+        }
+
+    }
+}

--- a/components/swim/src/server/expire.rs
+++ b/components/swim/src/server/expire.rs
@@ -1,0 +1,70 @@
+// Copyright (c) 2016 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Expire suspected members.
+//!
+//! This module keeps track of suspected members, and sets their stauts to confirmed if they remain
+//! suspect long enough.
+
+use std::thread;
+use std::time::Duration;
+
+use time::SteadyTime;
+
+use member::Health;
+use rumor::RumorKey;
+use server::Server;
+use server::outbound::Timing;
+
+pub struct Expire<'a> {
+    pub server: &'a Server,
+    pub timing: Timing,
+}
+
+impl<'a> Expire<'a> {
+    /// Takes a reference to a server, and a `Timing`, returns you an Expire struct.
+    pub fn new(server: &'a Server, timing: Timing) -> Expire {
+        Expire {
+            server: server,
+            timing: timing,
+        }
+    }
+
+    /// Run the expire thread.
+    pub fn run(&self) {
+        loop {
+            let mut expired_list: Vec<String> = Vec::new();
+            self.server.member_list.with_suspects(|(id, suspect)| {
+                let now = SteadyTime::now();
+                if *suspect + self.timing.suspicion_timeout_duration() > now {
+                    expired_list.push(String::from(id));
+                    self.server.member_list.insert_health_by_id(id, Health::Confirmed);
+                    self.server.member_list.with_member(id, |has_member| {
+                        let member = has_member.expect("Member does not exist when expiring it");
+                        debug!("Marking {:?} as Confirmed", member);
+                        trace_swim!(&self.server,
+                                    "probe-marked-confirmed",
+                                    member.get_address(),
+                                    None);
+                    });
+                }
+            });
+            for mid in expired_list.iter() {
+                self.server.member_list.expire(mid);
+                self.server.rumor_list.insert(RumorKey::new("member", mid.clone()));
+            }
+            thread::sleep(Duration::from_millis(500));
+        }
+    }
+}

--- a/components/swim/src/server/inbound.rs
+++ b/components/swim/src/server/inbound.rs
@@ -1,0 +1,198 @@
+// Copyright (c) 2016 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! The inbound thread.
+//!
+//! This module handles all the inbound SWIM messages.
+
+use std::sync::mpsc;
+use std::sync::atomic::Ordering;
+use std::net::SocketAddr;
+use std::thread;
+use std::time::Duration;
+
+use protobuf;
+
+use message::swim::{Swim, Swim_Type};
+use server::{Server, outbound};
+use member::{Member, Health};
+
+/// Takes the Server and a channel to send recieved Acks to the outbound thread.
+pub struct Inbound<'a> {
+    pub server: &'a Server,
+    pub tx_outbound: mpsc::Sender<(SocketAddr, Swim)>,
+}
+
+impl<'a> Inbound<'a> {
+    /// Create a new Inbound.
+    pub fn new(server: &'a Server, tx_outbound: mpsc::Sender<(SocketAddr, Swim)>) -> Inbound {
+        Inbound {
+            server: server,
+            tx_outbound: tx_outbound,
+        }
+    }
+
+    /// Run the thread. Listens for messages up to 1k in size, and then processes them accordingly.
+    pub fn run(&self) {
+        let mut recv_buffer: Vec<u8> = vec![0; 1024];
+        loop {
+            if self.server.pause.load(Ordering::Relaxed) {
+                thread::sleep(Duration::from_millis(100));
+                continue;
+            }
+            match self.server.socket.recv_from(&mut recv_buffer[..]) {
+                Ok((length, addr)) => {
+                    if self.server.check_blacklist(&addr) {
+                        debug!("Not processing message from {} - it is blacklisted", addr);
+                        continue;
+                    }
+                    let msg: Swim = match protobuf::parse_from_bytes(&recv_buffer[0..length]) {
+                        Ok(msg) => msg,
+                        Err(e) => {
+                            // NOTE: In the future, we might want to blacklist people who send us
+                            // garbage all the time.
+                            error!("Error parsing protobuf: {:?}", e);
+                            continue;
+                        }
+                    };
+                    debug!("SWIM Message: {:?}", msg);
+                    match msg.get_field_type() {
+                        Swim_Type::PING => {
+                            self.process_ping(addr, msg);
+                        }
+                        Swim_Type::ACK => {
+                            self.process_ack(addr, msg);
+                        }
+                        Swim_Type::PINGREQ => {
+                            self.process_pingreq(addr, msg);
+                        }
+                    }
+                }
+                Err(e) => {
+                    match e.raw_os_error() {
+                        Some(35) => {
+                            // This is the normal non-blocking result
+                        }
+                        Some(_) => {
+                            error!("UDP Receive error: {}", e);
+                            debug!("UDP Receive error debug: {:?}", e);
+                        }
+                        None => {
+                            error!("UDP Receive error: {}", e);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Process pingreq messages.
+    fn process_pingreq(&self, addr: SocketAddr, mut msg: Swim) {
+        trace_swim!(&self.server,
+                    "recv-pingreq",
+                    &format!("{}", addr),
+                    Some(&msg));
+        // We need to get msg to be owned by the closure, so we're going to have to
+        // allocate here to get the id. Kind of a bummer, but life goes on.
+        let mid = String::from(msg.get_pingreq().get_target().get_id());
+        self.server.member_list.with_member(&mid, |m| {
+            let target = match m {
+                Some(target) => target,
+                None => {
+                    error!("PingReq request {:?} for invalid target", msg);
+                    return;
+                }
+            };
+            // Set the route-back address to the one we received the pingreq from
+            let mut from = msg.mut_pingreq().take_from();
+            from.set_address(format!("{}", addr));
+            outbound::ping(self.server,
+                           target,
+                           target.socket_address(),
+                           Some(from.into()));
+        });
+    }
+
+    /// Process ack messages; forwards to the outbound thread.
+    fn process_ack(&self, addr: SocketAddr, mut msg: Swim) {
+        trace_swim!(&self.server, "recv-ack", &format!("{}", addr), Some(&msg));
+        info!("Ack from {}@{}", msg.get_ack().get_from().get_id(), addr);
+        if msg.get_ack().has_forward_to() {
+            let me = match self.server.member.read() {
+                Ok(me) => me,
+                Err(e) => panic!("Member lock is poisoned: {:?}", e),
+            };
+            if me.get_id() != msg.get_ack().get_forward_to().get_id() {
+                let forward_to_addr = match msg.get_ack().get_forward_to().get_address().parse() {
+                    Ok(addr) => addr,
+                    Err(e) => {
+                        error!("Abandoning Ack forward: cannot parse member address: {}, {}",
+                               msg.get_ack().get_forward_to().get_address(),
+                               e);
+                        return;
+                    }
+                };
+                info!("Forwarding Ack from {}@{} to {}@{}",
+                      msg.get_ack().get_from().get_id(),
+                      addr,
+                      msg.get_ack().get_forward_to().get_id(),
+                      msg.get_ack().get_forward_to().get_address(),
+                      );
+                msg.mut_ack().mut_from().set_address(format!("{}", addr));
+                outbound::forward_ack(self.server, forward_to_addr, msg);
+                return;
+            }
+        }
+        let membership = {
+            let membership: Vec<(Member, Health)> = msg.take_membership()
+                .iter()
+                .map(|m| (Member::from(m.get_member()), Health::from(m.get_health())))
+                .collect();
+            membership
+        };
+        match self.tx_outbound.send((addr, msg)) {
+            Ok(()) => {}
+            Err(e) => panic!("Outbound thread has died - this shouldn't happen: #{:?}", e),
+        }
+        self.server.insert_from_rumors(membership);
+    }
+
+    /// Process ping messages.
+    fn process_ping(&self, addr: SocketAddr, mut msg: Swim) {
+        trace_swim!(&self.server, "recv-ping", &format!("{}", addr), Some(&msg));
+        let target: Member = msg.get_ping().get_from().into();
+        if msg.get_ping().has_forward_to() {
+            outbound::ack(self.server,
+                          &target,
+                          addr,
+                          Some(msg.mut_ping().take_forward_to().into()));
+        } else {
+            outbound::ack(self.server, &target, addr, None);
+        }
+        // Populate the member for this sender with its remote address
+        let from = {
+            let mut ping = msg.mut_ping();
+            let mut from = ping.take_from();
+            from.set_address(format!("{}", addr));
+            from
+        };
+        info!("Ping from {}@{}", from.get_id(), addr);
+        self.server.insert_member(from.into(), Health::Alive);
+        let membership: Vec<(Member, Health)> = msg.take_membership()
+            .iter()
+            .map(|m| (Member::from(m.get_member()), Health::from(m.get_health())))
+            .collect();
+        self.server.insert_from_rumors(membership);
+    }
+}

--- a/components/swim/src/server/mod.rs
+++ b/components/swim/src/server/mod.rs
@@ -1,0 +1,274 @@
+// Copyright (c) 2016 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! The SWIM server.
+//!
+//! Creates `Server` structs, that hold everything we need to run the SWIM protocol. Winds up with
+//! 3 separate threads - inbound (incoming connections), outbound (the Probe protocl), and expire
+//! (turning Suspect members into Confirmed members).
+
+pub mod expire;
+pub mod inbound;
+pub mod outbound;
+
+use std::collections::HashSet;
+use std::clone::Clone;
+use std::fmt;
+use std::net::{ToSocketAddrs, UdpSocket, SocketAddr};
+use std::sync::{Arc, RwLock};
+use std::sync::atomic::{AtomicBool, AtomicIsize, Ordering};
+use std::sync::mpsc::channel;
+use std::time::Duration;
+use std::thread;
+
+use error::{Result, Error};
+use member::{Member, Health, MemberList};
+use trace::Trace;
+use rumor::{RumorList, RumorKey};
+
+/// The server struct. Is thread-safe.
+#[derive(Debug)]
+pub struct Server {
+    pub name: Arc<RwLock<String>>,
+    pub socket: UdpSocket,
+    pub member: Arc<RwLock<Member>>,
+    pub member_list: MemberList,
+    pub rumor_list: RumorList,
+    // These are all here for testing support
+    pub pause: Arc<AtomicBool>,
+    pub trace: Arc<RwLock<Trace>>,
+    pub rounds: Arc<AtomicIsize>,
+    pub blacklist: Arc<RwLock<HashSet<SocketAddr>>>,
+}
+
+
+impl Server {
+    /// Create a new server, bound to the `addr`, hosting a particular `member`, and with a
+    /// `Trace` struct.
+    ///
+    /// # Errors
+    ///
+    /// * Returns `Error::CannotBind` if the socket cannot be bound
+    /// * Returns `Error::SocketSetReadTimeout` if the socket read timeout cannot be set
+    /// * Returns `Error::SocketSetWriteTimeout` if the socket write timeout cannot be set
+    pub fn new<A: ToSocketAddrs>(addr: A, member: Member, trace: Trace) -> Result<Server> {
+        let socket = match UdpSocket::bind(addr) {
+            Ok(socket) => socket,
+            Err(e) => return Err(Error::CannotBind(e)),
+        };
+        try!(socket.set_read_timeout(Some(Duration::from_millis(1000))).map_err(|e| Error::SocketSetReadTimeout(e)));
+        try!(socket.set_write_timeout(Some(Duration::from_millis(1000))).map_err(|e| Error::SocketSetReadTimeout(e)));
+        Ok(Server {
+            name: Arc::new(RwLock::new(String::from(member.get_id()))),
+            socket: socket,
+            member: Arc::new(RwLock::new(member)),
+            member_list: MemberList::new(),
+            rumor_list: RumorList::default(),
+            pause: Arc::new(AtomicBool::new(false)),
+            trace: Arc::new(RwLock::new(trace)),
+            rounds: Arc::new(AtomicIsize::new(0)),
+            blacklist: Arc::new(RwLock::new(HashSet::new())),
+        })
+    }
+
+    fn try_clone(&self) -> Result<Server> {
+        let socket = match self.socket.try_clone() {
+            Ok(socket) => socket,
+            Err(e) => {
+                error!("Failed to clone socket; trying again: {:?}", e);
+                return Err(Error::ServerCloneError);
+            }
+        };
+        Ok(Server {
+            name: self.name.clone(),
+            socket: socket,
+            member: self.member.clone(),
+            member_list: self.member_list.clone(),
+            rumor_list: self.rumor_list.clone(),
+            pause: self.pause.clone(),
+            trace: self.trace.clone(),
+            rounds: self.rounds.clone(),
+            blacklist: self.blacklist.clone(),
+        })
+    }
+
+    /// Every iteration of the outbound protocol (which means every member has been pinged if they
+    /// are available) increments the round. If we exceed an isize in rounds, we reset to 0.
+    ///
+    /// This is useful in integration testing, to allow tests to time out after a worst-case
+    /// boundary in rounds.
+    pub fn rounds(&self) -> isize {
+        self.rounds.load(Ordering::SeqCst)
+    }
+
+    /// Adds 1 to the current round, atomically.
+    pub fn update_round(&self) {
+        let current_round = self.rounds.load(Ordering::SeqCst);
+        match current_round.checked_add(1) {
+            Some(_number) => {
+                self.rounds.fetch_add(1, Ordering::SeqCst);
+            }
+            None => {
+                debug!("Exceeded an isize integer in rounds. Congratulations, this is a very \
+                        long running supervisor!");
+                self.rounds.store(0, Ordering::SeqCst);
+            }
+        }
+    }
+
+    /// Start the server, aloung with a `Timing` for outbound connections. Spawns the `inbound`,
+    /// `outbound`, and `expire` threads.
+    pub fn start(&self, timing: outbound::Timing) -> Result<()> {
+        let (tx_outbound, rx_inbound) = channel();
+
+        let server_a = try!(self.try_clone());
+        let server_b = try!(self.try_clone());
+        let server_c = try!(self.try_clone());
+        let timing_b = timing.clone();
+
+        let _ = thread::Builder::new().name("inbound".to_string()).spawn(move || {
+            inbound::Inbound::new(&server_a, tx_outbound).run();
+            panic!("You should never, ever get here, judy");
+        });
+        let _ = thread::Builder::new().name("outbound".to_string()).spawn(move || {
+            outbound::Outbound::new(&server_b, rx_inbound, timing).run();
+            panic!("You should never, ever get here, bob");
+        });
+        let _ = thread::Builder::new().name("expire".to_string()).spawn(move || {
+            expire::Expire::new(&server_c, timing_b).run();
+            panic!("You should never, ever get here, bob");
+        });
+        Ok(())
+    }
+
+    /// Blacklist a given address, causing no traffic to be seen.
+    pub fn add_to_blacklist(&self, addr: SocketAddr) {
+        let mut blacklist = self.blacklist.write().expect("Write lock for blacklist is poisoned");
+        blacklist.insert(addr);
+    }
+
+    /// Remove a given address from the blacklist.
+    pub fn remove_from_blacklist(&self, addr: &SocketAddr) {
+        let mut blacklist = self.blacklist.write().expect("Write lock for blacklist is poisoned");
+        blacklist.remove(addr);
+    }
+
+    /// Check that a given address is on the blacklist.
+    pub fn check_blacklist(&self, addr: &SocketAddr) -> bool {
+        let blacklist = self.blacklist.write().expect("Write lock for blacklist is poisoned");
+        blacklist.contains(addr)
+    }
+
+    /// Stop the outbound and inbound threads from processing work.
+    pub fn pause(&mut self) {
+        self.pause.compare_and_swap(false, true, Ordering::Relaxed);
+    }
+
+    /// Allow the outbound and inbound threads to process work.
+    pub fn unpause(&mut self) {
+        self.pause.compare_and_swap(true, false, Ordering::Relaxed);
+    }
+
+    /// Whether this server is currently paused.
+    pub fn paused(&self) -> bool {
+        self.pause.load(Ordering::Relaxed)
+    }
+
+    /// Return the port number of the socket we are bound to.
+    pub fn port(&self) -> u16 {
+        self.socket
+            .local_addr()
+            .expect("Cannot get the port number; this socket is very bad")
+            .port()
+    }
+
+    /// Return the name of this server.
+    pub fn name(&self) -> String {
+        self.name.read().expect("Server name lock is poisoned").clone()
+    }
+
+    /// Insert a member to the `MemberList`, and update its `RumorKey` appropriately.
+    pub fn insert_member(&self, member: Member, health: Health) {
+        let rk: RumorKey = RumorKey::from(&member);
+        if self.member_list.insert(member, health) {
+            self.rumor_list.insert(rk);
+        }
+    }
+
+    /// Change the helth of a `Member`, and update its `RumorKey`.
+    pub fn insert_health(&self, member: &Member, health: Health) {
+        let rk: RumorKey = RumorKey::from(&member);
+        if self.member_list.insert_health(member, health) {
+            self.rumor_list.insert(rk);
+        }
+    }
+
+    /// Insert members from a list of received rumors.
+    pub fn insert_from_rumors(&self, members: Vec<(Member, Health)>) {
+        let mut me = self.member.write().expect("Member lock is poisoned");
+        for (member, mut health) in members.into_iter() {
+            let mut incremented_incarnation = false;
+            let rk: RumorKey = RumorKey::from(&member);
+            if member.get_id() == me.get_id() {
+                if health != Health::Alive {
+                    let mut incarnation = me.get_incarnation();
+                    incarnation += 1;
+                    me.set_incarnation(incarnation);
+                    health = Health::Alive;
+                    incremented_incarnation = true;
+                }
+            }
+            if self.member_list.insert(member, health) || incremented_incarnation {
+                self.rumor_list.insert(rk);
+            }
+        }
+    }
+}
+
+impl fmt::Display for Server {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}@{}", self.name(), self.port())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    mod server {
+        use server::Server;
+        use server::outbound::Timing;
+        use member::Member;
+        use trace::Trace;
+        use std::sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
+
+        static SERVER_PORT: AtomicUsize = ATOMIC_USIZE_INIT;
+
+        fn start_server() -> Server {
+            SERVER_PORT.compare_and_swap(0, 6666, Ordering::Relaxed);
+            let my_port = SERVER_PORT.fetch_add(1, Ordering::Relaxed);
+            let listen = format!("127.0.0.1:{}", my_port);
+            Server::new(&listen[..], Member::new(), Trace::default()).unwrap()
+        }
+
+        #[test]
+        fn new() {
+            start_server();
+        }
+
+        #[test]
+        fn start_listener() {
+            let server = start_server();
+            server.start(Timing::default()).expect("Server failed to start");
+        }
+    }
+}

--- a/components/swim/src/server/outbound.rs
+++ b/components/swim/src/server/outbound.rs
@@ -1,0 +1,410 @@
+// Copyright (c) 2016 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! The outbound thread.
+//!
+//! This module handles the implementation of the swim probe protocol.
+
+use std::default::Default;
+use std::sync::atomic::Ordering;
+use std::sync::mpsc;
+use std::net::SocketAddr;
+use std::thread;
+use std::time::Duration;
+use std::fmt;
+
+use time::{SteadyTime, Duration as TimeDuration};
+use protobuf::{Message, RepeatedField};
+
+use message::swim::{Ack, Ping, PingReq, Swim, Swim_Type};
+use server::Server;
+use member::{Member, Health};
+
+/// How long to sleep between calls to `recv`.
+const PING_RECV_QUEUE_EMPTY_SLEEP_MS: u64 = 10;
+/// How long to wait for an Ack after we ping
+const PING_TIMING_DEFAULT_MS: i64 = 1000;
+/// How long to wait for an Ack after we PingReq - should be at least 2x the PING_TIMING_DEFAULT_MS
+const PINGREQ_TIMING_DEFAULT_MS: i64 = 2100;
+/// How many protocol periods before a suspect member is marked as confirmed.
+const SUSPICION_TIMEOUT_DEFAULT_PROTOCOL_PERIODS: i64 = 3;
+
+/// Where an Ack came from; either Ping or PingReq.
+#[derive(Debug)]
+enum AckFrom {
+    Ping,
+    PingReq,
+}
+
+impl fmt::Display for AckFrom {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            &AckFrom::Ping => write!(f, "Ping"),
+            &AckFrom::PingReq => write!(f, "PingReq"),
+        }
+    }
+}
+
+/// The timing of the outbound thread.
+#[derive(Debug, Clone)]
+pub struct Timing {
+    pub ping_ms: i64,
+    pub pingreq_ms: i64,
+    pub suspicion_timeout_protocol_periods: i64,
+}
+
+impl Default for Timing {
+    fn default() -> Timing {
+        Timing {
+            ping_ms: PING_TIMING_DEFAULT_MS,
+            pingreq_ms: PINGREQ_TIMING_DEFAULT_MS,
+            suspicion_timeout_protocol_periods: SUSPICION_TIMEOUT_DEFAULT_PROTOCOL_PERIODS,
+        }
+    }
+}
+
+impl Timing {
+    /// Set up a new Timing
+    pub fn new(ping_ms: i64, pingreq_ms: i64, suspicion_timeout_protocol_periods: i64) -> Timing {
+        Timing {
+            ping_ms: ping_ms,
+            pingreq_ms: pingreq_ms,
+            suspicion_timeout_protocol_periods: suspicion_timeout_protocol_periods,
+        }
+    }
+
+    /// How long is a protocl period, in millis.
+    pub fn protocol_period_ms(&self) -> i64 {
+        self.ping_ms + self.pingreq_ms
+    }
+
+    /// When should this ping record time out?
+    pub fn ping_timeout(&self) -> SteadyTime {
+        SteadyTime::now() + TimeDuration::milliseconds(self.ping_ms)
+    }
+
+    /// When should this pingreq timeout?
+    pub fn pingreq_timeout(&self) -> SteadyTime {
+        SteadyTime::now() + TimeDuration::milliseconds(self.pingreq_ms)
+    }
+
+    /// How long before the next scheduled protocol period
+    pub fn next_protocol_period(&self) -> SteadyTime {
+        SteadyTime::now() + TimeDuration::milliseconds(self.ping_ms + self.pingreq_ms)
+    }
+
+    /// How long before this suspect entry times out
+    pub fn suspicion_timeout_duration(&self) -> TimeDuration {
+        TimeDuration::milliseconds(self.protocol_period_ms() *
+                                   self.suspicion_timeout_protocol_periods)
+    }
+}
+
+/// The outbound thread
+pub struct Outbound<'a> {
+    pub server: &'a Server,
+    pub rx_inbound: mpsc::Receiver<(SocketAddr, Swim)>,
+    pub timing: Timing,
+}
+
+impl<'a> Outbound<'a> {
+    /// Creates a new Outbound struct.
+    pub fn new(server: &'a Server,
+               rx_inbound: mpsc::Receiver<(SocketAddr, Swim)>,
+               timing: Timing)
+               -> Outbound {
+        Outbound {
+            server: server,
+            rx_inbound: rx_inbound,
+            timing: timing,
+        }
+    }
+
+    /// Run the outbound thread. Gets a list of members to pinmg, then walks the list, probing each
+    /// member.
+    ///
+    /// If the probe completes before the next protocol period is scheduled, waits for the protocol
+    /// period to finish before starting the next probe.
+    pub fn run(&mut self) {
+        loop {
+            if self.server.pause.load(Ordering::Relaxed) {
+                thread::sleep(Duration::from_millis(100));
+                continue;
+            }
+
+            self.server.update_round();
+
+            let check_list = self.server
+                .member_list
+                .check_list(self.server
+                    .member
+                    .read()
+                    .expect("Member is poisoned")
+                    .get_id());
+
+            for member in check_list {
+                let pingable = self.server
+                    .member_list
+                    .member_alive_suspect_or_persistent(&member);
+
+                if pingable {
+                    // This is the timeout for the next protocol period - if we
+                    // complete faster than this, we want to wait in the end
+                    // until this timer expires.
+                    let next_protocol_period = self.timing.next_protocol_period();
+
+                    self.probe(member);
+
+                    if SteadyTime::now() <= next_protocol_period {
+                        let wait_time = next_protocol_period - SteadyTime::now();
+                        debug!("Waiting {} until the next protocol period",
+                               wait_time.num_milliseconds());
+                        thread::sleep(Duration::from_millis(wait_time.num_milliseconds() as u64));
+                    }
+                }
+            }
+        }
+    }
+
+    ///
+    /// Probe Loop
+    ///
+    /// First, we send the ping to the remote address. This operation never blocks - we just
+    /// pass the data straight on to the kernel for UDP goodness. Then we grab a timer for how
+    /// long we're willing to run this phase, and start listening for Ack packets from the
+    /// Inbound thread. If we receive an Ack that is for any Member other than the one we are
+    /// currently pinging, we discard it. Otherwise, we set the address for the Member whose Ack
+    /// we received to the one we saw on the wire, and insert it into the MemberList.
+    ///
+    /// If we don't receive anything on the channel, we check if the current time has exceeded
+    /// our timeout. If it has, we break out of the Ping loop, and proceed to the PingReq loop.
+    /// If the timer has not been exceeded, we park this thread for
+    /// PING_RECV_QUEUE_EMPTY_SLEEP_MS, and try again.
+    ///
+    /// If we don't recieve anything at all in the Ping/PingReq loop, we mark the member as Suspect.
+    fn probe(&mut self, member: Member) {
+        let addr = member.socket_address();
+
+        trace_swim!(&self.server, "probe-begin", &format!("{}", addr), None);
+
+        // Ping the member, and wait for the ack.
+        ping(self.server, &member, addr, None);
+        if self.recv_ack(&member, addr, AckFrom::Ping) {
+            trace_swim!(&self.server,
+                        "probe-ack-received",
+                        &format!("{}", addr),
+                        None);
+            trace_swim!(&self.server, "probe-complete", &format!("{}", addr), None);
+            return;
+        }
+
+        {
+            let me = match self.server.member.read() {
+                Ok(me) => me,
+                Err(e) => panic!("The member lock is poisoned: {:?}", e),
+            };
+            self.server.member_list.with_pingreq_targets(&me, &member, |pingreq_target| {
+                trace_swim!(&self.server,
+                            "probe-pingreq",
+                            pingreq_target.get_address(),
+                            None);
+                pingreq(self.server, pingreq_target, &member);
+            });
+        }
+        if !self.recv_ack(&member, addr, AckFrom::PingReq) {
+            // We mark as suspect when we fail to get a response from the PingReq. That moves us
+            // into the suspicion phase, where anyone marked as suspect has a certain number of
+            // protocol periods to recover.
+            warn!("Marking {} as Suspect", member.get_id());
+            trace_swim!(&self.server,
+                        "probe-marked-suspect",
+                        &format!("{}", addr),
+                        None);
+            self.server.insert_member(member, Health::Suspect);
+        }
+        trace_swim!(&self.server, "probe-complete", &format!("{}", addr), None);
+    }
+
+    /// Listen for an ack from the `Inbound` thread.
+    fn recv_ack(&mut self, member: &Member, addr: SocketAddr, ack_from: AckFrom) -> bool {
+        let timeout = match ack_from {
+            AckFrom::Ping => self.timing.ping_timeout(),
+            AckFrom::PingReq => self.timing.pingreq_timeout(),
+        };
+        loop {
+            match self.rx_inbound.try_recv() {
+                Ok((real_addr, mut swim)) => {
+                    let mut ack_from = swim.mut_ack().take_from();
+                    if member.get_id() != ack_from.get_id() {
+                        error!("Discarding ack from {}@{}; expected {}",
+                               ack_from.get_id(),
+                               real_addr,
+                               member.get_id());
+                        // Keep listening, we want the ack we expected
+                        continue;
+                    }
+                    // If this was forwarded to us, we want to retain the address of the member who
+                    // sent the ack, not the one we recieved on the socket.
+                    if !swim.get_ack().has_forward_to() {
+                        ack_from.set_address(format!("{}", real_addr));
+                    }
+                    let ack_from_member: Member = ack_from.into();
+                    self.server.insert_member(ack_from_member, Health::Alive);
+                    // We got the ack we are looking for; return.
+                    return true;
+                }
+                Err(mpsc::TryRecvError::Empty) => {
+                    if SteadyTime::now() > timeout {
+                        warn!("Timed out waiting for Ack from {}@{}",
+                              member.get_id(),
+                              addr);
+                        return false;
+                    }
+                    thread::sleep(Duration::from_millis(PING_RECV_QUEUE_EMPTY_SLEEP_MS));
+                }
+                Err(mpsc::TryRecvError::Disconnected) => {
+                    panic!("Outbound thread has disconnected! This is fatal.");
+                }
+            }
+        }
+    }
+}
+
+/// Populate a SWIM message with rumors.
+pub fn populate_membership_rumors(server: &Server, target: &Member, swim: &mut Swim) {
+    let rumors = server.rumor_list.take_by_kind(target.get_id(), 6, "member");
+    let mut membership_entries = RepeatedField::new();
+    for &(ref rkey, _heat) in rumors.iter() {
+        membership_entries.push(server.member_list.membership_for(&rkey.key));
+    }
+    server.rumor_list.update_heat(target.get_id(), &rumors);
+    swim.set_membership(membership_entries);
+}
+
+/// Send a PingReq.
+pub fn pingreq(server: &Server, pingreq_target: &Member, target: &Member) {
+    let addr = pingreq_target.socket_address();
+    let mut swim = Swim::new();
+    swim.set_field_type(Swim_Type::PINGREQ);
+    let mut pingreq = PingReq::new();
+    {
+        let member = server.member.read().unwrap();
+        pingreq.set_from(member.proto.clone());
+    }
+    pingreq.set_target(target.proto.clone());
+    swim.set_pingreq(pingreq);
+    populate_membership_rumors(server, target, &mut swim);
+    match server.socket.send_to(&swim.write_to_bytes().unwrap(), addr) {
+        Ok(_s) => {
+            info!("Sent PingReq to {}@{} for {}@{}",
+                  pingreq_target.get_id(),
+                  addr,
+                  target.get_id(),
+                  target.socket_address())
+        }
+        Err(e) => {
+            error!("Failed PingReq to {}@{} for {}@{}: {}",
+                   pingreq_target.get_id(),
+                   addr,
+                   target.get_id(),
+                   target.socket_address(),
+                   e)
+        }
+    }
+    trace_swim!(server, "send-pingreq", &format!("{}", addr), Some(&swim));
+}
+
+/// Send a Ping.
+pub fn ping(server: &Server, target: &Member, addr: SocketAddr, mut forward_to: Option<Member>) {
+    let mut swim = Swim::new();
+    swim.set_field_type(Swim_Type::PING);
+    let mut ping = Ping::new();
+    {
+        let member = server.member.read().unwrap();
+        ping.set_from(member.proto.clone());
+    }
+    if forward_to.is_some() {
+        let member = forward_to.take().unwrap();
+        ping.set_forward_to(member.proto);
+    }
+    swim.set_ping(ping);
+    populate_membership_rumors(server, target, &mut swim);
+
+    match server.socket.send_to(&swim.write_to_bytes().unwrap(), addr) {
+        Ok(_s) => {
+            if forward_to.is_some() {
+                info!("Sent Ping to {} on behalf of {}@{}",
+                      addr,
+                      swim.get_ping().get_forward_to().get_id(),
+                      swim.get_ping().get_forward_to().get_address());
+            } else {
+                info!("Sent Ping to {}", addr);
+            }
+        }
+        Err(e) => error!("Failed Ping to {}: {}", addr, e),
+    }
+    trace_swim!(server, "send-ping", &format!("{}", addr), Some(&swim));
+}
+
+/// Forward an ack on.
+pub fn forward_ack(server: &Server, addr: SocketAddr, swim: Swim) {
+    trace_swim!(server,
+                "send-forward-ack",
+                &format!("{}", addr),
+                Some(&swim));
+    match server.socket.send_to(&swim.write_to_bytes().unwrap(), addr) {
+        Ok(_s) => {
+            info!("Forwarded ack to {}@{}",
+                  swim.get_ack().get_from().get_id(),
+                  addr)
+        }
+        Err(e) => {
+            error!("Failed ack to {}@{}: {}",
+                   swim.get_ack().get_from().get_id(),
+                   addr,
+                   e)
+        }
+    }
+}
+
+/// Send an Ack.
+pub fn ack(server: &Server, target: &Member, addr: SocketAddr, mut forward_to: Option<Member>) {
+    let mut swim = Swim::new();
+    swim.set_field_type(Swim_Type::ACK);
+    let mut ack = Ack::new();
+    {
+        let member = server.member.read().unwrap();
+        ack.set_from(member.proto.clone());
+    }
+    if forward_to.is_some() {
+        let member = forward_to.take().unwrap();
+        ack.set_forward_to(member.proto);
+    }
+    swim.set_ack(ack);
+    populate_membership_rumors(server, target, &mut swim);
+    match server.socket.send_to(&swim.write_to_bytes().unwrap(), addr) {
+        Ok(_s) => {
+            info!("Sent ack to {}@{}",
+                  swim.get_ack().get_from().get_id(),
+                  addr)
+        }
+        Err(e) => {
+            error!("Failed ack to {}@{}: {}",
+                   swim.get_ack().get_from().get_id(),
+                   addr,
+                   e)
+        }
+    }
+    trace_swim!(server, "send-ack", &format!("{}", addr), Some(&swim));
+}

--- a/components/swim/src/trace.rs
+++ b/components/swim/src/trace.rs
@@ -1,0 +1,166 @@
+// Copyright (c) 2016 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! This module handles the writing of swim trace files, which can later be post-processed to see
+//! whats happening in a network.
+
+use time;
+
+use std::default::Default;
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+use std::io::Write;
+
+use server::Server;
+use message::swim::Swim;
+
+/// The trace struct handles writing trace files to a directory path.
+#[derive(Debug)]
+pub struct Trace {
+    pub directory: PathBuf,
+    pub file: Option<fs::File>,
+    pub on: bool,
+}
+
+impl Default for Trace {
+    fn default() -> Trace {
+        Trace {
+            directory: PathBuf::from("/tmp/habitat-swim-trace"),
+            file: None,
+            on: false,
+        }
+    }
+}
+
+impl Trace {
+    /// Initialize the trace object; only happens once.
+    pub fn init(&mut self, server: &Server) {
+        if self.file.is_none() {
+            let now = time::now_utc();
+            let filename = format!("{}-{}.swimtrace", server.name(), now.rfc3339());
+            match fs::File::create(self.directory.join(&filename)) {
+                Ok(f) => self.file = Some(f),
+                Err(e) => {
+                    panic!("Trace requested, but cannot create file {:?}: {}",
+                           self.directory.join(&filename),
+                           e)
+                }
+            }
+        }
+    }
+
+    /// Returns true if the TRACE_SWIM environment variable exists.
+    pub fn on(&self) -> bool {
+        match env::var("TRACE_SWIM") {
+            Ok(_val) => true,
+            Err(_e) => self.on,
+        }
+    }
+
+    /// Write a line to the trace file.
+    pub fn write(&mut self,
+                 module_path: &str,
+                 line: &u32,
+                 server_name: &str,
+                 server_id: &str,
+                 listening: &str,
+                 thread_name: &str,
+                 msg_type: &str,
+                 to_addr: &str,
+                 payload: Option<&Swim>) {
+        let now = time::now_utc();
+        let time_string = format!("{}-{}-{}-{}-{}-{}-{}",
+                                  1900 + now.tm_year,
+                                  now.tm_mon + 1,
+                                  now.tm_mday,
+                                  now.tm_hour,
+                                  now.tm_min,
+                                  now.tm_sec,
+                                  now.tm_nsec);
+        let dump = format!("{:#?}", self);
+        match self.file.as_mut() {
+            Some(mut file) => {
+                match write!(file,
+                             "{}!*!{}!*!{}!*!{}!*!{}!*!{}!*!{}!*!{}!*!{}!*!{:?}\n",
+                             time_string,
+                             module_path,
+                             line,
+                             server_name,
+                             server_id,
+                             listening,
+                             thread_name,
+                             msg_type,
+                             to_addr,
+                             payload) {
+                    Ok(_) => {}
+                    Err(e) => panic!("Trace requested, but failed to write {:?}", e),
+                }
+            }
+            None => {
+                panic!("Trace requested, but init was never called; use the trace! macro \
+                        instead: {:#?}",
+                       dump);
+            }
+        }
+    }
+
+    // Outbound
+    // datetime!*!server.name!*!member.id!*!socket!*!outbound!*!MsgType!*!ToAddr!*!Payload
+    //
+    // Inbound
+    // datetime!*!server.name!*!member.id!*!socket!*!inbound!*!MsgType!*!FromAddr!*!Payload
+}
+
+macro_rules! trace_swim {
+    ($server:expr, $msg_type:expr, $to_addr:expr, $payload:expr) => {
+        {
+            let mut trace = $server.trace.write().expect("Trace write lock is poisoned");
+            if trace.on() {
+                trace.init($server);
+                let member_id = {
+                    let member = $server.member.read().expect("Member lock is read poisoned");
+                    String::from(member.get_id())
+                };
+                let local_addr = $server.socket.local_addr().expect("Socket has no listen address; should be impossible");
+                let thread_name = String::from(thread::current().name().expect("Tried to trace an un-named thread; use thread-builder"));
+                trace.write(
+                    &module_path!(),
+                    &line!(),
+                    &$server.name(),
+                    &member_id,
+                    &format!("{}", local_addr),
+                    &thread_name,
+                    $msg_type,
+                    $to_addr,
+                    $payload
+                );
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    mod trace {
+        use trace::Trace;
+        use std::path::Path;
+
+        #[test]
+        fn default() {
+            let trace = Trace::default();
+            assert_eq!(trace.directory, Path::new("/tmp/habitat-swim-trace"));
+        }
+    }
+}

--- a/components/swim/tests/common/mod.rs
+++ b/components/swim/tests/common/mod.rs
@@ -1,0 +1,48 @@
+// Copyright (c) 2016 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[macro_use]
+pub mod net;
+
+use std::sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
+
+use habitat_swim::server::Server;
+use habitat_swim::member::Member;
+use habitat_swim::trace::Trace;
+use habitat_swim::server::outbound::Timing;
+
+static SERVER_PORT: AtomicUsize = ATOMIC_USIZE_INIT;
+
+pub fn start_server(name: &str) -> Server {
+    SERVER_PORT.compare_and_swap(0, 6666, Ordering::Relaxed);
+    let my_port = SERVER_PORT.fetch_add(1, Ordering::Relaxed);
+    let listen = format!("127.0.0.1:{}", my_port);
+    let server = Server::new(&listen[..], Member::new(), Trace::default()).unwrap();
+    {
+        let mut server_name = server.name.write().expect("Server name lock is poisoned");
+        server_name.clear();
+        server_name.push_str(name);
+    }
+    server.start(Timing::default());
+    server
+}
+
+pub fn member_from_server(server: &Server) -> Member {
+    let mut new_member = Member::new();
+    let server_member = server.member.read().expect("Member lock is poisoned");
+    new_member.set_id(String::from(server_member.get_id()));
+    new_member.set_incarnation(server_member.get_incarnation());
+    new_member.set_address(format!("127.0.0.1:{}", server.port()));
+    new_member
+}

--- a/components/swim/tests/common/net.rs
+++ b/components/swim/tests/common/net.rs
@@ -1,0 +1,266 @@
+// Copyright (c) 2016 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::thread;
+use std::ops::{Deref, DerefMut, Range};
+use std::time::Duration;
+
+use time::SteadyTime;
+
+use common;
+use habitat_swim::server::Server;
+use habitat_swim::member::{Member, Health};
+use habitat_swim::server::outbound::Timing;
+
+#[derive(Debug)]
+pub struct SwimNet {
+    members: Vec<Server>,
+}
+
+impl Deref for SwimNet {
+    type Target = Vec<Server>;
+
+    fn deref(&self) -> &Vec<Server> {
+        &self.members
+    }
+}
+
+impl DerefMut for SwimNet {
+    fn deref_mut(&mut self) -> &mut Vec<Server> {
+        &mut self.members
+    }
+}
+
+impl SwimNet {
+    pub fn new(count: usize) -> SwimNet {
+        let mut members = Vec::with_capacity(count);
+        for x in 0..count {
+            members.push(common::start_server(&format!("{}", x)));
+        }
+        SwimNet { members: members }
+    }
+
+    pub fn connect(&mut self, from_entry: usize, to_entry: usize) {
+        let to = common::member_from_server(&self.members[to_entry]);
+        self.members[from_entry].insert_member(to, Health::Alive);
+    }
+
+    // Fully mesh the network
+    pub fn mesh(&mut self) {
+        for pos in 0..self.members.len() {
+            let mut to_mesh: Vec<Member> = Vec::new();
+            for x_pos in 0..self.members.len() {
+                if pos == x_pos {
+                    continue;
+                }
+                let server_b = self.members.get(x_pos).unwrap();
+                to_mesh.push(common::member_from_server(server_b))
+            }
+            let server_a = self.members.get(pos).unwrap();
+            for server_b in to_mesh.into_iter() {
+                server_a.insert_member(server_b, Health::Alive);
+            }
+        }
+    }
+
+    pub fn blacklist(&self, from_entry: usize, to_entry: usize) {
+        let from =
+            self.members.get(from_entry).expect("Asked for a network member who is out of bounds");
+        let to =
+            self.members.get(to_entry).expect("Asked for a network member who is out of bounds");
+        let to_addr = to.socket.local_addr().expect("Socket does not have an address");
+        from.add_to_blacklist(to_addr);
+    }
+
+    pub fn unblacklist(&self, from_entry: usize, to_entry: usize) {
+        let from =
+            self.members.get(from_entry).expect("Asked for a network member who is out of bounds");
+        let to =
+            self.members.get(to_entry).expect("Asked for a network member who is out of bounds");
+        let to_addr = to.socket.local_addr().expect("Socket does not have an address");
+        from.remove_from_blacklist(&to_addr);
+    }
+
+    pub fn health_of(&self, from_entry: usize, to_entry: usize) -> Option<Health> {
+        let from =
+            self.members.get(from_entry).expect("Asked for a network member who is out of bounds");
+
+        let to =
+            self.members.get(to_entry).expect("Asked for a network member who is out of bounds");
+        let to_member = to.member.read().expect("Member lock is poisoned");
+        from.member_list.health_of(&to_member)
+    }
+
+    pub fn network_health_of(&self, to_check: usize) -> Vec<Option<Health>> {
+        let mut health_summary = Vec::with_capacity(self.members.len() - 1);
+        let length = self.members.len();
+        for x in 0..length {
+            if x == to_check {
+                continue;
+            }
+            health_summary.push(self.health_of(x, to_check));
+        }
+        health_summary
+    }
+
+    pub fn max_rounds(&self) -> isize {
+        3
+    }
+
+    pub fn rounds(&self) -> Vec<isize> {
+        self.members.iter().map(|m| m.rounds()).collect()
+    }
+
+    pub fn rounds_in(&self, count: isize) -> Vec<isize> {
+        self.rounds().iter().map(|r| r + count).collect()
+    }
+
+    pub fn check_rounds(&self, rounds_in: &Vec<isize>) -> bool {
+        let mut finished = Vec::with_capacity(rounds_in.len());
+        for (i, round) in rounds_in.into_iter().enumerate() {
+            if self.members[i].paused() {
+                finished.push(true);
+            } else {
+                if self.members[i].rounds() > *round {
+                    finished.push(true);
+                } else {
+                    finished.push(false);
+                }
+            }
+        }
+        if finished.iter().all(|m| m == &true) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    pub fn wait_for_rounds(&self, rounds: isize) {
+        let rounds_in = self.rounds_in(rounds);
+        loop {
+            if self.check_rounds(&rounds_in) {
+                return;
+            }
+            thread::sleep(Duration::from_millis(500));
+        }
+    }
+
+    pub fn partition(&self, left_range: Range<usize>, right_range: Range<usize>) {
+        let left: Vec<usize> = left_range.collect();
+        let right: Vec<usize> = right_range.collect();
+        for l in left.iter() {
+            for r in right.iter() {
+                println!("Partitioning {} from {}", *l, *r);
+                self.blacklist(*l, *r);
+                self.blacklist(*r, *l);
+            }
+        }
+    }
+
+    pub fn unpartition(&self, left_range: Range<usize>, right_range: Range<usize>) {
+        let left: Vec<usize> = left_range.collect();
+        let right: Vec<usize> = right_range.collect();
+        for l in left.iter() {
+            for r in right.iter() {
+                println!("UnPartitioning {} from {}", *l, *r);
+                self.unblacklist(*l, *r);
+                self.unblacklist(*r, *l);
+            }
+        }
+    }
+
+    pub fn wait_for_health_of(&self, from_entry: usize, to_check: usize, health: Health) -> bool {
+        let rounds_in = self.rounds_in(self.max_rounds());
+        loop {
+            if let Some(real_health) = self.health_of(from_entry, to_check) {
+                if real_health == health {
+                    return true;
+                }
+            }
+            if self.check_rounds(&rounds_in) {
+                println!("Failed health check for\n***FROM***{:#?}\n***TO***\n{:#?}",
+                         self.members[from_entry],
+                         self.members[to_check]);
+                return false;
+            }
+        }
+    }
+
+    pub fn wait_for_network_health_of(&self, to_check: usize, health: Health) -> bool {
+        let rounds_in = self.rounds_in(self.max_rounds());
+        loop {
+            let network_health = self.network_health_of(to_check);
+            if network_health.iter().all(|x| if let &Some(ref h) = x {
+                *h == health
+            } else {
+                false
+            }) {
+                return true;
+            } else if self.check_rounds(&rounds_in) {
+                for (i, some_health) in network_health.iter().enumerate() {
+                    match some_health {
+                        &Some(ref health) => println!("{}: {:?}", i, health),
+                        &None => {}
+                    }
+                }
+                // println!("Failed network health check dump: {:#?}", self);
+                return false;
+            }
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn wait_protocol_period(&self) {
+        let timing = Timing::default();
+        let next_period = timing.next_protocol_period();
+        loop {
+            if SteadyTime::now() <= next_period {
+                thread::sleep(Duration::from_millis(100));
+            } else {
+                return;
+            }
+        }
+    }
+}
+
+macro_rules! assert_health_of {
+    ($network:expr, $to:expr, $health:expr) => {
+        assert!($network.network_health_of($to).into_iter().all(|x| x == $health), "Member {} does not always have health {}", $to, $health)
+    };
+    ($network:expr, $from: expr, $to:expr, $health:expr) => {
+        assert!($network.health_of($from, $to) == $health, "Member {} does not see {} as {}", $from, $to, $health)
+    }
+}
+
+macro_rules! assert_wait_for_health_of {
+    ($network:expr, [$from: expr, $to:expr], $health:expr) => {
+        let left: Vec<usize> = $from.collect();
+        let right: Vec<usize> = $to.collect();
+        for l in left.iter() {
+            for r in right.iter() {
+                if l == r {
+                    continue;
+                }
+                assert!($network.wait_for_health_of(*l, *r, $health), "Member {} does not see {} as {}", l, r, $health);
+                assert!($network.wait_for_health_of(*r, *l, $health), "Member {} does not see {} as {}", r, l, $health);
+            }
+        }
+    };
+    ($network:expr, $to:expr, $health:expr) => {
+        assert!($network.wait_for_network_health_of($to, $health), "Member {} does not always have health {}", $to, $health)
+    };
+    ($network:expr, $from: expr, $to:expr, $health:expr) => {
+        assert!($network.wait_for_health_of($from, $to, $health), "Member {} does not see {} as {}", $from, $to, $health)
+    };
+}

--- a/components/swim/tests/integration.rs
+++ b/components/swim/tests/integration.rs
@@ -1,0 +1,127 @@
+// Copyright (c) 2016 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+extern crate env_logger;
+extern crate time;
+extern crate habitat_swim;
+
+#[macro_use]
+mod common;
+
+use habitat_swim::member::Health;
+
+#[test]
+fn two_members_meshed_confirm_one_member() {
+    let mut net = common::net::SwimNet::new(2);
+    net.mesh();
+    assert_wait_for_health_of!(net, 0, 1, Health::Alive);
+    assert_wait_for_health_of!(net, 1, 0, Health::Alive);
+
+    net[0].pause();
+    assert_wait_for_health_of!(net, 1, 0, Health::Suspect);
+    assert_wait_for_health_of!(net, 1, 0, Health::Confirmed);
+}
+
+#[test]
+fn six_members_meshed_confirm_one_member() {
+    let mut net = common::net::SwimNet::new(6);
+    net.mesh();
+    net[0].pause();
+    assert_wait_for_health_of!(net, 0, Health::Confirmed);
+}
+
+#[test]
+fn six_members_meshed_partition_one_node_from_another_node_remains_alive() {
+    let mut net = common::net::SwimNet::new(6);
+    net.mesh();
+    net.blacklist(0, 1);
+    net.wait_for_rounds(1);
+    assert_wait_for_health_of!(net, 1, Health::Alive);
+}
+
+#[test]
+fn six_members_meshed_partition_half_of_nodes_from_each_other_both_sides_confirmed() {
+    let mut net = common::net::SwimNet::new(6);
+    net.mesh();
+    assert_wait_for_health_of!(net, 0, Health::Alive);
+    net.partition(0..3, 3..6);
+    assert_wait_for_health_of!(net, [0..3, 3..6], Health::Confirmed);
+}
+
+#[test]
+fn six_members_unmeshed_become_fully_meshed_via_gossip() {
+    let mut net = common::net::SwimNet::new(6);
+    net.connect(0, 1);
+    net.connect(1, 2);
+    net.connect(2, 3);
+    net.connect(3, 4);
+    net.connect(4, 5);
+    assert_wait_for_health_of!(net, [0..6, 0..6], Health::Alive);
+}
+
+#[test]
+fn six_members_unmeshed_confirm_one_member() {
+    let mut net = common::net::SwimNet::new(6);
+    net.connect(0, 1);
+    net.connect(1, 2);
+    net.connect(2, 3);
+    net.connect(3, 4);
+    net.connect(4, 5);
+    assert_wait_for_health_of!(net, [0..6, 0..6], Health::Alive);
+    net[0].pause();
+    assert_wait_for_health_of!(net, 0, Health::Confirmed);
+}
+
+#[test]
+fn six_members_unmeshed_partition_and_rejoin_no_permanant_peers() {
+    let mut net = common::net::SwimNet::new(6);
+    net.connect(0, 1);
+    net.connect(1, 2);
+    net.connect(2, 3);
+    net.connect(3, 4);
+    net.connect(4, 5);
+    assert_wait_for_health_of!(net, [0..6, 0..6], Health::Alive);
+    net.partition(0..3, 3..6);
+    assert_wait_for_health_of!(net, [0..3, 3..6], Health::Confirmed);
+    net.unpartition(0..3, 3..6);
+    net.wait_for_rounds(1);
+    assert_wait_for_health_of!(net, [0..3, 3..6], Health::Confirmed);
+}
+
+#[test]
+fn six_members_unmeshed_partition_and_rejoin_permanant_peers() {
+    let mut net = common::net::SwimNet::new(6);
+    net[0].member.write().expect("Member lock is poisoned").set_persistent(true);
+    net[4].member.write().expect("Member lock is poisoned").set_persistent(true);
+    net.connect(0, 1);
+    net.connect(1, 2);
+    net.connect(2, 3);
+    net.connect(3, 4);
+    net.connect(4, 5);
+    assert_wait_for_health_of!(net, [0..6, 0..6], Health::Alive);
+    net.partition(0..3, 3..6);
+    assert_wait_for_health_of!(net, [0..3, 3..6], Health::Confirmed);
+    net.unpartition(0..3, 3..6);
+    net.wait_for_rounds(1);
+    assert_wait_for_health_of!(net, [0..3, 3..6], Health::Alive);
+}
+
+#[test]
+#[ignore]
+fn fifty_members_meshed_confirm_one_member() {
+    let mut net = common::net::SwimNet::new(50);
+    net.mesh();
+    net[0].pause();
+    assert_wait_for_health_of!(net, 0, Health::Confirmed);
+}


### PR DESCRIPTION
This adds an independent habitat_swim library. It uses small UDP packets
(under 512 bytes) and a much simpler implementation.

* Simpler architecture - one server, two threads (Inbound / Outbound)
* All timing happens in the application, not the network
* Trace file support with TRACE_SWIM=1
* Test suite based on building a "network", with software based
  blacklisting and pausing for partitions.
* Uses Protobufs for the network serialization

TODO:

  * Implement sharing of membership status as piggyback
  * Finish test suite for SWIM basic, and SWIM+piggyback
  * Documentation