### PR TITLE
builder service plan bug fixes

### DIFF
--- a/components/builder-admin/habitat/config/config.toml
+++ b/components/builder-admin/habitat/config/config.toml
@@ -8,7 +8,7 @@ root = "{{pkg.svc_static_path}}"
 {{toToml cfg.github}}
 
 {{~#eachAlive bind.router.members as |member|}}
-[[router]]
+[[routers]]
 host = "{{member.sys.ip}}"
 port = {{member.cfg.port}}
 {{~/eachAlive}}

--- a/components/builder-api/habitat/config/config.toml
+++ b/components/builder-api/habitat/config/config.toml
@@ -13,7 +13,7 @@ root = "{{pkg.svc_static_path}}"
 {{toToml cfg.github}}
 
 {{~#eachAlive bind.router.members as |member|}}
-[[router]]
+[[routers]]
 host = "{{member.sys.ip}}"
 port = {{member.cfg.port}}
 {{~/eachAlive}}

--- a/components/builder-api/habitat/default.toml
+++ b/components/builder-api/habitat/default.toml
@@ -19,5 +19,5 @@ www_url          = "https://www.habitat.sh"
 
 [depot]
 insecure = false
-builds_enabled = false
+builds_enabled = true
 events_enabled = false

--- a/components/builder-jobsrv/habitat/config/config.toml
+++ b/components/builder-jobsrv/habitat/config/config.toml
@@ -1,7 +1,7 @@
 shards = {{toToml cfg.shards}}
 
 {{~#eachAlive bind.router.members as |member|}}
-[[router]]
+[[routers]]
 host = "{{member.sys.ip}}"
 port = {{member.cfg.port}}
 heartbeat = {{member.cfg.heartbeat}}

--- a/components/builder-originsrv/habitat/config/config.toml
+++ b/components/builder-originsrv/habitat/config/config.toml
@@ -1,7 +1,7 @@
 shards = {{toToml cfg.shards}}
 
 {{~#eachAlive bind.router.members as |member|}}
-[[router]]
+[[routers]]
 host = "{{member.sys.ip}}"
 port = {{member.cfg.port}}
 heartbeat = {{member.cfg.heartbeat}}

--- a/components/builder-scheduler/habitat/config/config.toml
+++ b/components/builder-scheduler/habitat/config/config.toml
@@ -3,7 +3,7 @@ shards = [
 ]
 
 {{~#eachAlive bind.router.members as |member|}}
-[[router]]
+[[routers]]
 host = "{{member.sys.ip}}"
 port = {{member.cfg.port}}
 heartbeat = {{member.cfg.heartbeat}}

--- a/components/builder-sessionsrv/habitat/config/config.toml
+++ b/components/builder-sessionsrv/habitat/config/config.toml
@@ -7,7 +7,7 @@ shards = {{toToml cfg.shards}}
 {{toToml cfg.github}}
 
 {{~#eachAlive bind.router.members as |member|}}
-[[router]]
+[[routers]]
 host = "{{member.sys.ip}}"
 port = {{member.cfg.port}}
 heartbeat = {{member.cfg.heartbeat}}

--- a/terraform/templates/hab-sup.service
+++ b/terraform/templates/hab-sup.service
@@ -2,6 +2,7 @@
 Description=Habitat Supervisor
 
 [Service]
+ExecStartPre=/bin/bash -c "/bin/systemctl set-environment SSL_CERT_FILE=$(hab pkg path core/cacerts)/ssl/cert.pem"
 ExecStart=/bin/hab sup run --peer ${peer_ip}:${gossip_listen_port} ${flags}
 
 [Install]


### PR DESCRIPTION
* Set a more sensible default value for enabling builds in api config
* Fix issue in plans where routers would not be properly configured
* Ensure SSL_CERT env var is set before running supervisor. This is a
  workaround for now, we really need to address this

![tenor-253658283](https://cloud.githubusercontent.com/assets/54036/25927613/e392f2f4-35ab-11e7-9b71-2423b2656001.gif)
