### PR TITLE
Start services using specified hab_svc_user on windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,6 +240,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypt32-sys"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ctrlc"
 version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -861,6 +870,7 @@ name = "habitat_core"
 version = "0.0.0"
 dependencies = [
  "base64 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crypt32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "errno 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "gcc 0.3.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat_win_users 0.0.0",
@@ -882,7 +892,9 @@ dependencies = [
  "time 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "userenv-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "users 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "widestring 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1019,9 +1031,11 @@ name = "habitat_sup"
 version = "0.0.0"
 dependencies = [
  "ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.23.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crypt32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ctrlc 3.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "features 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1053,12 +1067,14 @@ dependencies = [
  "time 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "habitat_win_users"
 version = "0.0.0"
 dependencies = [
+ "gcc 0.3.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "widestring 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2290,6 +2306,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "userenv-sys"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2447,6 +2472,7 @@ dependencies = [
 "checksum cmake 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)" = "d18d68987ed4c516dcc3e7913659bfa4076f5182eea4a7e0038bb060953e76ac"
 "checksum conduit-mime-types 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "95ca30253581af809925ef68c2641cc140d6183f43e12e0af4992d53768bd7b8"
 "checksum copperline 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3e80a6471b77449d3bd5c2192441ee3138184f69a2bba233c036ca21dcd626f3"
+"checksum crypt32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e34988f7e069e0b2f3bfc064295161e489b2d4e04a2e4248fb94360cdf00b4ec"
 "checksum ctrlc 3.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f26287fa3893461876a4851d1bee53b82f04954f85e2d7cd30ae053d0edefd72"
 "checksum curl-sys 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)" = "23e7e544dc5e1ba42c4a4a678bd47985e84b9c3f4d3404c29700622a029db9c3"
 "checksum digest 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7a68d759d7a66a4f63d5bd2a2b14ad7e8cf93fe8c9be227031cd4e72ab0e9ee8"
@@ -2623,6 +2649,7 @@ dependencies = [
 "checksum urlencoded 0.5.0 (git+https://github.com/iron/urlencoded)" = "<none>"
 "checksum urlencoded 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8c28708636d6f7298a53b1cdb6af40f1ab523209a7cb83cf4d41b3ebc671d319"
 "checksum user32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4ef4711d107b21b410a3a974b1204d9accc8b10dad75d8324b5d755de1617d47"
+"checksum userenv-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "71d28ea36bbd9192d75bd9fa9b39f96ddb986eaee824adae5d53b6e51919b2f3"
 "checksum users 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7ae8fdf783cb9652109c99886459648feb92ecc749e6b8e7930f6decba74c7c"
 "checksum utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a1ca13c08c41c9c3e04224ed9ff80461d97e121589ff27c753a16cb10830ae0f"
 "checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,6 +28,8 @@ environment:
     secure: il1kqjDtQSFOoD12nDaJhCBntC905Q8T9jRzyTZtqlJPxc3vCoS1bBeNbB55J82M
   ORIGIN_KEY:
     secure: T03FGJrevgQSlLfkc0mDaIkRyfu0/ci6+ryDnSqrezAmbtTayisHStac1yS4/96fMQmyfPYpGP5tMtvjuyw0cplUAUEtXarcK8CgatwnE+t7c9sjpBWgKfSE3wLOiDla
+  HAB_CRYPTO_KEY:
+    secure: ClumTYe8anMpdAb9ehrDURcO72ufvegDrweI7h+mBODkdlYkW6SzaCFbXbwUgbNCI4bDVQNw3N9/yhU3DUJ3vwmyLRHh/J5JR9aChxJJwYlwRSdVmdTA+G6EgRdEv259
 
   matrix:
     - hab_build_action: "test;build"

--- a/components/core/Cargo.toml
+++ b/components/core/Cargo.toml
@@ -6,6 +6,7 @@ workspace = "../../"
 build = "build.rs"
 
 [build-dependencies]
+base64 = "*"
 gcc = "0.3"
 
 [dependencies]
@@ -36,7 +37,10 @@ users = "*"
 path = "../win-users"
 
 [target.'cfg(windows)'.dependencies]
+crypt32-sys = "*"
 kernel32-sys = "*"
+userenv-sys = "*"
+widestring = "*"
 winapi = "*"
 
 [dev-dependencies]

--- a/components/core/build.rs
+++ b/components/core/build.rs
@@ -1,8 +1,22 @@
+extern crate base64;
 extern crate gcc;
+
+use std::env;
+use std::fs::File;
+use std::io::prelude::*;
+use std::path::Path;
 
 #[cfg(windows)]
 fn main() {
     gcc::compile_library("libadmincheck.a", &["./src/os/users/admincheck.c"]);
+    let mut file = File::create(Path::new(&env::var("OUT_DIR").unwrap()).join("hab-crypt"))
+        .unwrap();
+    match env::var("HAB_CRYPTO_KEY") {
+        Ok(key) => {
+            file.write_all(&base64::decode(&key).unwrap()).unwrap();
+        }
+        Err(_) => {}
+    }
 }
 
 #[cfg(not(windows))]

--- a/components/core/src/crypto/dpapi.rs
+++ b/components/core/src/crypto/dpapi.rs
@@ -1,0 +1,109 @@
+// Copyright (c) 2016-2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::io;
+use std::mem;
+use std::ptr;
+
+use base64;
+use crypt32;
+use winapi;
+
+use error::{Error, Result};
+
+const COMPLEXITY: &'static [u8] = include_bytes!(concat!(env!("OUT_DIR"), "/hab-crypt"));
+
+pub fn decrypt(secret: String) -> Result<String> {
+    unsafe {
+        let mut bytes = base64::decode(secret.as_str()).unwrap();
+        let mut in_blob = winapi::CRYPTOAPI_BLOB {
+            cbData: bytes.len() as winapi::DWORD,
+            pbData: bytes.as_mut_ptr(),
+        };
+        let mut out_blob = winapi::CRYPTOAPI_BLOB {
+            cbData: 0,
+            pbData: ptr::null_mut(),
+        };
+        let mut entropy = ptr::null_mut();
+        let mut blob: winapi::CRYPTOAPI_BLOB = mem::zeroed::<winapi::CRYPTOAPI_BLOB>();
+        let mut complexity_vec = COMPLEXITY.to_vec();
+        if complexity_vec.len() > 0 {
+            blob.cbData = complexity_vec.len() as winapi::DWORD;
+            blob.pbData = complexity_vec.as_mut_ptr();
+            entropy = &mut blob;
+        }
+        let ret = crypt32::CryptUnprotectData(
+            &mut in_blob,
+            ptr::null_mut(),
+            entropy,
+            ptr::null_mut(),
+            ptr::null_mut(),
+            0,
+            &mut out_blob,
+        );
+        if ret == 0 {
+            return Err(Error::CryptUnprotectDataFailed(format!(
+                "Failed to decrypt secret: {}",
+                io::Error::last_os_error()
+            )));
+        }
+        let sz = out_blob.cbData as usize;
+        let mut dst: Vec<u8> = Vec::with_capacity(sz);
+        dst.set_len(sz);
+        ptr::copy(out_blob.pbData, dst.as_mut_ptr(), sz);
+        Ok(String::from_utf8(dst)?)
+    }
+}
+
+pub fn encrypt(secret: String) -> Result<String> {
+    unsafe {
+        let mut secret_bytes = secret.into_bytes();
+        let mut in_blob = winapi::CRYPTOAPI_BLOB {
+            cbData: secret_bytes.len() as winapi::DWORD,
+            pbData: secret_bytes.as_mut_ptr(),
+        };
+        let mut out_blob = winapi::CRYPTOAPI_BLOB {
+            cbData: 0,
+            pbData: ptr::null_mut(),
+        };
+        let mut entropy = ptr::null_mut();
+        let mut blob: winapi::CRYPTOAPI_BLOB = mem::zeroed::<winapi::CRYPTOAPI_BLOB>();
+        let mut complexity_vec = COMPLEXITY.to_vec();
+        if complexity_vec.len() > 0 {
+            blob.cbData = complexity_vec.len() as winapi::DWORD;
+            blob.pbData = complexity_vec.as_mut_ptr();
+            entropy = &mut blob;
+        }
+        let ret = crypt32::CryptProtectData(
+            &mut in_blob,
+            ptr::null(),
+            entropy,
+            ptr::null_mut(),
+            ptr::null_mut(),
+            4, // CRYPTPROTECT_LOCAL_MACHINE
+            &mut out_blob,
+        );
+        if ret == 0 {
+            return Err(Error::CryptProtectDataFailed(format!(
+                "Failed to encrypt secret: {}",
+                io::Error::last_os_error()
+            )));
+        }
+        let sz = out_blob.cbData as usize;
+        let mut dst: Vec<u8> = Vec::with_capacity(sz);
+        dst.set_len(sz);
+        ptr::copy(out_blob.pbData, dst.as_mut_ptr(), sz);
+        Ok(base64::encode(&dst))
+    }
+}

--- a/components/core/src/crypto/mod.rs
+++ b/components/core/src/crypto/mod.rs
@@ -269,6 +269,8 @@ pub use self::keys::sym_key::SymKey;
 pub use self::keys::sig_key_pair::SigKeyPair;
 
 pub mod artifact;
+#[cfg(windows)]
+pub mod dpapi;
 pub mod hash;
 pub mod keys;
 

--- a/components/core/src/error.rs
+++ b/components/core/src/error.rs
@@ -77,6 +77,12 @@ pub enum Error {
     ConfigInvalidUsize(&'static str),
     /// Crypto library error
     CryptoError(String),
+    /// Occurs when a call to CreateProcessAsUserW fails
+    CreateProcessAsUserFailed(io::Error),
+    /// Occurs when a call to CryptProtectData fails
+    CryptProtectDataFailed(String),
+    /// Occurs when a call to CryptUnprotectData fails
+    CryptUnprotectDataFailed(String),
     /// Occurs when a file that should exist does not or could not be read.
     FileNotFound(String),
     /// Occurs when a package identifier string cannot be successfully parsed.
@@ -91,6 +97,10 @@ pub enum Error {
     InvalidServiceGroup(String),
     /// Occurs when making lower level IO calls.
     IO(io::Error),
+    // When LogonUserW does not have the correct logon type
+    LogonTypeNotGranted,
+    /// Occurs when a call to LogonUserW fails
+    LogonUserFailed(io::Error),
     /// Occurs when a BIND or BIND_OPTIONAL MetaFile is read and contains a bad entry.
     MetaFileBadBind,
     /// Occurs when a package metadata file cannot be opened, read, or parsed.
@@ -101,6 +111,8 @@ pub enum Error {
     MetaFileIO(io::Error),
     /// Occurs when we can't find an outbound IP address
     NoOutboundAddr,
+    /// Occurs when a call to OpenDesktopW fails
+    OpenDesktopFailed(String),
     /// Occurs when a suitable installed package cannot be found.
     PackageNotFound(package::PackageIdent),
     /// When an error occurs parsing an integer.
@@ -109,6 +121,8 @@ pub enum Error {
     PermissionFailed(String),
     /// Error parsing the contents of a plan file were incomplete or malformed.
     PlanMalformed,
+    // When CreateProcessAsUserW does not have the correct privileges
+    PrivilegeNotHeld,
     /// When an error occurs parsing or compiling a regular expression.
     RegexParse(regex::Error),
     /// When an error occurs converting a `String` from a UTF-8 byte vector.
@@ -242,7 +256,12 @@ impl fmt::Display for Error {
             Error::ConfigInvalidUsize(ref f) => {
                 format!("Invalid usize value in config, field={}", f)
             }
+            Error::CreateProcessAsUserFailed(ref e) => {
+                format!("Failure calling CreateProcessAsUserW: {:?}", e)
+            }
             Error::CryptoError(ref e) => format!("Crypto error: {}", e),
+            Error::CryptProtectDataFailed(ref e) => format!("{}", e),
+            Error::CryptUnprotectDataFailed(ref e) => format!("{}", e),
             Error::FileNotFound(ref e) => format!("File not found at: {}", e),
             Error::InvalidPackageIdent(ref e) => {
                 format!(
@@ -268,6 +287,13 @@ impl fmt::Display for Error {
                 )
             }
             Error::IO(ref err) => format!("{}", err),
+            Error::LogonTypeNotGranted => {
+                format!(
+                    "hab_svc_user user must possess the 'SE_SERVICE_LOGON_NAME' \
+                account right to be spawned as a service by the supervisor"
+                )
+            }
+            Error::LogonUserFailed(ref e) => format!("Failure calling LogonUserW: {:?}", e),
             Error::MetaFileBadBind => format!("Bad value parsed from BIND or BIND_OPTIONAL"),
             Error::MetaFileMalformed(ref e) => {
                 format!("MetaFile: {:?}, didn't contain a valid UTF-8 string", e)
@@ -275,6 +301,7 @@ impl fmt::Display for Error {
             Error::MetaFileNotFound(ref e) => format!("Couldn't read MetaFile: {}, not found", e),
             Error::MetaFileIO(ref e) => format!("IO error while accessing MetaFile: {:?}", e),
             Error::NoOutboundAddr => format!("Failed to discover this hosts outbound IP address"),
+            Error::OpenDesktopFailed(ref e) => format!("{}", e),
             Error::PackageNotFound(ref pkg) => {
                 if pkg.fully_qualified() {
                     format!("Cannot find package: {}", pkg)
@@ -285,6 +312,12 @@ impl fmt::Display for Error {
             Error::ParseIntError(ref e) => format!("{}", e),
             Error::PlanMalformed => format!("Failed to read or parse contents of Plan file"),
             Error::PermissionFailed(ref e) => format!("{}", e),
+            Error::PrivilegeNotHeld => {
+                format!(
+                    "Current user must possess the 'SE_INCREASE_QUOTA_NAME' \
+                and 'SE_ASSIGNPRIMARYTOKEN_NAME' privilege to spawn a new process as a different user"
+                )
+            }
             Error::RegexParse(ref e) => format!("{}", e),
             Error::StringFromUtf8Error(ref e) => format!("{}", e),
             Error::TargetMatchError(ref e) => format!("{}", e),
@@ -368,7 +401,10 @@ impl error::Error for Error {
             Error::ConfigInvalidUsize(_) => {
                 "Invalid usize value encountered while parsing a configuration file"
             }
+            Error::CreateProcessAsUserFailed(_) => "CreateProcessAsUserW failed",
             Error::CryptoError(_) => "Crypto error",
+            Error::CryptProtectDataFailed(_) => "CryptProtectData failed",
+            Error::CryptUnprotectDataFailed(_) => "CryptUnprotectData failed",
             Error::FileNotFound(_) => "File not found",
             Error::InvalidPackageIdent(_) => {
                 "Package identifiers must be in origin/name format (example: acme/redis)"
@@ -382,15 +418,21 @@ impl error::Error for Error {
                 "Service group strings must be in service.group format (example: redis.production)"
             }
             Error::IO(ref err) => err.description(),
+            Error::LogonTypeNotGranted => {
+                "Logon type not granted to hab_svc_user to be spawned by the supervisor"
+            }
+            Error::LogonUserFailed(_) => "LogonUserW failed",
             Error::MetaFileBadBind => "Bad value parsed from BIND or BIND_OPTIONAL MetaFile",
             Error::MetaFileMalformed(_) => "MetaFile didn't contain a valid UTF-8 string",
             Error::MetaFileNotFound(_) => "Failed to read an archive's metafile",
             Error::MetaFileIO(_) => "MetaFile could not be read or written to",
             Error::NoOutboundAddr => "Failed to discover the outbound IP address",
+            Error::OpenDesktopFailed(_) => "OpenDesktopW failed",
             Error::PackageNotFound(_) => "Cannot find a package",
             Error::ParseIntError(_) => "Failed to parse an integer from a string!",
             Error::PermissionFailed(_) => "Failed to set permissions",
             Error::PlanMalformed => "Failed to read or parse contents of Plan file",
+            Error::PrivilegeNotHeld => "Privilege not held to spawn process as different user",
             Error::RegexParse(_) => "Failed to parse a regular expression",
             Error::StringFromUtf8Error(_) => "Failed to convert a string from a Vec<u8> as UTF-8",
             Error::TargetMatchError(_) => "System target does not match package target",

--- a/components/core/src/lib.rs
+++ b/components/core/src/lib.rs
@@ -43,7 +43,13 @@ extern crate users as linux_users;
 #[cfg(windows)]
 extern crate habitat_win_users;
 #[cfg(windows)]
+extern crate crypt32;
+#[cfg(windows)]
 extern crate kernel32;
+#[cfg(windows)]
+extern crate userenv;
+#[cfg(windows)]
+extern crate widestring;
 #[cfg(windows)]
 extern crate winapi;
 

--- a/components/core/src/os/process/windows.rs
+++ b/components/core/src/os/process/windows.rs
@@ -341,6 +341,7 @@ impl ExitStatusExt for HabExitStatus {
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
+    use super::super::super::users::get_current_username;
     use super::super::*;
 
     #[test]
@@ -349,6 +350,8 @@ mod tests {
             "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
             vec!["-noprofile", "-command", "while($true) { Start-Sleep 1 }"],
             &HashMap::new(),
+            &get_current_username().unwrap(),
+            None,
         ).unwrap();
 
         let mut hab_child = HabChild::from(&mut child).unwrap();
@@ -362,6 +365,8 @@ mod tests {
             "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
             vec!["-noprofile", "-command", "$a='b'"],
             &HashMap::new(),
+            &get_current_username().unwrap(),
+            None,
         ).unwrap();
         let mut hab_child = HabChild::from(&mut child).unwrap();
 
@@ -376,6 +381,8 @@ mod tests {
             "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
             vec!["-noprofile", "-command", "while($true) { Start-Sleep 1 }"],
             &HashMap::new(),
+            &get_current_username().unwrap(),
+            None,
         ).unwrap();
 
         let mut hab_child = HabChild::from(&mut child).unwrap();
@@ -390,6 +397,8 @@ mod tests {
             "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
             vec!["-noprofile", "-command", "exit 5000"],
             &HashMap::new(),
+            &get_current_username().unwrap(),
+            None,
         ).unwrap();
 
         let mut hab_child = HabChild::from(&mut child).unwrap();

--- a/components/core/src/os/users/windows.rs
+++ b/components/core/src/os/users/windows.rs
@@ -23,7 +23,12 @@ extern "C" {
 
 fn get_sid_by_name(name: &str) -> Option<String> {
     match Account::from_name(name) {
-        Some(acct) => Some(acct.sid.to_string()),
+        Some(acct) => {
+            match acct.sid.to_string() {
+                Ok(username) => Some(username),
+                Err(_) => None,
+            }
+        }
         None => None,
     }
 }

--- a/components/sup/Cargo.toml
+++ b/components/sup/Cargo.toml
@@ -17,6 +17,7 @@ name = "functional"
 
 [dependencies]
 ansi_term = "*"
+base64 = "*"
 bitflags = "*"
 byteorder = "*"
 clap = { version = "*", features = [ "suggestions", "color", "unstable" ] }
@@ -52,6 +53,8 @@ url = "*"
 
 [target.'cfg(windows)'.dependencies]
 ctrlc = "*"
+crypt32-sys = "*"
+winapi = "*"
 
 [dev-dependencies]
 hyper = "*"

--- a/components/sup/src/manager/service/hooks.rs
+++ b/components/sup/src/manager/service/hooks.rs
@@ -112,8 +112,13 @@ pub trait Hook: fmt::Debug + Sized {
     }
 
     /// Run a compiled hook.
-    fn run(&self, service_group: &ServiceGroup, pkg: &Pkg) -> Self::ExitValue {
-        let mut child = match exec::run_cmd(self.path(), &pkg) {
+    fn run(
+        &self,
+        service_group: &ServiceGroup,
+        pkg: &Pkg,
+        svc_encrypted_password: Option<&str>,
+    ) -> Self::ExitValue {
+        let mut child = match exec::run_cmd(self.path(), &pkg, svc_encrypted_password) {
             Ok(child) => child,
             Err(err) => {
                 outputln!(preamble service_group,
@@ -342,10 +347,10 @@ impl Hook for RunHook {
         }
     }
 
-    fn run(&self, _: &ServiceGroup, _: &Pkg) -> Self::ExitValue {
+    fn run(&self, _: &ServiceGroup, _: &Pkg, _: Option<&str>) -> Self::ExitValue {
         panic!(
             "The run hook is a an exception to the lifetime of a service. It should only be \
-                run by the supervisor module!"
+             run by the supervisor module!"
         );
     }
 

--- a/components/sup/src/manager/service/spec.rs
+++ b/components/sup/src/manager/service/spec.rs
@@ -89,6 +89,7 @@ pub struct ServiceSpec {
     #[serde(deserialize_with = "deserialize_using_from_str",
             serialize_with = "serialize_using_to_string")]
     pub start_style: StartStyle,
+    pub svc_encrypted_password: Option<String>,
 }
 
 impl ServiceSpec {
@@ -218,6 +219,7 @@ impl Default for ServiceSpec {
             config_from: None,
             desired_state: DesiredState::default(),
             start_style: StartStyle::default(),
+            svc_encrypted_password: None,
         }
     }
 }
@@ -458,6 +460,7 @@ mod test {
             config_from: Some(PathBuf::from("/only/for/development")),
             desired_state: DesiredState::Down,
             start_style: StartStyle::Persistent,
+            svc_encrypted_password: None,
         };
         let toml = spec.to_toml_string().unwrap();
 
@@ -600,6 +603,7 @@ mod test {
             config_from: Some(PathBuf::from("/only/for/development")),
             desired_state: DesiredState::Down,
             start_style: StartStyle::Persistent,
+            svc_encrypted_password: None,
         };
         spec.to_file(&path).unwrap();
         let toml = string_from_file(path);

--- a/components/sup/src/manager/service/supervisor.rs
+++ b/components/sup/src/manager/service/supervisor.rs
@@ -106,7 +106,7 @@ impl Supervisor {
         (healthy, status)
     }
 
-    pub fn start(&mut self, pkg: &Pkg) -> Result<()> {
+    pub fn start(&mut self, pkg: &Pkg, svc_encrypted_password: Option<&str>) -> Result<()> {
         if self.child.is_some() {
             outputln!(preamble & self.preamble, "Already started");
             return Ok(());
@@ -121,7 +121,7 @@ impl Supervisor {
                   &pkg.svc_user,
                   &pkg.svc_group);
         self.enter_state(ProcessState::Start);
-        let mut child = exec::run_cmd(&pkg.svc_run, &pkg)?;
+        let mut child = exec::run_cmd(&pkg.svc_run, &pkg, svc_encrypted_password)?;
         self.child = Some(HabChild::from(&mut child)?);
         let c_stdout = child.stdout;
         let c_stderr = child.stderr;
@@ -164,10 +164,10 @@ impl Supervisor {
         Ok(())
     }
 
-    pub fn restart(&mut self, pkg: &Pkg) -> Result<()> {
+    pub fn restart(&mut self, pkg: &Pkg, svc_encrypted_password: Option<&str>) -> Result<()> {
         self.enter_state(ProcessState::Restart);
         try!(self.stop());
-        try!(self.start(pkg));
+        try!(self.start(pkg, svc_encrypted_password));
         Ok(())
     }
 

--- a/components/win-users/Cargo.toml
+++ b/components/win-users/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.0"
 authors = ["Matt Wrock <matt@mattwrock.com>"]
 description = "Habitat library for win32 account api calls"
 workspace = "../../"
+build = "build.rs"
+
+[build-dependencies]
+gcc = "0.3"
 
 [target.'cfg(windows)'.dependencies]
 kernel32-sys = "*"

--- a/components/win-users/build.rs
+++ b/components/win-users/build.rs
@@ -1,0 +1,5 @@
+extern crate gcc;
+
+fn main() {
+    gcc::compile_library("libsid.a", &["./src/obtain_sid.c"]);
+}

--- a/components/win-users/src/account.rs
+++ b/components/win-users/src/account.rs
@@ -153,13 +153,21 @@ mod tests {
     #[test]
     fn well_known_group_account_has_well_known_sid() {
         let sid = Account::from_name("Everyone").unwrap().sid;
-        assert_eq!(sid.to_string(), "S-1-1-0")
+        assert_eq!(sid.to_string().unwrap(), "S-1-1-0")
     }
 
     #[test]
     fn mixing_case_returns_same_account() {
-        let lower_sid = Account::from_name("administrator").unwrap().sid;
-        let upper_sid = Account::from_name("ADMINISTRATOR").unwrap().sid;
-        assert_eq!(lower_sid.to_string(), upper_sid.to_string())
+        let current_user = env::var("USERNAME").unwrap();
+        let lower_sid = Account::from_name(current_user.to_lowercase().as_str())
+            .unwrap()
+            .sid;
+        let upper_sid = Account::from_name(current_user.to_uppercase().as_str())
+            .unwrap()
+            .sid;
+        assert_eq!(
+            lower_sid.to_string().unwrap(),
+            upper_sid.to_string().unwrap()
+        )
     }
 }

--- a/components/win-users/src/obtain_sid.c
+++ b/components/win-users/src/obtain_sid.c
@@ -1,0 +1,108 @@
+// This function was copied from the snippet published on MSDH
+// at https://msdn.microsoft.com/en-us/library/windows/desktop/aa379608(v=vs.85).aspx
+#include <windows.h>
+
+BOOL ObtainSid(HANDLE hToken, PSID *psid)
+
+    {
+    BOOL                    bSuccess = FALSE; // assume function will
+                                                // fail
+    DWORD                   dwIndex;
+    DWORD                   dwLength = 0;
+    TOKEN_INFORMATION_CLASS tic      = TokenGroups;
+    PTOKEN_GROUPS           ptg      = NULL;
+
+    __try
+            {
+            // 
+            // determine the size of the buffer
+    // 
+            if (!GetTokenInformation(
+            hToken,
+            tic,
+            (LPVOID)ptg,
+            0,
+            &dwLength
+            ))
+                {
+                if (GetLastError() == ERROR_INSUFFICIENT_BUFFER)
+                    {
+                    ptg = (PTOKEN_GROUPS)HeapAlloc(
+                        GetProcessHeap(),
+                HEAP_ZERO_MEMORY,
+                dwLength
+                );
+                    if (ptg == NULL)
+                        __leave;
+                    }
+                else
+                    __leave;
+        }
+
+            // 
+            // obtain the groups the access token belongs to
+            // 
+            if (!GetTokenInformation(
+                hToken,
+            tic,
+            (LPVOID)ptg,
+            dwLength,
+            &dwLength
+            ))
+                __leave;
+
+            // 
+            // determine which group is the logon sid
+            // 
+            for (dwIndex = 0; dwIndex < ptg->GroupCount; dwIndex++)
+                {
+            if ((ptg->Groups[dwIndex].Attributes & SE_GROUP_LOGON_ID)
+                ==  SE_GROUP_LOGON_ID)
+                    {
+                    // 
+                    // determine the length of the sid
+                    // 
+                    dwLength = GetLengthSid(ptg->Groups[dwIndex].Sid);
+
+                    // 
+                    // allocate a buffer for the logon sid
+                    // 
+                    *psid = (PSID)HeapAlloc(
+                        GetProcessHeap(),
+                HEAP_ZERO_MEMORY,
+                dwLength
+                );
+                if (*psid == NULL)
+                    __leave;
+
+                // 
+                // obtain a copy of the logon sid
+                // 
+                if (!CopySid(dwLength, *psid, ptg->Groups[dwIndex].Sid))
+                    __leave;
+
+                // 
+                // break out of the loop because the logon sid has been
+                // found
+                // 
+                break;
+                }
+            }
+
+            // 
+            // indicate success
+            // 
+            bSuccess = TRUE;
+            }
+    __finally
+            {
+            // 
+    // free the buffer for the token group
+    // 
+            if (ptg != NULL)
+                HeapFree(GetProcessHeap(), 0, (LPVOID)ptg);
+            }
+
+    return bSuccess;
+
+}

--- a/components/win-users/src/sid.rs
+++ b/components/win-users/src/sid.rs
@@ -12,39 +12,325 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::ptr::null_mut;
-use std::io::Error;
+#![allow(non_snake_case)]
 
-use kernel32::LocalFree;
+use std::ptr::{copy, null_mut};
+use std::io;
+use std::mem;
+
+use kernel32::{self, LocalFree};
 use widestring::WideCString;
-use winapi::{HLOCAL, LPCWSTR, BOOL, PSID};
+use winapi;
+
+#[repr(C)]
+struct ACL_SIZE_INFORMATION {
+    aceCount: winapi::DWORD,
+    aclBytesInUse: winapi::DWORD,
+    aclBytesFree: winapi::DWORD,
+}
+
+#[repr(C)]
+struct ACE_HEADER {
+    aceType: winapi::BYTE,
+    aceFlags: winapi::BYTE,
+    aceSize: winapi::WORD,
+}
+type PaceHeader = *mut ACE_HEADER;
+
+#[repr(C)]
+struct ACCESS_ALLOWED_ACE {
+    header: ACE_HEADER,
+    mask: winapi::ACCESS_MASK,
+    sidStart: winapi::DWORD,
+}
 
 extern "system" {
-    fn ConvertSidToStringSidW(Sid: PSID, StringSid: LPCWSTR) -> BOOL;
+    fn ObtainSid(hToken: winapi::HANDLE, psid: *mut winapi::PSID) -> winapi::BOOL;
 }
+
+#[link(name = "user32")]
+extern "system" {
+    fn AddAccessAllowedAceEx(
+        pAcl: winapi::PACL,
+        dwAceRevision: winapi::DWORD,
+        aceFlags: winapi::DWORD,
+        accessMask: winapi::DWORD,
+        pSid: winapi::PSID,
+    ) -> winapi::BOOL;
+    fn AddAce(
+        pAcl: winapi::PACL,
+        dwAceRevision: winapi::DWORD,
+        dwStartingAceIndex: winapi::DWORD,
+        pAceList: winapi::LPVOID,
+        nAceListLength: winapi::DWORD,
+    ) -> winapi::BOOL;
+    fn ConvertSidToStringSidW(Sid: winapi::PSID, StringSid: winapi::LPCWSTR) -> winapi::BOOL;
+    fn GetAce(
+        pAcl: winapi::PACL,
+        dwAceIndex: winapi::DWORD,
+        pAce: *mut winapi::LPVOID,
+    ) -> winapi::BOOL;
+    fn GetAclInformation(
+        pAcl: winapi::PACL,
+        pAclInformation: winapi::LPVOID,
+        nAclInformationLength: winapi::DWORD,
+        dwAclInformationClass: winapi::DWORD,
+    ) -> winapi::BOOL;
+    fn OpenProcessToken(
+        processHandle: winapi::HANDLE,
+        desiredAccess: winapi::DWORD,
+        tokenHandle: winapi::PHANDLE,
+    ) -> winapi::BOOL;
+    fn GetLengthSid(pSid: winapi::PSID) -> winapi::DWORD;
+    fn GetSecurityDescriptorDacl(
+        pSecurityDescriptor: winapi::PSECURITY_DESCRIPTOR,
+        lpbDaclPresent: winapi::LPBOOL,
+        pDacl: *mut winapi::PACL,
+        lpbDaclDefaulted: winapi::LPBOOL,
+    ) -> winapi::BOOL;
+    fn GetUserObjectSecurity(
+        hObj: winapi::HANDLE,
+        pSIRequested: winapi::PSECURITY_INFORMATION,
+        pSD: winapi::PSECURITY_INFORMATION,
+        nLength: winapi::DWORD,
+        lpnLengthNeeded: winapi::LPDWORD,
+    ) -> winapi::BOOL;
+    fn InitializeAcl(
+        pAcl: winapi::PACL,
+        nAclLength: winapi::DWORD,
+        dwAclRevision: winapi::DWORD,
+    ) -> winapi::BOOL;
+    fn InitializeSecurityDescriptor(
+        pSecurityDescriptor: winapi::PSECURITY_DESCRIPTOR,
+        dwRevision: winapi::DWORD,
+    ) -> winapi::BOOL;
+    fn SetSecurityDescriptorDacl(
+        pSecurityDescriptor: winapi::PSECURITY_DESCRIPTOR,
+        bDaclPresent: winapi::BOOL,
+        pDacl: winapi::PACL,
+        bDaclDefaulted: winapi::BOOL,
+    ) -> winapi::BOOL;
+    fn SetUserObjectSecurity(
+        hObj: winapi::HANDLE,
+        pSIRequested: winapi::PSECURITY_INFORMATION,
+        pSID: winapi::PSECURITY_DESCRIPTOR,
+    ) -> winapi::BOOL;
+}
+
+pub const GENERIC_READ: winapi::DWORD = 0x80000000;
+pub const GENERIC_WRITE: winapi::DWORD = 0x40000000;
+pub const GENERIC_EXECUTE: winapi::DWORD = 0x20000000;
+pub const GENERIC_ALL: winapi::DWORD = 0x10000000;
+
+pub const WINSTA_ALL_ACCESS: winapi::DWORD = 0x37F;
+pub const DELETE: winapi::DWORD = 0x00010000;
+pub const READ_CONTROL: winapi::DWORD = 0x00020000;
+pub const WRITE_DAC: winapi::DWORD = 0x00040000;
+pub const WRITE_OWNER: winapi::DWORD = 0x00080000;
+
+pub const DESKTOP_CREATEMENU: winapi::DWORD = 0x0004;
+pub const DESKTOP_CREATEWINDOW: winapi::DWORD = 0x0002;
+pub const DESKTOP_ENUMERATE: winapi::DWORD = 0x0040;
+pub const DESKTOP_HOOKCONTROL: winapi::DWORD = 0x0008;
+pub const DESKTOP_JOURNALPLAYBACK: winapi::DWORD = 0x0020;
+pub const DESKTOP_JOURNALRECORD: winapi::DWORD = 0x0010;
+pub const DESKTOP_READOBJECTS: winapi::DWORD = 0x0001;
+pub const DESKTOP_SWITCHDESKTOP: winapi::DWORD = 0x0100;
+pub const DESKTOP_WRITEOBJECTS: winapi::DWORD = 0x0080;
+
+pub const OBJECECT_INHERIT_ACE: winapi::DWORD = 0x1;
+pub const CONTAINER_INHERIT_ACE: winapi::DWORD = 0x2;
+pub const NO_PROPAGATE_INHERIT_ACE: winapi::DWORD = 0x4;
+pub const INHERIT_ONLY_ACE: winapi::DWORD = 0x8;
 
 pub struct Sid {
     pub raw: Vec<u8>,
 }
 
 impl Sid {
-    pub fn to_string(&self) -> String {
-        let mut buffer: LPCWSTR = null_mut();
-        let ret = unsafe {
-            ConvertSidToStringSidW(
-                self.raw.as_ptr() as PSID,
-                (&mut buffer as *mut LPCWSTR) as LPCWSTR,
-            )
-        };
-        if ret == 0 {
-            panic!(
-                "Failed to convert sid to string: {}",
-                Error::last_os_error()
-            );
-        } else {
-            let widestr = unsafe { WideCString::from_ptr_str(buffer) };
-            unsafe { LocalFree(buffer as HLOCAL) };
-            widestr.to_string_lossy()
+    pub fn from_current_user() -> io::Result<Self> {
+        unsafe {
+            let handle = kernel32::GetCurrentProcess();
+            let mut token = null_mut();
+            cvt(OpenProcessToken(handle, winapi::TOKEN_READ, &mut token))?;
+            let sid = Self::from_token(token);
+            kernel32::CloseHandle(token);
+            kernel32::CloseHandle(handle);
+            Ok(sid?)
         }
+    }
+
+    pub fn from_token(token: winapi::HANDLE) -> io::Result<Self> {
+        unsafe {
+            let mut sid: winapi::PSID = null_mut();
+            cvt(ObtainSid(token, &mut sid))?;
+
+            let sz = GetLengthSid(sid) as usize;
+            let mut buf: Vec<u8> = Vec::with_capacity(sz);
+            copy(sid, buf.as_mut_ptr() as winapi::PSID, sz);
+            Ok(Self { raw: buf })
+        }
+    }
+
+    pub fn to_string(&self) -> io::Result<String> {
+        let mut buffer: winapi::LPCWSTR = null_mut();
+        unsafe {
+            cvt(ConvertSidToStringSidW(
+                self.raw.as_ptr() as winapi::PSID,
+                (&mut buffer as *mut winapi::LPCWSTR) as winapi::LPCWSTR,
+            ))?
+        };
+
+        let widestr = unsafe { WideCString::from_ptr_str(buffer) };
+        unsafe { LocalFree(buffer as winapi::HLOCAL) };
+        Ok(widestr.to_string_lossy())
+    }
+
+    // This code was adapted from much of the C++ code in
+    // https://msdn.microsoft.com/en-us/library/windows/desktop/aa379608(v=vs.85).aspx
+    pub fn add_to_user_object(
+        &self,
+        handle: winapi::HANDLE,
+        ace_flags: winapi::DWORD,
+        access_mask: winapi::DWORD,
+    ) -> io::Result<()> {
+        unsafe {
+            let mut needed_len: u32 = 0;
+            let mut sd: Vec<u8> = Vec::new();
+            let mut sd_new: Vec<u8> = Vec::new();
+            let mut dacl_present: winapi::BOOL = winapi::FALSE;
+            let mut dacl_exist: winapi::BOOL = winapi::FALSE;
+            let mut pacl: winapi::PACL = null_mut();
+
+            if GetUserObjectSecurity(
+                handle,
+                &mut winapi::DACL_SECURITY_INFORMATION,
+                null_mut(),
+                0,
+                &mut needed_len,
+            ) == 0
+            {
+                match io::Error::last_os_error().raw_os_error() {
+                    Some(error) => {
+                        match error as u32 {
+                            winapi::winerror::ERROR_INSUFFICIENT_BUFFER => {
+                                sd = Vec::with_capacity((needed_len) as usize);
+                                sd_new = Vec::with_capacity((needed_len) as usize);
+                            }
+                            _ => return Err(io::Error::last_os_error()),
+                        }
+                    }
+                    None => {}
+                }
+            }
+
+            cvt(GetUserObjectSecurity(
+                handle,
+                &mut winapi::DACL_SECURITY_INFORMATION,
+                sd.as_mut_ptr() as winapi::PSECURITY_INFORMATION,
+                needed_len,
+                &mut needed_len,
+            ))?;
+
+            cvt(InitializeSecurityDescriptor(
+                sd_new.as_mut_ptr() as winapi::PSECURITY_DESCRIPTOR,
+                1,
+            ))?; // SECURITY_DESCRIPTOR_REVISION
+
+            let pd: winapi::PSECURITY_DESCRIPTOR = sd.as_mut_ptr() as winapi::PSECURITY_DESCRIPTOR;
+            cvt(GetSecurityDescriptorDacl(
+                pd,
+                &mut dacl_present,
+                &mut pacl,
+                &mut dacl_exist,
+            ))?;
+
+            let mut size_info = ACL_SIZE_INFORMATION {
+                aceCount: 0,
+                aclBytesInUse: mem::size_of::<winapi::ACL>() as winapi::DWORD,
+                aclBytesFree: 0,
+            };
+            if pacl != null_mut() {
+                let mut acl_size_buf: Vec<u8> =
+                    Vec::with_capacity(mem::size_of::<ACL_SIZE_INFORMATION>());
+                cvt(GetAclInformation(
+                    pacl,
+                    acl_size_buf.as_mut_ptr() as winapi::LPVOID,
+                    mem::size_of::<ACL_SIZE_INFORMATION>() as winapi::DWORD,
+                    2, // AclSizeInformation
+                ))?;
+
+                let psize_info = &mut *(acl_size_buf.as_mut_ptr() as *mut ACL_SIZE_INFORMATION);
+                size_info.aceCount = (*psize_info).aceCount;
+                size_info.aclBytesInUse = (*psize_info).aclBytesInUse;
+                size_info.aclBytesFree = (*psize_info).aclBytesFree;
+            }
+
+            let psid_length = GetLengthSid(self.raw.as_ptr() as winapi::PSID);
+            let new_acl_size = size_info.aclBytesInUse +
+                (2 * (mem::size_of::<ACCESS_ALLOWED_ACE>() as winapi::DWORD)) +
+                (2 * psid_length) -
+                (2 * (mem::size_of::<winapi::DWORD>() as winapi::DWORD));
+            let mut new_acl_buf: Vec<u8> = Vec::with_capacity(new_acl_size as usize);
+            cvt(InitializeAcl(
+                new_acl_buf.as_mut_ptr() as winapi::PACL,
+                new_acl_size,
+                2, // ACL_REVISION
+            ))?;
+
+            if dacl_present == winapi::TRUE {
+                for i in 0..size_info.aceCount {
+                    let mut temp_acl: winapi::LPVOID = null_mut();
+                    cvt(GetAce(pacl, i, &mut temp_acl))?;
+                    cvt(AddAce(
+                        new_acl_buf.as_mut_ptr() as winapi::PACL,
+                        2, // ACL_REVISION
+                        winapi::MAXDWORD,
+                        temp_acl,
+                        (*(temp_acl as PaceHeader)).aceSize as winapi::DWORD,
+                    ))?;
+                }
+            }
+
+            cvt(AddAccessAllowedAceEx(
+                new_acl_buf.as_mut_ptr() as winapi::PACL,
+                2, // ACL_REVISION
+                ace_flags,
+                access_mask,
+                self.raw.as_ptr() as winapi::PSID,
+            ))?;
+
+            cvt(SetSecurityDescriptorDacl(
+                sd_new.as_mut_ptr() as winapi::PSECURITY_DESCRIPTOR,
+                winapi::TRUE,
+                new_acl_buf.as_mut_ptr() as winapi::PACL,
+                winapi::FALSE,
+            ))?;
+            cvt(SetUserObjectSecurity(
+                handle,
+                &mut winapi::DACL_SECURITY_INFORMATION,
+                sd_new.as_mut_ptr() as winapi::PSECURITY_DESCRIPTOR,
+            ))?;
+
+            Ok(())
+        }
+    }
+}
+
+fn cvt(i: i32) -> io::Result<i32> {
+    if i == 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(i)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn current_user_sid() {
+        assert!(Sid::from_current_user().is_ok())
     }
 }


### PR DESCRIPTION
Currently we do not honor `hab_svc_user` on windows. We start windows based services under the same account that the supervisor is running as. This PR launches services using the logon token of `hab_svc_user` if specified.

Because we need to generate a logon token for the user, we need the logon credentials of that user and also need to persist those credentials so that the supervisor can use them if it needs to restart the service or start a newly loaded service. We use DPAPI to encrypt the user password and store it in the service spec on disk. Both `hab sup start` and `hab sup load` will take a `--password` parameter and store it in the spec. The password can only be decrypted by the hab binary as long as it is compiled with an additional byte array that provides added entropy to the encryption. If no byte array is provided at compile time, the passwords could feasibly be decrypted as long as the decryption is attempted on the same machine where the password was encrypted. We are storing a production byte array in base64 format in our password vault and passing to the appveyor build via a secure environment variable.

In order to start services using another user's logon token, the account  running the supervisor must have the `SE_INCREASE_QUOTA_NAME` and `SE_ASSIGNPRIMARYTOKEN_NAME` privileges assigned. The supervisor will validate these privileges are assigned and will return an error stating which is missing when attempting to start services with lacking privileges.