### PR TITLE
use a -w flag instead of env var to enter windows studio and fix uninitialized studio

### DIFF
--- a/components/hab/src/command/studio/mod.rs
+++ b/components/hab/src/command/studio/mod.rs
@@ -178,8 +178,7 @@ mod inner {
     const HAB_WINDOWS_STUDIO: &'static str = "HAB_WINDOWS_STUDIO";
 
     pub fn start(_ui: &mut UI, args: Vec<OsString>) -> Result<()> {
-        //TODO: Remove HAB_WINDOWS_STUDIO check after windows studio support is official
-        if cfg!(target_os = "windows") && henv::var(HAB_WINDOWS_STUDIO).is_ok() {
+        if is_windows_studio(&args) {
             start_windows_studio(_ui, args)
         } else {
             start_docker_studio(_ui, args)
@@ -378,6 +377,21 @@ mod inner {
     fn image_identifier() -> String {
         let version: Vec<&str> = VERSION.split("/").collect();
         henv::var(DOCKER_IMAGE_ENVVAR).unwrap_or(format!("{}:{}", DOCKER_IMAGE, version[0]))
+    }
+
+    fn is_windows_studio(args: &Vec<OsString>) -> bool {
+        if cfg!(not(target_os = "windows")) {
+            return false;
+        }
+
+        for arg in args.iter() {
+            let str_arg = arg.to_string_lossy().to_lowercase();
+            if str_arg == String::from("--windows") || str_arg == String::from("-w") {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     #[cfg(test)]

--- a/components/studio/bin/hab-studio.ps1
+++ b/components/studio/bin/hab-studio.ps1
@@ -65,6 +65,7 @@ COMMON FLAGS:
     -n  Do not mount the source path into the Studio (default: mount the path)
     -q  Prints less output for better use in scripts
     -v  Prints more verbose output
+    -w  Use a Windows studio instead of a docker studio (only available on windows)
 
 COMMON OPTIONS:
     -k <HAB_ORIGIN_KEYS>  Installs secret origin keys (default:\$HAB_ORIGIN )
@@ -268,6 +269,9 @@ function Enter-Studio {
   if($printHelp) {
     Write-EnterHelp
     return
+  }
+  if(!(Test-Path $HAB_STUDIO_ROOT)) {
+    mkdir $HAB_STUDIO_ROOT | Out-Null
   }
   $env:HAB_STUDIO_ENTER_ROOT = Resolve-Path $HAB_STUDIO_ROOT
   New-Studio

--- a/components/studio/bin/hab-studio.sh
+++ b/components/studio/bin/hab-studio.sh
@@ -65,6 +65,7 @@ COMMON FLAGS:
     -q  Prints less output for better use in scripts
     -v  Prints more verbose output
     -V  Prints version information
+    -w  Use a Windows studio instead of a docker studio (only available on windows)
 
 COMMON OPTIONS:
     -k <HAB_ORIGIN_KEYS>  Installs secret origin keys (default:\$HAB_ORIGIN )


### PR DESCRIPTION
Using a environment variable to enter a windows studio is a bad UX which has been fine so far but we need to make this visible to the cli now that we are publicizing windows functionality. This PR adds a `-w` flag that will enter a windows studio on windows.

This also fixes a bug when first entering a studio that was previously uninitialized.

Signed-off-by: Matt Wrock <matt@mattwrock.com>