### PR TITLE
Don't restart child process if reconfigure hook is defined

### DIFF
--- a/components/sup/src/topology/mod.rs
+++ b/components/sup/src/topology/mod.rs
@@ -333,10 +333,12 @@ fn run_internal(sm: &mut StateMachine<State, Worker, SupError>,
                         // Write the configuration, and restart if needed
                         if try!(service_config.write(&package)) {
                             try!(package.copy_run(&service_config));
-                            try!(package.reconfigure(&service_config));
                             outputln!("Restarting because the service config was updated via the \
                                        census");
-                            restart_process = true;
+                            let has_reconfigure = try!(package.reconfigure(&service_config));
+                            if !has_reconfigure {
+                                restart_process = true;
+                            }
                         }
                     }
                 }
@@ -380,8 +382,8 @@ fn run_internal(sm: &mut StateMachine<State, Worker, SupError>,
                 service_config.cfg(&package);
                 if try!(service_config.write(&package)) {
                     try!(package.copy_run(&service_config));
-                    let existed = try!(package.reconfigure(&service_config));
-                    if !existed {
+                    let has_reconfigure = try!(package.reconfigure(&service_config));
+                    if !has_reconfigure {
                         restart_process = true;
                     }
                 }

--- a/test/fixtures/simple_service_with_reconfigure/bin/simple_service
+++ b/test/fixtures/simple_service_with_reconfigure/bin/simple_service
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+EXIT_NOW=0
+
+received_int() {
+  echo "RECEIVED INT"
+  EXIT_NOW=1
+}
+
+
+received_term() {
+    echo "RECEIVED TERM"
+    EXIT_NOW=1
+}
+
+received_hup() {
+    echo "RECEIVED HUP"
+    EXIT_NOW=1
+}
+
+trap "received_int" INT
+trap "received_term" TERM
+trap "received_hup" HUP
+
+echo "Shipping out to Boston"
+
+while [ 1 ]; do
+  if [ $EXIT_NOW = 1 ]; then
+     echo "Exiting on signal"
+     exit 0
+  fi
+  sleep 1
+done
+

--- a/test/fixtures/simple_service_with_reconfigure/config/simple.conf
+++ b/test/fixtures/simple_service_with_reconfigure/config/simple.conf
@@ -1,0 +1,3 @@
+### Configuration ###
+setting: {{setting}}
+### End Configuration ###

--- a/test/fixtures/simple_service_with_reconfigure/default.toml
+++ b/test/fixtures/simple_service_with_reconfigure/default.toml
@@ -1,0 +1,1 @@
+setting = "true"

--- a/test/fixtures/simple_service_with_reconfigure/hooks/reconfigure
+++ b/test/fixtures/simple_service_with_reconfigure/hooks/reconfigure
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "RUNNING RECONFIGURE HOOK"

--- a/test/fixtures/simple_service_with_reconfigure/plan.sh
+++ b/test/fixtures/simple_service_with_reconfigure/plan.sh
@@ -1,0 +1,37 @@
+pkg_name=simple_service_with_reconfigure
+pkg_origin=hab_test
+pkg_version=0.0.1
+pkg_license=('Apache2')
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_source=nosuchfile.tar.gz
+pkg_bin_dirs=(bin)
+pkg_deps=()
+pkg_svc_run="simple_service"
+
+do_download() {
+  return 0
+}
+
+do_verify() {
+  return 0
+}
+
+do_unpack() {
+  return 0
+}
+
+do_prepare() {
+  return 0
+}
+
+do_build() {
+  return 0
+}
+
+do_install() {
+  cp -r $PLAN_CONTEXT/bin $pkg_prefix
+  # this is outside of the chroot, so it won't work
+  #cp -r /src/components/sup/target/debug/hab-sup $pkg_prefix/bin
+  chmod 755 $pkg_prefix/bin
+  chmod 755 $pkg_prefix/bin/*
+}

--- a/test/fixtures/simple_service_without_reconfigure/bin/simple_service
+++ b/test/fixtures/simple_service_without_reconfigure/bin/simple_service
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+EXIT_NOW=0
+
+received_int() {
+  echo "RECEIVED INT"
+  EXIT_NOW=1
+}
+
+received_term() {
+    echo "RECEIVED TERM"
+    EXIT_NOW=1
+}
+
+received_hup() {
+    echo "RECEIVED HUP"
+    EXIT_NOW=1
+}
+
+trap "received_int" INT
+trap "received_term" TERM
+trap "received_hup" HUP
+
+echo "Shipping out to Boston"
+
+while [ 1 ]; do
+  if [ $EXIT_NOW = 1 ]; then
+     echo "Exiting on signal"
+     exit 0
+  fi
+  sleep 1
+done
+

--- a/test/fixtures/simple_service_without_reconfigure/config/simple.conf
+++ b/test/fixtures/simple_service_without_reconfigure/config/simple.conf
@@ -1,0 +1,3 @@
+### Configuration ###
+setting: {{setting}}
+### End Configuration ###

--- a/test/fixtures/simple_service_without_reconfigure/default.toml
+++ b/test/fixtures/simple_service_without_reconfigure/default.toml
@@ -1,0 +1,1 @@
+setting = "true"

--- a/test/fixtures/simple_service_without_reconfigure/plan.sh
+++ b/test/fixtures/simple_service_without_reconfigure/plan.sh
@@ -1,0 +1,37 @@
+pkg_name=simple_service_without_reconfigure
+pkg_origin=hab_test
+pkg_version=0.0.1
+pkg_license=('Apache2')
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_source=nosuchfile.tar.gz
+pkg_bin_dirs=(bin)
+pkg_deps=()
+pkg_svc_run="simple_service"
+
+do_download() {
+  return 0
+}
+
+do_verify() {
+  return 0
+}
+
+do_unpack() {
+  return 0
+}
+
+do_prepare() {
+  return 0
+}
+
+do_build() {
+  return 0
+}
+
+do_install() {
+  cp -r $PLAN_CONTEXT/bin $pkg_prefix
+  # this is outside of the chroot, so it won't work
+  #cp -r /src/components/sup/target/debug/hab-sup $pkg_prefix/bin
+  chmod 755 $pkg_prefix/bin
+  chmod 755 $pkg_prefix/bin/*
+}


### PR DESCRIPTION
I used https://github.com/habitat-sh/habitat/pull/1074 as a starting point, refactored out the `has_reconfigure` code and added an additional case. Tests included for 0) a package that has a reconfigure hook and 1) a package that doesn't have a reconfigure hook.

Sorry about the whitespace cleanup 😿 