### PR TITLE
Have `hab setup` check and use `HAB_ORIGIN` and `HAB_AUTH_TOKEN` as defaults

### DIFF
--- a/components/hab/src/command/cli.rs
+++ b/components/hab/src/command/cli.rs
@@ -19,6 +19,7 @@ pub mod setup {
     use hcore::crypto::SigKeyPair;
     use hcore::env;
 
+    use ORIGIN_ENVVAR;
     use analytics;
     use command;
     use config;
@@ -165,7 +166,7 @@ pub mod setup {
                                    &o)));
                 Some(o)
             }
-            None => env::var("USER").ok(),
+            None => env::var(ORIGIN_ENVVAR).or(env::var("USER")).ok(),
         };
         Ok(try!(ui.prompt_ask("Default origin name", default.as_ref().map(|x| &**x))))
     }

--- a/components/hab/src/command/cli.rs
+++ b/components/hab/src/command/cli.rs
@@ -19,7 +19,7 @@ pub mod setup {
     use hcore::crypto::SigKeyPair;
     use hcore::env;
 
-    use ORIGIN_ENVVAR;
+    use {AUTH_TOKEN_ENVVAR, ORIGIN_ENVVAR};
     use analytics;
     use command;
     use config;
@@ -183,7 +183,7 @@ pub mod setup {
                               change it if you wish."));
                 Some(o)
             }
-            None => None,
+            None => env::var(AUTH_TOKEN_ENVVAR).ok(),
         };
         Ok(try!(ui.prompt_ask("GitHub access token", default.as_ref().map(|x| &**x))))
     }

