### PR TITLE
[builder-worker] Remove unused `[datastore]` from `config.toml`.

### DIFF
--- a/components/builder-worker/habitat/config/config.toml
+++ b/components/builder-worker/habitat/config/config.toml
@@ -10,9 +10,3 @@ host = "{{member.sys.ip}}"
 port = {{member.cfg.worker_port}}
 heartbeat = {{member.cfg.worker_heartbeat}}
 {{~/eachAlive}}
-
-{{~#eachAlive bind.datastore.members as |member|}}
-[datastore]
-host = "{{member.sys.ip}}"
-port = {{member.cfg.port}}
-{{~/eachAlive}}


### PR DESCRIPTION
As far as I can tell, this entry is not being used, and worse, there is
no required or optional `datastore` binding meaning that the `eachAlive`
will never contain members.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>