### PR TITLE
[sup/functional] Support running functionals as a non-root user.

### DIFF
--- a/components/sup/tests/compilation.rs
+++ b/components/sup/tests/compilation.rs
@@ -19,8 +19,10 @@
 
 mod utils;
 
+extern crate habitat_core as hcore;
 #[macro_use]
 extern crate lazy_static;
+extern crate tempdir;
 
 // The fixture location is derived from the name of this test
 // suite. By convention, it is the same as the file name.

--- a/components/sup/tests/utils/hab_root.rs
+++ b/components/sup/tests/utils/hab_root.rs
@@ -29,8 +29,9 @@ use std::io::Read;
 use std::path::{PathBuf, Path};
 use std::string::ToString;
 
-extern crate tempdir;
-use self::tempdir::TempDir;
+use hcore::fs::PKG_PATH;
+use hcore::package::metadata::MetaFile;
+use tempdir::TempDir;
 
 #[derive(Debug)]
 pub struct HabRoot(TempDir);
@@ -57,14 +58,35 @@ impl HabRoot {
         T: AsRef<Path>,
     {
         self.0
-            .as_ref()
-            .to_path_buf()
-            .join("hab")
-            .join("pkgs")
+            .path()
+            .join(PKG_PATH)
             .join(origin.as_ref())
             .join(pkg_name.as_ref())
             .join("1.0.0")
             .join("20170721000000")
+    }
+
+    /// Returns the path to the service user metafile for a given package.
+    pub fn svc_user_path<S, T>(&self, origin: S, pkg_name: T) -> PathBuf
+    where
+        S: AsRef<Path>,
+        T: AsRef<Path>,
+    {
+        self.pkg_path(origin, pkg_name).join(
+            MetaFile::SvcUser.to_string(),
+        )
+    }
+
+    /// Returns the path to the service group metafile for a given package.
+    pub fn svc_group_path<S, T>(&self, origin: S, pkg_name: T) -> PathBuf
+    where
+        S: AsRef<Path>,
+        T: AsRef<Path>,
+    {
+        self.pkg_path(origin, pkg_name).join(
+            MetaFile::SvcGroup
+                .to_string(),
+        )
     }
 
     /// The path to which a spec file should be written for a given

--- a/components/sup/tests/utils/test_sup.rs
+++ b/components/sup/tests/utils/test_sup.rs
@@ -137,6 +137,12 @@ where
     bin
 }
 
+/// Return whether or not the tests are being run with the `--nocapture` flag meaning we want to
+/// see more output.
+fn nocapture() -> bool {
+    env::args().any(|arg| arg == "--nocapture")
+}
+
 impl TestSup {
     /// Create a new `TestSup` that will listen on randomly-selected
     /// ports for both gossip and HTTP requests so tests run in
@@ -220,9 +226,11 @@ impl TestSup {
             .arg("--listen-http")
             .arg(format!("{}:{}", listen_host, http_port))
             .arg(format!("{}/{}", origin, pkg_name))
-            .stdin(Stdio::null())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped());
+            .stdin(Stdio::null());
+        if !nocapture() {
+            cmd.stdout(Stdio::null());
+            cmd.stderr(Stdio::null());
+        }
 
         let bc = test_butterfly::Client::new(&pkg_name, &service_group, butterfly_port);
 


### PR DESCRIPTION
## [sup/functional] Support running functionals as a non-root user.

For the current functional tests which exercise hook file creation, the
service user running the service is not critical and not the subject
under test. Therefore, when preparing a fixture package, the following
package metafiles will be created *unless* one is present in the fixture
directory:

* `SVC_USER`: defaults to the current user running the tests
* `SVC_GROUP`: defaults to the current user's primary group running the
  tests

This approach will pass the service user/group assertions that the
Supervisor makes when creating the service directories without changing
production/runtime behavior.

As a result, and with the inclusion of #3022, all doc, unit, and
functional tests for the Supervisor can be run with a non-root user.

## [sup/functional] Print sup output in tests if `--nocapture` is set.

[sup/functional] Print sup output in tests if `--nocapture` is set. …This change helps to better debug when functional supervsior tests are failing. Existing behavior is preserved when running the tests; that is to not output supervisor messages. However, if a developer wishes to see more test output using the standard `--nocapture` flag, then the supervisor output will be emitted.  To see the difference you can run:      cd components/sup     cargo test -- --nocapture

![tenor-152562062](https://user-images.githubusercontent.com/261548/29793875-e270ee6e-8c02-11e7-9e89-ef3b1564a4ea.gif)
