### PR TITLE
Tweak the query for get_origin_package_latest_v1

### DIFF
--- a/components/builder-originsrv/src/migrations/origin_packages.rs
+++ b/components/builder-originsrv/src/migrations/origin_packages.rs
@@ -84,7 +84,7 @@ pub fn migrate(migrator: &mut Migrator) -> Result<()> {
                     op_target text
                  ) RETURNS SETOF origin_packages AS $$
                     BEGIN
-                        RETURN QUERY SELECT * FROM origin_packages WHERE ident LIKE (op_ident  || '%') AND target = op_target;
+                        RETURN QUERY SELECT * FROM origin_packages WHERE ident LIKE (op_ident  || '/%') AND target = op_target;
                         RETURN;
                     END
                     $$ LANGUAGE plpgsql STABLE"#)?;


### PR DESCRIPTION
Modify the search query for latest packages to scope the search correctly.

Signed-off-by: Salim Alam <salam@chef.io>