### PR TITLE
Add config for builder auto-promotion

### DIFF
--- a/components/builder-scheduler/habitat/config/config.toml
+++ b/components/builder-scheduler/habitat/config/config.toml
@@ -1,3 +1,12 @@
+auth_token = "{{cfg.auth_token}}"
+promote_channel = "{{cfg.promote_channel}}"
+log_dir = "{{pkg.svc_var_path}}"
+{{~#if cfg.depot_url}}
+depot_url = "{{cfg.depot_url}}"
+{{~else}}
+depot_url = "{{bind.depot.first.cfg.url}}/depot"
+{{~/if}}
+
 {{~#eachAlive bind.router.members as |member|}}
 [[routers]]
 host = "{{member.sys.ip}}"

--- a/components/builder-scheduler/habitat/default.toml
+++ b/components/builder-scheduler/habitat/default.toml
@@ -1,3 +1,6 @@
+auth_token = ""
+promote_channel = "unstable"
+
 [datastore]
 user = "hab"
 password = ""

--- a/components/builder-scheduler/habitat/plan.sh
+++ b/components/builder-scheduler/habitat/plan.sh
@@ -11,6 +11,7 @@ pkg_build_deps=(core/protobuf core/protobuf-rust core/coreutils core/cacerts
 pkg_binds=(
   [router]="port heartbeat"
   [datastore]="port"
+  [depot]="url"
 )
 bin="bldr-scheduler"
 pkg_svc_run="$bin start -c ${pkg_svc_config_path}/config.toml"

--- a/components/builder-scheduler/src/config.rs
+++ b/components/builder-scheduler/src/config.rs
@@ -40,7 +40,10 @@ pub struct Config {
     pub log_path: PathBuf,
     /// List of net addresses for routing servers to connect to
     pub routers: Vec<RouterAddr>,
+    /// Configuration for the DB to connect to
     pub datastore: DataStoreCfg,
+    /// Channel to auto-promote successful groups to
+    pub promote_channel: String,
 }
 
 impl Default for Config {
@@ -56,6 +59,7 @@ impl Default for Config {
             log_path: PathBuf::from("/tmp"),
             routers: vec![RouterAddr::default()],
             datastore: datastore,
+            promote_channel: String::from("unstable"),
         }
     }
 }
@@ -91,6 +95,7 @@ mod tests {
         let content = r#"
         auth_token = "mytoken"
         depot_url = "mydepot"
+        promote_channel = "foo"
         shards = [
             0
         ]
@@ -114,6 +119,7 @@ mod tests {
         let config = Config::from_raw(&content).unwrap();
         assert_eq!(&config.auth_token, "mytoken");
         assert_eq!(&config.depot_url, "mydepot");
+        assert_eq!(&config.promote_channel, "foo");
         assert_eq!(config.datastore.port, 9000);
         assert_eq!(config.datastore.user, "test");
         assert_eq!(config.datastore.database, "test_scheduler");
@@ -134,5 +140,6 @@ mod tests {
         let config = Config::from_raw(&content).unwrap();
         assert_eq!(config.worker_threads, 0);
         assert_eq!(&config.auth_token, "");
+        assert_eq!(&config.promote_channel, "unstable");
     }
 }


### PR DESCRIPTION
Update to add configuration to builder for channel to auto-promote to.  By default, it is set to 'unstable' (which essentially is a no-op for promotion).

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-94459862](https://user-images.githubusercontent.com/13542112/28386695-3abf6a10-6c81-11e7-8b07-a7aef28634e0.gif)
