### PR TITLE
[sup] Install a package only if missing for `start` & `load`.

### DIFF
--- a/components/sup/src/util/pkg.rs
+++ b/components/sup/src/util/pkg.rs
@@ -18,7 +18,7 @@ use common;
 use common::command::package::install::InstallSource;
 use common::ui::UI;
 use hcore::fs::{self, FS_ROOT_PATH};
-use hcore::package::PackageInstall;
+use hcore::package::{PackageIdent, PackageInstall};
 
 use {PRODUCT, VERSION};
 use error::{Result, SupError};
@@ -47,4 +47,10 @@ pub fn install(
         fs_root_path,
         &fs::cache_artifact_path(None::<String>),
     ).map_err(SupError::from)
+}
+
+/// Returns an installed package for the given ident, if one is present.
+pub fn installed(ident: &PackageIdent) -> Option<PackageInstall> {
+    let fs_root_path = Path::new(&*FS_ROOT_PATH);
+    PackageInstall::load(ident, Some(fs_root_path)).ok()
 }

--- a/test/integration/service-upgrade.bats
+++ b/test/integration/service-upgrade.bats
@@ -41,7 +41,11 @@ teardown() {
     run ${hab} svc load --strategy=at-once --force core/redis
     assert_success
 
+    # The first restart is due to the service reloading via `--force`
     wait_for_service_to_restart redis "${initial_pid}"
+    reloaded_pid=$(pid_of_service redis)
+
+    wait_for_service_to_restart redis "${reloaded_pid}"
     updated_running_version=$(current_running_version_for redis)
 
     # Since the latest version of Redis will change as time goes on,

--- a/test/integration/svc-load.bats
+++ b/test/integration/svc-load.bats
@@ -35,6 +35,19 @@ setup() {
     assert_spec_exists_for redis
 }
 
+@test "load a service loads from installed package" {
+    desired_version="core/redis/3.2.3/20160920131015"
+    # Pre-install this older package. Loading the service should not cause a
+    # newer package to be installed.
+    run ${hab} pkg install "${desired_version}"
+
+    run ${hab} svc load "core/redis"
+    assert_success
+
+    assert_package_and_deps_installed "${desired_version}"
+    assert_spec_exists_for redis
+}
+
 @test "CANNOT load a service from hart file" {
     # First, grab a hart file!
     desired_version="core/redis/3.2.4/20170514150022"

--- a/test/integration/svc-start.bats
+++ b/test/integration/svc-start.bats
@@ -37,6 +37,18 @@ teardown() {
     assert_service_running "${desired_version}"
 }
 
+@test "start a service: pre-installed" {
+    desired_version="core/redis/3.2.3/20160920131015"
+    # Pre-install this older package. Starting the service should not cause a
+    # newer package to be installed.
+    run ${hab} pkg install "${desired_version}"
+    background ${hab} svc start "core/redis"
+    wait_for_service_to_run redis
+
+    assert_package_and_deps_installed "${desired_version}"
+    assert_service_running "${desired_version}"
+}
+
 @test "CAN start a service from hart file" {
     desired_version="core/redis/3.2.4/20170514150022"
 


### PR DESCRIPTION
This resolves an issue in `hab-sup start` and `hab-sup load` where the
Supervisor was unconditionally attempting to install a package saving
the Service spec. Without an explicit update strategy, the Supervisor
should find an load the latest version of an installed package on disk.
Otherwise, newer releases of a package will be download and installed
whenever a new candidate is present in the Builder API.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>