### PR TITLE
Makes button style consistent globally, fixes padding on posts

### DIFF
--- a/www/source/index.html.slim
+++ b/www/source/index.html.slim
@@ -13,7 +13,7 @@ section.home--hero
         Native manner.
     .home--button-wrap.hero
       = link_to 'Try Habitat Now', '/try', class: "button cta"
-      = link_to 'Download Habitat', '/docs/get-habitat', class: "button cta outline"
+      = link_to 'Download Habitat', '/docs/get-habitat', class: "button outline"
   .home--hero--highlight-wrap
     a.home--hero--highlight href="https://chefconf.chef.io/2017/" target="_blank"
       .home--hero--highlight--left

--- a/www/source/layouts/blog_post.slim
+++ b/www/source/layouts/blog_post.slim
@@ -49,7 +49,7 @@
                       - article.tags.each do |tag|
                         li
                           = link_to "#{tag}", tag_path(tag)
-                  .blog-index--post-summary--body
+                  .blog-index--post-summary--body.body-content
                     h2
                       = link_to article.title, article
                     = article.summary

--- a/www/source/stylesheets/_footer.scss
+++ b/www/source/stylesheets/_footer.scss
@@ -27,6 +27,13 @@
 .footer--cta-button {
   @extend .button;
   @include primary-button;
+
+  &.outline {
+    margin-left: 1rem;
+    font-weight: normal;
+    color: $hab-white !important;
+    text-shadow: none;
+  }
 }
 
 .footer--cta-subtext {

--- a/www/source/stylesheets/_global.scss
+++ b/www/source/stylesheets/_global.scss
@@ -259,22 +259,7 @@ code {
   }
 
   &.outline {
-    border-radius: 7px;
-    background: transparent;
-    border: 1px solid $hab-orange;
-    color: $hab-orange;
-
-    &.footer--cta-button {
-      box-shadow: none;
-      margin-left: rem-calc(20);
-      text-shadow: none;
-      color: $hab-white;
-
-      &:hover {
-        @include shadow-float;
-        transition: all .2s;
-      }
-    }
+    @include button;
   }
 }
 
@@ -284,6 +269,7 @@ code {
   &.outline {
     background-image: none;
     color: $body-font-color;
+    font-weight: normal;
     text-shadow: none;
   }
 }

--- a/www/source/stylesheets/_home.scss
+++ b/www/source/stylesheets/_home.scss
@@ -102,6 +102,7 @@ body.home {
       top: 50%;
       transform: translateY(-50%);
       right: 15px;
+      transition: right .1s;
     }
   }
 
@@ -109,7 +110,12 @@ body.home {
   &:focus,
   &:active {
     color: $white;
-    box-shadow: 0 0 36px 0 rgba(164, 207, 241, 0.21);
+    box-shadow: 0 0 30px 0 rgba(164, 207, 241, 0.12);
+
+    &:after {
+      right: 12px;
+      transition: right .2s;
+    }
   }
 }
 
@@ -121,25 +127,21 @@ body.home {
   min-width: 50px;
   height: 50px;
   background: linear-gradient(to bottom, #BBDB8D, #62AAA8);
-  border-radius: 5px;
+  border-radius: $global-radius 0 0 $global-radius;
   text-align: center;
-  font-size: 12px;
+  font-size: rem-calc(12);
 
   & > span {
     display: block;
-    font-size: 22px;
+    font-size: rem-calc(18);
+    font-weight: 700;
     line-height: 19px;
   }
 
   @include breakpoint(medium) {
     min-width: 72px;
     height: 72px;
-    font-size: 16px;
-
-    & > span {
-      font-size: 25px;
-      line-height: 20px;
-    }
+    font-size: rem-calc(16);
   }
 }
 
@@ -289,8 +291,12 @@ body.home {
   }
 
   & > .button.cta {
-    margin: 1rem;
-    color: $white;
+    @include primary-button;
+    margin-right: 1rem;
+  }
+
+  & > .button.outline {
+    @include button;
   }
 
   & > p {

--- a/www/source/stylesheets/_mixins.scss
+++ b/www/source/stylesheets/_mixins.scss
@@ -22,6 +22,7 @@
   &:hover {
     background-color: transparent;
     box-shadow: $input-shadow-focus;
+    transition: all .2s;
   }
 }
 
@@ -29,12 +30,8 @@
   @include button;
   background-image: linear-gradient(to left, lighten($hab-orange, 13%), lighten($hab-orange-dark, 5%) 100%);
   color: $white;
+  font-weight: 700;
   text-shadow: 0 1px 2px #EB6852;
-
-  &:hover {
-    @include shadow-float;
-    transition: all .2s;
-  }
 }
 
 @mixin linear-gradient($pos, $g1, $g2: null,

--- a/www/source/stylesheets/_settings.scss
+++ b/www/source/stylesheets/_settings.scss
@@ -281,7 +281,7 @@ $breadcrumbs-item-slash: true;
 // 11. Button
 // ----------
 
-$button-padding: rem-calc(15) rem-calc(20);
+$button-padding: rem-calc(10) rem-calc(20);
 $button-margin: 0 0 $global-margin 0;
 $button-fill: solid;
 $button-background: $hab-cta;


### PR DESCRIPTION
Fixes #2450 

What started with different sized buttons on the community page led to an overall scrubbing to make all buttons similar across the site (minor fix that was long overdue). Also increased the font weight on the primary call-to-action buttons (with gradient orange background) to increase contrast and thus make them more readable.

Also fixes padding on the recommended posts that appear at the bottom of a post, and a little touch up for the highlighted event on the home page.
![screenshot 2017-05-20 15 50 42](https://cloud.githubusercontent.com/assets/446285/26279253/3352f10c-3d74-11e7-9662-38a1ead640d1.png)
![screenshot 2017-05-20 15 51 02](https://cloud.githubusercontent.com/assets/446285/26279251/334c01ee-3d74-11e7-9c16-27383d7b2c23.png)
![screenshot 2017-05-20 15 51 17](https://cloud.githubusercontent.com/assets/446285/26279252/3351c8a4-3d74-11e7-860d-b54c82c898e3.png)




Signed-off-by: Ryan Keairns <rkeairns@chef.io>