### PR TITLE
set defaults for jobsrv config

### DIFF
--- a/components/builder-jobsrv/habitat/default.toml
+++ b/components/builder-jobsrv/habitat/default.toml
@@ -16,4 +16,9 @@ connection_timeout_sec = 3600
 
 [archive]
 backend = "local"
-dir = "/tmp" # You don't want to use /tmp for real
+key = ""
+secret = ""
+endpoint = ""
+bucket = ""
+region = "us-east-1"
+local_dir = ""


### PR DESCRIPTION
Based on [builder-jobsrv's ArchiveCfg options](https://github.com/habitat-sh/habitat/blob/e1a5ee9c83f3d46a1ce59ec0de3101ff797bd93c/components/builder-jobsrv/src/config.rs#L165-L173), these values should have defaults in the plan's toml. Resolves exceptions thrown when no custom config is provided.

Starting the service with the existing default.toml errored on a missing `local_dir`.

```
hab-sup(SV): builder-jobsrv.default - process 6794 died with exit code 101
hab-sup(SV): builder-jobsrv.default - Service exited
builder-jobsrv.default(SV): Starting process as user=hab, group=hab
builder-jobsrv.default(O): ERROR:habitat_builder_db::async: Dispatching sync_jobs
builder-jobsrv.default(O): thread 'log-ingester' panicked at 'Missing local archive directory!', /checkout/src/libcore/option.rs:794
builder-jobsrv.default(O): note: Run with `RUST_BACKTRACE=1` for a backtrace.
builder-jobsrv.default(O): thread 'main' panicked at 'log-ingester thread startup error, err=receiving on a closed channel', src/server/log_ingester.rs:82
```