### PR TITLE
[plan-build] Ensure that `TERMINFO` is not present for all builds.

### DIFF
--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -382,6 +382,13 @@ graceful_exit=true
 # We want everything to be build as `rwx-r-x-r-x`
 umask 0022
 
+# In order to ensure that the external environment does not affect the build
+# time behavior of a Plan, we explicitly unset several know environment
+# variables which are known to be used by underlying autoconf-like tools
+# and other build software.
+unset TERMINFO
+
+
 # ## Private/Internal helper functions
 #
 # These functions are part of the private/internal API of this program and


### PR DESCRIPTION
This change addresses an issues introduced when every Studio instance
started exporting the `TERMINFO` environment variable which was in scope
when the build program ran. Specifically, the build time behavior of the
`core/ncurses` package is different with and without this environment
variable. When set, no `$pkg_prefix/share/terminfo` directory is created
and when not set, the directory is created.

While this particular environment variable affects one currently known
package, there may be others current or future which could have
different build behaviors with this variable. In an attempt to preserve
the build system's "brutal minimalism", we've opted to explicitly unset
this environment variable.

Note that this is a warning to any future environment variables that are
added to a Studio instance--it may be hard to determine the impact such
a variable may have so best err on being conservative and explicitly
unsetting when it is desirable/necessary.

References #1435

![gif-keyboard-12878899955496040301](https://cloud.githubusercontent.com/assets/261548/19912199/71e4c336-a05e-11e6-8d55-4e5db6749e58.gif)
