### PR TITLE
improve docs documentation and add run task to Makefile

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,28 +89,7 @@ The Habitat Builder web application is in the components/builder-web directory. 
 
 ## Documentation
 
-Habitat's website and documentation is generated using [Middleman](https://middlemanapp.com/) and is located in the `www` directory of the Habitat source code. To work on the documentation, you will need to have a working [Ruby](https://ruby-lang.org) installation and Bundler. We recommend Ruby 2.3.1 or greater.
-
-To install Middleman, follow these instructions:
-
-1. Change to the `www` directory and type:
-
-       `bundle install --path=vendor`
-
-2. To build the documentation, either before or after you make your change, change to the `www` directory and type:
-
-       `bundle exec middleman build`
-
-3. The documentation is built into the `source` directory. You can instruct Middleman to serve the site by typing:
-
-       `bundle exec middleman serve`
-
-4. Middleman will start a small webserver on your computer and indicate what URL you should load in your browser to preview it.
-
-       `== View your site at "http://mylaptop.example.com:4567", "http://192.168.1.101:4567"`
-
-5. You can continue to make changes to the documentation files and Middleman will reload them live.
-6. Press `Ctrl-C` to terminate the webserver when you are finished working with Middleman.
+Habitat's website and documentation is located in the `www` directory of the Habitat source code. See [it's README](www/README.md) for more information.
 
 ### Documentation for Rust Crates
 

--- a/www/Makefile
+++ b/www/Makefile
@@ -6,6 +6,9 @@ build: clean
 clean:
 	rm -Rdf build
 
+run: build
+	bundle exec middleman serve
+
 sync: export AWS_BUCKET=habitat-www
 sync: export AWS_DEFAULT_REGION=us-west-2
 sync: build check-env

--- a/www/README.md
+++ b/www/README.md
@@ -2,15 +2,31 @@
 
 Static site content for www.habitat.sh
 
-## How-To: Deploy
+## Setup
 
-1. Install Ruby 2.x
+1. Install Ruby 2.3.1 or greater
 1. Install Bundler
 
     ```
     $ gem install bundler
     ```
 
+## How-To: Serve Docs Locally
+
+1. Execute the `run` task to build and start the docs server on your local machine
+
+    `make run`
+
+1. The task will contain server output indicating what URL you should load in your browser to preview it
+
+    `== View your site at "http://mylaptop.example.com:4567", "http://192.168.1.101:4567"`
+
+1. You can continue to make changes to the documentation files and Middleman will reload them live
+1. Press `Ctrl-C` to terminate the server when you are finished
+
+## How-To: Deploy
+
+1. [Setup your workstation](#setup)
 1. Configure your environment
 
   * AWS_ACCESS_KEY_ID - your personal AWS account identifier


### PR DESCRIPTION
Minor changes to the main README to reference the `www` README directly and also the inclusion of a `make run` task to serve docs locally. The goal here, and with a lot of our other make tasks, is to abstract away the implementation under the hood.