### PR TITLE
[builder] Update version computing logic in plan.sh files.

### DIFF
--- a/components/builder-admin-proxy/plan.sh
+++ b/components/builder-admin-proxy/plan.sh
@@ -13,10 +13,7 @@ pkg_svc_group="root"
 
 do_verify() {
   pushd $PLAN_CONTEXT/../.. > /dev/null
-  pkg_version=`git rev-list master --count`
-  pkg_dirname="${pkg_name}-${pkg_version}"
-  pkg_prefix="$HAB_PKG_PATH/${pkg_origin}/${pkg_name}/${pkg_version}/${pkg_release}"
-  pkg_artifact="$HAB_CACHE_ARTIFACT_PATH/${pkg_origin}-${pkg_name}-${pkg_version}-${pkg_release}-${pkg_target}.${_artifact_ext}"
+  update_pkg_version
   popd > /dev/null
 }
 
@@ -30,6 +27,25 @@ do_build() {
 
 do_download() {
   return 0
+}
+
+update_pkg_version() {
+  # Update the `$pkg_version` using Git to determine the value
+  pkg_version="$(git rev-list master --count)"
+  build_line "Version updated to $pkg_version"
+
+  # Several metadata values get their defaults from the value of `$pkg_version`
+  # so we must update these as well
+  pkg_dirname=${pkg_name}-${pkg_version}
+  pkg_prefix=$HAB_PKG_PATH/${pkg_origin}/${pkg_name}/${pkg_version}/${pkg_release}
+  pkg_artifact="$HAB_CACHE_ARTIFACT_PATH/${pkg_origin}-${pkg_name}-${pkg_version}-${pkg_release}-${pkg_target}.${_artifact_ext}"
+  if [[ "$CACHE_PATH" == "$SRC_PATH" ]]; then
+    local update_src_path=true
+  fi
+  CACHE_PATH="$HAB_CACHE_SRC_PATH/$pkg_dirname"
+  if [[ "${update_src_path:-}" == true ]]; then
+    SRC_PATH="$CACHE_PATH"
+  fi
 }
 
 do_install() {

--- a/components/builder-admin/habitat/plan.sh
+++ b/components/builder-admin/habitat/plan.sh
@@ -13,10 +13,7 @@ pkg_svc_run="$bin start -c ${pkg_svc_path}/config.toml"
 
 do_verify() {
   pushd $PLAN_CONTEXT/../../.. > /dev/null
-  pkg_version=`git rev-list master --count`
-  pkg_dirname="${pkg_name}-${pkg_version}"
-  pkg_prefix="$HAB_PKG_PATH/${pkg_origin}/${pkg_name}/${pkg_version}/${pkg_release}"
-  pkg_artifact="$HAB_CACHE_ARTIFACT_PATH/${pkg_origin}-${pkg_name}-${pkg_version}-${pkg_release}-${pkg_target}.${_artifact_ext}"
+  update_pkg_version
   popd > /dev/null
 }
 
@@ -62,6 +59,25 @@ do_install() {
 do_strip() {
   if [[ "$build_type" != "--debug" ]]; then
     do_default_strip
+  fi
+}
+
+update_pkg_version() {
+  # Update the `$pkg_version` using Git to determine the value
+  pkg_version="$(git rev-list master --count)"
+  build_line "Version updated to $pkg_version"
+
+  # Several metadata values get their defaults from the value of `$pkg_version`
+  # so we must update these as well
+  pkg_dirname=${pkg_name}-${pkg_version}
+  pkg_prefix=$HAB_PKG_PATH/${pkg_origin}/${pkg_name}/${pkg_version}/${pkg_release}
+  pkg_artifact="$HAB_CACHE_ARTIFACT_PATH/${pkg_origin}-${pkg_name}-${pkg_version}-${pkg_release}-${pkg_target}.${_artifact_ext}"
+  if [[ "$CACHE_PATH" == "$SRC_PATH" ]]; then
+    local update_src_path=true
+  fi
+  CACHE_PATH="$HAB_CACHE_SRC_PATH/$pkg_dirname"
+  if [[ "${update_src_path:-}" == true ]]; then
+    SRC_PATH="$CACHE_PATH"
   fi
 }
 

--- a/components/builder-api-proxy/plan.sh
+++ b/components/builder-api-proxy/plan.sh
@@ -13,10 +13,7 @@ pkg_svc_group="root"
 
 do_verify() {
   pushd $PLAN_CONTEXT/../.. > /dev/null
-  pkg_version=`git rev-list master --count`
-  pkg_dirname="${pkg_name}-${pkg_version}"
-  pkg_prefix="$HAB_PKG_PATH/${pkg_origin}/${pkg_name}/${pkg_version}/${pkg_release}"
-  pkg_artifact="$HAB_CACHE_ARTIFACT_PATH/${pkg_origin}-${pkg_name}-${pkg_version}-${pkg_release}-${pkg_target}.${_artifact_ext}"
+  update_pkg_version
   popd > /dev/null
 }
 
@@ -26,6 +23,25 @@ do_begin() {
 
 do_build() {
   return 0
+}
+
+update_pkg_version() {
+  # Update the `$pkg_version` using Git to determine the value
+  pkg_version="$(git rev-list master --count)"
+  build_line "Version updated to $pkg_version"
+
+  # Several metadata values get their defaults from the value of `$pkg_version`
+  # so we must update these as well
+  pkg_dirname=${pkg_name}-${pkg_version}
+  pkg_prefix=$HAB_PKG_PATH/${pkg_origin}/${pkg_name}/${pkg_version}/${pkg_release}
+  pkg_artifact="$HAB_CACHE_ARTIFACT_PATH/${pkg_origin}-${pkg_name}-${pkg_version}-${pkg_release}-${pkg_target}.${_artifact_ext}"
+  if [[ "$CACHE_PATH" == "$SRC_PATH" ]]; then
+    local update_src_path=true
+  fi
+  CACHE_PATH="$HAB_CACHE_SRC_PATH/$pkg_dirname"
+  if [[ "${update_src_path:-}" == true ]]; then
+    SRC_PATH="$CACHE_PATH"
+  fi
 }
 
 do_download() {

--- a/components/builder-api/habitat/plan.sh
+++ b/components/builder-api/habitat/plan.sh
@@ -18,10 +18,7 @@ pkg_svc_run="$bin start -c ${pkg_svc_path}/config.toml"
 
 do_verify() {
   pushd $PLAN_CONTEXT/../../.. > /dev/null
-  pkg_version=`git rev-list master --count`
-  pkg_dirname="${pkg_name}-${pkg_version}"
-  pkg_prefix="$HAB_PKG_PATH/${pkg_origin}/${pkg_name}/${pkg_version}/${pkg_release}"
-  pkg_artifact="$HAB_CACHE_ARTIFACT_PATH/${pkg_origin}-${pkg_name}-${pkg_version}-${pkg_release}-${pkg_target}.${_artifact_ext}"
+  update_pkg_version
   popd > /dev/null
 }
 
@@ -84,6 +81,25 @@ do_install() {
 do_strip() {
   if [[ "$build_type" != "--debug" ]]; then
     do_default_strip
+  fi
+}
+
+update_pkg_version() {
+  # Update the `$pkg_version` using Git to determine the value
+  pkg_version="$(git rev-list master --count)"
+  build_line "Version updated to $pkg_version"
+
+  # Several metadata values get their defaults from the value of `$pkg_version`
+  # so we must update these as well
+  pkg_dirname=${pkg_name}-${pkg_version}
+  pkg_prefix=$HAB_PKG_PATH/${pkg_origin}/${pkg_name}/${pkg_version}/${pkg_release}
+  pkg_artifact="$HAB_CACHE_ARTIFACT_PATH/${pkg_origin}-${pkg_name}-${pkg_version}-${pkg_release}-${pkg_target}.${_artifact_ext}"
+  if [[ "$CACHE_PATH" == "$SRC_PATH" ]]; then
+    local update_src_path=true
+  fi
+  CACHE_PATH="$HAB_CACHE_SRC_PATH/$pkg_dirname"
+  if [[ "${update_src_path:-}" == true ]]; then
+    SRC_PATH="$CACHE_PATH"
   fi
 }
 

--- a/components/builder-depot/habitat/plan.sh
+++ b/components/builder-depot/habitat/plan.sh
@@ -12,10 +12,7 @@ pkg_svc_run="$bin start -c ${pkg_svc_path}/config.toml"
 
 do_verify() {
   pushd $PLAN_CONTEXT/../../.. > /dev/null
-  pkg_version=`git rev-list master --count`
-  pkg_dirname="${pkg_name}-${pkg_version}"
-  pkg_prefix="$HAB_PKG_PATH/${pkg_origin}/${pkg_name}/${pkg_version}/${pkg_release}"
-  pkg_artifact="$HAB_CACHE_ARTIFACT_PATH/${pkg_origin}-${pkg_name}-${pkg_version}-${pkg_release}-${pkg_target}.${_artifact_ext}"
+  update_pkg_version
   popd > /dev/null
 }
 
@@ -60,6 +57,25 @@ do_install() {
 do_strip() {
   if [[ "$build_type" != "--debug" ]]; then
     do_default_strip
+  fi
+}
+
+update_pkg_version() {
+  # Update the `$pkg_version` using Git to determine the value
+  pkg_version="$(git rev-list master --count)"
+  build_line "Version updated to $pkg_version"
+
+  # Several metadata values get their defaults from the value of `$pkg_version`
+  # so we must update these as well
+  pkg_dirname=${pkg_name}-${pkg_version}
+  pkg_prefix=$HAB_PKG_PATH/${pkg_origin}/${pkg_name}/${pkg_version}/${pkg_release}
+  pkg_artifact="$HAB_CACHE_ARTIFACT_PATH/${pkg_origin}-${pkg_name}-${pkg_version}-${pkg_release}-${pkg_target}.${_artifact_ext}"
+  if [[ "$CACHE_PATH" == "$SRC_PATH" ]]; then
+    local update_src_path=true
+  fi
+  CACHE_PATH="$HAB_CACHE_SRC_PATH/$pkg_dirname"
+  if [[ "${update_src_path:-}" == true ]]; then
+    SRC_PATH="$CACHE_PATH"
   fi
 }
 

--- a/components/builder-jobsrv/habitat/plan.sh
+++ b/components/builder-jobsrv/habitat/plan.sh
@@ -18,10 +18,7 @@ pkg_svc_run="$bin start -c ${pkg_svc_path}/config.toml"
 
 do_verify() {
   pushd $PLAN_CONTEXT/../../.. > /dev/null
-  pkg_version=`git rev-list master --count`
-  pkg_dirname="${pkg_name}-${pkg_version}"
-  pkg_prefix="$HAB_PKG_PATH/${pkg_origin}/${pkg_name}/${pkg_version}/${pkg_release}"
-  pkg_artifact="$HAB_CACHE_ARTIFACT_PATH/${pkg_origin}-${pkg_name}-${pkg_version}-${pkg_release}-${pkg_target}.${_artifact_ext}"
+  update_pkg_version
   popd > /dev/null
 }
 
@@ -67,6 +64,25 @@ do_install() {
 do_strip() {
   if [[ "$build_type" != "--debug" ]]; then
     do_default_strip
+  fi
+}
+
+update_pkg_version() {
+  # Update the `$pkg_version` using Git to determine the value
+  pkg_version="$(git rev-list master --count)"
+  build_line "Version updated to $pkg_version"
+
+  # Several metadata values get their defaults from the value of `$pkg_version`
+  # so we must update these as well
+  pkg_dirname=${pkg_name}-${pkg_version}
+  pkg_prefix=$HAB_PKG_PATH/${pkg_origin}/${pkg_name}/${pkg_version}/${pkg_release}
+  pkg_artifact="$HAB_CACHE_ARTIFACT_PATH/${pkg_origin}-${pkg_name}-${pkg_version}-${pkg_release}-${pkg_target}.${_artifact_ext}"
+  if [[ "$CACHE_PATH" == "$SRC_PATH" ]]; then
+    local update_src_path=true
+  fi
+  CACHE_PATH="$HAB_CACHE_SRC_PATH/$pkg_dirname"
+  if [[ "${update_src_path:-}" == true ]]; then
+    SRC_PATH="$CACHE_PATH"
   fi
 }
 

--- a/components/builder-originsrv/habitat/plan.sh
+++ b/components/builder-originsrv/habitat/plan.sh
@@ -13,10 +13,7 @@ pkg_svc_run="$bin start -c ${pkg_svc_path}/config.toml"
 
 do_verify() {
   pushd $PLAN_CONTEXT/../../.. > /dev/null
-  pkg_version=`git rev-list master --count`
-  pkg_dirname="${pkg_name}-${pkg_version}"
-  pkg_prefix="$HAB_PKG_PATH/${pkg_origin}/${pkg_name}/${pkg_version}/${pkg_release}"
-  pkg_artifact="$HAB_CACHE_ARTIFACT_PATH/${pkg_origin}-${pkg_name}-${pkg_version}-${pkg_release}-${pkg_target}.${_artifact_ext}"
+  update_pkg_version
   popd > /dev/null
 }
 
@@ -62,6 +59,25 @@ do_install() {
 do_strip() {
   if [[ "$build_type" != "--debug" ]]; then
     do_default_strip
+  fi
+}
+
+update_pkg_version() {
+  # Update the `$pkg_version` using Git to determine the value
+  pkg_version="$(git rev-list master --count)"
+  build_line "Version updated to $pkg_version"
+
+  # Several metadata values get their defaults from the value of `$pkg_version`
+  # so we must update these as well
+  pkg_dirname=${pkg_name}-${pkg_version}
+  pkg_prefix=$HAB_PKG_PATH/${pkg_origin}/${pkg_name}/${pkg_version}/${pkg_release}
+  pkg_artifact="$HAB_CACHE_ARTIFACT_PATH/${pkg_origin}-${pkg_name}-${pkg_version}-${pkg_release}-${pkg_target}.${_artifact_ext}"
+  if [[ "$CACHE_PATH" == "$SRC_PATH" ]]; then
+    local update_src_path=true
+  fi
+  CACHE_PATH="$HAB_CACHE_SRC_PATH/$pkg_dirname"
+  if [[ "${update_src_path:-}" == true ]]; then
+    SRC_PATH="$CACHE_PATH"
   fi
 }
 

--- a/components/builder-router/habitat/plan.sh
+++ b/components/builder-router/habitat/plan.sh
@@ -18,10 +18,7 @@ pkg_svc_run="$bin start -c ${pkg_svc_path}/config.toml"
 
 do_verify() {
   pushd $PLAN_CONTEXT/../../.. > /dev/null
-  pkg_version=`git rev-list master --count`
-  pkg_dirname="${pkg_name}-${pkg_version}"
-  pkg_prefix="$HAB_PKG_PATH/${pkg_origin}/${pkg_name}/${pkg_version}/${pkg_release}"
-  pkg_artifact="$HAB_CACHE_ARTIFACT_PATH/${pkg_origin}-${pkg_name}-${pkg_version}-${pkg_release}-${pkg_target}.${_artifact_ext}"
+  update_pkg_version
   popd > /dev/null
 }
 
@@ -67,6 +64,25 @@ do_install() {
 do_strip() {
   if [[ "$build_type" != "--debug" ]]; then
     do_default_strip
+  fi
+}
+
+update_pkg_version() {
+  # Update the `$pkg_version` using Git to determine the value
+  pkg_version="$(git rev-list master --count)"
+  build_line "Version updated to $pkg_version"
+
+  # Several metadata values get their defaults from the value of `$pkg_version`
+  # so we must update these as well
+  pkg_dirname=${pkg_name}-${pkg_version}
+  pkg_prefix=$HAB_PKG_PATH/${pkg_origin}/${pkg_name}/${pkg_version}/${pkg_release}
+  pkg_artifact="$HAB_CACHE_ARTIFACT_PATH/${pkg_origin}-${pkg_name}-${pkg_version}-${pkg_release}-${pkg_target}.${_artifact_ext}"
+  if [[ "$CACHE_PATH" == "$SRC_PATH" ]]; then
+    local update_src_path=true
+  fi
+  CACHE_PATH="$HAB_CACHE_SRC_PATH/$pkg_dirname"
+  if [[ "${update_src_path:-}" == true ]]; then
+    SRC_PATH="$CACHE_PATH"
   fi
 }
 

--- a/components/builder-scheduler/habitat/plan.sh
+++ b/components/builder-scheduler/habitat/plan.sh
@@ -13,10 +13,7 @@ pkg_svc_run="$bin start -c ${pkg_svc_path}/config.toml"
 
 do_verify() {
   pushd $PLAN_CONTEXT/../../.. > /dev/null
-  pkg_version=`git rev-list master --count`
-  pkg_dirname="${pkg_name}-${pkg_version}"
-  pkg_prefix="$HAB_PKG_PATH/${pkg_origin}/${pkg_name}/${pkg_version}/${pkg_release}"
-  pkg_artifact="$HAB_CACHE_ARTIFACT_PATH/${pkg_origin}-${pkg_name}-${pkg_version}-${pkg_release}-${pkg_target}.${_artifact_ext}"
+  update_pkg_version
   popd > /dev/null
 }
 
@@ -62,6 +59,25 @@ do_install() {
 do_strip() {
   if [[ "$build_type" != "--debug" ]]; then
     do_default_strip
+  fi
+}
+
+update_pkg_version() {
+  # Update the `$pkg_version` using Git to determine the value
+  pkg_version="$(git rev-list master --count)"
+  build_line "Version updated to $pkg_version"
+
+  # Several metadata values get their defaults from the value of `$pkg_version`
+  # so we must update these as well
+  pkg_dirname=${pkg_name}-${pkg_version}
+  pkg_prefix=$HAB_PKG_PATH/${pkg_origin}/${pkg_name}/${pkg_version}/${pkg_release}
+  pkg_artifact="$HAB_CACHE_ARTIFACT_PATH/${pkg_origin}-${pkg_name}-${pkg_version}-${pkg_release}-${pkg_target}.${_artifact_ext}"
+  if [[ "$CACHE_PATH" == "$SRC_PATH" ]]; then
+    local update_src_path=true
+  fi
+  CACHE_PATH="$HAB_CACHE_SRC_PATH/$pkg_dirname"
+  if [[ "${update_src_path:-}" == true ]]; then
+    SRC_PATH="$CACHE_PATH"
   fi
 }
 

--- a/components/builder-sessionsrv/habitat/plan.sh
+++ b/components/builder-sessionsrv/habitat/plan.sh
@@ -13,10 +13,7 @@ pkg_svc_run="$bin start -c ${pkg_svc_path}/config.toml"
 
 do_verify() {
   pushd $PLAN_CONTEXT/../../.. > /dev/null
-  pkg_version=`git rev-list master --count`
-  pkg_dirname="${pkg_name}-${pkg_version}"
-  pkg_prefix="$HAB_PKG_PATH/${pkg_origin}/${pkg_name}/${pkg_version}/${pkg_release}"
-  pkg_artifact="$HAB_CACHE_ARTIFACT_PATH/${pkg_origin}-${pkg_name}-${pkg_version}-${pkg_release}-${pkg_target}.${_artifact_ext}"
+  update_pkg_version
   popd > /dev/null
 }
 
@@ -62,6 +59,25 @@ do_install() {
 do_strip() {
   if [[ "$build_type" != "--debug" ]]; then
     do_default_strip
+  fi
+}
+
+update_pkg_version() {
+  # Update the `$pkg_version` using Git to determine the value
+  pkg_version="$(git rev-list master --count)"
+  build_line "Version updated to $pkg_version"
+
+  # Several metadata values get their defaults from the value of `$pkg_version`
+  # so we must update these as well
+  pkg_dirname=${pkg_name}-${pkg_version}
+  pkg_prefix=$HAB_PKG_PATH/${pkg_origin}/${pkg_name}/${pkg_version}/${pkg_release}
+  pkg_artifact="$HAB_CACHE_ARTIFACT_PATH/${pkg_origin}-${pkg_name}-${pkg_version}-${pkg_release}-${pkg_target}.${_artifact_ext}"
+  if [[ "$CACHE_PATH" == "$SRC_PATH" ]]; then
+    local update_src_path=true
+  fi
+  CACHE_PATH="$HAB_CACHE_SRC_PATH/$pkg_dirname"
+  if [[ "${update_src_path:-}" == true ]]; then
+    SRC_PATH="$CACHE_PATH"
   fi
 }
 

--- a/components/builder-worker/habitat/plan.sh
+++ b/components/builder-worker/habitat/plan.sh
@@ -16,10 +16,7 @@ pkg_svc_group="root"
 
 do_verify() {
   pushd $PLAN_CONTEXT/../../.. > /dev/null
-  pkg_version=`git rev-list master --count`
-  pkg_dirname="${pkg_name}-${pkg_version}"
-  pkg_prefix="$HAB_PKG_PATH/${pkg_origin}/${pkg_name}/${pkg_version}/${pkg_release}"
-  pkg_artifact="$HAB_CACHE_ARTIFACT_PATH/${pkg_origin}-${pkg_name}-${pkg_version}-${pkg_release}-${pkg_target}.${_artifact_ext}"
+  update_pkg_version
   popd > /dev/null
 }
 
@@ -73,6 +70,25 @@ do_install() {
 do_strip() {
   if [[ "$build_type" != "--debug" ]]; then
     do_default_strip
+  fi
+}
+
+update_pkg_version() {
+  # Update the `$pkg_version` using Git to determine the value
+  pkg_version="$(git rev-list master --count)"
+  build_line "Version updated to $pkg_version"
+
+  # Several metadata values get their defaults from the value of `$pkg_version`
+  # so we must update these as well
+  pkg_dirname=${pkg_name}-${pkg_version}
+  pkg_prefix=$HAB_PKG_PATH/${pkg_origin}/${pkg_name}/${pkg_version}/${pkg_release}
+  pkg_artifact="$HAB_CACHE_ARTIFACT_PATH/${pkg_origin}-${pkg_name}-${pkg_version}-${pkg_release}-${pkg_target}.${_artifact_ext}"
+  if [[ "$CACHE_PATH" == "$SRC_PATH" ]]; then
+    local update_src_path=true
+  fi
+  CACHE_PATH="$HAB_CACHE_SRC_PATH/$pkg_dirname"
+  if [[ "${update_src_path:-}" == true ]]; then
+    SRC_PATH="$CACHE_PATH"
   fi
 }
 


### PR DESCRIPTION
This change updates how the Builder components calculate their
`pkg_version` value. The resulting behavior is the same, but additional
work needs to happen with the newly introduced `$SRC_PATH` and
`$CACHE_ROOT`. As this method of lazily computing the `pkg_version`
isn't yet officially supported, I'm not concerned with this fix.
However, the logic to deal with changing a `pkg_version` value
mid-flight has been extracted into a common, generic-ish function in
each Plan. This is fast becoming the proto-implementation of a generic
user-facing helper which a Plan author can use for exactly this use
case. A future pull request will add this capability and at that point,
we can delete the manual versions. Moving forward!

![gif-keyboard-16139136148037153649](https://cloud.githubusercontent.com/assets/261548/24963550/244e86fc-1f5c-11e7-9d09-e3331e4916a3.gif)
