### PR TITLE
Depot platform validation

### DIFF
--- a/components/builder-api/src/config.rs
+++ b/components/builder-api/src/config.rs
@@ -96,6 +96,7 @@ impl ConfigFile for Config {
                              &mut cfg.depot.github_client_secret));
         try!(toml.parse_into("cfg.events_enabled", &mut cfg.events_enabled));
         try!(toml.parse_into("cfg.events_enabled", &mut cfg.depot.events_enabled));
+        try!(toml.parse_into("cfg.supported_target", &mut cfg.depot.supported_target));
         Ok(cfg)
     }
 }

--- a/components/builder-depot/src/config.rs
+++ b/components/builder-depot/src/config.rs
@@ -16,6 +16,7 @@ use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 
 use hab_core::config::{ConfigFile, ParseInto};
 use hab_net::config::{GitHubOAuth, RouteAddrs};
+use hab_core::package::PackageTarget;
 use redis;
 use toml;
 
@@ -48,6 +49,8 @@ pub struct Config {
     pub insecure: bool,
     /// Whether to log events for funnel metrics
     pub events_enabled: bool,
+    /// Supported targets - comma separated
+    pub supported_target: PackageTarget,
 }
 
 impl ConfigFile for Config {
@@ -60,6 +63,7 @@ impl ConfigFile for Config {
         try!(toml.parse_into("cfg.datastore_addr", &mut cfg.datastore_addr));
         try!(toml.parse_into("cfg.router_addrs", &mut cfg.routers));
         try!(toml.parse_into("cfg.events_enabled", &mut cfg.events_enabled));
+        try!(toml.parse_into("cfg.supported_target", &mut cfg.supported_target));
         Ok(cfg)
     }
 }
@@ -76,6 +80,7 @@ impl Default for Config {
             github_client_secret: DEV_GITHUB_CLIENT_SECRET.to_string(),
             insecure: false,
             events_enabled: false, // TODO: change to default to true later
+            supported_target: PackageTarget::default(),
         }
     }
 }

--- a/components/builder-depot/src/lib.rs
+++ b/components/builder-depot/src/lib.rs
@@ -61,7 +61,7 @@ use std::path::{Path, PathBuf};
 
 use crypto::sha2::Sha256;
 use crypto::digest::Digest;
-use hab_core::package::{Identifiable, PackageArchive};
+use hab_core::package::{Identifiable, PackageArchive, PackageTarget};
 use hab_net::server::NetIdent;
 use iron::typemap;
 
@@ -101,11 +101,13 @@ impl Depot {
         self.packages_path()
             .join(format!("{:x}", output[0]))
             .join(format!("{:x}", output[1]))
-            .join(format!("{}-{}-{}-{}-x86_64-linux.hart",
+            .join(format!("{}-{}-{}-{}-{}-{}.hart",
                           ident.origin(),
                           ident.name(),
                           ident.version().unwrap(),
-                          ident.release().unwrap()))
+                          ident.release().unwrap(),
+                          self.config.supported_target.architecture,
+                          self.config.supported_target.platform))
     }
 
     fn key_path(&self, key: &str, rev: &str) -> PathBuf {

--- a/components/core/src/config.rs
+++ b/components/core/src/config.rs
@@ -20,6 +20,7 @@ use std::net::{IpAddr, SocketAddr};
 use std::path::Path;
 use std::result;
 use std::str::FromStr;
+use package::PackageTarget;
 
 use toml;
 
@@ -335,6 +336,21 @@ impl ParseInto<Vec<BTreeMap<String, String>>> for toml::Value {
             }
         } else {
             Ok(false)
+        }
+    }
+}
+
+impl ParseInto<PackageTarget> for toml::Value {
+    fn parse_into(&self, field: &'static str, out: &mut PackageTarget) -> Result<bool> {
+        if let Some(val) = self.lookup(field) {
+            if let Some(v) = val.as_str() {
+                *out = PackageTarget::from_str(v).unwrap();
+                Ok(true)
+            } else {
+                Err(Error::ConfigInvalidTargetString(field))
+            }
+        } else {
+            Ok(true)
         }
     }
 }

--- a/components/core/src/error.rs
+++ b/components/core/src/error.rs
@@ -46,6 +46,8 @@ pub enum Error {
     ConfigInvalidSocketAddr(&'static str),
     /// Expected a string for configuration field value.
     ConfigInvalidString(&'static str),
+    /// Expected a valid target string for configuration field value.
+    ConfigInvalidTargetString(&'static str),
     /// Crypto library error
     CryptoError(String),
     /// Occurs when a file that should exist does not or could not be read.
@@ -128,6 +130,9 @@ impl fmt::Display for Error {
             Error::ConfigInvalidString(ref f) => {
                 format!("Invalid string value in config, field={}.", f)
             }
+            Error::ConfigInvalidTargetString(ref f) => {
+                format!("Invalid target string value in config, field={}.", f)
+            }
             Error::CryptoError(ref e) => format!("Crypto error: {}", e),
             Error::FileNotFound(ref e) => format!("File not found at: {}", e),
             Error::InvalidPackageIdent(ref e) => {
@@ -199,6 +204,9 @@ impl error::Error for Error {
             }
             Error::ConfigInvalidString(_) => {
                 "Invalid string value encountered while parsing a configuration file"
+            }
+            Error::ConfigInvalidTargetString(_) => {
+                "Invalid target string value encountered while parsing a configuration file"
             }
             Error::CryptoError(_) => "Crypto error",
             Error::FileNotFound(_) => "File not found",

--- a/components/core/src/serde_types.in.rs
+++ b/components/core/src/serde_types.in.rs
@@ -49,7 +49,7 @@ pub mod package_target {
 
     /// Describes the platform (operating system/kernel)
     /// and architecture (x86_64, i386, etc..) that a package is built for
-    #[derive(Serialize, Deserialize, Debug, Clone, Hash)]
+    #[derive(Deserialize, Serialize, Eq, PartialEq, Debug, Clone, Hash)]
     pub struct PackageTarget {
         pub platform: Platform,
         pub architecture: Architecture,

--- a/components/hab/src/command/pkg.rs
+++ b/components/hab/src/command/pkg.rs
@@ -562,6 +562,9 @@ pub mod upload {
             Err(depot_client::Error::APIError(StatusCode::Conflict, _)) => {
                 println!("Package already exists on remote; skipping.");
             }
+            Err(depot_client::Error::APIError(StatusCode::NotImplemented, _)) => {
+                println!("Package platform or architecture not supported; skipping.")
+            }
             Err(depot_client::Error::APIError(StatusCode::UnprocessableEntity, _)) => {
                 return Err(Error::PackageArchiveMalformed(format!("{}", archive.path.display())));
             }


### PR DESCRIPTION
First step in adding platform awareness to the Habitat Depot.

- [X] Updated `hab pkg upload` to understand the `StatusCode::NotImplemented` and not continue to retry the package upload.
- [X] Reject packages that do not target x86_64 Linux (now that Windows packages are closer to being a thing and we did have a Mac package slip by once).  Packages with unsupported platform or architectures are rejected with a `StatusCode::NotImplemented`.
- [X] Remove the hard coding of `-x86_64-linux` in the building of the archive path name for local storage in the depot.  Use either the actual target from the archive or default to the platform the depot is running on.
- [X] Add configuration element to identify supported target for the depot.