### PR TITLE
Move --organization to manager configuration from ServiceSpec

### DIFF
--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -99,6 +99,7 @@ pub struct ManagerConfig {
     pub ring: Option<String>,
     pub name: Option<String>,
     pub custom_state_path: Option<PathBuf>,
+    pub organization: Option<String>,
 }
 
 pub struct Manager {
@@ -110,6 +111,7 @@ pub struct Manager {
     watcher: SpecWatcher,
     gossip_listen: GossipListenAddr,
     http_listen: http_gateway::ListenAddr,
+    organization: Option<String>,
 }
 
 impl Manager {
@@ -163,6 +165,7 @@ impl Manager {
                fs_cfg: Arc::new(fs_cfg),
                gossip_listen: cfg.gossip_listen,
                http_listen: cfg.http_listen,
+               organization: cfg.organization,
            })
     }
 
@@ -271,7 +274,8 @@ impl Manager {
         let service = Service::load(spec,
                                     &self.gossip_listen,
                                     &self.http_listen,
-                                    self.fs_cfg.clone())?;
+                                    self.fs_cfg.clone(),
+                                    self.organization.as_ref().map(|org| &**org))?;
         service.add()?;
         self.butterfly.insert_service(service.to_rumor(self.butterfly.member_id()));
         if service.topology == Topology::Leader {

--- a/components/sup/src/manager/service/spec.rs
+++ b/components/sup/src/manager/service/spec.rs
@@ -43,7 +43,6 @@ pub struct ServiceSpec {
     )]
     pub ident: PackageIdent,
     pub group: String,
-    pub organization: Option<String>,
     pub depot_url: String,
     pub topology: Topology,
     pub update_strategy: UpdateStrategy,
@@ -160,7 +159,6 @@ impl Default for ServiceSpec {
         ServiceSpec {
             ident: PackageIdent::default(),
             group: DEFAULT_GROUP.to_string(),
-            organization: None,
             depot_url: DEFAULT_DEPOT_URL.to_string(),
             topology: Topology::default(),
             update_strategy: UpdateStrategy::default(),
@@ -266,7 +264,6 @@ mod test {
 
             ident = "origin/name/1.2.3/20170223130020"
             group = "jobs"
-            organization = "acmecorp"
             depot_url = "http://example.com/depot"
             topology = "leader"
             update_strategy = "rolling"
@@ -280,7 +277,6 @@ mod test {
         assert_eq!(spec.ident,
                    PackageIdent::from_str("origin/name/1.2.3/20170223130020").unwrap());
         assert_eq!(spec.group, String::from("jobs"));
-        assert_eq!(spec.organization, Some(String::from("acmecorp")));
         assert_eq!(spec.depot_url, String::from("http://example.com/depot"));
         assert_eq!(spec.topology, Topology::Leader);
         assert_eq!(spec.update_strategy, UpdateStrategy::Rolling);
@@ -347,7 +343,6 @@ mod test {
         let spec = ServiceSpec {
             ident: PackageIdent::from_str("origin/name/1.2.3/20170223130020").unwrap(),
             group: String::from("jobs"),
-            organization: Some(String::from("acmecorp")),
             depot_url: String::from("http://example.com/depot"),
             topology: Topology::Leader,
             update_strategy: UpdateStrategy::AtOnce,
@@ -359,7 +354,6 @@ mod test {
 
         assert!(toml.contains(r#"ident = "origin/name/1.2.3/20170223130020""#));
         assert!(toml.contains(r#"group = "jobs""#));
-        assert!(toml.contains(r#"organization = "acmecorp""#));
         assert!(toml.contains(r#"depot_url = "http://example.com/depot""#));
         assert!(toml.contains(r#"topology = "leader""#));
         assert!(toml.contains(r#"update_strategy = "at-once""#));
@@ -392,7 +386,6 @@ mod test {
         let toml = r#"
             ident = "origin/name/1.2.3/20170223130020"
             group = "jobs"
-            organization = "acmecorp"
             depot_url = "http://example.com/depot"
             topology = "leader"
             update_strategy = "rolling"
@@ -407,7 +400,6 @@ mod test {
         assert_eq!(spec.ident,
                    PackageIdent::from_str("origin/name/1.2.3/20170223130020").unwrap());
         assert_eq!(spec.group, String::from("jobs"));
-        assert_eq!(spec.organization, Some(String::from("acmecorp")));
         assert_eq!(spec.depot_url, String::from("http://example.com/depot"));
         assert_eq!(spec.topology, Topology::Leader);
         assert_eq!(spec.update_strategy, UpdateStrategy::Rolling);
@@ -474,7 +466,6 @@ mod test {
         let spec = ServiceSpec {
             ident: PackageIdent::from_str("origin/name/1.2.3/20170223130020").unwrap(),
             group: String::from("jobs"),
-            organization: Some(String::from("acmecorp")),
             depot_url: String::from("http://example.com/depot"),
             topology: Topology::Leader,
             update_strategy: UpdateStrategy::AtOnce,
@@ -487,7 +478,6 @@ mod test {
 
         assert!(toml.contains(r#"ident = "origin/name/1.2.3/20170223130020""#));
         assert!(toml.contains(r#"group = "jobs""#));
-        assert!(toml.contains(r#"organization = "acmecorp""#));
         assert!(toml.contains(r#"depot_url = "http://example.com/depot""#));
         assert!(toml.contains(r#"topology = "leader""#));
         assert!(toml.contains(r#"update_strategy = "at-once""#));


### PR DESCRIPTION
This change effectively declares that all services running in a
supervisor share the same organization (if set)

* Move --organization flag to start subcommand from svc args group
* Move organization field from ServiceSpec to ManagerCfg

![gif-keyboard-3541512869975124630](https://cloud.githubusercontent.com/assets/54036/24636443/140f6f32-188f-11e7-9cd2-8f3fbd1d98d5.gif)
