### PR TITLE
pull in cacerts in windows build and then use them in http client

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -242,6 +242,12 @@ $env:LIBZMQ_PREFIX              = Split-Path $ChocolateyHabitatLibDir -Parent
 
 Write-RustToolVersion
 
+if(!(Test-Path "$env:TEMP\cacert.pem")) {
+    Write-Host "Downloading cacerts.pem"
+    Invoke-WebRequest -UseBasicParsing -Uri "http://curl.haxx.se/ca/cacert.pem" -OutFile "$env:TEMP\cacert.pem"
+}
+$env:SSL_CERT_FILE="$env:TEMP\cacert.pem"
+
 if ($Test) { Invoke-Test $Path -Clean:$Clean -Release:$Release }
 if (!$SkipBuild) { Invoke-Build $Path -Clean:$Clean -Release:$Release }
 if($Package) { New-HartPackage }

--- a/components/hab-butterfly/plan.ps1
+++ b/components/hab-butterfly/plan.ps1
@@ -6,9 +6,10 @@ $pkg_license = @("Apache-2.0")
 $pkg_source = "https://s3-us-west-2.amazonaws.com/habitat-win-deps/hab-win-deps.zip"
 $pkg_shasum="0a99b1e171ff1075cca139cf9f695685f7a04b122f1704f82f2b852561847710"
 $pkg_bin_dirs = @("bin")
-$pkg_build_deps = @("core/visual-cpp-redist-2013", "core/rust")
+$pkg_build_deps = @("core/visual-cpp-redist-2013", "core/rust", "core/cacerts")
 
 function Invoke-Prepare {
+    $env:SSL_CERT_FILE              = "$(Get-HabPackagePath "cacerts")/ssl/certs/cacert.pem"
     $env:PLAN_VERSION               = "$pkg_version/$pkg_release"
     $env:CARGO_TARGET_DIR           = "$HAB_CACHE_SRC_PATH/$pkg_dirname"
     $env:LIB                        = "$HAB_CACHE_SRC_PATH/$pkg_dirname/lib"

--- a/components/hab/plan.ps1
+++ b/components/hab/plan.ps1
@@ -6,9 +6,10 @@ $pkg_license = @("Apache-2.0")
 $pkg_source = "https://s3-us-west-2.amazonaws.com/habitat-win-deps/hab-win-deps.zip"
 $pkg_shasum="0a99b1e171ff1075cca139cf9f695685f7a04b122f1704f82f2b852561847710"
 $pkg_bin_dirs = @("bin")
-$pkg_build_deps = @("core/rust")
+$pkg_build_deps = @("core/rust", "core/cacerts")
 
 function Invoke-Prepare {
+    $env:SSL_CERT_FILE              = "$(Get-HabPackagePath "cacerts")/ssl/certs/cacert.pem"
     $env:PLAN_VERSION               = "$pkg_version/$pkg_release"
     $env:CARGO_TARGET_DIR           = "$HAB_CACHE_SRC_PATH/$pkg_dirname"
     $env:LIB                        += ";$HAB_CACHE_SRC_PATH/$pkg_dirname/lib"

--- a/components/http-client/build.rs
+++ b/components/http-client/build.rs
@@ -2,7 +2,7 @@ fn main() {
     inner::main()
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(not(target_os = "macos"))]
 mod inner {
     use std::env;
     use std::fs;
@@ -17,7 +17,7 @@ mod inner {
     }
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(target_os = "macos")]
 mod inner {
     pub fn main() {}
 }

--- a/components/http-client/src/lib.rs
+++ b/components/http-client/src/lib.rs
@@ -31,7 +31,7 @@ pub mod proxy;
 pub use api_client::ApiClient;
 pub use error::{Error, Result};
 
-#[cfg(target_os = "linux")]
+#[cfg(not(target_os = "macos"))]
 mod ssl {
     use std::fs::{self, File};
     use std::io::Write;
@@ -76,7 +76,7 @@ mod ssl {
     }
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(target_os = "macos")]
 mod ssl {
     use std::path::Path;
 

--- a/components/sup/plan.ps1
+++ b/components/sup/plan.ps1
@@ -6,9 +6,10 @@ $pkg_license = @("Apache-2.0")
 $pkg_source = "https://s3-us-west-2.amazonaws.com/habitat-win-deps/hab-win-deps.zip"
 $pkg_shasum="0a99b1e171ff1075cca139cf9f695685f7a04b122f1704f82f2b852561847710"
 $pkg_bin_dirs = @("bin")
-$pkg_build_deps = @("core/visual-cpp-redist-2013", "core/rust")
+$pkg_build_deps = @("core/visual-cpp-redist-2013", "core/rust", "core/cacerts")
 
 function Invoke-Prepare {
+    $env:SSL_CERT_FILE              = "$(Get-HabPackagePath "cacerts")/ssl/certs/cacert.pem"
     $env:PLAN_VERSION               = "$pkg_version/$pkg_release"
     $env:CARGO_TARGET_DIR           = "$HAB_CACHE_SRC_PATH/$pkg_dirname"
     $env:LIB                        = "$HAB_CACHE_SRC_PATH/$pkg_dirname/lib"


### PR DESCRIPTION
This consolidates SSL logic between linux and windows and just alters the windows plans and build.ps1 to pull down the cacerts.pem.

My only worry here is if this will break MAC builds.

Signed-off-by: Matt Wrock <matt@mattwrock.com>