### PR TITLE
ensure keys inserted into postgres remain unique

### DIFF
--- a/components/builder-originsrv/src/migrations/origin_public_keys.rs
+++ b/components/builder-originsrv/src/migrations/origin_public_keys.rs
@@ -28,7 +28,7 @@ pub fn migrate(migrator: &mut Migrator) -> Result<()> {
                     owner_id bigint,
                     name text,
                     revision text,
-                    full_name text,
+                    full_name text UNIQUE,
                     body bytea,
                     created_at timestamptz DEFAULT now(),
                     updated_at timestamptz

--- a/components/builder-originsrv/src/migrations/origin_secret_keys.rs
+++ b/components/builder-originsrv/src/migrations/origin_secret_keys.rs
@@ -28,7 +28,7 @@ pub fn migrate(migrator: &mut Migrator) -> Result<()> {
                     owner_id bigint,
                     name text,
                     revision text,
-                    full_name text,
+                    full_name text UNIQUE,
                     body bytea,
                     created_at timestamptz DEFAULT now(),
                     updated_at timestamptz


### PR DESCRIPTION
In the process of writing the builder data migrations and testing for duplicate resiliance, I discovered we have no db level constraints for inserting duplicate keys.

Signed-off-by: Matt Wrock <matt@mattwrock.com>