### PR TITLE
Fix panic when sending rumors of departed members

### DIFF
--- a/components/butterfly/src/client.rs
+++ b/components/butterfly/src/client.rs
@@ -36,7 +36,10 @@ pub struct Client {
 
 impl Client {
     /// Connect this client to the address, and optionally encrypt the traffic.
-    pub fn new<A: ToString>(addr: A, ring_key: Option<SymKey>) -> Result<Client> {
+    pub fn new<A>(addr: A, ring_key: Option<SymKey>) -> Result<Client>
+    where
+        A: ToString,
+    {
         let socket = (**ZMQ_CONTEXT).as_mut().socket(zmq::PUSH).expect(
             "Failure to create the ZMQ push socket",
         );
@@ -64,7 +67,10 @@ impl Client {
     }
 
     /// Create a departure notification and send it to the server.
-    pub fn send_departure(&mut self, member_id: String) -> Result<()> {
+    pub fn send_departure<T>(&mut self, member_id: T) -> Result<()>
+    where
+        T: ToString,
+    {
         let departure = Departure::new(member_id);
         self.send(departure)
     }
@@ -101,7 +107,7 @@ impl Client {
     /// Send any `Rumor` to the server.
     pub fn send<T: Rumor>(&mut self, rumor: T) -> Result<()> {
         let bytes = rumor.write_to_bytes()?;
-        let wire_msg = message::generate_wire(bytes, &self.ring_key)?;
+        let wire_msg = message::generate_wire(bytes, self.ring_key.as_ref())?;
         self.socket.send(&wire_msg, 0).map_err(Error::ZmqSendError)
     }
 }

--- a/components/butterfly/src/message/mod.rs
+++ b/components/butterfly/src/message/mod.rs
@@ -26,9 +26,9 @@ use error::Result;
 use message::swim::Wire;
 use protobuf::{self, Message};
 
-pub fn generate_wire(payload: Vec<u8>, ring_key: &Option<SymKey>) -> Result<Vec<u8>> {
+pub fn generate_wire(payload: Vec<u8>, ring_key: Option<&SymKey>) -> Result<Vec<u8>> {
     let mut wire = Wire::new();
-    if let Some(ref ring_key) = *ring_key {
+    if let Some(ring_key) = ring_key {
         wire.set_encrypted(true);
         let (nonce, encrypted_payload) = ring_key.encrypt(&payload)?;
         wire.set_nonce(nonce);
@@ -39,9 +39,9 @@ pub fn generate_wire(payload: Vec<u8>, ring_key: &Option<SymKey>) -> Result<Vec<
     Ok(wire.write_to_bytes()?)
 }
 
-pub fn unwrap_wire(payload: &[u8], ring_key: &Option<SymKey>) -> Result<Vec<u8>> {
+pub fn unwrap_wire(payload: &[u8], ring_key: Option<&SymKey>) -> Result<Vec<u8>> {
     let mut wire: Wire = protobuf::parse_from_bytes(payload)?;
-    if let Some(ref ring_key) = *ring_key {
+    if let Some(ring_key) = ring_key {
         Ok(ring_key.decrypt(wire.get_nonce(), wire.get_payload())?)
     } else {
         Ok(wire.take_payload())

--- a/components/butterfly/src/rumor/dat_file.rs
+++ b/components/butterfly/src/rumor/dat_file.rs
@@ -351,8 +351,9 @@ impl DatFile {
             "Member list lock poisoned",
         );
         for member in members.values() {
-            let membership = member_list.membership_for(member.get_id());
-            total += self.write_member(writer, &membership)?;
+            if let Some(membership) = member_list.membership_for(member.get_id()) {
+                total += self.write_member(writer, &membership)?;
+            }
         }
         Ok(total)
     }

--- a/components/butterfly/src/rumor/departure.rs
+++ b/components/butterfly/src/rumor/departure.rs
@@ -76,14 +76,14 @@ impl DerefMut for Departure {
 impl Departure {
     pub fn new<U>(member_id: U) -> Self
     where
-        U: Into<String>,
+        U: ToString,
     {
         let mut rumor = ProtoRumor::new();
         rumor.set_from_id(String::from("butterflyclient"));
         rumor.set_field_type(ProtoRumor_Type::Departure);
 
         let mut proto = ProtoDeparture::new();
-        proto.set_member_id(member_id.into());
+        proto.set_member_id(member_id.to_string());
         rumor.set_departure(proto);
         Departure(rumor)
     }

--- a/components/butterfly/src/rumor/mod.rs
+++ b/components/butterfly/src/rumor/mod.rs
@@ -60,11 +60,15 @@ pub struct RumorKey {
 }
 
 impl RumorKey {
-    pub fn new<A: Into<String>, B: Into<String>>(kind: Rumor_Type, id: A, key: B) -> RumorKey {
+    pub fn new<A, B>(kind: Rumor_Type, id: A, key: B) -> RumorKey
+    where
+        A: ToString,
+        B: ToString,
+    {
         RumorKey {
             kind: kind,
-            id: id.into(),
-            key: key.into(),
+            id: id.to_string(),
+            key: key.to_string(),
         }
     }
 

--- a/components/butterfly/src/server/mod.rs
+++ b/components/butterfly/src/server/mod.rs
@@ -461,8 +461,8 @@ impl Server {
         }
     }
 
-    /// Set our member to departed, then send up to 10 out of order ack messages to other members to seed
-    /// our status.
+    /// Set our member to departed, then send up to 10 out of order ack messages to other
+    /// members to seed our status.
     pub fn set_departed(&self) {
         if self.socket.is_some() {
             let member = {
@@ -598,7 +598,7 @@ impl Server {
     /// Insert a departure rumor into the departure store.
     pub fn insert_departure(&self, departure: Departure) {
         let rk = RumorKey::from(&departure);
-        if &self.member_id[..] == departure.get_member_id() {
+        if &*self.member_id == departure.get_member_id() {
             self.departed.compare_and_swap(
                 false,
                 true,
@@ -1009,11 +1009,11 @@ impl Server {
     }
 
     fn generate_wire(&self, payload: Vec<u8>) -> Result<Vec<u8>> {
-        message::generate_wire(payload, &self.ring_key)
+        message::generate_wire(payload, (*self.ring_key).as_ref())
     }
 
     fn unwrap_wire(&self, payload: &[u8]) -> Result<Vec<u8>> {
-        message::unwrap_wire(payload, &self.ring_key)
+        message::unwrap_wire(payload, (*self.ring_key).as_ref())
     }
 
     fn persist_data(&self) {

--- a/components/butterfly/src/server/outbound.rs
+++ b/components/butterfly/src/server/outbound.rs
@@ -264,8 +264,9 @@ pub fn populate_membership_rumors(server: &Server, target: &Member, swim: &mut S
     // targets current status. This ensures that members always get a "Confirmed" rumor, before we
     // have the chance to flip it to "Alive", which helps make sure we heal from a partition.
     if server.member_list.contains_member(target.get_id()) {
-        let always_target = server.member_list.membership_for(target.get_id());
-        membership_entries.push(always_target);
+        if let Some(always_target) = server.member_list.membership_for(target.get_id()) {
+            membership_entries.push(always_target);
+        }
     }
     let rumors = server.rumor_list.take_by_kind(
         target.get_id(),
@@ -273,7 +274,9 @@ pub fn populate_membership_rumors(server: &Server, target: &Member, swim: &mut S
         Rumor_Type::Member,
     );
     for &(ref rkey, _heat) in rumors.iter() {
-        membership_entries.push(server.member_list.membership_for(&rkey.key()));
+        if let Some(member) = server.member_list.membership_for(&rkey.key()) {
+            membership_entries.push(member);
+        }
     }
     // We don't want to update the heat for rumors that we know we are sending to a target that is
     // confirmed dead; the odds are, they won't receive them. Lets spam them a little harder with


### PR DESCRIPTION
This PR is largely a change to the signature of
`member::membership_for`. We previously asserted that there was no
condition where a member could not be present in the member list
which we had never heard about. With the introduction of departed
members, we now have this case to deal with so `membership_for` and
any calling functions will now handle an Option case

![tenor-137390284](https://user-images.githubusercontent.com/54036/28643159-c424bf98-7209-11e7-80a2-656ef6745ee0.gif)
