### PR TITLE
[core] Add `PackageInstall.is_runnable()` & use in Docker exporter.

### DIFF
--- a/components/core/src/package/install.rs
+++ b/components/core/src/package/install.rs
@@ -202,6 +202,19 @@ impl PackageInstall {
         }
     }
 
+    /// Determines whether or not this package has a runnable service.
+    pub fn is_runnable(&self) -> bool {
+        // Currently, a runnable package can be determined by checking if a `run` hook exists in
+        // package's hooks directory or directly in the package prefix.
+        if self.installed_path.join("hooks").join("run").is_file() ||
+            self.installed_path.join("run").is_file()
+        {
+            true
+        } else {
+            false
+        }
+    }
+
     pub fn binds(&self) -> Result<Vec<Bind>> {
         match self.read_metafile(MetaFile::Binds) {
             Ok(body) => {

--- a/components/pkg-export-docker/src/build.rs
+++ b/components/pkg-export-docker/src/build.rs
@@ -314,7 +314,7 @@ impl BuildRootContext {
                 PackageIdent::from_str(ident_or_archive)?
             };
             let pkg_install = PackageInstall::load(&ident, Some(&rootfs))?;
-            if pkg_install.installed_path.join("run").is_file() {
+            if pkg_install.is_runnable() {
                 idents.push(PkgIdentType::Svc(SvcIdent {
                     ident: ident,
                     exposes: pkg_install.exposes()?,


### PR DESCRIPTION
This change adds a method on `PackageInstall` called `is_runnable()`
which helps determine whether or not the package has a runnable service.
The current implementation uses the presence of a `run` hook file which
is the minimally-necessary contract for the Supervisor.

![tenor-250968068](https://user-images.githubusercontent.com/261548/30694586-96d49382-9f0f-11e7-9e3d-98eb2756c739.gif)
