### PR TITLE
Reload

### DIFF
--- a/components/sup/src/fs.rs
+++ b/components/sup/src/fs.rs
@@ -60,3 +60,8 @@ pub fn svc_var_path<T: AsRef<Path>>(service_name: T) -> PathBuf {
 pub fn svc_logs_path<T: AsRef<Path>>(service_name: T) -> PathBuf {
     svc_path(service_name).join("logs")
 }
+
+/// Returns the path to a given service's pid file.
+pub fn svc_pid_file<T: AsRef<Path>>(service_name: T) -> PathBuf {
+    svc_path(service_name).join("PID")
+}

--- a/components/sup/src/manager/service/config.rs
+++ b/components/sup/src/manager/service/config.rs
@@ -494,6 +494,7 @@ pub struct Pkg {
     pub svc_files_path: PathBuf,
     pub svc_static_path: PathBuf,
     pub svc_var_path: PathBuf,
+    pub svc_pid_file: PathBuf,
     pub svc_user: String,
     pub svc_group: String,
 }
@@ -517,6 +518,7 @@ impl Pkg {
             svc_files_path: fs::svc_files_path(&package.ident.name),
             svc_static_path: fs::svc_static_path(&package.ident.name),
             svc_var_path: fs::svc_var_path(&package.ident.name),
+            svc_pid_file: fs::svc_pid_file(&package.ident.name),
             svc_user: runtime.svc_user.to_string(),
             svc_group: runtime.svc_group.to_string(),
         })

--- a/components/sup/src/supervisor.rs
+++ b/components/sup/src/supervisor.rs
@@ -41,7 +41,6 @@ use error::{Result, Error};
 use fs;
 use util;
 
-const PIDFILE_NAME: &'static str = "PID";
 static LOGKEY: &'static str = "SV";
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -258,7 +257,7 @@ impl Supervisor {
     }
 
     pub fn pid_file(&self) -> PathBuf {
-        self.service_dir().join(PIDFILE_NAME)
+        fs::svc_pid_file(&self.package.read().expect("Package lock poisoned").ident().name)
     }
 
     /// Create a pid file for a package

--- a/components/sup/src/supervisor.rs
+++ b/components/sup/src/supervisor.rs
@@ -30,6 +30,7 @@ use std::sync::{Arc, RwLock};
 use std::thread;
 
 use hcore::os::process::{HabChild, ExitStatusExt};
+use hcore::util::perm::set_owner;
 use hcore::package::PackageInstall;
 use hcore::service::ServiceGroup;
 use serde::{Serialize, Serializer};
@@ -271,7 +272,10 @@ impl Supervisor {
                 debug!("Creating PID file for child {} -> {:?}",
                        pid_file.display(),
                        pid);
-                let mut f = try!(File::create(pid_file));
+                let mut f = try!(File::create(&pid_file));
+                try!(set_owner(pid_file,
+                               &self.runtime_config.svc_user,
+                               &self.runtime_config.svc_group));
                 try!(write!(f, "{}", pid));
                 Ok(())
             }

--- a/components/sup/tests/fixtures/complex_config.toml
+++ b/components/sup/tests/fixtures/complex_config.toml
@@ -20,6 +20,7 @@ svc_path = "/hab/svc/lsyncd"
 svc_static_path = "/hab/svc/lsyncd/static"
 svc_user = "hab"
 svc_var_path = "/hab/svc/lsyncd/var"
+svc_pid_file = "/hab/svc/lsyncd/PID"
 version = "0.1.0"
 
 [[pkg.deps]]

--- a/components/sup/tests/fixtures/simple_config.toml
+++ b/components/sup/tests/fixtures/simple_config.toml
@@ -20,6 +20,7 @@ svc_path = "/hab/svc/testplan"
 svc_static_path = "/hab/svc/testplan/static"
 svc_user = "hab"
 svc_var_path = "/hab/svc/testplan/var"
+svc_pid_file = "/hab/svc/testplan/PID"
 version = "0.1.0"
 
 [[pkg.deps]]

--- a/www/source/docs/reference/plan-syntax.html.md
+++ b/www/source/docs/reference/plan-syntax.html.md
@@ -373,10 +373,15 @@ init
 
   This hook is run when a Habitat topology starts.
 
+reload
+: File location: `<plan>/hooks/reload`
+
+For processes that can update their configuration without requiring a restart a `reload` hook can be written. This hook will execute instead of the default behaviour of restarting the process. `{{pkg.svc_pid_file}}` can be used to get a handle on the `PID` of the service.
+
 reconfigure
 : File location: `<plan>/hooks/reconfigure`
 
-  This hook is run when service configuration information has changed through a set of Habitat services that are peers with each other.
+  This hook is run when service configuration information has changed through a set of Habitat services that are peers with each other. Before the `reconfigure` hook the config files are re-rendered and the process is either restarted or the `reload` hook is called if present.
 
 suitability
 : File location: `<plan>/hooks/suitability`


### PR DESCRIPTION
Add support for a `reload` hook.

For processes that can update their configuration without requiring a restart a `reload` hook can be written. This hook will execute instead of the default behaviour of restarting the process. `{{pkg.svc_pid_file}}` can be used to get a handle on the `PID` of the service.

Closes https://github.com/habitat-sh/habitat/issues/1801