### PR TITLE
Enhancements to `hab plan init`

### DIFF
--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -226,7 +226,9 @@ pub fn get() -> App<'static, 'static> {
             (@subcommand init =>
                 (about: "Generates common package specific configuration files. Executing without \
                     argument will create a `habitat` directory in your current folder for the plan. \
-                    If `PKG_NAME` is specified it will create a folder with that name.")
+                    If `PKG_NAME` is specified it will create a folder with that name. \
+                    Environment variables (those starting with 'pkg_') that are set will be used \
+                    in the generated plan")
                 (aliases: &["i", "in", "ini"])
                 (@arg PKG_NAME: +takes_value "Name for the new app.")
                 (@arg ORIGIN: --origin -o +takes_value "Origin for the new app")

--- a/components/hab/src/command/plan.rs
+++ b/components/hab/src/command/plan.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 pub mod init {
+    use std::env;
     use std::fs::create_dir_all;
     use std::fs::{File, canonicalize};
     use std::io::Write;
@@ -53,6 +54,14 @@ pub mod init {
         let mut data = HashMap::new();
         data.insert("pkg_name".to_string(), name);
         data.insert("pkg_origin".to_string(), origin);
+
+        // Add all environment variables that start with "pkg_" as variables in
+        // the template.
+        for (key, value) in env::vars() {
+            if key.starts_with("pkg_") {
+                data.insert(key, value);
+            }
+        }
 
         // We want to render the configured variables.
         let rendered_plan = try!(handlebars.template_render(PLAN_TEMPLATE, &data));

--- a/components/hab/static/template_plan.sh
+++ b/components/hab/static/template_plan.sh
@@ -14,54 +14,163 @@ pkg_origin={{ pkg_origin }}
 
 # Required.
 # Sets the version of the package.
-pkg_version=0.1.0
-
+{{#if pkg_version ~}}
+pkg_version="{{ pkg_version }}"
+{{else ~}}
+pkg_version="0.1.0"
+{{/if}}
+# Optional.
+# The name and email address of the package maintainer.
+{{#if pkg_maintainer ~}}
+pkg_maintainer="{{ pkg_maintainer }}"
+{{else ~}}
+# pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+{{/if}}
+# Optional.
+# An array of valid software licenses that relate to this package.
+# Please choose a license from http://spdx.org/licenses/
+{{#if pkg_license ~}}
+pkg_license={{ pkg_license }}
+{{else ~}}
+# pkg_license=('Apache-2.0')
+{{/if}}
 # Required.
 # A URL that specifies where to download the source from. Any valid wget url
 # will work. Typically, the relative path for the URL is partially constructed
 # from the pkg_name and pkg_version values; however, this convention is not
 # required.
-pkg_source=http://some_source_url/releases/${pkg_name}-${pkg_version}.tar.gz
-
+{{#if pkg_source ~}}
+pkg_source="{{ pkg_source }}"
+{{else ~}}
+pkg_source="http://some_source_url/releases/${pkg_name}-${pkg_version}.tar.gz"
+{{/if}}
+# Optional.
+# The resulting filename for the download, typically constructed from the
+# pkg_name and pkg_version values.
+{{#if pkg_filename ~}}
+pkg_filename="{{ pkg_filename }}"
+{{else ~}}
+# pkg_filename="${pkg_name}-${pkg_version}.tar.gz"
+{{/if}}
 # Required if a valid URL is provided for pkg_source or unless do_verify() is overridden.
 # The value for pkg_shasum is a sha-256 sum of the downloaded pkg_source. If you
 # do not have the checksum, you can easily generate it by downloading the source
 # and using the sha256sum or gsha256sum tools. Also, if you do not have
 # do_verify() overridden, and you do not have the correct sha-256 sum, then the
 # expected value will be shown in the build output of your package.
-pkg_shasum=TODO
-
-# Optional.
-# The name and email address of the package maintainer.
-# pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-
-# Required for core plans, optional otherwise.
-# A short description of the package. It can be a simple string, or you can
-# create a multi-line description using markdown to provide a rich description
-# of your package.
-# pkg_description="Some description."
-
-# Required for core plans, optional otherwise.
-# The project home page for the package.
-# pkg_upstream_url=http://example.com/project-name
-
-# Optional.
-# An array of valid software licenses that relate to this package.
-# Please choose a license from http://spdx.org/licenses/
-# pkg_license=('Apache-2.0')
-
-# Optional.
-# An array of paths, relative to the final install of the software, where
-# binaries can be found. Used to populate PATH for software that depends on
-# your package.
-# pkg_bin_dirs=(bin)
-
-# Optional.
-# An array of the package dependencies needed only at build time.
-# pkg_build_deps=(core/make core/gcc)
-
+{{#if pkg_shasum ~}}
+pkg_shasum="{{ pkg_shasum }}"
+{{else ~}}
+pkg_shasum="TODO"
+{{/if}}
 # Optional.
 # An array of package dependencies needed at runtime. You can refer to packages
 # at three levels of specificity: `origin/package`, `origin/package/version`, or
 # `origin/package/version/release`.
+{{#if pkg_deps ~}}
+pkg_deps={{ pkg_deps }}
+{{else ~}}
 # pkg_deps=(core/glibc)
+{{/if}}
+# Optional.
+# An array of the package dependencies needed only at build time.
+{{#if pkg_build_deps ~}}
+pkg_build_deps={{ pkg_build_deps }}
+{{else ~}}
+# pkg_build_deps=(core/make core/gcc)
+{{/if}}
+# Optional.
+# An array of paths, relative to the final install of the software, where
+# libraries can be found. Used to populate LD_FLAGS and LD_RUN_PATH for
+# software that depends on your package.
+{{#if pkg_lib_dirs ~}}
+pkg_lib_dirs={{ pkg_lib_dirs }}
+{{else ~}}
+# pkg_lib_dirs=(lib)
+{{/if}}
+# Optional.
+# An array of paths, relative to the final install of the software, where
+# headers can be found. Used to populate CFLAGS for software that depends on
+# your package.
+{{#if pkg_include_dirs ~}}
+pkg_include_dirs={{ pkg_include_dirs }}
+{{else ~}}
+# pkg_include_dirs=(include)
+{{/if}}
+# Optional.
+# An array of paths, relative to the final install of the software, where
+# binaries can be found. Used to populate PATH for software that depends on
+# your package.
+{{#if pkg_bin_dirs ~}}
+pkg_bin_dirs={{ pkg_bin_dirs }}
+{{else ~}}
+# pkg_bin_dirs=(bin)
+{{/if}}
+# Optional.
+# An array of paths, relative to the final install of the software, where
+# pkg-config metadata (.pc files) can be found. Used to populate
+# PKG_CONFIG_PATH for software that depends on your package.
+{{#if pkg_pconfig_dirs ~}}
+pkg_pconfig_dirs={{ pkg_pconfig_dirs }}
+{{else ~}}
+# pkg_pconfig_dirs=(lib/pconfig)
+{{/if}}
+# Optional.
+# The command for the supervisor to execute when starting a service. You can
+# omit this setting if your package is not intended to be run directly by a
+# supervisor of if your plan contains a run hook in hooks/run.
+{{#if pkg_svc_run ~}}
+pkg_svc_run="{{ pkg_svc_run }}"
+{{else ~}}
+# pkg_svc_run="bin/haproxy -f $pkg_svc_config_path/haproxy.conf"
+{{/if}}
+# Optional.
+# An array of ports this service exposes when you create a Docker image from
+# your package.
+{{#if pkg_expose ~}}
+pkg_expose={{ pkg_expose }}
+{{else ~}}
+# pkg_expose=(80 443)
+{{/if}}
+# Optional.
+# An array of interpreters used in shebang lines for scripts. Specify the
+# subdirectory where the binary is relative to the package, for example,
+# bin/bash or libexec/neverland, since binaries can be located in directories
+# besides bin. This list of interpreters will be written to the metadata
+# INTERPRETERS file, located inside a package, with their fully-qualified path.
+# Then these can be used with the fix_interpreter function.
+{{#if pkg_interpreters ~}}
+pkg_interpreters={{ pkg_interpreters }}
+{{else ~}}
+# pkg_interpreters=(bin/bash)
+{{/if}}
+# Optional.
+# The user to run the service as. The default is hab.
+{{#if pkg_svc_user ~}}
+pkg_svc_user="{{ pkg_svc_user }}"
+{{else ~}}
+# pkg_svc_user="hab"
+{{/if}}
+# Optional.
+# The group to run the service as. The default is hab.
+{{#if pkg_svc_group ~}}
+pkg_svc_group="{{ pkg_svc_group }}"
+{{else ~}}
+# pkg_svc_group="$pkg_svc_user"
+{{/if}}
+# Required for core plans, optional otherwise.
+# A short description of the package. It can be a simple string, or you can
+# create a multi-line description using markdown to provide a rich description
+# of your package.
+{{#if pkg_description ~}}
+pkg_description="{{ pkg_description }}"
+{{else ~}}
+# pkg_description="Some description."
+{{/if}}
+# Required for core plans, optional otherwise.
+# The project home page for the package.
+{{#if pkg_upstream_url ~}}
+pkg_upstream_url="{{ pkg_upstream_url }}"
+{{else ~}}
+# pkg_upstream_url="http://example.com/project-name"
+{{/if}}


### PR DESCRIPTION
* Add all of the variables listed in the docs
* Make the variable be listed in the same order as they are in the docs
  (this is probably the wrong order for what we want in the end, but
  it's now consistent between the two and can be argued about later.)
* Allow all "pkg_*" variables (except name and origin) to be set by environment
  variables. So now you can type:

```
    env pkg_svc_user=me pkg_deps="(core/foo core/bar)" \
      pkg_license="('MIT' 'Apache-2.0')" pkg_bin_dirs="(bin sbin)" \
      pkg_version=1.0.0 pkg_description="foo" pkg_maintainer="you" \
      hab plan init foo
```

and it does what you would want.

Signed-off-by: Nathan L Smith <smith@chef.io>