### PR TITLE
`hab install --binlink` skip if dst exists

### DIFF
--- a/components/common/src/ui.rs
+++ b/components/common/src/ui.rs
@@ -50,6 +50,7 @@ pub enum Status {
     Using,
     Verified,
     Verifying,
+    Warning,
     Custom(char, String),
 }
 
@@ -76,6 +77,7 @@ impl Status {
             Status::Using => ('→', "Using".into(), Colour::Green),
             Status::Verified => ('✓', "Verified".into(), Colour::Green),
             Status::Verifying => ('☛', "Verifying".into(), Colour::Green),
+            Status::Warning => ('⚠', "Warning".into(), Colour::Yellow),
             Status::Custom(c, ref s) => (c, s.to_string(), Colour::Green),
         }
     }

--- a/components/common/src/ui.rs
+++ b/components/common/src/ui.rs
@@ -50,7 +50,6 @@ pub enum Status {
     Using,
     Verified,
     Verifying,
-    Warning,
     Custom(char, String),
 }
 
@@ -77,7 +76,6 @@ impl Status {
             Status::Using => ('→', "Using".into(), Colour::Green),
             Status::Verified => ('✓', "Verified".into(), Colour::Green),
             Status::Verifying => ('☛', "Verifying".into(), Colour::Green),
-            Status::Warning => ('⚠', "Warning".into(), Colour::Yellow),
             Status::Custom(c, ref s) => (c, s.to_string(), Colour::Green),
         }
     }

--- a/components/hab/src/command/pkg/binlink.rs
+++ b/components/hab/src/command/pkg/binlink.rs
@@ -58,7 +58,7 @@ pub fn start(
             Status::Warning,
             format!("{} exists, skipping...", dst.display()),
         )?;
-        return Ok(())
+        return Ok(());
     }
     match fs::read_link(&dst) {
         Ok(path) => {

--- a/components/hab/src/command/pkg/binlink.rs
+++ b/components/hab/src/command/pkg/binlink.rs
@@ -54,10 +54,7 @@ pub fn start(
         fs::create_dir_all(&dst_path)?
     }
     if dst.exists() {
-        ui.status(
-            Status::Warning,
-            format!("{} exists, skipping...", dst.display()),
-        )?;
+        ui.warn(format!("{} exists, skipping...", dst.display()))?;
         return Ok(());
     }
     match fs::read_link(&dst) {

--- a/components/hab/src/command/pkg/binlink.rs
+++ b/components/hab/src/command/pkg/binlink.rs
@@ -53,6 +53,13 @@ pub fn start(
         )?;
         fs::create_dir_all(&dst_path)?
     }
+    if dst.exists() {
+        ui.status(
+            Status::Warning,
+            format!("{} exists, skipping...", dst.display()),
+        )?;
+        return Ok(())
+    }
     match fs::read_link(&dst) {
         Ok(path) => {
             if path != src {


### PR DESCRIPTION
fixes #2798

Notes:

* If the destination path for the link exists, print a warning and skip
* Adds `Status::Warning`

Example:

```
$ hab install core/openssh --binlink
» Installing core/openssh from channel 'stable'
→ Using core/openssh/7.5p1/20170711154302
★ Install of core/openssh/7.5p1/20170711154302 complete with 0 new packages installed.
» Symlinking ssh from core/openssh/7.5p1/20170711154302 into /bin
⚠ Warning /bin/ssh exists, skipping...
» Symlinking ssh-keyscan from core/openssh/7.5p1/20170711154302 into /bin
⚠ Warning /bin/ssh-keyscan exists, skipping...
» Symlinking ssh-keygen from core/openssh/7.5p1/20170711154302 into /bin
⚠ Warning /bin/ssh-keygen exists, skipping...
.
.
.
```

Signed-off-by: Victor Yap <victor@vicyap.com>