### PR TITLE
Fix running builds with packaged builder worker

### DIFF
--- a/components/builder-worker/habitat/plan.sh
+++ b/components/builder-worker/habitat/plan.sh
@@ -11,6 +11,8 @@ pkg_build_deps=(core/make core/cmake core/protobuf core/protobuf-rust core/coreu
   core/rust core/gcc core/pkg-config)
 bin="bldr-worker"
 pkg_svc_run="$bin start -c ${pkg_svc_path}/config.toml"
+pkg_svc_user="root"
+pkg_svc_group="root"
 
 do_prepare() {
   # Can be either `--release` or `--debug` to determine cargo build strategy

--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -2068,6 +2068,7 @@ do_default_build_service() {
       build_line "Writing ${pkg_prefix}/run script to run ${pkg_svc_run} as ${pkg_svc_user}:${pkg_svc_group}"
       cat <<EOT >> $pkg_prefix/run
 #!/bin/sh
+export HOME=$pkg_svc_data_path
 cd $pkg_svc_path
 
 if [ "\$(whoami)" = "root" ]; then


### PR DESCRIPTION
This PR contains two small changes which were stopping the package builder-worker from actually building packages.

1. We need to set the `$HOME` environment variable to something more appropriate instead of what is inherited from the environment of the calling shell
1. The worker starts a studio which *must* be run as root and can't be run as `hab`