### PR TITLE
[plan-build] Only write SVC_USER/SVC_GROUP metafiles if pkg is a svc.

### DIFF
--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -2536,8 +2536,13 @@ _build_metadata() {
   echo "${pkg_origin}/${pkg_name}/${pkg_version}/${pkg_release}" \
     >> $pkg_prefix/IDENT
 
-  echo "$pkg_svc_user" > $pkg_prefix/SVC_USER
-  echo "$pkg_svc_group" > $pkg_prefix/SVC_GROUP
+  # Only generate `SVC_USER` & `SVC_GROUP` files if this package is a service.
+  # We determine this by checking if there is a `hooks/run` script and/or
+  # a set `$pkg_svc_run` value.
+  if [[ -f "$PLAN_CONTEXT/hooks/run" || -n "${pkg_svc_run:-}" ]]; then
+    echo "$pkg_svc_user" > $pkg_prefix/SVC_USER
+    echo "$pkg_svc_group" > $pkg_prefix/SVC_GROUP
+  fi
 
   # Generate the blake2b hashes of all the files in the package. This
   # is not in the resulting MANIFEST because MANIFEST is included!


### PR DESCRIPTION
This fixes an issue that has affected packages built since #1050 where
both `SVC_USER` & `SVC_GROUP` metadata files were unconditionally
written whether or not the package contained a service to be run by the
Supervisor. As a result, library and tool packages such as `core/sed`
and `core/rust` would contain this extra metadata.

In an effort to clarify the purpose for these metadata files and in an
attempt to reduce metadata which is not required, these files will only
be written in one or both of the 2 following conditions:

* If the Plan author has included a `hooks/run` script in their Plan
  directory
* If the Plan author (or Scaffolding package) has set the `$pkg_svc_run`
  build variable that would auto-generate a `run` hook.

As these are the only 2 ways a run hook is produced yielding a "service
package" this covers all cases.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>