### PR TITLE
Hab plan init rewrite with autodetection

### DIFF
--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -291,10 +291,11 @@ pub fn get() -> App<'static, 'static> {
                     Environment variables (those starting with 'pkg_') that are set will be used \
                     in the generated plan")
                 (aliases: &["i", "in", "ini"])
-                (@arg PKG_NAME: +takes_value "Name for the new app.")
+                (@arg PKG_NAME: +takes_value "Name for the new app")
                 (@arg ORIGIN: --origin -o +takes_value "Origin for the new app")
-                (@arg NO_CALLBACKS: --nocallbacks -f
-                    "Do not include callback functions in template")
+                (@arg WITH_DOCS: --withdocs -d "Include plan options documentation")
+                (@arg WITH_CALLBACKS: --withcallbacks -f
+                    "Include callback functions in template")
             )
         )
         (@subcommand ring =>

--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -293,9 +293,13 @@ pub fn get() -> App<'static, 'static> {
                 (aliases: &["i", "in", "ini"])
                 (@arg PKG_NAME: +takes_value "Name for the new app")
                 (@arg ORIGIN: --origin -o +takes_value "Origin for the new app")
-                (@arg WITH_DOCS: --withdocs -d "Include plan options documentation")
-                (@arg WITH_CALLBACKS: --withcallbacks -f
+                (@arg WITH_DOCS: --withdocs "Include plan options documentation")
+                (@arg WITH_CALLBACKS: --withcallbacks
                     "Include callback functions in template")
+                (@arg WITH_ALL: --withall
+                    "Generate omnibus plan with all available plan options")
+                (@arg SCAFFOLDING: --scaffolding -s +takes_value
+                    "Specify explicit scaffolding type for your app")
             )
         )
         (@subcommand ring =>

--- a/components/hab/src/command/plan/init.rs
+++ b/components/hab/src/command/plan/init.rs
@@ -103,34 +103,26 @@ pub fn start(
 
     // We want to render the configured variables.
     if with_all || scaffold.is_none() {
-        let rendered_plan = try!(handlebars.template_render(FULL_PLAN_TEMPLATE, &data));
-        try!(create_with_template(
-            ui,
-            &format!("{}/plan.sh", root),
-            &rendered_plan,
-        ));
+        let rendered_plan = handlebars.template_render(FULL_PLAN_TEMPLATE, &data)?;
+        create_with_template(ui, &format!("{}/plan.sh", root), &rendered_plan)?;
     } else {
-        let rendered_plan = try!(handlebars.template_render(DEFAULT_PLAN_TEMPLATE, &data));
-        try!(create_with_template(
-            ui,
-            &format!("{}/plan.sh", root),
-            &rendered_plan,
-        ));
+        let rendered_plan = handlebars.template_render(DEFAULT_PLAN_TEMPLATE, &data)?;
+        create_with_template(ui, &format!("{}/plan.sh", root), &rendered_plan)?;
     }
-    try!(ui.para(
+    ui.para(
         "The `plan.sh` is the foundation of your new habitat. You can \
         define core metadata, dependencies, and tasks.",
-    ));
-    let rendered_default_toml = try!(handlebars.template_render(DEFAULT_TOML_TEMPLATE, &data));
-    try!(create_with_template(
+    )?;
+    let rendered_default_toml = handlebars.template_render(DEFAULT_TOML_TEMPLATE, &data)?;
+    create_with_template(
         ui,
         &format!("{}/default.toml", root),
         &rendered_default_toml,
-    ));
-    try!(ui.para(
+    )?;
+    ui.para(
         "The `default.toml` allows you to declare default values for `cfg` prefixed
         variables.",
-    ));
+    )?;
 
     let config_path = format!("{}/config/", root);
     match Path::new(&config_path).exists() {
@@ -148,10 +140,10 @@ pub fn start(
             create_dir_all(&config_path)?;
         }
     };
-    try!(ui.para(
+    ui.para(
         "The `config` directory is where you can set up configuration files for your app. \
         They are influenced by `default.toml`.",
-    ));
+    )?;
 
     let hooks_path = format!("{}/hooks/", root);
     match Path::new(&hooks_path).exists() {
@@ -169,22 +161,22 @@ pub fn start(
             create_dir_all(&hooks_path)?;
         }
     };
-    try!(ui.para(
+    ui.para(
         "The `hooks` directory is where you can create a number of automation hooks into \
         your habitat.",
-    ));
+    )?;
 
-    try!(ui.para(
+    ui.para(
         "For more information on any of the generated files: \
         https://www.habitat.sh/docs/reference/plan-syntax/#basic-settings \
         https://www.habitat.sh/docs/reference/plan-syntax/#runtime-configuration-settings \
         https://www.habitat.sh/docs/reference/plan-syntax/#hooks \
         https://www.habitat.sh/docs/reference/plan-syntax/#callbacks",
-    ));
+    )?;
 
     render_ignorefile(ui, &root)?;
 
-    try!(ui.end("An abode for your code has been initialized!"));
+    ui.end("An abode for your code has been initialized!")?;
     Ok(())
 }
 

--- a/components/hab/src/lib.rs
+++ b/components/hab/src/lib.rs
@@ -42,6 +42,7 @@ pub mod cli;
 pub mod command;
 pub mod config;
 pub mod error;
+pub mod scaffolding;
 mod exec;
 
 pub const PRODUCT: &'static str = "hab";

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -46,7 +46,9 @@ use hcore::package::PackageIdent;
 use hcore::service::ServiceGroup;
 use hcore::url::{DEFAULT_DEPOT_URL, DEPOT_URL_ENVVAR};
 
-use hab::{analytics, cli, command, config, AUTH_TOKEN_ENVVAR, ORIGIN_ENVVAR, PRODUCT, VERSION};
+use hab::{analytics, cli, command, config, scaffolding, AUTH_TOKEN_ENVVAR, ORIGIN_ENVVAR, PRODUCT,
+          VERSION};
+// the above will include scaffolding
 use hab::error::{Error, Result};
 
 /// Makes the --org CLI param optional when this env var is set
@@ -372,7 +374,18 @@ fn sub_plan_init(ui: &mut UI, m: &ArgMatches) -> Result<()> {
     let origin = try!(origin_param_or_env(&m));
     let with_docs = m.is_present("WITH_DOCS");
     let with_callbacks = m.is_present("WITH_CALLBACKS");
-    command::plan::init::start(ui, origin, with_docs, with_callbacks, name)
+    let with_all = m.is_present("WITH_ALL");
+    let scaffolding_ident = scaffolding::scaffold_check(ui, m.value_of("SCAFFOLDING"))?;
+
+    command::plan::init::start(
+        ui,
+        origin,
+        with_docs,
+        with_callbacks,
+        with_all,
+        scaffolding_ident,
+        name,
+    )
 }
 
 fn sub_pkg_install(ui: &mut UI, m: &ArgMatches) -> Result<()> {

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -369,9 +369,10 @@ fn sub_pkg_hash(m: &ArgMatches) -> Result<()> {
 
 fn sub_plan_init(ui: &mut UI, m: &ArgMatches) -> Result<()> {
     let name = m.value_of("PKG_NAME").map(|v| v.into());
-    let origin = origin_param_or_env(&m)?;
-    let include_callbacks = !m.is_present("NO_CALLBACKS");
-    command::plan::init::start(ui, origin, include_callbacks, name)
+    let origin = try!(origin_param_or_env(&m));
+    let with_docs = m.is_present("WITH_DOCS");
+    let with_callbacks = m.is_present("WITH_CALLBACKS");
+    command::plan::init::start(ui, origin, with_docs, with_callbacks, name)
 }
 
 fn sub_pkg_install(ui: &mut UI, m: &ArgMatches) -> Result<()> {

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -48,7 +48,6 @@ use hcore::url::{DEFAULT_DEPOT_URL, DEPOT_URL_ENVVAR};
 
 use hab::{analytics, cli, command, config, scaffolding, AUTH_TOKEN_ENVVAR, ORIGIN_ENVVAR, PRODUCT,
           VERSION};
-// the above will include scaffolding
 use hab::error::{Error, Result};
 
 /// Makes the --org CLI param optional when this env var is set

--- a/components/hab/src/scaffolding.rs
+++ b/components/hab/src/scaffolding.rs
@@ -1,0 +1,167 @@
+// Copyright (c) 2016-2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+use std::str::FromStr;
+use std::path::Path;
+use std::io;
+use std::fs;
+
+use error::Result;
+
+use hcore::crypto::init;
+use hcore::package::PackageIdent;
+use common::ui::{UI, Status};
+
+// Check to see if the --scaffolding passed matches available core scaffolding
+// If not check if we've been given a pkg ident for a custom scaffolding
+pub fn scaffold_check(ui: &mut UI, maybe_scaffold: Option<&str>) -> Result<Option<PackageIdent>> {
+    match maybe_scaffold {
+        Some(scaffold) => {
+            init();
+            match scaffold {
+                "core/scaffolding-ruby" |
+                "ruby" |
+                "rails" |
+                "RUBY" |
+                "ruby-scaffolding" => {
+                    let ident = PackageIdent::from_str("core/scaffolding-ruby")?;
+                    let _ = ui.status(Status::Using, &format!("ruby scaffolding '{}'", ident));
+                    Ok(Some(ident))
+                }
+                "core/scaffolding-go" |
+                "go" |
+                "golang" |
+                "GO" |
+                "go-scaffolding" => {
+                    let ident = PackageIdent::from_str("core/scaffolding-go")?;
+                    let _ = ui.status(Status::Using, &format!("go scaffolding '{}'", ident));
+                    Ok(Some(ident))
+                }
+                "core/scaffolding-node" |
+                "node" |
+                "node.js" |
+                "javascript" |
+                "js" => {
+                    let ident = PackageIdent::from_str("core/scaffolding-node")?;
+                    let _ = ui.status(Status::Using, &format!("node scaffolding '{}'", ident));
+                    Ok(Some(ident))
+                }
+                _ => {
+                    let ident = PackageIdent::from_str(scaffold)?;
+                    let _ = ui.status(Status::Using, &format!("custom scaffolding: '{}'", ident));
+                    Ok(Some(ident))
+                }
+            }
+        }
+        // If nothing was passed try to autodiscover the codebase
+        // I'm not saying it's magic. But, MAGIC.
+        None => magic_function(ui),
+    }
+}
+fn magic_function(ui: &mut UI) -> Result<Option<PackageIdent>> {
+    // Determine if the current dir has an app that can use
+    // one of our scaffoldings and use it by default
+    try!(ui.begin("Attempting autodiscovery "));
+    try!(ui.para(
+        "No scaffolding type was provided. Let's see if we can figure out \
+        what kind of application you're planning to package.",
+    ));
+    let current_path = Path::new(".");
+    if is_project_ruby(&current_path) {
+        let ident = PackageIdent::from_str("core/scaffolding-ruby")?;
+        try!(ui.begin("We've detected your app as Ruby"));
+        let _ = ui.status(Status::Using, &format!("scaffolding package: '{}'", ident));
+        try!(ui.para(""));
+        Ok(Some(ident))
+    } else if is_project_golang(&current_path) {
+        let ident = PackageIdent::from_str("core/scaffolding-go")?;
+        try!(ui.begin("We've detected your app as Golang"));
+        let _ = ui.status(Status::Using, &format!("scaffolding package: '{}'", ident));
+        try!(ui.para(""));
+        Ok(Some(ident))
+    } else if is_project_node(&current_path) {
+        let ident = PackageIdent::from_str("core/scaffolding-node")?;
+        try!(ui.begin("We've detected your app as Node.js"));
+        let _ = ui.status(Status::Using, &format!("scaffolding package: '{}'", ident));
+        try!(ui.para(""));
+        Ok(Some(ident))
+    } else {
+        try!(ui.warn(
+            "Unable to determine the type of app in your current directory",
+        ));
+        try!(ui.para(
+            "For now, we'll generate a plan with all of the available plan options and callbacks. \
+            For more documentation on plan options try passing --withdocs or visit \
+            https://www.habitat.sh/docs/reference/plan-syntax/",
+        ));
+        Ok(None)
+    }
+}
+
+fn is_project_ruby(path: &Path) -> bool {
+    if path.join("Gemfile").is_file() {
+        return true;
+    }
+
+    if let Some(parent) = path.parent() {
+        return is_project_ruby(&parent);
+    }
+
+    return false;;
+}
+
+fn is_project_golang(path: &Path) -> bool {
+    if path.join("main.go").is_file() || path.join("Godeps/Godeps.json").is_file() ||
+        path.join("vendor/vendor.json").is_file() || path.join("glide.yaml").is_file() ||
+        project_uses_gb(path).expect("Result<bool> not returned from .go file check")
+    {
+        return true;
+    }
+
+    if let Some(parent) = path.parent() {
+        return is_project_golang(&parent);
+    }
+
+    return false;;
+}
+
+fn is_project_node(path: &Path) -> bool {
+    if path.join("package.json").is_file() {
+        return true;
+    }
+
+    if let Some(parent) = path.parent() {
+        return is_project_node(&parent);
+    }
+
+    return false;;
+}
+
+fn project_uses_gb(dir: &Path) -> io::Result<(bool)> {
+    if dir.is_dir() {
+        for entry in fs::read_dir(dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            if path.is_dir() {
+                project_uses_gb(&path)?;
+            } else if path.is_file() {
+                if path.extension().unwrap() == "go" {
+                    return Ok(true);
+                }
+            } else {
+                return Ok(false);
+            }
+        }
+    }
+    return Ok(false);;
+}

--- a/components/hab/static/default_template_plan.sh
+++ b/components/hab/static/default_template_plan.sh
@@ -1,0 +1,26 @@
+{{#if with_docs ~}}
+# This file is the heart of your application's habitat.
+# See full docs at https://www.habitat.sh/docs/reference/plan-syntax/
+
+# Required.
+# Sets the name of the package. This will be used in along with `pkg_origin`,
+# and `pkg_version` to define the fully-qualified package name, which determines
+# where the package is installed to on disk, how it is referred to in package
+# metadata, and so on.
+{{/if}}
+pkg_name={{ pkg_name }}
+{{#if with_docs ~}}
+# Required unless overridden by the `HAB_ORIGIN` environment variable.
+# The origin is used to denote a particular upstream of a package.
+{{/if}}
+pkg_origin={{ pkg_origin }}
+{{#if with_docs ~}}
+# Required.
+# Sets the version of the package
+{{/if}}.
+{{#if pkg_version ~}}
+pkg_version="{{ pkg_version }}"
+{{else ~}}
+pkg_version="0.1.0"
+{{/if}}
+pkg_scaffolding="TODO:Codebase Detection"

--- a/components/hab/static/default_template_plan.sh
+++ b/components/hab/static/default_template_plan.sh
@@ -7,20 +7,63 @@
 # and `pkg_version` to define the fully-qualified package name, which determines
 # where the package is installed to on disk, how it is referred to in package
 # metadata, and so on.
-{{/if}}
+{{/if ~}}
 pkg_name={{ pkg_name }}
 {{#if with_docs ~}}
 # Required unless overridden by the `HAB_ORIGIN` environment variable.
 # The origin is used to denote a particular upstream of a package.
-{{/if}}
+{{/if ~}}
 pkg_origin={{ pkg_origin }}
 {{#if with_docs ~}}
 # Required.
 # Sets the version of the package
-{{/if}}.
+{{/if ~}}
 {{#if pkg_version ~}}
 pkg_version="{{ pkg_version }}"
-{{else ~}}
-pkg_version="0.1.0"
-{{/if}}
-pkg_scaffolding="TODO:Codebase Detection"
+{{/if ~}}
+pkg_scaffolding="{{ scaffolding_ident }}"
+{{#if with_callbacks ~}}
+do_begin() {
+  return 0
+}
+
+do_download() {
+  do_default_download
+}
+
+do_verify() {
+  do_default_verify
+}
+
+do_clean() {
+  do_default_clean
+}
+
+do_unpack() {
+  do_default_unpack
+}
+
+do_prepare() {
+  return 0
+}
+
+do_build() {
+  do_default_build
+}
+
+do_check() {
+  return 0
+}
+
+do_install() {
+  do_default_install
+}
+
+do_strip() {
+  do_default_strip
+}
+
+do_end() {
+  return 0
+}
+{{/if ~}}

--- a/components/hab/static/full_template_plan.sh
+++ b/components/hab/static/full_template_plan.sh
@@ -352,7 +352,6 @@ do_end() {
 }
 {{/if ~}}
 {{else ~}}
-
 pkg_name={{ pkg_name }}
 pkg_origin={{ pkg_origin }}
 {{#if pkg_version ~}}
@@ -369,6 +368,9 @@ pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license={{ pkg_license }}
 {{else ~}}
 pkg_license=('Apache-2.0')
+{{/if ~}}
+{{#if scaffolding_ident ~}}
+pkg_scaffolding="{{ scaffolding_ident }}"
 {{/if ~}}
 {{#if pkg_source ~}}
 pkg_source="{{ pkg_source }}"
@@ -517,5 +519,6 @@ do_strip() {
 do_end() {
   return 0
 }
+
 {{/if ~}}
 {{/if ~}}

--- a/components/hab/static/full_template_plan.sh
+++ b/components/hab/static/full_template_plan.sh
@@ -1,3 +1,4 @@
+{{#if with_docs ~}}
 # This file is the heart of your application's habitat.
 # See full docs at https://www.habitat.sh/docs/reference/plan-syntax/
 
@@ -13,27 +14,30 @@ pkg_name={{ pkg_name }}
 pkg_origin={{ pkg_origin }}
 
 # Required.
-# Sets the version of the package.
+# Sets the version of the package
 {{#if pkg_version ~}}
 pkg_version="{{ pkg_version }}"
 {{else ~}}
 pkg_version="0.1.0"
 {{/if}}
+
 # Optional.
 # The name and email address of the package maintainer.
 {{#if pkg_maintainer ~}}
 pkg_maintainer="{{ pkg_maintainer }}"
 {{else ~}}
-# pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 {{/if}}
+
 # Optional.
 # An array of valid software licenses that relate to this package.
 # Please choose a license from http://spdx.org/licenses/
 {{#if pkg_license ~}}
 pkg_license={{ pkg_license }}
 {{else ~}}
-# pkg_license=('Apache-2.0')
+pkg_license=('Apache-2.0')
 {{/if}}
+
 # Optional.
 # A URL that specifies where to download the source from. Any valid wget url
 # will work. Typically, the relative path for the URL is partially constructed
@@ -44,6 +48,7 @@ pkg_source="{{ pkg_source }}"
 {{else ~}}
 pkg_source="http://some_source_url/releases/${pkg_name}-${pkg_version}.tar.gz"
 {{/if}}
+
 # Optional.
 # The resulting filename for the download, typically constructed from the
 # pkg_name and pkg_version values.
@@ -52,6 +57,7 @@ pkg_filename="{{ pkg_filename }}"
 {{else ~}}
 # pkg_filename="${pkg_name}-${pkg_version}.tar.gz"
 {{/if}}
+
 # Required if a valid URL is provided for pkg_source or unless do_verify() is overridden.
 # The value for pkg_shasum is a sha-256 sum of the downloaded pkg_source. If you
 # do not have the checksum, you can easily generate it by downloading the source
@@ -63,6 +69,7 @@ pkg_shasum="{{ pkg_shasum }}"
 {{else ~}}
 pkg_shasum="TODO"
 {{/if}}
+
 # Optional.
 # An array of package dependencies needed at runtime. You can refer to packages
 # at three levels of specificity: `origin/package`, `origin/package/version`, or
@@ -70,15 +77,17 @@ pkg_shasum="TODO"
 {{#if pkg_deps ~}}
 pkg_deps={{ pkg_deps }}
 {{else ~}}
-# pkg_deps=(core/glibc)
+pkg_deps=(core/glibc)
 {{/if}}
+
 # Optional.
 # An array of the package dependencies needed only at build time.
 {{#if pkg_build_deps ~}}
 pkg_build_deps={{ pkg_build_deps }}
 {{else ~}}
-# pkg_build_deps=(core/make core/gcc)
+pkg_build_deps=(core/make core/gcc)
 {{/if}}
+
 # Optional.
 # An array of paths, relative to the final install of the software, where
 # libraries can be found. Used to populate LD_FLAGS and LD_RUN_PATH for
@@ -88,6 +97,7 @@ pkg_lib_dirs={{ pkg_lib_dirs }}
 {{else ~}}
 # pkg_lib_dirs=(lib)
 {{/if}}
+
 # Optional.
 # An array of paths, relative to the final install of the software, where
 # headers can be found. Used to populate CFLAGS for software that depends on
@@ -97,6 +107,7 @@ pkg_include_dirs={{ pkg_include_dirs }}
 {{else ~}}
 # pkg_include_dirs=(include)
 {{/if}}
+
 # Optional.
 # An array of paths, relative to the final install of the software, where
 # binaries can be found. Used to populate PATH for software that depends on
@@ -106,6 +117,7 @@ pkg_bin_dirs={{ pkg_bin_dirs }}
 {{else ~}}
 # pkg_bin_dirs=(bin)
 {{/if}}
+
 # Optional.
 # An array of paths, relative to the final install of the software, where
 # pkg-config metadata (.pc files) can be found. Used to populate
@@ -115,6 +127,7 @@ pkg_pconfig_dirs={{ pkg_pconfig_dirs }}
 {{else ~}}
 # pkg_pconfig_dirs=(lib/pconfig)
 {{/if}}
+
 # Optional.
 # The command for the supervisor to execute when starting a service. You can
 # omit this setting if your package is not intended to be run directly by a
@@ -124,6 +137,7 @@ pkg_svc_run="{{ pkg_svc_run }}"
 {{else ~}}
 # pkg_svc_run="bin/haproxy -f $pkg_svc_config_path/haproxy.conf"
 {{/if}}
+
 # Optional.
 # An associative array representing configuration data which should be gossiped to peers. The keys
 # in this array represent the name the value will be assigned and the values represent the toml path
@@ -137,6 +151,7 @@ pkg_exports={{ pkg_exports }}
 #   [ssl-port]=srv.ssl.port
 # )
 {{/if}}
+
 # Optional.
 # An array of `pkg_exports` keys containing default values for which ports that this package
 # exposes. These values are used as sensible defaults for other tools. For example, when exporting
@@ -146,6 +161,7 @@ pkg_exposes={{ pkg_exposes }}
 {{else ~}}
 # pkg_exposes=(port ssl-port)
 {{/if}}
+
 # Optional.
 # An associative array representing services which you depend on and the configuration keys that
 # you expect the service to export (by their `pkg_exports`). These binds *must* be set for the
@@ -159,6 +175,7 @@ pkg_binds={{ pkg_binds }}
 #   [database]="port host"
 # )
 {{/if}}
+
 # Optional.
 # Same as `pkg_binds` but these represent optional services to connect to.
 {{#if pkg_binds_optional ~}}
@@ -168,6 +185,7 @@ pkg_binds_optional={{ pkg_binds_optional }}
 #   [storage]="port host"
 # )
 {{/if}}
+
 # Optional.
 # An array of interpreters used in shebang lines for scripts. Specify the
 # subdirectory where the binary is relative to the package, for example,
@@ -180,6 +198,7 @@ pkg_interpreters={{ pkg_interpreters }}
 {{else ~}}
 # pkg_interpreters=(bin/bash)
 {{/if}}
+
 # Optional.
 # The user to run the service as. The default is hab.
 {{#if pkg_svc_user ~}}
@@ -187,6 +206,7 @@ pkg_svc_user="{{ pkg_svc_user }}"
 {{else ~}}
 # pkg_svc_user="hab"
 {{/if}}
+
 # Optional.
 # The group to run the service as. The default is hab.
 {{#if pkg_svc_group ~}}
@@ -194,6 +214,7 @@ pkg_svc_group="{{ pkg_svc_group }}"
 {{else ~}}
 # pkg_svc_group="$pkg_svc_user"
 {{/if}}
+
 # Required for core plans, optional otherwise.
 # A short description of the package. It can be a simple string, or you can
 # create a multi-line description using markdown to provide a rich description
@@ -203,6 +224,7 @@ pkg_description="{{ pkg_description }}"
 {{else ~}}
 # pkg_description="Some description."
 {{/if}}
+
 # Required for core plans, optional otherwise.
 # The project home page for the package.
 {{#if pkg_upstream_url ~}}
@@ -211,7 +233,7 @@ pkg_upstream_url="{{ pkg_upstream_url }}"
 # pkg_upstream_url="http://example.com/project-name"
 {{/if}}
 
-{{#if include_callbacks ~}}
+{{#if with_callbacks ~}}
 # Callback Functions
 #
 # When defining your plan, you have the flexibility to override the default
@@ -328,4 +350,172 @@ do_strip() {
 do_end() {
   return 0
 }
+{{/if ~}}
+{{else ~}}
+
+pkg_name={{ pkg_name }}
+pkg_origin={{ pkg_origin }}
+{{#if pkg_version ~}}
+pkg_version="{{ pkg_version }}"
+{{else ~}}
+pkg_version="0.1.0"
+{{/if ~}}
+{{#if pkg_maintainer ~}}
+pkg_maintainer="{{ pkg_maintainer }}"
+{{else ~}}
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+{{/if~}}
+{{#if pkg_license ~}}
+pkg_license={{ pkg_license }}
+{{else ~}}
+pkg_license=('Apache-2.0')
+{{/if ~}}
+{{#if pkg_source ~}}
+pkg_source="{{ pkg_source }}"
+{{else ~}}
+pkg_source="http://some_source_url/releases/${pkg_name}-${pkg_version}.tar.gz"
+{{/if ~}}
+{{#if pkg_filename ~}}
+pkg_filename="{{ pkg_filename }}"
+{{else ~}}
+# pkg_filename="${pkg_name}-${pkg_version}.tar.gz"
+{{/if ~}}
+{{#if pkg_shasum ~}}
+pkg_shasum="{{ pkg_shasum }}"
+{{else ~}}
+# pkg_shasum="TODO"
+{{/if ~}}
+{{#if pkg_deps ~}}
+pkg_deps={{ pkg_deps }}
+{{else ~}}
+# pkg_deps=(core/glibc)
+{{/if ~}}
+{{#if pkg_build_deps ~}}
+pkg_build_deps={{ pkg_build_deps }}
+{{else ~}}
+# pkg_build_deps=(core/make core/gcc)
+{{/if ~}}
+{{#if pkg_lib_dirs ~}}
+pkg_lib_dirs={{ pkg_lib_dirs }}
+{{else ~}}
+# pkg_lib_dirs=(lib)
+{{/if ~}}
+{{#if pkg_include_dirs ~}}
+pkg_include_dirs={{ pkg_include_dirs }}
+{{else ~}}
+# pkg_include_dirs=(include)
+{{/if ~}}
+{{#if pkg_bin_dirs ~}}
+pkg_bin_dirs={{ pkg_bin_dirs }}
+{{else ~}}
+# pkg_bin_dirs=(bin)
+{{/if ~}}
+{{#if pkg_pconfig_dirs ~}}
+pkg_pconfig_dirs={{ pkg_pconfig_dirs }}
+{{else ~}}
+# pkg_pconfig_dirs=(lib/pconfig)
+{{/if ~}}
+{{#if pkg_svc_run ~}}
+pkg_svc_run="{{ pkg_svc_run }}"
+{{else ~}}
+# pkg_svc_run="bin/haproxy -f $pkg_svc_config_path/haproxy.conf"
+{{/if ~}}
+{{#if pkg_exports ~}}
+pkg_exports={{ pkg_exports }}
+{{else ~}}
+# pkg_exports=(
+#   [host]=srv.address
+#   [port]=srv.port
+#   [ssl-port]=srv.ssl.port
+# )
+{{/if ~}}
+{{#if pkg_exposes ~}}
+pkg_exposes={{ pkg_exposes }}
+{{else ~}}
+# pkg_exposes=(port ssl-port)
+{{/if ~}}
+{{#if pkg_binds ~}}
+pkg_binds={{ pkg_binds }}
+{{else ~}}
+# pkg_binds=(
+#   [database]="port host"
+# )
+{{/if ~}}
+{{#if pkg_binds_optional ~}}
+pkg_binds_optional={{ pkg_binds_optional }}
+{{else ~}}
+# pkg_binds_optional=(
+#   [storage]="port host"
+# )
+{{/if ~}}
+{{#if pkg_interpreters ~}}
+pkg_interpreters={{ pkg_interpreters }}
+{{else ~}}
+# pkg_interpreters=(bin/bash)
+{{/if ~}}
+{{#if pkg_svc_user ~}}
+pkg_svc_user="{{ pkg_svc_user }}"
+{{else ~}}
+# pkg_svc_user="hab"
+{{/if ~}}
+{{#if pkg_svc_group ~}}
+pkg_svc_group="{{ pkg_svc_group }}"
+{{else ~}}
+# pkg_svc_group="$pkg_svc_user"
+{{/if ~}}
+{{#if pkg_description ~}}
+pkg_description="{{ pkg_description }}"
+{{else ~}}
+# pkg_description="Some description."
+{{/if ~}}
+{{#if pkg_upstream_url ~}}
+pkg_upstream_url="{{ pkg_upstream_url }}"
+{{else ~}}
+# pkg_upstream_url="http://example.com/project-name"
+{{/if ~}}
+{{#if with_callbacks ~}}
+do_begin() {
+  return 0
+}
+
+do_download() {
+  do_default_download
+}
+
+do_verify() {
+  do_default_verify
+}
+
+do_clean() {
+  do_default_clean
+}
+
+do_unpack() {
+  do_default_unpack
+}
+
+do_prepare() {
+  return 0
+}
+
+do_build() {
+  do_default_build
+}
+
+do_check() {
+  return 0
+}
+
+do_install() {
+  do_default_install
+}
+
+do_strip() {
+  do_default_strip
+}
+
+do_end() {
+  return 0
+}
+{{/if ~}}
 {{/if ~}}


### PR DESCRIPTION
Signed-off-by: eeyun <ihenry@chef.io>

This pr is the first iteration of rewriting the `hab plan init` subcommand to start using auto detection and push new users towards leveraging the scaffolding.

A reminder that this pr consists of the first two commits that move towards utilizing this autodiscovery behavior out of the box for new users.

