### PR TITLE
Fix travis deploy for PRs redux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -216,12 +216,23 @@ matrix:
           - /root/travis_bootstrap
           - /hab/studios/home--travis--build--habitat-sh
           - /root/.cargo
-      before_install:
+      script:
         - ./support/ci/fast_pass.sh || exit 0
+      before_deploy:
         - if [[ ! -x ./support/ci/deploy.sh ]]; then chmod +x ./support/ci/deploy.sh; fi
         - openssl aes-256-cbc -K $encrypted_50e90ce07941_key -iv $encrypted_50e90ce07941_iv -in ./support/ci/habitat-srv-admin.enc -out /tmp/habitat-srv-admin -d
-      script:
-        - sudo ./support/ci/deploy.sh
+      deploy:
+        # This is split into two because tags overrides branch setting
+        - provider: script
+          script:
+            - sudo ./support/ci/deploy.sh
+          on:
+            branch: master
+        - provider: script
+          script:
+            - sudo ./support/ci/deploy.sh
+          on:
+            tags: true
 notifications:
   webhooks:
     urls:


### PR DESCRIPTION
This is an updated version of the original changes in PR #2020. This fixes the issue with tagged builds not calling `deploy.sh`.

These changes were throughly tested in my [travis-prs](https://github.com/georgemarshall/travis-prs) repo and the results can be seen on the accompanying [Travis CI project](https://travis-ci.org/georgemarshall/travis-prs)

@mwrock 