### PR TITLE
Explicitly binlink bash and sh to /bin in exported images

### DIFF
--- a/components/studio/libexec/hab-studio-type-bare.sh
+++ b/components/studio/libexec/hab-studio-type-bare.sh
@@ -73,8 +73,8 @@ finish_setup() {
   _hab pkg binlink --dest $HAB_ROOT_PATH/bin core/hab hab
 
   # Create `/bin/{sh,bash}` for software that hardcodes these shells
-  _hab pkg binlink core/busybox-static bash
-  _hab pkg binlink core/busybox-static sh
+  _hab pkg binlink --dest=/bin core/busybox-static bash
+  _hab pkg binlink --dest=/bin core/busybox-static sh
 
   # Set the login shell for any relevant user to be `/bin/bash`
   $bb sed -e "s,/bin/sh,$busybox_path/bin/bash,g" -i $HAB_STUDIO_ROOT/etc/passwd

--- a/components/studio/libexec/hab-studio-type-baseimage.sh
+++ b/components/studio/libexec/hab-studio-type-baseimage.sh
@@ -73,8 +73,8 @@ finish_setup() {
   _hab pkg binlink --dest $HAB_ROOT_PATH/bin core/hab hab
 
   # Create `/bin/{sh,bash}` for software that hardcodes these shells
-  _hab pkg binlink core/busybox-static bash
-  _hab pkg binlink core/busybox-static sh
+  _hab pkg binlink --dest=/bin core/busybox-static bash
+  _hab pkg binlink --dest=/bin core/busybox-static sh
 
   # Set the login shell for any relevant user to be `/bin/bash`
   $bb sed -e "s,/bin/sh,$busybox_path/bin/bash,g" -i $HAB_STUDIO_ROOT/etc/passwd


### PR DESCRIPTION
There appears to be some leaking over of the `HAB_BINLINK_DIR`
environment variable set in the default studio setup script that
causes `/bin/sh` to not exist in Docker containers exported by version
0.30.1.

While more work will need to be done to properly insulate things,
explicitly overriding the link destination will get these working now,
unblocking the various people that have encountered this bug.

Fixes #2989

Signed-off-by: Christopher Maier <cmaier@chef.io>