### PR TITLE
Fix origins errors

### DIFF
--- a/components/builder-web/app/origin/origins-page/origins-page.component.html
+++ b/components/builder-web/app/origin/origins-page/origins-page.component.html
@@ -6,7 +6,7 @@
     <div class="origin-create">
       <a md-raised-button color="primary" [routerLink]="['/origins', 'create']">Create origin</a>
     </div>
-    <div *ngIf="ui.loading">&nbsp;</div>
+    <hab-icon symbol="loading" class="spinning" *ngIf="ui.loading"></hab-icon>
     <div *ngIf="!ui.loading">
       <p *ngIf="ui.errorMessage">
         Failed to load origins: {{ui.errorMessage}}

--- a/components/builder-web/app/origin/origins-page/origins-page.component.ts
+++ b/components/builder-web/app/origin/origins-page/origins-page.component.ts
@@ -58,12 +58,12 @@ export class OriginsPageComponent implements OnInit {
     }
 
     ngOnInit() {
-        this.store.dispatch(fetchMyOrigins(
-            this.store.getState().gitHub.authToken
-        ));
-        this.store.dispatch(fetchMyOriginInvitations(
-            this.store.getState().gitHub.authToken
-        ));
+        const token = this.store.getState().gitHub.authToken;
+
+        if (token) {
+            this.store.dispatch(fetchMyOrigins(token));
+            this.store.dispatch(fetchMyOriginInvitations(token));
+        }
     }
 
     routeToOrigin(origin) {

--- a/components/builder-web/app/reducers/feature-flags.ts
+++ b/components/builder-web/app/reducers/feature-flags.ts
@@ -17,12 +17,13 @@ import initialState from "../initialState";
 import { Map } from "immutable";
 
 export default function featureFlags(state = initialState["featureFlags"], action) {
+
   switch (action.type) {
     case actionTypes.SET_FEATURE_FLAGS:
       return state.set("current", action.payload || Map());
 
     case actionTypes.SET_FEATURE_FLAG:
-      return state.get("current").set(action.payload.name, action.payload.value);
+      return state.setIn(["current", action.payload.name], action.payload.value);
 
     default:
       return state;


### PR DESCRIPTION
This change fixes a display error stemming from attempting to load the signed-in user’s origins before an auth token is available. It also adds a spinner to indicate when origins are still being loaded, and fixes a bug how we’re setting individual feature flags.

Signed-off-by: Christian Nunciato <cnunciato@chef.io>

Fixes #3314.

![](https://media.tenor.com/images/8ba0b32e6cb7ff5df33975dbcdf93d86/tenor.gif)