### PR TITLE
traverse full path of exported toml key path

### DIFF
--- a/components/sup/tests/fixtures/exporting_service/EXPORTS
+++ b/components/sup/tests/fixtures/exporting_service/EXPORTS
@@ -1,0 +1,2 @@
+port=network.port
+ip=address

--- a/components/sup/tests/fixtures/exporting_service/default.toml
+++ b/components/sup/tests/fixtures/exporting_service/default.toml
@@ -1,0 +1,4 @@
+address = "1.2.3.4"
+
+[network]
+port = 443


### PR DESCRIPTION
This is more fallout from the toml 3.0 update. The toml library cannot perform a `get` on a multi part key. They have to be pulled separately. This was noticed a couple weeks ago by @chefsalim at https://github.com/alexcrichton/toml-rs/issues/154. This basically ports his same fix from core config and also adds some tests around exported toml.

Signed-off-by: Matt Wrock <matt@mattwrock.com>