### PR TITLE
Supervisor on windows can "supervise" process for state change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -459,6 +459,7 @@ dependencies = [
  "gcc 0.3.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat_win_users 0.0.0",
  "hyper 0.9.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libarchive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -472,6 +473,7 @@ dependencies = [
  "toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "users 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/components/core/Cargo.toml
+++ b/components/core/Cargo.toml
@@ -28,6 +28,10 @@ users = "*"
 [target.'cfg(windows)'.dependencies.habitat_win_users]
 path = "../win-users"
 
+[target.'cfg(windows)'.dependencies]
+kernel32-sys = "*"
+winapi = "*"
+
 [dev-dependencies]
 hyper = "*"
 tempdir = "*"

--- a/components/core/src/error.rs
+++ b/components/core/src/error.rs
@@ -86,6 +86,12 @@ pub enum Error {
     TargetMatchError(String),
     /// Occurs when a `uname` libc call returns an error.
     UnameFailed(String),
+    /// Occurs when a `waitpid` libc call returns an error.
+    WaitpidFailed(String),
+    /// Occurs when a `GetExitCodeProcess` win32 call returns an error.
+    GetExitCodeProcessFailed(String),
+    /// Occurs when a `HabChild` constructor fails to return a process.
+    GetHabChildFailed(String),
     /// When an error occurs attempting to interpret a sequence of u8 as a string.
     Utf8Error(str::Utf8Error),
 }
@@ -158,6 +164,9 @@ impl fmt::Display for Error {
             Error::StringFromUtf8Error(ref e) => format!("{}", e),
             Error::TargetMatchError(ref e) => format!("{}", e),
             Error::UnameFailed(ref e) => format!("{}", e),
+            Error::WaitpidFailed(ref e) => format!("{}", e),
+            Error::GetExitCodeProcessFailed(ref e) => format!("{}", e),
+            Error::GetHabChildFailed(ref e) => format!("{}", e),
             Error::Utf8Error(ref e) => format!("{}", e),
         };
         write!(f, "{}", msg)
@@ -209,6 +218,9 @@ impl error::Error for Error {
             Error::StringFromUtf8Error(_) => "Failed to convert a string from a Vec<u8> as UTF-8",
             Error::TargetMatchError(_) => "System target does not match package target",
             Error::UnameFailed(_) => "uname failed",
+            Error::WaitpidFailed(_) => "waitpid failed",
+            Error::GetExitCodeProcessFailed(_) => "GetExitCodeProcess failed",
+            Error::GetHabChildFailed(_) => "Failed to return a HabChild",
             Error::Utf8Error(_) => "Failed to interpret a sequence of bytes as a string",
         }
     }

--- a/components/core/src/lib.rs
+++ b/components/core/src/lib.rs
@@ -36,6 +36,10 @@ extern crate users as linux_users;
 
 #[cfg(windows)]
 extern crate habitat_win_users;
+#[cfg(windows)]
+extern crate kernel32;
+#[cfg(windows)]
+extern crate winapi;
 
 pub use self::error::{Error, Result};
 

--- a/components/core/src/os/process/linux.rs
+++ b/components/core/src/os/process/linux.rs
@@ -12,32 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use libc::{pid_t, c_int};
+use libc;
 use std::ffi::OsString;
 use std::path::PathBuf;
 use std::os::unix::process::CommandExt;
-use std::process::Command;
+use std::process::{self, Command};
 
-use error::Result;
+use error::{Error, Result};
+
+use super::{HabExitStatus, ExitStatusExt};
 
 extern "C" {
     fn kill(pid: i32, sig: u32) -> u32;
-    fn waitpid(pid: pid_t, status: *mut c_int, options: c_int) -> pid_t;
+    fn waitpid(pid: libc::pid_t, status: *mut libc::c_int, options: libc::c_int) -> libc::pid_t;
 }
 
 pub fn become_command(command: PathBuf, args: Vec<OsString>) -> Result<()> {
     become_exec_command(command, args)
 }
 
