### PR TITLE
Add missing health data to Census

### DIFF
--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -161,6 +161,9 @@ impl Manager {
             });
             self.state.butterfly.member_list.with_members(|member| {
                 cl.populate_from_member(member);
+                if let Some(health) = self.state.butterfly.member_list.health_of(member) {
+                    cl.populate_from_health(member, health);
+                }
             });
             *self.state.census_list.write().expect("Census list lock is poisoned!") = cl;
             return Ok((true, update));


### PR DESCRIPTION
When populating the Census data with membership information, we forgot
to update the Health of the member. This fixes that. :)

![gif-keyboard-2805584453978765978](https://cloud.githubusercontent.com/assets/4304/20809981/98b37442-b7bc-11e6-9d8a-48addffc2108.gif)


Signed-off-by: Adam Jacob <adam@chef.io>