### PR TITLE
Load hooks at Service creation time

### DIFF
--- a/test/fixtures/app-server/hooks/run
+++ b/test/fixtures/app-server/hooks/run
@@ -11,7 +11,7 @@ echo "-- Starting App --"
 echo ""
 cat {{pkg.svc_config_path}}/app.conf
 echo ""
-echo "-- Running on {{svc.me.ip}} --"
+echo "-- Running on {{svc.me.sys.ip}} --"
 
 while [ 1 ]; do
   if [ $EXIT_NOW = 1 ]; then

--- a/test/fixtures/database-server/hooks/run
+++ b/test/fixtures/database-server/hooks/run
@@ -11,7 +11,7 @@ echo "-- Starting Database --"
 echo ""
 cat {{pkg.svc_config_path}}/database.conf
 echo ""
-echo "-- Running on {{svc.me.ip}} --"
+echo "-- Running on {{svc.me.sys.ip}} --"
 
 while [ 1 ]; do
   if [ $EXIT_NOW = 1 ]; then


### PR DESCRIPTION
Loading them in the initialize() function is too late since they must
have been loaded in order to compile them during the update config
section of the tick function.