### PR TITLE
Add load/unload/stop/run command to Supervisor

### DIFF
--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -295,6 +295,35 @@ pub fn get() -> App<'static, 'static> {
                     (@arg ORG: "The service organization")
                 )
             )
+            (@subcommand load =>
+                (about: "Load a service to be started and supervised by Habitat from a package or \
+                    artifact. Services started in this manner will persist through Supervisor \
+                    restarts.")
+                (@setting Hidden)
+            )
+            (@subcommand unload =>
+                (about: "Unload a persistent or transient service started by the Habitat \
+                    supervisor. If the Supervisor is running when the service is unloaded the \
+                    service will be stopped.")
+                (@setting Hidden)
+            )
+            (@subcommand start =>
+                (about: "Start a loaded, but stopped, Habitat service or a transient service from \
+                    a package or artifact. If the Habitat Supervisor is not already running this \
+                    will additionally start one for you.")
+                (@setting Hidden)
+            )
+            (@subcommand stop =>
+                (about: "Stop a running Habitat service.")
+                (@setting Hidden)
+            )
+            (after_help: "\nALIASES:\
+                \n    load       Alias for: 'sup load'\
+                \n    unload     Alias for: 'sup unload'\
+                \n    start      Alias for: 'sup start'\
+                \n    stop       Alias for: 'sup stop'\
+                \n"
+            )
         )
         (@subcommand studio =>
             (about: "Commands relating to Habitat Studios")

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[macro_use]
 extern crate clap;
 extern crate env_logger;
 extern crate hab;

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -497,6 +497,10 @@ fn exec_subcommand_if_called(ui: &mut UI) -> Result<()> {
         }
         ("sup", _) => command::sup::start(ui, env::args_os().skip(2).collect()),
         ("start", _) => command::sup::start(ui, env::args_os().skip(1).collect()),
+        ("service", "load") |
+        ("service", "unload") |
+        ("service", "start") |
+        ("service", "stop") => command::sup::start(ui, env::args_os().skip(2).collect()),
         _ => Ok(()),
     }
 }

--- a/components/sup/src/command/mod.rs
+++ b/components/sup/src/command/mod.rs
@@ -14,5 +14,5 @@
 
 //! The CLI commands.
 
-pub mod start;
 pub mod shell;
+pub mod start;

--- a/components/sup/src/error.rs
+++ b/components/sup/src/error.rs
@@ -126,6 +126,7 @@ pub enum Error {
     NulError(ffi::NulError),
     PackageNotFound(package::PackageIdent),
     Permissions(String),
+    ProcessLockCorrupt,
     ProcessLocked(u32),
     ProcessLockIO(PathBuf, io::Error),
     ServiceSpecFileRead(String, String),
@@ -204,6 +205,7 @@ impl fmt::Display for SupError {
                     format!("Cannot find a release of package: {}", pkg)
                 }
             }
