### PR TITLE
[pkg-export-docker] Ensure image name & custom tag are lowercased.

### DIFF
--- a/components/pkg-export-docker/src/docker.rs
+++ b/components/pkg-export-docker/src/docker.rs
@@ -461,7 +461,7 @@ impl DockerBuildRoot {
         let image_name = match naming.custom_image_name {
             Some(ref custom) => Handlebars::new().template_render(custom, &json)?,
             None => format!("{}/{}", ident.origin, ident.name),
-        };
+        }.to_lowercase();
 
         let mut image = DockerImage::new(self.0.workdir(), image_name);
         if naming.version_release_tag {
@@ -474,7 +474,11 @@ impl DockerBuildRoot {
             image = image.tag("latest".to_string());
         }
         if let Some(ref custom) = naming.custom_tag {
-            image = image.tag(Handlebars::new().template_render(custom, &json)?);
+            image = image.tag(
+                Handlebars::new()
+                    .template_render(custom, &json)?
+                    .to_lowercase(),
+            );
         }
         image.build()
     }


### PR DESCRIPTION
```sh
> hab pkg export docker --image-name fnichol/ANGRY-REDIS --tag-custom ANGRY-TAG core/redis
» Building a runnable Docker image with: core/redis
Ω Creating build root in /tmp/hab-pkg-export-docker.BEAjckkKUqbu
Ω Creating root filesystem
Ω Creating artifact cache symlink
» Installing core/hab from channel 'stable'
...
Ω Creating user 'hab' in /etc/passwd
Ω Creating group 'hab' in /etc/group
Ω Creating entrypoint script
Ω Creating image Dockerfile
Ω Creating Docker image
Sending build context to Docker daemon  121.4MB
Step 1/7 : FROM scratch
 --->
Step 2/7 : ENV PATH /bin
 ---> Running in b9f1350a5e34
 ---> 26f3a0c40f72
Removing intermediate container b9f1350a5e34
Step 3/7 : ADD rootfs /
 ---> 2db5cf8f5a3c
Step 4/7 : VOLUME /hab/svc/redis/data /hab/svc/redis/config
 ---> Running in e4da35758db7
 ---> ee232e272623
Removing intermediate container e4da35758db7
Step 5/7 : EXPOSE 9631 6379
 ---> Running in 49f14eeec50c
 ---> 51506fd733b7
Removing intermediate container 49f14eeec50c
Step 6/7 : ENTRYPOINT /init.sh
 ---> Running in 3f7037c771d7
 ---> 63d1bf9c2403
Removing intermediate container 3f7037c771d7
Step 7/7 : CMD start core/redis
 ---> Running in 083a09a318f1
 ---> b4d27f01bcdc
Removing intermediate container 083a09a318f1
Successfully built b4d27f01bcdc
Successfully tagged fnichol/angry-redis:3.2.4-20170514150022
Successfully tagged fnichol/angry-redis:3.2.4
Successfully tagged fnichol/angry-redis:latest
Successfully tagged fnichol/angry-redis:angry-tag
☒ Deleting temporary files
★ Docker image 'fnichol/angry-redis' created with tags: 3.2.4-20170514150022, 3.2.4, latest, angry-tag
Ω Creating build report /home/fnichol/Projects/github.com/habitat-sh/habitat/components/pkg-export-docker/results/last_docker_export.env

> docker images
REPOSITORY            TAG                    IMAGE ID            CREATED             SIZE
fnichol/angry-redis   3.2.4                  b4d27f01bcdc        11 seconds ago      117MB
fnichol/angry-redis   3.2.4-20170514150022   b4d27f01bcdc        11 seconds ago      117MB
fnichol/angry-redis   angry-tag              b4d27f01bcdc        11 seconds ago      117MB
fnichol/angry-redis   latest                 b4d27f01bcdc        11 seconds ago      117MB
```

Closes #3497
References #2417

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>