### PR TITLE
Use appropriate build script for builder-protocol crate

### DIFF
--- a/components/builder-protocol/Cargo.toml
+++ b/components/builder-protocol/Cargo.toml
@@ -3,7 +3,7 @@ name = "habitat_builder_protocol"
 version = "0.0.0"
 authors = ["Adam Jacob <adam@chef.io>", "Jamie Winsor <reset@chef.io>", "Fletcher Nichol <fnichol@chef.io>", "Joshua Timberman <joshua@chef.io>", "Dave Parfitt <dparfitt@chef.io>"]
 description = "Habitat-Builder Network Server Protocol"
-build = "../bldr-build.rs"
+build = "build.rs"
 workspace = "../../"
 
 [dependencies]

--- a/components/builder-protocol/build.rs
+++ b/components/builder-protocol/build.rs
@@ -2,7 +2,7 @@ extern crate pkg_config;
 
 use std::env;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::process::Command;
 
 fn main() {

--- a/components/builder-protocol/src/message/depotsrv.rs
+++ b/components/builder-protocol/src/message/depotsrv.rs
@@ -9,6 +9,7 @@
 
 #![allow(box_pointers)]
 #![allow(dead_code)]
+#![allow(missing_docs)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
@@ -20,7 +21,7 @@
 use protobuf::Message as Message_imported_for_functions;
 use protobuf::ProtobufEnum as ProtobufEnum_imported_for_functions;
 
-#[derive(Clone,Default)]
+#[derive(PartialEq,Clone,Default)]
 pub struct PackageIdent {
     // message fields
     origin: ::protobuf::SingularField<::std::string::String>,
@@ -29,7 +30,7 @@ pub struct PackageIdent {
     release: ::protobuf::SingularField<::std::string::String>,
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    cached_size: ::protobuf::CachedSize,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -46,16 +47,7 @@ impl PackageIdent {
             ptr: 0 as *const PackageIdent,
         };
         unsafe {
-            instance.get(|| {
-                PackageIdent {
-                    origin: ::protobuf::SingularField::none(),
-                    name: ::protobuf::SingularField::none(),
-                    version: ::protobuf::SingularField::none(),
-                    release: ::protobuf::SingularField::none(),
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
+            instance.get(PackageIdent::new)
         }
     }
 
@@ -93,6 +85,14 @@ impl PackageIdent {
             Some(v) => &v,
             None => "",
         }
+    }
+
+    fn get_origin_for_reflect(&self) -> &::protobuf::SingularField<::std::string::String> {
+        &self.origin
+    }
+
+    fn mut_origin_for_reflect(&mut self) -> &mut ::protobuf::SingularField<::std::string::String> {
+        &mut self.origin
     }
 
     // required string name = 2;
@@ -131,6 +131,14 @@ impl PackageIdent {
         }
     }
 
+    fn get_name_for_reflect(&self) -> &::protobuf::SingularField<::std::string::String> {
+        &self.name
+    }
+
+    fn mut_name_for_reflect(&mut self) -> &mut ::protobuf::SingularField<::std::string::String> {
+        &mut self.name
+    }
+
     // optional string version = 3;
 
     pub fn clear_version(&mut self) {
@@ -165,6 +173,14 @@ impl PackageIdent {
             Some(v) => &v,
             None => "",
         }
+    }
+
+    fn get_version_for_reflect(&self) -> &::protobuf::SingularField<::std::string::String> {
+        &self.version
+    }
+
+    fn mut_version_for_reflect(&mut self) -> &mut ::protobuf::SingularField<::std::string::String> {
+        &mut self.version
     }
 
     // optional string release = 4;
@@ -202,6 +218,14 @@ impl PackageIdent {
             None => "",
         }
     }
+
+    fn get_release_for_reflect(&self) -> &::protobuf::SingularField<::std::string::String> {
+        &self.release
+    }
+
+    fn mut_release_for_reflect(&mut self) -> &mut ::protobuf::SingularField<::std::string::String> {
+        &mut self.release
+    }
 }
 
 impl ::protobuf::Message for PackageIdent {
@@ -216,23 +240,23 @@ impl ::protobuf::Message for PackageIdent {
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
-        while !try!(is.eof()) {
-            let (field_number, wire_type) = try!(is.read_tag_unpack());
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
-                    try!(::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.origin));
+                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.origin)?;
                 },
                 2 => {
-                    try!(::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.name));
+                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.name)?;
                 },
                 3 => {
-                    try!(::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.version));
+                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.version)?;
                 },
                 4 => {
-                    try!(::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.release));
+                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.release)?;
                 },
                 _ => {
-                    try!(::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields()));
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
                 },
             };
         }
