### PR TITLE
Show and delete a Docker integration

### DIFF
--- a/components/builder-web/app/BuilderApiClient.ts
+++ b/components/builder-web/app/BuilderApiClient.ts
@@ -344,48 +344,54 @@ export class BuilderApiClient {
         });
     }
 
-    public getDockerHubCredentials(originName: string) {
+    public getDockerIntegration(originName: string) {
         return new Promise((resolve, reject) => {
             fetch(`${this.urlPrefix}/depot/origins/${originName}/integrations/docker/names`, {
-                headers: this.headers,
-            }).then(response => {
+                headers: this.headers
+            })
+            .then(response => {
                 if (response.ok) {
                     resolve(response.json());
                 } else {
                     reject(new Error(response.statusText));
                 }
-            }).catch(error => reject(error));
+            })
+            .catch(error => reject(error));
         });
     }
 
-    public addDockerHubCredentials(originName: string, credentials) {
+    public setDockerIntegration(originName: string, credentials) {
         return new Promise((resolve, reject) => {
             fetch(`${this.urlPrefix}/depot/origins/${originName}/integrations/docker/docker`, {
                 headers: this.headers,
                 method: "PUT",
                 body: JSON.stringify(credentials)
-            }).then(response => {
+            })
+            .then(response => {
                 if (response.ok) {
-                    resolve(response.json());
+                    resolve();
                 } else {
                     reject(new Error(response.statusText));
                 }
-            }).catch(error => reject(error));
+            })
+            .catch(error => reject(error));
         });
     }
 
-    public deleteDockerHubCredentials(originName: string) {
+    public deleteDockerIntegration(origin: string, name: string) {
         return new Promise((resolve, reject) => {
-            fetch(`${this.urlPrefix}/depot/origins/${originName}/integrations/docker/docker`, {
+            fetch(`${this.urlPrefix}/depot/origins/${origin}/integrations/docker/${name}`, {
                 headers: this.headers,
                 method: "DELETE",
-            }).then(response => {
+            })
+            .then(response => {
                 if (response.ok) {
-                    resolve(response.json());
+                    resolve();
                 } else {
                     reject(new Error(response.statusText));
                 }
-            }).catch(error => reject(error));
+            })
+            .catch(error => reject(error));
         });
     }
 }

--- a/components/builder-web/app/actions/index.ts
+++ b/components/builder-web/app/actions/index.ts
@@ -32,10 +32,8 @@ export const POPULATE_GITHUB_REPOS = gitHubActions.POPULATE_GITHUB_REPOS;
 export const POPULATE_GITHUB_USER_DATA = gitHubActions.POPULATE_GITHUB_USER_DATA;
 export const RESET_GITHUB_ORGS = gitHubActions.RESET_GITHUB_ORGS;
 export const RESET_GITHUB_REPOS = gitHubActions.RESET_GITHUB_REPOS;
-export const SET_GITHUB_ORGS_LOADING_FLAG =
-    gitHubActions.SET_GITHUB_ORGS_LOADING_FLAG;
-export const SET_GITHUB_REPOS_LOADING_FLAG =
-    gitHubActions.SET_GITHUB_REPOS_LOADING_FLAG;
+export const SET_GITHUB_ORGS_LOADING_FLAG = gitHubActions.SET_GITHUB_ORGS_LOADING_FLAG;
+export const SET_GITHUB_REPOS_LOADING_FLAG = gitHubActions.SET_GITHUB_REPOS_LOADING_FLAG;
 export const SET_GITHUB_AUTH_STATE = gitHubActions.SET_GITHUB_AUTH_STATE;
 export const SET_GITHUB_AUTH_TOKEN = gitHubActions.SET_GITHUB_AUTH_TOKEN;
 export const SET_SELECTED_GITHUB_ORG = gitHubActions.SET_SELECTED_GITHUB_ORG;
@@ -51,35 +49,23 @@ export const STREAM_BUILD_LOG = buildActions.STREAM_BUILD_LOG;
 export const ADD_NOTIFICATION = notificationActions.ADD_NOTIFICATION;
 export const REMOVE_NOTIFICATION = notificationActions.REMOVE_NOTIFICATION;
 
+export const CLEAR_DOCKER_INTEGRATIONS = originActions.CLEAR_DOCKER_INTEGRATIONS;
 export const POPULATE_MY_ORIGINS = originActions.POPULATE_MY_ORIGINS;
 export const SET_PACKAGE_COUNT_FOR_ORIGIN = originActions.SET_PACKAGE_COUNT_FOR_ORIGIN;
