### PR TITLE
only build mac cli off master and only when hab or hab deps change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -188,8 +188,11 @@ matrix:
       osx_image: xcode6.4
       language: generic
       sudo: true
+      before_install:
+        - ./support/ci/fast_pass.sh || exit 0
       script: support/ci/macos-pkg.sh
       env:
+        - AFFECTED_DIRS="components/hab|components/common|components/core|components/builder-depot-client|components/http-client"
         - secure: WUMBBYM1qMbmwXlf883rl6g5UqFTjtelawCOAhpSFSe9Kcit8HakutFr6b1NfTDF0b4S7R7YLj6j0Di2RP/Tk8brol/z/xmHHCWfFvadxhf/95HJbWmTeD0zDD3wpAbOfQCYHhSKYpLoXVpd/uZnnYLsTJNibFyO54SmOyApH0whHI0bYMZAOluB9vkIduH7Hv80lm4GA0xirHsuXYAirm0wYKdCx+ArWZfA9nci6NCa/D1swRvlmcnXeqvtTF3AJ5B6GP3+H5iDbam8anBe+dAe3YyqxTWw/+Th1h2F0h9Gghuh/dQNHZ7QqGV/rc5jY5jiRo41kptbgj8TBuY+4URsCfm/l5lKvm7GCtUp9LFq/rIaLLatp7mCwQeGwepWTnw9qe2scSP4XsyxusWbvxMQTfmccRq6dydwD1JgXy25pOKVTKY8uVk9THF5uvViYwsdUOGJWvkOHUZArHc0oSqi3cFp7DKTrP1nig4Oqd+9w6lbOPnEdWgGcu11k2rG/cpF0X/+sXD+CAR607ctVTxxW5WzZePtwqWqy5IujO4Uh8CnwUDB51TETbhIsteFHBwv2n08DUVEatew2sEhXJJ2eI3UMxnXPOFCI2197BoTjHU7FHW+z5Vx2JSKb6VTULCDHXYId4XjjVbh7WzyAEVkFituAcddqXpn6HOxqOo=
       deploy:
         on: master

--- a/support/ci/macos-pkg.sh
+++ b/support/ci/macos-pkg.sh
@@ -6,7 +6,7 @@ set -eu
 
 src_root=$(dirname $0)/../../
 
-if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+if ([ "${TRAVIS_PULL_REQUEST}" = "false" ] && ["${TRAVIS_BRANCH}" = "master" ]); then
   sudo -E $src_root/components/hab/mac/mac-build.sh $src_root/components/hab/mac
   mkdir -p $src_root/out/hab-x86_64-darwin
   source $src_root/results/last_build.env
@@ -37,7 +37,7 @@ cat <<- EOF > $src_root/out/hab-bintray.json
   "files": [
     {
       "includePattern": "out/hab-x86_64-darwin.zip",
-      "uploadPattern": "hab-${pkg_version}-${pkg_release}-x86_64-darwin.zip"
+      "uploadPattern": "darwin/x86_64/hab-${pkg_version}-${pkg_release}-x86_64-darwin.zip"
     }
   ],
   "publish": true


### PR DESCRIPTION
@reset the mac build attempts to run on sentinel evals of merges and will run for any changes to the repo.  These changes should scope the build to running only when the `hab` or its deps change.

Signed-off-by: Steven Murawski <steven.murawski@gmail.com>