### PR TITLE
Less greedy when attempting to query latest packages

### DIFF
--- a/components/builder-originsrv/src/data_store.rs
+++ b/components/builder-originsrv/src/data_store.rs
@@ -548,7 +548,8 @@ impl DataStore {
                                      -> Result<Option<originsrv::OriginPackageIdent>> {
         let conn = self.pool.get(opc)?;
         let rows = conn.query("SELECT * FROM get_origin_package_latest_v1($1, $2)",
-                              &[&opc.get_ident().to_string(), &opc.get_target()])
+                              &[&self.searchable_ident(opc.get_ident().to_string()),
+                                &opc.get_target()])
             .map_err(Error::OriginPackageLatestGet)?;
         if rows.len() != 0 {
             let mut pkgs: Vec<PackageIdent> = Vec::new();
@@ -576,7 +577,7 @@ impl DataStore {
                                              -> Result<Option<originsrv::OriginPackageIdent>> {
         let conn = self.pool.get(ocpg)?;
         let rows = conn.query("SELECT * FROM get_origin_channel_package_latest_v1($1, $2, $3, $4)",
-                              &[&ocpg.get_ident().get_origin(),
+                              &[&self.searchable_ident(ocpg.get_ident().get_origin()),
                                 &ocpg.get_name(),
                                 &ocpg.get_ident().to_string(),
                                 &ocpg.get_target()])

--- a/components/builder-originsrv/src/migrations/origin_packages.rs
+++ b/components/builder-originsrv/src/migrations/origin_packages.rs
@@ -84,7 +84,7 @@ pub fn migrate(migrator: &mut Migrator) -> Result<()> {
                     op_target text
                  ) RETURNS SETOF origin_packages AS $$
                     BEGIN
-                        RETURN QUERY SELECT * FROM origin_packages WHERE ident LIKE (op_ident  || '/%') AND target = op_target;
+                        RETURN QUERY SELECT * FROM origin_packages WHERE ident LIKE (op_ident  || '%') AND target = op_target;
                         RETURN;
                     END
                     $$ LANGUAGE plpgsql STABLE"#)?;


### PR DESCRIPTION
When a user is looking for latest, they are sending a partial package ident but
at the very least it will contain a full origin/name or origin/name/version. We
should only attempt to be greedy past the / separating their query from the next
field

![tenor-5091607](https://cloud.githubusercontent.com/assets/54036/26275615/d262d312-3d19-11e7-92f0-89efa9cb7612.gif)
