### PR TITLE
Don’t run the tests unless I ask

### DIFF
--- a/components/builder-web/bin/start
+++ b/components/builder-web/bin/start
@@ -4,6 +4,4 @@ set -x
 concurrently \
   "npm run build-css-watch" \
   "npm run build-js-watch" \
-  "npm run test-unit -- --no-single-run" \
-  "npm run lint-css-watch" \
   "lite-server"


### PR DESCRIPTION
These frequently either peg my CPU or bury compile errors. If I want to run the tests, I can run either `npm run test` or `npm run test-watch`.

Signed-off-by: Christian Nunciato <cnunciato@chef.io>

![](https://media.tenor.com/images/5625e4236668d0dfc7a46e2447866161/tenor.gif)