### PR TITLE
Adjustments to builder-web support script

### DIFF
--- a/support/builder_web.sh
+++ b/support/builder_web.sh
@@ -1,10 +1,13 @@
-#/bin/bash
+#!/bin/bash
+
+unset NODE_ENV
 
 if [ ! -f "$HOME/.nvm/nvm.sh" ]; then
     curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.1/install.sh | bash
-    export NVM_DIR="$HOME/.nvm"
-    [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
 fi
+
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
 
 cd components/builder-web
 
@@ -12,9 +15,17 @@ if [ ! -f habitat.conf.js ]; then
     cp habitat.conf.sample.js habitat.conf.js
 fi
 
-if [ ! nvm use ]; then
-    nvm install $(cat .nvmrc)
-fi
-
+nvm install
 npm install
-npm start
+npm run build
+
+echo '{
+  "port": 3000,
+  "open": false,
+  "files": false,
+  "server": {
+    "baseDir": "./"
+  }
+}' > /tmp/bs-config.json
+
+./node_modules/.bin/lite-server -c /tmp/bs-config.json


### PR DESCRIPTION
Currently, if the `web` process crashes because of a CSS or JS complication error, which happens frequently during development, it takes down everything in the Procfile with it. This tweaks a few things to prevent interference with builder-web development workflow:

* Always export NVM_DIR and source the NVM script
* Always install and use the locally specified Node version (NVM detects it automatically from .nvmrc, bypassing if already installed)
* Build a bundle and serve it without watching for file-system changes (since we do this by running `npm start` locally)

![](https://i.giphy.com/13HBDT4QSTpveU.gif)

Signed-off-by: Christian Nunciato <cnunciato@chef.io>