### PR TITLE
Auto update

### DIFF
--- a/components/hab/src/analytics.rs
+++ b/components/hab/src/analytics.rs
@@ -196,7 +196,6 @@ use clap;
 use common::ui::{Status, UI};
 use hcore;
 use http_client::ApiClient;
-use url::Url;
 use url::percent_encoding::{utf8_percent_encode, PATH_SEGMENT_ENCODE_SET};
 use uuid::Uuid;
 
@@ -493,15 +492,6 @@ fn should_send() -> bool {
 /// The presence of a `false` return value is enough to assume that we want to save this event to
 /// disk for later retry.
 fn send_event(payload: &str) -> bool {
-    // Take the analytics URL string slice and parse it into a `Url` struct. Despite the fact that
-    // the string value is a constant, this could still fail and therefore has to be accounted for.
-    let url = match Url::parse(GOOGLE_ANALYTICS_URL) {
-        Ok(url) => url,
-        Err(e) => {
-            debug!("Error parsing URL: {}", e);
-            return false;
-        }
-    };
     // Create a new Hyper HTTP client, using a helper from the `habitat_http_client` crate. This
     // function is responsible for setting up the SSL context, finding suitable SSL root certificate
     // files, etc. The `None` reference is for a more advanced use case which is the Rust way of
@@ -513,10 +503,10 @@ fn send_event(payload: &str) -> bool {
     // matching arm is when something (or anything) goes wrong. In this case we absolutely do not
     // want to crash, panic this thread, or otherwise impact the real operation potentially running
     // concurrently. So, the strategy here is to report and early return.
-    let client = match ApiClient::new(&url, PRODUCT, super::VERSION, None) {
+    let client = match ApiClient::new(GOOGLE_ANALYTICS_URL, PRODUCT, super::VERSION, None) {
         Ok(c) => c,
         Err(e) => {
-            debug!("Error create HTTP client: {}", e);
+            debug!("Unable to create HTTP client for analytics: {}", e);
             return false;
         }
     };

--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -443,8 +443,10 @@ fn sub_pkg_build() -> App<'static, 'static> {
 fn sub_pkg_install() -> App<'static, 'static> {
     let sub = clap_app!(@subcommand install =>
         (about: "Installs a Habitat package from a Depot or locally from a Habitat Artifact")
-        (@arg DEPOT_URL: -u --url +takes_value {valid_url}
-            "Use a specific Depot URL (ex: http://depot.example.com/v1/depot)")
+        (@arg DEPOT_URL: --url -u +takes_value {valid_url}
+            "Use a specific Depot URL [default: https://app.habitat.sh/v1/depot]")
+        (@arg CHANNEL: --channel +takes_value
+            "Install from the specified release channel")
         (@arg PKG_IDENT_OR_ARTIFACT: +required +multiple
             "One or more Habitat package identifiers (ex: acme/redis) and/or filepaths \
             to a Habitat Artifact (ex: /home/acme-redis-3.0.7-21120102031201-x86_64-linux.hart)")

--- a/components/hab/src/command/pkg/export.rs
+++ b/components/hab/src/command/pkg/export.rs
@@ -101,6 +101,7 @@ mod inner {
                 try!(ui.status(Status::Missing, format!("package for {}", &format_ident)));
                 try!(install::start(ui,
                                     &default_depot_url(),
+                                    None,
                                     &format_ident.to_string(),
                                     PRODUCT,
                                     VERSION,

--- a/components/hab/src/command/pkg/search.rs
+++ b/components/hab/src/command/pkg/search.rs
@@ -17,8 +17,8 @@ use depot_client::Client;
 use {PRODUCT, VERSION};
 
 pub fn start(st: &str, url: &str) -> Result<()> {
-    let depot_client = try!(Client::new(url, PRODUCT, VERSION, None));
-    let (packages, more) = try!(depot_client.search_package(st.to_string()));
+    let depot_client = Client::new(url, PRODUCT, VERSION, None)?;
+    let (packages, more) = depot_client.search_package(st)?;
     match packages.len() {
         0 => println!("No packages found that match '{}'", st),
         _ => {

--- a/components/hab/src/command/pkg/upload.rs
+++ b/components/hab/src/command/pkg/upload.rs
@@ -89,7 +89,7 @@ pub fn start<P: AsRef<Path>>(ui: &mut UI,
     try!(ui.begin(format!("Uploading {}", archive_path.as_ref().display())));
     let tdeps = try!(archive.tdeps());
     for dep in tdeps.into_iter() {
-        match depot_client.show_package(&dep) {
+        match depot_client.show_package(&dep, None) {
             Ok(_) => try!(ui.status(Status::Using, format!("existing {}", &dep))),
             Err(depot_client::Error::APIError(StatusCode::NotFound, _)) => {
                 let candidate_path = match archive_path.as_ref().parent() {
@@ -115,7 +115,7 @@ pub fn start<P: AsRef<Path>>(ui: &mut UI,
         }
     }
     let ident = try!(archive.ident());
-    match depot_client.show_package(&ident) {
+    match depot_client.show_package(&ident, None) {
         Ok(_) => {
             try!(ui.status(Status::Using, format!("existing {}", &ident)));
             Ok(())
@@ -157,7 +157,10 @@ fn upload_into_depot(ui: &mut UI,
         Err(depot_client::Error::APIError(StatusCode::UnprocessableEntity, _)) => {
             return Err(Error::PackageArchiveMalformed(format!("{}", archive.path.display())));
         }
-        Err(depot_client::Error::APIError(StatusCode::NotImplemented, _)) => println!("Package platform or architecture not supported by the targted depot; skipping."),
+        Err(depot_client::Error::APIError(StatusCode::NotImplemented, _)) => {
+            println!("Package platform or architecture not supported by the targted \
+                    depot; skipping.");
+        }
         Err(e) => return Err(Error::from(e)),
     };
     try!(ui.status(Status::Uploaded, ident));

--- a/components/hab/src/exec.rs
+++ b/components/hab/src/exec.rs
@@ -60,6 +60,7 @@ pub fn command_from_min_pkg(ui: &mut UI,
             try!(ui.status(Status::Missing, format!("package for {}", &ident)));
             try!(common::command::package::install::start(ui,
                                                           &default_depot_url(),
+                                                          None,
                                                           &ident.to_string(),
                                                           PRODUCT,
                                                           VERSION,

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -342,6 +342,7 @@ fn sub_plan_init(ui: &mut UI, m: &ArgMatches) -> Result<()> {
 fn sub_pkg_install(ui: &mut UI, m: &ArgMatches) -> Result<()> {
     let env_or_default = henv::var(DEPOT_URL_ENVVAR).unwrap_or(DEFAULT_DEPOT_URL.to_string());
     let url = m.value_of("DEPOT_URL").unwrap_or(&env_or_default);
+    let channel = m.value_of("CHANNEL");
     let ident_or_artifacts = m.values_of("PKG_IDENT_OR_ARTIFACT").unwrap(); // Required via clap
     let ignore_target = if m.is_present("IGNORE_TARGET") {
         true
@@ -353,6 +354,7 @@ fn sub_pkg_install(ui: &mut UI, m: &ArgMatches) -> Result<()> {
     for ident_or_artifact in ident_or_artifacts {
         let pkg_ident = try!(common::command::package::install::start(ui,
                                                       url,
+                                                      channel,
                                                       ident_or_artifact,
                                                       PRODUCT,
                                                       VERSION,

--- a/components/sup/src/command/start.rs
+++ b/components/sup/src/command/start.rs
@@ -76,6 +76,7 @@ pub fn run(cfg: ManagerConfig,
                       Yellow.bold().paint(artifact));
             common::command::package::install::start(&mut ui,
                                                      &spec.depot_url,
+                                                     spec.channel.as_ref().map(String::as_ref),
                                                      artifact,
                                                      PRODUCT,
                                                      VERSION,

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -111,10 +111,13 @@ fn cli<'a, 'b>() -> App<'a, 'b> {
             (@arg NAME: --("override-name") +takes_value
                 "The name for the state directory if there is more than one Supervisor running \
                 [default: default]")
+            (@arg CHANNEL: --channel +takes_value
+                "Receive package updates from the specified release channel")
             (@arg GROUP: --group +takes_value
                 "The service group; shared config and topology [default: default].")
             (@arg DEPOT_URL: --url -u +takes_value {valid_url}
-                "Use a specific Depot URL (ex: http://depot.example.com/v1/depot)")
+                "Receive package updates from the Depot at the specified URL \
+                [default: https://app.habitat.sh/v1/depot]")
             (@arg TOPOLOGY: --topology -t +takes_value {valid_topology}
                 "Service topology; [default: none]")
             (@arg STRATEGY: --strategy -s +takes_value {valid_update_strategy}
@@ -178,10 +181,13 @@ fn cli<'a, 'b>() -> App<'a, 'b> {
             (@arg PKG_IDENT_OR_ARTIFACT: +required +takes_value
                 "A Habitat package identifier (ex: core/redis) or filepath to a Habitat Artifact \
                 (ex: /home/core-redis-3.0.7-21120102031201-x86_64-linux.hart)")
+            (@arg CHANNEL: --channel +takes_value
+                "Receive package updates from the specified release channel")
             (@arg GROUP: --group +takes_value
                 "The service group; shared config and topology [default: default].")
             (@arg DEPOT_URL: --url -u +takes_value {valid_url}
-                "Use a specific Depot URL (ex: http://depot.example.com/v1/depot)")
+                "Receive package updates from the Depot at the specified URL \
+                [default: https://app.habitat.sh/v1/depot]")
             (@arg TOPOLOGY: --topology -t +takes_value {valid_topology}
                 "Service topology; [default: none]")
             (@arg STRATEGY: --strategy -s +takes_value {valid_update_strategy}
@@ -496,8 +502,10 @@ fn spec_from_matches(ident: PackageIdent, m: &ArgMatches) -> Result<ServiceSpec>
         spec.group = group.to_string();
     }
     let env_or_default = henv::var(DEPOT_URL_ENVVAR).unwrap_or(DEFAULT_DEPOT_URL.to_string());
-    let url = m.value_of("DEPOT_URL").unwrap_or(&env_or_default);
-    spec.depot_url = String::from(url);
+    spec.depot_url = m.value_of("DEPOT_URL")
+        .unwrap_or(&env_or_default)
+        .to_string();
+    spec.channel = m.value_of("CHANNEL").map(|c| c.to_string());
     if let Some(topology) = m.value_of("TOPOLOGY") {
         spec.topology = Topology::from_str(topology)?;
     }

--- a/components/sup/src/manager/service/mod.rs
+++ b/components/sup/src/manager/service/mod.rs
@@ -71,6 +71,7 @@ lazy_static! {
 pub struct Service {
     pub service_group: ServiceGroup,
     pub depot_url: String,
+    pub channel: Option<String>,
     pub spec_file: PathBuf,
     pub spec_ident: PackageIdent,
     pub start_style: StartStyle,
@@ -116,6 +117,7 @@ impl Service {
                cfg: Cfg::new(&pkg, spec.config_from.as_ref())?,
                config_renderer: CfgRenderer::new(&config_root)?,
                depot_url: spec.depot_url,
+               channel: spec.channel,
                health_check: HealthCheck::default(),
                hooks: HookTable::load(&service_group, &hooks_root),
                initialized: false,
@@ -329,6 +331,7 @@ impl Service {
         let mut spec = ServiceSpec::default_for(self.spec_ident.clone());
         spec.group = self.service_group.group().to_string();
         spec.depot_url = self.depot_url.clone();
+        spec.channel = self.channel.clone();
         spec.topology = self.topology;
         spec.update_strategy = self.update_strategy;
         spec.binds = self.binds.clone();

--- a/components/sup/src/manager/service/spec.rs
+++ b/components/sup/src/manager/service/spec.rs
@@ -80,6 +80,7 @@ pub struct ServiceSpec {
     pub ident: PackageIdent,
     pub group: String,
     pub depot_url: String,
+    pub channel: Option<String>,
     pub topology: Topology,
     pub update_strategy: UpdateStrategy,
     pub binds: Vec<ServiceBind>,
@@ -211,6 +212,7 @@ impl Default for ServiceSpec {
             ident: PackageIdent::default(),
             group: DEFAULT_GROUP.to_string(),
             depot_url: DEFAULT_DEPOT_URL.to_string(),
+            channel: None,
             topology: Topology::default(),
             update_strategy: UpdateStrategy::default(),
             binds: Vec::default(),
@@ -435,6 +437,7 @@ mod test {
             ident: PackageIdent::from_str("origin/name/1.2.3/20170223130020").unwrap(),
             group: String::from("jobs"),
             depot_url: String::from("http://example.com/depot"),
+            channel: Some(String::from("stable")),
             topology: Topology::Leader,
             update_strategy: UpdateStrategy::AtOnce,
             binds: vec![ServiceBind::from_str("cache:redis.cache@acmecorp").unwrap(),
@@ -448,6 +451,7 @@ mod test {
         assert!(toml.contains(r#"ident = "origin/name/1.2.3/20170223130020""#));
         assert!(toml.contains(r#"group = "jobs""#));
         assert!(toml.contains(r#"depot_url = "http://example.com/depot""#));
+        assert!(toml.contains(r#"channel = "stable""#));
         assert!(toml.contains(r#"topology = "leader""#));
         assert!(toml.contains(r#"update_strategy = "at-once""#));
         assert!(toml.contains(r#""cache:redis.cache@acmecorp""#));
@@ -563,6 +567,7 @@ mod test {
             ident: PackageIdent::from_str("origin/name/1.2.3/20170223130020").unwrap(),
             group: String::from("jobs"),
             depot_url: String::from("http://example.com/depot"),
+            channel: Some(String::from("stable")),
             topology: Topology::Leader,
             update_strategy: UpdateStrategy::AtOnce,
             binds: vec![ServiceBind::from_str("cache:redis.cache@acmecorp").unwrap(),
@@ -577,6 +582,7 @@ mod test {
         assert!(toml.contains(r#"ident = "origin/name/1.2.3/20170223130020""#));
         assert!(toml.contains(r#"group = "jobs""#));
         assert!(toml.contains(r#"depot_url = "http://example.com/depot""#));
+        assert!(toml.contains(r#"channel = "stable""#));
         assert!(toml.contains(r#"topology = "leader""#));
         assert!(toml.contains(r#"update_strategy = "at-once""#));
         assert!(toml.contains(r#""cache:redis.cache@acmecorp""#));

--- a/terraform/instances.tf
+++ b/terraform/instances.tf
@@ -46,8 +46,8 @@ resource "aws_instance" "api" {
       "sudo systemctl daemon-reload",
       "sudo systemctl start hab-sup",
       "sudo systemctl enable hab-sup",
-      "sudo hab service load core/builder-api --group ${var.env} --bind router:builder-router.${var.env}",
-      "sudo hab service load core/builder-api-proxy --group ${var.env} --bind http:builder-api.${var.env}",
+      "sudo hab service load core/builder-api --group ${var.env} --bind router:builder-router.${var.env} --strategy at-once --url ${var.depot_url} --channel ${var.release_channel}",
+      "sudo hab service load core/builder-api-proxy --group ${var.env} --bind http:builder-api.${var.env} --strategy at-once --url ${var.depot_url} --channel ${var.release_channel}",
     ]
   }
 
@@ -104,8 +104,8 @@ resource "aws_instance" "admin" {
       "sudo systemctl daemon-reload",
       "sudo systemctl start hab-sup",
       "sudo systemctl enable hab-sup",
-      "sudo hab service load core/builder-admin --group ${var.env} --bind router:builder-router.${var.env}",
-      "sudo hab service load core/builder-admin-proxy --group ${var.env} --bind http:builder-admin.${var.env}",
+      "sudo hab service load core/builder-admin --group ${var.env} --bind router:builder-router.${var.env} --strategy at-once --url ${var.depot_url} --channel ${var.release_channel}",
+      "sudo hab service load core/builder-admin-proxy --group ${var.env} --bind http:builder-admin.${var.env} --strategy at-once --url ${var.depot_url} --channel ${var.release_channel}",
     ]
   }
 
@@ -165,7 +165,7 @@ resource "aws_instance" "datastore" {
       "sudo systemctl daemon-reload",
       "sudo systemctl start hab-sup",
       "sudo systemctl enable hab-sup",
-      "sudo hab service load core/builder-datastore --group ${var.env}"
+      "sudo hab service load core/builder-datastore --group ${var.env} --strategy at-once --url ${var.depot_url} --channel ${var.release_channel}"
     ]
   }
 
@@ -225,7 +225,7 @@ resource "aws_instance" "jobsrv" {
       "sudo systemctl daemon-reload",
       "sudo systemctl start hab-sup",
       "sudo systemctl enable hab-sup",
-      "sudo hab service load core/builder-jobsrv --group ${var.env} --bind router:builder-router.${var.env} --bind datastore:builder-datastore.${var.env}"
+      "sudo hab service load core/builder-jobsrv --group ${var.env} --bind router:builder-router.${var.env} --bind datastore:builder-datastore.${var.env} --strategy at-once --url ${var.depot_url} --channel ${var.release_channel}"
     ]
   }
 
@@ -284,7 +284,7 @@ resource "aws_instance" "originsrv" {
       "sudo systemctl daemon-reload",
       "sudo systemctl start hab-sup",
       "sudo systemctl enable hab-sup",
-      "sudo hab service load core/builder-originsrv --group ${var.env} --bind router:builder-router.${var.env} --bind datastore:builder-datastore.${var.env}"
+      "sudo hab service load core/builder-originsrv --group ${var.env} --bind router:builder-router.${var.env} --bind datastore:builder-datastore.${var.env} --strategy at-once --url ${var.depot_url} --channel ${var.release_channel}"
     ]
   }
 
@@ -342,7 +342,7 @@ resource "aws_instance" "router" {
       "sudo systemctl daemon-reload",
       "sudo systemctl start hab-sup",
       "sudo systemctl enable hab-sup",
-      "sudo hab service load core/builder-router --group ${var.env}"
+      "sudo hab service load core/builder-router --group ${var.env} --strategy at-once --url ${var.depot_url} --channel ${var.release_channel}"
     ]
   }
 
@@ -401,7 +401,7 @@ resource "aws_instance" "scheduler" {
       "sudo systemctl daemon-reload",
       "sudo systemctl start hab-sup",
       "sudo systemctl enable hab-sup",
-      "sudo hab service load core/builder-scheduler --group ${var.env} --bind router:builder-router.${var.env} --bind datastore:builder-datastore.${var.env}"
+      "sudo hab service load core/builder-scheduler --group ${var.env} --bind router:builder-router.${var.env} --bind datastore:builder-datastore.${var.env} --strategy at-once --url ${var.depot_url} --channel ${var.release_channel}"
     ]
   }
 
@@ -460,7 +460,7 @@ resource "aws_instance" "sessionsrv" {
       "sudo systemctl daemon-reload",
       "sudo systemctl start hab-sup",
       "sudo systemctl enable hab-sup",
-      "sudo hab service load core/builder-sessionsrv --group ${var.env} --bind router:builder-router.${var.env} --bind datastore:builder-datastore.${var.env}"
+      "sudo hab service load core/builder-sessionsrv --group ${var.env} --bind router:builder-router.${var.env} --bind datastore:builder-datastore.${var.env} --strategy at-once --url ${var.depot_url} --channel ${var.release_channel}"
     ]
   }
 
@@ -519,7 +519,7 @@ resource "aws_instance" "worker" {
       "sudo systemctl daemon-reload",
       "sudo systemctl start hab-sup",
       "sudo systemctl enable hab-sup",
-      "sudo hab service load core/builder-worker --group ${var.env} --bind jobsrv:builder-jobsrv.${var.env} --bind depot:builder-api.${var.env}",
+      "sudo hab service load core/builder-worker --group ${var.env} --bind jobsrv:builder-jobsrv.${var.env} --bind depot:builder-api.${var.env} --strategy at-once --url ${var.depot_url} --channel ${var.release_channel}",
     ]
   }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -39,6 +39,16 @@ variable "hab_sup_sg" {
   description = "Identifier for AWS security group for habitat supervisor connectivity"
 }
 
+variable "depot_url" {
+  description = "URL of Depot to receive package updates from"
+  default     = "https://app.habitat.sh/v1/depot"
+}
+
+variable "release_channel" {
+  description = "Release channel in Depot to receive package updates from"
+  default     = "stable"
+}
+
 variable "gossip_listen_port" {
   description = "Port for Habitat Supervisor's --gossip-listen"
   default     = 9638


### PR DESCRIPTION
* Channels are now respected when an update strategy is specified on `svc start` or `svc load` by passing `--channel {name}`
* Update Terraform instance provisioners to use a parameterized depot-url and release-channel variable

![tenor-33973058](https://cloud.githubusercontent.com/assets/54036/26225748/a29becc8-3bdd-11e7-934d-0d3ebc943ffd.gif)
