### PR TITLE
Run mac build separately and in an isolated directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -195,11 +195,11 @@ matrix:
         - secure: "OCq9oDAEP3Cc0BiGrnZHE0FoNdyqsAy2LPTwEoOKvgiZdrw5o2bvpN1Kl+DKpw2auKtkeAS1aVSE/CMrglxrDs+VolvK9ttW3kj8c7+AeuCYjBsyWqdnZ1/24u6P+20fKanYrsMsnFb2r9OWwxZVlFnfmks81LWToOlGFJpL5KnmSPrB2vlWPbiaH9+yg8aslrmCq0reSoSVSnoZHoTolWtjzx2WdPYqA4gu0HHASVbH5qP+PoQSGIWvwbBaU4xhwkp1K8rWCjI8lre2YpBMOdfZv+9arMjc3Xg/kgD9oGU9DN7Q3UzAWxTSJv/3Cm4LArwiI57rXMLDKf8N1MhvGMHP1xgbuN8JWFKqFuWpqCf6qJkYG8+VZkruKYOo/2tXtBY4hpbR2abcWvYU/S9AQFHKGJQ2vcArnp5SKO+Oq/fNVneeHli4RbGMRQCMVq+X0SSC148F0zEVVwkNM5eq4askfc/2y4asySrH0MT/5T3yBp8fr3zXpnj82h2ytCZOUs0o+La9+wt5gSDUJHdY/BwSSPrgnKSp7ixslM/g7lMy3nAOs6qLql8/vW543CXBurCACWTqwKcy3/wRparTkmZcs1d7vUrbcfYv7XJzh0pw2P1hCjWD9BtkowbuLVo8K9ndPl2rbFY9XljqFXMTcHxp4ETeCc23azHCs+SYFb0="
         # HAB_ORIGIN_KEY
         - secure: "uZ70GE8qK3GBgs7ZIsoy5DhPlHNs2hoLxLBGKq+u+0XrE017pOnW6mNHsn7J7i2r8CPtd4KFsFEN52wZSA+Sf96MFIL2w9E+geykBgbRMZzv4icuCf0xSGwm4iRMgZ9A08TfurMX6y6N+4JNsrCv9syVNuGq09EL2wLHPXOQhesMpodijQLcFikxfEXXbaWla1xHnYxJk+fbvYDoXVCbdqnpdeLTmGuQHFaaNI7jm1B3L/dl+IGZxwFdvqBT3G9mHiXBdyi8bALs7rcZNdV7PqtFFpp98zIeqwNHtHPd5cBRmqDRTRxucRSACS/lurrz9J+001a9RjPvUkYlLrn0hQY9pN6oo+kCpN/1r0bc17i4FbGx7R73FnFgPK/cno0ENBFygNZn7/jg6cENgjkBlHsZhc1+L1xhILo46nQU9XbWJrwelVYUOOGXI76tECOkGhkglx1vYK8fcMVLJMhL7psgPpbGbDJQDuAKhHS+75txNK+356ompNL+YUzeWZc4KSGZCNTQsPK+rsGttmA+JXtAaquFaY5xwSgyKHwETiSVg4dYXb3xh6goNxf2JTOZOosWaypyykHqcqsqCu2fzIDdmkgCx6I5/5q8I/7Z0es0jlUpHamlihZwe4E5YdYFCSouaDoeTnVdJKVI1p9fnAjpFqjivFgqLE/Z504vCNU="
-        - BINTRAY_USER=smurawski
+        - BINTRAY_USER=mwrock
         # BINTRAY_KEY
