### PR TITLE
Improve site search by scoping to main content on page

### DIFF
--- a/www/source/layouts/blog_post.slim
+++ b/www/source/layouts/blog_post.slim
@@ -3,7 +3,7 @@
       .main-sidebar
         = partial("blog/partials/blog_sidebar")
 
-      .main-content__has-sidebar
+      .main-content__has-sidebar data-swiftype-index="true"
         article.article-detail
           header
             = stylesheet_link_tag :ocean

--- a/www/source/layouts/layout.slim
+++ b/www/source/layouts/layout.slim
@@ -23,6 +23,8 @@ html prefix="og: http://ogp.me/ns#"
     meta name="twitter:creator" content="@chef"
     meta name="twitter:image" content=social_image
 
+    meta class="swiftype" name="body" data-type="text" content=current_page.data.description
+
     link href="/favicon.png" rel="icon" type="image/png"
     link href="/favicon.ico" rel="icon"
 

--- a/www/source/layouts/sidebar.slim
+++ b/www/source/layouts/sidebar.slim
@@ -19,7 +19,7 @@
                             li.main-sidebar--list--item  class=link_classes(current_resource.url, sub_link)
                               = link_to sub_link.title, sub_link.link
 
-      .main-content__has-sidebar
+      .main-content__has-sidebar data-swiftype-index="true"
           == yield
 
   / Swiftype JS Snippet

--- a/www/source/layouts/tutorials_sidebar.slim
+++ b/www/source/layouts/tutorials_sidebar.slim
@@ -21,7 +21,7 @@
                             li.main-sidebar--list--item  class=link_classes(current_resource.url, sub_link)
                               = link_to sub_link.title, sub_link.link, class: (sub_link.icon || '')
 
-      .main-content__has-sidebar
+      .main-content__has-sidebar data-swiftype-index="true"
           == yield
 
   / Swiftype JS Snippet


### PR DESCRIPTION
- Scopes site search to content inside of the main <div> element on the page. 

- Also allows override to what's presented in search queries by using a `description` frontmatter field. If none is present, the text within the <div> element referenced above will be used.

Signed-off-by: David Wrede <dwrede@chef.io>