### PR TITLE
[Builder] Drop `/v1` from `app_url` when building dev container.

### DIFF
--- a/support/builder/config.sh
+++ b/support/builder/config.sh
@@ -12,7 +12,7 @@ client_id = "$GITHUB_CLIENT_ID"
 client_secret = "$GITHUB_CLIENT_SECRET"
 
 [web]
-app_url          = "http://$APP_HOSTNAME/v1"
+app_url          = "http://$APP_HOSTNAME"
 community_url    = "https://www.habitat.sh/community"
 docs_url         = "https://www.habitat.sh/docs"
 environment      = "production"


### PR DESCRIPTION
I believe this was missed in #3239, or was merged afterwards--something like that. This is used when building the Builder development container.

@reset Does this look right to you?