### PR TITLE
Inter-site navigation improvements, Part II

### DIFF
--- a/www/config.rb
+++ b/www/config.rb
@@ -72,8 +72,12 @@ helpers do
     else
       ''
     end
-
   end
+
+  def builder_web_url
+    ENV["BUILDER_WEB_URL"] || "https://bldr.habitat.sh"
+  end
+
   def render_markdown(text)
     Kramdown::Document.new(text).to_html
   end

--- a/www/source/javascripts/all.js
+++ b/www/source/javascripts/all.js
@@ -1,5 +1,6 @@
 //= require vendor/jquery.min
 //= require vendor/foundation.min
 //= require vendor/what-input.min
+//= require vendor/js.cookie
 //= require nav.js
 //= require home.js

--- a/www/source/javascripts/nav.js
+++ b/www/source/javascripts/nav.js
@@ -7,6 +7,83 @@ const navPageLinks = ['about', 'docs', 'tutorials', 'community', 'blog'];
 const stickyBreakpoint = 280;
 const stickyVisibleBreakpoint = 300;
 
+(function nav($, cookies) {
+  var profile;
+
+  $(document).ready(function() {
+    var signedOutElements = $(".signed-out");
+    var signedInElements = $(".signed-in");
+    var logo = $(".main-nav--logo a");
+    var avatar = signedInElements.find(".avatar");
+    var dropdown = signedInElements.find(".dropdown");
+    var username = dropdown.find(".username");
+    var signOutLink = dropdown.find(".sign-out");
+
+    if (token()) {
+      $.get("https://api.github.com/user?access_token=" + token())
+        .then(function(p) {
+          signIn(p);
+        }, function(err) {
+          console.error(err);
+          signOut();
+        });
+    }
+    else {
+      signOut();
+    }
+
+    avatar.click(function(e) {
+      e.stopPropagation();
+      dropdown.toggle();
+    });
+
+    signOutLink.click(function() {
+      signOut();
+    });
+
+    logo.click(function(e) {
+      if (signedIn()) {
+        e.preventDefault();
+        location.href = logo.data("builder-url");
+      }
+    });
+
+    $(document).click(function() {
+      dropdown.hide();
+    });
+
+    function token() {
+      return cookies.get("gitHubAuthToken");
+    }
+
+    function signedIn() {
+      return !!token();
+    }
+
+    function signIn(profile) {
+      avatar.find("img").attr("src", profile.avatar_url);
+      username.text(profile.login);
+      signedInElements.css("display", "inline-block");
+    }
+
+    function signOut() {
+      cookies.remove("gitHubAuthState", { domain: cookieDomain() });
+      cookies.remove("gitHubAuthToken", { domain: cookieDomain() });
+      cookies.remove("featureFlags", { domain: cookieDomain() });
+      signedOutElements.css("display", "inline-block");
+      signedInElements.hide();
+    }
+
+    function cookieDomain() {
+        let delim = ".";
+        return location.hostname
+            .split(delim)
+            .splice(-2)
+            .join(delim);
+    }
+  });
+})($, Cookies);
+
 var toggleStickyNav = function() {
   if ($mainNav.is(":not(.has-sidebar)")) {
     if ($(window).width() > navBreakpoint) {

--- a/www/source/javascripts/vendor/js.cookie.js
+++ b/www/source/javascripts/vendor/js.cookie.js
@@ -1,0 +1,165 @@
+/*!
+ * JavaScript Cookie v2.1.4
+ * https://github.com/js-cookie/js-cookie
+ *
+ * Copyright 2006, 2015 Klaus Hartl & Fagner Brack
+ * Released under the MIT license
+ */
+;(function (factory) {
+	var registeredInModuleLoader = false;
+	if (typeof define === 'function' && define.amd) {
+		define(factory);
+		registeredInModuleLoader = true;
+	}
+	if (typeof exports === 'object') {
+		module.exports = factory();
+		registeredInModuleLoader = true;
+	}
+	if (!registeredInModuleLoader) {
+		var OldCookies = window.Cookies;
+		var api = window.Cookies = factory();
+		api.noConflict = function () {
+			window.Cookies = OldCookies;
+			return api;
+		};
+	}
+}(function () {
+	function extend () {
+		var i = 0;
+		var result = {};
+		for (; i < arguments.length; i++) {
+			var attributes = arguments[ i ];
+			for (var key in attributes) {
+				result[key] = attributes[key];
+			}
+		}
+		return result;
+	}
+
+	function init (converter) {
+		function api (key, value, attributes) {
+			var result;
+			if (typeof document === 'undefined') {
+				return;
+			}
+
+			// Write
+
+			if (arguments.length > 1) {
+				attributes = extend({
+					path: '/'
+				}, api.defaults, attributes);
+
+				if (typeof attributes.expires === 'number') {
+					var expires = new Date();
+					expires.setMilliseconds(expires.getMilliseconds() + attributes.expires * 864e+5);
+					attributes.expires = expires;
+				}
+
+				// We're using "expires" because "max-age" is not supported by IE
+				attributes.expires = attributes.expires ? attributes.expires.toUTCString() : '';
+
+				try {
+					result = JSON.stringify(value);
+					if (/^[\{\[]/.test(result)) {
+						value = result;
+					}
+				} catch (e) {}
+
+				if (!converter.write) {
+					value = encodeURIComponent(String(value))
+						.replace(/%(23|24|26|2B|3A|3C|3E|3D|2F|3F|40|5B|5D|5E|60|7B|7D|7C)/g, decodeURIComponent);
+				} else {
+					value = converter.write(value, key);
+				}
+
+				key = encodeURIComponent(String(key));
+				key = key.replace(/%(23|24|26|2B|5E|60|7C)/g, decodeURIComponent);
+				key = key.replace(/[\(\)]/g, escape);
+
+				var stringifiedAttributes = '';
+
+				for (var attributeName in attributes) {
+					if (!attributes[attributeName]) {
+						continue;
+					}
+					stringifiedAttributes += '; ' + attributeName;
+					if (attributes[attributeName] === true) {
+						continue;
+					}
+					stringifiedAttributes += '=' + attributes[attributeName];
+				}
+				return (document.cookie = key + '=' + value + stringifiedAttributes);
+			}
+
+			// Read
+
+			if (!key) {
+				result = {};
+			}
+
+			// To prevent the for loop in the first place assign an empty array
+			// in case there are no cookies at all. Also prevents odd result when
+			// calling "get()"
+			var cookies = document.cookie ? document.cookie.split('; ') : [];
+			var rdecode = /(%[0-9A-Z]{2})+/g;
+			var i = 0;
+
+			for (; i < cookies.length; i++) {
+				var parts = cookies[i].split('=');
+				var cookie = parts.slice(1).join('=');
+
+				if (cookie.charAt(0) === '"') {
+					cookie = cookie.slice(1, -1);
+				}
+
+				try {
+					var name = parts[0].replace(rdecode, decodeURIComponent);
+					cookie = converter.read ?
+						converter.read(cookie, name) : converter(cookie, name) ||
+						cookie.replace(rdecode, decodeURIComponent);
+
+					if (this.json) {
+						try {
+							cookie = JSON.parse(cookie);
+						} catch (e) {}
+					}
+
+					if (key === name) {
+						result = cookie;
+						break;
+					}
+
+					if (!key) {
+						result[name] = cookie;
+					}
+				} catch (e) {}
+			}
+
+			return result;
+		}
+
+		api.set = api;
+		api.get = function (key) {
+			return api.call(api, key);
+		};
+		api.getJSON = function () {
+			return api.apply({
+				json: true
+			}, [].slice.call(arguments));
+		};
+		api.defaults = {};
+
+		api.remove = function (key, attributes) {
+			api(key, '', extend(attributes, {
+				expires: -1
+			}));
+		};
+
+		api.withConverter = init;
+
+		return api;
+	}
+
+	return init(function () {});
+}));

--- a/www/source/layouts/_footer.slim
+++ b/www/source/layouts/_footer.slim
@@ -33,9 +33,9 @@ footer#main-footer class="#{layout_class}"
               li
                 h4 Build Service
               li.footer--sitemap--link
-                a href="https://bldr.habitat.sh/" Find Packages
+                a href="#{builder_web_url}/#/pkgs/core" Find Packages
               li.footer--sitemap--link
-                a href="https://bldr.habitat.sh/#/sign-in" Sign In
+                a href="#{builder_web_url}/#/sign-in" Sign In
               li.footer--sitemap--link
                 a href="/docs/get-habitat/" Download CLI
 

--- a/www/source/layouts/_nav.slim
+++ b/www/source/layouts/_nav.slim
@@ -11,16 +11,16 @@
 
   .main-nav--container.clearfix
     .main-nav--logo
-      a href="/"
+      a href="/" data-builder-url="#{builder_web_url}"
         h1 habitat
     nav.main-nav--links-wrap
       .main-nav--toggle
         = partial "layouts/nav-toggle-icon.svg"
-      .main-nav--cta
-        a.button href="/try" Try Habitat
+      .main-nav--cta.signed-out
+        a.button href="/try" Get Started
       ul.main-nav--links
         li.main-nav--link
-          = link_to 'Why Habitat', '/about/index.html', class: 'about'
+          = link_to 'Explore', "#{builder_web_url}/#/explore"
         li.main-nav--link
           a.tutorials href="/tutorials" Tutorials
         li.main-nav--link
@@ -30,6 +30,14 @@
         li.main-nav--link
           a.blog href="/blog" Blog
         li.main-nav--link
-          a.chefconf href="https://chefconf.chef.io/2017/" ChefConf
-        li.main-nav--link.cta-link
-          a.login href="https://bldr.habitat.sh/#/sign-in" Sign In
+          = link_to 'Depot', "#{builder_web_url}/#/pkgs"
+        li.main-nav--link.cta-link.signed-out
+          a.login href="#{builder_web_url}/#/sign-in" Sign In
+        li.main-nav--link.signed-in
+          .avatar
+            img
+          .dropdown
+            ul
+              li.username
+              li.sign-out
+                a href="#" Sign Out

--- a/www/source/stylesheets/_layout.scss
+++ b/www/source/stylesheets/_layout.scss
@@ -6,7 +6,7 @@ body.body-article {
   background: linear-gradient(0deg, $hab-navy-light, $hab-navy) fixed;
 
   #content-outer {
-    margin: rem-calc(60) 0 rem-calc(90);
+    margin: 0 0 rem-calc(90);
   }
 }
 

--- a/www/source/stylesheets/_mixins.scss
+++ b/www/source/stylesheets/_mixins.scss
@@ -16,8 +16,7 @@
   border-radius: $global-radius;
   color: $hab-orange;
   font-size: rem-calc(16);
-  letter-spacing: rem-calc(1);
-  padding: rem-calc(15) rem-calc(20);
+  padding: rem-calc(10) rem-calc(20);
   transition: all .2s;
 
   &:hover {

--- a/www/source/stylesheets/_nav.scss
+++ b/www/source/stylesheets/_nav.scss
@@ -133,15 +133,81 @@ $main-nav-breakpoint: 769px;
 
     &.main-nav--link {
       margin-top: 0;
+
+      &.signed-out, &.signed-in {
+        display: none;
+      }
+
+      &.signed-in {
+        position: relative;
+        padding-right: 0;
+        margin-right: 12px;
+
+        .avatar {
+          display: block;
+          float: right;
+          border-radius: 50%;
+          border: 1px solid $hab-orange;
+          padding: 2px;
+          cursor: pointer;
+
+          img {
+            display: block;
+            border: solid 2px $hab-white;
+            border-radius: 50%;
+            height: 40px;
+            width: 40px;
+          }
+
+          @include breakpoint(small only) {
+            display: none;
+          }
+        }
+
+        .dropdown {
+          display: none;
+          box-shadow: 0 2px 20px 0 rgba(195,198,200,0.4);
+          background-color: $hab-white;
+          border-radius: 7px;
+          height: auto;
+          padding: 0.9375rem;
+          width: auto;
+          color: #a8adb0;
+          position: absolute;
+          right: 0;
+          top: 52px;
+          z-index: 9999;
+
+          ul {
+            margin-left: 0;
+
+            li {
+              display: block;
+              min-width: 8em;
+              padding-bottom: 0.625rem;
+              text-align: left;
+
+              &:last-child {
+                border-top: 1px solid #D8D8D8;
+                margin-top: 0.5rem;
+                padding-bottom: 0;
+                padding-top: 0.75rem;
+              }
+
+              a {
+                color: #87B09B;
+                line-height: 1.5em;
+                margin-left: 0;
+              }
+            }
+          }
+        }
+      }
     }
   }
 
   @include breakpoint(small only) {
     left: map-get($grid-column-gutter, small)/2;
-  }
-
-  @include breakpoint(medium) {
-    left: rem-calc(15);
   }
 
   @include large-nav {
@@ -157,7 +223,7 @@ $main-nav-breakpoint: 769px;
     }
 
     .main-nav--link {
-      padding: 0 rem-calc(40) 0 0;
+      padding: 0 rem-calc(30) 0 0;
     }
   }
 }
@@ -216,6 +282,10 @@ $main-nav-breakpoint: 769px;
 .main-nav--cta {
   float: right;
   padding: rem-calc(4) rem-calc(20) 0 0;
+
+  &.signed-in, &.signed-out {
+    display: none;
+  }
 
   .button {
     @include button;

--- a/www/source/stylesheets/_settings.scss
+++ b/www/source/stylesheets/_settings.scss
@@ -109,7 +109,7 @@ $body-background: $hab-white;
 $body-font-color: $hab-blue-grey;
 $body-font-family: 'Titillium Web', 'Helvetica Neue', Helvetica, Roboto, Arial, sans-serif;
 $body-antialiased: true;
-$header-height: 106px;
+$header-height: 122px;
 $header-height-mobile: 63px;
 $global-margin: 1rem;
 $global-padding: 1rem;

--- a/www/source/stylesheets/vendor/foundation/components/_button.scss
+++ b/www/source/stylesheets/vendor/foundation/components/_button.scss
@@ -61,7 +61,7 @@ $button-opacity-disabled: 0.25 !default;
   @include disable-mouse-outline;
   display: inline-block;
   text-align: center;
-  line-height: 1;
+  line-height: 1.5;
   cursor: pointer;
   -webkit-appearance: none;
   transition: background-color 0.25s ease-out, color 0.25s ease-out;


### PR DESCRIPTION
This adds some logic to the Habitat web site to detect the visitor’s signed-in status and conditionally display their avatar and a profile menu.

Also adds configurability of the Habitat Depot URL (by default, it's app.habitat.sh), and updates some styles to match current design specs.

![](https://m.popkey.co/886343/DQv7q.gif)

Signed-off-by: Christian Nunciato <cnunciato@chef.io>