### PR TITLE
allow config and supervisor commands on windows only disallowing on mac

### DIFF
--- a/components/hab/src/command/butterfly.rs
+++ b/components/hab/src/command/butterfly.rs
@@ -22,7 +22,7 @@ pub fn start(ui: &mut UI, args: Vec<OsString>) -> Result<()> {
     inner::start(ui, args)
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(not(target_os = "macos"))]
 mod inner {
     use std::ffi::OsString;
     use std::path::PathBuf;
@@ -63,7 +63,7 @@ mod inner {
     }
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(target_os = "macos")]
 mod inner {
     use std::ffi::OsString;
 

--- a/components/hab/src/command/sup/mod.rs
+++ b/components/hab/src/command/sup/mod.rs
@@ -22,7 +22,7 @@ pub fn start(ui: &mut UI, args: Vec<OsString>) -> Result<()> {
     inner::start(ui, args)
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(not(target_os = "macos"))]
 mod inner {
     use std::ffi::OsString;
     use std::path::PathBuf;
@@ -77,7 +77,7 @@ mod inner {
     }
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(target_os = "macos")]
 mod inner {
     use std::env;
     use std::ffi::OsString;


### PR DESCRIPTION
With the commit to make depot uploads and downloads target aware and a working private depot at https://depot.stevenmurawski.com, this PR is the only change needed to have a fully demoable windows POC hab.exe.

I really dont see risk in openning these commands to windows users even though windows supervisor support is not officially provided.

Signed-off-by: Matt Wrock <matt@mattwrock.com>