### PR TITLE
Run the supervisor in a studio

### DIFF
--- a/components/studio/bin/hab-studio.sh
+++ b/components/studio/bin/hab-studio.sh
@@ -679,9 +679,23 @@ enter_studio() {
     set -x
   fi
 
+  echo "$studio_supervisor_start_command" | $bb chroot "$HAB_STUDIO_ROOT" \
+    $studio_env_command -i $env $studio_run_command
+
+  trap stop_supervisor EXIT
+
   # Become the `chroot` process
-  exec $bb chroot "$HAB_STUDIO_ROOT" \
+  $bb chroot "$HAB_STUDIO_ROOT" \
     $studio_env_command -i $env $studio_enter_command $*
+}
+
+# **Internal** Run when an entered studio exits.
+stop_supervisor() {
+  lock_file="$HAB_STUDIO_ROOT/hab/sup/default/LOCK"
+
+  if [ -f $lock_file ]; then
+    $bb kill $($bb cat $lock_file)
+  fi
 }
 
 # **Internal** Run a build command using a Studio.

--- a/components/studio/libexec/hab-studio-type-bare.sh
+++ b/components/studio/libexec/hab-studio-type-bare.sh
@@ -5,6 +5,7 @@ studio_build_environment=
 studio_build_command=
 studio_run_environment=
 studio_run_command=
+studio_supervisor_start_command=
 
 base_pkgs="core/hab core/hab-sup"
 : ${PKGS:=}

--- a/components/studio/libexec/hab-studio-type-baseimage.sh
+++ b/components/studio/libexec/hab-studio-type-baseimage.sh
@@ -5,6 +5,7 @@ studio_build_environment=
 studio_build_command=
 studio_run_environment=
 studio_run_command=
+studio_supervisor_start_command=
 
 base_pkgs="core/hab core/hab-sup"
 : ${PKGS:=}

--- a/components/studio/libexec/hab-studio-type-busybox.sh
+++ b/components/studio/libexec/hab-studio-type-busybox.sh
@@ -7,6 +7,7 @@ studio_build_environment=
 studio_build_command=
 studio_run_environment=
 studio_run_command="/opt/busybox/busybox sh -l"
+studio_supervisor_start_command=
 
 finish_setup() {
   # Copy in the busybox binary under `/opt/busybox`

--- a/components/studio/libexec/hab-studio-type-stage1.sh
+++ b/components/studio/libexec/hab-studio-type-stage1.sh
@@ -7,6 +7,7 @@ studio_build_environment=
 studio_build_command=
 studio_run_environment=
 studio_run_command=
+studio_supervisor_start_command=
 
 : ${STAGE1_TOOLS_URL:=https://s3-us-west-2.amazonaws.com/habitat-studio-stage1/habitat-studio-stage1-20160612022150.tar.xz}
 : ${TAR_DIR:=/tmp}

--- a/www/source/docs/run-packages-overview.html.md.erb
+++ b/www/source/docs/run-packages-overview.html.md.erb
@@ -8,10 +8,14 @@ Habitat packages used to start services are run under the Habitat supervisor. At
 
 ## Running single packages for testing
 
-Packages can be tested in the interactive studio environment or natively on a host machine running Linux. To run packages directly:
+Packages can be tested in the interactive studio environment or natively on a host machine running Linux.
+
+When entering an interactive studio, a supervisor is started for you in the background. To run packages inside of this supervisor:
 
 1. [Build your package](/docs/create-packages-build) inside an interactive studio. Do not exit the studio after it is built.
-2. To start your service, type `hab start yourorigin/yourname`, substituting the name and origin of the package you built in step 1. Your service should now be running.
+2. To start your service in the running supervisor, type `hab sup start yourorigin/yourname`, substituting the name and origin of the package you built in step 1. Your service should now be running.
+
+Because the supervisor is running in the background, you will not see the supervisor output as you start your service. However you can use the `slog` (supervisor log) command that will stream the tail of the supervisor output.
 
 If your host machine is running Linux, do the following to run your packages:
 


### PR DESCRIPTION
This starts an empty supervisor inside of an interactive studio. The supervisor is started in the background and is terminated when the studio exits. A convenience function is added to the studio profile `tail_sup` (very open to better names) which runs `tail -f` on the log file that the supervisor output is piped to.

Signed-off-by: Matt Wrock <matt@mattwrock.com>