### PR TITLE
Activate asset_hash extension to improve browser caching

### DIFF
--- a/www/config.rb
+++ b/www/config.rb
@@ -58,6 +58,9 @@ configure :build do
 
   # Minify Javascript on build
   # activate :minify_javascript
+
+  # Asset hash to defeat caching between builds
+  activate :asset_hash
 end
 
 activate :autoprefixer


### PR DESCRIPTION
Our recent site redesign ended up looking terrible for some users due to browser caching. This will prevent that issue from happening in the future. 

Signed-off-by: Maggie Walker <magwalk@gmail.com>