### PR TITLE
[http-client] Restore CA discovery logic when configuring SSL client.

### DIFF
--- a/components/http-client/build.rs
+++ b/components/http-client/build.rs
@@ -11,7 +11,9 @@ mod inner {
     pub fn main() {
         let src = env::var("SSL_CERT_FILE").unwrap();
         let dst = Path::new(&env::var("OUT_DIR").unwrap()).join("cacert.pem");
-        fs::copy(src, dst).unwrap();
+        if !dst.exists() {
+            fs::copy(src, dst).unwrap();
+        }
     }
 }
 

--- a/components/http-client/src/api_client.rs
+++ b/components/http-client/src/api_client.rs
@@ -30,6 +30,7 @@ use url::Url;
 use error::Result;
 use net::ProxyHttpsConnector;
 use proxy::{ProxyInfo, proxy_unless_domain_exempted};
+use ssl;
 
 // Read and write TCP socket timeout for Hyper/HTTP client calls.
 const CLIENT_SOCKET_RW_TIMEOUT: u64 = 30;
@@ -298,9 +299,7 @@ fn ssl_connector(fs_root_path: Option<&Path>) -> Result<SslConnector> {
     options.toggle(SSL_OP_NO_SSLV2);
     options.toggle(SSL_OP_NO_SSLV3);
     options.toggle(SSL_OP_NO_COMPRESSION);
-    if let Some(path) = fs_root_path {
-        try!(conn.builder_mut().set_ca_file(path));
-    }
+    try!(ssl::set_ca(conn.builder_mut(), fs_root_path));
     conn.builder_mut().set_options(options);
     try!(conn.builder_mut().set_cipher_list("ALL!EXPORT!EXPORT40!EXPORT56!aNULL!LOW!RC4@STRENGTH"));
     Ok(conn.build())

--- a/components/http-client/src/lib.rs
+++ b/components/http-client/src/lib.rs
@@ -80,7 +80,7 @@ mod ssl {
 mod ssl {
     use std::path::Path;
 
-    use openssl::ssl::SslContext;
+    use openssl::ssl::SslContextBuilder;
 
     use error::Result;
 

--- a/components/http-client/src/lib.rs
+++ b/components/http-client/src/lib.rs
@@ -30,3 +30,62 @@ pub mod proxy;
 
 pub use api_client::ApiClient;
 pub use error::{Error, Result};
+
+#[cfg(target_os = "linux")]
+mod ssl {
+    use std::fs::{self, File};
+    use std::io::Write;
+    use std::path::Path;
+    use std::str::FromStr;
+
+    use hab_core::env;
+    use hab_core::fs::cache_ssl_path;
+    use hab_core::package::{PackageIdent, PackageInstall};
+    use openssl::ssl::SslContextBuilder;
+
+    use error::Result;
+
+    const CACERTS_PKG_IDENT: &'static str = "core/cacerts";
+    const CACERT_PEM: &'static str = include_str!(concat!(env!("OUT_DIR"), "/cacert.pem"));
+
+    pub fn set_ca(ctx: &mut SslContextBuilder, fs_root_path: Option<&Path>) -> Result<()> {
+        let cacerts_ident = try!(PackageIdent::from_str(CACERTS_PKG_IDENT));
+
+        if let Ok(_) = env::var("SSL_CERT_FILE") {
+            try!(ctx.set_default_verify_paths());
+        } else if let Ok(_) = env::var("SSL_CERT_DIR") {
+            try!(ctx.set_default_verify_paths());
+        } else if let Ok(pkg_install) = PackageInstall::load(&cacerts_ident, fs_root_path) {
+            let pkg_certs = pkg_install.installed_path().join("ssl/cert.pem");
+            debug!("Setting CA file for SSL context to: {}",
+                   pkg_certs.display());
+            try!(ctx.set_ca_file(pkg_certs));
+        } else {
+            let cached_certs = cache_ssl_path(fs_root_path).join("cert.pem");
+            if !cached_certs.exists() {
+                try!(fs::create_dir_all(cache_ssl_path(fs_root_path)));
+                debug!("Creating cached cacert.pem at: {}", cached_certs.display());
+                let mut file = try!(File::create(&cached_certs));
+                try!(file.write_all(CACERT_PEM.as_bytes()));
+            }
+            debug!("Setting CA file for SSL context to: {}",
+                   cached_certs.display());
+            try!(ctx.set_ca_file(cached_certs));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+mod ssl {
+    use std::path::Path;
+
+    use openssl::ssl::SslContext;
+
+    use error::Result;
+
+    pub fn set_ca(ctx: &mut SslContextBuilder, _fs_root_path: Option<&Path>) -> Result<()> {
+        try!(ctx.set_default_verify_paths());
+        Ok(())
+    }
+}


### PR DESCRIPTION
This resolves a runtime bug triggered when `"/"` is passed into an unsafe OpenSSL C block which is expecting a path to a CA certs file. Instead, we continue to use the original fallback logic of looking at environment variables, a `core/cacerts` package and an inlined copy to ensure that the Hyper client is properly wired no matter what the operating system.