### PR TITLE
fix error: no default toolchain configured in appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,8 @@
 image: Visual Studio 2015
 
 cache:
-  - c:\cargo
+  - c:\cargo\registry
+  - c:\cargo\git
   - c:\projects\habitat\target
 
 branches:


### PR DESCRIPTION
Appveyor builds started throwing `error: no default toolchain configured` with new caching so I'm restoring the old cargo caches and just adding target.

Signed-off-by: Matt Wrock <matt@mattwrock.com>