### PR TITLE
[sup] Add feature flag support to Supervisor program.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,6 +239,14 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "features"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "filetime"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -780,8 +788,10 @@ name = "habitat_sup"
 version = "0.0.0"
 dependencies = [
  "ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.21.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "features 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat_butterfly 0.1.0",
  "habitat_common 0.0.0",
@@ -1996,6 +2006,7 @@ dependencies = [
 "checksum error 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "a6e606f14042bb87cc02ef6a14db6c90ab92ed6f62d87e69377bc759fd7987cc"
 "checksum error-chain 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "318cb3c71ee4cdea69fdc9e15c173b245ed6063e1709029e8fd32525a881120f"
 "checksum fallible-iterator 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "5d48ab1bc11a086628e8cc0cc2c2dc200b884ac05c4b48fb71d6036b6999ff1d"
+"checksum features 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b64b2e49155f3b9a3bd08d9a7432c11ea5910f3a2a4ea23d68ec89eadf2e52e1"
 "checksum filetime 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "5363ab8e4139b8568a6237db5248646e5a8a2f89bd5ccb02092182b11fd3e922"
 "checksum fixedbitset 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "88c3c33fc4c00db33f5174eb98aea809c4c007db0b71351d810a7e094ea3b64d"
 "checksum fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6cc484842f1e2884faf56f529f960cc12ad8c71ce96cc7abba0a067c98fee344"

--- a/components/sup/Cargo.toml
+++ b/components/sup/Cargo.toml
@@ -17,13 +17,18 @@ name = "functional"
 
 [dependencies]
 ansi_term = "*"
+clap = { version = "*", features = [ "suggestions", "color", "unstable" ] }
 env_logger = "*"
 glob = "*"
+habitat_butterfly = { path = "../butterfly" }
+habitat_common = { path = "../common" }
+habitat_core = { path = "../core" }
+habitat_depot_client = { path = "../builder-depot-client" }
 handlebars = { version = "*", features = ["serde_type", "partial4"], default-features = false }
+iron = "*"
 lazy_static = "*"
 libc = "*"
 log = "*"
-iron = "*"
 notify = "*"
 persistent = "*"
 prometheus = "*"
@@ -37,22 +42,6 @@ tempdir = "*"
 time = "*"
 toml = { version = "*", features = ["serde"], default-features = false, git = "https://github.com/alexcrichton/toml-rs" , rev = "d39c3f7b3ec95cb3cc1e579d7d747206c66aab74"}
 url = "*"
-
-[dependencies.habitat_core]
-path = "../core"
-
-[dependencies.habitat_common]
-path = "../common"
-
-[dependencies.habitat_depot_client]
-path = "../builder-depot-client"
-
-[dependencies.habitat_butterfly]
-path = "../butterfly"
-
-[dependencies.clap]
-version = "*"
-features = [ "suggestions", "color", "unstable" ]
 
 [dev-dependencies]
 hyper = "*"

--- a/components/sup/Cargo.toml
+++ b/components/sup/Cargo.toml
@@ -17,8 +17,10 @@ name = "functional"
 
 [dependencies]
 ansi_term = "*"
+bitflags = "*"
 clap = { version = "*", features = [ "suggestions", "color", "unstable" ] }
 env_logger = "*"
+features = "*"
 glob = "*"
 habitat_butterfly = { path = "../butterfly" }
 habitat_common = { path = "../common" }

--- a/components/sup/src/lib.rs
+++ b/components/sup/src/lib.rs
@@ -39,35 +39,35 @@
 //! * [The Habitat Command Line Reference](command)
 //! * [The Habitat Supervisor Sidecar; http interface to promises](sidecar)
 
+extern crate ansi_term;
+extern crate glob;
 extern crate habitat_butterfly as butterfly;
-extern crate habitat_core as hcore;
 extern crate habitat_common as common;
+extern crate habitat_core as hcore;
 extern crate habitat_depot_client as depot_client;
 extern crate handlebars;
+extern crate iron;
+#[macro_use]
+extern crate lazy_static;
+extern crate libc;
 #[macro_use]
 extern crate log;
-extern crate tempdir;
-extern crate ansi_term;
-extern crate regex;
-extern crate libc;
-extern crate url;
-extern crate iron;
-extern crate glob;
 extern crate notify;
+extern crate persistent;
+#[macro_use]
+extern crate prometheus;
 extern crate rand;
+extern crate regex;
 #[macro_use]
 extern crate router;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 extern crate serde_json;
+extern crate tempdir;
 extern crate time;
 extern crate toml;
-extern crate persistent;
-#[macro_use]
-extern crate prometheus;
-#[macro_use]
-extern crate lazy_static;
+extern crate url;
 
 #[macro_export]
 /// Creates a new SupError, embedding the current file name, line number, column, and module path.

--- a/components/sup/src/lib.rs
+++ b/components/sup/src/lib.rs
@@ -40,6 +40,10 @@
 //! * [The Habitat Supervisor Sidecar; http interface to promises](sidecar)
 
 extern crate ansi_term;
+#[macro_use]
+extern crate bitflags;
+#[macro_use]
+extern crate features;
 extern crate glob;
 extern crate habitat_butterfly as butterfly;
 extern crate habitat_common as common;
@@ -290,6 +294,12 @@ lazy_static!{
         let arg0 = env::args().next().map(|p| PathBuf::from(p));
         arg0.as_ref().and_then(|p| p.file_stem()).and_then(|p| p.to_str()).unwrap().to_string()
     };
+}
+
+features! {
+    pub mod feat {
+        const List = 0b00000001
+    }
 }
 
 const PRODUCT: &'static str = "hab-sup";

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -16,7 +16,6 @@ extern crate habitat_common as common;
 extern crate habitat_core as hcore;
 #[macro_use]
 extern crate habitat_sup as sup;
-#[macro_use]
 extern crate log;
 extern crate env_logger;
 extern crate ansi_term;


### PR DESCRIPTION
This change adds the ability for us to feature flag parts of the
Supervisor behavior at runtime (as opposed to compile time). The
implementation rides on top of a small crate (`features`) and a
consistently named environment variable. Future features may revist the
environment variable approach or add support from a config file, but
this first pass is quick, effecient and well supported in shell scripts,
init systems such as systemd units, 12-factor apps, etc.

A developer wishing to add a new feature flag would add a `const` to the
`features!` macro in `components/sup/src/lib.rs` (let's use the example
`BitTorrent`) like so:

```rust
features! {
    pub mod feat {
        const List = 0b00000001,
        const BitTorrent = 0b00000010
    }
}
```

then, in `components/sup/src/main.rs`, add an entry to the `features`
vec in the `enable_features_from_env()` function:

```rust
fn enable_features_from_env() {
    let features = vec![(feat::List, "LIST"), (feat::BitTorrent, "BIT_TORRENT")];
}
```

This automatically provides:

* A module-level function check of `feat::is_enabled(feat::BitTorrent)`
callable from anywhere in the codebase
* An environment variable, in this case `HAB_FEAT_BIT_TORRENT`, which if
set to either `"true"` or `"TRUE"` will enable the feature toggle before
CLI parsing takes place.

A user who wishes to know the currently available feature toggles can
run `hab-sup` with the environment variable `HAB_FEAT_LIST=true`.

If this pattern bears fruit it can be expanded to other programs, but
for the moment this may be useful when delivering the first user-facing
changes in supporting a multi-service capable supervisor.

---

There are also a few chore/cleanup commits with messages that describe the why :wink: 