### PR TITLE
Use `as |thing|` form for all `#each` examples

### DIFF
--- a/components/sup/tests/fixtures/all_members.txt
+++ b/components/sup/tests/fixtures/all_members.txt
@@ -1,9 +1,9 @@
-{{~#each svc.members}}
-{{~#if alive}}
-Member ID: {{member_id}}
+{{~#each svc.members as |member| }}
+{{~#if member.alive}}
+Member ID: {{member.member_id}}
 {{~/if}}
 {{~/each}}
 
-{{~#each svc.members}}
-Member ID: {{member_id}}
+{{~#each svc.members as |member| }}
+Member ID: {{member.member_id}}
 {{~/each}}

--- a/components/sup/tests/fixtures/each_alive.txt
+++ b/components/sup/tests/fixtures/each_alive.txt
@@ -2,6 +2,6 @@
 Member ID: {{member_id}}
 {{~/eachAlive}}
 
-{{~#each svc.members}}
-Member ID: {{member_id}}
+{{~#each svc.members as |member| }}
+Member ID: {{member.member_id}}
 {{~/each}}

--- a/test/fixtures/app-server/config/app.conf
+++ b/test/fixtures/app-server/config/app.conf
@@ -1,9 +1,9 @@
 {{toml cfg}}
 
-{{~#each bind.database.members}}
-{{~#if alive }}
-[[database.{{sys.hostname}}]]
-port={{cfg.port}}
-host="{{cfg.host}}"
+{{~#each bind.database.members as |member|}}
+{{~#if member.alive }}
+[[database.{{member.sys.hostname}}]]
+port={{member.cfg.port}}
+host="{{member.cfg.host}}"
 {{~/if}}
 {{/each}}

--- a/www/source/docs/create-packages-configure.html.md
+++ b/www/source/docs/create-packages-configure.html.md
@@ -100,10 +100,10 @@ Helpers can also be nested and used together in block expressions. Here is anoth
 
 Here's an example using `each` to render multiple server entries:
 
-    {{~#each cfg.servers}}
+    {{~#each cfg.servers as |server| }}
     server {
-      host {{host}}
-      port {{port}}
+      host {{server.host}}
+      port {{server.port}}
     }
     {{~/each}}
 

--- a/www/source/docs/run-packages-binding.html.md
+++ b/www/source/docs/run-packages-binding.html.md
@@ -35,10 +35,10 @@ Once you've defined both ends of the contract you can leverage the bind in any o
 
 ~~~
 {{#if bind.has_database }}
-{{~#each bind.database.members}}
-{{~#if alive }}
-  database = "{{sys.ip}}:{{cfg.port}}"
-  database-secure = "{{sys.ip}}:{{cfg.ssl-port}}"
+{{~#each bind.database.members as |member| }}
+{{~#if member.alive }}
+  database = "{{member.sys.ip}}:{{member.cfg.port}}"
+  database-secure = "{{member.sys.ip}}:{{member.cfg.ssl-port}}"
 {{~/if}}
 {{~/each}}
 {{~/if}}


### PR DESCRIPTION
Doing it this way removes confusing ambiguity.

If you're not using it and you want to refer to something with the same
key as the item you're iterating over, you have to do `../thing`, which
is an extra thing to learn and easily leads to errors and confusion.

Always using `as |thing|` makes it so you never have to think about
shadowing variables and you templates, while a smidge longer, are always
clear.

The examples for `#eachAlive` were not changed because of #1903.

Signed-off-by: Nathan L Smith <smith@chef.io>