### PR TITLE
No longer render `me` for services not running

### DIFF
--- a/components/sup/src/manager/census.rs
+++ b/components/sup/src/manager/census.rs
@@ -342,8 +342,8 @@ impl Census {
         }
     }
 
-    pub fn me(&self) -> &CensusEntry {
-        self.population.get(&self.member_id).unwrap()
+    pub fn me(&self) -> Option<&CensusEntry> {
+        self.population.get(&self.member_id)
     }
 
     pub fn get_leader(&self) -> Option<&CensusEntry> {

--- a/components/sup/src/manager/service/config.rs
+++ b/components/sup/src/manager/service/config.rs
@@ -285,7 +285,6 @@ fn service_entry(census: &Census) -> toml::Table {
     let service = toml::Value::String(String::from(census.get_service()));
     let group = toml::Value::String(String::from(census.get_group()));
     let ident = toml::Value::String(census.get_service_group());
-    let me = toml::encode(census.me());
     let leader = census.get_leader().map(|ce| toml::encode(ce));
     let mut members: Vec<toml::Value> = Vec::new();
     let mut member_id = toml::Table::new();
@@ -297,7 +296,10 @@ fn service_entry(census: &Census) -> toml::Table {
     result.insert("service".to_string(), service);
     result.insert("group".to_string(), group);
     result.insert("ident".to_string(), ident);
-    result.insert("me".to_string(), me);
+    if let Some(me) = census.me() {
+        let toml_me = toml::encode(me);
+        result.insert("me".to_string(), toml_me);
+    }
     if let Some(l) = leader {
         result.insert("leader".to_string(), l);
     }

--- a/components/sup/src/manager/service/mod.rs
+++ b/components/sup/src/manager/service/mod.rs
@@ -103,7 +103,9 @@ impl Service {
                 if let Some(census) = census_list.get(&format!("{}.{}",
                                                                self.service_group.service,
                                                                self.service_group.group)) {
-                    let me = census.me();
+                    // We know perfectly well we are in this census, because we asked for
+                    // our own service group *by name*
+                    let me = census.me().unwrap();
                     if me.get_election_is_running() {
                         if self.last_restart_display != LastRestartDisplay::ElectionInProgress {
                             outputln!(preamble self.service_group_str(),


### PR DESCRIPTION
Previously, the supervisor would always render something for `all.me`,
for every service, regardless of whether this supervisor actually has a
running service or not.

This change makes it so that we now render a `me` value only if the
current supervisor has an instance of a service running in a given
service group.

Signed-off-by: Adam Jacob <adam@chef.io>