### PR TITLE
Release Launcher's LOCK on Supervisor restart

### DIFF
--- a/components/launcher-client/src/lib.rs
+++ b/components/launcher-client/src/lib.rs
@@ -20,7 +20,8 @@ extern crate protobuf;
 pub mod error;
 mod client;
 
-pub use protocol::{ERR_NO_RETRY_EXCODE, OK_NO_RETRY_EXCODE};
+pub use protocol::{LAUNCHER_LOCK_CLEAN_ENV, LAUNCHER_PID_ENV, ERR_NO_RETRY_EXCODE,
+                   OK_NO_RETRY_EXCODE};
 
 pub use client::LauncherCli;
 pub use error::Error;

--- a/components/launcher-protocol/src/lib.rs
+++ b/components/launcher-protocol/src/lib.rs
@@ -27,6 +27,9 @@ use message::net::*;
 
 pub const LAUNCHER_PIPE_ENV: &'static str = "HAB_LAUNCHER_PIPE";
 pub const LAUNCHER_PID_ENV: &'static str = "HAB_LAUNCHER_PID";
+// Set to instruct the Supervisor to clean the Launcher's process LOCK on startup. This is useful
+// when restarting a Supervisor which terminated normally.
+pub const LAUNCHER_LOCK_CLEAN_ENV: &'static str = "HAB_LAUNCHER_LOCK_CLEAN";
 /// Process exit code from Supervisor which indicates to Launcher that the Supervisor
 /// ran to completion with a successful result. The Launcher should not attempt to restart
 /// the Supervisor and should exit immediately with a successful exit code.


### PR DESCRIPTION
Added an environment variable to signal the Supervisor to release the
Launcher's process lock before attempting to obtain a new one. This
is useful for when a Supervisor shuts down gracefully and is restarted
by the Launcher. Prior to this change the Supervisor would fail to
start and exit with an `ERR_NO_RETRY_EXCODE`

![tenor-26767290](https://user-images.githubusercontent.com/54036/28686918-bbe82636-72c1-11e7-8f90-0ed016615f0a.gif)
