### PR TITLE
Build and publish unstable `hab` CLI builds off master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -187,7 +187,6 @@ matrix:
     - os: linux
       env:
         - AFFECTED_DIRS="components/hab|components/common|components/core|components/builder-depot-client|components/http-client"
-        - HAB_BINTRAY_REPO=unstable
         # HAB_ORIGIN_KEY
         - secure: "uZ70GE8qK3GBgs7ZIsoy5DhPlHNs2hoLxLBGKq+u+0XrE017pOnW6mNHsn7J7i2r8CPtd4KFsFEN52wZSA+Sf96MFIL2w9E+geykBgbRMZzv4icuCf0xSGwm4iRMgZ9A08TfurMX6y6N+4JNsrCv9syVNuGq09EL2wLHPXOQhesMpodijQLcFikxfEXXbaWla1xHnYxJk+fbvYDoXVCbdqnpdeLTmGuQHFaaNI7jm1B3L/dl+IGZxwFdvqBT3G9mHiXBdyi8bALs7rcZNdV7PqtFFpp98zIeqwNHtHPd5cBRmqDRTRxucRSACS/lurrz9J+001a9RjPvUkYlLrn0hQY9pN6oo+kCpN/1r0bc17i4FbGx7R73FnFgPK/cno0ENBFygNZn7/jg6cENgjkBlHsZhc1+L1xhILo46nQU9XbWJrwelVYUOOGXI76tECOkGhkglx1vYK8fcMVLJMhL7psgPpbGbDJQDuAKhHS+75txNK+356ompNL+YUzeWZc4KSGZCNTQsPK+rsGttmA+JXtAaquFaY5xwSgyKHwETiSVg4dYXb3xh6goNxf2JTOZOosWaypyykHqcqsqCu2fzIDdmkgCx6I5/5q8I/7Z0es0jlUpHamlihZwe4E5YdYFCSouaDoeTnVdJKVI1p9fnAjpFqjivFgqLE/Z504vCNU="
         - BINTRAY_USER=smurawski

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ matrix:
         apt: true
         cargo: true
         directories:
-        - /root/travis_bootstrap
+          - /root/travis_bootstrap
       before_install:
         - ./support/ci/fast_pass.sh || exit 0
       script:
@@ -184,6 +184,34 @@ matrix:
       before_install: ./support/ci/fast_pass.sh || exit 0
       install: "(cd www && bundle install)"
       script: ./support/ci/deploy_website.sh
