### PR TITLE
Remove Optimizely

### DIFF
--- a/www/source/layouts/layout.slim
+++ b/www/source/layouts/layout.slim
@@ -6,8 +6,6 @@ html prefix="og: http://ogp.me/ns#"
     meta content="width=device-width,initial-scale=1.0,minimum-scale=1.0,maximum-scale=1.0,user-scalable=no" name="viewport"
     meta name="description" content=current_page.data.description
 
-    script src="https://cdn.optimizely.com/js/6807120590.js"
-
     - current_page.data.title ||= "Habitat"
     - canonical_url = "https://www.habitat.sh"
     - social_image = "#{canonical_url}/images/habitat-social.jpg"


### PR DESCRIPTION
We no longer use Optimizely for our sites. This removes that tag.

Signed-off-by: Christopher Webber <cwebber@chef.io>