### PR TITLE
Add Terraform services log level customization

### DIFF
--- a/terraform/instances.tf
+++ b/terraform/instances.tf
@@ -541,6 +541,7 @@ data "template_file" "hab_sup" {
     flags               = "--listen-gossip 0.0.0.0:${var.gossip_listen_port} --listen-http 0.0.0.0:${var.http_listen_port}"
     gossip_listen_port  = "${var.gossip_listen_port}"
     peer_ip             = "${aws_instance.datastore.0.private_ip}"
+    log_level           = "${var.log_level}"
   }
 }
 
@@ -551,6 +552,7 @@ data "template_file" "hab_sup_permanent" {
     flags               = "--listen-gossip 0.0.0.0:${var.gossip_listen_port} --listen-http 0.0.0.0:${var.http_listen_port} --permanent-peer"
     gossip_listen_port  = "${var.gossip_listen_port}"
     peer_ip             = "${aws_instance.datastore.0.private_ip}"
+    log_level           = "${var.log_level}"
   }
 }
 
@@ -561,5 +563,6 @@ data "template_file" "hab_sup_seed" {
     flags               = "--listen-gossip 0.0.0.0:${var.gossip_listen_port} --listen-http 0.0.0.0:${var.http_listen_port} --permanent-peer"
     gossip_listen_port  = "${var.gossip_listen_port}"
     peer_ip             = "127.0.0.1"
+    log_level           = "${var.log_level}"
   }
 }

--- a/terraform/templates/hab-sup.service
+++ b/terraform/templates/hab-sup.service
@@ -2,6 +2,7 @@
 Description=Habitat Supervisor
 
 [Service]
+Environment=RUST_LOG=${log_level},habitat_butterfly=error
 ExecStartPre=/bin/bash -c "/bin/systemctl set-environment SSL_CERT_FILE=$(hab pkg path core/cacerts)/ssl/cert.pem"
 ExecStart=/bin/hab run --peer ${peer_ip}:${gossip_listen_port} ${flags}
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -49,6 +49,11 @@ variable "release_channel" {
   default     = "stable"
 }
 
+variable "log_level" {
+  description = "The RUST_LOG logging level for the builder services"
+  default     = "error"
+}
+
 variable "gossip_listen_port" {
   description = "Port for Habitat Supervisor's --gossip-listen"
   default     = 9638


### PR DESCRIPTION
This change adds the ability to customize the Terraform services logging level.  It defaults to error level logging.

Signed-off-by: Salim Alam <salam@chef.io>