### PR TITLE
Fixup broken get started tutorial link

### DIFF
--- a/components/builder-web/app/side-nav/SideNavComponent.ts
+++ b/components/builder-web/app/side-nav/SideNavComponent.ts
@@ -41,7 +41,7 @@ import config from "../config";
                 <a href="{{ config['docs_url'] }}">Habitat Docs</a>
             </li>
             <li>
-                <a href="{{ config['tutorials_url'] }}/getting-started/overview">Getting Started</a>
+                <a href="{{ config['tutorials_url'] }}/get-started">Get Started</a>
             </li>
             <li>
                 <a href="{{ config['www_url'] }}/about">Why Habitat?</a>


### PR DESCRIPTION
Hiya!

I'm finally giving Habitat another look and after signing in to the habitat site, eager to get going I clicked the Getting Started link to the left and was greeted with this:

![2017-08-29 at 13 54](https://user-images.githubusercontent.com/724/29838833-f16c93b8-8cc1-11e7-96da-c4f40d58afe9.png)

Naturally I had a bit of a sad so I caught up my fork and sent you this patch to the link I _think_ you were intending to send me to instead. Let me know if this is not the case.