### PR TITLE
version get_origin_package_latest function so that the db gets the correct query

### DIFF
--- a/components/builder-originsrv/src/data_store.rs
+++ b/components/builder-originsrv/src/data_store.rs
@@ -569,7 +569,7 @@ impl DataStore {
                                      opc: &originsrv::OriginPackageLatestGet)
                                      -> Result<Option<originsrv::OriginPackageIdent>> {
         let conn = self.pool.get(opc)?;
-        let rows = conn.query("SELECT * FROM get_origin_package_latest_v1($1, $2)",
+        let rows = conn.query("SELECT * FROM get_origin_package_latest_v2($1, $2)",
                               &[&self.searchable_ident(opc.get_ident()), &opc.get_target()])
             .map_err(Error::OriginPackageLatestGet)?;
         if rows.len() != 0 {

--- a/components/builder-originsrv/src/migrations/origin_packages.rs
+++ b/components/builder-originsrv/src/migrations/origin_packages.rs
@@ -84,7 +84,7 @@ pub fn migrate(migrator: &mut Migrator) -> Result<()> {
                     op_target text
                  ) RETURNS SETOF origin_packages AS $$
                     BEGIN
-                        RETURN QUERY SELECT * FROM origin_packages WHERE ident LIKE (op_ident  || '%') AND target = op_target;
+                        RETURN QUERY SELECT * FROM origin_packages WHERE ident LIKE (op_ident  || '/%') AND target = op_target;
                         RETURN;
                     END
                     $$ LANGUAGE plpgsql STABLE"#)?;
@@ -208,6 +208,16 @@ pub fn migrate(migrator: &mut Migrator) -> Result<()> {
                  ) RETURNS TABLE(version text, release_count bigint, latest text) AS $$
                     BEGIN
                         RETURN QUERY SELECT p.partial_ident[3] AS version, COUNT(p.partial_ident[4]) AS release_count, MAX(p.partial_ident[4]) as latest FROM (SELECT regexp_split_to_array(op.ident, '/') AS partial_ident FROM origin_packages op INNER JOIN origins o ON o.id = op.origin_id WHERE o.name = op_origin AND op.name = op_pkg) AS p GROUP BY version;
+                        RETURN;
+                    END
+                    $$ LANGUAGE plpgsql STABLE"#)?;
+    migrator.migrate("originsrv",
+                 r#"CREATE OR REPLACE FUNCTION get_origin_package_latest_v2 (
+                    op_ident text,
+                    op_target text
+                 ) RETURNS SETOF origin_packages AS $$
+                    BEGIN
+                        RETURN QUERY SELECT * FROM origin_packages WHERE ident LIKE (op_ident  || '%') AND target = op_target;
                         RETURN;
                     END
                     $$ LANGUAGE plpgsql STABLE"#)?;


### PR DESCRIPTION
This should fix production which is using a v1 that adds a `/` to the query which we now do in rust so we are querryng for `ident/name//`.

Signed-off-by: Matt Wrock <matt@mattwrock.com>