### PR TITLE
Bug fixes for builder

### DIFF
--- a/components/builder-api/src/config.rs
+++ b/components/builder-api/src/config.rs
@@ -100,6 +100,7 @@ impl ConfigFile for Config {
                              &mut cfg.depot.github_client_secret));
         try!(toml.parse_into("cfg.events_enabled", &mut cfg.events_enabled));
         try!(toml.parse_into("cfg.events_enabled", &mut cfg.depot.events_enabled));
+        try!(toml.parse_into("cfg.builds_enabled", &mut cfg.depot.builds_enabled));
         try!(toml.parse_into("pkg.svc_var_path", &mut cfg.log_dir));
         try!(toml.parse_into("pkg.svc_var_path", &mut cfg.depot.log_dir));
         try!(toml.parse_into("cfg.supported_targets", &mut cfg.depot.supported_targets));

--- a/components/builder-depot-client/src/lib.rs
+++ b/components/builder-depot-client/src/lib.rs
@@ -89,12 +89,12 @@ impl Into<depotsrv::OriginKeyIdent> for OriginKeyIdent {
 
 #[derive(Clone, Serialize, Deserialize)]
 pub struct OriginSecretKey {
-    pub id: String,
-    pub origin_id: String,
+    pub id: u64,
+    pub origin_id: u64,
     pub name: String,
     pub revision: String,
-    pub body: String,
-    pub owner_id: String,
+    pub body: Vec<u8>,
+    pub owner_id: u64,
 }
 
 #[derive(Clone, Deserialize)]

--- a/components/builder-worker/src/runner/mod.rs
+++ b/components/builder-worker/src/runner/mod.rs
@@ -152,7 +152,9 @@ impl Runner {
         match self.depot_cli.fetch_origin_secret_key(self.job().origin(), &self.auth_token) {
             Ok(key) => {
                 let cache = crypto::default_cache_key_path(None);
-                match crypto::SigKeyPair::write_file_from_str(&key.body, &cache) {
+                let s: String = String::from_utf8(key.body).expect("Found invalid UTF-8");
+
+                match crypto::SigKeyPair::write_file_from_str(&s, &cache) {
                     Ok((pair, pair_type)) => {
                         debug!("Imported {} origin key {}.",
                                &pair_type,


### PR DESCRIPTION
A couple of minor fixes:
1. The secret key protocol format changed during transition to origin server - the builder depot client needs to be updated to reflect that change.
2. The builds_enabled config also needs to be loaded in the builder-api.

Signed-off-by: Salim Alam <salam@chef.io>

![giphy 17](https://cloud.githubusercontent.com/assets/13542112/24782984/7a7e0532-1afe-11e7-8e07-e9900a78cffa.gif)
