### PR TITLE
[devshell] Fix Dockerfile post-Delivery cookbook removal.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,6 @@ RUN (adduser --system hab || true) && (addgroup --system hab || true) \
   && useradd -m -s /bin/bash -G sudo jdoe && echo jdoe:1234 | chpasswd
 
 COPY support/devshell_profile.sh /root/.bash_profile
-COPY .delivery/scripts/ssh_wrapper.sh /usr/local/bin
 COPY components/hab/install.sh /tmp
 RUN /tmp/install.sh \
   && hab install core/busybox-static \


### PR DESCRIPTION
This change removes the copying of a shell helper script from the
`./delivery/` directory. Without removing this line, the devshell cannot
be built.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>