### PR TITLE
[tools] Add hab-channel-list-pkgs.sh.

### DIFF
--- a/tools/hab-channel-list-pkgs/README.md
+++ b/tools/hab-channel-list-pkgs/README.md
@@ -1,0 +1,20 @@
+## List All Packages in a Channel
+
+This is a a tool which will fetch all packages that are in an origin's channel across multiple paged API responses.
+
+### Usage
+
+The following command line tools are required and will be checked before running:
+
+* `curl`
+* `jq`
+
+To run:
+
+```sh
+hab-channel-list-pkgs.sh core unstable
+```
+
+A list of all fully qualified package identifiers that exist in the channel will be returned, printed to standard out, one entry per line.
+
+This program also honors the `HAB_BLDR_URL` environment variable and will default to the public Builder.

--- a/tools/hab-channel-list-pkgs/hab-channel-list-pkgs.sh
+++ b/tools/hab-channel-list-pkgs/hab-channel-list-pkgs.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+#
+# Returns a list of all fully qualified package identifiers that exist in an
+# origin's release channel. Prints the package identifiers to standard out, one
+# entry per line.
+#
+set -eu
+if [ -n "${DEBUG:-}" ]; then set -x; fi
+
+main() {
+  need_cmd curl
+  need_cmd jq
+
+  # Set the default Builder URL
+  : ${HAB_BLDR_URL:=https://bldr.habitat.sh}
+  # Origin name is required
+  origin="${1:-}"
+  if [[ -z "$origin" ]]; then
+    echo "Usage: $(basename $0) <ORIGIN> <CHANNEL>" >&2
+    exit 1
+  fi
+  shift
+  # Channel name is required
+  channel="${1:-}"
+  if [[ -z "$channel" ]]; then
+    echo "Usage: $(basename $0) <ORIGIN> <CHANNEL>" >&2
+    exit 1
+  fi
+  # Calculate the channel URL from which to fetch
+  url="$HAB_BLDR_URL/v1/depot/channels/$origin/$channel/pkgs"
+
+  # Determine the number of results per page
+  npp="$(curl -s "$url" | jq '.range_end - .range_start + 1')"
+
+  # Determine the number of pages to fetch. It sort of sucks that jq's `ceil`
+  # doesn't work...going to do this the hard way...
+  num_pages=$(curl -s "$url" \
+    | jq "if ((.total_count / $npp) - ((.total_count / $npp) | floor)) > 0 then
+          ((.total_count / $npp) | floor) + 1
+        else
+          ((.total_count / $npp) | floor)
+        end")
+
+  # Fetch each page and output a fully qualified package identifier, one per
+  # line
+  for (( n=0; n<$num_pages; n+=1 )) do
+    curl -s "${url}?range=$(( ${n}*${npp} ))" \
+      | jq --raw-output '.data[] | "\(.origin)/\(.name)/\(.version)/\(.release)"'
+  done
+}
+
+need_cmd() {
+  if ! command -v "$1" > /dev/null 2>&1; then
+    echo "Required command '$1' not found on PATH" >&2
+    exit 127
+  fi
+}
+
+main "$@" || exit 99


### PR DESCRIPTION
This is a a tool which will fetch all packages that are in a channel
across multiple paged API responses. A list of all fully qualified
package identifiers that exist in the channel will be returned, printed
to standard out, one entry per line.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>