### PR TITLE
Remove package-identifier assertion

### DIFF
--- a/components/builder-core/src/package_graph.rs
+++ b/components/builder-core/src/package_graph.rs
@@ -127,11 +127,6 @@ impl PackageGraph {
         }
 
         let (_, pkg_node) = *self.package_map.get(&pkg_short_name).unwrap();
-        let pkg_ident = PackageIdent::from_str(&name).unwrap();
-        match self.latest_map.get(&pkg_short_name) {
-            Some(latest) => assert!(pkg_ident >= *latest),
-            None => (),
-        }
 
         // Temporarily remove edges
         let mut saved_nodes = Vec::new();


### PR DESCRIPTION
This removes an assertion that identifiers of new packages should always be greater than the latest version in the graph. (Allows for previous package versions to be uploaded.)

Signed-off-by: Christian Nunciato <cnunciato@chef.io>

![](https://media.tenor.com/images/b4b15223411366a8dc50e7a58138d65e/tenor.gif)