### PR TITLE
mount docker.sock on windows host even if it is not a file

### DIFF
--- a/components/hab/src/command/studio.rs
+++ b/components/hab/src/command/studio.rs
@@ -227,7 +227,7 @@ mod inner {
         if let Ok(cache_artifact_path) = henv::var(super::ARTIFACT_PATH_ENVVAR) {
             volumes.push(format!("{}:/{}", cache_artifact_path, CACHE_ARTIFACT_PATH));
         }
-        if Path::new(DOCKER_SOCKET).exists() {
+        if Path::new(DOCKER_SOCKET).exists() || cfg!(target_os = "windows") {
             volumes.push(format!("{}:{}", DOCKER_SOCKET, DOCKER_SOCKET));
         }
 


### PR DESCRIPTION
In a recent release the docker studio on windows has lost contact with the host docker daemon causing `hab pkg export` to fail. We look to see if `/var/run/docker.sock` exists and then mount it. It will not exist on the windows host because the actual docker engine runs on a small linux vm. We should mount that socket regardless from a windows host so that it can connect to the daemon on that vm.

I have tested this PR on windows (tweaking the version so that it pulls the right image) and confirmed `hab pkg export` works.

Signed-off-by: Matt Wrock <matt@mattwrock.com>