### PR TITLE
Update the dev docs

### DIFF
--- a/BUILDER_DEV.md
+++ b/BUILDER_DEV.md
@@ -5,15 +5,15 @@ This document outlines the steps to start and run a Builder environment for deve
 
 ## Pre-Reqs
 1. Use a Linux OS - either native or VM.
-2. Clone the habitat repo to your local filesystem. (If using a VM, you should use the local filesystem for the hab repo instead of using a mounted filesystem, otherwise things may fail later when running services).
-3. Ensure you have a Github auth token. Create from the Github site if you don't have one already. Token Capabilities needed: read:org, user:email
-4. The sample commands below use the 'httpie' tool. Install it if not present on your system (https://github.com/jkbrzt/httpie).
-5. A recent version of the habitat cli should also be installed in your dev environment (https://www.habitat.sh/docs/get-habitat/)
+1. Clone the habitat repo to your local filesystem. (If using a VM, you should use the local filesystem for the hab repo instead of using a mounted filesystem, otherwise things may fail later when running services).
+1. Ensure you have a Github auth token. Create from the Github site if you don't have one already. Token Capabilities needed: read:org, user:email
+1. The sample commands below use the 'httpie' tool. Install it if not present on your system (https://github.com/jkbrzt/httpie).
+1. A recent version of the habitat cli should also be installed in your dev environment (https://www.habitat.sh/docs/get-habitat/)
 
 ## Bootstrap the OS with required packages
 You need to make sure you have the required packages installed.
 Run the appropriate shell script under the `support/linux` folder to install the packages.
-Refer to [BUILDING.md](https://github.com/habitat-sh/habitat/blob/master/BUILDING.md) doc for the detailed steps.
+Refer to [BUILDING.md](./BUILDING.md) doc for the detailed steps.
 
 ## Create configuration files
 Some capabilities (such as allowing builder permissions, and turning on auto-building when new packages are uploaded to the depot) require passing in a custom config to the Builder services.
@@ -57,6 +57,7 @@ auto_publish = true
 local = true
 local_dir = "/tmp"
 ```
+
 (Note: If you want your log files to persist across restarts of your development machine, replace `/tmp` with some other directory. It *must* exist and be writable before you start the job server).
 
 Now, modify the `Procfile` (located in your hab repo in the `support` folder) to point the api, sessionsrv, jobsrv, and worker services to the previously created config files, e.g.
@@ -70,60 +71,56 @@ jobsrv: target/debug/bldr-job-srv start --config /home/your_alias/habitat/config
 
 ## Run the Builder services
 1. Open a new terminal window.
-2. Create or import the private and public keys for your origin using `hab setup` or `hab origin key import` (for example, a pre-existing origin)
-3. Export the following environment variables:
+1. Export the following environment variables:
+
 ```
 export HAB_AUTH_TOKEN=<your github token>
 export HAB_DEPOT_URL=http://localhost:9636/v1/depot
 export HAB_ORIGIN=<your origin>
 ```
-4. Now, do a `make bldr-run` from the root of your hab repo.
+
+1. Now, switch to the root user and do a `make bldr-run` from the root of your hab repo.
 
 The first time this command runs, it will create the required databases. Let it run for a while, and then re-start it if there are errors (this is normal for the first time setup).
 
 When `make bldr-run` can proceed with all the services up and running, you are ready to proceed to the next step.
 
 ## Create your origin
+There are a couple of ways to do this.
+
+### From the command line
 1. Open a new terminal window.
-2. Export the HAB_ORIGIN and HAB_AUTH_TOKEN as above
-2. Create an origin in the DB by issuing the following command:
+1. Export the `HAB_ORIGIN` and `HAB_AUTH_TOKEN` as above
+1. Create an origin in the DB by issuing the following command:
 
-```
-http POST http://localhost:9636/v1/depot/origins Content-Type:application/json Authorization:Bearer:${HAB_AUTH_TOKEN} name=${HAB_ORIGIN}
-```
+    ```
+    http POST http://localhost:9636/v1/depot/origins Content-Type:application/json Authorization:Bearer:${HAB_AUTH_TOKEN} name=${HAB_ORIGIN}
+    ```
 
-The response should be something like:
-```
-HTTP/1.1 201 Created
-Access-Control-Allow-Headers: authorization, range
-Access-Control-Allow-Methods: PUT, DELETE
-Access-Control-Allow-Origin: *
-Content-Length: 93
-Content-Type: application/json
-Date: Mon, 07 Nov 2016 19:55:03 GMT
+    The response should be something like:
 
-{
-    "id": 151409091187589122,
-    "name": "core",
-    "owner_id": "133508078967455744",
-    "private_key_name": ""
-}
-```
+    ```
+    HTTP/1.1 201 Created
+
+    {
+        "id": 151409091187589122,
+        "name": "core",
+        "owner_id": "133508078967455744",
+        "private_key_name": ""
+    }
+    ```
+
+### In the browser
+The `make bldr-run` command you ran above also starts the Builder Web UI, which should be listening on port 3000. If that process is running in a container or VM, and you've forwarded port 3000 to your host, you should be able to browse to http://localhost:3000/#/pkgs, sign in with GitHub, and click My Origins in the sidebar to create an origin.
 
 ## Import origin keys to the Depot
-This can be done via the builder depot web UI. Make sure you have both the public and private keys available for your origin.
+This can be done via the Builder Web UI. Make sure you have both the public and private keys available for your origin.
 
-1. The `make bldr-run` should have started the web UI. If not, you can run it via a separate terminal window:
-```
-cd habitat/components/builder-web
-npm install
-npm start
-```
-The web UI should come up at http://localhost:3000. (If you need to bring up the UI at a different address or port, please refer to the builder-web [README](https://github.com/habitat-sh/habitat/blob/master/components/builder-web/README.md) for setting up a custom OAuth app).
+The web UI should be running at http://localhost:3000/#/pkgs. (If you need to bring up the UI at a different address or port, please refer to the builder-web [README](./components/builder-web/README.md) for setting up a custom OAuth app).
 
-2. Log into the web UI via your Github account
-3. Go to the origins page, and select the your origin
-4. Go to the keys tab, and follow the instructions for uploading the public and private keys.
+1. Log into the web UI via your GitHub account
+1. Go to the origins page, and select your origin
+1. Go to the keys tab, and follow the instructions for uploading the public and private keys.
 
 ## Create the project(s) you want to build
 In order to build a package, there needs to be a project created in the database.
@@ -131,50 +128,51 @@ If the DB has been newly created, there will initially not be any projects avail
 
 Create a project for the package you want to build:
 
-1. Create a project file (eg, ```project.json```) on your local filesystem (see example below for core/nginx)
-```
-{
-    "origin": "core",
-    "plan_path": "nginx/plan.sh",
-    "github": {
-        "organization": "habitat-sh",
-        "repo": "core-plans"
-    }
-}
-```
+1. Create a project file (eg, `project.json`) on your local filesystem (see example below for core/nginx):
 
-2. Issue the following command:
-```
-http POST http://localhost:9636/v1/projects Authorization:Bearer:${HAB_AUTH_TOKEN} < project.json
-```
+    ```
+    {
+        "origin": "core",
+        "plan_path": "nginx/plan.sh",
+        "github": {
+            "organization": "habitat-sh",
+            "repo": "core-plans"
+        }
+    }
+    ```
+
+1. Issue the following command:
+
+    ```
+    http POST http://localhost:9636/v1/projects Authorization:Bearer:${HAB_AUTH_TOKEN} < project.json
+    ```
 
 The response should be something like this:
-```
-HTTP/1.1 201 Created
-Access-Control-Allow-Headers: authorization, range
-Access-Control-Allow-Methods: PUT, DELETE
-Access-Control-Allow-Origin: *
-Content-Length: 121
-Content-Type: application/json
-Date: Mon, 07 Nov 2016 20:01:52 GMT
 
-{
-    "id": "core/nginx",
-    "plan_path": "nginx/plan.sh",
-    "vcs": {
-        "type": "git",
-        "url": "https://github.com/habitat-sh/core-plans.git"
+    ```
+    HTTP/1.1 201 Created
+
+    {
+        "id": "730634033288978462",
+        "name": "core/nginx",
+        "origin_id": "730632763933204510",
+        "origin_name": "core",
+        "owner_id": "730632479777497215",
+        "package_name": "nginx",
+        "plan_path": "nginx/plan.sh",
+        "vcs_data": "https://github.com/habitat-sh/core-plans.git",
+        "vcs_type": "git"
     }
-}
-```
+    ```
 
 Repeat the above steps for any other projects that you want to build.
 
 ## Run a build
 
-Issue the following command (replace `origin/name` as needed):
+Issue the following command (replace `core/nginx` with your origin and package names):
+
 ```
-http POST http://localhost:9636/v1/jobs Authorization:Bearer:${HAB_AUTH_TOKEN} project_id="<origin/name>"
+http POST http://localhost:9636/v1/jobs Authorization:Bearer:${HAB_AUTH_TOKEN} project_id="core/nginx"
 ```
 
 This should create a build job, and then dispatch it to the build worker.
@@ -182,18 +180,14 @@ This should create a build job, and then dispatch it to the build worker.
 You should see a response similar to the following:
 
 ```
-Response:
 HTTP/1.1 201 Created
-Access-Control-Allow-Headers: authorization, range
-Access-Control-Allow-Methods: PUT, DELETE
-Access-Control-Allow-Origin: *
-Content-Length: 35
-Content-Type: application/json
-Date: Mon, 07 Nov 2016 20:06:32 GMT
 
 {
-    "id": 151414870149955584,
-    "state": 0
+    "created_at": "",
+    "id": "0",
+    "name": "nginx",
+    "origin": "core",
+    "state": "Pending"
 }
 ```
 
@@ -243,24 +237,24 @@ http GET http://localhost:9636/v1/depot/origins/core/users Authorization:Bearer:
 1. If you get the following error when building, check to make sure you have imported the origin keys, and that the `HAB_DEPOT_URL` export was done correctly in the terminal session that ran `make bldr-run`:
 `ERROR:habitat_builder_worker::runner: Unable to retrieve secret key, err=[404 Not Found]`
 
-2. If you get a build failing with a `401 Unauthorized`, make sure the builder worker is pointed to a valid Github token (via a config.toml in the Procfile)
+1. If you get a build failing with a `401 Unauthorized`, make sure the builder worker is pointed to a valid Github token (via a config.toml in the Procfile)
 
-3. If you get a `NOSPC` error when starting depot UI, see the following:
+1. If you get a `NOSPC` error when starting depot UI, see the following:
 http://stackoverflow.com/questions/22475849/node-js-error-enospc
 
 ### Postgres troubleshooting:
 1. If you are not able to connect at all, check the `pg_hba.conf` file in `/hab/svc/postgresql` or `/hab/svc/postgres/config`.
 Add the following line if not present to see if it resolves your issue:
-```
-local all all trust
-```
+    ```
+    local all all trust
+    ```
 
-2. If you are not seeing any persistent data in the DB, check the `user.toml` file in `/hab/svc/postgresql`. Make sure the search_path is not set to `pg_temp` (the DB tests create this setting explicitly in order to set the DB to be in ephemeral mode for each connection, so that it resets after every test).
+1. If you are not seeing any persistent data in the DB, check the `user.toml` file in `/hab/svc/postgresql`. Make sure the search_path is not set to `pg_temp` (the DB tests create this setting explicitly in order to set the DB to be in ephemeral mode for each connection, so that it resets after every test).
 
-3. If Postgres is not starting with `make bldr-run`, see if you can start it in a separate terminal windows with `hab start core/postgresql` or `sudo hab start core/postgresql`
+1. If Postgres is not starting with `make bldr-run`, see if you can start it in a separate terminal windows with `hab start core/postgresql` or `sudo hab start core/postgresql`
 
-4. In order to connect to Postgres (to examine the DB, etc), you can do the following from a separate terminal window (the specific path to Postgres may be different):
-```
-su - hab
-/hab/pkgs/core/postgresql/9.6.1/20170215221136/bin/psql -h 127.0.0.1 <db_name>
-```
+1. In order to connect to Postgres (to examine the DB, etc), you can do the following from a separate terminal window (the version and release portions of the path may be different):
+    ```
+    su - hab
+    /hab/pkgs/core/postgresql/9.6.1/20170215221136/bin/psql -h 127.0.0.1 <db_name>
+    ```

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -4,7 +4,7 @@
 
 These install instructions assume you want to develop, build, and run the
 various Habitat software components in a Linux environment. The Habitat core
-team suggests that you use our consistent development environment that we can
+team suggests that you use our consistent development environment that we call
 the "devshell" as the easiest way to get started.
 
 1. [Install Docker for Mac](https://www.docker.com/products/docker)
@@ -35,7 +35,7 @@ the latest version of rustfmt. An easy way to install it (assuming you have
 Rust installed as above), is to run `cargo install rustfmt` and adding
 `$HOME/.cargo/bin` to your `PATH`.
 
-**Note2:** While this Docker container will work well for getting started with Habitat development, you may want to consider using a VM as you start compiling Habitat components.  To do this, create a VM with your preferred flavor of Linux and follow the appropriate instructions for that flavor below.
+**Note2:** While this Docker container will work well for getting started with Habitat development, [you may want to consider using a VM](#vm-vs-docker-development) as you start compiling Habitat components.  To do this, create a VM with your preferred flavor of Linux and follow the appropriate instructions for that flavor below.
 
 
 ## Mac OS X for Native Development
@@ -59,7 +59,7 @@ cp components/hab/install.sh /tmp/
 sh support/mac/install_dev_0_mac_latest.sh
 sh support/mac/install_dev_9_mac.sh
 . ~/.profile
-export PKG_CONFIG_PATH="/usr/local/opt/libarchive/lib/pkgconfig:/usr/local/opt/openssl/lib/pkgconfig:$PKG_CONFIG_PATH"
+export PKG_CONFIG_PATH="/usr/local/opt/libarchive/lib/pkgconfig:/usr/local/opt/openssl/lib/pkgconfig:/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH"
 export IN_DOCKER=false
 make
 ```
@@ -73,7 +73,7 @@ such as [direnv](https://direnv.net/), you can set up the following in the root
 of the git repository:
 
 ```
-echo 'export PKG_CONFIG_PATH="/usr/local/opt/libarchive/lib/pkgconfig:/usr/local/opt/openssl/lib/pkgconfig:$PKG_CONFIG_PATH"' > .direnv
+echo 'export PKG_CONFIG_PATH="/usr/local/opt/libarchive/lib/pkgconfig:/usr/local/opt/openssl/lib/pkgconfig:/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH"' > .direnv
 direnv allow
 ```
 
@@ -206,7 +206,20 @@ sudo su - jdoe
 
 While the available docker images can provide a convenient contributor onboarding experience, they may not prove ideal for extensive habitat development. Building habitat components is a disk intensive operation. Mounted file systems accross network boundaries, even when confined to a single local host, can yield build times dramatically slower than building against a locally attached file system. Build times will be best on either a bare metal linux environment or a dedicated linux vm. Also note that when using vagrant to provision a vm for habitat development, it is strongly advised that you do not put your habitat repo on a synced folder or at least do not use that folder as your build target. You should copy or clone the repository to a local directory in order to realize much faster build times.
 
-Here is a [vagrantfile](https://github.com/mwrock/vagrantfile/blob/master/UbuHab) that provisions an ubuntu environment for habitat development. It leverages a Hyper-V provisioner but its provisioning script can be used in any hypervisor that uses an ubuntu 14.04 box.
+In the root of the project is a Vagrantfile that provisions an Ubuntu environment for Habitat development:
+
+```
+vagrant up --provider virtualbox  # See the Vagrantfile for additional providers and boxes
+```
+
+Feel free to use this file as a jumping-off point for customizing your own Habitat development environment.
+
+Once your VM is up and running, SSH into it (`vagrant ssh`), change to the location of the Habitat source (e.g., `cd /vagrant`), and get started:
+
+```
+cd components/builder-api
+cargo test
+```
 
 ## Windows
 
@@ -222,9 +235,7 @@ making `git` better in your PowerShell console (`install-module posh-git`).
 git clone https://github.com/habitat-sh/habitat.git
 
 cd habitat
-
 ./build.ps1 components/hab -configure
-
 ```
 
 
@@ -236,9 +247,8 @@ cd habitat
 - Executable names are specified in each components `Cargo.toml` file in a TOML
   table like this:
 
-		[[bin]]
-		name = "hab-depot"
-
+	  [[bin]]
+	  name = "hab-depot"
 
 ## Windows build notes
 
@@ -261,13 +271,13 @@ Let's say you want to do this with the supervisor (which lives in the components
 Change directories into the component you want to build
 
 ```
-  $ cd habitat/components/sup
+cd components/sup
 ```
 
 Then run
 
 ```
-  $ cargo build
+cargo build
 ```
 
 Once it is finished compiling, you can find the new build in root hab_repo/target/debug
@@ -275,7 +285,7 @@ Once it is finished compiling, you can find the new build in root hab_repo/targe
 Head back to the root of the Habitat repo
 
 ```
-  $ cd ../..
+cd ../..
 ```
 
 And you will find your build in target/debug
@@ -283,7 +293,7 @@ And you will find your build in target/debug
 If you built the sup component, this is where you would find the new build
 
 ```
-  $ target/debug/hab-sup
+target/debug/hab-sup
 ```
 
 ## Running
@@ -291,5 +301,5 @@ If you built the sup component, this is where you would find the new build
 You can now run this newly built component with
 
 ```
-  $ ./target/debug/hab-sup
+./target/debug/hab-sup
 ```

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,34 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+$script = <<SCRIPT
+cd /vagrant
+cp components/hab/install.sh /tmp/
+sh support/linux/install_dev_0_ubuntu_latest.sh
+sh support/linux/install_dev_9_linux.sh
+. ~/.profile
+make
+SCRIPT
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "bento/ubuntu-16.04"
+  config.vm.provision "shell", inline: $script, privileged: true
+
+  # For builder-api
+  config.vm.network "forwarded_port", guest: 9636, host: 9636, auto_correct: true
+
+  # For builder-web
+  config.vm.network "forwarded_port", guest: 3000, host: 3000, auto_correct: true
+
+  config.vm.provider "virtualbox" do |v|
+    v.memory = 2048
+    v.cpus = 2
+  end
+
+  config.vm.provider "hyperv" do |hv, override|
+    override.vm.box = "ericmann/trusty64"
+    hv.ip_address_timeout = 240
+    hv.memory = 2048
+    hv.cpus = 2
+  end
+end

--- a/support/Procfile
+++ b/support/Procfile
@@ -1,3 +1,4 @@
+web: support/builder_web.sh
 postgres: support/db/start.sh
 api: target/debug/bldr-api start --path /tmp/depot
 admin: target/debug/bldr-admin start

--- a/support/builder_web.sh
+++ b/support/builder_web.sh
@@ -15,6 +15,13 @@ if [ ! -f habitat.conf.js ]; then
     cp habitat.conf.sample.js habitat.conf.js
 fi
 
+# When the Habitat source tree is shared with a guest OS, the builder-web/node_modules
+# directories get shared as well -- including their bundled/compiled native binaries,
+# which is rarely what you want.  This keeps the guest-built stuff on the guest
+# and the host-built stuff on the host.
+mkdir -p "$HOME/.builder_web_node_modules" ./node_modules
+sudo mount --bind "$HOME/.builder_web_node_modules" ./node_modules
+
 nvm install
 npm install
 npm run build


### PR DESCRIPTION
* Minor cleanups and clarifications
* Add a simple Vagrantfile for help getting started
* Re-enable the `web` process for use with `make bldr-run`, and handle conflicts stemming from shared node_modules
* Round out the builder-web setup instructions

![](https://media.tenor.com/images/4a165f3bb6ebe00e3228e5a815961c95/tenor.gif)

Signed-off-by: Christian Nunciato <cnunciato@chef.io>