### PR TITLE
[core] Add explicit, testing-only fs root support.

### DIFF
--- a/components/sup/tests/compilation.rs
+++ b/components/sup/tests/compilation.rs
@@ -17,12 +17,14 @@
 /// Integration tests for exercising the hook and config recompilation
 /// behavior of the supervisor
 
-mod utils;
-
 extern crate habitat_core as hcore;
+extern crate habitat_sup as sup;
 #[macro_use]
 extern crate lazy_static;
+extern crate rand;
 extern crate tempdir;
+
+mod utils;
 
 // The fixture location is derived from the name of this test
 // suite. By convention, it is the same as the file name.

--- a/components/sup/tests/utils/test_sup.rs
+++ b/components/sup/tests/utils/test_sup.rs
@@ -24,10 +24,11 @@ use std::sync::Mutex;
 use std::thread;
 use std::time::Duration;
 
-use super::test_butterfly;
+use hcore::url::DEPOT_URL_ENVVAR;
+use rand;
+use rand::distributions::{IndependentSample, Range};
 
-extern crate rand;
-use self::rand::distributions::{IndependentSample, Range};
+use super::test_butterfly;
 
 lazy_static! {
     /// Keep track of all TCP ports currently being used by TestSup
@@ -217,9 +218,11 @@ impl TestSup {
         let pkg_name = pkg_name.to_string();
         let service_group = service_group.to_string();
 
-        cmd.env("FS_ROOT", fs_root.as_ref().to_string_lossy().as_ref())
-            .env("HAB_SUP_BINARY", &sup_exe)
-            .env("HAB_DEPOT_URL", "http://hab.sup.test/v1/depot")
+        cmd.env(
+            "TESTING_FS_ROOT",
+            fs_root.as_ref().to_string_lossy().as_ref(),
+        ).env("HAB_SUP_BINARY", &sup_exe)
+            .env(DEPOT_URL_ENVVAR, "http://hab.sup.test/v1/depot")
             .arg("start")
             .arg("--listen-gossip")
             .arg(format!("{}:{}", listen_host, butterfly_port))


### PR DESCRIPTION
This change reverts the behvaior change of the `FS_ROOT` environment
variable in #2729 and introduces a new, testing only environment
variable to manipulate the filesystem root when being used in
integration and functional testing.

In the Habitat codebase we try to discourage reading environment
variables inside library code which could affect a program's behavior at
runtime. Instead, we highly encourage reading and dealing with
environment variables during the CLI argument parsing phase of a program
and using explicit Rust types when passing data into inner libraries.
Note that there can still be default-generating functions which could
read from an environment variable, but the calling sites for these
functions should still be at a program CLI parsing phase.

In order to better support running the Supervisor on Windows in a Studio
environment, we relax this rule due to the behavior of Windows path and
PowerShell filesystem mounts. We hope that this is temporary and will be
resolved once we add better Studio isolation on Windows. The non-Windows
platforms however remain unchanged.

There is a very limited use case for an `FS_ROOT` environment variable
which only the `hab` CLI uses for certain subcommands including `hab pkg
install` and `hab pkg binlink`. This is present to support use cases
where a Habitat user may need to install packages on a mounted volume
that will become the bootable, root filesystem at a later point in time
(think operating system installers). The Supervisor and most other `hab`
CLI subcommands don't honor this environment variable because the
internal linking in most Habitat packages will not support running
packages out of another directory (linked libraries in Habitat are
linked via absolute pathing to maximize portability and correct behavior).

Recently, some excellent work was done to improve testing of the
Supervisor as a black box program. Some of the tests only require
minimal packages with no executing code and could therefore be run out
of temporary directories, and so these tests used the `FS_ROOT`
environment variable to manipulate the root of all Habitat paths.

This change preserves the strategy of these tests but rather introduces
a test-only environment variable which the test suite can set, knowing
what the consequences will be (see above). Additionally, if this
environment variable is used, a message will be printed to the standard
error stream notifying any user that this is intended only for testing
and not production. Note that by default, the test suites have their
stdout/stderr streams redirected and so this warning wouldn't appear
unless the `--nocapture` flag is added. This is one instance where the
rule above ("don't honor environment varibles in inner library code")
isn't an unbreakable law, it just needs to be carefully considered.

![tenor-59160273](https://user-images.githubusercontent.com/261548/29832698-3ce027c2-8ca6-11e7-94bf-97fd811a7db3.gif)
