### PR TITLE
[hab] Refactor `install.sh` for Habitat 'hab' program.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ See [BUILDING.md](BUILDING.md) for platform specific info on building Habitat fr
 * [Writing Robust Bash Shell Scripts](http://www.davidpashley.com/articles/writing-robust-shell-scripts/)
 * [Wikibook: Bourne Shell Scripting](https://en.wikibooks.org/wiki/Bourne_Shell_Scripting)
 * [What is the difference between test, \[ and \[\[ ?](http://mywiki.wooledge.org/BashFAQ/031)
+* [POSIX Shell Command Language](http://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html)
 
 
 ## License


### PR DESCRIPTION
* Uses a consistent, minimal POSIX shell style which passes a shellcheck
  execution of `shellcheck -e SC2039 components/hab/install.sh`
* Executes with minimal shell implementations such as Busybox's `sh`
  (used in Alpine linux, for example), Ubuntu's `dash`, vanilla `sh`,
  as well as `bash`
* Uses a command set consistent with a base macOS installation for Mac
  systems and a Busybox userland for Linux systems (in addition to an
  SSL-enabled `wget` or `curl`)
* Ensures that each function has explicit required command checks via the
  `need_cmd()` function (an idea borrowed from Rust's rustup shell wrapper)
* Renders minimal structured output via `info()` and `exit_with()`
  functions (currently no color support)
* Randomizes temporary work directory via `mktemp` while still preferring
  a subdirectory of `/var/tmp` for Red Hat systems that have nosuid set
  on `/tmp` file system mounts
* Only strictly supports the targets that Habitat currently supports,
  namely x86_64-linux and x86_64-darwin (unix-based) which reduces
  additional checks and fallbacks that are never exercised but need to be
  reviewed and tested
* Fixes several unset variable issues when `set -u` was being truely
  honored (issues were not present in all shells)
* Increases the internal consistency of UI output with the rest of the
  Habitat ecosystem
* Modularizes work into smaller functions with a `main()` entrypoint
  (hey, that's a bit like a Rust program)
* Inspired from Chef's mixlib-install [function helpers][mixlib], Rust's
  rustup [installer wrapper][rustup], the [Studio codebase][studio], and
  the [launch-era][launch] simplified version
* Removes progress bars for `curl` and `wget` file downloads
* Preserves channel support via `-c` flag
* Preserves specific version support via `-v` flag
* Add help/usage via `-h` flag

Tested against:

* macOS 10.9 and 10.10
* Alpine Linux (via `alpine:3.4` Docker image)
* Ubuntu Linux (via `ubuntu:16.04` Docker image)
* CentOS Linux (via `centos:7` Docker image)

[mixlib]:
https://github.com/chef/mixlib-install/blob/master/support/install_command.sh
[rustup]:
https://github.com/rust-lang-nursery/rustup.rs/blob/master/rustup-init.sh
[studio]:
https://github.com/habitat-sh/habitat/blob/master/components/studio/bin/hab-studio.sh
[launch]:
https://github.com/habitat-sh/habitat/blob/ae943e0cb7ec3c882105065f7b1eaa1994a4350e/components/hab/install.sh

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>