### PR TITLE
Remove leader / follower bit in CensusMember on every ElectionRumor

### DIFF
--- a/components/sup/src/census.rs
+++ b/components/sup/src/census.rs
@@ -549,7 +549,9 @@ impl CensusMember {
         if self.election_is_finished {
             if self.member_id == election.get_member_id() {
                 self.leader = true;
+                self.follower = false;
             } else {
+                self.leader = false;
                 self.follower = true;
             }
         }
@@ -563,7 +565,9 @@ impl CensusMember {
         if self.update_election_is_finished {
             if self.member_id == election.get_member_id() {
                 self.update_leader = true;
+                self.update_follower = false;
             } else {
+                self.update_leader = false;
                 self.update_follower = true;
             }
         }


### PR DESCRIPTION
Currently it is possible for multiple `CensusMembers` to have `leader = true`.