### PR TITLE
Switch to GitHub apps

### DIFF
--- a/components/builder-web/app/BuilderApiClient.ts
+++ b/components/builder-web/app/BuilderApiClient.ts
@@ -109,6 +109,21 @@ export class BuilderApiClient {
         });
     }
 
+    public findFileInRepo(installationId: string, owner: string, repo: string, filename: string, page: number = 1, per_page: number = 100) {
+        return new Promise((resolve, reject) => {
+            fetch(`${this.urlPrefix}/ext/installations/${installationId}/search/code?q=repo:${owner}/${repo}+filename:${filename}&page=${page}&per_page=${per_page}`, {
+                method: "GET",
+                headers: this.headers,
+            }).then(response => {
+                if (response.ok) {
+                    resolve(response.json());
+                } else {
+                    reject(new Error(response.statusText));
+                }
+            });
+        });
+    }
+
     public updateProject(projectId, project) {
         return new Promise((resolve, reject) => {
             fetch(`${this.urlPrefix}/projects/${projectId}`, {
@@ -205,6 +220,21 @@ export class BuilderApiClient {
                     }
                 })
                 .catch(error => reject(error));
+        });
+    }
+
+    public getGitHubFileContent(installationId: string, owner: string, repo: string, path: string) {
+        return new Promise((resolve, reject) => {
+            fetch(`${this.urlPrefix}/ext/installations/${installationId}/repos/${repo}/contents/${encodeURIComponent(path)}`, {
+                method: "GET",
+                headers: this.headers
+            }).then(response => {
+                if (response.ok) {
+                    resolve(response.json());
+                } else {
+                    reject(new Error(response.statusText));
+                }
+            });
         });
     }
 

--- a/components/builder-web/app/GitHubApiClient.ts
+++ b/components/builder-web/app/GitHubApiClient.ts
@@ -35,64 +35,6 @@ export interface FileResponse {
 export class GitHubApiClient {
     constructor(private token: string) { }
 
-    // Checks to see if a file exists at a location
-    public doesFileExist(owner: string, repo: string, path: string) {
-        return new Promise((resolve, reject) => {
-            fetch(`${config["github_api_url"]}/repos/${owner}/${repo}/contents/${path}?access_token=${this.token}`, {
-                method: "GET"
-            }).then(response => {
-                if (response.status === 404) {
-                    reject(false);
-                } else {
-                    // Check to see if it's a file
-                    response.json().then(data => {
-                        if ("type" in data && data["type"] === "file") {
-                            resolve(true);
-                        } else {
-                            reject(false);
-                        }
-                    });
-                    resolve(true);
-                }
-            }).catch(error => reject(error));
-        });
-    }
-
-    // Search for a filename within a repo
-    public findFileInRepo(owner: string, repo: string, filename: string, page: number = 1, per_page: number = 100) {
-        return new Promise((resolve, reject) => {
-            fetch(`${config["github_api_url"]}/search/code?q=repo:${owner}/${repo}+filename:${filename}&page=${page}&per_page=${per_page}`, {
-                method: "GET",
-                headers: {
-                    "Authorization": `token ${this.token}`
-                }
-            }).then(response => {
-                if (response.ok) {
-                    resolve(response.json());
-                } else {
-                    reject(new Error(response.statusText));
-                }
-            });
-        });
-    }
-
-    public getFileContent(owner: string, repo: string, path: string) {
-        return new Promise((resolve, reject) => {
-            fetch(`${config["github_api_url"]}/repos/${owner}/${repo}/contents/${path}`, {
-                method: "GET",
-                headers: {
-                    "Authorization": `token ${this.token}`
-                }
-            }).then(response => {
-                if (response.ok) {
-                    resolve(response.json());
-                } else {
-                    reject(new Error(response.statusText));
-                }
-            });
-        });
-    }
-
     public getUser(username: string) {
         return new Promise((resolve, reject) => {
             fetch(`${config["github_api_url"]}/users/${username}?access_token=${this.token}`, {
@@ -108,6 +50,54 @@ export class GitHubApiClient {
                     }
                 }
             }).catch(error => reject(error));
+        });
+    }
+
+    public getUserInstallations() {
+        return new Promise((resolve, reject) => {
+            fetch(`${config["github_api_url"]}/user/installations?access_token=${this.token}`, {
+                method: "GET",
+                headers: {
+                    "Accept": [
+                        "application/vnd.github.v3+json",
+                        "application/vnd.github.machine-man-preview+json"
+                    ]
+                }
+            })
+            .then(response => {
+                if (response.ok) {
+                    resolve(response.json());
+                } else {
+                    reject(new Error(response.statusText));
+                }
+            })
+            .catch(error => {
+                reject(error);
+            });
+        });
+    }
+
+    public getUserInstallationRepositories(installationId: string) {
+        return new Promise((resolve, reject) => {
+            fetch(`${config["github_api_url"]}/user/installations/${installationId}/repositories?access_token=${this.token}`, {
+                method: "GET",
+                headers: {
+                    "Accept": [
+                        "application/vnd.github.v3+json",
+                        "application/vnd.github.machine-man-preview+json"
+                    ]
+                }
+            })
+            .then(response => {
+                if (response.ok) {
+                    resolve(response.json());
+                } else {
+                    reject(new Error(response.statusText));
+                }
+            })
+            .catch(error => {
+                reject(error);
+            });
         });
     }
 }

