### PR TITLE
Populate LD_RUN_PATH correctly

### DIFF
--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -1946,7 +1946,7 @@ _build_environment() {
       ld_run_path_part+=("$trimmed")
     fi
   done
-  if [[ -z $ld_run_path_part ]]; then
+  if [[ ! -z $ld_run_path_part ]]; then
     export LD_RUN_PATH=$(join_by ':' ${ld_run_path_part[@]})
   fi
 


### PR DESCRIPTION
This conditional was reversed, if ld_run_path_part is NOT empty, we
want to set the LD_RUN_PATH variable.

Signed-off-by: Steven Danna <steve@chef.io>