### PR TITLE
Adding windows user implementations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,32 +1,10 @@
 [root]
-name = "habitat_sup"
+name = "habitat_win_users"
 version = "0.0.0"
 dependencies = [
- "ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "clap 2.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "habitat_common 0.0.0",
- "habitat_core 0.0.0",
- "habitat_depot_client 0.0.0",
- "handlebars 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.9.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "iron 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)",
- "router 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "temp_utp 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "threadpool 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "uuid 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "wonder 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "widestring 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -198,6 +176,7 @@ dependencies = [
  "habitat_core 0.0.0",
  "habitat_depot_client 0.0.0",
  "habitat_http_client 0.0.0",
+ "handlebars 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.9.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -437,6 +416,7 @@ version = "0.0.0"
 dependencies = [
  "errno 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "gcc 0.3.38 (registry+https://github.com/rust-lang/crates.io-index)",
+ "habitat_win_users 0.0.0",
  "hyper 0.9.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libarchive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -563,6 +543,37 @@ dependencies = [
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zmq 0.8.0 (git+https://github.com/erickt/rust-zmq.git)",
+]
+
+[[package]]
+name = "habitat_sup"
+version = "0.0.0"
+dependencies = [
+ "ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "habitat_common 0.0.0",
+ "habitat_core 0.0.0",
+ "habitat_depot_client 0.0.0",
+ "handlebars 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.9.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iron 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "router 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "temp_utp 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "threadpool 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wonder 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1473,6 +1484,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "widestring"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "winapi"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1638,6 +1654,7 @@ dependencies = [
 "checksum uuid 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1a9ff57156caf7e22f37baf3c9d8f6ce8194842c23419dafcb0716024514d162"
 "checksum vec_map 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cac5efe5cb0fa14ec2f84f83c701c562ee63f6dcc680861b21d65c682adfb05f"
 "checksum walkdir 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "98da26f00240118fbb7a06fa29579d1b39d34cd6e0505ea5c125b26d5260a967"
+"checksum widestring 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7157704c2e12e3d2189c507b7482c52820a16dfa4465ba91add92f266667cadb"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 "checksum wonder 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "07666280a40a706383d9c32f5783c213ca4c9d745102d3f0c9916f5675aad563"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,7 @@ clone_folder: c:\projects\habitat
 environment:
   matrix:
     - hab_build_action: "test;build"
-      hab_components: "core;http-client;builder-protocol;builder-depot-client;common;hab"
+      hab_components: "core;http-client;builder-protocol;builder-depot-client;common;hab;sup;win-users"
 
 install:
   - ps: ./build.ps1 -Configure -SkipBuild

--- a/components/core/Cargo.toml
+++ b/components/core/Cargo.toml
@@ -25,6 +25,9 @@ url = "*"
 [target.'cfg(not(windows))'.dependencies]
 users = "*"
 
+[target.'cfg(windows)'.dependencies.habitat_win_users]
+path = "../win-users"
+
 [dev-dependencies]
 hyper = "*"
 tempdir = "*"

--- a/components/core/src/lib.rs
+++ b/components/core/src/lib.rs
@@ -34,6 +34,9 @@ extern crate url as extern_url;
 #[cfg(not(windows))]
 extern crate users as linux_users;
 
+#[cfg(windows)]
+extern crate habitat_win_users;
+
 pub use self::error::{Error, Result};
 
 pub mod config;

--- a/components/core/src/os/filesystem/windows.rs
+++ b/components/core/src/os/filesystem/windows.rs
@@ -17,7 +17,7 @@ use std::ffi::CStr;
 use std::path::Path;
 use std::io;
 
-pub fn chown(r_path: *const c_char, uid: u32, gid: u32) -> c_int {
+pub fn chown(r_path: *const c_char, uid: String, gid: String) -> c_int {
     unimplemented!();
 }
 

--- a/components/core/src/os/users/linux.rs
+++ b/components/core/src/os/users/linux.rs
@@ -40,3 +40,7 @@ pub fn get_effective_uid() -> u32 {
 pub fn get_home_for_user(username: &str) -> Option<PathBuf> {
     linux_users::get_user_by_name(username).map(|u| PathBuf::from(u.home_dir()))
 }
+
+pub fn root_level_account() -> String {
+    "root".to_string()
+}

--- a/components/core/src/os/users/windows.rs
+++ b/components/core/src/os/users/windows.rs
@@ -12,26 +12,40 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::env;
 use std::path::PathBuf;
+
+use habitat_win_users::account::Account;
 
 extern "C" {
     pub fn GetUserTokenStatus() -> u32;
 }
 
-pub fn get_uid_by_name(owner: &str) -> Option<u32> {
-    unimplemented!();
+fn get_sid_by_name(name: &str) -> Option<String> {
+  match Account::from_name(name) {
+    Some(acct) => Some(acct.sid.to_string()),
+    None => None
+  }
 }
 
-pub fn get_gid_by_name(group: &str) -> Option<u32> {
-    unimplemented!();
+pub fn get_uid_by_name(owner: &str) -> Option<String> {
+  get_sid_by_name(owner)
+}
+
+pub fn get_gid_by_name(group: &str) -> Option<String> {
+  get_sid_by_name(group)
 }
 
 pub fn get_current_username() -> Option<String> {
-    unimplemented!();
+  match env::var("USERNAME").ok() {
+    Some(username) => Some(username.to_lowercase()),
+    None => None
+  }
 }
 
+// this is a no-op on windows
 pub fn get_current_groupname() -> Option<String> {
-    unimplemented!();
+    Some(String::new())
 }
 
 pub fn get_effective_uid() -> u32 {
@@ -40,4 +54,27 @@ pub fn get_effective_uid() -> u32 {
 
 pub fn get_home_for_user(username: &str) -> Option<PathBuf> {
     unimplemented!();
+}
+
+pub fn root_level_account() -> String {
+    env::var("COMPUTERNAME").unwrap().to_uppercase() + "$"
+}
+
+#[cfg(test)]
+mod tests {
+    use std::env;
+
+    use super::*;
+
+    #[test]
+    fn downcase_current_username() {
+      env::set_var("USERNAME", "uSer");
+      assert_eq!(get_current_username().unwrap(), "user")
+    }
+
+    #[test]
+    fn return_none_when_no_user() {
+      env::remove_var("USERNAME");
+      assert_eq!(get_current_username(), None)
+    }
 }

--- a/components/sup/src/package/hooks.rs
+++ b/components/sup/src/package/hooks.rs
@@ -22,6 +22,7 @@ use handlebars::Handlebars;
 
 use error::{Error, Result};
 use hcore::util;
+use hcore::os::users;
 use package::Package;
 use service_config::{ServiceConfig, never_escape_fn};
 use util::convert;
@@ -126,8 +127,8 @@ impl Hook {
     #[cfg(any(target_os="linux", target_os="macos"))]
     fn run_platform(&self, cmd: &mut Command) -> Result<()> {
         use std::os::unix::process::CommandExt;
-        let uid = hab_users::user_name_to_uid(&self.user);
-        let gid = hab_users::group_name_to_gid(&self.group);
+        let uid = users::get_uid_by_name(&self.user);
+        let gid = users::get_gid_by_name(&self.group);
         if let None = uid {
             panic!("Can't determine uid");
         }

--- a/components/sup/src/supervisor.rs
+++ b/components/sup/src/supervisor.rs
@@ -27,14 +27,13 @@ use std::process::{Command, Stdio, Child};
 use std::thread;
 
 use hcore;
-use hcore::os::process;
+use hcore::os::{process, users};
 use hcore::package::PackageIdent;
 use libc::c_int;
 use time::{Duration, SteadyTime};
 
 use error::{Result, Error};
 use util::signals;
-use util::users as hab_users;
 
 const PIDFILE_NAME: &'static str = "PID";
 static LOGKEY: &'static str = "SV";
@@ -201,8 +200,8 @@ impl Supervisor {
     #[cfg(any(target_os="linux", target_os="macos"))]
     fn start_platform(&mut self, cmd: &mut Command) -> Result<()> {
         use std::os::unix::process::CommandExt;
-        let uid = hab_users::user_name_to_uid(&self.runtime_config.svc_user);
-        let gid = hab_users::group_name_to_gid(&self.runtime_config.svc_group);
+        let uid = users::get_uid_by_name(&self.runtime_config.svc_user);
+        let gid = users::get_gid_by_name(&self.runtime_config.svc_group);
         if let None = uid {
             panic!("Can't determine uid");
         }

--- a/components/sup/src/util/users.rs
+++ b/components/sup/src/util/users.rs
@@ -64,10 +64,10 @@ fn check_pkg_user_and_group(pkg_install: &PackageInstall) -> Result<Option<(Stri
             let current_user = current_user.unwrap();
             let current_group = current_group.unwrap();
 
-            if current_user == "root" {
+            if current_user == users::root_level_account() {
                 Ok(Some((user, group)))
             } else {
-                if current_user == user && current_group == group {
+                if current_user == user && (cfg!(target_os = "windows") || current_group == group) {
                     // ok, sup is running as svc_user/svc_group already
                     Ok(Some((user, group)))
                 } else {
@@ -89,7 +89,7 @@ fn get_default_user_and_group() -> Result<(String, String)> {
     let uid = users::get_uid_by_name(DEFAULT_USER);
     let gid = users::get_gid_by_name(DEFAULT_GROUP);
     match (uid, gid) {
-        (Some(uid), Some(gid)) => return Ok((DEFAULT_USER.to_string(), DEFAULT_GROUP.to_string())),
+        (Some(_), Some(_)) => return Ok((DEFAULT_USER.to_string(), DEFAULT_GROUP.to_string())),
         _ => {
             debug!("hab:hab does NOT exist");
             let user = users::get_current_username();
@@ -119,12 +119,4 @@ pub fn get_user_and_group(pkg_install: &PackageInstall) -> Result<(String, Strin
         let defaults = try!(get_default_user_and_group());
         Ok(defaults)
     }
-}
-
-pub fn user_name_to_uid(user: &str) -> Option<u32> {
-    users::get_uid_by_name(user)
-}
-
-pub fn group_name_to_gid(group: &str) -> Option<u32> {
-    users::get_gid_by_name(group)
 }

--- a/components/win-users/Cargo.toml
+++ b/components/win-users/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "habitat_win_users"
+version = "0.0.0"
+authors = ["Matt Wrock <matt@mattwrock.com>"]
+description = "Habitat library for win32 account api calls"
+workspace = "../../"
+
+[target.'cfg(windows)'.dependencies]
+kernel32-sys = "*"
+widestring = "*"
+winapi = "*"

--- a/components/win-users/src/account.rs
+++ b/components/win-users/src/account.rs
@@ -1,0 +1,129 @@
+// Copyright (c) 2016 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::ptr::null_mut;
+use std::io::Error;
+
+use widestring::WideCString;
+use winapi::{LPCWSTR, BOOL, PSID, PSID_NAME_USE, LPDWORD, SID_NAME_USE};
+use winapi::winerror::*;
+
+use super::sid::Sid;
+
+extern "system" {
+  fn LookupAccountNameW(
+      lpSystemName: LPCWSTR, lpAccountName: LPCWSTR, Sid: PSID, 
+      cbSid: LPDWORD, ReferencedDomainName: LPCWSTR,
+      cchReferencedDomainName: LPDWORD, peUse: PSID_NAME_USE,
+  ) -> BOOL;
+}
+
+pub struct Account {
+  pub name: String,
+  pub system_name: Option<String>,
+  pub domain: String,
+  pub account_type: SID_NAME_USE,
+  pub sid: Sid
+}
+
+impl Account {
+  pub fn from_name(name: &str) -> Option<Account> {
+    lookup_account(name, None)
+  }
+
+  pub fn from_name_and_system(name: &str, system_name: &str) -> Option<Account> {
+    lookup_account(name, Some(system_name.to_string()))
+  }
+}
+
+fn lookup_account(name: &str, system_name: Option<String>) -> Option<Account> {
+  let mut sid_size: u32 = 0;
+  let mut domain_size: u32 = 0;
+  let wide = WideCString::from_str(name).unwrap();
+  unsafe {
+    LookupAccountNameW(null_mut(), wide.as_ptr(), null_mut(), &mut sid_size as LPDWORD, null_mut(), &mut domain_size as LPDWORD, null_mut())
+  };
+  match Error::last_os_error().raw_os_error().unwrap() as u32 {
+      ERROR_INSUFFICIENT_BUFFER => {},
+      ERROR_NONE_MAPPED => return None,
+      _ => panic!("Error while looking up account for {}: {}", name, Error::last_os_error())
+  }
+
+  let mut sid: Vec<u8> = Vec::with_capacity(sid_size as usize);
+  let mut domain: Vec<u16> = Vec::with_capacity(domain_size as usize);
+  let mut sid_type = SID_NAME_USE(0);
+
+  let ret = unsafe {
+    LookupAccountNameW(null_mut(), wide.as_ptr(), sid.as_mut_ptr() as PSID, &mut sid_size as LPDWORD, domain.as_mut_ptr(), &mut domain_size as LPDWORD, &mut sid_type as PSID_NAME_USE)
+  };
+  if ret == 0 {
+    panic!("Failed to retrieve SID for {}: {}", name, Error::last_os_error());
+  }
+  unsafe { 
+    domain.set_len(domain_size as usize);
+    sid.set_len(sid_size as usize);
+  }
+  let domain_str = WideCString::from_vec(domain).unwrap().to_string_lossy();
+  Some(Account {name: name.to_string(), system_name: system_name, domain: domain_str, account_type: sid_type, sid: Sid {raw: sid}})
+}
+
+#[cfg(test)]
+mod tests {
+  use std::env;
+
+  use winapi::winnt::{SidTypeUser, SidTypeWellKnownGroup};
+
+  use super::*;
+
+  #[test]
+  fn real_account_returns_some() {
+    assert_eq!(Account::from_name("Administrator").is_some(), true)
+  }
+
+  #[test]
+  fn bogus_account_returns_none() {
+    assert_eq!(Account::from_name("bogus").is_none(), true)
+  }
+
+  #[test]
+  fn user_account_returns_user_type() {
+    let acct_type = Account::from_name("Administrator").unwrap().account_type;
+    assert_eq!(acct_type, SidTypeUser)
+  }
+
+  #[test]
+  fn local_user_account_returns_local_machine_as_domain() {
+    let acct_domain = Account::from_name("Administrator").unwrap().domain;
+    assert_eq!(acct_domain, env::var("COMPUTERNAME").unwrap())
+  }
+
+  #[test]
+  fn well_known_group_account_returns_correct_type() {
+    let acct_type = Account::from_name("Everyone").unwrap().account_type;
+    assert_eq!(acct_type, SidTypeWellKnownGroup)
+  }
+
+  #[test]
+  fn well_known_group_account_has_well_known_sid() {
+    let sid = Account::from_name("Everyone").unwrap().sid;
+    assert_eq!(sid.to_string(), "S-1-1-0")
+  }
+
+  #[test]
+  fn mixing_case_returns_same_account() {
+    let lower_sid = Account::from_name("administrator").unwrap().sid;
+    let upper_sid = Account::from_name("ADMINISTRATOR").unwrap().sid;
+    assert_eq!(lower_sid.to_string(), upper_sid.to_string())
+  }
+}

--- a/components/win-users/src/lib.rs
+++ b/components/win-users/src/lib.rs
@@ -12,17 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[allow(unused_variables)]
-#[cfg(windows)]
-mod windows;
+extern crate kernel32;
+extern crate widestring;
+extern crate winapi;
 
-#[cfg(windows)]
-pub use self::windows::{get_uid_by_name, get_gid_by_name, get_effective_uid, get_home_for_user,
-                        get_current_username, get_current_groupname, root_level_account};
-
-#[cfg(not(windows))]
-pub mod linux;
-
-#[cfg(not(windows))]
-pub use self::linux::{get_uid_by_name, get_gid_by_name, get_effective_uid, get_home_for_user,
-                      get_current_username, get_current_groupname, root_level_account};
+pub mod account;
+pub mod sid;

--- a/components/win-users/src/sid.rs
+++ b/components/win-users/src/sid.rs
@@ -1,0 +1,45 @@
+// Copyright (c) 2016 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::ptr::null_mut;
+use std::io::Error;
+
+use kernel32::LocalFree;
+use widestring::WideCString;
+use winapi::{HLOCAL, LPCWSTR, BOOL, PSID};
+
+extern "system" {
+  fn ConvertSidToStringSidW(Sid: PSID, StringSid: LPCWSTR) -> BOOL;
+}
+
+pub struct Sid {
+  pub raw: Vec<u8>
+}
+
+impl Sid {
+  pub fn to_string(&self) -> String {
+    let mut buffer: LPCWSTR = null_mut();
+    let ret = unsafe {
+      ConvertSidToStringSidW(self.raw.as_ptr() as PSID, (&mut buffer as *mut LPCWSTR) as LPCWSTR)
+    };
+    if ret == 0 {
+      panic!("Failed to convert sid to string: {}", Error::last_os_error());
+    }
+    else {
+      let widestr = unsafe { WideCString::from_ptr_str(buffer) };
+      unsafe { LocalFree(buffer as HLOCAL) };
+      widestr.to_string_lossy()
+    }
+  }
+}

--- a/support/ci/appveyor.ps1
+++ b/support/ci/appveyor.ps1
@@ -9,14 +9,11 @@ $RunTests = (git diff master --name-only |
 
 foreach ($BuildAction in ($env:hab_build_action -split ';')) {
     if (($RunTests -or (test-path env:HAB_FORCE_BUILD)) -and ($BuildAction -like 'build')) {
-        @('hab', 'sup') |
-        foreach-object {
-            Write-Host "Building $_..."
-            pushd "c:/projects/habitat/components/$_"
-            cargo build
-            if ($LASTEXITCODE -ne 0) {exit $LASTEXITCODE}
-            popd
-        }
+        Write-Host "Building hab..."
+        pushd "c:/projects/habitat/components/hab"
+        cargo build
+        if ($LASTEXITCODE -ne 0) {exit $LASTEXITCODE}
+        popd
         ./target/debug/hab.exe --version
         if ($LASTEXITCODE -ne 0) {exit $LASTEXITCODE}            
     }


### PR DESCRIPTION
This adds a new crate to wrap windows api calls around user calls and is called from core. `cargo test` now passes for the superviso on windows and the supervisor no longer needs a `SVC_GROUP` to run. Also the machine account is given the same "root" privileges we give to `root` on linux.