### PR TITLE
[docs] Add building/setup instructions for native Mac.

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,6 +1,6 @@
 # Building Habitat from source
 
-## Mac OS X
+## Mac OS X for Linux Development
 
 These install instructions assume you want to develop, build, and run the
 various Habitat software components in a Linux environment. The Habitat core
@@ -34,6 +34,46 @@ code formatting. If you are submitting changes, please ensure that your work
 has been run through the latest version of rustfmt. An easy way to install it
 (assuming you have Rust installed as above), is to run `cargo install rustfmt`
 and adding `$HOME/.cargo/bin` to your `PATH`.
+
+
+## Mac OS X for Native Development
+
+These instructions assume you want to develop, build, and run the various
+Habitat software components in a macOS environment. While components other than
+the `hab` CLI itself aren't officially supported on Mac, it is possible and
+sometimes useful to run parts of the Habitat ecosystem without virtualization.
+
+First clone the codebase and enter the directory:
+
+```
+git clone https://github.com/habitat-sh/habitat.git
+cd habitat
+```
+
+Then, run the system preparation scripts and try to compile the project:
+
+```
+cp components/hab/install.sh /tmp/
+sh support/mac/install_dev_0_mac_latest.sh
+sh support/mac/install_dev_9_mac.sh
+. ~/.profile
+export PKG_CONFIG_PATH="/usr/local/opt/libarchive/lib/pkgconfig:/usr/local/opt/openssl/lib/pkgconfig:$PKG_CONFIG_PATH"
+export IN_DOCKER=false
+make
+```
+
+For the builds to find the libarchive and openssl libraries, you will need to
+set the `PKG_CONFIG_PATH` environment variable as above before running `cargo
+build`, `cargo test`, etc. Additionally to use the Makefile on Mac and not have
+the tasks execute in the Docker-based devshell (see above), you will need to
+set `IN_DOCKER=false` in your environment. If you use an environment switcher
+such as [direnv](https://direnv.net/), you can set up the following in the root
+of the git repository:
+
+```
+echo 'export PKG_CONFIG_PATH="/usr/local/opt/libarchive/lib/pkgconfig:/usr/local/opt/openssl/lib/pkgconfig:$PKG_CONFIG_PATH"' > .direnv
+direnv allow
+```
 
 
 ## Ubuntu: Latest (16.10/Yakkety)

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,11 @@
 UNAME_S := $(shell uname -s)
-ifeq ($(UNAME_S),Darwin)
+ifneq (${IN_DOCKER},)
+	IN_DOCKER := ${IN_DOCKER}
+else ifeq ($(UNAME_S),Darwin)
 	IN_DOCKER := true
 endif
 
-ifneq ($(IN_DOCKER),)
+ifeq ($(IN_DOCKER),true)
 	build_args := --build-arg HAB_DEPOT_URL=$(HAB_DEPOT_URL)
 	run_args := -e HAB_DEPOT_URL=$(HAB_DEPOT_URL)
 	run_args := $(run_args) -e HAB_ORIGIN=$(HAB_ORIGIN)
@@ -111,7 +113,7 @@ serve-docs: docs ## serves the project documentation from an HTTP server
 	$(docs_run) sh -c 'set -e; cd ./target/doc; python -m SimpleHTTPServer 9633;'
 .PHONY: serve-docs
 
-ifneq ($(IN_DOCKER),)
+ifeq ($(IN_DOCKER),true)
 distclean: ## fully cleans up project tree and any associated Docker images and containers
 	$(compose_cmd) stop
 	$(compose_cmd) rm -f -v

--- a/support/mac/install_dev_0_mac_latest.sh
+++ b/support/mac/install_dev_0_mac_latest.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -eux
+
+if ! command -v brew >/dev/null; then
+  echo "Homebrew missing, attempting to install"
+  /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)" < /dev/null
+fi
+
+brew update
+
+brew install \
+  libarchive \
+  libsodium \
+  node \
+  openssl \
+  zeromq

--- a/support/mac/install_dev_9_mac.sh
+++ b/support/mac/install_dev_9_mac.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -eux
+
+# Install Rust
+curl -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
+. $HOME/.cargo/env
+# cargo install protobuf
+rustc --version
+cargo --version
+
+npm install -g docco
+echo "Node $(node --version)"
+echo "npm $(npm --version)"
+echo "docco $(docco --version)"
+
+sh /tmp/install.sh
+rm -rf /tmp/install.sh


### PR DESCRIPTION
This change adds 2 installation scripts similar to the Linux setup
instructions but this time for macOS. The instructions should allow a
user to compile all the Rust software components directly on a Mac
without any virtualization. Note that these instructions are close but
not identical to the build strategy for a production `hab` binary (the
official releases are largely statically compiled).

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>

![gif-keyboard-12726206460469384115](https://cloud.githubusercontent.com/assets/261548/21404575/1537ec42-c77f-11e6-8b3a-8808de899cc1.gif)
