### PR TITLE
Re-enable Windows tutorial + copyedits and refactoring

### DIFF
--- a/www/source/tutorials/partials/_create_plan_sample_app.html.md.erb
+++ b/www/source/tutorials/partials/_create_plan_sample_app.html.md.erb
@@ -107,7 +107,7 @@ To create your plan, do the following in your terminal window:
     ```bash
     pkg_version="0.1.0"
     ```
-4. As part of the health_check hook that you will create in the next step, you also need to add a runtime dependency on `core/curl`.
+4. As part of the `health_check` hook that you will create in the next step, you also need to add a runtime dependency on `core/curl`.
 
     ```bash
     pkg_deps=( core/curl )

--- a/www/source/tutorials/partials/_platform_switcher.slim
+++ b/www/source/tutorials/partials/_platform_switcher.slim
@@ -6,5 +6,5 @@
     li class=('active' if platform == 'linux')
       = link_to 'Linux', '/tutorials/sample-app/linux/', class: 'linux'
 
-    // li class=('active' if platform == 'windows')
-    //  = link_to 'Windows', '/tutorials/sample-app/windows/', class: 'windows'
+    li class=('active' if platform == 'windows')
+     = link_to 'Windows', '/tutorials/sample-app/windows/', class: 'windows'

--- a/www/source/tutorials/partials/_prerequisites.html.md.erb
+++ b/www/source/tutorials/partials/_prerequisites.html.md.erb
@@ -10,4 +10,4 @@ to complete the tutorial without downloading the `hab` CLI, setting up your loca
 > Note: The minimum Docker version required for Habitat is greater than or equal to the version specified in the latest stable
 `core/docker` package, which currently is 1.31.1.
 
-Also, we will be using Docker Compose in the tutorial. If you already have Docker Community Edition for Mac installed and running, then you are set up to use Docker Compose. For Linux users, please follow the instructions to install <%= link_to 'Docker Compose', 'https://docs.docker.com/compose/install/', target: '_blank' %>.
+Also, we will be using Docker Compose in the tutorial. If you already have Docker Community Edition for Mac or Docker Community Edition for Windows installed and running, then you are set up to use Docker Compose. For Linux users, please follow the instructions to install <%= link_to 'Docker Compose', 'https://docs.docker.com/compose/install/', target: '_blank' %>.

--- a/www/source/tutorials/partials/_run_app_common.html.md.erb
+++ b/www/source/tutorials/partials/_run_app_common.html.md.erb
@@ -2,3 +2,43 @@ Services can currently be run in two ways: natively on a modern, 64-bit Linux di
 greater than 2.6.32, or in a supported external runtime format. Running services natively allows you to rapidly install 
 and test your services on bare metal machines or VMs, but exporting your package into a different runtime 
 format provides flexibility in where your packages run.
+
+Because this version of the tutorial shows how to use Habitat with Docker containers, we will use Docker Compose to run the containers created in the previous step.
+
+## Update the docker-compose.yml File
+
+When you cloned the `habitat-example-plans` repo, a `docker-compose.yml` file was included in the root of the `myrailsapp` directory.
+
+```yaml
+version: '3'
+services:
+  db:
+    image: core/postgresql
+    volumes:
+      - "./updated_config.toml:/updated_config.toml"
+  railsapp:
+      image: originname/myrailsapp
+      ports:
+        - 8000:8000
+      links:
+      - db
+      command: --peer db --bind database:postgresql.default
+```
+
+Let's quickly review the file to understand how these containers will be brought up.
+
+* The images for both the database and your Rails application are already installed on your local workstation as part of the `export` subcommand you ran in the last step.
+
+* As part of updating the configuration values to connect the Rails application to the PostgreSQL database, you will use a TOML file to send configuration updates between supervisors connected together in the ring. The `updated_config.toml` file is bind mounted from the root location of the `myrailsapp` directory to the root directory of the database container.
+
+* The port number for the Rails container is exposed so you can view the Rails app page from within your host browser.
+
+* The entrypoint for the Rails container has a few additional command arguments to connect it to the database container and set the binding to the appropriate database service group.
+
+Now that you understand how the docker-compose.yml file will be used, open the docker-compose.yml file in a text editor and update the following line with the name of your origin.
+
+```yaml
+image: originname/myrailsapp
+```
+
+Save the file and exit the editor.

--- a/www/source/tutorials/partials/_update_app_rake_output.html.md.erb
+++ b/www/source/tutorials/partials/_update_app_rake_output.html.md.erb
@@ -1,5 +1,4 @@
 ~~~
-$ docker-compose exec railsapp myrailsapp-rake db:setup
 Created database 'myrailsapp_production'
 -- enable_extension("plpgsql")
 D, [2017-07-17T19:40:25.811350 #118] DEBUG -- :   SQL (1.9ms)  CREATE EXTENSION IF NOT EXISTS "plpgsql"

--- a/www/source/tutorials/sample-app/basic-concepts.html.slim
+++ b/www/source/tutorials/sample-app/basic-concepts.html.slim
@@ -13,4 +13,4 @@ section
   .buttons
     =link_to 'MacOS', '/tutorials/sample-app/mac/', class: 'button outline mac'
     =link_to 'Linux', '/tutorials/sample-app/linux/', class: 'button outline linux'
-    =link_to 'Windows: Coming Soon', '/tutorials/sample-app/windows/', class: 'button outline windows', disabled: 'disabled'
+    =link_to 'Windows', '/tutorials/sample-app/windows/', class: 'button outline windows'

--- a/www/source/tutorials/sample-app/linux/add-health-check-hook.html.slim
+++ b/www/source/tutorials/sample-app/linux/add-health-check-hook.html.slim
@@ -9,6 +9,6 @@ section.sample-app
 
   = partial "/tutorials/partials/add_hooks_sample_app", locals: { is_windows: false }
 
-  p Congratulations, you have added a custom health_check hook to your sample application. It's time to build your sample Rails application.
+  p Congratulations, you have added a custom <code>health_check</code> hook to your sample application. It's time to build your sample Rails application.
 
 = link_to 'Next: Build the Package', '/tutorials/sample-app/linux/build-package/', class: 'button cta'

--- a/www/source/tutorials/sample-app/linux/run-app.html.slim
+++ b/www/source/tutorials/sample-app/linux/run-app.html.slim
@@ -9,48 +9,6 @@ section.sample-app
 
   = partial "/tutorials/partials/run_app_common"
 
-  p Because this version of the tutorial shows how to use Habitat with Docker containers, we will use Docker Compose to run the containers created in the previous step.
-
-  h2 Update the docker-compose.yml File
-
-  p When you cloned the <code>habitat-example-plans</code> repo, a <code>docker-compose.yml</code> file was included in the root of the <code>myrailsapp</code> directory.
-
-  pre
-    code.yaml
-      |
-        version: '3'
-        services:
-          db:
-            image: core/postgresql
-            volumes:
-              - "./updated_config.toml:/updated_config.toml"
-          railsapp:
-              image: originname/myrailsapp
-              ports:
-                - 8000:8000
-              links:
-              - db
-              command: --peer db --bind database:postgresql.default
-
-  p Let's quickly review the file to understand how these containers will be brought up.
-
-  ul
-    li
-      p The images for both the database and your Rails application are already installed on your local workstation as part of the <code>export</code> subcommand you ran in the last step.
-    li
-      p As part of updating the configuration values to connect the Rails application to the PostgreSQL database, you will use a TOML file to spread configuration updates between supervisors connected together in the ring. The <code>updated_config.toml</code> file is bind mounted from the root location of the <code>myrailsapp</code> directory to the root directory.
-    li
-      p The port number for the Rails container is exposed so you can view the Rails app page from within your host browser.
-    li
-      p The the entrypoint for the Rails container has a few additional command arguments to connect it to the database container and set the binding to the appropriate database service group.
-
-  p Now that you understand how the docker-compose.yml file will be used, open the docker-compose.yml file in a text editor and update the following line with the name of your origin.
-
-  pre
-    code.yaml image: originname/myrailsapp
-
-  p Save the file and exit the editor.
-
   h2 Start Up the Containers
 
   p Now that you have an understanding of how the containers will be brought up, it's time to start them up with Docker Compose.
@@ -68,8 +26,7 @@ section.sample-app
 
       = partial "/tutorials/partials/run_app_output"
 
-  blockquote
-    p Note: If you need to stop the containers at any time, run <code>Ctrl-C</code>. If you want to bring them back up, run <code>docker-compose down</code> before running <code>docker-compose up</code> again. This will ensure the IP address of the database container resolves correctly when the <code>myrailsapp</code> container tries to bind to it. If you want to remove the containers from your machine, run <code>docker-compose rm</code>.
+    p If you need to stop the containers at any time, run <code>Ctrl-C</code>. If you want to bring them back up, run <code>docker-compose down</code> before running <code>docker-compose up</code> again. This will ensure the IP address of the database container resolves correctly when the <code>myrailsapp</code> container tries to bind to it. If you want to remove the containers from your machine, run <code>docker-compose rm</code>.
 
   p Learn how to fix this error by dynamically updating the configuration of the myrailsapp package in the next step.
 

--- a/www/source/tutorials/sample-app/linux/update-app.html.slim
+++ b/www/source/tutorials/sample-app/linux/update-app.html.slim
@@ -113,7 +113,7 @@ section.sample-app
 
 	= partial "/tutorials/partials/update_app_output_2"
 
-	p Periodically, the health_check hook that you created will run in the background. You should see the output of the curl command in the supervisor log.
+	p Periodically, the <code>health_check</code> hook that you created will run in the background. You should see the output of the curl command in the supervisor log.
 
 	p Once the rake tasks have completed, you can go to #{link_to 'http://localhost:8000', 'http://localhost:8000', target: '_blank'} on your host machine to see a random value pulled from the PostgreSQL database! Feel free to refresh the page to see other values.
 

--- a/www/source/tutorials/sample-app/mac/add-health-check-hook.html.slim
+++ b/www/source/tutorials/sample-app/mac/add-health-check-hook.html.slim
@@ -9,7 +9,7 @@ section.sample-app
 
   = partial "/tutorials/partials/add_hooks_sample_app", locals: { is_windows: false }
 
-  p Congratulations, you have added a custom health_check hook to your sample application. It's time to build your sample Rails application.
+  p Congratulations, you have added a custom <code>health_check</code> hook to your sample application. It's time to build your sample Rails application.
 
 = link_to 'Next: Build the Package', '/tutorials/sample-app/mac/build-package/', class: 'button cta'
 

--- a/www/source/tutorials/sample-app/mac/run-app.html.slim
+++ b/www/source/tutorials/sample-app/mac/run-app.html.slim
@@ -9,48 +9,6 @@ section.sample-app
 
   = partial "/tutorials/partials/run_app_common"
 
-  p Because this version of the tutorial shows how to use Habitat with Docker containers, we will use Docker Compose to run the containers created in the previous step.
-
-  h2 Update the docker-compose.yml File
-
-  p When you cloned the <code>habitat-example-plans</code> repo, a <code>docker-compose.yml</code> file was included in the root of the <code>myrailsapp</code> directory.
-
-  pre
-    code.yaml
-      |
-        version: '3'
-        services:
-          db:
-            image: core/postgresql
-            volumes:
-              - "./updated_config.toml:/updated_config.toml"
-          railsapp:
-              image: originname/myrailsapp
-              ports:
-                - 8000:8000
-              links:
-              - db
-              command: --peer db --bind database:postgresql.default
-
-  p Let's quickly review the file to understand how these containers will be brought up.
-
-  ul
-    li
-      p The images for both the database and your Rails application are already installed on your local workstation as part of the <code>export</code> subcommand you ran in the last step.
-    li
-      p As part of updating the configuration values to connect the Rails application to the PostgreSQL database, you will use a TOML file to spread configuration updates between supervisors connected together in the ring. The <code>updated_config.toml</code> file is bind mounted from the root location of the <code>myrailsapp</code> directory to the root directory.
-    li
-      p The port number for the Rails container is exposed so you can view the Rails app page from within your host browser.
-    li
-      p The entrypoint for the Rails container has a few additional command arguments to connect it to the database container and set the binding to the appropriate database service group.
-
-  p Now that you understand how the docker-compose.yml file will be used, open the docker-compose.yml file in a text editor and update the following line with the name of your origin.
-
-  pre
-    code.yaml image: originname/myrailsapp
-
-  p Save the file and exit the editor.
-
   h2 Start Up the Containers
 
   p Now that you have an understanding of how the containers will be brought up, it's time to start them up with Docker Compose.
@@ -65,8 +23,7 @@ section.sample-app
 
       = partial "/tutorials/partials/run_app_output"
 
-  blockquote
-    p Note: If you need to stop the containers at any time, run <code>Ctrl-C</code>. If you want to bring them back up, run <code>docker-compose down</code> before running <code>docker-compose up</code> again. This will ensure the IP address of the database container resolves correctly when the <code>myrailsapp</code> container tries to bind to it. If you want to remove the containers from your machine, run <code>docker-compose rm</code>.
+    p If you need to stop the containers at any time, run <code>Ctrl-C</code>. If you want to bring them back up, run <code>docker-compose down</code> before running <code>docker-compose up</code> again. This will ensure the IP address of the database container resolves correctly when the <code>myrailsapp</code> container tries to bind to it. If you want to remove the containers from your machine, run <code>docker-compose rm</code>.
 
   p Learn how to fix this error by dynamically updating the configuration of the myrailsapp package in the next step.
 

--- a/www/source/tutorials/sample-app/mac/update-app.html.slim
+++ b/www/source/tutorials/sample-app/mac/update-app.html.slim
@@ -113,7 +113,7 @@ section.sample-app
 
 	= partial "/tutorials/partials/update_app_output_2"
 
-	p Periodically, the health_check hook that you created will run in the background. You should see the output of the curl command in the supervisor log.
+	p Periodically, the <code>health_check</code> hook that you created will run in the background. You should see the output of the curl command in the supervisor log.
 
 	p Once the rake tasks have completed, you can go to #{link_to 'http://localhost:8000', 'http://localhost:8000', target: '_blank'} on your host machine to see a random value pulled from the PostgreSQL database! Feel free to refresh the page to see other values.
 

--- a/www/source/tutorials/sample-app/windows/add-health-check-hook.html.slim
+++ b/www/source/tutorials/sample-app/windows/add-health-check-hook.html.slim
@@ -9,6 +9,6 @@ section.sample-app
 
   = partial "/tutorials/partials/add_hooks_sample_app", locals: { is_windows: true }
 
-  p Congratulations, you have added a custom health_check hook to your sample application. It's time to build your sample Rails application.
+  p Congratulations, you have added a custom <code>health_check</code> hook to your sample application. It's time to build your sample Rails application.
 
 = link_to 'Next: Build the Package', '/tutorials/sample-app/windows/build-package/', class: 'button cta'

--- a/www/source/tutorials/sample-app/windows/build-package.html.slim
+++ b/www/source/tutorials/sample-app/windows/build-package.html.slim
@@ -9,7 +9,7 @@ section.sample-app
 
     p The studio is an isolated environment used to build and test Habitat packages. For Windows platforms, there are two versions of the studio. One uses a Linux-based Docker container to create a #{link_to 'chrooted', 'https://en.wikipedia.org/wiki/Chroot'} shell environment and the other is a native Windows environment. Because this tutorial involves using some functionality that is currently only available for Linux-based packages, we will use the Linux-based studio that resides in a Docker container.
 
-    p The studio itself is a Habitat package, and all of the dependent packages for the studio will be downloaded, unpacked, and installed. The studio will also import any secret origin keys created by <code>hab setup</code>. When running macOS or Windows on your host machine, the studio runs inside a Docker container as root.
+    p The studio itself is a Habitat package, and all of the dependent packages for the studio will be downloaded, unpacked, and installed. The studio will also import any secret origin keys created by <code>hab setup</code>. When running Windows on your host machine, the studio runs inside a Docker container as root.
 
     p Packages are built in the studio through the <code>hab-plan-build</code> script, which handles creating Habitat packages from plan files. The <code>hab-plan-build</code> script looks for <code>plan.sh</code> either in the current directory, or in a <code>.\habitat</code> directory.
 

--- a/www/source/tutorials/sample-app/windows/run-app.html.slim
+++ b/www/source/tutorials/sample-app/windows/run-app.html.slim
@@ -9,48 +9,6 @@ section.sample-app
 
   = partial "/tutorials/partials/run_app_common"
 
-  p Because this version of the tutorial shows how to use Habitat with Docker containers, we will use Docker Compose to run the containers created in the previous step.
-
-  h2 Update the docker-compose.yml File
-
-  p When you cloned the <code>habitat-example-plans</code> repo, a <code>docker-compose.yml</code> file was included in the root of the <code>myrailsapp</code> directory.
-
-  pre
-    code.yaml
-      |
-        version: '3'
-        services:
-          db:
-            image: core/postgresql
-            volumes:
-              - "./updated_config.toml:/updated_config.toml"
-          railsapp:
-              image: originname/myrailsapp
-              ports:
-                - 8000:8000
-              links:
-              - db
-              command: --peer db --bind database:postgresql.default
-
-  p Let's quickly review the file to understand how these containers will be brought up.
-
-  ul
-    li
-      p The images for both the database and your Rails application are already installed on your local workstation as part of the <code>export</code> subcommand you ran in the last step.
-    li
-      p As part of updating the configuration values to connect the Rails application to the PostgreSQL database, you will use a TOML file to spread configuration updates between supervisors connected together in the ring. The <code>updated_config.toml</code> file is bind mounted from the root location of the <code>myrailsapp</code> directory to the root directory.
-    li
-      p The port number for the Rails container is exposed so you can view the Rails app page from within your host browser.
-    li
-      p The the entrypoint for the Rails container has a few additional command arguments to connect it to the database container and set the binding to the appropriate database service group.
-
-  p Now that you understand how the docker-compose.yml file will be used, open the docker-compose.yml file in a text editor and update the following line with the name of your origin.
-
-  pre
-    code.yaml image: originname/myrailsapp
-
-  p Save the file and exit the editor.
-
   h2 Start Up the Containers
 
   p Now that you have an understanding of how the containers will be brought up, it's time to start them up with Docker Compose.
@@ -61,15 +19,11 @@ section.sample-app
     li
       p Run <code>docker-compose up</code> to start up the containers. Missing packages will be downloaded and installed before the myrailsapp package and PostgreSQL packages start.
 
-      blockquote
-        p Note: If you did not add the <code>docker</code> group and your current user to that group after you installed Docker, you will have to use <code>sudo</code> when running <code>docker-compose</code>. For more details, see the Docker #{link_to 'Post-installation steps for Linux', 'https://docs.docker.com/engine/installation/linux/linux-postinstall/', target: '_blank'}.
-
       p If everything started up successfully, the Rails application should loop through a message similar to the following where it requires an environment variable to be set before proceeding with the rest of the initialization process.
 
       = partial "/tutorials/partials/run_app_output"
 
-  blockquote
-    p Note: If you need to stop the containers at any time, run <code>Ctrl-C</code>. If you want to bring them back up, run <code>docker-compose down</code> before running <code>docker-compose up</code> again. This will ensure the IP address of the database container resolves correctly when the <code>myrailsapp</code> container tries to bind to it. If you want to remove the containers from your machine, run <code>docker-compose rm</code>.
+    p If you need to stop the containers at any time, run <code>Ctrl-C</code>. If you want to bring them back up, run <code>docker-compose down</code> before running <code>docker-compose up</code> again. This will ensure the IP address of the database container resolves correctly when the <code>myrailsapp</code> container tries to bind to it. If you want to remove the containers from your machine, run <code>docker-compose rm</code>.
 
   p Learn how to fix this error by dynamically updating the configuration of the myrailsapp package in the next step.
 

--- a/www/source/tutorials/sample-app/windows/update-app.html.slim
+++ b/www/source/tutorials/sample-app/windows/update-app.html.slim
@@ -79,7 +79,7 @@ section.sample-app
 			p Once your containers have started, run the <code>hab config apply</code> subcommand in your new window to send configuration updates to the <code>myrailsapp.default</code> service group.
 
 			pre
-				code PS > docker-compose exec db sh -c "hab config apply --peer railsapp myrailsapp.default $(date +%s) updated_config.toml
+				code PS > docker-compose exec db sh -c "hab config apply --peer railsapp myrailsapp.default $([Math]::Truncate((Get-Date -UFormat %s))) updated_config.toml"
 
 			blockquote
 				p Note: This command executes a command directly on the running database container. If your host machine (or another container running the Habitat  supervisor) was joined to the other two services, then it could push the  configuration changes as well. Also, the command above used the <code>date</code> command to return the current date-time as seconds. Because <code>hab config apply</code> requires a positive incremental integer value, using this command is a good way of not having to manually input the value every time you make a configuration update.
@@ -113,7 +113,7 @@ section.sample-app
 
 	= partial "/tutorials/partials/update_app_output_2"
 
-	p Periodically, the health_check hook that you created will run in the background. You should see the output of the curl command in the supervisor log.
+	p Periodically, the <code>health_check</code> hook that you created will run in the background. You should see the output of the curl command in the supervisor log.
 
 	p Once the rake tasks have completed, you can go to #{link_to 'http://localhost:8000', 'http://localhost:8000', target: '_blank'} on your host machine to see a random value pulled from the PostgreSQL database! Feel free to refresh the page to see other values.
 


### PR DESCRIPTION
- Adding back in the Windows version of the tutorial after testing the changes out with 0.29.1.

- Did a bit of minor refactoring and copyedits

Signed-off-by: David Wrede <dwrede@chef.io>