### PR TITLE
Pipe optional binds through to RenderContext

### DIFF
--- a/components/sup/src/templating/context.rs
+++ b/components/sup/src/templating/context.rs
@@ -24,7 +24,9 @@ use manager::service::{Cfg, Pkg, ServiceBind};
 pub struct Binds<'a>(HashMap<String, BindGroup<'a>>);
 
 impl<'a> Binds<'a> {
-    fn new(bindings: &[ServiceBind], census: &'a CensusRing) -> Self {
+    fn new<T>(bindings: T, census: &'a CensusRing) -> Self
+        where T: Iterator<Item = &'a ServiceBind>
+    {
         let mut map = HashMap::default();
         for bind in bindings {
             if let Some(group) = census.census_group_for(&bind.service_group) {
@@ -60,13 +62,15 @@ pub struct RenderContext<'a> {
 }
 
 impl<'a> RenderContext<'a> {
-    pub fn new(service_group: &ServiceGroup,
-               sys: &'a Sys,
-               pkg: &'a Pkg,
-               cfg: &'a Cfg,
-               census: &'a CensusRing,
-               bindings: &[ServiceBind])
-               -> RenderContext<'a> {
+    pub fn new<T>(service_group: &ServiceGroup,
+                  sys: &'a Sys,
+                  pkg: &'a Pkg,
+                  cfg: &'a Cfg,
+                  census: &'a CensusRing,
+                  bindings: T)
+                  -> RenderContext<'a>
+        where T: Iterator<Item = &'a ServiceBind>
+    {
         let census_group = census
             .census_group_for(&service_group)
             .expect("Census Group missing from list!");


### PR DESCRIPTION
It doesn't appear that optional binds are populated in the RenderContext which means they never get rendered into our templates. Let's make sure this is all hooked up!