### PR TITLE
[plan-build] Add optional helper to dynamically compute pkg_version.

### DIFF
--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -1910,6 +1910,67 @@ pkg_interpreter_for() {
     return 1
 }
 
+# Updates the value of `$pkg_version` and recomputes any relevant variables.
+# This function must be called before the `do_prepare()` build phase otherwise
+# it will fail the build process.
+#
+# This function depends on the Plan author implementing a `pkg_version()`
+# function which prints a computed version string on standard output. Then,
+# this function must be explicitly called in an appropriate build phase--most
+# likely `do_before()`. For example:
+#
+# ```sh
+# pkg_origin=acme
+# pkg_name=myapp
+#
+# pkg_version() {
+#   cat "$SRC_PATH/version.txt"
+# }
+#
+# do_before() {
+#   do_default_before
+#   update_pkg_version
+# }
+# ```
+update_pkg_version() {
+  local update_src_path
+
+  if [[ "${_verify_vars:-}" == true ]]; then
+    local e
+    e="Plan called 'update_pkg_version()' in phase 'do_prepare()' or later"
+    e="$e which is not supported. Package version must be determined before"
+    e="$e 'do_prepare()' phase."
+    exit_with "$e" 21
+  fi
+
+  if [[ "$(type -t pkg_version)" == "function" ]]; then
+    pkg_version="$(pkg_version)"
+    build_line "Version updated to '$pkg_version'"
+  else
+    debug "pkg_version() function not found, retaining pkg_version=$pkg_version"
+  fi
+
+  # `$pkg_dirname` needs to be recomputed, unless it was explicitly set by the
+  # Plan author.
+  if [[ "${_pkg_dirname_initially_unset:-}" == true ]]; then
+    pkg_dirname="${pkg_name}-${pkg_version}"
+  fi
+  pkg_prefix=$HAB_PKG_PATH/${pkg_origin}/${pkg_name}/${pkg_version}/${pkg_release}
+  pkg_artifact="$HAB_CACHE_ARTIFACT_PATH/${pkg_origin}-${pkg_name}-${pkg_version}-${pkg_release}-${pkg_target}.${_artifact_ext}"
+  # If the `$CACHE_PATH` and `$SRC_PATH` are the same, then we are building
+  # third party software using `$pkg_source` and
+  # downloading/verifying/unpacking it.
+  if [[ "$CACHE_PATH" == "$SRC_PATH" ]]; then
+    update_src_path=true
+  fi
+  CACHE_PATH="$HAB_CACHE_SRC_PATH/$pkg_dirname"
+  # Only update `$SRC_PATH` if we are building third party software using
+  # `$pkg_source`.
+  if [[ "${update_src_path:-}" == true ]]; then
+    SRC_PATH="$CACHE_PATH"
+  fi
+}
+
 # ## Build Phases
 #
 # Stub build phases, in the order they are executed. These can be overridden by
@@ -2285,6 +2346,19 @@ _fix_libtool() {
     build_line "Fixing libtool script $file"
     sed -i -e 's^eval sys_lib_.*search_path=.*^^' "$file"
   done
+}
+
+# **Internal** Verifies that any lazily-computed, required variables have been
+# set, otherwise it fails the build.
+_verify_vars() {
+  if [[ "${pkg_version:-}" == "__pkg__version__unset__" ]]; then
+    local e
+    e="Plan did not set 'pkg_version' and did not call 'update_pkg_version()'"
+    e="$e before the 'do_prepare()' build phase."
+    exit_with "$e" 2
+  fi
+
+  _verify_vars=true
 }
 
 # This function simply makes sure that the working directory for the prepare
@@ -2925,7 +2999,6 @@ build_line "Validating plan metadata"
 required_variables=(
   pkg_name
   pkg_origin
-  pkg_version
 )
 for var in "${required_variables[@]}"
 do
@@ -2948,6 +3021,14 @@ if [[ -n "${pkg_svc_run+xxx}" ]]; then
   pkg_svc_run="$(echo $pkg_svc_run | sed "s|@__pkg_name__@|$pkg_name|g")"
 fi
 
