### PR TITLE
prevent "API API" in raml titles

### DIFF
--- a/components/sup/doc/api.raml
+++ b/components/sup/doc/api.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 ---
-title: Habitat Supervisor API
+title: Habitat Supervisor
 
 baseUri: http://{rootUri}
 baseUriParameters:


### PR DESCRIPTION
The `raml2html` generator puts the string "API documentation" at the end of the title, so this will stop the word "API" from being repeated.