### PR TITLE
configurable update strategy frequency and better update messaging

### DIFF
--- a/components/sup/src/manager/service/mod.rs
+++ b/components/sup/src/manager/service/mod.rs
@@ -386,6 +386,8 @@ impl Service {
     pub fn update_package(&mut self, package: PackageInstall) {
         match Pkg::from_install(package) {
             Ok(pkg) => {
+                outputln!(preamble self.service_group,
+                            "Updating service {} to {}", self.pkg.ident, pkg.ident);
                 match CfgRenderer::new(&Self::config_root(&pkg, self.config_from.as_ref())) {
                     Ok(renderer) => self.config_renderer = renderer,
                     Err(e) => {

--- a/www/source/docs/reference/environment-vars.html.md
+++ b/www/source/docs/reference/environment-vars.html.md
@@ -21,6 +21,7 @@ This is a list of all environment variables that can be used to modify the opera
 | `HAB_RING_KEY` | supervisor | no default | The name of the ring key when running with [wire encryption](/docs/run-packages-security/#wire-encryption) |
 | `HAB_STUDIOS_HOME` | build system | `/hab/studios` if running as root; `$HOME/.hab/studios` if running as non-root | Directory in which to create build studios |
 | `HAB_STUDIO_ROOT` | build system | no default | Root of the current studio under `$HAB_STUDIOS_HOME`. Infrequently overridden. |
+| `HAB_UPDATE_STRATEGY_FREQUENCY_MS` | supervisor | 60000 | Frequency of milliseconds to check for updates when running with an [update strategy](/docs/run-packages-update-strategy) |
 | `HAB_USER` | supervisor | no default | User key to use when running with [service group encryption](/docs/run-packages-security/#service-group-encryption) |
 | `http_proxy` | build system, supervisor | no default | A URL for a local HTTP proxy server optionally supporting basic authentication |
 | `https_proxy` | build system, supervisor | no default | A URL for a local HTTPS proxy server optionally supporting basic authentication |


### PR DESCRIPTION
This fixes #2316 and also makes some small improvements to update output. The messages emitted when an update worker dies may raise a red flag in the mind of an observer when none is warranted. A dying update worker is a healthy milestone of the updater lifecycle. This is now a debug mrssage to protect those sensitive to death. This also clearly states the old and new release versions.

Signed-off-by: Matt Wrock <matt@mattwrock.com>