### PR TITLE
sup start and load report status on loaded/started service

### DIFF
--- a/components/sup/src/config.rs
+++ b/components/sup/src/config.rs
@@ -34,7 +34,7 @@ pub const GOSSIP_DEFAULT_PORT: u16 = 9638;
 
 static LOGKEY: &'static str = "CFG";
 
-#[derive(PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct GossipListenAddr(SocketAddr);
 
 impl Default for GossipListenAddr {

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -151,7 +151,7 @@ impl FsCfg {
     }
 }
 
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct ManagerConfig {
     pub gossip_listen: GossipListenAddr,
     pub http_listen: http_gateway::ListenAddr,

--- a/components/sup/src/supervisor.rs
+++ b/components/sup/src/supervisor.rs
@@ -44,7 +44,7 @@ use util;
 
 static LOGKEY: &'static str = "SV";
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, PartialEq, Deserialize, Serialize)]
 pub enum ProcessState {
     Down,
     Up,


### PR DESCRIPTION
fixes #2121. This causes `hab sup start` and `hab sup load` to report status on the started or loaded service. It will wait up to 5 seconds for the service to reach its desired state. It will return an exit of 1 if the desired state is not reached. If the supervisor is not running, the behavior remains the same.

Signed-off-by: Matt Wrock <matt@mattwrock.com>