### PR TITLE
[ci] Drop requirement for nightly cargo installation.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ branches:
     - /^test_development-.*$/
 env:
   global:
-    - PATH=$HOME/bin:$HOME/.cargo/bin:$PATH
+    - PATH=$HOME/.cargo/bin:$PATH
 matrix:
   include:
   - language: ruby
@@ -63,7 +63,6 @@ matrix:
       - ./support/ci/compile_libarchive.sh
       - ./support/ci/compile_zmq.sh
       - ./support/ci/install_rustfmt.sh
-      - ./support/ci/install_cargo.sh
     script:
       - ./support/ci/rust_tests.sh
       - ./support/ci/lint.sh
@@ -101,7 +100,6 @@ matrix:
       - ./support/ci/compile_libarchive.sh
       - ./support/ci/compile_zmq.sh
       - ./support/ci/install_rustfmt.sh
-      - ./support/ci/install_cargo.sh
     script:
       - ./support/ci/rust_tests.sh
       - ./support/ci/lint.sh
@@ -139,7 +137,6 @@ matrix:
       - ./support/ci/compile_libarchive.sh
       - ./support/ci/compile_zmq.sh
       - ./support/ci/install_rustfmt.sh
-      - ./support/ci/install_cargo.sh
     script:
       - ./support/ci/rust_tests.sh
       - ./support/ci/lint.sh

--- a/support/ci/install_cargo.sh
+++ b/support/ci/install_cargo.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-set -eu
-
-curl -s https://static.rust-lang.org/cargo-dist/cargo-nightly-x86_64-unknown-linux-gnu.tar.gz | tar xzm
-cargo-nightly-x86_64-unknown-linux-gnu/install.sh --prefix=$HOME


### PR DESCRIPTION
Now that the Travis platform is running the Rust 1.12.0 release, we no
longer need to rely on installing nightly cargo for the workspace
feature.

Another ~1 min or so saved per run ;)

![gif-keyboard-15411004060845202373](https://cloud.githubusercontent.com/assets/261548/19137629/973c0540-8b32-11e6-859d-b9e95d0f2071.gif)
