### PR TITLE
remove service rumor offset to avoid dropping rumors

### DIFF
--- a/components/sup/src/census.rs
+++ b/components/sup/src/census.rs
@@ -65,7 +65,6 @@ impl CensusRing {
     }
 
     pub fn update_from_rumors(&mut self,
-                              service_rumor_offset: usize,
                               service_rumors: &RumorStore<ServiceRumor>,
                               election_rumors: &RumorStore<ElectionRumor>,
                               election_update_rumors: &RumorStore<ElectionUpdateRumor>,
@@ -73,7 +72,7 @@ impl CensusRing {
                               service_config_rumors: &RumorStore<ServiceConfigRumor>,
                               service_file_rumors: &RumorStore<ServiceFileRumor>) {
         self.changed = false;
-        self.update_from_service_store(service_rumor_offset, service_rumors);
+        self.update_from_service_store(service_rumors);
         self.update_from_election_store(election_rumors);
         self.update_from_election_update_store(election_update_rumors);
         self.update_from_member_list(member_list);
@@ -90,9 +89,7 @@ impl CensusRing {
     }
 
     fn update_from_service_store(&mut self,
-                                 service_rumor_offset: usize,
                                  service_rumors: &RumorStore<ServiceRumor>) {
-        self.last_service_counter += service_rumor_offset;
         if service_rumors.get_update_counter() <= self.last_service_counter {
             return;
         }
@@ -643,8 +640,7 @@ mod tests {
             let service_config_store: RumorStore<ServiceConfigRumor> = RumorStore::default();
             let service_file_store: RumorStore<ServiceFileRumor> = RumorStore::default();
             let mut ring = CensusRing::new("member-b".to_string());
-            ring.update_from_rumors(0,
-                                    &service_store,
+            ring.update_from_rumors(&service_store,
                                     &election_store,
                                     &election_update_store,
                                     &member_list,

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -402,7 +402,6 @@ impl Manager {
             })
             .expect("unable to start sup-eventsrv thread");
 
-        let mut service_rumor_offset = 0;
 
         loop {
             let next_check = SteadyTime::now() + TimeDuration::milliseconds(1000);
@@ -411,17 +410,15 @@ impl Manager {
                 return Ok(());
             }
             self.update_running_services_from_watcher()?;
-            service_rumor_offset += self.check_for_updated_packages();
+            self.check_for_updated_packages();
             self.restart_elections();
             self.census_ring
-                .update_from_rumors(service_rumor_offset,
-                                    &self.butterfly.service_store,
+                .update_from_rumors(&self.butterfly.service_store,
                                     &self.butterfly.election_store,
                                     &self.butterfly.update_store,
                                     &self.butterfly.member_list,
                                     &self.butterfly.service_config_store,
                                     &self.butterfly.service_file_store);
-            service_rumor_offset = 0;
 
             if self.census_ring.changed {
                 self.persist_state();
@@ -453,7 +450,6 @@ impl Manager {
                     .iter_mut() {
                 if service.tick(&self.census_ring) {
                     self.gossip_latest_service_rumor(&service);
-                    service_rumor_offset += 1;
                 }
             }
             let time_to_wait = (next_check - SteadyTime::now()).num_milliseconds();
@@ -509,8 +505,7 @@ impl Manager {
     ///
     /// The run loop's last updated census is a required parameter on this function to inform the
     /// main loop that we, ourselves, updated the service counter when we updated ourselves.
-    fn check_for_updated_packages(&mut self) -> usize {
-        let mut updated_services = 0;
+    fn check_for_updated_packages(&mut self) {
         for service in self.services
                 .write()
                 .expect("Services lock is poisoned!")
@@ -519,10 +514,8 @@ impl Manager {
                    .check_for_updated_package(service, &self.census_ring) {
                 service.populate(&self.census_ring);
                 self.gossip_latest_service_rumor(&service);
-                updated_services += 1;
             }
         }
-        updated_services
     }
 
     fn gossip_latest_service_rumor(&self, service: &Service) {


### PR DESCRIPTION
This is a potential fix for #1816. When a service package is updated (in this case from a `hab config apply`), we add a service rumor to the service rumor store. However this rumor does not update the census group members and as a result the binds of one service that would have been altered by another's change are never processed.

Its really a mystery what this offset is intended to accomplish. Its clearly there for a reason but perhaps it is legacy?

There is a good chance that I am not seeing its true purpose which may be important so I would really like @adamhjk and/or @reset to weigh in. As this PR stands, I now see config updates refresh the binds of other services.

Signed-off-by: Matt Wrock <matt@mattwrock.com>