### PR TITLE
Fix broken platform support for MacOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,6 +198,7 @@ dependencies = [
  "habitat_core 0.0.0",
  "habitat_depot_client 0.0.0",
  "habitat_http_client 0.0.0",
+ "handlebars 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.9.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/core/src/os/system/mod.rs
+++ b/components/core/src/os/system/mod.rs
@@ -40,6 +40,7 @@ pub enum Architecture {
 pub enum Platform {
     Linux,
     Windows,
+    MacOS,
 }
 
 #[derive(Debug)]
@@ -85,6 +86,7 @@ impl FromStr for Platform {
         match platform.as_ref() {
             "linux" => Ok(Platform::Linux),
             "windows" => Ok(Platform::Windows),
+            "macos" => Ok(Platform::MacOS),
             _ => return Err(Error::InvalidPlatform(value.to_string())),
         }
     }


### PR DESCRIPTION
With the addition of the packaging system becoming aware of
PackageTarget and Architecture we mistakenly left off support
for MacOS. This will add the MacOS support to these new functions
and also improve the test cases to catch this problem if/when we add
additional platforms and architectures.

![gif-keyboard-10920606898101022657](https://cloud.githubusercontent.com/assets/54036/20286742/492f23f4-aa7d-11e6-8761-05d3cf04575e.gif)
