### PR TITLE
Change how we check origin membership to make the Members tab show up

### DIFF
--- a/components/builder-web/app/origin-page/OriginPageComponent.ts
+++ b/components/builder-web/app/origin-page/OriginPageComponent.ts
@@ -16,9 +16,9 @@ import {Component, OnInit, OnDestroy} from "@angular/core";
 import {RouterLink, ActivatedRoute} from "@angular/router";
 import {AppStore} from "../AppStore";
 import {fetchOrigin, fetchOriginInvitations, fetchOriginMembers,
-    fetchOriginPublicKeys, inviteUserToOrigin, setCurrentOriginAddingPublicKey,
-    setCurrentOriginAddingPrivateKey, uploadOriginPrivateKey,
-    uploadOriginPublicKey, filterPackagesBy, fetchProjectsForPackages,
+        fetchOriginPublicKeys, inviteUserToOrigin, setCurrentOriginAddingPublicKey,
+        setCurrentOriginAddingPrivateKey, uploadOriginPrivateKey,
+        uploadOriginPublicKey, filterPackagesBy, fetchMyOrigins,
         setProjectHint, requestRoute, setCurrentProject} from "../actions/index";
 import config from "../config";
 import {KeyAddFormComponent} from "./KeyAddFormComponent";
@@ -319,8 +319,14 @@ export class OriginPageComponent implements OnInit, OnDestroy {
         return (!this.packagesUi.exists || this.packages.size === 0) && !this.packagesUi.loading;
     }
 
+    get myOrigins() {
+        return this.store.getState().origins.mine;
+    }
+
     get iAmPartOfThisOrigin() {
-        return this.members.size > 0;
+        return !!this.myOrigins.find(org => {
+            return org["name"] === this.origin.name;
+        });
     }
 
     private linkToRepo(p): boolean {
@@ -381,6 +387,7 @@ export class OriginPageComponent implements OnInit, OnDestroy {
     public ngOnInit() {
         requireSignIn(this);
         this.store.dispatch(fetchOrigin(this.origin.name));
+        this.store.dispatch(fetchMyOrigins());
         this.store.dispatch(fetchOriginPublicKeys(
             this.origin.name, this.gitHubAuthToken
         ));


### PR DESCRIPTION
![gif-keyboard-12113208429394061114](https://cloud.githubusercontent.com/assets/947/19570201/ccb14a06-96ad-11e6-89d8-a19561e28fc1.gif)

Hopefully this fixes the bug where the Members tab erroneously showed up for @juliandunn when he wasn't actually a member of core.

Signed-off-by: Josh Black <raskchanky@gmail.com>