### PR TITLE
[sup] Begin a new service lifecycle after pkg update

### DIFF
--- a/components/sup/src/manager/service/mod.rs
+++ b/components/sup/src/manager/service/mod.rs
@@ -463,8 +463,11 @@ impl Service {
         }
         *self.package.write().expect("Package lock poisoned") = package;
 
+        if let Err(err) = self.supervisor.down() {
+            outputln!(preamble self.service_group,
+                      "Error stopping process while updating package: {}", err);
+        }
         self.initialized = false;
-        self.initialize();
     }
 
     pub fn to_rumor<T: ToString>(&self, member_id: T) -> ServiceRumor {


### PR DESCRIPTION
When a package is updated the service should reset and begin a new
lifecycle. This commit stops the service after an update and resets the
initialized flag allowing the initialization process to take place via
the regular `execute_hooks()` code path on the next `service.tick()` call.

Closes #1641