### PR TITLE
Ensure the requestor is a member of the origin, not the person invited.

### DIFF
--- a/components/builder-vault/src/server/handlers.rs
+++ b/components/builder-vault/src/server/handlers.rs
@@ -154,7 +154,7 @@ pub fn origin_invitation_create(req: &mut Envelope,
     let mut invitation = proto::OriginInvitation::new();
     if !try!(state.datastore
         .origins
-        .is_origin_member(msg.get_account_id(), msg.get_origin_name())) {
+        .is_origin_member(msg.get_owner_id(), msg.get_origin_name())) {
         debug!("Can't invite to this org unless your already a member");
         let err = net::err(ErrCode::ACCESS_DENIED, "vt:origin-create:0");
         try!(req.reply_complete(sock, &err));


### PR DESCRIPTION
Rather than check if the person we're inviting is a member of the origin, which doesn't make any sense, let's instead check if the person sending the invite is a member of the origin.  This resolves the `Unauthorized` message that appears when you invite someone to an origin.

![](http://i.giphy.com/l41m5YJ56zcextOSY.gif)

Signed-off-by: Josh Black <raskchanky@gmail.com>