### PR TITLE
Fix clippy warnings on components/core

### DIFF
--- a/components/core/src/channel.rs
+++ b/components/core/src/channel.rs
@@ -30,5 +30,5 @@ pub fn default() -> String {
     env::var(DEPOT_CHANNEL_ENVVAR)
         .ok()
         .and_then(|c| Some(c.to_string()))
-        .unwrap_or(STABLE_CHANNEL.to_string())
+        .unwrap_or_else(|| STABLE_CHANNEL.to_string())
 }

--- a/components/core/src/config.rs
+++ b/components/core/src/config.rs
@@ -47,7 +47,7 @@ pub trait ConfigFile: DeserializeOwned + Sized {
     }
 
     fn from_raw(raw: &str) -> Result<Self, Self::Error> {
-        let value = toml::from_str(&raw).map_err(|e| Error::ConfigFileSyntax(e))?;
+        let value = toml::from_str(raw).map_err(Error::ConfigFileSyntax)?;
         Ok(value)
     }
 }

--- a/components/core/src/crypto/hash.rs
+++ b/components/core/src/crypto/hash.rs
@@ -25,7 +25,7 @@ use error::Result;
 
 const BUF_SIZE: usize = 1024;
 
-/// Calculate the BLAKE2b hash of a file, return as a hex string
+/// Calculate the `BLAKE2b` hash of a file, return as a hex string
 /// digest size = 32 BYTES
 /// NOTE: the hashing is keyless
 pub fn hash_file<P>(filename: P) -> Result<String>

