### PR TITLE
[hab,studio] Add noninteractive & no coloring modes via environment variables.

### DIFF
--- a/components/pkg-aci/bin/hab-pkg-aci.sh
+++ b/components/pkg-aci/bin/hab-pkg-aci.sh
@@ -73,14 +73,18 @@ USAGE:
 # exit_with "Something bad went down" 55
 # ```
 exit_with() {
-  case "${TERM:-}" in
-    *term | xterm-* | rxvt | screen | screen-*)
-      printf -- "\033[1;31mERROR: \033[1;37m$1\033[0m\n"
-      ;;
-    *)
-      printf -- "ERROR: $1\n"
-      ;;
-  esac
+  if [ "${HAB_NOCOLORING:-}" = "true" ]; then
+    printf -- "ERROR: $1\n"
+  else
+    case "${TERM:-}" in
+      *term | xterm-* | rxvt | screen | screen-*)
+        printf -- "\033[1;31mERROR: \033[1;37m$1\033[0m\n"
+        ;;
+      *)
+        printf -- "ERROR: $1\n"
+        ;;
+    esac
+  fi
   exit $2
 }
 

--- a/components/pkg-dockerize/bin/hab-pkg-dockerize.sh
+++ b/components/pkg-dockerize/bin/hab-pkg-dockerize.sh
@@ -60,14 +60,18 @@ USAGE:
 # exit_with "Something bad went down" 55
 # ```
 exit_with() {
-  case "${TERM:-}" in
-    *term | xterm-* | rxvt | screen | screen-*)
-      printf -- "\033[1;31mERROR: \033[1;37m$1\033[0m\n"
-      ;;
-    *)
-      printf -- "ERROR: $1\n"
-      ;;
-  esac
+  if [ "${HAB_NOCOLORING:-}" = "true" ]; then
+    printf -- "ERROR: $1\n"
+  else
+    case "${TERM:-}" in
+      *term | xterm-* | rxvt | screen | screen-*)
+        printf -- "\033[1;31mERROR: \033[1;37m$1\033[0m\n"
+        ;;
+      *)
+        printf -- "ERROR: $1\n"
+        ;;
+    esac
+  fi
   exit $2
 }
 

--- a/components/pkg-mesosize/bin/hab-pkg-mesosize.sh
+++ b/components/pkg-mesosize/bin/hab-pkg-mesosize.sh
@@ -79,14 +79,18 @@ ARGS:
 # exit_with "Something bad went down" 55
 # ```
 exit_with() {
-  case "${TERM:-}" in
-    *term | xterm-* | rxvt | screen | screen-*)
-      printf -- "\033[1;31mERROR: \033[1;37m$1\033[0m\n"
-      ;;
-    *)
-      printf -- "ERROR: $1\n"
-      ;;
-  esac
+  if [ "${HAB_NOCOLORING:-}" = "true" ]; then
+    printf -- "ERROR: $1\n"
+  else
+    case "${TERM:-}" in
+      *term | xterm-* | rxvt | screen | screen-*)
+        printf -- "\033[1;31mERROR: \033[1;37m$1\033[0m\n"
+        ;;
+      *)
+        printf -- "ERROR: $1\n"
+        ;;
+    esac
+  fi
   exit $2
 }
 

--- a/components/pkg-tarize/bin/hab-pkg-tarize.sh
+++ b/components/pkg-tarize/bin/hab-pkg-tarize.sh
@@ -69,14 +69,18 @@ ARGS:
 # exit_with "Something bad went down" 55
 # ```
 exit_with() {
-  case "${TERM:-}" in
-    *term | xterm-* | rxvt | screen | screen-*)
-      printf -- "\033[1;31mERROR: \033[1;37m$1\033[0m\n"
-      ;;
-    *)
-      printf -- "ERROR: $1\n"
-      ;;
-  esac
+  if [ "${HAB_NOCOLORING:-}" = "true" ]; then
+    printf -- "ERROR: $1\n"
+  else
+    case "${TERM:-}" in
+      *term | xterm-* | rxvt | screen | screen-*)
+        printf -- "\033[1;31mERROR: \033[1;37m$1\033[0m\n"
+        ;;
+      *)
+        printf -- "ERROR: $1\n"
+        ;;
+    esac
+  fi
   exit $2
 }
 

--- a/components/studio/libexec/hab-studio-type-default.sh
+++ b/components/studio/libexec/hab-studio-type-default.sh
@@ -7,7 +7,7 @@ studio_build_command="record \${1:-} $HAB_ROOT_PATH/bin/build"
 studio_run_environment=
 studio_run_command="$HAB_ROOT_PATH/bin/hab pkg exec core/hab-backline bash -l"
 
-pkgs="core/hab-backline"
+pkgs="${HAB_BACKLINE_PKG:-core/hab-backline}"
 
 run_user="hab"
 run_group="$run_user"

