### PR TITLE
Suitability

### DIFF
--- a/components/butterfly-test/src/net.rs
+++ b/components/butterfly-test/src/net.rs
@@ -393,7 +393,7 @@ impl SwimNet {
         self[member].insert_service_file(s);
     }
 
-    pub fn add_election(&mut self, member: usize, service: &str, suitability: u64) {
+    pub fn add_election(&mut self, member: usize, service: &str) {
         self[member].start_election(ServiceGroup::new(service, "prod", None), suitability, 0);
     }
 }

--- a/components/butterfly/src/main.rs
+++ b/components/butterfly/src/main.rs
@@ -16,6 +16,7 @@ extern crate env_logger;
 #[macro_use]
 extern crate log;
 extern crate habitat_butterfly;
+extern crate habitat_core;
 
 use std::env;
 use std::thread;
@@ -23,6 +24,16 @@ use std::time::Duration;
 use std::net::SocketAddr;
 
 use habitat_butterfly::{server, member, trace};
+use habitat_butterfly::server::Suitability;
+use habitat_core::service::ServiceGroup;
+
+#[derive(Debug)]
+struct ZeroSuitability;
+impl Suitability for ZeroSuitability {
+    fn get(&self, _service_group: &ServiceGroup) -> u64 {
+        0
+    }
+}
 
 fn main() {
     env_logger::init().unwrap();
@@ -47,7 +58,8 @@ fn main() {
                                      member,
                                      trace::Trace::default(),
                                      None,
-                                     None)
+                                     None,
+                                     Box::new(ZeroSuitability))
         .unwrap();
     println!("Server ID: {}", server.member_id);
 

--- a/components/butterfly/src/server/mod.rs
+++ b/components/butterfly/src/server/mod.rs
@@ -28,6 +28,7 @@ pub mod timing;
 
 use std::collections::{HashSet, HashMap};
 use std::fmt;
+use std::fmt::Debug;
 use std::io;
 use std::net::{ToSocketAddrs, UdpSocket, SocketAddr};
 use std::result;
@@ -54,6 +55,11 @@ use rumor::service_file::ServiceFile;
 use rumor::election::{Election, ElectionUpdate};
 use message;
 
