### PR TITLE
Automatically determine default publish settings for builder-worker

### DIFF
--- a/BUILDER_DEV.md
+++ b/BUILDER_DEV.md
@@ -64,7 +64,6 @@ worker: target/debug/bldr-worker start --config /home/your_alias/habitat/config_
 export HAB_AUTH_TOKEN=<your github token>
 export HAB_DEPOT_URL=http://localhost:9636/v1/depot
 export HAB_ORIGIN=<your origin>
-export HAB_DEPOT_PUBLISH=true
 ```
 4. Now, do a `make bldr-run` from the root of your hab repo.
 

--- a/components/builder-api/habitat/plan.sh
+++ b/components/builder-api/habitat/plan.sh
@@ -10,6 +10,7 @@ pkg_build_deps=(core/protobuf core/protobuf-rust core/coreutils core/cacerts
   core/rust core/gcc core/git core/pkg-config core/node core/phantomjs core/python2 core/make)
 pkg_exports=(
   [port]=http.port
+  [url]=web.app_url
 )
 pkg_exposes=(port)
 pkg_binds=(

--- a/components/builder-worker/habitat/config/config.toml
+++ b/components/builder-worker/habitat/config/config.toml
@@ -1,5 +1,6 @@
 {{toToml cfg}}
 data_path = "{{pkg.svc_data_path}}"
+depot_url = "{{bind.depot.first.cfg.url}}"
 
 {{~#eachAlive bind.jobsrv.members as |member|}}
 [[jobsrv]]

--- a/components/builder-worker/habitat/default.toml
+++ b/components/builder-worker/habitat/default.toml
@@ -1,1 +1,3 @@
 auth_token = ""
+auto_publish = true
+depot_channel = "unstable"

--- a/components/builder-worker/habitat/plan.sh
+++ b/components/builder-worker/habitat/plan.sh
@@ -14,6 +14,7 @@ pkg_svc_user="root"
 pkg_svc_group="root"
 pkg_binds=(
   [jobsrv]="worker_port worker_heartbeat"
+  [depot]="url"
 )
 
 do_prepare() {

--- a/components/builder-worker/src/config.rs
+++ b/components/builder-worker/src/config.rs
@@ -15,18 +15,28 @@
 //! Configuration for a Habitat JobSrv Worker
 
 use std::net::{IpAddr, Ipv4Addr};
+use std::path::PathBuf;
 
 use hab_core::config::ConfigFile;
+use hab_core::url;
 
 use error::Error;
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 #[serde(default)]
 pub struct Config {
     /// Token for authenticating with the public builder-api
     pub auth_token: String,
+    /// Enable automatic publishing for all builds by default
+    pub auto_publish: bool,
     /// Filepath where persistent application data is stored
-    pub data_path: String,
+    pub data_path: PathBuf,
+    /// Default channel name for Publish post-processor to use to determine which channel to
+    /// publish artifacts to
+    pub depot_channel: String,
+    /// Default URL for Publish post-processor to use to determine which Builder Depot to use
+    /// for retrieving signing keys and publishing artifacts
+    pub depot_url: String,
     /// List of Job Servers to connect to
     pub jobsrv: JobSrvCfg,
 }
@@ -48,7 +58,10 @@ impl Default for Config {
     fn default() -> Self {
         Config {
             auth_token: "".to_string(),
-            data_path: "/tmp".to_string(),
+            auto_publish: true,
+            data_path: PathBuf::from("/tmp"),
+            depot_channel: String::from("unstable"),
+            depot_url: url::default_depot_url(),
             jobsrv: vec![JobSrvAddr::default()],
         }
     }
@@ -75,7 +88,7 @@ impl Default for JobSrvAddr {
             host: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
             port: 5566,
             heartbeat: 5567,
-            log_port: 5568
+            log_port: 5568,
         }
     }
 }

--- a/components/builder-worker/src/runner/workspace.rs
+++ b/components/builder-worker/src/runner/workspace.rs
@@ -30,8 +30,10 @@ pub struct Workspace {
 }
 
 impl Workspace {
-    pub fn new(data_path: String, job: Job) -> Self {
-        let root = PathBuf::from(data_path).join(job.get_id().to_string());
+    pub fn new<T>(data_path: T, job: Job) -> Self
+        where T: AsRef<Path>
+    {
+        let root = data_path.as_ref().join(job.get_id().to_string());
         Workspace {
             job: job,
             out: root.join("out"),

--- a/components/core/src/url.rs
+++ b/components/core/src/url.rs
@@ -12,43 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use env as henv;
+use env;
 
 /// Default Depot URL
 pub const DEFAULT_DEPOT_URL: &'static str = "https://willem.habitat.sh/v1/depot";
 
-/// Default Depot channel
-pub const DEFAULT_DEPOT_CHANNEL: &'static str = "unstable";
-
-/// Default Depot publishing
-pub const DEFAULT_DEPOT_PUBLISH: &'static str = "false";
-
 /// Default Depot URL environment variable
 pub const DEPOT_URL_ENVVAR: &'static str = "HAB_DEPOT_URL";
 
-/// Default Depot Channel environment variable
-pub const DEPOT_CHANNEL_ENVVAR: &'static str = "HAB_DEPOT_CHANNEL";
-
-/// Default Depot Builder publishing environment variable
-pub const DEPOT_PUBLISH_ENVVAR: &'static str = "HAB_DEPOT_PUBLISH";
-
 pub fn default_depot_url() -> String {
-    match henv::var(DEPOT_URL_ENVVAR) {
+    match env::var(DEPOT_URL_ENVVAR) {
         Ok(val) => val,
         Err(_) => DEFAULT_DEPOT_URL.to_string(),
-    }
-}
-
-pub fn default_depot_channel() -> String {
-    match henv::var(DEPOT_CHANNEL_ENVVAR) {
-        Ok(val) => val,
-        Err(_) => DEFAULT_DEPOT_CHANNEL.to_string(),
-    }
-}
-
-pub fn default_depot_publish() -> String {
-    match henv::var(DEPOT_PUBLISH_ENVVAR) {
-        Ok(val) => val,
-        Err(_) => DEFAULT_DEPOT_PUBLISH.to_string(),
     }
 }

--- a/terraform/instances.tf
+++ b/terraform/instances.tf
@@ -519,7 +519,7 @@ resource "aws_instance" "worker" {
       "sudo systemctl daemon-reload",
       "sudo systemctl start hab-sup",
       "sudo systemctl enable hab-sup",
-      "sudo hab service load core/builder-worker --group ${var.env} --bind jobsrv:builder-jobsrv.${var.env}",
+      "sudo hab service load core/builder-worker --group ${var.env} --bind jobsrv:builder-jobsrv.${var.env} --bind depot:builder-api.${var.env}",
     ]
   }
 


### PR DESCRIPTION
* builder-worker now binds to builder-api to retrieve the public url
  for where to download keys and publish artifacts
* Remove environment variables determining defaults for publishing
  artifacts in the worker and define those settings as fields in
  worker config

![tenor-21311803](https://cloud.githubusercontent.com/assets/54036/26020560/adde4296-3734-11e7-8dc0-819420183a9b.gif)

