### PR TITLE
Create lib, bin, include, and pkconfig dirs in prepare

### DIFF
--- a/components/plan-build-ps1/bin/hab-plan-build.ps1
+++ b/components/plan-build-ps1/bin/hab-plan-build.ps1
@@ -578,7 +578,7 @@ function _Complete-DependencyResolution {
       _Exit-With "Resolving '$dep' failed, should this be built first?" 1
     }
   }
- 
+
   # Build `${pkg_build_tdeps_resolved[@]}` containing all the direct build
   # dependencies, and the run dependencies for each direct build dependency.
 
@@ -849,9 +849,9 @@ function Invoke-DefaultBuild {
 # ```
 function Invoke-CheckWrapper {
     if ((_Check-Command Invoke-Check) -and (Test-Path Env:\DO_CHECK)) {
-        Write-BuildLine "Running post-compile tests"
-        Push-Location "$HAB_CACHE_SRC_PATH\$pkg_dirname"
-        try { Invoke-Check } finally { Pop-Location }
+      Write-BuildLine "Running post-compile tests"
+      Push-Location "$HAB_CACHE_SRC_PATH\$pkg_dirname"
+      try { Invoke-Check } finally { Pop-Location }
     }
 }
 
@@ -860,6 +860,18 @@ function Invoke-CheckWrapper {
 function Invoke-InstallWrapper {
     Write-BuildLine "Installing"
     New-Item "$pkg_prefix" -ItemType Directory -Force | Out-Null
+    foreach($dir in $pkg_lib_dirs) {
+      New-Item "$pkg_prefix\$dir" -ItemType Directory -Force | Out-Null
+    }
+    foreach($dir in $pkg_bin_dirs) {
+      New-Item "$pkg_prefix\$dir" -ItemType Directory -Force | Out-Null
+    }
+    foreach($dir in $pkg_include_dirs) {
+      New-Item "$pkg_prefix\$dir" -ItemType Directory -Force | Out-Null
+    }
+    foreach($dir in $pkg_pconfig_dirs) {
+      New-Item "$pkg_prefix\$dir" -ItemType Directory -Force | Out-Null
+    }
     Push-Location "$HAB_CACHE_SRC_PATH\$pkg_dirname"
     try { Invoke-Install } finally { Pop-Location }
 }
@@ -1038,8 +1050,8 @@ function _Write-Metadata {
             Out-File "$pkg_prefix\EXPOSES" -Encoding ascii
     }
 
-   # @TODO fin - INTERPRETERS
-    
+    # @TODO fin - INTERPRETERS
+
     $pkg_build_deps_resolved | % {
         Resolve-HabPkgPath $_ | Out-File $pkg_prefix\BUILD_DEPS -Encoding ascii -Append
     }

--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -1809,6 +1809,18 @@ do_check_wrapper() {
 do_install_wrapper() {
   build_line "Installing"
   mkdir -pv "$pkg_prefix"
+  for dir in "${pkg_lib_dirs[@]}"; do
+    mkdir -pv "$pkg_prefix/$dir"
+  done
+  for dir in "${pkg_bin_dirs[@]}"; do
+    mkdir -pv "$pkg_prefix/$dir"
+  done
+  for dir in "${pkg_include_dirs[@]}"; do
+    mkdir -pv "$pkg_prefix/$dir"
+  done
+  for dir in "${pkg_pconfig_dirs[@]}"; do
+    mkdir -pv "$pkg_prefix/$dir"
+  done
   pushd "$HAB_CACHE_SRC_PATH/$pkg_dirname" > /dev/null
   do_install
   popd > /dev/null


### PR DESCRIPTION
We set expectations in the metadata that these directories will exist so we should automatically create them in the preparation step. This will remove the need to manually create them before using them for plan authors. We might want to think about warning if the contents of these directories are empty at the end of a build to ask the author, "Did you really mean to have an empty lib dir?"

![gif-keyboard-440374529918932873](https://cloud.githubusercontent.com/assets/54036/22102883/f1b01116-dded-11e6-97a4-7d536ca46c02.gif)
