### PR TITLE
Create a .gitignore file with `hab plan init`

### DIFF
--- a/components/hab/static/template_gitignore
+++ b/components/hab/static/template_gitignore
@@ -1,0 +1,1 @@
+results/


### PR DESCRIPTION
For git-managed projects, this adds a .gitignore file when one doesn’t already exist, appending only those lines that wouldn't result in duplicates.

![](https://media.tenor.com/images/f44d99fbbe49d9de2836418cf2046036/tenor.gif)

Closes #2544.

Signed-off-by: Christian Nunciato <cnunciato@chef.io>