### PR TITLE
Fix Supervisor re-attaching to processes after update & service update

### DIFF
--- a/components/sup/src/manager/service/mod.rs
+++ b/components/sup/src/manager/service/mod.rs
@@ -242,7 +242,7 @@ impl Service {
         }
     }
 
-    pub fn stop(&mut self, launcher: Option<&LauncherCli>) {
+    pub fn stop(&mut self, launcher: &LauncherCli) {
         if let Err(err) = self.supervisor.stop(launcher) {
             outputln!(preamble self.service_group, "Service stop failed: {}", err);
         }
@@ -401,7 +401,7 @@ impl Service {
     }
 
     /// Replace the package of the running service and restart it's system process.
-    pub fn update_package(&mut self, package: PackageInstall) {
+    pub fn update_package(&mut self, package: PackageInstall, launcher: &LauncherCli) {
         match Pkg::from_install(package) {
             Ok(pkg) => {
                 outputln!(preamble self.service_group,
@@ -426,8 +426,7 @@ impl Service {
                 return;
             }
         }
-        // JW TODO: Do I need to ask the launcher to terminate this process here?
-        if let Err(err) = self.supervisor.stop(None) {
+        if let Err(err) = self.supervisor.stop(launcher) {
             outputln!(preamble self.service_group,
                       "Error stopping process while updating package: {}", err);
         }

--- a/components/sup/src/manager/service/supervisor.rs
+++ b/components/sup/src/manager/service/supervisor.rs
@@ -140,19 +140,11 @@ impl Supervisor {
         (healthy, status)
     }
 
-    pub fn stop(&mut self, launcher: Option<&LauncherCli>) -> Result<()> {
+    pub fn stop(&mut self, launcher: &LauncherCli) -> Result<()> {
         if self.pid.is_none() {
             return Ok(());
         }
-        if let Some(launcher) = launcher {
-            if let Err(err) = launcher.terminate(self.pid.unwrap()) {
-                warn!(
-                    "Unable to signal launcher to terminate {}, {}",
-                    self.pid.unwrap(),
-                    err
-                );
-            }
-        }
+        launcher.terminate(self.pid.unwrap())?;
         self.cleanup_pidfile();
         self.change_state(ProcessState::Down);
         Ok(())


### PR DESCRIPTION
This commit fixes two bugs regarding re-attaching to processes after
a supervisor update and restarting a service after an automatic update

* We now only remove a service's PID file if the Launcher is told to
  terminate a process and it returns an `Ok` result
* The Launcher is now asked to terminate a service after it was
  automatically updated

Fixes #2961

/cc @tyler-ball 

![tenor-259473773](https://user-images.githubusercontent.com/54036/29475066-0c5583b8-8413-11e7-8d7b-053715f970b1.gif)
