### PR TITLE
Remove panic on bad peer input

### DIFF
--- a/components/sup/src/error.rs
+++ b/components/sup/src/error.rs
@@ -125,6 +125,7 @@ pub enum Error {
     JsonEncode(json::EncoderError),
     KeyNotFound(String),
     MetaFileIO(io::Error),
+    NameLookup(io::Error),
     NetParseError(net::AddrParseError),
     NoRunFile,
     NulError(ffi::NulError),
@@ -192,6 +193,7 @@ impl fmt::Display for SupError {
             Error::JsonEncode(ref e) => format!("JSON encoding error: {}", e),
             Error::KeyNotFound(ref e) => format!("Key not found in key cache: {}", e),
             Error::MetaFileIO(ref e) => format!("IO error while accessing MetaFile: {:?}", e),
+            Error::NameLookup(ref e) => format!("Error resolving a name or IP address: {}", e),
             Error::NetParseError(ref e) => format!("Can't parse ip:port: {}", e),
             Error::NoRunFile => {
                 format!("No run file is present for this package; specify a run hook or \
@@ -280,6 +282,7 @@ impl error::Error for SupError {
             Error::KeyNotFound(_) => "Key not found in key cache",
             Error::MetaFileIO(_) => "MetaFile could not be read or written to",
             Error::NetParseError(_) => "Can't parse IP:port",
+            Error::NameLookup(_) => "Error resolving a name or IP address",
             Error::NoRunFile => {
                 "No run file is present for this package; specify a run hook or $pkg_svc_run \
                  in your plan"

--- a/components/sup/src/manager/service/mod.rs
+++ b/components/sup/src/manager/service/mod.rs
@@ -62,11 +62,11 @@ pub struct Service {
 
 impl Service {
     pub fn new<S: Into<String>>(package: Package,
-               group: S,
-               organization: Option<String>,
-               topology: Topology,
-               update_strategy: UpdateStrategy)
-               -> Result<Service> {
+                                group: S,
+                                organization: Option<String>,
+                                topology: Topology,
+                                update_strategy: UpdateStrategy)
+                                -> Result<Service> {
         let service_group = ServiceGroup::new(package.name.clone(), group, organization);
         let (svc_user, svc_group) = try!(util::users::get_user_and_group(&package.pkg_install));
         let sg = format!("{}.{}", service_group.service, service_group.group);
@@ -74,9 +74,7 @@ impl Service {
                   &svc_user,
                   &svc_group);
         let runtime_config = RuntimeConfig::new(svc_user, svc_group);
-        let supervisor = Supervisor::new(package.ident().clone(),
-                                         &service_group,
-                                         runtime_config);
+        let supervisor = Supervisor::new(package.ident().clone(), &service_group, runtime_config);
         Ok(Service {
             service_group: service_group,
             supervisor: supervisor,


### PR DESCRIPTION
This commit has the hab-sup return an error to the user when name lookup
or address parsing fails. It adds a `NameLookup` error, and bubbles that
all the way back out to abort the supervisor.

![gif-keyboard-11931895464880035200](https://cloud.githubusercontent.com/assets/4304/21944701/71766474-d98c-11e6-9457-c6306681af0a.gif)

Signed-off-by: Adam Jacob <adam@chef.io>
