### PR TITLE
Add make lint target and clippy for all components

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,19 @@ unit-lib: $(addprefix unit-,$(LIB)) ## executes the library components' unit tes
 unit-srv: $(addprefix unit-,$(SRV)) ## executes the service components' unit test suites
 .PHONY: unit-srv
 
+lint: lint-bin lint-lib lint-srv ## executs all components' lints
+lint-all: lint
+.PHONY: lint lint-all
+
+lint-bin: $(addprefix lint-,$(BIN))
+.PHONY: lint-bin
+
+lint-lib: $(addprefix lint-,$(LIB))
+.PHONY: lint-lib
+
+lint-srv: $(addprefix lint-,$(SRV))
+.PHONY: lint-srv
+
 functional: functional-bin functional-lib functional-srv ## executes all the components' functional test suites
 functional-all: functional
 test: functional ## executes all components' test suites
@@ -193,9 +206,15 @@ define UNIT
 unit-$1: image ## executes the $1 component's unit test suite
 	$(run) sh -c 'cd components/$1 && cargo test'
 .PHONY: unit-$1
-
 endef
 $(foreach component,$(ALL),$(eval $(call UNIT,$(component))))
+
+define LINT
+lint-$1: image ## executes the $1 component's linter checks
+	$(run) sh -c 'cd components/$1 && cargo build --features clippy'
+.PHONY: lint-$1
+endef
+$(foreach component,$(ALL),$(eval $(call LINT,$(component))))
 
 define FUNCTIONAL
 functional-$1: image ## executes the $1 component's functional test suite

--- a/components/builder-admin/Cargo.toml
+++ b/components/builder-admin/Cargo.toml
@@ -11,6 +11,7 @@ name = "bldr-admin"
 doc = false
 
 [dependencies]
+clippy = {version = "*", optional = true}
 bodyparser = "*"
 env_logger = "*"
 hyper = "*"
@@ -46,3 +47,6 @@ path = "../builder-protocol"
 
 [dependencies.habitat_net]
 path = "../net"
+
+[features]
+default = []

--- a/components/builder-admin/src/lib.rs
+++ b/components/builder-admin/src/lib.rs
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#![cfg_attr(feature="clippy", feature(plugin))]
+#![cfg_attr(feature="clippy", plugin(clippy))]
 
 extern crate bodyparser;
 extern crate habitat_builder_protocol as protocol;

--- a/components/builder-admin/src/main.rs
+++ b/components/builder-admin/src/main.rs
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#![cfg_attr(feature="clippy", feature(plugin))]
+#![cfg_attr(feature="clippy", plugin(clippy))]
 
 #[macro_use]
 extern crate clap;

--- a/components/builder-api/Cargo.toml
+++ b/components/builder-api/Cargo.toml
@@ -11,6 +11,7 @@ name = "bldr-api"
 doc = false
 
 [dependencies]
+clippy = {version = "*", optional = true}
 base64 = "*"
 bodyparser = "*"
 env_logger = "*"
@@ -50,4 +51,5 @@ path = "../builder-protocol"
 path = "../net"
 
 [features]
+default = []
 functional = []

--- a/components/builder-api/src/lib.rs
+++ b/components/builder-api/src/lib.rs
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#![cfg_attr(feature="clippy", feature(plugin))]
+#![cfg_attr(feature="clippy", plugin(clippy))]
 
 extern crate base64;
 extern crate bodyparser;

--- a/components/builder-api/src/main.rs
+++ b/components/builder-api/src/main.rs
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#![cfg_attr(feature="clippy", feature(plugin))]
+#![cfg_attr(feature="clippy", plugin(clippy))]
 
 #[macro_use]
 extern crate clap;

--- a/components/builder-core/Cargo.toml
+++ b/components/builder-core/Cargo.toml
@@ -6,6 +6,7 @@ workspace = "../../"
 build = "../bldr-build.rs"
 
 [dependencies]
+clippy = {version = "*", optional = true}
 log = "*"
 statsd = "*"
 petgraph = "*"
