### PR TITLE
Added API docs to be served on sup :9631/

### DIFF
--- a/components/sup/Cargo.toml
+++ b/components/sup/Cargo.toml
@@ -2,7 +2,7 @@
 name = "habitat_sup"
 version = "0.0.0"
 authors = ["Adam Jacob <adam@chef.io>", "Jamie Winsor <reset@chef.io>", "Fletcher Nichol <fnichol@chef.io>", "Joshua Timberman <joshua@chef.io>", "Dave Parfitt <dparfitt@chef.io>"]
-build = "../build.rs"
+build = "./build.rs"
 workspace = "../../"
 
 [lib]
@@ -57,3 +57,4 @@ hyper = "*"
 
 [features]
 functional = []
+apidocs =[]

--- a/components/sup/build.rs
+++ b/components/sup/build.rs
@@ -1,0 +1,53 @@
+use std::env;
+use std::fs::File;
+use std::io::BufReader;
+use std::io::prelude::*;
+use std::path::Path;
+use std::process::Command;
+
+fn main() {
+    let version = match env::var("PLAN_VERSION") {
+        Ok(ver) => ver,
+        _ => read_version(),
+    };
+    generate_apidocs();
+    let mut f = File::create(Path::new(&env::var("OUT_DIR").unwrap()).join("VERSION")).unwrap();
+    f.write_all(version.trim().as_bytes()).unwrap();
+}
+
+fn generate_apidocs() {
+    let dst = Path::new(&env::var("OUT_DIR").unwrap()).join("api.html");
+    match env::var("CARGO_FEATURE_APIDOCS") {
+   	Ok(_) => {
+    	    let src = Path::new(&env::var("CARGO_MANIFEST_DIR").unwrap()).join("doc/api.raml");
+    	    let cmd = Command::new("raml2html")
+		.arg("-i")
+		.arg(src)
+		.arg("-o")
+		.arg(dst)
+		.status()
+		.expect("failed to compile html from raml");
+
+    	   assert!(cmd.success());
+	}
+	Err(_) => {
+	   let mut file = File::create(dst).unwrap();
+	   file.write_all(b"No API docs provided at build").unwrap();
+	}
+    };
+    
+}
+
+fn read_version() -> String {
+    let ver_file = Path::new(&env::var("CARGO_MANIFEST_DIR").unwrap())
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .join("VERSION");
+    let f = File::open(ver_file).unwrap();
+    let mut reader = BufReader::new(f);
+    let mut ver = String::new();
+    reader.read_line(&mut ver).unwrap();
+    ver
+}

--- a/components/sup/doc/api.raml
+++ b/components/sup/doc/api.raml
@@ -1,4 +1,4 @@
-#%RAML 0.8
+#%RAML 1.0
 ---
 title: Habitat Supervisor API
 

--- a/components/sup/plan.sh
+++ b/components/sup/plan.sh
@@ -4,12 +4,11 @@ pkg_origin=core
 pkg_version=$(cat "$PLAN_CONTEXT/../../VERSION")
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
-pkg_source=nosuchfile.tar.gz
 pkg_deps=(
   core/busybox-static
   core/glibc core/gcc-libs core/libarchive core/libsodium core/openssl core/zeromq
 )
-pkg_build_deps=(core/coreutils core/cacerts core/rust core/gcc core/protobuf)
+pkg_build_deps=(core/coreutils core/cacerts core/rust core/gcc core/protobuf core/raml2html)
 pkg_bin_dirs=(bin)
 
 bin=$_pkg_distname
@@ -52,7 +51,7 @@ do_prepare() {
 do_build() {
   export LIBRARY_PATH=$LIBZMQ_PREFIX/lib
   pushd $PLAN_CONTEXT > /dev/null
-  cargo build ${build_type#--debug} --target=$rustc_target --verbose
+  cargo build ${build_type#--debug} --target=$rustc_target --verbose --features apidocs
   popd > /dev/null
 }
 
@@ -65,17 +64,4 @@ do_strip() {
   if [[ "$build_type" != "--debug" ]]; then
     do_default_strip
   fi
-}
-
-# Turn the remaining default phases into no-ops
-do_download() {
-  return 0
-}
-
-do_verify() {
-  return 0
-}
-
-do_unpack() {
-  return 0
 }

--- a/components/sup/src/http_gateway.rs
+++ b/components/sup/src/http_gateway.rs
@@ -32,7 +32,6 @@ use persistent;
 use prometheus::{self, CounterVec, HistogramVec, TextEncoder, Encoder};
 use router::Router;
 use serde_json;
-
 use error::{Result, Error, SupError};
 use fs;
 use manager;
@@ -40,6 +39,7 @@ use manager::service::HealthCheck;
 use manager::service::hooks::{self, HealthCheckHook};
 
 static LOGKEY: &'static str = "HG";
+const APIDOCS: &'static str = include_str!(concat!(env!("OUT_DIR"), "/api.html"));
 
 // Simple macro to encapsulate the HTTP metrics for each endpoint
 macro_rules! with_metrics {
@@ -143,6 +143,7 @@ pub struct Server(Iron<Chain>, ListenAddr);
 impl Server {
     pub fn new(manager_state: Arc<manager::FsCfg>, listen_addr: ListenAddr) -> Self {
         let router = router!(
+            doc: get "/" => with_metrics!(doc, "doc"),
             butterfly: get "/butterfly" => with_metrics!(butterfly, "butterfly"),
             census: get "/census" => with_metrics!(census, "census"),
             metrics: get "/metrics" => with_metrics!(metrics, "metrics"),
@@ -171,6 +172,7 @@ impl Server {
                                              .http(*self.1)
                                              .expect("unable to start http-gateway thread");
                                      }));
+
         Ok(handle)
     }
 }
@@ -250,6 +252,10 @@ fn services(req: &mut Request) -> IronResult<Response> {
         Ok(file) => Ok(Response::with((status::Ok, Header(headers::ContentType::json()), file))),
         Err(_) => Ok(Response::with(status::ServiceUnavailable)),
     }
+}
+
+fn doc(_req: &mut Request) -> IronResult<Response> {
+   Ok(Response::with((status::Ok, Header(headers::ContentType::html()), APIDOCS)))
 }
 
 fn metrics(_req: &mut Request) -> IronResult<Response> {


### PR DESCRIPTION
WAIT TO MERGE
Until we get the raml2html habitat package made. Once that is completed (hopefully in a few minutes) this should compile our RAML docs to HTML and serve them up as part of the binary when you attempt to hit the :9631/

This should keep users from having to hit habitat.sh/docs when they forget the REST endpoints for the supervisor.

Signed-off-by: eeyun <ihenry@chef.io>