### PR TITLE
Disambiguate key 'port' from listening port

### DIFF
--- a/www/source/shared/_configure_plan_common.html.md.erb
+++ b/www/source/shared/_configure_plan_common.html.md.erb
@@ -18,12 +18,14 @@ In this tutorial, our Node.js app already has a configuration file called `confi
 
     Because we want to be able to configure both of the settings above, we are going to replace the existing values in the file with references to handlebar expressions. Those expressions will look to a TOML file to define an initial set of values if they are not overridden at start up.
 
-4. Replace the values in `config.json` with the expressions **cfg.message** and **cfg.port**.
+4. Replace the values in `config.json` with the expressions **cfg.message** and **cfg.listening_port**.
 
        {
            "message": "{{cfg.message}}",
-           "port": "{{cfg.port}}"
+           "port": "{{cfg.listening_port}}"
        }
+
+   > Note: The key `port` and the value `cfg.listening_port` map to the `pkg_exports` key and value pair you added to your plan.sh.
 
 5. Save the file.
 
@@ -41,7 +43,7 @@ As we said, a TOML file is associated with your configuration file and specifies
        message = "Hello, World!"
 
        # The port number that is listening for requests.
-       port = 8080
+       listening_port = 8080
 
     We use the same values as the ones specified in the original `config.json` file to keep the initial start up experience the same. Also, the port value specified is specific to the Node.js application and it will bind to the port of its host. In this case, the host is the Docker container you will create in the next step.
 

--- a/www/source/shared/_create_plan_common.html.md.erb
+++ b/www/source/shared/_create_plan_common.html.md.erb
@@ -83,29 +83,27 @@ We now have a skeleton plan, but we need to modify some of its settings before w
 4. Leave the `pkg_upstream_url` and `pkg_source` values as they are. The `pkg_upstream_url` is a metadata setting for your project/application -- in this case, the `habitat-example-plans` GitHub repo. The `pkg_source` setting is required, but since you will be building your package with cloned source files, you do not need to specify a valid URL.
 5. Our Node.js application depends on the `node` and `npm` binaries at runtime, so include one of the core Habitat packages, `core/node`, as a runtime dependency. Transitive dependencies, such as `core/glibc` used by `core/node`, do not need to be listed when creating plans.
 
-        pkg_deps=(core/node)
+       pkg_deps=(core/node)
 
    > Note: Later on in this topic we are going to install the `nconf` module into our package, which requires the `npm` binary; however, we do not need to include `core/node` as a build dependency because the build script automatically installs build and runtime dependencies and adds their bin directories to the `$PATH` variable before building the package. So, if you need the same dependent binary for both build and runtime operations, you only need to include it as a runtime dependency.
 
 6. Set the `pkg_exports` value to an associative array with one key value pair. This is an alias of a default configuration which will be shared to consumers who `--bind` to your package. All service configuration is considered "private" to the supervisor and not shared without an explicit entry here. We will setup the `default.toml` for the configuration soon.
 
-    pkg_exports=(
-      [port]=port
-    )
+       pkg_exports=(
+         [port]=listening_port
+       )
 
-7. Set the `pkg_exposes` value to `port`. The `pkg_exposes` values are used to create an `EXPOSE` instruction in a generated Dockerfile, which we will use to create an optional Docker container; however, specifying the `pkg_exposes` value does not publish this port for access by the host machine. We will do that later.
+7. Set the `pkg_exposes` value to the key "port". The `pkg_exposes` values are used to create an `EXPOSE` instruction in a generated Dockerfile, which we will use to create an optional Docker container; however, specifying the `pkg_exposes` value does not publish this port for access by the host machine. We will do that later.
 
    Add the following line to your plan:
 
-        pkg_exposes=(port)
+       pkg_exposes=(port)
 
 It's important to note that the Node.js application in this tutorial does not create any new binaries or libraries of its own; however, for those packages that compile binaries and/or libraries, you must also include settings that specify the directory names where those files will be located, such as:
 
-     pkg_bin_dirs=(bin)
-     pkg_include_dirs=(include)
-     pkg_lib_dirs=(lib)
-
-## Create a default.toml
+    pkg_bin_dirs=(bin)
+    pkg_include_dirs=(include)
+    pkg_lib_dirs=(lib)
 
 ## Add in callbacks
 
@@ -170,7 +168,7 @@ pkg_upstream_url=https://github.com/habitat-sh/habitat-example-plans
 pkg_source=nosuchfile.tar.gz
 pkg_deps=(core/node)
 pkg_exports=(
-  [port]=port
+  [port]=listening_port
 )
 pkg_exposes=(port)
 


### PR DESCRIPTION
Having both the key and the value named "port" could potentially confuse people when they are defining `pkg_exposes`.

Signed-off-by: David Wrede <dwrede@chef.io>