### PR TITLE
Clear logs before fetching, and only poll for updates when necessary

### DIFF
--- a/components/builder-web/app/actions/index.ts
+++ b/components/builder-web/app/actions/index.ts
@@ -39,6 +39,7 @@ export const SET_GITHUB_AUTH_TOKEN = gitHubActions.SET_GITHUB_AUTH_TOKEN;
 export const SET_SELECTED_GITHUB_ORG = gitHubActions.SET_SELECTED_GITHUB_ORG;
 
 export const CLEAR_BUILD = buildActions.CLEAR_BUILD;
+export const CLEAR_BUILD_LOG = buildActions.CLEAR_BUILD_LOG;
 export const CLEAR_BUILDS = buildActions.CLEAR_BUILDS;
 export const POPULATE_BUILD = buildActions.POPULATE_BUILD;
 export const POPULATE_BUILDS = buildActions.POPULATE_BUILDS;

--- a/components/builder-web/app/build/build.component.spec.ts
+++ b/components/builder-web/app/build/build.component.spec.ts
@@ -73,25 +73,45 @@ describe("BuildComponent", () => {
     expect(util.requireSignIn).toHaveBeenCalledWith(fixture.componentInstance);
   });
 
-  it("fetches the specified build", () => {
-    spyOn(actions, "fetchBuild");
-    fixture.detectChanges();
+  describe("on init", () => {
 
-    expect(actions.fetchBuild).toHaveBeenCalledWith(
-      store.getState().builds.selected.info.id,
-      store.getState().gitHub.authToken
-    );
+    it("fetches the specified build", () => {
+      spyOn(actions, "fetchBuild");
+      fixture.detectChanges();
+
+      expect(actions.fetchBuild).toHaveBeenCalledWith(
+        store.getState().builds.selected.info.id,
+        store.getState().gitHub.authToken
+      );
+    });
+
+    it("fetches the specified build log", () => {
+      spyOn(actions, "fetchBuildLog");
+      fixture.detectChanges();
+
+      expect(actions.fetchBuildLog).toHaveBeenCalledWith(
+        store.getState().builds.selected.info.id,
+        store.getState().gitHub.authToken,
+        0
+      );
+    });
+
+    it("initiates log streaming", () => {
+      spyOn(actions, "streamBuildLog");
+      fixture.detectChanges();
+
+      expect(actions.streamBuildLog).toHaveBeenCalledWith(true);
+    });
   });
 
-  it("fetches the specified build log", () => {
-    spyOn(actions, "fetchBuildLog");
-    fixture.detectChanges();
+  describe("on destroy", () => {
 
-    expect(actions.fetchBuildLog).toHaveBeenCalledWith(
-      store.getState().builds.selected.info.id,
-      store.getState().gitHub.authToken,
-      0
-    );
+    it("terminates log streaming", () => {
+      spyOn(actions, "streamBuildLog");
+      component.ngOnDestroy();
+
+      expect(actions.streamBuildLog).toHaveBeenCalledWith(false);
+    });
   });
 
   xit("shows the selected build status", () => {

--- a/components/builder-web/app/build/build.component.ts
+++ b/components/builder-web/app/build/build.component.ts
@@ -26,12 +26,11 @@ export class BuildComponent implements OnInit, OnDestroy {
     }
 
     ngOnDestroy() {
+        this.store.dispatch(streamBuildLog(false));
+
         if (this.sub) {
             this.sub.unsubscribe();
         }
-
-        this.store.dispatch(streamBuildLog(false));
-        this.store.dispatch(clearBuild());
     }
 
     iconFor(state) {

--- a/components/builder-web/app/reducers/builds.ts
+++ b/components/builder-web/app/reducers/builds.ts
@@ -7,7 +7,10 @@ export default function builds(state = initialState["builds"], action) {
 
         case actionTypes.CLEAR_BUILD:
             return state
-                .setIn(["selected", "info"], Record({})())
+                .setIn(["selected", "info"], Record({})());
+
+        case actionTypes.CLEAR_BUILD_LOG:
+            return state
                 .setIn(["selected", "log"], Record({})());
 
         case actionTypes.CLEAR_BUILDS:
@@ -19,6 +22,14 @@ export default function builds(state = initialState["builds"], action) {
 
         case actionTypes.POPULATE_BUILD_LOG:
             let payload = action.payload;
+
+            // It'll be common to get log requests for builds that haven't
+            // started yet (which will surface as errors), so in that case,
+            // we'll just hand back the current state.
+            if (action.error) {
+                return state;
+            }
+
             let content = ((payload.start === 0) ? [] : state.get("selected").log.content) || [];
 
             return state.setIn(["selected", "log"], {


### PR DESCRIPTION
This change restricts log polling by limiting follow-up requests based on a property set by the build-view component. It ensures we poll for logs only when someone is watching them.

Also clears build and log state before fetching (keeping stale data out of the view) and fixes a minor bug with the polling intervals.

![](https://i.giphy.com/IZCMWdxaz7Vrq.gif)

Signed-off-by: Christian Nunciato <cnunciato@chef.io>