### PR TITLE
only get key revisions for a requested key type

### DIFF
--- a/components/core/src/crypto/keys/box_key_pair.rs
+++ b/components/core/src/crypto/keys/box_key_pair.rs
@@ -77,7 +77,8 @@ impl BoxKeyPair {
         T: AsRef<str>,
         P: AsRef<Path>,
     {
-        let revisions = get_key_revisions(name.as_ref(), cache_key_path.as_ref(), None)?;
+        let revisions =
+            get_key_revisions(name.as_ref(), cache_key_path.as_ref(), None, &KeyType::Box)?;
         let mut key_pairs = Vec::new();
         for name_with_rev in revisions {
             debug!(

--- a/components/core/src/crypto/keys/sig_key_pair.rs
+++ b/components/core/src/crypto/keys/sig_key_pair.rs
@@ -81,7 +81,7 @@ impl SigKeyPair {
         cache_key_path: &P,
         pair_type: Option<&PairType>,
     ) -> Result<Vec<Self>> {
-        let revisions = get_key_revisions(name, cache_key_path.as_ref(), pair_type)?;
+        let revisions = get_key_revisions(name, cache_key_path.as_ref(), pair_type, &KeyType::Sig)?;
         debug!("revisions = {:?}", &revisions);
         let mut key_pairs = Vec::new();
         for name_with_rev in &revisions {

--- a/components/core/src/crypto/keys/sym_key.rs
+++ b/components/core/src/crypto/keys/sym_key.rs
@@ -68,7 +68,7 @@ impl SymKey {
         name: &str,
         cache_key_path: &P,
     ) -> Result<Vec<Self>> {
-        let revisions = get_key_revisions(name, cache_key_path.as_ref(), None)?;
+        let revisions = get_key_revisions(name, cache_key_path.as_ref(), None, &KeyType::Sym)?;
         let mut key_pairs = Vec::new();
         for name_with_rev in &revisions {
             debug!(


### PR DESCRIPTION
Currently when we pull revisions for a key, we do not discrimitate for a particular type (signing, user, ring, etc) but simply grab all revisions that match the key name. In reality keys of different types can have the same name.

When it comes to the secret keys, we could simply check the file names and rework the `check_filename` logic to ignore secret key filenames with a suffix that does not match the requested key type. However, all public keys have the same extention `.pub` and changing extensions at this point would introduce serious compatibility issues.

The only sure way to validate that a key file is of a certain type is to check its content. In particular, the first line which should begin with the key type string. This pr does that.

Signed-off-by: Matt Wrock <matt@mattwrock.com>