### PR TITLE
Remove build job API - use scheduler API instead

### DIFF
--- a/components/builder-api/src/server/mod.rs
+++ b/components/builder-api/src/server/mod.rs
@@ -64,7 +64,6 @@ impl HttpGateway for ApiSrv {
             status: get "/status" => status,
             authenticate: get "/authenticate/:code" => github_authenticate,
 
-            jobs: post "/jobs" => XHandler::new(job_create).before(basic.clone()),
             job: get "/jobs/:id" => XHandler::new(job_show).before(opt.clone()),
             job_log: get "/jobs/:id/log" => job_log,
             job_group_promote: post "/jobs/group/:id/promote/:channel" => {


### PR DESCRIPTION
This change removes the build job API, and routes the hab cli 'job start' build requests through the scheduler API instead.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-28942881](https://user-images.githubusercontent.com/13542112/30838331-bad4c58c-a21f-11e7-941c-5505f99c4fee.gif)
