### PR TITLE
set cookie domain to current host on ip address hosts

### DIFF
--- a/components/builder-web/app/actions.test.ts
+++ b/components/builder-web/app/actions.test.ts
@@ -65,18 +65,21 @@ describe("actions", () => {
                 spyOn(gitHub, "currentHostname").and.returnValues(
                     "localhost",
                     "builder.habitat.sh",
-                    "builder.acceptance.habitat.foo"
+                    "builder.acceptance.habitat.foo",
+                    "1.2.3.4"
                 );
 
                 gitHub.setCookie("gitHubAuthToken", "some-token");
                 gitHub.setCookie("gitHubAuthToken", "some-token");
                 gitHub.setCookie("gitHubAuthToken", "some-token");
-
+                gitHub.setCookie("gitHubAuthToken", "some-token");
+                
                 expect(cookies.set.calls.allArgs()).toEqual(
                     [
                         [ "gitHubAuthToken", "some-token", { domain: "localhost", secure: false } ],
                         [ "gitHubAuthToken", "some-token", { domain: "habitat.sh", secure: false } ],
-                        [ "gitHubAuthToken", "some-token", { domain: "habitat.foo", secure: false } ]
+                        [ "gitHubAuthToken", "some-token", { domain: "habitat.foo", secure: false } ],
+                        [ "gitHubAuthToken", "some-token", { domain: "1.2.3.4", secure: false } ]
                     ]
                 );
             });

--- a/components/builder-web/app/actions/gitHub.ts
+++ b/components/builder-web/app/actions/gitHub.ts
@@ -223,14 +223,21 @@ function resetGitHubRepos() {
 }
 
 // Return up to two trailing segments of the current hostname
-// for purposes of setting the cookie domain.
+// for purposes of setting the cookie domain unless the domain
+// is an IP address.
 function cookieDomain() {
     let delim = ".";
+    let hostname = currentHostname();
+    let tld = hostname.split(delim).pop();
 
-    return currentHostname()
+    if (isNaN(Number(tld))) {
+        return hostname
         .split(delim)
         .splice(-2)
         .join(delim);
+    } else {
+        return hostname;
+    }
 }
 
 export const currentHostname = () => {


### PR DESCRIPTION
This should fix dev environments that need to use an IP address as a host name.

Signed-off-by: Matt Wrock <matt@mattwrock.com>