--- a/components/core/src/crypto/keys/box_key_pair.rs
+++ b/components/core/src/crypto/keys/box_key_pair.rs
@@ -138,7 +138,7 @@ impl BoxKeyPair {
         match all.len() {
             0 => {
                 let msg = format!("No revisions found for {} box key", name.as_ref());
-                return Err(Error::CryptoError(msg));
+                Err(Error::CryptoError(msg))
             }
             _ => Ok(all.remove(0)),
         }
@@ -255,7 +255,7 @@ impl BoxKeyPair {
         match box_::open(&ciphertext, &nonce, sender.public()?, receiver.secret()?) {
             Ok(v) => Ok(v),
             Err(_) => {
-                return Err(Error::CryptoError(
+                Err(Error::CryptoError(
                     "Secret key, public key, and nonce could not \
                                                     decrypt ciphertext"
                         .to_string(),
@@ -276,8 +276,8 @@ impl BoxKeyPair {
         debug!("secret box keyfile = {}", secret_keyfile.display());
 
         write_keypair_files(
-            KeyType::Box,
-            &name_with_rev,
+            &KeyType::Box,
+            name_with_rev,
             Some(&public_keyfile),
             Some(&base64::encode(&pk[..]).into_bytes()),
             Some(&secret_keyfile),
@@ -297,7 +297,7 @@ impl BoxKeyPair {
         match BoxPublicKey::from_slice(&bytes) {
             Some(sk) => Ok(sk),
             None => {
-                return Err(Error::CryptoError(format!(
+                Err(Error::CryptoError(format!(
                     "Can't read box public key for {}",
                     key_with_rev.as_ref()
                 )))
@@ -316,7 +316,7 @@ impl BoxKeyPair {
         match BoxSecretKey::from_slice(&bytes) {
             Some(sk) => Ok(sk),
             None => {
-                return Err(Error::CryptoError(format!(
+                Err(Error::CryptoError(format!(
                     "Can't read box secret key for {}",
                     key_with_rev.as_ref()
                 )))

--- a/components/core/src/crypto/keys/mod.rs
+++ b/components/core/src/crypto/keys/mod.rs
@@ -74,7 +74,7 @@ impl FromStr for PairType {
             "public" => Ok(PairType::Public),
             "secret" => Ok(PairType::Secret),
             _ => {
-                return Err(Error::CryptoError(
+                Err(Error::CryptoError(
                     format!("Invalid PairType conversion from {}", value),
                 ))
             }
@@ -136,7 +136,7 @@ impl<P, S> KeyPair<P, S> {
                     "Public key is required but not present for {}",
                     self.name_with_rev()
                 );
-                return Err(Error::CryptoError(msg));
+                Err(Error::CryptoError(msg))
             }
         }
     }
@@ -149,7 +149,7 @@ impl<P, S> KeyPair<P, S> {
                     "Secret key is required but not present for {}",
                     self.name_with_rev()
                 );
-                return Err(Error::CryptoError(msg));
+                Err(Error::CryptoError(msg))
             }
         }
     }
@@ -161,11 +161,11 @@ impl<P, S> KeyPair<P, S> {
 /// added to the set.
 fn check_filename(
     keyname: &str,
-    filename: String,
+    filename: &str,
     candidates: &mut HashSet<String>,
     pair_type: Option<&PairType>,
 ) {
-    let caps = match KEYFILE_RE.captures(&filename) {
+    let caps = match KEYFILE_RE.captures(filename) {
         Some(c) => c,
         None => {
             debug!("check_filename: Cannot parse {}", &filename);
@@ -210,21 +210,10 @@ fn check_filename(
 
         let do_insert = match pair_type {
             Some(&PairType::Secret) => {
-                if suffix == SECRET_SIG_KEY_SUFFIX || suffix == SECRET_BOX_KEY_SUFFIX ||
+                suffix == SECRET_SIG_KEY_SUFFIX || suffix == SECRET_BOX_KEY_SUFFIX ||
                     suffix == SECRET_SYM_KEY_SUFFIX
-                {
-                    true
-                } else {
-                    false
-                }
             }
-            Some(&PairType::Public) => {
-                if suffix == PUBLIC_KEY_SUFFIX {
-                    true
-                } else {
-                    false
-                }
-            }
+            Some(&PairType::Public) => suffix == PUBLIC_KEY_SUFFIX,
             None => true,
         };
 
@@ -235,7 +224,7 @@ fn check_filename(
 }
 
 /// Take a key name (ex "habitat"), and find all revisions of that
-/// keyname in the default_cache_key_path().
+/// keyname in the `default_cache_key_path()`.
 fn get_key_revisions<P>(
     keyname: &str,
     cache_key_path: P,
@@ -281,11 +270,11 @@ where
             Err(e) => {
                 // filename is still an OsString, so print it as debug output
                 debug!("Invalid filename {:?}", e);
-                return Err(Error::CryptoError(format!("Invalid filename in key path")));
+                return Err(Error::CryptoError("Invalid filename in key path".to_owned()));
             }
         };
         debug!("checking file: {}", &filename);
-        check_filename(keyname, filename, &mut candidates, pair_type);
+        check_filename(keyname, &filename, &mut candidates, pair_type);
     }
 
     // traverse the candidates set and sort the entries
@@ -321,7 +310,7 @@ fn mk_revision_string() -> Result<String> {
     // http://man7.org/linux/man-pages/man3/strftime.3.html
     match now.strftime("%Y%m%d%H%M%S") {
         Ok(result) => Ok(result.to_string()),
-        Err(_) => return Err(Error::CryptoError("Can't parse system time".to_string())),
+        Err(_) => Err(Error::CryptoError("Can't parse system time".to_string())),
     }
 }
 
@@ -370,7 +359,7 @@ pub fn is_valid_origin_name(name: &str) -> bool {
 fn read_key_bytes(keyfile: &Path) -> Result<Vec<u8>> {
     let mut f = File::open(keyfile)?;
     let mut s = String::new();
-    if f.read_to_string(&mut s)? <= 0 {
+    if f.read_to_string(&mut s)? == 0 {
         return Err(Error::CryptoError("Can't read key bytes".to_string()));
     }
     match s.lines().nth(3) {
@@ -393,7 +382,7 @@ fn read_key_bytes(keyfile: &Path) -> Result<Vec<u8>> {
 }
 
 fn write_keypair_files(
-    key_type: KeyType,
+    key_type: &KeyType,
     keyname: &str,
     public_keyfile: Option<&Path>,
     public_content: Option<&[u8]>,
@@ -401,7 +390,7 @@ fn write_keypair_files(
     secret_content: Option<&[u8]>,
 ) -> Result<()> {
     if let Some(public_keyfile) = public_keyfile {
-        let public_version = match key_type {
+        let public_version = match *key_type {
             KeyType::Sig => PUBLIC_SIG_KEY_VERSION,
             KeyType::Box => PUBLIC_BOX_KEY_VERSION,
             KeyType::Sym => unreachable!("Sym keys do not have a public key"),
@@ -434,7 +423,7 @@ fn write_keypair_files(
     }
 
     if let Some(secret_keyfile) = secret_keyfile {
-        let secret_version = match key_type {
+        let secret_version = match *key_type {
             KeyType::Sig => SECRET_SIG_KEY_VERSION,
             KeyType::Box => SECRET_BOX_KEY_VERSION,
             KeyType::Sym => SECRET_SYM_KEY_VERSION,

--- a/components/core/src/crypto/keys/sig_key_pair.rs
+++ b/components/core/src/crypto/keys/sig_key_pair.rs
@@ -64,8 +64,8 @@ impl SigKeyPair {
         debug!("secret sig keyfile = {}", secret_keyfile.display());
 
         write_keypair_files(
-            KeyType::Sig,
-            &name_with_rev,
+            &KeyType::Sig,
+            name_with_rev,
             Some(&public_keyfile),
             Some(&base64::encode(&pk[..]).into_bytes()),
             Some(&secret_keyfile),
@@ -144,7 +144,7 @@ impl SigKeyPair {
         match all.len() {
             0 => {
                 let msg = format!("No revisions found for {} sig key", name);
-                return Err(Error::CryptoError(msg));
+                Err(Error::CryptoError(msg))
             }
             _ => Ok(all.remove(0)),
         }
@@ -277,22 +277,22 @@ impl SigKeyPair {
         match pair_type {
             PairType::Public => {
                 write_keypair_files(
-                    KeyType::Sig,
+                    &KeyType::Sig,
                     &name_with_rev,
                     Some(&tmpfile.path),
-                    Some(&key_body.as_bytes()),
+                    Some(key_body.as_bytes()),
                     None,
                     None,
                 )?;
             }
             PairType::Secret => {
                 write_keypair_files(
-                    KeyType::Sig,
+                    &KeyType::Sig,
                     &name_with_rev,
                     None,
                     None,
                     Some(&tmpfile.path),
-                    Some(&key_body.as_bytes()),
+                    Some(key_body.as_bytes()),
                 )?;
             }
         }
@@ -444,7 +444,7 @@ impl SigKeyPair {
         match SigPublicKey::from_slice(&bytes) {
             Some(sk) => Ok(sk),
             None => {
-                return Err(Error::CryptoError(
+                Err(Error::CryptoError(
                     format!("Can't read sig public key for {}", key_with_rev),
                 ))
             }
@@ -457,7 +457,7 @@ impl SigKeyPair {
         match SigSecretKey::from_slice(&bytes) {
             Some(sk) => Ok(sk),
             None => {
-                return Err(Error::CryptoError(
+                Err(Error::CryptoError(
                     format!("Can't read sig secret key for {}", key_with_rev),
                 ))
             }

--- a/components/core/src/crypto/mod.rs
+++ b/components/core/src/crypto/mod.rs
@@ -137,7 +137,7 @@
 //! note unlike the format of keys, the compressed tarball is **not** Base64 encoded--it is the
 //! compressed tarball itself.
 //!
-//! Note that the BLAKE2b hash functions use a digest length of 32 bytes (256 bits!). More details
+//! Note that the `BLAKE2b` hash functions use a digest length of 32 bytes (256 bits!). More details
 //! about the hashing strategy can be found in the [libsodium hashing
 //! documentation](https://download.libsodium.org/doc/hashing/generic_hashing.html).
 //!
@@ -243,9 +243,9 @@ pub static SECRET_BOX_KEY_SUFFIX: &'static str = "box.key";
 /// The suffix on the end of a secret symmetric key file
 pub static SECRET_SYM_KEY_SUFFIX: &'static str = "sym.key";
 /// The hashing function we're using during sign/verify
-/// See also: https://download.libsodium.org/doc/hashing/generic_hashing.html
+/// See also: `https://download.libsodium.org/doc/hashing/generic_hashing.html`
 pub static SIG_HASH_TYPE: &'static str = "BLAKE2b";
-/// This environment variable allows you to override the fs::CACHE_KEY_PATH
+/// This environment variable allows you to override the `fs::CACHE_KEY_PATH`
 /// at runtime. This is useful for testing.
 pub static CACHE_KEY_PATH_ENV_VAR: &'static str = "HAB_CACHE_KEY_PATH";
 pub static HART_FORMAT_VERSION: &'static str = "HART-1";

--- a/components/core/src/error.rs
+++ b/components/core/src/error.rs
@@ -168,100 +168,109 @@ impl fmt::Display for Error {
                     e
                 )
             }
-            Error::ConfigInvalidArraySocketAddr(ref f) => {
+            Error::ConfigInvalidArraySocketAddr(f) => {
                 format!(
                     "Invalid array value of network address pair strings config, field={}. \
                          (example: [\"127.0.0.1:8080\", \"10.0.0.4:22\"])",
                     f
                 )
             }
-            Error::ConfigInvalidArrayTableString(ref f) => {
+            Error::ConfigInvalidArrayTableString(f) => {
                 format!(
                     "Invalid array value of tables containing string fields and values in \
                          config, field={}",
                     f
                 )
             }
-            Error::ConfigInvalidArrayTarget(ref f) => {
+            Error::ConfigInvalidArrayTarget(f) => {
                 format!(
                     "Invalid array value of targets containing string fields and values in \
                          config, field={}",
                     f
                 )
             }
-            Error::ConfigInvalidArrayU16(ref f) => {
+            Error::ConfigInvalidArrayU16(f) => {
                 format!(
                     "Invalid array value of u16 entries in config, field={}. (example: [1, 2])",
                     f
                 )
             }
-            Error::ConfigInvalidArrayU32(ref f) => {
+            Error::ConfigInvalidArrayU32(f) => {
                 format!(
                     "Invalid array value of u32 entries in config, field={}. (example: [1, 2])",
                     f
                 )
             }
-            Error::ConfigInvalidArrayU64(ref f) => {
+            Error::ConfigInvalidArrayU64(f) => {
                 format!(
                     "Invalid array value of u64 entries in config, field={}. (example: [1, 2])",
                     f
                 )
             }
-            Error::ConfigInvalidBool(ref f) => {
+            Error::ConfigInvalidBool(f) => {
                 format!(
                     "Invalid boolean value in config, field={}. (example: true)",
                     f
                 )
             }
-            Error::ConfigInvalidIdent(ref f) => {
+            Error::ConfigInvalidIdent(f) => {
                 format!(
                     "Invalid package identifier string value in config, field={}. (example: \
                          \"core/redis\")",
                     f
                 )
             }
-            Error::ConfigInvalidIpAddr(ref f) => {
+            Error::ConfigInvalidIpAddr(f) => {
                 format!(
                     "Invalid IP address string value in config, field={}. (example: \
                          \"127.0.0.0\")",
                     f
                 )
             }
-            Error::ConfigInvalidSocketAddr(ref f) => {
+            Error::ConfigInvalidSocketAddr(f) => {
                 format!(
                     "Invalid network address pair string value in config, field={}. (example: \
                          \"127.0.0.0:8080\")",
                     f
                 )
             }
-            Error::ConfigInvalidString(ref f) => {
+            Error::ConfigInvalidString(f) => {
                 format!("Invalid string value in config, field={}.", f)
             }
-            Error::ConfigInvalidTableString(ref f) => {
+            Error::ConfigInvalidTableString(f) => {
                 format!(
                     "Invalid table value of string fields and values in config, field={}",
                     f
                 )
             }
-            Error::ConfigInvalidTarget(ref f) => {
+            Error::ConfigInvalidTarget(f) => {
                 format!(
                     "Invalid package target string value in config, field={}. (example: \
                          \"x86_64-linux\")",
                     f
                 )
             }
-            Error::ConfigInvalidU16(ref f) => format!("Invalid u16 value in config, field={}", f),
-            Error::ConfigInvalidU32(ref f) => format!("Invalid u32 value in config, field={}", f),
-            Error::ConfigInvalidU64(ref f) => format!("Invalid u64 value in config, field={}", f),
-            Error::ConfigInvalidUsize(ref f) => {
-                format!("Invalid usize value in config, field={}", f)
-            }
+            Error::ConfigInvalidU16(f) => format!("Invalid u16 value in config, field={}", f),
+            Error::ConfigInvalidU32(f) => format!("Invalid u32 value in config, field={}", f),
+            Error::ConfigInvalidU64(f) => format!("Invalid u64 value in config, field={}", f),
+            Error::ConfigInvalidUsize(f) => format!("Invalid usize value in config, field={}", f),
             Error::CreateProcessAsUserFailed(ref e) => {
                 format!("Failure calling CreateProcessAsUserW: {:?}", e)
             }
             Error::CryptoError(ref e) => format!("Crypto error: {}", e),
-            Error::CryptProtectDataFailed(ref e) => format!("{}", e),
-            Error::CryptUnprotectDataFailed(ref e) => format!("{}", e),
+
+            Error::CryptProtectDataFailed(ref e) |
+            Error::OpenDesktopFailed(ref e) |
+            Error::PermissionFailed(ref e) |
+            Error::TargetMatchError(ref e) |
+            Error::UnameFailed(ref e) |
+            Error::WaitpidFailed(ref e) |
+            Error::GetExitCodeProcessFailed(ref e) |
+            Error::CreateToolhelp32SnapshotFailed(ref e) |
+            Error::WaitForSingleObjectFailed(ref e) |
+            Error::TerminateProcessFailed(ref e) |
+            Error::CryptUnprotectDataFailed(ref e) => e.to_owned(),
+
             Error::FileNotFound(ref e) => format!("File not found at: {}", e),
             Error::InvalidApplicationEnvironment(ref e) => {
                 format!(
@@ -295,20 +304,18 @@ impl fmt::Display for Error {
             }
             Error::IO(ref err) => format!("{}", err),
             Error::LogonTypeNotGranted => {
-                format!(
-                    "hab_svc_user user must possess the 'SE_SERVICE_LOGON_NAME' \
+                "hab_svc_user user must possess the 'SE_SERVICE_LOGON_NAME' \
                 account right to be spawned as a service by the supervisor"
-                )
+                    .to_owned()
             }
             Error::LogonUserFailed(ref e) => format!("Failure calling LogonUserW: {:?}", e),
-            Error::MetaFileBadBind => format!("Bad value parsed from BIND or BIND_OPTIONAL"),
+            Error::MetaFileBadBind => "Bad value parsed from BIND or BIND_OPTIONAL".to_owned(),
             Error::MetaFileMalformed(ref e) => {
                 format!("MetaFile: {:?}, didn't contain a valid UTF-8 string", e)
             }
             Error::MetaFileNotFound(ref e) => format!("Couldn't read MetaFile: {}, not found", e),
             Error::MetaFileIO(ref e) => format!("IO error while accessing MetaFile: {:?}", e),
-            Error::NoOutboundAddr => format!("Failed to discover this hosts outbound IP address"),
-            Error::OpenDesktopFailed(ref e) => format!("{}", e),
+            Error::NoOutboundAddr => "Failed to discover this hosts outbound IP address".to_owned(),
             Error::PackageNotFound(ref pkg) => {
                 if pkg.fully_qualified() {
                     format!("Cannot find package: {}", pkg)
@@ -317,27 +324,18 @@ impl fmt::Display for Error {
                 }
             }
             Error::ParseIntError(ref e) => format!("{}", e),
-            Error::PlanMalformed => format!("Failed to read or parse contents of Plan file"),
-            Error::PermissionFailed(ref e) => format!("{}", e),
+            Error::PlanMalformed => "Failed to read or parse contents of Plan file".to_owned(),
             Error::PrivilegeNotHeld => {
-                format!(
-                    "Current user must possess the 'SE_INCREASE_QUOTA_NAME' and \
+                "Current user must possess the 'SE_INCREASE_QUOTA_NAME' and \
                     'SE_ASSIGNPRIMARYTOKEN_NAME' privilege to spawn a new process as a different \
                     user"
-                )
+                    .to_owned()
             }
             Error::RegexParse(ref e) => format!("{}", e),
             Error::StringFromUtf8Error(ref e) => format!("{}", e),
-            Error::TargetMatchError(ref e) => format!("{}", e),
-            Error::UnameFailed(ref e) => format!("{}", e),
-            Error::WaitpidFailed(ref e) => format!("{}", e),
             Error::SignalFailed(ref r, ref e) => {
                 format!("Failed to send a signal to the child process: {}, {}", r, e)
             }
-            Error::GetExitCodeProcessFailed(ref e) => format!("{}", e),
-            Error::CreateToolhelp32SnapshotFailed(ref e) => format!("{}", e),
-            Error::WaitForSingleObjectFailed(ref e) => format!("{}", e),
-            Error::TerminateProcessFailed(ref e) => format!("{}", e),
             Error::Utf8Error(ref e) => format!("{}", e),
         };
         write!(f, "{}", msg)

--- a/components/core/src/event.rs
+++ b/components/core/src/event.rs
@@ -100,21 +100,21 @@ impl fmt::Display for Event {
     #[cfg_attr(rustfmt, rustfmt_skip)]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let msg = match *self {
-            Event::ProjectCreate { origin: _, package: _, account: _ } => "project-create",
-            Event::PackageUpload { origin: _, package: _, version: _, release: _, target: _, account: _ } => {
+            Event::ProjectCreate { .. } => "project-create",
+            Event::PackageUpload { .. } => {
                 "package-upload"
             }
-            Event::OriginKeyUpload { origin: _, version: _, account: _ } => "origin-key-upload",
-            Event::OriginSecretKeyUpload { origin: _, version: _, account: _ } => {
+            Event::OriginKeyUpload { .. } => "origin-key-upload",
+            Event::OriginSecretKeyUpload { .. } => {
                 "origin-secret-key-upload"
             }
-            Event::OriginInvitationSend { origin: _, user: _, id: _, account: _ } => {
+            Event::OriginInvitationSend { .. } => {
                 "origin-invitation-send"
             }
-            Event::OriginInvitationAccept { id: _, account: _ } => "origin-invitation-accept",
-            Event::OriginInvitationIgnore { id: _, account: _ } => "origin-invitation-ignore",
-            Event::JobCreate { package: _, account: _ } => "job-create",
-            Event::GithubAuthenticate { user: _, account: _ } => "github-authenticate",
+            Event::OriginInvitationAccept { .. } => "origin-invitation-accept",
+            Event::OriginInvitationIgnore { .. } => "origin-invitation-ignore",
+            Event::JobCreate { .. } => "job-create",
+            Event::GithubAuthenticate { .. } => "github-authenticate",
         };
 
         write!(f, "{}", msg)
@@ -174,13 +174,7 @@ impl Serialize for Event {
             Event::OriginInvitationAccept {
                 id: ref i,
                 account: ref a,
-            } => {
-                let mut strukt = serializer.serialize_struct("event", 3)?;
-                strukt.serialize_field("name", &self.to_string())?;
-                strukt.serialize_field("id", i)?;
-                strukt.serialize_field("account", a)?;
-                strukt
-            }
+            } |
             Event::OriginInvitationIgnore {
                 id: ref i,
                 account: ref a,
@@ -215,14 +209,7 @@ impl Serialize for Event {
                 origin: ref o,
                 version: ref v,
                 account: ref a,
-            } => {
-                let mut strukt = serializer.serialize_struct("event", 4)?;
-                strukt.serialize_field("name", &self.to_string())?;
-                strukt.serialize_field("origin", o)?;
-                strukt.serialize_field("version", v)?;
-                strukt.serialize_field("account", a)?;
-                strukt
-            }
+            } |
             Event::OriginSecretKeyUpload {
                 origin: ref o,
                 version: ref v,

--- a/components/core/src/lib.rs
+++ b/components/core/src/lib.rs
@@ -81,7 +81,7 @@ pub use os::users;
 
 lazy_static!{
     pub static ref PROGRAM_NAME: String = {
-        let arg0 = std::env::args().next().map(|p| PathBuf::from(p));
+        let arg0 = std::env::args().next().map(PathBuf::from);
         arg0.as_ref().and_then(|p| p.file_stem()).and_then(|p| p.to_str()).unwrap().to_string()
     };
 }

--- a/components/core/src/os/process/mod.rs
+++ b/components/core/src/os/process/mod.rs
@@ -57,7 +57,7 @@ impl From<i32> for Signal {
             4 => Signal::ILL,
             6 => Signal::ABRT,
             8 => Signal::FPE,
-            9 => Signal::KILL,
+            // 9 caught by _
             10 => Signal::USR1,
             11 => Signal::SEGV,
             12 => Signal::USR2,

--- a/components/core/src/os/system/mod.rs
+++ b/components/core/src/os/system/mod.rs
@@ -69,7 +69,7 @@ impl FromStr for Architecture {
         let architecture = value.trim().to_lowercase();
         match architecture.as_ref() {
             "x86_64" => Ok(Architecture::X86_64),
-            _ => return Err(Error::InvalidArchitecture(value.to_string())),
+            _ => Err(Error::InvalidArchitecture(value.to_string()))
         }
     }
 }
@@ -83,7 +83,7 @@ impl FromStr for Platform {
             "linux" => Ok(Platform::Linux),
             "windows" => Ok(Platform::Windows),
             "darwin" => Ok(Platform::Darwin),
-            _ => return Err(Error::InvalidPlatform(value.to_string())),
+            _ => Err(Error::InvalidPlatform(value.to_string()))
         }
     }
 }

--- a/components/core/src/os/users/linux.rs
+++ b/components/core/src/os/users/linux.rs
@@ -22,7 +22,7 @@ pub fn get_uid_by_name(owner: &str) -> Option<u32> {
 }
 
 pub fn get_gid_by_name(group: &str) -> Option<u32> {
-    linux_users::get_group_by_name(&group.as_ref()).map(|g| g.gid())
+    linux_users::get_group_by_name(group.as_ref()).map(|g| g.gid())
 }
 
 pub fn get_current_username() -> Option<String> {

--- a/components/core/src/package/archive.rs
+++ b/components/core/src/package/archive.rs
@@ -134,7 +134,7 @@ impl PackageArchive {
     pub fn exposes(&mut self) -> Result<Vec<u16>> {
         match self.read_metadata(MetaFile::Exposes) {
             Ok(Some(data)) => {
-                let ports: Vec<u16> = data.split(" ")
+                let ports: Vec<u16> = data.split(' ')
                     .filter_map(|port| port.parse::<u16>().ok())
                     .collect();
                 Ok(ports)
@@ -147,7 +147,7 @@ impl PackageArchive {
     pub fn ident(&mut self) -> Result<PackageIdent> {
         match self.read_metadata(MetaFile::Ident) {
             Ok(None) => Err(Error::MetaFileNotFound(MetaFile::Ident)),
-            Ok(Some(data)) => PackageIdent::from_str(&data),
+            Ok(Some(data)) => PackageIdent::from_str(data),
             Err(e) => Err(e),
         }
     }
@@ -184,7 +184,7 @@ impl PackageArchive {
     pub fn target(&mut self) -> Result<PackageTarget> {
         match self.read_metadata(MetaFile::Target) {
             Ok(None) => Err(Error::MetaFileNotFound(MetaFile::Target)),
-            Ok(Some(data)) => PackageTarget::from_str(&data),
+            Ok(Some(data)) => PackageTarget::from_str(data),
             Err(e) => Err(e),
         }
     }
@@ -215,7 +215,7 @@ impl PackageArchive {
     ///
     /// * If the package cannot be unpacked
     pub fn unpack(&self, fs_root_path: Option<&Path>) -> Result<()> {
-        let root = fs_root_path.unwrap_or(Path::new("/"));
+        let root = fs_root_path.unwrap_or_else(|| Path::new("/"));
         let tar_reader = artifact::get_archive_reader(&self.path)?;
         let mut builder = reader::Builder::new();
         builder.support_format(ReadFormat::Gnutar)?;

--- a/components/core/src/package/ident.rs
+++ b/components/core/src/package/ident.rs
@@ -162,7 +162,7 @@ impl FromStr for PackageIdent {
     type Err = Error;
 
     fn from_str(value: &str) -> result::Result<Self, Self::Err> {
-        let items: Vec<&str> = value.split("/").collect();
+        let items: Vec<&str> = value.split('/').collect();
         let (origin, name, ver, rel) = match items.len() {
             2 => (items[0], items[1], None, None),
             3 => (items[0], items[1], Some(items[2]), None),
@@ -324,11 +324,11 @@ pub fn version_sort(a_version: &str, b_version: &str) -> Result<Ordering> {
     // the plain digits who win.
     // 1.0.0-alpha1 vs 1.0.0
     if a_extension.is_some() && b_extension.is_none() {
-        return Ok(Ordering::Less);
+        Ok(Ordering::Less)
     } else if a_extension.is_none() && b_extension.is_some() {
-        return Ok(Ordering::Greater);
+        Ok(Ordering::Greater)
     } else if a_extension.is_none() && b_extension.is_none() {
-        return Ok(Ordering::Equal);
+        Ok(Ordering::Equal)
     } else {
         let a = match a_extension {
             Some(a) => a,
@@ -338,7 +338,7 @@ pub fn version_sort(a_version: &str, b_version: &str) -> Result<Ordering> {
             Some(b) => b,
             None => String::new(),
         };
-        return Ok(a.cmp(&b));
+        Ok(a.cmp(&b))
     }
 }
 

--- a/components/core/src/package/plan.rs
+++ b/components/core/src/package/plan.rs
@@ -34,7 +34,7 @@ impl Plan {
         let mut version: Option<String> = None;
         for line in bytes.lines() {
             if let Ok(line) = line {
-                let parts: Vec<&str> = line.splitn(2, "=").collect();
+                let parts: Vec<&str> = line.splitn(2, '=').collect();
                 match parts[0] {
                     "pkg_name" => name = Some(parts[1].to_string()),
                     "pkg_version" => version = Some(parts[1].to_string()),

--- a/components/core/src/package/target.rs
+++ b/components/core/src/package/target.rs
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#![cfg_attr(feature="clippy", allow(ifs_same_cond))]
 
 use std::fmt;
 use std::result;
@@ -25,7 +26,7 @@ pub trait Target: fmt::Display + Into<PackageTarget> {
 }
 
 /// Describes the platform (operating system/kernel)
-/// and architecture (x86_64, i386, etc..) that a package is built for
+/// and architecture (`x86_64`, `i386`, etc..) that a package is built for
 #[derive(Deserialize, Serialize, Eq, PartialEq, Debug, Clone, Hash)]
 pub struct PackageTarget {
     #[serde(deserialize_with = "deserialize_using_from_str",
@@ -107,7 +108,7 @@ impl FromStr for PackageTarget {
     type Err = Error;
 
     fn from_str(value: &str) -> result::Result<Self, Self::Err> {
-        let items: Vec<&str> = value.split("-").collect();
+        let items: Vec<&str> = value.split('-').collect();
         let (architecture, platform) = match items.len() {
             2 => {
                 (

--- a/components/core/src/service.rs
+++ b/components/core/src/service.rs
@@ -75,11 +75,9 @@ impl ServiceGroup {
     }
 
     pub fn validate(value: &str) -> Result<()> {
-        let caps = SG_FROM_STR_RE.captures(value).ok_or(
-            Error::InvalidServiceGroup(
-                value.to_string(),
-            ),
-        )?;
+        let caps = SG_FROM_STR_RE.captures(value).ok_or_else(|| {
+            Error::InvalidServiceGroup(value.to_string())
+        })?;
         if caps.name("service").is_none() {
             return Err(Error::InvalidServiceGroup(value.to_string()));
         }
@@ -219,9 +217,9 @@ impl ApplicationEnvironment {
     }
 
     pub fn validate(value: &str) -> Result<()> {
-        let caps = AE_FROM_STR_RE.captures(value).ok_or(
-            Error::InvalidApplicationEnvironment(value.to_string()),
-        )?;
+        let caps = AE_FROM_STR_RE.captures(value).ok_or_else(|| {
+            Error::InvalidApplicationEnvironment(value.to_string())
+        })?;
         if caps.name("application").is_none() {
             return Err(Error::InvalidApplicationEnvironment(value.to_string()));
         }

--- a/components/core/src/util/perm.rs
+++ b/components/core/src/util/perm.rs
@@ -26,7 +26,7 @@ pub fn set_owner<T: AsRef<Path>, X: AsRef<str>>(path: T, owner: X, group: X) -> 
         &owner.as_ref()
     );
 
-    let uid = match users::get_uid_by_name(&owner.as_ref()) {
+    let uid = match users::get_uid_by_name(owner.as_ref()) {
         Some(user) => user,
         None => {
             let msg = format!(
@@ -39,7 +39,7 @@ pub fn set_owner<T: AsRef<Path>, X: AsRef<str>>(path: T, owner: X, group: X) -> 
         }
     };
 
-    let gid = match users::get_gid_by_name(&group.as_ref()) {
+    let gid = match users::get_gid_by_name(group.as_ref()) {
         Some(group) => group,
         None => {
             let msg = format!(

--- a/components/core/src/util/sys.rs
+++ b/components/core/src/util/sys.rs
@@ -22,7 +22,7 @@ static GOOGLE_DNS: &'static str = "8.8.8.8:53";
 
 pub fn ip() -> Result<IpAddr> {
     let socket = UdpSocket::bind("0.0.0.0:0")?;
-    let _ = socket.connect(GOOGLE_DNS)?;
+    socket.connect(GOOGLE_DNS)?;
     let addr = socket.local_addr()?;
     Ok(addr.ip())
 }


### PR DESCRIPTION
doc_markdown fixes
Fix needless_returns
Replace potentially confusing if tree with match (also fixes collapsible_if)
Fix unneeded_fields
Fix redundant_closures
Fix needless_borrows
Fix let_unit_values
Fix absurd extreme comparisons
Fix needless_pass_by_values
Fix needless bools
Fix needless_borrows
Fix a needless borrow and needless format!s to to_owned
Fix match_same_arms
Fix single_matches
Fix single_char patterns
Fix or_fun_calls
Fix explicit_iter_loops
Fix len_zero
Fix ptr_args
Remove unneeded clones (fixes clone double ref)
Allow ifs_same_cond in target.rs
Fix single_char_pattern
Fix redundant closures

Signed-off-by: Vesa Kaihlavirta <vk@discord.tech>