### PR TITLE
[sup] Regression: fix when specifying multiple service opts.

### DIFF
--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -113,7 +113,7 @@ fn cli<'a, 'b>() -> App<'a, 'b> {
                 "A Habitat package identifier (ex: acme/redis) or filepath to a Habitat Artifact \
                 (ex: /home/acme-redis-3.0.7-21120102031201-x86_64-linux.hart)")
             (@group SVC_ARGS =>
-                (@attributes requires[PKG_IDENT_OR_ARTIFACT])
+                (@attributes +multiple requires[PKG_IDENT_OR_ARTIFACT])
                 (@arg GROUP: --group +takes_value
                     "The service group; shared config and topology [default: default].")
                 (@arg ORGANIZATION: --org +takes_value


### PR DESCRIPTION
This fixes a regression introduced in #1791 which refactors some of the
Supervisor's CLI parsing logic. A missing clap attribute of
`multiple(true)` was missing from an argument group, resulting in only
*one* of the group arguments being valid.

![gif-keyboard-16097381123387564990](https://cloud.githubusercontent.com/assets/261548/23095226/a834352e-f5c3-11e6-9810-3acc9e7297c1.gif)
