### PR TITLE
[bldr] Push common args into their subcommands to prevent mis-invoking.

### DIFF
--- a/components/builder-admin/src/main.rs
+++ b/components/builder-admin/src/main.rs
@@ -49,11 +49,11 @@ fn app<'a, 'b>() -> clap::App<'a, 'b> {
         (about: "Habitat builder-admin")
         (@setting VersionlessSubcommands)
         (@setting SubcommandRequiredElseHelp)
-        (@arg config: -c --config +takes_value +global
-            "Filepath to configuration file. [default: /hab/svc/hab-builder-admin/config.toml]")
-        (@arg port: --port +takes_value +global "Listen port. [default: 8080]")
         (@subcommand start =>
             (about: "Run the builder-admin server")
+            (@arg config: -c --config +takes_value
+                "Filepath to configuration file. [default: /hab/svc/hab-builder-admin/config.toml]")
+            (@arg port: --port +takes_value "Listen port. [default: 8080]")
         )
     )
 }

--- a/components/builder-api/src/main.rs
+++ b/components/builder-api/src/main.rs
@@ -49,13 +49,13 @@ fn app<'a, 'b>() -> clap::App<'a, 'b> {
         (about: "Habitat builder-api")
         (@setting VersionlessSubcommands)
         (@setting SubcommandRequiredElseHelp)
-        (@arg config: -c --config +takes_value +global
-            "Filepath to configuration file. [default: /hab/svc/hab-builder-api/config.toml]")
-        (@arg path: -p --path +takes_value +global
-            "Filepath to service storage for the Depot service")
-        (@arg port: --port +takes_value +global "Listen port. [default: 9636]")
         (@subcommand start =>
             (about: "Run the builder-api server")
+            (@arg config: -c --config +takes_value
+                "Filepath to configuration file. [default: /hab/svc/hab-builder-api/config.toml]")
+            (@arg path: -p --path +takes_value
+                "Filepath to service storage for the Depot service")
+            (@arg port: --port +takes_value "Listen port. [default: 9636]")
         )
     )
 }

--- a/components/builder-jobsrv/src/main.rs
+++ b/components/builder-jobsrv/src/main.rs
@@ -48,10 +48,10 @@ fn app<'a, 'b>() -> clap::App<'a, 'b> {
         (about: "Habitat builder-jobsrv")
         (@setting VersionlessSubcommands)
         (@setting SubcommandRequiredElseHelp)
-        (@arg config: -c --config +takes_value +global
-            "Filepath to configuration file. [default: /hab/svc/hab-builder-jobsrv/config.toml]")
         (@subcommand start =>
             (about: "Run a Habitat Builder job server")
+            (@arg config: -c --config +takes_value
+                "Filepath to configuration file. [default: /hab/svc/hab-builder-jobsrv/config.toml]")
         )
     )
 }

--- a/components/builder-router/src/main.rs
+++ b/components/builder-router/src/main.rs
@@ -49,11 +49,11 @@ fn app<'a, 'b>() -> clap::App<'a, 'b> {
         (about: "Habitat builder-router")
         (@setting VersionlessSubcommands)
         (@setting SubcommandRequiredElseHelp)
-        (@arg config: -c --config +takes_value +global
-            "Filepath to configuration file. [default: /hab/svc/hab-builder-router/config.toml]")
-        (@arg port: --port +takes_value +global "Listen port. [default: 5560]")
         (@subcommand start =>
             (about: "Run a Habitat-Builder router")
+            (@arg config: -c --config +takes_value
+                "Filepath to configuration file. [default: /hab/svc/hab-builder-router/config.toml]")
+            (@arg port: --port +takes_value "Listen port. [default: 5560]")
         )
     )
 }

--- a/components/builder-sessionsrv/src/main.rs
+++ b/components/builder-sessionsrv/src/main.rs
@@ -48,10 +48,10 @@ fn app<'a, 'b>() -> clap::App<'a, 'b> {
         (about: "Habitat builder-sessionsrv")
         (@setting VersionlessSubcommands)
         (@setting SubcommandRequiredElseHelp)
-        (@arg config: -c --config +takes_value +global
-        "Filepath to configuration file. [default: /hab/svc/hab-builder-sessionsrv/config.toml]")
         (@subcommand start =>
             (about: "Run a Habitat-Builder session server")
+            (@arg config: -c --config +takes_value
+            "Filepath to configuration file. [default: /hab/svc/hab-builder-sessionsrv/config.toml]")
         )
     )
 }

--- a/components/builder-vault/src/main.rs
+++ b/components/builder-vault/src/main.rs
@@ -49,10 +49,10 @@ fn app<'a, 'b>() -> clap::App<'a, 'b> {
         (about: "Habitat builder-vaultsrv")
         (@setting VersionlessSubcommands)
         (@setting SubcommandRequiredElseHelp)
-        (@arg config: -c --config +takes_value +global
-            "Filepath to configuration file. [default: /hab/svc/hab-builder-vault/config.toml]")
         (@subcommand start =>
             (about: "Run a Habitat-Builder vault server")
+            (@arg config: -c --config +takes_value +global
+                "Filepath to configuration file. [default: /hab/svc/hab-builder-vault/config.toml]")
         )
     )
 }

--- a/components/builder-worker/src/main.rs
+++ b/components/builder-worker/src/main.rs
@@ -48,10 +48,10 @@ fn app<'a, 'b>() -> clap::App<'a, 'b> {
         (about: "Habitat builder-worker")
         (@setting VersionlessSubcommands)
         (@setting SubcommandRequiredElseHelp)
-        (@arg config: -c --config +takes_value +global
-            "Filepath to configuration file. [default: /hab/svc/hab-builder-worker/config.toml]")
         (@subcommand start =>
             (about: "Run a Habitat-Builder worker")
+            (@arg config: -c --config +takes_value +global
+                "Filepath to configuration file. [default: /hab/svc/hab-builder-worker/config.toml]")
         )
     )
 }


### PR DESCRIPTION
This change clears up a usability issue that I stumbled upon myself,
initially in `core/bldr-api`. I wanted to use a custom config and ran
the following:

    bldr-api --config /path/to/config.toml start

To my confusion, no matter what I did, my config was not getting picked
up. Upon re-reading the code and double checking against the clap API, I
learned that the `global` attribute on an argument will leave the arg
match at the level it was provided by the user (and not also copied down
to the subcommand). This means that both of these invocations result in
a started service:

    bldr-api --config /path/to/config.toml start
    bldr-api start --config /path/to/config.toml

The catch is that only the second one actually applies the config. Oi.

This fix provided here drops the `global` attribute on the `Arg` and
pushes them down into the `start` subcommand. Currently all the Builder
services only provide a `start` subcommand but in the future additional
subcommands may be added. At this point there is some `start` hardcoding
that needs to be generalized anyway and any copious arg duplication can
be dealt with then.

The new behavior is as follows:

```sh
> bldr-api start --config /path/to/config.toml
```

```sh
> bldr-api --config /path/to/config.toml start
error: Found argument '--config' which wasn't expected, or isn't valid in this context

USAGE:
    bldr-api [SUBCOMMAND]

For more information try --help
```

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>