### PR TITLE
Use GitHub App integration over OAuth App for authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ tags
 *.rustfmt
 .envrc
 .vscode
+.secrets

--- a/BUILDER_DEV.md
+++ b/BUILDER_DEV.md
@@ -6,10 +6,10 @@ This document outlines the steps to start and run a Builder environment for deve
 ## Pre-Reqs
 1. Use a Linux OS - either native or VM.
 1. Clone the habitat repo to your local filesystem. (If using a VM, you should use the local filesystem for the hab repo instead of using a mounted filesystem, otherwise things may fail later when running services).
-1. Ensure you have a Github auth token. Create from the Github site if you don't have one already. Token Capabilities needed: read:org, user:email
 1. The sample commands below use the 'httpie' tool. Install it if not present on your system (https://github.com/jkbrzt/httpie).
 1. A recent version of the habitat cli should also be installed in your dev environment (https://www.habitat.sh/docs/get-habitat/)
 1. Ensure that `sudo -E` functions correctly. Some OSes don't respect the -E flag. If this is the case, remove the `secure_path` section of your sudoers file.
+1. Copy `habitat-builder-dev.2017-10-02.private-key.pem` from 1Password into `.secrets/builder-github-app.pem`
 
 ## Bootstrap the OS with required packages
 You need to make sure you have the required packages installed.

--- a/components/builder-api/habitat/config/config.toml
+++ b/components/builder-api/habitat/config/config.toml
@@ -10,6 +10,7 @@ root = "{{pkg.svc_static_path}}"
 {{toToml cfg.web}}
 
 [github]
+app_private_key_path = "{{pkg.svc_files_path}}/builder-github-app.pem"
 {{toToml cfg.github}}
 
 {{~#eachAlive bind.router.members as |member|}}

--- a/components/builder-api/habitat/default.toml
+++ b/components/builder-api/habitat/default.toml
@@ -10,7 +10,6 @@ web_url = "https://github.com"
 client_id = ""
 client_secret = ""
 app_id = 5565
-app_private_key_path = "/hab/svc/builder-worker/files/github_app_private_key.pem"
 
 [web]
 app_url               = "https://bldr.habitat.sh"

--- a/components/builder-api/src/server/handlers.rs
+++ b/components/builder-api/src/server/handlers.rs
@@ -82,10 +82,6 @@ pub fn github_authenticate(req: &mut Request) -> IronResult<Response> {
 
             Ok(render_json(status::Ok, &session))
         }
-        Err(e @ HubError::AuthScope(_)) => {
-            let err = NetError::new(ErrCode::AUTH_SCOPE, e.to_string());
-            Ok(render_net_error(&err))
-        }
         Err(HubError::Auth(e)) => {
             let err = NetError::new(ErrCode::ACCESS_DENIED, e.error);
             Ok(render_net_error(&err))

--- a/components/builder-sessionsrv/habitat/config/config.toml
+++ b/components/builder-sessionsrv/habitat/config/config.toml
@@ -4,6 +4,7 @@ shards = {{toToml cfg.shards}}
 {{toToml cfg.permissions}}
 
 [github]
+app_private_key_path = "{{pkg.svc_files_path}}/builder-github-app.pem"
 {{toToml cfg.github}}
 
 {{~#eachAlive bind.router.members as |member|}}

--- a/components/builder-sessionsrv/habitat/default.toml
+++ b/components/builder-sessionsrv/habitat/default.toml
@@ -19,4 +19,3 @@ web_url = "https://github.com"
 client_id = ""
 client_secret = ""
 app_id = 5565
-app_private_key_path = "/hab/svc/builder-sessionsrv/files/github_app_private_key.pem"

--- a/components/builder-sessionsrv/src/config.rs
+++ b/components/builder-sessionsrv/src/config.rs
@@ -71,14 +71,14 @@ impl AppCfg for Config {
 pub struct PermissionsCfg {
     /// A GitHub Team identifier for which members will automatically have administration
     /// privileges assigned to their session
-    pub admin_team: u64,
+    pub admin_team: u32,
     /// GitHub team's whose members are granted Builder Worker abilities. These abilities
     /// include downloading the latest private key for any origin and uploading a package into
     /// any origin regardless of membership. This is essentially a user who ignores all rules.
-    pub build_worker_teams: Vec<u64>,
+    pub build_worker_teams: Vec<u32>,
     /// GitHub team's assigned to the early access group who may have access to features in Builder
     /// before a normal user.
-    pub early_access_teams: Vec<u64>,
+    pub early_access_teams: Vec<u32>,
 }
 
 #[cfg(test)]

--- a/components/builder-web/app/util.ts
+++ b/components/builder-web/app/util.ts
@@ -18,18 +18,11 @@ import config from "./config";
 import {Project} from "./records/Project";
 import {AppStore} from "./AppStore";
 
-// These OAuth scopes are required for a user to be authenticated. If this list is updated, then
-// the back-end also needs to be updated in `components/github-api-client/src/client.rs`. Both the
-// front-end app and back-end app should have identical requirements to make things easier for
-// our users and less cumbersome for us to message out.
-const AUTH_SCOPES = ["user:email", "read:org"];
-
 // Create a GitHub login URL
 export function createGitHubLoginUrl(state) {
     const params = {
         client_id: config["github_client_id"],
-        redirect_uri: `${window.location.protocol}//${window.location.host}`,
-        scope: AUTH_SCOPES.join(","),
+        redirect_uri: `${window.location.protocol}//${window.location.host}/`,
         state
     };
     const urlPrefix = `${config["github_web_url"]}/login/oauth/authorize`;

--- a/components/builder-web/habitat.conf.sample.js
+++ b/components/builder-web/habitat.conf.sample.js
@@ -12,9 +12,8 @@ habitatConfig({
     // The environment in which we're running. If "production", enable
     // production mode
     environment: "production",
-    // GitHub Client ID for OAuth2
-    // The example is for builder-dev: https://github.com/settings/connections/applications/0c2f738a7d0bd300de10
-    github_client_id: "0c2f738a7d0bd300de10",
+    // GitHub Client ID for GitHubApp
+    github_client_id: "Iv1.732260b62f84db15",
     // The API URL for GitHub
     github_api_url: "https://api.github.com",
     // The Web URL for GitHub

--- a/components/builder-worker/habitat/config/config.toml
+++ b/components/builder-worker/habitat/config/config.toml
@@ -7,6 +7,7 @@ bldr_url = "{{bind.depot.first.cfg.url}}"
 features_enabled = "{{cfg.features_enabled}}"
 
 [github]
+app_private_key_path = "{{pkg.svc_files_path}}/builder-github-app.pem"
 {{toToml cfg.github}}
 
 {{~#eachAlive bind.jobsrv.members as |member|}}

--- a/components/builder-worker/habitat/default.toml
+++ b/components/builder-worker/habitat/default.toml
@@ -10,4 +10,3 @@ web_url = "https://github.com"
 client_id = ""
 client_secret = ""
 app_id = 5565
-app_private_key_path = "/hab/svc/builder-worker/files/github_app_private_key.pem"

--- a/components/github-api-client/src/config.rs
+++ b/components/github-api-client/src/config.rs
@@ -16,17 +16,16 @@
 pub const DEFAULT_GITHUB_URL: &'static str = "https://api.github.com";
 /// URL to GitHub Web endpoint
 pub const DEFAULT_GITHUB_WEB_URL: &'static str = "https://github.com";
-/// Default Client ID for providing a default value in development environments only. This is
-/// associated to the habitat-sh GitHub account and is configured to re-direct and point to a local
-/// builder-api.
+/// Default Client ID providing a value in development environments only.
 ///
-/// See https://github.com/settings/connections/applications/0c2f738a7d0bd300de10
-pub const DEV_GITHUB_CLIENT_ID: &'static str = "0c2f738a7d0bd300de10";
-/// Default Client Secret for development purposes only. See the `DEV_GITHUB_CLIENT_ID` for
-/// additional comments.
-pub const DEV_GITHUB_CLIENT_SECRET: &'static str = "438223113eeb6e7edf2d2f91a232b72de72b9bdf";
+/// See https://developer.github.com/apps
+pub const DEV_GITHUB_CLIENT_ID: &'static str = "Iv1.732260b62f84db15";
+/// Default Client Secret providing a value in development environments only.
+///
+/// See https://developer.github.com/apps
+pub const DEV_GITHUB_CLIENT_SECRET: &'static str = "fc7654ed8c65ccfe014cd339a55e3538f935027a";
 /// Default github application id created in the habitat-sh org
-pub const DEFAULT_GITHUB_APP_ID: u64 = 5565;
+pub const DEFAULT_GITHUB_APP_ID: u32 = 5629;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(default)]
@@ -42,7 +41,7 @@ pub struct GitHubCfg {
     /// Client secret used for GitHub API requests
     pub client_secret: String,
     /// App Id used for builder integration
-    pub app_id: u64,
+    pub app_id: u32,
 }
 
 impl Default for GitHubCfg {
@@ -50,7 +49,7 @@ impl Default for GitHubCfg {
         GitHubCfg {
             url: DEFAULT_GITHUB_URL.to_string(),
             web_url: DEFAULT_GITHUB_WEB_URL.to_string(),
-            app_private_key: "".to_string(),
+            app_private_key: "/src/.secrets/builder-github-app.pem".to_string(),
             client_id: DEV_GITHUB_CLIENT_ID.to_string(),
             client_secret: DEV_GITHUB_CLIENT_SECRET.to_string(),
             app_id: DEFAULT_GITHUB_APP_ID,

--- a/components/github-api-client/src/error.rs
+++ b/components/github-api-client/src/error.rs
@@ -30,7 +30,6 @@ pub enum HubError {
     ApiError(hyper::status::StatusCode, HashMap<String, String>),
     AppAuth(types::AppAuthErr),
     Auth(types::AuthErr),
-    AuthScope(Vec<&'static str>),
     ContentDecode(base64::DecodeError),
     HttpClient(hyper::Error),
     HttpClientParse(hyper::error::ParseError),
@@ -51,7 +50,6 @@ impl fmt::Display for HubError {
             }
             HubError::AppAuth(ref e) => format!("GitHub App Authentication error, {}", e),
             HubError::Auth(ref e) => format!("GitHub Authentication error, {}", e),
-            HubError::AuthScope(ref e) => format!("Missing OAuth scope(s), '{}'", e.join(", ")),
             HubError::ContentDecode(ref e) => format!("{}", e),
             HubError::HttpClient(ref e) => format!("{}", e),
             HubError::HttpClientParse(ref e) => format!("{}", e),
@@ -69,7 +67,6 @@ impl error::Error for HubError {
             HubError::ApiError(_, _) => "Response returned a non-200 status code.",
             HubError::AppAuth(_) => "GitHub App authorization error.",
             HubError::Auth(_) => "GitHub authorization error.",
-            HubError::AuthScope(_) => "Authentication token is missing required OAuth scopes.",
             HubError::ContentDecode(ref err) => err.description(),
             HubError::HttpClient(ref err) => err.description(),
             HubError::HttpClientParse(ref err) => err.description(),

--- a/components/github-api-client/src/types.rs
+++ b/components/github-api-client/src/types.rs
@@ -18,13 +18,6 @@ use base64;
 
 use error::{HubError, HubResult};
 
-// These OAuth scopes are required for a user to be authenticated. If this list is updated, then
-// the front-end also needs to be updated in `components/builder-web/app/util.ts`. Both the
-// front-end app and back-end app should have identical requirements to make things easier for
-// our users and less cumbersome for us to message out.
-// https://developer.github.com/v3/oauth/#scopes
-const AUTH_SCOPES: &'static [&'static str] = &["user:email", "read:org"];
-
 #[derive(Debug, Deserialize, Serialize)]
 pub struct App {
     pub id: u32,
@@ -65,23 +58,6 @@ pub struct AuthOk {
     pub access_token: String,
     pub scope: String,
     pub token_type: String,
-}
-
-impl AuthOk {
-    pub fn missing_auth_scopes(&self) -> Vec<&'static str> {
-        let mut scopes = vec![];
-        for scope in AUTH_SCOPES.iter() {
-            if !self.scope.split(",").collect::<Vec<&str>>().iter().any(
-                |p| {
-                    p == scope
-                },
-            )
-            {
-                scopes.push(*scope);
-            }
-        }
-        scopes
-    }
 }
 
 #[derive(Deserialize, Serialize, Debug)]
@@ -225,7 +201,7 @@ pub struct GitHubAppInstallation {
 #[serde(default)]
 pub struct GitHubWebhookSender {
     pub login: String,
-    pub id: u64,
+    pub id: u32,
     pub avatar_url: String,
     pub gravatar_id: Option<String>,
     pub url: String,
@@ -254,7 +230,7 @@ pub struct GitHubOwner {
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[serde(default)]
 pub struct PushRepository {
-    pub id: u64,
+    pub id: u32,
     pub name: String,
     pub full_name: String,
     pub owner: Organization,
@@ -273,7 +249,7 @@ pub struct PushRepository {
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[serde(default)]
 pub struct Repository {
-    pub id: u64,
+    pub id: u32,
     pub name: String,
     pub full_name: String,
     pub owner: User,
@@ -293,7 +269,7 @@ pub struct Repository {
 #[serde(default)]
 pub struct Organization {
     pub login: String,
-    pub id: u64,
+    pub id: u32,
     pub avatar_url: String,
     pub url: String,
     pub company: Option<String>,
@@ -317,7 +293,7 @@ pub struct Organization {
 #[derive(Debug, Default, Serialize, Deserialize)]
 #[serde(default)]
 pub struct Team {
-    pub id: u64,
+    pub id: u32,
     pub url: String,
     pub name: String,
     pub slug: String,
@@ -326,16 +302,15 @@ pub struct Team {
     pub permission: String,
     pub members_url: String,
     pub repositories_url: String,
-    pub members_count: u64,
-    pub repos_count: u64,
+    pub members_count: u32,
+    pub repos_count: u32,
     pub organization: Organization,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
-#[serde(default)]
 pub struct User {
     pub login: String,
-    pub id: u64,
+    pub id: u32,
     pub avatar_url: String,
     pub gravatar_id: String,
     pub url: String,
@@ -349,7 +324,6 @@ pub struct User {
     pub repos_url: String,
     pub events_url: String,
     pub received_events_url: String,
-    pub site_admin: bool,
     pub name: Option<String>,
     pub company: Option<String>,
     pub blog: Option<String>,
@@ -365,16 +339,17 @@ pub struct User {
     pub updated_at: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
-pub struct Email {
-    pub email: String,
-    pub primary: bool,
-    pub verified: bool,
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct UserPlan {
+    pub name: String,
+    pub space: u32,
+    pub private_repos: u32,
+    pub collaborators: u32,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Search {
-    pub total_count: u64,
+    pub total_count: u32,
     pub incomplete_results: bool,
     pub items: Vec<SearchItem>,
 }
@@ -388,5 +363,18 @@ pub struct SearchItem {
     pub git_url: String,
     pub html_url: String,
     pub repository: Repository,
-    pub score: f64,
+    pub score: f32,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct TeamMembership {
+    pub url: String,
+    pub role: String,
+    pub state: String,
+}
+
+impl TeamMembership {
+    pub fn active(&self) -> bool {
+        self.state == "active"
+    }
 }

--- a/components/hab/src/command/cli/setup.rs
+++ b/components/hab/src/command/cli/setup.rs
@@ -117,11 +117,6 @@ pub fn start(ui: &mut UI, cache_path: &Path, analytics_path: &Path) -> Result<()
                addition, it is how you can perform continuous deployment with Habitat.",
     )?;
     ui.para(
-        "The depot uses GitHub authentication by personal access token with the \
-                  user:email and read:org scopes (https://help.github.\
-                  com/articles/creating-an-access-token-for-command-line-use/).",
-    )?;
-    ui.para(
         "If you would like to share your packages on the depot, please enter your GitHub \
                access token. Otherwise, just enter No.",
     )?;


### PR DESCRIPTION
This removes the need for user scopes and replaces the default dev
credentials for our applications with default credentials for our
dev GitHub App. User scopes are no longer required when using a GitHub
App, the permissions are instead based on what the user grants what
the App is asking for and what they make available.

Emails aren't guraranteed to be available to the GitHub App API so
we are optionally checking for it's value before setting it.
Additionally teams are handled differently and we will need to
do a bit of work to re-enable feature flagging on the back end.
We aren't currently using it so this shouldn't matter too much.

![tenor-107737936](https://user-images.githubusercontent.com/54036/31101067-005b2fb8-a781-11e7-8e88-aad1acf77cd4.gif)
