### PR TITLE
Add `disable_callbacks` helper.

### DIFF
--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -1636,6 +1636,26 @@ pkg_interpreter_for() {
     return 1
 }
 
+# Disables callbacks if they exist. Accepts multiple arguments.
+# Callbacks must be prefixed with `do_` to provide some level of
+# safety for disabling functions.
+# ```
+# disable_callbacks "do_download" "do_verify" "do_unpack"
+# ```
+disable_callbacks() {
+  local callback_names
+  callback_names=("$@")
+
+  for callback in "${callback_names[@]}"; do
+    if [[ "$callback" =~ ^do_.* ]] && [[ "$(type -t "$callback")" == "function" ]]; then
+      build_line "Disabling callback $callback"
+      eval "$callback() { return 0; }"
+    else
+      build_line "Unable to disable callback $callback"
+    fi
+  done
+}
+
 # ## Build Phases
 #
 # Stub build phases, in the order they are executed. These can be overridden by

--- a/www/source/docs/reference/plan-syntax.html.md
+++ b/www/source/docs/reference/plan-syntax.html.md
@@ -634,6 +634,13 @@ exit_with "Something bad happened" 55
 trim()
 : Trims leading and trailing whitespace characters from a bash variable.
 
+disable_callbacks()
+: Disables one or more callbacks by forcing them to only execute `return 0`. Only supports callbacks which are prefixed with `do_` to limit unexpected behaviors in disabling other functions. All arguments must be quoted, otherwise it will attempt to execute the callbacks rather than disable them.
+
+~~~
+disable_callbacks "do_download" "do_verify" "do_unpack"
+~~~
+
 ***
 
 ## Iterative Development


### PR DESCRIPTION
I found myself writing things like this a lot:

```
do_download() {
  return 0
}

do_verify() {
  return 0
}

do_unpack() {
  return 0
}
```

In the spirit of scaffolding I decided to add this helper to simplify this common task. This function makes disabling callbacks easier to read and perform, while making the call more DRY with a simple one-line call: `disable_callbacks "do_download" "do_verify" "do_unpack"`

Signed-off-by: Ryan Hass <rhass@users.noreply.github.com>