### PR TITLE
More infra and events for builder services

### DIFF
--- a/components/builder-api/src/config.rs
+++ b/components/builder-api/src/config.rs
@@ -95,6 +95,7 @@ impl ConfigFile for Config {
         try!(toml.parse_into("cfg.github.client_secret",
                              &mut cfg.depot.github_client_secret));
         try!(toml.parse_into("cfg.events_enabled", &mut cfg.events_enabled));
+        try!(toml.parse_into("cfg.events_enabled", &mut cfg.depot.events_enabled));
         Ok(cfg)
     }
 }

--- a/components/builder-depot/src/config.rs
+++ b/components/builder-depot/src/config.rs
@@ -46,6 +46,8 @@ pub struct Config {
     pub github_client_secret: String,
     /// allows you to upload packages and public keys without auth
     pub insecure: bool,
+    /// Whether to log events for funnel metrics
+    pub events_enabled: bool,
 }
 
 impl ConfigFile for Config {
@@ -57,6 +59,7 @@ impl ConfigFile for Config {
         try!(toml.parse_into("cfg.bind_addr", &mut cfg.listen_addr));
         try!(toml.parse_into("cfg.datastore_addr", &mut cfg.datastore_addr));
         try!(toml.parse_into("cfg.router_addrs", &mut cfg.routers));
+        try!(toml.parse_into("cfg.events_enabled", &mut cfg.events_enabled));
         Ok(cfg)
     }
 }
@@ -72,6 +75,7 @@ impl Default for Config {
             github_client_id: DEV_GITHUB_CLIENT_ID.to_string(),
             github_client_secret: DEV_GITHUB_CLIENT_SECRET.to_string(),
             insecure: false,
+            events_enabled: false, // TODO: change to default to true later
         }
     }
 }

--- a/components/builder-depot/src/lib.rs
+++ b/components/builder-depot/src/lib.rs
@@ -14,6 +14,7 @@
 
 extern crate habitat_builder_dbcache as dbcache;
 extern crate habitat_builder_protocol as protocol;
+#[macro_use]
 extern crate habitat_core as hab_core;
 extern crate habitat_net as hab_net;
 extern crate bodyparser;

--- a/components/core/src/event.rs
+++ b/components/core/src/event.rs
@@ -49,13 +49,51 @@ pub enum Event<'a> {
         package: &'a str,
         account: &'a str,
     },
+    PackageUpload {
+        origin: &'a str,
+        package: &'a str,
+        version: &'a str,
+        release: &'a str,
+        account: &'a str,
+    },
+    OriginKeyUpload {
+        origin: &'a str,
+        version: &'a str,
+        account: &'a str,
+    },
+    OriginSecretKeyUpload {
+        origin: &'a str,
+        version: &'a str,
+        account: &'a str,
+    },
+    OriginInvitationSend {
+        origin: &'a str,
+        user: &'a str,
+        id: &'a str,
+        account: &'a str,
+    },
+    OriginInvitationAccept { id: &'a str, account: &'a str },
+    OriginInvitationIgnore { id: &'a str, account: &'a str },
+    JobCreate { package: &'a str, account: &'a str },
+    GithubAuthenticate { user: &'a str, account: &'a str },
 }
 
 impl<'a> fmt::Display for Event<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let msg = match *self {
             Event::ProjectCreate { origin: _, package: _, account: _ } => "project-create",
+            Event::PackageUpload { origin: _, package: _, version: _, release: _, account: _ } => {
+                "package-upload"
+            }
+            Event::OriginKeyUpload { origin: _, version: _, account: _ } => "origin-key-upload",
+            Event::OriginSecretKeyUpload { origin: _, version: _, account: _ } => "origin-secret-key-upload",
+            Event::OriginInvitationSend { origin: _, user: _, id: _, account: _ } => "origin-invitation-send",
+            Event::OriginInvitationAccept { id: _, account: _ } => "origin-invitation-accept",
+            Event::OriginInvitationIgnore { id: _, account: _ } => "origin-invitation-ignore",
+            Event::JobCreate { package: _, account: _ } => "job-create",
+            Event::GithubAuthenticate { user: _, account: _ } => "github-authenticate",
         };
