### PR TITLE
Refactor Hooks and add SmokeTest hook

### DIFF
--- a/components/sup/src/error.rs
+++ b/components/sup/src/error.rs
@@ -57,7 +57,6 @@ use hcore::{self, package};
 use hcore::package::Identifiable;
 use toml;
 
-use manager::service::hooks::HookType;
 use output::StructuredOutput;
 use PROGRAM_NAME;
 
@@ -110,9 +109,6 @@ pub enum Error {
     HabitatCore(hcore::Error),
     TemplateFileError(handlebars::TemplateFileError),
     TemplateRenderError(handlebars::RenderError),
-    /// A hook failed to successfully execute. This error contains the type of hook which failed
-    /// to run and the exit code.
-    HookFailed(HookType, i32),
     InvalidBinding(String),
     InvalidKeyParameter(String),
     InvalidPidFile,
@@ -164,9 +160,6 @@ impl fmt::Display for SupError {
             Error::DepotClient(ref err) => format!("{}", err),
             Error::EnvJoinPathsError(ref err) => format!("{}", err),
             Error::FileNotFound(ref e) => format!("File not found at: {}", e),
-            Error::HookFailed(ref hook, ref code) => {
-                format!("{} hook failed to run with exit code {}", hook, code)
-            }
             Error::InvalidBinding(ref binding) => {
                 format!("Invalid binding - must be ':' delimited: {}", binding)
             }
@@ -258,7 +251,6 @@ impl error::Error for SupError {
             Error::DepotClient(ref err) => err.description(),
             Error::EnvJoinPathsError(ref err) => err.description(),
             Error::FileNotFound(_) => "File not found",
-            Error::HookFailed(_, _) => "Hook failed to run",
             Error::InvalidBinding(_) => "Invalid binding parameter",
             Error::InvalidKeyParameter(_) => "Key parameter error",
             Error::InvalidPort(_) => "Invalid port number in package expose metadata",

--- a/components/sup/src/manager/service/hooks.rs
+++ b/components/sup/src/manager/service/hooks.rs
@@ -17,109 +17,348 @@ use std::fmt;
 use std::io::BufReader;
 use std::io::prelude::*;
 use std::path::{Path, PathBuf};
-use std::process::Child;
+use std::process::{Child, ExitStatus};
+use std::result;
 
 use hcore;
 use hcore::service::ServiceGroup;
+use serde::{Serialize, Serializer};
 
-use error::{Error, Result};
+use super::health;
+use error::Result;
 use manager::service::ServiceConfig;
 use supervisor::RuntimeConfig;
 use templating::Template;
 use util;
 
 pub const HOOK_PERMISSIONS: u32 = 0o755;
-pub const INIT_FILENAME: &'static str = "init";
-pub const HEALTHCHECK_FILENAME: &'static str = "health_check";
-pub const FILEUPDATED_FILENAME: &'static str = "file_updated";
-pub const RECONFIGURE_FILENAME: &'static str = "reconfigure";
-pub const SMOKETEST_FILENAME: &'static str = "smoke_test";
-pub const RUN_FILENAME: &'static str = "run";
-
 static LOGKEY: &'static str = "HK";
 
-#[derive(Debug, Serialize)]
-pub struct Hook {
-    pub htype: HookType,
-    pub template: PathBuf,
-    pub path: PathBuf,
-    pub user: String,
-    pub group: String,
+#[derive(Debug, Copy, Clone)]
+pub struct ExitCode(i32);
+
+impl Default for ExitCode {
+    fn default() -> ExitCode {
+        ExitCode(-1)
+    }
 }
 
-impl Hook {
-    pub fn new(htype: HookType,
-               template: PathBuf,
-               path: PathBuf,
-               user: String,
-               group: String)
-               -> Self {
-        Hook {
-            htype: htype,
-            template: template,
-            path: path,
-            user: user,
-            group: group,
+pub trait Hook: fmt::Debug + Sized {
+    type ExitValue: Default;
+
+    fn file_name() -> &'static str;
+
+    fn load<C, T>(service_group: &ServiceGroup, concrete_path: C, template_path: T) -> Option<Self>
+        where C: AsRef<Path>,
+              T: AsRef<Path>
+    {
+        let concrete = concrete_path.as_ref().join(Self::file_name());
+        let template = template_path.as_ref().join(Self::file_name());
+        match std::fs::metadata(&template) {
+            Ok(_) => {
+                match Self::new(concrete, template) {
+                    Ok(hook) => Some(hook),
+                    Err(err) => {
+                        outputln!(preamble service_group, "Failed to load hook: {}", err);
+                        None
+                    }
+                }
+            }
+            Err(_) => {
+                debug!("{} not found at {}, not loading",
+                       Self::file_name(),
+                       template.display());
+                None
+            }
         }
     }
 
-    /// Run a compiled hook.
-    pub fn run(&self, service_group: &ServiceGroup) -> Result<()> {
-        let mut child = try!(util::create_command(&self.path, &self.user, &self.group).spawn());
-        self.stream_output(service_group, &mut child);
-        let exit_status = try!(child.wait());
-        if exit_status.success() {
-            Ok(())
-        } else {
-            Err(sup_error!(Error::HookFailed(self.htype, exit_status.code().unwrap_or(-1))))
-        }
-    }
+    fn new<C, T>(concrete_path: C, template_path: T) -> Result<Self>
+        where C: Into<PathBuf>,
+              T: AsRef<Path>;
 
     /// Compile a hook into it's destination service directory.
-    pub fn compile(&self, cfg: &ServiceConfig) -> Result<()> {
-        let mut template = Template::new();
-        try!(template.register_template_file("hook", &self.template));
+    fn compile(&self, cfg: &ServiceConfig) -> Result<()> {
         let toml = try!(cfg.to_toml());
         let svc_data = util::convert::toml_to_json(toml);
-        let data = try!(template.render("hook", &svc_data));
-        let mut file = try!(std::fs::File::create(&self.path));
+        let data = try!(self.template().render("hook", &svc_data));
+        let mut file = try!(std::fs::File::create(self.path()));
         try!(file.write_all(data.as_bytes()));
-        try!(hcore::util::perm::set_owner(&self.path, &self.user, &self.group));
-        try!(hcore::util::perm::set_permissions(&self.path, HOOK_PERMISSIONS));
+        try!(hcore::util::perm::set_owner(self.path(), &cfg.pkg.svc_user, &cfg.pkg.svc_group));
+        try!(hcore::util::perm::set_permissions(self.path(), HOOK_PERMISSIONS));
+        debug!("{} compiled to {}",
+               Self::file_name(),
+               self.path().display());
         Ok(())
     }
 
-    fn stream_output(&self, service_group: &ServiceGroup, process: &mut Child) {
-        let preamble_str = self.stream_preamble(service_group);
-        if let Some(ref mut stdout) = process.stdout {
-            for line in BufReader::new(stdout).lines() {
-                if let Some(ref l) = line.ok() {
-                    outputln!(preamble preamble_str, l);
-                }
+    /// Run a compiled hook.
+    fn run(&self, service_group: &ServiceGroup, cfg: &RuntimeConfig) -> Self::ExitValue {
+        let mut child = match util::create_command(self.path(), &cfg.svc_user, &cfg.svc_group)
+            .spawn() {
+            Ok(child) => child,
+            Err(err) => {
+                outputln!(preamble service_group,
+                    "Hook failed to run, {}, {}", Self::file_name(), err);
+                return Self::ExitValue::default();
             }
-        }
-        if let Some(ref mut stderr) = process.stderr {
-            for line in BufReader::new(stderr).lines() {
-                if let Some(ref l) = line.ok() {
-                    outputln!(preamble preamble_str, l);
-                }
+        };
+        stream_output::<Self>(service_group, &mut child);
+        match child.wait() {
+            Ok(status) => self.handle_exit(service_group, &status),
+            Err(err) => {
+                outputln!(preamble service_group,
+                    "Hook failed to run, {}, {}", Self::file_name(), err);
+                Self::ExitValue::default()
             }
         }
     }
 
-    fn stream_preamble(&self, service_group: &ServiceGroup) -> String {
-        format!("{} hook[{}]:", service_group, self.htype)
+    fn handle_exit(&self, group: &ServiceGroup, status: &ExitStatus) -> Self::ExitValue;
+
+    fn path(&self) -> &Path;
+
+    fn template(&self) -> &Template;
+}
+
+#[derive(Debug, Serialize)]
+pub struct FileUpdatedHook(RenderPair);
+
+impl Hook for FileUpdatedHook {
+    type ExitValue = bool;
+
+    fn file_name() -> &'static str {
+        "file_updated"
+    }
+
+    fn new<C, T>(concrete_path: C, template_path: T) -> Result<Self>
+        where C: Into<PathBuf>,
+              T: AsRef<Path>
+    {
+        let pair = RenderPair::new(concrete_path, template_path)?;
+        Ok(FileUpdatedHook(pair))
+    }
+
+    fn handle_exit(&self, _: &ServiceGroup, status: &ExitStatus) -> Self::ExitValue {
+        status.success()
+    }
+
+    fn path(&self) -> &Path {
+        &self.0.path
+    }
+
+    fn template(&self) -> &Template {
+        &self.0.template
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct HealthCheckHook(RenderPair);
+
+impl Hook for HealthCheckHook {
+    type ExitValue = health::HealthCheck;
+
+    fn file_name() -> &'static str {
+        "health_check"
+    }
+
+    fn new<C, T>(concrete_path: C, template_path: T) -> Result<Self>
+        where C: Into<PathBuf>,
+              T: AsRef<Path>
+    {
+        let pair = RenderPair::new(concrete_path, template_path)?;
+        Ok(HealthCheckHook(pair))
+    }
+
+    fn handle_exit(&self, service_group: &ServiceGroup, status: &ExitStatus) -> Self::ExitValue {
+        match status.code() {
+            Some(0) => health::HealthCheck::Ok,
+            Some(1) => health::HealthCheck::Warning,
+            Some(2) => health::HealthCheck::Critical,
+            Some(3) => health::HealthCheck::Unknown,
+            Some(code) => {
+                outputln!(preamble service_group,
+                    "Health check exited with an unknown status code, {}", code);
+                health::HealthCheck::default()
+            }
+            None => {
+                outputln!(preamble service_group,
+                    "{} exited without a status code", Self::file_name());
+                health::HealthCheck::default()
+            }
+        }
+    }
+
+    fn path(&self) -> &Path {
+        &self.0.path
+    }
+
+    fn template(&self) -> &Template {
+        &self.0.template
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct InitHook(RenderPair);
+
+impl Hook for InitHook {
+    type ExitValue = ExitCode;
+
+    fn file_name() -> &'static str {
+        "init"
+    }
+
+    fn new<C, T>(concrete_path: C, template_path: T) -> Result<Self>
+        where C: Into<PathBuf>,
+              T: AsRef<Path>
+    {
+        let pair = RenderPair::new(concrete_path, template_path)?;
+        Ok(InitHook(pair))
+    }
+
+    fn handle_exit(&self, service_group: &ServiceGroup, status: &ExitStatus) -> Self::ExitValue {
+        match status.code() {
+            Some(code) => ExitCode(code),
+            None => {
+                outputln!(preamble service_group,
+                    "{} exited without a status code", Self::file_name());
+                ExitCode::default()
+            }
+        }
+    }
+
+    fn path(&self) -> &Path {
+        &self.0.path
+    }
+
+    fn template(&self) -> &Template {
+        &self.0.template
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct ReconfigureHook(RenderPair);
+
+impl Hook for ReconfigureHook {
+    type ExitValue = ExitCode;
+
+    fn file_name() -> &'static str {
+        "reconfigure"
+    }
+
+    fn new<C, T>(concrete_path: C, template_path: T) -> Result<Self>
+        where C: Into<PathBuf>,
+              T: AsRef<Path>
+    {
+        let pair = RenderPair::new(concrete_path, template_path)?;
+        Ok(ReconfigureHook(pair))
+    }
+
+    fn handle_exit(&self, service_group: &ServiceGroup, status: &ExitStatus) -> Self::ExitValue {
+        match status.code() {
+            Some(code) => ExitCode(code),
+            None => {
+                outputln!(preamble service_group,
+                    "{} exited without a status code", Self::file_name());
+                ExitCode::default()
+            }
+        }
+    }
+
+    fn path(&self) -> &Path {
+        &self.0.path
+    }
+
+    fn template(&self) -> &Template {
+        &self.0.template
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct RunHook(RenderPair);
+
+impl Hook for RunHook {
+    type ExitValue = ExitCode;
+
+    fn file_name() -> &'static str {
+        "run"
+    }
+
+    fn new<C, T>(concrete_path: C, template_path: T) -> Result<Self>
+        where C: Into<PathBuf>,
+              T: AsRef<Path>
+    {
+        let pair = RenderPair::new(concrete_path, template_path)?;
+        Ok(RunHook(pair))
+    }
+
+    fn handle_exit(&self, service_group: &ServiceGroup, status: &ExitStatus) -> Self::ExitValue {
+        match status.code() {
+            Some(code) => ExitCode(code),
+            None => {
+                outputln!(preamble service_group,
+                    "{} exited without a status code", Self::file_name());
+                ExitCode::default()
+            }
+        }
+    }
+
+    fn path(&self) -> &Path {
+        &self.0.path
+    }
+
+    fn template(&self) -> &Template {
+        &self.0.template
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct SmokeTestHook(RenderPair);
+
+impl Hook for SmokeTestHook {
+    type ExitValue = health::SmokeCheck;
+
+    fn file_name() -> &'static str {
+        "smoke_test"
+    }
+
+    fn new<C, T>(concrete_path: C, template_path: T) -> Result<Self>
+        where C: Into<PathBuf>,
+              T: AsRef<Path>
+    {
+        let pair = RenderPair::new(concrete_path, template_path)?;
+        Ok(SmokeTestHook(pair))
+    }
+
+    fn handle_exit(&self, service_group: &ServiceGroup, status: &ExitStatus) -> Self::ExitValue {
+        match status.code() {
+            Some(0) => health::SmokeCheck::Ok,
+            Some(code) => health::SmokeCheck::Failed(code),
+            None => {
+                outputln!(preamble service_group,
+                    "{} exited without a status code", Self::file_name());
+                health::SmokeCheck::Failed(-1)
+            }
+        }
+    }
+
+    fn path(&self) -> &Path {
+        &self.0.path
+    }
+
+    fn template(&self) -> &Template {
+        &self.0.template
     }
 }
 
 #[derive(Debug, Default, Serialize)]
 pub struct HookTable {
-    pub init: Option<Hook>,
-    pub health_check: Option<Hook>,
-    pub reconfigure: Option<Hook>,
-    pub file_updated: Option<Hook>,
-    pub run: Option<Hook>,
-    pub smoke_test: Option<Hook>,
+    pub health_check: Option<HealthCheckHook>,
+    pub init: Option<InitHook>,
+    pub file_updated: Option<FileUpdatedHook>,
+    pub reconfigure: Option<ReconfigureHook>,
+    pub run: Option<RunHook>,
+    pub smoke_test: Option<SmokeTestHook>,
     cfg_incarnation: u64,
 }
 
@@ -127,6 +366,9 @@ impl HookTable {
     /// Compile all loaded hooks from the table into their destination service directory.
     pub fn compile(&mut self, service_group: &ServiceGroup, config: &ServiceConfig) {
         if self.cfg_incarnation != 0 && config.incarnation <= self.cfg_incarnation {
+            debug!("{}, Hooks already compiled with the latest configuration incarnation, \
+                    skipping",
+                   service_group);
             return;
         }
         self.cfg_incarnation = config.incarnation;
@@ -148,107 +390,92 @@ impl HookTable {
         if let Some(ref hook) = self.smoke_test {
             self.compile_one(hook, service_group, config);
         }
+        debug!("{}, Hooks compiled", service_group);
     }
 
     /// Read all available hook templates from the table's package directory into the table.
-    pub fn load_hooks<T, U>(mut self, cfg: &RuntimeConfig, hooks: T, templates: U) -> Self
+    pub fn load_hooks<T, U>(mut self, service_group: &ServiceGroup, hooks: T, templates: U) -> Self
         where T: AsRef<Path>,
               U: AsRef<Path>
     {
         if let Some(meta) = std::fs::metadata(templates.as_ref()).ok() {
             if meta.is_dir() {
-                self.init = self.load_hook(HookType::Init, cfg, &hooks, &templates);
-                self.file_updated = self.load_hook(HookType::FileUpdated, cfg, &hooks, &templates);
-                self.reconfigure = self.load_hook(HookType::Reconfigure, cfg, &hooks, &templates);
-                self.health_check = self.load_hook(HookType::HealthCheck, cfg, &hooks, &templates);
-                self.run = self.load_hook(HookType::Run, cfg, &hooks, &templates);
-                self.smoke_test = self.load_hook(HookType::SmokeTest, cfg, &hooks, &templates);
+                self.file_updated = FileUpdatedHook::load(service_group, &hooks, &templates);
+                self.health_check = HealthCheckHook::load(service_group, &hooks, &templates);
+                self.init = InitHook::load(service_group, &hooks, &templates);
+                self.reconfigure = ReconfigureHook::load(service_group, &hooks, &templates);
+                self.run = RunHook::load(service_group, &hooks, &templates);
+                self.smoke_test = SmokeTestHook::load(service_group, &hooks, &templates);
             }
         }
+        debug!("{}, Hooks loaded, destination={}, templates={}",
+               service_group,
+               hooks.as_ref().display(),
+               templates.as_ref().display());
         self
     }
 
-    /// Run the hook of the given type if the table has a hook of that type loaded and compiled.
-    ///
-    /// Returns affirmatively if the service does not have the desired hook.
-    pub fn try_run(&self, hook: HookType, group: &ServiceGroup) -> Result<()> {
-        let hook = match hook {
-            HookType::FileUpdated => &self.file_updated,
-            HookType::HealthCheck => &self.health_check,
-            HookType::Init => &self.init,
-            HookType::Reconfigure => &self.reconfigure,
-            HookType::Run => &self.run,
-            HookType::SmokeTest => &self.smoke_test,
-        };
-        match *hook {
-            Some(ref h) => h.run(group),
-            None => Ok(()),
-        }
-    }
-
-    fn compile_one(&self, hook: &Hook, service_group: &ServiceGroup, config: &ServiceConfig) {
+    fn compile_one<H>(&self, hook: &H, service_group: &ServiceGroup, config: &ServiceConfig)
+        where H: Hook
+    {
         hook.compile(config).unwrap_or_else(|e| {
             outputln!(preamble service_group,
-                "Failed to compile {} hook: {}", hook.htype, e);
+                "Failed to compile {} hook: {}", H::file_name(), e);
         });
     }
+}
 
-    fn load_hook<T, U>(&self,
-                       hook_type: HookType,
-                       runtime_cfg: &RuntimeConfig,
-                       hooks: T,
-                       templates: U)
-                       -> Option<Hook>
-        where T: AsRef<Path>,
-              U: AsRef<Path>
+struct RenderPair {
+    path: PathBuf,
+    template: Template,
+}
+
+impl RenderPair {
+    pub fn new<C, T>(concrete_path: C, template_path: T) -> Result<Self>
+        where C: Into<PathBuf>,
+              T: AsRef<Path>
     {
-        let template = hook_path(&hook_type, templates);
-        let concrete = hook_path(&hook_type, hooks);
-        match std::fs::metadata(&template) {
-            Ok(_) => {
-                Some(Hook::new(hook_type,
-                               template,
-                               concrete,
-                               runtime_cfg.svc_user.clone(),
-                               runtime_cfg.svc_group.clone()))
-            }
-            Err(_) => None,
-        }
+        let mut template = Template::new();
+        template.register_template_file("hook", template_path.as_ref())?;
+        Ok(RenderPair {
+            path: concrete_path.into(),
+            template: template,
+        })
     }
 }
 
-#[derive(Debug, Clone, Copy, Serialize)]
-pub enum HookType {
-    HealthCheck,
-    Reconfigure,
-    FileUpdated,
-    Run,
-    Init,
-    SmokeTest,
-}
-
-impl fmt::Display for HookType {
+impl fmt::Debug for RenderPair {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            HookType::Init => write!(f, "init"),
-            HookType::HealthCheck => write!(f, "health_check"),
-            HookType::FileUpdated => write!(f, "file_updated"),
-            HookType::Reconfigure => write!(f, "reconfigure"),
-            HookType::Run => write!(f, "run"),
-            HookType::SmokeTest => write!(f, "smoke_test"),
+        write!(f, "path: {}", self.path.display())
+    }
+}
+
+impl Serialize for RenderPair {
+    fn serialize<S>(&self, serializer: &mut S) -> result::Result<(), S::Error>
+        where S: Serializer
+    {
+        serializer.serialize_str(&self.path.as_os_str().to_string_lossy().into_owned())
+    }
+}
+
+fn stream_output<H: Hook>(service_group: &ServiceGroup, process: &mut Child) {
+    let preamble_str = stream_preamble::<H>(service_group);
+    if let Some(ref mut stdout) = process.stdout {
+        for line in BufReader::new(stdout).lines() {
+            if let Some(ref l) = line.ok() {
+                outputln!(preamble preamble_str, l);
+            }
+        }
+    }
+    if let Some(ref mut stderr) = process.stderr {
+        for line in BufReader::new(stderr).lines() {
+            if let Some(ref l) = line.ok() {
+                outputln!(preamble preamble_str, l);
+            }
         }
     }
 }
 
-pub fn hook_path<T>(hook_type: &HookType, path: T) -> PathBuf
-    where T: AsRef<Path>
-{
-    match *hook_type {
-        HookType::Init => path.as_ref().join(INIT_FILENAME),
-        HookType::HealthCheck => path.as_ref().join(HEALTHCHECK_FILENAME),
-        HookType::FileUpdated => path.as_ref().join(FILEUPDATED_FILENAME),
-        HookType::Reconfigure => path.as_ref().join(RECONFIGURE_FILENAME),
-        HookType::Run => path.as_ref().join(RUN_FILENAME),
-        HookType::SmokeTest => path.as_ref().join(SMOKETEST_FILENAME),
-    }
+fn stream_preamble<H: Hook>(service_group: &ServiceGroup) -> String {
+    format!("{} hook[{}]:", service_group, H::file_name())
 }


### PR DESCRIPTION
This change stubs out a new hook to be run on service start after the
first initial successful health check. The Smoke Test hook is our first
long running hook which needs to be executed in a background thread
so I haven't hooked it up just yet. More refactoring is necessary to
the way we schedule a service to do work before the background runner
can be implemented.

In addition to the new hook this commit also refactors hooks into a
concrete struct implementing the new `Hook` trait eliminating the
HookType enum. This change allows us to move hook execution behaviour
into the hooks module. Running a hook now has an associated type for
it's return which can be massaged into any type. For example, the
`HealthCheckHook` and `SmokeTestHook` return a health/smoke check
instead of an i32. This will allow us to build more complex return
values from hooks and allows us to define them on the hook itself.

Lastly, hooks are no longer compiled on demand. This prior change
meant that people running a hook needed a mutable reference of the
Service struct. We now just compile after configuration and during
initialization.

![gif-keyboard-3488498315577892481](https://cloud.githubusercontent.com/assets/54036/23240831/745e3308-f924-11e6-9717-efe907db039b.gif)
