### PR TITLE
[hab] Attempt to call `sudo` on `hab studio *` for non-root users.

### DIFF
--- a/components/core/src/os/process/linux.rs
+++ b/components/core/src/os/process/linux.rs
@@ -1,0 +1,39 @@
+// Copyright (c) 2016 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::ffi::OsString;
+use std::path::PathBuf;
+use std::os::unix::process::CommandExt;
+use std::process::Command;
+
+use error::Result;
+
+pub fn become_command(command: PathBuf, args: Vec<OsString>) -> Result<()> {
+    become_exec_command(command, args)
+}
+
+/// Makes an `execvp(3)` system call to become a new program.
+///
+/// Note that if sucessful, this function will not return.
+///
+/// # Failures
+///
+/// * If the system call fails the error will be returned, otherwise this function does not return
+fn become_exec_command(command: PathBuf, args: Vec<OsString>) -> Result<()> {
+    debug!("Calling execvp(): ({:?}) {:?}", command.display(), &args);
+    let error_if_failed = Command::new(command).args(&args).exec();
+    // The only possible return for the above function is an `Error` so return it, meaning that we
+    // failed to exec to our target program
+    return Err(error_if_failed.into());
+}

--- a/components/core/src/os/process/mod.rs
+++ b/components/core/src/os/process/mod.rs
@@ -12,8 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod users;
-pub mod filesystem;
-pub mod system;
-pub mod ffi;
-pub mod process;
+#[cfg(windows)]
+mod windows;
+
+#[cfg(windows)]
+pub use self::windows::become_command;
+
+#[cfg(not(windows))]
+pub mod linux;
+
+#[cfg(not(windows))]
+pub use self::linux::become_command;

--- a/components/core/src/os/process/windows.rs
+++ b/components/core/src/os/process/windows.rs
@@ -1,0 +1,39 @@
+// Copyright (c) 2016 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::ffi::OsString;
+use std::path::PathBuf;
+use std::process::{self, Command};
+
+use error::Result;
+
+pub fn become_command(command: PathBuf, args: Vec<OsString>) -> Result<()> {
+    become_child_command(command, args)
+}
+
+/// Executes a command as a child process and exits with the child's exit code.
+///
+/// Note that if sucessful, this function will not return.
+///
+/// # Failures
+///
+/// * If the child process cannot be created
+fn become_child_command(command: PathBuf, args: Vec<OsString>) -> Result<()> {
+    debug!("Calling child process: ({:?}) {:?}",
+           command.display(),
+           &args);
+    let status = try!(Command::new(command).args(&args).status());
+    // Let's honor the exit codes from the child process we finished running
+    process::exit(status.code().unwrap())
+}

--- a/components/hab/src/command/pkg.rs
+++ b/components/hab/src/command/pkg.rs
@@ -108,11 +108,11 @@ pub mod exec {
     use std::env;
     use std::ffi::OsString;
 
+    use hcore::os::process;
     use hcore::package::{PackageIdent, PackageInstall};
     use hcore::fs::find_command;
 
     use error::{Error, Result};
-    use exec;
 
     pub fn start(ident: &PackageIdent, command: &str, args: Vec<OsString>) -> Result<()> {
         let pkg_install = try!(PackageInstall::load(&ident, None));
@@ -129,7 +129,7 @@ pub mod exec {
             display_args.push_str(arg.to_string_lossy().as_ref());
         }
         info!("Running: {}", display_args);
-        exec::exec_command(command, args)
+        Ok(try!(process::become_command(command, args)))
     }
 }
 

