### PR TITLE
install package on load and start in the cli

### DIFF
--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -31,6 +31,7 @@ use std::str::FromStr;
 
 use ansi_term::Colour::{Red, Yellow};
 use clap::{App, ArgMatches};
+use common::ui::UI;
 use hcore::env as henv;
 use hcore::crypto::{default_cache_key_path, SymKey};
 use hcore::crypto::init as crypto_init;
@@ -48,6 +49,7 @@ use sup::manager::{Manager, ManagerConfig, ServiceStatus};
 use sup::manager::service::{DesiredState, ServiceBind, Topology, UpdateStrategy};
 use sup::manager::service::{ServiceSpec, StartStyle};
 use sup::supervisor::ProcessState;
+use sup::util;
 
 /// Our output key
 static LOGKEY: &'static str = "MN";
@@ -244,6 +246,7 @@ fn sub_load(m: &ArgMatches) -> Result<()> {
     }
     let mut spec = spec_from_matches(default_spec.ident, m)?;
     spec.start_style = StartStyle::Persistent;
+    util::pkg::install_from_spec(&mut UI::default(), &spec)?;
     Manager::save_spec_for(&cfg, spec)
 }
 
@@ -315,7 +318,11 @@ fn sub_start(m: &ArgMatches) -> Result<()> {
                         }
                     }
                 }
-                Err(_) => Some(spec_from_matches(default_spec.ident, m)?),
+                Err(_) => {
+                    let spec = spec_from_matches(default_spec.ident, m)?;
+                    util::pkg::install_from_spec(&mut UI::default(), &spec)?;
+                    Some(spec)
+                }
             }
         }
         None => None,

--- a/components/sup/src/manager/service/mod.rs
+++ b/components/sup/src/manager/service/mod.rs
@@ -170,23 +170,7 @@ impl Service {
                                    manager_fs_cfg: Arc<manager::FsCfg>,
                                    organization: Option<&str>)
                                    -> Result<Service> {
-        let mut ui = UI::default();
-        let package = match PackageInstall::load(&spec.ident, Some(&Path::new(&*FS_ROOT_PATH))) {
-            Ok(package) => {
-                match spec.update_strategy {
-                    UpdateStrategy::AtOnce => {
-                        util::pkg::maybe_install_newer(&mut ui, &spec, package)?
-                    }
-                    UpdateStrategy::None | UpdateStrategy::Rolling => package,
-                }
-            }
-            Err(_) => {
-                outputln!("{} not found in local package cache, installing from {}",
-                          Yellow.bold().paint(spec.ident.to_string()),
-                          &spec.depot_url);
-                util::pkg::install(&mut ui, &spec.depot_url, &spec.ident)?
-            }
-        };
+        let package = util::pkg::install_from_spec(&mut UI::default(), &spec)?;
         let service = Self::new(local_member_id.into(),
                                 package,
                                 spec,


### PR DESCRIPTION
This fixes #2110. This simply attempts a package install at load and start time in the cli thread instead of the supervisor thread. This way if there is an issue with package loading, it is more obvious. Also the supervisor will not load a package that does not install.

Signed-off-by: Matt Wrock <matt@mattwrock.com>