### PR TITLE
Fix issue with package display

### DIFF
--- a/components/builder-web/app/depotApi.ts
+++ b/components/builder-web/app/depotApi.ts
@@ -36,10 +36,17 @@ export function get(params, nextRange: number = 0) {
             }
 
             response.json().then(resultsObj => {
+                let results;
+
                 const endRange = parseInt(resultsObj.range_end, 10);
                 const totalCount = parseInt(resultsObj.total_count, 10);
                 const nextRange = totalCount > (endRange + 1) ? endRange + 1 : 0;
-                const results = resultsObj.package_list;
+
+                if (resultsObj["package_list"]) {
+                    results = resultsObj["package_list"];
+                } else {
+                    results = resultsObj;
+                }
 
                 resolve({ results, totalCount, nextRange });
             });

--- a/components/builder-web/app/origin-page/OriginPageComponent.ts
+++ b/components/builder-web/app/origin-page/OriginPageComponent.ts
@@ -403,7 +403,7 @@ export class OriginPageComponent implements OnInit, OnDestroy {
             "",
             this.store.getState().packages.nextRange,
             true,
-            this.gitHubAuthToken);
+            this.gitHubAuthToken));
 
         return false;
     }


### PR DESCRIPTION
Turns out the depot API returns results differently, depending on whether you're searching for packages or just fetching a single package.  This accounts for that difference, and should clear up the current error in production about `Failed to load package. Error: Cannot read property 'replace' of undefined`

![gif-keyboard-17360463245754132353](https://cloud.githubusercontent.com/assets/947/19874832/59f0d2d0-9f85-11e6-9048-ae93943ed1bd.gif)

Signed-off-by: Josh Black <raskchanky@gmail.com>