--- a/components/hab/src/command/studio.rs
+++ b/components/hab/src/command/studio.rs
@@ -211,8 +211,9 @@ mod inner {
         // requiring a TTY.
 
         let current_dir = format!("{}:/src", env::current_dir().unwrap().to_string_lossy());
-        let key_cache_path =
-            format!("{}:/{}", default_cache_key_path(None).to_string_lossy(), CACHE_KEY_PATH);
+        let key_cache_path = format!("{}:/{}",
+                                     default_cache_key_path(None).to_string_lossy(),
+                                     CACHE_KEY_PATH);
         let version_output = Command::new(&cmd)
             .arg("run")
             .arg("--rm")

--- a/components/hab/src/lib.rs
+++ b/components/hab/src/lib.rs
@@ -42,4 +42,5 @@ mod exec;
 
 pub const PRODUCT: &'static str = "hab";
 pub const VERSION: &'static str = include_str!(concat!(env!("OUT_DIR"), "/VERSION"));
+pub const AUTH_TOKEN_ENVVAR: &'static str = "HAB_AUTH_TOKEN";
 pub const ORIGIN_ENVVAR: &'static str = "HAB_ORIGIN";

--- a/components/hab/src/lib.rs
+++ b/components/hab/src/lib.rs
@@ -42,3 +42,4 @@ mod exec;
 
 pub const PRODUCT: &'static str = "hab";
 pub const VERSION: &'static str = include_str!(concat!(env!("OUT_DIR"), "/VERSION"));
+pub const ORIGIN_ENVVAR: &'static str = "HAB_ORIGIN";

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -40,11 +40,9 @@ use hcore::service::ServiceGroup;
 use hcore::package::PackageIdent;
 use hcore::url::{DEFAULT_DEPOT_URL, DEPOT_URL_ENVVAR};
 
-use hab::{analytics, cli, command, config, ORIGIN_ENVVAR, PRODUCT, VERSION};
+use hab::{analytics, cli, command, config, AUTH_TOKEN_ENVVAR, ORIGIN_ENVVAR, PRODUCT, VERSION};
 use hab::error::{Error, Result};
 
-/// Makes the --auth-token CLI param optional when this env var is set
-const HABITAT_AUTH_TOKEN_ENVVAR: &'static str = "HAB_AUTH_TOKEN";
 /// Makes the --org CLI param optional when this env var is set
 const HABITAT_ORG_ENVVAR: &'static str = "HAB_ORG";
 
@@ -503,13 +501,13 @@ fn raw_parse_args() -> (Vec<OsString>, Vec<OsString>) {
 }
 
 /// Check to see if the user has passed in an AUTH_TOKEN param. If not, check the
-/// HABITAT_AUTH_TOKEN env var. If not, check the CLI config to see if there is a default auth
+/// HAB_AUTH_TOKEN env var. If not, check the CLI config to see if there is a default auth
 /// token set. If that's empty too, then error.
 fn auth_token_param_or_env(m: &ArgMatches) -> Result<String> {
     match m.value_of("AUTH_TOKEN") {
         Some(o) => Ok(o.to_string()),
         None => {
-            match henv::var(HABITAT_AUTH_TOKEN_ENVVAR) {
+            match henv::var(AUTH_TOKEN_ENVVAR) {
                 Ok(v) => Ok(v),
                 Err(_) => {
                     let config = try!(config::load());

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -40,13 +40,11 @@ use hcore::service::ServiceGroup;
 use hcore::package::PackageIdent;
 use hcore::url::{DEFAULT_DEPOT_URL, DEPOT_URL_ENVVAR};
 
-use hab::{analytics, cli, command, config, PRODUCT, VERSION};
+use hab::{analytics, cli, command, config, ORIGIN_ENVVAR, PRODUCT, VERSION};
 use hab::error::{Error, Result};
 
 /// Makes the --auth-token CLI param optional when this env var is set
 const HABITAT_AUTH_TOKEN_ENVVAR: &'static str = "HAB_AUTH_TOKEN";
-/// Makes the --origin CLI param optional when this env var is set
-const HABITAT_ORIGIN_ENVVAR: &'static str = "HAB_ORIGIN";
 /// Makes the --org CLI param optional when this env var is set
 const HABITAT_ORG_ENVVAR: &'static str = "HAB_ORG";
 
@@ -532,7 +530,7 @@ fn origin_param_or_env(m: &ArgMatches) -> Result<String> {
     match m.value_of("ORIGIN") {
         Some(o) => Ok(o.to_string()),
         None => {
-            match henv::var(HABITAT_ORIGIN_ENVVAR) {
+            match henv::var(ORIGIN_ENVVAR) {
                 Ok(v) => Ok(v),
                 Err(_) => {
                     let config = try!(config::load());


### PR DESCRIPTION
## 	[hab] Use `HAB_ORIGIN` envvar if present as default origin in `hab setup`

This change makes the `hab setup` defaults slightly better, especially
when executed inside a Studio where the `HAB_ORIGIN` environment
variable is likely to be set. Unless a cli.toml was already present with
the value for `origin`, the previous behavior was to default the value
to the `USER` environment variable. For example:

```
> env USER=seniorcoolpants hab setup

Habitat CLI Setup
=================

...

Set up a default origin? [Yes/no/quit]

  Enter the name of your origin. If you plan to publish your packages
  publicly, we recommend that you select one that is not already in use on
  the Habitat build service found at https://app.habitat.sh/.

Default origin name: [default: seniorcoolpants]

Create origin key pair

  It doesn't look like you have a signing key for the origin
  `seniorcoolpants'. Without it, you won't be able to build new packages
  successfully.

  You can either create a new signing key now, or, if you are building
  packages for an origin that already exists, ask the owner to give you
  the signing key.

  For more information on the use of origin keys, please consult the
  documentation at https://www.habitat.sh/docs/concepts-keys/#origin-keys

Create an origin key for `seniorcoolpants'? [Yes/no/quit] quit
```

With this change, the presence of the `HAB_ORIGIN` environment variable
will be preferred over the `USER` environment variable. For example:

```
> env USER=seniorcoolpants HAB_ORIGIN=admiralsweaterjacket hab setup

Habitat CLI Setup
=================

...

Set up a default origin? [Yes/no/quit]

  Enter the name of your origin. If you plan to publish your packages
  publicly, we recommend that you select one that is not already in use on
  the Habitat build service found at https://app.habitat.sh/.

Default origin name: [default: admiralsweaterjacket]

Create origin key pair

  It doesn't look like you have a signing key for the origin
  `admiralsweaterjacket'. Without it, you won't be able to build new
  packages successfully.

  You can either create a new signing key now, or, if you are building
  packages for an origin that already exists, ask the owner to give you
  the signing key.

  For more information on the use of origin keys, please consult the
  documentation at https://www.habitat.sh/docs/concepts-keys/#origin-keys

Create an origin key for `admiralsweaterjacket'? [Yes/no/quit] quit
```

## 	[hab] Use `HAB_AUTH_TOKEN` envvar if present as default auth token in `hab setup`

This change makes the `hab setup` defaults slightly better, especially
when a user has their `HAB_AUTH_TOKEN` environment variable set. Now,
unless a cli.toml was already present with the value for `auth`, the
value of the `HAB_AUTH_TOKEN` will be used if present as the default.
For example:

```
> env HAB_AUTH_TOKEN=wakkawakka hab setup

Habitat CLI Setup
=================

...

GitHub access token: [default: wakkawakka]
Analytics

  The `hab` command-line tool will optionally send anonymous usage data to
  Habitat's Google Analytics account. This is a strictly opt-in activity
  and no tracking will occur unless you respond affirmatively to the
  question below.

  We collect this data to help improve Habitat's user experience. For
  example, we would like to know the category of tasks users are
  performing, and which ones they are having trouble with (e.g. mistyping
  command line arguments).

  To see what kinds of data are sent and how they are anonymized, please
  read more about our analytics here:
  https://www.habitat.sh/docs/about-analytics/

Enable analytics? [Yes/no/quit] quit
```