### PR TITLE
Fix cross-link error in package upload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -551,9 +551,9 @@ dependencies = [
 name = "habitat_builder_scheduler"
 version = "0.0.0"
 dependencies = [
+ "builder_core 0.0.0",
  "clap 2.22.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "builder_core 0.0.0",
  "habitat_builder_db 0.0.0",
  "habitat_builder_protocol 0.0.0",
  "habitat_core 0.0.0",

--- a/components/builder-depot/Cargo.toml
+++ b/components/builder-depot/Cargo.toml
@@ -37,6 +37,7 @@ unicase = "*"
 url = "*"
 urlencoded = "*"
 walkdir = "*"
+uuid = { version = "0.4", features = ["v4"] }
 
 [dependencies.clap]
 version = "*"

--- a/components/builder-depot/src/lib.rs
+++ b/components/builder-depot/src/lib.rs
@@ -51,6 +51,7 @@ extern crate url;
 extern crate urlencoded;
 extern crate walkdir;
 extern crate zmq;
+extern crate uuid;
 
 pub mod config;
 pub mod error;
@@ -116,6 +117,15 @@ impl Depot {
                           ident.release().unwrap(),
                           target.architecture,
                           target.platform))
+    }
+
+    // Return a formatted string representing the folder location for an archive.
+    fn archive_parent<T: Identifiable>(&self, ident: &T) -> PathBuf {
+        let mut digest = Sha256::new();
+        let mut output = [0; 64];
+        digest.input_str(&ident.to_string());
+        digest.result(&mut output);
+        self.packages_path().join(format!("{:x}", output[0])).join(format!("{:x}", output[1]))
     }
 
     fn packages_path(&self) -> PathBuf {


### PR DESCRIPTION
This fixes a file system 'cross-link' error that can occur when depot server is running in a Docker environment.

![giphy-downsized-large](https://cloud.githubusercontent.com/assets/13542112/24528893/874e0880-155d-11e7-864b-71c3385b5ab0.gif)

Signed-off-by: Salim Alam <salam@chef.io>