### PR TITLE
Updating CLI docs, export docs, and scheduler info

### DIFF
--- a/www/source/docs/container-orchestration-ecs.html.md
+++ b/www/source/docs/container-orchestration-ecs.html.md
@@ -35,3 +35,9 @@ Once Docker images are pushed to ECR, they may be run on Amazon's ECS within a [
 From the example, the ```mongo``` and ```national-parks``` services use the Docker images from the ECR. The ```links``` entry manages the deployment order of the container and according to the [Docker Compose documentation](https://docs.docker.com/engine/userguide/networking/default_network/dockerlinks/#/updating-the-etchosts-file) ```links``` should create ```/etc/hosts``` entries. This does not appear to currently work with ECS so we assign the ```hostname: "mongodb"```.
 
 The ```command``` entry for the National Parks Tomcat application allows the Habitat supervisor to ```--peer``` to the ```mongo``` gossip ring and ```--bind``` applies ```database``` entries to its Mongo configuration.
+
+## Additional Reading 
+
+* [Blog: A Journey with Habitat on Amazon ECS, Part 1](blog/2017/09/a-journey-with-habitat-on-amazon-ecs-part1/)
+* [Blog: A Journey with Habitat on Amazon ECS, Part 2](blog/2017/09/a-journey-with-habitat-on-amazon-ecs-part2/)
+* [Blog: A Journey with Habitat on Amazon ECS, Part 3](blog/2017/09/a-journey-with-habitat-on-amazon-ecs-part3/)

--- a/www/source/docs/container-orchestration-kubernetes.html.md
+++ b/www/source/docs/container-orchestration-kubernetes.html.md
@@ -2,11 +2,15 @@
 title: Kubernetes with Habitat
 ---
 
-[Kubernetes](http://kubernetes.io/) is an open source container cluster manager that is available as a stand-alone platform or embedded in several distributed platforms including [Google's Container Engine](https://cloud.google.com/container-engine/) and [Tectonic](https://tectonic.com/) by [CoreOS](https://coreos.com/). Habitat and Kubernetes are complementary, Kubernetes focuses on providing a platform for deployment, scaling, and operations of application containers across clusters of hosts while Habitat manages the creation and configuration of those application containers.
+[Kubernetes](http://kubernetes.io/) is an open source container cluster manager that is available as a stand-alone platform or embedded in several distributed platforms including [Google's Container Engine](https://cloud.google.com/container-engine/) and [Tectonic](https://tectonic.com/) by [CoreOS](https://coreos.com/). Habitat and Kubernetes are complementary: Kubernetes focuses on providing a platform for deployment, scaling, and operations of application containers across clusters of hosts while Habitat manages the creation and configuration of those application containers.
+
+## Habitat Kubernetes Operator 
+
+The [Habitat Kubernetes Operator](https://github.com/kinvolk/habitat-operator) is on-going work to create an operator that leverages Kubernetes API services to create a native and robust integration between the two technologies. Follow along on [github](https://github.com/kinvolk/habitat-operator), and join us in our #kubernetes channel in the [Habitat Slack Channel](https://slack.habitat.sh) for more information.
 
 ## Docker and ACI
 
-Habitat packages are supported in both Docker and ACI formats. Kubernetes currently supports the Docker runtime and integration of the rkt container runtime (an implementation of the App Container spec) is under active development.
+Habitat packages can be exported in both Docker and ACI formats (as well as others). Kubernetes currently supports the Docker runtime and integration of the rkt container runtime (an implementation of the App Container spec) is under active development.
 
 ## kubectl
 
@@ -25,3 +29,10 @@ Kubernetes supports passing [environment variables](http://kubernetes.io/docs/us
 ## Multi-container Pods
 
 Multi-container pod support through Habitat is still under active development. There may need to be a generated configuration file output from a CLI. Habitat's gossip protocol is on port 9638 and transmitted via UDP. It needs to be available by default to all of the containers in the pod.
+
+## Related Reading 
+
+* [In flight: Running a service group in kubernetes](https://github.com/habitat-sh/habitat/issues/2804)
+* [Habitat Kubernetes Operator](https://github.com/kinvolk/habitat-operator)
+* [Export a habitat package](/docs/run-packages-export)
+* [Habitat CLI](/docs/habitat-cli)

--- a/www/source/docs/reference/habitat-cli.html.md
+++ b/www/source/docs/reference/habitat-cli.html.md
@@ -577,7 +577,7 @@ Exports the package to the specified format
 
 **ARGS** 
 
-    <FORMAT>       The export format (ex: docker, aci, mesos, or tar)
+    <FORMAT>       The export format (docker, aci, mesos, or tar)
     <PKG_IDENT>    A package identifier (ex: core/redis, core/busybox-static/1.42.2)
 
 <h2 id="hab-pkg-hash" class="anchor">hab pkg hash</h2>
@@ -776,11 +776,16 @@ set will be used in the generated plan
 **OPTIONS** 
 
     -o, --origin <ORIGIN>              Origin for the new app
-    -s, --scaffolding <SCAFFOLDING>    Specify explicit scaffolding type for your app
+    -s, --scaffolding <SCAFFOLDING>    Specify explicit scaffolding type for your app (ruby, node, go)
 
 **ARGS** 
 
     <PKG_NAME>    Name for the new app
+
+**Scaffolding Options** 
+
+You can specify which scaffolding you want to use via the `hab plan init -s` command. 
+Current fully supported scaffoldings are accessed via the keyword `ruby`, `node`, or `go`.
 
 <h2 id="hab-ring-key" class="anchor">hab ring key</h2>
 Commands relating to Habitat ring keys

--- a/www/source/docs/run-packages-export.html.md
+++ b/www/source/docs/run-packages-export.html.md
@@ -5,7 +5,7 @@ title: Export a package
 # Export a package
 Packages can be exported into multiple external, immutable runtime formats. This topic will be updated as more formats are supported in the future. Currently there are exports for: docker, ACI, mesos, tar. 
 
-The command to export a package is `hab pkg export <FORMAT> <PKG_IDENT>`. [Habitat CLI Reference Guide](/docs/reference/habitat-cli/#hab-pkg-export/)
+The command to export a package is `hab pkg export <FORMAT> <PKG_IDENT>`. See the [Habitat CLI Reference Guide](/docs/reference/habitat-cli/#hab-pkg-export/) for more CLI information.
 
 Read on for more detailed instructions.
 
@@ -14,7 +14,9 @@ Read on for more detailed instructions.
 You can create a Docker container image for any package by performing the following steps:
 
 1. Ensure you have a Docker daemon running on your host system. The exporter shares the Docker socket (`unix:///var/run/docker.sock`) into the studio.
+
 2. Create an interactive studio with the `hab studio enter` command.
+
 3. Install or [build](/docs/create-packages-build) the Habitat package from which you want to create a Docker container image, for example:
 
        hab pkg install yourorigin/yourpackage
@@ -30,6 +32,7 @@ For an example of using Docker Compose to run multiple Habitat containers togeth
 ## Exporting to a tarball 
 
 1. Enter the habitat studio by using `hab studio enter`. 
+
 2. Install or [build](/docs/create-packages-build) the Habitat package from which you want to create a tarball, for example: 
 
         hab pkg install yourorigin/yourpackage 
@@ -58,6 +61,26 @@ You can create an Application Container Image (ACI) for any package by performin
        SIGN=true hab pkg export aci yourorigin/yourpackage
 
 5. The `.aci` can now be moved to any runtime capable of running ACIs (e.g. [rkt](https://coreos.com/rkt/) on CoreOS) for execution.
+
+##Exporting to Apache Mesos and DC/OS 
+
+1. Create an interactive studio in any directory with the `hab studio enter` command.
+
+2. Install or [build](/docs/create-packages-build) the Habitat package from which you want to create a Marathon application, for example: 
+
+        hab pkg install yourorigin/yourpackage 
+
+3. Run the Mesos exporter on the package. 
+
+        hab pkg export mesos yourorigin/yourpackage 
+
+4. This will create a Mesos container-format tarball in the results directory, and also print the JSON needed to load the application into Marathon. Note that the tarball needs to be uploaded to a download location and the "uris" in the JSON need to be updated manually. This is an example of the output:
+
+        { "id": "yourorigin/yourpackage", "cmd": "/bin/id -u hab &>/dev/null || /sbin/useradd hab; /bin/chown -R hab:hab *; mount -t proc proc proc/; mount -t sysfs sys sys/;mount -o bind /dev dev/; /usr/sbin/chroot . ./init.sh start yourorigin/yourpackage", "cpus": 0.5, "disk": 0, "mem": 256, "instances": 1, "uris": ["https://storage.googleapis.com/mesos-habitat/yourorigin/yourpackage-0.0.1-20160611121519.tgz" ] }
+
+5. Note that the default resource allocation for the application is very small: 0.5 units of CPU, no disk, one instance, and 256MB of memory. To change these resource allocations, pass different values to the Mesos exporter as command line options (defaults are documented with `--help`).
+
+6. See the article [Apaches Mesos and DC/OS](/docs/container-orchestration-mesos) for more information on getting your application running on Mesos. 
 
 <hr>
 <ul class="main-content--link-nav">


### PR DESCRIPTION
Signed-off-by: Tasha Drew <tasha.drew@gmail.com>

- Adds scaffolding options to cli docs (which will need to be updated as soon as jvm lands via @fnichol) 
- Adds mesos format to export docs 
- Adds kubernetes information to kubernetes info
- Adds references to kubernetes & ecs docs 
- Closes #3095 

