### PR TITLE
Updated overview page + added a bit more info on OAuth scopes

### DIFF
--- a/www/source/docs/overview.html.md
+++ b/www/source/docs/overview.html.md
@@ -9,10 +9,31 @@ Habitat centers application configuration, management, and behavior around the a
 
 The Habitat documentation is broken out into the following sections:
 
+**Getting Started**
+
+- [Get Habitat](/docs/get-habitat): Download the `hab` command-line interface tool (CLI) for Mac, Linux, and Windows to get started using Habitat.
 - [Tutorials](/tutorials): Location for our getting started and advanced tutorials. Currently, only the getting started tutorial is available. You should start here if you are new to Habitat.
 - [Concepts](/docs/concepts-overview): Describes the major components of Habitat and how they work.
+
+**Using Habitat**
+
 - [Create packages](/docs/create-packages-overview): Learn how to create a plan, what all of the plan settings are, how to configure a package, and how to build packages.
 - [Run packages](/docs/run-packages-overview): Learn how to run a package natively as well as through an external runtime format, such as a Docker or rkt container.
+- [Share packages](/docs/share-packages-overview): Describes how to upload, share, and run Habitat packages from the public depot.
+- [Continuous deployment](/docs/continuous-deployment-overview): Explains the how Habitat supports continuous deployment and the implementation details of deploying Habitat packages through Chef Automate.
+- [Container orchestration](/docs/container-orchestration): Describes how to use Habitat with container orchestration technologies such as EC2 Container Service, Mesos, and Kubernetes.
+- [Habitat internals](/docs/internals-overview): Provides deeper explanations on topics such as how the supervisor works, how leader election happens, etc.
+
+**Reference**
+
+- [CLI reference](/docs/reference/habitat-cli): Usage and basic help documentation for all `hab` CLI commands and subcommands.
+- [Plan syntax](/docs/reference/plan-syntax): All settings, variables, callbacks, functions, and other configuration options that can be used when creating your plan.
+- [Environment variables](/docs/reference/environment-vars): All environment variables that you can modify when using the `hab` CLI. 
+- [Package contents](/docs/reference/package-contents): Dependency, build, and configuration files that are included in a Habitat package.
+
+**Contribute**
+
+- [Help build Habitat](/docs/contribute-help-build): Additional functionality and that we would love the community to help us define and implement.
 
 ## Where to begin
 

--- a/www/source/docs/share-packages-overview.html.md
+++ b/www/source/docs/share-packages-overview.html.md
@@ -18,7 +18,7 @@ We will use the public depot provided by the Habitat project for this section. H
 
 ## Creating an account in the depot
 
-The depot software presently only supports GitHub authentication. For the public depot, visit https://app.habitat.sh/ in your browser and sign up for an account. Allow it to use GitHub for authorization.
+The depot software presently only supports GitHub authentication. For the public depot, visit <https://app.habitat.sh/> in your browser and sign up for an account. Allow it to use GitHub for authorization.
 
 ## Creating an origin or joining an existing origin
 
@@ -26,7 +26,9 @@ You can create your own origin in the depot or be invited to join an existing on
 
 ## Setting up hab to authenticate to the depot
 
