### PR TITLE
Remove duplicate key field

### DIFF
--- a/components/builder-jobsrv/habitat/default.toml
+++ b/components/builder-jobsrv/habitat/default.toml
@@ -16,4 +16,3 @@ connection_timeout_sec = 3600
 
 [archive]
 backend = "local"
-local_dir = "/tmp"


### PR DESCRIPTION
We need to remove local_dir from default.toml since we have it defined in config.toml from an internal path, not cfg.  Currently we get a duplicate key error when starting up jobsrv.

Signed-off-by: Salim Alam <salam@chef.io>