### PR TITLE
Add back async start to jobsrv

### DIFF
--- a/components/builder-jobsrv/src/server/mod.rs
+++ b/components/builder-jobsrv/src/server/mod.rs
@@ -180,6 +180,9 @@ impl Application for Server {
             ds
         };
 
+        // Start the background sync
+        datastore.start_async();
+
         let ds2 = datastore.clone();
         let ingester_datastore = datastore.clone();
 


### PR DESCRIPTION
The background thread to sync job server status to the scheduler inadvertently got removed - adding it back in. 

Signed-off-by: Salim Alam <salam@chef.io>