### PR TITLE
Minor improvements to Supervisor logging

### DIFF
--- a/components/sup/src/manager/service_updater.rs
+++ b/components/sup/src/manager/service_updater.rs
@@ -365,7 +365,7 @@ impl Worker {
                             Err(e) => warn!("Failed to install updated package: {:?}", e),
                         }
                     } else {
-                        info!("Package found is not newer than ours");
+                        debug!("Package found is not newer than ours");
                     }
                 }
                 Err(e) => warn!("Updater failed to get latest package: {:?}", e),


### PR DESCRIPTION
* Move `info` logging generated by a service to `outputln`
* Move `info` logging that shouldn't be outputln to `debug`

Signed-off-by: Jamie Winsor <jamie@vialstudios.com>