### PR TITLE
Add callbacks to `hab plan init`

### DIFF
--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -232,6 +232,7 @@ pub fn get() -> App<'static, 'static> {
                 (aliases: &["i", "in", "ini"])
                 (@arg PKG_NAME: +takes_value "Name for the new app.")
                 (@arg ORIGIN: --origin -o +takes_value "Origin for the new app")
+                (@arg NO_CALLBACKS: --nocallbacks -f "Do not include callback functions in template")
             )
         )
         (@subcommand ring =>
@@ -413,7 +414,11 @@ fn file_exists(val: String) -> result::Result<(), String> {
 }
 
 fn file_exists_or_stdin(val: String) -> result::Result<(), String> {
-    if val == "-" { Ok(()) } else { file_exists(val) }
+    if val == "-" {
+        Ok(())
+    } else {
+        file_exists(val)
+    }
 }
 
 fn valid_pair_type(val: String) -> result::Result<(), String> {

--- a/components/hab/src/command/plan.rs
+++ b/components/hab/src/command/plan.rs
@@ -28,7 +28,11 @@ pub mod init {
     const PLAN_TEMPLATE: &'static str = include_str!("../../static/template_plan.sh");
     const DEFAULT_TOML_TEMPLATE: &'static str = include_str!("../../static/template_default.toml");
 
-    pub fn start(ui: &mut UI, origin: String, maybe_name: Option<String>) -> Result<()> {
+    pub fn start(ui: &mut UI,
+                 origin: String,
+                 include_callbacks: bool,
+                 maybe_name: Option<String>)
+                 -> Result<()> {
         try!(ui.begin("Constructing a cozy habitat for your app..."));
         try!(ui.br());
 
@@ -38,14 +42,14 @@ pub mod init {
             None => {
                 ("habitat".into(),
                  canonicalize(".")
-                     .ok()
-                     .and_then(|path| {
-                         path.components().last().and_then(|val| {
-                             // Type gymnastics!
-                             val.as_os_str().to_os_string().into_string().ok()
-                         })
-                     })
-                     .unwrap_or("unnamed".into()))
+                    .ok()
+                    .and_then(|path| {
+                        path.components().last().and_then(|val| {
+                            // Type gymnastics!
+                            val.as_os_str().to_os_string().into_string().ok()
+                        })
+                    })
+                    .unwrap_or("unnamed".into()))
             }
         };
 
@@ -54,6 +58,9 @@ pub mod init {
         let mut data = HashMap::new();
         data.insert("pkg_name".to_string(), name);
         data.insert("pkg_origin".to_string(), origin);
+        if include_callbacks {
+            data.insert("include_callbacks".to_string(), "true".to_string());
+        }
 
         // Add all environment variables that start with "pkg_" as variables in
         // the template.

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -315,7 +315,8 @@ fn sub_pkg_hash(m: &ArgMatches) -> Result<()> {
 fn sub_plan_init(ui: &mut UI, m: &ArgMatches) -> Result<()> {
     let name = m.value_of("PKG_NAME").map(|v| v.into());
     let origin = try!(origin_param_or_env(&m));
-    command::plan::init::start(ui, origin, name)
+    let include_callbacks = !m.is_present("NO_CALLBACKS");
+    command::plan::init::start(ui, origin, include_callbacks, name)
 }
 
 fn sub_pkg_install(ui: &mut UI, m: &ArgMatches) -> Result<()> {

--- a/components/hab/static/template_plan.sh
+++ b/components/hab/static/template_plan.sh
@@ -174,3 +174,122 @@ pkg_upstream_url="{{ pkg_upstream_url }}"
 {{else ~}}
 # pkg_upstream_url="http://example.com/project-name"
 {{/if}}
+
+{{#if include_callbacks ~}}
+# Callback Functions
+#
+# When defining your plan, you have the flexibility to override the default
+# behavior of Habitat in each part of the package building stage through a
+# series of callbacks. To define a callback, simply create a shell function
+# of the same name in your plan.sh file and then write your script. If you do
+# not want to use the default callback behavior, you must override the callback
+# and return 0 in the function definition.
+#
+# Callbacks are defined here with either their "do_default_x", if they have a
+# default implementation, or empty with "return 0" if they have no default
+# implementation (Bash does not allow empty function bodies.) If callbacks do
+# nothing or do the same as the default implementation, they can be removed from
+# this template.
+#
+# The default implementations (the do_default_* functions) are defined in the
+# plan build script:
+# https://github.com/habitat-sh/habitat/tree/master/components/plan-build/bin/hab-plan-build.sh
+
+# There is no default implementation of this callback. You can use it to execute
+# any arbitrary commands before anything else happens.
+do_begin() {
+  return 0
+}
+
+# The default implementation is that the software specified in $pkg_source is
+# downloaded, checksum-verified, and placed in $HAB_CACHE_SRC_PATH/$pkgfilename,
+# which resolves to a path like /hab/cache/src/filename.tar.gz. You should
+# override this behavior if you need to change how your binary source is
+# downloaded, if you are not downloading any source code at all, or if your are
+# cloning from git. If you do clone a repo from git, you must override
+# do_verify() to return 0.
+do_download() {
+  do_default_download
+}
+
+# The default implementation tries to verify the checksum specified in the plan
+# against the computed checksum after downloading the source tarball to disk.
+# If the specified checksum doesn't match the computed checksum, then an error
+# and a message specifying the mismatch will be printed to stderr. You should
+# not need to override this behavior unless your package does not download
+# any files.
+do_verify() {
+  do_default_verify
+}
+
+# The default implementation removes the HAB_CACHE_SRC_PATH/$pkg_dirname folder
+# in case there was a previously-built version of your package installed on
+# disk. This ensures you start with a clean build environment.
+do_clean() {
+  do_default_clean
+}
+
+# The default implementation extracts your tarball source file into
+# HAB_CACHE_SRC_PATH. The supported archives are: .tar, .tar.bz2, .tar.gz,
+# .tar.xz, .rar, .zip, .Z, .7z. If the file archive could not be found or was
+# not supported, then a message will be printed to stderr with additional
+# information.
+do_unpack() {
+  do_default_unpack
+}
+
+# There is no default implementation of this callback. At this point in the
+# build process, the tarball source has been downloaded, unpacked, and the build
+# environment variables have been set, so you can use this callback to perform
+# any actions before the package starts building, such as exporting variables,
+# adding symlinks, and so on.
+do_prepare() {
+  return 0
+}
+
+# The default implementation is to update the prefix path for the configure
+# script to use $pkg_prefix and then run make to compile the downloaded source.
+# This means the script in the default implementation does
+# ./configure --prefix=$pkg_prefix && make. You should override this behavior
+# if you have additional configuration changes to make or other software to
+# build and install as part of building your package.
+do_build() {
+  do_default_build
+}
+
+# The default implementation runs nothing during post-compile. An example of a
+# command you might use in this callback is make test. To use this callback, two
+# conditions must be true. A) do_check() function has been declared, B) DO_CHECK
+# environment variable exists and set to true, env DO_CHECK=true.
+do_check() {
+  return 0
+}
+
+# The default implementation is to run make install on the source files and
+# place the compiled binaries or libraries in HAB_CACHE_SRC_PATH/$pkg_dirname,
+# which resolves to a path like /hab/cache/src/packagename-version/. It uses
+# this location because of do_build() using the --prefix option when calling the
+# configure script. You should override this behavior if you need to perform
+# custom installation steps, such as copying files from HAB_CACHE_SRC_PATH to
+# specific directories in your package, or installing pre-built binaries into
+# your package.
+do_install() {
+  do_default_install
+}
+
+# The default implementation is to strip any binaries in $pkg_prefix of their
+# debugging symbols. You should override this behavior if you want to change
+# how the binaries are stripped, which additional binaries located in
+# subdirectories might also need to be stripped, or whether you do not want the
+# binaries stripped at all.
+do_strip() {
+  do_default_strip
+}
+
+# There is no default implementation of this callback. This is called after the
+# package has been built and installed. You can use this callback to remove any
+# temporary files or perform other post-install clean-up actions.
+do_end() {
+  return 0
+}
+{{/if ~}}

--- a/www/source/docs/reference/plan-syntax.html.md
+++ b/www/source/docs/reference/plan-syntax.html.md
@@ -256,9 +256,6 @@ do_download()
 do_verify()
 : The default implementation tries to verify the checksum specified in the plan against the computed checksum after downloading the source tarball to disk. If the specified checksum doesn't match the computed checksum, then an error and a message specifying the mismatch will be printed to stderr. You should not need to override this behavior unless your package does not download any files.
 
-do_check()
-: The default implementation runs nothing during post-compile.  An example of a command you might use in this callback is `make test`. To use this callback, two conditions must be true. A) `do_check()` function has been declared, B) `DO_CHECK` environment variable exists and set to true, `env DO_CHECK=true`.
-
 do_clean()
 : The default implementation removes the *HAB_CACHE_SRC_PATH/$pkg_dirname* folder in case there was a previously-built version of your package installed on disk. This ensures you start with a clean build environment.
 
@@ -270,6 +267,10 @@ do_prepare()
 
 do_build()
 : The default implementation is to update the prefix path for the configure script to use $pkg_prefix and then run `make` to compile the downloaded source. This means the script in the default implementation does `./configure --prefix=$pkg_prefix && make`. You should override this behavior if you have additional configuration changes to make or other software to build and install as part of building your package.
+
+do_check()
+: The default implementation runs nothing during post-compile.  An example of a command you might use in this callback is `make test`. To use this callback, two conditions must be true. A) `do_check()` function has been declared, B) `DO_CHECK` environment variable exists and set to true, `env DO_CHECK=true`.
+
 
 do_install()
 : The default implementation is to run `make install` on the source files and place the compiled binaries or libraries in *HAB_CACHE_SRC_PATH/$pkg_dirname*, which resolves to a path like `/hab/cache/src/packagename-version/`. It uses this location because of **do_build()** using the `--prefix` option when calling the configure script. You should override this behavior if you need to perform custom installation steps, such as copying files from HAB_CACHE_SRC_PATH to specific directories in your package, or installing pre-built binaries into your package.


### PR DESCRIPTION
* Make it so callbacks are in the default `hab plan init output`
* If you don't want callbacks, use `-f` (for "no callback _f_unctions?" I
  guess?) or `--nocallbacks` (I wanted to call it `--no-callbacks` but this
  didn't work. Bug in clap maybe? I don't know, I'm on a plane.)
* Put the `do_check` in the correct order in the docs
* Reformatting resulting from rustfmt runs on affected files

![gif-keyboard-5052353087804354620](https://cloud.githubusercontent.com/assets/9912/21792045/9b21c2ec-d6ac-11e6-9bad-6902b1032d58.gif)
