### PR TITLE
Don't cache response for integration names

### DIFF
--- a/components/builder-depot/src/handlers/integrations.rs
+++ b/components/builder-depot/src/handlers/integrations.rs
@@ -17,6 +17,7 @@ use std::collections::HashMap;
 use bldr_core;
 use bodyparser;
 use http_gateway::http::controller::*;
+use http_gateway::http::helpers;
 use iron::status::{self, Status};
 
 use protocol::originsrv::*;
@@ -83,7 +84,11 @@ pub fn fetch_origin_integration_names(req: &mut Request) -> IronResult<Response>
     request.set_origin(params["origin"].clone());
     request.set_integration(params["integration"].clone());
     match route_message::<OriginIntegrationGetNames, OriginIntegrationNames>(req, &request) {
-        Ok(integration) => Ok(render_json(status::Ok, &integration)),
+        Ok(integration) => {
+            let mut response = render_json(status::Ok, &integration);
+            helpers::dont_cache_response(&mut response);
+            Ok(response)
+        }
         Err(err) => {
             match err.get_code() {
                 ErrCode::ENTITY_NOT_FOUND => Ok(Response::with((status::NotFound))),

--- a/components/builder-depot/src/server.rs
+++ b/components/builder-depot/src/server.rs
@@ -28,7 +28,7 @@ use hab_core::crypto::{BoxKeyPair, SigKeyPair};
 use hab_core::crypto::PUBLIC_BOX_KEY_VERSION;
 use hab_core::event::*;
 use http_gateway::http::controller::*;
-use http_gateway::http::helpers;
+use http_gateway::http::helpers::{self, dont_cache_response};
 use http_gateway::http::middleware::XRouteClient;
 use hab_net::{privilege, ErrCode, NetOk, NetResult};
 use hyper::header::{Charset, ContentDisposition, DispositionType, DispositionParam};
@@ -2122,12 +2122,6 @@ where
 fn do_cache_response(response: &mut Response) {
     response.headers.set(CacheControl(
         format!("public, max-age={}", ONE_YEAR_IN_SECS),
-    ));
-}
-
-fn dont_cache_response(response: &mut Response) {
-    response.headers.set(CacheControl(
-        format!("private, no-cache, no-store"),
     ));
 }
 

--- a/components/builder-http-gateway/src/http/helpers.rs
+++ b/components/builder-http-gateway/src/http/helpers.rs
@@ -58,6 +58,12 @@ pub fn get_authenticated_session(req: &mut Request) -> Option<Session> {
     }
 }
 
+pub fn dont_cache_response(response: &mut Response) {
+    response.headers.set(CacheControl(
+        format!("private, no-cache, no-store"),
+    ));
+}
+
 pub fn validate_params(
     req: &mut Request,
     expected_params: &[&str],


### PR DESCRIPTION
We need to set the no-cache for one of the depot API calls.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-262581493](https://user-images.githubusercontent.com/13542112/31147330-616c41c6-a83e-11e7-8943-a04d2582177f.gif)
