### PR TITLE
Add sealed box encryption support

### DIFF
--- a/components/butterfly/src/rumor/service_config.rs
+++ b/components/butterfly/src/rumor/service_config.rs
@@ -101,7 +101,7 @@ impl ServiceConfig {
 
     pub fn encrypt(&mut self, user_pair: &BoxKeyPair, service_pair: &BoxKeyPair) -> Result<()> {
         let config = self.take_config();
-        let encrypted_config = user_pair.encrypt(&config, service_pair)?;
+        let encrypted_config = user_pair.encrypt(&config, Some(service_pair))?;
         self.set_config(encrypted_config);
         self.set_encrypted(true);
         Ok(())

--- a/components/butterfly/src/rumor/service_file.rs
+++ b/components/butterfly/src/rumor/service_file.rs
@@ -108,7 +108,7 @@ impl ServiceFile {
     /// Encrypt the contents of the service file
     pub fn encrypt(&mut self, user_pair: &BoxKeyPair, service_pair: &BoxKeyPair) -> Result<()> {
         let body = self.take_body();
-        let encrypted_body = user_pair.encrypt(&body, service_pair)?;
+        let encrypted_body = user_pair.encrypt(&body, Some(service_pair))?;
         self.set_body(encrypted_body);
         self.set_encrypted(true);
         Ok(())

--- a/components/core/src/crypto/mod.rs
+++ b/components/core/src/crypto/mod.rs
@@ -250,6 +250,7 @@ pub static SIG_HASH_TYPE: &'static str = "BLAKE2b";
 pub static CACHE_KEY_PATH_ENV_VAR: &'static str = "HAB_CACHE_KEY_PATH";
 pub static HART_FORMAT_VERSION: &'static str = "HART-1";
 pub static BOX_FORMAT_VERSION: &'static str = "BOX-1";
+pub static ANONYMOUS_BOX_FORMAT_VERSION: &'static str = "ANONYMOUS-BOX-1";
 /// Create secret key files with these permissions
 static PUBLIC_KEY_PERMISSIONS: u32 = 0o400;
 static SECRET_KEY_PERMISSIONS: u32 = 0o400;

--- a/components/hab-butterfly/src/command/config.rs
+++ b/components/hab-butterfly/src/command/config.rs
@@ -85,7 +85,10 @@ pub mod apply {
                     service_pair.unwrap().name_with_rev()
                 ),
             )?;
-            body = user_pair.unwrap().encrypt(&body, service_pair.unwrap())?;
+            body = user_pair.unwrap().encrypt(
+                &body,
+                Some(service_pair.unwrap()),
+            )?;
             encrypted = true;
         }
 

--- a/components/hab-butterfly/src/command/file.rs
+++ b/components/hab-butterfly/src/command/file.rs
@@ -65,7 +65,10 @@ pub mod upload {
                     service_pair.unwrap().name_with_rev()
                 ),
             )?;
-            body = user_pair.unwrap().encrypt(&body, service_pair.unwrap())?;
+            body = user_pair.unwrap().encrypt(
+                &body,
+                Some(service_pair.unwrap()),
+            )?;
             encrypted = true;
         }
 


### PR DESCRIPTION
This change adds the ability for the core crypto library to encrypt a payload without specifying a specific recipient. This allows encryption to be done with only the sender's public key, and a private key is only needed for the decryption. This infrastructure will be leveraged in order to provide the ability for builder to store and retrieve user secrets.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-79144976](https://user-images.githubusercontent.com/13542112/29476675-f2297646-8419-11e7-9756-8fa564445504.gif)
