### PR TITLE
[studio] Only honor `.studiorc` in `hab studio enter`.

### DIFF
--- a/components/hab/src/command/studio/docker.rs
+++ b/components/hab/src/command/studio/docker.rs
@@ -63,6 +63,7 @@ pub fn start_docker_studio(_ui: &mut UI, mut args: Vec<OsString>) -> Result<()> 
         "HAB_BLDR_URL",
         "HAB_BLDR_CHANNEL",
         "HAB_ORIGIN",
+        "HAB_STUDIO_NOSTUDIORC",
         "HAB_STUDIO_SUP",
         "HAB_UPDATE_STRATEGY_FREQUENCY_MS",
         "http_proxy",

--- a/components/studio/bin/hab-studio.sh
+++ b/components/studio/bin/hab-studio.sh
@@ -93,7 +93,9 @@ ENVIRONMENT VARIABLES:
     HAB_ORIGIN          Propagates this variable into any studios
     HAB_ORIGIN_KEYS     Installs secret keys (\`-k' option overrides)
     HAB_STUDIOS_HOME    Sets a home path for all Studios (default: /hab/studios)
+    HAB_STUDIO_NOSTUDIORC Disables sourcing a \`.studiorc' in \`studio enter'
     HAB_STUDIO_ROOT     Sets a Studio root (\`-r' option overrides)
+    HAB_STUDIO_SUP      Sets args for a Supervisor in \`studio enter'
     NO_ARTIFACT_PATH    If set, do not mount the source artifact cache path (\`-N' flag overrides)
     NO_SRC_PATH         If set, do not mount the source path (\`-n' flag overrides)
     QUIET               Prints less output (\`-q' flag overrides)
@@ -956,6 +958,11 @@ chroot_env() {
   if [ -n "${HAB_ORIGIN:-}" ]; then
     env="$env HAB_ORIGIN=$HAB_ORIGIN"
   fi
+  # If a skip .studiorc environment variable is set, then propagate it into the
+  # Studio's environment.
+  if [ -n "${HAB_STUDIO_NOSTUDIORC:-}" ]; then
+    env="$env HAB_STUDIO_NOSTUDIORC=$HAB_STUDIO_NOSTUDIORC"
+  fi
   # Used to customize the arguments to pass to an automatically launched
   # Supervisor, or to disable the automatic launching (by setting to 'false').
   if [ -n "${HAB_STUDIO_SUP:-}" ]; then
@@ -1010,6 +1017,9 @@ report_env_vars() {
   fi
   if [ -n "${HAB_NONINTERACTIVE:-}" ]; then
     info "Exported: HAB_NONINTERACTIVE=$HAB_NONINTERACTIVE"
+  fi
+  if [ -n "${HAB_STUDIO_NOSTUDIORC:-}" ]; then
+    info "Exported: HAB_STUDIO_NOSTUDIORC=$HAB_STUDIO_NOSTUDIORC"
   fi
   if [ -n "${HAB_STUDIO_SUP:-}" ]; then
     info "Exported: HAB_STUDIO_SUP=$HAB_STUDIO_SUP"

--- a/components/studio/libexec/hab-studio-type-default.sh
+++ b/components/studio/libexec/hab-studio-type-default.sh
@@ -163,16 +163,18 @@ if [[ -n "\${STUDIO_ENTER:-}" ]]; then
   source /etc/profile.enter
 fi
 
-# Source /src/.studiorc so we can apply user-specific configuration
-if [ -f /src/.studiorc ];then
-  source /src/.studiorc
-fi
-
 # Add command line completion
 source <(hab cli completers --shell bash)
 PROFILE
 
   $bb cat > $HAB_STUDIO_ROOT/etc/profile.enter <<PROFILE_ENTER
+# Source /src/.studiorc so we can apply user-specific configuration
+if [[ -f /src/.studiorc && -z "\${HAB_STUDIO_NOSTUDIORC:-}" ]]; then
+  echo "--> Detected and loading /src/.studiorc"
+  echo ""
+  source /src/.studiorc
+fi
+
 # Automatically run the Habitat Supervisor
 case "\${HAB_STUDIO_SUP:-}" in
   false|FALSE|no|NO|0)

--- a/www/source/partials/docs/_reference-environment-vars.html.md.erb
+++ b/www/source/partials/docs/_reference-environment-vars.html.md.erb
@@ -18,6 +18,7 @@ This is a list of all environment variables that can be used to modify the opera
 | `HAB_RING_KEY` | Supervisor | no default | The name of the ring key when running with [wire encryption](/docs/using-habitat#using-encryption) |
 | `HAB_STUDIOS_HOME` | build system | `/hab/studios` if running as root; `$HOME/.hab/studios` if running as non-root | Directory in which to create build studios |
 | `HAB_STUDIO_ROOT` | build system | no default | Root of the current studio under `$HAB_STUDIOS_HOME`. Infrequently overridden. |
+| `HAB_STUDIO_NOSTUDIORC` | build system | no default | When set to a non-empty value, a `.studiorc` will not be sourced when entering an interactive Studio via `hab studio enter`. |
 | `HAB_STUDIO_SUP` | build system | no default | Used to customize the arguments passed to an automatically launched Supervisor, or to disable the automatic launching by setting it to `false`, `no`, or `0`. |
 | `HAB_UPDATE_STRATEGY_FREQUENCY_MS` | Supervisor | 60000 | Frequency of milliseconds to check for updates when running with an [update strategy](/docs/using-habitat#using-updates) |
 | `HAB_USER` | Supervisor | no default | User key to use when running with [service group encryption](/docs/using-habitat#using-encryption) |
@@ -36,3 +37,5 @@ customizations to help you develop your plans from within the studio.
 
 To use this feature, place a `.studiorc` in the current working directory
 where you will run `hab studio enter`.
+
+Note that a `.studiorc` will only be source when using `hab studio enter`--it will not be sourced when calling `hab studio run` or `hab studio build` (also `hab pkg build`).


### PR DESCRIPTION
This change restricts where a provided `.studiorc` gets sourced to only
interactive Studios, i.e with `hab studio enter`.

The danger of sourcing such a file when performing an automated, clean
build via `hab pkg build` is that the build program can't account for
whatever changes to the Studio environment a `.studiorc` might perform.
Moreover, this feature was intended more for development use cases,
implying interactively entering the Studio. Restricting the use case for
.studiorc` also makes automated building safer by being more consistent,
and not prone to intended (or unintended) injection of an outside
environment.

HAB_STUDIO_NOSTUDIORC
---------------------

An additional environment variable is also introduced,
`HAB_STUDIO_NOSTUDIORC`, which disables the sourcing of a `.studiorc`
when interactively entering a Studio (via `hab studio enter`). Setting
this environment variable to a non-empty value sets this source-skipping
behavior.

Closes #3503