### PR TITLE
Relax requirement for version in plan deserialize

### DIFF
--- a/components/core/src/package/plan.rs
+++ b/components/core/src/package/plan.rs
@@ -42,10 +42,20 @@ impl Plan {
                 }
             }
         }
-        if name.is_none() || version.is_none() {
+
+        // Only the name is required to be present initiallly in the plan.sh
+        if name.is_none() {
             return Err(Error::PlanMalformed);
         }
-        let plan = Plan::new(name.unwrap(), version.unwrap());
+
+        // Default the version to 'undefined' if it's not present
+        let v = if version.is_none() {
+            String::from("undefined")
+        } else {
+            version.unwrap()
+        };
+
+        let plan = Plan::new(name.unwrap(), v);
         Ok(plan)
     }
 }


### PR DESCRIPTION
When we deserialize a plan we need to relax the restriction that a version is present. This is because we can have cases where the version is dynamically computed, and not initially present as a static pkg_version in the plan.

Signed-off-by: Salim Alam <salam@chef.io>

![giphy 27](https://cloud.githubusercontent.com/assets/13542112/25678143/948dd3b2-2ffd-11e7-9331-ecaec7d57d07.gif)
