### PR TITLE
Add configuration option to disable SSL

### DIFF
--- a/components/builder-admin-proxy/config/nginx.conf
+++ b/components/builder-admin-proxy/config/nginx.conf
@@ -60,11 +60,11 @@ http {
     listen       *:{{cfg.http.listen_port}};
     server_name  localhost;
     root /hab/svc/hab-builder-admin/static;
-
+{{#if cfg.http.enable_ssl}}
     if ($http_x_forwarded_proto = "http") {
       rewrite ^(.*)$ https://$host$1 permanent;
     }
-
+{{/if}}
     location ~* ^/favicon.ico/ {
         access_log off;
         break;

--- a/components/builder-admin-proxy/default.toml
+++ b/components/builder-admin-proxy/default.toml
@@ -10,3 +10,7 @@ sendfile = "on"
 tcp_nopush = "on"
 tcp_nodelay = "on"
 keepalive_timeout = "20s"
+
+# This disables the SSL redirect in the nginx.conf configuration.
+# DO NOT DISABLE THIS IN PRODUCTION ENVIRONMENTS!
+enable_ssl = true

--- a/components/builder-api-proxy/config/nginx.conf
+++ b/components/builder-api-proxy/config/nginx.conf
@@ -64,11 +64,11 @@ http {
     listen       *:80;
     server_name  localhost;
     root /hab/svc/hab-builder-api/static;
-
+{{#if cfg.http.enable_ssl}}
     if ($http_x_forwarded_proto = "http") {
       rewrite ^(.*)$ https://$host$1 permanent;
     }
-
+{{/if}}
     location ~* ^/favicon.ico/ {
         access_log off;
         break;

--- a/components/builder-api-proxy/default.toml
+++ b/components/builder-api-proxy/default.toml
@@ -10,3 +10,7 @@ sendfile = "on"
 tcp_nopush = "on"
 tcp_nodelay = "on"
 keepalive_timeout = "20s"
+
+# This disables the SSL redirect in the nginx.conf configuration.
+# DO NOT DISABLE THIS IN PRODUCTION ENVIRONMENTS!
+enable_ssl = true


### PR DESCRIPTION
NOTE: THIS IS FOR DEVELOPMENT PURPOSES ONLY!!

In production environments, we want to use SSL for the NGINX proxies that sit in front of the API services. However, in development it may be desireable to disable SSL for testing purposes, as we may not want to generate and manage SSL certificates.

This commit adds a new `http.enable_ssl` option for the builder-admin-proxy and builder-api-proxy configuration files. It defaults to true.

It can be disabled, for example, using the following `UNSAFE.toml` file:

```toml
[http]
enable_ssl = false
```

```sh
HAB_BUILDER_API_PROXY=$(cat UNSAFE.toml) /bin/hab start core/builder-api-proxy
```

Signed-off-by: Joshua Timberman <joshua@chef.io>