+    - os: linux
+      env:
+        - AFFECTED_DIRS="components/hab|components/common|components/core|components/builder-depot-client|components/http-client"
+        - HAB_BINTRAY_REPO=unstable
+        # HAB_ORIGIN_KEY
+        - secure: "uZ70GE8qK3GBgs7ZIsoy5DhPlHNs2hoLxLBGKq+u+0XrE017pOnW6mNHsn7J7i2r8CPtd4KFsFEN52wZSA+Sf96MFIL2w9E+geykBgbRMZzv4icuCf0xSGwm4iRMgZ9A08TfurMX6y6N+4JNsrCv9syVNuGq09EL2wLHPXOQhesMpodijQLcFikxfEXXbaWla1xHnYxJk+fbvYDoXVCbdqnpdeLTmGuQHFaaNI7jm1B3L/dl+IGZxwFdvqBT3G9mHiXBdyi8bALs7rcZNdV7PqtFFpp98zIeqwNHtHPd5cBRmqDRTRxucRSACS/lurrz9J+001a9RjPvUkYlLrn0hQY9pN6oo+kCpN/1r0bc17i4FbGx7R73FnFgPK/cno0ENBFygNZn7/jg6cENgjkBlHsZhc1+L1xhILo46nQU9XbWJrwelVYUOOGXI76tECOkGhkglx1vYK8fcMVLJMhL7psgPpbGbDJQDuAKhHS+75txNK+356ompNL+YUzeWZc4KSGZCNTQsPK+rsGttmA+JXtAaquFaY5xwSgyKHwETiSVg4dYXb3xh6goNxf2JTOZOosWaypyykHqcqsqCu2fzIDdmkgCx6I5/5q8I/7Z0es0jlUpHamlihZwe4E5YdYFCSouaDoeTnVdJKVI1p9fnAjpFqjivFgqLE/Z504vCNU="
+        - BINTRAY_USER=smurawski
+        # BINTRAY_KEY
+        - secure: "CHOiAfgFYbUBwYNIx7yJ7Y6697IzoX5zZtxHnByblU7Mei990vP+wUMjWrp2OY4I5UKdfSg5bkUtkEHBMUdoaiZZB+420dnZWPX94hQEYAGSdFzsgZlNZlu9vwnHout6+tDhylW0eIv7yMB1BViyOpeGxJ5rgCCmdDBEF5uWfnzuOMSeaOmcMQe24mzHY7vxIwfqJwEbVD08AOtJXVp2Kk0nLoA0GfJS1ZCcibK6TbXuZfUwYmF9jaZZdQj26UH8KtkiKYLy4Ti1c54XLwVahGeszBdi3xCAY6OWidAaTtnvEahtltXRl0HQCmhgLxpuZ/94lB4Mo4TqSf9NgZS7pqDB35YpYddy2hwW5HZFZlZoXgAqCTT+70NB0hoICpvNlvo4p7zRB7PVHbipgg64eA/OlLW+Bd4KXTHn+y+JrN1g9pDR9YF2lVewbmtzKbmxgQZYIrSK9SVZNP30DeN6uoedAxFFZGqgmPoC6Fcu5HG9Y1BY08HRVwRxLtLj8bciKgMHLNSKfVOdNlFac9nGn65aqenRGEmCd4wyjMZ7gd74V75aMdZozhFacDva0Qw5hRzhnJ8rYXBzG0juyodznMtVCARlRijPn0TW9LjYNb8+5f7LoxtywRmCNwYBB1OWghOePhWGMHBVAYTLzalIkX4WR0fc+xdhOq6lfAbgU4s="
+        # BINTRAY_PASSPHRASE
+        - secure: "XkZuLadu8aGACYdDN9QLUvuuGciiC8PahELGn2gfI8ILeIozzsWCclmNp2eKfduYsAu0otdps2dHAI1VwYH6+xGq+6byMMpXaXbQl3fahMe2vwaREpstmjbglWMNHcBqH4Bccx3aMxZjROO6NeT1U49uk7lKW+Enf+Dhw90L8sVP3v/xbmynYnue32heeQklkNH57RZ3uWJOUOPxOn5vcXsI0PqvJ8i53qIiUDQLivjLmOJUuudQiU/WP6rpewiIMoPO/REfyxq3gkCcYkzeXxytpVLEFwWjS6mvpLQbTJ+8/tp06sLXBxqknFboEWsqcraswROXi4ZXpubraFFNO/9jn9c1RaSmJqBEIQEK0/4K5VDYjukWMWpMQcwGq/I5dqUaDZJpoWPGqvw9b3zgsZNjlvLq2FEeuQEj2eD2Z4S5/PpgQRFhJMS+uMdPpingQMQAn9y83bZeDdtakWcX/IRjMBSF+UXCaXfTF9SWwURsCqakMEQhtZ+A3g5MAtZ6N/2QMsUcI7K56PjxXJiRSnZw821+VJgkpbk8Z8M2koZ6+Jy4jOGrUvDVGZ8umj3ipNmX8nFjP2s8jS7ihfIuG33p1fNw2397dEf0pDnPdsCnT/43c1RgTunpjla8486GirOApl/P8B0VXimwrquhkXxVItOYHX+O400UtC6C7MQ="
+      sudo: required
+      addons:
+        apt:
+          packages:
+          - ca-certificates
+          - curl
+          - wget
+      cache:
+        apt: true
+        directories:
+          - /root/travis_bootstrap
+          - /hab/studios/home--travis--build--habitat-sh
+          - /root/.cargo
+      before_install:
+        - ./support/ci/fast_pass.sh || exit 0
+      script:
+        - sudo ./support/ci/deploy_unstable.sh
     - os: osx
       osx_image: xcode6.4
       language: generic

--- a/components/bintray-publish/bin/publish-hab.sh
+++ b/components/bintray-publish/bin/publish-hab.sh
@@ -301,7 +301,7 @@ EOF
 # ## Default variables
 
 BINTRAY_ORG=habitat
-BINTRAY_REPO=${HAB_BINTRAY_REPO:-stable}
+BINTRAY_REPO=stable
 PATH=@path@
 
 # The current version of this program

--- a/components/bintray-publish/bin/publish-hab.sh
+++ b/components/bintray-publish/bin/publish-hab.sh
@@ -301,7 +301,7 @@ EOF
 # ## Default variables
 
 BINTRAY_ORG=habitat