-export const POPULATE_MY_ORIGIN_INVITATIONS =
-    originActions.POPULATE_MY_ORIGIN_INVITATIONS;
-export const POPULATE_ORIGIN_INVITATIONS =
-    originActions.POPULATE_ORIGIN_INVITATIONS;
-export const POPULATE_ORIGIN_MEMBERS =
-    originActions.POPULATE_ORIGIN_MEMBERS;
-export const POPULATE_ORIGIN_PUBLIC_KEYS =
-    originActions.POPULATE_ORIGIN_PUBLIC_KEYS;
-export const POPULATE_ORIGIN_INTEGRATIONS =
-    originActions.POPULATE_ORIGIN_INTEGRATIONS;
+export const POPULATE_MY_ORIGIN_INVITATIONS = originActions.POPULATE_MY_ORIGIN_INVITATIONS;
+export const POPULATE_ORIGIN_INVITATIONS = originActions.POPULATE_ORIGIN_INVITATIONS;
+export const POPULATE_ORIGIN_MEMBERS = originActions.POPULATE_ORIGIN_MEMBERS;
+export const POPULATE_ORIGIN_PUBLIC_KEYS = originActions.POPULATE_ORIGIN_PUBLIC_KEYS;
+export const POPULATE_ORIGIN_DOCKER_INTEGRATIONS = originActions.POPULATE_ORIGIN_DOCKER_INTEGRATIONS;
 export const SET_CURRENT_ORIGIN = originActions.SET_CURRENT_ORIGIN;
-export const SET_CURRENT_ORIGIN_CREATING_FLAG =
-    originActions.SET_CURRENT_ORIGIN_CREATING_FLAG;
-export const SET_CURRENT_ORIGIN_ADDING_PRIVATE_KEY =
-    originActions.SET_CURRENT_ORIGIN_ADDING_PRIVATE_KEY;
-export const SET_CURRENT_ORIGIN_ADDING_PUBLIC_KEY =
-    originActions.SET_CURRENT_ORIGIN_ADDING_PUBLIC_KEY;
-export const SET_CURRENT_ORIGIN_LOADING =
-    originActions.SET_CURRENT_ORIGIN_LOADING;
-export const SET_ORIGIN_PRIVATE_KEY_UPLOAD_ERROR_MESSAGE =
-    originActions.SET_ORIGIN_PRIVATE_KEY_UPLOAD_ERROR_MESSAGE;
-export const SET_ORIGIN_PUBLIC_KEY_UPLOAD_ERROR_MESSAGE =
-    originActions.SET_ORIGIN_PUBLIC_KEY_UPLOAD_ERROR_MESSAGE;
-export const SET_ORIGIN_USER_INVITE_ERROR_MESSAGE =
-    originActions.SET_ORIGIN_USER_INVITE_ERROR_MESSAGE;
-export const SET_ORIGIN_INTEGRATION_SAVE_ERROR_MESSAGE =
-    originActions.SET_ORIGIN_INTEGRATION_SAVE_ERROR_MESSAGE;
+export const SET_CURRENT_ORIGIN_CREATING_FLAG = originActions.SET_CURRENT_ORIGIN_CREATING_FLAG;
+export const SET_CURRENT_ORIGIN_ADDING_PRIVATE_KEY = originActions.SET_CURRENT_ORIGIN_ADDING_PRIVATE_KEY;
+export const SET_CURRENT_ORIGIN_ADDING_PUBLIC_KEY = originActions.SET_CURRENT_ORIGIN_ADDING_PUBLIC_KEY;
+export const SET_CURRENT_ORIGIN_LOADING = originActions.SET_CURRENT_ORIGIN_LOADING;
+export const SET_ORIGIN_PRIVATE_KEY_UPLOAD_ERROR_MESSAGE = originActions.SET_ORIGIN_PRIVATE_KEY_UPLOAD_ERROR_MESSAGE;
+export const SET_ORIGIN_PUBLIC_KEY_UPLOAD_ERROR_MESSAGE = originActions.SET_ORIGIN_PUBLIC_KEY_UPLOAD_ERROR_MESSAGE;
+export const SET_ORIGIN_USER_INVITE_ERROR_MESSAGE = originActions.SET_ORIGIN_USER_INVITE_ERROR_MESSAGE;
+export const SET_ORIGIN_INTEGRATION_SAVE_ERROR_MESSAGE = originActions.SET_ORIGIN_INTEGRATION_SAVE_ERROR_MESSAGE;
 export const TOGGLE_ORIGIN_PICKER = originActions.TOGGLE_ORIGIN_PICKER;
 export const SET_ORIGIN_PRIVACY_SETTINGS = originActions.SET_ORIGIN_PRIVACY_SETTINGS;
 
