### PR TITLE
Add listen-peer flag back as hidden flag to supervisor

### DIFF
--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -323,8 +323,6 @@ fn sub_cli_setup() -> App<'static, 'static> {
     )
 }
 
-
-
 fn sub_cli_completers() -> App<'static, 'static> {
     let sub = clap_app!(@subcommand completers =>
         (about: "Creates command-line completers for your shell."));

--- a/components/sup/src/http_gateway.rs
+++ b/components/sup/src/http_gateway.rs
@@ -12,8 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4};
+use std::io;
+use std::net::{IpAddr, Ipv4Addr, ToSocketAddrs, SocketAddr, SocketAddrV4};
 use std::ops::{Deref, DerefMut};
+use std::option;
 use std::str::FromStr;
 use std::thread::{self, JoinHandle};
 
@@ -33,7 +35,7 @@ use manager;
 static LOGKEY: &'static str = "HG";
 
 #[derive(PartialEq, Eq, Debug)]
-pub struct ListenAddr(pub SocketAddr);
+pub struct ListenAddr(SocketAddr);
 
 impl Default for ListenAddr {
     fn default() -> ListenAddr {
@@ -72,6 +74,14 @@ impl FromStr for ListenAddr {
                 }
             }
         }
+    }
+}
+
+impl ToSocketAddrs for ListenAddr {
+    type Iter = option::IntoIter<SocketAddr>;
+
+    fn to_socket_addrs(&self) -> io::Result<Self::Iter> {
+        self.0.to_socket_addrs()
     }
 }
 

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -67,12 +67,10 @@ pub struct Manager {
 
 impl Manager {
     pub fn new() -> Result<Manager> {
-        let gossip_addr: SocketAddr = try!(gconfig().gossip_listen().parse());
-
         let mut member = Member::new();
         member.set_persistent(gconfig().gossip_permanent());
-        member.set_swim_port(gossip_addr.port() as i32);
-        member.set_gossip_port(gossip_addr.port() as i32);
+        member.set_swim_port(gconfig().gossip_listen().port() as i32);
+        member.set_gossip_port(gconfig().gossip_listen().port() as i32);
 
         let ring_key = match gconfig().ring() {
             &Some(ref ring_with_revision) => {
@@ -227,7 +225,8 @@ impl Manager {
         // Set the global signal handlers
         signals::init();
 
-        outputln!("Starting butterfly on {}", gconfig().gossip_listen());
+        outputln!("Starting butterfly on {}",
+                  gconfig().gossip_listen().to_string());
         try!(self.state.butterfly.start(Timing::default()));
         debug!("butterfly server started");
         outputln!("Starting http-gateway on {}", gconfig().http_listen_addr());


### PR DESCRIPTION
Temporarily add back the listen-peer flag along with a deprecation
message. This flag was recently renamed to the more appropriate
listen-gossip flag, but let's give some people time to get used to it's
new name ;)