### PR TITLE
Need a way to promote ChefConf

### DIFF
--- a/www/source/layouts/_nav.slim
+++ b/www/source/layouts/_nav.slim
@@ -28,4 +28,6 @@
         li.main-nav--link
           a.community href="/community" Community
         li.main-nav--link
+          a.chefconf href="https://chefconf.chef.io/2017/" ChefConf
+        li.main-nav--link
           a.login href="https://app.habitat.sh/#/sign-in" Log In


### PR DESCRIPTION
Adding a ChefConf link to the main navigation might not be the best way
to highlight the conference but it is a quick and easy way to link to
our conference without also taking over the home page's hero which is
currently being used for our 'next' Habitat event.

Open to other suggestions!

Signed-off-by: Nathen Harvey <nharvey@chef.io>