-Because the depot uses GitHub to authenticate, you must generate a [GitHub access token](https://help.github.com/articles/creating-an-access-token-for-command-line-use/) for use with the `hab` command-line utility. The GitHub personal access token needs the `user:email` and `read:org` scopes. Habitat uses this for authentication and to determine features based on team membership.
+When you upload a package to a depot, you are required to supply an OAuth token as part of the `hab pkg upload` subcommand. Because the depot uses GitHub to authenticate, you must generate a [GitHub access token](https://help.github.com/articles/creating-an-access-token-for-command-line-use/) for use with the `hab` command-line utility. 
+
+The depot uses the following OAuth scopes when performing GitHub authentication: `user:email` and `read:org`; therefore, you must enable these [scopes](https://developer.github.com/v3/oauth/#scopes) for your personal access token. Habitat uses the information provided through these scopes for authentication and to determine features based on team membership.
 
 Once you have this token, you can set the `HAB_AUTH_TOKEN` [environment variable](/docs/reference/environment-vars/) to this value, so that any commands requiring authentication will use it.
 

--- a/www/source/tutorials/getting-started/linux/setup-environment.html.md.erb
+++ b/www/source/tutorials/getting-started/linux/setup-environment.html.md.erb
@@ -23,7 +23,9 @@ The `hab` command-line interface (CLI) tool downloads its other components when 
 
     <%= partial "/shared/setup_environment_script_step" %>
 
-    > Note: The GitHub personal access token needs the `user:email` and `read:org` scopes. Habitat uses this for authentication and to determine features based on team membership. Also, you can opt-out of providing usage data at a later point in time by re-running the `hab setup` subcommand and typing `No` when asked if you want to provide usage data.
+    > Note: The GitHub personal access token needs information provided from the `user:email` and `read:org` OAuth scopes. Habitat uses the information provided through these scopes for authentication and to determine features based on team membership. For more information, see [Setting up the `hab` CLI to authenticate to the depot](/docs/share-packages-overview#setting-up-hab-to-authenticate-to-the-depot).
+    
+    Also, you can opt-out of providing usage data at a later point in time by re-running the `hab setup` subcommand and typing `No` when asked if you want to provide usage data.
 
 That's it. You're all set up and ready to create your first package. The first step in that process is to create a plan.
 

--- a/www/source/tutorials/getting-started/mac/setup-environment.html.md.erb
+++ b/www/source/tutorials/getting-started/mac/setup-environment.html.md.erb
@@ -28,7 +28,9 @@ The `hab` command-line interface (CLI) tool downloads its other components when 
 
    <%= partial "/shared/setup_environment_script_step" %>
 
-   > Note: The GitHub personal access token needs the `user:email` and `read:org` scopes. Habitat uses this for authentication and to determine features based on team membership. Also, you can opt-out of providing usage data at a later point in time by re-running the `hab setup` subcommand and typing `No` when asked if you want to provide usage data.
+    > Note: The GitHub personal access token needs information provided from the `user:email` and `read:org` OAuth scopes. Habitat uses the information provided through these scopes for authentication and to determine features based on team membership. For more information, see [Setting up the `hab` CLI to authenticate to the depot](/docs/share-packages-overview#setting-up-hab-to-authenticate-to-the-depot).
+    
+    Also, you can opt-out of providing usage data at a later point in time by re-running the `hab setup` subcommand and typing `No` when asked if you want to provide usage data.
 
 That's it. You're all set up and ready to create your first package. The first step in that process is to create a plan.
 

--- a/www/source/tutorials/getting-started/windows/setup-environment.html.md.erb
+++ b/www/source/tutorials/getting-started/windows/setup-environment.html.md.erb
@@ -28,7 +28,9 @@ The `hab` command-line interface (CLI) tool downloads its other components when 
 
    <%= partial "/shared/setup_environment_script_step" %>
 
-   > Note: The GitHub personal access token needs the `user:email` and `read:org` scopes. Habitat uses this for authentication and to determine features based on team membership. Also, you can opt-out of providing usage data at a later point in time by re-running the `hab setup` subcommand and typing `No` when asked if you want to provide usage data.
+    > Note: The GitHub personal access token needs information provided from the `user:email` and `read:org` OAuth scopes. Habitat uses the information provided through these scopes for authentication and to determine features based on team membership. For more information, see [Setting up the `hab` CLI to authenticate to the depot](/docs/share-packages-overview#setting-up-hab-to-authenticate-to-the-depot).
+    
+    Also, you can opt-out of providing usage data at a later point in time by re-running the `hab setup` subcommand and typing `No` when asked if you want to provide usage data.
 
    For the remainder of the tutorial, we will assume that you are running any command-line steps in Windows PowerShell. 
 


### PR DESCRIPTION
In response to #1189 and #1194, I've updated the notes in the tutorial to point people to an existing section in our docs that talks about OAuth scopes in the context of authenticating with the depot (which is the only place they seem to be used). If/when new scopes are required, we can break the scopes content out into a new topic.

Also updated the overview page to more accurately reflect the current nav structure of the docs.