### PR TITLE
Short-circuit project API processing for non-core origins

### DIFF
--- a/components/builder-api/src/http/mod.rs
+++ b/components/builder-api/src/http/mod.rs
@@ -52,6 +52,10 @@ pub fn router(config: Arc<Config>) -> Result<Chain> {
         },
         user_origins: get "/user/origins" => XHandler::new(list_user_origins).before(basic.clone()),
 
+        // NOTE: Each of the handler functions for projects currently
+        // short-circuits processing if trying to do anything with a
+        // non-"core" origin, since we're not enabling Builder for any
+        // other origins at the moment.
         projects: post "/projects" => XHandler::new(project_create).before(basic.clone()),
         project: get "/projects/:origin/:name" => project_show,
         project_jobs: get "/projects/:origin/:name/jobs" => project_jobs,


### PR DESCRIPTION
At release, the Builder service is only enabled for projects in the
`core` origin. We currently block project creation for any other
origin. This PR adds short-circuit logic to other project-related
APIs; if anything is operating on an origin other than `core`, we
immediately stop processing and return an appropriate error.

This just reduces internal system traffic.

Follow-up to #2362

Signed-off-by: Christopher Maier <cmaier@chef.io>

