### PR TITLE
Make `fix_interpreter` resolve symbolic links

### DIFF
--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -1322,6 +1322,11 @@ fix_interpreter() {
         continue
       fi
 
+      # Resolve symbolic links to fix the actual file instead of replacing it
+      if [[ -L $t ]]; then
+        t="$(readlink --canonicalize --no-newline "$t")"
+      fi
+
       build_line "Replacing '${interpreter_old}' with '${interpreter_new}' in '${t}'"
       sed -e "s#\#\!${interpreter_old}#\#\!${interpreter_new}#" -i $t
     done


### PR DESCRIPTION
Currently if fix_interpreter runs into a symlink, it will fix the
interpreter, then replace the symlink with an actual copy of the fixed
file. This can lead to bad things if that's not what you wanted it to
do.

This will make it so if `fix_interpreter` encounters a symlink, it will
fix the file pointed to by the symlink instead of the symlink itself.

![gif-keyboard-6994451035191943505](https://cloud.githubusercontent.com/assets/9912/19612460/4ba433f6-97ac-11e6-840f-326b111c5fc1.gif)
