### PR TITLE
Add links to build history

### DIFF
--- a/components/builder-web/app/build-list/_build-list.component.scss
+++ b/components/builder-web/app/build-list/_build-list.component.scss
@@ -36,9 +36,10 @@
 
     li {
       @include row;
+      position: relative;
 
       font-size: rem(12);
-      border-bottom: 1px solid $light-gray;
+      border-bottom: 1px solid $very-light-gray;
       padding: 0 10px;
 
       &.heading {
@@ -55,7 +56,7 @@
           cursor: pointer;
           background-color: rgba($medium-gray, 0.05);
 
-          .status {
+          .icons {
             .octicon-chevron-right {
               display: block;
             }
@@ -81,12 +82,19 @@
         @include span-columns(3);
       }
 
-      .status {
+      .icons {
         @include span-columns(3);
-        position: relative;
 
         .octicon {
           font-size: rem(20);
+          position: absolute;
+          right: 0;
+          top: 50%;
+          transform: translateY(-50%);
+
+          &.status {
+            right: 52px;
+          }
 
           &.complete {
             color: $hab-green;
@@ -96,6 +104,8 @@
             color: $hab-orange;
             height: rem(20);
             width: rem(16);
+            top: 36%;
+            transform: translateY(-36%);
             animation-duration: 1s;
             animation-iteration-count: infinite;
             animation-name: spinning;
@@ -110,6 +120,14 @@
             color: $hab-red;
           }
 
+          &.octicon-chevron-right {
+            display: none;
+            position: absolute;
+            right: 0;
+            top: 50%;
+            transform: translateY(-50%);
+          }
+
           @keyframes spinning {
             from {
               transform: rotate(0deg);
@@ -118,14 +136,6 @@
             to {
               transform: rotate(360deg);
             }
-          }
-
-          &.octicon-chevron-right {
-            display: none;
-            position: absolute;
-            right: 0;
-            top: 50%;
-            transform: translateY(-50%);
           }
         }
       }

--- a/components/builder-web/app/build-list/build-list.component.html
+++ b/components/builder-web/app/build-list/build-list.component.html
@@ -27,8 +27,9 @@
       <div class="created">
         {{ dateFor(build.created_at) }}
       </div>
-      <div class="status" title="{{ build.state | titlecase }}">
-        <div class="octicon octicon-{{ iconFor(build.state) }} {{ build.state | lowercase }}"></div>
+      <div class="icons">
+        <div class="status octicon octicon-{{ iconFor(build.state) }} {{ build.state | lowercase }}"
+           title="{{ build.state | titlecase }}"></div>
         <div class="octicon octicon-chevron-right"></div>
       </div>
     </li>

--- a/components/builder-web/app/build-list/build-list.component.spec.ts
+++ b/components/builder-web/app/build-list/build-list.component.spec.ts
@@ -74,9 +74,9 @@ describe("BuildListComponent", () => {
       expect(items.length).toBe(3);
       expect(items[0].query(By.css(".version")).nativeElement.textContent).toContain("1.0.0");
       expect(items[0].query(By.css(".status")).nativeElement.getAttribute("title")).toBe("Complete");
-      expect(items[0].query(By.css(".status .octicon")).nativeElement.getAttribute("class")).toContain("complete");
-      expect(items[1].query(By.css(".status .octicon")).nativeElement.getAttribute("class")).toContain("pending");
-      expect(items[2].query(By.css(".status .octicon")).nativeElement.getAttribute("class")).toContain("failed");
+      expect(items[0].query(By.css(".status")).nativeElement.getAttribute("class")).toContain("complete");
+      expect(items[1].query(By.css(".status")).nativeElement.getAttribute("class")).toContain("pending");
+      expect(items[2].query(By.css(".status")).nativeElement.getAttribute("class")).toContain("failed");
     });
 
     describe("when a build item is clicked", () => {

--- a/components/builder-web/app/build/build.component.spec.ts
+++ b/components/builder-web/app/build/build.component.spec.ts
@@ -72,6 +72,16 @@ describe("BuildComponent", () => {
         name: "nginx",
         id: "123"
       };
+
+      fixture.detectChanges();
+    });
+
+    describe("the return-to-builds link", () => {
+
+      it("links to the build-history list", () => {
+        let link = element.query(By.css(".back a")).nativeElement;
+        expect(link.getAttribute("href")).toBe("/pkgs/core/nginx/builds");
+      });
     });
   });
 

--- a/components/builder-web/app/build/build.component.ts
+++ b/components/builder-web/app/build/build.component.ts
@@ -100,13 +100,7 @@ export class BuildComponent implements OnChanges, OnDestroy {
     }
 
     get buildsLink() {
-        let link = ["/pkgs", this.build.origin, this.build.name];
-
-        if (this.build.version) {
-            link.push(this.build.version);
-        }
-
-        return link;
+        return ["/pkgs", this.build.origin, this.build.name, "builds"];
     }
 
     get elapsed() {

--- a/components/builder-web/app/package-builds/_package-builds.component.scss
+++ b/components/builder-web/app/package-builds/_package-builds.component.scss
@@ -10,9 +10,8 @@
 
   .page-body {
 
-    hab-build-list {
-      margin-top: 8px;
-      @include span-columns(9);
+    .hab-build-list {
+      margin-top: 14px;
     }
   }
 }

--- a/components/builder-web/app/packages-page/_packages-page.scss
+++ b/components/builder-web/app/packages-page/_packages-page.scss
@@ -73,6 +73,11 @@
     }
   }
 
+  .build-history {
+    margin-top: 22px;
+    font-size: rem(14);
+  }
+
   .page-body--sidebar {
 
     h4 {

--- a/components/builder-web/app/packages-page/packages-page.component.html
+++ b/components/builder-web/app/packages-page/packages-page.component.html
@@ -20,9 +20,9 @@
     <div class="page-body" [class.has-sidebar]="iCanRequestABuild">
         <div [class.page-body--main]="iCanRequestABuild">
             <input *ngIf="showSearch"
-         type="search" autofocus
-         [formControl]="searchBox"
-         placeholder="Search Packages&hellip;">
+                type="search" autofocus
+                [formControl]="searchBox"
+                placeholder="Search Packages&hellip;">
 
             <div class="active {{ activeBuild.state | lowercase }}" *ngIf="activeBuild">
                 A build is in progress.
@@ -43,6 +43,13 @@
                      {{(totalCount - packages.size) > perPage ? perPage : totalCount - packages.size }}
                      more</a>.
              </div>
+
+             <div class="build-history" *ngIf="showBuildHistoryLink">
+                <a [routerLink]="['/pkgs', origin, name, 'builds']">
+                    View full build history
+                    <span class="octicon octicon-chevron-right"></span>
+                </a>
+            </div>
         </div>
         <div class="page-body--sidebar" *ngIf="iCanRequestABuild">
             <h4>Build</h4>

--- a/components/builder-web/app/packages-page/packages-page.component.spec.ts
+++ b/components/builder-web/app/packages-page/packages-page.component.spec.ts
@@ -124,6 +124,29 @@ describe("PackagesPageComponent", () => {
           fixture.detectChanges();
           expect(element.query(By.css(".page-body--sidebar button"))).toBeNull();
         });
+
+        it("shows a link to the build-history list", () => {
+          fixture.detectChanges();
+          let link = element.query(By.css(".build-history a")).nativeElement;
+
+          expect(link.getAttribute("href")).toBe("/pkgs/core/linux-headers/builds");
+          expect(link.textContent).toContain("View full build history");
+        });
+      });
+
+      describe("when the user is not signed in", () => {
+
+        beforeEach(() => {
+          MockAppStore.state.origins.mine = List();
+          MockAppStore.state.gitHub.authToken = undefined;
+        });
+
+        it("does not show a link to the build-history list", () => {
+          fixture.detectChanges();
+          let link = element.query(By.css(".build-history a"));
+
+          expect(link).toBeNull();
+        });
       });
     });
   });

--- a/components/builder-web/app/packages-page/packages-page.component.ts
+++ b/components/builder-web/app/packages-page/packages-page.component.ts
@@ -18,7 +18,6 @@ import { ActivatedRoute, Router } from "@angular/router";
 import { AppStore } from "../AppStore";
 import { clearBuilds, fetchBuilds, fetchPackageVersions, filterPackagesBy,
          scheduleBuild, setPackagesSearchQuery } from "../actions/index";
-import { requireSignIn } from "../util";
 import { Subscription } from "rxjs/Subscription";
 
 @Component({
@@ -110,6 +109,12 @@ export class PackagesPageComponent implements OnInit, OnDestroy {
         }
 
         return false;
+    }
+
+    get showBuildHistoryLink() {
+        return !!this.store.getState().gitHub.authToken &&
+            this.layout !== "origin" &&
+            this.origin === "core";
     }
 
     get layout() {


### PR DESCRIPTION
This adds a link to the bottom of package-list views to the full build history of a package, including running and failed builds.

Closes #2573.

![](https://media.tenor.com/images/21a91bf34fbf93d0664fedf78694b28b/tenor.gif) 

Signed-off-by: Christian Nunciato <cnunciato@chef.io>