@@ -22,4 +23,5 @@ path = "../core"
 path = "../builder-protocol"
 
 [features]
+default = []
 functional = []

--- a/components/builder-core/src/lib.rs
+++ b/components/builder-core/src/lib.rs
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#![cfg_attr(feature="clippy", feature(plugin))]
+#![cfg_attr(feature="clippy", plugin(clippy))]
 
 extern crate habitat_core as hab_core;
 extern crate habitat_builder_protocol as protocol;

--- a/components/builder-db/Cargo.toml
+++ b/components/builder-db/Cargo.toml
@@ -6,6 +6,7 @@ description = "Habitat-Builder Database Library"
 workspace = "../../"
 
 [dependencies]
+clippy = {version = "*", optional = true}
 log = "*"
 r2d2 = "*"
 time = "*"
@@ -29,4 +30,5 @@ path = "../net"
 path = "../builder-protocol"
 
 [features]
+default = []
 functional = []

--- a/components/builder-db/src/lib.rs
+++ b/components/builder-db/src/lib.rs
@@ -60,6 +60,8 @@
 //! 1. Q: Won't this impact database performance? A: Probably, but in a positive way. Think about it - 99% of the time, you run the same queries all the time. This is the equivalent of having them prepared in advance for you all the time.
 //! 1. Q: But what about those horror stories? A: The horror stories are about encoding your business logic in the database. For example, doing complex transformations on the data, or map reducing it, or all kinds of other crazy business. Both our application and our access patterns mean we likely won't need to do a whole lot of that.
 //!
+#![cfg_attr(feature="clippy", feature(plugin))]
+#![cfg_attr(feature="clippy", plugin(clippy))]
 
 extern crate fnv;
 #[macro_use]

--- a/components/builder-depot-client/Cargo.toml
+++ b/components/builder-depot-client/Cargo.toml
@@ -6,6 +6,7 @@ build = "../bldr-build.rs"
 workspace = "../../"
 
 [dependencies]
+clippy = {version = "*", optional = true}
 broadcast = "*"
 hyper = "*"
 hyper-openssl = ""
@@ -29,4 +30,5 @@ path = "../core"
 path = "../http-client"
 
 [features]
+default = []
 functional = []

--- a/components/builder-depot-client/src/lib.rs
+++ b/components/builder-depot-client/src/lib.rs
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#![cfg_attr(feature="clippy", feature(plugin))]
+#![cfg_attr(feature="clippy", plugin(clippy))]
 
 extern crate habitat_builder_protocol as protocol;
 extern crate habitat_core as hab_core;

--- a/components/builder-depot/Cargo.toml
+++ b/components/builder-depot/Cargo.toml
@@ -11,6 +11,7 @@ name = "bldr-depot"
 doc = false
 
 [dependencies]
+clippy = {version = "*", optional = true}
 bodyparser = "*"
 env_logger = "*"
 hyper = "*"
@@ -65,4 +66,5 @@ url = "*"
 uuid = "*"
 
 [features]
+default = []
 functional = []

--- a/components/builder-depot/src/lib.rs
+++ b/components/builder-depot/src/lib.rs
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#![cfg_attr(feature="clippy", feature(plugin))]
+#![cfg_attr(feature="clippy", plugin(clippy))]
 
 extern crate habitat_builder_protocol as protocol;
 #[macro_use]

--- a/components/builder-depot/src/main.rs
+++ b/components/builder-depot/src/main.rs
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#![cfg_attr(feature="clippy", feature(plugin))]
+#![cfg_attr(feature="clippy", plugin(clippy))]
 
 extern crate habitat_core as hab_core;
 extern crate habitat_depot as depot;

--- a/components/builder-graph/Cargo.toml
+++ b/components/builder-graph/Cargo.toml
@@ -11,6 +11,7 @@ name = "bldr-graph"
 doc = false
 
 [dependencies]
+clippy = {version = "*", optional = true}
 log = "*"
 env_logger = "*"
 petgraph = "*"
