### PR TITLE
Add Join and Concat template helpers

### DIFF
--- a/components/sup/src/lib.rs
+++ b/components/sup/src/lib.rs
@@ -74,6 +74,8 @@ extern crate router;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;
+#[allow(unused_imports)]
+#[macro_use]
 extern crate serde_json;
 extern crate serde_yaml;
 extern crate tempdir;

--- a/components/sup/src/templating/helpers/mod.rs
+++ b/components/sup/src/templating/helpers/mod.rs
@@ -14,6 +14,8 @@
 
 mod each_alive;
 mod pkg_path_for;
+mod str_concat;
+mod str_join;
 mod str_replace;
 mod to_json;
 mod to_lowercase;
@@ -21,11 +23,14 @@ mod to_toml;
 mod to_uppercase;
 mod to_yaml;
 
+
 use serde::Serialize;
 use serde_json::{self, Value as Json};
 
 pub use self::each_alive::EACH_ALIVE;
 pub use self::pkg_path_for::PKG_PATH_FOR;
+pub use self::str_concat::STR_CONCAT;
+pub use self::str_join::STR_JOIN;
 pub use self::str_replace::STR_REPLACE;
 pub use self::to_json::TO_JSON;
 pub use self::to_lowercase::TO_LOWERCASE;

--- a/components/sup/src/templating/helpers/str_concat.rs
+++ b/components/sup/src/templating/helpers/str_concat.rs
@@ -1,0 +1,54 @@
+// Copyright (c) 2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use handlebars::{Handlebars, Helper, HelperDef, RenderContext};
+
+use super::super::RenderResult;
+
+#[derive(Clone, Copy)]
+pub struct StrConcatHelper;
+
+impl HelperDef for StrConcatHelper {
+    fn call(&self, h: &Helper, _: &Handlebars, rc: &mut RenderContext) -> RenderResult<()> {
+        let list: Vec<String> = h.params()
+            .iter()
+            .map(|v| v.value())
+            .filter(|v| !v.is_object())
+            .map(|v| v.to_string().replace("\"", ""))
+            .collect();
+
+        rc.writer.write(list.concat().into_bytes().as_ref())?;
+        Ok(())
+    }
+}
+
+pub static STR_CONCAT: StrConcatHelper = StrConcatHelper;
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_concat_helper() {
+        let mut handlebars = Handlebars::new();
+        handlebars.register_helper("strConcat", Box::new(STR_CONCAT));
+        let expected = "foobarbaz";
+        assert_eq!(
+            expected,
+            handlebars
+                .template_render("{{strConcat \"foo\" \"bar\" \"baz\"}}", &json!({}))
+                .unwrap()
+        );
+    }
+}

--- a/components/sup/src/templating/helpers/str_join.rs
+++ b/components/sup/src/templating/helpers/str_join.rs
@@ -1,0 +1,74 @@
+// Copyright (c) 2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use handlebars::{Handlebars, Helper, HelperDef, RenderContext, RenderError};
+
+use super::super::RenderResult;
+
+#[derive(Clone, Copy)]
+pub struct StrJoinHelper;
+
+impl HelperDef for StrJoinHelper {
+    fn call(&self, h: &Helper, _: &Handlebars, rc: &mut RenderContext) -> RenderResult<()> {
+        let list: Vec<String> = h.param(0)
+            .and_then(|v| v.value().as_array())
+            .ok_or_else(|| RenderError::new("Expected 2 parameters for \"strJoin\""))?
+            .iter()
+            .filter(|v| !v.is_object())
+            .map(|v| v.to_string().replace("\"", ""))
+            .collect();
+        let seperator = h.param(1).and_then(|v| v.value().as_str()).ok_or_else(|| {
+            RenderError::new("Expected 2 parameters for \"strJoin\"")
+        })?;
+
+        rc.writer.write(list.join(seperator).into_bytes().as_ref())?;
+        Ok(())
+    }
+}
+
+pub static STR_JOIN: StrJoinHelper = StrJoinHelper;
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_join_helper() {
+        let json = json!({
+            "list": ["foo", "bar", "baz"]
+        });
+        let mut handlebars = Handlebars::new();
+        handlebars.register_helper("strJoin", Box::new(STR_JOIN));
+        let expected = "foo,bar,baz";
+        assert_eq!(
+            expected,
+            handlebars.template_render("{{strJoin list \",\"}}", &json).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_join_helper_errors_on_objects() {
+        let json = json!({
+            "list": [{
+                "foo": "bar"
+            }]
+        });
+        let mut handlebars = Handlebars::new();
+        handlebars.register_helper("strJoin", Box::new(STR_JOIN));
+        assert_eq!(
+            "",
+            handlebars.template_render("{{strJoin list \",\"}}", &json).unwrap()
+        );
+    }
+}

--- a/components/sup/src/templating/mod.rs
+++ b/components/sup/src/templating/mod.rs
@@ -37,6 +37,8 @@ impl TemplateRenderer {
         let mut handlebars = Handlebars::new();
         handlebars.register_helper("eachAlive", Box::new(helpers::EACH_ALIVE));
         handlebars.register_helper("pkgPathFor", Box::new(helpers::PKG_PATH_FOR));
+        handlebars.register_helper("strConcat", Box::new(helpers::STR_CONCAT));
+        handlebars.register_helper("strJoin", Box::new(helpers::STR_JOIN));
         handlebars.register_helper("strReplace", Box::new(helpers::STR_REPLACE));
         handlebars.register_helper("toUppercase", Box::new(helpers::TO_UPPERCASE));
         handlebars.register_helper("toLowercase", Box::new(helpers::TO_LOWERCASE));


### PR DESCRIPTION
![tenor-6979218](https://user-images.githubusercontent.com/1130349/30528475-5c9cac66-9c6e-11e7-9fa2-da5003b5216b.gif)
Add ability to use `{{strConcat "foo" var "baz"}}` to get the result "foobarbaz"
Add ability to use `{{strJoin list ","}}` to get the result "one,two,three"

Signed-off-by: Elliott Davis <edavis@chef.io>