### PR TITLE
[sup] Fix hook table unit test which relied on lazy static value.

### DIFF
--- a/components/sup/src/manager/service/mod.rs
+++ b/components/sup/src/manager/service/mod.rs
@@ -126,7 +126,11 @@ impl Service {
             depot_url: spec.depot_url,
             channel: spec.channel,
             health_check: HealthCheck::default(),
-            hooks: HookTable::load(&service_group, &hooks_root),
+            hooks: HookTable::load(
+                &service_group,
+                &hooks_root,
+                fs::svc_hooks_path(&service_group.service()),
+            ),
             initialized: false,
             last_election_status: ElectionStatus::None,
             needs_reload: false,
@@ -420,6 +424,7 @@ impl Service {
                 self.hooks = HookTable::load(
                     &self.service_group,
                     &Self::hooks_root(&pkg, self.config_from.as_ref()),
+                    fs::svc_hooks_path(self.service_group.service()),
                 );
                 self.pkg = pkg;
             }


### PR DESCRIPTION
This change fixes a unit test that would not consistently pass or fail
when run as a non-root user. Prior to this change, the
`HookTable::load()` function computed its hook path using the
`sup::fs::svc_hooks_path()` which uses a `lazy_static` constant to
determine the root filesystem path for all future calls.

Rust unit test suites run many tests concurrently in threads so that
ordering is nondeterministic. Since all threads share the same
constants, the first test to fire code which calls-and-sets the
`core::fs::FS_ROOT_PATH` constant will "win" and all other threads will
use this value. The test in question attempted to set the filesystem
root to a temporary path and so would sometimes "win" and sometimes
"lose".

This change changes the signature of `HookTable::load()` to take the
path explicitly, leading to easer test setup and a more explicit
dependency injection for the production Supervisor code.

Also, this test shouldn't fail randomly any more. Not bad, eh?

---

Ready? Ready?

It's a HOOK. TABLE.

![tenor-151990844](https://user-images.githubusercontent.com/261548/29846602-d8fd89b4-8cd4-11e7-8288-5eb7ec40d052.gif)

Ha!