### PR TITLE
Don't fail entire schedule if job fails

### DIFF
--- a/components/builder-core/src/package_graph.rs
+++ b/components/builder-core/src/package_graph.rs
@@ -152,6 +152,15 @@ impl PackageGraph {
                 let depname = format!("{}", dep);
                 let (_, dep_node) = self.generate_id(&depname);
                 self.graph.extend_with_edges(&[(dep_node, pkg_node)]);
+
+                // sanity check
+                if is_cyclic_directed(&self.graph) {
+                    warn!("graph is cyclic after adding {} -> {} - rolling back",
+                          depname,
+                          name);
+                    let e = self.graph.find_edge(dep_node, pkg_node).unwrap();
+                    self.graph.remove_edge(e).unwrap();
+                }
             }
         }
 

--- a/components/builder-scheduler/src/data_store.rs
+++ b/components/builder-scheduler/src/data_store.rs
@@ -520,7 +520,8 @@ impl DataStore {
 
         let state = match job.get_state() {
             JobState::Complete => "Success",
-            JobState::Failed | JobState::Rejected => "Failure",
+            JobState::Rejected => "NotStarted", // retry submission
+            JobState::Failed => "Failure",
             _ => "InProgress",
         };
 


### PR DESCRIPTION
This change allows certain jobs to fail without failing the entire group of scheduled jobs. If a job fails, the dependents that were scheduled for build will be skipped. The graph code can now also handle circular dependencies by warning and rolling back the graph update that caused the circular dependency.  Later we will disallow uploading any package that causes us to get in this state.

Signed-off-by: Salim Alam <salam@chef.io>

![giphy 36](https://user-images.githubusercontent.com/13542112/26853212-f44f0e46-4ac5-11e7-8069-c3608ec8d5b1.gif)
