### PR TITLE
Appveyor building `hab` and testing ported crates

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,7 @@ image: Visual Studio 2015
 
 cache:
     - c:\Program Files (x86)\Rust
+    - c:\Users\appveyor\.cargo
 
 branches:
   only:
@@ -15,6 +16,11 @@ skip_tags: true
 
 clone_folder: c:\projects\habitat
 
+environment:
+  matrix:
+    - hab_build_action: "test;build"
+      hab_components: "core;http-client;builder-protocol;builder-depot-client;common;hab"
+
 install:
   - ps: ./components/hab/win/win-build.ps1
   - rustc -V
@@ -23,5 +29,4 @@ install:
 build: false
 
 test_script:
-  - cd c:\projects\habitat\components\hab
-  - cargo build --verbose
+  - c:\projects\habitat\support\ci\appveyor.bat

--- a/support/ci/appveyor.bat
+++ b/support/ci/appveyor.bat
@@ -1,0 +1,1 @@
+powershell -nologo -noprofile -executionpolicy bypass -file c:\projects\habitat\support\ci\appveyor.ps1 

--- a/support/ci/appveyor.ps1
+++ b/support/ci/appveyor.ps1
@@ -1,0 +1,30 @@
+pushd c:\projects\habitat
+
+$RunTests = (git diff master --name-only | 
+                where-object {$_ -like 'components/*'} | 
+                foreach-object { $_ -replace 'components/(\w+-*\w*)/.*$', '$1'} | 
+                sort-object -unique | 
+                where-object {($env:HAB_COMPONENTS -split ';') -contains $_}
+            ).count -ge 1
+
+foreach ($BuildAction in ($env:hab_build_action -split ';')) {
+    if (($RunTests -or (test-path env:HAB_FORCE_BUILD)) -and ($BuildAction -like 'build')) {
+        pushd "c:/projects/habitat/components/hab"
+        cargo build
+        if ($LASTEXITCODE -ne 0) {exit $LASTEXITCODE}    
+        popd
+        ./target/debug/hab.exe --version
+        if ($LASTEXITCODE -ne 0) {exit $LASTEXITCODE}            
+    }
+    elseif (($RunTests -or (test-path env:HAB_FORCE_TEST)) -and ($BuildAction -like 'test')) {
+        foreach ($component in ($env:hab_components -split ';')) {
+            pushd "c:/projects/habitat/components/$component"
+            cargo test
+            if ($LASTEXITCODE -ne 0) {exit $LASTEXITCODE}
+            popd
+        }
+    }
+    else {
+        Write-Host "Nothing changed in ported crates. Skipping $BuildAction."
+    }
+}


### PR DESCRIPTION
I moved the execution of the build and test cycles into a powershell script (`./support/ci/appveyor.ps1`) which is called by (`./support/ci/appveyor.bat`).  

We use a batch file to start things off because AppVeyor's PowerShell host treats stderr from native executables (like `cargo`) as errors on the error stream and adds all sorts of ugly output.

Calling PowerShell.exe from a batch file, while an odd hack, works to keep the output looking good but have the better scripting experience of PowerShell.

Now, the build will check if any files have changed in the ported crates and, if so, it'll run cargo test against all ported crates and then build `hab.exe` and run `hab --version` to validate `hab.exe` can run successfully.

Builds can be forced by setting a value to $env:HAB_FORCE_BUILD and tests can be forced with $env:HAB_FORCE_TEST

Signed-off-by: Steven Murawski <steven.murawski@gmail.com>