### PR TITLE
Update package graph module

### DIFF
--- a/components/builder-originsrv/src/migrations/origin_packages.rs
+++ b/components/builder-originsrv/src/migrations/origin_packages.rs
@@ -124,9 +124,9 @@ pub fn migrate(migrator: &mut Migrator) -> Result<()> {
                     END
                     $$ LANGUAGE plpgsql STABLE"#)?;
     migrator.migrate("originsrv",
-                     r#"CREATE OR REPLACE FUNCTION sync_packages_v1() RETURNS TABLE(account_id bigint, package_id bigint, package_ident text) AS $$
+                     r#"CREATE OR REPLACE FUNCTION sync_packages_v1() RETURNS TABLE(account_id bigint, package_id bigint, package_ident text, package_deps text) AS $$
                     BEGIN
-                        RETURN QUERY SELECT origin_packages.owner_id, origin_packages.id, origin_packages.ident FROM origin_packages WHERE origin_packages.scheduler_sync = false;
+                        RETURN QUERY SELECT origin_packages.owner_id, origin_packages.id, origin_packages.ident, origin_packages.deps FROM origin_packages WHERE origin_packages.scheduler_sync = false;
                         RETURN;
                     END
                     $$ LANGUAGE plpgsql STABLE"#)?;

--- a/components/builder-scheduler/src/server/handlers.rs
+++ b/components/builder-scheduler/src/server/handlers.rs
@@ -64,7 +64,7 @@ pub fn group_create(req: &mut Envelope,
     let rdeps_opt = {
         let graph = state.graph().read().unwrap();
         start_time = PreciseTime::now();
-        let ret = graph.rdeps(&project_ident);
+        let ret = graph.rdeps(&project_name);
         end_time = PreciseTime::now();
         ret
     };
@@ -76,8 +76,15 @@ pub fn group_create(req: &mut Envelope,
                    start_time.to(end_time));
 
             for s in rdeps {
-                debug!("Adding to projects: {} ({})", s.0, s.1);
-                projects.push(s);
+                let origin = s.0.split("/").nth(0).unwrap();
+
+                // We only build core packages for now
+                if origin == "core" {
+                    debug!("Adding to projects: {} ({})", s.0, s.1);
+                    projects.push(s.clone());
+                } else {
+                    debug!("Skipping non-core project: {} ({})", s.0, s.1);
+                }
             }
         }
         None => {

--- a/components/hab-spider/src/main.rs
+++ b/components/hab-spider/src/main.rs
@@ -162,7 +162,6 @@ fn do_stats(graph: &PackageGraph) {
     println!("Edge count: {}", stats.edge_count);
     println!("Connected components: {}", stats.connected_comp);
     println!("Is cyclic: {}", stats.is_cyclic);
-    println!("Plan count: {}\n", stats.plan_count);
 }
 
 fn do_top(graph: &PackageGraph, count: usize) {


### PR DESCRIPTION
This change makes some updates and fixes to the package graph module and related infrastructure. The package graph now only keeps the latest package versions in the graph when building it initially. If the graph needs to be extended, it will re-add the impacted package dependencies. This makes the graph much smaller, and also fixes some issues with 'orphaned' packages in the graph. 

In addition, there is a change in the PackageIdent versioning to add support for non-numeric versions. Mixing and matching numeric and non-numeric versions can be ambiguous when comparing versions so that is still not recommended. 

There are some other minor fixes and cleanups as well.

Signed-off-by: Salim Alam <salam@chef.io>

![giphy 28](https://cloud.githubusercontent.com/assets/13542112/25732103/fd4ec5e2-3100-11e7-974c-eb04ac0831d0.gif)
