### PR TITLE
Default to plain log output

### DIFF
--- a/components/builder-api/doc/api.raml
+++ b/components/builder-api/doc/api.raml
@@ -312,11 +312,11 @@ securitySchemes:
                         default: 0
                         minimum: 0
                         example: 100
-                    strip:
+                    color:
                       description: |
-                        Strip ANSI color codes from the log output. By
-                        default, all ANSI sequences are left in the
-                        output.
+                        Whether or not to include embedded ANSI color
+                        codes in the log output. By default, all ANSI
+                        sequences are removed, yielding plain output.
 
                         The following values are interpreted as `true`:
                           * `true`

--- a/components/builder-api/src/http/handlers.rs
+++ b/components/builder-api/src/http/handlers.rs
@@ -172,9 +172,9 @@ pub fn job_log(req: &mut Request) -> IronResult<Response> {
         }
     };
 
-    let strip = req.get_ref::<Params>()
+    let include_color = req.get_ref::<Params>()
         .unwrap()
-        .find(&["strip"])
+        .find(&["color"])
         .and_then(FromValue::from_value)
         .unwrap_or(false);
     
@@ -191,7 +191,7 @@ pub fn job_log(req: &mut Request) -> IronResult<Response> {
 
     match conn.route::<JobLogGet, JobLog>(&request) {
         Ok(mut log) => {
-            if strip {
+            if !include_color {
                 log.strip_ansi();
             }
             Ok(render_json(status::Ok, &log))


### PR DESCRIPTION
By default, we will now strip out any ANSI color codes from log
output. If an API client would like them to remain, they must specify
`color=true` as a query parameter.

Signed-off-by: Christopher Maier <cmaier@chef.io>