### PR TITLE
[devshell] Add a non-root user, jdoe, for root/sudo checking codepaths.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,8 @@ RUN env -u CARGO_HOME cargo install protobuf && rm -rf /root/.cargo/registry
 RUN curl -sSL https://get.docker.io | sh && rm -rf /var/lib/apt/lists/* && docker -v
 RUN ln -snf /usr/bin/nodejs /usr/bin/node && npm install -g docco && echo "docco `docco -V`"
 
-RUN (adduser --system hab || true) && (addgroup --system hab || true)
+RUN (adduser --system hab || true) && (addgroup --system hab || true) \
+  && useradd -m -s /bin/bash -G sudo jdoe && echo jdoe:1234 | chpasswd
 
 COPY support/devshell_profile.sh /root/.bash_profile
 COPY .delivery/scripts/ssh_wrapper.sh /usr/local/bin


### PR DESCRIPTION
An arbitrary user such as this ends up being used over and over in
testing situations that having a known non-root user is useful for
Habitat developers. The user is `jdoe` with a simple password of `1234`
and who is also in the `sudo` group (thus being able to use `sudo`
commands).

![gif-keyboard-14029776973537934149](https://cloud.githubusercontent.com/assets/261548/20025810/da715882-a2b7-11e6-8eb9-caefa4e58574.gif)