### PR TITLE
Add member data to butterfly http gateway output

### DIFF
--- a/components/butterfly/src/server/mod.rs
+++ b/components/butterfly/src/server/mod.rs
@@ -822,7 +822,8 @@ impl Serialize for Server {
     fn serialize<S>(&self, serializer: S) -> result::Result<S::Ok, S::Error>
         where S: Serializer
     {
-        let mut strukt = try!(serializer.serialize_struct("butterfly", 5));
+        let mut strukt = try!(serializer.serialize_struct("butterfly", 6));
+        try!(strukt.serialize_field("member", &self.member_list));
         try!(strukt.serialize_field("service", &self.service_store));
         try!(strukt.serialize_field("service_config", &self.service_config_store));
         try!(strukt.serialize_field("service_file", &self.service_file_store));


### PR DESCRIPTION
This commit adds membership data to butterfly's http gateway output.
I needed this to effectively debug #1994, and it's pretty handy to have
around in general.

![gif-keyboard-15713325824907376455](https://cloud.githubusercontent.com/assets/4304/24323745/d25ff920-1137-11e7-92ac-d1aee79d80f6.gif)

Signed-off-by: Adam Jacob <adam@chef.io>