### PR TITLE
[studio] Kill Launcher process when shutting down Studio.

### DIFF
--- a/components/studio/libexec/hab-studio-type-default.sh
+++ b/components/studio/libexec/hab-studio-type-default.sh
@@ -119,6 +119,7 @@ sup-run() {
   echo "--> Launching the Habitat Supervisor in the background..."
   echo "    Running: hab sup run \$*"
   hab sup run \$* > /hab/sup/default/sup.log &
+  echo \$! > /hab/sup/default/launch.pid
   echo "    * Use 'hab svc start' & 'hab svc stop' to start and stop services"
   echo "    * Use 'sup-log' to tail the Supervisor's output (Ctrl+c to stop)"
   echo "    * Use 'sup-term' to terminate the Supervisor"
@@ -131,13 +132,14 @@ sup-run() {
 }
 
 sup-term() {
-  if [ -f /hab/sup/default/LOCK ]; then
+  local pid_file="/hab/sup/default/launch.pid "
+  if [ -f \$pid_file ]; then
     echo "--> Killing Habitat Supervisor running in the background..."
-    kill \$(cat /hab/sup/default/LOCK) \\
-      && echo "    Supervisor killed." \\
+    kill \$(cat \$pid_file) \\
+      && (echo "    Supervisor killed." && rm -f \$pid_file)\\
       || echo "--> Error killing Supervisor."
   else
-    echo "--> No Supervisor lock file found, Supervisor may not be running."
+    echo "--> No Launcher pid file found, Supervisor may not be running."
   fi
 }
 


### PR DESCRIPTION
This change follows the introduction of the Launcher in the 0.26.0
release. Prior to this commit the Studio cleanup logic would attempt to
kill the Supevisor but with the introduction of the Launcher, this would
leave a `hab-launch` process behind and running in Linux Studios. With
this change, the process ID of the Launcher is recorded in a file and is
checked on Studio shutdown for which process to kill. As the Launcher is
now the parent process of the Supervisor, the full chain of processes
should terminate as expected.

When making this change, I made a couple of refactoring around the
`cleanup_studio()` function including extracting the 3 cleanup tasks
into their own functions and fixed on bug in `studio rm` where a local
variable `$v` was missing.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>