### PR TITLE
[core] Validate cache path when running hab studio

### DIFF
--- a/components/core/src/fs.rs
+++ b/components/core/src/fs.rs
@@ -44,6 +44,17 @@ const SVC_PATH: &'static str = "hab/svc";
 lazy_static! {
     static ref EUID: u32 = users::get_effective_uid();
 
+    static ref MY_CACHE_PATH: PathBuf = {
+        if *EUID == 0u32 {
+            PathBuf::from(ROOT_PATH)
+        } else {
+            match env::home_dir() {
+                Some(home) => home.join(format!(".{}", ROOT_PATH)),
+                None => PathBuf::from(ROOT_PATH),
+            }
+        }
+    };
+
     static ref MY_CACHE_ANALYTICS_PATH: PathBuf = {
         if *EUID == 0u32 {
             PathBuf::from(CACHE_ANALYTICS_PATH)
@@ -98,6 +109,14 @@ lazy_static! {
             }
         }
     };
+}
+
+/// Returns the root path to the cache, optionally taking a custom filesystem root.
+pub fn cache_path(fs_root_path: Option<&Path>) -> PathBuf {
+    match fs_root_path {
+        Some(fs_root_path) => Path::new(fs_root_path).join(&*MY_CACHE_PATH),
+        None => Path::new(FS_ROOT_PATH).join(&*MY_CACHE_PATH),
+    }
 }
 
 /// Returns the path to the analytics cache, optionally taking a custom filesystem root.

--- a/components/hab/src/command/studio.rs
+++ b/components/hab/src/command/studio.rs
@@ -71,7 +71,7 @@ mod inner {
     use common::ui::UI;
     use hcore::crypto::{init, default_cache_key_path};
     use hcore::env as henv;
-    use hcore::fs::{am_i_root, find_command};
+    use hcore::fs::{am_i_root, find_command, cache_path};
     use hcore::os::process;
     use hcore::package::PackageIdent;
 
@@ -109,6 +109,15 @@ mod inner {
         // If I have root permissions, early return, we are done.
         if am_i_root() {
             return Ok(());
+        }
+
+        // Make sure we have run 'hab setup' already (i.e, .hab folder exists)
+        let cache_dir = cache_path(None);
+        if !cache_dir.exists() {
+            try!(ui.warn(format!("Could not find cache path: `{}'.", cache_dir.display())));
+            try!(ui.warn("Please retry this command after running 'hab setup'"));
+            try!(ui.br());
+            return Err(Error::FileNotFound(cache_dir.to_string_lossy().into_owned()));
         }
 
         // Otherwise we will try to re-run this program using `sudo`


### PR DESCRIPTION
Signed-off-by: Salim Alam <salam@chef.io>

This change adds a check to make sure we catch a case that was missed when automatically elevating a user running hab studio. Specifically, we want to make sure that the user's .hab directory is present (ie, hab setup has been done) before we automatically elevate. If we auto-elevate without the .hab directory present, it can get created with root owner which is not what we want.