### PR TITLE
Fix hook compilation and Run hook copying

### DIFF
--- a/components/core/src/crypto/hash.rs
+++ b/components/core/src/crypto/hash.rs
@@ -28,7 +28,10 @@ const BUF_SIZE: usize = 1024;
 /// Calculate the BLAKE2b hash of a file, return as a hex string
 /// digest size = 32 BYTES
 /// NOTE: the hashing is keyless
-pub fn hash_file<P: AsRef<Path>>(filename: &P) -> Result<String> {
+pub fn hash_file<P>(filename: P) -> Result<String>
+where
+    P: AsRef<Path>,
+{
     let file = File::open(filename.as_ref())?;
     let mut reader = BufReader::new(file);
     hash_reader(&mut reader)

--- a/components/sup/tests/utils/test_butterfly.rs
+++ b/components/sup/tests/utils/test_butterfly.rs
@@ -79,7 +79,7 @@ impl Client {
         let incarnation = Self::new_incarnation();
         self.butterfly_client
             .send_service_config(
-                ServiceGroup::new(&self.package_name, &self.service_group, None).unwrap(),
+                ServiceGroup::new(None, &self.package_name, &self.service_group, None).unwrap(),
                 incarnation,
                 payload,
                 false,

--- a/components/sup/tests/utils/test_sup.rs
+++ b/components/sup/tests/utils/test_sup.rs
@@ -72,7 +72,7 @@ fn unclaimed_port(tries: u16) -> u16 {
     }
     let p = random_port();
     match TcpListener::bind(format!("127.0.0.1:{}", p)) {
-        Ok(listener) => {
+        Ok(_listener) => {
             // The system hasn't bound it. Now we make sure none of
             // our other tests have bound it.
             let mut ports = CLAIMED_PORTS.lock().unwrap();
@@ -80,15 +80,14 @@ fn unclaimed_port(tries: u16) -> u16 {
                 // Oops, another test is using it, try again
                 thread::sleep(Duration::from_millis(500));
                 unclaimed_port(tries - 1)
-            }
-            else {
+            } else {
                 // Nobody was using it. Return the port; the TcpListener
                 // that is currently bound to the port will be dropped,
                 // thus freeing the port for our use.
                 ports.insert(p);
                 p
             }
-        },
+        }
         Err(_) => {
             // port already in use, try again
             unclaimed_port(tries - 1)
@@ -116,7 +115,8 @@ fn random_port() -> u16 {
 ///    /home/me/habitat/target/debug/hab-sup
 ///
 fn find_exe<B>(binary_name: B) -> PathBuf
-    where B: AsRef<Path>
+where
+    B: AsRef<Path>,
 {
     let exe_root = env::current_exe()
         .unwrap()
@@ -128,7 +128,11 @@ fn find_exe<B>(binary_name: B) -> PathBuf
     let bin = exe_root.join(binary_name.as_ref());
     assert!(
         bin.exists(),
-        format!("Expected to find a {:?} executable at {:?}", binary_name.as_ref(), bin)
+        format!(
+            "Expected to find a {:?} executable at {:?}",
+            binary_name.as_ref(),
+            bin
+        )
     );
     bin
 }


### PR DESCRIPTION
* Render all hooks even if one fails to render
* Always copy run hook if missing. This fixes a case where `pkg_svc_run`
  was set to generate a run hook and the hook wouldn't be copied

![tenor-45344881](https://user-images.githubusercontent.com/54036/28537705-ad60aa42-7060-11e7-8686-6e24783ae962.gif)
