### PR TITLE
[Builder] Run the development container in privileged mode.

### DIFF
--- a/BUILDER_CONTAINER.md
+++ b/BUILDER_CONTAINER.md
@@ -44,5 +44,5 @@ $ docker build --no-cache -f BLDR-Dockerfile --build-arg GITHUB_CLIENT_ID=02fb7d
 ## Running
 
 ```
-$ docker run -p 80:80 -p 443:443 -p 9631:9631 -p 9638:9638 habitat/builder
+$ docker run -p 80:80 -p 443:443 -p 9631:9631 -p 9638:9638 --privileged --name builder habitat/builder
 ```


### PR DESCRIPTION
This change is required for Studio builds to execute via the worker.

Adding a `--name` makes this container easier to resolve, meaning you
can run `docker exec -ti builder sh` to enter the container. Due to the
port mappings back to localhost, there can only be one Builder container
running anyway, so you may as well tack a nice name on it.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>