### PR TITLE
Auto update channel default

### DIFF
--- a/components/core/src/channel.rs
+++ b/components/core/src/channel.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use env;
+
 pub const UNSTABLE_CHANNEL: &'static str = "unstable";
 pub const STABLE_CHANNEL: &'static str = "stable";
 
@@ -21,4 +23,12 @@ pub const DEPOT_CHANNEL_ENVVAR: &'static str = "HAB_DEPOT_CHANNEL";
 /// Helper function for Builder dynamic channels
 pub fn bldr_channel_name(id: u64) -> String {
     format!("bldr-{}", id)
+}
+
+/// Return the default release channel to use
+pub fn default() -> String {
+    env::var(DEPOT_CHANNEL_ENVVAR)
+        .ok()
+        .and_then(|c| Some(c.to_string()))
+        .unwrap_or(STABLE_CHANNEL.to_string())
 }

--- a/components/sup/src/command/start.rs
+++ b/components/sup/src/command/start.rs
@@ -84,7 +84,7 @@ pub fn run(
             common::command::package::install::start(
                 &mut ui,
                 &spec.depot_url,
-                spec.channel.as_ref().map(String::as_ref),
+                Some(&spec.channel),
                 artifact,
                 PRODUCT,
                 VERSION,

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -116,7 +116,7 @@ pub struct ManagerConfig {
     pub auto_update: bool,
     pub eventsrv_group: Option<ServiceGroup>,
     pub update_url: String,
-    pub update_channel: Option<String>,
+    pub update_channel: String,
     pub gossip_listen: GossipListenAddr,
     pub http_listen: http_gateway::ListenAddr,
     pub gossip_peers: Vec<SocketAddr>,

--- a/components/sup/src/manager/self_updater.rs
+++ b/components/sup/src/manager/self_updater.rs
@@ -37,11 +37,11 @@ pub struct SelfUpdater {
     rx: Receiver<PackageInstall>,
     current: PackageIdent,
     update_url: String,
-    update_channel: Option<String>,
+    update_channel: String,
 }
 
 impl SelfUpdater {
-    pub fn new(current: PackageIdent, update_url: String, update_channel: Option<String>) -> Self {
+    pub fn new(current: PackageIdent, update_url: String, update_channel: String) -> Self {
         let rx = Self::init(current.clone(), &update_url, update_channel.clone());
         SelfUpdater {
             rx: rx,
@@ -54,7 +54,7 @@ impl SelfUpdater {
     fn init(
         current: PackageIdent,
         update_url: &str,
-        update_channel: Option<String>,
+        update_channel: String,
     ) -> Receiver<PackageInstall> {
         let (tx, rx) = sync_channel(0);
         let client = DepotClient::new(update_url, PRODUCT, VERSION, None).unwrap();
@@ -69,13 +69,13 @@ impl SelfUpdater {
         sender: SyncSender<PackageInstall>,
         current: PackageIdent,
         depot: DepotClient,
-        channel: Option<String>,
+        channel: String,
     ) {
         let spec_ident = PackageIdent::from_str(SUP_PKG_IDENT).unwrap();
         debug!("Self updater current package, {}", current);
         loop {
             let next_check = SteadyTime::now() + TimeDuration::milliseconds(update_frequency());
-            match depot.show_package(&spec_ident, channel.as_ref().map(String::as_ref)) {
+            match depot.show_package(&spec_ident, Some(&channel)) {
                 Ok(mut remote) => {
                     debug!("Self updater found remote, {}", remote.get_ident());
                     let latest: PackageIdent = remote.take_ident().into();

--- a/components/sup/src/manager/service/mod.rs
+++ b/components/sup/src/manager/service/mod.rs
@@ -71,7 +71,7 @@ lazy_static! {
 pub struct Service {
     pub service_group: ServiceGroup,
     pub depot_url: String,
-    pub channel: Option<String>,
+    pub channel: String,
     pub spec_file: PathBuf,
     pub spec_ident: PackageIdent,
     pub start_style: StartStyle,

--- a/components/sup/src/manager/service/spec.rs
+++ b/components/sup/src/manager/service/spec.rs
@@ -21,6 +21,7 @@ use std::path::{Path, PathBuf};
 use std::result;
 use std::str::FromStr;
 
+use hcore::channel::STABLE_CHANNEL;
 use hcore::package::{PackageIdent, PackageInstall};
 use hcore::service::{ApplicationEnvironment, ServiceGroup};
 use hcore::url::DEFAULT_DEPOT_URL;
@@ -97,7 +98,7 @@ pub struct ServiceSpec {
             skip_serializing_if = "Option::is_none")]
     pub application_environment: Option<ApplicationEnvironment>,
     pub depot_url: String,
-    pub channel: Option<String>,
+    pub channel: String,
     pub topology: Topology,
     pub update_strategy: UpdateStrategy,
     pub binds: Vec<ServiceBind>,
@@ -232,7 +233,7 @@ impl Default for ServiceSpec {
             group: DEFAULT_GROUP.to_string(),
             application_environment: None,
             depot_url: DEFAULT_DEPOT_URL.to_string(),
-            channel: None,
+            channel: STABLE_CHANNEL.to_string(),
             topology: Topology::default(),
             update_strategy: UpdateStrategy::default(),
             binds: Vec::default(),
@@ -481,7 +482,7 @@ mod test {
                     .unwrap(),
             ),
             depot_url: String::from("http://example.com/depot"),
-            channel: Some(String::from("stable")),
+            channel: String::from("unstable"),
             topology: Topology::Leader,
             update_strategy: UpdateStrategy::AtOnce,
             binds: vec![
@@ -503,7 +504,7 @@ mod test {
             r#"application_environment = "theinternet.preprod""#,
         ));
         assert!(toml.contains(r#"depot_url = "http://example.com/depot""#));
-        assert!(toml.contains(r#"channel = "stable""#));
+        assert!(toml.contains(r#"channel = "unstable""#));
         assert!(toml.contains(r#"topology = "leader""#));
         assert!(toml.contains(r#"update_strategy = "at-once""#));
         assert!(toml.contains(r#""cache:redis.cache@acmecorp""#));
@@ -570,6 +571,7 @@ mod test {
                 ServiceBind::from_str("db:postgres.app@acmecorp").unwrap(),
             ]
         );
+        assert_eq!(&spec.channel, "stable");
         assert_eq!(
             spec.config_from,
             Some(PathBuf::from("/only/for/development"))
@@ -638,7 +640,7 @@ mod test {
                     .unwrap(),
             ),
             depot_url: String::from("http://example.com/depot"),
-            channel: Some(String::from("stable")),
+            channel: String::from("unstable"),
             topology: Topology::Leader,
             update_strategy: UpdateStrategy::AtOnce,
             binds: vec![
@@ -661,7 +663,7 @@ mod test {
             r#"application_environment = "theinternet.preprod""#,
         ));
         assert!(toml.contains(r#"depot_url = "http://example.com/depot""#));
-        assert!(toml.contains(r#"channel = "stable""#));
+        assert!(toml.contains(r#"channel = "unstable""#));
         assert!(toml.contains(r#"topology = "leader""#));
         assert!(toml.contains(r#"update_strategy = "at-once""#));
         assert!(toml.contains(r#""cache:redis.cache@acmecorp""#));

--- a/components/sup/src/manager/service_updater.rs
+++ b/components/sup/src/manager/service_updater.rs
@@ -290,7 +290,7 @@ struct Worker {
     current: PackageIdent,
     spec_ident: PackageIdent,
     depot: depot_client::Client,
-    channel: Option<String>,
+    channel: String,
     update_strategy: UpdateStrategy,
     ui: UI,
 }
@@ -351,7 +351,7 @@ impl Worker {
             let mut package: Option<PackageInstall> = None;
             match self.depot.show_package(
                 &self.spec_ident,
-                self.channel.as_ref().map(String::as_ref),
+                Some(&self.channel),
             ) {
                 Ok(remote) => {
                     let latest: PackageIdent = remote.get_ident().clone().into();

--- a/components/sup/src/util/pkg.rs
+++ b/components/sup/src/util/pkg.rs
@@ -56,7 +56,7 @@ pub fn maybe_install_newer(
 ) -> Result<PackageInstall> {
     let latest_ident: PackageIdent = {
         let depot_client = Client::new(&spec.depot_url, PRODUCT, VERSION, None)?;
-        match depot_client.show_package(&spec.ident, spec.channel.as_ref().map(String::as_ref)) {
+        match depot_client.show_package(&spec.ident, Some(&spec.channel)) {
             Ok(pkg) => pkg.get_ident().clone().into(),
             Err(_) => return Ok(current),
         }
@@ -69,12 +69,7 @@ pub fn maybe_install_newer(
             latest_ident,
             spec.depot_url
         );
-        self::install(
-            ui,
-            &spec.depot_url,
-            &latest_ident,
-            spec.channel.as_ref().map(String::as_ref),
-        )
+        self::install(ui, &spec.depot_url, &latest_ident, Some(&spec.channel))
     } else {
         outputln!(
             "Confirmed latest version of {} is {}",
@@ -103,7 +98,7 @@ pub fn install_from_spec(ui: &mut UI, spec: &ServiceSpec) -> Result<PackageInsta
                 ui,
                 spec.depot_url.as_str(),
                 &spec.ident,
-                spec.channel.as_ref().map(String::as_ref),
+                Some(&spec.channel),
             )?)
         }
     }

--- a/terraform/instances.tf
+++ b/terraform/instances.tf
@@ -547,7 +547,7 @@ data "template_file" "hab_sup" {
   template = "${file("${path.module}/templates/hab-sup.service")}"
 
   vars {
-    flags               = "--listen-gossip 0.0.0.0:${var.gossip_listen_port} --listen-http 0.0.0.0:${var.http_listen_port}"
+    flags               = "--auto-update --channel ${var.release_channel} --events hab-eventsrv.default --listen-gossip 0.0.0.0:${var.gossip_listen_port} --listen-http 0.0.0.0:${var.http_listen_port}"
     gossip_listen_port  = "${var.gossip_listen_port}"
     peer_ip             = "${aws_instance.datastore.0.private_ip}"
     log_level           = "${var.log_level}"
@@ -558,7 +558,7 @@ data "template_file" "hab_sup_permanent" {
   template = "${file("${path.module}/templates/hab-sup.service")}"
 
   vars {
-    flags               = "--listen-gossip 0.0.0.0:${var.gossip_listen_port} --listen-http 0.0.0.0:${var.http_listen_port} --permanent-peer"
+    flags               = "--auto-update --channel ${var.release_channel} --events hab-eventsrv.default --listen-gossip 0.0.0.0:${var.gossip_listen_port} --listen-http 0.0.0.0:${var.http_listen_port} --permanent-peer"
     gossip_listen_port  = "${var.gossip_listen_port}"
     peer_ip             = "${aws_instance.datastore.0.private_ip}"
     log_level           = "${var.log_level}"
@@ -569,7 +569,7 @@ data "template_file" "hab_sup_seed" {
   template = "${file("${path.module}/templates/hab-sup.service")}"
 
   vars {
-    flags               = "--listen-gossip 0.0.0.0:${var.gossip_listen_port} --listen-http 0.0.0.0:${var.http_listen_port} --permanent-peer"
+    flags               = "--auto-update --channel ${var.release_channel} --events hab-eventsrv.default --listen-gossip 0.0.0.0:${var.gossip_listen_port} --listen-http 0.0.0.0:${var.http_listen_port} --permanent-peer"
     gossip_listen_port  = "${var.gossip_listen_port}"
     peer_ip             = "127.0.0.1"
     log_level           = "${var.log_level}"


### PR DESCRIPTION
This will resolve an issue where the new `--auto-update` flag was
incorrectly automatically retrieving updates from the unstable
channel by default. This change should additionally prevent mistakes
like this from escaping in the future by explicitly requiring a channel
and more clearly stating how our default channel is calculated.

![tenor-215320992](https://user-images.githubusercontent.com/54036/28549856-d945e11e-7091-11e7-93f6-cf42f74b1066.gif)
