### PR TITLE
Return a friendly error when a token has insufficient permissions

### DIFF
--- a/components/builder-depot-client/src/lib.rs
+++ b/components/builder-depot-client/src/lib.rs
@@ -155,7 +155,16 @@ impl Client {
         };
         match result {
             Ok(Response { status: StatusCode::Created, .. }) => Ok(()),
-            Ok(response) => Err(err_from_response(response)),
+            Ok(response) => {
+                if response.status == StatusCode::Unauthorized {
+                    Err(Error::APIError(response.status,
+                                        "Your GitHub token requires both user:email and read:org \
+                                         permissions."
+                                            .to_string()))
+                } else {
+                    Err(err_from_response(response))
+                }
+            }
             Err(e) => Err(Error::from(e)),
         }
     }


### PR DESCRIPTION
We are already returning a 401 instead of a 504 when a token doesn't have sufficient permissions, so that's an improvement, but the error message is cryptic and doesn't tell a user what the problem actually is.

Resolves #1444 

![69vyw](https://cloud.githubusercontent.com/assets/947/20777707/92f74e2e-b71d-11e6-83be-91596f427fce.gif)

Signed-off-by: Josh Black <raskchanky@gmail.com>