### PR TITLE
[hab,studio] Support artifact caching across Studios.

### DIFF
--- a/components/core/src/os/users/linux.rs
+++ b/components/core/src/os/users/linux.rs
@@ -41,6 +41,10 @@ pub fn get_home_for_user(username: &str) -> Option<PathBuf> {
     linux_users::get_user_by_name(username).map(|u| PathBuf::from(u.home_dir()))
 }
 
+pub fn get_primary_gid_for_user(username: &str) -> Option<u32> {
+    linux_users::get_user_by_name(username).map(|u| u.primary_group_id())
+}
+
 pub fn root_level_account() -> String {
     "root".to_string()
 }

--- a/components/core/src/os/users/mod.rs
+++ b/components/core/src/os/users/mod.rs
@@ -18,11 +18,13 @@ mod windows;
 
 #[cfg(windows)]
 pub use self::windows::{get_uid_by_name, get_gid_by_name, get_effective_uid, get_home_for_user,
-                        get_current_username, get_current_groupname, root_level_account};
+                        get_current_username, get_current_groupname, get_primary_gid_for_user,
+                        root_level_account};
 
 #[cfg(not(windows))]
 pub mod linux;
 
 #[cfg(not(windows))]
 pub use self::linux::{get_uid_by_name, get_gid_by_name, get_effective_uid, get_home_for_user,
-                      get_current_username, get_current_groupname, root_level_account};
+                      get_current_username, get_current_groupname, get_primary_gid_for_user,
+                      root_level_account};

--- a/components/core/src/os/users/windows.rs
+++ b/components/core/src/os/users/windows.rs
@@ -61,7 +61,7 @@ pub fn get_home_for_user(username: &str) -> Option<PathBuf> {
     unimplemented!();
 }
 
