### PR TITLE
Add HAB_UPDATE_STRATEGY_FREQUENCY_MS to studio propagated vars

### DIFF
--- a/components/hab/src/command/studio/mod.rs
+++ b/components/hab/src/command/studio/mod.rs
@@ -305,6 +305,7 @@ mod inner {
         let env_vars = vec!["HAB_DEPOT_URL",
                             "HAB_ORIGIN",
                             "HAB_STUDIO_SUP",
+                            "HAB_UPDATE_STRATEGY_FREQUENCY_MS",
                             "http_proxy",
                             "https_proxy"];
         for var in env_vars {


### PR DESCRIPTION
This is needed to tell the supervisor how often to check for updates,
which, in a studio, you often want to do right away after you've built a
package.

This is not available as a command line option to `hab sup run`, so it
cannot be set via the `HAB_STUDIO_SUP` options. Therefore, we make it so
it can be set outside the studio.

![tenor-72610810](https://cloud.githubusercontent.com/assets/9912/26702340/346d7ce0-46ea-11e7-8bf4-e56c8b6d420a.gif)
