### PR TITLE
[http-client] Set a 30-second read/write timeout on HTTP client calls.

### DIFF
--- a/components/http-client/src/api_client.rs
+++ b/components/http-client/src/api_client.rs
@@ -31,6 +31,9 @@ use net::ProxyHttpsConnector;
 use proxy::{ProxyInfo, proxy_unless_domain_exempted};
 use ssl;
 
+// Read and write TCP socket timeout for Hyper/HTTP client calls.
+const CLIENT_SOCKET_RW_TIMEOUT: u64 = 30;
+
 header! { (ProxyAuthorization, "Proxy-Authorization") => [String] }
 
 /// A generic wrapper around a Hyper HTTP client intended for API-like usage.
@@ -230,7 +233,7 @@ impl ApiClient {
 fn new_hyper_client(for_domain: Option<&Url>, fs_root_path: Option<&Path>) -> Result<HyperClient> {
     let ctx = try!(ssl_ctx(fs_root_path));
     let ssl_client = Openssl { context: Arc::new(ctx) };
-    let timeout = Some(Duration::from_secs(5));
+    let timeout = Some(Duration::from_secs(CLIENT_SOCKET_RW_TIMEOUT));
 
     match try!(proxy_unless_domain_exempted(for_domain)) {
         Some(proxy) => {


### PR DESCRIPTION
Read and write TCP socket timeout for Hyper/HTTP client calls. If,
during a read, no data can be read from a socket then this triggers the
client call to terminate (similar for a write/upload operation). In the
presence of server side caching, there could be a period of time where
no data is sent back to a client--for example, a large Habitat artifact
is being served and first needs to be fully read to a reverse proxy for
future requests. If the amount of time taken to read the artifact into
the cache exceeds this timeout, then the client will prematurely give up
and potentially trigger a retry. We set this value to 30 seconds as a
long enough time to read sufficiently large artifacts into server side
caches but a short enough time to avoid a forever-blocking client (also,
some proxies and firewalls will have a 30-seconds idle
connection-severing policy).

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>