### PR TITLE
[core] Fix hyper test compilation churn.

### DIFF
--- a/components/core/Cargo.toml
+++ b/components/core/Cargo.toml
@@ -26,11 +26,8 @@ url = "*"
 users = "*"
 
 [dev-dependencies]
+hyper = "*"
 tempdir = "*"
-
-[dev-dependencies.hyper]
-version = "*"
-default-features = false
 
 [features]
 functional = []


### PR DESCRIPTION
This fixes an issue that we see in our CI system and occasionally in
development. It turns out that the core component built the hyper crate
differently in test mode (as a dev-dependencies entry) than the rest of
the components in either test or normal mode.

Building the sequence of "LIB" crates (as provided in our Makefile)
leads eventually to a build of hyper that is different than the version
of hyper which was built alongside the iron crate (used in the depot and
vanilla http client crates). This behavior goes back almost to June, but
I posit that in combination with our Travis caching and the
short-circuiting logic present in `./support/ci/fast_pass.sh` has masked
this issue for months.

![gif-keyboard-11842040260886519815](https://cloud.githubusercontent.com/assets/261548/19606107/40c4a814-977d-11e6-9f6a-597aa24f432f.gif)
