### PR TITLE
fixes #2701 making hab pkg build -w work on windows

### DIFF
--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -495,6 +495,15 @@ fn sub_pkg_build() -> App<'static, 'static> {
                 .short("R")
                 .long("reuse"),
         )
+    } else if cfg!(target_os = "windows") {
+        sub.arg(
+            Arg::with_name("WINDOWS")
+                .help(
+                    "Use a Windows studio instead of a docker studio",
+                )
+                .short("w")
+                .long("windows"),
+        )
     } else {
         sub
     }

--- a/components/hab/src/command/pkg/build.rs
+++ b/components/hab/src/command/pkg/build.rs
@@ -26,6 +26,7 @@ pub fn start(
     src: Option<&str>,
     keys: Option<&str>,
     reuse: bool,
+    windows: bool,
 ) -> Result<()> {
     let mut args: Vec<OsString> = Vec::new();
     if let Some(root) = root {
@@ -45,5 +46,8 @@ pub fn start(
         args.push("-R".into());
     }
     args.push(plan_context.into());
+    if cfg!(target_os = "windows") && windows {
+        args.push("-w".into());
+    }
     studio::start(ui, args)
 }

--- a/components/hab/src/command/studio/mod.rs
+++ b/components/hab/src/command/studio/mod.rs
@@ -175,8 +175,6 @@ mod inner {
     const DOCKER_IMAGE_ENVVAR: &'static str = "HAB_DOCKER_STUDIO_IMAGE";
     const DOCKER_OPTS: &'static str = "HAB_DOCKER_OPTS";
 
-    const HAB_WINDOWS_STUDIO: &'static str = "HAB_WINDOWS_STUDIO";
-
     pub fn start(_ui: &mut UI, args: Vec<OsString>) -> Result<()> {
         if is_windows_studio(&args) {
             start_windows_studio(_ui, args)

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -297,8 +297,9 @@ fn sub_pkg_build(ui: &mut UI, m: &ArgMatches) -> Result<()> {
         None => None,
     };
     let reuse = m.is_present("REUSE");
+    let windows = m.is_present("WINDOWS");
 
-    command::pkg::build::start(ui, plan_context, root, src, keys, reuse)
+    command::pkg::build::start(ui, plan_context, root, src, keys, reuse, windows)
 }
 
 fn sub_pkg_config(m: &ArgMatches) -> Result<()> {


### PR DESCRIPTION
This passes `-w` from `hab pkg build` to the studio call

Signed-off-by: Matt Wrock <matt@mattwrock.com>