### PR TITLE
Ignore all `results/` directories in `.gitignore`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ terraform.tfstate*
 .delivery/cli.toml
 .tags*
 log/
-components/*/results
+results/
 tmp/
 .vagrant/
 *.sig.key


### PR DESCRIPTION
The previous behavior only ignored directories under `components/`,
however all buildable projects must be entered from the root of the Git
project (or a higher parent directory).

![tenor-124926808](https://user-images.githubusercontent.com/261548/30848919-dba15ba2-a25d-11e7-893b-d5980d31455a.gif)
