### PR TITLE
[sup] fix env variable name in sup error

### DIFF
--- a/components/sup/src/error.rs
+++ b/components/sup/src/error.rs
@@ -201,8 +201,8 @@ impl fmt::Display for SupError {
                 )
             }
             Error::BadStartStyle(ref style) => format!("Unknown service start style '{}'", style),
-            Error::BadEnvConfig(ref pkg) => {
-                format!("Unable to find valid TOML or JSON in HAB_{} ENVVAR", pkg)
+            Error::BadEnvConfig(ref varname) => {
+                format!("Unable to find valid TOML or JSON in {} ENVVAR", varname)
             }
             Error::ButterflyError(ref err) => format!("Butterfly error: {}", err),
             Error::ExecCommandNotFound(ref c) => {

--- a/components/sup/src/manager/service/config.rs
+++ b/components/sup/src/manager/service/config.rs
@@ -190,9 +190,7 @@ impl Cfg {
                     Err(err) => debug!("Attempted to parse env config as json and failed {}", err),
                 }
                 self.environment = None;
-                Err(sup_error!(
-                    Error::BadEnvConfig(package.name.to_ascii_uppercase())
-                ))
+                Err(sup_error!(Error::BadEnvConfig(var_name)))
             }
             Err(e) => {
                 debug!(


### PR DESCRIPTION
For a service called foo-bar, with a bad config in `HAB_FOO_BAR`, this
would log the error

    hab-sup(CF)[src/manager/service/config.rs:193:20]: Unable to find valid TOML or JSON in HAB_FOO-BAR ENVVAR

with this change, the mentioned "ENVVAR" should be HAB_FOO_BAR.

⚠️ I haven't been able to verify this change locally. It builds (so what's left to ask for?), but `cargo test` in `component/sup` (via `make shell`) fails 5 of 5 tests. Also, I wasn't able to figure out how to have the actual hart use _my_ sup instead of that core one. That said, I didn't try too hard, either, as the change _looks pretty obvious_...