### PR TITLE
Read HAB_NON_ROOT when installing package to allow for non-root usage.

### DIFF
--- a/components/common/src/command/package/install.rs
+++ b/components/common/src/command/package/install.rs
@@ -72,19 +72,14 @@ where
     P1: AsRef<Path> + ?Sized,
     P2: AsRef<Path> + ?Sized,
 {
-    if !am_i_root() {
-        if let Some(_) = env::var_os("HAB_NON_ROOT") {
-            ui.warn("Allowing install by non-root user!")?;
-            ui.br()?;
-        } else {
-            ui.warn(
-                "Installing a package requires root or administrator privileges. Please retry \
+    if env::var_os("HAB_NON_ROOT").is_none() && !am_i_root() {
+        ui.warn(
+            "Installing a package requires root or administrator privileges. Please retry \
                    this command as a super user or use a privilege-granting facility such as \
                    sudo.",
-            )?;
-            ui.br()?;
-            return Err(Error::RootRequired);
-        }
+        )?;
+        ui.br()?;
+        return Err(Error::RootRequired);
     }
 
     let cache_key_path = cache_key_path(Some(fs_root_path.as_ref()));

--- a/components/common/src/command/package/install.rs
+++ b/components/common/src/command/package/install.rs
@@ -35,6 +35,7 @@
 //! * Unpack it
 //!
 
+use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
@@ -72,13 +73,18 @@ where
     P2: AsRef<Path> + ?Sized,
 {
     if !am_i_root() {
-        ui.warn(
-            "Installing a package requires root or administrator privileges. Please retry \
+        if let Some(_) = env::var_os("HAB_NON_ROOT") {
+            ui.warn("Allowing install by non-root user!")?;
+            ui.br()?;
+        } else {
+            ui.warn(
+                "Installing a package requires root or administrator privileges. Please retry \
                    this command as a super user or use a privilege-granting facility such as \
                    sudo.",
-        )?;
-        ui.br()?;
-        return Err(Error::RootRequired);
+            )?;
+            ui.br()?;
+            return Err(Error::RootRequired);
+        }
     }
 
     let cache_key_path = cache_key_path(Some(fs_root_path.as_ref()));

--- a/components/core/src/package/archive.rs
+++ b/components/core/src/package/archive.rs
@@ -224,7 +224,6 @@ impl PackageArchive {
         let writer = writer::Disk::new();
         let mut extract_options = ExtractOptions::new();
         extract_options.add(ExtractOption::Time);
-        extract_options.add(ExtractOption::Owner);
         extract_options.add(ExtractOption::Permissions);
         writer.set_options(&extract_options)?;
         writer.set_standard_lookup()?;

--- a/www/source/docs/reference/environment-vars.html.md
+++ b/www/source/docs/reference/environment-vars.html.md
@@ -25,7 +25,7 @@ This is a list of all environment variables that can be used to modify the opera
 | `HAB_STUDIO_SUP` | build system | no default | Used to customize the arguments passed to an automatically launched Supervisor, or to disable the automatic launching by setting it to `false`, `no`, or `0`. |
 | `HAB_UPDATE_STRATEGY_FREQUENCY_MS` | supervisor | 60000 | Frequency of milliseconds to check for updates when running with an [update strategy](/docs/run-packages-update-strategy) |
 | `HAB_USER` | supervisor | no default | User key to use when running with [service group encryption](/docs/run-packages-security/#service-group-encryption) |
-| `HAB_NON_ROOT` | supervisor | no default | Enable the supervisor to install and run packages as non-root user. *Warning* it is highly reckomended not to use this setting except under very specific circumstances due to associated security risks. |
+| `HAB_NON_ROOT` | supervisor | no default | Enable the supervisor to install packages as non-root user. *Warning* it is highly recommended not to use this setting except under very specific circumstances due to associated security risks. |
 | `http_proxy` | build system, supervisor | no default | A URL for a local HTTP proxy server optionally supporting basic authentication |
 | `https_proxy` | build system, supervisor | no default | A URL for a local HTTPS proxy server optionally supporting basic authentication |
 | `no_proxy` | build system, supervisor | no default | A comma-separated list of domain exclusions for the `http_proxy` and `https_proxy` environment variables |

--- a/www/source/docs/reference/environment-vars.html.md
+++ b/www/source/docs/reference/environment-vars.html.md
@@ -25,6 +25,7 @@ This is a list of all environment variables that can be used to modify the opera
 | `HAB_STUDIO_SUP` | build system | no default | Used to customize the arguments passed to an automatically launched Supervisor, or to disable the automatic launching by setting it to `false`, `no`, or `0`. |
 | `HAB_UPDATE_STRATEGY_FREQUENCY_MS` | supervisor | 60000 | Frequency of milliseconds to check for updates when running with an [update strategy](/docs/run-packages-update-strategy) |
 | `HAB_USER` | supervisor | no default | User key to use when running with [service group encryption](/docs/run-packages-security/#service-group-encryption) |
+| `HAB_NON_ROOT` | supervisor | no default | Enable the supervisor to install and run packages as non-root user. *Warning* it is highly reckomended not to use this setting except under very specific circumstances due to associated security risks. |
 | `http_proxy` | build system, supervisor | no default | A URL for a local HTTP proxy server optionally supporting basic authentication |
 | `https_proxy` | build system, supervisor | no default | A URL for a local HTTPS proxy server optionally supporting basic authentication |
 | `no_proxy` | build system, supervisor | no default | A comma-separated list of domain exclusions for the `http_proxy` and `https_proxy` environment variables |


### PR DESCRIPTION
Setting the environment variable `HAB_NON_ROOT` will enable the `hab` cli to install packages without root permissions.

There is still the issue that when running `HAB_NON_ROOT=true hab start x/y` the env-var doesn't get propagated from the hab cli to `hab-sup` and won't take effect if the package hasn't already been installed.

I'm submitting this PR to get feedback and start discussion about the current implementation and expected behaviour.