### PR TITLE
accommodate _DIRS with multiple paths on windows

### DIFF
--- a/components/plan-build-ps1/bin/hab-plan-build.ps1
+++ b/components/plan-build-ps1/bin/hab-plan-build.ps1
@@ -653,12 +653,16 @@ function _Add-Paths($fromFile) {
     if (Test-Path "$dep_path/$fromFile") {
       Push-Location $originalPath
       try {
-        $data = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath((Get-Content "$dep_path/$fromFile").Trim())
-        if (!$path_part) {
-          $path_part = $data
-        }
-        else {
-          $path_part += ";$data"
+        $paths = (Get-Content "$dep_path/$fromFile").Trim().Split(";")
+
+        foreach($path in  $paths) {
+            $data = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($path)
+            if (!$path_part) {
+            $path_part = $data
+            }
+            else {
+            $path_part += ";$data"
+            }
         }
       }
       finally { Pop-Location }
@@ -697,6 +701,8 @@ function _Set-Path {
   }
 
   Write-BuildLine "Setting PATH=$env:PATH"
+  Write-BuildLine "Setting LIB=$env:LIB"
+  Write-BuildLine "Setting INCLUDE=$env:INCLUDE"
 }
 
 function _Get-SHA256Converter {


### PR DESCRIPTION
The current windows hab_plan script does not correctly resolve all paths if `bin`, `lib` or `include` have multiple paths. Only the first is fully resolved to a windows cannonical absolute path (eg c:\hab\...). The remainder stay in their raw format (eg /hab/...). Some tools will not find the later path resulting in failed builds.

Signed-off-by: Matt Wrock <matt@mattwrock.com>