@@ -42,3 +43,6 @@ path = "../net"
 
 [build-dependencies]
 pkg-config = "0.3"
+
+[features]
+default = []

--- a/components/builder-graph/src/main.rs
+++ b/components/builder-graph/src/main.rs
@@ -12,6 +12,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#![cfg_attr(feature="clippy", feature(plugin))]
+#![cfg_attr(feature="clippy", plugin(clippy))]
 
 #[macro_use]
 extern crate log;

--- a/components/builder-jobsrv/Cargo.toml
+++ b/components/builder-jobsrv/Cargo.toml
@@ -11,6 +11,7 @@ name = "bldr-job-srv"
 doc = false
 
 [dependencies]
+clippy = {version = "*", optional = true}
 aws-sdk-rust = "*"
 env_logger = "*"
 linked-hash-map = "*"
@@ -48,4 +49,5 @@ git = "https://github.com/erickt/rust-zmq"
 branch = "release/v0.8"
 
 [features]
+default = []
 functional = []

--- a/components/builder-jobsrv/src/lib.rs
+++ b/components/builder-jobsrv/src/lib.rs
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#![cfg_attr(feature="clippy", feature(plugin))]
+#![cfg_attr(feature="clippy", plugin(clippy))]
 
 extern crate aws_sdk_rust;
 extern crate chrono;

--- a/components/builder-jobsrv/src/main.rs
+++ b/components/builder-jobsrv/src/main.rs
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#![cfg_attr(feature="clippy", feature(plugin))]
+#![cfg_attr(feature="clippy", plugin(clippy))]
 
 #[macro_use]
 extern crate clap;

--- a/components/builder-originsrv/Cargo.toml
+++ b/components/builder-originsrv/Cargo.toml
@@ -11,6 +11,7 @@ name = "bldr-origin-srv"
 doc = false
 
 [dependencies]
+clippy = {version = "*", optional = true}
 env_logger = "*"
 log = "*"
 protobuf = "*"
@@ -41,4 +42,5 @@ git = "https://github.com/erickt/rust-zmq"
 branch = "release/v0.8"
 
 [features]
+default = []
 functional = []

--- a/components/builder-originsrv/src/lib.rs
+++ b/components/builder-originsrv/src/lib.rs
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#![cfg_attr(feature="clippy", feature(plugin))]
+#![cfg_attr(feature="clippy", plugin(clippy))]
 
 extern crate habitat_builder_db as db;
 extern crate habitat_builder_protocol as protocol;

--- a/components/builder-originsrv/src/main.rs
+++ b/components/builder-originsrv/src/main.rs
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#![cfg_attr(feature="clippy", feature(plugin))]
+#![cfg_attr(feature="clippy", plugin(clippy))]
 
 #[macro_use]
 extern crate clap;

--- a/components/builder-protocol/Cargo.toml
+++ b/components/builder-protocol/Cargo.toml
@@ -7,6 +7,7 @@ build = "build.rs"
 workspace = "../../"
 
 [dependencies]
+clippy = {version = "*", optional = true}
 protobuf = "*"
 serde = "*"
 serde_derive = "*"
@@ -21,5 +22,6 @@ path = "../core"
 pkg-config = "0.3"
 
 [features]
+default = []
 functional = []
 protocols = []

--- a/components/builder-protocol/src/lib.rs
+++ b/components/builder-protocol/src/lib.rs
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#![cfg_attr(feature="clippy", feature(plugin))]
+#![cfg_attr(feature="clippy", plugin(clippy))]
 
 extern crate habitat_core as hab_core;
 #[macro_use]

--- a/components/builder-router/Cargo.toml
+++ b/components/builder-router/Cargo.toml
@@ -11,6 +11,7 @@ name = "bldr-router"
 doc = false
 
 [dependencies]
+clippy = {version = "*", optional = true}
 env_logger = "*"
 log = "*"
 protobuf = "*"
@@ -35,3 +36,6 @@ path = "../core"
 
 [dependencies.habitat_net]
 path = "../net"
