### PR TITLE
[hab] Add the option to binlink binaries on install

### DIFF
--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -413,6 +413,7 @@ fn sub_pkg_install() -> App<'static, 'static> {
         (@arg PKG_IDENT_OR_ARTIFACT: +required +multiple
             "One or more Habitat package identifiers (ex: acme/redis) and/or filepaths \
             to a Habitat Artifact (ex: /home/acme-redis-3.0.7-21120102031201-x86_64-linux.hart)")
+        (@arg BINLINK: -b --binlink "Binlink all binaries from installed package(s)")
     );
     sub.arg(Arg::with_name("IGNORE_TARGET")
         .help("Skips target validation for package installation.")
@@ -430,7 +431,11 @@ fn file_exists(val: String) -> result::Result<(), String> {
 }
 
 fn file_exists_or_stdin(val: String) -> result::Result<(), String> {
-    if val == "-" { Ok(()) } else { file_exists(val) }
+    if val == "-" {
+        Ok(())
+    } else {
+        file_exists(val)
+    }
 }
 
 fn valid_pair_type(val: String) -> result::Result<(), String> {

--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -431,11 +431,7 @@ fn file_exists(val: String) -> result::Result<(), String> {
 }
 
 fn file_exists_or_stdin(val: String) -> result::Result<(), String> {
-    if val == "-" {
-        Ok(())
-    } else {
-        file_exists(val)
-    }
+    if val == "-" { Ok(()) } else { file_exists(val) }
 }
 
 fn valid_pair_type(val: String) -> result::Result<(), String> {

--- a/components/hab/src/command/pkg/binlink.rs
+++ b/components/hab/src/command/pkg/binlink.rs
@@ -72,10 +72,13 @@ pub fn binlink_all_in_pkg(ui: &mut UI,
     for bin_path in pkg_path.paths()? {
         for bin in fs::read_dir(&bin_path)? {
             let bin_file = bin?;
-            let bin_name = bin_file.file_name()
-                .to_str()
-                .ok_or(Error::Utf8Error("Not a valid Utf8 string".to_string()))?
-                .to_owned();
+            let bin_name = match bin_file.file_name().to_str() {
+                Some(bn) => bn.to_owned(),
+                None => {
+                    try!(ui.warn("Found a binary with an invalid name.  Skipping binlink."));
+                    continue;
+                }
+            };
             self::start(ui, &pkg_ident, &bin_name, &dest_path, &fs_root_path)?;
         }
     }

--- a/components/hab/src/command/pkg/binlink.rs
+++ b/components/hab/src/command/pkg/binlink.rs
@@ -62,3 +62,22 @@ pub fn start(ui: &mut UI,
                         &dst.display())));
     Ok(())
 }
+
+pub fn binlink_all_in_pkg(ui: &mut UI,
+                          pkg_ident: &PackageIdent,
+                          dest_path: &Path,
+                          fs_root_path: &Path)
+                          -> Result<()> {
+    let pkg_path = PackageInstall::load(&pkg_ident, Some(fs_root_path))?;
+    for bin_path in pkg_path.paths()? {
+        for bin in fs::read_dir(&bin_path)? {
+            let bin_file = bin?;
+            let bin_name = bin_file.file_name()
+                .to_str()
+                .ok_or(Error::Utf8Error("Not a valid Utf8 string".to_string()))?
+                .to_owned();
+            self::start(ui, &pkg_ident, &bin_name, &dest_path, &fs_root_path)?;
+        }
+    }
+    Ok(())
+}

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -351,8 +351,7 @@ fn sub_pkg_install(ui: &mut UI, m: &ArgMatches) -> Result<()> {
             command::pkg::binlink::binlink_all_in_pkg(ui,
                                                       &pkg_ident,
                                                       dest_dir,
-                                                      &Path::new(&fs_root))
-                ?;
+                                                      &Path::new(&fs_root))?;
         }
     }
     Ok(())

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -338,7 +338,7 @@ fn sub_pkg_install(ui: &mut UI, m: &ArgMatches) -> Result<()> {
     init();
 
     for ident_or_artifact in ident_or_artifacts {
-        try!(common::command::package::install::start(ui,
+        let pkg_ident = try!(common::command::package::install::start(ui,
                                                       url,
                                                       ident_or_artifact,
                                                       PRODUCT,
@@ -346,6 +346,14 @@ fn sub_pkg_install(ui: &mut UI, m: &ArgMatches) -> Result<()> {
                                                       Path::new(&fs_root),
                                                       &cache_artifact_path(fs_root_path),
                                                       ignore_target));
+        if m.is_present("BINLINK") {
+            let dest_dir = Path::new(m.value_of("DEST_DIR").unwrap_or(DEFAULT_BINLINK_DIR));
+            command::pkg::binlink::binlink_all_in_pkg(ui,
+                                                      &pkg_ident,
+                                                      dest_dir,
+                                                      &Path::new(&fs_root))
+                ?;
+        }
     }
     Ok(())
 }

--- a/www/source/docs/reference/habitat-cli.html.md
+++ b/www/source/docs/reference/habitat-cli.html.md
@@ -327,6 +327,7 @@ Installs a Habitat package from a Depot or locally from a Habitat Artifact
 
 **FLAGS**
 
+    -b, --binlink    Binlink all binaries from installed package(s)
     -h, --help       Prints help information
     -V, --version    Prints version information
 


### PR DESCRIPTION
This feature adds a command line argrument (`-b`)to `hab pkg install` to
automatically binlink all binaries in the bin paths defined in the
plan.

```
target/debug/hab pkg install -b core/nginx
» Installing core/nginx
✓ Installed core/bzip2/1.0.6/20161208225359
✓ Installed core/cacerts/2016.09.14/20161031044952
✓ Installed core/gcc-libs/5.2.0/20161208223920
✓ Installed core/glibc/2.22/20160612063629
✓ Installed core/libedit/3.1.20150325/20161214073631
✓ Installed core/linux-headers/4.3/20160612063537
✓ Installed core/ncurses/6.0/20161213233720
✓ Installed core/openssl/1.0.2j/20161214012334
✓ Installed core/pcre/8.38/20161213233903
✓ Installed core/zlib/1.2.8/20161118033245
✓ Installed core/nginx/1.10.2/20170105001225
★ Install of core/nginx/1.10.2/20170105001225 complete with 11 new
packages installed.
» Symlinking nginx from core/nginx/1.10.2/20170105001225 into /bin
★ Binary nginx from core/nginx/1.10.2/20170105001225 symlinked to
/bin/nginx
```

Fixes #1679

Signed-off-by: Nolan Davidson <ndavidson@chef.io>