### PR TITLE
Add infra for operational metrics

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,7 @@ matrix:
       language: rust
       env:
         - COMPONENTS=lib LIBSODIUM_PREFIX=$HOME/pkgs/libsodium/1.0.8 LIBARCHIVE_PREFIX=$HOME/pkgs/libarchive/3.2.0 LIBZMQ_PREFIX=$HOME/pkgs/zeromq/4.1.4 PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$LIBARCHIVE_PREFIX/lib/pkgconfig:$LIBSODIUM_PREFIX/lib/pkgconfig:$LIBZMQ_PREFIX/lib/pkgconfig" LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$LIBARCHIVE_PREFIX/lib:$LIBSODIUM_PREFIX/lib:$LIBZMQ_PREFIX/lib" LIBRARY_PATH="$LIBRARY_PATH:$LIBZMQ_PREFIX/lib"
-        - AFFECTED_DIRS="components/builder-dbcache|components/builder-protocol|components/common|components/core|components/builder-depot-client|components/http-client|components/net|components/butterfly"
+        - AFFECTED_DIRS="components/builder-dbcache|components/builder-core|components/builder-protocol|components/common|components/core|components/builder-depot-client|components/http-client|components/net|components/butterfly"
       rust: stable
       sudo: false
       addons:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,6 +48,15 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "builder_core"
