### PR TITLE
Ensure 64bit integers are represented as strings in JSON

### DIFF
--- a/components/builder-api/doc/api.raml
+++ b/components/builder-api/doc/api.raml
@@ -28,7 +28,7 @@ schemas:
         {
             "properties": {
                 "id": {
-                    "type": "integer",
+                    "type": "string",
                     "required": true
                 },
                 "state": {
@@ -170,7 +170,7 @@ securitySchemes:
                                 "token": "0b79bab50daca910b000d4f1a2b675d604257e42",
                                 "email": "reset@chef.io",
                                 "name": "reset",
-                                "id": 73089155726360582,
+                                "id": "73089155726360582",
                                 "flags": 0
                             }
 /jobs:
@@ -190,7 +190,7 @@ securitySchemes:
                     application/json:
                         example: |
                             {
-                                "id": 73089155726360582,
+                                "id": "73089155726360582",
                                 "state": 0
                             }
             400:

--- a/components/builder-depot/doc/api.raml
+++ b/components/builder-depot/doc/api.raml
@@ -97,7 +97,7 @@ securitySchemes:
                         schema: origin
                         example: |
                             {
-                                "id": 77732030103691265,
+                                "id": "77732030103691265",
                                 "name": "reset",
                                 "owner_id": "77730215748435968"
                             }
@@ -110,7 +110,7 @@ securitySchemes:
                     schema: origin
                     example: |
                         {
-                            "id": 77732030103691265,
+                            "id": "77732030103691265",
                             "name": "reset",
                             "owner_id": "77730215748435968"
                         }

--- a/components/builder-protocol/src/sessionsrv.rs
+++ b/components/builder-protocol/src/sessionsrv.rs
@@ -178,7 +178,7 @@ impl ToJson for Session {
         m.insert("token".to_string(), self.get_token().to_json());
         m.insert("email".to_string(), self.get_email().to_json());
         m.insert("name".to_string(), self.get_name().to_json());
-        m.insert("id".to_string(), self.get_id().to_json());
+        m.insert("id".to_string(), self.get_id().to_string().to_json());
         m.insert("flags".to_string(), self.get_flags().to_json());
         Json::Object(m)
     }

--- a/components/builder-protocol/src/vault.rs
+++ b/components/builder-protocol/src/vault.rs
@@ -47,7 +47,7 @@ impl Routable for OriginCreate {
 impl ToJson for Origin {
     fn to_json(&self) -> Json {
         let mut m = BTreeMap::new();
-        m.insert("id".to_string(), self.get_id().to_json());
+        m.insert("id".to_string(), self.get_id().to_string().to_json());
         m.insert("name".to_string(), self.get_name().to_json());
         m.insert("owner_id".to_string(),
                  self.get_owner_id().to_string().to_json());
@@ -89,7 +89,8 @@ impl ToJson for OriginSecretKey {
     fn to_json(&self) -> Json {
         let mut m = BTreeMap::new();
         m.insert("id".to_string(), self.get_id().to_string().to_json());
-        m.insert("origin_id".to_string(), self.get_origin_id().to_json());
+        m.insert("origin_id".to_string(),
+                 self.get_origin_id().to_string().to_json());
         m.insert("name".to_string(), self.get_name().to_json());
         m.insert("revision".to_string(),
                  self.get_revision().to_string().to_json());
@@ -141,8 +142,6 @@ impl Persistable for OriginInvitation {
 impl ToJson for OriginInvitation {
     fn to_json(&self) -> Json {
         let mut m = BTreeMap::new();
-        // NOTE: all numbers are represented as strings, because they
-        // overflow JSON number representation in some tools
         m.insert("id".to_string(), self.get_id().to_string().to_json());
         m.insert("account_id".to_string(),
                  self.get_account_id().to_string().to_json());


### PR DESCRIPTION
JavaScript doesn't inherently support 64bit integers so the suggested way to represent these in JSON serialization is as a string. This PR cleans up the few places where we haven't done that.

![gif-keyboard-5084409693510304509](https://cloud.githubusercontent.com/assets/54036/21202706/4dbbb0e2-c204-11e6-9d6e-b1dca1c2ab89.gif)
