### PR TITLE
More Travis Fun

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -208,6 +208,7 @@ matrix:
           - /root/.cargo
       before_install:
         - ./support/ci/fast_pass.sh || exit 0
+        - if [[ ! -x ./support/ci/deploy_unstable.sh ]]; then chmod +x ./support/ci/deploy_unstable.sh; fi
       script:
         - sudo ./support/ci/deploy_unstable.sh
     - os: osx

--- a/support/ci/deploy_unstable.sh
+++ b/support/ci/deploy_unstable.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # fail fast if we aren't on the desired branch or if this is a pull request
-if [[ "${TRAVIS_PULL_REQUEST}" = "true" ]] || [[ "${TRAVIS_BRANCH}" != "master" ]]; then
+if [[ "${TRAVIS_PULL_REQUEST}" != "false" ]] || [[ "${TRAVIS_BRANCH}" != "master" ]]; then
     echo "We only publish on successful builds of master."
     exit 0
 fi


### PR DESCRIPTION
First off, I should RTFM better - TRAVIS_PULL_REQUEST is the PR # or false, not true or false, so my conditional was wrong.  

Second, somewhere, sometimes, Travis seems to lose the executable status of ./support/ci/deploy_unstable.sh.  What's odd is that it works on some builds but not others.  I added a conditional into the travis steps to check if it is executable and if not, make it so.  It feels so ugly, but I'm not sure what else to do there.