### PR TITLE
Replace Google Custom Search with Swiftype

### DIFF
--- a/www/source/docs/search.html.slim
+++ b/www/source/docs/search.html.slim
@@ -4,15 +4,6 @@ title: Search Habitat Docs
 
 h1 Search the Habitat Documentation
 
-javascript:
-  (function() {
-    var cx = '011296053525108164109:o0ho6ygiuka';
-    var gcse = document.createElement('script');
-    gcse.type = 'text/javascript';
-    gcse.async = true;
-    gcse.src = 'https://cse.google.com/cse.js?cx=' + cx;
-    var s = document.getElementsByTagName('script')[0];
-    s.parentNode.insertBefore(gcse, s);
-  })();
+input.st-default-search-input
 
-<gcse:search webSearchResultSetSize="20"></gcse:search>
+.st-search-container

--- a/www/source/layouts/sidebar.slim
+++ b/www/source/layouts/sidebar.slim
@@ -4,7 +4,7 @@
       .main-sidebar
           - if sidebar_layout == 'docs'
             form.main-sidebar--search action="/docs/search/" method="get"
-              input type="text" placeholder="Search Documentation" name="q"
+              input.st-default-search-input type="text" placeholder="Search Documentation" name="q"
           ul.no-bullet
             - sidebar_data(sidebar_layout).each do |item|
               li.main-sidebar--heading
@@ -21,3 +21,13 @@
 
       .main-content__has-sidebar
           == yield
+
+  / Swiftype JS Snippet
+  - if sidebar_layout == 'docs'
+    javascript:
+      (function(w,d,t,u,n,s,e){w['SwiftypeObject']=n;w[n]=w[n]||function(){
+      (w[n].q=w[n].q||[]).push(arguments);};s=d.createElement(t);
+      e=d.getElementsByTagName(t)[0];s.async=1;s.src=u;e.parentNode.insertBefore(s,e);
+      })(window,document,'script','//s.swiftypecdn.com/install/v2/st.js','_st');
+
+      _st('install','8zxCLti7_7RsxUtSukaJ','2.0.0');

--- a/www/source/stylesheets/_layout.scss
+++ b/www/source/stylesheets/_layout.scss
@@ -90,11 +90,16 @@ body.body-article {
 
   [type='text'] {
     padding: rem-calc(10) rem-calc(20);
-    background-color: transparent;
+    background: transparent;
     border-color: $hab-green;
     color: $white;
     line-height: 1rem;
     height: auto;
+    // overrides for Swiftype
+    box-sizing: border-box;
+    font-size: 1rem;
+    width: 100%;
+    font-family: inherit;
   }
 }
 

--- a/www/source/stylesheets/_search.scss
+++ b/www/source/stylesheets/_search.scss
@@ -1,49 +1,24 @@
-// Overrides to make the Google Search results look better
-.gsc-table-result,
-.gsc-above-wrapper-area-container,
-.gsc-resultsHeader,
-.gsc-search-box,
-.gcsc-branding {
-  tbody {
-    background: transparent;
-    border: none;
-  }
+// Swiftype overrides
+input.st-ui-search-input,
+input.st-default-search-input {
+  width: 100%;
+  margin-bottom: 1rem;
+  box-sizing: border-box;
+  height: auto;
+  font-family: inherit;
+  font-size: 1rem;
+  background-position: 8px 12px;
 }
 
-.gsc-search-box {
-  td.gsc-input,
-  td.gsc-search-button,
-  td.gsc-clear-button {
-    padding: initial;
-  }
+.st-ui-injected-on-page-container {
+  font-family: inherit !important;
 
-  td.gsc-search-box {
-    padding-right: 12px;
-  }
-}
-
-input.gsc-input {
-  margin-bottom: 0;
-}
-
-.gsc-above-wrapper-area-container td {
-  padding: initial;
-}
-
-.gsc-resultsHeader {
-  display: none;
-}
-
-#___gcse_0 {
-  .gsc-control-cse {
-    padding: 0;
+  .st-ui-type-detail-bold {
+    font-size: 14px;
   }
 
-  .gsc-results .gsc-cursor-box .gsc-cursor-current-page {
-    color: $white;
-    border-color: $hab-green;
-    background: $hab-green;
-    text-shadow: none;
-    border-radius: 3px;
+  a.st-ui-result .st-ui-type-detail {
+    font-size: 14px;
+    max-height: 38px;
   }
 }


### PR DESCRIPTION
Since Google is EOL-ing Google Custom Search Engine, we are
replacing it with Swiftype. This adds the necessary JS snippets,
markup, and CSS overrides.

Signed-off-by: Maggie Walker <magwalk@gmail.com>


![screen shot 2017-07-05 at 3 25 25 pm](https://user-images.githubusercontent.com/7217000/27887609-81bd8816-6196-11e7-89a6-721bc4af7825.png)

