### PR TITLE
Use ANSI color codes in build output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -545,8 +545,10 @@ name = "habitat_builder_protocol"
 version = "0.0.0"
 dependencies = [
  "habitat_core 0.0.0",
+ "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/builder-api/doc/api.raml
+++ b/components/builder-api/doc/api.raml
@@ -312,6 +312,34 @@ securitySchemes:
                         default: 0
                         minimum: 0
                         example: 100
+                    strip:
+                      description: |
+                        Strip ANSI color codes from the log output. By
+                        default, all ANSI sequences are left in the
+                        output.
+
+                        The following values are interpreted as `true`:
+                          * `true`
+                          * `TRUE`
+                          * `t`
+                          * `T`
+                          * `1`
+                          * `on`
+                          * `ON`
+
+                        The following values are interpreted as `false`:
+                          * `false`
+                          * `FALSE`
+                          * `f`
+                          * `F`
+                          * `0`
+                          * `off`
+                          * `OFF`
+
+                        All other values are considered `false`.
+                      type: boolean
+                      default: false
+                      required: false
                 responses:
                     200:
                         body:

--- a/components/builder-protocol/Cargo.toml
+++ b/components/builder-protocol/Cargo.toml
@@ -11,6 +11,8 @@ protobuf = "*"
 serde = "*"
 serde_derive = "*"
 time = "*"
+regex = "*"
+lazy_static = "*"
 
 [dependencies.habitat_core]
 path = "../core"

--- a/components/builder-protocol/src/lib.rs
+++ b/components/builder-protocol/src/lib.rs
@@ -13,7 +13,10 @@
 // limitations under the License.
 
 extern crate habitat_core as hab_core;
+#[macro_use]
+extern crate lazy_static;
 extern crate protobuf;
+extern crate regex;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;

--- a/components/builder-worker/src/runner/mod.rs
+++ b/components/builder-worker/src/runner/mod.rs
@@ -264,6 +264,7 @@ impl Runner {
                     .args(&args)
                     .env_clear()
                     .env("HAB_NONINTERACTIVE", "true")
+                    .env("TERM", "xterm-256color") // Gives us ANSI color codes
                     .stdout(Stdio::piped())
                     .stderr(Stdio::piped())
                     .spawn()


### PR DESCRIPTION
This will allow us to display the colors in the UI. We are not adding
it to builds running in debug mode, since that presumably will be only
under specific circumstances when we're debugging a problem and ANSI
codes would be more of a nuissance.

A `strip` query parameter is added to the `jobs/{id}/log` API
endpoint. Specifying this parameter with a value of `true` (or
anything that can reasonably be interpreted as `true`; see the RAML
docs for details) will return log content with ANSI codes stripped
out. Leaving the parameter off (or with a `false` value) will yield
log lines with embedded ANSI codes.

Signed-off-by: Christopher Maier <cmaier@chef.io>