### PR TITLE
Add pkgPathFor helper to templating language

### DIFF
--- a/components/sup/src/templating/mod.rs
+++ b/components/sup/src/templating/mod.rs
@@ -22,10 +22,16 @@ pub struct Template(Handlebars);
 impl Template {
     pub fn new() -> Self {
         let mut handlebars = Handlebars::new();
-        handlebars.register_helper("json", Box::new(helpers::json_helper));
-        handlebars.register_helper("toml", Box::new(helpers::toml_helper));
+        handlebars.register_helper("pkgPathFor", Box::new(helpers::pkg_path_for));
         handlebars.register_helper("toUppercase", Box::new(helpers::to_uppercase));
         handlebars.register_helper("toLowercase", Box::new(helpers::to_lowercase));
+        handlebars.register_helper("toJson", Box::new(helpers::to_json));
+        handlebars.register_helper("toToml", Box::new(helpers::to_toml));
+
+        // JW TODO: remove these at a later date, these are an alias for toJson/toToml
+        handlebars.register_helper("json", Box::new(helpers::to_json));
+        handlebars.register_helper("toml", Box::new(helpers::to_toml));
+
         handlebars.register_escape_fn(never_escape);
         Template(handlebars)
     }
@@ -48,4 +54,75 @@ impl DerefMut for Template {
 /// Disables HTML escaping which is enabled by default in Handlebars.
 fn never_escape(data: &str) -> String {
     String::from(data)
+}
+
+#[cfg(test)]
+mod test {
+    use std::collections::BTreeMap;
+    use super::*;
+
+    #[test]
+    fn test_handlebars_json_helper() {
+        let content = "{{toJson x}}".to_string();
+        let mut data = BTreeMap::new();
+        data.insert("test".into(), "something".into());
+
+        let mut template = Template::new();
+        template.register_template_string("t", content).unwrap();
+
+        let mut m: BTreeMap<String, BTreeMap<String, String>> = BTreeMap::new();
+        m.insert("x".into(), data);
+
+        let r = template.render("t", &m);
+
+        assert_eq!(r.ok().unwrap(),
+                   r#"{
+  "test": "something"
+}"#
+                       .to_string());
+    }
+
+    #[test]
+    fn test_handlebars_toml_helper() {
+        let content = "{{toToml x}}".to_string();
+        let mut data = BTreeMap::new();
+        data.insert("test".into(), "something".into());
+
+        let mut template = Template::new();
+        template.register_template_string("t", content).unwrap();
+
+        let mut m: BTreeMap<String, BTreeMap<String, String>> = BTreeMap::new();
+        m.insert("x".into(), data);
+
+        let r = template.render("t", &m);
+
+        assert_eq!(r.ok().unwrap(),
+                   r#"test = "something"
+"#
+                       .to_string());
+    }
+
+    #[test]
+    fn to_uppercase_helper() {
+        let content = "{{toUppercase var}}".to_string();
+        let mut template = Template::new();
+        template.register_template_string("t", content).unwrap();
+
+        let mut m: BTreeMap<String, String> = BTreeMap::new();
+        m.insert("var".into(), "value".into());
+        let rendered = template.render("t", &m).unwrap();
+        assert_eq!(rendered, "VALUE".to_string());
+    }
+
+    #[test]
+    fn to_lowercase_helper() {
+        let content = "{{toLowercase var}}".to_string();
+        let mut template = Template::new();
+        template.register_template_string("t", content).unwrap();
+
+        let mut m: BTreeMap<String, String> = BTreeMap::new();
+        m.insert("var".into(), "VALUE".into());
+        let rendered = template.render("t", &m).unwrap();
+        assert_eq!(rendered, "value".to_string());
+    }
 }

--- a/www/source/docs/create-packages-configure.html.md
+++ b/www/source/docs/create-packages-configure.html.md
@@ -48,16 +48,17 @@ syntax is the same for all block expressions and looks like this:
       {{expression}}
     {{/helper}}
 
-Habitat supports the following helpers:
+Habitat supports the standard [built-in helpers](http://handlebarsjs.com/builtin_helpers.html):
 
-* each
-* if
-* with
-* lookup
-* partial
-* block
-* include >
-* log
+* `if`
+* `unless`
+* `each`
+* `with`
+* `lookup`
+* `>` ([partials](http://handlebarsjs.com/partials.html))
+* `log`
+
+> Note: Habitat also has a collection of [advanced helpers](#advanced-helpers) to assist in writing configuration and hook files.
 
 The most common block helpers that you will probably use are the `if` and `with` helpers.
 
@@ -89,7 +90,6 @@ When writing your template, you can use the `with` helper to reduce duplication:
       repl-disable-tcp-nodelay {{disable-tcp-nodelay}}
     {{/with}}
 
-
 Helpers can also be nested and used together in block expressions. Here is another example from the redis.config file where the `if` and `with` helpers are used together to set up `core/redis` Habitat services  in a leader-follower topology.
 
     {{#if svc.me.follower}}
@@ -97,7 +97,6 @@ Helpers can also be nested and used together in block expressions. Here is anoth
       slaveof {{ip}} {{port}}
      {{/with}}
     {/if}}
-
 
 Here's an example using `each` to render multiple server entries:
 
@@ -120,11 +119,37 @@ like this:
     host = host-2
     port = 3434
 
-## File format helpers
+## Advanced Helpers
 
-### JSON
+Habitat's templating flavour includes a number of useful helpers for writing configuration and hook files
 
-To output configuration data as JSON, you can use the `json` helper.
+* [`toLowercase`](#tolowercase-helper)
+* [`toUppercase`](#touppercase-helper)
+* [`pkgPathFor`](#pkgpathfor-helper)
+* [`toJson`](#tojson-helper)
+* [`toToml`](#totoml-helper)
+
+### toLowercase Helper
+
+Returns the lowercase equivalent of the given string literal.
+
+    my_value={{toLowercase "UPPER-CASE"}}
+
+### toUppercase Helper
+
+Returns the uppercase equivalent of the given string literal.
+
+    my_value={{toUppercase "lower-case"}}
+
+### pkgPathFor Helper
+
+Returns the absolute filepath to the package directory of the package best resolved from the given package identifier. The `pkgPathFor` helper will only resolve against dependent packages of the package the template belongs to - in other words, you will always get what you expect and the template won't leak to other packages on the system.
+
+    export JAVA_HOME="{{pkgPathFor core/jdk8}}"
+
+### toJson Helper
+
+To output configuration data as JSON, you can use the `toJson` helper.
 
 Given a default.toml that looks like:
 
@@ -140,7 +165,7 @@ Given a default.toml that looks like:
 
 and a template:
 
-    {{ json cfg.web }}
+    {{toJson cfg.web}}
 
 when rendered, it will look like:
 
@@ -160,9 +185,9 @@ when rendered, it will look like:
 This can be useful if you have a configuration file that is in JSON format and
 has the same structure as your TOML configuration data.
 
-### TOML
+### toToml Helper
 
-The `toml` helper can be used to output TOML.
+The `toToml` helper can be used to output TOML.
 
 Given a default.toml that looks like:
 
@@ -172,7 +197,7 @@ Given a default.toml that looks like:
 
 and a template:
 
-    {{ toml cfg.web }}
+    {{toToml cfg.web}}
 
 when rendered, it will look like:
 


### PR DESCRIPTION
* add `pkgPathFor` helper and documentation
* add `toUppercase` helper documentation
* add `toLowercase` helper documentation
* rename `json` helper to `toJson`, leaving `json` as an alias
* rename `toml` helper to `toToml`, leaving `toml` as an alias
* add `toJson` helper documentation
* add `toToml` helper documentation
* clarify the difference between built-in helpers and advanced helpers
  in documentation

![gif-keyboard-3687287127878529798](https://cloud.githubusercontent.com/assets/54036/22205764/1a21ed44-e12d-11e6-8270-68d6c8be96c5.gif)
