### PR TITLE
[sup] Introduce optional application environment qualifier on Service Group

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,6 +20,8 @@ environment:
   CARGO_HOME: "c:\\cargo"
   RUSTUP_HOME: "c:\\multirust"
   CARGO_TARGET_DIR: "c:\\projects\\habitat\\target"
+  RUSTUP_USE_HYPER: 1
+  CARGO_HTTP_CHECK_REVOKE: false
   HAB_WINDOWS_STUDIO: true
   HAB_AUTH_TOKEN:
     secure: il1kqjDtQSFOoD12nDaJhCBntC905Q8T9jRzyTZtqlJPxc3vCoS1bBeNbB55J82M

--- a/components/butterfly-test/src/lib.rs
+++ b/components/butterfly-test/src/lib.rs
@@ -468,7 +468,7 @@ impl SwimNet {
         let ident = PackageIdent::from_str(package).expect(
             "package needs to be a fully qualified package identifier",
         );
-        let sg = ServiceGroup::new(ident.name(), "prod", None).unwrap();
+        let sg = ServiceGroup::new(None, ident.name(), "prod", None).unwrap();
         let s = Service::new(
             self[member].member_id().to_string(),
             &ident,
@@ -483,7 +483,7 @@ impl SwimNet {
         let config_bytes: Vec<u8> = Vec::from(config);
         let s = ServiceConfig::new(
             self[member].member_id(),
-            ServiceGroup::new(service, "prod", None).unwrap(),
+            ServiceGroup::new(None, service, "prod", None).unwrap(),
             config_bytes,
         );
         self[member].insert_service_config(s);
@@ -493,7 +493,7 @@ impl SwimNet {
         let body_bytes: Vec<u8> = Vec::from(body);
         let s = ServiceFile::new(
             self[member].member_id(),
-            ServiceGroup::new(service, "prod", None).unwrap(),
+            ServiceGroup::new(None, service, "prod", None).unwrap(),
             filename,
             body_bytes,
         );
@@ -506,7 +506,7 @@ impl SwimNet {
     }
 
     pub fn add_election(&mut self, member: usize, service: &str) {
-        self[member].start_election(ServiceGroup::new(service, "prod", None).unwrap(), 0);
+        self[member].start_election(ServiceGroup::new(None, service, "prod", None).unwrap(), 0);
     }
 }
 

--- a/components/butterfly/src/rumor/election.rs
+++ b/components/butterfly/src/rumor/election.rs
@@ -294,7 +294,7 @@ mod tests {
     fn create_election(member_id: &str, suitability: u64) -> Election {
         Election::new(
             member_id,
-            ServiceGroup::new("tdep", "prod", None).unwrap(),
+            ServiceGroup::new(None, "tdep", "prod", None).unwrap(),
             suitability,
         )
     }

--- a/components/butterfly/src/rumor/service.rs
+++ b/components/butterfly/src/rumor/service.rs
@@ -173,7 +173,7 @@ mod tests {
 
     fn create_service(member_id: &str) -> Service {
         let pkg = PackageIdent::from_str("core/neurosis/1.2.3/20161208121212").unwrap();
-        let sg = ServiceGroup::new(pkg.name(), "production", None).unwrap();
+        let sg = ServiceGroup::new(None, pkg.name(), "production", None).unwrap();
         Service::new(member_id.to_string(), &pkg, &sg, &SysInfo::default(), None)
     }
 
@@ -259,7 +259,7 @@ mod tests {
     #[should_panic]
     fn service_package_name_mismatch() {
         let ident = PackageIdent::from_str("core/overwatch/1.2.3/20161208121212").unwrap();
-        let sg = ServiceGroup::new("counter-strike", "times", Some("ofgrace")).unwrap();
+        let sg = ServiceGroup::new(None, "counter-strike", "times", Some("ofgrace")).unwrap();
         Service::new(
             "bad-member".to_string(),
             &ident,

--- a/components/butterfly/src/rumor/service_config.rs
+++ b/components/butterfly/src/rumor/service_config.rs
@@ -179,7 +179,7 @@ mod tests {
         let config_bytes: Vec<u8> = Vec::from(config);
         ServiceConfig::new(
             member_id,
-            ServiceGroup::new("neurosis", "production", None).unwrap(),
+            ServiceGroup::new(None, "neurosis", "production", None).unwrap(),
             config_bytes,
         )
     }

--- a/components/butterfly/src/rumor/service_file.rs
+++ b/components/butterfly/src/rumor/service_file.rs
@@ -173,7 +173,7 @@ mod tests {
         let body_bytes: Vec<u8> = Vec::from(body);
         ServiceFile::new(
             member_id,
-            ServiceGroup::new("neurosis", "production", None).unwrap(),
+            ServiceGroup::new(None, "neurosis", "production", None).unwrap(),
             filename,
             body_bytes,
         )

--- a/components/butterfly/tests/rumor/service_config.rs
+++ b/components/butterfly/tests/rumor/service_config.rs
@@ -40,7 +40,7 @@ fn service_config_via_client() {
     let payload = Vec::from("I want to get lost in you, tokyo".as_bytes());
     client
         .send_service_config(
-            ServiceGroup::new("witcher", "prod", None).unwrap(),
+            ServiceGroup::new(None, "witcher", "prod", None).unwrap(),
             0,
             payload,
             false,

--- a/components/butterfly/tests/rumor/service_file.rs
+++ b/components/butterfly/tests/rumor/service_file.rs
@@ -45,7 +45,7 @@ fn service_file_via_client() {
     let payload = Vec::from("I want to get lost in you, tokyo".as_bytes());
     client
         .send_service_file(
-            ServiceGroup::new("witcher", "prod", None).unwrap(),
+            ServiceGroup::new(None, "witcher", "prod", None).unwrap(),
             "devil-wears-prada.txt",
             0,
             payload,

--- a/components/core/src/error.rs
+++ b/components/core/src/error.rs
@@ -85,6 +85,8 @@ pub enum Error {
     CryptUnprotectDataFailed(String),
     /// Occurs when a file that should exist does not or could not be read.
     FileNotFound(String),
+    /// Occurs when an application environment string cannot be successfully parsed.
+    InvalidApplicationEnvironment(String),
     /// Occurs when a package identifier string cannot be successfully parsed.
     InvalidPackageIdent(String),
     /// Occurs when a package target string cannot be successfully parsed.
@@ -261,6 +263,13 @@ impl fmt::Display for Error {
             Error::CryptProtectDataFailed(ref e) => format!("{}", e),
             Error::CryptUnprotectDataFailed(ref e) => format!("{}", e),
             Error::FileNotFound(ref e) => format!("File not found at: {}", e),
+            Error::InvalidApplicationEnvironment(ref e) => {
+                format!(
+                    "Invalid application environment: {}. A valid application environment string \
+                        is in the form application.environment (example: twitter.prod)",
+                    e
+                )
+            }
             Error::InvalidPackageIdent(ref e) => {
                 format!(
                     "Invalid package identifier: {:?}. A valid identifier is in the form \
@@ -404,6 +413,10 @@ impl error::Error for Error {
             Error::CryptProtectDataFailed(_) => "CryptProtectData failed",
             Error::CryptUnprotectDataFailed(_) => "CryptUnprotectData failed",
             Error::FileNotFound(_) => "File not found",
+            Error::InvalidApplicationEnvironment(_) => {
+                "Application environment strings must be in \
+                 application.environment format (example: twitter.prod)"
+            }
             Error::InvalidPackageIdent(_) => {
                 "Package identifiers must be in origin/name format (example: acme/redis)"
             }

--- a/components/core/src/service.rs
+++ b/components/core/src/service.rs
@@ -22,38 +22,60 @@ use regex::Regex;
 use error::{Error, Result};
 
 lazy_static! {
-    static ref FROM_STR_RE: Regex =
-        Regex::new(r"\A(?P<service>[^.]+)\.(?P<group>[^.@]+)(@(?P<organization>.+))?\z").unwrap();
+    static ref SG_FROM_STR_RE: Regex =
+        Regex::new(r"\A((?P<application_environment>[^#@]+)#)?(?P<service>[^#@.]+)\.(?P<group>[^#@.]+)(@(?P<organization>[^#@.]+))?\z").unwrap();
+
+    static ref AE_FROM_STR_RE: Regex =
+        Regex::new(r"\A(?P<application>[^#.@]+)\.(?P<environment>[^#.@]+)\z").unwrap();
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Deserialize, Serialize)]
 pub struct ServiceGroup(String);
 
 impl ServiceGroup {
-    pub fn new<S1, S2>(service: S1, group: S2, organization: Option<&str>) -> Result<Self>
+    pub fn new<S1, S2>(
+        app_env: Option<&ApplicationEnvironment>,
+        service: S1,
+        group: S2,
+        organization: Option<&str>,
+    ) -> Result<Self>
     where
         S1: AsRef<str>,
         S2: AsRef<str>,
     {
-        let formatted = Self::format(service, group, organization);
+        let formatted = Self::format(app_env, service, group, organization);
         Self::validate(&formatted)?;
         Ok(ServiceGroup(formatted))
     }
 
-    fn format<S1, S2>(service: S1, group: S2, organization: Option<&str>) -> String
+    fn format<S1, S2>(
+        app_env: Option<&ApplicationEnvironment>,
+        service: S1,
+        group: S2,
+        organization: Option<&str>,
+    ) -> String
     where
         S1: AsRef<str>,
         S2: AsRef<str>,
     {
-        if let Some(org) = organization {
-            format!("{}.{}@{}", service.as_ref(), group.as_ref(), org)
-        } else {
-            format!("{}.{}", service.as_ref(), group.as_ref())
+        match (app_env, organization) {
+            (Some(app_env), Some(org)) => {
+                format!(
+                    "{}#{}.{}@{}",
+                    app_env,
+                    service.as_ref(),
+                    group.as_ref(),
+                    org
+                )
+            }
+            (Some(app_env), None) => format!("{}#{}.{}", app_env, service.as_ref(), group.as_ref()),
+            (None, Some(org)) => format!("{}.{}@{}", service.as_ref(), group.as_ref(), org),
+            (None, None) => format!("{}.{}", service.as_ref(), group.as_ref()),
         }
     }
 
     pub fn validate(value: &str) -> Result<()> {
-        let caps = FROM_STR_RE.captures(value).ok_or(
+        let caps = SG_FROM_STR_RE.captures(value).ok_or(
             Error::InvalidServiceGroup(
                 value.to_string(),
             ),
@@ -67,8 +89,20 @@ impl ServiceGroup {
         Ok(())
     }
 
+    pub fn application_environment(&self) -> Option<ApplicationEnvironment> {
+        SG_FROM_STR_RE
+            .captures(&self.0)
+            .unwrap()
+            .name("application_environment")
+            .and_then(|v| {
+                Some(ApplicationEnvironment::from_str(v.as_str()).expect(
+                    "ApplicationEnvironment is valid and parses.",
+                ))
+            })
+    }
+
     pub fn service(&self) -> &str {
-        FROM_STR_RE
+        SG_FROM_STR_RE
             .captures(&self.0)
             .unwrap()
             .name("service")
@@ -77,7 +111,7 @@ impl ServiceGroup {
     }
 
     pub fn group(&self) -> &str {
-        FROM_STR_RE
+        SG_FROM_STR_RE
             .captures(&self.0)
             .unwrap()
             .name("group")
@@ -86,7 +120,7 @@ impl ServiceGroup {
     }
 
     pub fn org(&self) -> Option<&str> {
-        FROM_STR_RE
+        SG_FROM_STR_RE
             .captures(&self.0)
             .unwrap()
             .name("organization")
@@ -97,7 +131,12 @@ impl ServiceGroup {
     ///
     /// This is useful if the organization was lazily loaded or added after creation.
     pub fn set_org<T: AsRef<str>>(&mut self, org: T) {
-        self.0 = Self::format(self.service(), self.group(), Some(org.as_ref()));
+        self.0 = Self::format(
+            self.application_environment().as_ref(),
+            self.service(),
+            self.group(),
+            Some(org.as_ref()),
+        );
     }
 }
 
@@ -131,7 +170,7 @@ impl FromStr for ServiceGroup {
     type Err = Error;
 
     fn from_str(value: &str) -> result::Result<Self, Self::Err> {
-        let caps = match FROM_STR_RE.captures(value) {
+        let caps = match SG_FROM_STR_RE.captures(value) {
             Some(c) => c,
             None => return Err(Error::InvalidServiceGroup(value.to_string())),
         };
@@ -143,52 +182,274 @@ impl FromStr for ServiceGroup {
             Some(g) => g.as_str(),
             None => return Err(Error::InvalidServiceGroup(value.to_string())),
         };
+        let app_env = match caps.name("application_environment") {
+            Some(a) => Some(ApplicationEnvironment::from_str(a.as_str())?),
+            None => None,
+        };
         let org = match caps.name("organization") {
             Some(o) => Some(o.as_str()),
             None => None,
         };
-        Ok(ServiceGroup(ServiceGroup::format(service, group, org)))
+        Ok(ServiceGroup(
+            ServiceGroup::format(app_env.as_ref(), service, group, org),
+        ))
     }
 }
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Deserialize, Serialize)]
+pub struct ApplicationEnvironment(String);
+
+impl ApplicationEnvironment {
+    pub fn new<S1, S2>(app: S1, env: S2) -> Result<Self>
+    where
+        S1: AsRef<str>,
+        S2: AsRef<str>,
+    {
+        let formatted = Self::format(app, env);
+        Self::validate(&formatted)?;
+        Ok(ApplicationEnvironment(formatted))
+    }
+
+    fn format<S1, S2>(app: S1, env: S2) -> String
+    where
+        S1: AsRef<str>,
+        S2: AsRef<str>,
+    {
+        format!("{}.{}", app.as_ref(), env.as_ref())
+    }
+
+    pub fn validate(value: &str) -> Result<()> {
+        let caps = AE_FROM_STR_RE.captures(value).ok_or(
+            Error::InvalidApplicationEnvironment(value.to_string()),
+        )?;
+        if caps.name("application").is_none() {
+            return Err(Error::InvalidApplicationEnvironment(value.to_string()));
+        }
+        if caps.name("environment").is_none() {
+            return Err(Error::InvalidApplicationEnvironment(value.to_string()));
+        }
+        Ok(())
+    }
+
+    pub fn application(&self) -> &str {
+        AE_FROM_STR_RE
+            .captures(&self.0)
+            .unwrap()
+            .name("application")
+            .unwrap()
+            .as_str()
+    }
+
+    pub fn environment(&self) -> &str {
+        AE_FROM_STR_RE
+            .captures(&self.0)
+            .unwrap()
+            .name("environment")
+            .unwrap()
+            .as_str()
+    }
+}
+
+impl AsRef<str> for ApplicationEnvironment {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Deref for ApplicationEnvironment {
+    type Target = String;
+
+    fn deref(&self) -> &String {
+        &self.0
+    }
+}
+
+impl DerefMut for ApplicationEnvironment {
+    fn deref_mut(&mut self) -> &mut String {
+        &mut self.0
+    }
+}
+
+impl fmt::Display for ApplicationEnvironment {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl FromStr for ApplicationEnvironment {
+    type Err = Error;
+
+    fn from_str(value: &str) -> result::Result<Self, Self::Err> {
+        let caps = match AE_FROM_STR_RE.captures(value) {
+            Some(c) => c,
+            None => return Err(Error::InvalidApplicationEnvironment(value.to_string())),
+        };
+        let app = match caps.name("application") {
+            Some(s) => s.as_str(),
+            None => return Err(Error::InvalidApplicationEnvironment(value.to_string())),
+        };
+        let env = match caps.name("environment") {
+            Some(g) => g.as_str(),
+            None => return Err(Error::InvalidApplicationEnvironment(value.to_string())),
+        };
+        Ok(ApplicationEnvironment(
+            ApplicationEnvironment::format(app, env),
+        ))
+    }
+}
+
 
 #[cfg(test)]
 mod test {
     use std::str::FromStr;
 
-    use super::ServiceGroup;
+    use super::{ApplicationEnvironment, ServiceGroup};
 
     #[test]
-    fn service_groups_with_org() {
+    fn service_group_from_str_with_org() {
         let x = ServiceGroup::from_str("foo.bar").unwrap();
+        assert!(x.application_environment().is_none());
         assert_eq!(x.service(), "foo");
         assert_eq!(x.group(), "bar");
         assert!(x.org().is_none());
 
         let y = ServiceGroup::from_str("foo.bar@baz").unwrap();
+        assert!(x.application_environment().is_none());
         assert_eq!(y.service(), "foo");
         assert_eq!(y.group(), "bar");
-        assert_eq!(y.org().unwrap(), "baz");
+        assert_eq!(y.org(), Some("baz"));
 
-        assert!(ServiceGroup::from_str("foo.bar@").is_err());
-        assert!(ServiceGroup::from_str("f.oo.bar@baz").is_err());
         assert!(ServiceGroup::from_str("foo@baz").is_err());
     }
 
     #[test]
+    fn service_group_from_str_with_app() {
+        let x = ServiceGroup::from_str("oz.prod#foo.bar").unwrap();
+        assert_eq!(
+            x.application_environment(),
+            Some(ApplicationEnvironment::from_str("oz.prod").unwrap())
+        );
+        assert_eq!(x.service(), "foo");
+        assert_eq!(x.group(), "bar");
+        assert!(x.org().is_none());
+    }
+
+    #[test]
+    fn service_group_from_str_with_app_and_org() {
+        let x = ServiceGroup::from_str("oz.prod#foo.bar@baz").unwrap();
+        assert_eq!(
+            x.application_environment(),
+            Some(ApplicationEnvironment::from_str("oz.prod").unwrap())
+        );
+        assert_eq!(x.service(), "foo");
+        assert_eq!(x.group(), "bar");
+        assert_eq!(x.org(), Some("baz"));
+
+        assert!(ServiceGroup::from_str("f#o#o.bar@baz").is_err());
+    }
+
+    #[test]
+    #[should_panic(expected = "foo@baz")]
+    fn service_group_from_str_no_group() {
+        ServiceGroup::from_str("foo@baz").unwrap();
+    }
+
+    #[test]
     #[should_panic(expected = "not.allowed@")]
-    fn from_str_ending_with_at() {
+    fn service_group_from_str_ending_with_at() {
         ServiceGroup::from_str("not.allowed@").unwrap();
     }
 
     #[test]
     #[should_panic(expected = "only.one.period@allowed")]
-    fn from_str_too_many_periods() {
+    fn service_group_from_str_too_many_periods() {
         ServiceGroup::from_str("only.one.period@allowed").unwrap();
     }
 
     #[test]
+    #[should_panic(expected = "only#one#hash@allowed")]
+    fn service_group_from_str_too_many_hashes() {
+        ServiceGroup::from_str("only#one#hash@allowed").unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "#cool.wings@")]
+    fn service_group_from_str_start_with_hash_and_ending_with_at() {
+        ServiceGroup::from_str("#cool.wings@").unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "#hash.tag")]
+    fn service_group_from_str_starting_with_pound() {
+        ServiceGroup::from_str("#hash.tag").unwrap();
+    }
+
+    #[test]
     #[should_panic(expected = "oh-noes")]
-    fn from_str_not_enough_periods() {
+    fn service_group_from_str_not_enough_periods() {
         ServiceGroup::from_str("oh-noes").unwrap();
+    }
+
+    #[test]
+    fn application_environment_new() {
+        let x = ApplicationEnvironment::new("application", "environment").unwrap();
+        assert_eq!(x.application(), "application");
+        assert_eq!(x.environment(), "environment");
+        assert_eq!(x.as_str(), "application.environment");
+    }
+
+    #[test]
+    fn application_environment_from_str() {
+        let x = ApplicationEnvironment::from_str("foo.bar").unwrap();
+        assert_eq!(x.application(), "foo");
+        assert_eq!(x.environment(), "bar");
+    }
+
+    #[test]
+    #[should_panic(expected = "oh-noes")]
+    fn application_environment_from_str_missing_period() {
+        ApplicationEnvironment::from_str("oh-noes").unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "only.one.period.allowed")]
+    fn application_environment_from_str_too_many_periods() {
+        ApplicationEnvironment::from_str("only.one.period.allowed").unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "@not.allowed")]
+    fn application_environment_from_str_with_ats_front() {
+        ApplicationEnvironment::from_str("@not.allowed").unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "not.allowed@")]
+    fn application_environment_from_str_with_ats_end() {
+        ApplicationEnvironment::from_str("not.allowed@").unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "ats.not@allowed")]
+    fn application_environment_from_str_with_ats_middle() {
+        ApplicationEnvironment::from_str("ats.not@allowed").unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "#not.allowed")]
+    fn application_environment_from_str_with_hashes_front() {
+        ApplicationEnvironment::from_str("#not.allowed").unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "not.allowed#")]
+    fn application_environment_from_str_with_hashes_end() {
+        ApplicationEnvironment::from_str("not.allowed#").unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "hashes.not#allowed")]
+    fn application_environment_from_str_with_hashes_middle() {
+        ApplicationEnvironment::from_str("hashes.not#allowed").unwrap();
     }
 }

--- a/components/hab/plan.ps1
+++ b/components/hab/plan.ps1
@@ -35,7 +35,7 @@ function Invoke-Unpack {
 function Invoke-Build {
     Push-Location "$PLAN_CONTEXT"
     try {
-        cargo build --release
+        cargo build --release --verbose
         if($LASTEXITCODE -ne 0) {
             Write-Error "Cargo build failed!"
         }

--- a/components/sup/src/census.rs
+++ b/components/sup/src/census.rs
@@ -656,12 +656,12 @@ mod tests {
             Some("0.10.4"),
             Some("20170419115548"),
         );
-        let sg_one = ServiceGroup::new("shield", "one", None).unwrap();
+        let sg_one = ServiceGroup::new(None, "shield", "one", None).unwrap();
 
         let service_store: RumorStore<ServiceRumor> = RumorStore::default();
         let service_one =
             ServiceRumor::new("member-a".to_string(), &pg_id, &sg_one, &sys_info, None);
-        let sg_two = ServiceGroup::new("shield", "two", None).unwrap();
+        let sg_two = ServiceGroup::new(None, "shield", "two", None).unwrap();
         let service_two =
             ServiceRumor::new("member-b".to_string(), &pg_id, &sg_two, &sys_info, None);
         let service_three =

--- a/components/sup/src/http_gateway.rs
+++ b/components/sup/src/http_gateway.rs
@@ -25,7 +25,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::thread::{self, JoinHandle};
 
-use hcore::service::ServiceGroup;
+use hcore::service::{ApplicationEnvironment, ServiceGroup};
 use iron::prelude::*;
 use iron::{headers, status, typemap};
 use iron::modifiers::Header;
@@ -330,7 +330,19 @@ impl Into<status::Status> for HealthCheck {
 }
 
 fn build_service_group(req: &mut Request) -> Result<ServiceGroup> {
+    let app_env = match req.extensions.get::<Router>().unwrap().find(
+        "application_environment",
+    ) {
+        Some(s) => {
+            match ApplicationEnvironment::from_str(s) {
+                Ok(app_env) => Some(app_env),
+                Err(_) => None,
+            }
+        }
+        None => None,
+    };
     let sg = ServiceGroup::new(
+        app_env.as_ref(),
         req.extensions
             .get::<Router>()
             .unwrap()

--- a/components/sup/src/manager/service/hooks.rs
+++ b/components/sup/src/manager/service/hooks.rs
@@ -929,8 +929,9 @@ mod tests {
             InitHook::file_name()
         ));
         let mut hook_output = HookOutput::new(&stdout_log, &stderr_log);
-        let service_group =
-            ServiceGroup::new("dummy", "service", None).expect("couldn't create ServiceGroup");
+        let service_group = ServiceGroup::new(None, "dummy", "service", None).expect(
+            "couldn't create ServiceGroup",
+        );
 
         hook_output.stream_output::<InitHook>(&service_group, &mut child);
 

--- a/components/sup/src/manager/service/mod.rs
+++ b/components/sup/src/manager/service/mod.rs
@@ -111,7 +111,12 @@ impl Service {
         spec.validate(&package)?;
         let pkg = Pkg::from_install(package)?;
         let spec_file = manager_fs_cfg.specs_path.join(spec.file_name());
-        let service_group = ServiceGroup::new(&pkg.name, spec.group, organization)?;
+        let service_group = ServiceGroup::new(
+            spec.application_environment.as_ref(),
+            &pkg.name,
+            spec.group,
+            organization,
+        )?;
         let config_root = Self::config_root(&pkg, spec.config_from.as_ref());
         let hooks_root = Self::hooks_root(&pkg, spec.config_from.as_ref());
         Ok(Service {


### PR DESCRIPTION
This change adds a new optional qualifier to a Service Group string,
called an Application Environment. The printed representation of a
Service Group with Application Environment delimited with a hash
character and the application name and environment name are delimited
with a period character. For example, a Service Group containing an
application name "twitter" and environment name of "production" would
look like:

    twitter.production#redis.cache

The components of the Service Group are as follows:

        twitter   . production  #  redis  . cache
    |-application-|-environment-|-service-|-group-|

To load a service, 2 new options are added which are used together
(`--application/-a` and `--environment/-e`). For example:

    hab svc load core/redis \
      --group cache \
      --application twitter \
      --environment production
