### PR TITLE
Defaults hab origin key export to type=public

### DIFF
--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -96,7 +96,7 @@ pub fn get() -> App<'static, 'static> {
                     (about: "Outputs the latest origin key contents to stdout")
                     (aliases: &["e", "ex", "exp", "expo", "expor"])
                     (@arg ORIGIN: +required +takes_value)
-                    (@arg PAIR_TYPE: -t --type +takes_value +required {valid_pair_type}
+                    (@arg PAIR_TYPE: -t --type +takes_value {valid_pair_type}
                     "Export either the `public' or `secret' key")
                 )
                 (@subcommand generate =>

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -203,7 +203,7 @@ fn sub_origin_key_download(ui: &mut UI, m: &ArgMatches) -> Result<()> {
 
 fn sub_origin_key_export(m: &ArgMatches) -> Result<()> {
     let origin = m.value_of("ORIGIN").unwrap(); // Required via clap
-    let pair_type = try!(PairType::from_str(m.value_of("PAIR_TYPE").unwrap()));
+    let pair_type = try!(PairType::from_str(m.value_of("PAIR_TYPE").unwrap_or("public")));
     init();
 
     command::origin::key::export::start(origin, pair_type, &default_cache_key_path(Some(&*FS_ROOT)))

--- a/www/source/docs/reference/habitat-cli.html.md
+++ b/www/source/docs/reference/habitat-cli.html.md
@@ -165,7 +165,7 @@ Outputs the latest origin key contents to stdout
 
 **OPTIONS**
 
-    -t, --type <PAIR_TYPE>    Export either the `public' or `secret' key
+    -t, --type <PAIR_TYPE>    Export either the `public' or `secret' key (default: public)
 
 **ARGS**
 


### PR DESCRIPTION
This change makes the `--type` option to `hab origin key export`
command optional, and defaults it to public if not specified.

```
../../target/debug/hab origin key export <origin>
SIG-PUB-1
<origin>-<timestamp>

<supersecretkeydata>
```

Fixes #1728 

Signed-off-by: Nolan Davidson <ndavidson@chef.io>