### PR TITLE
Now that swim is butterfly, fix the Makefile to reflect that

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ else
 endif
 
 BIN = director hab sup
-LIB = builder-dbcache builder-protocol common core builder-depot-client http-client net swim
+LIB = builder-dbcache builder-protocol common core builder-depot-client http-client net butterfly
 SRV = builder-api builder-admin builder-depot builder-router builder-jobsrv builder-sessionsrv builder-vault builder-worker
 ALL = $(BIN) $(LIB) $(SRV)
 VERSION := $(shell cat VERSION)


### PR DESCRIPTION
This fixes the broken test in #1388 

The Makefile currently lists "swim" instead of "butterfly" which makes the tests fail when the Makefile tries to cd into "components/swim".

Signed-off-by: Steven Murawski <steven.murawski@gmail.com>