### PR TITLE
Build devshell in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,35 +1,39 @@
-shell:
-  image: habitat/devshell
-  privileged: true
-  volumes:
-    - .:/src
-    - /var/run/docker.sock:/var/run/docker.sock
-  volumes_from:
-    - cache_artifacts
-    - cache_keys
-    - cargo
-    - etc
+version: '2'
 
-cache_artifacts:
-  image: tianon/true
-  command: /true
-  volumes:
-    - /hab/cache/artifacts
+services:
+  shell:
+    image: habitat/devshell
+    build: ./
+    privileged: true
+    volumes:
+      - .:/src
+      - /var/run/docker.sock:/var/run/docker.sock
+    volumes_from:
+      - cache_artifacts
+      - cache_keys
+      - cargo
+      - etc
 
-cache_keys:
-  image: tianon/true
-  command: /true
-  volumes:
-    - /hab/cache/keys
+  cache_artifacts:
+    image: tianon/true
+    command: /true
+    volumes:
+      - /hab/cache/artifacts
 
-cargo:
-  image: tianon/true
-  command: /true
-  volumes:
-    - /cargo-cache
+  cache_keys:
+    image: tianon/true
+    command: /true
+    volumes:
+      - /hab/cache/keys
 
-etc:
-  image: tianon/true
-  command: /true
-  volumes:
-    - /hab/etc
+  cargo:
+    image: tianon/true
+    command: /true
+    volumes:
+      - /cargo-cache
+
+  etc:
+    image: tianon/true
+    command: /true
+    volumes:
+      - /hab/etc


### PR DESCRIPTION
Switching the docker-compose.yml filed to 'v2' allows adding the
`build:` key in addition to the `image:` key. That way docker compose
can build the habitat/devshell image without needing to pull it. This
makes for an improved worklfow since habitat/devshell is currently not
publicly available for download.

Fixes https://github.com/habitat-sh/habitat/issues/1745