### PR TITLE
[devshell] Re-add `redis-server` pkg for `make bldr-run-shell` target.

### DIFF
--- a/support/linux/install_dev_0_ubuntu_latest.sh
+++ b/support/linux/install_dev_0_ubuntu_latest.sh
@@ -22,6 +22,7 @@ sudo -E apt-get install -y --no-install-recommends \
   npm \
   pkg-config \
   protobuf-compiler \
+  redis-server \
   software-properties-common \
   sudo \
   tmux \


### PR DESCRIPTION
I made an incorrect assumption that the `redis-server` Ubuntu package
was not being used for anything, when it was for running the Builder
service stack via the `make bldr-run-shell` script. This change readds
that package to the default "devshell".

![gif-keyboard-6325974613419619595](https://cloud.githubusercontent.com/assets/261548/21432639/ab7fdbce-c829-11e6-9fe8-5178b1588297.gif)