### PR TITLE
Fix package navigation, add status indicators and log coloring

### DIFF
--- a/components/builder-web/app/BuilderApiClient.ts
+++ b/components/builder-web/app/BuilderApiClient.ts
@@ -141,7 +141,7 @@ export class BuilderApiClient {
 
     public getBuildLog(id: string, start = 0) {
         return new Promise((resolve, reject) => {
-            fetch(`${this.urlPrefix}/jobs/${id}/log?start=${start}`, {
+            fetch(`${this.urlPrefix}/jobs/${id}/log?start=${start}&color=true`, {
                 method: "GET",
                 headers: this.headers
             })
@@ -157,6 +157,12 @@ export class BuilderApiClient {
     }
 
     public getBuilds(origin: string, name: string) {
+
+        // Don't bother requesting unless the origin is core
+        if (origin !== "core") {
+            Promise.resolve({ jobs: [] });
+        }
+
         return new Promise((resolve, reject) => {
             fetch(`${this.urlPrefix}/projects/${origin}/${name}/jobs`, {
                 method: "GET",

--- a/components/builder-web/app/PackageBreadcrumbsComponent.ts
+++ b/components/builder-web/app/PackageBreadcrumbsComponent.ts
@@ -29,10 +29,6 @@ import { Component, Input } from "@angular/core";
         <a [routerLink]="['/pkgs', ident.origin, ident.name, ident.version]">
             {{ident.version}}
         </a>
-        <span *ngIf="ident.release">/</span>
-        <a [routerLink]="['/pkgs', ident.origin, ident.name, ident.version, ident.release]">
-            {{ident.release}}
-        </a>
     </span>`
 })
 

--- a/components/builder-web/app/actions/packages.ts
+++ b/components/builder-web/app/actions/packages.ts
@@ -86,6 +86,7 @@ export function fetchLatestPackage(origin: string, name: string) {
 
 export function fetchPackageVersions(origin: string, name: string) {
     return dispatch => {
+        dispatch(clearPackages());
         dispatch(clearPackageVersions());
         depotApi.getPackageVersions(origin, name).then(response => {
             dispatch(setCurrentPackageVersions(response));
@@ -109,7 +110,11 @@ export function getUniquePackages(
             dispatch(setVisiblePackages(response["results"]));
             dispatch(setPackagesTotalCount(response["totalCount"]));
             dispatch(setPackagesNextRange(response["nextRange"]));
-            dispatch(fetchProjectsForPackages(response["results"], token));
+
+            // Only for core
+            if (origin === "core") {
+                dispatch(fetchProjectsForPackages(response["results"], token));
+            }
         }).catch(error => {
             dispatch(setVisiblePackages(undefined, error));
         });
@@ -125,6 +130,7 @@ export function filterPackagesBy(
     return dispatch => {
         if (nextRange === 0) {
             dispatch(clearPackages());
+            dispatch(clearPackageVersions());
         }
 
         if (query) {

--- a/components/builder-web/app/app.module.ts
+++ b/components/builder-web/app/app.module.ts
@@ -40,6 +40,7 @@ import { OrganizationMembersComponent } from "./organization-members/Organizatio
 import { OrganizationsPageComponent } from "./organizations-page/OrganizationsPageComponent";
 import { PackageBreadcrumbsComponent } from "./PackageBreadcrumbsComponent";
 import { BuildComponent } from "./build/build.component";
+import { BuildStatusComponent } from "./build-status/build-status.component";
 import { PackageBuildsComponent } from "./package-builds/package-builds.component";
 import { PackageInfoComponent } from "./package-info/PackageInfoComponent";
 import { PackageListComponent } from "./package-page/PackageListComponent";
@@ -70,6 +71,7 @@ import { UserNavComponent } from "./header/user-nav/UserNavComponent";
     declarations: [
         AppComponent,
         BuildListComponent,
+        BuildStatusComponent,
         CheckingInputComponent,
         DashboardComponent,
         ExploreComponent,

--- a/components/builder-web/app/app.scss
+++ b/components/builder-web/app/app.scss
@@ -31,6 +31,7 @@
 @import "header/header";
 @import "header/user-nav/user-nav";
 @import "build-list/build-list.component";
+@import "build-status/build-status.component";
 @import "notifications/notifications";
 @import "origin-create-page/origin-create-page";
 @import "origin-page/origin-page";
@@ -41,6 +42,7 @@
 @import "package-builds/package-builds.component";
 @import "package-page/package-page";
 @import "package-versions-page/package-versions-page";
+@import "packages-list/packages-list.component";
 @import "packages-page/packages-page";
 @import "project-create-page/project-create-page";
 @import "project-page/project-page";
@@ -130,6 +132,12 @@ body {
 
     &:last-child {
       margin-bottom: 0;
+    }
+  }
+
+  .hab-package-breadcrumbs {
+    span {
+      color: $hab-green;
     }
   }
 }

--- a/components/builder-web/app/build-status/_build-status.component.scss
+++ b/components/builder-web/app/build-status/_build-status.component.scss
@@ -1,0 +1,46 @@
+hab-build-status {
+
+  .octicon {
+    font-size: rem(20);
+
+    &.complete {
+      color: $hab-green;
+    }
+
+    &.dispatched, &.processing {
+      color: $hab-orange;
+      height: rem(20);
+      width: rem(16);
+      animation-duration: 1s;
+      animation-iteration-count: infinite;
+      animation-name: spinning;
+      animation-timing-function: linear;
+    }
+
+    &.pending {
+      color: $hab-blue;
+    }
+
+    &.failed, &.rejected {
+      color: $hab-red;
+    }
+
+    @keyframes spinning {
+      from {
+        transform: rotate(0deg);
+      }
+
+      to {
+        transform: rotate(360deg);
+      }
+    }
+
+    &.octicon-chevron-right {
+      display: none;
+      position: absolute;
+      right: 0;
+      top: 50%;
+      transform: translateY(-50%);
+    }
+  }
+}

--- a/components/builder-web/app/build-status/build-status.component.ts
+++ b/components/builder-web/app/build-status/build-status.component.ts
@@ -1,0 +1,44 @@
+import { Component, Input } from "@angular/core";
+import { AppStore } from "../AppStore";
+
+@Component({
+  selector: "hab-build-status",
+  template: `
+    <span *ngIf="state" class='octicon octicon-{{ iconFor(state) }} {{ state | lowercase }}'></span>
+  `
+})
+export class BuildStatusComponent {
+  @Input() origin;
+  @Input() name;
+  @Input() version;
+  @Input() release;
+
+  constructor(private store: AppStore) {}
+
+  iconFor(state) {
+      return {
+          Complete: "check",
+          Dispatched: "sync",
+          Failed: "issue-opened",
+          Pending: "clock",
+          Processing: "sync",
+          Rejected: "issue-opened"
+      }[state];
+  }
+
+  get id() {
+    return this.first() ? this.first().id : null;
+  }
+
+  get state() {
+    return this.first() ? this.first().state : null;
+  }
+
+  private first() {
+    return this.store.getState().builds.visible.find((b) => {
+      if (b.origin === this.origin && b.name === this.name) {
+        return this.version ? b.version === this.version : true;
+      }
+    });
+  }
+}

--- a/components/builder-web/app/build/build.component.html
+++ b/components/builder-web/app/build/build.component.html
@@ -34,6 +34,6 @@
         </div>
       </div>
     </div>
-    <pre class="output" *ngIf="log">{{ log }}</pre>
+    <pre class="output" [innerHTML]="log"></pre>
   </div>
 </div>

--- a/components/builder-web/app/build/build.component.ts
+++ b/components/builder-web/app/build/build.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit, OnDestroy } from "@angular/core";
+import { DomSanitizer } from "@angular/platform-browser";
 import { ActivatedRoute } from "@angular/router";
 import { Subscription } from "rxjs";
 import { clearBuild, fetchBuild, fetchBuildLog, streamBuildLog } from "../actions/index";
@@ -13,7 +14,8 @@ export class BuildComponent implements OnInit, OnDestroy {
 
     constructor(
         private store: AppStore,
-        private route: ActivatedRoute) {
+        private route: ActivatedRoute,
+        private sanitizer: DomSanitizer) {
         requireSignIn(this);
     }
 
@@ -63,9 +65,7 @@ export class BuildComponent implements OnInit, OnDestroy {
         let content = selected.log.content;
 
         if (content && content.length) {
-            return content.join("\n")
-                // TODO: Remove this once the debug output is cleaned up.
-                .replace(/^ ?[\d: ]+/gm, "");
+            return this.sanitizer.bypassSecurityTrustHtml(content.join("\n"));
         }
     }
 

--- a/components/builder-web/app/dashboard/_dashboard.component.scss
+++ b/components/builder-web/app/dashboard/_dashboard.component.scss
@@ -178,13 +178,20 @@
     &.lower {
 
       .recent {
-        @include span-columns(9);
+        @include span-columns(12);
 
-        // Use this border when we have right-hand side elements to display
+        // TODO: Replace the above span-columns setting with the settings
+        // below when we have right-hand side content to display.
+        // @include span-columns(9);
         // border-right: 1px solid rgba($light-gray, 0.4);
       }
 
       .new {
+
+        // TODO: As above, remove this display: none when we have content
+        // for this section.
+        display: none;
+
         @include span-columns(3);
 
         li {

--- a/components/builder-web/app/dashboard/dashboard.component.html
+++ b/components/builder-web/app/dashboard/dashboard.component.html
@@ -116,22 +116,22 @@
         </div>
         <ul class="packages" *ngIf="myPackages.size">
           <li class="heading">
-            <div class="package-name">
-              <h5>Package</h5>
-            </div>
             <div class="package-origin">
               <h5>Origin</h5>
             </div>
+            <div class="package-name">
+              <h5>Package</h5>
+            </div>
             <div class="package-updated">
-              <h5>Last Updated</h5>
+              <h5>Last Update</h5>
             </div>
           </li>
           <li class="item" *ngFor="let pkg of myPackages" (click)="navigateToPackage(pkg)">
-            <div class="package-name">
-              {{ pkg.name }}
-            </div>
             <div class="package-origin">
               {{ pkg.origin }}
+            </div>
+            <div class="package-name">
+              {{ pkg.name }}
             </div>
             <div class="package-updated">
               {{ fromNow(pkg.release) }}

--- a/components/builder-web/app/dashboard/dashboard.component.ts
+++ b/components/builder-web/app/dashboard/dashboard.component.ts
@@ -64,7 +64,7 @@ export class DashboardComponent implements OnInit {
     }
 
     navigateToPackage(pkg) {
-        this.router.navigate(["pkgs", pkg.origin, pkg.name, pkg.version, pkg.release]);
+        this.router.navigate(["pkgs", pkg.origin, pkg.name]);
     }
 
     selectOrigin(name: string) {

--- a/components/builder-web/app/depotApi.ts
+++ b/components/builder-web/app/depotApi.ts
@@ -26,23 +26,25 @@ export function getUnique(origin: string, nextRange: number = 0) {
             if (response.status >= 400) {
                 reject(new Error(response.statusText));
             }
+            else {
+                response.json().then(resultsObj => {
+                    let results;
 
-            response.json().then(resultsObj => {
-                let results;
+                    const endRange = parseInt(resultsObj.range_end, 10);
+                    const totalCount = parseInt(resultsObj.total_count, 10);
+                    const nextRange = totalCount > (endRange + 1) ? endRange + 1 : 0;
 
-                const endRange = parseInt(resultsObj.range_end, 10);
-                const totalCount = parseInt(resultsObj.total_count, 10);
-                const nextRange = totalCount > (endRange + 1) ? endRange + 1 : 0;
+                    if (resultsObj["package_list"]) {
+                        results = resultsObj["package_list"];
+                    } else {
+                        results = resultsObj;
+                    }
 
-                if (resultsObj["package_list"]) {
-                    results = resultsObj["package_list"];
-                } else {
-                    results = resultsObj;
-                }
-
-                resolve({ results, totalCount, nextRange });
-            });
-        }).catch(error => reject(error));
+                    resolve({ results, totalCount, nextRange });
+                });
+            }
+        })
+        .catch(error => reject(error));
     });
 }
 
@@ -54,11 +56,13 @@ export function getLatest(origin: string, pkg: string) {
             if (response.status >= 400) {
                 reject(new Error(response.statusText));
             }
-
-            response.json().then(results => {
-                resolve(results);
-            });
-        }).catch(error => reject(error));
+            else {
+                response.json().then(results => {
+                    resolve(results);
+                });
+            }
+        })
+        .catch(error => reject(error));
     });
 }
 
@@ -82,24 +86,25 @@ export function get(params, nextRange: number = 0) {
             if (response.status >= 400) {
                 reject(new Error(response.statusText));
             }
+            else {
+                response.json().then(resultsObj => {
+                    let results;
 
-            response.json().then(resultsObj => {
-                let results;
+                    const endRange = parseInt(resultsObj.range_end, 10);
+                    const totalCount = parseInt(resultsObj.total_count, 10);
+                    const nextRange = totalCount > (endRange + 1) ? endRange + 1 : 0;
 
-                const endRange = parseInt(resultsObj.range_end, 10);
-                const totalCount = parseInt(resultsObj.total_count, 10);
-                const nextRange = totalCount > (endRange + 1) ? endRange + 1 : 0;
+                    if (resultsObj["package_list"]) {
+                        results = resultsObj["package_list"];
+                    } else {
+                        results = resultsObj;
+                    }
 
-                if (resultsObj["package_list"]) {
-                    results = resultsObj["package_list"];
-                } else {
-                    results = resultsObj;
-                }
-
-                resolve({ results, totalCount, nextRange });
-            });
-
-        }).catch(error => reject(error));
+                    resolve({ results, totalCount, nextRange });
+                });
+            }
+        })
+        .catch(error => reject(error));
     });
 }
 
@@ -111,11 +116,13 @@ export function getPackageVersions(origin: string, pkg: string) {
             if (response.status >= 400) {
                 reject(new Error(response.statusText));
             }
-
-            response.json().then(results => {
-                resolve(results);
-            });
-        }).catch(error => reject(error));
+            else {
+                response.json().then(results => {
+                    resolve(results);
+                });
+            }
+        })
+        .catch(error => reject(error));
     });
 }
 

--- a/components/builder-web/app/header/HeaderComponent.ts
+++ b/components/builder-web/app/header/HeaderComponent.ts
@@ -63,7 +63,7 @@ import config from "../config";
             </li>
             <li class="main-nav--link">
               <a class="depot"
-                [routerLink]="['/']"
+                [routerLink]="['/pkgs']"
                 [class.is-current-page]="area === 'depot'">Depot</a>
             </li>
           </ul>

--- a/components/builder-web/app/origin-page/OriginPageComponent.ts
+++ b/components/builder-web/app/origin-page/OriginPageComponent.ts
@@ -73,7 +73,7 @@ export enum KeyType {
                   <div *ngIf="!noPackages">
                     <div class="pkg-container">
                         <div class="pkg-col-1">Package Name</div>
-                        <div class="pkg-col-2">Build Settings</div>
+                        <div class="pkg-col-2">&nbsp;</div>
                         <div class="pkg-col-3">Versions</div>
                     </div>
 
@@ -82,13 +82,7 @@ export enum KeyType {
                         <h3>{{pkg.name}}</h3>
                       </div>
                       <div class="pkg-col-2">
-                        <a href (click)="projectSettings(pkg)" *ngIf="projectForPackage(pkg) === projectStatus.Settings">
-                          <img src="../assets/images/icon-gear.svg" alt="Settings" title="Settings">
-                        </a>
-                        <a href (click)="linkToRepo(pkg)" *ngIf="projectForPackage(pkg) === projectStatus.Connect">
-                          <img src="../assets/images/icon-link.svg" alt="Connect a Repo" title="Connect a Repo">
-                        </a>
-                        <img src="../assets/images/icon-gear.svg" alt="Settings" title="Settings" class="disabled-settings" *ngIf="projectForPackage(pkg) === projectStatus.Lacking">
+                        &nbsp;
                       </div>
                       <div class="pkg-col-3">
                         <a [routerLink]="['/pkgs', pkg.origin, pkg.name]">

--- a/components/builder-web/app/package-builds/package-builds.component.html
+++ b/components/builder-web/app/package-builds/package-builds.component.html
@@ -4,7 +4,7 @@
       <hab-package-breadcrumbs [ident]="ident"></hab-package-breadcrumbs>
     </h2>
     <h4>
-      package
+      build history
     </h4>
   </div>
   <div class="page-body">

--- a/components/builder-web/app/package-page/PackagePageComponent.ts
+++ b/components/builder-web/app/package-page/PackagePageComponent.ts
@@ -19,24 +19,17 @@ import {AppStore} from "../AppStore";
 import {Package} from "../records/Package";
 import {Origin} from "../records/Origin";
 import {isPackage, isSignedIn} from "../util";
-import {fetchPackage, fetchProject, setProjectHint, requestRoute} from "../actions/index";
+import {fetchPackage, setProjectHint, requestRoute} from "../actions/index";
 import {BuilderApiClient} from "../BuilderApiClient";
 import {Subscription} from "rxjs/Subscription";
 
 @Component({
     template: `
     <div class="hab-package page-title">
-        <h2>Package</h2>
-        <h4>
-            <hab-package-breadcrumbs [ident]="package.ident">
-            </hab-package-breadcrumbs>
-        </h4>
-        <div class="builds" *ngIf="originParam === 'core'">
-            <a [routerLink]="['/pkgs', originParam, nameParam, 'builds']">Builds</a>
-        </div>
-        <hab-spinner [isSpinning]="ui.loading" [onClick]="spinnerFetchPackage">
-        </hab-spinner>
-        <button class="origin" (click)="viewOrigin()">View {{origin}} origin</button>
+        <h2>
+            <hab-package-breadcrumbs [ident]="package.ident"></hab-package-breadcrumbs>
+        </h2>
+        <h4 *ngIf="releaseParam">{{ releaseParam }}</h4>
     </div>
     <div *ngIf="!ui.loading && !ui.exists">
       <p>
@@ -46,27 +39,9 @@ import {Subscription} from "rxjs/Subscription";
           </span>
       </p>
     </div>
-    <div *ngIf="showRepoButton" class="project-header">
-      <button class="build-project-button" (click)="createProject()">Connect a repo</button> As a member of the {{origin}} origin, you can setup automated builds for this package by connecting a repo.
-    </div>
     <div class="page-body has-sidebar">
       <hab-package-info [package]="package"></hab-package-info>
     </div>
-    <hab-tabs *ngIf="!ui.loading && ui.exists && projectExists">
-      <hab-tab tabTitle="Info">
-        <div class="page-body has-sidebar">
-          <hab-package-info [package]="package"></hab-package-info>
-        </div>
-      </hab-tab>
-      <hab-tab tabTitle="Builds">
-        <div class="builds">
-        </div>
-      </hab-tab>
-      <hab-tab tabTitle="Settings">
-        <div class="settings">
-        </div>
-      </hab-tab>
-    </hab-tabs>
     `,
 })
 
@@ -88,7 +63,6 @@ export class PackagePageComponent implements OnDestroy {
             this.versionParam = params["version"];
             this.releaseParam = params["release"];
             this.fetchPackage();
-            this.fetchProject();
         });
     }
 
@@ -135,20 +109,8 @@ export class PackagePageComponent implements OnDestroy {
         return this.store.getState().packages.ui.current;
     }
 
-    get projectExists() {
-        return this.project !== undefined;
-    }
-
     get memberOfOrigin() {
         return this.store.getState().origins.mine.includes(Origin({name: this.package.ident.origin}));
-    }
-
-    get showRepoButton() {
-        return !this.ui.loading && this.ui.exists && !this.projectExists && this.memberOfOrigin;
-    }
-
-    viewOrigin() {
-        this.store.dispatch(requestRoute(["/origins", this.origin]));
     }
 
     createProject() {
@@ -170,11 +132,5 @@ export class PackagePageComponent implements OnDestroy {
 
     private fetchPackage () {
         this.store.dispatch(fetchPackage(this.package));
-    }
-
-    private fetchProject() {
-        if (isSignedIn()) {
-            this.store.dispatch(fetchProject(this.projectId, this.token, false));
-        }
     }
 }

--- a/components/builder-web/app/packages-list/PackagesListComponent.ts
+++ b/components/builder-web/app/packages-list/PackagesListComponent.ts
@@ -14,6 +14,7 @@
 
 import { Component, Input } from "@angular/core";
 import { List } from "immutable";
+import { packageString } from "../util";
 
 @Component({
     selector: "hab-packages-list",
@@ -21,7 +22,25 @@ import { List } from "immutable";
 })
 
 export class PackagesListComponent {
+    @Input() errorMessage: string;
     @Input() noPackages: boolean;
     @Input() packages: List<Object>;
-    @Input() errorMessage: string;
+    @Input() versions: List<Object>;
+    @Input() layout: string;
+
+    routeFor(pkg) {
+        let link = ["/pkgs", pkg.origin];
+
+        [pkg.name, pkg.version, pkg.release].forEach((p) => {
+            if (p) {
+                link.push(p);
+            }
+        });
+
+        return link;
+    }
+
+    packageString(pkg) {
+        return packageString(pkg);
+    }
 }

--- a/components/builder-web/app/packages-list/_packages-list.component.scss
+++ b/components/builder-web/app/packages-list/_packages-list.component.scss
@@ -1,0 +1,162 @@
+.hab-packages-list {
+
+  .pkg-versions {
+    li.heading {
+      @include row;
+
+      border-bottom: 1px solid $very-light-gray;
+      padding: 1em 1.5em;
+
+      h3 {
+        text-transform: uppercase;
+      }
+
+      .name {
+        @include span-columns(2);
+      }
+
+      .build-count {
+        @include span-columns(2);
+        text-align: center;
+      }
+
+      .latest-release {
+        @include span-columns(2);
+        @include omega;
+        text-align: center;
+      }
+    }
+  }
+
+  .pkg-builds {
+
+    li.heading {
+      @include row;
+
+      border-bottom: 1px solid $very-light-gray;
+      padding: 1em 1.5em;
+
+      h3 {
+        text-transform: uppercase;
+      }
+
+      .name {
+        @include span-columns(4);
+      }
+
+      .completed {
+        @include span-columns(2);
+        @include omega;
+        text-align: center;
+      }
+    }
+
+    .hab-packages-package {
+
+      a {
+        @include row;
+        @include transform(none);
+
+        border-radius: 0;
+        border: none;
+        border-bottom: 1px solid $very-light-gray;
+
+        &:hover {
+          box-shadow: none;
+          background-color: rgba($medium-gray, 0.05);
+        }
+
+        .name {
+          @include span-columns(4);
+        }
+
+        .completed {
+          @include span-columns(2);
+          @include omega;
+          text-align: center;
+        }
+      }
+    }
+  }
+
+  li {
+    position: relative;
+    cursor: pointer;
+    font-size: rem(12);
+
+    a {
+      display: block;
+
+      .octicon-chevron-right {
+        position: absolute;
+        display: none;
+        right: 24px;
+        top: 50%;
+        transform: translateY(-50%);
+      }
+
+      &:hover {
+
+        .octicon-chevron-right {
+          display: block;
+        }
+      }
+
+      .name {
+        font-family: $heading-font-family;
+      }
+
+      hab-build-status {
+
+        .octicon {
+          position: absolute;
+          right: 52px;
+          top: 50%;
+          transform: translateY(-50%);
+        }
+      }
+    }
+
+    &.hab-packages-package {
+
+      .name {
+
+        &.large {
+          font-size: rem(16);
+        }
+      }
+    }
+
+    &.hab-packages-version {
+
+      a {
+        @include row;
+        @include transform(none);
+
+        border-radius: 0;
+        border: none;
+        border-bottom: 1px solid $very-light-gray;
+
+        &:hover {
+          box-shadow: none;
+          background-color: rgba($medium-gray, 0.05);
+        }
+
+        .name {
+          @include span-columns(2);
+        }
+
+        .build-count {
+          @include span-columns(2);
+          text-align: center;
+        }
+
+        .latest-release {
+          @include span-columns(2);
+          @include omega;
+          text-align: center;
+        }
+      }
+    }
+  }
+}

--- a/components/builder-web/app/packages-list/packages-list.component.html
+++ b/components/builder-web/app/packages-list/packages-list.component.html
@@ -1,4 +1,4 @@
-<ul class="hab-packages-plan-list">
+<ul class="hab-packages-list">
     <div *ngIf="noPackages">
         <p>
         No packages found.
@@ -7,21 +7,50 @@
         </span>
         </p>
     </div>
-    <li class="hab-packages-package" *ngFor="let pkg of packages">
-        <a [routerLink]="['/pkgs', pkg.origin,
-        pkg.name,
-        'versions']">
-            <div class="item-title">
-                <h3>{{pkg.origin}} / {{pkg.name}}</h3>
-            </div>
-            <div class="item-info">
-                <span class="count" *ngIf="pkg.starCount">
-                    <!-- TODO: import octicons -->
-                    <span class="octicon octicon-star"></span>
-                    {{pkg.starCount}}
+    <div *ngIf="layout === 'versions'" class="pkg-{{ layout }}">
+        <li class="heading">
+            <h3 class="name">Version</h3>
+            <h3 class="build-count">Builds</h3>
+            <h3 class="latest-release">Latest</h3>
+        </li>
+        <li class="hab-packages-version" *ngFor="let version of versions">
+            <a [routerLink]="routeFor(version)">
+                <span class="name">
+                    {{ version.version }}
                 </span>
-                <img src="/node_modules/octicons/svg/chevron-right.svg" />
-            </div>
-        </a>
-    </li>
+                <span class="build-count">
+                    {{ version.release_count }}
+                </span>
+                <span class="latest-release">
+                    {{ version.latest }}
+                </span>
+                <hab-build-status
+                    [origin]="version.origin"
+                    [name]="version.name"
+                    [version]="version.version"></hab-build-status>
+                <div class="octicon octicon-chevron-right"></div>
+            </a>
+        </li>
+    </div>
+    <div class="pkg-{{ layout }}">
+        <li *ngIf="layout === 'builds'" class="heading">
+            <h3 class="name">Build</h3>
+            <h3 class="completed">Completed</h3>
+        </li>
+        <li class="hab-packages-package" *ngFor="let pkg of packages" (click)="select(pkg)">
+            <a [routerLink]="routeFor(pkg)">
+                <span class="name" [class.large]="!pkg.version">
+                    {{ packageString(pkg) }}
+                </span>
+                <span *ngIf="layout === 'builds'" class="completed">
+                    {{ pkg.release }}
+                </span>
+                <hab-build-status
+                    [origin]="pkg.origin"
+                    [name]="pkg.name"
+                    [version]="pkg.version"></hab-build-status>
+                <div class="octicon octicon-chevron-right"></div>
+            </a>
+        </li>
+    </div>
 </ul>

--- a/components/builder-web/app/packages-page/_packages-page.scss
+++ b/components/builder-web/app/packages-page/_packages-page.scss
@@ -14,6 +14,38 @@
 
 .hab-packages {
 
+  .active {
+    @include row;
+
+    line-height: rem(42);
+    border-radius: 7px;
+    font-size: rem(14);
+    padding: 0 12px;
+    margin-bottom: 22px;
+
+    a {
+      text-decoration: underline;
+    }
+
+    &.dispatched, &.processing {
+      border: 1px solid $hab-orange;
+      color: $hab-orange;
+
+      a {
+        color: $hab-orange;
+      }
+    }
+
+    &.pending {
+      border: 1px solid $hab-blue;
+      color: $hab-blue;
+
+      a {
+        color: $hab-blue;
+      }
+    }
+  }
+
   .builds {
     font-family: $heading-font-family;
     font-size: rem(12);
@@ -35,7 +67,7 @@
     float: right;
   }
 
-  &-plan-list {
+  &-list {
     li a {
       @extend .hab-item-list;
     }

--- a/components/builder-web/app/packages-page/packages-page.component.spec.ts
+++ b/components/builder-web/app/packages-page/packages-page.component.spec.ts
@@ -2,7 +2,9 @@ import { DebugElement } from "@angular/core";
 import { TestBed, ComponentFixture } from "@angular/core/testing";
 import { ReactiveFormsModule } from "@angular/forms";
 import { By } from "@angular/platform-browser";
+import { ActivatedRoute } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
+import { Observable } from "rxjs";
 import { MockComponent } from "ng2-mock-component";
 import { AppStore } from "../AppStore";
 import { PackagesPageComponent } from "./PackagesPageComponent";
@@ -10,9 +12,20 @@ import { PackagesPageComponent } from "./PackagesPageComponent";
 class MockAppStore {
   getState() {
     return {
-      packages: []
+      packages: [],
+      gitHub: {
+        authToken: undefined
+      }
     };
   }
+}
+
+class MockRoute {
+  get params() {
+    return {
+      subscribe: () => {}
+    };
+  };
 }
 
 describe("PackagesPageComponent", () => {
@@ -31,16 +44,18 @@ describe("PackagesPageComponent", () => {
         MockComponent({ selector: "hab-spinner", inputs: ["isSpinning"] }),
         MockComponent({
           selector: "hab-packages-list",
-          inputs: ["noPackages", "packages", "errorMessage"]
+          inputs: [ "errorMessage", "noPackages", "packages", "versions" ]
         }),
         PackagesPageComponent
       ],
       providers: [
-        { provide: AppStore, useClass: MockAppStore }
+        { provide: AppStore, useClass: MockAppStore },
+        { provide: ActivatedRoute, useClass: MockRoute }
       ]
     });
 
     fixture = TestBed.createComponent(PackagesPageComponent);
+    component = fixture.componentInstance;
     element = fixture.debugElement;
   });
 

--- a/components/builder-web/app/reducers/builds.ts
+++ b/components/builder-web/app/reducers/builds.ts
@@ -1,4 +1,5 @@
 import { List, Record } from "immutable";
+import * as AnsiUp from "ansi_up";
 import * as actionTypes from "../actions/index";
 import initialState from "../initialState";
 
@@ -31,11 +32,16 @@ export default function builds(state = initialState["builds"], action) {
             }
 
             let content = ((payload.start === 0) ? [] : state.get("selected").log.content) || [];
+            let appended = content.concat(payload.content);
+
+            let asHTML = appended.map((line) => {
+                return AnsiUp.ansi_to_html(line);
+            });
 
             return state.setIn(["selected", "log"], {
                 start: payload.start,
                 stop: payload.stop,
-                content: content.concat(payload.content),
+                content: asHTML,
                 is_complete: payload.is_complete
             });
 

--- a/components/builder-web/app/routes.spec.ts
+++ b/components/builder-web/app/routes.spec.ts
@@ -80,16 +80,9 @@ describe("Routes", () => {
   });
 
   describe("/pkgs", () => {
-    it("routes to PackagesPageComponent", () => {
+    it("redirects to /pkgs/core", () => {
       let r = route("pkgs");
-      expect(r.component).toBe(PackagesPageComponent);
-    });
-  });
-
-  describe("/pkgs/*/:name", () => {
-    it("routes to PackagesPageComponent", () => {
-      let r = route("pkgs/*/:name");
-      expect(r.component).toBe(PackagesPageComponent);
+      expect(r.redirectTo).toBe("/pkgs/core");
     });
   });
 

--- a/components/builder-web/app/routes.ts
+++ b/components/builder-web/app/routes.ts
@@ -60,27 +60,7 @@ export const routes: Routes = [
         component: OriginPageComponent,
     },
     {
-        path: "orgs",
-        component: OrganizationsPageComponent,
-    },
-    {
-        path: "orgs/create",
-        component: OrganizationCreatePageComponent,
-    },
-    {
-        path: "pkgs",
-        component: PackagesPageComponent
-    },
-    {
-        path: "pkgs/*/:name",
-        component: PackagesPageComponent
-    },
-    {
-        path: "pkgs/:origin",
-        component: PackagesPageComponent
-    },
-    {
-        path: "pkgs/:origin/:name",
+        path: "pkgs/search/:query",
         component: PackagesPageComponent,
     },
     {
@@ -88,20 +68,28 @@ export const routes: Routes = [
         component: PackageBuildsComponent
     },
     {
-        path: "pkgs/:origin/:name/versions",
-        component: PackageVersionsPageComponent,
+        path: "pkgs/:origin/:name/:version/:release",
+        component: PackagePageComponent
     },
     {
         path: "pkgs/:origin/:name/:version",
         component: PackagesPageComponent,
     },
     {
-        path: "pkgs/search/:query",
-        component: PackagesPageComponent,
+        path: "pkgs/:origin/:name",
+        component: PackagesPageComponent
     },
     {
-        path: "pkgs/:origin/:name/:version/:release",
-        component: PackagePageComponent
+        path: "pkgs/:origin",
+        component: PackagesPageComponent
+    },
+    {
+        path: "pkgs",
+        redirectTo: "/pkgs/core"
+    },
+    {
+        path: "sign-in",
+        component: SignInPageComponent
     },
     {
         path: "projects",
@@ -123,9 +111,15 @@ export const routes: Routes = [
         path: "scm-repos",
         component: SCMReposPageComponent,
     },
+
+    // TODO: Remove these and their associated actions and reducers.
     {
-        path: "sign-in",
-        component: SignInPageComponent
+        path: "orgs",
+        component: OrganizationsPageComponent,
+    },
+    {
+        path: "orgs/create",
+        component: OrganizationCreatePageComponent,
     }
 ];
 

--- a/components/builder-web/app/side-nav/SideNavComponent.ts
+++ b/components/builder-web/app/side-nav/SideNavComponent.ts
@@ -28,11 +28,10 @@ import config from "../config";
             </li>
             <li *ngIf="isSignedIn">
                 <a [routerLink]="['/origins']"
-                    routerLinkActive="active"
-                    [routerLinkActiveOptions]="{exact: true}">My Origins</a>
+                    routerLinkActive="active">My Origins</a>
             </li>
             <li>
-                <a [routerLink]="['/pkgs', 'core']"
+                <a [routerLink]="['/pkgs']"
                     routerLinkActive="active">Search Packages</a>
             </li>
         </ul>

--- a/components/builder-web/stylesheets/_mixins.scss
+++ b/components/builder-web/stylesheets/_mixins.scss
@@ -70,12 +70,14 @@
 
 %social-icons {
   .social {
+
     li {
-      margin-bottom: .625rem;
+      margin-bottom: 0.625rem;
     }
+
     a {
+      background: url("/assets/images/icons-social.svg") no-repeat;
       padding-left: 1.875rem;
-      background: url('/assets/images/icons-social.svg') no-repeat;
 
       &.github {
         background-position: left top;

--- a/components/builder-web/stylesheets/base/_typography.scss
+++ b/components/builder-web/stylesheets/base/_typography.scss
@@ -42,7 +42,7 @@ h1 {
 }
 
 h2 {
-  font-size: 125%;
+  font-size: 140%;
 
   .page-title & {
     margin: rem(20) 0 0;


### PR DESCRIPTION
This PR fixes navigating between package views and adds build-status indicators where possible for signed-in users. Also adds support for rendering ANSI-colored build logs.

![](http://i.giphy.com/3odn2RCIzApoY.gif)

Signed-off-by: Christian Nunciato <cnunciato@chef.io>