--- a/components/builder-web/app/actions/index.ts
+++ b/components/builder-web/app/actions/index.ts
@@ -25,13 +25,14 @@ import * as cookieActions from "./cookies";
 import * as featureFlagActions from "./feature-flags";
 
 // Action types
+export const CLEAR_GITHUB_FILES = gitHubActions.CLEAR_GITHUB_FILES;
+export const CLEAR_GITHUB_REPOS = gitHubActions.CLEAR_GITHUB_REPOS;
 export const LOAD_SESSION_STATE = gitHubActions.LOAD_SESSION_STATE;
 export const POPULATE_GITHUB_FILES = gitHubActions.POPULATE_GITHUB_FILES;
-export const POPULATE_GITHUB_ORGS = gitHubActions.POPULATE_GITHUB_ORGS;
+export const POPULATE_GITHUB_INSTALLATIONS = gitHubActions.POPULATE_GITHUB_INSTALLATIONS;
+export const POPULATE_GITHUB_INSTALLATION_REPOSITORIES = gitHubActions.POPULATE_GITHUB_INSTALLATION_REPOSITORIES;
 export const POPULATE_GITHUB_REPOS = gitHubActions.POPULATE_GITHUB_REPOS;
 export const POPULATE_GITHUB_USER_DATA = gitHubActions.POPULATE_GITHUB_USER_DATA;
-export const RESET_GITHUB_ORGS = gitHubActions.RESET_GITHUB_ORGS;
-export const RESET_GITHUB_REPOS = gitHubActions.RESET_GITHUB_REPOS;
 export const SET_GITHUB_ORGS_LOADING_FLAG = gitHubActions.SET_GITHUB_ORGS_LOADING_FLAG;
 export const SET_GITHUB_REPOS_LOADING_FLAG = gitHubActions.SET_GITHUB_REPOS_LOADING_FLAG;
 export const SET_GITHUB_AUTH_STATE = gitHubActions.SET_GITHUB_AUTH_STATE;
@@ -116,11 +117,9 @@ export const RESET = "RESET";
 // Actions
 export const authenticateWithGitHub = gitHubActions.authenticateWithGitHub;
 export const fetchGitHubFiles = gitHubActions.fetchGitHubFiles;
-export const clearGitHubRepos = gitHubActions.clearGitHubRepos;
-export const fetchGitHubOrgs = gitHubActions.fetchGitHubOrgs;
-export const fetchGitHubRepos = gitHubActions.fetchGitHubRepos;
+export const fetchGitHubInstallations = gitHubActions.fetchGitHubInstallations;
+export const fetchGitHubInstallationRepositories = gitHubActions.fetchGitHubInstallationRepositories;
 export const loadSessionState = gitHubActions.loadSessionState;
-export const onGitHubOrgSelect = gitHubActions.onGitHubOrgSelect;
 export const removeSessionStorage = gitHubActions.removeSessionStorage;
 export const requestGitHubAuthToken = gitHubActions.requestGitHubAuthToken;
 export const setGitHubAuthState = gitHubActions.setGitHubAuthState;