-        - secure: "CHOiAfgFYbUBwYNIx7yJ7Y6697IzoX5zZtxHnByblU7Mei990vP+wUMjWrp2OY4I5UKdfSg5bkUtkEHBMUdoaiZZB+420dnZWPX94hQEYAGSdFzsgZlNZlu9vwnHout6+tDhylW0eIv7yMB1BViyOpeGxJ5rgCCmdDBEF5uWfnzuOMSeaOmcMQe24mzHY7vxIwfqJwEbVD08AOtJXVp2Kk0nLoA0GfJS1ZCcibK6TbXuZfUwYmF9jaZZdQj26UH8KtkiKYLy4Ti1c54XLwVahGeszBdi3xCAY6OWidAaTtnvEahtltXRl0HQCmhgLxpuZ/94lB4Mo4TqSf9NgZS7pqDB35YpYddy2hwW5HZFZlZoXgAqCTT+70NB0hoICpvNlvo4p7zRB7PVHbipgg64eA/OlLW+Bd4KXTHn+y+JrN1g9pDR9YF2lVewbmtzKbmxgQZYIrSK9SVZNP30DeN6uoedAxFFZGqgmPoC6Fcu5HG9Y1BY08HRVwRxLtLj8bciKgMHLNSKfVOdNlFac9nGn65aqenRGEmCd4wyjMZ7gd74V75aMdZozhFacDva0Qw5hRzhnJ8rYXBzG0juyodznMtVCARlRijPn0TW9LjYNb8+5f7LoxtywRmCNwYBB1OWghOePhWGMHBVAYTLzalIkX4WR0fc+xdhOq6lfAbgU4s="
+        - secure: "KjnlECRQiJ5wNVKHTVYBDmpT0RuZfCXPPvJmqL42Pgec8NZuII/uVJlp+YMFiTqkE1nCfbOHIn9/7XfHwMhigUofQkkojFyVaNhYsJ09PCo80cK60cVD38S8zcu8dOL0JN1iNhivr3FvCo9Q2w04o8eR0rYgHzXw/n7E1j8Hvedph9odKCUZKjTHneL6ENON4Wl5trtEdJLN+WxWst7s3Kjl5BKNcmGIrvstjBhSsuhpIGikW2OECKCAWKbYsDB87jUsr9kVuoppBfu5jkMHZIwxgEkHZWcpZwMJqciX/w13igkNYIxJChl0qTygI8xDEqk04wNpciCItoX8pvzEF1MC+F7gmNE+Ga9N/Dw0c2MGSIlrGlCvcHkwxaJuXj0wD8ZsJZD3I7M3uA7r+FmPh7n43GX4MHQxSDWNJhLupvS/4rT5j3fdw1AKoD6LAjAaT2R5OzDVY2qhONeT/B4a3tlMhfTRDxd+PjUY/jUE1kOLdctl+6rKCTHmNxUO6MWnMN1ZWfbZSitfAkrkinmJ0APzhphvYB1r59PDQoLqNOSZS8iEtq7S9xVx+YWzx7KaTZhorHmaXu0iYm6VnoGeupJnEZcpJC98deRGhiSBaiZflmVkyh5w9z/2hLMkM7zVDxBMN8GqZjizJtGTK96ZgNJYI7DryAoYIcGa6ZIEeds="
         # BINTRAY_PASSPHRASE
