### PR TITLE
Use long arg form for Supervisor auto update in .envrc.

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,2 +1,2 @@
 export HAB_DOCKER_OPTS="-p 9636:80 -p 9631:9631 -p 9638:9638"
-export HAB_STUDIO_SUP="--channel unstable -A"
+export HAB_STUDIO_SUP="--channel unstable --auto-update"


### PR DESCRIPTION
A bit easier for newcomers to understand what is going on without
having to know what `-A` is or where to find out what it is.

Yep, in this case I was a newcomer. Had to check `hab sup run --help` to remember.