### PR TITLE
Render `pkg.ident` as string in RenderContext

### DIFF
--- a/components/sup/src/manager/service/package.rs
+++ b/components/sup/src/manager/service/package.rs
@@ -19,6 +19,7 @@ use std::path::{Path, PathBuf};
 
 use hcore::fs::FS_ROOT_PATH;
 use hcore::package::{PackageIdent, PackageInstall};
+use hcore::util::{deserialize_using_from_str, serialize_using_to_string};
 
 use error::{Error, Result};
 use fs;
@@ -76,6 +77,10 @@ impl Env {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Pkg {
+    #[serde(
+        deserialize_with = "deserialize_using_from_str",
+        serialize_with = "serialize_using_to_string"
+    )]
     pub ident: PackageIdent,
     pub origin: String,
     pub name: String,


### PR DESCRIPTION
We already render the parts of the ident as `pkg.name`, `pkg.origin`,
`pkg.release`, and `pkg.version`. `pkg.ident` should just be the
combined parts instead of an object of parts

This will incidentally fix the `[object]` which is in the place of the actual version of the package in the builder web-ui