### PR TITLE
Reformat with rustfmt 0.8.3

### DIFF
--- a/components/builder-api/src/http/handlers.rs
+++ b/components/builder-api/src/http/handlers.rs
@@ -95,10 +95,7 @@ pub fn job_create(req: &mut Request) -> IronResult<Response> {
         }
     }
     // TODO: SA - Eliminate need to clone the session
-    let session = req.extensions
-        .get::<Authenticated>()
-        .unwrap()
-        .clone();
+    let session = req.extensions.get::<Authenticated>().unwrap().clone();
     let mut conn = Broker::connect().unwrap();
     let project = match conn.route::<OriginProjectGet, OriginProject>(&project_get) {
         Ok(project) => project,
@@ -189,14 +186,8 @@ pub fn accept_invitation(req: &mut Request) -> IronResult<Response> {
     let mut request = OriginInvitationAcceptRequest::new();
     request.set_ignore(false);
     // TODO: SA - Eliminate need to clone the session and params
-    let session = req.extensions
-        .get::<Authenticated>()
-        .unwrap()
-        .clone();
-    let params = &req.extensions
-                      .get::<Router>()
-                      .unwrap()
-                      .clone();
+    let session = req.extensions.get::<Authenticated>().unwrap().clone();
+    let params = &req.extensions.get::<Router>().unwrap().clone();
 
     request.set_account_accepting_request(session.get_id());
     match params.find("invitation_id").unwrap().parse::<u64>() {
@@ -227,14 +218,8 @@ pub fn ignore_invitation(req: &mut Request) -> IronResult<Response> {
     let mut request = OriginInvitationAcceptRequest::new();
     request.set_ignore(true);
     // TODO: SA - Eliminate need to clone the session and params
-    let session = req.extensions
-        .get::<Authenticated>()
-        .unwrap()
-        .clone();
-    let params = &req.extensions
-                      .get::<Router>()
-                      .unwrap()
-                      .clone();
+    let session = req.extensions.get::<Authenticated>().unwrap().clone();
+    let params = &req.extensions.get::<Router>().unwrap().clone();
 
     request.set_account_accepting_request(session.get_id());
     match params.find("invitation_id").unwrap().parse::<u64>() {
@@ -265,10 +250,7 @@ pub fn project_create(req: &mut Request) -> IronResult<Response> {
     let mut project = OriginProject::new();
     let mut origin_get = OriginGet::new();
     let github = req.get::<persistent::Read<GitHubCli>>().unwrap();
-    let session = req.extensions
-        .get::<Authenticated>()
-        .unwrap()
-        .clone();
+    let session = req.extensions.get::<Authenticated>().unwrap().clone();
     let (organization, repo) = match req.get::<bodyparser::Struct<ProjectCreateReq>>() {
         Ok(Some(body)) => {
             if body.origin.len() <= 0 {

--- a/components/builder-core/src/file_walker.rs
+++ b/components/builder-core/src/file_walker.rs
@@ -24,7 +24,11 @@ pub struct FileWalker {
 
 impl FileWalker {
     pub fn new<T: AsRef<Path>>(path: T) -> Self {
-        FileWalker { walker: WalkDir::new(path.as_ref()).follow_links(false).into_iter() }
+        FileWalker {
+            walker: WalkDir::new(path.as_ref())
+                .follow_links(false)
+                .into_iter(),
+        }
     }
 }
 

--- a/components/builder-core/src/package_graph.rs
+++ b/components/builder-core/src/package_graph.rs
@@ -81,7 +81,8 @@ impl PackageGraph {
             assert_eq!(self.package_names[self.package_max], name);
 
             let node_index = self.graph.add_node(self.package_max);
-            self.package_map.insert(String::from(name), (self.package_max, node_index));
+            self.package_map
+                .insert(String::from(name), (self.package_max, node_index));
             self.package_max = self.package_max + 1;
 
             (self.package_max - 1, node_index)
@@ -178,8 +179,9 @@ impl PackageGraph {
                 .collect();
 
             // We can safely unwrap below since we checked the format
-            let mut pkgs: Vec<PackageIdent> =
-                v.iter().map(|x| PackageIdent::from_str(x).unwrap()).collect();
+            let mut pkgs: Vec<PackageIdent> = v.iter()
+                .map(|x| PackageIdent::from_str(x).unwrap())
+                .collect();
 
             // TODO: The PackageIdent compare is extremely slow, causing even small lists
             // to take significant time to sort. Look at speeding this up if it becomes a

--- a/components/builder-db/src/pool.rs
+++ b/components/builder-db/src/pool.rs
@@ -40,10 +40,12 @@ impl Pool {
                testing: bool)
                -> Result<Pool> {
         loop {
-            let pool_config_builder =
-                r2d2::Config::builder().pool_size(pool_size).connection_timeout(connection_timeout);
+            let pool_config_builder = r2d2::Config::builder()
+                .pool_size(pool_size)
+                .connection_timeout(connection_timeout);
             let pool_config = if testing {
-                pool_config_builder.connection_customizer(Box::new(TestConnectionCustomizer {}))
+                pool_config_builder
+                    .connection_customizer(Box::new(TestConnectionCustomizer {}))
                     .build()
             } else {
                 pool_config_builder.build()
@@ -88,9 +90,12 @@ impl r2d2::CustomizeConnection<postgres::Connection, r2d2_postgres::Error>
                                       schema_number);
         let sql_create_schema = format!("CREATE SCHEMA builder_db_test_{}", schema_number);
         let sql_search_path = format!("SET search_path TO builder_db_test_{}", schema_number);
-        conn.execute(&sql_drop_schema, &[]).map_err(r2d2_postgres::Error::Other)?;
-        conn.execute(&sql_create_schema, &[]).map_err(r2d2_postgres::Error::Other)?;
-        conn.execute(&sql_search_path, &[]).map_err(r2d2_postgres::Error::Other)?;
+        conn.execute(&sql_drop_schema, &[])
+            .map_err(r2d2_postgres::Error::Other)?;
+        conn.execute(&sql_create_schema, &[])
+            .map_err(r2d2_postgres::Error::Other)?;
+        conn.execute(&sql_search_path, &[])
+            .map_err(r2d2_postgres::Error::Other)?;
         Ok(())
     }
 }

--- a/components/builder-db/src/test.rs
+++ b/components/builder-db/src/test.rs
@@ -40,7 +40,9 @@ pub mod postgres {
 
     impl Postgres {
         fn new() -> Postgres {
-            let root_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests").join("db");
+            let root_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .join("tests")
+                .join("db");
             let start_path = root_path.join("start.sh");
             let child = Command::new("sudo")
                 .arg("-E")

--- a/components/builder-dbcache/src/data_store.rs
+++ b/components/builder-dbcache/src/data_store.rs
@@ -269,5 +269,7 @@ pub trait IndexSet: Bucket {
 }
 
 fn redis_connection_info(addr: &SocketAddr) -> redis::ConnectionInfo {
-    format!("redis://{}:{}", addr.ip(), addr.port()).into_connection_info().unwrap()
+    format!("redis://{}:{}", addr.ip(), addr.port())
+        .into_connection_info()
+        .unwrap()
 }

--- a/components/builder-depot-client/src/lib.rs
+++ b/components/builder-depot-client/src/lib.rs
@@ -114,14 +114,8 @@ impl Into<depotsrv::Package> for Package {
         out.set_ident(self.ident.into());
         out.set_checksum(self.checksum);
         out.set_manifest(self.manifest);
-        out.set_deps(self.deps
-                         .into_iter()
-                         .map(|m| m.into())
-                         .collect());
-        out.set_tdeps(self.tdeps
-                          .into_iter()
-                          .map(|m| m.into())
-                          .collect());
+        out.set_deps(self.deps.into_iter().map(|m| m.into()).collect());
+        out.set_tdeps(self.tdeps.into_iter().map(|m| m.into()).collect());
         out.set_exposes(self.exposes);
         out.set_config(self.config);
         out
@@ -196,7 +190,9 @@ impl Client {
     }
 
     pub fn show_origin_keys(&self, origin: &str) -> Result<Vec<depotsrv::OriginKeyIdent>> {
-        let mut res = try!(self.inner.get(&format!("origins/{}/keys", origin)).send());
+        let mut res = try!(self.inner
+                               .get(&format!("origins/{}/keys", origin))
+                               .send());
         debug!("Response: {:?}", res);
 
         if res.status != StatusCode::Ok {
@@ -275,8 +271,9 @@ impl Client {
     ///
     /// * Authorization token was not set on client
     pub fn fetch_origin_secret_key(&self, origin: &str, token: &str) -> Result<OriginSecretKey> {
-        let mut res = try!(self.add_authz(self.inner.get(&format!("origins/{}/secret_keys/latest",
-                                                                  origin)),
+        let mut res = try!(self.add_authz(self.inner
+                                              .get(&format!("origins/{}/secret_keys/latest",
+                                                            origin)),
                                           token)
                                .send());
         if res.status != StatusCode::Ok {
@@ -431,7 +428,9 @@ impl Client {
         let file_size = try!(file.metadata()).len();
         let path = format!("pkgs/{}", ident);
         let custom = |url: &mut Url| {
-            url.query_pairs_mut().append_pair("checksum", &checksum).append_pair("builder", "");
+            url.query_pairs_mut()
+                .append_pair("checksum", &checksum)
+                .append_pair("builder", "");
         };
         debug!("Reading from {}", &pa.path.display());
 
@@ -487,7 +486,9 @@ impl Client {
                           search_term: String)
                           -> Result<(Vec<hab_core::package::PackageIdent>, bool)> {
 
-        let mut res = try!(self.inner.get(&format!("pkgs/search/{}", search_term)).send());
+        let mut res = try!(self.inner
+                               .get(&format!("pkgs/search/{}", search_term))
+                               .send());
         match res.status {
             StatusCode::Ok |
             StatusCode::PartialContent => {
@@ -529,17 +530,20 @@ impl Client {
             Some(filename) => format!("{}", filename),
             None => return Err(Error::NoXFilename),
         };
-        let tmp_file_path =
-            dst_path.join(format!("{}.tmp-{}",
-                                  file_name,
-                                  thread_rng().gen_ascii_chars().take(8).collect::<String>()));
+        let tmp_file_path = dst_path.join(format!("{}.tmp-{}",
+                                                  file_name,
+                                                  thread_rng()
+                                                      .gen_ascii_chars()
+                                                      .take(8)
+                                                      .collect::<String>()));
         let dst_file_path = dst_path.join(file_name);
         debug!("Writing to {}", &tmp_file_path.display());
         let mut f = try!(File::create(&tmp_file_path));
         match progress {
             Some(mut progress) => {
-                let size: u64 =
-                    res.headers.get::<hyper::header::ContentLength>().map_or(0, |v| **v);
+                let size: u64 = res.headers
+                    .get::<hyper::header::ContentLength>()
+                    .map_or(0, |v| **v);
                 progress.size(size);
                 let mut writer = BroadcastWriter::new(&mut f, progress);
                 try!(io::copy(&mut res, &mut writer))

--- a/components/builder-depot/src/data_store.rs
+++ b/components/builder-depot/src/data_store.rs
@@ -59,18 +59,12 @@ impl DataStore {
     /// * If a read-write transaction could not be acquired for any of the databases in the
     ///   datastore
     pub fn clear(&self) -> Result<()> {
-        try!(redis::cmd("FLUSHDB").query(self.pool
-                                             .get()
-                                             .unwrap()
-                                             .deref()));
+        try!(redis::cmd("FLUSHDB").query(self.pool.get().unwrap().deref()));
         Ok(())
     }
 
     pub fn key_count(&self) -> Result<usize> {
-        let count = try!(redis::cmd("DBSIZE").query(self.pool
-                                                        .get()
-                                                        .unwrap()
-                                                        .deref()));
+        let count = try!(redis::cmd("DBSIZE").query(self.pool.get().unwrap().deref()));
         Ok(count)
     }
 }
@@ -152,10 +146,13 @@ impl PackagesIndex {
             Ok(ids) => {
                 // JW TODO: This in-memory sorting logic can be removed once the Redis sorted set
                 // is pre-sorted on write. For now, we'll do it on read each time.
-                let mut ids: Vec<package::PackageIdent> =
-                    ids.iter().map(|id| package::PackageIdent::from_str(id).unwrap()).collect();
+                let mut ids: Vec<package::PackageIdent> = ids.iter()
+                    .map(|id| package::PackageIdent::from_str(id).unwrap())
+                    .collect();
                 ids.sort();
-                let ids = ids.into_iter().map(|id| depotsrv::PackageIdent::from(id)).collect();
+                let ids = ids.into_iter()
+                    .map(|id| depotsrv::PackageIdent::from(id))
+                    .collect();
                 Ok(ids)
             }
             Err(e) => Err(Error::from(e)),
@@ -180,7 +177,9 @@ impl PackagesIndex {
                          })
                     .collect();
                 idz.sort();
-                let new_ids = idz.into_iter().map(|zd| depotsrv::PackageIdent::from(zd)).collect();
+                let new_ids = idz.into_iter()
+                    .map(|zd| depotsrv::PackageIdent::from(zd))
+                    .collect();
                 Ok(new_ids)
             }
             Err(e) => Err(Error::from(e)),
@@ -414,8 +413,10 @@ impl ChannelsTable {
         let key = format!("{}/{}", origin, channel);
 
         if let Some(packages) = self.channel_package_map.get(&key) {
-            let mut pkgs: Vec<&depotsrv::PackageIdent> =
-                packages.iter().filter(|pkg| pkg.to_string().contains(ident)).collect();
+            let mut pkgs: Vec<&depotsrv::PackageIdent> = packages
+                .iter()
+                .filter(|pkg| pkg.to_string().contains(ident))
+                .collect();
 
             if pkgs.is_empty() {
                 return None;
@@ -442,7 +443,8 @@ impl ChannelsTable {
         let key = format!("{}/{}", origin, channel);
 
         if let Some(packages) = self.channel_package_map.get(&key) {
-            packages.iter()
+            packages
+                .iter()
                 .enumerate()
                 .filter(|&(i, pkg)| if ident == origin {
                             i >= start as usize && i <= stop as usize
@@ -560,7 +562,8 @@ impl ChannelPkgIndex {
                 // JW TODO: This in-memory sorting logic can be removed once the Redis sorted set
                 // is pre-sorted on write. For now, we'll do it on read each time.
                 let mut set: Vec<package::PackageIdent> =
-                    set.map(|(id, _)| package::PackageIdent::from_str(&id).unwrap()).collect();
+                    set.map(|(id, _)| package::PackageIdent::from_str(&id).unwrap())
+                        .collect();
                 set.sort();
                 set.reverse();
                 Ok(set)

--- a/components/builder-depot/src/doctor.rs
+++ b/components/builder-depot/src/doctor.rs
@@ -163,18 +163,14 @@ impl<'a> Doctor<'a> {
         match fs::metadata(&self.depot.config.path) {
             Ok(meta) => {
                 if meta.is_file() {
-                    self.report.failure(OperationType::InitDepotFs(self.depot
-                                                                       .config
-                                                                       .path
-                                                                       .clone()),
-                                        Reason::FileExists);
+                    self.report
+                        .failure(OperationType::InitDepotFs(self.depot.config.path.clone()),
+                                 Reason::FileExists);
                 }
                 if meta.permissions().readonly() {
-                    self.report.failure(OperationType::InitDepotFs(self.depot
-                                                                       .config
-                                                                       .path
-                                                                       .clone()),
-                                        Reason::BadPermissions);
+                    self.report
+                        .failure(OperationType::InitDepotFs(self.depot.config.path.clone()),
+                                 Reason::BadPermissions);
                 }
                 try!(fs::create_dir_all(&self.depot.packages_path()));
             }
@@ -198,10 +194,7 @@ impl<'a> Doctor<'a> {
                 Ok(ident) => {
                     match depotsrv::Package::from_archive(&mut archive) {
                         Ok(object) => {
-                            try!(self.depot
-                                     .datastore
-                                     .packages
-                                     .write(&object));
+                            try!(self.depot.datastore.packages.write(&object));
                             let path = self.depot.archive_path(&ident, &try!(archive.target()));
                             if let Some(e) = fs::create_dir_all(path.parent().unwrap()).err() {
                                 self.report
@@ -227,7 +220,8 @@ impl<'a> Doctor<'a> {
                             // We should be moving this back to the garbage directory and recording
                             // the path of it there in this failure
                             self.report
-                                .failure(OperationType::ArchiveInsert(entry.path()
+                                .failure(OperationType::ArchiveInsert(entry
+                                                                          .path()
                                                                           .to_string_lossy()
                                                                           .to_string()),
                                          Reason::BadMetadata(e));
@@ -236,10 +230,12 @@ impl<'a> Doctor<'a> {
                 }
                 Err(e) => {
                     debug!("Error reading, archive={:?} error={:?}", &archive, &e);
-                    self.report.failure(OperationType::ArchiveInsert(entry.path()
-                                                                         .to_string_lossy()
-                                                                         .to_string()),
-                                        Reason::BadArchive);
+                    self.report
+                        .failure(OperationType::ArchiveInsert(entry
+                                                                  .path()
+                                                                  .to_string_lossy()
+                                                                  .to_string()),
+                                 Reason::BadArchive);
                 }
             }
         }
@@ -247,10 +243,11 @@ impl<'a> Doctor<'a> {
         for dir in directories.iter() {
             if let Some(e) = fs::remove_dir(dir.path()).err() {
                 debug!("Error deleting: {:?}", &e);
-                self.report.failure(OperationType::CleanupTrash(self.packages_path
-                                                                    .to_string_lossy()
-                                                                    .to_string()),
-                                    Reason::NotEmpty);
+                self.report
+                    .failure(OperationType::CleanupTrash(self.packages_path
+                                                             .to_string_lossy()
+                                                             .to_string()),
+                             Reason::NotEmpty);
             }
         }
         Ok(())
@@ -259,7 +256,8 @@ impl<'a> Doctor<'a> {
     fn truncate_datastore(&mut self, datastore: &DataStore) -> Result<()> {
         let count = try!(datastore.key_count());
         try!(datastore.clear());
-        self.report.success(OperationType::TruncateDataStore(count));
+        self.report
+            .success(OperationType::TruncateDataStore(count));
         Ok(())
     }
 }

--- a/components/builder-depot/src/lib.rs
+++ b/components/builder-depot/src/lib.rs
@@ -161,7 +161,9 @@ impl DepotUtil {
         let mut output = [0; 64];
         digest.input_str(&ident.to_string());
         digest.result(&mut output);
-        self.packages_path().join(format!("{:x}", output[0])).join(format!("{:x}", output[1]))
+        self.packages_path()
+            .join(format!("{:x}", output[0]))
+            .join(format!("{:x}", output[1]))
     }
 
     fn packages_path(&self) -> PathBuf {

--- a/components/builder-depot/src/server.rs
+++ b/components/builder-depot/src/server.rs
@@ -238,14 +238,8 @@ pub fn check_origin_access<T: ToString>(req: &mut Request,
 
 pub fn invite_to_origin(req: &mut Request) -> IronResult<Response> {
     // TODO: SA - Eliminate need to clone the session and params
-    let session = req.extensions
-        .get::<Authenticated>()
-        .unwrap()
-        .clone();
-    let params = req.extensions
-        .get::<Router>()
-        .unwrap()
-        .clone();
+    let session = req.extensions.get::<Authenticated>().unwrap().clone();
+    let params = req.extensions.get::<Router>().unwrap().clone();
     let origin = match params.find("origin") {
         Some(origin) => origin,
         None => return Ok(Response::with(status::BadRequest)),
@@ -393,14 +387,8 @@ fn write_archive(filename: &PathBuf, body: &mut Body) -> Result<PackageArchive> 
 fn upload_origin_key(req: &mut Request) -> IronResult<Response> {
     debug!("Upload Origin Public Key {:?}", req);
     // TODO: SA - Eliminate need to clone the session and params
-    let session = req.extensions
-        .get::<Authenticated>()
-        .unwrap()
-        .clone();
-    let params = req.extensions
-        .get::<Router>()
-        .unwrap()
-        .clone();
+    let session = req.extensions.get::<Authenticated>().unwrap().clone();
+    let params = req.extensions.get::<Router>().unwrap().clone();
     let mut conn = Broker::connect().unwrap();
     let mut request = OriginPublicKeyCreate::new();
     request.set_owner_id(session.get_id());
@@ -470,7 +458,9 @@ fn upload_origin_key(req: &mut Request) -> IronResult<Response> {
                                 format!("/origins/{}/keys/{}", &origin, &request.get_revision())));
             let mut base_url: url::Url = req.url.clone().into();
             base_url.set_path(&format!("key/{}-{}", &origin, &request.get_revision()));
-            response.headers.set(headers::Location(format!("{}", base_url)));
+            response
+                .headers
+                .set(headers::Location(format!("{}", base_url)));
             Ok(response)
         }
         Err(err) => Ok(render_net_error(&err)),
@@ -500,14 +490,8 @@ fn download_latest_origin_secret_key(req: &mut Request) -> IronResult<Response> 
 fn upload_origin_secret_key(req: &mut Request) -> IronResult<Response> {
     debug!("Upload Origin Secret Key {:?}", req);
     // TODO: SA - Eliminate need to clone the session and params
-    let session = req.extensions
-        .get::<Authenticated>()
-        .unwrap()
-        .clone();
-    let params = req.extensions
-        .get::<Router>()
-        .unwrap()
-        .clone();
+    let session = req.extensions.get::<Authenticated>().unwrap().clone();
+    let params = req.extensions.get::<Router>().unwrap().clone();
     let mut conn = Broker::connect().unwrap();
     let mut request = OriginSecretKeyCreate::new();
     request.set_owner_id(session.get_id());
@@ -579,7 +563,8 @@ fn upload_origin_secret_key(req: &mut Request) -> IronResult<Response> {
 }
 
 fn upload_package(req: &mut Request) -> IronResult<Response> {
-    let lock = req.get::<persistent::State<Depot>>().expect("depot not found");
+    let lock = req.get::<persistent::State<Depot>>()
+        .expect("depot not found");
     let depot = lock.read().expect("depot read lock is poisoned");
     let checksum_from_param = match extract_query_value("checksum", req) {
         Some(checksum) => checksum,
@@ -600,10 +585,7 @@ fn upload_package(req: &mut Request) -> IronResult<Response> {
            ident);
 
     // TODO: SA - Eliminate need to clone the session
-    let session = req.extensions
-        .get::<Authenticated>()
-        .unwrap()
-        .clone();
+    let session = req.extensions.get::<Authenticated>().unwrap().clone();
     if !depot.config.insecure {
         if !try!(check_origin_access(req, session.get_id(), &ident.get_origin())) {
             return Ok(Response::with(status::Forbidden));
@@ -640,7 +622,10 @@ fn upload_package(req: &mut Request) -> IronResult<Response> {
         }
     };
 
-    if !depot.config.supported_targets.contains(&target_from_artifact) {
+    if !depot
+            .config
+            .supported_targets
+            .contains(&target_from_artifact) {
         debug!("Unsupported package platform or architecture {}.",
                target_from_artifact);
         return Ok(Response::with(status::NotImplemented));
@@ -696,10 +681,7 @@ fn upload_package(req: &mut Request) -> IronResult<Response> {
         }
     };
     if ident.satisfies(object.get_ident()) {
-        depot.datastore
-            .packages
-            .write(&object)
-            .unwrap();
+        depot.datastore.packages.write(&object).unwrap();
 
         log_event!(req,
                    Event::PackageUpload {
@@ -739,7 +721,9 @@ fn upload_package(req: &mut Request) -> IronResult<Response> {
                                            format!("/pkgs/{}/download", object.get_ident())));
         let mut base_url: url::Url = req.url.clone().into();
         base_url.set_path(&format!("pkgs/{}/download", object.get_ident()));
-        response.headers.set(headers::Location(format!("{}", base_url)));
+        response
+            .headers
+            .set(headers::Location(format!("{}", base_url)));
         Ok(response)
     } else {
         info!("Ident mismatch, expected={:?}, got={:?}",
@@ -750,10 +734,7 @@ fn upload_package(req: &mut Request) -> IronResult<Response> {
 }
 
 fn schedule(req: &mut Request) -> IronResult<Response> {
-    let params = req.extensions
-        .get::<Router>()
-        .unwrap()
-        .clone();
+    let params = req.extensions.get::<Router>().unwrap().clone();
     let origin = match params.find("origin") {
         Some(origin) => origin,
         None => return Ok(Response::with(status::BadRequest)),
@@ -811,10 +792,7 @@ fn get_schedule(req: &mut Request) -> IronResult<Response> {
 fn download_origin_key(req: &mut Request) -> IronResult<Response> {
     let params = req.extensions.get::<Router>().unwrap();
     // TODO: SA - Eliminate need to clone the session and params
-    let session = req.extensions
-        .get::<Authenticated>()
-        .unwrap()
-        .clone();
+    let session = req.extensions.get::<Authenticated>().unwrap().clone();
     let mut conn = Broker::connect().unwrap();
     let mut request = OriginPublicKeyGet::new();
     request.set_owner_id(session.get_id());
@@ -837,7 +815,9 @@ fn download_origin_key(req: &mut Request) -> IronResult<Response> {
 
     let xfilename = format!("{}-{}.pub", key.get_name(), key.get_revision());
     let mut response = Response::with((status::Ok, key.get_body()));
-    response.headers.set(ContentDisposition(format!("attachment; filename=\"{}\"", xfilename)));
+    response
+        .headers
+        .set(ContentDisposition(format!("attachment; filename=\"{}\"", xfilename)));
     response.headers.set(XFileName(xfilename));
     do_cache_response(&mut response);
     Ok(response)
@@ -846,10 +826,7 @@ fn download_origin_key(req: &mut Request) -> IronResult<Response> {
 fn download_latest_origin_key(req: &mut Request) -> IronResult<Response> {
     let params = req.extensions.get::<Router>().unwrap();
     // TODO: SA - Eliminate need to clone the session and params
-    let session = req.extensions
-        .get::<Authenticated>()
-        .unwrap()
-        .clone();
+    let session = req.extensions.get::<Authenticated>().unwrap().clone();
     let mut conn = Broker::connect().unwrap();
     let mut request = OriginPublicKeyLatestGet::new();
     request.set_owner_id(session.get_id());
@@ -868,7 +845,9 @@ fn download_latest_origin_key(req: &mut Request) -> IronResult<Response> {
 
     let xfilename = format!("{}-{}.pub", key.get_name(), key.get_revision());
     let mut response = Response::with((status::Ok, key.get_body()));
-    response.headers.set(ContentDisposition(format!("attachment; filename=\"{}\"", xfilename)));
+    response
+        .headers
+        .set(ContentDisposition(format!("attachment; filename=\"{}\"", xfilename)));
     response.headers.set(XFileName(xfilename));
     dont_cache_response(&mut response);
     Ok(response)
@@ -877,7 +856,8 @@ fn download_latest_origin_key(req: &mut Request) -> IronResult<Response> {
 
 
 fn download_package(req: &mut Request) -> IronResult<Response> {
-    let lock = req.get::<persistent::State<Depot>>().expect("depot not found");
+    let lock = req.get::<persistent::State<Depot>>()
+        .expect("depot not found");
     let depot = lock.read().expect("depot read lock is poisoned");
     let params = req.extensions.get::<Router>().unwrap();
     let ident = ident_from_params(params);
@@ -895,7 +875,8 @@ fn download_package(req: &mut Request) -> IronResult<Response> {
                     Ok(_) => {
                         let mut response = Response::with((status::Ok, archive.path.clone()));
                         do_cache_response(&mut response);
-                        response.headers
+                        response
+                            .headers
                             .set(ContentDisposition(format!("attachment; filename=\"{}\"",
                                                             archive.file_name())));
                         response.headers.set(XFileName(archive.file_name()));
@@ -958,7 +939,8 @@ fn list_origin_keys(req: &mut Request) -> IronResult<Response> {
 }
 
 fn list_unique_packages(req: &mut Request) -> IronResult<Response> {
-    let lock = req.get::<persistent::State<Depot>>().expect("depot not found");
+    let lock = req.get::<persistent::State<Depot>>()
+        .expect("depot not found");
     let depot = lock.read().expect("depot read lock is poisoned");
     let (start, stop) = match extract_pagination(req) {
         Ok(range) => range,
@@ -970,12 +952,14 @@ fn list_unique_packages(req: &mut Request) -> IronResult<Response> {
         None => return Ok(Response::with(status::BadRequest)),
     };
 
-    match depot.datastore
+    match depot
+              .datastore
               .packages
               .index
               .unique(&ident, start, stop) {
         Ok(packages) => {
-            let count = depot.datastore
+            let count = depot
+                .datastore
                 .packages
                 .index
                 .count_unique(&ident)
@@ -992,9 +976,11 @@ fn list_unique_packages(req: &mut Request) -> IronResult<Response> {
                 Response::with((status::Ok, body))
             };
 
-            response.headers.set(ContentType(Mime(TopLevel::Application,
-                                                  SubLevel::Json,
-                                                  vec![(Attr::Charset, Value::Utf8)])));
+            response
+                .headers
+                .set(ContentType(Mime(TopLevel::Application,
+                                      SubLevel::Json,
+                                      vec![(Attr::Charset, Value::Utf8)])));
             dont_cache_response(&mut response);
             Ok(response)
         }
@@ -1009,7 +995,8 @@ fn list_unique_packages(req: &mut Request) -> IronResult<Response> {
 }
 
 fn list_packages(req: &mut Request) -> IronResult<Response> {
-    let lock = req.get::<persistent::State<Depot>>().expect("depot not found");
+    let lock = req.get::<persistent::State<Depot>>()
+        .expect("depot not found");
     let mut depot = lock.write().expect("depot read lock is poisoned");
     let (start, stop) = match extract_pagination(req) {
         Ok(range) => range,
@@ -1046,12 +1033,17 @@ fn list_packages(req: &mut Request) -> IronResult<Response> {
     match channel {
         Some(channel) => {
             // let's make sure this channel actually exists
-            if !depot.datastore.channels.channel_exists(&origin, &channel) {
+            if !depot
+                    .datastore
+                    .channels
+                    .channel_exists(&origin, &channel) {
                 return Ok(Response::with(status::NotFound));
             }
 
-            let packages =
-                depot.datastore.channels.all_packages(&origin, &channel, &ident, start, stop);
+            let packages = depot
+                .datastore
+                .channels
+                .all_packages(&origin, &channel, &ident, start, stop);
             let count = packages.len();
             let body = package_results_json(&packages, count as isize, start, stop);
 
@@ -1061,24 +1053,23 @@ fn list_packages(req: &mut Request) -> IronResult<Response> {
                 Response::with((status::Ok, body))
             };
 
-            response.headers.set(ContentType(Mime(TopLevel::Application,
-                                                  SubLevel::Json,
-                                                  vec![(Attr::Charset, Value::Utf8)])));
+            response
+                .headers
+                .set(ContentType(Mime(TopLevel::Application,
+                                      SubLevel::Json,
+                                      vec![(Attr::Charset, Value::Utf8)])));
 
             dont_cache_response(&mut response);
             Ok(response)
         }
         None => {
-            match depot.datastore
+            match depot
+                      .datastore
                       .packages
                       .index
                       .list(&ident, start, stop) {
                 Ok(packages) => {
-                    let count = depot.datastore
-                        .packages
-                        .index
-                        .count(&ident)
-                        .unwrap();
+                    let count = depot.datastore.packages.index.count(&ident).unwrap();
                     debug!("list_packages start: {}, stop: {}, total count: {}",
                            start,
                            stop,
@@ -1091,9 +1082,11 @@ fn list_packages(req: &mut Request) -> IronResult<Response> {
                         Response::with((status::Ok, body))
                     };
 
-                    response.headers.set(ContentType(Mime(TopLevel::Application,
-                                                          SubLevel::Json,
-                                                          vec![(Attr::Charset, Value::Utf8)])));
+                    response
+                        .headers
+                        .set(ContentType(Mime(TopLevel::Application,
+                                              SubLevel::Json,
+                                              vec![(Attr::Charset, Value::Utf8)])));
                     dont_cache_response(&mut response);
                     Ok(response)
                 }
@@ -1110,7 +1103,8 @@ fn list_packages(req: &mut Request) -> IronResult<Response> {
 }
 
 fn list_channels(req: &mut Request) -> IronResult<Response> {
-    let lock = req.get::<persistent::State<Depot>>().expect("depot not found");
+    let lock = req.get::<persistent::State<Depot>>()
+        .expect("depot not found");
     let mut depot = lock.write().expect("depot read lock is poisoned");
     let params = req.extensions.get::<Router>().unwrap();
 
@@ -1126,7 +1120,8 @@ fn list_channels(req: &mut Request) -> IronResult<Response> {
 }
 
 fn create_channel(req: &mut Request) -> IronResult<Response> {
-    let lock = req.get::<persistent::State<Depot>>().expect("depot not found");
+    let lock = req.get::<persistent::State<Depot>>()
+        .expect("depot not found");
     let mut depot = lock.write().expect("depot write lock is poisoned");
 
     let session_id: u64;
@@ -1164,7 +1159,8 @@ fn create_channel(req: &mut Request) -> IronResult<Response> {
 }
 
 fn delete_channel(req: &mut Request) -> IronResult<Response> {
-    let lock = req.get::<persistent::State<Depot>>().expect("depot not found");
+    let lock = req.get::<persistent::State<Depot>>()
+        .expect("depot not found");
     let mut depot = lock.write().expect("depot write lock is poisoned");
 
     let session_id: u64;
@@ -1204,7 +1200,8 @@ fn delete_channel(req: &mut Request) -> IronResult<Response> {
 }
 
 fn show_package(req: &mut Request) -> IronResult<Response> {
-    let lock = req.get::<persistent::State<Depot>>().expect("depot not found");
+    let lock = req.get::<persistent::State<Depot>>()
+        .expect("depot not found");
     let mut depot = lock.write().expect("depot read lock is poisoned");
 
     let (origin, mut ident, channel) = {
@@ -1232,12 +1229,18 @@ fn show_package(req: &mut Request) -> IronResult<Response> {
 
     if let Some(channel) = channel {
         // let's make sure this channel actually exists
-        if !depot.datastore.channels.channel_exists(&origin, &channel) {
+        if !depot
+                .datastore
+                .channels
+                .channel_exists(&origin, &channel) {
             return Ok(Response::with(status::NotFound));
         }
 
         if !ident.fully_qualified() {
-            match depot.datastore.channels.latest(&origin, channel.as_str(), &ident.to_string()) {
+            match depot
+                      .datastore
+                      .channels
+                      .latest(&origin, channel.as_str(), &ident.to_string()) {
                 Some(ident) => {
                     match depot.datastore.packages.find(&ident) {
                         Ok(pkg) => render_package(&pkg, false),
@@ -1269,7 +1272,8 @@ fn show_package(req: &mut Request) -> IronResult<Response> {
         if !ident.fully_qualified() {
             let agent_target = target_from_headers(&req.headers.get::<UserAgent>().unwrap())
                 .unwrap();
-            match depot.datastore
+            match depot
+                      .datastore
                       .packages
                       .index
                       .latest(&ident, &agent_target.to_string()) {
@@ -1304,7 +1308,8 @@ fn show_package(req: &mut Request) -> IronResult<Response> {
 }
 
 fn search_packages(req: &mut Request) -> IronResult<Response> {
-    let lock = req.get::<persistent::State<Depot>>().expect("depot not found");
+    let lock = req.get::<persistent::State<Depot>>()
+        .expect("depot not found");
     let depot = lock.read().expect("depot read lock is poisoned");
     let (start, stop) = match extract_pagination(req) {
         Ok(range) => range,
@@ -1318,7 +1323,8 @@ fn search_packages(req: &mut Request) -> IronResult<Response> {
     Gauge::PackageCount.set(depot.datastore.key_count().unwrap() as f64);
 
     // Note: the search call takes offset and count values
-    let (packages, total_count) = depot.datastore
+    let (packages, total_count) = depot
+        .datastore
         .packages
         .index
         .search(partial, start, stop - start + 1)
@@ -1338,9 +1344,11 @@ fn search_packages(req: &mut Request) -> IronResult<Response> {
         Response::with((status::Ok, body))
     };
 
-    response.headers.set(ContentType(Mime(TopLevel::Application,
-                                          SubLevel::Json,
-                                          vec![(Attr::Charset, Value::Utf8)])));
+    response
+        .headers
+        .set(ContentType(Mime(TopLevel::Application,
+                              SubLevel::Json,
+                              vec![(Attr::Charset, Value::Utf8)])));
 
     dont_cache_response(&mut response);
     Ok(response)
@@ -1349,10 +1357,14 @@ fn search_packages(req: &mut Request) -> IronResult<Response> {
 fn render_package(pkg: &depotsrv::Package, should_cache: bool) -> IronResult<Response> {
     let body = serde_json::to_string(&pkg).unwrap();
     let mut response = Response::with((status::Ok, body));
-    response.headers.set(ETag(pkg.get_checksum().to_string()));
-    response.headers.set(ContentType(Mime(TopLevel::Application,
-                                          SubLevel::Json,
-                                          vec![(Attr::Charset, Value::Utf8)])));
+    response
+        .headers
+        .set(ETag(pkg.get_checksum().to_string()));
+    response
+        .headers
+        .set(ContentType(Mime(TopLevel::Application,
+                              SubLevel::Json,
+                              vec![(Attr::Charset, Value::Utf8)])));
     if should_cache {
         do_cache_response(&mut response);
     } else {
@@ -1362,7 +1374,8 @@ fn render_package(pkg: &depotsrv::Package, should_cache: bool) -> IronResult<Res
 }
 
 fn promote_package(req: &mut Request) -> IronResult<Response> {
-    let lock = req.get::<persistent::State<Depot>>().expect("depot not found");
+    let lock = req.get::<persistent::State<Depot>>()
+        .expect("depot not found");
     let mut depot = lock.write().expect("depot write lock is poisoned");
     let (channel, origin, mut ident, session_id) = {
         let session = req.extensions.get::<Authenticated>().unwrap();
@@ -1407,7 +1420,10 @@ fn promote_package(req: &mut Request) -> IronResult<Response> {
     }
     ident.set_origin(origin);
 
-    match depot.datastore.channels.channel_exists(&ident.get_origin(), &channel) {
+    match depot
+              .datastore
+              .channels
+              .channel_exists(&ident.get_origin(), &channel) {
         true => {
             if !try!(check_origin_access(req, session_id, &ident.get_origin())) {
                 return Ok(Response::with(status::Forbidden));
@@ -1415,7 +1431,8 @@ fn promote_package(req: &mut Request) -> IronResult<Response> {
 
             match depot.datastore.packages.find(&ident) {
                 Ok(package) => {
-                    depot.datastore
+                    depot
+                        .datastore
                         .channels
                         .associate(&channel, &package)
                         .unwrap();
@@ -1451,8 +1468,9 @@ fn target_from_headers(user_agent_header: &UserAgent) -> result::Result<PackageT
 
     let user_agent_regex = Regex::new(r"(?P<client>\.*)\s\((?P<target>\w+-\w+); (?P<kernel>.*)\)")
         .unwrap();
-    let user_agent_capture =
-        user_agent_regex.captures(user_agent).expect("Invalid user agent supplied.");
+    let user_agent_capture = user_agent_regex
+        .captures(user_agent)
+        .expect("Invalid user agent supplied.");
     match PackageTarget::from_str(&user_agent_capture["target"]) {
         Ok(target) => Ok(target),
         Err(_) => Err(Response::with(status::BadRequest)),
@@ -1500,11 +1518,15 @@ fn extract_query_value(key: &str, req: &mut Request) -> Option<String> {
 }
 
 fn do_cache_response(response: &mut Response) {
-    response.headers.set(CacheControl(format!("public, max-age={}", ONE_YEAR_IN_SECS)));
+    response
+        .headers
+        .set(CacheControl(format!("public, max-age={}", ONE_YEAR_IN_SECS)));
 }
 
 fn dont_cache_response(response: &mut Response) {
-    response.headers.set(CacheControl(format!("private, no-cache, no-store")));
+    response
+        .headers
+        .set(CacheControl(format!("private, no-cache, no-store")));
 }
 
 pub fn routes<M: BeforeMiddleware + Clone>(insecure: bool, basic: M, worker: M) -> Router {
@@ -1657,7 +1679,10 @@ mod test {
     }
 
     pub fn hart_file(name: &str) -> PathBuf {
-        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests").join("fixtures").join(name)
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests")
+            .join("fixtures")
+            .join(name)
     }
 
     fn iron_request(method: method::Method,

--- a/components/builder-jobsrv/src/data_store.rs
+++ b/components/builder-jobsrv/src/data_store.rs
@@ -57,8 +57,9 @@ impl DataStore {
         migrator.setup()?;
 
         // The core jobs table
-        migrator.migrate("jobsrv",
-                         r#"CREATE TABLE jobs (
+        migrator
+            .migrate("jobsrv",
+                     r#"CREATE TABLE jobs (
                                     id bigint PRIMARY KEY,
                                     owner_id bigint,
                                     job_state text,
@@ -102,7 +103,8 @@ impl DataStore {
         // generate Job structs, and keeps things DRY.
         //
         // Just make sure you always address the columns by name, not by position.
-        migrator.migrate("jobsrv",
+        migrator
+            .migrate("jobsrv",
                      r#"CREATE OR REPLACE FUNCTION get_job_v1 (jid bigint) RETURNS SETOF jobs AS $$
                             BEGIN
                               RETURN QUERY SELECT * FROM jobs WHERE id = jid;

--- a/components/builder-jobsrv/src/server/worker_manager.rs
+++ b/components/builder-jobsrv/src/server/worker_manager.rs
@@ -112,13 +112,16 @@ impl WorkerMgr {
             let cfg = self.config.read().unwrap();
             println!("Listening for commands on {}",
                      cfg.worker_command_addr.to_addr_string());
-            try!(self.rq_sock.bind(&cfg.worker_command_addr.to_addr_string()));
+            try!(self.rq_sock
+                     .bind(&cfg.worker_command_addr.to_addr_string()));
             println!("Listening for heartbeats on {}",
                      cfg.worker_heartbeat_addr.to_addr_string());
-            try!(self.hb_sock.bind(&cfg.worker_heartbeat_addr.to_addr_string()));
+            try!(self.hb_sock
+                     .bind(&cfg.worker_heartbeat_addr.to_addr_string()));
             println!("Publishing job status on {}",
                      cfg.status_publisher_addr.to_addr_string());
-            try!(self.pub_sock.bind(&cfg.status_publisher_addr.to_addr_string()));
+            try!(self.pub_sock
+                     .bind(&cfg.status_publisher_addr.to_addr_string()));
         }
         let mut hb_sock = false;
         let mut rq_sock = false;
@@ -196,7 +199,9 @@ impl WorkerMgr {
                         self.datastore.set_job_state(&job)?;
                         continue;
                     }
-                    if self.rq_sock.send(&job.write_to_bytes().unwrap(), 0).is_err() {
+                    if self.rq_sock
+                           .send(&job.write_to_bytes().unwrap(), 0)
+                           .is_err() {
                         debug!("failed to send, worker went away, worker={:?}", worker);
                         job.set_state(jobsrv::JobState::Pending);
                         self.datastore.set_job_state(&job)?;
@@ -238,7 +243,8 @@ impl WorkerMgr {
             jobsrv::WorkerState::Ready => {
                 let now = Instant::now();
                 let expiry = now + Duration::from_millis(WORKER_TIMEOUT_MS);
-                self.workers.insert(heartbeat.get_endpoint().to_string(), expiry);
+                self.workers
+                    .insert(heartbeat.get_endpoint().to_string(), expiry);
             }
             jobsrv::WorkerState::Busy => {
                 self.workers.remove(heartbeat.get_endpoint());

--- a/components/builder-originsrv/src/data_store.rs
+++ b/components/builder-originsrv/src/data_store.rs
@@ -301,7 +301,9 @@ impl DataStore {
                                 &format!("{}-{}", osk.get_name(), osk.get_revision()),
                                 &osk.get_body()])
             .map_err(Error::OriginSecretKeyCreate)?;
-        let row = rows.iter().nth(0).expect("Insert returns row, but no row present");
+        let row = rows.iter()
+            .nth(0)
+            .expect("Insert returns row, but no row present");
         Ok(self.row_to_origin_secret_key(row))
     }
 
@@ -347,7 +349,9 @@ impl DataStore {
                                 &format!("{}-{}", opk.get_name(), opk.get_revision()),
                                 &opk.get_body()])
             .map_err(Error::OriginPublicKeyCreate)?;
-        let row = rows.iter().nth(0).expect("Insert returns row, but no row present");
+        let row = rows.iter()
+            .nth(0)
+            .expect("Insert returns row, but no row present");
         Ok(self.row_to_origin_public_key(row))
     }
 
@@ -439,7 +443,9 @@ impl DataStore {
                                 &origin.get_owner_name()])
             .map_err(Error::OriginCreate)?;
         if rows.len() == 1 {
-            let row = rows.iter().nth(0).expect("Insert returns row, but no row present");
+            let row = rows.iter()
+                .nth(0)
+                .expect("Insert returns row, but no row present");
             Ok(Some(self.row_to_origin(row)))
         } else {
             Ok(None)

--- a/components/builder-originsrv/src/migrations/origin_invitations.rs
+++ b/components/builder-originsrv/src/migrations/origin_invitations.rs
@@ -17,10 +17,12 @@ use db::migration::Migrator;
 use error::Result;
 
 pub fn migrate(migrator: &mut Migrator) -> Result<()> {
-    migrator.migrate("originsrv",
-                     r#"CREATE SEQUENCE IF NOT EXISTS origin_invitations_id_seq;"#)?;
-    migrator.migrate("originsrv",
-                     r#"CREATE TABLE origin_invitations (
+    migrator
+        .migrate("originsrv",
+                 r#"CREATE SEQUENCE IF NOT EXISTS origin_invitations_id_seq;"#)?;
+    migrator
+        .migrate("originsrv",
+                 r#"CREATE TABLE origin_invitations (
                         id bigint PRIMARY KEY DEFAULT next_id_v1('origin_invitations_id_seq'),
                         origin_id bigint REFERENCES origins(id),
                         origin_name text,
@@ -50,8 +52,9 @@ pub fn migrate(migrator: &mut Migrator) -> Result<()> {
                         END IF;
                      END
                  $$ LANGUAGE plpgsql VOLATILE"#)?;
-    migrator.migrate("originsrv",
-                     r#"CREATE OR REPLACE FUNCTION get_origin_invitations_for_origin_v1 (
+    migrator
+        .migrate("originsrv",
+                 r#"CREATE OR REPLACE FUNCTION get_origin_invitations_for_origin_v1 (
                    oi_origin_id bigint
                  ) RETURNS SETOF origin_invitations AS $$
                     BEGIN

--- a/components/builder-originsrv/src/migrations/origin_projects.rs
+++ b/components/builder-originsrv/src/migrations/origin_projects.rs
@@ -17,10 +17,12 @@ use db::migration::Migrator;
 use error::Result;
 
 pub fn migrate(migrator: &mut Migrator) -> Result<()> {
-    migrator.migrate("originsrv",
-                     r#"CREATE SEQUENCE IF NOT EXISTS origin_project_id_seq;"#)?;
-    migrator.migrate("originsrv",
-                     r#"CREATE TABLE origin_projects (
+    migrator
+        .migrate("originsrv",
+                 r#"CREATE SEQUENCE IF NOT EXISTS origin_project_id_seq;"#)?;
+    migrator
+        .migrate("originsrv",
+                 r#"CREATE TABLE origin_projects (
                         id bigint PRIMARY KEY DEFAULT next_id_v1('origin_project_id_seq'),
                         origin_id bigint REFERENCES origins(id),
                         origin_name text,
@@ -34,8 +36,9 @@ pub fn migrate(migrator: &mut Migrator) -> Result<()> {
                         updated_at timestamptz,
                         UNIQUE (origin_name, package_name, name)
                         )"#)?;
-    migrator.migrate("originsrv",
-                     r#"CREATE OR REPLACE FUNCTION insert_origin_project_v1 (
+    migrator
+        .migrate("originsrv",
+                 r#"CREATE OR REPLACE FUNCTION insert_origin_project_v1 (
                         project_origin_name text,
                         project_package_name text,
                         project_plan_path text,
@@ -65,8 +68,9 @@ pub fn migrate(migrator: &mut Migrator) -> Result<()> {
                          RETURN;
                      END
                  $$ LANGUAGE plpgsql VOLATILE"#)?;
-    migrator.migrate("originsrv",
-                     r#"CREATE OR REPLACE FUNCTION get_origin_project_v1 (
+    migrator
+        .migrate("originsrv",
+                 r#"CREATE OR REPLACE FUNCTION get_origin_project_v1 (
                     project_name text
                  ) RETURNS SETOF origin_projects AS $$
                     BEGIN
@@ -74,8 +78,9 @@ pub fn migrate(migrator: &mut Migrator) -> Result<()> {
                         RETURN;
                     END
                     $$ LANGUAGE plpgsql STABLE"#)?;
-    migrator.migrate("originsrv",
-                     r#"CREATE OR REPLACE FUNCTION delete_origin_project_v1 (
+    migrator
+        .migrate("originsrv",
+                 r#"CREATE OR REPLACE FUNCTION delete_origin_project_v1 (
                     project_name text
                  ) RETURNS void AS $$
                     BEGIN

--- a/components/builder-originsrv/src/migrations/origin_public_keys.rs
+++ b/components/builder-originsrv/src/migrations/origin_public_keys.rs
@@ -17,10 +17,12 @@ use db::migration::Migrator;
 use error::Result;
 
 pub fn migrate(migrator: &mut Migrator) -> Result<()> {
-    migrator.migrate("originsrv",
-                     r#"CREATE SEQUENCE IF NOT EXISTS origin_public_key_id_seq;"#)?;
-    migrator.migrate("originsrv",
-                     r#"CREATE TABLE origin_public_keys (
+    migrator
+        .migrate("originsrv",
+                 r#"CREATE SEQUENCE IF NOT EXISTS origin_public_key_id_seq;"#)?;
+    migrator
+        .migrate("originsrv",
+                 r#"CREATE TABLE origin_public_keys (
                     id bigint PRIMARY KEY DEFAULT next_id_v1('origin_public_key_id_seq'),
                     origin_id bigint REFERENCES origins(id),
                     owner_id bigint,
@@ -59,8 +61,9 @@ pub fn migrate(migrator: &mut Migrator) -> Result<()> {
                         RETURN;
                     END
                     $$ LANGUAGE plpgsql STABLE"#)?;
-    migrator.migrate("originsrv",
-                     r#"CREATE OR REPLACE FUNCTION get_origin_public_key_latest_v1 (
+    migrator
+        .migrate("originsrv",
+                 r#"CREATE OR REPLACE FUNCTION get_origin_public_key_latest_v1 (
                     opk_name text
                  ) RETURNS SETOF origin_public_keys AS $$
                     BEGIN

--- a/components/builder-originsrv/src/migrations/origin_secret_keys.rs
+++ b/components/builder-originsrv/src/migrations/origin_secret_keys.rs
@@ -17,10 +17,12 @@ use db::migration::Migrator;
 use error::Result;
 
 pub fn migrate(migrator: &mut Migrator) -> Result<()> {
-    migrator.migrate("originsrv",
-                     r#"CREATE SEQUENCE IF NOT EXISTS origin_secret_key_id_seq;"#)?;
-    migrator.migrate("originsrv",
-                     r#"CREATE TABLE origin_secret_keys (
+    migrator
+        .migrate("originsrv",
+                 r#"CREATE SEQUENCE IF NOT EXISTS origin_secret_key_id_seq;"#)?;
+    migrator
+        .migrate("originsrv",
+                 r#"CREATE TABLE origin_secret_keys (
                     id bigint PRIMARY KEY DEFAULT next_id_v1('origin_secret_key_id_seq'),
                     origin_id bigint REFERENCES origins(id),
                     owner_id bigint,
@@ -54,8 +56,9 @@ pub fn migrate(migrator: &mut Migrator) -> Result<()> {
                          RETURN;
                      END
                  $$ LANGUAGE plpgsql VOLATILE"#)?;
-    migrator.migrate("originsrv",
-                     r#"CREATE OR REPLACE FUNCTION get_origin_secret_key_v1 (
+    migrator
+        .migrate("originsrv",
+                 r#"CREATE OR REPLACE FUNCTION get_origin_secret_key_v1 (
                     osk_name text
                  ) RETURNS SETOF origin_secret_keys AS $$
                     BEGIN

--- a/components/builder-originsrv/src/migrations/origins.rs
+++ b/components/builder-originsrv/src/migrations/origins.rs
@@ -17,18 +17,21 @@ use db::migration::Migrator;
 use error::Result;
 
 pub fn migrate(migrator: &mut Migrator) -> Result<()> {
-    migrator.migrate("originsrv",
-                     r#"CREATE SEQUENCE IF NOT EXISTS origin_id_seq;"#)?;
-    migrator.migrate("originsrv",
-                     r#"CREATE TABLE origins (
+    migrator
+        .migrate("originsrv",
+                 r#"CREATE SEQUENCE IF NOT EXISTS origin_id_seq;"#)?;
+    migrator
+        .migrate("originsrv",
+                 r#"CREATE TABLE origins (
                     id bigint PRIMARY KEY DEFAULT next_id_v1('origin_id_seq'),
                     name text UNIQUE,
                     owner_id bigint,
                     created_at timestamptz DEFAULT now(),
                     updated_at timestamptz
              )"#)?;
-    migrator.migrate("originsrv",
-                     r#"CREATE TABLE origin_members (
+    migrator
+        .migrate("originsrv",
+                 r#"CREATE TABLE origin_members (
                     origin_id bigint REFERENCES origins(id),
                     origin_name text,
                     account_id bigint,

--- a/components/builder-originsrv/src/server/handlers.rs
+++ b/components/builder-originsrv/src/server/handlers.rs
@@ -150,7 +150,8 @@ pub fn origin_invitation_create(req: &mut Envelope,
     let msg: proto::OriginInvitationCreate = try!(req.parse_msg());
 
     let in_origin =
-        state.datastore
+        state
+            .datastore
             .check_account_in_origin_by_origin_and_account_id(msg.get_origin_name(),
                                                               msg.get_account_id() as i64)?;
     if !in_origin {
@@ -367,7 +368,9 @@ pub fn project_delete(req: &mut Envelope,
                       -> Result<()> {
     let msg: proto::OriginProjectDelete = try!(req.parse_msg());
 
-    match state.datastore.delete_origin_project_by_name(&msg.get_name()) {
+    match state
+              .datastore
+              .delete_origin_project_by_name(&msg.get_name()) {
         Ok(()) => try!(req.reply_complete(sock, &NetOk::new())),
         Err(err) => {
             error!("OriginProjectGet, err={:?}", err);
@@ -383,7 +386,9 @@ pub fn project_get(req: &mut Envelope,
                    state: &mut ServerState)
                    -> Result<()> {
     let msg: proto::OriginProjectGet = try!(req.parse_msg());
-    match state.datastore.get_origin_project_by_name(&msg.get_name()) {
+    match state
+              .datastore
+              .get_origin_project_by_name(&msg.get_name()) {
         Ok(Some(ref project)) => try!(req.reply_complete(sock, project)),
         Ok(None) => {
             let err = net::err(ErrCode::ENTITY_NOT_FOUND, "vt:origin-project-get:0");

--- a/components/builder-protocol/src/depotsrv.rs
+++ b/components/builder-protocol/src/depotsrv.rs
@@ -116,9 +116,18 @@ impl FromArchive for Package {
             Err(e) => return Err(hab_core::Error::from(e)),
         };
         let manifest = try!(archive.manifest());
-        let deps = try!(archive.deps()).into_iter().map(|d| d.into()).collect();
-        let tdeps = try!(archive.tdeps()).into_iter().map(|d| d.into()).collect();
-        let exposes = try!(archive.exposes()).into_iter().map(|d| d as u32).collect();
+        let deps = try!(archive.deps())
+            .into_iter()
+            .map(|d| d.into())
+            .collect();
+        let tdeps = try!(archive.tdeps())
+            .into_iter()
+            .map(|d| d.into())
+            .collect();
+        let exposes = try!(archive.exposes())
+            .into_iter()
+            .map(|d| d as u32)
+            .collect();
         let config = try!(archive.config());
         let checksum = try!(archive.checksum());
         let target = try!(archive.target());

--- a/components/builder-protocol/src/message/mod.rs
+++ b/components/builder-protocol/src/message/mod.rs
@@ -36,11 +36,7 @@ impl<'a, T: 'a + protobuf::Message> Message<'a, T> {
     }
 
     pub fn protocol(&self) -> net::Protocol {
-        match self.0
-                  .descriptor()
-                  .full_name()
-                  .rsplit(".")
-                  .last() {
+        match self.0.descriptor().full_name().rsplit(".").last() {
             Some("jobsrv") => net::Protocol::JobSrv,
             Some("net") => net::Protocol::Net,
             Some("routesrv") => net::Protocol::RouteSrv,
@@ -85,11 +81,7 @@ impl<'a, T: 'a + protobuf::Message> MessageBuilder<'a, T> {
                          .0
                          .write_to_bytes()
                          .expect("All message fields have been set"));
-        msg.set_message_id(self.msg
-                               .0
-                               .descriptor()
-                               .name()
-                               .to_string());
+        msg.set_message_id(self.msg.0.descriptor().name().to_string());
         if let Some(route_info) = self.route_info {
             msg.set_route_info(route_info);
         }

--- a/components/builder-protocol/src/scheduler.rs
+++ b/components/builder-protocol/src/scheduler.rs
@@ -26,7 +26,8 @@ impl From<depotsrv::Package> for Package {
 
         let name = format!("{}", value.get_ident());
 
-        let deps = value.get_deps()
+        let deps = value
+            .get_deps()
             .iter()
             .map(|x| format!("{}", x))
             .collect();

--- a/components/builder-router/src/server.rs
+++ b/components/builder-router/src/server.rs
@@ -145,10 +145,7 @@ impl Server {
                         self.state = SocketState::Cleaning;
                         continue;
                     }
-                    match self.envelope
-                              .msg
-                              .get_route_info()
-                              .get_protocol() {
+                    match self.envelope.msg.get_route_info().get_protocol() {
                         Protocol::RouteSrv => try!(self.handle_message()),
                         _ => try!(self.route_message()),
                     }
@@ -184,9 +181,12 @@ impl Server {
         let registration: routesrv::Registration = try!(parse_from_bytes(&self.req));
         debug!("received server reg, {:?}", registration);
         if !self.servers.contains_key(&registration.get_protocol()) {
-            self.servers.insert(registration.get_protocol(), HashMap::new());
+            self.servers
+                .insert(registration.get_protocol(), HashMap::new());
         }
-        let shards = self.servers.get_mut(&registration.get_protocol()).unwrap();
+        let shards = self.servers
+            .get_mut(&registration.get_protocol())
+            .unwrap();
         for shard in registration.get_shards().iter() {
             let server = hab_net::ServerReg::new(registration.get_endpoint().to_string());
             shards.insert(*shard, server);
@@ -207,7 +207,9 @@ impl Server {
                 let req: routesrv::Connect = parse_from_bytes(msg.get_body()).unwrap();
                 debug!("Connect={:?}", req);
                 let rep = protocol::Message::new(&routesrv::ConnectOk::new()).build();
-                self.fe_sock.send(&rep.write_to_bytes().unwrap(), 0).unwrap();
+                self.fe_sock
+                    .send(&rep.write_to_bytes().unwrap(), 0)
+                    .unwrap();
             }
             "Disconnect" => {
                 let req: routesrv::Disconnect = parse_from_bytes(msg.get_body()).unwrap();
@@ -239,11 +241,8 @@ impl Server {
                             try!(self.fe_sock.send(&*hop, zmq::SNDMORE));
                         }
                         try!(self.fe_sock.send(&[], zmq::SNDMORE));
-                        try!(self.fe_sock.send(&self.envelope
-                                                    .msg
-                                                    .write_to_bytes()
-                                                    .unwrap(),
-                                               0));
+                        try!(self.fe_sock
+                                 .send(&self.envelope.msg.write_to_bytes().unwrap(), 0));
                     }
                     None => {
                         warn!("failed to route message, no server servicing shard, msg={:?}",

--- a/components/builder-scheduler/src/data_store.rs
+++ b/components/builder-scheduler/src/data_store.rs
@@ -58,8 +58,9 @@ impl DataStore {
         migrator.setup()?;
 
         // The packages table
-        migrator.migrate("scheduler",
-                         r#"CREATE TABLE packages (
+        migrator
+            .migrate("scheduler",
+                     r#"CREATE TABLE packages (
                                      id bigserial PRIMARY KEY,
                                      ident text UNIQUE,
                                      deps text[],
@@ -67,8 +68,9 @@ impl DataStore {
                               )"#)?;
 
         // Insert a new package into the packages table
-        migrator.migrate("scheduler",
-                         r#"CREATE OR REPLACE FUNCTION insert_package_v1 (
+        migrator
+            .migrate("scheduler",
+                     r#"CREATE OR REPLACE FUNCTION insert_package_v1 (
                                     pident text,
                                     pdeps text[]
                                     ) RETURNS void AS $$
@@ -81,7 +83,8 @@ impl DataStore {
                                 "#)?;
 
         // Retrieve all packages from the packages table
-        migrator.migrate("scheduler",
+        migrator
+            .migrate("scheduler",
                      r#"CREATE OR REPLACE FUNCTION get_packages_v1 () RETURNS SETOF packages AS $$
                             BEGIN
                               RETURN QUERY SELECT * FROM packages;
@@ -90,8 +93,9 @@ impl DataStore {
                             $$ LANGUAGE plpgsql STABLE"#)?;
 
         // The groups table
-        migrator.migrate("scheduler",
-                         r#"CREATE TABLE groups (
+        migrator
+            .migrate("scheduler",
+                     r#"CREATE TABLE groups (
                                     id bigint PRIMARY KEY,
                                     group_state text,
                                     created_at timestamptz DEFAULT now(),
@@ -99,8 +103,9 @@ impl DataStore {
                              )"#)?;
 
         // The projects table
-        migrator.migrate("scheduler",
-                         r#"CREATE TABLE projects (
+        migrator
+            .migrate("scheduler",
+                     r#"CREATE TABLE projects (
                                      id bigserial PRIMARY KEY,
                                      owner_id bigint,
                                      project_name text,
@@ -220,7 +225,8 @@ impl DataStore {
 
         let conn = self.pool.get()?;
 
-        let rows = &conn.query("SELECT * FROM get_packages_v1()", &[]).map_err(Error::PackagesGet)?;
+        let rows = &conn.query("SELECT * FROM get_packages_v1()", &[])
+                        .map_err(Error::PackagesGet)?;
 
         if rows.is_empty() {
             warn!("No packages found");

--- a/components/builder-scheduler/src/server/scheduler.rs
+++ b/components/builder-scheduler/src/server/scheduler.rs
@@ -117,7 +117,8 @@ impl ScheduleMgr {
         rz.send(()).unwrap();
         loop {
             {
-                let mut items = [self.work_sock.as_poll_item(1), self.status_sock.as_poll_item(1)];
+                let mut items = [self.work_sock.as_poll_item(1),
+                                 self.status_sock.as_poll_item(1)];
                 try!(zmq::poll(&mut items, -1));
 
                 if (items[0].get_revents() & zmq::POLLIN) > 0 {
@@ -167,10 +168,10 @@ impl ScheduleMgr {
     }
 
     fn dispatch_group(&mut self, group: proto::Group) -> Result<()> {
-        for project in group.get_projects().into_iter().filter(|x| {
-                                                                   x.get_state() ==
-                                                                   proto::ProjectState::NotStarted
-                                                               }) {
+        for project in group
+                .get_projects()
+                .into_iter()
+                .filter(|x| x.get_state() == proto::ProjectState::NotStarted) {
             println!("Dispatching project: {:?}", project.get_name());
             assert!(project.get_state() == proto::ProjectState::NotStarted);
 
@@ -188,7 +189,8 @@ impl ScheduleMgr {
                            project.get_name(),
                            err);
 
-                    self.datastore.set_group_state(group.get_id(), proto::GroupState::Failed)?;
+                    self.datastore
+                        .set_group_state(group.get_id(), proto::GroupState::Failed)?;
                     // TBD? set_project_state(group.get_id(), project.get_name(), proto::ProjectState::Failure)?;
                     break;
                 }
@@ -251,10 +253,7 @@ impl ScheduleMgr {
         let mut msg: proto::GroupGet = proto::GroupGet::new();
         msg.set_group_id(group_id);
 
-        let group = self.datastore
-            .get_group(&msg)
-            .unwrap()
-            .unwrap(); // we know the group exists
+        let group = self.datastore.get_group(&msg).unwrap().unwrap(); // we know the group exists
 
         // Group state transition rules:
         // |   Start Group State     |  Projects State  |   New Group State   |

--- a/components/builder-sessionsrv/src/data_store.rs
+++ b/components/builder-sessionsrv/src/data_store.rs
@@ -84,7 +84,8 @@ impl AccountTable {
             try!(self.github.write(&req.get_extern_id(), account.get_id()));
             // TODO: route a message to the appropriate sessionsrv, and
             // that sessionsrv will write to the db
-            try!(self.user_to_account.write(&req.get_name().to_string(), account.get_id()));
+            try!(self.user_to_account
+                     .write(&req.get_name().to_string(), account.get_id()));
             Ok(account)
         }
     }

--- a/components/builder-sessionsrv/src/server/handlers.rs
+++ b/components/builder-sessionsrv/src/server/handlers.rs
@@ -27,7 +27,10 @@ pub fn account_get(req: &mut Envelope,
                    state: &mut ServerState)
                    -> Result<()> {
     let msg: proto::AccountGet = try!(req.parse_msg());
-    match state.datastore.accounts.find_by_username(&msg.get_name().to_string()) {
+    match state
+              .datastore
+              .accounts
+              .find_by_username(&msg.get_name().to_string()) {
         Ok(account) => try!(req.reply_complete(sock, &account)),
         Err(dbcache::Error::EntityNotFound) => {
             let err = net::err(ErrCode::ENTITY_NOT_FOUND, "ss:account-get:0");
@@ -53,7 +56,10 @@ pub fn account_search(req: &mut Envelope,
             state.datastore.accounts.find(&value)
         }
         proto::AccountSearchKey::Name => {
-            state.datastore.accounts.find_by_username(&msg.take_value())
+            state
+                .datastore
+                .accounts
+                .find_by_username(&msg.take_value())
         }
     };
     match result {
@@ -76,7 +82,10 @@ pub fn grant_flag(req: &mut Envelope,
                   state: &mut ServerState)
                   -> Result<()> {
     let msg: proto::GrantFlagToTeam = try!(req.parse_msg());
-    try!(state.datastore.features.grant(msg.get_flag(), msg.get_team_id()));
+    try!(state
+             .datastore
+             .features
+             .grant(msg.get_flag(), msg.get_team_id()));
     try!(req.reply_complete(sock, &NetOk::new()));
     Ok(())
 }
@@ -98,7 +107,10 @@ pub fn revoke_flag(req: &mut Envelope,
                    state: &mut ServerState)
                    -> Result<()> {
     let msg: proto::RevokeFlagFromTeam = try!(req.parse_msg());
-    try!(state.datastore.features.revoke(msg.get_flag(), msg.get_team_id()));
+    try!(state
+             .datastore
+             .features
+             .revoke(msg.get_flag(), msg.get_team_id()));
     try!(req.reply_complete(sock, &NetOk::new()));
     Ok(())
 }
@@ -108,10 +120,13 @@ pub fn session_create(req: &mut Envelope,
                       state: &mut ServerState)
                       -> Result<()> {
     let mut msg: proto::SessionCreate = try!(req.parse_msg());
-    let account: proto::Account = match state.datastore.sessions.find(&msg.get_token()
-                                             .to_string()) {
+    let account: proto::Account = match state
+              .datastore
+              .sessions
+              .find(&msg.get_token().to_string()) {
         Ok(session) => {
-            state.datastore
+            state
+                .datastore
                 .accounts
                 .find(&session.get_owner_id())
                 .unwrap()
@@ -122,7 +137,8 @@ pub fn session_create(req: &mut Envelope,
     session_token.set_token(msg.take_token());
     session_token.set_owner_id(account.get_id());
     session_token.set_provider(msg.get_provider());
-    if let Some(e) = state.datastore
+    if let Some(e) = state
+           .datastore
            .sessions
            .write(&mut session_token)
            .err() {
@@ -147,9 +163,13 @@ pub fn session_get(req: &mut Envelope,
                    state: &mut ServerState)
                    -> Result<()> {
     let msg: proto::SessionGet = try!(req.parse_msg());
-    match state.datastore.sessions.find(&msg.get_token().to_string()) {
+    match state
+              .datastore
+              .sessions
+              .find(&msg.get_token().to_string()) {
         Ok(mut token) => {
-            let account: proto::Account = state.datastore
+            let account: proto::Account = state
+                .datastore
                 .accounts
                 .find(&token.get_owner_id())
                 .unwrap();
@@ -189,10 +209,7 @@ fn set_features(state: &ServerState, session: &mut proto::Session) -> Result<()>
             flags.insert(privilege::ADMIN);
             continue;
         }
-        if let Some(raw_flags) = state.datastore
-               .features
-               .flags(team.id)
-               .ok() {
+        if let Some(raw_flags) = state.datastore.features.flags(team.id).ok() {
             for raw_flag in raw_flags {
                 let flag = FeatureFlags::from_bits(raw_flag).unwrap();
                 debug!("Granting feature flag={:?} for team={:?}", flag, team.name);

--- a/components/builder-worker/src/heartbeat.rs
+++ b/components/builder-worker/src/heartbeat.rs
@@ -202,7 +202,8 @@ impl HeartbeatMgr {
     // Broadcast to subscribers the HeartbeatMgr health and state
     fn pulse(&mut self) -> Result<()> {
         debug!("heartbeat pulsed");
-        try!(self.pub_sock.send(&self.reg.write_to_bytes().unwrap(), 0));
+        try!(self.pub_sock
+                 .send(&self.reg.write_to_bytes().unwrap(), 0));
         Ok(())
     }
 

--- a/components/builder-worker/src/runner/logger.rs
+++ b/components/builder-worker/src/runner/logger.rs
@@ -55,18 +55,26 @@ impl Logger {
 
     /// Log message to stdout logfile
     pub fn log_stdout(&mut self, msg: &[u8]) {
-        self.stdout.write_all(msg).expect(&format!("Logger unable to write to {:?}", self.stdout));
+        self.stdout
+            .write_all(msg)
+            .expect(&format!("Logger unable to write to {:?}", self.stdout));
     }
 
     /// Log message to stderr logfile
     pub fn log_stderr(&mut self, msg: &[u8]) {
-        self.stderr.write_all(msg).expect(&format!("Logger unable to write to {:?}", self.stderr))
+        self.stderr
+            .write_all(msg)
+            .expect(&format!("Logger unable to write to {:?}", self.stderr))
     }
 }
 
 impl Drop for Logger {
     fn drop(&mut self) {
-        self.stdout.sync_all().expect("Unable to sync stdout log file");
-        self.stderr.sync_all().expect("Unable to sync stderr log file");
+        self.stdout
+            .sync_all()
+            .expect("Unable to sync stdout log file");
+        self.stderr
+            .sync_all()
+            .expect("Unable to sync stderr log file");
     }
 }

--- a/components/builder-worker/src/runner/mod.rs
+++ b/components/builder-worker/src/runner/mod.rs
@@ -149,7 +149,8 @@ impl Runner {
             warn!("WARNING: No auth token specified, will likely fail fetching secret key");
         };
 
-        match self.depot_cli.fetch_origin_secret_key(self.job().origin(), &self.auth_token) {
+        match self.depot_cli
+                  .fetch_origin_secret_key(self.job().origin(), &self.auth_token) {
             Ok(key) => {
                 let cache = crypto::default_cache_key_path(None);
                 let s: String = String::from_utf8(key.body).expect("Found invalid UTF-8");
@@ -171,10 +172,7 @@ impl Runner {
                 return self.fail(net::err(ErrCode::SECRET_KEY_FETCH, "wk:run:3"));
             }
         }
-        if let Some(err) = self.job()
-               .vcs()
-               .clone(&self.workspace.src())
-               .err() {
+        if let Some(err) = self.job().vcs().clone(&self.workspace.src()).err() {
             error!("Unable to clone remote source repository, err={}", err);
             return self.fail(net::err(ErrCode::VCS_CLONE, "wk:run:4"));
         }

--- a/components/builder-worker/src/runner/postprocessor.rs
+++ b/components/builder-worker/src/runner/postprocessor.rs
@@ -56,7 +56,9 @@ impl Publish {
             return false;
         };
 
-        if let Some(err) = client.promote_package(archive, &self.channel, auth_token).err() {
+        if let Some(err) = client
+               .promote_package(archive, &self.channel, auth_token)
+               .err() {
             error!("post processing error promoting package, ERR={:?}", err);
             return false;
         };
@@ -67,7 +69,9 @@ impl Publish {
 impl Default for Publish {
     fn default() -> Self {
         Publish {
-            enabled: hab_core::url::default_depot_publish().parse::<bool>().unwrap(),
+            enabled: hab_core::url::default_depot_publish()
+                .parse::<bool>()
+                .unwrap(),
             url: hab_core::url::default_depot_url(),
             channel: hab_core::url::default_depot_channel(),
         }
@@ -92,7 +96,9 @@ pub struct PostProcessor {
 
 impl PostProcessor {
     pub fn new(workspace: &Workspace) -> Self {
-        let parent_path = Path::new(workspace.job.get_project().get_plan_path()).parent().unwrap();
+        let parent_path = Path::new(workspace.job.get_project().get_plan_path())
+            .parent()
+            .unwrap();
         let file_path = workspace.src().join(parent_path.join(CONFIG_FILE));
 
         PostProcessor { config_path: file_path }

--- a/components/builder-worker/src/server.rs
+++ b/components/builder-worker/src/server.rs
@@ -77,7 +77,8 @@ impl Server {
         let mut runner_msg = false;
         loop {
             {
-                let mut items = [self.fe_sock.as_poll_item(1), self.runner_cli.as_poll_item(1)];
+                let mut items = [self.fe_sock.as_poll_item(1),
+                                 self.runner_cli.as_poll_item(1)];
                 try!(zmq::poll(&mut items, -1));
                 if items[0].get_revents() & zmq::POLLIN > 0 {
                     fe_msg = true;

--- a/components/butterfly-test/src/lib.rs
+++ b/components/butterfly-test/src/lib.rs
@@ -59,15 +59,17 @@ pub fn start_server(name: &str, ring_key: Option<SymKey>, suitability: u64) -> S
     member.set_swim_port(swim_port as i32);
     member.set_gossip_port(gossip_port as i32);
     let mut server = Server::new(&listen_swim[..],
-                             &listen_gossip[..],
-                             member,
-                             Trace::default(),
-                             ring_key,
-                             Some(String::from(name)),
-                             None::<PathBuf>,
-                             Box::new(NSuitability(suitability)))
+                                 &listen_gossip[..],
+                                 member,
+                                 Trace::default(),
+                                 ring_key,
+                                 Some(String::from(name)),
+                                 None::<PathBuf>,
+                                 Box::new(NSuitability(suitability)))
             .unwrap();
-    server.start(Timing::default()).expect("Cannot start server");
+    server
+        .start(Timing::default())
+        .expect("Cannot start server");
     server
 }
 
@@ -152,10 +154,12 @@ impl SwimNet {
     }
 
     pub fn blacklist(&self, from_entry: usize, to_entry: usize) {
-        let from =
-            self.members.get(from_entry).expect("Asked for a network member who is out of bounds");
-        let to =
-            self.members.get(to_entry).expect("Asked for a network member who is out of bounds");
+        let from = self.members
+            .get(from_entry)
+            .expect("Asked for a network member who is out of bounds");
+        let to = self.members
+            .get(to_entry)
+            .expect("Asked for a network member who is out of bounds");
         trace_it!(TEST: &self.members[from_entry], format!("Blacklisted {} {}", self.members[to_entry].name(), self.members[to_entry].member_id()));
         from.add_to_blacklist(String::from(to.member
                                                .read()
@@ -164,20 +168,24 @@ impl SwimNet {
     }
 
     pub fn unblacklist(&self, from_entry: usize, to_entry: usize) {
-        let from =
-            self.members.get(from_entry).expect("Asked for a network member who is out of bounds");
-        let to =
-            self.members.get(to_entry).expect("Asked for a network member who is out of bounds");
+        let from = self.members
+            .get(from_entry)
+            .expect("Asked for a network member who is out of bounds");
+        let to = self.members
+            .get(to_entry)
+            .expect("Asked for a network member who is out of bounds");
         trace_it!(TEST: &self.members[from_entry], format!("Un-Blacklisted {} {}", self.members[to_entry].name(), self.members[to_entry].member_id()));
         from.remove_from_blacklist(to.member_id());
     }
 
     pub fn health_of(&self, from_entry: usize, to_entry: usize) -> Option<Health> {
-        let from =
-            self.members.get(from_entry).expect("Asked for a network member who is out of bounds");
+        let from = self.members
+            .get(from_entry)
+            .expect("Asked for a network member who is out of bounds");
 
-        let to =
-            self.members.get(to_entry).expect("Asked for a network member who is out of bounds");
+        let to = self.members
+            .get(to_entry)
+            .expect("Asked for a network member who is out of bounds");
         let to_member = to.member.read().expect("Member lock is poisoned");
         from.member_list.health_of(&to_member)
     }
@@ -203,17 +211,11 @@ impl SwimNet {
     }
 
     pub fn rounds(&self) -> Vec<isize> {
-        self.members
-            .iter()
-            .map(|m| m.swim_rounds())
-            .collect()
+        self.members.iter().map(|m| m.swim_rounds()).collect()
     }
 
     pub fn rounds_in(&self, count: isize) -> Vec<isize> {
-        self.rounds()
-            .iter()
-            .map(|r| r + count)
-            .collect()
+        self.rounds().iter().map(|r| r + count).collect()
     }
 
     pub fn gossip_rounds(&self) -> Vec<isize> {
@@ -299,12 +301,16 @@ impl SwimNet {
         let rounds_in = self.gossip_rounds_in(self.max_gossip_rounds());
         loop {
             let mut result = false;
-            let server =
-                self.members.get(e_num).expect("Asked for a network member who is out of bounds");
-            server.election_store.with_rumor(key, "election", |e| if e.is_some() &&
-                                                    e.unwrap().get_status() == status {
-                result = true;
-            });
+            let server = self.members
+                .get(e_num)
+                .expect("Asked for a network member who is out of bounds");
+            server
+                .election_store
+                .with_rumor(key,
+                            "election",
+                            |e| if e.is_some() && e.unwrap().get_status() == status {
+                                result = true;
+                            });
             if result {
                 return true;
             }
@@ -322,16 +328,22 @@ impl SwimNet {
         loop {
             let mut result = false;
 
-            let left_server =
-                self.members.get(left).expect("Asked for a network member who is out of bounds");
-            let right_server =
-                self.members.get(right).expect("Asked for a network member who is out of bounds");
+            let left_server = self.members
+                .get(left)
+                .expect("Asked for a network member who is out of bounds");
+            let right_server = self.members
+                .get(right)
+                .expect("Asked for a network member who is out of bounds");
 
-            left_server.election_store.with_rumor(key, "election", |l| {
-                right_server.election_store.with_rumor(key, "election", |r| {
-                    result = l.is_some() && r.is_some() && l.unwrap() == r.unwrap();
+            left_server
+                .election_store
+                .with_rumor(key, "election", |l| {
+                    right_server
+                        .election_store
+                        .with_rumor(key, "election", |r| {
+                            result = l.is_some() && r.is_some() && l.unwrap() == r.unwrap();
+                        });
                 });
-            });
             if result {
                 return true;
             }
@@ -396,11 +408,13 @@ impl SwimNet {
         let rounds_in = self.rounds_in(self.max_rounds());
         loop {
             let network_health = self.network_health_of(to_check);
-            if network_health.iter().all(|x| if let &Some(ref h) = x {
-                                             *h == health
-                                         } else {
-                                             false
-                                         }) {
+            if network_health
+                   .iter()
+                   .all(|x| if let &Some(ref h) = x {
+                            *h == health
+                        } else {
+                            false
+                        }) {
                 trace_it!(TEST_NET: self,
                           format!("Health {} {} as {}",
                                   self.members[to_check].name(),

--- a/components/butterfly/src/client.rs
+++ b/components/butterfly/src/client.rs
@@ -40,12 +40,21 @@ impl Client {
             .as_mut()
             .socket(zmq::PUSH)
             .expect("Failure to create the ZMQ push socket");
-        socket.set_linger(-1).expect("Failure to set the ZMQ push socket to not linger");
-        socket.set_tcp_keepalive(0)
+        socket
+            .set_linger(-1)
+            .expect("Failure to set the ZMQ push socket to not linger");
+        socket
+            .set_tcp_keepalive(0)
             .expect("Failure to set the ZMQ push socket to not use keepalive");
-        socket.set_immediate(true).expect("Failure to set the ZMQ push socket to immediate");
-        socket.set_sndhwm(1000).expect("Failure to set the ZMQ push socket hwm");
-        socket.set_sndtimeo(500).expect("Failure to set the ZMQ send timeout");
+        socket
+            .set_immediate(true)
+            .expect("Failure to set the ZMQ push socket to immediate");
+        socket
+            .set_sndhwm(1000)
+            .expect("Failure to set the ZMQ push socket hwm");
+        socket
+            .set_sndtimeo(500)
+            .expect("Failure to set the ZMQ send timeout");
         let to_addr = format!("tcp://{}", addr.to_string());
         try!(socket.connect(&to_addr).map_err(Error::ZmqConnectError));
         Ok(Client {
@@ -85,6 +94,8 @@ impl Client {
     pub fn send<T: Rumor>(&mut self, rumor: T) -> Result<()> {
         let bytes = try!(rumor.write_to_bytes());
         let wire_msg = try!(message::generate_wire(bytes, &self.ring_key));
-        self.socket.send(&wire_msg, 0).map_err(Error::ZmqSendError)
+        self.socket
+            .send(&wire_msg, 0)
+            .map_err(Error::ZmqSendError)
     }
 }

--- a/components/butterfly/src/main.rs
+++ b/components/butterfly/src/main.rs
@@ -75,7 +75,9 @@ fn main() {
         server.member_list.add_initial_member(member);
     }
 
-    server.start(server::timing::Timing::default()).expect("Cannot start server");
+    server
+        .start(server::timing::Timing::default())
+        .expect("Cannot start server");
     loop {
         println!("{:#?}", server.member_list);
         thread::sleep(Duration::from_millis(1000));

--- a/components/butterfly/src/member.rs
+++ b/components/butterfly/src/member.rs
@@ -229,19 +229,25 @@ impl MemberList {
     }
 
     pub fn len_initial_members(&self) -> usize {
-        let im = self.initial_members.read().expect("Initial members lock is poisoned");
+        let im = self.initial_members
+            .read()
+            .expect("Initial members lock is poisoned");
         im.len()
     }
 
     pub fn add_initial_member(&self, member: Member) {
-        let mut im = self.initial_members.write().expect("Initial members lock is poisoned");
+        let mut im = self.initial_members
+            .write()
+            .expect("Initial members lock is poisoned");
         im.push(member);
     }
 
     pub fn with_initial_members<F>(&self, mut with_closure: F) -> ()
         where F: FnMut(&Member)
     {
-        let im = self.initial_members.read().expect("Initial members lock is poisoned");
+        let im = self.initial_members
+            .read()
+            .expect("Initial members lock is poisoned");
         for member in im.iter() {
             with_closure(member);
         }
@@ -429,9 +435,11 @@ impl MemberList {
             .get(member_id)
             .expect("Should have membership before calling membership_for")
             .into();
-        let ml = self.members.read().expect("Member list lock is poisoned");
-        let member =
-            ml.get(member_id).expect("Should have membership before calling membership_for");
+        let ml = self.members
+            .read()
+            .expect("Member list lock is poisoned");
+        let member = ml.get(member_id)
+            .expect("Should have membership before calling membership_for");
         pm.set_health(mhealth);
         pm.set_member(member.proto.clone());
         pm
@@ -469,12 +477,15 @@ impl MemberList {
     {
         // This will lead to nested read locks if you don't deal with making a copy
         let mut members: Vec<Member> = {
-            let ml = self.members.read().expect("Member list lock is poisoned");
+            let ml = self.members
+                .read()
+                .expect("Member list lock is poisoned");
             ml.values().map(|v| v.clone()).collect()
         };
         let mut rng = thread_rng();
         rng.shuffle(&mut members);
-        for member in members.into_iter()
+        for member in members
+                .into_iter()
                 .filter(|m| {
                             m.get_id() != sending_member_id && m.get_id() != target_member_id &&
                             self.check_health_of_by_id(m.get_id(), Health::Alive)
@@ -540,7 +551,9 @@ impl MemberList {
 
     /// Expires a member from the suspect list.
     pub fn expire(&self, member_id: &str) {
-        let mut suspects = self.suspect.write().expect("Suspect list lock is poisoned");
+        let mut suspects = self.suspect
+            .write()
+            .expect("Suspect list lock is poisoned");
         suspects.remove(member_id);
     }
 

--- a/components/butterfly/src/rumor/dat_file.rs
+++ b/components/butterfly/src/rumor/dat_file.rs
@@ -64,26 +64,32 @@ impl DatFile {
         // won't be a performance issue for a long time anyway, if ever.
         let mut rumor_buf: Vec<u8> = vec![];
         let mut bytes_read = 0;
-        let file = File::open(&self.path).map_err(|err| Error::DatFileIO(self.path.clone(), err))?;
+        let file = File::open(&self.path)
+            .map_err(|err| Error::DatFileIO(self.path.clone(), err))?;
         let mut reader = BufReader::new(file);
-        reader.read_exact(&mut version).map_err(|err| Error::DatFileIO(self.path.clone(), err))?;
+        reader
+            .read_exact(&mut version)
+            .map_err(|err| Error::DatFileIO(self.path.clone(), err))?;
         debug!("Header Version: {}", version[0]);
-        self.header =
-            Header::from_file(&mut reader).map_err(|err| Error::DatFileIO(self.path.clone(), err))?;
+        self.header = Header::from_file(&mut reader)
+            .map_err(|err| Error::DatFileIO(self.path.clone(), err))?;
         debug!("Header: {:?}", self.header);
 
-        reader.seek(SeekFrom::Start(self.member_offset()))
+        reader
+            .seek(SeekFrom::Start(self.member_offset()))
             .map_err(|err| Error::DatFileIO(self.path.clone(), err))?;
         debug!("Reading membership list from {}", self.path().display());
         loop {
             if bytes_read >= self.header.member_len {
                 break;
             }
-            reader.read_exact(&mut size_buf)
+            reader
+                .read_exact(&mut size_buf)
                 .map_err(|err| Error::DatFileIO(self.path.clone(), err))?;
             let rumor_size = LittleEndian::read_u64(&size_buf);
             rumor_buf.resize(rumor_size as usize, 0);
-            reader.read_exact(&mut rumor_buf)
+            reader
+                .read_exact(&mut rumor_buf)
                 .map_err(|err| Error::DatFileIO(self.path.clone(), err))?;
             let mut proto = protobuf::parse_from_bytes::<ProtoMembership>(&rumor_buf)?;
             let member = Member::from(proto.take_member());
@@ -98,11 +104,13 @@ impl DatFile {
             if bytes_read >= self.header.service_len {
                 break;
             }
-            reader.read_exact(&mut size_buf)
+            reader
+                .read_exact(&mut size_buf)
                 .map_err(|err| Error::DatFileIO(self.path.clone(), err))?;
             let rumor_size = LittleEndian::read_u64(&size_buf);
             rumor_buf.resize(rumor_size as usize, 0);
-            reader.read_exact(&mut rumor_buf)
+            reader
+                .read_exact(&mut rumor_buf)
                 .map_err(|err| Error::DatFileIO(self.path.clone(), err))?;
             let rumor = Service::from_bytes(&rumor_buf)?;
             server.insert_service(rumor);
@@ -116,11 +124,13 @@ impl DatFile {
             if bytes_read >= self.header.service_config_len {
                 break;
             }
-            reader.read_exact(&mut size_buf)
+            reader
+                .read_exact(&mut size_buf)
                 .map_err(|err| Error::DatFileIO(self.path.clone(), err))?;
             let rumor_size = LittleEndian::read_u64(&size_buf);
             rumor_buf.resize(rumor_size as usize, 0);
-            reader.read_exact(&mut rumor_buf)
+            reader
+                .read_exact(&mut rumor_buf)
                 .map_err(|err| Error::DatFileIO(self.path.clone(), err))?;
             let rumor = ServiceConfig::from_bytes(&rumor_buf)?;
             server.insert_service_config(rumor);
@@ -133,11 +143,13 @@ impl DatFile {
             if bytes_read >= self.header.service_file_len {
                 break;
             }
-            reader.read_exact(&mut size_buf)
+            reader
+                .read_exact(&mut size_buf)
                 .map_err(|err| Error::DatFileIO(self.path.clone(), err))?;
             let rumor_size = LittleEndian::read_u64(&size_buf);
             rumor_buf.resize(rumor_size as usize, 0);
-            reader.read_exact(&mut rumor_buf)
+            reader
+                .read_exact(&mut rumor_buf)
                 .map_err(|err| Error::DatFileIO(self.path.clone(), err))?;
             let rumor = ServiceFile::from_bytes(&rumor_buf)?;
             server.insert_service_file(rumor);
@@ -150,11 +162,13 @@ impl DatFile {
             if bytes_read >= self.header.election_len {
                 break;
             }
-            reader.read_exact(&mut size_buf)
+            reader
+                .read_exact(&mut size_buf)
                 .map_err(|err| Error::DatFileIO(self.path.clone(), err))?;
             let rumor_size = LittleEndian::read_u64(&size_buf);
             rumor_buf.resize(rumor_size as usize, 0);
-            reader.read_exact(&mut rumor_buf)
+            reader
+                .read_exact(&mut rumor_buf)
                 .map_err(|err| Error::DatFileIO(self.path.clone(), err))?;
             let rumor = Election::from_bytes(&rumor_buf)?;
             server.insert_election(rumor);
@@ -168,11 +182,13 @@ impl DatFile {
             if bytes_read >= self.header.update_len {
                 break;
             }
-            reader.read_exact(&mut size_buf)
+            reader
+                .read_exact(&mut size_buf)
                 .map_err(|err| Error::DatFileIO(self.path.clone(), err))?;
             let rumor_size = LittleEndian::read_u64(&size_buf);
             rumor_buf.resize(rumor_size as usize, 0);
-            reader.read_exact(&mut rumor_buf)
+            reader
+                .read_exact(&mut rumor_buf)
                 .map_err(|err| Error::DatFileIO(self.path.clone(), err))?;
             let rumor = ElectionUpdate::from_bytes(&rumor_buf)?;
             server.insert_update_election(rumor);
@@ -183,7 +199,8 @@ impl DatFile {
 
     pub fn write(&self, server: &Server) -> Result<usize> {
         let mut header = Header::default();
-        let file = NamedTempFile::new().map_err(|err| Error::DatFileIO(self.path.clone(), err))?;
+        let file = NamedTempFile::new()
+            .map_err(|err| Error::DatFileIO(self.path.clone(), err))?;
         {
             let mut writer = BufWriter::new(&file);
             self.init(&mut writer)?;
@@ -195,13 +212,16 @@ impl DatFile {
                 self.write_rumor_store(&mut writer, &server.service_file_store)?;
             header.election_len = self.write_rumor_store(&mut writer, &server.election_store)?;
             header.update_len = self.write_rumor_store(&mut writer, &server.update_store)?;
-            writer.seek(SeekFrom::Start(1)).map_err(|err| {
-                Error::DatFileIO(self.path.clone(), err)
-            })?;
+            writer
+                .seek(SeekFrom::Start(1))
+                .map_err(|err| Error::DatFileIO(self.path.clone(), err))?;
             self.write_header(&mut writer, &header)?;
-            writer.flush().map_err(|err| Error::DatFileIO(self.path.clone(), err))?;
+            writer
+                .flush()
+                .map_err(|err| Error::DatFileIO(self.path.clone(), err))?;
         }
-        file.persist(&self.path).map_err(|err| Error::DatFileIO(self.path.clone(), err.error))?;
+        file.persist(&self.path)
+            .map_err(|err| Error::DatFileIO(self.path.clone(), err.error))?;
         Ok(0)
     }
 
@@ -210,9 +230,11 @@ impl DatFile {
     {
         let mut total = 0;
         let header_reserve = vec![0; mem::size_of::<Header>()];
-        total += writer.write(&[HEADER_VERSION])
+        total += writer
+            .write(&[HEADER_VERSION])
             .map_err(|err| Error::DatFileIO(self.path.clone(), err))?;
-        total += writer.write(&header_reserve)
+        total += writer
+            .write(&header_reserve)
             .map_err(|err| Error::DatFileIO(self.path.clone(), err))?;
         Ok(total)
     }
@@ -250,7 +272,9 @@ impl DatFile {
         where W: Write
     {
         let bytes = header.write_to_bytes().unwrap();
-        let total = writer.write(&bytes).map_err(|err| Error::DatFileIO(self.path.clone(), err))?;
+        let total = writer
+            .write(&bytes)
+            .map_err(|err| Error::DatFileIO(self.path.clone(), err))?;
         Ok(total)
     }
 
@@ -258,7 +282,10 @@ impl DatFile {
         where W: Write
     {
         let mut total = 0;
-        let members = member_list.members.read().expect("Member list lock poisoned");
+        let members = member_list
+            .members
+            .read()
+            .expect("Member list lock poisoned");
         for member in members.values() {
             let membership = member_list.membership_for(member.get_id());
             total += self.write_member(writer, &membership)?;
@@ -273,10 +300,12 @@ impl DatFile {
         let mut len_buf = [0; 8];
         let bytes = membership.write_to_bytes().unwrap();
         LittleEndian::write_u64(&mut len_buf, bytes.len() as u64);
-        total += writer.write(&len_buf).map_err(|err| Error::DatFileIO(self.path.clone(), err))? as
-                 u64;
-        total += writer.write(&bytes).map_err(|err| Error::DatFileIO(self.path.clone(), err))? as
-                 u64;
+        total += writer
+            .write(&len_buf)
+            .map_err(|err| Error::DatFileIO(self.path.clone(), err))? as u64;
+        total += writer
+            .write(&bytes)
+            .map_err(|err| Error::DatFileIO(self.path.clone(), err))? as u64;
         Ok(total)
     }
 
@@ -285,7 +314,8 @@ impl DatFile {
               W: Write
     {
         let mut total = 0;
-        for member in store.list
+        for member in store
+                .list
                 .read()
                 .expect("Rumor store lock poisoned")
                 .values() {
@@ -304,10 +334,12 @@ impl DatFile {
         let mut rumor_len = [0; 8];
         let bytes = rumor.write_to_bytes().unwrap();
         LittleEndian::write_u64(&mut rumor_len, bytes.len() as u64);
-        total += writer.write(&rumor_len)
+        total += writer
+            .write(&rumor_len)
             .map_err(|err| Error::DatFileIO(self.path.clone(), err))? as u64;
-        total += writer.write(&bytes).map_err(|err| Error::DatFileIO(self.path.clone(), err))? as
-                 u64;
+        total += writer
+            .write(&bytes)
+            .map_err(|err| Error::DatFileIO(self.path.clone(), err))? as u64;
         Ok(total)
     }
 }

--- a/components/butterfly/src/rumor/election.rs
+++ b/components/butterfly/src/rumor/election.rs
@@ -221,7 +221,9 @@ impl ElectionUpdate {
                                  suitability: u64)
                                  -> ElectionUpdate {
         let mut election = Election::new(member_id, service_group, suitability);
-        election.0.set_field_type(ProtoRumor_Type::ElectionUpdate);
+        election
+            .0
+            .set_field_type(ProtoRumor_Type::ElectionUpdate);
         ElectionUpdate(election)
     }
 }
@@ -243,7 +245,9 @@ impl DerefMut for ElectionUpdate {
 impl From<ProtoRumor> for ElectionUpdate {
     fn from(pr: ProtoRumor) -> ElectionUpdate {
         let mut election = Election::from(pr);
-        election.0.set_field_type(ProtoRumor_Type::ElectionUpdate);
+        election
+            .0
+            .set_field_type(ProtoRumor_Type::ElectionUpdate);
         ElectionUpdate(election)
     }
 }

--- a/components/butterfly/src/server/expire.rs
+++ b/components/butterfly/src/server/expire.rs
@@ -47,23 +47,32 @@ impl Expire {
     pub fn run(&self) {
         loop {
             let mut expired_list: Vec<String> = Vec::new();
-            self.server.member_list.with_suspects(|(id, suspect)| {
-                let now = SteadyTime::now();
-                if *suspect + self.timing.suspicion_timeout_duration() > now {
-                    expired_list.push(String::from(id));
-                    self.server.member_list.insert_health_by_id(id, Health::Confirmed);
-                    self.server.member_list.with_member(id, |has_member| {
-                        let member = has_member.expect("Member does not exist when expiring it");
-                        debug!("Marking {:?} as Confirmed", member);
-                        trace_it!(
+            self.server
+                .member_list
+                .with_suspects(|(id, suspect)| {
+                    let now = SteadyTime::now();
+                    if *suspect + self.timing.suspicion_timeout_duration() > now {
+                        expired_list.push(String::from(id));
+                        self.server
+                            .member_list
+                            .insert_health_by_id(id, Health::Confirmed);
+                        self.server
+                            .member_list
+                            .with_member(id, |has_member| {
+                                let member =
+                                    has_member.expect("Member does not exist when expiring it");
+                                debug!("Marking {:?} as Confirmed", member);
+                                trace_it!(
                             PROBE: &self.server,
                             TraceKind::ProbeConfirmed, member.get_id(), member.get_address());
-                    });
-                }
-            });
+                            });
+                    }
+                });
             for mid in expired_list.iter() {
                 self.server.member_list.expire(mid);
-                self.server.rumor_list.insert(RumorKey::new(Rumor_Type::Member, mid.clone(), ""));
+                self.server
+                    .rumor_list
+                    .insert(RumorKey::new(Rumor_Type::Member, mid.clone(), ""));
             }
             thread::sleep(Duration::from_millis(500));
         }

--- a/components/butterfly/src/server/inbound.rs
+++ b/components/butterfly/src/server/inbound.rs
@@ -81,7 +81,8 @@ impl Inbound {
                     debug!("SWIM Message: {:?}", msg);
                     match msg.get_field_type() {
                         Swim_Type::PING => {
-                            if self.server.check_blacklist(msg.get_ping().get_from().get_id()) {
+                            if self.server
+                                   .check_blacklist(msg.get_ping().get_from().get_id()) {
                                 debug!("Not processing message from {} - it is blacklisted",
                                        msg.get_ping().get_from().get_id());
                                 continue;
@@ -89,7 +90,8 @@ impl Inbound {
                             self.process_ping(addr, msg);
                         }
                         Swim_Type::ACK => {
-                            if self.server.check_blacklist(msg.get_ack().get_from().get_id()) &&
+                            if self.server
+                                   .check_blacklist(msg.get_ack().get_from().get_id()) &&
                                !msg.get_ack().has_forward_to() {
                                 debug!("Not processing message from {} - it is blacklisted",
                                        msg.get_ack().get_from().get_id());
@@ -98,7 +100,8 @@ impl Inbound {
                             self.process_ack(addr, msg);
                         }
                         Swim_Type::PINGREQ => {
-                            if self.server.check_blacklist(msg.get_pingreq().get_from().get_id()) {
+                            if self.server
+                                   .check_blacklist(msg.get_pingreq().get_from().get_id()) {
                                 debug!("Not processing message from {} - it is blacklisted",
                                        msg.get_pingreq().get_from().get_id());
                                 continue;
@@ -135,23 +138,25 @@ impl Inbound {
         // We need to get msg to be owned by the closure, so we're going to have to
         // allocate here to get the id. Kind of a bummer, but life goes on.
         let mid = String::from(msg.get_pingreq().get_target().get_id());
-        self.server.member_list.with_member(&mid, |m| {
-            let target = match m {
-                Some(target) => target,
-                None => {
-                    error!("PingReq request {:?} for invalid target", msg);
-                    return;
-                }
-            };
-            // Set the route-back address to the one we received the pingreq from
-            let mut from = msg.mut_pingreq().take_from();
-            from.set_address(format!("{}", addr.ip()));
-            outbound::ping(&self.server,
-                           &self.socket,
-                           target,
-                           target.swim_socket_address(),
-                           Some(from.into()));
-        });
+        self.server
+            .member_list
+            .with_member(&mid, |m| {
+                let target = match m {
+                    Some(target) => target,
+                    None => {
+                        error!("PingReq request {:?} for invalid target", msg);
+                        return;
+                    }
+                };
+                // Set the route-back address to the one we received the pingreq from
+                let mut from = msg.mut_pingreq().take_from();
+                from.set_address(format!("{}", addr.ip()));
+                outbound::ping(&self.server,
+                               &self.socket,
+                               target,
+                               target.swim_socket_address(),
+                               Some(from.into()));
+            });
     }
 
     /// Process ack messages; forwards to the outbound thread.
@@ -182,7 +187,9 @@ impl Inbound {
                       msg.get_ack().get_forward_to().get_id(),
                       msg.get_ack().get_forward_to().get_address(),
                       );
-                msg.mut_ack().mut_from().set_address(format!("{}", addr.ip()));
+                msg.mut_ack()
+                    .mut_from()
+                    .set_address(format!("{}", addr.ip()));
                 outbound::forward_ack(&self.server, &self.socket, forward_to_addr, msg);
                 return;
             }

--- a/components/butterfly/src/server/outbound.rs
+++ b/components/butterfly/src/server/outbound.rs
@@ -90,13 +90,15 @@ impl Outbound {
                 if self.server.member_list.len() >= min_to_start {
                     have_members = true;
                 } else {
-                    self.server.member_list.with_initial_members(|member| {
-                        ping(&self.server,
-                             &self.socket,
-                             &member,
-                             member.swim_socket_address(),
-                             None);
-                    });
+                    self.server
+                        .member_list
+                        .with_initial_members(|member| {
+                                                  ping(&self.server,
+                                                       &self.socket,
+                                                       &member,
+                                                       member.swim_socket_address(),
+                                                       None);
+                                              });
                 }
             }
 
@@ -109,11 +111,13 @@ impl Outbound {
 
             let long_wait = self.timing.next_protocol_period();
 
-            let check_list = self.server.member_list.check_list(self.server
-                                                                    .member
-                                                                    .read()
-                                                                    .expect("Member is poisoned")
-                                                                    .get_id());
+            let check_list = self.server
+                .member_list
+                .check_list(self.server
+                                .member
+                                .read()
+                                .expect("Member is poisoned")
+                                .get_id());
 
             for member in check_list {
                 if self.server.member_list.pingable(&member) {
@@ -173,15 +177,15 @@ impl Outbound {
             return;
         }
 
-        self.server.member_list.with_pingreq_targets(self.server.member_id(),
-                                                     member.get_id(),
-                                                     |pingreq_target| {
-            trace_it!(PROBE: &self.server,
+        self.server
+            .member_list
+            .with_pingreq_targets(self.server.member_id(), member.get_id(), |pingreq_target| {
+                trace_it!(PROBE: &self.server,
                           TraceKind::ProbePingReq,
                           pingreq_target.get_id(),
                           pingreq_target.get_address());
-            pingreq(&self.server, &self.socket, &pingreq_target, &member);
-        });
+                pingreq(&self.server, &self.socket, &pingreq_target, &member);
+            });
         if !self.recv_ack(&member, addr, AckFrom::PingReq) {
             // We mark as suspect when we fail to get a response from the PingReq. That moves us
             // into the suspicion phase, where anyone marked as suspect has a certain number of
@@ -250,7 +254,9 @@ pub fn populate_membership_rumors(server: &Server, target: &Member, swim: &mut S
         let always_target = server.member_list.membership_for(target.get_id());
         membership_entries.push(always_target);
     }
-    let rumors = server.rumor_list.take_by_kind(target.get_id(), 5, Rumor_Type::Member);
+    let rumors = server
+        .rumor_list
+        .take_by_kind(target.get_id(), 5, Rumor_Type::Member);
     for &(ref rkey, _heat) in rumors.iter() {
         membership_entries.push(server.member_list.membership_for(&rkey.key()));
     }

--- a/components/butterfly/src/server/pull.rs
+++ b/components/butterfly/src/server/pull.rs
@@ -46,10 +46,14 @@ impl Pull {
             .as_mut()
             .socket(zmq::PULL)
             .expect("Failure to create the ZMQ pull socket");
-        socket.set_linger(0).expect("Failure to set the ZMQ Pull socket to not linger");
-        socket.set_tcp_keepalive(0)
+        socket
+            .set_linger(0)
+            .expect("Failure to set the ZMQ Pull socket to not linger");
+        socket
+            .set_tcp_keepalive(0)
             .expect("Failure to set the ZMQ Pull socket to not use keepalive");
-        socket.bind(&format!("tcp://{}", self.server.gossip_addr()))
+        socket
+            .bind(&format!("tcp://{}", self.server.gossip_addr()))
             .expect("Failure to bind the ZMQ Pull socket to the port");
         'recv: loop {
             if self.server.pause.load(Ordering::Relaxed) {

--- a/components/butterfly/src/server/push.rs
+++ b/components/butterfly/src/server/push.rs
@@ -65,7 +65,9 @@ impl Push {
 
             self.server.update_gossip_round();
 
-            let mut check_list = self.server.member_list.check_list(self.server.member_id());
+            let mut check_list = self.server
+                .member_list
+                .check_list(self.server.member_id());
             let long_wait = self.timing.gossip_timeout();
 
             'fanout: loop {
@@ -89,7 +91,9 @@ impl Push {
                     // persistent members that are confirmed dead. When the failure detector thread
                     // finds them alive again, we'll go ahead and get back to the business at hand.
                     if self.server.member_list.pingable(&member) &&
-                       !self.server.member_list.persistent_and_confirmed(&member) {
+                       !self.server
+                            .member_list
+                            .persistent_and_confirmed(&member) {
                         let rumors = self.server.rumor_list.rumors(member.get_id());
                         if rumors.len() > 0 {
                             let sc = self.server.clone();
@@ -111,7 +115,9 @@ impl Push {
                 }
                 let num_threads = thread_list.len();
                 for guard in thread_list.drain(0..num_threads) {
-                    let _ = guard.join().map_err(|e| println!("Push worker died: {:?}", e));
+                    let _ = guard
+                        .join()
+                        .map_err(|e| println!("Push worker died: {:?}", e));
                 }
                 if SteadyTime::now() < next_gossip {
                     let wait_time = (next_gossip - SteadyTime::now()).num_milliseconds();
@@ -150,12 +156,21 @@ impl PushWorker {
             .as_mut()
             .socket(zmq::PUSH)
             .expect("Failure to create the ZMQ push socket");
-        socket.set_linger(1000).expect("Failure to set the ZMQ push socket to not linger");
-        socket.set_tcp_keepalive(0)
+        socket
+            .set_linger(1000)
+            .expect("Failure to set the ZMQ push socket to not linger");
+        socket
+            .set_tcp_keepalive(0)
             .expect("Failure to set the ZMQ push socket to not use keepalive");
-        socket.set_immediate(true).expect("Failure to set the ZMQ push socket to immediate");
-        socket.set_sndhwm(1000).expect("Failure to set the ZMQ push socket hwm");
-        socket.set_sndtimeo(500).expect("Failure to set the ZMQ send timeout");
+        socket
+            .set_immediate(true)
+            .expect("Failure to set the ZMQ push socket to immediate");
+        socket
+            .set_sndhwm(1000)
+            .expect("Failure to set the ZMQ push socket hwm");
+        socket
+            .set_sndtimeo(500)
+            .expect("Failure to set the ZMQ send timeout");
         let to_addr = format!("{}:{}", member.get_address(), member.get_gossip_port());
         match socket.connect(&format!("tcp://{}", to_addr)) {
             Ok(()) => debug!("Connected push socket to {:?}", member),
@@ -188,7 +203,9 @@ impl PushWorker {
                     //           TraceKind::SendRumor,
                     //           member.get_id(),
                     //           &send_rumor);
-                    match self.server.service_store.write_to_bytes(&rumor_key.key, &rumor_key.id) {
+                    match self.server
+                              .service_store
+                              .write_to_bytes(&rumor_key.key, &rumor_key.id) {
                         Ok(bytes) => bytes,
                         Err(e) => {
                             println!("Could not write our own rumor to bytes; abandoning \
@@ -203,8 +220,9 @@ impl PushWorker {
                     //           TraceKind::SendRumor,
                     //           member.get_id(),
                     //           &send_rumor);
-                    match self.server.service_config_store.write_to_bytes(&rumor_key.key,
-                                                                          &rumor_key.id) {
+                    match self.server
+                              .service_config_store
+                              .write_to_bytes(&rumor_key.key, &rumor_key.id) {
                         Ok(bytes) => bytes,
                         Err(e) => {
                             println!("Could not write our own rumor to bytes; abandoning \
@@ -219,8 +237,9 @@ impl PushWorker {
                     //           TraceKind::SendRumor,
                     //           member.get_id(),
                     //           &send_rumor);
-                    match self.server.service_file_store.write_to_bytes(&rumor_key.key,
-                                                                        &rumor_key.id) {
+                    match self.server
+                              .service_file_store
+                              .write_to_bytes(&rumor_key.key, &rumor_key.id) {
                         Ok(bytes) => bytes,
                         Err(e) => {
                             println!("Could not write our own rumor to bytes; abandoning \
@@ -235,7 +254,9 @@ impl PushWorker {
                     //           TraceKind::SendRumor,
                     //           member.get_id(),
                     //           &send_rumor);
-                    match self.server.election_store.write_to_bytes(&rumor_key.key, &rumor_key.id) {
+                    match self.server
+                              .election_store
+                              .write_to_bytes(&rumor_key.key, &rumor_key.id) {
                         Ok(bytes) => bytes,
                         Err(e) => {
                             println!("Could not write our own rumor to bytes; abandoning \
@@ -246,7 +267,9 @@ impl PushWorker {
                     }
                 }
                 ProtoRumor_Type::ElectionUpdate => {
-                    match self.server.update_store.write_to_bytes(&rumor_key.key, &rumor_key.id) {
+                    match self.server
+                              .update_store
+                              .write_to_bytes(&rumor_key.key, &rumor_key.id) {
                         Ok(bytes) => bytes,
                         Err(e) => {
                             println!("Could not write our own rumor to bytes; abandoning sending \
@@ -274,16 +297,20 @@ impl PushWorker {
                 Err(e) => println!("Could not send rumor to {:?}; ZMQ said: {:?}", member, e),
             }
         }
-        self.server.rumor_list.update_heat(member.get_id(), &rumors);
+        self.server
+            .rumor_list
+            .update_heat(member.get_id(), &rumors);
     }
 
     /// Given a rumorkey, creates a protobuf rumor for sharing.
     fn create_member_rumor(&self, rumor_key: &RumorKey) -> ProtoRumor {
         let mut member: ProtoMember = ProtoMember::new();
-        self.server.member_list.with_member(&rumor_key.key(), |m| {
-            // TODO: This should not stand
-            member = m.unwrap().proto.clone();
-        });
+        self.server
+            .member_list
+            .with_member(&rumor_key.key(), |m| {
+                // TODO: This should not stand
+                member = m.unwrap().proto.clone();
+            });
         let mut membership = ProtoMembership::new();
         membership.set_member(member);
         membership.set_health(self.server

--- a/components/common/src/command/package/install.rs
+++ b/components/common/src/command/package/install.rs
@@ -258,7 +258,8 @@ impl<'a> InstallTask<'a> {
         }
 
         try!(ui.status(Status::Downloading, ident));
-        match self.depot_client.fetch_package(ident, self.cache_artifact_path, ui.progress()) {
+        match self.depot_client
+                  .fetch_package(ident, self.cache_artifact_path, ui.progress()) {
             Ok(_) => Ok(()),
             Err(depot_client::Error::APIError(StatusCode::NotImplemented, _)) => {
                 println!("Host platform or architecture not supported by the targted depot; \
@@ -273,7 +274,8 @@ impl<'a> InstallTask<'a> {
         try!(ui.status(Status::Downloading,
                        format!("{} public origin key", &name_with_rev)));
         let (name, rev) = try!(parse_name_with_rev(&name_with_rev));
-        try!(self.depot_client.fetch_origin_key(&name, &rev, self.cache_key_path, ui.progress()));
+        try!(self.depot_client
+                 .fetch_origin_key(&name, &rev, self.cache_key_path, ui.progress()));
         try!(ui.status(Status::Cached,
                        format!("{} public origin key", &name_with_rev)));
         Ok(())

--- a/components/common/src/ui.rs
+++ b/components/common/src/ui.rs
@@ -120,7 +120,9 @@ impl UI {
             true => {
                 try!(write!(stream,
                             "{}\n",
-                            Colour::Yellow.bold().paint(format!("∅ {}", message.to_string()))));
+                            Colour::Yellow
+                                .bold()
+                                .paint(format!("∅ {}", message.to_string()))));
             }
             false => {
                 try!(write!(stream, "∅ {}\n", message.to_string()));
@@ -132,7 +134,8 @@ impl UI {
 
     pub fn fatal<T: fmt::Display>(&mut self, message: T) -> Result<()> {
         let ref mut stream = self.shell.err;
-        let formatted_message = message.to_string()
+        let formatted_message = message
+            .to_string()
             .lines()
             .map(|line| format!("✗✗✗ {}", line))
             .collect::<Vec<_>>()
@@ -142,8 +145,10 @@ impl UI {
             true => {
                 try!(write!(stream,
                             "{}\n",
-                            Colour::Red.bold().paint(format!("✗✗✗\n{}\n✗✗✗",
-                                                             formatted_message))));
+                            Colour::Red
+                                .bold()
+                                .paint(format!("✗✗✗\n{}\n✗✗✗",
+                                               formatted_message))));
             }
             false => {
                 try!(write!(stream, "✗✗✗\n{}\n✗✗✗\n", formatted_message));
@@ -168,9 +173,11 @@ impl UI {
                 try!(write!(stream, "{}\n", Colour::Green.bold().paint(text)));
                 try!(write!(stream,
                             "{}\n\n",
-                            Colour::Green.bold().paint(format!("{:=<width$}",
-                                                               "",
-                                                               width = text.chars().count()))));
+                            Colour::Green
+                                .bold()
+                                .paint(format!("{:=<width$}",
+                                               "",
+                                               width = text.chars().count()))));
             }
             false => {
                 try!(write!(stream, "{}\n", text));
@@ -257,10 +264,7 @@ impl UI {
                 let reference = self.shell.input.by_ref();
                 try!(BufReader::new(reference).read_line(&mut response));
             }
-            match response.trim()
-                      .chars()
-                      .next()
-                      .unwrap_or('\n') {
+            match response.trim().chars().next().unwrap_or('\n') {
                 'y' | 'Y' => return Ok(true),
                 'n' | 'N' => return Ok(false),
                 'q' | 'Q' => process::exit(0),
@@ -329,7 +333,9 @@ impl UI {
             true => {
                 try!(write!(stream,
                             "{}\n",
-                            color.bold().paint(format!("{} {}", symbol, message.to_string()))))
+                            color
+                                .bold()
+                                .paint(format!("{} {}", symbol, message.to_string()))))
             }
             false => try!(write!(stream, "{} {}\n", symbol, message.to_string())),
         }

--- a/components/core/src/config.rs
+++ b/components/core/src/config.rs
@@ -257,7 +257,8 @@ impl ParseInto<BTreeMap<String, String>> for toml::Value {
             Some(val) => {
                 match val.as_table() {
                     Some(val_table) => {
-                        let buf: Result<BTreeMap<String, String>> = val_table.iter()
+                        let buf: Result<BTreeMap<String, String>> = val_table
+                            .iter()
                             .map(|(k, v)| match v.as_str() {
                                      Some(val_str) => Ok((k.to_string(), val_str.to_string())),
                                      None => Err(Error::ConfigInvalidTableString(field)),

--- a/components/core/src/crypto/artifact.rs
+++ b/components/core/src/crypto/artifact.rs
@@ -355,7 +355,8 @@ mod test {
         let cache = TempDir::new("key_cache").unwrap();
         let dst = cache.path().join("signed.dat");
         let mut f = File::create(&dst).unwrap();
-        f.write_all("HART-1\nnope-nope\nuhoh".as_bytes()).unwrap();
+        f.write_all("HART-1\nnope-nope\nuhoh".as_bytes())
+            .unwrap();
 
         verify(&dst, cache.path()).unwrap();
     }
@@ -367,7 +368,8 @@ mod test {
         let pair = SigKeyPair::generate_pair_for_origin("unicorn", cache.path()).unwrap();
         let dst = cache.path().join("signed.dat");
         let mut f = File::create(&dst).unwrap();
-        f.write_all(format!("HART-1\n{}\n", pair.name_with_rev()).as_bytes()).unwrap();
+        f.write_all(format!("HART-1\n{}\n", pair.name_with_rev()).as_bytes())
+            .unwrap();
 
         verify(&dst, cache.path()).unwrap();
     }
@@ -379,7 +381,8 @@ mod test {
         let pair = SigKeyPair::generate_pair_for_origin("unicorn", cache.path()).unwrap();
         let dst = cache.path().join("signed.dat");
         let mut f = File::create(&dst).unwrap();
-        f.write_all(format!("HART-1\n{}\nBESTEST\nuhoh", pair.name_with_rev()).as_bytes()).unwrap();
+        f.write_all(format!("HART-1\n{}\nBESTEST\nuhoh", pair.name_with_rev()).as_bytes())
+            .unwrap();
 
         verify(&dst, cache.path()).unwrap();
     }
@@ -391,7 +394,8 @@ mod test {
         let pair = SigKeyPair::generate_pair_for_origin("unicorn", cache.path()).unwrap();
         let dst = cache.path().join("signed.dat");
         let mut f = File::create(&dst).unwrap();
-        f.write_all(format!("HART-1\n{}\nBLAKE2b\n", pair.name_with_rev()).as_bytes()).unwrap();
+        f.write_all(format!("HART-1\n{}\nBLAKE2b\n", pair.name_with_rev()).as_bytes())
+            .unwrap();
 
         verify(&dst, cache.path()).unwrap();
     }
@@ -437,31 +441,25 @@ mod test {
         let f = File::open(&dst).unwrap();
         let f = BufReader::new(f);
         let mut lines = f.lines();
-        corrupted.write(lines.next()
-                            .unwrap()
-                            .unwrap()
-                            .as_bytes())
+        corrupted
+            .write(lines.next().unwrap().unwrap().as_bytes())
             .unwrap(); // version
         corrupted.write("\n".as_bytes()).unwrap();
-        corrupted.write(lines.next()
-                            .unwrap()
-                            .unwrap()
-                            .as_bytes())
+        corrupted
+            .write(lines.next().unwrap().unwrap().as_bytes())
             .unwrap(); // key
         corrupted.write("\n".as_bytes()).unwrap();
-        corrupted.write(lines.next()
-                            .unwrap()
-                            .unwrap()
-                            .as_bytes())
+        corrupted
+            .write(lines.next().unwrap().unwrap().as_bytes())
             .unwrap(); // hash type
         corrupted.write("\n".as_bytes()).unwrap();
-        corrupted.write(lines.next()
-                            .unwrap()
-                            .unwrap()
-                            .as_bytes())
+        corrupted
+            .write(lines.next().unwrap().unwrap().as_bytes())
             .unwrap(); // signature
         corrupted.write("\n\n".as_bytes()).unwrap();
-        corrupted.write_all("payload-wont-match-signature".as_bytes()).unwrap(); // archive
+        corrupted
+            .write_all("payload-wont-match-signature".as_bytes())
+            .unwrap(); // archive
 
         verify(&dst_corrupted, cache.path()).unwrap();
     }

--- a/components/core/src/crypto/hash.rs
+++ b/components/core/src/crypto/hash.rs
@@ -163,7 +163,8 @@ mod test {
                     }
                     _ => Client::new(),
                 };
-                let mut response = client.get(url)
+                let mut response = client
+                    .get(url)
                     .header(header::Connection::close())
                     .send()
                     .unwrap();

--- a/components/core/src/crypto/keys/box_key_pair.rs
+++ b/components/core/src/crypto/keys/box_key_pair.rs
@@ -334,8 +334,14 @@ mod test {
             Ok(_) => assert!(true),
             Err(_) => panic!("Generated pair should have a secret key"),
         }
-        assert!(cache.path().join(format!("{}.pub", pair.name_with_rev())).exists());
-        assert!(cache.path().join(format!("{}.box.key", pair.name_with_rev())).exists());
+        assert!(cache
+                    .path()
+                    .join(format!("{}.pub", pair.name_with_rev()))
+                    .exists());
+        assert!(cache
+                    .path()
+                    .join(format!("{}.box.key", pair.name_with_rev()))
+                    .exists());
     }
 
     #[test]
@@ -352,8 +358,14 @@ mod test {
             Ok(_) => assert!(true),
             Err(_) => panic!("Generated pair should have a secret key"),
         }
-        assert!(cache.path().join(format!("{}.pub", pair.name_with_rev())).exists());
-        assert!(cache.path().join(format!("{}.box.key", pair.name_with_rev())).exists());
+        assert!(cache
+                    .path()
+                    .join(format!("{}.pub", pair.name_with_rev()))
+                    .exists());
+        assert!(cache
+                    .path()
+                    .join(format!("{}.box.key", pair.name_with_rev()))
+                    .exists());
     }
 
     #[test]
@@ -477,7 +489,8 @@ mod test {
             .unwrap();
         let user = BoxKeyPair::generate_pair_for_user("wecoyote", cache.path()).unwrap();
 
-        let ciphertext = user.encrypt("I wish to buy more rockets".as_bytes(), &service).unwrap();
+        let ciphertext = user.encrypt("I wish to buy more rockets".as_bytes(), &service)
+            .unwrap();
         let message = BoxKeyPair::decrypt(&ciphertext, cache.path()).unwrap();
         assert_eq!(message, "I wish to buy more rockets".as_bytes());
     }
@@ -489,7 +502,9 @@ mod test {
             .unwrap();
         let user = BoxKeyPair::generate_pair_for_user("wecoyote", cache.path()).unwrap();
 
-        let ciphertext = service.encrypt("Out of rockets".as_bytes(), &user).unwrap();
+        let ciphertext = service
+            .encrypt("Out of rockets".as_bytes(), &user)
+            .unwrap();
         let message = BoxKeyPair::decrypt(&ciphertext, cache.path()).unwrap();
         assert_eq!(message, "Out of rockets".as_bytes());
     }
@@ -543,7 +558,9 @@ mod test {
             let sender = BoxKeyPair::get_latest_pair_for("wecoyote", sender_cache.path()).unwrap();
             let receiver = BoxKeyPair::get_latest_pair_for("tnt.default@acme", sender_cache.path())
                 .unwrap();
-            sender.encrypt("Falling hurts".as_bytes(), &receiver).unwrap()
+            sender
+                .encrypt("Falling hurts".as_bytes(), &receiver)
+                .unwrap()
         };
 
         // Decrypt unpacks the ciphertext payload to read nonce , determines which secret key to
@@ -568,7 +585,9 @@ mod test {
         // Now reload the sender's pair which will be missing the secret key
         let sender = BoxKeyPair::get_latest_pair_for("wecoyote", cache.path()).unwrap();
 
-        sender.encrypt("not going to happen".as_bytes(), &receiver).unwrap();
+        sender
+            .encrypt("not going to happen".as_bytes(), &receiver)
+            .unwrap();
     }
 
     #[test]
@@ -586,7 +605,9 @@ mod test {
         // Now reload the receiver's pair which will be missing the public key
         let receiver = BoxKeyPair::get_latest_pair_for("tnt.default@acme", cache.path()).unwrap();
 
-        sender.encrypt("not going to happen".as_bytes(), &receiver).unwrap();
+        sender
+            .encrypt("not going to happen".as_bytes(), &receiver)
+            .unwrap();
     }
 
     #[test]
@@ -602,7 +623,9 @@ mod test {
                             .unwrap())
                 .unwrap();
 
-        let ciphertext = sender.encrypt("problems ahead".as_bytes(), &receiver).unwrap();
+        let ciphertext = sender
+            .encrypt("problems ahead".as_bytes(), &receiver)
+            .unwrap();
         BoxKeyPair::decrypt(&ciphertext, cache.path()).unwrap();
     }
 
@@ -619,7 +642,9 @@ mod test {
                             .unwrap())
                 .unwrap();
 
-        let ciphertext = sender.encrypt("problems ahead".as_bytes(), &receiver).unwrap();
+        let ciphertext = sender
+            .encrypt("problems ahead".as_bytes(), &receiver)
+            .unwrap();
         BoxKeyPair::decrypt(&ciphertext, cache.path()).unwrap();
     }
 
@@ -693,7 +718,9 @@ mod test {
         let receiver = BoxKeyPair::generate_pair_for_service("acme", "tnt.default", cache.path())
             .unwrap();
 
-        let payload = sender.encrypt("problems ahead".as_bytes(), &receiver).unwrap();
+        let payload = sender
+            .encrypt("problems ahead".as_bytes(), &receiver)
+            .unwrap();
         let mut botched = String::new();
         let mut lines = str::from_utf8(payload.as_slice()).unwrap().lines();
         botched.push_str(lines.next().unwrap()); // version
@@ -717,7 +744,9 @@ mod test {
         let receiver = BoxKeyPair::generate_pair_for_service("acme", "tnt.default", cache.path())
             .unwrap();
 
-        let payload = sender.encrypt("problems ahead".as_bytes(), &receiver).unwrap();
+        let payload = sender
+            .encrypt("problems ahead".as_bytes(), &receiver)
+            .unwrap();
         let mut botched = String::new();
         let mut lines = str::from_utf8(payload.as_slice()).unwrap().lines();
         botched.push_str(lines.next().unwrap()); // version

--- a/components/core/src/crypto/keys/mod.rs
+++ b/components/core/src/crypto/keys/mod.rs
@@ -263,7 +263,8 @@ fn mk_key_filename<P, S1, S2>(path: P, keyname: S1, suffix: S2) -> PathBuf
           S1: AsRef<str>,
           S2: AsRef<str>
 {
-    path.as_ref().join(format!("{}.{}", keyname.as_ref(), suffix.as_ref()))
+    path.as_ref()
+        .join(format!("{}.{}", keyname.as_ref(), suffix.as_ref()))
 }
 
 /// generates a revision string in the form:
@@ -501,7 +502,8 @@ mod test {
         let cache = TempDir::new("key_cache").unwrap();
         let keyfile = cache.path().join("missing-newlines");
         let mut f = File::create(&keyfile).unwrap();
-        f.write_all("header\nsomething\n\nI am not base64 content".as_bytes()).unwrap();
+        f.write_all("header\nsomething\n\nI am not base64 content".as_bytes())
+            .unwrap();
 
         super::read_key_bytes(keyfile.as_path()).unwrap();
     }

--- a/components/core/src/crypto/keys/sig_key_pair.rs
+++ b/components/core/src/crypto/keys/sig_key_pair.rs
@@ -241,10 +241,7 @@ impl SigKeyPair {
         let tmpfile = {
             let mut t = keyfile.clone();
             t.set_file_name(format!("{}.{}",
-                                    &keyfile.file_name()
-                                         .unwrap()
-                                         .to_str()
-                                         .unwrap(),
+                                    &keyfile.file_name().unwrap().to_str().unwrap(),
                                     &randombytes(6).as_slice().to_hex()));
             TmpKeyfile { path: t }
         };
@@ -463,8 +460,14 @@ mod test {
             Ok(_) => assert!(true),
             Err(_) => panic!("Generated pair should have a secret key"),
         }
-        assert!(cache.path().join(format!("{}.pub", pair.name_with_rev())).exists());
-        assert!(cache.path().join(format!("{}.sig.key", pair.name_with_rev())).exists());
+        assert!(cache
+                    .path()
+                    .join(format!("{}.pub", pair.name_with_rev()))
+                    .exists());
+        assert!(cache
+                    .path()
+                    .join(format!("{}.sig.key", pair.name_with_rev()))
+                    .exists());
     }
 
     #[test]
@@ -599,7 +602,9 @@ mod test {
         let new_content = {
             let mut new_content_file = File::open(new_key_file).unwrap();
             let mut new_content = String::new();
-            new_content_file.read_to_string(&mut new_content).unwrap();
+            new_content_file
+                .read_to_string(&mut new_content)
+                .unwrap();
             new_content
         };
 
@@ -621,7 +626,9 @@ mod test {
         let new_content = {
             let mut new_content_file = File::open(new_key_file).unwrap();
             let mut new_content = String::new();
-            new_content_file.read_to_string(&mut new_content).unwrap();
+            new_content_file
+                .read_to_string(&mut new_content)
+                .unwrap();
             new_content
         };
 
@@ -742,7 +749,9 @@ mod test {
         let cache = TempDir::new("key_cache").unwrap();
         let key = fixture("keys/origin-key-valid-20160509190508.sig.key");
         fs::copy(key,
-                 cache.path().join("origin-key-valid-20160509190508.sig.key"))
+                 cache
+                     .path()
+                     .join("origin-key-valid-20160509190508.sig.key"))
                 .unwrap();
 
         SigKeyPair::write_file_from_str(

--- a/components/core/src/crypto/keys/sym_key.rs
+++ b/components/core/src/crypto/keys/sym_key.rs
@@ -331,10 +331,7 @@ impl SymKey {
         let tmpfile = {
             let mut t = secret_keyfile.clone();
             t.set_file_name(format!("{}.{}",
-                                    &secret_keyfile.file_name()
-                                         .unwrap()
-                                         .to_str()
-                                         .unwrap(),
+                                    &secret_keyfile.file_name().unwrap().to_str().unwrap(),
                                     &randombytes(6).as_slice().to_hex()));
             TmpKeyfile { path: t }
         };
@@ -446,7 +443,10 @@ mod test {
             Ok(_) => assert!(true),
             Err(_) => panic!("Generated pair should have a secret key"),
         }
-        assert!(cache.path().join(format!("{}.sym.key", pair.name_with_rev())).exists());
+        assert!(cache
+                    .path()
+                    .join(format!("{}.sym.key", pair.name_with_rev()))
+                    .exists());
     }
 
     #[test]
@@ -588,7 +588,8 @@ mod test {
         let pair = SymKey::generate_pair_for_ring("beyonce", cache.path()).unwrap();
 
         let (_, ciphertext) = pair.encrypt("Ringonit".as_bytes()).unwrap();
-        pair.decrypt("crazyinlove".as_bytes(), &ciphertext).unwrap();
+        pair.decrypt("crazyinlove".as_bytes(), &ciphertext)
+            .unwrap();
     }
 
     #[test]
@@ -616,7 +617,9 @@ mod test {
         let new_content = {
             let mut new_content_file = File::open(new_key_file).unwrap();
             let mut new_content = String::new();
-            new_content_file.read_to_string(&mut new_content).unwrap();
+            new_content_file
+                .read_to_string(&mut new_content)
+                .unwrap();
             new_content
         };
 
@@ -677,7 +680,9 @@ mod test {
         let cache = TempDir::new("key_cache").unwrap();
         let key = fixture("keys/ring-key-valid-20160504220722.sym.key");
         fs::copy(key,
-                 cache.path().join("ring-key-valid-20160504220722.sym.key"))
+                 cache
+                     .path()
+                     .join("ring-key-valid-20160504220722.sym.key"))
                 .unwrap();
 
         SymKey::write_file_from_str("SYM-SEC-1\nring-key-valid-20160504220722\n\nsomething",

--- a/components/core/src/crypto/mod.rs
+++ b/components/core/src/crypto/mod.rs
@@ -294,8 +294,10 @@ pub mod test_support {
     use error as herror;
 
     pub fn fixture(name: &str) -> PathBuf {
-        let path =
-            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests").join("fixtures").join(name);
+        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests")
+            .join("fixtures")
+            .join(name);
         if !path.is_file() {
             panic!("Fixture '{}' not found at: {:?}", name, path);
         }

--- a/components/core/src/event.rs
+++ b/components/core/src/event.rs
@@ -126,7 +126,11 @@ impl Serialize for Event {
         where S: Serializer
     {
         let strukt = match *self {
-            Event::ProjectCreate { origin: ref o, package: ref p, account: ref a } => {
+            Event::ProjectCreate {
+                origin: ref o,
+                package: ref p,
+                account: ref a,
+            } => {
                 let mut strukt = try!(serializer.serialize_struct("event", 4));
                 try!(strukt.serialize_field("name", &self.to_string()));
                 try!(strukt.serialize_field("origin", o));
@@ -134,12 +138,14 @@ impl Serialize for Event {
                 try!(strukt.serialize_field("account", a));
                 strukt
             }
-            Event::PackageUpload { origin: ref o,
-                                   package: ref p,
-                                   version: ref v,
-                                   release: ref r,
-                                   target: ref t,
-                                   account: ref a } => {
+            Event::PackageUpload {
+                origin: ref o,
+                package: ref p,
+                version: ref v,
+                release: ref r,
+                target: ref t,
+                account: ref a,
+            } => {
                 let mut strukt = try!(serializer.serialize_struct("event", 6));
                 try!(strukt.serialize_field("name", &self.to_string()));
                 try!(strukt.serialize_field("origin", o));
@@ -150,10 +156,12 @@ impl Serialize for Event {
                 try!(strukt.serialize_field("account", a));
                 strukt
             }
-            Event::OriginInvitationSend { origin: ref o,
-                                          user: ref u,
-                                          id: ref i,
-                                          account: ref a } => {
+            Event::OriginInvitationSend {
+                origin: ref o,
+                user: ref u,
+                id: ref i,
+                account: ref a,
+            } => {
                 let mut strukt = try!(serializer.serialize_struct("event", 5));
                 try!(strukt.serialize_field("name", &self.to_string()));
                 try!(strukt.serialize_field("origin", o));
@@ -162,35 +170,51 @@ impl Serialize for Event {
                 try!(strukt.serialize_field("account", a));
                 strukt
             }
-            Event::OriginInvitationAccept { id: ref i, account: ref a } => {
+            Event::OriginInvitationAccept {
+                id: ref i,
+                account: ref a,
+            } => {
                 let mut strukt = try!(serializer.serialize_struct("event", 3));
                 try!(strukt.serialize_field("name", &self.to_string()));
                 try!(strukt.serialize_field("id", i));
                 try!(strukt.serialize_field("account", a));
                 strukt
             }
-            Event::OriginInvitationIgnore { id: ref i, account: ref a } => {
+            Event::OriginInvitationIgnore {
+                id: ref i,
+                account: ref a,
+            } => {
                 let mut strukt = try!(serializer.serialize_struct("event", 3));
                 try!(strukt.serialize_field("name", &self.to_string()));
                 try!(strukt.serialize_field("id", i));
                 try!(strukt.serialize_field("account", a));
                 strukt
             }
-            Event::JobCreate { package: ref p, account: ref a } => {
+            Event::JobCreate {
+                package: ref p,
+                account: ref a,
+            } => {
                 let mut strukt = try!(serializer.serialize_struct("event", 3));
                 try!(strukt.serialize_field("name", &self.to_string()));
                 try!(strukt.serialize_field("package", p));
                 try!(strukt.serialize_field("account", a));
                 strukt
             }
-            Event::GithubAuthenticate { user: ref u, account: ref a } => {
+            Event::GithubAuthenticate {
+                user: ref u,
+                account: ref a,
+            } => {
                 let mut strukt = try!(serializer.serialize_struct("event", 3));
                 try!(strukt.serialize_field("name", &self.to_string()));
                 try!(strukt.serialize_field("user", u));
                 try!(strukt.serialize_field("account", a));
                 strukt
             }
-            Event::OriginKeyUpload { origin: ref o, version: ref v, account: ref a } => {
+            Event::OriginKeyUpload {
+                origin: ref o,
+                version: ref v,
+                account: ref a,
+            } => {
                 let mut strukt = try!(serializer.serialize_struct("event", 4));
                 try!(strukt.serialize_field("name", &self.to_string()));
                 try!(strukt.serialize_field("origin", o));
@@ -198,7 +222,11 @@ impl Serialize for Event {
                 try!(strukt.serialize_field("account", a));
                 strukt
             }
-            Event::OriginSecretKeyUpload { origin: ref o, version: ref v, account: ref a } => {
+            Event::OriginSecretKeyUpload {
+                origin: ref o,
+                version: ref v,
+                account: ref a,
+            } => {
                 let mut strukt = try!(serializer.serialize_struct("event", 4));
                 try!(strukt.serialize_field("name", &self.to_string()));
                 try!(strukt.serialize_field("origin", o));
@@ -275,7 +303,8 @@ impl EventLogger {
     pub fn record_event(&self, event: Event) {
         if self.enabled {
             let envelope = Envelope::new(&event);
-            let file_path = self.log_dir.join(format!("event-{}.json", &envelope.timestamp));
+            let file_path = self.log_dir
+                .join(format!("event-{}.json", &envelope.timestamp));
             write_file(&self.log_dir, &file_path, &envelope);
         }
     }

--- a/components/core/src/fs.rs
+++ b/components/core/src/fs.rs
@@ -264,8 +264,8 @@ pub fn find_command_in_pkg(command: &str,
                            -> Result<Option<PathBuf>> {
     for path in try!(pkg_install.paths()) {
         let stripped =
-            path.strip_prefix("/").expect(&format!("Package path missing / prefix {}",
-                                                   path.to_string_lossy()));
+            path.strip_prefix("/")
+                .expect(&format!("Package path missing / prefix {}", path.to_string_lossy()));
         let candidate = fs_root_path.join(stripped).join(command);
         if candidate.is_file() {
             return Ok(Some(path.join(command)));

--- a/components/core/src/os/process/windows.rs
+++ b/components/core/src/os/process/windows.rs
@@ -260,7 +260,9 @@ mod tests {
     fn running_process_returns_no_exit_status() {
         let mut cmd = Command::new("C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.\
                                     exe");
-        cmd.arg("-noprofile").arg("-command").arg("while($true) { Start-Sleep 1 }");
+        cmd.arg("-noprofile")
+            .arg("-command")
+            .arg("while($true) { Start-Sleep 1 }");
         let mut child = cmd.spawn().unwrap();
 
         let mut hab_child = HabChild::from(&mut child).unwrap();
@@ -285,7 +287,9 @@ mod tests {
     fn terminated_process_returns_non_zero_exit() {
         let mut cmd = Command::new("C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.\
                                     exe");
-        cmd.arg("-noprofile").arg("-command").arg("while($true) { Start-Sleep 1 }");
+        cmd.arg("-noprofile")
+            .arg("-command")
+            .arg("while($true) { Start-Sleep 1 }");
         let mut child = cmd.spawn().unwrap();
 
         let mut hab_child = HabChild::from(&mut child).unwrap();

--- a/components/core/src/os/system/linux.rs
+++ b/components/core/src/os/system/linux.rs
@@ -34,10 +34,20 @@ unsafe fn uname_libc() -> Result<Uname> {
         return Err(Error::UnameFailed(format!("Error {} when calling uname: {}", code, errno)));
     }
     Ok(Uname {
-           sys_name: CStr::from_ptr(utsname.sysname.as_ptr()).to_string_lossy().into_owned(),
-           node_name: CStr::from_ptr(utsname.nodename.as_ptr()).to_string_lossy().into_owned(),
-           release: CStr::from_ptr(utsname.release.as_ptr()).to_string_lossy().into_owned(),
-           version: CStr::from_ptr(utsname.version.as_ptr()).to_string_lossy().into_owned(),
-           machine: CStr::from_ptr(utsname.machine.as_ptr()).to_string_lossy().into_owned(),
+           sys_name: CStr::from_ptr(utsname.sysname.as_ptr())
+               .to_string_lossy()
+               .into_owned(),
+           node_name: CStr::from_ptr(utsname.nodename.as_ptr())
+               .to_string_lossy()
+               .into_owned(),
+           release: CStr::from_ptr(utsname.release.as_ptr())
+               .to_string_lossy()
+               .into_owned(),
+           version: CStr::from_ptr(utsname.version.as_ptr())
+               .to_string_lossy()
+               .into_owned(),
+           machine: CStr::from_ptr(utsname.machine.as_ptr())
+               .to_string_lossy()
+               .into_owned(),
        })
 }

--- a/components/core/src/package/archive.rs
+++ b/components/core/src/package/archive.rs
@@ -134,8 +134,9 @@ impl PackageArchive {
     pub fn exposes(&mut self) -> Result<Vec<u16>> {
         match self.read_metadata(MetaFile::Exposes) {
             Ok(Some(data)) => {
-                let ports: Vec<u16> =
-                    data.split(" ").filter_map(|port| port.parse::<u16>().ok()).collect();
+                let ports: Vec<u16> = data.split(" ")
+                    .filter_map(|port| port.parse::<u16>().ok())
+                    .collect();
                 Ok(ports)
             }
             Ok(None) => Ok(vec![]),
@@ -313,10 +314,7 @@ impl PackageArchive {
             }
         }
         self.metadata = Some(metadata);
-        Ok(self.metadata
-               .as_ref()
-               .unwrap()
-               .get(&file))
+        Ok(self.metadata.as_ref().unwrap().get(&file))
     }
 }
 

--- a/components/core/src/package/install.rs
+++ b/components/core/src/package/install.rs
@@ -99,8 +99,9 @@ impl PackageInstall {
                 Err(Error::PackageNotFound(ident.clone()))
             }
         } else {
-            let latest: Option<PackageIdent> =
-                pl.iter().filter(|&p| p.satisfies(ident)).fold(None, |winner, b| match winner {
+            let latest: Option<PackageIdent> = pl.iter()
+                .filter(|&p| p.satisfies(ident))
+                .fold(None, |winner, b| match winner {
                     Some(a) => {
                         match a.partial_cmp(&b) {
                             Some(Ordering::Greater) => Some(a),
@@ -263,11 +264,13 @@ impl PackageInstall {
             Ok(body) => {
                 for line in body.lines() {
                     let mut parts = line.splitn(2, '=');
-                    let key = parts.next()
+                    let key = parts
+                        .next()
                         .and_then(|p| Some(p.to_string()))
                         .ok_or_else(|| Error::MetaFileMalformed(MetaFile::Environment))?;
                     let value =
-                        parts.next()
+                        parts
+                            .next()
                             .and_then(|p| Some(p.to_string()))
                             .ok_or_else(|| Error::MetaFileMalformed(MetaFile::Environment))?;
                     m.insert(key, value);
@@ -292,11 +295,13 @@ impl PackageInstall {
                 for line in body.lines() {
                     let mut parts = line.splitn(2, '=');
                     let key =
-                        parts.next()
+                        parts
+                            .next()
                             .and_then(|p| Some(p.to_string()))
                             .ok_or_else(|| Error::MetaFileMalformed(MetaFile::EnvironmentSep))?;
                     let value =
-                        parts.next()
+                        parts
+                            .next()
                             .and_then(|p| Some(p.to_string()))
                             .ok_or_else(|| Error::MetaFileMalformed(MetaFile::EnvironmentSep))?;
                     m.insert(key, value);
@@ -320,13 +325,15 @@ impl PackageInstall {
                 for line in body.lines() {
                     let mut parts = line.split('=');
                     let key =
-                        try!(parts.next()
-                        .and_then(|p| Some(p.to_string()))
-                        .ok_or_else(|| Error::MetaFileMalformed(MetaFile::Exports)));
+                        try!(parts
+                                 .next()
+                                 .and_then(|p| Some(p.to_string()))
+                                 .ok_or_else(|| Error::MetaFileMalformed(MetaFile::Exports)));
                     let value =
-                        try!(parts.next()
-                        .and_then(|p| Some(p.to_string()))
-                        .ok_or_else(|| Error::MetaFileMalformed(MetaFile::Exports)));
+                        try!(parts
+                                 .next()
+                                 .and_then(|p| Some(p.to_string()))
+                                 .ok_or_else(|| Error::MetaFileMalformed(MetaFile::Exports)));
                     m.insert(key, value);
                 }
                 Ok(m)
@@ -340,8 +347,9 @@ impl PackageInstall {
     pub fn exposes(&self) -> Result<Vec<String>> {
         match self.read_metafile(MetaFile::Exposes) {
             Ok(body) => {
-                let v: Vec<String> =
-                    body.split(' ').map(|x| String::from(x.trim_right_matches('\n'))).collect();
+                let v: Vec<String> = body.split(' ')
+                    .map(|x| String::from(x.trim_right_matches('\n')))
+                    .collect();
                 Ok(v)
             }
             Err(Error::MetaFileNotFound(MetaFile::Exposes)) => {
@@ -364,7 +372,9 @@ impl PackageInstall {
     pub fn paths(&self) -> Result<Vec<PathBuf>> {
         match self.read_metafile(MetaFile::Path) {
             Ok(body) => {
-                let v = env::split_paths(&body).map(|p| PathBuf::from(&p)).collect();
+                let v = env::split_paths(&body)
+                    .map(|p| PathBuf::from(&p))
+                    .collect();
                 Ok(v)
             }
             Err(Error::MetaFileNotFound(MetaFile::Path)) => {
@@ -394,8 +404,9 @@ impl PackageInstall {
         let env = self.environment()?;
         if !env.is_empty() {
             if let Some(path) = env.get("PATH") {
-                let mut v: Vec<PathBuf> =
-                    env::split_paths(&path).map(|p| PathBuf::from(&p)).collect();
+                let mut v: Vec<PathBuf> = env::split_paths(&path)
+                    .map(|p| PathBuf::from(&p))
+                    .collect();
                 legacy_run_paths.append(&mut v);
             }
 
@@ -414,8 +425,9 @@ impl PackageInstall {
             let env_sep = dep.environment_sep()?;
             if !env.is_empty() {
                 if let Some(path) = env.get("PATH") {
-                    let mut v: Vec<PathBuf> =
-                        env::split_paths(&path).map(|p| PathBuf::from(&p)).collect();
+                    let mut v: Vec<PathBuf> = env::split_paths(&path)
+                        .map(|p| PathBuf::from(&p))
+                        .collect();
                     legacy_run_paths.append(&mut v);
                 }
 
@@ -454,8 +466,9 @@ impl PackageInstall {
             let env_sep = dep.environment_sep()?;
             if !env.is_empty() {
                 if let Some(path) = env.get("PATH") {
-                    let mut v: Vec<PathBuf> =
-                        env::split_paths(&path).map(|p| PathBuf::from(&p)).collect();
+                    let mut v: Vec<PathBuf> = env::split_paths(&path)
+                        .map(|p| PathBuf::from(&p))
+                        .collect();
                     legacy_run_paths.append(&mut v);
                 }
 
@@ -488,7 +501,8 @@ impl PackageInstall {
         if has_legacy_run_paths {
             // Overwrite PATH with legacy_run_paths
             let p = env::join_paths(&legacy_run_paths).expect("Failed to build path string");
-            let v = p.into_string().expect("Failed to convert path to utf8 string");
+            let v = p.into_string()
+                .expect("Failed to convert path to utf8 string");
             run_envs.insert("PATH".to_string(), v);
         }
 
@@ -642,7 +656,8 @@ impl PackageInstall {
     fn walk_names(origin: &DirEntry, packages: &mut Vec<PackageIdent>) -> Result<()> {
         for name in try!(std::fs::read_dir(origin.path())) {
             let name = try!(name);
-            let origin = origin.file_name()
+            let origin = origin
+                .file_name()
                 .to_string_lossy()
                 .into_owned()
                 .to_string();
@@ -687,7 +702,8 @@ impl PackageInstall {
                 .to_string_lossy()
                 .into_owned()
                 .to_string();
-            let version = version.file_name()
+            let version = version
+                .file_name()
                 .to_string_lossy()
                 .into_owned()
                 .to_string();

--- a/components/core/src/package/mod.rs
+++ b/components/core/src/package/mod.rs
@@ -30,8 +30,10 @@ pub mod test_support {
     use std::path::PathBuf;
 
     pub fn fixture_path(name: &str) -> PathBuf {
-        let path =
-            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests").join("fixtures").join(name);
+        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests")
+            .join("fixtures")
+            .join(name);
         path
     }
 }

--- a/components/core/src/service.rs
+++ b/components/core/src/service.rs
@@ -51,8 +51,9 @@ impl ServiceGroup {
     }
 
     pub fn validate(value: &str) -> Result<()> {
-        let caps =
-            FROM_STR_RE.captures(value).ok_or(Error::InvalidServiceGroup(value.to_string()))?;
+        let caps = FROM_STR_RE
+            .captures(value)
+            .ok_or(Error::InvalidServiceGroup(value.to_string()))?;
         if caps.name("service").is_none() {
             return Err(Error::InvalidServiceGroup(value.to_string()));
         }
@@ -63,7 +64,8 @@ impl ServiceGroup {
     }
 
     pub fn service(&self) -> &str {
-        FROM_STR_RE.captures(&self.0)
+        FROM_STR_RE
+            .captures(&self.0)
             .unwrap()
             .name("service")
             .unwrap()
@@ -71,7 +73,8 @@ impl ServiceGroup {
     }
 
     pub fn group(&self) -> &str {
-        FROM_STR_RE.captures(&self.0)
+        FROM_STR_RE
+            .captures(&self.0)
             .unwrap()
             .name("group")
             .unwrap()
@@ -79,7 +82,8 @@ impl ServiceGroup {
     }
 
     pub fn org(&self) -> Option<&str> {
-        FROM_STR_RE.captures(&self.0)
+        FROM_STR_RE
+            .captures(&self.0)
             .unwrap()
             .name("organization")
             .and_then(|v| Some(v.as_str()))

--- a/components/hab-butterfly/src/command/config.rs
+++ b/components/hab-butterfly/src/command/config.rs
@@ -78,7 +78,8 @@ pub mod apply {
             try!(ui.status(Status::Applying, format!("to peer {}", peer)));
             let mut client = try!(Client::new(peer, ring_key.map(|k| k.clone()))
                 .map_err(|e| Error::ButterflyError(format!("{}", e))));
-            try!(client.send_service_config(sg.clone(), number, body.clone(), encrypted)
+            try!(client
+                     .send_service_config(sg.clone(), number, body.clone(), encrypted)
                      .map_err(|e| Error::ButterflyError(format!("{}", e))));
 
             // please take a moment to weep over the following line

--- a/components/hab-butterfly/src/command/file.rs
+++ b/components/hab-butterfly/src/command/file.rs
@@ -46,7 +46,8 @@ pub mod upload {
         try!(file.read_to_end(&mut body));
 
         // Safe because clap checks that this is a real file that exists
-        let filename = file_path.file_name()
+        let filename = file_path
+            .file_name()
             .unwrap()
             .to_string_lossy()
             .into_owned();
@@ -65,11 +66,12 @@ pub mod upload {
             try!(ui.status(Status::Applying, format!("to peer {}", peer)));
             let mut client = try!(Client::new(peer, ring_key.map(|k| k.clone()))
                 .map_err(|e| Error::ButterflyError(format!("{}", e))));
-            try!(client.send_service_file(sg.clone(),
-                                          filename.clone(),
-                                          number,
-                                          body.clone(),
-                                          encrypted)
+            try!(client
+                     .send_service_file(sg.clone(),
+                                        filename.clone(),
+                                        number,
+                                        body.clone(),
+                                        encrypted)
                      .map_err(|e| Error::ButterflyError(format!("{}", e))));
 
             // please take a moment to weep over the following line

--- a/components/hab-butterfly/src/main.rs
+++ b/components/hab-butterfly/src/main.rs
@@ -199,12 +199,16 @@ fn sub_file_upload(ui: &mut UI, m: &ArgMatches) -> Result<()> {
 }
 
 fn ui() -> UI {
-    let isatty = if henv::var(NONINTERACTIVE_ENVVAR).map(|val| val == "true").unwrap_or(false) {
+    let isatty = if henv::var(NONINTERACTIVE_ENVVAR)
+           .map(|val| val == "true")
+           .unwrap_or(false) {
         Some(false)
     } else {
         None
     };
-    let coloring = if henv::var(NOCOLORING_ENVVAR).map(|val| val == "true").unwrap_or(false) {
+    let coloring = if henv::var(NOCOLORING_ENVVAR)
+           .map(|val| val == "true")
+           .unwrap_or(false) {
         Coloring::Never
     } else {
         Coloring::Auto

--- a/components/hab-spider/src/data_store.rs
+++ b/components/hab-spider/src/data_store.rs
@@ -67,7 +67,8 @@ impl DataStore {
 
         let conn = self.pool.get()?;
 
-        let rows = &conn.query("SELECT * FROM get_packages_v1()", &[]).map_err(Error::PackagesGet)?;
+        let rows = &conn.query("SELECT * FROM get_packages_v1()", &[])
+                        .map_err(Error::PackagesGet)?;
 
         if rows.is_empty() {
             warn!("No packages found");

--- a/components/hab-spider/src/main.rs
+++ b/components/hab-spider/src/main.rs
@@ -44,7 +44,10 @@ fn main() {
     let matches = App::new("hab-spider")
         .version("0.1.0")
         .about("Habitat package graph builder")
-        .arg(Arg::with_name("URL").help("The DB connection URL").required(true).index(1))
+        .arg(Arg::with_name("URL")
+                 .help("The DB connection URL")
+                 .required(true)
+                 .index(1))
         .get_matches();
 
     let connection_url = matches.value_of("URL").unwrap();
@@ -72,7 +75,10 @@ fn main() {
     let mut done = false;
     while !done {
         print!("spider> ");
-        io::stdout().flush().ok().expect("Could not flush stdout");
+        io::stdout()
+            .flush()
+            .ok()
+            .expect("Could not flush stdout");
 
         let mut cmd = String::new();
         io::stdin().read_line(&mut cmd).unwrap();

--- a/components/hab/src/analytics.rs
+++ b/components/hab/src/analytics.rs
@@ -600,7 +600,8 @@ fn send_pending() {
         // If the directory entry is a file and the base file name starts with `event-`, then this
         // is a cached event. Otherwise proceed to the next entry.
         if metadata.is_file() &&
-           entry.file_name()
+           entry
+               .file_name()
                .to_string_lossy()
                .as_ref()
                .starts_with("event-") {

--- a/components/hab/src/command/butterfly.rs
+++ b/components/hab/src/command/butterfly.rs
@@ -74,13 +74,13 @@ mod inner {
     pub fn start(ui: &mut UI, args: Vec<OsString>) -> Result<()> {
         let mut args = args.iter();
         let subcmd = match (args.next()
-                   .map(|a| a.to_string_lossy())
-                   .unwrap_or_default()
-                   .as_ref(),
-               args.next()
-                   .map(|a| a.to_string_lossy())
-                   .unwrap_or_default()
-                   .as_ref()) {
+                                .map(|a| a.to_string_lossy())
+                                .unwrap_or_default()
+                                .as_ref(),
+                            args.next()
+                                .map(|a| a.to_string_lossy())
+                                .unwrap_or_default()
+                                .as_ref()) {
             ("config", "apply") => "config apply",
             ("config", _) => "config",
             ("file", "upload") => "file upload",

--- a/components/hab/src/command/pkg/provides.rs
+++ b/components/hab/src/command/pkg/provides.rs
@@ -43,7 +43,9 @@ pub fn start(filename: &str,
                 let mut comps = entry.path().components();
 
                 // skip prefix_count segments of the path
-                let _ = try!(comps.nth(prefix_count).ok_or(Error::FileNotFound(f.to_string())));
+                let _ = try!(comps
+                                 .nth(prefix_count)
+                                 .ok_or(Error::FileNotFound(f.to_string())));
 
                 let segments = if full_releases {
                     // take all 4 segments of the path
@@ -55,8 +57,9 @@ pub fn start(filename: &str,
                     comps.take(2)
                 };
 
-                let mapped_segs: Vec<String> =
-                    segments.map(|c| c.as_os_str().to_string_lossy().into_owned()).collect();
+                let mapped_segs: Vec<String> = segments
+                    .map(|c| c.as_os_str().to_string_lossy().into_owned())
+                    .collect();
                 let pkg_name = mapped_segs.join("/");
 
                 // if we show the full path, then don't bother stuffing

--- a/components/hab/src/command/plan/init.rs
+++ b/components/hab/src/command/plan/init.rs
@@ -45,14 +45,13 @@ pub fn start(ui: &mut UI,
              canonicalize(".")
                  .ok()
                  .and_then(|path| {
-                path.components().last().and_then(|val| {
-                    // Type gymnastics!
-                    val.as_os_str()
-                        .to_os_string()
-                        .into_string()
-                        .ok()
-                })
-            })
+                               path.components()
+                                   .last()
+                                   .and_then(|val| {
+                                                 // Type gymnastics!
+                                                 val.as_os_str().to_os_string().into_string().ok()
+                                             })
+                           })
                  .unwrap_or("unnamed".into()))
         }
     };

--- a/components/hab/src/command/studio/mod.rs
+++ b/components/hab/src/command/studio/mod.rs
@@ -119,8 +119,9 @@ mod inner {
         // Otherwise we will try to re-run this program using `sudo`
         match find_command(SUDO_CMD) {
             Some(sudo_prog) => {
-                let mut args: Vec<OsString> =
-                    vec!["-p".into(), "[sudo hab-studio] password for %u: ".into(), "-E".into()];
+                let mut args: Vec<OsString> = vec!["-p".into(),
+                                                   "[sudo hab-studio] password for %u: ".into(),
+                                                   "-E".into()];
                 args.append(&mut env::args_os().collect());
                 Ok(try!(process::become_command(sudo_prog, args)))
             }
@@ -225,7 +226,9 @@ mod inner {
                 .spawn()
                 .expect("docker failed to start");
 
-            let output = child.wait_with_output().expect("failed to wait on child");
+            let output = child
+                .wait_with_output()
+                .expect("failed to wait on child");
 
             if output.status.success() {
                 debug!("Docker image is reachable. Proceeding with launching docker.");

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -185,7 +185,8 @@ fn sub_cli_setup(ui: &mut UI) -> Result<()> {
 }
 
 fn sub_cli_completers(m: &ArgMatches) -> Result<()> {
-    let shell = m.value_of("SHELL").expect("Missing Shell; A shell is required");
+    let shell = m.value_of("SHELL")
+        .expect("Missing Shell; A shell is required");
     cli::get().gen_completions_to("hab", shell.parse::<Shell>().unwrap(), &mut io::stdout());
     Ok(())
 }
@@ -402,7 +403,9 @@ fn sub_pkg_upload(ui: &mut UI, m: &ArgMatches) -> Result<()> {
     let env_or_default = henv::var(DEPOT_URL_ENVVAR).unwrap_or(DEFAULT_DEPOT_URL.to_string());
     let key_path = cache_key_path(Some(&*FS_ROOT));
     // don't use a pathbuf, as the P generic param for upload::start below is bound to a &str
-    let key_path = try!(key_path.to_str().ok_or(Error::CryptoCLI("Invalid key path".to_string())));
+    let key_path = try!(key_path
+                            .to_str()
+                            .ok_or(Error::CryptoCLI("Invalid key path".to_string())));
     let url = m.value_of("DEPOT_URL").unwrap_or(&env_or_default);
     let token = try!(auth_token_param_or_env(&m));
     let artifact_paths = m.values_of("HART_FILE").unwrap(); // Required via clap
@@ -467,12 +470,16 @@ fn sub_user_key_generate(ui: &mut UI, m: &ArgMatches) -> Result<()> {
 }
 
 fn ui() -> UI {
-    let isatty = if henv::var(NONINTERACTIVE_ENVVAR).map(|val| val == "true").unwrap_or(false) {
+    let isatty = if henv::var(NONINTERACTIVE_ENVVAR)
+           .map(|val| val == "true")
+           .unwrap_or(false) {
         Some(false)
     } else {
         None
     };
-    let coloring = if henv::var(NOCOLORING_ENVVAR).map(|val| val == "true").unwrap_or(false) {
+    let coloring = if henv::var(NOCOLORING_ENVVAR)
+           .map(|val| val == "true")
+           .unwrap_or(false) {
         Coloring::Never
     } else {
         Coloring::Auto

--- a/components/http-client/src/api_client.rs
+++ b/components/http-client/src/api_client.rs
@@ -301,6 +301,7 @@ fn ssl_connector(fs_root_path: Option<&Path>) -> Result<SslConnector> {
     options.toggle(SSL_OP_NO_COMPRESSION);
     try!(ssl::set_ca(conn.builder_mut(), fs_root_path));
     conn.builder_mut().set_options(options);
-    try!(conn.builder_mut().set_cipher_list("ALL!EXPORT!EXPORT40!EXPORT56!aNULL!LOW!RC4@STRENGTH"));
+    try!(conn.builder_mut()
+             .set_cipher_list("ALL!EXPORT!EXPORT40!EXPORT56!aNULL!LOW!RC4@STRENGTH"));
     Ok(conn.build())
 }

--- a/components/http-client/src/net.rs
+++ b/components/http-client/src/net.rs
@@ -47,8 +47,8 @@ impl<S: SslClient> NetworkConnector for ProxyHttpsConnector<S> {
 
     fn connect(&self, host: &str, port: u16, scheme: &str) -> hyper::Result<Self::Stream> {
         // Initial connection to the proxy server, using an `HttpConnector`
-        let mut stream =
-            try!(self.proxy_connector.connect(self.proxy.host(), self.proxy.port(), "http"));
+        let mut stream = try!(self.proxy_connector
+                                  .connect(self.proxy.host(), self.proxy.port(), "http"));
         match scheme {
             "https" => {
                 // If the target URL is an `"https"` scheme, then we use proxy/TCP tunneling as

--- a/components/net/src/http/middleware.rs
+++ b/components/net/src/http/middleware.rs
@@ -163,10 +163,11 @@ pub struct Cors;
 impl AfterMiddleware for Cors {
     fn after(&self, _req: &mut Request, mut res: Response) -> IronResult<Response> {
         res.headers.set(headers::AccessControlAllowOrigin::Any);
-        res.headers.set(headers::AccessControlAllowHeaders(vec![UniCase("authorization"
-                                                                            .to_string()),
-                                                                UniCase("range".to_string())]));
-        res.headers.set(headers::AccessControlAllowMethods(vec![Method::Put, Method::Delete]));
+        res.headers
+            .set(headers::AccessControlAllowHeaders(vec![UniCase("authorization".to_string()),
+                                                         UniCase("range".to_string())]));
+        res.headers
+            .set(headers::AccessControlAllowMethods(vec![Method::Put, Method::Delete]));
         Ok(res)
     }
 }
@@ -178,7 +179,8 @@ pub fn session_create(github: &GitHubClient, token: &str) -> IronResult<Session>
             // no email is associated with account return an access denied error.
             let email = match github.emails(&token) {
                 Ok(ref emails) => {
-                    emails.iter()
+                    emails
+                        .iter()
                         .find(|e| e.primary)
                         .unwrap_or(&emails[0])
                         .email

--- a/components/net/src/server.rs
+++ b/components/net/src/server.rs
@@ -221,7 +221,9 @@ pub trait Service: NetIdent {
             try!(self.conn_mut().heartbeat.recv(&mut hb, 0));
             debug!("received reg request, {:?}", hb.as_str());
             try!(self.conn_mut().heartbeat.send_str("R", zmq::SNDMORE));
-            try!(self.conn_mut().heartbeat.send(&reg.write_to_bytes().unwrap(), 0));
+            try!(self.conn_mut()
+                     .heartbeat
+                     .send(&reg.write_to_bytes().unwrap(), 0));
             try!(self.conn_mut().heartbeat.recv(&mut hb, 0));
             ready += 1;
         }

--- a/components/net/src/supervisor.rs
+++ b/components/net/src/supervisor.rs
@@ -34,10 +34,7 @@ impl<T> Supervisor<T>
     // JW TODO: this should take a struct that implements "application config"
     pub fn new(config: Arc<RwLock<T::Config>>, state: <T as Dispatcher>::InitState) -> Self {
         let worker_count = {
-            config.read()
-                .unwrap()
-                .deref()
-                .worker_count()
+            config.read().unwrap().deref().worker_count()
         };
         Supervisor {
             config: config,
@@ -57,10 +54,7 @@ impl<T> Supervisor<T>
     // requests.
     fn init(&mut self) -> super::Result<()> {
         let worker_count = {
-            self.config
-                .read()
-                .unwrap()
-                .worker_count()
+            self.config.read().unwrap().worker_count()
         };
         for worker_id in 0..worker_count {
             try!(self.spawn_worker(worker_id));
@@ -70,10 +64,7 @@ impl<T> Supervisor<T>
 
     fn run(mut self) -> super::Result<()> {
         let worker_count = {
-            self.config
-                .read()
-                .unwrap()
-                .worker_count()
+            self.config.read().unwrap().worker_count()
         };
         thread::spawn(move || {
             loop {

--- a/components/sup/src/http_gateway.rs
+++ b/components/sup/src/http_gateway.rs
@@ -159,10 +159,12 @@ impl Server {
 
     pub fn start(self) -> Result<JoinHandle<()>> {
         let handle = try!(thread::Builder::new()
-            .name("http-gateway".to_string())
-            .spawn(move || {
-                self.0.http(*self.1).expect("unable to start http-gateway thread");
-            }));
+                              .name("http-gateway".to_string())
+                              .spawn(move || {
+                                         self.0
+                                             .http(*self.1)
+                                             .expect("unable to start http-gateway thread");
+                                     }));
         Ok(handle)
     }
 }
@@ -281,9 +283,6 @@ fn build_service_group(req: &mut Request) -> Result<ServiceGroup> {
                                    .unwrap()
                                    .find("group")
                                    .unwrap_or(""),
-                               req.extensions
-                                   .get::<Router>()
-                                   .unwrap()
-                                   .find("org"))?;
+                               req.extensions.get::<Router>().unwrap().find("org"))?;
     Ok(sg)
 }

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -284,7 +284,8 @@ fn sub_start(m: &ArgMatches) -> Result<()> {
         Some(ident_or_artifact) => {
             let ident = if Path::new(ident_or_artifact).is_file() {
                 maybe_local_artifact = Some(ident_or_artifact);
-                PackageArchive::new(Path::new(ident_or_artifact)).ident()?
+                PackageArchive::new(Path::new(ident_or_artifact))
+                    .ident()?
             } else {
                 PackageIdent::from_str(ident_or_artifact)?
             };
@@ -437,7 +438,9 @@ fn spec_from_matches(ident: PackageIdent, m: &ArgMatches) -> Result<ServiceSpec>
         outputln!("");
         outputln!("{} Setting '{}' should only be used in development, not production!",
                   Red.bold().paint("WARNING:".to_string()),
-                  Yellow.bold().paint(format!("--config-from {}", config_from)));
+                  Yellow
+                      .bold()
+                      .paint(format!("--config-from {}", config_from)));
         outputln!("");
     }
 

--- a/components/sup/src/manager/census.rs
+++ b/components/sup/src/manager/census.rs
@@ -436,10 +436,7 @@ impl Census {
 
     /// Return all members.
     pub fn members(&self) -> Vec<&CensusEntry> {
-        self.population
-            .values()
-            .map(|ce| ce)
-            .collect()
+        self.population.values().map(|ce| ce).collect()
     }
 
     /// Return all members ordered by member_id.
@@ -455,31 +452,24 @@ impl Census {
 
     /// Return the leader of the currently running update election or None if there is no leader.
     pub fn get_update_leader(&self) -> Option<&CensusEntry> {
-        self.population.values().find(|&ce| ce.get_update_leader())
+        self.population
+            .values()
+            .find(|&ce| ce.get_update_leader())
     }
 
     pub fn get_service_group(&self) -> String {
         // We know we have one, because otherwise the census wouldn't exist
-        let entry = self.population
-            .values()
-            .nth(0)
-            .unwrap();
+        let entry = self.population.values().nth(0).unwrap();
         entry.get_service_group()
     }
 
     pub fn get_group(&self) -> &str {
-        let entry = self.population
-            .values()
-            .nth(0)
-            .unwrap();
+        let entry = self.population.values().nth(0).unwrap();
         entry.get_group()
     }
 
     pub fn get_service(&self) -> &str {
-        let entry = self.population
-            .values()
-            .nth(0)
-            .unwrap();
+        let entry = self.population.values().nth(0).unwrap();
         entry.get_service()
     }
 
@@ -490,7 +480,9 @@ impl Census {
         if members.len() <= 1 || self.me().is_none() {
             return None;
         }
-        match members.iter().position(|ce| ce.member_id == self.me().unwrap().member_id) {
+        match members
+                  .iter()
+                  .position(|ce| ce.member_id == self.me().unwrap().member_id) {
             Some(idx) => {
                 let peer = idx + 1;
                 if peer >= members.len() {
@@ -510,7 +502,9 @@ impl Census {
         if members.len() <= 1 || self.me().is_none() {
             return None;
         }
-        match members.iter().position(|ce| ce.member_id == self.me().unwrap().member_id) {
+        match members
+                  .iter()
+                  .position(|ce| ce.member_id == self.me().unwrap().member_id) {
             Some(idx) => {
                 if idx <= 0 {
                     Some(members[members.len() - 1])
@@ -542,8 +536,9 @@ impl CensusList {
     }
 
     pub fn insert(&mut self, member_id: String, census_entry: CensusEntry) {
-        let census =
-            self.censuses.entry(census_entry.get_service_group()).or_insert(Census::new(member_id));
+        let census = self.censuses
+            .entry(census_entry.get_service_group())
+            .or_insert(Census::new(member_id));
         if census.contains_key(census_entry.get_member_id()) {
             let entry = census.get_mut(census_entry.get_member_id()).unwrap();
             *entry = census_entry;

--- a/components/sup/src/manager/service/config.rs
+++ b/components/sup/src/manager/service/config.rs
@@ -255,12 +255,15 @@ impl Bind {
         for ref bind in bindings.iter() {
             match census_list.get(&*bind.service_group) {
                 Some(census) => {
-                    self.0.insert(format!("has_{}", bind.name), toml::Value::Boolean(true));
-                    self.0.insert(bind.name.to_string(),
-                                  toml::Value::Table(service_entry(census)));
+                    self.0
+                        .insert(format!("has_{}", bind.name), toml::Value::Boolean(true));
+                    self.0
+                        .insert(bind.name.to_string(),
+                                toml::Value::Table(service_entry(census)));
                 }
                 None => {
-                    self.0.insert(format!("has_{}", bind.name), toml::Value::Boolean(false));
+                    self.0
+                        .insert(format!("has_{}", bind.name), toml::Value::Boolean(false));
                 }
             }
         }
@@ -276,14 +279,16 @@ pub struct Svc(toml::value::Table);
 
 impl Svc {
     pub fn populate(&mut self, service_group: &ServiceGroup, census_list: &CensusList) {
-        let mut top = service_entry(census_list.get(&*service_group)
-            .expect("Service Group's census entry missing from list!"));
+        let mut top = service_entry(census_list
+                                        .get(&*service_group)
+                                        .expect("Service Group's census entry missing from list!"));
         let mut all: Vec<toml::Value> = Vec::new();
         let mut named = toml::value::Table::new();
         for (_sg, c) in census_list.iter() {
             all.push(toml::Value::Table(service_entry(c)));
             let mut group = if named.contains_key(c.get_service()) {
-                named.get(c.get_service())
+                named
+                    .get(c.get_service())
                     .unwrap()
                     .as_table()
                     .unwrap()
@@ -313,7 +318,8 @@ fn service_entry(census: &Census) -> toml::value::Table {
     let service = toml::Value::String(String::from(census.get_service()));
     let group = toml::Value::String(String::from(census.get_group()));
     let ident = toml::Value::String(census.get_service_group());
-    let leader = census.get_leader()
+    let leader = census
+        .get_leader()
         .map(|ce| toml::Value::try_from(ce).expect("Can't convert into TOML Value"));
     let mut members: Vec<toml::Value> = Vec::new();
     let mut member_id = toml::value::Table::new();
@@ -488,8 +494,9 @@ impl Cfg {
     }
 
     fn load_environment(&mut self, package: &str) -> Result<()> {
-        let var_name =
-            format!("{}_{}", ENV_VAR_PREFIX, package).to_ascii_uppercase().replace("-", "_");
+        let var_name = format!("{}_{}", ENV_VAR_PREFIX, package)
+            .to_ascii_uppercase()
+            .replace("-", "_");
         match env::var(&var_name) {
             Ok(config) => {
                 let toml = try!(toml::de::from_str(&config)
@@ -652,7 +659,9 @@ fn toml_merge_recurse(me: &mut toml::value::Table,
                 }
             };
             try!(toml_merge_recurse(&mut me_at_key,
-                                    other_value.as_table().expect("TOML Value should be a Table"),
+                                    other_value
+                                        .as_table()
+                                        .expect("TOML Value should be a Table"),
                                     depth + 1));
         } else {
             me.insert(key.clone(), other_value.clone());
@@ -1003,10 +1012,7 @@ mod test {
         fn to_toml() {
             let s = Sys::new(&GossipListenAddr::default(), &ListenAddr::default());
             let toml = s.to_toml().unwrap();
-            let ip = toml.get("ip")
-                .unwrap()
-                .as_str()
-                .unwrap();
+            let ip = toml.get("ip").unwrap().as_str().unwrap();
             let re = Regex::new(r"\d+\.\d+\.\d+\.\d+").unwrap();
             assert!(re.is_match(&ip));
         }
@@ -1026,10 +1032,7 @@ mod test {
         fn to_toml() {
             let h = Hab::new();
             let version_toml = h.to_toml().unwrap();
-            let version = version_toml.get("version")
-                .unwrap()
-                .as_str()
-                .unwrap();
+            let version = version_toml.get("version").unwrap().as_str().unwrap();
             assert_eq!(version, VERSION);
         }
     }

--- a/components/sup/src/manager/service/hooks.rs
+++ b/components/sup/src/manager/service/hooks.rs
@@ -708,10 +708,11 @@ impl HookTable {
     fn compile_one<H>(&self, hook: &H, service_group: &ServiceGroup, config: &ServiceConfig)
         where H: Hook
     {
-        hook.compile(config).unwrap_or_else(|e| {
-                                                outputln!(preamble service_group,
+        hook.compile(config)
+            .unwrap_or_else(|e| {
+                                outputln!(preamble service_group,
                 "Failed to compile {} hook: {}", H::file_name(), e);
-                                            });
+                            });
     }
 }
 
@@ -726,7 +727,8 @@ impl RenderPair {
               T: AsRef<Path>
     {
         let mut template = Template::new();
-        template.register_template_file("hook", template_path.as_ref())?;
+        template
+            .register_template_file("hook", template_path.as_ref())?;
         Ok(RenderPair {
                path: concrete_path.into(),
                template: template,
@@ -744,10 +746,7 @@ impl Serialize for RenderPair {
     fn serialize<S>(&self, serializer: S) -> result::Result<S::Ok, S::Error>
         where S: Serializer
     {
-        serializer.serialize_str(&self.path
-                                      .as_os_str()
-                                      .to_string_lossy()
-                                      .into_owned())
+        serializer.serialize_str(&self.path.as_os_str().to_string_lossy().into_owned())
     }
 }
 
@@ -790,7 +789,9 @@ impl<'a> HookOutput<'a> {
             for line in BufReader::new(stdout).lines() {
                 if let Some(ref l) = line.ok() {
                     outputln!(preamble preamble_str, l);
-                    stdout_log.write_fmt(format_args!("{}\n", l)).expect("couldn't write line");
+                    stdout_log
+                        .write_fmt(format_args!("{}\n", l))
+                        .expect("couldn't write line");
                 }
             }
         }
@@ -798,7 +799,9 @@ impl<'a> HookOutput<'a> {
             for line in BufReader::new(stderr).lines() {
                 if let Some(ref l) = line.ok() {
                     outputln!(preamble preamble_str, l);
-                    stderr_log.write_fmt(format_args!("{}\n", l)).expect("couldn't write line");
+                    stderr_log
+                        .write_fmt(format_args!("{}\n", l))
+                        .expect("couldn't write line");
                 }
             }
         }
@@ -819,21 +822,33 @@ mod tests {
 
 
     fn hook_fixtures_path() -> PathBuf {
-        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests").join("fixtures").join("hooks")
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests")
+            .join("fixtures")
+            .join("hooks")
     }
 
     #[test]
     fn hook_output() {
         let tmp_dir = TempDir::new("habitat_hooks_test").expect("create temp dir");
         let logs_dir = tmp_dir.path().join("logs");
-        DirBuilder::new().recursive(true).create(logs_dir).expect("couldn't create logs dir");
+        DirBuilder::new()
+            .recursive(true)
+            .create(logs_dir)
+            .expect("couldn't create logs dir");
         let mut cmd = Command::new(hook_fixtures_path().join(InitHook::file_name()));
-        cmd.stdin(Stdio::null()).stdout(Stdio::piped()).stderr(Stdio::piped());
+        cmd.stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
         let mut child = cmd.spawn().expect("couldn't run hook");
-        let stdout_log =
-            tmp_dir.path().join("logs").join(format!("{}.stdout.log", InitHook::file_name()));
-        let stderr_log =
-            tmp_dir.path().join("logs").join(format!("{}.stderr.log", InitHook::file_name()));
+        let stdout_log = tmp_dir
+            .path()
+            .join("logs")
+            .join(format!("{}.stdout.log", InitHook::file_name()));
+        let stderr_log = tmp_dir
+            .path()
+            .join("logs")
+            .join(format!("{}.stderr.log", InitHook::file_name()));
         let mut hook_output = HookOutput::new(&stdout_log, &stderr_log);
         let service_group =
             ServiceGroup::new("dummy", "service", None).expect("couldn't create ServiceGroup");
@@ -841,14 +856,16 @@ mod tests {
         hook_output.stream_output::<InitHook>(&service_group, &mut child);
 
         let mut stdout = String::new();
-        hook_output.stdout()
+        hook_output
+            .stdout()
             .unwrap()
             .read_to_string(&mut stdout)
             .expect("couldn't read stdout");
         assert_eq!(stdout, "This is stdout\n");
 
         let mut stderr = String::new();
-        hook_output.stderr()
+        hook_output
+            .stderr()
             .unwrap()
             .read_to_string(&mut stderr)
             .expect("couldn't read stderr");

--- a/components/sup/src/manager/service/spec.rs
+++ b/components/sup/src/manager/service/spec.rs
@@ -111,7 +111,8 @@ impl ServiceSpec {
 
     pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Self> {
         let file =
-            File::open(&path).map_err(|err| {
+            File::open(&path)
+                .map_err(|err| {
                              sup_error!(Error::ServiceSpecFileIO(path.as_ref().to_path_buf(), err))
                          })?;
         let mut file = BufReader::new(file);
@@ -125,32 +126,29 @@ impl ServiceSpec {
         debug!("Writing service spec to '{}': {:?}",
                path.as_ref().display(),
                &self);
-        let dst_path =
-            path.as_ref().parent().expect("Cannot determine parent directory for service spec");
-        let tmpfile = path.as_ref().with_extension(thread_rng()
-                                                       .gen_ascii_chars()
-                                                       .take(8)
-                                                       .collect::<String>());
-        fs::create_dir_all(dst_path).map_err(|err| {
-                         sup_error!(Error::ServiceSpecFileIO(path.as_ref()
-                                                                    .to_path_buf(),
-                                                                err))
-                     })?;
+        let dst_path = path.as_ref()
+            .parent()
+            .expect("Cannot determine parent directory for service spec");
+        let tmpfile = path.as_ref()
+            .with_extension(thread_rng()
+                                .gen_ascii_chars()
+                                .take(8)
+                                .collect::<String>());
+        fs::create_dir_all(dst_path)
+            .map_err(|err| sup_error!(Error::ServiceSpecFileIO(path.as_ref().to_path_buf(), err)))?;
         // Release the write file handle before the end of the function since we're done
         {
             let mut file =
-                File::create(&tmpfile).map_err(|err| {
+                File::create(&tmpfile)
+                    .map_err(|err| {
                                  sup_error!(Error::ServiceSpecFileIO(tmpfile.to_path_buf(), err))
                              })?;
             let toml = self.to_toml_string()?;
             file.write_all(toml.as_bytes())
                 .map_err(|err| sup_error!(Error::ServiceSpecFileIO(tmpfile.to_path_buf(), err)))?;
         }
-        fs::rename(&tmpfile, path.as_ref()).map_err(|err| {
-                         sup_error!(Error::ServiceSpecFileIO(path.as_ref()
-                                                                    .to_path_buf(),
-                                                                err))
-                     })?;
+        fs::rename(&tmpfile, path.as_ref())
+            .map_err(|err| sup_error!(Error::ServiceSpecFileIO(path.as_ref().to_path_buf(), err)))?;
 
         Ok(())
     }
@@ -165,7 +163,8 @@ impl ServiceSpec {
     }
 
     fn validate_binds(&self, package: &PackageInstall) -> Result<()> {
-        let missing: Vec<String> = package.binds()?
+        let missing: Vec<String> = package
+            .binds()?
             .into_iter()
             .filter(|bind| {
                         self.binds
@@ -202,8 +201,8 @@ impl FromStr for ServiceSpec {
     type Err = SupError;
 
     fn from_str(toml: &str) -> result::Result<Self, Self::Err> {
-        let spec: ServiceSpec =
-            toml::from_str(toml).map_err(|e| sup_error!(Error::ServiceSpecParse(e)))?;
+        let spec: ServiceSpec = toml::from_str(toml)
+            .map_err(|e| sup_error!(Error::ServiceSpecParse(e)))?;
         if spec.ident == PackageIdent::default() {
             return Err(sup_error!(Error::MissingRequiredIdent));
         }
@@ -307,18 +306,20 @@ mod test {
 
     fn file_from_str<P: AsRef<Path>>(path: P, content: &str) {
         fs::create_dir_all(path.as_ref()
-                .parent()
-                .expect("failed to determine file's parent directory"))
-            .expect("failed to create parent directory recursively");
+                               .parent()
+                               .expect("failed to determine file's parent directory"))
+                .expect("failed to create parent directory recursively");
         let mut file = File::create(path).expect("failed to create file");
-        file.write_all(content.as_bytes()).expect("failed to write content to file");
+        file.write_all(content.as_bytes())
+            .expect("failed to write content to file");
     }
 
     fn string_from_file<P: AsRef<Path>>(path: P) -> String {
         let file = File::open(path).expect("failed to open file");
         let mut file = BufReader::new(file);
         let mut buf = String::new();
-        file.read_to_string(&mut buf).expect("cannot read file to string");
+        file.read_to_string(&mut buf)
+            .expect("cannot read file to string");
         buf
     }
 

--- a/components/sup/src/output.rs
+++ b/components/sup/src/output.rs
@@ -120,10 +120,9 @@ impl<'a> fmt::Display for StructuredOutput<'a> {
                        "{}({})[{}]: {}",
                        preamble_color.paint(self.preamble),
                        White.bold().paint(self.logkey),
-                       White.underline().paint(format!("{}:{}:{}",
-                                                       self.file,
-                                                       self.line,
-                                                       self.column)),
+                       White
+                           .underline()
+                           .paint(format!("{}:{}:{}", self.file, self.line, self.column)),
                        self.content)
             } else {
                 write!(f,

--- a/components/sup/src/templating/helpers.rs
+++ b/components/sup/src/templating/helpers.rs
@@ -30,7 +30,7 @@ type RenderResult = Result<(), RenderError>;
 pub fn each_alive(h: &Helper, r: &Handlebars, rc: &mut RenderContext) -> RenderResult {
     let value =
         try!(h.param(0)
-            .ok_or_else(|| RenderError::new("Param not found for helper \"eachAlive\"")))
+                 .ok_or_else(|| RenderError::new("Param not found for helper \"eachAlive\"")))
                 .value();
 
     let template =
@@ -88,7 +88,11 @@ pub fn pkg_path_for(h: &Helper, _: &Handlebars, rc: &mut RenderContext) -> Rende
         .deps
         .iter()
         .find(|ident| ident.satisfies(&param))
-        .and_then(|i| Some(fs::pkg_install_path(&i, None).to_string_lossy().into_owned()))
+        .and_then(|i| {
+                      Some(fs::pkg_install_path(&i, None)
+                               .to_string_lossy()
+                               .into_owned())
+                  })
         .unwrap_or("".to_string());
     try!(rc.writer.write(pkg.into_bytes().as_ref()));
     Ok(())
@@ -99,7 +103,8 @@ pub fn to_uppercase(h: &Helper, _: &Handlebars, rc: &mut RenderContext) -> Rende
         try!(h.param(0)
         .and_then(|v| v.value().as_str())
         .ok_or_else(|| RenderError::new("Expected a string parameter for \"toUppercase\"")));
-    try!(rc.writer.write(param.to_uppercase().into_bytes().as_ref()));
+    try!(rc.writer
+             .write(param.to_uppercase().into_bytes().as_ref()));
     Ok(())
 }
 
@@ -108,7 +113,8 @@ pub fn to_lowercase(h: &Helper, _: &Handlebars, rc: &mut RenderContext) -> Rende
         try!(h.param(0)
         .and_then(|v| v.value().as_str())
         .ok_or_else(|| RenderError::new("Expected a string parameter for \"toLowercase\"")));
-    try!(rc.writer.write(param.to_lowercase().into_bytes().as_ref()));
+    try!(rc.writer
+             .write(param.to_lowercase().into_bytes().as_ref()));
     Ok(())
 }
 
@@ -125,13 +131,14 @@ pub fn str_replace(h: &Helper, _: &Handlebars, rc: &mut RenderContext) -> Render
         try!(h.param(2)
         .and_then(|v| v.value().as_str())
         .ok_or_else(|| RenderError::new("Expected 3 string parameters for \"strReplace\"")));
-    try!(rc.writer.write(param.replace(old, new).into_bytes().as_ref()));
+    try!(rc.writer
+             .write(param.replace(old, new).into_bytes().as_ref()));
     Ok(())
 }
 
 pub fn to_json(h: &Helper, _: &Handlebars, rc: &mut RenderContext) -> RenderResult {
     let param = try!(h.param(0)
-            .ok_or_else(|| RenderError::new("Expected 1 parameter for \"toJson\"")))
+                         .ok_or_else(|| RenderError::new("Expected 1 parameter for \"toJson\"")))
             .value();
     let json =
         try!(serde_json::to_string_pretty(param)
@@ -142,7 +149,7 @@ pub fn to_json(h: &Helper, _: &Handlebars, rc: &mut RenderContext) -> RenderResu
 
 pub fn to_toml(h: &Helper, _: &Handlebars, rc: &mut RenderContext) -> RenderResult {
     let param = try!(h.param(0)
-            .ok_or_else(|| RenderError::new("Expected 1 parameter for \"toToml\"")))
+                         .ok_or_else(|| RenderError::new("Expected 1 parameter for \"toToml\"")))
             .value();
     let bytes =
         try!(toml::ser::to_vec(&param)

--- a/components/sup/src/templating/mod.rs
+++ b/components/sup/src/templating/mod.rs
@@ -208,10 +208,13 @@ mod test {
     fn each_alive_helper_content() {
         let mut template = Template::new();
         // template using the new `eachAlive` helper
-        template.register_template_file("each_alive", templates().join("each_alive.txt")).unwrap();
+        template
+            .register_template_file("each_alive", templates().join("each_alive.txt"))
+            .unwrap();
 
         // template using an each block with a nested if block filtering on `alive`
-        template.register_template_file("all_members", templates().join("all_members.txt"))
+        template
+            .register_template_file("all_members", templates().join("all_members.txt"))
             .unwrap();
 
         let data = service_config_json_from_toml_file("multiple_supervisors_config.toml");
@@ -226,10 +229,13 @@ mod test {
     fn each_alive_helper_first_node() {
         let mut template = Template::new();
         // template using the new `eachAlive` helper
-        template.register_template_file("each_alive", templates().join("each_alive.txt")).unwrap();
+        template
+            .register_template_file("each_alive", templates().join("each_alive.txt"))
+            .unwrap();
 
         // template using an each block with a nested if block filtering on `alive`
-        template.register_template_file("all_members", templates().join("all_members.txt"))
+        template
+            .register_template_file("all_members", templates().join("all_members.txt"))
             .unwrap();
 
         let data = service_config_json_from_toml_file("one_supervisor_not_started.toml");
@@ -244,12 +250,14 @@ mod test {
     fn each_alive_helper_with_identifier_alias() {
         let mut template = Template::new();
         // template using the new `eachAlive` helper
-        template.register_template_file("each_alive",
-                                        templates().join("each_alive_with_identifier.txt"))
+        template
+            .register_template_file("each_alive",
+                                    templates().join("each_alive_with_identifier.txt"))
             .unwrap();
 
         // template using an each block with a nested if block filtering on `alive`
-        template.register_template_file("all_members", templates().join("all_members.txt"))
+        template
+            .register_template_file("all_members", templates().join("all_members.txt"))
             .unwrap();
 
         let data = service_config_json_from_toml_file("multiple_supervisors_config.toml");

--- a/components/sup/src/util/mod.rs
+++ b/components/sup/src/util/mod.rs
@@ -72,10 +72,12 @@ pub fn parse_ip_port_with_defaults(s: Option<&str>,
 pub fn create_command<S: AsRef<OsStr>>(path: S, cfg: &RuntimeConfig) -> Result<Command> {
     let mut cmd = Command::new(path);
     use std::os::unix::process::CommandExt;
-    let uid = os::users::get_uid_by_name(&cfg.svc_user).ok_or(sup_error!(Error::Permissions(
-                format!("No uid for user '{}' could be found", &cfg.svc_user))))?;
-    let gid = os::users::get_gid_by_name(&cfg.svc_group).ok_or(sup_error!(Error::Permissions(
-                format!("No gid for group '{}' could be found", &cfg.svc_group))))?;
+    let uid = os::users::get_uid_by_name(&cfg.svc_user)
+        .ok_or(sup_error!(Error::Permissions(format!("No uid for user '{}' could be found",
+                                                     &cfg.svc_user))))?;
+    let gid = os::users::get_gid_by_name(&cfg.svc_group)
+        .ok_or(sup_error!(Error::Permissions(format!("No gid for group '{}' could be found",
+                                                     &cfg.svc_group))))?;
 
     cmd.stdin(Stdio::null())
         .stdout(Stdio::piped())

--- a/components/sup/src/util/path.rs
+++ b/components/sup/src/util/path.rs
@@ -145,7 +145,9 @@ pub fn append_interpreter_and_path(orig_paths: &mut Vec<PathBuf>) -> Result<Stri
         orig_paths.append(&mut os_paths);
     }
     let joined = try!(env::join_paths(orig_paths));
-    let path_str = joined.into_string().expect("Unable to convert OsStr path to string!");
+    let path_str = joined
+        .into_string()
+        .expect("Unable to convert OsStr path to string!");
     Ok(path_str)
 }
 

--- a/components/sup/src/util/pkg.rs
+++ b/components/sup/src/util/pkg.rs
@@ -45,7 +45,8 @@ pub fn maybe_install_newer(ui: &mut UI,
                            -> Result<PackageInstall> {
     let latest_ident: PackageIdent = {
         let depot_client = Client::new(&spec.depot_url, PRODUCT, VERSION, None)?;
-        depot_client.show_package(&spec.ident)?
+        depot_client
+            .show_package(&spec.ident)?
             .get_ident()
             .clone()
             .into()

--- a/support/ci/install_rustfmt.sh
+++ b/support/ci/install_rustfmt.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eu
 
-version=0.8.0
+version=0.8.3
 
 if command -v rustfmt >/dev/null; then
   if [[ $(rustfmt --version | cut -d ' ' -f 1) = "$version" ]]; then

--- a/support/ci/lint.sh
+++ b/support/ci/lint.sh
@@ -47,7 +47,7 @@ exit_with() {
 }
 
 program=$(basename $0)
-rf_version="0.8.0"
+rf_version="0.8.3"
 
 # Fix commit range in Travis, if set.
 # See: https://github.com/travis-ci/travis-ci/issues/4596


### PR DESCRIPTION
This PR reformats the source with rustfmt 0.8.3, and moves CI to match.

![gif-keyboard-15625627984140379618](https://cloud.githubusercontent.com/assets/4304/24874351/2a4fac68-1dd9-11e7-9c96-aae24c0971b7.gif)
