### PR TITLE
ignoring configured user and group validation on windows

### DIFF
--- a/components/sup/src/util/users.rs
+++ b/components/sup/src/util/users.rs
@@ -108,6 +108,7 @@ fn get_default_user_and_group() -> Result<(String, String)> {
 /// if not, we'll try and use hab/hab.
 /// If hab/hab doesn't exist, try to use (current username, current group).
 /// If that doesn't work, then give up.
+#[cfg(unix)]
 pub fn get_user_and_group(pkg_install: &PackageInstall) -> Result<(String, String)> {
     if let Some((user, group)) = try!(check_pkg_user_and_group(&pkg_install)) {
         Ok((user, group))
@@ -115,4 +116,13 @@ pub fn get_user_and_group(pkg_install: &PackageInstall) -> Result<(String, Strin
         let defaults = try!(get_default_user_and_group());
         Ok(defaults)
     }
+}
+
+/// For now we are ignoring any configured user and group
+/// because we do not start the supervisor on windows under
+/// alternate credentials
+#[cfg(windows)]
+pub fn get_user_and_group(pkg_install: &PackageInstall) -> Result<(String, String)> {
+    let defaults = try!(get_default_user_and_group());
+    Ok(defaults)
 }


### PR DESCRIPTION
Avoids these errors:

```
hab-sup(MN): Starting core/mytutorialapp
hab-sup(MR): Butterfly Member ID 1526033205374fa1bd2f7cc501186875
hab-sup(UR)[src\util\users.rs:41:27]: Package requires user hab to exist, but it doesn't
```

which occur unless a user and group is specified for the plan that match the curent user. We don't run supervisor hooks under different creds on windows, so lets skip validation unbtil that changes.

Signed-off-by: Matt Wrock <matt@mattwrock.com>