### PR TITLE
Add more support for channels to hab cli

### DIFF
--- a/components/builder-worker/src/runner/postprocessor.rs
+++ b/components/builder-worker/src/runner/postprocessor.rs
@@ -48,8 +48,9 @@ impl Publish {
             error!("post processing error uploading package, ERR={:?}", err);
             return false;
         };
+        let ident = archive.ident().unwrap();
         if let Some(err) = client
-            .promote_package(archive, &self.channel, auth_token)
+            .promote_package(&ident, &self.channel, auth_token)
             .err()
         {
             error!("post processing error promoting package, ERR={:?}", err);

--- a/components/common/src/command/package/install.rs
+++ b/components/common/src/command/package/install.rs
@@ -40,6 +40,7 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 use depot_client::{self, Client};
+use depot_client::Error::APIError;
 use hcore;
 use hcore::fs::{am_i_root, cache_key_path};
 use hcore::crypto::{artifact, SigKeyPair};
@@ -127,6 +128,27 @@ impl<'a> InstallTask<'a> {
         })
     }
 
+    fn get_channel_recommendations(&self, ident: &PackageIdent) -> Result<Vec<(String, String)>> {
+        let mut res = Vec::new();
+
+        let channels = match self.depot_client.list_channels(ident.origin()) {
+            Ok(channels) => channels,
+            Err(e) => {
+                debug!("Failed to get channel list: {:?}", e);
+                return Err(Error::PackageNotFound);
+            }
+        };
+
+        for channel in channels {
+            match self.fetch_latest_pkg_ident_for(ident, Some(&channel)) {
+                Ok(pkg) => res.push((channel, format!("{}", pkg))),
+                Err(_) => (),
+            };
+        }
+
+        Ok(res)
+    }
+
     pub fn from_ident(
         &self,
         ui: &mut UI,
@@ -136,7 +158,32 @@ impl<'a> InstallTask<'a> {
         try!(ui.begin(format!("Installing {}", &ident)));
         let mut ident = ident;
         if !ident.fully_qualified() {
-            ident = self.fetch_latest_pkg_ident_for(&ident, channel)?;
+            ident = match self.fetch_latest_pkg_ident_for(&ident, channel) {
+                Ok(ident) => ident,
+                Err(Error::DepotClient(APIError(StatusCode::NotFound, _))) => {
+                    match self.get_channel_recommendations(&ident) {
+                        Ok(channels) => {
+                            if !channels.is_empty() {
+                                try!(ui.warn(
+                                    "The package does not have any versions in the specified channel.",
+                                ));
+                                try!(ui.warn(
+                                    "Did you intend to install one of the folowing instead?",
+                                ));
+                                for c in channels {
+                                    try!(ui.warn(format!("  {} in channel {}", c.1, c.0)));
+                                }
+                            }
+                        }
+                        Err(_) => (),
+                    }
+                    return Err(Error::PackageNotFound);
+                }
+                Err(e) => {
+                    debug!("error fetching ident: {:?}", e);
+                    return Err(e);
+                }
+            }
         }
         if try!(self.is_package_installed(&ident)) {
             try!(ui.status(Status::Using, &ident));

--- a/components/common/src/error.rs
+++ b/components/common/src/error.rs
@@ -42,6 +42,7 @@ pub enum Error {
     StringFromUtf8Error(string::FromUtf8Error),
     TomlSerializeError(toml::ser::Error),
     WireDecode(String),
+    PackageNotFound,
 }
 
 impl fmt::Display for Error {
@@ -76,6 +77,7 @@ impl fmt::Display for Error {
             Error::StringFromUtf8Error(ref e) => format!("{}", e),
             Error::TomlSerializeError(ref e) => format!("Can't serialize TOML: {}", e),
             Error::WireDecode(ref m) => format!("Failed to decode wire message: {}", m),
+            Error::PackageNotFound => format!("Package not found"),
         };
         write!(f, "{}", msg)
     }
@@ -103,6 +105,7 @@ impl error::Error for Error {
             Error::StringFromUtf8Error(_) => "Failed to convert a string as UTF-8",
             Error::TomlSerializeError(_) => "Can't serialize TOML",
             Error::WireDecode(_) => "Failed to decode wire message",
+            Error::PackageNotFound => "Package not found",
         }
     }
 }

--- a/components/common/src/ui.rs
+++ b/components/common/src/ui.rs
@@ -45,6 +45,7 @@ pub enum Status {
     Uploading,
     Using,
     Verified,
+    Promoted,
     Custom(char, String),
 }
 
@@ -66,6 +67,7 @@ impl Status {
             Status::Uploading => ('↑', "Uploading".into(), Colour::Green),
             Status::Using => ('→', "Using".into(), Colour::Green),
             Status::Verified => ('✓', "Verified".into(), Colour::Green),
+            Status::Promoted => ('✓', "Promoted".into(), Colour::Green),
             Status::Custom(c, ref s) => (c, s.to_string(), Colour::Green),
         }
     }

