### PR TITLE
Ensure that public and secret key exports always work

### DIFF
--- a/components/core/src/crypto/artifact.rs
+++ b/components/core/src/crypto/artifact.rs
@@ -314,7 +314,7 @@ mod test {
             SigKeyPair::get_secret_key_path(&pair.name_with_rev(), cache.path()).unwrap(),
         ).unwrap();
         // Now reload the key pair which will be missing the secret key
-        let pair = SigKeyPair::get_latest_pair_for("unicorn", cache.path()).unwrap();
+        let pair = SigKeyPair::get_latest_pair_for("unicorn", cache.path(), None).unwrap();
 
         sign(&fixture("signme.dat"), &dst, &pair).unwrap();
     }
@@ -332,7 +332,7 @@ mod test {
             SigKeyPair::get_public_key_path(&pair.name_with_rev(), cache.path()).unwrap(),
         ).unwrap();
         // Now reload the key pair which will be missing the public key
-        let _ = SigKeyPair::get_latest_pair_for("unicorn", cache.path()).unwrap();
+        let _ = SigKeyPair::get_latest_pair_for("unicorn", cache.path(), None).unwrap();
 
         verify(&dst, cache.path()).unwrap();
     }

--- a/components/core/src/crypto/keys/box_key_pair.rs
+++ b/components/core/src/crypto/keys/box_key_pair.rs
@@ -77,7 +77,11 @@ impl BoxKeyPair {
         T: AsRef<str>,
         P: AsRef<Path>,
     {
-        let revisions = try!(get_key_revisions(name.as_ref(), cache_key_path.as_ref()));
+        let revisions = try!(get_key_revisions(
+            name.as_ref(),
+            cache_key_path.as_ref(),
+            None,
+        ));
         let mut key_pairs = Vec::new();
         for name_with_rev in revisions {
             debug!(

--- a/components/core/src/crypto/keys/sym_key.rs
+++ b/components/core/src/crypto/keys/sym_key.rs
@@ -68,7 +68,7 @@ impl SymKey {
         name: &str,
         cache_key_path: &P,
     ) -> Result<Vec<Self>> {
-        let revisions = try!(get_key_revisions(name, cache_key_path.as_ref()));
+        let revisions = try!(get_key_revisions(name, cache_key_path.as_ref(), None));
         let mut key_pairs = Vec::new();
         for name_with_rev in &revisions {
             debug!(

--- a/components/hab/src/command/cli/setup.rs
+++ b/components/hab/src/command/cli/setup.rs
@@ -174,7 +174,7 @@ fn write_cli_config_auth_token(auth_token: &str) -> Result<()> {
 }
 
 fn is_origin_in_cache(origin: &str, cache_path: &Path) -> bool {
-    match SigKeyPair::get_latest_pair_for(origin, cache_path) {
+    match SigKeyPair::get_latest_pair_for(origin, cache_path, None) {
         Ok(pair) => {
             match pair.secret() {
                 Ok(_) => true,

--- a/components/hab/src/command/origin/key/export.rs
+++ b/components/hab/src/command/origin/key/export.rs
@@ -22,7 +22,11 @@ use hcore::crypto::keys::PairType;
 use error::Result;
 
 pub fn start(origin: &str, pair_type: PairType, cache: &Path) -> Result<()> {
-    let latest = try!(SigKeyPair::get_latest_pair_for(origin, cache));
+    let latest = try!(SigKeyPair::get_latest_pair_for(
+        origin,
+        cache,
+        Some(&pair_type),
+    ));
     let path = match pair_type {
         PairType::Public => {
             try!(SigKeyPair::get_public_key_path(

--- a/components/hab/src/command/origin/key/upload_latest.rs
+++ b/components/hab/src/command/origin/key/upload_latest.rs
@@ -36,7 +36,7 @@ pub fn start(
     try!(ui.begin(
         format!("Uploading latest public origin key {}", &origin),
     ));
-    let latest = try!(SigKeyPair::get_latest_pair_for(origin, cache));
+    let latest = try!(SigKeyPair::get_latest_pair_for(origin, cache, None));
     let public_keyfile = try!(SigKeyPair::get_public_key_path(
         &latest.name_with_rev(),
         cache,

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -281,6 +281,7 @@ fn sub_pkg_build(ui: &mut UI, m: &ArgMatches) -> Result<()> {
                 let pair = try!(SigKeyPair::get_latest_pair_for(
                     key,
                     &default_cache_key_path(Some(&*FS_ROOT)),
+                    None,
                 ));
                 let _ = pair.secret();
             }
@@ -411,6 +412,7 @@ fn sub_pkg_sign(ui: &mut UI, m: &ArgMatches) -> Result<()> {
     let pair = try!(SigKeyPair::get_latest_pair_for(
         &try!(origin_param_or_env(&m)),
         &default_cache_key_path(Some(&*FS_ROOT)),
+        None,
     ));
 
     command::pkg::sign::start(ui, &pair, &src, &dst)


### PR DESCRIPTION
Previously, all you could do was ask for a list of keys, without being able to filter private and public keys separately.  This is totally fine if you always have matched public/private keys in your cache directory.  It caused problems, though, if you happen to be missing part of a key pair.

This whole flow of logic now takes an extra optional parameter for the `PairType` that lets you be specific about the key type you want.  All of the existing code that doesn't deal with key exporting that calls these functions passes `None`, meaning the existing behavior remains the same.  Origin key exporting utilizes the new parameter to filter keys based on the type of key you're trying to export.

Fixes #2524 

![tenor-23759639](https://user-images.githubusercontent.com/947/27609704-9140746c-5b40-11e7-9571-e579355e071c.gif)

Signed-off-by: Josh Black <raskchanky@gmail.com>