### PR TITLE
Make origin secret key fetch work again

### DIFF
--- a/components/builder-http-gateway/src/http/middleware.rs
+++ b/components/builder-http-gateway/src/http/middleware.rs
@@ -196,9 +196,9 @@ impl AfterMiddleware for Cors {
         res.headers.set(headers::AccessControlAllowMethods(
             vec![Method::Put, Method::Delete],
         ));
-        res.headers.set(headers::AccessControlExposeHeaders(vec![
-            UniCase("content-disposition".to_string()),
-        ]));
+        res.headers.set(headers::AccessControlExposeHeaders(
+            vec![UniCase("content-disposition".to_string())],
+        ));
         Ok(res)
     }
 }

--- a/components/builder-worker/src/runner/mod.rs
+++ b/components/builder-worker/src/runner/mod.rs
@@ -195,6 +195,7 @@ impl Runner {
                 self.depot_cli.fetch_origin_secret_key(
                     self.job().origin(),
                     &self.config.auth_token,
+                    &crypto::default_cache_key_path(None),
                 )
             },
             |res| {
@@ -205,23 +206,7 @@ impl Runner {
             },
         ) {
             Ok(res) => {
-                let cache = crypto::default_cache_key_path(None);
-                let key = res.unwrap(); // Ok to unwrap, we know it is a success
-                let s: String = String::from_utf8(key.body).expect("Found invalid UTF-8");
-
-                match crypto::SigKeyPair::write_file_from_str(&s, &cache) {
-                    Ok((pair, pair_type)) => {
-                        debug!(
-                            "Imported {} origin key {}.",
-                            &pair_type,
-                            &pair.name_with_rev()
-                        );
-                    }
-                    Err(err) => {
-                        error!("Unable to import secret key, err={}", err);
-                        return self.fail(net::err(ErrCode::SECRET_KEY_IMPORT, "wk:run:2"));
-                    }
-                }
+                debug!("Imported origin secret key to {:?}.", res.unwrap());
             }
             Err(_) => {
                 let msg = format!("Unable to retrieve secret key after {} retries", RETRIES);


### PR DESCRIPTION
The API for origin secret key fetch changed to send a file instead of bytes, and the worker needs to be updated to use the new API protocol.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-188032781](https://user-images.githubusercontent.com/13542112/31042252-857d76d6-a558-11e7-821b-c16d5b27de0e.gif)
