### PR TITLE
Fix typo in param

### DIFF
--- a/components/builder-scheduler/src/data_store.rs
+++ b/components/builder-scheduler/src/data_store.rs
@@ -347,9 +347,9 @@ impl DataStore {
 
         // Check for an active (Pending or Dispatched) group with a given root project name
         migrator.migrate("scheduler",
-                        r#"CREATE OR REPLACE FUNCTION check_active_group_v1(project_name text) RETURNS SETOF groups AS $$
+                        r#"CREATE OR REPLACE FUNCTION check_active_group_v1(pname text) RETURNS SETOF groups AS $$
                                SELECT * FROM groups
-                               WHERE project_name = project_name
+                               WHERE project_name = pname
                                AND group_state IN ('Pending', 'Dispatching')
                         $$ LANGUAGE SQL VOLATILE"#)?;
 


### PR DESCRIPTION
Fix a typo in a param name that made a clause in the check_active_group_v1 function a no-op. Fixing the function directly since we haven't deployed it outside of acceptance yet (normally this would merit a new function and code change).

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-32721475](https://user-images.githubusercontent.com/13542112/28988026-d2fff22e-7922-11e7-9f3a-0f88448c7694.gif)
