### PR TITLE
Rename `hab service` to `hab svc` and add `hab svc status`

### DIFF
--- a/components/hab/src/analytics.rs
+++ b/components/hab/src/analytics.rs
@@ -277,7 +277,7 @@ pub fn instrument_subcommand() {
         // subcommand.
         ("origin", "key", "generate") |
         ("ring", "key", "generate") |
-        ("service", "key", "generate") |
+        ("svc", "key", "generate") |
         ("user", "key", "generate") => {
             record_event(Event::Subcommand,
                          &format!("{}--{}--{}--{}", PRODUCT, arg1, arg2, arg3))
@@ -321,7 +321,7 @@ pub fn instrument_clap_error(err: &clap::Error) {
                          &format!("{:?}--{}--{}--{}", err.kind, PRODUCT, arg1, arg2))
         }
         // Match against subcommands which are 3 levels deep.
-        "origin" | "ring" | "service" | "user" => {
+        "origin" | "ring" | "svc" | "user" => {
             record_event(Event::CliError,
                          &format!("{:?}--{}--{}--{}--{}", err.kind, PRODUCT, arg1, arg2, arg3))
         }

--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -279,9 +279,9 @@ pub fn get() -> App<'static, 'static> {
                 )
             )
         )
-        (@subcommand service =>
+        (@subcommand svc =>
             (about: "Commands relating to Habitat services")
-            (aliases: &["se", "ser", "serv", "servi", "servic"])
+            (aliases: &["sv", "ser", "serv", "service"])
             (@setting ArgRequiredElseHelp)
             (@subcommand key =>
                 (about: "Commands relating to Habitat service keys")
@@ -322,6 +322,7 @@ pub fn get() -> App<'static, 'static> {
                 \n    unload     Alias for: 'sup unload'\
                 \n    start      Alias for: 'sup start'\
                 \n    stop       Alias for: 'sup stop'\
+                \n    status     Alias for: 'sup status'\
                 \n"
             )
         )

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -148,7 +148,7 @@ fn start(ui: &mut UI) -> Result<()> {
                 _ => unreachable!(),
             }
         }
-        ("service", Some(matches)) => {
+        ("svc", Some(matches)) => {
             match matches.subcommand() {
                 ("key", Some(m)) => {
                     match m.subcommand() {
@@ -504,10 +504,11 @@ fn exec_subcommand_if_called(ui: &mut UI) -> Result<()> {
         }
         ("sup", _) => command::sup::start(ui, env::args_os().skip(2).collect()),
         ("start", _) => command::sup::start(ui, env::args_os().skip(1).collect()),
-        ("service", "load") |
-        ("service", "unload") |
-        ("service", "start") |
-        ("service", "stop") => command::sup::start(ui, env::args_os().skip(2).collect()),
+        ("svc", "load") |
+        ("svc", "unload") |
+        ("svc", "start") |
+        ("svc", "status") |
+        ("svc", "stop") => command::sup::start(ui, env::args_os().skip(2).collect()),
         _ => Ok(()),
     }
 }

--- a/support/bash_completion.sh
+++ b/support/bash_completion.sh
@@ -29,7 +29,7 @@ _hab()
     if [ $COMP_CWORD -eq 1 ]; then
         case $prev in
             hab)
-                COMPREPLY=( $( compgen -W "apply artifact config file help install origin pkg ring service setup start studio sup user" -- "$cur" ) )
+                COMPREPLY=( $( compgen -W "apply artifact config file help install origin pkg ring svc setup start studio sup user" -- "$cur" ) )
                 ;;
                    esac
     elif [ $COMP_CWORD -eq 2 ]; then
@@ -62,7 +62,7 @@ _hab()
                 cmds=( "help key" )
                 COMPREPLY=( $( compgen -W "$cmds" -- "$cur") )
                 ;;
-            service)
+            svc)
                 cmds=( "help key" )
                 COMPREPLY=( $( compgen -W "$cmds" -- "$cur") )
                 ;;
@@ -99,7 +99,7 @@ _hab()
                     ;;
                 esac
             ;;
-            service) # hab service key
+            svc) # hab svc key
                 case "$prev" in
                     key)
                         cmds=( "generate help" )

