### PR TITLE
let user know that artifacts are being verified

### DIFF
--- a/components/common/src/command/package/install.rs
+++ b/components/common/src/command/package/install.rs
@@ -283,6 +283,7 @@ impl<'a> InstallTask<'a> {
         }
 
         let mut artifact = PackageArchive::new(try!(self.cached_artifact_path(&ident)));
+        try!(ui.status(Status::Verifying, try!(artifact.ident())));
         try!(self.verify_artifact(ui, &ident, &mut artifact));
         Ok(artifact)
     }

--- a/components/common/src/ui.rs
+++ b/components/common/src/ui.rs
@@ -46,6 +46,7 @@ pub enum Status {
     Uploading,
     Using,
     Verified,
+    Verifying,
     Promoted,
     Custom(char, String),
 }
@@ -69,6 +70,7 @@ impl Status {
             Status::Uploading => ('↑', "Uploading".into(), Colour::Green),
             Status::Using => ('→', "Using".into(), Colour::Green),
             Status::Verified => ('✓', "Verified".into(), Colour::Green),
+            Status::Verifying => ('☛', "Verifying".into(), Colour::Green),
             Status::Promoted => ('✓', "Promoted".into(), Colour::Green),
             Status::Custom(c, ref s) => (c, s.to_string(), Colour::Green),
         }


### PR DESCRIPTION
# Problem

Running `hab pkg install really_big.hart` currently presents no output to the user until after the artifact signature has been validated. This resulted in what looked like a hung shell and some confusion about whether the package was actually being installed.

# Solution

Say what's going on.

I settled on adding a "Verifying" status to UI and using that in the place I've deduced might be the most appropriate.

+ Is this the right place?
+ Is "Verifying" the right thing to call what's going on there?
+ Should I reuse the 👉 emoji for an "-ing" status?

```
root@vagrant:/vagrant/components/hab# ../../target/debug/hab pkg install /vagrant/robbkidd-dcob-0.1.0-20170506200500-x86_64-linux.hart
☛ Verifying robbkidd/dcob/0.1.0/20170506200500
↓ Downloading core/acl/2.2.52/20161208223311
    90.00 KB / 90.00 KB \ [========================================================================================================] 100.00 % 1.44 MB/s
☛ Verifying core/acl/2.2.52/20161208223311
↓ Downloading core/attr/2.4.47/20161208223238
    63.30 KB / 63.30 KB / [======================================================================================================] 100.00 % 793.34 KB/s
☛ Verifying core/attr/2.4.47/20161208223238
↓ Downloading core/cacerts/2016.09.14/20161031044952
    138.04 KB / 138.04 KB - [====================================================================================================] 100.00 % 705.09 KB/s
☛ Verifying core/cacerts/2016.09.14/20161031044952
↓ Downloading core/coreutils/8.25/20161208223423
    1.99 MB / 1.99 MB \ [==========================================================================================================] 100.00 % 1.30 MB/s
☛ Verifying core/coreutils/8.25/20161208223423
[... snip ...]
```

# Potential Terribad

+ This adds a line of output to every package being installed (via pkg ident or hartifact).

# Caveats

![really, no idea what I'm doing](https://user-images.githubusercontent.com/517302/28137429-44982dbc-671b-11e7-8af1-1f2f8b75679b.gif)

