### PR TITLE
Allow scheduler to build projects that are not known to the graph

### DIFF
--- a/components/builder-scheduler/src/server/handlers.rs
+++ b/components/builder-scheduler/src/server/handlers.rs
@@ -65,10 +65,10 @@ pub fn group_create(
         let ret = match graph.resolve(&project_name) {
             Some(s) => s,
             None => {
-                warn!("GroupCreate, project ident not found");
-                let err = NetError::new(ErrCode::ENTITY_NOT_FOUND, "sc:group-create:3");
-                conn.route_reply(req, &*err)?;
-                return Ok(());
+                warn!("GroupCreate, project ident not found for {}", project_name);
+                // If a package has never been uploaded, we won't see it in the graph
+                // Carry on with stiff upper lip
+                String::from("")
             }
         };
         end_time = PreciseTime::now();

--- a/components/builder-scheduler/src/server/scheduler.rs
+++ b/components/builder-scheduler/src/server/scheduler.rs
@@ -241,20 +241,25 @@ impl ScheduleMgr {
         {
             // Check the deps for the project. If we don't find any dep that
             // is in our project list and needs to be built, we can dispatch the project.
-            let package = self.datastore.get_package(&project.get_ident())?;
-            let deps = package.get_deps();
+            let dispatchable = if project.get_ident().is_empty() {
+                true
+            } else {
+                let mut check_status = true;
+                let package = self.datastore.get_package(&project.get_ident())?;
+                let deps = package.get_deps();
 
-            let mut dispatchable = true;
-            for dep in deps {
-                let parts: Vec<&str> = dep.split("/").collect();
-                assert!(parts.len() >= 2);
-                let name = format!("{}/{}", parts[0], parts[1]);
+                for dep in deps {
+                    let parts: Vec<&str> = dep.split("/").collect();
+                    assert!(parts.len() >= 2);
+                    let name = format!("{}/{}", parts[0], parts[1]);
 
-                if !self.check_dispatchable(group, &name) {
-                    dispatchable = false;
-                    break;
-                };
-            }
+                    if !self.check_dispatchable(group, &name) {
+                        check_status = false;
+                        break;
+                    };
+                }
+                check_status
+            };
 
             if dispatchable {
                 projects.push(project.clone());


### PR DESCRIPTION
Currently the scheduler only builds packages if the ident is present in the graph. If no package for the project has ever been uploaded, the graph does not know about it. This change allows for building brand new packages via the scheduler.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-138926799](https://user-images.githubusercontent.com/13542112/31040685-0726b518-a53f-11e7-899a-f9ba6c245e12.gif)
