### PR TITLE
Distinguish circular dep error vs. others

### DIFF
--- a/components/builder-depot/src/server.rs
+++ b/components/builder-depot/src/server.rs
@@ -765,12 +765,21 @@ fn upload_package(req: &mut Request) -> IronResult<Response> {
     match route_message::<PackagePreCreate, NetOk>(req, &pcr_req) {
         Ok(_) => (),
         Err(e) => {
-            debug!(
-                "Failed package circular dependency check: {:?}, err: {:?}",
-                ident,
-                e
-            );
-            return Ok(Response::with(status::FailedDependency));
+            if e.get_code() == ErrCode::ENTITY_CONFLICT {
+                warn!(
+                    "Failed package circular dependency check: {:?}, err: {:?}",
+                    ident,
+                    e
+                );
+                return Ok(Response::with(status::FailedDependency));
+            } else {
+                error!(
+                    "Unable to check package dependency: {:?}, err: {:?}",
+                    ident,
+                    e
+                );
+                return Ok(Response::with(status::InternalServerError));
+            }
         }
     }
 


### PR DESCRIPTION
Currently a failure when checking for circular dependencies on upload is always classified as a circular dependency found failure. However we can fail due to other reasons (eg, not able to reach the scheduler), so we need to distinguish between the cases.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-45630506](https://user-images.githubusercontent.com/13542112/28337446-826ccffa-6bba-11e7-907e-41fbe902c257.gif)
