### PR TITLE
Fix typo in supervisor start: process not prcoess

### DIFF
--- a/components/sup/src/supervisor.rs
+++ b/components/sup/src/supervisor.rs
@@ -109,7 +109,7 @@ impl Supervisor {
     pub fn start(&mut self) -> Result<()> {
         if self.child.is_none() {
             outputln!(preamble self.preamble,
-                      "Starting prcoess as user={}, group={}",
+                      "Starting process as user={}, group={}",
                       &self.runtime_config.svc_user,
                       &self.runtime_config.svc_group);
             self.enter_state(ProcessState::Start);


### PR DESCRIPTION
![gif-keyboard-1647166055035843216](https://cloud.githubusercontent.com/assets/9912/22408360/498d5766-e63d-11e6-931e-eda024ebd1c8.gif)
