### PR TITLE
Allow sourcing of /src/.studiorc to set hab env vars

### DIFF
--- a/components/studio/libexec/hab-studio-type-default.sh
+++ b/components/studio/libexec/hab-studio-type-default.sh
@@ -91,6 +91,11 @@ alias fgrep='fgrep --color=auto'
 # Set TERMINFO so hab can give us a delightful experience.
 export TERMINFO=$(_pkgpath_for core/ncurses)/share/terminfo
 
+# Source /src/.studiorc so we can set some user environment vars quicker.
+if [ -f /src/.studiorc ];then
+  source /src/.studiorc
+fi
+
 PROFILE
 
   echo "${run_user}:x:42:42:root:/:/bin/sh" >> $HAB_STUDIO_ROOT/etc/passwd

--- a/www/source/docs/reference/environment-vars.html.md
+++ b/www/source/docs/reference/environment-vars.html.md
@@ -20,3 +20,12 @@ This is a list of all environment variables that can be used to modify the opera
 | `HAB_STUDIO_ROOT` | build system | no default | Root of the current studio under `$HAB_STUDIOS_HOME`. Infrequently overridden. |
 | `HAB_USER` | supervisor | no default | User key to use when running with [service group encryption](/docs/run-packages-security/#service-group-encryption) |
 
+# Customizing Studio
+
+When you enter a studio, Habitat will attempt to locate `/src/.studiorc` and
+source it.  Think `~/.bashrc`. This file can be used to export any
+environment variables like the ones you see above as well as any other shell
+customizations to help you develop your plans from within the studio.
+
+To use this feature, place a `.studiorc` in the current working directory
+where you will run `hab studio enter`.


### PR DESCRIPTION
- modified profile to source `/src/.studiorc`
- added documentation on how to customize your studio

-----

This enables the following use cases:
- Set hab env vars that are only available inside studio. (ie. `HAB_AUTH_TOKEN` and `HAB_DEPOT_URL`)
- Be able to personalize the studio for own dev workflow

Signed-off-by: Ben Dang <me@bdang.it>