### PR TITLE
[web ui] fix navmenu overlap with logo when signed out

### DIFF
--- a/www/source/stylesheets/_nav.scss
+++ b/www/source/stylesheets/_nav.scss
@@ -60,12 +60,12 @@ $main-nav-breakpoint: 769px;
     }
 
     .main-nav--logo {
-      @media (min-width: 973px) {
+      @media (min-width: 1150px) {
         width: rem-calc(240);
         height: rem-calc(108);
       }
 
-      @media (max-width: 1550px) and (min-width: 973px) {
+      @media (max-width: 1550px) and (min-width: 1150px) {
         position: absolute;
         left: rem-calc(180);
       }
@@ -362,7 +362,7 @@ $main-nav-breakpoint: 769px;
   position: absolute;
   left: 0;
 
-  @media (min-width: 973px) {
+  @media (min-width: 1150px) {
     .home & {
       display: block;
     }


### PR DESCRIPTION
Resize habitat logo and hide github logo at a wider size to fix nav menu overlap when the viewer is not logged in. The "Get Started" button disappears when a user is signed in and the signed-in avatar is much narrower than the "Sign In" link it replaces.

Fixes #2415 

There's probably some more work that could be done in organizing the links/buttons, but with these new widths at least the menu doesn't intrude upon the logo.

## Magical Gif Examples:

### Signed Out:

![hide things at new width - signed out](https://user-images.githubusercontent.com/517302/27459567-e50b4f9e-577c-11e7-808b-3d365beea393.gif)

### Signed In:

![hide things at new width - signed in](https://user-images.githubusercontent.com/517302/27459569-e97e0382-577c-11e7-8b30-924510428f60.gif)
