### PR TITLE
Add windows binaries to available downloads

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -126,6 +126,7 @@ from the master branch on a bi-weekly schedule occurring every other Thursday.
   * hab-sup-static - `habitat/components/sup/static`
   * hab-director - `habitat/components/director`
 1. [Build Mac Components](#how-to-build-mac-components)
+1. [Build Windows Components](#how-to-build-windows-components)
 
 ## Publish Release
 
@@ -201,6 +202,18 @@ target component.
 	$ sudo ./mac-build.sh
 	```
 
+# How-To: Build Windows Components
+
+1. Ensure no pre-existing old virtual machine, then provision a new Windows machine
+
+    ```
+    $ cd ~/code/habitat/components/hab/win
+    $ vagrant destroy
+    $ vagrant up
+    ```
+
+The script provisioner in the Vagrantfile will pull down all dependencies and build the windows hab binary.
+
 # How-To: Release to Bintray
 
 1. On your workstation, change your code directory and enter a studio
@@ -222,13 +235,15 @@ target component.
     $ hab pkg exec core/hab-bintray-publish publish-studio
     ```
 
-1. Publish the Linux and Mac artifacts by selecting the appropriate `.hart` file
+1. Publish the Linux, Mac and Windows artifacts by selecting the appropriate `.hart` file
 
     ```
     $ hab pkg exec core/hab-bintray-publish publish-hab \
       ./results/core-hab-0.10.2-20160930230245-x86_64-linux.hart
     $ hab pkg exec core/hab-bintray-publish publish-hab \
       ./habitat/components/hab/mac/results/core-hab-0.10.2-20160930230245-x86_64-darwin.hart
+    $ hab pkg exec core/hab-bintray-publish publish-hab \
+      ./habitat/components/hab/win/results/core-hab-0.10.2-20160930230245-x86_64-windows.zip      
     ```
 
 More documentation for the Bintray releasing software can be found in the component's [Readme](components/bintray-publish/README.md).

--- a/components/hab/win/Vagrantfile
+++ b/components/hab/win/Vagrantfile
@@ -1,0 +1,10 @@
+$script = <<SCRIPT
+cd /src/components/hab/win
+./win-build.ps1
+SCRIPT
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "mwrock/Windows2016"
+  config.vm.synced_folder File.expand_path("../../../../", __FILE__), "/src"
+  config.vm.provision "shell", inline: $script
+end

--- a/components/hab/win/win-build.ps1
+++ b/components/hab/win/win-build.ps1
@@ -65,12 +65,12 @@ if (get-command -Name rustup.exe -ErrorAction SilentlyContinue) {
     $cargo = 'rustup run stable-x86_64-pc-windows-msvc cargo'
 }
 else {
-    $env:PATH = New-PathString -StartingPath $env:PATH -Path "C:\Program Files (x86)\Rust\bin"
+    $env:PATH = New-PathString -StartingPath $env:PATH -Path "C:\Program Files\Rust stable MSVC 1.12\bin"
     if (-not (get-command rustc -ErrorAction SilentlyContinue)) {
         write-host "installing rust"
-        Invoke-WebRequest -UseBasicParsing -Uri 'https://static.rust-lang.org/dist/rust-1.12.0-x86_64-pc-windows-msvc.msi' -OutFile './rust-12-stable.exe'
-        start-process -filepath ./rust-12-stable.exe -argumentlist  '/VERYSILENT', '/NORESTART', '/DIR="C:\Program Files (x86)\Rust"' -Wait
-        $env:PATH = New-PathString -StartingPath $env:PATH -Path "C:\Program Files (x86)\Rust\bin"
+        Invoke-WebRequest -UseBasicParsing -Uri 'https://static.rust-lang.org/dist/rust-1.12.0-x86_64-pc-windows-msvc.msi' -OutFile "$env:TEMP/rust-12-stable.msi"
+        start-process -filepath MSIExec.exe -argumentlist "/qn", "/i", "$env:TEMP\rust-12-stable.msi" -Wait
+        $env:PATH = New-PathString -StartingPath $env:PATH -Path "C:\Program Files\Rust stable MSVC 1.12\bin"
         while (-not (get-command cargo -ErrorAction SilentlyContinue)) {
             Write-Warning "`tWaiting for `cargo` to be available."
             start-sleep -Seconds 1
@@ -103,12 +103,25 @@ $env:OPENSSL_LIB_DIR            = $ChocolateyHabitatLibDir
 $env:OPENSSL_INCLUDE_DIR        = $ChocolateyHabitatIncludeDir
 $env:OPENSSL_STATIC             = $true
 
+if (Test-AppVeyor) { return }
 
 # Start the build
-if (-not (Test-AppVeyor)) {
-    Push-Location "$psscriptroot\.."
-    invoke-expression "$cargo clean"
-    Invoke-Expression "$cargo build" 
-    Pop-Location
-    exit $LASTEXITCODE
-}
+Push-Location "$psscriptroot\.."
+invoke-expression "$cargo clean"
+Invoke-Expression "$cargo build --release" 
+Pop-Location
+
+# Create the archive
+$pkgRoot = "results"
+New-Item -ItemType Directory -Path $pkgRoot -ErrorAction SilentlyContinue
+
+$pkgRelease = (Get-Date).ToString('yyyyMMddhhmmss')
+$pkgVersion = (Get-Content -Path ..\..\..\VERSION | Out-String).Trim()
+$pkgArtifact = "$pkgRoot/core-hab-$pkgVersion-$pkgRelease-x86_64-windows"
+Compress-Archive -Path @(
+    '..\..\..\target\Release\hab.exe',
+    'C:\Windows\System32\vcruntime140.dll',
+    'C:\ProgramData\chocolatey\lib\habitat_native_dependencies\builds\bin\*.dll'
+    ) -DestinationPath "$pkgArtifact.zip"
+
+exit $LASTEXITCODE

--- a/www/source/docs/get-habitat.html.md
+++ b/www/source/docs/get-habitat.html.md
@@ -23,7 +23,14 @@ _Habitat for Linux requires a 64-bit processor with a kernel greater than 2.6.32
 <a class="button" href="https://api.bintray.com/content/habitat/stable/linux/x86_64/hab-%24latest-x86_64-linux.tar.gz?bt_package=hab-x86_64-linux">Download Habitat for Linux</a>
 
 ### For Windows
-Habitat currently runs on Mac and Linux operating systems only. Windows support is coming soon.
+To start using Habitat on Windows, download the following binary.  
+If you intend to build Habitat packages on your Windows PC, you will also need to install [Docker for Windows](https://docs.docker.com/docker-for-windows/).  
+_Habitat for Windows requires 64bit Windows 10 Pro, Enterprise and Education (1511 November update, Build 10586 or later) and Microsoft Hyper-V.
+
+> Note: Currently Habitat can only build and manage linux based packages. Support for Windows based applications is coming.
+
+<a class="button" href="https://api.bintray.com/content/habitat/stable/windows/x86_64/hab-%24latest-x86_64-windows.zip?bt_package=hab-x86_64-windows">Download Habitat for Windows</a>
+<a class="button secondary" href="https://download.docker.com/win/stable/InstallDocker.msi">Download Docker for Windows</a>
 
 <hr>
 


### PR DESCRIPTION
This is nearly done, but the following needs to be polished:

* Secret key pasting is not injecting into stdin in a friendly way
* Add a disclaimer to the download making it clear that this only builds linux based applications
* Add windows based tutorial or change wording in the Mac tutorial to fit both Mac and Windows (this could be deferred to a separate PR)
* Make sure the "manually" generated hart will work with the bin tray publishing

Note we build, package and sign via powershell instead of `hab-plan-build.sh` since we don't have bash on Windows. shipping the VC based dependencies in the archive.