### PR TITLE
launch hab start commands in a new window from the studio

### DIFF
--- a/components/plan-build-ps1/bin/hab-plan-build.ps1
+++ b/components/plan-build-ps1/bin/hab-plan-build.ps1
@@ -209,7 +209,7 @@ function _Exit-With {
 # terminated.
 function _Get-SystemCommands {
     if (_Check-Command hab) {
-        $script:_hab_cmd = (Get-Command hab).Source
+        $script:_hab_cmd = (Get-Command hab.exe).Source
     } else {
         _Exit-With "We require hab to sign artifacts; aborting" 1
     }

--- a/components/studio/bin/hab-studio.ps1
+++ b/components/studio/bin/hab-studio.ps1
@@ -283,6 +283,17 @@ function Enter-Studio {
     function build {
       & "$env:STUDIO_SCRIPT_ROOT\hab-plan-build.ps1" @args
     }
+    # This captures 'hab start' commands and launches them in a new window
+    # We do this because breaking out of a service via ctrl-C breaks
+    # nested shells. Any other hab command should simply be passed through
+    function hab {
+      if($args.length -gt 1 -and ($args[0] -eq "start")) {
+        Start-Process hab.exe -ArgumentList $args
+      }
+      else {
+        & hab.exe @args
+      }
+    }
     New-PSDrive -Name "Habitat" -PSProvider FileSystem -Root $env:HAB_STUDIO_ENTER_ROOT | Out-Null
     Set-Location "Habitat:\src"
   }


### PR DESCRIPTION
Exiting a running hab service with ctrl-C from a windows studio causes the nested shell to break and provides an extremely awkward user experience. In the common case one enters the windows studio from powershell. This spawns a nested shell instance that is the studio. Ctrl-C broadcasts to all processes in the console which creates a weird case where both nested shells begin to respond simultaneously. I could not find a clean way to avoid this.

As a workaround that I do not think is ideal but not terrible and certainly far better then this off putting experience, we will intercept `hab start` commands from the windows studio and spawn them in a separate console window.

Signed-off-by: Matt Wrock <matt@mattwrock.com>