### PR TITLE
Consistent hook behaviour

### DIFF
--- a/components/sup/src/manager/census.rs
+++ b/components/sup/src/manager/census.rs
@@ -49,6 +49,14 @@ impl CensusUpdate {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+pub enum ElectionStatus {
+    None,
+    ElectionInProgress,
+    ElectionNoQuorum,
+    ElectionFinished,
+}
+
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, Default)]
 pub struct CensusEntry {
     pub member_id: String,
@@ -196,6 +204,18 @@ impl CensusEntry {
 
     pub fn get_election_is_finished(&self) -> bool {
         self.election_is_finished.unwrap_or(false)
+    }
+
+    pub fn get_election_status(&self) -> ElectionStatus {
+        if self.get_election_is_running() {
+            ElectionStatus::ElectionInProgress
+        } else if self.get_election_is_no_quorum() {
+            ElectionStatus::ElectionNoQuorum
+        } else if self.get_election_is_finished() {
+            ElectionStatus::ElectionFinished
+        } else {
+            ElectionStatus::None
+        }
     }
 
     pub fn set_update_election_is_running(&mut self, value: bool) {

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -167,31 +167,36 @@ impl Manager {
                 self.persist_service_files(&mut service);
                 let svc_cfg_updated = self.persist_service_config(&mut service);
 
-                if svc_cfg_updated || census_updated {
-                    let svc_cfg = service.reconfigure(&self.state
+                if !service.initialized {
+                    if service.initialize(&self.state
                         .census_list
                         .read()
-                        .expect("Census list lock is poisoned!"));
-                    if svc_cfg_updated && svc_cfg.is_some() {
-                        self.update_service_rumor_cfg(&service,
-                                                      svc_cfg.as_ref().unwrap(),
-                                                      &mut last_census_update);
+                        .expect("Census list lock is poisened!")) {
+                        service.start();
                     }
-                }
+                } else {
+                    if svc_cfg_updated || census_updated {
+                        let svc_cfg = service.reconfigure(&self.state
+                            .census_list
+                            .read()
+                            .expect("Census list lock is poisoned!"));
+                        if svc_cfg_updated && svc_cfg.is_some() {
+                            self.update_service_rumor_cfg(&service,
+                                                          svc_cfg.as_ref().unwrap(),
+                                                          &mut last_census_update);
+                        }
+                    }
 
-                service.initialize(&self.state
-                    .census_list
-                    .read()
-                    .expect("Census list lock is poisened!"));
-                service.check_process();
+                    service.check_process();
 
-                if service.initialized && (service.needs_restart || service.is_down()) {
-                    match service.restart(&self.state
-                        .census_list
-                        .read()
-                        .expect("Census list lock is poisoned!")) {
-                        Ok(()) => {}
-                        Err(e) => outputln!("Cannot restart service: {}", e),
+                    if service.initialized && (service.needs_restart || service.is_down()) {
+                        match service.restart(&self.state
+                            .census_list
+                            .read()
+                            .expect("Census list lock is poisoned!")) {
+                            Ok(()) => {}
+                            Err(e) => outputln!("Cannot restart service: {}", e),
+                        }
                     }
                 }
             }

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -167,6 +167,17 @@ impl Manager {
                 self.persist_service_files(&mut service);
                 let svc_cfg_updated = self.persist_service_config(&mut service);
 
+                let svc_cfg = service.render_service_config(&self.state
+                    .census_list
+                    .read()
+                    .expect("Census list lock is poisened!"));
+
+                if svc_cfg_updated && svc_cfg.is_some() {
+                    self.update_service_rumor_cfg(&service,
+                                                  svc_cfg.as_ref().unwrap(),
+                                                  &mut last_census_update);
+                }
+
                 if !service.initialized {
                     if service.initialize(&self.state
                         .census_list
@@ -175,26 +186,17 @@ impl Manager {
                         service.start();
                     }
                 } else {
-                    if svc_cfg_updated || census_updated {
-                        let svc_cfg = service.reconfigure(&self.state
-                            .census_list
-                            .read()
-                            .expect("Census list lock is poisoned!"));
-                        if svc_cfg_updated && svc_cfg.is_some() {
-                            self.update_service_rumor_cfg(&service,
-                                                          svc_cfg.as_ref().unwrap(),
-                                                          &mut last_census_update);
-                        }
-                    }
 
                     service.check_process();
 
-                    if service.initialized && (service.needs_restart || service.is_down()) {
+                    if service.needs_restart || service.is_down() {
                         match service.restart(&self.state
                             .census_list
                             .read()
                             .expect("Census list lock is poisoned!")) {
-                            Ok(()) => {}
+                            Ok(()) => {
+                                service.reconfigure();
+                            }
                             Err(e) => outputln!("Cannot restart service: {}", e),
                         }
                     }

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -179,7 +179,10 @@ impl Manager {
                     }
                 }
 
-                service.initialize();
+                service.initialize(&self.state
+                    .census_list
+                    .read()
+                    .expect("Census list lock is poisened!"));
                 service.check_process();
 
                 if service.initialized && (service.needs_restart || service.is_down()) {

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -190,13 +190,18 @@ impl Manager {
                     service.check_process();
 
                     if service.needs_restart || service.is_down() {
-                        if service.restart(&self.state
+                        match service.restart(&self.state
                             .census_list
                             .read()
                             .expect("Census list lock is poisoned!")) {
-                            service.reconfigure();
-                        } else {
-                           outputln!("Cannot restart service: {}", e),
+                            Ok(_) => {
+                                if !service.needs_restart {
+                                    service.reconfigure();
+                                }
+                            }
+                            Err(e) => {
+                                outputln!("Cannot restart service: {}", e);
+                            }
                         }
                     }
                 }

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -190,14 +190,13 @@ impl Manager {
                     service.check_process();
 
                     if service.needs_restart || service.is_down() {
-                        match service.restart(&self.state
+                        if service.restart(&self.state
                             .census_list
                             .read()
                             .expect("Census list lock is poisoned!")) {
-                            Ok(()) => {
-                                service.reconfigure();
-                            }
-                            Err(e) => outputln!("Cannot restart service: {}", e),
+                            service.reconfigure();
+                        } else {
+                           outputln!("Cannot restart service: {}", e),
                         }
                     }
                 }

--- a/components/sup/src/manager/service/mod.rs
+++ b/components/sup/src/manager/service/mod.rs
@@ -382,7 +382,7 @@ impl Service {
     }
 
     /// Run initialization hook if present
-    pub fn initialize(&mut self, census_list: &CensusList) {
+    pub fn initialize(&mut self, census_list: &CensusList) -> bool {
         if !self.initialized {
             match self.topology {
                 Topology::Leader => {
@@ -408,7 +408,7 @@ impl Service {
                                     outputln!(preamble self.service_group, "Initializing");
                                     if let Some(err) = self.hooks().try_run(HookType::Init).err() {
                                         outputln!(preamble self.service_group, "Initialization failed: {}", err);
-                                        return;
+                                        return false;
                                     }
                                     self.initialized = true;
                                 }
@@ -422,12 +422,13 @@ impl Service {
                     outputln!(preamble self.service_group, "Initializing");
                     if let Some(err) = self.hooks().try_run(HookType::Init).err() {
                         outputln!(preamble self.service_group, "Initialization failed: {}", err);
-                        return;
+                        return false;
                     }
                     self.initialized = true;
                 }
             }
         }
+        self.initialized
     }
 
     pub fn load_service_config(&self, census: &CensusList) -> Result<ServiceConfig> {

--- a/components/sup/src/manager/service/mod.rs
+++ b/components/sup/src/manager/service/mod.rs
@@ -39,7 +39,7 @@ pub use self::health::{HealthCheck, SmokeCheck};
 use self::hooks::{HOOK_PERMISSIONS, HookType};
 use error::{Error, Result, SupError};
 use manager::signals;
-use manager::census::CensusList;
+use manager::census::{CensusList, ElectionStatus};
 use package::Package;
 use supervisor::{Supervisor, RuntimeConfig};
 use util;
@@ -47,14 +47,6 @@ use util;
 static LOGKEY: &'static str = "SR";
 
 static DEFAULT_GROUP: &'static str = "default";
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
-pub enum LastRestartDisplay {
-    None,
-    ElectionInProgress,
-    ElectionNoQuorum,
-    ElectionFinished,
-}
 
 pub struct ServiceSpec {
     pub ident: PackageIdent,
@@ -92,7 +84,7 @@ pub struct Service {
     pub update_strategy: UpdateStrategy,
     pub current_service_files: HashMap<String, u64>,
     pub initialized: bool,
-    pub last_restart_display: LastRestartDisplay,
+    pub last_election_status: ElectionStatus,
     pub supervisor: Supervisor,
     pub depot_url: String,
     pub spec_ident: PackageIdent,
@@ -118,7 +110,7 @@ impl Service {
             needs_restart: false,
             update_strategy: spec.update_strategy,
             current_service_files: HashMap::new(),
-            last_restart_display: LastRestartDisplay::None,
+            last_election_status: ElectionStatus::None,
             initialized: false,
             cfg_incarnation: 0,
         })
@@ -135,32 +127,33 @@ impl Service {
                     // We know perfectly well we are in this census, because we asked for
                     // our own service group *by name*
                     let me = census.me().unwrap();
-                    if me.get_election_is_running() {
-                        if self.last_restart_display != LastRestartDisplay::ElectionInProgress {
-                            outputln!(preamble self.service_group,
-                                      "Not restarting service; {}",
-                                      Yellow.bold().paint("election in progress."));
-                            self.last_restart_display = LastRestartDisplay::ElectionInProgress;
+                    let current_status = me.get_election_status();
+                    if self.last_election_status != current_status {
+                        match me.get_election_status() {
+                            ElectionStatus::ElectionInProgress => {
+                                outputln!(preamble self.service_group,
+                                          "Not restarting service; {}",
+                                          Yellow.bold().paint("election in progress."));
+                            }
+                            ElectionStatus::ElectionNoQuorum => {
+                                outputln!(preamble self.service_group,
+                                          "Not restarting service; {}, {}.",
+                                          Yellow.bold().paint("election in progress"),
+                                          Red.bold().paint("and we have no quorum"));
+                            }
+                            ElectionStatus::ElectionFinished => {
+                                // We know we have a leader, so this is fine
+                                let leader_id = census.get_leader().unwrap().get_member_id();
+                                outputln!(preamble self.service_group,
+                                          "Restarting service; {} is the leader",
+                                          Green.bold().paint(leader_id));
+                                self.last_election_status = ElectionStatus::ElectionFinished;
+                                self.needs_restart = false;
+                                try!(self.supervisor.restart());
+                            }
+                            ElectionStatus::None => {}
                         }
-                    } else if me.get_election_is_no_quorum() {
-                        if self.last_restart_display != LastRestartDisplay::ElectionNoQuorum {
-                            outputln!(preamble self.service_group,
-                                      "Not restarting service; {}, {}.",
-                                      Yellow.bold().paint("election in progress"),
-                                      Red.bold().paint("and we have no quorum"));
-                            self.last_restart_display = LastRestartDisplay::ElectionNoQuorum;
-                        }
-                    } else if me.get_election_is_finished() {
-                        // We know we have a leader, so this is fine
-                        let leader_id = census.get_leader().unwrap().get_member_id();
-                        if self.last_restart_display != LastRestartDisplay::ElectionFinished {
-                            outputln!(preamble self.service_group,
-                                      "Restarting service; {} is the leader",
-                                      Green.bold().paint(leader_id));
-                            self.last_restart_display = LastRestartDisplay::ElectionFinished;
-                        }
-                        self.needs_restart = false;
-                        try!(self.supervisor.restart());
+                        self.last_election_status = current_status;
                     }
                 }
             }

--- a/components/sup/src/manager/service/mod.rs
+++ b/components/sup/src/manager/service/mod.rs
@@ -120,7 +120,7 @@ impl Service {
         self.supervisor.start()
     }
 
-    pub fn restart(&mut self, census_list: &CensusList) -> Result<()> {
+    pub fn restart(&mut self, census_list: &CensusList) -> bool {
         match self.topology {
             Topology::Leader => {
                 if let Some(census) = census_list.get(&*self.service_group) {
@@ -150,6 +150,7 @@ impl Service {
                                 self.last_election_status = ElectionStatus::ElectionFinished;
                                 self.needs_restart = false;
                                 try!(self.supervisor.restart());
+                                return true;
                             }
                             ElectionStatus::None => {}
                         }
@@ -160,9 +161,10 @@ impl Service {
             Topology::Standalone => {
                 self.needs_restart = false;
                 try!(self.supervisor.restart());
+                return true;
             }
         }
-        Ok(())
+        return false;
     }
 
     pub fn down(&mut self) -> Result<()> {

--- a/components/sup/src/manager/service/mod.rs
+++ b/components/sup/src/manager/service/mod.rs
@@ -120,7 +120,7 @@ impl Service {
         self.supervisor.start()
     }
 
-    pub fn restart(&mut self, census_list: &CensusList) -> bool {
+    pub fn restart(&mut self, census_list: &CensusList) -> Result<()> {
         match self.topology {
             Topology::Leader => {
                 if let Some(census) = census_list.get(&*self.service_group) {
@@ -150,7 +150,6 @@ impl Service {
                                 self.last_election_status = ElectionStatus::ElectionFinished;
                                 self.needs_restart = false;
                                 try!(self.supervisor.restart());
-                                return true;
                             }
                             ElectionStatus::None => {}
                         }
@@ -161,10 +160,9 @@ impl Service {
             Topology::Standalone => {
                 self.needs_restart = false;
                 try!(self.supervisor.restart());
-                return true;
             }
         }
-        return false;
+        Ok(())
     }
 
     pub fn down(&mut self) -> Result<()> {


### PR DESCRIPTION
This PR addresses issues raised in https://github.com/habitat-sh/habitat/issues/1742.

It addresses the following issues / bugs:
- init hook is only run when election is completed
- reconfigure hook is run after run hook (also on restart)

And includes some refactoring to make this possible (documented in commit messages).