### PR TITLE
Mount configurable EBS volume for datastore and API

### DIFF
--- a/terraform/scripts/foundation.sh
+++ b/terraform/scripts/foundation.sh
@@ -5,8 +5,6 @@
 
 set -eux
 
-# Set up the filesystem
-sudo mkfs.ext4 /dev/xvdf
 sudo mount /dev/xvdf /mnt
 echo '/dev/xvdf /hab     ext4   defaults 0 0' | sudo tee -a /etc/fstab
 sudo mkdir -p /mnt/hab

--- a/terraform/scripts/init_filesystem.sh
+++ b/terraform/scripts/init_filesystem.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -eux
+
+sudo mkfs.ext4 /dev/xvdf

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -115,3 +115,7 @@ variable "instance_size_worker" {
 variable "api_ebs_volume_id" {
   description = "ID for EBS volume to attach to the API server"
 }
+
+variable "database_ebs_volume_id" {
+  description = "ID for EBS volume to attach to the database server"
+}

--- a/terraform/volumes.tf
+++ b/terraform/volumes.tf
@@ -3,3 +3,9 @@ resource "aws_volume_attachment" "api" {
   volume_id   = "${var.api_ebs_volume_id}"
   instance_id = "${aws_instance.api.id}"
 }
+
+resource "aws_volume_attachment" "database" {
+  device_name = "/dev/xvdf"
+  volume_id   = "${var.database_ebs_volume_id}"
+  instance_id = "${aws_instance.datastore.id}"
+}


### PR DESCRIPTION
* Add a Terraform variable for mounting an EBS volume to the datastore
  and API instances
* Move filesystem initialization to another script to prevent
  reinitialization of the filesystem of mounted EBS volumes when
  running the rest of the foundation script
* Remove `depot` bind from scheduler provisioner - it's no longer
  required

Signed-off-by: Jamie Winsor <jamie@vialstudios.com>