@@ -95,8 +81,7 @@ export const SET_CURRENT_PACKAGE_VERSIONS = packageActions.SET_CURRENT_PACKAGE_V
 export const SET_LATEST_IN_CHANNEL = packageActions.SET_LATEST_IN_CHANNEL;
 export const SET_LATEST_PACKAGE = packageActions.SET_LATEST_PACKAGE;
 export const SET_PACKAGES_NEXT_RANGE = packageActions.SET_PACKAGES_NEXT_RANGE;
-export const SET_PACKAGES_SEARCH_QUERY =
-    packageActions.SET_PACKAGES_SEARCH_QUERY;
+export const SET_PACKAGES_SEARCH_QUERY = packageActions.SET_PACKAGES_SEARCH_QUERY;
 export const SET_PACKAGES_TOTAL_COUNT = packageActions.SET_PACKAGES_TOTAL_COUNT;
 
 export const SET_VISIBLE_PACKAGES = packageActions.SET_VISIBLE_PACKAGES;
@@ -155,7 +140,9 @@ export const removeNotification = notificationActions.removeNotification;
 
 export const acceptOriginInvitation = originActions.acceptOriginInvitation;
 export const createOrigin = originActions.createOrigin;
+export const deleteDockerIntegration = originActions.deleteDockerIntegration;
 export const ignoreOriginInvitation = originActions.ignoreOriginInvitation;
+export const fetchDockerIntegration = originActions.fetchDockerIntegration;
 export const fetchOrigin = originActions.fetchOrigin;
 export const fetchOriginInvitations = originActions.fetchOriginInvitations;
 export const fetchOriginMembers = originActions.fetchOriginMembers;
@@ -168,8 +155,7 @@ export const setCurrentOrigin = originActions.setCurrentOrigin;
 export const uploadOriginPrivateKey = originActions.uploadOriginPrivateKey;
 export const uploadOriginPublicKey = originActions.uploadOriginPublicKey;
 export const setOriginPrivacySettings = originActions.setOriginPrivacySettings;
-export const addDockerHubCredentials = originActions.addDockerHubCredentials;
-export const fetchIntegrations = originActions.fetchIntegrations;
+export const setDockerIntegration = originActions.setDockerIntegration;
 
 export const fetchDashboardRecent = packageActions.fetchDashboardRecent;
 export const fetchExplore = packageActions.fetchExplore;

--- a/components/builder-web/app/actions/origins.ts
+++ b/components/builder-web/app/actions/origins.ts
@@ -18,28 +18,23 @@ import * as depotApi from "../depotApi";
 import { BuilderApiClient } from "../BuilderApiClient";
 import { parseKey } from "../util";
 
+export const CLEAR_DOCKER_INTEGRATIONS = "CLEAR_DOCKER_INTEGRATIONS";
+export const DELETE_DOCKER_INTEGRATION = "DELETE_DOCKER_INTEGRATION";
 export const POPULATE_MY_ORIGINS = "POPULATE_MY_ORIGINS";
 export const POPULATE_MY_ORIGIN_INVITATIONS = "POPULATE_MY_ORIGIN_INVITATIONS";
 export const POPULATE_ORIGIN_INVITATIONS = "POPULATE_ORIGIN_INVITATIONS";
 export const POPULATE_ORIGIN_MEMBERS = "POPULATE_ORIGIN_MEMBERS";
 export const POPULATE_ORIGIN_PUBLIC_KEYS = "POPULATE_ORIGIN_PUBLIC_KEYS";
-export const POPULATE_ORIGIN_INTEGRATIONS = "POPULATE_ORIGIN_INTEGRATIONS";
+export const POPULATE_ORIGIN_DOCKER_INTEGRATIONS = "POPULATE_ORIGIN_DOCKER_INTEGRATIONS";
 export const SET_CURRENT_ORIGIN = "SET_CURRENT_ORIGIN";
