### PR TITLE
separate key file rendering from key generation to separate method

### DIFF
--- a/components/butterfly/tests/encryption/mod.rs
+++ b/components/butterfly/tests/encryption/mod.rs
@@ -20,7 +20,7 @@ use btest;
 #[test]
 fn symmetric_encryption_of_wire_payloads() {
     let ring_key =
-        SymKey::generate_in_memory("wolverine").expect("Failed to generate an in memory symkey");
+        SymKey::generate_pair_for_ring("wolverine").expect("Failed to generate an in memory symkey");
     let mut net = btest::SwimNet::new_ring_encryption(2, Some(ring_key));
     net.connect(0, 1);
     assert_wait_for_health_of!(net, [0..2, 0..2], Health::Alive);

--- a/components/core/src/crypto/artifact.rs
+++ b/components/core/src/crypto/artifact.rs
@@ -294,7 +294,8 @@ mod test {
     #[test]
     fn sign_and_verify() {
         let cache = TempDir::new("key_cache").unwrap();
-        let pair = SigKeyPair::generate_pair_for_origin("unicorn", cache.path()).unwrap();
+        let pair = SigKeyPair::generate_pair_for_origin("unicorn").unwrap();
+        pair.to_pair_files(cache.path()).unwrap();
         let dst = cache.path().join("signed.dat");
 
         sign(&fixture("signme.dat"), &dst, &pair).unwrap();
@@ -306,7 +307,8 @@ mod test {
     #[should_panic(expected = "Secret key is required but not present for")]
     fn sign_missing_private_key() {
         let cache = TempDir::new("key_cache").unwrap();
-        let pair = SigKeyPair::generate_pair_for_origin("unicorn", cache.path()).unwrap();
+        let pair = SigKeyPair::generate_pair_for_origin("unicorn").unwrap();
+        pair.to_pair_files(cache.path()).unwrap();
         let dst = cache.path().join("signed.dat");
 
         // Delete the secret key
@@ -323,7 +325,8 @@ mod test {
     #[should_panic(expected = "Public key is required but not present for")]
     fn verify_missing_public_key() {
         let cache = TempDir::new("key_cache").unwrap();
-        let pair = SigKeyPair::generate_pair_for_origin("unicorn", cache.path()).unwrap();
+        let pair = SigKeyPair::generate_pair_for_origin("unicorn").unwrap();
+        pair.to_pair_files(cache.path()).unwrap();
         let dst = cache.path().join("signed.dat");
         sign(&fixture("signme.dat"), &dst, &pair).unwrap();
 
@@ -385,7 +388,8 @@ mod test {
     #[should_panic(expected = "Corrupt payload, can\\'t read hash type")]
     fn verify_empty_hash_type() {
         let cache = TempDir::new("key_cache").unwrap();
-        let pair = SigKeyPair::generate_pair_for_origin("unicorn", cache.path()).unwrap();
+        let pair = SigKeyPair::generate_pair_for_origin("unicorn").unwrap();
+        pair.to_pair_files(cache.path()).unwrap();
         let dst = cache.path().join("signed.dat");
         let mut f = File::create(&dst).unwrap();
         f.write_all(format!("HART-1\n{}\n", pair.name_with_rev()).as_bytes())
@@ -398,7 +402,8 @@ mod test {
     #[should_panic(expected = "Unsupported signature type: BESTEST")]
     fn verify_invalid_hash_type() {
         let cache = TempDir::new("key_cache").unwrap();
-        let pair = SigKeyPair::generate_pair_for_origin("unicorn", cache.path()).unwrap();
+        let pair = SigKeyPair::generate_pair_for_origin("unicorn").unwrap();
+        pair.to_pair_files(cache.path()).unwrap();
         let dst = cache.path().join("signed.dat");
         let mut f = File::create(&dst).unwrap();
         f.write_all(
@@ -412,7 +417,8 @@ mod test {
     #[should_panic(expected = "Corrupt payload, can\\'t read signature")]
     fn verify_empty_signature() {
         let cache = TempDir::new("key_cache").unwrap();
-        let pair = SigKeyPair::generate_pair_for_origin("unicorn", cache.path()).unwrap();
+        let pair = SigKeyPair::generate_pair_for_origin("unicorn").unwrap();
+        pair.to_pair_files(cache.path()).unwrap();
         let dst = cache.path().join("signed.dat");
         let mut f = File::create(&dst).unwrap();
         f.write_all(
@@ -426,7 +432,8 @@ mod test {
     #[should_panic(expected = "Can\\'t decode signature")]
     fn verify_invalid_signature_decode() {
         let cache = TempDir::new("key_cache").unwrap();
-        let pair = SigKeyPair::generate_pair_for_origin("unicorn", cache.path()).unwrap();
+        let pair = SigKeyPair::generate_pair_for_origin("unicorn").unwrap();
+        pair.to_pair_files(cache.path()).unwrap();
         let dst = cache.path().join("signed.dat");
         let mut f = File::create(&dst).unwrap();
         f.write_all(
@@ -443,7 +450,8 @@ mod test {
     #[should_panic(expected = "Corrupt payload, can\\'t find end of header")]
     fn verify_missing_end_of_header() {
         let cache = TempDir::new("key_cache").unwrap();
-        let pair = SigKeyPair::generate_pair_for_origin("unicorn", cache.path()).unwrap();
+        let pair = SigKeyPair::generate_pair_for_origin("unicorn").unwrap();
+        pair.to_pair_files(cache.path()).unwrap();
         let dst = cache.path().join("signed.dat");
         let mut f = File::create(&dst).unwrap();
         f.write_all(
@@ -457,7 +465,8 @@ mod test {
     #[should_panic(expected = "Habitat artifact is invalid")]
     fn verify_corrupted_archive() {
         let cache = TempDir::new("key_cache").unwrap();
-        let pair = SigKeyPair::generate_pair_for_origin("unicorn", cache.path()).unwrap();
+        let pair = SigKeyPair::generate_pair_for_origin("unicorn").unwrap();
+        pair.to_pair_files(cache.path()).unwrap();
         let dst = cache.path().join("signed.dat");
         let dst_corrupted = cache.path().join("corrupted.dat");
 
@@ -492,7 +501,8 @@ mod test {
     #[test]
     fn get_archive_reader_working() {
         let cache = TempDir::new("key_cache").unwrap();
-        let pair = SigKeyPair::generate_pair_for_origin("unicorn", cache.path()).unwrap();
+        let pair = SigKeyPair::generate_pair_for_origin("unicorn").unwrap();
+        pair.to_pair_files(cache.path()).unwrap();
         let src = cache.path().join("src.in");
         let dst = cache.path().join("src.signed");
         let mut f = File::create(&src).unwrap();
@@ -508,7 +518,8 @@ mod test {
     #[test]
     fn verify_get_artifact_header() {
         let cache = TempDir::new("key_cache").unwrap();
-        let pair = SigKeyPair::generate_pair_for_origin("unicorn", cache.path()).unwrap();
+        let pair = SigKeyPair::generate_pair_for_origin("unicorn").unwrap();
+        pair.to_pair_files(cache.path()).unwrap();
         let src = cache.path().join("src.in");
         let dst = cache.path().join("src.signed");
         let mut f = File::create(&src).unwrap();

--- a/components/hab/src/command/origin/key/generate.rs
+++ b/components/hab/src/command/origin/key/generate.rs
@@ -26,7 +26,8 @@ pub fn start(ui: &mut UI, origin: &str, cache: &Path) -> Result<()> {
         false => Err(Error::from(InvalidOrigin(origin.to_string()))),
         true => {
             ui.begin(format!("Generating origin key for {}", &origin))?;
-            let pair = SigKeyPair::generate_pair_for_origin(origin, cache)?;
+            let pair = SigKeyPair::generate_pair_for_origin(origin)?;
+            pair.to_pair_files(cache)?;
             ui.end(format!(
                 "Generated origin key pair {}.",
                 &pair.name_with_rev()

--- a/components/hab/src/command/ring/key/generate.rs
+++ b/components/hab/src/command/ring/key/generate.rs
@@ -21,7 +21,8 @@ use error::Result;
 
 pub fn start(ui: &mut UI, ring: &str, cache: &Path) -> Result<()> {
     ui.begin(format!("Generating ring key for {}", &ring))?;
-    let pair = SymKey::generate_pair_for_ring(ring, cache)?;
+    let pair = SymKey::generate_pair_for_ring(ring)?;
+    pair.to_pair_files(cache)?;
     ui.end(format!(
         "Generated ring key pair {}.",
         &pair.name_with_rev()

--- a/components/hab/src/command/service/key/generate.rs
+++ b/components/hab/src/command/service/key/generate.rs
@@ -26,7 +26,8 @@ pub fn start(ui: &mut UI, org: &str, service_group: &ServiceGroup, cache: &Path)
         &service_group,
         org
     ))?;
-    let pair = BoxKeyPair::generate_pair_for_service(org, &service_group.to_string(), cache)?;
+    let pair = BoxKeyPair::generate_pair_for_service(org, &service_group.to_string())?;
+    pair.to_pair_files(cache)?;
     ui.end(format!(
         "Generated service key pair {}.",
         &pair.name_with_rev()

--- a/components/hab/src/command/user/key/generate.rs
+++ b/components/hab/src/command/user/key/generate.rs
@@ -21,7 +21,8 @@ use error::Result;
 
 pub fn start(ui: &mut UI, user: &str, cache: &Path) -> Result<()> {
     ui.begin(format!("Generating user key for {}", &user))?;
-    let pair = BoxKeyPair::generate_pair_for_user(user, cache)?;
+    let pair = BoxKeyPair::generate_pair_for_user(user)?;
+    pair.to_pair_files(cache)?;
     ui.end(format!(
         "Generated user key pair {}.",
         &pair.name_with_rev()


### PR DESCRIPTION
As we are beginning to encounter scenarios where we need to generate keys for builder but do not need to persist those keys on disk. This PR removes the key file creation from the key generators. It adds a `to_pair_files` method to the key implementations that handle the rendering of the keys to disk. This also exposes `to_public_string` and `to_private_string` methods in order to generate the same text that would be rended to file as a string that can be persisted elsewhere (like postgres).

BTW: I'm not crazy about the name `to_pair_files` but dont think its terrible. So if anyone wants to suggest a different name, it should be easy to "replace_all" on the name.

Signed-off-by: mwrock <matt@mattwrock.com>