### PR TITLE
Windows studio

### DIFF
--- a/components/studio/bin/hab-studio.bat
+++ b/components/studio/bin/hab-studio.bat
@@ -1,0 +1,2 @@
+@echo off
+"%~dp0powershell/powershell.exe" -NoProfile -ExecutionPolicy bypass -NoLogo -Command ". '%~dp0hab-studio.ps1'" %*

--- a/components/studio/bin/hab-studio.ps1
+++ b/components/studio/bin/hab-studio.ps1
@@ -1,0 +1,386 @@
+# # Usage
+#
+# ```powershell
+# $ hab-studio [FLAGS] [OPTIONS] <SUBCOMMAND> [ARG ...]
+# ```
+#
+# See the `Write-Help` function below for complete usage instructions.
+#
+# # Synopsis
+#
+# blah
+#
+# # License and Copyright
+#
+# ```
+# Copyright: Copyright (c) 2016 Chef Software, Inc.
+# License: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ```
+#
+#
+
+param (
+    [switch]$h,
+    [switch]$n,
+    [switch]$q,
+    [switch]$v,
+    [string]$command,
+    [string]$commandVal,
+    [string]$k,
+    [string]$r,
+    [string]$s
+)
+
+# # Internals
+
+# ## Help/Usage functions
+
+# **Internal** Prints help and usage information. Straight forward, no?
+function Write-Help {
+  Write-Host @"
+$program $version
+
+$author
+
+Habitat Studios - Plan for success!
+
+USAGE:
+        $program [FLAGS] [OPTIONS] <SUBCOMMAND> [ARG ..]
+
+COMMON FLAGS:
+    -h  Prints this message
+    -n  Do not mount the source path into the Studio (default: mount the path)
+    -q  Prints less output for better use in scripts
+    -v  Prints more verbose output
+
+COMMON OPTIONS:
+    -k <HAB_ORIGIN_KEYS>  Installs secret origin keys (default:\$HAB_ORIGIN )
+    -r <HAB_STUDIO_ROOT>  Sets a Studio root (default: /hab/studios/<DIR_NAME>)
+    -s <SRC_PATH>         Sets the source path (default: \$PWD)
+    -t <STUDIO_TYPE>      Sets a Studio type when creating (default: default)
+                          Valid types: [default baseimage busybox stage1]
+
+SUBCOMMANDS:
+    build     Build using a Studio
+    enter     Interactively enter a Studio
+    help      Prints this message
+    new       Creates a new Studio
+    rm        Destroys a Studio
+    run       Run a command in a Studio
+    version   Prints version information
+
+ENVIRONMENT VARIABLES:
+    HAB_ORIGIN        Propagates this variable into any studios
+    HAB_ORIGIN_KEYS   Installs secret keys (\`-k' option overrides)
+    HAB_STUDIOS_HOME  Sets a home path for all Studios (default: /hab/studios)
+    HAB_STUDIO_ROOT   Sets a Studio root (\`-r' option overrides)
+    NO_SRC_PATH       If set, do not mount source path (\`-n' flag overrides)
+    QUIET             Prints less output (\`-q' flag overrides)
+    SRC_PATH          Sets the source path (\`-s' option overrides)
+    STUDIO_TYPE       Sets a Studio type when creating (\`-t' option overrides)
+    VERBOSE           Prints more verbose output (\`-v' flag overrides)
+
+SUBCOMMAND HELP:
+    $program <SUBCOMMAND> -h
+
+EXAMPLES:
+
+    # Create a new default Studio
+    $program new
+
+    # Enter the default Studio
+    $program enter
+
+    # Run a command in the default Studio
+    $program run wget --version
+
+    # Destroy the default Studio
+    $program rm
+
+    # Create and enter a busybox type Studio with a custom root
+    $program -r /opt/slim -t busybox enter
+
+    # Run a command in the slim Studio, showing only the command output
+    $program -q -r /opt/slim run busybox ls -l /
+
+    # Verbosely destroy the slim Studio
+    $program -v -r /opt/slim rm
+
+"@
+}
+
+function Write-BuildHelp {
+  Write-Host @"
+${program}-build $version
+
+$author
+
+Habitat Studios - execute a build using a Studio
+
+USAGE:
+        $program [COMMON_FLAGS] [COMMON_OPTIONS] build [FLAGS] [PLAN_DIR]
+
+FLAGS:
+    -R  Reuse a previous Studio state (default: clean up before building)
+
+EXAMPLES:
+
+    # Build a Redis plan
+    $program build plans/redis
+
+    # Reuse previous Studio for a build
+    $program build -R plans/glibc
+
+"@
+}
+
+function Write-EnterHelp {
+  Write-Host @"
+${program}-enter $version
+
+$author
+
+Habitat Studios - interactively enter a Studio
+
+USAGE:
+        $program [COMMON_FLAGS] [COMMON_OPTIONS] enter
+
+"@
+}
+
+function Write-NewHelp {
+  Write-Host @"
+${program}-new $version
+
+$author
+
+Habitat Studios - create a new Studio
+
+USAGE:
+        $program [COMMON_FLAGS] [COMMON_OPTIONS] new
+
+"@
+}
+
+function Write-RmHelp {
+  Write-Host @"
+${program}-rm $version
+
+$author
+
+Habitat Studios - destroy a Studio
+
+USAGE:
+        $program [COMMON_FLAGS] [COMMON_OPTIONS] rm
+
+"@
+}
+
+function Write-RunHelp {
+  Write-Host @"
+${program}-run $version
+
+$author
+
+Habitat Studios - run a command in a Studio
+
+USAGE:
+        $program [COMMON_FLAGS] [COMMON_OPTIONS] run [CMD] [ARG ..]
+
+CMD:
+    Command to run in the Studio
+
+ARG:
+    Arguments to the command
+
+EXAMPLES:
+
+    $program run wget --version
+
+"@
+}
+
+function Write-HabInfo($Message) {
+  if($quiet) { return }
+  Write-Host "   ${program}: " -ForegroundColor Cyan -NoNewline
+  Write-Host $Message
+}
+
+# ## Subcommand functions
+#
+# These are the implementations for each subcommand in the program.
+
+function New-Studio {
+  if($printHelp) {
+    Write-NewHelp
+    return
+  }
+  Write-HabInfo "Creating Studio at $HAB_STUDIO_ROOT"
+
+  if(!(Test-Path $HAB_STUDIO_ROOT)) {
+    mkdir $HAB_STUDIO_ROOT | Out-Null
+  }
+
+  Set-Location $HAB_STUDIO_ROOT
+  if(!(Test-Path src) -and !($doNotMount)) {
+    mkdir src | Out-Null
+    New-Item -Name src -ItemType Junction -target $SRC_PATH.Path | Out-Null
+  }
+
+  $pathArray = @(
+    "$PSScriptRoot\hab",
+    "$PSScriptRoot\7zip",
+    "$PSScriptRoot",
+    "$env:WINDIR\system32",
+    "$env:WINDIR"
+  )
+
+  $env:PATH = [String]::Join(";", $pathArray)
+
+  if($env:HAB_ORIGIN_KEYS) {
+    $keys = @()
+    $env:HAB_ORIGIN_KEYS.Split(" ") | % {
+      $keys += & hab origin key export $_ --type=secret | Out-String
+    }
+
+    $env:FS_ROOT=$HAB_STUDIO_ROOT
+    try {
+      $keys | % { $_ | & hab origin key import }
+    }
+    finally {
+      $env:FS_ROOT=$null
+    }
+  }
+
+  New-PSDrive -Name "Habitat" -PSProvider FileSystem -Root $HAB_STUDIO_ROOT -Scope Script | Out-Null
+  Set-Location "Habitat:\src"
+}
+
+function Enter-Studio {
+  if($printHelp) {
+    Write-EnterHelp
+    return
+  }
+  New-Studio
+  Write-HabInfo "Entering Studio at $HAB_STUDIO_ROOT"
+  $env:HAB_STUDIO_ENTER_ROOT = $HAB_STUDIO_ROOT
+  $env:STUDIO_SCRIPT_ROOT = $PSScriptRoot
+  & "$PSScriptRoot\powershell\powershell.exe" -NoProfile -ExecutionPolicy bypass -NoLogo -NoExit -Command {
+    function prompt {
+      Write-Host "[HAB-STUDIO]" -NoNewLine -ForegroundColor Green
+      " $($executionContext.SessionState.Path.CurrentLocation)$('>' * ($nestedPromptLevel +1)) "
+    }
+    function build {
+      & "$env:STUDIO_SCRIPT_ROOT\hab-plan-build.ps1" @args
+    }
+    New-PSDrive -Name "Habitat" -PSProvider FileSystem -Root $env:HAB_STUDIO_ENTER_ROOT | Out-Null
+    Set-Location "Habitat:\src"
+  }
+}
+
+function Invoke-StudioRun($cmd) {
+  if($printHelp -or ($cmd -eq $null)) {
+    Write-RunHelp
+    return
+  }
+  New-Studio
+  Write-HabInfo "Running '$cmd' in Studio at $HAB_STUDIO_ROOT"
+  New-PSDrive -Name "Habitat" -PSProvider FileSystem -Root $HAB_STUDIO_ROOT | Out-Null
+  Set-Location "Habitat:\src"
+  Invoke-Expression $cmd
+}
+
+function Invoke-StudioBuild($location) {
+  if($printHelp -or ($location -eq $null)) {
+    Write-BuildHelp
+    return
+  }
+  New-Studio
+  Write-HabInfo "Building '$location' in Studio at $HAB_STUDIO_ROOT"
+
+  & "$PSScriptRoot\hab-plan-build.ps1" $location
+}
+
+function Remove-Studio {
+  if($printHelp) {
+    Write-RmHelp
+    return
+  }
+  Write-HabInfo "Destroying Studio at $HAB_STUDIO_ROOT"
+
+  if(Test-Path $HAB_STUDIO_ROOT) { Remove-Item $HAB_STUDIO_ROOT -Recurse -Force }
+}
+
+# The current version of Habitat Studio
+$script:version='@version@'
+# The author of this program
+$script:author='@author@'
+# The short version of the program name which is used in logging output
+$script:program="hab-studio"
+
+if($env:SRC_PATH) {
+  $script:SRC_PATH = Resolve-Path $env:SRC_PATH
+}
+else {
+  $script:SRC_PATH = Get-Location
+}
+if($s) { $script:SRC_PATH = Resolve-Path $s }
+$script:dir_name = $SRC_PATH.Path.Replace("$($SRC_PATH.Drive):\","").Replace("\","--")
+
+if(!$env:HAB_STUDIOS_HOME) {
+  $script:HAB_STUDIOS_HOME = "/hab/studios"
+}
+else {
+  $script:HAB_STUDIOS_HOME = $env:HAB_STUDIOS_HOME
+}
+
+if(!$env:HAB_STUDIO_ROOT) {
+  $script:HAB_STUDIO_ROOT = "$HAB_STUDIOS_HOME/$dir_name"
+}
+else {
+  $script:HAB_STUDIO_ROOT = $env:HAB_STUDIO_ROOT
+}
+if($r) { $script:HAB_STUDIO_ROOT = $r }
+
+if($k) {
+  $env:HAB_ORIGIN_KEYS = $k
+}
+else {
+  $env:HAB_ORIGIN_KEYS = $env:HAB_ORIGIN
+}
+
+if($h) { $script:printHelp = $true }
+if($n) { $script:doNotMount = $true }
+if($q) { $script:quiet = $true }
+
+$currentVerbose = $VerbosePreference
+if($v) { $VerbosePreference = "Continue" }
+
+try {
+  switch ($command) {
+    "new" { New-Studio }
+    "run" { Invoke-StudioRun $commandVal }
+    "rm" { Remove-Studio }
+    "enter" { Enter-Studio }
+    "build" { Invoke-StudioBuild $commandVal }
+    "version" { Write-Host "$program $version" }
+    "help" { Write-Help }
+    default {
+      Write-Help
+      Write-Error "Invalid Argument $command"
+    }
+  }
+}
+finally { $VerbosePreference = $currentVerbose }

--- a/components/studio/plan.ps1
+++ b/components/studio/plan.ps1
@@ -1,0 +1,34 @@
+$pkg_name="hab-studio"
+$pkg_origin="core"
+$pkg_version=Get-Content "$PLAN_CONTEXT/../../VERSION"
+$pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+$pkg_license=@("Apache-2.0")
+$pkg_source="nosuchfile.tar.gz"
+$pkg_build_deps=@("core/powershell", "core/hab", "core/hab-plan-build-ps1", "core/7zip")
+$pkg_bin_dirs=@("bin")
+
+function Invoke-Build {
+  Get-Content "$PLAN_CONTEXT/bin/hab-studio.ps1" | % {
+    $_.Replace("@author@", $pkg_maintainer).Replace("@version@", $pkg_version)
+  } | Add-Content -Path hab-studio.ps1
+  Copy-Item $PLAN_CONTEXT/bin/hab-studio.bat hab-studio.bat
+}
+
+function Invoke-Install {
+  mkdir "$pkg_prefix/bin/powershell"
+  mkdir "$pkg_prefix/bin/hab"
+  mkdir "$pkg_prefix/bin/7zip"
+
+  Copy-Item hab-studio.ps1 "$pkg_prefix/bin/hab-studio.ps1"
+  Copy-Item hab-studio.bat "$pkg_prefix/bin/hab-studio.bat"
+
+  Copy-Item "$(Get-HabPackagePath powershell)/bin/*" "$pkg_prefix/bin/powershell" -Recurse
+  Copy-Item "$(Get-HabPackagePath hab)/bin/*" "$pkg_prefix/bin/hab"
+  Copy-Item "$(Get-HabPackagePath 7zip)/bin/*" "$pkg_prefix/bin/7zip"
+  Copy-Item "$(Get-HabPackagePath hab-plan-build-ps1)/bin/*" "$pkg_prefix/bin"  
+}
+
+function Invoke-Download {}
+function Invoke-Verify {}
+function Invoke-Unpack {}
+function Invoke-Prepare {}


### PR DESCRIPTION
Adds a studio for windows. The studio environment will:

* Run inside of packaged core/powershell
* Strip the path to just hab binaries and vanilla windows paths (c:\windows and c:\windows\system32)
* An isolated hab environment in /hab/studios mounted to a PS-Drive named habitat
* A custom prompt that prefixes `[HAB-STUDIO]` to the prompt
* symlink the current working directory to `habitat:\src`

Until we officially MVP the windows work, `hab studio enter` should behave like it does today dropping the user in a docker/linux studio. This new windows studio should only be accessed via something like `hab studio enter --studio-type windows` 

Signed-off-by: Matt Wrock <matt@mattwrock.com>