### PR TITLE
General quality of life improvements to Supervisor

### DIFF
--- a/components/eventsrv/src/subscriber.rs
+++ b/components/eventsrv/src/subscriber.rs
@@ -42,7 +42,7 @@ fn main() {
 
     for p in args {
         let sub_connect = format!("tcp://localhost:{}", p);
-        println!("connecting to {}", sub_connect);
+        debug!("EventSrvSubscriber connecting to {}", sub_connect);
         assert!(socket.connect(&sub_connect).is_ok());
     }
     assert!(socket.set_subscribe(b"").is_ok()); // Subscribe to everything

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -325,17 +325,8 @@ fn sub_stop(m: &ArgMatches) -> Result<()> {
     let ident = PackageIdent::from_str(m.value_of("PKG_IDENT").unwrap())?;
     let spec_file = Manager::spec_path_for(&cfg, &ServiceSpec::default_for(ident));
     let mut spec = ServiceSpec::from_file(&spec_file)?;
-    match spec.start_style {
-        StartStyle::Transient => {
-            std::fs::remove_file(&spec_file).map_err(|err| {
-                sup_error!(Error::ServiceSpecFileIO(spec_file, err))
-            })
-        }
-        StartStyle::Persistent => {
-            spec.desired_state = DesiredState::Down;
-            Manager::save_spec_for(&cfg, spec)
-        }
-    }
+    spec.desired_state = DesiredState::Down;
+    Manager::save_spec_for(&cfg, spec)
 }
 
 fn mgrcfg_from_matches(m: &ArgMatches) -> Result<ManagerConfig> {


### PR DESCRIPTION
This change introduces some general quality of life improvements to the supervisor after our multi-service changes

* Transient services will no longer produce an IO error when stopping
* Moved some debug logging from EventSrvClient to debug logger
* Fix supervisor crash when a single service fails to load (fixes #2065, #2061, #2110)
* On service load failure we will now remove the offending service spec if it represents a transient service