--- a/components/builder-web/app/initialState.ts
+++ b/components/builder-web/app/initialState.ts
@@ -27,6 +27,8 @@ export default Record({
   gitHub: Record({
     authState: undefined,
     authToken: undefined,
+    installations: List(),
+    installationRepositories: List(),
     orgs: List(),
     repos: List(),
     files: List(),

--- a/components/builder-web/app/package/package-settings/package-settings.component.ts
+++ b/components/builder-web/app/package/package-settings/package-settings.component.ts
@@ -6,8 +6,8 @@ import { GitHubApiClient } from "../../GitHubApiClient";
 import { GitHubRepo } from "../../github/repo/shared/github-repo.model";
 import { requireSignIn } from "../../util";
 import { AppStore } from "../../AppStore";
-import { addNotification, addProject, updateProject, setProjectIntegrationSettings, deleteProject, fetchGitHubFiles, fetchGitHubOrgs,
-         fetchGitHubRepos, fetchProject, clearGitHubRepos } from "../../actions/index";
+import { addNotification, addProject, updateProject, setProjectIntegrationSettings, deleteProject,
+    fetchGitHubFiles, fetchProject } from "../../actions/index";
 import config from "../../config";
 
 @Component({

--- a/components/builder-web/app/reducers/gitHub.ts
+++ b/components/builder-web/app/reducers/gitHub.ts
@@ -18,16 +18,22 @@ import initialState from "../initialState";
 
 export default function gitHub(state = initialState["gitHub"], action) {
     switch (action.type) {
+
+        case actionTypes.CLEAR_GITHUB_FILES:
+            return state.set("files", List());
+
+        case actionTypes.CLEAR_GITHUB_REPOS:
+            return state.set("repos", List());
+
         case actionTypes.LOAD_SESSION_STATE:
             return state.set("authState", action.payload.gitHubAuthState).
                 set("authToken", action.payload.gitHubAuthToken);
 
-        case actionTypes.POPULATE_GITHUB_ORGS:
-            return state.set("orgs",
-                state.get("orgs").concat(fromJS(action.payload)).
-                    sortBy(org => org.get("login")
-                )
-            );
+        case actionTypes.POPULATE_GITHUB_INSTALLATIONS:
+            return state.set("installations", fromJS(action.payload.installations));
+
+        case actionTypes.POPULATE_GITHUB_INSTALLATION_REPOSITORIES:
+            return state.set("installationRepositories", fromJS(action.payload.repositories));
 
         case actionTypes.POPULATE_GITHUB_REPOS:
             return state.set("repos",
@@ -40,12 +46,6 @@ export default function gitHub(state = initialState["gitHub"], action) {
                 if (a.path > b.path) { return 1; }
                 return 0;
             })));
-
-        case actionTypes.RESET_GITHUB_ORGS:
-            return state.set("orgs", List());
-
-        case actionTypes.RESET_GITHUB_REPOS:
-            return state.set("repos", List());
 
         case actionTypes.SET_GITHUB_AUTH_STATE:
             return state.set("authState", action.payload);

--- a/components/builder-web/app/shared/github-repo-picker/github-repo-picker.component.ts
+++ b/components/builder-web/app/shared/github-repo-picker/github-repo-picker.component.ts
@@ -16,8 +16,7 @@ import { Component, Input, OnInit, Output, EventEmitter } from "@angular/core";
 import { List, Map, OrderedSet } from "immutable";
 import { AppStore } from "../../AppStore";
 import { GitHubRepo } from "../../github/repo/shared/github-repo.model";
-import {fetchGitHubOrgs, fetchGitHubRepos,
-  onGitHubOrgSelect, setSelectedGitHubOrg, resetRedirectRoute} from "../../actions/index";
+import { setSelectedGitHubOrg, resetRedirectRoute } from "../../actions/index";
 
 @Component({
   selector: "hab-github-repo-picker",
@@ -36,19 +35,12 @@ export class GitHubRepoPickerComponent implements OnInit {
   repoSelectCancel: Function;
 
   constructor(private store: AppStore) {
-    this.store.dispatch(fetchGitHubOrgs());
     this.clickFetchGitHubRepos = () => {
-      this.store.dispatch(fetchGitHubRepos(
-        this.selectedOrg, 1,
-        this.selectedOrg === this.user.get("login") ?
-          this.user.get("login") : undefined
-      ));
       return false;
     };
 
     this.orgSelect = (org, username) => {
       this.selectedOrg = org;
-      this.store.dispatch(onGitHubOrgSelect(org, username));
       return false;
     };
 
@@ -64,7 +56,7 @@ export class GitHubRepoPickerComponent implements OnInit {
   }
 
   public ngOnInit() {
-    // this.fetchGitHubOrgs();
+
   }
 
   get gitHub() {

--- a/components/builder-web/app/shared/plan-select/plan-select.component.ts
+++ b/components/builder-web/app/shared/plan-select/plan-select.component.ts
@@ -68,9 +68,6 @@ export class PackagePlanSelectComponent implements OnInit {
   repoSelected(ownerAndRepo: string) {
     [this.owner, this.repo] = ownerAndRepo.split("/");
 
-    this.gitHubClient.findFileInRepo(this.owner, this.repo, "plan.")
-      .then(this.handleGitHubFileResponse.bind(this));
-
     return false;
   };
 

--- a/components/builder-web/app/shared/project-settings/_project-settings.component.scss
+++ b/components/builder-web/app/shared/project-settings/_project-settings.component.scss
@@ -17,7 +17,7 @@ hab-project-settings {
       margin-bottom: 14px;
     }
 
-    .orgs {
+    .installations {
       @include span-columns(4.5 of 9);
 
       img {
@@ -41,7 +41,7 @@ hab-project-settings {
       @include row;
     }
 
-    .orgs, .repos {
+    .installations, .repos {
 
       li {
         line-height:  40px;

--- a/components/builder-web/app/shared/project-settings/project-settings.component.html
+++ b/components/builder-web/app/shared/project-settings/project-settings.component.html
@@ -48,36 +48,26 @@
             <li [class.active]="selectedRepo">Set path to Habitat plan file</li>
         </ol>
         <div class="browser" *ngIf="!selectedRepo">
-            <div class="orgs">
+            <div class="installations">
                 <h3>
                     <hab-icon symbol="github"></hab-icon>
-                    GitHub Orgs for {{ user.get("login") }}
+                    Installed Apps
                 </h3>
                 <ul>
-                    <li>
-                        <a (click)="selectUser(user.get('login'))"
-                            [class.active]='user.get("login") === selectedOrg'>
-                            <img src="{{ user.get('avatar_url') }}?s=32">
-                            {{ user.get("login") }}
-                            <hab-icon symbol="chevron-right"></hab-icon>
-                        </a>
-                    </li>
-                    <li *ngFor="let org of orgs">
-                        <a (click)="selectOrg(org.get('login'))"
-                            [class.active]="org.get('login') === selectedOrg">
-                            <img src='{{org.get("avatar_url")}}?s=32'>
-                            {{ org.get("login") }}
+                    <li *ngFor="let installation of installations">
+                        <a (click)="selectInstallation(installation)" [class.active]="installation === selectedInstallation">
+                            {{ installation.get("id") }}
                             <hab-icon symbol="chevron-right"></hab-icon>
                         </a>
                     </li>
                 </ul>
             </div>
             <div class="repos">
-                <h3>GitHub Repos for Selected Org</h3>
+                <h3>Repositories for App</h3>
                 <input [(ngModel)]="filter.name" placeholder="Filter by name">
                 <ul>
                     <li *ngFor="let repo of repos | habGitHubRepoFilter:filter:'name'">
-                        <a (click)="selectRepo(repo.get('name'))">
+                        <a (click)="selectRepo(repo)">
                             {{ repo.get("name") }}
                             <hab-icon symbol="chevron-right"></hab-icon>
                         </a>


### PR DESCRIPTION
This change provides initial support for migrating to GitHub apps. When connecting a plan, it first retrieves the list of app "installations," then uses Builder as a proxy to GitHub for listing and searching repositories.  

Signed-off-by: Christian Nunciato <cnunciato@chef.io>

![](https://media.tenor.com/images/2378e051f383b80e4fc41db42ff5d49b/tenor.gif)