### PR TITLE
[bldr] Use local, non-root data dirs for `make bldr-run` target.

### DIFF
--- a/support/Procfile
+++ b/support/Procfile
@@ -1,5 +1,5 @@
-redis: redis-server
-api: target/debug/bldr-api start
+redis: redis-server --dir tmp
+api: target/debug/bldr-api start --path tmp/depot
 admin: target/debug/bldr-admin start
 router: target/debug/bldr-router start
 jobsrv: target/debug/bldr-job-srv start


### PR DESCRIPTION
This change allows a developer to run `make bldr-run` on Mac (in Docker
via the devshell and natively) and on Linux without the requirement of
being a root user or requiring write access to directories under `/hab`.
There are 2 tweaks to the underlying `Procfile`:

* Tell the Redis server to use a `./tmp/` directory for any data
* Tell the API service to use `./tmp/depot` as its data directory, where
  keys and packages are persisted

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>