### PR TITLE
Add validation and docs for pkg_name and pkg_origin

### DIFF
--- a/components/plan-build-ps1/bin/hab-plan-build.ps1
+++ b/components/plan-build-ps1/bin/hab-plan-build.ps1
@@ -1247,9 +1247,11 @@ try {
         }
     }
 
-    # Test to ensure package name contains only valid characters
-    if (-Not ("$pkg_name" -match '^[A-Za-z0-9_-]+$')) {
-        _Exit-With "Failed to build. Package name '$pkg_name' contains invalid characters." 1
+    # Test to ensure package name and origin contain only valid characters
+    foreach ($var in @("pkg_name", "pkg_origin")) {
+      if (-Not ((Get-Content Variable:\$var) -match '^[A-Za-z0-9_-]+$')) {
+          _Exit-With "Failed to build. Package '$var' contains invalid characters." 1
+      }
     }
 
     # Pass over `$pkg_svc_run` to replace any `$pkg_name` placeholder tokens

--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -2481,10 +2481,12 @@ do
 done
 
 # Test to ensure package name contains only valid characters
-if [[ ! "${pkg_name}" =~ ^[A-Za-z0-9_-]+$ ]];
-then
-  exit_with "Failed to build. Package name '${pkg_name}' contains invalid characters." 1
-fi
+for var in pkg_name pkg_origin; do
+  if [[ ! "${!var}" =~ ^[A-Za-z0-9_-]+$ ]];
+  then
+    exit_with "Failed to build. Package $var '${!var}' contains invalid characters." 1
+  fi
+done
 
 # Pass over `$pkg_svc_run` to replace any `$pkg_name` placeholder tokens
 # from prior pkg_svc_* variables that were set before the Plan was loaded.

--- a/www/source/docs/reference/plan-syntax.html.md
+++ b/www/source/docs/reference/plan-syntax.html.md
@@ -20,14 +20,15 @@ This syntax guide is divided into six parts:
 The following settings are defined at the beginning of your plan. They specify basic information about your plan such as name, version, and dependencies.
 
 pkg_name
-: Required. Sets the name of the package. This will be used in along with `pkg_origin`, and `pkg_version` to define the fully-qualified package name, which determines where the package is installed to on disk, how it is referred to in package metadata, and so on.
+: Required. Sets the name of the package. This will be used in along with `pkg_origin`, and `pkg_version` to define the fully-qualified package name, which determines where the package is installed to on disk, how it is referred to in package metadata, and so on. A `pkg_name` can contain upper and lowercase letters, numbers, dashes, and underscores.
 
   ~~~
   pkg_name=zlib
   ~~~
 
 pkg_origin
-: Required unless overridden by the `HAB_ORIGIN` environment variable. The origin is used to denote a particular upstream of a package.
+: Required unless overridden by the `HAB_ORIGIN` environment variable. The origin is used to denote a particular upstream of a package. A `pkg_origin` can contain upper and lowercase letters, numbers, dashes, and underscores.
+
 
   ~~~
   pkg_origin=Habitat


### PR DESCRIPTION
* Say in the docs what characters are allowed in `pkg_name` and
  `pkg_origin`
* In the build scripts, check the validity of `pkg_origin` as well as
  `pkg_name`

I HAVE NOT TESTED THE CODE CHANGES IN BASH OR POWERSHELL - So please
test them. I don't have an environment set up for Powershell nor do I
know the language at all, so please verify my code.

I didn't try the bash because hab-plan-build is broken but will be fixed
once core-plans#410 is uploaded.

![gif-keyboard-1016230489335958086](https://cloud.githubusercontent.com/assets/9912/22704095/1ac06f54-ed2c-11e6-9926-56c1429b6143.gif)
