### PR TITLE
[jobsrv] Export `log_port` for discovery by workers.

### DIFF
--- a/components/builder-jobsrv/habitat/plan.sh
+++ b/components/builder-jobsrv/habitat/plan.sh
@@ -11,8 +11,9 @@ pkg_build_deps=(core/protobuf core/protobuf-rust core/coreutils core/cacerts
 pkg_exports=(
   [worker_port]=net.worker_command_port
   [worker_heartbeat]=net.worker_heartbeat_port
+  [log_port]=net.log_ingestion_port
 )
-pkg_exposes=(worker_port worker_heartbeat)
+pkg_exposes=(worker_port worker_heartbeat log_port)
 pkg_binds=(
   [router]="port"
   [datastore]="port"

--- a/components/builder-worker/habitat/config/config.toml
+++ b/components/builder-worker/habitat/config/config.toml
@@ -9,4 +9,5 @@ bldr_url = "{{bind.depot.first.cfg.url}}"
 host = "{{member.sys.ip}}"
 port = {{member.cfg.worker_port}}
 heartbeat = {{member.cfg.worker_heartbeat}}
+log_port = {{member.cfg.log_port}}
 {{~/eachAlive}}

--- a/components/builder-worker/habitat/plan.sh
+++ b/components/builder-worker/habitat/plan.sh
@@ -11,7 +11,7 @@ pkg_build_deps=(core/make core/cmake core/protobuf core/protobuf-rust core/coreu
 pkg_svc_user="root"
 pkg_svc_group="root"
 pkg_binds=(
-  [jobsrv]="worker_port worker_heartbeat"
+  [jobsrv]="worker_port worker_heartbeat log_port"
   [depot]="url"
 )
 bin="bldr-worker"

--- a/components/builder-worker/src/config.rs
+++ b/components/builder-worker/src/config.rs
@@ -111,6 +111,7 @@ mod tests {
         host = "1:1:1:1:1:1:1:1"
         port = 9000
         heartbeat = 9001
+        log_port = 9021
 
         [[jobsrv]]
         host = "2.2.2.2"
@@ -124,6 +125,7 @@ mod tests {
         assert_eq!(&format!("{}", config.jobsrv[0].host), "1:1:1:1:1:1:1:1");
         assert_eq!(config.jobsrv[0].port, 9000);
         assert_eq!(config.jobsrv[0].heartbeat, 9001);
+        assert_eq!(config.jobsrv[0].log_port, 9021);
         assert_eq!(&format!("{}", config.jobsrv[1].host), "2.2.2.2");
         assert_eq!(config.jobsrv[1].port, 9000);
         assert_eq!(config.jobsrv[1].heartbeat, 5567);


### PR DESCRIPTION
It appears that we were missing the jobsrv's worker log ingestion port as exported config which allows workers to update if this port number changes from its default. This change would require both `builder-jobsrv` and `builder-worker` to be built and deployed together.