### PR TITLE
Don't remove pidfile in Supervisor struct's deconstructor

### DIFF
--- a/components/sup/src/manager/service/supervisor.rs
+++ b/components/sup/src/manager/service/supervisor.rs
@@ -235,12 +235,6 @@ impl Serialize for Supervisor {
     }
 }
 
-impl Drop for Supervisor {
-    fn drop(&mut self) {
-        self.cleanup_pidfile();
-    }
-}
-
 fn read_pid<T>(pid_file: T) -> Result<u32>
 where
     T: AsRef<Path>,


### PR DESCRIPTION
This fixes a problem where all PID files would be removed if the
Supervisor was shutdown gracefully. The PID files should only be
removed if the launcher no longer is running the process or if the
launcher returns success on a termination request

![tenor-165293700](https://user-images.githubusercontent.com/54036/29481567-8e95a41a-8437-11e7-9359-729d57a29832.gif)
