### PR TITLE
Add a switch to `hab pkg install` to ignore target validation.

### DIFF
--- a/components/bintray-publish/bin/publish-hab.sh
+++ b/components/bintray-publish/bin/publish-hab.sh
@@ -178,7 +178,7 @@ _build_slim_release() {
   fi
   mkdir -p "$tmp_root/hab/cache/artifacts"
   cp $target_hart "$tmp_root/hab/cache/artifacts/"
-  env FS_ROOT="$tmp_root" $_hab_cmd pkg install "$target_hart"
+  env FS_ROOT="$tmp_root" $_hab_cmd pkg install "$target_hart" --ignore-target
   if [[ $(find "$tmp_root/hab/pkgs" \( -name hab -or -name hab.exe \) -type f | wc -l) -ne 1 ]]; then
     exit_with "$target_hart did not contain a \`hab' binary" 2
   fi

--- a/components/common/src/command/package/install.rs
+++ b/components/common/src/command/package/install.rs
@@ -60,7 +60,8 @@ pub fn start<P1: ?Sized, P2: ?Sized>(ui: &mut UI,
                                      product: &str,
                                      version: &str,
                                      fs_root_path: &P1,
-                                     cache_artifact_path: &P2)
+                                     cache_artifact_path: &P2,
+                                     ignore_target: bool)
                                      -> Result<PackageIdent>
     where P1: AsRef<Path>,
           P2: AsRef<Path>
@@ -81,7 +82,8 @@ pub fn start<P1: ?Sized, P2: ?Sized>(ui: &mut UI,
                                      version,
                                      fs_root_path.as_ref(),
                                      cache_artifact_path.as_ref(),
-                                     &cache_key_path));
+                                     &cache_key_path,
+                                     ignore_target));
 
     if Path::new(ident_or_archive).is_file() {
         task.from_artifact(ui, &Path::new(ident_or_archive))
@@ -95,6 +97,7 @@ struct InstallTask<'a> {
     fs_root_path: &'a Path,
     cache_artifact_path: &'a Path,
     cache_key_path: &'a Path,
+    ignore_target: bool,
 }
 
 impl<'a> InstallTask<'a> {
@@ -103,13 +106,15 @@ impl<'a> InstallTask<'a> {
                version: &str,
                fs_root_path: &'a Path,
                cache_artifact_path: &'a Path,
-               cache_key_path: &'a Path)
+               cache_key_path: &'a Path,
+               ignore_target: bool)
                -> Result<Self> {
         Ok(InstallTask {
             depot_client: try!(Client::new(url, product, version, Some(fs_root_path))),
             fs_root_path: fs_root_path,
             cache_artifact_path: cache_artifact_path,
             cache_key_path: cache_key_path,
+            ignore_target: ignore_target,
         })
     }
 
@@ -290,8 +295,13 @@ impl<'a> InstallTask<'a> {
                                                      ident.to_string())));
         }
 
-        let artifact_target = try!(artifact.target());
-        try!(artifact_target.validate());
+        if self.ignore_target {
+            info!("Skipping target validation for this package.");
+        } else {
+            let artifact_target = try!(artifact.target());
+            try!(artifact_target.validate());
+        }
+
 
         let nwr = try!(artifact::artifact_signer(&artifact.path));
         if let Err(_) = SigKeyPair::get_public_key_path(&nwr, self.cache_key_path) {

--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -388,13 +388,18 @@ fn sub_pkg_build() -> App<'static, 'static> {
 }
 
 fn sub_pkg_install() -> App<'static, 'static> {
-    clap_app!(@subcommand install =>
+    let sub = clap_app!(@subcommand install =>
         (about: "Installs a Habitat package from a Depot or locally from a Habitat Artifact")
         (@arg DEPOT_URL: -u --url +takes_value {valid_url} "Use a specific Depot URL (ex: http://depot.example.com/v1/depot)")
         (@arg PKG_IDENT_OR_ARTIFACT: +required +multiple
             "One or more Habitat package identifiers (ex: acme/redis) and/or filepaths \
             to a Habitat Artifact (ex: /home/acme-redis-3.0.7-21120102031201-x86_64-linux.hart)")
-    )
+    );
+    sub.arg(Arg::with_name("IGNORE_TARGET")
+        .help("Skips target validation for package installation.")
+        .short("i")
+        .long("ignore-target")
+        .hidden(true))
 }
 
 fn file_exists(val: String) -> result::Result<(), String> {

--- a/components/hab/src/command/pkg.rs
+++ b/components/hab/src/command/pkg.rs
@@ -227,7 +227,8 @@ pub mod export {
                                         PRODUCT,
                                         VERSION,
                                         Path::new(FS_ROOT_PATH),
-                                        &cache_artifact_path(None)));
+                                        &cache_artifact_path(None),
+                                        false));
                 }
             }
             let pkg_arg = OsString::from(&ident.to_string());

