### PR TITLE
Pull habitat events into the community page from events.chef.io

### DIFF
--- a/www/source/community.html.slim
+++ b/www/source/community.html.slim
@@ -20,14 +20,15 @@ section.community--hero
                 a.button.outline href="/docs/contribute-help-build/" Contribute to Habitat
 
 #community-event-template
-  .community--events--card.columns.medium-5
+  .community--events--card.columns.medium-4
     .community--events--card-heading.heading.a
       ul.no-bullet
         li
           | {{ event_type }}
     .body-content
-      a.h4 href="{{ event_link }}"
-        | {{ event_name }}
+      h4
+        a href="{{ event_link }}"
+          | {{ event_name }}
       p
         | {{ event_description }}
       .article-detail--meta

--- a/www/source/community.html.slim
+++ b/www/source/community.html.slim
@@ -19,89 +19,33 @@ section.community--hero
               li
                 a.button.outline href="/docs/contribute-help-build/" Contribute to Habitat
 
+#community-event-template
+  .community--events--card.columns.medium-5
+    .community--events--card-heading.heading.a
+      ul.no-bullet
+        li
+          | {{ event_type }}
+    .body-content
+      a.h4 href="{{ event_link }}"
+        | {{ event_name }}
+      p
+        | {{ event_description }}
+      .article-detail--meta
+        ul.no-bullet
+          li
+            img[src="/images/icons/icon-calendar.svg" alt="calendar icon"]
+            a. href="{{ event_date_url }}"
+              | {{ event_date }}
+          li
+            img[src="/images/icons/icon-pin.svg" alt="map pin icon"]
+              | {{ event_location }}
+
 section.community--events
   .row
     .columns.medium-12
       .community--events--content
         h2 Upcoming Events
-        .row
-          .community--events--card.columns.medium-5
-            .community--events--card-heading.heading.a
-              ul.no-bullet
-                li Meetup
-            .body-content
-              a.h4 href="https://events.chef.io/events/chef-london-meetup/" London Chef Meetup
-              p
-                | Following ChefConf 2017, the London Chef Meetup will discuss all of the
-                  awesome things learned and discovered in the Chef Ecosystem through the week.
-              .article-detail--meta
-                ul.no-bullet
-                  li
-                    img[src="/images/icons/icon-calendar.svg"
-                      onerror="this.src='/images/icons/icon-calendar.png'" alt="calendar icon"]
-                    a. href="https://events.chef.io/events/s/category/habitat/?scope%5B0%5D=2017-06-15&scope%5B1%5D=2017-06-15" June 15, 2017
-                  li
-                    img[src="/images/icons/icon-pin.svg"
-                      onerror="this.src='/images/icons/icon-pin.png'" alt="map pin icon"]
-                    | London, UK
-          .community--events--card.columns.medium-5
-            .community--events--card-heading.heading
-              ul.no-bullet
-                li Conference
-            .body-content
-              a.h4 href="https://events.chef.io/events/velocity/" Velocity Conference 2017
-              p
-                | Jamie Winsor walks you through the basics of building distributed systems.
-                  A keynote by Adam Jacob. Both will touch on Habitat and the ways it can help.
-              .article-detail--meta
-                ul.no-bullet
-                  li
-                    img[src="/images/icons/icon-calendar.svg"
-                      onerror="this.src='/images/icons/icon-calendar.png'" alt="calendar icon"]
-                    a. href="https://events.chef.io/events/s/category/habitat/?scope%5B0%5D=2017-06-20&scope%5B1%5D=2017-06-22" June 20-22, 2017
-                  li
-                    img[src="/images/icons/icon-pin.svg"
-                      onerror="this.src='/images/icons/icon-pin.png'" alt="map pin icon"]
-                    | San Jose, CA
-        .row
-          .community--events--card.columns.medium-5
-            .community--events--card-heading.heading
-              ul.no-bullet
-                li Conference
-            .body-content
-              a.h4 href="https://events.chef.io/events/mongodb-world/" MongoDB World
-              p
-                | Come stop by our booth at MongoDB World 2017 and learn how to deploy
-                  mission-critical applications at web-scale using Habitat.
-              .article-detail--meta
-                ul.no-bullet
-                  li
-                    img[src="/images/icons/icon-calendar.svg"
-                      onerror="this.src='/images/icons/icon-calendar.png'" alt="calendar icon"]
-                    a. href="https://events.chef.io/events/s/category/habitat/?scope%5B0%5D=2017-06-20&scope%5B1%5D=2017-06-22" June 20-21, 2017
-                  li
-                    img[src="/images/icons/icon-pin.svg"
-                      onerror="this.src='/images/icons/icon-pin.png'" alt="map pin icon"]
-                    | Chicago, IL
-          .community--events--card.columns.medium-5
-            .community--events--card-heading.heading
-              ul.no-bullet
-                li Conference
-            .body-content
-              a.h4 href="https://events.chef.io/events/devopsdays-amsterdam/" DevOpsDays Amsterdam
-              p
-                | Chef is sponsoring DevOpsDays Amsterdam 2017. Come talk to us, join the Open
-                  Spaces sessions and talk with us about the ways Habitat can enable your DevOps Transformation.
-              .article-detail--meta
-                ul.no-bullet
-                  li
-                    img[src="/images/icons/icon-calendar.svg"
-                      onerror="this.src='/images/icons/icon-calendar.png'" alt="calendar icon"]
-                    a. href="https://events.chef.io/events/s/category/habitat/?scope%5B0%5D=2017-06-29&scope%5B1%5D=2017-06-30" June 29-30, 2017
-                  li
-                    img[src="/images/icons/icon-pin.svg"
-                      onerror="this.src='/images/icons/icon-pin.png'" alt="map pin icon"]
-                    | Amsterdam, NL
+
 section.community--roadmap
   .row
     .columns.medium-12

