### PR TITLE
only use key pairs with secret keys for signing

### DIFF
--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -417,7 +417,7 @@ fn sub_pkg_sign(ui: &mut UI, m: &ArgMatches) -> Result<()> {
     let pair = SigKeyPair::get_latest_pair_for(
         &origin_param_or_env(&m)?,
         &default_cache_key_path(Some(&*FS_ROOT)),
-        None,
+        Some(&PairType::Secret),
     )?;
 
     command::pkg::sign::start(ui, &pair, &src, &dst)


### PR DESCRIPTION
This will only use keys from the cache that have a secret key for signing.

Signed-off-by: Matt Wrock <matt@mattwrock.com>