### PR TITLE
call powershell with noninteractive flag

### DIFF
--- a/components/launcher/src/sys/windows/service.rs
+++ b/components/launcher/src/sys/windows/service.rs
@@ -124,7 +124,7 @@ pub fn run(mut msg: protocol::Spawn) -> Result<Service> {
     };
     match Child::spawn(
         "powershell.exe",
-        vec!["-command", ps_cmd.as_str()],
+        vec!["-NonInteractive", "-command", ps_cmd.as_str()],
         msg.get_env(),
         msg.get_svc_user(),
         password,

--- a/components/sup/src/sys/windows/exec.rs
+++ b/components/sup/src/sys/windows/exec.rs
@@ -25,7 +25,7 @@ where
     S: AsRef<OsStr>,
 {
     let ps_cmd = format!("iex $(gc {} | out-string)", path.as_ref().to_string_lossy());
-    let args = vec!["-command", ps_cmd.as_str()];
+    let args = vec!["-NonInteractive", "-command", ps_cmd.as_str()];
     Ok(Child::spawn(
         "powershell.exe",
         args,


### PR DESCRIPTION
This prepares us for when https://github.com/PowerShell/PowerShell/pull/4283 is released and powershell no longer hangs on supervisor stops. In the mean time https://github.com/habitat-sh/core-plans/pull/670 will patch powershell to achive this same behavior regardless of `-NonInteractive` being specified.

Signed-off-by: Matt Wrock <matt@mattwrock.com>