### PR TITLE
Add the config data to the CensusEntry protobuf

### DIFF
--- a/components/eventsrv-client/src/lib.rs
+++ b/components/eventsrv-client/src/lib.rs
@@ -47,7 +47,6 @@ impl EventSrvClient {
         }
     }
 
-    // connect to an external process
     pub fn connect(&self) {
         for p in &self.ports {
             let push_connect = format!("tcp://localhost:{}", p);

--- a/components/eventsrv/src/subscriber.rs
+++ b/components/eventsrv/src/subscriber.rs
@@ -81,6 +81,9 @@ fn main() {
                             let data = parse_from_bytes::<CensusEntryProto>(&payload_buf).unwrap();
                             println!("SUBSCRIBER: Census Entry Member ID {}",
                                      data.get_member_id());
+                            let cfg = data.get_cfg().to_vec();
+                            let cfg_str = String::from_utf8(cfg).unwrap();
+                            println!("SUBSCRIBER: Census Entry Config {}", cfg_str);
 
                         }
                         EventEnvelope_Type::JSON |

--- a/components/sup/src/manager/census.rs
+++ b/components/sup/src/manager/census.rs
@@ -275,9 +275,8 @@ impl CensusEntry {
         cep.set_group(self.group.clone());
         cep.set_org(String::from(self.get_org()));
 
-        // JB TODO: cfg needs to be converted from a toml::Table::Value into a string first, then
-        // from a string to bytes.
-        // cep.set_cfg()
+        let cfg_str = toml::to_string(&self.cfg).unwrap();
+        cep.set_cfg(cfg_str.into_bytes());
 
         let mut sys_info = SysInfoProto::new();
         sys_info.set_ip(self.sys.ip.clone());

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -375,7 +375,7 @@ impl Manager {
                         ee.set_field_type(EventEnvelope_Type::ProtoBuf);
                         ee.set_payload(payload_buf);
                         ee.set_member_id(member_id);
-                        ee.set_service("habitat-supervisor".to_string());
+                        ee.set_service("habitat-sup".to_string());
                         let _ = client.send(ee);
                         Ok(())
                     }


### PR DESCRIPTION
I punted on including supervisor config data in the CensusEntry protobuf when I first implemented this because I wasn't sure how to do it.  This adds that in.

![](https://media.giphy.com/media/d60rwewXz7KYE/giphy.gif)

Signed-off-by: Josh Black <raskchanky@gmail.com>