### PR TITLE
Change JobSrv log-ingestion to 5568 from 5569

### DIFF
--- a/components/builder-jobsrv/habitat/default.toml
+++ b/components/builder-jobsrv/habitat/default.toml
@@ -7,7 +7,7 @@ worker_heartbeat_listen = "0.0.0.0"
 worker_heartbeat_port = 5567
 publisher_listen = "0.0.0.0"
 log_ingestion_listen = "0.0.0.0"
-log_ingestion_port = 5569
+log_ingestion_port = 5568
 
 [datastore]
 user = "hab"

--- a/components/builder-jobsrv/src/config.rs
+++ b/components/builder-jobsrv/src/config.rs
@@ -123,7 +123,7 @@ impl Default for NetCfg {
             worker_heartbeat_listen: IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
             worker_heartbeat_port: 5567,
             log_ingestion_listen: IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
-            log_ingestion_port: 5569,
+            log_ingestion_port: 5568,
         }
     }
 }

--- a/components/builder-worker/src/config.rs
+++ b/components/builder-worker/src/config.rs
@@ -75,7 +75,7 @@ impl Default for JobSrvAddr {
             host: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
             port: 5566,
             heartbeat: 5567,
-            log_port: 5569
+            log_port: 5568
         }
     }
 }

--- a/terraform/security-groups.tf
+++ b/terraform/security-groups.tf
@@ -101,7 +101,7 @@ resource "aws_security_group" "jobsrv" {
 
   ingress {
     from_port = 5566
-    to_port   = 5567
+    to_port   = 5568
     protocol  = "tcp"
 
     security_groups = [


### PR DESCRIPTION
This is a small modification to change the log-ingestion port from
5569 to 5568 which will ensure that all of the JobSrv ports are
contiguous. It is easier to represent a contiguous block of ports
in tools like Terraform than a set with a gap.

* Update JobSrv Habitat plan
* Increase port range in Terraform module

From @chefsalim's [code review](https://github.com/habitat-sh/habitat/pull/2301#discussion_r115859267)

/cc @christophermaier 