### PR TITLE
[hab] Install minimum version of exporters when used.

### DIFF
--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -215,12 +215,6 @@ pub fn get() -> App<'static, 'static> {
                 (@arg CHANNEL: --channel -c +takes_value
                     "Retrieve the container's package from the specified release channel \
                     (default: stable)")
-                (@arg HAB_DEPOT_URL: --("hab-url") -U +takes_value {valid_url}
-                    "Retrieve the Habitat toolchain for the container from the specified Depot \
-                    (default: https://bldr.habitat.sh/v1/depot)")
-                (@arg HAB_CHANNEL: --("hab-channel") -C +takes_value
-                    "Retrieve the Habitat toolchain for the container from the specified release \
-                    channel (default: stable)")
             )
             (@subcommand hash =>
                 (about: "Generates a blake2b hashsum from a target at any given filepath")

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -362,20 +362,8 @@ fn sub_pkg_export(ui: &mut UI, m: &ArgMatches) -> Result<()> {
     let channel = m.value_of("CHANNEL")
         .and_then(|c| Some(c.to_string()))
         .unwrap_or(channel::default());
-    let hab_url = m.value_of("HAB_DEPOT_URL").unwrap_or(&env_or_default);
-    let hab_channel = m.value_of("HAB_CHANNEL")
-        .and_then(|c| Some(c.to_string()))
-        .unwrap_or(channel::default());
     let export_fmt = command::pkg::export::format_for(ui, &format)?;
-    command::pkg::export::start(
-        ui,
-        &url,
-        &channel,
-        &hab_url,
-        &hab_channel,
-        &ident,
-        &export_fmt,
-    )
+    command::pkg::export::start(ui, &url, &channel, &ident, &export_fmt)
 }
 
 fn sub_pkg_hash(m: &ArgMatches) -> Result<()> {


### PR DESCRIPTION
This change updates the install-on-use behavior for all packages which
provide package export functionality (i.e. the implementations for `hab
pkg export *`). The behavior now is the same as the behavior for `hab
sup`, `hab run`, `hab svc *`, `hab config apply`, `hab pkg build`, and
`hab studio *` subcommands, where the same x.y.z version installed if
missing.

Prior to this change, upgrading the version of `core/hab` would not
upgrade the version of `core/hab-pkg-dockerize` (or other export
packages).

Note that in this change, 2 options were removed that affected the `hab
pkg export` subcommand, namely `--hab-url` and `hab-channel`. These
options were only used to install the `core/hab-pkg-dockerize` (and
similar) package itself which should not be required. Most importantly,
those options did not affect or influence which version of `core/hab`,
`core/hab-launcher`, and `core/hab-sup` were exported various export
types. A future change will introduce a re-written `hab-pkg-dockerize`
which fully supports targetting a different Depot URL and channel for
"base packages" such as the Supervisor and the Launcher.

Closes #3093

![tenor-241107560](https://user-images.githubusercontent.com/261548/30136229-35578650-931b-11e7-93ff-148e282c15ab.gif)
