### PR TITLE
Remove the reliance on sequence numbers from the db migrator.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -561,6 +561,7 @@ dependencies = [
  "fallible-iterator 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat_builder_protocol 0.0.0",
+ "habitat_core 0.0.0",
  "habitat_net 0.0.0",
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/builder-db/Cargo.toml
+++ b/components/builder-db/Cargo.toml
@@ -19,6 +19,9 @@ fnv = "*"
 fallible-iterator = "*"
 threadpool = "*"
 
+[dependencies.habitat_core]
+path = "../core"
+
 [dependencies.habitat_net]
 path = "../net"
 

--- a/components/builder-db/src/async.rs
+++ b/components/builder-db/src/async.rs
@@ -85,9 +85,7 @@ impl AsyncServer {
                 // Safe because we checked above
                 d.get(dispatch_key).unwrap().clone()
             };
-            let mut r = self.retry
-                .write()
-                .expect("Async retry lock is poisoned");
+            let mut r = self.retry.write().expect("Async retry lock is poisoned");
             r.insert(dispatch_key.to_string(), (SteadyTime::now(), function));
         }
         Ok(())
@@ -101,9 +99,7 @@ impl AsyncServer {
             d.insert(dispatch_key.clone(), callback.clone());
         }
         {
-            let mut r = self.retry
-                .write()
-                .expect("Async retry lock is poisoned");
+            let mut r = self.retry.write().expect("Async retry lock is poisoned");
             r.insert(dispatch_key, (SteadyTime::now(), callback));
         }
     }
