### PR TITLE
Fix RouteClient socket state issue when routing to self

### DIFF
--- a/components/net/src/app/mod.rs
+++ b/components/net/src/app/mod.rs
@@ -295,11 +295,6 @@ where
                 ConnErr::Socket,
             )?;
         }
-        // Send REQ Socket addr
-        self.pipe_out.recv(&mut self.recv_buf, 0).unwrap();
-        self.router_sock.send(&self.recv_buf, zmq::SNDMORE).unwrap();
-        // Remove REQ's additional delimitter
-        self.pipe_out.recv(&mut self.recv_buf, 0).unwrap();
         proxy_message::<T>(
             &mut self.pipe_out,
             &mut self.router_sock,


### PR DESCRIPTION
Changes the REQ socket in RouteClient to a DEALER socket to allow
for unrestricted send/recv pattern. This is required when a server
is handling a message and then attempts to route a message within
it's handler to a server and the destination happens to be itself.

Also removed `route_async` from RouteClient. Now that the socket
state is no longer enforced by ZMQ itself, we can't ensure that
messages we receive are completions for a given transaction. We
will need to create a TXN-id, store pending transactions, and then
use the TXN-id to complete those stored transactions. This work
will need to be done a bit later.

![tenor-252153023](https://user-images.githubusercontent.com/54036/30990945-e91e9b86-a457-11e7-981e-ab72697bf43a.gif)
