### PR TITLE
Revert "Make the `first` binding function return only live members"

### DIFF
--- a/components/sup/src/census.rs
+++ b/components/sup/src/census.rs
@@ -564,11 +564,6 @@ impl CensusMember {
             Health::Departed => self.departed = true,
         }
     }
-
-    /// Is this member currently considered to be alive or not?
-    pub fn alive(&self) -> bool {
-        self.alive
-    }
 }
 
 fn service_group_from_str(sg: &str) -> Result<ServiceGroup, hcore::Error> {

--- a/components/sup/src/templating/context.rs
+++ b/components/sup/src/templating/context.rs
@@ -137,18 +137,15 @@ impl<'a> Svc<'a> {
 #[derive(Clone, Debug, Serialize)]
 pub struct SvcMember<'a>(&'a CensusMember);
 
-/// Helper for pulling the leader or first alive member from a census
-/// group. This is used to populate the `.first` field in `bind` and
-/// `svc`.
+/// Helper for pulling the leader or first member from a census group. This is used to populate the
+/// `.first` field in `bind` and `svc`.
 fn select_first(census_group: &CensusGroup) -> Option<SvcMember> {
     match census_group.leader() {
         Some(member) => Some(SvcMember(member)),
         None => {
-            census_group
-                .members()
-                .into_iter()
-                .find(|ref m| m.alive())
-                .and_then(|m| Some(SvcMember(m)))
+            census_group.members().first().and_then(
+                |m| Some(SvcMember(m)),
+            )
         }
     }
 }


### PR DESCRIPTION
This reverts commit 880a7b0ec36806d2ee7cd0ce57e04a22d6a16e11.

The idea behind the change is sound, but there are further
ramifications that need to be addressed. Until such time, we'll revert
this change.