### PR TITLE
[sup] Activate the MVP multi-service Supervisor! (behind feature flag)

### DIFF
--- a/components/sup/src/command/start.rs
+++ b/components/sup/src/command/start.rs
@@ -47,6 +47,7 @@
 //! See the [documentation on topologies](../topology) for a deeper discussion of how they function.
 //!
 
+use std;
 use std::path::Path;
 
 use ansi_term::Colour::Yellow;
@@ -56,12 +57,16 @@ use hcore::fs::{self, FS_ROOT_PATH};
 
 use {PRODUCT, VERSION};
 use error::{Error, Result};
+use feat;
 use manager::{Manager, ManagerConfig};
 use manager::ServiceSpec;
 
 static LOGKEY: &'static str = "CS";
 
-pub fn package(cfg: ManagerConfig, spec: ServiceSpec, local_artifact: Option<&str>) -> Result<()> {
+pub fn package(cfg: ManagerConfig,
+               service_spec: Option<ServiceSpec>,
+               local_artifact: Option<&str>)
+               -> Result<()> {
     let mut ui = UI::default();
     if !fs::am_i_root() {
         ui.warn("Running the Habitat Supervisor requires root or administrator privileges. \
@@ -71,20 +76,43 @@ pub fn package(cfg: ManagerConfig, spec: ServiceSpec, local_artifact: Option<&st
         return Err(sup_error!(Error::RootRequired));
     }
 
-    if let Some(artifact) = local_artifact {
-        outputln!("Installing local artifact {}",
-                  Yellow.bold().paint(artifact));
-        common::command::package::install::start(&mut ui,
-                                                 &spec.depot_url,
-                                                 artifact,
-                                                 PRODUCT,
-                                                 VERSION,
-                                                 Path::new(&*FS_ROOT_PATH),
-                                                 &fs::cache_artifact_path(None),
-                                                 false)?;
+    // TODO fn: once we remove the `Multi` feature flag a refactoring of this function will clean
+    // things up substantially. If it looks slightly awkward, this was done with an eye to the end
+    // state, not this intermediate state. Cheers!
+
+    if let Some(spec) = service_spec.as_ref() {
+        if let Some(artifact) = local_artifact {
+            outputln!("Installing local artifact {}",
+                      Yellow.bold().paint(artifact));
+            common::command::package::install::start(&mut ui,
+                                                     &spec.depot_url,
+                                                     artifact,
+                                                     PRODUCT,
+                                                     VERSION,
+                                                     Path::new(&*FS_ROOT_PATH),
+                                                     &fs::cache_artifact_path(None),
+                                                     false)?;
+        }
     }
 
-    let mut manager = Manager::new(cfg)?;
-    manager.add_service(spec)?;
-    manager.run()
+    if feat::is_enabled(feat::Multi) {
+        if let Some(spec) = service_spec {
+            // If we're starting with a package, then we assume that any prior specs are out of
+            // date.  TODO fn: there are some assumptions to be tested here...
+            let specs_path = Manager::specs_path_for(&cfg);
+            if specs_path.exists() && specs_path.is_dir() {
+                std::fs::remove_dir_all(specs_path)?;
+            }
+            Manager::save_spec_for(&cfg, spec)?;
+        }
+
+        let mut manager = Manager::load(cfg)?;
+        manager.run()
+    } else {
+        let mut manager = Manager::load(cfg)?;
+        if let Some(spec) = service_spec {
+            manager.add_service(spec)?;
+        }
+        manager.run()
+    }
 }

--- a/components/sup/src/error.rs
+++ b/components/sup/src/error.rs
@@ -103,6 +103,7 @@ impl SupError {
 pub enum Error {
     BadDataFile(PathBuf, io::Error),
     BadDataPath(PathBuf, io::Error),
+    BadSpecsPath(PathBuf, io::Error),
     ButterflyError(butterfly::error::Error),
     CommandNotImplemented,
     DbInvalidPath,
@@ -166,6 +167,11 @@ impl fmt::Display for SupError {
             }
             Error::BadDataPath(ref path, ref err) => {
                 format!("Unable to read or write to data directory, {}, {}",
+                        path.display(),
+                        err)
+            }
+            Error::BadSpecsPath(ref path, ref err) => {
+                format!("Unable to create the specs directory '{}' ({})",
                         path.display(),
                         err)
             }
@@ -287,6 +293,7 @@ impl error::Error for SupError {
         match self.err {
             Error::BadDataFile(_, _) => "Unable to read or write to a data file",
             Error::BadDataPath(_, _) => "Unable to read or write to data directory",
+            Error::BadSpecsPath(_, _) => "Unable to create the specs directory",
             Error::ButterflyError(ref err) => err.description(),
             Error::ExecCommandNotFound(_) => "Exec command was not found on filesystem or in PATH",
             Error::TemplateFileError(ref err) => err.description(),

--- a/components/sup/src/lib.rs
+++ b/components/sup/src/lib.rs
@@ -298,7 +298,8 @@ lazy_static!{
 
 features! {
     pub mod feat {
-        const List = 0b00000001
+        const List = 0b00000001,
+        const Multi = 0b00000010
     }
 }
 

--- a/components/sup/src/manager/service/spec.rs
+++ b/components/sup/src/manager/service/spec.rs
@@ -32,6 +32,7 @@ use error::{Error, Result, SupError};
 
 static LOGKEY: &'static str = "SS";
 static DEFAULT_GROUP: &'static str = "default";
+pub const SPEC_FILE_EXT: &'static str = "spec.toml";
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[serde(default)]
@@ -83,6 +84,9 @@ impl ServiceSpec {
     }
 
     pub fn to_file<P: AsRef<Path>>(&self, path: P) -> Result<()> {
+        debug!("Writing service spec to '{}': {:?}",
+               path.as_ref().display(),
+               &self);
         let dst_path = path.as_ref()
             .parent()
             .ok_or(sup_error!(Error::ServiceSpecFileWrite(path.as_ref().display().to_string(),
@@ -122,6 +126,10 @@ impl ServiceSpec {
                      })?;
 
         Ok(())
+    }
+
+    pub fn file_name(&self) -> String {
+        format!("{}.{}", &self.ident.name, SPEC_FILE_EXT)
     }
 
     pub fn validate(&self, package: &PackageInstall) -> Result<()> {
@@ -505,6 +513,13 @@ mod test {
             }
             Ok(_) => panic!("Service spec file should not have been written"),
         }
+    }
+
+    #[test]
+    fn service_spec_file_name() {
+        let spec = ServiceSpec::default_for(PackageIdent::from_str("origin/hoopa/1.2.3").unwrap());
+
+        assert_eq!(String::from("hoopa.spec.toml"), spec.file_name());
     }
 
     #[test]


### PR DESCRIPTION
Hey there, how are ya? Are you interested in running more than one
service with a single Habitat Supervisor? Great! Let's talk.

First off, this is the first integration of several moving parts, and as
such is known to be not fully capable yet. But that's cool, because you
won't get the new behavior unless you start the Supervisor with an
environment variable to enable the `Multi` feature. Setting:

    HAB_FEAT_MULTI=true

will start the Supervisor with an extra component (internally called the
`SpecWatcher`) which will monitor a directory of service specification
TOML files, called Service Specs (internally referred to as a
`ServiceSpec` or a "spec" for short) following a strategy similar to
runit or daemontools.

The exiting behavior of `hab-sup start` is preserved except in one
circumstance described in the `Breaking Behavior` section below.

Quick TL;DR
-----------

![gif-keyboard-9576611079189079384](https://cloud.githubusercontent.com/assets/261548/24170390/62a8736c-0e46-11e7-987d-9564f72baa63.gif)

All of the file formats, directories, and start modes shown here are
explained below, so if this feels a touch magical...it's because you
haven't learned about it yet!

To run a single Supervisor that is running `core/redis`, `core/nginx`,
and `core/postgresql` (admittedly a bit contrived) you'll create 3
Service Specs TOML files in the default spec watch directory and then
start the Supervisor in its default mode. Assuming you've compiled the
Supervisor yourself locally:

```
sudo mkdir -p /hab/sup/default/specs
echo 'ident = "core/redis"' | sudo tee /hab/sup/default/specs/redis.spec.toml
echo 'ident = "core/nginx"' | sudo tee /hab/sup/default/specs/nginx.spec.toml
echo 'ident = "core/postgresql"' | sudo tee /hab/sup/default/specs/postgresql.spec.toml

sudo -E env HAB_FEAT_MULTI=true ./target/debug/hab-sup start
```

To kill the foregrounded Supervisor (as always), you can type `Ctrl+c`.
Then to start the Supervisor again with all previous services, the
same Supervisor identifier, etc.:

```
sudo -E env HAB_FEAT_MULTI=true ./target/debug/hab-sup start
```

For more details on the above example, read on!

Breaking Behavior
-----------------

First a note about potentially breaking behvaior. This change introduces
one breaking change wthat ill impact existing Habitat users who run more
than one Supervisor per host/VM/container/etc. More information is
provided in the `Supervisor State Directory` section below.

This only applies when running more than one Supervisor--you know this
because you will have had to explicitly set non-default values for the
`--listen-gossip` and `--listen-http` options. There are 2 strategies to
choose from:

1. Eliminate the multiple Supervisors launching via SystemD, init, etc.,
write a corresponding Service Spec TOML file per service (described
below in more detail), and launch a single Supervisor with `hab start`
(note the lack of package identifiers, topology strategies, etc.)
2. Alternatively, for each exisiting Supervisor, add an
`--override-name` option to the command with some unique value. This
will allow the Supervisors to write their own state information to
distinctly different directories.  Once stable, you are highly
encouraged to migrate to the single Supervisor strategy as explained
directly above.

If you have any questions or concerns, feel free to contact the Habitat
team in Slack (http://slack.habitat.sh/), on our forums
(https://forums.habitat.sh/), or by email (humans@habitat.sh).

Service Spec TOML Files
-----------------------

![gif-keyboard-18288171251351446621](https://cloud.githubusercontent.com/assets/261548/24170428/7b47ac26-0e46-11e7-9c96-ea45cf20ea90.gif)

While a near future workflow with the Supervisor shouldn't require users
to immediately understand Service Spec files (hereafter referred to as
specs), it might be instructional to those who wish to seed the
Supervisor with multiple service definitions before it boots to
understand the file format.

The file a flat key/value structure with no nesting and where each key
corresponds to a service-related option or flag currently existing on
the `hab-sup start` subcommand. Here is the current help output for
`hab-sup start`:

```
hab-sup-start
Start a Habitat-supervised service from a package or artifact

USAGE:
    hab-sup start [FLAGS] [OPTIONS] <PKG_IDENT_OR_ARTIFACT>

FLAGS:
        --no-color          Turn ANSI color off
    -I, --permanent-peer    If this service is a permanent peer
    -v                      Verbose output; shows line numbers
    -h, --help              Prints help information

OPTIONS:
        --bind <BIND>...                   One or more service groups to bind to a configuration
        --config-from <CONFIG_DIR>         Use package config from this path, rather than the package itself
    -u, --url <DEPOT_URL>                  Use a specific Depot URL (ex: http://depot.example.com/v1/depot)
        --group <GROUP>                    The service group; shared config and topology [default: default].
        --listen-gossip <LISTEN_GOSSIP>    The listen address for the gossip system [default: 0.0.0.0:9638]
        --listen-http <LISTEN_HTTP>        The listen address for the HTTP gateway [default: 0.0.0.0:9631]
        --org <ORGANIZATION>               The organization that a service is part of
        --peer <PEER>...                   The listen address of an initial peer (IP[:PORT])
    -r, --ring <RING>                      Ring key name
    -s, --strategy <STRATEGY>              The update strategy; [default: none] [values: none, at-once, rolling]
    -t, --topology <TOPOLOGY>              Service topology; [default: none]

ARGS:
    <PKG_IDENT_OR_ARTIFACT>    A Habitat package identifier (ex: acme/redis) or filepath to a Habitat Artifact (ex: /home/acme-redis-3.0.7-21120102031201-x86_64-linux.hart)
```

In particular, here is an invocation of the Supervisor with all service-related options spelled out explicitly:

```
hab-sup start \
  origin/name/1.2.3/20170223130020 \  # required
  --group jobs \                      # default is: "default"
  --org acmecorp \                    # default is: <unset> (optional value)
  --url http://example.com/depot \    # default is: "https://willem.habitat.sh/v1/depot"
  --topology leader \                 # default is: "none"
  --strategy at-once \                # default is: "none"
  --bind cache:redis.cache@acmecorp \ # default is <unset> (option values)
  --bind db:postgres.app@acmecorp
```

A corresponding spec file, named `name.spec.toml` would be:

```
ident = "origin/name/1.2.3/20170223130020"
group = "jobs"
organization = "acmecorp"
depot_url = "http://example.com/depot"
topology = "leader"
update_strategy = "rolling"
binds = ["cache:redis.cache@acmecorp", "db:postgres.app@acmecorp"]
```

There is only *1* required key/value pair in a spec file:

```
ident = "origin/name"
```

As with the `hab-sup start` command, all other key/value pairs have the
same defaults and are optional.

Supervisor Start Modes
----------------------

There are 2 slightly different behaviors when starting the Supervisor
via `hab-sup start` (or `hab start`). Previously, a Package Identifier
or local Package Artifact was a required argument, however now this is
optional. See the following sections for details:

 ### Specifying No Identifiers Or Artifacts

![gif-keyboard-14610798927384970348](https://cloud.githubusercontent.com/assets/261548/24170489/a12da4a4-0e46-11e7-8722-6b62ecae44f4.gif)

In this mode on a brand new system, the Supervisor starts with no
services to run. Currently the only way to add services to the
Supervisor is by adding a spec file in the specs watch directory
(described below). Future features will add user tooling to automate the
creation and removal of these files, but interacting directly with these
spec files is still useful when working with configuration management
tools such as Chef or in container preparation workflows like creating a
Docker container.

For init systems such as SystemD, runit, etc. the new recommended
command to start the Supervisor would be:

    hab start

that is, without specifying any Package Identifiers. In this invocation,
the Supervisor will check its specs watch directory for specs to load
and start all related services. Restarting the entire Supervisor (and
therefore also all supervised services) would mean killing the `hab-sup
start` process and re-running `hab start`. All previous Supervisor state
and desired service specifications will be used when it boots next.

 ### Specifying A Package Identifier

![gif-keyboard-11126045281174846351](https://cloud.githubusercontent.com/assets/261548/24170588/02f75a2c-0e47-11e7-85bb-6f5dfd3dee35.gif)

This is intended for one-off Supervisor launches such as in testing,
local development or simple deployments such as in containers, etc. A
spec file for the corresponding Package Identifier (and related options
and flags) will be created in the specs watch directory (described
below) and the Supervisor will start. Think of this as a convenience
"short cut" of 2 activities:

1. Add a service to be supervised
2. Start the Supervisor

If you intend to start more than one service, you are highly suggested
to start the supervisor with *no* Package Identifiers, as described
above. More user tooling will be added in the near future to make the
activity of adding (and removing) additional services easier.

 ### Specifying A Local Package Artifact

![gif-keyboard-13041148434355848888](https://cloud.githubusercontent.com/assets/261548/24170619/12dc48ee-0e47-11e7-978e-0507991a801c.gif)

This is intended primarily for local development and testing and is not
recommended for use in production--you are highly encouraged to use the
*no* Package Identifiers scenario described above, or secondarily the
Package Identifier scenario described above.

This follows the same behavior as above, with one major distinction: the
Supervisor will install the local Package Artifact before continuing and
lock the Package Identifier to the fully qualified value extracted from
the artifact. For example a Package Artifact
`"origin-name-1.2.3-20170223130020-x86_64-linux.hart"` would produce a
spec file containing the line:

    ident = "origin/name/1.2.3/20170223130020"

That would mean, in effect, there is no update strategy (there is only
one possible package that satisfies a fully qualified Package
Identifier) and any `update_strategy` value would be null-and-void.

Supervisor State Directory
--------------------------

![gif-keyboard-12629087991134924323](https://cloud.githubusercontent.com/assets/261548/24170707/612fd83a-0e47-11e7-91ca-9a8ef6fdc254.gif)

When the Supervisor starts, it determines a directory for itself to
persist some Supervisor-specific data and state. By default, this
directory is:

     /hab/sup/default

The Habitat team would like to note that once the multi-service support
in the Supervisor is stable, we highly recommend running *one*
Supervisor per host/VM/container/etc. The setup is much simpler, the
network traffic is far less, and most improvement and innovation will
assume this mode of operation. There may be users and use cases for
running more than one Supervisor and for these scenarios you can supply
an `--override-name` option to the Supervisor when starting. Currently,
the only use for this value is in determining the state directory of the
Supervisor. For example, starting the Supervisor with
`hab-sup start --override-name secondary` would use a Supervisor state
directory of `/hab/sup/secondary`.

Again, it is our assumption that most Habitat users will use one
Supervisor per host/VM/container/etc. Our hypothesis follows that this
shouldn't impact many users and the vast majority of users (who even
need to know about this path), would use `/hab/sup/default/*` without
thinking about it.

Service Specs Watch Directory
-----------------------------

![gif-keyboard-6893989295495612039](https://cloud.githubusercontent.com/assets/261548/24170721/6e513f2c-0e47-11e7-82af-5527ba9c3d31.gif)

Given the determination of the Supervisor state directory above, the
Supervisor will create a child directory called `specs/` (by default
`/hab/sup/default/specs`) which will be monitored for spec file changes
during the running of the Supervisor.

During the booting process, the Supervisor will use any spec files found
in the specs directory to populate itself and start the corresponding
services.

---

There are several know issues and while things aren't perfect, this is more than an initial start. Celebrate!

![gif-keyboard-5617735478235085312](https://cloud.githubusercontent.com/assets/261548/24170803/a89b8444-0e47-11e7-96eb-c93d0530c0de.gif)
