### PR TITLE
[sup] Set correct `PATH` for all service child processes.

### DIFF
--- a/components/sup/src/manager/service/config.rs
+++ b/components/sup/src/manager/service/config.rs
@@ -703,6 +703,10 @@ mod test {
         toml::from_str(content).expect(&format!("Content should parse as TOML: {}", content))
     }
 
+    fn runtime_config() -> RuntimeConfig {
+        RuntimeConfig::new("hab".to_string(), "hab".to_string(), HashMap::new())
+    }
+
     pub fn root() -> PathBuf {
         PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests")
     }
@@ -730,7 +734,7 @@ mod test {
     fn to_toml_hab() {
         let pkg = gen_pkg();
         let sc = ServiceConfig::new(&pkg,
-                                    &RuntimeConfig::new("hab".to_string(), "hab".to_string()),
+                                    &runtime_config(),
                                     PathBuf::from("/hab/pkgs/neurosis/redis/2000/20160222201258"),
                                     Vec::new(),
                                     &GossipListenAddr::default(),
@@ -752,7 +756,7 @@ mod test {
     fn to_toml_pkg() {
         let pkg = gen_pkg();
         let sc = ServiceConfig::new(&pkg,
-                                    &RuntimeConfig::new("hab".to_string(), "hab".to_string()),
+                                    &runtime_config(),
                                     PathBuf::from("/hab/pkgs/neurosis/redis/2000/20160222201258"),
                                     Vec::new(),
                                     &GossipListenAddr::default(),
@@ -774,7 +778,7 @@ mod test {
     fn to_toml_sys() {
         let pkg = gen_pkg();
         let sc = ServiceConfig::new(&pkg,
-                                    &RuntimeConfig::new("hab".to_string(), "hab".to_string()),
+                                    &runtime_config(),
                                     PathBuf::from("/hab/pkgs/neurosis/redis/2000/20160222201258"),
                                     Vec::new(),
                                     &GossipListenAddr::default(),
@@ -797,7 +801,7 @@ mod test {
     fn to_toml_exported_cfg() {
         let pkg = gen_exporting_pkg();
         let sc = ServiceConfig::new(&pkg,
-                                    &RuntimeConfig::new("hab".to_string(), "hab".to_string()),
+                                    &runtime_config(),
                                     fixtures().join("exporting_service"),
                                     Vec::new(),
                                     &GossipListenAddr::default(),
@@ -811,7 +815,7 @@ mod test {
     fn to_toml_exported_table_cfg() {
         let pkg = gen_exporting_pkg();
         let sc = ServiceConfig::new(&pkg,
-                                    &RuntimeConfig::new("hab".to_string(), "hab".to_string()),
+                                    &runtime_config(),
                                     fixtures().join("exporting_service"),
                                     Vec::new(),
                                     &GossipListenAddr::default(),


### PR DESCRIPTION
This change finally addresses a known issue in the supervisor which
manifested itself when multiple services were being supervised. In the
code, an environment variables `HashMap` is being created in the
`RuntimeConfig` which a `Service` uses to create its `Supervisor` and
uses when it runs hooks.

For users, they should see that no concurrently running service should
impact the `PATH` value for any given service.

This change can be verified with the following:

```
 # Setup
> sudo mkdir -p /hab/sup/default/specs
> echo 'ident = "core/redis"' | sudo tee /hab/sup/default/specs/redis.spec.toml
core/redis
> echo 'ident = "core/nginx"' | sudo tee /hab/sup/default/specs/nginx.spec.toml
core/nginx
> echo 'ident = "core/postgresql"' | sudo tee /hab/sup/default/specs/postgresql.spec.toml
core/postgresql

 # Inspect PATH-setting debugging for each service
> sudo -E env HAB_FEAT_MULTI=true RUST_LOG=habitat_sup::supervisor PATH=/devops ./target/debug/hab-sup start | grep 'Setting PATH'
DEBUG:habitat_sup::supervisor: Setting PATH for redis.default to PATH='/hab/pkgs/core/redis/3.2.4/20170215222111/bin:/hab/pkgs/core/glibc/2.22/20160612063629/bin:/hab/pkgs/core/busybox-static/1.24.2/20161214032531/bin:/devops'
DEBUG:habitat_sup::supervisor: Creating PID file for child /hab/svc/redis/PID -> 87236
DEBUG:habitat_sup::supervisor: Setting PATH for postgresql.default to PATH='/hab/pkgs/core/postgresql/9.6.1/20170215221136/bin:/hab/pkgs/core/bash/4.3.42/20161213234235/bin:/hab/pkgs/core/glibc/2.22/20160612063629/bin:/hab/pkgs/core/openssl/1.0.2j/20161214012334/bin:/hab/pkgs/core/perl/5.22.1/20161213235304/bin:/hab/pkgs/core/libossp-uuid/1.6.2/20161214075157/bin:/hab/pkgs/core/acl/2.2.52/20161208223311/bin:/hab/pkgs/core/attr/2.4.47/20161208223238/bin:/hab/pkgs/core/bzip2/1.0.6/20161208225359/bin:/hab/pkgs/core/coreutils/8.25/20161208223423/bin:/hab/pkgs/core/db/5.3.28/20161213234940/bin:/hab/pkgs/core/gdbm/1.11/20161208225425/bin:/hab/pkgs/core/less/481/20161213235230/bin:/hab/pkgs/core/libcap/2.24/20161208223353/bin:/hab/pkgs/core/ncurses/6.0/20161213233720/bin:/hab/pkgs/core/pcre/8.38/20161213233903/bin:/hab/pkgs/core/busybox-static/1.24.2/20161214032531/bin:/devops'
DEBUG:habitat_sup::supervisor: Creating PID file for child /hab/svc/postgresql/PID -> 87246
DEBUG:habitat_sup::supervisor: Setting PATH for nginx.default to PATH='/hab/pkgs/core/nginx/1.11.10/20170215235242/sbin:/hab/pkgs/core/glibc/2.22/20160612063629/bin:/hab/pkgs/core/ncurses/6.0/20161213233720/bin:/hab/pkgs/core/bzip2/1.0.6/20161208225359/bin:/hab/pkgs/core/openssl/1.0.2j/20161214012334/bin:/hab/pkgs/core/pcre/8.38/20161213233903/bin:/hab/pkgs/core/busybox-static/1.24.2/20161214032531/bin:/devops'
DEBUG:habitat_sup::supervisor: Creating PID file for child /hab/svc/nginx/PID -> 87255
```

References #1976

![gif-keyboard-18046381999709756788](https://cloud.githubusercontent.com/assets/261548/24233168/13bc13ec-0f56-11e7-8bca-0b3ad66917be.gif)
