### PR TITLE
Add `origin key list` subcommand to cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -723,6 +723,7 @@ dependencies = [
  "clap 2.25.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy 0.0.144 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat_api_client 0.0.0",
  "habitat_common 0.0.0",
  "habitat_core 0.0.0",

--- a/components/hab/Cargo.toml
+++ b/components/hab/Cargo.toml
@@ -14,6 +14,7 @@ clippy = {version = "*", optional = true}
 base64 = "*"
 ansi_term = "*"
 env_logger = "*"
+glob = "*"
 hyper = "*"
 handlebars = { version = "*", features = ["partial4"], default-features = false }
 lazy_static = "*"

--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -160,6 +160,10 @@ pub fn get() -> App<'static, 'static> {
                         contents and writes the key to disk")
                     (aliases: &["i", "im", "imp", "impo", "impor"])
                 )
+                (@subcommand list =>
+                    (about: "Lists origin keys")
+                    (aliases: &["l", "li", "lis"])
+                )
                 (@subcommand upload =>
                     (@group upload =>
                         (@attributes +required)

--- a/components/hab/src/command/origin/key/list.rs
+++ b/components/hab/src/command/origin/key/list.rs
@@ -1,0 +1,42 @@
+// Copyright (c) 2016-2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use glob::glob;
+use std::path::Path;
+use common::ui::UI;
+
+use error::Result;
+
+pub fn start(ui: &mut UI, cache: &Path) -> Result<()> {
+    ui.heading("Local origin keys:")?;
+    let path = cache.join("*.pub");
+
+    match path.to_str() {
+        Some(pattern) => {
+            glob(&pattern)?
+                .filter_map(|key| key.ok())
+                .filter(|key| key.is_file())
+                // It is safe to use `unwrap()` here because the only case in which `file_name()`
+                // returns `None` is if the path is a directory, but we filter out directories in the
+                // line above.
+                .map(|key| key.file_name().unwrap().to_os_string())
+                // We need this conversion because `OsString` does not implement `Display`.
+                .filter_map(|key| key.into_string().ok())
+                .for_each(|key| println!("» {}", key))
+        }
+        None => debug!("Failed to parse path: {:?}", path),
+    }
+
+    Ok(())
+}

--- a/components/hab/src/command/origin/key/mod.rs
+++ b/components/hab/src/command/origin/key/mod.rs
@@ -16,6 +16,7 @@ pub mod download;
 pub mod export;
 pub mod generate;
 pub mod import;
+pub mod list;
 pub mod upload_latest;
 pub mod upload;
 

--- a/components/hab/src/error.rs
+++ b/components/hab/src/error.rs
@@ -26,6 +26,7 @@ use depot_client;
 use common;
 use hcore;
 use handlebars;
+use glob;
 use toml;
 
 pub type Result<T> = result::Result<T, Error>;
@@ -48,6 +49,7 @@ pub enum Error {
     ExecCommandNotFound(PathBuf),
     FFINulError(ffi::NulError),
     FileNotFound(String),
+    GlobError(glob::GlobError),
     HabitatCommon(common::Error),
     HabitatCore(hcore::Error),
     HandlebarsRenderError(handlebars::TemplateRenderError),
@@ -58,6 +60,7 @@ pub enum Error {
     PackageArchiveMalformed(String),
     ParseIntError(num::ParseIntError),
     PathPrefixError(path::StripPrefixError),
+    PatternError(glob::PatternError),
     ProvidesError(String),
     RootRequired,
     SubcommandNotSupported(String),
@@ -129,6 +132,7 @@ impl fmt::Display for Error {
             }
             Error::FFINulError(ref e) => format!("{}", e),
             Error::FileNotFound(ref e) => format!("File not found at: {}", e),
+            Error::GlobError(ref e) => format!("{}", e),
             Error::HabitatCommon(ref e) => format!("{}", e),
             Error::HabitatCore(ref e) => format!("{}", e),
             Error::HandlebarsRenderError(ref e) => format!("{}", e),
@@ -146,6 +150,7 @@ impl fmt::Display for Error {
             }
             Error::ParseIntError(ref err) => format!("{}", err),
             Error::PathPrefixError(ref err) => format!("{}", err),
+            Error::PatternError(ref err) => format!("{}", err),
             Error::ProvidesError(ref err) => format!("Can't find {}", err),
             Error::RootRequired => {
                 "Root or administrator permissions required to complete operation".to_string()
@@ -184,6 +189,7 @@ impl error::Error for Error {
             Error::ExecCommandNotFound(_) => "Exec command was not found on filesystem or in PATH",
             Error::FFINulError(ref err) => err.description(),
             Error::FileNotFound(_) => "File not found",
+            Error::GlobError(ref err) => err.description(),
             Error::HabitatCommon(ref err) => err.description(),
             Error::HabitatCore(ref err) => err.description(),
             Error::HandlebarsRenderError(ref err) => err.description(),
@@ -198,6 +204,7 @@ impl error::Error for Error {
             }
             Error::ParseIntError(ref err) => err.description(),
             Error::PathPrefixError(ref err) => err.description(),
+            Error::PatternError(ref err) => err.description(),
             Error::ProvidesError(_) => {
                 "Can't find a package that provides the given search parameter"
             }
@@ -247,6 +254,18 @@ impl From<handlebars::TemplateRenderError> for Error {
 impl From<io::Error> for Error {
     fn from(err: io::Error) -> Error {
         Error::IO(err)
+    }
+}
+
+impl From<glob::GlobError> for Error {
+    fn from(err: glob::GlobError) -> Error {
+        Error::GlobError(err)
+    }
+}
+
+impl From<glob::PatternError> for Error {
+    fn from(err: glob::PatternError) -> Error {
+        Error::PatternError(err)
     }
 }
 

--- a/components/hab/src/lib.rs
+++ b/components/hab/src/lib.rs
@@ -26,6 +26,7 @@ extern crate handlebars;
 extern crate ansi_term;
 #[macro_use]
 extern crate clap;
+extern crate glob;
 extern crate hyper;
 #[macro_use]
 extern crate log;

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -122,6 +122,7 @@ fn start(ui: &mut UI) -> Result<()> {
                         ("export", Some(sc)) => sub_origin_key_export(sc)?,
                         ("generate", Some(sc)) => sub_origin_key_generate(ui, sc)?,
                         ("import", Some(_)) => sub_origin_key_import(ui)?,
+                        ("list", Some(_)) => sub_origin_key_list(ui)?,
                         ("upload", Some(sc)) => sub_origin_key_upload(ui, sc)?,
                         _ => unreachable!(),
                     }
@@ -271,6 +272,10 @@ fn sub_origin_key_import(ui: &mut UI) -> Result<()> {
     init();
 
     command::origin::key::import::start(ui, &content, &default_cache_key_path(Some(&*FS_ROOT)))
+}
+
+fn sub_origin_key_list(ui: &mut UI) -> Result<()> {
+    command::origin::key::list::start(ui, &default_cache_key_path(Some(&*FS_ROOT)))
 }
 
 fn sub_origin_key_upload(ui: &mut UI, m: &ArgMatches) -> Result<()> {


### PR DESCRIPTION
This subcommand provides an easy way for users to list the origin keys
installed on their system.

Closes #2559.

Signed-off-by: Lorenzo Manacorda <lorenzo@kinvolk.io>