### PR TITLE
Fix log-streaming performance

### DIFF
--- a/components/builder-web/app/actions/builds.ts
+++ b/components/builder-web/app/actions/builds.ts
@@ -59,11 +59,13 @@ export function fetchBuildLog(id: string, token: string, start = 0) {
       .then((data) => {
           dispatch(populateBuildLog(data));
 
-          if (data["is_complete"] && start !== 0) {
+          let complete = data["is_complete"];
+
+          if (complete && data["start"] !== 0) {
             setTimeout(() => { dispatch(fetchBuild(id, token)); }, 5000);
           }
-          else if (getState().builds.selected.stream) {
-            setTimeout(() => { dispatch(fetchBuildLog(id, token, data["stop"])); }, 1000);
+          else if (!complete && getState().builds.selected.stream) {
+            setTimeout(() => { dispatch(fetchBuildLog(id, token, data["stop"])); }, 2000);
           }
       })
       .catch((error) => dispatch(populateBuildLog(null, error)));

--- a/components/builder-web/app/app.module.ts
+++ b/components/builder-web/app/app.module.ts
@@ -18,6 +18,8 @@ import { BrowserModule } from "@angular/platform-browser";
 import { routing } from "./routes";
 import { AppStore } from "./AppStore";
 import { AppComponent } from "./AppComponent";
+import { BuildComponent } from "./build/build.component";
+import { BuildStatusComponent } from "./build-status/build-status.component";
 import { CheckingInputComponent } from "./CheckingInputComponent";
 import { FormsModule, ReactiveFormsModule } from "@angular/forms";
 import { DashboardComponent } from "./dashboard/dashboard.component";
@@ -39,8 +41,6 @@ import { OrganizationCreatePageComponent } from "./organization-create-page/Orga
 import { OrganizationMembersComponent } from "./organization-members/OrganizationMembersComponent";
 import { OrganizationsPageComponent } from "./organizations-page/OrganizationsPageComponent";
 import { PackageBreadcrumbsComponent } from "./PackageBreadcrumbsComponent";
-import { BuildComponent } from "./build/build.component";
-import { BuildStatusComponent } from "./build-status/build-status.component";
 import { PackageBuildsComponent } from "./package-builds/package-builds.component";
 import { PackageInfoComponent } from "./package-info/PackageInfoComponent";
 import { PackageListComponent } from "./package-page/PackageListComponent";

--- a/components/builder-web/app/build/build.component.html
+++ b/components/builder-web/app/build/build.component.html
@@ -34,6 +34,6 @@
         </div>
       </div>
     </div>
-    <pre class="output" [innerHTML]="log"></pre>
+    <pre class="output"></pre>
   </div>
 </div>

--- a/components/builder-web/app/build/build.component.spec.ts
+++ b/components/builder-web/app/build/build.component.spec.ts
@@ -3,7 +3,7 @@ import { Component, DebugElement } from "@angular/core";
 import { By } from "@angular/platform-browser";
 import { ActivatedRoute, Router } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
-import { Observable } from "rxjs";
+import { BehaviorSubject, Observable } from "rxjs";
 import { Record } from "immutable";
 import { MockComponent } from "ng2-mock-component";
 import { AppStore } from "../AppStore";
@@ -20,7 +20,7 @@ class MockAppStore {
             id: "123"
           },
           log: {
-            content: []
+            content: new BehaviorSubject([])
           }
         })()
       },

--- a/components/builder-web/app/initialState.ts
+++ b/components/builder-web/app/initialState.ts
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {List, Map, Record} from "immutable";
-import {Origin} from "./records/Origin";
+import { List, Map, Record } from "immutable";
+import { BehaviorSubject } from "rxjs";
+import { Origin } from "./records/Origin";
 
 export default Record({
     app: Record({
@@ -53,7 +54,7 @@ export default Record({
             log: Record({
                 start: undefined,
                 stop: undefined,
-                content: undefined,
+                content: new BehaviorSubject([]),
                 is_complete: undefined,
                 stream: undefined
             })(),


### PR DESCRIPTION
Currently the build log is being rendered with Angular’s default change-detection behavior, which is causing it to be rendered much more often than it needs to be. This change adds an RxJS BehaviorSubject to allow subscribers to be notified when log segments are received, and updates the log component to append only those segments, rather than replace its content completely. Also drops back to two seconds just to go a little easier on the network calls.

![image](https://cloud.githubusercontent.com/assets/274700/26166309/f1b0eda0-3ae7-11e7-9486-bc5dd07c982f.png)

![](https://i.giphy.com/ncSGNAHEz6L6g.gif)

Signed-off-by: Christian Nunciato <cnunciato@chef.io>