### PR TITLE
A few fixes for the supervisor

### DIFF
--- a/components/builder-admin/Cargo.toml
+++ b/components/builder-admin/Cargo.toml
@@ -24,7 +24,7 @@ router = "*"
 serde = "*"
 serde_derive = "*"
 serde_json = "*"
-toml = { version = "*", features = ["serde"], default-features = false }
+toml = { version = "*", features = ["serde"], default-features = false, git = "https://github.com/alexcrichton/toml-rs" , rev = "d39c3f7b3ec95cb3cc1e579d7d747206c66aab74" }
 unicase = "*"
 urlencoded = "*"
 

--- a/components/builder-api/Cargo.toml
+++ b/components/builder-api/Cargo.toml
@@ -25,7 +25,7 @@ router = "*"
 serde = "*"
 serde_derive = "*"
 serde_json = "*"
-toml = { version = "*", features = ["serde"], default-features = false }
+toml = { version = "*", features = ["serde"], default-features = false, git = "https://github.com/alexcrichton/toml-rs" , rev = "d39c3f7b3ec95cb3cc1e579d7d747206c66aab74" }
 unicase = "*"
 
 [dependencies.clap]

--- a/components/builder-depot/Cargo.toml
+++ b/components/builder-depot/Cargo.toml
@@ -30,7 +30,7 @@ serde = "*"
 serde_derive = "*"
 serde_json = "*"
 time = "*"
-toml = { version = "*", features = ["serde"], default-features = false }
+toml = { version = "*", features = ["serde"], default-features = false, git = "https://github.com/alexcrichton/toml-rs" , rev = "d39c3f7b3ec95cb3cc1e579d7d747206c66aab74" }
 unicase = "*"
 url = "*"
 urlencoded = "*"

--- a/components/builder-jobsrv/Cargo.toml
+++ b/components/builder-jobsrv/Cargo.toml
@@ -17,7 +17,7 @@ log = "*"
 protobuf = "*"
 postgres = "*"
 r2d2 = "*"
-toml = { version = "*", features = ["serde"], default-features = false }
+toml = { version = "*", features = ["serde"], default-features = false, git = "https://github.com/alexcrichton/toml-rs" , rev = "d39c3f7b3ec95cb3cc1e579d7d747206c66aab74" }
 
 [dependencies.clap]
 version = "*"

--- a/components/builder-router/Cargo.toml
+++ b/components/builder-router/Cargo.toml
@@ -15,7 +15,7 @@ env_logger = "*"
 log = "*"
 protobuf = "*"
 rand = "*"
-toml = { version = "*", features = ["serde"], default-features = false }
+toml = { version = "*", features = ["serde"], default-features = false, git = "https://github.com/alexcrichton/toml-rs" , rev = "d39c3f7b3ec95cb3cc1e579d7d747206c66aab74" }
 
 [dependencies.clap]
 version = "*"

--- a/components/builder-scheduler/Cargo.toml
+++ b/components/builder-scheduler/Cargo.toml
@@ -17,7 +17,7 @@ log = "*"
 protobuf = "*"
 postgres = "*"
 r2d2 = "*"
-toml = { version = "*", features = ["serde"], default-features = false }
+toml = { version = "*", features = ["serde"], default-features = false, git = "https://github.com/alexcrichton/toml-rs" , rev = "d39c3f7b3ec95cb3cc1e579d7d747206c66aab74" }
 
 [dependencies.clap]
 version = "*"

--- a/components/builder-sessionsrv/Cargo.toml
+++ b/components/builder-sessionsrv/Cargo.toml
@@ -17,7 +17,7 @@ hyper = "*"
 log = "*"
 protobuf = "*"
 time = "*"
-toml = { version = "*", features = ["serde"], default-features = false }
+toml = { version = "*", features = ["serde"], default-features = false, git = "https://github.com/alexcrichton/toml-rs" , rev = "d39c3f7b3ec95cb3cc1e579d7d747206c66aab74" }
 
 [dependencies.clap]
 version = "*"

--- a/components/builder-vault/Cargo.toml
+++ b/components/builder-vault/Cargo.toml
@@ -14,7 +14,7 @@ doc = false
 env_logger = "*"
 log = "*"
 protobuf = "*"
-toml = { version = "*", features = ["serde"], default-features = false }
+toml = { version = "*", features = ["serde"], default-features = false, git = "https://github.com/alexcrichton/toml-rs" , rev = "d39c3f7b3ec95cb3cc1e579d7d747206c66aab74" }
 
 [dependencies.clap]
 version = "*"

--- a/components/builder-worker/Cargo.toml
+++ b/components/builder-worker/Cargo.toml
@@ -16,7 +16,7 @@ git2 = "*"
 lazy_static = "*"
 log = "*"
 protobuf = "*"
