### PR TITLE
Add job status notification to builder-scheduler

### DIFF
--- a/components/builder-jobsrv/src/config.rs
+++ b/components/builder-jobsrv/src/config.rs
@@ -33,6 +33,8 @@ pub struct Config {
     pub worker_command_addr: SocketAddr,
     /// Listening net address for heartbeat traffic from Workers.
     pub worker_heartbeat_addr: SocketAddr,
+    /// Publishing net address for job status updates
+    pub status_publisher_addr: SocketAddr,
     /// PostgreSQL connection URL
     pub datastore_connection_url: String,
     /// Timing to retry the connection to the data store if it cannot be established
@@ -58,6 +60,8 @@ impl Default for Config {
             worker_command_addr: SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(0, 0, 0, 0), 5566)),
             worker_heartbeat_addr: SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(0, 0, 0, 0),
                                                                     5567)),
+            status_publisher_addr: SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(0, 0, 0, 0),
+                                                                    5568)),
             datastore_connection_url: String::from("postgresql:://hab@127.0.0.1/builder_db_test"),
             datastore_connection_retry_ms: 300,
             datastore_connection_timeout: Duration::from_secs(3600),
@@ -78,6 +82,7 @@ impl ConfigFile for Config {
         try!(toml.parse_into("cfg.routers", &mut cfg.routers));
         try!(toml.parse_into("cfg.worker_command_addr", &mut cfg.worker_command_addr));
         try!(toml.parse_into("cfg.worker_heartbeat_addr", &mut cfg.worker_heartbeat_addr));
+        try!(toml.parse_into("cfg.status_publisher_addr", &mut cfg.status_publisher_addr));
         let mut connection_user = String::new();
         try!(toml.parse_into("cfg.datastore_connection_user", &mut connection_user));
         let mut connection_address = String::new();

--- a/components/builder-jobsrv/src/server/worker_manager.rs
+++ b/components/builder-jobsrv/src/server/worker_manager.rs
@@ -62,6 +62,7 @@ pub struct WorkerMgr {
     hb_sock: zmq::Socket,
     rq_sock: zmq::Socket,
     work_mgr_sock: zmq::Socket,
+    pub_sock: zmq::Socket,
     msg: zmq::Message,
     workers: LinkedHashMap<String, Instant>,
 }
@@ -71,6 +72,7 @@ impl WorkerMgr {
         let hb_sock = try!((**ZMQ_CONTEXT).as_mut().socket(zmq::SUB));
         let rq_sock = try!((**ZMQ_CONTEXT).as_mut().socket(zmq::ROUTER));
         let work_mgr_sock = try!((**ZMQ_CONTEXT).as_mut().socket(zmq::DEALER));
+        let pub_sock = try!((**ZMQ_CONTEXT).as_mut().socket(zmq::PUB));
         try!(rq_sock.set_router_mandatory(true));
         try!(hb_sock.set_subscribe(&[]));
         try!(work_mgr_sock.set_rcvhwm(1));
@@ -83,6 +85,7 @@ impl WorkerMgr {
             hb_sock: hb_sock,
             rq_sock: rq_sock,
             work_mgr_sock: work_mgr_sock,
+            pub_sock: pub_sock,
             msg: msg,
             workers: LinkedHashMap::new(),
         })
@@ -113,6 +116,9 @@ impl WorkerMgr {
             println!("Listening for heartbeats on {}",
                      cfg.worker_heartbeat_addr.to_addr_string());
             try!(self.hb_sock.bind(&cfg.worker_heartbeat_addr.to_addr_string()));
+            println!("Publishing job status on {}",
+                     cfg.status_publisher_addr.to_addr_string());
+            try!(self.pub_sock.bind(&cfg.status_publisher_addr.to_addr_string()));
         }
         let mut hb_sock = false;
         let mut rq_sock = false;
@@ -197,7 +203,13 @@ impl WorkerMgr {
                         continue;
                     }
                 }
-                None => break,
+                None => {
+                    debug!("no workers available - bailing for now");
+                    job.set_state(jobsrv::JobState::Pending);
+                    self.datastore.set_job_state(&job)?;
+                    try!(self.work_mgr_sock.recv(&mut self.msg, 0));
+                    return Ok(());
+                }
             }
         }
         Ok(())
@@ -243,6 +255,10 @@ impl WorkerMgr {
         let job: jobsrv::Job = try!(parse_from_bytes(&self.msg));
         debug!("job_status={:?}", job);
         try!(self.datastore.set_job_state(&job));
+
+        // Publish job status to any subscribers
+        try!(self.pub_sock.send(&job.write_to_bytes().unwrap(), 0));
+
         Ok(())
     }
 }

