### PR TITLE
use 0.26.1 to build windows harts and then use current studio to test that it works

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,6 +37,7 @@ environment:
       hab_components: "core;http-client;builder-protocol;builder-depot-client;common;win-users;sup;hab-butterfly"
 
     - hab_build_action: "package"
+      hab_exe_version: "0.26.1-20170718004619"
       hab_components: "hab;plan-build-ps1;studio;sup;hab-butterfly"
 
 build_script:

--- a/support/ci/appveyor.ps1
+++ b/support/ci/appveyor.ps1
@@ -77,7 +77,7 @@ if (($env:APPVEYOR_REPO_TAG_NAME -eq "$(Get-Content VERSION)") -or (Test-SourceC
         elseif ($BuildAction -like 'package') {
             Write-Host "Download and install latest release of hab.exe"
             $bootstrapDir = "c:\habitat"
-            $url = "https://api.bintray.com/content/habitat/stable/windows/x86_64/hab-%24latest-x86_64-windows.zip?bt_package=hab-x86_64-windows"
+            $url = "https://api.bintray.com/content/habitat/stable/windows/x86_64/hab-$($env:hab_exe_version)-x86_64-windows.zip?bt_package=hab-x86_64-windows"
             mkdir $bootstrapDir -Force
             # download a hab binary to build hab from source in a studio
             Invoke-WebRequest -UseBasicParsing -Uri $url -OutFile hab.zip
@@ -135,7 +135,7 @@ if (($env:APPVEYOR_REPO_TAG_NAME -eq "$(Get-Content VERSION)") -or (Test-SourceC
                 }
                 if ($component -eq "studio") {
                     # Now that we have built the studio we can use current hab and studio bits
-                    Copy-Item "/hab/pkgs/core/hab/*/*/bin/*" $bootstrapDir -Force
+                    Copy-Item "/hab/pkgs/core/hab/*/*/bin/*" (Split-Path $habExe -Parent) -Force
                 }
             }
         }


### PR DESCRIPTION
This does 2 things:

* Uses 0.26.1 to build the windows harts in appveyor because 0.27.0 will panic. We should use `latest` after 0.27.1 releases.
* Once the new studio is built. use that new studio to build the rest of the components. This should have been working before but had a bug because the built executable was copies one level too shallow. This should prevent a panicking studio from releasing again.

Signed-off-by: Matt Wrock <matt@mattwrock.com>