### PR TITLE
[sup] Enable supervisor to start with no services.

### DIFF
--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -109,7 +109,7 @@ fn cli<'a, 'b>() -> App<'a, 'b> {
                 "The listen address of an initial peer (IP[:PORT])")
             (@arg PERMANENT_PEER: --("permanent-peer") -I "If this service is a permanent peer")
             (@arg RING: --ring -r +takes_value "Ring key name")
-            (@arg PKG_IDENT_OR_ARTIFACT: +required
+            (@arg PKG_IDENT_OR_ARTIFACT:
                 "A Habitat package identifier (ex: acme/redis) or filepath to a Habitat Artifact \
                 (ex: /home/acme-redis-3.0.7-21120102031201-x86_64-linux.hart)")
             (@group SVC_ARGS =>
@@ -229,16 +229,20 @@ fn sub_start(m: &ArgMatches) -> Result<()> {
     }
 
     let mut maybe_local_artifact: Option<&str> = None;
-    let ident_or_artifact = m.value_of("PKG_IDENT_OR_ARTIFACT").unwrap();
-    let ident = if Path::new(ident_or_artifact).is_file() {
-        maybe_local_artifact = Some(ident_or_artifact);
-        try!(PackageArchive::new(Path::new(ident_or_artifact)).ident())
-    } else {
-        try!(PackageIdent::from_str(ident_or_artifact))
+    let maybe_spec = match m.value_of("PKG_IDENT_OR_ARTIFACT") {
+        Some(ident_or_artifact) => {
+            let ident = if Path::new(ident_or_artifact).is_file() {
+                maybe_local_artifact = Some(ident_or_artifact);
+                try!(PackageArchive::new(Path::new(ident_or_artifact)).ident())
+            } else {
+                try!(PackageIdent::from_str(ident_or_artifact))
+            };
+            Some(try!(spec_from_matches(&ident, m)))
+        }
+        None => None,
     };
-    let spec = try!(spec_from_matches(&ident, m));
 
-    try!(command::start::package(cfg, spec, maybe_local_artifact));
+    try!(command::start::package(cfg, maybe_spec, maybe_local_artifact));
     Ok(())
 }
 


### PR DESCRIPTION
This change alters to CLI parsing logic of `hab-sup start` to make the
`PKG_IDENT_OR_ARTIFACT` argument optional. In this mode all
service-related options and flags are turned illegal and will cause the
program to abort if attempted. For example `hab-sup start --group nope`
would fail whereas `hab-sup start core/redis --group nope` would
succeed.

All previous behavior has been preserved, so in this respect it is not a
breaking change. To make the package identifier optional is the only
external "breaking change" in that there is net-new behavior that has
previously been not possible.

It is glorious and fast:

```
> hab-sup start
hab-sup(MR): Butterfly Member ID 39dfde6f41a74f688074c2b36cdedcda
hab-sup(CS): **Note**: No package identifier or artifact file was provided so no services will be started
hab-sup(MR): Starting butterfly on 0.0.0.0:9638
hab-sup(MR): Starting http-gateway on 0.0.0.0:9631
```