--- a/www/source/docs/reference/environment-vars.html.md
+++ b/www/source/docs/reference/environment-vars.html.md
@@ -11,6 +11,8 @@ This is a list of all environment variables that can be used to modify the opera
 | `HAB_AUTH_TOKEN` | build system | no default | Authorization token used to perform privileged operations against the depot, e.g. uploading packages or keys.
 | `HAB_CACHE_KEY_PATH` | build system, supervisor | `/hab/cache/keys` if running as root; `$HOME/.hab/cache/keys` if running as non-root | Cache directory for origin signing keys |
 | `HAB_DEPOT_URL` | build system, supervisor | `https://willem.habitat.sh/v1/depot` | The depot (or materialized view in the depot) used by the Habitat build system or supervisor |
+| `HAB_NOCOLORING` | build system | no default | If set to the lowercase string `"true"` this environment variable will unconditionally disable text coloring where possible |
+| `HAB_NONINTERACTIVE` | build system | no default | If set to the lowercase string `"true"` this environment variable will unconditionally disable interactive progress bars (i.e. "spinners") where possible |
 | `HAB_ORG` | supervisor | no default | Organization to use when running with [service group encryption](/docs/run-packages-security/#service-group-encryption)
 | `HAB_ORIGIN` | build system | no default | Origin used to build packages. The signing key for this origin is passed to the build system. |
 | `HAB_ORIGIN_KEYS` | build system | no default | Comma-separated list of origin keys to automatically share with the build system |
@@ -19,6 +21,9 @@ This is a list of all environment variables that can be used to modify the opera
 | `HAB_STUDIOS_HOME` | build system | `/hab/studios` if running as root; `$HOME/.hab/studios` if running as non-root | Directory in which to create build studios |
 | `HAB_STUDIO_ROOT` | build system | no default | Root of the current studio under `$HAB_STUDIOS_HOME`. Infrequently overridden. |
 | `HAB_USER` | supervisor | no default | User key to use when running with [service group encryption](/docs/run-packages-security/#service-group-encryption) |
+| `http_proxy` | build system, supervisor | no default | A URL for a local HTTP proxy server optionally supporting basic authentication |
+| `https_proxy` | build system, supervisor | no default | A URL for a local HTTPS proxy server optionally supporting basic authentication |
+| `no_proxy` | build system, supervisor | no default | A comma-separated list of domain exclusions for the `http_proxy` and `https_proxy` environment variables |
 
 # Customizing Studio
 


### PR DESCRIPTION
The primary use case driving this feature is running builds in a CI environment. Some logging streams do not cope well with progress bar style output which behave by using carriage returns to the terminal to set its cursor back to the start of the line and "redraw" the current line. These logging streams frequently start outputting each progress tick/redraw as a full new line and very quickly consume a large amount of output. In systems such as Travis there is a upper bound to the number of log lines provided back to the user. As we care about the build output not spinners of doom, we needed a way to turn these off.

This change adds a way for users of Habitat tooling (such as `hab`, `hab pkg build`, `hab studio`, etc.) to explicitly drop single-line progress bar indicators or to disable text coloring by setting 2 new environment variables. As this feature is targeted for CI environments, environment variables were used so that the command issued in CI is virtually identical to the command issued on a developer's workstation. Additionally, running a `hab pkg build` will invoke a `hab` process which invokes a `hab-studio` process which may contain further `hab` subprocess before completing. The amount of work required to only support explicit flags on all the related tools would have made this feature much more complex and error prone. The choice of prefixing these environment variables with `HAB_` ensures that there's almost no chance these variables would affect the build of any software and so can be safely passed over the Studio's barrier of isolation.

Currently, `hab`'s  UI system will check 2 things to determine its behavior:

* Coloring is determined by checking the `TERM` environment variable to check the local terminfo database. If the `TERM` supports color, then `hab` will add ansi coloring.
* Progress bars is determined by checking if the input and output streams (i.e. stdin, stdout, stderr) have a TTY assigned (using `libc::isatty()` or equivalent depending in platform).

This change checks an environment variable `HAB_NONINTERACTIVE` which if set to `"true"`, will override the default detection logic and tell the UI that it does *not* have a TTY assigned. As a consequence, downloading and uploading progress bars will be disabled.

Additionally, another environment variable `HAB_NOCOLORING` is checked, and if set to `"true"` will disable all coloring from `hab`, `hab-studio`, `hab-plan-build`, etc.

tl;dr
-----

To skip spinners in CI either:

    env HAB_NONINTERACTIVE=true hab pkg build ...

or

    export HAB_NONINTERACTIVE=true
    hab pkg build ...

References #1280 

![gif-keyboard-4359273550099528466](https://cloud.githubusercontent.com/assets/261548/22374176/66029ecc-e4a5-11e6-85f4-aac659b67b2c.gif)