-export const SET_CURRENT_ORIGIN_CREATING_FLAG =
-    "SET_CURRENT_ORIGIN_CREATING_FLAG";
+export const SET_CURRENT_ORIGIN_CREATING_FLAG = "SET_CURRENT_ORIGIN_CREATING_FLAG";
 export const SET_CURRENT_ORIGIN_LOADING = "SET_CURRENT_ORIGIN_LOADING";
-export const SET_CURRENT_ORIGIN_ADDING_PRIVATE_KEY =
-    "SET_CURRENT_ORIGIN_ADDING_PRIVATE_KEY";
-export const SET_CURRENT_ORIGIN_ADDING_PUBLIC_KEY =
-    "SET_CURRENT_ORIGIN_ADDING_PUBLIC_KEY";
-export const SET_ORIGIN_PRIVATE_KEY_UPLOAD_ERROR_MESSAGE =
-    "SET_ORIGIN_PRIVATE_KEY_UPLOAD_ERROR_MESSAGE";
-export const SET_ORIGIN_PUBLIC_KEY_UPLOAD_ERROR_MESSAGE =
-    "SET_ORIGIN_PUBLIC_KEY_UPLOAD_ERROR_MESSAGE";
-export const SET_ORIGIN_USER_INVITE_ERROR_MESSAGE =
-    "SET_ORIGIN_USER_INVITE_ERROR_MESSAGE";
-export const SET_ORIGIN_INTEGRATION_SAVE_ERROR_MESSAGE =
-    "SET_ORIGIN_INTEGRATION_SAVE_ERROR_MESSAGE";
+export const SET_CURRENT_ORIGIN_ADDING_PRIVATE_KEY = "SET_CURRENT_ORIGIN_ADDING_PRIVATE_KEY";
+export const SET_CURRENT_ORIGIN_ADDING_PUBLIC_KEY = "SET_CURRENT_ORIGIN_ADDING_PUBLIC_KEY";
+export const SET_ORIGIN_PRIVATE_KEY_UPLOAD_ERROR_MESSAGE = "SET_ORIGIN_PRIVATE_KEY_UPLOAD_ERROR_MESSAGE";
+export const SET_ORIGIN_PUBLIC_KEY_UPLOAD_ERROR_MESSAGE = "SET_ORIGIN_PUBLIC_KEY_UPLOAD_ERROR_MESSAGE";
+export const SET_ORIGIN_USER_INVITE_ERROR_MESSAGE = "SET_ORIGIN_USER_INVITE_ERROR_MESSAGE";
+export const SET_ORIGIN_INTEGRATION_SAVE_ERROR_MESSAGE = "SET_ORIGIN_INTEGRATION_SAVE_ERROR_MESSAGE";
 export const TOGGLE_ORIGIN_PICKER = "TOGGLE_ORIGIN_PICKER";
 export const SET_PACKAGE_COUNT_FOR_ORIGIN = "SET_PACKAGE_COUNT_FOR_ORIGIN";
 export const SET_ORIGIN_PRIVACY_SETTINGS = "SET_ORIGIN_PRIVACY_SETTINGS";
@@ -188,25 +183,39 @@ export function inviteUserToOrigin(username: string, origin: string, token: stri
     };
 }
 
-
-export function addDockerHubCredentials(origin: string, credentials, token: string) {
+export function deleteDockerIntegration(origin: string, token: string, name: string) {
     return dispatch => {
-        new BuilderApiClient(token).addDockerHubCredentials(origin, credentials).
-            then(response => {
-                dispatch(fetchIntegrations(origin, token));
-            }).catch(error => {
-                dispatch(setOriginIntegrationSaveErrorMessage(error.message));
+        new BuilderApiClient(token).deleteDockerIntegration(origin, name)
+            .then(response => {
+                dispatch(fetchDockerIntegration(origin, token));
+            })
+            .catch(error => {
+                dispatch(populateDockerIntegrations(undefined, error.message));
             });
     };
 }
 
-export function fetchIntegrations(origin: string, token: string) {
+export function fetchDockerIntegration(origin: string, token: string) {
     return dispatch => {
-        new BuilderApiClient(token).getDockerHubCredentials(origin).
-            then(response => {
-                dispatch(populateIntegrations(response));
-            }).catch(error => {
-                dispatch(populateIntegrations(undefined, error.message));
+        dispatch(clearDockerIntegration());
+        new BuilderApiClient(token).getDockerIntegration(origin)
+            .then(response => {
+                dispatch(populateDockerIntegrations(response));
+            })
+            .catch(error => {
+                dispatch(populateDockerIntegrations(undefined, error.message));
+            });
+    };
+}
+
+export function setDockerIntegration(origin: string, credentials, token: string) {
+    return dispatch => {
+        new BuilderApiClient(token).setDockerIntegration(origin, credentials)
+            .then(() => {
+                dispatch(fetchDockerIntegration(origin, token));
+            })
+            .catch(error => {
+                dispatch(setOriginIntegrationSaveErrorMessage(error.message));
             });
     };
 }
@@ -230,6 +239,12 @@ export function fetchOriginsPackageCount(origins) {
                     dispatch(populatePackageCountForOrigin(error.message));
                 });
         });
+    };
+}
+
+function clearDockerIntegration() {
+    return {
+        type: CLEAR_DOCKER_INTEGRATIONS
     };
 }
 
@@ -273,9 +288,9 @@ function populateOriginPublicKeys(payload, error = undefined) {
     };
 }
 
