### PR TITLE
fix originsrv compile errors around searchable_ident and add originsrv to travis components

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -106,7 +106,7 @@ matrix:
       language: rust
       env:
         - COMPONENTS=srv LIBSODIUM_PREFIX=$HOME/pkgs/libsodium/1.0.12 LIBARCHIVE_PREFIX=$HOME/pkgs/libarchive/3.2.0 LIBZMQ_PREFIX=$HOME/pkgs/zeromq/4.1.4 PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$LIBARCHIVE_PREFIX/lib/pkgconfig:$LIBSODIUM_PREFIX/lib/pkgconfig:$LIBZMQ_PREFIX/lib/pkgconfig" LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$LIBARCHIVE_PREFIX/lib:$LIBSODIUM_PREFIX/lib:$LIBZMQ_PREFIX/lib" LIBRARY_PATH="$LIBRARY_PATH:$LIBZMQ_PREFIX/lib"
-        - AFFECTED_DIRS="components/builder-api|components/builder-admin|components/builder-jobsrv|components/builder-sessionsrv|components/builder-vault|components/builder-worker|components/builder-depot"
+        - AFFECTED_DIRS="components/builder-api|components/builder-admin|components/builder-jobsrv|components/builder-sessionsrv|components/builder-originsrv|components/builder-worker|components/builder-depot"
       rust: stable
       sudo: required
       addons:

--- a/components/builder-originsrv/src/data_store.rs
+++ b/components/builder-originsrv/src/data_store.rs
@@ -549,7 +549,7 @@ impl DataStore {
                                      -> Result<Option<originsrv::OriginPackageIdent>> {
         let conn = self.pool.get(opc)?;
         let rows = conn.query("SELECT * FROM get_origin_package_latest_v1($1, $2)",
-                              &[&self.searchable_ident(opc.get_ident().to_string()),
+                              &[&self.searchable_ident(opc.get_ident()),
                                 &opc.get_target()])
             .map_err(Error::OriginPackageLatestGet)?;
         if rows.len() != 0 {
@@ -578,9 +578,9 @@ impl DataStore {
                                              -> Result<Option<originsrv::OriginPackageIdent>> {
         let conn = self.pool.get(ocpg)?;
         let rows = conn.query("SELECT * FROM get_origin_channel_package_latest_v1($1, $2, $3, $4)",
-                              &[&self.searchable_ident(ocpg.get_ident().get_origin()),
+                              &[&ocpg.get_ident().get_origin(),
                                 &ocpg.get_name(),
-                                &ocpg.get_ident().to_string(),
+                                &self.searchable_ident(ocpg.get_ident()),
                                 &ocpg.get_target()])
             .map_err(Error::OriginChannelPackageLatestGet)?;
         if rows.len() != 0 {


### PR DESCRIPTION
Looks like https://github.com/habitat-sh/habitat/pull/2439/commits/0bcbf6ee020a9a024ed6de94b81079cdc055fc46 was not compiling. This fixes those compile errors and also adjusts our travis job to build originsrv changes.

Signed-off-by: Matt Wrock <matt@mattwrock.com>