### PR TITLE
[studio] Properly propagate the exit code when `build` fails.

### DIFF
--- a/components/studio/bin/hab-studio.sh
+++ b/components/studio/bin/hab-studio.sh
@@ -617,7 +617,7 @@ record() {
     $bb mkdir -p $($bb dirname $log)
     unset BUSYBOX LOGDIR
 
-    $bb script -c "$bb env -i $env $cmd $*" $log
+    $bb script -c "$bb env -i $env $cmd $*" -e $log
   ); return $?
 }
 


### PR DESCRIPTION
Can I write more words to explain this fix than the fix itself? It seems
I already did.

The `hab-studio build` subcommand (which is also invoked via `hab studio
build` and `hab pkg build`) has a shell function called [`record()`][]
to log the entire build activity in a log file via the [`script(1)`][]
program. It turns out that the exit code of the child process is not
returned by default as I initially assumed and therefore the `script`
call always return an exit code of `0`.

This fix adds a `--return` flag (short form of which is `-e`) to return
the exit code of the child proces--in our case this is the `build`
program itself. Adding this exit code return properly bubbles back the
exit code to its parent process (the bash program inside the
`chroot(1)`) and we get a proper exit code when `hab-studio`
terminates...as we expected in the first place.

Note that I went with the short flag form of `-e` in an attempt to make
this portable across to the BusyBox version if it happens to be
activated. This is one situation where I deviated from my defaulting to
always use the long, explicit version in calling programs and
scripts--we can't all remember every `docker` and `netstat` flag, right?

Closes #1285

[`record()`]:
https://github.com/habitat-sh/habitat/blob/f470c41146bd3c796adb0a610d3994497557dde0/components/studio/bin/hab-studio.sh#L604-L622
[`script(1)`]:
http://man7.org/linux/man-pages/man1/script.1.html

/cc @reset I think this is going to help you out this week...

![gif-keyboard-143735727654487103](https://cloud.githubusercontent.com/assets/261548/19136422/c96c2d3c-8b29-11e6-86ff-02748727f509.gif)
