### PR TITLE
Fix breakage in origin create API

### DIFF
--- a/components/builder-depot/doc/api.raml
+++ b/components/builder-depot/doc/api.raml
@@ -25,6 +25,11 @@ schemas:
                 "owner_id": {
                     "type": "string",
                     "required": false
+                },
+                "default_package_visibility": {
+                    "type": "string",
+                    "enum": ["Public", "Private"],
+                    "required": false
                 }
             }
         }
@@ -51,7 +56,7 @@ schemas:
                     "type": "string",
                     "required": true
                 },
-                "onwer_id": {
+                "owner_id": {
                     "type": "string",
                     "required": true
                 }
@@ -88,7 +93,8 @@ securitySchemes:
                 schema: origin
                 example: |
                     {
-                        "name": "reset"
+                        "name": "reset",
+                        "default_package_visibility": "public"
                     }
         responses:
             200:
@@ -99,7 +105,8 @@ securitySchemes:
                             {
                                 "id": "77732030103691265",
                                 "name": "reset",
-                                "owner_id": "77730215748435968"
+                                "owner_id": "77730215748435968",
+                                "default_package_visibility": "public"
                             }
             409:
                 description: The origin already exists
@@ -115,6 +122,7 @@ securitySchemes:
                             "id": "77732030103691265",
                             "name": "reset",
                             "owner_id": "77730215748435968"
+                            "default_package_visibility": "public"
                         }
         /keys:
             get:

--- a/components/builder-depot/src/server.rs
+++ b/components/builder-depot/src/server.rs
@@ -58,7 +58,7 @@ define_event_log!();
 #[derive(Clone, Serialize, Deserialize)]
 struct OriginCreateReq {
     name: String,
-    default_package_visibility: String,
+    default_package_visibility: Option<String>,
 }
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -115,13 +115,13 @@ pub fn origin_create(req: &mut Request) -> IronResult<Response> {
 
     match req.get::<bodyparser::Struct<OriginCreateReq>>() {
         Ok(Some(body)) => {
-            let dpv = match body.default_package_visibility
-                .parse::<OriginPackageVisibility>() {
-                Ok(x) => x,
-                Err(_) => return Ok(Response::with(status::UnprocessableEntity)),
-            };
+            if let Some(vis) = body.default_package_visibility {
+                match vis.parse::<OriginPackageVisibility>() {
+                    Ok(vis) => request.set_default_package_visibility(vis),
+                    Err(_) => return Ok(Response::with(status::UnprocessableEntity)),
+                }
+            }
             request.set_name(body.name);
-            request.set_default_package_visibility(dpv);
         }
         _ => return Ok(Response::with(status::UnprocessableEntity)),
     }


### PR DESCRIPTION
* `default_package_visibility` was added but must be optional if we
  are to add this functionality to the `v1` api. This change will
  remove the requirement on the gateway while still preserving the
  default behaviour in the backend
* Updated API docs for depot to include `default_package_visibility`
  field