-        - secure: "XkZuLadu8aGACYdDN9QLUvuuGciiC8PahELGn2gfI8ILeIozzsWCclmNp2eKfduYsAu0otdps2dHAI1VwYH6+xGq+6byMMpXaXbQl3fahMe2vwaREpstmjbglWMNHcBqH4Bccx3aMxZjROO6NeT1U49uk7lKW+Enf+Dhw90L8sVP3v/xbmynYnue32heeQklkNH57RZ3uWJOUOPxOn5vcXsI0PqvJ8i53qIiUDQLivjLmOJUuudQiU/WP6rpewiIMoPO/REfyxq3gkCcYkzeXxytpVLEFwWjS6mvpLQbTJ+8/tp06sLXBxqknFboEWsqcraswROXi4ZXpubraFFNO/9jn9c1RaSmJqBEIQEK0/4K5VDYjukWMWpMQcwGq/I5dqUaDZJpoWPGqvw9b3zgsZNjlvLq2FEeuQEj2eD2Z4S5/PpgQRFhJMS+uMdPpingQMQAn9y83bZeDdtakWcX/IRjMBSF+UXCaXfTF9SWwURsCqakMEQhtZ+A3g5MAtZ6N/2QMsUcI7K56PjxXJiRSnZw821+VJgkpbk8Z8M2koZ6+Jy4jOGrUvDVGZ8umj3ipNmX8nFjP2s8jS7ihfIuG33p1fNw2397dEf0pDnPdsCnT/43c1RgTunpjla8486GirOApl/P8B0VXimwrquhkXxVItOYHX+O400UtC6C7MQ="
+        - secure: "jOhfYhQShwodrNuXwkh1PMiVBPgokP8Q+orBTampINoTJ/P4W6vNiXbc1VaAHhqxqvTebIiB2CkNICLSt/Fys9eO0d7DQREhhkvQIjhX9rFs3AYYop5HZ+m+uZYGfqSY1G298XaCA0IAGfl2EWp5VFM/+NENCFtdlUSDaVHekmWKgGbfzhmL7Ho+jRas4naIehDSUBJZfQ837DJ8Xeew2Ec3wPnbsU+NeE/Fv042QmOGsmEoKlUf9Ak/6jAc6sOQl+84UKB7xrIpA5BOHq3DA2td+vgFEByBfthvDsF6VexISARFk36M5OC4EtjjZ3hkJA47AlE1jdPlo1PbNOwoPhWLsfHbCqffg3VAmiY5horPZoyGuyFQsXq6DHhyiiYUAqSMuRYwEzpp3dl3g1lK1Y7akgqSqxrNcjgwmExwt9ncfTTC2jjN+nzLD3zAruuNpqHOnrK6xLG4JfvpC53o+LvmTjuUPEe2q7LgixjWid+Zk8AezfndtKVk0T+0JJk+XAmq/MQIHTKQOy1hJGFUkBEi8xM0hFw6+h/PXqhsuv0J2dwDuLhhXtvYExyTLJEo0qIUAPnnAFmBI/rR4KjSpv4I1A6cw8i1prrGOMQ+BK5xqXArixR6HUooq4KmWGoBf2E8tgJOJRYXBPrTFpL9/e5fy4+jNgUDcpFwlTKhXUM="
       sudo: required
       services:
         - docker
@@ -223,6 +223,33 @@ matrix:
         - openssl aes-256-cbc -K $encrypted_50e90ce07941_key -iv $encrypted_50e90ce07941_iv -in ./support/ci/habitat-srv-admin.enc -out /tmp/habitat-srv-admin -d
       script:
         - sudo ./support/ci/deploy.sh
