### PR TITLE
add target awareness to PackageArchive and PackageInstall

### DIFF
--- a/components/common/src/command/package/install.rs
+++ b/components/common/src/command/package/install.rs
@@ -42,21 +42,22 @@ use std::str::FromStr;
 use depot_client::Client;
 use hcore;
 use hcore::fs::{am_i_root, cache_key_path};
+use hcore::os::system;
 use hcore::crypto::{artifact, SigKeyPair};
 use hcore::crypto::keys::parse_name_with_rev;
-use hcore::package::{Identifiable, PackageArchive, PackageIdent, PackageInstall};
+use hcore::package::{Identifiable, PackageArchive, PackageIdent, Target, PackageInstall};
 
 use error::{Error, Result};
 use ui::{Status, UI};
 
 pub fn start<P1: ?Sized, P2: ?Sized>(ui: &mut UI,
-                                                 url: &str,
-                                                 ident_or_archive: &str,
-                                                 product: &str,
-                                                 version: &str,
-                                                 fs_root_path: &P1,
-                                                 cache_artifact_path: &P2)
-                                                 -> Result<PackageIdent>
+                                     url: &str,
+                                     ident_or_archive: &str,
+                                     product: &str,
+                                     version: &str,
+                                     fs_root_path: &P1,
+                                     cache_artifact_path: &P2)
+                                     -> Result<PackageIdent>
     where P1: AsRef<Path>,
           P2: AsRef<Path>
 {
@@ -273,6 +274,9 @@ impl<'a> InstallTask<'a> {
                                                      artifact_ident.to_string(),
                                                      ident.to_string())));
         }
