### PR TITLE
Get the builds green

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -186,7 +186,7 @@ matrix:
       script: ./support/ci/deploy_website.sh
     - os: linux
       env:
-        - AFFECTED_DIRS="components/hab|components/common|components/core|components/builder-depot-client|components/http-client"
+        - AFFECTED_DIRS="Cargo\.toml|Cargo\.lock|components/hab|components/common|components/core|components/builder-depot-client|components/http-client"
         # HAB_ORIGIN_KEY
         - secure: "uZ70GE8qK3GBgs7ZIsoy5DhPlHNs2hoLxLBGKq+u+0XrE017pOnW6mNHsn7J7i2r8CPtd4KFsFEN52wZSA+Sf96MFIL2w9E+geykBgbRMZzv4icuCf0xSGwm4iRMgZ9A08TfurMX6y6N+4JNsrCv9syVNuGq09EL2wLHPXOQhesMpodijQLcFikxfEXXbaWla1xHnYxJk+fbvYDoXVCbdqnpdeLTmGuQHFaaNI7jm1B3L/dl+IGZxwFdvqBT3G9mHiXBdyi8bALs7rcZNdV7PqtFFpp98zIeqwNHtHPd5cBRmqDRTRxucRSACS/lurrz9J+001a9RjPvUkYlLrn0hQY9pN6oo+kCpN/1r0bc17i4FbGx7R73FnFgPK/cno0ENBFygNZn7/jg6cENgjkBlHsZhc1+L1xhILo46nQU9XbWJrwelVYUOOGXI76tECOkGhkglx1vYK8fcMVLJMhL7psgPpbGbDJQDuAKhHS+75txNK+356ompNL+YUzeWZc4KSGZCNTQsPK+rsGttmA+JXtAaquFaY5xwSgyKHwETiSVg4dYXb3xh6goNxf2JTOZOosWaypyykHqcqsqCu2fzIDdmkgCx6I5/5q8I/7Z0es0jlUpHamlihZwe4E5YdYFCSouaDoeTnVdJKVI1p9fnAjpFqjivFgqLE/Z504vCNU="
         - BINTRAY_USER=smurawski
@@ -219,7 +219,7 @@ matrix:
         - ./support/ci/fast_pass.sh || exit 0
       script: support/ci/macos-pkg.sh
       env:
-        - AFFECTED_DIRS="components/hab|components/common|components/core|components/builder-depot-client|components/http-client"
+        - AFFECTED_DIRS="Cargo\.toml|Cargo\.lock|components/hab|components/common|components/core|components/builder-depot-client|components/http-client"
         - secure: WUMBBYM1qMbmwXlf883rl6g5UqFTjtelawCOAhpSFSe9Kcit8HakutFr6b1NfTDF0b4S7R7YLj6j0Di2RP/Tk8brol/z/xmHHCWfFvadxhf/95HJbWmTeD0zDD3wpAbOfQCYHhSKYpLoXVpd/uZnnYLsTJNibFyO54SmOyApH0whHI0bYMZAOluB9vkIduH7Hv80lm4GA0xirHsuXYAirm0wYKdCx+ArWZfA9nci6NCa/D1swRvlmcnXeqvtTF3AJ5B6GP3+H5iDbam8anBe+dAe3YyqxTWw/+Th1h2F0h9Gghuh/dQNHZ7QqGV/rc5jY5jiRo41kptbgj8TBuY+4URsCfm/l5lKvm7GCtUp9LFq/rIaLLatp7mCwQeGwepWTnw9qe2scSP4XsyxusWbvxMQTfmccRq6dydwD1JgXy25pOKVTKY8uVk9THF5uvViYwsdUOGJWvkOHUZArHc0oSqi3cFp7DKTrP1nig4Oqd+9w6lbOPnEdWgGcu11k2rG/cpF0X/+sXD+CAR607ctVTxxW5WzZePtwqWqy5IujO4Uh8CnwUDB51TETbhIsteFHBwv2n08DUVEatew2sEhXJJ2eI3UMxnXPOFCI2197BoTjHU7FHW+z5Vx2JSKb6VTULCDHXYId4XjjVbh7WzyAEVkFituAcddqXpn6HOxqOo=
       deploy:
         on: master

