### PR TITLE
Adds test for ring encryption

### DIFF
--- a/components/butterfly/src/main.rs
+++ b/components/butterfly/src/main.rs
@@ -46,6 +46,7 @@ fn main() {
                                      gossip_bind_addr,
                                      member,
                                      trace::Trace::default(),
+                                     None,
                                      None)
         .unwrap();
     println!("Server ID: {}", server.member_id);

--- a/components/butterfly/tests/common/mod.rs
+++ b/components/butterfly/tests/common/mod.rs
@@ -21,10 +21,11 @@ use habitat_butterfly::server::Server;
 use habitat_butterfly::member::Member;
 use habitat_butterfly::trace::Trace;
 use habitat_butterfly::server::timing::Timing;
+use habitat_core::crypto::keys::sym_key::SymKey;
 
 static SERVER_PORT: AtomicUsize = ATOMIC_USIZE_INIT;
 
-pub fn start_server(name: &str) -> Server {
+pub fn start_server(name: &str, ring_key: Option<SymKey>) -> Server {
     SERVER_PORT.compare_and_swap(0, 6666, Ordering::Relaxed);
     let swim_port = SERVER_PORT.fetch_add(1, Ordering::Relaxed);
     let gossip_port = SERVER_PORT.fetch_add(1, Ordering::Relaxed);
@@ -37,6 +38,7 @@ pub fn start_server(name: &str) -> Server {
                              &listen_gossip[..],
                              member,
                              Trace::default(),
+                             ring_key,
                              Some(String::from(name)))
         .unwrap();
     server.start(Timing::default()).expect("Cannot start server");

--- a/components/butterfly/tests/common/net.rs
+++ b/components/butterfly/tests/common/net.rs
@@ -26,6 +26,7 @@ use habitat_butterfly::service::Service;
 use habitat_butterfly::service_config::ServiceConfig;
 use habitat_butterfly::message::swim::Election_Status;
 use habitat_core::service::ServiceGroup;
+use habitat_core::crypto::keys::sym_key::SymKey;
 
 #[derive(Debug)]
 pub struct SwimNet {
@@ -50,7 +51,16 @@ impl SwimNet {
     pub fn new(count: usize) -> SwimNet {
         let mut members = Vec::with_capacity(count);
         for x in 0..count {
-            members.push(common::start_server(&format!("{}", x)));
+            members.push(common::start_server(&format!("{}", x), None));
+        }
+        SwimNet { members: members }
+    }
+
+    pub fn new_ring_encryption(count: usize, ring_key: Option<SymKey>) -> SwimNet {
+        let mut members = Vec::with_capacity(count);
+        for x in 0..count {
+            let rk = ring_key.clone();
+            members.push(common::start_server(&format!("{}", x), rk));
         }
         SwimNet { members: members }
     }

--- a/components/butterfly/tests/encryption/mod.rs
+++ b/components/butterfly/tests/encryption/mod.rs
@@ -1,0 +1,30 @@
+// Copyright (c) 2016 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use habitat_butterfly::member::Health;
+use habitat_core::crypto::keys::sym_key::SymKey;
+
+use common;
+
+#[test]
+fn symmetric_encryption_of_wire_payloads() {
+    let ring_key = SymKey::generate_in_memory("wolverine")
+        .expect("Failed to generate an in memory symkey");
+    let mut net = common::net::SwimNet::new_ring_encryption(2, Some(ring_key));
+    net.connect(0, 1);
+    assert_wait_for_health_of!(net, [0..2, 0..2], Health::Alive);
+    net.add_service(0, "beast");
+    net.wait_for_gossip_rounds(2);
+    net[1].service_store.with_rumor("beast.prod", net[0].member_id(), |u| assert!(u.is_some()));
+}

--- a/components/butterfly/tests/integration.rs
+++ b/components/butterfly/tests/integration.rs
@@ -21,6 +21,7 @@ extern crate habitat_core;
 #[macro_use]
 mod common;
 mod rumor;
+mod encryption;
 
 use habitat_butterfly::member::Health;
 

--- a/components/butterfly/tests/rumor/election.rs
+++ b/components/butterfly/tests/rumor/election.rs
@@ -66,7 +66,7 @@ fn two_members_find_quorum_when_a_third_comes() {
     assert_wait_for_equal_election!(net, [0..2, 0..2], "witcher.prod");
     assert_wait_for_election_status!(net, [0..2], "witcher.prod", Election_Status::NoQuorum);
 
-    net.members.push(common::start_server("2"));
+    net.members.push(common::start_server("2", None));
     net.add_service(2, "witcher");
     net.connect(2, 0);
     assert_wait_for_election_status!(net, [0..2], "witcher.prod", Election_Status::Finished);

--- a/components/core/src/crypto/keys/sym_key.rs
+++ b/components/core/src/crypto/keys/sym_key.rs
@@ -36,6 +36,12 @@ impl fmt::Debug for SymKey {
 }
 
 impl SymKey {
+    pub fn generate_in_memory<S: ToString>(name: S) -> Result<Self> {
+        let revision = try!(mk_revision_string());
+        let secret_key = secretbox::gen_key();
+        Ok(SymKey::new(name.to_string(), revision, Some(()), Some(secret_key)))
+    }
+
     pub fn generate_pair_for_ring<P: AsRef<Path> + ?Sized>(name: &str,
                                                            cache_key_path: &P)
                                                            -> Result<Self> {


### PR DESCRIPTION
Adds a test that turns on symmetric ring encryption, and verifies that
we can still share rumors.

![gif-keyboard-12928836254379074458](https://cloud.githubusercontent.com/assets/4304/19840020/466450ce-9eaa-11e6-862f-19ab2a2e7d36.gif)

Signed-off-by: Adam Jacob adam@chef.io
