### PR TITLE
Fix TOML serialize for package default_cfg

### DIFF
--- a/components/core/src/package/mod.rs
+++ b/components/core/src/package/mod.rs
@@ -24,3 +24,14 @@ pub use self::ident::{Identifiable, PackageIdent};
 pub use self::install::PackageInstall;
 pub use self::plan::Plan;
 pub use self::target::{Target, PackageTarget};
+
+#[cfg(test)]
+pub mod test_support {
+    use std::path::PathBuf;
+
+    pub fn fixture_path(name: &str) -> PathBuf {
+        let path =
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests").join("fixtures").join(name);
+        path
+    }
+}

--- a/components/core/tests/fixtures/test_package/default.toml
+++ b/components/core/tests/fixtures/test_package/default.toml
@@ -1,0 +1,40 @@
+port = 6379
+bind = []
+protected-mode = "yes"
+timeout = 0
+tcp-keepalive = 0
+loglevel = "notice"
+logfile = "\"\""
+databases = 16
+stop-writes-on-bgsave-error = "yes"
+rbcompression = "yes"
+rbchecksum = "yes"
+dbfilename = "dump.rdb"
+slave-serve-stale-data = "yes"
+slave-read-only = "yes"
+repl-diskless-sync = "no"
+repl-diskless-synx-delay = 5
+repl-ping-slave-period = 10
+repl-timeout = 60
+repl-disable-tcp-nodelay = "no"
+repl-backlog-size = "1mb"
+repl-backlog-ttl = "3600"
+slave-priority = "100"
+min-slaves-to-write = false
+min-slaves-max-lag = false
+requirepass = ""
+appendonly = "no"
+appendfsync = "everysec"
+no-appendfsync-on-rewrite = "no"
+
+[[save]]
+sec = 900
+keys = 1
+
+[[save]]
+sec = 300
+keys = 10
+
+[[save]]
+sec = 60
+keys = 10000


### PR DESCRIPTION
This fixes the breakage described in issue #1908. The package default config is now deserialized as a TOML Value, instead of the a TOML Table, which preserves the ordering constraint that TOML serialization requires.

Signed-off-by: Salim Alam <salam@chef.io>

![giphy 10](https://cloud.githubusercontent.com/assets/13542112/23633272/f3007cbc-0279-11e7-8a27-4c55489dacc4.gif)
