### PR TITLE
Update `pkgPathFor` template helper example in docs.

### DIFF
--- a/www/source/docs/create-packages-configure.html.md
+++ b/www/source/docs/create-packages-configure.html.md
@@ -145,7 +145,7 @@ Returns the uppercase equivalent of the given string literal.
 
 Returns the absolute filepath to the package directory of the package best resolved from the given package identifier. The `pkgPathFor` helper will only resolve against dependent packages of the package the template belongs to - in other words, you will always get what you expect and the template won't leak to other packages on the system.
 
-    export JAVA_HOME="{{pkgPathFor core/jdk8}}"
+    export JAVA_HOME={{pkgPathFor "core/jre8"}}
 
 ### toJson Helper
 


### PR DESCRIPTION
This change adds double-quoting around the package identifier (which is
required for the helper) and drops the outer quoting in an attempt to
not confuse a reader with too many nested double quotes.

![gif-keyboard-17546678199012266139](https://cloud.githubusercontent.com/assets/261548/22214224/32eeb8c4-e197-11e6-84aa-494b6066e604.gif)
