### PR TITLE
[ci] Remove unused and redundant cache directories.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,10 +53,7 @@ matrix:
       apt: true
       cargo: true
       directories:
-        - "$HOME/rust"
         - "$HOME/pkgs"
-        - "$HOME/.cargo"
-        - target
     before_install:
       - ./support/ci/fast_pass.sh || exit 0
       - ./support/ci/compile_libsodium.sh
@@ -90,10 +87,7 @@ matrix:
       apt: true
       cargo: true
       directories:
-        - "$HOME/rust"
         - "$HOME/pkgs"
-        - "$HOME/.cargo"
-        - target
     before_install:
       - ./support/ci/fast_pass.sh || exit 0
       - ./support/ci/compile_libsodium.sh
@@ -127,10 +121,7 @@ matrix:
       apt: true
       cargo: true
       directories:
-        - "$HOME/rust"
         - "$HOME/pkgs"
-        - "$HOME/.cargo"
-        - target
     before_install:
       - ./support/ci/fast_pass.sh || exit 0
       - ./support/ci/compile_libsodium.sh


### PR DESCRIPTION
This change removes the `$HOME/rust` directory which appears to be
long-unused (introduced in #513), and also removes the `$HOME/.cargo`
and `target` entries which appear to be
[handled](https://docs.travis-ci.com/user/caching/#Rust-Cargo-cache) by
the `cargo: true` lines in the .travis.yml.

This should reduce the time spent downloading (extra?) caches tarballs
off s3 and marginally speed up the build times.
