### PR TITLE
default db url properties so that config tomls do not need to include them

### DIFF
--- a/components/builder-jobsrv/src/config.rs
+++ b/components/builder-jobsrv/src/config.rs
@@ -83,11 +83,11 @@ impl ConfigFile for Config {
         try!(toml.parse_into("cfg.worker_command_addr", &mut cfg.worker_command_addr));
         try!(toml.parse_into("cfg.worker_heartbeat_addr", &mut cfg.worker_heartbeat_addr));
         try!(toml.parse_into("cfg.status_publisher_addr", &mut cfg.status_publisher_addr));
-        let mut connection_user = String::new();
+        let mut connection_user = String::from("hab");
         try!(toml.parse_into("cfg.datastore_connection_user", &mut connection_user));
-        let mut connection_address = String::new();
+        let mut connection_address = String::from("127.0.0.1");
         try!(toml.parse_into("cfg.datastore_connection_address", &mut connection_address));
-        let mut connection_db = String::new();
+        let mut connection_db = String::from("builder_jobsrv");
         try!(toml.parse_into("cfg.datastore_connection_db", &mut connection_db));
 
         cfg.datastore_connection_url = format!("postgresql://{}@{}/{}",

--- a/components/builder-originsrv/src/config.rs
+++ b/components/builder-originsrv/src/config.rs
@@ -71,11 +71,11 @@ impl ConfigFile for Config {
         let mut cfg = Config::default();
         try!(toml.parse_into("cfg.routers", &mut cfg.routers));
 
-        let mut connection_user = String::new();
+        let mut connection_user = String::from("hab");
         try!(toml.parse_into("cfg.datastore_connection_user", &mut connection_user));
-        let mut connection_address = String::new();
+        let mut connection_address = String::from("127.0.0.1");
         try!(toml.parse_into("cfg.datastore_connection_address", &mut connection_address));
-        let mut connection_db = String::new();
+        let mut connection_db = String::from("builder_originsrv");
         try!(toml.parse_into("cfg.datastore_connection_db", &mut connection_db));
 
         cfg.datastore_connection_url = format!("postgresql://{}@{}/{}",

--- a/components/builder-scheduler/src/config.rs
+++ b/components/builder-scheduler/src/config.rs
@@ -92,11 +92,11 @@ impl ConfigFile for Config {
     fn from_toml(toml: toml::Value) -> Result<Self> {
         let mut cfg = Config::default();
         try!(toml.parse_into("cfg.routers", &mut cfg.routers));
-        let mut connection_user = String::new();
+        let mut connection_user = String::from("hab");
         try!(toml.parse_into("cfg.datastore_connection_user", &mut connection_user));
-        let mut connection_address = String::new();
+        let mut connection_address = String::from("127.0.0.1");
         try!(toml.parse_into("cfg.datastore_connection_address", &mut connection_address));
-        let mut connection_db = String::new();
+        let mut connection_db = String::from("builder_scheduler");
         try!(toml.parse_into("cfg.datastore_connection_db", &mut connection_db));
 
         cfg.datastore_connection_url = format!("postgresql://{}@{}/{}",

--- a/components/builder-sessionsrv/src/config.rs
+++ b/components/builder-sessionsrv/src/config.rs
@@ -93,11 +93,11 @@ impl ConfigFile for Config {
         let mut cfg = Config::default();
         try!(toml.parse_into("cfg.routers", &mut cfg.routers));
 
-        let mut connection_user = String::new();
+        let mut connection_user = String::from("hab");
         try!(toml.parse_into("cfg.datastore_connection_user", &mut connection_user));
-        let mut connection_address = String::new();
+        let mut connection_address = String::from("127.0.0.1");
         try!(toml.parse_into("cfg.datastore_connection_address", &mut connection_address));
-        let mut connection_db = String::new();
+        let mut connection_db = String::from("builder_sessionsrv");
         try!(toml.parse_into("cfg.datastore_connection_db", &mut connection_db));
 
         cfg.datastore_connection_url = format!("postgresql://{}@{}/{}",


### PR DESCRIPTION
I was overriding github oauth creds in the `builder-sessionsrv` component and while auth succeeded, the session server was not able to create db connections. It looks like all services that connect to postgres have a `from_toml` that will clear out the default db conection properties if they are not explicitly included in a `toml` file. This ensures that `toml` files can include only the settings one needs to override.

Signed-off-by: Matt Wrock <matt@mattwrock.com>