### PR TITLE
pkg-dockerize: fix function name

### DIFF
--- a/components/pkg-dockerize/bin/hab-pkg-dockerize.sh
+++ b/components/pkg-dockerize/bin/hab-pkg-dockerize.sh
@@ -142,7 +142,7 @@ WORKDIR /
 ADD rootfs /
 VOLUME $HAB_ROOT_PATH/svc/${pkg_name}/data $HAB_ROOT_PATH/svc/${pkg_name}/config
 EXPOSE 9631 $(package_exposes $1)
-RUN ["ln", "-s", "$(pkg_latest_path core/cacerts)/ssl", "/etc/"]
+RUN ["ln", "-s", "$(package_latest_path core/cacerts)/ssl", "/etc/"]
 ENTRYPOINT ["/init.sh"]
 CMD ["start", "$1"]
 EOT


### PR DESCRIPTION
Before, `hab pkg export docker mine/foo` would have this line in the
output:

    /hab/pkgs/core/hab-pkg-dockerize/0.29.1/20170811002005/bin/hab-pkg-dockerize: line 138: pkg_latest_path: command not found

Now, it shouldn't.

Again, I've not tested this properly, I'd love to learn how I could do
that. I feel like I'd have to build a habitat artifact from this, and
then tell `hab pkg export XYZ mine/foo`, but I'm not sure what to use
for XYZ to have it pick up my hart.

(🏓 @eeyun 😉)