### PR TITLE
[sup] Don't set ownership when rendering hooks.

### DIFF
--- a/components/sup/src/manager/service/hooks.rs
+++ b/components/sup/src/manager/service/hooks.rs
@@ -107,7 +107,6 @@ pub trait Hook: fmt::Debug + Sized {
                 Self::file_name(),
                 self.path().display()
             );
-            hcore::util::perm::set_owner(self.path(), &ctx.pkg.svc_user, &ctx.pkg.svc_group)?;
             hcore::util::perm::set_permissions(self.path(), HOOK_PERMISSIONS)?;
             Ok(true)
         } else {


### PR DESCRIPTION
This change simplifies the writing out of rendered hooks by leaving the
owner/group to the user executing the Supervisor process (currently this
is root). The services running should not need write access to the hook
files but only permission to read and execute the hooks, which the
`set_permissions()` call allows.

Adding the ownership call creates a situation where any code testing
this functionality must be run either as the package service user
(usually `hab`) or as a root user which can set ownership on files. This
resolves an issue where several hook tests in the unit test suite cannot
be performed without running as root or under `sudo`.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>