### PR TITLE
fix updated package template rendering

### DIFF
--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -626,8 +626,10 @@ impl Manager {
                 .write()
                 .expect("Services lock is poisoned!")
                 .iter_mut() {
-            self.updater
-                .check_for_updated_package(service, &self.census_ring);
+            if self.updater
+                   .check_for_updated_package(service, &self.census_ring) {
+                self.gossip_latest_service_rumor(&service);
+            }
         }
     }
 

--- a/components/sup/src/manager/service/mod.rs
+++ b/components/sup/src/manager/service/mod.rs
@@ -385,7 +385,11 @@ impl Service {
     /// Replace the package of the running service and restart it's system process.
     pub fn update_package(&mut self, package: PackageInstall) {
         match Pkg::from_install(package) {
-            Ok(pkg) => self.pkg = pkg,
+            Ok(pkg) => {
+                let hooks_root = Self::hooks_root(&pkg, self.config_from.as_ref());
+                self.hooks = HookTable::load(&self.service_group, &hooks_root);
+                self.pkg = pkg;
+            }
             Err(err) => {
                 outputln!(preamble self.service_group,
                           "Unexpected error while updating package, {}", err);


### PR DESCRIPTION
This fixes a regression in package updating where an updated package's templates are not recompiled.

This came down to two bugs:

1. We stopped gossiping on package update and as a result, a recompile was not triggered. @reset and I had discussed this in the refactor and I believe there was the thought that the service tick would update the templates and that would trigger the update rumor to be gossiped. However, the templates are only updated if the census ring has changed. So this adds back the gossip on update.

2. Even with the above fixed and recompile actually running, we are recompiling against the old hook path. So this adds a `Hooktable::load` to the `update_package` function.

Signed-off-by: Matt Wrock <matt@mattwrock.com>