### PR TITLE
Move process signalling to core

### DIFF
--- a/components/core/src/os/process/linux.rs
+++ b/components/core/src/os/process/linux.rs
@@ -21,6 +21,7 @@ use std::process::Command;
 use error::Result;
 
 extern "C" {
+    fn kill(pid: i32, sig: u32) -> u32;
     fn waitpid(pid: pid_t, status: *mut c_int, options: c_int) -> pid_t;
 }
 
@@ -30,6 +31,13 @@ pub fn become_command(command: PathBuf, args: Vec<OsString>) -> Result<()> {
 
 pub fn wait_for_exit(pid: u32, status: *mut c_int) -> u32 {
     unsafe { waitpid(pid as i32, status, 1 as c_int) as u32 }
+}
+
+/// send a Unix signal to a pid
+pub fn send_signal(pid: u32, sig: u32) -> u32 {
+    unsafe {
+        kill(pid as i32, sig)
+    }
 }
 
 /// Makes an `execvp(3)` system call to become a new program.

--- a/components/core/src/os/process/mod.rs
+++ b/components/core/src/os/process/mod.rs
@@ -17,10 +17,10 @@
 mod windows;
 
 #[cfg(windows)]
-pub use self::windows::{become_command, wait_for_exit};
+pub use self::windows::{become_command, wait_for_exit, send_signal};
 
 #[cfg(not(windows))]
 pub mod linux;
 
 #[cfg(not(windows))]
-pub use self::linux::{become_command, wait_for_exit};
+pub use self::linux::{become_command, wait_for_exit, send_signal};

--- a/components/core/src/os/process/windows.rs
+++ b/components/core/src/os/process/windows.rs
@@ -27,6 +27,10 @@ pub fn wait_for_exit(pid: u32, status: *mut c_int) -> u32 {
     unimplemented!();
 }
 
+pub fn send_signal(pid: u32, sig: u32) -> u32 {
+    unimplemented!();
+}
+
 /// Executes a command as a child process and exits with the child's exit code.
 ///
 /// Note that if sucessful, this function will not return.

--- a/components/sup/src/package/hooks.rs
+++ b/components/sup/src/package/hooks.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use std::fmt;
-use std::fs::{self, File, OpenOptions};
+use std::fs::{self, File};
 use std::io::prelude::*;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};


### PR DESCRIPTION
Habitat was failing to link because of the C call to `Kill`. This lifts the signalling out of sup and into core where is can be handled per os. Will need to backfill windows in the near future.

Signed-off-by: Matt Wrock <matt@mattwrock.com>