### PR TITLE
Fix $PATH in build to include transitive dependencies

### DIFF
--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -1596,7 +1596,7 @@ _resolve_dependencies() {
   )
   for dep in "${pkg_tdeps_resolved[@]}" "${pkg_build_tdeps_resolved[@]}"; do
     pkg_all_tdeps_resolved=(
-      $(_return_or_append_to_set "$tdep" "${pkg_all_tdeps_resolved[@]}")
+      $(_return_or_append_to_set "$dep" "${pkg_all_tdeps_resolved[@]}")
     )
   done
 


### PR DESCRIPTION
Fixes #1895 

This changes the variable name referenced inside https://github.com/habitat-sh/habitat/blob/master/components/plan-build/bin/hab-plan-build.sh#L1597-L1601 

This was tested by creating a simple plan with `core/composer` as a build dependency and `attach`ing during the build phase to verify that `git` was in the `$PATH`. 

Signed-off-by: Scott Macfarlane <macfarlane.scott@gmail.com>