### PR TITLE
Warn when installing a fully qualified package not present in the given channel

### DIFF
--- a/components/builder-depot-client/src/lib.rs
+++ b/components/builder-depot-client/src/lib.rs
@@ -413,10 +413,11 @@ impl Client {
 
     /// Download the latest release of a package.
     ///
-    /// An optional version and release can be specified which, when provided, will increase
-    /// specificity of the release retrieved. Specifying a version and no release will retrieve
-    /// the latest release of a given version. Specifying both a version and a release will
-    /// retrieve that exact package.
+    /// By the time this function is called, the ident must be fully qualified. The download URL in
+    /// the depot requires a fully qualified ident to work. If you want the latest version of
+    /// a package, e.g. core/redis, you can display package details for that via a different URL,
+    /// e.g. /pkgs/core/redis/latest but that only _shows_ you the details - it doesn't download
+    /// the package.
     ///
     /// # Failures
     ///
@@ -434,9 +435,9 @@ impl Client {
         I: Identifiable,
         D: DisplayProgress + Sized,
     {
-        // JW TODO: We need to add a channel scoped /download route to the API server. Technically
-        // this is wrong because we only want to download packages that are in the channel we
-        // specified to the API client
+        // Given that the download URL requires a fully qualified package, the channel is
+        // irrelevant, per https://github.com/habitat-sh/habitat/issues/2722. This function is fine
+        // as is.
         match self.download(&package_download(ident), dst_path.as_ref(), progress) {
             Ok(file) => Ok(PackageArchive::new(PathBuf::from(file))),
             Err(e) => Err(e),

--- a/components/builder-depot/src/server.rs
+++ b/components/builder-depot/src/server.rs
@@ -1638,7 +1638,7 @@ fn search_packages(req: &mut Request) -> IronResult<Response> {
         let decoded_query = match url::percent_encoding::percent_decode(query.as_bytes())
             .decode_utf8() {
             Ok(q) => q.to_string(),
-            Err(e) => return Ok(Response::with(status::BadRequest)),
+            Err(_) => return Ok(Response::with(status::BadRequest)),
         };
 
         match PackageIdent::from_str(decoded_query.as_ref()) {

--- a/components/common/src/command/package/install.rs
+++ b/components/common/src/command/package/install.rs
@@ -193,6 +193,23 @@ impl<'a> InstallTask<'a> {
                     return Err(e);
                 }
             }
+        } else {
+            if channel.is_some() {
+                let ch = channel.unwrap().to_string();
+                match self.depot_client.package_channels(&ident) {
+                    Ok(channels) => {
+                        if channels.iter().find(|ref c| ***c == ch).is_none() {
+                            ui.warn(format!(
+                                "Can not find {} in the {} channel but installing anyway since the package ident was fully qualified.", &ident, &ch
+                            ))?;
+                        }
+                    }
+                    Err(e) => {
+                        debug!("Failed to get channel list: {:?}", e);
+                        return Err(Error::ChannelNotFound);
+                    }
+                };
+            }
         }
 
         if try!(self.is_package_installed(&ident)) {

--- a/components/common/src/error.rs
+++ b/components/common/src/error.rs
@@ -30,6 +30,7 @@ pub type Result<T> = result::Result<T, Error>;
 pub enum Error {
     ArtifactIdentMismatch((String, String, String)),
     CantUploadGossipToml,
+    ChannelNotFound,
     CryptoKeyError(String),
     GossipFileRelativePath(String),
     DepotClient(depot_client::Error),
@@ -59,6 +60,7 @@ impl fmt::Display for Error {
             Error::CantUploadGossipToml => {
                 format!("Can't upload gossip.toml, it's a reserved file name")
             }
+            Error::ChannelNotFound => format!("Channel not found"),
             Error::CryptoKeyError(ref s) => format!("Missing or invalid key: {}", s),
             Error::GossipFileRelativePath(ref s) => {
                 format!(
@@ -90,6 +92,7 @@ impl error::Error for Error {
                 "Artifact ident does not match expected ident"
             }
             Error::CantUploadGossipToml => "Can't upload gossip.toml, it's a reserved filename",
+            Error::ChannelNotFound => "Channel not found",
             Error::CryptoKeyError(_) => "Missing or invalid key",
             Error::GossipFileRelativePath(_) => {
                 "Path for gossip file cannot have relative components (eg: ..)"

--- a/support/ci/appveyor.ps1
+++ b/support/ci/appveyor.ps1
@@ -9,7 +9,7 @@ function Test-ComponentChanged ($path) {
 
 function Test-PullRequest() {
     ($env:APPVEYOR_REPO_BRANCH -like 'master') -and
-        (test-path env:/APPVEYOR_PULL_REQUEST_NUMBER) -and 
+        (test-path env:/APPVEYOR_PULL_REQUEST_NUMBER) -and
         (-not [string]::IsNullOrEmpty($env:APPVEYOR_PULL_REQUEST_NUMBER))
 }
 
@@ -19,24 +19,24 @@ function Test-SentinelBuild() {
 
 function Test-SourceChanged {
     $files = if (Test-PullRequest -or Test-SentinelBuild) {
-        # for pull requests or sentinel builds diff 
+        # for pull requests or sentinel builds diff
         # against master
-        git diff master --name-only        
+        git diff master --name-only
     } else {
         # for master builds, check against the last merge
-        git show :/^Merge --pretty=format:%H -m --name-only    
+        git show :/^Merge --pretty=format:%H -m --name-only
     }
 
-    $BuildFiles = "appveyor.yml", "build.ps1", "support/ci/appveyor.ps1", "support/ci/appveyor.bat", 
+    $BuildFiles = "appveyor.yml", "build.ps1", "support/ci/appveyor.ps1", "support/ci/appveyor.bat",
                   "Cargo.toml", "Cargo.lock"
-    ($files | 
+    ($files |
         where-object {
             ($BuildFiles -contains $_ ) -or
-            (($_ -like 'components/*') -and 
+            (($_ -like 'components/*') -and
                 (Test-ComponentChanged $_))
         }
     ).count -ge 1
-} 
+}
 
 pushd "c:/projects/habitat"
 Write-Host "Configuring build environment"
@@ -52,14 +52,14 @@ if (($env:APPVEYOR_REPO_TAG_NAME -eq "$(Get-Content VERSION)") -or (Test-SourceC
 
     foreach ($BuildAction in ($env:hab_build_action -split ';')) {
         if ($BuildAction -like 'build') {
-            
+
             Write-Host "Building hab..."
             Write-Host ""
 
             ./build.ps1 -Path "components/hab" -Release
             if ($LASTEXITCODE -ne 0) {exit $LASTEXITCODE}
             ./target/release/hab.exe --version
-            if ($LASTEXITCODE -ne 0) {exit $LASTEXITCODE}  
+            if ($LASTEXITCODE -ne 0) {exit $LASTEXITCODE}
 
         }
         elseif ($BuildAction -like 'test') {
@@ -67,7 +67,7 @@ if (($env:APPVEYOR_REPO_TAG_NAME -eq "$(Get-Content VERSION)") -or (Test-SourceC
                 pushd "c:/projects/habitat/components/$component"
                 Write-Host "Testing $component"
                 Write-Host ""
-                cargo test
+                cargo test --verbose
                 if ($LASTEXITCODE -ne 0) {exit $LASTEXITCODE}
                 popd
             }
@@ -81,7 +81,7 @@ if (($env:APPVEYOR_REPO_TAG_NAME -eq "$(Get-Content VERSION)") -or (Test-SourceC
             Invoke-WebRequest -UseBasicParsing -Uri $url -OutFile hab.zip
             Expand-Archive -Path hab.zip -DestinationPath $bootstrapDir
             $habExe = (Get-Item "$bootstrapDir/*/hab.exe").FullName
-            
+
             # This will override plan's CARGO_TARGET_DIR so we do not have to build each clean
             $env:HAB_CARGO_TARGET_DIR = "c:\projects\habitat\target"
 
@@ -101,7 +101,7 @@ if (($env:APPVEYOR_REPO_TAG_NAME -eq "$(Get-Content VERSION)") -or (Test-SourceC
                 Write-Host ""
                 & $habExe studio build components/$component -w
                 if ($LASTEXITCODE -ne 0) {exit $LASTEXITCODE}
-                
+
                 $hart = Get-Item "C:\hab\studios\projects--habitat\src\components\$component\results\*.hart"
                 Write-Host "Copying $hart to artifacts directory..."
                 Copy-Item $hart.FullName results
@@ -124,7 +124,7 @@ if (($env:APPVEYOR_REPO_TAG_NAME -eq "$(Get-Content VERSION)") -or (Test-SourceC
                     Copy-Item "/hab/pkgs/core/hab/*/*/bin/*" $zipDir
 
                     mkdir $stagingZipDir -Force
-                    Compress-Archive -Path $zipDir -DestinationPath "$stagingZipDir/$zip" 
+                    Compress-Archive -Path $zipDir -DestinationPath "$stagingZipDir/$zip"
                     if(Test-ReleaseBuild) {
                         mkdir "results/prod" -Force
                         Compress-Archive -Path ./windows -DestinationPath "results/prod/$zip"
@@ -139,7 +139,7 @@ if (($env:APPVEYOR_REPO_TAG_NAME -eq "$(Get-Content VERSION)") -or (Test-SourceC
         }
         else {
             Write-Warning "Unsupported Build Action: $BuildAction."
-        }  
+        }
     }
 }
 else {


### PR DESCRIPTION
This adds a warning if you try to `hab pkg install` a fully qualified package identifier, e.g. `core/redis/3.2.4/20170514150022` and that package doesn't exist in the channel that's specified.  If no channel is specified, then `stable` is assumed.

I've also added a few clarifying comments in places that felt relevant as I was reviewing the existing code.

![tenor-245383576](https://user-images.githubusercontent.com/947/28136753-bf7f1d40-66ff-11e7-9091-ce8eadadeb97.gif)

Closes #2722 

Signed-off-by: Josh Black <raskchanky@gmail.com>