### PR TITLE
Add `hab sup term` command and additional aliases to `hab`

### DIFF
--- a/components/core/src/os/process/mod.rs
+++ b/components/core/src/os/process/mod.rs
@@ -26,7 +26,29 @@ mod imp;
 #[path = "linux.rs"]
 mod imp;
 
-pub use self::imp::{become_command, current_pid, is_alive};
+pub use self::imp::{become_command, current_pid, is_alive, signal, Pid, SignalCode};
+
+pub trait OsSignal {
+    fn os_signal(&self) -> SignalCode;
+    fn from_signal_code(SignalCode) -> Option<Signal>;
+}
+
+#[allow(non_snake_case)]
+#[derive(Clone, Copy, Debug)]
+pub enum Signal {
+    INT,
+    ILL,
+    ABRT,
+    FPE,
+    KILL,
+    SEGV,
+    TERM,
+    HUP,
+    QUIT,
+    ALRM,
+    USR1,
+    USR2,
+}
 
 pub enum ShutdownMethod {
     AlreadyExited,
@@ -57,7 +79,7 @@ impl HabChild {
         }
     }
 
-    pub fn id(&self) -> u32 {
+    pub fn id(&self) -> Pid {
         self.inner.id()
     }
 

--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -353,6 +353,7 @@ pub fn get() -> App<'static, 'static> {
         (subcommand: alias_run())
         (subcommand: alias_setup)
         (subcommand: alias_start())
+        (subcommand: alias_stop())
         (subcommand: alias_term())
         (after_help: "\nALIASES:\
             \n    apply      Alias for: 'config apply'\
@@ -360,6 +361,7 @@ pub fn get() -> App<'static, 'static> {
             \n    run        Alias for: 'sup run'\
             \n    setup      Alias for: 'cli setup'\
             \n    start      Alias for: 'svc start'\
+            \n    stop       Alias for: 'svc stop'\
             \n    term       Alias for: 'sup term'\
             \n"
         )
@@ -377,6 +379,14 @@ fn alias_start() -> App<'static, 'static> {
     clap_app!(@subcommand start =>
         (about: "Starts a Habitat-supervised service")
         (aliases: &["sta", "star"])
+        (@setting Hidden)
+    )
+}
+
+fn alias_stop() -> App<'static, 'static> {
+    clap_app!(@subcommand stop =>
+        (about: "Stop a running Habitat service.")
+        (aliases: &["sto"])
         (@setting Hidden)
     )
 }

--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -34,7 +34,6 @@ pub fn get() -> App<'static, 'static> {
         .about("Alias for 'cli setup'")
         .aliases(&["set", "setu"])
         .setting(AppSettings::Hidden);
-    let alias_start = alias_start().aliases(&["st", "sta", "star"]);
 
     clap_app!(hab =>
         (about: "\"A Habitat is the natural environment for your services\" - Alan Turing")
@@ -351,21 +350,40 @@ pub fn get() -> App<'static, 'static> {
         )
         (subcommand: alias_apply)
         (subcommand: alias_install)
+        (subcommand: alias_run())
         (subcommand: alias_setup)
-        (subcommand: alias_start)
+        (subcommand: alias_start())
+        (subcommand: alias_term())
         (after_help: "\nALIASES:\
             \n    apply      Alias for: 'config apply'\
             \n    install    Alias for: 'pkg install'\
+            \n    run        Alias for: 'sup run'\
             \n    setup      Alias for: 'cli setup'\
-            \n    start      Alias for: 'sup start'\
+            \n    start      Alias for: 'svc start'\
+            \n    term       Alias for: 'sup term'\
             \n"
         )
+    )
+}
+
+fn alias_run() -> App<'static, 'static> {
+    clap_app!(@subcommand run =>
+        (about: "Run the Habitat Supervisor")
+        (@setting Hidden)
     )
 }
 
 fn alias_start() -> App<'static, 'static> {
     clap_app!(@subcommand start =>
         (about: "Starts a Habitat-supervised service")
+        (aliases: &["sta", "star"])
+        (@setting Hidden)
+    )
+}
+
+fn alias_term() -> App<'static, 'static> {
+    clap_app!(@subcommand term =>
+        (about: "Gracefully terminate the Habitat Supervisor and all of it's running services")
         (@setting Hidden)
     )
 }

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -507,6 +507,7 @@ fn exec_subcommand_if_called(ui: &mut UI) -> Result<()> {
         }
         ("sup", _) => command::sup::start(ui, env::args_os().skip(2).collect()),
         ("start", _) => command::sup::start(ui, env::args_os().skip(1).collect()),
+        ("stop", _) => command::sup::start(ui, env::args_os().skip(1).collect()),
         ("svc", "load") |
         ("svc", "unload") |
         ("svc", "start") |

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -501,6 +501,7 @@ fn exec_subcommand_if_called(ui: &mut UI) -> Result<()> {
         ("config", _) | ("file", _) => {
             command::butterfly::start(ui, env::args_os().skip(1).collect())
         }
+        ("run", _) => command::sup::start(ui, env::args_os().skip(1).collect()),
         ("stu", _) | ("stud", _) | ("studi", _) | ("studio", _) => {
             command::studio::start(ui, env::args_os().skip(2).collect())
         }
@@ -511,6 +512,7 @@ fn exec_subcommand_if_called(ui: &mut UI) -> Result<()> {
         ("svc", "start") |
         ("svc", "status") |
         ("svc", "stop") => command::sup::start(ui, env::args_os().skip(2).collect()),
+        ("term", _) => command::sup::start(ui, env::args_os().skip(1).collect()),
         _ => Ok(()),
     }
 }

--- a/components/sup/src/error.rs
+++ b/components/sup/src/error.rs
@@ -55,6 +55,7 @@ use depot_client;
 use glob;
 use handlebars;
 use hcore;
+use hcore::os::process;
 use hcore::package::{self, Identifiable, PackageInstall};
 use notify;
 use serde_json;
@@ -133,7 +134,7 @@ pub enum Error {
     PackageNotFound(package::PackageIdent),
     Permissions(String),
     ProcessLockCorrupt,
-    ProcessLocked(u32),
+    ProcessLocked(process::Pid),
     ProcessLockIO(PathBuf, io::Error),
     RenderContextSerialization(serde_json::Error),
     ServiceDeserializationError(serde_json::Error),

--- a/components/sup/src/manager/signals/mod.rs
+++ b/components/sup/src/manager/signals/mod.rs
@@ -14,10 +14,12 @@
 
 //! Contains the cross-platform signal behavior.
 
+use hcore::os::process;
+
 #[allow(dead_code)]
 pub enum SignalEvent {
     Shutdown,
-    Passthrough(u32),
+    Passthrough(process::Signal),
 }
 
 #[cfg(unix)]
@@ -27,7 +29,7 @@ mod unix;
 mod windows;
 
 #[cfg(unix)]
-pub use manager::signals::unix::{init, check_for_signal, send_signal, Signal};
+pub use manager::signals::unix::{init, check_for_signal};
 
 #[cfg(windows)]
-pub use manager::signals::windows::{init, check_for_signal, send_signal, Signal};
+pub use manager::signals::windows::{init, check_for_signal};

--- a/components/sup/src/manager/signals/windows.rs
+++ b/components/sup/src/manager/signals/windows.rs
@@ -18,33 +18,10 @@ use std::sync::atomic::{AtomicBool, Ordering, ATOMIC_BOOL_INIT};
 
 use ctrlc;
 
-use error::Result;
 use super::SignalEvent;
 
 // True when we have caught ctrl-c
 static CAUGHT: AtomicBool = ATOMIC_BOOL_INIT;
-
-/// This is complete bullshit!
-#[allow(dead_code)]
-#[derive(Debug, Clone)]
-pub enum Signal {
-    /// terminate process - terminal line hangup
-    SIGHUP = 1,
-    /// terminate process - interrupt program
-    SIGINT = 2,
-    /// create core image - quit program
-    SIGQUIT = 3,
-    /// Kill a process
-    SIGKILL = 9,
-    /// terminate process - real-time timer expired
-    SIGALRM = 14,
-    /// terminate process - software termination signal
-    SIGTERM = 15,
-    /// terminate process - User defined signal 1
-    SIGUSR1 = 30,
-    /// terminate process - User defined signal 2
-    SIGUSR2 = 31,
-}
 
 pub fn init() {
     ctrlc::set_handler(move || {
@@ -60,10 +37,4 @@ pub fn check_for_signal() -> Option<SignalEvent> {
     } else {
         None
     }
-}
-
-/// send a signal to a pid
-pub fn send_signal(pid: u32, sig: u32) -> Result<()> {
-    debug!("sending no-op(windows) signal {} to pid {}", sig, pid);
-    Ok(())
 }


### PR DESCRIPTION
* Add `hab sup term` command: this will gracefully stop a supervisor
  if one is running. This is the opposite of `hab sup run`
* Add `hab term` alias
* Add `hab run` alias
* General improvements to core::os::process module in core crate
* Leverage core::os::process module where possible in
  sup::manager::signal module
* Add the counterpart to `hab start` - `hab stop`

![tenor-70456540](https://cloud.githubusercontent.com/assets/54036/26237702/1f29900e-3c2b-11e7-8939-c83f96007a21.gif)

Closes #2377