### PR TITLE
Add `pkg_binds` and `pkg_binds_optional` plan variables

### DIFF
--- a/components/core/src/error.rs
+++ b/components/core/src/error.rs
@@ -64,10 +64,12 @@ pub enum Error {
     InvalidServiceGroup(String),
     /// Occurs when making lower level IO calls.
     IO(io::Error),
+    /// Occurs when a BIND or BIND_OPTIONAL MetaFile is read and contains a bad entry.
+    MetaFileBadBind,
     /// Occurs when a package metadata file cannot be opened, read, or parsed.
-    MetaFileMalformed(package::MetaFile),
+    MetaFileMalformed(package::metadata::MetaFile),
     /// Occurs when a particular package metadata file is not found.
-    MetaFileNotFound(package::MetaFile),
+    MetaFileNotFound(package::metadata::MetaFile),
     /// When an IO error while accessing a MetaFile.
     MetaFileIO(io::Error),
     /// Occurs when we can't find an outbound IP address
@@ -153,6 +155,7 @@ impl fmt::Display for Error {
                         e)
             }
             Error::IO(ref err) => format!("{}", err),
+            Error::MetaFileBadBind => format!("Bad value parsed from BIND or BIND_OPTIONAL"),
             Error::MetaFileMalformed(ref e) => {
                 format!("MetaFile: {:?}, didn't contain a valid UTF-8 string", e)
             }
@@ -222,6 +225,7 @@ impl error::Error for Error {
                 "Service group strings must be in service.group format (example: redis.production)"
             }
             Error::IO(ref err) => err.description(),
+            Error::MetaFileBadBind => "Bad value parsed from BIND or BIND_OPTIONAL MetaFile",
             Error::MetaFileMalformed(_) => "MetaFile didn't contain a valid UTF-8 string",
             Error::MetaFileNotFound(_) => "Failed to read an archive's metafile",
             Error::MetaFileIO(_) => "MetaFile could not be read or written to",

--- a/components/core/src/package/archive.rs
+++ b/components/core/src/package/archive.rs
@@ -23,9 +23,10 @@ use libarchive::reader::{self, Reader};
 use libarchive::archive::{Entry, ReadFilter, ReadFormat, ExtractOption, ExtractOptions};
 use regex::Regex;
 
+use super::{Identifiable, PackageIdent, PackageTarget};
+use super::metadata::MetaFile;
 use error::{Error, Result};
 use crypto::{artifact, hash};
