### PR TITLE
[hab] Support running out of `/var/tmp` if available.

### DIFF
--- a/components/hab/install.sh
+++ b/components/hab/install.sh
@@ -283,7 +283,13 @@ do_install() {
 }
 
 # Download location for the temporary files
-tmp_dir="${TMPDIR:-/tmp}/hab"
+if [ -n "${TMPDIR:-}" ]; then
+  tmp_dir="${TMPDIR}/hab"
+elif [ -d /var/tmp ]; then
+  tmp_dir=/var/tmp/hab
+else
+  tmp_dir=/tmp/hab
+fi
 
 # Use stable Bintray channel by default
 channel="stable"


### PR DESCRIPTION
This change helps the `install.sh` script to support running on Red Hat
based distributions by default. The `/tmp` file system mount typically
sets `noexec` meaning that running `/tmp/hab/.../hab install core/hab`
will result in a failure. Running out of `/var/tmp` however works. The
logic to determine the temp dir is now as follows (first match wins):

1. Use the value of the `$TMPDIR` environment variable if set
2. Use the `/var/tmp` directory if exists
3. Otherwise use the `/tmp` directory

I ran this install.sh on a CentOS 7.3 VM, an Ubuntu 16.04 VM, and an Arch Linux Docker container to make sure there aren't any regressions.