### PR TITLE
Quiet the unused variable warnings in stubbed out functions

### DIFF
--- a/components/core/src/os/filesystem/mod.rs
+++ b/components/core/src/os/filesystem/mod.rs
@@ -12,8 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[allow(unused_variables)]
 #[cfg(windows)]
 mod windows;
+
 
 #[cfg(windows)]
 pub use self::windows::{chown, chmod, symlink};

--- a/components/core/src/os/process/mod.rs
+++ b/components/core/src/os/process/mod.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[allow(unused_variables)]
 #[cfg(windows)]
 mod windows;
 

--- a/components/core/src/os/users/mod.rs
+++ b/components/core/src/os/users/mod.rs
@@ -12,14 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[allow(unused_variables)]
 #[cfg(windows)]
 mod windows;
 
 #[cfg(windows)]
-pub use self::windows::{get_uid_by_name, get_gid_by_name, get_effective_uid, get_home_for_user, get_current_username, get_current_groupname};
+pub use self::windows::{get_uid_by_name, get_gid_by_name, get_effective_uid, get_home_for_user,
+                        get_current_username, get_current_groupname};
 
 #[cfg(not(windows))]
 pub mod linux;
 
 #[cfg(not(windows))]
-pub use self::linux::{get_uid_by_name, get_gid_by_name, get_effective_uid, get_home_for_user, get_current_username, get_current_groupname};
+pub use self::linux::{get_uid_by_name, get_gid_by_name, get_effective_uid, get_home_for_user,
+                      get_current_username, get_current_groupname};


### PR DESCRIPTION
filling out the stubbed out functions for windows in core is further down the road than I expected.  the warning make the build/test cycle more noisy than it needs to be, so this shuts them up.

Signed-off-by: Steven Murawski <steven.murawski@gmail.com>