### PR TITLE
Encode search-query parameters

### DIFF
--- a/components/builder-web/app/actions.test.ts
+++ b/components/builder-web/app/actions.test.ts
@@ -15,6 +15,7 @@
 import * as cookies from "js-cookie";
 import * as gitHub from "./actions/gitHub";
 import * as actions from "./actions/index";
+import * as depotApi from "./depotApi";
 
 describe("actions", () => {
 
@@ -38,6 +39,18 @@ describe("actions", () => {
             expect(actions.populateExploreStats(data)).toEqual({
                 type: actions.POPULATE_EXPLORE_STATS,
                 payload: data
+            });
+        });
+    });
+
+    describe("filterPackagesBy", () => {
+
+        describe("given a query parameter", () => {
+
+            it("encodes the parameter before sending it", () => {
+                spyOn(depotApi, "get").and.returnValue(new Promise(() => {}));
+                actions.filterPackagesBy({}, "core/awesome", false)(() => {});
+                expect(depotApi.get).toHaveBeenCalledWith({ query: "core%2Fawesome" }, 0);
             });
         });
     });

--- a/components/builder-web/app/actions/packages.ts
+++ b/components/builder-web/app/actions/packages.ts
@@ -134,11 +134,11 @@ export function filterPackagesBy(
         }
 
         if (query) {
-            params = { query };
+            params.query = encodeURIComponent(query);
         }
 
         if (distinct) {
-            params["distinct"] = true;
+            params.distinct = true;
         }
 
         depotApi.get(params, nextRange).then(response => {


### PR DESCRIPTION
Search queries can contain URL-unfriendly characters (e.g., slashes). This just escapes them before sending them. (See #2440)

![](https://media.tenor.co/images/ffdca63ebf612874f3d5a986fb24c954/tenor.gif)

Signed-off-by: Christian Nunciato <cnunciato@chef.io>