### PR TITLE
Appveyor artifacts for all windows HARTs and CLI zip and upload to depot on PR merge

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,18 +21,31 @@ skip_tags: true
 clone_folder: c:\projects\habitat
 
 environment:
+  CARGO_HOME: "c:\\cargo"
+  RUSTUP_HOME: "c:\\multirust"
+  CARGO_TARGET_DIR: "c:\\projects\\habitat\\target"
+  HAB_DEPOT_URL: "https://depot.stevenmurawski.com/v1/depot"
+  HAB_WINDOWS_STUDIO: true
+  HAB_AUTH_TOKEN:
+    secure: il1kqjDtQSFOoD12nDaJhCBntC905Q8T9jRzyTZtqlJPxc3vCoS1bBeNbB55J82M
+  ORIGIN_KEY:
+    secure: S1rfa/qXZgO8skQfr/YGrGpma37Q+OBEbAH8dPXsBKtUYDOTuMXpnNq1asu6XkTkpQjaJvhst6AxSlYDweE9V+xlUzLQdd6hgIPCFNOb0Uos5iMIgbJGcyKmeY2q80Ig
+
   matrix:
-    - CARGO_HOME: "c:\\cargo"
-      RUSTUP_HOME: "c:\\multirust"
-      hab_build_action: "test;build"
-      hab_components: "core;http-client;builder-protocol;builder-depot-client;common;win-users;sup"
+    - hab_build_action: "test;build"
+      hab_components: "core;http-client;builder-protocol;builder-depot-client;common;win-users;sup;hab-butterfly"
+
+    - hab_build_action: "package"
+      hab_components: "hab;plan-build-ps1;studio;sup;hab-butterfly"
 
 build_script:
   - ps: Update-AppveyorBuild -Version "$((gc -raw ./VERSION).trim())-$((Get-Date).ToString('yyyyMMddHHmmss'))"
   - c:\projects\habitat\support\ci\appveyor.bat
 
 artifacts:
-  - path: hab-$(appveyor_build_version)-x86_64-windows.zip
+  - path: 'results\*.hart'
+
+  - path: 'results\*.zip'
     name: HabCLI
 
 deploy:

--- a/components/hab-butterfly/plan.ps1
+++ b/components/hab-butterfly/plan.ps1
@@ -9,9 +9,15 @@ $pkg_bin_dirs = @("bin")
 $pkg_build_deps = @("core/visual-cpp-redist-2013", "core/rust", "core/cacerts")
 
 function Invoke-Prepare {
+    if($env:HAB_CARGO_TARGET_DIR) {
+        $env:CARGO_TARGET_DIR           = "$env:HAB_CARGO_TARGET_DIR"
+    }
+    else {
+        $env:CARGO_TARGET_DIR           = "$env:HAB_CACHE_SRC_PATH/$pkg_dirname"
+    }
+
     $env:SSL_CERT_FILE              = "$(Get-HabPackagePath "cacerts")/ssl/certs/cacert.pem"
     $env:PLAN_VERSION               = "$pkg_version/$pkg_release"
-    $env:CARGO_TARGET_DIR           = "$HAB_CACHE_SRC_PATH/$pkg_dirname"
     $env:LIB                        += ";$HAB_CACHE_SRC_PATH/$pkg_dirname/lib"
     $env:INCLUDE                    += ";$HAB_CACHE_SRC_PATH/$pkg_dirname/include"
     $env:SODIUM_LIB_DIR             = "$HAB_CACHE_SRC_PATH/$pkg_dirname/lib"

--- a/components/hab/plan.ps1
+++ b/components/hab/plan.ps1
@@ -9,9 +9,15 @@ $pkg_bin_dirs = @("bin")
 $pkg_build_deps = @("core/rust", "core/cacerts")
 
 function Invoke-Prepare {
+    if($env:HAB_CARGO_TARGET_DIR) {
+        $env:CARGO_TARGET_DIR           = "$env:HAB_CARGO_TARGET_DIR"
+    }
+    else {
+        $env:CARGO_TARGET_DIR           = "$env:HAB_CACHE_SRC_PATH/$pkg_dirname"
+    }
+
     $env:SSL_CERT_FILE              = "$(Get-HabPackagePath "cacerts")/ssl/certs/cacert.pem"
     $env:PLAN_VERSION               = "$pkg_version/$pkg_release"
-    $env:CARGO_TARGET_DIR           = "$HAB_CACHE_SRC_PATH/$pkg_dirname"
     $env:LIB                        += ";$HAB_CACHE_SRC_PATH/$pkg_dirname/lib"
     $env:INCLUDE                    += ";$HAB_CACHE_SRC_PATH/$pkg_dirname/include"
     $env:SODIUM_LIB_DIR             = "$HAB_CACHE_SRC_PATH/$pkg_dirname/lib"

--- a/components/sup/plan.ps1
+++ b/components/sup/plan.ps1
@@ -10,9 +10,15 @@ $pkg_deps = @("core/powershell")
 $pkg_build_deps = @("core/visual-cpp-redist-2013", "core/rust", "core/cacerts")
 
 function Invoke-Prepare {
+    if($env:HAB_CARGO_TARGET_DIR) {
+        $env:CARGO_TARGET_DIR           = "$env:HAB_CARGO_TARGET_DIR"
+    }
+    else {
+        $env:CARGO_TARGET_DIR           = "$env:HAB_CACHE_SRC_PATH/$pkg_dirname"
+    }
+
     $env:SSL_CERT_FILE              = "$(Get-HabPackagePath "cacerts")/ssl/certs/cacert.pem"
     $env:PLAN_VERSION               = "$pkg_version/$pkg_release"
-    $env:CARGO_TARGET_DIR           = "$HAB_CACHE_SRC_PATH/$pkg_dirname"
     $env:LIB                        += ";$HAB_CACHE_SRC_PATH/$pkg_dirname/lib"
     $env:INCLUDE                    += ";$HAB_CACHE_SRC_PATH/$pkg_dirname/include"
     $env:SODIUM_LIB_DIR             = "$HAB_CACHE_SRC_PATH/$pkg_dirname/lib"


### PR DESCRIPTION
This PR will build all windows plans and will also install the hab plan and extract its bin to the cli zip. On PR merge it will upload the harts to our temp depot.

The down side is this adds about 15 minutes to the build. I think we need to pay appveyor to get the packaging build and the testing build to run concurrently. I will look into that because I think the benefit is worth it.

As a fortunate byproduct, this also adds some functional test coverage since it runs several hab commands using the built hab.exe and also runs the builds off of the plan-build script and studio from master.

Signed-off-by: Matt Wrock <matt@mattwrock.com>