### PR TITLE
Add a Build Output tab to the manifest view

### DIFF
--- a/components/builder-web/app/actions/builds.ts
+++ b/components/builder-web/app/actions/builds.ts
@@ -3,7 +3,6 @@ import { BuilderApiClient } from "../BuilderApiClient";
 export const CLEAR_BUILD = "CLEAR_BUILD";
 export const CLEAR_BUILD_LOG = "CLEAR_BUILD_LOG";
 export const CLEAR_BUILDS = "CLEAR_BUILDS";
-export const FETCH_BUILDS = "FETCH_BUILDS";
 export const POPULATE_BUILD = "POPULATE_BUILD";
 export const POPULATE_BUILDS = "POPULATE_BUILDS";
 export const POPULATE_BUILD_LOG = "POPULATE_BUILD_LOG";

--- a/components/builder-web/app/actions/packages.ts
+++ b/components/builder-web/app/actions/packages.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { groupBy, map } from "lodash";
+import { groupBy } from "lodash";
 import * as depotApi from "../depotApi";
 import * as fakeApi from "../fakeApi";
 import { fetchProjectsForPackages } from "./projects";
@@ -152,7 +152,7 @@ export function filterPackagesBy(
 }
 
 export function populateDashboardRecent(data) {
-    let grouped = groupBy(data.results, "name");
+    let grouped = groupBy(data.results.reverse(), "name");
     let mapped = [];
 
     for (let k in grouped) {

--- a/components/builder-web/app/app.module.ts
+++ b/components/builder-web/app/app.module.ts
@@ -19,6 +19,7 @@ import { routing } from "./routes";
 import { AppStore } from "./AppStore";
 import { AppComponent } from "./AppComponent";
 import { BuildComponent } from "./build/build.component";
+import { BuildPageComponent } from "./build-page/build-page.component";
 import { BuildStatusComponent } from "./build-status/build-status.component";
 import { CheckingInputComponent } from "./CheckingInputComponent";
 import { FormsModule, ReactiveFormsModule } from "@angular/forms";
@@ -70,6 +71,8 @@ import { UserNavComponent } from "./header/user-nav/UserNavComponent";
     ],
     declarations: [
         AppComponent,
+        BuildComponent,
+        BuildPageComponent,
         BuildListComponent,
         BuildStatusComponent,
         CheckingInputComponent,
@@ -91,7 +94,6 @@ import { UserNavComponent } from "./header/user-nav/UserNavComponent";
         OrganizationMembersComponent,
         OrganizationsPageComponent,
         PackageBreadcrumbsComponent,
-        BuildComponent,
         PackageBuildsComponent,
         PackageInfoComponent,
         PackageListComponent,

--- a/components/builder-web/app/app.scss
+++ b/components/builder-web/app/app.scss
@@ -30,6 +30,7 @@
 @import "github-repo-picker/github-repo-picker";
 @import "header/header";
 @import "header/user-nav/user-nav";
+@import "build/build.component";
 @import "build-list/build-list.component";
 @import "build-status/build-status.component";
 @import "notifications/notifications";
@@ -38,7 +39,6 @@
 @import "organization-create-page/organization-create-page";
 @import "organization-members/organization-members";
 @import "organizations-page/organizations-page";
-@import "build/build.component";
 @import "package-builds/package-builds.component";
 @import "package-page/package-page";
 @import "package-versions-page/package-versions-page";

--- a/components/builder-web/app/build-page/build-page.component.html
+++ b/components/builder-web/app/build-page/build-page.component.html
@@ -1,0 +1,13 @@
+<div>
+  <div class="page-title">
+    <h2>
+      <hab-package-breadcrumbs [ident]="ident"></hab-package-breadcrumbs>
+    </h2>
+    <h4>
+      build
+    </h4>
+  </div>
+  <div class="page-body">
+    <hab-build [build]="build" stream="true"></hab-build>
+  </div>
+</div>

--- a/components/builder-web/app/build-page/build-page.component.ts
+++ b/components/builder-web/app/build-page/build-page.component.ts
@@ -1,0 +1,52 @@
+import { Component, OnInit, OnDestroy } from "@angular/core";
+import { ActivatedRoute } from "@angular/router";
+import { Subscription } from "rxjs";
+import { fetchBuild } from "../actions/index";
+import { requireSignIn } from "../util";
+import { AppStore } from "../AppStore";
+
+@Component({
+  template: require("./build-page.component.html")
+})
+export class BuildPageComponent implements OnInit, OnDestroy {
+    private routeSub: Subscription;
+
+    constructor(
+        private store: AppStore,
+        private route: ActivatedRoute) {
+        requireSignIn(this);
+    }
+
+    ngOnInit() {
+        this.routeSub = this.route.params.subscribe((p) => {
+            this.store.dispatch(fetchBuild(p.id, this.token));
+        });
+    }
+
+    ngOnDestroy() {
+        if (this.routeSub) {
+            this.routeSub.unsubscribe();
+        }
+    }
+
+    get build() {
+      return this.store.getState().builds.selected.info;
+    }
+
+    get ident() {
+        return {
+            origin: this.info.origin,
+            name: this.info.name,
+            version: this.info.version,
+            release: this.info.release
+        };
+    }
+
+    get info() {
+        return this.store.getState().builds.selected.info;
+    }
+
+    get token() {
+      return this.store.getState().gitHub.authToken;
+    }
+}

--- a/components/builder-web/app/build/_build.component.scss
+++ b/components/builder-web/app/build/_build.component.scss
@@ -1,106 +1,96 @@
-.hab-package-job {
+.hab-build {
 
-  .page-title {
+  .back {
+    margin-bottom: 20px;
+    color: $medium-gray;
+    font-size: rem(14);
 
-    h4 {
-      font-weight: normal;
-      text-transform: none;
+    a {
+      color: $medium-gray;
     }
   }
 
-  .page-body {
+  .summary {
+    @include row;
+    border: 1px solid $very-light-gray;
+    border-radius: 7px;
+    padding: 14px;
+    font-size: rem(12);
+    color: $dark-gray;
+    margin-bottom: 20px;
 
-    .back {
-      margin-bottom: 20px;
-      color: $medium-gray;
+    .status {
+      @include span-columns(6);
+      position: relative;
       font-size: rem(14);
 
-      a {
-        color: $medium-gray;
-      }
-    }
-
-    .summary {
-      @include row;
-      border: 1px solid $very-light-gray;
-      border-radius: 7px;
-      padding: 14px;
-      font-size: rem(12);
-      color: $dark-gray;
-      margin-bottom: 20px;
-
-      .status {
-        @include span-columns(6);
-        position: relative;
-        font-size: rem(14);
-
-        strong {
-          padding-left: 26px;
-        }
-
-        .octicon {
-          font-size: rem(20);
-          position: absolute;
-
-          &.complete {
-            color: $hab-green;
-          }
-
-          &.dispatched, &.processing {
-            color: $hab-orange;
-            height: rem(20);
-            width: rem(16);
-            animation-duration: 1s;
-            animation-iteration-count: infinite;
-            animation-name: spinning;
-            animation-timing-function: linear;
-          }
-
-          &.pending {
-            color: $hab-blue;
-          }
-
-          &.failed, &.rejected {
-            color: $hab-red;
-          }
-
-          @keyframes spinning {
-            from {
-              transform: rotate(0deg);
-            }
-
-            to {
-              transform: rotate(360deg);
-            }
-          }
-        }
+      strong {
+        padding-left: 26px;
+        color: $dim-slate-gray;
       }
 
-      .detail {
-        @include span-columns(6);
+      .octicon {
+        font-size: rem(20);
+        position: absolute;
 
-        .item {
+        &.complete {
+          color: $hab-green;
+        }
 
-          .label {
-            @include span-columns(1 of 6);
-            font-weight: 600;
+        &.dispatched, &.processing {
+          color: $hab-orange;
+          height: rem(20);
+          width: rem(16);
+          animation-duration: 1s;
+          animation-iteration-count: infinite;
+          animation-name: spinning;
+          animation-timing-function: linear;
+        }
+
+        &.pending {
+          color: $hab-blue;
+        }
+
+        &.failed, &.rejected {
+          color: $hab-red;
+        }
+
+        @keyframes spinning {
+          from {
+            transform: rotate(0deg);
           }
 
-          .data {
-            @include span-columns(5 of 6);
+          to {
+            transform: rotate(360deg);
           }
         }
       }
     }
 
-    .output {
-      font-family: $monospace-font-family;
-      font-size: $monospace-font-size;
-      @include pad($base-spacing);
-      background: $hab-gray-dark;
-      border-radius: $global-radius;
-      color: $medium-gray;
-      overflow: auto;
+    .detail {
+      @include span-columns(6);
+
+      .item {
+
+        .label {
+          @include span-columns(1 of 6);
+          font-weight: 600;
+        }
+
+        .data {
+          @include span-columns(5 of 6);
+        }
+      }
     }
+  }
+
+  .output {
+    font-family: $monospace-font-family;
+    font-size: $monospace-font-size;
+    @include pad($base-spacing);
+    background: $hab-gray-dark;
+    border-radius: $global-radius;
+    color: $medium-gray;
+    overflow: auto;
   }
 }

--- a/components/builder-web/app/build/build.component.html
+++ b/components/builder-web/app/build/build.component.html
@@ -1,39 +1,25 @@
-<div class="hab-package-job">
-  <div class="page-title">
-    <h2>
-      <hab-package-breadcrumbs [ident]="ident"></hab-package-breadcrumbs>
-    </h2>
-    <h4>
-      build
-    </h4>
+<div class="hab-build">
+  <div class="back">
+    <a [routerLink]="buildsLink">
+      <span class="octicon octicon-chevron-left"></span>
+      Back to build history
+    </a>
   </div>
-  <div class="page-body">
-    <div class="back">
-      <a [routerLink]="['/pkgs', ident.origin, ident.name, 'builds']">
-        <span class="octicon octicon-chevron-left"></span>
-        Back to build history
-      </a>
+  <div class="summary" *ngIf="info.state">
+    <div class="status">
+      <div class="octicon octicon-{{ iconFor(info.state) }} {{ info.state | lowercase }}"></div>
+      <strong>Build {{ info.state }}</strong>
     </div>
-    <div class="summary" *ngIf="info.state">
-      <div class="status">
-        <div class="octicon octicon-{{ iconFor(info.state) }} {{ info.state | lowercase }}"></div>
-        <strong>Build {{ info.state }}</strong>
+    <div class="detail">
+      <div class="item">
+        <div class="label">Build Time</div>
+        <div class="data">{{ elapsed || "&mdash;" }}</div>
       </div>
-      <div class="detail">
-        <div class="item">
-          <div class="label">Created</div>
-          <div class="data">{{ info.created_at || "&mdash;" }}</div>
-        </div>
-        <div class="item">
-          <div class="label">Started</div>
-          <div class="data">{{ info.build_started_at || "&mdash;" }}</div>
-        </div>
-        <div class="item">
-          <div class="label">Finished</div>
-          <div class="data">{{ info.build_finished_at || "&mdash;" }}</div>
-        </div>
+      <div class="item">
+        <div class="label">Completed</div>
+        <div class="data">{{ completed || "&mdash;" }}</div>
       </div>
     </div>
-    <pre class="output"></pre>
   </div>
+  <pre class="output"></pre>
 </div>

--- a/components/builder-web/app/build/build.component.spec.ts
+++ b/components/builder-web/app/build/build.component.spec.ts
@@ -32,14 +32,6 @@ class MockAppStore {
   dispatch() {}
 }
 
-class MockRoute {
-  params = Observable.of({
-    origin: "core",
-    name: "nginx",
-    id: "123"
-  });
-}
-
 describe("BuildComponent", () => {
   let fixture: ComponentFixture<BuildComponent>;
   let component: BuildComponent;
@@ -58,8 +50,7 @@ describe("BuildComponent", () => {
         MockComponent({ selector: "hab-package-breadcrumbs", inputs: [ "ident" ] })
       ],
       providers: [
-        { provide: AppStore, useClass: MockAppStore },
-        { provide: ActivatedRoute, useClass: MockRoute }
+        { provide: AppStore, useClass: MockAppStore }
       ]
     });
 
@@ -75,32 +66,67 @@ describe("BuildComponent", () => {
 
   describe("on init", () => {
 
-    it("fetches the specified build", () => {
-      spyOn(actions, "fetchBuild");
-      fixture.detectChanges();
-
-      expect(actions.fetchBuild).toHaveBeenCalledWith(
-        store.getState().builds.selected.info.id,
-        store.getState().gitHub.authToken
-      );
+    beforeEach(() => {
+      component.build = {
+        origin: "core",
+        name: "nginx",
+        id: "123"
+      };
     });
+  });
 
-    it("fetches the specified build log", () => {
-      spyOn(actions, "fetchBuildLog");
-      fixture.detectChanges();
+  describe("on changes", () => {
 
-      expect(actions.fetchBuildLog).toHaveBeenCalledWith(
-        store.getState().builds.selected.info.id,
-        store.getState().gitHub.authToken,
-        0
-      );
-    });
+    describe("when a build is provided", () => {
+      let changes;
 
-    it("initiates log streaming", () => {
-      spyOn(actions, "streamBuildLog");
-      fixture.detectChanges();
+      beforeEach(() => {
+        changes = {
+          build: {
+            currentValue: {
+              id: "123"
+            }
+          }
+        };
+      });
 
-      expect(actions.streamBuildLog).toHaveBeenCalledWith(true);
+      it("fetches the specified build log", () => {
+        spyOn(actions, "fetchBuildLog");
+        component.ngOnChanges(changes);
+
+        expect(actions.fetchBuildLog).toHaveBeenCalledWith(
+          store.getState().builds.selected.info.id,
+          store.getState().gitHub.authToken,
+          0
+        );
+      });
+
+      describe("log streaming", () => {
+
+        describe("by default", () => {
+
+          it("is set to false", () => {
+            spyOn(actions, "streamBuildLog");
+            component.ngOnChanges(changes);
+
+            expect(actions.streamBuildLog).toHaveBeenCalledWith(false);
+          });
+        });
+
+        describe("when requested", () => {
+
+          beforeEach(() => {
+            component.stream = true;
+          });
+
+          it("is set to true", () => {
+            spyOn(actions, "streamBuildLog");
+            component.ngOnChanges(changes);
+
+            expect(actions.streamBuildLog).toHaveBeenCalledWith(true);
+          });
+        });
+      });
     });
   });
 

--- a/components/builder-web/app/dashboard/_dashboard.component.scss
+++ b/components/builder-web/app/dashboard/_dashboard.component.scss
@@ -245,6 +245,11 @@
             font-weight: 600;
           }
 
+          .package-updated {
+            color: $dim-slate-gray;
+            font-size: rem(12);
+          }
+
           &:hover {
             cursor: pointer;
             background-color: rgba($very-light-gray, 0.2);
@@ -265,6 +270,7 @@
           &.heading {
 
             h5 {
+              color: $dark-gray;
               font-size: rem(12);
               text-transform: uppercase;
             }

--- a/components/builder-web/app/dashboard/dashboard.component.html
+++ b/components/builder-web/app/dashboard/dashboard.component.html
@@ -123,7 +123,7 @@
               <h5>Package</h5>
             </div>
             <div class="package-updated">
-              <h5>Last Update</h5>
+              <h5>Latest</h5>
             </div>
           </li>
           <li class="item" *ngFor="let pkg of myPackages" (click)="navigateToPackage(pkg)">
@@ -134,7 +134,7 @@
               {{ pkg.name }}
             </div>
             <div class="package-updated">
-              {{ fromNow(pkg.release) }}
+              {{ releaseToDate(pkg.release) }}
             </div>
             <span class="octicon octicon-chevron-right"></span>
           </li>

--- a/components/builder-web/app/dashboard/dashboard.component.ts
+++ b/components/builder-web/app/dashboard/dashboard.component.ts
@@ -3,7 +3,7 @@ import * as cookies from "js-cookie";
 import { AppStore } from "../AppStore";
 import { Router } from "@angular/router";
 import { fetchMyOrigins, fetchDashboardRecent } from "../actions";
-import * as moment from "moment";
+import { releaseToDate } from "../util";
 import config from "../config";
 
 @Component({
@@ -55,8 +55,8 @@ export class DashboardComponent implements OnInit {
         return this.store.getState().packages.dashboard.origin;
     }
 
-    fromNow(release) {
-        return moment(release, "YYYYMMDDHHmmss").fromNow();
+    releaseToDate(release) {
+        return releaseToDate(release);
     }
 
     showSection(section) {

--- a/components/builder-web/app/packages-list/PackagesListComponent.ts
+++ b/components/builder-web/app/packages-list/PackagesListComponent.ts
@@ -14,7 +14,7 @@
 
 import { Component, Input } from "@angular/core";
 import { List } from "immutable";
-import { packageString } from "../util";
+import { packageString, releaseToDate } from "../util";
 
 @Component({
     selector: "hab-packages-list",
@@ -42,5 +42,9 @@ export class PackagesListComponent {
 
     packageString(pkg) {
         return packageString(pkg);
+    }
+
+    releaseToDate(release) {
+        return releaseToDate(release);
     }
 }

--- a/components/builder-web/app/packages-list/packages-list.component.html
+++ b/components/builder-web/app/packages-list/packages-list.component.html
@@ -22,7 +22,7 @@
                     {{ version.release_count }}
                 </span>
                 <span class="latest-release">
-                    {{ version.latest }}
+                    {{ releaseToDate(version.latest) || "&mdash;" }}
                 </span>
                 <hab-build-status
                     [origin]="version.origin"
@@ -43,7 +43,7 @@
                     {{ packageString(pkg) }}
                 </span>
                 <span *ngIf="layout === 'builds'" class="completed">
-                    {{ pkg.release }}
+                    {{ releaseToDate(pkg.release) || "&mdash;" }}
                 </span>
                 <hab-build-status
                     [origin]="pkg.origin"

--- a/components/builder-web/app/routes.spec.ts
+++ b/components/builder-web/app/routes.spec.ts
@@ -1,3 +1,4 @@
+import { BuildPageComponent } from "./build-page/build-page.component";
 import { DashboardComponent } from "./dashboard/dashboard.component";
 import { ExploreComponent } from "./explore/explore.component";
 import { OriginCreatePageComponent } from "./origin-create-page/OriginCreatePageComponent";
@@ -6,7 +7,6 @@ import { OriginsPageComponent } from "./origins-page/OriginsPageComponent";
 import { OrganizationCreatePageComponent } from "./organization-create-page/OrganizationCreatePageComponent";
 import { OrganizationsPageComponent } from "./organizations-page/OrganizationsPageComponent";
 import { PackageBuildsComponent } from "./package-builds/package-builds.component";
-import { BuildComponent } from "./build/build.component";
 import { PackagePageComponent } from "./package-page/PackagePageComponent";
 import { PackagesPageComponent } from "./packages-page/PackagesPageComponent";
 import { ProjectCreatePageComponent } from "./project-create-page/ProjectCreatePageComponent";
@@ -38,9 +38,9 @@ describe("Routes", () => {
   });
 
   describe("/builds/:id", () => {
-    it("routes to BuildComponent", () => {
+    it("routes to BuildPageComponent", () => {
       let r = route("builds/:id");
-      expect(r.component).toBe(BuildComponent);
+      expect(r.component).toBe(BuildPageComponent);
     });
   });
 

--- a/components/builder-web/app/routes.ts
+++ b/components/builder-web/app/routes.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import { Routes, RouterModule } from "@angular/router";
+import { BuildPageComponent } from "./build-page/build-page.component";
 import { DashboardComponent } from "./dashboard/dashboard.component";
 import { DashboardGuard } from "./dashboard/dashboard.guard";
 import { ExploreComponent } from "./explore/explore.component";
@@ -21,7 +22,6 @@ import { OriginPageComponent } from "./origin-page/OriginPageComponent";
 import { OriginsPageComponent } from "./origins-page/OriginsPageComponent";
 import { OrganizationCreatePageComponent } from "./organization-create-page/OrganizationCreatePageComponent";
 import { OrganizationsPageComponent } from "./organizations-page/OrganizationsPageComponent";
-import { BuildComponent } from "./build/build.component";
 import { PackageBuildsComponent } from "./package-builds/package-builds.component";
 import { PackagePageComponent } from "./package-page/PackagePageComponent";
 import { PackageVersionsPageComponent } from "./package-versions-page/package-versions-page.component";
@@ -45,7 +45,7 @@ export const routes: Routes = [
     },
     {
         path: "builds/:id",
-        component: BuildComponent
+        component: BuildPageComponent
     },
     {
         path: "origins",

--- a/components/builder-web/app/util.ts
+++ b/components/builder-web/app/util.ts
@@ -45,6 +45,12 @@ export function duration(s) {
     return moment.utc(s * 1000).format("m [min] s [sec]");
 }
 
+// Parse a release and return a formatted date
+export function releaseToDate(release) {
+    let m = moment.utc(release, "YYYYMMDDHHmmss");
+    return m.isValid() ? m.format("YYYY-MM-DD") : null;
+}
+
 // Pretty-printed time
 export function friendlyTime(t) {
     return moment(t).fromNow();


### PR DESCRIPTION
This exposes historical logs by adding a Build Output tab to the manifest view, visible to signed-in users. It does this by pulling the build-log view into a new component shared by both the in-progress ("streaming") build view and the manifest view.  Also adds a bit of cleanup by formatting release dates in lists, and fixes a date-display bug in recent-packages list on the dashboard.

![](http://i.giphy.com/m8DnDYfRwEtvG.gif)

Signed-off-by: Christian Nunciato <cnunciato@chef.io>