### PR TITLE
Add Habitat plan for EventSrv

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -761,9 +761,12 @@ version = "0.1.0"
 dependencies = [
  "byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "habitat_core 0.0.0",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "zmq 0.8.1 (git+https://github.com/erickt/rust-zmq?branch=release/v0.8)",
 ]

--- a/components/eventsrv/Cargo.toml
+++ b/components/eventsrv/Cargo.toml
@@ -10,8 +10,11 @@ workspace = "../../"
 [dependencies]
 byteorder = "*"
 env_logger = "*"
+habitat_core = { path = "../core" }
 log = "*"
 protobuf = "*"
+serde = "*"
+serde_derive = "*"
 time = "*"
 
 [dependencies.zmq]

--- a/components/eventsrv/habitat/config/config.toml
+++ b/components/eventsrv/habitat/config/config.toml
@@ -1,0 +1,1 @@
+{{toToml cfg}}

--- a/components/eventsrv/habitat/default.toml
+++ b/components/eventsrv/habitat/default.toml
@@ -1,0 +1,2 @@
+consumer_port = 9689
+producer_port = 9688

--- a/components/eventsrv/habitat/plan.sh
+++ b/components/eventsrv/habitat/plan.sh
@@ -1,0 +1,15 @@
+source "../../../support/ci/builder-base-plan.sh"
+pkg_name=hab-eventsrv
+pkg_origin=core
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=('Apache-2.0')
+pkg_bin_dirs=(bin)
+pkg_deps=(core/glibc core/gcc-libs core/zeromq core/libsodium core/libarchive)
+pkg_build_deps=(core/rust core/gcc core/pkg-config)
+pkg_exports=(
+  [consumer_port]=consumer_port
+  [producer_port]=producer_port
+)
+pkg_exposes=(consumer_port producer_port)
+bin="eventsrv"
+pkg_svc_run="$bin ${pkg_svc_path}/config.toml"

--- a/components/eventsrv/src/config.rs
+++ b/components/eventsrv/src/config.rs
@@ -1,0 +1,56 @@
+// Copyright (c) 2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Configuration for a Habitat OriginSrv service
+
+use core::config::ConfigFile;
+
+use error::Error;
+
+#[derive(Debug, Deserialize)]
+#[serde(default)]
+pub struct Config {
+    pub consumer_port: u16,
+    pub producer_port: u16,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Config {
+            consumer_port: 9689,
+            producer_port: 9688,
+        }
+    }
+}
+
+impl ConfigFile for Config {
+    type Error = Error;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_from_file() {
+        let content = r#"
+        producer_port = 9000
+        consumer_port = 9001
+        "#;
+
+        let config = Config::from_raw(&content).unwrap();
+        assert_eq!(config.producer_port, 9000);
+        assert_eq!(config.consumer_port, 9001);
+    }
+}

--- a/components/eventsrv/src/error.rs
+++ b/components/eventsrv/src/error.rs
@@ -1,0 +1,49 @@
+// Copyright (c) 2016-2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::error;
+use std::fmt;
+use std::result;
+
+use core;
+
+#[derive(Debug)]
+pub enum Error {
+    HabitatCore(core::Error),
+}
+
+pub type Result<T> = result::Result<T, Error>;
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let msg = match *self {
+            Error::HabitatCore(ref e) => format!("{}", e),
+        };
+        write!(f, "{}", msg)
+    }
+}
+
+impl error::Error for Error {
+    fn description(&self) -> &str {
+        match *self {
+            Error::HabitatCore(ref err) => err.description(),
+        }
+    }
+}
+
+impl From<core::Error> for Error {
+    fn from(err: core::Error) -> Error {
+        Error::HabitatCore(err)
+    }
+}

--- a/components/eventsrv/src/lib.rs
+++ b/components/eventsrv/src/lib.rs
@@ -12,19 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+extern crate habitat_core as core;
 #[macro_use]
 extern crate log;
 extern crate protobuf;
+extern crate serde;
+#[macro_use]
+extern crate serde_derive;
 extern crate time;
 extern crate zmq;
 
+pub mod config;
+pub mod error;
 pub mod message;
 
-use message::event::EventEnvelope;
-use protobuf::parse_from_bytes;
 use std::collections::HashMap;
 use std::collections::HashSet;
+
+use protobuf::parse_from_bytes;
 use zmq::{Context, PULL, XPUB};
+
+use message::event::EventEnvelope;
 
 /// Proxies messages coming into `frontend_port` out through
 /// `backend_port`, caching recent messages for new subscribers.
@@ -48,7 +56,7 @@ use zmq::{Context, PULL, XPUB};
 ///
 /// If either `frontend_port` or `backend_port` cannot be bound to
 /// sockets (e.g., they're already in use), the thread will panic.
-pub fn proxy(frontend_port: i32, backend_port: i32) {
+pub fn proxy(frontend_port: u16, backend_port: u16) {
     let ctx = Context::new();
 
     let pull_sock = ctx.socket(PULL).unwrap();

--- a/components/eventsrv/src/main.rs
+++ b/components/eventsrv/src/main.rs
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-extern crate habitat_eventsrv;
+extern crate habitat_core as core;
+extern crate habitat_eventsrv as eventsrv;
 extern crate log;
 extern crate protobuf;
 
@@ -20,20 +21,21 @@ mod message;
 
 use std::env;
 
+use core::config::ConfigFile;
+use eventsrv::config::Config;
+
 fn main() {
-    let mut args: Vec<_> = env::args().collect();
+    let config = if let Some(path) = env::args().nth(1) {
+        Config::from_file(&path).unwrap_or(Config::default())
+    } else {
+        Config::default()
+    };
 
-    let port1 = args.remove(1);
-    let frontend_port: i32 = port1.parse().unwrap();
+    assert!(config.producer_port != config.consumer_port);
 
-    let port2 = args.remove(1);
-    let backend_port: i32 = port2.parse().unwrap();
-
-    assert!(frontend_port != backend_port);
-
-    println!("Frontend port is {}", frontend_port);
-    println!("Backend port is {}", backend_port);
+    println!("Producer port is {}", config.producer_port);
+    println!("Consumer port is {}", config.consumer_port);
     println!("Starting proxy service...");
 
-    habitat_eventsrv::proxy(frontend_port, backend_port);
+    eventsrv::proxy(config.producer_port, config.consumer_port);
 }

--- a/components/eventsrv/src/message/mod.rs
+++ b/components/eventsrv/src/message/mod.rs
@@ -1,1 +1,15 @@
+// Copyright (c) 2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 pub mod event;


### PR DESCRIPTION
* Add Habitat plan for EventSrv
* Add config module to EventSrv
* Add error module to EventSrv
* `eventsrv` binary now takes one optional argument on start. This
  argument is the path to a configuration file. If not supplied or
  an invalid configuration is found, a default will be used instead