### PR TITLE
Handle errors from the stats API

### DIFF
--- a/components/builder-web/app/depotApi.ts
+++ b/components/builder-web/app/depotApi.ts
@@ -152,7 +152,11 @@ export function getStats(origin: string) {
     return new Promise((resolve, reject) => {
         fetch(url)
             .then(response => {
-                response.json().then(data => resolve(data));
+                if (response.ok) {
+                    response.json().then(data => resolve(data));
+                } else {
+                    reject(new Error(response.statusText));
+                }
             })
             .catch(error => reject(error));
     });


### PR DESCRIPTION
Prevents the UI from breaking when the stats API responds with an error. (See #2441.)

![](https://media.tenor.co/images/5928958c42329cf6e101dda2ad295393/tenor.gif)

Signed-off-by: Christian Nunciato <cnunciato@chef.io>