### PR TITLE
[hab-spider] Remove release profile from Cargo.toml.

### DIFF
--- a/components/hab-spider/Cargo.toml
+++ b/components/hab-spider/Cargo.toml
@@ -21,6 +21,3 @@ path = "../builder-protocol"
 
 [build-dependencies]
 pkg-config = "0.3"
-
-[profile.release]
-debug = true


### PR DESCRIPTION
This change removes a Cargo warning which reports that per-component profiles will no longer be honored in future Cargo releases.