-function populateIntegrations(payload, error = undefined) {
+function populateDockerIntegrations(payload, error = undefined) {
     return {
-        type: POPULATE_ORIGIN_INTEGRATIONS,
+        type: POPULATE_ORIGIN_DOCKER_INTEGRATIONS,
         payload,
         error
     };

--- a/components/builder-web/app/initialState.ts
+++ b/components/builder-web/app/initialState.ts
@@ -113,7 +113,9 @@ export default Record({
     currentPendingInvitations: List(),
     mine: List(),
     myInvitations: List(),
-    currentIntegrations: List(),
+    currentIntegrations: Record({
+      docker: List()
+    })(),
     ui: Record({
       current: Record({
         addingPublicKey: false,

--- a/components/builder-web/app/origin/origin-page/origin-integrations-tab/_origin-integrations-tab.component.scss
+++ b/components/builder-web/app/origin/origin-page/origin-integrations-tab/_origin-integrations-tab.component.scss
@@ -5,9 +5,56 @@
   h3 {
     font-family: $heading-font-family;
     font-size: rem(12);
+    text-transform: uppercase;
+
+    hab-icon {
+      margin-right: 6px;
+    }
   }
 
   p {
     margin-bottom: 18px;
+  }
+
+  ul {
+    margin-top: 18px;
+    border-top: 1px solid $very-light-gray;
+
+    li {
+      @include row;
+      border-bottom: 1px solid $very-light-gray;
+      padding: 12px;
+      font-size: rem(12);
+
+      hab-icon {
+        width: 16px;
+        height: 16px;
+      }
+
+      .name {
+        @include span-columns(10);
+        font-weight: 600;
+
+        hab-icon {
+          margin-right: 6px;
+        }
+      }
+
+      .actions {
+        @include span-columns(2);
+        text-align: right;
+
+        hab-icon {
+          color: $hab-blue;
+          cursor: pointer;
+          margin-left: 12px;
+          transition: color .2s linear;
+
+          &:hover {
+            color: darken($hab-blue, 10%);
+          }
+        }
+      }
+    }
   }
 }

--- a/components/builder-web/app/origin/origin-page/origin-integrations-tab/dialog/integration-delete-confirm/integration-delete-confirm.dialog.html
+++ b/components/builder-web/app/origin/origin-page/origin-integrations-tab/dialog/integration-delete-confirm/integration-delete-confirm.dialog.html
@@ -1,0 +1,18 @@
+<div class="dialog integration-delete-confirm">
+    <section class="heading">
+      <hab-icon symbol="delete"></hab-icon>
+      <h1>Confirm Delete</h1>
+    </section>
+    <section class="body">
+      <p>
+        Are you sure you want to remove this integration?
+        Packages will no longer be published to this Docker Hub account.
+      </p>
+    </section>
+    <section class="controls">
+      <button md-raised-button color="primary" class="button" (click)="ok()">
+          Yes, delete it
+      </button>
+      <a (click)="cancel()">Cancel</a>
+    </section>
+  </div>

--- a/components/builder-web/app/origin/origin-page/origin-integrations-tab/dialog/integration-delete-confirm/integration-delete-confirm.dialog.ts
+++ b/components/builder-web/app/origin/origin-page/origin-integrations-tab/dialog/integration-delete-confirm/integration-delete-confirm.dialog.ts
@@ -1,0 +1,17 @@
+import { Component, Inject } from "@angular/core";
+import { MdDialog, MdDialogRef, MD_DIALOG_DATA } from "@angular/material";
+
+@Component({
+  template: require("./integration-delete-confirm.dialog.html")
+})
+export class IntegrationDeleteConfirmDialog {
+  constructor(private ref: MdDialogRef<IntegrationDeleteConfirmDialog>) {}
+
+  ok() {
+    this.ref.close(true);
+  }
+
+  cancel() {
+    this.ref.close(false);
+  }
+}

--- a/components/builder-web/app/origin/origin-page/origin-integrations-tab/origin-integrations-tab.component.html
+++ b/components/builder-web/app/origin/origin-page/origin-integrations-tab/origin-integrations-tab.component.html
@@ -1,13 +1,28 @@
 <div class="page-body integrations-tab">
-  <h3 class="uppercase">
-    <hab-icon symbol="docker"></hab-icon>
-    Docker Hub Integration
-  </h3>
-  <p>
-    By adding this integration, the Habitat Build Service can export the result of your package
-    build jobs (.hart file) to a Docker container and publish it to your Docker Hub account.
-  </p>
   <div>
-    <a md-raised-button color="primary" (click)="openDialog()">Add Docker Hub account</a>
+    <h3>
+      <hab-icon symbol="docker"></hab-icon>
+      Docker Hub Integration
+    </h3>
+    <p>
+      By adding this integration, the Habitat Build Service can export the result of your package
+      build jobs (.hart file) to a Docker container and publish it to your Docker Hub account.
+    </p>
+    <div *ngIf="integrations.docker.size === 0">
+      <a md-raised-button color="primary" (click)="addDocker()">Add Docker Hub account</a>
+    </div>
+  </div>
+  <div *ngIf="integrations.docker.size > 0">
+    <ul>
+      <li *ngFor="let name of integrations.docker">
+        <span class="name">
+          <hab-icon symbol="docker"></hab-icon>
+          {{ name }}
+        </span>
+        <span class="actions">
+          <hab-icon symbol="cancel" title="Delete this integration" (click)="deleteDocker(name)"></hab-icon>
+        </span>
+      </li>
+    </ul>
   </div>
 </div>

--- a/components/builder-web/app/origin/origin-page/origin-page.component.ts
+++ b/components/builder-web/app/origin/origin-page/origin-page.component.ts
@@ -16,16 +16,12 @@ import { Component, OnInit, OnDestroy } from "@angular/core";
 import { RouterLink, ActivatedRoute } from "@angular/router";
 import { Subscription } from "rxjs/Subscription";
 import { AppStore } from "../../AppStore";
-import { FeatureFlags } from "../../Privilege";
-import {
-    fetchOrigin, fetchOriginInvitations, fetchOriginMembers,
-    inviteUserToOrigin,
-    filterPackagesBy, fetchMyOrigins,
-    setProjectHint, requestRoute, setCurrentProject, getUniquePackages, fetchIntegrations
-} from "../../actions";
 import config from "../../config";
 import { Origin } from "../../records/Origin";
 import { requireSignIn, packageString } from "../../util";
+import {  fetchOrigin, fetchOriginInvitations, fetchOriginMembers, inviteUserToOrigin, filterPackagesBy,
+    fetchMyOrigins, setProjectHint, requestRoute, setCurrentProject, getUniquePackages,
+    fetchDockerIntegration } from "../../actions";
 
 export enum ProjectStatus {
     Connect,
@@ -54,17 +50,11 @@ export class OriginPageComponent implements OnInit, OnDestroy {
         requireSignIn(this);
         this.store.dispatch(fetchOrigin(this.origin.name));
         this.store.dispatch(fetchMyOrigins(this.gitHubAuthToken));
-        this.store.dispatch(fetchOriginMembers(
-            this.origin.name, this.gitHubAuthToken
-        ));
-        this.store.dispatch(fetchOriginInvitations(
-            this.origin.name, this.gitHubAuthToken
-        ));
+        this.store.dispatch(fetchOriginMembers(this.origin.name, this.gitHubAuthToken));
+        this.store.dispatch(fetchOriginInvitations(this.origin.name, this.gitHubAuthToken));
+        this.store.dispatch(fetchDockerIntegration(this.origin.name, this.gitHubAuthToken));
         this.getPackages();
         this.loadPackages = this.getPackages.bind(this);
-        this.store.dispatch(fetchIntegrations(
-            this.origin.name, this.gitHubAuthToken
-        ));
     }
 
     ngOnDestroy() {

--- a/components/builder-web/app/origin/origin-page/origin-page.module.ts
+++ b/components/builder-web/app/origin/origin-page/origin-page.module.ts
@@ -18,6 +18,7 @@ import { FormsModule, ReactiveFormsModule } from "@angular/forms";
 import { NgModule } from "@angular/core";
 import { RouterModule } from "@angular/router";
 import { MdTabsModule, MdRadioModule, MdButtonModule, MdDialogModule } from "@angular/material";
+import { IntegrationDeleteConfirmDialog } from "./origin-integrations-tab/dialog/integration-delete-confirm/integration-delete-confirm.dialog";
 import { KeyAddFormDialog } from "./origin-keys-tab/key-add-form/key-add-form.dialog";
 import { KeyListComponent } from "./origin-keys-tab/key-list/key-list.component";
 import { OriginPageRoutingModule } from "./origin-page-routing.module";
@@ -45,19 +46,21 @@ export const imports = [
 ];
 
 export const declarations = [
+  DockerCredentialsFormDialog,
+  IntegrationDeleteConfirmDialog,
   KeyAddFormDialog,
   KeyListComponent,
-  OriginPageComponent,
-  OriginPackagesTabComponent,
-  OriginMembersTabComponent,
   OriginKeysTabComponent,
+  OriginMembersTabComponent,
+  OriginPackagesTabComponent,
+  OriginPageComponent,
   OriginSettingsTabComponent,
-  DockerCredentialsFormDialog,
   OriginIntegrationsTabComponent
 ];
 
 const entryComponents = [
   DockerCredentialsFormDialog,
+  IntegrationDeleteConfirmDialog,
   KeyAddFormDialog
 ];
 

--- a/components/builder-web/app/origin/origin-page/origin-settings-tab/origin-settings-tab.component.ts
+++ b/components/builder-web/app/origin/origin-page/origin-settings-tab/origin-settings-tab.component.ts
@@ -17,8 +17,8 @@ import { AppStore } from "../../../AppStore";
 import { setOriginPrivacySettings } from "../../../actions/index";
 import { MdDialog, MdDialogRef } from "@angular/material";
 import { DockerCredentialsFormDialog } from "../docker-credentials-form/docker-credentials-form.dialog";
+
 @Component({
-    selector: "hab-origin-settings-tab",
     template: require("./origin-settings-tab.component.html")
 })
 

--- a/components/builder-web/app/reducers/origins.ts
+++ b/components/builder-web/app/reducers/origins.ts
@@ -19,6 +19,9 @@ import { Origin } from "../records/Origin";
 
 export default function origins(state = initialState["origins"], action) {
     switch (action.type) {
+        case actionTypes.CLEAR_DOCKER_INTEGRATIONS:
+            return state.setIn(["currentIntegrations", "docker"], List());
+
         case actionTypes.POPULATE_MY_ORIGINS:
             if (action.error) {
                 return state.setIn(["mine"], List()).
@@ -43,7 +46,6 @@ export default function origins(state = initialState["origins"], action) {
                 return state;
             }
 
-
         case actionTypes.POPULATE_MY_ORIGIN_INVITATIONS:
             return state.setIn(["myInvitations"],
                 List(action.payload));
@@ -56,9 +58,12 @@ export default function origins(state = initialState["origins"], action) {
             return state.setIn(["currentMembers"],
                 List(action.payload));
 
-        case actionTypes.POPULATE_ORIGIN_INTEGRATIONS:
-            return state.setIn(["currentIntegrations"],
-                List(action.payload));
+        case actionTypes.POPULATE_ORIGIN_DOCKER_INTEGRATIONS:
+            if (action.error) {
+                return state.setIn(["currentIntegrations", "docker"], List());
+            } else {
+                return state.setIn(["currentIntegrations", "docker"], List(action.payload.names));
+            }
 
         case actionTypes.POPULATE_ORIGIN_PUBLIC_KEYS:
             if (action.error) {


### PR DESCRIPTION
When a Docker integration exists for a given origin, this change shows it on the Integrations tab and allows it to be deleted. Also cleans up some whitespace. 

Fixes #3368.

Signed-off-by: Christian Nunciato <cnunciato@chef.io>

![](https://media.tenor.com/images/b36971a8a4753d22040373718d323952/tenor.gif)

