### PR TITLE
Add terminfo to studio for colorization

### DIFF
--- a/components/backline/plan.sh
+++ b/components/backline/plan.sh
@@ -14,6 +14,7 @@ pkg_deps=(
   core/mg
   core/util-linux
   core/vim
+  core/ncurses
 )
 
 do_download() {

--- a/components/studio/libexec/hab-studio-type-default.sh
+++ b/components/studio/libexec/hab-studio-type-default.sh
@@ -88,6 +88,9 @@ alias grep='grep --color=auto'
 alias egrep='egrep --color=auto'
 alias fgrep='fgrep --color=auto'
 
+# Set TERMINFO so hab can give us a delightful experience.
+export TERMINFO=$(_pkgpath_for core/ncurses)/share/terminfo
+
 PROFILE
 
   echo "${run_user}:x:42:42:root:/:/bin/sh" >> $HAB_STUDIO_ROOT/etc/passwd


### PR DESCRIPTION
Happy Hacktoberfest Habitatians(?)! This addresses #1314 

Simulating this change (editing /etc/profile in the studio) appears to give the expected behavior. 
![hab docker 2016-10-01 15-41-54](https://cloud.githubusercontent.com/assets/36851/19017722/cd533274-87f0-11e6-97d5-b7f04b4c113a.png)
 
I'm unsure how to build the studio, which I need to to do properly test this. I'd be happy to do so if I could get some assistance.
