### PR TITLE
Allow depot_url config option to be overridden in builder-worker config

### DIFF
--- a/components/builder-worker/habitat/config/config.toml
+++ b/components/builder-worker/habitat/config/config.toml
@@ -1,6 +1,12 @@
-{{toToml cfg}}
+auth_token = "{{cfg.auth_token}}"
+auto_publish = {{cfg.auto_publish}}
+depot_channel = "{{cfg.depot_channel}}"
 data_path = "{{pkg.svc_data_path}}"
-depot_url = "{{bind.depot.first.cfg.url}}"
+{{~#if cfg.depot_url}}
+depot_url = "{{cfg.depot_url}}"
+{{~else}}
+depot_url = "{{bind.depot.first.cfg.url}}/depot"
+{{~/if}}
 
 {{~#eachAlive bind.jobsrv.members as |member|}}
 [[jobsrv]]

--- a/components/builder-worker/src/runner/mod.rs
+++ b/components/builder-worker/src/runner/mod.rs
@@ -119,8 +119,8 @@ pub struct Runner {
 
 impl Runner {
     pub fn new(job: Job, config: Config) -> Self {
-        let url = format!("{}/depot", config.depot_url);
-        let depot_cli = depot_client::Client::new(&url, PRODUCT, VERSION, None).unwrap();
+        let depot_cli = depot_client::Client::new(&config.depot_url, PRODUCT, VERSION, None)
+            .unwrap();
         Runner {
             workspace: Workspace::new(config.data_path.clone(), job),
             config: config,

--- a/components/builder-worker/src/runner/postprocessor.rs
+++ b/components/builder-worker/src/runner/postprocessor.rs
@@ -38,20 +38,14 @@ impl Publish {
         if !self.enabled {
             return true;
         }
-
         debug!("post process: publish (url: {}, channel: {})",
                self.url,
                self.channel);
-
-        // Things to solve right now
-        // * Where do we get the token for authentication?
-        // * Should the workers ask for a lease from the JobSrv?
         let client = depot_client::Client::new(&self.url, PRODUCT, VERSION, None).unwrap();
         if let Some(err) = client.x_put_package(archive, auth_token).err() {
             error!("post processing error uploading package, ERR={:?}", err);
             return false;
         };
-
         if let Some(err) = client
                .promote_package(archive, &self.channel, auth_token)
                .err() {


### PR DESCRIPTION
![tenor-31733892](https://cloud.githubusercontent.com/assets/54036/26021875/763332cc-374b-11e7-92c0-44a87a2d44f7.gif)
