### PR TITLE
Various Studio Tapas, nom nom

### DIFF
--- a/components/studio/bin/hab-studio.sh
+++ b/components/studio/bin/hab-studio.sh
@@ -599,6 +599,8 @@ if command -v dircolors > /dev/null; then
   eval "$(dircolors -b)"
 fi
 alias ls="ls --color=auto"
+alias ll="ls -l"
+alias la="ls -al"
 
 # Set a prompt which tells us what kind of Studio we're in
 if [ "${HAB_NOCOLORING:-}" = "true" ]; then

--- a/components/studio/libexec/hab-studio-type-bare.sh
+++ b/components/studio/libexec/hab-studio-type-bare.sh
@@ -5,7 +5,6 @@ studio_build_environment=
 studio_build_command=
 studio_run_environment=
 studio_run_command=
-studio_supervisor_start_command=
 
 base_pkgs="core/hab core/hab-sup"
 : ${PKGS:=}

--- a/components/studio/libexec/hab-studio-type-baseimage.sh
+++ b/components/studio/libexec/hab-studio-type-baseimage.sh
@@ -5,7 +5,6 @@ studio_build_environment=
 studio_build_command=
 studio_run_environment=
 studio_run_command=
-studio_supervisor_start_command=
 
 base_pkgs="core/hab core/hab-sup"
 : ${PKGS:=}

--- a/components/studio/libexec/hab-studio-type-busybox.sh
+++ b/components/studio/libexec/hab-studio-type-busybox.sh
@@ -7,7 +7,6 @@ studio_build_environment=
 studio_build_command=
 studio_run_environment=
 studio_run_command="/opt/busybox/busybox sh -l"
