### PR TITLE
"Fix" deserialization of `ServiceConfig` inside Handlebars Helper

### DIFF
--- a/components/butterfly/src/rumor/service.rs
+++ b/components/butterfly/src/rumor/service.rs
@@ -146,9 +146,13 @@ pub struct SysInfo {
     pub ip: String,
     pub hostname: String,
     pub gossip_ip: String,
-    pub gossip_port: u16,
+    // TODO: revert to u16 when deserializing in the handlebars template
+    // works properly
+    pub gossip_port: String,
     pub http_gateway_ip: String,
-    pub http_gateway_port: u16,
+    // TODO: revert to u16 when deserializing in the handlebars template
+    // works properly
+    pub http_gateway_port: String,
 }
 
 #[cfg(test)]

--- a/components/sup/src/manager/census.rs
+++ b/components/sup/src/manager/census.rs
@@ -300,7 +300,7 @@ impl CensusEntry {
     pub fn populate_from_member(&mut self, member: &Member) {
         self.set_member_id(String::from(member.get_id()));
         self.sys.gossip_ip = member.get_address().to_string();
-        self.sys.gossip_port = member.get_gossip_port() as u16;
+        self.sys.gossip_port = member.get_gossip_port().to_string();
         self.set_persistent(true);
     }
 

--- a/components/sup/src/manager/service/config.rs
+++ b/components/sup/src/manager/service/config.rs
@@ -549,9 +549,9 @@ impl Sys {
             ip: ip,
             hostname: hostname,
             gossip_ip: manager_cfg.gossip_listen.ip().to_string(),
-            gossip_port: manager_cfg.gossip_listen.port(),
+            gossip_port: manager_cfg.gossip_listen.port().to_string(),
             http_gateway_ip: manager_cfg.http_listen.ip().to_string(),
-            http_gateway_port: manager_cfg.http_listen.port(),
+            http_gateway_port: manager_cfg.http_listen.port().to_string(),
         })
     }
 

