### PR TITLE
Always config scheduler & jobsrv with all shards

### DIFF
--- a/components/builder-jobsrv/habitat/config/config.toml
+++ b/components/builder-jobsrv/habitat/config/config.toml
@@ -1,5 +1,3 @@
-shards = {{toToml cfg.shards}}
-
 {{~#eachAlive bind.router.members as |member|}}
 [[routers]]
 host = "{{member.sys.ip}}"

--- a/components/builder-jobsrv/habitat/default.toml
+++ b/components/builder-jobsrv/habitat/default.toml
@@ -1,5 +1,3 @@
-shards = []
-
 [net]
 worker_command_listen = "0.0.0.0"
 worker_command_port = 5566

--- a/components/builder-scheduler/habitat/config/config.toml
+++ b/components/builder-scheduler/habitat/config/config.toml
@@ -1,7 +1,3 @@
-shards = [
-  0
-]
-
 {{~#eachAlive bind.router.members as |member|}}
 [[routers]]
 host = "{{member.sys.ip}}"


### PR DESCRIPTION
ScheduleSrv and JobSrv always need to host all shards - they are a
singleton in our infrastructure. We have no way to represent a
non-sharded service in our server to router registration protocol
just yet, so just leaving the shard configuration alone will get
us where we need to be