### PR TITLE
Properly sort latest origin packages

### DIFF
--- a/components/builder-originsrv/src/migrations/origin_packages.rs
+++ b/components/builder-originsrv/src/migrations/origin_packages.rs
@@ -84,9 +84,7 @@ pub fn migrate(migrator: &mut Migrator) -> Result<()> {
                     op_target text
                  ) RETURNS SETOF origin_packages AS $$
                     BEGIN
-                        RETURN QUERY SELECT * FROM origin_packages WHERE ident LIKE (op_ident  || '%') AND target = op_target
-                          ORDER BY ident DESC
-                          LIMIT 1;
+                        RETURN QUERY SELECT * FROM origin_packages WHERE ident LIKE (op_ident  || '%') AND target = op_target;
                         RETURN;
                     END
                     $$ LANGUAGE plpgsql STABLE"#)?;


### PR DESCRIPTION
When retrieving the latest package, we are not sorting correctly - we depend on the DB order by which does not work for versions. This change moves the version sorting to the application layer.

Signed-off-by: Salim Alam <salam@chef.io>