### PR TITLE
[core] Check invalid characters in package name on upload

### DIFF
--- a/components/builder-depot/src/server.rs
+++ b/components/builder-depot/src/server.rs
@@ -398,6 +398,12 @@ fn upload_package(req: &mut Request) -> IronResult<Response> {
         let params = req.extensions.get::<Router>().unwrap();
         ident_from_params(params)
     };
+
+    if !ident.valid() {
+        info!("Invalid package identifier: {}", ident);
+        return Ok(Response::with(status::BadRequest));
+    }
+
     let mut conn = Broker::connect().unwrap();
 
     debug!("UPLOADING checksum={}, ident={}",

--- a/components/core/src/package/ident.rs
+++ b/components/core/src/package/ident.rs
@@ -31,6 +31,11 @@ pub trait Identifiable: fmt::Display + Into<PackageIdent> {
         self.version().is_some() && self.release().is_some()
     }
 
+    fn valid(&self) -> bool {
+        let re = Regex::new(r"^[A-Za-z0-9_-]+$").unwrap();
+        re.is_match(self.name())
+    }
+
     fn satisfies<I: Identifiable>(&self, other: &I) -> bool {
         if self.origin() != other.origin() || self.name() != other.name() {
             return false;
@@ -471,5 +476,20 @@ mod tests {
         let full = PackageIdent::new("acme", "rocket", Some("1.2.3"), Some("1234"));
         assert!(!partial.fully_qualified());
         assert!(full.fully_qualified());
+    }
+
+    #[test]
+    fn check_valid_package_id() {
+        let valid1 = PackageIdent::new("acme", "rocket", Some("1.2.3"), Some("1234"));
+        let valid2 = PackageIdent::new("acme", "rocket-one", Some("1.2.3"), Some("1234"));
+        let valid3 = PackageIdent::new("acme", "rocket_one", Some("1.2.3"), Some("1234"));
+        let invalid1 = PackageIdent::new("acme", "rocket.one", Some("1.2.3"), Some("1234"));
+        let invalid2 = PackageIdent::new("acme", "rocket%one", Some("1.2.3"), Some("1234"));
+
+        assert!(valid1.valid());
+        assert!(valid2.valid());
+        assert!(valid3.valid());
+        assert!(!invalid1.valid());
+        assert!(!invalid2.valid());
     }
 }


### PR DESCRIPTION
Signed-off-by: Salim Alam <salam@chef.io>

Package names with invalid characters (such as '.') as no longer allowed to be uploaded to the depot.  This change adds checking on the server side.