### PR TITLE
Improve user output - show Docker pull progress on studio enter

### DIFF
--- a/components/hab/src/command/studio.rs
+++ b/components/hab/src/command/studio.rs
@@ -163,8 +163,8 @@ mod inner {
         let child = Command::new(&cmd)
             .arg("pull")
             .arg(&image_identifier())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
+            .stdout(Stdio::inherit())
+            .stderr(Stdio::inherit())
             .spawn()
             .expect("docker failed to start");
 


### PR DESCRIPTION
Signed-off-by: Salim Alam <salam@chef.io>

This change makes the standard output/error of the studio Docker pull command visible to the user.