@@ -192,10 +188,8 @@ impl AsyncServer {
                     let events = server.get_num_events(available_jobs);
                     for (key, event) in events.into_iter() {
                         let is_running = {
-                            let running_events = server
-                                .running
-                                .read()
-                                .expect("Running events lock poisoned");
+                            let running_events =
+                                server.running.read().expect("Running events lock poisoned");
                             running_events.contains(&key)
                         };
                         if !is_running {

--- a/components/builder-db/src/error.rs
+++ b/components/builder-db/src/error.rs
@@ -31,6 +31,7 @@ pub enum Error {
     AsyncFunctionUpdate(postgres::error::Error),
     ConnectionTimeout(r2d2::GetTimeout),
     FunctionCreate(postgres::error::Error),
+    FunctionDrop(postgres::error::Error),
     FunctionRun(postgres::error::Error),
     NetError(hab_net::Error),
     Migration(postgres::error::Error),
@@ -69,6 +70,7 @@ impl fmt::Display for Error {
             }
             Error::ConnectionTimeout(ref e) => format!("Connection timeout, {}", e),
             Error::FunctionCreate(ref e) => format!("Error creating a function: {}", e),
+            Error::FunctionDrop(ref e) => format!("Error dropping a function: {}", e),
             Error::FunctionRun(ref e) => format!("Error running a function: {}", e),
             Error::NetError(ref e) => format!("{}", e),
             Error::Migration(ref e) => format!("Error executing migration: {}", e),
@@ -103,6 +105,7 @@ impl error::Error for Error {
             Error::AsyncFunctionUpdate(ref e) => e.description(),
             Error::ConnectionTimeout(ref e) => e.description(),
             Error::FunctionCreate(_) => "Error creating database function",
+            Error::FunctionDrop(_) => "Error dropping database function",
             Error::FunctionRun(_) => "Error running a database function",
             Error::NetError(ref err) => err.description(),
             Error::Migration(_) => "Error executing migration",

--- a/components/builder-db/src/lib.rs
+++ b/components/builder-db/src/lib.rs
@@ -76,6 +76,7 @@ extern crate serde;
 extern crate serde_derive;
 extern crate fallible_iterator;
 extern crate habitat_builder_protocol as protocol;
+extern crate habitat_core as hcore;
 extern crate habitat_net as hab_net;
 
 pub mod config;

--- a/components/builder-db/tests/migration/mod.rs
+++ b/components/builder-db/tests/migration/mod.rs
@@ -67,3 +67,109 @@ fn migrate() {
         }
     });
 }
+
+#[test]
+#[allow(unused_must_use)]
+fn migrate_out_of_order_edits() {
+    with_pool!(pool, {
+        let conn = pool.get_raw().expect("cannot get connection");
+        {
+            let xact = conn.transaction().expect("cannot get transaction");
+            let mut migrator = Migrator::new(xact, vec![0, 1]);
+            migrator
+                .setup()
+                .expect("Migration setup must be idempotent");
+            migrator
+                .migrate("metal",
+                         r#"CREATE TABLE bands (
+                                    name text PRIMARY KEY,
+                                    style text
+                                 )"#)
+                .expect("Migration should be run successfully");
+            migrator
+                .migrate("metal",
+                         r#"CREATE TABLE cars (
+                                    name text PRIMARY KEY,
+                                    style text
+                                 )"#)
+                .expect("Migration should be run successfully");
+            migrator.finish();
+        }
+        {
+            let xact = conn.transaction().expect("cannot get transaction");
+            let mut migrator = Migrator::new(xact, vec![0, 1]);
+            migrator
+                .setup()
+                .expect("Migration setup must be idempotent");
+            migrator
+                .migrate("metal",
+                         r#"CREATE TABLE bands (
+                                    name text PRIMARY KEY,
+                                    style text
+                                 )"#)
+                .expect("Migration should be run successfully");
+            migrator
+                .migrate("metal",
+                         r#"CREATE TABLE hats (
+                                    name text PRIMARY KEY,
+                                    style text
+                                 )"#)
+                .expect("Migration should be run successfully");
+            migrator
+                .migrate("metal",
+                         r#"CREATE TABLE cars (
+                                    name text PRIMARY KEY,
+                                    style text
+                                 )"#)
+                .expect("Migration should be run successfully");
+            migrator.finish();
+        }
+        {
+            let xact = conn.transaction().expect("cannot get transaction");
+            let mut migrator = Migrator::new(xact, vec![0, 1]);
+            migrator
+                .setup()
+                .expect("Migration setup must be idempotent");
+            migrator
+                .migrate("metal",
+                         r#"CREATE TABLE bands (
+                                    name text PRIMARY KEY,
+                                    style text
+                                 )"#)
+                .expect("Migration should be run successfully");
+            migrator
+                .migrate("metal",
+                         r#"CREATE TABLE hats (
+                                    name text PRIMARY KEY,
+                                    style text
+                                 )"#)
+                .expect("Migration should be run successfully");
+            migrator
+                .migrate("metal",
+                         r#"CREATE TABLE cars (
+                                    name text PRIMARY KEY,
+                                    style text
+                                 )"#)
+                .expect("Migration should be run successfully");
+            migrator
+                .migrate("metal",
+                         r#"CREATE TABLE forks (
+                                    name text PRIMARY KEY,
+                                    style text
+                                 )"#)
+                .expect("Migration should be run successfully");
+            migrator.finish();
+        }
+        {
+            let xact = conn.transaction().expect("cannot get transaction");
+            xact.execute("SELECT * FROM bands", &[])
+                .expect("Table should exist");
+            xact.execute("SELECT * FROM hats", &[])
+                .expect("Table should exist");
+            xact.execute("SELECT * FROM cars", &[])
+                .expect("Table should exist");
+            xact.execute("SELECT * FROM forks", &[])
+                .expect("Table should exist");
+        }
+    });
+}

--- a/components/builder-jobsrv/src/data_store.rs
+++ b/components/builder-jobsrv/src/data_store.rs
@@ -82,7 +82,7 @@ impl DataStore {
         // The core jobs table
         migrator
             .migrate("jobsrv",
-                     r#"CREATE TABLE jobs (
+                     r#"CREATE TABLE IF NOT EXISTS jobs (
                                     id bigint PRIMARY KEY DEFAULT next_id_v1('job_id_seq'),
                                     owner_id bigint,
                                     job_state text,

--- a/components/builder-originsrv/src/migrations/origin_channels.rs
+++ b/components/builder-originsrv/src/migrations/origin_channels.rs
@@ -22,7 +22,7 @@ pub fn migrate(migrator: &mut Migrator) -> Result<()> {
                  r#"CREATE SEQUENCE IF NOT EXISTS origin_channel_id_seq;"#)?;
     migrator
         .migrate("originsrv",
-                 r#"CREATE TABLE origin_channels (
+                 r#"CREATE TABLE IF NOT EXISTS origin_channels (
                     id bigint PRIMARY KEY DEFAULT next_id_v1('origin_channel_id_seq'),
                     origin_id bigint REFERENCES origins(id),
                     owner_id bigint,
@@ -33,7 +33,7 @@ pub fn migrate(migrator: &mut Migrator) -> Result<()> {
              )"#)?;
     migrator
         .migrate("originsrv",
-                 r#"CREATE TABLE origin_channel_packages (
+                 r#"CREATE TABLE IF NOT EXISTS origin_channel_packages (
                     channel_id bigint REFERENCES origin_channels(id) ON DELETE CASCADE,
                     package_id bigint REFERENCES origin_packages(id),
                     created_at timestamptz DEFAULT now(),

--- a/components/builder-originsrv/src/migrations/origin_invitations.rs
+++ b/components/builder-originsrv/src/migrations/origin_invitations.rs
@@ -22,7 +22,7 @@ pub fn migrate(migrator: &mut Migrator) -> Result<()> {
                  r#"CREATE SEQUENCE IF NOT EXISTS origin_invitations_id_seq;"#)?;
     migrator
         .migrate("originsrv",
-                 r#"CREATE TABLE origin_invitations (
+                 r#"CREATE TABLE IF NOT EXISTS origin_invitations (
                         id bigint PRIMARY KEY DEFAULT next_id_v1('origin_invitations_id_seq'),
                         origin_id bigint REFERENCES origins(id),
                         origin_name text,

--- a/components/builder-originsrv/src/migrations/origin_packages.rs
+++ b/components/builder-originsrv/src/migrations/origin_packages.rs
@@ -22,7 +22,7 @@ pub fn migrate(migrator: &mut Migrator) -> Result<()> {
                  r#"CREATE SEQUENCE IF NOT EXISTS origin_package_id_seq;"#)?;
     migrator
         .migrate("originsrv",
-                 r#"CREATE TABLE origin_packages (
+                 r#"CREATE TABLE IF NOT EXISTS origin_packages (
                     id bigint PRIMARY KEY DEFAULT next_id_v1('origin_package_id_seq'),
                     origin_id bigint REFERENCES origins(id),
                     owner_id bigint,

--- a/components/builder-originsrv/src/migrations/origin_projects.rs
+++ b/components/builder-originsrv/src/migrations/origin_projects.rs
@@ -22,7 +22,7 @@ pub fn migrate(migrator: &mut Migrator) -> Result<()> {
                  r#"CREATE SEQUENCE IF NOT EXISTS origin_project_id_seq;"#)?;
     migrator
         .migrate("originsrv",
-                 r#"CREATE TABLE origin_projects (
+                 r#"CREATE TABLE IF NOT EXISTS origin_projects (
                         id bigint PRIMARY KEY DEFAULT next_id_v1('origin_project_id_seq'),
                         origin_id bigint REFERENCES origins(id),
                         origin_name text,

--- a/components/builder-originsrv/src/migrations/origin_public_keys.rs
+++ b/components/builder-originsrv/src/migrations/origin_public_keys.rs
@@ -22,7 +22,7 @@ pub fn migrate(migrator: &mut Migrator) -> Result<()> {
                  r#"CREATE SEQUENCE IF NOT EXISTS origin_public_key_id_seq;"#)?;
     migrator
         .migrate("originsrv",
-                 r#"CREATE TABLE origin_public_keys (
+                 r#"CREATE TABLE IF NOT EXISTS origin_public_keys (
                     id bigint PRIMARY KEY DEFAULT next_id_v1('origin_public_key_id_seq'),
                     origin_id bigint REFERENCES origins(id),
                     owner_id bigint,

--- a/components/builder-originsrv/src/migrations/origin_secret_keys.rs
+++ b/components/builder-originsrv/src/migrations/origin_secret_keys.rs
@@ -22,7 +22,7 @@ pub fn migrate(migrator: &mut Migrator) -> Result<()> {
                  r#"CREATE SEQUENCE IF NOT EXISTS origin_secret_key_id_seq;"#)?;
     migrator
         .migrate("originsrv",
-                 r#"CREATE TABLE origin_secret_keys (
+                 r#"CREATE TABLE IF NOT EXISTS origin_secret_keys (
                     id bigint PRIMARY KEY DEFAULT next_id_v1('origin_secret_key_id_seq'),
                     origin_id bigint REFERENCES origins(id),
                     owner_id bigint,

--- a/components/builder-originsrv/src/migrations/origins.rs
+++ b/components/builder-originsrv/src/migrations/origins.rs
@@ -22,7 +22,7 @@ pub fn migrate(migrator: &mut Migrator) -> Result<()> {
                  r#"CREATE SEQUENCE IF NOT EXISTS origin_id_seq;"#)?;
     migrator
         .migrate("originsrv",
-                 r#"CREATE TABLE origins (
+                 r#"CREATE TABLE IF NOT EXISTS origins (
                     id bigint PRIMARY KEY DEFAULT next_id_v1('origin_id_seq'),
                     name text UNIQUE,
                     owner_id bigint,
@@ -32,7 +32,7 @@ pub fn migrate(migrator: &mut Migrator) -> Result<()> {
              )"#)?;
     migrator
         .migrate("originsrv",
-                 r#"CREATE TABLE origin_members (
+                 r#"CREATE TABLE IF NOT EXISTS origin_members (
                     origin_id bigint REFERENCES origins(id),
                     origin_name text,
                     account_id bigint,

--- a/components/builder-scheduler/src/data_store.rs
+++ b/components/builder-scheduler/src/data_store.rs
@@ -60,7 +60,7 @@ impl DataStore {
         // The packages table
         migrator
             .migrate("scheduler",
-                     r#"CREATE TABLE packages (
+                     r#"CREATE TABLE IF NOT EXISTS packages (
                                      id bigserial PRIMARY KEY,
                                      ident text UNIQUE,
                                      deps text[],
@@ -122,7 +122,7 @@ impl DataStore {
         // The groups table
         migrator
             .migrate("scheduler",
-                     r#"CREATE TABLE groups (
+                     r#"CREATE TABLE IF NOT EXISTS groups (
                                     id bigint PRIMARY KEY,
                                     group_state text,
                                     created_at timestamptz DEFAULT now(),
@@ -132,7 +132,7 @@ impl DataStore {
         // The projects table
         migrator
             .migrate("scheduler",
-                     r#"CREATE TABLE projects (
+                     r#"CREATE TABLE IF NOT EXISTS projects (
                                      id bigserial PRIMARY KEY,
                                      owner_id bigint,
                                      project_name text,

--- a/components/builder-sessionsrv/src/migrations/accounts.rs
+++ b/components/builder-sessionsrv/src/migrations/accounts.rs
@@ -22,7 +22,7 @@ pub fn migrate(migrator: &mut Migrator) -> Result<()> {
                  r#"CREATE SEQUENCE IF NOT EXISTS accounts_id_seq;"#)?;
     migrator
         .migrate("accountsrv",
-                 r#"CREATE TABLE accounts (
+                 r#"CREATE TABLE IF NOT EXISTS accounts (
                         id bigint PRIMARY KEY DEFAULT next_id_v1('accounts_id_seq'),
                         name text UNIQUE,
                         email text UNIQUE,
@@ -70,7 +70,7 @@ pub fn migrate(migrator: &mut Migrator) -> Result<()> {
                  $$ LANGUAGE plpgsql STABLE"#)?;
     migrator
         .migrate("accountsrv",
-                 r#"CREATE TABLE account_origins (
+                 r#"CREATE TABLE IF NOT EXISTS account_origins (
                         account_id bigint,
                         account_name text,
                         origin_id bigint,

--- a/components/builder-sessionsrv/src/migrations/invitations.rs
+++ b/components/builder-sessionsrv/src/migrations/invitations.rs
@@ -22,7 +22,7 @@ pub fn migrate(migrator: &mut Migrator) -> Result<()> {
                  r#"CREATE SEQUENCE IF NOT EXISTS account_invitations_id_seq;"#)?;
     migrator
         .migrate("accountsrv",
-                 r#"CREATE TABLE account_invitations (
+                 r#"CREATE TABLE IF NOT EXISTS account_invitations (
                         id bigint PRIMARY KEY DEFAULT next_id_v1('account_invitations_id_seq'),
                         origin_invitation_id bigint,
                         origin_id bigint,

--- a/components/builder-sessionsrv/src/migrations/sessions.rs
+++ b/components/builder-sessionsrv/src/migrations/sessions.rs
@@ -19,7 +19,7 @@ use error::Result;
 pub fn migrate(migrator: &mut Migrator) -> Result<()> {
     migrator
         .migrate("accountsrv",
-                 r#"CREATE TABLE account_sessions (
+                 r#"CREATE TABLE IF NOT EXISTS account_sessions (
                         account_id bigint REFERENCES accounts(id),
                         token text,
                         provider text,


### PR DESCRIPTION
Instead, we take the incoming SQL content to migrate and hash it using BLAKE2b and check that hashed content against the migrations table. This allows for the flexibility of putting migrations anywhere you like within the migrations file.

This also allows people to edit migrations after they've already been migrated and everything should still work (provided you're not violating database rules like changing the arguments or return types of functions).  I don't think this is a good practice, however, even if it's possible.

Also note that some of the migrations inside of the migrator itself might seem a little odd, what with the altering of tables and adding/dropping columns and functions, but I wanted to make this work when run against an existing live system.  Taking down a running cluster and making manual edits to the db in order to apply this change felt like the wrong move.

Finally, note that I'm not saying this is the best solution to our problem.  I initially looked at integrating https://github.com/Keats/dbmigrate into our codebase as the way to do migrations, but making that library work with the way we shard things felt like a lot more effort than what's in this PR, and I wasn't sure if it was worth it or not.  There was also discussion of using sqitch, and I detailed the arguments against that in https://github.com/habitat-sh/habitat/issues/2498.  I'm interested in seeing what people think of this, and if it seems like a good way forward.

![4taziwp](https://user-images.githubusercontent.com/947/27109406-8994e994-5057-11e7-80f9-c82dd172632c.gif)

Closes https://github.com/habitat-sh/habitat/issues/2498

Signed-off-by: Josh Black <raskchanky@gmail.com>