### PR TITLE
store launcher pid in supervisor lock file

### DIFF
--- a/components/launcher-protocol/src/lib.rs
+++ b/components/launcher-protocol/src/lib.rs
@@ -26,6 +26,7 @@ pub use message::supervisor::*;
 use message::net::*;
 
 pub const LAUNCHER_PIPE_ENV: &'static str = "HAB_LAUNCHER_PIPE";
+pub const LAUNCHER_PID_ENV: &'static str = "HAB_LAUNCHER_PID";
 /// Process exit code from Supervisor which indicates to Launcher that the Supervisor
 /// ran to completion with a successful result. The Launcher should not attempt to restart
 /// the Supervisor and should exit immediately with a successful exit code.

--- a/components/launcher/src/server/mod.rs
+++ b/components/launcher/src/server/mod.rs
@@ -23,7 +23,7 @@ use std::time::Duration;
 
 use core;
 use core::package::{PackageIdent, PackageInstall};
-use core::os::process::Signal;
+use core::os::process::{self, Signal};
 use core::os::signals::{self, SignalEvent};
 use ipc_channel::ipc::{IpcOneShotServer, IpcReceiver, IpcSender};
 use protobuf;
@@ -301,6 +301,10 @@ fn spawn_supervisor(pipe: &str, args: &[String]) -> Result<Child> {
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit())
         .env(protocol::LAUNCHER_PIPE_ENV, pipe)
+        .env(
+            protocol::LAUNCHER_PID_ENV,
+            process::current_pid().to_string(),
+        )
         .args(args)
         .spawn()
         .map_err(Error::SupSpawn)?;

--- a/components/studio/bin/hab-studio.ps1
+++ b/components/studio/bin/hab-studio.ps1
@@ -294,21 +294,15 @@ function Enter-Studio {
     }
 
     function Stop-Supervisor {
-      if(Test-Path "$env:HAB_STUDIO_ENTER_ROOT\hab\sup\default\launch.pid") {
-        Stop-Process -Id (Get-Content "$env:HAB_STUDIO_ENTER_ROOT\hab\sup\default\launch.pid")
-        Remove-Item "$env:HAB_STUDIO_ENTER_ROOT\hab\sup\default\launch.pid"
+      if(Test-Path "$env:HAB_STUDIO_ENTER_ROOT\hab\sup\default\LOCK") {
+        Stop-Process -Id (Get-Content "$env:HAB_STUDIO_ENTER_ROOT\hab\sup\default\LOCK")
+        Remove-Item "$env:HAB_STUDIO_ENTER_ROOT\hab\sup\default\LOCK"
       }
     }
 
     New-PSDrive -Name "Habitat" -PSProvider FileSystem -Root $env:HAB_STUDIO_ENTER_ROOT | Out-Null
     mkdir $env:HAB_STUDIO_ENTER_ROOT\hab\sup\default -Force | Out-Null
     Start-Process hab.exe -ArgumentList "sup run" -NoNewWindow -RedirectStandardOutput $env:HAB_STUDIO_ENTER_ROOT\hab\sup\default\out.log
-    $proc = $null
-    while (!$proc) {
-      $proc = Get-Process -Name hab-launch -ErrorAction SilentlyContinue
-      Start-Sleep -Milliseconds 100
-    }
-    $proc.Id > "$env:HAB_STUDIO_ENTER_ROOT\hab\sup\default\launch.pid"
     Write-Host  "** The Habitat Supervisor has been started in the background." -ForegroundColor Cyan
     Write-Host  "** Use 'hab svc start' and 'hab svc stop' to start and stop services." -ForegroundColor Cyan
     Write-Host  "** Use the 'Get-SupervisorLog' command to stream the supervisor log." -ForegroundColor Cyan
@@ -318,8 +312,8 @@ function Enter-Studio {
     Set-Location "Habitat:\src"
   }
 
-  if(Test-Path "$env:HAB_STUDIO_ENTER_ROOT\hab\sup\default\launch.pid") {
-    Stop-Process -Id (Get-Content "$env:HAB_STUDIO_ENTER_ROOT\hab\sup\default\launch.pid")
+  if(Test-Path "$env:HAB_STUDIO_ENTER_ROOT\hab\sup\default\LOCK") {
+    Stop-Process -Id (Get-Content "$env:HAB_STUDIO_ENTER_ROOT\hab\sup\default\LOCK")
   }
 }
 

--- a/components/studio/bin/hab-studio.sh
+++ b/components/studio/bin/hab-studio.sh
@@ -1021,7 +1021,7 @@ cleanup_studio() {
 # **Internal** Kills a Launcher process, if one exists.
 kill_launcher() {
   local pid_file
-  pid_file="$HAB_STUDIO_ROOT/hab/sup/default/launch.pid"
+  pid_file="$HAB_STUDIO_ROOT/hab/sup/default/LOCK"
 
   if [ -f $pid_file ]; then
     $bb kill $($bb cat $pid_file) \

--- a/components/studio/libexec/hab-studio-type-default.sh
+++ b/components/studio/libexec/hab-studio-type-default.sh
@@ -119,7 +119,6 @@ sup-run() {
   echo "--> Launching the Habitat Supervisor in the background..."
   echo "    Running: hab sup run \$*"
   hab sup run \$* > /hab/sup/default/sup.log &
-  echo \$! > /hab/sup/default/launch.pid
   echo "    * Use 'hab svc start' & 'hab svc stop' to start and stop services"
   echo "    * Use 'sup-log' to tail the Supervisor's output (Ctrl+c to stop)"
   echo "    * Use 'sup-term' to terminate the Supervisor"
@@ -132,7 +131,7 @@ sup-run() {
 }
 
 sup-term() {
-  local pid_file="/hab/sup/default/launch.pid "
+  local pid_file="/hab/sup/default/LOCK "
   if [ -f \$pid_file ]; then
     echo "--> Killing Habitat Supervisor running in the background..."
     kill \$(cat \$pid_file) \\

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -443,11 +443,6 @@ fn cli<'a, 'b>() -> App<'a, 'b> {
                 "The name for the state directory if there is more than one Supervisor running \
                 [default: default]")
         )
-        (@subcommand term =>
-            (about: "Gracefully terminate the Habitat Supervisor and all of it's running services")
-            (@arg NAME: --("override-name") +takes_value
-                "The name of the Supervisor if more than one is running [default: default]")
-        )
     )
 }
 


### PR DESCRIPTION
This fixes #2822 and stores the launcher pid instead of the supervisor pid in the lock file. It also effectively reverts the recent studio PRs which this change renders unnecessary. Further, this removes the `term` command from windows since the current implementation is a "no-op" on windows.

A note on the implementation. #2822 specifies having the launcher "own" the lock. I started to go down the path of having the launcher crate maintain the file itself but it proved "awkward". The awkwardness was primarily around tracking the `state_path`. The supervisor needs this for its own artifact and the launcher would need that same path to write the lock file. While itr could look for a `--name` arg in the arguments to build the path, parsing the arguments here is ugly without clap and the supervisor still needs that path for its `term` command. In the end, sending the launcher pid to the supervisor ended up being MUCH simpler.

Signed-off-by: Matt Wrock <matt@mattwrock.com>