### PR TITLE
Fix deserialization of some GitHub Webhook messages

### DIFF
--- a/components/github-api-client/src/types.rs
+++ b/components/github-api-client/src/types.rs
@@ -140,7 +140,7 @@ pub struct GitHubWebhookPush {
     /// of 20 commits. If necessary, you can use the Commits API to fetch additional commits.
     /// This limit is applied to timeline events only and isn't applied to webhook deliveries)
     pub commits: Vec<GitHubWebhookCommit>,
-    pub head_commit: GitHubWebhookCommit,
+    pub head_commit: Option<GitHubWebhookCommit>,
     pub repository: PushRepository,
     pub pusher: GitHubOwner,
     pub sender: GitHubWebhookSender,


### PR DESCRIPTION
* make head_commit an optional field

Signed-off-by: Jamie Winsor <jamie@vialstudios.com>