-use package::{Identifiable, PackageIdent, PackageTarget, MetaFile};
 
 lazy_static! {
     static ref METAFILE_REGXS: HashMap<MetaFile, Regex> = {

--- a/components/core/src/package/metadata.rs
+++ b/components/core/src/package/metadata.rs
@@ -1,0 +1,88 @@
+// Copyright (c) 2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt;
+use std::str::FromStr;
+
+use error::{Error, Result};
+
+#[derive(Debug)]
+pub struct Bind {
+    pub service: String,
+    pub exports: Vec<String>,
+}
+
+impl FromStr for Bind {
+    type Err = Error;
+
+    fn from_str(line: &str) -> Result<Self> {
+        let mut parts = line.split('=');
+        let service = match parts.next() {
+            None => return Err(Error::MetaFileBadBind),
+            Some(service) => service.to_string(),
+        };
+        let exports = match parts.next() {
+            None => return Err(Error::MetaFileBadBind),
+            Some(exports) => exports.split(' ').map(|t| t.to_string()).collect(),
+        };
+        Ok(Bind {
+            service: service,
+            exports: exports,
+        })
+    }
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub enum MetaFile {
+    Binds,
+    BindsOptional,
+    CFlags,
+    Config,
+    Deps,
+    TDeps,
+    Exports,
+    Exposes,
+    Ident,
+    LdRunPath,
+    LdFlags,
+    Manifest,
+    Path,
+    SvcUser,
+    SvcGroup,
+    Target,
+}
+
+impl fmt::Display for MetaFile {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let id = match *self {
+            MetaFile::Binds => "BINDS",
+            MetaFile::BindsOptional => "BINDS_OPTIONAL",
+            MetaFile::CFlags => "CFLAGS",
+            MetaFile::Config => "default.toml",
+            MetaFile::Deps => "DEPS",
+            MetaFile::TDeps => "TDEPS",
+            MetaFile::Exports => "EXPORTS",
+            MetaFile::Exposes => "EXPOSES",
+            MetaFile::Ident => "IDENT",
+            MetaFile::LdRunPath => "LD_RUN_PATH",
+            MetaFile::LdFlags => "LDFLAGS",
+            MetaFile::Manifest => "MANIFEST",
+            MetaFile::Path => "PATH",
+            MetaFile::SvcUser => "SVC_USER",
+            MetaFile::SvcGroup => "SVC_GROUP",
+            MetaFile::Target => "TARGET",
+        };
+        write!(f, "{}", id)
+    }
+}

--- a/components/core/src/package/mod.rs
+++ b/components/core/src/package/mod.rs
@@ -15,6 +15,7 @@
 pub mod archive;
 pub mod ident;
 pub mod install;
+pub mod metadata;
 pub mod plan;
 pub mod target;
 
@@ -23,45 +24,3 @@ pub use self::ident::{Identifiable, PackageIdent};
 pub use self::install::PackageInstall;
 pub use self::plan::Plan;
 pub use self::target::{Target, PackageTarget};
-
-use std::fmt;
-
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
-pub enum MetaFile {
-    CFlags,
-    Config,
-    Deps,
-    TDeps,
-    Exports,
-    Exposes,
-    Ident,
-    LdRunPath,
-    LdFlags,
-    Manifest,
-    Path,
-    SvcUser,
-    SvcGroup,
-    Target,
-}
-
-impl fmt::Display for MetaFile {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let id = match *self {
-            MetaFile::CFlags => "CFLAGS",
-            MetaFile::Config => "default.toml",
-            MetaFile::Deps => "DEPS",
-            MetaFile::TDeps => "TDEPS",
-            MetaFile::Exports => "EXPORTS",
-            MetaFile::Exposes => "EXPOSES",
-            MetaFile::Ident => "IDENT",
-            MetaFile::LdRunPath => "LD_RUN_PATH",
-            MetaFile::LdFlags => "LDFLAGS",
-            MetaFile::Manifest => "MANIFEST",
-            MetaFile::Path => "PATH",
-            MetaFile::SvcUser => "SVC_USER",
-            MetaFile::SvcGroup => "SVC_GROUP",
-            MetaFile::Target => "TARGET",
-        };
-        write!(f, "{}", id)
-    }
-}

--- a/components/hab/static/template_plan.sh
+++ b/components/hab/static/template_plan.sh
@@ -147,6 +147,28 @@ pkg_exposes={{ pkg_exposes }}
 # pkg_exposes=(port ssl-port)
 {{/if}}
 # Optional.
+# An associative array representing services which you depend on and the configuration keys that
+# you expect the service to export (by their `pkg_exports`). These binds *must* be set for the
+# supervisor to load the service. The loaded service will wait to run until it's bind becomes
+# available. If the bind does not contain the expected keys, the service will not start
+# successfully.
+{{#if pkg_binds ~}}
+pkg_binds={{ pkg_binds }}
+{{else ~}}
+# pkg_binds=(
+#   [database]="port host"
+# )
+{{/if}}
+# Optional.
+# Same as `pkg_binds` but these represent optional services to connect to.
+{{#if pkg_binds_optional ~}}
+pkg_binds_optional={{ pkg_binds_optional }}
+{{else ~}}
+# pkg_binds_optional=(
+#   [storage]="port host"
+# )
+{{/if}}
+# Optional.
 # An array of interpreters used in shebang lines for scripts. Specify the
 # subdirectory where the binary is relative to the package, for example,
 # bin/bash or libexec/neverland, since binaries can be located in directories

--- a/components/sup/src/error.rs
+++ b/components/sup/src/error.rs
@@ -123,6 +123,7 @@ pub enum Error {
     IPFailed,
     KeyNotFound(String),
     MetaFileIO(io::Error),
+    MissingRequiredBind(Vec<String>),
     NameLookup(io::Error),
     NetParseError(net::AddrParseError),
     NoRunFile,
@@ -183,6 +184,9 @@ impl fmt::Display for SupError {
             Error::Io(ref err) => format!("{}", err),
             Error::IPFailed => format!("Failed to discover this hosts outbound IP address"),
             Error::KeyNotFound(ref e) => format!("Key not found in key cache: {}", e),
+            Error::MissingRequiredBind(ref e) => {
+                format!("Missing required bind(s), {}", e.join(", "))
+            }
             Error::MetaFileIO(ref e) => format!("IO error while accessing MetaFile: {:?}", e),
             Error::NameLookup(ref e) => format!("Error resolving a name or IP address: {}", e),
             Error::NetParseError(ref e) => format!("Can't parse ip:port: {}", e),
@@ -266,6 +270,9 @@ impl error::Error for SupError {
             Error::Io(ref err) => err.description(),
             Error::IPFailed => "Failed to discover the outbound IP address",
             Error::KeyNotFound(_) => "Key not found in key cache",
+            Error::MissingRequiredBind(_) => {
+                "A service to start without specifying a service group for all required binds"
+            }
             Error::MetaFileIO(_) => "MetaFile could not be read or written to",
             Error::NetParseError(_) => "Can't parse IP:port",
             Error::NameLookup(_) => "Error resolving a name or IP address",

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -246,7 +246,7 @@ fn spec_from_matches(ident: &PackageIdent, m: &ArgMatches) -> Result<ServiceSpec
         spec.update_strategy = try!(UpdateStrategy::from_str(strategy));
     }
     if let Some(binds) = m.values_of("BIND") {
-        spec.binds = binds.map(|s| s.to_string()).collect();
+        spec.binds = ServiceSpec::split_bindings(binds)?;
     }
     if let Some(ref config_from) = m.value_of("CONFIG_DIR") {
         spec.config_from = Some(PathBuf::from(config_from));

--- a/components/sup/src/templating/mod.rs
+++ b/components/sup/src/templating/mod.rs
@@ -173,7 +173,7 @@ mod test {
                                     &ManagerConfig::default(),
                                     &RuntimeConfig::default(),
                                     None,
-                                    &Vec::new())
+                                    Vec::new())
             .unwrap();
         let toml = sc.to_toml().unwrap();
         let data = convert::toml_to_json(toml);

--- a/test/fixtures/app-server/plan.sh
+++ b/test/fixtures/app-server/plan.sh
@@ -11,6 +11,12 @@ pkg_exports=(
   [host]=srv.host
 )
 pkg_exposes=(proxy-port port)
+pkg_binds=(
+  [database]="port host"
+)
+pkg_binds_optional=(
+  [storage]="port host"
+)
 
 do_download() {
   return 0

--- a/www/source/docs/reference/plan-syntax.html.md
+++ b/www/source/docs/reference/plan-syntax.html.md
@@ -139,7 +139,7 @@ pkg_svc_run
 > Note: You should use a [run hook](#hooks) instead if you have complex start up behavior.
 
 pkg_exports
-: Optional. An array of ports this service exposes when you create a Docker image from your package. An associative array representing configuration data which should be gossiped to peers. The keys in this array represent the name the value will be assigned and the values represent the TOML path to read the value.
+: Optional. An associative array representing configuration data which should be gossiped to peers. The keys in this array represent the name the value will be assigned and the values represent the TOML path to read the value.
 
   ~~~
   pkg_exports=(
@@ -156,6 +156,23 @@ pkg_exposes
   pkg_exposes=(port ssl-port)
   ~~~
 
+pkg_binds
+: Optional. An associative array representing services which you depend on and the configuration keys that you expect the service to export (by their `pkg_exports`). These binds *must* be set for the supervisor to load the service. The loaded service will wait to run until it's bind becomes available. If the bind does not contain the expected keys, the service will not start successfully.
+
+  ~~~
+  pkg_binds=(
+    [database]="port host"
+  )
+  ~~~
+
+pkg_binds_optional
+: Optional. Same as `pkg_binds` but these represent optional services to connect to.
+
+  ~~~
+  pkg_binds_optional=(
+    [storage]="port host"
+  )
+  ~~~
 
 pkg_interpreters
 : Optional. An array of interpreters used in [shebang](https://en.wikipedia.org/wiki/Shebang_(Unix)) lines for scripts. Specify the subdirectory where the binary is relative to the package, for example, `bin/bash` or `libexec/neverland`, since binaries can be located in directories besides `bin`. This list of interpreters will be written to the metadata INTERPRETERS file, located inside a package, with their fully-qualified path.  Then these can be used with the fix_interpreter function. For more information on declaring shebangs in Habitat, see [Plan hooks](#hooks), and for more information on the fix_interpreter function, see [Plan utility functions](#plan-utility-functions).

--- a/www/source/docs/run-packages-binding.html.md
+++ b/www/source/docs/run-packages-binding.html.md
@@ -4,34 +4,56 @@ title: Running packages with runtime binding
 
 # Runtime Binding
 
-*Runtime binding* in Habitat refers to the ability for service groups to be named generically in plans, and hence Habitat packages, and for those generic service group names to be resolved to actual service group names at runtime.
+*Runtime binding* in Habitat refers to the ability for one service group to connect to another forming a producer/consumer relationship where the consumer can use the producer's publicly available configuration to configure it's services at runtime. We form a [polymorphic relationship](https://en.wikipedia.org/wiki/Polymorphism_(computer_science)) between these two service groups defined by a [dynamically typed](https://en.wikipedia.org/wiki/Duck_typing) contract where the consumer specifies a generic name of the service it is consuming along with the configuration keys it expects the producer to export.
 
-For example, you might have a web application `foo` that depends on the value of the leader of a database service group. Rather than hardcoding the name of the service group in `foo`'s plan, which would limit its portability, you can _bind_ the name `database`, for example, to the service group name `postgresql.production` in a production environment, and `postgresql.development` in a development environment.
+For example, you might have a web application `app-server` that depends on the value of the leader of a database service group. Rather than hardcoding the name of the service group or package identifier in `app-servers`'s plan, which would limit its portability, you can _bind_ the name `database`, for example, to the `default` service group running PostgreSQL. If you have multiple service groups for PostgreSQL - perhaps you have a production and development environment - you could bind `database` to `postgresql.production` or `postgresql.development`. If `app-server` supports multiple different database backends you could even bind `database` to another, such as `redis.default` or `mysql.default`.
 
-## Example
+## Producer Contract
 
-For an example look at the [haproxy](https://github.com/habitat-sh/core-plans/blob/master/haproxy/config/haproxy.conf) core-plan. These lines in the [haproxy.conf](https://github.com/habitat-sh/core-plans/blob/master/haproxy/config/haproxy.conf#L18-L23) illustrate how to reference a service binding. When a binding is enabled, the config will be rendered with a backend for each healthy instance in the service group.
+The producer defines their contract by "exporting" configuration publicly to consumers. This is done by setting keys in the `pkg_exports` associative array defined in your package's `plan.sh`. For example, a database server named `amnesia` might define the exports:
+
+      pkg_exports=(
+        [port]=network.port
+        [ssl-port]=network.ssl.port
+      )
+
+This will export the value of `network.port` and `transport.ssl.port` defined in it's `default.toml` publicly as `port` and `ssl-port` respectively. All `pkg_exports` must define a default value in `default.toml` but their values may change at runtime by an operator configuring the service group. If this happens, the consumer will be notified that their producer's configuration has changed. We'll see how to leverage this on the consumer in the sections below.
+
+## Consumer Contract
+
+Consumers defines their half of the contract by defining required and optional "binds". These are also represented by key/value pairs in an associative array called `pkg_binds` and `pkg_binds_optional`. For example, An application server named `session-server` that depends on a database might define the following binds:
+
+    pkg_binds=(
+      [database]="port ssl-port"
+    )
+
+This says that `session-server` needs to bind to a service aliased as `database` and that service must export a configuration key for both `port` and `ssl-port`. This would make this application service compatible with the producer we defined above for a database called `amnesia` since it does export a value for both of these keys.
+
+## Consumer's Configuration Example
+
+Once you've defined both ends of the contract you can leverage the bind in any of your package's hooks or configuration files. Given the two example services above, a section of a configuration file for `session-server` might look like this:
 
 ~~~
-{{#if bind.has_backend }}
-{{~#each bind.backend.members}}
+{{#if bind.has_database }}
+{{~#each bind.database.members}}
 {{~#if alive }}
-  server {{sys.ip}} {{sys.ip}}:{{cfg.port}}
+  database = "{{sys.ip}}:{{cfg.port}}"
+  database-secure = "{{sys.ip}}:{{cfg.ssl-port}}"
 {{~/if}}
 {{~/each}}
 ~~~
 
-`backend` is a generic name which will be substituted with the real name
-using the `--bind` parameter to the supervisor, for example:
+## Starting A Consumer
 
-       hab start core/haproxy --bind backend:example-services
+Since your application server defined `database` as a required bind, you'll need to provide the name of a service group running a package which fulfills the contract using the `--bind` parameter to the supervisor, for example:
 
-which would bind `backend` to the `example-services` service group.
+       hab start my-origin/app-server --bind database:amnesia.default
 
-You can declare bindings to multiple service groups in your templates. The arguments to `--bind` are separated by commas.
+which would create a bind aliasing `database` to the `amnesia` service in the `default` service group.
 
-The supervisor will throw an error if you have declared bindings but failed to resolve all of them with `--bind` when starting the package.
+The service group passed to `--bind database:{service}.{group}` doesn't *need* to be the service `amnesia`. Again, this bind can be any service as long as they export a configuration key for `port` and `ssl-port`.
 
+You can declare bindings to multiple service groups in your templates. The arguments to `--bind` are separated by commas. Your service will not start if your package has declared a required bind and a value for it was not specified by `--bind`.
 
 <hr>
 <ul class="main-content--link-nav">


### PR DESCRIPTION
This adds two new plan variables:

* `pkg_binds`
* `pkg_binds_optional`

These plan variables define what is accepted by the supervisor's `--bind`
flag. `pkg_binds` defines what is *required* to be provided to the
`--bind` flag for the service to start.

This is an MVP of the consumer's portion of our inter-service contract.
The producer's side is defined by `pkg_exports`. In the future, this
metadata will also participate in the service's state machine to
determine when it is appropriate for a service to start up. They will
also prevent a service from binding to a group which does not export
the desired configuration.

![gif-keyboard-13026204423796826913](https://cloud.githubusercontent.com/assets/54036/22911234/7f26477a-f213-11e6-9f2f-a1e7e2612986.gif)
