### PR TITLE
Remove builder-core dependency from builder-api-client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -704,7 +704,6 @@ dependencies = [
 name = "habitat_api_client"
 version = "0.0.0"
 dependencies = [
- "builder_core 0.0.0",
  "clippy 0.0.144 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat_core 0.0.0",
  "habitat_http_client 0.0.0",

--- a/components/builder-api-client/Cargo.toml
+++ b/components/builder-api-client/Cargo.toml
@@ -16,9 +16,6 @@ serde_derive = "*"
 serde_json = "*"
 url = "*"
 
-[dependencies.builder_core]
-path = "../builder-core"
-
 [dependencies.habitat_core]
 path = "../core"
 

--- a/components/builder-api-client/src/lib.rs
+++ b/components/builder-api-client/src/lib.rs
@@ -15,7 +15,6 @@
 #![cfg_attr(feature="clippy", feature(plugin))]
 #![cfg_attr(feature="clippy", plugin(clippy))]
 
-extern crate builder_core;
 extern crate habitat_http_client as hab_http;
 extern crate habitat_core as hab_core;
 extern crate hyper;
@@ -36,7 +35,6 @@ pub use error::{Error, Result};
 use std::io::Read;
 use std::path::Path;
 
-use builder_core::data_structures::PartialJobGroupPromote;
 use hab_core::package::PackageIdent;
 use hab_http::ApiClient;
 use hab_http::util::decoded_response;
@@ -53,6 +51,12 @@ pub struct ReverseDependencies {
     pub origin: String,
     pub name: String,
     pub rdeps: Vec<String>,
+}
+
+#[derive(Default, Deserialize)]
+pub struct JobGroupPromoteResponse {
+    pub group_id: u64,
+    pub failed_projects: Vec<String>,
 }
 
 impl Client {
@@ -175,7 +179,7 @@ impl Client {
         // is_eof() will return true. We handle that edge case here by returning Ok, because for
         // us, this is a success case, even though it's an error case for serde. In the future, we
         // might want to investigate a way to have decoded_response handle this oddity.
-        match decoded_response::<PartialJobGroupPromote>(res).map_err(Error::HabitatHttpClient) {
+        match decoded_response::<JobGroupPromoteResponse>(res).map_err(Error::HabitatHttpClient) {
             Ok(value) => Ok(value.failed_projects),
             Err(Error::HabitatHttpClient(hab_http::Error::Json(e))) => {
                 if e.is_eof() {


### PR DESCRIPTION
This change fixes a break in the hab plan build that occurred due to ZMQ getting pulled into the dependency chain. This happened when we added builder_core to the dependencies for builder_api_client. The fix is to break that dependency (following a pattern that is being followed for other similar cases in the code).

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-187421983](https://user-images.githubusercontent.com/13542112/29542759-08819d8c-8691-11e7-8392-8c8171f5da77.gif)
