### PR TITLE
Fail powershell based builds if non terminating errors occur

### DIFF
--- a/components/plan-build-ps1/bin/hab-plan-build.ps1
+++ b/components/plan-build-ps1/bin/hab-plan-build.ps1
@@ -704,6 +704,9 @@ Set-Location "$PLAN_CONTEXT"
 # @TODO fin - is there a way to change directory only in this program without
 # affecting the calling powershell session?
 
+# We want to fail the build for both termionating and non terminating errors
+$ErrorActionPreference = "Stop"
+
 # Load the Plan
 Write-BuildLine "Loading $PLAN_CONTEXT\plan.ps1"
 . "$PLAN_CONTEXT\plan.ps1"


### PR DESCRIPTION
Powershell divides errors into terminating and non-terminating errors. By default, a terminating error will halt a script but non-terminating errors will emit the error to the console and then proceed. This behavior is fitting for many ad hoc scripts that process multiple items in a powershell pipeline and do not want to terminate if a single item fails. However for our purposes during a habitat package build, any error should halt the build.