### PR TITLE
Add nginx status and logging for builder API

### DIFF
--- a/components/builder-api-proxy/config/nginx.conf
+++ b/components/builder-api-proxy/config/nginx.conf
@@ -56,6 +56,10 @@ http {
   proxy_cache_path {{pkg.svc_var_path}}/cache levels=1:2 keys_zone=my_cache:10m max_size=10g inactive=60m use_temp_path=off;
   proxy_cache_key "$scheme$proxy_host$uri$is_args$args $http_user_agent";
 
+  log_format nginx '\$remote_addr - \$remote_user [\$time_local] '
+                   '"\$request" \$status \$body_bytes_sent \$request_time '
+                   '"\$http_referer" "\$http_user_agent"';
+
   upstream backend {
     server 127.0.0.1:{{bind.http.first.cfg.port}};
   }
@@ -70,9 +74,19 @@ http {
       rewrite ^(.*)$ https://$host$1 permanent;
     }
 
+    access_log {{pkg.svc_path}}/logs/host.access.log nginx;
+
     location = /health {
       return 200;
       access_log off;
+    }
+
+    location /nginx_status {
+        stub_status on;
+
+        access_log off;
+        allow 127.0.0.1;
+        deny all;
     }
 
     location ~* ^/favicon.ico/ {


### PR DESCRIPTION
Update the nginx configuration for builder API to add an internal status endpoint, along with custom nginx call logging.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-209923620](https://user-images.githubusercontent.com/13542112/30831551-ad78d6f8-a1fc-11e7-85ec-fa66a1780de9.gif)
