### PR TITLE
add a `hab pkg header` command to read the hart file header

### DIFF
--- a/components/core/src/crypto/artifact.rs
+++ b/components/core/src/crypto/artifact.rs
@@ -100,7 +100,9 @@ impl ArtifactHeader {
 /// Read only the header of the artifact, fails if any of the components
 /// are invalid/missing. Each component of the header has it's whitespace
 /// stripped before returning in an `ArtifactHeader` struct
-pub fn get_artifact_header<P: AsRef<Path>>(src: &P) -> Result<ArtifactHeader> {
+pub fn get_artifact_header<P: ?Sized>(src: &P) -> Result<ArtifactHeader>
+    where P: AsRef<Path>
+{
     let f = try!(File::open(src));
     let mut your_format_version = String::new();
     let mut your_key_name = String::new();

--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -209,6 +209,13 @@ pub fn get() -> App<'static, 'static> {
                     "A path to a Habitat Artifact \
                     (ex: /home/acme-redis-3.0.7-21120102031201-x86_64-linux.hart)")
             )
+            (@subcommand header =>
+                (about: "Returns the Habitat Artifact header")
+                (aliases: &["hea", "head", "heade", "header"])
+                (@arg SOURCE: +required {file_exists}
+                    "A path to a Habitat Artifact \
+                    (ex: /home/acme-redis-3.0.7-21120102031201-x86_64-linux.hart)")
+            )
         )
         (@subcommand ring =>
             (about: "Commands relating to Habitat rings")

--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -212,6 +212,7 @@ pub fn get() -> App<'static, 'static> {
             (@subcommand header =>
                 (about: "Returns the Habitat Artifact header")
                 (aliases: &["hea", "head", "heade", "header"])
+                (@setting Hidden)
                 (@arg SOURCE: +required {file_exists}
                     "A path to a Habitat Artifact \
                     (ex: /home/acme-redis-3.0.7-21120102031201-x86_64-linux.hart)")

--- a/components/hab/src/command/pkg.rs
+++ b/components/hab/src/command/pkg.rs
@@ -571,3 +571,33 @@ pub mod verify {
         Ok(())
     }
 }
+
+pub mod header {
+    use std::path::Path;
+
+    use common::ui::UI;
+    use hcore::crypto::artifact;
+    use std::io::{self, Write};
+
+    use error::Result;
+
+    pub fn start(ui: &mut UI, src: &Path) -> Result<()> {
+        try!(ui.begin(format!("Reading Artifact Header for {}", &src.display())));
+        try!(ui.para(""));
+        let artifact_header = artifact::get_artifact_header(src);
+        if artifact_header.is_ok() {
+            let header = artifact_header.unwrap();
+            try!(io::stdout()
+                .write(format!("Format Version : {}\n", header.format_version).as_bytes()));
+            try!(io::stdout().write(format!("Key Name       : {}\n", header.key_name).as_bytes()));
+            try!(io::stdout().write(format!("Hash Type      : {}\n", header.hash_type).as_bytes()));
+            try!(io::stdout()
+                .write(format!("Raw Signature  : {}\n", header.signature_raw).as_bytes()));
+        } else {
+            try!(ui.warn("Failed to Read Artifact Header."));
+        }
+        try!(ui.para(""));
+        try!(ui.end(format!("Finished Reading Artifact Header for {}.", &src.display())));
+        Ok(())
+    }
+}

--- a/components/hab/src/command/pkg.rs
+++ b/components/hab/src/command/pkg.rs
@@ -582,11 +582,12 @@ pub mod header {
     use error::Result;
 
     pub fn start(ui: &mut UI, src: &Path) -> Result<()> {
-        try!(ui.begin(format!("Reading Artifact Header for {}", &src.display())));
+        try!(ui.begin(format!("Reading package header for {}", &src.display())));
         try!(ui.para(""));
         let artifact_header = artifact::get_artifact_header(src);
         if artifact_header.is_ok() {
             let header = artifact_header.unwrap();
+            try!(io::stdout().write(format!("Package        : {}\n", &src.display()).as_bytes()));
             try!(io::stdout()
                 .write(format!("Format Version : {}\n", header.format_version).as_bytes()));
             try!(io::stdout().write(format!("Key Name       : {}\n", header.key_name).as_bytes()));
@@ -594,10 +595,8 @@ pub mod header {
             try!(io::stdout()
                 .write(format!("Raw Signature  : {}\n", header.signature_raw).as_bytes()));
         } else {
-            try!(ui.warn("Failed to Read Artifact Header."));
+            try!(ui.warn("Failed to read package header."));
         }
-        try!(ui.para(""));
-        try!(ui.end(format!("Finished Reading Artifact Header for {}.", &src.display())));
         Ok(())
     }
 }

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -129,6 +129,7 @@ fn start(ui: &mut UI) -> Result<()> {
                 ("sign", Some(m)) => try!(sub_pkg_sign(ui, m)),
                 ("upload", Some(m)) => try!(sub_pkg_upload(ui, m)),
                 ("verify", Some(m)) => try!(sub_pkg_verify(ui, m)),
+                ("header", Some(m)) => try!(sub_pkg_header(ui, m)),
                 _ => unreachable!(),
             }
         }
@@ -487,6 +488,13 @@ fn sub_pkg_verify(ui: &mut UI, m: &ArgMatches) -> Result<()> {
     init();
 
     command::pkg::verify::start(ui, &src, &default_cache_key_path(fs_root_path))
+}
+
+fn sub_pkg_header(ui: &mut UI, m: &ArgMatches) -> Result<()> {
+    let src = Path::new(m.value_of("SOURCE").unwrap());
+    init();
+
+    command::pkg::header::start(ui, &src)
 }
 
 fn sub_ring_key_export(m: &ArgMatches) -> Result<()> {


### PR DESCRIPTION
I had a few minutes this morning and thought this might be a handy subcommand.

/cc @juliandunn 

Signed-off-by: Steven Murawski <steven.murawski@gmail.com>