### PR TITLE
Temporarily use old & new forms of `hab pkg binlink`.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -187,7 +187,7 @@ bundle: image ## build the changelog
 
 changelog: image ## build the changelog
 	$(run) sh -c 'hab pkg install core/github_changelog_generator && \
-		hab pkg binlink core/github_changelog_generator github_changelog_generator && \
+		hab pkg binlink core/github_changelog_generator github_changelog_generator --force && \
 		github_changelog_generator --future-release $(VERSION) --token $(GITHUB_TOKEN)'
 
 docs: image ## build the docs

--- a/components/hab/install.sh
+++ b/components/hab/install.sh
@@ -263,7 +263,14 @@ install_hab() {
       info "Installing Habitat package using temporarily downloaded hab"
       # Install hab release using the extracted version and add/update symlink
       "${archive_dir}/hab" install "$_ident"
-      "${archive_dir}/hab" pkg binlink "$_ident" hab
+      # TODO fn: The updated binlink behavior is to skip targets that already
+      # exist so we want to use the `--force` flag. Unfortunetly, old versions
+      # of `hab` don't have this flag. For now, we'll run with the new flag and
+      # fall back to running the older behavior. This can be removed at a
+      # future date when we no lnger are worrying about Habitat versions 0.33.2
+      # and older. (2017-09-29)
+      "${archive_dir}/hab" pkg binlink "$_ident" hab --force \
+        || "${archive_dir}/hab" pkg binlink "$_ident" hab
       ;;
     *)
       exit_with "Unrecognized sys when installing: ${sys}" 5

--- a/terraform/scripts/install_base_packages.sh
+++ b/terraform/scripts/install_base_packages.sh
@@ -122,4 +122,11 @@ done
 
 # Now we ensure that the hab binary being used on the system is the
 # one that we just installed.
-${hab_bootstrap_bin} pkg binlink core/hab hab
+#
+# TODO fn: The updated binlink behavior is to skip targets that already exist
+# so we want to use the `--force` flag. Unfortunetly, old versions of `hab`
+# don't have this flag. For now, we'll run with the new flag and fall back to
+# running the older behavior. This can be removed at a future date when we no
+# lnger are worrying about Habitat versions 0.33.2 and older. (2017-09-29)
+${hab_bootstrap_bin} pkg binlink core/hab hab --force \
+  || ${hab_bootstrap_bin} pkg binlink core/hab hab


### PR DESCRIPTION
This change calls the old behavior (to force override existing targets)
and the new behavior (an explicit force behavior via flag) in a couple
parts of the codebase. The temporary fixes can be removed after a short
period has elapsed when versions of Habitat 0.33.2 and older are
considered "really old".

Note that in the places we're updating, we expect that the binlink target is updated, especially in installation scripts. Otherwise with the new behavior, the command will warn, not overwrite the target and a system would continue calling the previous version of `hab`.

Closes #3323

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>