### PR TITLE
update appveyor readme badge and reencrypt bintray api key for account switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Habitat
 
 [![Build Status](https://api.travis-ci.org/habitat-sh/habitat.svg?branch=master)](https://travis-ci.org/habitat-sh/habitat)
-[![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/ttt9p6r4q6fcipwb/branch/master?svg=true)](https://ci.appveyor.com/project/habitat/habitat/branch/master)
+[![Build status](https://ci.appveyor.com/api/projects/status/ejn8d6bkhiml16al/branch/master?svg=true)](https://ci.appveyor.com/project/chef/habitat/branch/master)
 [![Slack](http://slack.habitat.sh/badge.svg)](http://slack.habitat.sh/)
 
 Want to try Habitat? [Get started here](https://www.habitat.sh/try/).

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,9 +37,9 @@ artifacts:
 
 deploy:
 - provider: BinTray
-  username: smurawski
+  username: mwrock
   api_key:
-    secure: A+eSjC0ulsgkxVIQa3MKuE3tJQOevqELqtglbujYuLReEzzNqXUsclcWh+etQL3n
+    secure: 2DkUS4TNHW1uGjGTkNaepmkZ7lesimoVVWzM29tfGvcbBOuL7MeRjxcRd4PIY5X1
   subject: habitat
   repo: unstable
   package: hab-x86_64-windows


### PR DESCRIPTION
We migrated our appveyor account to the chef release engineering account that has a paid plan with 4 concurrent jobs. This updates the readme badge and reencrypts the bintray api key.

Signed-off-by: Matt Wrock <matt@mattwrock.com>