### PR TITLE
Corrects unexpected failure with hab-pkg-dockerize

### DIFF
--- a/components/studio/bin/hab-studio.sh
+++ b/components/studio/bin/hab-studio.sh
@@ -577,9 +577,21 @@ EOF
   # Studio filesystem so that commands such as `wget(1)` will work
   for f in /etc/hosts /etc/resolv.conf /etc/nsswitch.conf; do
     $bb mkdir -p $v $($bb dirname $f)
-    $bb cp $v $f $HAB_STUDIO_ROOT$f
     if [ $f = "/etc/nsswitch.conf" ] ; then
-      echo 'hosts: files dns' > $f
+      $bb touch $HAB_STUDIO_ROOT$f
+      $bb cat <<EOF > "$f"
+passwd:     files
+group:      files
+shadow:     files
+
+hosts:      files dns
+networks:   files
+
+rpc:        files
+services:   files
+EOF
+    else
+      $bb cp $v $f $HAB_STUDIO_ROOT$f
     fi
   done
 


### PR DESCRIPTION
Turns out that when we create a container with hab-pkg-dockerize we copy files from an intermediate container into the "final" container. This was bombing out because from Scratch or from Busybox do not provide nsswitch.conf

Signed-off-by: eeyun <ihenry@chef.io>