### PR TITLE
Add `leader` and `update_leader` fields to svc in rendering context

### DIFF
--- a/components/sup/src/templating/context.rs
+++ b/components/sup/src/templating/context.rs
@@ -87,6 +87,8 @@ pub struct Svc<'a> {
     pub update_election_finished: bool,
     pub me: SvcMember<'a>,
     pub members: Vec<SvcMember<'a>>,
+    pub leader: Option<SvcMember<'a>>,
+    pub update_leader: Option<SvcMember<'a>>,
 }
 
 impl<'a> Svc<'a> {
@@ -108,6 +110,8 @@ impl<'a> Svc<'a> {
                 .iter()
                 .map(|m| SvcMember(m))
                 .collect(),
+            leader: census_group.leader().map(|m| SvcMember(m)),
+            update_leader: census_group.update_leader().map(|m| SvcMember(m)),
         }
     }
 }

--- a/components/sup/src/templating/context.rs
+++ b/components/sup/src/templating/context.rs
@@ -79,12 +79,12 @@ impl<'a> RenderContext<'a> {
 #[derive(Clone, Debug, Serialize)]
 pub struct Svc<'a> {
     pub group: &'a ServiceGroup,
-    pub election_running: bool,
-    pub election_no_quorum: bool,
-    pub election_finished: bool,
-    pub update_election_running: bool,
-    pub update_election_no_quorum: bool,
-    pub update_election_finished: bool,
+    pub election_is_running: bool,
+    pub election_is_no_quorum: bool,
+    pub election_is_finished: bool,
+    pub update_election_is_running: bool,
+    pub update_election_is_no_quorum: bool,
+    pub update_election_is_finished: bool,
     pub me: SvcMember<'a>,
     pub members: Vec<SvcMember<'a>>,
     pub leader: Option<SvcMember<'a>>,
@@ -95,15 +95,15 @@ impl<'a> Svc<'a> {
     fn new(census_group: &'a CensusGroup) -> Self {
         Svc {
             group: &census_group.service_group,
-            election_running: census_group.election_status == ElectionStatus::ElectionInProgress,
-            election_no_quorum: census_group.election_status == ElectionStatus::ElectionNoQuorum,
-            election_finished: census_group.election_status == ElectionStatus::ElectionFinished,
-            update_election_running: census_group.election_status ==
-                                     ElectionStatus::ElectionInProgress,
-            update_election_no_quorum: census_group.election_status ==
-                                       ElectionStatus::ElectionNoQuorum,
-            update_election_finished: census_group.election_status ==
-                                      ElectionStatus::ElectionFinished,
+            election_is_running: census_group.election_status == ElectionStatus::ElectionInProgress,
+            election_is_no_quorum: census_group.election_status == ElectionStatus::ElectionNoQuorum,
+            election_is_finished: census_group.election_status == ElectionStatus::ElectionFinished,
+            update_election_is_running: census_group.election_status ==
+                                        ElectionStatus::ElectionInProgress,
+            update_election_is_no_quorum: census_group.election_status ==
+                                          ElectionStatus::ElectionNoQuorum,
+            update_election_is_finished: census_group.election_status ==
+                                         ElectionStatus::ElectionFinished,
             me: SvcMember(census_group.me().expect("Missing 'me'")),
             members: census_group
                 .members()

--- a/www/source/docs/create-packages-configure.html.md
+++ b/www/source/docs/create-packages-configure.html.md
@@ -93,9 +93,7 @@ When writing your template, you can use the `with` helper to reduce duplication:
 Helpers can also be nested and used together in block expressions. Here is another example from the redis.config file where the `if` and `with` helpers are used together to set up `core/redis` Habitat services  in a leader-follower topology.
 
     {{#if svc.me.follower}}
-      {{#with svc.leader}}
-      slaveof {{sys.ip}} {{cfg.port}}
-      {{/with}}
+      slaveof {{svc.leader.sys.ip}} {{svc.leader.cfg.port}}
     {/if}}
 
 Here's an example using `each` to render multiple server entries:

--- a/www/source/docs/run-packages-topologies.html.md
+++ b/www/source/docs/run-packages-topologies.html.md
@@ -31,9 +31,7 @@ Once you have quorum, one member is elected a leader, the supervisors in the ser
 Because Habitat provides for automation that is built into the application package, this includes letting the application developer define the application's behavior when run under different topologies, even from the same immutable package. Here is an example of a configuration template marked up with conditional logic that will cause the running application to behave differently based on whether it is a leader or a follower:
 
        {{#if svc.me.follower}}
-       {{#with svc.leader}}
-       slaveof {{sys.ip}} {{cfg.port}}
-       {{/with}}
+       slaveof {{svc.leader.sys.ip}} {{svc.leader.cfg.port}}
        {{/if}}
 
 This logic says that if this peer is a follower, it will become a read replica of the IP and port of service leader (`svc.leader`), which is has found by service discovery through the ring. However, if this peer is the leader, the entire list of statements here evaluate to empty text -- meaning that the peer starts up as the leader.


### PR DESCRIPTION
I accidentally omitted `svc.leader` and `svc.update_leader` fields from the top level `svc` portion of the rendering context. This adds them back and updates some docs on how to leverage them.

Fixes #2248