### PR TITLE
Documentation & Director updates for recent Supervisor changes

### DIFF
--- a/components/director/src/controller.rs
+++ b/components/director/src/controller.rs
@@ -61,7 +61,6 @@ impl Controller {
         let default_ip = try!(ip()).to_string();
         let listen_ip = try!(Ipv4Addr::from_str(&default_ip));
 
-
         let mut initial_peer: Option<SocketAddrV4> = self.config.dir_sup_listen;
 
         for sd in &self.config.service_defs {
@@ -111,7 +110,8 @@ impl Controller {
             let elapsed_millis = elapsed_time.num_milliseconds();
 
             if elapsed_millis < MINIMUM_LOOP_TIME_MS {
-                thread::sleep(Duration::from_millis((MINIMUM_LOOP_TIME_MS - elapsed_millis) as u64));
+                let time = Duration::from_millis((MINIMUM_LOOP_TIME_MS - elapsed_millis) as u64);
+                thread::sleep(time);
             }
         }
         Ok(())
@@ -257,14 +257,13 @@ mod tests {
 
         let test_ip = ip().unwrap().to_string();
         {
-
             let child = &controller.children.as_ref().unwrap()[0];
             let args = child.get_cmd_args().unwrap();
             assert_eq!(args.as_slice(),
                        ["start",
                         "core/redis",
                         "foo",
-                        "--listen-peer",
+                        "--listen-gossip",
                         format!("{}:9000", test_ip).as_str(),
                         "--listen-http",
                         format!("{}:8000", test_ip).as_str(),
@@ -282,7 +281,7 @@ mod tests {
                        ["start",
                         "core/rngd",
                         "bar",
-                        "--listen-peer",
+                        "--listen-gossip",
                         // did we increment the port?
                         format!("{}:9001", test_ip).as_str(),
                         "--listen-http",
@@ -296,7 +295,6 @@ mod tests {
                         // is the peer set to the previous port?
                         format!("{}:9000", test_ip).as_str()]);
         }
-
         {
             let child = &controller.children.as_ref().unwrap()[2];
             let args = child.get_cmd_args().unwrap();
@@ -304,7 +302,7 @@ mod tests {
             assert_eq!(args.as_slice(),
                        ["start",
                         "myorigin/xyz",
-                        "--listen-peer",
+                        "--listen-gossip",
                         // did we increment the port?
                         format!("{}:9002", test_ip).as_str(),
                         "--listen-http",
@@ -333,6 +331,5 @@ mod tests {
             c.children.as_ref().unwrap()[1].starts > 1 &&
             c.children.as_ref().unwrap()[2].starts > 1
         }));
-
     }
 }

--- a/components/director/src/main.rs
+++ b/components/director/src/main.rs
@@ -182,7 +182,7 @@ extern crate habitat_director as director;
 extern crate habitat_core as hcore;
 extern crate habitat_common as hcommon;
 #[macro_use]
-extern crate habitat_sup as hsup;
+extern crate habitat_sup;
 #[macro_use]
 extern crate clap;
 extern crate env_logger;

--- a/components/director/src/main.rs
+++ b/components/director/src/main.rs
@@ -65,14 +65,14 @@
 //!       │
 //!       │    ┌───────────────┐
 //!       │    │               │
-//!       └───▶│   Controller  │────┐    ┌────────────┐   ┌────────┐    ┌──────────┐
-//!            │               │    ├───▶│ ExecParams │──▶│  Task  │───▶│  hab-sup │
+//!       └───>│   Controller  │────┐    ┌────────────┐   ┌────────┐    ┌──────────┐
+//!            │               │    ├───>│ ExecParams │──>│  Task  │───>│  hab-sup │
 //!            └───────────────┘    │    └────────────┘   └────────┘    └──────────┘
 //!              ┌─────────────┐    │    ┌────────────┐   ┌────────┐    ┌──────────┐
-//!              │ ExecContext │────┼───▶│ ExecParams │──▶│  Task  │───▶│  hab-sup │
+//!              │ ExecContext │────┼───>│ ExecParams │──>│  Task  │───>│  hab-sup │
 //!              └─────────────┘    │    └────────────┘   └────────┘    └──────────┘
 //!                                 │    ┌────────────┐   ┌────────┐    ┌──────────┐
-//!                                 └───▶│ ExecParams │──▶│  Task  │───▶│  hab-sup │
+//!                                 └───>│ ExecParams │──>│  Task  │───>│  hab-sup │
 //!                                      └────────────┘   └────────┘    └──────────┘
 //! ```
 //! ### Config file format
@@ -143,7 +143,7 @@
 //! - Gossip port numbers are assigned starting with FIRST_GOSSIP_PORT (9000)
 //! - HTTP port numbers are assigned starting with FIRST_HTTP_PORT (8000)
 //! - If the hab-sup that's running the director is assigned ports other than
-//! the defaults (9634, 9631), there is a possibility that they could conflict
+//! the defaults (9638, 9631), there is a possibility that they could conflict
 //! with the automatically assigned port numbers of the child tasks.
 //! - The diagram below shows a hab-sup process running the director with it's
 //! default IP + port (changeable by the user). Each task that's started is
@@ -151,21 +151,21 @@
 //!
 //!                 ┌────────────────────────────┐
 //!                 │     hab-sup (Director)     │
-//!              ┌─▶│       Gossip = 9634        │ * default ports
+//!              ┌─>│       Gossip = 9638        │ * default ports
 //!              │  │       HTTP = 9631          │
 //!              │  └────────────────────────────┘
 //!              │
 //!         Peer │
 //!              │  ┌────────────────────────────┐
 //!              │  │Task 0                      │
-//!              └──│FIRST_GOSSIP_PORT (9000)    │◀─┐
+//!              └──│FIRST_GOSSIP_PORT (9000)    │<─┐
 //!                 │FIRST_HTTP_PORT (8000)      │  │
 //!                 └────────────────────────────┘  │
 //!                                                 │
 //!                                                 │ Peer
 //!                 ┌────────────────────────────┐  │
 //!                 │Task 1                      │  │
-//!              ┌─▶│FIRST_GOSSIP_PORT+1 (9001)  │──┘
+//!              ┌─>│FIRST_GOSSIP_PORT+1 (9001)  │──┘
 //!              │  │FIRST_HTTP_PORT+1 (8001)    │
 //!              │  └────────────────────────────┘
 //!              │

--- a/components/director/src/task.rs
+++ b/components/director/src/task.rs
@@ -41,7 +41,6 @@ extern "C" {
     fn waitpid(pid: pid_t, status: *mut c_int, options: c_int) -> pid_t;
 }
 
-
 /// Where and with what command a Task runs
 /// This is most useful for testing.
 #[derive(Debug, Clone)]
@@ -148,7 +147,7 @@ impl Task {
 
         args.insert(0, "start".to_string());
         args.insert(1, self.service_def.ident.to_string());
-        args.push("--listen-peer".to_string());
+        args.push("--listen-gossip".to_string());
         args.push(self.exec_params.gossip_listen.to_string());
         args.push("--listen-http".to_string());
         args.push(self.exec_params.sidecar_listen.to_string());
@@ -218,7 +217,6 @@ impl Task {
                 .name(String::from(name.clone()))
                 .spawn(move || -> Result<()> { child_reader(&mut child, name) }));
             debug!("Spawned child reader");
-
         } else {
             outputln!("{} already started", &self.service_def.to_string());
         }
@@ -300,7 +298,6 @@ impl Task {
     pub fn service_dir(&self) -> PathBuf {
         PathBuf::from(&self.exec_ctx.service_root).join("hab-director")
     }
-
 
     pub fn pid_file(&self) -> PathBuf {
         let sd = &self.service_def.to_string().replace(".", "-");
@@ -435,16 +432,13 @@ fn child_reader(child: &mut Child, child_name: String) -> Result<()> {
     Ok(())
 }
 
-
 #[cfg(test)]
 mod tests {
     use std::net::SocketAddrV4;
     use std::path::PathBuf;
     use std::str::FromStr;
 
-    // it's in lib.rs
     use super::super::ServiceDef;
-
     use super::*;
 
     fn get_test_dc() -> Task {
@@ -457,7 +451,7 @@ mod tests {
         Task::new(exec_ctx, exec_params, sd)
     }
 
-    /// parse args, inject listen-peer and listen-http, no peer
+    /// parse args, inject listen-gossip and listen-http, no peer
     #[test]
     fn cmd_args_parsing_no_peer() {
         let dc = get_test_dc();
@@ -468,7 +462,7 @@ mod tests {
                  "core/redis",
                  "-v",
                  "-foo=bar",
-                 "--listen-peer",
+                 "--listen-gossip",
                  "127.0.0.1:9000",
                  "--listen-http",
                  "127.0.0.1:8000",
@@ -478,7 +472,7 @@ mod tests {
                  "someorg"]);
     }
 
-    /// parse args, inject listen-peer, listen-http, peer
+    /// parse args, inject listen-gossip, listen-http, peer
     #[test]
     fn cmd_args_parsing_peer() {
         let mut dc = get_test_dc();
@@ -492,7 +486,7 @@ mod tests {
                  "core/redis",
                  "-v",
                  "-foo=bar",
-                 "--listen-peer",
+                 "--listen-gossip",
                  "127.0.0.1:9000",
                  "--listen-http",
                  "127.0.0.1:8000",
@@ -503,7 +497,6 @@ mod tests {
                  "--peer",
                  "127.0.0.1:9876"]);
     }
-
 
     /// test the pid filename using the default service directory
     #[test]

--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -71,7 +71,7 @@ pub fn get() -> App<'static, 'static> {
                 (@arg USER: +takes_value "Name of the user key")
                 (@arg PEER: -p --peer +takes_value
                     "A comma-delimited list of one or more Habitat Supervisor peers to infect \
-                    (default: 127.0.0.1:9634)")
+                    (default: 127.0.0.1:9638)")
                 (@arg RING: -r --ring +takes_value
                     "Ring key name, which will encrypt communication messages")
             )
@@ -350,7 +350,7 @@ fn sub_config_apply() -> App<'static, 'static> {
         (about: "Applies a configuration to a group of Habitat Supervisors")
         (@arg PEER: -p --peer +takes_value
             "A comma-delimited list of one or more Habitat Supervisor peers to infect \
-            (default: 127.0.0.1:9634)")
+            (default: 127.0.0.1:9638)")
         (@arg RING: -r --ring +takes_value
             "Ring key name, which will encrypt communication messages")
         (@arg SERVICE_GROUP: +required {valid_service_group}

--- a/test/spec/basic.rb
+++ b/test/spec/basic.rb
@@ -280,7 +280,7 @@ describe "Habitat CLI" do
                 end
 
                 # upload a new config to trigger a restart
-                ctx.cmd("config apply -p #{ctx.local_ip}:9634 #{package}.default 1 #{tomlfile.path}")
+                ctx.cmd("config apply -p #{ctx.local_ip}:9638 #{package}.default 1 #{tomlfile.path}")
                 loop do
                     line = stdout_err.readline()
                     puts line
@@ -299,9 +299,4 @@ describe "Habitat CLI" do
     it "sends a SIGTERM to a child process if a reconfigure hook doesn't exist" do
         start_and_config_apply("simple_service_without_reconfigure", "RECEIVED TERM")
     end
-
 end
-
-
-
-

--- a/www/source/docs/concepts-director.html.md
+++ b/www/source/docs/concepts-director.html.md
@@ -12,7 +12,7 @@ Services are listed a config.toml file. This file defines the start order, servi
 
 The director can be run inside of a supervisor as well. As with any other service, this allows the director to be updated with new configuration changes at runtime, which enable it to dynamically deploy different child service configurations and topologies.
 
-When running inside of a supervisor, the director will use the standard gossip and HTTP API ports of 9634 and 9631, respectively. However, child supervisor processes will use the same IP address of the director. The default for every service is to use ports 9634 and 9631, so to stop port collision from happening when the child `hab-sup` processes start up, the director defines ring and HTTP API port numbers for all children in sequential order starting with port 9000 for gossip connections and port 8000 for HTTP API connections. It's advisable to keep the director's port numbers at their default values to avoid port collisions.
+When running inside of a supervisor, the director will use the standard gossip and HTTP API ports of 9638 and 9631, respectively. However, child supervisor processes will use the same IP address of the director. The default for every service is to use ports 9638 and 9631, so to stop port collision from happening when the child `hab-sup` processes start up, the director defines ring and HTTP API port numbers for all children in sequential order starting with port 9000 for gossip connections and port 8000 for HTTP API connections. It's advisable to keep the director's port numbers at their default values to avoid port collisions.
 
 <hr>
 <ul class="main-content--link-nav">

--- a/www/source/docs/container-orchestration-kubernetes.html.md
+++ b/www/source/docs/container-orchestration-kubernetes.html.md
@@ -24,4 +24,4 @@ Kubernetes supports passing [environment variables](http://kubernetes.io/docs/us
 
 ## Multi-container Pods
 
-Multi-container pod support through Habitat is still under active development. There may need to be a generated configuration file output from a CLI. Habitat's gossip protocol is on port 9634 and transmitted via UDP. It needs to be available by default to all of the containers in the pod.
+Multi-container pod support through Habitat is still under active development. There may need to be a generated configuration file output from a CLI. Habitat's gossip protocol is on port 9638 and transmitted via UDP. It needs to be available by default to all of the containers in the pod.

--- a/www/source/docs/reference/habitat-cli.html.md
+++ b/www/source/docs/reference/habitat-cli.html.md
@@ -93,7 +93,7 @@ Applies configuration to a group of Habitat supervisors.
 
         --org <ORG>      Name of service organization
     -p, --peer <PEER>    A comma-delimited list of one or more Habitat Supervisor peers to
-                         communicate with (default: 127.0.0.1:9634)
+                         communicate with (default: 127.0.0.1:9638)
     -r, --ring <RING>    Ring key name, which will encrypt communication messages
 
 **ARGS**
@@ -118,7 +118,7 @@ Upload a file to a supervisor ring.
 
         --org <ORG>      Name of service organization
     -p, --peer <PEER>    A comma-delimited list of one or more Habitat Supervisor peers to infect
-                         (default: 127.0.0.1:9634)
+                         (default: 127.0.0.1:9638)
     -r, --ring <RING>    Ring key name, which will encrypt communication messages
 
 **ARGS**

--- a/www/source/docs/run-packages-apply-config-updates.html.md
+++ b/www/source/docs/run-packages-apply-config-updates.html.md
@@ -8,8 +8,8 @@ One of the key features of Habitat is the ability to define an immutable package
 
 
 ## Apply configuration updates to an individual service
-When starting a single service, you can provide alternate configuration values to those specified in `default.toml` through the use of an environment variable 
-with the following format: `HAB_PACKAGENAME='keyname1=newvalue1 keyname2=newvalue2'`. 
+When starting a single service, you can provide alternate configuration values to those specified in `default.toml` through the use of an environment variable
+with the following format: `HAB_PACKAGENAME='keyname1=newvalue1 keyname2=newvalue2'`.
 
     HAB_MYTUTORIALAPP='message = "Habitat rocks!"' hab start <origin>/<packagename>
 
@@ -20,7 +20,7 @@ file and pass it in using `HAB_PACKAGENAME="$(cat foo.toml)"`.
 
     HAB_MYTUTORIALAPP="$(cat my-env-stuff.toml)" hab start <origin>/<packagename>
 
-The main advantage of applying configuration updates to an individual service through an environment variable is that you can quickly test configuration settings to see how your service behaves at runtime. The disadvantages of this method are that configuration changes have to be applied to one service at a time, and you have to manually interrupt (Ctrl+C) a running service before changing its configuration settings again. 
+The main advantage of applying configuration updates to an individual service through an environment variable is that you can quickly test configuration settings to see how your service behaves at runtime. The disadvantages of this method are that configuration changes have to be applied to one service at a time, and you have to manually interrupt (Ctrl+C) a running service before changing its configuration settings again.
 
 For an example of how to use an environment variable to update default configuration values, see [Run your service](/tutorials/getting-started/linux/process-build) in the Getting Started tutorial.
 
@@ -52,9 +52,9 @@ Here are some examples of how to apply configuration changes through both the sh
     Your output would look something like this:
 
        » Applying configuration
-       ↑ Applying configuration for myapp.prod into ring via ["172.17.0.3:9634"]
-       Joining peer: 172.17.0.3:9634
-       Configuration applied to: 172.17.0.3:9634
+       ↑ Applying configuration for myapp.prod into ring via ["172.17.0.3:9638"]
+       Joining peer: 172.17.0.3:9638
+       Configuration applied to: 172.17.0.3:9638
        ★ Applied configuration.
 
   The services in the myapp.prod service group will restart according to the service group's [update strategy](/docs/run-packages-update-strategy).

--- a/www/source/docs/run-packages-service-groups.html.md
+++ b/www/source/docs/run-packages-service-groups.html.md
@@ -3,23 +3,23 @@ title: Run packages in a service group
 ---
 
 # Run packages in a service group
-A service group is a logical grouping of services with the same package and topology type connected together 
-in a ring. They are created to share configuration and file updates among the services within those groups 
-and can be segmented based on workflow or deployment needs (QA, Production, and so on). Updates can also be 
-[encrypted](/docs/run-packages-security#service-group-encryption) so that only members of a specific service 
+A service group is a logical grouping of services with the same package and topology type connected together
+in a ring. They are created to share configuration and file updates among the services within those groups
+and can be segmented based on workflow or deployment needs (QA, Production, and so on). Updates can also be
+[encrypted](/docs/run-packages-security#service-group-encryption) so that only members of a specific service
 group can decrypt the contents.
 
 By default, every service joins the _servicename_.**default** service group unless otherwise specified at runtime.
 
-In addition, multiple service groups can reside in the same ring. This allows data exposed by supervisors to 
+In addition, multiple service groups can reside in the same ring. This allows data exposed by supervisors to
 be shared with other members of the ring regardless of which group they are in.
 
 ## Joining a service group
-To join a service group, run your service either natively with the `hab start` command, or 
-through an external runtime format such as a Docker container. A best practice is to name the 
-group after an environment to support continuous deployment workflows. 
+To join a service group, run your service either natively with the `hab start` command, or
+through an external runtime format such as a Docker container. A best practice is to name the
+group after an environment to support continuous deployment workflows.
 
-> Note: When applying configuration updates, you must reference the fully-qualified service group name, _servicename_._groupname_. 
+> Note: When applying configuration updates, you must reference the fully-qualified service group name, _servicename_._groupname_.
 
 Here's how to start up the `myapp` service with the `prod` group name using the supervisor (`hab-sup`) directly:
 
@@ -29,7 +29,7 @@ Here's how to run the same command from a Docker container:
 
     docker run -it myorigin/myapp --group prod
 
-You will see a similar output below when your service starts. The census entry shows which service 
+You will see a similar output below when your service starts. The census entry shows which service
 group your service belongs to, which in this case is **myapp.prod**. Keep this service instance running.
 
     hab-sup(MN): Starting myorigin/myapp
@@ -37,26 +37,26 @@ group your service belongs to, which in this case is **myapp.prod**. Keep this s
     hab-sup(GS): Census myapp.prod: c60bfa12-c913-4f89-b4f3-d082d1310c3d
     ...
 
-Services only join together to form a ring when a peer IP address is specified by other similar services 
-at runtime.  In a new window or external runtime format, run the same command you ran above, but this time, 
+Services only join together to form a ring when a peer IP address is specified by other similar services
+at runtime.  In a new window or external runtime format, run the same command you ran above, but this time,
 reference the peer IP address of the previous service specified in the supervisor output above.
 
     hab start myorigin/myapp --group prod --peer 172.17.0.2
 
-> Note: The default port for listening to gossip rumors is `9634` unless specified at runtime by the initial service (through `--listen-peer` option 
+> Note: The default port for listening to gossip rumors is `9638` unless specified at runtime by the initial service (through `--listen-gossip` option
 at start up) and by any peers connecting to it through the `--peer` option. See `hab start --help` for more information and examples.
- 
-The output for this new service shows that it has either formed a new ring with the service above, or joined 
-an existing ring where the other service was a member. 
+
+The output for this new service shows that it has either formed a new ring with the service above, or joined
+an existing ring where the other service was a member.
 
     hab-sup(MN): Starting myorigin/myapp
     hab-sup(GS): Supervisor 172.17.0.3: 426f2b49-fb04-41fa-b656-f43260ab122e
     hab-sup(GS): Census myapp.prod: 1f9412eb-c1df-4df8-a07a-65540333826a
     hab-sup(GS): Starting inbound gossip listener
-    hab-sup(GS): Joining gossip peer at 172.17.0.2:9634
+    hab-sup(GS): Joining gossip peer at 172.17.0.2:9638
     ...
 
-> Note: It is important that you specified the group value above. If not, then your new service would have 
+> Note: It is important that you specified the group value above. If not, then your new service would have
 joined the **myapp.default** service group, but remained a gossip peer of the previous service.
 
 <hr>

--- a/www/source/docs/run-packages-upload-files.html.md
+++ b/www/source/docs/run-packages-upload-files.html.md
@@ -35,9 +35,9 @@ When running on a Mac OSX machine, because service and user keys generated with 
    If successful, you should see output similar to the following from where you ran the `hab` CLI:
 
        » Uploading file test.txt
-       ↑ Uploading status.json for myapp.test@myorg into ring via ["172.17.0.2:9634"]
-       Joining peer: 172.17.0.2:9634
-       Configuration applied to: 172.17.0.2:9634
+       ↑ Uploading status.json for myapp.test@myorg into ring via ["172.17.0.2:9638"]
+       Joining peer: 172.17.0.2:9638
+       Configuration applied to: 172.17.0.2:9638
        ★ Upload of test.txt complete.
 
      The output text will update as each peer in the service group receives the file.

--- a/www/source/try/responses/hab-config-apply.txt
+++ b/www/source/try/responses/hab-config-apply.txt
@@ -1,6 +1,6 @@
 Applying configuration ConfigFile redis.default 1 (F: gossip.toml, C: 21791f2efcee073816460e687bf5154) to redis.default
-Joining peer: 172.17.0.4:9634
-Configuration applied to: 172.17.0.4:9634
+Joining peer: 172.17.0.4:9638
+Configuration applied to: 172.17.0.4:9638
 Finished applying configuration
 
 [1;32mAnd just like that, you've applied your change and re-started your nodes.


### PR DESCRIPTION
* Update default gossip port references from 9634 to 9638
* Update `--listen-peer` to `--listen-gossip` in Director when starting Supervisors