### PR TITLE
Fix start command for builder/eventsrv plans

### DIFF
--- a/components/builder-admin/habitat/plan.sh
+++ b/components/builder-admin/habitat/plan.sh
@@ -15,4 +15,4 @@ pkg_binds=(
   [router]="port"
 )
 pkg_exposes=(port)
-pkg_svc_run="$bin start -c ${pkg_svc_path}/config/config.toml"
+pkg_svc_run="$bin start -c ${pkg_svc_config_path}/config.toml"

--- a/components/builder-api/habitat/plan.sh
+++ b/components/builder-api/habitat/plan.sh
@@ -16,7 +16,7 @@ pkg_binds=(
   [router]="port"
 )
 bin="bldr-api"
-pkg_svc_run="$bin start -c ${pkg_svc_path}/config.toml"
+pkg_svc_run="$bin start -c ${pkg_svc_config_path}/config.toml"
 
 do_prepare() {
   rm -Rdf $HAB_CACHE_SRC_PATH/ui-$pkg_name-$pkg_version

--- a/components/builder-jobsrv/habitat/plan.sh
+++ b/components/builder-jobsrv/habitat/plan.sh
@@ -18,4 +18,4 @@ pkg_binds=(
   [datastore]="port"
 )
 bin="bldr-job-srv"
-pkg_svc_run="$bin start -c ${pkg_svc_path}/config.toml"
+pkg_svc_run="$bin start -c ${pkg_svc_config_path}/config.toml"

--- a/components/builder-originsrv/habitat/plan.sh
+++ b/components/builder-originsrv/habitat/plan.sh
@@ -12,4 +12,4 @@ pkg_binds=(
   [datastore]="port"
 )
 bin="bldr-origin-srv"
-pkg_svc_run="$bin start -c ${pkg_svc_path}/config.toml"
+pkg_svc_run="$bin start -c ${pkg_svc_config_path}/config.toml"

--- a/components/builder-router/habitat/plan.sh
+++ b/components/builder-router/habitat/plan.sh
@@ -13,4 +13,4 @@ pkg_exports=(
 )
 pkg_exposes=(port heartbeat)
 bin="bldr-router"
-pkg_svc_run="$bin start -c ${pkg_svc_path}/config.toml"
+pkg_svc_run="$bin start -c ${pkg_svc_config_path}/config.toml"

--- a/components/builder-scheduler/habitat/plan.sh
+++ b/components/builder-scheduler/habitat/plan.sh
@@ -8,4 +8,4 @@ pkg_deps=(core/glibc core/openssl core/gcc-libs core/zeromq core/libsodium core/
 pkg_build_deps=(core/protobuf core/protobuf-rust core/coreutils core/cacerts
   core/rust core/gcc core/git core/pkg-config)
 bin="bldr-scheduler"
-pkg_svc_run="$bin start -c ${pkg_svc_path}/config.toml"
+pkg_svc_run="$bin start -c ${pkg_svc_config_path}/config.toml"

--- a/components/builder-sessionsrv/habitat/plan.sh
+++ b/components/builder-sessionsrv/habitat/plan.sh
@@ -12,4 +12,4 @@ pkg_binds=(
   [datastore]="port"
 )
 bin="bldr-session-srv"
-pkg_svc_run="$bin start -c ${pkg_svc_path}/config.toml"
+pkg_svc_run="$bin start -c ${pkg_svc_config_path}/config.toml"

--- a/components/builder-worker/habitat/plan.sh
+++ b/components/builder-worker/habitat/plan.sh
@@ -9,7 +9,7 @@ pkg_deps=(core/glibc core/openssl core/gcc-libs core/zeromq core/libsodium core/
 pkg_build_deps=(core/make core/cmake core/protobuf core/protobuf-rust core/coreutils core/cacerts
   core/rust core/gcc core/git core/pkg-config)
 bin="bldr-worker"
-pkg_svc_run="$bin start -c ${pkg_svc_path}/config.toml"
+pkg_svc_run="$bin start -c ${pkg_svc_config_path}/config.toml"
 pkg_svc_user="root"
 pkg_svc_group="root"
 pkg_binds=(

--- a/components/eventsrv/habitat/plan.sh
+++ b/components/eventsrv/habitat/plan.sh
@@ -12,4 +12,4 @@ pkg_exports=(
 )
 pkg_exposes=(consumer_port producer_port)
 bin="eventsrv"
-pkg_svc_run="$bin ${pkg_svc_path}/config.toml"
+pkg_svc_run="$bin ${pkg_svc_config_path}/config.toml"


### PR DESCRIPTION
We now read from the proper `config.toml` for every builder service
and the eventsrv. Prior to this change we were attempting to read
the raw `config.toml` generated by the supervisor.

![tenor-134204989](https://cloud.githubusercontent.com/assets/54036/25733294/742f40aa-310c-11e7-9064-9e5f98adfca8.gif)
