### PR TITLE
Update development build instructions and upgrade devshell software versions.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,6 +10,7 @@ plans
 results
 support
 !support/devshell_profile.sh
+!support/linux/install_dev_*.sh
 target
 terraform
 tmp

--- a/.dockerignore
+++ b/.dockerignore
@@ -10,6 +10,7 @@ plans
 results
 support
 !support/devshell_profile.sh
+target
 terraform
 tmp
 vendor

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -2,16 +2,26 @@
 
 ## Mac OS X
 
-1. [Install Docker](https://docs.docker.com/engine/installation/mac/#/docker-for-mac) (you'll need
-   at least Docker 1.9.)
-1. (Optional) Consider adding `eval "$(docker-machine env default)"` to your shell initialization
+These install instructions assume you want to develop, build, and run the
+various Habitat software components in a Linux environment. The Habitat core
+team suggests that you use our consistent development environment that we can
+the "devshell" as the easiest way to get started.
+
+1. [Install Docker for Mac](https://www.docker.com/products/docker)
 1. Checkout the source by running `git clone git@github.com:habitat-sh/habitat.git; cd habitat`
-1. Run `make`
+1. Run `make` to compile all Rust software components (this will take a while)
 1. (Optional) Run `make test` if you want to run the tests. This will take a while.
 
-Everything should come up green. Congratulations - you have a working Habitat development environment.
+Everything should come up green. Congratulations - you have a working Habitat
+development environment.
 
-**Note:** The Makefile targets are documented. Run `make help` to show the output. Habitat requires `perl`.
+You can enter a devshell by running `make shell`. This will drop you in a
+Docker container at a Bash shell. The source code is mounted in under `/src`,
+meaning you can use common Rust workflows such as `cd components/sup; cargo
+build`.
+
+**Note:** The Makefile targets are documented. Run `make help` to show the
+output. Habitat requires `perl`.
 
 **Optional:** This project compiles and runs inside Docker containers so while
 installing the Rust language isn't strictly necessary, you might want a local
@@ -21,14 +31,15 @@ Rust](https://www.rust-lang.org/install.html), run: `curl -sSf
 https://static.rust-lang.org/rustup.sh | sh`. Additionally, the project
 maintainers use [rustfmt](https://github.com/rust-lang-nursery/rustfmt) for
 code formatting. If you are submitting changes, please ensure that your work
-has been run through rustfmt. An easy way to install it (assuming you have Rust
-installed as above), is to run `cargo install rustfmt` and adding
-`$HOME/.cargo/bin` to your `PATH`.
+has been run through the latest version of rustfmt. An easy way to install it
+(assuming you have Rust installed as above), is to run `cargo install rustfmt`
+and adding `$HOME/.cargo/bin` to your `PATH`.
 
 
 ## Ubuntu: Xenial
 
-This installation method uses as many packages from Ubuntu as possible. If you'd like to build additional components from source, see the next section.
+This installation method uses as many packages from Ubuntu as possible. If
+you'd like to build additional components from source, see the next section.
 
 ```
 apt-get update && apt-get install -y --no-install-recommends \
@@ -71,7 +82,8 @@ cd habitat && make
 
 ## Ubuntu: 14.04+
 
-This can be used to build and install on older versions of Ubuntu where libsodium and czmq aren't available.
+This can be used to build and install on older versions of Ubuntu where
+libsodium and czmq aren't available.
 
 ```
 apt-get update && apt-get install -y --no-install-recommends \
@@ -164,17 +176,21 @@ cd habitat && make
 
 - If you have issues with libsodium at runtime, ensure that you've set `LD_LIBRARY_PATH`:
 
-	     export LD_LIBRARY_PATH=/usr/local/lib
+    export LD_LIBRARY_PATH=/usr/local/lib
 
 - These docs were tested with:
 
-		  docker run -it centos:centos7 /bin/bash
+    docker run -it centos:centos7 /bin/bash
 
 
 ## Windows
-These instructions are based on Windows 10 1607 (Anniversary update) or newer.  Most of it will probably work downlevel.
 
-All commands are in PowerShell unless otherwise stated.  It is assumed that you have `git` installed and configured.  Posh-Git is a handy PowerShell module for making `git` better in your PowerShell console (`install-module posh-git`).
+These instructions are based on Windows 10 1607 (Anniversary update) or newer.
+Most of it will probably work downlevel.
+
+All commands are in PowerShell unless otherwise stated.  It is assumed that you
+have `git` installed and configured.  Posh-Git is a handy PowerShell module for
+making `git` better in your PowerShell console (`install-module posh-git`).
 
 ```
 # Clone the Windows build script
@@ -194,19 +210,24 @@ cd ./hab-build-script
 invoke-psake
 ```
 
-
 ## General build notes
 
-- Once make has finished, executables will exist in `/src/target/debug/foo`, where `foo` is the name of an executable (`hab`, `hab-sup`, `hab-depot`, etc).
-
-- Executable names are specified in each components `Cargo.toml` file in a TOML table like this:
+- Once make has finished, executables will exist in `/src/target/debug/foo`,
+  where `foo` is the name of an executable (`hab`, `hab-sup`, `hab-depot`,
+  etc).
+- Executable names are specified in each components `Cargo.toml` file in a TOML
+  table like this:
 
 		[[bin]]
 		name = "hab-depot"
 
 
 ## Windows build notes
-The Windows build scripts referenced above and the default build task `invoke-psake` attempts to build the full habitat project as well as validates pre-reqs are installed. This is not always and ideal way to build or test. In some cases the following tasks may be more appropriate.
+
+The Windows build scripts referenced above and the default build task
+`invoke-psake` attempts to build the full habitat project as well as validates
+pre-reqs are installed. This is not always and ideal way to build or test. In
+some cases the following tasks may be more appropriate.
 
 ```
 # Build all the currently ported crates
@@ -224,7 +245,8 @@ invoke-psake -tasklist current_test
 
 #### Building the native dependencies
 
-You'll want to start in a fresh PowerShell instance, with the Visual C++ Build Tools paths and environment variables set.
+You'll want to start in a fresh PowerShell instance, with the Visual C++ Build
+Tools paths and environment variables set.
 
 I use a handy `Start-VsDevShell` function in my profile.
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -36,151 +36,107 @@ has been run through the latest version of rustfmt. An easy way to install it
 and adding `$HOME/.cargo/bin` to your `PATH`.
 
 
-## Ubuntu: Xenial
+## Ubuntu: Latest (16.10/Yakkety)
 
-This installation method uses as many packages from Ubuntu as possible. If
-you'd like to build additional components from source, see the next section.
+This installation method uses as many packages from Ubuntu as possible. This
+will closely reproduce the state of the Docker-based "devshell" as it also uses
+an Ubuntu base image.
+
+First clone the codebase and enter the directory:
 
 ```
-apt-get update && apt-get install -y --no-install-recommends \
-    build-essential \
-    ca-certificates \
-    curl \
-    file \
-    gdb \
-    git \
-    iproute2 \
-    libarchive-dev \
-    libprotobuf-dev \
-    libsodium-dev \
-    libssl-dev \
-    libczmq-dev \
-    man \
-    musl-tools \
-    npm \
-    pkg-config \
-    protobuf-compiler \
-    sudo \
-    wget
-
-curl -sSf https://sh.rustup.rs \
-    | sh -s -- -y --default-toolchain stable \
-  && rustup target add x86_64-unknown-linux-musl \
-  && rustc -V
-source $HOME/.cargo/env
-(adduser --system hab || true) && (addgroup --system hab || true)
-ln -snf /usr/bin/nodejs /usr/bin/node && npm install -g docco && echo "docco `docco -V`"
-
 git clone https://github.com/habitat-sh/habitat.git
-cd habitat && make
+cd habitat
 ```
 
-- these docs were tested with:
+Then, run the system preparation scripts and try to compile the project:
 
-		docker run -it ubuntu:xenial /bin/bash
+```
+cp components/hab/install.sh /tmp/
+sh support/linux/install_dev_0_ubuntu_latest.sh
+sh support/linux/install_dev_9_linux.sh
+. ~/.profile
+make
+```
+
+These docs were tested with a Docker image, created as follows:
+
+```
+docker run --rm -it ubuntu:yakkety bash
+apt-get update && apt-get install -y sudo git-core
+useradd -m -s /bin/bash -G sudo jdoe
+echo jdoe:1234 | chpasswd
+sudo su - jdoe
+```
 
 
-## Ubuntu: 14.04+
+## Ubuntu: 14.04+ (Trusty+)
 
 This can be used to build and install on older versions of Ubuntu where
 libsodium and czmq aren't available.
 
+First clone the codebase and enter the directory:
+
 ```
-apt-get update && apt-get install -y --no-install-recommends \
-    autotools-dev \
-    autoconf \
-    automake \
-    build-essential \
-    ca-certificates \
-    cmake \
-    curl \
-    file \
-    gdb \
-    git \
-    iproute2 \
-    libarchive-dev \
-    libprotobuf-dev \
-    libssl-dev \
-    libtool \
-    libunwind8-dev \
-    man \
-    musl-tools \
-    npm \
-    pkg-config \
-    protobuf-compiler \
-    sudo \
-    uuid-dev \
-    libpcre3-dev \
-    wget
-
-git clone https://github.com/jedisct1/libsodium.git
-(cd libsodium && ./autogen.sh && ./configure && make && make install)
-
-git clone git://github.com/zeromq/libzmq.git
-(cd libzmq && ./autogen.sh && ./configure --with-libsodium && make install && ldconfig)
-
-git clone https://github.com/zeromq/czmq.git
-(cd czmq && ./autogen.sh && ./configure && make install && ldconfig)
-
-curl -sSf https://sh.rustup.rs \
-    | sh -s -- -y --default-toolchain stable \
-  && rustup target add x86_64-unknown-linux-musl \
-  && rustc -V
-source $HOME/.cargo/env
-(adduser --system hab || true) && (addgroup --system hab || true)
-ln -snf /usr/bin/nodejs /usr/bin/node && npm install -g docco && echo "docco `docco -V`"
-
 git clone https://github.com/habitat-sh/habitat.git
-cd habitat && make
+cd habitat
 ```
 
-- these docs were tested with:
+Then, run the system preparation scripts and try to compile the project:
 
-		docker run -it ubuntu:14.04 /bin/bash
+```
+cp components/hab/install.sh /tmp/
+sh support/linux/install_dev_0_ubuntu_14.04.sh
+sh support/linux/install_dev_9_linux.sh
+. ~/.profile
+make
+```
+
+These docs were tested with a Docker image, created as follows:
+
+```
+docker run --rm -it ubuntu:trusty bash
+apt-get update && apt-get install -y sudo git-core
+useradd -m -s /bin/bash -G sudo jdoe
+echo jdoe:1234 | chpasswd
+sudo su - jdoe
+```
+
 
 ## Centos 7
 
+First clone the codebase and enter the directory:
+
 ```
-# Install the zeromq yum repo
-curl http://download.opensuse.org/repositories/home:/fengshuo:/zeromq/CentOS_CentOS-6/home:fengshuo:zeromq.repo > /etc/yum.repos.d/zeromq.repo
-
-# Install common development tools
-yum groupinstall -y 'Development Tools'
-# install sudo as the Rust installation needs it
-yum install -y sudo libarchive-devel protobuf-devel openssl-devel zeromq-devel libczmq1-devel gpm-libs which wget
-
-# pkg-config will be able to find libsodium with the following:
-export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
-# needed for the Habitat binaries to find libsodium at runtime
-export LD_LIBRARY_PATH=/usr/local/lib
-
-# Install libsodium from source
-git clone https://github.com/jedisct1/libsodium.git
-(cd libsodium && ./autogen.sh && ./configure && make && make install)
-
-# Install Rust
-curl -sSf https://sh.rustup.rs \
-    | sh -s -- -y --default-toolchain stable \
-  && rustup target add x86_64-unknown-linux-musl \
-  && rustc -V
-source $HOME/.cargo/env
-
-# Setup hab user and group
-useradd --system hab
-groupadd --system hab
-
-# Clone the Habitat source
 git clone https://github.com/habitat-sh/habitat.git
-cd habitat && make
+cd habitat
 ```
 
-- If you have issues with libsodium at runtime, ensure that you've set `LD_LIBRARY_PATH`:
+Then, run the system preparation scripts and try to compile the project:
+
+```
+cp components/hab/install.sh /tmp/
+sh support/linux/install_dev_0_centos_7.sh
+sh support/linux/install_dev_9_linux.sh
+. ~/.profile
+make
+```
+
+If you have issues with libsodium at runtime, ensure that you've set
+`LD_LIBRARY_PATH` and `PKG_CONFIG_PATH`:
 
     export LD_LIBRARY_PATH=/usr/local/lib
+    export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
 
-- These docs were tested with:
+These docs were tested with a Docker image, created as follows:
 
-    docker run -it centos:centos7 /bin/bash
+```
+docker run --rm -it centos:7 bash
+yum install -y sudo git
+useradd -m -s /bin/bash -G wheel jdoe
+echo jdoe:1234 | chpasswd
+sudo su - jdoe
+```
 
 
 ## Windows
@@ -209,6 +165,7 @@ cd ./hab-build-script
 # Build Habitat
 invoke-psake
 ```
+
 
 ## General build notes
 
@@ -242,6 +199,7 @@ invoke-psake -tasklist test_all
 # Run tests on the current crate in progress
 invoke-psake -tasklist current_test
 ```
+
 
 #### Building the native dependencies
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:xenial
+FROM ubuntu:yakkety
 MAINTAINER The Habitat Maintainers <humans@habitat.sh>
 
 ENV CARGO_HOME /cargo-cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,9 @@ COPY components/hab/install.sh \
   /tmp/
 COPY support/devshell_profile.sh /root/.bash_profile
 
-RUN sh /tmp/install_dev_0_ubuntu_latest.sh \
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends sudo \
+  && sh /tmp/install_dev_0_ubuntu_latest.sh \
   && sh /tmp/install_dev_9_linux.sh \
   && useradd -m -s /bin/bash -G sudo jdoe && echo jdoe:1234 | chpasswd \
   && rm -rf \

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ else
 	docs_host := 127.0.0.1
 endif
 
-BIN = director hab sup
+BIN = director hab hab-butterfly sup
 LIB = butterfly builder-dbcache builder-protocol common core builder-depot-client http-client net
 SRV = builder-api builder-admin builder-depot builder-router builder-jobsrv builder-sessionsrv builder-vault builder-worker
 ALL = $(BIN) $(LIB) $(SRV)

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ else
 endif
 
 BIN = director hab sup
-LIB = builder-dbcache builder-protocol common core builder-depot-client http-client net butterfly
+LIB = butterfly builder-dbcache builder-protocol common core builder-depot-client http-client net
 SRV = builder-api builder-admin builder-depot builder-router builder-jobsrv builder-sessionsrv builder-vault builder-worker
 ALL = $(BIN) $(LIB) $(SRV)
 VERSION := $(shell cat VERSION)

--- a/support/linux/install_dev_0_centos_7.sh
+++ b/support/linux/install_dev_0_centos_7.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+set -eux
+
+# Install the zeromq yum repo
+curl http://download.opensuse.org/repositories/home:/fengshuo:/zeromq/CentOS_CentOS-6/home:fengshuo:zeromq.repo | sudo -E tee /etc/yum.repos.d/zeromq.repo
+
+# Install the node.js yum repo
+curl -sL https://rpm.nodesource.com/setup_6.x | sudo -E bash
+
+# Install common development tools
+sudo -E yum groupinstall -y 'Development Tools'
+
+sudo -E yum install -y \
+  gpm-libs \
+  libarchive-devel \
+  nodejs \
+  openssl-devel \
+  protobuf-devel \
+  sudo \
+  wget \
+  which \
+  zeromq-devel
+
+# pkg-config will be able to find libsodium with the following:
+export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
+# needed for the Habitat binaries to find libsodium at runtime
+export LD_LIBRARY_PATH=/usr/local/lib
+
+# Install libsodium from source
+(cd /tmp && git clone https://github.com/jedisct1/libsodium.git)
+(cd /tmp/libsodium \
+  && ./autogen.sh \
+  && ./configure \
+  && make \
+  && sudo -E make install \
+)
+rm -rf /tmp/libsodium
+
+(cd /tmp && git clone git://github.com/zeromq/libzmq.git)
+(cd /tmp/libzmq \
+  && ./autogen.sh \
+  && ./configure --with-libsodium \
+  && make \
+  && sudo -E make install \
+  && sudo -E ldconfig \
+)
+rm -rf /tmp/libzmq
+
+(cd /tmp && git clone https://github.com/zeromq/czmq.git)
+(cd /tmp/czmq \
+  && ./autogen.sh \
+  && ./configure \
+  && make \
+  && sudo -E make install \
+  && sudo -E ldconfig \
+)
+rm -rf /tmp/czmq

--- a/support/linux/install_dev_0_ubuntu_14.04.sh
+++ b/support/linux/install_dev_0_ubuntu_14.04.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+set -eux
+
+sudo -E apt-get update
+
+sudo -E apt-get install -y --no-install-recommends \
+  autotools-dev \
+  autoconf \
+  automake \
+  build-essential \
+  ca-certificates \
+  cmake \
+  curl \
+  file \
+  gdb \
+  git \
+  iproute2 \
+  libarchive-dev \
+  libpcre3-dev \
+  libprotobuf-dev \
+  libssl-dev \
+  libtool \
+  libunwind8-dev \
+  man \
+  musl-tools \
+  npm \
+  pkg-config \
+  protobuf-compiler \
+  software-properties-common \
+  sudo \
+  uuid-dev \
+  vim \
+  wget
+
+(cd /tmp && git clone https://github.com/jedisct1/libsodium.git)
+(cd /tmp/libsodium \
+  && ./autogen.sh \
+  && ./configure \
+  && make \
+  && sudo -E make install \
+)
+rm -rf /tmp/libsodium
+
+(cd /tmp && git clone git://github.com/zeromq/libzmq.git)
+(cd /tmp/libzmq \
+  && ./autogen.sh \
+  && ./configure --with-libsodium \
+  && make \
+  && sudo -E make install \
+  && sudo -E ldconfig \
+)
+rm -rf /tmp/libzmq
+
+(cd /tmp && git clone https://github.com/zeromq/czmq.git)
+(cd /tmp/czmq \
+  && ./autogen.sh \
+  && ./configure \
+  && make \
+  && sudo -E make install \
+  && sudo -E ldconfig \
+)
+rm -rf /tmp/czmq

--- a/support/linux/install_dev_0_ubuntu_latest.sh
+++ b/support/linux/install_dev_0_ubuntu_latest.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 set -eux
 
-apt-get update
+sudo -E apt-get update
 
-apt-get install -y --no-install-recommends \
+sudo -E apt-get install -y --no-install-recommends \
   build-essential \
   ca-certificates \
   cmake \
@@ -22,9 +22,16 @@ apt-get install -y --no-install-recommends \
   npm \
   pkg-config \
   protobuf-compiler \
-  redis-server \
   software-properties-common \
   sudo \
   tmux \
   vim \
   wget
+
+# Let's get us a shiny new 7.12+ version of GDB to get the latest Rust support
+(gdb_pkg='http://launchpadlibrarian.net/289215234/gdb_7.12-0ubuntu1_amd64.deb' \
+  && cd /tmp \
+  && wget "$gdb_pkg" \
+  && sudo dpkg -i $(basename $gdb_pkg) \
+  && rm -f $(basename $gdb_pkg) \
+)

--- a/support/linux/install_dev_0_ubuntu_latest.sh
+++ b/support/linux/install_dev_0_ubuntu_latest.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+set -eux
+
+apt-get update
+
+apt-get install -y --no-install-recommends \
+  build-essential \
+  ca-certificates \
+  cmake \
+  curl \
+  file \
+  gdb \
+  iproute2 \
+  libarchive-dev \
+  libprotobuf-dev \
+  libsodium-dev \
+  libssl-dev \
+  libczmq-dev \
+  man \
+  musl-tools \
+  net-tools \
+  npm \
+  pkg-config \
+  protobuf-compiler \
+  redis-server \
+  software-properties-common \
+  sudo \
+  tmux \
+  vim \
+  wget

--- a/support/linux/install_dev_9_linux.sh
+++ b/support/linux/install_dev_9_linux.sh
@@ -3,29 +3,34 @@ set -eux
 
 # Install Rust and musl libc target
 curl -sSf https://sh.rustup.rs \
-  | env -u CARGO_HOME sh -s -- -y --no-modify-path --default-toolchain stable
+  | env -u CARGO_HOME sh -s -- -y --default-toolchain stable
+. $HOME/.cargo/env
 env -u CARGO_HOME rustup target add x86_64-unknown-linux-musl
 env -u CARGO_HOME cargo install protobuf
 rustc --version
 cargo --version
 
 # Install Docker
-curl -sSL https://get.docker.io | sh
+if [ -f /etc/lsb-release ] \
+    && [ "$(. /etc/lsb-release; echo $DISTRIB_DESCRIPTION)" = "Ubuntu 16.10" ]; then
+  # Until there is a 1.13 release, there is no stable Docker package for Yakkety :/
+  curl -sSL https://test.docker.com | sudo -E sh
+else
+  curl -sSL https://get.docker.io | sudo -E sh
+fi
 docker --version
 
 if [ ! -f /usr/bin/node ] && [ -f /usr/bin/nodejs ]; then
-  ln -snf /usr/bin/nodejs /usr/bin/node
+  sudo -E ln -snf /usr/bin/nodejs /usr/bin/node
 fi
-npm install -g docco
+sudo -E npm install -g docco
 echo "Node $(node --version)"
 echo "npm $(npm --version)"
 echo "docco $(docco --version)"
 
-adduser --system hab || true
-addgroup --system hab || true
+sudo -E adduser --system hab || true
+sudo -E addgroup --system hab || true
 
-sh /tmp/install.sh
-hab install core/busybox-static
-hab install core/hab-studio
-hab --version
-rm -rf /tmp/install.sh
+sudo -E sh /tmp/install.sh
+sudo -E hab install core/busybox-static core/hab-studio
+sudo -E rm -rf /tmp/install.sh

--- a/support/linux/install_dev_9_linux.sh
+++ b/support/linux/install_dev_9_linux.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+set -eux
+
+# Install Rust and musl libc target
+curl -sSf https://sh.rustup.rs \
+  | env -u CARGO_HOME sh -s -- -y --no-modify-path --default-toolchain stable
+env -u CARGO_HOME rustup target add x86_64-unknown-linux-musl
+env -u CARGO_HOME cargo install protobuf
+rustc --version
+cargo --version
+
+# Install Docker
+curl -sSL https://get.docker.io | sh
+docker --version
+
+if [ ! -f /usr/bin/node ] && [ -f /usr/bin/nodejs ]; then
+  ln -snf /usr/bin/nodejs /usr/bin/node
+fi
+npm install -g docco
+echo "Node $(node --version)"
+echo "npm $(npm --version)"
+echo "docco $(docco --version)"
+
+adduser --system hab || true
+addgroup --system hab || true
+
+sh /tmp/install.sh
+hab install core/busybox-static
+hab install core/hab-studio
+hab --version
+rm -rf /tmp/install.sh


### PR DESCRIPTION
This changeset updates the `BUILDING.md` entries for the Mac and Linux platforms to current working instructions. Among the changes are:

* Update the Mac instructions to current standards, using Docker for Mac
* Update devshell to latest Ubuntu release (16.10/Yakkety)
* Add gdb 7.12 to devshell for superior `rust-gdb` support
* Add `hab-butterfly` component into Makefile
* Split shell code out of Dockerfile and into reusable scripts that can be used by developers on Ubuntu workstations and VMs directly.
* Turn code blocks in `BUILDING.md` into reusable scripts for older Ubuntu and CentOS users

For more details, see the individual commit messages.