### PR TITLE
Add initial job creation ability to builder-scheduler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,7 +351,7 @@ dependencies = [
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mount 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "persistent 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "router 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -381,7 +381,7 @@ dependencies = [
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mount 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "persistent 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "redis 0.7.0 (git+https://github.com/habitat-sh/redis-rs?branch=habitat)",
  "router 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -413,7 +413,7 @@ dependencies = [
  "habitat_builder_protocol 0.0.0",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "r2d2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "r2d2_redis 0.4.0 (git+https://github.com/habitat-sh/r2d2-redis.git?branch=habitat)",
  "redis 0.7.0 (git+https://github.com/habitat-sh/redis-rs?branch=habitat)",
@@ -433,8 +433,9 @@ dependencies = [
  "linked-hash-map 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "postgres 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "r2d2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.3.0 (git+https://github.com/alexcrichton/toml-rs?rev=d39c3f7b3ec95cb3cc1e579d7d747206c66aab74)",
  "zmq 0.8.1 (git+https://github.com/erickt/rust-zmq?branch=release/v0.8)",
 ]
@@ -445,7 +446,7 @@ version = "0.0.0"
 dependencies = [
  "habitat_core 0.0.0",
  "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "redis 0.7.0 (git+https://github.com/habitat-sh/redis-rs?branch=habitat)",
  "serde 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -463,7 +464,7 @@ dependencies = [
  "habitat_core 0.0.0",
  "habitat_net 0.0.0",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.3.0 (git+https://github.com/alexcrichton/toml-rs?rev=d39c3f7b3ec95cb3cc1e579d7d747206c66aab74)",
  "zmq 0.8.1 (git+https://github.com/erickt/rust-zmq?branch=release/v0.8)",
@@ -482,7 +483,7 @@ dependencies = [
  "linked-hash-map 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "postgres 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "r2d2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.3.0 (git+https://github.com/alexcrichton/toml-rs?rev=d39c3f7b3ec95cb3cc1e579d7d747206c66aab74)",
  "zmq 0.8.1 (git+https://github.com/erickt/rust-zmq?branch=release/v0.8)",
@@ -501,7 +502,7 @@ dependencies = [
  "habitat_net 0.0.0",
  "hyper 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "redis 0.7.0 (git+https://github.com/habitat-sh/redis-rs?branch=habitat)",
  "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.3.0 (git+https://github.com/alexcrichton/toml-rs?rev=d39c3f7b3ec95cb3cc1e579d7d747206c66aab74)",
@@ -519,7 +520,7 @@ dependencies = [
  "habitat_core 0.0.0",
  "habitat_net 0.0.0",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "redis 0.7.0 (git+https://github.com/habitat-sh/redis-rs?branch=habitat)",
  "toml 0.3.0 (git+https://github.com/alexcrichton/toml-rs?rev=d39c3f7b3ec95cb3cc1e579d7d747206c66aab74)",
  "zmq 0.8.1 (git+https://github.com/erickt/rust-zmq?branch=release/v0.8)",
@@ -538,7 +539,7 @@ dependencies = [
  "habitat_net 0.0.0",
  "lazy_static 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.3.0 (git+https://github.com/alexcrichton/toml-rs?rev=d39c3f7b3ec95cb3cc1e579d7d747206c66aab74)",
  "zmq 0.8.1 (git+https://github.com/erickt/rust-zmq?branch=release/v0.8)",
 ]
@@ -553,7 +554,7 @@ dependencies = [
  "lazy_static 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -645,7 +646,7 @@ dependencies = [
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mount 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "persistent 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "r2d2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "r2d2_redis 0.4.0 (git+https://github.com/habitat-sh/r2d2-redis.git?branch=habitat)",
  "redis 0.7.0 (git+https://github.com/habitat-sh/redis-rs?branch=habitat)",
@@ -677,7 +678,7 @@ dependencies = [
  "hyper-openssl 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "pbr 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -715,7 +716,7 @@ dependencies = [
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "persistent 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1230,13 +1231,13 @@ dependencies = [
  "cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "protobuf"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1898,7 +1899,7 @@ dependencies = [
 "checksum postgres-protocol 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "283e27d237a5772ef00c9e3f97e632f9a565ff514761af3e88e129576af7077c"
 "checksum postgres-shared 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "857ef343933a7d81e365a334f505a07db16ab7be64d9d7cd82c78d2f486777e4"
 "checksum prometheus 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "e1a4c5d63fb87824169dee5286dbb880d4b0a3ce0aad74dca1ac4afdad83b267"
-"checksum protobuf 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "22eaac7d4be49a479dbd875f6f84ab79eef282aa51ba36ce884ec10efd91d355"
+"checksum protobuf 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c3e2ed6fe8ff3b20b44bb4b4f54de12ac89dc38cb451dce8ae5e9dcd1507f738"
 "checksum quick-error 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7ac990ab4e038dd8481a5e3fd00641067fcfc674ad663f3222752ed5284e05d4"
 "checksum quick-error 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0aad603e8d7fb67da22dbdf1f4b826ce8829e406124109e73cf1b2454b93a71c"
 "checksum quote 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)" = "08de3f12e670f83f61e450443cbae34496a35b665691fd8e99b24ec662f75865"

--- a/components/builder-api/src/http/handlers.rs
+++ b/components/builder-api/src/http/handlers.rs
@@ -274,7 +274,10 @@ pub fn project_create(req: &mut Request) -> IronResult<Response> {
                         }
                     }
                 }
-                Err(_) => return Ok(Response::with((status::UnprocessableEntity, "rg:pc:4"))),
+                Err(e) => {
+                    error!("Base64 decode failure: {:?}", e);
+                    return Ok(Response::with((status::UnprocessableEntity, "rg:pc:4")));
+                }
             }
         }
         Err(_) => return Ok(Response::with((status::UnprocessableEntity, "rg:pc:2"))),

--- a/components/builder-depot/src/server.rs
+++ b/components/builder-depot/src/server.rs
@@ -611,8 +611,8 @@ fn schedule_package(req: &mut Request) -> IronResult<Response> {
     let mut request = Schedule::new();
     request.set_ident(ident.clone());
     match conn.route::<Schedule, Group>(&request) {
-        Ok(_) => {
-            let mut response = render_json(status::Ok, &ident);
+        Ok(group) => {
+            let mut response = render_json(status::Ok, &group);
             dont_cache_response(&mut response);
             Ok(response)
         }
@@ -1298,7 +1298,7 @@ pub fn router(depot: Depot) -> Result<Chain> {
             if depot.config.insecure {
                 XHandler::new(schedule_package)
             } else {
-                XHandler::new(schedule_package).before(worker.clone())
+                XHandler::new(schedule_package).before(basic.clone())
             }
         },
 

--- a/components/builder-jobsrv/Cargo.toml
+++ b/components/builder-jobsrv/Cargo.toml
@@ -16,6 +16,7 @@ linked-hash-map = "*"
 log = "*"
 protobuf = "*"
 postgres = "*"
+rand = "*"
 r2d2 = "*"
 toml = { version = "*", features = ["serde"], default-features = false, git = "https://github.com/alexcrichton/toml-rs" , rev = "d39c3f7b3ec95cb3cc1e579d7d747206c66aab74" }
 

--- a/components/builder-jobsrv/src/config.rs
+++ b/components/builder-jobsrv/src/config.rs
@@ -25,6 +25,7 @@ use toml;
 
 use error::{Error, Result};
 
+#[derive(Debug)]
 pub struct Config {
     /// List of net addresses for routing servers to connect to
     pub routers: Vec<SocketAddr>,
@@ -90,7 +91,7 @@ impl ConfigFile for Config {
                                                connection_db);
         try!(toml.parse_into("cfg.datastore_connection_retry_ms",
                              &mut cfg.datastore_connection_retry_ms));
-        let mut timeout_seconds = 0;
+        let mut timeout_seconds = 3600;
         try!(toml.parse_into("cfg.datastore_connection_timeout", &mut timeout_seconds));
         cfg.datastore_connection_timeout = Duration::from_secs(timeout_seconds);
         try!(toml.parse_into("cfg.pool_size", &mut cfg.pool_size));

--- a/components/builder-jobsrv/src/lib.rs
+++ b/components/builder-jobsrv/src/lib.rs
@@ -24,6 +24,7 @@ extern crate protobuf;
 extern crate r2d2;
 extern crate toml;
 extern crate zmq;
+extern crate rand;
 
 pub mod config;
 pub mod data_store;

--- a/components/builder-jobsrv/src/server/handlers.rs
+++ b/components/builder-jobsrv/src/server/handlers.rs
@@ -27,8 +27,12 @@ pub fn job_create(req: &mut Envelope,
                   state: &mut ServerState)
                   -> Result<()> {
     let msg: proto::JobSpec = try!(req.parse_msg());
-    let job: proto::Job = msg.into();
-    state.datastore().create_job(&job)?;
+    let mut job: proto::Job = msg.into();
+    state.datastore().create_job(&mut job)?;
+    debug!("Job created: id={} owner_id={} state={:?}",
+           job.get_id(),
+           job.get_owner_id(),
+           job.get_state());
     try!(state.worker_mgr().notify_work());
     try!(req.reply_complete(sock, &job));
     Ok(())

--- a/components/builder-protocol/src/message/mod.rs
+++ b/components/builder-protocol/src/message/mod.rs
@@ -77,7 +77,7 @@ impl<'a, T: 'a + protobuf::Message> MessageBuilder<'a, T> {
 
     pub fn build(self) -> ::net::Msg {
         let mut msg = net::Msg::new();
-        msg.set_body(self.msg.0.write_to_bytes().unwrap());
+        msg.set_body(self.msg.0.write_to_bytes().expect("All message fields have been set"));
         msg.set_message_id(self.msg.0.descriptor().name().to_string());
         if let Some(route_info) = self.route_info {
             msg.set_route_info(route_info);

--- a/components/builder-protocol/src/scheduler.rs
+++ b/components/builder-protocol/src/scheduler.rs
@@ -12,15 +12,37 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::result;
 use message::Routable;
-use sharding::InstaId;
 
 pub use message::scheduler::*;
+use serde::{Serialize, Serializer};
+use serde::ser::SerializeStruct;
 
 impl Routable for Schedule {
-    type H = InstaId;
+    type H = String;
 
     fn route_key(&self) -> Option<Self::H> {
-        Some(InstaId(0))
+        Some(self.get_ident().to_string())
+    }
+}
+
+impl Serialize for GroupState {
+    fn serialize<S>(&self, serializer: S) -> result::Result<S::Ok, S::Error>
+        where S: Serializer
+    {
+        // Serialize the enum as a u64.
+        serializer.serialize_u64(*self as u64)
+    }
+}
+
+impl Serialize for Group {
+    fn serialize<S>(&self, serializer: S) -> result::Result<S::Ok, S::Error>
+        where S: Serializer
+    {
+        let mut strukt = try!(serializer.serialize_struct("group", 2));
+        try!(strukt.serialize_field("group_id", &self.get_group_id()));
+        try!(strukt.serialize_field("state", &self.get_state()));
+        strukt.end()
     }
 }

--- a/components/builder-scheduler/src/config.rs
+++ b/components/builder-scheduler/src/config.rs
@@ -81,7 +81,7 @@ impl ConfigFile for Config {
                                                connection_db);
         try!(toml.parse_into("cfg.datastore_connection_retry_ms",
                              &mut cfg.datastore_connection_retry_ms));
-        let mut timeout_seconds = 0;
+        let mut timeout_seconds = 3600;
         try!(toml.parse_into("cfg.datastore_connection_timeout", &mut timeout_seconds));
         cfg.datastore_connection_timeout = Duration::from_secs(timeout_seconds);
         try!(toml.parse_into("cfg.pool_size", &mut cfg.pool_size));

--- a/components/builder-scheduler/src/data_store.rs
+++ b/components/builder-scheduler/src/data_store.rs
@@ -13,20 +13,65 @@
 // limitations under the License.
 
 
-// TBD - This is just a stub for now
+// TBD - This is a WIP for now, persistence to be added later
+
+use std::collections::HashMap;
 
 use config::Config;
 use error::Result;
+use protocol::jobsrv::Job;
+use protocol::scheduler::{Group, GroupState};
 
 #[derive(Debug, Clone)]
-pub struct DataStore {}
+pub struct JobGroup {
+    group: Group,
+    jobs: HashMap<u64, Job>,
+}
+
+#[derive(Debug, Clone)]
+pub struct DataStore {
+    curr_id: u64,
+    job_groups: HashMap<u64, JobGroup>,
+}
 
 impl DataStore {
     pub fn new(_: &Config) -> Result<DataStore> {
-        Ok(DataStore {})
+        let groups = HashMap::new();
+        Ok(DataStore {
+            curr_id: 1,
+            job_groups: groups,
+        })
     }
 
     pub fn setup(&self) -> Result<()> {
+        Ok(())
+    }
+
+    pub fn create_group(&mut self, group: &mut Group) -> Result<()> {
+        group.set_group_id(self.curr_id);
+        group.set_state(GroupState::Pending);
+
+        let job_group = JobGroup {
+            group: group.clone(),
+            jobs: HashMap::new(),
+        };
+        self.job_groups.insert(self.curr_id, job_group);
+        self.curr_id = self.curr_id + 1;
+
+        Ok(())
+    }
+
+    pub fn set_group_state(&mut self, group: &Group) -> Result<()> {
+        if let Some(job_group) = self.job_groups.get_mut(&group.get_group_id()) {
+            (*job_group).group = group.clone();
+        };
+        Ok(())
+    }
+
+    pub fn add_group_job(&mut self, group: &Group, job: &Job) -> Result<()> {
+        if let Some(job_group) = self.job_groups.get_mut(&group.get_group_id()) {
+            (*job_group).jobs.insert(job.get_id(), job.clone());
+        };
         Ok(())
     }
 }

--- a/components/builder-scheduler/src/server/handlers.rs
+++ b/components/builder-scheduler/src/server/handlers.rs
@@ -15,21 +15,60 @@
 //! A collection of handlers for the Scheduler dispatcher
 
 use hab_net::server::Envelope;
-use protocol::net::{self, ErrCode};
 use protocol::scheduler as proto;
 use zmq;
+
+use protocol::jobsrv::{Job, JobSpec};
+use hab_net::routing::Broker;
+use protocol::vault::*;
 
 use super::ServerState;
 use error::Result;
 
-// TBD: This is currently a stub, to be fleshed out later.
+// TBD: This is currently a WIP to get end-to-end flow working.
 pub fn schedule(req: &mut Envelope, sock: &mut zmq::Socket, state: &mut ServerState) -> Result<()> {
     let msg: proto::Schedule = try!(req.parse_msg());
     println!("Scheduling: {:?}", msg);
 
     let mut group = proto::Group::new();
-    group.set_group_id(0);
-    group.set_state(proto::GroupState::Pending);
+    state.datastore().create_group(&mut group)?;
+
+    let mut project_get = ProjectGet::new();
+    let project_id = format!("{}/{}",
+                             msg.get_ident().get_origin(),
+                             msg.get_ident().get_name());
+    project_get.set_id(project_id.clone());
+
+    println!("Retreiving project: {}", project_id);
+    let mut conn = Broker::connect().unwrap();
+    let project = match conn.route::<ProjectGet, Project>(&project_get) {
+        Ok(project) => project,
+        Err(err) => {
+            error!("Unable to retrieve project: {:?}, error: {:?}",
+                   project_id,
+                   err);
+            group.set_state(proto::GroupState::Failed);
+            state.datastore().set_group_state(&group)?;
+            try!(req.reply_complete(sock, &group));
+            return Ok(());
+        }
+    };
+
+    let mut job_spec: JobSpec = JobSpec::new();
+    job_spec.set_owner_id(group.get_group_id());
+    job_spec.set_project(project);
+
+    match conn.route::<JobSpec, Job>(&job_spec) {
+        Ok(job) => {
+            println!("Job created: {:?}", job);
+            state.datastore().add_group_job(&group, &job)?;
+        }
+        Err(err) => {
+            error!("Job creation error: {:?}", err);
+            group.set_state(proto::GroupState::Failed);
+            state.datastore().set_group_state(&group)?;
+        }
+    }
 
     try!(req.reply_complete(sock, &group));
     Ok(())

--- a/components/builder-scheduler/src/server/mod.rs
+++ b/components/builder-scheduler/src/server/mod.rs
@@ -17,8 +17,10 @@ pub mod handlers;
 use std::ops::Deref;
 use std::sync::{Arc, RwLock};
 
+use hab_net::config::RouteAddrs;
 use hab_net::dispatcher::prelude::*;
 use hab_net::{Application, Supervisor};
+use hab_net::routing::Broker;
 use hab_net::server::{Envelope, NetIdent, RouteConn, Service, ZMQ_CONTEXT};
 use protocol::net;
 use zmq;
@@ -54,8 +56,8 @@ pub struct ServerState {
 }
 
 impl ServerState {
-    fn datastore(&self) -> &DataStore {
-        self.datastore.as_ref().unwrap()
+    fn datastore(&mut self) -> &mut DataStore {
+        self.datastore.as_mut().unwrap()
     }
 }
 
@@ -87,8 +89,8 @@ impl Dispatcher for Worker {
         println!("Message received: {}", message.message_id());
 
         match message.message_id() {
-            "Schedule" => handlers::schedule(message, sock, state),
-            _ => panic!("unhandled message"),
+            "Schedule" => handlers::schedule(message, sock, state).unwrap(),
+            _ => panic!("unexpected message: {:?}", message.message_id()),
         };
 
         Ok(())
@@ -152,7 +154,12 @@ impl Application for Server {
         let sup: Supervisor<Worker> = Supervisor::new(cfg, init_state);
         try!(sup.start());
         try!(self.connect());
+        let broker = {
+            let cfg = self.config.read().unwrap();
+            Broker::run(Self::net_ident(), cfg.route_addrs())
+        };
         try!(zmq::proxy(&mut self.router.socket, &mut self.be_sock));
+        broker.join().unwrap();
         Ok(())
     }
 }

--- a/components/net/src/oauth/github.rs
+++ b/components/net/src/oauth/github.rs
@@ -107,7 +107,14 @@ impl GitHubClient {
             let err: HashMap<String, String> = try!(serde_json::from_str(&body));
             return Err(Error::GitHubAPI(rep.status, err));
         }
-        let contents: Contents = serde_json::from_str(&body).unwrap();
+        let mut contents: Contents = serde_json::from_str(&body).unwrap();
+
+        // We need to strip line feeds as the Github API has started to return
+        // base64 content with line feeds.
+        if contents.encoding == "base64" {
+            contents.content = contents.content.replace("\n", "");
+        }
+
         Ok(contents)
     }
 
@@ -199,7 +206,7 @@ impl GitHubClient {
 }
 
 
-#[derive(Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct Contents {
     pub name: String,
     pub path: String,

--- a/support/Procfile
+++ b/support/Procfile
@@ -3,6 +3,7 @@ api: target/debug/bldr-api start --path tmp/depot
 admin: target/debug/bldr-admin start
 router: target/debug/bldr-router start
 jobsrv: target/debug/bldr-job-srv start
+scheduler: target/debug/bldr-scheduler start
 sessionsrv: target/debug/bldr-session-srv start
 vaultsrv: target/debug/bldr-vault start
 worker: target/debug/bldr-worker start


### PR DESCRIPTION
This change adds the ability for the builder-scheduler to actually schedule a build, by sending a message to the job server. It also starts fleshing out the data store. Currently, there is no actual persistence of the scheduler data store (will be added later). 

Some key fixes needed to be made along the way:
* We need to upgrade to protobuf 1.2.2 as there is a blocking bug in 1.2.1  (issue https://github.com/stepancheg/rust-protobuf/issues/207).
*  The Github API started returning linefeeds in base64 content, so we needed to start stripping linefeeds.
* The job server data store has a temporary workaround to return job ids instead of consuming them.
* There are a couple fixes in the job server and scheduler config code that were incorrectly setting connection timeouts to zero when reading from a config file that did not explicitly set the timeout.

Signed-off-by: Salim Alam <salam@chef.io>

![giphy 5](https://cloud.githubusercontent.com/assets/13542112/23345361/e775581a-fc41-11e6-9392-7ff99f8ee418.gif)