### PR TITLE
write hooks file using ::create to be os portable

### DIFF
--- a/components/sup/src/package/hooks.rs
+++ b/components/sup/src/package/hooks.rs
@@ -13,9 +13,8 @@
 // limitations under the License.
 
 use std::fmt;
-use std::fs::{self, OpenOptions};
+use std::fs::{self, File, OpenOptions};
 use std::io::prelude::*;
-use std::os::unix::fs::OpenOptionsExt;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 
@@ -163,14 +162,8 @@ impl Hook {
             let toml = try!(ctx.to_toml());
             let svc_data = convert::toml_to_json(toml);
             let data = try!(handlebars.render("hook", &svc_data));
-            let mut file = try!(OpenOptions::new()
-                .write(true)
-                .truncate(true)
-                .create(true)
-                .read(true)
-                .mode(0o770)
-                .open(&self.path));
-            try!(write!(&mut file, "{}", data));
+            let mut file = try!(File::create(&self.path));
+            try!(file.write_all(data.as_bytes()));
             try!(util::perm::set_owner(&self.path, &self.user, &self.group));
             try!(util::perm::set_permissions(&self.path, HOOK_PERMISSIONS));
             Ok(())


### PR DESCRIPTION
My first iteration on this was creating 2 os specific methods. The windows one did not use the `.mode` on the `OpenOptions`. After looking further, it seems like this approach was cleaner and I believe accomplishes the same end (but could be wrong).