### PR TITLE
[hab] Add Gradle Scaffolding support to `hab plan init`.

### DIFF
--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -335,7 +335,7 @@ pub fn get() -> App<'static, 'static> {
                 (@arg WITH_ALL: --("with-all")
                     "Generate omnibus plan with all available plan options")
                 (@arg SCAFFOLDING: --scaffolding -s +takes_value
-                    "Specify explicit scaffolding type for your app")
+                    "Specify explicit Scaffolding for your app (ex: node, ruby)")
             )
         )
         (@subcommand ring =>

--- a/components/hab/src/scaffolding.rs
+++ b/components/hab/src/scaffolding.rs
@@ -22,6 +22,10 @@ use hcore::crypto::init;
 use hcore::package::PackageIdent;
 use common::ui::{UI, Status};
 
+const SCAFFOLDING_GO_IDENT: &'static str = "core/scaffolding-go";
+const SCAFFOLDING_NODE_IDENT: &'static str = "core/scaffolding-node";
+const SCAFFOLDING_RUBY_IDENT: &'static str = "core/scaffolding-ruby";
+
 // Check to see if the --scaffolding passed matches available core scaffolding
 // If not check if we've been given a pkg ident for a custom scaffolding
 pub fn scaffold_check(ui: &mut UI, maybe_scaffold: Option<&str>) -> Result<Option<PackageIdent>> {
@@ -29,39 +33,32 @@ pub fn scaffold_check(ui: &mut UI, maybe_scaffold: Option<&str>) -> Result<Optio
         Some(scaffold) => {
             init();
             match scaffold.to_lowercase().as_ref() {
-                "core/scaffolding-ruby" |
-                "ruby" |
-                "rails" |
-                "ruby-scaffolding" => {
-                    let ident = PackageIdent::from_str("core/scaffolding-ruby").unwrap();
+                SCAFFOLDING_GO_IDENT |
+                "go" => {
+                    let ident = PackageIdent::from_str(SCAFFOLDING_GO_IDENT).unwrap();
                     ui.status(
                         Status::Using,
-                        &format!("ruby scaffolding '{}'", ident),
+                        &format!("Go Scaffolding '{}'", ident),
                     )?;
                     ui.para("")?;
                     Ok(Some(ident))
                 }
-                "core/scaffolding-go" |
-                "go" |
-                "golang" |
-                "go-scaffolding" => {
-                    let ident = PackageIdent::from_str("core/scaffolding-go").unwrap();
+                SCAFFOLDING_NODE_IDENT |
+                "node" => {
+                    let ident = PackageIdent::from_str(SCAFFOLDING_NODE_IDENT).unwrap();
                     ui.status(
                         Status::Using,
-                        &format!("go scaffolding '{}'", ident),
+                        &format!("Node Scaffolding '{}'", ident),
                     )?;
                     ui.para("")?;
                     Ok(Some(ident))
                 }
-                "core/scaffolding-node" |
-                "node" |
-                "node.js" |
-                "javascript" |
-                "js" => {
-                    let ident = PackageIdent::from_str("core/scaffolding-node").unwrap();
+                SCAFFOLDING_RUBY_IDENT |
+                "ruby" => {
+                    let ident = PackageIdent::from_str(SCAFFOLDING_RUBY_IDENT).unwrap();
                     ui.status(
                         Status::Using,
-                        &format!("node scaffolding '{}'", ident),
+                        &format!("Ruby Scaffolding '{}'", ident),
                     )?;
                     ui.para("")?;
                     Ok(Some(ident))
@@ -70,7 +67,7 @@ pub fn scaffold_check(ui: &mut UI, maybe_scaffold: Option<&str>) -> Result<Optio
                     let ident = PackageIdent::from_str(scaffold).unwrap();
                     ui.status(
                         Status::Using,
-                        &format!("custom scaffolding: '{}'", ident),
+                        &format!("custom Scaffolding: '{}'", ident),
                     )?;
                     ui.para("")?;
                     Ok(Some(ident))
@@ -79,10 +76,10 @@ pub fn scaffold_check(ui: &mut UI, maybe_scaffold: Option<&str>) -> Result<Optio
         }
         // If nothing was passed try to autodiscover the codebase
         // I'm not saying it's magic. But, MAGIC.
-        None => magic_function(ui),
+        None => autodiscover_scaffolding(ui),
     }
 }
-fn magic_function(ui: &mut UI) -> Result<Option<PackageIdent>> {
+fn autodiscover_scaffolding(ui: &mut UI) -> Result<Option<PackageIdent>> {
     // Determine if the current dir has an app that can use
     // one of our scaffoldings and use it by default
     ui.begin("Attempting autodiscovery ")?;
@@ -91,30 +88,30 @@ fn magic_function(ui: &mut UI) -> Result<Option<PackageIdent>> {
         what kind of application you're planning to package.",
     )?;
     let current_path = Path::new(".");
-    if is_project_ruby(&current_path) {
-        let ident = PackageIdent::from_str("core/scaffolding-ruby").unwrap();
-        ui.begin("We've detected your app as Ruby")?;
+    if is_project_go(&current_path) {
+        let ident = PackageIdent::from_str(SCAFFOLDING_GO_IDENT).unwrap();
+        ui.begin("We've detected a Go codebase")?;
         ui.status(
             Status::Using,
-            &format!("scaffolding package: '{}'", ident),
-        )?;
-        ui.para("")?;
-        Ok(Some(ident))
-    } else if is_project_golang(&current_path) {
-        let ident = PackageIdent::from_str("core/scaffolding-go").unwrap();
-        ui.begin("We've detected your app as Golang")?;
-        ui.status(
-            Status::Using,
-            &format!("scaffolding package: '{}'", ident),
+            &format!("Scaffolding package: '{}'", ident),
         )?;
         ui.para("")?;
         Ok(Some(ident))
     } else if is_project_node(&current_path) {
-        let ident = PackageIdent::from_str("core/scaffolding-node").unwrap();
-        ui.begin("We've detected your app as Node.js")?;
+        let ident = PackageIdent::from_str(SCAFFOLDING_NODE_IDENT).unwrap();
+        ui.begin("We've detected a Node.js codebase")?;
         ui.status(
             Status::Using,
-            &format!("scaffolding package: '{}'", ident),
+            &format!("Scaffolding package: '{}'", ident),
+        )?;
+        ui.para("")?;
+        Ok(Some(ident))
+    } else if is_project_ruby(&current_path) {
+        let ident = PackageIdent::from_str(SCAFFOLDING_RUBY_IDENT).unwrap();
+        ui.begin("We've detected a Ruby codebase")?;
+        ui.status(
+            Status::Using,
+            &format!("Scaffolding package: '{}'", ident),
         )?;
         ui.para("")?;
         Ok(Some(ident))
@@ -123,25 +120,15 @@ fn magic_function(ui: &mut UI) -> Result<Option<PackageIdent>> {
             "Unable to determine the type of app in your current directory",
         )?;
         ui.para(
-            "For now, we'll generate a plan with all of the available plan options and callbacks. \
-            For more documentation on plan options try passing --withdocs or visit \
-            https://www.habitat.sh/docs/reference/plan-syntax/",
+            "For now, we'll generate a plan with all of the available plan variables and build \
+            phase callbacks. For more documentation on plan options try passing --withdocs \
+            or visit https://www.habitat.sh/docs/reference/plan-syntax/",
         )?;
         Ok(None)
     }
 }
 
-fn is_project_ruby<T>(path: T) -> bool
-where
-    T: AsRef<Path>,
-{
-    if path.as_ref().join("Gemfile").is_file() {
-        return true;
-    }
-    return false;
-}
-
-fn is_project_golang<T>(path: T) -> bool
+fn is_project_go<T>(path: T) -> bool
 where
     T: AsRef<Path>,
 {
@@ -161,6 +148,16 @@ where
     T: AsRef<Path>,
 {
     if path.as_ref().join("package.json").is_file() {
+        return true;
+    }
+    return false;
+}
+
+fn is_project_ruby<T>(path: T) -> bool
+where
+    T: AsRef<Path>,
+{
+    if path.as_ref().join("Gemfile").is_file() {
         return true;
     }
     return false;

--- a/components/hab/src/scaffolding.rs
+++ b/components/hab/src/scaffolding.rs
@@ -23,6 +23,7 @@ use hcore::package::PackageIdent;
 use common::ui::{UI, Status};
 
 const SCAFFOLDING_GO_IDENT: &'static str = "core/scaffolding-go";
+const SCAFFOLDING_GRADLE_IDENT: &'static str = "core/scaffolding-gradle";
 const SCAFFOLDING_NODE_IDENT: &'static str = "core/scaffolding-node";
 const SCAFFOLDING_RUBY_IDENT: &'static str = "core/scaffolding-ruby";
 
@@ -39,6 +40,16 @@ pub fn scaffold_check(ui: &mut UI, maybe_scaffold: Option<&str>) -> Result<Optio
                     ui.status(
                         Status::Using,
                         &format!("Go Scaffolding '{}'", ident),
+                    )?;
+                    ui.para("")?;
+                    Ok(Some(ident))
+                }
+                SCAFFOLDING_GRADLE_IDENT |
+                "gradle" => {
+                    let ident = PackageIdent::from_str(SCAFFOLDING_GRADLE_IDENT).unwrap();
+                    ui.status(
+                        Status::Using,
+                        &format!("Gradle Scaffolding '{}'", ident),
                     )?;
                     ui.para("")?;
                     Ok(Some(ident))
@@ -97,6 +108,15 @@ fn autodiscover_scaffolding(ui: &mut UI) -> Result<Option<PackageIdent>> {
         )?;
         ui.para("")?;
         Ok(Some(ident))
+    } else if is_project_gradle(&current_path) {
+        let ident = PackageIdent::from_str(SCAFFOLDING_GRADLE_IDENT).unwrap();
+        ui.begin("We've detected a Gradle codebase")?;
+        ui.status(
+            Status::Using,
+            &format!("Scaffolding package: '{}'", ident),
+        )?;
+        ui.para("")?;
+        Ok(Some(ident))
     } else if is_project_node(&current_path) {
         let ident = PackageIdent::from_str(SCAFFOLDING_NODE_IDENT).unwrap();
         ui.begin("We've detected a Node.js codebase")?;
@@ -137,6 +157,18 @@ where
         path.as_ref().join("vendor/vendor.json").is_file() ||
         path.as_ref().join("glide.yaml").is_file() ||
         project_uses_gb(path.as_ref()).expect("Result<bool> not returned from .go file check")
+    {
+        return true;
+    }
+    return false;
+}
+
+fn is_project_gradle<T>(path: T) -> bool
+where
+    T: AsRef<Path>,
+{
+    if path.as_ref().join("build.gradle").is_file() ||
+        path.as_ref().join("settings.gradle").is_file()
     {
         return true;
     }


### PR DESCRIPTION
This change adds support in `hab plan init` for the [Gradle Scaffolding](https://github.com/habitat-sh/core-plans/tree/master/scaffolding-gradle).

Additionally, there are some light refactorings in the Scaffolding detection logic with an eye to adding more in the future:

* Lexically sort the Scaffolding types in `match` arms, detection order, and detection functions. This should help a future contributor to know where to put things and should help maintainers when scanning through the module.
* Drop extra scaffolding name matches other than the package identifier and the canonical name (i.e. "ruby", "node", etc.). It is hard to tell if some of the alternate scaffolding matching words might become full fledged Scaffoldings in the future. To avoid collisions such as these, it seems safer to have fewer matches. Additionally, with autodetection, it's less likely that a user would call the explicit `--scaffolding` option on the command line.
* Uppercase some words for consistency.