+
+[features]
+default = []

--- a/components/builder-router/src/lib.rs
+++ b/components/builder-router/src/lib.rs
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#![cfg_attr(feature="clippy", feature(plugin))]
+#![cfg_attr(feature="clippy", plugin(clippy))]
 
 extern crate habitat_builder_protocol as protocol;
 extern crate habitat_core as hab_core;

--- a/components/builder-router/src/main.rs
+++ b/components/builder-router/src/main.rs
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#![cfg_attr(feature="clippy", feature(plugin))]
+#![cfg_attr(feature="clippy", plugin(clippy))]
 
 #[macro_use]
 extern crate clap;

--- a/components/builder-scheduler/Cargo.toml
+++ b/components/builder-scheduler/Cargo.toml
@@ -11,6 +11,7 @@ name = "bldr-scheduler"
 doc = false
 
 [dependencies]
+clippy = {version = "*", optional = true}
 env_logger = "*"
 linked-hash-map = "*"
 log = "*"
@@ -48,4 +49,5 @@ git = "https://github.com/erickt/rust-zmq"
 branch = "release/v0.8"
 
 [features]
+default = []
 functional = []

--- a/components/builder-scheduler/src/lib.rs
+++ b/components/builder-scheduler/src/lib.rs
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#![cfg_attr(feature="clippy", feature(plugin))]
+#![cfg_attr(feature="clippy", plugin(clippy))]
 
 extern crate habitat_builder_protocol as protocol;
 extern crate habitat_core as hab_core;

--- a/components/builder-scheduler/src/main.rs
+++ b/components/builder-scheduler/src/main.rs
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#![cfg_attr(feature="clippy", feature(plugin))]
+#![cfg_attr(feature="clippy", plugin(clippy))]
 
 #[macro_use]
 extern crate clap;

--- a/components/builder-sessionsrv/Cargo.toml
+++ b/components/builder-sessionsrv/Cargo.toml
@@ -11,6 +11,7 @@ name = "bldr-session-srv"
 doc = false
 
 [dependencies]
+clippy = {version = "*", optional = true}
 bitflags = "*"
 env_logger = "*"
 hyper = "*"
@@ -44,4 +45,5 @@ git = "https://github.com/erickt/rust-zmq"
 branch = "release/v0.8"
 
 [features]
+default = []
 functional = []

--- a/components/builder-sessionsrv/src/lib.rs
+++ b/components/builder-sessionsrv/src/lib.rs
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#![cfg_attr(feature="clippy", feature(plugin))]
+#![cfg_attr(feature="clippy", plugin(clippy))]
 
 extern crate habitat_builder_db as db;
 extern crate habitat_builder_protocol as protocol;

--- a/components/builder-sessionsrv/src/main.rs
+++ b/components/builder-sessionsrv/src/main.rs
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#![cfg_attr(feature="clippy", feature(plugin))]
+#![cfg_attr(feature="clippy", plugin(clippy))]
 
 #[macro_use]
 extern crate clap;

--- a/components/builder-worker/Cargo.toml
+++ b/components/builder-worker/Cargo.toml
@@ -11,6 +11,7 @@ name = "bldr-worker"
 doc = false
 
 [dependencies]
+clippy = {version = "*", optional = true}
 chrono = { version = "*", features = ["serde"] }
 env_logger = "*"
 git2 = "*"
@@ -45,4 +46,5 @@ path = "../builder-depot-client"
 path = "../builder-protocol"
 
 [features]
+default = []
 functional = []

--- a/components/builder-worker/src/lib.rs
+++ b/components/builder-worker/src/lib.rs
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#![cfg_attr(feature="clippy", feature(plugin))]
+#![cfg_attr(feature="clippy", plugin(clippy))]
 
 extern crate chrono;
 extern crate habitat_builder_protocol as protocol;

--- a/components/builder-worker/src/main.rs
+++ b/components/builder-worker/src/main.rs
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#![cfg_attr(feature="clippy", feature(plugin))]
+#![cfg_attr(feature="clippy", plugin(clippy))]
 
 #[macro_use]
 extern crate clap;

