### PR TITLE
Hide image checking logic in Makefile display output.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ distclean: ## fully cleans up project tree and any associated Docker images and 
 .PHONY: distclean
 
 image: ## create an image
-	if [ -n "${force}" -o -n "${refresh}" -o -z "`$(docker_cmd) images -q $(dimage)`" ]; then \
+	@if [ -n "${force}" -o -n "${refresh}" -o -z "`$(docker_cmd) images -q $(dimage)`" ]; then \
 		if [ -n "${force}" ]; then \
 		  $(docker_cmd) build --no-cache $(build_args) -t $(dimage) .; \
 		else \


### PR DESCRIPTION
This cleans up the ugly shell if check on almost every make target.
Keeps the output a bit clearer for the end user.

And just like that…

![gif-keyboard-4772139031578086565](https://cloud.githubusercontent.com/assets/261548/20025754/618869c4-a2b7-11e6-826c-de87fcc926a1.gif)
