### PR TITLE
Add additional logging to LogForwarder and LogPipe.

### DIFF
--- a/components/builder-worker/src/runner/log_pipe.rs
+++ b/components/builder-worker/src/runner/log_pipe.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use bldr_core::logger::Logger;
+use error::{Error, Result};
 use hab_net::server::ZMQ_CONTEXT;
 use protobuf::Message;
 use protocol::jobsrv::{JobLogComplete, JobLogChunk};
@@ -32,6 +34,7 @@ const LOG_COMPLETE: &'static str = "C";
 pub struct LogPipe {
     job_id: u64,
     sock: zmq::Socket,
+    logger: Logger,
 }
 
 impl LogPipe {
@@ -41,9 +44,15 @@ impl LogPipe {
         sock.set_linger(5000).unwrap();
         sock.connect(INPROC_ADDR).unwrap();
 
+        let ident = format!("log_pipe-{}.log", workspace.job.get_id());
+
+        let mut logger = Logger::init(workspace.root(), &ident);
+        logger.log_ident(&ident);
+
         LogPipe {
             job_id: workspace.job.get_id(),
             sock: sock,
+            logger: logger,
         }
     }
 
@@ -52,26 +61,53 @@ impl LogPipe {
     ///
     /// Contents of STDOUT are streamed before any from STDERR (if
     /// any).
-    pub fn pipe(&mut self, process: &mut process::Child) {
+    pub fn pipe(&mut self, process: &mut process::Child) -> Result<()> {
         let mut line_count = 0;
 
+        self.logger.log("About to log stdout");
         if let Some(ref mut stdout) = process.stdout {
             let reader = BufReader::new(stdout);
-            line_count = self.stream_lines(reader, line_count);
+            line_count = self.stream_lines(reader, line_count)?;
         }
+        self.logger.log("Finished logging stdout");
+        self.logger.log("About to log stderr");
         if let Some(ref mut stderr) = process.stderr {
             let reader = BufReader::new(stderr);
             // not capturing line_count output because we don't use it
-            self.stream_lines(reader, line_count);
+            self.stream_lines(reader, line_count)?;
         }
-
+        self.logger.log("Finished logging stderr");
+        self.logger.log(
+            "About to tell log_forwarder that the job is complete",
+        );
         // Signal that the log is finished
         let mut complete = JobLogComplete::new();
         complete.set_job_id(self.job_id);
-        self.sock.send_str(LOG_COMPLETE, zmq::SNDMORE).unwrap();
-        self.sock
-            .send(complete.write_to_bytes().unwrap().as_slice(), 0)
-            .unwrap();
+        if let Err(e) = self.sock.send_str(LOG_COMPLETE, zmq::SNDMORE) {
+            self.logger.log(
+                format!("ZMQ error when sending LOG_COMPLETE: {:?}", &e).as_ref(),
+            );
+            return Err(Error::Zmq(e));
+        }
+        if let Err(e) = self.sock.send(
+            complete.write_to_bytes().unwrap().as_slice(),
+            0,
+        )
+        {
+            self.logger.log(
+                format!(
+                    "ZMQ error when sending JobLogComplete {:?} : {:?}",
+                    &complete,
+                    &e
+                ).as_ref(),
+            );
+            return Err(Error::Zmq(e));
+        }
+        self.logger.log(
+            "Finished telling log_forwarder that the job is complete",
+        );
+
+        Ok(())
     }
 
     /// Send the lines of the reader out over the ZMQ socket as
@@ -87,22 +123,39 @@ impl LogPipe {
     /// (I wrestled with the type system for an alternative
     /// implementation, but it defeated me :( This seems passable in
     /// the meantime.)
-    fn stream_lines<B: BufRead>(&mut self, reader: B, mut line_num: u64) -> u64 {
+    fn stream_lines<B: BufRead>(&mut self, reader: B, mut line_num: u64) -> Result<u64> {
         for line in reader.lines() {
             line_num = line_num + 1;
             let mut l: String = line.unwrap();
             l = l + EOL_MARKER;
+
+            self.logger.log(format!("Current line = {}", l).as_ref());
 
             let mut chunk = JobLogChunk::new();
             chunk.set_job_id(self.job_id);
             chunk.set_seq(line_num);
             chunk.set_content(l.clone());
 
-            self.sock.send_str(LOG_LINE, zmq::SNDMORE).unwrap();
-            self.sock
-                .send(chunk.write_to_bytes().unwrap().as_slice(), 0)
-                .unwrap();
+            if let Err(e) = self.sock.send_str(LOG_LINE, zmq::SNDMORE) {
+                self.logger.log(
+                    format!("ZMQ error when sending LOG_LINE: {:?}", &e).as_ref(),
+                );
+                return Err(Error::Zmq(e));
+            }
+            if let Err(e) = self.sock.send(
+                chunk.write_to_bytes().unwrap().as_slice(),
+                0,
+            )
+            {
+                self.logger.log(
+                    format!("ZMQ error when sending JobLogChunk {:?} : {:?}", &chunk, &e)
+                        .as_ref(),
+                );
+                return Err(Error::Zmq(e));
+            }
+            self.logger.log("Finished sending ^ to log_forwarder");
         }
-        line_num
+
+        Ok(line_num)
     }
 }

--- a/components/builder-worker/src/runner/mod.rs
+++ b/components/builder-worker/src/runner/mod.rs
@@ -300,7 +300,7 @@ impl Runner {
                     .expect("failed to spawn child")
             }
         };
-        self.log_pipe().pipe(&mut child);
+        self.log_pipe().pipe(&mut child)?;
         let exit_status = child.wait().expect("failed to wait on child");
         debug!("build complete, status={:?}", exit_status);
         if exit_status.success() {


### PR DESCRIPTION
Right now, there are intermittent problems where the worker will appear to hang
during a large build. The symptoms for this are a build log that freezes and
never progresses past a certain point. Current theories point to zeromq but
replicating the problem has proven difficult.

This change adds additional logging around what's being sent when and also
captures zeromq errors into the logs. Note that these logs are intentionally
left as files and are not sent to jobsrv. If it turns out that zeromq is indeed
part of the issue then our logging of the problem necessarily needs to not be
sent over zeromq.

![tenor-253983183](https://user-images.githubusercontent.com/947/27492473-2efdf4b6-57fb-11e7-96ae-804afc417009.gif)

Signed-off-by: Josh Black <raskchanky@gmail.com>