### PR TITLE
Add command line completers in the studio

### DIFF
--- a/components/studio/libexec/hab-studio-type-baseimage.sh
+++ b/components/studio/libexec/hab-studio-type-baseimage.sh
@@ -89,6 +89,8 @@ alias grep='grep --color=auto'
 alias egrep='egrep --color=auto'
 alias fgrep='fgrep --color=auto'
 
+# Add command line completion
+source <(hab cli completers --shell bash)
 PROFILE
 
   $bb cat <<EOT > $HAB_STUDIO_ROOT/etc/resolv.conf

--- a/components/studio/libexec/hab-studio-type-default.sh
+++ b/components/studio/libexec/hab-studio-type-default.sh
@@ -96,6 +96,8 @@ if [ -f /src/.studiorc ];then
   source /src/.studiorc
 fi
 
+# Add command line completion
+source <(hab cli completers --shell bash)
 PROFILE
 
   echo "${run_user}:x:42:42:root:/:/bin/sh" >> $HAB_STUDIO_ROOT/etc/passwd


### PR DESCRIPTION
In studios where we write out an /etc/profile, use the built-in hab
command line completion.

![gif-keyboard-5467337220890730602](https://cloud.githubusercontent.com/assets/9912/20773480/a83cff82-b717-11e6-9337-d80081649a13.gif)
