### PR TITLE
Updated export to docker snippets + text

### DIFF
--- a/www/source/partials/docs/_dev-pkgs-exports.html.md.erb
+++ b/www/source/partials/docs/_dev-pkgs-exports.html.md.erb
@@ -13,17 +13,13 @@ You can create a Docker container image for any package by performing the follow
 
 2. Create an interactive studio with the `hab studio enter` command.
 
-3. Install or [build](/docs/developing-packages/#plan-builds) the Habitat package from which you want to create a Docker container image, for example:
+3. [Build](/docs/developing-packages/#plan-builds) the Habitat package from which you want to create a Docker container image and then run the Docker exporter on the package.
 
     ```
-    $ hab pkg install yourorigin/yourpackage
+    $ hab pkg export docker ./results/<hart-filename>.hart
     ```
 
-4. Run the Docker exporter on the package.
-
-    ```
-    $ hab pkg export docker yourorigin/yourpackage
-    ```
+  > **Note** The command above is for local testing only. If you have uploaded your package to Builder, you can export it by calling <code>hab pkg export docker origin/package</code>. The default is to use the latest stable release; however, you can override that by specifying a different channel in an optional flag.
 
 5. You can now exit the studio. The new Docker container image exists on your computer and can be examined with `docker images` or run with `docker run`.
 

--- a/www/source/tutorials/build-your-own/build-test.html.slim
+++ b/www/source/tutorials/build-your-own/build-test.html.slim
@@ -63,7 +63,10 @@ section
  p After you have built your package and are ready to test it outside of the Studio, export it to a Docker container.
 
  pre
-  code # hab pkg export docker origin/package && exit
+  code # hab pkg export docker ./results/&lt;hart-filename>.hart && exit
+
+ blockquote
+  p <b>Note</b> The command above is for local testing only. If you have uploaded your package to Builder, you can export it by calling <code>hab pkg export docker origin/package</code>. The default is to use the latest stable release; however, you can override that by specifying a different channel in an optional flag.
 
  p The following example shows how to start the Docker container running your Habitat package.
 

--- a/www/source/tutorials/build-your-own/connect-database.html.slim
+++ b/www/source/tutorials/build-your-own/connect-database.html.slim
@@ -204,7 +204,7 @@ section
    |
     $ hab studio enter
     # build
-    # hab pkg export docker origin/package && exit
+    # hab pkg export docker ./results/&lt;hart-filename>.hart && exit
 
  p Run the docker container for your web application.
 
@@ -251,7 +251,7 @@ section
    |
     $ hab studio enter
     # build
-    # hab pkg export docker origin/package && exit
+    # hab pkg export docker ./results/&lt;hart-filename>.hart && exit
 
  p Because you're not interacting with another Habitat package as in the previous section, you do not need to set the service binding or join a ring with another service. Simply run the Docker container for your web application and set an exposed port so you can browse to your web application from your local workstation
 

--- a/www/source/tutorials/build-your-own/connect-nginx.html.slim
+++ b/www/source/tutorials/build-your-own/connect-nginx.html.slim
@@ -177,7 +177,7 @@ section
  pre
   code
    | 
-    # hab pkg export docker origin/reverse-proxy
+    # hab pkg export docker ./results/&lt;hart-filename>.hart
     
  h2 <a name="run-application">Run your package with your web application</a>
 

--- a/www/source/tutorials/sample-app/linux/build-package.html.slim
+++ b/www/source/tutorials/sample-app/linux/build-package.html.slim
@@ -53,15 +53,18 @@ section.sample-app
 
   p Habitat packages can be exported into multiple runtime formats where the Habitat Supervisor, user package, and any runtime dependencies are installed and setup in that environment. For Docker containers, this means creating an image using the Docker scratch image and building up the rest of the image with exported packages.
 
-  p Run <code>hab pkg export docker originname/myrailsapp</code> with the origin you chose at setup.
+  p Run <code>hab pkg export docker</code> and reference the .hart file you created in the previous section.
 
   pre
-    code.console [2][default:/src:0]# hab pkg export docker originname/myrailsapp
+    code.console [2][default:/src:0]# hab pkg export docker ./results/&lt;hart-filename>.hart
 
   p Because we need to connect to a PostgreSQL database managed by Habitat, export the PostgreSQL database package to a Docker container as well.
 
   pre
     code.console [1][default:/src:0]# hab pkg export docker core/postgresql
+
+  blockquote
+   p <b>Note</b> If you specify an <code>origin/package</code> identifier, such as <code>core/postgresql</code>, instead of a local .hart file the Habitat CLI will check Builder for the latest stable version of the package and export that.
 
   p Once you have finished exporting both packages, exit out of the Studio.
 

--- a/www/source/tutorials/sample-app/mac/build-package.html.slim
+++ b/www/source/tutorials/sample-app/mac/build-package.html.slim
@@ -56,15 +56,18 @@ section.sample-app
 
   p Habitat packages can be exported into multiple runtime formats where the Habitat Supervisor, user package, and any runtime dependencies are installed and setup in that environment. For Docker containers, this means creating an image using the Docker scratch image and building up the rest of the image with exported packages.
 
-  p Run <code>hab pkg export docker originname/myrailsapp</code> with the origin you chose at setup.
+  p Run <code>hab pkg export docker</code> and reference the .hart file you created in the previous section.
 
   pre
-    code.console [3][default:/src:0]# hab pkg export docker originname/myrailsapp
+    code.console [2][default:/src:0]# hab pkg export docker ./results/&lt;hart-filename>.hart
 
   p Because we need to connect to a PostgreSQL database managed by Habitat, export the PostgreSQL database package to a Docker container as well.
 
   pre
-    code.console [4][default:/src:0]# hab pkg export docker core/postgresql
+    code.console [1][default:/src:0]# hab pkg export docker core/postgresql
+
+  blockquote
+   p <b>Note</b> If you specify an <code>origin/package</code> identifier, such as <code>core/postgresql</code>, instead of a local .hart file the Habitat CLI will check Builder for the latest stable version of the package and export that.
 
   p Once you have finished exporting both packages, exit out of the Studio.
 

--- a/www/source/tutorials/sample-app/windows/build-package.html.slim
+++ b/www/source/tutorials/sample-app/windows/build-package.html.slim
@@ -56,15 +56,18 @@ section.sample-app
 
     p Habitat packages can be exported into multiple runtime formats where the Habitat Supervisor, user package, and any runtime dependencies are installed and setup in that environment. For Docker containers, this means creating an image using the Docker scratch image and building up the rest of the image with exported packages.
 
-    p Run <code>hab pkg export docker originname/myrailsapp</code> with the origin you chose at setup.
+    p Run <code>hab pkg export docker</code> and reference the .hart file you created in the previous section.
 
     pre
-      code.powershell [2][default:/src:0]# hab pkg export docker originname/myrailsapp
+      code.console [2][default:/src:0]# hab pkg export docker ./results/&lt;hart-filename>.hart
 
     p Because we need to connect to a PostgreSQL database managed by Habitat, export the PostgreSQL database package to a Docker container as well.
 
     pre
-      code.powershell [1][default:/src:0]# hab pkg export docker core/postgresql
+      code.console [1][default:/src:0]# hab pkg export docker core/postgresql
+
+    blockquote
+     p <b>Note</b> If you specify an <code>origin/package</code> identifier, such as <code>core/postgresql</code>, instead of a local .hart file the Habitat CLI will check Builder for the latest stable version of the package and export that.
 
     p Once you have finished exporting both packages, exit out of the Studio.
 


### PR DESCRIPTION
Changes in 0.34.1 now require that you specify a .hart if you want to build a Docker image from a local package.

Addresses #3467 

Signed-off-by: David Wrede <dwrede@chef.io>