### PR TITLE
[sup] Refactor most global `Config` into `ManagerConfig` & `ServiceSpec`

### DIFF
--- a/components/sup/src/command/start.rs
+++ b/components/sup/src/command/start.rs
@@ -59,10 +59,9 @@ use hcore::package::PackageIdent;
 
 use {PRODUCT, VERSION};
 use error::{Error, Result};
-use config::gconfig;
 use package::Package;
-use manager::{Manager, ManagerCfg};
-use manager::{Service, UpdateStrategy};
+use manager::{Manager, ManagerConfig};
+use manager::{Service, ServiceSpec, UpdateStrategy};
 
 static LOGKEY: &'static str = "CS";
 
@@ -74,7 +73,7 @@ static LOGKEY: &'static str = "CS";
 /// * Fails if it cannot find a package with the given name
 /// * Fails if the `run` method for the topology fails
 /// * Fails if an unknown topology was specified on the command line
-pub fn package(cfg: ManagerCfg) -> Result<()> {
+pub fn package(cfg: ManagerConfig, spec: ServiceSpec, local_artifact: Option<&str>) -> Result<()> {
     let mut ui = UI::default();
     if !am_i_root() {
         try!(ui.warn("Running the Habitat Supervisor requires root or administrator privileges. \
@@ -84,13 +83,11 @@ pub fn package(cfg: ManagerCfg) -> Result<()> {
         return Err(sup_error!(Error::RootRequired));
     }
 
-    match Package::load(gconfig().package(), Some(&*FS_ROOT_PATH)) {
+    match Package::load(&spec.ident, Some(&*FS_ROOT_PATH)) {
         Ok(mut package) => {
-            let update_strategy = gconfig().update_strategy();
-            match update_strategy {
+            match spec.update_strategy {
                 UpdateStrategy::None => {}
                 _ => {
-                    let url = gconfig().url();
                     outputln!("Checking Depot for newer versions...");
                     // It is important to pass `gconfig().package()` to `show_package()` instead
                     // of the package identifier of the loaded package. This will ensure that
@@ -100,13 +97,13 @@ pub fn package(cfg: ManagerCfg) -> Result<()> {
                     // If the operator does not specify a version number they will
                     // automatically receive updates for any releases, regardless of version
                     // number, for the started  package.
-                    let depot_client = try!(Client::new(url, PRODUCT, VERSION, None));
-                    let latest_pkg_data = try!(depot_client.show_package(gconfig().package()));
+                    let depot_client = try!(Client::new(&spec.depot_url, PRODUCT, VERSION, None));
+                    let latest_pkg_data = try!(depot_client.show_package(&spec.ident));
                     let latest_ident: PackageIdent = latest_pkg_data.get_ident().clone().into();
                     if &latest_ident > package.ident() {
                         outputln!("Downloading latest version from Depot: {}", latest_ident);
                         let new_pkg_data = try!(install::start(&mut ui,
-                                                               url,
+                                                               &spec.depot_url,
                                                                &latest_ident.to_string(),
                                                                PRODUCT,
                                                                VERSION,
@@ -119,16 +116,15 @@ pub fn package(cfg: ManagerCfg) -> Result<()> {
                     };
                 }
             }
-            start_package(package, cfg)
+            start_package(package, cfg, spec)
         }
         Err(_) => {
             outputln!("{} is not installed",
-                      Yellow.bold().paint(gconfig().package().to_string()));
-            let url = gconfig().url();
-            let new_pkg_data = match gconfig().local_artifact() {
+                      Yellow.bold().paint(spec.ident.to_string()));
+            let new_pkg_data = match local_artifact {
                 Some(artifact) => {
                     try!(install::start(&mut ui,
-                                        url,
+                                        &spec.depot_url,
                                         &artifact,
                                         PRODUCT,
                                         VERSION,
@@ -138,11 +134,11 @@ pub fn package(cfg: ManagerCfg) -> Result<()> {
                 }
                 None => {
                     outputln!("Searching for {} in remote {}",
-                              Yellow.bold().paint(gconfig().package().to_string()),
-                              url);
+                              Yellow.bold().paint(spec.ident.to_string()),
+                              &spec.depot_url);
                     try!(install::start(&mut ui,
-                                        url,
-                                        &gconfig().package().to_string(),
+                                        &spec.depot_url,
+                                        &spec.ident.to_string(),
                                         PRODUCT,
                                         VERSION,
                                         Path::new(&*FS_ROOT_PATH),
@@ -151,22 +147,18 @@ pub fn package(cfg: ManagerCfg) -> Result<()> {
                 }
             };
             let package = try!(Package::load(&new_pkg_data, Some(&*FS_ROOT_PATH)));
-            start_package(package, cfg)
+            start_package(package, cfg, spec)
         }
     }
 }
 
-fn start_package(package: Package, cfg: ManagerCfg) -> Result<()> {
+fn start_package(package: Package, cfg: ManagerConfig, spec: ServiceSpec) -> Result<()> {
     let run_path = try!(package.run_path());
     debug!("Setting the PATH to {}", run_path);
     env::set_var("PATH", &run_path);
 
     let mut manager = try!(Manager::new(cfg));
-    let service = try!(Service::new(package,
-                                    gconfig().group(),
-                                    gconfig().organization().clone(),
-                                    gconfig().topology(),
-                                    gconfig().update_strategy()));
+    let service = try!(Service::new(package, spec));
     try!(manager.add_service(service));
     manager.run()
 }

--- a/components/sup/src/config.rs
+++ b/components/sup/src/config.rs
@@ -30,11 +30,8 @@ use std::result;
 use std::str::FromStr;
 use std::sync::{Once, ONCE_INIT};
 
-use hcore::package::PackageIdent;
-
 use error::{Error, Result, SupError};
 use http_gateway;
-use manager::service::{Topology, UpdateStrategy};
 
 static LOGKEY: &'static str = "CFG";
 
@@ -122,139 +119,8 @@ impl fmt::Display for GossipListenAddr {
 /// Holds our configuration options.
 #[derive(Default, Debug, PartialEq, Eq)]
 pub struct Config {
+    // Currently only used by `ServiceConfig`
     pub service_config_http_listen: http_gateway::ListenAddr,
-    package: PackageIdent,
-    local_artifact: Option<String>,
-    url: String,
-    topology: Topology,
-    group: String,
-    bind: Vec<String>,
-    update_strategy: UpdateStrategy,
-    organization: Option<String>,
-    config_from: Option<String>,
-}
-
-impl Config {
-    /// Create a default `Config`
-    pub fn new() -> Config {
-        Config::default()
-    }
-
-    /// Set the config file from directory
-    pub fn set_config_from(&mut self, config_from: Option<String>) -> &mut Config {
-        self.config_from = config_from;
-        self
-    }
-
-    /// Return the config file from directory
-    pub fn config_from(&self) -> Option<&String> {
-        self.config_from.as_ref()
-    }
-
-    pub fn set_update_strategy(&mut self, strat: UpdateStrategy) -> &mut Config {
-        self.update_strategy = strat;
-        self
-    }
-
-    /// Return the command we used
-    pub fn update_strategy(&self) -> UpdateStrategy {
-        self.update_strategy
-    }
-
-    /// Set the group
-    pub fn set_group(&mut self, group: String) -> &mut Config {
-        self.group = group;
-        self
-    }
-
-    /// Return the group
-    pub fn group(&self) -> &str {
-        &self.group
-    }
-
-    /// Set the bindings
-    pub fn set_bind(&mut self, bind: Vec<String>) -> &mut Config {
-        self.bind = bind;
-        self
-    }
-
-    /// Return the bindings
-    pub fn bind(&self) -> Vec<String> {
-        self.bind.clone()
-    }
-
-    /// Set the url
-    pub fn set_url(&mut self, url: String) -> &mut Config {
-        self.url = url;
-        self
-    }
-
-    /// Return the url
-    pub fn url(&self) -> &str {
-        &self.url
-    }
-
-    /// Set the topology
-    pub fn set_topology(&mut self, topology: Topology) -> &mut Config {
-        self.topology = topology;
-        self
-    }
-
-    /// Return the topology
-    pub fn topology(&self) -> Topology {
-        self.topology
-    }
-
-    pub fn set_package(&mut self, ident: PackageIdent) -> &mut Config {
-        self.package = ident;
-        self
-    }
-
-    pub fn package(&self) -> &PackageIdent {
-        &self.package
-    }
-
-    pub fn set_local_artifact(&mut self, artifact: String) -> &mut Config {
-        self.local_artifact = Some(artifact);
-        self
-    }
-
-    pub fn local_artifact(&self) -> Option<&str> {
-        self.local_artifact.as_ref().map(String::as_ref)
-    }
-
-    pub fn set_organization(&mut self, org: String) -> &mut Config {
-        self.organization = Some(org);
-        self
-    }
-
-    pub fn organization(&self) -> Option<&str> {
-        self.organization.as_ref().map(|v| &**v)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use manager::service::Topology;
-    use super::Config;
-
-    #[test]
-    fn new() {
-        let c = Config::new();
-        assert_eq!(c.topology(), Topology::Standalone);
-    }
-
-    #[test]
-    fn url() {
-        let mut c = Config::new();
-        c.set_url(String::from("http://foolio.com"));
-        assert_eq!(c.url(), "http://foolio.com");
-    }
-
-    #[test]
-    fn topology() {
-        let mut c = Config::new();
-        c.set_topology(Topology::Leader);
-        assert_eq!(c.topology(), Topology::Leader);
-    }
+    // Currently only used by `Package`
+    pub package_config_from: Option<String>,
 }

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -25,11 +25,11 @@ extern crate clap;
 extern crate url;
 
 use std::net::{SocketAddr, ToSocketAddrs};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::result;
 use std::str::FromStr;
 
-use ansi_term::Colour::Yellow;
+use ansi_term::Colour::{Red, Yellow};
 use clap::{App, ArgMatches};
 use hcore::env as henv;
 use hcore::crypto::{default_cache_key_path, SymKey};
@@ -38,21 +38,18 @@ use hcore::package::{PackageArchive, PackageIdent};
 use hcore::url::{DEFAULT_DEPOT_URL, DEPOT_URL_ENVVAR};
 use url::Url;
 
-use sup::config::{gcache, gconfig, Config, GossipListenAddr};
+use sup::config::{gcache, Config, GossipListenAddr};
 use sup::error::{Error, Result};
 use sup::command;
 use sup::http_gateway;
-use sup::manager::ManagerCfg;
-use sup::manager::service::{UpdateStrategy, Topology};
+use sup::manager::ManagerConfig;
+use sup::manager::service::{ServiceSpec, Topology, UpdateStrategy};
 
 /// Our output key
 static LOGKEY: &'static str = "MN";
 
 /// The version number
 const VERSION: &'static str = include_str!(concat!(env!("OUT_DIR"), "/VERSION"));
-
-/// CLI defaults
-static DEFAULT_GROUP: &'static str = "default";
 
 static RING_ENVVAR: &'static str = "HAB_RING";
 static RING_KEY_ENVVAR: &'static str = "HAB_RING_KEY";
@@ -125,35 +122,30 @@ fn cli<'a, 'b>() -> App<'a, 'b> {
 }
 
 fn sub_bash(m: &ArgMatches) -> Result<()> {
-    let config = Config::new();
     if m.is_present("VERBOSE") {
         sup::output::set_verbose(true);
     }
     if m.is_present("NO_COLOR") {
         sup::output::set_no_color(true);
     }
-    debug!("Config:\n{:?}", config);
-    gcache(config);
+    try!(setup_global_config(m));
 
     command::shell::bash()
 }
 
 fn sub_sh(m: &ArgMatches) -> Result<()> {
-    let config = Config::new();
     if m.is_present("VERBOSE") {
         sup::output::set_verbose(true);
     }
     if m.is_present("NO_COLOR") {
         sup::output::set_no_color(true);
     }
-    debug!("Config:\n{:?}", config);
-    gcache(config);
+    try!(setup_global_config(m));
 
     command::shell::sh()
 }
 
 fn sub_start(m: &ArgMatches) -> Result<()> {
-    let mut config = Config::new();
     if m.is_present("VERBOSE") {
         sup::output::set_verbose(true);
     }
@@ -161,19 +153,16 @@ fn sub_start(m: &ArgMatches) -> Result<()> {
         sup::output::set_no_color(true);
     }
 
-    let mut manager_cfg = ManagerCfg::default();
+    let mut cfg = ManagerConfig::default();
 
     if let Some(addr_str) = m.value_of("LISTEN_GOSSIP") {
-        manager_cfg.gossip_listen = try!(GossipListenAddr::from_str(addr_str));
+        cfg.gossip_listen = try!(GossipListenAddr::from_str(addr_str));
     }
     if let Some(addr_str) = m.value_of("LISTEN_HTTP") {
-        let addr = try!(http_gateway::ListenAddr::from_str(addr_str));
-        // TODO fn: remove once ServiceConfig doesn't depend on global config
-        config.service_config_http_listen = addr.clone();
-        manager_cfg.http_listen = addr;
+        cfg.http_listen = try!(http_gateway::ListenAddr::from_str(addr_str));
     }
     if m.is_present("PERMANENT_PEER") {
-        manager_cfg.gossip_permanent = true;
+        cfg.gossip_permanent = true;
     }
     // TODO fn: Clean this up--using a for loop doesn't feel good however an iterator was
     // causing a lot of developer/compiler type confusion
@@ -196,7 +185,7 @@ fn sub_start(m: &ArgMatches) -> Result<()> {
             gossip_peers.push(addr);
         }
     }
-    manager_cfg.gossip_peers = gossip_peers;
+    cfg.gossip_peers = gossip_peers;
     let ring = match m.value_of("RING") {
         Some(val) => Some(try!(SymKey::get_latest_pair_for(&val, &default_cache_key_path(None)))),
         None => {
@@ -219,58 +208,77 @@ fn sub_start(m: &ArgMatches) -> Result<()> {
         }
     };
     if let Some(ring) = ring {
-        manager_cfg.ring = Some(ring.name_with_rev());
+        cfg.ring = Some(ring.name_with_rev());
     }
 
-    // TODO fn: This become service configuration
-    if let Some(ref config_from) = m.value_of("CONFIG_DIR") {
-        config.set_config_from(Some(config_from.to_string()));
-    }
-    // TODO fn: This become service configuration
-    if let Some(ref strategy) = m.value_of("STRATEGY") {
-        config.set_update_strategy(try!(UpdateStrategy::from_str(strategy)));
-    }
-    // TODO fn: This become service configuration
-    if let Some(ref ident_or_artifact) = m.value_of("PKG_IDENT_OR_ARTIFACT") {
+    let mut local_artifact: Option<&str> = None;
+    let ident = {
+        let ident_or_artifact = m.value_of("PKG_IDENT_OR_ARTIFACT").unwrap();
         if Path::new(ident_or_artifact).is_file() {
-            let ident = try!(PackageArchive::new(Path::new(ident_or_artifact)).ident());
-            config.set_package(ident);
-            config.set_local_artifact(ident_or_artifact.to_string());
+            local_artifact = Some(ident_or_artifact);
+            try!(PackageArchive::new(Path::new(ident_or_artifact)).ident())
         } else {
-            let ident = try!(PackageIdent::from_str(ident_or_artifact));
-            config.set_package(ident);
+            try!(PackageIdent::from_str(ident_or_artifact))
         }
-    }
-    // TODO fn: This become service configuration
-    if let Some(topology) = m.value_of("TOPOLOGY") {
-        config.set_topology(try!(Topology::from_str(topology)));
-    }
-    // TODO fn: This become service configuration
-    let env_or_default = henv::var(DEPOT_URL_ENVVAR).unwrap_or(DEFAULT_DEPOT_URL.to_string());
-    let url = m.value_of("DEPOT_URL").unwrap_or(&env_or_default);
-    config.set_url(url.to_string());
-    // TODO fn: This become service configuration
-    config.set_group(m.value_of("GROUP").unwrap_or(DEFAULT_GROUP).to_string());
-    // TODO fn: This become service configuration
-    if let Some(org) = m.value_of("ORGANIZATION") {
-        config.set_organization(org.to_string());
-    }
-    // TODO fn: This become service configuration
-    let bindings = match m.values_of("BIND") {
-        Some(bind) => bind.map(|s| s.to_string()).collect(),
-        None => vec![],
     };
-    config.set_bind(bindings);
+    let spec = try!(spec_from_matches(&ident, m));
 
+    try!(setup_global_config(m));
+
+    outputln!("Starting {}", Yellow.bold().paint(ident.to_string()));
+    try!(command::start::package(cfg, spec, local_artifact));
+    outputln!("Finished with {}", Yellow.bold().paint(ident.to_string()));
+    Ok(())
+}
+
+// TODO fn: Once the remaining fields of Config are gone, the struct and this function can be
+// deleted
+fn setup_global_config(m: &ArgMatches) -> Result<()> {
+    let mut config = Config::default();
+    // TODO fn: remove once ServiceConfig doesn't depend on global config
+    if let Some(addr_str) = m.value_of("LISTEN_HTTP") {
+        config.service_config_http_listen = try!(http_gateway::ListenAddr::from_str(addr_str));
+    }
+    // TODO fn: remove once Package doesn't depend on global config
+    if let Some(ref config_from) = m.value_of("CONFIG_DIR") {
+        config.package_config_from = Some(config_from.to_string());
+    }
     debug!("Config:\n{:?}", config);
     gcache(config);
-
-    outputln!("Starting {}",
-              Yellow.bold().paint(gconfig().package().to_string()));
-    try!(command::start::package(manager_cfg));
-    outputln!("Finished with {}",
-              Yellow.bold().paint(gconfig().package().to_string()));
     Ok(())
+}
+
+fn spec_from_matches(ident: &PackageIdent, m: &ArgMatches) -> Result<ServiceSpec> {
+    let mut spec = ServiceSpec::default_for(ident.clone());
+
+    if let Some(group) = m.value_of("GROUP") {
+        spec.group = group.to_string();
+    }
+    if let Some(org) = m.value_of("ORGANIZATION") {
+        spec.organization = Some(org.to_string());
+    }
+    let env_or_default = henv::var(DEPOT_URL_ENVVAR).unwrap_or(DEFAULT_DEPOT_URL.to_string());
+    let url = m.value_of("DEPOT_URL").unwrap_or(&env_or_default);
+    spec.depot_url = String::from(url);
+    if let Some(topology) = m.value_of("TOPOLOGY") {
+        spec.topology = try!(Topology::from_str(topology));
+    }
+    if let Some(ref strategy) = m.value_of("STRATEGY") {
+        spec.update_strategy = try!(UpdateStrategy::from_str(strategy));
+    }
+    if let Some(binds) = m.values_of("BIND") {
+        spec.binds = binds.map(|s| s.to_string()).collect();
+    }
+    if let Some(ref config_from) = m.value_of("CONFIG_DIR") {
+        spec.dev_config_from = Some(PathBuf::from(config_from));
+        outputln!("");
+        outputln!("{} Setting '{}' should only be used in development, not production!",
+                  Red.bold().paint("WARNING:".to_string()),
+                  Yellow.bold().paint(format!("--config-from {}", config_from)));
+        outputln!("");
+    }
+
+    Ok(spec)
 }
 
 fn dir_exists(val: String) -> result::Result<(), String> {

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -31,7 +31,7 @@ use hcore::crypto::{default_cache_key_path, SymKey};
 use time::{SteadyTime, Duration as TimeDuration};
 use toml;
 
-pub use manager::service::{Service, ServiceConfig, UpdateStrategy, Topology};
+pub use manager::service::{Service, ServiceConfig, ServiceSpec, UpdateStrategy, Topology};
 use self::service_updater::ServiceUpdater;
 use error::Result;
 use config::GossipListenAddr;
@@ -59,7 +59,7 @@ impl State {
 }
 
 #[derive(Default)]
-pub struct ManagerCfg {
+pub struct ManagerConfig {
     pub gossip_listen: GossipListenAddr,
     pub http_listen: http_gateway::ListenAddr,
     pub gossip_peers: Vec<SocketAddr>,
@@ -74,7 +74,7 @@ pub struct Manager {
 }
 
 impl Manager {
-    pub fn new(cfg: ManagerCfg) -> Result<Manager> {
+    pub fn new(cfg: ManagerConfig) -> Result<Manager> {
         let mut member = Member::new();
         member.set_persistent(cfg.gossip_permanent);
         member.set_swim_port(cfg.gossip_listen.port() as i32);

--- a/components/sup/src/manager/service/config.rs
+++ b/components/sup/src/manager/service/config.rs
@@ -69,7 +69,7 @@ impl ServiceConfig {
     pub fn new(service_group: &str,
                package: &Package,
                cl: &CensusList,
-               bindings: Vec<String>)
+               bindings: &[String])
                -> Result<ServiceConfig> {
         let cfg = try!(Cfg::new(package));
         let bind = try!(Bind::new(bindings, &cl));
@@ -126,7 +126,7 @@ impl ServiceConfig {
     }
 
     /// Replace the `svc` data.
-    pub fn bind(&mut self, bindings: Vec<String>, cl: &CensusList) {
+    pub fn bind(&mut self, bindings: &[String], cl: &CensusList) {
         // This is only safe because we will fail the first time if the bindings are badly
         // formatted - so we know we can't fail here.
         self.bind = Bind::new(bindings, cl).unwrap();
@@ -214,7 +214,7 @@ impl ServiceConfig {
 pub struct Bind(toml::Table);
 
 impl Bind {
-    fn new(binding_cfg: Vec<String>, cl: &CensusList) -> Result<Bind> {
+    fn new(binding_cfg: &[String], cl: &CensusList) -> Result<Bind> {
         let mut top = toml::Table::new();
         let bindings = try!(Bind::split_bindings(binding_cfg));
         for (bind, service_group) in bindings {
@@ -231,7 +231,7 @@ impl Bind {
         Ok(Bind(top))
     }
 
-    fn split_bindings(bindings: Vec<String>) -> Result<Vec<(String, String)>> {
+    fn split_bindings(bindings: &[String]) -> Result<Vec<(String, String)>> {
         let mut bresult = Vec::new();
         for bind in bindings.into_iter() {
             let values: Vec<&str> = bind.splitn(2, ':').collect();
@@ -736,10 +736,10 @@ mod test {
 
     #[test]
     fn to_toml_hab() {
-        gcache(Config::new());
+        gcache(Config::default());
         let pkg = gen_pkg();
         let cl = gen_census_list();
-        let sc = ServiceConfig::new("redis.default", &pkg, &cl, Vec::new()).unwrap();
+        let sc = ServiceConfig::new("redis.default", &pkg, &cl, &Vec::new()).unwrap();
         let toml = sc.to_toml().unwrap();
         let version = toml.lookup("hab.version").unwrap().as_str().unwrap();
         assert_eq!(version, VERSION);
@@ -747,10 +747,10 @@ mod test {
 
     #[test]
     fn to_toml_pkg() {
-        gcache(Config::new());
+        gcache(Config::default());
         let pkg = gen_pkg();
         let cl = gen_census_list();
-        let sc = ServiceConfig::new("redis.default", &pkg, &cl, Vec::new()).unwrap();
+        let sc = ServiceConfig::new("redis.default", &pkg, &cl, &Vec::new()).unwrap();
         let toml = sc.to_toml().unwrap();
         let name = toml.lookup("pkg.name").unwrap().as_str().unwrap();
         assert_eq!(name, "redis");
@@ -758,10 +758,10 @@ mod test {
 
     #[test]
     fn to_toml_sys() {
-        gcache(Config::new());
+        gcache(Config::default());
         let pkg = gen_pkg();
         let cl = gen_census_list();
-        let sc = ServiceConfig::new("redis.default", &pkg, &cl, Vec::new()).unwrap();
+        let sc = ServiceConfig::new("redis.default", &pkg, &cl, &Vec::new()).unwrap();
         let toml = sc.to_toml().unwrap();
         let ip = toml.lookup("sys.ip").unwrap().as_str().unwrap();
         let re = Regex::new(r"\d+\.\d+\.\d+\.\d+").unwrap();
@@ -921,7 +921,7 @@ mod test {
 
         #[test]
         fn ip() {
-            gcache(Config::new());
+            gcache(Config::default());
             let s = Sys::new();
             let re = Regex::new(r"\d+\.\d+\.\d+\.\d+").unwrap();
             assert!(re.is_match(&s.ip));
@@ -929,7 +929,7 @@ mod test {
 
         #[test]
         fn hostname() {
-            gcache(Config::new());
+            gcache(Config::default());
             let s = Sys::new();
             let re = Regex::new(r"\w+").unwrap();
             assert!(re.is_match(&s.hostname));
@@ -937,7 +937,7 @@ mod test {
 
         #[test]
         fn to_toml() {
-            gcache(Config::new());
+            gcache(Config::default());
             let s = Sys::new();
             let toml = s.to_toml().unwrap();
             let ip = toml.lookup("ip").unwrap().as_str().unwrap();

--- a/components/sup/src/manager/service/config.rs
+++ b/components/sup/src/manager/service/config.rs
@@ -598,8 +598,8 @@ impl Sys {
         Sys(SysInfo {
             ip: ip,
             hostname: hostname,
-            http_gateway_ip: gconfig().http_listen_addr().ip().to_string(),
-            http_gateway_port: gconfig().http_listen_addr().port(),
+            http_gateway_ip: gconfig().service_config_http_listen.ip().to_string(),
+            http_gateway_port: gconfig().service_config_http_listen.port(),
         })
     }
 

--- a/components/sup/src/package.rs
+++ b/components/sup/src/package.rs
@@ -190,8 +190,8 @@ impl Package {
     }
 
     pub fn config_from(&self) -> PathBuf {
-        gconfig().config_from().as_ref().map_or(self.pkg_install.installed_path().clone(),
-                                                |p| PathBuf::from(p))
+        gconfig().package_config_from.as_ref().map_or(self.pkg_install.installed_path().clone(),
+                                                      |p| PathBuf::from(p))
     }
 
     /// Return an iterator of the configuration file names to render.


### PR DESCRIPTION
This is further refactoring work with an aim to eliminating the need for the single global `Config` struct. This change breaks most of the data into 2 intermediary structs:

* `ManagerConfig` - used to prepare and launch the `Manager`
* `ServiceSpec` - a representation the the _intended_ service behavior, used the prepare a `Service`

The 2 remaining fields in the global `Config` struct each have only 1 call site each and have been skipped for the moment as they won't directly impact a zero-to-n supervised service setup.

As this is a refactor, there should be no external behavior changes.