### PR TITLE
Refactor graph construction

### DIFF
--- a/components/builder-core/src/file_walker.rs
+++ b/components/builder-core/src/file_walker.rs
@@ -1,0 +1,75 @@
+// Copyright (c) 2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::path::{Path, PathBuf};
+use walkdir::{WalkDir, Iter};
+use hab_core::package::{FromArchive, PackageArchive};
+use protocol::depotsrv;
+
+pub struct FileWalker {
+    walker: Iter,
+}
+
+impl FileWalker {
+    pub fn new<T: AsRef<Path>>(path: T) -> Self {
+        FileWalker { walker: WalkDir::new(path.as_ref()).follow_links(false).into_iter() }
+    }
+}
+
+pub fn extract_package<T: AsRef<Path>>(path: T) -> Option<depotsrv::Package> {
+    let mut archive = PackageArchive::new(PathBuf::from(path.as_ref()));
+
+    match archive.ident() {
+        Ok(_) => {
+            match depotsrv::Package::from_archive(&mut archive) {
+                Ok(p) => {
+                    return Some(p);
+                }
+                Err(e) => {
+                    error!("Error parsing package from archive: {:?}", e);
+                    return None;
+                }
+            }
+        }
+        Err(e) => {
+            error!("Error reading, archive={:?} error={:?}", &archive, &e);
+            return None;
+        }
+    }
+}
+
+impl Iterator for FileWalker {
+    type Item = depotsrv::Package;
+
+    fn next(&mut self) -> Option<depotsrv::Package> {
+        loop {
+            match self.walker.next() {
+                Some(entry) => {
+                    let entry = entry.unwrap();
+                    if entry.metadata().unwrap().is_dir() {
+                        continue;
+                    } else {
+                        match extract_package(entry.path()) {
+                            Some(p) => return Some(p),
+                            None => continue,
+                        }
+                    }
+                }
+                None => {
+                    return None;
+                }
+            }
+        }
+    }
+}

--- a/components/builder-core/src/lib.rs
+++ b/components/builder-core/src/lib.rs
@@ -26,4 +26,5 @@ extern crate habitat_builder_protocol as protocol;
 
 pub mod metrics;
 pub mod rdeps;
-pub mod graph_walker;
+pub mod package_graph;
+pub mod file_walker;


### PR DESCRIPTION
This is a minor refactor of the dependency graph construction that moves it forward toward using the DB to build the package graph.  The PackageGraph implementation now takes in a Package iterator, and the file system walker functionality is moved into a separate module.

Signed-off-by: Salim Alam <salam@chef.io>

![giphy 3](https://cloud.githubusercontent.com/assets/13542112/22716984/5b35653c-ed4d-11e6-9d7b-4062c4620643.gif)