### PR TITLE
Fix Hook output and remove "output" from HealthCheck and Hook errors

### DIFF
--- a/components/sup/Cargo.toml
+++ b/components/sup/Cargo.toml
@@ -19,12 +19,10 @@ name = "functional"
 ansi_term = "*"
 env_logger = "*"
 handlebars = "*"
-hyper = "*"
 lazy_static = "*"
 libc = "*"
 log = "*"
 iron = "*"
-openssl = "0.7" # lock until hyper bumps to 0.8+
 persistent = "*"
 regex = "*"
 rustc-serialize = "*"
@@ -49,6 +47,10 @@ path = "../butterfly"
 [dependencies.clap]
 version = "*"
 features = [ "suggestions", "color", "unstable" ]
+
+[dev-dependencies]
+hyper = "*"
+openssl = "0.7" # lock until hyper bumps to 0.8+
 
 [features]
 functional = []

--- a/components/sup/src/health_check.rs
+++ b/components/sup/src/health_check.rs
@@ -15,52 +15,21 @@
 use std::fmt::{self, Display, Formatter};
 
 #[derive(Debug, Clone, PartialEq, Eq, RustcEncodable)]
-pub enum Status {
+pub enum CheckResult {
     Ok,
     Warning,
     Critical,
     Unknown,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, RustcEncodable)]
-pub struct CheckResult {
-    pub status: Status,
-    pub output: String,
-}
-
-impl CheckResult {
-    pub fn ok(output: String) -> Self {
-        Self::new(Status::Ok, output)
-    }
-
-    pub fn warning(output: String) -> Self {
-        Self::new(Status::Warning, output)
-    }
-
-    pub fn critical(output: String) -> Self {
-        Self::new(Status::Critical, output)
-    }
-
-    pub fn unknown(output: String) -> Self {
-        Self::new(Status::Unknown, output)
-    }
-
-    fn new(status: Status, output: String) -> Self {
-        CheckResult {
-            status: status,
-            output: output,
-        }
-    }
-}
-
 impl Display for CheckResult {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        let status_code = match self.status {
-            Status::Ok => "OK",
-            Status::Warning => "WARNING",
-            Status::Critical => "CRITICAL",
-            Status::Unknown => "UNKNOWN",
+        let msg = match *self {
+            CheckResult::Ok => "OK",
+            CheckResult::Warning => "WARNING",
+            CheckResult::Critical => "CRITICAL",
+            CheckResult::Unknown => "UNKNOWN",
         };
-        write!(f, "{} - {}", status_code, self.output)
+        write!(f, "{}", msg)
     }
 }

