### PR TITLE
Bump RouteSrv TTL from 32s to 35s

### DIFF
--- a/components/builder-router/src/server/mod.rs
+++ b/components/builder-router/src/server/mod.rs
@@ -28,7 +28,7 @@ use config::Config;
 use conn::{ConnErr, ConnEvent, SrvConn};
 use error::{Error, Result};
 
-const SERVER_TTL: i64 = PING_INTERVAL_MS + 2_000;
+const SERVER_TTL: i64 = PING_INTERVAL_MS + 5_000;
 
 pub struct Server {
     /// Server's configuration.


### PR DESCRIPTION
This will give clients 3 seconds longer to heartbeat but will also
cause a registration to take 3 seconds longer to expire if a client
hard disconnects without sending a disconnect message

Signed-off-by: Jamie Winsor <jamie@vialstudios.com>