### PR TITLE
Add platforms and channels to project_jobs API endpoint

### DIFF
--- a/components/builder-api/src/http/handlers.rs
+++ b/components/builder-api/src/http/handlers.rs
@@ -19,9 +19,10 @@ use std::env;
 use base64;
 use bodyparser;
 use bld_core;
-use bld_core::api::{channels_for_package_ident, promote_job_group_to_channel};
+use bld_core::api::{channels_for_package_ident, platforms_for_package_ident,
+                    promote_job_group_to_channel};
 use depot::server::check_origin_access;
-use hab_core::package::{Identifiable, Plan};
+use hab_core::package::Plan;
 use hab_core::event::*;
 use hab_net;
 use hab_net::http::controller::*;
@@ -31,7 +32,7 @@ use iron::status;
 use iron::typemap;
 use params::{Params, Value, FromValue};
 use persistent;
-use protocol::jobsrv::{Job, JobGet, JobLogGet, JobLog, JobSpec, ProjectJobsGet,
+use protocol::jobsrv::{Job, JobGet, JobLogGet, JobLog, JobSpec, JobState, ProjectJobsGet,
                        ProjectJobsGetResponse};
 use protocol::scheduler::{ReverseDependenciesGet, ReverseDependencies};
 use protocol::originsrv::*;
@@ -646,10 +647,19 @@ pub fn project_jobs(req: &mut Request) -> IronResult<Response> {
             let list: Vec<serde_json::Value> = response
                 .get_jobs()
                 .iter()
-                .map(|job| if job.get_package_ident().fully_qualified() {
+                .map(|job| if job.get_state() == JobState::Complete {
                     let channels = channels_for_package_ident(&job.get_package_ident());
+                    let platforms = platforms_for_package_ident(&job.get_package_ident());
                     let mut job_json = serde_json::to_value(job).unwrap();
-                    job_json["channels"] = json!(channels);
+
+                    if channels.is_some() {
+                        job_json["channels"] = json!(channels);
+                    }
+
+                    if platforms.is_some() {
+                        job_json["platforms"] = json!(platforms);
+                    }
+
                     job_json
                 } else {
                     serde_json::to_value(job).unwrap()

--- a/components/builder-api/src/lib.rs
+++ b/components/builder-api/src/lib.rs
@@ -34,6 +34,7 @@ extern crate protobuf;
 extern crate router;
 #[macro_use]
 extern crate serde_derive;
+#[macro_use]
 extern crate serde_json;
 extern crate staticfile;
 extern crate toml;

--- a/components/builder-core/src/api.rs
+++ b/components/builder-core/src/api.rs
@@ -22,7 +22,9 @@ use protocol::originsrv::{CheckOriginAccessRequest, CheckOriginAccessResponse, O
                           OriginChannel, OriginChannelCreate, OriginChannelGet, OriginGet,
                           OriginPackage, OriginPackageChannelListRequest,
                           OriginPackageChannelListResponse, OriginPackageGet,
-                          OriginPackageGroupPromote, OriginPackageIdent, OriginPackagePromote};
+                          OriginPackageGroupPromote, OriginPackageIdent,
+                          OriginPackagePlatformListRequest, OriginPackagePlatformListResponse,
+                          OriginPackagePromote};
 use protocol::net::{ErrCode, NetError, NetOk};
 use protocol::scheduler::{Group, GroupGet, Project, ProjectState};
 use protocol::sessionsrv::{Session, SessionCreate, SessionGet};
@@ -47,6 +49,20 @@ pub fn channels_for_package_ident(package: &OriginPackageIdent) -> Option<Vec<St
 
             Some(list)
         }
+        Err(_) => None,
+    }
+}
+
+// Get platforms for a package
+pub fn platforms_for_package_ident(package: &OriginPackageIdent) -> Option<Vec<String>> {
+    let mut conn = Broker::connect().unwrap();
+    let mut opplr = OriginPackagePlatformListRequest::new();
+    opplr.set_ident(package.clone());
+
+    match conn.route::<OriginPackagePlatformListRequest, OriginPackagePlatformListResponse>(
+        &opplr,
+    ) {
+        Ok(p) => Some(p.get_platforms().to_vec()),
         Err(_) => None,
     }
 }

--- a/components/builder-depot/src/server.rs
+++ b/components/builder-depot/src/server.rs
@@ -23,6 +23,7 @@ use base64;
 
 use uuid::Uuid;
 use bld_core;
+use bld_core::api::channels_for_package_ident;
 use bodyparser;
 use hab_core::package::{Identifiable, FromArchive, PackageArchive, PackageIdent, PackageTarget,
                         ident};
@@ -2054,26 +2055,6 @@ pub fn do_promotion(
             error!("promote:2, err={:?}", &e);
             Ok(Response::with(status::InternalServerError))
         }
-    }
-}
-
-// Get channels for a package
-fn channels_for_package_ident(package: &OriginPackageIdent) -> Option<Vec<String>> {
-    let mut conn = Broker::connect().unwrap();
-    let mut opclr = OriginPackageChannelListRequest::new();
-    opclr.set_ident(package.clone());
-
-    match conn.route::<OriginPackageChannelListRequest, OriginPackageChannelListResponse>(&opclr) {
-        Ok(channels) => {
-            let list: Vec<String> = channels
-                .get_channels()
-                .iter()
-                .map(|channel| channel.get_name().to_string())
-                .collect();
-
-            Some(list)
-        }
-        Err(_) => None,
     }
 }
 

--- a/components/builder-depot/src/server.rs
+++ b/components/builder-depot/src/server.rs
@@ -23,7 +23,7 @@ use base64;
 
 use uuid::Uuid;
 use bld_core;
-use bld_core::api::channels_for_package_ident;
+use bld_core::api::{channels_for_package_ident, platforms_for_package_ident};
 use bodyparser;
 use hab_core::package::{Identifiable, FromArchive, PackageArchive, PackageIdent, PackageTarget,
                         ident};
@@ -2055,20 +2055,6 @@ pub fn do_promotion(
             error!("promote:2, err={:?}", &e);
             Ok(Response::with(status::InternalServerError))
         }
-    }
-}
-
-// Get platforms for a package
-fn platforms_for_package_ident(package: &OriginPackageIdent) -> Option<Vec<String>> {
-    let mut conn = Broker::connect().unwrap();
-    let mut opplr = OriginPackagePlatformListRequest::new();
-    opplr.set_ident(package.clone());
-
-    match conn.route::<OriginPackagePlatformListRequest, OriginPackagePlatformListResponse>(
-        &opplr,
-    ) {
-        Ok(p) => Some(p.get_platforms().to_vec()),
-        Err(_) => None,
     }
 }
 

--- a/components/builder-protocol/protocols/jobsrv.proto
+++ b/components/builder-protocol/protocols/jobsrv.proto
@@ -46,8 +46,7 @@ message Job {
   // The RFC3339-formatted time the `hab studio build` process
   // stopped, successful or not.
   optional string build_finished_at = 8;
-  // The identifier of the package built by the job. Set only a
-  // successfully-built Job.
+  // The identifier of the package built/attempted by the job.
   optional originsrv.OriginPackageIdent package_ident = 9;
   // Whether or not the log for the job has been archived
   optional bool is_archived = 11;


### PR DESCRIPTION
Note that `platforms` and `channels` will only be available if the build completed successfully.

Closes https://github.com/habitat-sh/habitat/issues/3048

![tenor-26024819](https://user-images.githubusercontent.com/947/30191515-0508d702-93f6-11e7-9681-4a7569f41d61.gif)
