### PR TITLE
fix expansion of program to spawn on windows so it chooses the first path with a match and not the last

### DIFF
--- a/components/core/src/os/process/windows_child.rs
+++ b/components/core/src/os/process/windows_child.rs
@@ -173,6 +173,7 @@ impl Child {
                     );
                     if fs::metadata(&path).is_ok() {
                         res = Some(path.into_os_string());
+                        break;
                     }
                 }
                 break;


### PR DESCRIPTION
This addresses a bug I ran into at our customer engagement where hooks are not running inside of our packaged powershell because `powershell.exe` is not resolving to the first path in the `PATH` variable that has a `powershell.exe`. So instead of resolving to the packaged powershell it is using the OS native powershell and thus behaving differently than expected.

Signed-off-by: Matt Wrock <matt@mattwrock.com>