### PR TITLE
Add hab bldr encrypt command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -574,6 +574,7 @@ name = "hab"
 version = "0.0.0"
 dependencies = [
  "ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.25.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy 0.0.144 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/builder-depot-client/src/lib.rs
+++ b/components/builder-depot-client/src/lib.rs
@@ -303,6 +303,26 @@ impl Client {
         Ok(revisions)
     }
 
+    /// Download the latest builder public key from a remote Depot
+    /// to the given filepath.
+    ///
+    /// # Failures
+    ///
+    /// * Key cannot be found
+    /// * Remote Depot is not available
+    /// * File cannot be created and written to
+    pub fn fetch_builder_latest_key<D, P: ?Sized>(
+        &self,
+        dst_path: &P,
+        progress: Option<D>,
+    ) -> Result<PathBuf>
+    where
+        P: AsRef<Path>,
+        D: DisplayProgress + Sized,
+    {
+        self.download("builder/keys/latest", dst_path.as_ref(), progress)
+    }
+
     /// Return a list of channels for a given package
     ///
     /// # Failures

--- a/components/hab/Cargo.toml
+++ b/components/hab/Cargo.toml
@@ -11,6 +11,7 @@ doc = false
 
 [dependencies]
 clippy = {version = "*", optional = true}
+base64 = "*"
 ansi_term = "*"
 env_logger = "*"
 hyper = "*"

--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -75,6 +75,18 @@ pub fn get() -> App<'static, 'static> {
                     "Ring key name, which will encrypt communication messages")
             )
         )
+        (@subcommand bldr =>
+            (about: "Commands relating to Habitat build service")
+            (aliases: &["b", "bl", "bld"])
+            (@setting ArgRequiredElseHelp)
+            (@subcommand encrypt =>
+                (about: "Reads a stdin stream containing plain text and outputs \
+                    an encrypted representation")
+                (aliases: &["e", "en", "enc", "encr", "encry"])
+                (@arg DEPOT_URL: -u --url +takes_value {valid_url}
+                    "Use a specific Depot URL (ex: http://depot.example.com/v1/depot)")
+            )
+        )
         (@subcommand job =>
             (about: "Commands relating to build job control")
             (aliases: &["j", "jo"])

--- a/components/hab/src/command/bldr/encrypt.rs
+++ b/components/hab/src/command/bldr/encrypt.rs
@@ -1,0 +1,64 @@
+// Copyright (c) 2016-2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::str;
+use std::path::Path;
+
+use base64;
+use hcore::crypto::BoxKeyPair;
+use common::ui::UI;
+use depot_client::{self, Client};
+use common::command::package::install::{RETRIES, RETRY_WAIT};
+
+use {PRODUCT, VERSION};
+use error::{Error, Result};
+
+use retry::retry;
+
+pub const BUILDER_KEY_NAME: &'static str = "bldr";
+
+pub fn start(ui: &mut UI, depot_url: &str, content: &str, cache: &Path) -> Result<()> {
+    let depot_client = Client::new(depot_url, PRODUCT, VERSION, None)?;
+    ui.begin("Downloading builder public key")?;
+
+    download_builder_key(ui, &depot_client, cache)?;
+    let kp = BoxKeyPair::get_latest_pair_for(BUILDER_KEY_NAME, cache)?;
+    let ciphertext = kp.encrypt(content.as_bytes(), None)?;
+    let s = base64::encode(&ciphertext);
+
+    ui.end("Encryption complete")?;
+    println!("{}", s);
+
+    Ok(())
+}
+
+fn download_builder_key(ui: &mut UI, depot_client: &Client, cache: &Path) -> Result<()> {
+    let download_fn = || -> Result<()> {
+        depot_client.fetch_builder_latest_key(cache, ui.progress())?;
+        Ok(())
+    };
+
+    if retry(RETRIES, RETRY_WAIT, download_fn, |res| res.is_ok()).is_err() {
+        return Err(Error::from(depot_client::Error::DownloadFailed(format!(
+            "We tried {} \
+                    times but \
+                    could not \
+                    download the \
+                    builder public key. \
+                    Giving up.",
+            RETRIES
+        ))));
+    };
+    Ok(())
+}

--- a/components/hab/src/command/bldr/mod.rs
+++ b/components/hab/src/command/bldr/mod.rs
@@ -12,16 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod butterfly;
-pub mod cli;
-pub mod job;
-pub mod launcher;
-pub mod origin;
-pub mod pkg;
-pub mod plan;
-pub mod ring;
-pub mod service;
-pub mod studio;
-pub mod sup;
-pub mod user;
-pub mod bldr;
+pub mod encrypt;

--- a/components/hab/src/lib.rs
+++ b/components/hab/src/lib.rs
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+#![recursion_limit="128"]
 #![cfg_attr(feature="clippy", feature(plugin))]
 #![cfg_attr(feature="clippy", plugin(clippy))]
 
@@ -37,6 +39,7 @@ extern crate toml;
 extern crate url;
 extern crate uuid;
 extern crate walkdir;
+extern crate base64;
 
 pub mod analytics;
 pub mod cli;


### PR DESCRIPTION
This change adds a 'hab bldr encrypt' command to the cli. The command takes plain text and encrypts it with the builder's public key. The encrypted text can only be decrypted by the builder, and can be used to pass secrets to the builder as needed for CI functionality.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-42487944](https://user-images.githubusercontent.com/13542112/29593081-122bfc20-875d-11e7-8e4c-26bcd8d3535d.gif)
