### PR TITLE
Improve error handling

### DIFF
--- a/components/builder-api/doc/api.raml
+++ b/components/builder-api/doc/api.raml
@@ -419,6 +419,8 @@ securitySchemes:
                             }
             400:
                 description: Received a malformed JSON body
+            409:
+                description: This project already exists
             422:
                 description: |
                     The request body contained missing or invalid values or the file at the given

--- a/components/builder-api/src/http/handlers.rs
+++ b/components/builder-api/src/http/handlers.rs
@@ -29,7 +29,8 @@ use iron::status;
 use iron::typemap;
 use params::{Params, Value, FromValue};
 use persistent;
-use protocol::jobsrv::{Job, JobGet, JobLogGet, JobLog, JobSpec, ProjectJobsGet, ProjectJobsGetResponse};
+use protocol::jobsrv::{Job, JobGet, JobLogGet, JobLog, JobSpec, ProjectJobsGet,
+                       ProjectJobsGetResponse};
 use protocol::originsrv::*;
 use protocol::sessionsrv;
 use protocol::net::{self, NetOk, ErrCode};
@@ -163,12 +164,13 @@ pub fn job_log(req: &mut Request) -> IronResult<Response> {
                 match val.parse::<u64>() {
                     Ok(num) => num,
                     Err(e) => {
-                        debug!("Tried to parse 'start' parameter as a number but failed: {:?}", e);
-                        return Ok(Response::with(status::BadRequest))
+                        debug!("Tried to parse 'start' parameter as a number but failed: {:?}",
+                               e);
+                        return Ok(Response::with(status::BadRequest));
                     }
                 }
-            },
-            _ => 0
+            }
+            _ => 0,
         }
     };
 
@@ -177,7 +179,7 @@ pub fn job_log(req: &mut Request) -> IronResult<Response> {
         .find(&["color"])
         .and_then(FromValue::from_value)
         .unwrap_or(false);
-    
+
     let params = req.extensions.get::<Router>().unwrap();
     let id = match params.find("id").unwrap().parse::<u64>() {
         Ok(id) => id,
@@ -196,7 +198,7 @@ pub fn job_log(req: &mut Request) -> IronResult<Response> {
             }
             Ok(render_json(status::Ok, &log))
         }
-        Err(err) => Ok(render_net_error(&err))
+        Err(err) => Ok(render_net_error(&err)),
     }
 
 }
