### PR TITLE
Use OS icons in the Dashboard, Versions tab, Sidebar

### DIFF
--- a/components/builder-web/app/dashboard/_dashboard.component.scss
+++ b/components/builder-web/app/dashboard/_dashboard.component.scss
@@ -239,8 +239,8 @@
           border-bottom: 1px solid rgba($light-gray, 0.4);
           margin-right: 20px;
 
-          .package-name, .package-origin, .package-updated {
-            @include span-columns(2.8 of 9);
+          .package-name, .package-origin, .package-updated, .package-icons {
+            @include span-columns(2 of 9);
           }
 
           .package-name, .package-origin {
@@ -256,12 +256,12 @@
             cursor: pointer;
             background-color: rgba($very-light-gray, 0.2);
 
-            hab-icon {
+            hab-icon[symbol="chevron-right"] {
               display: block;
             }
           }
 
-          hab-icon {
+          hab-icon[symbol="chevron-right"] {
             display: none;
             position: absolute;
             width: 20px;

--- a/components/builder-web/app/dashboard/dashboard.component.html
+++ b/components/builder-web/app/dashboard/dashboard.component.html
@@ -125,6 +125,9 @@
             <div class="package-updated">
               <h5>Latest</h5>
             </div>
+            <div class="package-icons">
+              <!-- TBD -->
+            </div>
           </li>
           <li class="item" *ngFor="let pkg of myPackages" (click)="navigateToPackage(pkg)">
             <div class="package-origin">
@@ -135,6 +138,9 @@
             </div>
             <div class="package-updated">
               {{ releaseToDate(pkg.release) }}
+            </div>
+            <div class="package-icons">
+              <hab-platform-icon [platform]="pkg.platforms[0]"></hab-platform-icon>
             </div>
             <hab-icon symbol="chevron-right"></hab-icon>
           </li>

--- a/components/builder-web/app/dashboard/dashboard.component.spec.ts
+++ b/components/builder-web/app/dashboard/dashboard.component.spec.ts
@@ -54,7 +54,8 @@ describe("DashboardComponent", () => {
       ],
       declarations: [
         DashboardComponent,
-        MockComponent({ selector: "hab-icon", inputs: [ "symbol" ] })
+        MockComponent({ selector: "hab-icon", inputs: [ "symbol" ] }),
+        MockComponent({ selector: "hab-platform-icon", inputs: [ "platform" ] })
       ],
       providers: [
         { provide: AppStore, useClass: MockAppStore }
@@ -139,10 +140,12 @@ describe("DashboardComponent", () => {
         beforeEach(() => {
           MockAppStore.recentPackages = List([
             {
-              "name": "thing1"
+              "name": "thing1",
+              "platforms": ["x86_64-linux"]
             },
             {
-              "name": "thing2"
+              "name": "thing2",
+              "platforms": ["x86_64-linux"]
             }
           ]);
 

--- a/components/builder-web/app/package/package-detail/package-detail.component.html
+++ b/components/builder-web/app/package/package-detail/package-detail.component.html
@@ -14,7 +14,7 @@
         <dt>Release</dt>
         <dd>
           {{ package.ident.release }}
-          <hab-icon [symbol]="osIconFor(package)" class="icon-os" title="Supported OS"></hab-icon>
+          <hab-platform-icon [platform]="package.target"></hab-platform-icon>
         </dd>
       </div>
       <div>

--- a/components/builder-web/app/package/package-detail/package-detail.component.spec.ts
+++ b/components/builder-web/app/package/package-detail/package-detail.component.spec.ts
@@ -26,7 +26,7 @@ describe("PackageDetailComponent", () => {
     TestBed.configureTestingModule({
       declarations: [
         PackageDetailComponent,
-        MockComponent({ selector: "hab-icon", inputs: [ "symbol" ]}),
+        MockComponent({ selector: "hab-platform-icon", inputs: [ "platform" ]}),
         MockComponent({ selector: "hab-channels", inputs: [ "channels" ]}),
         MockComponent({ selector: "hab-package-list", inputs: [ "currentPackage", "packages" ]}),
       ]

--- a/components/builder-web/app/package/package-detail/package-detail.component.ts
+++ b/components/builder-web/app/package/package-detail/package-detail.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input } from "@angular/core";
-import { releaseToDate } from "../../util";
+import { targetToPlatform, releaseToDate } from "../../util";
 
 @Component({
     selector: "hab-package-detail",
@@ -22,19 +22,4 @@ export class PackageDetailComponent {
 
       return name;
     }
-
-    osIconFor(pkg) {
-      let icon;
-
-      if (pkg.target) {
-        if (pkg.target.match("windows")) {
-          icon = "windows";
-        }
-        else if (pkg.target.match("linux")) {
-          icon = "linux";
-        }
-      }
-
-      return icon;
-  }
 }

--- a/components/builder-web/app/package/package-sidebar/_package-sidebar.component.scss
+++ b/components/builder-web/app/package/package-sidebar/_package-sidebar.component.scss
@@ -1,12 +1,26 @@
 .hab-package-sidebar {
 
-  .build, .latest-stable, .command {
+  .build button {
+    font-size: rem(14);
+  }
+
+  .build, .platforms, .latest-stable, .command {
     margin-bottom: 30px;
   }
 
   .latest-stable {
+
     p {
       font-size: rem(14);
+
+      a {
+        color: $hab-gray-dark;
+        text-decoration: underline;
+      }
+
+      hab-icon {
+        float: right;
+      }
     }
   }
 }

--- a/components/builder-web/app/package/package-sidebar/package-sidebar.component.html
+++ b/components/builder-web/app/package/package-sidebar/package-sidebar.component.html
@@ -3,10 +3,17 @@
     <h3>Build</h3>
     <button class="button" (click)="build()">Build latest version</button>
   </div>
+  <div class="platforms">
+    <h3>Supported Platforms</h3>
+    <hab-platform-icon [platform]="platform" *ngFor="let platform of platforms"></hab-platform-icon>
+  </div>
   <div class="latest-stable">
     <h3>Latest Stable</h3>
     <p>
-      <a [routerLink]="['./', latest.ident.version, latest.ident.release]">{{ latest.ident.version }}/{{ latest.ident.release }}</a>
+      <a [routerLink]="['./', latest.ident.version, latest.ident.release]">
+        {{ latest.ident.version }}/{{ latest.ident.release }}
+      </a>
+      <hab-platform-icon [platform]="latest.target"></hab-platform-icon>
     </p>
   </div>
   <div class="command">

--- a/components/builder-web/app/package/package-sidebar/package-sidebar.component.spec.ts
+++ b/components/builder-web/app/package/package-sidebar/package-sidebar.component.spec.ts
@@ -33,7 +33,8 @@ describe("PackageSidebarComponent", () => {
       ],
       declarations: [
         PackageSidebarComponent,
-        MockComponent({ selector: "hab-copyable", inputs: [ "command" ] })
+        MockComponent({ selector: "hab-copyable", inputs: [ "command" ] }),
+        MockComponent({ selector: "hab-platform-icon", inputs: [ "platform" ]})
       ],
       providers: [
         { provide: AppStore, useClass: MockAppStore }

--- a/components/builder-web/app/package/package-sidebar/package-sidebar.component.ts
+++ b/components/builder-web/app/package/package-sidebar/package-sidebar.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, OnChanges, SimpleChanges } from "@angular/core";
-import { packageString, releaseToDate } from "../../util";
+import { packageString, targetToPlatform, releaseToDate } from "../../util";
 import { AppStore } from "../../AppStore";
-import { fetchLatestPackage, submitJob } from "../../actions/index";
+import { fetchLatestPackage, fetchPackageVersions, submitJob } from "../../actions/index";
 
 @Component({
     selector: "hab-package-sidebar",
@@ -28,6 +28,7 @@ export class PackageSidebarComponent implements OnChanges {
 
         if (fetch) {
             this.fetchLatest();
+            this.fetchPackageVersions();
         }
     }
 
@@ -64,7 +65,26 @@ export class PackageSidebarComponent implements OnChanges {
       return false;
     }
 
+    get platforms() {
+        let targets = [];
+        let versions = this.store.getState().packages.versions || [];
+
+        versions.forEach((v) => {
+            v.platforms.forEach((p) => {
+                if (targets.indexOf(p) === -1) {
+                    targets.push(p);
+                }
+            });
+        });
+
+        return targets.sort();
+    }
+
     private fetchLatest() {
       this.store.dispatch(fetchLatestPackage(this.origin, this.name));
+    }
+
+    private fetchPackageVersions() {
+        this.store.dispatch(fetchPackageVersions(this.origin, this.name));
     }
 }

--- a/components/builder-web/app/package/package-versions/_package-versions.component.scss
+++ b/components/builder-web/app/package/package-versions/_package-versions.component.scss
@@ -9,7 +9,7 @@
         border-bottom: 1px solid $very-light-gray;
 
         h3, .version-name, .version-release-count, .version-latest{
-          @include span-columns(2);
+          @include span-columns(3);
         }
       }
 
@@ -27,15 +27,20 @@
 
         .summary {
           @include row;
-          padding: 15px 10px;
+          padding: 15px 0;
           position: relative;
 
           .version-name {
             font-weight: 600;
+            padding-left: 10px;
           }
 
           .version-release-count, .version-latest {
             color: $hab-gray;
+          }
+
+          .version-release-count {
+            padding-left: 8px;
           }
 
           hab-icon.toggle {
@@ -88,7 +93,7 @@
             }
 
             .build-date {
-              @include span-columns(2);
+              @include span-columns(3);
               color: $hab-gray;
             }
 

--- a/components/builder-web/app/package/package-versions/package-versions.component.html
+++ b/components/builder-web/app/package/package-versions/package-versions.component.html
@@ -4,18 +4,16 @@
       <h3>Version</h3>
       <h3>Releases</h3>
       <h3>Updated</h3>
-      <h3>
-        <!-- <hab-icon symbol="linux"></hab-icon> -->
-      </h3>
-      <h3>
-        <!-- <hab-icon symbol="windows"></hab-icon> -->
-      </h3>
+      <h3>Platforms</h3>
     </li>
     <li class="version" *ngFor="let version of versions" (click)="toggle(version)">
       <div class="summary">
         <span class="version-name">{{ version.version }}</span>
         <span class="version-release-count">{{ version.release_count }}</span>
         <span class="version-latest">{{ releaseToDate(version.latest) }}</span>
+        <span class="version-platforms">
+          <hab-platform-icon [platform]="platform" *ngFor="let platform of platforms"></hab-platform-icon>
+        </span>
         <hab-icon class="toggle" [symbol]="toggleFor(version)"></hab-icon>
       </div>
       <div class="version-packages" *ngIf="selected === version">
@@ -25,17 +23,17 @@
               <span class="release-name">{{ packageString(pkg) }}</span>
               <hab-channels [channels]="pkg.channels"></hab-channels>
             </div>
+            <div class="build-date">
+                {{ releaseToDate(pkg.release) }}
+              </div>
             <div class="os">
-              <!-- <hab-icon [symbol]="osIconFor(pkg)"></hab-icon> -->
+                <hab-platform-icon [platform]="pkg.platforms[0]" *ngFor="let platform of platforms"></hab-platform-icon>
             </div>
             <div class="visibility">
               <!-- TBD -->
             </div>
             <div class="build-source">
               <!-- TBD -->
-            </div>
-            <div class="build-date">
-              {{ releaseToDate(pkg.release) }}
             </div>
             <hab-icon symbol="chevron-right"></hab-icon>
           </li>

--- a/components/builder-web/app/package/package-versions/package-versions.component.spec.ts
+++ b/components/builder-web/app/package/package-versions/package-versions.component.spec.ts
@@ -52,6 +52,7 @@ describe("PackageVersionsComponent", () => {
       declarations: [
         PackageVersionsComponent,
         MockComponent({ selector: "hab-icon", inputs: [ "symbol", "title" ]}),
+        MockComponent({ selector: "hab-platform-icon", inputs: [ "platform" ]}),
         MockComponent({ selector: "hab-channels", inputs: [ "channels" ]})
       ],
       providers: [

--- a/components/builder-web/app/package/package-versions/package-versions.component.ts
+++ b/components/builder-web/app/package/package-versions/package-versions.component.ts
@@ -2,7 +2,7 @@ import { Component, OnDestroy, OnInit } from "@angular/core";
 import { ActivatedRoute, Router } from "@angular/router";
 import { Subscription } from "rxjs/subscription";
 import { AppStore } from "../../AppStore";
-import { packageString, releaseToDate } from "../../util";
+import { packageString, targetToPlatform, releaseToDate } from "../../util";
 import { fetchPackageVersions, fetchBuilds, fetchLatestPackage, filterPackagesBy, submitJob } from "../../actions/index";
 
 @Component({
@@ -56,6 +56,20 @@ export class PackageVersionsComponent implements OnDestroy {
         }
     }
 
+    get platforms() {
+        let targets = [];
+
+        this.versions.forEach((v) => {
+            v.platforms.forEach((p) => {
+                if (targets.indexOf(p) === -1) {
+                    targets.push(p);
+                }
+            });
+        });
+
+        return targets.sort();
+    }
+
     fetchPackages(params) {
         this.store.dispatch(filterPackagesBy(params, null, false));
     }
@@ -82,7 +96,7 @@ export class PackageVersionsComponent implements OnDestroy {
     }
 
     get versions() {
-        return this.store.getState().packages.versions;
+        return this.store.getState().packages.versions || [];
     }
 
     packagesFor(version) {

--- a/components/builder-web/app/shared/platform-icon/platform-icon.component.ts
+++ b/components/builder-web/app/shared/platform-icon/platform-icon.component.ts
@@ -1,0 +1,15 @@
+import { Component, Input } from "@angular/core";
+import { targetToPlatform } from "../../util";
+
+@Component({
+  selector: "hab-platform-icon",
+  template: `<hab-icon [symbol]="os" class="icon-os" [title]="os | titlecase"></hab-icon>`
+})
+export class PlatformIconComponent {
+
+  @Input() platform;
+
+  get os() {
+    return targetToPlatform(this.platform);
+  }
+}

--- a/components/builder-web/app/shared/shared.module.ts
+++ b/components/builder-web/app/shared/shared.module.ts
@@ -12,6 +12,7 @@ import { IconComponent } from "./icon/icon.component";
 import { PackageInfoComponent } from "./package-info/package-info.component";
 import { PackageListComponent } from "./package-list/package-list.component";
 import { ProgressBarComponent } from "./progress-bar/progress-bar.component";
+import { PlatformIconComponent } from "./platform-icon/platform-icon.component";
 
 @NgModule({
   imports: [
@@ -29,7 +30,8 @@ import { ProgressBarComponent } from "./progress-bar/progress-bar.component";
     IconComponent,
     PackageInfoComponent,
     PackageListComponent,
-    ProgressBarComponent
+    ProgressBarComponent,
+    PlatformIconComponent
   ],
   exports: [
     BreadcrumbsComponent,
@@ -40,7 +42,8 @@ import { ProgressBarComponent } from "./progress-bar/progress-bar.component";
     IconComponent,
     PackageInfoComponent,
     PackageListComponent,
-    ProgressBarComponent
+    ProgressBarComponent,
+    PlatformIconComponent
   ]
 })
 export class SharedModule {

--- a/components/builder-web/app/util.ts
+++ b/components/builder-web/app/util.ts
@@ -135,3 +135,8 @@ export function requireSignIn(pageComponent) {
 
     if (!hasToken) { store.dispatch(requestRoute(["/sign-in"])); }
 }
+
+// Plucks the os portion out of a target string (e.g., "x86_64-linux" -> "linux")
+export function targetToPlatform(target: string = ""): string {
+    return target.split("-").slice(-1).toString();
+}


### PR DESCRIPTION
This also adds a new component specifically for rendering an OS icon, since that requires a little bit of extra logic.

Signed-off-by: Christian Nunciato <cnunciato@chef.io>

![](https://media.tenor.com/images/d354384af742140d88d3275963a0d406/tenor.gif)
