### PR TITLE
add studio supervisor to windows studio

### DIFF
--- a/components/studio/libexec/hab-studio-type-default.sh
+++ b/components/studio/libexec/hab-studio-type-default.sh
@@ -119,7 +119,7 @@ start_supervisor() {
     echo "** The Habitat Supervisor has been started in the background."
     echo "** Use 'hab sup start' and 'hab sup stop' to start and stop services."
     echo "** Use the 'slog' command to stream the supervisor log."
-    echo "** Adding '\\\NO_BG_SUP=1' to your .studiorc file will disable the background supervisor."
+    echo "** Adding '\\NO_BG_SUP=1' to your .studiorc file will disable the background supervisor."
     echo ""
   else
     echo "** \\\$NO_BG_SUP was set. The Habitat Supervisor is not running."

--- a/components/sup/src/fs.rs
+++ b/components/sup/src/fs.rs
@@ -13,11 +13,12 @@
 // limitations under the License.
 
 use std::path::{Path, PathBuf};
+use hcore::fs::FS_ROOT_PATH;
 
 lazy_static! {
     /// The root path containing all runtime service directories and files
     pub static ref SVC_ROOT: PathBuf = {
-        PathBuf::from("/hab/svc")
+        Path::new(&*FS_ROOT_PATH).join("hab/svc")
     };
 }
 


### PR DESCRIPTION
In addition to adding the basic supervisor in studio implementation, I found that services running in the windows studio write to the non-studio `/sup` and `/svc` directories. So this also ensures those are properly rooted.

Signed-off-by: Matt Wrock <matt@mattwrock.com>