### PR TITLE
Reload the origin after private key upload so it shows up right away

### DIFF
--- a/components/builder-web/app/actions/origins.ts
+++ b/components/builder-web/app/actions/origins.ts
@@ -271,6 +271,7 @@ export function uploadOriginPrivateKey(key: string , token: string) {
         new BuilderApiClient(token).createOriginKey(key).then(() => {
             dispatch(setOriginPrivateKeyUploadErrorMessage(undefined));
             dispatch(setCurrentOriginAddingPrivateKey(false));
+            dispatch(fetchOrigin(parseKey(key).origin));  // we need this to make the keys appear after upload
             dispatch(addNotification({
                 title: "Origin Private Key Uploaded",
                 body: `'${parseKey(key).name}' has been uploaded`,


### PR DESCRIPTION
This makes the private key name show up in the UI right after an upload.  Without this, you have to reload the page to see it, or navigate away and back.

Signed-off-by: Josh Black <raskchanky@gmail.com>

![](https://dl.dropboxusercontent.com/u/15426/4tAZIwP.gif)