### PR TITLE
[api-proxy] Access logging should include originating client IP.

### DIFF
--- a/components/builder-admin-proxy/config/nginx.conf
+++ b/components/builder-admin-proxy/config/nginx.conf
@@ -55,6 +55,10 @@ http {
 
   proxy_cache_path {{pkg.svc_var_path}}/cache levels=1:2 keys_zone=my_cache:10m max_size=10g inactive=60m use_temp_path=off;
 
+  log_format main '$http_x_forwarded_for - $remote_user [$time_local] '
+                  '"$request" $status $body_bytes_sent "$http_referer" '
+                  '"$http_user_agent"' ;
+
   upstream backend {
     server 127.0.0.1:{{bind.http.first.cfg.port}};
   }
@@ -85,8 +89,8 @@ http {
     }
 
     location /v1 {
-       add_header Cache-Control "private, no-cache, no-store";
-       proxy_pass http://backend;
+      add_header Cache-Control "private, no-cache, no-store";
+      proxy_pass http://backend;
     }
   }
 }

--- a/components/builder-api-proxy/config/nginx.conf
+++ b/components/builder-api-proxy/config/nginx.conf
@@ -56,7 +56,7 @@ http {
   proxy_cache_path {{pkg.svc_var_path}}/cache levels=1:2 keys_zone=my_cache:10m max_size=10g inactive=60m use_temp_path=off;
   proxy_cache_key "$scheme$proxy_host$uri$is_args$args $http_user_agent";
 
-  log_format nginx '\$remote_addr - \$remote_user [\$time_local] '
+  log_format nginx '\$http_x_forwarded_for - \$remote_user [\$time_local] '
                    '"\$request" \$status \$body_bytes_sent \$request_time '
                    '"\$http_referer" "\$http_user_agent"';
 


### PR DESCRIPTION
This was related to a production issue last night where I couldn't reliably determine the originating client's IP addrees. We should consider adding/honoring `X-Real-IP` and/or `X-Forwarded-For` headers in the `api-proxy`. It will help us determine where client requests are originating.