### PR TITLE
Fix incorrect use of wildcard in gitignore

### DIFF
--- a/components/builder-web/.gitignore
+++ b/components/builder-web/.gitignore
@@ -1,5 +1,5 @@
-app**/*.js
-app**/*.js.map
+app/**/*.js
+app/**/*.js.map
 assets/app.css
 assets/app.css.map
 assets/app.js


### PR DESCRIPTION
The `components/builder-web/.gitignore` file was incorrectly using
`app**/*` instead of `app/**/*`.

Running ripgrep on the repo caused the following warning to be printed:

```
error parsing glob 'app**/*.js': invalid use of **; must be one path component
```