### PR TITLE
Really fix the admin status check on Windows this time

### DIFF
--- a/components/core/src/os/users/admincheck.c
+++ b/components/core/src/os/users/admincheck.c
@@ -43,8 +43,9 @@ int GetUserTokenStatus()
                     user_token_status =  1;
                 }
             break;
+            default:
+                user_token_status =  5;
         }
-        user_token_status =  5;
     }
     return user_token_status;
 } 


### PR DESCRIPTION
had the default from the switch outside the switch, which overrode the actual token state.

Tested:

- [X] `hab origin key generate` as an elevated admin creates keys in `$env:systemdrive/hab/cache/keys`
- [X] `hab origin key generate` as an filtered admin creates keys in `$env:UserProfile/.hab/cache/keys`
- [X] `hab pkg install` as an elevated admin installs a package to  `$env:systemdrive/hab/pkgs`
- [X] `hab pkg install` as an filtered admin errors and advises that the process needs admin rights

Signed-off-by: Steven Murawski <steven.murawski@gmail.com>