### PR TITLE
Retry network operations if they fail

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,6 +203,7 @@ dependencies = [
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "pbr 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "retry 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "temp_utp 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,6 +423,7 @@ dependencies = [
  "openssl 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "pbr 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "retry 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1059,6 +1060,14 @@ version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "retry"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "route-recognizer"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1586,6 +1595,7 @@ dependencies = [
 "checksum redis 0.7.0 (git+https://github.com/habitat-sh/redis-rs?branch=habitat)" = "<none>"
 "checksum regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)" = "4fd4ace6a8cf7860714a2c2280d6c1f7e6a413486c13298bbc86fd3da019402f"
 "checksum regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "f9ec002c35e86791825ed294b50008eea9ddfc8def4420124fbc6b08db834957"
+"checksum retry 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "29460f6011a25fc70b22010e796bd98330baccaa0005cba6f90b858a510dec0d"
 "checksum route-recognizer 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "4f0a750d020adb1978f5964ea7bca830585899b09da7cbb3f04961fc2400122d"
 "checksum router 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b94397bfa5b772b4375be4da12560a7c1c1e74b2e35c46ed312958aad56df726"
 "checksum rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)" = "f76d05d3993fd5f4af9434e8e436db163a12a9d40e1a58a726f27a01dfd12a2a"

--- a/components/builder-depot-client/src/error.rs
+++ b/components/builder-depot-client/src/error.rs
@@ -32,6 +32,7 @@ pub enum Error {
     IO(io::Error),
     NoFilePart,
     NoXFilename,
+    UploadFailed(String),
     UrlParseError(url::ParseError),
     WriteSyncFailed,
 }
@@ -54,6 +55,7 @@ impl fmt::Display for Error {
             Error::NoXFilename => {
                 format!("Invalid download from a Depot - missing X-Filename header")
             }
+            Error::UploadFailed(ref s) => format!("Upload failed: {}", s),
             Error::UrlParseError(ref e) => format!("{}", e),
             Error::WriteSyncFailed => {
                 format!("Could not write to destination; perhaps the disk is full?")
@@ -75,6 +77,7 @@ impl error::Error for Error {
                 "An invalid path was passed - we needed a filename, and this path does not have one"
             }
             Error::NoXFilename => "Invalid download from a Depot - missing X-Filename header",
+            Error::UploadFailed(_) => "Upload failed",
             Error::UrlParseError(ref err) => err.description(),
             Error::WriteSyncFailed => {
                 "Could not write to destination; bytes written was 0 on a non-0 buffer"

--- a/components/builder-depot-client/src/error.rs
+++ b/components/builder-depot-client/src/error.rs
@@ -26,6 +26,7 @@ use hab_http;
 #[derive(Debug)]
 pub enum Error {
     APIError(hyper::status::StatusCode, String),
+    DownloadFailed(String),
     HabitatCore(hab_core::Error),
     HabitatHttpClient(hab_http::Error),
     HyperError(hyper::error::Error),
@@ -44,6 +45,7 @@ impl fmt::Display for Error {
         let msg = match *self {
             Error::APIError(ref c, ref m) if m.len() > 0 => format!("[{}] {}", c, m),
             Error::APIError(ref c, _) => format!("[{}]", c),
+            Error::DownloadFailed(ref s) => format!("Download failed: {}", s),
             Error::HabitatCore(ref e) => format!("{}", e),
             Error::HabitatHttpClient(ref e) => format!("{}", e),
             Error::HyperError(ref err) => format!("{}", err),
@@ -69,6 +71,7 @@ impl error::Error for Error {
     fn description(&self) -> &str {
         match *self {
             Error::APIError(_, _) => "Received a non-2XX response code from API",
+            Error::DownloadFailed(_) => "Download failed",
             Error::HabitatCore(ref err) => err.description(),
             Error::HabitatHttpClient(ref err) => err.description(),
             Error::HyperError(ref err) => err.description(),

--- a/components/common/Cargo.toml
+++ b/components/common/Cargo.toml
@@ -11,6 +11,7 @@ log = "*"
 openssl = "0.7" # lock until hyper bumps to 0.8+
 pbr = "0.2" # lock until ready to support 0.3+ interface
 regex = "*"
+retry = "*"
 rustc-serialize = "*"
 term = "*"
 time = "*"

--- a/components/common/src/command/package/install.rs
+++ b/components/common/src/command/package/install.rs
@@ -39,7 +39,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
-use depot_client::Client;
+use depot_client::{self, Client};
 use hcore;
 use hcore::fs::{am_i_root, cache_key_path};
 use hcore::crypto::{artifact, SigKeyPair};
@@ -183,9 +183,12 @@ impl<'a> InstallTask<'a> {
                      || self.fetch_artifact(ui, &ident, src_path),
                      |res| res.is_ok())
                 .is_err() {
-                return Err(Error::DownloadError("We tried to download 5 times and were \
-                                                 unsuccessful. Giving up."
-                    .to_string()));
+                return Err(Error::from(depot_client::Error::DownloadFailed(format!("We tried 5 \
+                                                                                    times but \
+                                                                                    could not \
+                                                                                    download {}. \
+                                                                                    Giving up.",
+                                                                                   &ident))));
             }
         }
 

--- a/components/common/src/command/package/install.rs
+++ b/components/common/src/command/package/install.rs
@@ -51,6 +51,9 @@ use ui::{Status, UI};
 
 use retry::retry;
 
+pub const RETRIES: u64 = 5;
+pub const RETRY_WAIT: u64 = 3000;
+
 pub fn start<P1: ?Sized, P2: ?Sized>(ui: &mut UI,
                                      url: &str,
                                      ident_or_archive: &str,
@@ -178,16 +181,17 @@ impl<'a> InstallTask<'a> {
             debug!("Found {} in artifact cache, skipping remote download",
                    &ident);
         } else {
-            if retry(5,
-                     3000,
+            if retry(RETRIES,
+                     RETRY_WAIT,
                      || self.fetch_artifact(ui, &ident, src_path),
                      |res| res.is_ok())
                 .is_err() {
-                return Err(Error::from(depot_client::Error::DownloadFailed(format!("We tried 5 \
+                return Err(Error::from(depot_client::Error::DownloadFailed(format!("We tried {} \
                                                                                     times but \
                                                                                     could not \
                                                                                     download {}. \
                                                                                     Giving up.",
+                                                                                   RETRIES,
                                                                                    &ident))));
             }
         }

--- a/components/common/src/error.rs
+++ b/components/common/src/error.rs
@@ -32,7 +32,6 @@ pub enum Error {
     CryptoKeyError(String),
     GossipFileRelativePath(String),
     DepotClient(depot_client::Error),
-    DownloadError(String),
     FileNameError,
     HabitatCore(hcore::Error),
     InvalidTomlError(String),
@@ -64,7 +63,6 @@ impl fmt::Display for Error {
                         s)
             }
             Error::DepotClient(ref err) => format!("{}", err),
-            Error::DownloadError(ref s) => format!("Download failed: {}", s),
             Error::FileNameError => format!("Failed to extract a filename"),
             Error::HabitatCore(ref e) => format!("{}", e),
             Error::InvalidTomlError(ref e) => format!("Invalid TOML: {}", e),
@@ -94,7 +92,6 @@ impl error::Error for Error {
                 "Path for gossip file cannot have relative components (eg: ..)"
             }
             Error::DepotClient(ref err) => err.description(),
-            Error::DownloadError(_) => "Download failed",
             Error::FileNameError => "Failed to extract a filename from a path",
             Error::HabitatCore(ref err) => err.description(),
             Error::InvalidTomlError(_) => "Invalid TOML",

--- a/components/common/src/error.rs
+++ b/components/common/src/error.rs
@@ -32,6 +32,7 @@ pub enum Error {
     CryptoKeyError(String),
     GossipFileRelativePath(String),
     DepotClient(depot_client::Error),
+    DownloadError(String),
     FileNameError,
     HabitatCore(hcore::Error),
     InvalidTomlError(String),
@@ -63,6 +64,7 @@ impl fmt::Display for Error {
                         s)
             }
             Error::DepotClient(ref err) => format!("{}", err),
+            Error::DownloadError(ref s) => format!("Download failed: {}", s),
             Error::FileNameError => format!("Failed to extract a filename"),
             Error::HabitatCore(ref e) => format!("{}", e),
             Error::InvalidTomlError(ref e) => format!("Invalid TOML: {}", e),
@@ -92,6 +94,7 @@ impl error::Error for Error {
                 "Path for gossip file cannot have relative components (eg: ..)"
             }
             Error::DepotClient(ref err) => err.description(),
+            Error::DownloadError(_) => "Download failed",
             Error::FileNameError => "Failed to extract a filename from a path",
             Error::HabitatCore(ref err) => err.description(),
             Error::InvalidTomlError(_) => "Invalid TOML",

--- a/components/common/src/lib.rs
+++ b/components/common/src/lib.rs
@@ -21,6 +21,7 @@ extern crate log;
 extern crate openssl;
 extern crate pbr;
 extern crate regex;
+extern crate retry;
 extern crate rustc_serialize;
 #[cfg(test)]
 extern crate tempdir;

--- a/components/hab/Cargo.toml
+++ b/components/hab/Cargo.toml
@@ -18,6 +18,7 @@ libc = "*"
 log = "*"
 pbr = "*"
 regex = "*"
+retry = "*"
 rustc-serialize = "*"
 # Temporary depdency for gossip/rumor injection code duplication.
 temp_utp = "*"

--- a/components/hab/src/command/origin.rs
+++ b/components/hab/src/command/origin.rs
@@ -55,6 +55,7 @@ pub mod key {
         use common::ui::{Status, UI};
         use depot_client::{self, Client};
         use hcore::crypto::SigKeyPair;
+        use common::command::package::install::{RETRIES, RETRY_WAIT};
 
         use {PRODUCT, VERSION};
         use error::{Error, Result};
@@ -125,11 +126,11 @@ pub mod key {
                         Ok(())
                     };
 
-                    if retry(5, 3000, download_fn, |res| res.is_ok()).is_err() {
+                    if retry(RETRIES, RETRY_WAIT, download_fn, |res| res.is_ok()).is_err() {
                         return Err(Error::from(depot_client::Error::DownloadFailed(format!(
-                                        "We tried 5 times but could not \
+                                        "We tried {} times but could not \
                                          download {}/{} origin key. Giving up.",
-                                        &name, &rev))));
+                                        RETRIES, &name, &rev))));
                     }
                 }
             }
@@ -204,6 +205,7 @@ pub mod key {
         use std::path::Path;
 
         use common::ui::{Status, UI};
+        use common::command::package::install::{RETRIES, RETRY_WAIT};
         use depot_client::{self, Client};
         use hcore::crypto::keys::parse_name_with_rev;
         use hcore::crypto::{PUBLIC_SIG_KEY_VERSION, SECRET_SIG_KEY_VERSION};
@@ -243,15 +245,16 @@ pub mod key {
                     Ok(())
                 };
 
-                if retry(5, 3000, upload_fn, |res| res.is_ok()).is_err() {
+                if retry(RETRIES, RETRY_WAIT, upload_fn, |res| res.is_ok()).is_err() {
                     return Err(Error::from(depot_client::Error::UploadFailed(format!("We tried \
-                                                                                      5 times \
+                                                                                      {} times \
                                                                                       but could \
                                                                                       not upload \
                                                                                       {}/{} public \
                                                                                       origin key. \
                                                                                       Giving up.\
                                                                                       ",
+                                                                                     RETRIES,
                                                                                      &name,
                                                                                      &rev))));
                 }
@@ -283,15 +286,16 @@ pub mod key {
                     }
                 };
 
-                if retry(5, 3000, upload_fn, |res| res.is_ok()).is_err() {
+                if retry(RETRIES, RETRY_WAIT, upload_fn, |res| res.is_ok()).is_err() {
                     return Err(Error::from(depot_client::Error::UploadFailed(format!("We tried \
-                                                                                      5 times \
+                                                                                      {} times \
                                                                                       but could \
                                                                                       not upload \
                                                                                       {}/{} secret \
                                                                                       origin key. \
                                                                                       Giving up.\
                                                                                       ",
+                                                                                     RETRIES,
                                                                                      &name,
                                                                                      &rev))));
                 }

--- a/components/hab/src/lib.rs
+++ b/components/hab/src/lib.rs
@@ -26,6 +26,7 @@ extern crate hyper;
 extern crate log;
 extern crate pbr;
 extern crate regex;
+extern crate retry;
 extern crate rustc_serialize;
 extern crate toml;
 extern crate url;

--- a/components/http-client/src/api_client.rs
+++ b/components/http-client/src/api_client.rs
@@ -14,6 +14,7 @@
 
 use std::sync::Arc;
 use std::path::Path;
+use std::time::Duration;
 
 use hab_core::util::sys;
 use hyper::client::Client as HyperClient;
@@ -234,12 +235,20 @@ fn new_hyper_client(for_domain: Option<&Url>, fs_root_path: Option<&Path>) -> Re
             debug!("Using proxy {}:{}...", proxy.host(), proxy.port());
             let connector = try!(ProxyHttpsConnector::new(proxy, ssl_client));
             let pool = Pool::with_connector(Config::default(), connector);
-            Ok(HyperClient::with_protocol(Http11Protocol::with_connector(pool)))
+            let mut client = HyperClient::with_protocol(Http11Protocol::with_connector(pool));
+            let timeout = Some(Duration::from_secs(5));
+            client.set_read_timeout(timeout);
+            client.set_write_timeout(timeout);
+            Ok(client)
         }
         None => {
             let connector = HttpsConnector::new(ssl_client);
             let pool = Pool::with_connector(Config::default(), connector);
-            Ok(HyperClient::with_protocol(Http11Protocol::with_connector(pool)))
+            let mut client = HyperClient::with_protocol(Http11Protocol::with_connector(pool));
+            let timeout = Some(Duration::from_secs(5));
+            client.set_read_timeout(timeout);
+            client.set_write_timeout(timeout);
+            Ok(client)
         }
     }
 }

--- a/components/http-client/src/api_client.rs
+++ b/components/http-client/src/api_client.rs
@@ -230,13 +230,14 @@ impl ApiClient {
 fn new_hyper_client(for_domain: Option<&Url>, fs_root_path: Option<&Path>) -> Result<HyperClient> {
     let ctx = try!(ssl_ctx(fs_root_path));
     let ssl_client = Openssl { context: Arc::new(ctx) };
+    let timeout = Some(Duration::from_secs(5));
+
     match try!(proxy_unless_domain_exempted(for_domain)) {
         Some(proxy) => {
             debug!("Using proxy {}:{}...", proxy.host(), proxy.port());
             let connector = try!(ProxyHttpsConnector::new(proxy, ssl_client));
             let pool = Pool::with_connector(Config::default(), connector);
             let mut client = HyperClient::with_protocol(Http11Protocol::with_connector(pool));
-            let timeout = Some(Duration::from_secs(5));
             client.set_read_timeout(timeout);
             client.set_write_timeout(timeout);
             Ok(client)
@@ -245,7 +246,6 @@ fn new_hyper_client(for_domain: Option<&Url>, fs_root_path: Option<&Path>) -> Re
             let connector = HttpsConnector::new(ssl_client);
             let pool = Pool::with_connector(Config::default(), connector);
             let mut client = HyperClient::with_protocol(Http11Protocol::with_connector(pool));
-            let timeout = Some(Duration::from_secs(5));
             client.set_read_timeout(timeout);
             client.set_write_timeout(timeout);
             Ok(client)


### PR DESCRIPTION
This sets a read/write timeout on the HTTP client that hab uses and then leverages the retry crate to retry network operations 5 times, waiting 3 seconds between each try.  I tried my best to encapsulate enough logic in the retryable closure that the user could tell from the UI that hab was retrying things.

It's worth noting that I initially tried to make this change in the HTTP client itself, thinking that since all of the hab network operations ended up in that place, it made sense to implement the retry logic there, rather than have it spread throughout the codebase in all the various commands.  That didn't work out because by the time the actual transferring of bytes over the network happened, hyper had already returned a response and was out of the picture.  From hyper's point of view, everything succeeded, regardless of whether the network connection was interrupted in mid upload/download.

Also note that in the most recent version of hyper, you cannot control the connection timeout.  This means that the current flow of things looks like this:

* `hab pkg download core/foo`
* <Download begins and is interrupted a second later>
* <5 second read timeout expires>
* <hab tries to establish a new connection to download the package again>
* <a long wait happens here as hyper's connection timeout is not configurable>

I notice that the connection timeout _is_ configurable in the hyper master branch but not in the latest stable release.

These changes work, but on the whole, it feels less elegant than I would've liked, so I'm definitely open to suggestions on better ways to do this.

![gif-keyboard-14918230011999129624](https://cloud.githubusercontent.com/assets/947/19950909/ded2c11e-a117-11e6-99ce-5caba8fb23e0.gif)
