### PR TITLE
Decouple http_gateway module from Manager's shared state

### DIFF
--- a/components/sup/src/fs.rs
+++ b/components/sup/src/fs.rs
@@ -26,7 +26,12 @@ pub fn svc_path<T: AsRef<Path>>(service_name: T) -> PathBuf {
     SVC_ROOT.join(service_name)
 }
 
-/// Returns the path to a given service's configuration.
+/// Returns the path to the config.toml file for a given service.
+pub fn svc_config_file<T: AsRef<Path>>(service_name: T) -> PathBuf {
+    svc_path(service_name).join("config.toml")
+}
+
+/// Returns the path to the configuration directory for a given service.
 pub fn svc_config_path<T: AsRef<Path>>(service_name: T) -> PathBuf {
     svc_path(service_name).join("config")
 }

--- a/components/sup/src/manager/service/config.rs
+++ b/components/sup/src/manager/service/config.rs
@@ -170,7 +170,7 @@ impl ServiceConfig {
     pub fn write(&mut self) -> Result<bool> {
         let final_toml = try!(self.to_toml());
         {
-            let mut last_toml = try!(File::create(self.pkg.svc_path.join("config.toml")));
+            let mut last_toml = try!(File::create(fs::svc_config_file(&self.pkg.name)));
             try!(last_toml.write_all(&try!(toml::to_vec(&final_toml))));
         }
         let mut template = Template::new();

--- a/components/sup/src/manager/service/health.rs
+++ b/components/sup/src/manager/service/health.rs
@@ -14,7 +14,7 @@
 
 use std::fmt;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize)]
 pub enum HealthCheck {
     Ok,
     Warning,
@@ -25,6 +25,18 @@ pub enum HealthCheck {
 impl Default for HealthCheck {
     fn default() -> HealthCheck {
         HealthCheck::Unknown
+    }
+}
+
+impl From<i8> for HealthCheck {
+    fn from(value: i8) -> HealthCheck {
+        match value {
+            0 => HealthCheck::Ok,
+            1 => HealthCheck::Warning,
+            2 => HealthCheck::Critical,
+            3 => HealthCheck::Unknown,
+            _ => HealthCheck::Unknown,
+        }
     }
 }
 

--- a/test/fixtures/database-server/hooks/health_check
+++ b/test/fixtures/database-server/hooks/health_check
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+echo "OK"
+exit 0


### PR DESCRIPTION
This commit removes the reliance of obtaining read locks on
the Manager's shared state in the http-gateway to communicate
supervisor state to a consumer. Essentially, the http-gateway
can no longer be used to interupt program flow.

* Removes `manager::State` struct and replaces it with
  `manager::FsCfg`. This is used to communicate file system config
  to the http-gateway and service threads. This struct is write once
  on boot and read only.
* Census, Butterfly, Service List, and last run health check results
  are now all cached to disk in an atomic way so the http-gateway
  can consume them.

Associated with #1973

![gif-keyboard-17720029054697840210](https://cloud.githubusercontent.com/assets/54036/24271786/b9d2d3d4-0fd7-11e7-9f57-ce1c0c692444.gif)
