### PR TITLE
Remove octicons build step

### DIFF
--- a/components/builder-web/bin/dist
+++ b/components/builder-web/bin/dist
@@ -10,7 +10,6 @@ mkdir -p dist/assets
 cp -R assets favicon.ico fixtures robots.txt dist
 npm run build
 mkdir -p dist/node_modules
-cp -R node_modules/octicons dist/node_modules
 cp habitat.conf.sample.js dist/habitat.conf.js
 
 css_sha=$(openssl dgst -sha256 assets/app.css | cut -d ' ' -f 2)


### PR DESCRIPTION
A previous change removed octicons, but missed this line that expects them to be there.

![](https://media.tenor.com/images/2e29e6cb881aacb01d855fe777105ece/tenor.gif)

Signed-off-by: Christian Nunciato <cnunciato@chef.io>