### PR TITLE
do not randomize shard 0

### DIFF
--- a/components/builder-db/src/pool.rs
+++ b/components/builder-db/src/pool.rs
@@ -95,17 +95,7 @@ impl Pool {
             .map(|k| k.hash(&mut FnvHasher::default()));
 
         let shard_id = match optional_shard_id {
-            Some(id) => {
-                if id == 0 {
-                    let mut rng = rand::thread_rng();
-                    match rng.choose(&self.shards) {
-                        Some(shard) => *shard,
-                        None => 0,
-                    }
-                } else {
-                    (id % SHARD_COUNT as u64) as u32
-                }
-            }
+            Some(id) => (id % SHARD_COUNT as u64) as u32,
             None => {
                 let mut rng = rand::thread_rng();
                 match rng.choose(&self.shards) {

--- a/components/builder-router/src/server.rs
+++ b/components/builder-router/src/server.rs
@@ -277,11 +277,10 @@ impl Server {
     }
 
     fn select_shard(&mut self) -> u32 {
-        let route_hash = self.envelope.route_info().get_hash();
-        if route_hash == 0 {
-            (self.rng.gen::<u64>() % SHARD_COUNT as u64) as u32
+        if self.envelope.route_info().has_hash() {
+            (self.envelope.route_info().get_hash() % SHARD_COUNT as u64) as u32
         } else {
-            (route_hash % SHARD_COUNT as u64) as u32
+            (self.rng.gen::<u64>() % SHARD_COUNT as u64) as u32
         }
     }
 }


### PR DESCRIPTION
This fixes a bug that came up in the data migration from redis to postgres. The bug is that if a record (an origin in our case) was created on shard 0, subsequent shard assignments based on its route key would be randomized and its a foreign key violation party!

We have not encountered this bug in our test environments due to a very narrow distribution of origins but in migrating the origins from production data, there are several origins legally residing in shard 0.

This simply removes the shard randomizer for keys that route to shard 0. I would really like to get @adamhjk 's feedback to make sure he did not have a case here that I am overlooking.

Signed-off-by: Matt Wrock <matt@mattwrock.com>