### PR TITLE
Add post-processing infra to builder-worker

### DIFF
--- a/components/builder-vault/src/server/mod.rs
+++ b/components/builder-vault/src/server/mod.rs
@@ -87,7 +87,10 @@ impl Dispatcher for Worker {
             "ProjectDelete" => handlers::project_delete(message, sock, state),
             "ProjectGet" => handlers::project_get(message, sock, state),
             "ProjectUpdate" => handlers::project_update(message, sock, state),
-            _ => panic!("unhandled message"),
+            _ => {
+                debug!("dispatch: unhandled message: {}", message.message_id());
+                Ok(())
+            }
         }
     }
 

--- a/components/builder-worker/src/runner/postprocessor.rs
+++ b/components/builder-worker/src/runner/postprocessor.rs
@@ -1,0 +1,128 @@
+// Copyright (c) 2016 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use error::{Error, Result};
+use std::path::{Path, PathBuf};
+use toml;
+
+use hab_core::package::archive::PackageArchive;
+use hab_core::config::{ConfigFile, ParseInto};
+use hab_core;
+
+use depot_client;
+use {PRODUCT, VERSION};
+use super::workspace::Workspace;
+
+/// Postprocessing config file name
+const CONFIG_FILE: &'static str = "builder.toml";
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Publish {
+    /// Whether publish is enabled
+    pub enabled: bool,
+    /// URL to Depot API
+    pub url: String,
+}
+
+impl Publish {
+    pub fn run(&mut self, archive: &mut PackageArchive, auth_token: &str) -> bool {
+        if !self.enabled {
+            return true;
+        }
+
+        debug!("post process: publish (url: {})", self.url);
+
+        // Things to solve right now
+        // * Where do we get the token for authentication?
+        // * Should the workers ask for a lease from the JobSrv?
+        let client = depot_client::Client::new(&self.url, PRODUCT, VERSION, None).unwrap();
+        if let Some(err) = client.x_put_package(archive, auth_token).err() {
+            error!("post processing error, ERR={:?}", err);
+            return false;
+        };
+        true
+    }
+}
+
+impl Default for Publish {
+    fn default() -> Self {
+        Publish {
+            enabled: false,
+            url: hab_core::url::default_depot_url(),
+        }
+    }
+}
+
+impl ConfigFile for Publish {
+    type Error = Error;
+
+    fn from_toml(toml: toml::Value) -> Result<Self> {
+        let mut cfg = Publish::default();
+        try!(toml.parse_into("publish.enabled", &mut cfg.enabled));
+        try!(toml.parse_into("publish.url", &mut cfg.url));
+        Ok(cfg)
+    }
+}
+
+pub struct PostProcessor {
+    config_path: PathBuf,
+}
+
+impl PostProcessor {
+    pub fn new(workspace: &Workspace) -> Self {
+        let parent_path = Path::new(workspace.job.get_project().get_plan_path()).parent().unwrap();
+        let file_path = workspace.src().join(parent_path.join(CONFIG_FILE));
+
+        PostProcessor { config_path: file_path }
+    }
+
+    pub fn run(&mut self, archive: &mut PackageArchive, auth_token: &str) -> bool {
+        if !self.config_path.exists() {
+            debug!("no post processing config - skipping");
+            return true;
+        }
+
+        debug!("starting post processing");
+        let mut cfg = match Publish::from_file(&self.config_path) {
+            Ok(value) => value,
+            Err(e) => {
+                debug!("failed to parse config file! {:?}", e);
+                return false;
+            }
+        };
+        cfg.run(archive, auth_token)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use toml;
+    use hab_core::config::ConfigFile;
+
+    #[test]
+    fn test_publish_config_from_toml() {
+        let config_toml = r#"
+        [publish]
+        enabled = false
+        url = "https://willem.habitat.sh/v1/depot"
+        "#;
+
+        let root: toml::Value = config_toml.parse().unwrap();
+        let cfg = Publish::from_toml(root).unwrap();
+
+        assert_eq!("https://willem.habitat.sh/v1/depot", cfg.url);
+        assert_eq!(false, cfg.enabled);
+    }
+}

--- a/components/core/src/config.rs
+++ b/components/core/src/config.rs
@@ -152,6 +152,21 @@ impl ParseInto<Option<String>> for toml::Value {
     }
 }
 
+impl ParseInto<bool> for toml::Value {
+    fn parse_into(&self, field: &'static str, out: &mut bool) -> Result<bool> {
+        if let Some(val) = self.lookup(field) {
+            if let Some(v) = val.as_bool() {
+                *out = v as bool;
+                Ok(true)
+            } else {
+                Err(Error::ConfigInvalidString(field))
+            }
+        } else {
+            Ok(false)
+        }
+    }
+}
+
 impl ParseInto<usize> for toml::Value {
     fn parse_into(&self, field: &'static str, out: &mut usize) -> Result<bool> {
         if let Some(val) = self.lookup(field) {

--- a/components/net/src/oauth/github.rs
+++ b/components/net/src/oauth/github.rs
@@ -119,7 +119,15 @@ impl GitHubClient {
             let err: HashMap<String, String> = try!(json::decode(&body));
             return Err(Error::GitHubAPI(rep.status, err));
         }
-        let repo: Repo = json::decode(&body).unwrap();
+
+        let repo: Repo = match json::decode(&body) {
+            Ok(r) => r,
+            Err(e) => {
+                debug!("github repo decode failed: {}. response body: {}", e, body);
+                return Err(Error::from(e));
+            }
+        };
+
         Ok(repo)
     }
 
@@ -211,7 +219,7 @@ pub struct Repo {
     pub owner: User,
     pub private: bool,
     pub html_url: String,
-    pub description: String,
+    pub description: Option<String>,
     pub fork: bool,
     pub url: String,
     pub forks_url: String,


### PR DESCRIPTION
Signed-off-by: Salim Alam <salam@chef.io>

This change adds an infra for post-processing builder builds. The post-processing is configured and driven with a 'builder.toml' file that lives as a peer of the plan.sh. Currently, there is only a single post-processor (publish) that is available and ready to be enabled. This change also contains some minor fixes that needed to be made to unblock this code and make debugging easier in the future.