### PR TITLE
Point to proper static directory in builder-proxy configs

### DIFF
--- a/components/builder-admin-proxy/config/nginx.conf
+++ b/components/builder-admin-proxy/config/nginx.conf
@@ -65,7 +65,7 @@ http {
     index index.html;
     listen       *:{{cfg.http.listen_port}};
     server_name  {{sys.hostname}};
-    root {{pkg.svc_static_path}};
+    root /hab/svc/builder-admin/static;
 
     if ($http_x_forwarded_proto = "http") {
       rewrite ^(.*)$ https://$host$1 permanent;

--- a/components/builder-api-proxy/config/nginx.conf
+++ b/components/builder-api-proxy/config/nginx.conf
@@ -66,7 +66,7 @@ http {
     index index.html;
     listen       *:{{cfg.http.listen_port}};
     server_name  {{sys.hostname}};
-    root {{pkg.svc_static_path}};
+    root /hab/svc/builder-api/static;
 
     if ($http_x_forwarded_proto = "http") {
       rewrite ^(.*)$ https://$host$1 permanent;


### PR DESCRIPTION
![tenor-200702050](https://cloud.githubusercontent.com/assets/54036/25920586/4f9ddc54-3587-11e7-8700-29349b0399f7.gif)
