### PR TITLE
Setup environment before determining version in plan build

### DIFF
--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -3090,13 +3090,13 @@ _determine_hab_bin
 
 _resolve_dependencies
 
-# Set up runtime environment
-_set_environment
-
 mkdir -pv "$HAB_CACHE_SRC_PATH"
 
-# Run any code after the environment is set but before the build starts
+# Run any code before environment is set and the build starts
 do_before
+
+# Set up runtime environment
+_set_environment
 
 # Download the source
 do_download


### PR DESCRIPTION
The changes in #2234 and #2235 are awesome but it looks like we've got a small issue. The `_set_environment` should probably run prior to determining the value for `pkg_version`. It uses that variable in itself and it populates metadata, including the PATH metafile, which includes that in it's path. Here's a sample of output:

![screen shot 2017-05-05 at 1 26 54 am](https://cloud.githubusercontent.com/assets/54036/25738425/f80f9f62-3131-11e7-9d8e-6434d973a056.png)

I'm going to merge this one in for now to get us unblocked. @fnichol please feel free to make any additional changes if you think we should load some of the parts before and some after, etc