### PR TITLE
Auto-scroll when viewing a running build

### DIFF
--- a/components/builder-web/app/build/_build.component.scss
+++ b/components/builder-web/app/build/_build.component.scss
@@ -1,4 +1,5 @@
 .hab-build {
+  position: relative;
 
   .back {
     margin-bottom: 20px;
@@ -80,6 +81,45 @@
         .data {
           @include span-columns(5 of 6);
         }
+      }
+    }
+  }
+
+  .controls {
+    padding: 4px;
+    background: $hab-white;
+    border-radius: $global-radius;
+    box-shadow: 0 1px 14px 0 $hab-gray-dark;
+
+    button {
+      display: block;
+      background: $dark-blue;
+      font-size: rem(12);
+      text-transform: none;
+      text-align: left;
+      width: 100%;
+      padding: 2px 8px;
+      outline: none;
+
+      &:first-child {
+        border-radius: 4px 4px 0 0;
+      }
+
+      &:last-child {
+        margin-top: 1px;
+        border-radius: 0 0 4px 4px;
+      }
+
+      &:hover {
+        background-color: $hab-green-dark;
+      }
+
+      &.active {
+        background-color: $hab-green;
+      }
+
+      .octicon {
+        margin-right: 4px;
       }
     }
   }

--- a/components/builder-web/app/build/build.component.html
+++ b/components/builder-web/app/build/build.component.html
@@ -21,5 +21,15 @@
       </div>
     </div>
   </div>
+  <div class="controls" [ngStyle]="controlsStyles">
+    <button type="button" class="jump-to-top" (click)="scrollToTop()">
+      <span class="octicon octicon-chevron-up"></span>
+      <span>Jump to top</span>
+    </button>
+    <button type="button" class="jump-to-end" (click)="toggleFollow()" [class.active]="followLog">
+      <span class="octicon octicon-chevron-down"></span>
+      <span>{{ completed ? "Jump to end" : "Follow log" }}</span>
+    </button>
+  </div>
   <pre class="output"></pre>
 </div>

--- a/components/builder-web/app/build/build.component.spec.ts
+++ b/components/builder-web/app/build/build.component.spec.ts
@@ -127,6 +127,49 @@ describe("BuildComponent", () => {
           });
         });
       });
+
+      describe("log navigation", () => {
+
+        describe("jump-to-top button", () => {
+
+          it("scrolls to top", () => {
+            spyOn(window, "scrollTo");
+            element.query(By.css("button.jump-to-top")).triggerEventHandler("click", {});
+            expect(window.scrollTo).toHaveBeenCalledWith(0, 0);
+          });
+
+          describe("when log following is enabled", () => {
+
+            beforeEach(() => {
+              component.followLog = true;
+            });
+
+            it("disables log following", () => {
+              element.query(By.css("button.jump-to-top")).triggerEventHandler("click", {});
+              expect(component.followLog).toBe(false);
+            });
+          });
+        });
+
+        describe("follow-log button", () => {
+
+          it("enables log following", () => {
+            expect(component.followLog).toBe(false);
+
+            spyOn(window, "scrollTo");
+            spyOn(document, "querySelector").and.returnValues(
+              { getBoundingClientRect: () => { return { height: 100 }; } }, // contentHeight
+              { getBoundingClientRect: () => { return { height: 50 }; } },  // footerHeight
+              { getBoundingClientRect: () => { return { height: 10 }; } }   // navHeight
+            );
+
+            element.query(By.css("button.jump-to-end")).triggerEventHandler("click", {});
+
+            expect(window.scrollTo).toHaveBeenCalledWith(0, 30);
+            expect(component.followLog).toBe(true);
+          });
+        });
+      });
     });
   });
 


### PR DESCRIPTION
This adds a couple of buttons to the build-log view that let you jump to the beginning and end of a build log, and when a log is running, pin to the end of it.

![](https://media.tenor.com/images/ecbf3eeacb3eb01cfe0a4c9ccecb2288/tenor.gif)

Closes #2537.

Signed-off-by: Christian Nunciato <cnunciato@chef.io>