### PR TITLE
Updated installation instructions in tutorial

### DIFF
--- a/www/source/docs/get-habitat.html.md
+++ b/www/source/docs/get-habitat.html.md
@@ -5,11 +5,12 @@ description: Download Habitat, an open source project created by Chef, so your a
 ---
 
 # Get Habitat
-To get started with Habitat, you only need to download the `hab` command-line interface tool for your specific operating system.
+To get started with Habitat, you only need to download the `hab` command-line interface tool (CLI) for your specific operating system.
 
 ### For Mac
-To start using Habitat on Mac OS X, download the following binary.  Then unzip `hab` to `/usr/local/bin` and run `chmod a+x hab` to make it executable.
-If you intend to build Habitat packages on your Mac, you will also need to install [Docker for Mac](https://www.docker.com/products/docker#/mac).  
+To start using Habitat on Mac OS X and macOS, download the following binary. Then unzip `hab` to `/usr/local/bin` and run `chmod a+x hab` to make it executable. By copying it into `/usr/local/bin`, it will be automatically added to your `PATH` variable. 
+If you intend to build Habitat packages on your Mac, you will also need to install [Docker for Mac](https://www.docker.com/products/docker#/mac). 
+
 _Habitat for Mac requires a 64-bit processor running Mac OS X version 10.9+._
 
 
@@ -17,17 +18,24 @@ _Habitat for Mac requires a 64-bit processor running Mac OS X version 10.9+._
 <a class="button secondary" href="https://www.docker.com/products/docker#/mac">Download Docker for Mac</a>
 
 ### For Linux
-To start using Habitat on Linux, download the following binary.  
+To start using Habitat on Linux, download the following binary. Then unzip `hab` to `/usr/local/bin` and run `chmod a+x hab` to make it executable. As with the Mac instructions above, by copying the `hab` CLI into `/usr/local/bin`, it will automatically be added to your `PATH` variable.
+
 _Habitat for Linux requires a 64-bit processor with a kernel greater than 2.6.32._
 
 <a class="button" href="https://api.bintray.com/content/habitat/stable/linux/x86_64/hab-%24latest-x86_64-linux.tar.gz?bt_package=hab-x86_64-linux">Download Habitat for Linux</a>
 
 ### For Windows
-To start using Habitat on Windows, download the following binary.  Then unzip `hab` to `C:\habitat` and add `C:\habitat` to your `PATH`.  
-If you intend to build Habitat packages on your Windows PC, you will also need to install [Docker for Windows](https://docs.docker.com/docker-for-windows/). 
+To start using Habitat on Windows, download the following binary.  Then unzip `hab` to `C:\habitat` and add `C:\habitat` to your `PATH`. Here's an example of how to do that in PowerShell:
+
+    $env:PATH += "C:\habitat"
+
+To keep from typing this in for every PowerShell window you use, add the above statement to your PowerShell profile. You can learn more about PowerShell profiles [here](https://msdn.microsoft.com/en-us/powershell/reference/5.1/microsoft.powershell.core/about/about_profiles).
+
+If you intend to build Habitat packages on your Windows PC, you will also need to install [Docker for Windows](https://docs.docker.com/docker-for-windows/).
+
 _Habitat for Windows requires 64bit Windows 10 Pro, Enterprise and Education (1511 November update, Build 10586 or later) and Microsoft Hyper-V._
 
-> Note: Currently Habitat can only build and manage linux based packages. Support for Windows based applications is coming.
+> Note: Currently Habitat can only build and manage linux based packages. Support for Windows-based applications is coming.
 
 <a class="button" href="https://api.bintray.com/content/habitat/stable/windows/x86_64/hab-%24latest-x86_64-windows.zip?bt_package=hab-x86_64-windows">Download Habitat for Windows</a>
 <a class="button secondary" href="https://download.docker.com/win/stable/InstallDocker.msi">Download Docker for Windows</a>

--- a/www/source/tutorials/getting-started/linux/setup-environment.html.md.erb
+++ b/www/source/tutorials/getting-started/linux/setup-environment.html.md.erb
@@ -13,9 +13,7 @@ title: Getting set up with Habitat | Linux
 # Set up your environment
 The `hab` command-line interface (CLI) tool downloads its other components when it needs them, so setup for Habitat is centered on where you want the `hab` CLI installed and getting it integrated into your shell.
 
-1. Open a terminal window and copy `hab` to your `/bin` directory. This is because running the `hab` CLI natively on Linux requires you to run as root or with sudo privileges.
-
-       sudo cp where/you/extracted/hab /bin
+1. [Download the `hab` CLI](/docs/get-habitat) and install it per the instructions on the download page. 
 
 2. Run `hab setup` and follow the instructions in the setup script.
 

--- a/www/source/tutorials/getting-started/mac/setup-environment.html.md.erb
+++ b/www/source/tutorials/getting-started/mac/setup-environment.html.md.erb
@@ -13,18 +13,9 @@ title: Getting set up with Habitat | Mac
 # Set up your environment
 The `hab` command-line interface (CLI) tool downloads its other components when it needs them, so setup for Habitat is centered on where you want the `hab` CLI installed and getting it integrated into your shell.
 
-1.  Open a terminal window. Change directory to the directory where you want to place the `hab` CLI and copy the `hab` CLI to that directory.
+1. [Download the `hab` CLI](/docs/get-habitat) and install it per the instructions on the download page. 
 
-        mkdir -p ~/bin
-        cp where/you/extracted/hab ~/bin
-
-2. Add the location for the `hab` CLI to your `PATH` environment variable.
-
-       export PATH=$PATH:~/bin
-
-    To keep from typing this in for every terminal window you use, add the above statement to your shell profile.
-
-3. Run `hab setup` and follow the instructions in the setup script.
+2. Run `hab setup` and follow the instructions in the setup script.
 
    <%= partial "/shared/setup_environment_script_step" %>
 

--- a/www/source/tutorials/getting-started/overview.html.md
+++ b/www/source/tutorials/getting-started/overview.html.md
@@ -13,7 +13,6 @@ As a first step in understanding Habitat, this tutorial will show you how to cre
 
 Before starting this tutorial, you need to have the following:
 
-*   The `hab` command-line interface tool. See [Get Habitat](/docs/get-habitat) if you don't already have this installed on your machine.
 *   An active GitHub account is recommended. If you don't already have an account, [sign up](https://github.com/) for one now. Note: This is required to upload and share your packages with others in the Habitat community.
 *   Your favorite text editor.
 *   If you are running Mac OS X on your host machine, then you need [Docker for Mac](https://www.docker.com/products/docker#/mac) installed.

--- a/www/source/tutorials/getting-started/windows/setup-environment.html.md.erb
+++ b/www/source/tutorials/getting-started/windows/setup-environment.html.md.erb
@@ -13,16 +13,7 @@ title: Getting set up with Habitat | Mac
 # Set up your environment
 The `hab` command-line interface (CLI) tool downloads its other components when it needs them, so setup for Habitat is centered on where you want the `hab` CLI installed and getting it integrated into your shell.
 
-1. Open a PowerShell window. Change directory to the directory where you want to place the `hab` CLI and copy the `hab` CLI (and the included DLLs) to that directory.
-
-        mkdir ~/bin
-        cp ./where/you/extracted/hab/* -Destination ~/bin
-
-2. Add the location for the `hab` CLI to your `PATH` environment variable.
-
-       $env:PATH += "$env:PATH;$env:USERPROFILE/bin"
-
-    To keep from typing this in for every PowerShell window you use, add the above statement to your PowerShell profile.
+1. [Download the `hab` CLI](/docs/get-habitat) and install it per the instructions on the download page.
 
 3. Run `hab setup` and follow the instructions in the setup script.
 


### PR DESCRIPTION
- Refactored any `hab` CLI setup steps out of the tutorial and referred to the instructions in get-habitat instead.

This will keep basic installation steps separate from the tutorial, which should make them more discoverable.

Signed-off-by: David Wrede <dwrede@chef.io>