### PR TITLE
Add max_locks_per_transaction to Postgres dev config

### DIFF
--- a/support/db/user.toml
+++ b/support/db/user.toml
@@ -1,3 +1,5 @@
+max_locks_per_transaction = 128
+
 [superuser]
 name = 'hab'
 password = 'hab'


### PR DESCRIPTION
This [optional setting](https://www.postgresql.org/docs/9.6/static/runtime-config-locks.html) gets us around the `out of shared memory` error we often see in development with `make bldr-run`.

![](https://media.tenor.com/images/0edd53dd2110147b786329c2e24fb1d0/tenor.gif)

Signed-off-by: Christian Nunciato <cnunciato@chef.io>