### PR TITLE
Only return distinct results on package search if specified in the URL

### DIFF
--- a/components/builder-depot/doc/api.raml
+++ b/components/builder-depot/doc/api.raml
@@ -196,9 +196,34 @@ securitySchemes:
                                         "origin_id": "77731431660388352"
                                     }
 /pkgs:
+    /search:
+        /{query}:
+            get:
+                description: Search for packages with a query string
+                queryParameters:
+                    distinct:
+                        description: Whether to show a distinct list of packages or not
+                        type: boolean
+                        required: false
+                        default: false
+                        example: true
+                responses:
+                    200:
+                        description: Packages were found and fit on one page
+                    206:
+                        description: Packages were found and require pagination
+                    500:
+                        description: Internal server error
     /{origin}:
         get:
             description: List packages for an origin
+            queryParameters:
+                distinct:
+                    description: Whether to show a distinct list of packages or not
+                    type: boolean
+                    required: false
+                    default: false
+                    example: true
             responses:
                 200:
                 400:

--- a/components/builder-depot/src/server.rs
+++ b/components/builder-depot/src/server.rs
@@ -1492,7 +1492,11 @@ fn search_packages(req: &mut Request) -> IronResult<Response> {
     // search both the origin name and the package name for the query string provided. This is
     // likely sub-optimal for performance but it makes things work right now and we should probably
     // switch to some kind of full-text search engine in the future anyway.
-    request.set_distinct(true);
+    // Also, to get this behavior, you need to ensure that "distinct" is a URL parameter in your
+    // request, e.g. blah?distinct=true
+    if extract_query_value("distinct", req).is_some() {
+        request.set_distinct(true);
+    }
 
     match route_message::<OriginPackageSearchRequest, OriginPackageListResponse>(req, &request) {
         Ok(packages) => {

--- a/components/builder-depot/src/server.rs
+++ b/components/builder-depot/src/server.rs
@@ -1183,7 +1183,12 @@ fn list_packages(req: &mut Request) -> IronResult<Response> {
             let mut request = OriginPackageListRequest::new();
             request.set_start(start as u64);
             request.set_stop(stop as u64);
-            request.set_distinct(true);
+
+            // only set this if "distinct" is present as a URL parameter, e.g. ?distinct=true
+            if extract_query_value("distinct", req).is_some() {
+                request.set_distinct(true);
+            }
+
             request.set_ident(OriginPackageIdent::from_str(ident.as_str()).expect("invalid package identifier"));
             packages = route_message::<OriginPackageListRequest,
                                        OriginPackageListResponse>(req, &request);

--- a/components/builder-web/app/actions/packages.ts
+++ b/components/builder-web/app/actions/packages.ts
@@ -119,6 +119,7 @@ export function getUniquePackages(
 export function filterPackagesBy(
     params,
     query: string,
+    distinct: boolean,
     nextRange: number = 0
 ) {
     return dispatch => {
@@ -128,6 +129,10 @@ export function filterPackagesBy(
 
         if (query) {
             params = { query };
+        }
+
+        if (distinct) {
+            params["distinct"] = true;
         }
 
         depotApi.get(params, nextRange).then(response => {

--- a/components/builder-web/app/depotApi.ts
+++ b/components/builder-web/app/depotApi.ts
@@ -63,10 +63,14 @@ export function getLatest(origin: string, pkg: string) {
 }
 
 export function get(params, nextRange: number = 0) {
-    const url = `${urlPrefix}/depot/pkgs/` +
+    let url = `${urlPrefix}/depot/pkgs/` +
         (params["query"] ? `search/${params["query"]}`
                            : packageString(params)) +
         `?range=${nextRange}`;
+
+    if (params["distinct"]) {
+        url += "&distinct=true";
+    }
 
     return new Promise((resolve, reject) => {
         fetch(url).then(response => {

--- a/components/builder-web/app/packages-page/PackagesPageComponent.ts
+++ b/components/builder-web/app/packages-page/PackagesPageComponent.ts
@@ -116,6 +116,7 @@ export class PackagesPageComponent implements OnInit, OnDestroy {
     fetchMorePackages() {
         this.store.dispatch(filterPackagesBy(this.packageParams(),
             this.searchQuery,
+            true,
             this.store.getState().packages.nextRange));
         return false;
     }
@@ -131,7 +132,7 @@ export class PackagesPageComponent implements OnInit, OnDestroy {
 
     private fetchPackages() {
         this.store.dispatch(filterPackagesBy(this.packageParams(),
-            this.searchQuery));
+            this.searchQuery, true));
     }
 
     private search(query) {


### PR DESCRIPTION
Originally, package search returned a lot of results, one for each package version and release that was found.  This is how the depot in production works today.  Then I broke that with my package search PR which made all the results unique to the `:origin/:name` combination.  The original functionality was still there under the hood, but I hid it by setting `distinct` to `true` on the package search request.

That was a bad idea.

Now you can have either behavior you like, by specifying a URL parameter.  If you specify nothing, you get the original behavior, with all the results, the way production works today.  If you specify `?distinct=true` in the URL, you get the new behavior, with packages uniqued.

![](https://media.giphy.com/media/3oKIPcmh01poXviKZ2/giphy.gif)

Closes https://github.com/habitat-sh/habitat/issues/2346

Signed-off-by: Josh Black <raskchanky@gmail.com>