### PR TITLE
[plan-build] Rename Scaffolding load function to `scaffolding_load()`.

### DIFF
--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -994,9 +994,10 @@ _set_build_tdeps_resolved() {
   done
 }
 
-# **Internal** Loads specified scaffolding to extend plan DSL. This assumes
-# the scaffolding lives within `lib` and is named `scaffolding.sh` for each
-# application/project type.
+# **Internal** Loads a Scaffolding package if `$pkg_scaffolding` is set. If the
+# Scaffolding package's implementation contains a `scaffolding_load()`
+# function, it is executed here so that the package can further influence the
+# run and build dependencies of the Plan.
 _load_scaffolding() {
   local lib
   if [[ -z "${pkg_scaffolding:-}" ]]; then
@@ -1009,8 +1010,8 @@ _load_scaffolding() {
     exit_with "Failed to load Scaffolding from $lib" 17
   fi
 
-  if [[ "$(type -t _scaffolding_begin)" == "function" ]]; then
-    _scaffolding_begin
+  if [[ "$(type -t scaffolding_load)" == "function" ]]; then
+    scaffolding_load
   fi
 }
 

--- a/www/source/docs/concepts-scaffolding.html.md
+++ b/www/source/docs/concepts-scaffolding.html.md
@@ -58,7 +58,7 @@ Each scaffolding defines a set of callbacks which are unique to the scaffolding 
 
 ### Internal Callbacks
 
-#### `_scaffolding_begin`
+#### `scaffolding_load`
 
 The default_begin phase is executed prior to loading the scaffolding. This internal callback allow the scaffolding to run anything we need to execute before the download and build.
 


### PR DESCRIPTION
This change updates the name of the optional load hook for a Scaffolding
package from the previously named `_scaffolding_begin()` to
`scaffolding_load()`. There are 2 reasons for the rename:

1. From the Scaffolding package author's point of view, this function is
part of the build system's public API and therefore should not be
considered an internal function. The build program itself will call this
function when appropriate, and this is internal implementation detail.
2. When explaining the Scaffolding functionality, it has been common to
say "when the Scaffolding is loaded". As such, a function name
containing the word `load` is probably more intuitive.

![gif-keyboard-856764819056664931](https://cloud.githubusercontent.com/assets/261548/25727960/5c274156-30e9-11e7-856d-a644c6dee080.gif)
