### PR TITLE
Automatically determine jobsrv key_dir in Habitat plan

### DIFF
--- a/components/builder-jobsrv/habitat/config/config.toml
+++ b/components/builder-jobsrv/habitat/config/config.toml
@@ -1,3 +1,5 @@
+key_dir = "{{pkg.svc_files_path}}"
+
 {{~#eachAlive bind.router.members as |member|}}
 [[routers]]
 host = "{{member.sys.ip}}"


### PR DESCRIPTION
Use `{{pkg.svc_files_path}}` to determine the path for JobSrv's key_dir configuration setting

![tenor-173587473](https://user-images.githubusercontent.com/54036/30933239-dd20295a-a37e-11e7-94f1-1e8625b0193e.gif)
