### PR TITLE
remove health cache when removing service

### DIFF
--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -419,6 +419,12 @@ impl Manager {
                           err);
             }
         }
+
+        if let Err(err) = fs::remove_file(self.fs_cfg.health_check_cache(&service.service_group)) {
+            outputln!("Unable to cleanup service health cache, {}, {}",
+                      service,
+                      err);
+        }
     }
 
     pub fn run(&mut self) -> Result<()> {

--- a/components/sup/src/manager/service/mod.rs
+++ b/components/sup/src/manager/service/mod.rs
@@ -605,8 +605,7 @@ impl Service {
 
     fn cache_health_check(&self, check_result: HealthCheck) {
         let state_file = self.manager_fs_cfg
-            .data_path
-            .join(format!("{}.health", self.service_group.service()));
+            .health_check_cache(&self.service_group);
         let tmp_file = state_file.with_extension("tmp");
         let file = match File::create(&tmp_file) {
             Ok(file) => file,


### PR DESCRIPTION
Fixes #2103 and clears the health check cache of a service when it is removed.

Signed-off-by: Matt Wrock <matt@mattwrock.com>