### PR TITLE
Document how to create a new bootstrap bundle

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -77,3 +77,30 @@ Draft a new Release, specify the tag, and title it with the same (eg, 0.18.0). T
    1. general (Habitat Slack)
    1. announcements (Habitat Slack)
 1. Tweet a link to the announcement @habitatsh
+
+## Update Builder Bootstrap Bundle
+
+For the time being, there is one final manual step, and that is to
+generate a new bootstrap bundle for Builder using the release you just
+created. (A bootstrap bundle is a tarball containing all the Habitat
+packages needed to stand up a complete instance of Builder, without
+needing to talk to another Builder in the process.)
+
+You should run this from a Linux system, since that is the platform
+that Builder itself runs on. It should also be run as `root`, since it
+is installing packages (but in a separate directory, so your existing
+`/hab` directory structure will remain unchanged). Furthermore, you
+should have appropriate AWS credentials in your environment in order
+to push files to the `habitat_builder_bootstrap` S3 bucket.
+
+Finally, you'll need to know what release you just created :)
+
+So, with all that in place, the generation and upload of the bundle is
+rather simple:
+
+```
+terraform/scripts/create_builder_bootstrap.sh 0.32.0
+```
+
+(Of course, substitute `0.32.0` above with whatever the real version
+number is.)

--- a/terraform/scripts/create_bootstrap_bundle.sh
+++ b/terraform/scripts/create_bootstrap_bundle.sh
@@ -61,16 +61,13 @@ hab=$(find_if_exists hab)
 shasum=$(find_if_exists shasum)
 sort=$(find_if_exists sort)
 
-# hab-launcher is versioned differently than the other packages
-# (monotonically increasing integer only). It also isn't going to
-# change much at all. This is the current version.
-#
-# TODO: Accept this as an optional argument?
-launcher_version=4435
-
 # The packages needed to run a Habitat Supervisor. These will be
 # installed on all machines.
-sup_packages=(core/hab-launcher/${launcher_version}
+#
+# hab-launcher is versioned differently than the other packages. It is
+# also changed and released relatively infrequently. We can just ask
+# the depot for the latest stable version of it.
+sup_packages=(core/hab-launcher
               core/hab/${hab_version}
               core/hab-sup/${hab_version}
               core/hab-butterfly/${hab_version})


### PR DESCRIPTION
Now more than one person can do it!

This also tweaks the creation script to always pull in the latest
stable `hab-launcher`. Previously, the version was hard-coded in the
script (because it changes relatively infrequently), but we can just
as the Depot for the latest stable version and achieve the same effect
while eliminating unnecessary script changes.

Signed-off-by: Christopher Maier <cmaier@chef.io>