### PR TITLE
hab-cli will always attempt to install/use latest launcher

### DIFF
--- a/components/hab/src/command/launcher.rs
+++ b/components/hab/src/command/launcher.rs
@@ -42,22 +42,19 @@ mod inner {
     use super::{LAUNCH_CMD, LAUNCH_CMD_ENVVAR, LAUNCH_PKG_IDENT};
     use error::{Error, Result};
     use exec;
-    use VERSION;
 
     pub fn start(ui: &mut UI, args: Vec<OsString>) -> Result<()> {
         let command = match henv::var(LAUNCH_CMD_ENVVAR) {
             Ok(command) => PathBuf::from(command),
             Err(_) => {
                 init();
-                let version: Vec<&str> = VERSION.split("/").collect();
-                let cmd =
-                    exec::command_from_min_pkg(
-                        ui,
-                        LAUNCH_CMD,
-                        &PackageIdent::from_str(&format!("{}/{}", LAUNCH_PKG_IDENT, version[0]))?,
-                        &default_cache_key_path(None),
-                        0,
-                    )?;
+                let cmd = exec::command_from_min_pkg(
+                    ui,
+                    LAUNCH_CMD,
+                    &PackageIdent::from_str(LAUNCH_PKG_IDENT)?,
+                    &default_cache_key_path(None),
+                    0,
+                )?;
                 PathBuf::from(cmd)
             }
         };


### PR DESCRIPTION
The Launcher is versioned separately than the supervisor and cli
and follows a different versioning pattern. The latest version of
the launcher should always be used if possible

![tenor-194598858](https://user-images.githubusercontent.com/54036/28235331-ac235a00-68c0-11e7-8404-45c8e88bc2e5.gif)
