### PR TITLE
Add core/curl as runtime dep for builder-worker

### DIFF
--- a/components/builder-worker/habitat/plan.sh
+++ b/components/builder-worker/habitat/plan.sh
@@ -6,7 +6,7 @@ pkg_license=('Apache-2.0')
 pkg_source=nosuchfile.tar.gz
 pkg_bin_dirs=(bin)
 pkg_deps=(core/glibc core/openssl core/gcc-libs core/zeromq core/libsodium core/libarchive
-  core/zlib core/hab-studio)
+  core/zlib core/hab-studio core/curl)
 pkg_build_deps=(core/make core/cmake core/protobuf core/protobuf-rust core/coreutils core/cacerts
   core/rust core/gcc core/pkg-config)
 bin="bldr-worker"


### PR DESCRIPTION
Crate dependencies were updated but the plan needed a bit more work to actually output a build!

![gif-keyboard-10304810994009266158](https://cloud.githubusercontent.com/assets/54036/20022048/e765e818-a295-11e6-8173-ce703d7ece3c.gif)