### PR TITLE
Rename slog filename from log.out to out.log

### DIFF
--- a/components/studio/bin/hab-studio.ps1
+++ b/components/studio/bin/hab-studio.ps1
@@ -285,17 +285,17 @@ function Enter-Studio {
     # We do this because breaking out of the tail stream via ctrl-C breaks
     # nested shells.
     function slog {
-      Start-Process "$env:STUDIO_SCRIPT_ROOT\powershell\powershell.exe" -ArgumentList "-Command `"& {Get-Content $env:HAB_STUDIO_ENTER_ROOT\hab\sup\default\log.out -Tail 100 -Wait}`""
+      Start-Process "$env:STUDIO_SCRIPT_ROOT\powershell\powershell.exe" -ArgumentList "-Command `"& {Get-Content $env:HAB_STUDIO_ENTER_ROOT\hab\sup\default\out.log -Tail 100 -Wait}`""
     }
 
     New-PSDrive -Name "Habitat" -PSProvider FileSystem -Root $env:HAB_STUDIO_ENTER_ROOT | Out-Null
     mkdir $env:HAB_STUDIO_ENTER_ROOT\hab\sup\default -Force | Out-Null
-    Start-Process hab.exe -ArgumentList "sup run" -NoNewWindow -RedirectStandardOutput $env:HAB_STUDIO_ENTER_ROOT\hab\sup\default\log.out
+    Start-Process hab.exe -ArgumentList "sup run" -NoNewWindow -RedirectStandardOutput $env:HAB_STUDIO_ENTER_ROOT\hab\sup\default\out.log
     Write-Host  "** The Habitat Supervisor has been started in the background." -ForegroundColor Cyan
     Write-Host  "** Use 'hab sup start' and 'hab sup stop' to start and stop services." -ForegroundColor Cyan
     Write-Host  "** Use the 'slog' command to stream the supervisor log." -ForegroundColor Cyan
     Write-Host  ""
-    
+
     Set-Location "Habitat:\src"
   }
 

--- a/components/studio/libexec/hab-studio-type-default.sh
+++ b/components/studio/libexec/hab-studio-type-default.sh
@@ -48,7 +48,7 @@ finish_setup() {
         echo "This test will print your signing key to the console or error if it cannot find the key."
         echo "To create a signing key, you can run 'hab origin key generate $key'"
         echo "You'll also be prompted to create an origin signing key when you run 'hab setup'"
-        
+
         exit 1
       fi
     done
@@ -88,7 +88,7 @@ EOF
 
   $bb cat <<TAIL_SUP > $HAB_STUDIO_ROOT$HAB_ROOT_PATH/bin/slog
 #!$bash_path/bin/sh
-exec tail -f /hab/sup/default/log.out
+exec tail -f /hab/sup/default/out.log
 TAIL_SUP
   $bb chmod $v 755 $HAB_STUDIO_ROOT$HAB_ROOT_PATH/bin/slog
 
@@ -115,7 +115,7 @@ fi
 
 start_supervisor() {
   if [ -z \$NO_BG_SUP ]; then
-    $HAB_ROOT_PATH/bin/hab sup run > /hab/sup/default/log.out &
+    $HAB_ROOT_PATH/bin/hab sup run > /hab/sup/default/out.log &
     echo "** The Habitat Supervisor has been started in the background."
     echo "** Use 'hab sup start' and 'hab sup stop' to start and stop services."
     echo "** Use the 'slog' command to stream the supervisor log."


### PR DESCRIPTION
This is an insanely minor nitpick, but this changes the name of the output log file from `log.out` to `out.log`