### PR TITLE
Set logfile name based on pkg_name

### DIFF
--- a/components/studio/bin/hab-studio.sh
+++ b/components/studio/bin/hab-studio.sh
@@ -607,7 +607,11 @@ record() {
       >&2 echo "Usage: record <SESSION> [CMD [ARG ..]]"
       return 1
     fi
-    name=$1; shift
+    name="$(awk -F '=' '/^pkg_name/ {print $2}' $1/plan.sh 2>/dev/null | sed "s/['\"]//g")"
+    if [[ -z "${name:-}" ]]; then
+      name="unknown"
+    fi
+    shift
     cmd="${1:-${SHELL:-sh} -l}"; shift
     bb=${BUSYBOX:-}
     env="$($bb env \


### PR DESCRIPTION
This addresses #888 

I made the assumption that `record()` will always be used in the context of building a package, and can expect `plan.sh` to be present. This looks to be the case now, but if I missed something or there are other uses planned, this change is not good. 

This works by attempting to read the `pkg_name=string` line from the `plan.sh`, and then removes any surrounding quotes.  I wasn't sure how aggressive to be in cleaning it up, but decided `['\"]` would be the minimum needed since `foo="bar"` is pretty common in shell scripts.  If it's unable to set `$name`, it defaults to `unknown`. This is to catch cases where `plan.sh` isn't present, or the plan doesn't have `pkg_name` set and prevents log files like `.TIMESTAMP.log`.  

I tested this by entering the dev shell with `make shell`, and built the studio with my modifications.  I then installed the studio with `hab pkg install results/core-hab-studio-0.11.0-20161021024449-x86_64-linux.hart`.  I then used the studio to build empty test packages. 

Given:
`demo/a/plan.sh`
`demo/b/plan.sh`

with contents (elided for brevity)
`pkg_name=a`
`pkg_name="b"`

Running the following commands:

```
hab pkg build demo/a
hab pkg build demo/b
cd demo; hab pkg build a
cd a; hab pkg build .
cd ../..; hab pkg build demo
```

results in the following logfiles:

```
/src/results/logs/a.2016-10-21-024746.log
/src/results/logs/b.2016-10-21-025135.log
/src/results/logs/a.2016-10-21-025307.log
/src/results/logs/a.2016-10-21-025443.log
/src/results/logs/unknown.2016-10-21-025639.log
```

Signed-off-by: Scott Macfarlane macfarlane.scott@gmail.com
