### PR TITLE
improve appveyor rust build caching to match travis

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,8 +2,8 @@
 image: Visual Studio 2015
 
 cache:
-  - c:\cargo\registry
-  - c:\cargo\git
+  - c:\cargo
+  - c:\projects\habitat\target
 
 branches:
   only:


### PR DESCRIPTION
According to travis docs, `cache: cargo` caches `$HOME/.cargo` and `$TRAVIS_BUILD_DIR/target`. So this should do the same on appveyor. Also based on some appveyor research, the cache will not be impacted until this is merged so I may merge it as soon as this goes green.

Signed-off-by: Matt Wrock <matt@mattwrock.com>