### PR TITLE
upload release builds to stable, otherwise unstable

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,6 @@ image: Visual Studio 2015
 
 cache:
   - c:\cargo\git
-  - c:\projects\habitat\target
 
 branches:
   only:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,6 @@ environment:
   CARGO_HOME: "c:\\cargo"
   RUSTUP_HOME: "c:\\multirust"
   CARGO_TARGET_DIR: "c:\\projects\\habitat\\target"
-  HAB_DEPOT_URL: "https://bldr.habitat.sh/v1/depot"
   HAB_WINDOWS_STUDIO: true
   HAB_AUTH_TOKEN:
     secure: il1kqjDtQSFOoD12nDaJhCBntC905Q8T9jRzyTZtqlJPxc3vCoS1bBeNbB55J82M

--- a/support/ci/appveyor.ps1
+++ b/support/ci/appveyor.ps1
@@ -46,8 +46,10 @@ write-host "TAG: $env:APPVEYOR_REPO_TAG_NAME"
 Write-Host "VERSION: $(Get-Content VERSION)"
 if (($env:APPVEYOR_REPO_TAG_NAME -eq "$(Get-Content VERSION)") -or (Test-SourceChanged) -or (test-path env:HAB_FORCE_TEST)) {
     if(Test-ReleaseBuild) {
-        # appveyor.yml sets this to acceptance
-        $env:HAB_DEPOT_URL=$null
+        $channel = "stable"
+    }
+    else {
+        $channel = "unstable"
     }
 
     foreach ($BuildAction in ($env:hab_build_action -split ';')) {
@@ -109,7 +111,7 @@ if (($env:APPVEYOR_REPO_TAG_NAME -eq "$(Get-Content VERSION)") -or (Test-SourceC
                 if ($LASTEXITCODE -ne 0) {exit $LASTEXITCODE}
 
                 if($env:HAB_AUTH_TOKEN -and (!(Test-PullRequest))) {
-                    & $habExe pkg upload $hart --channel stable
+                    & $habExe pkg upload $hart --channel $channel
                     if ($LASTEXITCODE -ne 0) {exit $LASTEXITCODE}
                 }
 

--- a/support/ci/deploy.sh
+++ b/support/ci/deploy.sh
@@ -16,10 +16,10 @@ HAB_DOWNLOAD_URL="https://api.bintray.com/content/habitat/stable/linux/x86_64/ha
 export HAB_ORIGIN=core
 
 BINTRAY_REPO=unstable
+CHANNEL=unstable
 if [ "$(cat VERSION)" == "$TRAVIS_TAG" ]; then
   BINTRAY_REPO=stable
-else
-  export HAB_DEPOT_URL=http://app.acceptance.habitat.sh/v1/depot
+  CHANNEL=stable
 fi
 
 mkdir -p ${BOOTSTRAP_DIR}
@@ -60,7 +60,7 @@ do
   fi
 
   if [ -n "$HAB_AUTH_TOKEN" ]; then
-    ${TRAVIS_HAB} pkg upload $HART --channel stable
+    ${TRAVIS_HAB} pkg upload $HART --channel $CHANNEL
   fi
 
   rm $HART


### PR DESCRIPTION
This continues the work in #2757 and makes sure to promote to the correct channel - stable for releases and unstable for PR merges.

Signed-off-by: Matt Wrock <matt@mattwrock.com>