+version = "0.0.0"
+dependencies = [
+ "habitat_core 0.0.0",
+ "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "statsd 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "clap"
 version = "2.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -60,6 +69,14 @@ dependencies = [
  "unicode-segmentation 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "vec_map 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "clock_ticks"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -481,6 +498,7 @@ name = "habitat_depot"
 version = "0.0.0"
 dependencies = [
  "bodyparser 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "builder_core 0.0.0",
  "clap 2.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat_builder_dbcache 0.0.0",
@@ -738,6 +756,11 @@ dependencies = [
  "libc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "libc"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
@@ -1238,6 +1261,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "statsd"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "clock_ticks 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "strsim"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1573,6 +1605,7 @@ dependencies = [
 "checksum bodyparser 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "07b171b407e583dc8f01011a713f20575a81ac60acecf3b8153012709aeb1fd6"
 "checksum broadcast 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fb214f702da3cc6aa1666520f40ea66f506644db5e1065be4bbc972f7ec3750b"
 "checksum clap 2.19.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef87e92396a3d29bf7e611c8a595be35ae90d9cb844a3571425900eaca4f51c8"
+"checksum clock_ticks 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "da9bd98fefcf1904a3f80ead86d366d9373c34db7b8a8e48c1fdcaac4787800d"
 "checksum cmake 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "0e5bcf27e097a184c1df4437654ed98df3d7a516e8508a6ba45d8b092bbdf283"
 "checksum conduit-mime-types 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "95ca30253581af809925ef68c2641cc140d6183f43e12e0af4992d53768bd7b8"
 "checksum cookie 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0e3d6405328b6edb412158b3b7710e2634e23f3614b9bb1c412df7952489a626"
@@ -1598,6 +1631,7 @@ dependencies = [
 "checksum lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "49247ec2a285bb3dcb23cbd9c35193c025e7251bfce77c1d5da97e6362dffe7f"
 "checksum libarchive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3da06b22cd19af338a40f5d44a0aa6352ae43839d0855a049881cbc7e1b9c914"
 "checksum libarchive3-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3cd3beae8f59a4c7a806523269b5392037577c150446e88d684dfa6de6031ca7"
+"checksum libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "e32a70cf75e5846d53a673923498228bbec6a8624708a9ea5645f075d6276122"
 "checksum libc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)" = "044d1360593a78f5c8e5e710beccdc24ab71d1f01bc19a29bcacdba22e8475d8"
 "checksum libgit2-sys 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8dd65176b163aa0667afe8e0bac790d353ff64160f8289a4b7197878a3f336a1"
 "checksum libressl-pnacl-sys 2.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "cbc058951ab6a3ef35ca16462d7642c4867e6403520811f28537a4e2f2db3e71"
@@ -1658,6 +1692,7 @@ dependencies = [
 "checksum sodiumoxide 0.0.12 (registry+https://github.com/rust-lang/crates.io-index)" = "8d9da099120def269669aa349e0c3e97de4ab2c5cb9a54a765041651dd0055eb"
 "checksum solicit 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "172382bac9424588d7840732b250faeeef88942e37b6e35317dce98cafdd75b2"
 "checksum staticfile 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7638ee7543e08b10d13f9e6c4488534d47c2269b258bf76a6fb998bfd7f54937"
+"checksum statsd 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e0df260da0c3cbf1c1e5820ea368d0706c8136e506277166f6eb3cc792fbf819"
 "checksum strsim 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "50c069df92e4b01425a8bf3576d5d417943a6a7272fbabaf5bd80b1aaa76442e"
 "checksum syn 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "76c2db66dc579998854d84ff0ff4a81cb73e69596764d144ce7cece4d04ce6b5"
 "checksum syntex 0.48.0 (registry+https://github.com/rust-lang/crates.io-index)" = "17e2e2ad78f4942d011750c304e9a9874717b6986c8fa2f6072f58fbd0835dcb"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
   "components/builder-admin",
   "components/builder-api",
+  "components/builder-core",
   "components/builder-dbcache",
   "components/builder-depot",
   "components/builder-depot-client",

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ else
 endif
 
 BIN = director hab hab-butterfly sup
-LIB = butterfly builder-dbcache builder-protocol common core builder-depot-client http-client net
+LIB = butterfly builder-dbcache builder-core builder-protocol common core builder-depot-client http-client net
 SRV = builder-api builder-admin builder-depot builder-router builder-jobsrv builder-sessionsrv builder-vault builder-worker
 ALL = $(BIN) $(LIB) $(SRV)
 VERSION := $(shell cat VERSION)

--- a/components/builder-core/Cargo.toml
+++ b/components/builder-core/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "builder_core"
+version = "0.0.0"
+authors = ["Adam Jacob <adam@chef.io>", "Jamie Winsor <reset@chef.io>", "Fletcher Nichol <fnichol@chef.io>", "Joshua Timberman <joshua@chef.io>", "Dave Parfitt <dparfitt@chef.io>", "Steven Murawski <smurawski@chef.io>"]
+workspace = "../../"
+build = "../bldr-build.rs"
+
+[dependencies]
+log = "*"
+statsd = "*"
+
+[dependencies.habitat_core]
+path = "../core"
+
+[features]
+functional = []

--- a/components/builder-core/README.md
+++ b/components/builder-core/README.md
@@ -1,0 +1,3 @@
+# builder-core
+
+Core infrastructure for builder services

--- a/components/builder-core/src/lib.rs
+++ b/components/builder-core/src/lib.rs
@@ -1,0 +1,23 @@
+// Copyright (c) 2016 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+#[macro_use]
+extern crate log;
+extern crate statsd;
+
+#[macro_use]
+extern crate habitat_core as hab_core;
+
+pub mod metrics;

--- a/components/builder-core/src/metrics.rs
+++ b/components/builder-core/src/metrics.rs
@@ -1,0 +1,232 @@
+// Copyright (c) 2016 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::{Once, ONCE_INIT};
+use std::sync::mpsc::{channel, sync_channel, Sender, Receiver, SyncSender};
+use std::thread;
+use statsd::Client;
+use hab_core::env;
+
+// Statsd Application name
+pub const APP_NAME: &'static str = "bldr";
+
+// Statsd Listener Address
+pub const STATS_ENV: &'static str = "HAB_STATS_ADDR";
+
+// Supported metrics
+#[derive(Debug, Clone)]
+pub enum Counter {
+    SearchPackages,
+}
+
+// Supported metrics
+#[derive(Debug, Clone)]
+pub enum Gauge {
+    PackageCount,
+}
+
+// Helper types
+#[derive(Debug, Clone, Copy)]
+enum MetricType {
+    Counter,
+    Gauge,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum MetricOperation {
+    Increment,
+    Decrement,
+    SetValue,
+}
+
+type MetricId = &'static str;
+type MetricValue = f64;
+type MetricTuple = (MetricType, MetricOperation, MetricId, Option<MetricValue>);
+
+trait Metric {
+    fn id(&self) -> &'static str;
+}
+
+// One-time initialization
+static mut SENDER: *const Sender<MetricTuple> = 0 as *const Sender<MetricTuple>;
+
+static INIT: Once = ONCE_INIT;
+
+fn sender() -> Sender<MetricTuple> {
+    unsafe {
+        INIT.call_once(|| {
+            SENDER = Box::into_raw(Box::new(init()));
+        });
+        (*SENDER).clone()
+    }
+}
+
+// init creates a worker thread ready to receive and process metric events,
+// and returns a channel for use by metric senders
+fn init() -> Sender<MetricTuple> {
+    let (tx, rx) = channel::<MetricTuple>();
+    let (rztx, rzrx) = sync_channel(0); // rendezvous channel
+
+    thread::Builder::new()
+        .name("metrics".to_string())
+        .spawn(move || receive(rztx, rx))
+        .expect("couldn't start metrics thread");
+
+    match rzrx.recv() {
+        Ok(()) => tx,
+        Err(e) => panic!("metrics thread startup error, err={}", e),
+    }
+}
+
+// receive runs in a separate thread and processes all metrics events
+fn receive(rz: SyncSender<()>, rx: Receiver<MetricTuple>) {
+    let mut client = statsd_client();
+    rz.send(()).unwrap(); // Blocks until the matching receive is called
+
+    loop {
+        let (mtyp, mop, mid, mval): MetricTuple = rx.recv().unwrap();
+        debug!("Received metrics tuple: {:?}", (mtyp, mop, mid, mval));
+
+        match client {
+            Some(ref mut cli) => {
+                match mtyp {
+                    MetricType::Counter => {
+                        match mop {
+                            MetricOperation::Increment => cli.incr(mid),
+                            MetricOperation::Decrement => cli.decr(mid),
+                            _ => error!("Unexpected metric operation: {:?}", mop),
+                        }
+                    }
+                    MetricType::Gauge => {
+                        match mop {
+                            MetricOperation::SetValue => cli.gauge(mid, mval.unwrap()),
+                            _ => error!("Unexpected metric operation: {:?}", mop),
+                        }
+                    }
+                }
+            }
+            None => (),
+        }
+    }
+}
+
+fn statsd_client() -> Option<Client> {
+    match env::var(STATS_ENV) {
+        Ok(addr) => {
+            match Client::new(&addr, APP_NAME) {
+                Ok(c) => Some(c),
+                Err(e) => {
+                    debug!("Error creating statsd client: {:?}", e);
+                    None
+                }
+            }
+        }
+        Err(_) => None,
+    }
+}
+
+impl Counter {
+    pub fn increment(&self) {
+        match sender().send((MetricType::Counter, MetricOperation::Increment, &self.id(), None)) {
+            Ok(_) => (),
+            Err(e) => error!("Failed to increment counter, error: {:?}", e),
+        }
+    }
+
+    pub fn decrement(&self) {
+        match sender().send((MetricType::Counter, MetricOperation::Decrement, &self.id(), None)) {
+            Ok(_) => (),
+            Err(e) => error!("Failed to decrement counter, error: {:?}", e),
+        }
+    }
+}
+
+impl Gauge {
+    pub fn set(&self, val: f64) {
+        match sender().send((MetricType::Gauge, MetricOperation::SetValue, &self.id(), Some(val))) {
+            Ok(_) => (),
+            Err(e) => error!("Failed to set gauge, error: {:?}", e),
+        }
+    }
+}
+
+impl Metric for Counter {
+    fn id(&self) -> &'static str {
+        match *self {
+            Counter::SearchPackages => "search-packages",
+        }
+    }
+}
+
+impl Metric for Gauge {
+    fn id(&self) -> &'static str {
+        match *self {
+            Gauge::PackageCount => "package-count",
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::{Counter, Gauge};
+    use metrics::Metric;
+    use std::time::Duration;
+    use std::thread;
+
+    #[test]
+    fn counter_id() {
+        let expected = r#"search-packages"#;
+        let disp = Counter::SearchPackages.id();
+        assert!(disp == expected);
+    }
+
+    #[test]
+    fn guage_id() {
+        let expected = r#"package-count"#;
+        let disp = Gauge::PackageCount.id();
+        assert!(disp == expected);
+    }
+
+    #[test]
+    #[ignore]
+    fn increment_counter() {
+        Counter::SearchPackages.increment();
+    }
+
+    #[test]
+    #[ignore]
+    fn decrement_counter() {
+        Counter::SearchPackages.decrement();
+    }
+
+    #[test]
+    #[ignore]
+    fn set_gauge() {
+        Gauge::PackageCount.set(10.0);
+    }
+
+    #[test]
+    #[ignore]
+    fn calls_from_multiple_threads() {
+        for n in 0..10 {
+            thread::spawn(move || {
+                Counter::SearchPackages.increment();
+                Gauge::PackageCount.set(n as f64);
+                Counter::SearchPackages.decrement();
+            });
+        }
+
+        thread::sleep(Duration::from_millis(500))
+    }
+}

--- a/components/builder-depot/Cargo.toml
+++ b/components/builder-depot/Cargo.toml
@@ -45,6 +45,9 @@ path = "../builder-dbcache"
 [dependencies.habitat_builder_protocol]
 path = "../builder-protocol"
 
+[dependencies.builder_core]
+path = "../builder-core"
+
 [dependencies.habitat_core]
 path = "../core"
 

--- a/components/builder-depot/src/lib.rs
+++ b/components/builder-depot/src/lib.rs
@@ -17,6 +17,8 @@ extern crate habitat_builder_protocol as protocol;
 #[macro_use]
 extern crate habitat_core as hab_core;
 extern crate habitat_net as hab_net;
+#[macro_use]
+extern crate builder_core as bld_core;
 extern crate bodyparser;
 extern crate crypto;
 #[macro_use]


### PR DESCRIPTION
Signed-off-by: Salim Alam <salam@chef.io>

This change adds infrastructure for adding operational metrics to the Hab builder services. The underlying infrastructure is based on a statsd aggregator, howver the metrics API abstracts out any specific statsd dependency.  In order for the metrics to be sent to statsd, the following env variable needs to be configured: HAB_STATS_ADDR, with a value of [IP Addr]:[Port], eg, 192.168.1.1:8125

![giphy](https://cloud.githubusercontent.com/assets/13542112/21625290/cd3ce596-d1bf-11e6-8121-3ad4149858d9.gif)
