### PR TITLE
Make sure nsswitch.conf is created inside the studio filesystem

### DIFF
--- a/components/studio/bin/hab-studio.sh
+++ b/components/studio/bin/hab-studio.sh
@@ -580,7 +580,7 @@ EOF
     $bb mkdir -p $v $($bb dirname $f)
     if [ $f = "/etc/nsswitch.conf" ] ; then
       $bb touch $HAB_STUDIO_ROOT$f
-      $bb cat <<EOF > "$f"
+      $bb cat <<EOF > "$HAB_STUDIO_ROOT$f"
 passwd:     files
 group:      files
 shadow:     files


### PR DESCRIPTION
Currently, when writing the custom nsswitch.conf it ends up being
written outside the studio, and overwriting the system's nsswitch.conf,
which can cause issues with systems that are configured to use LDAP or
other authentication/name resolution methods. This ensures the file is
created inside the studio.

Signed-off-by: Mark Harrison <mark@mivok.net>