### PR TITLE
[sup] Reimplement recursive toml config merging.

### DIFF
--- a/components/sup/src/error.rs
+++ b/components/sup/src/error.rs
@@ -138,6 +138,7 @@ pub enum Error {
     StrFromUtf8Error(str::Utf8Error),
     StringFromUtf8Error(string::FromUtf8Error),
     TomlEncode(toml::Error),
+    TomlMergeError(String),
     TomlParser(Vec<toml::ParserError>),
     TryRecvError(mpsc::TryRecvError),
     UnknownTopology(String),
@@ -225,6 +226,7 @@ impl fmt::Display for SupError {
             Error::StrFromUtf8Error(ref e) => format!("{}", e),
             Error::StringFromUtf8Error(ref e) => format!("{}", e),
             Error::TomlEncode(ref e) => format!("Failed to encode toml: {}", e),
+            Error::TomlMergeError(ref e) => format!("Failed to merge toml: {}", e),
             Error::TomlParser(ref errs) => {
                 format!("Failed to parse toml:\n{}", toml_parser_string(errs))
             }
@@ -299,6 +301,7 @@ impl error::Error for SupError {
             Error::StrFromUtf8Error(_) => "Failed to convert a str from a &[u8] as UTF-8",
             Error::StringFromUtf8Error(_) => "Failed to convert a string from a Vec<u8> as UTF-8",
             Error::TomlEncode(_) => "Failed to encode toml!",
+            Error::TomlMergeError(_) => "Failed to merge toml!",
             Error::TomlParser(_) => "Failed to parse toml!",
             Error::TryRecvError(_) => "A channel failed to recieve a response",
             Error::UnknownTopology(_) => "Unknown topology",


### PR DESCRIPTION
This change reimplements the logic which is responsible for merging down
runtime, environment, user, and default config for a service. The
initial implementation was a shallow merge only, meaning that sub tables
where not merged with each other--only top level keys. The next
implementation built on this code by supporting deep merging of toml
tables if present. There were a few issues with this implementation when
different value types were present for the same key. Additionally, the
Rust match-based logic was extended to support this which resulted in a
harder to understand function. Lastly, using recursion as part of the
implementation introduced a potential attack vector where a user could
craft a data structure deep enough to overflow the stack and cause the
supervisor to unwind and terminate.

This current implementation reduces the merging logic to the following:

* There are 2 toml tables: `me` (the current, config which will be
  mutated in place) and `other` (a reference to a config which override
  the current config).
* For each key in `other`, perform one of two things:
* If the values at `key` in `me` and `other` both contains toml tables,
  then call `toml_merge_recurse` on those value tables to recursively
  merge them down.
* Otherwise copy the value of `other` at `key` into the value of `key`
  in `me`. It makes no difference if the value types differ or are the
  same--the `other` table will always override anything in `me`.

The merge logic also contains a maximum recursive depth check in an
attempt to prevent burning through all stack space.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>