-pub fn wait_for_exit(pid: u32, status: *mut c_int) -> u32 {
-    unsafe { waitpid(pid as i32, status, 1 as c_int) as u32 }
-}
-
 /// send a Unix signal to a pid
 pub fn send_signal(pid: u32, sig: u32) -> u32 {
-    unsafe {
-        kill(pid as i32, sig)
-    }
+    unsafe { kill(pid as i32, sig) }
 }
 
 /// Makes an `execvp(3)` system call to become a new program.
@@ -53,4 +49,121 @@ fn become_exec_command(command: PathBuf, args: Vec<OsString>) -> Result<()> {
     // The only possible return for the above function is an `Error` so return it, meaning that we
     // failed to exec to our target program
     return Err(error_if_failed.into());
+}
+
+pub struct Child {
+    pid: u32,
+}
+
+impl Child {
+    pub fn new(child: &mut process::Child) -> Result<Child> {
+        Ok(Child { pid: child.id() })
+    }
+
+    pub fn id(&self) -> u32 {
+        self.pid
+    }
+
+    pub fn status(&mut self) -> Result<HabExitStatus> {
+        let mut exit_status: i32 = 0;
+
+        match unsafe { waitpid(self.pid as i32, &mut exit_status, libc::WNOHANG) } {
+            0 => Ok(HabExitStatus { status: None }),
+            -1 => Err(Error::WaitpidFailed(format!("Error calling waitpid on pid: {}", self.pid))),
+            _ => Ok(HabExitStatus { status: Some(exit_status as u32) }),
+        }
+    }
+}
+
+impl ExitStatusExt for HabExitStatus {
+    fn code(&self) -> Option<u32> {
+        unsafe {
+            match self.status {
+                None => None,
+                Some(status) if libc::WIFEXITED(status as libc::c_int) => {
+                    Some(libc::WEXITSTATUS(status as libc::c_int) as u32)
+                }
+                _ => None,
+            }
+        }
+    }
+
+    fn signal(&self) -> Option<u32> {
+        unsafe {
+            match self.status {
+                None => None,
+                Some(status) if !libc::WIFEXITED(status as libc::c_int) => {
+                    Some(libc::WTERMSIG(status as libc::c_int) as u32)
+                }
+                _ => None,
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use libc;
+    use std::process::Command;
+    use super::super::*;
+
+    #[test]
+    fn running_process_returns_no_exit_status() {
+        let mut cmd = Command::new("/bin/bash");
+        cmd.arg("-c").arg("while : ; do /bin/sleep 1; done");
+        let mut child = cmd.spawn().unwrap();
+
+        let mut hab_child = HabChild::from(&mut child).unwrap();
+
+        assert!(hab_child.status().unwrap().no_status())
+    }
+
+    #[test]
+    fn succesfully_run_process_exits_zero() {
+        let mut cmd = Command::new("/bin/bash");
+        cmd.arg("-c").arg("a='b'");
+        let mut child = cmd.spawn().unwrap();
+
+        let mut hab_child = HabChild::from(&mut child).unwrap();
+        let mut exit = hab_child.status().unwrap();
+
+        while exit.no_status() {
+            exit = hab_child.status().unwrap();
+        }
+
+        assert_eq!(exit.code(), Some(0))
+    }
+
+    #[test]
+    fn terminated_process_returns_non_zero_exit() {
+        let mut cmd = Command::new("/bin/bash");
+        cmd.arg("-c").arg("while : ; do /bin/sleep 1; done");
+        let mut child = cmd.spawn().unwrap();
+
+        let mut hab_child = HabChild::from(&mut child).unwrap();
+        let _ = child.kill();
+
+        let mut exit = hab_child.status().unwrap();
+        while exit.no_status() {
+            exit = hab_child.status().unwrap();
+        }
+
+        assert_eq!(exit.signal(), Some(libc::SIGKILL as u32))
+    }
+
+    #[test]
+    fn process_that_exits_with_specific_code_has_same_exit_code() {
+        let mut cmd = Command::new("/bin/bash");
+        cmd.arg("-c").arg("exit 5");
+        let mut child = cmd.spawn().unwrap();
+
+        let mut hab_child = HabChild::from(&mut child).unwrap();
+        let mut exit = hab_child.status().unwrap();
+
+        while exit.no_status() {
+            exit = hab_child.status().unwrap();
+        }
+
+        assert_eq!(exit.code(), Some(5))
+    }
 }

--- a/components/core/src/os/process/windows.rs
+++ b/components/core/src/os/process/windows.rs
@@ -12,20 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use libc::c_int;
 use std::ffi::OsString;
 use std::path::PathBuf;
 use std::process::{self, Command};
+use std::ptr;
+use std::io;
 
-use error::Result;
+use kernel32;
+use winapi;
+
+use error::{Error, Result};
+
+use super::{HabExitStatus, ExitStatusExt};
+
+const STILL_ACTIVE: u32 = 259;
 
 pub fn become_command(command: PathBuf, args: Vec<OsString>) -> Result<()> {
     become_child_command(command, args)
-}
-
-//TODO: REALLY wait for exit
-pub fn wait_for_exit(pid: u32, status: *mut c_int) -> u32 {
-    0
 }
 
 pub fn send_signal(pid: u32, sig: u32) -> u32 {
@@ -46,4 +49,174 @@ fn become_child_command(command: PathBuf, args: Vec<OsString>) -> Result<()> {
     let status = try!(Command::new(command).args(&args).status());
     // Let's honor the exit codes from the child process we finished running
     process::exit(status.code().unwrap())
+}
+
+fn handle_from_pid(pid: u32) -> Option<winapi::HANDLE> {
+    unsafe {
+        let proc_handle = kernel32::OpenProcess(winapi::PROCESS_QUERY_LIMITED_INFORMATION,
+                                                winapi::FALSE,
+                                                pid as winapi::DWORD);
+
+        // we expect this to happen if the process died
+        // before OpenProcess completes
+        if proc_handle == ptr::null_mut() {
+            return None;
+        } else {
+            return Some(proc_handle);
+        }
+    }
+}
+
+pub struct Child {
+    handle: Option<winapi::HANDLE>,
+    last_status: Option<u32>,
+    pid: u32,
+}
+
+impl Child {
+    // On windows we need the process handle to capture status
+    // Here we will attempt to get the handle from the pid but if the
+    // process dies before we can get it, we will just wait() on the
+    // std::process::Child and cache the exit_status which we will return
+    // when ststus is called.
+    pub fn new(child: &mut process::Child) -> Result<Child> {
+        let (win_handle, status) = match handle_from_pid(child.id()) {
+            Some(handle) => (Some(handle), Ok(None)),
+            _ => {
+                (None,
+                 {
+                    match child.wait() {
+                        Ok(exit) => Ok(Some(exit.code().unwrap() as u32)),
+                        Err(e) => {
+                            Err(format!("Failed to retrieve exit code for pid {} : {}",
+                                        child.id(),
+                                        e))
+                        }
+                    }
+                })
+            }
+        };
+
+        match status {
+            Ok(status) => {
+                Ok(Child {
+                    handle: win_handle,
+                    last_status: status,
+                    pid: child.id(),
+                })
+            }
+            Err(e) => Err(Error::GetHabChildFailed(e)),
+        }
+    }
+
+    pub fn id(&self) -> u32 {
+        self.pid
+    }
+
+    pub fn status(&mut self) -> Result<HabExitStatus> {
+        if self.last_status.is_some() {
+            return Ok(HabExitStatus { status: Some(self.last_status.unwrap()) });
+        }
+
+        let mut exit_status: u32 = 0;
+
+        unsafe {
+            let ret = kernel32::GetExitCodeProcess(self.handle.unwrap(),
+                                                   &mut exit_status as winapi::LPDWORD);
+            if ret == 0 {
+                return Err(Error::GetExitCodeProcessFailed(format!("Failed to retrieve Exit \
+                                                                    Code for pid {}: {}",
+                                                                   self.pid,
+                                                                   io::Error::last_os_error())));
+            }
+        }
+
+        if exit_status == STILL_ACTIVE {
+            return Ok(HabExitStatus { status: None });
+        };
+
+        Ok(HabExitStatus { status: Some(exit_status) })
+    }
+}
+
+// Have to implement these due to our HANDLE field
+unsafe impl Send for Child {}
+unsafe impl Sync for Child {}
+
+impl Drop for Child {
+    fn drop(&mut self) {
+        match self.handle {
+            None => {}
+            Some(handle) => unsafe {
+                let _ = kernel32::CloseHandle(handle);
+            },
+        }
+    }
+}
+
+impl ExitStatusExt for HabExitStatus {
+    fn code(&self) -> Option<u32> {
+        self.status
+    }
+
+    fn signal(&self) -> Option<u32> {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::process::Command;
+    use super::super::*;
+
+    #[test]
+    fn running_process_returns_no_exit_status() {
+        let mut cmd = Command::new("C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.\
+                                    exe");
+        cmd.arg("-noprofile").arg("-command").arg("while($true) { Start-Sleep 1 }");
+        let mut child = cmd.spawn().unwrap();
+
+        let mut hab_child = HabChild::from(&mut child).unwrap();
+
+        assert!(hab_child.status().unwrap().no_status())
+    }
+
+    #[test]
+    fn succesfully_run_process_exits_zero() {
+        let mut cmd = Command::new("C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.\
+                                    exe");
+        cmd.arg("-noprofile").arg("-command").arg("$a='b'");
+        let mut child = cmd.spawn().unwrap();
+
+        let mut hab_child = HabChild::from(&mut child).unwrap();
+        let _ = child.wait();
+
+        assert_eq!(hab_child.status().unwrap().code(), Some(0))
+    }
+
+    #[test]
+    fn terminated_process_returns_non_zero_exit() {
+        let mut cmd = Command::new("C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.\
+                                    exe");
+        cmd.arg("-noprofile").arg("-command").arg("while($true) { Start-Sleep 1 }");
+        let mut child = cmd.spawn().unwrap();
+
+        let mut hab_child = HabChild::from(&mut child).unwrap();
+        let _ = child.kill();
+
+        assert!(hab_child.status().unwrap().code() != Some(0))
+    }
+
+    #[test]
+    fn process_that_exits_with_specific_code_has_same_exit_code() {
+        let mut cmd = Command::new("C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.\
+                                    exe");
+        cmd.arg("-noprofile").arg("-command").arg("exit 5000");
+        let mut child = cmd.spawn().unwrap();
+
+        let mut hab_child = HabChild::from(&mut child).unwrap();
+        let _ = child.wait();
+
+        assert_eq!(hab_child.status().unwrap().code(), Some(5000))
+    }
 }

--- a/components/sup/src/manager/service/mod.rs
+++ b/components/sup/src/manager/service/mod.rs
@@ -148,16 +148,17 @@ impl Service {
     }
 
     pub fn send_signal(&self, signal: u32) -> Result<()> {
-        if self.supervisor.pid.is_some() {
-            signals::send_signal(self.supervisor.pid.unwrap(), signal)
-        } else {
-            debug!("No process to send the signal to");
-            Ok(())
+        match self.supervisor.child {
+            Some(ref child) => signals::send_signal(child.id(), signal),
+            None => {
+                debug!("No process to send the signal to");
+                Ok(())
+            }
         }
     }
 
     pub fn is_down(&self) -> bool {
-        self.supervisor.pid.is_none()
+        self.supervisor.child.is_none()
     }
 
     pub fn check_process(&mut self) -> Result<()> {

--- a/components/sup/src/supervisor.rs
+++ b/components/sup/src/supervisor.rs
@@ -28,10 +28,9 @@ use std::result;
 use std::thread;
 
 use hcore;
-use hcore::os::process;
+use hcore::os::process::{HabChild, ExitStatusExt};
 use hcore::package::PackageIdent;
 use hcore::service::ServiceGroup;
-use libc::c_int;
 use rustc_serialize::{Encodable, Encoder};
 use time::{Duration, SteadyTime};
 
@@ -41,62 +40,6 @@ use manager::signals;
 
 const PIDFILE_NAME: &'static str = "PID";
 static LOGKEY: &'static str = "SV";
-
-/// A simple compatability type for external functions
-#[allow(non_camel_case_types)]
-pub type idtype_t = c_int;
-
-pub const P_ALL: idtype_t = 0;
-pub const P_PID: idtype_t = 1;
-pub const P_PGID: idtype_t = 2;
-
-// Process flags
-pub const WCONTINUED: c_int = 8;
-pub const WNOHANG: c_int = 1;
-pub const WUNTRACED: c_int = 2;
-pub const WEXITED: c_int = 4;
-pub const WNOWAIT: c_int = 16777216;
-pub const WSTOPPED: c_int = 2;
-
-/// Get the exit status from waitpid's errno
-#[allow(non_snake_case)]
-pub fn WEXITSTATUS(status: c_int) -> c_int {
-    (status & 0xff00) >> 8
-}
-
-/// Get the exit status from waitpid's errno
-#[allow(non_snake_case)]
-pub fn WIFCONTINUED(status: c_int) -> bool {
-    status == 0xffff
-}
-
-#[allow(non_snake_case)]
-pub fn WIFEXITED(status: c_int) -> bool {
-    WTERMSIG(status) == 0
-}
-
-/// Has a value if our child was signaled
-#[allow(non_snake_case)]
-pub fn WIFSIGNALED(status: c_int) -> bool {
-    ((((status) & 0x7f) + 1) as i8 >> 1) > 0
-}
-
-#[allow(non_snake_case)]
-pub fn WIFSTOPPED(status: c_int) -> bool {
-    (status & 0xff) == 0x7f
-}
-
-#[allow(non_snake_case)]
-pub fn WSTOPSIG(status: c_int) -> c_int {
-    WEXITSTATUS(status)
-}
-
-#[allow(non_snake_case)]
-pub fn WTERMSIG(status: c_int) -> c_int {
-    status & 0x7f
-}
-
-pub type Pid = u32;
 
 #[derive(Debug, RustcEncodable)]
 pub enum ProcessState {
@@ -140,7 +83,7 @@ impl RuntimeConfig {
 
 #[derive(Debug)]
 pub struct Supervisor {
-    pub pid: Option<Pid>,
+    pub child: Option<HabChild>,
     pub package_ident: PackageIdent,
     pub preamble: String,
     pub state: ProcessState,
@@ -155,7 +98,7 @@ impl Supervisor {
                runtime_config: RuntimeConfig)
                -> Supervisor {
         Supervisor {
-            pid: None,
+            child: None,
             package_ident: package_ident,
             preamble: format!("{}", service_group),
             state: ProcessState::Down,
@@ -183,7 +126,7 @@ impl Supervisor {
     }
 
     pub fn start(&mut self) -> Result<()> {
-        if self.pid.is_none() {
+        if self.child.is_none() {
             outputln!(preamble & self.preamble, "Starting");
             self.enter_state(ProcessState::Start);
             let mut child = try!(util::create_command(self.run_cmd(),
@@ -191,7 +134,8 @@ impl Supervisor {
                                                       &self.runtime_config.svc_group)
                 .spawn());
 
-            self.pid = Some(child.id());
+            let hab_child = try!(HabChild::from(&mut child));
+            self.child = Some(hab_child);
             try!(self.create_pidfile());
             let package_name = self.preamble.clone();
             try!(thread::Builder::new()
@@ -207,8 +151,9 @@ impl Supervisor {
 
     /// Send a SIGTERM to a process, wait 8 seconds, then send SIGKILL
     pub fn stop(&mut self) -> Result<()> {
-        let wait = match self.pid {
-            Some(ref pid) => {
+        let wait = match self.child {
+            Some(ref child) => {
+                let ref pid = child.id();
                 outputln!(preamble & self.preamble, "Stopping");
                 try!(signals::send_signal(*pid, signals::Signal::SIGTERM as u32));
                 true
@@ -222,12 +167,12 @@ impl Supervisor {
                 if SteadyTime::now() > stop_time {
                     outputln!(preamble & self.preamble,
                               "Process failed to stop with SIGTERM; sending SIGKILL");
-                    if let Some(pid) = self.pid {
-                        try!(signals::send_signal(pid, signals::Signal::SIGKILL as u32));
+                    if let Some(ref mut child) = self.child {
+                        try!(signals::send_signal(child.id(), signals::Signal::SIGKILL as u32));
                     }
                     break;
                 }
-                if self.pid.is_none() {
+                if self.child.is_none() {
                     break;
                 } else {
                     continue;
@@ -269,64 +214,54 @@ impl Supervisor {
 
     /// Pass through a Unix signal to a process
     pub fn send_unix_signal(&self, sig: signals::Signal) -> Result<()> {
-        if let Some(pid) = self.pid {
-            try!(signals::send_signal(pid, sig as u32));
+        if let Some(ref child) = self.child {
+            try!(signals::send_signal(child.id(), sig as u32));
         }
         Ok(())
     }
 
     /// if the child process exists, check it's status via waitpid().
     pub fn check_process(&mut self) -> Result<()> {
-        if self.pid.is_none() {
-            return Ok(());
+        let changed = match self.child {
+            None => false,
+            Some(ref mut child) => {
+                match child.status() {
+                    Ok(ref status) if status.no_status() => false,
+                    Ok(ref status) => {
+                        if status.code().is_some() {
+                            outputln!("{} - process {} died with exit code {}",
+                                      self.preamble,
+                                      child.id(),
+                                      status.code().unwrap());
+                        } else if status.signal().is_some() {
+                            outputln!("{} - process {} died with signal {}",
+                                      self.preamble,
+                                      child.id(),
+                                      status.signal().unwrap());
+                        }
+                        true
+                    }
+                    Err(e) => {
+                        debug!("Error checking process status: {}, continuing", e);
+                        false
+                    }
+                }
+            }
+        };
+
+        if changed {
+            match self.state {
+                ProcessState::Up | ProcessState::Start | ProcessState::Restart => {
+                    outputln!("{} - Service exited", self.preamble);
+                    self.child = None;
+                }
+                ProcessState::Down => {
+                    self.enter_state(ProcessState::Down);
+                    self.child = None;
+                }
+            }
         }
 
-        let mut status: c_int = 0;
-        let cpid = self.pid.unwrap();
-        match process::wait_for_exit(cpid, &mut status) {
-            0 => {} // Nothing returned,
-            pid if pid == cpid => {
-                if WIFEXITED(status) {
-                    let exit_code = WEXITSTATUS(status);
-                    outputln!("{} - process {} died with exit code {}",
-                              self.preamble,
-                              pid,
-                              exit_code);
-                } else if WIFSIGNALED(status) {
-                    let exit_signal = WTERMSIG(status);
-                    outputln!("{} - process {} died with signal {}",
-                              self.preamble,
-                              pid,
-                              exit_signal);
-                } else {
-                    outputln!("{} - process {} died, but I don't know how.",
-                              self.preamble,
-                              pid);
-                }
-                match self.state {
-                    ProcessState::Up | ProcessState::Start | ProcessState::Restart => {
-                        outputln!("{} - Service exited", self.preamble);
-                        self.pid = None;
-                    }
-                    ProcessState::Down => {
-                        self.enter_state(ProcessState::Down);
-                        self.pid = None;
-                    }
-                }
-            }
-            // ZOMBIES! Bad zombies! We listen for zombies. ZOMBOCOM!
-            pid => {
-                if WIFEXITED(status) {
-                    let exit_code = WEXITSTATUS(status);
-                    debug!("Process {} died with exit code {}", pid, exit_code);
-                } else if WIFSIGNALED(status) {
-                    let exit_signal = WTERMSIG(status);
-                    debug!("Process {} terminated with signal {}", pid, exit_signal);
-                } else {
-                    debug!("Process {} died, but I don't know how.", pid);
-                }
-            }
-        }
         Ok(())
     }
 
@@ -346,9 +281,10 @@ impl Supervisor {
     /// The existence of this file does not guarantee that a
     /// process exists at the PID contained within.
     pub fn create_pidfile(&self) -> Result<()> {
-        match self.pid {
-            Some(ref pid) => {
+        match self.child {
+            Some(ref child) => {
                 let pid_file = self.pid_file();
+                let ref pid = child.id();
                 debug!("Creating PID file for child {} -> {:?}",
                        pid_file.display(),
                        pid);
@@ -378,7 +314,7 @@ impl Supervisor {
     /// attempt to read the pidfile for this package.
     /// If the pidfile does not exist, then return None,
     /// otherwise, return Some(pid, uptime_seconds).
-    pub fn read_pidfile(&self) -> Result<Option<Pid>> {
+    pub fn read_pidfile(&self) -> Result<Option<u32>> {
         let pid_file = self.pid_file();
         debug!("Reading pidfile {}", &pid_file.display());
 
@@ -399,8 +335,13 @@ impl Supervisor {
 
 impl Encodable for Supervisor {
     fn encode<S: Encoder>(&self, s: &mut S) -> result::Result<(), S::Error> {
+        let pid = match self.child {
+            Some(ref child) => Some(child.id()),
+            None => None,
+        };
+
         try!(s.emit_struct("supervisor", 7, |s| {
-            try!(s.emit_struct_field("pid", 0, |s| self.pid.encode(s)));
+            try!(s.emit_struct_field("pid", 0, |s| pid.encode(s)));
             try!(s.emit_struct_field("package_ident", 1, |s| self.package_ident.encode(s)));
             try!(s.emit_struct_field("preamble", 2, |s| self.preamble.encode(s)));
             try!(s.emit_struct_field("state", 3, |s| self.state.encode(s)));


### PR DESCRIPTION
This adds support for windows processes under a supervisor's supervision. Previously when the supervisor checked the status of a running process executed from a supervisor's run hook, we hard coded a `waitpid` status of `0` which means there is no transition state for the process and it is running normally. This allowed us to at least run the supervisor and launch run hooks on windows but prevented us from taking any sort of intervention steps.

This PR adds a `HabChild` struct that has different `status` trait implementatins on linux and windows and both return a `HabExitStatus`. Linux runs the familiar `waitpid` and now windows will obtain a process `HANDLE` which it can probe for status. In the event that the process dies immediately and there is no handle to obtain, we call `wait()` and cache the exit code and return that the next tine the supervisor requests status.

This PR also refactors the process status "interpretation" logic formerly used by linux:

1. `supervisor.rs` previously had several internal functions to retrieve exit code or signal. That is now moved to the `HabExitStatus` struct and it mostly leverages `libc` for these functions. The logic in `HabExitStatus` is modeled after the `std::process::ExitStatus` logic which will return an exit code if the process terminated otherwise it assumes the termination was signaled and it returns the signal.
2. The previous logic in the supervisor had a "catch all" arm that assumed that it was possible that a termination could succesfully be reported that was neither from a signal or normal exit. Based on how we are calling `waitpid`(with the `WNOHANG` option only), that is not possible.
3. The former supervisor had logic that if `waitpid` returned a pid that was different from the pid being supervised, it would check their signal/exit code. Again, based on the way we are calling `waitpid` (with a specific pid) we will ONLY receive termination status for THAT pid. The intent of this logic appears to have been for reaping zombies and perhaps did just that at one time but I am removing it here since it does not fit well within the new structure and is effectively dead code. That said we may want to pursue a separate fix to address zombies propperly since the current supervisor has no awareness of any process other than the one launched from the run hook.
