### PR TITLE
Add nginx integration with Datadog on the API node

### DIFF
--- a/terraform/files/nginx.yaml
+++ b/terraform/files/nginx.yaml
@@ -1,0 +1,6 @@
+init_config:
+
+instances:
+  - nginx_status_url: http://localhost/nginx_status/
+    tags:
+      - instance:api

--- a/terraform/instances.tf
+++ b/terraform/instances.tf
@@ -59,6 +59,17 @@ resource "null_resource" "api_provision" {
     inline = [
       "DD_INSTALL_ONLY=true DD_API_KEY=${var.datadog_api_key} /bin/bash -c \"$(curl -L https://raw.githubusercontent.com/DataDog/dd-agent/master/packaging/datadog-agent/source/install_agent.sh)\"",
       "sudo sed -i \"$ a tags: env:${var.env}, role:api\" /etc/dd-agent/datadog.conf",
+    ]
+  }
+
+  provisioner "file" {
+    source = "${path.module}/files/nginx.yaml"
+    destination = "/tmp/nginx.yaml"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "sudo cp /tmp/nginx.yaml /etc/dd-agent/conf.d/nginx.yaml",
       "sudo /etc/init.d/datadog-agent start"
     ]
   }


### PR DESCRIPTION
Small change to add Nginx status integration to Datadog for the API node.  This will power the internal API dashboard.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-39817086](https://user-images.githubusercontent.com/13542112/30946966-dc905afe-a3bb-11e7-972e-adef77e0db7f.gif)
