### PR TITLE
Downcases tags used for docker images.

### DIFF
--- a/components/pkg-dockerize/bin/hab-pkg-dockerize.sh
+++ b/components/pkg-dockerize/bin/hab-pkg-dockerize.sh
@@ -139,8 +139,10 @@ EXPOSE 9631 $(package_exposes $1)
 ENTRYPOINT ["/init.sh"]
 CMD ["start", "$1"]
 EOT
-  docker build --force-rm --no-cache -t $version_tag .
-  docker tag $version_tag $latest_tag
+  # Docker tags downcased via ${string,,}
+  # https://www.gnu.org/software/bash/manual/bashref.html#Shell-Parameter-Expansion
+  docker build --force-rm --no-cache -t ${version_tag,,} .
+  docker tag ${version_tag,,} ${latest_tag,,}
 }
 
 # The root of the filesystem. If the program is running on a separate


### PR DESCRIPTION
Docker's code doesn't allow uppercase tags, despite what their
documentation claims.
https://github.com/docker/distribution/blob/master/reference/regexp.go#L6

Signed-off-by: Matt Ray <matthewhray@gmail.com>