### PR TITLE
Add jobs dashboard

### DIFF
--- a/terraform/files/postgres.yaml
+++ b/terraform/files/postgres.yaml
@@ -1,0 +1,40 @@
+init_config:
+
+instances:
+  - host: localhost
+    port: 5432
+    username: hab
+    password: REPLACETHIS
+    dbname: builder_jobsrv
+    ssl: False
+    tags:
+      - jobsrv
+    custom_metrics:
+    - # Completed jobs
+      descriptors:
+        - [job_state, completed]
+      metrics:
+         COUNT(job_state): [postgresql.job_state.completed, GAUGE]
+      query: SELECT job_state, %s from shard_0.jobs WHERE job_state = 'Complete' GROUP BY job_state;
+      relation: false
+    - # Failed jobs
+      descriptors:
+        - [job_state, failed]
+      metrics:
+         COUNT(job_state): [postgresql.job_state.failed, GAUGE]
+      query: SELECT job_state, %s from shard_0.jobs WHERE job_state = 'Failed' GROUP BY job_state;
+      relation: false
+    - # Pending jobs
+      descriptors:
+        - [job_state, waiting]
+      metrics:
+         COUNT(job_state): [postgresql.job_state.waiting, GAUGE]
+      query: SELECT job_state, %s from shard_0.jobs WHERE job_state = 'Pending' GROUP BY job_state;
+      relation: false
+    - # Dispatched jobs
+      descriptors:
+        - [job_state, working]
+      metrics:
+         COUNT(job_state): [postgresql.job_state.working, GAUGE]
+      query: SELECT job_state, %s from shard_0.jobs WHERE job_state = 'Dispatched' GROUP BY job_state;
+      relation: false

--- a/terraform/templates/sch_log_parser.py
+++ b/terraform/templates/sch_log_parser.py
@@ -1,0 +1,32 @@
+import time
+from datetime import datetime
+
+def my_log_parser(logger, line):
+    if line.count(',') >= 6:
+        date, report_type, group_id, job_id, event, package, rest = line.split(',',6)
+
+    if report_type == 'J' and event != 'Pending':
+        date = datetime.strptime(date, "%Y-%m-%d %H:%M:%S")
+        date = time.mktime(date.timetuple())
+        url = '${api_url}/#/pkgs/{0}/builds/{1}'.format(package, job_id)
+
+        if event == 'Failed':
+            error = rest.split(',')[4]
+            message = package + ' ' + error + ' ' + url
+        elif event == 'Complete':
+            message = package + ' ' + url
+        else:
+            message = package
+
+        logged_event = {
+            'msg_title': event,
+            'timestamp': date,
+            'msg_text': message,
+            'priority': 'normal',
+            'event_type': report_type,
+            'aggregation_key': group_id,
+            'alert_type': 'info'
+        }
+        return logged_event
+
+    return None

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -47,6 +47,11 @@ variable "depot_url" {
   default     = "https://bldr.habitat.sh/v1/depot"
 }
 
+variable "api_url" {
+  description = "URL of the Builder API"
+  default     = "https://bldr.habitat.sh"
+}
+
 variable "release_channel" {
   description = "Release channel in Depot to receive package updates from"
   default     = "stable"


### PR DESCRIPTION
This change adds the support files for the Builder Jobs dashboard to Terraform.  This is the first part of the change, to be accompanied by a corresponding change to the cloud environments repo.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-217990642](https://user-images.githubusercontent.com/13542112/30517391-4dc11112-9b12-11e7-954a-a4342407a5bb.gif)


