### PR TITLE
Link to Versions when there’s no latest stable

### DIFF
--- a/components/builder-web/app/initialState.ts
+++ b/components/builder-web/app/initialState.ts
@@ -170,6 +170,18 @@ export default Record({
         exists: false,
         loading: true,
       })(),
+      latestInChannel: Record({
+        stable: Record({
+          errorMessage: undefined,
+          exists: false,
+          loading: true,
+        })(),
+        unstable: Record({
+          errorMessage: undefined,
+          exists: false,
+          loading: true,
+        })()
+      })(),
       versions: Record({
         errorMessage: undefined,
         exists: false,

--- a/components/builder-web/app/package/package-sidebar/package-sidebar.component.html
+++ b/components/builder-web/app/package/package-sidebar/package-sidebar.component.html
@@ -13,13 +13,16 @@
     <h3>Supported Platforms</h3>
     <hab-platform-icon [platform]="platform" *ngFor="let platform of platforms"></hab-platform-icon>
   </div>
-  <div class="latest-stable" *ngIf="latestStable">
+  <div class="latest-stable">
     <h3>Latest Stable</h3>
-    <p>
+    <p *ngIf="latestStable">
       <a [routerLink]="['./', latestStable.ident.version, latestStable.ident.release]">
         {{ latestStable.ident.version }}/{{ latestStable.ident.release }}
       </a>
       <hab-platform-icon [platform]="latestStable.target"></hab-platform-icon>
+    </p>
+    <p *ngIf="!latestStable && !loadingLatestStable">
+      None. <a [routerLink]="['./']">View available versions</a>.
     </p>
   </div>
   <div class="command">

--- a/components/builder-web/app/package/package-sidebar/package-sidebar.component.ts
+++ b/components/builder-web/app/package/package-sidebar/package-sidebar.component.ts
@@ -34,10 +34,6 @@ export class PackageSidebarComponent implements OnChanges {
         }
     }
 
-    get latestStable() {
-        return this.store.getState().packages.latestInChannel.stable;
-    }
-
     build() {
         if (this.buildable) {
             let token = this.store.getState().gitHub.authToken;
@@ -52,6 +48,15 @@ export class PackageSidebarComponent implements OnChanges {
     get exportCommand() {
         return `hab pkg export docker ${this.origin}/${this.name}`;
     }
+
+    get latestStable() {
+        return this.store.getState().packages.latestInChannel.stable;
+    }
+
+    get loadingLatestStable() {
+        return this.store.getState().packages.ui.latestInChannel.stable.loading;
+    }
+
 
     get runCommand() {
         return `hab start ${this.origin}/${this.name}`;

--- a/components/builder-web/app/reducers/packages.ts
+++ b/components/builder-web/app/reducers/packages.ts
@@ -36,7 +36,10 @@ export default function packages(state = initialState["packages"], action) {
             return state.set("latest", Package());
 
         case actionTypes.CLEAR_LATEST_IN_CHANNEL:
-            return state.setIn(["latestInChannel", action.payload.channel], undefined);
+            return state.setIn(["latestInChannel", action.payload.channel], undefined).
+                setIn(["ui", "latestInChannel", action.payload.channel, "errorMessage"], undefined).
+                setIn(["ui", "latestInChannel", action.payload.channel, "exists"], false).
+                setIn(["ui", "latestInChannel", action.payload.channel, "loading"], true);
 
         case actionTypes.POPULATE_DASHBOARD_RECENT:
             return state.setIn(["dashboard", "recent"], List(action.payload));
@@ -83,8 +86,16 @@ export default function packages(state = initialState["packages"], action) {
             }
 
         case actionTypes.SET_LATEST_IN_CHANNEL:
-            if (!action.error) {
-                return state.setIn(["latestInChannel", action.payload.channel], Package(action.payload.pkg));
+            if (action.error) {
+                return state.setIn(["latestInChannel", action.payload.channel], undefined).
+                    setIn(["ui", "latestInChannel", action.payload.channel, "errorMessage"], action.error.message).
+                    setIn(["ui", "latestInChannel", action.payload.channel, "exists"], false).
+                    setIn(["ui", "latestInChannel", action.payload.channel, "loading"], false);
+            } else {
+                return state.setIn(["latestInChannel", action.payload.channel], Package(action.payload.pkg)).
+                    setIn(["ui", "latestInChannel", action.payload.channel, "errorMessage"], undefined).
+                    setIn(["ui", "latestInChannel", action.payload.channel, "exists"], true).
+                    setIn(["ui", "latestInChannel", action.payload.channel, "loading"], false);
             }
 
         case actionTypes.SET_LATEST_PACKAGE:


### PR DESCRIPTION
This change has the UI display a link to view available versions when a package has no stable version on file. (See the comments on #3359 for details.)

Signed-off-by: Christian Nunciato <cnunciato@chef.io>

![](https://media.tenor.com/images/360e1ae20a05bf5a068148cc9d87eda0/tenor.gif)