+    - os: linux
+      env:
+        - COMPONENTS="sup hab-butterfly hab plan-build backline bintray-publish studio pkg-aci pkg-dockerize pkg-mesosize pkg-tarize"
+        - AFFECTED_DIRS="support/ci/deploy\.sh|Cargo\.toml|Cargo\.lock|components/hab|components/common|components/core|components/builder-depot-client|components/http-client|components/sup|components/hab-butterfly|components/butterfly|components/studio|VERSION"
+        # HAB_ORIGIN_KEY
+        - secure: "uZ70GE8qK3GBgs7ZIsoy5DhPlHNs2hoLxLBGKq+u+0XrE017pOnW6mNHsn7J7i2r8CPtd4KFsFEN52wZSA+Sf96MFIL2w9E+geykBgbRMZzv4icuCf0xSGwm4iRMgZ9A08TfurMX6y6N+4JNsrCv9syVNuGq09EL2wLHPXOQhesMpodijQLcFikxfEXXbaWla1xHnYxJk+fbvYDoXVCbdqnpdeLTmGuQHFaaNI7jm1B3L/dl+IGZxwFdvqBT3G9mHiXBdyi8bALs7rcZNdV7PqtFFpp98zIeqwNHtHPd5cBRmqDRTRxucRSACS/lurrz9J+001a9RjPvUkYlLrn0hQY9pN6oo+kCpN/1r0bc17i4FbGx7R73FnFgPK/cno0ENBFygNZn7/jg6cENgjkBlHsZhc1+L1xhILo46nQU9XbWJrwelVYUOOGXI76tECOkGhkglx1vYK8fcMVLJMhL7psgPpbGbDJQDuAKhHS+75txNK+356ompNL+YUzeWZc4KSGZCNTQsPK+rsGttmA+JXtAaquFaY5xwSgyKHwETiSVg4dYXb3xh6goNxf2JTOZOosWaypyykHqcqsqCu2fzIDdmkgCx6I5/5q8I/7Z0es0jlUpHamlihZwe4E5YdYFCSouaDoeTnVdJKVI1p9fnAjpFqjivFgqLE/Z504vCNU="
+        - BINTRAY_USER=mwrock
+        # BINTRAY_KEY
+        - secure: "KjnlECRQiJ5wNVKHTVYBDmpT0RuZfCXPPvJmqL42Pgec8NZuII/uVJlp+YMFiTqkE1nCfbOHIn9/7XfHwMhigUofQkkojFyVaNhYsJ09PCo80cK60cVD38S8zcu8dOL0JN1iNhivr3FvCo9Q2w04o8eR0rYgHzXw/n7E1j8Hvedph9odKCUZKjTHneL6ENON4Wl5trtEdJLN+WxWst7s3Kjl5BKNcmGIrvstjBhSsuhpIGikW2OECKCAWKbYsDB87jUsr9kVuoppBfu5jkMHZIwxgEkHZWcpZwMJqciX/w13igkNYIxJChl0qTygI8xDEqk04wNpciCItoX8pvzEF1MC+F7gmNE+Ga9N/Dw0c2MGSIlrGlCvcHkwxaJuXj0wD8ZsJZD3I7M3uA7r+FmPh7n43GX4MHQxSDWNJhLupvS/4rT5j3fdw1AKoD6LAjAaT2R5OzDVY2qhONeT/B4a3tlMhfTRDxd+PjUY/jUE1kOLdctl+6rKCTHmNxUO6MWnMN1ZWfbZSitfAkrkinmJ0APzhphvYB1r59PDQoLqNOSZS8iEtq7S9xVx+YWzx7KaTZhorHmaXu0iYm6VnoGeupJnEZcpJC98deRGhiSBaiZflmVkyh5w9z/2hLMkM7zVDxBMN8GqZjizJtGTK96ZgNJYI7DryAoYIcGa6ZIEeds="
+        # BINTRAY_PASSPHRASE
+        - secure: "jOhfYhQShwodrNuXwkh1PMiVBPgokP8Q+orBTampINoTJ/P4W6vNiXbc1VaAHhqxqvTebIiB2CkNICLSt/Fys9eO0d7DQREhhkvQIjhX9rFs3AYYop5HZ+m+uZYGfqSY1G298XaCA0IAGfl2EWp5VFM/+NENCFtdlUSDaVHekmWKgGbfzhmL7Ho+jRas4naIehDSUBJZfQ837DJ8Xeew2Ec3wPnbsU+NeE/Fv042QmOGsmEoKlUf9Ak/6jAc6sOQl+84UKB7xrIpA5BOHq3DA2td+vgFEByBfthvDsF6VexISARFk36M5OC4EtjjZ3hkJA47AlE1jdPlo1PbNOwoPhWLsfHbCqffg3VAmiY5horPZoyGuyFQsXq6DHhyiiYUAqSMuRYwEzpp3dl3g1lK1Y7akgqSqxrNcjgwmExwt9ncfTTC2jjN+nzLD3zAruuNpqHOnrK6xLG4JfvpC53o+LvmTjuUPEe2q7LgixjWid+Zk8AezfndtKVk0T+0JJk+XAmq/MQIHTKQOy1hJGFUkBEi8xM0hFw6+h/PXqhsuv0J2dwDuLhhXtvYExyTLJEo0qIUAPnnAFmBI/rR4KjSpv4I1A6cw8i1prrGOMQ+BK5xqXArixR6HUooq4KmWGoBf2E8tgJOJRYXBPrTFpL9/e5fy4+jNgUDcpFwlTKhXUM="
+      sudo: required
+      addons:
+        apt:
+          packages:
+          - ca-certificates
+      cache:
+        apt: true
+        directories:
+          - /root/travis_bootstrap
+      before_install:
+        - ./support/ci/fast_pass.sh || exit 0
+        - ./support/ci/only_master_or_release.sh || exit 0
+        - if [[ ! -x ./support/ci/deploy_mac_launcher.sh ]]; then chmod +x ./support/ci/deploy_mac_launcher.sh; fi
+        - openssl aes-256-cbc -K $encrypted_50e90ce07941_key -iv $encrypted_50e90ce07941_iv -in ./support/ci/habitat-srv-admin.enc -out /tmp/habitat-srv-admin -d
+      script:
+        - sudo ./support/ci/deploy_mac_launcher.sh
 notifications:
   webhooks:
     urls:

