### PR TITLE
Implement "hab job start" command.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -708,8 +708,9 @@ dependencies = [
  "hyper-openssl 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -574,6 +574,7 @@ dependencies = [
  "clap 2.25.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy 0.0.144 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "habitat_api_client 0.0.0",
  "habitat_common 0.0.0",
  "habitat_core 0.0.0",
  "habitat_depot_client 0.0.0",
@@ -694,6 +695,22 @@ dependencies = [
  "protobuf 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "habitat_api_client"
+version = "0.0.0"
+dependencies = [
+ "clippy 0.0.144 (registry+https://github.com/rust-lang/crates.io-index)",
+ "habitat_core 0.0.0",
+ "habitat_http_client 0.0.0",
+ "hyper 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper-openssl 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
   "components/builder-admin",
   "components/builder-api",
+  "components/builder-api-client",
   "components/builder-core",
   "components/builder-db",
   "components/builder-depot",

--- a/components/builder-api-client/Cargo.toml
+++ b/components/builder-api-client/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "habitat_api_client"
+version = "0.0.0"
+authors = ["Josh Black <jblack@chef.io>"]
+build = "../bldr-build.rs"
+workspace = "../../"
+
+[dependencies]
+clippy = {version = "*", optional = true}
+hyper = "*"
+hyper-openssl = ""
+log = "*"
+regex = "*"
+serde = "*"
+serde_json = "*"
+url = "*"
+
+[dependencies.habitat_core]
+path = "../core"
+
+[dependencies.habitat_http_client]
+path = "../http-client"
+
+[features]
+default = []
+functional = []

--- a/components/builder-api-client/Cargo.toml
+++ b/components/builder-api-client/Cargo.toml
@@ -12,6 +12,7 @@ hyper-openssl = ""
 log = "*"
 regex = "*"
 serde = "*"
+serde_derive = "*"
 serde_json = "*"
 url = "*"
 

--- a/components/builder-api-client/src/error.rs
+++ b/components/builder-api-client/src/error.rs
@@ -18,6 +18,7 @@ use std::io;
 use std::result;
 
 use hyper;
+use serde_json;
 use url;
 
 use hab_http;
@@ -28,6 +29,7 @@ pub enum Error {
     HabitatHttpClient(hab_http::Error),
     HyperError(hyper::error::Error),
     IO(io::Error),
+    JSON(serde_json::Error),
     URL(url::ParseError),
 }
 
@@ -41,6 +43,7 @@ impl fmt::Display for Error {
             Error::HabitatHttpClient(ref e) => format!("{}", e),
             Error::HyperError(ref err) => format!("{}", err),
             Error::IO(ref e) => format!("{}", e),
+            Error::JSON(ref e) => format!("{}", e),
             Error::URL(ref e) => format!("{}", e),
         };
         write!(f, "{}", msg)
@@ -54,6 +57,7 @@ impl error::Error for Error {
             Error::HabitatHttpClient(ref err) => err.description(),
             Error::HyperError(ref err) => err.description(),
             Error::IO(ref err) => err.description(),
+            Error::JSON(ref err) => err.description(),
             Error::URL(ref err) => err.description(),
         }
     }

--- a/components/builder-api-client/src/error.rs
+++ b/components/builder-api-client/src/error.rs
@@ -1,0 +1,60 @@
+// Copyright (c) 2016-2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::error;
+use std::fmt;
+use std::io;
+use std::result;
+
+use hyper;
+use url;
+
+use hab_http;
+
+#[derive(Debug)]
+pub enum Error {
+    APIError(hyper::status::StatusCode, String),
+    HabitatHttpClient(hab_http::Error),
+    HyperError(hyper::error::Error),
+    IO(io::Error),
+    URL(url::ParseError),
+}
+
+pub type Result<T> = result::Result<T, Error>;
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let msg = match *self {
+            Error::APIError(ref c, ref m) if m.len() > 0 => format!("[{}] {}", c, m),
+            Error::APIError(ref c, _) => format!("[{}]", c),
+            Error::HabitatHttpClient(ref e) => format!("{}", e),
+            Error::HyperError(ref err) => format!("{}", err),
+            Error::IO(ref e) => format!("{}", e),
+            Error::URL(ref e) => format!("{}", e),
+        };
+        write!(f, "{}", msg)
+    }
+}
+
+impl error::Error for Error {
+    fn description(&self) -> &str {
+        match *self {
+            Error::APIError(_, _) => "Received a non-2XX response code from API",
+            Error::HabitatHttpClient(ref err) => err.description(),
+            Error::HyperError(ref err) => err.description(),
+            Error::IO(ref err) => err.description(),
+            Error::URL(ref err) => err.description(),
+        }
+    }
+}

--- a/components/builder-api-client/src/lib.rs
+++ b/components/builder-api-client/src/lib.rs
@@ -1,0 +1,117 @@
+// Copyright (c) 2016-2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![cfg_attr(feature="clippy", feature(plugin))]
+#![cfg_attr(feature="clippy", plugin(clippy))]
+
+extern crate habitat_http_client as hab_http;
+extern crate habitat_core as hab_core;
+extern crate hyper;
+extern crate hyper_openssl;
+#[macro_use]
+extern crate log;
+extern crate regex;
+extern crate serde;
+#[macro_use]
+extern crate serde_json;
+extern crate url;
+
+pub mod error;
+pub use error::{Error, Result};
+
+use std::io::Read;
+use std::path::Path;
+
+use hab_core::package::PackageIdent;
+use hab_http::ApiClient;
+use hyper::client::{IntoUrl, Response, RequestBuilder};
+use hyper::header::{Accept, Authorization, Bearer, ContentType};
+use hyper::status::StatusCode;
+use regex::Regex;
+
+pub struct Client(ApiClient);
+
+impl Client {
+    pub fn new<U>(
+        depot_url: U,
+        product: &str,
+        version: &str,
+        fs_root_path: Option<&Path>,
+    ) -> Result<Self>
+    where
+        U: IntoUrl,
+    {
+        let re = Regex::new(r"depot/?$").unwrap();
+        let mut url = depot_url.into_url().map_err(Error::URL)?;
+
+        if re.is_match(url.path()) {
+            let mut psm = url.path_segments_mut().unwrap();
+            psm.pop();
+        }
+
+        let api_url = url.as_str();
+
+        Ok(Client(
+            ApiClient::new(api_url, product, version, fs_root_path)
+                .map_err(Error::HabitatHttpClient)?,
+        ))
+    }
+
+    /// Create a job.
+    ///
+    /// # Failures
+    ///
+    /// * Remote API Server is not available
+    ///
+    /// # Panics
+    ///
+    /// * Authorization token was not set on client
+    pub fn create_job(&self, ident: &PackageIdent, token: &str) -> Result<()> {
+        debug!("Creating a job for {}", ident);
+
+        let body = json!({
+            "project_id": format!("{}", ident)
+        });
+
+        let sbody = serde_json::to_string(&body).unwrap();
+
+        let result = self.add_authz(self.0.post("jobs"), token)
+            .body(&sbody)
+            .header(Accept::json())
+            .header(ContentType::json())
+            .send();
+        match result {
+            Ok(Response { status: StatusCode::Created, .. }) => Ok(()),
+            Ok(mut response) => {
+                if response.status == StatusCode::Unauthorized {
+                    Err(Error::APIError(
+                        response.status,
+                        "Your GitHub token requires both user:email and read:org \
+                                         permissions."
+                            .to_string(),
+                    ))
+                } else {
+                    let mut s = String::new();
+                    response.read_to_string(&mut s).map_err(Error::IO)?;
+                    Err(Error::APIError(response.status, s))
+                }
+            }
+            Err(e) => Err(Error::HyperError(e)),
+        }
+    }
+
+    fn add_authz<'a>(&'a self, rb: RequestBuilder<'a>, token: &str) -> RequestBuilder {
+        rb.header(Authorization(Bearer { token: token.to_string() }))
+    }
+}

--- a/components/builder-api/doc/api.raml
+++ b/components/builder-api/doc/api.raml
@@ -365,6 +365,28 @@ securitySchemes:
                         description: |
                           Job does not exist with corresponding jobId,
                           or no log was found for the given job.
+/rdeps:
+    /{origin}:
+        /{name}:
+            get:
+                description: |
+                    Retrieves the list of reverse dependencies for this package.
+                responses:
+                    200:
+                        body:
+                            application/json:
+                                example: |
+                                    {
+                                        "origin": "core",
+                                        "name": "linux-headers",
+                                        "rdeps": [
+                                            "core/redis"
+                                        ]
+                                    }
+                    404:
+                        description: Package not found
+                    500:
+                        description: Internal server error
 /user:
     /invitations:
         get:

--- a/components/builder-api/src/http/handlers.rs
+++ b/components/builder-api/src/http/handlers.rs
@@ -117,7 +117,14 @@ pub fn job_create(req: &mut Request) -> IronResult<Response> {
     {
         match req.get::<bodyparser::Struct<JobCreateReq>>() {
             Ok(Some(body)) => project_get.set_name(body.project_id),
-            _ => return Ok(Response::with(status::UnprocessableEntity)),
+            Ok(None) => {
+                debug!("The request body was empty");
+                return Ok(Response::with(status::UnprocessableEntity));
+            }
+            Err(body) => {
+                debug!("The request body was malformed: {:?}", &body);
+                return Ok(Response::with(status::UnprocessableEntity));
+            }
         }
     }
     // TODO: SA - Eliminate need to clone the session
@@ -143,7 +150,10 @@ pub fn job_create(req: &mut Request) -> IronResult<Response> {
             );
             Ok(render_json(status::Created, &job))
         }
-        Err(err) => Ok(render_net_error(&err)),
+        Err(err) => {
+            debug!("Error creating job: {:?}", &err);
+            Ok(render_net_error(&err))
+        }
     }
 }
 

