### PR TITLE
[sup] Refactor Service to install itself & load from a ServiceSpec.

### DIFF
--- a/components/sup/src/util/mod.rs
+++ b/components/sup/src/util/mod.rs
@@ -14,6 +14,7 @@
 
 pub mod convert;
 pub mod path;
+pub mod pkg;
 pub mod sys;
 pub mod users;
 

--- a/components/sup/src/util/pkg.rs
+++ b/components/sup/src/util/pkg.rs
@@ -1,0 +1,63 @@
+// Copyright (c) 2016-2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::path::Path;
+
+use common;
+use common::ui::UI;
+use depot_client::Client;
+use hcore::fs::{self, FS_ROOT_PATH};
+use hcore::package::{PackageIdent, PackageInstall};
+
+use {PRODUCT, VERSION};
+use error::Result;
+use manager::ServiceSpec;
+
+static LOGKEY: &'static str = "PK";
+
+pub fn install(ui: &mut UI, depot_url: &str, ident: &PackageIdent) -> Result<PackageInstall> {
+    let fs_root_path = Path::new(&*FS_ROOT_PATH);
+    let installed_ident = common::command::package::install::start(ui,
+                                                                   depot_url,
+                                                                   &ident.to_string(),
+                                                                   PRODUCT,
+                                                                   VERSION,
+                                                                   fs_root_path,
+                                                                   &fs::cache_artifact_path(None),
+                                                                   false)?;
+    Ok(PackageInstall::load(&installed_ident, Some(&fs_root_path))?)
+}
+
+pub fn maybe_install_newer(ui: &mut UI,
+                           spec: &ServiceSpec,
+                           current: PackageInstall)
+                           -> Result<PackageInstall> {
+    let latest_ident: PackageIdent = {
+        let depot_client = Client::new(&spec.depot_url, PRODUCT, VERSION, None)?;
+        depot_client.show_package(&spec.ident)?.get_ident().clone().into()
+    };
+
+    if &latest_ident > current.ident() {
+        outputln!("Newer version of {} detected. Installing {} from {}",
+                  spec.ident,
+                  latest_ident,
+                  spec.depot_url);
+        self::install(ui, &spec.depot_url, &latest_ident)
+    } else {
+        outputln!("Confirmed latest version of {} is {}",
+                  spec.ident,
+                  current.ident());
+        Ok(current)
+    }
+}


### PR DESCRIPTION
This internal refactoring tries to accomplish

* Push the initial package installation into a `Service` concern--it
  should be responsible for ensuring that the desired package is
  installed.
* Allow a `Service` to be created or "loaded" from a `ServiceSpec` (and
  possible a couple of other small bits of info). This makes future work
  to start additional services much easier as they load from a simple
  value struct. **Note:** the `Service::new` wasn't overriden and remains
  public so that future testing work could construct a `Service` from a
  pretend or faked out `PackageInstall`.
* Divest a `Service` from needing to know about a `ManagerConfig` as
  this value struct is consumed when the `Manager` is first built--future
  services will not be able to use this struct once the `Manager` is
  running.
* Prepare the codebase for a use of the `Manager` without any services.
* Begin to add the concept of a `Service` being added (i.e. initialized,
  booted up, brought into being) and being removed (i.e. decommissioned,
  torn down, deleted) in the `Manager`'s lifecycle.'
* Begin to further centralize the logic to install a package in the
  Supervisor that will eventually be used anywhere this task is required,
  leading to fewer bugs and one code path for all future package
  installation improvements and fixes.

As this is a refactoring change, and being incremental not everything
here is perfect or as nice as I'd like. Future refactorings will
endeavor to tighten up the code even more. This was enough to unlock the
feature work of multiple services.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>