### PR TITLE
Migrate Service Spec files using an older format

### DIFF
--- a/components/sup/src/manager/spec_watcher.rs
+++ b/components/sup/src/manager/spec_watcher.rs
@@ -267,6 +267,14 @@ impl SpecWatcher {
                 );
                 continue;
             }
+            // Migrate spec files using an older format
+            if let Err(err) = spec.to_file(&spec_file) {
+                outputln!(
+                    "Unable to migrate service spec, {}, {}",
+                    spec_file.display(),
+                    err
+                );
+            }
             specs.insert(spec.ident.name.clone(), spec);
         }
         Ok(specs)


### PR DESCRIPTION
This change will rewrite any loaded spec file from spec watcher which
will ensure that spec files are "migrated" between each Supervisor
release. Spec files are only written on `hab svc load`, so it is
important for us to migrate them as they enter the system on read
or they will never get updated.

@fnichol #3239 this one too :)