### PR TITLE
Remove the X-Contact Tag from S3 buckets

### DIFF
--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -23,7 +23,6 @@ resource "aws_s3_bucket" "jobs" {
 
   tags {
     Name          = "habitat-jobs-${var.env}"
-    X-Contact     = "The Habitat Maintainers <humans@habitat.sh>"
     X-Environment = "${var.env}"
     X-ManagedBy   = "Terraform"
   }

--- a/terraform/www.tf
+++ b/terraform/www.tf
@@ -39,7 +39,6 @@ resource "aws_s3_bucket" "www" {
 
   tags {
     Name          = "habitat-www-${var.env}"
-    X-Contact     = "The Habitat Maintainers <humans@habitat.sh>"
     X-Environment = "${var.env}"
     X-ManagedBy   = "Terraform"
   }


### PR DESCRIPTION
S3 doesn't allow email characters in tags, apparently.

Signed-off-by: Christopher Maier <cmaier@chef.io>