+            Error::ProcessLockCorrupt => format!("Unable to decode contents of process lock"),
             Error::ProcessLocked(ref pid) => {
                 format!("Unable to start Habitat Supervisor because another instance is already \
                     running with the pid {}. If your intention was to run multiple Supervisors - \
@@ -291,6 +293,7 @@ impl error::Error for SupError {
             Error::NulError(_) => "An attempt was made to build a CString with a null byte inside it",
             Error::PackageNotFound(_) => "Cannot find a package",
             Error::Permissions(_) => "File system permissions error",
+            Error::ProcessLockCorrupt => "Unable to decode contents of process lock",
             Error::ProcessLocked(_) => "Another instance of the Habitat Supervisor is already running",
             Error::ProcessLockIO(_, _) => "Unable to write or read to a process lock",
             Error::ServiceSpecFileRead(_, _) => "Service spec file could not be read successfully",

--- a/components/sup/src/error.rs
+++ b/components/sup/src/error.rs
@@ -102,7 +102,9 @@ impl SupError {
 pub enum Error {
     BadDataFile(PathBuf, io::Error),
     BadDataPath(PathBuf, io::Error),
+    BadDesiredState(String),
     BadSpecsPath(PathBuf, io::Error),
+    BadStartStyle(String),
     ButterflyError(butterfly::error::Error),
     DepotClient(depot_client::Error),
     EnvJoinPathsError(env::JoinPathsError),
@@ -129,10 +131,10 @@ pub enum Error {
     ProcessLockCorrupt,
     ProcessLocked(u32),
     ProcessLockIO(PathBuf, io::Error),
-    ServiceSpecFileRead(String, String),
-    ServiceSpecFileWrite(String, String),
-    ServiceSpecParse(String),
-    ServiceSpecRender(String),
+    ServiceLoaded(package::PackageIdent),
+    ServiceSpecFileIO(PathBuf, io::Error),
+    ServiceSpecParse(toml::de::Error),
+    ServiceSpecRender(toml::ser::Error),
     SignalFailed,
     SpecWatcherDirNotFound(String),
     SpecWatcherGlob(glob::PatternError),
@@ -161,11 +163,15 @@ impl fmt::Display for SupError {
                         path.display(),
                         err)
             }
+            Error::BadDesiredState(ref state) => {
+                format!("Unknown service desired state style '{}'", state)
+            }
             Error::BadSpecsPath(ref path, ref err) => {
                 format!("Unable to create the specs directory '{}' ({})",
                         path.display(),
                         err)
             }
+            Error::BadStartStyle(ref style) => format!("Unknown service start style '{}'", style),
             Error::ButterflyError(ref err) => format!("Butterfly error: {}", err),
             Error::ExecCommandNotFound(ref c) => {
                 format!("`{}' was not found on the filesystem or in PATH", c)
@@ -219,22 +225,19 @@ impl fmt::Display for SupError {
                         path.display(),
                         err)
             }
-            Error::ServiceSpecFileRead(ref path, ref details) => {
-                format!("Service spec file '{}' could not be read successfully: {}",
-                        path,
-                        details)
+            Error::ServiceLoaded(ref ident) => {
+                format!("Service already loaded, unload '{}' and try again", ident)
             }
-            Error::ServiceSpecFileWrite(ref path, ref details) => {
-                format!("Service spec file '{}' could not be written successfully: {}",
-                        path,
-                        details)
+            Error::ServiceSpecFileIO(ref path, ref err) => {
+                format!("Unable to write or read to a service spec file at {}, {}",
+                        path.display(),
+                        err)
             }
-            Error::ServiceSpecParse(ref details) => {
-                format!("Service spec could not be parsed successfully: {}", details)
+            Error::ServiceSpecParse(ref err) => {
+                format!("Unable to parse contents of service spec file, {}", err)
             }
-            Error::ServiceSpecRender(ref details) => {
-                format!("Service spec TOML could not be rendered successfully: {}",
-                        details)
+            Error::ServiceSpecRender(ref err) => {
+                format!("Service spec could not be rendered successfully: {}", err)
             }
             Error::SignalFailed => format!("Failed to send a signal to the child process"),
             Error::SpecWatcherDirNotFound(ref path) => {
@@ -269,7 +272,9 @@ impl error::Error for SupError {
         match self.err {
             Error::BadDataFile(_, _) => "Unable to read or write to a data file",
             Error::BadDataPath(_, _) => "Unable to read or write to data directory",
+            Error::BadDesiredState(_) => "Unknown desired state in service spec",
             Error::BadSpecsPath(_, _) => "Unable to create the specs directory",
+            Error::BadStartStyle(_) => "Unknown start style in service spec",
             Error::ButterflyError(ref err) => err.description(),
             Error::ExecCommandNotFound(_) => "Exec command was not found on filesystem or in PATH",
             Error::TemplateFileError(ref err) => err.description(),
@@ -296,8 +301,8 @@ impl error::Error for SupError {
             Error::ProcessLockCorrupt => "Unable to decode contents of process lock",
             Error::ProcessLocked(_) => "Another instance of the Habitat Supervisor is already running",
             Error::ProcessLockIO(_, _) => "Unable to write or read to a process lock",
-            Error::ServiceSpecFileRead(_, _) => "Service spec file could not be read successfully",
-            Error::ServiceSpecFileWrite(_, _) => "Service spec file could not be written successfully",
+            Error::ServiceLoaded(_) => "Service load or start called when service already loaded",
+            Error::ServiceSpecFileIO(_, _) => "Unable to write or read to a service spec file",
             Error::ServiceSpecParse(_) => "Service spec could not be parsed successfully",
             Error::ServiceSpecRender(_) => "Service spec TOML could not be rendered successfully",
             Error::SignalFailed => "Failed to send a signal to the child process",

--- a/components/sup/src/lib.rs
+++ b/components/sup/src/lib.rs
@@ -300,8 +300,7 @@ lazy_static!{
 
 features! {
     pub mod feat {
-        const List = 0b00000001,
-        const Multi = 0b00000010
+        const List = 0b00000001
     }
 }
 

--- a/components/sup/src/lib.rs
+++ b/components/sup/src/lib.rs
@@ -304,5 +304,5 @@ features! {
     }
 }
 
-const PRODUCT: &'static str = "hab-sup";
-const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+pub const PRODUCT: &'static str = "hab-sup";
+pub const VERSION: &'static str = include_str!(concat!(env!("OUT_DIR"), "/VERSION"));

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -101,7 +101,7 @@ fn cli<'a, 'b>() -> App<'a, 'b> {
         )
         (@subcommand start =>
             (about: "Start a Habitat-supervised service from a package or artifact")
-            (aliases: &["st", "sta", "star"])
+            (aliases: &["sta", "star"])
             (@arg LISTEN_GOSSIP: --("listen-gossip") +takes_value
                 "The listen address for the gossip system [default: 0.0.0.0:9638]")
             (@arg LISTEN_HTTP: --("listen-http") +takes_value
@@ -259,7 +259,7 @@ fn sub_start(m: &ArgMatches) -> Result<()> {
         }
         None => None,
     };
-    try!(command::start::package(cfg, maybe_spec, maybe_local_artifact));
+    try!(command::start::run(cfg, maybe_spec, maybe_local_artifact));
     Ok(())
 }
 

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -259,18 +259,6 @@ fn sub_start(m: &ArgMatches) -> Result<()> {
         }
         None => None,
     };
-    if !feat::is_enabled(feat::Multi) && !m.is_present("PKG_IDENT_OR_ARTIFACT") {
-        // For now, mimick the "required argument" error message to preserve original behavior of a
-        // require pkg ident or artifact
-        println!("{} The following required arguments were not provided:",
-                 clap::Format::Error("error:"));
-        println!("    {}", clap::Format::Error("<PKG_IDENT_OR_ARTIFACT>"));
-        println!("");
-        println!("{}", m.usage());
-        println!("");
-        println!("For more information try {}", clap::Format::Good("--help"));
-        std::process::exit(1);
-    }
     try!(command::start::package(cfg, maybe_spec, maybe_local_artifact));
     Ok(())
 }
@@ -339,7 +327,7 @@ fn valid_url(val: String) -> result::Result<(), String> {
 }
 
 fn enable_features_from_env() {
-    let features = vec![(feat::List, "LIST"), (feat::Multi, "MULTI")];
+    let features = vec![(feat::List, "LIST")];
 
     for feature in &features {
         match henv::var(format!("HAB_FEAT_{}", feature.1)) {

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -121,8 +121,9 @@ fn cli<'a, 'b>() -> App<'a, 'b> {
                 previously loaded and running this operation will also restart the service")
         )
         (@subcommand unload =>
-            (about: "Unload a persistent or transient service started by the Habitat supervisor. \
-            If the Supervisor is running when the service is unloaded the service will be stopped.")
+            (about: "Unload a persistent or transient service started by the Habitat \
+                supervisor. If the Supervisor is running when the service is unloaded the \
+                service will be stopped.")
             (aliases: &["un", "unl", "unlo", "unloa"])
             (@arg PKG_IDENT: +required +takes_value "A Habitat package identifier (ex: core/redis)")
             (@arg NAME: --("override-name") +takes_value

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -43,7 +43,6 @@ pub use manager::service::{Service, ServiceConfig, ServiceSpec, UpdateStrategy, 
 use self::service_updater::ServiceUpdater;
 use self::spec_watcher::{SpecWatcher, SpecWatcherEvent};
 use error::{Error, Result};
-use feat;
 use config::GossipListenAddr;
 use manager::census::{CensusUpdate, CensusList, CensusEntry};
 use manager::signals::SignalEvent;
@@ -299,10 +298,7 @@ impl Manager {
 
     pub fn run(&mut self) -> Result<()> {
         signals::init();
-
-        if feat::is_enabled(feat::Multi) {
-            self.start_initial_services_from_watcher()?;
-        }
+        self.start_initial_services_from_watcher()?;
 
         outputln!("Starting butterfly on {}", self.butterfly.gossip_addr());
         try!(self.butterfly.start(Timing::default()));
@@ -320,9 +316,7 @@ impl Manager {
                 self.shutdown();
                 return Ok(());
             }
-            if feat::is_enabled(feat::Multi) {
-                self.update_running_services_from_watcher()?;
-            }
+            self.update_running_services_from_watcher()?;
             self.check_for_updated_packages(&mut last_census_update);
             self.restart_elections();
             let (census_updated, ncu) = self.build_census(&last_census_update);

--- a/components/sup/src/manager/service/spec.rs
+++ b/components/sup/src/manager/service/spec.rs
@@ -35,6 +35,40 @@ static DEFAULT_GROUP: &'static str = "default";
 pub const SPEC_FILE_EXT: &'static str = "spec.toml";
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub enum DesiredState {
+    Down,
+    Up,
+}
+
+impl Default for DesiredState {
+    fn default() -> DesiredState {
+        DesiredState::Up
+    }
+}
+
+impl fmt::Display for DesiredState {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let value = match *self {
+            DesiredState::Down => "down",
+            DesiredState::Up => "up",
+        };
+        write!(f, "{}", value)
+    }
+}
+
+impl FromStr for DesiredState {
+    type Err = SupError;
+
+    fn from_str(value: &str) -> result::Result<Self, Self::Err> {
+        match value.to_lowercase().as_ref() {
+            "down" => Ok(DesiredState::Down),
+            "up" => Ok(DesiredState::Up),
+            _ => Err(sup_error!(Error::BadDesiredState(value.to_string()))),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[serde(default)]
 pub struct ServiceSpec {
     #[serde(
@@ -49,6 +83,16 @@ pub struct ServiceSpec {
     pub binds: Vec<ServiceBind>,
     #[serde(skip_deserializing, skip_serializing)]
     pub config_from: Option<PathBuf>,
+    #[serde(
+        deserialize_with = "deserialize_using_from_str",
+        serialize_with = "serialize_using_to_string"
+    )]
+    pub desired_state: DesiredState,
+    #[serde(
+        deserialize_with = "deserialize_using_from_str",
+        serialize_with = "serialize_using_to_string"
+    )]
+    pub start_style: StartStyle,
 }
 
 impl ServiceSpec {
@@ -62,23 +106,18 @@ impl ServiceSpec {
         if self.ident == PackageIdent::default() {
             return Err(sup_error!(Error::MissingRequiredIdent));
         }
-
-        toml::to_string(self).map_err(|e| sup_error!(Error::ServiceSpecRender(e.to_string())))
+        toml::to_string(self).map_err(|err| sup_error!(Error::ServiceSpecRender(err)))
     }
 
     pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Self> {
-        let file = File::open(&path).map_err(|e| {
-                         sup_error!(Error::ServiceSpecFileRead(path.as_ref().display().to_string(),
-                                                               e.to_string()))
-                     })?;
+        let file =
+            File::open(&path).map_err(|err| {
+                             sup_error!(Error::ServiceSpecFileIO(path.as_ref().to_path_buf(), err))
+                         })?;
         let mut file = BufReader::new(file);
         let mut buf = String::new();
         file.read_to_string(&mut buf)
-            .map_err(|e| {
-                         sup_error!(Error::ServiceSpecFileRead(path.as_ref().display().to_string(),
-                                                               e.to_string()))
-                     })?;
-
+            .map_err(|err| sup_error!(Error::ServiceSpecFileIO(path.as_ref().to_path_buf(), err)))?;
         Self::from_str(&buf)
     }
 
@@ -86,42 +125,31 @@ impl ServiceSpec {
         debug!("Writing service spec to '{}': {:?}",
                path.as_ref().display(),
                &self);
-        let dst_path = path.as_ref()
-            .parent()
-            .ok_or(sup_error!(Error::ServiceSpecFileWrite(path.as_ref().display().to_string(),
-                                                          "cannot determine parent directory"
-                                                              .to_string())))?;
+        let dst_path =
+            path.as_ref().parent().expect("Cannot determine parent directory for service spec");
         let tmpfile = path.as_ref().with_extension(thread_rng()
                                                        .gen_ascii_chars()
                                                        .take(8)
                                                        .collect::<String>());
-
-        fs::create_dir_all(dst_path).map_err(|e| {
-                         sup_error!(Error::ServiceSpecFileWrite(path.as_ref()
-                                                                    .display()
-                                                                    .to_string(),
-                                                                e.to_string()))
+        fs::create_dir_all(dst_path).map_err(|err| {
+                         sup_error!(Error::ServiceSpecFileIO(path.as_ref()
+                                                                    .to_path_buf(),
+                                                                err))
                      })?;
-
         // Release the write file handle before the end of the function since we're done
         {
-            let mut file = File::create(&tmpfile).map_err(|e| {
-                             sup_error!(Error::ServiceSpecFileWrite(tmpfile.display().to_string(),
-                                                                    e.to_string()))
-                         })?;
+            let mut file =
+                File::create(&tmpfile).map_err(|err| {
+                                 sup_error!(Error::ServiceSpecFileIO(tmpfile.to_path_buf(), err))
+                             })?;
             let toml = self.to_toml_string()?;
             file.write_all(toml.as_bytes())
-                .map_err(|e| {
-                             sup_error!(Error::ServiceSpecFileWrite(tmpfile.display().to_string(),
-                                                                    e.to_string()))
-                         })?;
+                .map_err(|err| sup_error!(Error::ServiceSpecFileIO(tmpfile.to_path_buf(), err)))?;
         }
-
-        fs::rename(&tmpfile, path.as_ref()).map_err(|e| {
-                         sup_error!(Error::ServiceSpecFileWrite(path.as_ref()
-                                                                    .display()
-                                                                    .to_string(),
-                                                                e.to_string()))
+        fs::rename(&tmpfile, path.as_ref()).map_err(|err| {
+                         sup_error!(Error::ServiceSpecFileIO(path.as_ref()
+                                                                    .to_path_buf(),
+                                                                err))
                      })?;
 
         Ok(())
@@ -164,6 +192,8 @@ impl Default for ServiceSpec {
             update_strategy: UpdateStrategy::default(),
             binds: vec![],
             config_from: None,
+            desired_state: DesiredState::default(),
+            start_style: StartStyle::default(),
         }
     }
 }
@@ -173,7 +203,7 @@ impl FromStr for ServiceSpec {
 
     fn from_str(toml: &str) -> result::Result<Self, Self::Err> {
         let spec: ServiceSpec =
-            toml::from_str(toml).map_err(|e| sup_error!(Error::ServiceSpecParse(e.to_string())))?;
+            toml::from_str(toml).map_err(|e| sup_error!(Error::ServiceSpecParse(e)))?;
         if spec.ident == PackageIdent::default() {
             return Err(sup_error!(Error::MissingRequiredIdent));
         }
@@ -225,6 +255,40 @@ impl serde::Serialize for ServiceBind {
     }
 }
 
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub enum StartStyle {
+    Persistent,
+    Transient,
+}
+
+impl Default for StartStyle {
+    fn default() -> StartStyle {
+        StartStyle::Transient
+    }
+}
+
+impl fmt::Display for StartStyle {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let value = match *self {
+            StartStyle::Persistent => "persistent",
+            StartStyle::Transient => "transient",
+        };
+        write!(f, "{}", value)
+    }
+}
+
+impl FromStr for StartStyle {
+    type Err = SupError;
+
+    fn from_str(value: &str) -> result::Result<Self, Self::Err> {
+        match value.to_lowercase().as_ref() {
+            "persistent" => Ok(StartStyle::Persistent),
+            "transient" => Ok(StartStyle::Transient),
+            _ => Err(sup_error!(Error::BadStartStyle(value.to_string()))),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use std::fs::{self, File};
@@ -238,7 +302,7 @@ mod test {
     use tempdir::TempDir;
     use toml;
 
-    use super::{ServiceBind, ServiceSpec, Topology, UpdateStrategy};
+    use super::*;
     use error::Error::*;
 
     fn file_from_str<P: AsRef<Path>>(path: P, content: &str) {
@@ -261,13 +325,13 @@ mod test {
     #[test]
     fn service_spec_from_str() {
         let toml = r#"
-
             ident = "origin/name/1.2.3/20170223130020"
             group = "jobs"
             depot_url = "http://example.com/depot"
             topology = "leader"
             update_strategy = "rolling"
             binds = ["cache:redis.cache@acmecorp", "db:postgres.app@acmecorp"]
+            start_style = "persistent"
 
             config_from = "should not be parsed"
             extra_stuff = "should be ignored"
@@ -284,6 +348,7 @@ mod test {
                    vec![ServiceBind::from_str("cache:redis.cache@acmecorp").unwrap(),
                         ServiceBind::from_str("db:postgres.app@acmecorp").unwrap()]);
         assert_eq!(spec.config_from, None);
+        assert_eq!(spec.start_style, StartStyle::Persistent);
     }
 
     #[test]
@@ -349,6 +414,8 @@ mod test {
             binds: vec![ServiceBind::from_str("cache:redis.cache@acmecorp").unwrap(),
                         ServiceBind::from_str("db:postgres.app@acmecorp").unwrap()],
             config_from: Some(PathBuf::from("/")),
+            desired_state: DesiredState::Down,
+            start_style: StartStyle::Persistent,
         };
         let toml = spec.to_toml_string().unwrap();
 
@@ -359,6 +426,8 @@ mod test {
         assert!(toml.contains(r#"update_strategy = "at-once""#));
         assert!(toml.contains(r#""cache:redis.cache@acmecorp""#));
         assert!(toml.contains(r#""db:postgres.app@acmecorp""#));
+        assert!(toml.contains(r#"desired_state = "down""#));
+        assert!(toml.contains(r#"start_style = "persistent""#));
         assert!(!toml.contains(r#"config_from = "#));
     }
 
@@ -417,7 +486,7 @@ mod test {
         match ServiceSpec::from_file(&path) {
             Err(e) => {
                 match e.err {
-                    ServiceSpecFileRead(p, _) => assert_eq!(path.display().to_string(), p),
+                    ServiceSpecFileIO(p, _) => assert_eq!(path, p),
                     wrong => panic!("Unexpected error returned: {:?}", wrong),
                 }
             }
@@ -472,6 +541,8 @@ mod test {
             binds: vec![ServiceBind::from_str("cache:redis.cache@acmecorp").unwrap(),
                         ServiceBind::from_str("db:postgres.app@acmecorp").unwrap()],
             config_from: Some(PathBuf::from("/")),
+            desired_state: DesiredState::Down,
+            start_style: StartStyle::Persistent,
         };
         spec.to_file(&path).unwrap();
         let toml = string_from_file(path);
@@ -483,6 +554,8 @@ mod test {
         assert!(toml.contains(r#"update_strategy = "at-once""#));
         assert!(toml.contains(r#""cache:redis.cache@acmecorp""#));
         assert!(toml.contains(r#""db:postgres.app@acmecorp""#));
+        assert!(toml.contains(r#"desired_state = "down""#));
+        assert!(toml.contains(r#"start_style = "persistent""#));
         assert!(!toml.contains(r#"config_from = "#));
     }
 

--- a/components/sup/src/manager/service/spec.rs
+++ b/components/sup/src/manager/service/spec.rs
@@ -32,7 +32,7 @@ use error::{Error, Result, SupError};
 
 static LOGKEY: &'static str = "SS";
 static DEFAULT_GROUP: &'static str = "default";
-pub const SPEC_FILE_EXT: &'static str = "spec.toml";
+pub const SPEC_FILE_EXT: &'static str = "spec";
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub enum DesiredState {
@@ -451,7 +451,7 @@ mod test {
     #[test]
     fn service_spec_from_file() {
         let tmpdir = TempDir::new("specs").unwrap();
-        let path = tmpdir.path().join("name.spec.toml");
+        let path = tmpdir.path().join("name.spec");
         let toml = r#"
             ident = "origin/name/1.2.3/20170223130020"
             group = "jobs"
@@ -481,7 +481,7 @@ mod test {
     #[test]
     fn service_spec_from_file_missing() {
         let tmpdir = TempDir::new("specs").unwrap();
-        let path = tmpdir.path().join("nope.spec.toml");
+        let path = tmpdir.path().join("nope.spec");
 
         match ServiceSpec::from_file(&path) {
             Err(e) => {
@@ -497,7 +497,7 @@ mod test {
     #[test]
     fn service_spec_from_file_empty() {
         let tmpdir = TempDir::new("specs").unwrap();
-        let path = tmpdir.path().join("empty.spec.toml");
+        let path = tmpdir.path().join("empty.spec");
         file_from_str(&path, "");
 
         match ServiceSpec::from_file(&path) {
@@ -514,7 +514,7 @@ mod test {
     #[test]
     fn service_spec_from_file_bad_contents() {
         let tmpdir = TempDir::new("specs").unwrap();
-        let path = tmpdir.path().join("bad.spec.toml");
+        let path = tmpdir.path().join("bad.spec");
         file_from_str(&path, "You're gonna have a bad time");
 
         match ServiceSpec::from_file(&path) {
@@ -531,7 +531,7 @@ mod test {
     #[test]
     fn service_spec_to_file() {
         let tmpdir = TempDir::new("specs").unwrap();
-        let path = tmpdir.path().join("name.spec.toml");
+        let path = tmpdir.path().join("name.spec");
         let spec = ServiceSpec {
             ident: PackageIdent::from_str("origin/name/1.2.3/20170223130020").unwrap(),
             group: String::from("jobs"),
@@ -562,7 +562,7 @@ mod test {
     #[test]
     fn service_spec_to_file_invalid_ident() {
         let tmpdir = TempDir::new("specs").unwrap();
-        let path = tmpdir.path().join("name.spec.toml");
+        let path = tmpdir.path().join("name.spec");
         // Remember: the default implementation of `PackageIdent` is an invalid identifier, missing
         // origin and name--we're going to exploit this here
         let spec = ServiceSpec::default();
@@ -582,7 +582,7 @@ mod test {
     fn service_spec_file_name() {
         let spec = ServiceSpec::default_for(PackageIdent::from_str("origin/hoopa/1.2.3").unwrap());
 
-        assert_eq!(String::from("hoopa.spec.toml"), spec.file_name());
+        assert_eq!(String::from("hoopa.spec"), spec.file_name());
     }
 
     #[test]

--- a/components/sup/src/manager/spec_watcher.rs
+++ b/components/sup/src/manager/spec_watcher.rs
@@ -30,8 +30,8 @@ use manager::service::ServiceSpec;
 
 static LOGKEY: &'static str = "SW";
 const WATCHER_DELAY_MS: u64 = 2_000;
-const SPEC_FILE_EXT: &'static str = "spec.toml";
-const SPEC_FILE_GLOB: &'static str = "*.spec.toml";
+const SPEC_FILE_EXT: &'static str = "spec";
+const SPEC_FILE_GLOB: &'static str = "*.spec";
 
 #[derive(Debug, PartialEq)]
 pub enum SpecWatcherEvent {
@@ -457,7 +457,7 @@ mod test {
     fn loading_spec_missing_ident_doesnt_impact_others() {
         let tmpdir = TempDir::new("specs").unwrap();
         let alpha = new_saved_spec(tmpdir.path(), "acme/alpha");
-        fs::File::create(tmpdir.path().join(format!("beta.spec.toml"))).expect("can't create file");
+        fs::File::create(tmpdir.path().join(format!("beta.spec"))).expect("can't create file");
 
         let mut watcher = SpecWatcher::run(tmpdir.path()).unwrap();
 
@@ -472,7 +472,7 @@ mod test {
         let tmpdir = TempDir::new("specs").unwrap();
         let alpha = new_saved_spec(tmpdir.path(), "acme/alpha");
         {
-            let mut bad = fs::File::create(tmpdir.path().join(format!("beta.spec.toml"))).
+            let mut bad = fs::File::create(tmpdir.path().join(format!("beta.spec"))).
                 expect("can't create file");
             bad.write_all(r#"ident = "acme/beta"
                           I am a bad bad file."#
@@ -493,7 +493,7 @@ mod test {
         let tmpdir = TempDir::new("specs").unwrap();
         let alpha = new_saved_spec(tmpdir.path(), "acme/alpha");
         {
-            let mut bad = fs::File::create(tmpdir.path().join(format!("beta.spec.toml"))).
+            let mut bad = fs::File::create(tmpdir.path().join(format!("beta.spec"))).
                 expect("can't create file");
             bad.write_all(r#"ident = "acme/NEAL_MORSE_BAND""#.as_bytes()).
                 expect("can't write file content");
@@ -515,18 +515,18 @@ mod test {
         fn behavior_new_spec<P: AsRef<Path>>(&mut self, path: P) {
             new_saved_spec(path.as_ref(), "acme/newbie");
             self.tx
-                .send(notify::DebouncedEvent::Write(path.as_ref().join("newbie.spec.toml")))
+                .send(notify::DebouncedEvent::Write(path.as_ref().join("newbie.spec")))
                 .expect("couldn't send event");
         }
 
         fn behavior_removed_spec<P: AsRef<Path>>(&mut self, path: P) {
-            let toml_path = path.as_ref().join("oldie.spec.toml");
+            let toml_path = path.as_ref().join("oldie.spec");
             fs::remove_file(&toml_path).expect("couldn't delete spec toml");
             self.tx.send(notify::DebouncedEvent::Remove(toml_path)).expect("couldn't send event");
         }
 
         fn behavior_changed_spec<P: AsRef<Path>>(&mut self, path: P) {
-            let toml_path = path.as_ref().join("transformer.spec.toml");
+            let toml_path = path.as_ref().join("transformer.spec");
             let mut spec = ServiceSpec::from_file(&toml_path).expect("couldn't load spec file");
             spec.group = String::from("autobots");
             spec.to_file(&toml_path).expect("couldn't write spec file");
@@ -587,7 +587,7 @@ mod test {
 
     fn new_saved_spec(tmpdir: &Path, ident: &str) -> ServiceSpec {
         let spec = new_spec(ident);
-        spec.to_file(tmpdir.join(format!("{}.spec.toml", &spec.ident.name))).
+        spec.to_file(tmpdir.join(format!("{}.spec", &spec.ident.name))).
             expect("couldn't save spec to disk");
         spec
     }

--- a/www/data/docs_sidebar.yml
+++ b/www/data/docs_sidebar.yml
@@ -57,6 +57,8 @@ sidebar_links:
       link: "/docs/run-packages-binding/"
     - title: Update strategy
       link: "/docs/run-packages-update-strategy/"
+    - title: Multiple Services
+      link: "/docs/run-packages-multiple-services/"
     - title: Export packages
       link: "/docs/run-packages-export/"
     - title: Monitoring

--- a/www/source/docs/run-packages-multiple-services.html.md
+++ b/www/source/docs/run-packages-multiple-services.html.md
@@ -1,0 +1,66 @@
+---
+title: Running Multiple Services with one Supervisor
+---
+
+# Run Multiple Services with one Supervisor
+
+The Habitat supervisor is designed to supervise one or more services concurrently so if you are running Habitat on bare metal or a virtual machine there is only need for one supervisor. This is also useful in a container environment if you require a secondary so-called "sidecar" service running alongside your primary service.
+
+## Starting only the Supervisor
+
+Starting the supervisor is as simple as running:
+
+		hab sup run
+
+This command also lets you override the default gossip and http gateway binding ports, just like when using `hab start`.
+
+## Running the Supervisor with a Host's init System
+
+As only one supervisor is required on a host, this means that only one system service needs to be added. Your choice of Linux distribution may dictate which init system is in use (i.e. SysVinit, Systemd, runit, etc), but all options boil down to simply running `hab sup run` as the runnable program. The following example assumes that the Habitat program `hab` is installed, binlinked as `/bin/hab`, and a `hab` user and group are present.
+
+For example, a suitable Systemd unit would simply be:
+
+		[Unit]
+		Description=The Habitat Supervisor
+
+		[Service]
+		ExecStart=/bin/hab sup run
+
+		[Install]
+		WantedBy=default.target
+
+It is important to start the supervisor via the `hab` program as upgrades to the `core/hab` Habitat package will also upgrade the version of the supervisor on next start.
+
+## Loading a Service for Supervision
+
+To add a service to a Supervisor, you use the `hab service load` subcommand. It has many of the same service-related flags and options as `hab start`, so there's nothing extra to learn here (for more details, read through the [Run packages sections](/docs/run-packages-overview)). For example, to load `yourorigin/yourname` in a Leader topology, a Rolling update strategy and a Group of "acme", run the following:
+
+		hab service load yourorigin/yourname --topology leader --strategy rolling --group acme
+
+Running the `hab service load` subcommand multiple times with different package identifiers will result in multiple services running on the same supervisor. Let's add `core/redis` to the supervisor for some fun:
+
+		hab service load core/redis
+
+## Unloading a Service from Supervision
+
+To unload and consequently remove a service from supervision, you use the `hab service unload` subcommand. If the service is was running, then it will be stopped first, then removed last. This means that the next time the Supervisor is started (or restarted), it will not run this unloaded service. For example, to remove the `yourorigin/yourname` service:
+
+		hab service unload yourorigin/yourname
+
+## Stopping a Loaded Running Service
+
+Sometimes you need to stop a running service for a period of time, for example during a maintenance outage. Rather than completely removing a service from supervision, you can use the `hab service stop` subcommand which will shut down the running service and leave it in this state until you start it again with the `hab service start` subcommand, explained next. This means that all service-related options such as service topology, update strategy, etc. are preserved until the service is started again. For example, to stop the running `core/redis` service:
+
+		hab service stop core/redis
+
+## Starting a Loaded Stopped Service
+
+To resume running a service which has been loaded but stopped (via the `hab service stop` subcommand explained above), you use the `hab service start` subcommand. Let's resume our `core/redis` service with:
+
+		hab service start core/redis
+
+<hr>
+<ul class="main-content--link-nav">
+  <li>Continue to the next topic</li>
+  <li><a href="/docs/run-packages-export">Export packages</a></li>
+</ul>

--- a/www/source/docs/run-packages-overview.html.md.erb
+++ b/www/source/docs/run-packages-overview.html.md.erb
@@ -4,9 +4,10 @@ title: How to run packages
 
 # Run packages
 
-Habitat packages are run under the Habitat supervisor. At runtime, you can join supervisors together in a service group running the same topology, send configuration updates to that group, and more. You can also export the supervisor together with the package to an external immutable format, such as a Docker container.
+Habitat packages used to start services which are run under the Habitat supervisor. At runtime, you can join supervisors together in a service group running the same topology, send configuration updates to that group, and more. You can also export the supervisor together with the package to an external immutable format, such as a Docker container.
 
-## Running packages for testing
+## Running single packages for testing
+
 Packages can be tested in the interactive studio environment or natively on a host machine running Linux. To run packages directly:
 
 1. [Build your package](/docs/create-packages-build) inside an interactive studio. Do not exit the studio after it is built.
@@ -26,20 +27,25 @@ If your host machine is running Linux, do the following to run your packages:
 
 ## Running packages in any environment
 
-The `hab` program can also be installed on servers. It will retrieve the necessary components (like the current release of the supervisor) in order to run packages. Thus, you can type `hab start yourorigin/yourname` on any compatible system.
+The `hab` program can also be installed on servers. It will retrieve the necessary components (like the current release of the supervisor) in order to run packages. Thus, you can start the supervisor on any compatible system. As the supervisor can run more than one service (for more details, see the [multiple services](/docs/run-packages-multiple-services) page), only one is necessary per host.
 
-You can also write an init script or a systemd unit file to start the supervisor. For example, for systemd:
+To start the supervisor, you can write an init script or a systemd unit file. For example, for systemd:
 
-       [Unit]
-       Description=My Habitat Application
+      [Unit]
+      Description=The Habitat Supervisor
 
-       [Service]
-       ExecStart=/usr/bin/hab start yourorigin/yourapp
+      [Service]
+      ExecStart=/bin/hab sup run
 
-       [Install]
-       WantedBy=default.target
+      [Install]
+      WantedBy=default.target
+
+Next use `hab service load` to load one or more services into the supervisor for permanent supervision. Using the example from above:
+
+      sudo hab service load yourorigin/yourname
 
 ## Section details
+
 This section is divided into the following areas:
 
 - [Service groups](/docs/run-packages-service-groups): Defines service groups and how to join them.
@@ -49,6 +55,7 @@ This section is divided into the following areas:
 - [Security](/docs/run-packages-security): Describes how to encrypt communication between supervisors, and between users and service groups.
 - [Binding](/docs/run-packages-binding): Learn how to bind to unknown service group names at runtime.
 - [Update strategy](/docs/run-packages-update-strategy): Describes how the supervisor and its peers within a service group should respond when a new version of a package is available.
+- [Multiple services](/docs/run-packages-multiple-services): Lean how to run multiple services with one supervisor.
 - [Export packages](/docs/run-packages-export): Learn how to export packages into multiple external, immutable runtime formats and work with container cluster managers like Kubernetes and Mesos.
 - [Monitor services through the HTTP API](/docs/run-packages-monitoring): Discover how to use the HTTP API to retrieve census, status, and health information from your running services.
 

--- a/www/source/docs/run-packages-update-strategy.html.md
+++ b/www/source/docs/run-packages-update-strategy.html.md
@@ -52,5 +52,5 @@ _At the moment, the `hab` command-line tool lacks the ability to create and mana
 <hr>
 <ul class="main-content--link-nav">
   <li>Continue to the next topic</li>
-  <li><a href="/docs/run-packages-export">Export packages</a></li>
+  <li><a href="/docs/run-packages-multiple-services">Multiple services</a></li>
 </ul>


### PR DESCRIPTION
The multi-tenant supervisor work is nearly complete but still lacks the ability to start a transient service vs a permanent service. Currently, any services started by `hab start` are recorded as a persistent service but this should instead be transient - a service which will not be started if the supervisor itself experiences a restart.

* Add `hab sup load` command to start or mark a running service as persistent
* Add `hab sup unload` command to remove a persistent service and stop it if it is running
* Modify `hab sup start <PKG_IDENT>` command to require an argument for `PKG_IDENT` and start it's target as a transient service
* Add `hab sup run` command to start a Supervisor with no additional transient services
* Add `hab sup stop` command to stop a running permanent or transient service
