### PR TITLE
[butterfly] Write dat random tmpfile locally then move.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -633,7 +633,6 @@ dependencies = [
  "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempfile 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "threadpool 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.3.0 (git+https://github.com/alexcrichton/toml-rs?rev=d39c3f7b3ec95cb3cc1e579d7d747206c66aab74)",

--- a/components/butterfly/Cargo.toml
+++ b/components/butterfly/Cargo.toml
@@ -24,7 +24,6 @@ protobuf = "*"
 rand = "*"
 serde = "*"
 serde_derive = "*"
-tempfile = "*"
 time = "*"
 threadpool = "*"
 toml = { version = "*", features = ["serde"], default-features = false, git = "https://github.com/alexcrichton/toml-rs" , rev = "d39c3f7b3ec95cb3cc1e579d7d747206c66aab74"}

--- a/components/butterfly/src/lib.rs
+++ b/components/butterfly/src/lib.rs
@@ -51,7 +51,6 @@ extern crate rand;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;
-extern crate tempfile;
 extern crate time;
 extern crate toml;
 extern crate uuid;


### PR DESCRIPTION
This change fixes an issue when running the Supervisor on a Linux host
which has a separate `/tmp` filesystem, a `tmpfs` filesystem, etc. The
previous implementation used `tempfile` crate which writes a file into
the system temporary file space such as `/tmp`, `/var/tmp`, etc. on a
Unix system. This means that if there is a separate filesystem, a file
move may cross a filesystem boundary which could fail, incur an IO
penalty if the file is large, etc. A better strategy is to make the file
in the same destination directory with a different, nondeterministic
name (i.e. random), then move it into place, becoming a more atomic
operation.

In my case, I am using an Arch Linux distro which is using zfs for the
userland and tmpfs for `/tmp`. As a result I was seeing many errors
containing the following:

```
Invalid cross-device link (os error 18)
```

Fixes #2078

![gif-keyboard-7645919768694759737](https://cloud.githubusercontent.com/assets/261548/25025644/4665b9a4-2060-11e7-8f88-ae3d494a8bf6.gif)