### PR TITLE
Various plan fixes for builder-admin, builder-api, and builder-sessionsrv

### DIFF
--- a/components/builder-admin/habitat/config/config.toml
+++ b/components/builder-admin/habitat/config/config.toml
@@ -1,7 +1,11 @@
 [ui]
 root = "{{pkg.svc_static_path}}"
 
-{{toToml cfg}}
+[http]
+{{toToml cfg.http}}
+
+[github]
+{{toToml cfg.github}}
 
 {{~#eachAlive bind.router.members as |member|}}
 [[router]]

--- a/components/builder-admin/habitat/default.toml
+++ b/components/builder-admin/habitat/default.toml
@@ -4,5 +4,5 @@ port = 8080
 
 [github]
 url = "https://api.github.com"
-client_id = "0c2f738a7d0bd300de10"
-client_secret = "438223113eeb6e7edf2d2f91a232b72de72b9bdf"
+client_id = ""
+client_secret = ""

--- a/components/builder-api/habitat/config/config.toml
+++ b/components/builder-api/habitat/config/config.toml
@@ -5,8 +5,10 @@ root = "{{pkg.svc_static_path}}"
 
 [http]
 {{toToml cfg.http}}
+
 [web]
 {{toToml cfg.web}}
+
 [github]
 {{toToml cfg.github}}
 

--- a/components/builder-api/habitat/default.toml
+++ b/components/builder-api/habitat/default.toml
@@ -4,8 +4,8 @@ port = 9636
 
 [github]
 url = "https://api.github.com"
-client_id = "0c2f738a7d0bd300de10"
-client_secret = "438223113eeb6e7edf2d2f91a232b72de72b9bdf"
+client_id = ""
+client_secret = ""
 
 [web]
 app_url          = "https://willem.habitat.sh/v1"

--- a/components/builder-sessionsrv/habitat/config/config.toml
+++ b/components/builder-sessionsrv/habitat/config/config.toml
@@ -1,4 +1,10 @@
+github_admin_team = {{cfg.github_admin_team}}
+github_builder_teams = {{cfg.github_builder_teams}}
+github_build_worker_teams = {{cfg.github_build_worker_teams}}
 shards = {{toToml cfg.shards}}
+
+[github]
+{{toToml cfg.github}}
 
 {{~#eachAlive bind.router.members as |member|}}
 [[router]]

--- a/components/builder-sessionsrv/habitat/default.toml
+++ b/components/builder-sessionsrv/habitat/default.toml
@@ -12,5 +12,5 @@ connection_timeout_sec = 3600
 
 [github]
 url = "https://api.github.com"
-client_id = "0c2f738a7d0bd300de10"
-client_secret = "438223113eeb6e7edf2d2f91a232b72de72b9bdf"
+client_id = ""
+client_secret = ""


### PR DESCRIPTION
* Write GitHub config section to admin and sessionsrv plans
* Write http config section to admin plan
* Remove dev github credentials from `default.toml` of sessionsrv, api,
  and admin plans. This should make it more clear that these settings
  haven't been configured and you almost certainly never want to use
  the dev settings when installing from a Habitat package

![tenor-143641386](https://cloud.githubusercontent.com/assets/54036/25924125/fb0d9cb0-3595-11e7-9402-3cad8d89775d.gif)
