### PR TITLE
Disable password prompt in builder init hooks

### DIFF
--- a/components/builder-jobsrv/habitat/hooks/init
+++ b/components/builder-jobsrv/habitat/hooks/init
@@ -3,6 +3,6 @@ set -e
 
 PGPASSWORD={{cfg.datastore.password}}
 
-if [ $(psql -l -U hab -h {{bind.datastore.first.sys.ip}} | grep {{cfg.datastore.database}} | wc -l) -eq 0 ]; then
-  createdb -h {{bind.datastore.first.sys.ip}} -p {{bind.datastore.first.cfg.port}} -U hab {{cfg.datastore.database}}
+if [ $(psql -lw -U hab -h {{bind.datastore.first.sys.ip}} | grep {{cfg.datastore.database}} | wc -l) -eq 0 ]; then
+  createdb -w -h {{bind.datastore.first.sys.ip}} -p {{bind.datastore.first.cfg.port}} -U hab {{cfg.datastore.database}}
 fi

--- a/components/builder-originsrv/habitat/hooks/init
+++ b/components/builder-originsrv/habitat/hooks/init
@@ -3,6 +3,6 @@ set -e
 
 PGPASSWORD={{cfg.datastore.password}}
 
-if [ $(psql -l -U hab -h {{bind.datastore.first.sys.ip}} | grep {{cfg.datastore.database}} | wc -l) -eq 0 ]; then
-  createdb -h {{bind.datastore.first.sys.ip}} -p {{bind.datastore.first.cfg.port}} -U hab {{cfg.datastore.database}}
+if [ $(psql -lw -U hab -h {{bind.datastore.first.sys.ip}} | grep {{cfg.datastore.database}} | wc -l) -eq 0 ]; then
+  createdb -w -h {{bind.datastore.first.sys.ip}} -p {{bind.datastore.first.cfg.port}} -U hab {{cfg.datastore.database}}
 fi

--- a/components/builder-scheduler/habitat/hooks/init
+++ b/components/builder-scheduler/habitat/hooks/init
@@ -3,6 +3,6 @@ set -e
 
 PGPASSWORD={{cfg.datastore.password}}
 
-if [ $(psql -l -U hab -h {{bind.datastore.first.sys.ip}} | grep {{cfg.datastore.database}} | wc -l) -eq 0 ]; then
-  createdb -h {{bind.datastore.first.sys.ip}} -p {{bind.datastore.first.cfg.port}} -U hab {{cfg.datastore.database}}
+if [ $(psql -lw -U hab -h {{bind.datastore.first.sys.ip}} | grep {{cfg.datastore.database}} | wc -l) -eq 0 ]; then
+  createdb -w -h {{bind.datastore.first.sys.ip}} -p {{bind.datastore.first.cfg.port}} -U hab {{cfg.datastore.database}}
 fi

--- a/components/builder-sessionsrv/habitat/hooks/init
+++ b/components/builder-sessionsrv/habitat/hooks/init
@@ -3,6 +3,6 @@ set -e
 
 PGPASSWORD={{cfg.datastore.password}}
 
-if [ $(psql -l -U hab -h {{bind.datastore.first.sys.ip}} | grep {{cfg.datastore.database}} | wc -l) -eq 0 ]; then
-  createdb -h {{bind.datastore.first.sys.ip}} -p {{bind.datastore.first.cfg.port}} -U hab {{cfg.datastore.database}}
+if [ $(psql -lw -U hab -h {{bind.datastore.first.sys.ip}} | grep {{cfg.datastore.database}} | wc -l) -eq 0 ]; then
+  createdb -w -h {{bind.datastore.first.sys.ip}} -p {{bind.datastore.first.cfg.port}} -U hab {{cfg.datastore.database}}
 fi


### PR DESCRIPTION
If PGPASSWORD was null because a value for the password had not been
provided, then one of the init hooks for a service connecting to
postgresql could indefinitely hang. This change will ensure that a
password prompt doesn't interrupt execution regardless of the state
of the PGPASSWORD env var

![tenor-181620148](https://cloud.githubusercontent.com/assets/54036/25879123/9f5872ca-34e4-11e7-9a77-bddf6e8902c5.gif)
