### PR TITLE
do not use annotaded tags to fix appveyor deployments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,7 +177,7 @@ docs: image ## build the docs
 		echo "<meta http-equiv=refresh content=0;url=habitat_sup/index.html>" > target/doc/index.html;'
 
 tag-release:
-	sh -c 'git tag -a $(VERSION) -m \"$(VERSION)\"'
+	sh -c 'git tag $(VERSION)'
 
 define BUILD
 build-$1: image ## builds the $1 component


### PR DESCRIPTION
For the past few releases, the initial tag push has not been triggering an appveyor deploy. I've had to delete the tag and re push. Those subsequent tag pushes always work. I did not make the connection at first, but a key difference between the first and subsequent tags is that the first was annotated, created by our makefile. In this release, I made sure that the first push was not annotated and appveyor picked it up.

This strikes me as odd but gets us over a hurdle. I'll follow up with appveyor to see if I can find out more.

Signed-off-by: Matt Wrock <matt@mattwrock.com>