-toml = { version = "*", features = ["serde"], default-features = false }
+toml = { version = "*", features = ["serde"], default-features = false, git = "https://github.com/alexcrichton/toml-rs" , rev = "d39c3f7b3ec95cb3cc1e579d7d747206c66aab74" }
 
 [dependencies.clap]
 version = "*"

--- a/components/butterfly/Cargo.toml
+++ b/components/butterfly/Cargo.toml
@@ -25,7 +25,7 @@ serde = "*"
 serde_derive = "*"
 time = "*"
 threadpool = "*"
-toml = { version = "*", features = ["serde"], default-features = false }
+toml = { version = "*", features = ["serde"], default-features = false, git = "https://github.com/alexcrichton/toml-rs" , rev = "d39c3f7b3ec95cb3cc1e579d7d747206c66aab74"}
 
 [dependencies.uuid]
 version = "*"

--- a/components/common/Cargo.toml
+++ b/components/common/Cargo.toml
@@ -14,7 +14,7 @@ regex = "*"
 retry = "*"
 term = "*"
 time = "*"
-toml = { version = "*", features = ["serde"], default-features = false }
+toml = { version = "*", features = ["serde"], default-features = false, git = "https://github.com/alexcrichton/toml-rs" , rev = "d39c3f7b3ec95cb3cc1e579d7d747206c66aab74" }
 
 [dependencies.habitat_core]
 path = "../core"

--- a/components/core/Cargo.toml
+++ b/components/core/Cargo.toml
@@ -23,7 +23,7 @@ serde_derive = "*"
 serde_json = "*"
 sodiumoxide = "*"
 time = "*"
-toml = { version = "*", features = ["serde"], default-features = false }
+toml = { version = "*", features = ["serde"], default-features = false, git = "https://github.com/alexcrichton/toml-rs" , rev = "d39c3f7b3ec95cb3cc1e579d7d747206c66aab74" }
 url = "*"
 
 [target.'cfg(not(windows))'.dependencies]

--- a/components/hab-butterfly/Cargo.toml
+++ b/components/hab-butterfly/Cargo.toml
@@ -20,7 +20,7 @@ pbr = "*"
 retry = "*"
 # Temporary depdency for gossip/rumor injection code duplication.
 temp_utp = "*"
-toml = { version = "*", features = ["serde"], default-features = false }
+toml = { version = "*", features = ["serde"], default-features = false, git = "https://github.com/alexcrichton/toml-rs" , rev = "d39c3f7b3ec95cb3cc1e579d7d747206c66aab74"}
 url = "*"
 walkdir = "*"
 

--- a/components/hab/Cargo.toml
+++ b/components/hab/Cargo.toml
@@ -22,7 +22,7 @@ regex = "*"
 retry = "*"
 serde = "*"
 serde_derive = "*"
-toml = { version = "*", features = ["serde"], default-features = false }
+toml = { version = "*", features = ["serde"], default-features = false, git = "https://github.com/alexcrichton/toml-rs" , rev = "d39c3f7b3ec95cb3cc1e579d7d747206c66aab74" }
 url = "*"
 walkdir = "*"
 

--- a/components/sup/Cargo.toml
+++ b/components/sup/Cargo.toml
@@ -32,7 +32,7 @@ serde_derive = "*"
 serde_json = "*"
 tempdir = "*"
 time = "*"
-toml = { version = "*", features = ["serde"], default-features = false }
+toml = { version = "*", features = ["serde"], default-features = false, git = "https://github.com/alexcrichton/toml-rs" , rev = "d39c3f7b3ec95cb3cc1e579d7d747206c66aab74"}
 url = "*"
 
 [dependencies.habitat_core]

--- a/components/sup/src/templating/helpers.rs
+++ b/components/sup/src/templating/helpers.rs
@@ -14,11 +14,11 @@
 
 use std::str::FromStr;
 use std::string::ToString;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 
 use hcore::package::{PackageIdent, Identifiable};
 use hcore::fs;
-use manager::service::config::{ServiceConfig, Svc};
+use manager::service::config::ServiceConfig;
 use handlebars::{Handlebars, Helper, Renderable, RenderContext, RenderError, Context};
 use serde_json;
 use toml;

--- a/components/sup/src/templating/helpers.rs
+++ b/components/sup/src/templating/helpers.rs
@@ -43,7 +43,7 @@ pub fn each_alive(h: &Helper, r: &Handlebars, rc: &mut RenderContext) -> RenderR
                                           content is: {:?}",
                                          value_array[i]))
             }));
