### PR TITLE
[plan-build] Introduce `do_before()` & `do_after()` build phases.

### DIFF
--- a/www/source/docs/reference/plan-syntax.html.md
+++ b/www/source/docs/reference/plan-syntax.html.md
@@ -288,7 +288,10 @@ When defining your plan, you have the flexibility to override the default behavi
 These callbacks are listed in the order that they are called by the package build script.
 
 do_begin()
-: There is no default implementation of this callback. You can use it to execute any arbitrary commands before anything else happens.
+: There is an empty default implementation of this callback. You can use it to execute any arbitrary commands before anything else happens. Note that at this phase of the build, no dependencies are resolved, the `$PATH` and environment is not set, and no external source has been downloaded. For a phase that is more completely set up, see the `do_before()` phase.
+
+do_before()
+: There is an empty default implementation of this callback. At this phase, the origin key has been checked for, all package dependencies have been resolved and downloaded, and the `$PATH` and environment are set.
 
 do_download()
 : The default implementation is that the software specified in $pkg_source is downloaded, checksum-verified, and placed in *$HAB_CACHE_SRC_PATH/$pkg_filename*, which resolves to a path like `/hab/cache/src/filename.tar.gz`. You should override this behavior if you need to change how your binary source is downloaded, if you are not downloading any source code at all, or if you are cloning from git. If you do clone a repo from git, you must override **do_verify()** to return 0.
@@ -318,8 +321,11 @@ do_install()
 do_strip()
 : The default implementation is to strip any binaries in $pkg_prefix of their debugging symbols. You should override this behavior if you want to change how the binaries are stripped, which additional binaries located in subdirectories might also need to be stripped, or whether you do not want the binaries stripped at all.
 
+do_after()
+: There is an empty default implementation of this callback. At this phase, the package has been built, installed, stripped, but before the package metadata is written and the artifact is created and signed.
+
 do_end()
-: There is no default implementation of this callback. This is called after the package has been built and installed. You can use this callback to remove any temporary files or perform other post-install clean-up actions.
+: There is an empty default implementation of this callback. This is called after the package artifact has been created. You can use this callback to remove any temporary files or perform other post-build clean-up actions.
 
 
 ***


### PR DESCRIPTION
This change introduces 2 new build phases to the public build API:

* `do_before()` (with an empty `do_default_before()` implementation)
* `do_after()` (with an empty `do_default_after()` implementation)

After inspecting more Plans in the wild, it has become apparent that
there is a missing build phase which Plan authors would have used rather
than hooking into the `do_download()` phase to perform tasks like
dynamically calculating a new `$pkg_version` value, etc.

The `do_begin()` phase is often far too early in the build process to
perform many tasks as package dependencies are not yet loaded, the
`$PATH` is not yet set, and other build environment variables are not
yet present. The first publicly supported phase in which to perform
such tasks is `do_download()` which occurs directly after resolving
dependencies and setting up the build environment.

Rather than allowing this "hacked" pattern to continue unfettered, an
additional build phase is introduced **before** the downloading,
building, installing is started.

In an attempt to properly "bookend" the `do_before()` build phase, a
`do_after()` build phase is added after the `do_strip()` build phase. At
this point in the build, the package has been built, installed, and
stripped, but before the package metadata is written and before the
artifact is created and signed. This is a mirror to `do_begin()`
(extremely early) and `do_end()` (extremely late).

Future work may optionally exploit the `do_before()` phase by allowing a
documented location to recompute the `$pkg_version` value.

![gif-keyboard-9918045239862007893](https://cloud.githubusercontent.com/assets/261548/25733416/fd6cbc9a-3115-11e7-9fb6-c29edc442c60.gif)
