### PR TITLE
Refactor the way channels are retrieved for packages.

### DIFF
--- a/components/builder-depot/src/lib.rs
+++ b/components/builder-depot/src/lib.rs
@@ -37,6 +37,7 @@ extern crate router;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;
+#[macro_use]
 extern crate serde_json;
 extern crate tempfile;
 extern crate time;

--- a/components/builder-web/app/actions/index.ts
+++ b/components/builder-web/app/actions/index.ts
@@ -84,12 +84,10 @@ export const TOGGLE_ORIGIN_PICKER = originActions.TOGGLE_ORIGIN_PICKER;
 
 export const CLEAR_PACKAGES = packageActions.CLEAR_PACKAGES;
 export const POPULATE_DASHBOARD_RECENT = packageActions.POPULATE_DASHBOARD_RECENT;
-export const CLEAR_PACKAGE_CHANNELS = packageActions.CLEAR_PACKAGE_CHANNELS;
 export const CLEAR_PACKAGE_VERSIONS = packageActions.CLEAR_PACKAGE_VERSIONS;
 export const POPULATE_EXPLORE = packageActions.POPULATE_EXPLORE;
 export const POPULATE_EXPLORE_STATS = packageActions.POPULATE_EXPLORE_STATS;
 export const SET_CURRENT_PACKAGE = packageActions.SET_CURRENT_PACKAGE;
-export const SET_CURRENT_PACKAGE_CHANNELS = packageActions.SET_CURRENT_PACKAGE_CHANNELS;
 export const SET_CURRENT_PACKAGE_VERSIONS = packageActions.SET_CURRENT_PACKAGE_VERSIONS;
 export const SET_PACKAGES_NEXT_RANGE = packageActions.SET_PACKAGES_NEXT_RANGE;
 export const SET_PACKAGES_SEARCH_QUERY =
@@ -97,7 +95,6 @@ export const SET_PACKAGES_SEARCH_QUERY =
 export const SET_PACKAGES_TOTAL_COUNT = packageActions.SET_PACKAGES_TOTAL_COUNT;
 
 export const SET_VISIBLE_PACKAGES = packageActions.SET_VISIBLE_PACKAGES;
-export const SET_VISIBLE_PACKAGE_CHANNELS = packageActions.SET_VISIBLE_PACKAGE_CHANNELS;
 
 export const POPULATE_PROJECT = projectActions.POPULATE_PROJECT;
 export const SET_CURRENT_PROJECT = projectActions.SET_CURRENT_PROJECT;
@@ -170,7 +167,6 @@ export const uploadOriginPrivateKey = originActions.uploadOriginPrivateKey;
 export const uploadOriginPublicKey = originActions.uploadOriginPublicKey;
 
 export const fetchDashboardRecent = packageActions.fetchDashboardRecent;
-export const fetchCurrentPackageChannels = packageActions.fetchCurrentPackageChannels;
 export const fetchExplore = packageActions.fetchExplore;
 export const fetchPackage = packageActions.fetchPackage;
 export const fetchLatestPackage = packageActions.fetchLatestPackage;

--- a/components/builder-web/app/actions/packages.ts
+++ b/components/builder-web/app/actions/packages.ts
@@ -20,7 +20,6 @@ import { Package } from "../records/Package";
 
 export const CLEAR_PACKAGES = "CLEAR_PACKAGES";
 export const POPULATE_DASHBOARD_RECENT = "POPULATE_DASHBOARD_RECENT";
-export const CLEAR_PACKAGE_CHANNELS = "CLEAR_PACKAGE_CHANNELS";
 export const CLEAR_PACKAGE_VERSIONS = "CLEAR_PACKAGE_VERSIONS";
 export const POPULATE_EXPLORE = "POPULATE_EXPLORE";
 export const POPULATE_EXPLORE_STATS = "POPULATE_EXPLORE_STATS";
@@ -44,12 +43,6 @@ export function fetchDashboardRecent(origin: string) {
         return depotApi.get({ origin: origin })
             .then(data => dispatch(populateDashboardRecent(data)))
             .catch(error => console.error(error));
-    };
-}
-
-function clearPackageChannels() {
-    return {
-        type: CLEAR_PACKAGE_CHANNELS
     };
 }
 
@@ -78,34 +71,8 @@ export function fetchPackage(pkg) {
         dispatch(clearPackages());
         depotApi.get(pkg.ident).then(response => {
             dispatch(setCurrentPackage(response["results"]));
-            dispatch(fetchCurrentPackageChannels(pkg));
         }).catch(error => {
             dispatch(setCurrentPackage(undefined, error));
-        });
-    };
-}
-
-export function fetchCurrentPackageChannels(pkg) {
-    return dispatch => {
-        dispatch(clearPackageChannels());
-        depotApi.getPackageChannels(pkg.ident)
-            .then(channels => dispatch(setCurrentPackageChannels(channels)))
-            .catch(error => dispatch(setCurrentPackageChannels(undefined, error)));
-    };
-}
-
-export function fetchVisiblePackageChannels(pkgs) {
-    return dispatch => {
-        pkgs.forEach((pkg) => {
-
-            // Only fetch for fully qualified packages
-            if (pkg.origin && pkg.name && pkg.version && pkg.release) {
-                depotApi.getPackageChannels(pkg)
-                    .then(channels => {
-                        dispatch(setVisiblePackageChannels(pkg, channels));
-                    })
-                .catch(error => console.error(error));
-            }
         });
     };
 }
