### PR TITLE
[ci] Support `$STEAM_ROLLER` to force a build unconditionally.

### DIFF
--- a/support/ci/fast_pass.sh
+++ b/support/ci/fast_pass.sh
@@ -7,12 +7,14 @@
 # .travis.yml in the `before_install`, we exit non-zero if we want the build to
 # be skipped, so we can do `|| exit 0` in the YAML.
 
-# Don't do anything if $AFFECTED_DIRS is not set
-if [ -z "$AFFECTED_DIRS" ]; then
+if [ -n "$STEAM_ROLLER" ]; then
+  echo 'STEAM_ROLLER is set. Not exiting and running everything.'
+elif [ -z "$AFFECTED_DIRS" ]; then
+  # Don't do anything if $AFFECTED_DIRS is not set
   echo 'AFFECTED_DIRS is not set. Not exiting and running everything.'
-# If $AFFECTED_DIRS (a "|" separated list of directories) is set, see if we have
-# any changes
 else
+  # If $AFFECTED_DIRS (a "|" separated list of directories) is set, see if we have
+  # any changes
   git diff --name-only "$TRAVIS_COMMIT_RANGE" | grep -qE "^($AFFECTED_DIRS)" || {
     echo "No files in $AFFECTED_DIRS have changed. Skipping CI run."
     exit 1


### PR DESCRIPTION
This adds "un-shortcircuiting" logic to `support/ci/fast_pass.sh` to force a full build no matter the state of the pull request. This is used in conjunction with setting [variables in repository settings](https://docs.travis-ci.com/user/environment-variables/#Defining-Variables-in-Repository-Settings) when cache-busting to ensure a full, clean build.

![gif-keyboard-2652453615604834322](https://cloud.githubusercontent.com/assets/261548/19138923/8bd4f5bc-8b3d-11e6-9048-468e589c02ed.gif)
