### PR TITLE
[plan-build] pass -o to unzip

### DIFF
--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -1806,7 +1806,7 @@ unpack_file() {
       *.bz2)  bunzip2 $unpack_file    ;;
       *.rar)  rar x $unpack_file      ;;
       *.gz)   gunzip $unpack_file     ;;
-      *.zip)  unzip $unpack_file      ;;
+      *.zip)  unzip -o $unpack_file   ;;
       *.Z)    uncompress $unpack_file ;;
       *.7z)   7z x $unpack_file       ;;
       *)


### PR DESCRIPTION
The busybox unzip used in the plan build process will drop to a prompt
like this if a file already exists:

```
   nomad: Unpacking nomad_0.5.6_linux_amd64.zip
Archive:  /hab/cache/src/nomad_0.5.6_linux_amd64.zip
replace nomad? [y]es, [n]o, [A]ll, [N]one, [r]ename:
```

Pass `-o` for "overwrite" so it just overwrites the file.

![tenor-55591793](https://cloud.githubusercontent.com/assets/9912/26649078/3706fe6c-460a-11e7-8546-ca57ad7489d0.gif)
