### PR TITLE
build all release packages and upload to acceptance on master merges

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -187,7 +187,10 @@ matrix:
       script: ./support/ci/deploy_website.sh
     - os: linux
       env:
+        - COMPONENTS="sup hab-butterfly hab plan-build backline bintray-publish studio pkg-aci pkg-dockerize pkg-mesosize pkg-tarize"
         - AFFECTED_DIRS="Cargo\.toml|Cargo\.lock|components/hab|components/common|components/core|components/builder-depot-client|components/http-client"
+        # HAB_AUTH_TOKEN
+        - secure: "OCq9oDAEP3Cc0BiGrnZHE0FoNdyqsAy2LPTwEoOKvgiZdrw5o2bvpN1Kl+DKpw2auKtkeAS1aVSE/CMrglxrDs+VolvK9ttW3kj8c7+AeuCYjBsyWqdnZ1/24u6P+20fKanYrsMsnFb2r9OWwxZVlFnfmks81LWToOlGFJpL5KnmSPrB2vlWPbiaH9+yg8aslrmCq0reSoSVSnoZHoTolWtjzx2WdPYqA4gu0HHASVbH5qP+PoQSGIWvwbBaU4xhwkp1K8rWCjI8lre2YpBMOdfZv+9arMjc3Xg/kgD9oGU9DN7Q3UzAWxTSJv/3Cm4LArwiI57rXMLDKf8N1MhvGMHP1xgbuN8JWFKqFuWpqCf6qJkYG8+VZkruKYOo/2tXtBY4hpbR2abcWvYU/S9AQFHKGJQ2vcArnp5SKO+Oq/fNVneeHli4RbGMRQCMVq+X0SSC148F0zEVVwkNM5eq4askfc/2y4asySrH0MT/5T3yBp8fr3zXpnj82h2ytCZOUs0o+La9+wt5gSDUJHdY/BwSSPrgnKSp7ixslM/g7lMy3nAOs6qLql8/vW543CXBurCACWTqwKcy3/wRparTkmZcs1d7vUrbcfYv7XJzh0pw2P1hCjWD9BtkowbuLVo8K9ndPl2rbFY9XljqFXMTcHxp4ETeCc23azHCs+SYFb0="
         # HAB_ORIGIN_KEY
         - secure: "uZ70GE8qK3GBgs7ZIsoy5DhPlHNs2hoLxLBGKq+u+0XrE017pOnW6mNHsn7J7i2r8CPtd4KFsFEN52wZSA+Sf96MFIL2w9E+geykBgbRMZzv4icuCf0xSGwm4iRMgZ9A08TfurMX6y6N+4JNsrCv9syVNuGq09EL2wLHPXOQhesMpodijQLcFikxfEXXbaWla1xHnYxJk+fbvYDoXVCbdqnpdeLTmGuQHFaaNI7jm1B3L/dl+IGZxwFdvqBT3G9mHiXBdyi8bALs7rcZNdV7PqtFFpp98zIeqwNHtHPd5cBRmqDRTRxucRSACS/lurrz9J+001a9RjPvUkYlLrn0hQY9pN6oo+kCpN/1r0bc17i4FbGx7R73FnFgPK/cno0ENBFygNZn7/jg6cENgjkBlHsZhc1+L1xhILo46nQU9XbWJrwelVYUOOGXI76tECOkGhkglx1vYK8fcMVLJMhL7psgPpbGbDJQDuAKhHS+75txNK+356ompNL+YUzeWZc4KSGZCNTQsPK+rsGttmA+JXtAaquFaY5xwSgyKHwETiSVg4dYXb3xh6goNxf2JTOZOosWaypyykHqcqsqCu2fzIDdmkgCx6I5/5q8I/7Z0es0jlUpHamlihZwe4E5YdYFCSouaDoeTnVdJKVI1p9fnAjpFqjivFgqLE/Z504vCNU="
         - BINTRAY_USER=smurawski
@@ -204,6 +207,7 @@ matrix:
           - wget
       cache:
         apt: true
+        cargo: true
         directories:
           - /root/travis_bootstrap
           - /hab/studios/home--travis--build--habitat-sh

