### PR TITLE
Update the Procfile to use new service names

### DIFF
--- a/support/Procfile
+++ b/support/Procfile
@@ -3,8 +3,8 @@ postgres: support/db/start.sh
 api: target/debug/bldr-api start --path /tmp/depot
 admin: target/debug/bldr-admin start
 router: target/debug/bldr-router start
-jobsrv: target/debug/bldr-job-srv start
+jobsrv: target/debug/bldr-jobsrv start
 scheduler: target/debug/bldr-scheduler start
-sessionsrv: target/debug/bldr-session-srv start
-originsrv: target/debug/bldr-origin-srv start
+sessionsrv: target/debug/bldr-sessionsrv start
+originsrv: target/debug/bldr-originsrv start
 worker: target/debug/bldr-worker start


### PR DESCRIPTION
It looks like some services' names were were changed recently. This fixes the Procfile to use the new ones.

Signed-off-by: Christian Nunciato <cnunciato@chef.io>

![](https://media.tenor.com/images/5ef8e11cd7b742c92e94069a4c20d1f2/tenor.gif)
