### PR TITLE
Makefile escaped Char

### DIFF
--- a/www/Makefile
+++ b/www/Makefile
@@ -17,7 +17,7 @@ purge_cache: check-env
 	curl -H "Fastly-Key: ${FASTLY_API_KEY}" -X POST "https://api.fastly.com/service/${FASTLY_SERVICE_KEY}/purge_all"
 
 prep:
-	sed -i '/^Disallow:/ s/$/ \//' build/robots.txt
+	sed -i '/^Disallow:/ s/$$/ \//' build/robots.txt
 	zip -r website.zip build
 
 deploy: build sync purge_cache


### PR DESCRIPTION
Site deploy dying when travis calls the makefile because of the `SHELL` environment set inside of a makefile. Escaped the `$` character that was getting eaten during travis build. Local tests appear to work.

Signed-off-by: Ian Henry <ihenry@chef.io>