### PR TITLE
[Builder] Update hab-entrypoint.sh so that Launcher is PID 1.

### DIFF
--- a/support/builder/hab-entrypoint.sh
+++ b/support/builder/hab-entrypoint.sh
@@ -5,4 +5,4 @@ SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
 
 /bin/hab term
 sleep 1
-/bin/hab "$@"
+exec /bin/hab "$@"


### PR DESCRIPTION
We need to `exec` the last line so this script becomes the Launcher
which lets it reap zombie processes.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>