### PR TITLE
[hab/mac] Fix mac-build.sh for new install.sh logic.

### DIFF
--- a/components/hab/mac/mac-build.sh
+++ b/components/hab/mac/mac-build.sh
@@ -41,8 +41,9 @@ if (( $EUID != 0 )); then
   exit 1
 fi
 
-if [[ ! -f /bin/hab ]]; then
+if [[ ! -f /usr/local/bin/hab ]]; then
   info "Habitat CLI missing, attempting to install latest release"
+  mkdir -p /usr/local/bin
   sh $(dirname $0)/../install.sh
 fi
 


### PR DESCRIPTION
This fix makes our release process work again.