-pub fn get_primary_gid_for_user(username: &str) -> Option<u32> {
+pub fn get_primary_gid_for_user(username: &str) -> Option<String> {
     None
 }
 

--- a/components/core/src/os/users/windows.rs
+++ b/components/core/src/os/users/windows.rs
@@ -61,6 +61,10 @@ pub fn get_home_for_user(username: &str) -> Option<PathBuf> {
     unimplemented!();
 }
 
+pub fn get_primary_gid_for_user(username: &str) -> Option<u32> {
+    None
+}
+
 pub fn root_level_account() -> String {
     env::var("COMPUTERNAME").unwrap().to_uppercase() + "$"
 }

--- a/components/hab/src/command/studio.rs
+++ b/components/hab/src/command/studio.rs
@@ -150,8 +150,8 @@ mod inner {
 #[cfg(not(target_os = "linux"))]
 mod inner {
     use std::env;
-    use std::ffi::OsString;
-    use std::path::PathBuf;
+    use std::ffi::{OsStr, OsString};
+    use std::path::{Path, PathBuf};
     use std::process::{Command, Stdio};
     use std::str::FromStr;
 
@@ -170,7 +170,8 @@ mod inner {
     const DOCKER_CMD_ENVVAR: &'static str = "HAB_DOCKER_BINARY";
     const DOCKER_IMAGE: &'static str = "habitat-docker-registry.bintray.io/studio";
     const DOCKER_IMAGE_ENVVAR: &'static str = "HAB_DOCKER_STUDIO_IMAGE";
-    const DOCKER_OPTS: &'static str = "HAB_DOCKER_OPTS";
+    const DOCKER_OPTS_ENVVAR: &'static str = "HAB_DOCKER_OPTS";
+    const DOCKER_SOCKET: &'static str = "/var/run/docker.sock";
 
     pub fn start(_ui: &mut UI, args: Vec<OsString>) -> Result<()> {
         if is_windows_studio(&args) {
@@ -208,77 +209,122 @@ mod inner {
     }
 
     pub fn start_docker_studio(_ui: &mut UI, args: Vec<OsString>) -> Result<()> {
-        let docker = henv::var(DOCKER_CMD_ENVVAR).unwrap_or(DOCKER_CMD.to_string());
+        let docker_cmd = find_docker_cmd()?;
 
-        let cmd = match find_command(&docker) {
-            Some(cmd) => cmd,
-            None => return Err(Error::ExecCommandNotFound(docker.into())),
-        };
-
-        let output = Command::new(&cmd)
-            .arg("images")
-            .arg(&image_identifier())
-            .arg("-q")
-            .output()
-            .expect("docker failed to start");
-
-        let stdout = String::from_utf8(output.stdout).unwrap();
-        if stdout.is_empty() {
-            debug!("Failed to find studio image locally.");
-
-            let child = Command::new(&cmd)
-                .arg("pull")
-                .arg(&image_identifier())
-                .stdout(Stdio::inherit())
-                .stderr(Stdio::inherit())
-                .spawn()
-                .expect("docker failed to start");
-
-            let output = child.wait_with_output().expect("failed to wait on child");
-
-            if output.status.success() {
-                debug!("Docker image is reachable. Proceeding with launching docker.");
-            } else {
-                debug!(
-                    "Docker image is unreachable. Exit code = {:?}",
-                    output.status
-                );
-
-                let err_output = String::from_utf8(output.stderr).unwrap();
-
-                if err_output.contains("image") && err_output.contains("not found") {
-                    return Err(Error::DockerImageNotFound(image_identifier().to_string()));
-                } else if err_output.contains("Cannot connect to the Docker daemon") {
-                    return Err(Error::DockerDaemonDown);
-                } else {
-                    return Err(Error::DockerNetworkDown(image_identifier().to_string()));
-                }
-            }
+        if is_image_present(&docker_cmd) {
+            debug!("Found Studio Docker image locally.");
         } else {
-            debug!("Found studio image locally.");
-            debug!("Local image id: {}", stdout);
+            debug!("Failed to find Studio Docker image locally.");
+            pull_image(&docker_cmd)?;
         }
 
-        // We need to ensure that filesystem sharing has been enabled, otherwise the user will
-        // be greeted with a horrible error message that's difficult to make sense of. To
-        // mitigate this, we check the studio version. This will cause Docker to go through the
-        // mounting steps, so we can watch stderr for failure, but has the advantage of not
-        // requiring a TTY.
+        let mut volumes = vec![
+            format!("{}:/src", env::current_dir().unwrap().to_string_lossy()),
+            format!(
+                "{}:/{}",
+                default_cache_key_path(None).to_string_lossy(),
+                CACHE_KEY_PATH
+            ),
+        ];
+        if Path::new(DOCKER_SOCKET).exists() {
+            volumes.push(format!("{}:{}", DOCKER_SOCKET, DOCKER_SOCKET));
+        }
 
-        let current_dir = format!("{}:/src", env::current_dir().unwrap().to_string_lossy());
-        let key_cache_path = format!(
-            "{}:/{}",
-            default_cache_key_path(None).to_string_lossy(),
-            CACHE_KEY_PATH
-        );
-        let version_output = Command::new(&cmd)
+        let env_vars = vec![
+            "HAB_DEPOT_URL",
+            "HAB_DEPOT_CHANNEL",
+            "HAB_ORIGIN",
+            "HAB_STUDIO_SUP",
+            "HAB_UPDATE_STRATEGY_FREQUENCY_MS",
+            "http_proxy",
+            "https_proxy",
+        ];
+
+        check_mounts(&docker_cmd, volumes.iter())?;
+        run_container(docker_cmd, args, volumes.iter(), env_vars.iter())
+    }
+
+    pub fn rerun_with_sudo_if_needed(_ui: &mut UI) -> Result<()> {
+        // No sudo calls necessary here--we are calling `docker` commands instead
+        Ok(())
+    }
+
+    fn find_docker_cmd() -> Result<PathBuf> {
+        let docker_cmd = henv::var(DOCKER_CMD_ENVVAR).unwrap_or(DOCKER_CMD.to_string());
+
+        match find_command(&docker_cmd) {
+            Some(docker_abs_path) => Ok(docker_abs_path),
+            None => Err(Error::ExecCommandNotFound(docker_cmd.into())),
+        }
+    }
+
+    fn is_image_present(docker_cmd: &Path) -> bool {
+        let mut cmd = Command::new(docker_cmd);
+        cmd.arg("images").arg(&image_identifier()).arg("-q");
+        debug!("Running command: {:?}", cmd);
+        let result = cmd.output().expect("Docker command failed to spawn");
+
+        !String::from_utf8_lossy(&result.stdout).as_ref().is_empty()
+    }
+
+    fn pull_image(docker_cmd: &Path) -> Result<()> {
+        let image = image_identifier();
+        let mut cmd = Command::new(docker_cmd);
+        cmd.arg("pull")
+            .arg(&image)
+            .stdout(Stdio::inherit())
+            .stderr(Stdio::inherit());
+        debug!("Running command: {:?}", cmd);
+        let result = cmd.spawn()
+            .expect("Docker command failed to spawn")
+            .wait_with_output()
+            .expect("Failed to wait on child process");
+
+        if result.status.success() {
+            debug!("Docker image '{}' is present locally.", &image);
+        } else {
+            debug!(
+                "Pulling Docker image '{}' failed with exit code: {:?}",
+                &image,
+                result.status
+            );
+
+            let err_output = String::from_utf8_lossy(&result.stderr);
+
+            if err_output.contains("image") && err_output.contains("not found") {
+                return Err(Error::DockerImageNotFound(image_identifier().to_string()));
+            } else if err_output.contains("Cannot connect to the Docker daemon") {
+                return Err(Error::DockerDaemonDown);
+            } else {
+                return Err(Error::DockerNetworkDown(image_identifier().to_string()));
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Checks whether or not the volume mounts are working.
+    ///
+    /// We need to ensure that filesystem sharing has been enabled, otherwise the user will be
+    /// greeted with a horrible error message that's difficult to make sense of. To mitigate this,
+    /// we check the studio version. This will cause Docker to go through the mounting steps, so we
+    /// can watch stderr for failure, but has the advantage of not requiring a TTY.
+    fn check_mounts<I, S>(docker_cmd: &Path, volumes: I) -> Result<()>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+    {
+        let mut volume_args: Vec<OsString> = Vec::new();
+        for vol in volumes {
+            volume_args.push("--volume".into());
+            volume_args.push(vol.as_ref().into());
+        }
+
+        let version_output = Command::new(docker_cmd)
             .arg("run")
             .arg("--rm")
             .arg("--privileged")
-            .arg("--volume")
-            .arg(&key_cache_path)
-            .arg("--volume")
-            .arg(&current_dir)
+            .args(volume_args)
             .arg(image_identifier())
             .arg("-V")
             .output()
@@ -291,10 +337,21 @@ mod inner {
         {
             return Err(Error::DockerFileSharingNotEnabled);
         }
+        Ok(())
+    }
 
-        // If we make it here, filesystem sharing has been setup correctly, so let's proceed like
-        // normal.
-
+    fn run_container<I, J, S, T>(
+        docker_cmd: PathBuf,
+        args: Vec<OsString>,
+        volumes: I,
+        env_vars: J,
+    ) -> Result<()>
+    where
+        I: IntoIterator<Item = S>,
+        J: IntoIterator<Item = T>,
+        S: AsRef<OsStr>,
+        T: AsRef<str>,
+    {
         let mut cmd_args: Vec<OsString> = vec![
             "run".into(),
             "--rm".into(),
@@ -302,68 +359,46 @@ mod inner {
             "--interactive".into(),
             "--privileged".into(),
         ];
-
-        // All the args already placed in `cmd_args` are things that we don't want to insert again.
-        // Later args such as `--env` will overwrite any options (potentially) set mistakenly here.
-        if let Ok(opts) = henv::var(DOCKER_OPTS) {
+        if let Ok(opts) = henv::var(DOCKER_OPTS_ENVVAR) {
             let opts = opts.split(" ")
                 .map(|v| v.into())
                 // Ensure we're not passing something like `--tty` again here.
                 .filter(|v| !cmd_args.contains(v))
                 .collect::<Vec<_>>();
-            debug!("Docker opts originating from DOCKER_OPTS = {:?}", opts);
-            cmd_args.extend_from_slice(opts.as_slice());
-        }
-
-        let env_vars = vec![
-            "HAB_DEPOT_URL",
-            "HAB_DEPOT_CHANNEL",
-            "HAB_ORIGIN",
-            "HAB_STUDIO_SUP",
-            "HAB_UPDATE_STRATEGY_FREQUENCY_MS",
-            "http_proxy",
-            "https_proxy",
-        ];
-        for var in env_vars {
-            if let Ok(val) = henv::var(var) {
+            if !opts.is_empty() {
                 debug!(
-                    "Propagating environment variable into container: {}={}",
-                    var,
-                    val
+                    "Adding extra Docker options from {} = {:?}",
+                    DOCKER_OPTS_ENVVAR,
+                    opts
                 );
-                cmd_args.push("--env".into());
-                cmd_args.push(format!("{}={}", var, val).into());
+                cmd_args.extend_from_slice(opts.as_slice());
             }
         }
-
-        cmd_args.push("--volume".into());
-        cmd_args.push("/var/run/docker.sock:/var/run/docker.sock".into());
-        cmd_args.push("--volume".into());
-        cmd_args.push(key_cache_path.into());
-        cmd_args.push("--volume".into());
-        cmd_args.push(current_dir.into());
-
+        for var in env_vars {
+            if let Ok(val) = henv::var(var.as_ref()) {
+                debug!("Setting container env var: {:?}='{}'", var.as_ref(), val);
+                cmd_args.push("--env".into());
+                cmd_args.push(format!("{}={}", var.as_ref(), val).into());
+            }
+        }
+        for vol in volumes {
+            cmd_args.push("--volume".into());
+            cmd_args.push(vol.as_ref().into());
+        }
         cmd_args.push(image_identifier().into());
         cmd_args.extend_from_slice(args.as_slice());
 
+        unset_proxy_env_vars();
+        Ok(process::become_command(docker_cmd, cmd_args)?)
+    }
+
+    fn unset_proxy_env_vars() {
         for var in vec!["http_proxy", "https_proxy"] {
             if let Ok(_) = henv::var(var) {
-                debug!(
-                    "Unsetting proxy environment variable '{}' before calling `{}'",
-                    var,
-                    docker
-                );
+                debug!("Unsetting process environment variable '{}'", var);
                 env::remove_var(var);
             }
         }
-
-        debug!("Docker arguments = {:?}", cmd_args);
-        Ok(process::become_command(cmd, cmd_args)?)
-    }
-
-    pub fn rerun_with_sudo_if_needed(_ui: &mut UI) -> Result<()> {
-        // No sudo calls necessary here--we are calling `docker` commands instead
-        Ok(())
     }
 
     /// Returns the Docker Studio image with tag for the desired version which corresponds to the

--- a/components/studio/build-docker-image.sh
+++ b/components/studio/build-docker-image.sh
@@ -90,7 +90,8 @@ FROM busybox:latest
 MAINTAINER The Habitat Maintainers <humans@habitat.sh>
 ADD rootfs /
 WORKDIR /src
-RUN env NO_MOUNT=true hab studio new
+RUN env NO_MOUNT=true hab studio new \
+  && rm -rf /hab/studios/src/hab/cache/artifacts
 ENTRYPOINT ["/bin/hab", "studio"]
 EOF
 cd $tmp_root

--- a/components/studio/libexec/hab-studio-type-bare.sh
+++ b/components/studio/libexec/hab-studio-type-bare.sh
@@ -95,8 +95,6 @@ esac
 EOT
   $bb chmod a+x $HAB_STUDIO_ROOT/init.sh
 
-  $bb rm -f $HAB_STUDIO_ROOT$HAB_CACHE_ARTIFACT_PATH/*
-
   # remove the unnecessary supporting filesystem
   $bb rm -rf $HAB_STUDIO_ROOT/home $HAB_STUDIO_ROOT/lib $HAB_STUDIO_ROOT/lib64 $HAB_STUDIO_ROOT/mnt $HAB_STUDIO_ROOT/opt $HAB_STUDIO_ROOT/root $HAB_STUDIO_ROOT/run $HAB_STUDIO_ROOT/sbin $HAB_STUDIO_ROOT/src $HAB_STUDIO_ROOT/usr
 

--- a/components/studio/libexec/hab-studio-type-baseimage.sh
+++ b/components/studio/libexec/hab-studio-type-baseimage.sh
@@ -125,8 +125,6 @@ esac
 EOT
   $bb chmod a+x $HAB_STUDIO_ROOT/init.sh
 
-  $bb rm -f $HAB_STUDIO_ROOT$HAB_CACHE_ARTIFACT_PATH/*
-
   studio_env_command="$busybox_path/bin/env"
 }
 


### PR DESCRIPTION
## [hab,studio] Support artifact caching across Studios.

![tenor-101473861](https://user-images.githubusercontent.com/261548/28220704-bf87b39a-687d-11e7-9d38-34509d5c6be2.gif)

This change adds a new capability to the Studio software which allows the downloaded Habitat artifacts (i.e. `*.hart` files) to be shared between different Studio instances or the between setup and tear downs of the same Studio instance. The sharing is accomplished by mounting in a common artifact cache directory into each Studio so that all artifact downloads get combined into one location for the benefit of all instances.

For non-root users using Linux and for Windows and Mac users, a directory of `$HOME/.hab/cache/artifacts` will now be created and mounted into the Studio's artifact cache directory which is always at `/hab/cache/artifacts`. For a root user using Linux, the host's system `/hab/cache/artifacts` directory will be mounted into the Studio--the assumption we make in Habitat is that the root user would have their own home directory configuration that is different from the system's.

The net effect of this change is that users of the Studio should see a substantial reduction in bandwidth usage when building software. A couple of things to note however:

* The install logic will still (as before) check the Depot to ensure that we still have the latest artifact cached. If a newer artifact exists in the Depot, it will still be downloaded. Therefore, as of this feature, you will still need internet access when running Studio builds. Any potential future "offline" feature would require this caching as a prerequisite which is why it has been implemented first.
* While an artifact may be pre-cached, the Studio code still needs to install it into the Studio instance, meaning that on-disk extraction and artifact verification is still being performed every time (as before).

Studio Usage Additions
----------------------

The following new flags and options are added to the `hab-studio` program which gets called directly on Linux when using `hab studio` or `hab pkg build` calls:

* `-N` Do not mount the source artifact cache path into the Studio (default: mount the path).
* `-a <ARTIFACT_PATH>` Sets the source artifact cache path (default: `/hab/cache/artifacts`). For non-root users the default will be `$HOME/.hab/cache/artifacts`.

As well, and to match the patterns already established in the Studio codebase, the following Studio-only environment variables are added:

* `ARTIFACT_PATH` - Sets the source artifact cache path (\`-a' option overrides). This is named to line up with the `SRC_PATH` environment variable already in use.
* `NO_ARTIFACT_PATH` - If set, do not mount the source artifact cache path (\`-N' flag overrides).

Notes
-----

Some additional call outs:

* An additional core users function named `get_primary_gid_for_user` was added to help set correct ownership details on newly created user cache directories. There appears to be no good Windows equivalent call and therefore `None` is returned which should be correct behavior.
* Now that `/hab/cache/artifacts` in a Studio is assumed to be an externally bind mounted directory we should no longer clear out this directory when preparing Docker images, the default Docker Studio image, etc. Otherwise the built up user cache will be cleared for no good reason. This is why there are some updates which remove `rm` statements or add them in other cases.
* The Rust code in Hab's "silently use sudo and check on user settings and env vars" `studio` module is stating to become less clear than I'd like. While I don't believe I have this code set up 100% ideally, it works for the moment and isn't worse than before. Just an area I'd like to keep an eye on.
* While the benefits of saving on re-downloads is great, we introduce a new resource issue for users to keep an eye on: the size of their `~/.hab/cache/artifacts` directory.


## [hab] Refactor Docker Studio setup code.

![tenor-27372330](https://user-images.githubusercontent.com/261548/28220761-e961c5d4-687d-11e7-8441-008c69e6ef39.gif)

This refactoring attempts to clarify *what* the code is doing at a high level and less about *how*. Prior to this change the entire operation of checking if the Docker engine is alive, pulling images, verifying volume mounts, etc. was done in one function resulting in potentially many `docker` spawned processes. While the number of process spawns hasn't been reduced, the logical operations have been extracted into their own functions named after the goal they represent.
