### PR TITLE
Inter-site navigation improvements, Part I

### DIFF
--- a/components/builder-web/app/actions.test.ts
+++ b/components/builder-web/app/actions.test.ts
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import * as cookies from "js-cookie";
+import * as gitHub from "./actions/gitHub";
 import * as actions from "./actions/index";
 
 describe("actions", () => {
@@ -36,6 +38,34 @@ describe("actions", () => {
             expect(actions.populateExploreStats(data)).toEqual({
                 type: actions.POPULATE_EXPLORE_STATS,
                 payload: data
+            });
+        });
+    });
+
+    describe("gitHub", () => {
+
+        describe("setCookie", () => {
+
+            it("applies the proper domain", () => {
+                spyOn(cookies, "set");
+
+                spyOn(gitHub, "currentHostname").and.returnValues(
+                    "localhost",
+                    "builder.habitat.sh",
+                    "builder.acceptance.habitat.foo"
+                );
+
+                gitHub.setCookie("gitHubAuthToken", "some-token");
+                gitHub.setCookie("gitHubAuthToken", "some-token");
+                gitHub.setCookie("gitHubAuthToken", "some-token");
+
+                expect(cookies.set.calls.allArgs()).toEqual(
+                    [
+                        [ "gitHubAuthToken", "some-token", { domain: "localhost", secure: false } ],
+                        [ "gitHubAuthToken", "some-token", { domain: "habitat.sh", secure: false } ],
+                        [ "gitHubAuthToken", "some-token", { domain: "habitat.foo", secure: false } ]
+                    ]
+                );
             });
         });
     });

--- a/components/builder-web/app/actions/gitHub.ts
+++ b/components/builder-web/app/actions/gitHub.ts
@@ -171,9 +171,9 @@ function populateGitHubUserData(payload) {
 
 export function removeSessionStorage() {
     return dispatch => {
-        cookies.remove("gitHubAuthState");
-        cookies.remove("gitHubAuthToken");
-        cookies.remove("featureFlags");
+        cookies.remove("gitHubAuthState", { domain: cookieDomain() });
+        cookies.remove("gitHubAuthToken", { domain: cookieDomain() });
+        cookies.remove("featureFlags", { domain: cookieDomain() });
     };
 }
 
@@ -222,8 +222,24 @@ function resetGitHubRepos() {
     };
 }
 
+// Return up to two trailing segments of the current hostname
+// for purposes of setting the cookie domain.
+function cookieDomain() {
+    let delim = ".";
+
+    return currentHostname()
+        .split(delim)
+        .splice(-2)
+        .join(delim);
+}
+
+export const currentHostname = () => {
+    return location.hostname;
+};
+
 export function setCookie (key, value) {
     return cookies.set(key, value, {
+        domain: cookieDomain(),
         secure: window.location.protocol === "https"
     });
 }

--- a/components/builder-web/app/header/HeaderComponent.ts
+++ b/components/builder-web/app/header/HeaderComponent.ts
@@ -66,6 +66,9 @@ import config from "../config";
                 [routerLink]="['/pkgs']"
                 [class.is-current-page]="area === 'depot'">Depot</a>
             </li>
+            <li class="main-nav--link cta-link" *ngIf="!isSignedIn">
+              <a [routerLink]="['/sign-in']">Sign In</a>
+            </li>
           </ul>
         </nav>
       </div>`

--- a/components/builder-web/app/header/_header.scss
+++ b/components/builder-web/app/header/_header.scss
@@ -136,7 +136,7 @@ $main-nav-breakpoint: 710px;
 
   @media (min-width: 820px) {
     .main-nav--link {
-      padding: 0 rem(44) 0 0;
+      padding: 0 rem(30) 0 0;
     }
   }
 }
@@ -176,11 +176,19 @@ $main-nav-breakpoint: 710px;
       padding-bottom: rem(30);
     }
   }
+
+  &.cta-link {
+    a {
+      margin-left: rem(60);
+      color: $hab-orange;
+    }
+  }
 }
 
 .main-nav--cta {
   float: right;
-  margin: rem(10) rem(10) 0 0;
+  padding: 0;
+  margin: 0;
 
   .button {
     background: transparent;

--- a/components/builder-web/app/header/user-nav/UserNavComponent.ts
+++ b/components/builder-web/app/header/user-nav/UserNavComponent.ts
@@ -13,12 +13,13 @@
 // limitations under the License.
 
 import {Component, ElementRef, HostListener, Input} from "@angular/core";
+import config from "../../config";
 
 @Component({
     selector: "hab-user-nav",
     template: `
     <div class="main-nav--cta" *ngIf="!isSignedIn">
-      <a class="button" [routerLink]="['/sign-in']">Sign In</a>
+      <a class="button" href="{{ config['www_url'] }}/try">Get Started</a>
     </div>
     <div class="main-nav--profile" *ngIf="isSignedIn">
         <span class="main-nav--avatar">
@@ -56,5 +57,9 @@ export class UserNavComponent {
             (!this.isOpen && this.element.nativeElement.contains(event.target))) {
             this.toggleUserNavMenu();
         }
+    }
+
+    get config() {
+        return config;
     }
 }

--- a/components/builder-web/app/routes.spec.ts
+++ b/components/builder-web/app/routes.spec.ts
@@ -162,4 +162,13 @@ describe("Routes", () => {
       expect(r.component).toBe(SignInPageComponent);
     });
   });
+
+  describe("non-existent routes", () => {
+    it("redirect to /pkgs/core", () => {
+      let r = route("*");
+      let lastRoute = routes[routes.length - 1];
+      expect(r.redirectTo).toBe("/pkgs/core");
+      expect(lastRoute).toBe(r);
+    });
+  });
 });

--- a/components/builder-web/app/routes.ts
+++ b/components/builder-web/app/routes.ts
@@ -120,6 +120,10 @@ export const routes: Routes = [
     {
         path: "orgs/create",
         component: OrganizationCreatePageComponent,
+    },
+    {
+        path: "*",
+        redirectTo: "/pkgs/core"
     }
 ];
 

--- a/components/builder-web/stylesheets/base/_variables.scss
+++ b/components/builder-web/stylesheets/base/_variables.scss
@@ -33,7 +33,7 @@ $global-radius: $base-border-radius;
 $base-spacing: rem(20);
 $small-spacing: $base-spacing / 2;
 $base-z-index: 0;
-$header-height: 106px;
+$header-height: 122px;
 $header-height-mobile: 63px;
 
 // Colors


### PR DESCRIPTION
This change adds a `domain` property to our cookie-setting logic to allow us to share the user’s signed-in state with www.habitat.sh. Also updates a few styles and adds a wildcard route handler to direct unmatched requests to the package-search view.

![](http://i.imgur.com/3qheXo0.gif)

Signed-off-by: Christian Nunciato <cnunciato@chef.io>