### PR TITLE
Process GitHub Push Hook notifications

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,7 +174,7 @@ dependencies = [
  "serde_derive 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "staticfile 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "urlencoded 0.5.0 (git+https://github.com/iron/urlencoded)",
  "zmq 0.8.2 (git+https://github.com/erickt/rust-zmq?branch=release/v0.8)",
@@ -187,6 +187,7 @@ dependencies = [
  "base64 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy 0.0.144 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat-builder-protocol 0.0.0",
  "habitat_core 0.0.0",
  "habitat_net 0.0.0",
@@ -200,6 +201,7 @@ dependencies = [
  "serde_json 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "statsd 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1237,6 +1239,7 @@ dependencies = [
 name = "habitat_net"
 version = "0.0.0"
 dependencies = [
+ "base64 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy 0.0.144 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat-builder-protocol 0.0.0",
@@ -2543,7 +2546,6 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/bldr.toml
+++ b/bldr.toml
@@ -1,0 +1,138 @@
+[builder-admin-proxy]
+paths = ["components/builder-admin-proxy/*"]
+
+[builder-admin]
+paths = [
+  "components/builder-admin/*",
+  "components/builder-http-gateway/*",
+  "components/builder-protocol/*",
+  "components/core/*",
+  "components/github-api-client/*",
+  "components/net/*",
+]
+
+[builder-api-proxy]
+paths = ["components/builder-api-proxy/*"]
+
+[builder-api]
+paths = [
+  "components/builder-api/*",
+  "components/builder-core/*",
+  "components/builder-depot/*",
+  "components/builder-http-gateway/*",
+  "components/builder-protocol/*",
+  "components/core/*",
+  "components/github-api-client/*",
+  "components/net/*",
+]
+
+[builder-datastore]
+paths = [
+  "components/builder-datastore"
+]
+
+[builder-jobsrv]
+paths = [
+  "components/builder-jobsrv/*",
+  "components/builder-core/*",
+  "components/builder-protocol/*",
+  "components/builder-db/*",
+  "components/core/*",
+  "components/net/*",
+]
+
+[builder-originsrv]
+paths = [
+  "components/builder-originsrv/*",
+  "components/builder-protocol/*",
+  "components/builder-db/*",
+  "components/core/*",
+  "components/net/*",
+]
+
+[builder-router]
+paths = [
+  "components/builder-router/*",
+  "components/builder-protocol/*",
+  "components/core/*",
+  "components/net/*",
+]
+
+[builder-scheduler]
+paths = [
+  "components/builder-scheduler/*",
+  "components/builder-core/*",
+  "components/builder-protocol/*",
+  "components/builder-db/*",
+  "components/core/*",
+  "components/net/*",
+]
+
+[builder-sessionsrv]
+paths = [
+  "components/builder-sessionsrv/*",
+  "components/builder-protocol/*",
+  "components/builder-db/*",
+  "components/core/*",
+  "components/github-api-client/*",
+  "components/net/*",
+]
+
+[builder-worker]
+paths = [
+  "components/builder-worker/*",
+  "components/builder-core/*",
+  "components/builder-depot-client/*",
+  "components/builder-protocol/*",
+  "components/core/*",
+  "components/github-api-client/*",
+  "components/net/*",
+]
+
+[hab]
+paths = [
+  "components/hab/*",
+  "components/builder-api-client/*",
+  "components/builder-depot-client/*",
+  "components/common/*",
+  "components/core/*",
+  "components/http-client/*",
+]
+
+[hab-backline]
+paths = ["components/backline/*"]
+
+[hab-bintray-publish]
+paths = ["components/hab-bintray-publish/*"]
+
+[hab-butterfly]
+paths = [
+  "components/hab-butterfly/*",
+  "components/butterfly/*",
+  "components/common/*",
+  "components/core/*",
+  "components/hab/*",
+]
+
+[hab-eventsrv]
+paths = [
+  "components/eventsrv/*",
+  "components/eventsrv-protocol/*",
+  "components/core/*",
+]
+
+[hab-launcher]
+paths = [
+  "components/launcher/*",
+  "components/launcher-protocol/*",
+]
+
+[hab-sup]
+paths = [
+  "components/sup/*",
+  "components/eventsrv-client/*",
+  "components/launcher-client/*",
+  "components/butterfly/*",
+  "components/core/*",
+  "components/builder-depot-client/*",
+]

--- a/components/builder-admin/src/config.rs
+++ b/components/builder-admin/src/config.rs
@@ -17,7 +17,6 @@
 use std::io;
 use std::net::{Ipv4Addr, IpAddr, SocketAddr, ToSocketAddrs};
 use std::option::IntoIter;
-use std::path::PathBuf;
 
 use http_gateway::config::prelude::*;
 
@@ -34,32 +33,6 @@ pub struct Config {
 
 impl ConfigFile for Config {
     type Error = Error;
-}
-
-impl GitHubOAuth for Config {
-    fn github_url(&self) -> &str {
-        &self.github.url
-    }
-
-    fn github_web_url(&self) -> &str {
-        &self.github.web_url
-    }
-
-    fn github_client_id(&self) -> &str {
-        &self.github.client_id
-    }
-
-    fn github_client_secret(&self) -> &str {
-        &self.github.client_secret
-    }
-
-    fn github_app_id(&self) -> u64 {
-        self.github.app_id
-    }
-
-    fn github_app_private_key_path(&self) -> PathBuf {
-        self.github.app_private_key_path.clone()
-    }
 }
 
 impl GatewayCfg for Config {

--- a/components/builder-admin/src/server/mod.rs
+++ b/components/builder-admin/src/server/mod.rs
@@ -35,7 +35,7 @@ impl HttpGateway for AdminSrv {
 
     fn add_middleware(config: Arc<Self::Config>, chain: &mut iron::Chain) {
         chain.link(persistent::Read::<GitHubCli>::both(
-            GitHubClient::new(&*config),
+            GitHubClient::new(config.github.clone()),
         ));
     }
 
@@ -50,7 +50,7 @@ impl HttpGateway for AdminSrv {
     }
 
     fn router(config: Arc<Self::Config>) -> Router {
-        let admin = Authenticated::new(&*config).require(privilege::ADMIN);
+        let admin = Authenticated::new(config.github.clone()).require(privilege::ADMIN);
         router!(
             status: get "/status" => status,
             search: post "/search" => XHandler::new(search).before(admin.clone()),

--- a/components/builder-api/src/config.rs
+++ b/components/builder-api/src/config.rs
@@ -18,7 +18,6 @@ use std::env;
 use std::io;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr, ToSocketAddrs};
 use std::option::IntoIter;
-use std::path::PathBuf;
 
 use http_gateway::config::prelude::*;
 use depot;
@@ -60,32 +59,6 @@ impl Default for Config {
 
 impl ConfigFile for Config {
     type Error = Error;
-}
-
-impl GitHubOAuth for Config {
-    fn github_url(&self) -> &str {
-        &self.github.url
-    }
-
-    fn github_web_url(&self) -> &str {
-        &self.github.web_url
-    }
-
-    fn github_client_id(&self) -> &str {
-        &self.github.client_id
-    }
-
-    fn github_client_secret(&self) -> &str {
-        &self.github.client_secret
-    }
-
-    fn github_app_id(&self) -> u64 {
-        self.github.app_id
-    }
-
-    fn github_app_private_key_path(&self) -> PathBuf {
-        self.github.app_private_key_path.clone()
-    }
 }
 
 impl GatewayCfg for Config {

--- a/components/builder-api/src/error.rs
+++ b/components/builder-api/src/error.rs
@@ -34,6 +34,7 @@ pub enum Error {
     IO(io::Error),
     NetError(hab_net::NetError),
     Protobuf(protobuf::ProtobufError),
+    UnknownGitHubEvent(String),
     Zmq(zmq::Error),
 }
 
@@ -50,6 +51,9 @@ impl fmt::Display for Error {
             Error::IO(ref e) => format!("{}", e),
             Error::NetError(ref e) => format!("{}", e),
             Error::Protobuf(ref e) => format!("{}", e),
+            Error::UnknownGitHubEvent(ref e) => {
+                format!("Unknown or unsupported GitHub event, {}", e)
+            }
             Error::Zmq(ref e) => format!("{}", e),
         };
         write!(f, "{}", msg)
@@ -67,6 +71,9 @@ impl error::Error for Error {
             Error::IO(ref err) => err.description(),
             Error::NetError(ref err) => err.description(),
             Error::Protobuf(ref err) => err.description(),
+            Error::UnknownGitHubEvent(_) => {
+                "Unknown or unsupported GitHub event received in request"
+            }
             Error::Zmq(ref err) => err.description(),
         }
     }

--- a/components/builder-api/src/github.rs
+++ b/components/builder-api/src/github.rs
@@ -1,0 +1,222 @@
+// Copyright (c) 2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::str::FromStr;
+
+use bodyparser;
+use bldr_core::build_config::{BLDR_CFG, BuildCfg};
+use github_api_client::GitHubClient;
+use hab_core::package::Plan;
+use http_gateway::http::controller::*;
+use iron::status;
+use persistent;
+use protocol::scheduler::{Group, GroupCreate};
+
+use error::Error;
+use headers::*;
+use types::*;
+
+pub enum GitHubEvent {
+    Push,
+    Ping,
+}
+
+impl FromStr for GitHubEvent {
+    type Err = Error;
+
+    fn from_str(event: &str) -> Result<Self, Self::Err> {
+        match event {
+            "ping" => Ok(GitHubEvent::Ping),
+            "push" => Ok(GitHubEvent::Push),
+            _ => Err(Error::UnknownGitHubEvent(event.to_string())),
+        }
+    }
+}
+
+enum HandleResult<T> {
+    Ok(T),
+    Err(Response),
+}
+
+pub fn handle_event(req: &mut Request) -> IronResult<Response> {
+    let event = match req.headers.get::<XGitHubEvent>() {
+        Some(&XGitHubEvent(ref event)) => {
+            match GitHubEvent::from_str(event) {
+                Ok(event) => event,
+                Err(err) => return Ok(Response::with((status::BadRequest, err.to_string()))),
+            }
+        }
+        _ => return Ok(Response::with(status::BadRequest)),
+    };
+    match event {
+        GitHubEvent::Ping => Ok(Response::with(status::Ok)),
+        GitHubEvent::Push => handle_push(req),
+    }
+}
+
+fn handle_push(req: &mut Request) -> IronResult<Response> {
+    // JW TODO: THIS NEEDS TO BE AUTHENTICATED
+    // use sender.login to get user ID to get account & see if they have access to origin
+    let hook = match req.get::<bodyparser::Struct<GitHubWebhookPush>>() {
+        Ok(Some(hook)) => hook,
+        Ok(None) => return Ok(Response::with(status::UnprocessableEntity)),
+        Err(err) => {
+            return Ok(Response::with(
+                (status::UnprocessableEntity, err.to_string()),
+            ));
+        }
+    };
+    let github = req.get::<persistent::Read<GitHubCli>>().unwrap();
+    let token = match github.app_installation_token(hook.installation.id) {
+        Ok(token) => token,
+        Err(err) => {
+            return Ok(Response::with((status::BadGateway, err.to_string())));
+        }
+    };
+    // JW TODO: Add searching for Windows plans (ps1) when Windows builders are completed
+    let plans = match github.search_file(&token, &hook.repository.full_name, "plan.sh") {
+        Ok(search) => search.items,
+        Err(err) => return Ok(Response::with((status::BadGateway, err.to_string()))),
+    };
+    if plans.is_empty() {
+        return Ok(Response::with(status::Ok));
+    }
+    let config = match github.search_file(&token, &hook.repository.full_name, &BLDR_CFG) {
+        Ok(search) => {
+            match search
+                .items
+                .into_iter()
+                .filter(|i| i.path == BLDR_CFG)
+                .collect::<Vec<SearchItem>>()
+                .pop() {
+                Some(item) => {
+                    match read_bldr_config(&*github, &token, &hook, &item.path) {
+                        HandleResult::Ok(cfg) => Some(cfg),
+                        HandleResult::Err(response) => return Ok(response),
+                    }
+                }
+                None => None,
+            }
+        }
+        Err(err) => return Ok(Response::with((status::BadGateway, err.to_string()))),
+    };
+    debug!("Config, {:?}", config);
+    let mut plans = match read_plans(&github, &token, &hook, plans) {
+        HandleResult::Ok(plans) => plans,
+        HandleResult::Err(err) => return Ok(err),
+    };
+    debug!("Plans, {:?}", plans);
+    if let Some(cfg) = config {
+        plans.retain(|plan| match cfg.get(&plan.name) {
+            Some(project) => hook.changed().iter().any(|f| project.triggered_by(f)),
+            None => false,
+        })
+    }
+    build_plans(req, plans)
+}
+
+fn build_plans(req: &mut Request, plans: Vec<Plan>) -> IronResult<Response> {
+    // JW TODO: Validate that this repository is where these plans belong. You could theoretically
+    // create a plan in a different repo and force a build of another piece of software without
+    // this check.
+    let mut request = GroupCreate::new();
+    for plan in plans.into_iter() {
+        debug!("Scheduling, {:?}", plan);
+        request.set_origin(plan.origin);
+        request.set_package(plan.name);
+        // JW TODO: We need to be able to determine which platform this build is for based on
+        // the directory structure the plan is found in or metadata inside the plan. We will need
+        // to have this done before we support building additional targets with Builder.
+        request.set_target("x86_64-linux".to_string());
+        match route_message::<GroupCreate, Group>(req, &request) {
+            Ok(group) => debug!("Group created, {:?}", group),
+            Err(err) => debug!("Failed to create group, {:?}", err),
+        }
+    }
+    Ok(Response::with(status::Ok))
+}
+
+fn read_bldr_config(
+    github: &GitHubClient,
+    token: &str,
+    hook: &GitHubWebhookPush,
+    path: &str,
+) -> HandleResult<BuildCfg> {
+    match github.contents(
+        token,
+        &hook.repository.organization,
+        &hook.repository.name,
+        path,
+    ) {
+        Ok(contents) => {
+            match contents.decode() {
+                Ok(ref bytes) => {
+                    match BuildCfg::from_slice(bytes) {
+                        Ok(cfg) => HandleResult::Ok(cfg),
+                        Err(err) => HandleResult::Err(Response::with(
+                            (status::UnprocessableEntity, err.to_string()),
+                        )),
+                    }
+                }
+                Err(err) => {
+                    HandleResult::Err(Response::with(
+                        (status::UnprocessableEntity, err.to_string()),
+                    ))
+                }
+            }
+        }
+        Err(err) => HandleResult::Err(Response::with((status::BadGateway, err.to_string()))),
+    }
+}
+
+fn read_plans(
+    github: &GitHubClient,
+    token: &str,
+    hook: &GitHubWebhookPush,
+    plans: Vec<SearchItem>,
+) -> HandleResult<Vec<Plan>> {
+    let mut parsed = Vec::with_capacity(plans.len());
+    for plan in plans {
+        match github.contents(
+            token,
+            &hook.repository.organization,
+            &hook.repository.name,
+            &plan.path,
+        ) {
+            Ok(contents) => {
+                match contents.decode() {
+                    Ok(bytes) => {
+                        match Plan::from_bytes(bytes.as_slice()) {
+                            Ok(plan) => parsed.push(plan),
+                            Err(err) => {
+                                return HandleResult::Err(Response::with(
+                                    (status::UnprocessableEntity, err.to_string()),
+                                ))
+                            }
+                        }
+                    }
+                    Err(err) => {
+                        return HandleResult::Err(Response::with(
+                            (status::UnprocessableEntity, err.to_string()),
+                        ))
+                    }
+                }
+            }
+            Err(err) => {
+                return HandleResult::Err(Response::with((status::BadGateway, err.to_string())))
+            }
+        }
+    }
+    HandleResult::Ok(parsed)
+}

--- a/components/builder-api/src/headers.rs
+++ b/components/builder-api/src/headers.rs
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub use std::net::{IpAddr, Ipv4Addr, SocketAddr, ToSocketAddrs};
-
-pub use super::GatewayCfg;
-pub use core::config::ConfigFile;
-pub use github_api_client::config::GitHubCfg;
-pub use hab_net::app::config::RouterAddr;
+header! { (XGitHubDelivery, "X-GitHub-Delivery") => [String] }
+header! { (XGitHubEvent, "X-GitHub-Event") => [String] }
+header! { (XHubSignature, "X-Hub-Signature") => [String] }

--- a/components/builder-api/src/lib.rs
+++ b/components/builder-api/src/lib.rs
@@ -25,6 +25,7 @@ extern crate habitat_builder_protocol as protocol;
 extern crate habitat_core as hab_core;
 extern crate habitat_depot as depot;
 extern crate habitat_net as hab_net;
+#[macro_use]
 extern crate hyper;
 extern crate iron;
 #[macro_use]
@@ -47,7 +48,10 @@ extern crate zmq;
 
 pub mod config;
 pub mod error;
+pub mod github;
+pub mod headers;
 pub mod server;
+mod types;
 
 pub use self::config::Config;
 pub use self::error::{Error, Result};

--- a/components/builder-api/src/types.rs
+++ b/components/builder-api/src/types.rs
@@ -12,9 +12,29 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub use std::net::{IpAddr, Ipv4Addr, SocketAddr, ToSocketAddrs};
+pub use github_api_client::types::*;
 
-pub use super::GatewayCfg;
-pub use core::config::ConfigFile;
-pub use github_api_client::config::GitHubCfg;
-pub use hab_net::app::config::RouterAddr;
+#[derive(Clone, Serialize, Deserialize)]
+pub struct JobCreateReq {
+    pub project_id: String,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct ProjectCreateReq {
+    pub origin: String,
+    pub plan_path: String,
+    pub github: GitHubProject,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct ProjectUpdateReq {
+    pub plan_path: String,
+    pub github: GitHubProject,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct GitHubProject {
+    pub organization: String,
+    pub repo: String,
+    pub installation_id: Option<u32>,
+}

--- a/components/builder-core/Cargo.toml
+++ b/components/builder-core/Cargo.toml
@@ -8,6 +8,7 @@ workspace = "../../"
 base64 = "*"
 chrono = { version = "*", features = ["serde"] }
 clippy = { version = "*", optional = true }
+glob = "*"
 habitat-builder-protocol = { path = "../builder-protocol" }
 iron = "*"
 libarchive = "*"
@@ -19,6 +20,7 @@ serde_derive = "*"
 serde_json = "*"
 statsd = "*"
 time = "*"
+toml = { version = "*", features = ["serde"], default-features = false }
 walkdir = "*"
 
 [dependencies.habitat_core]

--- a/components/builder-core/src/build_config.rs
+++ b/components/builder-core/src/build_config.rs
@@ -1,0 +1,171 @@
+// Copyright (c) 2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::fmt;
+use std::ops::Deref;
+use std::result;
+use std::str::FromStr;
+use std::string::ToString;
+
+use glob;
+use hab_core::channel::UNSTABLE_CHANNEL;
+use hab_core::config::ConfigFile;
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+use toml;
+
+use error::{Error, Result};
+
+/// Postprocessing config file name
+pub const BLDR_CFG: &'static str = "bldr.toml";
+pub const DEFAULT_CHANNEL: &'static str = UNSTABLE_CHANNEL;
+
+#[derive(Debug, Default, Deserialize, Serialize)]
+pub struct BuildCfg(HashMap<String, ProjectCfg>);
+
+impl BuildCfg {
+    pub fn from_slice(bytes: &[u8]) -> Result<Self> {
+        let value = toml::from_slice::<HashMap<String, ProjectCfg>>(bytes)
+            .map_err(|e| Error::DecryptError(e.to_string()))?;
+        Ok(BuildCfg(value))
+    }
+}
+
+impl ConfigFile for BuildCfg {
+    type Error = Error;
+}
+
+impl Deref for BuildCfg {
+    type Target = HashMap<String, ProjectCfg>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ProjectCfg {
+    #[serde(default)]
+    pub paths: Vec<Pattern>,
+    /// Additional Release Channel to promote built packages into.
+    #[serde(default)]
+    pub channels: Vec<String>,
+}
+
+impl ProjectCfg {
+    pub fn triggered_by(&self, path: &str) -> bool {
+        self.paths.iter().any(|p| p.matches(path))
+    }
+}
+
+impl Default for ProjectCfg {
+    fn default() -> Self {
+        ProjectCfg {
+            paths: vec![],
+            channels: vec![],
+        }
+    }
+}
+
+pub struct Pattern {
+    inner: glob::Pattern,
+    options: glob::MatchOptions,
+}
+
+impl Pattern {
+    pub fn matches<T>(&self, value: T) -> bool
+    where
+        T: AsRef<str>,
+    {
+        self.inner.matches_with(value.as_ref(), &self.options)
+    }
+
+    fn default_options() -> glob::MatchOptions {
+        glob::MatchOptions {
+            case_sensitive: false,
+            require_literal_separator: false,
+            require_literal_leading_dot: false,
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for Pattern {
+    fn deserialize<D>(deserializer: D) -> result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        let inner: glob::Pattern = FromStr::from_str(&s).map_err(de::Error::custom)?;
+        Ok(Pattern {
+            inner: inner,
+            options: Pattern::default_options(),
+        })
+    }
+}
+
+impl fmt::Debug for Pattern {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.inner)
+    }
+}
+
+impl Serialize for Pattern {
+    fn serialize<S>(&self, serializer: S) -> result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.inner.to_string())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn from_contents() {
+        let raw = r#"
+        [hab-sup]
+        channels = [
+          "stable"
+        ]
+        paths = [
+          "components/hab-sup/*"
+        ]
+
+        [builder-api]
+        paths = [
+          "components/builder-api/*"
+        ]
+        "#;
+        let cfg = BuildCfg::from_slice(raw.as_bytes()).unwrap();
+        assert_eq!(cfg.len(), 2);
+        assert_eq!(
+            cfg.get("hab-sup").unwrap().triggered_by(
+                "components/hab-sup/Cargo.toml",
+            ),
+            true
+        );
+        assert_eq!(
+            cfg.get("hab-sup").unwrap().triggered_by(
+                "components/hAb-Sup/Cargo.toml",
+            ),
+            true
+        );
+        assert_eq!(
+            cfg.get("hab-sup").unwrap().triggered_by("components"),
+            false
+        );
+    }
+}

--- a/components/builder-core/src/error.rs
+++ b/components/builder-core/src/error.rs
@@ -18,6 +18,7 @@ use std::result;
 use std::string;
 
 use base64;
+use hab_core;
 
 #[derive(Debug)]
 pub enum Error {
@@ -25,6 +26,7 @@ pub enum Error {
     DecryptError(String),
     EncryptError(String),
     FromUtf8Error(string::FromUtf8Error),
+    HabitatCore(hab_core::Error),
 }
 
 pub type Result<T> = result::Result<T, Error>;
@@ -36,6 +38,7 @@ impl fmt::Display for Error {
             Error::DecryptError(ref e) => format!("{}", e),
             Error::EncryptError(ref e) => format!("{}", e),
             Error::FromUtf8Error(ref e) => format!("{}", e),
+            Error::HabitatCore(ref e) => format!("{}", e),
         };
         write!(f, "{}", msg)
     }
@@ -48,6 +51,13 @@ impl error::Error for Error {
             Error::DecryptError(_) => "Error decrypting integration",
             Error::EncryptError(_) => "Error encrypting integration",
             Error::FromUtf8Error(ref e) => e.description(),
+            Error::HabitatCore(ref err) => err.description(),
         }
+    }
+}
+
+impl From<hab_core::Error> for Error {
+    fn from(err: hab_core::Error) -> Error {
+        Error::HabitatCore(err)
     }
 }

--- a/components/builder-core/src/lib.rs
+++ b/components/builder-core/src/lib.rs
@@ -15,6 +15,7 @@
 #![cfg_attr(feature="clippy", feature(plugin))]
 #![cfg_attr(feature="clippy", plugin(clippy))]
 
+extern crate glob;
 extern crate habitat_builder_protocol as protocol;
 extern crate habitat_core as hab_core;
 extern crate habitat_net as hab_net;
@@ -32,16 +33,18 @@ extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 extern crate serde_json;
+extern crate toml;
 
+pub mod build_config;
 pub mod data_structures;
 pub mod error;
 pub mod file_walker;
 pub mod integrations;
+pub mod keys;
 pub mod logger;
 pub mod metrics;
 pub mod package_graph;
-pub mod target_graph;
 pub mod rdeps;
-pub mod keys;
+pub mod target_graph;
 
 pub use error::Error;

--- a/components/builder-depot/src/config.rs
+++ b/components/builder-depot/src/config.rs
@@ -86,32 +86,6 @@ impl GatewayCfg for Config {
     }
 }
 
-impl GitHubOAuth for Config {
-    fn github_url(&self) -> &str {
-        &self.github.url
-    }
-
-    fn github_web_url(&self) -> &str {
-        &self.github.web_url
-    }
-
-    fn github_client_id(&self) -> &str {
-        &self.github.client_id
-    }
-
-    fn github_client_secret(&self) -> &str {
-        &self.github.client_secret
-    }
-
-    fn github_app_id(&self) -> u64 {
-        self.github.app_id
-    }
-
-    fn github_app_private_key_path(&self) -> PathBuf {
-        self.github.app_private_key_path.clone()
-    }
-}
-
 #[derive(Clone, Debug, Deserialize)]
 #[serde(default)]
 pub struct HttpCfg {

--- a/components/builder-depot/src/server.rs
+++ b/components/builder-depot/src/server.rs
@@ -2222,8 +2222,8 @@ where
 }
 
 pub fn router(depot: DepotUtil) -> Result<Chain> {
-    let basic = Authenticated::new(&depot.config);
-    let worker = Authenticated::new(&depot.config).require(privilege::BUILD_WORKER);
+    let basic = Authenticated::new(depot.config.github.clone());
+    let worker = Authenticated::new(depot.config.github.clone()).require(privilege::BUILD_WORKER);
     let router = routes(basic, worker);
     let mut chain = Chain::new(router);
     chain.link(persistent::Read::<EventLog>::both(EventLogger::new(

--- a/components/builder-http-gateway/src/http/middleware.rs
+++ b/components/builder-http-gateway/src/http/middleware.rs
@@ -14,7 +14,7 @@
 
 use std::env;
 
-use github_api_client::{self, GitHubClient, HubError};
+use github_api_client::{GitHubCfg, GitHubClient, HubError};
 use hab_net::{ErrCode, NetError};
 use hab_net::conn::RouteClient;
 use hab_net::privilege::FeatureFlags;
@@ -106,10 +106,7 @@ pub struct Authenticated {
 }
 
 impl Authenticated {
-    pub fn new<T>(config: &T) -> Self
-    where
-        T: github_api_client::config::GitHubOAuth,
-    {
+    pub fn new(config: GitHubCfg) -> Self {
         let github = GitHubClient::new(config);
         Authenticated {
             github: github,

--- a/components/builder-jobsrv/src/data_store.rs
+++ b/components/builder-jobsrv/src/data_store.rs
@@ -677,7 +677,7 @@ fn row_to_job(row: &postgres::rows::Row) -> Result<jobsrv::Job> {
             project.set_vcs_data(vcsa.remove(0).expect("expected vcs data"));
             if vcsa.len() > 0 {
                 if let Some(install_id) = vcsa.remove(0) {
-                    project.set_vcs_installation_id(install_id.parse::<u64>().map_err(
+                    project.set_vcs_installation_id(install_id.parse::<u32>().map_err(
                         Error::ParseVCSInstallationId,
                     )?);
                 }

--- a/components/builder-originsrv/src/data_store.rs
+++ b/components/builder-originsrv/src/data_store.rs
@@ -164,7 +164,7 @@ impl DataStore {
         project.set_vcs_data(row.get("vcs_data"));
 
         if let Some(Ok(install_id)) = row.get_opt::<&str, i64>("vcs_installation_id") {
-            project.set_vcs_installation_id(install_id as u64);
+            project.set_vcs_installation_id(install_id as u32);
         }
 
         project

--- a/components/builder-protocol/protocols/originsrv.proto
+++ b/components/builder-protocol/protocols/originsrv.proto
@@ -1,6 +1,5 @@
 package originsrv;
 
-// Account
 message AccountInvitationListRequest {
   optional uint64 account_id = 1;
 }
@@ -25,7 +24,6 @@ message CheckOriginAccessResponse {
   optional bool has_access = 1;
 }
 
-// Origin
 enum OriginPackageVisibility {
   Public = 1;
   Private = 2;
@@ -60,7 +58,6 @@ message OriginUpdate {
   optional OriginPackageVisibility default_package_visibility = 3;
 }
 
-// Origin Channel
 message OriginChannel {
   optional uint64 id = 1;
   optional uint64 origin_id = 2;
@@ -120,7 +117,6 @@ message OriginChannelDelete {
   optional uint64 origin_id = 2;
 }
 
-// Origin Invitation
 message OriginInvitation {
   optional uint64 id = 1;
   optional uint64 account_id = 2;
@@ -170,7 +166,6 @@ message OriginKeyIdent {
   optional string location = 3;
 }
 
-// Origin Member
 message OriginMemberListRequest {
   optional uint64 origin_id = 1;
 }
@@ -185,7 +180,6 @@ message OriginMemberRemove {
   optional uint64 user_id = 2;
 }
 
-// Origin Package
 message OriginPackage {
   optional uint64 id = 1;
   optional uint64 owner_id = 2;
@@ -330,7 +324,6 @@ message OriginPackageVersionListResponse {
   repeated OriginPackageVersion versions = 1;
 }
 
-// Origin Project
 message OriginProject {
   optional uint64 id = 1;
   optional uint64 origin_id = 2;
@@ -341,7 +334,7 @@ message OriginProject {
   optional uint64 owner_id = 7;
   optional string vcs_type = 8;
   optional string vcs_data = 9;
-  optional uint64 vcs_installation_id = 12;
+  optional uint32 vcs_installation_id = 12;
 }
 
 message OriginProjectCreate {
@@ -370,7 +363,6 @@ message OriginProjectList {
   repeated string names = 1;
 }
 
-// Origin Public Key
 message OriginPublicKey {
   optional uint64 id = 1;
   optional uint64 origin_id = 2;
@@ -409,7 +401,6 @@ message OriginPublicKeyListResponse {
   repeated OriginPublicKey keys = 2;
 }
 
-// Origin Secret Key
 message OriginSecretKey {
   optional uint64 id = 1;
   optional uint64 origin_id = 2;
@@ -432,7 +423,6 @@ message OriginSecretKeyGet {
   optional string origin = 2;
 }
 
-// Origin Integration
 message OriginIntegration {
   optional string origin = 1;
   optional string integration = 2;
@@ -465,7 +455,6 @@ message OriginIntegrationResponse {
   repeated OriginIntegration integrations = 1;
 }
 
-// Origin Project Integration
 message OriginProjectIntegration {
   optional string origin = 1;
   optional string name = 2;

--- a/components/builder-protocol/src/jobsrv.rs
+++ b/components/builder-protocol/src/jobsrv.rs
@@ -27,6 +27,8 @@ use sharding::InstaId;
 
 pub use message::jobsrv::*;
 
+pub const GITHUB_PUSH_NOTIFY_ID: u64 = 23;
+
 #[derive(Debug)]
 pub enum Error {
     BadJobState,

--- a/components/builder-protocol/src/message/originsrv.rs
+++ b/components/builder-protocol/src/message/originsrv.rs
@@ -15015,7 +15015,7 @@ pub struct OriginProject {
     owner_id: ::std::option::Option<u64>,
     vcs_type: ::protobuf::SingularField<::std::string::String>,
     vcs_data: ::protobuf::SingularField<::std::string::String>,
-    vcs_installation_id: ::std::option::Option<u64>,
+    vcs_installation_id: ::std::option::Option<u32>,
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
     cached_size: ::protobuf::CachedSize,
@@ -15384,7 +15384,7 @@ impl OriginProject {
         &mut self.vcs_data
     }
 
-    // optional uint64 vcs_installation_id = 12;
+    // optional uint32 vcs_installation_id = 12;
 
     pub fn clear_vcs_installation_id(&mut self) {
         self.vcs_installation_id = ::std::option::Option::None;
@@ -15395,19 +15395,19 @@ impl OriginProject {
     }
 
     // Param is passed by value, moved
-    pub fn set_vcs_installation_id(&mut self, v: u64) {
+    pub fn set_vcs_installation_id(&mut self, v: u32) {
         self.vcs_installation_id = ::std::option::Option::Some(v);
     }
 
-    pub fn get_vcs_installation_id(&self) -> u64 {
+    pub fn get_vcs_installation_id(&self) -> u32 {
         self.vcs_installation_id.unwrap_or(0)
     }
 
-    fn get_vcs_installation_id_for_reflect(&self) -> &::std::option::Option<u64> {
+    fn get_vcs_installation_id_for_reflect(&self) -> &::std::option::Option<u32> {
         &self.vcs_installation_id
     }
 
-    fn mut_vcs_installation_id_for_reflect(&mut self) -> &mut ::std::option::Option<u64> {
+    fn mut_vcs_installation_id_for_reflect(&mut self) -> &mut ::std::option::Option<u32> {
         &mut self.vcs_installation_id
     }
 }
@@ -15464,7 +15464,7 @@ impl ::protobuf::Message for OriginProject {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
                         return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
                     };
-                    let tmp = is.read_uint64()?;
+                    let tmp = is.read_uint32()?;
                     self.vcs_installation_id = ::std::option::Option::Some(tmp);
                 },
                 _ => {
@@ -15543,7 +15543,7 @@ impl ::protobuf::Message for OriginProject {
             os.write_string(9, &v)?;
         };
         if let Some(v) = self.vcs_installation_id {
-            os.write_uint64(12, v)?;
+            os.write_uint32(12, v)?;
         };
         os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
@@ -15634,7 +15634,7 @@ impl ::protobuf::MessageStatic for OriginProject {
                     OriginProject::get_vcs_data_for_reflect,
                     OriginProject::mut_vcs_data_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint64>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint32>(
                     "vcs_installation_id",
                     OriginProject::get_vcs_installation_id_for_reflect,
                     OriginProject::mut_vcs_installation_id_for_reflect,
@@ -23007,7 +23007,7 @@ static file_descriptor_proto_data: &'static [u8] = &[
     0x73, 0x5f, 0x64, 0x61, 0x74, 0x61, 0x18, 0x09, 0x20, 0x01, 0x28, 0x09, 0x52, 0x07, 0x76, 0x63,
     0x73, 0x44, 0x61, 0x74, 0x61, 0x12, 0x2e, 0x0a, 0x13, 0x76, 0x63, 0x73, 0x5f, 0x69, 0x6e, 0x73,
     0x74, 0x61, 0x6c, 0x6c, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x5f, 0x69, 0x64, 0x18, 0x0c, 0x20, 0x01,
-    0x28, 0x04, 0x52, 0x11, 0x76, 0x63, 0x73, 0x49, 0x6e, 0x73, 0x74, 0x61, 0x6c, 0x6c, 0x61, 0x74,
+    0x28, 0x0d, 0x52, 0x11, 0x76, 0x63, 0x73, 0x49, 0x6e, 0x73, 0x74, 0x61, 0x6c, 0x6c, 0x61, 0x74,
     0x69, 0x6f, 0x6e, 0x49, 0x64, 0x22, 0x49, 0x0a, 0x13, 0x4f, 0x72, 0x69, 0x67, 0x69, 0x6e, 0x50,
     0x72, 0x6f, 0x6a, 0x65, 0x63, 0x74, 0x43, 0x72, 0x65, 0x61, 0x74, 0x65, 0x12, 0x32, 0x0a, 0x07,
     0x70, 0x72, 0x6f, 0x6a, 0x65, 0x63, 0x74, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x18, 0x2e,

--- a/components/builder-sessionsrv/src/config.rs
+++ b/components/builder-sessionsrv/src/config.rs
@@ -13,10 +13,8 @@
 // limitations under the License.
 // Configuration for a Habitat SessionSrv service
 
-use std::path::PathBuf;
-
 use db::config::DataStoreCfg;
-use github_api_client::config::{GitHubCfg, GitHubOAuth};
+use github_api_client::config::GitHubCfg;
 use hab_net::app::config::*;
 
 use error::SrvError;
@@ -65,32 +63,6 @@ impl AppCfg for Config {
 
     fn worker_count(&self) -> usize {
         self.worker_threads
-    }
-}
-
-impl GitHubOAuth for Config {
-    fn github_url(&self) -> &str {
-        &self.github.url
-    }
-
-    fn github_web_url(&self) -> &str {
-        &self.github.web_url
-    }
-
-    fn github_client_id(&self) -> &str {
-        &self.github.client_id
-    }
-
-    fn github_client_secret(&self) -> &str {
-        &self.github.client_secret
-    }
-
-    fn github_app_id(&self) -> u64 {
-        self.github.app_id
-    }
-
-    fn github_app_private_key_path(&self) -> PathBuf {
-        self.github.app_private_key_path.clone()
     }
 }
 

--- a/components/builder-sessionsrv/src/server/mod.rs
+++ b/components/builder-sessionsrv/src/server/mod.rs
@@ -134,7 +134,7 @@ impl ServerState {
     fn new(cfg: &Config) -> SrvResult<Self> {
         Ok(ServerState {
             datastore: DataStore::new(cfg)?,
-            github: Arc::new(Box::new(GitHubClient::new(cfg))),
+            github: Arc::new(Box::new(GitHubClient::new(cfg.github.clone()))),
             permissions: Arc::new(cfg.permissions.clone()),
             sessions: Arc::new(Box::new(RwLock::new(HashSet::default()))),
         })

--- a/components/builder-worker/src/config.rs
+++ b/components/builder-worker/src/config.rs
@@ -17,7 +17,7 @@
 use std::net::{IpAddr, Ipv4Addr};
 use std::path::PathBuf;
 
-use github_api_client::config::{GitHubCfg, GitHubOAuth};
+use github_api_client::config::GitHubCfg;
 use hab_core::config::ConfigFile;
 use hab_core::url;
 
@@ -80,32 +80,6 @@ impl Default for Config {
 
 impl ConfigFile for Config {
     type Error = Error;
-}
-
-impl GitHubOAuth for Config {
-    fn github_url(&self) -> &str {
-        &self.github.url
-    }
-
-    fn github_web_url(&self) -> &str {
-        &self.github.web_url
-    }
-
-    fn github_client_id(&self) -> &str {
-        &self.github.client_id
-    }
-
-    fn github_client_secret(&self) -> &str {
-        &self.github.client_secret
-    }
-
-    fn github_app_id(&self) -> u64 {
-        self.github.app_id
-    }
-
-    fn github_app_private_key_path(&self) -> PathBuf {
-        self.github.app_private_key_path.clone()
-    }
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/components/core/src/package/plan.rs
+++ b/components/core/src/package/plan.rs
@@ -16,46 +16,40 @@ use std::io::BufRead;
 
 use error::{Error, Result};
 
+#[derive(Debug)]
 pub struct Plan {
     pub name: String,
+    pub origin: String,
     pub version: String,
 }
 
 impl Plan {
-    pub fn new(name: String, version: String) -> Self {
-        Plan {
-            name: name,
-            version: version,
-        }
-    }
-
     pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
         let mut name: Option<String> = None;
+        let mut origin: Option<String> = None;
         let mut version: Option<String> = None;
         for line in bytes.lines() {
             if let Ok(line) = line {
                 let parts: Vec<&str> = line.splitn(2, "=").collect();
                 match parts[0] {
                     "pkg_name" => name = Some(parts[1].to_string()),
+                    "pkg_origin" => origin = Some(parts[1].to_string()),
                     "pkg_version" => version = Some(parts[1].to_string()),
                     _ => (),
                 }
             }
         }
 
-        // Only the name is required to be present initiallly in the plan.sh
-        if name.is_none() {
+        if name.is_none() || origin.is_none() {
             return Err(Error::PlanMalformed);
         }
 
         // Default the version to 'undefined' if it's not present
-        let v = if version.is_none() {
-            String::from("undefined")
-        } else {
-            version.unwrap()
-        };
-
-        let plan = Plan::new(name.unwrap(), v);
-        Ok(plan)
+        let version = version.unwrap_or("undefined".to_string());
+        Ok(Plan {
+            name: name.unwrap(),
+            origin: origin.unwrap(),
+            version: version,
+        })
     }
 }

--- a/components/github-api-client/src/config.rs
+++ b/components/github-api-client/src/config.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Chef Software Inc. and/or applicable contributors
+// Copyright (c) 2017 Chef Software Inc. and/or applicable contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,8 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-use std::path::PathBuf;
 
 /// URL to GitHub API endpoint
 pub const DEFAULT_GITHUB_URL: &'static str = "https://api.github.com";
@@ -29,17 +27,6 @@ pub const DEV_GITHUB_CLIENT_ID: &'static str = "0c2f738a7d0bd300de10";
 pub const DEV_GITHUB_CLIENT_SECRET: &'static str = "438223113eeb6e7edf2d2f91a232b72de72b9bdf";
 /// Default github application id created in the habitat-sh org
 pub const DEFAULT_GITHUB_APP_ID: u64 = 5565;
-/// Default github application id created in the habitat-sh org
-pub const DEFAULT_GITHUB_APP_PRIVATE_KEY_PATH: &'static str = "/hab/svc/builder-worker/files/github_app_private_key.pem";
-
-pub trait GitHubOAuth {
-    fn github_url(&self) -> &str;
-    fn github_web_url(&self) -> &str;
-    fn github_client_id(&self) -> &str;
-    fn github_client_secret(&self) -> &str;
-    fn github_app_id(&self) -> u64;
-    fn github_app_private_key_path(&self) -> PathBuf;
-}
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(default)]
@@ -48,14 +35,14 @@ pub struct GitHubCfg {
     pub url: String,
     /// URL to GitHub Web
     pub web_url: String,
+    /// Path to GitHub App private key
+    pub app_private_key: String,
     /// Client identifier used for GitHub API requests
     pub client_id: String,
     /// Client secret used for GitHub API requests
     pub client_secret: String,
     /// App Id used for builder integration
     pub app_id: u64,
-    /// Private key associated with github app
-    pub app_private_key_path: PathBuf,
 }
 
 impl Default for GitHubCfg {
@@ -63,10 +50,10 @@ impl Default for GitHubCfg {
         GitHubCfg {
             url: DEFAULT_GITHUB_URL.to_string(),
             web_url: DEFAULT_GITHUB_WEB_URL.to_string(),
+            app_private_key: "".to_string(),
             client_id: DEV_GITHUB_CLIENT_ID.to_string(),
             client_secret: DEV_GITHUB_CLIENT_SECRET.to_string(),
             app_id: DEFAULT_GITHUB_APP_ID,
-            app_private_key_path: PathBuf::from(DEFAULT_GITHUB_APP_PRIVATE_KEY_PATH),
         }
     }
 }

--- a/components/github-api-client/src/error.rs
+++ b/components/github-api-client/src/error.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2017 Chef Software Inc. and/or applicable contributors
+// Copyright (c) 2017 Chef Software Inc. and/or applicable contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,20 +21,20 @@ use base64;
 use hyper;
 use serde_json;
 
-use client;
+use types;
 
 pub type HubResult<T> = Result<T, HubError>;
 
 #[derive(Debug)]
 pub enum HubError {
     ApiError(hyper::status::StatusCode, HashMap<String, String>),
-    Auth(client::AuthErr),
+    AppAuth(types::AppAuthErr),
+    Auth(types::AuthErr),
     AuthScope(Vec<&'static str>),
     ContentDecode(base64::DecodeError),
     HttpClient(hyper::Error),
     HttpClientParse(hyper::error::ParseError),
     HttpResponse(hyper::status::StatusCode),
-    InstallationAuth(client::InstallationAuthErr),
     IO(io::Error),
     Serialization(serde_json::Error),
 }
@@ -49,15 +49,13 @@ impl fmt::Display for HubError {
                     response
                 )
             }
+            HubError::AppAuth(ref e) => format!("GitHub App Authentication error, {}", e),
             HubError::Auth(ref e) => format!("GitHub Authentication error, {}", e),
             HubError::AuthScope(ref e) => format!("Missing OAuth scope(s), '{}'", e.join(", ")),
             HubError::ContentDecode(ref e) => format!("{}", e),
             HubError::HttpClient(ref e) => format!("{}", e),
             HubError::HttpClientParse(ref e) => format!("{}", e),
             HubError::HttpResponse(ref e) => format!("{}", e),
-            HubError::InstallationAuth(ref e) => {
-                format!("GitHub App Installation Authentication error, {}", e)
-            }
             HubError::IO(ref e) => format!("{}", e),
             HubError::Serialization(ref e) => format!("{}", e),
         };
@@ -69,21 +67,21 @@ impl error::Error for HubError {
     fn description(&self) -> &str {
         match *self {
             HubError::ApiError(_, _) => "Response returned a non-200 status code.",
+            HubError::AppAuth(_) => "GitHub App authorization error.",
             HubError::Auth(_) => "GitHub authorization error.",
             HubError::AuthScope(_) => "Authentication token is missing required OAuth scopes.",
             HubError::ContentDecode(ref err) => err.description(),
             HubError::HttpClient(ref err) => err.description(),
             HubError::HttpClientParse(ref err) => err.description(),
             HubError::HttpResponse(_) => "Non-200 HTTP response.",
-            HubError::InstallationAuth(_) => "GitHub App Installation authorization error.",
             HubError::IO(ref err) => err.description(),
             HubError::Serialization(ref err) => err.description(),
         }
     }
 }
 
-impl From<client::AuthErr> for HubError {
-    fn from(err: client::AuthErr) -> Self {
+impl From<types::AuthErr> for HubError {
+    fn from(err: types::AuthErr) -> Self {
         HubError::Auth(err)
     }
 }

--- a/components/github-api-client/src/lib.rs
+++ b/components/github-api-client/src/lib.rs
@@ -27,6 +27,8 @@ extern crate time;
 pub mod client;
 pub mod config;
 pub mod error;
+pub mod types;
 
 pub use client::GitHubClient;
+pub use config::GitHubCfg;
 pub use error::{HubError, HubResult};

--- a/components/github-api-client/src/types.rs
+++ b/components/github-api-client/src/types.rs
@@ -1,0 +1,392 @@
+// Copyright (c) 2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt;
+
+use base64;
+
+use error::{HubError, HubResult};
+
+// These OAuth scopes are required for a user to be authenticated. If this list is updated, then
+// the front-end also needs to be updated in `components/builder-web/app/util.ts`. Both the
+// front-end app and back-end app should have identical requirements to make things easier for
+// our users and less cumbersome for us to message out.
+// https://developer.github.com/v3/oauth/#scopes
+const AUTH_SCOPES: &'static [&'static str] = &["user:email", "read:org"];
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct App {
+    pub id: u32,
+    pub owner: AppOwner,
+    pub name: String,
+    pub description: String,
+    pub external_url: String,
+    pub html_url: String,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct AppInstallationToken {
+    pub token: String,
+    pub expires_at: String,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct AppAuthErr {
+    pub message: String,
+    pub documentation_url: String,
+}
+
+impl fmt::Display for AppAuthErr {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "message={}, documentation_url={}",
+            self.message,
+            self.documentation_url
+        )
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct AuthOk {
+    pub access_token: String,
+    pub scope: String,
+    pub token_type: String,
+}
+
+impl AuthOk {
+    pub fn missing_auth_scopes(&self) -> Vec<&'static str> {
+        let mut scopes = vec![];
+        for scope in AUTH_SCOPES.iter() {
+            if !self.scope.split(",").collect::<Vec<&str>>().iter().any(
+                |p| {
+                    p == scope
+                },
+            )
+            {
+                scopes.push(*scope);
+            }
+        }
+        scopes
+    }
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct AuthErr {
+    pub error: String,
+    pub error_description: String,
+    pub error_uri: String,
+}
+
+impl fmt::Display for AuthErr {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "err={}, desc={}, uri={}",
+            self.error,
+            self.error_description,
+            self.error_uri
+        )
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct AppOwner {
+    pub login: String,
+    pub id: u32,
+    pub avatar_url: String,
+    pub gravatar_id: String,
+    pub url: String,
+    pub html_url: String,
+    pub followers_url: String,
+    pub following_url: String,
+    pub gists_url: String,
+    pub starred_url: String,
+    pub subscriptions_url: String,
+    pub organizations_url: String,
+    pub repos_url: String,
+    pub events_url: String,
+    pub received_events_url: String,
+    #[serde(rename = "type")]
+    pub _type: String,
+    pub site_admin: bool,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Contents {
+    pub name: String,
+    pub path: String,
+    pub sha: String,
+    pub size: usize,
+    pub url: String,
+    pub html_url: String,
+    pub git_url: String,
+    pub download_url: String,
+    pub content: String,
+    pub encoding: String,
+}
+
+impl Contents {
+    pub fn decode(&self) -> HubResult<Vec<u8>> {
+        base64::decode(&self.content).map_err(HubError::ContentDecode)
+    }
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct GitHubWebhookPush {
+    /// The full Git ref that was pushed. Example: "refs/heads/master"
+    #[serde(rename = "ref")]
+    pub git_ref: String,
+    /// The SHA of the most recent commit on ref before the push
+    pub before: String,
+    /// The SHA of the most recent commit on ref after the push
+    pub after: String,
+    pub created: bool,
+    pub deleted: bool,
+    pub forced: bool,
+    pub base_ref: Option<String>,
+    pub compare: String,
+    /// An array of commit objects describing the pushed commits (The array includes a maximum
+    /// of 20 commits. If necessary, you can use the Commits API to fetch additional commits.
+    /// This limit is applied to timeline events only and isn't applied to webhook deliveries)
+    pub commits: Vec<GitHubWebhookCommit>,
+    pub head_commit: GitHubWebhookCommit,
+    pub repository: PushRepository,
+    pub pusher: GitHubOwner,
+    pub sender: GitHubWebhookSender,
+    pub installation: GitHubAppInstallation,
+}
+
+impl GitHubWebhookPush {
+    pub fn changed(&self) -> Vec<&String> {
+        let mut paths = vec![];
+        for commit in self.commits.iter() {
+            paths.extend(&commit.added);
+            paths.extend(&commit.removed);
+            paths.extend(&commit.modified);
+        }
+        paths.sort();
+        paths.dedup();
+        paths
+    }
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct GitHubWebhookCommit {
+    pub id: String,
+    pub tree_id: String,
+    /// Whether this commit is distinct from any that have been pushed before
+    pub distinct: bool,
+    /// The commit message
+    pub message: String,
+    pub timestamp: String,
+    /// Points to the commit API resource
+    pub url: String,
+    /// The git author of the commit
+    pub author: GitHubAuthor,
+    pub committer: GitHubAuthor,
+    pub added: Vec<String>,
+    pub removed: Vec<String>,
+    pub modified: Vec<String>,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct GitHubAuthor {
+    /// Public name of commit author
+    pub name: String,
+    /// Public email of commit author
+    pub email: String,
+    /// Display name of commit author
+    pub username: String,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct GitHubAppInstallation {
+    pub id: u32,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct GitHubWebhookSender {
+    pub login: String,
+    pub id: u64,
+    pub avatar_url: String,
+    pub gravatar_id: Option<String>,
+    pub url: String,
+    pub html_url: String,
+    pub followers_url: String,
+    pub following_url: String,
+    pub gists_url: String,
+    pub starred_url: String,
+    pub subscriptions_url: String,
+    pub organizations_url: String,
+    pub repos_url: String,
+    pub events_url: String,
+    pub received_events_url: String,
+    pub site_admin: bool,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct GitHubOwner {
+    /// Public name of commit author
+    pub name: String,
+    /// Public email of commit author
+    pub email: String,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct PushRepository {
+    pub id: u64,
+    pub name: String,
+    pub full_name: String,
+    pub owner: Organization,
+    pub private: bool,
+    pub html_url: String,
+    pub description: Option<String>,
+    pub fork: bool,
+    pub git_url: String,
+    pub ssh_url: String,
+    pub clone_url: String,
+    pub default_branch: String,
+    pub master_branch: String,
+    pub organization: String,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct Repository {
+    pub id: u64,
+    pub name: String,
+    pub full_name: String,
+    pub owner: User,
+    pub private: bool,
+    pub html_url: String,
+    pub description: Option<String>,
+    pub fork: bool,
+    pub git_url: String,
+    pub ssh_url: String,
+    pub clone_url: String,
+    pub default_branch: String,
+    pub master_branch: String,
+    pub organization: String,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct Organization {
+    pub login: String,
+    pub id: u64,
+    pub avatar_url: String,
+    pub url: String,
+    pub company: Option<String>,
+    pub description: Option<String>,
+    pub gravatar_id: Option<String>,
+    pub hooks_url: Option<String>,
+    pub html_url: Option<String>,
+    pub followers_url: Option<String>,
+    pub following_url: Option<String>,
+    pub gists_url: Option<String>,
+    pub starred_url: Option<String>,
+    pub subscriptions_url: Option<String>,
+    pub organizations_url: Option<String>,
+    pub repos_url: Option<String>,
+    pub events_url: Option<String>,
+    pub received_events_url: Option<String>,
+    pub members_url: Option<String>,
+    pub site_admin: Option<bool>,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct Team {
+    pub id: u64,
+    pub url: String,
+    pub name: String,
+    pub slug: String,
+    pub description: Option<String>,
+    pub privacy: String,
+    pub permission: String,
+    pub members_url: String,
+    pub repositories_url: String,
+    pub members_count: u64,
+    pub repos_count: u64,
+    pub organization: Organization,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct User {
+    pub login: String,
+    pub id: u64,
+    pub avatar_url: String,
+    pub gravatar_id: String,
+    pub url: String,
+    pub html_url: String,
+    pub followers_url: String,
+    pub following_url: String,
+    pub gists_url: String,
+    pub starred_url: String,
+    pub subscriptions_url: String,
+    pub organizations_url: String,
+    pub repos_url: String,
+    pub events_url: String,
+    pub received_events_url: String,
+    pub site_admin: bool,
+    pub name: Option<String>,
+    pub company: Option<String>,
+    pub blog: Option<String>,
+    pub location: Option<String>,
+    pub email: Option<String>,
+    pub hireable: Option<bool>,
+    pub bio: Option<String>,
+    pub public_repos: Option<u32>,
+    pub public_gists: Option<u32>,
+    pub followers: Option<u32>,
+    pub following: Option<u32>,
+    pub created_at: Option<String>,
+    pub updated_at: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Email {
+    pub email: String,
+    pub primary: bool,
+    pub verified: bool,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Search {
+    pub total_count: u64,
+    pub incomplete_results: bool,
+    pub items: Vec<SearchItem>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct SearchItem {
+    pub name: String,
+    pub path: String,
+    pub sha: String,
+    pub url: String,
+    pub git_url: String,
+    pub html_url: String,
+    pub repository: Repository,
+    pub score: f64,
+}

--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Adam Jacob <adam@chef.io>", "Jamie Winsor <reset@chef.io>", "Fletche
 workspace = "../../"
 
 [dependencies]
+base64 = "*"
 clippy = {version = "*", optional = true}
 bitflags = "*"
 habitat-builder-protocol = { path = "../builder-protocol" }

--- a/components/net/src/lib.rs
+++ b/components/net/src/lib.rs
@@ -15,6 +15,7 @@
 #![cfg_attr(feature="clippy", feature(plugin))]
 #![cfg_attr(feature="clippy", plugin(clippy))]
 
+extern crate base64;
 #[macro_use]
 extern crate bitflags;
 extern crate habitat_builder_protocol as protocol;


### PR DESCRIPTION
This commit changes how we make authenticated requests to the GitHub API
on behalf of the user and adds the ability to process GitHub Webhook
notifications for Ping and Push.

In order to support Ping and Push notifications for Private repositories
we needed to switch to integrating with GitHub using a full GitHub App
instead of just an OAuth App. This PR changes the github-api-client to
only make requests which a GitHub App could make and signs the commits
appropriately.

The authorization process has changed to a per repo basis and no longer
requires a user to setup a personal access token.

![tenor-169787551](https://user-images.githubusercontent.com/54036/31064277-839effd6-a6ef-11e7-8225-b6f67bafba30.gif)