--- a/support/ci/appveyor.ps1
+++ b/support/ci/appveyor.ps1
@@ -6,7 +6,8 @@ function Test-ComponentChanged ($path) {
 }
 
 function Test-SourceChanged {
-    $BuildFiles = "appveyor.yml", "build.ps1", "support/ci/appveyor.ps1", "support/ci/appveyor.bat"
+    $BuildFiles = "appveyor.yml", "build.ps1", "support/ci/appveyor.ps1", "support/ci/appveyor.bat", 
+                  "Cargo.toml", "Cargo.lock"
     (git diff master --name-only | 
                 where-object {
                     ($BuildFiles -contains $_ ) -or

--- a/support/ci/deploy_unstable.sh
+++ b/support/ci/deploy_unstable.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# fail fast if we aren't on the desired branch or if this is a pull request
+if ([ "${TRAVIS_PULL_REQUEST}" = "true" ] || ["${TRAVIS_BRANCH}" != "smurawski/fix_linux_build" ]); then
+    exit 0
+fi
+
 BOOTSTRAP_DIR=/root/travis_bootstrap
 TEST_BIN_DIR=/root/hab_bins
 TRAVIS_HAB=${BOOTSTRAP_DIR}/hab
@@ -12,9 +17,14 @@ wget -O hab.tar.gz "${HAB_DOWNLOAD_URL}"
 # install it in a custom location
 tar xvzf ./hab.tar.gz --strip 1 -C ${BOOTSTRAP_DIR}
 
+# so key stuff doesn't get funky
 unset SUDO_USER
 
+# move up one level so our hab studio build is in the right place
+# as it expects to be one level up from the source dir.
 cd ..
+
+# create our origin key
 cat << EOF > core.sig.key
 SIG-SEC-1
 core-20160810182414
@@ -25,17 +35,20 @@ EOF
 ${TRAVIS_HAB} origin key import < ./core.sig.key
 rm ./core.sig.key
 
-if ([ "${TRAVIS_PULL_REQUEST}" = "false" ] && ["${TRAVIS_BRANCH}" = "master" ]); then
-    mkdir -p ./release
-    rm -rf ./release/*
-    echo "Building bintray-publish"
-    ${TRAVIS_HAB} studio build habitat/components/bintray-publish > /root/bintray-publish_build.log 2>&1
-    echo "Building hab"
-    ${TRAVIS_HAB} studio build habitat/components/hab > /root/hab_build.log 2>&1
-    echo "Built new unstable version of hab"
-    PUBLISH=$(find ./results -name core-hab-bintray*.hart)
-    RELEASE=$(find ./results -name core-hab-0*.hart)
-    echo "Publishing hab to unstable"
-    ${TRAVIS_HAB} pkg install $PUBLISH
-    ${TRAVIS_HAB} pkg exec core/hab-bintray-publish publish-hab -r unstable $RELEASE
-fi
+# make sure we don't have an older, cached release
+mkdir -p ./release
+rm -rf ./release/*
+
+# until we pulish the newer version of bintray-publish with the cli switches
+# we have to build it here
+echo "Building bintray-publish"
+${TRAVIS_HAB} studio build habitat/components/bintray-publish > /root/bintray-publish_build.log 2>&1
+echo "Building hab"
+${TRAVIS_HAB} studio build habitat/components/hab > /root/hab_build.log 2>&1
+echo "Built new unstable version of hab"
+
+echo "Publishing hab to unstable"
+PUBLISH=$(find ./results -name core-hab-bintray*.hart)
+RELEASE=$(find ./results -name core-hab-0*.hart)
+${TRAVIS_HAB} pkg install $PUBLISH
+${TRAVIS_HAB} pkg exec core/hab-bintray-publish publish-hab -r unstable $RELEASE

--- a/support/ci/deploy_unstable.sh
+++ b/support/ci/deploy_unstable.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 # fail fast if we aren't on the desired branch or if this is a pull request
-if ([ "${TRAVIS_PULL_REQUEST}" = "true" ] || ["${TRAVIS_BRANCH}" != "smurawski/fix_linux_build" ]); then
+if [[ "${TRAVIS_PULL_REQUEST}" = "true" ]] || [[ "${TRAVIS_BRANCH}" != "master" ]]; then
+    echo "We only publish on successful builds of master."
     exit 0
 fi
 
@@ -11,7 +12,7 @@ TRAVIS_HAB=${BOOTSTRAP_DIR}/hab
 HAB_DOWNLOAD_URL="https://api.bintray.com/content/habitat/stable/linux/x86_64/hab-%24latest-x86_64-linux.tar.gz?bt_package=hab-x86_64-linux"
 export HAB_ORIGIN=core
 
-
+mkdir -p ${BOOTSTRAP_DIR}
 # download a hab binary to build hab from source in a studio
 wget -O hab.tar.gz "${HAB_DOWNLOAD_URL}"
 # install it in a custom location
@@ -44,7 +45,7 @@ rm -rf ./release/*
 echo "Building bintray-publish"
 ${TRAVIS_HAB} studio build habitat/components/bintray-publish > /root/bintray-publish_build.log 2>&1
 echo "Building hab"
-${TRAVIS_HAB} studio build habitat/components/hab > /root/hab_build.log 2>&1
+${TRAVIS_HAB} studio build habitat/components/hab
 echo "Built new unstable version of hab"
 
 echo "Publishing hab to unstable"

--- a/support/ci/fast_pass.sh
+++ b/support/ci/fast_pass.sh
@@ -15,7 +15,12 @@ elif [ -z "$AFFECTED_DIRS" ]; then
 else
   # If $AFFECTED_DIRS (a "|" separated list of directories) is set, see if we have
   # any changes
-  git diff --name-only "$TRAVIS_COMMIT_RANGE" | grep -qE "^($AFFECTED_DIRS)" || {
+
+  # TRAVIS_COMMIT_RANGE is empty for the first push to a new branch (which is how our bot
+  # validates before merge), so if TRAVIS_COMMIT_RANGE is empty, we'll look for the
+  # last merge commit and check from there.
+  COMMIT_RANGE=${TRAVIS_COMMIT_RANGE:-$(git show :/^Merge --pretty=format:%H)}
+  git diff --name-only "$COMMIT_RANGE" | grep -qE "^($AFFECTED_DIRS)" || {
     echo "No files in $AFFECTED_DIRS have changed. Skipping CI run."
     exit 1
   }


### PR DESCRIPTION
After both @adamhjk  and @chefsalim had errors in their builds due to failure to exec the deploy_unstable.sh, I dug deeper and found it lost its execute context.

I fixed that and cleaned up and commented some of the steps.

I also added Cargo.toml and Cargo.lock as possible triggers for rebuilds to unstable for Linux, Mac, and Windows builds