### PR TITLE
allow for depot searches to contain origin/name

### DIFF
--- a/components/builder-depot/src/server.rs
+++ b/components/builder-depot/src/server.rs
@@ -1489,7 +1489,13 @@ fn search_packages(req: &mut Request) -> IronResult<Response> {
 
     {
         let params = req.extensions.get::<Router>().unwrap();
-        request.set_query(params.find("query").unwrap().to_string());
+        request.set_query(url::percent_encoding::percent_decode(params
+                                                                    .find("query")
+                                                                    .unwrap()
+                                                                    .as_bytes())
+                                  .decode_utf8()
+                                  .unwrap()
+                                  .to_string());
     };
 
     debug!("search_packages called with: {}", request.get_query());
@@ -2713,7 +2719,7 @@ mod test {
         broker.setup::<OriginPackageSearchRequest, OriginPackageListResponse>(&pkg_res);
 
         let (response, msgs) = iron_request(method::Get,
-                                            "http://localhost/pkgs/search/name?range=2",
+                                            "http://localhost/pkgs/search/org%2Fname?range=2",
                                             &mut Vec::new(),
                                             Headers::new(),
                                             broker);
@@ -2748,7 +2754,7 @@ mod test {
         let package_req = msgs.get::<OriginPackageSearchRequest>().unwrap();
         assert_eq!(package_req.get_start(), 2);
         assert_eq!(package_req.get_stop(), 51);
-        assert_eq!(package_req.get_query(), "name".to_string());
+        assert_eq!(package_req.get_query(), "org/name".to_string());
     }
 
     #[test]

--- a/components/builder-originsrv/src/data_store.rs
+++ b/components/builder-originsrv/src/data_store.rs
@@ -747,7 +747,7 @@ impl DataStore {
         let conn = self.pool.get(ops)?;
 
         let rows = if *&ops.get_distinct() {
-            conn.query("SELECT * FROM search_all_origin_packages_dynamic_v1($1, $2, $3)",
+            conn.query("SELECT * FROM search_all_origin_packages_dynamic_v2($1, $2, $3)",
                        &[&ops.get_query(), &ops.limit(), &(ops.get_start() as i64)])
                 .map_err(Error::OriginPackageSearch)?
         } else {

--- a/components/builder-originsrv/tests/data_store/mod.rs
+++ b/components/builder-originsrv/tests/data_store/mod.rs
@@ -1185,24 +1185,20 @@ fn search_origin_package_for_origin() {
     let pkg1 = result3.get_idents().iter().nth(0).unwrap();
     assert_eq!(pkg1.to_string(), ident4.to_string());
 
-    ops.set_query("re".to_string());
+    ops.set_query("core/re".to_string());
     ops.set_start(0);
     ops.set_stop(20);
     ops.set_distinct(true);
     let result2 = ds.search_origin_package_for_origin(&ops)
         .expect("Could not get the packages from the database");
-    assert_eq!(result2.get_idents().len(), 4);
+    assert_eq!(result2.get_idents().len(), 2);
     assert_eq!(result2.get_start(), 0);
-    assert_eq!(result2.get_stop(), 3);
-    assert_eq!(result2.get_count(), 1);
+    assert_eq!(result2.get_stop(), 1);
+    assert_eq!(result2.get_count(), 2);
     let pkg1 = result2.get_idents().iter().nth(0).unwrap();
-    assert_eq!(pkg1.to_string(), "core/red_dog");
+    assert_eq!(pkg1.to_string(), "core/red");
     let pkg2 = result2.get_idents().iter().nth(1).unwrap();
-    assert_eq!(pkg2.to_string(), "core/red");
-    let pkg3 = result2.get_idents().iter().nth(2).unwrap();
-    assert_eq!(pkg3.to_string(), "core2/red");
-    let pkg4 = result2.get_idents().iter().nth(3).unwrap();
-    assert_eq!(pkg4.to_string(), "josh/red_dog");
+    assert_eq!(pkg2.to_string(), "core/red_dog");
 }
 
 #[test]


### PR DESCRIPTION
This is the back side of https://github.com/habitat-sh/habitat/pull/2465 and:

1. decodes the query
2. changes the db query to do a `LIKE` search of the package ident instead of searching for the query in either the origin name or the package name.

Signed-off-by: Matt Wrock <matt@mattwrock.com>