### PR TITLE
Make Admin/Elevated Admin Token == root for hab commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -409,6 +409,7 @@ name = "habitat_core"
 version = "0.0.0"
 dependencies = [
  "errno 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libarchive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/core/Cargo.toml
+++ b/components/core/Cargo.toml
@@ -1,8 +1,12 @@
 [package]
 name = "habitat_core"
 version = "0.0.0"
-authors = ["Adam Jacob <adam@chef.io>", "Jamie Winsor <reset@chef.io>", "Fletcher Nichol <fnichol@chef.io>", "Joshua Timberman <joshua@chef.io>", "Dave Parfitt <dparfitt@chef.io>"]
+authors = ["Adam Jacob <adam@chef.io>", "Jamie Winsor <reset@chef.io>", "Fletcher Nichol <fnichol@chef.io>", "Joshua Timberman <joshua@chef.io>", "Dave Parfitt <dparfitt@chef.io>", "Steven Murawski <smurawski@chef.io>"]
 workspace = "../../"
+build = "build.rs"
+
+[build-dependencies]
+gcc = "0.3"
 
 [dependencies]
 errno = "*"

--- a/components/core/build.rs
+++ b/components/core/build.rs
@@ -1,0 +1,6 @@
+extern crate gcc;
+
+#[cfg(windows)]
+fn main() {
+    gcc::compile_library("libadmincheck.a", &["./src/os/users/admincheck.c"]);
+}

--- a/components/core/build.rs
+++ b/components/core/build.rs
@@ -4,3 +4,6 @@ extern crate gcc;
 fn main() {
     gcc::compile_library("libadmincheck.a", &["./src/os/users/admincheck.c"]);
 }
+
+#[cfg(not(windows))]
+fn main() {}

--- a/components/core/src/os/users/admincheck.c
+++ b/components/core/src/os/users/admincheck.c
@@ -1,0 +1,90 @@
+#include <windows.h>
+#include <winnt.h>
+#include <ShlObj.h>
+
+#pragma comment (lib,"shell32.lib")
+
+TOKEN_ELEVATION_TYPE s_elevationType = TokenElevationTypeDefault;
+BOOL                 s_bIsAdmin = FALSE;
+
+// returns 0 if an admin
+// returns 1 if not
+int GetElevationState()
+{
+    if (GetProcessElevation(&s_elevationType, &s_bIsAdmin)) {
+        switch(s_elevationType) {
+            // Default user or UAC is disabled
+            case TokenElevationTypeDefault:  
+                if (IsUserAnAdmin()) {
+                    return 0;
+                } else {
+                    return 1;
+                }
+            break;
+            // Process has been successfully elevated
+            case TokenElevationTypeFull:
+                if (IsUserAnAdmin()) {
+                    return 0;
+                } else {
+                    return 1;
+                }
+            break; 
+            // Process is running with limited privileges
+            case TokenElevationTypeLimited:
+                if (IsUserAnAdmin()) {
+                    // Not sure what capabilities a filtered admin has
+                    // So, for now, I'll treat that as non-admin
+                    return 1;
+                } else {
+                    return 1;
+                }
+            break;
+        }
+        return 1;
+    }
+    return 1;
+} 
+
+BOOL GetProcessElevation(TOKEN_ELEVATION_TYPE* pElevationType, BOOL* pIsAdmin) {
+   HANDLE hToken = NULL;
+   DWORD dwSize;
+
+   // Get current process token
+   if (!OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &hToken))
+      return(FALSE);
+
+   BOOL bResult = FALSE;
+
+   // Retrieve elevation type information
+   if (GetTokenInformation(hToken, TokenElevationType,
+      pElevationType, sizeof(TOKEN_ELEVATION_TYPE), &dwSize)) {
+      // Create the SID corresponding to the Administrators group
+      BYTE adminSID[SECURITY_MAX_SID_SIZE];
+      dwSize = sizeof(adminSID);
+      CreateWellKnownSid(WinBuiltinAdministratorsSid, NULL, &adminSID,
+         &dwSize);
+
+      if (*pElevationType == TokenElevationTypeLimited) {
+         // Get handle to linked token (will have one if we are lua)
+         HANDLE hUnfilteredToken = NULL;
+         GetTokenInformation(hToken, TokenLinkedToken, (VOID*)
+            &hUnfilteredToken, sizeof(HANDLE), &dwSize);
+
+         // Check if this original token contains admin SID
+         if (CheckTokenMembership(hUnfilteredToken, &adminSID, pIsAdmin)) {
+            bResult = TRUE;
+         }
+
+         // Don't forget to close the unfiltered token
+         CloseHandle(hUnfilteredToken);
+      } else {
+         *pIsAdmin = IsUserAnAdmin();
+         bResult = TRUE;
+      }
+   }
+
+   // Don't forget to close the process token
+   CloseHandle(hToken);
+
+   return(bResult);
+}

--- a/components/core/src/os/users/windows.rs
+++ b/components/core/src/os/users/windows.rs
@@ -14,6 +14,10 @@
 
 use std::path::PathBuf;
 
+extern "C" {
+    pub fn GetUserTokenStatus() -> u32;
+}
+
 pub fn get_uid_by_name(owner: &str) -> Option<u32> {
     unimplemented!();
 }
@@ -23,7 +27,7 @@ pub fn get_gid_by_name(group: &str) -> Option<u32> {
 }
 
 pub fn get_effective_uid() -> u32 {
-    0u32
+    unsafe { GetUserTokenStatus() }
 }
 
 pub fn get_home_for_user(username: &str) -> Option<PathBuf> {


### PR DESCRIPTION
This plumbs in a process token check to see if the user account has admin rights and, if UAC is enabled, if the token is elevated or filtered.

Admins (without UAC) and admins with elevated tokens will be treated as root by the `hab` command.

There are some additions to the core crate - an admincheck.c which is a wrapper around the win32 api calls required to validate above in an easier to consume fashion, a build.rs file to compile and link that C code, as well as updates to the build script to handle the native code linking to system apis.