+
+        let artifact_target = try!(artifact.target());
+        try!(artifact_target.valid_for(try!(system::uname())));
 
         let nwr = try!(artifact::artifact_signer(&artifact.path));
         if let Err(_) = SigKeyPair::get_public_key_path(&nwr, self.cache_key_path) {

--- a/components/common/src/command/package/install.rs
+++ b/components/common/src/command/package/install.rs
@@ -42,7 +42,6 @@ use std::str::FromStr;
 use depot_client::Client;
 use hcore;
 use hcore::fs::{am_i_root, cache_key_path};
-use hcore::os::system;
 use hcore::crypto::{artifact, SigKeyPair};
 use hcore::crypto::keys::parse_name_with_rev;
 use hcore::package::{Identifiable, PackageArchive, PackageIdent, Target, PackageInstall};
@@ -276,7 +275,7 @@ impl<'a> InstallTask<'a> {
         }
 
         let artifact_target = try!(artifact.target());
-        try!(artifact_target.valid_for(try!(system::uname())));
+        try!(artifact_target.validate());
 
         let nwr = try!(artifact::artifact_signer(&artifact.path));
         if let Err(_) = SigKeyPair::get_public_key_path(&nwr, self.cache_key_path) {

--- a/components/core/src/error.rs
+++ b/components/core/src/error.rs
@@ -55,9 +55,9 @@ pub enum Error {
     /// Occurs when a package target string cannot be successfully parsed.
     InvalidPackageTarget(String),
     /// Occurs when validating a package target for an unsupported architecture.
-    InvalidPackageTargetArchitecture(String),
+    InvalidArchitecture(String),
     /// Occurs when validating a package target for an unsupported platform.
-    InvalidPackageTargetPlatform(String),
+    InvalidPlatform(String),
     /// Occurs when a service group string cannot be successfully parsed.
     InvalidServiceGroup(String),
     /// Occurs when making lower level IO calls.
@@ -126,16 +126,12 @@ impl fmt::Display for Error {
                         e)
             }
             Error::InvalidPackageTarget(ref e) => {
-                format!("Invalid package target: {:?}. A valid target is in the form \
+                format!("Invalid package target: {}. A valid target is in the form \
                          architecture-platform (example: x86_64-linux)",
                         e)
             }
-            Error::InvalidPackageTargetArchitecture(ref e) => {
-                format!("Invalid package target architecture: {:?}.", e)
-            }
-            Error::InvalidPackageTargetPlatform(ref e) => {
-                format!("Invalid package target platform: {:?}.", e)
-            }
+            Error::InvalidArchitecture(ref e) => format!("Invalid architecture: {}.", e),
+            Error::InvalidPlatform(ref e) => format!("Invalid platform: {}.", e),
             Error::InvalidServiceGroup(ref e) => {
                 format!("Invalid service group: {:?}. A valid service group string is in the form \
                          service.group (example: redis.production)",
@@ -195,10 +191,8 @@ impl error::Error for Error {
             Error::InvalidPackageTarget(_) => {
                 "Package targets must be in architecture-platform format (example: x86_64-linux)"
             }
-            Error::InvalidPackageTargetArchitecture(_) => {
-                "Unsupported target architecture supplied."
-            }
-            Error::InvalidPackageTargetPlatform(_) => "Unsupported target platform supplied.",
+            Error::InvalidArchitecture(_) => "Unsupported target architecture supplied.",
+            Error::InvalidPlatform(_) => "Unsupported target platform supplied.",
             Error::InvalidServiceGroup(_) => {
                 "Service group strings must be in service.group format (example: redis.production)"
             }

--- a/components/core/src/error.rs
+++ b/components/core/src/error.rs
@@ -52,6 +52,12 @@ pub enum Error {
     FileNotFound(String),
     /// Occurs when a package identifier string cannot be successfully parsed.
     InvalidPackageIdent(String),
+    /// Occurs when a package target string cannot be successfully parsed.
+    InvalidPackageTarget(String),
+    /// Occurs when validating a package target for an unsupported architecture.
+    InvalidPackageTargetArchitecture(String),
+    /// Occurs when validating a package target for an unsupported platform.
+    InvalidPackageTargetPlatform(String),
     /// Occurs when a service group string cannot be successfully parsed.
     InvalidServiceGroup(String),
     /// Occurs when making lower level IO calls.
@@ -76,6 +82,8 @@ pub enum Error {
     RegexParse(regex::Error),
     /// When an error occurs converting a `String` from a UTF-8 byte vector.
     StringFromUtf8Error(string::FromUtf8Error),
+    /// When the system target (platform and architecture) do not match the package target.
+    TargetMatchError(String),
     /// Occurs when a `uname` libc call returns an error.
     UnameFailed(String),
     /// When an error occurs attempting to interpret a sequence of u8 as a string.
@@ -117,6 +125,17 @@ impl fmt::Display for Error {
                          origin/name (example: acme/redis)",
                         e)
             }
+            Error::InvalidPackageTarget(ref e) => {
+                format!("Invalid package target: {:?}. A valid target is in the form \
+                         architecture-platform (example: x86_64-linux)",
+                        e)
+            }
+            Error::InvalidPackageTargetArchitecture(ref e) => {
+                format!("Invalid package target architecture: {:?}.", e)
+            }
+            Error::InvalidPackageTargetPlatform(ref e) => {
+                format!("Invalid package target platform: {:?}.", e)
+            }
             Error::InvalidServiceGroup(ref e) => {
                 format!("Invalid service group: {:?}. A valid service group string is in the form \
                          service.group (example: redis.production)",
@@ -141,6 +160,7 @@ impl fmt::Display for Error {
             Error::PermissionFailed(ref e) => format!("{}", e),
             Error::RegexParse(ref e) => format!("{}", e),
             Error::StringFromUtf8Error(ref e) => format!("{}", e),
+            Error::TargetMatchError(ref e) => format!("{}", e),
             Error::UnameFailed(ref e) => format!("{}", e),
             Error::Utf8Error(ref e) => format!("{}", e),
         };
@@ -172,6 +192,13 @@ impl error::Error for Error {
             Error::InvalidPackageIdent(_) => {
                 "Package identifiers must be in origin/name format (example: acme/redis)"
             }
+            Error::InvalidPackageTarget(_) => {
+                "Package targets must be in architecture-platform format (example: x86_64-linux)"
+            }
+            Error::InvalidPackageTargetArchitecture(_) => {
+                "Unsupported target architecture supplied."
+            }
+            Error::InvalidPackageTargetPlatform(_) => "Unsupported target platform supplied.",
             Error::InvalidServiceGroup(_) => {
                 "Service group strings must be in service.group format (example: redis.production)"
             }
@@ -186,6 +213,7 @@ impl error::Error for Error {
             Error::PlanMalformed => "Failed to read or parse contents of Plan file",
             Error::RegexParse(_) => "Failed to parse a regular expression",
             Error::StringFromUtf8Error(_) => "Failed to convert a string from a Vec<u8> as UTF-8",
+            Error::TargetMatchError(_) => "System target does not match package target",
             Error::UnameFailed(_) => "uname failed",
             Error::Utf8Error(_) => "Failed to interpret a sequence of bytes as a string",
         }

--- a/components/core/src/fs.rs
+++ b/components/core/src/fs.rs
@@ -412,6 +412,7 @@ mod test_find_command {
             }
 
             #[test]
+            #[allow(non_snake_case)]
             fn command_exists_with_extension_in_PATHEXT() {
                 setup_environment();
                 let result = find_command("bin_with_extension");
@@ -419,6 +420,7 @@ mod test_find_command {
             }
 
             #[test]
+            #[allow(non_snake_case)]
             fn command_exists_with_extension_not_in_PATHEXT() {
                 setup_environment();
                 let result = find_command("win95_dominator");

--- a/components/core/src/os/system/linux.rs
+++ b/components/core/src/os/system/linux.rs
@@ -17,18 +17,9 @@ use std::mem;
 
 use libc;
 
+use os::system::Uname;
 use errno::errno;
 use error::{Error, Result};
-
-
-#[derive(Debug)]
-pub struct Uname {
-    pub sys_name: String,
-    pub node_name: String,
-    pub release: String,
-    pub version: String,
-    pub machine: String,
-}
 
 pub fn uname() -> Result<Uname> {
     unsafe { uname_libc() }

--- a/components/core/src/os/system/windows.rs
+++ b/components/core/src/os/system/windows.rs
@@ -12,17 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use os::system::Uname;
 use error::Result;
-
-// We can probably pull this from Win32_OperatingSystem
-#[derive(Debug)]
-pub struct Uname {
-    pub sys_name: String, // static - Windows
-    pub node_name: String, // __SERVER
-    pub release: String, // Version
-    pub version: String, // Caption
-    pub machine: String, // OSArchitecture - but converted to standard x86_64 or i386
-}
 
 pub fn uname() -> Result<Uname> {
     Ok(Uname {

--- a/components/core/src/package/archive.rs
+++ b/components/core/src/package/archive.rs
@@ -25,7 +25,7 @@ use regex::Regex;
 
 use error::{Error, Result};
 use crypto::{artifact, hash};
-use package::{Identifiable, PackageIdent, MetaFile};
+use package::{Identifiable, PackageIdent, PackageTarget, MetaFile};
 
 lazy_static! {
     static ref METAFILE_REGXS: HashMap<MetaFile, Regex> = {
@@ -40,6 +40,7 @@ lazy_static! {
         map.insert(MetaFile::LdFlags, Regex::new(&format!(r"^hab/pkgs/([^/]+)/([^/]+)/([^/]+)/([^/]+)/{}$", MetaFile::LdFlags)).unwrap());
         map.insert(MetaFile::Manifest, Regex::new(&format!(r"^hab/pkgs/([^/]+)/([^/]+)/([^/]+)/([^/]+)/{}$", MetaFile::Manifest)).unwrap());
         map.insert(MetaFile::Path, Regex::new(&format!(r"^hab/pkgs/([^/]+)/([^/]+)/([^/]+)/([^/]+)/{}$", MetaFile::Path)).unwrap());
+        map.insert(MetaFile::Target, Regex::new(&format!(r"^hab/pkgs/([^/]+)/([^/]+)/([^/]+)/([^/]+)/{}$", MetaFile::Target)).unwrap());
         map
     };
 }
@@ -153,6 +154,14 @@ impl PackageArchive {
     pub fn path(&mut self) -> Result<Option<String>> {
         match self.read_metadata(MetaFile::Path) {
             Ok(data) => Ok(data.cloned()),
+            Err(e) => Err(e),
+        }
+    }
+
+    pub fn target(&mut self) -> Result<PackageTarget> {
+        match self.read_metadata(MetaFile::Target) {
+            Ok(None) => Err(Error::MetaFileNotFound(MetaFile::Target)),
+            Ok(Some(data)) => PackageTarget::from_str(&data),
             Err(e) => Err(e),
         }
     }
@@ -295,6 +304,8 @@ pub trait FromArchive: Sized {
 #[cfg(test)]
 mod test {
     use std::path::PathBuf;
+    use os::system::Uname;
+    use package::Target;
     use super::*;
 
     #[test]
@@ -331,5 +342,46 @@ mod test {
         let tdeps = hart.tdeps().unwrap();
         assert_eq!(1024, tdeps.len());
     }
+
+    #[test]
+    fn reading_artifact_target() {
+        let mut hart = PackageArchive::new(fixtures()
+            .join("unhappyhumans-possums-8.1.4-20160427165340-x86_64-linux.hart"));
+        let target = hart.target().unwrap();
+        assert_eq!(target.platform, "linux");
+        assert_eq!(target.architecture, "x86_64");
+    }
+
+    #[test]
+    fn testing_artifact_valid_for_platform() {
+        let mut hart = PackageArchive::new(fixtures()
+            .join("unhappyhumans-possums-8.1.4-20160427165340-x86_64-linux.hart"));
+        let current_system = Uname {
+            sys_name: "linux".to_string(),
+            node_name: "test_node".to_string(),
+            release: "4.2.0-25-generic".to_string(),
+            version: "#30-Ubuntu SMP Mon Jan 18 12:31:50 UTC 201".to_string(),
+            machine: "x86_64".to_string(),
+        };
+        let target = hart.target().unwrap();
+        let _ = target.valid_for(current_system).unwrap();
+    }
+
+    #[test]
+    #[should_panic]
+    fn testing_artifact_invalid_for_platform() {
+        let mut hart = PackageArchive::new(fixtures()
+            .join("unhappyhumans-possums-8.1.4-20160427165340-x86_64-linux.hart"));
+        let current_system = Uname {
+            sys_name: "windows".to_string(),
+            node_name: "test_node".to_string(),
+            release: "Server 2008 R2".to_string(),
+            version: "6.1.7601".to_string(),
+            machine: "x86_64".to_string(),
+        };
+        let target = hart.target().unwrap();
+        let _ = target.valid_for(current_system).unwrap();
+    }
+
 
 }

--- a/components/core/src/package/archive.rs
+++ b/components/core/src/package/archive.rs
@@ -304,8 +304,7 @@ pub trait FromArchive: Sized {
 #[cfg(test)]
 mod test {
     use std::path::PathBuf;
-    use os::system::Uname;
-    use package::Target;
+    use os::system::{Architecture, Platform};
     use super::*;
 
     #[test]
@@ -348,40 +347,7 @@ mod test {
         let mut hart = PackageArchive::new(fixtures()
             .join("unhappyhumans-possums-8.1.4-20160427165340-x86_64-linux.hart"));
         let target = hart.target().unwrap();
-        assert_eq!(target.platform, "linux");
-        assert_eq!(target.architecture, "x86_64");
+        assert_eq!(target.platform, Platform::Linux);
+        assert_eq!(target.architecture, Architecture::X86_64);
     }
-
-    #[test]
-    fn testing_artifact_valid_for_platform() {
-        let mut hart = PackageArchive::new(fixtures()
-            .join("unhappyhumans-possums-8.1.4-20160427165340-x86_64-linux.hart"));
-        let current_system = Uname {
-            sys_name: "linux".to_string(),
-            node_name: "test_node".to_string(),
-            release: "4.2.0-25-generic".to_string(),
-            version: "#30-Ubuntu SMP Mon Jan 18 12:31:50 UTC 201".to_string(),
-            machine: "x86_64".to_string(),
-        };
-        let target = hart.target().unwrap();
-        let _ = target.valid_for(current_system).unwrap();
-    }
-
-    #[test]
-    #[should_panic]
-    fn testing_artifact_invalid_for_platform() {
-        let mut hart = PackageArchive::new(fixtures()
-            .join("unhappyhumans-possums-8.1.4-20160427165340-x86_64-linux.hart"));
-        let current_system = Uname {
-            sys_name: "windows".to_string(),
-            node_name: "test_node".to_string(),
-            release: "Server 2008 R2".to_string(),
-            version: "6.1.7601".to_string(),
-            machine: "x86_64".to_string(),
-        };
-        let target = hart.target().unwrap();
-        let _ = target.valid_for(current_system).unwrap();
-    }
-
-
 }

--- a/components/core/src/package/install.rs
+++ b/components/core/src/package/install.rs
@@ -23,7 +23,6 @@ use std::str::FromStr;
 
 use error::{Error, Result};
 use fs::{self, PKG_PATH};
-use os::system;
 use package::{Identifiable, MetaFile, PackageIdent, Target, PackageTarget};
 
 #[derive(Clone, Debug)]
@@ -47,7 +46,7 @@ impl PackageInstall {
     pub fn load(ident: &PackageIdent, fs_root_path: Option<&Path>) -> Result<PackageInstall> {
         let package_install = try!(Self::resolve_package_install(ident, fs_root_path));
         let package_target = try!(package_install.target());
-        match package_target.valid_for(try!(system::uname())) {
+        match package_target.validate() {
             Ok(()) => Ok(package_install),
             Err(e) => Err(e),
         }

--- a/components/core/src/package/install.rs
+++ b/components/core/src/package/install.rs
@@ -23,7 +23,8 @@ use std::str::FromStr;
 
 use error::{Error, Result};
 use fs::{self, PKG_PATH};
-use package::{Identifiable, MetaFile, PackageIdent};
+use os::system;
+use package::{Identifiable, MetaFile, PackageIdent, Target, PackageTarget};
 
 #[derive(Clone, Debug)]
 pub struct PackageInstall {
@@ -44,6 +45,17 @@ impl PackageInstall {
     /// An optional `fs_root` path may be provided to search for a package that is mounted on a
     /// filesystem not currently rooted at `/`.
     pub fn load(ident: &PackageIdent, fs_root_path: Option<&Path>) -> Result<PackageInstall> {
+        let package_install = try!(Self::resolve_package_install(ident, fs_root_path));
+        let package_target = try!(package_install.target());
+        match package_target.valid_for(try!(system::uname())) {
+            Ok(()) => Ok(package_install),
+            Err(e) => Err(e),
+        }
+    }
+
+    fn resolve_package_install(ident: &PackageIdent,
+                               fs_root_path: Option<&Path>)
+                               -> Result<PackageInstall> {
         let fs_root_path = fs_root_path.unwrap_or(Path::new("/"));
         let package_root_path = fs_root_path.join(PKG_PATH);
         if !package_root_path.exists() {
@@ -239,6 +251,13 @@ impl PackageInstall {
         match self.read_metafile(MetaFile::SvcGroup) {
             Ok(body) => Ok(Some(body)),
             Err(Error::MetaFileNotFound(MetaFile::SvcGroup)) => Ok(None),
+            Err(e) => Err(e),
+        }
+    }
+
+    pub fn target(&self) -> Result<PackageTarget> {
+        match self.read_metafile(MetaFile::Target) {
+            Ok(body) => PackageTarget::from_str(&body),
             Err(e) => Err(e),
         }
     }

--- a/components/core/src/package/mod.rs
+++ b/components/core/src/package/mod.rs
@@ -16,11 +16,13 @@ pub mod archive;
 pub mod ident;
 pub mod install;
 pub mod plan;
+pub mod target;
 
 pub use self::archive::{FromArchive, PackageArchive};
 pub use self::ident::{Identifiable, PackageIdent};
 pub use self::install::PackageInstall;
 pub use self::plan::Plan;
+pub use self::target::{Target, PackageTarget};
 
 use std::fmt;
 
@@ -38,6 +40,7 @@ pub enum MetaFile {
     Path,
     SvcUser,
     SvcGroup,
+    Target,
 }
 
 impl fmt::Display for MetaFile {
@@ -55,6 +58,7 @@ impl fmt::Display for MetaFile {
             MetaFile::Path => "PATH",
             MetaFile::SvcUser => "SVC_USER",
             MetaFile::SvcGroup => "SVC_GROUP",
+            MetaFile::Target => "TARGET",
         };
         write!(f, "{}", id)
     }

--- a/components/core/src/package/target.rs
+++ b/components/core/src/package/target.rs
@@ -15,88 +15,79 @@
 use std::fmt;
 use std::result;
 use std::str::FromStr;
-use os::system::{uname, Uname};
+use os::system::{Architecture, Platform};
 
 use error::{Error, Result};
 
+
 pub trait Target: fmt::Display + Into<PackageTarget> {
-    fn platform(&self) -> &str;
-    fn architecture(&self) -> &str;
-    fn valid_for(&self, uname: Uname) -> Result<()>;
+    fn validate(&self) -> Result<()>;
 }
 
 /// Describes the platform (operating system/kernel)
 /// and architecture (x86_64, i386, etc..) that a package is built for
 #[derive(RustcEncodable, RustcDecodable, Debug, Clone, Hash)]
 pub struct PackageTarget {
-    pub platform: String,
-    pub architecture: String,
+    pub platform: Platform,
+    pub architecture: Architecture,
 }
 
 impl PackageTarget {
     /// Creates a new package target
     ///
     /// Errors:
-    /// * InvalidPackageTargetPlatform
-    /// * InvalidPackageTargetArchitecture
-    pub fn new<T: Into<String>>(platform: T, architecture: T) -> Self {
-        let valid_platform = PackageTarget::supported_platform(platform).unwrap();
-        let valid_arch = PackageTarget::supported_architecture(architecture).unwrap();
+    /// * InvalidPlatform
+    /// * InvalidArchitecture
+    pub fn new(platform: Platform, architecture: Architecture) -> Self {
         PackageTarget {
-            platform: valid_platform,
-            architecture: valid_arch,
+            platform: platform,
+            architecture: architecture,
         }
     }
 
-    fn supported_platform<T: Into<String>>(value: T) -> Result<String> {
-        let platform = value.into();
-        let valid_platforms = vec!["linux", "windows",];
-        if valid_platforms.iter().any(|&x| x == platform) {
-            Ok(platform)
+    pub fn current_platform() -> Platform {
+        if cfg!(target_os = "windows") {
+            Platform::Windows
         } else {
-            Err(Error::InvalidPackageTargetPlatform(platform))
+            if cfg!(target_os = "linux") {
+                Platform::Linux
+            } else {
+                unimplemented!()
+            }
         }
     }
 
-    fn supported_architecture<T: Into<String>>(value: T) -> Result<String> {
-        let architecture = value.into();
-        let valid_architectures = vec!["x86_64"];
-        if valid_architectures.iter().any(|&x| x == architecture) {
-            Ok(architecture)
+    pub fn current_architecture() -> Architecture {
+        if cfg!(target_arch = "x86_64") {
+            Architecture::X86_64
         } else {
-            Err(Error::InvalidPackageTargetArchitecture(architecture))
+            unimplemented!()
         }
     }
 }
 
 impl Target for PackageTarget {
-    fn platform(&self) -> &str {
-        &self.platform
-    }
-    fn architecture(&self) -> &str {
-        &self.architecture
-    }
-    fn valid_for(&self, uname: Uname) -> Result<()> {
-        let architecture = uname.machine.trim().to_lowercase();
-        let platform = uname.sys_name.trim().to_lowercase();
-        if self.architecture == architecture && self.platform == platform {
+    fn validate(&self) -> Result<()> {
+        let default = PackageTarget::default();
+        if self.architecture == default.architecture && self.platform == default.platform {
             Ok(())
         } else {
             Err(Error::TargetMatchError(format!("Package target ({}-{}) does not match system \
                                                  target ({}-{}).",
                                                 self.architecture,
                                                 self.platform,
-                                                architecture,
-                                                platform,)))
+                                                default.architecture,
+                                                default.platform,)))
         }
     }
 }
 
 impl Default for PackageTarget {
     fn default() -> PackageTarget {
-        let current_system = uname().unwrap();
-        PackageTarget::new(current_system.sys_name.trim().to_lowercase(),
-                           current_system.machine.trim().to_lowercase())
+        PackageTarget {
+            platform: Self::current_platform(),
+            architecture: Self::current_architecture(),
+        }
     }
 }
 
@@ -106,19 +97,16 @@ impl fmt::Display for PackageTarget {
     }
 }
 
-impl AsRef<PackageTarget> for PackageTarget {
-    fn as_ref(&self) -> &PackageTarget {
-        self
-    }
-}
-
 impl FromStr for PackageTarget {
     type Err = Error;
 
     fn from_str(value: &str) -> result::Result<Self, Self::Err> {
         let items: Vec<&str> = value.split("-").collect();
         let (architecture, platform) = match items.len() {
-            2 => (items[0], items[1]),
+            2 => {
+                (try!(Architecture::from_str(items[0].into())),
+                 try!(Platform::from_str(items[1]).into()))
+            }
             _ => return Err(Error::InvalidPackageTarget(value.to_string())),
         };
         Ok(PackageTarget::new(platform, architecture))
@@ -129,24 +117,24 @@ impl FromStr for PackageTarget {
 mod tests {
     use super::*;
     use std::str::FromStr;
-    use os::system::Uname;
+    use os::system::{Architecture, Platform};
 
     #[test]
     fn package_target_matches_current_operating_system() {
         let target = PackageTarget::default();
         if cfg!(target_os = "windows") {
-            assert_eq!(target.platform, "windows");
+            assert_eq!(target.platform, Platform::Windows);
         } else {
-            assert_eq!(target.platform, "linux");
+            assert_eq!(target.platform, Platform::Linux);
         }
-        assert_eq!(target.architecture, "x86_64");
+        assert_eq!(target.architecture, Architecture::X86_64);
     }
 
     #[test]
     fn package_target_from_string() {
         let target = PackageTarget::from_str("x86_64-windows").unwrap();
-        assert_eq!(target.platform, "windows");
-        assert_eq!(target.architecture, "x86_64");
+        assert_eq!(target.platform, Platform::Windows);
+        assert_eq!(target.architecture, Architecture::X86_64);
     }
 
     #[test]
@@ -167,31 +155,32 @@ mod tests {
         let _ = PackageTarget::from_str("i986-linux").unwrap();
     }
 
-    #[test]
-    fn package_target_valid_for_matching_platform_and_architecture() {
-        let target = PackageTarget::from_str("x86_64-linux").unwrap();
-        let _ = target.valid_for(Uname {
-                sys_name: "linux".to_string(),
-                node_name: "test_node".to_string(),
-                release: "4.2.0-25-generic".to_string(),
-                version: "#30-Ubuntu SMP Mon Jan 18 12:31:50 UTC 201".to_string(),
-                machine: "x86_64".to_string(),
-            })
-            .unwrap();
+    fn current_platform_target() -> PackageTarget {
+        if cfg!(target_os = "windows") {
+            PackageTarget::from_str("x86_64-windows").unwrap()
+        } else {
+            PackageTarget::from_str("x86_64-linux").unwrap()
+        }
+    }
 
+    fn unsupported_platform_target() -> PackageTarget {
+        if cfg!(target_os = "windows") {
+            PackageTarget::from_str("x86_64-linux").unwrap()
+        } else {
+            PackageTarget::from_str("x86_64-windows").unwrap()
+        }
+    }
+
+    #[test]
+    fn package_target_validate_matching_platform_and_architecture() {
+        let target = current_platform_target();
+        let _ = target.validate().unwrap();
     }
 
     #[test]
     #[should_panic]
-    fn package_target_invalid_for_different_platform() {
-        let target = PackageTarget::from_str("x86_64-windows").unwrap();
-        let _ = target.valid_for(Uname {
-                sys_name: "linux".to_string(),
-                node_name: "test_node".to_string(),
-                release: "4.2.0-25-generic".to_string(),
-                version: "#30-Ubuntu SMP Mon Jan 18 12:31:50 UTC 201".to_string(),
-                machine: "x86_64".to_string(),
-            })
-            .unwrap();
+    fn package_target_does_not_validate_different_platform() {
+        let target = unsupported_platform_target();
+        let _ = target.validate().unwrap();
     }
 }

--- a/components/core/src/package/target.rs
+++ b/components/core/src/package/target.rs
@@ -1,0 +1,197 @@
+// Copyright (c) 2016 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt;
+use std::result;
+use std::str::FromStr;
+use os::system::{uname, Uname};
+
+use error::{Error, Result};
+
+pub trait Target: fmt::Display + Into<PackageTarget> {
+    fn platform(&self) -> &str;
+    fn architecture(&self) -> &str;
+    fn valid_for(&self, uname: Uname) -> Result<()>;
+}
+
+/// Describes the platform (operating system/kernel)
+/// and architecture (x86_64, i386, etc..) that a package is built for
+#[derive(RustcEncodable, RustcDecodable, Debug, Clone, Hash)]
+pub struct PackageTarget {
+    pub platform: String,
+    pub architecture: String,
+}
+
+impl PackageTarget {
+    /// Creates a new package target
+    ///
+    /// Errors:
+    /// * InvalidPackageTargetPlatform
+    /// * InvalidPackageTargetArchitecture
+    pub fn new<T: Into<String>>(platform: T, architecture: T) -> Self {
+        let valid_platform = PackageTarget::supported_platform(platform).unwrap();
+        let valid_arch = PackageTarget::supported_architecture(architecture).unwrap();
+        PackageTarget {
+            platform: valid_platform,
+            architecture: valid_arch,
+        }
+    }
+
+    fn supported_platform<T: Into<String>>(value: T) -> Result<String> {
+        let platform = value.into();
+        let valid_platforms = vec!["linux", "windows",];
+        if valid_platforms.iter().any(|&x| x == platform) {
+            Ok(platform)
+        } else {
+            Err(Error::InvalidPackageTargetPlatform(platform))
+        }
+    }
+
+    fn supported_architecture<T: Into<String>>(value: T) -> Result<String> {
+        let architecture = value.into();
+        let valid_architectures = vec!["x86_64"];
+        if valid_architectures.iter().any(|&x| x == architecture) {
+            Ok(architecture)
+        } else {
+            Err(Error::InvalidPackageTargetArchitecture(architecture))
+        }
+    }
+}
+
+impl Target for PackageTarget {
+    fn platform(&self) -> &str {
+        &self.platform
+    }
+    fn architecture(&self) -> &str {
+        &self.architecture
+    }
+    fn valid_for(&self, uname: Uname) -> Result<()> {
+        let architecture = uname.machine.trim().to_lowercase();
+        let platform = uname.sys_name.trim().to_lowercase();
+        if self.architecture == architecture && self.platform == platform {
+            Ok(())
+        } else {
+            Err(Error::TargetMatchError(format!("Package target ({}-{}) does not match system \
+                                                 target ({}-{}).",
+                                                self.architecture,
+                                                self.platform,
+                                                architecture,
+                                                platform,)))
+        }
+    }
+}
+
+impl Default for PackageTarget {
+    fn default() -> PackageTarget {
+        let current_system = uname().unwrap();
+        PackageTarget::new(current_system.sys_name.trim().to_lowercase(),
+                           current_system.machine.trim().to_lowercase())
+    }
+}
+
+impl fmt::Display for PackageTarget {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}-{}", self.architecture, self.platform)
+    }
+}
+
+impl AsRef<PackageTarget> for PackageTarget {
+    fn as_ref(&self) -> &PackageTarget {
+        self
+    }
+}
+
+impl FromStr for PackageTarget {
+    type Err = Error;
+
+    fn from_str(value: &str) -> result::Result<Self, Self::Err> {
+        let items: Vec<&str> = value.split("-").collect();
+        let (architecture, platform) = match items.len() {
+            2 => (items[0], items[1]),
+            _ => return Err(Error::InvalidPackageTarget(value.to_string())),
+        };
+        Ok(PackageTarget::new(platform, architecture))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+    use os::system::Uname;
+
+    #[test]
+    fn package_target_matches_current_operating_system() {
+        let target = PackageTarget::default();
+        if cfg!(target_os = "windows") {
+            assert_eq!(target.platform, "windows");
+        } else {
+            assert_eq!(target.platform, "linux");
+        }
+        assert_eq!(target.architecture, "x86_64");
+    }
+
+    #[test]
+    fn package_target_from_string() {
+        let target = PackageTarget::from_str("x86_64-windows").unwrap();
+        assert_eq!(target.platform, "windows");
+        assert_eq!(target.architecture, "x86_64");
+    }
+
+    #[test]
+    #[should_panic]
+    fn package_target_with_reversed_target_string() {
+        let _ = PackageTarget::from_str("linux-x86_64").unwrap();
+    }
+
+    #[test]
+    #[should_panic]
+    fn package_target_with_invalid_platform() {
+        let _ = PackageTarget::from_str("x86_64-intermezzos").unwrap();
+    }
+
+    #[test]
+    #[should_panic]
+    fn package_target_with_invalid_architecture() {
+        let _ = PackageTarget::from_str("i986-linux").unwrap();
+    }
+
+    #[test]
+    fn package_target_valid_for_matching_platform_and_architecture() {
+        let target = PackageTarget::from_str("x86_64-linux").unwrap();
+        let _ = target.valid_for(Uname {
+                sys_name: "linux".to_string(),
+                node_name: "test_node".to_string(),
+                release: "4.2.0-25-generic".to_string(),
+                version: "#30-Ubuntu SMP Mon Jan 18 12:31:50 UTC 201".to_string(),
+                machine: "x86_64".to_string(),
+            })
+            .unwrap();
+
+    }
+
+    #[test]
+    #[should_panic]
+    fn package_target_invalid_for_different_platform() {
+        let target = PackageTarget::from_str("x86_64-windows").unwrap();
+        let _ = target.valid_for(Uname {
+                sys_name: "linux".to_string(),
+                node_name: "test_node".to_string(),
+                release: "4.2.0-25-generic".to_string(),
+                version: "#30-Ubuntu SMP Mon Jan 18 12:31:50 UTC 201".to_string(),
+                machine: "x86_64".to_string(),
+            })
+            .unwrap();
+    }
+}


### PR DESCRIPTION
Adds validation of the TARGET (platform and architecture) from the package to the host running/installing the package.

This impacts both the `hab` and `hab-sup` executables and prevents the installation or execution of packages whose target does not match the host OS.

Signed-off-by: Steven Murawski <steven.murawski@gmail.com>