### PR TITLE
remove pkg-config hack from worker plan

### DIFF
--- a/components/builder-worker/habitat/plan.sh
+++ b/components/builder-worker/habitat/plan.sh
@@ -39,11 +39,6 @@ do_prepare() {
   # Used by libssh2-sys
   export DEP_Z_ROOT="$(pkg_path_for zlib)"
   export DEP_Z_INCLUDE="$(pkg_path_for zlib)/include"
-
-  # Temporarily set PKG_CONFIG_PATH - this can be removed after all core packages are rebuilt with
-  # hab-plan-build 0.11.x and pushed to the public depot.
-  export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$(pkg_path_for zlib)/lib/pkgconfig"
-  export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$(pkg_path_for openssl)/lib/pkgconfig"
 }
 
 do_build() {


### PR DESCRIPTION
This hack can be closed out now that we've released Hab 0.11.0 and merged & uploaded https://github.com/habitat-sh/core-plans/pull/185. No more need to mess with PKG_CONFIG_PATH in your plans, yay!

![gif-keyboard-8291932148252134074](https://cloud.githubusercontent.com/assets/54036/19406234/36dbb2d4-9237-11e6-9073-0ee7ad431547.gif)