--- a/components/builder-worker/habitat/plan.sh
+++ b/components/builder-worker/habitat/plan.sh
@@ -35,8 +35,12 @@ do_prepare() {
   export PLAN_VERSION="${pkg_version}/${pkg_release}"
   build_line "Setting PLAN_VERSION=$PLAN_VERSION"
 
-  # Used by Cargo to use a pristine, isolated directory for all compilation
-  export CARGO_TARGET_DIR="$HAB_CACHE_SRC_PATH/$pkg_dirname"
+  if [ -z "$HAB_CARGO_TARGET_DIR" ]; then
+    # Used by Cargo to use a pristine, isolated directory for all compilation
+    export CARGO_TARGET_DIR="$HAB_CACHE_SRC_PATH/$pkg_dirname"
+  else
+    export CARGO_TARGET_DIR="$HAB_CARGO_TARGET_DIR"
+  fi
   build_line "Setting CARGO_TARGET_DIR=$CARGO_TARGET_DIR"
 
   export LIBARCHIVE_LIB_DIR="$(pkg_path_for libarchive)/lib"

--- a/components/hab-butterfly/plan.sh
+++ b/components/hab-butterfly/plan.sh
@@ -25,8 +25,12 @@ _common_prepare() {
   export PLAN_VERSION="${pkg_version}/${pkg_release}"
   build_line "Setting PLAN_VERSION=$PLAN_VERSION"
 
-  # Used by Cargo to use a pristine, isolated directory for all compilation
-  export CARGO_TARGET_DIR="$HAB_CACHE_SRC_PATH/$pkg_dirname"
+  if [ -z "$HAB_CARGO_TARGET_DIR" ]; then
+    # Used by Cargo to use a pristine, isolated directory for all compilation
+    export CARGO_TARGET_DIR="$HAB_CACHE_SRC_PATH/$pkg_dirname"
+  else
+    export CARGO_TARGET_DIR="$HAB_CARGO_TARGET_DIR"
+  fi
   build_line "Setting CARGO_TARGET_DIR=$CARGO_TARGET_DIR"
 }
 

--- a/components/hab/plan.sh
+++ b/components/hab/plan.sh
@@ -26,9 +26,13 @@ _common_prepare() {
   # Used by the `build.rs` program to set the version of the binaries
   export PLAN_VERSION="${pkg_version}/${pkg_release}"
   build_line "Setting PLAN_VERSION=$PLAN_VERSION"
-
-  # Used by Cargo to use a pristine, isolated directory for all compilation
-  export CARGO_TARGET_DIR="$HAB_CACHE_SRC_PATH/$pkg_dirname"
+  
+  if [ -z "$HAB_CARGO_TARGET_DIR" ]; then
+    # Used by Cargo to use a pristine, isolated directory for all compilation
+    export CARGO_TARGET_DIR="$HAB_CACHE_SRC_PATH/$pkg_dirname"
+  else
+    export CARGO_TARGET_DIR="$HAB_CARGO_TARGET_DIR"
+  fi
   build_line "Setting CARGO_TARGET_DIR=$CARGO_TARGET_DIR"
 }
 

--- a/components/sup/plan.sh
+++ b/components/sup/plan.sh
@@ -25,8 +25,12 @@ _common_prepare() {
   export PLAN_VERSION="${pkg_version}/${pkg_release}"
   build_line "Setting PLAN_VERSION=$PLAN_VERSION"
 
-  # Used by Cargo to use a pristine, isolated directory for all compilation
-  export CARGO_TARGET_DIR="$HAB_CACHE_SRC_PATH/$pkg_dirname"
+  if [ -z "$HAB_CARGO_TARGET_DIR" ]; then
+    # Used by Cargo to use a pristine, isolated directory for all compilation
+    export CARGO_TARGET_DIR="$HAB_CACHE_SRC_PATH/$pkg_dirname"
+  else
+    export CARGO_TARGET_DIR="$HAB_CARGO_TARGET_DIR"
+  fi
   build_line "Setting CARGO_TARGET_DIR=$CARGO_TARGET_DIR"
 }
 

--- a/support/ci/deploy_unstable.sh
+++ b/support/ci/deploy_unstable.sh
@@ -1,12 +1,63 @@
 #!/bin/bash
 
+set -e
+
 # fail fast if we aren't on the desired branch or if this is a pull request
 if [[ "${TRAVIS_PULL_REQUEST}" != "false" ]] || [[ "${TRAVIS_BRANCH}" != "master" ]]; then
     echo "We only publish on successful builds of master."
     exit 0
 fi
 
-# kick off the mac unstable build first
+# now do the linux unstable build
+BOOTSTRAP_DIR=/root/travis_bootstrap
+TEST_BIN_DIR=/root/hab_bins
+TRAVIS_HAB=${BOOTSTRAP_DIR}/hab
+HAB_DOWNLOAD_URL="https://api.bintray.com/content/habitat/stable/linux/x86_64/hab-%24latest-x86_64-linux.tar.gz?bt_package=hab-x86_64-linux"
+export HAB_ORIGIN=core
+export HAB_DEPOT_URL=http://app.acceptance.habitat.sh/v1/depot
+
+mkdir -p ${BOOTSTRAP_DIR}
+# download a hab binary to build hab from source in a studio
+wget -O hab.tar.gz "${HAB_DOWNLOAD_URL}"
+# install it in a custom location
+tar xvzf ./hab.tar.gz --strip 1 -C ${BOOTSTRAP_DIR}
+
+# so key stuff doesn't get funky
+unset SUDO_USER
+
+# create our origin key
+ cat << EOF > core.sig.key
+SIG-SEC-1
+core-20160810182414
+
+${HAB_ORIGIN_KEY}
+EOF
+
+${TRAVIS_HAB} origin key import < ./core.sig.key
+rm ./core.sig.key
+
+COMPONENTS=($COMPONENTS)
+for component in "${COMPONENTS[@]}"
+do
+  echo "Building $component"
+  ${TRAVIS_HAB} studio run HAB_CARGO_TARGET_DIR=/src/target build components/${component}
+
+  HART=$(find ./results -name *${component}*.hart)
+  ${TRAVIS_HAB} pkg install $HART
+
+  if [ -n "$HAB_AUTH_TOKEN" ]; then
+    ${TRAVIS_HAB} pkg upload -u http://app.acceptance.habitat.sh/v1/depot $HART
+  fi
+
+  # once we have built the stuio, switch over to bits built here
+  if [[ "${component}" == "studio" ]]; then
+    TRAVIS_HAB=$(find /hab/pkgs/core/hab -type f -name hab)
+  elif [[ "${component}" == "hab" ]]; then
+    RELEASE=$HART
+  fi
+done
+
+# kick off the mac unstable build
 echo "Kicking off the unstable mac build"
 var_file=/tmp/our-awesome-vars
 mac_builder=admin@74.80.245.236
@@ -34,53 +85,7 @@ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
   -i /tmp/habitat-srv-admin ${mac_builder} \
   "sudo ~/code/habitat/support/ci/deploy_mac_unstable.sh"
 
-echo "Unstable mac build has finished. Proceeding with the linux unstable build."
-
-# now do the linux unstable build
-BOOTSTRAP_DIR=/root/travis_bootstrap
-TEST_BIN_DIR=/root/hab_bins
-TRAVIS_HAB=${BOOTSTRAP_DIR}/hab
-HAB_DOWNLOAD_URL="https://api.bintray.com/content/habitat/stable/linux/x86_64/hab-%24latest-x86_64-linux.tar.gz?bt_package=hab-x86_64-linux"
-export HAB_ORIGIN=core
-
-mkdir -p ${BOOTSTRAP_DIR}
-# download a hab binary to build hab from source in a studio
-wget -O hab.tar.gz "${HAB_DOWNLOAD_URL}"
-# install it in a custom location
-tar xvzf ./hab.tar.gz --strip 1 -C ${BOOTSTRAP_DIR}
-
-# so key stuff doesn't get funky
-unset SUDO_USER
-
-# move up one level so our hab studio build is in the right place
-# as it expects to be one level up from the source dir.
-cd ..
-
-# create our origin key
-cat << EOF > core.sig.key
-SIG-SEC-1
-core-20160810182414
-
-${HAB_ORIGIN_KEY}
-EOF
-
-${TRAVIS_HAB} origin key import < ./core.sig.key
-rm ./core.sig.key
-
-# make sure we don't have an older, cached release
-mkdir -p ./release
-rm -rf ./release/*
-
-# until we publish the newer version of bintray-publish with the cli switches
-# we have to build it here
-echo "Building bintray-publish"
-${TRAVIS_HAB} studio build habitat/components/bintray-publish > /root/bintray-publish_build.log 2>&1
-echo "Building hab"
-${TRAVIS_HAB} studio build habitat/components/hab
-echo "Built new unstable version of hab"
-
 echo "Publishing hab to unstable"
 PUBLISH=$(find ./results -name core-hab-bintray*.hart)
-RELEASE=$(find ./results -name core-hab-0*.hart)
 ${TRAVIS_HAB} pkg install $PUBLISH
 ${TRAVIS_HAB} pkg exec core/hab-bintray-publish publish-hab -r unstable $RELEASE


### PR DESCRIPTION
This will build hart files for all plans we publish at release time and upload them to the acceptance depot on master merges. I had hoped to build them and not upload them for PR pushes but couldn't get the time down to an acceptable limit.

This was tested by moving the check for master merges just above the mac build step. So I was able to test travis building and uploading to acceptance. I have moved the master check back to the top of the script.

This lays some groundwork for additional refactoring to upload to production along with uploading harts to bintray production on release tag pushes.

Signed-off-by: Matt Wrock <matt@mattwrock.com>