### PR TITLE
[builder-worker] Add initial support for Docker exporting.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1024,11 +1024,13 @@ dependencies = [
 name = "habitat_builder_worker"
 version = "0.0.0"
 dependencies = [
+ "bitflags 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "builder_core 0.0.0",
  "chrono 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.25.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy 0.0.144 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "features 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "git2 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat-builder-protocol 0.0.0",
  "habitat_core 0.0.0",

--- a/components/builder-worker/Cargo.toml
+++ b/components/builder-worker/Cargo.toml
@@ -12,9 +12,11 @@ path = "src/main.rs"
 doc = false
 
 [dependencies]
+bitflags = "*"
 clippy = {version = "*", optional = true}
 chrono = { version = "*", features = ["serde"] }
 env_logger = "*"
+features = "*"
 habitat-builder-protocol = { path = "../builder-protocol" }
 git2 = "*"
 hyper = "*"

--- a/components/builder-worker/build.rs
+++ b/components/builder-worker/build.rs
@@ -6,6 +6,8 @@ use std::env;
 fn main() {
     builder::common();
     write_studio_pkg_ident();
+    write_docker_exporter_pkg_ident();
+    write_docker_pkg_ident();
 }
 
 fn write_studio_pkg_ident() {
@@ -16,4 +18,24 @@ fn write_studio_pkg_ident() {
         _ => String::from("core/hab-studio"),
     };
     util::write_out_dir_file("STUDIO_PKG_IDENT", ident);
+}
+
+fn write_docker_exporter_pkg_ident() {
+    let ident = match env::var("PLAN_DOCKER_EXPORTER_PKG_IDENT") {
+        // Use the value provided by the build system if present
+        Ok(ident) => ident,
+        // Use the latest installed package as a default for development
+        _ => String::from("core/hab-pkg-export-docker"),
+    };
+    util::write_out_dir_file("DOCKER_EXPORTER_PKG_IDENT", ident);
+}
+
+fn write_docker_pkg_ident() {
+    let ident = match env::var("PLAN_DOCKER_PKG_IDENT") {
+        // Use the value provided by the build system if present
+        Ok(ident) => ident,
+        // Use the latest installed package as a default for development
+        _ => String::from("core/docker"),
+    };
+    util::write_out_dir_file("DOCKER_PKG_IDENT", ident);
 }

--- a/components/builder-worker/habitat/config/config.toml
+++ b/components/builder-worker/habitat/config/config.toml
@@ -4,6 +4,7 @@ data_path = "{{pkg.svc_data_path}}"
 log_path = "{{pkg.svc_var_path}}"
 bldr_channel = "{{cfg.bldr_channel}}"
 bldr_url = "{{bind.depot.first.cfg.url}}"
+features_enabled = "{{cfg.features_enabled}}"
 
 {{~#eachAlive bind.jobsrv.members as |member|}}
 [[jobsrv]]

--- a/components/builder-worker/habitat/default.toml
+++ b/components/builder-worker/habitat/default.toml
@@ -2,3 +2,4 @@ log_level = "info"
 auth_token = ""
 auto_publish = true
 bldr_channel = "unstable"
+features_enabled = ""

--- a/components/builder-worker/habitat/plan.sh
+++ b/components/builder-worker/habitat/plan.sh
@@ -5,7 +5,7 @@ pkg_maintainer="Jamie Winsor <reset@chef.io>"
 pkg_license=('Apache-2.0')
 pkg_bin_dirs=(bin)
 pkg_deps=(core/glibc core/openssl core/gcc-libs core/zeromq core/libsodium core/libarchive
-  core/zlib core/hab-studio core/curl)
+  core/zlib core/hab-studio core/hab-pkg-export-docker core/docker core/curl)
 pkg_build_deps=(core/make core/cmake core/protobuf core/protobuf-rust core/coreutils core/cacerts
   core/rust core/gcc core/git core/pkg-config)
 pkg_svc_user="root"
@@ -22,4 +22,19 @@ do_prepare() {
   # Used by libssh2-sys
   export DEP_Z_ROOT="$(pkg_path_for zlib)"
   export DEP_Z_INCLUDE="$(pkg_path_for zlib)/include"
+
+  # Compile the fully-qualified Studio package identifier into the binary
+  PLAN_STUDIO_PKG_IDENT=$(pkg_path_for hab-studio | sed "s,^$HAB_PKG_PATH/,,")
+  export PLAN_STUDIO_PKG_IDENT
+  build_line "Setting PLAN_STUDIO_PKG_IDENT=$PLAN_STUDIO_PKG_IDENT"
+
+  # Compile the fully-qualified Docker exporter package identifier into the binary
+  PLAN_DOCKER_EXPORTER_PKG_IDENT=$(pkg_path_for hab-pkg-export-docker | sed "s,^$HAB_PKG_PATH/,,")
+  export PLAN_DOCKER_EXPORTER_PKG_IDENT
+  build_line "Setting PLAN_DOCKER_EXPORTER_PKG_IDENT=$PLAN_DOCKER_EXPORTER_PKG_IDENT"
+
+  # Compile the fully-qualified Docker package identifier into the binary
+  PLAN_DOCKER_PKG_IDENT=$(pkg_path_for docker | sed "s,^$HAB_PKG_PATH/,,")
+  export PLAN_DOCKER_PKG_IDENT
+  build_line "Setting PLAN_DOCKER_PKG_IDENT=$PLAN_DOCKER_PKG_IDENT"
 }

--- a/components/builder-worker/src/config.rs
+++ b/components/builder-worker/src/config.rs
@@ -43,6 +43,7 @@ pub struct Config {
     pub bldr_url: String,
     /// List of Job Servers to connect to
     pub jobsrv: JobSrvCfg,
+    pub features_enabled: String,
 }
 
 impl Config {
@@ -68,6 +69,7 @@ impl Default for Config {
             bldr_channel: String::from("unstable"),
             bldr_url: url::default_bldr_url(),
             jobsrv: vec![JobSrvAddr::default()],
+            features_enabled: "".to_string(),
         }
     }
 }
@@ -106,6 +108,7 @@ mod tests {
         auth_token = "mytoken"
         data_path = "/path/to/data"
         log_path = "/path/to/logs"
+        features_enabled = "FOO,BAR"
 
         [[jobsrv]]
         host = "1:1:1:1:1:1:1:1"
@@ -129,5 +132,6 @@ mod tests {
         assert_eq!(&format!("{}", config.jobsrv[1].host), "2.2.2.2");
         assert_eq!(config.jobsrv[1].port, 9000);
         assert_eq!(config.jobsrv[1].heartbeat, 5567);
+        assert_eq!(&config.features_enabled, "FOO,BAR");
     }
 }

--- a/components/builder-worker/src/lib.rs
+++ b/components/builder-worker/src/lib.rs
@@ -15,7 +15,11 @@
 #![cfg_attr(feature="clippy", feature(plugin))]
 #![cfg_attr(feature="clippy", plugin(clippy))]
 
+#[macro_use]
+extern crate bitflags;
 extern crate chrono;
+#[macro_use]
+extern crate features;
 extern crate habitat_builder_protocol as protocol;
 extern crate habitat_core as hab_core;
 extern crate habitat_depot_client as depot_client;
@@ -47,6 +51,12 @@ pub mod vcs;
 
 pub use self::config::Config;
 pub use self::error::{Error, Result};
+
+features! {
+    pub mod feat {
+        const List = 0b00000001
+    }
+}
 
 pub const PRODUCT: &'static str = "builder-worker";
 pub const VERSION: &'static str = include_str!(concat!(env!("OUT_DIR"), "/VERSION"));

--- a/components/builder-worker/src/lib.rs
+++ b/components/builder-worker/src/lib.rs
@@ -54,7 +54,8 @@ pub use self::error::{Error, Result};
 
 features! {
     pub mod feat {
-        const List = 0b00000001
+        const List = 0b00000001,
+        const Docker = 0b00000010
     }
 }
 

--- a/components/builder-worker/src/runner/docker.rs
+++ b/components/builder-worker/src/runner/docker.rs
@@ -1,0 +1,199 @@
+// Copyright (c) 2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fs::{self, File};
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::{Child, Command, ExitStatus, Stdio};
+
+use hab_core::env;
+use hab_core::fs as hfs;
+use hab_core::os::process::{self, Signal};
+
+use error::Result;
+use runner::log_pipe::LogPipe;
+use runner::{NONINTERACTIVE_ENVVAR, RUNNER_DEBUG_ENVVAR};
+use runner::workspace::Workspace;
+
+lazy_static! {
+    /// Absolute path to the Docker exporter program
+    static ref DOCKER_EXPORTER_PROGRAM: PathBuf = hfs::resolve_cmd_in_pkg(
+        "hab-pkg-export-docker",
+        include_str!(concat!(env!("OUT_DIR"), "/DOCKER_EXPORTER_PKG_IDENT")),
+    );
+
+    /// Absolute path to the Dockerd program
+    static ref DOCKERD_PROGRAM: PathBuf = hfs::resolve_cmd_in_pkg(
+        "dockerd",
+        include_str!(concat!(env!("OUT_DIR"), "/DOCKER_PKG_IDENT")),
+    );
+}
+
+const DOCKER_HOST_ENVVAR: &'static str = "DOCKER_HOST";
+
+pub struct DockerExporter<'a> {
+    workspace: &'a Workspace,
+    bldr_url: &'a str,
+}
+
+impl<'a> DockerExporter<'a> {
+    /// Creates a new Docker exporter for a given `Workspace` and Builder URL.
+    pub fn new(workspace: &'a Workspace, bldr_url: &'a str) -> Self {
+        DockerExporter {
+            workspace,
+            bldr_url,
+        }
+    }
+
+    /// Spawns a Docker export command, pipes output streams to the given `LogPipe` and returns the
+    /// process' `ExitStatus`.
+    ///
+    /// # Errors
+    ///
+    /// * If the child process can't be spawned
+    /// * If the calling thread can't wait on the child process
+    /// * If the `LogPipe` fails to pipe output
+    pub fn export(&self, log_pipe: &mut LogPipe) -> Result<ExitStatus> {
+        let dockerd = self.spawn_dockerd()?;
+        let exit_status = self.run_export(log_pipe);
+        self.teardown_dockerd(dockerd).err().map(|e| {
+            error!("failed to teardown dockerd instance, err={:?}", e)
+        });
+        exit_status
+    }
+
+    fn run_export(&self, log_pipe: &mut LogPipe) -> Result<ExitStatus> {
+        let sock = self.dockerd_sock();
+
+        let mut cmd = Command::new(&*DOCKER_EXPORTER_PROGRAM);
+        cmd.current_dir(self.workspace.root());
+        cmd.arg("--base-pkgs-url");
+        cmd.arg(&self.bldr_url);
+        cmd.arg("--url");
+        cmd.arg(&self.bldr_url);
+        cmd.arg("--tag-latest");
+        cmd.arg("--tag-version");
+        cmd.arg("--tag-version-release");
+        // TODO fn: enable push once passwords are gettable
+        // cmd.arg("--push-image");
+        // cmd.arg("--username");
+        // cmd.arg(username);
+        // cmd.arg("--password");
+        // cmd.arg(password);
+        // TODO fn: cleanup image once pushing is rolling
+        // cmd.arg("--rm-image");
+        cmd.arg(self.workspace.last_built()?.path); // Locally built artifact
+        debug!("building docker export command, cmd={:?}", &cmd);
+
+        cmd.env_clear();
+        if let Some(_) = env::var_os(RUNNER_DEBUG_ENVVAR) {
+            cmd.env("RUST_LOG", "debug");
+        }
+        cmd.env(NONINTERACTIVE_ENVVAR, "true"); // Disables progress bars
+        cmd.env("TERM", "xterm-256color"); // Emits ANSI color codes
+        debug!(
+            "setting docker export command env, {}={}",
+            DOCKER_HOST_ENVVAR,
+            sock
+        );
+        cmd.env(DOCKER_HOST_ENVVAR, sock); // Use the job-specific `dockerd`
+        cmd.stdout(Stdio::piped());
+        cmd.stderr(Stdio::piped());
+
+        debug!("spawning docker export command");
+        let mut child = cmd.spawn()?;
+        log_pipe.pipe(&mut child)?;
+        let exit_status = child.wait()?;
+        debug!("completed docker export command, status={:?}", exit_status);
+        Ok(exit_status)
+    }
+
+    fn spawn_dockerd(&self) -> Result<Child> {
+        let root = self.dockerd_path();
+        let env_path = &*DOCKERD_PROGRAM.parent().expect(
+            "Dockerd parent directory exists",
+        );
+        let daemon_json = root.join("etc/daemon.json");
+        fs::create_dir_all(daemon_json.parent().expect(
+            "Daemon JSON parent directory exists",
+        ))?;
+        {
+            let mut f = File::create(&daemon_json)?;
+            f.write_all(b"{}")?;
+        }
+
+        let mut cmd = Command::new(&*DOCKERD_PROGRAM);
+        if let Some(_) = env::var_os(RUNNER_DEBUG_ENVVAR) {
+            cmd.arg("-D");
+        }
+        cmd.arg("-H");
+        cmd.arg(self.dockerd_sock());
+        cmd.arg("--pidfile");
+        cmd.arg(root.join("var/run/docker.pid"));
+        cmd.arg("--data-root");
+        cmd.arg(root.join("var/lib/docker"));
+        cmd.arg("--exec-root");
+        cmd.arg(root.join("var/run/docker"));
+        cmd.arg("--config-file");
+        cmd.arg(daemon_json);
+        // TODO fn: Hard-coding this feels wrong. I'd like the {{pkg.svc_run_group}} for this
+        // service ideally. Probably plumb more config through for this.
+        cmd.arg("--group");
+        cmd.arg("hab");
+        cmd.arg("--iptables=false");
+        cmd.arg("--ip-masq=false");
+        cmd.arg("--ipv6=false");
+        cmd.arg("--raw-logs");
+        debug!("building dockerd command, cmd={:?}", &cmd);
+        cmd.env_clear();
+        debug!(
+            "setting docker export command env, PATH={}",
+            env_path.display()
+        );
+        cmd.env("PATH", env_path); // Sadly, `dockerd` needs its collaborator programs on `PATH`
+        cmd.stdout(Stdio::from(File::create(
+            self.workspace.root().join("dockerd.stdout.log"),
+        )?));
+        cmd.stderr(Stdio::from(File::create(
+            self.workspace.root().join("dockerd.stderr.log"),
+        )?));
+
+        debug!("spawning dockerd export command");
+        Ok(cmd.spawn()?)
+    }
+
+    fn teardown_dockerd(&self, mut dockerd: Child) -> Result<()> {
+        debug!(
+            "signaling dockerd to shutdown pid={}, sig={:?}",
+            dockerd.id(),
+            Signal::TERM
+        );
+        process::signal(dockerd.id(), Signal::TERM)?;
+        dockerd.wait()?;
+        debug!("terminated dockerd");
+        // TODO fn: clean up `self.dockerd_root()` directory
+        Ok(())
+    }
+
+    fn dockerd_path(&self) -> PathBuf {
+        self.workspace.root().join("dockerd")
+    }
+
+    fn dockerd_sock(&self) -> String {
+        format!(
+            "unix://{}",
+            self.dockerd_path().join("var/run/docker.sock").display()
+        )
+    }
+}

--- a/components/builder-worker/src/server.rs
+++ b/components/builder-worker/src/server.rs
@@ -149,7 +149,8 @@ impl Server {
     }
 
     fn enable_features_from_config(&self) {
-        let features: HashMap<_, _> = HashMap::from_iter(vec![("LIST", feat::List)]);
+        let features: HashMap<_, _> =
+            HashMap::from_iter(vec![("LIST", feat::List), ("DOCKER", feat::Docker)]);
         let features_enabled = self.config.features_enabled.split(",").map(|f| {
             f.trim().to_uppercase()
         });


### PR DESCRIPTION
This change adds support for exporting a built package into a Docker
image. The behavior is very much MVP as it lacks support for pushing to
Docker Hub still lacking (due to credentials), and cleaning up the
Docker images layers.

Here are some things to note:

* The Docker exporting shares the same log stream as the Studio build so
these will show up one after the other with a very simple section
starting/ending line.
* The exporting logic is handled with `hab-pkg-export-docker`.
* The worker will spawn its own isolated Docker Engine instance only to
be used by the current job and will later be destroyed after being
terminated. It should have no inbound network access and only runs for
the duration of the export process. The worker handles process
management so there is no additonal provisioning or Habitat services
needed on the worker.
* Currently, the behavior is to create a Docker image if the package is
found to be "runnable" without checking any `Job` data.
* No Docker Hub credentials are checked for and as a result, the image
is not currently pushed.

This exporting behavior is behind a small feature flag which is off by
default. Adding the feature token in the workers config will enable like
so:

```
features_enabled = "DOCKER"
```

Toggling this on at runtime under Habitat supervision can be
accomplished with `hab apply`:

```
echo 'features_enabled = "DOCKER"' \
  | hab apply builder-worker.default $(date +%s)
```

And turned off by removing the `DOCKER` token in the string:

```
echo 'features_enabled = ""' \
  | hab apply builder-worker.default $(date +%s)
```

---

Also…

## [builder-worker] Add behavioral feature flagging using config value

This change adds feature flags to the worker which can be enabled by
setting the `features_enabled` string field in the config as a comma
separated list of uppercase string tokens such as `"FOO,BAR"`.

References #3342

![tenor-5976805](https://user-images.githubusercontent.com/261548/31065228-eedc6034-a700-11e7-93df-4dbe40cf6b1c.gif)
