### PR TITLE
Install Datadog agent on builder nodes

### DIFF
--- a/terraform/instances.tf
+++ b/terraform/instances.tf
@@ -40,6 +40,13 @@ resource "aws_instance" "api" {
     ]
   }
 
+  provisioner "remote-exec" {
+    inline = [
+      "DD_API_KEY=${var.datadog_api_key} /bin/bash -c \"$(curl -L https://raw.githubusercontent.com/DataDog/dd-agent/master/packaging/datadog-agent/source/install_agent.sh)\"",
+      "sudo sed -i \"$ a tags: env:${var.env}, role:api\" /etc/dd-agent/datadog.conf",
+      "sudo /etc/init.d/datadog-agent restart"
+    ]
+  }
   provisioner "file" {
     content     = "${data.template_file.sup_service.rendered}"
     destination = "/home/ubuntu/hab-sup.service"
@@ -104,6 +111,14 @@ resource "aws_instance" "admin" {
   provisioner "remote-exec" {
     scripts = [
       "${path.module}/scripts/foundation.sh",
+    ]
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "DD_API_KEY=${var.datadog_api_key} /bin/bash -c \"$(curl -L https://raw.githubusercontent.com/DataDog/dd-agent/master/packaging/datadog-agent/source/install_agent.sh)\"",
+      "sudo sed -i \"$ a tags: env:${var.env}, role:admin\" /etc/dd-agent/datadog.conf",
+      "sudo /etc/init.d/datadog-agent restart"
     ]
   }
 
@@ -177,6 +192,14 @@ resource "aws_instance" "datastore" {
     ]
   }
 
+  provisioner "remote-exec" {
+    inline = [
+      "DD_API_KEY=${var.datadog_api_key} /bin/bash -c \"$(curl -L https://raw.githubusercontent.com/DataDog/dd-agent/master/packaging/datadog-agent/source/install_agent.sh)\"",
+      "sudo sed -i \"$ a tags: env:${var.env}, role:datastore\" /etc/dd-agent/datadog.conf",
+      "sudo /etc/init.d/datadog-agent restart"
+    ]
+  }
+
   provisioner "file" {
     content     = "${data.template_file.sup_service.rendered}"
     destination = "/home/ubuntu/hab-sup.service"
@@ -243,6 +266,14 @@ resource "aws_instance" "jobsrv" {
   provisioner "remote-exec" {
     scripts = [
       "${path.module}/scripts/foundation.sh",
+    ]
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "DD_API_KEY=${var.datadog_api_key} /bin/bash -c \"$(curl -L https://raw.githubusercontent.com/DataDog/dd-agent/master/packaging/datadog-agent/source/install_agent.sh)\"",
+      "sudo sed -i \"$ a tags: env:${var.env}, role:jobsrv\" /etc/dd-agent/datadog.conf",
+      "sudo /etc/init.d/datadog-agent restart"
     ]
   }
 
@@ -314,6 +345,14 @@ resource "aws_instance" "originsrv" {
     ]
   }
 
+  provisioner "remote-exec" {
+    inline = [
+      "DD_API_KEY=${var.datadog_api_key} /bin/bash -c \"$(curl -L https://raw.githubusercontent.com/DataDog/dd-agent/master/packaging/datadog-agent/source/install_agent.sh)\"",
+      "sudo sed -i \"$ a tags: env:${var.env}, role:originsrv\" /etc/dd-agent/datadog.conf",
+      "sudo /etc/init.d/datadog-agent restart"
+    ]
+  }
+
   provisioner "file" {
     content     = "${data.template_file.sup_service.rendered}"
     destination = "/home/ubuntu/hab-sup.service"
@@ -378,6 +417,14 @@ resource "aws_instance" "router" {
   provisioner "remote-exec" {
     scripts = [
       "${path.module}/scripts/foundation.sh",
+    ]
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "DD_API_KEY=${var.datadog_api_key} /bin/bash -c \"$(curl -L https://raw.githubusercontent.com/DataDog/dd-agent/master/packaging/datadog-agent/source/install_agent.sh)\"",
+      "sudo sed -i \"$ a tags: env:${var.env}, role:router\" /etc/dd-agent/datadog.conf",
+      "sudo /etc/init.d/datadog-agent restart"
     ]
   }
 
@@ -449,6 +496,14 @@ resource "aws_instance" "scheduler" {
     ]
   }
 
+  provisioner "remote-exec" {
+    inline = [
+      "DD_API_KEY=${var.datadog_api_key} /bin/bash -c \"$(curl -L https://raw.githubusercontent.com/DataDog/dd-agent/master/packaging/datadog-agent/source/install_agent.sh)\"",
+      "sudo sed -i \"$ a tags: env:${var.env}, role:scheduler\" /etc/dd-agent/datadog.conf",
+      "sudo /etc/init.d/datadog-agent restart"
+    ]
+  }
+
   provisioner "file" {
     content     = "${data.template_file.sup_service.rendered}"
     destination = "/home/ubuntu/hab-sup.service"
@@ -517,6 +572,14 @@ resource "aws_instance" "sessionsrv" {
     ]
   }
 
+  provisioner "remote-exec" {
+    inline = [
+      "DD_API_KEY=${var.datadog_api_key} /bin/bash -c \"$(curl -L https://raw.githubusercontent.com/DataDog/dd-agent/master/packaging/datadog-agent/source/install_agent.sh)\"",
+      "sudo sed -i \"$ a tags: env:${var.env}, role:sessionsrv\" /etc/dd-agent/datadog.conf",
+      "sudo /etc/init.d/datadog-agent restart"
+    ]
+  }
+
   provisioner "file" {
     content     = "${data.template_file.sup_service.rendered}"
     destination = "/home/ubuntu/hab-sup.service"
@@ -582,6 +645,14 @@ resource "aws_instance" "worker" {
   provisioner "remote-exec" {
     scripts = [
       "${path.module}/scripts/foundation.sh",
+    ]
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "DD_API_KEY=${var.datadog_api_key} /bin/bash -c \"$(curl -L https://raw.githubusercontent.com/DataDog/dd-agent/master/packaging/datadog-agent/source/install_agent.sh)\"",
+      "sudo sed -i \"$ a tags: env:${var.env}, role:worker\" /etc/dd-agent/datadog.conf",
+      "sudo /etc/init.d/datadog-agent restart"
     ]
   }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -99,3 +99,7 @@ variable "connection_agent" {
 variable "connection_private_key" {
   description = "File path to AWS keypair private key"
 }
+
+variable "datadog_api_key" {
+  description = "API key for the DataDog agent"
+}


### PR DESCRIPTION
This change adds the Datadog agent on all the builder service nodes.
This is the first part of the change, there will be a corresponding change in the cloud environments repo.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-210635371](https://user-images.githubusercontent.com/13542112/30411744-d27a6806-98c7-11e7-8c58-489a06a326f1.gif)