--- a/components/builder-api/src/http/mod.rs
+++ b/components/builder-api/src/http/mod.rs
@@ -47,6 +47,7 @@ pub fn router(config: Arc<Config>) -> Result<Chain> {
         jobs: post "/jobs" => XHandler::new(job_create).before(basic.clone()),
         job: get "/jobs/:id" => job_show,
         job_log: get "/jobs/:id/log" => job_log,
+        rdeps: get "/rdeps/:origin/:name" => rdeps_show,
 
         user_invitations: get "/user/invitations" => {
             XHandler::new(list_account_invitations).before(basic.clone())

--- a/components/builder-jobsrv/src/server/handlers.rs
+++ b/components/builder-jobsrv/src/server/handlers.rs
@@ -32,15 +32,15 @@ pub fn job_create(
 ) -> Result<()> {
     let msg: proto::JobSpec = req.parse_msg()?;
     let mut job: proto::Job = msg.into();
-    state.datastore().create_job(&mut job)?;
+    let created_job = state.datastore().create_job(&mut job)?;
     debug!(
         "Job created: id={} owner_id={} state={:?}",
-        job.get_id(),
-        job.get_owner_id(),
-        job.get_state()
+        created_job.get_id(),
+        created_job.get_owner_id(),
+        created_job.get_state()
     );
     state.worker_mgr().notify_work()?;
-    req.reply_complete(sock, &job)?;
+    req.reply_complete(sock, &created_job)?;
     Ok(())
 }
 

--- a/components/builder-protocol/protocols/scheduler.proto
+++ b/components/builder-protocol/protocols/scheduler.proto
@@ -55,6 +55,17 @@ message PackageCreate {
   repeated string deps = 2;
 }
 
+message ReverseDependenciesGet {
+  optional string origin = 1;
+  optional string name = 2;
+}
+
+message ReverseDependencies {
+  optional string origin = 1;
+  optional string name = 2;
+  repeated string rdeps = 3;
+}
+
 message PackageStatsGet {
   optional string origin = 1;
 }

--- a/components/builder-protocol/src/message/scheduler.rs
+++ b/components/builder-protocol/src/message/scheduler.rs
@@ -1870,6 +1870,547 @@ impl ::protobuf::reflect::ProtobufValue for PackageCreate {
 }
 
 #[derive(PartialEq,Clone,Default)]
+pub struct ReverseDependenciesGet {
+    // message fields
+    origin: ::protobuf::SingularField<::std::string::String>,
+    name: ::protobuf::SingularField<::std::string::String>,
+    // special fields
+    unknown_fields: ::protobuf::UnknownFields,
+    cached_size: ::protobuf::CachedSize,
+}
+
+// see codegen.rs for the explanation why impl Sync explicitly
+unsafe impl ::std::marker::Sync for ReverseDependenciesGet {}
+
+impl ReverseDependenciesGet {
+    pub fn new() -> ReverseDependenciesGet {
+        ::std::default::Default::default()
+    }
+
+    pub fn default_instance() -> &'static ReverseDependenciesGet {
+        static mut instance: ::protobuf::lazy::Lazy<ReverseDependenciesGet> = ::protobuf::lazy::Lazy {
+            lock: ::protobuf::lazy::ONCE_INIT,
+            ptr: 0 as *const ReverseDependenciesGet,
+        };
+        unsafe {
+            instance.get(ReverseDependenciesGet::new)
+        }
+    }
+
+    // optional string origin = 1;
+
+    pub fn clear_origin(&mut self) {
+        self.origin.clear();
+    }
+
+    pub fn has_origin(&self) -> bool {
+        self.origin.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_origin(&mut self, v: ::std::string::String) {
+        self.origin = ::protobuf::SingularField::some(v);
+    }
+
+    // Mutable pointer to the field.
+    // If field is not initialized, it is initialized with default value first.
+    pub fn mut_origin(&mut self) -> &mut ::std::string::String {
+        if self.origin.is_none() {
+            self.origin.set_default();
+        }
+        self.origin.as_mut().unwrap()
+    }
+
+    // Take field
+    pub fn take_origin(&mut self) -> ::std::string::String {
+        self.origin.take().unwrap_or_else(|| ::std::string::String::new())
+    }
+
+    pub fn get_origin(&self) -> &str {
+        match self.origin.as_ref() {
+            Some(v) => &v,
+            None => "",
+        }
+    }
+
+    fn get_origin_for_reflect(&self) -> &::protobuf::SingularField<::std::string::String> {
+        &self.origin
+    }
+
+    fn mut_origin_for_reflect(&mut self) -> &mut ::protobuf::SingularField<::std::string::String> {
+        &mut self.origin
+    }
+
+    // optional string name = 2;
+
+    pub fn clear_name(&mut self) {
+        self.name.clear();
+    }
+
+    pub fn has_name(&self) -> bool {
+        self.name.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_name(&mut self, v: ::std::string::String) {
+        self.name = ::protobuf::SingularField::some(v);
+    }
+
+    // Mutable pointer to the field.
+    // If field is not initialized, it is initialized with default value first.
+    pub fn mut_name(&mut self) -> &mut ::std::string::String {
+        if self.name.is_none() {
+            self.name.set_default();
+        }
+        self.name.as_mut().unwrap()
+    }
+
+    // Take field
+    pub fn take_name(&mut self) -> ::std::string::String {
+        self.name.take().unwrap_or_else(|| ::std::string::String::new())
+    }
+
+    pub fn get_name(&self) -> &str {
+        match self.name.as_ref() {
+            Some(v) => &v,
+            None => "",
+        }
+    }
+
+    fn get_name_for_reflect(&self) -> &::protobuf::SingularField<::std::string::String> {
+        &self.name
+    }
+
+    fn mut_name_for_reflect(&mut self) -> &mut ::protobuf::SingularField<::std::string::String> {
+        &mut self.name
+    }
+}
+
+impl ::protobuf::Message for ReverseDependenciesGet {
+    fn is_initialized(&self) -> bool {
+        true
+    }
+
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
+            match field_number {
+                1 => {
+                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.origin)?;
+                },
+                2 => {
+                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.name)?;
+                },
+                _ => {
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
+                },
+            };
+        }
+        ::std::result::Result::Ok(())
+    }
+
+    // Compute sizes of nested messages
+    #[allow(unused_variables)]
+    fn compute_size(&self) -> u32 {
+        let mut my_size = 0;
+        if let Some(ref v) = self.origin.as_ref() {
+            my_size += ::protobuf::rt::string_size(1, &v);
+        }
+        if let Some(ref v) = self.name.as_ref() {
+            my_size += ::protobuf::rt::string_size(2, &v);
+        }
+        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
+        self.cached_size.set(my_size);
+        my_size
+    }
+
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+        if let Some(ref v) = self.origin.as_ref() {
+            os.write_string(1, &v)?;
+        }
+        if let Some(ref v) = self.name.as_ref() {
+            os.write_string(2, &v)?;
+        }
+        os.write_unknown_fields(self.get_unknown_fields())?;
+        ::std::result::Result::Ok(())
+    }
+
+    fn get_cached_size(&self) -> u32 {
+        self.cached_size.get()
+    }
+
+    fn get_unknown_fields(&self) -> &::protobuf::UnknownFields {
+        &self.unknown_fields
+    }
+
+    fn mut_unknown_fields(&mut self) -> &mut ::protobuf::UnknownFields {
+        &mut self.unknown_fields
+    }
+
+    fn as_any(&self) -> &::std::any::Any {
+        self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
+    }
+
+    fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
+        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+    }
+}
+
+impl ::protobuf::MessageStatic for ReverseDependenciesGet {
+    fn new() -> ReverseDependenciesGet {
+        ReverseDependenciesGet::new()
+    }
+
+    fn descriptor_static(_: ::std::option::Option<ReverseDependenciesGet>) -> &'static ::protobuf::reflect::MessageDescriptor {
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
+            lock: ::protobuf::lazy::ONCE_INIT,
+            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+        };
+        unsafe {
+            descriptor.get(|| {
+                let mut fields = ::std::vec::Vec::new();
+                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
+                    "origin",
+                    ReverseDependenciesGet::get_origin_for_reflect,
+                    ReverseDependenciesGet::mut_origin_for_reflect,
+                ));
+                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
+                    "name",
+                    ReverseDependenciesGet::get_name_for_reflect,
+                    ReverseDependenciesGet::mut_name_for_reflect,
+                ));
+                ::protobuf::reflect::MessageDescriptor::new::<ReverseDependenciesGet>(
+                    "ReverseDependenciesGet",
+                    fields,
+                    file_descriptor_proto()
+                )
+            })
+        }
+    }
+}
+
+impl ::protobuf::Clear for ReverseDependenciesGet {
+    fn clear(&mut self) {
+        self.clear_origin();
+        self.clear_name();
+        self.unknown_fields.clear();
+    }
+}
+
+impl ::std::fmt::Debug for ReverseDependenciesGet {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        ::protobuf::text_format::fmt(self, f)
+    }
+}
+
+impl ::protobuf::reflect::ProtobufValue for ReverseDependenciesGet {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Message(self)
+    }
+}
+
+#[derive(PartialEq,Clone,Default)]
+pub struct ReverseDependencies {
+    // message fields
+    origin: ::protobuf::SingularField<::std::string::String>,
+    name: ::protobuf::SingularField<::std::string::String>,
+    rdeps: ::protobuf::RepeatedField<::std::string::String>,
+    // special fields
+    unknown_fields: ::protobuf::UnknownFields,
+    cached_size: ::protobuf::CachedSize,
+}
+
+// see codegen.rs for the explanation why impl Sync explicitly
+unsafe impl ::std::marker::Sync for ReverseDependencies {}
+
+impl ReverseDependencies {
+    pub fn new() -> ReverseDependencies {
+        ::std::default::Default::default()
+    }
+
+    pub fn default_instance() -> &'static ReverseDependencies {
+        static mut instance: ::protobuf::lazy::Lazy<ReverseDependencies> = ::protobuf::lazy::Lazy {
+            lock: ::protobuf::lazy::ONCE_INIT,
+            ptr: 0 as *const ReverseDependencies,
+        };
+        unsafe {
+            instance.get(ReverseDependencies::new)
+        }
+    }
+
+    // optional string origin = 1;
+
+    pub fn clear_origin(&mut self) {
+        self.origin.clear();
+    }
+
+    pub fn has_origin(&self) -> bool {
+        self.origin.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_origin(&mut self, v: ::std::string::String) {
+        self.origin = ::protobuf::SingularField::some(v);
+    }
+
+    // Mutable pointer to the field.
+    // If field is not initialized, it is initialized with default value first.
+    pub fn mut_origin(&mut self) -> &mut ::std::string::String {
+        if self.origin.is_none() {
+            self.origin.set_default();
+        }
+        self.origin.as_mut().unwrap()
+    }
+
+    // Take field
+    pub fn take_origin(&mut self) -> ::std::string::String {
+        self.origin.take().unwrap_or_else(|| ::std::string::String::new())
+    }
+
+    pub fn get_origin(&self) -> &str {
+        match self.origin.as_ref() {
+            Some(v) => &v,
+            None => "",
+        }
+    }
+
+    fn get_origin_for_reflect(&self) -> &::protobuf::SingularField<::std::string::String> {
+        &self.origin
+    }
+
+    fn mut_origin_for_reflect(&mut self) -> &mut ::protobuf::SingularField<::std::string::String> {
+        &mut self.origin
+    }
+
+    // optional string name = 2;
+
+    pub fn clear_name(&mut self) {
+        self.name.clear();
+    }
+
+    pub fn has_name(&self) -> bool {
+        self.name.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_name(&mut self, v: ::std::string::String) {
+        self.name = ::protobuf::SingularField::some(v);
+    }
+
+    // Mutable pointer to the field.
+    // If field is not initialized, it is initialized with default value first.
+    pub fn mut_name(&mut self) -> &mut ::std::string::String {
+        if self.name.is_none() {
+            self.name.set_default();
+        }
+        self.name.as_mut().unwrap()
+    }
+
+    // Take field
+    pub fn take_name(&mut self) -> ::std::string::String {
+        self.name.take().unwrap_or_else(|| ::std::string::String::new())
+    }
+
+    pub fn get_name(&self) -> &str {
+        match self.name.as_ref() {
+            Some(v) => &v,
+            None => "",
+        }
+    }
+
+    fn get_name_for_reflect(&self) -> &::protobuf::SingularField<::std::string::String> {
+        &self.name
+    }
+
+    fn mut_name_for_reflect(&mut self) -> &mut ::protobuf::SingularField<::std::string::String> {
+        &mut self.name
+    }
+
+    // repeated string rdeps = 3;
+
+    pub fn clear_rdeps(&mut self) {
+        self.rdeps.clear();
+    }
+
+    // Param is passed by value, moved
+    pub fn set_rdeps(&mut self, v: ::protobuf::RepeatedField<::std::string::String>) {
+        self.rdeps = v;
+    }
+
+    // Mutable pointer to the field.
+    pub fn mut_rdeps(&mut self) -> &mut ::protobuf::RepeatedField<::std::string::String> {
+        &mut self.rdeps
+    }
+
+    // Take field
+    pub fn take_rdeps(&mut self) -> ::protobuf::RepeatedField<::std::string::String> {
+        ::std::mem::replace(&mut self.rdeps, ::protobuf::RepeatedField::new())
+    }
+
+    pub fn get_rdeps(&self) -> &[::std::string::String] {
+        &self.rdeps
+    }
+
+    fn get_rdeps_for_reflect(&self) -> &::protobuf::RepeatedField<::std::string::String> {
+        &self.rdeps
+    }
+
+    fn mut_rdeps_for_reflect(&mut self) -> &mut ::protobuf::RepeatedField<::std::string::String> {
+        &mut self.rdeps
+    }
+}
+
+impl ::protobuf::Message for ReverseDependencies {
+    fn is_initialized(&self) -> bool {
+        true
+    }
+
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
+            match field_number {
+                1 => {
+                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.origin)?;
+                },
+                2 => {
+                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.name)?;
+                },
+                3 => {
+                    ::protobuf::rt::read_repeated_string_into(wire_type, is, &mut self.rdeps)?;
+                },
+                _ => {
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
+                },
+            };
+        }
+        ::std::result::Result::Ok(())
+    }
+
+    // Compute sizes of nested messages
+    #[allow(unused_variables)]
+    fn compute_size(&self) -> u32 {
+        let mut my_size = 0;
+        if let Some(ref v) = self.origin.as_ref() {
+            my_size += ::protobuf::rt::string_size(1, &v);
+        }
+        if let Some(ref v) = self.name.as_ref() {
+            my_size += ::protobuf::rt::string_size(2, &v);
+        }
+        for value in &self.rdeps {
+            my_size += ::protobuf::rt::string_size(3, &value);
+        };
+        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
+        self.cached_size.set(my_size);
+        my_size
+    }
+
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+        if let Some(ref v) = self.origin.as_ref() {
+            os.write_string(1, &v)?;
+        }
+        if let Some(ref v) = self.name.as_ref() {
+            os.write_string(2, &v)?;
+        }
+        for v in &self.rdeps {
+            os.write_string(3, &v)?;
+        };
+        os.write_unknown_fields(self.get_unknown_fields())?;
+        ::std::result::Result::Ok(())
+    }
+
+    fn get_cached_size(&self) -> u32 {
+        self.cached_size.get()
+    }
+
+    fn get_unknown_fields(&self) -> &::protobuf::UnknownFields {
+        &self.unknown_fields
+    }
+
+    fn mut_unknown_fields(&mut self) -> &mut ::protobuf::UnknownFields {
+        &mut self.unknown_fields
+    }
+
+    fn as_any(&self) -> &::std::any::Any {
+        self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
+    }
+
+    fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
+        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+    }
+}
+
+impl ::protobuf::MessageStatic for ReverseDependencies {
+    fn new() -> ReverseDependencies {
+        ReverseDependencies::new()
+    }
+
+    fn descriptor_static(_: ::std::option::Option<ReverseDependencies>) -> &'static ::protobuf::reflect::MessageDescriptor {
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
+            lock: ::protobuf::lazy::ONCE_INIT,
+            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+        };
+        unsafe {
+            descriptor.get(|| {
+                let mut fields = ::std::vec::Vec::new();
+                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
+                    "origin",
+                    ReverseDependencies::get_origin_for_reflect,
+                    ReverseDependencies::mut_origin_for_reflect,
+                ));
+                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
+                    "name",
+                    ReverseDependencies::get_name_for_reflect,
+                    ReverseDependencies::mut_name_for_reflect,
+                ));
+                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
+                    "rdeps",
+                    ReverseDependencies::get_rdeps_for_reflect,
+                    ReverseDependencies::mut_rdeps_for_reflect,
+                ));
+                ::protobuf::reflect::MessageDescriptor::new::<ReverseDependencies>(
+                    "ReverseDependencies",
+                    fields,
+                    file_descriptor_proto()
+                )
+            })
+        }
+    }
+}
+
+impl ::protobuf::Clear for ReverseDependencies {
+    fn clear(&mut self) {
+        self.clear_origin();
+        self.clear_name();
+        self.clear_rdeps();
+        self.unknown_fields.clear();
+    }
+}
+
+impl ::std::fmt::Debug for ReverseDependencies {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        ::protobuf::text_format::fmt(self, f)
+    }
+}
+
+impl ::protobuf::reflect::ProtobufValue for ReverseDependencies {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Message(self)
+    }
+}
+
+#[derive(PartialEq,Clone,Default)]
 pub struct PackageStatsGet {
     // message fields
     origin: ::protobuf::SingularField<::std::string::String>,
@@ -2596,121 +3137,144 @@ static file_descriptor_proto_data: &'static [u8] = b"\
     (\tR\x04deps\"<\n\x10PackagePreCreate\x12\x14\n\x05ident\x18\x01\x20\x01\
     (\tR\x05ident\x12\x12\n\x04deps\x18\x02\x20\x03(\tR\x04deps\"9\n\rPackag\
     eCreate\x12\x14\n\x05ident\x18\x01\x20\x01(\tR\x05ident\x12\x12\n\x04dep\
-    s\x18\x02\x20\x03(\tR\x04deps\")\n\x0fPackageStatsGet\x12\x16\n\x06origi\
-    n\x18\x01\x20\x01(\tR\x06origin\"<\n\x0cPackageStats\x12\x14\n\x05plans\
-    \x18\x01\x20\x01(\x04R\x05plans\x12\x16\n\x06builds\x18\x02\x20\x01(\x04\
-    R\x06builds\"*\n\tJobStatus\x12\x1d\n\x03job\x18\x01\x20\x01(\x0b2\x0b.j\
-    obsrv.JobR\x03job*U\n\x0cProjectState\x12\x0e\n\nNotStarted\x10\0\x12\
-    \x0e\n\nInProgress\x10\x01\x12\x0b\n\x07Success\x10\x02\x12\x0b\n\x07Fai\
-    lure\x10\x03\x12\x0b\n\x07Skipped\x10\x04*D\n\nGroupState\x12\x0b\n\x07P\
-    ending\x10\0\x12\x0f\n\x0bDispatching\x10\x01\x12\x0c\n\x08Complete\x10\
-    \x02\x12\n\n\x06Failed\x10\x03J\x9c\x11\n\x06\x12\x04\0\0D\x01\n\x08\n\
-    \x01\x02\x12\x03\0\x08\x11\n\t\n\x02\x03\0\x12\x03\x01\x07\x1f\n\n\n\x02\
-    \x05\0\x12\x04\x03\0\t\x01\n\n\n\x03\x05\0\x01\x12\x03\x03\x05\x11\n\x0b\
-    \n\x04\x05\0\x02\0\x12\x03\x04\x02\x11\n\x0c\n\x05\x05\0\x02\0\x01\x12\
-    \x03\x04\x02\x0c\n\x0c\n\x05\x05\0\x02\0\x02\x12\x03\x04\x0f\x10\n\x0b\n\
-    \x04\x05\0\x02\x01\x12\x03\x05\x02\x11\n\x0c\n\x05\x05\0\x02\x01\x01\x12\
-    \x03\x05\x02\x0c\n\x0c\n\x05\x05\0\x02\x01\x02\x12\x03\x05\x0f\x10\n\x0b\
-    \n\x04\x05\0\x02\x02\x12\x03\x06\x02\x0e\n\x0c\n\x05\x05\0\x02\x02\x01\
-    \x12\x03\x06\x02\t\n\x0c\n\x05\x05\0\x02\x02\x02\x12\x03\x06\x0c\r\n\x0b\
-    \n\x04\x05\0\x02\x03\x12\x03\x07\x02\x0e\n\x0c\n\x05\x05\0\x02\x03\x01\
-    \x12\x03\x07\x02\t\n\x0c\n\x05\x05\0\x02\x03\x02\x12\x03\x07\x0c\r\n\x0b\
-    \n\x04\x05\0\x02\x04\x12\x03\x08\x02\x0e\n\x0c\n\x05\x05\0\x02\x04\x01\
-    \x12\x03\x08\x02\t\n\x0c\n\x05\x05\0\x02\x04\x02\x12\x03\x08\x0c\r\n\n\n\
-    \x02\x04\0\x12\x04\x0b\0\x10\x01\n\n\n\x03\x04\0\x01\x12\x03\x0b\x08\x0f\
-    \n\x0b\n\x04\x04\0\x02\0\x12\x03\x0c\x02\x1b\n\x0c\n\x05\x04\0\x02\0\x04\
-    \x12\x03\x0c\x02\n\n\x0c\n\x05\x04\0\x02\0\x05\x12\x03\x0c\x0b\x11\n\x0c\
-    \n\x05\x04\0\x02\0\x01\x12\x03\x0c\x12\x16\n\x0c\n\x05\x04\0\x02\0\x03\
-    \x12\x03\x0c\x19\x1a\n\x0b\n\x04\x04\0\x02\x01\x12\x03\r\x02\x1c\n\x0c\n\
-    \x05\x04\0\x02\x01\x04\x12\x03\r\x02\n\n\x0c\n\x05\x04\0\x02\x01\x05\x12\
-    \x03\r\x0b\x11\n\x0c\n\x05\x04\0\x02\x01\x01\x12\x03\r\x12\x17\n\x0c\n\
-    \x05\x04\0\x02\x01\x03\x12\x03\r\x1a\x1b\n\x0b\n\x04\x04\0\x02\x02\x12\
-    \x03\x0e\x02\"\n\x0c\n\x05\x04\0\x02\x02\x04\x12\x03\x0e\x02\n\n\x0c\n\
-    \x05\x04\0\x02\x02\x06\x12\x03\x0e\x0b\x17\n\x0c\n\x05\x04\0\x02\x02\x01\
-    \x12\x03\x0e\x18\x1d\n\x0c\n\x05\x04\0\x02\x02\x03\x12\x03\x0e\x20!\n\
-    \x0b\n\x04\x04\0\x02\x03\x12\x03\x0f\x02\x1d\n\x0c\n\x05\x04\0\x02\x03\
-    \x04\x12\x03\x0f\x02\n\n\x0c\n\x05\x04\0\x02\x03\x05\x12\x03\x0f\x0b\x11\
-    \n\x0c\n\x05\x04\0\x02\x03\x01\x12\x03\x0f\x12\x18\n\x0c\n\x05\x04\0\x02\
-    \x03\x03\x12\x03\x0f\x1b\x1c\n\n\n\x02\x05\x01\x12\x04\x12\0\x17\x01\n\n\
-    \n\x03\x05\x01\x01\x12\x03\x12\x05\x0f\n\x0b\n\x04\x05\x01\x02\0\x12\x03\
-    \x13\x02\x0e\n\x0c\n\x05\x05\x01\x02\0\x01\x12\x03\x13\x02\t\n\x0c\n\x05\
-    \x05\x01\x02\0\x02\x12\x03\x13\x0c\r\n\x0b\n\x04\x05\x01\x02\x01\x12\x03\
-    \x14\x02\x12\n\x0c\n\x05\x05\x01\x02\x01\x01\x12\x03\x14\x02\r\n\x0c\n\
-    \x05\x05\x01\x02\x01\x02\x12\x03\x14\x10\x11\n\x0b\n\x04\x05\x01\x02\x02\
-    \x12\x03\x15\x02\x0f\n\x0c\n\x05\x05\x01\x02\x02\x01\x12\x03\x15\x02\n\n\
-    \x0c\n\x05\x05\x01\x02\x02\x02\x12\x03\x15\r\x0e\n\x0b\n\x04\x05\x01\x02\
-    \x03\x12\x03\x16\x02\r\n\x0c\n\x05\x05\x01\x02\x03\x01\x12\x03\x16\x02\
-    \x08\n\x0c\n\x05\x05\x01\x02\x03\x02\x12\x03\x16\x0b\x0c\n\n\n\x02\x04\
-    \x01\x12\x04\x19\0\x1d\x01\n\n\n\x03\x04\x01\x01\x12\x03\x19\x08\x13\n\
-    \x0b\n\x04\x04\x01\x02\0\x12\x03\x1a\x02\x1d\n\x0c\n\x05\x04\x01\x02\0\
-    \x04\x12\x03\x1a\x02\n\n\x0c\n\x05\x04\x01\x02\0\x05\x12\x03\x1a\x0b\x11\
-    \n\x0c\n\x05\x04\x01\x02\0\x01\x12\x03\x1a\x12\x18\n\x0c\n\x05\x04\x01\
-    \x02\0\x03\x12\x03\x1a\x1b\x1c\n\x0b\n\x04\x04\x01\x02\x01\x12\x03\x1b\
-    \x02\x1e\n\x0c\n\x05\x04\x01\x02\x01\x04\x12\x03\x1b\x02\n\n\x0c\n\x05\
-    \x04\x01\x02\x01\x05\x12\x03\x1b\x0b\x11\n\x0c\n\x05\x04\x01\x02\x01\x01\
-    \x12\x03\x1b\x12\x19\n\x0c\n\x05\x04\x01\x02\x01\x03\x12\x03\x1b\x1c\x1d\
-    \n\x0b\n\x04\x04\x01\x02\x02\x12\x03\x1c\x02\x1e\n\x0c\n\x05\x04\x01\x02\
-    \x02\x04\x12\x03\x1c\x02\n\n\x0c\n\x05\x04\x01\x02\x02\x05\x12\x03\x1c\
-    \x0b\x0f\n\x0c\n\x05\x04\x01\x02\x02\x01\x12\x03\x1c\x10\x19\n\x0c\n\x05\
-    \x04\x01\x02\x02\x03\x12\x03\x1c\x1c\x1d\n\n\n\x02\x04\x02\x12\x04\x1f\0\
-    !\x01\n\n\n\x03\x04\x02\x01\x12\x03\x1f\x08\x10\n\x0b\n\x04\x04\x02\x02\
-    \0\x12\x03\x20\x02\x1f\n\x0c\n\x05\x04\x02\x02\0\x04\x12\x03\x20\x02\n\n\
-    \x0c\n\x05\x04\x02\x02\0\x05\x12\x03\x20\x0b\x11\n\x0c\n\x05\x04\x02\x02\
-    \0\x01\x12\x03\x20\x12\x1a\n\x0c\n\x05\x04\x02\x02\0\x03\x12\x03\x20\x1d\
-    \x1e\n\n\n\x02\x04\x03\x12\x04#\0(\x01\n\n\n\x03\x04\x03\x01\x12\x03#\
-    \x08\r\n\x0b\n\x04\x04\x03\x02\0\x12\x03$\x02\x19\n\x0c\n\x05\x04\x03\
-    \x02\0\x04\x12\x03$\x02\n\n\x0c\n\x05\x04\x03\x02\0\x05\x12\x03$\x0b\x11\
-    \n\x0c\n\x05\x04\x03\x02\0\x01\x12\x03$\x12\x14\n\x0c\n\x05\x04\x03\x02\
-    \0\x03\x12\x03$\x17\x18\n\x0b\n\x04\x04\x03\x02\x01\x12\x03%\x02\x20\n\
-    \x0c\n\x05\x04\x03\x02\x01\x04\x12\x03%\x02\n\n\x0c\n\x05\x04\x03\x02\
-    \x01\x06\x12\x03%\x0b\x15\n\x0c\n\x05\x04\x03\x02\x01\x01\x12\x03%\x16\
-    \x1b\n\x0c\n\x05\x04\x03\x02\x01\x03\x12\x03%\x1e\x1f\n\x0b\n\x04\x04\
-    \x03\x02\x02\x12\x03&\x02\x20\n\x0c\n\x05\x04\x03\x02\x02\x04\x12\x03&\
-    \x02\n\n\x0c\n\x05\x04\x03\x02\x02\x06\x12\x03&\x0b\x12\n\x0c\n\x05\x04\
-    \x03\x02\x02\x01\x12\x03&\x13\x1b\n\x0c\n\x05\x04\x03\x02\x02\x03\x12\
-    \x03&\x1e\x1f\n\x0b\n\x04\x04\x03\x02\x03\x12\x03'\x02!\n\x0c\n\x05\x04\
-    \x03\x02\x03\x04\x12\x03'\x02\n\n\x0c\n\x05\x04\x03\x02\x03\x05\x12\x03'\
-    \x0b\x11\n\x0c\n\x05\x04\x03\x02\x03\x01\x12\x03'\x12\x1c\n\x0c\n\x05\
-    \x04\x03\x02\x03\x03\x12\x03'\x1f\x20\n\n\n\x02\x04\x04\x12\x04*\0-\x01\
-    \n\n\n\x03\x04\x04\x01\x12\x03*\x08\x0f\n\x0b\n\x04\x04\x04\x02\0\x12\
-    \x03+\x02\x1c\n\x0c\n\x05\x04\x04\x02\0\x04\x12\x03+\x02\n\n\x0c\n\x05\
-    \x04\x04\x02\0\x05\x12\x03+\x0b\x11\n\x0c\n\x05\x04\x04\x02\0\x01\x12\
-    \x03+\x12\x17\n\x0c\n\x05\x04\x04\x02\0\x03\x12\x03+\x1a\x1b\n\x0b\n\x04\
-    \x04\x04\x02\x01\x12\x03,\x02\x1b\n\x0c\n\x05\x04\x04\x02\x01\x04\x12\
-    \x03,\x02\n\n\x0c\n\x05\x04\x04\x02\x01\x05\x12\x03,\x0b\x11\n\x0c\n\x05\
-    \x04\x04\x02\x01\x01\x12\x03,\x12\x16\n\x0c\n\x05\x04\x04\x02\x01\x03\
-    \x12\x03,\x19\x1a\n\n\n\x02\x04\x05\x12\x04/\02\x01\n\n\n\x03\x04\x05\
-    \x01\x12\x03/\x08\x18\n\x0b\n\x04\x04\x05\x02\0\x12\x030\x02\x1c\n\x0c\n\
-    \x05\x04\x05\x02\0\x04\x12\x030\x02\n\n\x0c\n\x05\x04\x05\x02\0\x05\x12\
-    \x030\x0b\x11\n\x0c\n\x05\x04\x05\x02\0\x01\x12\x030\x12\x17\n\x0c\n\x05\
-    \x04\x05\x02\0\x03\x12\x030\x1a\x1b\n\x0b\n\x04\x04\x05\x02\x01\x12\x031\
-    \x02\x1b\n\x0c\n\x05\x04\x05\x02\x01\x04\x12\x031\x02\n\n\x0c\n\x05\x04\
-    \x05\x02\x01\x05\x12\x031\x0b\x11\n\x0c\n\x05\x04\x05\x02\x01\x01\x12\
-    \x031\x12\x16\n\x0c\n\x05\x04\x05\x02\x01\x03\x12\x031\x19\x1a\n\n\n\x02\
-    \x04\x06\x12\x044\07\x01\n\n\n\x03\x04\x06\x01\x12\x034\x08\x15\n\x0b\n\
-    \x04\x04\x06\x02\0\x12\x035\x02\x1c\n\x0c\n\x05\x04\x06\x02\0\x04\x12\
-    \x035\x02\n\n\x0c\n\x05\x04\x06\x02\0\x05\x12\x035\x0b\x11\n\x0c\n\x05\
-    \x04\x06\x02\0\x01\x12\x035\x12\x17\n\x0c\n\x05\x04\x06\x02\0\x03\x12\
-    \x035\x1a\x1b\n\x0b\n\x04\x04\x06\x02\x01\x12\x036\x02\x1b\n\x0c\n\x05\
-    \x04\x06\x02\x01\x04\x12\x036\x02\n\n\x0c\n\x05\x04\x06\x02\x01\x05\x12\
-    \x036\x0b\x11\n\x0c\n\x05\x04\x06\x02\x01\x01\x12\x036\x12\x16\n\x0c\n\
-    \x05\x04\x06\x02\x01\x03\x12\x036\x19\x1a\n\n\n\x02\x04\x07\x12\x049\0;\
-    \x01\n\n\n\x03\x04\x07\x01\x12\x039\x08\x17\n\x0b\n\x04\x04\x07\x02\0\
-    \x12\x03:\x02\x1d\n\x0c\n\x05\x04\x07\x02\0\x04\x12\x03:\x02\n\n\x0c\n\
-    \x05\x04\x07\x02\0\x05\x12\x03:\x0b\x11\n\x0c\n\x05\x04\x07\x02\0\x01\
-    \x12\x03:\x12\x18\n\x0c\n\x05\x04\x07\x02\0\x03\x12\x03:\x1b\x1c\n\n\n\
-    \x02\x04\x08\x12\x04=\0@\x01\n\n\n\x03\x04\x08\x01\x12\x03=\x08\x14\n\
-    \x0b\n\x04\x04\x08\x02\0\x12\x03>\x02\x1c\n\x0c\n\x05\x04\x08\x02\0\x04\
-    \x12\x03>\x02\n\n\x0c\n\x05\x04\x08\x02\0\x05\x12\x03>\x0b\x11\n\x0c\n\
-    \x05\x04\x08\x02\0\x01\x12\x03>\x12\x17\n\x0c\n\x05\x04\x08\x02\0\x03\
-    \x12\x03>\x1a\x1b\n\x0b\n\x04\x04\x08\x02\x01\x12\x03?\x02\x1d\n\x0c\n\
-    \x05\x04\x08\x02\x01\x04\x12\x03?\x02\n\n\x0c\n\x05\x04\x08\x02\x01\x05\
-    \x12\x03?\x0b\x11\n\x0c\n\x05\x04\x08\x02\x01\x01\x12\x03?\x12\x18\n\x0c\
-    \n\x05\x04\x08\x02\x01\x03\x12\x03?\x1b\x1c\n\n\n\x02\x04\t\x12\x04B\0D\
-    \x01\n\n\n\x03\x04\t\x01\x12\x03B\x08\x11\n\x0b\n\x04\x04\t\x02\0\x12\
-    \x03C\x02\x1e\n\x0c\n\x05\x04\t\x02\0\x04\x12\x03C\x02\n\n\x0c\n\x05\x04\
-    \t\x02\0\x06\x12\x03C\x0b\x15\n\x0c\n\x05\x04\t\x02\0\x01\x12\x03C\x16\
-    \x19\n\x0c\n\x05\x04\t\x02\0\x03\x12\x03C\x1c\x1d\
+    s\x18\x02\x20\x03(\tR\x04deps\"D\n\x16ReverseDependenciesGet\x12\x16\n\
+    \x06origin\x18\x01\x20\x01(\tR\x06origin\x12\x12\n\x04name\x18\x02\x20\
+    \x01(\tR\x04name\"W\n\x13ReverseDependencies\x12\x16\n\x06origin\x18\x01\
+    \x20\x01(\tR\x06origin\x12\x12\n\x04name\x18\x02\x20\x01(\tR\x04name\x12\
+    \x14\n\x05rdeps\x18\x03\x20\x03(\tR\x05rdeps\")\n\x0fPackageStatsGet\x12\
+    \x16\n\x06origin\x18\x01\x20\x01(\tR\x06origin\"<\n\x0cPackageStats\x12\
+    \x14\n\x05plans\x18\x01\x20\x01(\x04R\x05plans\x12\x16\n\x06builds\x18\
+    \x02\x20\x01(\x04R\x06builds\"*\n\tJobStatus\x12\x1d\n\x03job\x18\x01\
+    \x20\x01(\x0b2\x0b.jobsrv.JobR\x03job*U\n\x0cProjectState\x12\x0e\n\nNot\
+    Started\x10\0\x12\x0e\n\nInProgress\x10\x01\x12\x0b\n\x07Success\x10\x02\
+    \x12\x0b\n\x07Failure\x10\x03\x12\x0b\n\x07Skipped\x10\x04*D\n\nGroupSta\
+    te\x12\x0b\n\x07Pending\x10\0\x12\x0f\n\x0bDispatching\x10\x01\x12\x0c\n\
+    \x08Complete\x10\x02\x12\n\n\x06Failed\x10\x03J\xa5\x14\n\x06\x12\x04\0\
+    \0O\x01\n\x08\n\x01\x02\x12\x03\0\x08\x11\n\t\n\x02\x03\0\x12\x03\x01\
+    \x07\x1f\n\n\n\x02\x05\0\x12\x04\x03\0\t\x01\n\n\n\x03\x05\0\x01\x12\x03\
+    \x03\x05\x11\n\x0b\n\x04\x05\0\x02\0\x12\x03\x04\x02\x11\n\x0c\n\x05\x05\
+    \0\x02\0\x01\x12\x03\x04\x02\x0c\n\x0c\n\x05\x05\0\x02\0\x02\x12\x03\x04\
+    \x0f\x10\n\x0b\n\x04\x05\0\x02\x01\x12\x03\x05\x02\x11\n\x0c\n\x05\x05\0\
+    \x02\x01\x01\x12\x03\x05\x02\x0c\n\x0c\n\x05\x05\0\x02\x01\x02\x12\x03\
+    \x05\x0f\x10\n\x0b\n\x04\x05\0\x02\x02\x12\x03\x06\x02\x0e\n\x0c\n\x05\
+    \x05\0\x02\x02\x01\x12\x03\x06\x02\t\n\x0c\n\x05\x05\0\x02\x02\x02\x12\
+    \x03\x06\x0c\r\n\x0b\n\x04\x05\0\x02\x03\x12\x03\x07\x02\x0e\n\x0c\n\x05\
+    \x05\0\x02\x03\x01\x12\x03\x07\x02\t\n\x0c\n\x05\x05\0\x02\x03\x02\x12\
+    \x03\x07\x0c\r\n\x0b\n\x04\x05\0\x02\x04\x12\x03\x08\x02\x0e\n\x0c\n\x05\
+    \x05\0\x02\x04\x01\x12\x03\x08\x02\t\n\x0c\n\x05\x05\0\x02\x04\x02\x12\
+    \x03\x08\x0c\r\n\n\n\x02\x04\0\x12\x04\x0b\0\x10\x01\n\n\n\x03\x04\0\x01\
+    \x12\x03\x0b\x08\x0f\n\x0b\n\x04\x04\0\x02\0\x12\x03\x0c\x02\x1b\n\x0c\n\
+    \x05\x04\0\x02\0\x04\x12\x03\x0c\x02\n\n\x0c\n\x05\x04\0\x02\0\x05\x12\
+    \x03\x0c\x0b\x11\n\x0c\n\x05\x04\0\x02\0\x01\x12\x03\x0c\x12\x16\n\x0c\n\
+    \x05\x04\0\x02\0\x03\x12\x03\x0c\x19\x1a\n\x0b\n\x04\x04\0\x02\x01\x12\
+    \x03\r\x02\x1c\n\x0c\n\x05\x04\0\x02\x01\x04\x12\x03\r\x02\n\n\x0c\n\x05\
+    \x04\0\x02\x01\x05\x12\x03\r\x0b\x11\n\x0c\n\x05\x04\0\x02\x01\x01\x12\
+    \x03\r\x12\x17\n\x0c\n\x05\x04\0\x02\x01\x03\x12\x03\r\x1a\x1b\n\x0b\n\
+    \x04\x04\0\x02\x02\x12\x03\x0e\x02\"\n\x0c\n\x05\x04\0\x02\x02\x04\x12\
+    \x03\x0e\x02\n\n\x0c\n\x05\x04\0\x02\x02\x06\x12\x03\x0e\x0b\x17\n\x0c\n\
+    \x05\x04\0\x02\x02\x01\x12\x03\x0e\x18\x1d\n\x0c\n\x05\x04\0\x02\x02\x03\
+    \x12\x03\x0e\x20!\n\x0b\n\x04\x04\0\x02\x03\x12\x03\x0f\x02\x1d\n\x0c\n\
+    \x05\x04\0\x02\x03\x04\x12\x03\x0f\x02\n\n\x0c\n\x05\x04\0\x02\x03\x05\
+    \x12\x03\x0f\x0b\x11\n\x0c\n\x05\x04\0\x02\x03\x01\x12\x03\x0f\x12\x18\n\
+    \x0c\n\x05\x04\0\x02\x03\x03\x12\x03\x0f\x1b\x1c\n\n\n\x02\x05\x01\x12\
+    \x04\x12\0\x17\x01\n\n\n\x03\x05\x01\x01\x12\x03\x12\x05\x0f\n\x0b\n\x04\
+    \x05\x01\x02\0\x12\x03\x13\x02\x0e\n\x0c\n\x05\x05\x01\x02\0\x01\x12\x03\
+    \x13\x02\t\n\x0c\n\x05\x05\x01\x02\0\x02\x12\x03\x13\x0c\r\n\x0b\n\x04\
+    \x05\x01\x02\x01\x12\x03\x14\x02\x12\n\x0c\n\x05\x05\x01\x02\x01\x01\x12\
+    \x03\x14\x02\r\n\x0c\n\x05\x05\x01\x02\x01\x02\x12\x03\x14\x10\x11\n\x0b\
+    \n\x04\x05\x01\x02\x02\x12\x03\x15\x02\x0f\n\x0c\n\x05\x05\x01\x02\x02\
+    \x01\x12\x03\x15\x02\n\n\x0c\n\x05\x05\x01\x02\x02\x02\x12\x03\x15\r\x0e\
+    \n\x0b\n\x04\x05\x01\x02\x03\x12\x03\x16\x02\r\n\x0c\n\x05\x05\x01\x02\
+    \x03\x01\x12\x03\x16\x02\x08\n\x0c\n\x05\x05\x01\x02\x03\x02\x12\x03\x16\
+    \x0b\x0c\n\n\n\x02\x04\x01\x12\x04\x19\0\x1d\x01\n\n\n\x03\x04\x01\x01\
+    \x12\x03\x19\x08\x13\n\x0b\n\x04\x04\x01\x02\0\x12\x03\x1a\x02\x1d\n\x0c\
+    \n\x05\x04\x01\x02\0\x04\x12\x03\x1a\x02\n\n\x0c\n\x05\x04\x01\x02\0\x05\
+    \x12\x03\x1a\x0b\x11\n\x0c\n\x05\x04\x01\x02\0\x01\x12\x03\x1a\x12\x18\n\
+    \x0c\n\x05\x04\x01\x02\0\x03\x12\x03\x1a\x1b\x1c\n\x0b\n\x04\x04\x01\x02\
+    \x01\x12\x03\x1b\x02\x1e\n\x0c\n\x05\x04\x01\x02\x01\x04\x12\x03\x1b\x02\
+    \n\n\x0c\n\x05\x04\x01\x02\x01\x05\x12\x03\x1b\x0b\x11\n\x0c\n\x05\x04\
+    \x01\x02\x01\x01\x12\x03\x1b\x12\x19\n\x0c\n\x05\x04\x01\x02\x01\x03\x12\
+    \x03\x1b\x1c\x1d\n\x0b\n\x04\x04\x01\x02\x02\x12\x03\x1c\x02\x1e\n\x0c\n\
+    \x05\x04\x01\x02\x02\x04\x12\x03\x1c\x02\n\n\x0c\n\x05\x04\x01\x02\x02\
+    \x05\x12\x03\x1c\x0b\x0f\n\x0c\n\x05\x04\x01\x02\x02\x01\x12\x03\x1c\x10\
+    \x19\n\x0c\n\x05\x04\x01\x02\x02\x03\x12\x03\x1c\x1c\x1d\n\n\n\x02\x04\
+    \x02\x12\x04\x1f\0!\x01\n\n\n\x03\x04\x02\x01\x12\x03\x1f\x08\x10\n\x0b\
+    \n\x04\x04\x02\x02\0\x12\x03\x20\x02\x1f\n\x0c\n\x05\x04\x02\x02\0\x04\
+    \x12\x03\x20\x02\n\n\x0c\n\x05\x04\x02\x02\0\x05\x12\x03\x20\x0b\x11\n\
+    \x0c\n\x05\x04\x02\x02\0\x01\x12\x03\x20\x12\x1a\n\x0c\n\x05\x04\x02\x02\
+    \0\x03\x12\x03\x20\x1d\x1e\n\n\n\x02\x04\x03\x12\x04#\0(\x01\n\n\n\x03\
+    \x04\x03\x01\x12\x03#\x08\r\n\x0b\n\x04\x04\x03\x02\0\x12\x03$\x02\x19\n\
+    \x0c\n\x05\x04\x03\x02\0\x04\x12\x03$\x02\n\n\x0c\n\x05\x04\x03\x02\0\
+    \x05\x12\x03$\x0b\x11\n\x0c\n\x05\x04\x03\x02\0\x01\x12\x03$\x12\x14\n\
+    \x0c\n\x05\x04\x03\x02\0\x03\x12\x03$\x17\x18\n\x0b\n\x04\x04\x03\x02\
+    \x01\x12\x03%\x02\x20\n\x0c\n\x05\x04\x03\x02\x01\x04\x12\x03%\x02\n\n\
+    \x0c\n\x05\x04\x03\x02\x01\x06\x12\x03%\x0b\x15\n\x0c\n\x05\x04\x03\x02\
+    \x01\x01\x12\x03%\x16\x1b\n\x0c\n\x05\x04\x03\x02\x01\x03\x12\x03%\x1e\
+    \x1f\n\x0b\n\x04\x04\x03\x02\x02\x12\x03&\x02\x20\n\x0c\n\x05\x04\x03\
+    \x02\x02\x04\x12\x03&\x02\n\n\x0c\n\x05\x04\x03\x02\x02\x06\x12\x03&\x0b\
+    \x12\n\x0c\n\x05\x04\x03\x02\x02\x01\x12\x03&\x13\x1b\n\x0c\n\x05\x04\
+    \x03\x02\x02\x03\x12\x03&\x1e\x1f\n\x0b\n\x04\x04\x03\x02\x03\x12\x03'\
+    \x02!\n\x0c\n\x05\x04\x03\x02\x03\x04\x12\x03'\x02\n\n\x0c\n\x05\x04\x03\
+    \x02\x03\x05\x12\x03'\x0b\x11\n\x0c\n\x05\x04\x03\x02\x03\x01\x12\x03'\
+    \x12\x1c\n\x0c\n\x05\x04\x03\x02\x03\x03\x12\x03'\x1f\x20\n\n\n\x02\x04\
+    \x04\x12\x04*\0-\x01\n\n\n\x03\x04\x04\x01\x12\x03*\x08\x0f\n\x0b\n\x04\
+    \x04\x04\x02\0\x12\x03+\x02\x1c\n\x0c\n\x05\x04\x04\x02\0\x04\x12\x03+\
+    \x02\n\n\x0c\n\x05\x04\x04\x02\0\x05\x12\x03+\x0b\x11\n\x0c\n\x05\x04\
+    \x04\x02\0\x01\x12\x03+\x12\x17\n\x0c\n\x05\x04\x04\x02\0\x03\x12\x03+\
+    \x1a\x1b\n\x0b\n\x04\x04\x04\x02\x01\x12\x03,\x02\x1b\n\x0c\n\x05\x04\
+    \x04\x02\x01\x04\x12\x03,\x02\n\n\x0c\n\x05\x04\x04\x02\x01\x05\x12\x03,\
+    \x0b\x11\n\x0c\n\x05\x04\x04\x02\x01\x01\x12\x03,\x12\x16\n\x0c\n\x05\
+    \x04\x04\x02\x01\x03\x12\x03,\x19\x1a\n\n\n\x02\x04\x05\x12\x04/\02\x01\
+    \n\n\n\x03\x04\x05\x01\x12\x03/\x08\x18\n\x0b\n\x04\x04\x05\x02\0\x12\
+    \x030\x02\x1c\n\x0c\n\x05\x04\x05\x02\0\x04\x12\x030\x02\n\n\x0c\n\x05\
+    \x04\x05\x02\0\x05\x12\x030\x0b\x11\n\x0c\n\x05\x04\x05\x02\0\x01\x12\
+    \x030\x12\x17\n\x0c\n\x05\x04\x05\x02\0\x03\x12\x030\x1a\x1b\n\x0b\n\x04\
+    \x04\x05\x02\x01\x12\x031\x02\x1b\n\x0c\n\x05\x04\x05\x02\x01\x04\x12\
+    \x031\x02\n\n\x0c\n\x05\x04\x05\x02\x01\x05\x12\x031\x0b\x11\n\x0c\n\x05\
+    \x04\x05\x02\x01\x01\x12\x031\x12\x16\n\x0c\n\x05\x04\x05\x02\x01\x03\
+    \x12\x031\x19\x1a\n\n\n\x02\x04\x06\x12\x044\07\x01\n\n\n\x03\x04\x06\
+    \x01\x12\x034\x08\x15\n\x0b\n\x04\x04\x06\x02\0\x12\x035\x02\x1c\n\x0c\n\
+    \x05\x04\x06\x02\0\x04\x12\x035\x02\n\n\x0c\n\x05\x04\x06\x02\0\x05\x12\
+    \x035\x0b\x11\n\x0c\n\x05\x04\x06\x02\0\x01\x12\x035\x12\x17\n\x0c\n\x05\
+    \x04\x06\x02\0\x03\x12\x035\x1a\x1b\n\x0b\n\x04\x04\x06\x02\x01\x12\x036\
+    \x02\x1b\n\x0c\n\x05\x04\x06\x02\x01\x04\x12\x036\x02\n\n\x0c\n\x05\x04\
+    \x06\x02\x01\x05\x12\x036\x0b\x11\n\x0c\n\x05\x04\x06\x02\x01\x01\x12\
+    \x036\x12\x16\n\x0c\n\x05\x04\x06\x02\x01\x03\x12\x036\x19\x1a\n\n\n\x02\
+    \x04\x07\x12\x049\0<\x01\n\n\n\x03\x04\x07\x01\x12\x039\x08\x1e\n\x0b\n\
+    \x04\x04\x07\x02\0\x12\x03:\x02\x1d\n\x0c\n\x05\x04\x07\x02\0\x04\x12\
+    \x03:\x02\n\n\x0c\n\x05\x04\x07\x02\0\x05\x12\x03:\x0b\x11\n\x0c\n\x05\
+    \x04\x07\x02\0\x01\x12\x03:\x12\x18\n\x0c\n\x05\x04\x07\x02\0\x03\x12\
+    \x03:\x1b\x1c\n\x0b\n\x04\x04\x07\x02\x01\x12\x03;\x02\x1b\n\x0c\n\x05\
+    \x04\x07\x02\x01\x04\x12\x03;\x02\n\n\x0c\n\x05\x04\x07\x02\x01\x05\x12\
+    \x03;\x0b\x11\n\x0c\n\x05\x04\x07\x02\x01\x01\x12\x03;\x12\x16\n\x0c\n\
+    \x05\x04\x07\x02\x01\x03\x12\x03;\x19\x1a\n\n\n\x02\x04\x08\x12\x04>\0B\
+    \x01\n\n\n\x03\x04\x08\x01\x12\x03>\x08\x1b\n\x0b\n\x04\x04\x08\x02\0\
+    \x12\x03?\x02\x1d\n\x0c\n\x05\x04\x08\x02\0\x04\x12\x03?\x02\n\n\x0c\n\
+    \x05\x04\x08\x02\0\x05\x12\x03?\x0b\x11\n\x0c\n\x05\x04\x08\x02\0\x01\
+    \x12\x03?\x12\x18\n\x0c\n\x05\x04\x08\x02\0\x03\x12\x03?\x1b\x1c\n\x0b\n\
+    \x04\x04\x08\x02\x01\x12\x03@\x02\x1b\n\x0c\n\x05\x04\x08\x02\x01\x04\
+    \x12\x03@\x02\n\n\x0c\n\x05\x04\x08\x02\x01\x05\x12\x03@\x0b\x11\n\x0c\n\
+    \x05\x04\x08\x02\x01\x01\x12\x03@\x12\x16\n\x0c\n\x05\x04\x08\x02\x01\
+    \x03\x12\x03@\x19\x1a\n\x0b\n\x04\x04\x08\x02\x02\x12\x03A\x02\x1c\n\x0c\
+    \n\x05\x04\x08\x02\x02\x04\x12\x03A\x02\n\n\x0c\n\x05\x04\x08\x02\x02\
+    \x05\x12\x03A\x0b\x11\n\x0c\n\x05\x04\x08\x02\x02\x01\x12\x03A\x12\x17\n\
+    \x0c\n\x05\x04\x08\x02\x02\x03\x12\x03A\x1a\x1b\n\n\n\x02\x04\t\x12\x04D\
+    \0F\x01\n\n\n\x03\x04\t\x01\x12\x03D\x08\x17\n\x0b\n\x04\x04\t\x02\0\x12\
+    \x03E\x02\x1d\n\x0c\n\x05\x04\t\x02\0\x04\x12\x03E\x02\n\n\x0c\n\x05\x04\
+    \t\x02\0\x05\x12\x03E\x0b\x11\n\x0c\n\x05\x04\t\x02\0\x01\x12\x03E\x12\
+    \x18\n\x0c\n\x05\x04\t\x02\0\x03\x12\x03E\x1b\x1c\n\n\n\x02\x04\n\x12\
+    \x04H\0K\x01\n\n\n\x03\x04\n\x01\x12\x03H\x08\x14\n\x0b\n\x04\x04\n\x02\
+    \0\x12\x03I\x02\x1c\n\x0c\n\x05\x04\n\x02\0\x04\x12\x03I\x02\n\n\x0c\n\
+    \x05\x04\n\x02\0\x05\x12\x03I\x0b\x11\n\x0c\n\x05\x04\n\x02\0\x01\x12\
+    \x03I\x12\x17\n\x0c\n\x05\x04\n\x02\0\x03\x12\x03I\x1a\x1b\n\x0b\n\x04\
+    \x04\n\x02\x01\x12\x03J\x02\x1d\n\x0c\n\x05\x04\n\x02\x01\x04\x12\x03J\
+    \x02\n\n\x0c\n\x05\x04\n\x02\x01\x05\x12\x03J\x0b\x11\n\x0c\n\x05\x04\n\
+    \x02\x01\x01\x12\x03J\x12\x18\n\x0c\n\x05\x04\n\x02\x01\x03\x12\x03J\x1b\
+    \x1c\n\n\n\x02\x04\x0b\x12\x04M\0O\x01\n\n\n\x03\x04\x0b\x01\x12\x03M\
+    \x08\x11\n\x0b\n\x04\x04\x0b\x02\0\x12\x03N\x02\x1e\n\x0c\n\x05\x04\x0b\
+    \x02\0\x04\x12\x03N\x02\n\n\x0c\n\x05\x04\x0b\x02\0\x06\x12\x03N\x0b\x15\
+    \n\x0c\n\x05\x04\x0b\x02\0\x01\x12\x03N\x16\x19\n\x0c\n\x05\x04\x0b\x02\
+    \0\x03\x12\x03N\x1c\x1d\
 ";
 
 static mut file_descriptor_proto_lazy: ::protobuf::lazy::Lazy<::protobuf::descriptor::FileDescriptorProto> = ::protobuf::lazy::Lazy {

--- a/components/builder-protocol/src/scheduler.rs
+++ b/components/builder-protocol/src/scheduler.rs
@@ -102,6 +102,14 @@ impl Routable for PackageStatsGet {
     }
 }
 
+impl Routable for ReverseDependenciesGet {
+    type H = String;
+
+    fn route_key(&self) -> Option<Self::H> {
+        Some(format!("{}/{}", self.get_origin(), self.get_name()))
+    }
+}
+
 impl Routable for JobStatus {
     type H = String;
 
@@ -165,6 +173,19 @@ impl Serialize for Group {
         strukt.serialize_field("state", &self.get_state())?;
         strukt.serialize_field("projects", &self.get_projects())?;
         strukt.serialize_field("created_at", &self.get_created_at())?;
+        strukt.end()
+    }
+}
+
+impl Serialize for ReverseDependencies {
+    fn serialize<S>(&self, serializer: S) -> result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut strukt = serializer.serialize_struct("reversedependencies", 3)?;
+        strukt.serialize_field("origin", &self.get_origin())?;
+        strukt.serialize_field("name", &self.get_name())?;
+        strukt.serialize_field("rdeps", &self.get_rdeps())?;
         strukt.end()
     }
 }

--- a/components/builder-scheduler/src/server/handlers.rs
+++ b/components/builder-scheduler/src/server/handlers.rs
@@ -131,16 +131,16 @@ pub fn reverse_dependencies_get(
 
     match rdeps {
         Some(rd) => {
-            let mut rdps = RepeatedField::new();
+            let mut short_deps = RepeatedField::new();
 
             // the tuples inside rd are of the form: (core/redis, core/redis/3.2.4/20170717232232)
             // we're only interested in the short form, not the fully qualified form
             for (id, _fully_qualified_id) in rd {
-                rdps.push(id);
+                short_deps.push(id);
             }
 
-            rdps.sort_by(|a, b| a.cmp(b));
-            rd_reply.set_rdeps(rdps);
+            short_deps.sort();
+            rd_reply.set_rdeps(short_deps);
         }
         None => debug!("No rdeps found for {}", ident),
     }

--- a/components/builder-scheduler/src/server/handlers.rs
+++ b/components/builder-scheduler/src/server/handlers.rs
@@ -114,6 +114,42 @@ pub fn group_create(
     Ok(())
 }
 
+pub fn reverse_dependencies_get(
+    req: &mut Envelope,
+    sock: &mut zmq::Socket,
+    state: &mut ServerState,
+) -> Result<()> {
+    let msg: proto::ReverseDependenciesGet = req.parse_msg()?;
+    debug!("reverse_dependencies_get message: {:?}", msg);
+
+    let ident = format!("{}/{}", msg.get_origin(), msg.get_name());
+    let graph = state.graph().read().expect("Graph lock is poisoned");
+    let rdeps = graph.rdeps(&ident);
+    let mut rd_reply = proto::ReverseDependencies::new();
+    rd_reply.set_origin(msg.get_origin().to_string());
+    rd_reply.set_name(msg.get_name().to_string());
+
+    match rdeps {
+        Some(rd) => {
+            let mut rdps = RepeatedField::new();
+
+            // the tuples inside rd are of the form: (core/redis, core/redis/3.2.4/20170717232232)
+            // we're only interested in the short form, not the fully qualified form
+            for (id, _fully_qualified_id) in rd {
+                rdps.push(id);
+            }
+
+            rdps.sort_by(|a, b| a.cmp(b));
+            rd_reply.set_rdeps(rdps);
+        }
+        None => debug!("No rdeps found for {}", ident),
+    }
+
+    req.reply_complete(sock, &rd_reply)?;
+
+    Ok(())
+}
+
 pub fn group_get(
     req: &mut Envelope,
     sock: &mut zmq::Socket,

--- a/components/builder-scheduler/src/server/mod.rs
+++ b/components/builder-scheduler/src/server/mod.rs
@@ -115,6 +115,7 @@ impl Dispatcher for Worker {
             "PackagePreCreate" => handlers::package_precreate(message, sock, state),
             "JobStatus" => handlers::job_status(message, sock, state),
             "PackageStatsGet" => handlers::package_stats_get(message, sock, state),
+            "ReverseDependenciesGet" => handlers::reverse_dependencies_get(message, sock, state),
             _ => panic!("unexpected message: {:?}", message.message_id()),
         }
     }

--- a/components/common/src/ui.rs
+++ b/components/common/src/ui.rs
@@ -32,6 +32,7 @@ pub const NOCOLORING_ENVVAR: &'static str = "HAB_NOCOLORING";
 pub enum Status {
     Applying,
     Cached,
+    Created,
     Creating,
     Deleting,
     Demoted,
@@ -56,6 +57,7 @@ impl Status {
         match *self {
             Status::Applying => ('↑', "Applying".into(), Colour::Green),
             Status::Cached => ('☑', "Cached".into(), Colour::Green),
+            Status::Created => ('✓', "Created".into(), Colour::Green),
             Status::Creating => ('Ω', "Creating".into(), Colour::Green),
             Status::Deleting => ('☒', "Deleting".into(), Colour::Green),
             Status::Demoted => ('✓', "Demoted".into(), Colour::Green),

--- a/components/hab/Cargo.toml
+++ b/components/hab/Cargo.toml
@@ -40,6 +40,9 @@ path = "../common"
 [dependencies.habitat_depot_client]
 path = "../builder-depot-client"
 
+[dependencies.habitat_api_client]
+path = "../builder-api-client"
+
 [dependencies.habitat_http_client]
 path = "../http-client"
 

--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -75,6 +75,22 @@ pub fn get() -> App<'static, 'static> {
                     "Ring key name, which will encrypt communication messages")
             )
         )
+        (@subcommand job =>
+            (about: "Commands relating to job control")
+            (aliases: &["j", "jo"])
+            (@setting ArgRequiredElseHelp)
+            (@subcommand start =>
+                (about: "Schedule a job or group of jobs.")
+                (aliases: &["s", "st", "sta", "star"])
+                (@arg PKG_IDENT: +required +takes_value
+                    "The origin and name of the package to schedule a job for \
+                    (ex: core/redis)")
+                (@arg DEPOT_URL: -u --url +takes_value {valid_url}
+                    "Use a specific Depot URL (ex: http://depot.example.com/v1/depot)")
+                (@arg AUTH_TOKEN: -z --auth +takes_value "Authentication token for the Depot")
+                (@arg GROUP: -g --group "Schedule jobs for this package and all of its reverse dependencies")
+            )
+        )
         (@subcommand origin =>
             (about: "Commands relating to Habitat origin keys")
             (aliases: &["o", "or", "ori", "orig", "origi"])

--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -76,7 +76,7 @@ pub fn get() -> App<'static, 'static> {
             )
         )
         (@subcommand job =>
-            (about: "Commands relating to job control")
+            (about: "Commands relating to build job control")
             (aliases: &["j", "jo"])
             (@setting ArgRequiredElseHelp)
             (@subcommand start =>

--- a/components/hab/src/command/job/mod.rs
+++ b/components/hab/src/command/job/mod.rs
@@ -12,15 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod butterfly;
-pub mod cli;
-pub mod job;
-pub mod launcher;
-pub mod origin;
-pub mod pkg;
-pub mod plan;
-pub mod ring;
-pub mod service;
-pub mod studio;
-pub mod sup;
-pub mod user;
+pub mod start;

--- a/components/hab/src/command/job/start.rs
+++ b/components/hab/src/command/job/start.rs
@@ -1,0 +1,48 @@
+// Copyright (c) 2016-2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use api_client::Client as ApiClient;
+use depot_client::Client as DepotClient;
+use common::ui::{Status, UI};
+use hcore::package::PackageIdent;
+
+use {PRODUCT, VERSION};
+use error::{Error, Result};
+
+pub fn start(
+    ui: &mut UI,
+    depot_url: &str,
+    ident: &PackageIdent,
+    token: &str,
+    group: bool,
+) -> Result<()> {
+    debug!("Starting a job for {}", &ident);
+
+    if group {
+        let depot_client = DepotClient::new(depot_url, PRODUCT, VERSION, None)
+            .map_err(Error::DepotClient)?;
+        depot_client.schedule_job(ident, token).map_err(
+            Error::DepotClient,
+        )?;
+    } else {
+        let api_client = ApiClient::new(depot_url, PRODUCT, VERSION, None).map_err(
+            Error::APIClient,
+        )?;
+        api_client.create_job(ident, token).map_err(
+            Error::APIClient,
+        )?;
+    }
+    ui.status(Status::Creating, format!("job for {}", ident))?;
+    Ok(())
+}

--- a/components/hab/src/error.rs
+++ b/components/hab/src/error.rs
@@ -19,6 +19,7 @@ use std::io;
 use std::path::{self, PathBuf};
 use std::result;
 
+use api_client;
 use depot_client;
 use common;
 use hcore;
@@ -30,6 +31,7 @@ pub type Result<T> = result::Result<T, Error>;
 #[derive(Debug)]
 #[allow(dead_code)]
 pub enum Error {
+    APIClient(api_client::Error),
     ArgumentError(&'static str),
     ButterflyError(String),
     CannotRemoveFromChannel((String, String)),
@@ -61,6 +63,7 @@ pub enum Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let msg = match *self {
+            Error::APIClient(ref err) => format!("{}", err),
             Error::ArgumentError(ref e) => format!("{}", e),
             Error::ButterflyError(ref e) => format!("{}", e),
             Error::CannotRemoveFromChannel((ref p, ref c)) => {
@@ -148,6 +151,7 @@ impl fmt::Display for Error {
 impl error::Error for Error {
     fn description(&self) -> &str {
         match *self {
+            Error::APIClient(ref err) => err.description(),
             Error::ArgumentError(_) => "There was an error parsing an error or with it's value",
             Error::ButterflyError(_) => "Butterfly has had an error",
             Error::CannotRemoveFromChannel(_) => {

--- a/components/hab/src/lib.rs
+++ b/components/hab/src/lib.rs
@@ -17,6 +17,7 @@
 extern crate habitat_core as hcore;
 extern crate habitat_common as common;
 extern crate habitat_depot_client as depot_client;
+extern crate habitat_api_client as api_client;
 extern crate habitat_http_client as http_client;
 extern crate handlebars;
 

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -126,6 +126,12 @@ fn start(ui: &mut UI) -> Result<()> {
                 _ => unreachable!(),
             }
         }
+        ("job", Some(matches)) => {
+            match matches.subcommand() {
+                ("start", Some(m)) => sub_job_start(ui, m)?,
+                _ => unreachable!(),
+            }
+        }
         ("pkg", Some(matches)) => {
             match matches.subcommand() {
                 ("binlink", Some(m)) => sub_pkg_binlink(ui, m)?,
@@ -378,6 +384,16 @@ fn sub_pkg_hash(m: &ArgMatches) -> Result<()> {
             Ok(())
         }
     }
+}
+
+fn sub_job_start(ui: &mut UI, m: &ArgMatches) -> Result<()> {
+    let env_or_default = henv::var(DEPOT_URL_ENVVAR).unwrap_or(DEFAULT_DEPOT_URL.to_string());
+    let ident = PackageIdent::from_str(m.value_of("PKG_IDENT").unwrap())?; // Required via clap
+    let url = m.value_of("DEPOT_URL").unwrap_or(&env_or_default);
+    let group = m.is_present("GROUP");
+    let token = auth_token_param_or_env(&m)?;
+    command::job::start::start(ui, &url, &ident, &token, group)?;
+    Ok(())
 }
 
 fn sub_plan_init(ui: &mut UI, m: &ArgMatches) -> Result<()> {


### PR DESCRIPTION
This command lets the user start a job manually by specifying a package
identifier to be built, as well as whether they want to just build that package
or that package and all of its reverse dependencies as well. If they choose to
do the entire group, they will be shown what will be built first and prompted
to confirm that's what they want.

This change also introduces the builder-api-client crate for communicating with
builder-api. This is similar to the builder-depot-client crate but is specific
to the URL and routes available in builder-api.

This fulfills one piece of https://github.com/habitat-sh/habitat/issues/2686

Signed-off-by: Josh Black <raskchanky@gmail.com>