### PR TITLE
Fix studio exit

### DIFF
--- a/components/studio/bin/hab-studio.sh
+++ b/components/studio/bin/hab-studio.sh
@@ -354,6 +354,8 @@ subcommand_run() {
 
 # **Internal** Creates a new Studio.
 new_studio() {
+
+
   # Check if a pre-existing Studio configuration is found and use that to
   # determine the type
   if [ -s "$studio_config" ]; then
@@ -678,6 +680,9 @@ enter_studio() {
 
   local env="$(chroot_env "$studio_path" "$studio_enter_environment")"
 
+  info "=============================="
+  info "WE ARE CREATING THE STUDIO!!!!"
+  info "=============================="
   info "Entering Studio at $HAB_STUDIO_ROOT ($STUDIO_TYPE)"
   report_env_vars
   echo
@@ -774,48 +779,7 @@ rm_studio() {
 
   info "Destroying Studio at $HAB_STUDIO_ROOT ($STUDIO_TYPE)"
 
-  # Set the verbose flag (i.e. `-v`) for any coreutils-like commands if verbose
-  # mode was requested
-  if [ -n "$VERBOSE" ]; then
-    local v="-v"
-  else
-    local v=
-  fi
-
-  # Unmount filesystems that were previously set up in, but only if they are
-  # currently mounted. You know, so you can run this all day long, like, for
-  # fun and stuff.
-
-  if $bb mount | $bb grep -q "on $HAB_STUDIO_ROOT/src type"; then
-    $bb umount $v -l $HAB_STUDIO_ROOT/src
-  fi
-
-  if $bb mount | $bb grep -q "on $HAB_STUDIO_ROOT/run type"; then
-    $bb umount $v $HAB_STUDIO_ROOT/run
-  fi
-
-  if $bb mount | $bb grep -q "on $HAB_STUDIO_ROOT/sys type"; then
-    $bb umount $v $HAB_STUDIO_ROOT/sys
-  fi
-
-  if $bb mount | $bb grep -q "on $HAB_STUDIO_ROOT/proc type"; then
-    $bb umount $v $HAB_STUDIO_ROOT/proc
-  fi
-
-  if $bb mount | $bb grep -q "on $HAB_STUDIO_ROOT/dev/pts type"; then
-    $bb umount $v $HAB_STUDIO_ROOT/dev/pts
-  fi
-
-  if $bb mount | $bb grep -q "on $HAB_STUDIO_ROOT/dev type"; then
-    $bb umount $v -l $HAB_STUDIO_ROOT/dev
-  fi
-
-  if $bb mount | $bb grep -q "on $HAB_STUDIO_ROOT/var/run/docker.sock type"; then
-    $bb umount $v -l $HAB_STUDIO_ROOT/var/run/docker.sock
-  fi
-
-  # Remove remaining filesystem
-  $bb rm -rf $v $HAB_STUDIO_ROOT
+  trap cleanup_studio EXIT
 }
 
 
@@ -1022,6 +986,51 @@ cleanup_studio() {
   if [ -f $lock_file ]; then
     $bb kill $($bb cat $lock_file)
   fi
+
+  # Set the verbose flag (i.e. `-v`) for any coreutils-like commands if verbose
+  # mode was requested
+  if [ -n "$VERBOSE" ]; then
+    local v="-v"
+  else
+    local v=
+  fi
+
+
+  # Unmount filesystems that were previously set up in, but only if they are
+  # currently mounted. You know, so you can run this all day long, like, for
+  # fun and stuff.
+
+  if $bb mount | $bb grep -q "on $HAB_STUDIO_ROOT/src type"; then
+    $bb umount $v -l $HAB_STUDIO_ROOT/src
+  fi
+
+  if $bb mount | $bb grep -q "on $HAB_STUDIO_ROOT/run type"; then
+    $bb umount $v $HAB_STUDIO_ROOT/run
+  fi
+
+  if $bb mount | $bb grep -q "on $HAB_STUDIO_ROOT/sys type"; then
+    $bb umount $v $HAB_STUDIO_ROOT/sys
+  fi
+
+  if $bb mount | $bb grep -q "on $HAB_STUDIO_ROOT/proc type"; then
+    $bb umount $v $HAB_STUDIO_ROOT/proc
+  fi
+
+  if $bb mount | $bb grep -q "on $HAB_STUDIO_ROOT/dev/pts type"; then
+    $bb umount $v $HAB_STUDIO_ROOT/dev/pts
+  fi
+
+  if $bb mount | $bb grep -q "on $HAB_STUDIO_ROOT/dev type"; then
+    $bb umount $v -l $HAB_STUDIO_ROOT/dev
+  fi
+
+  if $bb mount | $bb grep -q "on $HAB_STUDIO_ROOT/var/run/docker.sock type"; then
+    $bb umount $v -l $HAB_STUDIO_ROOT/var/run/docker.sock
+  fi
+
+  # Remove remaining filesystem
+  $bb rm -rf $v $HAB_STUDIO_ROOT
+
 }
 
 # **Internal** Sets the `$libexec_path` variable, which is the absolute path to

--- a/components/studio/bin/hab-studio.sh
+++ b/components/studio/bin/hab-studio.sh
@@ -354,8 +354,6 @@ subcommand_run() {
 
 # **Internal** Creates a new Studio.
 new_studio() {
-
-
   # Check if a pre-existing Studio configuration is found and use that to
   # determine the type
   if [ -s "$studio_config" ]; then

--- a/components/studio/bin/hab-studio.sh
+++ b/components/studio/bin/hab-studio.sh
@@ -680,9 +680,6 @@ enter_studio() {
 
   local env="$(chroot_env "$studio_path" "$studio_enter_environment")"
 
-  info "=============================="
-  info "WE ARE CREATING THE STUDIO!!!!"
-  info "=============================="
   info "Entering Studio at $HAB_STUDIO_ROOT ($STUDIO_TYPE)"
   report_env_vars
   echo

--- a/components/studio/bin/hab-studio.sh
+++ b/components/studio/bin/hab-studio.sh
@@ -775,6 +775,9 @@ rm_studio() {
   info "Destroying Studio at $HAB_STUDIO_ROOT ($STUDIO_TYPE)"
 
   trap cleanup_studio EXIT
+
+  # Remove remaining filesystem
+  $bb rm -rf $v $HAB_STUDIO_ROOT
 }
 
 
@@ -1023,9 +1026,11 @@ cleanup_studio() {
     $bb umount $v -l $HAB_STUDIO_ROOT/var/run/docker.sock
   fi
 
-  # Remove remaining filesystem
-  $bb rm -rf $v $HAB_STUDIO_ROOT
+  # Remove `/dev/console` device
+  $bb rm $HAB_STUDIO_ROOT/dev/console
 
+  # Remove `/dev/null` device
+  $bb rm $HAB_STUDIO_ROOT/dev/null
 }
 
 # **Internal** Sets the `$libexec_path` variable, which is the absolute path to


### PR DESCRIPTION
Fixes #1705 

![Agent Carter Go To Work](https://images.duckduckgo.com/iu/?u=https%3A%2F%2Fuproxx.files.wordpress.com%2F2014%2F11%2Fagent-carter-peggy-carter-goes-to-work-01a.gif%3Fw%3D650&f=1)

This makes it so that we unmount studio directories whenever someone exits the studio.  This should help reduce the times we see the bug where someone manually removes a studio directory (at /hab/studios) and it removes everything within the habitat directory (and sometimes parts of the user's workstation).  

There is still a possibility of this error happening if someone enters a studio, does not exit, and then manually removes the studio directory at /hab/studios.