### PR TITLE
Download keys for verification when updating services

### DIFF
--- a/components/sup/src/manager/service_updater.rs
+++ b/components/sup/src/manager/service_updater.rs
@@ -19,7 +19,7 @@ use std::thread;
 use std::time::Duration;
 
 use butterfly;
-use common::ui::{Status, UI};
+use common::ui::{Coloring, Status, UI};
 use depot_client;
 use env;
 use hcore::package::{PackageIdent, PackageInstall};
@@ -306,7 +306,7 @@ impl Worker {
             depot: depot_client::Client::new(&service.depot_url, PRODUCT, VERSION, None).unwrap(),
             channel: service.channel.clone(),
             update_strategy: service.update_strategy.clone(),
-            ui: UI::default(),
+            ui: UI::default_with(Coloring::Never, None),
         }
     }
 

--- a/components/sup/src/manager/service_updater.rs
+++ b/components/sup/src/manager/service_updater.rs
@@ -435,7 +435,7 @@ impl Worker {
                     Err(_) => {
                         outputln!(
                             "Unable to parse '{}' from {} as a valid integer. Falling back \
-                                  to defailt {} MS frequency.",
+                                  to default {} MS frequency.",
                             val,
                             FREQUENCY_ENVVAR,
                             DEFAULT_FREQUENCY


### PR DESCRIPTION
Previously we wouldn't download keys, which meant that we could fail
to verify an updated service package if we didn't happen to already
have the key with which it was signed in our local cache.

The implementation is admittedly awful, being lifted (almost verbatim)
from `common::command::package::install`; however, we have package
installation logic scattered around in several places in the codebase,
and I am in the middle of overhauling and consolidating all of it
right now. This patch should fix this bug now, and the proper solution
will be along Real Soon Now (TM).

(I'm not making a corresponding change to
`sup::manager::self_updater`, because that is only ever updating
`core/hab-sup`, which we should always have the keys for anyway. In
any event, that package installation path will also be subsumed in the
aforementioned refactoring, so it should be a moot point soon anyway.)

Fixes #3121
