### PR TITLE
[hab] Install same version of helper packages as hab if not present.

### DIFF
--- a/components/hab/src/command/butterfly.rs
+++ b/components/hab/src/command/butterfly.rs
@@ -37,18 +37,21 @@ mod inner {
 
     use error::{Error, Result};
     use exec;
+    use VERSION;
 
     const CMD: &'static str = "hab-butterfly";
     const CMD_ENVVAR: &'static str = "HAB_BUTTERFLY_BINARY";
 
     pub fn start(ui: &mut UI, args: Vec<OsString>) -> Result<()> {
-        let sup_ident = "core/hab-butterfly";
+        let butterfly_ident = "core/hab-butterfly";
         let command = match henv::var(CMD_ENVVAR) {
             Ok(command) => PathBuf::from(command),
             Err(_) => {
                 init();
-                let ident = try!(PackageIdent::from_str(sup_ident));
-                try!(exec::command_from_pkg(ui, CMD, &ident, &default_cache_key_path(None), 0))
+                let version: Vec<&str> = VERSION.split("/").collect();
+                let ident =
+                    try!(PackageIdent::from_str(&format!("{}/{}", butterfly_ident, version[0])));
+                try!(exec::command_from_min_pkg(ui, CMD, &ident, &default_cache_key_path(None), 0))
             }
         };
 

--- a/components/hab/src/command/studio/mod.rs
+++ b/components/hab/src/command/studio/mod.rs
@@ -81,6 +81,7 @@ mod inner {
 
     use error::{Error, Result};
     use exec;
+    use VERSION;
 
     const SUDO_CMD: &'static str = "sudo";
 
@@ -89,12 +90,15 @@ mod inner {
             Ok(command) => PathBuf::from(command),
             Err(_) => {
                 init();
-                let ident = try!(PackageIdent::from_str(super::STUDIO_PACKAGE_IDENT));
-                try!(exec::command_from_pkg(ui,
-                                            super::STUDIO_CMD,
-                                            &ident,
-                                            &default_cache_key_path(None),
-                                            0))
+                let version: Vec<&str> = VERSION.split("/").collect();
+                let ident = try!(PackageIdent::from_str(&format!("{}/{}",
+                                                                 super::STUDIO_PACKAGE_IDENT,
+                                                                 version[0])));
+                try!(exec::command_from_min_pkg(ui,
+                                                super::STUDIO_CMD,
+                                                &ident,
+                                                &default_cache_key_path(None),
+                                                0))
             }
         };
 
@@ -174,12 +178,15 @@ mod inner {
             Ok(command) => PathBuf::from(command),
             Err(_) => {
                 init();
-                let ident = try!(PackageIdent::from_str(super::STUDIO_PACKAGE_IDENT));
-                try!(exec::command_from_pkg(ui,
-                                            super::STUDIO_CMD,
-                                            &ident,
-                                            &default_cache_key_path(None),
-                                            0))
+                let version: Vec<&str> = VERSION.split("/").collect();
+                let ident = try!(PackageIdent::from_str(&format!("{}/{}",
+                                                                 super::STUDIO_PACKAGE_IDENT,
+                                                                 version[0])));
+                try!(exec::command_from_min_pkg(ui,
+                                                super::STUDIO_CMD,
+                                                &ident,
+                                                &default_cache_key_path(None),
+                                                0))
             }
         };
 

--- a/components/hab/src/command/sup/mod.rs
+++ b/components/hab/src/command/sup/mod.rs
@@ -37,6 +37,7 @@ mod inner {
 
     use error::{Error, Result};
     use exec;
+    use VERSION;
 
     const SUP_CMD: &'static str = "hab-sup";
     const SUP_CMD_ENVVAR: &'static str = "HAB_SUP_BINARY";
@@ -58,8 +59,13 @@ mod inner {
             Ok(command) => PathBuf::from(command),
             Err(_) => {
                 init();
-                let ident = try!(PackageIdent::from_str(sup_ident));
-                try!(exec::command_from_pkg(ui, SUP_CMD, &ident, &default_cache_key_path(None), 0))
+                let version: Vec<&str> = VERSION.split("/").collect();
+                let ident = try!(PackageIdent::from_str(&format!("{}/{}", sup_ident, version[0])));
+                try!(exec::command_from_min_pkg(ui,
+                                                SUP_CMD,
+                                                &ident,
+                                                &default_cache_key_path(None),
+                                                0))
             }
         };
 


### PR DESCRIPTION
This feature aims to give a user a more intuitive initial experience
when using a particular version of `hab`. This behavior currently only
applies to Linux targets as Windows and Mac have alternative or disabled
implementations. The following `hab` subcommands are affected:

* `hab pkg build` (delegates to `core/hab-studio` package)
* `hab studio` (delegates to `core/hab-studio` package)
* `hab sup` (delegates to `core/hab-sup` package)
* `hab start` (delegates to `core/hab-sup` package)
* `hab config apply` (delegates to `core/hab-butterfly` package)
* `hab file upload` (delegates to `core/hab-butterfly` package)
* `hab apply` (delegates to `core/hab-butterfly` package)

All of the above commands will install an initial version of their
helper package on first use. The previous behavior was to install the
latest version and release of the helper package. For example, running
`hab studio enter` would install the equivalent of first running `hab
install core/hab-studio`. Note that if the version of `hab` was `1.1`
and the latest version of `hab-studio` was `2.2`, then installing
`core/hab-studio` would yield `core/hab-studio/2.2/<RELEASE>` installed
and executed.

This change uses the `VERSION` coordinate of `hab`'s package identifier
when performing the initial installation. For example, given the
following version of `hab`:

    > hab --version
    hab 1.2.3/20170127132343

it would attempt to install the latest release of `core/hab-studio/1.2.3`
when running `hab pkg build`.

Favoring Later Versions On Disk
-------------------------------

There is an exception to the behavior described above. If, as a user on
a system (or some automated process), I choose to install a newer
version of the Supervisor (let's say `core/hab-sup/5.6.7`), then running
`hab sup start` would find this newer installed package and use that
rather than its `1.2.3` version (which may or may not be installed on
disk).

The feature is written in this way to prevent an unplanned pinning back
of the Supervisor during upgrades. In other words, if `hab` only ever
ran the same version of the Supervisor, the Studio, etc., a user would
have to remember to always update the version (and possibly symlink or
binlink) of `hab` in order to run the newer software.

The tl;dr here is:

* `hab` will only install the same version of `hab-sup`, `hab-studio`,
  `hab-butterfly` if a package is not already installed
* `hab` will not run a version of the above packages that is older than
  itself
* `hab` will use and run a version of the above packages if it is newer
  than itself, but only if previously installed

Closes #1409
Closes #1578

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>