### PR TITLE
 Rename pkg_expose to pkg_exposes and refactor to leverage pkg_exports

### DIFF
--- a/components/builder-api/habitat/default.toml
+++ b/components/builder-api/habitat/default.toml
@@ -1,3 +1,6 @@
+[srv]
+port = 9636
+
 [ui]
 app_url          = "https://willem.habitat.sh/v1"
 community_url    = "https://www.habitat.sh/community"

--- a/components/builder-api/habitat/plan.sh
+++ b/components/builder-api/habitat/plan.sh
@@ -9,7 +9,10 @@ pkg_deps=(core/glibc core/openssl core/coreutils core/gcc-libs core/zeromq core/
   core/libarchive)
 pkg_build_deps=(core/protobuf core/protobuf-rust core/coreutils core/cacerts
   core/rust core/gcc core/git core/pkg-config core/node core/phantomjs)
-pkg_expose=(9636)
+pkg_exports=(
+  [port]=srv.port
+)
+pkg_exposes=(port)
 bin="bldr-api"
 pkg_svc_run="$bin start -c ${pkg_svc_path}/config.toml"
 

--- a/components/builder-jobsrv/habitat/default.toml
+++ b/components/builder-jobsrv/habitat/default.toml
@@ -1,0 +1,3 @@
+[srv]
+port = 5566
+heartbeat = 5567

--- a/components/builder-jobsrv/habitat/plan.sh
+++ b/components/builder-jobsrv/habitat/plan.sh
@@ -8,7 +8,11 @@ pkg_bin_dirs=(bin)
 pkg_deps=(core/glibc core/openssl core/gcc-libs core/zeromq core/libsodium core/libarchive)
 pkg_build_deps=(core/protobuf core/protobuf-rust core/coreutils core/cacerts
   core/rust core/gcc core/git core/pkg-config)
-pkg_expose=(5566 5567)
+pkg_exports(
+  [port]=srv.port
+  [heartbeat]=srv.heartbeat
+)
+pkg_exposes=(port heartbeat)
 bin="bldr-job-srv"
 pkg_svc_run="$bin start -c ${pkg_svc_path}/config.toml"
 

--- a/components/builder-router/habitat/default.toml
+++ b/components/builder-router/habitat/default.toml
@@ -1,0 +1,3 @@
+[srv]
+port = 5562
+heartbeat = 5563

--- a/components/builder-router/habitat/plan.sh
+++ b/components/builder-router/habitat/plan.sh
@@ -8,7 +8,11 @@ pkg_bin_dirs=(bin)
 pkg_deps=(core/glibc core/openssl core/gcc-libs core/zeromq core/libsodium core/libarchive)
 pkg_build_deps=(core/protobuf core/protobuf-rust core/coreutils core/cacerts
   core/rust core/gcc core/git core/pkg-config)
-pkg_expose=(5562 5563)
+pkg_exports(
+  [port]=srv.port
+  [heartbeat]=srv.heartbeat
+)
+pkg_exposes=(port heartbeat)
 bin="bldr-router"
 pkg_svc_run="$bin start -c ${pkg_svc_path}/config.toml"
 

--- a/components/hab/static/template_plan.sh
+++ b/components/hab/static/template_plan.sh
@@ -128,22 +128,23 @@ pkg_svc_run="{{ pkg_svc_run }}"
 # An associative array representing configuration data which should be gossiped to peers. The keys
 # in this array represent the name the value will be assigned and the values represent the toml path
 # to read the value.
