### PR TITLE
Filter on the correct package params

### DIFF
--- a/components/builder-web/app/packages-page/PackagesPageComponent.ts
+++ b/components/builder-web/app/packages-page/PackagesPageComponent.ts
@@ -128,7 +128,7 @@ export class PackagesPageComponent implements OnInit, OnDestroy {
     }
 
     private fetchMorePackages() {
-        this.store.dispatch(filterPackagesBy(this.route.params,
+        this.store.dispatch(filterPackagesBy(this.packageParams(),
             this.searchQuery,
             this.store.getState().packages.nextRange));
         return false;


### PR DESCRIPTION
Now we actually see more packages when going to the next page, instead of a sad error in the console.

![gif-keyboard-13617902670044642223](https://cloud.githubusercontent.com/assets/947/19899971/30323f34-a01f-11e6-904f-8797b9694153.gif)

Signed-off-by: Josh Black <raskchanky@gmail.com>