### PR TITLE
Panic if run hook run() called directly

### DIFF
--- a/components/sup/src/manager/service/hooks.rs
+++ b/components/sup/src/manager/service/hooks.rs
@@ -258,13 +258,13 @@ impl Hook for InitHook {
         match status.code() {
             Some(0) => true,
             Some(code) => {
-                outputln!(preamble service_group,
-                    "Initialization failed! '{}' exited with status code {}", Self::file_name(), code);
+                outputln!(preamble service_group, "Initialization failed! '{}' exited with \
+                    status code {}", Self::file_name(), code);
                 false
             }
             None => {
-                outputln!(preamble service_group,
-                    "Initialization failed! '{}' exited without a status code", Self::file_name());
+                outputln!(preamble service_group, "Initialization failed! '{}' exited without a \
+                    status code", Self::file_name());
                 false
             }
         }
@@ -347,6 +347,11 @@ impl Hook for RunHook {
     {
         let pair = RenderPair::new(concrete_path, template_path)?;
         Ok(RunHook(pair, logs_prefix.into()))
+    }
+
+    fn run(&self, _: &ServiceGroup, _: &RuntimeConfig) -> Self::ExitValue {
+        panic!("The run hook is a an exception to the lifetime of a service. It should only be \
+                run by the supervisor module!");
     }
 
     fn handle_exit(&self,
@@ -457,16 +462,19 @@ impl Hook for SuitabilityHook {
                             Ok(line) => {
                                 match line.trim().parse::<u64>() {
                                     Ok(suitability) => {
-                                        outputln!(preamble service_group, "Reporting suitability of: {}", suitability);
+                                        outputln!(preamble service_group, "Reporting suitability \
+                                            of: {}", suitability);
                                         return Some(suitability);
                                     }
                                     Err(err) => {
-                                        outputln!(preamble service_group, "Parsing suitability failed: {}", err);
+                                        outputln!(preamble service_group,
+                                            "Parsing suitability failed: {}", err);
                                     }
                                 };
                             }
                             Err(err) => {
-                                outputln!(preamble service_group, "Failed to read last line of stdout: {}", err);
+                                outputln!(preamble service_group,
+                                    "Failed to read last line of stdout: {}", err);
                             }
                         };
                         None


### PR DESCRIPTION
The run hook is a special hook and needs to be handled a bit differently
than the others. It's not really part of the lifecycle as much as it is
the main entry point for a service. Because of this and, unless the
supervisor needs to restart the process, it can't be run more than once
or out of turn in anyway. It also can't log it's output like another
lifecycle hook might.

This change overrides the run() function of the RunHook with a panic!
to warn the developer. In the future we should think about refactoring
the code a bit to be more clear about the special nature of the
run hook.

/cc @bodymindarts 

![gif-keyboard-3489729577402260259](https://cloud.githubusercontent.com/assets/54036/23379452/da1a0e54-fceb-11e6-9feb-a41a9c5fb8e3.gif)