--- a/components/sup/tests/fixtures/complex_config.toml
+++ b/components/sup/tests/fixtures/complex_config.toml
@@ -1,0 +1,350 @@
+[bind]
+
+[cfg]
+
+[hab]
+version = "0.0.0"
+
+[pkg]
+exposes = []
+ident = "smith/lsyncd/0.1.0/20170215230753"
+name = "lsyncd"
+origin = "smith"
+path = "/hab/pkgs/smith/lsyncd/0.1.0/20170215230753"
+release = "20170215230753"
+svc_config_path = "/hab/svc/lsyncd/config"
+svc_data_path = "/hab/svc/lsyncd/data"
+svc_files_path = "/hab/svc/lsyncd/files"
+svc_group = "hab"
+svc_path = "/hab/svc/lsyncd"
+svc_static_path = "/hab/svc/lsyncd/static"
+svc_user = "hab"
+svc_var_path = "/hab/svc/lsyncd/var"
+version = "0.1.0"
+
+[[pkg.deps]]
+name = "acl"
+origin = "core"
+release = "20161208223311"
+version = "2.2.52"
+
+[[pkg.deps]]
+name = "attr"
+origin = "core"
+release = "20161208223238"
+version = "2.4.47"
+
+[[pkg.deps]]
+name = "bzip2"
+origin = "core"
+release = "20161208225359"
+version = "1.0.6"
+
+[[pkg.deps]]
+name = "coreutils"
+origin = "core"
+release = "20161208223423"
+version = "8.25"
+
+[[pkg.deps]]
+name = "db"
+origin = "core"
+release = "20161213234940"
+version = "5.3.28"
+
+[[pkg.deps]]
+name = "gcc-libs"
+origin = "core"
+release = "20161208223920"
+version = "5.2.0"
+
+[[pkg.deps]]
+name = "gdbm"
+origin = "core"
+release = "20161208225425"
+version = "1.11"
+
+[[pkg.deps]]
+name = "glibc"
+origin = "core"
+release = "20160612063629"
+version = "2.22"
+
+[[pkg.deps]]
+name = "gmp"
+origin = "core"
+release = "20161208212521"
+version = "6.1.0"
+
+[[pkg.deps]]
+name = "less"
+origin = "core"
+release = "20161213235230"
+version = "481"
+
+[[pkg.deps]]
+name = "libcap"
+origin = "core"
+release = "20161208223353"
+version = "2.24"
+
+[[pkg.deps]]
+name = "linux-headers"
+origin = "core"
+release = "20160612063537"
+version = "4.3"
+
+[[pkg.deps]]
+name = "lsyncd"
+origin = "core"
+release = "20170215185907"
+version = "2.1.6"
+
+[[pkg.deps]]
+name = "ncurses"
+origin = "core"
+release = "20161213233720"
+version = "6.0"
+
+[[pkg.deps]]
+name = "pcre"
+origin = "core"
+release = "20161213233903"
+version = "8.38"
+
+[[pkg.deps]]
+name = "perl"
+origin = "core"
+release = "20161213235304"
+version = "5.22.1"
+
+[[pkg.deps]]
+name = "rsync"
+origin = "core"
+release = "20161215000807"
+version = "3.1.2"
+
+[[pkg.deps]]
+name = "zlib"
+origin = "core"
+release = "20161118033245"
+version = "1.2.8"
+
+[pkg.exports]
+
+[svc]
+group = "default"
+ident = "lsyncd.default"
+service = "lsyncd"
+
+[[svc.all]]
+group = "default"
+ident = "lsyncd.default"
+service = "lsyncd"
+
+[svc.all.me]
+group = "default"
+member_id = "b3130c943a2d481492af62891f34cad3"
+service = "lsyncd"
+
+[svc.all.me.cfg]
+
+[svc.all.me.pkg]
+name = "lsyncd"
+origin = "smith"
+release = "20170215230753"
+version = "0.1.0"
+
+[svc.all.me.sys]
+gossip_ip = "0.0.0.0"
+gossip_port = "9638"
+hostname = "ef8549a34328"
+http_gateway_ip = "0.0.0.0"
+http_gateway_port = "9631"
+ip = "172.17.0.4"
+
+[svc.all.member_id]
+[svc.all.member_id.b3130c943a2d481492af62891f34cad3]
+group = "default"
+member_id = "b3130c943a2d481492af62891f34cad3"
+service = "lsyncd"
+
+[svc.all.member_id.b3130c943a2d481492af62891f34cad3.cfg]
+
+[svc.all.member_id.b3130c943a2d481492af62891f34cad3.pkg]
+name = "lsyncd"
+origin = "smith"
+release = "20170215230753"
+version = "0.1.0"
+
+[svc.all.member_id.b3130c943a2d481492af62891f34cad3.sys]
+gossip_ip = "0.0.0.0"
+gossip_port = "9638"
+hostname = "ef8549a34328"
+http_gateway_ip = "0.0.0.0"
+http_gateway_port = "9631"
+ip = "172.17.0.4"
+
+[[svc.all.members]]
+group = "default"
+member_id = "b3130c943a2d481492af62891f34cad3"
+service = "lsyncd"
+
+[svc.all.members.cfg]
+
+[svc.all.members.pkg]
+name = "lsyncd"
+origin = "smith"
+release = "20170215230753"
+version = "0.1.0"
+
+[svc.all.members.sys]
+gossip_ip = "0.0.0.0"
+gossip_port = "9638"
+hostname = "ef8549a34328"
+http_gateway_ip = "0.0.0.0"
+http_gateway_port = "9631"
+ip = "172.17.0.4"
+
+[svc.me]
+group = "default"
+member_id = "b3130c943a2d481492af62891f34cad3"
+service = "lsyncd"
+
+[svc.me.cfg]
+
+[svc.me.pkg]
+name = "lsyncd"
+origin = "smith"
+release = "20170215230753"
+version = "0.1.0"
+
+[svc.me.sys]
+gossip_ip = "0.0.0.0"
+gossip_port = "9638"
+hostname = "ef8549a34328"
+http_gateway_ip = "0.0.0.0"
+http_gateway_port = "9631"
+ip = "172.17.0.4"
+
+[svc.member_id]
+[svc.member_id.b3130c943a2d481492af62891f34cad3]
+group = "default"
+member_id = "b3130c943a2d481492af62891f34cad3"
+service = "lsyncd"
+
+[svc.member_id.b3130c943a2d481492af62891f34cad3.cfg]
+
+[svc.member_id.b3130c943a2d481492af62891f34cad3.pkg]
+name = "lsyncd"
+origin = "smith"
+release = "20170215230753"
+version = "0.1.0"
+
+[svc.member_id.b3130c943a2d481492af62891f34cad3.sys]
+gossip_ip = "0.0.0.0"
+gossip_port = "9638"
+hostname = "ef8549a34328"
+http_gateway_ip = "0.0.0.0"
+http_gateway_port = "9631"
+ip = "172.17.0.4"
+
+[[svc.members]]
+group = "default"
+member_id = "b3130c943a2d481492af62891f34cad3"
+service = "lsyncd"
+
+[svc.members.cfg]
+
+[svc.members.pkg]
+name = "lsyncd"
+origin = "smith"
+release = "20170215230753"
+version = "0.1.0"
+
+[svc.members.sys]
+gossip_ip = "0.0.0.0"
+gossip_port = "9638"
+hostname = "ef8549a34328"
+http_gateway_ip = "0.0.0.0"
+http_gateway_port = "9631"
+ip = "172.17.0.4"
+
+[svc.named]
+[svc.named.lsyncd]
+[svc.named.lsyncd.default]
+group = "default"
+ident = "lsyncd.default"
+service = "lsyncd"
+
+[svc.named.lsyncd.default.me]
+group = "default"
+member_id = "b3130c943a2d481492af62891f34cad3"
+service = "lsyncd"
+
+[svc.named.lsyncd.default.me.cfg]
+
+[svc.named.lsyncd.default.me.pkg]
+name = "lsyncd"
+origin = "smith"
+release = "20170215230753"
+version = "0.1.0"
+
+[svc.named.lsyncd.default.me.sys]
+gossip_ip = "0.0.0.0"
+gossip_port = "9638"
+hostname = "ef8549a34328"
+http_gateway_ip = "0.0.0.0"
+http_gateway_port = "9631"
+ip = "172.17.0.4"
+
+[svc.named.lsyncd.default.member_id]
+[svc.named.lsyncd.default.member_id.b3130c943a2d481492af62891f34cad3]
+group = "default"
+member_id = "b3130c943a2d481492af62891f34cad3"
+service = "lsyncd"
+
+[svc.named.lsyncd.default.member_id.b3130c943a2d481492af62891f34cad3.cfg]
+
+[svc.named.lsyncd.default.member_id.b3130c943a2d481492af62891f34cad3.pkg]
+name = "lsyncd"
+origin = "smith"
+release = "20170215230753"
+version = "0.1.0"
+
+[svc.named.lsyncd.default.member_id.b3130c943a2d481492af62891f34cad3.sys]
+gossip_ip = "0.0.0.0"
+gossip_port = "9638"
+hostname = "ef8549a34328"
+http_gateway_ip = "0.0.0.0"
+http_gateway_port = "9631"
+ip = "172.17.0.4"
+
+[[svc.named.lsyncd.default.members]]
+group = "default"
+member_id = "b3130c943a2d481492af62891f34cad3"
+service = "lsyncd"
+
+[svc.named.lsyncd.default.members.cfg]
+
+[svc.named.lsyncd.default.members.pkg]
+name = "lsyncd"
+origin = "smith"
+release = "20170215230753"
+version = "0.1.0"
+
+[svc.named.lsyncd.default.members.sys]
+gossip_ip = "0.0.0.0"
+gossip_port = "9638"
+hostname = "ef8549a34328"
+http_gateway_ip = "0.0.0.0"
+http_gateway_port = "9631"
+ip = "172.17.0.4"
+
+[sys]
+gossip_ip = "0.0.0.0"
+gossip_port = "9638"
+hostname = "ef8549a34328"
+http_gateway_ip = "0.0.0.0"
+http_gateway_port = "9631"
+ip = "172.17.0.4"

