### PR TITLE
sleep 100 milliseconds to allow zmq to enqueue message before freeing the zmq socket

### DIFF
--- a/components/hab-butterfly/src/command/config.rs
+++ b/components/hab-butterfly/src/command/config.rs
@@ -17,6 +17,8 @@ pub mod apply {
     use std::path::Path;
     use std::io::{self, Read};
     use std::fs::File;
+    use std::thread;
+    use std::time;
 
     use butterfly::client::Client;
     use common::ui::{Status, UI};
@@ -89,6 +91,7 @@ pub mod apply {
                 .map_err(|e| Error::ButterflyError(format!("{}", e))));
             try!(client.send_service_config(sg.clone(), number, body.clone(), encrypted)
                 .map_err(|e| Error::ButterflyError(format!("{}", e))));
+            thread::sleep(time::Duration::from_millis(100));
         }
         try!(ui.end("Applied configuration"));
         Ok(())

--- a/components/hab-butterfly/src/command/file.rs
+++ b/components/hab-butterfly/src/command/file.rs
@@ -17,6 +17,8 @@ pub mod upload {
     use std::path::Path;
     use std::io::{self, Read};
     use std::fs::File;
+    use std::thread;
+    use std::time;
 
     use butterfly::client::Client;
     use common::ui::{Status, UI};
@@ -68,6 +70,7 @@ pub mod upload {
                                    body.clone(),
                                    encrypted)
                 .map_err(|e| Error::ButterflyError(format!("{}", e))));
+            thread::sleep(time::Duration::from_millis(100));
         }
         try!(ui.end("Uploaded file"));
 


### PR DESCRIPTION
Even with an infinite linger, messages sent over zmq may be lost if the underlying zmq socket is immediately freed after send. While an infinite linger guarantees that `zmq_close` (called in the socket's `drop` implementation) will block, sending all queued messages, this assumes the messages are queued in the first place. My guess is that the socket is closed before zmq even queues them.

This pr adds a 100 millisecond wait which is very conservative. Others have not seen this loss occur at all and I find that just a single millisecond consistently prevents the loss. Since we only incur the sleep on a manual cli call, I think 100 ms is appropriate.

I looked through the zmq api and did some experimentation but did not find anything in the api that more elegantly handles this.