### PR TITLE
Fix integer overflow cast causing longer than expected thread sleeps

### DIFF
--- a/components/butterfly/src/server/outbound.rs
+++ b/components/butterfly/src/server/outbound.rs
@@ -127,17 +127,20 @@ impl<'a> Outbound<'a> {
                     self.probe(member);
 
                     if SteadyTime::now() <= next_protocol_period {
-                        let wait_time = next_protocol_period - SteadyTime::now();
-                        debug!("Waiting {} until the next protocol period",
-                               wait_time.num_milliseconds());
-                        thread::sleep(Duration::from_millis(wait_time.num_milliseconds() as u64));
+                        let wait_time = (next_protocol_period - SteadyTime::now()).num_milliseconds();
+                        if wait_time > 0 {
+                            debug!("Waiting {} until the next protocol period", wait_time);
+                            thread::sleep(Duration::from_millis(wait_time as u64));
+                        }
                     }
                 }
             }
 
             if SteadyTime::now() <= long_wait {
-                let wait_time = long_wait - SteadyTime::now();
-                thread::sleep(Duration::from_millis(wait_time.num_milliseconds() as u64));
+                let wait_time = (long_wait - SteadyTime::now()).num_milliseconds();
+                if wait_time > 0 {
+                    thread::sleep(Duration::from_millis(wait_time as u64));
+                }
             }
         }
     }

--- a/components/butterfly/src/server/push.rs
+++ b/components/butterfly/src/server/push.rs
@@ -85,7 +85,6 @@ impl<'a> Push<'a> {
                                member.get_id());
                         continue;
                     }
-
                     // Unlike the SWIM mechanism, we don't actually want to send gossip traffic to
                     // persistent members that are confirmed dead. When the failure detector thread
                     // finds them alive again, we'll go ahead and get back to the business at hand.
@@ -115,15 +114,18 @@ impl<'a> Push<'a> {
                     let _ = guard.join().map_err(|e| println!("Push worker died: {:?}", e));
                 }
                 if SteadyTime::now() < next_gossip {
-                    let wait_time = next_gossip - SteadyTime::now();
-                    thread::sleep(Duration::from_millis(wait_time.num_milliseconds() as u64));
+                    let wait_time = (next_gossip - SteadyTime::now()).num_milliseconds();
+                    if wait_time > 0 {
+                        thread::sleep(Duration::from_millis(wait_time as u64));
+                    }
                 }
             }
             if SteadyTime::now() < long_wait {
-                let wait_time = long_wait - SteadyTime::now();
-                thread::sleep(Duration::from_millis(wait_time.num_milliseconds() as u64));
+                let wait_time = (long_wait - SteadyTime::now()).num_milliseconds();
+                if wait_time > 0 {
+                    thread::sleep(Duration::from_millis(wait_time as u64));
+                }
             }
-
         }
     }
 }

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -356,9 +356,9 @@ impl Manager {
                 }
             }
 
-            let time_to_wait = next_check - SteadyTime::now();
-            if time_to_wait.num_milliseconds() > 0 {
-                thread::sleep(Duration::from_millis(time_to_wait.num_milliseconds() as u64));
+            let time_to_wait = (next_check - SteadyTime::now()).num_milliseconds();
+            if time_to_wait > 0 {
+                thread::sleep(Duration::from_millis(time_to_wait as u64));
             }
         }
     }

--- a/components/sup/src/manager/service_updater.rs
+++ b/components/sup/src/manager/service_updater.rs
@@ -337,8 +337,10 @@ impl Worker {
                 }
                 Err(e) => warn!("Failed to install updated package: {:?}", e),
             }
-            let time_to_wait = next_check - SteadyTime::now();
-            thread::sleep(Duration::from_millis(time_to_wait.num_milliseconds() as u64));
+            let time_to_wait = (next_check - SteadyTime::now()).num_milliseconds();
+            if time_to_wait > 0 {
+                thread::sleep(Duration::from_millis(time_to_wait as u64));
+            }
         }
     }
 
@@ -365,8 +367,10 @@ impl Worker {
                 }
                 Err(e) => warn!("Updater failed to get latest package: {:?}", e),
             }
-            let time_to_wait = next_check - SteadyTime::now();
-            thread::sleep(Duration::from_millis(time_to_wait.num_milliseconds() as u64));
+            let time_to_wait = (next_check - SteadyTime::now()).num_milliseconds();
+            if time_to_wait > 0 {
+                thread::sleep(Duration::from_millis(time_to_wait as u64));
+            }
         }
     }
 


### PR DESCRIPTION
We should always check if we have a positive wait time before casting a
signed integer into an unsigned integer. This fixes a few different
server loops by ensuring this check is made.

![gif-keyboard-7288508588526934601](https://cloud.githubusercontent.com/assets/54036/21731776/f43068f6-d40a-11e6-97e5-da058347ef4c.gif)
