### PR TITLE
[plan-build.sh] Fix a `last_build.env` formatting regression.

### DIFF
--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -2358,7 +2358,7 @@ _generate_artifact() {
 
 _prepare_build_outputs() {
   _pkg_sha256sum=$($_shasum_cmd $pkg_artifact | cut -d " " -f 1)
-  _pkg_blake2bsum=$($HAB_BIN pkg hash $pkg_artifact)
+  _pkg_blake2bsum=$($HAB_BIN pkg hash $pkg_artifact | cut -d " " -f 1)
   mkdir -pv "$pkg_output_path"
   cp -v "$pkg_artifact" "$pkg_output_path"/
 


### PR DESCRIPTION
This restores the format of the `./results/last_build.env` file's
`pkg_blake2bsum` line. Some speed improvements and refactoring in #1804
resulted in `hab pkg hash` to now output the checksum *and* filename
rather than simply the checksum. This fix only keeps the first token in
the command's result string--that is, the checksum only.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>