### PR TITLE
Add basic retry capability to build post-processor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -980,6 +980,7 @@ dependencies = [
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "retry 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/builder-core/src/logger.rs
+++ b/components/builder-core/src/logger.rs
@@ -15,6 +15,7 @@
 use std::fs::File;
 use std::io::Write;
 use std::path::Path;
+use std::fs::OpenOptions;
 use chrono::prelude::*;
 
 use protocol::jobsrv::Job;
@@ -27,7 +28,14 @@ pub struct Logger {
 impl Logger {
     pub fn init<T: AsRef<Path>>(log_path: T, filename: &str) -> Self {
         let filepath = log_path.as_ref().to_path_buf().join(filename);
-        Logger { file: File::create(filepath).expect("Failed to initialize log file") }
+
+        Logger {
+            file: OpenOptions::new()
+                .append(true)
+                .create(true)
+                .open(filepath)
+                .expect("Failed to initialize log file"),
+        }
     }
 
     pub fn log(&mut self, msg: &str) {

--- a/components/builder-worker/Cargo.toml
+++ b/components/builder-worker/Cargo.toml
@@ -19,6 +19,7 @@ git2 = "*"
 lazy_static = "*"
 log = "*"
 protobuf = "*"
+retry = "*"
 serde = "*"
 serde_derive = "*"
 toml = { version = "*", features = ["serde"], default-features = false }

--- a/components/builder-worker/src/lib.rs
+++ b/components/builder-worker/src/lib.rs
@@ -32,6 +32,7 @@ extern crate toml;
 extern crate zmq;
 extern crate habitat_builder_protocol;
 extern crate builder_core as bldr_core;
+extern crate retry;
 
 pub mod config;
 pub mod error;

--- a/components/builder-worker/src/runner/mod.rs
+++ b/components/builder-worker/src/runner/mod.rs
@@ -232,9 +232,7 @@ impl Runner {
         self.workspace.job.set_package_ident(ident);
 
         let mut post_processor = PostProcessor::new(&self.workspace);
-        if !post_processor.run(&mut archive, &self.config) {
-            // JW TODO: We should shelve the built artifacts and allow a retry on post-processing.
-            // If the job is killed then we can kill the shelved artifacts.
+        if !post_processor.run(&mut archive, &self.config, &mut self.logger) {
             return self.fail(net::err(ErrCode::POST_PROCESSOR, "wk:run:6"));
         }
 


### PR DESCRIPTION
This change adds a basic retry capability to the upload and promote path of the build worker.  It also updates the build scheduler to ignore job status updates for jobs that were not built via the scheduler (ie, owner ids that it does not recognize).  Also a minor tweak to the file logging used by the builder to not re-create the log every time the process restarts.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-200654859](https://user-images.githubusercontent.com/13542112/30131160-9c3435d2-9300-11e7-8cdd-b3eb3bad5e31.gif)