--- a/components/butterfly-test/Cargo.toml
+++ b/components/butterfly-test/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Adam Jacob <adam@chef.io>"]
 workspace = "../../"
 
 [dependencies]
+clippy = {version = "*", optional = true}
 env_logger = "*"
 time = "*"
 
@@ -13,3 +14,6 @@ path = "../butterfly"
 
 [dependencies.habitat_core]
 path = "../core"
+
+[features]
+default = []

--- a/components/butterfly-test/src/lib.rs
+++ b/components/butterfly-test/src/lib.rs
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#![cfg_attr(feature="clippy", feature(plugin))]
+#![cfg_attr(feature="clippy", plugin(clippy))]
 
 extern crate env_logger;
 extern crate time;

--- a/components/butterfly/Cargo.toml
+++ b/components/butterfly/Cargo.toml
@@ -16,6 +16,7 @@ path = "../butterfly-test"
 pkg-config = "0.3"
 
 [dependencies]
+clippy = {version = "*", optional = true}
 byteorder = "*"
 env_logger = "*"
 log = "*"
@@ -40,5 +41,6 @@ branch = "release/v0.8"
 path = "../core"
 
 [features]
+default = []
 functional = []
 protocols = []

--- a/components/butterfly/src/lib.rs
+++ b/components/butterfly/src/lib.rs
@@ -39,6 +39,8 @@
 //! 1. A 'pull' thread, which takes messages from any push source and applies them locally.
 //!
 //! Start exploring the code base by following the thread of execution in the `server` module.
+#![cfg_attr(feature="clippy", feature(plugin))]
+#![cfg_attr(feature="clippy", plugin(clippy))]
 
 extern crate byteorder;
 extern crate habitat_core;

--- a/components/butterfly/src/main.rs
+++ b/components/butterfly/src/main.rs
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#![cfg_attr(feature="clippy", feature(plugin))]
+#![cfg_attr(feature="clippy", plugin(clippy))]
 
 extern crate env_logger;
 extern crate log;

--- a/components/common/Cargo.toml
+++ b/components/common/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Adam Jacob <adam@chef.io>", "Jamie Winsor <reset@chef.io>", "Fletche
 workspace = "../../"
 
 [dependencies]
+clippy = {version = "*", optional = true}
 ansi_term = "*"
 hyper = "*"
 libc = "*"
@@ -33,4 +34,5 @@ winapi = "*"
 tempdir = "*"
 
 [features]
+default = []
 functional = []

--- a/components/common/src/lib.rs
+++ b/components/common/src/lib.rs
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#![cfg_attr(feature="clippy", feature(plugin))]
+#![cfg_attr(feature="clippy", plugin(clippy))]
 
 extern crate habitat_builder_protocol as protocol;
 extern crate habitat_core as hcore;

--- a/components/core/Cargo.toml
+++ b/components/core/Cargo.toml
@@ -11,6 +11,7 @@ gcc = "0.3"
 
 [dependencies]
 ansi_term = "*"
+clippy = {version = "*", optional = true}
 base64 = "*"
 errno = "*"
 hex = "*"
@@ -50,4 +51,5 @@ hyper = "*"
 tempdir = "*"
 
 [features]
+default = []
 functional = []

--- a/components/core/src/lib.rs
+++ b/components/core/src/lib.rs
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#![cfg_attr(feature="clippy", feature(plugin))]
+#![cfg_attr(feature="clippy", plugin(clippy))]
 
 extern crate ansi_term;
 extern crate base64;

--- a/components/eventsrv-client/Cargo.toml
+++ b/components/eventsrv-client/Cargo.toml
@@ -10,6 +10,7 @@ description = "Habitat EventSrv client"
 workspace = "../../"
 
 [dependencies]
+clippy = {version = "*", optional = true}
 byteorder = "*"
 env_logger = "*"
 habitat-eventsrv-protocol = { path = "../eventsrv-protocol" }
