### PR TITLE
Move `address` field on CensusEntry to `sys.gossip_ip`

### DIFF
--- a/components/butterfly/src/rumor/service.rs
+++ b/components/butterfly/src/rumor/service.rs
@@ -145,6 +145,8 @@ impl Rumor for Service {
 pub struct SysInfo {
     pub ip: String,
     pub hostname: String,
+    pub gossip_ip: String,
+    pub gossip_port: u16,
     pub http_gateway_ip: String,
     pub http_gateway_port: u16,
 }

--- a/components/sup/src/command/start.rs
+++ b/components/sup/src/command/start.rs
@@ -87,7 +87,7 @@ pub fn package(cfg: ManagerConfig, spec: ServiceSpec, local_artifact: Option<&st
                 UpdateStrategy::None => {}
                 _ => {
                     outputln!("Checking Depot for newer versions...");
-                    // It is important to pass `gconfig().package()` to `show_package()` instead
+                    // It is important to pass `spec.ident` to `show_package()` instead
                     // of the package identifier of the loaded package. This will ensure that
                     // if the operator starts a package while specifying a version number, they
                     // will only automatically receive release updates for the started package.
@@ -151,8 +151,8 @@ pub fn package(cfg: ManagerConfig, spec: ServiceSpec, local_artifact: Option<&st
 }
 
 fn start_package(package: PackageInstall, cfg: ManagerConfig, spec: ServiceSpec) -> Result<()> {
+    let service = try!(Service::new(package, spec, &cfg));
     let mut manager = try!(Manager::new(cfg));
-    let service = try!(Service::new(package, spec));
     try!(manager.add_service(service));
     manager.run()
 }

--- a/components/sup/src/manager/census.rs
+++ b/components/sup/src/manager/census.rs
@@ -55,7 +55,6 @@ pub struct CensusEntry {
     pub service: String,
     pub group: String,
     pub org: Option<String>,
-    pub address: String,
     pub cfg: toml::Table,
     pub sys: SysInfo,
     pub pkg: Option<PackageIdent>,
@@ -121,14 +120,6 @@ impl CensusEntry {
 
     pub fn set_org(&mut self, value: String) {
         self.org = Some(value);
-    }
-
-    pub fn get_address(&self) -> &str {
-        &self.address
-    }
-
-    pub fn set_address(&mut self, value: String) {
-        self.address = value;
     }
 
     pub fn get_pkg(&self) -> &PackageIdent {
@@ -288,7 +279,8 @@ impl CensusEntry {
 
     pub fn populate_from_member(&mut self, member: &Member) {
         self.set_member_id(String::from(member.get_id()));
-        self.set_address(String::from(member.get_address()));
+        self.sys.gossip_ip = member.get_address().to_string();
+        self.sys.gossip_port = member.get_gossip_port() as u16;
         self.set_persistent(true);
     }
 
@@ -612,7 +604,7 @@ mod tests {
             member.set_persistent(true);
             ce.populate_from_member(&member);
             assert_eq!(ce.get_member_id(), member.get_id());
-            assert_eq!(ce.get_address(), member.get_address());
+            assert_eq!(ce.sys.gossip_ip, member.get_address());
             assert_eq!(ce.get_persistent(), member.get_persistent());
         }
     }

--- a/components/sup/src/manager/service/mod.rs
+++ b/components/sup/src/manager/service/mod.rs
@@ -42,6 +42,7 @@ pub use self::health::{HealthCheck, SmokeCheck};
 use self::hooks::{HOOK_PERMISSIONS, HookTable, HookType};
 use error::{Error, Result, SupError};
 use fs;
+use manager::ManagerConfig;
 use manager::signals;
 use manager::census::{CensusList, CensusUpdate};
 use prometheus::Opts;
@@ -108,13 +109,20 @@ pub struct Service {
 }
 
 impl Service {
-    pub fn new(package: PackageInstall, spec: ServiceSpec) -> Result<Service> {
+    pub fn new(package: PackageInstall,
+               spec: ServiceSpec,
+               mgr_cfg: &ManagerConfig)
+               -> Result<Service> {
         let service_group = ServiceGroup::new(&package.ident.name,
                                               spec.group,
                                               spec.organization.as_ref().map(|x| &**x))?;
         let (svc_user, svc_group) = try!(util::users::get_user_and_group(&package));
         let runtime_cfg = RuntimeConfig::new(svc_user, svc_group);
-        let svc_cfg = ServiceConfig::new(&package, &runtime_cfg, spec.config_from, &spec.binds)?;
+        let svc_cfg = ServiceConfig::new(&package,
+                                         mgr_cfg,
+                                         &runtime_cfg,
+                                         spec.config_from,
+                                         &spec.binds)?;
         let hook_template_path = svc_cfg.config_root.join("hooks");
         let hooks_path = fs::svc_hooks_path(service_group.service());
         Ok(Service {

--- a/components/sup/src/templating/mod.rs
+++ b/components/sup/src/templating/mod.rs
@@ -67,10 +67,8 @@ mod test {
 
     use util::convert;
     use hcore::package::{PackageIdent, PackageInstall};
-    use serde_json;
 
-    use config::{gcache, Config};
-    use manager::ServiceConfig;
+    use manager::{ManagerConfig, ServiceConfig};
     use supervisor::RuntimeConfig;
 
     #[test]
@@ -170,9 +168,13 @@ mod test {
         let mut template = Template::new();
         template.register_template_string("t", content).unwrap();
 
-        gcache(Config::default());
         let pkg = gen_pkg();
-        let sc = ServiceConfig::new(&pkg, &RuntimeConfig::default(), None, &Vec::new()).unwrap();
+        let sc = ServiceConfig::new(&pkg,
+                                    &ManagerConfig::default(),
+                                    &RuntimeConfig::default(),
+                                    None,
+                                    &Vec::new())
+            .unwrap();
         let toml = sc.to_toml().unwrap();
         let data = convert::toml_to_json(toml);
         let rendered = template.render("t", &data).unwrap();


### PR DESCRIPTION
This is the last change to cleanup the CensusEntry keyspace. All
system related configuration is now located under `sys` and no longer
at it's top level.

* Move and rename `address` field on CensusEntry to `sys.gossip_ip`
* Add `sys.gossip_port` field to CensusEntry
* Finished refactoring global config struct into ManagerConfig

![gif-keyboard-2748578354783661125](https://cloud.githubusercontent.com/assets/54036/22913031/4e284f42-f21d-11e6-84f7-e1d0897b4b63.gif)
