### PR TITLE
[hab-butterfly] Update zmq socket linger to `-1`.

### DIFF
--- a/components/butterfly/src/client.rs
+++ b/components/butterfly/src/client.rs
@@ -40,7 +40,7 @@ impl Client {
             .as_mut()
             .socket(zmq::PUSH)
             .expect("Failure to create the ZMQ push socket");
-        socket.set_linger(1000)
+        socket.set_linger(-1)
             .expect("Failure to set the ZMQ push socket to not linger");
         socket.set_tcp_keepalive(0)
             .expect("Failure to set the ZMQ push socket to not use keepalive");


### PR DESCRIPTION
This change sets the linger period for the socket to wait forever
(infinite).

With thanks to @adamhjk for the debugging session!
