### PR TITLE
Tighten the scope of pkg_path_for's deserializing

### DIFF
--- a/components/sup/src/manager/service/mod.rs
+++ b/components/sup/src/manager/service/mod.rs
@@ -53,7 +53,7 @@ use manager::census::{CensusList, CensusUpdate, ElectionStatus};
 use supervisor::{Supervisor, RuntimeConfig};
 use util;
 
-pub use self::config::ServiceConfig;
+pub use self::config::{ServiceConfig, Pkg};
 pub use self::health::{HealthCheck, SmokeCheck};
 pub use self::spec::{DesiredState, ServiceBind, ServiceSpec, StartStyle};
 

--- a/components/sup/src/templating/mod.rs
+++ b/components/sup/src/templating/mod.rs
@@ -180,14 +180,14 @@ mod test {
 
     #[test]
     fn pkg_path_for_helper() {
-        let content = "{{pkgPathFor \"core/jq-static\"}}".to_string();
+        let content = "{{pkgPathFor \"core/acl\"}}".to_string();
         let mut template = Template::new();
         template.register_template_string("t", content).unwrap();
 
-        let data = service_config_json_from_toml_file("simple_config.toml");
+        let data = service_config_json_from_toml_file("complex_config.toml");
         let rendered = template.render("t", &data).unwrap();
         assert_eq!(PathBuf::from(rendered),
-                   PathBuf::from("/hab/pkgs/core/jq-static/1.10/20160909011845"));
+                   PathBuf::from("/hab/pkgs/core/acl/2.2.52/20161208223311"));
     }
 
     #[test]


### PR DESCRIPTION
#See https://github.com/habitat-sh/habitat/issues/2067 for more details about the buggy behavior

Goal:
- [X] Target just the `Pkgl` struct for de-serialization in the `pkg_path_for` helper

Bonus points:
- [ ] Find where, when hydrating the `ServiceConfig` struct that the toml parse error is coming from (the values should all be coming from the json object, so hydrating part of that struct has a side effect somewhere) 

/cc @bodymindarts 

Signed-off-by: Steven Murawski <steven.murawski@gmail.com>