### PR TITLE
Recompile hooks on reconfig

### DIFF
--- a/components/sup/src/manager/service/mod.rs
+++ b/components/sup/src/manager/service/mod.rs
@@ -420,6 +420,7 @@ impl Service {
             match self.config.write() {
                 Ok(true) => {
                     self.needs_reconfiguration = true;
+                    self.hooks.compile(&self.service_group, &self.config);
                     if let Some(err) = self.copy_run().err() {
                         outputln!(preamble self.service_group, "Failed to copy run hook: {}", err);
                     }


### PR DESCRIPTION
fixes #1797 

I am leaving this WIP for now until I have time to test more thoroughly.

We copy the run file in the supervisor's initialize function which is called from `execute_hooks` called in `tick`. Before `tick` runs the hooks it calls `update_configuration` which also tries `copy_run` but too early.

Signed-off-by: Matt Wrock <matt@mattwrock.com>