@@ -280,9 +282,9 @@ pub fn project_create(req: &mut Request) -> IronResult<Response> {
 
     // Only allow projects to be created for the core origin initially.
     if origin.get_name() != BUILDER_ENABLED_ORIGIN {
-        return Ok(Response::with((status::UnprocessableEntity, "rg:pc:5")))
+        return Ok(Response::with((status::UnprocessableEntity, "rg:pc:5")));
     }
-    
+
     match github.contents(&session.get_token(),
                           &organization,
                           &repo,
@@ -342,7 +344,7 @@ pub fn project_delete(req: &mut Request) -> IronResult<Response> {
         // origin initially. Thus, if we try to delete a project for any
         // other origin, we can safely short-circuit processing.
         if origin != BUILDER_ENABLED_ORIGIN {
-            return Ok(Response::with((status::NotFound, "rg:pd:1")))
+            return Ok(Response::with((status::NotFound, "rg:pd:1")));
         }
 
         project_del.set_name(format!("{}/{}", origin, name));
@@ -363,7 +365,7 @@ pub fn project_delete(req: &mut Request) -> IronResult<Response> {
 
 /// Update the given project
 pub fn project_update(req: &mut Request) -> IronResult<Response> {
-  
+
     let (name, origin) = {
         let params = req.extensions.get::<Router>().unwrap();
         let origin = params.find("origin").unwrap().to_owned();
@@ -373,7 +375,7 @@ pub fn project_update(req: &mut Request) -> IronResult<Response> {
         // origin initially. Thus, if we try to update a project for
         // any other origin, we can safely short-circuit processing.
         if origin != BUILDER_ENABLED_ORIGIN {
-            return Ok(Response::with((status::NotFound, "rg:pu:6")))
+            return Ok(Response::with((status::NotFound, "rg:pu:6")));
         }
         (name, origin)
     };
@@ -424,7 +426,7 @@ pub fn project_update(req: &mut Request) -> IronResult<Response> {
                 Ok(ref bytes) => {
                     match Plan::from_bytes(bytes) {
                         Ok(plan) => {
-                           if !try!(check_origin_access(req, session_id, &origin)) {
+                            if !try!(check_origin_access(req, session_id, &origin)) {
                                 return Ok(Response::with(status::Forbidden));
                             }
                             if plan.name != name {
@@ -465,9 +467,9 @@ pub fn project_show(req: &mut Request) -> IronResult<Response> {
         // origin initially. Thus, if we try to get a project for any
         // other origin, we can safely short-circuit processing.
         if origin != BUILDER_ENABLED_ORIGIN {
-            return Ok(Response::with((status::NotFound, "rg:ps:1")))
+            return Ok(Response::with((status::NotFound, "rg:ps:1")));
         }
-        
+
         let name = params.find("name").unwrap();
         project_get.set_name(format!("{}/{}", origin, name));
     }
@@ -492,7 +494,7 @@ pub fn project_jobs(req: &mut Request) -> IronResult<Response> {
         // origin initially. Thus, if we try to get jobs for any
         // project in another, we can safely short-circuit processing.
         if origin != BUILDER_ENABLED_ORIGIN {
-            return Ok(Response::with((status::NotFound, "rg:pj:1")))
+            return Ok(Response::with((status::NotFound, "rg:pj:1")));
         }
 
         let name = params.find("name").unwrap();

--- a/components/builder-depot/doc/api.raml
+++ b/components/builder-depot/doc/api.raml
@@ -101,6 +101,8 @@ securitySchemes:
                                 "name": "reset",
                                 "owner_id": "77730215748435968"
                             }
+            409:
+                description: The origin already exists
             422:
                 description: Malformed origin in request body
     /{originId}:
@@ -181,6 +183,8 @@ securitySchemes:
                                             "body": "",
                                             "owner_id": ""
                                         }
+                        409:
+                            description: Secret key already exists in origin
         /users:
             get:
                 description: List all members of an origin

--- a/components/builder-originsrv/src/data_store.rs
+++ b/components/builder-originsrv/src/data_store.rs
@@ -450,6 +450,9 @@ impl DataStore {
                 .expect("Insert returns row, but no row present");
             Ok(Some(self.row_to_origin(row)))
         } else {
+            // I don't think this will ever happen because a unique constraint violation (or any
+            // other error) will trigger an error on the query and return from this function
+            // before this if statement ever executes.
             Ok(None)
         }
     }

--- a/components/builder-originsrv/src/migrations/origin_public_keys.rs
+++ b/components/builder-originsrv/src/migrations/origin_public_keys.rs
@@ -43,7 +43,7 @@ pub fn migrate(migrator: &mut Migrator) -> Result<()> {
                     opk_body bytea
                  ) RETURNS SETOF origin_public_keys AS $$
                      BEGIN
-                         RETURN QUERY INSERT INTO origin_public_keys (origin_id, owner_id, name, revision, full_name, body) 
+                         RETURN QUERY INSERT INTO origin_public_keys (origin_id, owner_id, name, revision, full_name, body)
                                 VALUES (opk_origin_id, opk_owner_id, opk_name, opk_revision, opk_full_name, opk_body)
                                 RETURNING *;
                          RETURN;
@@ -83,11 +83,15 @@ pub fn migrate(migrator: &mut Migrator) -> Result<()> {
                         RETURN;
                     END
                     $$ LANGUAGE plpgsql STABLE"#)?;
-
-    migrator.migrate("originsrv",
-                     r#"ALTER TABLE origin_public_keys
+    migrator
+        .migrate("originsrv",
+                 r#"ALTER TABLE origin_public_keys
                         DROP CONSTRAINT IF EXISTS
                           origin_public_keys_full_name_key"#)?;
-
+    migrator
+        .migrate("originsrv-2",
+                 r#"ALTER TABLE origin_public_keys
+                        ADD CONSTRAINT origin_public_keys_full_name_key
+                        UNIQUE (full_name)"#)?;
     Ok(())
 }

--- a/components/builder-originsrv/src/migrations/origin_public_keys.rs
+++ b/components/builder-originsrv/src/migrations/origin_public_keys.rs
@@ -90,6 +90,15 @@ pub fn migrate(migrator: &mut Migrator) -> Result<()> {
                           origin_public_keys_full_name_key"#)?;
     migrator
         .migrate("originsrv-2",
+                 r#"DELETE FROM origin_public_keys
+                        WHERE id IN (
+                            SELECT id FROM (
+                                SELECT id, ROW_NUMBER() OVER (
+                                    partition BY full_name ORDER BY id
+                                ) AS rnum FROM origin_public_keys
+                            ) t WHERE t.rnum > 1)"#)?;
+    migrator
+        .migrate("originsrv-3",
                  r#"ALTER TABLE origin_public_keys
                         ADD CONSTRAINT origin_public_keys_full_name_key
                         UNIQUE (full_name)"#)?;

--- a/components/builder-originsrv/src/migrations/origin_secret_keys.rs
+++ b/components/builder-originsrv/src/migrations/origin_secret_keys.rs
@@ -50,7 +50,7 @@ pub fn migrate(migrator: &mut Migrator) -> Result<()> {
                     osk_body bytea
                  ) RETURNS SETOF origin_secret_keys AS $$
                      BEGIN
-                         RETURN QUERY INSERT INTO origin_secret_keys (origin_id, owner_id, name, revision, full_name, body) 
+                         RETURN QUERY INSERT INTO origin_secret_keys (origin_id, owner_id, name, revision, full_name, body)
                                 VALUES (osk_origin_id, osk_owner_id, osk_name, osk_revision, osk_full_name, osk_body)
                                 RETURNING *;
                          RETURN;
@@ -62,17 +62,21 @@ pub fn migrate(migrator: &mut Migrator) -> Result<()> {
                     osk_name text
                  ) RETURNS SETOF origin_secret_keys AS $$
                     BEGIN
-                        RETURN QUERY SELECT * FROM origin_secret_keys WHERE name = osk_name 
+                        RETURN QUERY SELECT * FROM origin_secret_keys WHERE name = osk_name
                           ORDER BY full_name DESC
                           LIMIT 1;
                         RETURN;
                     END
                     $$ LANGUAGE plpgsql STABLE"#)?;
-
-    migrator.migrate("originsrv",
-                     r#"ALTER TABLE origin_secret_keys
+    migrator
+        .migrate("originsrv",
+                 r#"ALTER TABLE origin_secret_keys
                         DROP CONSTRAINT IF EXISTS
                           origin_secret_keys_full_name_key"#)?;
-
+    migrator
+        .migrate("originsrv-2",
+                 r#"ALTER TABLE origin_secret_keys
+                        ADD CONSTRAINT origin_secret_keys_full_name_key
+                        UNIQUE (full_name)"#)?;
     Ok(())
 }

--- a/components/builder-originsrv/src/migrations/origin_secret_keys.rs
+++ b/components/builder-originsrv/src/migrations/origin_secret_keys.rs
@@ -75,6 +75,15 @@ pub fn migrate(migrator: &mut Migrator) -> Result<()> {
                           origin_secret_keys_full_name_key"#)?;
     migrator
         .migrate("originsrv-2",
+                 r#"DELETE FROM origin_secret_keys
+                        WHERE id IN (
+                            SELECT id FROM (
+                                SELECT id, ROW_NUMBER() OVER (
+                                    partition BY full_name ORDER BY id
+                                ) AS rnum FROM origin_secret_keys
+                            ) t WHERE t.rnum > 1)"#)?;
+    migrator
+        .migrate("originsrv-3",
                  r#"ALTER TABLE origin_secret_keys
                         ADD CONSTRAINT origin_secret_keys_full_name_key
                         UNIQUE (full_name)"#)?;

--- a/components/builder-originsrv/tests/data_store/mod.rs
+++ b/components/builder-originsrv/tests/data_store/mod.rs
@@ -194,6 +194,49 @@ fn create_origin_public_key() {
 }
 
 #[test]
+fn create_origin_public_key_handles_unique_constraint_violations_correctly() {
+    let ds = datastore_test!(DataStore);
+    let mut origin = originsrv::OriginCreate::new();
+    origin.set_name(String::from("neurosis"));
+    origin.set_owner_id(1);
+    origin.set_owner_name(String::from("scottkelly"));
+    ds.create_origin(&origin).expect("Should create origin");
+
+    let neurosis = ds.get_origin_by_name("neurosis")
+        .expect("Could not retrieve origin")
+        .expect("Origin does not exist");
+
+    // Create a new origin public key
+    let mut oskc = originsrv::OriginPublicKeyCreate::new();
+    oskc.set_name(String::from("neurosis"));
+    oskc.set_revision(String::from("20160612031944"));
+    oskc.set_origin_id(neurosis.get_id());
+    oskc.set_owner_id(1);
+    oskc.set_body(String::from("very_public").into_bytes());
+    ds.create_origin_public_key(&oskc)
+        .expect("Failed to create origin public key");
+    let mut oskc2 = originsrv::OriginPublicKeyCreate::new();
+    oskc2.set_name(String::from("neurosis"));
+    oskc2.set_origin_id(neurosis.get_id());
+    oskc2.set_owner_id(1);
+    oskc2.set_revision(String::from("20160612031945"));
+    oskc2.set_body(String::from("very_very_public").into_bytes());
+    ds.create_origin_public_key(&oskc2)
+        .expect("Failed to create origin public key");
+
+    // Create a duplicate origin public key, which should fail
+    let mut opkc = originsrv::OriginPublicKeyCreate::new();
+    opkc.set_name(String::from("neurosis"));
+    opkc.set_revision(String::from("20160612031944"));
+    opkc.set_origin_id(neurosis.get_id());
+    opkc.set_owner_id(1);
+    opkc.set_body(String::from("very_public").into_bytes());
+    let resp = ds.create_origin_public_key(&opkc);
+
+    assert!(resp.is_err(), "Insertion should've triggered an error");
+}
+
+#[test]
 fn get_origin_public_key_latest() {
     let ds = datastore_test!(DataStore);
     let mut origin = originsrv::OriginCreate::new();

--- a/components/builder-originsrv/tests/data_store/mod.rs
+++ b/components/builder-originsrv/tests/data_store/mod.rs
@@ -39,6 +39,24 @@ fn create_origin_poop() {
 }
 
 #[test]
+fn create_origin_handles_unique_constraint_violations_correctly() {
+    let ds = datastore_test!(DataStore);
+    let mut origin = originsrv::OriginCreate::new();
+    origin.set_name(String::from("neurosis"));
+    origin.set_owner_id(1);
+    origin.set_owner_name(String::from("scottkelly"));
+    ds.create_origin(&origin).expect("Should create origin");
+
+    let mut origin2 = originsrv::OriginCreate::new();
+    origin2.set_name(String::from("neurosis"));
+    origin2.set_owner_id(1);
+    origin2.set_owner_name(String::from("scottkelly"));
+    let resp2 = ds.create_origin(&origin2);
+
+    assert!(resp2.is_err(), "Insertion should've triggered an error");
+}
+
+#[test]
 fn get_origin_by_name() {
     let ds = datastore_test!(DataStore);
     let mut origin = originsrv::OriginCreate::new();
@@ -287,9 +305,7 @@ fn create_origin_invitation() {
         .expect("Failed to create the origin invitation again, which should be a no-op");
 
     // We should never create an invitation for the same person and org
-    let conn = ds.pool
-        .get(&oic)
-        .expect("Cannot get connection from pool");
+    let conn = ds.pool.get(&oic).expect("Cannot get connection from pool");
     let rows = conn.query("SELECT COUNT(*) FROM origin_invitations", &[])
         .expect("Failed to query database for number of invitations");
     let count: i64 = rows.iter().nth(0).unwrap().get(0);
@@ -758,19 +774,16 @@ fn get_latest_package() {
     search_ident.set_name("cacerts".to_string());
     package_get.set_ident(search_ident.clone());
     package_get.set_target("x86_64-windows".to_string());
-    let result1 = ds.get_origin_package_latest(&package_get.clone())
-        .unwrap();
+    let result1 = ds.get_origin_package_latest(&package_get.clone()).unwrap();
 
     search_ident.set_version("2017.01.18".to_string());
     package_get.set_ident(search_ident.clone());
     package_get.set_target("x86_64-linux".to_string());
-    let result2 = ds.get_origin_package_latest(&package_get.clone())
-        .unwrap();
+    let result2 = ds.get_origin_package_latest(&package_get.clone()).unwrap();
 
     package_get.set_ident(search_ident.clone());
     package_get.set_target("x86_64-windows".to_string());
-    let result3 = ds.get_origin_package_latest(&package_get.clone())
-        .unwrap();
+    let result3 = ds.get_origin_package_latest(&package_get.clone()).unwrap();
 
     assert_eq!(result1.unwrap().to_string(), ident1.to_string());
     assert_eq!(result2.unwrap().to_string(), ident3.to_string());
@@ -1223,9 +1236,7 @@ fn create_origin_channel() {
         .expect("Failed to create origin public key");
 
     // Create new database connection
-    let conn = ds.pool
-        .get(&oscc)
-        .expect("Cannot get connection from pool");
+    let conn = ds.pool.get(&oscc).expect("Cannot get connection from pool");
 
     let rows = conn.query("SELECT COUNT(*) FROM origin_channels", &[])
         .expect("Failed to query database for number of channels");

--- a/components/hab/src/command/studio/mod.rs
+++ b/components/hab/src/command/studio/mod.rs
@@ -92,8 +92,8 @@ mod inner {
                 init();
                 let version: Vec<&str> = VERSION.split("/").collect();
                 let ident = try!(PackageIdent::from_str(&format!("{}/{}",
-                                                                 super::STUDIO_PACKAGE_IDENT,
-                                                                 version[0])));
+                                                                super::STUDIO_PACKAGE_IDENT,
+                                                                version[0])));
                 try!(exec::command_from_min_pkg(ui,
                                                 super::STUDIO_CMD,
                                                 &ident,
@@ -181,8 +181,8 @@ mod inner {
                 init();
                 let version: Vec<&str> = VERSION.split("/").collect();
                 let ident = try!(PackageIdent::from_str(&format!("{}/{}",
-                                                                 super::STUDIO_PACKAGE_IDENT,
-                                                                 version[0])));
+                                                                super::STUDIO_PACKAGE_IDENT,
+                                                                version[0])));
                 try!(exec::command_from_min_pkg(ui,
                                                 super::STUDIO_CMD,
                                                 &ident,
@@ -226,9 +226,7 @@ mod inner {
                 .spawn()
                 .expect("docker failed to start");
 
-            let output = child
-                .wait_with_output()
-                .expect("failed to wait on child");
+            let output = child.wait_with_output().expect("failed to wait on child");
 
             if output.status.success() {
                 debug!("Docker image is reachable. Proceeding with launching docker.");

--- a/support/ci/install_rustfmt.sh
+++ b/support/ci/install_rustfmt.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eu
 
-version=0.8.3
+version=0.8.4
 
 if command -v rustfmt >/dev/null; then
   if [[ $(rustfmt --version | cut -d ' ' -f 1) = "$version" ]]; then

--- a/support/ci/lint.sh
+++ b/support/ci/lint.sh
@@ -47,7 +47,7 @@ exit_with() {
 }
 
 program=$(basename $0)
-rf_version="0.8.3"
+rf_version="0.8.4"
 
 # Fix commit range in Travis, if set.
 # See: https://github.com/travis-ci/travis-ci/issues/4596


### PR DESCRIPTION
We have a number of API calls that all create things.  For the purposes of this PR, those are:

* origin
* channel
* public key
* secret key
* project

Currently, all of these endpoints will return a 503 Service Unavailable if you try to create a duplicate of something that already exists.  This is sub-optimal, to say the least, because it means you can't e.g. upload packages to the depot.  `hab` will try to upload the public key and will immediately abort because the key already exists.  https://github.com/habitat-sh/habitat/pull/2424 removed the unique constraints for keys so that the depot could function until proper responses were implemented.

This PR implements those "proper" responses, namely a 409 Conflict if you try to create a duplicate of something that already exists.  It also adds the unique constraints on keys back via new migrations.

Note: it's possible that duplicate keys currently exist in the public and/or acceptance depots.  If so, then the migrations associated with this PR will fail.  We should plan how to make this update carefully.

![tenor-109385722](https://cloud.githubusercontent.com/assets/947/26704454/0a06b7f6-46e4-11e7-96ec-f8060c0a48d3.gif)
