### PR TITLE
Remove text from Call To Action

### DIFF
--- a/www/source/index.html.slim
+++ b/www/source/index.html.slim
@@ -16,8 +16,6 @@ section.home--hero
         .home--button-wrap.hero
           = link_to 'Try Habitat Now', '/try', class: "button cta"
           = link_to 'Download Habitat', '/docs/get-habitat', class: "button cta outline"
-          p
-            | Take a quick, interactive tour of Habitat features, or download the bits and get your hands dirty
 
 section.home--sub-hero
   .row

--- a/www/source/layouts/_footer.slim
+++ b/www/source/layouts/_footer.slim
@@ -6,9 +6,6 @@ footer#main-footer class="#{layout_class}"
           h2.footer--cta-heading See how it works in less than 10 minutes.
           a.footer--cta-button href="/try" Try Habitat Now
           a.footer--cta-button.outline href="/docs/get-habitat" Download Habitat
-          p.footer--cta-subtext
-            | Take a quick, interactive tour of Habitat features<br/>
-              or download the bits and get your hands dirty.
 
   .footer--sitemap
     .row


### PR DESCRIPTION
Signed-off-by: Michael Ducy <michael@chef.io>

Removing the Call To Action text because it is superfluous.