### PR TITLE
[plan-build] Add limited readline functionality to `attach()` function.

### DIFF
--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -1192,7 +1192,8 @@ attach() {
   set +e
   # Loop through input, REPL-style until either `"exit"` or `"quit"` is found
   while [[ "$cmd" != "exit" && "$cmd" != "quit" ]]; do
-    read -p "[$replno] ${pkg_name}($fname)> " cmd
+    read -e -r -p "[$replno] ${pkg_name}($fname)> " cmd
+    history -s $cmd
     case "$cmd" in
       vars) (set -o posix; set);;
       whereami*|\@*)


### PR DESCRIPTION
This change enables minimal command history and file tab complete for
the `attach` (i.e. "debugger") helper. It's pretty sweet.

![gif-keyboard-13130318854541392338](https://cloud.githubusercontent.com/assets/261548/24939525/3e6f75ca-1efb-11e7-95e7-d0f348512d6c.gif)