--- a/www/source/javascripts/community.js
+++ b/www/source/javascripts/community.js
@@ -1,19 +1,73 @@
-var community_events = function(data) {
-    if ($(".community-events")) {
-        if (Array.isArray(data)) {
-            data.forEach(function(e) {
-                var ev = "<p>";
-                ev += e.title;
-                ev += "<br>";
-                ev += e.link;
-                ev += "<br>";
-                ev += e.pub_date;
-                ev += "<br>";
-                ev += e.description;
-                ev += "</p>";
+$(function() {
+  var htmlDecode = function(input) {
+    var doc = new DOMParser().parseFromString(input, "text/html");
+    return doc.documentElement.textContent;
+  }
 
-                $(".community-events").append(ev);
-            });
-        }
+  var makeCommunityEvent = function(e) {
+    if (e === undefined) {
+      return e;
     }
-};
+
+    var eventType;
+
+    if (e["event_category"]) {
+      var parts = e["event_category"].split(",");
+      var index = parts.indexOf("Habitat");
+
+      if (index >= 0) {
+        parts.splice(index, 1);
+      }
+
+      eventType = parts[0];
+    } else {
+      eventType = "Conference";
+    }
+
+    var eventLink = htmlDecode(e["guid"]);
+    var eventName = e["event_name"];
+    var omg = "<div>" + e["post_content"] + "</div>";
+    var eventDescription = $(omg).text().replace(/(\r\n)|(\n)|(\r)/g, "<br>");
+    var eventDateUrl = "https://events.chef.io/events/s/category/habitat/?scope[0]=" + e["start_date"] + "&scope[1]=" + e["start_date"];
+    var eventDateEncoded = encodeURI(eventDateUrl);
+    var eventDate = e["start_date"];
+    var eventLocation = "";
+
+    if (e.event_location && e.event_location.city && e.event_location.country) {
+      eventLocation = e.event_location.city + ", " + e.event_location.country;
+    }
+
+    var t = $("#community-event-template").clone().show().html();
+    var template = t.replace("{{ event_type }}", eventType)
+                    .replace("{{ event_link }}", eventLink)
+                    .replace("{{ event_name }}", eventName)
+                    .replace("{{ event_description }}", eventDescription)
+                    .replace("{{ event_date_url }}", eventDateEncoded)
+                    .replace("{{ event_date }}", eventDate)
+                    .replace("{{ event_location }}", eventLocation);
+
+    return template;
+  }
+
+  if ($(".community--events--content").length) {
+    $.getJSON("https://events.chef.io/wp-json/events/category/habitat", function(data) {
+      if (Array.isArray(data)) {
+        for (var i=0; i < data.length; i+=2) {
+          var row = $("<div>", {
+            class: "row"
+          });
+
+          var first = makeCommunityEvent(data[i]);
+          var second = makeCommunityEvent(data[i+1]);
+
+          row.append(first);
+          if (second) {
+            row.append(second);
+          }
+
+          $("div.community--events--content").append(row);
+        }
+      }
+    });
+  }
+});

--- a/www/source/javascripts/community.js
+++ b/www/source/javascripts/community.js
@@ -52,17 +52,21 @@ $(function() {
   if ($(".community--events--content").length) {
     $.getJSON("https://events.chef.io/wp-json/events/category/habitat", function(data) {
       if (Array.isArray(data)) {
-        for (var i=0; i < data.length; i+=2) {
+        for (var i=0; i < data.length; i+=3) {
           var row = $("<div>", {
             class: "row"
           });
 
           var first = makeCommunityEvent(data[i]);
           var second = makeCommunityEvent(data[i+1]);
+          var third = makeCommunityEvent(data[i+2]);
 
           row.append(first);
           if (second) {
             row.append(second);
+          }
+          if (third) {
+            row.append(third);
           }
 
           $("div.community--events--content").append(row);

--- a/www/source/stylesheets/_community.scss
+++ b/www/source/stylesheets/_community.scss
@@ -128,6 +128,12 @@ $community-xlarge-breakpoint: rem-calc(1060);
 
   .community--events--card {
     @extend %card-box;
+    padding: 1rem;
+
+    .body-content > p {
+      max-height: 240px;
+      overflow-y: scroll;
+    }
   }
 }
 

--- a/www/source/stylesheets/_community.scss
+++ b/www/source/stylesheets/_community.scss
@@ -216,3 +216,7 @@ iframe {
 .community .footer--cta {
   display: none;
 }
+
+#community-event-template {
+  display: none;
+}

--- a/www/source/stylesheets/_global.scss
+++ b/www/source/stylesheets/_global.scss
@@ -474,8 +474,6 @@ img {
 %card-box {
   margin-bottom: 1.5rem;
   padding: 0;
-  background-color: $hab-white;
-  border-radius: $global-radius;
   text-align: left;
 
   p {
@@ -529,6 +527,8 @@ img {
   }
 
   .body-content {
+    background-color: $hab-white;
     padding: 1.5rem;
+    border-radius: 0 0 $global-radius $global-radius;
   }
 }


### PR DESCRIPTION
This populates the events on [the community page](https://www.habitat.sh/community/) with live events from the events.chef.io feed.

The upside here is that we no longer have to manually edit this page to put events in.  It will just reflect the current state of the Chef events site.

The downside here is how it looks.  Here's a screenshot of it running locally for reference.

![](https://dl.dropboxusercontent.com/s/nzzfveq3fi6se4k/2017-06-05%20at%2011.16%20AM.png)

The content body of these posts come across with HTML formatting inside of them, which I'm currently stripping out completely, as that made the formatting of this stuff look super weird.  I'm also not real excited at how the building of the HTML tags turned out in `community.js`.  It feels messy.  If anyone has suggestions on how to improve that, I'm eager to hear them.

![tenor-231421390](https://cloud.githubusercontent.com/assets/947/26797286/38f4a4ba-49e1-11e7-8cb9-00ddf3bb12ba.gif)

/cc @cnunciato @ryankeairns 

Signed-off-by: Josh Black <raskchanky@gmail.com>