### PR TITLE
Remove uniqueness constraints on keys

### DIFF
--- a/components/builder-originsrv/src/migrations/origin_public_keys.rs
+++ b/components/builder-originsrv/src/migrations/origin_public_keys.rs
@@ -84,5 +84,10 @@ pub fn migrate(migrator: &mut Migrator) -> Result<()> {
                     END
                     $$ LANGUAGE plpgsql STABLE"#)?;
 
+    migrator.migrate("originsrv",
+                     r#"ALTER TABLE origin_public_keys
+                        DROP CONSTRAINT IF EXISTS
+                          origin_public_keys_full_name_key"#)?;
+
     Ok(())
 }

--- a/components/builder-originsrv/src/migrations/origin_secret_keys.rs
+++ b/components/builder-originsrv/src/migrations/origin_secret_keys.rs
@@ -69,5 +69,10 @@ pub fn migrate(migrator: &mut Migrator) -> Result<()> {
                     END
                     $$ LANGUAGE plpgsql STABLE"#)?;
 
+    migrator.migrate("originsrv",
+                     r#"ALTER TABLE origin_secret_keys
+                        DROP CONSTRAINT IF EXISTS
+                          origin_secret_keys_full_name_key"#)?;
+
     Ok(())
 }


### PR DESCRIPTION
We *do* need uniqueness constraints on the origin keys, but more than
just these database constraints must be in place. For instance, on a
fresh system, it is impossible to upload packages because `hab`
attempts to upload public keys at the same time, but the API does not
send back 409 conflict if a key is already there; it sends back a
503. We need to fix the API before this constraint is added.

This is an effective reversion of
c2a906cc2852c65ac25f2a8a25941a2961714b2c. The original change was to
an existing migration, which means that any systems already in
existence would not have applied the migration (because they "already
had it"). As such, this behavior was not caught until now, when a
fresh system was created, and the aforementioned errors were
observed. This commit restores previous functionality, paving the way
for an API change and a re-enablement of these uniqueness constraints.

Signed-off-by: Christopher Maier <cmaier@chef.io>