### PR TITLE
Fully serialize the `pkg` field of the Service struct

### DIFF
--- a/components/sup/doc/api.raml
+++ b/components/sup/doc/api.raml
@@ -73,7 +73,50 @@ types:
                 type: integer
             started:
                 type: boolean
-    specIdent:
+    pkg:
+        type: object
+        properties:
+            ident:
+                type: string
+            origin:
+                type: string
+            name:
+                type: string
+            version:
+                type: string
+            release:
+                type: string
+            deps:
+                type: pkgIdent[]
+            env:
+                type: object
+            exposes:
+                type: string[]
+            exports:
+                type: object
+            path:
+                type: string
+            svc_path:
+                type: string
+            svc_config_path:
+                type: string
+            svc_data_path:
+                type: string
+            svc_files_path:
+                type: string
+            svc_static_path:
+                type: string
+            svc_var_path:
+                type: string
+            svc_pid_file:
+                type: string
+            svc_run:
+                type: string
+            svc_user:
+                type: string
+            svc_group:
+                type: string
+    pkgIdent:
         type: object
         properties:
             origin:
@@ -96,7 +139,7 @@ types:
             spec_file:
                 type: string
             spec_ident:
-                type: specIdent
+                type: pkgIdent
             start_style:
                 enum: [
                     "Transient",
@@ -116,7 +159,7 @@ types:
             cfg:
                 type: object
             pkg:
-                type: string
+                type: pkg
             sys:
                 type: systemInfo
             health_check:

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -336,7 +336,8 @@ fn sub_start(m: &ArgMatches) -> Result<()> {
     try!(command::start::run(cfg.clone(), maybe_spec.clone(), maybe_local_artifact));
     if running {
         if let Some(spec) = maybe_spec {
-            outputln!("The supervisor is starting the {} service. See the supervisor output for more details.",
+            outputln!("The supervisor is starting the {} service. See the supervisor output for \
+                      more details.",
                       spec.ident);
         }
     }
@@ -377,21 +378,21 @@ fn sub_status(m: &ArgMatches) -> Result<()> {
         match status.process.state {
             ProcessState::Up => {
                 outputln!("The {} service entered the running state with PID: {} {} seconds ago.",
-                          status.package,
+                          status.pkg.ident,
                           status.process.pid.unwrap(),
                           status.process.elapsed.num_seconds())
             }
             ProcessState::Down => {
-                outputln!("The {} service is not currently running.", status.package);
+                outputln!("The {} service is not currently running.", status.pkg.ident);
             }
             ProcessState::Start => {
                 outputln!("The {} service entered the starting state {} seconds ago.",
-                          status.package,
+                          status.pkg.ident,
                           status.process.elapsed.num_seconds());
             }
             ProcessState::Restart => {
                 outputln!("The {} service entered the restarting state {} seconds ago.",
-                          status.package,
+                          status.pkg.ident,
                           status.process.elapsed.num_seconds());
             }
         }

--- a/components/sup/src/manager/service/mod.rs
+++ b/components/sup/src/manager/service/mod.rs
@@ -67,12 +67,6 @@ lazy_static! {
     };
 }
 
-fn serialize_pkg<S>(x: &Pkg, s: S) -> result::Result<S::Ok, S::Error>
-    where S: serde::Serializer
-{
-    s.serialize_str(&x.ident.to_string())
-}
-
 #[derive(Debug, Serialize)]
 pub struct Service {
     pub service_group: ServiceGroup,
@@ -83,7 +77,6 @@ pub struct Service {
     pub topology: Topology,
     pub update_strategy: UpdateStrategy,
     pub cfg: Cfg,
-    #[serde(serialize_with="serialize_pkg")]
     pub pkg: Pkg,
     pub sys: Arc<Sys>,
 
@@ -100,7 +93,6 @@ pub struct Service {
     config_from: Option<PathBuf>,
     #[serde(skip_serializing)]
     last_health_check: Instant,
-    #[serde(skip_serializing)]
     manager_fs_cfg: Arc<manager::FsCfg>,
     #[serde(rename="process")]
     supervisor: Supervisor,


### PR DESCRIPTION
This will serialize the entire contents of the `Pkg` struct instead of just the name of the package

Fixes #2250

![tenor-136280610](https://cloud.githubusercontent.com/assets/54036/26030397/80ea7538-3807-11e7-85bc-36fa527ed961.gif)
