### PR TITLE
Fix worker environment, and misc fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,6 +130,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "builder_core"
 version = "0.0.0"
 dependencies = [
+ "chrono 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat_builder_protocol 0.0.0",
  "habitat_core 0.0.0",
  "libarchive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -704,6 +705,7 @@ dependencies = [
 name = "habitat_builder_worker"
 version = "0.0.0"
 dependencies = [
+ "builder_core 0.0.0",
  "chrono 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.23.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/builder-core/Cargo.toml
+++ b/components/builder-core/Cargo.toml
@@ -12,6 +12,7 @@ petgraph = "*"
 walkdir = "*"
 libarchive = "*"
 time = "*"
+chrono = { version = "*", features = ["serde"] }
 
 [dependencies.habitat_core]
 path = "../core"

--- a/components/builder-core/src/lib.rs
+++ b/components/builder-core/src/lib.rs
@@ -20,8 +20,10 @@ extern crate statsd;
 extern crate time;
 extern crate petgraph;
 extern crate walkdir;
+extern crate chrono;
 
 pub mod metrics;
 pub mod rdeps;
 pub mod package_graph;
 pub mod file_walker;
+pub mod logger;

--- a/components/builder-depot/src/server.rs
+++ b/components/builder-depot/src/server.rs
@@ -985,11 +985,9 @@ fn download_package(req: &mut Request) -> IronResult<Response> {
                     Err(_) => Ok(Response::with(status::NotFound)),
                 }
             } else {
-                // This should never happen. Writing the package to disk and recording it's
-                // existence in the metadata is a transactional operation and one cannot exist
-                // without the other.
-                panic!("Inconsistent package metadata! Exit and run `hab-depot repair` to fix \
-                        data integrity.");
+                // This can happen if the package is not found in the file system for some reason
+                error!("package not found - inconsistentcy between metadata and filesystem. download_package:2");
+                Ok(Response::with(status::InternalServerError))
             }
         }
         Err(err) => {

--- a/components/builder-scheduler/src/server/mod.rs
+++ b/components/builder-scheduler/src/server/mod.rs
@@ -14,7 +14,6 @@
 
 pub mod handlers;
 pub mod scheduler;
-pub mod logger;
 
 use std::ops::Deref;
 use std::sync::{Arc, RwLock};

--- a/components/builder-scheduler/src/server/scheduler.rs
+++ b/components/builder-scheduler/src/server/scheduler.rs
@@ -30,7 +30,7 @@ use data_store::DataStore;
 use error::{Result, Error};
 
 use config::Config;
-use server::logger::Logger;
+use bldr_core::logger::Logger;
 
 const SCHEDULER_ADDR: &'static str = "inproc://scheduler";
 const STATUS_ADDR: &'static str = "inproc://scheduler-status";
@@ -106,7 +106,7 @@ impl ScheduleMgr {
             let cfg = config.read().unwrap();
             PathBuf::from(cfg.log_path.clone())
         };
-        let logger = Logger::init(log_path);
+        let logger = Logger::init(log_path, "builder-scheduler.log");
 
         Ok(ScheduleMgr {
                datastore: datastore,
@@ -211,7 +211,7 @@ impl ScheduleMgr {
             }
 
             debug!("Dispatching project: {:?}", project.get_name());
-            self.logger.log_project(&group, &project);
+            self.logger.log_group_project(&group, &project);
 
             assert!(project.get_state() == proto::ProjectState::NotStarted);
 
@@ -394,7 +394,7 @@ impl ScheduleMgr {
         let job: Job = parse_from_bytes(&self.msg)?;
         let group: proto::Group = self.get_group(job.get_owner_id())?;
 
-        self.logger.log_job(&group, &job);
+        self.logger.log_group_job(&group, &job);
 
         match self.datastore.set_group_job_state(&job) {
             Ok(_) => {

--- a/components/builder-worker/Cargo.toml
+++ b/components/builder-worker/Cargo.toml
@@ -32,6 +32,9 @@ branch = "release/v0.8"
 [dependencies.habitat_core]
 path = "../core"
 
+[dependencies.builder_core]
+path = "../builder-core"
+
 [dependencies.habitat_net]
 path = "../net"
 

--- a/components/builder-worker/src/config.rs
+++ b/components/builder-worker/src/config.rs
@@ -31,6 +31,8 @@ pub struct Config {
     pub auto_publish: bool,
     /// Filepath where persistent application data is stored
     pub data_path: PathBuf,
+    /// Path to worker event logs
+    pub log_path: PathBuf,
     /// Default channel name for Publish post-processor to use to determine which channel to
     /// publish artifacts to
     pub depot_channel: String,
@@ -60,6 +62,7 @@ impl Default for Config {
             auth_token: "".to_string(),
             auto_publish: true,
             data_path: PathBuf::from("/tmp"),
+            log_path: PathBuf::from("/tmp"),
             depot_channel: String::from("unstable"),
             depot_url: url::default_depot_url(),
             jobsrv: vec![JobSrvAddr::default()],
@@ -102,6 +105,7 @@ mod tests {
         let content = r#"
         auth_token = "mytoken"
         data_path = "/path/to/data"
+        log_path = "/path/to/logs"
 
         [[jobsrv]]
         host = "1:1:1:1:1:1:1:1"
@@ -116,6 +120,7 @@ mod tests {
         let config = Config::from_raw(&content).unwrap();
         assert_eq!(&config.auth_token, "mytoken");
         assert_eq!(&format!("{}", config.data_path.display()), "/path/to/data");
+        assert_eq!(&format!("{}", config.log_path.display()), "/path/to/logs");
         assert_eq!(&format!("{}", config.jobsrv[0].host), "1:1:1:1:1:1:1:1");
         assert_eq!(config.jobsrv[0].port, 9000);
         assert_eq!(config.jobsrv[0].heartbeat, 9001);

--- a/components/builder-worker/src/lib.rs
+++ b/components/builder-worker/src/lib.rs
@@ -29,6 +29,7 @@ extern crate serde_derive;
 extern crate toml;
 extern crate zmq;
 extern crate habitat_builder_protocol;
+extern crate builder_core as bldr_core;
 
 pub mod config;
 pub mod error;


### PR DESCRIPTION
This PR does the following: 
1. Fix the builder-worker to run studio builds in the context of a specified depot url (thus enabling builds to pull dependent packages from a specific environment).
2. Update the builder-jobsrv datastore to read and write job error data (error code and message).
3. Add text file logging to the builder-worker, and move the logger to builder-core.

Signed-off-by: Salim Alam <salam@chef.io>