+if [[ -z "${pkg_version:-}" && "$(type -t pkg_version)" == "function" ]]; then
+  pkg_version="__pkg__version__unset__"
+elif [[ -z "${pkg_version:-}" ]]; then
+  e="Failed to build. 'pkg_version' must be set or 'pkg_version()' function"
+  e="$e must be implemented and then invoking by calling 'update_pkg_version()'."
+  exit_with "$e" 1
+fi
+
 # If `$pkg_source` is used, default `$pkg_filename` to the basename of
 # `$pkg_source` if it is not already set by the Plan.
 if [[ -n "${pkg_source:-}" && -z "${pkg_filename+xxx}" ]]; then
@@ -2958,6 +3039,7 @@ fi
 # already set by the Plan.
 if [[ -z "${pkg_dirname+xxx}" ]]; then
   pkg_dirname="${pkg_name}-${pkg_version}"
+  _pkg_dirname_initially_unset=true
 fi
 
 # Set `$pkg_prefix` if not already set by the Plan.
@@ -3032,6 +3114,9 @@ _build_environment
 
 # Fix any libtool scripts in the source
 _fix_libtool
+
+# Make sure all required variables are set
+_verify_vars
 
 # Prepare the source
 do_prepare_wrapper

--- a/www/source/docs/reference/plan-syntax.html.md
+++ b/www/source/docs/reference/plan-syntax.html.md
@@ -288,7 +288,10 @@ When defining your plan, you have the flexibility to override the default behavi
 These callbacks are listed in the order that they are called by the package build script.
 
 do_begin()
-: There is no default implementation of this callback. You can use it to execute any arbitrary commands before anything else happens.
+: There is an empty default implementation of this callback. You can use it to execute any arbitrary commands before anything else happens. Note that at this phase of the build, no dependencies are resolved, the `$PATH` and environment is not set, and no external source has been downloaded. For a phase that is more completely set up, see the `do_before()` phase.
+
+do_before()
+: There is an empty default implementation of this callback. At this phase, the origin key has been checked for, all package dependencies have been resolved and downloaded, and the `$PATH` and environment are set.
 
 do_download()
 : The default implementation is that the software specified in $pkg_source is downloaded, checksum-verified, and placed in *$HAB_CACHE_SRC_PATH/$pkg_filename*, which resolves to a path like `/hab/cache/src/filename.tar.gz`. You should override this behavior if you need to change how your binary source is downloaded, if you are not downloading any source code at all, or if you are cloning from git. If you do clone a repo from git, you must override **do_verify()** to return 0.
@@ -318,8 +321,11 @@ do_install()
 do_strip()
 : The default implementation is to strip any binaries in $pkg_prefix of their debugging symbols. You should override this behavior if you want to change how the binaries are stripped, which additional binaries located in subdirectories might also need to be stripped, or whether you do not want the binaries stripped at all.
 
+do_after()
+: There is an empty default implementation of this callback. At this phase, the package has been built, installed, stripped, but before the package metadata is written and the artifact is created and signed.
+
 do_end()
-: There is no default implementation of this callback. This is called after the package has been built and installed. You can use this callback to remove any temporary files or perform other post-install clean-up actions.
+: There is an empty default implementation of this callback. This is called after the package artifact has been created. You can use this callback to remove any temporary files or perform other post-build clean-up actions.
 
 
 ***

--- a/www/source/docs/reference/plan-syntax.html.md
+++ b/www/source/docs/reference/plan-syntax.html.md
@@ -35,7 +35,7 @@ pkg_origin
   ~~~
 
 pkg_version
-: Required. Sets the version of the package.
+: Optional (Required unless `pkg_version()` function is defined). Sets the version of the package.
 
   ~~~
   pkg_version=1.2.8
@@ -58,13 +58,11 @@ pkg_license
 > Note: If your package has a custom license, use a string literal matching the title of the license. For example, you'll see `pkg_license=('Boost Software License')` for the `cmake` plan.
 
 pkg_source
-: Required. A URL that specifies where to download the source from. Any valid `wget` url will work. Typically, the relative path for the URL is partially constructed from the `pkg_name` and `pkg_version` values; however, this convention is not required.
+: Optional. A URL that specifies where to download an external source from. Any valid `wget` url will work. Typically, the relative path for the URL is partially constructed from the `pkg_name` and `pkg_version` values; however, this convention is not required.
 
   ~~~
   pkg_source=http://downloads.sourceforge.net/project/libpng/$pkg_name/${pkg_version}/${pkg_name}-${pkg_version}.tar.gz
   ~~~
