### PR TITLE
Fix populating health of census members

### DIFF
--- a/components/butterfly/src/member.rs
+++ b/components/butterfly/src/member.rs
@@ -62,7 +62,8 @@ impl FromStr for Health {
             "alive" => Ok(Health::Alive),
             "suspect" => Ok(Health::Suspect),
             "confirmed" => Ok(Health::Confirmed),
-            _ => Ok(Health::Alive),
+            "departed" => Ok(Health::Departed),
+            value => panic!("No match for Health from string, {}", value),
         }
     }
 }
@@ -403,7 +404,7 @@ impl MemberList {
         match self.health.read().expect("Health lock is poisoned").get(
             member.get_id(),
         ) {
-            Some(health) => Some(health.clone()),
+            Some(health) => Some(*health),
             None => None,
         }
     }
@@ -413,7 +414,7 @@ impl MemberList {
         match self.health.read().expect("Health lock is poisoned").get(
             member_id,
         ) {
-            Some(health) => Some(health.clone()),
+            Some(health) => Some(*health),
             None => None,
         }
     }


### PR DESCRIPTION
Prior to this change we were updating only the health of members in
the first service group for which they appeared. This meant that
health in the Census would not properly be reported if a peer had
more than one service running

![tenor-135101462](https://user-images.githubusercontent.com/54036/28650723-81c59e14-7232-11e7-9a0c-ebda0079f127.gif)