@@ -179,7 +146,6 @@ export function filterPackagesBy(
 
         depotApi.get(params, nextRange).then(response => {
             dispatch(setVisiblePackages(response["results"]));
-            dispatch(fetchVisiblePackageChannels(response["results"]));
             dispatch(setPackagesTotalCount(response["totalCount"]));
             dispatch(setPackagesNextRange(response["nextRange"]));
         }).catch(error => {
@@ -224,14 +190,6 @@ export function setCurrentPackage(pkg, error = undefined) {
     };
 }
 
-export function setCurrentPackageChannels(channels, error = undefined) {
-    return {
-        type: SET_CURRENT_PACKAGE_CHANNELS,
-        payload: channels,
-        error: error,
-    };
-}
-
 export function setCurrentPackageVersions(versions, error = undefined) {
     return {
         type: SET_CURRENT_PACKAGE_VERSIONS,
@@ -266,12 +224,5 @@ export function setVisiblePackages(params, error = undefined) {
         type: SET_VISIBLE_PACKAGES,
         payload: params,
         error: error,
-    };
-}
-
-export function setVisiblePackageChannels(pkg, channels) {
-    return {
-        type: SET_VISIBLE_PACKAGE_CHANNELS,
-        payload: { pkg, channels }
     };
 }

--- a/components/builder-web/app/depotApi.ts
+++ b/components/builder-web/app/depotApi.ts
@@ -126,24 +126,6 @@ export function getPackageVersions(origin: string, pkg: string) {
     });
 }
 
-export function getPackageChannels(pkg) {
-    const ident = packageString(pkg);
-    const url = `${urlPrefix}/depot/pkgs/${ident}/channels`;
-
-    return new Promise((resolve, reject) => {
-        fetch(url)
-            .then(response => {
-                if (response.status >= 400) {
-                    reject(new Error(response.statusText));
-                }
-                else {
-                    response.json().then(results => resolve(results));
-                }
-            })
-            .catch(error => reject(error));
-    });
-}
-
 export function scheduleBuild(origin: string, pkg: string, token: string) {
     const url = `${urlPrefix}/depot/pkgs/schedule/${origin}/${pkg}`;
 

--- a/components/builder-web/app/reducers/packages.ts
+++ b/components/builder-web/app/reducers/packages.ts
@@ -33,9 +33,6 @@ export default function packages(state = initialState["packages"], action) {
         case actionTypes.POPULATE_DASHBOARD_RECENT:
             return state.setIn(["dashboard", "recent"], List(action.payload));
 
-        case actionTypes.CLEAR_PACKAGE_CHANNELS:
-            return state.setIn(["current", "channels"], []);
-
         case actionTypes.CLEAR_PACKAGE_VERSIONS:
             return state.set("versions", undefined);
 
@@ -61,13 +58,6 @@ export default function packages(state = initialState["packages"], action) {
                     setIn(["ui", "current", "errorMessage"], undefined).
                     setIn(["ui", "current", "exists"], true).
                     setIn(["ui", "current", "loading"], false);
-            }
-
-        case actionTypes.SET_CURRENT_PACKAGE_CHANNELS:
-            if (action.error) {
-                return state.setIn(["current", "channels"], []);
-            } else {
-                return state.setIn(["current", "channels"], action.payload);
             }
 
         case actionTypes.SET_CURRENT_PACKAGE_VERSIONS:
@@ -106,25 +96,6 @@ export default function packages(state = initialState["packages"], action) {
                     setIn(["ui", "visible", "errorMessage"], undefined).
                     setIn(["ui", "visible", "exists"], true).
                     setIn(["ui", "visible", "loading"], false);
-            }
-
-        case actionTypes.SET_VISIBLE_PACKAGE_CHANNELS:
-            let visible = state.get("visible");
-
-            let i = visible.findIndex(p => {
-                return action.payload.pkg.origin === p.origin &&
-                    action.payload.pkg.name === p.name &&
-                    action.payload.pkg.version === p.version &&
-                    action.payload.pkg.release === p.release;
-            });
-
-            if (i >= 0) {
-                let pkg = visible.get(i);
-                pkg.channels = action.payload.channels;
-                return state.setIn(["visible", i], pkg);
-            }
-            else {
-                return state;
             }
 
         default:


### PR DESCRIPTION
This optimization removes N+1 HTTP requests from the client to fetch channels for package listings and replaces it with a mechanism for retrieving the channels on the server side and returning them with the package details.

I was startled by the number of changes to `Cargo.lock` but I think what happened is https://github.com/habitat-sh/habitat/pull/2772 was merged earlier today, and I notice there were no changes to `Cargo.lock` in that PR.  My guess is that running the various cargo commands required while testing this PR pulled in what should've been in that PR.

![tenor-80103849](https://user-images.githubusercontent.com/947/28343892-8876e68c-6bd4-11e7-8852-ca277f794642.gif)

Signed-off-by: Josh Black <raskchanky@gmail.com>