### PR TITLE
[sup] Move location of adding/removing services in `Manager` tick loop.

### DIFF
--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -236,14 +236,14 @@ impl Manager {
                 outputln!("Habitat thanks you - shutting down!");
                 return Ok(());
             }
+            if feat::is_enabled(feat::Multi) {
+                self.update_running_services_from_watcher()?;
+            }
             self.check_for_updated_packages(&mut last_census_update);
             self.restart_elections();
             let (census_updated, ncu) = self.build_census(&last_census_update);
             if census_updated {
                 last_census_update = ncu;
-            }
-            if feat::is_enabled(feat::Multi) {
-                self.update_running_services_from_watcher()?;
             }
             for service in self.state
                     .services


### PR DESCRIPTION
This change enables the Supervisor to pick up new spec files in the spec
watch directory once the Supervisor is running.

This resolves a service starting issue once the Supervisor is
running. Relocating when we look for new services to add or old services
to remove allows `build_census()` to run before delegating to each
service's internal tick loop.

It remains to be seen if this is the correct location to remove services
(on first glance, I think so), but this will become clearer with more
exercise and testing.

References #1976

![gif-keyboard-17902720377295782230](https://cloud.githubusercontent.com/assets/261548/24273024/c552884a-0fe5-11e7-8381-bb12f0dbcae6.gif)
