### PR TITLE
Service butterfly decoupling

### DIFF
--- a/components/butterfly/src/server/mod.rs
+++ b/components/butterfly/src/server/mod.rs
@@ -26,7 +26,7 @@ mod pull;
 mod push;
 pub mod timing;
 
-use std::collections::{HashSet, HashMap};
+use std::collections::HashSet;
 use std::ffi;
 use std::fmt::{self, Debug};
 use std::fs;
@@ -45,7 +45,6 @@ use habitat_core::service::ServiceGroup;
 use habitat_core::crypto::SymKey;
 use serde::{Serialize, Serializer};
 use serde::ser::SerializeStruct;
-use toml;
 
 use error::{Result, Error};
 use member::{Member, Health, MemberList};
@@ -754,27 +753,6 @@ impl Server {
         if self.update_store.insert(election) {
             self.rumor_list.insert(rk);
         }
-    }
-
-    /// Returns (incarnation, config) if the service group has a configuration.
-    pub fn service_config_for(&self,
-                              service_group: &str,
-                              incarnation: Option<u64>)
-                              -> Option<(u64, toml::Value)> {
-        let mut result = None;
-        self.service_config_store
-            .with_rumor(service_group,
-                        "service_config",
-                        |maybe_sc| if let Some(sc) = maybe_sc {
-                            if incarnation.is_none() ||
-                               sc.get_incarnation() > incarnation.unwrap() {
-                                match sc.config() {
-                                    Ok(config) => result = Some((sc.get_incarnation(), config)),
-                                    Err(err) => warn!("{}", err),
-                                }
-                            }
-                        });
-        result
     }
 
     fn generate_wire(&self, payload: Vec<u8>) -> Result<Vec<u8>> {

--- a/components/butterfly/src/server/mod.rs
+++ b/components/butterfly/src/server/mod.rs
@@ -756,36 +756,6 @@ impl Server {
         }
     }
 
-    pub fn service_files_for(&self,
-                             service_group: &str,
-                             current_service_files: &HashMap<String, u64>)
-                             -> Vec<(u64, String, Vec<u8>)> {
-        let mut service_files = Vec::new();
-
-        self.service_file_store
-            .with_rumors(service_group, |sf| {
-                let current_incarnation = current_service_files.get(sf.get_filename());
-                if current_incarnation.is_none() ||
-                   sf.get_incarnation() > *current_incarnation.unwrap() {
-                    match sf.body() {
-                        Ok(body) => {
-                            service_files.push((sf.get_incarnation(),
-                                                String::from(sf.get_filename()),
-                                                body))
-                        }
-                        Err(e) => {
-                            warn!("Cannot decrypt service file for {} {} {}: {}",
-                                  service_group,
-                                  sf.get_filename(),
-                                  sf.get_incarnation(),
-                                  e)
-                        }
-                    }
-                }
-            });
-        service_files
-    }
-
     /// Returns (incarnation, config) if the service group has a configuration.
     pub fn service_config_for(&self,
                               service_group: &str,

--- a/components/sup/src/census.rs
+++ b/components/sup/src/census.rs
@@ -31,7 +31,7 @@ use toml;
 
 static LOGKEY: &'static str = "CE";
 
-type MemberId = String;
+pub type MemberId = String;
 #[derive(Debug, Deserialize, Serialize)]
 pub struct CensusRing {
     pub changed: bool,

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -419,7 +419,8 @@ impl Manager {
                                     &self.butterfly.service_store,
                                     &self.butterfly.election_store,
                                     &self.butterfly.update_store,
-                                    &self.butterfly.member_list);
+                                    &self.butterfly.member_list,
+                                    &self.butterfly.service_file_store);
             service_rumor_offset = 0;
 
             if self.census_ring.changed {

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -308,7 +308,8 @@ impl Manager {
         // back to us. Since we consume and deconstruct the spec in `Service::new()` which
         // `Service::load()` eventually delegates to we just can't have that. We should clean
         // this up in the future.
-        let service = match Service::load(spec.clone(),
+        let service = match Service::load(self.butterfly.member_id(),
+            spec.clone(),
                                           &self.gossip_listen,
                                           &self.http_listen,
                                           self.fs_cfg.clone(),

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -309,7 +309,7 @@ impl Manager {
         // `Service::load()` eventually delegates to we just can't have that. We should clean
         // this up in the future.
         let service = match Service::load(self.butterfly.member_id(),
-            spec.clone(),
+                                          spec.clone(),
                                           &self.gossip_listen,
                                           &self.http_listen,
                                           self.fs_cfg.clone(),
@@ -323,8 +323,7 @@ impl Manager {
                 return;
             }
         };
-        self.butterfly
-            .insert_service(service.to_rumor(self.butterfly.member_id()));
+        self.butterfly.insert_service(service.to_rumor(1));
         if service.topology == Topology::Leader {
             self.butterfly
                 .start_election(service.service_group.clone(), 0);

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -452,7 +452,7 @@ impl Manager {
                     .write()
                     .expect("Services lock is poisoned!")
                     .iter_mut() {
-                if service.tick(&self.butterfly, &self.census_ring) {
+                if service.tick(&self.census_ring) {
                     self.gossip_latest_service_rumor(&service);
                     service_rumor_offset += 1;
                 }

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -420,6 +420,7 @@ impl Manager {
                                     &self.butterfly.election_store,
                                     &self.butterfly.update_store,
                                     &self.butterfly.member_list,
+                                    &self.butterfly.service_config_store,
                                     &self.butterfly.service_file_store);
             service_rumor_offset = 0;
 

--- a/components/sup/src/manager/service/mod.rs
+++ b/components/sup/src/manager/service/mod.rs
@@ -456,7 +456,7 @@ impl Service {
         self.initialized = false;
     }
 
-    pub fn to_rumor<T: ToString>(&self, member_id: T) -> ServiceRumor {
+    pub fn to_rumor(&self, incarnation: u64) -> ServiceRumor {
         let exported = match self.config.to_exported() {
             Ok(exported) => Some(exported),
             Err(err) => {
@@ -466,11 +466,13 @@ impl Service {
                 None
             }
         };
-        ServiceRumor::new(member_id.to_string(),
-                          &self.package().ident,
-                          &self.service_group,
-                          &*self.config.sys,
-                          exported.as_ref())
+        let mut rumor = ServiceRumor::new(self.local_member_id.clone(),
+                                          &self.package().ident,
+                                          &self.service_group,
+                                          &*self.config.sys,
+                                          exported.as_ref());
+        rumor.set_incarnation(incarnation);
+        rumor
     }
 
     /// Run initialization hook if present


### PR DESCRIPTION
This PR removes the dependency from Service to butterfly::Server by adding the ServiceConfig and ServiceFile struct to the census module.

Part of https://github.com/habitat-sh/habitat/issues/2094.