@@ -243,17 +267,17 @@ impl ::protobuf::Message for PackageIdent {
     #[allow(unused_variables)]
     fn compute_size(&self) -> u32 {
         let mut my_size = 0;
-        for value in &self.origin {
-            my_size += ::protobuf::rt::string_size(1, &value);
+        if let Some(v) = self.origin.as_ref() {
+            my_size += ::protobuf::rt::string_size(1, &v);
         };
-        for value in &self.name {
-            my_size += ::protobuf::rt::string_size(2, &value);
+        if let Some(v) = self.name.as_ref() {
+            my_size += ::protobuf::rt::string_size(2, &v);
         };
-        for value in &self.version {
-            my_size += ::protobuf::rt::string_size(3, &value);
+        if let Some(v) = self.version.as_ref() {
+            my_size += ::protobuf::rt::string_size(3, &v);
         };
-        for value in &self.release {
-            my_size += ::protobuf::rt::string_size(4, &value);
+        if let Some(v) = self.release.as_ref() {
+            my_size += ::protobuf::rt::string_size(4, &v);
         };
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
         self.cached_size.set(my_size);
@@ -262,18 +286,18 @@ impl ::protobuf::Message for PackageIdent {
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.origin.as_ref() {
-            try!(os.write_string(1, &v));
+            os.write_string(1, &v)?;
         };
         if let Some(v) = self.name.as_ref() {
-            try!(os.write_string(2, &v));
+            os.write_string(2, &v)?;
         };
         if let Some(v) = self.version.as_ref() {
-            try!(os.write_string(3, &v));
+            os.write_string(3, &v)?;
         };
         if let Some(v) = self.release.as_ref() {
-            try!(os.write_string(4, &v));
+            os.write_string(4, &v)?;
         };
-        try!(os.write_unknown_fields(self.get_unknown_fields()));
+        os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
 
@@ -289,12 +313,14 @@ impl ::protobuf::Message for PackageIdent {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<PackageIdent>()
-    }
-
     fn as_any(&self) -> &::std::any::Any {
         self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -315,25 +341,25 @@ impl ::protobuf::MessageStatic for PackageIdent {
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_string_accessor(
+                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
                     "origin",
-                    PackageIdent::has_origin,
-                    PackageIdent::get_origin,
+                    PackageIdent::get_origin_for_reflect,
+                    PackageIdent::mut_origin_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_string_accessor(
+                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
                     "name",
-                    PackageIdent::has_name,
-                    PackageIdent::get_name,
+                    PackageIdent::get_name_for_reflect,
+                    PackageIdent::mut_name_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_string_accessor(
+                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
                     "version",
-                    PackageIdent::has_version,
-                    PackageIdent::get_version,
+                    PackageIdent::get_version_for_reflect,
+                    PackageIdent::mut_version_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_string_accessor(
+                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
                     "release",
-                    PackageIdent::has_release,
-                    PackageIdent::get_release,
+                    PackageIdent::get_release_for_reflect,
+                    PackageIdent::mut_release_for_reflect,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<PackageIdent>(
                     "PackageIdent",
@@ -355,23 +381,19 @@ impl ::protobuf::Clear for PackageIdent {
     }
 }
 
-impl ::std::cmp::PartialEq for PackageIdent {
-    fn eq(&self, other: &PackageIdent) -> bool {
-        self.origin == other.origin &&
-        self.name == other.name &&
-        self.version == other.version &&
-        self.release == other.release &&
-        self.unknown_fields == other.unknown_fields
-    }
-}
-
 impl ::std::fmt::Debug for PackageIdent {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
-#[derive(Clone,Default)]
+impl ::protobuf::reflect::ProtobufValue for PackageIdent {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Message(self)
+    }
+}
+
+#[derive(PartialEq,Clone,Default)]
 pub struct Package {
     // message fields
     ident: ::protobuf::SingularPtrField<PackageIdent>,
@@ -383,7 +405,7 @@ pub struct Package {
     config: ::protobuf::SingularField<::std::string::String>,
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    cached_size: ::protobuf::CachedSize,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -400,19 +422,7 @@ impl Package {
             ptr: 0 as *const Package,
         };
         unsafe {
-            instance.get(|| {
-                Package {
-                    ident: ::protobuf::SingularPtrField::none(),
-                    checksum: ::protobuf::SingularField::none(),
-                    manifest: ::protobuf::SingularField::none(),
-                    deps: ::protobuf::RepeatedField::new(),
-                    tdeps: ::protobuf::RepeatedField::new(),
-                    exposes: ::std::vec::Vec::new(),
-                    config: ::protobuf::SingularField::none(),
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
+            instance.get(Package::new)
         }
     }
 
@@ -447,6 +457,14 @@ impl Package {
 
     pub fn get_ident(&self) -> &PackageIdent {
         self.ident.as_ref().unwrap_or_else(|| PackageIdent::default_instance())
+    }
+
+    fn get_ident_for_reflect(&self) -> &::protobuf::SingularPtrField<PackageIdent> {
+        &self.ident
+    }
+
+    fn mut_ident_for_reflect(&mut self) -> &mut ::protobuf::SingularPtrField<PackageIdent> {
+        &mut self.ident
     }
 
     // required string checksum = 2;
@@ -485,6 +503,14 @@ impl Package {
         }
     }
 
+    fn get_checksum_for_reflect(&self) -> &::protobuf::SingularField<::std::string::String> {
+        &self.checksum
+    }
+
+    fn mut_checksum_for_reflect(&mut self) -> &mut ::protobuf::SingularField<::std::string::String> {
+        &mut self.checksum
+    }
+
     // required string manifest = 3;
 
     pub fn clear_manifest(&mut self) {
@@ -521,6 +547,14 @@ impl Package {
         }
     }
 
+    fn get_manifest_for_reflect(&self) -> &::protobuf::SingularField<::std::string::String> {
+        &self.manifest
+    }
+
+    fn mut_manifest_for_reflect(&mut self) -> &mut ::protobuf::SingularField<::std::string::String> {
+        &mut self.manifest
+    }
+
     // repeated .depotsrv.PackageIdent deps = 4;
 
     pub fn clear_deps(&mut self) {
@@ -544,6 +578,14 @@ impl Package {
 
     pub fn get_deps(&self) -> &[PackageIdent] {
         &self.deps
+    }
+
+    fn get_deps_for_reflect(&self) -> &::protobuf::RepeatedField<PackageIdent> {
+        &self.deps
+    }
+
+    fn mut_deps_for_reflect(&mut self) -> &mut ::protobuf::RepeatedField<PackageIdent> {
+        &mut self.deps
     }
 
     // repeated .depotsrv.PackageIdent tdeps = 5;
@@ -571,6 +613,14 @@ impl Package {
         &self.tdeps
     }
 
+    fn get_tdeps_for_reflect(&self) -> &::protobuf::RepeatedField<PackageIdent> {
+        &self.tdeps
+    }
+
+    fn mut_tdeps_for_reflect(&mut self) -> &mut ::protobuf::RepeatedField<PackageIdent> {
+        &mut self.tdeps
+    }
+
     // repeated uint32 exposes = 6;
 
     pub fn clear_exposes(&mut self) {
@@ -594,6 +644,14 @@ impl Package {
 
     pub fn get_exposes(&self) -> &[u32] {
         &self.exposes
+    }
+
+    fn get_exposes_for_reflect(&self) -> &::std::vec::Vec<u32> {
+        &self.exposes
+    }
+
+    fn mut_exposes_for_reflect(&mut self) -> &mut ::std::vec::Vec<u32> {
+        &mut self.exposes
     }
 
     // optional string config = 7;
@@ -631,6 +689,14 @@ impl Package {
             None => "",
         }
     }
+
+    fn get_config_for_reflect(&self) -> &::protobuf::SingularField<::std::string::String> {
+        &self.config
+    }
+
+    fn mut_config_for_reflect(&mut self) -> &mut ::protobuf::SingularField<::std::string::String> {
+        &mut self.config
+    }
 }
 
 impl ::protobuf::Message for Package {
@@ -648,32 +714,32 @@ impl ::protobuf::Message for Package {
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
-        while !try!(is.eof()) {
-            let (field_number, wire_type) = try!(is.read_tag_unpack());
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
-                    try!(::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.ident));
+                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.ident)?;
                 },
                 2 => {
-                    try!(::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.checksum));
+                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.checksum)?;
                 },
                 3 => {
-                    try!(::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.manifest));
+                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.manifest)?;
                 },
                 4 => {
-                    try!(::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.deps));
+                    ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.deps)?;
                 },
                 5 => {
-                    try!(::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.tdeps));
+                    ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.tdeps)?;
                 },
                 6 => {
-                    try!(::protobuf::rt::read_repeated_uint32_into(wire_type, is, &mut self.exposes));
+                    ::protobuf::rt::read_repeated_uint32_into(wire_type, is, &mut self.exposes)?;
                 },
                 7 => {
-                    try!(::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.config));
+                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.config)?;
                 },
                 _ => {
-                    try!(::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields()));
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
                 },
             };
         }
@@ -684,15 +750,15 @@ impl ::protobuf::Message for Package {
     #[allow(unused_variables)]
     fn compute_size(&self) -> u32 {
         let mut my_size = 0;
-        for value in &self.ident {
-            let len = value.compute_size();
+        if let Some(v) = self.ident.as_ref() {
+            let len = v.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
         };
-        for value in &self.checksum {
-            my_size += ::protobuf::rt::string_size(2, &value);
+        if let Some(v) = self.checksum.as_ref() {
+            my_size += ::protobuf::rt::string_size(2, &v);
         };
-        for value in &self.manifest {
-            my_size += ::protobuf::rt::string_size(3, &value);
+        if let Some(v) = self.manifest.as_ref() {
+            my_size += ::protobuf::rt::string_size(3, &v);
         };
         for value in &self.deps {
             let len = value.compute_size();
@@ -705,8 +771,8 @@ impl ::protobuf::Message for Package {
         if !self.exposes.is_empty() {
             my_size += ::protobuf::rt::vec_packed_varint_size(6, &self.exposes);
         };
-        for value in &self.config {
-            my_size += ::protobuf::rt::string_size(7, &value);
+        if let Some(v) = self.config.as_ref() {
+            my_size += ::protobuf::rt::string_size(7, &v);
         };
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
         self.cached_size.set(my_size);
@@ -715,38 +781,38 @@ impl ::protobuf::Message for Package {
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.ident.as_ref() {
-            try!(os.write_tag(1, ::protobuf::wire_format::WireTypeLengthDelimited));
-            try!(os.write_raw_varint32(v.get_cached_size()));
-            try!(v.write_to_with_cached_sizes(os));
+            os.write_tag(1, ::protobuf::wire_format::WireTypeLengthDelimited)?;
+            os.write_raw_varint32(v.get_cached_size())?;
+            v.write_to_with_cached_sizes(os)?;
         };
         if let Some(v) = self.checksum.as_ref() {
-            try!(os.write_string(2, &v));
+            os.write_string(2, &v)?;
         };
         if let Some(v) = self.manifest.as_ref() {
-            try!(os.write_string(3, &v));
+            os.write_string(3, &v)?;
         };
         for v in &self.deps {
-            try!(os.write_tag(4, ::protobuf::wire_format::WireTypeLengthDelimited));
-            try!(os.write_raw_varint32(v.get_cached_size()));
-            try!(v.write_to_with_cached_sizes(os));
+            os.write_tag(4, ::protobuf::wire_format::WireTypeLengthDelimited)?;
+            os.write_raw_varint32(v.get_cached_size())?;
+            v.write_to_with_cached_sizes(os)?;
         };
         for v in &self.tdeps {
-            try!(os.write_tag(5, ::protobuf::wire_format::WireTypeLengthDelimited));
-            try!(os.write_raw_varint32(v.get_cached_size()));
-            try!(v.write_to_with_cached_sizes(os));
+            os.write_tag(5, ::protobuf::wire_format::WireTypeLengthDelimited)?;
+            os.write_raw_varint32(v.get_cached_size())?;
+            v.write_to_with_cached_sizes(os)?;
         };
         if !self.exposes.is_empty() {
-            try!(os.write_tag(6, ::protobuf::wire_format::WireTypeLengthDelimited));
+            os.write_tag(6, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             // TODO: Data size is computed again, it should be cached
-            try!(os.write_raw_varint32(::protobuf::rt::vec_packed_varint_data_size(&self.exposes)));
+            os.write_raw_varint32(::protobuf::rt::vec_packed_varint_data_size(&self.exposes))?;
             for v in &self.exposes {
-                try!(os.write_uint32_no_tag(*v));
+                os.write_uint32_no_tag(*v)?;
             };
         };
         if let Some(v) = self.config.as_ref() {
-            try!(os.write_string(7, &v));
+            os.write_string(7, &v)?;
         };
-        try!(os.write_unknown_fields(self.get_unknown_fields()));
+        os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
 
@@ -762,12 +828,14 @@ impl ::protobuf::Message for Package {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<Package>()
-    }
-
     fn as_any(&self) -> &::std::any::Any {
         self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -788,37 +856,40 @@ impl ::protobuf::MessageStatic for Package {
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_message_accessor(
+                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<PackageIdent>>(
                     "ident",
-                    Package::has_ident,
-                    Package::get_ident,
+                    Package::get_ident_for_reflect,
+                    Package::mut_ident_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_string_accessor(
+                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
                     "checksum",
-                    Package::has_checksum,
-                    Package::get_checksum,
+                    Package::get_checksum_for_reflect,
+                    Package::mut_checksum_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_string_accessor(
+                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
                     "manifest",
-                    Package::has_manifest,
-                    Package::get_manifest,
+                    Package::get_manifest_for_reflect,
+                    Package::mut_manifest_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_message_accessor(
+                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<PackageIdent>>(
                     "deps",
-                    Package::get_deps,
+                    Package::get_deps_for_reflect,
+                    Package::mut_deps_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_message_accessor(
+                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<PackageIdent>>(
                     "tdeps",
-                    Package::get_tdeps,
+                    Package::get_tdeps_for_reflect,
+                    Package::mut_tdeps_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_u32_accessor(
+                fields.push(::protobuf::reflect::accessor::make_vec_accessor::<_, ::protobuf::types::ProtobufTypeUint32>(
                     "exposes",
-                    Package::get_exposes,
+                    Package::get_exposes_for_reflect,
+                    Package::mut_exposes_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_string_accessor(
+                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
                     "config",
-                    Package::has_config,
-                    Package::get_config,
+                    Package::get_config_for_reflect,
+                    Package::mut_config_for_reflect,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<Package>(
                     "Package",
@@ -843,32 +914,25 @@ impl ::protobuf::Clear for Package {
     }
 }
 
-impl ::std::cmp::PartialEq for Package {
-    fn eq(&self, other: &Package) -> bool {
-        self.ident == other.ident &&
-        self.checksum == other.checksum &&
-        self.manifest == other.manifest &&
-        self.deps == other.deps &&
-        self.tdeps == other.tdeps &&
-        self.exposes == other.exposes &&
-        self.config == other.config &&
-        self.unknown_fields == other.unknown_fields
-    }
-}
-
 impl ::std::fmt::Debug for Package {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
-#[derive(Clone,Default)]
+impl ::protobuf::reflect::ProtobufValue for Package {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Message(self)
+    }
+}
+
+#[derive(PartialEq,Clone,Default)]
 pub struct View {
     // message fields
     name: ::protobuf::SingularField<::std::string::String>,
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    cached_size: ::protobuf::CachedSize,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -885,13 +949,7 @@ impl View {
             ptr: 0 as *const View,
         };
         unsafe {
-            instance.get(|| {
-                View {
-                    name: ::protobuf::SingularField::none(),
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
+            instance.get(View::new)
         }
     }
 
@@ -930,6 +988,14 @@ impl View {
             None => "",
         }
     }
+
+    fn get_name_for_reflect(&self) -> &::protobuf::SingularField<::std::string::String> {
+        &self.name
+    }
+
+    fn mut_name_for_reflect(&mut self) -> &mut ::protobuf::SingularField<::std::string::String> {
+        &mut self.name
+    }
 }
 
 impl ::protobuf::Message for View {
@@ -941,14 +1007,14 @@ impl ::protobuf::Message for View {
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
-        while !try!(is.eof()) {
-            let (field_number, wire_type) = try!(is.read_tag_unpack());
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
-                    try!(::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.name));
+                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.name)?;
                 },
                 _ => {
-                    try!(::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields()));
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
                 },
             };
         }
@@ -959,8 +1025,8 @@ impl ::protobuf::Message for View {
     #[allow(unused_variables)]
     fn compute_size(&self) -> u32 {
         let mut my_size = 0;
-        for value in &self.name {
-            my_size += ::protobuf::rt::string_size(1, &value);
+        if let Some(v) = self.name.as_ref() {
+            my_size += ::protobuf::rt::string_size(1, &v);
         };
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
         self.cached_size.set(my_size);
@@ -969,9 +1035,9 @@ impl ::protobuf::Message for View {
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.name.as_ref() {
-            try!(os.write_string(1, &v));
+            os.write_string(1, &v)?;
         };
-        try!(os.write_unknown_fields(self.get_unknown_fields()));
+        os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
 
@@ -987,12 +1053,14 @@ impl ::protobuf::Message for View {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<View>()
-    }
-
     fn as_any(&self) -> &::std::any::Any {
         self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -1013,10 +1081,10 @@ impl ::protobuf::MessageStatic for View {
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_string_accessor(
+                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
                     "name",
-                    View::has_name,
-                    View::get_name,
+                    View::get_name_for_reflect,
+                    View::mut_name_for_reflect,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<View>(
                     "View",
@@ -1035,20 +1103,19 @@ impl ::protobuf::Clear for View {
     }
 }
 
-impl ::std::cmp::PartialEq for View {
-    fn eq(&self, other: &View) -> bool {
-        self.name == other.name &&
-        self.unknown_fields == other.unknown_fields
-    }
-}
-
 impl ::std::fmt::Debug for View {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
-#[derive(Clone,Default)]
+impl ::protobuf::reflect::ProtobufValue for View {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Message(self)
+    }
+}
+
+#[derive(PartialEq,Clone,Default)]
 pub struct OriginKeyIdent {
     // message fields
     origin: ::protobuf::SingularField<::std::string::String>,
@@ -1056,7 +1123,7 @@ pub struct OriginKeyIdent {
     location: ::protobuf::SingularField<::std::string::String>,
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    cached_size: ::protobuf::CachedSize,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -1073,15 +1140,7 @@ impl OriginKeyIdent {
             ptr: 0 as *const OriginKeyIdent,
         };
         unsafe {
-            instance.get(|| {
-                OriginKeyIdent {
-                    origin: ::protobuf::SingularField::none(),
-                    revision: ::protobuf::SingularField::none(),
-                    location: ::protobuf::SingularField::none(),
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
+            instance.get(OriginKeyIdent::new)
         }
     }
 
@@ -1121,6 +1180,14 @@ impl OriginKeyIdent {
         }
     }
 
+    fn get_origin_for_reflect(&self) -> &::protobuf::SingularField<::std::string::String> {
+        &self.origin
+    }
+
+    fn mut_origin_for_reflect(&mut self) -> &mut ::protobuf::SingularField<::std::string::String> {
+        &mut self.origin
+    }
+
     // required string revision = 2;
 
     pub fn clear_revision(&mut self) {
@@ -1155,6 +1222,14 @@ impl OriginKeyIdent {
             Some(v) => &v,
             None => "",
         }
+    }
+
+    fn get_revision_for_reflect(&self) -> &::protobuf::SingularField<::std::string::String> {
+        &self.revision
+    }
+
+    fn mut_revision_for_reflect(&mut self) -> &mut ::protobuf::SingularField<::std::string::String> {
+        &mut self.revision
     }
 
     // required string location = 3;
@@ -1192,6 +1267,14 @@ impl OriginKeyIdent {
             None => "",
         }
     }
+
+    fn get_location_for_reflect(&self) -> &::protobuf::SingularField<::std::string::String> {
+        &self.location
+    }
+
+    fn mut_location_for_reflect(&mut self) -> &mut ::protobuf::SingularField<::std::string::String> {
+        &mut self.location
+    }
 }
 
 impl ::protobuf::Message for OriginKeyIdent {
@@ -1209,20 +1292,20 @@ impl ::protobuf::Message for OriginKeyIdent {
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
-        while !try!(is.eof()) {
-            let (field_number, wire_type) = try!(is.read_tag_unpack());
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
-                    try!(::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.origin));
+                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.origin)?;
                 },
                 2 => {
-                    try!(::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.revision));
+                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.revision)?;
                 },
                 3 => {
-                    try!(::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.location));
+                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.location)?;
                 },
                 _ => {
-                    try!(::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields()));
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
                 },
             };
         }
@@ -1233,14 +1316,14 @@ impl ::protobuf::Message for OriginKeyIdent {
     #[allow(unused_variables)]
     fn compute_size(&self) -> u32 {
         let mut my_size = 0;
-        for value in &self.origin {
-            my_size += ::protobuf::rt::string_size(1, &value);
+        if let Some(v) = self.origin.as_ref() {
+            my_size += ::protobuf::rt::string_size(1, &v);
         };
-        for value in &self.revision {
-            my_size += ::protobuf::rt::string_size(2, &value);
+        if let Some(v) = self.revision.as_ref() {
+            my_size += ::protobuf::rt::string_size(2, &v);
         };
-        for value in &self.location {
-            my_size += ::protobuf::rt::string_size(3, &value);
+        if let Some(v) = self.location.as_ref() {
+            my_size += ::protobuf::rt::string_size(3, &v);
         };
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
         self.cached_size.set(my_size);
@@ -1249,15 +1332,15 @@ impl ::protobuf::Message for OriginKeyIdent {
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.origin.as_ref() {
-            try!(os.write_string(1, &v));
+            os.write_string(1, &v)?;
         };
         if let Some(v) = self.revision.as_ref() {
-            try!(os.write_string(2, &v));
+            os.write_string(2, &v)?;
         };
         if let Some(v) = self.location.as_ref() {
-            try!(os.write_string(3, &v));
+            os.write_string(3, &v)?;
         };
-        try!(os.write_unknown_fields(self.get_unknown_fields()));
+        os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
 
@@ -1273,12 +1356,14 @@ impl ::protobuf::Message for OriginKeyIdent {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<OriginKeyIdent>()
-    }
-
     fn as_any(&self) -> &::std::any::Any {
         self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -1299,20 +1384,20 @@ impl ::protobuf::MessageStatic for OriginKeyIdent {
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_string_accessor(
+                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
                     "origin",
-                    OriginKeyIdent::has_origin,
-                    OriginKeyIdent::get_origin,
+                    OriginKeyIdent::get_origin_for_reflect,
+                    OriginKeyIdent::mut_origin_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_string_accessor(
+                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
                     "revision",
-                    OriginKeyIdent::has_revision,
-                    OriginKeyIdent::get_revision,
+                    OriginKeyIdent::get_revision_for_reflect,
+                    OriginKeyIdent::mut_revision_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_string_accessor(
+                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
                     "location",
-                    OriginKeyIdent::has_location,
-                    OriginKeyIdent::get_location,
+                    OriginKeyIdent::get_location_for_reflect,
+                    OriginKeyIdent::mut_location_for_reflect,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<OriginKeyIdent>(
                     "OriginKeyIdent",
@@ -1333,18 +1418,15 @@ impl ::protobuf::Clear for OriginKeyIdent {
     }
 }
 
-impl ::std::cmp::PartialEq for OriginKeyIdent {
-    fn eq(&self, other: &OriginKeyIdent) -> bool {
-        self.origin == other.origin &&
-        self.revision == other.revision &&
-        self.location == other.location &&
-        self.unknown_fields == other.unknown_fields
-    }
-}
-
 impl ::std::fmt::Debug for OriginKeyIdent {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
+    }
+}
+
+impl ::protobuf::reflect::ProtobufValue for OriginKeyIdent {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 

--- a/components/builder-protocol/src/message/jobsrv.rs
+++ b/components/builder-protocol/src/message/jobsrv.rs
@@ -9,6 +9,7 @@
 
 #![allow(box_pointers)]
 #![allow(dead_code)]
+#![allow(missing_docs)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
@@ -20,7 +21,7 @@
 use protobuf::Message as Message_imported_for_functions;
 use protobuf::ProtobufEnum as ProtobufEnum_imported_for_functions;
 
-#[derive(Clone,Default)]
+#[derive(PartialEq,Clone,Default)]
 pub struct Heartbeat {
     // message fields
     endpoint: ::protobuf::SingularField<::std::string::String>,
@@ -28,7 +29,7 @@ pub struct Heartbeat {
     state: ::std::option::Option<WorkerState>,
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    cached_size: ::protobuf::CachedSize,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -45,15 +46,7 @@ impl Heartbeat {
             ptr: 0 as *const Heartbeat,
         };
         unsafe {
-            instance.get(|| {
-                Heartbeat {
-                    endpoint: ::protobuf::SingularField::none(),
-                    os: ::std::option::Option::None,
-                    state: ::std::option::Option::None,
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
+            instance.get(Heartbeat::new)
         }
     }
 
@@ -93,6 +86,14 @@ impl Heartbeat {
         }
     }
 
+    fn get_endpoint_for_reflect(&self) -> &::protobuf::SingularField<::std::string::String> {
+        &self.endpoint
+    }
+
+    fn mut_endpoint_for_reflect(&mut self) -> &mut ::protobuf::SingularField<::std::string::String> {
+        &mut self.endpoint
+    }
+
     // required .jobsrv.Os os = 2;
 
     pub fn clear_os(&mut self) {
@@ -110,6 +111,14 @@ impl Heartbeat {
 
     pub fn get_os(&self) -> Os {
         self.os.unwrap_or(Os::Linux)
+    }
+
+    fn get_os_for_reflect(&self) -> &::std::option::Option<Os> {
+        &self.os
+    }
+
+    fn mut_os_for_reflect(&mut self) -> &mut ::std::option::Option<Os> {
+        &mut self.os
     }
 
     // required .jobsrv.WorkerState state = 3;
@@ -130,6 +139,14 @@ impl Heartbeat {
     pub fn get_state(&self) -> WorkerState {
         self.state.unwrap_or(WorkerState::Ready)
     }
+
+    fn get_state_for_reflect(&self) -> &::std::option::Option<WorkerState> {
+        &self.state
+    }
+
+    fn mut_state_for_reflect(&mut self) -> &mut ::std::option::Option<WorkerState> {
+        &mut self.state
+    }
 }
 
 impl ::protobuf::Message for Heartbeat {
@@ -147,28 +164,28 @@ impl ::protobuf::Message for Heartbeat {
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
-        while !try!(is.eof()) {
-            let (field_number, wire_type) = try!(is.read_tag_unpack());
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
-                    try!(::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.endpoint));
+                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.endpoint)?;
                 },
                 2 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
                         return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
                     };
-                    let tmp = try!(is.read_enum());
+                    let tmp = is.read_enum()?;
                     self.os = ::std::option::Option::Some(tmp);
                 },
                 3 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
                         return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
                     };
-                    let tmp = try!(is.read_enum());
+                    let tmp = is.read_enum()?;
                     self.state = ::std::option::Option::Some(tmp);
                 },
                 _ => {
-                    try!(::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields()));
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
                 },
             };
         }
@@ -179,14 +196,14 @@ impl ::protobuf::Message for Heartbeat {
     #[allow(unused_variables)]
     fn compute_size(&self) -> u32 {
         let mut my_size = 0;
-        for value in &self.endpoint {
-            my_size += ::protobuf::rt::string_size(1, &value);
+        if let Some(v) = self.endpoint.as_ref() {
+            my_size += ::protobuf::rt::string_size(1, &v);
         };
-        for value in &self.os {
-            my_size += ::protobuf::rt::enum_size(2, *value);
+        if let Some(v) = self.os {
+            my_size += ::protobuf::rt::enum_size(2, v);
         };
-        for value in &self.state {
-            my_size += ::protobuf::rt::enum_size(3, *value);
+        if let Some(v) = self.state {
+            my_size += ::protobuf::rt::enum_size(3, v);
         };
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
         self.cached_size.set(my_size);
@@ -195,15 +212,15 @@ impl ::protobuf::Message for Heartbeat {
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.endpoint.as_ref() {
-            try!(os.write_string(1, &v));
+            os.write_string(1, &v)?;
         };
         if let Some(v) = self.os {
-            try!(os.write_enum(2, v.value()));
+            os.write_enum(2, v.value())?;
         };
         if let Some(v) = self.state {
-            try!(os.write_enum(3, v.value()));
+            os.write_enum(3, v.value())?;
         };
-        try!(os.write_unknown_fields(self.get_unknown_fields()));
+        os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
 
@@ -219,12 +236,14 @@ impl ::protobuf::Message for Heartbeat {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<Heartbeat>()
-    }
-
     fn as_any(&self) -> &::std::any::Any {
         self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -245,20 +264,20 @@ impl ::protobuf::MessageStatic for Heartbeat {
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_string_accessor(
+                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
                     "endpoint",
-                    Heartbeat::has_endpoint,
-                    Heartbeat::get_endpoint,
+                    Heartbeat::get_endpoint_for_reflect,
+                    Heartbeat::mut_endpoint_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_enum_accessor(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeEnum<Os>>(
                     "os",
-                    Heartbeat::has_os,
-                    Heartbeat::get_os,
+                    Heartbeat::get_os_for_reflect,
+                    Heartbeat::mut_os_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_enum_accessor(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeEnum<WorkerState>>(
                     "state",
-                    Heartbeat::has_state,
-                    Heartbeat::get_state,
+                    Heartbeat::get_state_for_reflect,
+                    Heartbeat::mut_state_for_reflect,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<Heartbeat>(
                     "Heartbeat",
@@ -279,22 +298,19 @@ impl ::protobuf::Clear for Heartbeat {
     }
 }
 
-impl ::std::cmp::PartialEq for Heartbeat {
-    fn eq(&self, other: &Heartbeat) -> bool {
-        self.endpoint == other.endpoint &&
-        self.os == other.os &&
-        self.state == other.state &&
-        self.unknown_fields == other.unknown_fields
-    }
-}
-
 impl ::std::fmt::Debug for Heartbeat {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
-#[derive(Clone,Default)]
+impl ::protobuf::reflect::ProtobufValue for Heartbeat {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Message(self)
+    }
+}
+
+#[derive(PartialEq,Clone,Default)]
 pub struct Job {
     // message fields
     id: ::std::option::Option<u64>,
@@ -304,7 +320,7 @@ pub struct Job {
     error: ::protobuf::SingularPtrField<super::net::NetError>,
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    cached_size: ::protobuf::CachedSize,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -321,17 +337,7 @@ impl Job {
             ptr: 0 as *const Job,
         };
         unsafe {
-            instance.get(|| {
-                Job {
-                    id: ::std::option::Option::None,
-                    owner_id: ::std::option::Option::None,
-                    state: ::std::option::Option::None,
-                    project: ::protobuf::SingularPtrField::none(),
-                    error: ::protobuf::SingularPtrField::none(),
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
+            instance.get(Job::new)
         }
     }
 
@@ -354,6 +360,14 @@ impl Job {
         self.id.unwrap_or(0)
     }
 
+    fn get_id_for_reflect(&self) -> &::std::option::Option<u64> {
+        &self.id
+    }
+
+    fn mut_id_for_reflect(&mut self) -> &mut ::std::option::Option<u64> {
+        &mut self.id
+    }
+
     // required uint64 owner_id = 2;
 
     pub fn clear_owner_id(&mut self) {
@@ -373,6 +387,14 @@ impl Job {
         self.owner_id.unwrap_or(0)
     }
 
+    fn get_owner_id_for_reflect(&self) -> &::std::option::Option<u64> {
+        &self.owner_id
+    }
+
+    fn mut_owner_id_for_reflect(&mut self) -> &mut ::std::option::Option<u64> {
+        &mut self.owner_id
+    }
+
     // required .jobsrv.JobState state = 3;
 
     pub fn clear_state(&mut self) {
@@ -390,6 +412,14 @@ impl Job {
 
     pub fn get_state(&self) -> JobState {
         self.state.unwrap_or(JobState::Pending)
+    }
+
+    fn get_state_for_reflect(&self) -> &::std::option::Option<JobState> {
+        &self.state
+    }
+
+    fn mut_state_for_reflect(&mut self) -> &mut ::std::option::Option<JobState> {
+        &mut self.state
     }
 
     // required .vault.Project project = 4;
@@ -425,6 +455,14 @@ impl Job {
         self.project.as_ref().unwrap_or_else(|| super::vault::Project::default_instance())
     }
 
+    fn get_project_for_reflect(&self) -> &::protobuf::SingularPtrField<super::vault::Project> {
+        &self.project
+    }
+
+    fn mut_project_for_reflect(&mut self) -> &mut ::protobuf::SingularPtrField<super::vault::Project> {
+        &mut self.project
+    }
+
     // optional .net.NetError error = 5;
 
     pub fn clear_error(&mut self) {
@@ -457,6 +495,14 @@ impl Job {
     pub fn get_error(&self) -> &super::net::NetError {
         self.error.as_ref().unwrap_or_else(|| super::net::NetError::default_instance())
     }
+
+    fn get_error_for_reflect(&self) -> &::protobuf::SingularPtrField<super::net::NetError> {
+        &self.error
+    }
+
+    fn mut_error_for_reflect(&mut self) -> &mut ::protobuf::SingularPtrField<super::net::NetError> {
+        &mut self.error
+    }
 }
 
 impl ::protobuf::Message for Job {
@@ -477,38 +523,38 @@ impl ::protobuf::Message for Job {
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
-        while !try!(is.eof()) {
-            let (field_number, wire_type) = try!(is.read_tag_unpack());
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
                         return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
                     };
-                    let tmp = try!(is.read_uint64());
+                    let tmp = is.read_uint64()?;
                     self.id = ::std::option::Option::Some(tmp);
                 },
                 2 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
                         return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
                     };
-                    let tmp = try!(is.read_uint64());
+                    let tmp = is.read_uint64()?;
                     self.owner_id = ::std::option::Option::Some(tmp);
                 },
                 3 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
                         return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
                     };
-                    let tmp = try!(is.read_enum());
+                    let tmp = is.read_enum()?;
                     self.state = ::std::option::Option::Some(tmp);
                 },
                 4 => {
-                    try!(::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.project));
+                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.project)?;
                 },
                 5 => {
-                    try!(::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.error));
+                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.error)?;
                 },
                 _ => {
-                    try!(::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields()));
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
                 },
             };
         }
@@ -519,21 +565,21 @@ impl ::protobuf::Message for Job {
     #[allow(unused_variables)]
     fn compute_size(&self) -> u32 {
         let mut my_size = 0;
-        for value in &self.id {
-            my_size += ::protobuf::rt::value_size(1, *value, ::protobuf::wire_format::WireTypeVarint);
+        if let Some(v) = self.id {
+            my_size += ::protobuf::rt::value_size(1, v, ::protobuf::wire_format::WireTypeVarint);
         };
-        for value in &self.owner_id {
-            my_size += ::protobuf::rt::value_size(2, *value, ::protobuf::wire_format::WireTypeVarint);
+        if let Some(v) = self.owner_id {
+            my_size += ::protobuf::rt::value_size(2, v, ::protobuf::wire_format::WireTypeVarint);
         };
-        for value in &self.state {
-            my_size += ::protobuf::rt::enum_size(3, *value);
+        if let Some(v) = self.state {
+            my_size += ::protobuf::rt::enum_size(3, v);
         };
-        for value in &self.project {
-            let len = value.compute_size();
+        if let Some(v) = self.project.as_ref() {
+            let len = v.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
         };
-        for value in &self.error {
-            let len = value.compute_size();
+        if let Some(v) = self.error.as_ref() {
+            let len = v.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
         };
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
@@ -543,25 +589,25 @@ impl ::protobuf::Message for Job {
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.id {
-            try!(os.write_uint64(1, v));
+            os.write_uint64(1, v)?;
         };
         if let Some(v) = self.owner_id {
-            try!(os.write_uint64(2, v));
+            os.write_uint64(2, v)?;
         };
         if let Some(v) = self.state {
-            try!(os.write_enum(3, v.value()));
+            os.write_enum(3, v.value())?;
         };
         if let Some(v) = self.project.as_ref() {
-            try!(os.write_tag(4, ::protobuf::wire_format::WireTypeLengthDelimited));
-            try!(os.write_raw_varint32(v.get_cached_size()));
-            try!(v.write_to_with_cached_sizes(os));
+            os.write_tag(4, ::protobuf::wire_format::WireTypeLengthDelimited)?;
+            os.write_raw_varint32(v.get_cached_size())?;
+            v.write_to_with_cached_sizes(os)?;
         };
         if let Some(v) = self.error.as_ref() {
-            try!(os.write_tag(5, ::protobuf::wire_format::WireTypeLengthDelimited));
-            try!(os.write_raw_varint32(v.get_cached_size()));
-            try!(v.write_to_with_cached_sizes(os));
+            os.write_tag(5, ::protobuf::wire_format::WireTypeLengthDelimited)?;
+            os.write_raw_varint32(v.get_cached_size())?;
+            v.write_to_with_cached_sizes(os)?;
         };
-        try!(os.write_unknown_fields(self.get_unknown_fields()));
+        os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
 
@@ -577,12 +623,14 @@ impl ::protobuf::Message for Job {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<Job>()
-    }
-
     fn as_any(&self) -> &::std::any::Any {
         self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -603,30 +651,30 @@ impl ::protobuf::MessageStatic for Job {
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_u64_accessor(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint64>(
                     "id",
-                    Job::has_id,
-                    Job::get_id,
+                    Job::get_id_for_reflect,
+                    Job::mut_id_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_u64_accessor(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint64>(
                     "owner_id",
-                    Job::has_owner_id,
-                    Job::get_owner_id,
+                    Job::get_owner_id_for_reflect,
+                    Job::mut_owner_id_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_enum_accessor(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeEnum<JobState>>(
                     "state",
-                    Job::has_state,
-                    Job::get_state,
+                    Job::get_state_for_reflect,
+                    Job::mut_state_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_message_accessor(
+                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<super::vault::Project>>(
                     "project",
-                    Job::has_project,
-                    Job::get_project,
+                    Job::get_project_for_reflect,
+                    Job::mut_project_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_message_accessor(
+                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<super::net::NetError>>(
                     "error",
-                    Job::has_error,
-                    Job::get_error,
+                    Job::get_error_for_reflect,
+                    Job::mut_error_for_reflect,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<Job>(
                     "Job",
@@ -649,30 +697,25 @@ impl ::protobuf::Clear for Job {
     }
 }
 
-impl ::std::cmp::PartialEq for Job {
-    fn eq(&self, other: &Job) -> bool {
-        self.id == other.id &&
-        self.owner_id == other.owner_id &&
-        self.state == other.state &&
-        self.project == other.project &&
-        self.error == other.error &&
-        self.unknown_fields == other.unknown_fields
-    }
-}
-
 impl ::std::fmt::Debug for Job {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
-#[derive(Clone,Default)]
+impl ::protobuf::reflect::ProtobufValue for Job {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Message(self)
+    }
+}
+
+#[derive(PartialEq,Clone,Default)]
 pub struct JobGet {
     // message fields
     id: ::std::option::Option<u64>,
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    cached_size: ::protobuf::CachedSize,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -689,13 +732,7 @@ impl JobGet {
             ptr: 0 as *const JobGet,
         };
         unsafe {
-            instance.get(|| {
-                JobGet {
-                    id: ::std::option::Option::None,
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
+            instance.get(JobGet::new)
         }
     }
 
@@ -717,6 +754,14 @@ impl JobGet {
     pub fn get_id(&self) -> u64 {
         self.id.unwrap_or(0)
     }
+
+    fn get_id_for_reflect(&self) -> &::std::option::Option<u64> {
+        &self.id
+    }
+
+    fn mut_id_for_reflect(&mut self) -> &mut ::std::option::Option<u64> {
+        &mut self.id
+    }
 }
 
 impl ::protobuf::Message for JobGet {
@@ -728,18 +773,18 @@ impl ::protobuf::Message for JobGet {
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
-        while !try!(is.eof()) {
-            let (field_number, wire_type) = try!(is.read_tag_unpack());
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
                         return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
                     };
-                    let tmp = try!(is.read_uint64());
+                    let tmp = is.read_uint64()?;
                     self.id = ::std::option::Option::Some(tmp);
                 },
                 _ => {
-                    try!(::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields()));
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
                 },
             };
         }
@@ -750,8 +795,8 @@ impl ::protobuf::Message for JobGet {
     #[allow(unused_variables)]
     fn compute_size(&self) -> u32 {
         let mut my_size = 0;
-        for value in &self.id {
-            my_size += ::protobuf::rt::value_size(1, *value, ::protobuf::wire_format::WireTypeVarint);
+        if let Some(v) = self.id {
+            my_size += ::protobuf::rt::value_size(1, v, ::protobuf::wire_format::WireTypeVarint);
         };
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
         self.cached_size.set(my_size);
@@ -760,9 +805,9 @@ impl ::protobuf::Message for JobGet {
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.id {
-            try!(os.write_uint64(1, v));
+            os.write_uint64(1, v)?;
         };
-        try!(os.write_unknown_fields(self.get_unknown_fields()));
+        os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
 
@@ -778,12 +823,14 @@ impl ::protobuf::Message for JobGet {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<JobGet>()
-    }
-
     fn as_any(&self) -> &::std::any::Any {
         self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -804,10 +851,10 @@ impl ::protobuf::MessageStatic for JobGet {
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_u64_accessor(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint64>(
                     "id",
-                    JobGet::has_id,
-                    JobGet::get_id,
+                    JobGet::get_id_for_reflect,
+                    JobGet::mut_id_for_reflect,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<JobGet>(
                     "JobGet",
@@ -826,27 +873,26 @@ impl ::protobuf::Clear for JobGet {
     }
 }
 
-impl ::std::cmp::PartialEq for JobGet {
-    fn eq(&self, other: &JobGet) -> bool {
-        self.id == other.id &&
-        self.unknown_fields == other.unknown_fields
-    }
-}
-
 impl ::std::fmt::Debug for JobGet {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
-#[derive(Clone,Default)]
+impl ::protobuf::reflect::ProtobufValue for JobGet {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Message(self)
+    }
+}
+
+#[derive(PartialEq,Clone,Default)]
 pub struct JobSpec {
     // message fields
     owner_id: ::std::option::Option<u64>,
     project: ::protobuf::SingularPtrField<super::vault::Project>,
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    cached_size: ::protobuf::CachedSize,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -863,14 +909,7 @@ impl JobSpec {
             ptr: 0 as *const JobSpec,
         };
         unsafe {
-            instance.get(|| {
-                JobSpec {
-                    owner_id: ::std::option::Option::None,
-                    project: ::protobuf::SingularPtrField::none(),
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
+            instance.get(JobSpec::new)
         }
     }
 
@@ -891,6 +930,14 @@ impl JobSpec {
 
     pub fn get_owner_id(&self) -> u64 {
         self.owner_id.unwrap_or(0)
+    }
+
+    fn get_owner_id_for_reflect(&self) -> &::std::option::Option<u64> {
+        &self.owner_id
+    }
+
+    fn mut_owner_id_for_reflect(&mut self) -> &mut ::std::option::Option<u64> {
+        &mut self.owner_id
     }
 
     // required .vault.Project project = 2;
@@ -925,6 +972,14 @@ impl JobSpec {
     pub fn get_project(&self) -> &super::vault::Project {
         self.project.as_ref().unwrap_or_else(|| super::vault::Project::default_instance())
     }
+
+    fn get_project_for_reflect(&self) -> &::protobuf::SingularPtrField<super::vault::Project> {
+        &self.project
+    }
+
+    fn mut_project_for_reflect(&mut self) -> &mut ::protobuf::SingularPtrField<super::vault::Project> {
+        &mut self.project
+    }
 }
 
 impl ::protobuf::Message for JobSpec {
@@ -939,21 +994,21 @@ impl ::protobuf::Message for JobSpec {
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
-        while !try!(is.eof()) {
-            let (field_number, wire_type) = try!(is.read_tag_unpack());
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
                         return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
                     };
-                    let tmp = try!(is.read_uint64());
+                    let tmp = is.read_uint64()?;
                     self.owner_id = ::std::option::Option::Some(tmp);
                 },
                 2 => {
-                    try!(::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.project));
+                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.project)?;
                 },
                 _ => {
-                    try!(::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields()));
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
                 },
             };
         }
@@ -964,11 +1019,11 @@ impl ::protobuf::Message for JobSpec {
     #[allow(unused_variables)]
     fn compute_size(&self) -> u32 {
         let mut my_size = 0;
-        for value in &self.owner_id {
-            my_size += ::protobuf::rt::value_size(1, *value, ::protobuf::wire_format::WireTypeVarint);
+        if let Some(v) = self.owner_id {
+            my_size += ::protobuf::rt::value_size(1, v, ::protobuf::wire_format::WireTypeVarint);
         };
-        for value in &self.project {
-            let len = value.compute_size();
+        if let Some(v) = self.project.as_ref() {
+            let len = v.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
         };
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
@@ -978,14 +1033,14 @@ impl ::protobuf::Message for JobSpec {
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.owner_id {
-            try!(os.write_uint64(1, v));
+            os.write_uint64(1, v)?;
         };
         if let Some(v) = self.project.as_ref() {
-            try!(os.write_tag(2, ::protobuf::wire_format::WireTypeLengthDelimited));
-            try!(os.write_raw_varint32(v.get_cached_size()));
-            try!(v.write_to_with_cached_sizes(os));
+            os.write_tag(2, ::protobuf::wire_format::WireTypeLengthDelimited)?;
+            os.write_raw_varint32(v.get_cached_size())?;
+            v.write_to_with_cached_sizes(os)?;
         };
-        try!(os.write_unknown_fields(self.get_unknown_fields()));
+        os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
 
@@ -1001,12 +1056,14 @@ impl ::protobuf::Message for JobSpec {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<JobSpec>()
-    }
-
     fn as_any(&self) -> &::std::any::Any {
         self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -1027,15 +1084,15 @@ impl ::protobuf::MessageStatic for JobSpec {
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_u64_accessor(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint64>(
                     "owner_id",
-                    JobSpec::has_owner_id,
-                    JobSpec::get_owner_id,
+                    JobSpec::get_owner_id_for_reflect,
+                    JobSpec::mut_owner_id_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_message_accessor(
+                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<super::vault::Project>>(
                     "project",
-                    JobSpec::has_project,
-                    JobSpec::get_project,
+                    JobSpec::get_project_for_reflect,
+                    JobSpec::mut_project_for_reflect,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<JobSpec>(
                     "JobSpec",
@@ -1055,17 +1112,15 @@ impl ::protobuf::Clear for JobSpec {
     }
 }
 
-impl ::std::cmp::PartialEq for JobSpec {
-    fn eq(&self, other: &JobSpec) -> bool {
-        self.owner_id == other.owner_id &&
-        self.project == other.project &&
-        self.unknown_fields == other.unknown_fields
-    }
-}
-
 impl ::std::fmt::Debug for JobSpec {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
+    }
+}
+
+impl ::protobuf::reflect::ProtobufValue for JobSpec {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
@@ -1115,6 +1170,12 @@ impl ::protobuf::ProtobufEnum for Os {
 impl ::std::marker::Copy for Os {
 }
 
+impl ::protobuf::reflect::ProtobufValue for Os {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Enum(self.descriptor())
+    }
+}
+
 #[derive(Clone,PartialEq,Eq,Debug,Hash)]
 pub enum WorkerState {
     Ready = 0,
@@ -1156,6 +1217,12 @@ impl ::protobuf::ProtobufEnum for WorkerState {
 }
 
 impl ::std::marker::Copy for WorkerState {
+}
+
+impl ::protobuf::reflect::ProtobufValue for WorkerState {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Enum(self.descriptor())
+    }
 }
 
 #[derive(Clone,PartialEq,Eq,Debug,Hash)]
@@ -1211,6 +1278,12 @@ impl ::protobuf::ProtobufEnum for JobState {
 }
 
 impl ::std::marker::Copy for JobState {
+}
+
+impl ::protobuf::reflect::ProtobufValue for JobState {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Enum(self.descriptor())
+    }
 }
 
 static file_descriptor_proto_data: &'static [u8] = &[

--- a/components/builder-protocol/src/message/net.rs
+++ b/components/builder-protocol/src/message/net.rs
@@ -9,6 +9,7 @@
 
 #![allow(box_pointers)]
 #![allow(dead_code)]
+#![allow(missing_docs)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
@@ -20,14 +21,14 @@
 use protobuf::Message as Message_imported_for_functions;
 use protobuf::ProtobufEnum as ProtobufEnum_imported_for_functions;
 
-#[derive(Clone,Default)]
+#[derive(PartialEq,Clone,Default)]
 pub struct RouteInfo {
     // message fields
     protocol: ::std::option::Option<Protocol>,
     hash: ::std::option::Option<u64>,
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    cached_size: ::protobuf::CachedSize,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -44,14 +45,7 @@ impl RouteInfo {
             ptr: 0 as *const RouteInfo,
         };
         unsafe {
-            instance.get(|| {
-                RouteInfo {
-                    protocol: ::std::option::Option::None,
-                    hash: ::std::option::Option::None,
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
+            instance.get(RouteInfo::new)
         }
     }
 
@@ -74,6 +68,14 @@ impl RouteInfo {
         self.protocol.unwrap_or(Protocol::Net)
     }
 
+    fn get_protocol_for_reflect(&self) -> &::std::option::Option<Protocol> {
+        &self.protocol
+    }
+
+    fn mut_protocol_for_reflect(&mut self) -> &mut ::std::option::Option<Protocol> {
+        &mut self.protocol
+    }
+
     // optional uint64 hash = 2;
 
     pub fn clear_hash(&mut self) {
@@ -92,6 +94,14 @@ impl RouteInfo {
     pub fn get_hash(&self) -> u64 {
         self.hash.unwrap_or(0)
     }
+
+    fn get_hash_for_reflect(&self) -> &::std::option::Option<u64> {
+        &self.hash
+    }
+
+    fn mut_hash_for_reflect(&mut self) -> &mut ::std::option::Option<u64> {
+        &mut self.hash
+    }
 }
 
 impl ::protobuf::Message for RouteInfo {
@@ -103,25 +113,25 @@ impl ::protobuf::Message for RouteInfo {
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
-        while !try!(is.eof()) {
-            let (field_number, wire_type) = try!(is.read_tag_unpack());
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
                         return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
                     };
-                    let tmp = try!(is.read_enum());
+                    let tmp = is.read_enum()?;
                     self.protocol = ::std::option::Option::Some(tmp);
                 },
                 2 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
                         return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
                     };
-                    let tmp = try!(is.read_uint64());
+                    let tmp = is.read_uint64()?;
                     self.hash = ::std::option::Option::Some(tmp);
                 },
                 _ => {
-                    try!(::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields()));
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
                 },
             };
         }
@@ -132,11 +142,11 @@ impl ::protobuf::Message for RouteInfo {
     #[allow(unused_variables)]
     fn compute_size(&self) -> u32 {
         let mut my_size = 0;
-        for value in &self.protocol {
-            my_size += ::protobuf::rt::enum_size(1, *value);
+        if let Some(v) = self.protocol {
+            my_size += ::protobuf::rt::enum_size(1, v);
         };
-        for value in &self.hash {
-            my_size += ::protobuf::rt::value_size(2, *value, ::protobuf::wire_format::WireTypeVarint);
+        if let Some(v) = self.hash {
+            my_size += ::protobuf::rt::value_size(2, v, ::protobuf::wire_format::WireTypeVarint);
         };
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
         self.cached_size.set(my_size);
@@ -145,12 +155,12 @@ impl ::protobuf::Message for RouteInfo {
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.protocol {
-            try!(os.write_enum(1, v.value()));
+            os.write_enum(1, v.value())?;
         };
         if let Some(v) = self.hash {
-            try!(os.write_uint64(2, v));
+            os.write_uint64(2, v)?;
         };
-        try!(os.write_unknown_fields(self.get_unknown_fields()));
+        os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
 
@@ -166,12 +176,14 @@ impl ::protobuf::Message for RouteInfo {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<RouteInfo>()
-    }
-
     fn as_any(&self) -> &::std::any::Any {
         self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -192,15 +204,15 @@ impl ::protobuf::MessageStatic for RouteInfo {
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_enum_accessor(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeEnum<Protocol>>(
                     "protocol",
-                    RouteInfo::has_protocol,
-                    RouteInfo::get_protocol,
+                    RouteInfo::get_protocol_for_reflect,
+                    RouteInfo::mut_protocol_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_u64_accessor(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint64>(
                     "hash",
-                    RouteInfo::has_hash,
-                    RouteInfo::get_hash,
+                    RouteInfo::get_hash_for_reflect,
+                    RouteInfo::mut_hash_for_reflect,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<RouteInfo>(
                     "RouteInfo",
@@ -220,21 +232,19 @@ impl ::protobuf::Clear for RouteInfo {
     }
 }
 
-impl ::std::cmp::PartialEq for RouteInfo {
-    fn eq(&self, other: &RouteInfo) -> bool {
-        self.protocol == other.protocol &&
-        self.hash == other.hash &&
-        self.unknown_fields == other.unknown_fields
-    }
-}
-
 impl ::std::fmt::Debug for RouteInfo {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
-#[derive(Clone,Default)]
+impl ::protobuf::reflect::ProtobufValue for RouteInfo {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Message(self)
+    }
+}
+
+#[derive(PartialEq,Clone,Default)]
 pub struct Msg {
     // message fields
     message_id: ::protobuf::SingularField<::std::string::String>,
@@ -242,7 +252,7 @@ pub struct Msg {
     route_info: ::protobuf::SingularPtrField<RouteInfo>,
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    cached_size: ::protobuf::CachedSize,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -259,15 +269,7 @@ impl Msg {
             ptr: 0 as *const Msg,
         };
         unsafe {
-            instance.get(|| {
-                Msg {
-                    message_id: ::protobuf::SingularField::none(),
-                    body: ::protobuf::SingularField::none(),
-                    route_info: ::protobuf::SingularPtrField::none(),
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
+            instance.get(Msg::new)
         }
     }
 
@@ -307,6 +309,14 @@ impl Msg {
         }
     }
 
+    fn get_message_id_for_reflect(&self) -> &::protobuf::SingularField<::std::string::String> {
+        &self.message_id
+    }
+
+    fn mut_message_id_for_reflect(&mut self) -> &mut ::protobuf::SingularField<::std::string::String> {
+        &mut self.message_id
+    }
+
     // required bytes body = 2;
 
     pub fn clear_body(&mut self) {
@@ -343,6 +353,14 @@ impl Msg {
         }
     }
 
+    fn get_body_for_reflect(&self) -> &::protobuf::SingularField<::std::vec::Vec<u8>> {
+        &self.body
+    }
+
+    fn mut_body_for_reflect(&mut self) -> &mut ::protobuf::SingularField<::std::vec::Vec<u8>> {
+        &mut self.body
+    }
+
     // optional .net.RouteInfo route_info = 3;
 
     pub fn clear_route_info(&mut self) {
@@ -375,6 +393,14 @@ impl Msg {
     pub fn get_route_info(&self) -> &RouteInfo {
         self.route_info.as_ref().unwrap_or_else(|| RouteInfo::default_instance())
     }
+
+    fn get_route_info_for_reflect(&self) -> &::protobuf::SingularPtrField<RouteInfo> {
+        &self.route_info
+    }
+
+    fn mut_route_info_for_reflect(&mut self) -> &mut ::protobuf::SingularPtrField<RouteInfo> {
+        &mut self.route_info
+    }
 }
 
 impl ::protobuf::Message for Msg {
@@ -389,20 +415,20 @@ impl ::protobuf::Message for Msg {
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
-        while !try!(is.eof()) {
-            let (field_number, wire_type) = try!(is.read_tag_unpack());
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
-                    try!(::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.message_id));
+                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.message_id)?;
                 },
                 2 => {
-                    try!(::protobuf::rt::read_singular_bytes_into(wire_type, is, &mut self.body));
+                    ::protobuf::rt::read_singular_bytes_into(wire_type, is, &mut self.body)?;
                 },
                 3 => {
-                    try!(::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.route_info));
+                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.route_info)?;
                 },
                 _ => {
-                    try!(::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields()));
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
                 },
             };
         }
@@ -413,14 +439,14 @@ impl ::protobuf::Message for Msg {
     #[allow(unused_variables)]
     fn compute_size(&self) -> u32 {
         let mut my_size = 0;
-        for value in &self.message_id {
-            my_size += ::protobuf::rt::string_size(1, &value);
+        if let Some(v) = self.message_id.as_ref() {
+            my_size += ::protobuf::rt::string_size(1, &v);
         };
-        for value in &self.body {
-            my_size += ::protobuf::rt::bytes_size(2, &value);
+        if let Some(v) = self.body.as_ref() {
+            my_size += ::protobuf::rt::bytes_size(2, &v);
         };
-        for value in &self.route_info {
-            let len = value.compute_size();
+        if let Some(v) = self.route_info.as_ref() {
+            let len = v.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
         };
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
@@ -430,17 +456,17 @@ impl ::protobuf::Message for Msg {
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.message_id.as_ref() {
-            try!(os.write_string(1, &v));
+            os.write_string(1, &v)?;
         };
         if let Some(v) = self.body.as_ref() {
-            try!(os.write_bytes(2, &v));
+            os.write_bytes(2, &v)?;
         };
         if let Some(v) = self.route_info.as_ref() {
-            try!(os.write_tag(3, ::protobuf::wire_format::WireTypeLengthDelimited));
-            try!(os.write_raw_varint32(v.get_cached_size()));
-            try!(v.write_to_with_cached_sizes(os));
+            os.write_tag(3, ::protobuf::wire_format::WireTypeLengthDelimited)?;
+            os.write_raw_varint32(v.get_cached_size())?;
+            v.write_to_with_cached_sizes(os)?;
         };
-        try!(os.write_unknown_fields(self.get_unknown_fields()));
+        os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
 
@@ -456,12 +482,14 @@ impl ::protobuf::Message for Msg {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<Msg>()
-    }
-
     fn as_any(&self) -> &::std::any::Any {
         self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -482,20 +510,20 @@ impl ::protobuf::MessageStatic for Msg {
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_string_accessor(
+                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
                     "message_id",
-                    Msg::has_message_id,
-                    Msg::get_message_id,
+                    Msg::get_message_id_for_reflect,
+                    Msg::mut_message_id_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_bytes_accessor(
+                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeBytes>(
                     "body",
-                    Msg::has_body,
-                    Msg::get_body,
+                    Msg::get_body_for_reflect,
+                    Msg::mut_body_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_message_accessor(
+                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<RouteInfo>>(
                     "route_info",
-                    Msg::has_route_info,
-                    Msg::get_route_info,
+                    Msg::get_route_info_for_reflect,
+                    Msg::mut_route_info_for_reflect,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<Msg>(
                     "Msg",
@@ -516,29 +544,26 @@ impl ::protobuf::Clear for Msg {
     }
 }
 
-impl ::std::cmp::PartialEq for Msg {
-    fn eq(&self, other: &Msg) -> bool {
-        self.message_id == other.message_id &&
-        self.body == other.body &&
-        self.route_info == other.route_info &&
-        self.unknown_fields == other.unknown_fields
-    }
-}
-
 impl ::std::fmt::Debug for Msg {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
-#[derive(Clone,Default)]
+impl ::protobuf::reflect::ProtobufValue for Msg {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Message(self)
+    }
+}
+
+#[derive(PartialEq,Clone,Default)]
 pub struct NetError {
     // message fields
     code: ::std::option::Option<ErrCode>,
     msg: ::protobuf::SingularField<::std::string::String>,
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    cached_size: ::protobuf::CachedSize,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -555,14 +580,7 @@ impl NetError {
             ptr: 0 as *const NetError,
         };
         unsafe {
-            instance.get(|| {
-                NetError {
-                    code: ::std::option::Option::None,
-                    msg: ::protobuf::SingularField::none(),
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
+            instance.get(NetError::new)
         }
     }
 
@@ -583,6 +601,14 @@ impl NetError {
 
     pub fn get_code(&self) -> ErrCode {
         self.code.unwrap_or(ErrCode::BUG)
+    }
+
+    fn get_code_for_reflect(&self) -> &::std::option::Option<ErrCode> {
+        &self.code
+    }
+
+    fn mut_code_for_reflect(&mut self) -> &mut ::std::option::Option<ErrCode> {
+        &mut self.code
     }
 
     // required string msg = 2;
@@ -620,6 +646,14 @@ impl NetError {
             None => "",
         }
     }
+
+    fn get_msg_for_reflect(&self) -> &::protobuf::SingularField<::std::string::String> {
+        &self.msg
+    }
+
+    fn mut_msg_for_reflect(&mut self) -> &mut ::protobuf::SingularField<::std::string::String> {
+        &mut self.msg
+    }
 }
 
 impl ::protobuf::Message for NetError {
@@ -634,21 +668,21 @@ impl ::protobuf::Message for NetError {
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
-        while !try!(is.eof()) {
-            let (field_number, wire_type) = try!(is.read_tag_unpack());
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
                         return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
                     };
-                    let tmp = try!(is.read_enum());
+                    let tmp = is.read_enum()?;
                     self.code = ::std::option::Option::Some(tmp);
                 },
                 2 => {
-                    try!(::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.msg));
+                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.msg)?;
                 },
                 _ => {
-                    try!(::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields()));
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
                 },
             };
         }
@@ -659,11 +693,11 @@ impl ::protobuf::Message for NetError {
     #[allow(unused_variables)]
     fn compute_size(&self) -> u32 {
         let mut my_size = 0;
-        for value in &self.code {
-            my_size += ::protobuf::rt::enum_size(1, *value);
+        if let Some(v) = self.code {
+            my_size += ::protobuf::rt::enum_size(1, v);
         };
-        for value in &self.msg {
-            my_size += ::protobuf::rt::string_size(2, &value);
+        if let Some(v) = self.msg.as_ref() {
+            my_size += ::protobuf::rt::string_size(2, &v);
         };
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
         self.cached_size.set(my_size);
@@ -672,12 +706,12 @@ impl ::protobuf::Message for NetError {
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.code {
-            try!(os.write_enum(1, v.value()));
+            os.write_enum(1, v.value())?;
         };
         if let Some(v) = self.msg.as_ref() {
-            try!(os.write_string(2, &v));
+            os.write_string(2, &v)?;
         };
-        try!(os.write_unknown_fields(self.get_unknown_fields()));
+        os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
 
@@ -693,12 +727,14 @@ impl ::protobuf::Message for NetError {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<NetError>()
-    }
-
     fn as_any(&self) -> &::std::any::Any {
         self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -719,15 +755,15 @@ impl ::protobuf::MessageStatic for NetError {
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_enum_accessor(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeEnum<ErrCode>>(
                     "code",
-                    NetError::has_code,
-                    NetError::get_code,
+                    NetError::get_code_for_reflect,
+                    NetError::mut_code_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_string_accessor(
+                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
                     "msg",
-                    NetError::has_msg,
-                    NetError::get_msg,
+                    NetError::get_msg_for_reflect,
+                    NetError::mut_msg_for_reflect,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<NetError>(
                     "NetError",
@@ -747,25 +783,23 @@ impl ::protobuf::Clear for NetError {
     }
 }
 
-impl ::std::cmp::PartialEq for NetError {
-    fn eq(&self, other: &NetError) -> bool {
-        self.code == other.code &&
-        self.msg == other.msg &&
-        self.unknown_fields == other.unknown_fields
-    }
-}
-
 impl ::std::fmt::Debug for NetError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
-#[derive(Clone,Default)]
+impl ::protobuf::reflect::ProtobufValue for NetError {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Message(self)
+    }
+}
+
+#[derive(PartialEq,Clone,Default)]
 pub struct NetOk {
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    cached_size: ::protobuf::CachedSize,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -782,12 +816,7 @@ impl NetOk {
             ptr: 0 as *const NetOk,
         };
         unsafe {
-            instance.get(|| {
-                NetOk {
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
+            instance.get(NetOk::new)
         }
     }
 }
@@ -798,11 +827,11 @@ impl ::protobuf::Message for NetOk {
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
-        while !try!(is.eof()) {
-            let (field_number, wire_type) = try!(is.read_tag_unpack());
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 _ => {
-                    try!(::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields()));
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
                 },
             };
         }
@@ -819,7 +848,7 @@ impl ::protobuf::Message for NetOk {
     }
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
-        try!(os.write_unknown_fields(self.get_unknown_fields()));
+        os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
 
@@ -835,12 +864,14 @@ impl ::protobuf::Message for NetOk {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<NetOk>()
-    }
-
     fn as_any(&self) -> &::std::any::Any {
         self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -877,23 +908,23 @@ impl ::protobuf::Clear for NetOk {
     }
 }
 
-impl ::std::cmp::PartialEq for NetOk {
-    fn eq(&self, other: &NetOk) -> bool {
-        self.unknown_fields == other.unknown_fields
-    }
-}
-
 impl ::std::fmt::Debug for NetOk {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
-#[derive(Clone,Default)]
+impl ::protobuf::reflect::ProtobufValue for NetOk {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Message(self)
+    }
+}
+
+#[derive(PartialEq,Clone,Default)]
 pub struct Ping {
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    cached_size: ::protobuf::CachedSize,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -910,12 +941,7 @@ impl Ping {
             ptr: 0 as *const Ping,
         };
         unsafe {
-            instance.get(|| {
-                Ping {
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
+            instance.get(Ping::new)
         }
     }
 }
@@ -926,11 +952,11 @@ impl ::protobuf::Message for Ping {
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
-        while !try!(is.eof()) {
-            let (field_number, wire_type) = try!(is.read_tag_unpack());
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 _ => {
-                    try!(::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields()));
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
                 },
             };
         }
@@ -947,7 +973,7 @@ impl ::protobuf::Message for Ping {
     }
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
-        try!(os.write_unknown_fields(self.get_unknown_fields()));
+        os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
 
@@ -963,12 +989,14 @@ impl ::protobuf::Message for Ping {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<Ping>()
-    }
-
     fn as_any(&self) -> &::std::any::Any {
         self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -1005,23 +1033,23 @@ impl ::protobuf::Clear for Ping {
     }
 }
 
-impl ::std::cmp::PartialEq for Ping {
-    fn eq(&self, other: &Ping) -> bool {
-        self.unknown_fields == other.unknown_fields
-    }
-}
-
 impl ::std::fmt::Debug for Ping {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
-#[derive(Clone,Default)]
+impl ::protobuf::reflect::ProtobufValue for Ping {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Message(self)
+    }
+}
+
+#[derive(PartialEq,Clone,Default)]
 pub struct Pong {
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    cached_size: ::protobuf::CachedSize,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -1038,12 +1066,7 @@ impl Pong {
             ptr: 0 as *const Pong,
         };
         unsafe {
-            instance.get(|| {
-                Pong {
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
+            instance.get(Pong::new)
         }
     }
 }
@@ -1054,11 +1077,11 @@ impl ::protobuf::Message for Pong {
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
-        while !try!(is.eof()) {
-            let (field_number, wire_type) = try!(is.read_tag_unpack());
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 _ => {
-                    try!(::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields()));
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
                 },
             };
         }
@@ -1075,7 +1098,7 @@ impl ::protobuf::Message for Pong {
     }
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
-        try!(os.write_unknown_fields(self.get_unknown_fields()));
+        os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
 
@@ -1091,12 +1114,14 @@ impl ::protobuf::Message for Pong {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<Pong>()
-    }
-
     fn as_any(&self) -> &::std::any::Any {
         self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -1133,15 +1158,15 @@ impl ::protobuf::Clear for Pong {
     }
 }
 
-impl ::std::cmp::PartialEq for Pong {
-    fn eq(&self, other: &Pong) -> bool {
-        self.unknown_fields == other.unknown_fields
-    }
-}
-
 impl ::std::fmt::Debug for Pong {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
+    }
+}
+
+impl ::protobuf::reflect::ProtobufValue for Pong {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
@@ -1195,6 +1220,12 @@ impl ::protobuf::ProtobufEnum for Protocol {
 }
 
 impl ::std::marker::Copy for Protocol {
+}
+
+impl ::protobuf::reflect::ProtobufValue for Protocol {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Enum(self.descriptor())
+    }
 }
 
 #[derive(Clone,PartialEq,Eq,Debug,Hash)]
@@ -1286,6 +1317,12 @@ impl ::protobuf::ProtobufEnum for ErrCode {
 }
 
 impl ::std::marker::Copy for ErrCode {
+}
+
+impl ::protobuf::reflect::ProtobufValue for ErrCode {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Enum(self.descriptor())
+    }
 }
 
 static file_descriptor_proto_data: &'static [u8] = &[

--- a/components/builder-protocol/src/message/routesrv.rs
+++ b/components/builder-protocol/src/message/routesrv.rs
@@ -9,6 +9,7 @@
 
 #![allow(box_pointers)]
 #![allow(dead_code)]
+#![allow(missing_docs)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
@@ -20,13 +21,13 @@
 use protobuf::Message as Message_imported_for_functions;
 use protobuf::ProtobufEnum as ProtobufEnum_imported_for_functions;
 
-#[derive(Clone,Default)]
+#[derive(PartialEq,Clone,Default)]
 pub struct Connect {
     // message fields
     registration: ::protobuf::SingularPtrField<Registration>,
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    cached_size: ::protobuf::CachedSize,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -43,13 +44,7 @@ impl Connect {
             ptr: 0 as *const Connect,
         };
         unsafe {
-            instance.get(|| {
-                Connect {
-                    registration: ::protobuf::SingularPtrField::none(),
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
+            instance.get(Connect::new)
         }
     }
 
@@ -85,6 +80,14 @@ impl Connect {
     pub fn get_registration(&self) -> &Registration {
         self.registration.as_ref().unwrap_or_else(|| Registration::default_instance())
     }
+
+    fn get_registration_for_reflect(&self) -> &::protobuf::SingularPtrField<Registration> {
+        &self.registration
+    }
+
+    fn mut_registration_for_reflect(&mut self) -> &mut ::protobuf::SingularPtrField<Registration> {
+        &mut self.registration
+    }
 }
 
 impl ::protobuf::Message for Connect {
@@ -96,14 +99,14 @@ impl ::protobuf::Message for Connect {
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
-        while !try!(is.eof()) {
-            let (field_number, wire_type) = try!(is.read_tag_unpack());
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
-                    try!(::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.registration));
+                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.registration)?;
                 },
                 _ => {
-                    try!(::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields()));
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
                 },
             };
         }
@@ -114,8 +117,8 @@ impl ::protobuf::Message for Connect {
     #[allow(unused_variables)]
     fn compute_size(&self) -> u32 {
         let mut my_size = 0;
-        for value in &self.registration {
-            let len = value.compute_size();
+        if let Some(v) = self.registration.as_ref() {
+            let len = v.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
         };
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
@@ -125,11 +128,11 @@ impl ::protobuf::Message for Connect {
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.registration.as_ref() {
-            try!(os.write_tag(1, ::protobuf::wire_format::WireTypeLengthDelimited));
-            try!(os.write_raw_varint32(v.get_cached_size()));
-            try!(v.write_to_with_cached_sizes(os));
+            os.write_tag(1, ::protobuf::wire_format::WireTypeLengthDelimited)?;
+            os.write_raw_varint32(v.get_cached_size())?;
+            v.write_to_with_cached_sizes(os)?;
         };
-        try!(os.write_unknown_fields(self.get_unknown_fields()));
+        os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
 
@@ -145,12 +148,14 @@ impl ::protobuf::Message for Connect {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<Connect>()
-    }
-
     fn as_any(&self) -> &::std::any::Any {
         self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -171,10 +176,10 @@ impl ::protobuf::MessageStatic for Connect {
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_message_accessor(
+                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<Registration>>(
                     "registration",
-                    Connect::has_registration,
-                    Connect::get_registration,
+                    Connect::get_registration_for_reflect,
+                    Connect::mut_registration_for_reflect,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<Connect>(
                     "Connect",
@@ -193,24 +198,23 @@ impl ::protobuf::Clear for Connect {
     }
 }
 
-impl ::std::cmp::PartialEq for Connect {
-    fn eq(&self, other: &Connect) -> bool {
-        self.registration == other.registration &&
-        self.unknown_fields == other.unknown_fields
-    }
-}
-
 impl ::std::fmt::Debug for Connect {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
-#[derive(Clone,Default)]
+impl ::protobuf::reflect::ProtobufValue for Connect {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Message(self)
+    }
+}
+
+#[derive(PartialEq,Clone,Default)]
 pub struct ConnectOk {
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    cached_size: ::protobuf::CachedSize,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -227,12 +231,7 @@ impl ConnectOk {
             ptr: 0 as *const ConnectOk,
         };
         unsafe {
-            instance.get(|| {
-                ConnectOk {
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
+            instance.get(ConnectOk::new)
         }
     }
 }
@@ -243,11 +242,11 @@ impl ::protobuf::Message for ConnectOk {
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
-        while !try!(is.eof()) {
-            let (field_number, wire_type) = try!(is.read_tag_unpack());
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 _ => {
-                    try!(::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields()));
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
                 },
             };
         }
@@ -264,7 +263,7 @@ impl ::protobuf::Message for ConnectOk {
     }
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
-        try!(os.write_unknown_fields(self.get_unknown_fields()));
+        os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
 
@@ -280,12 +279,14 @@ impl ::protobuf::Message for ConnectOk {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<ConnectOk>()
-    }
-
     fn as_any(&self) -> &::std::any::Any {
         self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -322,23 +323,23 @@ impl ::protobuf::Clear for ConnectOk {
     }
 }
 
-impl ::std::cmp::PartialEq for ConnectOk {
-    fn eq(&self, other: &ConnectOk) -> bool {
-        self.unknown_fields == other.unknown_fields
-    }
-}
-
 impl ::std::fmt::Debug for ConnectOk {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
-#[derive(Clone,Default)]
+impl ::protobuf::reflect::ProtobufValue for ConnectOk {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Message(self)
+    }
+}
+
+#[derive(PartialEq,Clone,Default)]
 pub struct Disconnect {
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    cached_size: ::protobuf::CachedSize,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -355,12 +356,7 @@ impl Disconnect {
             ptr: 0 as *const Disconnect,
         };
         unsafe {
-            instance.get(|| {
-                Disconnect {
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
+            instance.get(Disconnect::new)
         }
     }
 }
@@ -371,11 +367,11 @@ impl ::protobuf::Message for Disconnect {
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
-        while !try!(is.eof()) {
-            let (field_number, wire_type) = try!(is.read_tag_unpack());
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 _ => {
-                    try!(::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields()));
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
                 },
             };
         }
@@ -392,7 +388,7 @@ impl ::protobuf::Message for Disconnect {
     }
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
-        try!(os.write_unknown_fields(self.get_unknown_fields()));
+        os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
 
@@ -408,12 +404,14 @@ impl ::protobuf::Message for Disconnect {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<Disconnect>()
-    }
-
     fn as_any(&self) -> &::std::any::Any {
         self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -450,19 +448,19 @@ impl ::protobuf::Clear for Disconnect {
     }
 }
 
-impl ::std::cmp::PartialEq for Disconnect {
-    fn eq(&self, other: &Disconnect) -> bool {
-        self.unknown_fields == other.unknown_fields
-    }
-}
-
 impl ::std::fmt::Debug for Disconnect {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
-#[derive(Clone,Default)]
+impl ::protobuf::reflect::ProtobufValue for Disconnect {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Message(self)
+    }
+}
+
+#[derive(PartialEq,Clone,Default)]
 pub struct Registration {
     // message fields
     protocol: ::std::option::Option<super::net::Protocol>,
@@ -470,7 +468,7 @@ pub struct Registration {
     shards: ::std::vec::Vec<u32>,
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    cached_size: ::protobuf::CachedSize,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -487,15 +485,7 @@ impl Registration {
             ptr: 0 as *const Registration,
         };
         unsafe {
-            instance.get(|| {
-                Registration {
-                    protocol: ::std::option::Option::None,
-                    endpoint: ::protobuf::SingularField::none(),
-                    shards: ::std::vec::Vec::new(),
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
+            instance.get(Registration::new)
         }
     }
 
@@ -516,6 +506,14 @@ impl Registration {
 
     pub fn get_protocol(&self) -> super::net::Protocol {
         self.protocol.unwrap_or(super::net::Protocol::Net)
+    }
+
+    fn get_protocol_for_reflect(&self) -> &::std::option::Option<super::net::Protocol> {
+        &self.protocol
+    }
+
+    fn mut_protocol_for_reflect(&mut self) -> &mut ::std::option::Option<super::net::Protocol> {
+        &mut self.protocol
     }
 
     // required string endpoint = 2;
@@ -554,6 +552,14 @@ impl Registration {
         }
     }
 
+    fn get_endpoint_for_reflect(&self) -> &::protobuf::SingularField<::std::string::String> {
+        &self.endpoint
+    }
+
+    fn mut_endpoint_for_reflect(&mut self) -> &mut ::protobuf::SingularField<::std::string::String> {
+        &mut self.endpoint
+    }
+
     // repeated uint32 shards = 3;
 
     pub fn clear_shards(&mut self) {
@@ -578,6 +584,14 @@ impl Registration {
     pub fn get_shards(&self) -> &[u32] {
         &self.shards
     }
+
+    fn get_shards_for_reflect(&self) -> &::std::vec::Vec<u32> {
+        &self.shards
+    }
+
+    fn mut_shards_for_reflect(&mut self) -> &mut ::std::vec::Vec<u32> {
+        &mut self.shards
+    }
 }
 
 impl ::protobuf::Message for Registration {
@@ -592,24 +606,24 @@ impl ::protobuf::Message for Registration {
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
-        while !try!(is.eof()) {
-            let (field_number, wire_type) = try!(is.read_tag_unpack());
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
                         return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
                     };
-                    let tmp = try!(is.read_enum());
+                    let tmp = is.read_enum()?;
                     self.protocol = ::std::option::Option::Some(tmp);
                 },
                 2 => {
-                    try!(::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.endpoint));
+                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.endpoint)?;
                 },
                 3 => {
-                    try!(::protobuf::rt::read_repeated_uint32_into(wire_type, is, &mut self.shards));
+                    ::protobuf::rt::read_repeated_uint32_into(wire_type, is, &mut self.shards)?;
                 },
                 _ => {
-                    try!(::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields()));
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
                 },
             };
         }
@@ -620,11 +634,11 @@ impl ::protobuf::Message for Registration {
     #[allow(unused_variables)]
     fn compute_size(&self) -> u32 {
         let mut my_size = 0;
-        for value in &self.protocol {
-            my_size += ::protobuf::rt::enum_size(1, *value);
+        if let Some(v) = self.protocol {
+            my_size += ::protobuf::rt::enum_size(1, v);
         };
-        for value in &self.endpoint {
-            my_size += ::protobuf::rt::string_size(2, &value);
+        if let Some(v) = self.endpoint.as_ref() {
+            my_size += ::protobuf::rt::string_size(2, &v);
         };
         if !self.shards.is_empty() {
             my_size += ::protobuf::rt::vec_packed_varint_size(3, &self.shards);
@@ -636,20 +650,20 @@ impl ::protobuf::Message for Registration {
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.protocol {
-            try!(os.write_enum(1, v.value()));
+            os.write_enum(1, v.value())?;
         };
         if let Some(v) = self.endpoint.as_ref() {
-            try!(os.write_string(2, &v));
+            os.write_string(2, &v)?;
         };
         if !self.shards.is_empty() {
-            try!(os.write_tag(3, ::protobuf::wire_format::WireTypeLengthDelimited));
+            os.write_tag(3, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             // TODO: Data size is computed again, it should be cached
-            try!(os.write_raw_varint32(::protobuf::rt::vec_packed_varint_data_size(&self.shards)));
+            os.write_raw_varint32(::protobuf::rt::vec_packed_varint_data_size(&self.shards))?;
             for v in &self.shards {
-                try!(os.write_uint32_no_tag(*v));
+                os.write_uint32_no_tag(*v)?;
             };
         };
-        try!(os.write_unknown_fields(self.get_unknown_fields()));
+        os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
 
@@ -665,12 +679,14 @@ impl ::protobuf::Message for Registration {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<Registration>()
-    }
-
     fn as_any(&self) -> &::std::any::Any {
         self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -691,19 +707,20 @@ impl ::protobuf::MessageStatic for Registration {
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_enum_accessor(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeEnum<super::net::Protocol>>(
                     "protocol",
-                    Registration::has_protocol,
-                    Registration::get_protocol,
+                    Registration::get_protocol_for_reflect,
+                    Registration::mut_protocol_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_string_accessor(
+                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
                     "endpoint",
-                    Registration::has_endpoint,
-                    Registration::get_endpoint,
+                    Registration::get_endpoint_for_reflect,
+                    Registration::mut_endpoint_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_u32_accessor(
+                fields.push(::protobuf::reflect::accessor::make_vec_accessor::<_, ::protobuf::types::ProtobufTypeUint32>(
                     "shards",
-                    Registration::get_shards,
+                    Registration::get_shards_for_reflect,
+                    Registration::mut_shards_for_reflect,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<Registration>(
                     "Registration",
@@ -724,18 +741,15 @@ impl ::protobuf::Clear for Registration {
     }
 }
 
-impl ::std::cmp::PartialEq for Registration {
-    fn eq(&self, other: &Registration) -> bool {
-        self.protocol == other.protocol &&
-        self.endpoint == other.endpoint &&
-        self.shards == other.shards &&
-        self.unknown_fields == other.unknown_fields
-    }
-}
-
 impl ::std::fmt::Debug for Registration {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
+    }
+}
+
+impl ::protobuf::reflect::ProtobufValue for Registration {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 

--- a/components/builder-protocol/src/message/sessionsrv.rs
+++ b/components/builder-protocol/src/message/sessionsrv.rs
@@ -9,6 +9,7 @@
 
 #![allow(box_pointers)]
 #![allow(dead_code)]
+#![allow(missing_docs)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
@@ -20,7 +21,7 @@
 use protobuf::Message as Message_imported_for_functions;
 use protobuf::ProtobufEnum as ProtobufEnum_imported_for_functions;
 
-#[derive(Clone,Default)]
+#[derive(PartialEq,Clone,Default)]
 pub struct Account {
     // message fields
     id: ::std::option::Option<u64>,
@@ -28,7 +29,7 @@ pub struct Account {
     name: ::protobuf::SingularField<::std::string::String>,
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    cached_size: ::protobuf::CachedSize,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -45,15 +46,7 @@ impl Account {
             ptr: 0 as *const Account,
         };
         unsafe {
-            instance.get(|| {
-                Account {
-                    id: ::std::option::Option::None,
-                    email: ::protobuf::SingularField::none(),
-                    name: ::protobuf::SingularField::none(),
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
+            instance.get(Account::new)
         }
     }
 
@@ -74,6 +67,14 @@ impl Account {
 
     pub fn get_id(&self) -> u64 {
         self.id.unwrap_or(0)
+    }
+
+    fn get_id_for_reflect(&self) -> &::std::option::Option<u64> {
+        &self.id
+    }
+
+    fn mut_id_for_reflect(&mut self) -> &mut ::std::option::Option<u64> {
+        &mut self.id
     }
 
     // required string email = 2;
@@ -112,6 +113,14 @@ impl Account {
         }
     }
 
+    fn get_email_for_reflect(&self) -> &::protobuf::SingularField<::std::string::String> {
+        &self.email
+    }
+
+    fn mut_email_for_reflect(&mut self) -> &mut ::protobuf::SingularField<::std::string::String> {
+        &mut self.email
+    }
+
     // required string name = 3;
 
     pub fn clear_name(&mut self) {
@@ -147,6 +156,14 @@ impl Account {
             None => "",
         }
     }
+
+    fn get_name_for_reflect(&self) -> &::protobuf::SingularField<::std::string::String> {
+        &self.name
+    }
+
+    fn mut_name_for_reflect(&mut self) -> &mut ::protobuf::SingularField<::std::string::String> {
+        &mut self.name
+    }
 }
 
 impl ::protobuf::Message for Account {
@@ -164,24 +181,24 @@ impl ::protobuf::Message for Account {
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
-        while !try!(is.eof()) {
-            let (field_number, wire_type) = try!(is.read_tag_unpack());
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
                         return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
                     };
-                    let tmp = try!(is.read_uint64());
+                    let tmp = is.read_uint64()?;
                     self.id = ::std::option::Option::Some(tmp);
                 },
                 2 => {
-                    try!(::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.email));
+                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.email)?;
                 },
                 3 => {
-                    try!(::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.name));
+                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.name)?;
                 },
                 _ => {
-                    try!(::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields()));
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
                 },
             };
         }
@@ -192,14 +209,14 @@ impl ::protobuf::Message for Account {
     #[allow(unused_variables)]
     fn compute_size(&self) -> u32 {
         let mut my_size = 0;
-        for value in &self.id {
-            my_size += ::protobuf::rt::value_size(1, *value, ::protobuf::wire_format::WireTypeVarint);
+        if let Some(v) = self.id {
+            my_size += ::protobuf::rt::value_size(1, v, ::protobuf::wire_format::WireTypeVarint);
         };
-        for value in &self.email {
-            my_size += ::protobuf::rt::string_size(2, &value);
+        if let Some(v) = self.email.as_ref() {
+            my_size += ::protobuf::rt::string_size(2, &v);
         };
-        for value in &self.name {
-            my_size += ::protobuf::rt::string_size(3, &value);
+        if let Some(v) = self.name.as_ref() {
+            my_size += ::protobuf::rt::string_size(3, &v);
         };
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
         self.cached_size.set(my_size);
@@ -208,15 +225,15 @@ impl ::protobuf::Message for Account {
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.id {
-            try!(os.write_uint64(1, v));
+            os.write_uint64(1, v)?;
         };
         if let Some(v) = self.email.as_ref() {
-            try!(os.write_string(2, &v));
+            os.write_string(2, &v)?;
         };
         if let Some(v) = self.name.as_ref() {
-            try!(os.write_string(3, &v));
+            os.write_string(3, &v)?;
         };
-        try!(os.write_unknown_fields(self.get_unknown_fields()));
+        os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
 
@@ -232,12 +249,14 @@ impl ::protobuf::Message for Account {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<Account>()
-    }
-
     fn as_any(&self) -> &::std::any::Any {
         self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -258,20 +277,20 @@ impl ::protobuf::MessageStatic for Account {
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_u64_accessor(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint64>(
                     "id",
-                    Account::has_id,
-                    Account::get_id,
+                    Account::get_id_for_reflect,
+                    Account::mut_id_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_string_accessor(
+                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
                     "email",
-                    Account::has_email,
-                    Account::get_email,
+                    Account::get_email_for_reflect,
+                    Account::mut_email_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_string_accessor(
+                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
                     "name",
-                    Account::has_name,
-                    Account::get_name,
+                    Account::get_name_for_reflect,
+                    Account::mut_name_for_reflect,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<Account>(
                     "Account",
@@ -292,28 +311,25 @@ impl ::protobuf::Clear for Account {
     }
 }
 
-impl ::std::cmp::PartialEq for Account {
-    fn eq(&self, other: &Account) -> bool {
-        self.id == other.id &&
-        self.email == other.email &&
-        self.name == other.name &&
-        self.unknown_fields == other.unknown_fields
-    }
-}
-
 impl ::std::fmt::Debug for Account {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
-#[derive(Clone,Default)]
+impl ::protobuf::reflect::ProtobufValue for Account {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Message(self)
+    }
+}
+
+#[derive(PartialEq,Clone,Default)]
 pub struct AccountGet {
     // message fields
     name: ::protobuf::SingularField<::std::string::String>,
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    cached_size: ::protobuf::CachedSize,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -330,13 +346,7 @@ impl AccountGet {
             ptr: 0 as *const AccountGet,
         };
         unsafe {
-            instance.get(|| {
-                AccountGet {
-                    name: ::protobuf::SingularField::none(),
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
+            instance.get(AccountGet::new)
         }
     }
 
@@ -375,6 +385,14 @@ impl AccountGet {
             None => "",
         }
     }
+
+    fn get_name_for_reflect(&self) -> &::protobuf::SingularField<::std::string::String> {
+        &self.name
+    }
+
+    fn mut_name_for_reflect(&mut self) -> &mut ::protobuf::SingularField<::std::string::String> {
+        &mut self.name
+    }
 }
 
 impl ::protobuf::Message for AccountGet {
@@ -386,14 +404,14 @@ impl ::protobuf::Message for AccountGet {
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
-        while !try!(is.eof()) {
-            let (field_number, wire_type) = try!(is.read_tag_unpack());
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
-                    try!(::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.name));
+                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.name)?;
                 },
                 _ => {
-                    try!(::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields()));
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
                 },
             };
         }
@@ -404,8 +422,8 @@ impl ::protobuf::Message for AccountGet {
     #[allow(unused_variables)]
     fn compute_size(&self) -> u32 {
         let mut my_size = 0;
-        for value in &self.name {
-            my_size += ::protobuf::rt::string_size(1, &value);
+        if let Some(v) = self.name.as_ref() {
+            my_size += ::protobuf::rt::string_size(1, &v);
         };
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
         self.cached_size.set(my_size);
@@ -414,9 +432,9 @@ impl ::protobuf::Message for AccountGet {
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.name.as_ref() {
-            try!(os.write_string(1, &v));
+            os.write_string(1, &v)?;
         };
-        try!(os.write_unknown_fields(self.get_unknown_fields()));
+        os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
 
@@ -432,12 +450,14 @@ impl ::protobuf::Message for AccountGet {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<AccountGet>()
-    }
-
     fn as_any(&self) -> &::std::any::Any {
         self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -458,10 +478,10 @@ impl ::protobuf::MessageStatic for AccountGet {
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_string_accessor(
+                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
                     "name",
-                    AccountGet::has_name,
-                    AccountGet::get_name,
+                    AccountGet::get_name_for_reflect,
+                    AccountGet::mut_name_for_reflect,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<AccountGet>(
                     "AccountGet",
@@ -480,27 +500,26 @@ impl ::protobuf::Clear for AccountGet {
     }
 }
 
-impl ::std::cmp::PartialEq for AccountGet {
-    fn eq(&self, other: &AccountGet) -> bool {
-        self.name == other.name &&
-        self.unknown_fields == other.unknown_fields
-    }
-}
-
 impl ::std::fmt::Debug for AccountGet {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
-#[derive(Clone,Default)]
+impl ::protobuf::reflect::ProtobufValue for AccountGet {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Message(self)
+    }
+}
+
+#[derive(PartialEq,Clone,Default)]
 pub struct AccountSearch {
     // message fields
     key: ::std::option::Option<AccountSearchKey>,
     value: ::protobuf::SingularField<::std::string::String>,
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    cached_size: ::protobuf::CachedSize,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -517,14 +536,7 @@ impl AccountSearch {
             ptr: 0 as *const AccountSearch,
         };
         unsafe {
-            instance.get(|| {
-                AccountSearch {
-                    key: ::std::option::Option::None,
-                    value: ::protobuf::SingularField::none(),
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
+            instance.get(AccountSearch::new)
         }
     }
 
@@ -545,6 +557,14 @@ impl AccountSearch {
 
     pub fn get_key(&self) -> AccountSearchKey {
         self.key.unwrap_or(AccountSearchKey::Id)
+    }
+
+    fn get_key_for_reflect(&self) -> &::std::option::Option<AccountSearchKey> {
+        &self.key
+    }
+
+    fn mut_key_for_reflect(&mut self) -> &mut ::std::option::Option<AccountSearchKey> {
+        &mut self.key
     }
 
     // required string value = 2;
@@ -582,6 +602,14 @@ impl AccountSearch {
             None => "",
         }
     }
+
+    fn get_value_for_reflect(&self) -> &::protobuf::SingularField<::std::string::String> {
+        &self.value
+    }
+
+    fn mut_value_for_reflect(&mut self) -> &mut ::protobuf::SingularField<::std::string::String> {
+        &mut self.value
+    }
 }
 
 impl ::protobuf::Message for AccountSearch {
@@ -596,21 +624,21 @@ impl ::protobuf::Message for AccountSearch {
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
-        while !try!(is.eof()) {
-            let (field_number, wire_type) = try!(is.read_tag_unpack());
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
                         return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
                     };
-                    let tmp = try!(is.read_enum());
+                    let tmp = is.read_enum()?;
                     self.key = ::std::option::Option::Some(tmp);
                 },
                 2 => {
-                    try!(::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.value));
+                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.value)?;
                 },
                 _ => {
-                    try!(::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields()));
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
                 },
             };
         }
@@ -621,11 +649,11 @@ impl ::protobuf::Message for AccountSearch {
     #[allow(unused_variables)]
     fn compute_size(&self) -> u32 {
         let mut my_size = 0;
-        for value in &self.key {
-            my_size += ::protobuf::rt::enum_size(1, *value);
+        if let Some(v) = self.key {
+            my_size += ::protobuf::rt::enum_size(1, v);
         };
-        for value in &self.value {
-            my_size += ::protobuf::rt::string_size(2, &value);
+        if let Some(v) = self.value.as_ref() {
+            my_size += ::protobuf::rt::string_size(2, &v);
         };
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
         self.cached_size.set(my_size);
@@ -634,12 +662,12 @@ impl ::protobuf::Message for AccountSearch {
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.key {
-            try!(os.write_enum(1, v.value()));
+            os.write_enum(1, v.value())?;
         };
         if let Some(v) = self.value.as_ref() {
-            try!(os.write_string(2, &v));
+            os.write_string(2, &v)?;
         };
-        try!(os.write_unknown_fields(self.get_unknown_fields()));
+        os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
 
@@ -655,12 +683,14 @@ impl ::protobuf::Message for AccountSearch {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<AccountSearch>()
-    }
-
     fn as_any(&self) -> &::std::any::Any {
         self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -681,15 +711,15 @@ impl ::protobuf::MessageStatic for AccountSearch {
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_enum_accessor(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeEnum<AccountSearchKey>>(
                     "key",
-                    AccountSearch::has_key,
-                    AccountSearch::get_key,
+                    AccountSearch::get_key_for_reflect,
+                    AccountSearch::mut_key_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_string_accessor(
+                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
                     "value",
-                    AccountSearch::has_value,
-                    AccountSearch::get_value,
+                    AccountSearch::get_value_for_reflect,
+                    AccountSearch::mut_value_for_reflect,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<AccountSearch>(
                     "AccountSearch",
@@ -709,28 +739,26 @@ impl ::protobuf::Clear for AccountSearch {
     }
 }
 
-impl ::std::cmp::PartialEq for AccountSearch {
-    fn eq(&self, other: &AccountSearch) -> bool {
-        self.key == other.key &&
-        self.value == other.value &&
-        self.unknown_fields == other.unknown_fields
-    }
-}
-
 impl ::std::fmt::Debug for AccountSearch {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
-#[derive(Clone,Default)]
+impl ::protobuf::reflect::ProtobufValue for AccountSearch {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Message(self)
+    }
+}
+
+#[derive(PartialEq,Clone,Default)]
 pub struct GrantFlagToTeam {
     // message fields
     flag: ::std::option::Option<u32>,
     team_id: ::std::option::Option<u64>,
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    cached_size: ::protobuf::CachedSize,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -747,14 +775,7 @@ impl GrantFlagToTeam {
             ptr: 0 as *const GrantFlagToTeam,
         };
         unsafe {
-            instance.get(|| {
-                GrantFlagToTeam {
-                    flag: ::std::option::Option::None,
-                    team_id: ::std::option::Option::None,
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
+            instance.get(GrantFlagToTeam::new)
         }
     }
 
@@ -777,6 +798,14 @@ impl GrantFlagToTeam {
         self.flag.unwrap_or(0)
     }
 
+    fn get_flag_for_reflect(&self) -> &::std::option::Option<u32> {
+        &self.flag
+    }
+
+    fn mut_flag_for_reflect(&mut self) -> &mut ::std::option::Option<u32> {
+        &mut self.flag
+    }
+
     // required uint64 team_id = 2;
 
     pub fn clear_team_id(&mut self) {
@@ -795,6 +824,14 @@ impl GrantFlagToTeam {
     pub fn get_team_id(&self) -> u64 {
         self.team_id.unwrap_or(0)
     }
+
+    fn get_team_id_for_reflect(&self) -> &::std::option::Option<u64> {
+        &self.team_id
+    }
+
+    fn mut_team_id_for_reflect(&mut self) -> &mut ::std::option::Option<u64> {
+        &mut self.team_id
+    }
 }
 
 impl ::protobuf::Message for GrantFlagToTeam {
@@ -809,25 +846,25 @@ impl ::protobuf::Message for GrantFlagToTeam {
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
-        while !try!(is.eof()) {
-            let (field_number, wire_type) = try!(is.read_tag_unpack());
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
                         return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
                     };
-                    let tmp = try!(is.read_uint32());
+                    let tmp = is.read_uint32()?;
                     self.flag = ::std::option::Option::Some(tmp);
                 },
                 2 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
                         return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
                     };
-                    let tmp = try!(is.read_uint64());
+                    let tmp = is.read_uint64()?;
                     self.team_id = ::std::option::Option::Some(tmp);
                 },
                 _ => {
-                    try!(::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields()));
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
                 },
             };
         }
@@ -838,11 +875,11 @@ impl ::protobuf::Message for GrantFlagToTeam {
     #[allow(unused_variables)]
     fn compute_size(&self) -> u32 {
         let mut my_size = 0;
-        for value in &self.flag {
-            my_size += ::protobuf::rt::value_size(1, *value, ::protobuf::wire_format::WireTypeVarint);
+        if let Some(v) = self.flag {
+            my_size += ::protobuf::rt::value_size(1, v, ::protobuf::wire_format::WireTypeVarint);
         };
-        for value in &self.team_id {
-            my_size += ::protobuf::rt::value_size(2, *value, ::protobuf::wire_format::WireTypeVarint);
+        if let Some(v) = self.team_id {
+            my_size += ::protobuf::rt::value_size(2, v, ::protobuf::wire_format::WireTypeVarint);
         };
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
         self.cached_size.set(my_size);
@@ -851,12 +888,12 @@ impl ::protobuf::Message for GrantFlagToTeam {
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.flag {
-            try!(os.write_uint32(1, v));
+            os.write_uint32(1, v)?;
         };
         if let Some(v) = self.team_id {
-            try!(os.write_uint64(2, v));
+            os.write_uint64(2, v)?;
         };
-        try!(os.write_unknown_fields(self.get_unknown_fields()));
+        os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
 
@@ -872,12 +909,14 @@ impl ::protobuf::Message for GrantFlagToTeam {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<GrantFlagToTeam>()
-    }
-
     fn as_any(&self) -> &::std::any::Any {
         self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -898,15 +937,15 @@ impl ::protobuf::MessageStatic for GrantFlagToTeam {
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_u32_accessor(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint32>(
                     "flag",
-                    GrantFlagToTeam::has_flag,
-                    GrantFlagToTeam::get_flag,
+                    GrantFlagToTeam::get_flag_for_reflect,
+                    GrantFlagToTeam::mut_flag_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_u64_accessor(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint64>(
                     "team_id",
-                    GrantFlagToTeam::has_team_id,
-                    GrantFlagToTeam::get_team_id,
+                    GrantFlagToTeam::get_team_id_for_reflect,
+                    GrantFlagToTeam::mut_team_id_for_reflect,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<GrantFlagToTeam>(
                     "GrantFlagToTeam",
@@ -926,28 +965,26 @@ impl ::protobuf::Clear for GrantFlagToTeam {
     }
 }
 
-impl ::std::cmp::PartialEq for GrantFlagToTeam {
-    fn eq(&self, other: &GrantFlagToTeam) -> bool {
-        self.flag == other.flag &&
-        self.team_id == other.team_id &&
-        self.unknown_fields == other.unknown_fields
-    }
-}
-
 impl ::std::fmt::Debug for GrantFlagToTeam {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
-#[derive(Clone,Default)]
+impl ::protobuf::reflect::ProtobufValue for GrantFlagToTeam {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Message(self)
+    }
+}
+
+#[derive(PartialEq,Clone,Default)]
 pub struct RevokeFlagFromTeam {
     // message fields
     flag: ::std::option::Option<u32>,
     team_id: ::std::option::Option<u64>,
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    cached_size: ::protobuf::CachedSize,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -964,14 +1001,7 @@ impl RevokeFlagFromTeam {
             ptr: 0 as *const RevokeFlagFromTeam,
         };
         unsafe {
-            instance.get(|| {
-                RevokeFlagFromTeam {
-                    flag: ::std::option::Option::None,
-                    team_id: ::std::option::Option::None,
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
+            instance.get(RevokeFlagFromTeam::new)
         }
     }
 
@@ -992,6 +1022,14 @@ impl RevokeFlagFromTeam {
 
     pub fn get_flag(&self) -> u32 {
         self.flag.unwrap_or(0)
+    }
+
+    fn get_flag_for_reflect(&self) -> &::std::option::Option<u32> {
+        &self.flag
+    }
+
+    fn mut_flag_for_reflect(&mut self) -> &mut ::std::option::Option<u32> {
+        &mut self.flag
     }
 
     // required uint64 team_id = 2;
@@ -1012,6 +1050,14 @@ impl RevokeFlagFromTeam {
     pub fn get_team_id(&self) -> u64 {
         self.team_id.unwrap_or(0)
     }
+
+    fn get_team_id_for_reflect(&self) -> &::std::option::Option<u64> {
+        &self.team_id
+    }
+
+    fn mut_team_id_for_reflect(&mut self) -> &mut ::std::option::Option<u64> {
+        &mut self.team_id
+    }
 }
 
 impl ::protobuf::Message for RevokeFlagFromTeam {
@@ -1026,25 +1072,25 @@ impl ::protobuf::Message for RevokeFlagFromTeam {
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
-        while !try!(is.eof()) {
-            let (field_number, wire_type) = try!(is.read_tag_unpack());
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
                         return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
                     };
-                    let tmp = try!(is.read_uint32());
+                    let tmp = is.read_uint32()?;
                     self.flag = ::std::option::Option::Some(tmp);
                 },
                 2 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
                         return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
                     };
-                    let tmp = try!(is.read_uint64());
+                    let tmp = is.read_uint64()?;
                     self.team_id = ::std::option::Option::Some(tmp);
                 },
                 _ => {
-                    try!(::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields()));
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
                 },
             };
         }
@@ -1055,11 +1101,11 @@ impl ::protobuf::Message for RevokeFlagFromTeam {
     #[allow(unused_variables)]
     fn compute_size(&self) -> u32 {
         let mut my_size = 0;
-        for value in &self.flag {
-            my_size += ::protobuf::rt::value_size(1, *value, ::protobuf::wire_format::WireTypeVarint);
+        if let Some(v) = self.flag {
+            my_size += ::protobuf::rt::value_size(1, v, ::protobuf::wire_format::WireTypeVarint);
         };
-        for value in &self.team_id {
-            my_size += ::protobuf::rt::value_size(2, *value, ::protobuf::wire_format::WireTypeVarint);
+        if let Some(v) = self.team_id {
+            my_size += ::protobuf::rt::value_size(2, v, ::protobuf::wire_format::WireTypeVarint);
         };
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
         self.cached_size.set(my_size);
@@ -1068,12 +1114,12 @@ impl ::protobuf::Message for RevokeFlagFromTeam {
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.flag {
-            try!(os.write_uint32(1, v));
+            os.write_uint32(1, v)?;
         };
         if let Some(v) = self.team_id {
-            try!(os.write_uint64(2, v));
+            os.write_uint64(2, v)?;
         };
-        try!(os.write_unknown_fields(self.get_unknown_fields()));
+        os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
 
@@ -1089,12 +1135,14 @@ impl ::protobuf::Message for RevokeFlagFromTeam {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<RevokeFlagFromTeam>()
-    }
-
     fn as_any(&self) -> &::std::any::Any {
         self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -1115,15 +1163,15 @@ impl ::protobuf::MessageStatic for RevokeFlagFromTeam {
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_u32_accessor(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint32>(
                     "flag",
-                    RevokeFlagFromTeam::has_flag,
-                    RevokeFlagFromTeam::get_flag,
+                    RevokeFlagFromTeam::get_flag_for_reflect,
+                    RevokeFlagFromTeam::mut_flag_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_u64_accessor(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint64>(
                     "team_id",
-                    RevokeFlagFromTeam::has_team_id,
-                    RevokeFlagFromTeam::get_team_id,
+                    RevokeFlagFromTeam::get_team_id_for_reflect,
+                    RevokeFlagFromTeam::mut_team_id_for_reflect,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<RevokeFlagFromTeam>(
                     "RevokeFlagFromTeam",
@@ -1143,27 +1191,25 @@ impl ::protobuf::Clear for RevokeFlagFromTeam {
     }
 }
 
-impl ::std::cmp::PartialEq for RevokeFlagFromTeam {
-    fn eq(&self, other: &RevokeFlagFromTeam) -> bool {
-        self.flag == other.flag &&
-        self.team_id == other.team_id &&
-        self.unknown_fields == other.unknown_fields
-    }
-}
-
 impl ::std::fmt::Debug for RevokeFlagFromTeam {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
-#[derive(Clone,Default)]
+impl ::protobuf::reflect::ProtobufValue for RevokeFlagFromTeam {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Message(self)
+    }
+}
+
+#[derive(PartialEq,Clone,Default)]
 pub struct ListFlagGrants {
     // message fields
     flag: ::std::option::Option<u32>,
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    cached_size: ::protobuf::CachedSize,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -1180,13 +1226,7 @@ impl ListFlagGrants {
             ptr: 0 as *const ListFlagGrants,
         };
         unsafe {
-            instance.get(|| {
-                ListFlagGrants {
-                    flag: ::std::option::Option::None,
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
+            instance.get(ListFlagGrants::new)
         }
     }
 
@@ -1208,6 +1248,14 @@ impl ListFlagGrants {
     pub fn get_flag(&self) -> u32 {
         self.flag.unwrap_or(0)
     }
+
+    fn get_flag_for_reflect(&self) -> &::std::option::Option<u32> {
+        &self.flag
+    }
+
+    fn mut_flag_for_reflect(&mut self) -> &mut ::std::option::Option<u32> {
+        &mut self.flag
+    }
 }
 
 impl ::protobuf::Message for ListFlagGrants {
@@ -1219,18 +1267,18 @@ impl ::protobuf::Message for ListFlagGrants {
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
-        while !try!(is.eof()) {
-            let (field_number, wire_type) = try!(is.read_tag_unpack());
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
                         return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
                     };
-                    let tmp = try!(is.read_uint32());
+                    let tmp = is.read_uint32()?;
                     self.flag = ::std::option::Option::Some(tmp);
                 },
                 _ => {
-                    try!(::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields()));
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
                 },
             };
         }
@@ -1241,8 +1289,8 @@ impl ::protobuf::Message for ListFlagGrants {
     #[allow(unused_variables)]
     fn compute_size(&self) -> u32 {
         let mut my_size = 0;
-        for value in &self.flag {
-            my_size += ::protobuf::rt::value_size(1, *value, ::protobuf::wire_format::WireTypeVarint);
+        if let Some(v) = self.flag {
+            my_size += ::protobuf::rt::value_size(1, v, ::protobuf::wire_format::WireTypeVarint);
         };
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
         self.cached_size.set(my_size);
@@ -1251,9 +1299,9 @@ impl ::protobuf::Message for ListFlagGrants {
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.flag {
-            try!(os.write_uint32(1, v));
+            os.write_uint32(1, v)?;
         };
-        try!(os.write_unknown_fields(self.get_unknown_fields()));
+        os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
 
@@ -1269,12 +1317,14 @@ impl ::protobuf::Message for ListFlagGrants {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<ListFlagGrants>()
-    }
-
     fn as_any(&self) -> &::std::any::Any {
         self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -1295,10 +1345,10 @@ impl ::protobuf::MessageStatic for ListFlagGrants {
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_u32_accessor(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint32>(
                     "flag",
-                    ListFlagGrants::has_flag,
-                    ListFlagGrants::get_flag,
+                    ListFlagGrants::get_flag_for_reflect,
+                    ListFlagGrants::mut_flag_for_reflect,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<ListFlagGrants>(
                     "ListFlagGrants",
@@ -1317,26 +1367,25 @@ impl ::protobuf::Clear for ListFlagGrants {
     }
 }
 
-impl ::std::cmp::PartialEq for ListFlagGrants {
-    fn eq(&self, other: &ListFlagGrants) -> bool {
-        self.flag == other.flag &&
-        self.unknown_fields == other.unknown_fields
-    }
-}
-
 impl ::std::fmt::Debug for ListFlagGrants {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
-#[derive(Clone,Default)]
+impl ::protobuf::reflect::ProtobufValue for ListFlagGrants {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Message(self)
+    }
+}
+
+#[derive(PartialEq,Clone,Default)]
 pub struct FlagGrants {
     // message fields
     teams: ::std::vec::Vec<u64>,
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    cached_size: ::protobuf::CachedSize,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -1353,13 +1402,7 @@ impl FlagGrants {
             ptr: 0 as *const FlagGrants,
         };
         unsafe {
-            instance.get(|| {
-                FlagGrants {
-                    teams: ::std::vec::Vec::new(),
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
+            instance.get(FlagGrants::new)
         }
     }
 
@@ -1387,6 +1430,14 @@ impl FlagGrants {
     pub fn get_teams(&self) -> &[u64] {
         &self.teams
     }
+
+    fn get_teams_for_reflect(&self) -> &::std::vec::Vec<u64> {
+        &self.teams
+    }
+
+    fn mut_teams_for_reflect(&mut self) -> &mut ::std::vec::Vec<u64> {
+        &mut self.teams
+    }
 }
 
 impl ::protobuf::Message for FlagGrants {
@@ -1395,14 +1446,14 @@ impl ::protobuf::Message for FlagGrants {
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
-        while !try!(is.eof()) {
-            let (field_number, wire_type) = try!(is.read_tag_unpack());
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
-                    try!(::protobuf::rt::read_repeated_uint64_into(wire_type, is, &mut self.teams));
+                    ::protobuf::rt::read_repeated_uint64_into(wire_type, is, &mut self.teams)?;
                 },
                 _ => {
-                    try!(::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields()));
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
                 },
             };
         }
@@ -1423,9 +1474,9 @@ impl ::protobuf::Message for FlagGrants {
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
         for v in &self.teams {
-            try!(os.write_uint64(1, *v));
+            os.write_uint64(1, *v)?;
         };
-        try!(os.write_unknown_fields(self.get_unknown_fields()));
+        os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
 
@@ -1441,12 +1492,14 @@ impl ::protobuf::Message for FlagGrants {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<FlagGrants>()
-    }
-
     fn as_any(&self) -> &::std::any::Any {
         self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -1467,9 +1520,10 @@ impl ::protobuf::MessageStatic for FlagGrants {
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_repeated_u64_accessor(
+                fields.push(::protobuf::reflect::accessor::make_vec_accessor::<_, ::protobuf::types::ProtobufTypeUint64>(
                     "teams",
-                    FlagGrants::get_teams,
+                    FlagGrants::get_teams_for_reflect,
+                    FlagGrants::mut_teams_for_reflect,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<FlagGrants>(
                     "FlagGrants",
@@ -1488,20 +1542,19 @@ impl ::protobuf::Clear for FlagGrants {
     }
 }
 
-impl ::std::cmp::PartialEq for FlagGrants {
-    fn eq(&self, other: &FlagGrants) -> bool {
-        self.teams == other.teams &&
-        self.unknown_fields == other.unknown_fields
-    }
-}
-
 impl ::std::fmt::Debug for FlagGrants {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
-#[derive(Clone,Default)]
+impl ::protobuf::reflect::ProtobufValue for FlagGrants {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Message(self)
+    }
+}
+
+#[derive(PartialEq,Clone,Default)]
 pub struct Session {
     // message fields
     id: ::std::option::Option<u64>,
@@ -1511,7 +1564,7 @@ pub struct Session {
     flags: ::std::option::Option<u32>,
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    cached_size: ::protobuf::CachedSize,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -1528,17 +1581,7 @@ impl Session {
             ptr: 0 as *const Session,
         };
         unsafe {
-            instance.get(|| {
-                Session {
-                    id: ::std::option::Option::None,
-                    email: ::protobuf::SingularField::none(),
-                    name: ::protobuf::SingularField::none(),
-                    token: ::protobuf::SingularField::none(),
-                    flags: ::std::option::Option::None,
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
+            instance.get(Session::new)
         }
     }
 
@@ -1559,6 +1602,14 @@ impl Session {
 
     pub fn get_id(&self) -> u64 {
         self.id.unwrap_or(0)
+    }
+
+    fn get_id_for_reflect(&self) -> &::std::option::Option<u64> {
+        &self.id
+    }
+
+    fn mut_id_for_reflect(&mut self) -> &mut ::std::option::Option<u64> {
+        &mut self.id
     }
 
     // required string email = 2;
@@ -1597,6 +1648,14 @@ impl Session {
         }
     }
 
+    fn get_email_for_reflect(&self) -> &::protobuf::SingularField<::std::string::String> {
+        &self.email
+    }
+
+    fn mut_email_for_reflect(&mut self) -> &mut ::protobuf::SingularField<::std::string::String> {
+        &mut self.email
+    }
+
     // required string name = 3;
 
     pub fn clear_name(&mut self) {
@@ -1631,6 +1690,14 @@ impl Session {
             Some(v) => &v,
             None => "",
         }
+    }
+
+    fn get_name_for_reflect(&self) -> &::protobuf::SingularField<::std::string::String> {
+        &self.name
+    }
+
+    fn mut_name_for_reflect(&mut self) -> &mut ::protobuf::SingularField<::std::string::String> {
+        &mut self.name
     }
 
     // required string token = 4;
@@ -1669,6 +1736,14 @@ impl Session {
         }
     }
 
+    fn get_token_for_reflect(&self) -> &::protobuf::SingularField<::std::string::String> {
+        &self.token
+    }
+
+    fn mut_token_for_reflect(&mut self) -> &mut ::protobuf::SingularField<::std::string::String> {
+        &mut self.token
+    }
+
     // required uint32 flags = 5;
 
     pub fn clear_flags(&mut self) {
@@ -1686,6 +1761,14 @@ impl Session {
 
     pub fn get_flags(&self) -> u32 {
         self.flags.unwrap_or(0)
+    }
+
+    fn get_flags_for_reflect(&self) -> &::std::option::Option<u32> {
+        &self.flags
+    }
+
+    fn mut_flags_for_reflect(&mut self) -> &mut ::std::option::Option<u32> {
+        &mut self.flags
     }
 }
 
@@ -1710,34 +1793,34 @@ impl ::protobuf::Message for Session {
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
-        while !try!(is.eof()) {
-            let (field_number, wire_type) = try!(is.read_tag_unpack());
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
                         return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
                     };
-                    let tmp = try!(is.read_uint64());
+                    let tmp = is.read_uint64()?;
                     self.id = ::std::option::Option::Some(tmp);
                 },
                 2 => {
-                    try!(::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.email));
+                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.email)?;
                 },
                 3 => {
-                    try!(::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.name));
+                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.name)?;
                 },
                 4 => {
-                    try!(::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.token));
+                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.token)?;
                 },
                 5 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
                         return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
                     };
-                    let tmp = try!(is.read_uint32());
+                    let tmp = is.read_uint32()?;
                     self.flags = ::std::option::Option::Some(tmp);
                 },
                 _ => {
-                    try!(::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields()));
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
                 },
             };
         }
@@ -1748,20 +1831,20 @@ impl ::protobuf::Message for Session {
     #[allow(unused_variables)]
     fn compute_size(&self) -> u32 {
         let mut my_size = 0;
-        for value in &self.id {
-            my_size += ::protobuf::rt::value_size(1, *value, ::protobuf::wire_format::WireTypeVarint);
+        if let Some(v) = self.id {
+            my_size += ::protobuf::rt::value_size(1, v, ::protobuf::wire_format::WireTypeVarint);
         };
-        for value in &self.email {
-            my_size += ::protobuf::rt::string_size(2, &value);
+        if let Some(v) = self.email.as_ref() {
+            my_size += ::protobuf::rt::string_size(2, &v);
         };
-        for value in &self.name {
-            my_size += ::protobuf::rt::string_size(3, &value);
+        if let Some(v) = self.name.as_ref() {
+            my_size += ::protobuf::rt::string_size(3, &v);
         };
-        for value in &self.token {
-            my_size += ::protobuf::rt::string_size(4, &value);
+        if let Some(v) = self.token.as_ref() {
+            my_size += ::protobuf::rt::string_size(4, &v);
         };
-        for value in &self.flags {
-            my_size += ::protobuf::rt::value_size(5, *value, ::protobuf::wire_format::WireTypeVarint);
+        if let Some(v) = self.flags {
+            my_size += ::protobuf::rt::value_size(5, v, ::protobuf::wire_format::WireTypeVarint);
         };
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
         self.cached_size.set(my_size);
@@ -1770,21 +1853,21 @@ impl ::protobuf::Message for Session {
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.id {
-            try!(os.write_uint64(1, v));
+            os.write_uint64(1, v)?;
         };
         if let Some(v) = self.email.as_ref() {
-            try!(os.write_string(2, &v));
+            os.write_string(2, &v)?;
         };
         if let Some(v) = self.name.as_ref() {
-            try!(os.write_string(3, &v));
+            os.write_string(3, &v)?;
         };
         if let Some(v) = self.token.as_ref() {
-            try!(os.write_string(4, &v));
+            os.write_string(4, &v)?;
         };
         if let Some(v) = self.flags {
-            try!(os.write_uint32(5, v));
+            os.write_uint32(5, v)?;
         };
-        try!(os.write_unknown_fields(self.get_unknown_fields()));
+        os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
 
@@ -1800,12 +1883,14 @@ impl ::protobuf::Message for Session {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<Session>()
-    }
-
     fn as_any(&self) -> &::std::any::Any {
         self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -1826,30 +1911,30 @@ impl ::protobuf::MessageStatic for Session {
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_u64_accessor(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint64>(
                     "id",
-                    Session::has_id,
-                    Session::get_id,
+                    Session::get_id_for_reflect,
+                    Session::mut_id_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_string_accessor(
+                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
                     "email",
-                    Session::has_email,
-                    Session::get_email,
+                    Session::get_email_for_reflect,
+                    Session::mut_email_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_string_accessor(
+                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
                     "name",
-                    Session::has_name,
-                    Session::get_name,
+                    Session::get_name_for_reflect,
+                    Session::mut_name_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_string_accessor(
+                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
                     "token",
-                    Session::has_token,
-                    Session::get_token,
+                    Session::get_token_for_reflect,
+                    Session::mut_token_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_u32_accessor(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint32>(
                     "flags",
-                    Session::has_flags,
-                    Session::get_flags,
+                    Session::get_flags_for_reflect,
+                    Session::mut_flags_for_reflect,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<Session>(
                     "Session",
@@ -1872,24 +1957,19 @@ impl ::protobuf::Clear for Session {
     }
 }
 
-impl ::std::cmp::PartialEq for Session {
-    fn eq(&self, other: &Session) -> bool {
-        self.id == other.id &&
-        self.email == other.email &&
-        self.name == other.name &&
-        self.token == other.token &&
-        self.flags == other.flags &&
-        self.unknown_fields == other.unknown_fields
-    }
-}
-
 impl ::std::fmt::Debug for Session {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
-#[derive(Clone,Default)]
+impl ::protobuf::reflect::ProtobufValue for Session {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Message(self)
+    }
+}
+
+#[derive(PartialEq,Clone,Default)]
 pub struct SessionToken {
     // message fields
     token: ::protobuf::SingularField<::std::string::String>,
@@ -1897,7 +1977,7 @@ pub struct SessionToken {
     provider: ::std::option::Option<OAuthProvider>,
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    cached_size: ::protobuf::CachedSize,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -1914,15 +1994,7 @@ impl SessionToken {
             ptr: 0 as *const SessionToken,
         };
         unsafe {
-            instance.get(|| {
-                SessionToken {
-                    token: ::protobuf::SingularField::none(),
-                    owner_id: ::std::option::Option::None,
-                    provider: ::std::option::Option::None,
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
+            instance.get(SessionToken::new)
         }
     }
 
@@ -1960,6 +2032,14 @@ impl SessionToken {
             Some(v) => &v,
             None => "",
         }
+    }
+
+    fn get_token_for_reflect(&self) -> &::protobuf::SingularField<::std::string::String> {
+        &self.token
+    }
+
+    fn mut_token_for_reflect(&mut self) -> &mut ::protobuf::SingularField<::std::string::String> {
+        &mut self.token
     }
 
     // required uint64 owner_id = 2;
@@ -1981,6 +2061,14 @@ impl SessionToken {
         self.owner_id.unwrap_or(0)
     }
 
+    fn get_owner_id_for_reflect(&self) -> &::std::option::Option<u64> {
+        &self.owner_id
+    }
+
+    fn mut_owner_id_for_reflect(&mut self) -> &mut ::std::option::Option<u64> {
+        &mut self.owner_id
+    }
+
     // required .sessionsrv.OAuthProvider provider = 3;
 
     pub fn clear_provider(&mut self) {
@@ -1999,6 +2087,14 @@ impl SessionToken {
     pub fn get_provider(&self) -> OAuthProvider {
         self.provider.unwrap_or(OAuthProvider::GitHub)
     }
+
+    fn get_provider_for_reflect(&self) -> &::std::option::Option<OAuthProvider> {
+        &self.provider
+    }
+
+    fn mut_provider_for_reflect(&mut self) -> &mut ::std::option::Option<OAuthProvider> {
+        &mut self.provider
+    }
 }
 
 impl ::protobuf::Message for SessionToken {
@@ -2016,28 +2112,28 @@ impl ::protobuf::Message for SessionToken {
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
-        while !try!(is.eof()) {
-            let (field_number, wire_type) = try!(is.read_tag_unpack());
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
-                    try!(::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.token));
+                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.token)?;
                 },
                 2 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
                         return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
                     };
-                    let tmp = try!(is.read_uint64());
+                    let tmp = is.read_uint64()?;
                     self.owner_id = ::std::option::Option::Some(tmp);
                 },
                 3 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
                         return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
                     };
-                    let tmp = try!(is.read_enum());
+                    let tmp = is.read_enum()?;
                     self.provider = ::std::option::Option::Some(tmp);
                 },
                 _ => {
-                    try!(::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields()));
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
                 },
             };
         }
@@ -2048,14 +2144,14 @@ impl ::protobuf::Message for SessionToken {
     #[allow(unused_variables)]
     fn compute_size(&self) -> u32 {
         let mut my_size = 0;
-        for value in &self.token {
-            my_size += ::protobuf::rt::string_size(1, &value);
+        if let Some(v) = self.token.as_ref() {
+            my_size += ::protobuf::rt::string_size(1, &v);
         };
-        for value in &self.owner_id {
-            my_size += ::protobuf::rt::value_size(2, *value, ::protobuf::wire_format::WireTypeVarint);
+        if let Some(v) = self.owner_id {
+            my_size += ::protobuf::rt::value_size(2, v, ::protobuf::wire_format::WireTypeVarint);
         };
-        for value in &self.provider {
-            my_size += ::protobuf::rt::enum_size(3, *value);
+        if let Some(v) = self.provider {
+            my_size += ::protobuf::rt::enum_size(3, v);
         };
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
         self.cached_size.set(my_size);
@@ -2064,15 +2160,15 @@ impl ::protobuf::Message for SessionToken {
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.token.as_ref() {
-            try!(os.write_string(1, &v));
+            os.write_string(1, &v)?;
         };
         if let Some(v) = self.owner_id {
-            try!(os.write_uint64(2, v));
+            os.write_uint64(2, v)?;
         };
         if let Some(v) = self.provider {
-            try!(os.write_enum(3, v.value()));
+            os.write_enum(3, v.value())?;
         };
-        try!(os.write_unknown_fields(self.get_unknown_fields()));
+        os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
 
@@ -2088,12 +2184,14 @@ impl ::protobuf::Message for SessionToken {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<SessionToken>()
-    }
-
     fn as_any(&self) -> &::std::any::Any {
         self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -2114,20 +2212,20 @@ impl ::protobuf::MessageStatic for SessionToken {
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_string_accessor(
+                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
                     "token",
-                    SessionToken::has_token,
-                    SessionToken::get_token,
+                    SessionToken::get_token_for_reflect,
+                    SessionToken::mut_token_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_u64_accessor(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint64>(
                     "owner_id",
-                    SessionToken::has_owner_id,
-                    SessionToken::get_owner_id,
+                    SessionToken::get_owner_id_for_reflect,
+                    SessionToken::mut_owner_id_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_enum_accessor(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeEnum<OAuthProvider>>(
                     "provider",
-                    SessionToken::has_provider,
-                    SessionToken::get_provider,
+                    SessionToken::get_provider_for_reflect,
+                    SessionToken::mut_provider_for_reflect,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<SessionToken>(
                     "SessionToken",
@@ -2148,22 +2246,19 @@ impl ::protobuf::Clear for SessionToken {
     }
 }
 
-impl ::std::cmp::PartialEq for SessionToken {
-    fn eq(&self, other: &SessionToken) -> bool {
-        self.token == other.token &&
-        self.owner_id == other.owner_id &&
-        self.provider == other.provider &&
-        self.unknown_fields == other.unknown_fields
-    }
-}
-
 impl ::std::fmt::Debug for SessionToken {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
-#[derive(Clone,Default)]
+impl ::protobuf::reflect::ProtobufValue for SessionToken {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Message(self)
+    }
+}
+
+#[derive(PartialEq,Clone,Default)]
 pub struct SessionCreate {
     // message fields
     token: ::protobuf::SingularField<::std::string::String>,
@@ -2173,7 +2268,7 @@ pub struct SessionCreate {
     provider: ::std::option::Option<OAuthProvider>,
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    cached_size: ::protobuf::CachedSize,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -2190,17 +2285,7 @@ impl SessionCreate {
             ptr: 0 as *const SessionCreate,
         };
         unsafe {
-            instance.get(|| {
-                SessionCreate {
-                    token: ::protobuf::SingularField::none(),
-                    extern_id: ::std::option::Option::None,
-                    email: ::protobuf::SingularField::none(),
-                    name: ::protobuf::SingularField::none(),
-                    provider: ::std::option::Option::None,
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
+            instance.get(SessionCreate::new)
         }
     }
 
@@ -2240,6 +2325,14 @@ impl SessionCreate {
         }
     }
 
+    fn get_token_for_reflect(&self) -> &::protobuf::SingularField<::std::string::String> {
+        &self.token
+    }
+
+    fn mut_token_for_reflect(&mut self) -> &mut ::protobuf::SingularField<::std::string::String> {
+        &mut self.token
+    }
+
     // required uint64 extern_id = 2;
 
     pub fn clear_extern_id(&mut self) {
@@ -2257,6 +2350,14 @@ impl SessionCreate {
 
     pub fn get_extern_id(&self) -> u64 {
         self.extern_id.unwrap_or(0)
+    }
+
+    fn get_extern_id_for_reflect(&self) -> &::std::option::Option<u64> {
+        &self.extern_id
+    }
+
+    fn mut_extern_id_for_reflect(&mut self) -> &mut ::std::option::Option<u64> {
+        &mut self.extern_id
     }
 
     // required string email = 3;
@@ -2295,6 +2396,14 @@ impl SessionCreate {
         }
     }
 
+    fn get_email_for_reflect(&self) -> &::protobuf::SingularField<::std::string::String> {
+        &self.email
+    }
+
+    fn mut_email_for_reflect(&mut self) -> &mut ::protobuf::SingularField<::std::string::String> {
+        &mut self.email
+    }
+
     // required string name = 4;
 
     pub fn clear_name(&mut self) {
@@ -2331,6 +2440,14 @@ impl SessionCreate {
         }
     }
 
+    fn get_name_for_reflect(&self) -> &::protobuf::SingularField<::std::string::String> {
+        &self.name
+    }
+
+    fn mut_name_for_reflect(&mut self) -> &mut ::protobuf::SingularField<::std::string::String> {
+        &mut self.name
+    }
+
     // required .sessionsrv.OAuthProvider provider = 5;
 
     pub fn clear_provider(&mut self) {
@@ -2348,6 +2465,14 @@ impl SessionCreate {
 
     pub fn get_provider(&self) -> OAuthProvider {
         self.provider.unwrap_or(OAuthProvider::GitHub)
+    }
+
+    fn get_provider_for_reflect(&self) -> &::std::option::Option<OAuthProvider> {
+        &self.provider
+    }
+
+    fn mut_provider_for_reflect(&mut self) -> &mut ::std::option::Option<OAuthProvider> {
+        &mut self.provider
     }
 }
 
@@ -2372,34 +2497,34 @@ impl ::protobuf::Message for SessionCreate {
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
-        while !try!(is.eof()) {
-            let (field_number, wire_type) = try!(is.read_tag_unpack());
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
-                    try!(::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.token));
+                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.token)?;
                 },
                 2 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
                         return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
                     };
-                    let tmp = try!(is.read_uint64());
+                    let tmp = is.read_uint64()?;
                     self.extern_id = ::std::option::Option::Some(tmp);
                 },
                 3 => {
-                    try!(::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.email));
+                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.email)?;
                 },
                 4 => {
-                    try!(::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.name));
+                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.name)?;
                 },
                 5 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
                         return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
                     };
-                    let tmp = try!(is.read_enum());
+                    let tmp = is.read_enum()?;
                     self.provider = ::std::option::Option::Some(tmp);
                 },
                 _ => {
-                    try!(::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields()));
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
                 },
             };
         }
@@ -2410,20 +2535,20 @@ impl ::protobuf::Message for SessionCreate {
     #[allow(unused_variables)]
     fn compute_size(&self) -> u32 {
         let mut my_size = 0;
-        for value in &self.token {
-            my_size += ::protobuf::rt::string_size(1, &value);
+        if let Some(v) = self.token.as_ref() {
+            my_size += ::protobuf::rt::string_size(1, &v);
         };
-        for value in &self.extern_id {
-            my_size += ::protobuf::rt::value_size(2, *value, ::protobuf::wire_format::WireTypeVarint);
+        if let Some(v) = self.extern_id {
+            my_size += ::protobuf::rt::value_size(2, v, ::protobuf::wire_format::WireTypeVarint);
         };
-        for value in &self.email {
-            my_size += ::protobuf::rt::string_size(3, &value);
+        if let Some(v) = self.email.as_ref() {
+            my_size += ::protobuf::rt::string_size(3, &v);
         };
-        for value in &self.name {
-            my_size += ::protobuf::rt::string_size(4, &value);
+        if let Some(v) = self.name.as_ref() {
+            my_size += ::protobuf::rt::string_size(4, &v);
         };
-        for value in &self.provider {
-            my_size += ::protobuf::rt::enum_size(5, *value);
+        if let Some(v) = self.provider {
+            my_size += ::protobuf::rt::enum_size(5, v);
         };
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
         self.cached_size.set(my_size);
@@ -2432,21 +2557,21 @@ impl ::protobuf::Message for SessionCreate {
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.token.as_ref() {
-            try!(os.write_string(1, &v));
+            os.write_string(1, &v)?;
         };
         if let Some(v) = self.extern_id {
-            try!(os.write_uint64(2, v));
+            os.write_uint64(2, v)?;
         };
         if let Some(v) = self.email.as_ref() {
-            try!(os.write_string(3, &v));
+            os.write_string(3, &v)?;
         };
         if let Some(v) = self.name.as_ref() {
-            try!(os.write_string(4, &v));
+            os.write_string(4, &v)?;
         };
         if let Some(v) = self.provider {
-            try!(os.write_enum(5, v.value()));
+            os.write_enum(5, v.value())?;
         };
-        try!(os.write_unknown_fields(self.get_unknown_fields()));
+        os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
 
@@ -2462,12 +2587,14 @@ impl ::protobuf::Message for SessionCreate {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<SessionCreate>()
-    }
-
     fn as_any(&self) -> &::std::any::Any {
         self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -2488,30 +2615,30 @@ impl ::protobuf::MessageStatic for SessionCreate {
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_string_accessor(
+                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
                     "token",
-                    SessionCreate::has_token,
-                    SessionCreate::get_token,
+                    SessionCreate::get_token_for_reflect,
+                    SessionCreate::mut_token_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_u64_accessor(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint64>(
                     "extern_id",
-                    SessionCreate::has_extern_id,
-                    SessionCreate::get_extern_id,
+                    SessionCreate::get_extern_id_for_reflect,
+                    SessionCreate::mut_extern_id_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_string_accessor(
+                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
                     "email",
-                    SessionCreate::has_email,
-                    SessionCreate::get_email,
+                    SessionCreate::get_email_for_reflect,
+                    SessionCreate::mut_email_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_string_accessor(
+                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
                     "name",
-                    SessionCreate::has_name,
-                    SessionCreate::get_name,
+                    SessionCreate::get_name_for_reflect,
+                    SessionCreate::mut_name_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_enum_accessor(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeEnum<OAuthProvider>>(
                     "provider",
-                    SessionCreate::has_provider,
-                    SessionCreate::get_provider,
+                    SessionCreate::get_provider_for_reflect,
+                    SessionCreate::mut_provider_for_reflect,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<SessionCreate>(
                     "SessionCreate",
@@ -2534,30 +2661,25 @@ impl ::protobuf::Clear for SessionCreate {
     }
 }
 
-impl ::std::cmp::PartialEq for SessionCreate {
-    fn eq(&self, other: &SessionCreate) -> bool {
-        self.token == other.token &&
-        self.extern_id == other.extern_id &&
-        self.email == other.email &&
-        self.name == other.name &&
-        self.provider == other.provider &&
-        self.unknown_fields == other.unknown_fields
-    }
-}
-
 impl ::std::fmt::Debug for SessionCreate {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
-#[derive(Clone,Default)]
+impl ::protobuf::reflect::ProtobufValue for SessionCreate {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Message(self)
+    }
+}
+
+#[derive(PartialEq,Clone,Default)]
 pub struct SessionGet {
     // message fields
     token: ::protobuf::SingularField<::std::string::String>,
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    cached_size: ::protobuf::CachedSize,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -2574,13 +2696,7 @@ impl SessionGet {
             ptr: 0 as *const SessionGet,
         };
         unsafe {
-            instance.get(|| {
-                SessionGet {
-                    token: ::protobuf::SingularField::none(),
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
+            instance.get(SessionGet::new)
         }
     }
 
@@ -2619,6 +2735,14 @@ impl SessionGet {
             None => "",
         }
     }
+
+    fn get_token_for_reflect(&self) -> &::protobuf::SingularField<::std::string::String> {
+        &self.token
+    }
+
+    fn mut_token_for_reflect(&mut self) -> &mut ::protobuf::SingularField<::std::string::String> {
+        &mut self.token
+    }
 }
 
 impl ::protobuf::Message for SessionGet {
@@ -2630,14 +2754,14 @@ impl ::protobuf::Message for SessionGet {
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
-        while !try!(is.eof()) {
-            let (field_number, wire_type) = try!(is.read_tag_unpack());
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
-                    try!(::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.token));
+                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.token)?;
                 },
                 _ => {
-                    try!(::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields()));
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
                 },
             };
         }
@@ -2648,8 +2772,8 @@ impl ::protobuf::Message for SessionGet {
     #[allow(unused_variables)]
     fn compute_size(&self) -> u32 {
         let mut my_size = 0;
-        for value in &self.token {
-            my_size += ::protobuf::rt::string_size(1, &value);
+        if let Some(v) = self.token.as_ref() {
+            my_size += ::protobuf::rt::string_size(1, &v);
         };
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
         self.cached_size.set(my_size);
@@ -2658,9 +2782,9 @@ impl ::protobuf::Message for SessionGet {
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.token.as_ref() {
-            try!(os.write_string(1, &v));
+            os.write_string(1, &v)?;
         };
-        try!(os.write_unknown_fields(self.get_unknown_fields()));
+        os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
 
@@ -2676,12 +2800,14 @@ impl ::protobuf::Message for SessionGet {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<SessionGet>()
-    }
-
     fn as_any(&self) -> &::std::any::Any {
         self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -2702,10 +2828,10 @@ impl ::protobuf::MessageStatic for SessionGet {
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_string_accessor(
+                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
                     "token",
-                    SessionGet::has_token,
-                    SessionGet::get_token,
+                    SessionGet::get_token_for_reflect,
+                    SessionGet::mut_token_for_reflect,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<SessionGet>(
                     "SessionGet",
@@ -2724,16 +2850,15 @@ impl ::protobuf::Clear for SessionGet {
     }
 }
 
-impl ::std::cmp::PartialEq for SessionGet {
-    fn eq(&self, other: &SessionGet) -> bool {
-        self.token == other.token &&
-        self.unknown_fields == other.unknown_fields
-    }
-}
-
 impl ::std::fmt::Debug for SessionGet {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
+    }
+}
+
+impl ::protobuf::reflect::ProtobufValue for SessionGet {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
@@ -2777,6 +2902,12 @@ impl ::protobuf::ProtobufEnum for OAuthProvider {
 impl ::std::marker::Copy for OAuthProvider {
 }
 
+impl ::protobuf::reflect::ProtobufValue for OAuthProvider {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Enum(self.descriptor())
+    }
+}
+
 #[derive(Clone,PartialEq,Eq,Debug,Hash)]
 pub enum AccountSearchKey {
     Id = 0,
@@ -2818,6 +2949,12 @@ impl ::protobuf::ProtobufEnum for AccountSearchKey {
 }
 
 impl ::std::marker::Copy for AccountSearchKey {
+}
+
+impl ::protobuf::reflect::ProtobufValue for AccountSearchKey {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Enum(self.descriptor())
+    }
 }
 
 static file_descriptor_proto_data: &'static [u8] = &[

--- a/components/builder-protocol/src/message/vault.rs
+++ b/components/builder-protocol/src/message/vault.rs
@@ -9,6 +9,7 @@
 
 #![allow(box_pointers)]
 #![allow(dead_code)]
+#![allow(missing_docs)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
@@ -20,7 +21,7 @@
 use protobuf::Message as Message_imported_for_functions;
 use protobuf::ProtobufEnum as ProtobufEnum_imported_for_functions;
 
-#[derive(Clone,Default)]
+#[derive(PartialEq,Clone,Default)]
 pub struct Origin {
     // message fields
     id: ::std::option::Option<u64>,
@@ -29,7 +30,7 @@ pub struct Origin {
     private_key_name: ::protobuf::SingularField<::std::string::String>,
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    cached_size: ::protobuf::CachedSize,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -46,16 +47,7 @@ impl Origin {
             ptr: 0 as *const Origin,
         };
         unsafe {
-            instance.get(|| {
-                Origin {
-                    id: ::std::option::Option::None,
-                    name: ::protobuf::SingularField::none(),
-                    owner_id: ::std::option::Option::None,
-                    private_key_name: ::protobuf::SingularField::none(),
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
+            instance.get(Origin::new)
         }
     }
 
@@ -76,6 +68,14 @@ impl Origin {
 
     pub fn get_id(&self) -> u64 {
         self.id.unwrap_or(0)
+    }
+
+    fn get_id_for_reflect(&self) -> &::std::option::Option<u64> {
+        &self.id
+    }
+
+    fn mut_id_for_reflect(&mut self) -> &mut ::std::option::Option<u64> {
+        &mut self.id
     }
 
     // required string name = 2;
@@ -114,6 +114,14 @@ impl Origin {
         }
     }
 
+    fn get_name_for_reflect(&self) -> &::protobuf::SingularField<::std::string::String> {
+        &self.name
+    }
+
+    fn mut_name_for_reflect(&mut self) -> &mut ::protobuf::SingularField<::std::string::String> {
+        &mut self.name
+    }
+
     // required uint64 owner_id = 3;
 
     pub fn clear_owner_id(&mut self) {
@@ -131,6 +139,14 @@ impl Origin {
 
     pub fn get_owner_id(&self) -> u64 {
         self.owner_id.unwrap_or(0)
+    }
+
+    fn get_owner_id_for_reflect(&self) -> &::std::option::Option<u64> {
+        &self.owner_id
+    }
+
+    fn mut_owner_id_for_reflect(&mut self) -> &mut ::std::option::Option<u64> {
+        &mut self.owner_id
     }
 
     // optional string private_key_name = 4;
@@ -168,6 +184,14 @@ impl Origin {
             None => "",
         }
     }
+
+    fn get_private_key_name_for_reflect(&self) -> &::protobuf::SingularField<::std::string::String> {
+        &self.private_key_name
+    }
+
+    fn mut_private_key_name_for_reflect(&mut self) -> &mut ::protobuf::SingularField<::std::string::String> {
+        &mut self.private_key_name
+    }
 }
 
 impl ::protobuf::Message for Origin {
@@ -185,31 +209,31 @@ impl ::protobuf::Message for Origin {
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
-        while !try!(is.eof()) {
-            let (field_number, wire_type) = try!(is.read_tag_unpack());
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
                         return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
                     };
-                    let tmp = try!(is.read_uint64());
+                    let tmp = is.read_uint64()?;
                     self.id = ::std::option::Option::Some(tmp);
                 },
                 2 => {
-                    try!(::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.name));
+                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.name)?;
                 },
                 3 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
                         return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
                     };
-                    let tmp = try!(is.read_uint64());
+                    let tmp = is.read_uint64()?;
                     self.owner_id = ::std::option::Option::Some(tmp);
                 },
                 4 => {
-                    try!(::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.private_key_name));
+                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.private_key_name)?;
                 },
                 _ => {
-                    try!(::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields()));
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
                 },
             };
         }
@@ -220,17 +244,17 @@ impl ::protobuf::Message for Origin {
     #[allow(unused_variables)]
     fn compute_size(&self) -> u32 {
         let mut my_size = 0;
-        for value in &self.id {
-            my_size += ::protobuf::rt::value_size(1, *value, ::protobuf::wire_format::WireTypeVarint);
+        if let Some(v) = self.id {
+            my_size += ::protobuf::rt::value_size(1, v, ::protobuf::wire_format::WireTypeVarint);
         };
-        for value in &self.name {
-            my_size += ::protobuf::rt::string_size(2, &value);
+        if let Some(v) = self.name.as_ref() {
+            my_size += ::protobuf::rt::string_size(2, &v);
         };
-        for value in &self.owner_id {
-            my_size += ::protobuf::rt::value_size(3, *value, ::protobuf::wire_format::WireTypeVarint);
+        if let Some(v) = self.owner_id {
+            my_size += ::protobuf::rt::value_size(3, v, ::protobuf::wire_format::WireTypeVarint);
         };
-        for value in &self.private_key_name {
-            my_size += ::protobuf::rt::string_size(4, &value);
+        if let Some(v) = self.private_key_name.as_ref() {
+            my_size += ::protobuf::rt::string_size(4, &v);
         };
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
         self.cached_size.set(my_size);
@@ -239,18 +263,18 @@ impl ::protobuf::Message for Origin {
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.id {
-            try!(os.write_uint64(1, v));
+            os.write_uint64(1, v)?;
         };
         if let Some(v) = self.name.as_ref() {
-            try!(os.write_string(2, &v));
+            os.write_string(2, &v)?;
         };
         if let Some(v) = self.owner_id {
-            try!(os.write_uint64(3, v));
+            os.write_uint64(3, v)?;
         };
         if let Some(v) = self.private_key_name.as_ref() {
-            try!(os.write_string(4, &v));
+            os.write_string(4, &v)?;
         };
-        try!(os.write_unknown_fields(self.get_unknown_fields()));
+        os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
 
@@ -266,12 +290,14 @@ impl ::protobuf::Message for Origin {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<Origin>()
-    }
-
     fn as_any(&self) -> &::std::any::Any {
         self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -292,25 +318,25 @@ impl ::protobuf::MessageStatic for Origin {
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_u64_accessor(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint64>(
                     "id",
-                    Origin::has_id,
-                    Origin::get_id,
+                    Origin::get_id_for_reflect,
+                    Origin::mut_id_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_string_accessor(
+                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
                     "name",
-                    Origin::has_name,
-                    Origin::get_name,
+                    Origin::get_name_for_reflect,
+                    Origin::mut_name_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_u64_accessor(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint64>(
                     "owner_id",
-                    Origin::has_owner_id,
-                    Origin::get_owner_id,
+                    Origin::get_owner_id_for_reflect,
+                    Origin::mut_owner_id_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_string_accessor(
+                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
                     "private_key_name",
-                    Origin::has_private_key_name,
-                    Origin::get_private_key_name,
+                    Origin::get_private_key_name_for_reflect,
+                    Origin::mut_private_key_name_for_reflect,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<Origin>(
                     "Origin",
@@ -332,23 +358,19 @@ impl ::protobuf::Clear for Origin {
     }
 }
 
-impl ::std::cmp::PartialEq for Origin {
-    fn eq(&self, other: &Origin) -> bool {
-        self.id == other.id &&
-        self.name == other.name &&
-        self.owner_id == other.owner_id &&
-        self.private_key_name == other.private_key_name &&
-        self.unknown_fields == other.unknown_fields
-    }
-}
-
 impl ::std::fmt::Debug for Origin {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
-#[derive(Clone,Default)]
+impl ::protobuf::reflect::ProtobufValue for Origin {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Message(self)
+    }
+}
+
+#[derive(PartialEq,Clone,Default)]
 pub struct OriginCreate {
     // message fields
     name: ::protobuf::SingularField<::std::string::String>,
@@ -356,7 +378,7 @@ pub struct OriginCreate {
     owner_name: ::protobuf::SingularField<::std::string::String>,
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    cached_size: ::protobuf::CachedSize,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -373,15 +395,7 @@ impl OriginCreate {
             ptr: 0 as *const OriginCreate,
         };
         unsafe {
-            instance.get(|| {
-                OriginCreate {
-                    name: ::protobuf::SingularField::none(),
-                    owner_id: ::std::option::Option::None,
-                    owner_name: ::protobuf::SingularField::none(),
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
+            instance.get(OriginCreate::new)
         }
     }
 
@@ -421,6 +435,14 @@ impl OriginCreate {
         }
     }
 
+    fn get_name_for_reflect(&self) -> &::protobuf::SingularField<::std::string::String> {
+        &self.name
+    }
+
+    fn mut_name_for_reflect(&mut self) -> &mut ::protobuf::SingularField<::std::string::String> {
+        &mut self.name
+    }
+
     // required uint64 owner_id = 2;
 
     pub fn clear_owner_id(&mut self) {
@@ -438,6 +460,14 @@ impl OriginCreate {
 
     pub fn get_owner_id(&self) -> u64 {
         self.owner_id.unwrap_or(0)
+    }
+
+    fn get_owner_id_for_reflect(&self) -> &::std::option::Option<u64> {
+        &self.owner_id
+    }
+
+    fn mut_owner_id_for_reflect(&mut self) -> &mut ::std::option::Option<u64> {
+        &mut self.owner_id
     }
 
     // required string owner_name = 3;
@@ -475,6 +505,14 @@ impl OriginCreate {
             None => "",
         }
     }
+
+    fn get_owner_name_for_reflect(&self) -> &::protobuf::SingularField<::std::string::String> {
+        &self.owner_name
+    }
+
+    fn mut_owner_name_for_reflect(&mut self) -> &mut ::protobuf::SingularField<::std::string::String> {
+        &mut self.owner_name
+    }
 }
 
 impl ::protobuf::Message for OriginCreate {
@@ -492,24 +530,24 @@ impl ::protobuf::Message for OriginCreate {
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
-        while !try!(is.eof()) {
-            let (field_number, wire_type) = try!(is.read_tag_unpack());
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
-                    try!(::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.name));
+                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.name)?;
                 },
                 2 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
                         return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
                     };
-                    let tmp = try!(is.read_uint64());
+                    let tmp = is.read_uint64()?;
                     self.owner_id = ::std::option::Option::Some(tmp);
                 },
                 3 => {
-                    try!(::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.owner_name));
+                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.owner_name)?;
                 },
                 _ => {
-                    try!(::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields()));
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
                 },
             };
         }
@@ -520,14 +558,14 @@ impl ::protobuf::Message for OriginCreate {
     #[allow(unused_variables)]
     fn compute_size(&self) -> u32 {
         let mut my_size = 0;
-        for value in &self.name {
-            my_size += ::protobuf::rt::string_size(1, &value);
+        if let Some(v) = self.name.as_ref() {
+            my_size += ::protobuf::rt::string_size(1, &v);
         };
-        for value in &self.owner_id {
-            my_size += ::protobuf::rt::value_size(2, *value, ::protobuf::wire_format::WireTypeVarint);
+        if let Some(v) = self.owner_id {
+            my_size += ::protobuf::rt::value_size(2, v, ::protobuf::wire_format::WireTypeVarint);
         };
-        for value in &self.owner_name {
-            my_size += ::protobuf::rt::string_size(3, &value);
+        if let Some(v) = self.owner_name.as_ref() {
+            my_size += ::protobuf::rt::string_size(3, &v);
         };
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
         self.cached_size.set(my_size);
@@ -536,15 +574,15 @@ impl ::protobuf::Message for OriginCreate {
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.name.as_ref() {
-            try!(os.write_string(1, &v));
+            os.write_string(1, &v)?;
         };
         if let Some(v) = self.owner_id {
-            try!(os.write_uint64(2, v));
+            os.write_uint64(2, v)?;
         };
         if let Some(v) = self.owner_name.as_ref() {
-            try!(os.write_string(3, &v));
+            os.write_string(3, &v)?;
         };
-        try!(os.write_unknown_fields(self.get_unknown_fields()));
+        os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
 
@@ -560,12 +598,14 @@ impl ::protobuf::Message for OriginCreate {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<OriginCreate>()
-    }
-
     fn as_any(&self) -> &::std::any::Any {
         self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -586,20 +626,20 @@ impl ::protobuf::MessageStatic for OriginCreate {
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_string_accessor(
+                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
                     "name",
-                    OriginCreate::has_name,
-                    OriginCreate::get_name,
+                    OriginCreate::get_name_for_reflect,
+                    OriginCreate::mut_name_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_u64_accessor(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint64>(
                     "owner_id",
-                    OriginCreate::has_owner_id,
-                    OriginCreate::get_owner_id,
+                    OriginCreate::get_owner_id_for_reflect,
+                    OriginCreate::mut_owner_id_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_string_accessor(
+                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
                     "owner_name",
-                    OriginCreate::has_owner_name,
-                    OriginCreate::get_owner_name,
+                    OriginCreate::get_owner_name_for_reflect,
+                    OriginCreate::mut_owner_name_for_reflect,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<OriginCreate>(
                     "OriginCreate",
@@ -620,28 +660,25 @@ impl ::protobuf::Clear for OriginCreate {
     }
 }
 
-impl ::std::cmp::PartialEq for OriginCreate {
-    fn eq(&self, other: &OriginCreate) -> bool {
-        self.name == other.name &&
-        self.owner_id == other.owner_id &&
-        self.owner_name == other.owner_name &&
-        self.unknown_fields == other.unknown_fields
-    }
-}
-
 impl ::std::fmt::Debug for OriginCreate {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
-#[derive(Clone,Default)]
+impl ::protobuf::reflect::ProtobufValue for OriginCreate {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Message(self)
+    }
+}
+
+#[derive(PartialEq,Clone,Default)]
 pub struct OriginDelete {
     // message fields
     name: ::protobuf::SingularField<::std::string::String>,
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    cached_size: ::protobuf::CachedSize,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -658,13 +695,7 @@ impl OriginDelete {
             ptr: 0 as *const OriginDelete,
         };
         unsafe {
-            instance.get(|| {
-                OriginDelete {
-                    name: ::protobuf::SingularField::none(),
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
+            instance.get(OriginDelete::new)
         }
     }
 
@@ -703,6 +734,14 @@ impl OriginDelete {
             None => "",
         }
     }
+
+    fn get_name_for_reflect(&self) -> &::protobuf::SingularField<::std::string::String> {
+        &self.name
+    }
+
+    fn mut_name_for_reflect(&mut self) -> &mut ::protobuf::SingularField<::std::string::String> {
+        &mut self.name
+    }
 }
 
 impl ::protobuf::Message for OriginDelete {
@@ -714,14 +753,14 @@ impl ::protobuf::Message for OriginDelete {
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
-        while !try!(is.eof()) {
-            let (field_number, wire_type) = try!(is.read_tag_unpack());
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
-                    try!(::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.name));
+                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.name)?;
                 },
                 _ => {
-                    try!(::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields()));
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
                 },
             };
         }
@@ -732,8 +771,8 @@ impl ::protobuf::Message for OriginDelete {
     #[allow(unused_variables)]
     fn compute_size(&self) -> u32 {
         let mut my_size = 0;
-        for value in &self.name {
-            my_size += ::protobuf::rt::string_size(1, &value);
+        if let Some(v) = self.name.as_ref() {
+            my_size += ::protobuf::rt::string_size(1, &v);
         };
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
         self.cached_size.set(my_size);
@@ -742,9 +781,9 @@ impl ::protobuf::Message for OriginDelete {
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.name.as_ref() {
-            try!(os.write_string(1, &v));
+            os.write_string(1, &v)?;
         };
-        try!(os.write_unknown_fields(self.get_unknown_fields()));
+        os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
 
@@ -760,12 +799,14 @@ impl ::protobuf::Message for OriginDelete {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<OriginDelete>()
-    }
-
     fn as_any(&self) -> &::std::any::Any {
         self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -786,10 +827,10 @@ impl ::protobuf::MessageStatic for OriginDelete {
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_string_accessor(
+                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
                     "name",
-                    OriginDelete::has_name,
-                    OriginDelete::get_name,
+                    OriginDelete::get_name_for_reflect,
+                    OriginDelete::mut_name_for_reflect,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<OriginDelete>(
                     "OriginDelete",
@@ -808,26 +849,25 @@ impl ::protobuf::Clear for OriginDelete {
     }
 }
 
-impl ::std::cmp::PartialEq for OriginDelete {
-    fn eq(&self, other: &OriginDelete) -> bool {
-        self.name == other.name &&
-        self.unknown_fields == other.unknown_fields
-    }
-}
-
 impl ::std::fmt::Debug for OriginDelete {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
-#[derive(Clone,Default)]
+impl ::protobuf::reflect::ProtobufValue for OriginDelete {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Message(self)
+    }
+}
+
+#[derive(PartialEq,Clone,Default)]
 pub struct OriginGet {
     // message fields
     name: ::protobuf::SingularField<::std::string::String>,
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    cached_size: ::protobuf::CachedSize,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -844,13 +884,7 @@ impl OriginGet {
             ptr: 0 as *const OriginGet,
         };
         unsafe {
-            instance.get(|| {
-                OriginGet {
-                    name: ::protobuf::SingularField::none(),
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
+            instance.get(OriginGet::new)
         }
     }
 
@@ -889,6 +923,14 @@ impl OriginGet {
             None => "",
         }
     }
+
+    fn get_name_for_reflect(&self) -> &::protobuf::SingularField<::std::string::String> {
+        &self.name
+    }
+
+    fn mut_name_for_reflect(&mut self) -> &mut ::protobuf::SingularField<::std::string::String> {
+        &mut self.name
+    }
 }
 
 impl ::protobuf::Message for OriginGet {
@@ -900,14 +942,14 @@ impl ::protobuf::Message for OriginGet {
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
-        while !try!(is.eof()) {
-            let (field_number, wire_type) = try!(is.read_tag_unpack());
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
-                    try!(::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.name));
+                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.name)?;
                 },
                 _ => {
-                    try!(::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields()));
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
                 },
             };
         }
@@ -918,8 +960,8 @@ impl ::protobuf::Message for OriginGet {
     #[allow(unused_variables)]
     fn compute_size(&self) -> u32 {
         let mut my_size = 0;
-        for value in &self.name {
-            my_size += ::protobuf::rt::string_size(1, &value);
+        if let Some(v) = self.name.as_ref() {
+            my_size += ::protobuf::rt::string_size(1, &v);
         };
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
         self.cached_size.set(my_size);
@@ -928,9 +970,9 @@ impl ::protobuf::Message for OriginGet {
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.name.as_ref() {
-            try!(os.write_string(1, &v));
+            os.write_string(1, &v)?;
         };
-        try!(os.write_unknown_fields(self.get_unknown_fields()));
+        os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
 
@@ -946,12 +988,14 @@ impl ::protobuf::Message for OriginGet {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<OriginGet>()
-    }
-
     fn as_any(&self) -> &::std::any::Any {
         self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -972,10 +1016,10 @@ impl ::protobuf::MessageStatic for OriginGet {
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_string_accessor(
+                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
                     "name",
-                    OriginGet::has_name,
-                    OriginGet::get_name,
+                    OriginGet::get_name_for_reflect,
+                    OriginGet::mut_name_for_reflect,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<OriginGet>(
                     "OriginGet",
@@ -994,27 +1038,26 @@ impl ::protobuf::Clear for OriginGet {
     }
 }
 
-impl ::std::cmp::PartialEq for OriginGet {
-    fn eq(&self, other: &OriginGet) -> bool {
-        self.name == other.name &&
-        self.unknown_fields == other.unknown_fields
-    }
-}
-
 impl ::std::fmt::Debug for OriginGet {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
-#[derive(Clone,Default)]
+impl ::protobuf::reflect::ProtobufValue for OriginGet {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Message(self)
+    }
+}
+
+#[derive(PartialEq,Clone,Default)]
 pub struct OriginMemberRemove {
     // message fields
     origin_id: ::std::option::Option<u64>,
     user_id: ::std::option::Option<u64>,
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    cached_size: ::protobuf::CachedSize,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -1031,14 +1074,7 @@ impl OriginMemberRemove {
             ptr: 0 as *const OriginMemberRemove,
         };
         unsafe {
-            instance.get(|| {
-                OriginMemberRemove {
-                    origin_id: ::std::option::Option::None,
-                    user_id: ::std::option::Option::None,
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
+            instance.get(OriginMemberRemove::new)
         }
     }
 
@@ -1059,6 +1095,14 @@ impl OriginMemberRemove {
 
     pub fn get_origin_id(&self) -> u64 {
         self.origin_id.unwrap_or(0)
+    }
+
+    fn get_origin_id_for_reflect(&self) -> &::std::option::Option<u64> {
+        &self.origin_id
+    }
+
+    fn mut_origin_id_for_reflect(&mut self) -> &mut ::std::option::Option<u64> {
+        &mut self.origin_id
     }
 
     // required uint64 user_id = 2;
@@ -1079,6 +1123,14 @@ impl OriginMemberRemove {
     pub fn get_user_id(&self) -> u64 {
         self.user_id.unwrap_or(0)
     }
+
+    fn get_user_id_for_reflect(&self) -> &::std::option::Option<u64> {
+        &self.user_id
+    }
+
+    fn mut_user_id_for_reflect(&mut self) -> &mut ::std::option::Option<u64> {
+        &mut self.user_id
+    }
 }
 
 impl ::protobuf::Message for OriginMemberRemove {
@@ -1093,25 +1145,25 @@ impl ::protobuf::Message for OriginMemberRemove {
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
-        while !try!(is.eof()) {
-            let (field_number, wire_type) = try!(is.read_tag_unpack());
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
                         return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
                     };
-                    let tmp = try!(is.read_uint64());
+                    let tmp = is.read_uint64()?;
                     self.origin_id = ::std::option::Option::Some(tmp);
                 },
                 2 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
                         return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
                     };
-                    let tmp = try!(is.read_uint64());
+                    let tmp = is.read_uint64()?;
                     self.user_id = ::std::option::Option::Some(tmp);
                 },
                 _ => {
-                    try!(::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields()));
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
                 },
             };
         }
@@ -1122,11 +1174,11 @@ impl ::protobuf::Message for OriginMemberRemove {
     #[allow(unused_variables)]
     fn compute_size(&self) -> u32 {
         let mut my_size = 0;
-        for value in &self.origin_id {
-            my_size += ::protobuf::rt::value_size(1, *value, ::protobuf::wire_format::WireTypeVarint);
+        if let Some(v) = self.origin_id {
+            my_size += ::protobuf::rt::value_size(1, v, ::protobuf::wire_format::WireTypeVarint);
         };
-        for value in &self.user_id {
-            my_size += ::protobuf::rt::value_size(2, *value, ::protobuf::wire_format::WireTypeVarint);
+        if let Some(v) = self.user_id {
+            my_size += ::protobuf::rt::value_size(2, v, ::protobuf::wire_format::WireTypeVarint);
         };
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
         self.cached_size.set(my_size);
@@ -1135,12 +1187,12 @@ impl ::protobuf::Message for OriginMemberRemove {
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.origin_id {
-            try!(os.write_uint64(1, v));
+            os.write_uint64(1, v)?;
         };
         if let Some(v) = self.user_id {
-            try!(os.write_uint64(2, v));
+            os.write_uint64(2, v)?;
         };
-        try!(os.write_unknown_fields(self.get_unknown_fields()));
+        os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
 
@@ -1156,12 +1208,14 @@ impl ::protobuf::Message for OriginMemberRemove {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<OriginMemberRemove>()
-    }
-
     fn as_any(&self) -> &::std::any::Any {
         self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -1182,15 +1236,15 @@ impl ::protobuf::MessageStatic for OriginMemberRemove {
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_u64_accessor(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint64>(
                     "origin_id",
-                    OriginMemberRemove::has_origin_id,
-                    OriginMemberRemove::get_origin_id,
+                    OriginMemberRemove::get_origin_id_for_reflect,
+                    OriginMemberRemove::mut_origin_id_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_u64_accessor(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint64>(
                     "user_id",
-                    OriginMemberRemove::has_user_id,
-                    OriginMemberRemove::get_user_id,
+                    OriginMemberRemove::get_user_id_for_reflect,
+                    OriginMemberRemove::mut_user_id_for_reflect,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<OriginMemberRemove>(
                     "OriginMemberRemove",
@@ -1210,27 +1264,25 @@ impl ::protobuf::Clear for OriginMemberRemove {
     }
 }
 
-impl ::std::cmp::PartialEq for OriginMemberRemove {
-    fn eq(&self, other: &OriginMemberRemove) -> bool {
-        self.origin_id == other.origin_id &&
-        self.user_id == other.user_id &&
-        self.unknown_fields == other.unknown_fields
-    }
-}
-
 impl ::std::fmt::Debug for OriginMemberRemove {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
-#[derive(Clone,Default)]
+impl ::protobuf::reflect::ProtobufValue for OriginMemberRemove {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Message(self)
+    }
+}
+
+#[derive(PartialEq,Clone,Default)]
 pub struct OriginMemberListRequest {
     // message fields
     origin_id: ::std::option::Option<u64>,
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    cached_size: ::protobuf::CachedSize,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -1247,13 +1299,7 @@ impl OriginMemberListRequest {
             ptr: 0 as *const OriginMemberListRequest,
         };
         unsafe {
-            instance.get(|| {
-                OriginMemberListRequest {
-                    origin_id: ::std::option::Option::None,
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
+            instance.get(OriginMemberListRequest::new)
         }
     }
 
@@ -1275,6 +1321,14 @@ impl OriginMemberListRequest {
     pub fn get_origin_id(&self) -> u64 {
         self.origin_id.unwrap_or(0)
     }
+
+    fn get_origin_id_for_reflect(&self) -> &::std::option::Option<u64> {
+        &self.origin_id
+    }
+
+    fn mut_origin_id_for_reflect(&mut self) -> &mut ::std::option::Option<u64> {
+        &mut self.origin_id
+    }
 }
 
 impl ::protobuf::Message for OriginMemberListRequest {
@@ -1286,18 +1340,18 @@ impl ::protobuf::Message for OriginMemberListRequest {
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
-        while !try!(is.eof()) {
-            let (field_number, wire_type) = try!(is.read_tag_unpack());
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
                         return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
                     };
-                    let tmp = try!(is.read_uint64());
+                    let tmp = is.read_uint64()?;
                     self.origin_id = ::std::option::Option::Some(tmp);
                 },
                 _ => {
-                    try!(::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields()));
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
                 },
             };
         }
@@ -1308,8 +1362,8 @@ impl ::protobuf::Message for OriginMemberListRequest {
     #[allow(unused_variables)]
     fn compute_size(&self) -> u32 {
         let mut my_size = 0;
-        for value in &self.origin_id {
-            my_size += ::protobuf::rt::value_size(1, *value, ::protobuf::wire_format::WireTypeVarint);
+        if let Some(v) = self.origin_id {
+            my_size += ::protobuf::rt::value_size(1, v, ::protobuf::wire_format::WireTypeVarint);
         };
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
         self.cached_size.set(my_size);
@@ -1318,9 +1372,9 @@ impl ::protobuf::Message for OriginMemberListRequest {
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.origin_id {
-            try!(os.write_uint64(1, v));
+            os.write_uint64(1, v)?;
         };
-        try!(os.write_unknown_fields(self.get_unknown_fields()));
+        os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
 
@@ -1336,12 +1390,14 @@ impl ::protobuf::Message for OriginMemberListRequest {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<OriginMemberListRequest>()
-    }
-
     fn as_any(&self) -> &::std::any::Any {
         self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -1362,10 +1418,10 @@ impl ::protobuf::MessageStatic for OriginMemberListRequest {
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_u64_accessor(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint64>(
                     "origin_id",
-                    OriginMemberListRequest::has_origin_id,
-                    OriginMemberListRequest::get_origin_id,
+                    OriginMemberListRequest::get_origin_id_for_reflect,
+                    OriginMemberListRequest::mut_origin_id_for_reflect,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<OriginMemberListRequest>(
                     "OriginMemberListRequest",
@@ -1384,27 +1440,26 @@ impl ::protobuf::Clear for OriginMemberListRequest {
     }
 }
 
-impl ::std::cmp::PartialEq for OriginMemberListRequest {
-    fn eq(&self, other: &OriginMemberListRequest) -> bool {
-        self.origin_id == other.origin_id &&
-        self.unknown_fields == other.unknown_fields
-    }
-}
-
 impl ::std::fmt::Debug for OriginMemberListRequest {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
-#[derive(Clone,Default)]
+impl ::protobuf::reflect::ProtobufValue for OriginMemberListRequest {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Message(self)
+    }
+}
+
+#[derive(PartialEq,Clone,Default)]
 pub struct OriginMemberListResponse {
     // message fields
     origin_id: ::std::option::Option<u64>,
     members: ::protobuf::RepeatedField<::std::string::String>,
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    cached_size: ::protobuf::CachedSize,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -1421,14 +1476,7 @@ impl OriginMemberListResponse {
             ptr: 0 as *const OriginMemberListResponse,
         };
         unsafe {
-            instance.get(|| {
-                OriginMemberListResponse {
-                    origin_id: ::std::option::Option::None,
-                    members: ::protobuf::RepeatedField::new(),
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
+            instance.get(OriginMemberListResponse::new)
         }
     }
 
@@ -1449,6 +1497,14 @@ impl OriginMemberListResponse {
 
     pub fn get_origin_id(&self) -> u64 {
         self.origin_id.unwrap_or(0)
+    }
+
+    fn get_origin_id_for_reflect(&self) -> &::std::option::Option<u64> {
+        &self.origin_id
+    }
+
+    fn mut_origin_id_for_reflect(&mut self) -> &mut ::std::option::Option<u64> {
+        &mut self.origin_id
     }
 
     // repeated string members = 2;
@@ -1475,6 +1531,14 @@ impl OriginMemberListResponse {
     pub fn get_members(&self) -> &[::std::string::String] {
         &self.members
     }
+
+    fn get_members_for_reflect(&self) -> &::protobuf::RepeatedField<::std::string::String> {
+        &self.members
+    }
+
+    fn mut_members_for_reflect(&mut self) -> &mut ::protobuf::RepeatedField<::std::string::String> {
+        &mut self.members
+    }
 }
 
 impl ::protobuf::Message for OriginMemberListResponse {
@@ -1486,21 +1550,21 @@ impl ::protobuf::Message for OriginMemberListResponse {
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
-        while !try!(is.eof()) {
-            let (field_number, wire_type) = try!(is.read_tag_unpack());
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
                         return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
                     };
-                    let tmp = try!(is.read_uint64());
+                    let tmp = is.read_uint64()?;
                     self.origin_id = ::std::option::Option::Some(tmp);
                 },
                 2 => {
-                    try!(::protobuf::rt::read_repeated_string_into(wire_type, is, &mut self.members));
+                    ::protobuf::rt::read_repeated_string_into(wire_type, is, &mut self.members)?;
                 },
                 _ => {
-                    try!(::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields()));
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
                 },
             };
         }
@@ -1511,8 +1575,8 @@ impl ::protobuf::Message for OriginMemberListResponse {
     #[allow(unused_variables)]
     fn compute_size(&self) -> u32 {
         let mut my_size = 0;
-        for value in &self.origin_id {
-            my_size += ::protobuf::rt::value_size(1, *value, ::protobuf::wire_format::WireTypeVarint);
+        if let Some(v) = self.origin_id {
+            my_size += ::protobuf::rt::value_size(1, v, ::protobuf::wire_format::WireTypeVarint);
         };
         for value in &self.members {
             my_size += ::protobuf::rt::string_size(2, &value);
@@ -1524,12 +1588,12 @@ impl ::protobuf::Message for OriginMemberListResponse {
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.origin_id {
-            try!(os.write_uint64(1, v));
+            os.write_uint64(1, v)?;
         };
         for v in &self.members {
-            try!(os.write_string(2, &v));
+            os.write_string(2, &v)?;
         };
-        try!(os.write_unknown_fields(self.get_unknown_fields()));
+        os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
 
@@ -1545,12 +1609,14 @@ impl ::protobuf::Message for OriginMemberListResponse {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<OriginMemberListResponse>()
-    }
-
     fn as_any(&self) -> &::std::any::Any {
         self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -1571,14 +1637,15 @@ impl ::protobuf::MessageStatic for OriginMemberListResponse {
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_u64_accessor(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint64>(
                     "origin_id",
-                    OriginMemberListResponse::has_origin_id,
-                    OriginMemberListResponse::get_origin_id,
+                    OriginMemberListResponse::get_origin_id_for_reflect,
+                    OriginMemberListResponse::mut_origin_id_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_string_accessor(
+                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
                     "members",
-                    OriginMemberListResponse::get_members,
+                    OriginMemberListResponse::get_members_for_reflect,
+                    OriginMemberListResponse::mut_members_for_reflect,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<OriginMemberListResponse>(
                     "OriginMemberListResponse",
@@ -1598,27 +1665,25 @@ impl ::protobuf::Clear for OriginMemberListResponse {
     }
 }
 
-impl ::std::cmp::PartialEq for OriginMemberListResponse {
-    fn eq(&self, other: &OriginMemberListResponse) -> bool {
-        self.origin_id == other.origin_id &&
-        self.members == other.members &&
-        self.unknown_fields == other.unknown_fields
-    }
-}
-
 impl ::std::fmt::Debug for OriginMemberListResponse {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
-#[derive(Clone,Default)]
+impl ::protobuf::reflect::ProtobufValue for OriginMemberListResponse {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Message(self)
+    }
+}
+
+#[derive(PartialEq,Clone,Default)]
 pub struct AccountOriginListRequest {
     // message fields
     account_id: ::std::option::Option<u64>,
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    cached_size: ::protobuf::CachedSize,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -1635,13 +1700,7 @@ impl AccountOriginListRequest {
             ptr: 0 as *const AccountOriginListRequest,
         };
         unsafe {
-            instance.get(|| {
-                AccountOriginListRequest {
-                    account_id: ::std::option::Option::None,
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
+            instance.get(AccountOriginListRequest::new)
         }
     }
 
@@ -1663,6 +1722,14 @@ impl AccountOriginListRequest {
     pub fn get_account_id(&self) -> u64 {
         self.account_id.unwrap_or(0)
     }
+
+    fn get_account_id_for_reflect(&self) -> &::std::option::Option<u64> {
+        &self.account_id
+    }
+
+    fn mut_account_id_for_reflect(&mut self) -> &mut ::std::option::Option<u64> {
+        &mut self.account_id
+    }
 }
 
 impl ::protobuf::Message for AccountOriginListRequest {
@@ -1674,18 +1741,18 @@ impl ::protobuf::Message for AccountOriginListRequest {
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
-        while !try!(is.eof()) {
-            let (field_number, wire_type) = try!(is.read_tag_unpack());
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
                         return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
                     };
-                    let tmp = try!(is.read_uint64());
+                    let tmp = is.read_uint64()?;
                     self.account_id = ::std::option::Option::Some(tmp);
                 },
                 _ => {
-                    try!(::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields()));
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
                 },
             };
         }
@@ -1696,8 +1763,8 @@ impl ::protobuf::Message for AccountOriginListRequest {
     #[allow(unused_variables)]
     fn compute_size(&self) -> u32 {
         let mut my_size = 0;
-        for value in &self.account_id {
-            my_size += ::protobuf::rt::value_size(1, *value, ::protobuf::wire_format::WireTypeVarint);
+        if let Some(v) = self.account_id {
+            my_size += ::protobuf::rt::value_size(1, v, ::protobuf::wire_format::WireTypeVarint);
         };
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
         self.cached_size.set(my_size);
@@ -1706,9 +1773,9 @@ impl ::protobuf::Message for AccountOriginListRequest {
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.account_id {
-            try!(os.write_uint64(1, v));
+            os.write_uint64(1, v)?;
         };
-        try!(os.write_unknown_fields(self.get_unknown_fields()));
+        os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
 
@@ -1724,12 +1791,14 @@ impl ::protobuf::Message for AccountOriginListRequest {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<AccountOriginListRequest>()
-    }
-
     fn as_any(&self) -> &::std::any::Any {
         self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -1750,10 +1819,10 @@ impl ::protobuf::MessageStatic for AccountOriginListRequest {
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_u64_accessor(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint64>(
                     "account_id",
-                    AccountOriginListRequest::has_account_id,
-                    AccountOriginListRequest::get_account_id,
+                    AccountOriginListRequest::get_account_id_for_reflect,
+                    AccountOriginListRequest::mut_account_id_for_reflect,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<AccountOriginListRequest>(
                     "AccountOriginListRequest",
@@ -1772,27 +1841,26 @@ impl ::protobuf::Clear for AccountOriginListRequest {
     }
 }
 
-impl ::std::cmp::PartialEq for AccountOriginListRequest {
-    fn eq(&self, other: &AccountOriginListRequest) -> bool {
-        self.account_id == other.account_id &&
-        self.unknown_fields == other.unknown_fields
-    }
-}
-
 impl ::std::fmt::Debug for AccountOriginListRequest {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
-#[derive(Clone,Default)]
+impl ::protobuf::reflect::ProtobufValue for AccountOriginListRequest {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Message(self)
+    }
+}
+
+#[derive(PartialEq,Clone,Default)]
 pub struct AccountOriginListResponse {
     // message fields
     account_id: ::std::option::Option<u64>,
     origins: ::protobuf::RepeatedField<::std::string::String>,
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    cached_size: ::protobuf::CachedSize,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -1809,14 +1877,7 @@ impl AccountOriginListResponse {
             ptr: 0 as *const AccountOriginListResponse,
         };
         unsafe {
-            instance.get(|| {
-                AccountOriginListResponse {
-                    account_id: ::std::option::Option::None,
-                    origins: ::protobuf::RepeatedField::new(),
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
+            instance.get(AccountOriginListResponse::new)
         }
     }
 
@@ -1837,6 +1898,14 @@ impl AccountOriginListResponse {
 
     pub fn get_account_id(&self) -> u64 {
         self.account_id.unwrap_or(0)
+    }
+
+    fn get_account_id_for_reflect(&self) -> &::std::option::Option<u64> {
+        &self.account_id
+    }
+
+    fn mut_account_id_for_reflect(&mut self) -> &mut ::std::option::Option<u64> {
+        &mut self.account_id
     }
 
     // repeated string origins = 2;
@@ -1863,6 +1932,14 @@ impl AccountOriginListResponse {
     pub fn get_origins(&self) -> &[::std::string::String] {
         &self.origins
     }
+
+    fn get_origins_for_reflect(&self) -> &::protobuf::RepeatedField<::std::string::String> {
+        &self.origins
+    }
+
+    fn mut_origins_for_reflect(&mut self) -> &mut ::protobuf::RepeatedField<::std::string::String> {
+        &mut self.origins
+    }
 }
 
 impl ::protobuf::Message for AccountOriginListResponse {
@@ -1874,21 +1951,21 @@ impl ::protobuf::Message for AccountOriginListResponse {
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
-        while !try!(is.eof()) {
-            let (field_number, wire_type) = try!(is.read_tag_unpack());
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
                         return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
                     };
-                    let tmp = try!(is.read_uint64());
+                    let tmp = is.read_uint64()?;
                     self.account_id = ::std::option::Option::Some(tmp);
                 },
                 2 => {
-                    try!(::protobuf::rt::read_repeated_string_into(wire_type, is, &mut self.origins));
+                    ::protobuf::rt::read_repeated_string_into(wire_type, is, &mut self.origins)?;
                 },
                 _ => {
-                    try!(::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields()));
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
                 },
             };
         }
@@ -1899,8 +1976,8 @@ impl ::protobuf::Message for AccountOriginListResponse {
     #[allow(unused_variables)]
     fn compute_size(&self) -> u32 {
         let mut my_size = 0;
-        for value in &self.account_id {
-            my_size += ::protobuf::rt::value_size(1, *value, ::protobuf::wire_format::WireTypeVarint);
+        if let Some(v) = self.account_id {
+            my_size += ::protobuf::rt::value_size(1, v, ::protobuf::wire_format::WireTypeVarint);
         };
         for value in &self.origins {
             my_size += ::protobuf::rt::string_size(2, &value);
@@ -1912,12 +1989,12 @@ impl ::protobuf::Message for AccountOriginListResponse {
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.account_id {
-            try!(os.write_uint64(1, v));
+            os.write_uint64(1, v)?;
         };
         for v in &self.origins {
-            try!(os.write_string(2, &v));
+            os.write_string(2, &v)?;
         };
-        try!(os.write_unknown_fields(self.get_unknown_fields()));
+        os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
 
@@ -1933,12 +2010,14 @@ impl ::protobuf::Message for AccountOriginListResponse {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<AccountOriginListResponse>()
-    }
-
     fn as_any(&self) -> &::std::any::Any {
         self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -1959,14 +2038,15 @@ impl ::protobuf::MessageStatic for AccountOriginListResponse {
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_u64_accessor(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint64>(
                     "account_id",
-                    AccountOriginListResponse::has_account_id,
-                    AccountOriginListResponse::get_account_id,
+                    AccountOriginListResponse::get_account_id_for_reflect,
+                    AccountOriginListResponse::mut_account_id_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_string_accessor(
+                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
                     "origins",
-                    AccountOriginListResponse::get_origins,
+                    AccountOriginListResponse::get_origins_for_reflect,
+                    AccountOriginListResponse::mut_origins_for_reflect,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<AccountOriginListResponse>(
                     "AccountOriginListResponse",
@@ -1986,28 +2066,26 @@ impl ::protobuf::Clear for AccountOriginListResponse {
     }
 }
 
-impl ::std::cmp::PartialEq for AccountOriginListResponse {
-    fn eq(&self, other: &AccountOriginListResponse) -> bool {
-        self.account_id == other.account_id &&
-        self.origins == other.origins &&
-        self.unknown_fields == other.unknown_fields
-    }
-}
-
 impl ::std::fmt::Debug for AccountOriginListResponse {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
-#[derive(Clone,Default)]
+impl ::protobuf::reflect::ProtobufValue for AccountOriginListResponse {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Message(self)
+    }
+}
+
+#[derive(PartialEq,Clone,Default)]
 pub struct CheckOriginAccessRequest {
     // message oneof groups
     account_info: ::std::option::Option<CheckOriginAccessRequest_oneof_account_info>,
     origin_info: ::std::option::Option<CheckOriginAccessRequest_oneof_origin_info>,
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    cached_size: ::protobuf::CachedSize,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -2036,14 +2114,7 @@ impl CheckOriginAccessRequest {
             ptr: 0 as *const CheckOriginAccessRequest,
         };
         unsafe {
-            instance.get(|| {
-                CheckOriginAccessRequest {
-                    account_info: ::std::option::Option::None,
-                    origin_info: ::std::option::Option::None,
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
+            instance.get(CheckOriginAccessRequest::new)
         }
     }
 
@@ -2091,7 +2162,6 @@ impl CheckOriginAccessRequest {
     }
 
     // Mutable pointer to the field.
-    // If field is not initialized, it is initialized with default value first.
     pub fn mut_account_name(&mut self) -> &mut ::std::string::String {
         if let ::std::option::Option::Some(CheckOriginAccessRequest_oneof_account_info::account_name(_)) = self.account_info {
         } else {
@@ -2166,7 +2236,6 @@ impl CheckOriginAccessRequest {
     }
 
     // Mutable pointer to the field.
-    // If field is not initialized, it is initialized with default value first.
     pub fn mut_origin_name(&mut self) -> &mut ::std::string::String {
         if let ::std::option::Option::Some(CheckOriginAccessRequest_oneof_origin_info::origin_name(_)) = self.origin_info {
         } else {
@@ -2204,35 +2273,35 @@ impl ::protobuf::Message for CheckOriginAccessRequest {
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
-        while !try!(is.eof()) {
-            let (field_number, wire_type) = try!(is.read_tag_unpack());
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
                         return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
                     };
-                    self.account_info = ::std::option::Option::Some(CheckOriginAccessRequest_oneof_account_info::account_id(try!(is.read_uint64())));
+                    self.account_info = ::std::option::Option::Some(CheckOriginAccessRequest_oneof_account_info::account_id(is.read_uint64()?));
                 },
                 2 => {
                     if wire_type != ::protobuf::wire_format::WireTypeLengthDelimited {
                         return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
                     };
-                    self.account_info = ::std::option::Option::Some(CheckOriginAccessRequest_oneof_account_info::account_name(try!(is.read_string())));
+                    self.account_info = ::std::option::Option::Some(CheckOriginAccessRequest_oneof_account_info::account_name(is.read_string()?));
                 },
                 3 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
                         return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
                     };
-                    self.origin_info = ::std::option::Option::Some(CheckOriginAccessRequest_oneof_origin_info::origin_id(try!(is.read_uint64())));
+                    self.origin_info = ::std::option::Option::Some(CheckOriginAccessRequest_oneof_origin_info::origin_id(is.read_uint64()?));
                 },
                 4 => {
                     if wire_type != ::protobuf::wire_format::WireTypeLengthDelimited {
                         return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
                     };
-                    self.origin_info = ::std::option::Option::Some(CheckOriginAccessRequest_oneof_origin_info::origin_name(try!(is.read_string())));
+                    self.origin_info = ::std::option::Option::Some(CheckOriginAccessRequest_oneof_origin_info::origin_name(is.read_string()?));
                 },
                 _ => {
-                    try!(::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields()));
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
                 },
             };
         }
@@ -2272,24 +2341,24 @@ impl ::protobuf::Message for CheckOriginAccessRequest {
         if let ::std::option::Option::Some(ref v) = self.account_info {
             match v {
                 &CheckOriginAccessRequest_oneof_account_info::account_id(v) => {
-                    try!(os.write_uint64(1, v));
+                    os.write_uint64(1, v)?;
                 },
                 &CheckOriginAccessRequest_oneof_account_info::account_name(ref v) => {
-                    try!(os.write_string(2, v));
+                    os.write_string(2, v)?;
                 },
             };
         };
         if let ::std::option::Option::Some(ref v) = self.origin_info {
             match v {
                 &CheckOriginAccessRequest_oneof_origin_info::origin_id(v) => {
-                    try!(os.write_uint64(3, v));
+                    os.write_uint64(3, v)?;
                 },
                 &CheckOriginAccessRequest_oneof_origin_info::origin_name(ref v) => {
-                    try!(os.write_string(4, v));
+                    os.write_string(4, v)?;
                 },
             };
         };
-        try!(os.write_unknown_fields(self.get_unknown_fields()));
+        os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
 
@@ -2305,12 +2374,14 @@ impl ::protobuf::Message for CheckOriginAccessRequest {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<CheckOriginAccessRequest>()
-    }
-
     fn as_any(&self) -> &::std::any::Any {
         self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -2331,22 +2402,22 @@ impl ::protobuf::MessageStatic for CheckOriginAccessRequest {
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_u64_accessor(
+                fields.push(::protobuf::reflect::accessor::make_singular_u64_accessor::<_>(
                     "account_id",
                     CheckOriginAccessRequest::has_account_id,
                     CheckOriginAccessRequest::get_account_id,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_string_accessor(
+                fields.push(::protobuf::reflect::accessor::make_singular_string_accessor::<_>(
                     "account_name",
                     CheckOriginAccessRequest::has_account_name,
                     CheckOriginAccessRequest::get_account_name,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_u64_accessor(
+                fields.push(::protobuf::reflect::accessor::make_singular_u64_accessor::<_>(
                     "origin_id",
                     CheckOriginAccessRequest::has_origin_id,
                     CheckOriginAccessRequest::get_origin_id,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_string_accessor(
+                fields.push(::protobuf::reflect::accessor::make_singular_string_accessor::<_>(
                     "origin_name",
                     CheckOriginAccessRequest::has_origin_name,
                     CheckOriginAccessRequest::get_origin_name,
@@ -2371,27 +2442,25 @@ impl ::protobuf::Clear for CheckOriginAccessRequest {
     }
 }
 
-impl ::std::cmp::PartialEq for CheckOriginAccessRequest {
-    fn eq(&self, other: &CheckOriginAccessRequest) -> bool {
-        self.account_info == other.account_info &&
-        self.origin_info == other.origin_info &&
-        self.unknown_fields == other.unknown_fields
-    }
-}
-
 impl ::std::fmt::Debug for CheckOriginAccessRequest {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
-#[derive(Clone,Default)]
+impl ::protobuf::reflect::ProtobufValue for CheckOriginAccessRequest {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Message(self)
+    }
+}
+
+#[derive(PartialEq,Clone,Default)]
 pub struct CheckOriginAccessResponse {
     // message fields
     has_access: ::std::option::Option<bool>,
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    cached_size: ::protobuf::CachedSize,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -2408,13 +2477,7 @@ impl CheckOriginAccessResponse {
             ptr: 0 as *const CheckOriginAccessResponse,
         };
         unsafe {
-            instance.get(|| {
-                CheckOriginAccessResponse {
-                    has_access: ::std::option::Option::None,
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
+            instance.get(CheckOriginAccessResponse::new)
         }
     }
 
@@ -2436,6 +2499,14 @@ impl CheckOriginAccessResponse {
     pub fn get_has_access(&self) -> bool {
         self.has_access.unwrap_or(false)
     }
+
+    fn get_has_access_for_reflect(&self) -> &::std::option::Option<bool> {
+        &self.has_access
+    }
+
+    fn mut_has_access_for_reflect(&mut self) -> &mut ::std::option::Option<bool> {
+        &mut self.has_access
+    }
 }
 
 impl ::protobuf::Message for CheckOriginAccessResponse {
@@ -2447,18 +2518,18 @@ impl ::protobuf::Message for CheckOriginAccessResponse {
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
-        while !try!(is.eof()) {
-            let (field_number, wire_type) = try!(is.read_tag_unpack());
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
                         return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
                     };
-                    let tmp = try!(is.read_bool());
+                    let tmp = is.read_bool()?;
                     self.has_access = ::std::option::Option::Some(tmp);
                 },
                 _ => {
-                    try!(::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields()));
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
                 },
             };
         }
@@ -2469,7 +2540,7 @@ impl ::protobuf::Message for CheckOriginAccessResponse {
     #[allow(unused_variables)]
     fn compute_size(&self) -> u32 {
         let mut my_size = 0;
-        if self.has_access.is_some() {
+        if let Some(v) = self.has_access {
             my_size += 2;
         };
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
@@ -2479,9 +2550,9 @@ impl ::protobuf::Message for CheckOriginAccessResponse {
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.has_access {
-            try!(os.write_bool(1, v));
+            os.write_bool(1, v)?;
         };
-        try!(os.write_unknown_fields(self.get_unknown_fields()));
+        os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
 
@@ -2497,12 +2568,14 @@ impl ::protobuf::Message for CheckOriginAccessResponse {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<CheckOriginAccessResponse>()
-    }
-
     fn as_any(&self) -> &::std::any::Any {
         self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -2523,10 +2596,10 @@ impl ::protobuf::MessageStatic for CheckOriginAccessResponse {
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_bool_accessor(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeBool>(
                     "has_access",
-                    CheckOriginAccessResponse::has_has_access,
-                    CheckOriginAccessResponse::get_has_access,
+                    CheckOriginAccessResponse::get_has_access_for_reflect,
+                    CheckOriginAccessResponse::mut_has_access_for_reflect,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<CheckOriginAccessResponse>(
                     "CheckOriginAccessResponse",
@@ -2545,26 +2618,25 @@ impl ::protobuf::Clear for CheckOriginAccessResponse {
     }
 }
 
-impl ::std::cmp::PartialEq for CheckOriginAccessResponse {
-    fn eq(&self, other: &CheckOriginAccessResponse) -> bool {
-        self.has_access == other.has_access &&
-        self.unknown_fields == other.unknown_fields
-    }
-}
-
 impl ::std::fmt::Debug for CheckOriginAccessResponse {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
-#[derive(Clone,Default)]
+impl ::protobuf::reflect::ProtobufValue for CheckOriginAccessResponse {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Message(self)
+    }
+}
+
+#[derive(PartialEq,Clone,Default)]
 pub struct AccountInvitationListRequest {
     // message fields
     account_id: ::std::option::Option<u64>,
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    cached_size: ::protobuf::CachedSize,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -2581,13 +2653,7 @@ impl AccountInvitationListRequest {
             ptr: 0 as *const AccountInvitationListRequest,
         };
         unsafe {
-            instance.get(|| {
-                AccountInvitationListRequest {
-                    account_id: ::std::option::Option::None,
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
+            instance.get(AccountInvitationListRequest::new)
         }
     }
 
@@ -2609,6 +2675,14 @@ impl AccountInvitationListRequest {
     pub fn get_account_id(&self) -> u64 {
         self.account_id.unwrap_or(0)
     }
+
+    fn get_account_id_for_reflect(&self) -> &::std::option::Option<u64> {
+        &self.account_id
+    }
+
+    fn mut_account_id_for_reflect(&mut self) -> &mut ::std::option::Option<u64> {
+        &mut self.account_id
+    }
 }
 
 impl ::protobuf::Message for AccountInvitationListRequest {
@@ -2620,18 +2694,18 @@ impl ::protobuf::Message for AccountInvitationListRequest {
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
-        while !try!(is.eof()) {
-            let (field_number, wire_type) = try!(is.read_tag_unpack());
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
                         return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
                     };
-                    let tmp = try!(is.read_uint64());
+                    let tmp = is.read_uint64()?;
                     self.account_id = ::std::option::Option::Some(tmp);
                 },
                 _ => {
-                    try!(::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields()));
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
                 },
             };
         }
@@ -2642,8 +2716,8 @@ impl ::protobuf::Message for AccountInvitationListRequest {
     #[allow(unused_variables)]
     fn compute_size(&self) -> u32 {
         let mut my_size = 0;
-        for value in &self.account_id {
-            my_size += ::protobuf::rt::value_size(1, *value, ::protobuf::wire_format::WireTypeVarint);
+        if let Some(v) = self.account_id {
+            my_size += ::protobuf::rt::value_size(1, v, ::protobuf::wire_format::WireTypeVarint);
         };
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
         self.cached_size.set(my_size);
@@ -2652,9 +2726,9 @@ impl ::protobuf::Message for AccountInvitationListRequest {
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.account_id {
-            try!(os.write_uint64(1, v));
+            os.write_uint64(1, v)?;
         };
-        try!(os.write_unknown_fields(self.get_unknown_fields()));
+        os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
 
@@ -2670,12 +2744,14 @@ impl ::protobuf::Message for AccountInvitationListRequest {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<AccountInvitationListRequest>()
-    }
-
     fn as_any(&self) -> &::std::any::Any {
         self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -2696,10 +2772,10 @@ impl ::protobuf::MessageStatic for AccountInvitationListRequest {
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_u64_accessor(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint64>(
                     "account_id",
-                    AccountInvitationListRequest::has_account_id,
-                    AccountInvitationListRequest::get_account_id,
+                    AccountInvitationListRequest::get_account_id_for_reflect,
+                    AccountInvitationListRequest::mut_account_id_for_reflect,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<AccountInvitationListRequest>(
                     "AccountInvitationListRequest",
@@ -2718,27 +2794,26 @@ impl ::protobuf::Clear for AccountInvitationListRequest {
     }
 }
 
-impl ::std::cmp::PartialEq for AccountInvitationListRequest {
-    fn eq(&self, other: &AccountInvitationListRequest) -> bool {
-        self.account_id == other.account_id &&
-        self.unknown_fields == other.unknown_fields
-    }
-}
-
 impl ::std::fmt::Debug for AccountInvitationListRequest {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
-#[derive(Clone,Default)]
+impl ::protobuf::reflect::ProtobufValue for AccountInvitationListRequest {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Message(self)
+    }
+}
+
+#[derive(PartialEq,Clone,Default)]
 pub struct AccountInvitationListResponse {
     // message fields
     account_id: ::std::option::Option<u64>,
     invitations: ::protobuf::RepeatedField<OriginInvitation>,
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    cached_size: ::protobuf::CachedSize,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -2755,14 +2830,7 @@ impl AccountInvitationListResponse {
             ptr: 0 as *const AccountInvitationListResponse,
         };
         unsafe {
-            instance.get(|| {
-                AccountInvitationListResponse {
-                    account_id: ::std::option::Option::None,
-                    invitations: ::protobuf::RepeatedField::new(),
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
+            instance.get(AccountInvitationListResponse::new)
         }
     }
 
@@ -2785,6 +2853,14 @@ impl AccountInvitationListResponse {
         self.account_id.unwrap_or(0)
     }
 
+    fn get_account_id_for_reflect(&self) -> &::std::option::Option<u64> {
+        &self.account_id
+    }
+
+    fn mut_account_id_for_reflect(&mut self) -> &mut ::std::option::Option<u64> {
+        &mut self.account_id
+    }
+
     // repeated .vault.OriginInvitation invitations = 2;
 
     pub fn clear_invitations(&mut self) {
@@ -2809,6 +2885,14 @@ impl AccountInvitationListResponse {
     pub fn get_invitations(&self) -> &[OriginInvitation] {
         &self.invitations
     }
+
+    fn get_invitations_for_reflect(&self) -> &::protobuf::RepeatedField<OriginInvitation> {
+        &self.invitations
+    }
+
+    fn mut_invitations_for_reflect(&mut self) -> &mut ::protobuf::RepeatedField<OriginInvitation> {
+        &mut self.invitations
+    }
 }
 
 impl ::protobuf::Message for AccountInvitationListResponse {
@@ -2820,21 +2904,21 @@ impl ::protobuf::Message for AccountInvitationListResponse {
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
-        while !try!(is.eof()) {
-            let (field_number, wire_type) = try!(is.read_tag_unpack());
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
                         return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
                     };
-                    let tmp = try!(is.read_uint64());
+                    let tmp = is.read_uint64()?;
                     self.account_id = ::std::option::Option::Some(tmp);
                 },
                 2 => {
-                    try!(::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.invitations));
+                    ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.invitations)?;
                 },
                 _ => {
-                    try!(::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields()));
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
                 },
             };
         }
@@ -2845,8 +2929,8 @@ impl ::protobuf::Message for AccountInvitationListResponse {
     #[allow(unused_variables)]
     fn compute_size(&self) -> u32 {
         let mut my_size = 0;
-        for value in &self.account_id {
-            my_size += ::protobuf::rt::value_size(1, *value, ::protobuf::wire_format::WireTypeVarint);
+        if let Some(v) = self.account_id {
+            my_size += ::protobuf::rt::value_size(1, v, ::protobuf::wire_format::WireTypeVarint);
         };
         for value in &self.invitations {
             let len = value.compute_size();
@@ -2859,14 +2943,14 @@ impl ::protobuf::Message for AccountInvitationListResponse {
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.account_id {
-            try!(os.write_uint64(1, v));
+            os.write_uint64(1, v)?;
         };
         for v in &self.invitations {
-            try!(os.write_tag(2, ::protobuf::wire_format::WireTypeLengthDelimited));
-            try!(os.write_raw_varint32(v.get_cached_size()));
-            try!(v.write_to_with_cached_sizes(os));
+            os.write_tag(2, ::protobuf::wire_format::WireTypeLengthDelimited)?;
+            os.write_raw_varint32(v.get_cached_size())?;
+            v.write_to_with_cached_sizes(os)?;
         };
-        try!(os.write_unknown_fields(self.get_unknown_fields()));
+        os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
 
@@ -2882,12 +2966,14 @@ impl ::protobuf::Message for AccountInvitationListResponse {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<AccountInvitationListResponse>()
-    }
-
     fn as_any(&self) -> &::std::any::Any {
         self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -2908,14 +2994,15 @@ impl ::protobuf::MessageStatic for AccountInvitationListResponse {
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_u64_accessor(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint64>(
                     "account_id",
-                    AccountInvitationListResponse::has_account_id,
-                    AccountInvitationListResponse::get_account_id,
+                    AccountInvitationListResponse::get_account_id_for_reflect,
+                    AccountInvitationListResponse::mut_account_id_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_message_accessor(
+                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<OriginInvitation>>(
                     "invitations",
-                    AccountInvitationListResponse::get_invitations,
+                    AccountInvitationListResponse::get_invitations_for_reflect,
+                    AccountInvitationListResponse::mut_invitations_for_reflect,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<AccountInvitationListResponse>(
                     "AccountInvitationListResponse",
@@ -2935,27 +3022,25 @@ impl ::protobuf::Clear for AccountInvitationListResponse {
     }
 }
 
-impl ::std::cmp::PartialEq for AccountInvitationListResponse {
-    fn eq(&self, other: &AccountInvitationListResponse) -> bool {
-        self.account_id == other.account_id &&
-        self.invitations == other.invitations &&
-        self.unknown_fields == other.unknown_fields
-    }
-}
-
 impl ::std::fmt::Debug for AccountInvitationListResponse {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
-#[derive(Clone,Default)]
+impl ::protobuf::reflect::ProtobufValue for AccountInvitationListResponse {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Message(self)
+    }
+}
+
+#[derive(PartialEq,Clone,Default)]
 pub struct OriginInvitationListRequest {
     // message fields
     origin_id: ::std::option::Option<u64>,
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    cached_size: ::protobuf::CachedSize,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -2972,13 +3057,7 @@ impl OriginInvitationListRequest {
             ptr: 0 as *const OriginInvitationListRequest,
         };
         unsafe {
-            instance.get(|| {
-                OriginInvitationListRequest {
-                    origin_id: ::std::option::Option::None,
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
+            instance.get(OriginInvitationListRequest::new)
         }
     }
 
@@ -3000,6 +3079,14 @@ impl OriginInvitationListRequest {
     pub fn get_origin_id(&self) -> u64 {
         self.origin_id.unwrap_or(0)
     }
+
+    fn get_origin_id_for_reflect(&self) -> &::std::option::Option<u64> {
+        &self.origin_id
+    }
+
+    fn mut_origin_id_for_reflect(&mut self) -> &mut ::std::option::Option<u64> {
+        &mut self.origin_id
+    }
 }
 
 impl ::protobuf::Message for OriginInvitationListRequest {
@@ -3011,18 +3098,18 @@ impl ::protobuf::Message for OriginInvitationListRequest {
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
-        while !try!(is.eof()) {
-            let (field_number, wire_type) = try!(is.read_tag_unpack());
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
                         return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
                     };
-                    let tmp = try!(is.read_uint64());
+                    let tmp = is.read_uint64()?;
                     self.origin_id = ::std::option::Option::Some(tmp);
                 },
                 _ => {
-                    try!(::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields()));
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
                 },
             };
         }
@@ -3033,8 +3120,8 @@ impl ::protobuf::Message for OriginInvitationListRequest {
     #[allow(unused_variables)]
     fn compute_size(&self) -> u32 {
         let mut my_size = 0;
-        for value in &self.origin_id {
-            my_size += ::protobuf::rt::value_size(1, *value, ::protobuf::wire_format::WireTypeVarint);
+        if let Some(v) = self.origin_id {
+            my_size += ::protobuf::rt::value_size(1, v, ::protobuf::wire_format::WireTypeVarint);
         };
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
         self.cached_size.set(my_size);
@@ -3043,9 +3130,9 @@ impl ::protobuf::Message for OriginInvitationListRequest {
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.origin_id {
-            try!(os.write_uint64(1, v));
+            os.write_uint64(1, v)?;
         };
-        try!(os.write_unknown_fields(self.get_unknown_fields()));
+        os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
 
@@ -3061,12 +3148,14 @@ impl ::protobuf::Message for OriginInvitationListRequest {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<OriginInvitationListRequest>()
-    }
-
     fn as_any(&self) -> &::std::any::Any {
         self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -3087,10 +3176,10 @@ impl ::protobuf::MessageStatic for OriginInvitationListRequest {
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_u64_accessor(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint64>(
                     "origin_id",
-                    OriginInvitationListRequest::has_origin_id,
-                    OriginInvitationListRequest::get_origin_id,
+                    OriginInvitationListRequest::get_origin_id_for_reflect,
+                    OriginInvitationListRequest::mut_origin_id_for_reflect,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<OriginInvitationListRequest>(
                     "OriginInvitationListRequest",
@@ -3109,27 +3198,26 @@ impl ::protobuf::Clear for OriginInvitationListRequest {
     }
 }
 
-impl ::std::cmp::PartialEq for OriginInvitationListRequest {
-    fn eq(&self, other: &OriginInvitationListRequest) -> bool {
-        self.origin_id == other.origin_id &&
-        self.unknown_fields == other.unknown_fields
-    }
-}
-
 impl ::std::fmt::Debug for OriginInvitationListRequest {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
-#[derive(Clone,Default)]
+impl ::protobuf::reflect::ProtobufValue for OriginInvitationListRequest {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Message(self)
+    }
+}
+
+#[derive(PartialEq,Clone,Default)]
 pub struct OriginInvitationListResponse {
     // message fields
     origin_id: ::std::option::Option<u64>,
     invitations: ::protobuf::RepeatedField<OriginInvitation>,
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    cached_size: ::protobuf::CachedSize,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -3146,14 +3234,7 @@ impl OriginInvitationListResponse {
             ptr: 0 as *const OriginInvitationListResponse,
         };
         unsafe {
-            instance.get(|| {
-                OriginInvitationListResponse {
-                    origin_id: ::std::option::Option::None,
-                    invitations: ::protobuf::RepeatedField::new(),
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
+            instance.get(OriginInvitationListResponse::new)
         }
     }
 
@@ -3174,6 +3255,14 @@ impl OriginInvitationListResponse {
 
     pub fn get_origin_id(&self) -> u64 {
         self.origin_id.unwrap_or(0)
+    }
+
+    fn get_origin_id_for_reflect(&self) -> &::std::option::Option<u64> {
+        &self.origin_id
+    }
+
+    fn mut_origin_id_for_reflect(&mut self) -> &mut ::std::option::Option<u64> {
+        &mut self.origin_id
     }
 
     // repeated .vault.OriginInvitation invitations = 2;
@@ -3200,6 +3289,14 @@ impl OriginInvitationListResponse {
     pub fn get_invitations(&self) -> &[OriginInvitation] {
         &self.invitations
     }
+
+    fn get_invitations_for_reflect(&self) -> &::protobuf::RepeatedField<OriginInvitation> {
+        &self.invitations
+    }
+
+    fn mut_invitations_for_reflect(&mut self) -> &mut ::protobuf::RepeatedField<OriginInvitation> {
+        &mut self.invitations
+    }
 }
 
 impl ::protobuf::Message for OriginInvitationListResponse {
@@ -3211,21 +3308,21 @@ impl ::protobuf::Message for OriginInvitationListResponse {
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
-        while !try!(is.eof()) {
-            let (field_number, wire_type) = try!(is.read_tag_unpack());
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
                         return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
                     };
-                    let tmp = try!(is.read_uint64());
+                    let tmp = is.read_uint64()?;
                     self.origin_id = ::std::option::Option::Some(tmp);
                 },
                 2 => {
-                    try!(::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.invitations));
+                    ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.invitations)?;
                 },
                 _ => {
-                    try!(::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields()));
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
                 },
             };
         }
@@ -3236,8 +3333,8 @@ impl ::protobuf::Message for OriginInvitationListResponse {
     #[allow(unused_variables)]
     fn compute_size(&self) -> u32 {
         let mut my_size = 0;
-        for value in &self.origin_id {
-            my_size += ::protobuf::rt::value_size(1, *value, ::protobuf::wire_format::WireTypeVarint);
+        if let Some(v) = self.origin_id {
+            my_size += ::protobuf::rt::value_size(1, v, ::protobuf::wire_format::WireTypeVarint);
         };
         for value in &self.invitations {
             let len = value.compute_size();
@@ -3250,14 +3347,14 @@ impl ::protobuf::Message for OriginInvitationListResponse {
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.origin_id {
-            try!(os.write_uint64(1, v));
+            os.write_uint64(1, v)?;
         };
         for v in &self.invitations {
-            try!(os.write_tag(2, ::protobuf::wire_format::WireTypeLengthDelimited));
-            try!(os.write_raw_varint32(v.get_cached_size()));
-            try!(v.write_to_with_cached_sizes(os));
+            os.write_tag(2, ::protobuf::wire_format::WireTypeLengthDelimited)?;
+            os.write_raw_varint32(v.get_cached_size())?;
+            v.write_to_with_cached_sizes(os)?;
         };
-        try!(os.write_unknown_fields(self.get_unknown_fields()));
+        os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
 
@@ -3273,12 +3370,14 @@ impl ::protobuf::Message for OriginInvitationListResponse {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<OriginInvitationListResponse>()
-    }
-
     fn as_any(&self) -> &::std::any::Any {
         self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -3299,14 +3398,15 @@ impl ::protobuf::MessageStatic for OriginInvitationListResponse {
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_u64_accessor(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint64>(
                     "origin_id",
-                    OriginInvitationListResponse::has_origin_id,
-                    OriginInvitationListResponse::get_origin_id,
+                    OriginInvitationListResponse::get_origin_id_for_reflect,
+                    OriginInvitationListResponse::mut_origin_id_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_message_accessor(
+                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<OriginInvitation>>(
                     "invitations",
-                    OriginInvitationListResponse::get_invitations,
+                    OriginInvitationListResponse::get_invitations_for_reflect,
+                    OriginInvitationListResponse::mut_invitations_for_reflect,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<OriginInvitationListResponse>(
                     "OriginInvitationListResponse",
@@ -3326,21 +3426,19 @@ impl ::protobuf::Clear for OriginInvitationListResponse {
     }
 }
 
-impl ::std::cmp::PartialEq for OriginInvitationListResponse {
-    fn eq(&self, other: &OriginInvitationListResponse) -> bool {
-        self.origin_id == other.origin_id &&
-        self.invitations == other.invitations &&
-        self.unknown_fields == other.unknown_fields
-    }
-}
-
 impl ::std::fmt::Debug for OriginInvitationListResponse {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
-#[derive(Clone,Default)]
+impl ::protobuf::reflect::ProtobufValue for OriginInvitationListResponse {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Message(self)
+    }
+}
+
+#[derive(PartialEq,Clone,Default)]
 pub struct OriginInvitation {
     // message fields
     id: ::std::option::Option<u64>,
@@ -3351,7 +3449,7 @@ pub struct OriginInvitation {
     owner_id: ::std::option::Option<u64>,
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    cached_size: ::protobuf::CachedSize,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -3368,18 +3466,7 @@ impl OriginInvitation {
             ptr: 0 as *const OriginInvitation,
         };
         unsafe {
-            instance.get(|| {
-                OriginInvitation {
-                    id: ::std::option::Option::None,
-                    account_id: ::std::option::Option::None,
-                    account_name: ::protobuf::SingularField::none(),
-                    origin_id: ::std::option::Option::None,
-                    origin_name: ::protobuf::SingularField::none(),
-                    owner_id: ::std::option::Option::None,
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
+            instance.get(OriginInvitation::new)
         }
     }
 
@@ -3402,6 +3489,14 @@ impl OriginInvitation {
         self.id.unwrap_or(0)
     }
 
+    fn get_id_for_reflect(&self) -> &::std::option::Option<u64> {
+        &self.id
+    }
+
+    fn mut_id_for_reflect(&mut self) -> &mut ::std::option::Option<u64> {
+        &mut self.id
+    }
+
     // required uint64 account_id = 2;
 
     pub fn clear_account_id(&mut self) {
@@ -3419,6 +3514,14 @@ impl OriginInvitation {
 
     pub fn get_account_id(&self) -> u64 {
         self.account_id.unwrap_or(0)
+    }
+
+    fn get_account_id_for_reflect(&self) -> &::std::option::Option<u64> {
+        &self.account_id
+    }
+
+    fn mut_account_id_for_reflect(&mut self) -> &mut ::std::option::Option<u64> {
+        &mut self.account_id
     }
 
     // required string account_name = 3;
@@ -3457,6 +3560,14 @@ impl OriginInvitation {
         }
     }
 
+    fn get_account_name_for_reflect(&self) -> &::protobuf::SingularField<::std::string::String> {
+        &self.account_name
+    }
+
+    fn mut_account_name_for_reflect(&mut self) -> &mut ::protobuf::SingularField<::std::string::String> {
+        &mut self.account_name
+    }
+
     // required uint64 origin_id = 4;
 
     pub fn clear_origin_id(&mut self) {
@@ -3474,6 +3585,14 @@ impl OriginInvitation {
 
     pub fn get_origin_id(&self) -> u64 {
         self.origin_id.unwrap_or(0)
+    }
+
+    fn get_origin_id_for_reflect(&self) -> &::std::option::Option<u64> {
+        &self.origin_id
+    }
+
+    fn mut_origin_id_for_reflect(&mut self) -> &mut ::std::option::Option<u64> {
+        &mut self.origin_id
     }
 
     // required string origin_name = 5;
@@ -3512,6 +3631,14 @@ impl OriginInvitation {
         }
     }
 
+    fn get_origin_name_for_reflect(&self) -> &::protobuf::SingularField<::std::string::String> {
+        &self.origin_name
+    }
+
+    fn mut_origin_name_for_reflect(&mut self) -> &mut ::protobuf::SingularField<::std::string::String> {
+        &mut self.origin_name
+    }
+
     // required uint64 owner_id = 6;
 
     pub fn clear_owner_id(&mut self) {
@@ -3529,6 +3656,14 @@ impl OriginInvitation {
 
     pub fn get_owner_id(&self) -> u64 {
         self.owner_id.unwrap_or(0)
+    }
+
+    fn get_owner_id_for_reflect(&self) -> &::std::option::Option<u64> {
+        &self.owner_id
+    }
+
+    fn mut_owner_id_for_reflect(&mut self) -> &mut ::std::option::Option<u64> {
+        &mut self.owner_id
     }
 }
 
@@ -3556,45 +3691,45 @@ impl ::protobuf::Message for OriginInvitation {
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
-        while !try!(is.eof()) {
-            let (field_number, wire_type) = try!(is.read_tag_unpack());
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
                         return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
                     };
-                    let tmp = try!(is.read_uint64());
+                    let tmp = is.read_uint64()?;
                     self.id = ::std::option::Option::Some(tmp);
                 },
                 2 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
                         return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
                     };
-                    let tmp = try!(is.read_uint64());
+                    let tmp = is.read_uint64()?;
                     self.account_id = ::std::option::Option::Some(tmp);
                 },
                 3 => {
-                    try!(::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.account_name));
+                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.account_name)?;
                 },
                 4 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
                         return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
                     };
-                    let tmp = try!(is.read_uint64());
+                    let tmp = is.read_uint64()?;
                     self.origin_id = ::std::option::Option::Some(tmp);
                 },
                 5 => {
-                    try!(::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.origin_name));
+                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.origin_name)?;
                 },
                 6 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
                         return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
                     };
-                    let tmp = try!(is.read_uint64());
+                    let tmp = is.read_uint64()?;
                     self.owner_id = ::std::option::Option::Some(tmp);
                 },
                 _ => {
-                    try!(::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields()));
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
                 },
             };
         }
@@ -3605,23 +3740,23 @@ impl ::protobuf::Message for OriginInvitation {
     #[allow(unused_variables)]
     fn compute_size(&self) -> u32 {
         let mut my_size = 0;
-        for value in &self.id {
-            my_size += ::protobuf::rt::value_size(1, *value, ::protobuf::wire_format::WireTypeVarint);
+        if let Some(v) = self.id {
+            my_size += ::protobuf::rt::value_size(1, v, ::protobuf::wire_format::WireTypeVarint);
         };
-        for value in &self.account_id {
-            my_size += ::protobuf::rt::value_size(2, *value, ::protobuf::wire_format::WireTypeVarint);
+        if let Some(v) = self.account_id {
+            my_size += ::protobuf::rt::value_size(2, v, ::protobuf::wire_format::WireTypeVarint);
         };
-        for value in &self.account_name {
-            my_size += ::protobuf::rt::string_size(3, &value);
+        if let Some(v) = self.account_name.as_ref() {
+            my_size += ::protobuf::rt::string_size(3, &v);
         };
-        for value in &self.origin_id {
-            my_size += ::protobuf::rt::value_size(4, *value, ::protobuf::wire_format::WireTypeVarint);
+        if let Some(v) = self.origin_id {
+            my_size += ::protobuf::rt::value_size(4, v, ::protobuf::wire_format::WireTypeVarint);
         };
-        for value in &self.origin_name {
-            my_size += ::protobuf::rt::string_size(5, &value);
+        if let Some(v) = self.origin_name.as_ref() {
+            my_size += ::protobuf::rt::string_size(5, &v);
         };
-        for value in &self.owner_id {
-            my_size += ::protobuf::rt::value_size(6, *value, ::protobuf::wire_format::WireTypeVarint);
+        if let Some(v) = self.owner_id {
+            my_size += ::protobuf::rt::value_size(6, v, ::protobuf::wire_format::WireTypeVarint);
         };
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
         self.cached_size.set(my_size);
@@ -3630,24 +3765,24 @@ impl ::protobuf::Message for OriginInvitation {
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.id {
-            try!(os.write_uint64(1, v));
+            os.write_uint64(1, v)?;
         };
         if let Some(v) = self.account_id {
-            try!(os.write_uint64(2, v));
+            os.write_uint64(2, v)?;
         };
         if let Some(v) = self.account_name.as_ref() {
-            try!(os.write_string(3, &v));
+            os.write_string(3, &v)?;
         };
         if let Some(v) = self.origin_id {
-            try!(os.write_uint64(4, v));
+            os.write_uint64(4, v)?;
         };
         if let Some(v) = self.origin_name.as_ref() {
-            try!(os.write_string(5, &v));
+            os.write_string(5, &v)?;
         };
         if let Some(v) = self.owner_id {
-            try!(os.write_uint64(6, v));
+            os.write_uint64(6, v)?;
         };
-        try!(os.write_unknown_fields(self.get_unknown_fields()));
+        os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
 
@@ -3663,12 +3798,14 @@ impl ::protobuf::Message for OriginInvitation {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<OriginInvitation>()
-    }
-
     fn as_any(&self) -> &::std::any::Any {
         self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -3689,35 +3826,35 @@ impl ::protobuf::MessageStatic for OriginInvitation {
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_u64_accessor(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint64>(
                     "id",
-                    OriginInvitation::has_id,
-                    OriginInvitation::get_id,
+                    OriginInvitation::get_id_for_reflect,
+                    OriginInvitation::mut_id_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_u64_accessor(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint64>(
                     "account_id",
-                    OriginInvitation::has_account_id,
-                    OriginInvitation::get_account_id,
+                    OriginInvitation::get_account_id_for_reflect,
+                    OriginInvitation::mut_account_id_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_string_accessor(
+                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
                     "account_name",
-                    OriginInvitation::has_account_name,
-                    OriginInvitation::get_account_name,
+                    OriginInvitation::get_account_name_for_reflect,
+                    OriginInvitation::mut_account_name_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_u64_accessor(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint64>(
                     "origin_id",
-                    OriginInvitation::has_origin_id,
-                    OriginInvitation::get_origin_id,
+                    OriginInvitation::get_origin_id_for_reflect,
+                    OriginInvitation::mut_origin_id_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_string_accessor(
+                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
                     "origin_name",
-                    OriginInvitation::has_origin_name,
-                    OriginInvitation::get_origin_name,
+                    OriginInvitation::get_origin_name_for_reflect,
+                    OriginInvitation::mut_origin_name_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_u64_accessor(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint64>(
                     "owner_id",
-                    OriginInvitation::has_owner_id,
-                    OriginInvitation::get_owner_id,
+                    OriginInvitation::get_owner_id_for_reflect,
+                    OriginInvitation::mut_owner_id_for_reflect,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<OriginInvitation>(
                     "OriginInvitation",
@@ -3741,25 +3878,19 @@ impl ::protobuf::Clear for OriginInvitation {
     }
 }
 
-impl ::std::cmp::PartialEq for OriginInvitation {
-    fn eq(&self, other: &OriginInvitation) -> bool {
-        self.id == other.id &&
-        self.account_id == other.account_id &&
-        self.account_name == other.account_name &&
-        self.origin_id == other.origin_id &&
-        self.origin_name == other.origin_name &&
-        self.owner_id == other.owner_id &&
-        self.unknown_fields == other.unknown_fields
-    }
-}
-
 impl ::std::fmt::Debug for OriginInvitation {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
-#[derive(Clone,Default)]
+impl ::protobuf::reflect::ProtobufValue for OriginInvitation {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Message(self)
+    }
+}
+
+#[derive(PartialEq,Clone,Default)]
 pub struct OriginInvitationCreate {
     // message fields
     account_id: ::std::option::Option<u64>,
@@ -3769,7 +3900,7 @@ pub struct OriginInvitationCreate {
     owner_id: ::std::option::Option<u64>,
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    cached_size: ::protobuf::CachedSize,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -3786,17 +3917,7 @@ impl OriginInvitationCreate {
             ptr: 0 as *const OriginInvitationCreate,
         };
         unsafe {
-            instance.get(|| {
-                OriginInvitationCreate {
-                    account_id: ::std::option::Option::None,
-                    account_name: ::protobuf::SingularField::none(),
-                    origin_id: ::std::option::Option::None,
-                    origin_name: ::protobuf::SingularField::none(),
-                    owner_id: ::std::option::Option::None,
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
+            instance.get(OriginInvitationCreate::new)
         }
     }
 
@@ -3817,6 +3938,14 @@ impl OriginInvitationCreate {
 
     pub fn get_account_id(&self) -> u64 {
         self.account_id.unwrap_or(0)
+    }
+
+    fn get_account_id_for_reflect(&self) -> &::std::option::Option<u64> {
+        &self.account_id
+    }
+
+    fn mut_account_id_for_reflect(&mut self) -> &mut ::std::option::Option<u64> {
+        &mut self.account_id
     }
 
     // required string account_name = 2;
@@ -3855,6 +3984,14 @@ impl OriginInvitationCreate {
         }
     }
 
+    fn get_account_name_for_reflect(&self) -> &::protobuf::SingularField<::std::string::String> {
+        &self.account_name
+    }
+
+    fn mut_account_name_for_reflect(&mut self) -> &mut ::protobuf::SingularField<::std::string::String> {
+        &mut self.account_name
+    }
+
     // required uint64 origin_id = 3;
 
     pub fn clear_origin_id(&mut self) {
@@ -3872,6 +4009,14 @@ impl OriginInvitationCreate {
 
     pub fn get_origin_id(&self) -> u64 {
         self.origin_id.unwrap_or(0)
+    }
+
+    fn get_origin_id_for_reflect(&self) -> &::std::option::Option<u64> {
+        &self.origin_id
+    }
+
+    fn mut_origin_id_for_reflect(&mut self) -> &mut ::std::option::Option<u64> {
+        &mut self.origin_id
     }
 
     // required string origin_name = 4;
@@ -3910,6 +4055,14 @@ impl OriginInvitationCreate {
         }
     }
 
+    fn get_origin_name_for_reflect(&self) -> &::protobuf::SingularField<::std::string::String> {
+        &self.origin_name
+    }
+
+    fn mut_origin_name_for_reflect(&mut self) -> &mut ::protobuf::SingularField<::std::string::String> {
+        &mut self.origin_name
+    }
+
     // required uint64 owner_id = 5;
 
     pub fn clear_owner_id(&mut self) {
@@ -3927,6 +4080,14 @@ impl OriginInvitationCreate {
 
     pub fn get_owner_id(&self) -> u64 {
         self.owner_id.unwrap_or(0)
+    }
+
+    fn get_owner_id_for_reflect(&self) -> &::std::option::Option<u64> {
+        &self.owner_id
+    }
+
+    fn mut_owner_id_for_reflect(&mut self) -> &mut ::std::option::Option<u64> {
+        &mut self.owner_id
     }
 }
 
@@ -3951,38 +4112,38 @@ impl ::protobuf::Message for OriginInvitationCreate {
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
-        while !try!(is.eof()) {
-            let (field_number, wire_type) = try!(is.read_tag_unpack());
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
                         return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
                     };
-                    let tmp = try!(is.read_uint64());
+                    let tmp = is.read_uint64()?;
                     self.account_id = ::std::option::Option::Some(tmp);
                 },
                 2 => {
-                    try!(::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.account_name));
+                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.account_name)?;
                 },
                 3 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
                         return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
                     };
-                    let tmp = try!(is.read_uint64());
+                    let tmp = is.read_uint64()?;
                     self.origin_id = ::std::option::Option::Some(tmp);
                 },
                 4 => {
-                    try!(::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.origin_name));
+                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.origin_name)?;
                 },
                 5 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
                         return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
                     };
-                    let tmp = try!(is.read_uint64());
+                    let tmp = is.read_uint64()?;
                     self.owner_id = ::std::option::Option::Some(tmp);
                 },
                 _ => {
-                    try!(::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields()));
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
                 },
             };
         }
@@ -3993,20 +4154,20 @@ impl ::protobuf::Message for OriginInvitationCreate {
     #[allow(unused_variables)]
     fn compute_size(&self) -> u32 {
         let mut my_size = 0;
-        for value in &self.account_id {
-            my_size += ::protobuf::rt::value_size(1, *value, ::protobuf::wire_format::WireTypeVarint);
+        if let Some(v) = self.account_id {
+            my_size += ::protobuf::rt::value_size(1, v, ::protobuf::wire_format::WireTypeVarint);
         };
-        for value in &self.account_name {
-            my_size += ::protobuf::rt::string_size(2, &value);
+        if let Some(v) = self.account_name.as_ref() {
+            my_size += ::protobuf::rt::string_size(2, &v);
         };
-        for value in &self.origin_id {
-            my_size += ::protobuf::rt::value_size(3, *value, ::protobuf::wire_format::WireTypeVarint);
+        if let Some(v) = self.origin_id {
+            my_size += ::protobuf::rt::value_size(3, v, ::protobuf::wire_format::WireTypeVarint);
         };
-        for value in &self.origin_name {
-            my_size += ::protobuf::rt::string_size(4, &value);
+        if let Some(v) = self.origin_name.as_ref() {
+            my_size += ::protobuf::rt::string_size(4, &v);
         };
-        for value in &self.owner_id {
-            my_size += ::protobuf::rt::value_size(5, *value, ::protobuf::wire_format::WireTypeVarint);
+        if let Some(v) = self.owner_id {
+            my_size += ::protobuf::rt::value_size(5, v, ::protobuf::wire_format::WireTypeVarint);
         };
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
         self.cached_size.set(my_size);
@@ -4015,21 +4176,21 @@ impl ::protobuf::Message for OriginInvitationCreate {
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.account_id {
-            try!(os.write_uint64(1, v));
+            os.write_uint64(1, v)?;
         };
         if let Some(v) = self.account_name.as_ref() {
-            try!(os.write_string(2, &v));
+            os.write_string(2, &v)?;
         };
         if let Some(v) = self.origin_id {
-            try!(os.write_uint64(3, v));
+            os.write_uint64(3, v)?;
         };
         if let Some(v) = self.origin_name.as_ref() {
-            try!(os.write_string(4, &v));
+            os.write_string(4, &v)?;
         };
         if let Some(v) = self.owner_id {
-            try!(os.write_uint64(5, v));
+            os.write_uint64(5, v)?;
         };
-        try!(os.write_unknown_fields(self.get_unknown_fields()));
+        os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
 
@@ -4045,12 +4206,14 @@ impl ::protobuf::Message for OriginInvitationCreate {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<OriginInvitationCreate>()
-    }
-
     fn as_any(&self) -> &::std::any::Any {
         self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -4071,30 +4234,30 @@ impl ::protobuf::MessageStatic for OriginInvitationCreate {
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_u64_accessor(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint64>(
                     "account_id",
-                    OriginInvitationCreate::has_account_id,
-                    OriginInvitationCreate::get_account_id,
+                    OriginInvitationCreate::get_account_id_for_reflect,
+                    OriginInvitationCreate::mut_account_id_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_string_accessor(
+                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
                     "account_name",
-                    OriginInvitationCreate::has_account_name,
-                    OriginInvitationCreate::get_account_name,
+                    OriginInvitationCreate::get_account_name_for_reflect,
+                    OriginInvitationCreate::mut_account_name_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_u64_accessor(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint64>(
                     "origin_id",
-                    OriginInvitationCreate::has_origin_id,
-                    OriginInvitationCreate::get_origin_id,
+                    OriginInvitationCreate::get_origin_id_for_reflect,
+                    OriginInvitationCreate::mut_origin_id_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_string_accessor(
+                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
                     "origin_name",
-                    OriginInvitationCreate::has_origin_name,
-                    OriginInvitationCreate::get_origin_name,
+                    OriginInvitationCreate::get_origin_name_for_reflect,
+                    OriginInvitationCreate::mut_origin_name_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_u64_accessor(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint64>(
                     "owner_id",
-                    OriginInvitationCreate::has_owner_id,
-                    OriginInvitationCreate::get_owner_id,
+                    OriginInvitationCreate::get_owner_id_for_reflect,
+                    OriginInvitationCreate::mut_owner_id_for_reflect,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<OriginInvitationCreate>(
                     "OriginInvitationCreate",
@@ -4117,24 +4280,19 @@ impl ::protobuf::Clear for OriginInvitationCreate {
     }
 }
 
-impl ::std::cmp::PartialEq for OriginInvitationCreate {
-    fn eq(&self, other: &OriginInvitationCreate) -> bool {
-        self.account_id == other.account_id &&
-        self.account_name == other.account_name &&
-        self.origin_id == other.origin_id &&
-        self.origin_name == other.origin_name &&
-        self.owner_id == other.owner_id &&
-        self.unknown_fields == other.unknown_fields
-    }
-}
-
 impl ::std::fmt::Debug for OriginInvitationCreate {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
-#[derive(Clone,Default)]
+impl ::protobuf::reflect::ProtobufValue for OriginInvitationCreate {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Message(self)
+    }
+}
+
+#[derive(PartialEq,Clone,Default)]
 pub struct OriginInvitationAcceptRequest {
     // message fields
     account_accepting_request: ::std::option::Option<u64>,
@@ -4142,7 +4300,7 @@ pub struct OriginInvitationAcceptRequest {
     ignore: ::std::option::Option<bool>,
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    cached_size: ::protobuf::CachedSize,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -4159,15 +4317,7 @@ impl OriginInvitationAcceptRequest {
             ptr: 0 as *const OriginInvitationAcceptRequest,
         };
         unsafe {
-            instance.get(|| {
-                OriginInvitationAcceptRequest {
-                    account_accepting_request: ::std::option::Option::None,
-                    invite_id: ::std::option::Option::None,
-                    ignore: ::std::option::Option::None,
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
+            instance.get(OriginInvitationAcceptRequest::new)
         }
     }
 
@@ -4190,6 +4340,14 @@ impl OriginInvitationAcceptRequest {
         self.account_accepting_request.unwrap_or(0)
     }
 
+    fn get_account_accepting_request_for_reflect(&self) -> &::std::option::Option<u64> {
+        &self.account_accepting_request
+    }
+
+    fn mut_account_accepting_request_for_reflect(&mut self) -> &mut ::std::option::Option<u64> {
+        &mut self.account_accepting_request
+    }
+
     // required uint64 invite_id = 2;
 
     pub fn clear_invite_id(&mut self) {
@@ -4207,6 +4365,14 @@ impl OriginInvitationAcceptRequest {
 
     pub fn get_invite_id(&self) -> u64 {
         self.invite_id.unwrap_or(0)
+    }
+
+    fn get_invite_id_for_reflect(&self) -> &::std::option::Option<u64> {
+        &self.invite_id
+    }
+
+    fn mut_invite_id_for_reflect(&mut self) -> &mut ::std::option::Option<u64> {
+        &mut self.invite_id
     }
 
     // required bool ignore = 3;
@@ -4227,6 +4393,14 @@ impl OriginInvitationAcceptRequest {
     pub fn get_ignore(&self) -> bool {
         self.ignore.unwrap_or(false)
     }
+
+    fn get_ignore_for_reflect(&self) -> &::std::option::Option<bool> {
+        &self.ignore
+    }
+
+    fn mut_ignore_for_reflect(&mut self) -> &mut ::std::option::Option<bool> {
+        &mut self.ignore
+    }
 }
 
 impl ::protobuf::Message for OriginInvitationAcceptRequest {
@@ -4244,32 +4418,32 @@ impl ::protobuf::Message for OriginInvitationAcceptRequest {
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
-        while !try!(is.eof()) {
-            let (field_number, wire_type) = try!(is.read_tag_unpack());
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
                         return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
                     };
-                    let tmp = try!(is.read_uint64());
+                    let tmp = is.read_uint64()?;
                     self.account_accepting_request = ::std::option::Option::Some(tmp);
                 },
                 2 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
                         return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
                     };
-                    let tmp = try!(is.read_uint64());
+                    let tmp = is.read_uint64()?;
                     self.invite_id = ::std::option::Option::Some(tmp);
                 },
                 3 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
                         return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
                     };
-                    let tmp = try!(is.read_bool());
+                    let tmp = is.read_bool()?;
                     self.ignore = ::std::option::Option::Some(tmp);
                 },
                 _ => {
-                    try!(::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields()));
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
                 },
             };
         }
@@ -4280,13 +4454,13 @@ impl ::protobuf::Message for OriginInvitationAcceptRequest {
     #[allow(unused_variables)]
     fn compute_size(&self) -> u32 {
         let mut my_size = 0;
-        for value in &self.account_accepting_request {
-            my_size += ::protobuf::rt::value_size(1, *value, ::protobuf::wire_format::WireTypeVarint);
+        if let Some(v) = self.account_accepting_request {
+            my_size += ::protobuf::rt::value_size(1, v, ::protobuf::wire_format::WireTypeVarint);
         };
-        for value in &self.invite_id {
-            my_size += ::protobuf::rt::value_size(2, *value, ::protobuf::wire_format::WireTypeVarint);
+        if let Some(v) = self.invite_id {
+            my_size += ::protobuf::rt::value_size(2, v, ::protobuf::wire_format::WireTypeVarint);
         };
-        if self.ignore.is_some() {
+        if let Some(v) = self.ignore {
             my_size += 2;
         };
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
@@ -4296,15 +4470,15 @@ impl ::protobuf::Message for OriginInvitationAcceptRequest {
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.account_accepting_request {
-            try!(os.write_uint64(1, v));
+            os.write_uint64(1, v)?;
         };
         if let Some(v) = self.invite_id {
-            try!(os.write_uint64(2, v));
+            os.write_uint64(2, v)?;
         };
         if let Some(v) = self.ignore {
-            try!(os.write_bool(3, v));
+            os.write_bool(3, v)?;
         };
-        try!(os.write_unknown_fields(self.get_unknown_fields()));
+        os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
 
@@ -4320,12 +4494,14 @@ impl ::protobuf::Message for OriginInvitationAcceptRequest {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<OriginInvitationAcceptRequest>()
-    }
-
     fn as_any(&self) -> &::std::any::Any {
         self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -4346,20 +4522,20 @@ impl ::protobuf::MessageStatic for OriginInvitationAcceptRequest {
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_u64_accessor(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint64>(
                     "account_accepting_request",
-                    OriginInvitationAcceptRequest::has_account_accepting_request,
-                    OriginInvitationAcceptRequest::get_account_accepting_request,
+                    OriginInvitationAcceptRequest::get_account_accepting_request_for_reflect,
+                    OriginInvitationAcceptRequest::mut_account_accepting_request_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_u64_accessor(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint64>(
                     "invite_id",
-                    OriginInvitationAcceptRequest::has_invite_id,
-                    OriginInvitationAcceptRequest::get_invite_id,
+                    OriginInvitationAcceptRequest::get_invite_id_for_reflect,
+                    OriginInvitationAcceptRequest::mut_invite_id_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_bool_accessor(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeBool>(
                     "ignore",
-                    OriginInvitationAcceptRequest::has_ignore,
-                    OriginInvitationAcceptRequest::get_ignore,
+                    OriginInvitationAcceptRequest::get_ignore_for_reflect,
+                    OriginInvitationAcceptRequest::mut_ignore_for_reflect,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<OriginInvitationAcceptRequest>(
                     "OriginInvitationAcceptRequest",
@@ -4380,26 +4556,23 @@ impl ::protobuf::Clear for OriginInvitationAcceptRequest {
     }
 }
 
-impl ::std::cmp::PartialEq for OriginInvitationAcceptRequest {
-    fn eq(&self, other: &OriginInvitationAcceptRequest) -> bool {
-        self.account_accepting_request == other.account_accepting_request &&
-        self.invite_id == other.invite_id &&
-        self.ignore == other.ignore &&
-        self.unknown_fields == other.unknown_fields
-    }
-}
-
 impl ::std::fmt::Debug for OriginInvitationAcceptRequest {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
-#[derive(Clone,Default)]
+impl ::protobuf::reflect::ProtobufValue for OriginInvitationAcceptRequest {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Message(self)
+    }
+}
+
+#[derive(PartialEq,Clone,Default)]
 pub struct OriginInvitationAcceptResponse {
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    cached_size: ::protobuf::CachedSize,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -4416,12 +4589,7 @@ impl OriginInvitationAcceptResponse {
             ptr: 0 as *const OriginInvitationAcceptResponse,
         };
         unsafe {
-            instance.get(|| {
-                OriginInvitationAcceptResponse {
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
+            instance.get(OriginInvitationAcceptResponse::new)
         }
     }
 }
@@ -4432,11 +4600,11 @@ impl ::protobuf::Message for OriginInvitationAcceptResponse {
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
-        while !try!(is.eof()) {
-            let (field_number, wire_type) = try!(is.read_tag_unpack());
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 _ => {
-                    try!(::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields()));
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
                 },
             };
         }
@@ -4453,7 +4621,7 @@ impl ::protobuf::Message for OriginInvitationAcceptResponse {
     }
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
-        try!(os.write_unknown_fields(self.get_unknown_fields()));
+        os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
 
@@ -4469,12 +4637,14 @@ impl ::protobuf::Message for OriginInvitationAcceptResponse {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<OriginInvitationAcceptResponse>()
-    }
-
     fn as_any(&self) -> &::std::any::Any {
         self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -4511,19 +4681,19 @@ impl ::protobuf::Clear for OriginInvitationAcceptResponse {
     }
 }
 
-impl ::std::cmp::PartialEq for OriginInvitationAcceptResponse {
-    fn eq(&self, other: &OriginInvitationAcceptResponse) -> bool {
-        self.unknown_fields == other.unknown_fields
-    }
-}
-
 impl ::std::fmt::Debug for OriginInvitationAcceptResponse {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
-#[derive(Clone,Default)]
+impl ::protobuf::reflect::ProtobufValue for OriginInvitationAcceptResponse {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Message(self)
+    }
+}
+
+#[derive(PartialEq,Clone,Default)]
 pub struct OriginSecretKey {
     // message fields
     id: ::std::option::Option<u64>,
@@ -4534,7 +4704,7 @@ pub struct OriginSecretKey {
     owner_id: ::std::option::Option<u64>,
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    cached_size: ::protobuf::CachedSize,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -4551,18 +4721,7 @@ impl OriginSecretKey {
             ptr: 0 as *const OriginSecretKey,
         };
         unsafe {
-            instance.get(|| {
-                OriginSecretKey {
-                    id: ::std::option::Option::None,
-                    origin_id: ::std::option::Option::None,
-                    name: ::protobuf::SingularField::none(),
-                    revision: ::protobuf::SingularField::none(),
-                    body: ::protobuf::SingularField::none(),
-                    owner_id: ::std::option::Option::None,
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
+            instance.get(OriginSecretKey::new)
         }
     }
 
@@ -4585,6 +4744,14 @@ impl OriginSecretKey {
         self.id.unwrap_or(0)
     }
 
+    fn get_id_for_reflect(&self) -> &::std::option::Option<u64> {
+        &self.id
+    }
+
+    fn mut_id_for_reflect(&mut self) -> &mut ::std::option::Option<u64> {
+        &mut self.id
+    }
+
     // required uint64 origin_id = 2;
 
     pub fn clear_origin_id(&mut self) {
@@ -4602,6 +4769,14 @@ impl OriginSecretKey {
 
     pub fn get_origin_id(&self) -> u64 {
         self.origin_id.unwrap_or(0)
+    }
+
+    fn get_origin_id_for_reflect(&self) -> &::std::option::Option<u64> {
+        &self.origin_id
+    }
+
+    fn mut_origin_id_for_reflect(&mut self) -> &mut ::std::option::Option<u64> {
+        &mut self.origin_id
     }
 
     // required string name = 3;
@@ -4640,6 +4815,14 @@ impl OriginSecretKey {
         }
     }
 
+    fn get_name_for_reflect(&self) -> &::protobuf::SingularField<::std::string::String> {
+        &self.name
+    }
+
+    fn mut_name_for_reflect(&mut self) -> &mut ::protobuf::SingularField<::std::string::String> {
+        &mut self.name
+    }
+
     // required string revision = 4;
 
     pub fn clear_revision(&mut self) {
@@ -4674,6 +4857,14 @@ impl OriginSecretKey {
             Some(v) => &v,
             None => "",
         }
+    }
+
+    fn get_revision_for_reflect(&self) -> &::protobuf::SingularField<::std::string::String> {
+        &self.revision
+    }
+
+    fn mut_revision_for_reflect(&mut self) -> &mut ::protobuf::SingularField<::std::string::String> {
+        &mut self.revision
     }
 
     // required bytes body = 5;
@@ -4712,6 +4903,14 @@ impl OriginSecretKey {
         }
     }
 
+    fn get_body_for_reflect(&self) -> &::protobuf::SingularField<::std::vec::Vec<u8>> {
+        &self.body
+    }
+
+    fn mut_body_for_reflect(&mut self) -> &mut ::protobuf::SingularField<::std::vec::Vec<u8>> {
+        &mut self.body
+    }
+
     // required uint64 owner_id = 6;
 
     pub fn clear_owner_id(&mut self) {
@@ -4729,6 +4928,14 @@ impl OriginSecretKey {
 
     pub fn get_owner_id(&self) -> u64 {
         self.owner_id.unwrap_or(0)
+    }
+
+    fn get_owner_id_for_reflect(&self) -> &::std::option::Option<u64> {
+        &self.owner_id
+    }
+
+    fn mut_owner_id_for_reflect(&mut self) -> &mut ::std::option::Option<u64> {
+        &mut self.owner_id
     }
 }
 
@@ -4756,41 +4963,41 @@ impl ::protobuf::Message for OriginSecretKey {
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
-        while !try!(is.eof()) {
-            let (field_number, wire_type) = try!(is.read_tag_unpack());
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
                         return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
                     };
-                    let tmp = try!(is.read_uint64());
+                    let tmp = is.read_uint64()?;
                     self.id = ::std::option::Option::Some(tmp);
                 },
                 2 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
                         return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
                     };
-                    let tmp = try!(is.read_uint64());
+                    let tmp = is.read_uint64()?;
                     self.origin_id = ::std::option::Option::Some(tmp);
                 },
                 3 => {
-                    try!(::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.name));
+                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.name)?;
                 },
                 4 => {
-                    try!(::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.revision));
+                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.revision)?;
                 },
                 5 => {
-                    try!(::protobuf::rt::read_singular_bytes_into(wire_type, is, &mut self.body));
+                    ::protobuf::rt::read_singular_bytes_into(wire_type, is, &mut self.body)?;
                 },
                 6 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
                         return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
                     };
-                    let tmp = try!(is.read_uint64());
+                    let tmp = is.read_uint64()?;
                     self.owner_id = ::std::option::Option::Some(tmp);
                 },
                 _ => {
-                    try!(::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields()));
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
                 },
             };
         }
@@ -4801,23 +5008,23 @@ impl ::protobuf::Message for OriginSecretKey {
     #[allow(unused_variables)]
     fn compute_size(&self) -> u32 {
         let mut my_size = 0;
-        for value in &self.id {
-            my_size += ::protobuf::rt::value_size(1, *value, ::protobuf::wire_format::WireTypeVarint);
+        if let Some(v) = self.id {
+            my_size += ::protobuf::rt::value_size(1, v, ::protobuf::wire_format::WireTypeVarint);
         };
-        for value in &self.origin_id {
-            my_size += ::protobuf::rt::value_size(2, *value, ::protobuf::wire_format::WireTypeVarint);
+        if let Some(v) = self.origin_id {
+            my_size += ::protobuf::rt::value_size(2, v, ::protobuf::wire_format::WireTypeVarint);
         };
-        for value in &self.name {
-            my_size += ::protobuf::rt::string_size(3, &value);
+        if let Some(v) = self.name.as_ref() {
+            my_size += ::protobuf::rt::string_size(3, &v);
         };
-        for value in &self.revision {
-            my_size += ::protobuf::rt::string_size(4, &value);
+        if let Some(v) = self.revision.as_ref() {
+            my_size += ::protobuf::rt::string_size(4, &v);
         };
-        for value in &self.body {
-            my_size += ::protobuf::rt::bytes_size(5, &value);
+        if let Some(v) = self.body.as_ref() {
+            my_size += ::protobuf::rt::bytes_size(5, &v);
         };
-        for value in &self.owner_id {
-            my_size += ::protobuf::rt::value_size(6, *value, ::protobuf::wire_format::WireTypeVarint);
+        if let Some(v) = self.owner_id {
+            my_size += ::protobuf::rt::value_size(6, v, ::protobuf::wire_format::WireTypeVarint);
         };
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
         self.cached_size.set(my_size);
@@ -4826,24 +5033,24 @@ impl ::protobuf::Message for OriginSecretKey {
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.id {
-            try!(os.write_uint64(1, v));
+            os.write_uint64(1, v)?;
         };
         if let Some(v) = self.origin_id {
-            try!(os.write_uint64(2, v));
+            os.write_uint64(2, v)?;
         };
         if let Some(v) = self.name.as_ref() {
-            try!(os.write_string(3, &v));
+            os.write_string(3, &v)?;
         };
         if let Some(v) = self.revision.as_ref() {
-            try!(os.write_string(4, &v));
+            os.write_string(4, &v)?;
         };
         if let Some(v) = self.body.as_ref() {
-            try!(os.write_bytes(5, &v));
+            os.write_bytes(5, &v)?;
         };
         if let Some(v) = self.owner_id {
-            try!(os.write_uint64(6, v));
+            os.write_uint64(6, v)?;
         };
-        try!(os.write_unknown_fields(self.get_unknown_fields()));
+        os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
 
@@ -4859,12 +5066,14 @@ impl ::protobuf::Message for OriginSecretKey {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<OriginSecretKey>()
-    }
-
     fn as_any(&self) -> &::std::any::Any {
         self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -4885,35 +5094,35 @@ impl ::protobuf::MessageStatic for OriginSecretKey {
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_u64_accessor(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint64>(
                     "id",
-                    OriginSecretKey::has_id,
-                    OriginSecretKey::get_id,
+                    OriginSecretKey::get_id_for_reflect,
+                    OriginSecretKey::mut_id_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_u64_accessor(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint64>(
                     "origin_id",
-                    OriginSecretKey::has_origin_id,
-                    OriginSecretKey::get_origin_id,
+                    OriginSecretKey::get_origin_id_for_reflect,
+                    OriginSecretKey::mut_origin_id_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_string_accessor(
+                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
                     "name",
-                    OriginSecretKey::has_name,
-                    OriginSecretKey::get_name,
+                    OriginSecretKey::get_name_for_reflect,
+                    OriginSecretKey::mut_name_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_string_accessor(
+                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
                     "revision",
-                    OriginSecretKey::has_revision,
-                    OriginSecretKey::get_revision,
+                    OriginSecretKey::get_revision_for_reflect,
+                    OriginSecretKey::mut_revision_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_bytes_accessor(
+                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeBytes>(
                     "body",
-                    OriginSecretKey::has_body,
-                    OriginSecretKey::get_body,
+                    OriginSecretKey::get_body_for_reflect,
+                    OriginSecretKey::mut_body_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_u64_accessor(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint64>(
                     "owner_id",
-                    OriginSecretKey::has_owner_id,
-                    OriginSecretKey::get_owner_id,
+                    OriginSecretKey::get_owner_id_for_reflect,
+                    OriginSecretKey::mut_owner_id_for_reflect,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<OriginSecretKey>(
                     "OriginSecretKey",
@@ -4937,25 +5146,19 @@ impl ::protobuf::Clear for OriginSecretKey {
     }
 }
 
-impl ::std::cmp::PartialEq for OriginSecretKey {
-    fn eq(&self, other: &OriginSecretKey) -> bool {
-        self.id == other.id &&
-        self.origin_id == other.origin_id &&
-        self.name == other.name &&
-        self.revision == other.revision &&
-        self.body == other.body &&
-        self.owner_id == other.owner_id &&
-        self.unknown_fields == other.unknown_fields
-    }
-}
-
 impl ::std::fmt::Debug for OriginSecretKey {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
-#[derive(Clone,Default)]
+impl ::protobuf::reflect::ProtobufValue for OriginSecretKey {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Message(self)
+    }
+}
+
+#[derive(PartialEq,Clone,Default)]
 pub struct OriginSecretKeyCreate {
     // message fields
     origin_id: ::std::option::Option<u64>,
@@ -4965,7 +5168,7 @@ pub struct OriginSecretKeyCreate {
     owner_id: ::std::option::Option<u64>,
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    cached_size: ::protobuf::CachedSize,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -4982,17 +5185,7 @@ impl OriginSecretKeyCreate {
             ptr: 0 as *const OriginSecretKeyCreate,
         };
         unsafe {
-            instance.get(|| {
-                OriginSecretKeyCreate {
-                    origin_id: ::std::option::Option::None,
-                    name: ::protobuf::SingularField::none(),
-                    revision: ::protobuf::SingularField::none(),
-                    body: ::protobuf::SingularField::none(),
-                    owner_id: ::std::option::Option::None,
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
+            instance.get(OriginSecretKeyCreate::new)
         }
     }
 
@@ -5013,6 +5206,14 @@ impl OriginSecretKeyCreate {
 
     pub fn get_origin_id(&self) -> u64 {
         self.origin_id.unwrap_or(0)
+    }
+
+    fn get_origin_id_for_reflect(&self) -> &::std::option::Option<u64> {
+        &self.origin_id
+    }
+
+    fn mut_origin_id_for_reflect(&mut self) -> &mut ::std::option::Option<u64> {
+        &mut self.origin_id
     }
 
     // required string name = 2;
@@ -5051,6 +5252,14 @@ impl OriginSecretKeyCreate {
         }
     }
 
+    fn get_name_for_reflect(&self) -> &::protobuf::SingularField<::std::string::String> {
+        &self.name
+    }
+
+    fn mut_name_for_reflect(&mut self) -> &mut ::protobuf::SingularField<::std::string::String> {
+        &mut self.name
+    }
+
     // required string revision = 3;
 
     pub fn clear_revision(&mut self) {
@@ -5085,6 +5294,14 @@ impl OriginSecretKeyCreate {
             Some(v) => &v,
             None => "",
         }
+    }
+
+    fn get_revision_for_reflect(&self) -> &::protobuf::SingularField<::std::string::String> {
+        &self.revision
+    }
+
+    fn mut_revision_for_reflect(&mut self) -> &mut ::protobuf::SingularField<::std::string::String> {
+        &mut self.revision
     }
 
     // required bytes body = 4;
@@ -5123,6 +5340,14 @@ impl OriginSecretKeyCreate {
         }
     }
 
+    fn get_body_for_reflect(&self) -> &::protobuf::SingularField<::std::vec::Vec<u8>> {
+        &self.body
+    }
+
+    fn mut_body_for_reflect(&mut self) -> &mut ::protobuf::SingularField<::std::vec::Vec<u8>> {
+        &mut self.body
+    }
+
     // required uint64 owner_id = 5;
 
     pub fn clear_owner_id(&mut self) {
@@ -5140,6 +5365,14 @@ impl OriginSecretKeyCreate {
 
     pub fn get_owner_id(&self) -> u64 {
         self.owner_id.unwrap_or(0)
+    }
+
+    fn get_owner_id_for_reflect(&self) -> &::std::option::Option<u64> {
+        &self.owner_id
+    }
+
+    fn mut_owner_id_for_reflect(&mut self) -> &mut ::std::option::Option<u64> {
+        &mut self.owner_id
     }
 }
 
@@ -5164,34 +5397,34 @@ impl ::protobuf::Message for OriginSecretKeyCreate {
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
-        while !try!(is.eof()) {
-            let (field_number, wire_type) = try!(is.read_tag_unpack());
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
                         return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
                     };
-                    let tmp = try!(is.read_uint64());
+                    let tmp = is.read_uint64()?;
                     self.origin_id = ::std::option::Option::Some(tmp);
                 },
                 2 => {
-                    try!(::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.name));
+                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.name)?;
                 },
                 3 => {
-                    try!(::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.revision));
+                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.revision)?;
                 },
                 4 => {
-                    try!(::protobuf::rt::read_singular_bytes_into(wire_type, is, &mut self.body));
+                    ::protobuf::rt::read_singular_bytes_into(wire_type, is, &mut self.body)?;
                 },
                 5 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
                         return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
                     };
-                    let tmp = try!(is.read_uint64());
+                    let tmp = is.read_uint64()?;
                     self.owner_id = ::std::option::Option::Some(tmp);
                 },
                 _ => {
-                    try!(::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields()));
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
                 },
             };
         }
@@ -5202,20 +5435,20 @@ impl ::protobuf::Message for OriginSecretKeyCreate {
     #[allow(unused_variables)]
     fn compute_size(&self) -> u32 {
         let mut my_size = 0;
-        for value in &self.origin_id {
-            my_size += ::protobuf::rt::value_size(1, *value, ::protobuf::wire_format::WireTypeVarint);
+        if let Some(v) = self.origin_id {
+            my_size += ::protobuf::rt::value_size(1, v, ::protobuf::wire_format::WireTypeVarint);
         };
-        for value in &self.name {
-            my_size += ::protobuf::rt::string_size(2, &value);
+        if let Some(v) = self.name.as_ref() {
+            my_size += ::protobuf::rt::string_size(2, &v);
         };
-        for value in &self.revision {
-            my_size += ::protobuf::rt::string_size(3, &value);
+        if let Some(v) = self.revision.as_ref() {
+            my_size += ::protobuf::rt::string_size(3, &v);
         };
-        for value in &self.body {
-            my_size += ::protobuf::rt::bytes_size(4, &value);
+        if let Some(v) = self.body.as_ref() {
+            my_size += ::protobuf::rt::bytes_size(4, &v);
         };
-        for value in &self.owner_id {
-            my_size += ::protobuf::rt::value_size(5, *value, ::protobuf::wire_format::WireTypeVarint);
+        if let Some(v) = self.owner_id {
+            my_size += ::protobuf::rt::value_size(5, v, ::protobuf::wire_format::WireTypeVarint);
         };
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
         self.cached_size.set(my_size);
@@ -5224,21 +5457,21 @@ impl ::protobuf::Message for OriginSecretKeyCreate {
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.origin_id {
-            try!(os.write_uint64(1, v));
+            os.write_uint64(1, v)?;
         };
         if let Some(v) = self.name.as_ref() {
-            try!(os.write_string(2, &v));
+            os.write_string(2, &v)?;
         };
         if let Some(v) = self.revision.as_ref() {
-            try!(os.write_string(3, &v));
+            os.write_string(3, &v)?;
         };
         if let Some(v) = self.body.as_ref() {
-            try!(os.write_bytes(4, &v));
+            os.write_bytes(4, &v)?;
         };
         if let Some(v) = self.owner_id {
-            try!(os.write_uint64(5, v));
+            os.write_uint64(5, v)?;
         };
-        try!(os.write_unknown_fields(self.get_unknown_fields()));
+        os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
 
@@ -5254,12 +5487,14 @@ impl ::protobuf::Message for OriginSecretKeyCreate {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<OriginSecretKeyCreate>()
-    }
-
     fn as_any(&self) -> &::std::any::Any {
         self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -5280,30 +5515,30 @@ impl ::protobuf::MessageStatic for OriginSecretKeyCreate {
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_u64_accessor(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint64>(
                     "origin_id",
-                    OriginSecretKeyCreate::has_origin_id,
-                    OriginSecretKeyCreate::get_origin_id,
+                    OriginSecretKeyCreate::get_origin_id_for_reflect,
+                    OriginSecretKeyCreate::mut_origin_id_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_string_accessor(
+                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
                     "name",
-                    OriginSecretKeyCreate::has_name,
-                    OriginSecretKeyCreate::get_name,
+                    OriginSecretKeyCreate::get_name_for_reflect,
+                    OriginSecretKeyCreate::mut_name_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_string_accessor(
+                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
                     "revision",
-                    OriginSecretKeyCreate::has_revision,
-                    OriginSecretKeyCreate::get_revision,
+                    OriginSecretKeyCreate::get_revision_for_reflect,
+                    OriginSecretKeyCreate::mut_revision_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_bytes_accessor(
+                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeBytes>(
                     "body",
-                    OriginSecretKeyCreate::has_body,
-                    OriginSecretKeyCreate::get_body,
+                    OriginSecretKeyCreate::get_body_for_reflect,
+                    OriginSecretKeyCreate::mut_body_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_u64_accessor(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint64>(
                     "owner_id",
-                    OriginSecretKeyCreate::has_owner_id,
-                    OriginSecretKeyCreate::get_owner_id,
+                    OriginSecretKeyCreate::get_owner_id_for_reflect,
+                    OriginSecretKeyCreate::mut_owner_id_for_reflect,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<OriginSecretKeyCreate>(
                     "OriginSecretKeyCreate",
@@ -5326,31 +5561,26 @@ impl ::protobuf::Clear for OriginSecretKeyCreate {
     }
 }
 
-impl ::std::cmp::PartialEq for OriginSecretKeyCreate {
-    fn eq(&self, other: &OriginSecretKeyCreate) -> bool {
-        self.origin_id == other.origin_id &&
-        self.name == other.name &&
-        self.revision == other.revision &&
-        self.body == other.body &&
-        self.owner_id == other.owner_id &&
-        self.unknown_fields == other.unknown_fields
-    }
-}
-
 impl ::std::fmt::Debug for OriginSecretKeyCreate {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
-#[derive(Clone,Default)]
+impl ::protobuf::reflect::ProtobufValue for OriginSecretKeyCreate {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Message(self)
+    }
+}
+
+#[derive(PartialEq,Clone,Default)]
 pub struct OriginSecretKeyGet {
     // message fields
     owner_id: ::std::option::Option<u64>,
     origin: ::protobuf::SingularField<::std::string::String>,
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    cached_size: ::protobuf::CachedSize,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -5367,14 +5597,7 @@ impl OriginSecretKeyGet {
             ptr: 0 as *const OriginSecretKeyGet,
         };
         unsafe {
-            instance.get(|| {
-                OriginSecretKeyGet {
-                    owner_id: ::std::option::Option::None,
-                    origin: ::protobuf::SingularField::none(),
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
+            instance.get(OriginSecretKeyGet::new)
         }
     }
 
@@ -5395,6 +5618,14 @@ impl OriginSecretKeyGet {
 
     pub fn get_owner_id(&self) -> u64 {
         self.owner_id.unwrap_or(0)
+    }
+
+    fn get_owner_id_for_reflect(&self) -> &::std::option::Option<u64> {
+        &self.owner_id
+    }
+
+    fn mut_owner_id_for_reflect(&mut self) -> &mut ::std::option::Option<u64> {
+        &mut self.owner_id
     }
 
     // required string origin = 2;
@@ -5432,6 +5663,14 @@ impl OriginSecretKeyGet {
             None => "",
         }
     }
+
+    fn get_origin_for_reflect(&self) -> &::protobuf::SingularField<::std::string::String> {
+        &self.origin
+    }
+
+    fn mut_origin_for_reflect(&mut self) -> &mut ::protobuf::SingularField<::std::string::String> {
+        &mut self.origin
+    }
 }
 
 impl ::protobuf::Message for OriginSecretKeyGet {
@@ -5446,21 +5685,21 @@ impl ::protobuf::Message for OriginSecretKeyGet {
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
-        while !try!(is.eof()) {
-            let (field_number, wire_type) = try!(is.read_tag_unpack());
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
                         return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
                     };
-                    let tmp = try!(is.read_uint64());
+                    let tmp = is.read_uint64()?;
                     self.owner_id = ::std::option::Option::Some(tmp);
                 },
                 2 => {
-                    try!(::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.origin));
+                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.origin)?;
                 },
                 _ => {
-                    try!(::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields()));
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
                 },
             };
         }
@@ -5471,11 +5710,11 @@ impl ::protobuf::Message for OriginSecretKeyGet {
     #[allow(unused_variables)]
     fn compute_size(&self) -> u32 {
         let mut my_size = 0;
-        for value in &self.owner_id {
-            my_size += ::protobuf::rt::value_size(1, *value, ::protobuf::wire_format::WireTypeVarint);
+        if let Some(v) = self.owner_id {
+            my_size += ::protobuf::rt::value_size(1, v, ::protobuf::wire_format::WireTypeVarint);
         };
-        for value in &self.origin {
-            my_size += ::protobuf::rt::string_size(2, &value);
+        if let Some(v) = self.origin.as_ref() {
+            my_size += ::protobuf::rt::string_size(2, &v);
         };
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
         self.cached_size.set(my_size);
@@ -5484,12 +5723,12 @@ impl ::protobuf::Message for OriginSecretKeyGet {
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.owner_id {
-            try!(os.write_uint64(1, v));
+            os.write_uint64(1, v)?;
         };
         if let Some(v) = self.origin.as_ref() {
-            try!(os.write_string(2, &v));
+            os.write_string(2, &v)?;
         };
-        try!(os.write_unknown_fields(self.get_unknown_fields()));
+        os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
 
@@ -5505,12 +5744,14 @@ impl ::protobuf::Message for OriginSecretKeyGet {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<OriginSecretKeyGet>()
-    }
-
     fn as_any(&self) -> &::std::any::Any {
         self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -5531,15 +5772,15 @@ impl ::protobuf::MessageStatic for OriginSecretKeyGet {
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_u64_accessor(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint64>(
                     "owner_id",
-                    OriginSecretKeyGet::has_owner_id,
-                    OriginSecretKeyGet::get_owner_id,
+                    OriginSecretKeyGet::get_owner_id_for_reflect,
+                    OriginSecretKeyGet::mut_owner_id_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_string_accessor(
+                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
                     "origin",
-                    OriginSecretKeyGet::has_origin,
-                    OriginSecretKeyGet::get_origin,
+                    OriginSecretKeyGet::get_origin_for_reflect,
+                    OriginSecretKeyGet::mut_origin_for_reflect,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<OriginSecretKeyGet>(
                     "OriginSecretKeyGet",
@@ -5559,21 +5800,19 @@ impl ::protobuf::Clear for OriginSecretKeyGet {
     }
 }
 
-impl ::std::cmp::PartialEq for OriginSecretKeyGet {
-    fn eq(&self, other: &OriginSecretKeyGet) -> bool {
-        self.owner_id == other.owner_id &&
-        self.origin == other.origin &&
-        self.unknown_fields == other.unknown_fields
-    }
-}
-
 impl ::std::fmt::Debug for OriginSecretKeyGet {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
-#[derive(Clone,Default)]
+impl ::protobuf::reflect::ProtobufValue for OriginSecretKeyGet {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Message(self)
+    }
+}
+
+#[derive(PartialEq,Clone,Default)]
 pub struct Project {
     // message fields
     id: ::protobuf::SingularField<::std::string::String>,
@@ -5583,7 +5822,7 @@ pub struct Project {
     vcs: ::std::option::Option<Project_oneof_vcs>,
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    cached_size: ::protobuf::CachedSize,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -5605,16 +5844,7 @@ impl Project {
             ptr: 0 as *const Project,
         };
         unsafe {
-            instance.get(|| {
-                Project {
-                    id: ::protobuf::SingularField::none(),
-                    owner_id: ::std::option::Option::None,
-                    plan_path: ::protobuf::SingularField::none(),
-                    vcs: ::std::option::Option::None,
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
+            instance.get(Project::new)
         }
     }
 
@@ -5654,6 +5884,14 @@ impl Project {
         }
     }
 
+    fn get_id_for_reflect(&self) -> &::protobuf::SingularField<::std::string::String> {
+        &self.id
+    }
+
+    fn mut_id_for_reflect(&mut self) -> &mut ::protobuf::SingularField<::std::string::String> {
+        &mut self.id
+    }
+
     // required uint64 owner_id = 2;
 
     pub fn clear_owner_id(&mut self) {
@@ -5671,6 +5909,14 @@ impl Project {
 
     pub fn get_owner_id(&self) -> u64 {
         self.owner_id.unwrap_or(0)
+    }
+
+    fn get_owner_id_for_reflect(&self) -> &::std::option::Option<u64> {
+        &self.owner_id
+    }
+
+    fn mut_owner_id_for_reflect(&mut self) -> &mut ::std::option::Option<u64> {
+        &mut self.owner_id
     }
 
     // required string plan_path = 3;
@@ -5709,6 +5955,14 @@ impl Project {
         }
     }
 
+    fn get_plan_path_for_reflect(&self) -> &::protobuf::SingularField<::std::string::String> {
+        &self.plan_path
+    }
+
+    fn mut_plan_path_for_reflect(&mut self) -> &mut ::protobuf::SingularField<::std::string::String> {
+        &mut self.plan_path
+    }
+
     // optional .vault.VCSGit git = 4;
 
     pub fn clear_git(&mut self) {
@@ -5728,7 +5982,6 @@ impl Project {
     }
 
     // Mutable pointer to the field.
-    // If field is not initialized, it is initialized with default value first.
     pub fn mut_git(&mut self) -> &mut VCSGit {
         if let ::std::option::Option::Some(Project_oneof_vcs::git(_)) = self.vcs {
         } else {
@@ -5775,30 +6028,30 @@ impl ::protobuf::Message for Project {
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
-        while !try!(is.eof()) {
-            let (field_number, wire_type) = try!(is.read_tag_unpack());
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
-                    try!(::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.id));
+                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.id)?;
                 },
                 2 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
                         return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
                     };
-                    let tmp = try!(is.read_uint64());
+                    let tmp = is.read_uint64()?;
                     self.owner_id = ::std::option::Option::Some(tmp);
                 },
                 3 => {
-                    try!(::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.plan_path));
+                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.plan_path)?;
                 },
                 4 => {
                     if wire_type != ::protobuf::wire_format::WireTypeLengthDelimited {
                         return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
                     };
-                    self.vcs = ::std::option::Option::Some(Project_oneof_vcs::git(try!(is.read_message())));
+                    self.vcs = ::std::option::Option::Some(Project_oneof_vcs::git(is.read_message()?));
                 },
                 _ => {
-                    try!(::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields()));
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
                 },
             };
         }
@@ -5809,14 +6062,14 @@ impl ::protobuf::Message for Project {
     #[allow(unused_variables)]
     fn compute_size(&self) -> u32 {
         let mut my_size = 0;
-        for value in &self.id {
-            my_size += ::protobuf::rt::string_size(1, &value);
+        if let Some(v) = self.id.as_ref() {
+            my_size += ::protobuf::rt::string_size(1, &v);
         };
-        for value in &self.owner_id {
-            my_size += ::protobuf::rt::value_size(2, *value, ::protobuf::wire_format::WireTypeVarint);
+        if let Some(v) = self.owner_id {
+            my_size += ::protobuf::rt::value_size(2, v, ::protobuf::wire_format::WireTypeVarint);
         };
-        for value in &self.plan_path {
-            my_size += ::protobuf::rt::string_size(3, &value);
+        if let Some(v) = self.plan_path.as_ref() {
+            my_size += ::protobuf::rt::string_size(3, &v);
         };
         if let ::std::option::Option::Some(ref v) = self.vcs {
             match v {
@@ -5833,24 +6086,24 @@ impl ::protobuf::Message for Project {
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.id.as_ref() {
-            try!(os.write_string(1, &v));
+            os.write_string(1, &v)?;
         };
         if let Some(v) = self.owner_id {
-            try!(os.write_uint64(2, v));
+            os.write_uint64(2, v)?;
         };
         if let Some(v) = self.plan_path.as_ref() {
-            try!(os.write_string(3, &v));
+            os.write_string(3, &v)?;
         };
         if let ::std::option::Option::Some(ref v) = self.vcs {
             match v {
                 &Project_oneof_vcs::git(ref v) => {
-                    try!(os.write_tag(4, ::protobuf::wire_format::WireTypeLengthDelimited));
-                    try!(os.write_raw_varint32(v.get_cached_size()));
-                    try!(v.write_to_with_cached_sizes(os));
+                    os.write_tag(4, ::protobuf::wire_format::WireTypeLengthDelimited)?;
+                    os.write_raw_varint32(v.get_cached_size())?;
+                    v.write_to_with_cached_sizes(os)?;
                 },
             };
         };
-        try!(os.write_unknown_fields(self.get_unknown_fields()));
+        os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
 
@@ -5866,12 +6119,14 @@ impl ::protobuf::Message for Project {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<Project>()
-    }
-
     fn as_any(&self) -> &::std::any::Any {
         self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -5892,22 +6147,22 @@ impl ::protobuf::MessageStatic for Project {
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_string_accessor(
+                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
                     "id",
-                    Project::has_id,
-                    Project::get_id,
+                    Project::get_id_for_reflect,
+                    Project::mut_id_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_u64_accessor(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint64>(
                     "owner_id",
-                    Project::has_owner_id,
-                    Project::get_owner_id,
+                    Project::get_owner_id_for_reflect,
+                    Project::mut_owner_id_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_string_accessor(
+                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
                     "plan_path",
-                    Project::has_plan_path,
-                    Project::get_plan_path,
+                    Project::get_plan_path_for_reflect,
+                    Project::mut_plan_path_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_message_accessor(
+                fields.push(::protobuf::reflect::accessor::make_singular_message_accessor::<_, VCSGit>(
                     "git",
                     Project::has_git,
                     Project::get_git,
@@ -5932,30 +6187,26 @@ impl ::protobuf::Clear for Project {
     }
 }
 
-impl ::std::cmp::PartialEq for Project {
-    fn eq(&self, other: &Project) -> bool {
-        self.id == other.id &&
-        self.owner_id == other.owner_id &&
-        self.plan_path == other.plan_path &&
-        self.vcs == other.vcs &&
-        self.unknown_fields == other.unknown_fields
-    }
-}
-
 impl ::std::fmt::Debug for Project {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
-#[derive(Clone,Default)]
+impl ::protobuf::reflect::ProtobufValue for Project {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Message(self)
+    }
+}
+
+#[derive(PartialEq,Clone,Default)]
 pub struct ProjectUpdate {
     // message fields
     requestor_id: ::std::option::Option<u64>,
     project: ::protobuf::SingularPtrField<Project>,
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    cached_size: ::protobuf::CachedSize,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -5972,14 +6223,7 @@ impl ProjectUpdate {
             ptr: 0 as *const ProjectUpdate,
         };
         unsafe {
-            instance.get(|| {
-                ProjectUpdate {
-                    requestor_id: ::std::option::Option::None,
-                    project: ::protobuf::SingularPtrField::none(),
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
+            instance.get(ProjectUpdate::new)
         }
     }
 
@@ -6000,6 +6244,14 @@ impl ProjectUpdate {
 
     pub fn get_requestor_id(&self) -> u64 {
         self.requestor_id.unwrap_or(0)
+    }
+
+    fn get_requestor_id_for_reflect(&self) -> &::std::option::Option<u64> {
+        &self.requestor_id
+    }
+
+    fn mut_requestor_id_for_reflect(&mut self) -> &mut ::std::option::Option<u64> {
+        &mut self.requestor_id
     }
 
     // required .vault.Project project = 2;
@@ -6034,6 +6286,14 @@ impl ProjectUpdate {
     pub fn get_project(&self) -> &Project {
         self.project.as_ref().unwrap_or_else(|| Project::default_instance())
     }
+
+    fn get_project_for_reflect(&self) -> &::protobuf::SingularPtrField<Project> {
+        &self.project
+    }
+
+    fn mut_project_for_reflect(&mut self) -> &mut ::protobuf::SingularPtrField<Project> {
+        &mut self.project
+    }
 }
 
 impl ::protobuf::Message for ProjectUpdate {
@@ -6048,21 +6308,21 @@ impl ::protobuf::Message for ProjectUpdate {
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
-        while !try!(is.eof()) {
-            let (field_number, wire_type) = try!(is.read_tag_unpack());
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
                         return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
                     };
-                    let tmp = try!(is.read_uint64());
+                    let tmp = is.read_uint64()?;
                     self.requestor_id = ::std::option::Option::Some(tmp);
                 },
                 2 => {
-                    try!(::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.project));
+                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.project)?;
                 },
                 _ => {
-                    try!(::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields()));
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
                 },
             };
         }
@@ -6073,11 +6333,11 @@ impl ::protobuf::Message for ProjectUpdate {
     #[allow(unused_variables)]
     fn compute_size(&self) -> u32 {
         let mut my_size = 0;
-        for value in &self.requestor_id {
-            my_size += ::protobuf::rt::value_size(1, *value, ::protobuf::wire_format::WireTypeVarint);
+        if let Some(v) = self.requestor_id {
+            my_size += ::protobuf::rt::value_size(1, v, ::protobuf::wire_format::WireTypeVarint);
         };
-        for value in &self.project {
-            let len = value.compute_size();
+        if let Some(v) = self.project.as_ref() {
+            let len = v.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
         };
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
@@ -6087,14 +6347,14 @@ impl ::protobuf::Message for ProjectUpdate {
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.requestor_id {
-            try!(os.write_uint64(1, v));
+            os.write_uint64(1, v)?;
         };
         if let Some(v) = self.project.as_ref() {
-            try!(os.write_tag(2, ::protobuf::wire_format::WireTypeLengthDelimited));
-            try!(os.write_raw_varint32(v.get_cached_size()));
-            try!(v.write_to_with_cached_sizes(os));
+            os.write_tag(2, ::protobuf::wire_format::WireTypeLengthDelimited)?;
+            os.write_raw_varint32(v.get_cached_size())?;
+            v.write_to_with_cached_sizes(os)?;
         };
-        try!(os.write_unknown_fields(self.get_unknown_fields()));
+        os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
 
@@ -6110,12 +6370,14 @@ impl ::protobuf::Message for ProjectUpdate {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<ProjectUpdate>()
-    }
-
     fn as_any(&self) -> &::std::any::Any {
         self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -6136,15 +6398,15 @@ impl ::protobuf::MessageStatic for ProjectUpdate {
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_u64_accessor(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint64>(
                     "requestor_id",
-                    ProjectUpdate::has_requestor_id,
-                    ProjectUpdate::get_requestor_id,
+                    ProjectUpdate::get_requestor_id_for_reflect,
+                    ProjectUpdate::mut_requestor_id_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_message_accessor(
+                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<Project>>(
                     "project",
-                    ProjectUpdate::has_project,
-                    ProjectUpdate::get_project,
+                    ProjectUpdate::get_project_for_reflect,
+                    ProjectUpdate::mut_project_for_reflect,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<ProjectUpdate>(
                     "ProjectUpdate",
@@ -6164,27 +6426,25 @@ impl ::protobuf::Clear for ProjectUpdate {
     }
 }
 
-impl ::std::cmp::PartialEq for ProjectUpdate {
-    fn eq(&self, other: &ProjectUpdate) -> bool {
-        self.requestor_id == other.requestor_id &&
-        self.project == other.project &&
-        self.unknown_fields == other.unknown_fields
-    }
-}
-
 impl ::std::fmt::Debug for ProjectUpdate {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
-#[derive(Clone,Default)]
+impl ::protobuf::reflect::ProtobufValue for ProjectUpdate {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Message(self)
+    }
+}
+
+#[derive(PartialEq,Clone,Default)]
 pub struct ProjectCreate {
     // message fields
     project: ::protobuf::SingularPtrField<Project>,
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    cached_size: ::protobuf::CachedSize,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -6201,13 +6461,7 @@ impl ProjectCreate {
             ptr: 0 as *const ProjectCreate,
         };
         unsafe {
-            instance.get(|| {
-                ProjectCreate {
-                    project: ::protobuf::SingularPtrField::none(),
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
+            instance.get(ProjectCreate::new)
         }
     }
 
@@ -6243,6 +6497,14 @@ impl ProjectCreate {
     pub fn get_project(&self) -> &Project {
         self.project.as_ref().unwrap_or_else(|| Project::default_instance())
     }
+
+    fn get_project_for_reflect(&self) -> &::protobuf::SingularPtrField<Project> {
+        &self.project
+    }
+
+    fn mut_project_for_reflect(&mut self) -> &mut ::protobuf::SingularPtrField<Project> {
+        &mut self.project
+    }
 }
 
 impl ::protobuf::Message for ProjectCreate {
@@ -6254,14 +6516,14 @@ impl ::protobuf::Message for ProjectCreate {
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
-        while !try!(is.eof()) {
-            let (field_number, wire_type) = try!(is.read_tag_unpack());
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
-                    try!(::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.project));
+                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.project)?;
                 },
                 _ => {
-                    try!(::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields()));
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
                 },
             };
         }
@@ -6272,8 +6534,8 @@ impl ::protobuf::Message for ProjectCreate {
     #[allow(unused_variables)]
     fn compute_size(&self) -> u32 {
         let mut my_size = 0;
-        for value in &self.project {
-            let len = value.compute_size();
+        if let Some(v) = self.project.as_ref() {
+            let len = v.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
         };
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
@@ -6283,11 +6545,11 @@ impl ::protobuf::Message for ProjectCreate {
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.project.as_ref() {
-            try!(os.write_tag(1, ::protobuf::wire_format::WireTypeLengthDelimited));
-            try!(os.write_raw_varint32(v.get_cached_size()));
-            try!(v.write_to_with_cached_sizes(os));
+            os.write_tag(1, ::protobuf::wire_format::WireTypeLengthDelimited)?;
+            os.write_raw_varint32(v.get_cached_size())?;
+            v.write_to_with_cached_sizes(os)?;
         };
-        try!(os.write_unknown_fields(self.get_unknown_fields()));
+        os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
 
@@ -6303,12 +6565,14 @@ impl ::protobuf::Message for ProjectCreate {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<ProjectCreate>()
-    }
-
     fn as_any(&self) -> &::std::any::Any {
         self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -6329,10 +6593,10 @@ impl ::protobuf::MessageStatic for ProjectCreate {
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_message_accessor(
+                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<Project>>(
                     "project",
-                    ProjectCreate::has_project,
-                    ProjectCreate::get_project,
+                    ProjectCreate::get_project_for_reflect,
+                    ProjectCreate::mut_project_for_reflect,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<ProjectCreate>(
                     "ProjectCreate",
@@ -6351,27 +6615,26 @@ impl ::protobuf::Clear for ProjectCreate {
     }
 }
 
-impl ::std::cmp::PartialEq for ProjectCreate {
-    fn eq(&self, other: &ProjectCreate) -> bool {
-        self.project == other.project &&
-        self.unknown_fields == other.unknown_fields
-    }
-}
-
 impl ::std::fmt::Debug for ProjectCreate {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
-#[derive(Clone,Default)]
+impl ::protobuf::reflect::ProtobufValue for ProjectCreate {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Message(self)
+    }
+}
+
+#[derive(PartialEq,Clone,Default)]
 pub struct ProjectDelete {
     // message fields
     id: ::protobuf::SingularField<::std::string::String>,
     requestor_id: ::std::option::Option<u64>,
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    cached_size: ::protobuf::CachedSize,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -6388,14 +6651,7 @@ impl ProjectDelete {
             ptr: 0 as *const ProjectDelete,
         };
         unsafe {
-            instance.get(|| {
-                ProjectDelete {
-                    id: ::protobuf::SingularField::none(),
-                    requestor_id: ::std::option::Option::None,
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
+            instance.get(ProjectDelete::new)
         }
     }
 
@@ -6433,6 +6689,14 @@ impl ProjectDelete {
             Some(v) => &v,
             None => "",
         }
+    }
+
+    fn get_id_for_reflect(&self) -> &::protobuf::SingularField<::std::string::String> {
+        &self.id
+    }
+
+    fn mut_id_for_reflect(&mut self) -> &mut ::protobuf::SingularField<::std::string::String> {
+        &mut self.id
     }
 
     // required uint64 requestor_id = 2;
@@ -6453,6 +6717,14 @@ impl ProjectDelete {
     pub fn get_requestor_id(&self) -> u64 {
         self.requestor_id.unwrap_or(0)
     }
+
+    fn get_requestor_id_for_reflect(&self) -> &::std::option::Option<u64> {
+        &self.requestor_id
+    }
+
+    fn mut_requestor_id_for_reflect(&mut self) -> &mut ::std::option::Option<u64> {
+        &mut self.requestor_id
+    }
 }
 
 impl ::protobuf::Message for ProjectDelete {
@@ -6467,21 +6739,21 @@ impl ::protobuf::Message for ProjectDelete {
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
-        while !try!(is.eof()) {
-            let (field_number, wire_type) = try!(is.read_tag_unpack());
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
-                    try!(::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.id));
+                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.id)?;
                 },
                 2 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
                         return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
                     };
-                    let tmp = try!(is.read_uint64());
+                    let tmp = is.read_uint64()?;
                     self.requestor_id = ::std::option::Option::Some(tmp);
                 },
                 _ => {
-                    try!(::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields()));
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
                 },
             };
         }
@@ -6492,11 +6764,11 @@ impl ::protobuf::Message for ProjectDelete {
     #[allow(unused_variables)]
     fn compute_size(&self) -> u32 {
         let mut my_size = 0;
-        for value in &self.id {
-            my_size += ::protobuf::rt::string_size(1, &value);
+        if let Some(v) = self.id.as_ref() {
+            my_size += ::protobuf::rt::string_size(1, &v);
         };
-        for value in &self.requestor_id {
-            my_size += ::protobuf::rt::value_size(2, *value, ::protobuf::wire_format::WireTypeVarint);
+        if let Some(v) = self.requestor_id {
+            my_size += ::protobuf::rt::value_size(2, v, ::protobuf::wire_format::WireTypeVarint);
         };
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
         self.cached_size.set(my_size);
@@ -6505,12 +6777,12 @@ impl ::protobuf::Message for ProjectDelete {
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.id.as_ref() {
-            try!(os.write_string(1, &v));
+            os.write_string(1, &v)?;
         };
         if let Some(v) = self.requestor_id {
-            try!(os.write_uint64(2, v));
+            os.write_uint64(2, v)?;
         };
-        try!(os.write_unknown_fields(self.get_unknown_fields()));
+        os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
 
@@ -6526,12 +6798,14 @@ impl ::protobuf::Message for ProjectDelete {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<ProjectDelete>()
-    }
-
     fn as_any(&self) -> &::std::any::Any {
         self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -6552,15 +6826,15 @@ impl ::protobuf::MessageStatic for ProjectDelete {
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_string_accessor(
+                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
                     "id",
-                    ProjectDelete::has_id,
-                    ProjectDelete::get_id,
+                    ProjectDelete::get_id_for_reflect,
+                    ProjectDelete::mut_id_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_u64_accessor(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint64>(
                     "requestor_id",
-                    ProjectDelete::has_requestor_id,
-                    ProjectDelete::get_requestor_id,
+                    ProjectDelete::get_requestor_id_for_reflect,
+                    ProjectDelete::mut_requestor_id_for_reflect,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<ProjectDelete>(
                     "ProjectDelete",
@@ -6580,27 +6854,25 @@ impl ::protobuf::Clear for ProjectDelete {
     }
 }
 
-impl ::std::cmp::PartialEq for ProjectDelete {
-    fn eq(&self, other: &ProjectDelete) -> bool {
-        self.id == other.id &&
-        self.requestor_id == other.requestor_id &&
-        self.unknown_fields == other.unknown_fields
-    }
-}
-
 impl ::std::fmt::Debug for ProjectDelete {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
-#[derive(Clone,Default)]
+impl ::protobuf::reflect::ProtobufValue for ProjectDelete {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Message(self)
+    }
+}
+
+#[derive(PartialEq,Clone,Default)]
 pub struct ProjectGet {
     // message fields
     id: ::protobuf::SingularField<::std::string::String>,
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    cached_size: ::protobuf::CachedSize,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -6617,13 +6889,7 @@ impl ProjectGet {
             ptr: 0 as *const ProjectGet,
         };
         unsafe {
-            instance.get(|| {
-                ProjectGet {
-                    id: ::protobuf::SingularField::none(),
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
+            instance.get(ProjectGet::new)
         }
     }
 
@@ -6662,6 +6928,14 @@ impl ProjectGet {
             None => "",
         }
     }
+
+    fn get_id_for_reflect(&self) -> &::protobuf::SingularField<::std::string::String> {
+        &self.id
+    }
+
+    fn mut_id_for_reflect(&mut self) -> &mut ::protobuf::SingularField<::std::string::String> {
+        &mut self.id
+    }
 }
 
 impl ::protobuf::Message for ProjectGet {
@@ -6673,14 +6947,14 @@ impl ::protobuf::Message for ProjectGet {
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
-        while !try!(is.eof()) {
-            let (field_number, wire_type) = try!(is.read_tag_unpack());
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
-                    try!(::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.id));
+                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.id)?;
                 },
                 _ => {
-                    try!(::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields()));
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
                 },
             };
         }
@@ -6691,8 +6965,8 @@ impl ::protobuf::Message for ProjectGet {
     #[allow(unused_variables)]
     fn compute_size(&self) -> u32 {
         let mut my_size = 0;
-        for value in &self.id {
-            my_size += ::protobuf::rt::string_size(1, &value);
+        if let Some(v) = self.id.as_ref() {
+            my_size += ::protobuf::rt::string_size(1, &v);
         };
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
         self.cached_size.set(my_size);
@@ -6701,9 +6975,9 @@ impl ::protobuf::Message for ProjectGet {
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.id.as_ref() {
-            try!(os.write_string(1, &v));
+            os.write_string(1, &v)?;
         };
-        try!(os.write_unknown_fields(self.get_unknown_fields()));
+        os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
 
@@ -6719,12 +6993,14 @@ impl ::protobuf::Message for ProjectGet {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<ProjectGet>()
-    }
-
     fn as_any(&self) -> &::std::any::Any {
         self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -6745,10 +7021,10 @@ impl ::protobuf::MessageStatic for ProjectGet {
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_string_accessor(
+                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
                     "id",
-                    ProjectGet::has_id,
-                    ProjectGet::get_id,
+                    ProjectGet::get_id_for_reflect,
+                    ProjectGet::mut_id_for_reflect,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<ProjectGet>(
                     "ProjectGet",
@@ -6767,26 +7043,25 @@ impl ::protobuf::Clear for ProjectGet {
     }
 }
 
-impl ::std::cmp::PartialEq for ProjectGet {
-    fn eq(&self, other: &ProjectGet) -> bool {
-        self.id == other.id &&
-        self.unknown_fields == other.unknown_fields
-    }
-}
-
 impl ::std::fmt::Debug for ProjectGet {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
-#[derive(Clone,Default)]
+impl ::protobuf::reflect::ProtobufValue for ProjectGet {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Message(self)
+    }
+}
+
+#[derive(PartialEq,Clone,Default)]
 pub struct VCSGit {
     // message fields
     url: ::protobuf::SingularField<::std::string::String>,
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
-    cached_size: ::std::cell::Cell<u32>,
+    cached_size: ::protobuf::CachedSize,
 }
 
 // see codegen.rs for the explanation why impl Sync explicitly
@@ -6803,13 +7078,7 @@ impl VCSGit {
             ptr: 0 as *const VCSGit,
         };
         unsafe {
-            instance.get(|| {
-                VCSGit {
-                    url: ::protobuf::SingularField::none(),
-                    unknown_fields: ::protobuf::UnknownFields::new(),
-                    cached_size: ::std::cell::Cell::new(0),
-                }
-            })
+            instance.get(VCSGit::new)
         }
     }
 
@@ -6848,6 +7117,14 @@ impl VCSGit {
             None => "",
         }
     }
+
+    fn get_url_for_reflect(&self) -> &::protobuf::SingularField<::std::string::String> {
+        &self.url
+    }
+
+    fn mut_url_for_reflect(&mut self) -> &mut ::protobuf::SingularField<::std::string::String> {
+        &mut self.url
+    }
 }
 
 impl ::protobuf::Message for VCSGit {
@@ -6859,14 +7136,14 @@ impl ::protobuf::Message for VCSGit {
     }
 
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
-        while !try!(is.eof()) {
-            let (field_number, wire_type) = try!(is.read_tag_unpack());
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
-                    try!(::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.url));
+                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.url)?;
                 },
                 _ => {
-                    try!(::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields()));
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
                 },
             };
         }
@@ -6877,8 +7154,8 @@ impl ::protobuf::Message for VCSGit {
     #[allow(unused_variables)]
     fn compute_size(&self) -> u32 {
         let mut my_size = 0;
-        for value in &self.url {
-            my_size += ::protobuf::rt::string_size(1, &value);
+        if let Some(v) = self.url.as_ref() {
+            my_size += ::protobuf::rt::string_size(1, &v);
         };
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
         self.cached_size.set(my_size);
@@ -6887,9 +7164,9 @@ impl ::protobuf::Message for VCSGit {
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.url.as_ref() {
-            try!(os.write_string(1, &v));
+            os.write_string(1, &v)?;
         };
-        try!(os.write_unknown_fields(self.get_unknown_fields()));
+        os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
 
@@ -6905,12 +7182,14 @@ impl ::protobuf::Message for VCSGit {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::any::TypeId {
-        ::std::any::TypeId::of::<VCSGit>()
-    }
-
     fn as_any(&self) -> &::std::any::Any {
         self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -6931,10 +7210,10 @@ impl ::protobuf::MessageStatic for VCSGit {
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_string_accessor(
+                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
                     "url",
-                    VCSGit::has_url,
-                    VCSGit::get_url,
+                    VCSGit::get_url_for_reflect,
+                    VCSGit::mut_url_for_reflect,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<VCSGit>(
                     "VCSGit",
@@ -6953,16 +7232,15 @@ impl ::protobuf::Clear for VCSGit {
     }
 }
 
-impl ::std::cmp::PartialEq for VCSGit {
-    fn eq(&self, other: &VCSGit) -> bool {
-        self.url == other.url &&
-        self.unknown_fields == other.unknown_fields
-    }
-}
-
 impl ::std::fmt::Debug for VCSGit {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
+    }
+}
+
+impl ::protobuf::reflect::ProtobufValue for VCSGit {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 


### PR DESCRIPTION
I inadvertently set the builder-protocol crate to use the wrong build
script when switching from serde_codegen to serde_derive. This commit
provides a fix for that and regenerates the protocols to remove the
warnings on compilation

![gif-keyboard-5141878345474111921](https://cloud.githubusercontent.com/assets/54036/22952571/6208f4ee-f2c2-11e6-8429-8356d3ca54d6.gif)
