### PR TITLE
[hab/install.sh] Allow installation of specific hab releases.

### DIFF
--- a/components/hab/install.sh
+++ b/components/hab/install.sh
@@ -274,7 +274,7 @@ do_install() {
       ;;
     "linux")
       ident="core/hab"
-      if [ ! -z "${version-}" ] && [ "${version}" != "%24latest" ]; then ident="$ident/$version"; fi
+      if [ ! -z "${version-}" ]; then ident="$ident/$version"; fi
       # Install hab release using the extracted version and add/update symlink
       "$archive_dir/hab" install "$ident"
       "$archive_dir/hab" pkg binlink "$ident" hab
@@ -285,8 +285,11 @@ do_install() {
 # Download location for the temporary files
 tmp_dir="${TMPDIR:-/tmp}/hab"
 
-# use stable channel by default
+# Use stable Bintray channel by default
 channel="stable"
+
+# Set an empty version variable, signaling we want the latest release
+version=""
 
 # ## CLI Argument Parsing
 
@@ -314,8 +317,8 @@ trap 'rm -rf $tmp_dir; exit $?' INT TERM EXIT
 rm -rf "$tmp_dir"
 (umask 077 && mkdir -p $tmp_dir) || exit 1
 
-version=${version:-%24latest}
-download_url="https://api.bintray.com/content/habitat/$channel/$platform/x86_64/hab-$version-x86_64-$platform.$file_ext"
+bt_version="$(echo ${version:-%24latest} | tr '/' '-')"
+download_url="https://api.bintray.com/content/habitat/$channel/$platform/x86_64/hab-$bt_version-x86_64-$platform.$file_ext"
 bt_query="?bt_package=hab-x86_64-$platform"
 
 do_download "${download_url}${bt_query}" "${tmp_dir}/hab-latest.${file_ext}"


### PR DESCRIPTION
This change fixes the logic in hab's `install.sh` script to support
installation of fully qualified hab versions (i.e.
`0.12.1/20161102212401`).

Prior to this change, specifying a `verion/release` format such as
`sh install.sh -v 0.12.1/20161102212401` resulted in a 404 error which
was caused because in Bintray the *version* string is `version-release`
rather than `version/release`.

Note that on Linux, the same version of the desired `hab` binary is
downloaded even though the Bintray binary is thrown away at the end of
the installation process--it is only used as a trusted binary to install
the full `core/hab` Habitat package from the Depot. This may help in the
future to test any possible breaking changes in `hab install` and `hab
pkg binlink` commands.

Finally note that *only* `version/release` strings are
supported--specifying only the Habitat version string component (i.e.
`0.12.1`) will not work correctly and requires much more Bintray API
querying--it simply is not worth the effort.

---

## Install latest version, no arugments

```
> docker run --rm -ti --privileged -v $(pwd):/src alpine sh
/ # apk add --no-cache wget ca-certificates gnupg && echo "#### BEGIN ###" && /src/components/hab/install.sh
fetch http://dl-cdn.alpinelinux.org/alpine/v3.4/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.4/community/x86_64/APKINDEX.tar.gz
(1/17) Installing ca-certificates (20160104-r4)
(2/17) Installing libgpg-error (1.23-r0)
(3/17) Installing libassuan (2.4.2-r0)
(4/17) Installing libcap (2.25-r0)
(5/17) Installing ncurses-terminfo-base (6.0-r7)
(6/17) Installing ncurses-terminfo (6.0-r7)
(7/17) Installing ncurses-libs (6.0-r7)
(8/17) Installing pinentry (0.9.7-r0)
Executing pinentry-0.9.7-r0.post-install
(9/17) Installing libbz2 (1.0.6-r5)
(10/17) Installing libgcrypt (1.7.0-r1)
(11/17) Installing libksba (1.3.4-r0)
(12/17) Installing db (5.3.28-r0)
(13/17) Installing libsasl (2.1.26-r7)
(14/17) Installing libldap (2.4.44-r1)
(15/17) Installing npth (1.2-r0)
(16/17) Installing gnupg (2.1.12-r0)
(17/17) Installing wget (1.18-r0)
Executing busybox-1.24.2-r9.trigger
Executing ca-certificates-20160104-r4.trigger
OK: 21 MiB in 28 packages
#### BEGIN ###
downloading https://api.bintray.com/content/habitat/stable/linux/x86_64/hab-%24latest-x86_64-linux.tar.gz?bt_package=hab-x86_64-linux
  to file /tmp/hab/hab-latest.tar.gz
trying wget...
downloading https://api.bintray.com/content/habitat/stable/linux/x86_64/hab-%24latest-x86_64-linux.tar.gz.sha256sum?bt_package=hab-x86_64-linux
  to file /tmp/hab/hab-latest.tar.gz.sha256sum
trying wget...
'/tmp/hab/hab-latest.tar.gz' -> '/tmp/hab/hab-0.13.1-20161114235527-x86_64-linux.tar.gz'
'/tmp/hab/hab-latest.tar.gz.sha256sum' -> '/tmp/hab/hab-0.13.1-20161114235527-x86_64-linux.tar.gz.sha256sum'
downloading https://api.bintray.com/content/habitat/stable/linux/x86_64/hab-%24latest-x86_64-linux.tar.gz.sha256sum.asc?bt_package=hab-x86_64-linux
  to file /tmp/hab/hab-0.13.1-20161114235527-x86_64-linux.tar.gz.sha256sum.asc
trying wget...
downloading https://bintray.com/user/downloadSubjectPublicKey?username=habitat
  to file /tmp/hab/habitat.asc
trying wget...
gpg: directory '/root/.gnupg' created
gpg: new configuration file '/root/.gnupg/dirmngr.conf' created
gpg: new configuration file '/root/.gnupg/gpg.conf' created
gpg: keybox '/root/.gnupg/pubring.kbx' created
gpg: assuming signed data in '/tmp/hab/hab-0.13.1-20161114235527-x86_64-linux.tar.gz.sha256sum'
gpg: Signature made Tue Nov 15 02:15:40 2016 UTC using RSA key ID 7F61CCE7
gpg: /root/.gnupg/trustdb.gpg: trustdb created
gpg: Good signature from "Habitat Packages <packages@habitat.sh>" [unknown]
gpg: WARNING: This key is not certified with a trusted signature!
gpg:          There is no indication that the signature belongs to the owner.
Primary key fingerprint: 49EB C7FF 577F 0B15 A930  821C F27D 6DD6 7F61 CCE7
hab-0.13.1-20161114235527-x86_64-linux.tar.gz: OK
» Installing core/hab
↓ Downloading core/hab/0.13.1/20161114235527
    2.39 MB / 2.39 MB - [=========================================================] 100.00 % 4.78 MB/s
↓ Downloading core-20160810182414 public origin key
    75 B / 75 B | [===============================================================] 100.00 % 2.34 MB/s
☑ Cached core-20160810182414 public origin key
✓ Installed core/hab/0.13.1/20161114235527
★ Install of core/hab/0.13.1/20161114235527 complete with 1 new packages installed.
» Symlinking hab from core/hab into /bin
★ Binary hab from core/hab/0.13.1/20161114235527 symlinked to /bin/hab
/ # hab --version
hab 0.13.1/20161114235527
```

## Install specific version/release

```
> docker run --rm -ti --privileged -v $(pwd):/src alpine sh
/ # apk add --no-cache wget ca-certificates gnupg && echo "#### BEGIN ###" && /src/components/hab/install.sh -v 0.12.1/20161102212401
fetch http://dl-cdn.alpinelinux.org/alpine/v3.4/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.4/community/x86_64/APKINDEX.tar.gz
(1/17) Installing ca-certificates (20160104-r4)
(2/17) Installing libgpg-error (1.23-r0)
(3/17) Installing libassuan (2.4.2-r0)
(4/17) Installing libcap (2.25-r0)
(5/17) Installing ncurses-terminfo-base (6.0-r7)
(6/17) Installing ncurses-terminfo (6.0-r7)
(7/17) Installing ncurses-libs (6.0-r7)
(8/17) Installing pinentry (0.9.7-r0)
Executing pinentry-0.9.7-r0.post-install
(9/17) Installing libbz2 (1.0.6-r5)
(10/17) Installing libgcrypt (1.7.0-r1)
(11/17) Installing libksba (1.3.4-r0)
(12/17) Installing db (5.3.28-r0)
(13/17) Installing libsasl (2.1.26-r7)
(14/17) Installing libldap (2.4.44-r1)
(15/17) Installing npth (1.2-r0)
(16/17) Installing gnupg (2.1.12-r0)
(17/17) Installing wget (1.18-r0)
Executing busybox-1.24.2-r9.trigger
Executing ca-certificates-20160104-r4.trigger
OK: 21 MiB in 28 packages
#### BEGIN ###
downloading https://api.bintray.com/content/habitat/stable/linux/x86_64/hab-0.12.1-20161102212401-x86_64-linux.tar.gz?bt_package=hab-x86_64-linux
  to file /tmp/hab/hab-latest.tar.gz
trying wget...
downloading https://api.bintray.com/content/habitat/stable/linux/x86_64/hab-0.12.1-20161102212401-x86_64-linux.tar.gz.sha256sum?bt_package=hab-x86_64-linux
  to file /tmp/hab/hab-latest.tar.gz.sha256sum
trying wget...
'/tmp/hab/hab-latest.tar.gz' -> '/tmp/hab/hab-0.12.1-20161102212401-x86_64-linux.tar.gz'
'/tmp/hab/hab-latest.tar.gz.sha256sum' -> '/tmp/hab/hab-0.12.1-20161102212401-x86_64-linux.tar.gz.sha256sum'
downloading https://api.bintray.com/content/habitat/stable/linux/x86_64/hab-0.12.1-20161102212401-x86_64-linux.tar.gz.sha256sum.asc?bt_package=hab-x86_64-linux
  to file /tmp/hab/hab-0.12.1-20161102212401-x86_64-linux.tar.gz.sha256sum.asc
trying wget...
downloading https://bintray.com/user/downloadSubjectPublicKey?username=habitat
  to file /tmp/hab/habitat.asc
trying wget...
gpg: directory '/root/.gnupg' created
gpg: new configuration file '/root/.gnupg/dirmngr.conf' created
gpg: new configuration file '/root/.gnupg/gpg.conf' created
gpg: keybox '/root/.gnupg/pubring.kbx' created
gpg: assuming signed data in '/tmp/hab/hab-0.12.1-20161102212401-x86_64-linux.tar.gz.sha256sum'
gpg: Signature made Wed Nov  2 23:05:36 2016 UTC using RSA key ID 7F61CCE7
gpg: /root/.gnupg/trustdb.gpg: trustdb created
gpg: Good signature from "Habitat Packages <packages@habitat.sh>" [unknown]
gpg: WARNING: This key is not certified with a trusted signature!
gpg:          There is no indication that the signature belongs to the owner.
Primary key fingerprint: 49EB C7FF 577F 0B15 A930  821C F27D 6DD6 7F61 CCE7
hab-0.12.1-20161102212401-x86_64-linux.tar.gz: OK
» Installing core/hab/0.12.1/20161102212401
↓ Downloading core/hab/0.12.1/20161102212401
    2.34 MB / 2.34 MB | [=========================================================================] 100.00 % 1.78 MB/s
↓ Downloading core-20160810182414 public origin key
    75 B / 75 B | [===============================================================================] 100.00 % 1.46 MB/s
☑ Cached core-20160810182414 public origin key
✓ Installed core/hab/0.12.1/20161102212401
★ Install of core/hab/0.12.1/20161102212401 complete with 1 new packages installed.
» Symlinking hab from core/hab/0.12.1/20161102212401 into /bin
★ Binary hab from core/hab/0.12.1/20161102212401 symlinked to /bin/hab
/ # hab --version
hab 0.12.1/20161102212401
```

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>