### PR TITLE
Add channel support to builder-worker

### DIFF
--- a/components/builder-depot-client/src/lib.rs
+++ b/components/builder-depot-client/src/lib.rs
@@ -443,6 +443,39 @@ impl Client {
         }
     }
 
+    /// Promote a package to a given channel
+    ///
+    /// # Failures
+    ///
+    /// * Remote Depot is not available
+    ///
+    /// # Panics
+    /// * If package archive does not have a version/release
+    /// * Authorization token was not set on client
+    pub fn promote_package(&self,
+                           pa: &mut PackageArchive,
+                           channel: &str,
+                           token: &str)
+                           -> Result<()> {
+        let ident = try!(pa.ident());
+        let path = format!("channels/{}/{}/pkgs/{}/{}/{}/promote",
+                           ident.origin,
+                           channel,
+                           ident.name,
+                           ident.version.unwrap(),
+                           ident.release.unwrap());
+
+        debug!("Promoting package, path: {}", path);
+
+        let res = self.add_authz(self.inner.put(&path), token).send()?;
+
+        if res.status != StatusCode::Ok {
+            return Err(err_from_response(res));
+        };
+
+        Ok(())
+    }
+
     /// Returns a vector of PackageIdent structs
     ///
     /// # Failures

--- a/components/core/src/url.rs
+++ b/components/core/src/url.rs
@@ -17,12 +17,25 @@ use env as henv;
 /// Default Depot URL
 pub const DEFAULT_DEPOT_URL: &'static str = "https://willem.habitat.sh/v1/depot";
 
+/// Default Depot channel
+pub const DEFAULT_DEPOT_CHANNEL: &'static str = "unstable";
+
 /// Default Depot URL environment variable
 pub const DEPOT_URL_ENVVAR: &'static str = "HAB_DEPOT_URL";
+
+/// Default Depot Channel environment variable
+pub const DEPOT_CHANNEL_ENVVAR: &'static str = "HAB_DEPOT_CHANNEL";
 
 pub fn default_depot_url() -> String {
     match henv::var(DEPOT_URL_ENVVAR) {
         Ok(val) => val,
         Err(_) => DEFAULT_DEPOT_URL.to_string(),
+    }
+}
+
+pub fn default_depot_channel() -> String {
+    match henv::var(DEPOT_CHANNEL_ENVVAR) {
+        Ok(val) => val,
+        Err(_) => DEFAULT_DEPOT_CHANNEL.to_string(),
     }
 }


### PR DESCRIPTION
This change adds the ability for the builder worker to promote builds to specified channels (by default, to "unstable"). The channel to be promoted to can be configured via the builder.toml file.

Signed-off-by: Salim Alam <salam@chef.io>

![giphy 15](https://cloud.githubusercontent.com/assets/13542112/24571095/fac2d464-1623-11e7-8549-74009e372b11.gif)
