### PR TITLE
[studio] Fully canonicalize the Studio root path through symlinks.

### DIFF
--- a/components/studio/bin/hab-studio.sh
+++ b/components/studio/bin/hab-studio.sh
@@ -375,6 +375,10 @@ new_studio() {
       ;;
   esac
 
+  # Properly canonicalize the root path of the Studio by following all symlinks.
+  $bb mkdir -p $HAB_STUDIO_ROOT
+  HAB_STUDIO_ROOT="$($bb readlink -f $HAB_STUDIO_ROOT)"
+
   info "Creating Studio at $HAB_STUDIO_ROOT ($STUDIO_TYPE)"
 
   # Set the verbose flag (i.e. `-v`) for any coreutils-like commands if verbose
@@ -770,6 +774,11 @@ rm_studio() {
     STUDIO_TYPE=$studio_type
   else
     STUDIO_TYPE=unknown
+  fi
+
+  if [ -d "$HAB_STUDIO_ROOT" ]; then
+    # Properly canonicalize the root path of the Studio by following all symlinks.
+    HAB_STUDIO_ROOT="$($bb readlink -f $HAB_STUDIO_ROOT)"
   fi
 
   info "Destroying Studio at $HAB_STUDIO_ROOT ($STUDIO_TYPE)"


### PR DESCRIPTION
This is a bug fix which addresses one major failure scenario when
running `hab studio rm` in an environment where a Studio instance's root
path contains a symlink.

**Note:** future work will introduce more error checking and recovery
around cleaning up Studio instances to be more resilient.

Failure Scenario
----------------

![gif-keyboard-5712846764395420767](https://cloud.githubusercontent.com/assets/261548/26020754/e3e716f0-373f-11e7-854e-98df5416cdd9.gif)

Prior to this change, when a Studio instance existed with a root path
containing one or more symlinks, the cleanup logic in the `rm`
subcommand would not properly find the mounted filesystems namely
`/dev` and `/src` which are bind-mounted in from the underlying host
system. As a final step, the code attempts to remove the root directory
recursively which causes it to try and remove devices such as
`/dev/null` and the mounted source context files and directories mounted
under `/src`.

A simple example case is a system which stores all Habitat software and
state in `/mnt/hab` with a symlink to `/hab`. In this case, the
unmounting logic would look for `/hab/studios/<some_path>` in the
`mount` command when it should have been looking for
`/mnt/hab/studios/<some_path>`.

This fix ensures that in the `new_studio` code (which all subcommands
except `rm`, `help`, and `version` trigger), the `$HAB_STUDIO_ROOT` path
is fully canonicalized using `readlink -f`. Additionally in the
`rm_studio` code (which the `rm` and `build` subcommands trigger), the
same operation is performed, after checking for the presence of the path
first.

Previous Behavior
-----------------

![gif-keyboard-7752810867623130514](https://cloud.githubusercontent.com/assets/261548/26020749/d94470e4-373f-11e7-990c-c1298f44a91d.gif)

This is a reproducible test case in a Docker container (to limit the
any system damage) which uses the `/mnt/hab` -> `/hab` symlink scenario
explained above.

```
> docker run --rm -ti --privileged bscott/habitat sh

/src # hab install core/hab-studio
» Installing core/hab-studio
↓ Downloading core/hab-studio/0.23.0/20170511220040
    2.92 MB / 2.92 MB - [===============================] 100.00 % 1.99 MB/s
↓ Downloading core-20160810182414 public origin key
    75 B / 75 B | [=====================================] 100.00 % 2.29 MB/s
☑ Cached core-20160810182414 public origin key
✓ Installed core/hab-studio/0.23.0/20170511220040
★ Install of core/hab-studio/0.23.0/20170511220040 complete with 1 new packages installed.

/src # mv /hab /mnt/
/src # ln -snf /mnt/hab /hab
/src # ls -l /hab
lrwxrwxrwx    1 root     root             8 May 12 23:53 /hab -> /mnt/hab

/src # hab studio new
   hab-studio: Creating Studio at /hab/studios/src (default)
» Installing core/hab-backline
...
✓ Installed core/hab-backline/0.23.0/20170511220008
★ Install of core/hab-backline/0.23.0/20170511220008 complete with 40 new packages installed.
» Symlinking hab from core/hab into /hab/studios/src/hab/bin
★ Binary hab from core/hab/0.23.0/20170511215221 symlinked to /hab/studios/src/hab/bin/hab
» Symlinking bash from core/bash into /hab/studios/src/bin
★ Binary bash from core/bash/4.3.42/20161213234235 symlinked to /hab/studios/src/bin/bash
» Symlinking sh from core/bash into /hab/studios/src/bin
★ Binary sh from core/bash/4.3.42/20161213234235 symlinked to /hab/studios/src/bin/sh

/src # hab studio rm
   hab-studio: Destroying Studio at /hab/studios/src (default)
rm: can't remove '/hab/studios/src/src': Resource busy
rm: can't remove '/hab/studios/src/dev/console': Resource busy
rm: can't remove '/hab/studios/src/dev/shm': Resource busy
rm: can't remove '/hab/studios/src/dev/mqueue': Resource busy
...
rm: can't remove '/hab/studios/src/run': Resource busy
rm: can't remove '/hab/studios/src': Directory not empty

/src # echo $?
1
```

Fixed Behavior
--------------

![gif-keyboard-3418509571365522958](https://cloud.githubusercontent.com/assets/261548/26020746/d029ae70-373f-11e7-8816-205a8e57fe9f.gif)

And now with the fixed behavior. Note that both the `new` and `rm`
commands refer to the correct absolute Studio root path of
`/mnt/hab/studios/src`.

```
> docker run --rm -ti --privileged -v $(pwd):/extra bscott/habitat sh

/src # hab install /extra/core-hab-studio-0.24.0-dev-20170512235001-x86_64-lin
ux.hart
↓ Downloading core-20160810182414 public origin key
    75 B / 75 B | [=====================================] 100.00 % 2.09 MB/s
☑ Cached core-20160810182414 public origin key
✓ Installed core/hab-studio/0.24.0-dev/20170512235001
★ Install of core/hab-studio/0.24.0-dev/20170512235001 complete with 1 new packages installed.

/src # mv /hab /mnt/
/src # ln -snf /mnt/hab /hab
/src # ls -l /hab
lrwxrwxrwx    1 root     root             8 May 12 23:58 /hab -> /mnt/hab

/src # hab studio new
   hab-studio: Creating Studio at /mnt/hab/studios/src (default)
» Installing core/hab-backline
...
✓ Installed core/hab-backline/0.23.0/20170511220008
★ Install of core/hab-backline/0.23.0/20170511220008 complete with 40 new packages installed.
» Symlinking hab from core/hab into /mnt/hab/studios/src/hab/bin
★ Binary hab from core/hab/0.23.0/20170511215221 symlinked to /mnt/hab/studios/src/hab/bin/hab
» Symlinking bash from core/bash into /mnt/hab/studios/src/bin
★ Binary bash from core/bash/4.3.42/20161213234235 symlinked to /mnt/hab/studios/src/bin/bash
» Symlinking sh from core/bash into /mnt/hab/studios/src/bin
★ Binary sh from core/bash/4.3.42/20161213234235 symlinked to /mnt/hab/studios/src/bin/sh

/src # hab studio rm
   hab-studio: Destroying Studio at /mnt/hab/studios/src (default)

/src # echo $?
0
```
