### PR TITLE
Move a manual build step to Makefile from README for www project

### DIFF
--- a/www/Makefile
+++ b/www/Makefile
@@ -1,4 +1,5 @@
 build: clean
+	bundle install
 	bundle exec middleman build
 .PHONY: build
 

--- a/www/README.md
+++ b/www/README.md
@@ -31,12 +31,6 @@ Static site content for www.habitat.sh
    $ cd www
    ```
 
-1. Ensure you have all the required gems installed, if this is your first time completing this process.
-
-   ```
-   $ bundle install
-   ```
-
 1. Run the deploy make task
 
     ```


### PR DESCRIPTION
Minor change here from the addition in #1359 - we'll run bundle install for you in the Makefile instead of asking you to do it yourself. Bundle install is idempotent in nature so this is an easy fix.