### PR TITLE
Fix compiler warnings on macOS platform.

### DIFF
--- a/components/hab/src/command/launcher.rs
+++ b/components/hab/src/command/launcher.rs
@@ -18,10 +18,6 @@ use common::ui::UI;
 
 use error::Result;
 
-const LAUNCH_CMD: &'static str = "hab-launch";
-const LAUNCH_CMD_ENVVAR: &'static str = "HAB_LAUNCH_BINARY";
-const LAUNCH_PKG_IDENT: &'static str = "core/hab-launcher";
-
 pub fn start(ui: &mut UI, args: Vec<OsString>) -> Result<()> {
     inner::start(ui, args)
 }
@@ -39,11 +35,14 @@ mod inner {
     use hcore::os::process;
     use hcore::package::PackageIdent;
 
-    use super::{LAUNCH_CMD, LAUNCH_CMD_ENVVAR, LAUNCH_PKG_IDENT};
     use super::super::sup::{SUP_CMD, SUP_CMD_ENVVAR, SUP_PKG_IDENT};
     use error::{Error, Result};
     use exec;
     use VERSION;
+
+    const LAUNCH_CMD: &'static str = "hab-launch";
+    const LAUNCH_CMD_ENVVAR: &'static str = "HAB_LAUNCH_BINARY";
+    const LAUNCH_PKG_IDENT: &'static str = "core/hab-launcher";
 
     pub fn start(ui: &mut UI, args: Vec<OsString>) -> Result<()> {
         init();

--- a/components/hab/src/command/studio/enter.rs
+++ b/components/hab/src/command/studio/enter.rs
@@ -168,16 +168,14 @@ mod inner {
 
 #[cfg(not(target_os = "linux"))]
 mod inner {
-    use std::env;
-    use std::ffi::{OsStr, OsString};
-    use std::path::{Path, PathBuf};
-    use std::process::{Command, Stdio};
+    use std::ffi::OsString;
+    use std::path::PathBuf;
     use std::str::FromStr;
 
     use common::ui::UI;
     use hcore::crypto::{init, default_cache_key_path};
     use hcore::env as henv;
-    use hcore::fs::{CACHE_ARTIFACT_PATH, CACHE_KEY_PATH, find_command};
+    use hcore::fs::find_command;
     use hcore::os::process;
     use hcore::package::PackageIdent;
 


### PR DESCRIPTION
A little quality-of-life involving cleaning up some old imports and
constants which are not used on all targets.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>