### PR TITLE
Fix path and dependency bugs in plan-build-ps1

### DIFF
--- a/components/plan-build-ps1/bin/hab-plan-build.ps1
+++ b/components/plan-build-ps1/bin/hab-plan-build.ps1
@@ -264,7 +264,7 @@ Get-HabPackagePath "glibc/2.22"
     param($Identity)
 
     foreach($e in $pkg_all_deps_resolved) {
-        if("$($e.Replace("\", "/"))/".Contains("/$Identity/")) {
+        if((Resolve-HabPkgPath $e).Contains("/$Identity/")) {
           return $e
         }
     }
@@ -400,7 +400,7 @@ function _Get-TdepsFor($dependency) {
 function _return_or_append_to_set($dependency, $depArray) {
   foreach($e in $depArray) {
     if ($e -eq $dependency) {
-      $depArray
+      return $depArray
     }
   }
   $depArray + $dependency


### PR DESCRIPTION
This fixes a couple bugs in the windows build that have surfaced in doing the studio work:

1. Fixes resolving package path for the `hab` package by only looking at the ident portion of the path. Otherwise the `/hab/` at the front will cause any package to match.
2. We were adding duplicate package paths to the `PATH` leading to some extremely large path values.

Signed-off-by: Matt Wrock <matt@mattwrock.com>