### PR TITLE
pkg_upstream_url is required in core plans

### DIFF
--- a/components/hab/static/template_plan.sh
+++ b/components/hab/static/template_plan.sh
@@ -41,6 +41,10 @@ pkg_shasum=TODO
 # of your package.
 # pkg_description="Some description."
 
+# Required for core plans, optional otherwise.
+# The project home page for the package.
+# pkg_upstream_url=http://example.com/project-name
+
 # Optional.
 # An array of valid software licenses that relate to this package.
 # Please choose a license from http://spdx.org/licenses/


### PR DESCRIPTION
When using `hab plan init` to create a new core plan, we will fail the build in travis because we're enforcing that all packages have a project home page - `pkg_upstream_url`:

https://github.com/habitat-sh/core-plans/blob/master/bin/check-default-variables.sh

Signed-off-by: Joshua Timberman <joshua@chef.io>