### PR TITLE
[sup] Use a consistent clap features set.

### DIFF
--- a/components/sup/Cargo.toml
+++ b/components/sup/Cargo.toml
@@ -48,7 +48,7 @@ path = "../butterfly"
 
 [dependencies.clap]
 version = "*"
-features = ["suggestions", "color"]
+features = [ "suggestions", "color", "unstable" ]
 
 [features]
 functional = []


### PR DESCRIPTION
This change updates the feature set for the Supervisor's clap crate to
include `"stable"`. All other Habitat clap-depenent crates use the same
feature set (suggestions, color, and unstable) which led to crates being
recompiled more often than necessary (churning on differing clap
builds).

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>