-BINTRAY_REPO=stable
+BINTRAY_REPO=${HAB_BINTRAY_REPO:-stable}
 PATH=@path@
 
 # The current version of this program

--- a/support/ci/deploy_unstable.sh
+++ b/support/ci/deploy_unstable.sh
@@ -5,7 +5,7 @@ TEST_BIN_DIR=/root/hab_bins
 TRAVIS_HAB=${BOOTSTRAP_DIR}/hab
 HAB_DOWNLOAD_URL="https://api.bintray.com/content/habitat/stable/linux/x86_64/hab-%24latest-x86_64-linux.tar.gz?bt_package=hab-x86_64-linux"
 export HAB_ORIGIN=core
-export HAB_BINTRAY_REPO=unstable
+
 
 # download a hab binary to build hab from source in a studio
 wget -O hab.tar.gz "${HAB_DOWNLOAD_URL}"
@@ -37,5 +37,5 @@ if ([ "${TRAVIS_PULL_REQUEST}" = "false" ] && ["${TRAVIS_BRANCH}" = "master" ]);
     RELEASE=$(find ./results -name core-hab-0*.hart)
     echo "Publishing hab to unstable"
     ${TRAVIS_HAB} pkg install $PUBLISH
-    ${TRAVIS_HAB} pkg exec core/hab-bintray-publish publish-hab $RELEASE
+    ${TRAVIS_HAB} pkg exec core/hab-bintray-publish publish-hab -r unstable $RELEASE
 fi

--- a/support/ci/deploy_unstable.sh
+++ b/support/ci/deploy_unstable.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+BOOTSTRAP_DIR=/root/travis_bootstrap
+TEST_BIN_DIR=/root/hab_bins
+TRAVIS_HAB=${BOOTSTRAP_DIR}/hab
+HAB_DOWNLOAD_URL="https://api.bintray.com/content/habitat/stable/linux/x86_64/hab-%24latest-x86_64-linux.tar.gz?bt_package=hab-x86_64-linux"
+export HAB_ORIGIN=core
+export HAB_BINTRAY_REPO=unstable
+
+# download a hab binary to build hab from source in a studio
+wget -O hab.tar.gz "${HAB_DOWNLOAD_URL}"
+# install it in a custom location
+tar xvzf ./hab.tar.gz --strip 1 -C ${BOOTSTRAP_DIR}
+
+unset SUDO_USER
+
+cd ..
+cat << EOF > core.sig.key
+SIG-SEC-1
+core-20160810182414
+
+${HAB_ORIGIN_KEY}
+EOF
+
+${TRAVIS_HAB} origin key import < ./core.sig.key
+rm ./core.sig.key
+
+if ([ "${TRAVIS_PULL_REQUEST}" = "false" ] && ["${TRAVIS_BRANCH}" = "master" ]); then
+    mkdir -p ./release
+    rm -rf ./release/*
+    echo "Building bintray-publish"
+    ${TRAVIS_HAB} studio build habitat/components/bintray-publish > /root/bintray-publish_build.log 2>&1
+    echo "Building hab"
+    ${TRAVIS_HAB} studio build habitat/components/hab > /root/hab_build.log 2>&1
+    echo "Built new unstable version of hab"
+    PUBLISH=$(find ./results -name core-hab-bintray*.hart)
+    RELEASE=$(find ./results -name core-hab-0*.hart)
+    echo "Publishing hab to unstable"
+    ${TRAVIS_HAB} pkg install $PUBLISH
+    ${TRAVIS_HAB} pkg exec core/hab-bintray-publish publish-hab $RELEASE
+fi

--- a/support/ci/macos-pkg.sh
+++ b/support/ci/macos-pkg.sh
@@ -6,7 +6,7 @@ set -eu
 
 src_root=$(dirname $0)/../../
 
-if ([ "${TRAVIS_PULL_REQUEST}" = "false" ] && ["${TRAVIS_BRANCH}" = "master" ]); then
+if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
   sudo -E $src_root/components/hab/mac/mac-build.sh $src_root/components/hab/mac
   mkdir -p $src_root/out/hab-x86_64-darwin
   source $src_root/results/last_build.env


### PR DESCRIPTION

This builds and publishes trunk builds for the linux `hab` CLI when their are changes to the `hab` CLI  (or supporting crates) merged to master.  

Signed-off-by: Steven Murawski <steven.murawski@gmail.com>