### PR TITLE
Handle failed acceptance of origin invites

### DIFF
--- a/components/builder-web/app/BuilderApiClient.spec.ts
+++ b/components/builder-web/app/BuilderApiClient.spec.ts
@@ -1,0 +1,51 @@
+import { BuilderApiClient } from "./BuilderApiClient";
+
+describe("BuilderApiClient", () => {
+
+  describe("acceptOriginInvitation", () => {
+
+    describe("on success", () => {
+      let myObj;
+
+      beforeEach(() => {
+        myObj = { myCallback: () => {} };
+        spyOn(myObj, "myCallback");
+        spyOn(window, "fetch").and.callFake(() => {
+          return Promise.resolve({ ok: true });
+        });
+      });
+
+      it("resolves true", (done) => {
+        new BuilderApiClient("mytoken")
+          .acceptOriginInvitation("123", "myorigin")
+          .then(myObj.myCallback)
+          .then(() => {
+            expect(myObj.myCallback).toHaveBeenCalledWith(true);
+            done();
+          });
+      });
+    });
+
+    describe("on failure", () => {
+      let myObj;
+
+      beforeEach(() => {
+        myObj = { myCallback: () => {} };
+        spyOn(myObj, "myCallback");
+        spyOn(window, "fetch").and.callFake(() => {
+          return Promise.resolve({ ok: false });
+        });
+      });
+
+      it("resolves with an instance of Error", (done) => {
+        new BuilderApiClient("some-token")
+          .acceptOriginInvitation("123", "myorigin")
+          .catch(myObj.myCallback)
+          .then(() => {
+            expect(myObj.myCallback).toHaveBeenCalledWith(jasmine.any(Error));
+            done();
+          });
+      });
+    });
+  });
+});

--- a/components/builder-web/app/BuilderApiClient.ts
+++ b/components/builder-web/app/BuilderApiClient.ts
@@ -30,9 +30,15 @@ export class BuilderApiClient {
           fetch(`${this.urlPrefix}/depot/origins/${originName}/invitations/${invitationId}`, {
                 headers: this.headers,
                 method: "PUT",
-            }).then(response => {
-                resolve(true);
-            }).catch(error => reject(error));
+            })
+            .then(response => {
+                if (response.ok) {
+                    resolve(true);
+                } else {
+                    reject(new Error(response.statusText));
+                }
+            })
+            .catch(error => reject(error));
         });
     }
 


### PR DESCRIPTION
This change has us reject the promise when response status is other than OK (i.e., outside 200-299).

![](http://i.giphy.com/l2SpUoAPo0CBOkyxq.gif)

Signed-off-by: Christian Nunciato <cnunciato@chef.io>