### PR TITLE
[builder] deprecate Content-Range header usage

### DIFF
--- a/components/builder-web/app/origin-page/OriginPageComponent.ts
+++ b/components/builder-web/app/origin-page/OriginPageComponent.ts
@@ -107,6 +107,15 @@ export enum KeyType {
                         </a>
                       </div>
                     </div>
+
+                    <div *ngIf="packages.size < totalCount">
+                        Showing {{packages.size}} of {{totalCount}} packages.
+                        <a href="#" (click)="fetchMorePackages()">
+                            Load
+                            {{(totalCount - packages.size) > perPage ? perPage : totalCount - packages.size }}
+                            more</a>.
+                    </div>
+
                   </div>
                 </div>
                 <div class="hab-origin--right hab-origin--pkg-list">
@@ -315,6 +324,10 @@ export class OriginPageComponent implements OnInit, OnDestroy {
         return this.store.getState().packages.visible;
     }
 
+    get totalCount() {
+        return this.store.getState().packages.totalCount;
+    }
+
     get noPackages() {
         return (!this.packagesUi.exists || this.packages.size === 0) && !this.packagesUi.loading;
     }
@@ -382,6 +395,17 @@ export class OriginPageComponent implements OnInit, OnDestroy {
         this.store.dispatch(filterPackagesBy(
             {origin: this.origin.name}, "", 0, true, this.gitHubAuthToken
         ));
+    }
+
+    private fetchMorePackages() {
+        this.store.dispatch(filterPackagesBy(
+            {origin: this.origin.name},
+            "",
+            this.store.getState().packages.nextRange,
+            true,
+            this.gitHubAuthToken);
+
+        return false;
     }
 
     public ngOnInit() {

--- a/components/net/src/http/headers.rs
+++ b/components/net/src/http/headers.rs
@@ -14,8 +14,5 @@
 
 header! { (CacheControl, "Cache-Control") => [String] }
 header! { (ContentDisposition, "Content-Disposition") => [String] }
-header! { (ContentRange, "Content-Range") => [String] }
-header! { (NextRange, "Next-Range") => [isize] }
-header! { (XContentRange, "X-Content-Range") => [String] }
 header! { (XFileName, "X-Filename") => [String] }
 header! { (ETag, "ETag") => [String] }


### PR DESCRIPTION
Signed-off-by: Salim Alam salam@chef.io

This change fixes pagination for the Packages Search and Origins pages on the builder-web site. It deprecates the use of HTTP headers to send pagination info (in the Content-Range, X-Content-Range, and Next-Range headers). Instead, a query string parameter combined with JSON payload metadata is used to pass the pagination information between the web client and the depot server.  In addition, pagination code is added where it was previously missing on the Origins page. It also cleans up some of the logic relating to the Redis data store calls to make it more obvious where the APIs take start/stop range values vs. offset/count values.
