### PR TITLE
Don't fail when directory exists.

### DIFF
--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -2583,7 +2583,7 @@ do_default_build_config() {
     find "$PLAN_CONTEXT/config" $find_exclusions | while read FILE
     do
       if [[ -d "$FILE" ]]; then
-        mkdir "$pkg_prefix${FILE#$PLAN_CONTEXT}"
+        mkdir -p "$pkg_prefix${FILE#$PLAN_CONTEXT}"
       else
         cp "$FILE" "$pkg_prefix${FILE#$PLAN_CONTEXT}"
       fi


### PR DESCRIPTION
In some situations directories can be created in earlier phases than do_default_build_config. This allows us to use the directory when generating files into the directories from templates rather than failing when attempting to create an already existing directory.