--- a/support/ci/deploy.sh
+++ b/support/ci/deploy.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 # fail fast if we aren't on the desired branch or if this is a pull request
 if  [[ "${TRAVIS_BRANCH}" != "$(cat VERSION)" && ("${TRAVIS_PULL_REQUEST}" != "false" || "${TRAVIS_BRANCH}" != "master") ]]; then
     echo "We only publish on successful builds of master."
@@ -25,37 +27,6 @@ mkdir -p ${BOOTSTRAP_DIR}
 wget -O hab.tar.gz "${HAB_DOWNLOAD_URL}"
 # install it in a custom location
 tar xvzf ./hab.tar.gz --strip 1 -C ${BOOTSTRAP_DIR}
-
-# kick off the mac unstable build
-echo "Kicking off the unstable mac build"
-var_file=/tmp/our-awesome-vars
-mac_builder=admin@74.80.245.236
-
-# first update the copy of the habitat code stored on the mac server to the latest
-ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-  -i /tmp/habitat-srv-admin ${mac_builder} \
-  "~/bin/update_habitat_code.sh"
-
-set -e
-
-# passing environment variables over ssh is a pain and never worked quite right.
-# instead, write this out to a file and scp it over, to source later.
-cat << EOF >${var_file}
-export BINTRAY_REPO=$BINTRAY_REPO
-export HAB_ORIGIN_KEY=$HAB_ORIGIN_KEY
-export BINTRAY_USER=$BINTRAY_USER
-export BINTRAY_KEY=$BINTRAY_KEY
-export BINTRAY_PASSPHRASE=$BINTRAY_PASSPHRASE
-EOF
-
-scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-  -i /tmp/habitat-srv-admin ${var_file} ${mac_builder}:~/tmp
-rm ${var_file}
-
-# kick off the build
-ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-  -i /tmp/habitat-srv-admin ${mac_builder} \
-  "sudo ~/code/habitat/support/ci/deploy_mac.sh"
 
 # so key stuff doesn't get funky
 unset SUDO_USER

--- a/support/ci/deploy_mac.sh
+++ b/support/ci/deploy_mac.sh
@@ -5,20 +5,11 @@
 # BINTRAY_PASSPHRASE
 # BINTRAY_KEY
 # BINTRAY_REPO
+# TRAVIS_BUILD_NUMBER
 
 set -eu
 
-hab_src_dir="$HOME/code/habitat"
-bootstrap_dir="$HOME/mac_unstable"
 var_file="$HOME/tmp/our-awesome-vars"
-mac_dir="${hab_src_dir}/components/hab/mac"
-mac_hab="${bootstrap_dir}/hab"
-gnu_tar=/usr/local/bin/tar
-hab_download_url="https://api.bintray.com/content/habitat/stable/darwin/x86_64/hab-%24latest-x86_64-darwin.zip?bt_package=hab-x86_64-darwin"
-our_path="$HOME/.cargo/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/bin:/usr/sbin:/sbin"
-export HAB_ORIGIN=core
-export PATH="${our_path}"
-
 if [[ -f ${var_file} ]]; then
   echo "Located the file with the magic environment variables."
   source ${var_file}
@@ -27,6 +18,21 @@ else
   echo "${var_file} does not appear to exist or at least not pass the -f test."
   echo "This script will likely abort shortly."
 fi
