### PR TITLE
De-duplicate the list of packages on the origin detail page

### DIFF
--- a/components/builder-depot/src/data_store.rs
+++ b/components/builder-depot/src/data_store.rs
@@ -238,7 +238,25 @@ impl PackagesIndex {
                           record.get_ident().get_version(),
                           record.to_string()),
                   0)
+            .ignore()
+            .zadd(Self::unique_prefix(),
+                  format!("{}:{}",
+                          record.get_ident().get_origin(),
+                          record.get_ident().get_name()),
+                  0)
+            .ignore()
+            .zadd(Self::unique_idx(record), record.get_ident().get_name())
             .ignore();
+    }
+
+    fn unique_prefix() -> &'static str {
+        "package:ident:unique:index"
+    }
+
+    fn unique_idx(package: &depotsrv::Package) -> String {
+        format!("{}:{}",
+                Self::unique_prefix(),
+                package.get_ident().get_origin())
     }
 
     fn origin_idx(package: &depotsrv::Package) -> String {

--- a/components/builder-depot/src/data_store.rs
+++ b/components/builder-depot/src/data_store.rs
@@ -170,11 +170,12 @@ impl PackagesIndex {
             Ok(ids) => {
                 // JW TODO: This in-memory sorting logic can be removed once the Redis sorted set
                 // is pre-sorted on write. For now, we'll do it on read each time.
-                let mut ids: Vec<package::PackageIdent> =
-                    ids.iter().map(|id| package::PackageIdent::from_str(id).unwrap()).collect();
-                ids.sort();
-                let ids = ids.into_iter().map(|id| depotsrv::PackageIdent::from(id)).collect();
-                Ok(ids)
+                let mut idz: Vec<package::PackageIdent> = ids.iter()
+                    .map(|iz| package::PackageIdent::from_str(&format!("{}/{}", &id, &iz)).unwrap())
+                    .collect();
+                idz.sort();
+                let new_ids = idz.into_iter().map(|zd| depotsrv::PackageIdent::from(zd)).collect();
+                Ok(new_ids)
             }
             Err(e) => Err(Error::from(e)),
         }

--- a/components/builder-depot/src/server.rs
+++ b/components/builder-depot/src/server.rs
@@ -1049,8 +1049,7 @@ pub fn router(depot: Depot) -> Result<Chain> {
 
         package_search: get "/pkgs/search/:query" => search_packages,
         packages: get "/pkgs/:origin" => list_packages,
-        // JB TODO - this URL needs to change otherwise no one will be able to upload a package called "unique"
-        packages_unique: get "/pkgs/:origin/unique" => list_unique_packages,
+        packages_unique: get "/pkgs-unique/:origin" => list_unique_packages,
         packages_pkg: get "/pkgs/:origin/:pkg" => list_packages,
         package_pkg_latest: get "/pkgs/:origin/:pkg/latest" => show_package,
         packages_version: get "/pkgs/:origin/:pkg/:version" => list_packages,

--- a/components/builder-depot/src/server.rs
+++ b/components/builder-depot/src/server.rs
@@ -664,6 +664,49 @@ fn list_origin_keys(req: &mut Request) -> IronResult<Response> {
     }
 }
 
+fn list_unique_packages(req: &mut Request) -> IronResult<Response> {
+    let depot = req.get::<persistent::Read<Depot>>().unwrap();
+    let (start, stop) = match extract_pagination(req) {
+        Ok(range) => range,
+        Err(response) => return Ok(response),
+    };
+    let params = req.extensions.get::<Router>().unwrap();
+    let ident: String = match params.find("origin") {
+        Some(origin) => origin.to_string(),
+        None => return Ok(Response::with(status::BadRequest)),
+    };
+
+    match depot.datastore.packages.index.unique(&ident, start, stop) {
+        Ok(packages) => {
+            let count = depot.datastore.packages.index.count_unique(&ident).unwrap();
+            debug!("list_unique_packages start: {}, stop: {}, total count: {}",
+                   start,
+                   stop,
+                   count);
+            let body = package_results_json(&packages, count as isize, start, stop);
+
+            let mut response = if count as isize > (stop + 1) {
+                Response::with((status::PartialContent, body))
+            } else {
+                Response::with((status::Ok, body))
+            };
+
+            response.headers.set(ContentType(Mime(TopLevel::Application,
+                                                  SubLevel::Json,
+                                                  vec![(Attr::Charset, Value::Utf8)])));
+            dont_cache_response(&mut response);
+            Ok(response)
+        }
+        Err(Error::DataStore(dbcache::Error::EntityNotFound)) => {
+            Ok(Response::with((status::NotFound)))
+        }
+        Err(e) => {
+            error!("list_packages:2, err={:?}", e);
+            Ok(Response::with(status::InternalServerError))
+        }
+    }
+}
+
 fn list_packages(req: &mut Request) -> IronResult<Response> {
     let depot = req.get::<persistent::Read<Depot>>().unwrap();
     let (start, stop) = match extract_pagination(req) {
@@ -1006,6 +1049,8 @@ pub fn router(depot: Depot) -> Result<Chain> {
 
         package_search: get "/pkgs/search/:query" => search_packages,
         packages: get "/pkgs/:origin" => list_packages,
+        // JB TODO - this URL needs to change otherwise no one will be able to upload a package called "unique"
+        packages_unique: get "/pkgs/:origin/unique" => list_unique_packages,
         packages_pkg: get "/pkgs/:origin/:pkg" => list_packages,
         package_pkg_latest: get "/pkgs/:origin/:pkg/latest" => show_package,
         packages_version: get "/pkgs/:origin/:pkg/:version" => list_packages,

--- a/components/builder-depot/src/server.rs
+++ b/components/builder-depot/src/server.rs
@@ -1049,7 +1049,7 @@ pub fn router(depot: Depot) -> Result<Chain> {
 
         package_search: get "/pkgs/search/:query" => search_packages,
         packages: get "/pkgs/:origin" => list_packages,
-        packages_unique: get "/pkgs-unique/:origin" => list_unique_packages,
+        packages_unique: get "/:origin/pkgs" => list_unique_packages,
         packages_pkg: get "/pkgs/:origin/:pkg" => list_packages,
         package_pkg_latest: get "/pkgs/:origin/:pkg/latest" => show_package,
         packages_version: get "/pkgs/:origin/:pkg/:version" => list_packages,

--- a/components/builder-web/app/actions/index.ts
+++ b/components/builder-web/app/actions/index.ts
@@ -153,6 +153,7 @@ export const populateExplore = packageActions.populateExplore;
 export const setCurrentPackage = packageActions.setCurrentPackage;
 export const setPackagesSearchQuery = packageActions.setPackagesSearchQuery;
 export const setVisiblePackages = packageActions.setVisiblePackages;
+export const getUniquePackages = packageActions.getUniquePackages;
 
 export const addProject = projectActions.addProject;
 export const fetchBuilds = projectActions.fetchBuilds;

--- a/components/builder-web/app/actions/packages.ts
+++ b/components/builder-web/app/actions/packages.ts
@@ -50,12 +50,31 @@ export function fetchPackage(pkg) {
     };
 }
 
+export function getUniquePackages(
+    origin: string,
+    nextRange: number = 0,
+    token: string = ""
+) {
+    return dispatch => {
+        if (nextRange === 0) {
+            dispatch(clearPackages());
+        }
+
+        depotApi.getUnique(origin, nextRange).then(response => {
+            dispatch(setVisiblePackages(response["results"]));
+            dispatch(setPackagesTotalCount(response["totalCount"]));
+            dispatch(setPackagesNextRange(response["nextRange"]));
+            dispatch(fetchProjectsForPackages(response["results"], token));
+        }).catch(error => {
+            dispatch(setVisiblePackages(undefined, error));
+        });
+    };
+}
+
 export function filterPackagesBy(
     params,
     query: string,
-    nextRange: number = 0,
-    fetchProjects: boolean = false,
-    token: string = ""
+    nextRange: number = 0
 ) {
     return dispatch => {
         if (nextRange === 0) {
@@ -70,10 +89,6 @@ export function filterPackagesBy(
             dispatch(setVisiblePackages(response["results"]));
             dispatch(setPackagesTotalCount(response["totalCount"]));
             dispatch(setPackagesNextRange(response["nextRange"]));
-
-            if (fetchProjects) {
-                dispatch(fetchProjectsForPackages(response["results"], token));
-            }
         }).catch(error => {
             dispatch(setVisiblePackages(undefined, error));
         });

--- a/components/builder-web/app/depotApi.ts
+++ b/components/builder-web/app/depotApi.ts
@@ -18,6 +18,34 @@ import {packageString} from "./util";
 
 const urlPrefix = config["habitat_api_url"] || "";
 
+export function getUnique(origin: string, nextRange: number = 0) {
+    const url = `${urlPrefix}/depot/pkgs-unique/${origin}?range=${nextRange}`;
+
+    return new Promise((resolve, reject) => {
+        fetch(url).then(response => {
+            if (response.status >= 400) {
+                reject(new Error(response.statusText));
+            }
+
+            response.json().then(resultsObj => {
+                let results;
+
+                const endRange = parseInt(resultsObj.range_end, 10);
+                const totalCount = parseInt(resultsObj.total_count, 10);
+                const nextRange = totalCount > (endRange + 1) ? endRange + 1 : 0;
+
+                if (resultsObj["package_list"]) {
+                    results = resultsObj["package_list"];
+                } else {
+                    results = resultsObj;
+                }
+
+                resolve({ results, totalCount, nextRange });
+            });
+        }).catch(error => reject(error));
+    });
+}
+
 export function get(params, nextRange: number = 0) {
     const url = `${urlPrefix}/depot/pkgs/` +
         (params["query"] ? `search/${params["query"]}`

--- a/components/builder-web/app/depotApi.ts
+++ b/components/builder-web/app/depotApi.ts
@@ -19,7 +19,7 @@ import {packageString} from "./util";
 const urlPrefix = config["habitat_api_url"] || "";
 
 export function getUnique(origin: string, nextRange: number = 0) {
-    const url = `${urlPrefix}/depot/pkgs-unique/${origin}?range=${nextRange}`;
+    const url = `${urlPrefix}/depot/${origin}/pkgs?range=${nextRange}`;
 
     return new Promise((resolve, reject) => {
         fetch(url).then(response => {

--- a/components/builder-web/app/origin-page/OriginPageComponent.ts
+++ b/components/builder-web/app/origin-page/OriginPageComponent.ts
@@ -19,7 +19,7 @@ import {fetchOrigin, fetchOriginInvitations, fetchOriginMembers,
         fetchOriginPublicKeys, inviteUserToOrigin, setCurrentOriginAddingPublicKey,
         setCurrentOriginAddingPrivateKey, uploadOriginPrivateKey,
         uploadOriginPublicKey, filterPackagesBy, fetchMyOrigins,
-        setProjectHint, requestRoute, setCurrentProject} from "../actions/index";
+        setProjectHint, requestRoute, setCurrentProject, getUniquePackages} from "../actions/index";
 import config from "../config";
 import {KeyAddFormComponent} from "./KeyAddFormComponent";
 import {KeyListComponent} from "./KeyListComponent";
@@ -27,7 +27,7 @@ import {Origin} from "../records/Origin";
 import {OriginMembersTabComponent} from "./OriginMembersTabComponent";
 import {TabComponent} from "../TabComponent";
 import {TabsComponent} from "../TabsComponent";
-import {requireSignIn} from "../util";
+import {requireSignIn, packageString} from "../util";
 import {PackagesListComponent} from "../packages-list/PackagesListComponent";
 import {Subscription} from "rxjs/Subscription";
 import {FeatureFlags} from "../Privilege";
@@ -392,19 +392,15 @@ export class OriginPageComponent implements OnInit, OnDestroy {
     }
 
     public getPackages() {
-        this.store.dispatch(filterPackagesBy(
-            {origin: this.origin.name}, "", 0, true, this.gitHubAuthToken
-        ));
+        this.store.dispatch(getUniquePackages(this.origin.name, 0, this.gitHubAuthToken));
     }
 
     private fetchMorePackages() {
-        this.store.dispatch(filterPackagesBy(
-            {origin: this.origin.name},
-            "",
+        this.store.dispatch(getUniquePackages(
+            this.origin.name,
             this.store.getState().packages.nextRange,
-            true,
-            this.gitHubAuthToken));
-
+            this.gitHubAuthToken
+        ));
         return false;
     }
 

--- a/components/builder-web/npm-shrinkwrap.json
+++ b/components/builder-web/npm-shrinkwrap.json
@@ -4,156 +4,156 @@
   "dependencies": {
     "@angular/common": {
       "version": "2.0.0-rc.5",
-      "from": "@angular/common@2.0.0-rc.5",
+      "from": "https://registry.npmjs.org/@angular/common/-/common-2.0.0-rc.5.tgz",
       "resolved": "https://registry.npmjs.org/@angular/common/-/common-2.0.0-rc.5.tgz"
     },
     "@angular/compiler": {
       "version": "2.0.0-rc.5",
-      "from": "@angular/compiler@2.0.0-rc.5",
+      "from": "https://registry.npmjs.org/@angular/compiler/-/compiler-2.0.0-rc.5.tgz",
       "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-2.0.0-rc.5.tgz"
     },
     "@angular/core": {
       "version": "2.0.0-rc.5",
-      "from": "@angular/core@2.0.0-rc.5",
+      "from": "https://registry.npmjs.org/@angular/core/-/core-2.0.0-rc.5.tgz",
       "resolved": "https://registry.npmjs.org/@angular/core/-/core-2.0.0-rc.5.tgz"
     },
     "@angular/forms": {
       "version": "0.3.0",
-      "from": "@angular/forms@0.3.0",
+      "from": "https://registry.npmjs.org/@angular/forms/-/forms-0.3.0.tgz",
       "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-0.3.0.tgz"
     },
     "@angular/http": {
       "version": "2.0.0-rc.5",
-      "from": "@angular/http@2.0.0-rc.5",
+      "from": "https://registry.npmjs.org/@angular/http/-/http-2.0.0-rc.5.tgz",
       "resolved": "https://registry.npmjs.org/@angular/http/-/http-2.0.0-rc.5.tgz"
     },
     "@angular/platform-browser": {
       "version": "2.0.0-rc.5",
-      "from": "@angular/platform-browser@2.0.0-rc.5",
+      "from": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-2.0.0-rc.5.tgz",
       "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-2.0.0-rc.5.tgz"
     },
     "@angular/platform-browser-dynamic": {
       "version": "2.0.0-rc.5",
-      "from": "@angular/platform-browser-dynamic@2.0.0-rc.5",
+      "from": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-2.0.0-rc.5.tgz",
       "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-2.0.0-rc.5.tgz"
     },
     "@angular/platform-server": {
       "version": "2.0.0-rc.5",
-      "from": "@angular/platform-server@2.0.0-rc.5",
+      "from": "https://registry.npmjs.org/@angular/platform-server/-/platform-server-2.0.0-rc.5.tgz",
       "resolved": "https://registry.npmjs.org/@angular/platform-server/-/platform-server-2.0.0-rc.5.tgz",
       "dependencies": {
         "parse5": {
           "version": "1.3.2",
-          "from": "parse5@1.3.2",
+          "from": "https://registry.npmjs.org/parse5/-/parse5-1.3.2.tgz",
           "resolved": "https://registry.npmjs.org/parse5/-/parse5-1.3.2.tgz"
         }
       }
     },
     "@angular/router": {
       "version": "3.0.0-rc.1",
-      "from": "@angular/router@3.0.0-rc.1",
+      "from": "https://registry.npmjs.org/@angular/router/-/router-3.0.0-rc.1.tgz",
       "resolved": "https://registry.npmjs.org/@angular/router/-/router-3.0.0-rc.1.tgz"
     },
     "@angular/upgrade": {
       "version": "2.0.0-rc.5",
-      "from": "@angular/upgrade@2.0.0-rc.5",
+      "from": "https://registry.npmjs.org/@angular/upgrade/-/upgrade-2.0.0-rc.5.tgz",
       "resolved": "https://registry.npmjs.org/@angular/upgrade/-/upgrade-2.0.0-rc.5.tgz"
     },
     "ansi_up": {
       "version": "1.3.0",
-      "from": "ansi_up@>=1.3.0 <2.0.0",
+      "from": "https://registry.npmjs.org/ansi_up/-/ansi_up-1.3.0.tgz",
       "resolved": "https://registry.npmjs.org/ansi_up/-/ansi_up-1.3.0.tgz"
     },
     "blueimp-md5": {
       "version": "2.3.1",
-      "from": "blueimp-md5@>=2.3.0 <3.0.0",
+      "from": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.3.1.tgz",
       "resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.3.1.tgz"
     },
     "bourbon": {
       "version": "4.2.7",
-      "from": "bourbon@>=4.2.6 <5.0.0",
+      "from": "https://registry.npmjs.org/bourbon/-/bourbon-4.2.7.tgz",
       "resolved": "https://registry.npmjs.org/bourbon/-/bourbon-4.2.7.tgz"
     },
     "bourbon-neat": {
       "version": "1.8.0",
-      "from": "bourbon-neat@>=1.7.2 <2.0.0",
+      "from": "https://registry.npmjs.org/bourbon-neat/-/bourbon-neat-1.8.0.tgz",
       "resolved": "https://registry.npmjs.org/bourbon-neat/-/bourbon-neat-1.8.0.tgz"
     },
     "core-js": {
       "version": "2.4.1",
-      "from": "core-js@>=2.4.1 <3.0.0",
+      "from": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
     },
     "immutable": {
       "version": "3.8.1",
-      "from": "immutable@>=3.7.6 <4.0.0",
+      "from": "https://registry.npmjs.org/immutable/-/immutable-3.8.1.tgz",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.1.tgz"
     },
     "js-cookie": {
       "version": "2.1.3",
-      "from": "js-cookie@>=2.1.2 <3.0.0",
+      "from": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.1.3.tgz",
       "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.1.3.tgz"
     },
     "marked": {
       "version": "0.3.6",
-      "from": "marked@>=0.3.5 <0.4.0",
+      "from": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
       "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz"
     },
     "moment": {
       "version": "2.15.0",
-      "from": "moment@>=2.11.2 <3.0.0",
+      "from": "https://registry.npmjs.org/moment/-/moment-2.15.0.tgz",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.15.0.tgz"
     },
     "node-uuid": {
       "version": "1.4.7",
-      "from": "node-uuid@>=1.4.7 <2.0.0",
+      "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
       "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
     },
     "normalize-scss": {
       "version": "4.2.1",
-      "from": "normalize-scss@>=4.0.3 <5.0.0",
+      "from": "https://registry.npmjs.org/normalize-scss/-/normalize-scss-4.2.1.tgz",
       "resolved": "https://registry.npmjs.org/normalize-scss/-/normalize-scss-4.2.1.tgz"
     },
     "octicons": {
       "version": "3.5.0",
-      "from": "octicons@>=3.5.0 <4.0.0",
+      "from": "https://registry.npmjs.org/octicons/-/octicons-3.5.0.tgz",
       "resolved": "https://registry.npmjs.org/octicons/-/octicons-3.5.0.tgz"
     },
     "parse-link-header": {
       "version": "0.4.1",
-      "from": "parse-link-header@>=0.4.1 <0.5.0",
+      "from": "https://registry.npmjs.org/parse-link-header/-/parse-link-header-0.4.1.tgz",
       "resolved": "https://registry.npmjs.org/parse-link-header/-/parse-link-header-0.4.1.tgz",
       "dependencies": {
         "xtend": {
           "version": "4.0.1",
-          "from": "xtend@>=4.0.0 <4.1.0",
+          "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
         }
       }
     },
     "redux": {
       "version": "3.6.0",
-      "from": "redux@>=3.0.5 <4.0.0",
+      "from": "https://registry.npmjs.org/redux/-/redux-3.6.0.tgz",
       "resolved": "https://registry.npmjs.org/redux/-/redux-3.6.0.tgz",
       "dependencies": {
         "lodash": {
           "version": "4.15.0",
-          "from": "lodash@>=4.2.1 <5.0.0",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-4.15.0.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.15.0.tgz"
         },
         "lodash-es": {
           "version": "4.15.0",
-          "from": "lodash-es@>=4.2.1 <5.0.0",
+          "from": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.15.0.tgz",
           "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.15.0.tgz"
         },
         "loose-envify": {
           "version": "1.2.0",
-          "from": "loose-envify@>=1.1.0 <2.0.0",
+          "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.2.0.tgz",
           "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.2.0.tgz",
           "dependencies": {
             "js-tokens": {
               "version": "1.0.3",
-              "from": "js-tokens@>=1.0.1 <2.0.0",
+              "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz",
               "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz"
             }
           }
@@ -162,43 +162,43 @@
     },
     "redux-reset": {
       "version": "0.1.3",
-      "from": "redux-reset@>=0.1.3 <0.2.0",
+      "from": "https://registry.npmjs.org/redux-reset/-/redux-reset-0.1.3.tgz",
       "resolved": "https://registry.npmjs.org/redux-reset/-/redux-reset-0.1.3.tgz"
     },
     "redux-thunk": {
       "version": "2.1.0",
-      "from": "redux-thunk@>=2.1.0 <3.0.0",
+      "from": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.1.0.tgz"
     },
     "reflect-metadata": {
       "version": "0.1.8",
-      "from": "reflect-metadata@>=0.1.8 <0.2.0",
+      "from": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.8.tgz",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.8.tgz"
     },
     "rxjs": {
       "version": "5.0.0-beta.6",
-      "from": "rxjs@5.0.0-beta.6",
+      "from": "https://registry.npmjs.org/rxjs/-/rxjs-5.0.0-beta.6.tgz",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.0.0-beta.6.tgz"
     },
     "symbol-observable": {
       "version": "1.0.2",
-      "from": "symbol-observable@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.2.tgz"
     },
     "typescript": {
       "version": "1.8.10",
-      "from": "typescript@>=1.8.10 <2.0.0",
+      "from": "https://registry.npmjs.org/typescript/-/typescript-1.8.10.tgz",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-1.8.10.tgz"
     },
     "whatwg-fetch": {
       "version": "0.11.1",
-      "from": "whatwg-fetch@>=0.11.0 <0.12.0",
+      "from": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-0.11.1.tgz",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-0.11.1.tgz"
     },
     "zone.js": {
-      "version": "0.6.21",
-      "from": "zone.js@>=0.6.12 <0.7.0",
-      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.6.21.tgz"
+      "version": "0.6.6",
+      "from": "git://github.com/angular/zone.js.git#a8ea55",
+      "resolved": "git://github.com/angular/zone.js.git#a8ea55dd977898a9cba4d695beb93bf23e0cbc50"
     }
   }
 }

--- a/components/builder-web/package.json
+++ b/components/builder-web/package.json
@@ -66,7 +66,7 @@
     "symbol-observable": "^1.0.1",
     "typescript": "^1.8.10",
     "whatwg-fetch": "^0.11.0",
-    "zone.js": "^0.6.12"
+    "zone.js": "git://github.com/angular/zone.js.git#a8ea55"
   },
   "devDependencies": {
     "assertion-error": "^1.0.1",


### PR DESCRIPTION
This PR is about improving the UI/UX on the origin detail page.

Previously, when you browsed to an origin, you'd see a giant list of packages and there would likely be duplicates.  The duplicates were because the front-end was retrieving a list of packages from the server, but the server was returning everything, including versions.  So, for example, if you had 4 versions of redis in your depot, then you'd see "redis" in the list of packages 4 times.  It looks like this:

![](https://dl.dropboxusercontent.com/s/fmplia3tuue6kpr/2016-11-23%20at%209.47%20AM.png)

This behavior is ideal when we're viewing a list of packages in the main package search UI, because we can see versions there and it all makes sense.  This behavior is less than ideal on the origin page because all we want to see is a list of unique package names.  Now, with this change, it looks like this:

![](https://dl.dropboxusercontent.com/s/ulph5n5o59k3u1w/2016-11-23%20at%209.47%20AM%20%281%29.png)

To accomplish this, there's a new index in redis that stores unique names per origin.  A new API endpoint has also been created that fetches directly from that index.  Finally, the origin page utilizes the new API endpoint for retrieving a list of unique package names, instead of the search API endpoint that it previously used.

![fzwbb](https://cloud.githubusercontent.com/assets/947/20573146/51e39d62-b163-11e6-8213-82d95f8cc565.gif)
