### PR TITLE
Update hab-spider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,6 +383,8 @@ dependencies = [
  "postgres 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "r2d2 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/components/hab-spider/Cargo.toml
+++ b/components/hab-spider/Cargo.toml
@@ -15,6 +15,8 @@ clap = "2"
 protobuf = "*"
 postgres = "*"
 r2d2 = "*"
+serde = "*"
+serde_derive = "*"
 
 [dependencies.habitat_core]
 path = "../core"

--- a/components/hab-spider/src/config.rs
+++ b/components/hab-spider/src/config.rs
@@ -1,0 +1,76 @@
+// Copyright (c) 2016-2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Configuration for a Habitat Scheduler service
+
+use db::config::DataStoreCfg;
+use hab_core::config::ConfigFile;
+
+use error::Error;
+
+#[derive(Debug, Deserialize)]
+#[serde(default)]
+pub struct Config {
+    pub datastore: DataStoreCfg,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        let mut datastore = DataStoreCfg::default();
+        datastore.database = String::from("builder_scheduler");
+        Config { datastore: datastore }
+    }
+}
+
+impl ConfigFile for Config {
+    type Error = Error;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_from_file() {
+        let content = r#"
+        [datastore]
+        host = "1.1.1.1"
+        port = 9000
+        user = "test"
+        database = "test_scheduler"
+        connection_retry_ms = 500
+        connection_timeout_sec = 4800
+        connection_test = true
+        pool_size = 1
+        "#;
+
+        let config = Config::from_raw(&content).unwrap();
+        assert_eq!(config.datastore.port, 9000);
+        assert_eq!(config.datastore.user, "test");
+        assert_eq!(config.datastore.database, "test_scheduler");
+        assert_eq!(config.datastore.connection_retry_ms, 500);
+        assert_eq!(config.datastore.connection_timeout_sec, 4800);
+        assert_eq!(config.datastore.connection_test, true);
+        assert_eq!(config.datastore.pool_size, 1);
+    }
+
+    #[test]
+    fn config_from_file_defaults() {
+        let content = r#"
+        "#;
+
+        let config = Config::from_raw(&content).unwrap();
+        assert_eq!(config.datastore.database, String::from("builder_scheduler"));
+    }
+}


### PR DESCRIPTION
This change updates the package graph tool to get it working again with the new postgres changes. It also updates the package graph module to return only unique plans in the reverse dependency list, and return the plan count in the graph statistics.

Signed-off-by: Salim Alam <salam@chef.io>

![giphy 26](https://cloud.githubusercontent.com/assets/13542112/25646071/5a116f4e-2f69-11e7-966b-181097c9f9ba.gif)
