### PR TITLE
Add hab-launcher to studio baseimage

### DIFF
--- a/components/studio/libexec/hab-studio-type-baseimage.sh
+++ b/components/studio/libexec/hab-studio-type-baseimage.sh
@@ -6,7 +6,7 @@ studio_build_command=
 studio_run_environment=
 studio_run_command=
 
-base_pkgs="core/hab core/hab-sup"
+base_pkgs="core/hab core/hab-launcher core/hab-sup"
 : ${PKGS:=}
 
 run_user="hab"
@@ -42,7 +42,7 @@ finish_setup() {
   local busybox_path=$(_pkgpath_for core/busybox-static)
 
   local full_path=""
-  for path_pkg in $PKGS core/hab-sup core/busybox-static; do
+  for path_pkg in $PKGS core/hab-launcher core/hab-sup core/busybox-static; do
     local path_file="$HAB_STUDIO_ROOT/$(_pkgpath_for $path_pkg)/PATH"
     if [ -f "$path_file" ]; then
       if [ -z "$full_path" ]; then


### PR DESCRIPTION
When a exported docker container is run initially the launcher is
downloaded. This change makes the container self contained with the
launcher already installed during the export process.

Fixes https://github.com/habitat-sh/habitat/issues/2935

Signed-off-by: Justin Carter <justin@starkandwayne.com>