### PR TITLE
Schedule a registration retry OnError from RouteSrv

### DIFF
--- a/components/net/src/app/error.rs
+++ b/components/net/src/app/error.rs
@@ -19,7 +19,6 @@ use protocol;
 use zmq;
 
 use conn;
-use error::NetError;
 
 pub type AppResult<T, E> = Result<T, AppError<E>>;
 
@@ -37,8 +36,6 @@ where
     NoRouter,
     /// Wrapper for protocol serialization and deserialization errors.
     Protocol(protocol::ProtocolError),
-    /// RouteSrv asked application to terminate.
-    Terminated(NetError),
 }
 
 impl<T> fmt::Display for AppError<T>
@@ -51,7 +48,6 @@ where
             AppError::Init(ref e) => write!(f, "Application failed to initialize, {}", e),
             AppError::NoRouter => write!(f, "Failed to route request, no reachable RouteSrv"),
             AppError::Protocol(ref e) => write!(f, "{}", e),
-            AppError::Terminated(ref e) => write!(f, "received termination request, {}", e),
         }
     }
 }
@@ -66,7 +62,6 @@ where
             AppError::Init(_) => "Application failed to initialize.",
             AppError::NoRouter => "Failed to route request, no reachable RouteSrv.",
             AppError::Protocol(ref err) => err.description(),
-            AppError::Terminated(_) => "RouteSrv asked application to terminate.",
         }
     }
 }

--- a/components/net/src/conn/mod.rs
+++ b/components/net/src/conn/mod.rs
@@ -218,7 +218,7 @@ where
     route(socket, message)
 }
 
-pub fn send_to(socket: &zmq::Socket, message: &mut Message, dest: &[u8]) -> Result<(), ConnErr> {
+pub fn send_to(socket: &zmq::Socket, message: &Message, dest: &[u8]) -> Result<(), ConnErr> {
     socket.send(dest, zmq::SNDMORE)?;
     socket.send(&[], zmq::SNDMORE)?;
     send_header(socket, message)?;


### PR DESCRIPTION
The current behaviour is to shutdown a backend service connected
to RouteSrv if RouteSrv sends a registration conflict error. This
happens when you attempt to register to the RouteSrv and it rejects
your registration.

This change keeps the server running and replies to a REG_NOT_FOUND
with a registration message

Signed-off-by: Jamie Winsor <jamie@vialstudios.com>