### PR TITLE
Add builder key retrieval API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1081,6 +1081,7 @@ dependencies = [
 name = "habitat_depot"
 version = "0.0.0"
 dependencies = [
+ "base64 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bodyparser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "builder_core 0.0.0",
  "clap 2.25.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/builder-api/habitat/config/config.toml
+++ b/components/builder-api/habitat/config/config.toml
@@ -21,4 +21,5 @@ port = {{member.cfg.port}}
 [depot]
 path = "{{pkg.svc_data_path}}"
 log_dir = "{{pkg.svc_var_path}}"
+key_dir = "{{pkg.svc_files_path}}"
 {{toToml cfg.depot}}

--- a/components/builder-api/src/main.rs
+++ b/components/builder-api/src/main.rs
@@ -23,6 +23,7 @@ extern crate habitat_core as hab_core;
 extern crate log;
 
 use std::process;
+use std::path::PathBuf;
 use std::str::FromStr;
 
 use hab_core::config::ConfigFile;
@@ -77,7 +78,7 @@ fn config_from_args(matches: &clap::ArgMatches) -> Result<Config> {
         }
     }
     if let Some(path) = args.value_of("path") {
-        config.depot.path = path.to_string();
+        config.depot.path = PathBuf::from(path);
     }
     Ok(config)
 }

--- a/components/builder-core/src/keys.rs
+++ b/components/builder-core/src/keys.rs
@@ -1,0 +1,15 @@
+// Copyright (c) 2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub const BUILDER_KEY_NAME: &'static str = "bldr";

--- a/components/builder-core/src/lib.rs
+++ b/components/builder-core/src/lib.rs
@@ -38,3 +38,4 @@ pub mod logger;
 pub mod metrics;
 pub mod package_graph;
 pub mod rdeps;
+pub mod keys;

--- a/components/builder-depot/Cargo.toml
+++ b/components/builder-depot/Cargo.toml
@@ -12,6 +12,7 @@ doc = false
 
 [dependencies]
 clippy = {version = "*", optional = true}
+base64 = "*"
 bodyparser = "*"
 env_logger = "*"
 hyper = "*"

--- a/components/builder-depot/src/doctor.rs
+++ b/components/builder-depot/src/doctor.rs
@@ -162,13 +162,17 @@ impl<'a> Doctor<'a> {
             Ok(meta) => {
                 if meta.is_file() {
                     self.report.failure(
-                        OperationType::InitDepotFs(self.depot.config.path.clone()),
+                        OperationType::InitDepotFs(
+                            self.depot.config.path.to_string_lossy().into_owned(),
+                        ),
                         Reason::FileExists,
                     );
                 }
                 if meta.permissions().readonly() {
                     self.report.failure(
-                        OperationType::InitDepotFs(self.depot.config.path.clone()),
+                        OperationType::InitDepotFs(
+                            self.depot.config.path.to_string_lossy().into_owned(),
+                        ),
                         Reason::BadPermissions,
                     );
                 }

--- a/components/builder-depot/src/lib.rs
+++ b/components/builder-depot/src/lib.rs
@@ -48,6 +48,7 @@ extern crate urlencoded;
 extern crate walkdir;
 extern crate zmq;
 extern crate uuid;
+extern crate base64;
 
 pub mod config;
 pub mod error;

--- a/components/builder-depot/src/main.rs
+++ b/components/builder-depot/src/main.rs
@@ -26,6 +26,7 @@ extern crate log;
 extern crate zmq;
 
 use std::process;
+use std::path::PathBuf;
 use std::str::FromStr;
 
 use hab_core::config::ConfigFile;
@@ -91,7 +92,7 @@ fn config_from_args(matches: &clap::ArgMatches) -> Result<Config> {
     }
 
     if let Some(path) = args.value_of("path") {
-        config.path = path.to_string();
+        config.path = PathBuf::from(path);
     }
     Ok(config)
 }
@@ -114,7 +115,10 @@ fn dispatch(config: Config, matches: &clap::ArgMatches) -> Result<()> {
 ///
 /// * Fails if the depot server fails to start - cannot bind to the port, etc.
 fn start(config: Config) -> Result<()> {
-    println!("Starting package Depot at {}", config.path);
+    println!(
+        "Starting package Depot at {}",
+        config.path.to_string_lossy()
+    );
     println!(
         "Depot listening on {}:{}",
         config.http.listen,


### PR DESCRIPTION
This change adds a depot API to retrieve a public encryption key for builder. It will be used to provide secrets management capability to builder in the near future. 

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-184309047](https://user-images.githubusercontent.com/13542112/29482604-4dbff0a0-8449-11e7-96a3-663e8a19058b.gif)