-studio_supervisor_start_command=
 
 finish_setup() {
   # Copy in the busybox binary under `/opt/busybox`

--- a/components/studio/libexec/hab-studio-type-default.sh
+++ b/components/studio/libexec/hab-studio-type-default.sh
@@ -113,6 +113,14 @@ if [ -f /src/.studiorc ];then
   source /src/.studiorc
 fi
 
+emacs() {
+  if command -v emacs > /dev/null; then
+    emacs \$*
+  else
+    mg \$*
+  fi
+}
+
 start_supervisor() {
   if [ -z \$NO_BG_SUP ]; then
     $HAB_ROOT_PATH/bin/hab sup run > /hab/sup/default/out.log &

--- a/components/studio/libexec/hab-studio-type-stage1.sh
+++ b/components/studio/libexec/hab-studio-type-stage1.sh
@@ -7,7 +7,6 @@ studio_build_environment=
 studio_build_command=
 studio_run_environment=
 studio_run_command=
-studio_supervisor_start_command=
 
 : ${STAGE1_TOOLS_URL:=https://s3-us-west-2.amazonaws.com/habitat-studio-stage1/habitat-studio-stage1-20160612022150.tar.xz}
 : ${TAR_DIR:=/tmp}

--- a/www/source/docs/reference/environment-vars.html.md
+++ b/www/source/docs/reference/environment-vars.html.md
@@ -21,6 +21,7 @@ This is a list of all environment variables that can be used to modify the opera
 | `HAB_RING_KEY` | supervisor | no default | The name of the ring key when running with [wire encryption](/docs/run-packages-security/#wire-encryption) |
 | `HAB_STUDIOS_HOME` | build system | `/hab/studios` if running as root; `$HOME/.hab/studios` if running as non-root | Directory in which to create build studios |
 | `HAB_STUDIO_ROOT` | build system | no default | Root of the current studio under `$HAB_STUDIOS_HOME`. Infrequently overridden. |
+| `HAB_STUDIO_SUP` | build system | no default | Used to customize the arguments passed to an automatically launched Supervisor, or to disable the automatic launching by setting it to `false`, `no`, or `0`. |
 | `HAB_UPDATE_STRATEGY_FREQUENCY_MS` | supervisor | 60000 | Frequency of milliseconds to check for updates when running with an [update strategy](/docs/run-packages-update-strategy) |
 | `HAB_USER` | supervisor | no default | User key to use when running with [service group encryption](/docs/run-packages-security/#service-group-encryption) |
 | `http_proxy` | build system, supervisor | no default | A URL for a local HTTP proxy server optionally supporting basic authentication |

--- a/www/source/docs/run-packages-overview.html.md.erb
+++ b/www/source/docs/run-packages-overview.html.md.erb
@@ -15,7 +15,7 @@ When entering an interactive studio, a supervisor is started for you in the back
 1. [Build your package](/docs/create-packages-build) inside an interactive studio. Do not exit the studio after it is built.
 2. To start your service in the running supervisor, type `hab sup start yourorigin/yourname`, substituting the name and origin of the package you built in step 1. Your service should now be running.
 
-Because the supervisor is running in the background, you will not see the supervisor output as you start your service. However you can use the `slog` (supervisor log) command that will stream the tail of the supervisor output.
+Because the supervisor is running in the background, you will not see the supervisor output as you start your service. However you can use the `sup-log` (supervisor log) command that will stream the tail of the supervisor output.
 
 If your host machine is running Linux, do the following to run your packages:
 


### PR DESCRIPTION
A small collection of tasty treats for the Studio experience, nom nom…

![gif-keyboard-11114150899503848955](https://cloud.githubusercontent.com/assets/261548/26236131/f9f0db84-3c2b-11e7-8988-2dda4abb33a1.gif)

## [studio] Add `ll` & `la` aliases in default Studio type.

![gif-keyboard-4632894236727655231](https://cloud.githubusercontent.com/assets/261548/26236061/b0289974-3c2b-11e7-86f5-8b38900724d5.gif)

I believe this will satisfy a lot of people's muscle memory--including
my own.

This adds the following shell aliases in the default Studio:

* `alias ll='ls -l'`
* `alias la='ls -al'`

## [studio] Adds `emacs` function which runs `mg` unless `emacs` is found.

![gif-keyboard-16855903995633483723](https://cloud.githubusercontent.com/assets/261548/26236088/ced12454-3c2b-11e7-8338-4f80d44a294d.gif)

Did you know that every default Studio has a tiny emacs-like text editor
called `mg` installed? Well, enough emacs fans didn't know this so this
change is an attempt to make it a bit more discoverable.

A function called `emacs` is added into the default Studio type's Bash
profile which will find and run a real `emacs` if found on `PATH` and
otherwise will call the `mg` program.

For more information about `mg`, check out:

http://man.openbsd.org/OpenBSD-current/man1/mg.1

## [studio] Refactor the auto-running Supervisor experience.

![gif-keyboard-12586078895917689928](https://cloud.githubusercontent.com/assets/261548/26236157/2654caf0-3c2c-11e7-8394-e34542fa297e.gif)

This change refactors some of the implementation which runs a Supervisor
when entering an interactive Studio, but also adds a mechanism by which
you can terminate the Supervisor and customize it's run arguments via an
environment variable.

New Environment Variable
------------------------

A new environment can be passed to `hab studio enter` called
`HAB_STUDIO_SUP` which does 2 things: provide a way to not run a
Supervisor or to customize how the Supervisor runs by passing additional
command line arguments such as `--peer`, etc.

When set to `false`, `no`, or `0`, a Supervisor will not run
automatically in an interactive Studio, allowing a user to
export-and-forget if that is their preference.

Alternatively, when non-empty (and not set to a value above), it is
assumed that the value contains extra command line arguments that will
be passed to `hab sup run`. For example, to interactive enter a Studio
with a Supervisor running, joined to a ring you could run:

    env HAB_STUDIO_SUP='--peer 172.17.0.2' hab studio enter

New In-Studio Helper Functions
------------------------------

Three new functions are set inside an interactive Studio session:

* `sup-log`  - Tails the Supervisor's output (this replaces `slog`)
* `sup-term` - Terminates the Supervisor running in the background
* `sup-run`  - Runs a Supervisor in the background. You can pass
               additional arguments such as `--peer`, etc. This is what
               is called to automatically run the Supervisor in
               the background.

New Shortcut Aliases
--------------------

If you desire less typing (I sure do), there are also three new shell
aliases:

* `alias sl='sup-log'`
* `alias st='sup-term'`
* `alias sr='sup-run'`

Yes. You've just taught yourself to not make the `sl` typo and now
we're letting you type it again. Life keeps throwin' curveballs.