### PR TITLE
Add depot example URL to CLI help

### DIFF
--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -88,7 +88,7 @@ pub fn get() -> App<'static, 'static> {
                     (aliases: &["d", "do", "dow", "down", "downl", "downlo", "downloa"])
                     (@arg ORIGIN: +required "The origin name")
                     (@arg REVISION: "The key revision")
-                    (@arg DEPOT_URL: -u --url +takes_value {valid_url} "Use a specific Depot URL")
+                    (@arg DEPOT_URL: -u --url +takes_value {valid_url} "Use a specific Depot URL (ex: http://depot.example.com/v1/depot)")
                 )
                 (@subcommand export =>
                     (about: "Outputs the latest origin key contents to stdout")
@@ -120,7 +120,7 @@ pub fn get() -> App<'static, 'static> {
                         "Upload secret key in addition to the public key")
                     (@arg SECRET_FILE: --secfile +takes_value {file_exists} conflicts_with[ORIGIN]
                         "Path to a local secret origin key file on disk")
-                    (@arg DEPOT_URL: -u --url +takes_value {valid_url} "Use a specific Depot URL")
+                    (@arg DEPOT_URL: -u --url +takes_value {valid_url} "Use a specific Depot URL (ex: http://depot.example.com/v1/depot)")
                     (@arg AUTH_TOKEN: -z --auth +takes_value "Authentication token for the Depot")
                 )
             )
@@ -180,7 +180,7 @@ pub fn get() -> App<'static, 'static> {
             (@subcommand search =>
                 (about: "Search for a package on a Depot")
                 (@arg SEARCH_TERM: +required +takes_value "Search term")
-                (@arg DEPOT_URL: -u --url +takes_value {valid_url} "Use a specific Depot URL")
+                (@arg DEPOT_URL: -u --url +takes_value {valid_url} "Use a specific Depot URL (ex: http://depot.example.com/v1/depot)")
             )
             (@subcommand sign =>
                 (about: "Signs an archive with an origin key, generating a Habitat Artifact")
@@ -196,7 +196,7 @@ pub fn get() -> App<'static, 'static> {
             (@subcommand upload =>
                 (about: "Uploads a local Habitat Artifact to a Depot")
                 (aliases: &["u", "up", "upl", "uplo", "uploa"])
-                (@arg DEPOT_URL: -u --url +takes_value {valid_url} "Use a specific Depot URL")
+                (@arg DEPOT_URL: -u --url +takes_value {valid_url} "Use a specific Depot URL (ex: http://depot.example.com/v1/depot)")
                 (@arg AUTH_TOKEN: -z --auth +takes_value "Authentication token for the Depot")
                 (@arg HART_FILE: +required +multiple {file_exists}
                     "One or more filepaths to a Habitat Artifact \
@@ -369,7 +369,7 @@ fn sub_pkg_build() -> App<'static, 'static> {
 fn sub_pkg_install() -> App<'static, 'static> {
     clap_app!(@subcommand install =>
         (about: "Installs a Habitat package from a Depot or locally from a Habitat Artifact")
-        (@arg DEPOT_URL: -u --url +takes_value {valid_url} "Use a specific Depot URL")
+        (@arg DEPOT_URL: -u --url +takes_value {valid_url} "Use a specific Depot URL (ex: http://depot.example.com/v1/depot)")
         (@arg PKG_IDENT_OR_ARTIFACT: +required +multiple
             "One or more Habitat package identifiers (ex: acme/redis) and/or filepaths \
             to a Habitat Artifact (ex: /home/acme-redis-3.0.7-21120102031201-x86_64-linux.hart)")

--- a/www/source/docs/reference/habitat-cli.html.md
+++ b/www/source/docs/reference/habitat-cli.html.md
@@ -142,7 +142,7 @@ Download origin key(s) to `HAB_CACHE_KEY_PATH`
 
 **OPTIONS**
 
-    -u, --url <DEPOT_URL>    Use a specific Depot URL
+    -u, --url <DEPOT_URL>    Use a specific Depot URL (ex: http://depot.example.com/v1/depot)
 
 **ARGS**
 
@@ -215,7 +215,7 @@ Upload origin keys to the depot
 **OPTIONS**
 
     -z, --auth <AUTH_TOKEN>        Authentication token for the Depot
-    -u, --url <DEPOT_URL>          Use a specific Depot URL
+    -u, --url <DEPOT_URL>          Use a specific Depot URL (ex: http://depot.example.com/v1/depot)
         --pubfile <PUBLIC_FILE>    Path to a local public origin key file on disk
         --secfile <SECRET_FILE>    Path to a local secret origin key file on disk
 
@@ -332,7 +332,7 @@ Installs a Habitat package from a Depot or locally from a Habitat Artifact
 
 **OPTIONS**
 
-    -u, --url <DEPOT_URL>    Use a specific Depot URL
+    -u, --url <DEPOT_URL>    Use a specific Depot URL (ex: http://depot.example.com/v1/depot)
 
 **ARGS**
 
@@ -411,7 +411,7 @@ Uploads a local Habitat Artifact to a Depot
 **OPTIONS**
 
     -z, --auth <AUTH_TOKEN>    Authentication token for the Depot
-    -u, --url <DEPOT_URL>      Use a specific Depot URL
+    -u, --url <DEPOT_URL>      Use a specific Depot URL (ex: http://depot.example.com/v1/depot)
 
 **ARGS**
 


### PR DESCRIPTION
When using the hab CLI, it isn't intuitive how to specify the depot URI - the `/v1/depot` path is required. Let's add examples so users can see this when using `--help`.

Signed-off-by: Joshua Timberman <joshua@chef.io>