### PR TITLE
Refresh and reinitialize service after package update

### DIFF
--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -282,7 +282,7 @@ impl Manager {
                         .clone()
                 };
                 let incarnation = rumor.get_incarnation() + 1;
-                rumor.set_pkg(service.package.to_string());
+                rumor.set_pkg(service.package().to_string());
                 rumor.set_incarnation(incarnation);
                 service.populate(&census_list);
                 match service.config.to_exported() {

--- a/components/sup/src/manager/service/config.rs
+++ b/components/sup/src/manager/service/config.rs
@@ -81,10 +81,9 @@ impl ServiceConfig {
     pub fn new(package: &PackageInstall,
                mgr_cfg: &ManagerConfig,
                runtime_cfg: &RuntimeConfig,
-               config_root: Option<PathBuf>,
+               config_root: PathBuf,
                bindings: Vec<(String, ServiceGroup)>)
                -> Result<ServiceConfig> {
-        let config_root = config_root.unwrap_or(package.installed_path.clone());
         Ok(ServiceConfig {
             pkg: Pkg::new(package, runtime_cfg)?,
             hab: Hab::new(),
@@ -226,6 +225,17 @@ impl ServiceConfig {
         }
         self.needs_write = false;
         Ok(should_restart)
+    }
+
+    pub fn reload_package(&mut self,
+                          package: &PackageInstall,
+                          config_root: PathBuf,
+                          runtime: &RuntimeConfig)
+                          -> Result<()> {
+        self.config_root = config_root;
+        self.pkg = Pkg::new(package, runtime)?;
+        self.cfg = Cfg::new(package, &self.config_root)?;
+        Ok(())
     }
 }
 
@@ -661,7 +671,7 @@ mod test {
         let sc = ServiceConfig::new(&pkg,
                                     &ManagerConfig::default(),
                                     &RuntimeConfig::default(),
-                                    None,
+                                    PathBuf::from("/hab/pkgs/neurosis/redis/2000/20160222201258"),
                                     Vec::new())
             .unwrap();
         let toml = sc.to_toml().unwrap();
@@ -675,7 +685,7 @@ mod test {
         let sc = ServiceConfig::new(&pkg,
                                     &ManagerConfig::default(),
                                     &RuntimeConfig::default(),
-                                    None,
+                                    PathBuf::from("/hab/pkgs/neurosis/redis/2000/20160222201258"),
                                     Vec::new())
             .unwrap();
         let toml = sc.to_toml().unwrap();
@@ -689,7 +699,7 @@ mod test {
         let sc = ServiceConfig::new(&pkg,
                                     &ManagerConfig::default(),
                                     &RuntimeConfig::default(),
-                                    None,
+                                    PathBuf::from("/hab/pkgs/neurosis/redis/2000/20160222201258"),
                                     Vec::new())
             .unwrap();
         let toml = sc.to_toml().unwrap();

--- a/components/sup/src/manager/service_updater.rs
+++ b/components/sup/src/manager/service_updater.rs
@@ -99,7 +99,7 @@ impl ServiceUpdater {
             Some(&mut UpdaterState::AtOnce(ref mut rx)) => {
                 match rx.try_recv() {
                     Ok(package) => {
-                        service.package = package;
+                        service.update_package(package);
                         service.needs_restart = true;
                         return true;
                     }
@@ -162,7 +162,7 @@ impl ServiceUpdater {
                         match rx.try_recv() {
                             Ok(package) => {
                                 debug!("Rolling Update, polling found a new package");
-                                service.package = package;
+                                service.update_package(package);
                                 service.needs_restart = true;
                             }
                             Err(TryRecvError::Empty) => return false,
@@ -233,7 +233,7 @@ impl ServiceUpdater {
                             Some(census) => {
                                 match rx.try_recv() {
                                     Ok(package) => {
-                                        service.package = package;
+                                        service.update_package(package);
                                         service.needs_restart = true;
                                     }
                                     Err(TryRecvError::Empty) => return false,
@@ -276,7 +276,7 @@ struct Worker {
 impl Worker {
     pub fn new(service: &Service) -> Self {
         Worker {
-            current: service.package.ident().clone(),
+            current: service.package().ident().clone(),
             spec_ident: service.spec_ident.clone(),
             depot: depot_client::Client::new(&service.depot_url, PRODUCT, VERSION, None).unwrap(),
             ui: UI::default(),

--- a/components/sup/src/templating/mod.rs
+++ b/components/sup/src/templating/mod.rs
@@ -172,7 +172,7 @@ mod test {
         let sc = ServiceConfig::new(&pkg,
                                     &ManagerConfig::default(),
                                     &RuntimeConfig::default(),
-                                    None,
+                                    PathBuf::from("/hab/pkgs/neurosis/redis/2000/20160222201258"),
                                     Vec::new())
             .unwrap();
         let toml = sc.to_toml().unwrap();


### PR DESCRIPTION
Updates are currently broken because updated packages are not refreshing internal package data, reloading hooks and reinitializing the service.

This PR ensures that when a package is updated:
1. The data in the service, config and supervisor is refreshed with new package metadata and identity
2. All hooks are reloaded with the new template location
3. All hooks are recompiled
4. the init hook is run
5. and the run hook is copied to the run location

This uses an Arc<RwLock<<PackageInstall>> to share and access package data accross the service and supervisor to keep them synchronized.

Signed-off-by: Matt Wrock <matt@mattwrock.com>