### PR TITLE
Handle pending jobs when workers are ready

### DIFF
--- a/components/builder-originsrv/src/migrations/origins.rs
+++ b/components/builder-originsrv/src/migrations/origins.rs
@@ -51,7 +51,7 @@ pub fn migrate(migrator: &mut Migrator) -> Result<()> {
                      BEGIN
                          INSERT INTO origin_members (origin_id, origin_name, account_id, account_name)
                                 VALUES (om_origin_id, om_origin_name, om_account_id, om_account_name);
-                     END 
+                     END
                  $$ LANGUAGE plpgsql VOLATILE"#)?;
     migrator.migrate("originsrv",
                      r#"CREATE OR REPLACE FUNCTION insert_origin_v1 (
@@ -65,9 +65,11 @@ pub fn migrate(migrator: &mut Migrator) -> Result<()> {
                          INSERT INTO origins (name, owner_id)
                                 VALUES (origin_name, origin_owner_id) RETURNING * into inserted_origin;
                          PERFORM insert_origin_member_v1(inserted_origin.id, origin_name, origin_owner_id, origin_owner_name);
+                         PERFORM insert_origin_channel_v1(inserted_origin.id, origin_owner_id, 'unstable');
+                         PERFORM insert_origin_channel_v1(inserted_origin.id, origin_owner_id, 'stable');
                          RETURN NEXT inserted_origin;
                          RETURN;
-                     END 
+                     END
                  $$ LANGUAGE plpgsql VOLATILE"#)?;
     migrator.migrate("originsrv",
                      r#"CREATE OR REPLACE FUNCTION list_origin_members_v1 (

--- a/components/builder-originsrv/tests/data_store/mod.rs
+++ b/components/builder-originsrv/tests/data_store/mod.rs
@@ -26,6 +26,16 @@ fn create_origin_poop() {
     origin.set_owner_id(1);
     origin.set_owner_name(String::from("scottkelly"));
     ds.create_origin(&origin).expect("Should create origin");
+
+    // Create new database connection
+    let conn = ds.pool
+        .get(&origin)
+        .expect("Cannot get connection from pool");
+
+    let rows = conn.query("SELECT COUNT(*) FROM origin_channels", &[])
+        .expect("Failed to query database for number of channels");
+    let count: i64 = rows.iter().nth(0).unwrap().get(0);
+    assert_eq!(count, 2); // note: count of 2 is the 'unstable' and 'stable' channels
 }
 
 #[test]
@@ -1083,7 +1093,7 @@ fn create_origin_channel() {
     let rows = conn.query("SELECT COUNT(*) FROM origin_channels", &[])
         .expect("Failed to query database for number of channels");
     let count: i64 = rows.iter().nth(0).unwrap().get(0);
-    assert_eq!(count, 1);
+    assert_eq!(count, 3); // note: count of 3 includes the default 'unstable' and 'stable' channels
 }
 
 #[test]


### PR DESCRIPTION
This change fixes a bug in the builder job server where pending jobs could get lost if there were no workers ready when the job was created. Also, this fixes a couple of things with channels - it creates default 'stable' and 'unstable' channels when an origin is first created, and fixes a couple of routing/auth issues.

Signed-off-by: Salim Alam <salam@chef.io>

![giphy 20](https://cloud.githubusercontent.com/assets/13542112/25253718/f8958f70-25d6-11e7-944f-c9d39a0c339e.gif)
