### PR TITLE
Add config option for tuning HTTP handler thread count

### DIFF
--- a/components/builder-admin/src/config.rs
+++ b/components/builder-admin/src/config.rs
@@ -55,6 +55,10 @@ impl GitHubOAuth for Config {
 }
 
 impl GatewayCfg for Config {
+    fn handler_count(&self) -> usize {
+        self.http.handler_count
+    }
+
     fn listen_addr(&self) -> &IpAddr {
         &self.http.listen
     }
@@ -73,6 +77,7 @@ impl GatewayCfg for Config {
 pub struct HttpCfg {
     pub listen: IpAddr,
     pub port: u16,
+    pub handler_count: usize,
 }
 
 impl Default for HttpCfg {
@@ -80,6 +85,7 @@ impl Default for HttpCfg {
         HttpCfg {
             listen: IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
             port: 8080,
+            handler_count: Config::default_handler_count(),
         }
     }
 }

--- a/components/builder-api/src/config.rs
+++ b/components/builder-api/src/config.rs
@@ -81,6 +81,10 @@ impl GitHubOAuth for Config {
 }
 
 impl GatewayCfg for Config {
+    fn handler_count(&self) -> usize {
+        self.http.handler_count
+    }
+
     fn listen_addr(&self) -> &IpAddr {
         &self.http.listen
     }
@@ -100,6 +104,7 @@ impl GatewayCfg for Config {
 pub struct HttpCfg {
     pub listen: IpAddr,
     pub port: u16,
+    pub handler_count: usize,
 }
 
 impl Default for HttpCfg {
@@ -107,6 +112,7 @@ impl Default for HttpCfg {
         HttpCfg {
             listen: IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
             port: 9636,
+            handler_count: Config::default_handler_count(),
         }
     }
 }
@@ -142,6 +148,7 @@ mod tests {
         [http]
         listen = "0:0:0:0:0:0:0:1"
         port = 9636
+        handler_count = 128
 
         [ui]
         root = "/some/path"
@@ -175,6 +182,7 @@ mod tests {
         assert_eq!(config.non_core_builds_enabled, true);
         assert_eq!(&format!("{}", config.http.listen), "::1");
         assert_eq!(config.http.port, 9636);
+        assert_eq!(config.http.handler_count, 128);
         assert_eq!(&format!("{}", config.routers[0]), "172.18.0.2:9632");
         assert_eq!(config.github.url, "https://api.github.com");
         assert_eq!(config.github.client_id, "0c2f738a7d0bd300de10");

--- a/components/builder-http-gateway/src/config/mod.rs
+++ b/components/builder-http-gateway/src/config/mod.rs
@@ -17,20 +17,23 @@ pub mod prelude;
 use std::net::IpAddr;
 
 use hab_net::app::config::RouterAddr;
-
-// Iron defaults to a threadpool of size `8 * num_cpus`.
-// See: http://172.16.2.131:9633/iron/prelude/struct.Iron.html#method.http
-const HTTP_THREAD_COUNT: usize = 128;
+use num_cpus;
 
 pub trait GatewayCfg {
+    /// Default number of worker threads to simultaneously handle HTTP requests.
+    fn default_handler_count() -> usize {
+        num_cpus::get() * 8
+    }
+
+    /// Number of worker threads to simultaneously handle HTTP requests.
+    fn handler_count(&self) -> usize {
+        Self::default_handler_count()
+    }
+
     fn listen_addr(&self) -> &IpAddr;
 
     fn listen_port(&self) -> u16;
 
     /// Return a list of router addresses
     fn route_addrs(&self) -> &[RouterAddr];
-
-    fn handler_count(&self) -> usize {
-        HTTP_THREAD_COUNT
-    }
 }


### PR DESCRIPTION
Our front-end servers have been bumped up significantly in production which no longer requires the hard setting of 128. This number is actually lower than what we can now support!

* Add `http.handler_count` config option to API/Admin
* Add `handler_count()` to GatewayCfg
* Set default handler count to `num_cpu() * 8`. This is a sensible
  default for most occasions and can now be easily overidden