### PR TITLE
Updates to make builder compile with Rust 1.20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,7 +160,7 @@ dependencies = [
  "habitat_net 0.0.0",
  "libarchive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "petgraph 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "petgraph 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -814,7 +814,7 @@ dependencies = [
  "habitat_net 0.0.0",
  "libarchive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "petgraph 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "petgraph 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "postgres 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1856,7 +1856,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "petgraph"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fixedbitset 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2854,7 +2854,7 @@ dependencies = [
 "checksum pbr 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e048e3afebb6c454bb1c5d0fe73fda54698b4715d78ed8e7302447c37736d23a"
 "checksum persistent 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c9c94f2ef72dc272c6bcc8157ccf2bc7da14f4c58c69059ac2fc48492d6916"
 "checksum pest 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0a6dda33d67c26f0aac90d324ab2eb7239c819fc7b2552fe9faa4fe88441edc8"
-"checksum petgraph 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "28814c774eeabfe38b20e1651f9e9a5ff6efeb3b2a66df25e056f579051ee4b3"
+"checksum petgraph 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "14c6ae5ccb73b438781abc93d35615019b1ad6e24b44116377fb819cfd7587de"
 "checksum phf 0.7.21 (registry+https://github.com/rust-lang/crates.io-index)" = "cb325642290f28ee14d8c6201159949a872f220c62af6e110a56ea914fbe42fc"
 "checksum phf_codegen 0.7.21 (registry+https://github.com/rust-lang/crates.io-index)" = "d62594c0bb54c464f633175d502038177e90309daf2e0158be42ed5f023ce88f"
 "checksum phf_generator 0.7.21 (registry+https://github.com/rust-lang/crates.io-index)" = "6b07ffcc532ccc85e3afc45865469bf5d9e4ef5bfcf9622e3cfe80c2d275ec03"

--- a/components/builder-admin/Cargo.toml
+++ b/components/builder-admin/Cargo.toml
@@ -8,6 +8,7 @@ workspace = "../../"
 
 [[bin]]
 name = "bldr-admin"
+path = "src/main.rs"
 doc = false
 
 [dependencies]

--- a/components/builder-api/Cargo.toml
+++ b/components/builder-api/Cargo.toml
@@ -8,6 +8,7 @@ workspace = "../../"
 
 [[bin]]
 name = "bldr-api"
+path = "src/main.rs"
 doc = false
 
 [dependencies]

--- a/components/builder-depot/Cargo.toml
+++ b/components/builder-depot/Cargo.toml
@@ -8,6 +8,7 @@ workspace = "../../"
 
 [[bin]]
 name = "bldr-depot"
+path = "src/main.rs"
 doc = false
 
 [dependencies]

--- a/components/builder-graph/Cargo.toml
+++ b/components/builder-graph/Cargo.toml
@@ -8,6 +8,7 @@ workspace = "../../"
 
 [[bin]]
 name = "bldr-graph"
+path = "src/main.rs"
 doc = false
 
 [dependencies]

--- a/components/builder-jobsrv/Cargo.toml
+++ b/components/builder-jobsrv/Cargo.toml
@@ -8,6 +8,7 @@ workspace = "../../"
 
 [[bin]]
 name = "bldr-job-srv"
+path = "src/main.rs"
 doc = false
 
 [dependencies]

--- a/components/builder-originsrv/Cargo.toml
+++ b/components/builder-originsrv/Cargo.toml
@@ -8,6 +8,7 @@ workspace = "../../"
 
 [[bin]]
 name = "bldr-origin-srv"
+path = "src/main.rs"
 doc = false
 
 [dependencies]

--- a/components/builder-router/Cargo.toml
+++ b/components/builder-router/Cargo.toml
@@ -8,6 +8,7 @@ workspace = "../../"
 
 [[bin]]
 name = "bldr-router"
+path = "src/main.rs"
 doc = false
 
 [dependencies]

--- a/components/builder-scheduler/Cargo.toml
+++ b/components/builder-scheduler/Cargo.toml
@@ -8,6 +8,7 @@ workspace = "../../"
 
 [[bin]]
 name = "bldr-scheduler"
+path = "src/main.rs"
 doc = false
 
 [dependencies]

--- a/components/builder-sessionsrv/Cargo.toml
+++ b/components/builder-sessionsrv/Cargo.toml
@@ -8,6 +8,7 @@ workspace = "../../"
 
 [[bin]]
 name = "bldr-session-srv"
+path = "src/main.rs"
 doc = false
 
 [dependencies]

--- a/components/builder-worker/Cargo.toml
+++ b/components/builder-worker/Cargo.toml
@@ -8,6 +8,7 @@ workspace = "../../"
 
 [[bin]]
 name = "bldr-worker"
+path = "src/main.rs"
 doc = false
 
 [dependencies]

--- a/components/butterfly/Cargo.toml
+++ b/components/butterfly/Cargo.toml
@@ -7,6 +7,7 @@ workspace = "../../"
 
 [[bin]]
 name = "butterfly"
+path = "src/main.rs"
 doc = false
 
 [dev-dependencies.habitat_butterfly_test]

--- a/components/hab-butterfly/Cargo.toml
+++ b/components/hab-butterfly/Cargo.toml
@@ -7,6 +7,7 @@ workspace = "../../"
 
 [[bin]]
 name = "hab-butterfly"
+path = "src/main.rs"
 doc = false
 
 [dependencies]

--- a/components/launcher/Cargo.toml
+++ b/components/launcher/Cargo.toml
@@ -6,6 +6,7 @@ workspace = "../../"
 
 [[bin]]
 name = "hab-launch"
+path = "src/main.rs"
 doc = false
 
 [dependencies]

--- a/components/sup/Cargo.toml
+++ b/components/sup/Cargo.toml
@@ -10,6 +10,7 @@ name = "habitat_sup"
 
 [[bin]]
 name = "hab-sup"
+path = "src/main.rs"
 doc = false
 
 [dependencies]


### PR DESCRIPTION
* Update petgraph to 0.4.5
* Fix some cargo warnings by explicitly specifying where our binary gets built from

![tenor-89635564](https://user-images.githubusercontent.com/947/29938688-6ca07d1a-8e3e-11e7-80d8-566ceb789aa6.gif)

Signed-off-by: Josh Black <raskchanky@gmail.com>