### PR TITLE
Fixes www build error for bad link

### DIFF
--- a/www/source/docs/internals.html.md.erb
+++ b/www/source/docs/internals.html.md.erb
@@ -17,6 +17,6 @@ This section will dive into the implementation details of how various Habitat co
 ---
 <%= partial "/partials/docs/internals-leader-election"%>
 ---
-<%= partial "/partials/docs/internals#crypto-internals"%>
+<%= partial "/partials/docs/internals-crypto"%>
 ---
 <%= partial "/partials/docs/internals-bootstrapping"%>


### PR DESCRIPTION
A typo in the Internals docs caused a partial to break during the middleman build process.

Signed-off-by: Ryan Keairns <rkeairns@chef.io>