### PR TITLE
Fix unhandled case in build logfile name detection

### DIFF
--- a/components/studio/bin/hab-studio.sh
+++ b/components/studio/bin/hab-studio.sh
@@ -609,7 +609,11 @@ record() {
     fi
     name="$(awk -F '=' '/^pkg_name/ {print $2}' $1/plan.sh 2>/dev/null | sed "s/['\"]//g")"
     if [[ -z "${name:-}" ]]; then
-      name="unknown"
+      if [[ -f $1/habitat/plan.sh ]]; then
+        name="$(awk -F '=' '/^pkg_name/ {print $2}' $1/habitat/plan.sh 2>/dev/null | sed "s/['\"]//g")"
+      else
+        name="unknown"
+      fi
     fi
     shift
     cmd="${1:-${SHELL:-sh} -l}"; shift


### PR DESCRIPTION
Given `myapp/habitat/plan.sh`,  `hab pkg build myapp` will look for the plan in both `myapp` and `myapp/habitat`. 

Current behavior for `record()` in master doesn't handle this scenario and will generate a `unknown.TIMESTAMP.log` file.  This PR fixes this and causes `record()` to mimic the behavior of `hab pkg build`.

I'm not very happy with this solution, since any changes to habitats `plan.sh` detection behavior will likely break this.  If there are any ideas that make this cleaner, I'd be happy to update.  

Signed-off-by: Scott Macfarlane <macfarlane.scott@gmail.com>