-
-> Note: If your package does not require downloading any source code, you must enter a non-empty string for the value and override callbacks for **do_download()** and **do_unpack()**. See [Plan callbacks](#plan-callbacks) for more information.
 
 pkg_filename
 : Optional. The resulting filename for the download, typically constructed from the `pkg_name` and `pkg_version` values.
@@ -608,6 +606,12 @@ pkg_interpreter_for()
   ~~~
 
   This function will return 0 if the specified package and interpreter were found, and 1 if the package could not be found or the interpreter is not specified for that package.
+
+pkg_version()
+: An optional way to determine the value for `$pkg_version`. The function must print the computed version string to standard output and will be called when the Plan author invokes the `update_pkg_version()` helper.
+
+update_pkg_version()
+: Updates the value for `$pkg_version` by calling a Plan author-provided `pkg_version()` function. This function must be explicitly called in a Plan in or after the `do_before()` build phase but before the `do_prepare()` build phase. The `$pkg_version` variable will be updated and any other relevant variables will be recomputed.
 
 abspath()
 : Return the absolute path for a path, which might be absolute or relative.


### PR DESCRIPTION
(Note: this builds on #2234, which should be merged first)

This change adds an alternative way to determine the version of a Plan
when building a package. In seeing more Plans in the wild, it has become
clear that some Plan authors wish to determine the package version by
cat'ing a common version file, using a Git command, or by some other
means which is dynamic.

There are 2 challenges to computing a package version:

* how the version is computed
* when the version should be computed

To implement the "how", a Plan author needs to write a `pkg_version()`
function that prints the version string to standard output. The Plan
author then explicitly calls the new `update_pkg_version()` helper in a
build phase to determine the "when".

The `update_pkg_version()` can be called in the `do_before()` build
phase all the way up to but not including the `do_prepare()` build
phase, after which it is too late to safely recompute the other build
variables that depend on `$pkg_version`. If `update_pkg_version()` is
called too late, the build program will fail the build with an error
message.

Due to this new optional strategy, a Plan author can omit defining a
`pkg_version` variable, as long as they write a `pkg_version()`
function. This is checked for by the build program so that if the Plan
author omits the `pkg_version` variable and the `pkg_version()`
function, the build will fail.

Examples
--------

The following are partial Plan implementations with extra build phases
omitted for brevity.

This is a Plan which cats a static file in the source root of the
project to determine the version which can be safely determined in the
`do_before()` phase:

```
pkg_origin=acme
pkg_name=myapp

pkg_version() {
  cat "$SRC_PATH/version.txt"
}

do_before() {
  do_default_before
  update_pkg_version
}
```

Here is the same Plan which uses a Git command to compute the number of
commits in the repository as the version. Note that since we are using
the `git` command, we are adding the `core/git` package as a build
dependency:

```
pkg_origin=acme
pkg_name=myapp
pkg_build_deps=(core/git)

pkg_version() {
  git rev-list master --count
}

do_before() {
  do_default_before
  update_pkg_version
}
```

Finally, here is a partial implementation of a `cacerts` Plan which
greps a date (YYYY.mm.dd) from the CA certs file itself. The
`pkg_version()` function does some grep'ing and sed'ing before using the
date program to format the final version string to standard output. As
the downloaded file is required before running the version logic, the
`update_pkg_version()` helper is called in the `do_download()` build
phase:

```
pkg_origin=me
pkg_name=cacerts
pkg_source=http://curl.haxx.se/ca/cacert.pem

pkg_version() {
  local build_date

  # Extract the build date of the certificates file
  build_date=$(cat $HAB_CACHE_SRC_PATH/$pkg_filename \
    | grep 'Certificate data from Mozilla' \
    | sed 's/^## Certificate data from Mozilla as of: //')

  date --date="$build_date" "+%Y.%m.%d"
}

do_download() {
  do_default_download
  update_pkg_version
}

 # ...
```

Closes #2212 

![gif-keyboard-7704575195338198960](https://cloud.githubusercontent.com/assets/261548/25734451/32acbf86-3120-11e7-8195-d28cbd8803ff.gif)
