### PR TITLE
Make github web url configurable for builder-web

### DIFF
--- a/components/builder-api/habitat/config/habitat.conf.js
+++ b/components/builder-api/habitat/config/habitat.conf.js
@@ -5,6 +5,7 @@ habitatConfig({
     environment: "{{cfg.web.environment}}",
     friends_only: {{cfg.web.friends_only}},
     github_client_id: "{{cfg.github.client_id}}",
+    github_url: "{{cfg.github.web_url}}",
     source_code_url: "{{cfg.web.source_code_url}}",
     tutorials_url: "{{cfg.web.tutorials_url}}",
     version: "{{pkg.ident}}",

--- a/components/builder-api/habitat/default.toml
+++ b/components/builder-api/habitat/default.toml
@@ -4,6 +4,7 @@ port = 9636
 
 [github]
 url = "https://api.github.com"
+web_url = "https://github.com"
 client_id = ""
 client_secret = ""
 

--- a/components/builder-web/app/sign-in-page/SignInPageComponent.ts
+++ b/components/builder-web/app/sign-in-page/SignInPageComponent.ts
@@ -56,7 +56,7 @@ import { createGitHubLoginUrl, icon } from "../util";
                 The {{appName}} project is maintained on GitHub and packages are
                 built from plan files stored in GitHub repositories. GitHub
                 accounts are free.
-                <a href="https://github.com/join" _target="blank">
+                <a href="{{gitHubJoinUrl}}" _target="blank">
                     Create one now
                 </a>.
             </p>
@@ -84,6 +84,8 @@ export class SignInPageComponent implements OnInit, OnDestroy {
     get appName() { return this.store.getState().app.name; }
 
     get docsUrl() { return config["docs_url"]; }
+
+    get gitHubJoinUrl() { return `${config["github_url"]}/join`; }
 
     get gitHubLoginUrl() {
         return createGitHubLoginUrl(this.store.getState().gitHub.authState);

--- a/components/builder-web/app/util.ts
+++ b/components/builder-web/app/util.ts
@@ -32,7 +32,7 @@ export function createGitHubLoginUrl(state) {
         scope: AUTH_SCOPES.join(","),
         state
     };
-    const urlPrefix = "https://github.com/login/oauth/authorize";
+    const urlPrefix = `${config["github_url"]}/login/oauth/authorize`;
     const queryString = Object.keys(params).map((k) =>
         `${k}=${encodeURIComponent(params[k])}`).
         join("&");

--- a/components/builder-web/habitat.conf.sample.js
+++ b/components/builder-web/habitat.conf.sample.js
@@ -16,6 +16,8 @@ habitatConfig({
     // GitHub Client ID for OAuth2
     // The example is for builder-dev: https://github.com/settings/connections/applications/0c2f738a7d0bd300de10
     github_client_id: "0c2f738a7d0bd300de10",
+    // The URL for GitHub
+    github_url: "https://github.com"
     // The URL for the Habitat source code
     source_code_url: "https://github.com/habitat-sh/habitat",
     // The URL for tutorials
@@ -31,7 +33,7 @@ habitatConfig({
     // The URL for feature requests
     feature_requests_url: "https://portal.prodpad.com/24539",
     // The URL for forums
-    forums_url: "https://forums.habitat.sh/",    
+    forums_url: "https://forums.habitat.sh/",
     // The version of the software we're running. In production, this should
     // be automatically populated by Habitat
     version: "",


### PR DESCRIPTION
This will allow the login/sign-up buttons to redirect to
a different GitHub installation than github.com. This is
useful for users who wish to connect Builder to GitHub
Enterprise

![tenor-258279746](https://user-images.githubusercontent.com/54036/28231734-f0cbf05a-68a1-11e7-9517-422758f2fe7b.gif)