+
+hab_src_dir="$HOME/code/$TRAVIS_BUILD_NUMBER/habitat"
+function cleanup {
+  rm -rf "$hab_src_dir"
+}
+trap cleanup EXIT
+
+bootstrap_dir="$HOME/mac_unstable/$TRAVIS_BUILD_NUMBER"
+mac_dir="${hab_src_dir}/components/hab/mac"
+mac_hab="${bootstrap_dir}/hab"
+gnu_tar=/usr/local/bin/tar
+hab_download_url="https://api.bintray.com/content/habitat/stable/darwin/x86_64/hab-%24latest-x86_64-darwin.zip?bt_package=hab-x86_64-darwin"
+our_path="${HOME}/.cargo/bin:${PATH}"
+export HAB_ORIGIN=core
+export PATH="${our_path}"
 
 # start fresh
 rm -fr ${bootstrap_dir}

--- a/support/ci/deploy_mac_launcher.sh
+++ b/support/ci/deploy_mac_launcher.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+set -e
+
+# Current version being deployed
+version="$(cat VERSION)"
+# Address of the mac builder
+mac_builder=admin@74.80.245.236
+
+# fail fast if we aren't a merge to master or release tag
+if  [[ "${TRAVIS_BRANCH}" != $version && ("${TRAVIS_PULL_REQUEST}" = "true" || "${TRAVIS_BRANCH}" != "master") ]]; then
+    echo "We only publish on successful builds of master."
+    exit 0
+fi
+
+BINTRAY_REPO=unstable
+if [ $version == "$TRAVIS_TAG" ]; then
+  BINTRAY_REPO=stable
+fi
+
+# kick off the mac unstable build
+echo "Kicking off the $BINTRAY_REPO mac build"
+var_file=/tmp/our-awesome-vars
+ssh_args="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i /tmp/habitat-srv-admin"
+
+# first update the copy of the habitat code stored on the mac server to the latest
+ssh ${ssh_args} ${mac_builder} << EOF
+    hab_src_dir="\$HOME/code/$TRAVIS_BUILD_NUMBER"
+    mkdir -p \${hab_src_dir}
+    cd \${hab_src_dir}
+    git clone https://github.com/habitat-sh/habitat
+    cd habitat
+    git checkout $TRAVIS_COMMIT
+    chmod 755 support/ci/deploy_mac.sh
+EOF
+
+# passing environment variables over ssh is a pain and never worked quite right.
+# instead, write this out to a file and scp it over, to source later.
+cat << EOF >${var_file}
+export BINTRAY_REPO=$BINTRAY_REPO
+export HAB_ORIGIN_KEY=$HAB_ORIGIN_KEY
+export BINTRAY_USER=$BINTRAY_USER
+export BINTRAY_KEY=$BINTRAY_KEY
+export BINTRAY_PASSPHRASE=$BINTRAY_PASSPHRASE
+export TRAVIS_BUILD=$TRAVIS_BUILD_NUMBER
+EOF
+
+scp ${ssh_args} ${var_file} ${mac_builder}:~/tmp
+rm ${var_file}
+
+# kick off the build
+ssh ${ssh_args} ${mac_builder} \
+  "sudo ~/code/habitat/support/ci/deploy_mac.sh"


### PR DESCRIPTION
There are 2 key problems with Mac builds invoked by travis right now:

1. Concurrent builds try to build in the same directory causing various conflicts.
2. The Mac does a pull from master so regardless of the travis commit, the mac will always build from master

Further, the code that the mac builder uses to pull from git is on the builder and not in source control.

We should:

1. Create a subdirectory named after the travis build number where we clone and build
2. Checkout the travis commit
3. Send the git clone script to the builder instead of using an un sourced script
4. Separate the mac deploy scripts entirely from the linux deployment and have them run in separate travis jobs.

An additional benefit of pulling the mac build into its own job should be that we can avoid the error when the build log grows too large.

Signed-off-by: Matt Wrock <matt@mattwrock.com>