### PR TITLE
Add some new CNAMEs

### DIFF
--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -6,6 +6,30 @@ resource "aws_route53_record" "app" {
   records = ["${aws_elb.builder_api.dns_name}"]
 }
 
+resource "aws_route53_record" "build" {
+  zone_id = "${var.dns_zone_id}"
+  name    = "build-${var.env}"
+  type    = "CNAME"
+  ttl     = "300"
+  records = ["${aws_elb.builder_api.dns_name}"]
+}
+
+resource "aws_route53_record" "builder" {
+  zone_id = "${var.dns_zone_id}"
+  name    = "builder-${var.env}"
+  type    = "CNAME"
+  ttl     = "300"
+  records = ["${aws_elb.builder_api.dns_name}"]
+}
+
+resource "aws_route53_record" "depot" {
+  zone_id = "${var.dns_zone_id}"
+  name    = "depot-${var.env}"
+  type    = "CNAME"
+  ttl     = "300"
+  records = ["${aws_elb.builder_api.dns_name}"]
+}
+
 resource "aws_route53_record" "willem" {
   zone_id = "${var.dns_zone_id}"
   name    = "willem-${var.env}"


### PR DESCRIPTION
This adds support for build.habitat.sh, builder.habitat.sh and depot.habitat.sh.

![](http://i.giphy.com/SRx5tBBrTQOBi.gif)

Covers #2195, though additional work may need to be done (either here or elsewhere) to handle the redirection portion of that issue. (I did a little digging, and I'm not sure how that'd be done with our current setup.)

(This is mostly me asking, "Hey, is this right?" If not, feel free to comment and/or close.)

Signed-off-by: Christian Nunciato <chris@nunciato.org>