### PR TITLE
Add toUppercase and toLowercase Handlebars helpers

### DIFF
--- a/components/sup/src/error.rs
+++ b/components/sup/src/error.rs
@@ -106,8 +106,8 @@ pub enum Error {
     FileNotFound(String),
     HabitatCommon(common::Error),
     HabitatCore(hcore::Error),
-    HandlebarsTemplateFileError(handlebars::TemplateFileError),
-    HandlebarsRenderError(handlebars::RenderError),
+    TemplateFileError(handlebars::TemplateFileError),
+    TemplateRenderError(handlebars::RenderError),
     /// Health check exited with an invalid status code. Valid status codes are 0, 1, 2, and 3.
     HealthCheckBadExit(i32),
     /// A hook failed to successfully execute. This error contains the type of hook which failed
@@ -160,8 +160,8 @@ impl fmt::Display for SupError {
             Error::Permissions(ref err) => format!("{}", err),
             Error::HabitatCommon(ref err) => format!("{}", err),
             Error::HabitatCore(ref err) => format!("{}", err),
-            Error::HandlebarsTemplateFileError(ref err) => format!("{:?}", err),
-            Error::HandlebarsRenderError(ref err) => format!("{}", err),
+            Error::TemplateFileError(ref err) => format!("{:?}", err),
+            Error::TemplateRenderError(ref err) => format!("{}", err),
             Error::CommandNotImplemented => format!("Command is not yet implemented!"),
             Error::DbInvalidPath => format!("Invalid filepath to internal datastore"),
             Error::DepotClient(ref err) => format!("{}", err),
@@ -253,8 +253,8 @@ impl error::Error for SupError {
         match self.err {
             Error::ButterflyError(ref err) => err.description(),
             Error::ExecCommandNotFound(_) => "Exec command was not found on filesystem or in PATH",
-            Error::HandlebarsRenderError(ref err) => err.description(),
-            Error::HandlebarsTemplateFileError(ref err) => err.description(),
+            Error::TemplateFileError(ref err) => err.description(),
+            Error::TemplateRenderError(ref err) => err.description(),
             Error::HabitatCommon(ref err) => err.description(),
             Error::HabitatCore(ref err) => err.description(),
 
@@ -339,13 +339,13 @@ impl From<common::Error> for SupError {
 
 impl From<handlebars::RenderError> for SupError {
     fn from(err: handlebars::RenderError) -> SupError {
-        sup_error!(Error::HandlebarsRenderError(err))
+        sup_error!(Error::TemplateRenderError(err))
     }
 }
 
 impl From<handlebars::TemplateFileError> for SupError {
     fn from(err: handlebars::TemplateFileError) -> SupError {
-        sup_error!(Error::HandlebarsTemplateFileError(err))
+        sup_error!(Error::TemplateFileError(err))
     }
 }
 

--- a/components/sup/src/lib.rs
+++ b/components/sup/src/lib.rs
@@ -272,6 +272,7 @@ pub mod manager;
 pub mod output;
 pub mod package;
 pub mod supervisor;
+pub mod templating;
 pub mod util;
 
 use std::env;

--- a/components/sup/src/templating/mod.rs
+++ b/components/sup/src/templating/mod.rs
@@ -1,0 +1,51 @@
+// Copyright (c) 2016 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod helpers;
+
+use std::ops::{Deref, DerefMut};
+use handlebars::Handlebars;
+
+pub struct Template(Handlebars);
+
+impl Template {
+    pub fn new() -> Self {
+        let mut handlebars = Handlebars::new();
+        handlebars.register_helper("json", Box::new(helpers::json_helper));
+        handlebars.register_helper("toml", Box::new(helpers::toml_helper));
+        handlebars.register_helper("toUppercase", Box::new(helpers::to_uppercase));
+        handlebars.register_helper("toLowercase", Box::new(helpers::to_lowercase));
+        handlebars.register_escape_fn(never_escape);
+        Template(handlebars)
+    }
+}
+
+impl Deref for Template {
+    type Target = Handlebars;
+
+    fn deref(&self) -> &Handlebars {
+        &self.0
+    }
+}
+
+impl DerefMut for Template {
+    fn deref_mut(&mut self) -> &mut Handlebars {
+        &mut self.0
+    }
+}
+
+/// Disables HTML escaping which is enabled by default in Handlebars.
+fn never_escape(data: &str) -> String {
+    String::from(data)
+}

--- a/components/sup/src/util/mod.rs
+++ b/components/sup/src/util/mod.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 pub mod convert;
-pub mod handlebars_helpers;
 pub mod path;
 pub mod sys;
 pub mod users;


### PR DESCRIPTION
Refactor handlebars_helpers into a templating module which includes a
Template struct that configures the Handlebars registry properly on each
call to `::new()`. This will ensure that all helpers are available in
any template that the supervisor renders.

![gif-keyboard-4018791599846557943](https://cloud.githubusercontent.com/assets/54036/22110113/67403fca-de0f-11e6-9b7a-aaf630dec11a.gif)
