### PR TITLE
Set spec watcher back to 100ms poll

### DIFF
--- a/components/sup/src/manager/spec_watcher.rs
+++ b/components/sup/src/manager/spec_watcher.rs
@@ -661,7 +661,7 @@ mod test {
         active_specs: HashMap<String, ServiceSpec>,
     ) -> Vec<SpecWatcherEvent> {
         let start = Instant::now();
-        let timeout = Duration::from_millis(1000);
+        let timeout = Duration::from_millis(100);
         while start.elapsed() < timeout {
             let events = watcher.new_events(active_specs.clone()).unwrap();
             if !events.is_empty() {


### PR DESCRIPTION
It looks like we had accidentally set the spec watcher back to a
1_000ms poll (1 second) from 100ms. This will revert that change
which appears to have been accidental

/cc @christophermaier I think this came through in an unrelated PR from you. Did you mean to change this?