### PR TITLE
Don't upload to "stable" channel by default

### DIFF
--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -245,7 +245,9 @@ pub fn get() -> App<'static, 'static> {
                     "Use a specific Depot URL (ex: http://depot.example.com/v1/depot)")
                 (@arg AUTH_TOKEN: -z --auth +takes_value "Authentication token for the Depot")
                 (@arg CHANNEL: --channel -c +takes_value
-                    "Upload to the specified release channel (default: unstable)")
+                    "Additional release channel to upload package to. \
+                     Packages are always uploaded to `unstable`, regardless \
+                     of the value of this option. (default: none)")
                 (@arg HART_FILE: +required +multiple {file_exists}
                     "One or more filepaths to a Habitat Artifact \
                     (ex: /home/acme-redis-3.0.7-21120102031201-x86_64-linux.hart)")

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -488,13 +488,22 @@ fn sub_pkg_upload(ui: &mut UI, m: &ArgMatches) -> Result<()> {
     let env_or_default = henv::var(DEPOT_URL_ENVVAR).unwrap_or(DEFAULT_DEPOT_URL.to_string());
     let key_path = cache_key_path(Some(&*FS_ROOT));
     let url = m.value_of("DEPOT_URL").unwrap_or(&env_or_default);
-    let channel = m.value_of("CHANNEL")
-        .and_then(|c| Some(c.to_string()))
-        .unwrap_or(channel::default());
+
+    // When packages are uploaded, they *always* go to `unstable`;
+    // they can optionally get added to another channel, too.
+    let additional_release_channel: Option<&str> = m.value_of("CHANNEL");
+
     let token = auth_token_param_or_env(&m)?;
     let artifact_paths = m.values_of("HART_FILE").unwrap(); // Required via clap
     for artifact_path in artifact_paths {
-        command::pkg::upload::start(ui, &url, Some(&channel), &token, &artifact_path, &key_path)?;
+        command::pkg::upload::start(
+            ui,
+            &url,
+            additional_release_channel,
+            &token,
+            &artifact_path,
+            &key_path,
+        )?;
     }
     Ok(())
 }


### PR DESCRIPTION
When packages are uploaded, they *always* get added to the `unstable`
channel. However, by passing the `--channel` option to `hab pkg
upload`, users may specify an additional release channel to put the
package into.

Previously, we erroneously defaulted the value of this option to
`stable`, meaning that unless the user specified something else, every
package would be uploaded to both unstable `unstable` *and* `stable`
channels.

The fix turned out to be pretty easy. We were already passing around
an `Option` type for the channel name; now, that is simply a `None` if
the user doesn't supply a value. Docstrings, comments, and variable
names were changed to reflect this new state of affairs and make it
more clear what the desired behavior is.

Signed-off-by: Christopher Maier <cmaier@chef.io>