### PR TITLE
More events infra work

### DIFF
--- a/components/builder-api/src/config.rs
+++ b/components/builder-api/src/config.rs
@@ -41,6 +41,8 @@ pub struct Config {
     pub github_client_secret: String,
     /// Path to UI files to host over HTTP. If not set the UI will be disabled.
     pub ui_root: Option<String>,
+    /// Whether to log events for funnel metrics
+    pub events_enabled: bool,
 }
 
 impl Config {
@@ -61,6 +63,7 @@ impl Default for Config {
             github_client_id: DEV_GITHUB_CLIENT_ID.to_string(),
             github_client_secret: DEV_GITHUB_CLIENT_SECRET.to_string(),
             ui_root: None,
+            events_enabled: false, // TODO: change to default to true later
         }
     }
 }
@@ -80,15 +83,18 @@ impl ConfigFile for Config {
         try!(toml.parse_into("cfg.depot.datastore_addr", &mut cfg.depot.datastore_addr));
         try!(toml.parse_into("cfg.github.url", &mut cfg.github_url));
         try!(toml.parse_into("cfg.github.url", &mut cfg.depot.github_url));
-        if !try!(toml.parse_into("cfg.github.client_id", &mut cfg.github_client_id)) {
+        try!(toml.parse_into("cfg.github.client_id", &mut cfg.github_client_id));
+        if cfg.github_client_id.is_empty() {
             return Err(Error::from(hab_net::Error::RequiredConfigField("github.client_id")));
         }
         try!(toml.parse_into("cfg.github.client_id", &mut cfg.depot.github_client_id));
-        if !try!(toml.parse_into("cfg.github.client_secret", &mut cfg.github_client_secret)) {
+        try!(toml.parse_into("cfg.github.client_secret", &mut cfg.github_client_secret));
+        if cfg.github_client_secret.is_empty() {
             return Err(Error::from(hab_net::Error::RequiredConfigField("github.client_secret")));
         }
         try!(toml.parse_into("cfg.github.client_secret",
                              &mut cfg.depot.github_client_secret));
+        try!(toml.parse_into("cfg.events_enabled", &mut cfg.events_enabled));
         Ok(cfg)
     }
 }

--- a/components/builder-api/src/http/mod.rs
+++ b/components/builder-api/src/http/mod.rs
@@ -23,10 +23,11 @@ use depot;
 use hab_net::http::middleware::*;
 use hab_net::oauth::github::GitHubClient;
 use hab_net::privilege;
+use hab_core::event::EventLogger;
 use iron::prelude::*;
 use iron::Protocol;
 use mount::Mount;
-use persistent;
+use persistent::{self, Read};
 use staticfile::Static;
 
 use config::Config;
@@ -70,6 +71,8 @@ pub fn router(config: Arc<Config>) -> Result<Chain> {
     );
     let mut chain = Chain::new(router);
     chain.link(persistent::Read::<GitHubCli>::both(GitHubClient::new(&*config)));
+    chain.link(Read::<EventLog>::both(EventLogger::new("hab-builder-api", config.events_enabled)));
+
     chain.link_before(RouteBroker);
     chain.link_after(Cors);
     Ok(chain)

--- a/components/builder-api/src/lib.rs
+++ b/components/builder-api/src/lib.rs
@@ -14,6 +14,7 @@
 
 extern crate bodyparser;
 extern crate habitat_builder_protocol as protocol;
+#[macro_use]
 extern crate habitat_core as hab_core;
 extern crate habitat_depot as depot;
 extern crate habitat_net as hab_net;


### PR DESCRIPTION
Signed-off-by: Salim Alam <salam@chef.io>

This change adds the following:
1. Builder-api configuration for whether events logging is on or off (current default: off)
2. Capability to hook the EventLogger into the Iron chain
3. Add account id from Session into the project-create event

![source](https://cloud.githubusercontent.com/assets/13542112/20502492/20e2c68c-aff3-11e6-9759-803d675debf9.gif)
