### PR TITLE
Miscellaneous Terraform Tweaks

### DIFF
--- a/terraform/instances.tf
+++ b/terraform/instances.tf
@@ -56,6 +56,7 @@ resource "aws_instance" "api" {
     X-Contact     = "The Habitat Maintainers <humans@habitat.sh>"
     X-Environment = "${var.env}"
     X-Application = "builder"
+    X-ManagedBy   = "Terraform"
   }
 }
 
@@ -114,6 +115,7 @@ resource "aws_instance" "admin" {
     X-Contact     = "The Habitat Maintainers <humans@habitat.sh>"
     X-Environment = "${var.env}"
     X-Application = "builder"
+    X-ManagedBy   = "Terraform"
   }
 }
 
@@ -174,6 +176,7 @@ resource "aws_instance" "datastore" {
     X-Contact     = "The Habitat Maintainers <humans@habitat.sh>"
     X-Environment = "${var.env}"
     X-Application = "builder"
+    X-ManagedBy   = "Terraform"
   }
 }
 
@@ -234,6 +237,7 @@ resource "aws_instance" "jobsrv" {
     X-Contact     = "The Habitat Maintainers <humans@habitat.sh>"
     X-Environment = "${var.env}"
     X-Application = "builder"
+    X-ManagedBy   = "Terraform"
   }
 }
 
@@ -293,6 +297,7 @@ resource "aws_instance" "originsrv" {
     X-Contact     = "The Habitat Maintainers <humans@habitat.sh>"
     X-Environment = "${var.env}"
     X-Application = "builder"
+    X-ManagedBy   = "Terraform"
   }
 }
 
@@ -351,6 +356,7 @@ resource "aws_instance" "router" {
     X-Contact     = "The Habitat Maintainers <humans@habitat.sh>"
     X-Environment = "${var.env}"
     X-Application = "builder"
+    X-ManagedBy   = "Terraform"
   }
 }
 
@@ -410,6 +416,7 @@ resource "aws_instance" "scheduler" {
     X-Contact     = "The Habitat Maintainers <humans@habitat.sh>"
     X-Environment = "${var.env}"
     X-Application = "builder"
+    X-ManagedBy   = "Terraform"
   }
 }
 
@@ -469,6 +476,7 @@ resource "aws_instance" "sessionsrv" {
     X-Contact     = "The Habitat Maintainers <humans@habitat.sh>"
     X-Environment = "${var.env}"
     X-Application = "builder"
+    X-ManagedBy   = "Terraform"
   }
 }
 
@@ -528,6 +536,7 @@ resource "aws_instance" "worker" {
     X-Contact     = "The Habitat Maintainers <humans@habitat.sh>"
     X-Environment = "${var.env}"
     X-Application = "builder"
+    X-ManagedBy   = "Terraform"
   }
 }
 

--- a/terraform/load-balancers.tf
+++ b/terraform/load-balancers.tf
@@ -23,6 +23,7 @@ resource "aws_elb" "admin" {
   tags {
     X-Environment = "${var.env}"
     X-Application = "builder"
+    X-ManagedBy   = "Terraform"
   }
 }
 
@@ -51,6 +52,7 @@ resource "aws_elb" "api" {
   tags {
     X-Environment = "${var.env}"
     X-Application = "builder"
+    X-ManagedBy   = "Terraform"
   }
 }
 

--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -20,6 +20,12 @@ resource "aws_s3_bucket" "jobs" {
   lifecycle {
     prevent_destroy = true
   }
+
+  tags {
+    Name          = "habitat-jobs-${var.env}"
+    X-Contact     = "The Habitat Maintainers <humans@habitat.sh>"
+    X-Environment = "${var.env}"
+  }
 }
 
 data "aws_iam_policy_document" "job_user_can_get_and_put_logs" {

--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -25,6 +25,7 @@ resource "aws_s3_bucket" "jobs" {
     Name          = "habitat-jobs-${var.env}"
     X-Contact     = "The Habitat Maintainers <humans@habitat.sh>"
     X-Environment = "${var.env}"
+    X-ManagedBy   = "Terraform"
   }
 }
 

--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -7,6 +7,7 @@
 
 resource "aws_iam_user" "jobs" {
   name = "jobs-${var.env}"
+  force_destroy = false # be explicit here, because we will have access keys
 }
 
 // Job log storage; the server retrieves logs on behalf of requestors,

