### PR TITLE
at-once update strategy updates from local package cache as well as depot

### DIFF
--- a/components/sup/src/util/pkg.rs
+++ b/components/sup/src/util/pkg.rs
@@ -47,11 +47,10 @@ pub fn maybe_install_newer(ui: &mut UI,
                            -> Result<PackageInstall> {
     let latest_ident: PackageIdent = {
         let depot_client = Client::new(&spec.depot_url, PRODUCT, VERSION, None)?;
-        depot_client
-            .show_package(&spec.ident)?
-            .get_ident()
-            .clone()
-            .into()
+        match depot_client.show_package(&spec.ident) {
+            Ok(pkg) => pkg.get_ident().clone().into(),
+            Err(_) => return Ok(current),
+        }
     };
 
     if &latest_ident > current.ident() {

--- a/www/source/docs/run-packages-update-strategy.html.md
+++ b/www/source/docs/run-packages-update-strategy.html.md
@@ -28,7 +28,7 @@ It's important to note that because we must perform a leader election to determi
 
 ### At-Once Strategy
 
-This strategy does no peer coordination with other supervisors in the service group; it merely updates the underlying Habitat package whenever it detects that a new version has been published to a depot. No coordination between supervisors is done, each supervisor will poll a remote depot on their own.
+This strategy does no peer coordination with other supervisors in the service group; it merely updates the underlying Habitat package whenever it detects that a new version has either been published to a depot or installed to the local habitat `pkg` cache. No coordination between supervisors is done, each supervisor will poll a remote depot on their own.
 
 ## Configuring an Update Strategy with a Depot Channel
 


### PR DESCRIPTION
Fixes #2144. When using the `at-once` strategy, the `ServiceUpdater` will now check the local `/hab/pkg` directory for an updated package in addition to the depot. If a new one is discovered in either location, the one with the latest version/release will be chosen for update. Further, failure to locate the package in the depot will no longer result in a 404 error that prevents the service from starting.

Signed-off-by: Matt Wrock <matt@mattwrock.com>