### PR TITLE
Check special case during package upload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -977,6 +977,7 @@ dependencies = [
  "habitat_core 0.0.0",
  "habitat_depot_client 0.0.0",
  "habitat_net 0.0.0",
+ "hyper 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/builder-worker/Cargo.toml
+++ b/components/builder-worker/Cargo.toml
@@ -16,6 +16,7 @@ clippy = {version = "*", optional = true}
 chrono = { version = "*", features = ["serde"] }
 env_logger = "*"
 git2 = "*"
+hyper = "*"
 lazy_static = "*"
 log = "*"
 protobuf = "*"

--- a/components/builder-worker/src/lib.rs
+++ b/components/builder-worker/src/lib.rs
@@ -33,6 +33,7 @@ extern crate zmq;
 extern crate habitat_builder_protocol;
 extern crate builder_core as bldr_core;
 extern crate retry;
+extern crate hyper;
 
 pub mod config;
 pub mod error;


### PR DESCRIPTION
Add a check for a special case, where a build worker may get a Conflict message during the upload - if a previous upload actually succeeded, a Conflict indicates that the package exists, and should not fail the worker post-processing.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-230142814](https://user-images.githubusercontent.com/13542112/30254528-1a24d36a-964f-11e7-85f9-6b2059e6f464.gif)
