### PR TITLE
Strip quotes from package name when creating project

### DIFF
--- a/components/builder-api/src/server/handlers.rs
+++ b/components/builder-api/src/server/handlers.rs
@@ -360,7 +360,7 @@ pub fn project_create(req: &mut Request) -> IronResult<Response> {
                         Ok(plan) => {
                             project.set_origin_name(String::from(origin.get_name()));
                             project.set_origin_id(origin.get_id());
-                            project.set_package_name(String::from(plan.name));
+                            project.set_package_name(String::from(plan.name.trim_matches('"')));
                         }
                         Err(e) => {
                             debug!("Error matching Plan. e = {:?}", e);


### PR DESCRIPTION
When we create a project, we pull the package name from the github repo. If the package name has quotes around it (which is permissible), they can end up incorrectly added to the origin package data in the DB. This change strips quotes from the plan name upon ingestion.  There are only a couple of projects in this state, so migration / cleanup will be a separate (likely ad-hoc) step.

Fixes https://github.com/habitat-sh/habitat/issues/3236

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-147270229](https://user-images.githubusercontent.com/13542112/30882027-9734aeb0-a2bc-11e7-9d1f-57e65d808518.gif)
