### PR TITLE
[sup] Support optional package bind validation.

### DIFF
--- a/components/sup/src/error.rs
+++ b/components/sup/src/error.rs
@@ -118,6 +118,7 @@ pub enum Error {
     TemplateFileError(handlebars::TemplateFileError),
     TemplateRenderError(handlebars::RenderError),
     InvalidBinding(String),
+    InvalidBinds(Vec<String>),
     InvalidKeyParameter(String),
     InvalidPidFile,
     InvalidTopology(String),
@@ -198,6 +199,7 @@ impl fmt::Display for SupError {
                          <NAME> is a service name and <SERVICE_GROUP> is a valid service group",
                         binding)
             }
+            Error::InvalidBinds(ref e) => format!("Invalid bind(s), {}", e.join(", ")),
             Error::InvalidKeyParameter(ref e) => {
                 format!("Invalid parameter for key generation: {:?}", e)
             }
@@ -306,6 +308,7 @@ impl error::Error for SupError {
             Error::EnvJoinPathsError(ref err) => err.description(),
             Error::FileNotFound(_) => "File not found",
             Error::InvalidBinding(_) => "Invalid binding parameter",
+            Error::InvalidBinds(_) => "Service binds detected that are neither required nor optional package binds",
             Error::InvalidKeyParameter(_) => "Key parameter error",
             Error::InvalidPidFile => "Invalid child process PID file",
             Error::InvalidTopology(_) => "Invalid topology",


### PR DESCRIPTION
This change fixes a bug in the sense that until now, the optional
package binds would not be properly validated on service loading in the
Supervisor. Additionally, any bind provided that is not a required or
optional package bind will now correctly cause an error.

Example
-------

For this example, we have a Plan with 2 required binds (`alpha` &
`charlie`) and 1 optional bind (`echo`). The `plan.sh` is as follows:

```sh
pkg_origin=core
pkg_name=bindabind
pkg_version=0.1.0

pkg_binds=(
  [alpha]="beta"
  [charlie]="delta"
)

pkg_binds_optional=(
  [echo]="foxtrot"
)

do_build() {
  return 0
}

do_install() {
  return 0
}
```

When we start the Supervisor without any `--bind` options, we see that
it fails reporting the 2 missing required binds `alpha` & `charlie`:

```
> hab-sup start core/bindabind
hab-sup(MR): Supervisor Member-ID 7aaaf7f7a8cb474ca8f135223553f209
hab-sup(MR): Starting core/bindabind
hab-sup(MR): Unable to start core/bindabind, hab-sup(SS)[src/manager/service/spec.rs:183:23]: Missing required bind(s), alpha, charlie
hab-sup(MR): Starting gossip-listener on 0.0.0.0:9638
hab-sup(MR): Starting http-gateway on 0.0.0.0:9631
```

If we provide 1 of the 2 required binds, it still fails:

```
> hab-sup start core/bindabind --bind alpha:alpha.default
hab-sup(MR): Supervisor Member-ID 7aaaf7f7a8cb474ca8f135223553f209
hab-sup(MR): Starting core/bindabind
hab-sup(MR): Unable to start core/bindabind, hab-sup(SS)[src/manager/service/spec.rs:183:23]: Missing required bind(s), charlie
hab-sup(MR): Starting gossip-listener on 0.0.0.0:9638
hab-sup(MR): Starting http-gateway on 0.0.0.0:9631
```

Finally, if we satisfy both the required binds, the bind requirements
are satisfied and the service starts waiting for the service groups to
exist and be satisfied:

```
> hab-sup start core/bindabind --bind alpha:alpha.default --bind charlie:charline.default
hab-sup(MR): Supervisor Member-ID 7aaaf7f7a8cb474ca8f135223553f209
hab-sup(MR): Starting core/bindabind
hab-sup(MR): Starting gossip-listener on 0.0.0.0:9638
hab-sup(MR): Starting http-gateway on 0.0.0.0:9631
bindabind.default(SR): The specified service group 'alpha.default' for binding 'alpha' is not (yet?) present in the census data.
bindabind.default(SR): The specified service group 'charline.default' for binding 'charlie' is not (yet?) present in the census data.
bindabind.default(SR): Waiting for service binds...
```

We can also provide the optional bind `echo` which will be looked for as
well in the ring:

```
> hab-sup start core/bindabind --bind alpha:alpha.default --bind charlie:charline.default --bind echo:echo.default
hab-sup(MR): Supervisor Member-ID e9977e2475df429d97ccdea8009ef857
hab-sup(MR): Starting core/bindabind
hab-sup(MR): Starting gossip-listener on 0.0.0.0:9638
hab-sup(MR): Starting http-gateway on 0.0.0.0:9631
bindabind.default(SR): The specified service group 'alpha.default' for binding 'alpha' is not (yet?) present in the census data.
bindabind.default(SR): The specified service group 'charline.default' for binding 'charlie' is not (yet?) present in the census data.
bindabind.default(SR): The specified service group 'echo.default' for binding 'echo' is not (yet?) present in the census data.
bindabind.default(SR): Waiting for service binds...
```

If we provide both required binds and provide an additional bind that is
not a required or optional package bind name, we get an error:

```
> hab-sup start core/bindabind --bind alpha:alpha.default --bind charlie:charline.default --bind nope:nope.default
hab-sup(MR): Supervisor Member-ID 54bbc826adaa4dcca6a0ae2f5a7673f4
hab-sup(MR): Starting core/bindabind
hab-sup(MR): Unable to start core/bindabind, hab-sup(SS)[src/manager/service/spec.rs:195:23]: Invalid bind(s), nope
hab-sup(MR): Starting gossip-listener on 0.0.0.0:9638
hab-sup(MR): Starting http-gateway on 0.0.0.0:9631
```

We can trigger the previous failure even when providing an optional
bind:

```
> hab-sup start core/bindabind --bind alpha:alpha.default --bind charlie:charline.default --bind echo:echo.default --bind nope:nope.default
hab-sup(MR): Supervisor Member-ID 4bd7c5acc54a46228f8e6d5cd84a22d1
hab-sup(MR): Starting core/bindabind
hab-sup(MR): Unable to start core/bindabind, hab-sup(SS)[src/manager/service/spec.rs:195:23]: Invalid bind(s), nope
hab-sup(MR): Starting gossip-listener on 0.0.0.0:9638
hab-sup(MR): Starting http-gateway on 0.0.0.0:9631
```

References #2284

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>