### PR TITLE
Remove old static content before copying new in builder-api init hook

### DIFF
--- a/components/builder-api/habitat/hooks/init
+++ b/components/builder-api/habitat/hooks/init
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -e
 
+rm -Rdf {{pkg.svc_static_path}}/*
 cp -a {{pkg.path}}/static/* {{pkg.svc_static_path}}
-rm -f {{pkg.svc_static_path}}/habitat.conf.js
 ln -sf {{pkg.svc_config_path}}/habitat.conf.js {{pkg.svc_static_path}}/habitat.conf.js


### PR DESCRIPTION
The addition of the `set -e` flag in all init hooks has proven to be
immediately useful! We weren't successfully copying all static data
and were leaving old files between each upgrade. This change will
purge the static content directory before copying new content and
symlinking the web client's config

Signed-off-by: Jamie Winsor <jamie@vialstudios.com>