### PR TITLE
make runtime_environment windows compatible

### DIFF
--- a/components/core/src/package/install.rs
+++ b/components/core/src/package/install.rs
@@ -501,8 +501,7 @@ impl PackageInstall {
         match self.read_metafile(file) {
             Ok(body) => {
                 if body.len() > 0 {
-                    let ids: Vec<String> = body.split("\n").map(|d| d.to_string()).collect();
-                    for id in &ids {
+                    for id in body.lines() {
                         let package = PackageIdent::from_str(id)?;
                         if !package.fully_qualified() {
                             return Err(Error::InvalidPackageIdent(package.to_string()));

--- a/components/core/src/package/metadata.rs
+++ b/components/core/src/package/metadata.rs
@@ -22,6 +22,12 @@ use std::vec::IntoIter;
 
 use error::{Error, Result};
 
+#[cfg(not(windows))]
+const ENV_PATH_SEPARATOR: char = ':';
+
+#[cfg(windows)]
+const ENV_PATH_SEPARATOR: char = ';';
+
 pub fn parse_key_value(s: &str) -> Result<HashMap<String, String>> {
     Ok(HashMap::from_iter(
         s.lines()
@@ -99,7 +105,7 @@ impl PkgEnv {
                     value: p.into_string().expect(
                         "Failed to convert path to utf8 string"
                     ),
-                    separator: Some(':'),
+                    separator: Some(ENV_PATH_SEPARATOR),
                 },
             ],
         }
@@ -265,7 +271,7 @@ port=front-end.port
             EnvVar {
                 key: "PATH".to_string(),
                 value: "/hab/pkgs/python/setuptools/35.0.1/20170424072606/bin".to_string(),
-                separator: Some(':'),
+                separator: Some(ENV_PATH_SEPARATOR),
             },
         ];
 


### PR DESCRIPTION
this fixes #2635 and ensures dep file lines are parsed correctly on windows allowing for `\r\n` endings and also that the `PATH` joins all dependent paths using a `;` separator.

Signed-off-by: Matt Wrock <matt@mattwrock.com>