### PR TITLE
[sup,director] Remove profile sections from Cargo.toml files.

### DIFF
--- a/components/director/Cargo.toml
+++ b/components/director/Cargo.toml
@@ -48,6 +48,3 @@ tempdir = "*"
 
 [features]
 functional = []
-
-[profile.release]
-lto = true

--- a/components/sup/Cargo.toml
+++ b/components/sup/Cargo.toml
@@ -52,6 +52,3 @@ features = [ "suggestions", "color", "unstable" ]
 
 [features]
 functional = []
-
-[profile.release]
-lto = true


### PR DESCRIPTION
This removes the now-warning condition of:

```
warning: profiles for the non root package will be ignored, specify
profiles at the workspace root
```

when building components. Enabling `lto` is useful but hasn't been
consistently used accross all of our components. A future PR may
re-introduce release profiles after bechmarking the compile time to
binary size/speed trade offs.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>