### PR TITLE
Hide habitat summit banner

### DIFF
--- a/www/source/layouts/_nav.slim
+++ b/www/source/layouts/_nav.slim
@@ -1,10 +1,12 @@
 #main-nav class="#{layout_class}"
 
-  / Uncomment to enable the global message
-  / IMPORTANT NOTE: When the global message is enabled, add an additional 90px of
-  / top padding to #content-outer (for the small breakpoint) in layout.scss or
-  / the hero title gets covered by the navigation on mobile devices
-  = partial "layouts/message"
+  / GLOBAL MESSAGE BANNER
+  / Uncomment the layouts/message partial to display the global message
+  / IMPORTANT NOTE: When the global message is displayed, add an additional 90px
+  / of top padding to #content-outer (for the small breakpoint) in layout.scss
+  / or the hero title gets covered by the navigation on mobile devices
+
+  / = partial "layouts/message"
 
   .main-nav--container.clearfix
     .main-nav--logo

--- a/www/source/stylesheets/_layout.scss
+++ b/www/source/stylesheets/_layout.scss
@@ -11,7 +11,10 @@ body.try-hab {
 
 #content-outer {
   @include small-nav {
-    padding-top: $header-height-mobile + 90;
+    // Use this padding when the global message is not being displayed
+    padding-top: $header-height-mobile;
+    // Use this additional padding when the global message is being displayed
+    // padding-top: $header-height-mobile + 90;
   }
 
   &.has-sticky-nav {


### PR DESCRIPTION
This removes the green banner atop the website since the Habitat Summit is now over.

Signed-off-by: Ryan Keairns <rkeairns@chef.io>