-        if member["alive"].as_bool().unwrap_or(false) {
+        if member.contains_key("alive") && member["alive"].as_bool().unwrap_or(false) {
             debug!("Alive! {:?}", value_array[i]);
             let mut map = HashMap::default();
             let mut local_context = Context::wraps(&value_array[i]);

--- a/components/sup/src/templating/mod.rs
+++ b/components/sup/src/templating/mod.rs
@@ -214,4 +214,23 @@ mod test {
         assert_eq!(each_alive_render, each_if_render);
     }
 
+    #[test]
+    fn each_alive_helper_first_node() {
+        let mut template = Template::new();
+        // template using the new `eachAlive` helper
+        template.register_template_file("each_alive", fixtures().join("each_alive.txt"))
+            .unwrap();
+
+        // template using an each block with a nested if block filtering on `alive`
+        template.register_template_file("all_members", fixtures().join("all_members.txt"))
+            .unwrap();
+
+        let data = service_config_json_from_toml_file("one_supervisor_not_started.toml");
+
+        let each_alive_render = template.render("each_alive", &data).unwrap();
+        let each_if_render = template.render("all_members", &data).unwrap();
+
+        assert_eq!(each_alive_render, each_if_render);
+    }
+
 }

--- a/components/sup/tests/fixtures/one_supervisor_not_started.toml
+++ b/components/sup/tests/fixtures/one_supervisor_not_started.toml
@@ -1,0 +1,236 @@
+[bind]
+
+[cfg]
+
+[hab]
+version = "0.0.0"
+
+[pkg]
+ident = "core/testplan/0.1.0/20170224155210"
+name = "testplan"
+origin = "core"
+path = "/hab/pkgs/core/testplan/0.1.0/20170224155210"
+release = "20170224155210"
+svc_config_path = "/hab/svc/testplan/config"
+svc_data_path = "/hab/svc/testplan/data"
+svc_files_path = "/hab/svc/testplan/files"
+svc_group = "hab"
+svc_path = "/hab/svc/testplan"
+svc_static_path = "/hab/svc/testplan/static"
+svc_user = "hab"
+svc_var_path = "/hab/svc/testplan/var"
+version = "0.1.0"
+
+[[pkg.deps]]
+name = "jq-static"
+origin = "core"
+release = "20160909011845"
+version = "1.10"
+
+[svc]
+group = "default"
+ident = "testplan.default"
+service = "testplan"
+
+[[svc.all]]
+group = "default"
+ident = "testplan.default"
+service = "testplan"
+
+[[svc.all.members]]
+group = "default"
+member_id = "c0a11dee3c9b46eb8e314e2f486cb7f7"
+service = "testplan"
+
+[svc.all.members.cfg]
+
+[svc.all.members.pkg]
+name = "testplan"
+origin = "core"
+release = "20170224155210"
+version = "0.1.0"
+
+[svc.all.members.sys]
+gossip_ip = "0.0.0.0"
+gossip_port = "9638"
+hostname = "privatedepot"
+http_gateway_ip = "0.0.0.0"
+http_gateway_port = "9631"
+ip = "10.0.0.4"
+
+[svc.all.me]
+group = "default"
+member_id = "c0a11dee3c9b46eb8e314e2f486cb7f7"
+service = "testplan"
+
+[svc.all.me.cfg]
+
+[svc.all.me.pkg]
+name = "testplan"
+origin = "core"
+release = "20170224155210"
+version = "0.1.0"
+
+[svc.all.me.sys]
+gossip_ip = "0.0.0.0"
+gossip_port = "9638"
+hostname = "privatedepot"
+http_gateway_ip = "0.0.0.0"
+http_gateway_port = "9631"
+ip = "10.0.0.4"
+[svc.all.member_id.c0a11dee3c9b46eb8e314e2f486cb7f7]
+group = "default"
+member_id = "c0a11dee3c9b46eb8e314e2f486cb7f7"
+service = "testplan"
+
+[svc.all.member_id.c0a11dee3c9b46eb8e314e2f486cb7f7.cfg]
+
+[svc.all.member_id.c0a11dee3c9b46eb8e314e2f486cb7f7.pkg]
+name = "testplan"
+origin = "core"
+release = "20170224155210"
+version = "0.1.0"
+
+[svc.all.member_id.c0a11dee3c9b46eb8e314e2f486cb7f7.sys]
+gossip_ip = "0.0.0.0"
+gossip_port = "9638"
+hostname = "privatedepot"
+http_gateway_ip = "0.0.0.0"
+http_gateway_port = "9631"
+ip = "10.0.0.4"
+
+[[svc.members]]
+group = "default"
+member_id = "c0a11dee3c9b46eb8e314e2f486cb7f7"
+service = "testplan"
+
+[svc.members.cfg]
+
+[svc.members.pkg]
+name = "testplan"
+origin = "core"
+release = "20170224155210"
+version = "0.1.0"
+
+[svc.members.sys]
+gossip_ip = "0.0.0.0"
+gossip_port = "9638"
+hostname = "privatedepot"
+http_gateway_ip = "0.0.0.0"
+http_gateway_port = "9631"
+ip = "10.0.0.4"
+
+[svc.me]
+group = "default"
+member_id = "c0a11dee3c9b46eb8e314e2f486cb7f7"
+service = "testplan"
+
+[svc.me.cfg]
+
+[svc.me.pkg]
+name = "testplan"
+origin = "core"
+release = "20170224155210"
+version = "0.1.0"
+
+[svc.me.sys]
+gossip_ip = "0.0.0.0"
+gossip_port = "9638"
+hostname = "privatedepot"
+http_gateway_ip = "0.0.0.0"
+http_gateway_port = "9631"
+ip = "10.0.0.4"
+[svc.member_id.c0a11dee3c9b46eb8e314e2f486cb7f7]
+group = "default"
+member_id = "c0a11dee3c9b46eb8e314e2f486cb7f7"
+service = "testplan"
+
+[svc.member_id.c0a11dee3c9b46eb8e314e2f486cb7f7.cfg]
+
+[svc.member_id.c0a11dee3c9b46eb8e314e2f486cb7f7.pkg]
+name = "testplan"
+origin = "core"
+release = "20170224155210"
+version = "0.1.0"
+
+[svc.member_id.c0a11dee3c9b46eb8e314e2f486cb7f7.sys]
+gossip_ip = "0.0.0.0"
+gossip_port = "9638"
+hostname = "privatedepot"
+http_gateway_ip = "0.0.0.0"
+http_gateway_port = "9631"
+ip = "10.0.0.4"
+[svc.named.testplan.default]
+group = "default"
+ident = "testplan.default"
+service = "testplan"
+
+[[svc.named.testplan.default.members]]
+group = "default"
+member_id = "c0a11dee3c9b46eb8e314e2f486cb7f7"
+service = "testplan"
+
+[svc.named.testplan.default.members.cfg]
+
+[svc.named.testplan.default.members.pkg]
+name = "testplan"
+origin = "core"
+release = "20170224155210"
+version = "0.1.0"
+
+[svc.named.testplan.default.members.sys]
+gossip_ip = "0.0.0.0"
+gossip_port = "9638"
+hostname = "privatedepot"
+http_gateway_ip = "0.0.0.0"
+http_gateway_port = "9631"
+ip = "10.0.0.4"
+
+[svc.named.testplan.default.me]
+group = "default"
+member_id = "c0a11dee3c9b46eb8e314e2f486cb7f7"
+service = "testplan"
+
+[svc.named.testplan.default.me.cfg]
+
+[svc.named.testplan.default.me.pkg]
+name = "testplan"
+origin = "core"
+release = "20170224155210"
+version = "0.1.0"
+
+[svc.named.testplan.default.me.sys]
+gossip_ip = "0.0.0.0"
+gossip_port = "9638"
+hostname = "privatedepot"
+http_gateway_ip = "0.0.0.0"
+http_gateway_port = "9631"
+ip = "10.0.0.4"
+[svc.named.testplan.default.member_id.c0a11dee3c9b46eb8e314e2f486cb7f7]
+group = "default"
+member_id = "c0a11dee3c9b46eb8e314e2f486cb7f7"
+service = "testplan"
+
+[svc.named.testplan.default.member_id.c0a11dee3c9b46eb8e314e2f486cb7f7.cfg]
+
+[svc.named.testplan.default.member_id.c0a11dee3c9b46eb8e314e2f486cb7f7.pkg]
+name = "testplan"
+origin = "core"
+release = "20170224155210"
+version = "0.1.0"
+
+[svc.named.testplan.default.member_id.c0a11dee3c9b46eb8e314e2f486cb7f7.sys]
+gossip_ip = "0.0.0.0"
+gossip_port = "9638"
+hostname = "privatedepot"
+http_gateway_ip = "0.0.0.0"
+http_gateway_port = "9631"
+ip = "10.0.0.4"
+
+[sys]
+gossip_ip = "0.0.0.0"
+gossip_port = "9638"
+hostname = "privatedepot"
+http_gateway_ip = "0.0.0.0"
+http_gateway_port = "9631"
+ip = "10.0.0.4"


### PR DESCRIPTION
Fix the eachAlive helper (guard against the condition where the `alive` key is not present, like at supervisor startup).

Fix the toml serialization in `toml 0.3.0` (https://github.com/alexcrichton/toml-rs/issues/145) by pinning to a commit off master.  We can revert the Cargo.toml commit and cargo update when a new release of toml is out.

Fixes #1818 