### PR TITLE
Package activity should be properly rooted in a windows studio

### DIFF
--- a/components/core/src/fs.rs
+++ b/components/core/src/fs.rs
@@ -22,11 +22,6 @@ use error::Result;
 use super::package::PackageInstall;
 
 
-/// The default filesystem root path
-#[cfg(not(target_os="windows"))]
-pub const FS_ROOT_PATH: &'static str = "/";
-#[cfg(target_os="windows")]
-pub const FS_ROOT_PATH: &'static str = concat!(env!("SYSTEMDRIVE"), "/");
 /// The default root path of the Habitat filesystem
 pub const ROOT_PATH: &'static str = "hab";
 /// The default path for any analytics related files
@@ -41,10 +36,24 @@ pub const CACHE_SRC_PATH: &'static str = "hab/cache/src";
 pub const CACHE_SSL_PATH: &'static str = "hab/cache/ssl";
 /// The root path containing all locally installed packages
 pub const PKG_PATH: &'static str = "hab/pkgs";
+/// The environment variable pointing to the filesystem root. This exists for internal
+/// Habitat team usage and is not intended to be used by Habitat consumers.
+/// Using this variable could lead to broken supervisor services and it should
+/// be used with extreme caution.
+pub const FS_ROOT_ENVVAR: &'static str = "FS_ROOT";
 /// The root path containing all runtime service directories and files
 const SVC_PATH: &'static str = "hab/svc";
 
 lazy_static! {
+    /// The default filesystem root path
+    pub static ref FS_ROOT_PATH: String = {
+        if cfg!(target_os = "windows") && henv::var(FS_ROOT_ENVVAR).is_ok() {
+            henv::var(FS_ROOT_ENVVAR).unwrap()
+        } else {
+            "/".to_string()
+        }
+    };
+
     static ref EUID: u32 = users::get_effective_uid();
 
     static ref MY_CACHE_ANALYTICS_PATH: PathBuf = {
@@ -107,7 +116,7 @@ lazy_static! {
 pub fn cache_analytics_path(fs_root_path: Option<&Path>) -> PathBuf {
     match fs_root_path {
         Some(fs_root_path) => Path::new(fs_root_path).join(&*MY_CACHE_ANALYTICS_PATH),
-        None => Path::new(FS_ROOT_PATH).join(&*MY_CACHE_ANALYTICS_PATH),
+        None => Path::new(&*FS_ROOT_PATH).join(&*MY_CACHE_ANALYTICS_PATH),
     }
 }
 
@@ -115,7 +124,7 @@ pub fn cache_analytics_path(fs_root_path: Option<&Path>) -> PathBuf {
 pub fn cache_artifact_path(fs_root_path: Option<&Path>) -> PathBuf {
     match fs_root_path {
         Some(fs_root_path) => Path::new(fs_root_path).join(&*MY_CACHE_ARTIFACT_PATH),
-        None => Path::new(FS_ROOT_PATH).join(&*MY_CACHE_ARTIFACT_PATH),
+        None => Path::new(&*FS_ROOT_PATH).join(&*MY_CACHE_ARTIFACT_PATH),
     }
 }
 
@@ -123,7 +132,7 @@ pub fn cache_artifact_path(fs_root_path: Option<&Path>) -> PathBuf {
 pub fn cache_key_path(fs_root_path: Option<&Path>) -> PathBuf {
     match fs_root_path {
         Some(fs_root_path) => Path::new(fs_root_path).join(&*MY_CACHE_KEY_PATH),
-        None => Path::new(FS_ROOT_PATH).join(&*MY_CACHE_KEY_PATH),
+        None => Path::new(&*FS_ROOT_PATH).join(&*MY_CACHE_KEY_PATH),
     }
 }
 
@@ -131,7 +140,7 @@ pub fn cache_key_path(fs_root_path: Option<&Path>) -> PathBuf {
 pub fn cache_src_path(fs_root_path: Option<&Path>) -> PathBuf {
     match fs_root_path {
         Some(fs_root_path) => Path::new(fs_root_path).join(&*MY_CACHE_SRC_PATH),
-        None => Path::new(FS_ROOT_PATH).join(&*MY_CACHE_SRC_PATH),
+        None => Path::new(&*FS_ROOT_PATH).join(&*MY_CACHE_SRC_PATH),
     }
 }
 
@@ -139,7 +148,7 @@ pub fn cache_src_path(fs_root_path: Option<&Path>) -> PathBuf {
 pub fn cache_ssl_path(fs_root_path: Option<&Path>) -> PathBuf {
     match fs_root_path {
         Some(fs_root_path) => Path::new(fs_root_path).join(&*MY_CACHE_SSL_PATH),
-        None => Path::new(FS_ROOT_PATH).join(&*MY_CACHE_SSL_PATH),
+        None => Path::new(&*FS_ROOT_PATH).join(&*MY_CACHE_SSL_PATH),
     }
 }
 

--- a/components/hab/src/command/pkg/export.rs
+++ b/components/hab/src/command/pkg/export.rs
@@ -104,7 +104,7 @@ mod inner {
                                     &format_ident.to_string(),
                                     PRODUCT,
                                     VERSION,
-                                    Path::new(FS_ROOT_PATH),
+                                    Path::new(&*FS_ROOT_PATH),
                                     &cache_artifact_path(None),
                                     false));
             }

--- a/components/hab/src/config.rs
+++ b/components/hab/src/config.rs
@@ -104,5 +104,5 @@ fn cli_config_path(use_sudo_user: bool) -> PathBuf {
         }
     }
 
-    PathBuf::from(FS_ROOT_PATH).join(CLI_CONFIG_PATH)
+    PathBuf::from(&*FS_ROOT_PATH).join(CLI_CONFIG_PATH)
 }

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -35,7 +35,8 @@ use common::ui::{Coloring, UI, NOCOLORING_ENVVAR, NONINTERACTIVE_ENVVAR};
 use hcore::env as henv;
 use hcore::crypto::{init, default_cache_key_path, SigKeyPair};
 use hcore::crypto::keys::PairType;
-use hcore::fs::{cache_artifact_path, cache_analytics_path, cache_key_path, FS_ROOT_PATH};
+use hcore::fs::{cache_artifact_path, cache_analytics_path, cache_key_path, FS_ROOT_PATH,
+                FS_ROOT_ENVVAR};
 use hcore::service::ServiceGroup;
 use hcore::package::PackageIdent;
 use hcore::url::{DEFAULT_DEPOT_URL, DEPOT_URL_ENVVAR};
@@ -45,8 +46,6 @@ use hab::error::{Error, Result};
 
 /// Makes the --org CLI param optional when this env var is set
 const HABITAT_ORG_ENVVAR: &'static str = "HAB_ORG";
-
-const FS_ROOT_ENVVAR: &'static str = "FS_ROOT";
 
 const DEFAULT_BINLINK_DIR: &'static str = "/bin";
 

--- a/components/studio/bin/hab-studio.ps1
+++ b/components/studio/bin/hab-studio.ps1
@@ -256,12 +256,10 @@ function New-Studio {
     }
 
     $env:FS_ROOT=$HAB_STUDIO_ROOT
-    try {
-      $keys | % { $_ | & hab origin key import }
-    }
-    finally {
-      $env:FS_ROOT=$null
-    }
+    $keys | % { $_ | & hab origin key import }
+  }
+  else {
+    $env:FS_ROOT=$HAB_STUDIO_ROOT
   }
 
   New-PSDrive -Name "Habitat" -PSProvider FileSystem -Root $HAB_STUDIO_ROOT -Scope Script | Out-Null

--- a/components/sup/src/command/start.rs
+++ b/components/sup/src/command/start.rs
@@ -84,7 +84,7 @@ pub fn package() -> Result<()> {
         return Err(sup_error!(Error::RootRequired));
     }
 
-    match Package::load(gconfig().package(), None) {
+    match Package::load(gconfig().package(), Some(&*FS_ROOT_PATH)) {
         Ok(mut package) => {
             let update_strategy = gconfig().update_strategy();
             match update_strategy {
@@ -110,10 +110,10 @@ pub fn package() -> Result<()> {
                                                                &latest_ident.to_string(),
                                                                PRODUCT,
                                                                VERSION,
-                                                               Path::new(FS_ROOT_PATH),
+                                                               Path::new(&*FS_ROOT_PATH),
                                                                &cache_artifact_path(None),
                                                                false));
-                        package = try!(Package::load(&new_pkg_data, None));
+                        package = try!(Package::load(&new_pkg_data, Some(&*FS_ROOT_PATH)));
                     } else {
                         outputln!("Already running latest.");
                     };
@@ -132,7 +132,7 @@ pub fn package() -> Result<()> {
                                         &artifact,
                                         PRODUCT,
                                         VERSION,
-                                        Path::new(FS_ROOT_PATH),
+                                        Path::new(&*FS_ROOT_PATH),
                                         &cache_artifact_path(None),
                                         false))
                 }
@@ -145,12 +145,12 @@ pub fn package() -> Result<()> {
                                         &gconfig().package().to_string(),
                                         PRODUCT,
                                         VERSION,
-                                        Path::new(FS_ROOT_PATH),
+                                        Path::new(&*FS_ROOT_PATH),
                                         &cache_artifact_path(None),
                                         false))
                 }
             };
