### PR TITLE
Give just enough info at init time

### DIFF
--- a/components/hab/src/command/plan/init.rs
+++ b/components/hab/src/command/plan/init.rs
@@ -110,8 +110,8 @@ pub fn start(
         create_with_template(ui, &format!("{}/plan.sh", root), &rendered_plan)?;
     }
     ui.para(
-        "The `plan.sh` is the foundation of your new habitat. You can \
-        define core metadata, dependencies, and tasks.",
+        "`plan.sh` is the foundation of your new habitat. It contains \
+        metadata, dependencies, and tasks.",
     )?;
     let rendered_default_toml = handlebars.template_render(DEFAULT_TOML_TEMPLATE, &data)?;
     create_with_template(
@@ -120,8 +120,7 @@ pub fn start(
         &rendered_default_toml,
     )?;
     ui.para(
-        "The `default.toml` allows you to declare default values for `cfg` prefixed
-        variables.",
+        "`default.toml` contains default values for `cfg` prefixed variables.",
     )?;
 
     let config_path = format!("{}/config/", root);
@@ -141,8 +140,7 @@ pub fn start(
         }
     };
     ui.para(
-        "The `config` directory is where you can set up configuration files for your app. \
-        They are influenced by `default.toml`.",
+        "`/config/` contains configuration files for your app.",
     )?;
 
     let hooks_path = format!("{}/hooks/", root);
@@ -162,21 +160,17 @@ pub fn start(
         }
     };
     ui.para(
-        "The `hooks` directory is where you can create a number of automation hooks into \
-        your habitat.",
+        "`/hooks/` contains automation hooks into your habitat.",
     )?;
 
     ui.para(
-        "For more information on any of the generated files: \
-        https://www.habitat.sh/docs/reference/plan-syntax/#basic-settings \
-        https://www.habitat.sh/docs/reference/plan-syntax/#runtime-configuration-settings \
-        https://www.habitat.sh/docs/reference/plan-syntax/#hooks \
-        https://www.habitat.sh/docs/reference/plan-syntax/#callbacks",
+        "For more information on any of the files: \
+        https://www.habitat.sh/docs/reference/plan-syntax/",
     )?;
 
     render_ignorefile(ui, &root)?;
 
-    ui.end("An abode for your code has been initialized!")?;
+    ui.end("An abode for your code is initialized!")?;
     Ok(())
 }
 


### PR DESCRIPTION
This pull request cleans up the information the `hab plan init` command displays a bit.

1. Answer the question "What do these things have in them?"
2. Keep it short as possible.
3. Let the docs describe behavior, and link to them.

This command is one of the first commands a user runs when they are new to habitat, and might run right after `hab setup`. So in this case and in `hab setup` we're using a more conversational style. I tried to preserve that while making it clearer.

The four links at the bottom of the init command currently all drop on the same page in the docs. Giving one link in this case accomplishes the same thing.

I cleaned up the wording to use the active voice (ie: "is" instead of "has been"), and to remove wording of promises (ie: "you can", "allows you to") and instead simply state what the things *are* ("it contains").
Signed-off-by: echohack <echohack@users.noreply.github.com>