### PR TITLE
Add job id to scheduler log

### DIFF
--- a/components/builder-core/src/logger.rs
+++ b/components/builder-core/src/logger.rs
@@ -116,8 +116,9 @@ impl Logger {
         };
 
         let msg = format!(
-            "J,{},{:?},{},{},{}",
+            "J,{},{},{:?},{},{},{}",
             job.get_owner_id(),
+            job.get_id(),
             job.get_state(),
             job.get_project().get_name(),
             suffix,


### PR DESCRIPTION
Minor tweak to add the job id to the scheduler file logging.

Signed-off-by: Salim Alam <salam@chef.io>