### PR TITLE
`eachAlive` Handlebars Helper 

### DIFF
--- a/components/sup/src/templating/mod.rs
+++ b/components/sup/src/templating/mod.rs
@@ -23,6 +23,7 @@ impl Template {
     pub fn new() -> Self {
         let mut handlebars = Handlebars::new();
         handlebars.register_helper("pkgPathFor", Box::new(helpers::pkg_path_for));
+        handlebars.register_helper("eachAlive", Box::new(helpers::each_alive));
         handlebars.register_helper("toUppercase", Box::new(helpers::to_uppercase));
         handlebars.register_helper("toLowercase", Box::new(helpers::to_lowercase));
         handlebars.register_helper("strReplace", Box::new(helpers::str_replace));
@@ -193,6 +194,25 @@ mod test {
         let data = service_config_json_from_toml_file("complex_config.toml");
         let cfg = serde_json::from_value::<ServiceConfig>(data).unwrap();
         assert_eq!(cfg.pkg.name, "lsyncd");
+    }
+
+    #[test]
+    fn each_alive_helper_content() {
+        let mut template = Template::new();
+        // template using the new `eachAlive` helper
+        template.register_template_file("each_alive", fixtures().join("each_alive.txt"))
+            .unwrap();
+
+        // template using an each block with a nested if block filtering on `alive`
+        template.register_template_file("all_members", fixtures().join("all_members.txt"))
+            .unwrap();
+
+        let data = service_config_json_from_toml_file("multiple_supervisors_config.toml");
+
+        let each_alive_render = template.render("each_alive", &data).unwrap();
+        let each_if_render = template.render("all_members", &data).unwrap();
+
+        assert_eq!(each_alive_render, each_if_render);
     }
 
 }

--- a/components/sup/tests/fixtures/all_members.txt
+++ b/components/sup/tests/fixtures/all_members.txt
@@ -1,0 +1,9 @@
+{{~#each svc.members}}
+{{~#if alive}}
+Member ID: {{member_id}}
+{{~/if}}
+{{~/each}}
+
+{{~#each svc.members}}
+Member ID: {{member_id}}
+{{~/each}}

--- a/components/sup/tests/fixtures/each_alive.txt
+++ b/components/sup/tests/fixtures/each_alive.txt
@@ -1,0 +1,7 @@
+{{~#eachAlive svc.members}}
+Member ID: {{member_id}}
+{{~/eachAlive}}
+
+{{~#each svc.members}}
+Member ID: {{member_id}}
+{{~/each}}

--- a/components/sup/tests/fixtures/multiple_supervisors_config.toml
+++ b/components/sup/tests/fixtures/multiple_supervisors_config.toml
@@ -1,0 +1,584 @@
+[bind]
+
+[cfg]
+
+[hab]
+version = "0.0.0"
+
+[pkg]
+exposes = []
+ident = "core/testplan/0.1.0/20170208180805"
+name = "testplan"
+origin = "core"
+path = "/hab/pkgs/core/testplan/0.1.0/20170208180805"
+release = "20170208180805"
+svc_config_path = "/hab/svc/testplan/config"
+svc_data_path = "/hab/svc/testplan/data"
+svc_files_path = "/hab/svc/testplan/files"
+svc_group = "hab"
+svc_path = "/hab/svc/testplan"
+svc_static_path = "/hab/svc/testplan/static"
+svc_user = "hab"
+svc_var_path = "/hab/svc/testplan/var"
+version = "0.1.0"
+
+[[pkg.deps]]
+name = "jq-static"
+origin = "core"
+release = "20160909011845"
+version = "1.10"
+
+[pkg.exports]
+
+[svc]
+group = "mylab"
+ident = "testplan.mylab"
+service = "testplan"
+
+[[svc.all]]
+group = "mylab"
+ident = "testplan.mylab"
+service = "testplan"
+
+[svc.all.me]
+alive = true
+confirmed = false
+group = "mylab"
+member_id = "b162bfc10cf54eb4bce93689a8023eb9"
+persistent = true
+service = "testplan"
+suspect = false
+
+[svc.all.me.cfg]
+
+[svc.all.me.pkg]
+name = "testplan"
+origin = "core"
+release = "20170208180805"
+version = "0.1.0"
+
+[svc.all.me.sys]
+gossip_ip = "127.0.0.1"
+gossip_port = "9010"
+hostname = "privatedepot"
+http_gateway_ip = "0.0.0.0"
+http_gateway_port = "8010"
+ip = "10.0.0.4"
+
+[svc.all.member_id]
+[svc.all.member_id.8325c1d9c12543dc83a99f196500f44c]
+alive = true
+confirmed = false
+group = "mylab"
+member_id = "8325c1d9c12543dc83a99f196500f44c"
+persistent = true
+service = "testplan"
+suspect = false
+
+[svc.all.member_id.8325c1d9c12543dc83a99f196500f44c.cfg]
+
+[svc.all.member_id.8325c1d9c12543dc83a99f196500f44c.pkg]
+name = "testplan"
+origin = "core"
+release = "20170208180805"
+version = "0.1.0"
+
+[svc.all.member_id.8325c1d9c12543dc83a99f196500f44c.sys]
+gossip_ip = "127.0.0.1"
+gossip_port = "9011"
+hostname = "privatedepot"
+http_gateway_ip = "0.0.0.0"
+http_gateway_port = "8011"
+ip = "10.0.0.4"
+
+[svc.all.member_id.b162bfc10cf54eb4bce93689a8023eb9]
+alive = true
+confirmed = false
+group = "mylab"
+member_id = "b162bfc10cf54eb4bce93689a8023eb9"
+persistent = true
+service = "testplan"
+suspect = false
+
+[svc.all.member_id.b162bfc10cf54eb4bce93689a8023eb9.cfg]
+
+[svc.all.member_id.b162bfc10cf54eb4bce93689a8023eb9.pkg]
+name = "testplan"
+origin = "core"
+release = "20170208180805"
+version = "0.1.0"
+
+[svc.all.member_id.b162bfc10cf54eb4bce93689a8023eb9.sys]
+gossip_ip = "127.0.0.1"
+gossip_port = "9010"
+hostname = "privatedepot"
+http_gateway_ip = "0.0.0.0"
+http_gateway_port = "8010"
+ip = "10.0.0.4"
+
+[svc.all.member_id.b42cbf6699ea4f03be68e36ea9a41270]
+alive = false
+confirmed = true
+group = "mylab"
+member_id = "b42cbf6699ea4f03be68e36ea9a41270"
+persistent = true
+service = "testplan"
+suspect = false
+
+[svc.all.member_id.b42cbf6699ea4f03be68e36ea9a41270.cfg]
+
+[svc.all.member_id.b42cbf6699ea4f03be68e36ea9a41270.pkg]
+name = "testplan"
+origin = "core"
+release = "20170208180805"
+version = "0.1.0"
+
+[svc.all.member_id.b42cbf6699ea4f03be68e36ea9a41270.sys]
+gossip_ip = "127.0.0.1"
+gossip_port = "9011"
+hostname = "privatedepot"
+http_gateway_ip = "0.0.0.0"
+http_gateway_port = "8011"
+ip = "10.0.0.4"
+
+[[svc.all.members]]
+alive = true
+confirmed = false
+group = "mylab"
+member_id = "b162bfc10cf54eb4bce93689a8023eb9"
+persistent = true
+service = "testplan"
+suspect = false
+
+[svc.all.members.cfg]
+
+[svc.all.members.pkg]
+name = "testplan"
+origin = "core"
+release = "20170208180805"
+version = "0.1.0"
+
+[svc.all.members.sys]
+gossip_ip = "127.0.0.1"
+gossip_port = "9010"
+hostname = "privatedepot"
+http_gateway_ip = "0.0.0.0"
+http_gateway_port = "8010"
+ip = "10.0.0.4"
+
+[[svc.all.members]]
+alive = false
+confirmed = true
+group = "mylab"
+member_id = "b42cbf6699ea4f03be68e36ea9a41270"
+persistent = true
+service = "testplan"
+suspect = false
+
+[svc.all.members.cfg]
+
+[svc.all.members.pkg]
+name = "testplan"
+origin = "core"
+release = "20170208180805"
+version = "0.1.0"
+
+[svc.all.members.sys]
+gossip_ip = "127.0.0.1"
+gossip_port = "9011"
+hostname = "privatedepot"
+http_gateway_ip = "0.0.0.0"
+http_gateway_port = "8011"
+ip = "10.0.0.4"
+
+[[svc.all.members]]
+alive = true
+confirmed = false
+group = "mylab"
+member_id = "8325c1d9c12543dc83a99f196500f44c"
+persistent = true
+service = "testplan"
+suspect = false
+
+[svc.all.members.cfg]
+
+[svc.all.members.pkg]
+name = "testplan"
+origin = "core"
+release = "20170208180805"
+version = "0.1.0"
+
+[svc.all.members.sys]
+gossip_ip = "127.0.0.1"
+gossip_port = "9011"
+hostname = "privatedepot"
+http_gateway_ip = "0.0.0.0"
+http_gateway_port = "8011"
+ip = "10.0.0.4"
+
+[svc.me]
+alive = true
+confirmed = false
+group = "mylab"
+member_id = "b162bfc10cf54eb4bce93689a8023eb9"
+persistent = true
+service = "testplan"
+suspect = false
+
+[svc.me.cfg]
+
+[svc.me.pkg]
+name = "testplan"
+origin = "core"
+release = "20170208180805"
+version = "0.1.0"
+
+[svc.me.sys]
+gossip_ip = "127.0.0.1"
+gossip_port = "9010"
+hostname = "privatedepot"
+http_gateway_ip = "0.0.0.0"
+http_gateway_port = "8010"
+ip = "10.0.0.4"
+
+[svc.member_id]
+[svc.member_id.8325c1d9c12543dc83a99f196500f44c]
+alive = true
+confirmed = false
+group = "mylab"
+member_id = "8325c1d9c12543dc83a99f196500f44c"
+persistent = true
+service = "testplan"
+suspect = false
+
+[svc.member_id.8325c1d9c12543dc83a99f196500f44c.cfg]
+
+[svc.member_id.8325c1d9c12543dc83a99f196500f44c.pkg]
+name = "testplan"
+origin = "core"
+release = "20170208180805"
+version = "0.1.0"
+
+[svc.member_id.8325c1d9c12543dc83a99f196500f44c.sys]
+gossip_ip = "127.0.0.1"
+gossip_port = "9011"
+hostname = "privatedepot"
+http_gateway_ip = "0.0.0.0"
+http_gateway_port = "8011"
+ip = "10.0.0.4"
+
+[svc.member_id.b162bfc10cf54eb4bce93689a8023eb9]
+alive = true
+confirmed = false
+group = "mylab"
+member_id = "b162bfc10cf54eb4bce93689a8023eb9"
+persistent = true
+service = "testplan"
+suspect = false
+
+[svc.member_id.b162bfc10cf54eb4bce93689a8023eb9.cfg]
+
+[svc.member_id.b162bfc10cf54eb4bce93689a8023eb9.pkg]
+name = "testplan"
+origin = "core"
+release = "20170208180805"
+version = "0.1.0"
+
+[svc.member_id.b162bfc10cf54eb4bce93689a8023eb9.sys]
+gossip_ip = "127.0.0.1"
+gossip_port = "9010"
+hostname = "privatedepot"
+http_gateway_ip = "0.0.0.0"
+http_gateway_port = "8010"
+ip = "10.0.0.4"
+
+[svc.member_id.b42cbf6699ea4f03be68e36ea9a41270]
+alive = false
+confirmed = true
+group = "mylab"
+member_id = "b42cbf6699ea4f03be68e36ea9a41270"
+persistent = true
+service = "testplan"
+suspect = false
+
+[svc.member_id.b42cbf6699ea4f03be68e36ea9a41270.cfg]
+
+[svc.member_id.b42cbf6699ea4f03be68e36ea9a41270.pkg]
+name = "testplan"
+origin = "core"
+release = "20170208180805"
+version = "0.1.0"
+
+[svc.member_id.b42cbf6699ea4f03be68e36ea9a41270.sys]
+gossip_ip = "127.0.0.1"
+gossip_port = "9011"
+hostname = "privatedepot"
+http_gateway_ip = "0.0.0.0"
+http_gateway_port = "8011"
+ip = "10.0.0.4"
+
+[[svc.members]]
+alive = true
+confirmed = false
+group = "mylab"
+member_id = "b162bfc10cf54eb4bce93689a8023eb9"
+persistent = true
+service = "testplan"
+suspect = false
+
+[svc.members.cfg]
+
+[svc.members.pkg]
+name = "testplan"
+origin = "core"
+release = "20170208180805"
+version = "0.1.0"
+
+[svc.members.sys]
+gossip_ip = "127.0.0.1"
+gossip_port = "9010"
+hostname = "privatedepot"
+http_gateway_ip = "0.0.0.0"
+http_gateway_port = "8010"
+ip = "10.0.0.4"
+
+[[svc.members]]
+alive = false
+confirmed = true
+group = "mylab"
+member_id = "b42cbf6699ea4f03be68e36ea9a41270"
+persistent = true
+service = "testplan"
+suspect = false
+
+[svc.members.cfg]
+
+[svc.members.pkg]
+name = "testplan"
+origin = "core"
+release = "20170208180805"
+version = "0.1.0"
+
+[svc.members.sys]
+gossip_ip = "127.0.0.1"
+gossip_port = "9011"
+hostname = "privatedepot"
+http_gateway_ip = "0.0.0.0"
+http_gateway_port = "8011"
+ip = "10.0.0.4"
+
+[[svc.members]]
+alive = true
+confirmed = false
+group = "mylab"
+member_id = "8325c1d9c12543dc83a99f196500f44c"
+persistent = true
+service = "testplan"
+suspect = false
+
+[svc.members.cfg]
+
+[svc.members.pkg]
+name = "testplan"
+origin = "core"
+release = "20170208180805"
+version = "0.1.0"
+
+[svc.members.sys]
+gossip_ip = "127.0.0.1"
+gossip_port = "9011"
+hostname = "privatedepot"
+http_gateway_ip = "0.0.0.0"
+http_gateway_port = "8011"
+ip = "10.0.0.4"
+
+[svc.named]
+[svc.named.testplan]
+[svc.named.testplan.mylab]
+group = "mylab"
+ident = "testplan.mylab"
+service = "testplan"
+
+[svc.named.testplan.mylab.me]
+alive = true
+confirmed = false
+group = "mylab"
+member_id = "b162bfc10cf54eb4bce93689a8023eb9"
+persistent = true
+service = "testplan"
+suspect = false
+
+[svc.named.testplan.mylab.me.cfg]
+
+[svc.named.testplan.mylab.me.pkg]
+name = "testplan"
+origin = "core"
+release = "20170208180805"
+version = "0.1.0"
+
+[svc.named.testplan.mylab.me.sys]
+gossip_ip = "127.0.0.1"
+gossip_port = "9010"
+hostname = "privatedepot"
+http_gateway_ip = "0.0.0.0"
+http_gateway_port = "8010"
+ip = "10.0.0.4"
+
+[svc.named.testplan.mylab.member_id]
+[svc.named.testplan.mylab.member_id.8325c1d9c12543dc83a99f196500f44c]
+alive = true
+confirmed = false
+group = "mylab"
+member_id = "8325c1d9c12543dc83a99f196500f44c"
+persistent = true
+service = "testplan"
+suspect = false
+
+[svc.named.testplan.mylab.member_id.8325c1d9c12543dc83a99f196500f44c.cfg]
+
+[svc.named.testplan.mylab.member_id.8325c1d9c12543dc83a99f196500f44c.pkg]
+name = "testplan"
+origin = "core"
+release = "20170208180805"
+version = "0.1.0"
+
+[svc.named.testplan.mylab.member_id.8325c1d9c12543dc83a99f196500f44c.sys]
+gossip_ip = "127.0.0.1"
+gossip_port = "9011"
+hostname = "privatedepot"
+http_gateway_ip = "0.0.0.0"
+http_gateway_port = "8011"
+ip = "10.0.0.4"
+
+[svc.named.testplan.mylab.member_id.b162bfc10cf54eb4bce93689a8023eb9]
+alive = true
+confirmed = false
+group = "mylab"
+member_id = "b162bfc10cf54eb4bce93689a8023eb9"
+persistent = true
+service = "testplan"
+suspect = false
+
+[svc.named.testplan.mylab.member_id.b162bfc10cf54eb4bce93689a8023eb9.cfg]
+
+[svc.named.testplan.mylab.member_id.b162bfc10cf54eb4bce93689a8023eb9.pkg]
+name = "testplan"
+origin = "core"
+release = "20170208180805"
+version = "0.1.0"
+
+[svc.named.testplan.mylab.member_id.b162bfc10cf54eb4bce93689a8023eb9.sys]
+gossip_ip = "127.0.0.1"
+gossip_port = "9010"
+hostname = "privatedepot"
+http_gateway_ip = "0.0.0.0"
+http_gateway_port = "8010"
+ip = "10.0.0.4"
+
+[svc.named.testplan.mylab.member_id.b42cbf6699ea4f03be68e36ea9a41270]
+alive = false
+confirmed = true
+group = "mylab"
+member_id = "b42cbf6699ea4f03be68e36ea9a41270"
+persistent = true
+service = "testplan"
+suspect = false
+
+[svc.named.testplan.mylab.member_id.b42cbf6699ea4f03be68e36ea9a41270.cfg]
+
+[svc.named.testplan.mylab.member_id.b42cbf6699ea4f03be68e36ea9a41270.pkg]
+name = "testplan"
+origin = "core"
+release = "20170208180805"
+version = "0.1.0"
+
+[svc.named.testplan.mylab.member_id.b42cbf6699ea4f03be68e36ea9a41270.sys]
+gossip_ip = "127.0.0.1"
+gossip_port = "9011"
+hostname = "privatedepot"
+http_gateway_ip = "0.0.0.0"
+http_gateway_port = "8011"
+ip = "10.0.0.4"
+
+[[svc.named.testplan.mylab.members]]
+alive = true
+confirmed = false
+group = "mylab"
+member_id = "b162bfc10cf54eb4bce93689a8023eb9"
+persistent = true
+service = "testplan"
+suspect = false
+
+[svc.named.testplan.mylab.members.cfg]
+
+[svc.named.testplan.mylab.members.pkg]
+name = "testplan"
+origin = "core"
+release = "20170208180805"
+version = "0.1.0"
+
+[svc.named.testplan.mylab.members.sys]
+gossip_ip = "127.0.0.1"
+gossip_port = "9010"
+hostname = "privatedepot"
+http_gateway_ip = "0.0.0.0"
+http_gateway_port = "8010"
+ip = "10.0.0.4"
+
+[[svc.named.testplan.mylab.members]]
+alive = false
+confirmed = true
+group = "mylab"
+member_id = "b42cbf6699ea4f03be68e36ea9a41270"
+persistent = true
+service = "testplan"
+suspect = false
+
+[svc.named.testplan.mylab.members.cfg]
+
+[svc.named.testplan.mylab.members.pkg]
+name = "testplan"
+origin = "core"
+release = "20170208180805"
+version = "0.1.0"
+
+[svc.named.testplan.mylab.members.sys]
+gossip_ip = "127.0.0.1"
+gossip_port = "9011"
+hostname = "privatedepot"
+http_gateway_ip = "0.0.0.0"
+http_gateway_port = "8011"
+ip = "10.0.0.4"
+
+[[svc.named.testplan.mylab.members]]
+alive = true
+confirmed = false
+group = "mylab"
+member_id = "8325c1d9c12543dc83a99f196500f44c"
+persistent = true
+service = "testplan"
+suspect = false
+
+[svc.named.testplan.mylab.members.cfg]
+
+[svc.named.testplan.mylab.members.pkg]
+name = "testplan"
+origin = "core"
+release = "20170208180805"
+version = "0.1.0"
+
+[svc.named.testplan.mylab.members.sys]
+gossip_ip = "127.0.0.1"
+gossip_port = "9011"
+hostname = "privatedepot"
+http_gateway_ip = "0.0.0.0"
+http_gateway_port = "8011"
+ip = "10.0.0.4"
+
+[sys]
+gossip_ip = "127.0.0.1"
+gossip_port = "9010"
+hostname = "privatedepot"
+http_gateway_ip = "0.0.0.0"
+http_gateway_port = "8010"
+ip = "10.0.0.4"


### PR DESCRIPTION
to simplify the each/if pattern for supervisor templates.

To go from: 

Before

```
{{#if bind.has_backend }}
{{~#each bind.backend.members}}
{{~#if alive }}
server ip ip:port
{{~/if}}
{{~/each}}
{{~/if}}
```

```
{{#if bind.has_backend }}
{{~#eachAlive bind.backend.members}}
server ip ip:port
{{~/eachAlive}}
{{~/if}}
```

This will need a rebase on top of #1811 and needs docs yet.

Signed-off-by: Steven Murawski <steven.murawski@gmail.com>