--- a/components/builder-scheduler/src/server/scheduler.rs
+++ b/components/builder-scheduler/src/server/scheduler.rs
@@ -1,0 +1,151 @@
+// Copyright (c) 2016-2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::{mpsc, Arc, RwLock};
+use std::thread::{self, JoinHandle};
+
+use protobuf::parse_from_bytes;
+use hab_net::server::ZMQ_CONTEXT;
+use zmq;
+
+use protocol::jobsrv;
+use config::Config;
+use data_store::DataStore;
+use error::Result;
+
+const SCHEDULER_ADDR: &'static str = "inproc://scheduler";
+
+pub struct ScheduleClient {
+    socket: zmq::Socket,
+}
+
+impl ScheduleClient {
+    pub fn connect(&mut self) -> Result<()> {
+        try!(self.socket.connect(SCHEDULER_ADDR));
+        Ok(())
+    }
+
+    pub fn notify_work(&mut self) -> Result<()> {
+        try!(self.socket.send(&[1], 0));
+        Ok(())
+    }
+}
+
+impl Default for ScheduleClient {
+    fn default() -> ScheduleClient {
+        let socket = (**ZMQ_CONTEXT).as_mut().socket(zmq::DEALER).unwrap();
+        socket.set_sndhwm(1).unwrap();
+        socket.set_linger(0).unwrap();
+        socket.set_immediate(true).unwrap();
+        ScheduleClient { socket: socket }
+    }
+}
+
+pub struct ScheduleMgr {
+    config: Arc<RwLock<Config>>,
+    datastore: DataStore,
+    work_sock: zmq::Socket,
+    status_sock: zmq::Socket,
+    msg: zmq::Message,
+}
+
+impl ScheduleMgr {
+    pub fn new(config: Arc<RwLock<Config>>, datastore: DataStore) -> Result<Self> {
+        let status_sock = try!((**ZMQ_CONTEXT).as_mut().socket(zmq::SUB));
+        let work_sock = try!((**ZMQ_CONTEXT).as_mut().socket(zmq::DEALER));
+        try!(status_sock.set_subscribe(&[]));
+        try!(work_sock.set_rcvhwm(1));
+        try!(work_sock.set_linger(0));
+        try!(work_sock.set_immediate(true));
+        let msg = try!(zmq::Message::new());
+        Ok(ScheduleMgr {
+            config: config,
+            datastore: datastore,
+            work_sock: work_sock,
+            status_sock: status_sock,
+            msg: msg,
+        })
+    }
+
+    pub fn start(cfg: Arc<RwLock<Config>>, ds: DataStore) -> Result<JoinHandle<()>> {
+        let (tx, rx) = mpsc::sync_channel(1);
+        let handle = thread::Builder::new()
+            .name("scheduler".to_string())
+            .spawn(move || {
+                let mut schedule_mgr = Self::new(cfg, ds).unwrap();
+                schedule_mgr.run(tx).unwrap();
+            })
+            .unwrap();
+        match rx.recv() {
+            Ok(()) => Ok(handle),
+            Err(e) => panic!("scheduler thread startup error, err={}", e),
+        }
+    }
+
+    fn run(&mut self, rz: mpsc::SyncSender<()>) -> Result<()> {
+        try!(self.work_sock.bind(SCHEDULER_ADDR));
+        {
+            let cfg = self.config.read().unwrap();
+
+            for addr in cfg.jobsrv_addrs() {
+                println!("Connecting to job status publisher: {}", addr);
+                try!(self.status_sock.connect(&addr));
+            }
+        }
+
+        let mut status_sock = false;
+        let mut work_sock = false;
+        rz.send(()).unwrap();
+        loop {
+            {
+                let mut items = [self.work_sock.as_poll_item(1), self.status_sock.as_poll_item(1)];
+                try!(zmq::poll(&mut items, -1));
+
+                if (items[0].get_revents() & zmq::POLLIN) > 0 {
+                    work_sock = true;
+                }
+                if (items[1].get_revents() & zmq::POLLIN) > 0 {
+                    status_sock = true;
+                }
+            }
+
+            if work_sock {
+                try!(self.process_work());
+                work_sock = false;
+            }
+
+            if status_sock {
+                try!(self.process_status());
+                status_sock = false;
+            }
+        }
+    }
+
+    fn process_work(&mut self) -> Result<()> {
+        println!("Process work called");
+        try!(self.work_sock.recv(&mut self.msg, 0));
+
+        // TBD: Scheduling work will happen here
+        Ok(())
+    }
+
+    fn process_status(&mut self) -> Result<()> {
+        try!(self.status_sock.recv(&mut self.msg, 0));
+        let job: jobsrv::Job = try!(parse_from_bytes(&self.msg));
+        println!("Received job status: {:?}", job);
+
+        // TBD: Data store update will happen here
+        Ok(())
+    }
+}


### PR DESCRIPTION
This change adds the capability for the builder-scheduler to subscribe to job status notifications sent from the job server.

Signed-off-by: Salim Alam <salam@chef.io>

![giphy 9](https://cloud.githubusercontent.com/assets/13542112/23575158/973002ce-003d-11e7-875d-95058951b04a.gif)
