### PR TITLE
Move user functions from sup to core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,6 @@ dependencies = [
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "users 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "wonder 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/components/core/src/os/users/linux.rs
+++ b/components/core/src/os/users/linux.rs
@@ -25,6 +25,14 @@ pub fn get_gid_by_name(group: &str) -> Option<u32> {
     linux_users::get_group_by_name(&group.as_ref()).map(|g| g.gid())
 }
 
+pub fn get_current_username() -> Option<String> {
+    linux_users::get_current_username()
+}
+
+pub fn get_current_groupname() -> Option<String> {
+    linux_users::get_current_groupname()
+}
+
 pub fn get_effective_uid() -> u32 {
     linux_users::get_effective_uid()
 }

--- a/components/core/src/os/users/mod.rs
+++ b/components/core/src/os/users/mod.rs
@@ -16,10 +16,10 @@
 mod windows;
 
 #[cfg(windows)]
-pub use self::windows::{get_uid_by_name, get_gid_by_name, get_effective_uid, get_home_for_user};
+pub use self::windows::{get_uid_by_name, get_gid_by_name, get_effective_uid, get_home_for_user, get_current_username, get_current_groupname};
 
 #[cfg(not(windows))]
 pub mod linux;
 
 #[cfg(not(windows))]
-pub use self::linux::{get_uid_by_name, get_gid_by_name, get_effective_uid, get_home_for_user};
+pub use self::linux::{get_uid_by_name, get_gid_by_name, get_effective_uid, get_home_for_user, get_current_username, get_current_groupname};

--- a/components/core/src/os/users/windows.rs
+++ b/components/core/src/os/users/windows.rs
@@ -26,6 +26,14 @@ pub fn get_gid_by_name(group: &str) -> Option<u32> {
     unimplemented!();
 }
 
+pub fn get_current_username() -> Option<String> {
+    unimplemented!();
+}
+
+pub fn get_current_groupname() -> Option<String> {
+    unimplemented!();
+}
+
 pub fn get_effective_uid() -> u32 {
     unsafe { GetUserTokenStatus() }
 }

--- a/components/sup/Cargo.toml
+++ b/components/sup/Cargo.toml
@@ -36,7 +36,6 @@ openssl = "*"
 lazy_static = "*"
 handlebars = "*"
 wonder = "*"
-users = "*"
 
 [dependencies.habitat_core]
 path = "../core"


### PR DESCRIPTION
This moves the usage of the users crate out of the supervisoe and into core. Most functions were already implemented but I wrapped a couple that were not already there. We will add windows implementations in a separate PR.

Signed-off-by: Matt Wrock <matt@mattwrock.com>