### PR TITLE
Fix race condition in loading/unloading services

### DIFF
--- a/components/core/src/package/install.rs
+++ b/components/core/src/package/install.rs
@@ -360,10 +360,8 @@ impl PackageInstall {
         match self.read_metafile(MetaFile::Path) {
             Ok(body) => {
                 let v = env::split_paths(&body)
-                    .map(|p| {
-                        self.fs_root_path.join(PathBuf::from(
-                            &p.strip_prefix("/").unwrap(),
-                        ))
+                    .filter_map(|p| {
+                        p.strip_prefix("/").ok().map(|p| self.fs_root_path.join(p))
                     })
                     .collect();
                 Ok(v)


### PR DESCRIPTION
Move spec migration to Manager load before SpecWatcher is started
to reduce IO calls for reading/writing spec files. This appears to
fix an issue with loading and unloading services if the Supervisor
is running

![tenor-122895371](https://user-images.githubusercontent.com/54036/30788039-73ff1232-a14a-11e7-9409-c88b7750ec94.gif)
