### PR TITLE
cancel deployment for PRs before accessing secure variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -218,6 +218,7 @@ matrix:
           - /root/.cargo
       before_install:
         - ./support/ci/fast_pass.sh || exit 0
+        - ./support/ci/only_master_or_release.sh || exit 0
         - if [[ ! -x ./support/ci/deploy.sh ]]; then chmod +x ./support/ci/deploy.sh; fi
         - openssl aes-256-cbc -K $encrypted_50e90ce07941_key -iv $encrypted_50e90ce07941_iv -in ./support/ci/habitat-srv-admin.enc -out /tmp/habitat-srv-admin -d
       script:

--- a/support/ci/only_master_or_release.sh
+++ b/support/ci/only_master_or_release.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+#
+# fail fast if we aren't on the desired branch or if this is a pull request
+
+if  [[ "${TRAVIS_BRANCH}" != "$(cat VERSION)" && ("${TRAVIS_PULL_REQUEST}" != "false" || "${TRAVIS_BRANCH}" != "master") ]]; then
+    echo "We only deploy on successful builds of master or release builds."
+    exit 1
+fi


### PR DESCRIPTION
This was my thought for tackling the problem we have where calling `openssl aes-256-cbc` with encrypted variables in the travis.yml fails on PRs from forks. This adds a script to check for branch/tag conditions prior to accessing those variables.

cc @georgemarshall 

Signed-off-by: Matt Wrock <matt@mattwrock.com>