### PR TITLE
Fix file extension exclusion

### DIFF
--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -2017,7 +2017,7 @@ do_default_build_config() {
     fi
     find_exclusions=""
     for ext in "${config_exclude_exts[@]}"; do
-      find_exclusions+=" ! -name '$ext'"
+      find_exclusions+=" ! -name $ext"
     done
     find "$PLAN_CONTEXT/config" $find_exclusions | while read FILE
     do


### PR DESCRIPTION
Signed-off-by: Salim Alam <salam@chef.io>

The check to exclude certain file extensions did not work. The reason is that the bash quote expansion in the statement escapes the single quote and the find command silently ignores the -not -name parameter(s).  