### PR TITLE
Make install.sh version argument work

### DIFF
--- a/components/hab/install.sh
+++ b/components/hab/install.sh
@@ -315,7 +315,8 @@ trap 'rm -rf $tmp_dir; exit $?' INT TERM EXIT
 rm -rf "$tmp_dir"
 (umask 077 && mkdir -p $tmp_dir) || exit 1
 
-download_url="https://api.bintray.com/content/habitat/$channel/$platform/x86_64/hab-%24latest-x86_64-$platform.$file_ext"
+version=${version:-%24latest}
+download_url="https://api.bintray.com/content/habitat/$channel/$platform/x86_64/hab-$version-x86_64-$platform.$file_ext"
 bt_query="?bt_package=hab-x86_64-$platform"
 
 do_download "${download_url}${bt_query}" "${tmp_dir}/hab-latest.${file_ext}"


### PR DESCRIPTION
Previously the `-v` flag didn't do anything. This makes it work and use
latest if it isn't given.

![giphy2](https://cloud.githubusercontent.com/assets/9912/21065655/23240b62-be27-11e6-936e-7ea136a19458.gif)
