### PR TITLE
disallows indexing of the acceptance site

### DIFF
--- a/support/ci/deploy_website.sh
+++ b/support/ci/deploy_website.sh
@@ -11,6 +11,7 @@ else
     echo "We are on a PR or against the master branch. Deploying to Acceptance."
     cd www
     make build
+    sed -i '/^Disallow:/ s/$/ \//' build/robots.txt
     zip -r website.zip build
 
     curl -H "Content-Type: application/zip" \


### PR DESCRIPTION
should add `/` to the Disallow: key in robots.txt before zipping and shipping the acceptance site.

Signed-off-by: Ian Henry <ihenry@chef.io>