### PR TITLE
Connect to a majority of initial peers

### DIFF
--- a/components/butterfly/src/member.rs
+++ b/components/butterfly/src/member.rs
@@ -196,6 +196,11 @@ impl MemberList {
         self.update_counter.load(Ordering::Relaxed)
     }
 
+    pub fn len_initial_members(&self) -> usize {
+        let im = self.initial_members.read().expect("Initial members lock is poisoned");
+        im.len()
+    }
+
     pub fn add_initial_member(&self, member: Member) {
         let mut im = self.initial_members.write().expect("Initial members lock is poisoned");
         im.push(member);

--- a/components/butterfly/src/server/mod.rs
+++ b/components/butterfly/src/server/mod.rs
@@ -421,12 +421,6 @@ impl Server {
             return false;
         }
 
-        if total_population % 2 == 0 {
-            warn!("This census has an even population. If half the membership fails, quorum will \
-                   never be met, and no leader will be elected. Add another instance to the \
-                   service group!");
-        }
-
         alive_population >= ((total_population / 2) + 1)
     }
 

--- a/components/butterfly/src/server/outbound.rs
+++ b/components/butterfly/src/server/outbound.rs
@@ -81,9 +81,13 @@ impl<'a> Outbound<'a> {
     /// period to finish before starting the next probe.
     pub fn run(&mut self) {
         let mut have_members = false;
+        let num_initial = self.server.member_list.len_initial_members();
         loop {
-            if !have_members {
-                if self.server.member_list.len() > 0 {
+            if !have_members && num_initial != 0 {
+                // The minimum thats strictly more than half
+                let min_to_start = num_initial / 2 + 1;
+
+                if self.server.member_list.len() >= min_to_start {
                     have_members = true;
                 } else {
                     self.server.member_list.with_initial_members(|member| {


### PR DESCRIPTION
Rather than stopping when we connect to any peer, we instead try and
connect to all initial peers until we get a majority of them.

This ensures you can pass the full set of peers to a supervisor, and be
certain you won't accidentally wind up partitioned.

![image](https://cloud.githubusercontent.com/assets/4304/20848862/c8ba4d38-b888-11e6-8cca-956edd698f2c.png)


Signed-off-by: Adam Jacob <adam@chef.io>