### PR TITLE
Set no_intra_emphasis and with_toc_data options in redcarpet.

### DIFF
--- a/www/config.rb
+++ b/www/config.rb
@@ -1,7 +1,7 @@
 require 'slim'
 
 set :markdown_engine, :redcarpet
-set :markdown, fenced_code_blocks: true, tables: true
+set :markdown, fenced_code_blocks: true, tables: true, no_intra_emphasis: true, with_toc_data: true
 
 ###
 # Page options, layouts, aliases and proxies


### PR DESCRIPTION
Fixes #2917
Fixes #2918

Signed-off-by: Mark Harrison <mark@mivok.net>