-{{#if pkg_expose ~}}
+{{#if pkg_exports ~}}
 pkg_exports={{ pkg_exports }}
 {{else ~}}
 # pkg_exports=(
 #   [host]=srv.address
 #   [port]=srv.port
-#   [domain]=domain
+#   [ssl-port]=srv.ssl.port
 # )
 {{/if}}
 # Optional.
-# An array of ports this service exposes when you create a Docker image from
-# your package.
-{{#if pkg_expose ~}}
-pkg_expose={{ pkg_expose }}
+# An array of `pkg_exports` keys containing default values for which ports that this package
+# exposes. These values are used as sensible defaults for other tools. For example, when exporting
+# a package to a container format.
+{{#if pkg_exposes ~}}
+pkg_exposes={{ pkg_exposes }}
 {{else ~}}
-# pkg_expose=(80 443)
+# pkg_exposes=(port ssl-port)
 {{/if}}
 # Optional.
 # An array of interpreters used in shebang lines for scripts. Specify the

--- a/components/plan-build/plan.sh
+++ b/components/plan-build/plan.sh
@@ -18,6 +18,7 @@ pkg_deps=(
   core/grep
   core/gzip
   core/hab
+  core/rq
   core/sed
   core/tar
   core/unzip

--- a/support/linux/install_dev_9_linux.sh
+++ b/support/linux/install_dev_9_linux.sh
@@ -32,6 +32,10 @@ echo "Node $(node --version)"
 echo "npm $(npm --version)"
 echo "docco $(docco --version)"
 
+if [ ! -f /usr/local/bin/rq ]; then
+  curl -sSLf https://sh.dflemstr.name/rq | bash -s -- --yes false
+fi
+
 if command -v useradd > /dev/null; then
   sudo -E useradd --system --no-create-home hab || true
 else

--- a/test/fixtures/app-server/default.toml
+++ b/test/fixtures/app-server/default.toml
@@ -1,5 +1,8 @@
 log_level = "error"
 
-[srv]
+[proxy]
 port = 80
+
+[srv]
+port = 8080
 host = "127.0.0.1"

--- a/test/fixtures/app-server/plan.sh
+++ b/test/fixtures/app-server/plan.sh
@@ -6,9 +6,11 @@ pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=nosuchfile.tar.gz
 pkg_svc_run="app-server"
 pkg_exports=(
+  [proxy-port]=proxy.port
   [port]=srv.port
   [host]=srv.host
 )
+pkg_exposes=(proxy-port port)
 
 do_download() {
   return 0

--- a/www/source/about/habitat-and-modern-app.html.slim
+++ b/www/source/about/habitat-and-modern-app.html.slim
@@ -110,7 +110,11 @@ pre
     pkg_deps=(core/glibc chefops/jdk8)
     pkg_bin_dirs=(bin)
     pkg_lib_dirs=(lib)
-    pkg_expose=(9200 9300)
+    pkg_exports=(
+      [http-port]=network.port
+      [transport-port]=transport.port
+    )
+    pkg_exposes=(http-port transport-port)
     pkg_svc_run="es/bin/elasticsearch --default.path.conf=${pkg_svc_config_path} 2>&1"
     do_build() {
       return 0
@@ -127,11 +131,13 @@ p The first three values form part of the package's fully qualified name. The
   files. The <code>pkg_shasum</code> value is the package's checksum. The
   <code>pkg_deps</code> values list the runtime dependencies for ElasticSearch.
   The <code>pkg_bin_dirs</code> value specifies the location for the
-  ElasticSearch binary. The <code>pkg_expose</code> values specify which
-  Docker ports need to be exposed if this package is exported to a Docker
-  image. Finally, the <code>pkg_svc_run</code> value specifies how the
-  ElasticSearch binary should be run when the supervisor starts the
-  ElasticSearch package payload.
+  ElasticSearch binary. The <code>pkg_exports</code> associative array contains a
+  mapping of configuration keys to give public aliases to and make publicly
+  available. The <code>pkg_exposes</code> values specify which exported
+  configuration values representing service ports will be exposed if this
+  package is exported to a Docker image. Finally, the <code>pkg_svc_run</code>
+  value specifies how the ElasticSearch binary should be run when the supervisor
+  starts the ElasticSearch package payload.
 
 p The callbacks override certain default behaviors such as compiling and
   building binaries from source code and installing them into the package

--- a/www/source/docs/reference/plan-syntax.html.md
+++ b/www/source/docs/reference/plan-syntax.html.md
@@ -145,14 +145,15 @@ pkg_exports
   pkg_exports=(
     [port]=server.port
     [host]=server.host
+    [ssl-port]=ssl.port
   )
   ~~~
 
-pkg_expose
-: Optional. An array of ports this service exposes when you create a Docker image from your package.
+pkg_exposes
+: Optional. An array of `pkg_exports` keys containing default values for which ports that this package exposes. These values are used as sensible defaults for other tools. For example, when exporting a package to a container format.
 
   ~~~
-  pkg_expose=(80 443)
+  pkg_exposes=(port ssl-port)
   ~~~
 
 
@@ -422,7 +423,7 @@ deps
 : An array of runtime dependencies for your package based on the pkg_deps setting in a plan.
 
 exposes
-: The port(s) to expose for an application or service. This value is pulled from the pkg_expose setting in a plan.
+: The port(s) to expose for an application or service. This value is pulled from the pkg_exposes setting in a plan.
 
 path
 : The location where the fully-qualified package is installed.

--- a/www/source/shared/_create_plan_common.html.md.erb
+++ b/www/source/shared/_create_plan_common.html.md.erb
@@ -59,6 +59,7 @@ In your terminal window, do the following:
        pkg_source=nosuchfile.tar.gz
        pkg_deps=()
        pkg_exports=()
+       pkg_exposes=()
 
 Let's walk through these settings:
 
@@ -66,8 +67,9 @@ Let's walk through these settings:
 - The `pkg_maintainer` and `pkg_license` settings provide contact and license type information.
 - The `pkg_upstream_url` is used to provide project website metadata.
 - The `pkg_source` is a URL that specifies where to download the source from. If you are building the source locally, or do not need to download a file, you must still provide a non-empty string value.
-- The `pkg_deps` corresponds to the runtime package dependencies, and `pkg_expose` opens a network port when a Docker container is created (must be used along with the `-p` runtime option to publish it to the host machine).
-- The `pkg_exports` is a mapping of the private configuration keyspace to a public keyspace which makes configuration data available to peers by the gossip ring.
+- The `pkg_deps` corresponds to the runtime package dependencies.
+- The `pkg_exports` is a mapping of configuration to alias and make publicly available to peers by the gossip ring.
+- The `pkg_exposes` is a list of `pkg_exports` keys whose values are ports to give hints for other tools to operate with a set of sensible defaults. For example, this is used when exporting a Habitat package to a Docker container.
 
 ## Modify the plan
 
@@ -85,17 +87,25 @@ We now have a skeleton plan, but we need to modify some of its settings before w
 
    > Note: Later on in this topic we are going to install the `nconf` module into our package, which requires the `npm` binary; however, we do not need to include `core/node` as a build dependency because the build script automatically installs build and runtime dependencies and adds their bin directories to the `$PATH` variable before building the package. So, if you need the same dependent binary for both build and runtime operations, you only need to include it as a runtime dependency.
 
-6. Set the `pkg_expose` value to `8080`. The `pkg_expose` setting creates an `EXPOSE` instruction in a generated Dockerfile, which we will use to create an optional Docker container; however, specifying the `pkg_expose` value does not publish this port for access by the host machine. We will do that later.
+6. Set the `pkg_exports` value to an associative array with one key value pair. This is an alias of a default configuration which will be shared to consumers who `--bind` to your package. All service configuration is considered "private" to the supervisor and not shared without an explicit entry here. We will setup the `default.toml` for the configuration soon.
+
+    pkg_exports(
+      [port]=port
+    )
+
+7. Set the `pkg_exposes` value to `port`. The `pkg_exposes` values are used to create an `EXPOSE` instruction in a generated Dockerfile, which we will use to create an optional Docker container; however, specifying the `pkg_exposes` value does not publish this port for access by the host machine. We will do that later.
 
    Add the following line to your plan:
 
-        pkg_expose=(8080)
+        pkg_exposes=(port)
 
 It's important to note that the Node.js application in this tutorial does not create any new binaries or libraries of its own; however, for those packages that compile binaries and/or libraries, you must also include settings that specify the directory names where those files will be located, such as:
 
      pkg_bin_dirs=(bin)
      pkg_include_dirs=(include)
      pkg_lib_dirs=(lib)
+
+## Create a default.toml
 
 ## Add in callbacks
 
@@ -159,7 +169,10 @@ pkg_license=()
 pkg_upstream_url=https://github.com/habitat-sh/habitat-example-plans
 pkg_source=nosuchfile.tar.gz
 pkg_deps=(core/node)
-pkg_expose=(8080)
+pkg_exports(
+  [port]=port
+)
+pkg_exposes=(port)
 
 do_download() {
   return 0


### PR DESCRIPTION
This changes the accepted values for pkg_expose from a numeric literal
to a string representing a key in pkg_exports containing a valid port
number. The contents of EXPOSES will still contain the numeric
literal so this is not a breaking change for the Habitat runtime,
just a breaking change for hab-plan-build users.

* Rename pkg_expose to pkg_exposes
* A numeric literal is no longer a valid pkg_expose
* The default value of the pkg_export must be a valid port number
  or package generation will halt
* Package generation will fail if the pkg_export is missing

![gif-keyboard-601488567894941889](https://cloud.githubusercontent.com/assets/54036/22613651/e2b76e00-ea2e-11e6-8f8b-61b1731c3e5f.gif)