### PR TITLE
Show the org name instead of id when displaying installed apps

### DIFF
--- a/components/builder-web/app/shared/project-settings/project-settings.component.html
+++ b/components/builder-web/app/shared/project-settings/project-settings.component.html
@@ -56,7 +56,7 @@
                 <ul>
                     <li *ngFor="let installation of installations">
                         <a (click)="selectInstallation(installation)" [class.active]="installation === selectedInstallation">
-                            {{ installation.get("id") }}
+                            {{ installation.getIn(["account", "login"]) }}
                             <hab-icon symbol="chevron-right"></hab-icon>
                         </a>
                     </li>


### PR DESCRIPTION
Hopefully I did this right?  I haven't touched the UI in 8 months or so.

![tenor-173843117](https://user-images.githubusercontent.com/947/31190871-4685cc66-a8f1-11e7-9ddb-344d52f4fb03.gif)

Closes https://github.com/habitat-sh/habitat/issues/3504
Signed-off-by: Josh Black <raskchanky@gmail.com>