### PR TITLE
Fix some spelling and a warning on nightly.

### DIFF
--- a/components/butterfly/src/client.rs
+++ b/components/butterfly/src/client.rs
@@ -44,9 +44,12 @@ impl Client {
             .expect("Failure to set the ZMQ push socket to not linger");
         socket.set_tcp_keepalive(0)
             .expect("Failure to set the ZMQ push socket to not use keepalive");
-        socket.set_immediate(true).expect("Failure to set the ZMQ push socket to immediate");
-        socket.set_sndhwm(1000).expect("Failure to set the ZMQ push socket hwm");
-        socket.set_sndtimeo(500).expect("Failure to set the ZMQ send timeout");
+        socket.set_immediate(true)
+            .expect("Failure to set the ZMQ push socket to immediate");
+        socket.set_sndhwm(1000)
+            .expect("Failure to set the ZMQ push socket hwm");
+        socket.set_sndtimeo(500)
+            .expect("Failure to set the ZMQ send timeout");
         let to_addr = format!("tcp://{}", addr.to_string());
         try!(socket.connect(&to_addr).map_err(Error::ZmqConnectError));
         Ok(Client {

--- a/components/butterfly/src/rumor/mod.rs
+++ b/components/butterfly/src/rumor/mod.rs
@@ -21,7 +21,7 @@
 //! to. Each rumor is shared with every member `RUMOR_MAX` times.
 //!
 //! New rumors need to implement the `From` trait for `RumorKey`, and then can track the arrival of
-//! new rumors, and dispatch them according to thier `kind`.
+//! new rumors, and dispatch them according to their `kind`.
 
 pub mod election;
 pub mod service;
@@ -40,7 +40,6 @@ use message::swim::Rumor_Type;
 use error::{Result, Error};
 
 /// The description of a `RumorKey`.
-///
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct RumorKey {
     pub kind: Rumor_Type,
@@ -72,7 +71,7 @@ pub trait Rumor: Encodable {
     fn kind(&self) -> Rumor_Type;
     fn key(&self) -> &str;
     fn id(&self) -> &str;
-    fn merge(&mut self, mut other: Self) -> bool;
+    fn merge(&mut self, other: Self) -> bool;
     fn write_to_bytes(&self) -> Result<Vec<u8>>;
 }
 


### PR DESCRIPTION
This is a trivial PR which cleans up some inconsistent style, fixes a spelling error, and corrects a deprecation warning on nightly.

```
warning: patterns aren't allowed in methods without bodies, #[warn(patterns_in_fns_without_body)] on by default
  --> src/rumor/mod.rs:74:25
   |
74 |     fn merge(&mut self, mut other: Self) -> bool;
   |                         ^^^^^^^^^
   |
   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
   = note: for more information, see issue #35203 <https://github.com/rust-lang/rust/issues/35203>
```