### PR TITLE
Add `web_url` config option to GitHubCfg

### DIFF
--- a/components/builder-admin/habitat/default.toml
+++ b/components/builder-admin/habitat/default.toml
@@ -4,5 +4,6 @@ port = 8080
 
 [github]
 url = "https://api.github.com"
+web_url = "https://github.com"
 client_id = ""
 client_secret = ""

--- a/components/builder-admin/src/config.rs
+++ b/components/builder-admin/src/config.rs
@@ -41,6 +41,10 @@ impl GitHubOAuth for Config {
         &self.github.url
     }
 
+    fn github_web_url(&self) -> &str {
+        &self.github.web_url
+    }
+
     fn github_client_id(&self) -> &str {
         &self.github.client_id
     }

--- a/components/builder-api/src/config.rs
+++ b/components/builder-api/src/config.rs
@@ -64,6 +64,10 @@ impl GitHubOAuth for Config {
         &self.github.url
     }
 
+    fn github_web_url(&self) -> &str {
+        &self.github.web_url
+    }
+
     fn github_client_id(&self) -> &str {
         &self.github.client_id
     }

--- a/components/builder-depot/src/config.rs
+++ b/components/builder-depot/src/config.rs
@@ -73,6 +73,10 @@ impl GitHubOAuth for Config {
         &self.github.url
     }
 
+    fn github_web_url(&self) -> &str {
+        &self.github.web_url
+    }
+
     fn github_client_id(&self) -> &str {
         &self.github.client_id
     }

--- a/components/builder-sessionsrv/habitat/default.toml
+++ b/components/builder-sessionsrv/habitat/default.toml
@@ -14,5 +14,6 @@ connection_timeout_sec = 3600
 
 [github]
 url = "https://api.github.com"
+web_url = "https://github.com"
 client_id = ""
 client_secret = ""

--- a/components/builder-sessionsrv/src/config.rs
+++ b/components/builder-sessionsrv/src/config.rs
@@ -64,6 +64,10 @@ impl GitHubOAuth for Config {
         &self.github.url
     }
 
+    fn github_web_url(&self) -> &str {
+        &self.github.web_url
+    }
+
     fn github_client_id(&self) -> &str {
         &self.github.client_id
     }

--- a/components/net/src/config.rs
+++ b/components/net/src/config.rs
@@ -22,6 +22,8 @@ pub const DEFAULT_ROUTER_HEARTBEAT_PORT: u16 = 5563;
 
 /// URL to GitHub API endpoint
 pub const DEFAULT_GITHUB_URL: &'static str = "https://api.github.com";
+/// URL to GitHub Web endpoint
+pub const DEFAULT_GITHUB_WEB_URL: &'static str = "https://github.com";
 /// Default Client ID for providing a default value in development environments only. This is
 /// associated to the habitat-sh GitHub account and is configured to re-direct and point to a local
 /// builder-api.
@@ -45,14 +47,18 @@ pub trait DispatcherCfg {
 
 pub trait GitHubOAuth {
     fn github_url(&self) -> &str;
+    fn github_web_url(&self) -> &str;
     fn github_client_id(&self) -> &str;
     fn github_client_secret(&self) -> &str;
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(default)]
 pub struct GitHubCfg {
     /// URL to GitHub API
     pub url: String,
+    /// URL to GitHub Web
+    pub web_url: String,
     /// Client identifier used for GitHub API requests
     pub client_id: String,
     /// Client secret used for GitHub API requests
@@ -63,6 +69,7 @@ impl Default for GitHubCfg {
     fn default() -> Self {
         GitHubCfg {
             url: DEFAULT_GITHUB_URL.to_string(),
+            web_url: DEFAULT_GITHUB_WEB_URL.to_string(),
             client_id: DEV_GITHUB_CLIENT_ID.to_string(),
             client_secret: DEV_GITHUB_CLIENT_SECRET.to_string(),
         }

--- a/components/net/src/http/middleware.rs
+++ b/components/net/src/http/middleware.rs
@@ -95,7 +95,10 @@ pub struct Authenticated {
 }
 
 impl Authenticated {
-    pub fn new<T: config::GitHubOAuth>(config: &T) -> Self {
+    pub fn new<T>(config: &T) -> Self
+    where
+        T: config::GitHubOAuth,
+    {
         let github = GitHubClient::new(config);
         Authenticated {
             github: github,

--- a/components/net/src/oauth/github.rs
+++ b/components/net/src/oauth/github.rs
@@ -43,14 +43,19 @@ const AUTH_SCOPES: &'static [&'static str] = &["user:email", "read:org"];
 #[derive(Clone)]
 pub struct GitHubClient {
     pub url: String,
+    pub web_url: String,
     pub client_id: String,
     pub client_secret: String,
 }
 
 impl GitHubClient {
-    pub fn new<T: config::GitHubOAuth>(config: &T) -> Self {
+    pub fn new<T>(config: &T) -> Self
+    where
+        T: config::GitHubOAuth,
+    {
         GitHubClient {
             url: config.github_url().to_string(),
+            web_url: config.github_web_url().to_string(),
             client_id: config.github_client_id().to_string(),
             client_secret: config.github_client_secret().to_string(),
         }
@@ -58,8 +63,9 @@ impl GitHubClient {
 
     pub fn authenticate(&self, code: &str) -> Result<String> {
         let url = Url::parse(&format!(
-            "https://github.com/login/oauth/access_token?\
+            "{}/login/oauth/access_token?\
                                 client_id={}&client_secret={}&code={}",
+            self.web_url,
             self.client_id,
             self.client_secret,
             code


### PR DESCRIPTION
This will enable the admin, api, and sessionsrv the ability to
fully configure the GitHub server they communicate with

![tenor-203789040](https://user-images.githubusercontent.com/54036/28233500-23ea98ce-68ac-11e7-9167-749113682eaf.gif)