--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -14,6 +14,10 @@ resource "aws_s3_bucket" "jobs" {
   bucket = "habitat-jobs-${var.env}"
   acl    = "private"
   region = "${var.aws_region}"
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 // The job user (and only the job user) can put / get objects in the

--- a/terraform/security-groups.tf
+++ b/terraform/security-groups.tf
@@ -24,6 +24,7 @@ resource "aws_security_group" "datastore" {
     X-Contact     = "The Habitat Maintainers <humans@habitat.sh>"
     X-Environment = "${var.env}"
     X-Application = "builder"
+    X-ManagedBy   = "Terraform"
   }
 }
 
@@ -36,6 +37,7 @@ resource "aws_security_group" "datastore_client" {
     X-Contact     = "The Habitat Maintainers <humans@habitat.sh>"
     X-Environment = "${var.env}"
     X-Application = "builder"
+    X-ManagedBy   = "Terraform"
   }
 }
 
@@ -75,6 +77,7 @@ resource "aws_security_group" "gateway" {
     X-Contact     = "The Habitat Maintainers <humans@habitat.sh>"
     X-Environment = "${var.env}"
     X-Application = "builder"
+    X-ManagedBy   = "Terraform"
   }
 }
 
@@ -101,6 +104,7 @@ resource "aws_security_group" "gateway_elb" {
     X-Contact     = "The Habitat Maintainers <humans@habitat.sh>"
     X-Environment = "${var.env}"
     X-Application = "builder"
+    X-ManagedBy   = "Terraform"
   }
 }
 
@@ -123,6 +127,7 @@ resource "aws_security_group" "jobsrv" {
     X-Contact     = "The Habitat Maintainers <humans@habitat.sh>"
     X-Environment = "${var.env}"
     X-Application = "builder"
+    X-ManagedBy   = "Terraform"
   }
 }
 
@@ -135,6 +140,7 @@ resource "aws_security_group" "jobsrv_client" {
     X-Contact     = "The Habitat Maintainers <humans@habitat.sh>"
     X-Environment = "${var.env}"
     X-Application = "builder"
+    X-ManagedBy   = "Terraform"
   }
 }
 
@@ -174,6 +180,7 @@ resource "aws_security_group" "router" {
     X-Contact     = "The Habitat Maintainers <humans@habitat.sh>"
     X-Environment = "${var.env}"
     X-Application = "builder"
+    X-ManagedBy   = "Terraform"
   }
 }
 
@@ -192,6 +199,7 @@ resource "aws_security_group" "service" {
     X-Contact     = "The Habitat Maintainers <humans@habitat.sh>"
     X-Environment = "${var.env}"
     X-Application = "builder"
+    X-ManagedBy   = "Terraform"
   }
 }
 
@@ -210,5 +218,6 @@ resource "aws_security_group" "worker" {
     X-Contact     = "The Habitat Maintainers <humans@habitat.sh>"
     X-Environment = "${var.env}"
     X-Application = "builder"
+    X-ManagedBy   = "Terraform"
   }
 }

--- a/terraform/www.tf
+++ b/terraform/www.tf
@@ -41,6 +41,7 @@ resource "aws_s3_bucket" "www" {
     Name          = "habitat-www-${var.env}"
     X-Contact     = "The Habitat Maintainers <humans@habitat.sh>"
     X-Environment = "${var.env}"
+    X-ManagedBy   = "Terraform"
   }
 
   website {

--- a/terraform/www.tf
+++ b/terraform/www.tf
@@ -37,6 +37,12 @@ resource "aws_s3_bucket" "www" {
     prevent_destroy = true
   }
 
+  tags {
+    Name          = "habitat-www-${var.env}"
+    X-Contact     = "The Habitat Maintainers <humans@habitat.sh>"
+    X-Environment = "${var.env}"
+  }
+
   website {
     index_document = "index.html"
     error_document = "404/index.html"

--- a/terraform/www.tf
+++ b/terraform/www.tf
@@ -33,6 +33,10 @@ resource "aws_s3_bucket" "www" {
   bucket = "habitat-www-${var.env}"
   acl    = "public-read"
 
+  lifecycle {
+    prevent_destroy = true
+  }
+
   website {
     index_document = "index.html"
     error_document = "404/index.html"


### PR DESCRIPTION
Guess who spent the weekend learning how to use Terraform?

This PR introduces a few small changes, which are each introduced in their own PR. The most important ones are probably adding `prevent_destroy` lifecycle hooks on our `www` and `jobs` S3 buckets, and adding a `X-ManagedBy=Terraform` tag to everything that takes tags, because metadata is great.
