### PR TITLE
Run hooks after leader is elected and in correct order

### DIFF
--- a/components/sup/src/manager/census.rs
+++ b/components/sup/src/manager/census.rs
@@ -49,6 +49,14 @@ impl CensusUpdate {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+pub enum ElectionStatus {
+    None,
+    ElectionInProgress,
+    ElectionNoQuorum,
+    ElectionFinished,
+}
+
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, Default)]
 pub struct CensusEntry {
     pub member_id: String,
@@ -217,6 +225,18 @@ impl CensusEntry {
 
     pub fn get_update_election_is_finished(&self) -> bool {
         self.update_election_is_finished.unwrap_or(false)
+    }
+
+    pub fn get_election_status(&self) -> ElectionStatus {
+        if self.get_election_is_running() {
+            ElectionStatus::ElectionInProgress
+        } else if self.get_election_is_no_quorum() {
+            ElectionStatus::ElectionNoQuorum
+        } else if self.get_election_is_finished() {
+            ElectionStatus::ElectionFinished
+        } else {
+            ElectionStatus::None
+        }
     }
 
     pub fn set_initialized(&mut self, value: bool) {

--- a/components/sup/src/manager/service/mod.rs
+++ b/components/sup/src/manager/service/mod.rs
@@ -417,12 +417,11 @@ impl Service {
     /// Run reconfigure hook if present. Return false if it is not present, to trigger default
     /// restart behavior.
     pub fn reconfigure(&mut self) {
+        self.needs_reconfiguration = false;
         if let Some(err) = self.run_hook(HookType::Reconfigure).err() {
             outputln!(preamble self.service_group,
                       "Reconfiguration hook failed: {}",
                       err);
-        } else {
-            self.needs_reconfiguration = false;
         }
     }
 


### PR DESCRIPTION
When Topology::Leader is selected hooks are only run when the
election is completed. This garuantees {{svc.me.leader}} and
{{svc.me.follower}} will be in a consistent state when the hooks are
executed.
Also the execution of the reconfigure hook is now consistently after the
run hook (also on restarts) as is documented.

Fixes https://github.com/habitat-sh/habitat/issues/1742