### PR TITLE
Add missing `depot/` prefix from channel package list in client

### DIFF
--- a/components/builder-depot-client/src/lib.rs
+++ b/components/builder-depot-client/src/lib.rs
@@ -857,7 +857,7 @@ where
     I: Identifiable,
 {
     format!(
-        "pkgs/{}/{}/{}/{}/channels",
+        "depot/pkgs/{}/{}/{}/{}/channels",
         package.origin(),
         package.name(),
         package.version().unwrap(),


### PR DESCRIPTION
I missed this one when I refactored yesterday :(

Signed-off-by: Jamie Winsor <jamie@vialstudios.com>