### PR TITLE
warn when starting a studio with no origin specified

### DIFF
--- a/components/studio/libexec/hab-studio-type-default.sh
+++ b/components/studio/libexec/hab-studio-type-default.sh
@@ -51,6 +51,10 @@ finish_setup() {
         exit 1
       fi
     done
+  else
+    echo "\033[0;33mNo secret keys imported! This is likely because your HAB_ORIGIN is not set.\033[0m"
+    echo "To specify a HAB_ORIGIN, either set the HAB_ORIGIN environment variable"
+    echo "to your origin name or run 'hab setup' and specify a default origin"
   fi
 
   if [ -h "$HAB_STUDIO_ROOT$HAB_ROOT_PATH/bin/hab" ]; then


### PR DESCRIPTION
It can be confusing when entering a studio and no origin is specified when it cant find a signing key. We should be extra clear when a studio cant find any key name for importing by telling the user that no key  was imported and why.

Signed-off-by: Matt Wrock <matt@mattwrock.com>