### PR TITLE
Move incorrect warn statement to debug when try-loading a hook

### DIFF
--- a/components/sup/src/manager/service/hooks.rs
+++ b/components/sup/src/manager/service/hooks.rs
@@ -86,7 +86,7 @@ pub trait Hook: fmt::Debug + Sized {
                 Some(Self::new(service_group, pair))
             }
             Err(_) => {
-                warn!(
+                debug!(
                     "{} not found at {}, not loading",
                     Self::file_name(),
                     template.display()


### PR DESCRIPTION
Missed this one in the other modifications, oops!