--- a/components/sup/tests/fixtures/simple_config.toml
+++ b/components/sup/tests/fixtures/simple_config.toml
@@ -1,0 +1,248 @@
+[bind]
+
+[cfg]
+
+[hab]
+version = "0.0.0"
+
+[pkg]
+exposes = []
+ident = "core/testplan/0.1.0/20170208180805"
+name = "testplan"
+origin = "core"
+path = "/hab/pkgs/core/testplan/0.1.0/20170208180805"
+release = "20170208180805"
+svc_config_path = "/hab/svc/testplan/config"
+svc_data_path = "/hab/svc/testplan/data"
+svc_files_path = "/hab/svc/testplan/files"
+svc_group = "hab"
+svc_path = "/hab/svc/testplan"
+svc_static_path = "/hab/svc/testplan/static"
+svc_user = "hab"
+svc_var_path = "/hab/svc/testplan/var"
+version = "0.1.0"
+
+[[pkg.deps]]
+name = "jq-static"
+origin = "core"
+release = "20160909011845"
+version = "1.10"
+
+[pkg.exports]
+
+[svc]
+group = "mylab"
+ident = "testplan.mylab"
+service = "testplan"
+
+[[svc.all]]
+group = "mylab"
+ident = "testplan.mylab"
+service = "testplan"
+
+[svc.all.me]
+group = "mylab"
+member_id = "4ae2fbfbf3b74b2695071a61074f1798"
+service = "testplan"
+
+[svc.all.me.cfg]
+
+[svc.all.me.pkg]
+name = "testplan"
+origin = "core"
+release = "20170208180805"
+version = "0.1.0"
+
+[svc.all.me.sys]
+gossip_ip = "127.0.0.1"
+gossip_port = "9010"
+hostname = "privatedepot"
+http_gateway_ip = "0.0.0.0"
+http_gateway_port = "8010"
+ip = "10.0.0.4"
+
+[svc.all.member_id]
+[svc.all.member_id.4ae2fbfbf3b74b2695071a61074f1798]
+group = "mylab"
+member_id = "4ae2fbfbf3b74b2695071a61074f1798"
+service = "testplan"
+
+[svc.all.member_id.4ae2fbfbf3b74b2695071a61074f1798.cfg]
+
+[svc.all.member_id.4ae2fbfbf3b74b2695071a61074f1798.pkg]
+name = "testplan"
+origin = "core"
+release = "20170208180805"
+version = "0.1.0"
+
+[svc.all.member_id.4ae2fbfbf3b74b2695071a61074f1798.sys]
+gossip_ip = "127.0.0.1"
+gossip_port = "9010"
+hostname = "privatedepot"
+http_gateway_ip = "0.0.0.0"
+http_gateway_port = "8010"
+ip = "10.0.0.4"
+
+[[svc.all.members]]
+group = "mylab"
+member_id = "4ae2fbfbf3b74b2695071a61074f1798"
+service = "testplan"
+
+[svc.all.members.cfg]
+
+[svc.all.members.pkg]
+name = "testplan"
+origin = "core"
+release = "20170208180805"
+version = "0.1.0"
+
+[svc.all.members.sys]
+gossip_ip = "127.0.0.1"
+gossip_port = "9010"
+hostname = "privatedepot"
+http_gateway_ip = "0.0.0.0"
+http_gateway_port = "8010"
+ip = "10.0.0.4"
+
+[svc.me]
+group = "mylab"
+member_id = "4ae2fbfbf3b74b2695071a61074f1798"
+service = "testplan"
+
+[svc.me.cfg]
+
+[svc.me.pkg]
+name = "testplan"
+origin = "core"
+release = "20170208180805"
+version = "0.1.0"
+
+[svc.me.sys]
+gossip_ip = "127.0.0.1"
+gossip_port = "9010"
+hostname = "privatedepot"
+http_gateway_ip = "0.0.0.0"
+http_gateway_port = "8010"
+ip = "10.0.0.4"
+
+[svc.member_id]
+[svc.member_id.4ae2fbfbf3b74b2695071a61074f1798]
+group = "mylab"
+member_id = "4ae2fbfbf3b74b2695071a61074f1798"
+service = "testplan"
+
+[svc.member_id.4ae2fbfbf3b74b2695071a61074f1798.cfg]
+
+[svc.member_id.4ae2fbfbf3b74b2695071a61074f1798.pkg]
+name = "testplan"
+origin = "core"
+release = "20170208180805"
+version = "0.1.0"
+
+[svc.member_id.4ae2fbfbf3b74b2695071a61074f1798.sys]
+gossip_ip = "127.0.0.1"
+gossip_port = "9010"
+hostname = "privatedepot"
+http_gateway_ip = "0.0.0.0"
+http_gateway_port = "8010"
+ip = "10.0.0.4"
+
+[[svc.members]]
+group = "mylab"
+member_id = "4ae2fbfbf3b74b2695071a61074f1798"
+service = "testplan"
+
+[svc.members.cfg]
+
+[svc.members.pkg]
+name = "testplan"
+origin = "core"
+release = "20170208180805"
+version = "0.1.0"
+
+[svc.members.sys]
+gossip_ip = "127.0.0.1"
+gossip_port = "9010"
+hostname = "privatedepot"
+http_gateway_ip = "0.0.0.0"
+http_gateway_port = "8010"
+ip = "10.0.0.4"
+
+[svc.named]
+[svc.named.testplan]
+[svc.named.testplan.mylab]
+group = "mylab"
+ident = "testplan.mylab"
+service = "testplan"
+
+[svc.named.testplan.mylab.me]
+group = "mylab"
+member_id = "4ae2fbfbf3b74b2695071a61074f1798"
+service = "testplan"
+
+[svc.named.testplan.mylab.me.cfg]
+
+[svc.named.testplan.mylab.me.pkg]
+name = "testplan"
+origin = "core"
+release = "20170208180805"
+version = "0.1.0"
+
+[svc.named.testplan.mylab.me.sys]
+gossip_ip = "127.0.0.1"
+gossip_port = "9010"
+hostname = "privatedepot"
+http_gateway_ip = "0.0.0.0"
+http_gateway_port = "8010"
+ip = "10.0.0.4"
+
+[svc.named.testplan.mylab.member_id]
+[svc.named.testplan.mylab.member_id.4ae2fbfbf3b74b2695071a61074f1798]
+group = "mylab"
+member_id = "4ae2fbfbf3b74b2695071a61074f1798"
+service = "testplan"
+
+[svc.named.testplan.mylab.member_id.4ae2fbfbf3b74b2695071a61074f1798.cfg]
+
+[svc.named.testplan.mylab.member_id.4ae2fbfbf3b74b2695071a61074f1798.pkg]
+name = "testplan"
+origin = "core"
+release = "20170208180805"
+version = "0.1.0"
+
+[svc.named.testplan.mylab.member_id.4ae2fbfbf3b74b2695071a61074f1798.sys]
+gossip_ip = "127.0.0.1"
+gossip_port = "9010"
+hostname = "privatedepot"
+http_gateway_ip = "0.0.0.0"
+http_gateway_port = "8010"
+ip = "10.0.0.4"
+
+[[svc.named.testplan.mylab.members]]
+group = "mylab"
+member_id = "4ae2fbfbf3b74b2695071a61074f1798"
+service = "testplan"
+
+[svc.named.testplan.mylab.members.cfg]
+
+[svc.named.testplan.mylab.members.pkg]
+name = "testplan"
+origin = "core"
+release = "20170208180805"
+version = "0.1.0"
+
+[svc.named.testplan.mylab.members.sys]
+gossip_ip = "127.0.0.1"
+gossip_port = "9010"
+hostname = "privatedepot"
+http_gateway_ip = "0.0.0.0"
+http_gateway_port = "8010"
+ip = "10.0.0.4"
+
+[sys]
+gossip_ip = "127.0.0.1"
+gossip_port = "9010"
+hostname = "privatedepot"
+http_gateway_ip = "0.0.0.0"
+http_gateway_port = "8010"
+ip = "10.0.0.4"


### PR DESCRIPTION
This fills me with sadness and regret, but no numeric type would deserialize properly in the context of the handlebars helper.

When using `serde_json::from_value` outside of the handlebars context, values resolved properly.

By changing `gossip_port` and `http_gateway_port` on `SysInfo` into strings, things work as expected.

If we were to bump the version of handlebars or serde/serde_json, we hit some breaking changes in serde 0.9.x which will require a bit of work to sort out (which we'll need to do, but that's a much broader change to fixing this localized problem).

Fixes #1773 

Signed-off-by: Steven Murawski <steven.murawski@gmail.com>