### PR TITLE
pull the supervisor waitpid into core to be handled separately by os

### DIFF
--- a/components/core/src/os/process/linux.rs
+++ b/components/core/src/os/process/linux.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use libc::{pid_t, c_int};
 use std::ffi::OsString;
 use std::path::PathBuf;
 use std::os::unix::process::CommandExt;
@@ -19,8 +20,16 @@ use std::process::Command;
 
 use error::Result;
 
+extern "C" {
+    fn waitpid(pid: pid_t, status: *mut c_int, options: c_int) -> pid_t;
+}
+
 pub fn become_command(command: PathBuf, args: Vec<OsString>) -> Result<()> {
     become_exec_command(command, args)
+}
+
+pub fn wait_for_exit(pid: u32, status: *mut c_int) -> u32 {
+    unsafe { waitpid(pid as i32, status, 1 as c_int) as u32 }
 }
 
 /// Makes an `execvp(3)` system call to become a new program.

--- a/components/core/src/os/process/mod.rs
+++ b/components/core/src/os/process/mod.rs
@@ -16,10 +16,10 @@
 mod windows;
 
 #[cfg(windows)]
-pub use self::windows::become_command;
+pub use self::windows::{become_command, wait_for_exit};
 
 #[cfg(not(windows))]
 pub mod linux;
 
 #[cfg(not(windows))]
-pub use self::linux::become_command;
+pub use self::linux::{become_command, wait_for_exit};

--- a/components/core/src/os/process/windows.rs
+++ b/components/core/src/os/process/windows.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use libc::c_int;
 use std::ffi::OsString;
 use std::path::PathBuf;
 use std::process::{self, Command};
@@ -20,6 +21,10 @@ use error::Result;
 
 pub fn become_command(command: PathBuf, args: Vec<OsString>) -> Result<()> {
     become_child_command(command, args)
+}
+
+pub fn wait_for_exit(pid: u32, status: *mut c_int) -> u32 {
+    unimplemented!();
 }
 
 /// Executes a command as a child process and exits with the child's exit code.

--- a/components/sup/src/supervisor.rs
+++ b/components/sup/src/supervisor.rs
@@ -27,8 +27,9 @@ use std::process::{Command, Stdio, Child};
 use std::thread;
 
 use hcore;
+use hcore::os::process;
 use hcore::package::PackageIdent;
-use libc::{pid_t, c_int};
+use libc::c_int;
 use time::{Duration, SteadyTime};
 
 use error::{Result, Error};
@@ -37,11 +38,6 @@ use util::users as hab_users;
 
 const PIDFILE_NAME: &'static str = "PID";
 static LOGKEY: &'static str = "SV";
-
-// Functions from POSIX libc.
-extern "C" {
-    fn waitpid(pid: pid_t, status: *mut c_int, options: c_int) -> pid_t;
-}
 
 /// A simple compatability type for external functions
 #[allow(non_camel_case_types)]
@@ -311,51 +307,49 @@ impl Supervisor {
             return Ok(());
         }
 
-        unsafe {
-            let mut status: c_int = 0;
-            let cpid = self.pid.unwrap() as pid_t;
-            match waitpid(cpid, &mut status, 1 as c_int) {
-                0 => {} // Nothing returned,
-                pid if pid == cpid => {
-                    if WIFEXITED(status) {
-                        let exit_code = WEXITSTATUS(status);
-                        outputln!("{} - process {} died with exit code {}",
-                                  self.package_ident.name,
-                                  pid,
-                                  exit_code);
-                    } else if WIFSIGNALED(status) {
-                        let exit_signal = WTERMSIG(status);
-                        outputln!("{} - process {} died with signal {}",
-                                  self.package_ident.name,
-                                  pid,
-                                  exit_signal);
-                    } else {
-                        outputln!("{} - process {} died, but I don't know how.",
-                                  self.package_ident.name,
-                                  pid);
+        let mut status: c_int = 0;
+        let cpid = self.pid.unwrap();
+        match process::wait_for_exit(cpid, &mut status) {
+            0 => {} // Nothing returned,
+            pid if pid == cpid => {
+                if WIFEXITED(status) {
+                    let exit_code = WEXITSTATUS(status);
+                    outputln!("{} - process {} died with exit code {}",
+                              self.package_ident.name,
+                              pid,
+                              exit_code);
+                } else if WIFSIGNALED(status) {
+                    let exit_signal = WTERMSIG(status);
+                    outputln!("{} - process {} died with signal {}",
+                              self.package_ident.name,
+                              pid,
+                              exit_signal);
+                } else {
+                    outputln!("{} - process {} died, but I don't know how.",
+                              self.package_ident.name,
+                              pid);
+                }
+                match self.state {
+                    ProcessState::Up | ProcessState::Start | ProcessState::Restart => {
+                        outputln!("{} - Service exited", self.package_ident.name);
+                        self.pid = None;
                     }
-                    match self.state {
-                        ProcessState::Up | ProcessState::Start | ProcessState::Restart => {
-                            outputln!("{} - Service exited", self.package_ident.name);
-                            self.pid = None;
-                        }
-                        ProcessState::Down => {
-                            self.enter_state(ProcessState::Down);
-                            self.pid = None;
-                        }
+                    ProcessState::Down => {
+                        self.enter_state(ProcessState::Down);
+                        self.pid = None;
                     }
                 }
-                // ZOMBIES! Bad zombies! We listen for zombies. ZOMBOCOM!
-                pid => {
-                    if WIFEXITED(status) {
-                        let exit_code = WEXITSTATUS(status);
-                        debug!("Process {} died with exit code {}", pid, exit_code);
-                    } else if WIFSIGNALED(status) {
-                        let exit_signal = WTERMSIG(status);
-                        debug!("Process {} terminated with signal {}", pid, exit_signal);
-                    } else {
-                        debug!("Process {} died, but I don't know how.", pid);
-                    }
+            }
+            // ZOMBIES! Bad zombies! We listen for zombies. ZOMBOCOM!
+            pid => {
+                if WIFEXITED(status) {
+                    let exit_code = WEXITSTATUS(status);
+                    debug!("Process {} died with exit code {}", pid, exit_code);
+                } else if WIFSIGNALED(status) {
+                    let exit_signal = WTERMSIG(status);
+                    debug!("Process {} terminated with signal {}", pid, exit_signal);
+                } else {
+                    debug!("Process {} died, but I don't know how.", pid);
                 }
             }
         }


### PR DESCRIPTION
This is one step forward in allowing the supervisor to build on windows. The windows implementation for waiting on a process remains unimplemented and that will be added in a separate PR likely leveraging win api calls to `OpenProcess` and `WaitForSingleObject`.
