### PR TITLE
Fix deployment of middleman site

### DIFF
--- a/www/Gemfile
+++ b/www/Gemfile
@@ -19,6 +19,7 @@ gem 'middleman-sprockets', '~> 4.0'
 gem 'middleman-blog', '~> 4.0'
 gem 'middleman-syntax'
 gem 'middleman-minify-html'
+gem 'mime-types'
 
 gem 'rubocop', require: false
 gem 'scss_lint', require: false

--- a/www/Gemfile.lock
+++ b/www/Gemfile.lock
@@ -134,6 +134,9 @@ GEM
     middleman-syntax (3.0.0)
       middleman-core (>= 3.2)
       rouge (~> 2.0)
+    mime-types (3.0)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2016.0221)
     mini_portile2 (2.1.0)
     minitest (5.10.2)
     multi_json (1.12.1)
@@ -207,6 +210,7 @@ DEPENDENCIES
   middleman-s3_sync
   middleman-sprockets (~> 4.0)
   middleman-syntax
+  mime-types
   pry
   rubocop
   scss_lint


### PR DESCRIPTION
![tenor-263536209](https://cloud.githubusercontent.com/assets/54036/26081260/dca8d9c8-397e-11e7-9eac-79bbf1b667ac.gif)

Added the 'mime-types' gem which is required for deploying the recently added blog