### PR TITLE
Add --force option to hab pkg binlink

### DIFF
--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -26,6 +26,10 @@ pub fn get() -> App<'static, 'static> {
         .about("Alias for 'config apply'")
         .aliases(&["ap", "app", "appl"])
         .setting(AppSettings::Hidden);
+    let alias_binlink = sub_pkg_binlink()
+        .about("Alias for 'pkg binlink'")
+        .aliases(&["b", "bi", "bin", "binl", "binli", "binlin"])
+        .setting(AppSettings::Hidden);
     let alias_install = sub_pkg_install()
         .about("Alias for 'pkg install'")
         .aliases(&["i", "in", "ins", "inst", "insta", "instal"])
@@ -172,16 +176,7 @@ pub fn get() -> App<'static, 'static> {
             (about: "Commands relating to Habitat packages")
             (aliases: &["p", "pk", "package"])
             (@setting ArgRequiredElseHelp)
-            (@subcommand binlink =>
-                (about: "Creates a symlink for a package binary in a common 'PATH' location")
-                (aliases: &["bi", "bin", "binl", "binli", "binlin"])
-                (@arg PKG_IDENT: +required +takes_value
-                    "A package identifier (ex: core/redis, core/busybox-static/1.42.2)")
-                (@arg BINARY: +takes_value
-                    "The command to symlink (ex: bash)")
-                (@arg DEST_DIR: -d --dest +takes_value
-                    "Sets the destination directory (default: /bin)")
-            )
+            (subcommand: sub_pkg_binlink())
             (@subcommand config =>
                 (about: "Displays the default configuration options for a service")
                 (aliases: &["conf", "cfg"])
@@ -435,6 +430,7 @@ pub fn get() -> App<'static, 'static> {
             )
         )
         (subcommand: alias_apply)
+        (subcommand: alias_binlink)
         (subcommand: alias_install)
         (subcommand: alias_run())
         (subcommand: alias_setup)
@@ -575,6 +571,24 @@ fn sub_pkg_build() -> App<'static, 'static> {
     } else {
         sub
     }
+}
+
+fn sub_pkg_binlink() -> App<'static, 'static> {
+    let sub = clap_app!(@subcommand binlink =>
+        (about: "Creates a symlink for a package binary in a common 'PATH' location")
+        (@arg PKG_IDENT: +required +takes_value
+            "A package identifier (ex: core/redis, core/busybox-static/1.42.2)")
+        (@arg BINARY: +takes_value
+            "The command to symlink (ex: bash)")
+        (@arg DEST_DIR: -d --dest +takes_value
+            "Sets the destination directory (default: /bin)")
+    );
+    sub.arg(
+        Arg::with_name("FORCE")
+            .help("Overwrites existing files")
+            .short("f")
+            .long("force"),
+    )
 }
 
 fn sub_pkg_install() -> App<'static, 'static> {

--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -26,10 +26,6 @@ pub fn get() -> App<'static, 'static> {
         .about("Alias for 'config apply'")
         .aliases(&["ap", "app", "appl"])
         .setting(AppSettings::Hidden);
-    let alias_binlink = sub_pkg_binlink()
-        .about("Alias for 'pkg binlink'")
-        .aliases(&["b", "bi", "bin", "binl", "binli", "binlin"])
-        .setting(AppSettings::Hidden);
     let alias_install = sub_pkg_install()
         .about("Alias for 'pkg install'")
         .aliases(&["i", "in", "ins", "inst", "insta", "instal"])
@@ -176,7 +172,17 @@ pub fn get() -> App<'static, 'static> {
             (about: "Commands relating to Habitat packages")
             (aliases: &["p", "pk", "package"])
             (@setting ArgRequiredElseHelp)
-            (subcommand: sub_pkg_binlink())
+            (@subcommand binlink =>
+                (about: "Creates a symlink for a package binary in a common 'PATH' location")
+                (aliases: &["bi", "bin", "binl", "binli", "binlin"])
+                (@arg PKG_IDENT: +required +takes_value
+                    "A package identifier (ex: core/redis, core/busybox-static/1.42.2)")
+                (@arg BINARY: +takes_value
+                    "The command to symlink (ex: bash)")
+                (@arg DEST_DIR: -d --dest +takes_value
+                    "Sets the destination directory (default: /bin)")
+                (@arg FORCE: -f --force "Overwrite existing symlinks")
+            )
             (@subcommand config =>
                 (about: "Displays the default configuration options for a service")
                 (aliases: &["conf", "cfg"])
@@ -430,7 +436,6 @@ pub fn get() -> App<'static, 'static> {
             )
         )
         (subcommand: alias_apply)
-        (subcommand: alias_binlink)
         (subcommand: alias_install)
         (subcommand: alias_run())
         (subcommand: alias_setup)
@@ -573,24 +578,6 @@ fn sub_pkg_build() -> App<'static, 'static> {
     }
 }
 
-fn sub_pkg_binlink() -> App<'static, 'static> {
-    let sub = clap_app!(@subcommand binlink =>
-        (about: "Creates a symlink for a package binary in a common 'PATH' location")
-        (@arg PKG_IDENT: +required +takes_value
-            "A package identifier (ex: core/redis, core/busybox-static/1.42.2)")
-        (@arg BINARY: +takes_value
-            "The command to symlink (ex: bash)")
-        (@arg DEST_DIR: -d --dest +takes_value
-            "Sets the destination directory (default: /bin)")
-    );
-    sub.arg(
-        Arg::with_name("FORCE")
-            .help("Overwrites existing files")
-            .short("f")
-            .long("force"),
-    )
-}
-
 fn sub_pkg_install() -> App<'static, 'static> {
     let sub = clap_app!(@subcommand install =>
         (about: "Installs a Habitat package from Builder or locally from a Habitat Artifact")
@@ -602,6 +589,7 @@ fn sub_pkg_install() -> App<'static, 'static> {
             "One or more Habitat package identifiers (ex: acme/redis) and/or filepaths \
             to a Habitat Artifact (ex: /home/acme-redis-3.0.7-21120102031201-x86_64-linux.hart)")
         (@arg BINLINK: -b --binlink "Binlink all binaries from installed package(s)")
+        (@arg FORCE: -f --force "When using binlink, overwrite existing symlinks")
     );
     sub.arg(
         Arg::with_name("IGNORE_TARGET")

--- a/components/hab/src/command/pkg/binlink.rs
+++ b/components/hab/src/command/pkg/binlink.rs
@@ -69,7 +69,7 @@ pub fn start(
                 ui.end(&ui_symlinked)?;
             } else if path != src {
                 ui.warn(
-                    format!("Skipping symlink because {} already exists at {}. Use -f to overwrite",
+                    format!("Skipping symlink because {} already exists at {}. Use --force to overwrite",
                 &binary,
                 &dst.display(),
                 ),

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -297,9 +297,12 @@ fn sub_pkg_binlink(ui: &mut UI, m: &ArgMatches) -> Result<()> {
     let ident = PackageIdent::from_str(m.value_of("PKG_IDENT").unwrap())?;
     let env_or_default = default_binlink_dir();
     let dest_dir = Path::new(m.value_of("DEST_DIR").unwrap_or(&env_or_default));
+    let force = m.is_present("FORCE");
     match m.value_of("BINARY") {
-        Some(binary) => command::pkg::binlink::start(ui, &ident, &binary, &dest_dir, &*FS_ROOT),
-        None => command::pkg::binlink::binlink_all_in_pkg(ui, &ident, dest_dir, &*FS_ROOT),
+        Some(binary) => {
+            command::pkg::binlink::start(ui, &ident, &binary, &dest_dir, &*FS_ROOT, force)
+        }
+        None => command::pkg::binlink::binlink_all_in_pkg(ui, &ident, &dest_dir, &*FS_ROOT, force),
     }
 }
 
@@ -462,7 +465,8 @@ fn sub_pkg_install(ui: &mut UI, m: &ArgMatches) -> Result<()> {
         if m.is_present("BINLINK") {
             let env_or_default = default_binlink_dir();
             let dest_dir = Path::new(m.value_of("DEST_DIR").unwrap_or(&env_or_default));
-            command::pkg::binlink::binlink_all_in_pkg(ui, &pkg_ident, dest_dir, &*FS_ROOT)?;
+            let force = m.is_present("FORCE");
+            command::pkg::binlink::binlink_all_in_pkg(ui, &pkg_ident, &dest_dir, &*FS_ROOT, force)?;
         }
     }
     Ok(())

--- a/components/pkg-export-docker/src/build.rs
+++ b/components/pkg-export-docker/src/build.rs
@@ -149,8 +149,9 @@ impl<'a> BuildSpec<'a> {
             &base_pkgs.busybox,
             &dst,
             rootfs.as_ref(),
+            true,
         )?;
-        hab::command::pkg::binlink::start(ui, &base_pkgs.hab, "hab", &dst, rootfs.as_ref())?;
+        hab::command::pkg::binlink::start(ui, &base_pkgs.hab, "hab", &dst, rootfs.as_ref(), true)?;
 
         Ok(())
     }


### PR DESCRIPTION
This PR adds additional safety to the `hab pkg binlink` command.

Currently when running `hab pkg binlink core/busybox-static` the command will automatically overwrite any existing files with their busybox-static counterparts. Overwriting is potentially dangerous, so we should skip overwriting those binaries, and tell the user to run the command again with `-f` to overwrite.

Signed-off-by: echohack <echohack@users.noreply.github.com>