### PR TITLE
Default binlink to all bins in package

### DIFF
--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -137,7 +137,7 @@ pub fn get() -> App<'static, 'static> {
                 (aliases: &["bi", "bin", "binl", "binli", "binlin"])
                 (@arg PKG_IDENT: +required +takes_value
                     "A package identifier (ex: core/redis, core/busybox-static/1.42.2)")
-                (@arg BINARY: +required +takes_value
+                (@arg BINARY: +takes_value
                     "The command to symlink (ex: bash)")
                 (@arg DEST_DIR: -d --dest +takes_value
                     "Sets the destination directory (default: /bin)")
@@ -352,13 +352,13 @@ fn sub_cli_completers() -> App<'static, 'static> {
     // bad value to clap.
 
     sub.arg(Arg::with_name("SHELL")
-                .help("The name of the shell you want to generate the command-completion. \
-                      Supported Shells: bash, fish, zsh, powershell")
-                .short("s")
-                .long("shell")
-                .required(true)
-                .takes_value(true)
-                .possible_values(&supported_shells))
+        .help("The name of the shell you want to generate the command-completion. Supported \
+               Shells: bash, fish, zsh, powershell")
+        .short("s")
+        .long("shell")
+        .required(true)
+        .takes_value(true)
+        .possible_values(&supported_shells))
 }
 
 fn sub_config_apply() -> App<'static, 'static> {

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -252,10 +252,11 @@ fn sub_origin_key_upload(ui: &mut UI, m: &ArgMatches) -> Result<()> {
 
 fn sub_pkg_binlink(ui: &mut UI, m: &ArgMatches) -> Result<()> {
     let ident = try!(PackageIdent::from_str(m.value_of("PKG_IDENT").unwrap()));
-    let binary = m.value_of("BINARY").unwrap(); // Required via clap
     let dest_dir = Path::new(m.value_of("DEST_DIR").unwrap_or(DEFAULT_BINLINK_DIR));
-
-    command::pkg::binlink::start(ui, &ident, &binary, &dest_dir, &*FS_ROOT)
+    match m.value_of("BINARY") {
+        Some(binary) => command::pkg::binlink::start(ui, &ident, &binary, &dest_dir, &*FS_ROOT),
+        None => command::pkg::binlink::binlink_all_in_pkg(ui, &ident, dest_dir, &*FS_ROOT),
+    }
 }
 
 fn sub_pkg_build(ui: &mut UI, m: &ArgMatches) -> Result<()> {

--- a/www/source/docs/reference/habitat-cli.html.md
+++ b/www/source/docs/reference/habitat-cli.html.md
@@ -242,7 +242,7 @@ Creates a symlink for a package binary in a common 'PATH' location
 **ARGS**
 
     <PKG_IDENT>    A package identifier (ex: core/redis, core/busybox-static/1.42.2)
-    <BINARY>       The command to symlink (ex: bash)
+    <BINARY>       The command to symlink (ex: bash)  If no binary is specified, all binaries from the specified package will be symlinked.
 
 <h2 id="hab-pkg-build" class="anchor">hab pkg build</h2>
 Builds a Plan using a Studio


### PR DESCRIPTION
Fixes #1921

This change makes the BINARY argument to the binlink command optional.
If omitted, all binaries in the package will be symlinked.

```
 ../../target/debug/hab pkg binlink -d /usr/local/bin core/net-tools
» Symlinking dnsdomainname from core/net-tools into /usr/local/bin
★ Binary dnsdomainname from core/net-tools/1.60/20161214060044 symlinked
to /usr/local/bin/dnsdomainname
» Symlinking ypdomainname from core/net-tools into /usr/local/bin
★ Binary ypdomainname from core/net-tools/1.60/20161214060044 symlinked
to /usr/local/bin/ypdomainname
» Symlinking domainname from core/net-tools into /usr/local/bin
★ Binary domainname from core/net-tools/1.60/20161214060044 symlinked to
/usr/local/bin/domainname
» Symlinking hostname from core/net-tools into /usr/local/bin
★ Binary hostname from core/net-tools/1.60/20161214060044 symlinked to
/usr/local/bin/hostname
» Symlinking netstat from core/net-tools into /usr/local/bin
★ Binary netstat from core/net-tools/1.60/20161214060044 symlinked to
/usr/local/bin/netstat
```

Signed-off-by: Nolan Davidson <ndavidson@chef.io>