### PR TITLE
some minor deployment fixes

### DIFF
--- a/support/ci/appveyor.ps1
+++ b/support/ci/appveyor.ps1
@@ -108,7 +108,7 @@ if (($env:APPVEYOR_REPO_TAG_NAME -eq "$(Get-Content VERSION)") -or (Test-SourceC
                 & $habExe pkg install $hart.FullName
                 if ($LASTEXITCODE -ne 0) {exit $LASTEXITCODE}
 
-                if($env:HAB_AUTH_TOKEN -and (!Test-PullRequest)) {
+                if($env:HAB_AUTH_TOKEN -and (!(Test-PullRequest))) {
                     & $habExe pkg upload $hart
                     if ($LASTEXITCODE -ne 0) {exit $LASTEXITCODE}
                 }

--- a/support/ci/deploy.sh
+++ b/support/ci/deploy.sh
@@ -51,16 +51,16 @@ do
   HART=$(find ./results -name *${component}*.hart)
   ${TRAVIS_HAB} pkg install $HART
 
-  if [ -n "$HAB_AUTH_TOKEN" ]; then
-    ${TRAVIS_HAB} pkg upload $HART
-  fi
-
   # once we have built the stuio, switch over to bits built here
   if [[ "${component}" == "studio" ]]; then
     TRAVIS_HAB=$(find /hab/pkgs/core/hab -type f -name hab)
   elif [[ "${component}" == "hab" ]]; then
     RELEASE="${HART}_keep"
     cp $HART $RELEASE
+  fi
+
+  if [ -n "$HAB_AUTH_TOKEN" ]; then
+    ${TRAVIS_HAB} pkg upload $HART
   fi
 
   rm $HART


### PR DESCRIPTION
This ensures that we upload the studio with the new cli which will include a promote so that the uploaded studio will be found later in the build.

It also fixes an error in the appveyor build finding the functions that checks if we are on a PR.

Signed-off-by: Matt Wrock <matt@mattwrock.com>