### PR TITLE
[plan-build] Allow Scaffolding packages to add build deps for Plans.

### DIFF
--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -780,17 +780,33 @@ _get_deps_for() {
 #
 # Will return 0 in any case.
 _return_or_append_to_set() {
-  local e
   local appended_set
-  for e in "${@:2}"; do
-    if [[ "$e" == "$1" ]]; then
-      echo "${@:2}"
-      return 0
-    fi
-  done
+  if _array_contains "$1" "${@:2}"; then
+    echo "${@:2}"
+    return 0
+  fi
   appended_set=("${@:2}" "$1")
   echo "${appended_set[@]}"
   return 0
+}
+
+# **Internal** Returns 0 (true) if the element is present in the array and
+# non-zero (false) otherwise.
+#
+# ```
+# arr=(a b c)
+# [[ $(_array_contains "b" "${arr[@]}") -eq 0 ]]
+#
+# [[ $(_array_contains "nope" "${arr[@]}") -ne 0 ]]
+# ```
+_array_contains() {
+  local e
+  for e in "${@:2}"; do
+    if [[ "$e" == "$1" ]]; then
+      return 0
+    fi
+  done
+  return 1
 }
 
 # **Internal** Prints the source file, line number, and lines of context around


### PR DESCRIPTION
This change further refines the dependency resolving logic to allow a
Scaffolding package author to add **build** dependencies to a Plan. As a
result, the timing of the scaffolding loading is pulled before the full
build dependency resolving. This shouldn't affect any existing
Scaffolding packages as a Scaffolding package author should not be using
software dependencies that they have not directly added themselves. In
other words, if more build deps are required to run in the scaffolding
loading hook, then those deps should be added to the Scaffolding
package's `${pkg_deps[@]}`.

With this change, Scaffolding package can now hot-add more build
dependencies after inspecting the app's codebase.