### PR TITLE
Revert #3232 & related fix in #3306

### DIFF
--- a/components/core/src/fs.rs
+++ b/components/core/src/fs.rs
@@ -271,14 +271,23 @@ where
 /// # Failures
 ///
 /// * The path entries metadata cannot be loaded
-pub fn find_command_in_pkg<T>(command: T, pkg_install: &PackageInstall) -> Result<Option<PathBuf>>
+pub fn find_command_in_pkg<T, U>(
+    command: T,
+    pkg_install: &PackageInstall,
+    fs_root_path: U,
+) -> Result<Option<PathBuf>>
 where
     T: AsRef<Path>,
+    U: AsRef<Path>,
 {
     for path in pkg_install.paths()? {
-        let candidate = path.join(command.as_ref());
+        let stripped = path.strip_prefix("/").expect(&format!(
+            "Package path missing / prefix {}",
+            path.to_string_lossy()
+        ));
+        let candidate = fs_root_path.as_ref().join(stripped).join(command.as_ref());
         if candidate.is_file() {
-            return Ok(Some(candidate));
+            return Ok(Some(path.join(command.as_ref())));
         } else {
             match find_command_with_pathext(&candidate) {
                 Some(result) => return Ok(Some(result)),

--- a/components/core/src/os/net/windows.rs
+++ b/components/core/src/os/net/windows.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::env;
 use std::io;
 
 use kernel32;

--- a/components/core/src/package/install.rs
+++ b/components/core/src/package/install.rs
@@ -360,8 +360,10 @@ impl PackageInstall {
         match self.read_metafile(MetaFile::Path) {
             Ok(body) => {
                 let v = env::split_paths(&body)
-                    .filter_map(|p| {
-                        p.strip_prefix("/").ok().map(|p| self.fs_root_path.join(p))
+                    .map(|p| {
+                        self.fs_root_path.join(PathBuf::from(
+                            &p.strip_prefix("/").unwrap(),
+                        ))
                     })
                     .collect();
                 Ok(v)

--- a/components/core/src/package/install.rs
+++ b/components/core/src/package/install.rs
@@ -359,13 +359,7 @@ impl PackageInstall {
     pub fn paths(&self) -> Result<Vec<PathBuf>> {
         match self.read_metafile(MetaFile::Path) {
             Ok(body) => {
-                let v = env::split_paths(&body)
-                    .map(|p| {
-                        self.fs_root_path.join(PathBuf::from(
-                            &p.strip_prefix("/").unwrap(),
-                        ))
-                    })
-                    .collect();
+                let v = env::split_paths(&body).map(|p| PathBuf::from(&p)).collect();
                 Ok(v)
             }
             Err(Error::MetaFileNotFound(MetaFile::Path)) => {

--- a/components/hab/src/command/pkg/binlink.rs
+++ b/components/hab/src/command/pkg/binlink.rs
@@ -38,7 +38,7 @@ pub fn start(
         dst_path.display()
     ))?;
     let pkg_install = PackageInstall::load(&ident, Some(fs_root_path))?;
-    let src = match hfs::find_command_in_pkg(binary, &pkg_install)? {
+    let src = match hfs::find_command_in_pkg(binary, &pkg_install, fs_root_path)? {
         Some(c) => c,
         None => {
             return Err(Error::CommandNotFoundInPkg(
@@ -79,7 +79,7 @@ pub fn binlink_all_in_pkg(
 ) -> Result<()> {
     let pkg_path = PackageInstall::load(&pkg_ident, Some(fs_root_path))?;
     for bin_path in pkg_path.paths()? {
-        for bin in fs::read_dir(bin_path)? {
+        for bin in fs::read_dir(fs_root_path.join(bin_path.strip_prefix("/")?))? {
             let bin_file = bin?;
             let bin_name = match bin_file.file_name().to_str() {
                 Some(bn) => bn.to_owned(),
@@ -120,7 +120,7 @@ mod test {
         let ident = fake_bin_pkg_install("acme/cooltools", tools, rootfs.path());
         let dst_path = Path::new("/opt/bin");
 
-        let rootfs_src_dir = hcore::fs::pkg_install_path(&ident, Some(rootfs.path())).join("bin");
+        let rootfs_src_dir = hcore::fs::pkg_install_path(&ident, None::<&Path>).join("bin");
         let rootfs_bin_dir = rootfs.path().join("opt/bin");
 
         let (mut ui, _stdout, _stderr) = ui();
@@ -146,7 +146,7 @@ mod test {
         let ident = fake_bin_pkg_install("acme/securetools", tools, rootfs.path());
         let dst_path = Path::new("/opt/bin");
 
-        let rootfs_src_dir = hcore::fs::pkg_install_path(&ident, Some(rootfs.path()));
+        let rootfs_src_dir = hcore::fs::pkg_install_path(&ident, None::<&Path>);
         let rootfs_bin_dir = rootfs.path().join("opt/bin");
 
         let (mut ui, _stdout, _stderr) = ui();

--- a/components/hab/src/command/pkg/exec.rs
+++ b/components/hab/src/command/pkg/exec.rs
@@ -18,7 +18,7 @@ use std::path::PathBuf;
 
 use hcore::os::process;
 use hcore::package::{PackageIdent, PackageInstall};
-use hcore::fs::{find_command, FS_ROOT_PATH};
+use hcore::fs::find_command;
 
 use error::{Error, Result};
 
@@ -27,7 +27,7 @@ where
     T: Into<PathBuf>,
 {
     let command = command.into();
-    let pkg_install = PackageInstall::load(&ident, Some(&*FS_ROOT_PATH))?;
+    let pkg_install = PackageInstall::load(&ident, None)?;
     let run_env = pkg_install.runtime_environment()?;
     for (key, value) in run_env.into_iter() {
         debug!("Setting: {}='{}'", key, value);

--- a/components/hab/src/exec.rs
+++ b/components/hab/src/exec.rs
@@ -17,7 +17,7 @@ use std::path::{Path, PathBuf};
 use common;
 use common::ui::{Status, UI};
 use hcore;
-use hcore::fs::{self, cache_artifact_path, FS_ROOT_PATH};
+use hcore::fs::{self, cache_artifact_path};
 use hcore::package::{PackageIdent, PackageInstall};
 use hcore::url::default_bldr_url;
 
@@ -53,9 +53,10 @@ where
         return Err(Error::ExecCommandNotFound(command));
     }
 
+    let fs_root_path = Path::new("/");
     match PackageInstall::load_at_least(ident, None) {
         Ok(pi) => {
-            match fs::find_command_in_pkg(&command, &pi)? {
+            match fs::find_command_in_pkg(&command, &pi, fs_root_path)? {
                 Some(cmd) => Ok(cmd),
                 None => Err(Error::ExecCommandNotFound(command)),
             }
@@ -72,7 +73,7 @@ where
                 &ident.to_string(),
                 PRODUCT,
                 VERSION,
-                &*FS_ROOT_PATH,
+                fs_root_path,
                 &cache_artifact_path(None::<String>),
                 false,
             )?;

--- a/components/launcher/src/server/mod.rs
+++ b/components/launcher/src/server/mod.rs
@@ -340,7 +340,7 @@ fn supervisor_cmd() -> Result<PathBuf> {
     let ident = PackageIdent::from_str(SUP_PACKAGE_IDENT).unwrap();
     match PackageInstall::load_at_least(&ident, None) {
         Ok(install) => {
-            match core::fs::find_command_in_pkg(SUP_CMD, &install) {
+            match core::fs::find_command_in_pkg(SUP_CMD, &install, "/") {
                 Ok(Some(cmd)) => Ok(cmd),
                 _ => Err(Error::SupBinaryNotFound),
             }

--- a/components/pkg-export-docker/src/build.rs
+++ b/components/pkg-export-docker/src/build.rs
@@ -586,18 +586,17 @@ mod test {
                 .unwrap();
 
             assert_eq!(
-                hcore::fs::pkg_install_path(&base_pkgs.busybox, Some(rootfs.path()))
-                    .join("bin/busybox"),
+                hcore::fs::pkg_install_path(&base_pkgs.busybox, None::<&Path>).join("bin/busybox"),
                 rootfs.path().join("bin/busybox").read_link().unwrap(),
                 "busybox program is symlinked into /bin"
             );
             assert_eq!(
-                hcore::fs::pkg_install_path(&base_pkgs.busybox, Some(rootfs.path())).join("bin/sh"),
+                hcore::fs::pkg_install_path(&base_pkgs.busybox, None::<&Path>).join("bin/sh"),
                 rootfs.path().join("bin/sh").read_link().unwrap(),
                 "busybox's sh program is symlinked into /bin"
             );
             assert_eq!(
-                hcore::fs::pkg_install_path(&base_pkgs.hab, Some(rootfs.path())).join("bin/hab"),
+                hcore::fs::pkg_install_path(&base_pkgs.hab, None::<&Path>).join("bin/hab"),
                 rootfs.path().join("bin/hab").read_link().unwrap(),
                 "hab program is symlinked into /bin"
             );


### PR DESCRIPTION
This reverts the logic changes in #3232 and also #3306 as it started to fix a separate issue introduced in #3232.

The binlinking logic depends on correct behavior when operating with an alternate filesystem root such as when creating a Studio instance, creating a rootfs for a Docker image, etc. In this case, updating the failing tests invalidated their assertions of correctness which is why the test suites passed. More follow up afterwards, but we should be able to rework #3232 to get the correct behavior all around.