### PR TITLE
Tweak the Docker studio image

### DIFF
--- a/components/hab/src/command/studio.rs
+++ b/components/hab/src/command/studio.rs
@@ -201,6 +201,7 @@ mod inner {
             }
         } else {
             debug!("Found studio image locally.");
+            debug!("Local image id: {}", stdout);
         }
 
         let mut cmd_args: Vec<OsString> = vec!["run".into(),

--- a/components/studio/build-docker-image.sh
+++ b/components/studio/build-docker-image.sh
@@ -90,7 +90,7 @@ FROM busybox:latest
 MAINTAINER The Habitat Maintainers <humans@habitat.sh>
 ADD rootfs /
 WORKDIR /src
-RUN env NO_MOUNT=true hab studio new && rm -rf /hab/studios/src/hab/cache
+RUN env NO_MOUNT=true hab studio new
 ENTRYPOINT ["/bin/hab", "studio"]
 EOF
 cd $tmp_root


### PR DESCRIPTION
Signed-off-by: Salim Alam <salam@chef.io>

This change tweaks the Docker Habitat studio image to not remove the hab cache when it gets created. The hab cache contains the hart files that are used to populate the hab/pkgs folder. If the hab cache files are removed, a package upload that requires the cached hart files will fail until the cache is re-populated (eg, by re-installing the dependent package).