--- a/components/core/src/channel.rs
+++ b/components/core/src/channel.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Chef Software Inc. and/or applicable contributors
+// Copyright (c) 2017 Chef Software Inc. and/or applicable contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,17 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod binlink;
-pub mod build;
-pub mod env;
-pub mod exec;
-pub mod export;
-pub mod hash;
-pub mod header;
-pub mod path;
-pub mod provides;
-pub mod search;
-pub mod sign;
-pub mod upload;
-pub mod verify;
-pub mod promote;
+use env;
+
+/// Default Depot Channel
+pub const DEFAULT_DEPOT_CHANNEL: &'static str = "stable";
+
+/// Default Depot Channel environment variable
+pub const DEPOT_CHANNEL_ENVVAR: &'static str = "HAB_DEPOT_CHANNEL";
+
+pub fn default_depot_channel() -> String {
+    match env::var(DEPOT_CHANNEL_ENVVAR) {
+        Ok(val) => val,
+        Err(_) => DEFAULT_DEPOT_CHANNEL.to_string(),
+    }
+}

--- a/components/core/src/lib.rs
+++ b/components/core/src/lib.rs
@@ -60,6 +60,7 @@ pub mod util;
 pub mod crypto;
 pub mod os;
 pub mod event;
+pub mod channel;
 
 pub use os::filesystem;
 pub use os::users;

--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -216,9 +216,21 @@ pub fn get() -> App<'static, 'static> {
                 (@arg DEPOT_URL: -u --url +takes_value {valid_url}
                     "Use a specific Depot URL (ex: http://depot.example.com/v1/depot)")
                 (@arg AUTH_TOKEN: -z --auth +takes_value "Authentication token for the Depot")
+                (@arg CHANNEL: --channel +takes_value
+                    "Upload to the specified release channel")
                 (@arg HART_FILE: +required +multiple {file_exists}
                     "One or more filepaths to a Habitat Artifact \
                     (ex: /home/acme-redis-3.0.7-21120102031201-x86_64-linux.hart)")
+            )
+            (@subcommand promote =>
+                (about: "Promote a package to a specified channel")
+                (aliases: &["pr", "pro"])
+                (@arg DEPOT_URL: -u --url +takes_value {valid_url}
+                    "Use a specific Depot URL (ex: http://depot.example.com/v1/depot)")
+                (@arg PKG_IDENT: +required +takes_value
+                    "A package identifier (ex: core/redis, core/busybox-static/1.42.2)")
+                (@arg CHANNEL: +required +takes_value
+                    "Promote to the specified release channel")
             )
             (@subcommand verify =>
                 (about: "Verifies a Habitat Artifact with an origin key")

--- a/components/hab/src/command/pkg/export.rs
+++ b/components/hab/src/command/pkg/export.rs
@@ -105,7 +105,7 @@ mod inner {
                 try!(install::start(
                     ui,
                     &default_depot_url(),
-                    None,
+                    None, // TODO: Support channels for export
                     &format_ident.to_string(),
                     PRODUCT,
                     VERSION,

--- a/components/hab/src/command/pkg/promote.rs
+++ b/components/hab/src/command/pkg/promote.rs
@@ -1,0 +1,78 @@
+// Copyright (c) 2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Promote a package to a specified channel.
+//!
+//! # Examples
+//!
+//! ```bash
+//! $ hab pkg promote acme/redis/2.0.7/2112010203120101 stable
+//! ```
+//!//! This will promote the acme package specified to the stable channel.
+//!
+//! Notes:
+//!    The package should already have been uploaded to the Depot.
+//!    If the specified channel does not exist, it will be created.
+//!
+
+
+use common::ui::{Status, UI};
+use depot_client::{self, Client};
+use hcore::package::PackageIdent;
+use hyper::status::StatusCode;
+
+use {PRODUCT, VERSION};
+use error::{Error, Result};
+
+
+/// Promote a package to the specified channel.
+///
+/// # Failures
+///
+/// * Fails if it cannot find the specified package in the Depot
+pub fn start(
+    ui: &mut UI,
+    url: &str,
+    ident: &PackageIdent,
+    channel: &str,
+    token: &str,
+) -> Result<()> {
+
+    let depot_client = try!(Client::new(url, PRODUCT, VERSION, None));
+
+    try!(ui.begin(format!("Promoting {} to {}", ident, channel)));
+
+    if channel != "stable" && channel != "unstable" {
+        match depot_client.create_channel(&ident.origin, channel, token) {
+            Ok(_) => (),
+            Err(depot_client::Error::APIError(StatusCode::Conflict, _)) => (),
+            Err(e) => {
+                println!("Failed to create '{}' channel: {:?}", channel, e);
+                return Err(Error::from(e));
+            }
+        };
+    }
+
+    match depot_client.promote_package(ident, channel, token) {
+        Ok(_) => (),
+        Err(e) => {
+            println!("Failed to promote '{}': {:?}", ident, e);
+            return Err(Error::from(e));
+        }
+    }
+
+    try!(ui.status(Status::Promoted, ident));
+
+    Ok(())
+}


### PR DESCRIPTION
This change adds more support to the hab cli for channels. It adds a HAB_DEPOT_CHANNEL environment variable that can be used to specify a default channel.  If the env variable is not specified, the default channel is 'stable'. This change also lets the 'hab pkg upload' command specify a channel to promote the package to after upload. It also adds a 'hab pkg promote' command to promote a package to another channel.

NOTE: A release of hab cli with this change should only happen subsequent to migrating Depot packages to stable.

Signed-off-by: Salim Alam <salam@chef.io>