### PR TITLE
Default to unstable channel on package upload

### DIFF
--- a/components/core/build.rs
+++ b/components/core/build.rs
@@ -1,13 +1,13 @@
-extern crate base64;
-extern crate gcc;
-
-use std::env;
-use std::fs::File;
-use std::io::prelude::*;
-use std::path::Path;
-
 #[cfg(windows)]
 fn main() {
+    extern crate base64;
+    extern crate gcc;
+
+    use std::env;
+    use std::fs::File;
+    use std::io::prelude::*;
+    use std::path::Path;
+
     gcc::compile_library("libadmincheck.a", &["./src/os/users/admincheck.c"]);
     let mut file = File::create(Path::new(&env::var("OUT_DIR").unwrap()).join("hab-crypt"))
         .unwrap();

--- a/components/core/src/channel.rs
+++ b/components/core/src/channel.rs
@@ -12,17 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use env;
-
-/// Default Depot Channel
-pub const DEFAULT_DEPOT_CHANNEL: &'static str = "stable";
+pub const UNSTABLE_CHANNEL: &'static str = "unstable";
+pub const STABLE_CHANNEL: &'static str = "stable";
 
 /// Default Depot Channel environment variable
 pub const DEPOT_CHANNEL_ENVVAR: &'static str = "HAB_DEPOT_CHANNEL";
-
-pub fn default_depot_channel() -> String {
-    match env::var(DEPOT_CHANNEL_ENVVAR) {
-        Ok(val) => val,
-        Err(_) => DEFAULT_DEPOT_CHANNEL.to_string(),
-    }
-}

--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -217,7 +217,7 @@ pub fn get() -> App<'static, 'static> {
                     "Use a specific Depot URL (ex: http://depot.example.com/v1/depot)")
                 (@arg AUTH_TOKEN: -z --auth +takes_value "Authentication token for the Depot")
                 (@arg CHANNEL: --channel -c +takes_value
-                    "Upload to the specified release channel")
+                    "Upload to the specified release channel (default: unstable)")
                 (@arg HART_FILE: +required +multiple {file_exists}
                     "One or more filepaths to a Habitat Artifact \
                     (ex: /home/acme-redis-3.0.7-21120102031201-x86_64-linux.hart)")
@@ -504,9 +504,9 @@ fn sub_pkg_install() -> App<'static, 'static> {
     let sub = clap_app!(@subcommand install =>
         (about: "Installs a Habitat package from a Depot or locally from a Habitat Artifact")
         (@arg DEPOT_URL: --url -u +takes_value {valid_url}
-            "Use a specific Depot URL [default: https://bldr.habitat.sh/v1/depot]")
+            "Use a specific Depot URL (default: https://bldr.habitat.sh/v1/depot)")
         (@arg CHANNEL: --channel -c +takes_value
-            "Install from the specified release channel")
+            "Install from the specified release channel (default: stable)")
         (@arg PKG_IDENT_OR_ARTIFACT: +required +multiple
             "One or more Habitat package identifiers (ex: acme/redis) and/or filepaths \
             to a Habitat Artifact (ex: /home/acme-redis-3.0.7-21120102031201-x86_64-linux.hart)")

--- a/components/hab/src/command/pkg/upload.rs
+++ b/components/hab/src/command/pkg/upload.rs
@@ -52,26 +52,27 @@ use retry::retry;
 /// * Fails if it cannot find a package
 /// * Fails if the package doesn't have a `.hart` file in the cache
 /// * Fails if it cannot upload the file
-pub fn start<P: AsRef<Path>>(
+pub fn start<T, U>(
     ui: &mut UI,
     url: &str,
     channel: Option<&str>,
     token: &str,
-    archive_path: &P,
-    key_path: &P,
-) -> Result<()> {
+    archive_path: T,
+    key_path: U,
+) -> Result<()>
+where
+    T: AsRef<Path>,
+    U: AsRef<Path>,
+{
     let mut archive = PackageArchive::new(PathBuf::from(archive_path.as_ref()));
-
-    let hart_header = try!(get_artifact_header(&archive_path.as_ref()));
-
-    let key_buf = key_path.as_ref().to_path_buf();
+    let hart_header = get_artifact_header(&archive_path.as_ref())?;
     let public_keyfile_name = format!("{}.pub", &hart_header.key_name);
-    let public_keyfile = key_buf.join(&public_keyfile_name);
+    let public_keyfile = key_path.as_ref().join(&public_keyfile_name);
 
-    try!(ui.status(
+    ui.status(
         Status::Signed,
         format!("artifact with {}", &public_keyfile_name),
-    ));
+    )?;
 
     let (name, rev) = try!(parse_name_with_rev(&hart_header.key_name));
     let depot_client = try!(Client::new(url, PRODUCT, VERSION, None));


### PR DESCRIPTION
Packages should be uploaded to the unstable channel by default and not
the stable channel. The stable channel can be specified as the destination
*as well as unstable* by passing `--channel stable` to the command

![tenor-214863295](https://user-images.githubusercontent.com/54036/27973866-6a6bbd6a-6310-11e7-8957-7ecc7799e1c6.gif)

There's a little bit of cleanup in here as well