### PR TITLE
Revert "Remove confusing install step from tutorial."

### DIFF
--- a/www/source/tutorials/getting-started/overview.html.md
+++ b/www/source/tutorials/getting-started/overview.html.md
@@ -13,6 +13,7 @@ As a first step in understanding Habitat, this tutorial will show you how to cre
 
 Before starting this tutorial, you need to have the following:
 
+*   The `hab` command-line interface tool. See [Get Habitat](/docs/get-habitat) if you don't already have this installed on your machine.
 *   An active GitHub account is recommended. If you don't already have an account, [sign up](https://github.com/) for one now. Note: This is required to upload and share your packages with others in the Habitat community.
 *   Your favorite text editor.
 *   If you are running Mac OS X on your host machine, then you need [Docker for Mac](https://www.docker.com/products/docker#/mac) installed.


### PR DESCRIPTION
Reverts habitat-sh/habitat#1892

While the original copy is confusing, after removing it I heard from someone else new to habitat that it was confusing in a different way because now the tutorial doesn't link to the download page at all. Rather than attempt to fix things again I'll just admit I have no business writing docs and walk away. :)