### PR TITLE
Use event timestamps for date computations

### DIFF
--- a/www/source/javascripts/home.js
+++ b/www/source/javascripts/home.js
@@ -124,7 +124,7 @@ var homepageScripts = function() {
       var weekdayNames = ["Monday", "Tuesday", "Thursday", "Friday", "Saturday", "Sunday"]
       var monthNames = [ "January", "February", "March", "April", "May", "June",
           "July", "August", "September", "October", "November", "December" ];
-      var newDate = new Date(e["start_date"]);
+      var newDate = new Date(e["start"] * 1000);
       var formattedDate = weekdayNames[newDate.getDay()] + ', '  + monthNames[newDate.getMonth()] + ' ' + newDate.getDate();
       var month = monthNames[newDate.getMonth()];
 


### PR DESCRIPTION
Since we’re creating a new JS `Date` object here, we should use the numeric timestamp provided by the service, which is inherently UTC-based.

Signed-off-by: Christian Nunciato <cnunciato@chef.io>

![](https://media.tenor.com/images/83ebea77aef6e0a5bbf74f8d3bc823f7/tenor.gif)