### PR TITLE
Depot validates hab client target (platform/architecture) before returning packages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -522,6 +522,7 @@ dependencies = [
  "habitat_builder_protocol 0.0.0",
  "habitat_core 0.0.0",
  "habitat_depot_client 0.0.0",
+ "hyper 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/build.ps1
+++ b/build.ps1
@@ -126,7 +126,7 @@ function Invoke-Configure {
 
 function Get-RustcCommand {
     if(Test-RustUp) {
-        'rustup run stable-x86_64-pc-windows-msvc rustc'
+        'rustup run stable-i686-pc-windows-msvc rustc'
     }
     else {
         'rustc'
@@ -135,7 +135,7 @@ function Get-RustcCommand {
 
 function Get-CargoCommand {
     if(Test-RustUp) {
-        'rustup run stable-x86_64-pc-windows-msvc cargo'
+        'rustup run stable-i686-pc-windows-msvc cargo'
     }
     else {
         'cargo'

--- a/components/builder-api-proxy/config/nginx.conf
+++ b/components/builder-api-proxy/config/nginx.conf
@@ -57,6 +57,7 @@ http {
   add_header Strict-Transport-Security "max-age=31536000; includeSubDomains;";
 
   proxy_cache_path {{pkg.svc_var_path}}/cache levels=1:2 keys_zone=my_cache:10m max_size=10g inactive=60m use_temp_path=off;
+  proxy_cache_key "$scheme$proxy_host$uri$is_args$args $http_user_agent";
 
   server {
     index index.html;

--- a/components/builder-depot/src/lib.rs
+++ b/components/builder-depot/src/lib.rs
@@ -32,6 +32,7 @@ extern crate log;
 extern crate mount;
 extern crate persistent;
 extern crate protobuf;
+extern crate regex;
 extern crate r2d2;
 extern crate r2d2_redis;
 extern crate redis;

--- a/components/common/Cargo.toml
+++ b/components/common/Cargo.toml
@@ -6,6 +6,7 @@ workspace = "../../"
 
 [dependencies]
 ansi_term = "*"
+hyper = "*"
 libc = "*"
 log = "*"
 pbr = "0.2" # lock until ready to support 0.3+ interface

--- a/components/common/src/lib.rs
+++ b/components/common/src/lib.rs
@@ -16,6 +16,7 @@ extern crate habitat_builder_protocol as protocol;
 extern crate habitat_core as hcore;
 extern crate habitat_depot_client as depot_client;
 extern crate ansi_term;
+extern crate hyper;
 #[macro_use]
 extern crate log;
 extern crate pbr;

--- a/components/hab/src/command/pkg/upload.rs
+++ b/components/hab/src/command/pkg/upload.rs
@@ -157,6 +157,7 @@ fn upload_into_depot(ui: &mut UI,
         Err(depot_client::Error::APIError(StatusCode::UnprocessableEntity, _)) => {
             return Err(Error::PackageArchiveMalformed(format!("{}", archive.path.display())));
         }
+        Err(depot_client::Error::APIError(StatusCode::NotImplemented, _)) => println!("Package platform or architecture not supported by the targted depot; skipping."),
         Err(e) => return Err(Error::from(e)),
     };
     try!(ui.status(Status::Uploaded, ident));


### PR DESCRIPTION
This PR is basically a guard until the depot can handle multiple targets.  When a package is requested from the hab CLI from a client OS/architecture that is not supported by the depot, the client will receive an error message that their platform is not supported by the depot they've targeted.

Also, in the movement of some of the subcommands in hab to individual files, the handling for unsupported uploads was dropped, so that is added back in.  

Finally, with the move to Rust 1.15, the windows target triple for x64 msvc changed from x86_64 to i686.  Build.ps1 was updated to reflect that.
