### PR TITLE
Make the supervisor run on windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,7 +245,7 @@ dependencies = [
  "toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "urlencoded 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "zmq 0.8.0 (git+https://github.com/erickt/rust-zmq.git)",
+ "zmq 0.8.0 (git+https://github.com/habitat-sh/rust-zmq.git?tag=windows_fix_pr)",
 ]
 
 [[package]]
@@ -275,7 +275,7 @@ dependencies = [
  "staticfile 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zmq 0.8.0 (git+https://github.com/erickt/rust-zmq.git)",
+ "zmq 0.8.0 (git+https://github.com/habitat-sh/rust-zmq.git?tag=windows_fix_pr)",
 ]
 
 [[package]]
@@ -310,7 +310,7 @@ dependencies = [
  "redis 0.7.0 (git+https://github.com/habitat-sh/redis-rs?branch=habitat)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "zmq 0.8.0 (git+https://github.com/erickt/rust-zmq.git)",
+ "zmq 0.8.0 (git+https://github.com/habitat-sh/rust-zmq.git?tag=windows_fix_pr)",
 ]
 
 [[package]]
@@ -339,7 +339,7 @@ dependencies = [
  "protobuf 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "zmq 0.8.0 (git+https://github.com/erickt/rust-zmq.git)",
+ "zmq 0.8.0 (git+https://github.com/habitat-sh/rust-zmq.git?tag=windows_fix_pr)",
 ]
 
 [[package]]
@@ -360,7 +360,7 @@ dependencies = [
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "zmq 0.8.0 (git+https://github.com/erickt/rust-zmq.git)",
+ "zmq 0.8.0 (git+https://github.com/habitat-sh/rust-zmq.git?tag=windows_fix_pr)",
 ]
 
 [[package]]
@@ -378,7 +378,7 @@ dependencies = [
  "redis 0.7.0 (git+https://github.com/habitat-sh/redis-rs?branch=habitat)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "zmq 0.8.0 (git+https://github.com/erickt/rust-zmq.git)",
+ "zmq 0.8.0 (git+https://github.com/habitat-sh/rust-zmq.git?tag=windows_fix_pr)",
 ]
 
 [[package]]
@@ -396,7 +396,7 @@ dependencies = [
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "zmq 0.8.0 (git+https://github.com/erickt/rust-zmq.git)",
+ "zmq 0.8.0 (git+https://github.com/habitat-sh/rust-zmq.git?tag=windows_fix_pr)",
 ]
 
 [[package]]
@@ -415,7 +415,7 @@ dependencies = [
  "threadpool 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "zmq 0.8.0 (git+https://github.com/erickt/rust-zmq.git)",
+ "zmq 0.8.0 (git+https://github.com/habitat-sh/rust-zmq.git?tag=windows_fix_pr)",
 ]
 
 [[package]]
@@ -512,7 +512,7 @@ dependencies = [
  "urlencoded 0.4.0 (git+https://github.com/habitat-sh/urlencoded.git?branch=habitat)",
  "uuid 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "zmq 0.8.0 (git+https://github.com/erickt/rust-zmq.git)",
+ "zmq 0.8.0 (git+https://github.com/habitat-sh/rust-zmq.git?tag=windows_fix_pr)",
 ]
 
 [[package]]
@@ -583,7 +583,7 @@ dependencies = [
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zmq 0.8.0 (git+https://github.com/erickt/rust-zmq.git)",
+ "zmq 0.8.0 (git+https://github.com/habitat-sh/rust-zmq.git?tag=windows_fix_pr)",
 ]
 
 [[package]]
@@ -1559,17 +1559,17 @@ dependencies = [
 [[package]]
 name = "zmq"
 version = "0.8.0"
-source = "git+https://github.com/erickt/rust-zmq.git#5cd311a6127a7dd49920cc0a3f7f9501b155146c"
+source = "git+https://github.com/habitat-sh/rust-zmq.git?tag=windows_fix_pr#830530c5245024556f504ec44b5e7102fd2bae6e"
 dependencies = [
  "libc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "zmq-sys 0.8.0 (git+https://github.com/erickt/rust-zmq.git)",
+ "zmq-sys 0.8.0 (git+https://github.com/habitat-sh/rust-zmq.git?tag=windows_fix_pr)",
 ]
 
 [[package]]
 name = "zmq-sys"
 version = "0.8.0"
-source = "git+https://github.com/erickt/rust-zmq.git#5cd311a6127a7dd49920cc0a3f7f9501b155146c"
+source = "git+https://github.com/habitat-sh/rust-zmq.git?tag=windows_fix_pr#830530c5245024556f504ec44b5e7102fd2bae6e"
 dependencies = [
  "libc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1709,5 +1709,5 @@ dependencies = [
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 "checksum wonder 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "07666280a40a706383d9c32f5783c213ca4c9d745102d3f0c9916f5675aad563"
-"checksum zmq 0.8.0 (git+https://github.com/erickt/rust-zmq.git)" = "<none>"
-"checksum zmq-sys 0.8.0 (git+https://github.com/erickt/rust-zmq.git)" = "<none>"
+"checksum zmq 0.8.0 (git+https://github.com/habitat-sh/rust-zmq.git?tag=windows_fix_pr)" = "<none>"
+"checksum zmq-sys 0.8.0 (git+https://github.com/habitat-sh/rust-zmq.git?tag=windows_fix_pr)" = "<none>"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ environment:
   matrix:
     - CARGO_HOME: "c:\\cargo"
       hab_build_action: "test;build"
-      hab_components: "core;http-client;builder-protocol;builder-depot-client;common;win-users"
+      hab_components: "core;http-client;builder-protocol;builder-depot-client;common;win-users;sup"
 
 build_script:
   - ps: Update-AppveyorBuild -Version "$((gc -raw ./VERSION).trim())-$((Get-Date).ToString('yyyyMMddHHmmss'))" 

--- a/components/builder-admin/Cargo.toml
+++ b/components/builder-admin/Cargo.toml
@@ -34,7 +34,8 @@ version = "*"
 features = [ "suggestions", "color", "unstable" ]
 
 [dependencies.zmq]
-git = "https://github.com/erickt/rust-zmq.git"
+git = "https://github.com/habitat-sh/rust-zmq.git"
+tag = "windows_fix_pr"
 
 [dependencies.habitat_core]
 path = "../core"

--- a/components/builder-api/Cargo.toml
+++ b/components/builder-api/Cargo.toml
@@ -33,7 +33,8 @@ version = "*"
 features = [ "suggestions", "color", "unstable" ]
 
 [dependencies.zmq]
-git = "https://github.com/erickt/rust-zmq.git"
+git = "https://github.com/habitat-sh/rust-zmq.git"
+tag = "windows_fix_pr"
 
 [dependencies.habitat_core]
 path = "../core"

--- a/components/builder-depot/Cargo.toml
+++ b/components/builder-depot/Cargo.toml
@@ -64,7 +64,8 @@ git = "https://github.com/habitat-sh/urlencoded.git"
 branch = "habitat"
 
 [dependencies.zmq]
-git = "https://github.com/erickt/rust-zmq.git"
+git = "https://github.com/habitat-sh/rust-zmq.git"
+tag = "windows_fix_pr"
 
 [build-dependencies]
 serde_codegen = "*"

--- a/components/builder-jobsrv/Cargo.toml
+++ b/components/builder-jobsrv/Cargo.toml
@@ -23,7 +23,8 @@ version = "*"
 features = [ "suggestions", "color", "unstable" ]
 
 [dependencies.zmq]
-git = "https://github.com/erickt/rust-zmq.git"
+git = "https://github.com/habitat-sh/rust-zmq.git"
+tag = "windows_fix_pr"
 
 [dependencies.habitat_core]
 path = "../core"

--- a/components/builder-router/Cargo.toml
+++ b/components/builder-router/Cargo.toml
@@ -22,7 +22,8 @@ version = "*"
 features = [ "suggestions", "color", "unstable" ]
 
 [dependencies.zmq]
-git = "https://github.com/erickt/rust-zmq.git"
+git = "https://github.com/habitat-sh/rust-zmq.git"
+tag = "windows_fix_pr"
 
 [dependencies.habitat_builder_dbcache]
 path = "../builder-dbcache"

--- a/components/builder-sessionsrv/Cargo.toml
+++ b/components/builder-sessionsrv/Cargo.toml
@@ -25,7 +25,8 @@ version = "*"
 features = [ "suggestions", "color", "unstable" ]
 
 [dependencies.zmq]
-git = "https://github.com/erickt/rust-zmq.git"
+git = "https://github.com/habitat-sh/rust-zmq.git"
+tag = "windows_fix_pr"
 
 [dependencies.habitat_core]
 path = "../core"

--- a/components/builder-vault/Cargo.toml
+++ b/components/builder-vault/Cargo.toml
@@ -22,7 +22,8 @@ version = "*"
 features = [ "suggestions", "color", "unstable" ]
 
 [dependencies.zmq]
-git = "https://github.com/erickt/rust-zmq.git"
+git = "https://github.com/habitat-sh/rust-zmq.git"
+tag = "windows_fix_pr"
 
 [dependencies.habitat_core]
 path = "../core"

--- a/components/builder-worker/Cargo.toml
+++ b/components/builder-worker/Cargo.toml
@@ -23,7 +23,8 @@ version = "*"
 features = [ "suggestions", "color", "unstable" ]
 
 [dependencies.zmq]
-git = "https://github.com/erickt/rust-zmq.git"
+git = "https://github.com/habitat-sh/rust-zmq.git"
+tag = "windows_fix_pr"
 
 [dependencies.habitat_core]
 path = "../core"

--- a/components/butterfly/Cargo.toml
+++ b/components/butterfly/Cargo.toml
@@ -35,7 +35,8 @@ path = "../net"
 path = "../core"
 
 [dependencies.zmq]
-git = "https://github.com/erickt/rust-zmq.git"
+git = "https://github.com/habitat-sh/rust-zmq.git"
+tag = "windows_fix_pr"
 
 [features]
 functional = []

--- a/components/butterfly/src/server/inbound.rs
+++ b/components/butterfly/src/server/inbound.rs
@@ -109,7 +109,7 @@ impl<'a> Inbound<'a> {
                 }
                 Err(e) => {
                     match e.raw_os_error() {
-                        Some(35) | Some(11) => {
+                        Some(35) | Some(11) | Some(10035) | Some(10060) => {
                             // This is the normal non-blocking result, or a timeout
                         }
                         Some(_) => {

--- a/components/core/src/os/filesystem/windows.rs
+++ b/components/core/src/os/filesystem/windows.rs
@@ -12,23 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use libc::{c_int, c_char};
-use std::ffi::CStr;
+use libc::c_int;
 use std::path::Path;
 use std::io;
 
-pub fn chown(r_path: *const c_char, uid: String, gid: String) -> c_int {
-    unimplemented!();
+use error::Result;
+
+pub fn path_exists(path: &str) -> Result<c_int> {
+    match Path::new(path).exists() {
+        false => Ok(1),
+        true => Ok(0),
+    }
 }
 
-pub fn chmod(r_path: *const c_char, mode: u32) -> c_int {
-    unsafe {
-        let path = CStr::from_ptr(r_path).to_str().unwrap();
-        match Path::new(path).exists() {
-            false => 1,
-            true => 0,
-        }
-    }
+pub fn chown(path: &str, uid: String, gid: String) -> Result<c_int> {
+    path_exists(path)
+}
+
+pub fn chmod(path: &str, mode: u32) -> Result<c_int> {
+    path_exists(path)
 }
 
 pub fn symlink<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> io::Result<()> {

--- a/components/core/src/os/process/windows.rs
+++ b/components/core/src/os/process/windows.rs
@@ -23,8 +23,9 @@ pub fn become_command(command: PathBuf, args: Vec<OsString>) -> Result<()> {
     become_child_command(command, args)
 }
 
+//TODO: REALLY wait for exit
 pub fn wait_for_exit(pid: u32, status: *mut c_int) -> u32 {
-    unimplemented!();
+    0
 }
 
 pub fn send_signal(pid: u32, sig: u32) -> u32 {

--- a/components/core/src/package/install.rs
+++ b/components/core/src/package/install.rs
@@ -297,13 +297,15 @@ impl PackageInstall {
         let mut deps: Vec<PackageIdent> = vec![];
         match self.read_metafile(file) {
             Ok(body) => {
-                let ids: Vec<String> = body.split("\n").map(|d| d.to_string()).collect();
-                for id in &ids {
-                    let package = try!(PackageIdent::from_str(id));
-                    if !package.fully_qualified() {
-                        return Err(Error::InvalidPackageIdent(package.to_string()));
+                if body.len() > 0 {
+                    let ids: Vec<String> = body.split("\n").map(|d| d.to_string()).collect();
+                    for id in &ids {
+                        let package = try!(PackageIdent::from_str(id));
+                        if !package.fully_qualified() {
+                            return Err(Error::InvalidPackageIdent(package.to_string()));
+                        }
+                        deps.push(package);
                     }
-                    deps.push(package);
                 }
                 Ok(deps)
             }

--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -20,7 +20,8 @@ time = "*"
 unicase = "*"
 
 [dependencies.zmq]
-git = "https://github.com/erickt/rust-zmq.git"
+git = "https://github.com/habitat-sh/rust-zmq.git"
+tag = "windows_fix_pr"
 
 [dependencies.habitat_builder_protocol]
 path = "../builder-protocol"

--- a/components/sup/src/command/shell.rs
+++ b/components/sup/src/command/shell.rs
@@ -21,7 +21,7 @@ use hcore::fs::find_command;
 use libc;
 
 use error::{Error, Result};
-use util::path::busybox_paths;
+use util::path::interpreter_paths;
 
 /// Our output key
 static LOGKEY: &'static str = "SH";
@@ -42,7 +42,7 @@ pub fn sh() -> Result<()> {
 
 fn set_path() -> Result<()> {
     let mut paths = String::new();
-    for path in try!(busybox_paths()).iter() {
+    for path in try!(interpreter_paths()).iter() {
         if !paths.is_empty() {
             paths.push(':');
         }

--- a/components/sup/src/command/shell.rs
+++ b/components/sup/src/command/shell.rs
@@ -15,13 +15,14 @@
 use std::env;
 use std::ffi::CString;
 use std::ptr;
+use std::path::PathBuf;
 
 use hcore::env as henv;
 use hcore::fs::find_command;
 use libc;
 
 use error::{Error, Result};
-use util::path::interpreter_paths;
+use util::path;
 
 /// Our output key
 static LOGKEY: &'static str = "SH";
@@ -41,19 +42,11 @@ pub fn sh() -> Result<()> {
 }
 
 fn set_path() -> Result<()> {
-    let mut paths = String::new();
-    for path in try!(interpreter_paths()).iter() {
-        if !paths.is_empty() {
-            paths.push(':');
-        }
-        paths.push_str(&path.to_string_lossy());
-    }
-    if let Some(val) = henv::var_os("PATH") {
-        paths.push(':');
-        paths.push_str(&val.to_string_lossy());
-    }
-    debug!("Setting the PATH to {}", &paths);
-    env::set_var("PATH", &paths);
+    let mut paths: Vec<PathBuf> = Vec::new();
+    let new_path = try!(path::append_interpreter_and_path(&mut paths));
+
+    debug!("Setting the PATH to {}", &new_path);
+    env::set_var("PATH", &new_path);
     Ok(())
 }
 

--- a/components/sup/src/error.rs
+++ b/components/sup/src/error.rs
@@ -37,6 +37,7 @@
 //! it instead of the longer `Result` form.
 
 use std::io;
+use std::env;
 use std::error;
 use std::ffi;
 use std::fmt;
@@ -104,6 +105,7 @@ pub enum Error {
     CommandNotImplemented,
     DbInvalidPath,
     DepotClient(depot_client::Error),
+    EnvJoinPathsError(env::JoinPathsError),
     ExecCommandNotFound(String),
     FileNotFound(String),
     HabitatCommon(common::Error),
@@ -167,6 +169,7 @@ impl fmt::Display for SupError {
             Error::CommandNotImplemented => format!("Command is not yet implemented!"),
             Error::DbInvalidPath => format!("Invalid filepath to internal datastore"),
             Error::DepotClient(ref err) => format!("{}", err),
+            Error::EnvJoinPathsError(ref err) => format!("{}", err),
             Error::FileNotFound(ref e) => format!("File not found at: {}", e),
             Error::HealthCheck(ref e) => format!("Health Check failed: {}", e),
             Error::HookFailed(ref t, ref e, ref o) => {
@@ -258,9 +261,11 @@ impl error::Error for SupError {
             Error::HandlebarsTemplateFileError(ref err) => err.description(),
             Error::HabitatCommon(ref err) => err.description(),
             Error::HabitatCore(ref err) => err.description(),
+            
             Error::CommandNotImplemented => "Command is not yet implemented!",
             Error::DbInvalidPath => "A bad filepath was provided for an internal datastore",
             Error::DepotClient(ref err) => err.description(),
+            Error::EnvJoinPathsError(ref err) => err.description(),
             Error::FileNotFound(_) => "File not found",
             Error::HealthCheck(_) => "Health Check returned an unknown status code",
             Error::HookFailed(_, _, _) => "Hook failed to run",
@@ -376,6 +381,12 @@ impl From<ffi::NulError> for SupError {
 impl From<io::Error> for SupError {
     fn from(err: io::Error) -> SupError {
         sup_error!(Error::Io(err))
+    }
+}
+
+impl From<env::JoinPathsError> for SupError {
+    fn from(err: env::JoinPathsError) -> SupError {
+        sup_error!(Error::EnvJoinPathsError(err))
     }
 }
 

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -42,7 +42,6 @@ use sup::config::{gcache, gconfig, Command, Config, UpdateStrategy, Topology};
 use sup::error::{Error, Result, SupError};
 use sup::command::*;
 use sup::util::parse_ip_port_with_defaults;
-use sup::util::path::busybox_paths;
 use sup::util::sys::ip;
 
 /// Our output key

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -141,14 +141,6 @@ fn config_from_args(subcommand: &str, sub_args: &ArgMatches) -> Result<()> {
             .as_ref())
         .to_string());
 
-    let mut env_path = String::new();
-    for path in try!(busybox_paths()) {
-        if env_path.len() > 0 {
-            env_path.push(':');
-        }
-        env_path.push_str(path.to_string_lossy().as_ref());
-    }
-
     config.set_swim_listen(String::from(sub_args.value_of("listen-swim")
         .unwrap_or(DEFAULT_LISTEN_SWIM)));
     config.set_gossip_listen(String::from(sub_args.value_of("listen-gossip")

--- a/components/sup/src/manager/signals/windows.rs
+++ b/components/sup/src/manager/signals/windows.rs
@@ -12,21 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Contains the cross-platform signal behavior.
+//! Traps and notifies signals.
 
-pub enum SignalEvent {
-    Shutdown,
-    Passthrough(u32),
+use error::{Error, Result, SupError};
+use super::SignalEvent;
+
+pub fn init() {}
+
+pub fn check_for_signal() -> Option<SignalEvent> {
+    None
 }
 
-#[cfg(unix)]
-mod unix;
-
-#[cfg(windows)]
-mod windows;
-
-#[cfg(unix)]
-pub use manager::signals::unix::{init, check_for_signal, send_signal};
-
-#[cfg(windows)]
-pub use manager::signals::windows::{init, check_for_signal, send_signal};
+/// send a signal to a pid
+pub fn send_signal(pid: u32, sig: u32) -> Result<()> {
+    debug!("sending no-op(windows) signal {} to pid {}", sig, pid);
+    Ok(())
+}

--- a/components/sup/src/package/hooks.rs
+++ b/components/sup/src/package/hooks.rs
@@ -16,18 +16,17 @@ use std::fmt;
 use std::fs::{self, File};
 use std::io::prelude::*;
 use std::path::PathBuf;
-use std::process::{Command, Stdio};
 
 use handlebars::Handlebars;
 
 use error::{Error, Result};
 use hcore::util;
-use hcore::os::users;
 use package::Package;
 use manager::service::config::{ServiceConfig, never_escape_fn};
 use util::convert;
 use util::handlebars_helpers;
 use util::users as hab_users;
+use util::create_command;
 
 pub const HOOK_PERMISSIONS: u32 = 0o755;
 static LOGKEY: &'static str = "PH";
@@ -79,9 +78,7 @@ impl Hook {
     }
 
     pub fn run(&self) -> Result<String> {
-        let mut cmd = Command::new(&self.path);
-        try!(self.run_platform(&mut cmd));
-        let mut child = try!(cmd.spawn());
+        let mut child = try!(create_command(self.path.clone(), &self.user, &self.group).spawn());
         {
             let mut c_stdout = match child.stdout {
                 Some(ref mut s) => s,
@@ -121,34 +118,6 @@ impl Hook {
                                              exit_status.code().unwrap_or(-1),
                                              String::from("Failed"))))
         }
-    }
-
-    #[cfg(any(target_os="linux", target_os="macos"))]
-    fn run_platform(&self, cmd: &mut Command) -> Result<()> {
-        use std::os::unix::process::CommandExt;
-        let uid = users::get_uid_by_name(&self.user);
-        let gid = users::get_gid_by_name(&self.group);
-        if let None = uid {
-            panic!("Can't determine uid");
-        }
-
-        if let None = gid {
-            panic!("Can't determine gid");
-        }
-
-        let uid = uid.unwrap();
-        let gid = gid.unwrap();
-        cmd.stdin(Stdio::null())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .uid(uid)
-            .gid(gid);
-        Ok(())
-    }
-
-    #[cfg(target_os = "windows")]
-    fn run_platform(&self, cmd: &mut Command) -> Result<()> {
-        unimplemented!();
     }
 
     pub fn compile(&self, context: Option<&ServiceConfig>) -> Result<()> {

--- a/components/sup/src/package/hooks.rs
+++ b/components/sup/src/package/hooks.rs
@@ -26,7 +26,7 @@ use manager::service::config::{ServiceConfig, never_escape_fn};
 use util::convert;
 use util::handlebars_helpers;
 use util::users as hab_users;
-use util::create_command;
+use util as sup_util;
 
 pub const HOOK_PERMISSIONS: u32 = 0o755;
 static LOGKEY: &'static str = "PH";
@@ -78,7 +78,7 @@ impl Hook {
     }
 
     pub fn run(&self) -> Result<String> {
-        let mut child = try!(create_command(self.path.clone(), &self.user, &self.group).spawn());
+        let mut child = try!(sup_util::create_command(self.path.clone(), &self.user, &self.group).spawn());
         {
             let mut c_stdout = match child.stdout {
                 Some(ref mut s) => s,

--- a/components/sup/src/package/mod.rs
+++ b/components/sup/src/package/mod.rs
@@ -35,7 +35,7 @@ use error::{Error, Result, SupError};
 use health_check::{self, CheckResult};
 use manager::service::config::ServiceConfig;
 use supervisor::Supervisor;
-use util::path::busybox_paths;
+use util::path::interpreter_paths;
 use util::users as hab_users;
 
 static LOGKEY: &'static str = "PK";
@@ -96,7 +96,7 @@ impl Package {
     }
 
     /// Returns a string with the full run path for this package. This path is composed of any
-    /// binary paths specified by this package, or its TDEPS, plus a path to a BusyBox,
+    /// binary paths specified by this package, or its TDEPS, plus a path to a BusyBox(non-windows),
     /// plus the existing value of the PATH variable.
     ///
     /// This means we work on any operating system, as long as you can invoke the Supervisor,
@@ -106,7 +106,7 @@ impl Package {
             Ok(r) => r,
             Err(e) => return Err(sup_error!(Error::HabitatCore(e))),
         };
-        for path in try!(busybox_paths()).iter() {
+        for path in try!(interpreter_paths()).iter() {
             paths.push(':');
             paths.push_str(&path.to_string_lossy());
         }

--- a/components/sup/src/supervisor.rs
+++ b/components/sup/src/supervisor.rs
@@ -33,7 +33,8 @@ use libc::c_int;
 use time::{Duration, SteadyTime};
 
 use error::{Result, Error};
-use util::{create_command, signals};
+use util;
+use util::signals;
 
 const PIDFILE_NAME: &'static str = "PID";
 static LOGKEY: &'static str = "SV";
@@ -177,7 +178,7 @@ impl Supervisor {
         if self.pid.is_none() {
             outputln!(preamble & self.package_ident.name, "Starting");
             self.enter_state(ProcessState::Start);
-            let mut child = try!(create_command(self.run_cmd(),
+            let mut child = try!(util::create_command(self.run_cmd(),
                 &self.runtime_config.svc_user,
                 &self.runtime_config.svc_group).spawn());
 

--- a/components/sup/src/supervisor.rs
+++ b/components/sup/src/supervisor.rs
@@ -23,17 +23,17 @@ use std::fs::{self, File};
 use std::io::BufReader;
 use std::io::prelude::*;
 use std::path::PathBuf;
-use std::process::{Command, Stdio, Child};
+use std::process::Child;
 use std::thread;
 
 use hcore;
-use hcore::os::{process, users};
+use hcore::os::process;
 use hcore::package::PackageIdent;
 use libc::c_int;
 use time::{Duration, SteadyTime};
 
 use error::{Result, Error};
-use util::signals;
+use util::{create_command, signals};
 
 const PIDFILE_NAME: &'static str = "PID";
 static LOGKEY: &'static str = "SV";
@@ -177,10 +177,9 @@ impl Supervisor {
         if self.pid.is_none() {
             outputln!(preamble & self.package_ident.name, "Starting");
             self.enter_state(ProcessState::Start);
-
-            let mut cmd = Command::new(self.run_cmd());
-            try!(self.start_platform(&mut cmd));
-            let mut child = try!(cmd.spawn());
+            let mut child = try!(create_command(self.run_cmd(),
+                &self.runtime_config.svc_user,
+                &self.runtime_config.svc_group).spawn());
 
             self.pid = Some(child.id());
             try!(self.create_pidfile());
@@ -194,34 +193,6 @@ impl Supervisor {
             outputln!(preamble & self.package_ident.name, "Already started");
         }
         Ok(())
-    }
-
-    #[cfg(any(target_os="linux", target_os="macos"))]
-    fn start_platform(&mut self, cmd: &mut Command) -> Result<()> {
-        use std::os::unix::process::CommandExt;
-        let uid = users::get_uid_by_name(&self.runtime_config.svc_user);
-        let gid = users::get_gid_by_name(&self.runtime_config.svc_group);
-        if let None = uid {
-            panic!("Can't determine uid");
-        }
-
-        if let None = gid {
-            panic!("Can't determine gid");
-        }
-
-        let uid = uid.unwrap();
-        let gid = gid.unwrap();
-        cmd.stdin(Stdio::null())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .uid(uid)
-            .gid(gid);
-        Ok(())
-    }
-
-    #[cfg(target_os = "windows")]
-    fn start_platform(&mut self, cmd: &mut Command) -> Result<()> {
-        unimplemented!();
     }
 
     /// Send a SIGTERM to a process, wait 8 seconds, then send SIGKILL

--- a/components/sup/src/util/mod.rs
+++ b/components/sup/src/util/mod.rs
@@ -73,18 +73,9 @@ pub fn parse_ip_port_with_defaults(s: Option<&str>,
 pub fn create_command(path: PathBuf, user: &str, group: &str) -> Command {
     let mut cmd = Command::new(path);
     use std::os::unix::process::CommandExt;
-    let uid = os::users::get_uid_by_name(user);
-    let gid = os::users::get_gid_by_name(group);
-    if let None = uid {
-        panic!("Can't determine uid");
-    }
+    let uid = os::users::get_uid_by_name(user).expect("Can't determine uid");
+    let gid = os::users::get_gid_by_name(group).expect("Can't determine gid");
 
-    if let None = gid {
-        panic!("Can't determine gid");
-    }
-
-    let uid = uid.unwrap();
-    let gid = gid.unwrap();
     cmd.stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())

--- a/components/sup/src/util/path.rs
+++ b/components/sup/src/util/path.rs
@@ -130,6 +130,18 @@ pub fn interpreter_paths() -> Result<Vec<PathBuf>> {
     Ok(empty)
 }
 
+pub fn append_interpreter_and_path(orig_paths: &mut Vec<PathBuf>) -> Result<String> {
+    let mut paths = try!(interpreter_paths()).to_owned();
+    orig_paths.append(&mut paths);
+    if let Some(val) = env::var_os("PATH") {
+        let mut os_paths = env::split_paths(&val).collect::<Vec<PathBuf>>();
+        orig_paths.append(&mut os_paths);
+    }
+    let joined = try!(env::join_paths(orig_paths));
+    let path_str = joined.into_string().expect("Unable to convert OsStr path to string!");
+    Ok(path_str)
+}
+
 /// Returns a `PackageIdent` for a BusyBox package, assuming it exists in the provided metafile.
 fn busybox_dep_from_metafile(metafile: PathBuf) -> Option<PackageIdent> {
     let f = match File::open(metafile) {

--- a/components/sup/src/util/path.rs
+++ b/components/sup/src/util/path.rs
@@ -56,7 +56,8 @@ const BUSYBOX_IDENT: &'static str = "core/busybox-static";
 /// * If the parent directory of a located `busybox` binary cannot be computed
 /// * If the Supervisor is not executing inside a packge, and if no BusyBox package is installed,
 ///   and if no `busybox` binary can be found on the `PATH`
-pub fn busybox_paths() -> Result<Vec<PathBuf>> {
+#[cfg(any(target_os="linux", target_os="macos"))]
+pub fn interpreter_paths() -> Result<Vec<PathBuf>> {
     // First, we'll check if we're running inside a package. If we are, then we should  be able to
     // access the `../DEPS` metadata file and read it to get the specific version of BusyBox.
     let my_busybox_dep_ident = match env::current_exe() {
@@ -121,6 +122,12 @@ pub fn busybox_paths() -> Result<Vec<PathBuf>> {
         }
     };
     Ok(bb_paths)
+}
+
+#[cfg(target_os = "windows")]
+pub fn interpreter_paths() -> Result<Vec<PathBuf>> {
+    let empty: Vec<PathBuf> = Vec::new();
+    Ok(empty)
 }
 
 /// Returns a `PackageIdent` for a BusyBox package, assuming it exists in the provided metafile.


### PR DESCRIPTION
This pr gets the supervisor running on windows with the following caveats:
1. The hooks are assumed to be powershell and use whatever `powershell.exe` is on the path
2. Processes are spawned as the current user and not as the specified `SVC` user/group
3. The process is always assumed to be healty and the implementation for `wait_for_pid` is a noop
4. The `chown` and `chmod` functionalities are no op on windows
5. ctrl+c (stopping the supervisor) will produce an error because it cannot send a kill signal

To test this I cloned https://github.com/habitat-sh/habitat-windows-package to a windows local `/hab/packages` note it is important to delete the `.git` folder after clone or else the version will not be read correctly.