### PR TITLE
Add hab-spider (package graph builder)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,6 +192,11 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "fixedbitset"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "fnv"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -272,6 +277,22 @@ dependencies = [
  "toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "walkdir 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "hab-spider"
+version = "0.1.0"
+dependencies = [
+ "clap 2.19.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "habitat_builder_protocol 0.0.0",
+ "habitat_core 0.0.0",
+ "libarchive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "petgraph 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1017,6 +1038,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordermap"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "pbr"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1064,6 +1090,15 @@ dependencies = [
 name = "phf_shared"
 version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "petgraph"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "fixedbitset 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ordermap 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "pkg-config"
@@ -1727,6 +1762,7 @@ dependencies = [
 "checksum error 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "a6e606f14042bb87cc02ef6a14db6c90ab92ed6f62d87e69377bc759fd7987cc"
 "checksum error-chain 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "318cb3c71ee4cdea69fdc9e15c173b245ed6063e1709029e8fd32525a881120f"
 "checksum fallible-iterator 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "5d48ab1bc11a086628e8cc0cc2c2dc200b884ac05c4b48fb71d6036b6999ff1d"
+"checksum fixedbitset 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "88c3c33fc4c00db33f5174eb98aea809c4c007db0b71351d810a7e094ea3b64d"
 "checksum fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6cc484842f1e2884faf56f529f960cc12ad8c71ce96cc7abba0a067c98fee344"
 "checksum gcc 0.3.41 (registry+https://github.com/rust-lang/crates.io-index)" = "3689e1982a563af74960ae3a4758aa632bb8fd984cfc3cc3b60ee6109477ab6e"
 "checksum gdi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0912515a8ff24ba900422ecda800b52f4016a56251922d397c576bf92c690518"
@@ -1771,12 +1807,14 @@ dependencies = [
 "checksum openssl 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0c00da69323449142e00a5410f0e022b39e8bbb7dc569cee8fc6af279279483c"
 "checksum openssl-probe 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "756d49c8424483a3df3b5d735112b4da22109ced9a8294f1f5cdf80fb3810919"
 "checksum openssl-sys 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b1482f9a06f56c906007e17ea14d73d102210b5d27bc948bf5e175f493f3f7c3"
+"checksum ordermap 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "2bbbbe8a0d58a4c17b279401ba7aef107deac26d7ef07ff0008f69eb17ae97bf"
 "checksum pbr 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4f327770e4bd53a8889e8db2191aa84d83761540bac99759ec87a021ac8c61be"
 "checksum pbr 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9f37516f7ab051df67430a6572735d7992fe74dde52554495eec459fb57da41f"
 "checksum persistent 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c9c94f2ef72dc272c6bcc8157ccf2bc7da14f4c58c69059ac2fc48492d6916"
 "checksum pest 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0a6dda33d67c26f0aac90d324ab2eb7239c819fc7b2552fe9faa4fe88441edc8"
 "checksum phf 0.7.20 (registry+https://github.com/rust-lang/crates.io-index)" = "0c6afb2057bb5f846a7b75703f90bc1cef4970c35209f712925db7768e999202"
 "checksum phf_shared 0.7.20 (registry+https://github.com/rust-lang/crates.io-index)" = "286385a0e50d4147bce15b2c19f0cf84c395b0e061aaf840898a7bf664c2cfb7"
+"checksum petgraph 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "284bb4b0b61d2b0aba0202aad4d9625a5a2e7f9840dc4353709cbcfe9ae57bbd"
 "checksum pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8cee804ecc7eaf201a4a207241472cc870e825206f6c031e3ee2a72fa425f2fa"
 "checksum plugin 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "1a6a0dc3910bc8db877ffed8e457763b317cf880df4ae19109b9f77d277cf6e0"
 "checksum postgres 0.13.5 (registry+https://github.com/rust-lang/crates.io-index)" = "585ca978431cddac0aa926246f18fe30a47401eabbe9bbda573dc60389c10ea1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,4 +22,5 @@ members = [
   "components/butterfly",
   "components/butterfly-test",
   "components/hab-butterfly",
+  "components/hab-spider"
 ]

--- a/components/hab-spider/Cargo.toml
+++ b/components/hab-spider/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "hab-spider"
+version = "0.1.0"
+authors = ["Salim Alam <salam@chef.io>"]
+workspace = "../../"
+
+[dependencies]
+log = "*"
+env_logger = "*"
+petgraph = "*"
+walkdir = "*"
+libarchive = "*"
+time = "*"
+clap = "2"
+
+[dependencies.habitat_core]
+path = "../core"
+
+[dependencies.habitat_builder_protocol]
+path = "../builder-protocol"
+
+[build-dependencies]
+pkg-config = "0.3"
+
+[profile.release]
+debug = true

--- a/components/hab-spider/README.md
+++ b/components/hab-spider/README.md
@@ -1,0 +1,63 @@
+# Spider
+
+Spider is a tool for building and querying the reverse dependency graph of
+Habitat packages. It is intended to be used primarily by Habitat developers.
+
+The tool scans the specified path in the file system to read metadata from .hart
+files to construct the graph. Graph construction can take a while for a large
+corpus of files.
+
+## Features
+
+* Interactive shell
+* Query the reverse dependency graph of a given package
+* Find the top packages that have the highest number of reverse dependencies
+* Find the fully qualified package names from a given search phrase
+* Print statistics about the reverse dependency graph
+
+## Usage
+
+To use it, do the following:
+
+```
+$ hab-spider <path to packages>
+```
+
+Once the tool starts up and completes reading the input files, it will
+present some basic stats and the open an interactive shell for commands.
+
+Example run (on a small dataset):
+
+```
+hab-spider pkgs
+Crawling packages... please wait.
+OK: 65 nodes, 63 edges (PT4.848970454S sec)
+
+Available commands: HELP, STATS, TOP, FIND, RDEPS, EXIT
+
+spider> help
+HELP           - print this message
+STATS          - print graph statistics
+TOP [<count>]  - print nodes with the most reverse dependencies
+FIND  <term>   - find packages that match the search term
+RDEPS <name>   - print the reverse dependencies for the package
+EXIT           - exit the application
+
+spider> stats
+Node count: 65
+Edge count: 63
+Connected components: 5
+Is cyclic: false
+
+spider> find cacerts
+OK: 1 items (PT0.000083179S sec)
+
+core/cacerts/2016.04.20/20160612081125
+
+spider> rdeps core/cacerts/2016.04.20/20160612081125
+OK: 3 items (PT0.000849052S sec)
+
+core/git/2.10.0/20160914215433
+chefconf/habitat-demo/0.0.1/20160709
+core/jfrog-cli/1.3.1/20160729210516
+```

--- a/components/hab-spider/src/main.rs
+++ b/components/hab-spider/src/main.rs
@@ -1,0 +1,192 @@
+
+// Copyright (c) 2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[macro_use]
+extern crate log;
+extern crate env_logger;
+extern crate time;
+extern crate petgraph;
+extern crate walkdir;
+extern crate habitat_core as hab_core;
+extern crate habitat_builder_protocol as protocol;
+extern crate clap;
+
+pub mod rdeps;
+pub mod spider;
+
+use std::io::{self, Write};
+use clap::{Arg, App};
+use time::PreciseTime;
+use spider::Spider;
+
+fn main() {
+    env_logger::init().unwrap();
+
+    let matches = App::new("hab-spider")
+        .version("0.1.0")
+        .about("Habitat package graph builder")
+        .arg(Arg::with_name("PATH")
+            .help("The path to the packages root")
+            .required(true)
+            .index(1))
+        .get_matches();
+
+    let path = matches.value_of("PATH").unwrap();
+
+    println!("Crawling packages... please wait.");
+
+    let mut spider = Spider::new(&path);
+    let start_time = PreciseTime::now();
+    let (ncount, ecount) = spider.crawl();
+    let end_time = PreciseTime::now();
+
+    println!("OK: {} nodes, {} edges ({} sec)",
+             ncount,
+             ecount,
+             start_time.to(end_time));
+
+    println!("\nAvailable commands: HELP, STATS, TOP, FIND, RDEPS, EXIT\n");
+
+    let mut done = false;
+    while !done {
+        print!("spider> ");
+        io::stdout().flush().ok().expect("Could not flush stdout");
+
+        let mut cmd = String::new();
+        io::stdin().read_line(&mut cmd).unwrap();
+
+        let v: Vec<&str> = cmd.trim_right().split_whitespace().collect();
+
+        if v.len() > 0 {
+            match v[0].to_lowercase().as_str() {
+                "help" => do_help(),
+                "stats" => do_stats(&spider),
+                "top" => {
+                    let count = if v.len() < 2 {
+                        10
+                    } else {
+                        v[1].parse::<usize>().unwrap()
+                    };
+                    do_top(&spider, count);
+                }
+                "find" => {
+                    if v.len() < 2 {
+                        println!("Missing search term\n")
+                    } else {
+                        let max = if v.len() > 2 {
+                            v[2].parse::<usize>().unwrap()
+                        } else {
+                            10
+                        };
+                        do_find(&spider, v[1].to_lowercase().as_str(), max)
+                    }
+                }
+                "rdeps" => {
+                    if v.len() < 2 {
+                        println!("Missing package name\n")
+                    } else {
+                        let max = if v.len() > 2 {
+                            v[2].parse::<usize>().unwrap()
+                        } else {
+                            10
+                        };
+                        do_rdeps(&spider, v[1].to_lowercase().as_str(), max)
+                    }
+                }
+                "exit" => done = true,
+                _ => println!("Unknown command\n"),
+            }
+        }
+    }
+}
+
+fn do_help() {
+    println!("COMMANDS:");
+    println!("  help                    Print this message");
+    println!("  stats                   Print graph statistics");
+    println!("  top [<count>]           Print nodes with the most reverse dependencies");
+    println!("  find  <term> [<max>]    Find packages that match the search term, up to max items");
+    println!("  rdeps <name> [<max>]    Print the reverse dependencies for the package, up to max");
+    println!("  exit                    Exit the application\n");
+}
+
+fn do_stats(spider: &Spider) {
+    let stats = spider.stats();
+
+    println!("Node count: {}", stats.node_count);
+    println!("Edge count: {}", stats.edge_count);
+    println!("Connected components: {}", stats.connected_comp);
+    println!("Is cyclic: {}\n", stats.is_cyclic);
+}
+
+fn do_top(spider: &Spider, count: usize) {
+    let start_time = PreciseTime::now();
+    let top = spider.top(count);
+    let end_time = PreciseTime::now();
+
+    println!("OK: {} items ({} sec)\n",
+             top.len(),
+             start_time.to(end_time));
+
+    for (name, count) in top {
+        println!("{}: {}", name, count);
+    }
+    println!("");
+}
+
+fn do_find(spider: &Spider, phrase: &str, max: usize) {
+    let start_time = PreciseTime::now();
+    let mut v = spider.search(phrase);
+    let end_time = PreciseTime::now();
+
+    println!("OK: {} items ({} sec)\n", v.len(), start_time.to(end_time));
+
+    if v.is_empty() {
+        println!("No matching packages found")
+    } else {
+        if v.len() > max {
+            v.drain(max..);
+        }
+        for s in v {
+            println!("{}", s);
+        }
+    }
+
+    println!("");
+}
+
+fn do_rdeps(spider: &Spider, name: &str, max: usize) {
+    let start_time = PreciseTime::now();
+
+    match spider.rdeps(name) {
+        Some(mut rdeps) => {
+            let end_time = PreciseTime::now();
+            println!("OK: {} items ({} sec)\n",
+                     rdeps.len(),
+                     start_time.to(end_time));
+
+            if rdeps.len() > max {
+                rdeps.drain(max..);
+            }
+
+            for s in rdeps {
+                println!("{}", s);
+            }
+        }
+        None => println!("No entries found"),
+    }
+
+    println!("");
+}

--- a/components/hab-spider/src/rdeps.rs
+++ b/components/hab-spider/src/rdeps.rs
@@ -1,0 +1,119 @@
+// Copyright (c) 2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::{HashMap, HashSet};
+
+use petgraph::Graph;
+use petgraph::graph::NodeIndex;
+use petgraph::algo::{toposort, is_cyclic_directed};
+use petgraph::visit::{Bfs, Walker};
+
+#[derive(Debug, PartialEq)]
+pub enum GraphErr {
+    GraphCyclic,
+}
+
+pub type GType = usize;
+
+pub fn rdeps(g: &Graph<GType, GType>, n: NodeIndex) -> Result<Vec<GType>, GraphErr> {
+    if is_cyclic_directed(&g) {
+        error!("Input graph should not be cyclic!");
+        return Err(GraphErr::GraphCyclic);
+    }
+
+    // unwrap should never panic as we pre-check for cycle
+    let t: Vec<GType> = toposort(&g, None).unwrap().iter().map(|k| k.index()).collect();
+
+    let bfs: Vec<GType> = Bfs::new(&g, n).iter(&g).map(|k| k.index()).collect();
+
+    let mut topo_map: HashMap<usize, usize> = HashMap::new(); // Node -> Topo index
+
+    for (i, j) in t.iter().enumerate() {
+        topo_map.insert(*j, i);
+    }
+
+    // Collect BFS nodes in topological order
+    let start: usize = n.index();
+    let mut curr: usize = *topo_map.get(&start).unwrap(); // Where to start in topo array
+
+    let mut bfs_set: HashSet<&usize> = bfs.iter().collect();
+    let mut v: Vec<GType> = Vec::new();
+
+    bfs_set.remove(&start);
+    while !bfs_set.is_empty() {
+        if bfs_set.contains(&t[curr]) {
+            v.push(t[curr]);
+            bfs_set.remove(&t[curr]);
+        }
+        curr = curr + 1;
+    }
+
+    Ok(v)
+}
+
+#[cfg(test)]
+mod tests {
+    use petgraph::Graph;
+    use rdeps::*;
+
+    #[test]
+    fn fails_with_cyclic_graph() {
+        let mut deps = Graph::<usize, usize>::new();
+        let a = deps.add_node(10);
+        let b = deps.add_node(11);
+        let c = deps.add_node(12);
+
+        deps.extend_with_edges(&[(a, b), (b, c), (c, a)]);
+
+        match rdeps(&deps, a) {
+            Ok(_) => panic!("Cyclic graph should fail!"),
+            Err(e) => assert_eq!(e, GraphErr::GraphCyclic),
+        }
+    }
+
+    #[test]
+    fn basic_graph_works() {
+        let mut deps = Graph::<usize, usize>::new();
+        let a = deps.add_node(10);
+        let b = deps.add_node(11);
+        let c = deps.add_node(12);
+        let d = deps.add_node(13);
+        let e = deps.add_node(14);
+        let f = deps.add_node(15);
+        let g = deps.add_node(16);
+        let h = deps.add_node(17);
+
+        deps.extend_with_edges(&[(a, c), (b, c), (c, f), (c, e), (d, e), (e, f), (g, h)]);
+
+        match rdeps(&deps, a) {
+            Ok(v) => {
+                static EXPECTED: &'static [usize] = &[2, 4, 5];
+                assert_eq!(v.as_slice(), EXPECTED);
+            }
+            Err(e) => {
+                panic!("Failed with error: {:?}", e);
+            }
+        }
+
+        match rdeps(&deps, b) {
+            Ok(v) => {
+                static EXPECTED: &'static [usize] = &[2, 4, 5];
+                assert_eq!(v.as_slice(), EXPECTED);
+            }
+            Err(e) => {
+                panic!("Failed with error: {:?}", e);
+            }
+        }
+    }
+}

--- a/components/hab-spider/src/spider.rs
+++ b/components/hab-spider/src/spider.rs
@@ -1,0 +1,224 @@
+// Copyright (c) 2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::path::PathBuf;
+use std::collections::{HashMap, BinaryHeap};
+use std::cmp::Ordering;
+use walkdir::WalkDir;
+use hab_core::package::{FromArchive, PackageArchive};
+use protocol::depotsrv;
+use petgraph::Graph;
+use petgraph::graph::NodeIndex;
+use petgraph::algo::{is_cyclic_directed, connected_components};
+
+use rdeps::rdeps;
+
+#[derive(Debug)]
+pub struct Stats {
+    pub node_count: usize,
+    pub edge_count: usize,
+    pub connected_comp: usize,
+    pub is_cyclic: bool,
+}
+
+#[derive(Eq)]
+struct HeapEntry {
+    pkg_index: usize,
+    rdep_count: usize,
+}
+
+impl Ord for HeapEntry {
+    fn cmp(&self, other: &HeapEntry) -> Ordering {
+        self.rdep_count.cmp(&other.rdep_count)
+    }
+}
+
+impl PartialOrd for HeapEntry {
+    fn partial_cmp(&self, other: &HeapEntry) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl PartialEq for HeapEntry {
+    fn eq(&self, other: &HeapEntry) -> bool {
+        self.pkg_index == other.pkg_index
+    }
+}
+
+pub struct Spider {
+    packages_path: PathBuf,
+    package_max: usize,
+    package_map: HashMap<String, (usize, NodeIndex)>,
+    package_names: Vec<String>,
+    graph: Graph<usize, usize>,
+}
+
+impl Spider {
+    pub fn new(path: &str) -> Self {
+        Spider {
+            packages_path: PathBuf::from(path),
+            package_max: 0,
+            package_map: HashMap::new(),
+            package_names: Vec::new(),
+            graph: Graph::<usize, usize>::new(),
+        }
+    }
+
+    fn generate_id(&mut self, name: &str) -> (usize, NodeIndex) {
+        let id = if self.package_map.contains_key(name) {
+            let val = *self.package_map.get(name).unwrap();
+            val
+        } else {
+            self.package_names.push(String::from(name.clone()));
+            assert_eq!(self.package_names[self.package_max], name);
+
+            let node_index = self.graph.add_node(self.package_max);
+            self.package_map.insert(String::from(name), (self.package_max, node_index));
+            self.package_max = self.package_max + 1;
+
+            (self.package_max - 1, node_index)
+        };
+
+        id
+    }
+
+    pub fn crawl(&mut self) -> (usize, usize) {
+        assert!(self.package_max == 0);
+
+        let mut directories = vec![];
+
+        for entry in WalkDir::new(&self.packages_path).follow_links(false) {
+            let entry = entry.unwrap();
+            if entry.metadata().unwrap().is_dir() {
+                directories.push(entry);
+                continue;
+            }
+
+            let mut archive = PackageArchive::new(PathBuf::from(entry.path()));
+
+            match archive.ident() {
+                Ok(_) => {
+                    match depotsrv::Package::from_archive(&mut archive) {
+                        Ok(o) => {
+                            let name = format!("{}", o.get_ident());
+                            let (pkg_id, pkg_node) = self.generate_id(&name);
+
+                            assert_eq!(pkg_id, pkg_node.index());
+                            debug!("{} ({})", name, pkg_id);
+
+                            let deps = o.get_deps();
+                            for dep in deps {
+                                let depname = format!("{}", dep);
+                                debug!("|_ {}", depname);
+                                let (_, dep_node) = self.generate_id(&depname);
+                                self.graph.extend_with_edges(&[(dep_node, pkg_node)]);
+                            }
+                        }
+                        Err(e) => error!("Error parsing package from archive: {:?}", e),
+                    }
+                }
+                Err(e) => {
+                    error!("Error reading, archive={:?} error={:?}", &archive, &e);
+                }
+            }
+            debug!("");
+        }
+
+        (self.graph.node_count(), self.graph.edge_count())
+    }
+
+    pub fn rdeps(&self, name: &str) -> Option<Vec<String>> {
+        let mut v = Vec::new();
+
+        match self.package_map.get(name) {
+            Some(&(_, pkg_node)) => {
+                match rdeps(&self.graph, pkg_node) {
+                    Ok(deps) => {
+                        for n in deps {
+                            v.push(self.package_names[n].clone());
+                        }
+                    }
+                    Err(e) => panic!("Error: {:?}", e),
+                }
+            }
+            None => return None,
+        }
+
+        Some(v)
+    }
+
+    // Mostly for debugging
+    pub fn rdeps_dump(&self) {
+        debug!("Reverse dependencies:");
+
+        for (pkg_name, pkg_id) in &self.package_map {
+            let (_, node) = *pkg_id;
+            debug!("{}", pkg_name);
+
+            match rdeps(&self.graph, node) {
+                Ok(v) => {
+                    for n in v {
+                        debug!("|_ {}", self.package_names[n]);
+                    }
+                }
+                Err(e) => panic!("Error: {:?}", e),
+            }
+        }
+    }
+
+    pub fn search(&self, phrase: &str) -> Vec<String> {
+        let v: Vec<String> =
+            self.package_names.iter().cloned().filter(|s| s.contains(phrase)).collect();
+
+        v
+    }
+
+    pub fn stats(&self) -> Stats {
+        Stats {
+            node_count: self.graph.node_count(),
+            edge_count: self.graph.edge_count(),
+            connected_comp: connected_components(&self.graph),
+            is_cyclic: is_cyclic_directed(&self.graph),
+        }
+    }
+
+    pub fn top(&self, max: usize) -> Vec<(String, usize)> {
+        let mut v = Vec::new();
+        let mut heap = BinaryHeap::new();
+
+        for (_, pkg_id) in &self.package_map {
+            let (index, node) = *pkg_id;
+
+            match rdeps(&self.graph, node) {
+                Ok(v) => {
+                    let he = HeapEntry {
+                        pkg_index: index,
+                        rdep_count: v.len(),
+                    };
+                    heap.push(he);
+                }
+                Err(e) => panic!("Error: {:?}", e),
+            }
+        }
+
+        let mut i = 0;
+        while (i < max) && !heap.is_empty() {
+            let he = heap.pop().unwrap();
+            v.push((self.package_names[he.pkg_index].clone(), he.rdep_count));
+            i = i + 1;
+        }
+
+        v
+    }
+}


### PR DESCRIPTION
Signed-off-by: Salim Alam <salam@chef.io>

hab-spider is a tool for constructing the hab package dependency graph and querying for reverse dependencies and other related statistics. It provides a simple interactive shell to be able to issue commands. It is primarily intended to be used by habitat developers.

![giphy](https://cloud.githubusercontent.com/assets/13542112/22315815/d93c8562-e31d-11e6-84ce-7f860c3b4cb8.gif)

