### PR TITLE
Remove `pkg_source` from required plan variables.

### DIFF
--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -2657,7 +2657,6 @@ build_line "Validating plan metadata"
 required_variables=(
   pkg_name
   pkg_origin
-  pkg_source
   pkg_version
 )
 for var in "${required_variables[@]}"


### PR DESCRIPTION
The pkg_source variable is primarily only useful when building applications which are built from tarballs.

In cases were users build from local source, I think URI notation for this variable is the most desired option. However, there are many situations such as interpreted languages in which this variable doesn't serve a good purpose. Moreover, since the plan validation is run before we can inject scaffolding, we cannot optionally override the behavior in the validation for this variable for specific languages.

See original discussion in Slack as well:
https://habitat-sh.slack.com/archives/C0VBY57UP/p1491604342661130