@@ -28,3 +29,6 @@ pkg-config = "0.3"
 [[bin]]
 name = "eventsrv-client"
 path = "src/main.rs"
+
+[features]
+default = []

--- a/components/eventsrv-client/src/lib.rs
+++ b/components/eventsrv-client/src/lib.rs
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#![cfg_attr(feature="clippy", feature(plugin))]
+#![cfg_attr(feature="clippy", plugin(clippy))]
 
 extern crate env_logger;
 extern crate habitat_eventsrv_protocol as protocol;

--- a/components/eventsrv-client/src/main.rs
+++ b/components/eventsrv-client/src/main.rs
@@ -14,6 +14,8 @@
 
 // NOTE: This file is mostly used for testing purposes and isn't necessary for the main operation
 // of EventSrvClient.
+#![cfg_attr(feature="clippy", feature(plugin))]
+#![cfg_attr(feature="clippy", plugin(clippy))]
 
 extern crate byteorder;
 extern crate habitat_eventsrv_client as client;

--- a/components/eventsrv/Cargo.toml
+++ b/components/eventsrv/Cargo.toml
@@ -11,6 +11,7 @@ build = "build.rs"
 workspace = "../../"
 
 [dependencies]
+clippy = {version = "*", optional = true}
 byteorder = "*"
 env_logger = "*"
 habitat_core = { path = "../core" }
@@ -29,6 +30,7 @@ branch = "release/v0.8"
 pkg-config = "0.3"
 
 [features]
+default = []
 protocols = []
 
 [[bin]]
@@ -39,3 +41,4 @@ path = "src/main.rs"
 [[bin]]
 name = "subscriber"
 path = "src/subscriber.rs"
+

--- a/components/eventsrv/src/lib.rs
+++ b/components/eventsrv/src/lib.rs
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#![cfg_attr(feature="clippy", feature(plugin))]
+#![cfg_attr(feature="clippy", plugin(clippy))]
 
 extern crate habitat_core as core;
 extern crate habitat_eventsrv_protocol as protocol;

--- a/components/eventsrv/src/main.rs
+++ b/components/eventsrv/src/main.rs
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#![cfg_attr(feature="clippy", feature(plugin))]
+#![cfg_attr(feature="clippy", plugin(clippy))]
 
 extern crate habitat_core as core;
 extern crate habitat_eventsrv as eventsrv;

--- a/components/hab-butterfly/Cargo.toml
+++ b/components/hab-butterfly/Cargo.toml
@@ -10,6 +10,7 @@ name = "hab-butterfly"
 doc = false
 
 [dependencies]
+clippy = {version = "*", optional = true}
 ansi_term = "*"
 env_logger = "*"
 hyper = "*"
@@ -51,4 +52,5 @@ version = "*"
 features = ["v4"]
 
 [features]
+default = []
 functional = []

--- a/components/hab-butterfly/src/lib.rs
+++ b/components/hab-butterfly/src/lib.rs
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#![cfg_attr(feature="clippy", feature(plugin))]
+#![cfg_attr(feature="clippy", plugin(clippy))]
 
 extern crate hab;
 extern crate habitat_core as hcore;

--- a/components/hab-butterfly/src/main.rs
+++ b/components/hab-butterfly/src/main.rs
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#![cfg_attr(feature="clippy", feature(plugin))]
+#![cfg_attr(feature="clippy", plugin(clippy))]
 
 extern crate hab;
 #[macro_use]

--- a/components/hab/Cargo.toml
+++ b/components/hab/Cargo.toml
@@ -10,6 +10,7 @@ name = "hab"
 doc = false
 
 [dependencies]
+clippy = {version = "*", optional = true}
 ansi_term = "*"
 env_logger = "*"
 hyper = "*"
@@ -47,4 +48,5 @@ version = "*"
 features = ["v4"]
 
 [features]
+default = []
 functional = []

