### PR TITLE
Fixed issue where shared content wasn't showing up

### DIFF
--- a/www/source/docs/run-packages-overview.html.md.erb
+++ b/www/source/docs/run-packages-overview.html.md.erb
@@ -16,7 +16,8 @@ If your host machine is running Linux, do the following to run your packages:
 
 * Add the `hab` user and group.
 
-     <%= partial "/shared/add_hab_user_group" %>
+      sudo adduser --group hab
+      sudo useradd -g hab hab
 
 * Run the `hab` CLI as root.
 

--- a/www/source/tutorials/getting-started/linux/process-build.html.md.erb
+++ b/www/source/tutorials/getting-started/linux/process-build.html.md.erb
@@ -80,7 +80,8 @@ To natively run services on your Linux host machine, do the following:
 1. Build your package in the studio and then exit back to your host machine.
 2. Add the `hab` user and group to your machine. This is the default user and group for the child process in a service and they must be present for your service to run.
 
-      <%= partial "/shared/add_hab_user_group" %>
+       sudo adduser --group hab
+       sudo useradd -g hab hab
 
    > Note: One of the reasons you can run a service from within the studio is that the `hab` user is created for you when you enter the studio environment.
 


### PR DESCRIPTION
kramdown wasn't rendering the original shared block correctly when it was included as a partial. 

Because the shared code is so small and only used in two places, I'm just inlining it instead to get them to show up in the rendered content.

Signed-off-by: David Wrede <dwrede@chef.io>