### PR TITLE
Use build worker privilege for required depot APIs

### DIFF
--- a/components/builder-api/habitat/default.toml
+++ b/components/builder-api/habitat/default.toml
@@ -21,6 +21,5 @@ tutorials_url    = "https://www.habitat.sh/tutorials"
 www_url          = "https://www.habitat.sh"
 
 [depot]
-insecure = false
 builds_enabled = true
 events_enabled = false

--- a/components/builder-api/src/config.rs
+++ b/components/builder-api/src/config.rs
@@ -142,7 +142,6 @@ mod tests {
 
         [depot]
         path = "/hab/svc/hab-depot/data"
-        insecure = true
         builds_enabled = true
         events_enabled = true
         log_dir = "/hab/svc/hab-depot/var/log"

--- a/components/builder-depot/src/config.rs
+++ b/components/builder-depot/src/config.rs
@@ -33,8 +33,6 @@ pub struct Config {
     /// List of net addresses for routing servers to connect to
     pub routers: Vec<RouterAddr>,
     pub github: GitHubCfg,
-    /// Disable authenticated uploads for all entities
-    pub insecure: bool,
     /// Filepath to location on disk to store entities
     pub path: PathBuf,
     /// Whether to log events for funnel metrics
@@ -60,7 +58,6 @@ impl Default for Config {
             routers: vec![RouterAddr::default()],
             github: GitHubCfg::default(),
             path: PathBuf::from("/hab/svc/hab-depot/data"),
-            insecure: false,
             events_enabled: false, // TODO: change to default to true later
             builds_enabled: false,
             log_dir: PathBuf::from(env::temp_dir().to_string_lossy().into_owned()),
@@ -140,7 +137,6 @@ mod tests {
     fn config_from_file() {
         let content = r#"
         path = "/hab/svc/hab-depot/data"
-        insecure = true
         builds_enabled = true
         events_enabled = true
         log_dir = "/hab/svc/hab-depot/var/log"
@@ -170,7 +166,6 @@ mod tests {
 
         let config = Config::from_raw(&content).unwrap();
         assert_eq!(config.path, PathBuf::from("/hab/svc/hab-depot/data"));
-        assert_eq!(config.insecure, true);
         assert_eq!(config.builds_enabled, true);
         assert_eq!(config.events_enabled, true);
         assert_eq!(config.log_dir, PathBuf::from("/hab/svc/hab-depot/var/log"));


### PR DESCRIPTION
This change allows the build worker to make calls to upload, promote, and create channels for all origins. In addition, it cleans up the config to remove an 'insecure' flag that should not be used.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-94666039](https://user-images.githubusercontent.com/13542112/30601540-1b7b0422-9d17-11e7-8002-b4e9fb1d74d7.gif)
