### PR TITLE
Remove postinstall step from builder-api plan.

### DIFF
--- a/components/builder-api/habitat/plan.sh
+++ b/components/builder-api/habitat/plan.sh
@@ -62,7 +62,6 @@ do_build() {
     echo $b
     fix_interpreter $(readlink -f -n $b) core/coreutils bin/env
   done
-  npm run postinstall
   npm run dist
   popd > /dev/null
 


### PR DESCRIPTION
The `postinstall` script was removed from the `package.json` when we upgraded to Angular 4, TypeScript 2. This removes the call from the plan so we can successfully build a hart.