### PR TITLE
[studio/docker] Drop `-ti` from Docker command when calling `hab pkg build`.

### DIFF
--- a/components/hab/src/command/studio/docker.rs
+++ b/components/hab/src/command/studio/docker.rs
@@ -183,13 +183,14 @@ where
     S: AsRef<OsStr>,
     T: AsRef<str>,
 {
-    let mut cmd_args: Vec<OsString> = vec![
-        "run".into(),
-        "--rm".into(),
-        "--tty".into(),
-        "--interactive".into(),
-        "--privileged".into(),
-    ];
+    let mut cmd_args: Vec<OsString> = vec!["run".into(), "--rm".into(), "--privileged".into()];
+    match args.first().map(|f| f.to_str().unwrap_or_default()) {
+        Some("build") => {}
+        _ => {
+            cmd_args.push("--tty".into());
+            cmd_args.push("--interactive".into());
+        }
+    }
     if let Ok(opts) = henv::var(DOCKER_OPTS_ENVVAR) {
         let opts = opts.split(" ")
                 .map(|v| v.into())


### PR DESCRIPTION
This change changes the `docker run` arguments only when invoking the
`hab pkg build` subcommand. Specifically, the `--tty` and
`--interactive` flags are omitted for `build` but present for all other
`hab studio` invocations. This should help when `build` is called
non-interactively, such as in CI environments.

Closes #3325

![tenor-143165879](https://user-images.githubusercontent.com/261548/30848466-730cec10-a25c-11e7-9112-5473d018b050.gif)
