### PR TITLE
Adds footer link to status page

### DIFF
--- a/components/builder-api/habitat/config/habitat.conf.js
+++ b/components/builder-api/habitat/config/habitat.conf.js
@@ -12,4 +12,10 @@ habitatConfig({
     version: "{{pkg.ident}}",
     www_url: "{{cfg.web.www_url}}",
     status_url: "{{cfg.web.status_url}}",
+    forums_url: "{{cfg.web.forums_url}}",
+    events_url: "{{cfg.web.events_url}}",
+    roadmap_url: "{{cfg.web.roadmap_url}}",
+    feature_requests_url: "{{cfg.web.feature_requests_url}}",
+    slack_url: "{{cfg.web.slack_url}}",
+    youtube_url: "{{cfg.web.youtube_url}}",
 });

--- a/components/builder-api/habitat/config/habitat.conf.js
+++ b/components/builder-api/habitat/config/habitat.conf.js
@@ -11,4 +11,5 @@ habitatConfig({
     tutorials_url: "{{cfg.web.tutorials_url}}",
     version: "{{pkg.ident}}",
     www_url: "{{cfg.web.www_url}}",
+    status_url: "{{cfg.web.status_url}}",
 });

--- a/components/builder-api/habitat/default.toml
+++ b/components/builder-api/habitat/default.toml
@@ -11,15 +11,21 @@ client_id = ""
 client_secret = ""
 
 [web]
-app_url          = "https://bldr.habitat.sh"
-community_url    = "https://www.habitat.sh/community"
-docs_url         = "https://www.habitat.sh/docs"
-environment      = "production"
-friends_only     = false
-source_code_url  = "https://github.com/habitat-sh/habitat"
-tutorials_url    = "https://www.habitat.sh/tutorials"
-www_url          = "https://www.habitat.sh"
-status_url       = "https://status.habitat.sh/"
+app_url               = "https://bldr.habitat.sh"
+community_url         = "https://www.habitat.sh/community"
+docs_url              = "https://www.habitat.sh/docs"
+environment           = "production"
+friends_only          = false
+source_code_url       = "https://github.com/habitat-sh/habitat"
+tutorials_url         = "https://www.habitat.sh/tutorials"
+www_url               = "https://www.habitat.sh"
+status_url            = "https://status.habitat.sh/"
+forums_url            = "https://forums.habitat.sh/"
+events_url            = "https://events.chef.io/events/categories/habitat/"
+roadmap_url           = "https://ext.prodpad.com/ext/roadmap/d2938aed0d0ad1dd62669583e108357efd53b3a6"
+feature_requests_url  = "https://portal.prodpad.com/24539"
+slack_url             = "http://slack.habitat.sh/"
+youtube_url           = "https://www.youtube.com/playlist?list=PL11cZfNdwNyOxlvI1Kq6ae8eVBl5S3IKk"
 
 [depot]
 builds_enabled = true

--- a/components/builder-api/habitat/default.toml
+++ b/components/builder-api/habitat/default.toml
@@ -19,6 +19,7 @@ friends_only     = false
 source_code_url  = "https://github.com/habitat-sh/habitat"
 tutorials_url    = "https://www.habitat.sh/tutorials"
 www_url          = "https://www.habitat.sh"
+status_url       = "https://status.habitat.sh/"
 
 [depot]
 builds_enabled = true

--- a/components/builder-web/app/footer/FooterComponent.ts
+++ b/components/builder-web/app/footer/FooterComponent.ts
@@ -59,6 +59,7 @@ import config from "../config";
                     <li class="footer--sitemap--link"><a href="{{config['source_code_url']}}/issues">New Issues</a></li>
                     <li class="footer--sitemap--link"><a href="{{config['feature_requests_url']}}">Feature Request</a></li>
                     <li class="footer--sitemap--link"><a href="{{config['forums_url']}}">Forums</a></li>
+                    <li class="footer--sitemap--link"><a href="{{config['status_url']}}" target="_blank">Status</a></li>
                 </ul>
                 <ul class="no-bullet social">
                     <li><h4>Get in Touch</h4></li>

--- a/components/builder-web/habitat.conf.sample.js
+++ b/components/builder-web/habitat.conf.sample.js
@@ -35,6 +35,8 @@ habitatConfig({
     feature_requests_url: "https://portal.prodpad.com/24539",
     // The URL for forums
     forums_url: "https://forums.habitat.sh/",
+    // The URL for status
+    status_url: "https://status.habitat.sh/",
     // The version of the software we're running. In production, this should
     // be automatically populated by Habitat
     version: "",

--- a/www/source/layouts/_footer.slim
+++ b/www/source/layouts/_footer.slim
@@ -73,6 +73,8 @@ footer#main-footer class="#{layout_class}"
                 a href="https://portal.prodpad.com/24539" Feature Request
               li.footer--sitemap--link
                 a href="https://forums.habitat.sh/" Forums
+              li.footer--sitemap--link
+                a href="https://status.habitat.sh/" target="_blank" Status
 
           .columns.medium-2.small-6
             ul.no-bullet.social


### PR DESCRIPTION
Fixes #2823 
Adds a Status link in the footer (under Support) on both the website and web app.