--- a/components/sup/src/http_gateway.rs
+++ b/components/sup/src/http_gateway.rs
@@ -182,18 +182,18 @@ fn services(req: &mut Request) -> IronResult<Response> {
 
 impl Into<Response> for health_check::CheckResult {
     fn into(self) -> Response {
-        let status: status::Status = self.status.into();
-        Response::with((status, self.output))
+        let status: status::Status = self.into();
+        Response::with(status)
     }
 }
 
-impl Into<status::Status> for health_check::Status {
+impl Into<status::Status> for health_check::CheckResult {
     fn into(self) -> status::Status {
         match self {
-            health_check::Status::Ok |
-            health_check::Status::Warning => status::Ok,
-            health_check::Status::Critical => status::ServiceUnavailable,
-            health_check::Status::Unknown => status::InternalServerError,
+            health_check::CheckResult::Ok |
+            health_check::CheckResult::Warning => status::Ok,
+            health_check::CheckResult::Critical => status::ServiceUnavailable,
+            health_check::CheckResult::Unknown => status::InternalServerError,
         }
     }
 }

--- a/components/sup/src/lib.rs
+++ b/components/sup/src/lib.rs
@@ -45,8 +45,6 @@ extern crate habitat_common as common;
 extern crate habitat_depot_client as depot_client;
 extern crate handlebars;
 #[macro_use]
-extern crate hyper;
-#[macro_use]
 extern crate log;
 extern crate tempdir;
 extern crate rustc_serialize;

--- a/components/sup/src/manager/service/mod.rs
+++ b/components/sup/src/manager/service/mod.rs
@@ -311,12 +311,12 @@ impl Service {
     }
 
     pub fn health_check(&self) -> Result<health_check::CheckResult> {
-        self.package.health_check(&self.supervisor)
+        self.package.health_check(&self.supervisor, &self.service_group)
     }
 
     pub fn file_updated(&self) {
         if self.initialized {
-            match self.package.file_updated() {
+            match self.package.file_updated(&self.service_group) {
                 Ok(_) => outputln!(preamble self.service_group_str(), "{}", "File update hook succeeded."),
                 Err(e) => {
                     outputln!(preamble self.service_group_str(), "File update hook failed: {}", e)
@@ -327,7 +327,7 @@ impl Service {
 
     pub fn initialize(&mut self) {
         if !self.initialized {
-            match self.package.initialize() {
+            match self.package.initialize(&self.service_group) {
                 Ok(()) => {
                     outputln!(preamble self.service_group_str(), "{}", "Initializing");
                     self.initialized = true
@@ -358,7 +358,7 @@ impl Service {
         match service_config.write(&self.package) {
             Ok(true) => {
                 self.needs_restart = true;
-                match self.package.reconfigure() {
+                match self.package.reconfigure(&self.service_group) {
                     Ok(_) => {}
                     Err(e) => {
                         outputln!(preamble self.service_group_str(),

--- a/components/sup/src/util/mod.rs
+++ b/components/sup/src/util/mod.rs
@@ -18,17 +18,16 @@ pub mod path;
 pub mod sys;
 pub mod users;
 
-use std::net::Ipv4Addr;
-use std::net::SocketAddrV4;
+use std::ffi::OsStr;
+use std::net::{Ipv4Addr, SocketAddrV4};
 use std::str::FromStr;
-use std::path::PathBuf;
 use std::process::{Command, Stdio};
 
 use hcore::os;
-
 use time;
 
 use error::{Error, Result};
+
 static LOGKEY: &'static str = "UT";
 
 /// Gives us a time to stop for in seconds.
@@ -69,7 +68,7 @@ pub fn parse_ip_port_with_defaults(s: Option<&str>,
 }
 
 #[cfg(any(target_os="linux", target_os="macos"))]
-pub fn create_command(path: PathBuf, user: &str, group: &str) -> Command {
+pub fn create_command<S: AsRef<OsStr>>(path: S, user: &str, group: &str) -> Command {
     let mut cmd = Command::new(path);
     use std::os::unix::process::CommandExt;
     let uid = os::users::get_uid_by_name(user).expect("Can't determine uid");
@@ -84,9 +83,9 @@ pub fn create_command(path: PathBuf, user: &str, group: &str) -> Command {
 }
 
 #[cfg(target_os = "windows")]
-pub fn create_command(path: PathBuf, user: &str, group: &str) -> Command {
+pub fn create_command<S: AsRef<OsStr>>(path: S, user: &str, group: &str) -> Command {
     let mut cmd = Command::new("powershell.exe");
-    let ps_command = format!("iex $(gc {} | out-string)", path.to_str().unwrap());
+    let ps_command = format!("iex $(gc {} | out-string)", path.as_ref());
     cmd.arg("-command")
         .arg(ps_command)
         .stdin(Stdio::null())

--- a/components/sup/src/util/mod.rs
+++ b/components/sup/src/util/mod.rs
@@ -85,7 +85,7 @@ pub fn create_command<S: AsRef<OsStr>>(path: S, user: &str, group: &str) -> Comm
 #[cfg(target_os = "windows")]
 pub fn create_command<S: AsRef<OsStr>>(path: S, user: &str, group: &str) -> Command {
     let mut cmd = Command::new("powershell.exe");
-    let ps_command = format!("iex $(gc {} | out-string)", path.as_ref());
+    let ps_command = format!("iex $(gc {} | out-string)", path.as_ref().to_string_lossy());
     cmd.arg("-command")
         .arg(ps_command)
         .stdin(Stdio::null())


### PR DESCRIPTION
This PR accomplishes two goals:

1. stdout and stderr from running hooks will one again correctly be
   piped to the supervisor's output and it's originating service
   group will be included in it's preamble
2. The "output" member on the HealthCheck and Hook errors has been
   removed. See the description below for details

Originally we were storing the stdout of a failed hook and, by proxy, a
health check as a member of the error struct. We can't do this because
we don't know exactly how large the contents of the output would be and
this could cause the supervisor to crash. The output from hooks are
piped to the supervisor's console and can be retrieved from there.

![gif-keyboard-569115800137743555](https://cloud.githubusercontent.com/assets/54036/22071693/c8a652f6-dd54-11e6-82be-0a3edc6fb65d.gif)