--- a/terraform/instances.tf
+++ b/terraform/instances.tf
@@ -46,8 +46,8 @@ resource "aws_instance" "api" {
       "sudo systemctl daemon-reload",
       "sudo systemctl start hab-sup",
       "sudo systemctl enable hab-sup",
-      "sudo hab service load core/builder-api --group ${var.env} --bind router:builder-router.${var.env}",
-      "sudo hab service load core/builder-api-proxy --group ${var.env} --bind http:builder-api.${var.env}",
+      "sudo hab svc load core/builder-api --group ${var.env} --bind router:builder-router.${var.env}",
+      "sudo hab svc load core/builder-api-proxy --group ${var.env} --bind http:builder-api.${var.env}",
     ]
   }
 
@@ -104,8 +104,8 @@ resource "aws_instance" "admin" {
       "sudo systemctl daemon-reload",
       "sudo systemctl start hab-sup",
       "sudo systemctl enable hab-sup",
-      "sudo hab service load core/builder-admin --group ${var.env} --bind router:builder-router.${var.env}",
-      "sudo hab service load core/builder-admin-proxy --group ${var.env} --bind http:builder-admin.${var.env}",
+      "sudo hab svc load core/builder-admin --group ${var.env} --bind router:builder-router.${var.env}",
+      "sudo hab svc load core/builder-admin-proxy --group ${var.env} --bind http:builder-admin.${var.env}",
     ]
   }
 
@@ -165,7 +165,7 @@ resource "aws_instance" "datastore" {
       "sudo systemctl daemon-reload",
       "sudo systemctl start hab-sup",
       "sudo systemctl enable hab-sup",
-      "sudo hab service load core/builder-datastore --group ${var.env}"
+      "sudo hab svc load core/builder-datastore --group ${var.env}"
     ]
   }
 
@@ -225,7 +225,7 @@ resource "aws_instance" "jobsrv" {
       "sudo systemctl daemon-reload",
       "sudo systemctl start hab-sup",
       "sudo systemctl enable hab-sup",
-      "sudo hab service load core/builder-jobsrv --group ${var.env} --bind router:builder-router.${var.env} --bind datastore:builder-datastore.${var.env}"
+      "sudo hab svc load core/builder-jobsrv --group ${var.env} --bind router:builder-router.${var.env} --bind datastore:builder-datastore.${var.env}"
     ]
   }
 
@@ -284,7 +284,7 @@ resource "aws_instance" "originsrv" {
       "sudo systemctl daemon-reload",
       "sudo systemctl start hab-sup",
       "sudo systemctl enable hab-sup",
-      "sudo hab service load core/builder-originsrv --group ${var.env} --bind router:builder-router.${var.env} --bind datastore:builder-datastore.${var.env}"
+      "sudo hab svc load core/builder-originsrv --group ${var.env} --bind router:builder-router.${var.env} --bind datastore:builder-datastore.${var.env}"
     ]
   }
 
@@ -342,7 +342,7 @@ resource "aws_instance" "router" {
       "sudo systemctl daemon-reload",
       "sudo systemctl start hab-sup",
       "sudo systemctl enable hab-sup",
-      "sudo hab service load core/builder-router --group ${var.env}"
+      "sudo hab svc load core/builder-router --group ${var.env}"
     ]
   }
 
@@ -401,7 +401,7 @@ resource "aws_instance" "scheduler" {
       "sudo systemctl daemon-reload",
       "sudo systemctl start hab-sup",
       "sudo systemctl enable hab-sup",
-      "sudo hab service load core/builder-scheduler --group ${var.env} --bind router:builder-router.${var.env} --bind datastore:builder-datastore.${var.env}"
+      "sudo hab svc load core/builder-scheduler --group ${var.env} --bind router:builder-router.${var.env} --bind datastore:builder-datastore.${var.env}"
     ]
   }
 
