### PR TITLE
CensusMember is alive if it is ourself

### DIFF
--- a/components/sup/src/census.rs
+++ b/components/sup/src/census.rs
@@ -350,9 +350,15 @@ impl CensusGroup {
 
     fn update_from_service_rumors(&mut self, rumors: &HashMap<String, ServiceRumor>) {
         for (member_id, service_rumor) in rumors.iter() {
+            // Yeah - we are ourself - we're alive.
+            let is_self = member_id == &self.local_member_id;
             let mut member = self.population
                 .entry(member_id.to_string())
-                .or_insert(CensusMember::default());
+                .or_insert_with(|| {
+                                    let mut new_member = CensusMember::default();
+                                    new_member.alive = is_self;
+                                    new_member
+                                });
             member.update_from_service_rumor(&self.service_group, service_rumor);
         }
     }


### PR DESCRIPTION
When we construct a new CensusMember we always use the default trait.
The default trait will set the `alive` field to false. When a service
rumor is exchanged into a CensusMember we would previously not check
to see if the rumor originated from ourself.

With this change any CensusMember that we inject will first check
to see if it originated from our member_id. If it has, then we will
mark the CensusMember as alive.

![tenor-181872199](https://cloud.githubusercontent.com/assets/54036/26292542/a8aa351c-3e6b-11e7-9371-6c614081c649.gif)
