### PR TITLE
Fix thread panic when building Census in Supervisor

### DIFF
--- a/components/sup/src/census.rs
+++ b/components/sup/src/census.rs
@@ -483,15 +483,15 @@ pub struct CensusMember {
     pub update_election_is_no_quorum: bool,
     pub update_election_is_finished: bool,
     pub sys: SysInfo,
+    alive: bool,
+    suspect: bool,
+    confirmed: bool,
+    departed: bool,
     // Maps must be represented last in a serializable struct for the current version of the toml
     // crate. Additionally, this deserialization method is required to correct any ordering issues
     // with the table being serialized - https://docs.rs/toml/0.4.0/toml/ser/fn.tables_last.html
     #[serde(serialize_with = "toml::ser::tables_last")]
     pub cfg: toml::value::Table,
-    alive: bool,
-    suspect: bool,
-    confirmed: bool,
-    departed: bool,
 }
 
 impl CensusMember {


### PR DESCRIPTION
TOML tables must be serialized last and serde determines which field to
serialize based on their order in a struct. This change fixes a crash
in the Supervisor by ensuring that serialization of the cfg field on
the CensusMember struct is the last field.

Signed-off-by: Jamie Winsor <jamie@vialstudios.com>