### PR TITLE
Improve upon server/supervisor logging Level

### DIFF
--- a/components/builder-admin-proxy/hooks/health_check
+++ b/components/builder-admin-proxy/hooks/health_check
@@ -1,9 +1,7 @@
 #!/bin/sh
-set -x
-
 rc=0
 
-{{pkgPathFor "core/curl"}}/bin/curl --head --fail --max-time 1 \
+{{pkgPathFor "core/curl"}}/bin/curl --head --fail --max-time 1 -s \
   http://{{sys.ip}}:{{cfg.http.listen_port}}/health > /dev/null
 
 case $? in

--- a/components/builder-api-proxy/hooks/health_check
+++ b/components/builder-api-proxy/hooks/health_check
@@ -1,9 +1,7 @@
 #!/bin/sh
-set -x
-
 rc=0
 
-{{pkgPathFor "core/curl"}}/bin/curl --head --fail --max-time 1 \
+{{pkgPathFor "core/curl"}}/bin/curl --head --fail --max-time 1 -s \
   http://{{sys.ip}}:{{cfg.http.listen_port}}/health > /dev/null
 
 case $? in

--- a/components/butterfly/src/server/inbound.rs
+++ b/components/butterfly/src/server/inbound.rs
@@ -79,7 +79,7 @@ impl Inbound {
                             continue;
                         }
                     };
-                    debug!("SWIM Message: {:?}", msg);
+                    trace!("SWIM Message: {:?}", msg);
                     match msg.get_field_type() {
                         Swim_Type::PING => {
                             if self.server.check_blacklist(
@@ -178,7 +178,7 @@ impl Inbound {
                   msg.get_ack().get_from().get_id(),
                   addr,
                   &msg);
-        info!("Ack from {}@{}", msg.get_ack().get_from().get_id(), addr);
+        trace!("Ack from {}@{}", msg.get_ack().get_from().get_id(), addr);
         if msg.get_ack().has_forward_to() {
             if self.server.member_id() != msg.get_ack().get_forward_to().get_id() {
                 let forward_addr_str = format!(
@@ -197,7 +197,7 @@ impl Inbound {
                         return;
                     }
                 };
-                info!("Forwarding Ack from {}@{} to {}@{}",
+                trace!("Forwarding Ack from {}@{} to {}@{}",
                       msg.get_ack().get_from().get_id(),
                       addr,
                       msg.get_ack().get_forward_to().get_id(),
@@ -252,7 +252,7 @@ impl Inbound {
             from.set_address(format!("{}", addr.ip()));
             from
         };
-        info!("Ping from {}@{}", from.get_id(), addr);
+        trace!("Ping from {}@{}", from.get_id(), addr);
         if from.get_departed() {
             self.server.insert_member(from.into(), Health::Departed);
         } else {

--- a/components/butterfly/src/server/mod.rs
+++ b/components/butterfly/src/server/mod.rs
@@ -664,7 +664,7 @@ impl Server {
         let alive_population = electorate.len();
 
         if total_population < 3 {
-            info!(
+            trace!(
                 "Quorum size: {}/3 - election cannot complete",
                 total_population
             );

--- a/components/butterfly/src/server/outbound.rs
+++ b/components/butterfly/src/server/outbound.rs
@@ -322,7 +322,7 @@ pub fn pingreq(server: &Server, socket: &UdpSocket, pingreq_target: &Member, tar
     };
     match socket.send_to(&payload, addr) {
         Ok(_s) => {
-            info!(
+            trace!(
                 "Sent PingReq to {}@{} for {}@{}",
                 pingreq_target.get_id(),
                 addr,
@@ -390,14 +390,14 @@ pub fn ping(
     match socket.send_to(&payload, addr) {
         Ok(_s) => {
             if forward_to.is_some() {
-                info!(
+                trace!(
                     "Sent Ping to {} on behalf of {}@{}",
                     addr,
                     swim.get_ping().get_forward_to().get_id(),
                     swim.get_ping().get_forward_to().get_address()
                 );
             } else {
-                info!("Sent Ping to {}", addr);
+                trace!("Sent Ping to {}", addr);
             }
         }
         Err(e) => error!("Failed Ping to {}: {}", addr, e),
@@ -438,7 +438,7 @@ pub fn forward_ack(server: &Server, socket: &UdpSocket, addr: SocketAddr, swim: 
 
     match socket.send_to(&payload, addr) {
         Ok(_s) => {
-            info!(
+            trace!(
                 "Forwarded ack to {}@{}",
                 swim.get_ack().get_from().get_id(),
                 addr
@@ -494,7 +494,7 @@ pub fn ack(
 
     match socket.send_to(&payload, addr) {
         Ok(_s) => {
-            info!(
+            trace!(
                 "Sent ack to {}@{}",
                 swim.get_ack().get_from().get_id(),
                 addr

--- a/terraform/templates/hab-sup.service
+++ b/terraform/templates/hab-sup.service
@@ -2,7 +2,7 @@
 Description=Habitat Supervisor
 
 [Service]
-Environment=RUST_LOG=${log_level},habitat_butterfly=error
+Environment=RUST_LOG=${log_level}
 ExecStartPre=/bin/bash -c "/bin/systemctl set-environment SSL_CERT_FILE=$(hab pkg path core/cacerts)/ssl/cert.pem"
 ExecStart=/bin/hab run ${flags}
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -58,8 +58,8 @@ variable "release_channel" {
 }
 
 variable "log_level" {
-  description = "The RUST_LOG logging level for the builder services"
-  default     = "error"
+  description = "Logging level for the Habitat Supervisor"
+  default     = "info"
 }
 
 variable "gossip_listen_port" {


### PR DESCRIPTION
* Silence health check hooks for api/admin proxy
* Set default log level for Supervisor to info in Terraform
* Lower logging level in butterfly crate from info to trace/debug

![tenor-38080287](https://user-images.githubusercontent.com/54036/30527338-43afcbbc-9bdc-11e7-9c07-d5cc70dc92e3.gif)