@@ -460,7 +460,7 @@ resource "aws_instance" "sessionsrv" {
       "sudo systemctl daemon-reload",
       "sudo systemctl start hab-sup",
       "sudo systemctl enable hab-sup",
-      "sudo hab service load core/builder-sessionsrv --group ${var.env} --bind router:builder-router.${var.env} --bind datastore:builder-datastore.${var.env}"
+      "sudo hab svc load core/builder-sessionsrv --group ${var.env} --bind router:builder-router.${var.env} --bind datastore:builder-datastore.${var.env}"
     ]
   }
 
@@ -519,7 +519,7 @@ resource "aws_instance" "worker" {
       "sudo systemctl daemon-reload",
       "sudo systemctl start hab-sup",
       "sudo systemctl enable hab-sup",
-      "sudo hab service load core/builder-worker --group ${var.env} --bind jobsrv:builder-jobsrv.${var.env} --bind depot:builder-api.${var.env}",
+      "sudo hab svc load core/builder-worker --group ${var.env} --bind jobsrv:builder-jobsrv.${var.env} --bind depot:builder-api.${var.env}",
     ]
   }
 

--- a/www/source/docs/reference/habitat-cli.html.md
+++ b/www/source/docs/reference/habitat-cli.html.md
@@ -30,7 +30,7 @@ The commands and sub-commands for the Habitat CLI (`hab`) are listed below.
 - [hab ring key export](#hab-ring-key-export)
 - [hab ring key generate](#hab-ring-key-generate)
 - [hab ring key import](#hab-ring-key-import)
-- [hab service key generate](#hab-service-key-generate)
+- [hab svc key generate](#hab-service-key-generate)
 - [hab studio](#hab-studio)
 - [hab sup](#hab-sup)
 - [hab user key generate](#hab-user-key-generate)
@@ -506,12 +506,12 @@ Reads a stdin stream containing ring key contents and writes the key to disk
     -h, --help       Prints help information
     -V, --version    Prints version information
 
-<h2 id="hab-service-key-generate" class="anchor">hab service key generate</h2>
+<h2 id="hab-service-key-generate" class="anchor">hab svc key generate</h2>
 Generates a Habitat service key
 
 **USAGE**
 
-    hab service key generate [FLAGS] <SERVICE_GROUP> [ARGS]
+    hab svc key generate [FLAGS] <SERVICE_GROUP> [ARGS]
 
 **FLAGS**
 

--- a/www/source/docs/run-packages-multiple-services.html.md
+++ b/www/source/docs/run-packages-multiple-services.html.md
@@ -33,31 +33,31 @@ It is important to start the supervisor via the `hab` program as upgrades to the
 
 ## Loading a Service for Supervision
 
-To add a service to a Supervisor, you use the `hab service load` subcommand. It has many of the same service-related flags and options as `hab start`, so there's nothing extra to learn here (for more details, read through the [Run packages sections](/docs/run-packages-overview)). For example, to load `yourorigin/yourname` in a Leader topology, a Rolling update strategy and a Group of "acme", run the following:
+To add a service to a Supervisor, you use the `hab svc load` subcommand. It has many of the same service-related flags and options as `hab start`, so there's nothing extra to learn here (for more details, read through the [Run packages sections](/docs/run-packages-overview)). For example, to load `yourorigin/yourname` in a Leader topology, a Rolling update strategy and a Group of "acme", run the following:
 
-		hab service load yourorigin/yourname --topology leader --strategy rolling --group acme
+		hab svc load yourorigin/yourname --topology leader --strategy rolling --group acme
 
-Running the `hab service load` subcommand multiple times with different package identifiers will result in multiple services running on the same supervisor. Let's add `core/redis` to the supervisor for some fun:
+Running the `hab svc load` subcommand multiple times with different package identifiers will result in multiple services running on the same supervisor. Let's add `core/redis` to the supervisor for some fun:
 
-		hab service load core/redis
+		hab svc load core/redis
 
 ## Unloading a Service from Supervision
 
-To unload and consequently remove a service from supervision, you use the `hab service unload` subcommand. If the service is was running, then it will be stopped first, then removed last. This means that the next time the Supervisor is started (or restarted), it will not run this unloaded service. For example, to remove the `yourorigin/yourname` service:
+To unload and consequently remove a service from supervision, you use the `hab svc unload` subcommand. If the service is was running, then it will be stopped first, then removed last. This means that the next time the Supervisor is started (or restarted), it will not run this unloaded service. For example, to remove the `yourorigin/yourname` service:
 
-		hab service unload yourorigin/yourname
+		hab svc unload yourorigin/yourname
 
 ## Stopping a Loaded Running Service
 
-Sometimes you need to stop a running service for a period of time, for example during a maintenance outage. Rather than completely removing a service from supervision, you can use the `hab service stop` subcommand which will shut down the running service and leave it in this state until you start it again with the `hab service start` subcommand, explained next. This means that all service-related options such as service topology, update strategy, etc. are preserved until the service is started again. For example, to stop the running `core/redis` service:
+Sometimes you need to stop a running service for a period of time, for example during a maintenance outage. Rather than completely removing a service from supervision, you can use the `hab svc stop` subcommand which will shut down the running service and leave it in this state until you start it again with the `hab svc start` subcommand, explained next. This means that all service-related options such as service topology, update strategy, etc. are preserved until the service is started again. For example, to stop the running `core/redis` service:
 
-		hab service stop core/redis
+		hab svc stop core/redis
 
 ## Starting a Loaded Stopped Service
 
-To resume running a service which has been loaded but stopped (via the `hab service stop` subcommand explained above), you use the `hab service start` subcommand. Let's resume our `core/redis` service with:
+To resume running a service which has been loaded but stopped (via the `hab svc stop` subcommand explained above), you use the `hab svc start` subcommand. Let's resume our `core/redis` service with:
 
-		hab service start core/redis
+		hab svc start core/redis
 
 ## Querying the supervisor for service status
 You can query all services currently loaded or running under the local supervisor using the `hab sup status` command. This command will list all persistent services loaded by the supervisor along with their current state. It will also list transient services that are currently running or in a `starting` or `restarting` state. The `status` command includes the version and release of the servicwe and for services that are running, it will include the `PID` of the running service.

--- a/www/source/docs/run-packages-overview.html.md.erb
+++ b/www/source/docs/run-packages-overview.html.md.erb
@@ -44,9 +44,9 @@ To start the supervisor, you can write an init script or a systemd unit file. Fo
       [Install]
       WantedBy=default.target
 
-Next use `hab service load` to load one or more services into the supervisor for permanent supervision. Using the example from above:
+Next use `hab svc load` to load one or more services into the supervisor for permanent supervision. Using the example from above:
 
-      sudo hab service load yourorigin/yourname
+      sudo hab svc load yourorigin/yourname
 
 ## Section details
 

--- a/www/source/docs/run-packages-security.html.md
+++ b/www/source/docs/run-packages-security.html.md
@@ -49,7 +49,7 @@ As explained in the [security overview](/docs/internals-crypto), this process al
 
 1. Generate a service group key using the `hab` command-line tool. This can be done on your workstation. Because asymmetric encryption is being used, two files will be generated: a file with a `.box.key` extension, which is the service group's private key, and a file with a `.pub` extension, which is the service group's public key.
 
-       hab service key generate servicegroupname.example yourorg
+       hab svc key generate servicegroupname.example yourorg
 
 2. This generated a service group key for the service group `servicegroupname.example` in the organization `yourorg`. Copy the `.box.key` private key to the environment where the supervisor will run into the `/hab/cache/keys` directory. Ensure that it has the appropriate permissions so that only the supervisor can read it.
 3. Start the supervisor, specifying both the service group and organization that it belongs to:


### PR DESCRIPTION
* `hab service` has been renamed to `hab svc`. This is now a common
  command that we have begun to run with the multi-tenant supervisor.
  We've shortened `hab package` to `hab pkg` and this brings us inline
  with that standard
* Added `hab svc status` command. This forwards to `hab-sup status`

![tenor-248370356](https://cloud.githubusercontent.com/assets/54036/26029312/f76a0f96-37e6-11e7-8d9a-94cf89b17f87.gif)

