### PR TITLE
return an error if promoting a non fully qualified package

### DIFF
--- a/components/builder-depot-client/src/error.rs
+++ b/components/builder-depot-client/src/error.rs
@@ -35,6 +35,7 @@ pub enum Error {
     Json(serde_json::Error),
     NoFilePart,
     NoXFilename,
+    PromoteIdentNotFullyQualified,
     UploadFailed(String),
     UrlParseError(url::ParseError),
     WriteSyncFailed,
@@ -62,6 +63,12 @@ impl fmt::Display for Error {
             Error::NoXFilename => {
                 format!("Invalid download from a Depot - missing X-Filename header")
             }
+            Error::PromoteIdentNotFullyQualified => {
+                format!(
+                    "Cannot promote a package identifier that is not fully qualified; please \
+                        include the package version and release"
+                )
+            }
             Error::UploadFailed(ref s) => format!("Upload failed: {}", s),
             Error::UrlParseError(ref e) => format!("{}", e),
             Error::WriteSyncFailed => {
@@ -86,6 +93,9 @@ impl error::Error for Error {
                 "An invalid path was passed - we needed a filename, and this path does not have one"
             }
             Error::NoXFilename => "Invalid download from a Depot - missing X-Filename header",
+            Error::PromoteIdentNotFullyQualified => {
+                "Cannot promote a package identifier that is not fully qualified"
+            }
             Error::UploadFailed(_) => "Upload failed",
             Error::UrlParseError(ref err) => err.description(),
             Error::WriteSyncFailed => {

--- a/components/builder-depot-client/src/lib.rs
+++ b/components/builder-depot-client/src/lib.rs
@@ -530,6 +530,9 @@ impl Client {
     where
         I: Identifiable,
     {
+        if !ident.fully_qualified() {
+            return Err(Error::PromoteIdentNotFullyQualified);
+        }
         let path = channel_package_promote(channel, ident);
         debug!("Promoting package {}", ident);
 


### PR DESCRIPTION
Currently if a user attempts to promote a package that is not fully qualified, the cli panics because of the `unwrap` on version and release. This PR detects if the ident is not fully qualifies and informs the user that the ident must be fully qualified.

Signed-off-by: Matt Wrock <matt@mattwrock.com>