### PR TITLE
Create bucket for job logs

### DIFF
--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -1,0 +1,40 @@
+////////////////////////////////
+// Job Log Storage in S3
+//
+// Currently, we need to get a key and secret for this user and put
+// those into the jobsrv config. In the future, we may be able to just
+// use instance roles.
+resource "aws_iam_user" "jobs" {
+  name = "jobs-${var.env}"
+}
+
+// Job log storage; the server retrieves logs on behalf of requestors,
+// so this can be pretty locked down.
+resource "aws_s3_bucket" "jobs" {
+  bucket = "habitat-jobs-${var.env}"
+  acl    = "private"
+  region = "${var.aws_region}"
+}
+
+// The job user (and only the job user) can put / get objects in the
+// bucket!
+resource "aws_s3_bucket_policy" "jobs" {
+  bucket = "${aws_s3_bucket.jobs.id}"
+  policy = <<EOF
+{
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "${aws_iam_user.jobs.arn}"
+      },
+      "Resource": "${aws_s3_bucket.jobs.arn}/*",
+      "Action": [
+        "s3:GetObject",
+        "s3:PutObject"
+      ]
+    }
+  ]
+}
+EOF
+}


### PR DESCRIPTION
This creates an S3 bucket to store job logs in, along with an IAM user
and a bucket policy that only allows that user to put and get objects
from the bucket.

To configure the job server to use the bucket, we will need to create
a key and secret for this IAM user out-of-band, but we may be able to
use instance roles in the near-ish future.

Signed-off-by: Christopher Maier <cmaier@chef.io>