### PR TITLE
Add application/environment to ServiceSpec generated from a Service

### DIFF
--- a/components/sup/src/manager/service/mod.rs
+++ b/components/sup/src/manager/service/mod.rs
@@ -344,6 +344,9 @@ impl Service {
     pub fn to_spec(&self) -> ServiceSpec {
         let mut spec = ServiceSpec::default_for(self.spec_ident.clone());
         spec.group = self.service_group.group().to_string();
+        if let Some(appenv) = self.service_group.application_environment() {
+            spec.application_environment = Some(appenv)
+        }
         spec.depot_url = self.depot_url.clone();
         spec.channel = self.channel.clone();
         spec.topology = self.topology;


### PR DESCRIPTION
By not carrying this data over when generating a `ServiceSpec`, we
would always internally be tracking services with _no_
application/environment set (because it defaults to `None`). However,
all the spec files on disk did have this information.

This, coupled with the fact that we watch our spec directory with very
coarse event resolution (basically, if anything in the directory
changes, go check *all* specs to figure out what needs to be
restarted, etc.) means that anytime a new service was started or
stopped (anything that caused a change in the spec directory!), we'd
end up restarting services that had been started with
application/environment set. Our internal representation had no such
information, but the on-disk representation _did_ have it; that's a
difference, so we restart!

Fixes #2964

Signed-off-by: Christopher Maier <cmaier@chef.io>