### PR TITLE
Suitability

### DIFF
--- a/components/butterfly/src/server/mod.rs
+++ b/components/butterfly/src/server/mod.rs
@@ -475,7 +475,9 @@ impl Server {
     ///
     /// a) We are the leader, and we have lost quorum with the rest of the group.
     /// b) We are not the leader, and we have detected that the leader is confirmed dead.
-    pub fn restart_elections(&self) {
+    pub fn restart_elections<F>(&self, suitability_lookup: F)
+        where F: Fn(&String) -> u64
+    {
         let mut elections_to_restart = vec![];
         let mut update_elections_to_restart = vec![];
 
@@ -550,7 +552,7 @@ impl Server {
             let term = old_term + 1;
             warn!("Starting a new election for {} {}", sg, term);
             self.election_store.remove(&service_group, "election");
-            self.start_election(sg, 0, term);
+            self.start_election(sg, suitability_lookup(&service_group), term);
         }
 
         for (service_group, old_term) in update_elections_to_restart {

--- a/components/butterfly/src/server/mod.rs
+++ b/components/butterfly/src/server/mod.rs
@@ -28,6 +28,7 @@ pub mod timing;
 
 use std::collections::{HashSet, HashMap};
 use std::fmt;
+use std::fmt::Debug;
 use std::io;
 use std::net::{ToSocketAddrs, UdpSocket, SocketAddr};
 use std::result;
@@ -53,6 +54,10 @@ use rumor::service_file::ServiceFile;
 use rumor::election::{Election, ElectionUpdate};
 use message;
 
+pub trait Suitability: Debug + Send + Sync {
+    fn get(&self, service_group: &ServiceGroup) -> u64;
+}
+
 /// The server struct. Is thread-safe.
 #[derive(Debug, Clone)]
 pub struct Server {
@@ -69,6 +74,7 @@ pub struct Server {
     pub update_store: RumorStore<ElectionUpdate>,
     pub swim_addr: Arc<RwLock<SocketAddr>>,
     pub gossip_addr: Arc<RwLock<SocketAddr>>,
+    pub suitability_lookup: Arc<Box<Suitability>>,
     // These are all here for testing support
     pub pause: Arc<AtomicBool>,
     pub trace: Arc<RwLock<Trace>>,
@@ -101,7 +107,8 @@ impl Server {
                                  member: Member,
                                  trace: Trace,
                                  ring_key: Option<SymKey>,
-                                 name: Option<String>)
+                                 name: Option<String>,
+                                 suitability_lookup: Box<Suitability>)
                                  -> Result<Server> {
         let maybe_swim_socket_addr = swim_addr.to_socket_addrs().map(|mut iter| iter.next());
         let maybe_gossip_socket_addr = gossip_addr.to_socket_addrs().map(|mut iter| iter.next());
@@ -122,6 +129,7 @@ impl Server {
                     update_store: RumorStore::default(),
                     swim_addr: Arc::new(RwLock::new(swim_socket_addr)),
                     gossip_addr: Arc::new(RwLock::new(gossip_socket_addr)),
+                    suitability_lookup: Arc::new(suitability_lookup),
                     pause: Arc::new(AtomicBool::new(false)),
                     trace: Arc::new(RwLock::new(trace)),
                     swim_rounds: Arc::new(AtomicIsize::new(0)),
@@ -447,7 +455,8 @@ impl Server {
 
     /// Start an election for the given service group, declaring this members suitability and the
     /// term for the election.
-    pub fn start_election(&self, sg: ServiceGroup, suitability: u64, term: u64) {
+    pub fn start_election(&self, sg: ServiceGroup, term: u64) {
+        let suitability = self.suitability_lookup.get(&sg);
         let mut e = Election::new(self.member_id(), sg, suitability);
         e.set_term(term);
         let ek = RumorKey::from(&e);
@@ -475,9 +484,7 @@ impl Server {
     ///
     /// a) We are the leader, and we have lost quorum with the rest of the group.
     /// b) We are not the leader, and we have detected that the leader is confirmed dead.
-    pub fn restart_elections<F>(&self, suitability_lookup: F)
-        where F: Fn(&String) -> u64
-    {
+    pub fn restart_elections(&self) {
         let mut elections_to_restart = vec![];
         let mut update_elections_to_restart = vec![];
 
@@ -552,7 +559,7 @@ impl Server {
             let term = old_term + 1;
             warn!("Starting a new election for {} {}", sg, term);
             self.election_store.remove(&service_group, "election");
-            self.start_election(sg, suitability_lookup(&service_group), term);
+            self.start_election(sg, term);
         }
 
         for (service_group, old_term) in update_elections_to_restart {
@@ -595,7 +602,7 @@ impl Server {
                             return;
                         }
                     };
-                    self.start_election(sg, 0, election.get_term());
+                    self.start_election(sg, election.get_term());
                 }
                 // If we are the member that this election is voting for, then check to see if the
                 // election is over! If it is, mark this election as final before you process it.
@@ -631,7 +638,7 @@ impl Server {
                         return;
                     }
                 };
-                self.start_election(sg, 0, election.get_term());
+                self.start_election(sg, election.get_term());
             }
             if !election.is_finished() {
                 let has_quorum = self.check_quorum(election.key());

--- a/components/sup/src/manager/service/hooks.rs
+++ b/components/sup/src/manager/service/hooks.rs
@@ -35,6 +35,7 @@ pub const FILEUPDATED_FILENAME: &'static str = "file_updated";
 pub const RECONFIGURE_FILENAME: &'static str = "reconfigure";
 pub const SMOKETEST_FILENAME: &'static str = "smoke_test";
 pub const RUN_FILENAME: &'static str = "run";
+pub const SUITABILITY_FILENAME: &'static str = "suitability";
 
 static LOGKEY: &'static str = "HK";
 
@@ -148,6 +149,7 @@ pub struct HookTable {
     pub reconfigure: Option<Hook>,
     pub file_updated: Option<Hook>,
     pub run: Option<Hook>,
+    pub suitability: Option<Hook>,
     pub smoke_test: Option<Hook>,
     cfg_incarnation: u64,
 }
@@ -174,6 +176,9 @@ impl HookTable {
         if let Some(ref hook) = self.run {
             self.compile_one(hook, service_group, config);
         }
+        if let Some(ref hook) = self.suitability {
+            self.compile_one(hook, service_group, config);
+        }
         if let Some(ref hook) = self.smoke_test {
             self.compile_one(hook, service_group, config);
         }
@@ -191,6 +196,7 @@ impl HookTable {
                 self.reconfigure = self.load_hook(HookType::Reconfigure, cfg, &hooks, &templates);
                 self.health_check = self.load_hook(HookType::HealthCheck, cfg, &hooks, &templates);
                 self.run = self.load_hook(HookType::Run, cfg, &hooks, &templates);
+                self.suitability = self.load_hook(HookType::Suitability, cfg, &hooks, &templates);
                 self.smoke_test = self.load_hook(HookType::SmokeTest, cfg, &hooks, &templates);
             }
         }
@@ -207,6 +213,7 @@ impl HookTable {
             HookType::Init => &self.init,
             HookType::Reconfigure => &self.reconfigure,
             HookType::Run => &self.run,
+            HookType::Suitability => &self.suitability,
             HookType::SmokeTest => &self.smoke_test,
         };
         match *hook {
@@ -253,6 +260,7 @@ pub enum HookType {
     FileUpdated,
     Run,
     Init,
+    Suitability,
     SmokeTest,
 }
 
@@ -264,6 +272,7 @@ impl fmt::Display for HookType {
             HookType::FileUpdated => write!(f, "file_updated"),
             HookType::Reconfigure => write!(f, "reconfigure"),
             HookType::Run => write!(f, "run"),
+            HookType::Suitability => write!(f, "suitability"),
             HookType::SmokeTest => write!(f, "smoke_test"),
         }
     }
@@ -278,6 +287,7 @@ pub fn hook_path<T>(hook_type: &HookType, path: T) -> PathBuf
         HookType::FileUpdated => path.as_ref().join(FILEUPDATED_FILENAME),
         HookType::Reconfigure => path.as_ref().join(RECONFIGURE_FILENAME),
         HookType::Run => path.as_ref().join(RUN_FILENAME),
+        HookType::Suitability => path.as_ref().join(SUITABILITY_FILENAME),
         HookType::SmokeTest => path.as_ref().join(SMOKETEST_FILENAME),
     }
 }

--- a/components/sup/src/manager/service/mod.rs
+++ b/components/sup/src/manager/service/mod.rs
@@ -685,6 +685,21 @@ impl Service {
         false
     }
 
+    pub fn suitability(&mut self) -> Option<u64> {
+        if !self.initialized {
+            return None;
+        }
+        self.run_hook(HookType::Suitability)
+            .ok()
+            .as_ref()
+            .and_then(|hook_out| hook_out.stdout().lines().last())
+            .and_then(|line| line.trim().parse::<u64>().ok())
+            .map(|suitability| {
+                outputln!(preamble self.service_group, "Reporting suitability of: {}", suitability);
+                suitability
+            })
+    }
+
     /// Write service configuration from gossip data to disk.
     ///
     /// Returns true if a change was made and false if there were no updates.

--- a/components/sup/src/manager/service/mod.rs
+++ b/components/sup/src/manager/service/mod.rs
@@ -40,7 +40,7 @@ use hcore::util::perm::{set_owner, set_permissions};
 use serde::Serializer;
 use toml;
 
-use self::hooks::{HOOK_PERMISSIONS, HookTable, HookType};
+use self::hooks::{HOOK_PERMISSIONS, HookTable, HookType, HookOutput};
 use config::GossipListenAddr;
 use error::{Error, Result, SupError};
 use http_gateway;
@@ -508,7 +508,7 @@ impl Service {
             // In the near future, we will periodically run this hook and cache it's results on
             // the service struct itself.
             match self.hooks.try_run(HookType::HealthCheck, &self.service_group) {
-                Ok(()) => HealthCheck::Ok,
+                Ok(_) => HealthCheck::Ok,
                 Err(SupError { err: Error::HookFailed(_, 1), .. }) => HealthCheck::Warning,
                 Err(SupError { err: Error::HookFailed(_, 2), .. }) => HealthCheck::Critical,
                 Err(SupError { err: Error::HookFailed(_, 3), .. }) => HealthCheck::Unknown,
@@ -590,7 +590,7 @@ impl Service {
 
     pub fn smoke_test(&mut self) -> SmokeCheck {
         match self.run_hook(HookType::SmokeTest) {
-            Ok(()) => SmokeCheck::Ok,
+            Ok(_) => SmokeCheck::Ok,
             Err(SupError { err: Error::HookFailed(_, code), .. }) => SmokeCheck::Failed(code),
             Err(err) => {
                 outputln!(preamble self.service_group, "Smoke test couldn't be run, {}", err);
@@ -673,7 +673,7 @@ impl Service {
     fn file_updated(&mut self) -> bool {
         if self.initialized {
             match self.run_hook(HookType::FileUpdated) {
-                Ok(()) => {
+                Ok(_) => {
                     outputln!(preamble self.service_group, "File update hook succeeded");
                     return true;
                 }
@@ -729,7 +729,7 @@ impl Service {
         Ok(())
     }
 
-    fn run_hook(&mut self, hook: HookType) -> Result<()> {
+    fn run_hook(&mut self, hook: HookType) -> Result<HookOutput> {
         self.hooks.compile(&self.service_group, &self.config);
         self.hooks.try_run(hook, &self.service_group)
     }

--- a/www/source/docs/reference/plan-syntax.html.md
+++ b/www/source/docs/reference/plan-syntax.html.md
@@ -377,6 +377,11 @@ reconfigure
 
   This hook is run when service configuration information has changed through a set of Habitat services that are peers with each other.
 
+suitability
+: File location: `<plan>/hooks/suitability`
+
+  The suitability hook allows a service to report a priority by which it should be elected leader. The hook is called when a new election is triggered and the last line it outputs to `stdout` should be a number parsable as a `u64`. In the event that a leader goes down and an election is started the service with the highest reported suitabilty will become the new leader.
+
 run
 : File location: `<plan>/hooks/run`
 


### PR DESCRIPTION
Add support for suitability hook.
By printing a parsable u64 as the last line of stdout this hook allows services to report a priority by which they should be elected the new leader when an election is initiated.

Closes #1767