### PR TITLE
fix intermittent errors when renaming dat file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -551,9 +551,9 @@ dependencies = [
 name = "habitat_builder_scheduler"
 version = "0.0.0"
 dependencies = [
+ "builder_core 0.0.0",
  "clap 2.22.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "builder_core 0.0.0",
  "habitat_builder_db 0.0.0",
  "habitat_builder_protocol 0.0.0",
  "habitat_core 0.0.0",
@@ -622,6 +622,7 @@ dependencies = [
  "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.9.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 0.9.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "threadpool 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.3.0 (git+https://github.com/alexcrichton/toml-rs?rev=d39c3f7b3ec95cb3cc1e579d7d747206c66aab74)",

--- a/components/butterfly/Cargo.toml
+++ b/components/butterfly/Cargo.toml
@@ -24,6 +24,7 @@ protobuf = "*"
 rand = "*"
 serde = "*"
 serde_derive = "*"
+tempfile = "*"
 time = "*"
 threadpool = "*"
 toml = { version = "*", features = ["serde"], default-features = false, git = "https://github.com/alexcrichton/toml-rs" , rev = "d39c3f7b3ec95cb3cc1e579d7d747206c66aab74"}

--- a/components/butterfly/src/lib.rs
+++ b/components/butterfly/src/lib.rs
@@ -51,6 +51,7 @@ extern crate rand;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;
+extern crate tempfile;
 extern crate time;
 extern crate toml;
 extern crate uuid;


### PR DESCRIPTION
When starting a supervisor, the dat file rename occasionally throws an error stating that the file to be renamed cannot be found. This can occur when multiple threads are writing to the dat file and both flush their data at approximately the same time.

The current logic performs write operations to a temp file with the same name but different extantion and after the buffer is flushed, it renames the temp file to the persistent file. Multiple threads will have the same temp file name. The "first" thread will "win" and rename its temp file but in so doing will delete the other thread's file and that other thread "loses".

This pr uses the `tempfile` crate to write to a randomly named temp file. This way threads will each write to a unique file and the last one to flush and rename their temp file "wins" but no one loses.

I val;idated that the errors stop after running the supervisor with this change.

Signed-off-by: Matt Wrock <matt@mattwrock.com>