### PR TITLE
[sup] Restore support of the `--config-from` on `hab start`.

### DIFF
--- a/components/sup/src/manager/service/spec.rs
+++ b/components/sup/src/manager/service/spec.rs
@@ -81,7 +81,6 @@ pub struct ServiceSpec {
     pub topology: Topology,
     pub update_strategy: UpdateStrategy,
     pub binds: Vec<ServiceBind>,
-    #[serde(skip_deserializing, skip_serializing)]
     pub config_from: Option<PathBuf>,
     #[serde(
         deserialize_with = "deserialize_using_from_str",
@@ -333,8 +332,8 @@ mod test {
             update_strategy = "rolling"
             binds = ["cache:redis.cache@acmecorp", "db:postgres.app@acmecorp"]
             start_style = "persistent"
+            config_from = "/only/for/development"
 
-            config_from = "should not be parsed"
             extra_stuff = "should be ignored"
             "#;
         let spec = ServiceSpec::from_str(toml).unwrap();
@@ -348,7 +347,8 @@ mod test {
         assert_eq!(spec.binds,
                    vec![ServiceBind::from_str("cache:redis.cache@acmecorp").unwrap(),
                         ServiceBind::from_str("db:postgres.app@acmecorp").unwrap()]);
-        assert_eq!(spec.config_from, None);
+        assert_eq!(spec.config_from,
+                   Some(PathBuf::from("/only/for/development")));
         assert_eq!(spec.start_style, StartStyle::Persistent);
     }
 
@@ -414,7 +414,7 @@ mod test {
             update_strategy: UpdateStrategy::AtOnce,
             binds: vec![ServiceBind::from_str("cache:redis.cache@acmecorp").unwrap(),
                         ServiceBind::from_str("db:postgres.app@acmecorp").unwrap()],
-            config_from: Some(PathBuf::from("/")),
+            config_from: Some(PathBuf::from("/only/for/development")),
             desired_state: DesiredState::Down,
             start_style: StartStyle::Persistent,
         };
@@ -429,7 +429,7 @@ mod test {
         assert!(toml.contains(r#""db:postgres.app@acmecorp""#));
         assert!(toml.contains(r#"desired_state = "down""#));
         assert!(toml.contains(r#"start_style = "persistent""#));
-        assert!(!toml.contains(r#"config_from = "#));
+        assert!(toml.contains(r#"config_from = "/only/for/development""#));
     }
 
     #[test]
@@ -460,8 +460,8 @@ mod test {
             topology = "leader"
             update_strategy = "rolling"
             binds = ["cache:redis.cache@acmecorp", "db:postgres.app@acmecorp"]
+            config_from = "/only/for/development"
 
-            config_from = "should not be parsed"
             extra_stuff = "should be ignored"
             "#;
         file_from_str(&path, toml);
@@ -476,7 +476,8 @@ mod test {
         assert_eq!(spec.binds,
                    vec![ServiceBind::from_str("cache:redis.cache@acmecorp").unwrap(),
                         ServiceBind::from_str("db:postgres.app@acmecorp").unwrap()]);
-        assert_eq!(spec.config_from, None);
+        assert_eq!(spec.config_from,
+                   Some(PathBuf::from("/only/for/development")));
     }
 
     #[test]
@@ -541,7 +542,7 @@ mod test {
             update_strategy: UpdateStrategy::AtOnce,
             binds: vec![ServiceBind::from_str("cache:redis.cache@acmecorp").unwrap(),
                         ServiceBind::from_str("db:postgres.app@acmecorp").unwrap()],
-            config_from: Some(PathBuf::from("/")),
+            config_from: Some(PathBuf::from("/only/for/development")),
             desired_state: DesiredState::Down,
             start_style: StartStyle::Persistent,
         };
@@ -557,7 +558,7 @@ mod test {
         assert!(toml.contains(r#""db:postgres.app@acmecorp""#));
         assert!(toml.contains(r#"desired_state = "down""#));
         assert!(toml.contains(r#"start_style = "persistent""#));
-        assert!(!toml.contains(r#"config_from = "#));
+        assert!(toml.contains(r#"config_from = "/only/for/development""#));
     }
 
     #[test]


### PR DESCRIPTION
This is a bug fix change to restore the behavior of the `--config-from`
option for use in development. In a perverse twist, this behavior was
enforced by tests as the assumption at the time was this would only be
supported in the single-shot, development mode of running the
Supervisor. The end implementation however internally uses `ServiceSpec`
files consistently and as such we need to serialize (i.e. write) and
deserialize (i.e. read) this value. Restoring the (de)serializing logic
allows the user-provided option to flow through for the Supervisor to
use it. Sorry folks!

Fixes #2058

![gif-keyboard-3676460975549255524](https://cloud.githubusercontent.com/assets/261548/25022405/eb997dec-2052-11e7-9d20-055d883cc596.gif)
