### PR TITLE
Updating code snippets to remove sudo inline with hab 0.11 release

### DIFF
--- a/www/source/tutorials/getting-started/linux/create-plan.html.md.erb
+++ b/www/source/tutorials/getting-started/linux/create-plan.html.md.erb
@@ -31,7 +31,7 @@ In this tutorial, because we are copying source files from within our repo into 
 
 2. Enter into the studio environment.
 
-       sudo hab studio enter
+       hab studio enter
 
    The package download and installation process should only take a few moments. If successful, you should see another bash prompt like this:
 

--- a/www/source/tutorials/getting-started/linux/process-build.html.md.erb
+++ b/www/source/tutorials/getting-started/linux/process-build.html.md.erb
@@ -19,7 +19,7 @@ Before we can run our service, we need to rebuild our package to include the cha
 1. If you are not in the studio environment, change over to your plan directory and enter the studio.
 
         cd ~/habitat-example-plans/mytutorialapp
-        sudo hab studio enter
+        hab studio enter
 
 2. Build your mytutorialapp package.
 
@@ -84,13 +84,17 @@ To natively run services on your Linux host machine, do the following:
 
    > Note: One of the reasons you can run a service from within the studio is that the `hab` user is created for you when you enter the studio environment.
 
-3. Run `sudo hab install path/to/results/packagefilename.hart`. This will install your package in the same location on the host machine as it does in the studio (i.e. `/hab/pkgs`). Make sure you are in the
+3. Copy the origin public key you created during `hab setup` to `/hab/cache/keys`. Unless your public key has been uploaded to the public depot, you will have to place it in the global key cache before you can install your package for local testing.
+
+       sudo cp ~/.hab/cache/keys/myorigin-20160712195536.pub /hab/cache/keys
+
+4. Run `sudo hab install path/to/results/packagefilename.hart`. This will install your package in the same location on the host machine as it does in the studio (i.e. `/hab/pkgs`). Make sure you are in the
 `results` directory of `mytutorialapp` and the install the package.
 
        cd ~/habitat-example-plans/mytutorialapp/results
        sudo hab install myorigin-mytutorialapp-0.2.0-20160902224802-x86_64-linux.hart
 
-4. Run `sudo hab start origin/packagename`.
+5. Run `sudo hab start origin/packagename`.
 
        sudo hab start myorigin/mytutorialapp
 
@@ -104,7 +108,7 @@ To show the portability of Habitat, you can also export and run a Habitat servic
 2. Re-enter the studio.
 
        $ cd ~/habitat-example-plans/mytutorialapp
-       $ sudo hab studio enter
+       $ hab studio enter
        [1][default:/src:0]#
 
 3. Create a Docker image containing your package by running `hab pkg export docker origin/packagename` with the origin and name of your package.

--- a/www/source/tutorials/getting-started/linux/process-build.html.md.erb
+++ b/www/source/tutorials/getting-started/linux/process-build.html.md.erb
@@ -84,9 +84,9 @@ To natively run services on your Linux host machine, do the following:
 
    > Note: One of the reasons you can run a service from within the studio is that the `hab` user is created for you when you enter the studio environment.
 
-3. Copy the origin public key you created during `hab setup` to `/hab/cache/keys`. Unless your public key has been uploaded to the public depot, you will have to place it in the global key cache before you can install your package for local testing.
+3. Export the origin public key you created during `hab setup` and pipe the output into the `hab origin key import` subcommand. This will place the public key in the global keys cache on your machine. Before a package can be installed, the public key for that package must either be downloaded from a depot or placed in the correct cache location manually. The public key is then used to verify the integrity of the package.
 
-       sudo cp ~/.hab/cache/keys/myorigin-20160712195536.pub /hab/cache/keys
+       hab origin key export myorigin --type public | sudo hab origin key import 
 
 4. Run `sudo hab install path/to/results/packagefilename.hart`. This will install your package in the same location on the host machine as it does in the studio (i.e. `/hab/pkgs`). Make sure you are in the
 `results` directory of `mytutorialapp` and the install the package.

--- a/www/source/tutorials/getting-started/linux/setup-environment.html.md.erb
+++ b/www/source/tutorials/getting-started/linux/setup-environment.html.md.erb
@@ -13,7 +13,7 @@ title: Getting set up with Habitat | Linux
 # Set up your environment
 The `hab` command-line interface (CLI) tool downloads its other components when it needs them, so setup for Habitat is centered on where you want the `hab` CLI installed and getting it integrated into your shell.
 
-1. Open a terminal window and copy `hab` to your `/bin` directory. This is because running the `hab` CLI natively on Linux requires you to run as root.
+1. Open a terminal window and copy `hab` to your `/bin` directory. This is because running the `hab` CLI natively on Linux requires you to run as root or with sudo privileges.
 
        sudo cp where/you/extracted/hab /bin
 


### PR DESCRIPTION
- Removed a few `sudo` commands that are no longer needed.
- Also added a step to copy user origin keys into global key cache in order to run `hab install` with a locally-built package.

Signed-off-by: David Wrede <dwrede@chef.io>