### PR TITLE
Restore /user/origins API endpoint

### DIFF
--- a/components/builder-sessionsrv/src/data_store.rs
+++ b/components/builder-sessionsrv/src/data_store.rs
@@ -179,6 +179,26 @@ impl DataStore {
         }
     }
 
+    pub fn get_origins_by_account(&self,
+                                  request: &sessionsrv::AccountOriginListRequest)
+                                  -> Result<sessionsrv::AccountOriginListResponse> {
+        let conn = self.pool.get(request)?;
+        let rows = conn.query("SELECT * FROM get_account_origins_v1($1)",
+                              &[&(request.get_account_id() as i64)])
+            .map_err(Error::OriginAccountList)?;
+        let mut response = sessionsrv::AccountOriginListResponse::new();
+        response.set_account_id(request.get_account_id());
+        let mut origins = protobuf::RepeatedField::new();
+
+        if rows.len() > 0 {
+            for row in rows.iter() {
+                origins.push(row.get("origin_name"));
+            }
+        }
+        response.set_origins(origins);
+        Ok(response)
+    }
+
     pub fn accept_origin_invitation(&self,
                                     request: &sessionsrv::AccountOriginInvitationAcceptRequest)
                                     -> Result<()> {

--- a/components/builder-sessionsrv/src/error.rs
+++ b/components/builder-sessionsrv/src/error.rs
@@ -50,6 +50,7 @@ pub enum Error {
     AccountOriginInvitationCreate(postgres::error::Error),
     AccountOriginInvitationList(postgres::error::Error),
     AccountOriginInvitationAccept(postgres::error::Error),
+    OriginAccountList(postgres::error::Error),
 }
 
 pub type Result<T> = result::Result<T, Error>;
@@ -92,6 +93,9 @@ impl fmt::Display for Error {
             Error::AccountOriginInvitationAccept(ref e) => {
                 format!("Error accepting invitation in database, {}", e)
             }
+            Error::OriginAccountList(ref e) => {
+                format!("Error listing origins for account in database, {}", e)
+            }
 
         };
         write!(f, "{}", msg)
@@ -122,6 +126,7 @@ impl error::Error for Error {
             Error::AccountOriginInvitationCreate(ref err) => err.description(),
             Error::AccountOriginInvitationList(ref err) => err.description(),
             Error::AccountOriginInvitationAccept(ref err) => err.description(),
+            Error::OriginAccountList(ref err) => err.description(),
         }
     }
 }

--- a/components/builder-sessionsrv/src/migrations/accounts.rs
+++ b/components/builder-sessionsrv/src/migrations/accounts.rs
@@ -90,6 +90,16 @@ pub fn migrate(migrator: &mut Migrator) -> Result<()> {
                         INSERT INTO account_origins (account_id, account_name, origin_id, origin_name) VALUES (o_account_id, o_account_name, o_origin_id, o_origin_name);
                      END
                  $$ LANGUAGE plpgsql VOLATILE"#)?;
+    migrator
+        .migrate("accountsrv",
+                 r#"CREATE OR REPLACE FUNCTION get_account_origins_v1 (
+                    in_account_id bigint
+                 ) RETURNS SETOF account_origins AS $$
+                     BEGIN
+                        RETURN QUERY SELECT * FROM account_origins WHERE account_id = in_account_id;
+                        RETURN;
+                     END
+                 $$ LANGUAGE plpgsql STABLE"#)?;
 
     Ok(())
 }

--- a/components/builder-sessionsrv/src/server/handlers.rs
+++ b/components/builder-sessionsrv/src/server/handlers.rs
@@ -179,6 +179,24 @@ pub fn account_origin_invitation_accept(req: &mut Envelope,
     Ok(())
 }
 
+pub fn account_origin_list_request(req: &mut Envelope,
+                                   sock: &mut zmq::Socket,
+                                   state: &mut ServerState)
+                                   -> Result<()> {
+    let msg: proto::AccountOriginListRequest = try!(req.parse_msg());
+    match state.datastore.get_origins_by_account(&msg) {
+        Ok(reply) => {
+            try!(req.reply_complete(sock, &reply));
+        }
+        Err(e) => {
+            error!("Error listing origins for account, {}", e);
+            let err = net::err(ErrCode::DATA_STORE, "ss:account_origin_list_request:1");
+            try!(req.reply_complete(sock, &err));
+        }
+    }
+    Ok(())
+}
+
 pub fn account_invitation_list(req: &mut Envelope,
                                sock: &mut zmq::Socket,
                                state: &mut ServerState)

--- a/components/builder-sessionsrv/src/server/mod.rs
+++ b/components/builder-sessionsrv/src/server/mod.rs
@@ -97,6 +97,9 @@ impl Dispatcher for Worker {
             "AccountOriginInvitationAcceptRequest" => {
                 handlers::account_origin_invitation_accept(message, sock, state)
             }
+            "AccountOriginListRequest" => {
+                handlers::account_origin_list_request(message, sock, state)
+            }
             _ => panic!("unhandled message"),
         }
     }

--- a/test/builder-api/src/invitations.ts
+++ b/test/builder-api/src/invitations.ts
@@ -20,7 +20,6 @@ describe('Origin Invitations API', function() {
         .set('Authorization', globalAny.logan_bearer)
         .expect(201)
         .end(function(err, res) {
-          console.log(res.body);
           expect(res.body.account_id).to.equal(globalAny.session_bobo.id);
           expect(res.body.origin_id).to.equal(globalAny.origin_xmen.id);
           expect(res.body.owner_id).to.equal(globalAny.session_logan.id);
@@ -91,6 +90,18 @@ describe('Origin Invitations API', function() {
         .expect(200)
         .end(function(err, res) {
           expect(res.body.invitations.length).to.equal(0);
+          done(err);
+        });
+    });
+
+    it('xmen shows up in bobos list of organizations', function(done) {
+      request.get('/user/origins')
+        .set('Authorization', globalAny.bobo_bearer)
+        .expect(200)
+        .end(function(err, res) {
+          expect(res.body.account_id).to.equal(globalAny.session_bobo.id);
+          expect(res.body.origins.length).to.equal(1);
+          expect(res.body.origins[0]).to.equal("xmen");
           done(err);
         });
     });


### PR DESCRIPTION
This commit brings back the /user/origins API endpoint, along with
adding test coverage for it.

![gif-keyboard-742763583401108458](https://cloud.githubusercontent.com/assets/4304/24977830/57ad804e-1f83-11e7-9aa4-76aed59aff0d.gif)

Signed-off-by: Chris Nunciato <cnunciato@chef.io>
Signed-off-by: Adam Jacob <adam@chef.io>