+pub trait Suitability: Debug + Send + Sync {
+    fn get(&self, service_group: &ServiceGroup) -> u64;
+}
+
+
 /// The server struct. Is thread-safe.
 #[derive(Debug, Clone)]
 pub struct Server {
@@ -70,6 +76,7 @@ pub struct Server {
     pub update_store: RumorStore<ElectionUpdate>,
     pub swim_addr: Arc<RwLock<SocketAddr>>,
     pub gossip_addr: Arc<RwLock<SocketAddr>>,
+    pub suitability_lookup: Arc<Box<Suitability>>,
     // These are all here for testing support
     pub pause: Arc<AtomicBool>,
     pub trace: Arc<RwLock<Trace>>,
@@ -100,7 +107,8 @@ impl Server {
                                  member: Member,
                                  trace: Trace,
                                  ring_key: Option<SymKey>,
-                                 name: Option<String>)
+                                 name: Option<String>,
+                                 suitability_lookup: Box<Suitability>)
                                  -> Result<Server> {
         let maybe_swim_socket_addr = swim_addr.to_socket_addrs().map(|mut iter| iter.next());
         let maybe_gossip_socket_addr = gossip_addr.to_socket_addrs().map(|mut iter| iter.next());
@@ -121,6 +129,7 @@ impl Server {
                     update_store: RumorStore::default(),
                     swim_addr: Arc::new(RwLock::new(swim_socket_addr)),
                     gossip_addr: Arc::new(RwLock::new(gossip_socket_addr)),
+                    suitability_lookup: Arc::new(suitability_lookup),
                     pause: Arc::new(AtomicBool::new(false)),
                     trace: Arc::new(RwLock::new(trace)),
                     swim_rounds: Arc::new(AtomicIsize::new(0)),
@@ -446,7 +455,8 @@ impl Server {
 
     /// Start an election for the given service group, declaring this members suitability and the
     /// term for the election.
-    pub fn start_election(&self, sg: ServiceGroup, suitability: u64, term: u64) {
+    pub fn start_election(&self, sg: ServiceGroup, term: u64) {
+        let suitability = self.suitability_lookup.get(&sg);
         let mut e = Election::new(self.member_id(), sg, suitability);
         e.set_term(term);
         let ek = RumorKey::from(&e);
@@ -549,7 +559,7 @@ impl Server {
             let term = old_term + 1;
             warn!("Starting a new election for {} {}", sg, term);
             self.election_store.remove(&service_group, "election");
-            self.start_election(sg, 0, term);
+            self.start_election(sg, term);
         }
 
         for (service_group, old_term) in update_elections_to_restart {
@@ -592,7 +602,7 @@ impl Server {
                             return;
                         }
                     };
-                    self.start_election(sg, 0, election.get_term());
+                    self.start_election(sg, election.get_term());
                 }
                 // If we are the member that this election is voting for, then check to see if the
                 // election is over! If it is, mark this election as final before you process it.
@@ -628,7 +638,7 @@ impl Server {
                         return;
                     }
                 };
-                self.start_election(sg, 0, election.get_term());
+                self.start_election(sg, election.get_term());
             }
             if !election.is_finished() {
                 let has_quorum = self.check_quorum(election.key());
@@ -790,7 +800,8 @@ impl fmt::Display for Server {
 #[cfg(test)]
 mod tests {
     mod server {
-        use server::Server;
+        use habitat_core::service::ServiceGroup;
+        use server::{Server, Suitability};
         use server::timing::Timing;
         use member::Member;
         use trace::Trace;
@@ -798,6 +809,14 @@ mod tests {
 
         static SWIM_PORT: AtomicUsize = ATOMIC_USIZE_INIT;
         static GOSSIP_PORT: AtomicUsize = ATOMIC_USIZE_INIT;
+
+        #[derive(Debug)]
+        struct ZeroSuitability;
+        impl Suitability for ZeroSuitability {
+            fn get(&self, _service_group: &ServiceGroup) -> u64 {
+                0
+            }
+        }
 
         fn start_server() -> Server {
             SWIM_PORT.compare_and_swap(0, 6666, Ordering::Relaxed);
@@ -814,7 +833,8 @@ mod tests {
                         member,
                         Trace::default(),
                         None,
-                        None)
+                        None,
+                        Box::new(ZeroSuitability))
                 .unwrap()
         }
 
@@ -833,7 +853,8 @@ mod tests {
                                 member,
                                 Trace::default(),
                                 None,
-                                None)
+                                None,
+                                Box::new(ZeroSuitability))
                 .is_err())
         }
 

--- a/components/butterfly/tests/rumor/election.rs
+++ b/components/butterfly/tests/rumor/election.rs
@@ -25,9 +25,9 @@ fn three_members_run_election() {
     net.add_service(1, "core/witcher/1.2.3/20161208121212");
     net.add_service(2, "core/witcher/1.2.3/20161208121212");
 
-    net.add_election(0, "witcher", 0);
-    net.add_election(1, "witcher", 0);
-    net.add_election(2, "witcher", 0);
+    net.add_election(0, "witcher");
+    net.add_election(1, "witcher");
+    net.add_election(2, "witcher");
 
     assert_wait_for_election_status!(net, [0..3], "witcher.prod", Election_Status::Finished);
     assert_wait_for_equal_election!(net, [0..3, 0..3], "witcher.prod");
@@ -40,7 +40,7 @@ fn three_members_run_election_from_one_starting_rumor() {
     net.add_service(0, "core/witcher/1.2.3/20161208121212");
     net.add_service(1, "core/witcher/1.2.3/20161208121212");
     net.add_service(2, "core/witcher/1.2.3/20161208121212");
-    net.add_election(0, "witcher", 0);
+    net.add_election(0, "witcher");
     assert_wait_for_election_status!(net, [0..3], "witcher.prod", Election_Status::Finished);
     assert_wait_for_equal_election!(net, [0..3, 0..3], "witcher.prod");
 }
@@ -51,7 +51,7 @@ fn two_members_fail_to_find_quorum() {
     net.mesh();
     net.add_service(0, "core/witcher/1.2.3/20161208121212");
     net.add_service(1, "core/witcher/1.2.3/20161208121212");
-    net.add_election(0, "witcher", 0);
+    net.add_election(0, "witcher");
     assert_wait_for_equal_election!(net, [0..2, 0..2], "witcher.prod");
     assert_wait_for_election_status!(net, [0..2], "witcher.prod", Election_Status::NoQuorum);
 }
@@ -62,11 +62,11 @@ fn two_members_find_quorum_when_a_third_comes() {
     net.mesh();
     net.add_service(0, "core/witcher/1.2.3/20161208121212");
     net.add_service(1, "core/witcher/1.2.3/20161208121212");
-    net.add_election(0, "witcher", 0);
+    net.add_election(0, "witcher");
     assert_wait_for_equal_election!(net, [0..2, 0..2], "witcher.prod");
     assert_wait_for_election_status!(net, [0..2], "witcher.prod", Election_Status::NoQuorum);
 
-    net.members.push(btest::start_server("2", None));
+    net.members.push(btest::start_server("2", None, 0));
     net.add_service(2, "core/witcher/1.2.3/20161208121212");
     net.connect(2, 0);
     assert_wait_for_election_status!(net, [0..2], "witcher.prod", Election_Status::Finished);
@@ -82,7 +82,7 @@ fn five_members_elect_a_new_leader_when_the_old_one_dies() {
     net.add_service(2, "core/witcher/1.2.3/20161208121212");
     net.add_service(3, "core/witcher/1.2.3/20161208121212");
     net.add_service(4, "core/witcher/1.2.3/20161208121212");
-    net.add_election(0, "witcher", 0);
+    net.add_election(0, "witcher");
     assert_wait_for_election_status!(net, [0..5], "witcher.prod", Election_Status::Finished);
     assert_wait_for_equal_election!(net, [0..5, 0..5], "witcher.prod");
 
@@ -133,7 +133,7 @@ fn five_members_elect_a_new_leader_when_the_old_one_dies() {
 
 #[test]
 fn five_members_elect_a_new_leader_when_they_are_quorum_partitioned() {
-    let mut net = btest::SwimNet::new(5);
+    let mut net = btest::SwimNet::new_with_suitability(vec![1, 0, 0, 0, 0]);
     net[0].member.write().expect("Member lock is poisoned").set_persistent(true);
     net[4].member.write().expect("Member lock is poisoned").set_persistent(true);
     net.add_service(0, "core/witcher/1.2.3/20161208121212");
@@ -141,7 +141,7 @@ fn five_members_elect_a_new_leader_when_they_are_quorum_partitioned() {
     net.add_service(2, "core/witcher/1.2.3/20161208121212");
     net.add_service(3, "core/witcher/1.2.3/20161208121212");
     net.add_service(4, "core/witcher/1.2.3/20161208121212");
-    net.add_election(0, "witcher", 1);
+    net.add_election(0, "witcher");
     net.connect(0, 1);
     net.connect(1, 2);
     net.connect(2, 3);

--- a/components/sup/src/fs.rs
+++ b/components/sup/src/fs.rs
@@ -55,3 +55,8 @@ pub fn svc_static_path<T: AsRef<Path>>(service_name: T) -> PathBuf {
 pub fn svc_var_path<T: AsRef<Path>>(service_name: T) -> PathBuf {
     svc_path(service_name).join("var")
 }
+
+/// Returns the path to a given service's logs.
+pub fn svc_logs_path<T: AsRef<Path>>(service_name: T) -> PathBuf {
+    svc_path(service_name).join("logs")
+}

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -26,7 +26,9 @@ use butterfly;
 use butterfly::member::Member;
 use butterfly::trace::Trace;
 use butterfly::server::timing::Timing;
+use butterfly::server::Suitability;
 use hcore::crypto::{default_cache_key_path, SymKey};
+use hcore::service::ServiceGroup;
 use time::{SteadyTime, Duration as TimeDuration};
 use toml;
 
@@ -40,6 +42,20 @@ use http_gateway;
 
 static LOGKEY: &'static str = "MR";
 
+#[derive(Debug)]
+struct SuitabilityLookup(Arc<RwLock<Vec<Service>>>);
+impl Suitability for SuitabilityLookup {
+    fn get(&self, service_group: &ServiceGroup) -> u64 {
+        self.0
+            .write()
+            .expect("Services lock is poisoned!")
+            .iter_mut()
+            .find(|s| s.service_group == *service_group)
+            .and_then(|s| s.suitability())
+            .unwrap_or(u64::min_value())
+    }
+}
+
 #[derive(Clone)]
 pub struct State {
     pub butterfly: butterfly::Server,
@@ -48,11 +64,11 @@ pub struct State {
 }
 
 impl State {
-    pub fn new(butterfly: butterfly::Server) -> Self {
+    pub fn new(services: Arc<RwLock<Vec<Service>>>, butterfly: butterfly::Server) -> Self {
         State {
             butterfly: butterfly,
             census_list: Arc::new(RwLock::new(CensusList::new())),
-            services: Arc::new(RwLock::new(Vec::new())),
+            services: services,
         }
     }
 }
@@ -88,12 +104,14 @@ impl Manager {
             None => None,
         };
 
+        let services = Arc::new(RwLock::new(Vec::new()));
         let server = try!(butterfly::Server::new(&cfg.gossip_listen,
                                                  &cfg.gossip_listen,
                                                  member,
                                                  Trace::default(),
                                                  ring_key,
-                                                 None));
+                                                 None,
+                                                 Box::new(SuitabilityLookup(services.clone()))));
         outputln!("Butterfly Member ID {}", server.member_id());
         for peer_addr in &cfg.gossip_peers {
             let mut peer = Member::new();
@@ -104,7 +122,7 @@ impl Manager {
         }
         Ok(Manager {
             updater: ServiceUpdater::new(server.clone()),
-            state: State::new(server),
+            state: State::new(services, server),
             gossip_listen: cfg.gossip_listen,
             http_listen: cfg.http_listen,
         })
@@ -117,7 +135,7 @@ impl Manager {
         if service.topology == Topology::Leader {
             // Note - eventually, we need to deal with suitability here. The original implementation
             // didn't have this working either.
-            self.state.butterfly.start_election(service.service_group.clone(), 0, 0);
+            self.state.butterfly.start_election(service.service_group.clone(), 0);
         }
         self.updater.add(&service);
         self.state.services.write().expect("Services lock is poisoned!").push(service);

--- a/components/sup/src/manager/service/hooks.rs
+++ b/components/sup/src/manager/service/hooks.rs
@@ -16,6 +16,7 @@ use std;
 use std::fmt;
 use std::io::BufReader;
 use std::io::prelude::*;
+use std::fs::File;
 use std::path::{Path, PathBuf};
 use std::process::{Child, ExitStatus};
 use std::result;
@@ -48,15 +49,21 @@ pub trait Hook: fmt::Debug + Sized {
 
     fn file_name() -> &'static str;
 
-    fn load<C, T>(service_group: &ServiceGroup, concrete_path: C, template_path: T) -> Option<Self>
+    fn load<C, T, L>(service_group: &ServiceGroup,
+                     concrete_path: C,
+                     template_path: T,
+                     logs_path: L)
+                     -> Option<Self>
         where C: AsRef<Path>,
-              T: AsRef<Path>
+              T: AsRef<Path>,
+              L: AsRef<Path>
     {
         let concrete = concrete_path.as_ref().join(Self::file_name());
         let template = template_path.as_ref().join(Self::file_name());
+        let logs_prefix = logs_path.as_ref().join(Self::file_name());
         match std::fs::metadata(&template) {
             Ok(_) => {
-                match Self::new(concrete, template) {
+                match Self::new(concrete, template, logs_prefix) {
                     Ok(hook) => Some(hook),
                     Err(err) => {
                         outputln!(preamble service_group, "Failed to load hook: {}", err);
@@ -73,9 +80,10 @@ pub trait Hook: fmt::Debug + Sized {
         }
     }
 
-    fn new<C, T>(concrete_path: C, template_path: T) -> Result<Self>
+    fn new<C, T, L>(concrete_path: C, template_path: T, logs_prefix: L) -> Result<Self>
         where C: Into<PathBuf>,
-              T: AsRef<Path>;
+              T: AsRef<Path>,
+              L: Into<PathBuf>;
 
     /// Compile a hook into it's destination service directory.
     fn compile(&self, cfg: &ServiceConfig) -> Result<()> {
@@ -103,9 +111,10 @@ pub trait Hook: fmt::Debug + Sized {
                 return Self::ExitValue::default();
             }
         };
-        stream_output::<Self>(service_group, &mut child);
+        let mut hook_output = HookOutput::new(self.logs_prefix());
+        hook_output.stream_output::<Self>(service_group, &mut child);
         match child.wait() {
-            Ok(status) => self.handle_exit(service_group, &status),
+            Ok(status) => self.handle_exit(service_group, &hook_output, &status),
             Err(err) => {
                 outputln!(preamble service_group,
                     "Hook failed to run, {}, {}", Self::file_name(), err);
@@ -114,15 +123,21 @@ pub trait Hook: fmt::Debug + Sized {
         }
     }
 
-    fn handle_exit(&self, group: &ServiceGroup, status: &ExitStatus) -> Self::ExitValue;
+    fn handle_exit(&self,
+                   group: &ServiceGroup,
+                   output: &HookOutput,
+                   status: &ExitStatus)
+                   -> Self::ExitValue;
 
     fn path(&self) -> &Path;
 
     fn template(&self) -> &Template;
+
+    fn logs_prefix(&self) -> &Path;
 }
 
 #[derive(Debug, Serialize)]
-pub struct FileUpdatedHook(RenderPair);
+pub struct FileUpdatedHook(RenderPair, LogsPrefix);
 
 impl Hook for FileUpdatedHook {
     type ExitValue = bool;
@@ -131,15 +146,20 @@ impl Hook for FileUpdatedHook {
         "file_updated"
     }
 
-    fn new<C, T>(concrete_path: C, template_path: T) -> Result<Self>
+    fn new<C, T, L>(concrete_path: C, template_path: T, logs_prefix: L) -> Result<Self>
         where C: Into<PathBuf>,
-              T: AsRef<Path>
+              T: AsRef<Path>,
+              L: Into<PathBuf>
     {
         let pair = RenderPair::new(concrete_path, template_path)?;
-        Ok(FileUpdatedHook(pair))
+        Ok(FileUpdatedHook(pair, logs_prefix.into()))
     }
 
-    fn handle_exit(&self, _: &ServiceGroup, status: &ExitStatus) -> Self::ExitValue {
+    fn handle_exit(&self,
+                   _: &ServiceGroup,
+                   _: &HookOutput,
+                   status: &ExitStatus)
+                   -> Self::ExitValue {
         status.success()
     }
 
@@ -150,10 +170,14 @@ impl Hook for FileUpdatedHook {
     fn template(&self) -> &Template {
         &self.0.template
     }
+
+    fn logs_prefix(&self) -> &Path {
+        &self.1
+    }
 }
 
 #[derive(Debug, Serialize)]
-pub struct HealthCheckHook(RenderPair);
+pub struct HealthCheckHook(RenderPair, LogsPrefix);
 
 impl Hook for HealthCheckHook {
     type ExitValue = health::HealthCheck;
@@ -162,15 +186,20 @@ impl Hook for HealthCheckHook {
         "health_check"
     }
 
-    fn new<C, T>(concrete_path: C, template_path: T) -> Result<Self>
+    fn new<C, T, L>(concrete_path: C, template_path: T, logs_prefix: L) -> Result<Self>
         where C: Into<PathBuf>,
-              T: AsRef<Path>
+              T: AsRef<Path>,
+              L: Into<PathBuf>
     {
         let pair = RenderPair::new(concrete_path, template_path)?;
-        Ok(HealthCheckHook(pair))
+        Ok(HealthCheckHook(pair, logs_prefix.into()))
     }
 
-    fn handle_exit(&self, service_group: &ServiceGroup, status: &ExitStatus) -> Self::ExitValue {
+    fn handle_exit(&self,
+                   service_group: &ServiceGroup,
+                   _: &HookOutput,
+                   status: &ExitStatus)
+                   -> Self::ExitValue {
         match status.code() {
             Some(0) => health::HealthCheck::Ok,
             Some(1) => health::HealthCheck::Warning,
@@ -196,10 +225,14 @@ impl Hook for HealthCheckHook {
     fn template(&self) -> &Template {
         &self.0.template
     }
+
+    fn logs_prefix(&self) -> &Path {
+        &self.1
+    }
 }
 
 #[derive(Debug, Serialize)]
-pub struct InitHook(RenderPair);
+pub struct InitHook(RenderPair, LogsPrefix);
 
 impl Hook for InitHook {
     type ExitValue = ExitCode;
@@ -208,15 +241,20 @@ impl Hook for InitHook {
         "init"
     }
 
-    fn new<C, T>(concrete_path: C, template_path: T) -> Result<Self>
+    fn new<C, T, L>(concrete_path: C, template_path: T, logs_prefix: L) -> Result<Self>
         where C: Into<PathBuf>,
-              T: AsRef<Path>
+              T: AsRef<Path>,
+              L: Into<PathBuf>
     {
         let pair = RenderPair::new(concrete_path, template_path)?;
-        Ok(InitHook(pair))
+        Ok(InitHook(pair, logs_prefix.into()))
     }
 
-    fn handle_exit(&self, service_group: &ServiceGroup, status: &ExitStatus) -> Self::ExitValue {
+    fn handle_exit(&self,
+                   service_group: &ServiceGroup,
+                   _: &HookOutput,
+                   status: &ExitStatus)
+                   -> Self::ExitValue {
         match status.code() {
             Some(code) => ExitCode(code),
             None => {
@@ -234,10 +272,14 @@ impl Hook for InitHook {
     fn template(&self) -> &Template {
         &self.0.template
     }
+
+    fn logs_prefix(&self) -> &Path {
+        &self.1
+    }
 }
 
 #[derive(Debug, Serialize)]
-pub struct ReconfigureHook(RenderPair);
+pub struct ReconfigureHook(RenderPair, LogsPrefix);
 
 impl Hook for ReconfigureHook {
     type ExitValue = ExitCode;
@@ -246,15 +288,20 @@ impl Hook for ReconfigureHook {
         "reconfigure"
     }
 
-    fn new<C, T>(concrete_path: C, template_path: T) -> Result<Self>
+    fn new<C, T, L>(concrete_path: C, template_path: T, logs_prefix: L) -> Result<Self>
         where C: Into<PathBuf>,
-              T: AsRef<Path>
+              T: AsRef<Path>,
+              L: Into<PathBuf>
     {
         let pair = RenderPair::new(concrete_path, template_path)?;
-        Ok(ReconfigureHook(pair))
+        Ok(ReconfigureHook(pair, logs_prefix.into()))
     }
 
-    fn handle_exit(&self, service_group: &ServiceGroup, status: &ExitStatus) -> Self::ExitValue {
+    fn handle_exit(&self,
+                   service_group: &ServiceGroup,
+                   _: &HookOutput,
+                   status: &ExitStatus)
+                   -> Self::ExitValue {
         match status.code() {
             Some(code) => ExitCode(code),
             None => {
@@ -272,10 +319,14 @@ impl Hook for ReconfigureHook {
     fn template(&self) -> &Template {
         &self.0.template
     }
+
+    fn logs_prefix(&self) -> &Path {
+        &self.1
+    }
 }
 
 #[derive(Debug, Serialize)]
-pub struct RunHook(RenderPair);
+pub struct RunHook(RenderPair, LogsPrefix);
 
 impl Hook for RunHook {
     type ExitValue = ExitCode;
@@ -284,15 +335,20 @@ impl Hook for RunHook {
         "run"
     }
 
-    fn new<C, T>(concrete_path: C, template_path: T) -> Result<Self>
+    fn new<C, T, L>(concrete_path: C, template_path: T, logs_prefix: L) -> Result<Self>
         where C: Into<PathBuf>,
-              T: AsRef<Path>
+              T: AsRef<Path>,
+              L: Into<PathBuf>
     {
         let pair = RenderPair::new(concrete_path, template_path)?;
-        Ok(RunHook(pair))
+        Ok(RunHook(pair, logs_prefix.into()))
     }
 
-    fn handle_exit(&self, service_group: &ServiceGroup, status: &ExitStatus) -> Self::ExitValue {
+    fn handle_exit(&self,
+                   service_group: &ServiceGroup,
+                   _: &HookOutput,
+                   status: &ExitStatus)
+                   -> Self::ExitValue {
         match status.code() {
             Some(code) => ExitCode(code),
             None => {
@@ -310,10 +366,14 @@ impl Hook for RunHook {
     fn template(&self) -> &Template {
         &self.0.template
     }
+
+    fn logs_prefix(&self) -> &Path {
+        &self.1
+    }
 }
 
 #[derive(Debug, Serialize)]
-pub struct SmokeTestHook(RenderPair);
+pub struct SmokeTestHook(RenderPair, LogsPrefix);
 
 impl Hook for SmokeTestHook {
     type ExitValue = health::SmokeCheck;
@@ -322,15 +382,20 @@ impl Hook for SmokeTestHook {
         "smoke_test"
     }
 
-    fn new<C, T>(concrete_path: C, template_path: T) -> Result<Self>
+    fn new<C, T, L>(concrete_path: C, template_path: T, logs_prefix: L) -> Result<Self>
         where C: Into<PathBuf>,
-              T: AsRef<Path>
+              T: AsRef<Path>,
+              L: Into<PathBuf>
     {
         let pair = RenderPair::new(concrete_path, template_path)?;
-        Ok(SmokeTestHook(pair))
+        Ok(SmokeTestHook(pair, logs_prefix.into()))
     }
 
-    fn handle_exit(&self, service_group: &ServiceGroup, status: &ExitStatus) -> Self::ExitValue {
+    fn handle_exit(&self,
+                   service_group: &ServiceGroup,
+                   _: &HookOutput,
+                   status: &ExitStatus)
+                   -> Self::ExitValue {
         match status.code() {
             Some(0) => health::SmokeCheck::Ok,
             Some(code) => health::SmokeCheck::Failed(code),
@@ -348,6 +413,10 @@ impl Hook for SmokeTestHook {
 
     fn template(&self) -> &Template {
         &self.0.template
+    }
+
+    fn logs_prefix(&self) -> &Path {
+        &self.1
     }
 }
 
@@ -394,18 +463,27 @@ impl HookTable {
     }
 
     /// Read all available hook templates from the table's package directory into the table.
-    pub fn load_hooks<T, U>(mut self, service_group: &ServiceGroup, hooks: T, templates: U) -> Self
+    pub fn load_hooks<T, U, L>(mut self,
+                               service_group: &ServiceGroup,
+                               hooks: T,
+                               templates: U,
+                               logs_dir: L)
+                               -> Self
         where T: AsRef<Path>,
-              U: AsRef<Path>
+              U: AsRef<Path>,
+              L: AsRef<Path>
     {
         if let Some(meta) = std::fs::metadata(templates.as_ref()).ok() {
             if meta.is_dir() {
-                self.file_updated = FileUpdatedHook::load(service_group, &hooks, &templates);
-                self.health_check = HealthCheckHook::load(service_group, &hooks, &templates);
-                self.init = InitHook::load(service_group, &hooks, &templates);
-                self.reconfigure = ReconfigureHook::load(service_group, &hooks, &templates);
-                self.run = RunHook::load(service_group, &hooks, &templates);
-                self.smoke_test = SmokeTestHook::load(service_group, &hooks, &templates);
+                self.file_updated =
+                    FileUpdatedHook::load(service_group, &hooks, &templates, &logs_dir);
+                self.health_check =
+                    HealthCheckHook::load(service_group, &hooks, &templates, &logs_dir);
+                self.init = InitHook::load(service_group, &hooks, &templates, &logs_dir);
+                self.reconfigure =
+                    ReconfigureHook::load(service_group, &hooks, &templates, &logs_dir);
+                self.run = RunHook::load(service_group, &hooks, &templates, &logs_dir);
+                self.smoke_test = SmokeTestHook::load(service_group, &hooks, &templates, &logs_dir);
             }
         }
         debug!("{}, Hooks loaded, destination={}, templates={}",
@@ -424,6 +502,8 @@ impl HookTable {
         });
     }
 }
+
+type LogsPrefix = PathBuf;
 
 struct RenderPair {
     path: PathBuf,
@@ -458,24 +538,116 @@ impl Serialize for RenderPair {
     }
 }
 
-fn stream_output<H: Hook>(service_group: &ServiceGroup, process: &mut Child) {
-    let preamble_str = stream_preamble::<H>(service_group);
-    if let Some(ref mut stdout) = process.stdout {
-        for line in BufReader::new(stdout).lines() {
-            if let Some(ref l) = line.ok() {
-                outputln!(preamble preamble_str, l);
+pub struct HookOutput {
+    stdout_log_file: PathBuf,
+    stderr_log_file: PathBuf,
+}
+
+impl HookOutput {
+    fn new<P>(log_prefix: P) -> Self
+        where P: Into<PathBuf>
+    {
+        let mut stdout_log_file = log_prefix.into();
+        let mut stderr_log_file = stdout_log_file.clone();
+
+        stdout_log_file.set_extension("stdout.log");
+        stderr_log_file.set_extension("stderr.log");
+
+        HookOutput {
+            stdout_log_file: stdout_log_file,
+            stderr_log_file: stderr_log_file,
+        }
+    }
+
+    fn stdout(&self) -> Option<BufReader<File>> {
+        match File::open(&self.stdout_log_file) {
+            Ok(f) => Some(BufReader::new(f)),
+            Err(_) => None,
+        }
+    }
+
+    fn stderr(&self) -> Option<BufReader<File>> {
+        match File::open(&self.stderr_log_file.clone()) {
+            Ok(f) => Some(BufReader::new(f)),
+            Err(_) => None,
+        }
+    }
+
+    fn stream_output<H: Hook>(&mut self, service_group: &ServiceGroup, process: &mut Child) {
+        let mut stdout_log = File::create(&self.stdout_log_file)
+            .expect("couldn't create log output file");
+        let mut stderr_log = File::create(&self.stderr_log_file)
+            .expect("couldn't create log output file");
+
+        let preamble_str = self.stream_preamble::<H>(service_group);
+        if let Some(ref mut stdout) = process.stdout {
+            for line in BufReader::new(stdout).lines() {
+                if let Some(ref l) = line.ok() {
+                    outputln!(preamble preamble_str, l);
+                    stdout_log.write_all(l.as_bytes());
+                }
+            }
+        }
+        if let Some(ref mut stderr) = process.stderr {
+            for line in BufReader::new(stderr).lines() {
+                if let Some(ref l) = line.ok() {
+                    outputln!(preamble preamble_str, l);
+                    stderr_log.write_all(l.as_bytes());
+                }
             }
         }
     }
-    if let Some(ref mut stderr) = process.stderr {
-        for line in BufReader::new(stderr).lines() {
-            if let Some(ref l) = line.ok() {
-                outputln!(preamble preamble_str, l);
-            }
-        }
+
+    fn stream_preamble<H: Hook>(&self, service_group: &ServiceGroup) -> String {
+        format!("{} hook[{}]:", service_group, H::file_name())
     }
 }
 
-fn stream_preamble<H: Hook>(service_group: &ServiceGroup) -> String {
-    format!("{} hook[{}]:", service_group, H::file_name())
+#[cfg(test)]
+#[cfg(not(windows))]
+mod tests {
+    use super::*;
+    use std::fs::{self, DirBuilder};
+    use tempdir::TempDir;
+    use std::process::{Command, Stdio};
+
+
+    fn hook_fixtures_path() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests")
+            .join("fixtures")
+            .join("hooks")
+    }
+
+    #[test]
+    fn hook_output() {
+        let tmp_dir = TempDir::new("habitat_hooks_test").expect("create temp dir");
+        let logs_dir = tmp_dir.path().join("logs");
+        DirBuilder::new()
+            .recursive(true)
+            .create(logs_dir)
+            .expect("couldn't create logs dir");
+        let mut cmd = Command::new(hook_fixtures_path().join(InitHook::file_name()));
+        cmd.stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        let mut child = cmd.spawn().expect("couldn't run hook");
+
+        let log_path = tmp_dir.path().join("logs").join(InitHook::file_name());
+        let mut hook_output = HookOutput::new(log_path);
+        let service_group = ServiceGroup::new("dummy", "service", None)
+            .expect("couldn't create ServiceGroup");
+
+        hook_output.stream_output::<InitHook>(&service_group, &mut child);
+
+        let mut stdout = String::new();
+        hook_output.stdout().unwrap().read_to_string(&mut stdout).expect("couldn't read stdout");
+        assert_eq!(stdout, "This is stdout");
+
+        let mut stderr = String::new();
+        hook_output.stderr().unwrap().read_to_string(&mut stderr).expect("couldn't read stderr");
+        assert_eq!(stderr, "This is stderr");
+
+        fs::remove_dir_all(tmp_dir).expect("remove temp dir");
+    }
 }

--- a/components/sup/src/manager/service/mod.rs
+++ b/components/sup/src/manager/service/mod.rs
@@ -568,6 +568,14 @@ impl Service {
         }
     }
 
+    pub fn suitability(&self) -> Option<u64> {
+        self.hooks
+            .suitability
+            .as_ref()
+            .and_then(|hook| hook.run(&self.service_group, self.runtime_cfg()))
+    }
+
+
     /// Returns the root path for service configuration, files, and data.
     pub fn svc_path(&self) -> PathBuf {
         fs::svc_path(&self.service_group.service())

--- a/components/sup/tests/fixtures/hooks/init
+++ b/components/sup/tests/fixtures/hooks/init
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+echo "This is stdout"
+echo "This is stderr" 1>&2

--- a/www/source/docs/reference/plan-syntax.html.md
+++ b/www/source/docs/reference/plan-syntax.html.md
@@ -377,6 +377,11 @@ reconfigure
 
   This hook is run when service configuration information has changed through a set of Habitat services that are peers with each other.
 
+suitability
+: File location: `<plan>/hooks/suitability`
+
+  The suitability hook allows a service to report a priority by which it should be elected leader. The hook is called when a new election is triggered and the last line it outputs to `stdout` should be a number parsable as a `u64`. In the event that a leader goes down and an election is started the service with the highest reported suitabilty will become the new leader.
+
 run
 : File location: `<plan>/hooks/run`
 


### PR DESCRIPTION
Add support for `suitability` hook.
By printing a parsable u64 as the last line of stdout this hook allows services to report a priority by which they should be elected the new leader when an election is initiated.

Closes #1767 

Also all output from running hooks is streamed to 
```
{{pkg_svc_path}}/logs/<hook>.stdout.log
```
 and 
```
{{pkg_svc_path}}/logs/<hook>.stderr.log
```