### PR TITLE
implement supervisor status command

### DIFF
--- a/components/sup/src/manager/service/mod.rs
+++ b/components/sup/src/manager/service/mod.rs
@@ -40,6 +40,7 @@ use hcore::package::{PackageIdent, PackageInstall};
 use hcore::util::deserialize_using_from_str;
 use hcore::util::perm::{set_owner, set_permissions};
 use serde;
+use time::Timespec;
 use toml;
 
 use self::hooks::{HOOK_PERMISSIONS, Hook, HookTable};
@@ -92,6 +93,7 @@ pub struct Service {
     last_health_check: Instant,
     #[serde(skip_serializing)]
     manager_fs_cfg: Arc<manager::FsCfg>,
+    #[serde(rename="process")]
     supervisor: Supervisor,
 }
 
@@ -284,6 +286,10 @@ impl Service {
     /// Instructs the service's process supervisor to reap dead children.
     fn check_process(&mut self) {
         self.supervisor.check_process()
+    }
+
+    pub fn last_state_change(&self) -> Timespec {
+        self.supervisor.state_entered
     }
 
     pub fn tick(&mut self, census_ring: &CensusRing) -> bool {

--- a/components/sup/src/manager/spec_watcher.rs
+++ b/components/sup/src/manager/spec_watcher.rs
@@ -188,7 +188,7 @@ impl SpecWatcher {
         Ok(events)
     }
 
-    fn specs_from_watch_path<'a>(&self) -> Result<HashMap<String, ServiceSpec>> {
+    pub fn specs_from_watch_path<'a>(&self) -> Result<HashMap<String, ServiceSpec>> {
         let spec_files: Vec<PathBuf> = glob(&self.watch_path
                                                  .join(SPEC_FILE_GLOB)
                                                  .display()

--- a/www/source/docs/run-packages-monitoring.html.md
+++ b/www/source/docs/run-packages-monitoring.html.md
@@ -3,6 +3,20 @@ title: Monitor Habitat services
 description: Monitor services through the HTTP API
 ---
 
+# Monitoring services using the `hab sup status` command
+You can query all services currently loaded or running under the local supervisor using the `hab sup status` command. This command will list all persistent services loaded by the supervisor along with their current state. It will also list transient services that are currently running or in a `starting` or `restarting` state. The `status` command includes the version and release of the servicwe and for services that are running, it will include the `PID` of the running service.
+
+To retrieve status for an individual service, you can pass the service identifier:
+
+      hab sup status core/mysql
+
+The following exit codes are emitted by the `status` command:
+
+* `0` - The status command successfully reports status on loaded services
+* `1` - A generic error has occured calling the `hab` cli
+* `2` - A service identifier was passed to `hab sup status` and that service is not loaded by the supervisor
+* `3` - There is no local running supervisor
+
 # Monitor services through the HTTP API
 When a service starts, the supervisor exposes the status of its services' health and other information through an HTTP API endpoint. This information can be useful in monitoring service health, results of leader elections, and so on.
 

--- a/www/source/docs/run-packages-multiple-services.html.md
+++ b/www/source/docs/run-packages-multiple-services.html.md
@@ -59,6 +59,20 @@ To resume running a service which has been loaded but stopped (via the `hab serv
 
 		hab service start core/redis
 
+## Querying the supervisor for service status
+You can query all services currently loaded or running under the local supervisor using the `hab sup status` command. This command will list all persistent services loaded by the supervisor along with their current state. It will also list transient services that are currently running or in a `starting` or `restarting` state. The `status` command includes the version and release of the servicwe and for services that are running, it will include the `PID` of the running service.
+
+To retrieve status for an individual service, you can pass the service identifier:
+
+      hab sup status core/mysql
+
+The following exit codes are emitted by the `status` command:
+
+* `0` - The status command successfully reports status on loaded services
+* `1` - A generic error has occured calling the `hab` cli
+* `2` - A service identifier was passed to `hab sup status` and that service is not loaded by the supervisor
+* `3` - There is no local running supervisor
+
 <hr>
 <ul class="main-content--link-nav">
   <li>Continue to the next topic</li>


### PR DESCRIPTION
This adds a `status command to the supervisor. It takes an optional package ident argument. If this argument is not given then the command reports status for all services running in the supervisor.

Further yhis fixes a bug in the service data persistence where service state was not being persisted when a service's state changes. In production, the `/services` monitoring endpoint only reports the initial service state when the supervisor first runs and this would typically report that the services are `Down` with a `Null` PID. Now service states are checked for a change on each supervisor tick and persisted to disk on change.

Note that the `state_entered` supervisor field is now a `Timespec` rather than a `SteadyTime`. This is because `SteadyTime` does not lend itself well  to serialization/deserialization. Its internal state will differ based on platform whereas `Timespec` internal data should be uniform.

Signed-off-by: Matt Wrock <matt@mattwrock.com>