### PR TITLE
Update http timeout, add retry for key fetch

### DIFF
--- a/components/http-client/src/api_client.rs
+++ b/components/http-client/src/api_client.rs
@@ -32,7 +32,7 @@ use proxy::{ProxyInfo, proxy_unless_domain_exempted};
 use ssl;
 
 // Read and write TCP socket timeout for Hyper/HTTP client calls.
-const CLIENT_SOCKET_RW_TIMEOUT: u64 = 30;
+const CLIENT_SOCKET_RW_TIMEOUT: u64 = 60;
 
 header! { (ProxyAuthorization, "Proxy-Authorization") => [String] }
 


### PR DESCRIPTION
This change adds a retry to the origin key fetch in the builder worker.
It also updates the http client timeout to 60 secs, as we can hit the lower timeout with large package uploads.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-58907922](https://user-images.githubusercontent.com/13542112/30243656-b18893f0-9563-11e7-9d1b-a7b0ed3289ae.gif)

