### PR TITLE
Improve error messages around Docker

### DIFF
--- a/components/common/src/ui.rs
+++ b/components/common/src/ui.rs
@@ -122,18 +122,24 @@ impl UI {
 
     pub fn fatal<T: fmt::Display>(&mut self, message: T) -> Result<()> {
         let ref mut stream = self.shell.err;
+        let formatted_message = message.to_string()
+            .lines()
+            .map(|line| format!("✗✗✗ {}", line))
+            .collect::<Vec<_>>()
+            .join("\n");
+
         match stream.is_colored() {
             true => {
                 try!(write!(stream,
                             "{}\n",
                             Colour::Red.bold()
-                                .paint(format!("✗✗✗\n✗✗✗ {}\n✗✗✗",
-                                               message.to_string()))));
+                                .paint(format!("✗✗✗\n{}\n✗✗✗",
+                                               formatted_message))));
             }
             false => {
                 try!(write!(stream,
-                            "✗✗✗\n✗✗✗ {}\n✗✗✗\n",
-                            message.to_string()));
+                            "✗✗✗\n{}\n✗✗✗\n",
+                            formatted_message));
             }
         }
         try!(stream.flush());

--- a/components/hab/src/error.rs
+++ b/components/hab/src/error.rs
@@ -32,6 +32,9 @@ pub enum Error {
     CommandNotFoundInPkg((String, String)),
     CryptoCLI(String),
     DepotClient(depot_client::Error),
+    DockerDaemonDown,
+    DockerNetworkDown(String),
+    DockerImageNotFound(String),
     ExecCommandNotFound(String),
     FFINulError(ffi::NulError),
     FileNotFound(String),
@@ -56,6 +59,22 @@ impl fmt::Display for Error {
             }
             Error::CryptoCLI(ref e) => format!("{}", e),
             Error::DepotClient(ref err) => format!("{}", err),
+            Error::DockerDaemonDown => {
+                format!("Can not connect to Docker. Is the Docker daemon running?")
+            }
+            Error::DockerNetworkDown(ref e) => {
+                format!("The Docker image {} is unreachable due to a network error.\nThe \
+                         image must be reachable to ensure the versions of hab inside and \
+                         outside the studio match.\nYou can specify your own Docker image using \
+                         the HAB_DOCKER_STUDIO_IMAGE environment variable.",
+                        e)
+            }
+            Error::DockerImageNotFound(ref e) => {
+                format!("The Docker image {} was not found in the docker registry.\nYou can \
+                         specify your own Docker image using the HAB_DOCKER_STUDIO_IMAGE \
+                         environment variable.",
+                        e)
+            }
             Error::ExecCommandNotFound(ref c) => {
                 format!("`{}' was not found on the filesystem or in PATH", c)
             }
@@ -88,6 +107,9 @@ impl error::Error for Error {
             }
             Error::CryptoCLI(_) => "A cryptographic error has occurred",
             Error::DepotClient(ref err) => err.description(),
+            Error::DockerDaemonDown => "The Docker daemon could not be found.",
+            Error::DockerNetworkDown(_) => "The Docker registry is unreachable.",
+            Error::DockerImageNotFound(_) => "The Docker image was not found.",
             Error::ExecCommandNotFound(_) => "Exec command was not found on filesystem or in PATH",
             Error::FFINulError(ref err) => err.description(),
             Error::FileNotFound(_) => "File not found",


### PR DESCRIPTION
This adds more specific error messages around Docker shenanigans by trying to pull the studio image we need before launching the container with `docker run`.  We observe the stderr stream from Docker after the pull and use it to display friendly error messages.

As a side effect of this, we also now support multi-line error messages in `fatal`.

![gif-keyboard-11675946048040223630](https://cloud.githubusercontent.com/assets/947/19052691/9c8b1a4e-896c-11e6-8ec7-7867623b262c.gif)

Signed-off-by: Josh Black <raskchanky@gmail.com>