### PR TITLE
[common] use root cache key path for package install

### DIFF
--- a/components/common/src/command/package/install.rs
+++ b/components/common/src/command/package/install.rs
@@ -41,7 +41,7 @@ use std::str::FromStr;
 
 use depot_client::Client;
 use hcore;
-use hcore::fs::am_i_root;
+use hcore::fs::{am_i_root, cache_key_path};
 use hcore::crypto::{artifact, SigKeyPair};
 use hcore::crypto::keys::parse_name_with_rev;
 use hcore::package::{Identifiable, PackageArchive, PackageIdent, PackageInstall};
@@ -49,18 +49,16 @@ use hcore::package::{Identifiable, PackageArchive, PackageIdent, PackageInstall}
 use error::{Error, Result};
 use ui::{Status, UI};
 
-pub fn start<P1: ?Sized, P2: ?Sized, P3: ?Sized>(ui: &mut UI,
+pub fn start<P1: ?Sized, P2: ?Sized>(ui: &mut UI,
                                                  url: &str,
                                                  ident_or_archive: &str,
                                                  product: &str,
                                                  version: &str,
                                                  fs_root_path: &P1,
-                                                 cache_artifact_path: &P2,
-                                                 cache_key_path: &P3)
+                                                 cache_artifact_path: &P2)
                                                  -> Result<PackageIdent>
     where P1: AsRef<Path>,
-          P2: AsRef<Path>,
-          P3: AsRef<Path>
+          P2: AsRef<Path>
 {
     if !am_i_root() {
         try!(ui.warn("Installing a package requires root or administrator privileges. Please retry \
@@ -70,12 +68,15 @@ pub fn start<P1: ?Sized, P2: ?Sized, P3: ?Sized>(ui: &mut UI,
         return Err(Error::RootRequired);
     }
 
+    let cache_key_path = cache_key_path(Some(fs_root_path.as_ref()));
+    debug!("install cache_key_path: {}", cache_key_path.display());
+
     let task = try!(InstallTask::new(url,
                                      product,
                                      version,
                                      fs_root_path.as_ref(),
                                      cache_artifact_path.as_ref(),
-                                     cache_key_path.as_ref()));
+                                     &cache_key_path));
 
     if Path::new(ident_or_archive).is_file() {
         task.from_artifact(ui, &Path::new(ident_or_archive))

--- a/components/hab/src/command/pkg.rs
+++ b/components/hab/src/command/pkg.rs
@@ -172,7 +172,6 @@ pub mod export {
 
         use common::command::package::install;
         use common::ui::{Status, UI};
-        use hcore::crypto::default_cache_key_path;
         use hcore::fs::{cache_artifact_path, FS_ROOT_PATH};
         use hcore::package::{PackageIdent, PackageInstall};
         use hcore::url::default_depot_url;
@@ -228,8 +227,7 @@ pub mod export {
                                         PRODUCT,
                                         VERSION,
                                         Path::new(FS_ROOT_PATH),
-                                        &cache_artifact_path(None),
-                                        &default_cache_key_path(None)));
+                                        &cache_artifact_path(None)));
                 }
             }
             let pkg_arg = OsString::from(&ident.to_string());

--- a/components/hab/src/exec.rs
+++ b/components/hab/src/exec.rs
@@ -65,8 +65,7 @@ pub fn command_from_pkg(ui: &mut UI,
                                                           PRODUCT,
                                                           VERSION,
                                                           fs_root_path,
-                                                          &cache_artifact_path(None),
-                                                          cache_key_path));
+                                                          &cache_artifact_path(None)));
             command_from_pkg(ui, &command, &ident, &cache_key_path, retry + 1)
         }
         Err(e) => return Err(Error::from(e)),

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -419,8 +419,7 @@ fn sub_pkg_install(ui: &mut UI, m: &ArgMatches) -> Result<()> {
                                                       PRODUCT,
                                                       VERSION,
                                                       Path::new(&fs_root),
-                                                      &cache_artifact_path(fs_root_path),
-                                                      &default_cache_key_path(fs_root_path)));
+                                                      &cache_artifact_path(fs_root_path)));
     }
     Ok(())
 }

--- a/components/sup/src/command/start.rs
+++ b/components/sup/src/command/start.rs
@@ -63,7 +63,6 @@ use ansi_term::Colour::Yellow;
 use common::command::package::install;
 use common::ui::UI;
 use depot_client::Client;
-use hcore::crypto::default_cache_key_path;
 use hcore::fs::{am_i_root, cache_artifact_path, FS_ROOT_PATH};
 use hcore::package::PackageIdent;
 
@@ -121,8 +120,7 @@ pub fn package() -> Result<()> {
                                                                PRODUCT,
                                                                VERSION,
                                                                Path::new(FS_ROOT_PATH),
-                                                               &cache_artifact_path(None),
-                                                               &default_cache_key_path(None)));
+                                                               &cache_artifact_path(None)));
                         package = try!(Package::load(&new_pkg_data, None));
                     } else {
                         outputln!("Already running latest.");
@@ -143,8 +141,7 @@ pub fn package() -> Result<()> {
                                         PRODUCT,
                                         VERSION,
                                         Path::new(FS_ROOT_PATH),
-                                        &cache_artifact_path(None),
-                                        &default_cache_key_path(None)))
+                                        &cache_artifact_path(None)))
                 }
                 None => {
                     outputln!("Searching for {} in remote {}",
@@ -156,8 +153,7 @@ pub fn package() -> Result<()> {
                                         PRODUCT,
                                         VERSION,
                                         Path::new(FS_ROOT_PATH),
-                                        &cache_artifact_path(None),
-                                        &default_cache_key_path(None)))
+                                        &cache_artifact_path(None)))
                 }
             };
             let package = try!(Package::load(&new_pkg_data, None));


### PR DESCRIPTION
Signed-off-by: Salim Alam <salam@chef.io>

With this change, package install always uses the root hab cache as the location for the key cache. This alleviates an issue/edge case where entering hab studio with an automatic sudo ends up with the core key downloaded into the SUDO_USER's local hab cache instead of the global cache.