### PR TITLE
revert change to build.ps1

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -126,7 +126,7 @@ function Invoke-Configure {
 
 function Get-RustcCommand {
     if(Test-RustUp) {
-        'rustup run stable-i686-pc-windows-msvc rustc'
+        'rustup run stable-x86_64-pc-windows-msvc rustc'
     }
     else {
         'rustc'
@@ -135,7 +135,7 @@ function Get-RustcCommand {
 
 function Get-CargoCommand {
     if(Test-RustUp) {
-        'rustup run stable-i686-pc-windows-msvc cargo'
+        'rustup run stable-x86_64-pc-windows-msvc cargo'
     }
     else {
         'cargo'


### PR DESCRIPTION
rustup didn't have x86_64 msvc targets available on 2/2 and defaulted to installing the i686 target.  I misunderstood and thought they renamed the target.  Now we've got x86_64-msvc for Rust 1.15 in rustup, so reverting the change to `build.ps1`
 
Signed-off-by: Steven Murawski <steven.murawski@gmail.com>