### PR TITLE
Add builder-db component

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,6 +64,11 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "bufstream"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "builder_core"
 version = "0.0.0"
 dependencies = [
@@ -71,6 +76,11 @@ dependencies = [
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "statsd 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "byteorder"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "byteorder"
@@ -174,6 +184,11 @@ dependencies = [
 [[package]]
 name = "error-chain"
 version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "fallible-iterator"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -316,6 +331,18 @@ dependencies = [
  "toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zmq 0.8.1 (git+https://github.com/erickt/rust-zmq?branch=release/v0.8)",
+]
+
+[[package]]
+name = "habitat_builder_db"
+version = "0.0.0"
+dependencies = [
+ "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "postgres 0.13.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "r2d2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "r2d2_postgres 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -836,6 +863,11 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "md5"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "memchr"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1021,6 +1053,19 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "phf"
+version = "0.7.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "phf_shared 0.7.20 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.7.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1031,6 +1076,42 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "typemap 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "postgres"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bufstream 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fallible-iterator 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "postgres-protocol 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "postgres-shared 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "postgres-protocol"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fallible-iterator 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "md5 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "postgres-shared"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "fallible-iterator 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf 0.7.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "postgres-protocol 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1055,6 +1136,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "antidote 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "r2d2_postgres"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "postgres 0.13.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "r2d2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1622,6 +1712,8 @@ dependencies = [
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum bodyparser 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6928e817538b74a73d1dd6e9a942a2a35c632a597b6bb14fd009480f859a6bf5"
 "checksum broadcast 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fb214f702da3cc6aa1666520f40ea66f506644db5e1065be4bbc972f7ec3750b"
+"checksum bufstream 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7b48dbe2ff0e98fa2f03377d204a9637d3c9816cd431bfe05a8abbd0ea11d074"
+"checksum byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0fc10e8cc6b2580fda3f36eb6dc5316657f812a3df879a44a66fc9f0fdbc4855"
 "checksum byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c40977b0ee6b9885c9013cd41d9feffdd22deb3bb4dc3a71d901cc7a77de18c8"
 "checksum clap 2.19.3 (registry+https://github.com/rust-lang/crates.io-index)" = "95b78f3fe0fc94c13c731714363260e04b557a637166f33a4570d3189d642374"
 "checksum clock_ticks 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "da9bd98fefcf1904a3f80ead86d366d9373c34db7b8a8e48c1fdcaac4787800d"
@@ -1634,6 +1726,7 @@ dependencies = [
 "checksum errno 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "69f4f6bb013e7cf131c839851eefc87fd975f56ffa1cab2cf3de7f0212a2dc4e"
 "checksum error 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "a6e606f14042bb87cc02ef6a14db6c90ab92ed6f62d87e69377bc759fd7987cc"
 "checksum error-chain 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "318cb3c71ee4cdea69fdc9e15c173b245ed6063e1709029e8fd32525a881120f"
+"checksum fallible-iterator 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "5d48ab1bc11a086628e8cc0cc2c2dc200b884ac05c4b48fb71d6036b6999ff1d"
 "checksum fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6cc484842f1e2884faf56f529f960cc12ad8c71ce96cc7abba0a067c98fee344"
 "checksum gcc 0.3.41 (registry+https://github.com/rust-lang/crates.io-index)" = "3689e1982a563af74960ae3a4758aa632bb8fd984cfc3cc3b60ee6109477ab6e"
 "checksum gdi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0912515a8ff24ba900422ecda800b52f4016a56251922d397c576bf92c690518"
@@ -1660,6 +1753,7 @@ dependencies = [
 "checksum linked-hash-map 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6d262045c5b87c0861b3f004610afd0e2c851e2908d08b6c870cbb9d5f494ecd"
 "checksum log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ab83497bf8bf4ed2a74259c1c802351fcd67a65baa86394b6ba73c36f4838054"
 "checksum matches 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "efd7622e3022e1a6eaa602c4cea8912254e5582c9c692e9167714182244801b1"
+"checksum md5 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7df230903ccdffd6b3b4ec21624498ea64c912ce50297846907f0b8e1bb249dd"
 "checksum memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
 "checksum memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1dbccc0e46f1ea47b9f17e6d67c5a96bd27030519c519c9c91327e31275a47b4"
 "checksum metadeps 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "829fffe7ea1d747e23f64be972991bc516b2f1ac2ae4a3b33d8bea150c410151"
@@ -1681,12 +1775,18 @@ dependencies = [
 "checksum pbr 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9f37516f7ab051df67430a6572735d7992fe74dde52554495eec459fb57da41f"
 "checksum persistent 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c9c94f2ef72dc272c6bcc8157ccf2bc7da14f4c58c69059ac2fc48492d6916"
 "checksum pest 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0a6dda33d67c26f0aac90d324ab2eb7239c819fc7b2552fe9faa4fe88441edc8"
+"checksum phf 0.7.20 (registry+https://github.com/rust-lang/crates.io-index)" = "0c6afb2057bb5f846a7b75703f90bc1cef4970c35209f712925db7768e999202"
+"checksum phf_shared 0.7.20 (registry+https://github.com/rust-lang/crates.io-index)" = "286385a0e50d4147bce15b2c19f0cf84c395b0e061aaf840898a7bf664c2cfb7"
 "checksum pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8cee804ecc7eaf201a4a207241472cc870e825206f6c031e3ee2a72fa425f2fa"
 "checksum plugin 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "1a6a0dc3910bc8db877ffed8e457763b317cf880df4ae19109b9f77d277cf6e0"
+"checksum postgres 0.13.5 (registry+https://github.com/rust-lang/crates.io-index)" = "585ca978431cddac0aa926246f18fe30a47401eabbe9bbda573dc60389c10ea1"
+"checksum postgres-protocol 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "283e27d237a5772ef00c9e3f97e632f9a565ff514761af3e88e129576af7077c"
+"checksum postgres-shared 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6f09b8819c2586032ed23bfbe95f6edfbebdc18bf9d0fe02c1f785f659958fbb"
 "checksum protobuf 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "229112a9213bf62a59f0702871a6e4872fe928161fc7a08f17cdd6c8c7988bf7"
 "checksum quick-error 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0aad603e8d7fb67da22dbdf1f4b826ce8829e406124109e73cf1b2454b93a71c"
 "checksum quote 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)" = "e7b44fd83db28b83c1c58187159934906e5e955c812e211df413b76b03c909a5"
 "checksum r2d2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4ecfed1b03be2e66624ec87cef173dad54253f25405bd3c918b321e4dda3ad32"
+"checksum r2d2_postgres 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d9ea3d4773725bf025184675ad9c7328609e8e4ddd27557dd0b67fff29bf2c2f"
 "checksum r2d2_redis 0.4.0 (git+https://github.com/habitat-sh/r2d2-redis.git?branch=habitat)" = "<none>"
 "checksum rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "022e0636ec2519ddae48154b028864bdce4eaf7d35226ab8e65c611be97b189d"
 "checksum redis 0.7.0 (git+https://github.com/habitat-sh/redis-rs?branch=habitat)" = "<none>"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
   "components/builder-admin",
   "components/builder-api",
   "components/builder-core",
+  "components/builder-db",
   "components/builder-dbcache",
   "components/builder-depot",
   "components/builder-depot-client",

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ else
 endif
 
 BIN = hab hab-butterfly sup
-LIB = butterfly builder-dbcache builder-core builder-protocol common core builder-depot-client http-client net
+LIB = butterfly builder-dbcache builder-core builder-protocol common core builder-depot-client http-client net builder-db
 SRV = builder-api builder-admin builder-depot builder-router builder-jobsrv builder-sessionsrv builder-vault builder-worker
 ALL = $(BIN) $(LIB) $(SRV)
 VERSION := $(shell cat VERSION)

--- a/components/builder-db/Cargo.toml
+++ b/components/builder-db/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "habitat_builder_db"
+version = "0.0.0"
+authors = ["Adam Jacob <adam@chef.io>", "Jamie Winsor <reset@chef.io>", "Fletcher Nichol <fnichol@chef.io>", "Joshua Timberman <joshua@chef.io>", "Dave Parfitt <dparfitt@chef.io>"]
+description = "Habitat-Builder Database Library"
+workspace = "../../"
+
+[dependencies]
+log = "*"
+r2d2 = "*"
+rustc-serialize = "*"
+time = "*"
+postgres = "*"
+r2d2_postgres = "*"
+
+[features]
+functional = []

--- a/components/builder-db/src/config.rs
+++ b/components/builder-db/src/config.rs
@@ -1,0 +1,31 @@
+// Copyright (c) 2016 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::net::SocketAddr;
+
+use num_cpus;
+
+pub trait DataStoreCfg {
+    fn default_connection_retry_ms() -> u64 {
+        5_000
+    }
+
+    fn default_pool_size() -> u32 {
+        (num_cpus::get() * 8) as u32
+    }
+
+    fn connection_retry_ms(&self) -> u64;
+    fn connection_url(&self) -> String;
+    fn pool_size(&self) -> u32;
+}

--- a/components/builder-db/src/data_store.rs
+++ b/components/builder-db/src/data_store.rs
@@ -1,0 +1,31 @@
+// Copyright (c) 2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::error;
+use std::convert::From;
+
+use pool::Pool;
+use migration::Migrator;
+use error::Error;
+
+pub trait DataStore<E: From<Error>> {
+    fn migrator(&self) -> &Migrator;
+
+    fn pool(&self) -> &Pool;
+
+    fn setup(&self) -> Result<(), E> {
+        let result = self.migrator().setup()?;
+        Ok(result)
+    }
+}

--- a/components/builder-db/src/error.rs
+++ b/components/builder-db/src/error.rs
@@ -1,0 +1,93 @@
+// Copyright (c) 2016 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::error;
+use std::fmt;
+use std::result;
+
+use r2d2;
+use postgres;
+
+#[derive(Debug)]
+pub enum Error {
+    ConnectionTimeout(r2d2::GetTimeout),
+    FunctionCreate(postgres::error::Error),
+    FunctionRun(postgres::error::Error),
+    Migration(postgres::error::Error),
+    MigrationCheck(postgres::error::Error),
+    MigrationTable(postgres::error::Error),
+    MigrationTracking(postgres::error::Error),
+    PostgresConnect(postgres::error::ConnectError),
+    SchemaCreate(postgres::error::Error),
+    SetSearchPath(postgres::error::Error),
+    TransactionCreate(postgres::error::Error),
+    TransactionCommit(postgres::error::Error),
+}
+
+pub type Result<T> = result::Result<T, Error>;
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let msg = match *self {
+            Error::ConnectionTimeout(ref e) => format!("Connection timeout, {}", e),
+            Error::FunctionCreate(ref e) => format!("Error creating a function: {}", e),
+            Error::FunctionRun(ref e) => format!("Error running a function: {}", e),
+            Error::Migration(ref e) => format!("Error executing migration: {}", e),
+            Error::MigrationCheck(ref e) => format!("Error checking if a migration has run: {}", e),
+            Error::MigrationTable(ref e) => {
+                format!("Error creating migration tracking table: {}", e)
+            }
+            Error::MigrationTracking(ref e) => {
+                format!("Error updating migration tracking table: {}", e)
+            }
+            Error::PostgresConnect(ref e) => format!("Postgres connection error: {}", e),
+            Error::SchemaCreate(ref e) => format!("Error creating schema: {}", e),
+            Error::SetSearchPath(ref e) => format!("Error setting local search path: {}", e),
+            Error::TransactionCreate(ref e) => format!("Error creating transaction: {}", e),
+            Error::TransactionCommit(ref e) => format!("Error committing transaction: {}", e),
+        };
+        write!(f, "{}", msg)
+    }
+}
+
+impl error::Error for Error {
+    fn description(&self) -> &str {
+        match *self {
+            Error::ConnectionTimeout(ref e) => e.description(),
+            Error::FunctionCreate(_) => "Error creating database function",
+            Error::FunctionRun(_) => "Error running a database function",
+            Error::Migration(_) => "Error executing migration",
+            Error::MigrationCheck(_) => "Error checking if a migration has run",
+            Error::MigrationTable(_) => "Error creat2ing migration tracking table",
+            Error::MigrationTracking(_) => "Error updating migration tracking table",
+            Error::PostgresConnect(ref e) => e.description(),
+            Error::SchemaCreate(_) => "Error creating a schema",
+            Error::SetSearchPath(_) => "Error setting local search path",
+            Error::TransactionCreate(_) => "Error creating a transaction",
+            Error::TransactionCommit(_) => "Error committing a transaction",
+        }
+    }
+}
+
+impl From<r2d2::GetTimeout> for Error {
+    fn from(err: r2d2::GetTimeout) -> Self {
+        Error::ConnectionTimeout(err)
+    }
+}
+
+impl From<postgres::error::ConnectError> for Error {
+    fn from(err: postgres::error::ConnectError) -> Self {
+        Error::PostgresConnect(err)
+    }
+}

--- a/components/builder-db/src/lib.rs
+++ b/components/builder-db/src/lib.rs
@@ -1,0 +1,74 @@
+// Copyright (c) 2016 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! # Builder database design
+//!
+//! The database is designed to scale vertically, but is set up to allow for
+//! horizontal partitioning in the future.
+//!
+//! The tables are denormalized. Rather than follow the typical 3-4nf style, we
+//! accept duplication of data in order to ensure speedy retrieval.
+//!
+//!   * Joins are strictly forbidden. Prefer arrays comprised of natural keys, or of
+//!     hstore/jsonb.
+//!   * Database activity is driven by stored procedure; no raw queries in normal
+//!     course of events.
+//!   * The application itself is responsible for the schema; mirgrations are inline,
+//!     and any service that needs it can upgrade the database.
+//!   * Roll forward schema changes only. You can add columns, you can migrate data,
+//!     but you can't remove columns.
+//!   * All tables must include `created_at` and `updated_at`, as they are
+//!     automatically managed
+//!
+//! The `builder-db` module provides the backend for all database access - it provides:
+//!
+//! * Connection pooling
+//! * Migrations
+//! * Code for checking the migrations of registered backends
+//! * Shared test harness for crates that consume it
+//!
+//! In individual services, you implement a data_store module, which defines the
+//! schema, the procedures, the migrations, and the wrapper functions allowing your
+//! service handlers to work.
+//!
+//! ## A sidebar about stored procedures
+//!
+//! We drive much of the database access through stored procedures. It's controversial - we get it. Here is why we're doing it:
+//!
+//! 1. We want extensive test coverage of the database, and its migrations. It's a requirement.
+//! 1. We want the service itself to handle migrations at boot. It's automatic.
+//! 1. Versioned stored procedures will enforce several of the above rules - the big one being that only append-style migrations are allowed to tables. If you try and build a migration that breaks a query, the migration will fail inside its transaction, with the database being unharmed.
+//! 1. Access to the database through the stored procedure calls means we can use the same functions for maintenance as required.
+//! 1. We can ensure that a release of the service that manages a database component uses only the functions it was designed for - when the service upgrades, it gets the upgraded functions. Rollbacks will work cleanly.
+//! 1. In postgresql, and plpgsql function is automatically prepped by the query parser and analyzer. This means that, in general, they are as fast as a prepared statement, all the time, without having to actually build a prepared statement per-connection.
+//!
+//! Answers to common questions:
+//!
+//! 1. Q: Isn't this a lot of ceremony? A: Yes. We think its worth it.
+//! 1. Q: I don't know plpgsql. A: That's not a question. It's not hard. You learned Rust to get here :)
+//! 1. Q: Won't this impact database performance? A: Probably, but in a positive way. Think about it - 99% of the time, you run the same queries all the time. This is the equivalent of having them prepared in advance for you all the time.
+//! 1. Q: But what about those horror stories? A: The horror stories are about encoding your business logic in the database. For example, doing complex transformations on the data, or map reducing it, or all kinds of other crazy business. Both our application and our access patterns mean we likely won't need to do a whole lot of that.
+//!
+
+#[macro_use]
+extern crate log;
+extern crate r2d2;
+extern crate r2d2_postgres;
+extern crate postgres;
+
+pub mod error;
+pub mod migration;
+pub mod pool;
+pub mod data_store;
+pub mod test;

--- a/components/builder-db/src/migration.rs
+++ b/components/builder-db/src/migration.rs
@@ -1,0 +1,80 @@
+// Copyright (c) 2016 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use error::{Error, Result};
+use pool::Pool;
+
+#[derive(Debug)]
+pub struct Migrator<'a> {
+    pool: &'a Pool,
+}
+
+impl<'a> Migrator<'a> {
+    pub fn new(pool: &'a Pool) -> Migrator {
+        Migrator { pool: pool }
+    }
+
+    pub fn setup(&self) -> Result<()> {
+        let conn = self.pool.get()?;
+        conn.execute(r#"CREATE TABLE IF NOT EXISTS builder_db_migrations (
+            prefix text NOT NULL,
+            sequence_number bigint NOT NULL,
+            created_at timestamptz DEFAULT now(),
+            updated_at timestamptz,
+            PRIMARY KEY(prefix, sequence_number)
+        )"#,
+                     &[])
+            .map_err(Error::MigrationTable)?;
+        conn.execute(r#"CREATE OR REPLACE FUNCTION migration_has_run_v1(p text, sn bigint) RETURNS bool AS $$
+        DECLARE
+            result BOOLEAN;
+        BEGIN
+            SELECT true FROM builder_db_migrations WHERE prefix = p AND sequence_number = sn INTO result;
+            RETURN result;
+        END
+        $$ LANGUAGE plpgsql
+        "#,
+                     &[])
+            .map_err(Error::FunctionCreate)?;
+        Ok(())
+    }
+
+    pub fn check_migration_has_run(&self,
+                                   prefix: &str,
+                                   sequence_number: i64)
+                                   -> Result<Option<bool>> {
+        let conn = self.pool.get()?;
+        let check_result = conn.query("SELECT migration_has_run_v1($1, $2)",
+                   &[&prefix, &sequence_number])
+            .map_err(Error::MigrationCheck)?;
+
+        Ok(check_result.get(0).get(0))
+    }
+
+    pub fn migrate(&self, prefix: &str, sequence_number: i64, sql: &str) -> Result<()> {
+        let result = self.check_migration_has_run(prefix, sequence_number)?;
+        if !result.is_some() {
+            let conn = self.pool.get()?;
+            let tr = conn.transaction().map_err(Error::TransactionCreate)?;
+            tr.execute(sql, &[]).map_err(Error::Migration)?;
+            tr.execute("INSERT INTO builder_db_migrations (prefix, sequence_number) VALUES \
+                          ($1, $2)",
+                         &[&prefix, &sequence_number])
+                .map_err(Error::MigrationTracking)?;
+            tr.commit().map_err(Error::TransactionCommit)?;
+        }
+
+        Ok(())
+    }
+}

--- a/components/builder-db/src/pool.rs
+++ b/components/builder-db/src/pool.rs
@@ -1,0 +1,94 @@
+// Copyright (c) 2016 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::ops::{Deref, DerefMut};
+use std::result;
+use std::sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
+use std::thread;
+use std::time::Duration;
+
+use r2d2;
+use r2d2_postgres::{self, PostgresConnectionManager, TlsMode};
+use postgres::transaction::Transaction;
+use postgres;
+
+use error::{Error, Result};
+
+// We will use this to allocate test schmeas
+static GLOBAL_SCHEMA_COUNT: AtomicUsize = ATOMIC_USIZE_INIT;
+
+#[derive(Debug, Clone)]
+pub struct Pool {
+    inner: r2d2::Pool<PostgresConnectionManager>,
+}
+
+impl Pool {
+    pub fn new(connection_url: &str,
+               pool_size: u32,
+               connection_retry_ms: u64,
+               connection_timeout: Duration,
+               testing: bool)
+               -> Result<Pool> {
+        loop {
+            let pool_config_builder = r2d2::Config::builder()
+                .pool_size(pool_size)
+                .connection_timeout(connection_timeout);
+            let pool_config = if testing {
+                pool_config_builder.connection_customizer(Box::new(TestConnectionCustomizer {}))
+                    .build()
+            } else {
+                pool_config_builder.build()
+            };
+            let manager = PostgresConnectionManager::new(connection_url, TlsMode::None)?;
+            match r2d2::Pool::new(pool_config, manager) {
+                Ok(pool) => return Ok(Pool { inner: pool }),
+                Err(e) => {
+                    error!("Error initializing connection pool to Postgres, will retry: {}",
+                           e)
+                }
+            }
+            thread::sleep(Duration::from_millis(connection_retry_ms));
+        }
+    }
+}
+
+impl Deref for Pool {
+    type Target = r2d2::Pool<PostgresConnectionManager>;
+
+    fn deref(&self) -> &r2d2::Pool<PostgresConnectionManager> {
+        &self.inner
+    }
+}
+
+impl DerefMut for Pool {
+    fn deref_mut(&mut self) -> &mut r2d2::Pool<PostgresConnectionManager> {
+        &mut self.inner
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct TestConnectionCustomizer;
+
+impl r2d2::CustomizeConnection<postgres::Connection, r2d2_postgres::Error> for TestConnectionCustomizer {
+    fn on_acquire(&self, conn: &mut postgres::Connection) -> result::Result<(), r2d2_postgres::Error> {
+        let schema_number = GLOBAL_SCHEMA_COUNT.fetch_add(1, Ordering::SeqCst);
+        let sql_drop_schema = format!("DROP SCHEMA IF EXISTS builder_db_test_{} CASCADE", schema_number);
+        let sql_create_schema = format!("CREATE SCHEMA builder_db_test_{}", schema_number);
+        let sql_search_path = format!("SET search_path TO builder_db_test_{}", schema_number);
+        conn.execute(&sql_drop_schema, &[]).map_err(r2d2_postgres::Error::Other)?;
+        conn.execute(&sql_create_schema, &[]).map_err(r2d2_postgres::Error::Other)?;
+        conn.execute(&sql_search_path, &[]).map_err(r2d2_postgres::Error::Other)?;
+        Ok(())
+    }
+}

--- a/components/builder-db/tests/data_store/mod.rs
+++ b/components/builder-db/tests/data_store/mod.rs
@@ -1,0 +1,98 @@
+// Copyright (c) 2016 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use db::pool::Pool;
+use db::migration::Migrator;
+use db::error::{Result, Error};
+use db::data_store::DataStore;
+
+#[derive(Debug)]
+struct MusicDB {
+    pool: Pool,
+}
+
+impl MusicDB {
+    fn new(pool: Pool) -> MusicDB {
+        MusicDB { pool: pool }
+    }
+
+    fn setup(&self) -> Result<()> {
+        let migrator = Migrator::new(&self.pool);
+        migrator.setup()?;
+        migrator.migrate("music",
+                     1,
+                     r#"CREATE TABLE IF NOT EXISTS music (
+            band text PRIMARY KEY,
+            style text,
+            created_at timestamptz DEFAULT now(),
+            updated_at timestamptz
+        )"#)?;
+        migrator.migrate("music",
+                     2,
+                     r#"CREATE VIEW metal_bands AS 
+            SELECT band FROM music WHERE style = 'metal'"#)?;
+        migrator.migrate("music",
+                     3,
+                     r#"CREATE OR REPLACE FUNCTION insert_band_v1(band text, style text) RETURNS void AS $$
+                         BEGIN
+                            INSERT INTO music (band, style) VALUES (band, style);
+                         END
+                         $$ LANGUAGE plpgsql"#)?;
+        Ok(())
+    }
+
+    fn insert_band(&self, band: &str, style: &str) -> Result<()> {
+        let conn = self.pool.get()?;
+        conn.execute("SELECT insert_band_v1($1, $2)", &[&band, &style])
+            .map_err(Error::FunctionRun)?;
+        Ok(())
+    }
+
+    fn get_metal_bands(&self) -> Result<Vec<String>> {
+        let conn = self.pool.get()?;
+        let results = conn.query("SELECT band FROM metal_bands", &[]).map_err(Error::FunctionRun)?;
+        Ok(results.into_iter().map(|r| r.get(0)).collect())
+    }
+}
+
+#[test]
+fn create() {
+    with_pool!(pool, {
+        let mdb = MusicDB::new(pool);
+        mdb.setup().expect("Failed to migrate the music database");
+    });
+}
+
+#[test]
+fn insert() {
+    with_pool!(pool, {
+        let mdb = MusicDB::new(pool);
+        mdb.setup().expect("Failed to migrate the music database");
+        mdb.insert_band("katatonia", "metal").expect("Failed to migrate the music database");
+        mdb.insert_band("nirvana", "grunge").expect("Failed to migrate the music database");
+    });
+}
+
+#[test]
+fn query() {
+    with_pool!(pool, {
+        let mdb = MusicDB::new(pool);
+        mdb.setup().expect("Failed to migrate the music database");
+        mdb.insert_band("katatonia", "metal").expect("Failed to migrate the music database");
+        mdb.insert_band("nirvana", "grunge").expect("Failed to migrate the music database");
+        let metal_bands = mdb.get_metal_bands().expect("Failed to get metal bands");
+        assert!(metal_bands.contains(&String::from("katatonia")),
+                "There are no metal bands present, and katatonia is certainly a metal band");
+    });
+}

--- a/components/builder-db/tests/db/pg_hba.conf
+++ b/components/builder-db/tests/db/pg_hba.conf
@@ -1,0 +1,1 @@
+host all all 127.0.0.1/24 trust

--- a/components/builder-db/tests/db/user.toml
+++ b/components/builder-db/tests/db/user.toml
@@ -1,0 +1,3 @@
+listen_addresses = "127.0.0.1"
+search_path = "pg_temp"
+hba_file = "/hab/svc/postgresql/pg_hba.conf"

--- a/components/builder-db/tests/integration.rs
+++ b/components/builder-db/tests/integration.rs
@@ -1,0 +1,38 @@
+// Copyright (c) 2016 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[macro_use]
+extern crate habitat_builder_db as db;
+
+use std::time::Duration;
+
+mod pool {
+    use std::time::Duration;
+    use db::pool::Pool;
+    use db::test::init;
+
+    #[test]
+    fn creation() {
+        init::create_database();
+        let p = Pool::new("postgresql://hab@127.0.0.1/builder_db_test",
+                          1,
+                          300,
+                          Duration::from_secs(3600),
+                          false)
+            .expect("Failed to create pool");
+    }
+}
+
+mod migration;
+mod data_store;

--- a/components/builder-db/tests/migration/mod.rs
+++ b/components/builder-db/tests/migration/mod.rs
@@ -1,0 +1,64 @@
+// Copyright (c) 2016 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use db::migration::Migrator;
+
+#[test]
+fn setup() {
+    with_pool!(pool, {
+        let migrator = Migrator::new(&pool);
+        migrator.setup().expect("Migration setup failed");
+        migrator.setup().expect("Migration setup must be idempotent");
+    });
+}
+
+#[test]
+fn migrate() {
+    with_migration!(pool, migration, {
+        migration.migrate("metal",
+                     1,
+                     r#"CREATE TABLE bands (
+                        name text PRIMARY KEY,
+                        style text
+                     )"#)
+            .expect("Migration should be run successfully");
+
+        // Running the same migration twice should not fail, due to the internal migration checking
+        // logic.
+        migration.migrate("metal",
+                     1,
+                     r#"CREATE TABLE bands (
+                        name text PRIMARY KEY,
+                        style text
+                     )"#)
+            .expect("Migration should pass if its sequence number has been used, even if it \
+                     should fail by sql");
+    });
+
+    // ml.migrate("packages", 1, r#"CREATE TABLE packages (
+    //     ident text PRIMARY KEY,
+    //     origin text,
+    //     name text,
+    //     version text,
+    //     release text,
+    //     checksum text,
+    //     manifest text,
+    //     deps text[],
+    //     tdeps text[],
+    //     exposes integer[],
+    //     config text,
+    //     created_at timestamptz DEFAULT now(),
+    //     updated_at timestamptz,
+    // )"#);
+}


### PR DESCRIPTION
This commit adds a builder-db component. It serves as the base layer for
using PostgreSQL for persistence for builder services. Currently, it
provides 3 things:

* A simple `Pool`, which governs access to the database
* A `Migrator`, which handles database migrations
* A `test` namespace, which exports macros and functionality neccessary
  to build integration tests for services which use access the database

The top level module documentation includes some advice on design and
usage of the database within builder.

To run the test suite, you must first, in a separate terminal:

```sh
$ mkdir -p /hab/svc/postgresql
$ cp components/builder-db/tests/db/* /hab/svc/postgresql
$ hab start core/postgresql
```

You can then use `cargo test` as normal.

As we gain more experience writing the service components, I expect we
will automate that part of the process - hence, I'm leaving it out of
the formal documentation for now.

Signed-off-by: Adam Jacob <adam@chef.io>