### PR TITLE
[sup,hab] Add back `hap-sup config` subcommand.

### DIFF
--- a/components/common/src/command/package/config.rs
+++ b/components/common/src/command/package/config.rs
@@ -22,6 +22,7 @@
 //!
 //! Will show the `default.toml`.
 
+use std::io::{self, Write};
 use std::path::Path;
 
 use hcore::package::{PackageIdent, PackageInstall};
@@ -30,11 +31,19 @@ use toml;
 
 use error::Result;
 
-pub fn start(ident: &PackageIdent, fs_root_path: &Path) -> Result<()> {
-    let package = try!(PackageInstall::load(ident, Some(fs_root_path)));
+pub fn start<P>(ident: &PackageIdent, fs_root_path: P) -> Result<()>
+    where P: AsRef<Path>
+{
+    let package = try!(PackageInstall::load(ident, Some(fs_root_path.as_ref())));
     match package.default_cfg() {
         Some(cfg) => println!("{}", toml::encode_str(&cfg)),
-        None => println!("No '{}' found for {}", DEFAULT_CFG_FILE, &package.ident),
+        None => {
+            writeln!(&mut io::stderr(),
+                     "No '{}' found for {}",
+                     DEFAULT_CFG_FILE,
+                     &package.ident)
+                .expect("Failed printing to stderr")
+        }
     }
     Ok(())
 }

--- a/components/common/src/command/package/mod.rs
+++ b/components/common/src/command/package/mod.rs
@@ -12,4 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub mod config;
 pub mod install;

--- a/components/hab/src/command/pkg/mod.rs
+++ b/components/hab/src/command/pkg/mod.rs
@@ -14,7 +14,6 @@
 
 pub mod binlink;
 pub mod build;
-pub mod config;
 pub mod exec;
 pub mod export;
 pub mod hash;

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -285,7 +285,8 @@ fn sub_pkg_build(ui: &mut UI, m: &ArgMatches) -> Result<()> {
 fn sub_pkg_config(m: &ArgMatches) -> Result<()> {
     let ident = try!(PackageIdent::from_str(m.value_of("PKG_IDENT").unwrap()));
 
-    command::pkg::config::start(&ident, &*FS_ROOT)
+    try!(common::command::package::config::start(&ident, &*FS_ROOT));
+    Ok(())
 }
 
 fn sub_pkg_exec(m: &ArgMatches, cmd_args: Vec<OsString>) -> Result<()> {

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+extern crate habitat_common as common;
+extern crate habitat_core as hcore;
 #[macro_use]
 extern crate habitat_sup as sup;
-extern crate habitat_core as hcore;
 #[macro_use]
 extern crate log;
 extern crate env_logger;
@@ -67,6 +68,7 @@ fn start() -> Result<()> {
     let app_matches = cli().get_matches();
     match app_matches.subcommand() {
         ("bash", Some(m)) => sub_bash(m),
+        ("config", Some(m)) => sub_config(m),
         ("sh", Some(m)) => sub_sh(m),
         ("start", Some(m)) => sub_start(m),
         _ => unreachable!(),
@@ -85,6 +87,12 @@ fn cli<'a, 'b>() -> App<'a, 'b> {
         (@subcommand bash =>
             (about: "Start an interactive Bash-like shell")
             (aliases: &["b", "ba", "bas"])
+        )
+        (@subcommand config =>
+            (about: "Displays the default configuration options for a service")
+            (aliases: &["c", "co", "con", "conf", "confi"])
+            (@arg PKG_IDENT: +required +takes_value
+                "A package identifier (ex: core/redis, core/busybox-static/1.42.2)")
         )
         (@subcommand sh =>
             (about: "Start an interactive Bourne-like shell")
@@ -130,6 +138,13 @@ fn sub_bash(m: &ArgMatches) -> Result<()> {
     }
 
     command::shell::bash()
+}
+
+fn sub_config(m: &ArgMatches) -> Result<()> {
+    let ident = try!(PackageIdent::from_str(m.value_of("PKG_IDENT").unwrap()));
+
+    try!(common::command::package::config::start(&ident, "/"));
+    Ok(())
 }
 
 fn sub_sh(m: &ArgMatches) -> Result<()> {


### PR DESCRIPTION
This change restores the Supervisor's `config` subcommand to preserve
the behavior of the Supervisor in constrained environments, such as
in containers.

Additionally, in the event that the desired package does not have a
`default.toml`, a message explaining this will be printed to the
standard error stream rather than the standard output stream to help
with programs or scripts which may consume the raw TOML data.

References #1689
Fixes #1729

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>