### PR TITLE
Supervisor spring cleaning public fields

### DIFF
--- a/components/butterfly/src/main.rs
+++ b/components/butterfly/src/main.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 extern crate env_logger;
-#[macro_use]
 extern crate log;
 extern crate habitat_butterfly;
 extern crate habitat_core;
@@ -63,7 +62,7 @@ fn main() {
                                          None::<PathBuf>,
                                          Box::new(ZeroSuitability))
             .unwrap();
-    println!("Server ID: {}", server.member_id);
+    println!("Server ID: {}", server.member_id());
 
     let targets: Vec<String> = args.collect();
     for target in &targets {

--- a/components/butterfly/src/server/mod.rs
+++ b/components/butterfly/src/server/mod.rs
@@ -387,26 +387,6 @@ impl Server {
         }
     }
 
-    // // Currently DEAD CODE
-    // /// Change the health of a `Member`, and update its `RumorKey`.
-    // fn insert_health(&self, member: &Member, health: Health) {
-    //     let rk: RumorKey = RumorKey::from(&member);
-    //     // NOTE: This sucks so much right here. Check out how we allocate no matter what, because
-    //     // of just how the logic goes. The value of the trace is really high, though, so we suck it
-    //     // for now.
-    //     let trace_member_id = String::from(member.get_id());
-    //     let trace_incarnation = member.get_incarnation();
-    //     let trace_health = health.clone();
-    //     if self.member_list.insert_health(member, health) {
-    //         trace_it!(MEMBERSHIP: self,
-    //                   TraceKind::MemberUpdate,
-    //                   trace_member_id,
-    //                   trace_incarnation,
-    //                   trace_health);
-    //         self.rumor_list.insert(rk);
-    //     }
-    // }
-
     /// Given a membership record and some health, insert it into the Member List.
     fn insert_member_from_rumor(&self, member: Member, mut health: Health) {
         let mut incremented_incarnation = false;

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -46,7 +46,7 @@ use sup::command;
 use sup::http_gateway;
 use sup::manager::{Manager, ManagerConfig};
 use sup::manager::service::{DesiredState, ServiceBind, Topology, UpdateStrategy};
-use sup::manager::service::spec::{ServiceSpec, StartStyle};
+use sup::manager::service::{ServiceSpec, StartStyle};
 
 /// Our output key
 static LOGKEY: &'static str = "MN";

--- a/components/sup/src/manager/census.rs
+++ b/components/sup/src/manager/census.rs
@@ -58,32 +58,32 @@ pub enum ElectionStatus {
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, Default)]
 pub struct CensusEntry {
-    pub member_id: String,
-    pub service: String,
-    pub group: String,
-    pub org: Option<String>,
-    pub cfg: toml::value::Table,
-    pub sys: SysInfo,
+    member_id: String,
+    service: String,
+    group: String,
+    org: Option<String>,
+    cfg: toml::value::Table,
+    sys: SysInfo,
     pub pkg: Option<PackageIdent>,
-    pub leader: Option<bool>,
-    pub follower: Option<bool>,
-    pub update_leader: Option<bool>,
-    pub update_follower: Option<bool>,
-    pub election_is_running: Option<bool>,
-    pub election_is_no_quorum: Option<bool>,
-    pub election_is_finished: Option<bool>,
-    pub update_election_is_running: Option<bool>,
-    pub update_election_is_no_quorum: Option<bool>,
-    pub update_election_is_finished: Option<bool>,
-    pub initialized: Option<bool>,
-    pub alive: Option<bool>,
-    pub suspect: Option<bool>,
-    pub confirmed: Option<bool>,
-    pub persistent: Option<bool>,
+    leader: Option<bool>,
+    follower: Option<bool>,
+    update_leader: Option<bool>,
+    update_follower: Option<bool>,
+    election_is_running: Option<bool>,
+    election_is_no_quorum: Option<bool>,
+    election_is_finished: Option<bool>,
+    update_election_is_running: Option<bool>,
+    update_election_is_no_quorum: Option<bool>,
+    update_election_is_finished: Option<bool>,
+    initialized: Option<bool>,
+    alive: Option<bool>,
+    suspect: Option<bool>,
+    confirmed: Option<bool>,
+    persistent: Option<bool>,
 }
 
 impl CensusEntry {
-    pub fn get_service_group(&self) -> String {
+    fn get_service_group(&self) -> String {
         if self.org.is_some() {
             format!("{}.{}@{}",
                     self.get_service(),
@@ -98,15 +98,15 @@ impl CensusEntry {
         &self.member_id
     }
 
-    pub fn set_member_id(&mut self, value: String) {
+    fn set_member_id(&mut self, value: String) {
         self.member_id = value
     }
 
-    pub fn get_service(&self) -> &str {
+    fn get_service(&self) -> &str {
         &self.service
     }
 
-    pub fn set_service(&mut self, value: String) {
+    fn set_service(&mut self, value: String) {
         self.service = value;
     }
 
@@ -114,46 +114,48 @@ impl CensusEntry {
         &self.group
     }
 
-    pub fn set_group(&mut self, value: String) {
+    fn set_group(&mut self, value: String) {
         self.group = value;
     }
 
-    pub fn get_org(&self) -> &str {
+    fn get_org(&self) -> &str {
         match self.org.as_ref() {
             Some(v) => &v,
             None => "",
         }
     }
 
-    pub fn set_org(&mut self, value: String) {
+    fn set_org(&mut self, value: String) {
         self.org = Some(value);
     }
 
-    pub fn get_pkg(&self) -> &PackageIdent {
+    #[allow(dead_code)] // only used in tests
+    fn get_pkg(&self) -> &PackageIdent {
         self.pkg.as_ref().unwrap()
     }
 
-    pub fn set_pkg(&mut self, value: PackageIdent) {
+    fn set_pkg(&mut self, value: PackageIdent) {
         self.pkg = Some(value);
     }
 
-    pub fn set_leader(&mut self, value: bool) {
+    fn set_leader(&mut self, value: bool) {
         self.leader = Some(value);
     }
 
-    pub fn get_leader(&self) -> bool {
+    fn get_leader(&self) -> bool {
         self.leader.unwrap_or(false)
     }
 
-    pub fn set_follower(&mut self, value: bool) {
+    fn set_follower(&mut self, value: bool) {
         self.follower = Some(value);
     }
 
-    pub fn get_follower(&self) -> bool {
+    #[allow(dead_code)] // only used in tests
+    fn get_follower(&self) -> bool {
         self.follower.unwrap_or(false)
     }
 
-    pub fn set_update_leader(&mut self, value: bool) {
+    fn set_update_leader(&mut self, value: bool) {
         self.update_leader = Some(value);
     }
 
@@ -161,60 +163,44 @@ impl CensusEntry {
         self.update_leader.unwrap_or(false)
     }
 
-    pub fn set_update_follower(&mut self, value: bool) {
+    fn set_update_follower(&mut self, value: bool) {
         self.update_follower = Some(value);
     }
 
-    pub fn get_update_follower(&self) -> bool {
-        self.update_follower.unwrap_or(false)
-    }
-
-    pub fn set_election_is_running(&mut self, value: bool) {
+    fn set_election_is_running(&mut self, value: bool) {
         self.election_is_running = Some(value);
     }
 
-    pub fn get_election_is_running(&self) -> bool {
+    fn get_election_is_running(&self) -> bool {
         self.election_is_running.unwrap_or(false)
     }
 
-    pub fn set_election_is_no_quorum(&mut self, value: bool) {
+    fn set_election_is_no_quorum(&mut self, value: bool) {
         self.election_is_no_quorum = Some(value);
     }
 
-    pub fn get_election_is_no_quorum(&self) -> bool {
+    fn get_election_is_no_quorum(&self) -> bool {
         self.election_is_no_quorum.unwrap_or(false)
     }
 
-    pub fn set_election_is_finished(&mut self, value: bool) {
+    fn set_election_is_finished(&mut self, value: bool) {
         self.election_is_finished = Some(value);
     }
 
-    pub fn get_election_is_finished(&self) -> bool {
+    fn get_election_is_finished(&self) -> bool {
         self.election_is_finished.unwrap_or(false)
     }
 
-    pub fn set_update_election_is_running(&mut self, value: bool) {
+    fn set_update_election_is_running(&mut self, value: bool) {
         self.update_election_is_running = Some(value);
     }
 
-    pub fn get_update_election_is_running(&self) -> bool {
-        self.update_election_is_running.unwrap_or(false)
-    }
-
-    pub fn set_update_election_is_no_quorum(&mut self, value: bool) {
+    fn set_update_election_is_no_quorum(&mut self, value: bool) {
         self.update_election_is_no_quorum = Some(value);
     }
 
-    pub fn get_update_election_is_no_quorum(&self) -> bool {
-        self.update_election_is_no_quorum.unwrap_or(false)
-    }
-
-    pub fn set_update_election_is_finished(&mut self, value: bool) {
+    fn set_update_election_is_finished(&mut self, value: bool) {
         self.update_election_is_finished = Some(value);
-    }
-
-    pub fn get_update_election_is_finished(&self) -> bool {
-        self.update_election_is_finished.unwrap_or(false)
     }
 
     pub fn get_election_status(&self) -> ElectionStatus {
@@ -229,43 +215,28 @@ impl CensusEntry {
         }
     }
 
-    pub fn set_initialized(&mut self, value: bool) {
-        self.initialized = Some(value);
-    }
-
-    pub fn get_initialized(&self) -> bool {
-        self.initialized.unwrap_or(false)
-    }
-
-    pub fn set_alive(&mut self, value: bool) {
+    fn set_alive(&mut self, value: bool) {
         self.alive = Some(value);
     }
 
-    pub fn get_alive(&self) -> bool {
+    fn get_alive(&self) -> bool {
         self.alive.unwrap_or(false)
     }
 
-    pub fn set_suspect(&mut self, value: bool) {
+    fn set_suspect(&mut self, value: bool) {
         self.suspect = Some(value);
     }
 
-    pub fn get_suspect(&self) -> bool {
-        self.suspect.unwrap_or(false)
-    }
-
-    pub fn set_confirmed(&mut self, value: bool) {
+    fn set_confirmed(&mut self, value: bool) {
         self.confirmed = Some(value);
     }
 
-    pub fn get_confirmed(&self) -> bool {
-        self.confirmed.unwrap_or(false)
-    }
-
-    pub fn set_persistent(&mut self, value: bool) {
+    fn set_persistent(&mut self, value: bool) {
         self.persistent = Some(value);
     }
 
-    pub fn get_persistent(&self) -> bool {
+    #[allow(dead_code)] // only used in tests
+    fn get_persistent(&self) -> bool {
         self.persistent.unwrap_or(false)
     }
 
@@ -293,14 +264,14 @@ impl CensusEntry {
         self.sys = toml::from_slice(rumor.get_sys()).unwrap_or(SysInfo::default());
     }
 
-    pub fn populate_from_member(&mut self, member: &Member) {
+    fn populate_from_member(&mut self, member: &Member) {
         self.set_member_id(String::from(member.get_id()));
         self.sys.gossip_ip = member.get_address().to_string();
         self.sys.gossip_port = member.get_gossip_port().to_string();
         self.set_persistent(true);
     }
 
-    pub fn populate_from_health(&mut self, health: Health) {
+    fn populate_from_health(&mut self, health: Health) {
         match health {
             Health::Alive => {
                 self.set_alive(true);
@@ -320,7 +291,7 @@ impl CensusEntry {
         }
     }
 
-    pub fn populate_from_election(&mut self, election: &ElectionRumor) {
+    fn populate_from_election(&mut self, election: &ElectionRumor) {
         match election.get_status() {
             Election_Status::Running => {
                 self.set_leader(false);
@@ -351,7 +322,7 @@ impl CensusEntry {
         }
     }
 
-    pub fn populate_from_update_election(&mut self, election: &ElectionRumor) {
+    fn populate_from_update_election(&mut self, election: &ElectionRumor) {
         match election.get_status() {
             Election_Status::Running => {
                 self.set_update_leader(false);
@@ -389,8 +360,8 @@ pub struct Census {
     // allocations when ordering the population to determine who should update next in a rolling
     // update strategy. For now, we allocate a new vector every server tick by the members() and
     // members_ordered() functions.
-    pub population: HashMap<String, CensusEntry>,
-    pub member_id: String,
+    population: HashMap<String, CensusEntry>,
+    member_id: String,
 }
 
 impl Deref for Census {
@@ -408,7 +379,7 @@ impl DerefMut for Census {
 }
 
 impl Census {
-    pub fn new(member_id: String) -> Census {
+    fn new(member_id: String) -> Census {
         Census {
             population: HashMap::new(),
             member_id: member_id,
@@ -420,7 +391,7 @@ impl Census {
     }
 
     /// Return all alive members.
-    pub fn alive_members(&self) -> Vec<&CensusEntry> {
+    fn alive_members(&self) -> Vec<&CensusEntry> {
         self.population
             .values()
             .filter(|ce| ce.get_alive())
@@ -428,14 +399,14 @@ impl Census {
     }
 
     /// Return all alive members ordered by member_id.
-    pub fn alive_members_ordered(&self) -> Vec<&CensusEntry> {
+    fn alive_members_ordered(&self) -> Vec<&CensusEntry> {
         let mut members = self.alive_members();
         members.sort_by(|a, b| a.member_id.cmp(&b.member_id));
         members
     }
 
     /// Return all members.
-    pub fn members(&self) -> Vec<&CensusEntry> {
+    fn members(&self) -> Vec<&CensusEntry> {
         self.population.values().map(|ce| ce).collect()
     }
 
@@ -473,28 +444,6 @@ impl Census {
         entry.get_service()
     }
 
-    /// Return next alive peer, the peer to your right in the ordered members list, or None if you
-    /// have no alive peers.
-    pub fn next_peer(&self) -> Option<&CensusEntry> {
-        let members = self.alive_members_ordered();
-        if members.len() <= 1 || self.me().is_none() {
-            return None;
-        }
-        match members
-                  .iter()
-                  .position(|ce| ce.member_id == self.me().unwrap().member_id) {
-            Some(idx) => {
-                let peer = idx + 1;
-                if peer >= members.len() {
-                    Some(members[0])
-                } else {
-                    Some(members[peer])
-                }
-            }
-            None => None,
-        }
-    }
-
     /// Return previous alive peer, the peer to your left in the ordered members list, or None if
     /// you have no alive peers.
     pub fn previous_peer(&self) -> Option<&CensusEntry> {
@@ -519,7 +468,7 @@ impl Census {
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct CensusList {
-    pub censuses: HashMap<String, Census>,
+    censuses: HashMap<String, Census>,
 }
 
 impl Deref for CensusList {

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod census;
+mod census;
 pub mod service;
-pub mod signals;
-pub mod service_updater;
-pub mod spec_watcher;
+mod signals;
+mod service_updater;
+mod spec_watcher;
 
 use std::collections::HashMap;
 use std::fs::{self, File, OpenOptions};
@@ -61,16 +61,16 @@ static LOGKEY: &'static str = "MR";
 /// persistence data.
 #[derive(Debug)]
 pub struct FsCfg {
-    pub data_path: PathBuf,
+    data_path: PathBuf,
     pub butterfly_data_path: PathBuf,
     pub census_data_path: PathBuf,
     pub services_data_path: PathBuf,
-    pub specs_path: PathBuf,
-    pub proc_lock_file: PathBuf,
+    specs_path: PathBuf,
+    proc_lock_file: PathBuf,
 }
 
 impl FsCfg {
-    pub fn new<T>(sup_svc_root: T) -> Self
+    fn new<T>(sup_svc_root: T) -> Self
         where T: Into<PathBuf>
     {
         let sup_svc_root = sup_svc_root.into();
@@ -99,7 +99,7 @@ pub struct ManagerConfig {
     pub gossip_permanent: bool,
     pub ring: Option<String>,
     pub name: Option<String>,
-    pub custom_state_path: Option<PathBuf>,
+    custom_state_path: Option<PathBuf>,
     pub organization: Option<String>,
 }
 
@@ -145,7 +145,7 @@ impl Manager {
         Self::new(cfg, member, fs_cfg)
     }
 
-    pub fn new(cfg: ManagerConfig, mut member: Member, fs_cfg: FsCfg) -> Result<Manager> {
+    fn new(cfg: ManagerConfig, mut member: Member, fs_cfg: FsCfg) -> Result<Manager> {
         member.set_persistent(cfg.gossip_permanent);
         member.set_swim_port(cfg.gossip_listen.port() as i32);
         member.set_gossip_port(cfg.gossip_listen.port() as i32);
@@ -188,7 +188,7 @@ impl Manager {
            })
     }
 
-    pub fn load_member<T>(state_path: T) -> Result<Member>
+    fn load_member<T>(state_path: T) -> Result<Member>
         where T: AsRef<Path>
     {
         let mut member = Member::default();
@@ -290,7 +290,7 @@ impl Manager {
         }
     }
 
-    pub fn add_service(&mut self, spec: ServiceSpec) -> Result<()> {
+    fn add_service(&mut self, spec: ServiceSpec) -> Result<()> {
         let service = Service::load(spec,
                                     &self.gossip_listen,
                                     &self.http_listen,
@@ -313,7 +313,7 @@ impl Manager {
         Ok(())
     }
 
-    pub fn remove_service(&self, service: &mut Service) -> Result<()> {
+    fn remove_service(&self, service: &mut Service) -> Result<()> {
         // JW TODO: Update service rumor to remove service from cluster
         service.stop();
         if service.start_style == StartStyle::Transient {

--- a/components/sup/src/manager/service/config.rs
+++ b/components/sup/src/manager/service/config.rs
@@ -55,19 +55,19 @@ static TOML_MAX_MERGE_DEPTH: u16 = 30;
 /// namespaces available in `config.toml`.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ServiceConfig {
-    pub hab: Hab,
+    hab: Hab,
     pub pkg: Pkg,
     pub sys: Sys,
-    pub cfg: Cfg,
-    pub svc: Svc,
-    pub bind: Bind,
+    cfg: Cfg,
+    svc: Svc,
+    bind: Bind,
     #[serde(skip_serializing, skip_deserializing, default="default_for_pathbuf")]
     pub config_root: PathBuf,
     #[serde(skip_serializing, skip_deserializing)]
     pub incarnation: u64,
     // Set to 'true' if we have data that needs to be sent to a configuration file
     #[serde(skip_serializing, skip_deserializing)]
-    pub needs_write: bool,
+    needs_write: bool,
     #[serde(skip_serializing, skip_deserializing)]
     supported_bindings: Vec<ServiceBind>,
 }
@@ -247,7 +247,7 @@ impl ServiceConfig {
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
-pub struct Bind(toml::value::Table);
+struct Bind(toml::value::Table);
 
 impl Bind {
     fn populate(&mut self, bindings: &[ServiceBind], census_list: &CensusList) {
@@ -275,10 +275,10 @@ impl Bind {
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
-pub struct Svc(toml::value::Table);
+struct Svc(toml::value::Table);
 
 impl Svc {
-    pub fn populate(&mut self, service_group: &ServiceGroup, census_list: &CensusList) {
+    fn populate(&mut self, service_group: &ServiceGroup, census_list: &CensusList) {
         let mut top = service_entry(census_list
                                         .get(&*service_group)
                                         .expect("Service Group's census entry missing from list!"));
@@ -353,11 +353,11 @@ fn service_entry(census: &Census) -> toml::value::Table {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct Cfg {
-    pub default: Option<toml::Value>,
-    pub user: Option<toml::Value>,
-    pub gossip: Option<toml::Value>,
-    pub environment: Option<toml::Value>,
+struct Cfg {
+    default: Option<toml::Value>,
+    user: Option<toml::Value>,
+    gossip: Option<toml::Value>,
+    environment: Option<toml::Value>,
 }
 
 impl Cfg {
@@ -517,22 +517,22 @@ impl Cfg {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Pkg {
-    pub origin: String,
+    origin: String,
     pub name: String,
-    pub version: String,
-    pub release: String,
-    pub ident: String,
+    version: String,
+    release: String,
+    ident: String,
     pub deps: Vec<PackageIdent>,
-    pub exposes: Vec<String>,
-    pub exports: HashMap<String, String>,
-    pub path: PathBuf,
-    pub svc_path: PathBuf,
-    pub svc_config_path: PathBuf,
-    pub svc_data_path: PathBuf,
-    pub svc_files_path: PathBuf,
-    pub svc_static_path: PathBuf,
-    pub svc_var_path: PathBuf,
-    pub svc_pid_file: PathBuf,
+    exposes: Vec<String>,
+    exports: HashMap<String, String>,
+    path: PathBuf,
+    svc_path: PathBuf,
+    svc_config_path: PathBuf,
+    svc_data_path: PathBuf,
+    svc_files_path: PathBuf,
+    svc_static_path: PathBuf,
+    svc_var_path: PathBuf,
+    svc_pid_file: PathBuf,
     pub svc_user: String,
     pub svc_group: String,
 }
@@ -618,8 +618,8 @@ impl DerefMut for Sys {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct Hab {
-    pub version: String,
+struct Hab {
+    version: String,
 }
 
 impl Hab {
@@ -634,7 +634,7 @@ impl Hab {
 
 
 // Recursively merges the `other` TOML table into `me`
-pub fn toml_merge(me: &mut toml::value::Table, other: &toml::value::Table) -> Result<()> {
+fn toml_merge(me: &mut toml::value::Table, other: &toml::value::Table) -> Result<()> {
     toml_merge_recurse(me, other, 0)
 }
 
@@ -724,15 +724,15 @@ mod test {
         RuntimeConfig::new("hab".to_string(), "hab".to_string(), HashMap::new())
     }
 
-    pub fn root() -> PathBuf {
+    fn root() -> PathBuf {
         PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests")
     }
 
-    pub fn fixtures() -> PathBuf {
+    fn fixtures() -> PathBuf {
         root().join("fixtures")
     }
 
-    pub fn sample_configs() -> PathBuf {
+    fn sample_configs() -> PathBuf {
         fixtures().join("sample_configs")
     }
 

--- a/components/sup/src/manager/service/spec.rs
+++ b/components/sup/src/manager/service/spec.rs
@@ -32,7 +32,7 @@ use error::{Error, Result, SupError};
 
 static LOGKEY: &'static str = "SS";
 static DEFAULT_GROUP: &'static str = "default";
-pub const SPEC_FILE_EXT: &'static str = "spec";
+const SPEC_FILE_EXT: &'static str = "spec";
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub enum DesiredState {
@@ -102,7 +102,7 @@ impl ServiceSpec {
         spec
     }
 
-    pub fn to_toml_string(&self) -> Result<String> {
+    fn to_toml_string(&self) -> Result<String> {
         if self.ident == PackageIdent::default() {
             return Err(sup_error!(Error::MissingRequiredIdent));
         }
@@ -667,7 +667,7 @@ mod test {
     fn service_bind_toml_deserialize() {
         #[derive(Deserialize)]
         struct Data {
-            pub key: ServiceBind,
+            key: ServiceBind,
         }
         let toml = r#"
             key = "name:service.group@organization"
@@ -682,7 +682,7 @@ mod test {
     fn service_bind_toml_serialize() {
         #[derive(Serialize)]
         struct Data {
-            pub key: ServiceBind,
+            key: ServiceBind,
         }
         let data = Data {
             key: ServiceBind {

--- a/components/sup/src/manager/service_updater.rs
+++ b/components/sup/src/manager/service_updater.rs
@@ -280,7 +280,7 @@ struct Worker {
 }
 
 impl Worker {
-    pub fn new(service: &Service) -> Self {
+    fn new(service: &Service) -> Self {
         Worker {
             current: service.package().ident().clone(),
             spec_ident: service.spec_ident.clone(),
@@ -294,10 +294,7 @@ impl Worker {
     /// Passing an optional package identifier will make the worker perform a run-once update to
     /// retrieve a specific version from a remote Depot. If no package identifier is specified,
     /// then the updater will poll until a newer more suitable package is found.
-    pub fn start(mut self,
-                 sg: &ServiceGroup,
-                 ident: Option<PackageIdent>)
-                 -> Receiver<PackageInstall> {
+    fn start(mut self, sg: &ServiceGroup, ident: Option<PackageIdent>) -> Receiver<PackageInstall> {
         let (tx, rx) = sync_channel(0);
         thread::Builder::new()
             .name(format!("service-updater-{}", sg))

--- a/components/sup/src/templating/helpers.rs
+++ b/components/sup/src/templating/helpers.rs
@@ -18,7 +18,7 @@ use std::collections::HashMap;
 
 use hcore::package::{PackageIdent, Identifiable};
 use hcore::fs;
-use manager::service::config::ServiceConfig;
+use manager::service::ServiceConfig;
 use handlebars::{Handlebars, Helper, Renderable, RenderContext, RenderError, Context};
 use serde_json;
 use serde_json::map::Map;


### PR DESCRIPTION
This PR makes all public fields and methods not used by clients private.
This in itself does not really improve the design of the code base but it makes it significantly easier to perform additional refactoring because it is easier to figure out what the effective public interface of the objects are.

See https://github.com/habitat-sh/habitat/issues/2094 for more context.