### PR TITLE
Allow package search to work across origins.

### DIFF
--- a/components/builder-depot/src/server.rs
+++ b/components/builder-depot/src/server.rs
@@ -1486,7 +1486,13 @@ fn search_packages(req: &mut Request) -> IronResult<Response> {
 
     // TODO MW: constraining to core is temporary until we have a cross origin index
     request.set_origin("core".to_string());
+
+    // Setting distinct to true makes this query ignore the origin set above, because it's going to
+    // search both the origin name and the package name for the query string provided. This is
+    // likely sub-optimal for performance but it makes things work right now and we should probably
+    // switch to some kind of full-text search engine in the future anyway.
     request.set_distinct(true);
+
     match route_message::<OriginPackageSearchRequest, OriginPackageListResponse>(req, &request) {
         Ok(packages) => {
             debug!("search_packages start: {}, stop: {}, total count: {}",

--- a/components/builder-originsrv/src/migrations/origin_packages.rs
+++ b/components/builder-originsrv/src/migrations/origin_packages.rs
@@ -163,6 +163,26 @@ pub fn migrate(migrator: &mut Migrator) -> Result<()> {
                     END
                     $$ LANGUAGE plpgsql STABLE"#)?;
     migrator.migrate("originsrv",
+                     r#"CREATE OR REPLACE FUNCTION search_all_origin_packages_dynamic_v1 (
+                    op_query text,
+                    op_limit bigint,
+                    op_offset bigint
+                    ) RETURNS TABLE(total_count bigint, ident text) AS $$
+                    DECLARE
+                      schema RECORD;
+                    BEGIN
+                      FOR schema IN EXECUTE
+                        format(
+                          'SELECT schema_name FROM information_schema.schemata WHERE left(schema_name, 6) = %L',
+                          'shard_'
+                        )
+                      LOOP
+                        RETURN QUERY EXECUTE
+                        format('SELECT COUNT(p.partial_ident[1] || %L || p.partial_ident[2]) OVER () AS total_count, p.partial_ident[1] || %L || p.partial_ident[2] AS ident FROM (SELECT regexp_split_to_array(op.ident, %L) as partial_ident FROM %I.origins o INNER JOIN %I.origin_packages op ON o.id = op.origin_id WHERE o.name LIKE (%L || %L || %L) OR op.name LIKE (%L || %L || %L)) AS p GROUP BY (p.partial_ident[1] || %L || p.partial_ident[2]) LIMIT %L OFFSET %L', '/', '/', '/', schema.schema_name, schema.schema_name, '%', op_query, '%', '%', op_query, '%', '/', op_limit, op_offset);
+                      END LOOP;
+                    END;
+                    $$ LANGUAGE plpgsql STABLE"#)?;
+    migrator.migrate("originsrv",
                      r#"CREATE OR REPLACE FUNCTION sync_packages_v1() RETURNS TABLE(account_id bigint, package_id bigint, package_ident text, package_deps text) AS $$
                     BEGIN
                         RETURN QUERY SELECT origin_packages.owner_id, origin_packages.id, origin_packages.ident, origin_packages.deps FROM origin_packages WHERE origin_packages.scheduler_sync = false;

--- a/components/builder-originsrv/tests/data_store/mod.rs
+++ b/components/builder-originsrv/tests/data_store/mod.rs
@@ -1076,6 +1076,11 @@ fn search_origin_package_for_origin() {
         .expect("Should create origin")
         .unwrap();
 
+    origin.set_name(String::from("josh"));
+    let origin3 = ds.create_origin(&origin)
+        .expect("Should create origin")
+        .unwrap();
+
     let mut ident1 = originsrv::OriginPackageIdent::new();
     ident1.set_origin("core".to_string());
     ident1.set_name("red".to_string());
@@ -1099,6 +1104,12 @@ fn search_origin_package_for_origin() {
     ident4.set_name("red_dog".to_string());
     ident4.set_version("2017.01.19".to_string());
     ident4.set_release("20170209064045".to_string());
+
+    let mut ident5 = originsrv::OriginPackageIdent::new();
+    ident5.set_origin("josh".to_string());
+    ident5.set_name("red_dog".to_string());
+    ident5.set_version("2017.01.19".to_string());
+    ident5.set_release("20170209064045".to_string());
 
     let mut package = originsrv::OriginPackageCreate::new();
     package.set_owner_id(1);
@@ -1124,6 +1135,11 @@ fn search_origin_package_for_origin() {
 
     package.set_ident(ident4.clone());
     package.set_origin_id(origin1.get_id());
+    ds.create_origin_package(&package.clone())
+        .expect("Failed to create origin package");
+
+    package.set_ident(ident5.clone());
+    package.set_origin_id(origin3.get_id());
     ds.create_origin_package(&package.clone())
         .expect("Failed to create origin package");
 
@@ -1173,14 +1189,18 @@ fn search_origin_package_for_origin() {
     ops.set_distinct(true);
     let result2 = ds.search_origin_package_for_origin(&ops)
         .expect("Could not get the packages from the database");
-    assert_eq!(result2.get_idents().len(), 2);
+    assert_eq!(result2.get_idents().len(), 4);
     assert_eq!(result2.get_start(), 0);
-    assert_eq!(result2.get_stop(), 1);
-    assert_eq!(result2.get_count(), 2);
+    assert_eq!(result2.get_stop(), 3);
+    assert_eq!(result2.get_count(), 1);
     let pkg1 = result2.get_idents().iter().nth(0).unwrap();
-    assert_eq!(pkg1.to_string(), "core/red");
+    assert_eq!(pkg1.to_string(), "core/red_dog");
     let pkg2 = result2.get_idents().iter().nth(1).unwrap();
-    assert_eq!(pkg2.to_string(), "core/red_dog");
+    assert_eq!(pkg2.to_string(), "core/red");
+    let pkg3 = result2.get_idents().iter().nth(2).unwrap();
+    assert_eq!(pkg3.to_string(), "core2/red");
+    let pkg4 = result2.get_idents().iter().nth(3).unwrap();
+    assert_eq!(pkg4.to_string(), "josh/red_dog");
 }
 
 #[test]


### PR DESCRIPTION
This works by exploiting the dynamic SQL features provided by plpgsql.
It loops through every schema that starts with "shard_" and runs the
same SELECT query on each one. The function then returns all of those
results as one big result set.

Both origin name and package name are checked against the submitted
query, for maximum flexibility.

![](https://media.giphy.com/media/3oriO6qJiXajN0TyDu/giphy.gif)

Signed-off-by: Josh Black <raskchanky@gmail.com>