### PR TITLE
Warn users if Docker's file sharing isn't enabled.

### DIFF
--- a/components/hab/src/command/studio.rs
+++ b/components/hab/src/command/studio.rs
@@ -211,7 +211,8 @@ mod inner {
         // requiring a TTY.
 
         let current_dir = format!("{}:/src", env::current_dir().unwrap().to_string_lossy());
-        let key_cache_path = format!("{}:/{}", default_cache_key_path(None).to_string_lossy(), CACHE_KEY_PATH);
+        let key_cache_path =
+            format!("{}:/{}", default_cache_key_path(None).to_string_lossy(), CACHE_KEY_PATH);
         let version_output = Command::new(&cmd)
             .arg("run")
             .arg("--rm")
@@ -226,7 +227,9 @@ mod inner {
             .expect("docker failed to start");
 
         let stderr = String::from_utf8(version_output.stderr).unwrap();
-        if !stderr.is_empty() && stderr.as_str().contains("Mounts denied") {
+        if !stderr.is_empty() &&
+           (stderr.as_str().contains("Mounts denied") ||
+            stderr.as_str().contains("drive is not shared")) {
             return Err(Error::DockerFileSharingNotEnabled);
         }
 

--- a/components/hab/src/command/studio.rs
+++ b/components/hab/src/command/studio.rs
@@ -204,6 +204,34 @@ mod inner {
             debug!("Local image id: {}", stdout);
         }
 
+        // We need to ensure that filesystem sharing has been enabled, otherwise the user will
+        // be greeted with a horrible error message that's difficult to make sense of. To
+        // mitigate this, we check the studio version. This will cause Docker to go through the
+        // mounting steps, so we can watch stderr for failure, but has the advantage of not
+        // requiring a TTY.
+
+        let current_dir = format!("{}:/src", env::current_dir().unwrap().to_string_lossy());
+        let key_cache_path = format!("{}:/{}", default_cache_key_path(None).to_string_lossy(), CACHE_KEY_PATH);
+        let version_output = Command::new(&cmd)
+            .arg("run")
+            .arg("--rm")
+            .arg("--privileged")
+            .arg("--volume")
+            .arg(&key_cache_path)
+            .arg("--volume")
+            .arg(&current_dir)
+            .arg(image_identifier())
+            .arg("-V")
+            .output()
+            .expect("docker failed to start");
+
+        let stderr = String::from_utf8(version_output.stderr).unwrap();
+        if !stderr.is_empty() && stderr.as_str().contains("Mounts denied") {
+            return Err(Error::DockerFileSharingNotEnabled);
+        }
+
+        // If we make it here, filesystem sharing has been setup correctly, so let's proceed like normal.
+
         let mut cmd_args: Vec<OsString> = vec!["run".into(),
                                                "--rm".into(),
                                                "--tty".into(),
@@ -236,12 +264,9 @@ mod inner {
         cmd_args.push("--volume".into());
         cmd_args.push("/var/run/docker.sock:/var/run/docker.sock".into());
         cmd_args.push("--volume".into());
-        cmd_args.push(format!("{}:/{}",
-                              default_cache_key_path(None).to_string_lossy(),
-                              CACHE_KEY_PATH)
-            .into());
+        cmd_args.push(key_cache_path.into());
         cmd_args.push("--volume".into());
-        cmd_args.push(format!("{}:/src", env::current_dir().unwrap().to_string_lossy()).into());
+        cmd_args.push(current_dir.into());
 
         cmd_args.push(image_identifier().into());
         cmd_args.extend_from_slice(args.as_slice());

--- a/components/hab/src/error.rs
+++ b/components/hab/src/error.rs
@@ -70,10 +70,16 @@ impl fmt::Display for Error {
             Error::DockerDaemonDown => {
                 format!("Can not connect to Docker. Is the Docker daemon running?")
             }
+            #[cfg(not(windows))]
             Error::DockerFileSharingNotEnabled => {
                 format!("File Sharing must be enabled in order to enter a studio.\nPlease enable \
                          it in the Docker preferences and share (at a minimum) your home \
                          directory.")
+            }
+            #[cfg(windows)]
+            Error::DockerFileSharingNotEnabled => {
+                format!("File Sharing must be enabled in order to enter a studio.\nPlease select \
+                         a drive to share in the Docker preferences.")
             }
             Error::DockerImageNotFound(ref e) => {
                 format!("The Docker image {} was not found in the docker registry.\nYou can \

--- a/components/hab/src/error.rs
+++ b/components/hab/src/error.rs
@@ -35,8 +35,9 @@ pub enum Error {
     CryptoCLI(String),
     DepotClient(depot_client::Error),
     DockerDaemonDown,
-    DockerNetworkDown(String),
+    DockerFileSharingNotEnabled,
     DockerImageNotFound(String),
+    DockerNetworkDown(String),
     ExecCommandNotFound(String),
     FFINulError(ffi::NulError),
     FileNotFound(String),
@@ -69,17 +70,22 @@ impl fmt::Display for Error {
             Error::DockerDaemonDown => {
                 format!("Can not connect to Docker. Is the Docker daemon running?")
             }
-            Error::DockerNetworkDown(ref e) => {
-                format!("The Docker image {} is unreachable due to a network error.\nThe \
-                         image must be reachable to ensure the versions of hab inside and \
-                         outside the studio match.\nYou can specify your own Docker image using \
-                         the HAB_DOCKER_STUDIO_IMAGE environment variable.",
-                        e)
+            Error::DockerFileSharingNotEnabled => {
+                format!("File Sharing must be enabled in order to enter a studio.\nPlease enable \
+                         it in the Docker preferences and share (at a minimum) your home \
+                         directory.")
             }
             Error::DockerImageNotFound(ref e) => {
                 format!("The Docker image {} was not found in the docker registry.\nYou can \
                          specify your own Docker image using the HAB_DOCKER_STUDIO_IMAGE \
                          environment variable.",
+                        e)
+            }
+            Error::DockerNetworkDown(ref e) => {
+                format!("The Docker image {} is unreachable due to a network error.\nThe \
+                         image must be reachable to ensure the versions of hab inside and \
+                         outside the studio match.\nYou can specify your own Docker image using \
+                         the HAB_DOCKER_STUDIO_IMAGE environment variable.",
                         e)
             }
             Error::ExecCommandNotFound(ref c) => {
@@ -122,8 +128,9 @@ impl error::Error for Error {
             Error::CryptoCLI(_) => "A cryptographic error has occurred",
             Error::DepotClient(ref err) => err.description(),
             Error::DockerDaemonDown => "The Docker daemon could not be found.",
-            Error::DockerNetworkDown(_) => "The Docker registry is unreachable.",
+            Error::DockerFileSharingNotEnabled => "Docker file sharing is not enabled.",
             Error::DockerImageNotFound(_) => "The Docker image was not found.",
+            Error::DockerNetworkDown(_) => "The Docker registry is unreachable.",
             Error::ExecCommandNotFound(_) => "Exec command was not found on filesystem or in PATH",
             Error::FFINulError(ref err) => err.description(),
             Error::FileNotFound(_) => "File not found",


### PR DESCRIPTION
If people don't have file sharing enabled in Docker for Mac, then `hab studio enter` will fail when it's run with an error message that looks like this:

![screen shot 2016-12-30 at 3 12 53 pm](https://cloud.githubusercontent.com/assets/947/21574126/9312e7aa-cea2-11e6-8607-c022a33d3273.png)

This isn't the best user experience.  I couldn't find a way of detecting whether file sharing was enabled, either via the command line tools or the Docker Remote API.  Instead, we simulate a call to `hab studio -V` to check the version of the studio.  This has the effect of mounting the same directories that would be mounted when running a studio and if it fails with a particular kind of error message, we notice and tell the user about it.  Now the error message looks like this:

![screen shot 2016-12-30 at 3 13 25 pm](https://cloud.githubusercontent.com/assets/947/21574158/01f3d29c-cea3-11e6-8276-a1ad92c48e77.png)

I have no idea how this will work on Windows, as I don't have a Windows machine or VM to check on.  Perhaps @smurawski or @mwrock can weigh in with their thoughts.

![](http://i.giphy.com/en3um8SVlYtjy.gif)

Signed-off-by: Josh Black <raskchanky@gmail.com>