--- a/components/hab/src/command/sup.rs
+++ b/components/hab/src/command/sup.rs
@@ -32,6 +32,7 @@ mod inner {
     use hcore::crypto::{init, default_cache_key_path};
     use hcore::env as henv;
     use hcore::fs::find_command;
+    use hcore::os::process;
     use hcore::package::PackageIdent;
 
     use error::{Error, Result};
@@ -63,7 +64,7 @@ mod inner {
         };
 
         if let Some(cmd) = find_command(command.to_string_lossy().as_ref()) {
-            exec::exec_command(cmd, args)
+            Ok(try!(process::become_command(cmd, args)))
         } else {
             Err(Error::ExecCommandNotFound(command.to_string_lossy().into_owned()))
         }

--- a/components/hab/src/error.rs
+++ b/components/hab/src/error.rs
@@ -44,6 +44,7 @@ pub enum Error {
     PackageArchiveMalformed(String),
     PathPrefixError(path::StripPrefixError),
     ProvidesError(String),
+    RootRequired,
     SubcommandNotSupported(String),
     UnsupportedExportFormat(String),
 }
@@ -89,6 +90,9 @@ impl fmt::Display for Error {
             }
             Error::PathPrefixError(ref err) => format!("{}", err),
             Error::ProvidesError(ref err) => format!("Can't find {}", err),
+            Error::RootRequired => {
+                "Root or administrator permissions required to complete operation".to_string()
+            }
             Error::SubcommandNotSupported(ref e) => {
                 format!("Subcommand `{}' not supported on this operating system", e)
             }
@@ -122,6 +126,9 @@ impl error::Error for Error {
             Error::PathPrefixError(ref err) => err.description(),
             Error::ProvidesError(_) => {
                 "Can't find a package that provides the given search parameter"
+            }
+            Error::RootRequired => {
+                "Root or administrator permissions required to complete operation"
             }
             Error::SubcommandNotSupported(_) => "Subcommand not supported on this operating system",
             Error::UnsupportedExportFormat(_) => "Unsupported export format",

--- a/components/hab/src/exec.rs
+++ b/components/hab/src/exec.rs
@@ -12,11 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-extern crate libc;
-
-use std::ffi::OsString;
 use std::path::{Path, PathBuf};
-use std::process::{Command, exit};
 
 use common;
 use common::ui::{Status, UI};
@@ -30,23 +26,6 @@ use error::{Error, Result};
 
 #[allow(dead_code)] // Currently only used on Linux platforms
 const MAX_RETRIES: u8 = 4;
-
-/// Makes an `std::process::Command` call.
-///
-/// # Failures
-///
-/// * Command and/or command arguments cannot be converted into `CString`
-pub fn exec_command(command: PathBuf, args: Vec<OsString>) -> Result<()> {
-    debug!("Calling std::process::Command: ({:?}) {:?}", command.display(), &args);
-    let mut command = Command::new(command);
-
-    for arg in &args {
-        command.arg(arg);
-    }
-    let status = command.status().expect(&(format!("{:?} failed to start.", &command)));
-    // Let's bubble back up the error codes from the command we shell'd out to
-    exit(status.code().unwrap())
-}
 
 /// Returns the absolute path to the given command from the given package identifier.
 ///


### PR DESCRIPTION
This change set comprises 2 parts. The contents of each commit message is aggregated below:

# [hab] Attempt to call `sudo` on `hab studio *` for non-root users.

This change only currently affects Linux non-root users who attempt to run the following subcommands:

* `hab studio *`
* `hab pkg build *`

The behavior introduced here will attempt to re-exec the command with prepended with a `sudo -p "[sudo hab-studio] password for %u:" -E` in front of the original `hab` subcommand. If the `sudo` command cannot be found on the `PATH` then an error message is displayed to the user and the program terminates with a non-zero exit code. The end result is that, for non-root users on systems using sudoers:

    hab pkg build ...

Will be the same as running:

    sudo hab pkg build ...

Examples
--------

Running as a non-root user with appropriate permissions in sudoers:

```
> hab studio enter
[sudo hab-studio] password for jdoe:
   hab-studio: Creating Studio at /hab/studios/home--jdoe (default)
   hab-studio: Importing jdoe secret origin key
» Importing origin key from standard input
★ Imported secret origin key jdoe-20161005175939.
   hab-studio: Entering Studio at /hab/studios/home--jdoe (default)
   hab-studio: Exported: HAB_ORIGIN=jdoe

[1][default:/src:0]#
```

Running as a non-root user when the `sudo` command cannot be found on `PATH`:

```
> sudo mv /usr/bin/sudo /usr/bin/ssudo

> hab studio enter
∅ Could not find the `sudo' command on the filesystem or in PATH.
∅ Running Habitat Studio requires root or administrator privileges. Please retry this command as a super user or use a privilege-granting facility such as sudo.

✗✗✗
✗✗✗ Root or administrator permissions required to complete operation
✗✗✗
```

# [core] Add core `become_command()` to abstract Unix/Windows exec diffs.

This change extracts the formerly named `exec_command()` function from
hab's `exec` module into a common interface `become_command()` in core's
newly created `os::process` module. The intent of this function
philisophically is to turn the current process into some other process
that takes over for the duration of the new process. In other words, the
existing process ceases to do any work.

There are 2 implementations for this function, which depend on the
underlying target platform:

Unix (i.e. Linux, Mac, BSD, etc)
--------------------------------

This implementation uses [`execvp(3)`][] which is now provided by the
[`exec()`][] function on Rust's stdlib [`CommandExt`][] trait. This
insures that there isn't a deeply nested process chain and that signals
such as `Ctrl+C` correctly kill all related processes. If a developer
needs to create a child process and supervise it or act on the child's
results then this is **not** the appropriate API to invoke, hence the
name `become_command()`.

[`execvp(3)`]: https://linux.die.net/man/3/execvp
[`exec()`]:
https://doc.rust-lang.org/std/os/unix/process/trait.CommandExt.html#tymethod.exec
[`CommandExt`]:
https://doc.rust-lang.org/std/os/unix/process/trait.CommandExt.html

Windows
-------

This implementation uses Rust's stdlib [`Command`] to execute the
command as a child process and then exits with the child's exit code.
Due to the lack of `exec*()` behavior. Note that there is an older
`_execv()` in a POSIX compatibility layer in MSVCRT, but the native
approach is to use a child process here, and so that's what we do.
Also note that while the `hab` process is not replaced by the new
process, we explicitly terminate the `hab` process after the child
process completes. If a developer needs to create a child process and
supervise it or act on the child's results then this is **not** the
appropriate API to invoke, hence the name `become_command()`.

[`Command`]:
https://doc.rust-lang.org/std/process/struct.Command.html#method.exec
