### PR TITLE
Make the `first` binding function return only live members

### DIFF
--- a/components/sup/src/census.rs
+++ b/components/sup/src/census.rs
@@ -564,6 +564,11 @@ impl CensusMember {
             Health::Departed => self.departed = true,
         }
     }
+
+    /// Is this member currently considered to be alive or not?
+    pub fn alive(&self) -> bool {
+        self.alive
+    }
 }
 
 fn service_group_from_str(sg: &str) -> Result<ServiceGroup, hcore::Error> {

--- a/components/sup/src/templating/context.rs
+++ b/components/sup/src/templating/context.rs
@@ -137,15 +137,18 @@ impl<'a> Svc<'a> {
 #[derive(Clone, Debug, Serialize)]
 pub struct SvcMember<'a>(&'a CensusMember);
 
-/// Helper for pulling the leader or first member from a census group. This is used to populate the
-/// `.first` field in `bind` and `svc`.
+/// Helper for pulling the leader or first alive member from a census
+/// group. This is used to populate the `.first` field in `bind` and
+/// `svc`.
 fn select_first(census_group: &CensusGroup) -> Option<SvcMember> {
     match census_group.leader() {
         Some(member) => Some(SvcMember(member)),
         None => {
-            census_group.members().first().and_then(
-                |m| Some(SvcMember(m)),
-            )
+            census_group
+                .members()
+                .into_iter()
+                .find(|ref m| m.alive())
+                .and_then(|m| Some(SvcMember(m)))
         }
     }
 }


### PR DESCRIPTION
Previously, when running in a standalone topology and using a bind to
`first` in a template (as in `bind.foo.first.sys.ip`), the first
member of the bound group that the supervisor knew about was returned
regardless of whether it was alive or not.

This can obviously cause issues if you try to, say, bind to a database
server that is long gone.

Now `first` returns the first live member.

Signed-off-by: Christopher Maier <cmaier@chef.io>