### PR TITLE
[studio] Source .studiorc after superivsor is started

### DIFF
--- a/components/studio/libexec/hab-studio-type-default.sh
+++ b/components/studio/libexec/hab-studio-type-default.sh
@@ -100,11 +100,6 @@ alias fgrep='fgrep --color=auto'
 # Set TERMINFO so hab can give us a delightful experience.
 export TERMINFO=$(_pkgpath_for core/ncurses)/share/terminfo
 
-# Source /src/.studiorc so we can set some user environment vars quicker.
-if [ -f /src/.studiorc ];then
-  source /src/.studiorc
-fi
-
 emacs() {
   if command -v emacs > /dev/null; then
     emacs \$*
@@ -160,6 +155,11 @@ alias sl='sup-log'
 if [[ -n "\${STUDIO_ENTER:-}" ]]; then
   unset STUDIO_ENTER
   source /etc/profile.enter
+fi
+
+# Source /src/.studiorc so we can apply user-specific configuration
+if [ -f /src/.studiorc ];then
+  source /src/.studiorc
 fi
 
 # Add command line completion


### PR DESCRIPTION
In order to put something like

`echo foo=1 | hab apply bar.default 1` into my .studiorc, the supervisor
must first be running.

This change moves the sourcing to where after the supervisor starts so I
can interact with it in my .studiorc.

![tenor-102872141](https://cloud.githubusercontent.com/assets/9912/26567040/9b9bf54c-44bd-11e7-99d1-4697a51b6b21.gif)