--- a/components/hab/src/exec.rs
+++ b/components/hab/src/exec.rs
@@ -65,7 +65,8 @@ pub fn command_from_pkg(ui: &mut UI,
                                                           PRODUCT,
                                                           VERSION,
                                                           fs_root_path,
-                                                          &cache_artifact_path(None)));
+                                                          &cache_artifact_path(None),
+                                                          false));
             command_from_pkg(ui, &command, &ident, &cache_key_path, retry + 1)
         }
         Err(e) => return Err(Error::from(e)),

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -324,6 +324,11 @@ fn sub_pkg_install(ui: &mut UI, m: &ArgMatches) -> Result<()> {
     let env_or_default = henv::var(DEPOT_URL_ENVVAR).unwrap_or(DEFAULT_DEPOT_URL.to_string());
     let url = m.value_of("DEPOT_URL").unwrap_or(&env_or_default);
     let ident_or_artifacts = m.values_of("PKG_IDENT_OR_ARTIFACT").unwrap(); // Required via clap
+    let ignore_target = if m.is_present("IGNORE_TARGET") {
+        true
+    } else {
+        false
+    };
     init();
 
     for ident_or_artifact in ident_or_artifacts {
@@ -333,7 +338,8 @@ fn sub_pkg_install(ui: &mut UI, m: &ArgMatches) -> Result<()> {
                                                       PRODUCT,
                                                       VERSION,
                                                       Path::new(&fs_root),
-                                                      &cache_artifact_path(fs_root_path)));
+                                                      &cache_artifact_path(fs_root_path),
+                                                      ignore_target));
     }
     Ok(())
 }

--- a/components/sup/src/command/start.rs
+++ b/components/sup/src/command/start.rs
@@ -119,7 +119,8 @@ pub fn package() -> Result<()> {
                                                                PRODUCT,
                                                                VERSION,
                                                                Path::new(FS_ROOT_PATH),
-                                                               &cache_artifact_path(None)));
+                                                               &cache_artifact_path(None),
+                                                               false));
                         package = try!(Package::load(&new_pkg_data, None));
                     } else {
                         outputln!("Already running latest.");
@@ -140,7 +141,8 @@ pub fn package() -> Result<()> {
                                         PRODUCT,
                                         VERSION,
                                         Path::new(FS_ROOT_PATH),
-                                        &cache_artifact_path(None)))
+                                        &cache_artifact_path(None),
+                                        false))
                 }
                 None => {
                     outputln!("Searching for {} in remote {}",
@@ -152,7 +154,8 @@ pub fn package() -> Result<()> {
                                         PRODUCT,
                                         VERSION,
                                         Path::new(FS_ROOT_PATH),
-                                        &cache_artifact_path(None)))
+                                        &cache_artifact_path(None),
+                                        false))
                 }
             };
             let package = try!(Package::load(&new_pkg_data, None));


### PR DESCRIPTION
Adds a hidden option to `hab pkg install` of `-i` or `--ignore-target`.

This only impacts the install of a package.  The supervisor or `hab pkg exec` will still be unable to run packages with other targets.

This enables bintray-publish to extract non-linux packages as part of our deployment.