+
         write!(f, "{}", msg)
     }
 }
@@ -69,6 +107,52 @@ impl<'a> ToJson for Event<'a> {
             Event::ProjectCreate { origin: ref o, package: ref p, account: ref a } => {
                 m.insert("origin".to_string(), o.to_json());
                 m.insert("package".to_string(), p.to_json());
+                m.insert("account".to_string(), a.to_json());
+            }
+            Event::PackageUpload { origin: ref o,
+                                   package: ref p,
+                                   version: ref v,
+                                   release: ref r,
+                                   account: ref a } => {
+                m.insert("origin".to_string(), o.to_json());
+                m.insert("package".to_string(), p.to_json());
+                m.insert("version".to_string(), v.to_json());
+                m.insert("release".to_string(), r.to_json());
+                m.insert("account".to_string(), a.to_json());
+            }
+            Event::OriginInvitationSend { origin: ref o,
+                                          user: ref u,
+                                          id: ref i,
+                                          account: ref a } => {
+                m.insert("origin".to_string(), o.to_json());
+                m.insert("user".to_string(), u.to_json());
+                m.insert("id".to_string(), i.to_json());
+                m.insert("account".to_string(), a.to_json());
+            }
+            Event::OriginInvitationAccept { id: ref i, account: ref a } => {
+                m.insert("id".to_string(), i.to_json());
+                m.insert("account".to_string(), a.to_json());
+            }
+            Event::OriginInvitationIgnore { id: ref i, account: ref a } => {
+                m.insert("id".to_string(), i.to_json());
+                m.insert("account".to_string(), a.to_json());
+            }
+            Event::JobCreate { package: ref p, account: ref a } => {
+                m.insert("package".to_string(), p.to_json());
+                m.insert("account".to_string(), a.to_json());
+            }
+            Event::GithubAuthenticate { user: ref u, account: ref a } => {
+                m.insert("user".to_string(), u.to_json());
+                m.insert("account".to_string(), a.to_json());
+            }
+            Event::OriginKeyUpload { origin: ref o, version: ref v, account: ref a } => {
+                m.insert("origin".to_string(), o.to_json());
+                m.insert("version".to_string(), v.to_json());
+                m.insert("account".to_string(), a.to_json());
+            }
+            Event::OriginSecretKeyUpload { origin: ref o, version: ref v, account: ref a } => {
+                m.insert("origin".to_string(), o.to_json());
+                m.insert("version".to_string(), v.to_json());
                 m.insert("account".to_string(), a.to_json());
             }
         };

--- a/support/ci/install_rustfmt.sh
+++ b/support/ci/install_rustfmt.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eu
 
-version=0.6.2
+version=0.6.3
 
 if command -v rustfmt >/dev/null; then
   if [[ $(rustfmt --version | cut -d ' ' -f 1) = "$version" ]]; then

--- a/support/ci/lint.sh
+++ b/support/ci/lint.sh
@@ -47,7 +47,7 @@ exit_with() {
 }
 
 program=$(basename $0)
-rf_version="0.6.2"
+rf_version="0.6.3"
 
 # Fix commit range in Travis, if set.
 # See: https://github.com/travis-ci/travis-ci/issues/4596


### PR DESCRIPTION
Signed-off-by: Salim Alam <salam@chef.io>

This change adds event capability to builder-depot, and adds a number of new events to be written out to disk. By default, event logging is turned off (the default will be changed later), but can be turned on via the builder-api config file.

![200](https://cloud.githubusercontent.com/assets/13542112/20547823/940f8b00-b0d3-11e6-873d-aa45a9b1c828.gif)
