### PR TITLE
[hab/mac] Update Mac builds with 0.17.0 updates.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -180,11 +180,10 @@ Next we will be running the same commands for hab-butterfly, hab-sup, and hab-su
     ```
     $ cd ~/code/habitat/components/hab/mac
     $ vagrant destroy
+    $ export ORIGIN_KEY=$(hab origin key export core --type secret)
     $ vagrant up
     $ vagrant ssh
     ```
-
-1. Have the secret core origin key ready for pasting into the terminal. The `mac-build.sh` script will interactively prompt for pasting the key contents if no core origin key is installed on the VM.
 
 1. Build Hab for Mac
 

--- a/components/hab/mac/Vagrantfile
+++ b/components/hab/mac/Vagrantfile
@@ -5,4 +5,9 @@ Vagrant.configure("2") do |config|
     v.vmx["memsize"] = (5 * 1024).to_s
     v.vmx["numvcpus"] = "4"
   end
+  if key = ENV.has_key?("ORIGIN_KEY")
+    config.vm.provision "shell", inline: <<-EOF
+      echo '#{ENV.fetch("ORIGIN_KEY")}' > /tmp/hab.sig.key
+    EOF
+  end
 end

--- a/components/hab/mac/homebrew/hab-rq.rb
+++ b/components/hab/mac/homebrew/hab-rq.rb
@@ -1,0 +1,15 @@
+class HabRq < Formula
+  desc "Record Query - A tool for doing record analysis and transformation"
+  homepage "https://github.com/dflemstr/rq"
+  url "https://github.com/dflemstr/rq/releases/download/v0.9.2/rq-x86_64-apple-darwin"
+  sha256 "fbc9347d83ee575c10251ad2fff9c31a78c42d4cedc14bbb9be72739ed619496"
+
+  def install
+    mv "rq-x86_64-apple-darwin", "rq", verbose: true
+    bin.install "rq"
+  end
+
+  test do
+    system "#{bin}/rq", "--version"
+  end
+end

--- a/components/hab/mac/mac-build.sh
+++ b/components/hab/mac/mac-build.sh
@@ -52,8 +52,11 @@ fi
 while true; do
   if [[ $(ls -1 /hab/cache/keys/core-*.sig.key 2> /dev/null | wc -l) -gt 0 ]]; then
     break
+  elif [[ -f /tmp/hab.sig.key ]]; then
+    cat /tmp/hab.sig.key | hab origin key import
+    rm -f /tmp/hab.sig.key
   else
-    printf ${HAB_ORIGIN_KEY} | hab origin key import
+    printf ${ORIGIN_KEY} | hab origin key import
   fi
 done
 
@@ -80,6 +83,8 @@ fi
 install_if_missing coreutils
 install_if_missing gnu-tar
 install_if_missing wget
+install_if_missing bash
+install_if_missing hab-rq $(dirname $0)/homebrew/hab-rq.rb
 
 # Homebrew packages required to build `hab`
 install_if_missing zlib homebrew/dupes/zlib
@@ -101,10 +106,11 @@ fi
 info "Updating PATH to include GNU toolchain from HomeBrew"
 gnu_path="$(brew --prefix coreutils)/libexec/gnubin"
 gnu_path="$gnu_path:$(brew --prefix gnu-tar)/libexec/gnubin"
+gnu_path="$gnu_path:$(brew --prefix bash)/bin"
 export PATH="$gnu_path:$PATH"
 info "Setting PATH=$PATH"
 
 program="$(dirname $0)/../../plan-build/bin/hab-plan-build.sh"
 info "Executing: $program $*"
 echo
-exec $program $*
+exec $(brew --prefix bash)/bin/bash $program $*


### PR DESCRIPTION
This change makes the Mac builds work against master by:

* Importing the origin signing key, similar to the Windows build
* Runs `hab-plan-build.sh` with a newer version of GNU/Bash 4.x to support the export/exposes feature
* Adds `rq` to the system via a custom Homebrew formula to pass the `hab-plan-build.sh` system command checks

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>