### PR TITLE
Make `archive_name` platform/architecture aware

### DIFF
--- a/components/core/src/package/ident.rs
+++ b/components/core/src/package/ident.rs
@@ -19,6 +19,7 @@ use std::str::FromStr;
 
 use regex::Regex;
 
+use package::PackageTarget;
 use error::{Error, Result};
 
 pub trait Identifiable: fmt::Display + Into<PackageIdent> {
@@ -85,11 +86,14 @@ impl PackageIdent {
 
     pub fn archive_name(&self) -> Option<String> {
         if self.fully_qualified() {
-            Some(format!("{}-{}-{}-{}-x86_64-linux.hart",
+            let default_target = PackageTarget::default();
+            Some(format!("{}-{}-{}-{}-{}-{}.hart",
                          self.origin,
                          self.name,
                          self.version.as_ref().unwrap(),
-                         self.release.as_ref().unwrap()))
+                         self.release.as_ref().unwrap(),
+                         default_target.architecture,
+                         default_target.platform))
         } else {
             None
         }


### PR DESCRIPTION
move from hard coded `x86_64-linux` to the current OS and architecture and for the package name.

Signed-off-by: Steven Murawski <steven.murawski@gmail.com>