### PR TITLE
Add the path to the error message when find_command_in_pkg cant find the path

### DIFF
--- a/components/core/src/fs.rs
+++ b/components/core/src/fs.rs
@@ -273,7 +273,8 @@ pub fn find_command_in_pkg(command: &str,
                            fs_root_path: &Path)
                            -> Result<Option<PathBuf>> {
     for path in try!(pkg_install.paths()) {
-        let stripped = path.strip_prefix("/").expect("Package path missing / prefix");
+        let stripped = path.strip_prefix("/")
+            .expect(&format!("Package path missing / prefix {}", path.to_string_lossy()));
         let candidate = fs_root_path.join(stripped).join(command);
         if candidate.is_file() {
             return Ok(Some(path.join(command)));


### PR DESCRIPTION
Signed-off-by: Matt Wrock <matt@mattwrock.com>