### PR TITLE
Improve dead peer detection in RouteSrv and App

### DIFF
--- a/components/builder-http-gateway/src/app/mod.rs
+++ b/components/builder-http-gateway/src/app/mod.rs
@@ -102,7 +102,7 @@ pub mod prelude;
 use std::sync::Arc;
 use std::thread;
 
-use hab_net;
+use hab_net::socket;
 use iron;
 use iron::prelude::*;
 use mount::Mount;
@@ -164,6 +164,6 @@ where
         cfg.listen_port()
     );
     info!("{} is ready to go.", T::APP_NAME);
-    RouteBroker::start(hab_net::socket::srv_ident(), cfg.route_addrs())?;
+    RouteBroker::start(socket::srv_ident(), cfg.route_addrs())?;
     Ok(())
 }

--- a/components/builder-protocol/src/message/mod.rs
+++ b/components/builder-protocol/src/message/mod.rs
@@ -187,6 +187,18 @@ impl Message {
         self.header.message_id()
     }
 
+    /// Returns the identity of the socket which initially generated this message. Nothing is
+    /// returned if the message was not received from a socket thus having no originator.
+    pub fn originator(&self) -> Option<&[u8]> {
+        self.identities.first().map(Vec::as_slice)
+    }
+
+    /// Same as `originator()` but returns a lossy utf8 representation of the originators's
+    /// identity.
+    pub fn originator_str(&self) -> Option<Cow<str>> {
+        self.originator().map(String::from_utf8_lossy)
+    }
+
     pub fn parse<T>(&self) -> Result<T, ProtocolError>
     where
         T: protobuf::MessageStatic,
@@ -206,10 +218,13 @@ impl Message {
         self.txn.as_mut()
     }
 
+    /// Returns the identity of the socket which sent this message. Nothing is returned if the
+    /// message was not received from a socket thus having no sender.
     pub fn sender(&self) -> Option<&[u8]> {
-        self.identities.first().map(Vec::as_slice)
+        self.identities.last().map(Vec::as_slice)
     }
 
+    /// Same as `sender()` but returns a lossy utf8 representation of the sender's identity.
     pub fn sender_str(&self) -> Option<Cow<str>> {
         self.sender().map(String::from_utf8_lossy)
     }

--- a/components/builder-router/src/conn.rs
+++ b/components/builder-router/src/conn.rs
@@ -13,11 +13,10 @@
 // limitations under the License.
 
 pub use hab_net::conn::{route, route_reply, wait_recv, ConnErr, ConnEvent};
+use hab_net::socket;
 use protobuf;
 use protocol::Message;
 use zmq;
-
-use config::Config;
 
 pub struct SrvConn {
     socket: zmq::Socket,
@@ -25,11 +24,11 @@ pub struct SrvConn {
 }
 
 impl SrvConn {
-    pub fn new(context: &mut zmq::Context, cfg: &Config) -> Result<Self, ConnErr> {
+    pub fn new(context: &mut zmq::Context) -> Result<Self, ConnErr> {
         let socket = context.socket(zmq::ROUTER)?;
         socket.set_router_mandatory(true)?;
         socket.set_probe_router(true)?;
-        socket.set_identity(cfg.addr().as_bytes())?;
+        socket.set_identity(socket::srv_ident().as_bytes())?;
         Ok(SrvConn {
             socket: socket,
             recv_buf: zmq::Message::new()?,

--- a/components/builder-router/src/server/mod.rs
+++ b/components/builder-router/src/server/mod.rs
@@ -106,7 +106,7 @@ impl Server {
 
     /// Run the server blocking the calling thread until the server shuts down.
     fn run(&mut self) -> Result<()> {
-        let mut conn = SrvConn::new(&mut self.context, &self.config)?;
+        let mut conn = SrvConn::new(&mut self.context)?;
         let mut message = Message::default();
         conn.bind(&self.config.addr())?;
         println!("Listening on ({})", self.config.addr());


### PR DESCRIPTION
* Add Router to active router's table in `App` on-connect instead
  of when the App is started. This will ensure the connection is
  complete before attempting to route messages to a Router which
  we have not completed a connection to
* Remove Router/App if we attempt to route and receive a
  HostUnreachable error
* Turned on zmq socket option "router_mandatory" on both sides of
  the App->RouteSrv connection to ensure we receive a HostUnreachable
  error on send failure
* Identify Router socket with socket::srv_ident

Signed-off-by: Jamie Winsor <jamie@vialstudios.com>