### PR TITLE
Update channel parameters and command output

### DIFF
--- a/components/common/src/command/package/install.rs
+++ b/components/common/src/command/package/install.rs
@@ -155,7 +155,16 @@ impl<'a> InstallTask<'a> {
         ident: PackageIdent,
         channel: Option<&str>,
     ) -> Result<PackageIdent> {
-        try!(ui.begin(format!("Installing {}", &ident)));
+        if channel.is_some() {
+            try!(ui.begin(format!(
+                "Installing {} from channel '{}'",
+                &ident,
+                channel.unwrap()
+            )));
+        } else {
+            try!(ui.begin(format!("Installing {}", &ident)));
+        }
+
         let mut ident = ident;
         if !ident.fully_qualified() {
             ident = match self.fetch_latest_pkg_ident_for(&ident, channel) {
@@ -185,6 +194,7 @@ impl<'a> InstallTask<'a> {
                 }
             }
         }
+
         if try!(self.is_package_installed(&ident)) {
             try!(ui.status(Status::Using, &ident));
             try!(ui.end(format!(

--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -216,7 +216,7 @@ pub fn get() -> App<'static, 'static> {
                 (@arg DEPOT_URL: -u --url +takes_value {valid_url}
                     "Use a specific Depot URL (ex: http://depot.example.com/v1/depot)")
                 (@arg AUTH_TOKEN: -z --auth +takes_value "Authentication token for the Depot")
-                (@arg CHANNEL: --channel +takes_value
+                (@arg CHANNEL: --channel -c +takes_value
                     "Upload to the specified release channel")
                 (@arg HART_FILE: +required +multiple {file_exists}
                     "One or more filepaths to a Habitat Artifact \
@@ -493,7 +493,7 @@ fn sub_pkg_install() -> App<'static, 'static> {
         (about: "Installs a Habitat package from a Depot or locally from a Habitat Artifact")
         (@arg DEPOT_URL: --url -u +takes_value {valid_url}
             "Use a specific Depot URL [default: https://bldr.habitat.sh/v1/depot]")
-        (@arg CHANNEL: --channel +takes_value
+        (@arg CHANNEL: --channel -c +takes_value
             "Install from the specified release channel")
         (@arg PKG_IDENT_OR_ARTIFACT: +required +multiple
             "One or more Habitat package identifiers (ex: acme/redis) and/or filepaths \

--- a/components/hab/src/command/pkg/promote.rs
+++ b/components/hab/src/command/pkg/promote.rs
@@ -51,7 +51,9 @@ pub fn start(
 
     let depot_client = try!(Client::new(url, PRODUCT, VERSION, None));
 
-    try!(ui.begin(format!("Promoting {} to {}", ident, channel)));
+    try!(ui.begin(
+        format!("Promoting {} to channel '{}'", ident, channel),
+    ));
 
     if channel != "stable" && channel != "unstable" {
         match depot_client.create_channel(&ident.origin, channel, token) {

--- a/components/hab/src/command/pkg/upload.rs
+++ b/components/hab/src/command/pkg/upload.rs
@@ -213,6 +213,12 @@ fn upload_into_depot(
     // Promote to channel if specified
     if try_promote && channel.is_some() {
         let channel_str = channel.unwrap();
+        try!(ui.begin(format!(
+            "Promoting {} to channel '{}'",
+            ident,
+            channel_str
+        )));
+
         if channel_str != "stable" && channel_str != "unstable" {
             match depot_client.create_channel(&ident.origin, channel_str, token) {
                 Ok(_) => (),
@@ -220,6 +226,7 @@ fn upload_into_depot(
                 Err(e) => return Err(Error::from(e)),
             };
         }
+
         match depot_client.promote_package(ident, channel_str, token) {
             Ok(_) => (),
             Err(e) => return Err(Error::from(e)),


### PR DESCRIPTION
Minor update to tweak the hab cli output to be more explicit about the channel, and also add a '-c' param in addition to the '--channel' param to specify a channel.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-226721531](https://user-images.githubusercontent.com/13542112/27705998-b9bd4ff2-5cc4-11e7-826f-ad043e8cb5dc.gif)

