### PR TITLE
fix the mac and windows build

### DIFF
--- a/components/hab/mac/mac-build.sh
+++ b/components/hab/mac/mac-build.sh
@@ -101,6 +101,8 @@ if ! command -v rustc >/dev/null; then
   curl -s https://static.rust-lang.org/rustup.sh | sh -s -- -y
   rustc --version
   cargo --version
+else
+  rustup update
 fi
 
 info "Updating PATH to include GNU toolchain from HomeBrew"

--- a/components/studio/bin/hab-studio.ps1
+++ b/components/studio/bin/hab-studio.ps1
@@ -37,6 +37,7 @@ param (
     [switch]$q,
     [switch]$v,
     [switch]$R,
+    [switch]$w,
     [string]$command,
     [string]$commandVal,
     [string]$k,

--- a/support/ci/appveyor.ps1
+++ b/support/ci/appveyor.ps1
@@ -99,7 +99,7 @@ if (($env:APPVEYOR_REPO_TAG_NAME -eq "$(Get-Content VERSION)") -or (Test-SourceC
             foreach ($component in ($env:hab_components -split ';')) {
                 Write-Host "Building plan for $component"
                 Write-Host ""
-                & $habExe pkg build components/$component
+                & $habExe studio build components/$component -w
                 if ($LASTEXITCODE -ne 0) {exit $LASTEXITCODE}
                 
                 $hart = Get-Item "C:\hab\studios\projects--habitat\src\components\$component\results\*.hart"

--- a/support/ci/deploy_mac.sh
+++ b/support/ci/deploy_mac.sh
@@ -30,7 +30,7 @@ mac_dir="${hab_src_dir}/components/hab/mac"
 mac_hab="${bootstrap_dir}/hab"
 gnu_tar=/usr/local/bin/tar
 hab_download_url="https://api.bintray.com/content/habitat/stable/darwin/x86_64/hab-%24latest-x86_64-darwin.zip?bt_package=hab-x86_64-darwin"
-our_path="${HOME}/.cargo/bin:${PATH}"
+our_path="${HOME}/.cargo/bin:/usr/local/bin:${PATH}"
 export HAB_ORIGIN=core
 export PATH="${our_path}"
 


### PR DESCRIPTION
This fixes the following:

* Fix the travis build number variable passed to the mac builder causing us to target an old dev build
* Update rust - it was using 0.16.0 which was raising compile errors on the latest code
* Add /usr/local/bin to path which without was breaking all sorts of things
* use `hab studio build` instead of the broken `hab pkg build` on windows. Will be fixing `hab pkg build` later.

Signed-off-by: Matt Wrock <matt@mattwrock.com>