### PR TITLE
Implement ability to exclude config files through the HAB_CONFIG_EXCLUDE variable

### DIFF
--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -1997,7 +1997,24 @@ do_build_config() {
 do_default_build_config() {
   build_line "Writing configuration"
   if [[ -d "$PLAN_CONTEXT/config" ]]; then
-    cp -r "$PLAN_CONTEXT/config" $pkg_prefix
+    if [ -z "${HAB_CONFIG_EXCLUDE:-}" ]; then
+      # HAB_CONFIG_EXCLUDE not set, use defaults
+      config_exclude_exts=("*.sw?" "*~" "*.bak")
+    else
+      IFS=',' read -a config_exclude_exts <<< "$HAB_CONFIG_EXCLUDE"
+    fi
+    find_exclusions=""
+    for ext in "${config_exclude_exts[@]}"; do
+      find_exclusions+=" ! -name '$ext'"
+    done
+    find "$PLAN_CONTEXT/config" $find_exclusions | while read FILE
+    do
+      if [[ -d "$FILE" ]]; then
+        mkdir "$pkg_prefix${FILE#$PLAN_CONTEXT}"
+      else
+        cp "$FILE" "$pkg_prefix${FILE#$PLAN_CONTEXT}"
+      fi
+    done
     chmod 755 $pkg_prefix/config
   fi
   if [[ -d "$PLAN_CONTEXT/hooks" ]]; then

--- a/components/studio/bin/hab-studio.sh
+++ b/components/studio/bin/hab-studio.sh
@@ -887,6 +887,11 @@ chroot_env() {
   if [ -n "${HAB_ORIGIN:-}" ]; then
     env="$env HAB_ORIGIN=$HAB_ORIGIN"
   fi
+  # If a Habitat config filetype ignore string is set, then propogate it
+  # into the Studio's environment.
+  if [ -n "${HAB_CONFIG_EXCLUDE:-}" ]; then
+    env="$env HAB_CONFIG_EXCLUDE=$HAB_CONFIG_EXCLUDE"
+  fi
   # If HTTP proxy variables are detected in the current environment, propagate
   # them into the Studio's environment.
   if [ -n "${http_proxy:-}" ]; then
@@ -916,6 +921,9 @@ report_env_vars() {
   fi
   if [ -n "${HAB_DEPOT_URL:-}" ]; then
     info "Exported: HAB_DEPOT_URL=$HAB_DEPOT_URL"
+  fi
+  if [ -n "${HAB_CONFIG_EXCLUDE:-}" ]; then
+    info "Exported: HAB_CONFIG_EXCLUDE=$HAB_CONFIG_EXCLUDE"
   fi
   if [ -n "${http_proxy:-}" ]; then
     info "Exported: http_proxy=$http_proxy"


### PR DESCRIPTION
This implements the `HAB_CONFIG_EXCLUDE` variable, as discussed in #1120, which goes by the format of "<pattern>,<pattern>,<pattern>,...", and provides a few reasonable defaults.
