### PR TITLE
Add hab-op, a small operational tool with a few utilities.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,10 +1,12 @@
 [root]
-name = "habitat_win_users"
-version = "0.0.0"
+name = "op"
+version = "0.1.0"
 dependencies = [
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "widestring 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.23.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "habitat_builder_protocol 0.0.0",
+ "habitat_core 0.0.0",
+ "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -975,6 +977,15 @@ dependencies = [
  "time 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "habitat_win_users"
+version = "0.0.0"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "widestring 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
   "components/hab",
   "components/http-client",
   "components/net",
+  "components/op",
   "components/sup",
   "components/butterfly",
   "components/butterfly-test",

--- a/components/op/Cargo.toml
+++ b/components/op/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "op"
+version = "0.1.0"
+authors = ["Josh Black <raskchanky@gmail.com>"]
+description = "Operational tools for Habitat developers"
+workspace = "../../"
+
+[dependencies]
+fnv = "*"
+log = "*"
+habitat_core = { path = "../core" }
+
+[dependencies.habitat_builder_protocol]
+path = "../builder-protocol"
+
+[dependencies.clap]
+version = "*"
+features = [ "suggestions", "color", "unstable" ]

--- a/components/op/src/config.rs
+++ b/components/op/src/config.rs
@@ -1,0 +1,30 @@
+// Copyright (c) 2016-2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[derive(Clone, Debug)]
+pub struct Config {
+    // file to hash
+    pub file: Option<String>,
+    // origin to get the shard of
+    pub origin: Option<String>,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Config {
+            file: None,
+            origin: None,
+        }
+    }
+}

--- a/components/op/src/error.rs
+++ b/components/op/src/error.rs
@@ -1,0 +1,55 @@
+// Copyright (c) 2016-2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::error;
+use std::fmt;
+use std::result;
+
+use hcore;
+
+#[derive(Debug)]
+pub enum Error {
+    NoFile,
+    NoOrigin,
+    HabitatCore(hcore::Error),
+}
+
+pub type Result<T> = result::Result<T, Error>;
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let msg = match *self {
+            Error::NoFile => format!("No file was specified to hash"),
+            Error::NoOrigin => format!("No origin was specified to get a shard from"),
+            Error::HabitatCore(ref e) => format!("{}", e),
+        };
+        write!(f, "{}", msg)
+    }
+}
+
+impl error::Error for Error {
+    fn description(&self) -> &str {
+        match *self {
+            Error::NoFile => "No file was specified to hash",
+            Error::NoOrigin => "No origin was specified to get a shard from",
+            Error::HabitatCore(ref err) => err.description(),
+        }
+    }
+}
+
+impl From<hcore::Error> for Error {
+    fn from(err: hcore::Error) -> Error {
+        Error::HabitatCore(err)
+    }
+}

--- a/components/op/src/lib.rs
+++ b/components/op/src/lib.rs
@@ -1,0 +1,21 @@
+// Copyright (c) 2016-2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+extern crate fnv;
+extern crate habitat_builder_protocol as protocol;
+extern crate habitat_core as hcore;
+
+pub mod config;
+pub mod util;
+pub mod error;

--- a/components/op/src/main.rs
+++ b/components/op/src/main.rs
@@ -1,0 +1,90 @@
+// Copyright (c) 2016-2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[macro_use]
+extern crate clap;
+#[macro_use]
+extern crate log;
+extern crate op;
+
+use op::config::Config;
+use op::error::{Error, Result};
+use op::util;
+
+use std::process;
+
+const VERSION: &'static str = "0.1.0";
+
+fn main() {
+    let matches = app().get_matches();
+    debug!("CLI matches: {:?}", matches);
+    let config = match config_from_args(&matches) {
+        Ok(result) => result,
+        Err(e) => return exit_with(e, 1),
+    };
+    match dispatch(config, &matches) {
+        Ok(_) => std::process::exit(0),
+        Err(e) => exit_with(e, 1),
+    }
+}
+
+fn app<'a, 'b>() -> clap::App<'a, 'b> {
+    clap_app!(Op =>
+        (version: VERSION)
+        (about: "Habitat operational tool")
+        (@setting VersionlessSubcommands)
+        (@setting SubcommandRequiredElseHelp)
+        (@subcommand hash =>
+            (about: "Return the BLAKE2b hash for a file")
+            (@arg file: --file +takes_value "File to hash")
+        )
+        (@subcommand shard =>
+            (about: "Return the shard number for an origin")
+            (@arg origin: --origin +takes_value "Origin")
+        )
+    )
+}
+
+fn config_from_args(matches: &clap::ArgMatches) -> Result<Config> {
+    let cmd = matches.subcommand_name().unwrap();
+    let args = matches.subcommand_matches(cmd).unwrap();
+    let mut config = Config::default();
+
+    if let Some(origin) = args.value_of("origin") {
+        config.origin = Some(origin.to_string());
+    }
+
+    if let Some(file) = args.value_of("file") {
+        config.file = Some(file.to_string());
+    }
+
+    Ok(config)
+}
+
+fn dispatch(config: Config, matches: &clap::ArgMatches) -> Result<()> {
+    match matches.subcommand_name() {
+        Some("hash") => util::hash(config),
+        Some("shard") => util::shard(config),
+        Some(cmd) => {
+            debug!("Dispatch failed, no match for command: {:?}", cmd);
+            Ok(())
+        }
+        None => Ok(()),
+    }
+}
+
+fn exit_with(err: Error, code: i32) {
+    println!("{}", err);
+    process::exit(code)
+}

--- a/components/op/src/util.rs
+++ b/components/op/src/util.rs
@@ -1,0 +1,52 @@
+// Copyright (c) 2016-2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::hash::Hasher;
+use std::path::PathBuf;
+
+use fnv::FnvHasher;
+use hcore::crypto::hash::hash_file;
+use protocol::SHARD_COUNT;
+
+use config::Config;
+use error::{Error, Result};
+
+pub fn hash(config: Config) -> Result<()> {
+    if config.file.is_none() {
+        return Err(Error::NoFile);
+    }
+
+    let path = PathBuf::from(config.file.unwrap());
+    match hash_file(&path) {
+        Ok(checksum) => {
+            println!("{}", checksum);
+            Ok(())
+        }
+        Err(e) => Err(Error::HabitatCore(e)),
+    }
+}
+
+pub fn shard(config: Config) -> Result<()> {
+    if config.origin.is_none() {
+        return Err(Error::NoOrigin);
+    }
+
+    let origin = config.origin.unwrap();
+    let mut hasher = FnvHasher::default();
+    hasher.write(origin.as_bytes());
+    let hval = hasher.finish();
+    let result = hval % SHARD_COUNT as u64;
+    println!("{}", result);
+    Ok(())
+}


### PR DESCRIPTION
This is designed to be used by developers working on Habitat. This crate builds a command line tool called "op" and it provides two commands:

`op hash --file /path/to/file`

This will return the BLAKE2b hash checksum for said file, which is very useful if you need to upload files manually via curl, e.g. because the file is huge and `hab pkg upload` is timing out.

`op shard --origin myoriginname`

This will return the shard number for the origin provided, allowing you to know what to set the Postgres search path to in order to find what you need.

I'm sure everything in here could be done better.  I literally just hacked this together in an hour or so after getting tired of wanting these values for debugging and being unable to get them easily.

![tenor-148404736](https://user-images.githubusercontent.com/947/27346140-04c3be8a-55a1-11e7-948b-dd5935013915.gif)

Signed-off-by: Josh Black <raskchanky@gmail.com>