### PR TITLE
Add ability to get shard for account id

### DIFF
--- a/components/op/src/config.rs
+++ b/components/op/src/config.rs
@@ -18,6 +18,8 @@ pub struct Config {
     pub file: Option<String>,
     // origin to get the shard of
     pub origin: Option<String>,
+    // account to get the shard of
+    pub account: Option<u64>,
 }
 
 impl Default for Config {
@@ -25,6 +27,7 @@ impl Default for Config {
         Config {
             file: None,
             origin: None,
+            account: None,
         }
     }
 }

--- a/components/op/src/error.rs
+++ b/components/op/src/error.rs
@@ -21,7 +21,7 @@ use hcore;
 #[derive(Debug)]
 pub enum Error {
     NoFile,
-    NoOrigin,
+    NoParam,
     HabitatCore(hcore::Error),
 }
 
@@ -31,7 +31,9 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let msg = match *self {
             Error::NoFile => format!("No file was specified to hash"),
-            Error::NoOrigin => format!("No origin was specified to get a shard from"),
+            Error::NoParam => {
+                format!("No parameter was specified to get a shard from: try --origin or --account")
+            }
             Error::HabitatCore(ref e) => format!("{}", e),
         };
         write!(f, "{}", msg)
@@ -42,7 +44,9 @@ impl error::Error for Error {
     fn description(&self) -> &str {
         match *self {
             Error::NoFile => "No file was specified to hash",
-            Error::NoOrigin => "No origin was specified to get a shard from",
+            Error::NoParam => {
+                "No parameter was specified to get a shard from: try --origin or --account"
+            }
             Error::HabitatCore(ref err) => err.description(),
         }
     }

--- a/components/op/src/main.rs
+++ b/components/op/src/main.rs
@@ -52,8 +52,10 @@ fn app<'a, 'b>() -> clap::App<'a, 'b> {
             (@arg file: --file +takes_value "File to hash")
         )
         (@subcommand shard =>
-            (about: "Return the shard number for an origin")
+            (about: "Return the shard number for an origin or account id")
             (@arg origin: --origin +takes_value "Origin")
+            (@arg account: --account +takes_value "Account")
+
         )
     )
 }
@@ -65,6 +67,10 @@ fn config_from_args(matches: &clap::ArgMatches) -> Result<Config> {
 
     if let Some(origin) = args.value_of("origin") {
         config.origin = Some(origin.to_string());
+    }
+
+    if let Some(account) = args.value_of("account") {
+        config.account = Some(account.to_string().parse::<u64>().unwrap());
     }
 
     if let Some(file) = args.value_of("file") {


### PR DESCRIPTION
Update the op tool to add ability to retrieve shard from account id

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-119739269](https://user-images.githubusercontent.com/13542112/31103212-a157b8a6-a78a-11e7-8696-096840ee76c0.gif)
