### PR TITLE
Set proper default path for depot data path in builder-api plan

### DIFF
--- a/components/builder-api/habitat/config/config.toml
+++ b/components/builder-api/habitat/config/config.toml
@@ -19,6 +19,6 @@ port = {{member.cfg.port}}
 {{~/eachAlive}}
 
 [depot]
-data_path = "{{pkg.svc_data_path}}"
+path = "{{pkg.svc_data_path}}"
 log_dir = "{{pkg.svc_var_path}}"
 {{toToml cfg.depot}}


### PR DESCRIPTION
![tenor-138335306](https://cloud.githubusercontent.com/assets/54036/25978509/6baa85e6-3677-11e7-9d9f-d13a86a09539.gif)
