### PR TITLE
WIP: Enable relative paths in pkg_source

### DIFF
--- a/components/hab/static/template_plan.sh
+++ b/components/hab/static/template_plan.sh
@@ -35,10 +35,10 @@ pkg_license={{ pkg_license }}
 # pkg_license=('Apache-2.0')
 {{/if}}
 # Required.
-# A URL that specifies where to download the source from. Any valid wget url
-# will work. Typically, the relative path for the URL is partially constructed
-# from the pkg_name and pkg_version values; however, this convention is not
-# required.
+# A URL that specifies where to download the source from, or a relative path.
+# Any valid wget url or relative path from the plan.sh will work. Typically,
+# the relative path for the URL is partially constructed from the pkg_name
+# and pkg_version values; however, this convention is not required.
 {{#if pkg_source ~}}
 pkg_source="{{ pkg_source }}"
 {{else ~}}
@@ -52,7 +52,7 @@ pkg_filename="{{ pkg_filename }}"
 {{else ~}}
 # pkg_filename="${pkg_name}-${pkg_version}.tar.gz"
 {{/if}}
-# Required if a valid URL is provided for pkg_source or unless do_verify() is overridden.
+# Required if a valid URL is provided for pkg_source, not required for local dirs.
 # The value for pkg_shasum is a sha-256 sum of the downloaded pkg_source. If you
 # do not have the checksum, you can easily generate it by downloading the source
 # and using the sha256sum or gsha256sum tools. Also, if you do not have


### PR DESCRIPTION
This is a WIP PR to enable `pkg_source` to point to some arbitrary folder relative to `plan.sh` such as `../`.

This is primarily useful in the "in repo" variant workflow described in https://github.com/habitat-sh/habitat/pull/1416#issuecomment-257402252.

To do:

* [ ] Support local/relative tarballs or non-folders.
* [ ] Figure out how to best structure things.
* [ ] ???