### PR TITLE
remove mac release after publish

### DIFF
--- a/support/ci/deploy_mac.sh
+++ b/support/ci/deploy_mac.sh
@@ -76,7 +76,7 @@ sed \
 echo "Building hab"
 cd $mac_dir
 ./mac-build.sh
-echo "Built new unstable version of hab"
+echo "Built new version of hab"
 
 # link the brew installed gnu-tar to "tar" otherwise it won't get used
 # when publish-hab.sh runs and publish-hab.sh will abort
@@ -88,3 +88,4 @@ cd ${bootstrap_dir}
 echo "Publishing hab to $BINTRAY_REPO"
 release=$(find $mac_dir/results -name core-hab-0*.hart | sort -n | tail -n 1)
 $program -r $BINTRAY_REPO $release
+rm $release


### PR DESCRIPTION
The mac builder currently keeps every built release. When it builds a stable release it grabs the last release sorted in reverse order which will always choose a dev build over a production release. We can easily avoid this problem by deleting the release after the publish. We have no need for it after publish. I have manually deleted all of the releases from the builder.

Signed-off-by: Matt Wrock <matt@mattwrock.com>