### PR TITLE
Detect, warn, & exit on operations that require root/admin permissions.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -497,6 +497,7 @@ dependencies = [
  "ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "habitat_common 0.0.0",
  "habitat_core 0.0.0",
  "habitat_sup 0.0.0",
  "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/common/src/command/package/install.rs
+++ b/components/common/src/command/package/install.rs
@@ -41,6 +41,7 @@ use std::str::FromStr;
 
 use depot_client::Client;
 use hcore;
+use hcore::fs::am_i_root;
 use hcore::crypto::{artifact, SigKeyPair};
 use hcore::crypto::keys::parse_name_with_rev;
 use hcore::package::{Identifiable, PackageArchive, PackageIdent, PackageInstall};
@@ -61,6 +62,14 @@ pub fn start<P1: ?Sized, P2: ?Sized, P3: ?Sized>(ui: &mut UI,
           P2: AsRef<Path>,
           P3: AsRef<Path>
 {
+    if !am_i_root() {
+        try!(ui.warn("Installing a package requires root or administrator privileges. Please retry \
+                   this command as a super user or use a privilege-granting facility such as \
+                   sudo."));
+        try!(ui.br());
+        return Err(Error::RootRequired);
+    }
+
     let task = try!(InstallTask::new(url,
                                      product,
                                      version,

--- a/components/common/src/error.rs
+++ b/components/common/src/error.rs
@@ -39,6 +39,7 @@ pub enum Error {
     IO(io::Error),
     JsonDecode(json::DecoderError),
     JsonEncode(json::EncoderError),
+    RootRequired,
     StrFromUtf8Error(str::Utf8Error),
     StringFromUtf8Error(string::FromUtf8Error),
     WireDecode(String),
@@ -68,6 +69,9 @@ impl fmt::Display for Error {
             Error::IO(ref err) => format!("{}", err),
             Error::JsonDecode(ref e) => format!("JSON decoding error: {}", e),
             Error::JsonEncode(ref e) => format!("JSON encoding error: {}", e),
+            Error::RootRequired => {
+                "Root or administrator permissions required to complete operation".to_string()
+            }
             Error::StrFromUtf8Error(ref e) => format!("{}", e),
             Error::StringFromUtf8Error(ref e) => format!("{}", e),
             Error::WireDecode(ref m) => format!("Failed to decode wire message: {}", m),
@@ -94,6 +98,9 @@ impl error::Error for Error {
             Error::IO(ref err) => err.description(),
             Error::JsonDecode(_) => "JSON decoding error: {:?}",
             Error::JsonEncode(_) => "JSON encoding error",
+            Error::RootRequired => {
+                "Root or administrator permissions required to complete operation"
+            }
             Error::StrFromUtf8Error(_) => "Failed to convert a string as UTF-8",
             Error::StringFromUtf8Error(_) => "Failed to convert a string as UTF-8",
             Error::WireDecode(_) => "Failed to decode wire message",

--- a/components/director/Cargo.toml
+++ b/components/director/Cargo.toml
@@ -33,6 +33,9 @@ features = [ "suggestions", "color", "unstable" ]
 [dependencies.habitat_core]
 path = "../core"
 
+[dependencies.habitat_common]
+path = "../common"
+
 [dependencies.habitat_sup]
 path = "../sup"
 

--- a/components/director/src/error.rs
+++ b/components/director/src/error.rs
@@ -18,15 +18,18 @@ use std::fmt;
 use std::net;
 use std::result;
 
+use hcommon;
 use hcore;
 
 #[derive(Debug)]
 pub enum Error {
     AddrParseError(net::AddrParseError),
     DirectorError(String),
+    HabitatCommon(hcommon::Error),
     HabitatCore(hcore::Error),
     IO(io::Error),
     NoServices,
+    RootRequired,
 }
 
 pub type Result<T> = result::Result<T, Error>;
@@ -36,9 +39,13 @@ impl fmt::Display for Error {
         let msg = match *self {
             Error::AddrParseError(ref e) => format!("Can't parse IP address {}", e),
             Error::DirectorError(ref e) => format!("Director error: {}", e),
+            Error::HabitatCommon(ref err) => format!("{}", err),
             Error::HabitatCore(ref e) => format!("{}", e),
             Error::IO(ref e) => format!("{}", e),
             Error::NoServices => "No services specified in configuration".to_string(),
+            Error::RootRequired => {
+                "Root or administrator permissions required to complete operation".to_string()
+            }
         };
         write!(f, "{}", msg)
     }
@@ -49,10 +56,20 @@ impl error::Error for Error {
         match *self {
             Error::AddrParseError(_) => "Can't parse IP address",
             Error::DirectorError(_) => "Director Error",
+            Error::HabitatCommon(ref err) => err.description(),
             Error::HabitatCore(ref err) => err.description(),
             Error::IO(ref err) => err.description(),
             Error::NoServices => "No services specified in configuration",
+            Error::RootRequired => {
+                "Root or administrator permissions required to complete operation"
+            }
         }
+    }
+}
+
+impl From<hcommon::Error> for Error {
+    fn from(err: hcommon::Error) -> Error {
+        Error::HabitatCommon(err)
     }
 }
 

--- a/components/director/src/lib.rs
+++ b/components/director/src/lib.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+extern crate habitat_common as hcommon;
 extern crate habitat_core as hcore;
 #[macro_use]
 extern crate habitat_sup as hsup;

--- a/components/director/src/main.rs
+++ b/components/director/src/main.rs
@@ -180,6 +180,7 @@
 #[macro_use]
 extern crate habitat_director as director;
 extern crate habitat_core as hcore;
+extern crate habitat_common as hcommon;
 #[macro_use]
 extern crate habitat_sup as hsup;
 #[macro_use]
@@ -190,7 +191,9 @@ extern crate log;
 
 use std::process;
 
+use hcommon::ui::UI;
 use hcore::config::ConfigFile;
+use hcore::fs::am_i_root;
 
 use director::config::Config;
 use director::controller::Controller;
@@ -253,6 +256,15 @@ fn dispatch(config: Config, matches: &clap::ArgMatches) -> Result<()> {
 }
 
 fn start(config: Config) -> Result<()> {
+    let mut ui = UI::default();
+    if !am_i_root() {
+        try!(ui.warn("Running the Habitat Supervisor requires root or administrator privileges. \
+                      Please retry this command as a super user or use a privilege-granting \
+                      facility such as sudo."));
+        try!(ui.br());
+        return Err(Error::RootRequired);
+    }
+
     outputln!("Starting Controller");
     let ec = ExecContext::default();
     let mut controller = Controller::new(config, ec);

--- a/components/director/src/task.rs
+++ b/components/director/src/task.rs
@@ -133,11 +133,7 @@ impl Task {
     }
 
     pub fn status(&self) -> String {
-        let desc = if self.is_up() {
-            "Started"
-        } else {
-            "Stopped"
-        };
+        let desc = if self.is_up() { "Started" } else { "Stopped" };
         format!("{}: {} for {}",
                 self.service_def.to_string(),
                 desc,

--- a/components/studio/bin/hab-studio.sh
+++ b/components/studio/bin/hab-studio.sh
@@ -818,6 +818,32 @@ info() {
   return 0
 }
 
+# **Internal** Exit if current user is not root.
+ensure_root() {
+  # Early return if we are root, yay!
+  if [ $($bb id -u) -eq 0 ]; then
+    return
+  fi
+
+  # Otherwise, prepare to die with message formatting similar to the `hab` program.
+  local msg
+  local fatal
+
+  warn_msg="Running Habitat Studio requires root or administrator privileges. \
+Please retry this command as a super user or use a privilege-granting facility such as sudo."
+  fatal_msg="Root or administrator permissions required to complete operation"
+
+  case "${TERM:-}" in
+    *term | xterm-* | rxvt | screen | screen-*)
+      printf -- "\033[0;33m∅ $warn_msg\033[0m\n\n\033[0;31m✗✗✗\n✗✗✗ $fatal_msg\n✗✗✗\033[0m\n"
+      ;;
+    *)
+      printf -- "∅ $warn_msg\n\n✗✗✗\n✗✗✗ $fatal_msg\n✗✗✗\n"
+      ;;
+  esac
+  exit 9
+}
+
 # **Internal** Exit the program with an error message and a status code.
 #
 # ```sh
@@ -973,6 +999,8 @@ version='@version@'
 author='@author@'
 # The short version of the program name which is used in logging output
 program=$($bb basename $0)
+
+ensure_root
 
 
 # ## CLI Argument Parsing

--- a/components/sup/src/error.rs
+++ b/components/sup/src/error.rs
@@ -129,6 +129,7 @@ pub enum Error {
     PackageNotFound(package::PackageIdent),
     Permissions(String),
     RemotePackageNotFound(package::PackageIdent),
+    RootRequired,
     SignalFailed,
     SignalNotifierStarted,
     StrFromUtf8Error(str::Utf8Error),
@@ -208,6 +209,9 @@ impl fmt::Display for SupError {
                     format!("Cannot find a release of package in any sources: {}", pkg)
                 }
             }
+            Error::RootRequired => {
+                "Root or administrator permissions required to complete operation".to_string()
+            }
             Error::SignalFailed => format!("Failed to send a signal to the child process"),
             Error::SignalNotifierStarted => {
                 format!("Only one instance of a Signal Notifier may be running")
@@ -279,6 +283,9 @@ impl error::Error for SupError {
             Error::PackageNotFound(_) => "Cannot find a package",
             Error::Permissions(_) => "File system permissions error",
             Error::RemotePackageNotFound(_) => "Cannot find a package in any sources",
+            Error::RootRequired => {
+                "Root or administrator permissions required to complete operation"
+            }
             Error::SignalFailed => "Failed to send a signal to the child process",
             Error::SignalNotifierStarted => "Only one instance of a Signal Notifier may be running",
             Error::StrFromUtf8Error(_) => "Failed to convert a str from a &[u8] as UTF-8",


### PR DESCRIPTION
This feature is primarily targeted at humans with computers secondarily.  The goal is to prevent non-root users from invoking commands where rootlike permissions are absolutely required for success. The non-root user will see a warning message explaining that the command they are attempting to run must be run as root and will exit with a non-zero code, signaling a failure to any programs, scripts, or automation.

The following programs and subcommands were selected as requiring rootlike permissions for success:

* `hab-studio *` - calling the hab-studio program directly will check for all subcommands
* `hab studio *` & `hab pkg build` (currently on Linux) - there are 2 chances for failure: 1) running on first use which triggers the install-on-use functionality requiring root & 2) running the program itself--in this case we let the `hab-studio` program detect this as above
* `hab pkg install` & `hab install` - any installation behavior needs root permissions to unpack the hart files
* `hab-sup start` - the Supervisor itself deeply assumes root permissions for installation, process supervision, etc.
* `hab sup start` & `hab start` - as in the Studio case, there are 2 chances for failure: 1) running on first use which triggers the install-on-use functionality requiring root & 2) running the program itself--in this case we let the `hab-sup` program detect this as above
* `hab-director start` - the Director also assumes a few capabilities as root

Examples
--------

* Installing a package as a non-root user:

```
> hab install core/jq-static
∅ Installing a package requires root or administrator privileges. Please retry this command as a super user or use a privilege-granting facility such as sudo.

✗✗✗
✗✗✗ Root or administrator permissions required to complete operation
✗✗✗
```

* Running the Supervisor for the first time, requiring an install a as non-root user:

```
> hab start core/redis
∵ Missing package for core/hab-sup
∅ Installing a package requires root or administrator privileges. Please retry this command as a super user or use a privilege-granting facility such as sudo.

✗✗✗
✗✗✗ Root or administrator permissions required to complete operation
✗✗✗
```

* Running a Studio command as a non-root user:

```
> hab studio rm
∅ Running Habitat Studio requires root or administrator privileges. Please retry this command as a super user or use a privilege-granting facility such as sudo.

✗✗✗
✗✗✗ Root or administrator permissions required to complete operation
✗✗✗
```

* Running the raw Supervisor as a non-root user:

```
> hab-sup start core/redis
hab-sup(MN): Starting core/redis
∅ Running the Habitat Supervisor requires root or administrator privileges. Please retry this command as a super user or use a privilege-granting facility such as sudo.

hab-sup(CS)[src/command/start.rs:93:19]: Root or administrator permissions required to complete operation

```
