### PR TITLE
Honor channels and an alternate depot URL when exporting packages

### DIFF
--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -170,6 +170,18 @@ pub fn get() -> App<'static, 'static> {
                     "The export format (ex: docker, aci, mesos, or tar)")
                 (@arg PKG_IDENT: +required +takes_value
                     "A package identifier (ex: core/redis, core/busybox-static/1.42.2)")
+                (@arg DEPOT_URL: --url -u +takes_value {valid_url}
+                    "Retrieve the container's package from the specified Depot \
+                    (default: https://bldr.habitat.sh/v1/depot)")
+                (@arg CHANNEL: --channel -c +takes_value
+                    "Retrieve the container's package from the specified release channel \
+                    (default: stable)")
+                (@arg HAB_DEPOT_URL: --("hab-url") -U +takes_value {valid_url}
+                    "Retrieve the Habitat toolchain for the container from the specified Depot \
+                    (default: https://bldr.habitat.sh/v1/depot)")
+                (@arg HAB_CHANNEL: --("hab-channel") -C +takes_value
+                    "Retrieve the Habitat toolchain for the container from the specified release \
+                    channel (default: stable)")
             )
             (@subcommand hash =>
                 (about: "Generates a blake2b hashsum from a target at any given filepath")

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 #![cfg_attr(feature="clippy", feature(plugin))]
 #![cfg_attr(feature="clippy", plugin(clippy))]
 
@@ -324,10 +325,27 @@ fn sub_pkg_exec(m: &ArgMatches, cmd_args: Vec<OsString>) -> Result<()> {
 }
 
 fn sub_pkg_export(ui: &mut UI, m: &ArgMatches) -> Result<()> {
-    let ident = PackageIdent::from_str(m.value_of("PKG_IDENT").unwrap())?; // Required via clap
-    let format = &m.value_of("FORMAT").unwrap(); // Required via clap
+    let ident = PackageIdent::from_str(m.value_of("PKG_IDENT").unwrap())?;
+    let format = &m.value_of("FORMAT").unwrap();
+    let env_or_default = henv::var(DEPOT_URL_ENVVAR).unwrap_or(DEFAULT_DEPOT_URL.to_string());
+    let url = m.value_of("DEPOT_URL").unwrap_or(&env_or_default);
+    let channel = m.value_of("CHANNEL")
+        .and_then(|c| Some(c.to_string()))
+        .unwrap_or(channel::default());
+    let hab_url = m.value_of("HAB_DEPOT_URL").unwrap_or(&env_or_default);
+    let hab_channel = m.value_of("HAB_CHANNEL")
+        .and_then(|c| Some(c.to_string()))
+        .unwrap_or(channel::default());
     let export_fmt = command::pkg::export::format_for(ui, &format)?;
-    command::pkg::export::start(ui, &ident, &export_fmt)
+    command::pkg::export::start(
+        ui,
+        &url,
+        &channel,
+        &hab_url,
+        &hab_channel,
+        &ident,
+        &export_fmt,
+    )
 }
 
 fn sub_pkg_hash(m: &ArgMatches) -> Result<()> {


### PR DESCRIPTION
* Exporters will now by default be downloaded from the stable
  channel before running
* Add `--channel` flag to `pkg export`
* Add `--url` flag to `pkg export`

![tenor-201683009](https://user-images.githubusercontent.com/54036/28697361-2ebad4be-72f0-11e7-966b-807d3c53540c.gif)
