### PR TITLE
Better async job status handling

### DIFF
--- a/components/builder-jobsrv/src/error.rs
+++ b/components/builder-jobsrv/src/error.rs
@@ -17,6 +17,7 @@ use db;
 use extern_url;
 use hab_core;
 use hab_net;
+use protocol;
 use postgres;
 use protobuf;
 use r2d2;
@@ -55,7 +56,7 @@ pub enum Error {
     ProjectJobsGet(postgres::error::Error),
     Protobuf(protobuf::ProtobufError),
     UnknownVCS,
-    UnknownJobState,
+    UnknownJobState(protocol::jobsrv::Error),
     Zmq(zmq::Error),
 }
 
@@ -113,7 +114,7 @@ impl fmt::Display for Error {
                 format!("Database error getting jobs for project, {}", e)
             }
             Error::UnknownVCS => format!("Unknown VCS"),
-            Error::UnknownJobState => format!("Unknown Job State"),
+            Error::UnknownJobState(ref e) => format!("{}", e),
             Error::Zmq(ref e) => format!("{}", e),
         };
         write!(f, "{}", msg)
@@ -148,7 +149,7 @@ impl error::Error for Error {
             Error::NetError(ref err) => err.description(),
             Error::ProjectJobsGet(ref err) => err.description(),
             Error::Protobuf(ref err) => err.description(),
-            Error::UnknownJobState => "Unknown Job State",
+            Error::UnknownJobState(ref err) => err.description(),
             Error::UnknownVCS => "Unknown VCS",
             Error::Zmq(ref err) => err.description(),
         }

--- a/components/builder-scheduler/src/error.rs
+++ b/components/builder-scheduler/src/error.rs
@@ -45,13 +45,16 @@ pub enum Error {
     GroupPending(postgres::error::Error),
     GroupSetState(postgres::error::Error),
     ProjectSetState(postgres::error::Error),
+    MessageInsert(postgres::error::Error),
+    MessageGet(postgres::error::Error),
+    MessageDelete(postgres::error::Error),
     NetError(hab_net::Error),
     ProtoNetError(protocol::net::NetError),
     Protobuf(protobuf::ProtobufError),
     UnknownGroup,
     UnknownGroupState,
     UnknownProjectState,
-    UnknownJobState,
+    UnknownJobState(protocol::jobsrv::Error),
     UnknownPackage,
     Zmq(zmq::Error),
     ChannelCreate(depot_client::Error),
@@ -85,13 +88,31 @@ impl fmt::Display for Error {
             Error::GroupPending(ref e) => format!("Database error getting pending group, {}", e),
             Error::GroupSetState(ref e) => format!("Database error setting group state, {}", e),
             Error::ProjectSetState(ref e) => format!("Database error setting project state, {}", e),
+            Error::MessageInsert(ref e) => {
+                format!(
+                    "Database error inserting a message to the message queue, {}",
+                    e
+                )
+            }
+            Error::MessageGet(ref e) => {
+                format!(
+                    "Database error retrieving a message from the message queue, {}",
+                    e
+                )
+            }
+            Error::MessageDelete(ref e) => {
+                format!(
+                    "Database error deleting a message from the message queue, {}",
+                    e
+                )
+            }
             Error::NetError(ref e) => format!("{}", e),
             Error::ProtoNetError(ref e) => format!("{}", e),
             Error::Protobuf(ref e) => format!("{}", e),
             Error::UnknownGroup => format!("Unknown Group"),
             Error::UnknownGroupState => format!("Unknown Group State"),
             Error::UnknownProjectState => format!("Unknown Project State"),
-            Error::UnknownJobState => format!("Unknown Job State"),
+            Error::UnknownJobState(ref e) => format!("{}", e),
             Error::UnknownPackage => format!("Unknown Package"),
             Error::Zmq(ref e) => format!("{}", e),
             Error::ChannelCreate(ref e) => format!("{}", e),
@@ -120,13 +141,16 @@ impl error::Error for Error {
             Error::GroupPending(ref err) => err.description(),
             Error::GroupSetState(ref err) => err.description(),
             Error::ProjectSetState(ref err) => err.description(),
+            Error::MessageInsert(ref err) => err.description(),
+            Error::MessageGet(ref err) => err.description(),
+            Error::MessageDelete(ref err) => err.description(),
             Error::NetError(ref err) => err.description(),
             Error::ProtoNetError(ref err) => err.description(),
             Error::Protobuf(ref err) => err.description(),
             Error::UnknownGroup => "Unknown Group",
             Error::UnknownGroupState => "Unknown Group State",
             Error::UnknownProjectState => "Unknown Project State",
-            Error::UnknownJobState => "Unknown Job State",
+            Error::UnknownJobState(ref err) => err.description(),
             Error::UnknownPackage => "Unknown Package",
             Error::Zmq(ref err) => err.description(),
             Error::ChannelCreate(ref err) => err.description(),


### PR DESCRIPTION
This change fixes a race condition in the builder-scheduler where a job status can get lost. Now, the incoming job status is persisted by the handler thread, and later picked up from the datastore to be processed by the scheduler. Switching over to this mode also yields a simplification where we can eliminate the need to keep a separate socket around for status notifications.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-248153294](https://user-images.githubusercontent.com/13542112/28741493-cbfd2dcc-73cb-11e7-9372-28c3f926e69d.gif)
