### PR TITLE
Fix dependency issues in Scaffolding.

### DIFF
--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -1763,6 +1763,9 @@ _load_scaffolding() {
   if [[ "$(type -t _scaffolding_begin)" == "function" ]]; then
     _scaffolding_begin
   fi
+
+  build_line "Resolving Scaffolding dependencies"
+  _resolve_dependencies
 }
 
 # **Internal**  Build `$PATH` containing each path in our own
@@ -2768,11 +2771,11 @@ _inject_scaffolding_dependency
 # Download and resolve the dependencies
 _resolve_dependencies
 
-# Set up runtime environment
-_set_environment
-
 # Load scaffolding plans if they are being used.
 _load_scaffolding
+
+# Set up runtime environment
+_set_environment
 
 # Download the source
 mkdir -pv "$HAB_CACHE_SRC_PATH"


### PR DESCRIPTION
This moves the call to `_load_scaffolding` to before the ` _set_environment` call and adds a call to rerun the `_resolve_dependencies` to the `_load_scaffolding` function after the Scaffolding
has been sourced into plan-build.

By re-running `_resolve_dependencies` we ensure any build-time or run-time dependencies which are defined within the Scaffolding are downloaded and properly added to the path. This is common for interpreted languages which have tools to download and install packages which are written in the targeted language, thereby requiring the interpreter to be installed during both build and runtime.

Example `lib/scaffolding.sh`:
```bash
scaffolding_python_pkg="core/python"

_scaffolding_begin() {
  pkg_deps=(${pkg_deps[@]} $scaffolding_python_pkg)
  pkg_build_deps=(${pkg_build_deps[@]} $scaffolding_python_pkg)
}
```
Resolves Issue #2073.

Signed-off-by: Ryan Hass <rhass@users.noreply.github.com>