### PR TITLE
added json support to env var configuration injection

### DIFF
--- a/components/sup/src/error.rs
+++ b/components/sup/src/error.rs
@@ -111,6 +111,7 @@ pub enum Error {
     BadPackage(PackageInstall, hcore::error::Error),
     BadSpecsPath(PathBuf, io::Error),
     BadStartStyle(String),
+    BadEnvConfig(String),
     ButterflyError(butterfly::error::Error),
     DepotClient(depot_client::Error),
     EnvJoinPathsError(env::JoinPathsError),
@@ -200,6 +201,9 @@ impl fmt::Display for SupError {
                 )
             }
             Error::BadStartStyle(ref style) => format!("Unknown service start style '{}'", style),
+            Error::BadEnvConfig(ref pkg) => {
+                format!("Unable to find valid TOML or JSON in HAB_{} ENVVAR", pkg)
+            }
             Error::ButterflyError(ref err) => format!("Butterfly error: {}", err),
             Error::ExecCommandNotFound(ref c) => {
                 format!("`{}' was not found on the filesystem or in PATH", c)
@@ -339,6 +343,7 @@ impl error::Error for SupError {
             Error::BadPackage(_, _) => "Package was malformed or contained malformed contents",
             Error::BadSpecsPath(_, _) => "Unable to create the specs directory",
             Error::BadStartStyle(_) => "Unknown start style in service spec",
+            Error::BadEnvConfig(_) => "Unknown syntax in Env Configuration",
             Error::ButterflyError(ref err) => err.description(),
             Error::ExecCommandNotFound(_) => "Exec command was not found on filesystem or in PATH",
             Error::TemplateFileError(ref err) => err.description(),

--- a/www/source/docs/run-packages-apply-config-updates.html.md
+++ b/www/source/docs/run-packages-apply-config-updates.html.md
@@ -9,13 +9,13 @@ One of the key features of Habitat is the ability to define an immutable package
 
 ## Apply configuration updates to an individual service
 When starting a single service, you can provide alternate configuration values to those specified in `default.toml` through the use of an environment variable
-with the following format: `HAB_PACKAGENAME='keyname1=newvalue1 keyname2=newvalue2'`.
+with the following format: `HAB_PACKAGENAME='{"keyname1":"newvalue1", "tablename1":{"keyname2":"newvalue2"}}'`.
 
-    HAB_MYTUTORIALAPP='message = "Habitat rocks!"' hab start <origin>/<packagename>
+    HAB_MYTUTORIALAPP='{"message":"Habitat rocks!"}' hab start <origin>/<packagename>
 
-> Note: The package name in the environment variable must be uppercase, any dashes must be replaced with underscores, and if you are overriding values in a TOML table, you must override all values in the table.
+> Note: The preferred syntax used for applying configuration through environment variables is JSON but must be valid JSON input. The package name in the environment variable must be uppercase, any dashes must be replaced with underscores.
 
-For multiline environment variables, such as those in a TOML table, it's preferable to place your changes in a .toml
+For multiline environment variables, such as those in a TOML table or nested key value pairs, it can be easier to place your changes in a .toml
 file and pass it in using `HAB_PACKAGENAME="$(cat foo.toml)"`.
 
     HAB_MYTUTORIALAPP="$(cat my-env-stuff.toml)" hab start <origin>/<packagename>


### PR DESCRIPTION
Ok, this is a tough one and at first glance it feelsbadman. But this is the outcome of https://github.com/habitat-sh/habitat/issues/1938 . For history and explanation you can read read the lengthy backscroll on the issue.

That being said for the sake of anyone following along and for the sake of historical context I'm going to put the TL;DR here:

12 Factor application patterns include a specific API for application configuration which is the ENVVVAR. As habitat has adopted a design that makes the 12 Factor approach to apps easier we've included a granular way to  configure a habitat package via a habitat prefixed environment variable `HAB_PKGNAME`. 

As users have started to discover more workflow and patterns around building and testing their apps as habitat packages some pain points have arrived around this API. What we've discovered is that there's some real pain around utilizing it to do more than set a single value. The reason being the syntax is obtuse and not easily read due to only accepting TOML as our configuration values. TOML is excellently readable in a file format, but as it is line-break delimited injecting configuration values here feels obtuse and somewhat arcane.

This problem gets exacerbated further by other developer and ops tooling around the package. The prime example being docker-compose which is a TML format and doesn't support multi-line envvars. You run into similar issues with things like kubernetes pod definitions. There are workarounds in that you can mount a file that contains your configuration into each container that you run but this adds to a negative experience for first-time users who are expecting a more natural ENVVAR api.

Through lots of discussion on the above RFC I think that we've come to the conclusion that providing JSON as an optional input type for this specific API is the least gross method for correcting the problem currently.

Signed-off-by: eeyun <ihenry@chef.io>