### PR TITLE
Updated travis job to prep for 2phase deploy

### DIFF
--- a/support/ci/deploy_website.sh
+++ b/support/ci/deploy_website.sh
@@ -7,16 +7,9 @@ if [[ "${TRAVIS_PULL_REQUEST}" = "false" ]] && [[ "${TRAVIS_BRANCH}" = "master" 
   cd www
   make deploy
 else
-  if ! [[ "${TRAVIS_PULL_REQUEST}" = "false" ]] && [[ "${TRAVIS_BRANCH}" = "master" ]]; then
+  if [[ "${TRAVIS_PULL_REQUEST}" = "false" ]] && [[ "${TRAVIS_BRANCH}" =~ ^acceptance_deploy ]]; then
     echo "We are on a PR or against the master branch. Deploying to Acceptance."
     cd www
-    make build
-    sed -i '/^Disallow:/ s/$/ \//' build/robots.txt
-    zip -r website.zip build
-
-    curl -H "Content-Type: application/zip" \
-      -H "Authorization: Bearer $NETLIFYKEY" \
-      --data-binary "@website.zip" \
-      --url https://api.netlify.com/api/v1/sites/habitat-acceptance.netlify.com/deploys
+    make acceptance
   fi
 fi

--- a/www/Makefile
+++ b/www/Makefile
@@ -16,7 +16,17 @@ sync: build check-env
 purge_cache: check-env
 	curl -H "Fastly-Key: ${FASTLY_API_KEY}" -X POST "https://api.fastly.com/service/${FASTLY_SERVICE_KEY}/purge_all"
 
+prep:
+	sed -i '/^Disallow:/ s/$/ \//' build/robots.txt
+	zip -r website.zip build
+
 deploy: build sync purge_cache
+
+acceptance: build prep
+	curl -H "Content-Type: application/zip" \
+    -H "Authorization: Bearer $NETLIFYKEY" \
+    --data-binary "@website.zip" \
+    --url https://api.netlify.com/api/v1/sites/habitat-acceptance.netlify.com/deploys
 
 check-env:
 ifndef AWS_ACCESS_KEY_ID


### PR DESCRIPTION
Switching default behavior of site changes to deploy automatically to acceptance in preparation for 2-phase site deployment.

This should _NOT_ get merged until the mechanism for the sentinels deploying is completed. I've also stripped a majority of the logic out and moved it over into the makefile to keep in line with the way that we do the rest of the site related tasks.

Signed-off-by: Ian Henry <ihenry@chef.io>