--- a/components/hab/src/lib.rs
+++ b/components/hab/src/lib.rs
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#![cfg_attr(feature="clippy", feature(plugin))]
+#![cfg_attr(feature="clippy", plugin(clippy))]
 
 extern crate habitat_core as hcore;
 extern crate habitat_common as common;

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#![cfg_attr(feature="clippy", feature(plugin))]
+#![cfg_attr(feature="clippy", plugin(clippy))]
 
 extern crate clap;
 extern crate env_logger;

--- a/components/http-client/Cargo.toml
+++ b/components/http-client/Cargo.toml
@@ -6,6 +6,7 @@ build = "build.rs"
 workspace = "../../"
 
 [dependencies]
+clippy = {version = "*", optional = true}
 base64 = "*"
 log = "*"
 httparse = "*"
@@ -18,4 +19,5 @@ url = "*"
 path = "../core"
 
 [features]
+default = []
 functional = []

--- a/components/http-client/src/lib.rs
+++ b/components/http-client/src/lib.rs
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#![cfg_attr(feature="clippy", feature(plugin))]
+#![cfg_attr(feature="clippy", plugin(clippy))]
 
 extern crate base64;
 extern crate habitat_core as hab_core;

--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Adam Jacob <adam@chef.io>", "Jamie Winsor <reset@chef.io>", "Fletche
 workspace = "../../"
 
 [dependencies]
+clippy = {version = "*", optional = true}
 bitflags = "*"
 fnv = "*"
 habitat_builder_protocol = { path = "../builder-protocol" }
@@ -28,4 +29,5 @@ git = "https://github.com/erickt/rust-zmq"
 branch = "release/v0.8"
 
 [features]
+default = []
 functional = []

--- a/components/net/src/lib.rs
+++ b/components/net/src/lib.rs
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#![cfg_attr(feature="clippy", feature(plugin))]
+#![cfg_attr(feature="clippy", plugin(clippy))]
 
 #[macro_use]
 extern crate bitflags;

--- a/components/op/Cargo.toml
+++ b/components/op/Cargo.toml
@@ -6,6 +6,7 @@ description = "Operational tools for Habitat developers"
 workspace = "../../"
 
 [dependencies]
+clippy = {version = "*", optional = true}
 fnv = "*"
 log = "*"
 habitat_core = { path = "../core" }
@@ -16,3 +17,7 @@ path = "../builder-protocol"
 [dependencies.clap]
 version = "*"
 features = [ "suggestions", "color", "unstable" ]
+
+[features]
+default = []
+

--- a/components/op/src/lib.rs
+++ b/components/op/src/lib.rs
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#![cfg_attr(feature="clippy", feature(plugin))]
+#![cfg_attr(feature="clippy", plugin(clippy))]
 
 extern crate fnv;
 extern crate habitat_builder_protocol as protocol;

--- a/components/op/src/main.rs
+++ b/components/op/src/main.rs
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#![cfg_attr(feature="clippy", feature(plugin))]
+#![cfg_attr(feature="clippy", plugin(clippy))]
 
 #[macro_use]
 extern crate clap;

--- a/components/sup/Cargo.toml
+++ b/components/sup/Cargo.toml
@@ -16,6 +16,7 @@ doc = false
 name = "functional"
 
 [dependencies]
+clippy = {version = "*", optional = true}
 ansi_term = "*"
 base64 = "*"
 bitflags = "*"
@@ -60,5 +61,6 @@ winapi = "*"
 hyper = "*"
 
 [features]
+default = []
 functional = []
 apidocs =[]

--- a/components/win-users/src/lib.rs
+++ b/components/win-users/src/lib.rs
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#![cfg_attr(feature="clippy", feature(plugin))]
+#![cfg_attr(feature="clippy", plugin(clippy))]
 
 extern crate kernel32;
 extern crate widestring;


### PR DESCRIPTION
Add clippy support for all projects. Future PRs will be made for fixing the lint errors & warnings.

Earlier PR attempts https://github.com/habitat-sh/habitat/pull/2650 and https://github.com/habitat-sh/habitat/pull/2771 failed and closed due to git squashing being too difficult a concept for me :)