### PR TITLE
Adding clarity to the fact a callback is a way to override a build phase

### DIFF
--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -253,9 +253,9 @@
 # * `$PREFIX`: Where to install the software; same as $pkg_prefix
 # * `$LD_RUN_PATH`: Where to find binaries at run time
 #
-# ## Plan Callbacks
+# ## Plan Callbacks (Build Phases)
 #
-# `hab-plan-build` allows you to alter its behavior by defining callbacks
+# `hab-plan-build` allows you to alter its behavior by defining callbacks (or build phases)
 # within the `plan.sh`. While `zlib` is awesome and requires no callbacks, most
 # software isn't quite so simple to build. To define a callback, simply create
 # a shell function with its name - then write out your script.

--- a/www/data/docs_sidebar.yml
+++ b/www/data/docs_sidebar.yml
@@ -98,7 +98,7 @@ sidebar_links:
     sub_links:
     - title: Basic settings
       link: "/docs/reference/basic-settings/"
-    - title: Callbacks
+    - title: Callbacks (Build Phases)
       link: "/docs/reference/callbacks/"
     - title: Build variables
       link: "/docs/reference/build-variables/"

--- a/www/source/about/habitat-and-modern-app.html.slim
+++ b/www/source/about/habitat-and-modern-app.html.slim
@@ -139,7 +139,7 @@ p The first three values form part of the package's fully qualified name. The
   value specifies how the ElasticSearch binary should be run when the supervisor
   starts the ElasticSearch package payload.
 
-p The callbacks override certain default behaviors such as compiling and
+p Build phases, referenced as callbacks, override certain default behaviors such as compiling and
   building binaries from source code and installing them into the package
   directory. Instead, because the ElasticSearch archive does not contain any
   source code to compile, the <code>do_build</code> callback has been

--- a/www/source/docs/create-plans.html.md.erb
+++ b/www/source/docs/create-plans.html.md.erb
@@ -81,7 +81,7 @@ The main steps in the buildtime workflow are the following:
 2. Add licensing and contact information.
 3. Download and unpack your source files.
 4. Define your dependencies.
-5. (Optional) Override any callbacks.
+5. (Optional) Override any build phases by using callbacks.
 
 The following sections describe each of these steps in more detail.
 

--- a/www/source/docs/reference/callbacks.html.md
+++ b/www/source/docs/reference/callbacks.html.md
@@ -3,7 +3,7 @@ title: Callbacks
 ---
 
 # Callbacks
-When defining your plan, can override default Habitat build phase behavior by using callbacks. To define a callback, simply create a shell function of the same name in your `plan.sh` file and then write your script. If you do not want to use the default callback behavior, you must override the callback and `return 0` in the function definition.
+When defining your plan, you can override default Habitat build phase behavior by using callbacks. To define a callback, simply create a shell function of the same name in your `plan.sh` file and then write your script. If you do not want to use the default callback behavior, you must override the callback and `return 0` in the function definition.
 
 You can also use <a href="/docs/reference/build-variables">build variables</a> in your plans to place binaries, libraries, and files into their correct locations during package compilation or when running as a service.
 

--- a/www/source/docs/reference/callbacks.html.md
+++ b/www/source/docs/reference/callbacks.html.md
@@ -3,7 +3,7 @@ title: Callbacks
 ---
 
 # Callbacks
-When defining your plan, you have the flexibility to override the default behavior of Habitat in each part of the package building stage through a series of callbacks. To define a callback, simply create a shell function of the same name in your `plan.sh` file and then write your script. If you do not want to use the default callback behavior, you must override the callback and `return 0` in the function definition.
+When defining your plan, can override default Habitat build phase behavior by using callbacks. To define a callback, simply create a shell function of the same name in your `plan.sh` file and then write your script. If you do not want to use the default callback behavior, you must override the callback and `return 0` in the function definition.
 
 You can also use <a href="/docs/reference/build-variables">build variables</a> in your plans to place binaries, libraries, and files into their correct locations during package compilation or when running as a service.
 

--- a/www/source/docs/reference/plan-syntax.html.md
+++ b/www/source/docs/reference/plan-syntax.html.md
@@ -9,8 +9,8 @@ When defining a plan, there are several different settings, variables, and funct
 This syntax guide is divided into six parts:
 
 - [Basic settings](/docs/reference/basic-settings): The top-level settings that define your package identifier, runtime dependencies, etc.
-- [Callbacks](/docs/reference/callbacks): Functions that can be overridden to customize how your application is built.
-- [Build variables](/docs/reference/build-variables): Useful variables that you can use in callbacks to help package your application or service.
-- [Application Lifecycle Hooks](/docs/reference/hooks): Lifecycle event handlers that are called during the Habitat service's runtime.
+- [Callbacks](/docs/reference/callbacks): Callbacks are functions that allow you to customize how your application is built by overriding build phases.
+- [Build variables](/docs/reference/build-variables): Variables that you can use in callbacks to help package your application or service.
+- [Hooks](/docs/reference/hooks): Hooks allow you to tell the Supervisor to respond to runtime life cycle events in a specific way. 
 - [Runtime settings](/docs/reference/runtime-settings): Settings that can be used in hooks to get information about the currently-running service including templatized configuration settings in `default.toml`.
 - [Utility functions](/docs/reference/utility-functions): Functions that are useful in debugging buildtime errors, building packages, and so on.

--- a/www/source/docs/reference/utility-functions.html.md
+++ b/www/source/docs/reference/utility-functions.html.md
@@ -3,7 +3,7 @@ title: Utility functions
 ---
 
 # Utility functions
-The following helper functions can be useful in your plan to help you build your package correctly. They are mostly used for debugging and building packages.
+The following helper functions can be useful in your plan to help you build your package correctly. `attach()` is used for debugging packages. The others are used for building packages.
 
 **attach()**
 : Attaches your script to an interactive debugging session, which lets you check the state of variables, call arbitrary functions, and turn on higher levels of logging by using the `set -x` command and switch.
@@ -49,7 +49,7 @@ download_file http://example.com/file.tar.gz file.tar.gz ohnoes...
 Will return 0 if a file was downloaded or if a valid cached file was found.
 
 **pkg\_path\_for()**
-: Returns the path for a build or runtime package dependency on stdout from the list of dependencies referenced in `pkg_deps` or `pkg_build_deps`. This is useful if you need to install or reference specific dependencies from within a callback, such as `do_build()` or `do_install()`.
+: Returns the path for a build or runtime package dependency on stdout from the list of dependencies referenced in `pkg_deps` or `pkg_build_deps`. This is useful if you need to install or reference specific dependencies during a build phase from within a callback, such as `do_build()` or `do_install()`.
 
   Here's an example of how to use this function to retrieve the path to the perl binary in the core/perl package:
 


### PR DESCRIPTION
The way our documentation is organized, the concepts of `hooks` and `callbacks` get conceptually munged together. This PR adds that a callback is a way to override a build phase to a bunch of docs and comments so there is more context for users to grasp. 

Signed-off-by: Tasha Drew <tasha.drew@gmail.com>