### PR TITLE
[hab] Add default `pkg_version` when using `hab plan init`.

### DIFF
--- a/components/hab/src/command/plan/init.rs
+++ b/components/hab/src/command/plan/init.rs
@@ -42,6 +42,8 @@ const GITIGNORE_TEMPLATE: &'static str = include_str!(concat!(
     "/static/template_gitignore"
 ));
 
+const DEFAULT_PKG_VERSION: &'static str = "0.1.0";
+
 pub fn start(
     ui: &mut UI,
     origin: String,
@@ -78,6 +80,7 @@ pub fn start(
     let mut data = HashMap::new();
     data.insert("pkg_name".to_string(), name);
     data.insert("pkg_origin".to_string(), origin);
+    data.insert("pkg_version".to_string(), DEFAULT_PKG_VERSION.to_string());
 
     let scaffold = match scaffolding_ident {
         Some(ident) => Some(data.insert(


### PR DESCRIPTION
This change adds a default `pkg_version` of `"0.1.0"` which allows the
build program to build a package without further additions. Without this
value (which is required) the build program fails with an error message.

![tenor-235605855](https://user-images.githubusercontent.com/261548/30843770-a08f0394-a248-11e7-81fb-0e78f26a2b2f.gif)