-            let package = try!(Package::load(&new_pkg_data, None));
+            let package = try!(Package::load(&new_pkg_data, Some(&*FS_ROOT_PATH)));
             start_package(package)
         }
     }

--- a/components/sup/src/manager/service/config.rs
+++ b/components/sup/src/manager/service/config.rs
@@ -20,9 +20,11 @@ use std::env;
 use std::fs::File;
 use std::io::prelude::*;
 use std::ops::{Deref, DerefMut};
+use std::path::Path;
 
 use ansi_term::Colour::Purple;
 use butterfly::rumor::service::SysInfo;
+use hcore::fs::FS_ROOT_PATH;
 use hcore::package::PackageInstall;
 use hcore::crypto;
 use toml;
@@ -496,7 +498,7 @@ impl Pkg {
         };
         let mut deps = Vec::new();
         for d in pkg_deps.iter() {
-            if let Ok(p) = PackageInstall::load(d, None) {
+            if let Ok(p) = PackageInstall::load(d, Some(Path::new(&*FS_ROOT_PATH))) {
                 deps.push(Pkg::new(&p));
             } else {
                 outputln!("Failed to load {} - it will be missing from the configuration",

--- a/components/sup/src/manager/service_updater.rs
+++ b/components/sup/src/manager/service_updater.rs
@@ -355,7 +355,7 @@ impl Worker {
     }
 
     fn install(&mut self, package: &PackageIdent, recurse: bool) -> Result<Package> {
-        let package = match Package::load(package, None) {
+        let package = match Package::load(package, Some(&*FS_ROOT_PATH)) {
             Ok(pkg) => pkg,
             Err(_) => try!(self.download(package)),
         };
@@ -370,12 +370,12 @@ impl Worker {
     fn download(&mut self, package: &PackageIdent) -> Result<Package> {
         outputln!("Downloading {}", package);
         let mut archive = try!(self.depot.fetch_package(package,
-                                                        &Path::new(FS_ROOT_PATH)
+                                                        &Path::new(&*FS_ROOT_PATH)
                                                             .join(CACHE_ARTIFACT_PATH),
                                                         self.ui.progress()));
         try!(archive.verify(&default_cache_key_path(None)));
         outputln!("Installing {}", package);
         try!(archive.unpack(None));
-        Package::load(archive.ident().as_ref().unwrap(), None)
+        Package::load(archive.ident().as_ref().unwrap(), Some(&*FS_ROOT_PATH))
     }
 }

--- a/components/sup/src/package.rs
+++ b/components/sup/src/package.rs
@@ -21,6 +21,7 @@ use std::path::{Path, PathBuf};
 use std::string::ToString;
 use std::io::prelude::*;
 
+use hcore::fs::FS_ROOT_PATH;
 use hcore::package::{PackageIdent, PackageInstall};
 use hcore::util;
 
@@ -96,6 +97,19 @@ impl Package {
             Ok(r) => env::split_paths(&r).collect::<Vec<PathBuf>>(),
             Err(e) => return Err(sup_error!(Error::HabitatCore(e))),
         };
+
+        // Lets join the run paths to the FS_ROOT
+        // In most cases, this does nothing and should only mutate
+        // the paths in a windows studio where FS_ROOT_PATH will
+        // be the studio root path (ie c:\hab\studios\...). In any other
+        // environment FS_ROOT will be "/" and this will not make any
+        // meaningful change.
+        for i in 0..paths.len() {
+            if paths[i].starts_with("/") {
+                paths[i] = Path::new(&*FS_ROOT_PATH).join(paths[i].strip_prefix("/").unwrap());
+            }
+        }
+
         path::append_interpreter_and_path(&mut paths)
     }
 


### PR DESCRIPTION
This ensures that package handling inside of a windows studio occurs in the studio root directory in `c:\hab\studios\<studio path>\pkgs`. The following are impacted:

1. building packages that depend on other packages will be loaded and, if necessary downloaded, into the studio root.
2. starting services from the supervisor will load them from the studio root
3. The supervisor will load dependent packages from the studio root
4. When starting services, the bin PATHS of the service will be appended to the studio root directory

NOTE: This only affects windows. Linux studios, do not need this and can live in /hab due to the chrooted environment. This code will ignore the FS_ROOT variable for linux except where it already explicitly uses it (ie bintray).