### PR TITLE
Use origin_invitation_id for invitation acceptance

### DIFF
--- a/components/builder-web/app/origins-page/OriginsPageComponent.ts
+++ b/components/builder-web/app/origins-page/OriginsPageComponent.ts
@@ -61,7 +61,7 @@ import {requireSignIn} from "../util";
                        <h3 class="hab-item-list--title">{{invitation.origin_name}}</h3>
                        <button
                            class="count"
-                           (click)="acceptInvitation(invitation.id, invitation.origin_name)">
+                           (click)="acceptInvitation(invitation.origin_invitation_id, invitation.origin_name)">
                            Accept Invitation
                         </button>
                     </li>


### PR DESCRIPTION
We were using the wrong ID, which meant we ended up routing to the
incorrect shard when processing an invitation acceptance, making it
impossible to have anyone else in your origin.

Thanks to @adamhjk for researching and pinpointing the underlying
issue.

Signed-off-by: Christopher Maier <cmaier@chef.io>