### PR TITLE
Fix Terraform resource churn on API instances

### DIFF
--- a/terraform/instances.tf
+++ b/terraform/instances.tf
@@ -23,12 +23,6 @@ resource "aws_instance" "api" {
     agent       = "${var.connection_agent}"
   }
 
-  ebs_block_device {
-    device_name = "/dev/xvdf"
-    volume_size = 1500
-    volume_type = "gp2"
-  }
-
   provisioner "file" {
     source = "${path.module}/scripts/install_base_packages.sh"
     destination = "/tmp/install_base_packages.sh"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -111,3 +111,7 @@ variable "instance_size_api" {
 variable "instance_size_worker" {
   description = "AWS instance size for builder-worker server(s)"
 }
+
+variable "api_ebs_volume_id" {
+  description = "ID for EBS volume to attach to the API server"
+}

--- a/terraform/volumes.tf
+++ b/terraform/volumes.tf
@@ -1,0 +1,5 @@
+resource "aws_volume_attachment" "api" {
+  device_name = "/dev/xvdf"
+  volume_id   = "${var.api_ebs_volume_id}"
+  instance_id = "${aws_instance.api.id}"
+}


### PR DESCRIPTION
Move EBS volume definition to a separate volume block. For the time
being we will specify this volume manually with an ID into a
variable. This isn't a long term solution, eventually we will move
the package data to an S3 bucket and not need this volume anymore.
For now, let's prevent future resource churn which occurs when we
manually mount volumes to our API instances