### PR TITLE
Adjust .gitignore, add unintentionally git-ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ terraform.tfstate*
 .delivery/cli.toml
 .tags*
 log/
-results/
+components/*/results
 tmp/
 .vagrant/
 *.sig.key

--- a/components/builder-web/app/search/results/_results.component.scss
+++ b/components/builder-web/app/search/results/_results.component.scss
@@ -1,0 +1,48 @@
+.hab-search-results {
+
+  li {
+    position: relative;
+    cursor: pointer;
+    font-size: rem(12);
+
+    a {
+      display: block;
+      transition: all 0.6s;
+      background-blend-mode: overlay;
+      border: 1px solid $hab-blue-light;
+      border-radius: $global-radius;
+      margin-bottom: 0.5em;
+      padding: rem(10);
+      color: $hab-gray-dark;
+      font-family: $heading-font-family;
+      font-size: rem(16);
+
+      &:hover, &.active {
+        transform: scale(1.01);
+        transition: all 0.2s ease-in-out;
+        box-shadow: 0 1px 14px 0 $hab-blue-light;
+      }
+
+      hab-icon[symbol="chevron-right"] {
+        position: absolute;
+        display: none;
+        right: 24px;
+        width: $list-item-icon-width;
+        height: $list-item-icon-height;
+        top: 50%;
+        transform: translateY(-50%);
+      }
+
+      &:hover {
+
+        hab-icon[symbol="chevron-right"] {
+          display: block;
+        }
+      }
+
+      .name {
+        font-family: $heading-font-family;
+      }
+    }
+  }
+}

--- a/components/builder-web/app/search/results/results.component.html
+++ b/components/builder-web/app/search/results/results.component.html
@@ -1,0 +1,18 @@
+<ul class="hab-search-results">
+    <div *ngIf="noPackages">
+        <p>
+        No packages found.
+        <span *ngIf="errorMessage">
+            Error: {{errorMessage}}
+        </span>
+        </p>
+    </div>
+    <li *ngFor="let pkg of packages">
+        <a [routerLink]="routeFor(pkg)">
+            <div class="name">
+                <span>{{ packageString(pkg) }}</span>
+            </div>
+            <hab-icon symbol="chevron-right"></hab-icon>
+        </a>
+    </li>
+</ul>

--- a/components/builder-web/app/search/results/results.component.spec.ts
+++ b/components/builder-web/app/search/results/results.component.spec.ts
@@ -1,0 +1,66 @@
+import { TestBed, ComponentFixture } from "@angular/core/testing";
+import { RouterTestingModule } from "@angular/router/testing";
+import { Component, DebugElement } from "@angular/core";
+import { By } from "@angular/platform-browser";
+import { List } from "immutable";
+import { MockComponent } from "ng2-mock-component";
+import { SearchResultsComponent } from "./results.component";
+
+describe("SearchResultsListComponent", () => {
+  let fixture: ComponentFixture<SearchResultsComponent>;
+  let component: SearchResultsComponent;
+  let element: DebugElement;
+
+  beforeEach(() => {
+
+    TestBed.configureTestingModule({
+      imports: [
+        RouterTestingModule
+      ],
+      declarations: [
+        SearchResultsComponent,
+        MockComponent({ selector: "hab-icon", inputs: [ "symbol" ]}),
+        MockComponent({ selector: "hab-channels", inputs: [ "channels" ]}),
+        MockComponent({
+          selector: "hab-build-status",
+          inputs: [ "origin", "name", "version" ]
+        })
+      ]
+    });
+
+    fixture = TestBed.createComponent(SearchResultsComponent);
+    component = fixture.componentInstance;
+    element = fixture.debugElement;
+  });
+
+  beforeEach(() => {
+    component.packages = List([
+      {
+        origin: "core",
+        project: "nginx",
+        version: "1.0.2",
+        release: "20170101000002",
+        channels: [ "stable", "unstable" ]
+      },
+      {
+        origin: "core",
+        project: "nginx",
+        version: "1.0.1",
+        release: "20170101000001",
+        channels: [ "unstable" ]
+      },
+      {
+        origin: "core",
+        project: "nginx",
+        version: "1.0.0",
+        release: "20170101000000",
+        channels: []
+      }
+    ]);
+    fixture.detectChanges();
+  });
+
+  it("renders a list of packages", () => {
+    expect(element.queryAll(By.css(".hab-search-results li .name")).length).toBe(3);
+  });
+});

--- a/components/builder-web/app/search/results/results.component.ts
+++ b/components/builder-web/app/search/results/results.component.ts
@@ -1,0 +1,21 @@
+import { Component, Input } from "@angular/core";
+import { List } from "immutable";
+import { packageString, releaseToDate } from "../../util";
+
+@Component({
+    selector: "hab-search-results",
+    template: require("./results.component.html")
+})
+export class SearchResultsComponent {
+    @Input() errorMessage: string;
+    @Input() noPackages: boolean;
+    @Input() packages: List<Object>;
+
+    routeFor(pkg) {
+        return ["/pkgs", pkg.origin, pkg.name, "latest"];
+    }
+
+    packageString(pkg) {
+        return packageString(pkg);
+    }
+}


### PR DESCRIPTION
This adjusts the .gitignore file to ignore build-results directories more specifically, allowing other parts of the tree to contain directories named `results`. Also adds a missed `results` directory to builder-web.

Signed-off-by: Christian Nunciato <cnunciato@chef.io>

![](https://media.tenor.com/images/22806ccc259047fc121f9db6fc5da5e8/tenor.gif)