### PR TITLE
Roll graceful termination into habchild

### DIFF
--- a/components/core/src/error.rs
+++ b/components/core/src/error.rs
@@ -88,6 +88,8 @@ pub enum Error {
     UnameFailed(String),
     /// Occurs when a `waitpid` libc call returns an error.
     WaitpidFailed(String),
+    /// Occurs when a `kill` libc call returns an error.
+    SignalFailed(i32),
     /// Occurs when a `GetExitCodeProcess` win32 call returns an error.
     GetExitCodeProcessFailed(String),
     /// Occurs when a `HabChild` constructor fails to return a process.
@@ -165,6 +167,7 @@ impl fmt::Display for Error {
             Error::TargetMatchError(ref e) => format!("{}", e),
             Error::UnameFailed(ref e) => format!("{}", e),
             Error::WaitpidFailed(ref e) => format!("{}", e),
+            Error::SignalFailed(ref e) => format!("Failed to send a signal to the child process: {}", e),
             Error::GetExitCodeProcessFailed(ref e) => format!("{}", e),
             Error::GetHabChildFailed(ref e) => format!("{}", e),
             Error::Utf8Error(ref e) => format!("{}", e),
@@ -218,6 +221,7 @@ impl error::Error for Error {
             Error::StringFromUtf8Error(_) => "Failed to convert a string from a Vec<u8> as UTF-8",
             Error::TargetMatchError(_) => "System target does not match package target",
             Error::UnameFailed(_) => "uname failed",
+            Error::SignalFailed(_) => "Failed to send a signal to the child process",
             Error::WaitpidFailed(_) => "waitpid failed",
             Error::GetExitCodeProcessFailed(_) => "GetExitCodeProcess failed",
             Error::GetHabChildFailed(_) => "Failed to return a HabChild",

--- a/components/core/src/os/process/mod.rs
+++ b/components/core/src/os/process/mod.rs
@@ -26,7 +26,7 @@ mod imp;
 #[path = "linux.rs"]
 mod imp;
 
-pub use self::imp::{become_command, send_signal};
+pub use self::imp::{become_command};
 
 pub struct HabChild {
     inner: imp::Child,
@@ -46,6 +46,10 @@ impl HabChild {
 
     pub fn status(&mut self) -> Result<HabExitStatus> {
         self.inner.status()
+    }
+
+    pub fn kill(&mut self) -> Result<i32> {
+        self.inner.kill()
     }
 }
 

--- a/components/core/src/os/process/windows.rs
+++ b/components/core/src/os/process/windows.rs
@@ -31,10 +31,6 @@ pub fn become_command(command: PathBuf, args: Vec<OsString>) -> Result<()> {
     become_child_command(command, args)
 }
 
-pub fn send_signal(pid: u32, sig: u32) -> u32 {
-    unimplemented!();
-}
-
 /// Executes a command as a child process and exits with the child's exit code.
 ///
 /// Note that if sucessful, this function will not return.
@@ -136,6 +132,10 @@ impl Child {
         };
 
         Ok(HabExitStatus { status: Some(exit_status) })
+    }
+
+    pub fn kill(&mut self) -> Result<i32> {
+        unimplemented!();
     }
 }
 


### PR DESCRIPTION
This is in preparation of implementing graceful windows termination. Basically just moving current linux implementation from supervisoe to `HabChild`.

Signed-off-by: Matt Wrock <matt@mattwrock.com>