### PR TITLE
Make job archive configuration more robust

### DIFF
--- a/components/builder-jobsrv/habitat/default.toml
+++ b/components/builder-jobsrv/habitat/default.toml
@@ -16,8 +16,4 @@ connection_timeout_sec = 3600
 
 [archive]
 backend = "local"
-key = ""
-secret = ""
-endpoint = ""
-bucket = ""
-region = "us-east-1"
+local_dir = "/tmp"

--- a/components/builder-jobsrv/src/server/log_archiver/s3.rs
+++ b/components/builder-jobsrv/src/server/log_archiver/s3.rs
@@ -70,7 +70,11 @@ impl S3Archiver {
         // Parameterize this if anyone ends up needing V2 signatures
         let signature_type = Signature::V4;
         let final_endpoint = match config.endpoint {
-            Some(url) => Some(extern_url::Url::parse(url.as_str())?),
+            Some(url) => {
+                let url = extern_url::Url::parse(url.as_str())
+                    .expect("Invalid endpoint URL given");
+                Some(url)
+            },
             None => None,
         };
         let user_agent = format!("Habitat-Builder/{}", VERSION);


### PR DESCRIPTION
This fixes a few issues we ran into on a recent deploy of builder to production.