### PR TITLE
Don't print UI messages from updater threads

### DIFF
--- a/components/sup/src/manager/self_updater.rs
+++ b/components/sup/src/manager/self_updater.rs
@@ -22,7 +22,7 @@ use std::time::Duration;
 use time::{SteadyTime, Duration as TimeDuration};
 
 use common::command::package::install::InstallSource;
-use common::ui::{Coloring, UI};
+use common::ui::UI;
 use env;
 use hcore::package::{PackageIdent, PackageInstall};
 use util;
@@ -80,7 +80,8 @@ impl SelfUpdater {
             let next_check = SteadyTime::now() + TimeDuration::milliseconds(update_frequency());
 
             match util::pkg::install(
-                &mut UI::default_with(Coloring::Never, None),
+                // We don't want anything in here to print
+                &mut UI::with_sinks(),
                 &builder_url,
                 &install_source,
                 &channel,

--- a/components/sup/src/manager/service_updater.rs
+++ b/components/sup/src/manager/service_updater.rs
@@ -17,7 +17,7 @@ use std::sync::mpsc::{sync_channel, Receiver, SyncSender, TryRecvError};
 use std::thread;
 
 use butterfly;
-use common::ui::{Coloring, UI};
+use common::ui::UI;
 use env;
 use hcore::package::{PackageIdent, PackageInstall};
 use hcore::service::ServiceGroup;
@@ -302,7 +302,6 @@ struct Worker {
     spec_ident: PackageIdent,
     builder_url: String,
     channel: String,
-    ui: UI,
 }
 
 impl Periodic for Worker {
@@ -337,7 +336,6 @@ impl Worker {
             spec_ident: service.spec_ident.clone(),
             builder_url: service.bldr_url.clone(),
             channel: service.channel.clone(),
-            ui: UI::default_with(Coloring::Never, None),
         }
     }
 
@@ -390,7 +388,8 @@ impl Worker {
             let next_time = self.next_period_start();
 
             match util::pkg::install(
-                &mut self.ui,
+                // We don't want anything in here to print
+                &mut UI::with_sinks(),
                 &self.builder_url,
                 &install_source,
                 &self.channel,
@@ -415,7 +414,8 @@ impl Worker {
             let next_time = self.next_period_start();
 
             match util::pkg::install(
-                &mut self.ui,
+                // We don't want anything in here to print
+                &mut UI::with_sinks(),
                 &self.builder_url,
                 &install_source,
                 &self.channel,


### PR DESCRIPTION
We don't want to spam our supervsor logs with meaningless messages
about checking for updates and installing nothing every minute. Here,
we pass what are effectively no-op `UI` objects (their output
effectively goes to `/dev/null`).

Signed-off-by: Christopher Maier <cmaier@chef.io>

![tenor-45516043](https://user-images.githubusercontent.com/207178/31042435-ffba44c0-a575-11e7-8e24-10fe3668bb7e.gif)