### PR TITLE
Initial CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,5 @@
+components/builder-web @cnunciato
+components/builder-* @chefsalim
+components/butterfly* @christophermaier
+components/sup @christophermaier
+www @cnunciato


### PR DESCRIPTION
Adds an initial [CODEOWNERS](https://help.github.com/articles/about-codeowners/) file to the repo. People tagged in this file will be automatically pinged when PRs come in that affect any of the referenced files.

I have initially added only myself and @chefsalim, since I know which corners of the code we both own. I didn't want to speak for others, though, so please add yourself to corners of the code you wish to be an owner of.