### PR TITLE
Update for use with latest core/postgresql

### DIFF
--- a/support/db/pg_hba.conf
+++ b/support/db/pg_hba.conf
@@ -1,2 +1,0 @@
-local all all trust
-host all all 127.0.0.1/24 trust

--- a/support/db/user.toml
+++ b/support/db/user.toml
@@ -1,3 +1,3 @@
-listen_addresses = "127.0.0.1"
-search_path = "public"
-hba_file = "/hab/svc/postgresql/pg_hba.conf"
+[superuser]
+name = 'hab'
+password = 'hab'


### PR DESCRIPTION
The new postgresql package defaults to using the `admin` superuser… this just sets it to be `hab` like we had before.

Also removes our `pg_hba.conf`, because that’s already present.

Note: this is for getting our broken tests working again; the new `core/postgresql` changed how some things were laid out, and our test setup was no longer compatible.