### PR TITLE
Fix errant formatting in config update docs

### DIFF
--- a/www/source/docs/run-packages-apply-config-updates.html.md
+++ b/www/source/docs/run-packages-apply-config-updates.html.md
@@ -57,7 +57,7 @@ Here are some examples of how to apply configuration changes through both the sh
        Configuration applied to: 172.17.0.3:9634
        ★ Applied configuration.
 
-    The services in the myapp.prod service group will restart according to the service group's [update strategy](/docs/run-packages-update-strategy).
+  The services in the myapp.prod service group will restart according to the service group's [update strategy](/docs/run-packages-update-strategy).
 
       Writing new file from gossip: /hab/svc/myapp/gossip.toml
       hab-sup(SC): Updated config.json


### PR DESCRIPTION
Correct this bit of broken formatting:

![fix-pre](https://cloud.githubusercontent.com/assets/43662/19712539/a12a4f00-9af3-11e6-9a64-055abc0a9871.png)
