### PR TITLE
First attempt at synchronous sup start/stop

### DIFF
--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -348,12 +348,17 @@ pub fn get() -> App<'static, 'static> {
                 (about: "Stop a running Habitat service.")
                 (@setting Hidden)
             )
+            (@subcommand exec =>
+                (about: "Synchronously load a service, start it, display logs and unload it.")
+                (@setting Hidden)
+            )
             (after_help: "\nALIASES:\
                 \n    load       Alias for: 'sup load'\
                 \n    unload     Alias for: 'sup unload'\
                 \n    start      Alias for: 'sup start'\
                 \n    stop       Alias for: 'sup stop'\
                 \n    status     Alias for: 'sup status'\
+                \n    exec       Alias for: 'sup exec'\
                 \n"
             )
         )

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -568,6 +568,7 @@ fn exec_subcommand_if_called(ui: &mut UI) -> Result<()> {
         ("svc", "unload") |
         ("svc", "start") |
         ("svc", "status") |
+        ("svc", "exec") |
         ("svc", "stop") => command::sup::start(ui, env::args_os().skip(2).collect()),
         ("term", _) => command::sup::start(ui, env::args_os().skip(1).collect()),
         _ => Ok(()),

--- a/components/sup/src/error.rs
+++ b/components/sup/src/error.rs
@@ -103,6 +103,7 @@ impl SupError {
 /// All the kinds of errors we produce.
 #[derive(Debug)]
 pub enum Error {
+    AlreadyRunning(String),
     BadDataFile(PathBuf, io::Error),
     BadDataPath(PathBuf, io::Error),
     BadDesiredState(String),
@@ -163,6 +164,12 @@ impl fmt::Display for SupError {
     // verbose on, and print it.
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let content = match self.err {
+            Error::AlreadyRunning(ref pkg) => {
+                format!(
+                    "Service {} is already running",
+                    pkg
+                )
+            }
             Error::BadDataFile(ref path, ref err) => {
                 format!(
                     "Unable to read or write to data file, {}, {}",
@@ -313,6 +320,7 @@ impl fmt::Display for SupError {
 impl error::Error for SupError {
     fn description(&self) -> &str {
         match self.err {
+            Error::AlreadyRunning(_) => "Service is already running",
             Error::BadDataFile(_, _) => "Unable to read or write to a data file",
             Error::BadDataPath(_, _) => "Unable to read or write to data directory",
             Error::BadElectionStatus(_) => "Unknown election status",


### PR DESCRIPTION
This is my first PR for habitat, so please excuse me if I did something lame (not counting the commit message, it obviously will need to be rewritten).

This adds an exec command to sup instead of adding the synchronous flags to sup's start/stop commands. Exec basically loads the service, starts the supervisor, prints all the logging and unloads the service.

There's a catch though - I haven't been able to test it yet as I have problems with running `hab studio enter` using the `hab` binary in the `target/debug` directory, because I'm getting the following:
```
/home/kv/projects/chef/habitat/components/studio/bin/hab-studio.sh: line 1097: /home/kv/projects/chef/habitat/components/studio/libexec/busybox: No such file or directory
```

So I need to figure out the clean way to test it, first. But in the meantime - is it the way to go to address #2680?