### PR TITLE
Set initial version to 0.1.0 in `hab plan init`

### DIFF
--- a/components/hab/static/template_plan.sh
+++ b/components/hab/static/template_plan.sh
@@ -14,7 +14,7 @@ pkg_origin={{ pkg_origin }}
 
 # Required.
 # Sets the version of the package.
-pkg_version=0.0.1
+pkg_version=0.1.0
 
 # Required.
 # A URL that specifies where to download the source from. Any valid wget url


### PR DESCRIPTION
instead of 0.0.1. Small nitpick thing, but http://semver.org/#faq says:

> How should I deal with revisions in the 0.y.z initial development
> phase?

> The simplest thing to do is start your initial development release at
> 0.1.0 and then increment the minor version for each subsequent release.

So let's do that.

![gif-keyboard-15821273349619666947](https://cloud.githubusercontent.com/assets/9912/21690286/2b7507fe-d339-11e6-982d-92065c5b064d.gif)
