### PR TITLE
Stop datadog agent on worker for now

### DIFF
--- a/terraform/instances.tf
+++ b/terraform/instances.tf
@@ -652,7 +652,7 @@ resource "aws_instance" "worker" {
     inline = [
       "DD_API_KEY=${var.datadog_api_key} /bin/bash -c \"$(curl -L https://raw.githubusercontent.com/DataDog/dd-agent/master/packaging/datadog-agent/source/install_agent.sh)\"",
       "sudo sed -i \"$ a tags: env:${var.env}, role:worker\" /etc/dd-agent/datadog.conf",
-      "sudo /etc/init.d/datadog-agent restart"
+      "sudo /etc/init.d/datadog-agent stop"
     ]
   }
 


### PR DESCRIPTION
The datadog agent disk checks are causing the build worker to not unmount the studios. Turning off the agent on the worker for now until we have a good solution.

Signed-off-by: Salim Alam <salam@chef.io>