### PR TITLE
Use consistent features in handlebars crate to avoid compile churn.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -701,7 +701,6 @@ dependencies = [
  "pest 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/components/hab/Cargo.toml
+++ b/components/hab/Cargo.toml
@@ -13,7 +13,7 @@ doc = false
 ansi_term = "*"
 env_logger = "*"
 hyper = "*"
-handlebars = "*"
+handlebars = { version = "*", features = ["serde_type", "partial4"], default-features = false }
 libc = "*"
 log = "*"
 pbr = "*"


### PR DESCRIPTION
This change harmonizes the compiled feature set of the handlebars crate with the `sup` component. Without this tweak many components are marked dirty and have to be recompiled.