### PR TITLE
Promote events and blog posts

### DIFF
--- a/www/source/community.html.slim
+++ b/www/source/community.html.slim
@@ -12,8 +12,15 @@ section.hero.community
           | Habitat is an open source project created and supported
             by a passionate group of people. Our vision is grand — to bring automation
             to places previously unconsidered.
-        a.button.cta href="https://forums.habitat.sh/" target="_blank" Visit the Forums
-        a.button.cta href="http://slack.habitat.sh" target="_blank" Join us on Slack
+        .row
+          .columns.medium-12
+            a.button.cta href="http://slack.habitat.sh" target="_blank" Join us on Slack
+            a.button.cta href="https://forums.habitat.sh/" target="_blank" Visit the Forums
+        .row
+          .columns.medium-12
+            a.button.cta href="https://events.chef.io/events/categories/habitat/" target="_blank" Meet at Events
+            a.button.cta href="https://blog.chef.io/category/habitat/" target="_blank" Read Blog Posts
+
     .hero--graphic
       img[src="/images/graphics/hero-community.svg"
         onerror="this.src='/images/graphics/hero-community.png'" alt=""]


### PR DESCRIPTION
On the community page:

* List slack before forums
* Add link to upcoming Habitat events
  * https://events.chef.io/events/categories/habitat/
* Add link to Habitat-related blogs
  * https://blog.chef.io/category/habitat/

Signed-off-by: Nathen Harvey <nharvey@chef.io>