### PR TITLE
Manage origin members and invitations

### DIFF
--- a/components/builder-web/app/BuilderApiClient.ts
+++ b/components/builder-web/app/BuilderApiClient.ts
@@ -31,32 +31,65 @@ export class BuilderApiClient {
                 headers: this.headers,
                 method: "PUT",
             })
-                .then(response => {
-                    if (response.ok) {
-                        resolve(true);
-                    } else {
-                        reject(new Error(response.statusText));
-                    }
-                })
-                .catch(error => reject(error));
+            .then(response => {
+                if (response.ok) {
+                    resolve(true);
+                } else {
+                    reject(new Error(response.statusText));
+                }
+            })
+            .catch(error => reject(error));
         });
     }
 
-    // TED TODO: This is just accepting, make it reject
-    public ignoreOriginInvitation(invitationId: string, originName: string) {
+    public deleteOriginInvitation(invitationId: string, originName: string) {
         return new Promise((resolve, reject) => {
             fetch(`${this.urlPrefix}/depot/origins/${originName}/invitations/${invitationId}`, {
                 headers: this.headers,
+                method: "DELETE",
+            })
+            .then(response => {
+                if (response.ok) {
+                    resolve(true);
+                } else {
+                    reject(new Error(response.statusText));
+                }
+            })
+            .catch(error => reject(error));
+        });
+    }
+
+    public deleteOriginMember(origin: string, member: string) {
+        return new Promise((resolve, reject) => {
+            fetch(`${this.urlPrefix}/depot/origins/${origin}/users/${member}`, {
+                headers: this.headers,
+                method: "DELETE",
+            })
+            .then(response => {
+                if (response.ok) {
+                    resolve(true);
+                } else {
+                    reject(new Error(response.statusText));
+                }
+            })
+            .catch(error => reject(error));
+        });
+    }
+
+    public ignoreOriginInvitation(invitationId: string, originName: string) {
+        return new Promise((resolve, reject) => {
+            fetch(`${this.urlPrefix}/depot/origins/${originName}/invitations/${invitationId}/ignore`, {
+                headers: this.headers,
                 method: "PUT",
             })
-                .then(response => {
-                    if (response.ok) {
-                        resolve(true);
-                    } else {
-                        reject(new Error(response.statusText));
-                    }
-                })
-                .catch(error => reject(error));
+            .then(response => {
+                if (response.ok) {
+                    resolve(true);
+                } else {
+                    reject(new Error(response.statusText));
+                }
+            })
+            .catch(error => reject(error));
         });
     }
 

--- a/components/builder-web/app/actions/gitHub.ts
+++ b/components/builder-web/app/actions/gitHub.ts
@@ -17,7 +17,7 @@ import { URLSearchParams } from "@angular/http";
 import * as cookies from "js-cookie";
 import config from "../config";
 import { setFeatureFlags } from "./index";
-import { attemptSignIn, addNotification, goHome, fetchMyOrigins, requestRoute, setFeatureFlag,
+import { attemptSignIn, addNotification, goHome, fetchMyOrigins, fetchMyOriginInvitations, requestRoute, setFeatureFlag,
     signOut, setSigningInFlag } from "./index";
 import { DANGER, WARNING } from "./notifications";
 import { BuilderApiClient } from "../BuilderApiClient";
@@ -60,6 +60,7 @@ export function authenticateWithGitHub(token = undefined) {
             }).then(data => {
                 dispatch(populateGitHubUserData(data));
                 dispatch(fetchMyOrigins(token));
+                dispatch(fetchMyOriginInvitations(token));
                 dispatch(attemptSignIn(data["login"]));
             }).catch(error => {
                 // We can assume an error from the response is a 401; anything

--- a/components/builder-web/app/actions/index.ts
+++ b/components/builder-web/app/actions/index.ts
@@ -51,6 +51,8 @@ export const STREAM_BUILD_LOG = buildActions.STREAM_BUILD_LOG;
 export const ADD_NOTIFICATION = notificationActions.ADD_NOTIFICATION;
 export const REMOVE_NOTIFICATION = notificationActions.REMOVE_NOTIFICATION;
 
+export const CLEAR_MY_ORIGINS = originActions.CLEAR_MY_ORIGINS;
+export const CLEAR_MY_ORIGIN_INVITATIONS = originActions.CLEAR_MY_ORIGIN_INVITATIONS;
 export const CLEAR_DOCKER_INTEGRATIONS = originActions.CLEAR_DOCKER_INTEGRATIONS;
 export const POPULATE_MY_ORIGINS = originActions.POPULATE_MY_ORIGINS;
 export const SET_PACKAGE_COUNT_FOR_ORIGIN = originActions.SET_PACKAGE_COUNT_FOR_ORIGIN;
@@ -139,6 +141,8 @@ export const removeNotification = notificationActions.removeNotification;
 
 export const acceptOriginInvitation = originActions.acceptOriginInvitation;
 export const createOrigin = originActions.createOrigin;
+export const deleteOriginInvitation = originActions.deleteOriginInvitation;
+export const deleteOriginMember = originActions.deleteOriginMember;
 export const deleteDockerIntegration = originActions.deleteDockerIntegration;
 export const ignoreOriginInvitation = originActions.ignoreOriginInvitation;
 export const fetchDockerIntegration = originActions.fetchDockerIntegration;

--- a/components/builder-web/app/app.scss
+++ b/components/builder-web/app/app.scss
@@ -40,6 +40,10 @@ $output-bourbon-deprecation-warnings: false !default;
 @import "side-nav/side-nav";
 @import "sign-in-page/sign-in-page";
 
+html {
+  background-color: $dark-blue; // Firefox needs this for Material dialogs.
+}
+
 body {
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;

--- a/components/builder-web/app/origin/origin-create-page/origin-create-page.component.ts
+++ b/components/builder-web/app/origin/origin-create-page/origin-create-page.component.ts
@@ -14,6 +14,7 @@
 
 import { AfterViewInit, Component, OnInit } from "@angular/core";
 import { FormControl, FormGroup, FormBuilder, Validators } from "@angular/forms";
+import { Router } from "@angular/router";
 import { AppStore } from "../../AppStore";
 import { AsyncValidator } from "../../AsyncValidator";
 import { BuilderApiClient } from "../../BuilderApiClient";
@@ -23,7 +24,6 @@ import { requireSignIn } from "../../util";
 @Component({
     template: require("./origin-create-page.component.html")
 })
-
 export class OriginCreatePageComponent implements AfterViewInit, OnInit {
     form: FormGroup;
     isOriginAvailable: Function;
@@ -32,7 +32,7 @@ export class OriginCreatePageComponent implements AfterViewInit, OnInit {
     private api: BuilderApiClient;
     private name: FormControl;
 
-    constructor(private formBuilder: FormBuilder, private store: AppStore) {
+    constructor(private formBuilder: FormBuilder, private store: AppStore, private router: Router) {
         this.api = new BuilderApiClient(this.token);
 
         this.form = formBuilder.group({
@@ -72,6 +72,8 @@ export class OriginCreatePageComponent implements AfterViewInit, OnInit {
     }
 
     createOrigin(origin) {
-        this.store.dispatch(createOrigin(origin, this.token, this.form.get("generateKeys").value, this.isFirstOrigin));
+        this.store.dispatch(createOrigin(origin, this.token, this.form.get("generateKeys").value, this.isFirstOrigin, (origin) => {
+            this.router.navigate(["/origins", origin.name]);
+        }));
     }
 }

--- a/components/builder-web/app/origin/origin-page/origin-integrations-tab/dialog/integration-delete-confirm/integration-delete-confirm.dialog.html
+++ b/components/builder-web/app/origin/origin-page/origin-integrations-tab/dialog/integration-delete-confirm/integration-delete-confirm.dialog.html
@@ -1,18 +1,18 @@
 <div class="dialog integration-delete-confirm">
-    <section class="heading">
-      <hab-icon symbol="delete"></hab-icon>
-      <h1>Confirm Delete</h1>
-    </section>
-    <section class="body">
-      <p>
-        Are you sure you want to remove this integration?
-        Packages will no longer be published to this Docker Hub account.
-      </p>
-    </section>
-    <section class="controls">
-      <button md-raised-button color="primary" class="button" (click)="ok()">
-          Yes, delete it
-      </button>
-      <a (click)="cancel()">Cancel</a>
-    </section>
-  </div>
+  <section class="heading">
+    <hab-icon symbol="delete"></hab-icon>
+    <h1>Confirm Delete</h1>
+  </section>
+  <section class="body">
+    <p>
+      Are you sure you want to remove this integration?
+      Packages will no longer be published to this Docker Hub account.
+    </p>
+  </section>
+  <section class="controls">
+    <button md-raised-button color="primary" class="button" (click)="ok()">
+        Yes, delete it
+    </button>
+    <a (click)="cancel()">Cancel</a>
+  </section>
+</div>

--- a/components/builder-web/app/origin/origin-page/origin-integrations-tab/origin-integrations-tab.component.ts
+++ b/components/builder-web/app/origin/origin-page/origin-integrations-tab/origin-integrations-tab.component.ts
@@ -18,17 +18,22 @@ import { deleteDockerIntegration, setDockerIntegration } from "../../../actions"
 import { MdDialog, MdDialogRef } from "@angular/material";
 import { DockerCredentialsFormDialog } from "../docker-credentials-form/docker-credentials-form.dialog";
 import { IntegrationDeleteConfirmDialog } from "./dialog/integration-delete-confirm/integration-delete-confirm.dialog";
+import { fetchDockerIntegration } from "../../../actions/index";
 
 @Component({
   template: require("./origin-integrations-tab.component.html")
 })
-export class OriginIntegrationsTabComponent {
+export class OriginIntegrationsTabComponent implements OnInit {
 
   constructor(
     private store: AppStore,
     private credsDialog: MdDialog,
     private confirmDialog: MdDialog
   ) { }
+
+  ngOnInit() {
+    this.store.dispatch(fetchDockerIntegration(this.origin.name, this.token));
+  }
 
   get integrations() {
     return this.store.getState().origins.currentIntegrations;

--- a/components/builder-web/app/origin/origin-page/origin-keys-tab/origin-keys-tab.component.ts
+++ b/components/builder-web/app/origin/origin-page/origin-keys-tab/origin-keys-tab.component.ts
@@ -20,7 +20,7 @@ import { AppStore } from "../../../AppStore";
 import { BuilderApiClient } from "../../../BuilderApiClient";
 import { GenerateKeysConfirmDialog } from "./dialog/generate-keys-confirm/generate-keys-confirm.dialog";
 import { KeyAddFormDialog } from "./key-add-form/key-add-form.dialog";
-import { fetchOriginPublicKeys, generateOriginKeys } from "../../../actions/index";
+import { fetchOriginPublicKeys, fetchMyOrigins, generateOriginKeys } from "../../../actions/index";
 import { OriginService } from "../../origin.service";
 import config from "../../../config";
 
@@ -43,6 +43,7 @@ export class OriginKeysTabComponent implements OnInit, OnDestroy {
     ngOnInit() {
         this.sub = this.route.parent.params.subscribe((params) => {
             this.origin = params["origin"];
+            this.store.dispatch(fetchMyOrigins(this.token));
             this.store.dispatch(fetchOriginPublicKeys(this.origin, this.token));
         });
     }

--- a/components/builder-web/app/origin/origin-page/origin-members-tab/_origin-members-tab.component.scss
+++ b/components/builder-web/app/origin/origin-page/origin-members-tab/_origin-members-tab.component.scss
@@ -10,7 +10,7 @@
 
     .members-invites {
       @include row;
-      margin-bottom: 40px;
+      margin-bottom: 32px;
 
       .members-invite {
         @include span-columns(5 of 9);
@@ -24,7 +24,7 @@
           }
 
           input {
-            margin-top: 16px;
+            margin: 12px 0;
             box-sizing: border-box;
             padding: 12px;
             outline: none;
@@ -46,6 +46,7 @@
 
           .error {
             color: $hab-red;
+            font-size: inherit;
           }
         }
       }
@@ -75,6 +76,20 @@
 
         span {
           font-weight: 600;
+        }
+
+        .actions {
+
+          hab-icon {
+            color: $hab-blue;
+            cursor: pointer;
+            margin-left: 12px;
+            transition: color .2s linear;
+
+            &:hover {
+              color: darken($hab-blue, 10%);
+            }
+          }
         }
       }
     }

--- a/components/builder-web/app/origin/origin-page/origin-members-tab/origin-members-tab.component.html
+++ b/components/builder-web/app/origin/origin-page/origin-members-tab/origin-members-tab.component.html
@@ -21,7 +21,10 @@
         <p *ngIf="invitations.size === 0">No pending invitations.</p>
         <ul>
           <li *ngFor="let invitation of invitations" class="pending-invite">
-            <span>{{ invitation.account_name }}</span>
+            <span class="name">{{ invitation.account_name }}</span>
+            <span class="actions">
+              <hab-icon symbol="cancel" (click)="rescind(invitation)" title="Rescind this invitation"></hab-icon>
+            </span>
           </li>
         </ul>
       </div>
@@ -31,7 +34,10 @@
       <p *ngIf="members.size === 0">No Members.</p>
       <ul>
         <li *ngFor="let member of members">
-          <span>{{ member }}</span>
+          <span class="name">{{ member }}</span>
+          <span class="actions">
+            <hab-icon symbol="cancel" (click)="delete(member)" *ngIf="canDelete(member)" title="Remove this member from this origin"></hab-icon>
+          </span>
         </li>
       </ul>
     </div>

--- a/components/builder-web/app/origin/origin-page/origin-page.component.ts
+++ b/components/builder-web/app/origin/origin-page/origin-page.component.ts
@@ -19,7 +19,7 @@ import { AppStore } from "../../AppStore";
 import config from "../../config";
 import { Origin } from "../../records/Origin";
 import { requireSignIn, packageString } from "../../util";
-import {  fetchOrigin, fetchOriginInvitations, fetchOriginMembers, inviteUserToOrigin, filterPackagesBy,
+import { fetchOrigin, fetchOriginInvitations, fetchOriginMembers, inviteUserToOrigin, filterPackagesBy,
     fetchMyOrigins, requestRoute, setCurrentProject, getUniquePackages,
     fetchDockerIntegration } from "../../actions";
 
@@ -43,9 +43,6 @@ export class OriginPageComponent implements OnInit, OnDestroy {
         requireSignIn(this);
         this.store.dispatch(fetchOrigin(this.origin.name));
         this.store.dispatch(fetchMyOrigins(this.gitHubAuthToken));
-        this.store.dispatch(fetchOriginMembers(this.origin.name, this.gitHubAuthToken));
-        this.store.dispatch(fetchOriginInvitations(this.origin.name, this.gitHubAuthToken));
-        this.store.dispatch(fetchDockerIntegration(this.origin.name, this.gitHubAuthToken));
         this.getPackages();
         this.loadPackages = this.getPackages.bind(this);
     }

--- a/components/builder-web/app/origin/origins-page/_origins-page.component.scss
+++ b/components/builder-web/app/origin/origins-page/_origins-page.component.scss
@@ -20,91 +20,71 @@
       }
     }
 
-    .origin-invitations {
-      @include span-columns(12);
-      margin-top: 28px;
+    ul {
 
-      h3 {
-        margin-bottom: 18px;
+      li {
+        @include row;
+        border-bottom: 1px solid $very-light-gray;
         font-size: rem(14);
-        text-transform: uppercase;
-      }
-    }
+        padding: 15px 10px;
+        position: relative;
+        cursor: pointer;
 
-    .hab-origins-list, .hab-invitations-list {
+        h3, > span {
+          @include span-columns(4);
+          margin: 0;
+        }
 
-      ul.origins, ul.invitations {
+        h3 {
+          font-size: rem(12);
+          text-transform: uppercase;
+        }
 
-        li {
-          &.heading, &.origin, &.invitation {
-            @include row;
-            border-bottom: 1px solid $very-light-gray;
+        .name {
+          font-weight: 600;
+        }
 
-            h3, .origin-name, .origin-pkg-count{
-              @include span-columns(5);
-            }
-            .invitation-origin-name {
-              @include span-columns(9);
-            }
-            .invitations-actions {
-              @include span-columns(3);
-            }
+        &.invitation {
+          cursor: auto;
+
+          .name {
+            color: $medium-gray;
           }
+        }
 
-          &.heading {
-            padding: 0 10px;
+        .package-count {
+          font-size: rem(12);
+          color: $medium-gray;
+        }
 
-            h3 {
-              padding: 0;
-              font-size: rem(12px);
-              font-family: $heading-font-family;
-            }
-          }
+        .actions {
+          text-align: right;
+          color: $hab-blue;
 
-          &.origin, &.invitation {
+          .action {
+            border-radius: $global-radius;
+            padding: 4px 8px;
             cursor: pointer;
-            font-size: rem(14px);
+            margin-left: 8px;
+            transition: color .2s, background-color .2s;
 
-            .summary {
-              @include row;
-              padding: 15px 10px;
-              position: relative;
-
-              .origin-name, .invitation-origin-name {
-                font-weight: 600;
-              }
-
-              .origin-pkg-count {
-                font-size: rem(12);
-                color: $hab-gray;
-              }
-
-              .invitation-actions {
-
-                hab-icon.action {
-                  cursor: pointer;
-                  width: 20px;
-                  height: 20px;
-                }
-              }
-
-              hab-icon[symbol="chevron-right"] {
-                @include chevron-right;
-                display: none;
-              }
-
-              &:hover {
-                background-color: rgba($medium-gray, 0.05);
-
-                hab-icon[symbol="chevron-right"] {
-                  display: block;
-                }
-              }
+            &:hover {
+              background-color: lighten($hab-blue, 10%);
+              color: white;
             }
           }
+        }
 
-          &.invitation {
-            cursor: auto;
+        hab-icon[symbol="chevron-right"] {
+          @include chevron-right;
+          display: none;
+        }
+
+        &:hover {
+          background-color: rgba($medium-gray, 0.05);
+
+          hab-icon[symbol="chevron-right"] {
+            display: block;
           }
         }
       }

--- a/components/builder-web/app/origin/origins-page/origins-page.component.html
+++ b/components/builder-web/app/origin/origins-page/origins-page.component.html
@@ -25,49 +25,30 @@
         </p>
       </div>
       <div *ngIf="origins.size > 0">
-        <div class="hab-origins-list">
-          <ul class="origins">
-            <li class="heading">
-              <h3 class="uppercase">Origin Name</h3>
-              <h3 class="uppercase">Packages</h3>
-            </li>
-            <li class="origin" *ngFor="let origin of origins" (click)="routeToOrigin(origin.name)">
-              <div class="summary">
-                <span class="origin-name">{{ origin.name }}</span>
-                <span class="origin-pkg-count">{{ origin.packageCount }}</span>
-                <hab-icon symbol="chevron-right"></hab-icon>
-              </div>
-            </li>
-          </ul>
-        </div>
-      </div>
-      <div class="origin-invitations" *ngIf="invitations.size > 0">
-        <h3>Pending Invitations</h3>
-        <div class="hab-invitations-list">
-          <ul class="invitations">
-            <li class="heading">
-              <h3 class="uppercase invitation-origin-name">Origin Name</h3>
-              <h3 class="uppercase invitations-actions">Actions</h3>
-            </li>
-            <li class="invitation" *ngFor="let invitation of invitations">
-              <div class="summary">
-                <span class="invitation-origin-name">{{ invitation.origin_name }}</span>
-                <span class="invitation-actions">
-                    <hab-icon
-                      class="action"
-                      symbol="check"
-                      title="Accept invitation"
-                      (click)="acceptInvitation(invitation.origin_invitation_id, invitation.origin_name)"></hab-icon>
-                    <hab-icon
-                      class="action"
-                      symbol="no"
-                      title="Ignore invitation"
-                      (click)="ignoreInvitation(invitation.origin_invitation_id, invitation.origin_name)"></hab-icon>
-                  </span>
-              </div>
-            </li>
-          </ul>
-        </div>
+        <ul>
+          <li class="heading">
+            <h3>Origin Name</h3>
+            <h3>Packages</h3>
+            <h3>&nbsp;</h3>
+          </li>
+          <li [class.invitation]="isInvitation(item)" *ngFor="let item of origins" (click)="navigateTo(item)">
+            <span class="name">{{ name(item) }}</span>
+            <span class="package-count">{{ packageCount(item) }}</span>
+            <span class="actions">
+              <span *ngIf="isInvitation(item)">
+                <span class="action" (click)="accept(item)">
+                  <hab-icon symbol="check"></hab-icon>
+                  Accept Invitation
+                </span>
+                <span class="action" (click)="ignore(item)">
+                  <hab-icon symbol="no"></hab-icon>
+                  Ignore Invitation
+                </span>
+              </span>
+            </span>
+            <hab-icon symbol="chevron-right"></hab-icon>
+          </li>
+        </ul>
       </div>
     </div>
   </div>

--- a/components/builder-web/app/origin/origins-page/origins-page.component.spec.ts
+++ b/components/builder-web/app/origin/origins-page/origins-page.component.spec.ts
@@ -2,6 +2,7 @@ import { TestBed, ComponentFixture } from "@angular/core/testing";
 import { RouterTestingModule } from "@angular/router/testing";
 import { Component, DebugElement } from "@angular/core";
 import { By } from "@angular/platform-browser";
+import { MdDialog } from "@angular/material";
 import { List } from "immutable";
 import { ActivatedRoute, Router } from "@angular/router";
 import { Observable } from "rxjs";
@@ -34,6 +35,8 @@ class MockAppStore {
   dispatch() {}
 }
 
+class MockDialog {}
+
 describe("OriginsPageComponent", () => {
   let fixture: ComponentFixture<OriginsPageComponent>;
   let component: OriginsPageComponent;
@@ -56,7 +59,8 @@ describe("OriginsPageComponent", () => {
         MockComponent({ selector: "hab-icon", inputs: [ "symbol", "chevron-right" ]})
       ],
       providers: [
-        { provide: AppStore, useValue: store }
+        { provide: AppStore, useValue: store },
+        { provide: MdDialog, useClass: MockDialog }
       ]
     });
 
@@ -66,28 +70,25 @@ describe("OriginsPageComponent", () => {
   });
 
   describe("given origin and name", () => {
+
     it("fetches the list of origins", () => {
       fixture.detectChanges();
       expect(store.dispatch).toHaveBeenCalled();
       expect(actions.fetchMyOrigins).toHaveBeenCalledWith("token");
-      expect(component.origins.size).toEqual(1);
     });
 
     it("fetches the list of invitations", () => {
       fixture.detectChanges();
       expect(store.dispatch).toHaveBeenCalled();
       expect(actions.fetchMyOriginInvitations).toHaveBeenCalledWith("token");
-      expect(component.invitations.length).toEqual(0);
     });
   });
 
   it("routes to the correct origin", () => {
     fixture.detectChanges();
-    spyOn(component, "routeToOrigin");
-    // one element is the header and the other is the origin
-    expect(element.query(By.css(".origins")).children.length).toBe(2);
-    element.query(By.css(".origins > li:last-child")).nativeElement.click();
+    spyOn(component, "navigateTo");
+    element.query(By.css("li:last-child")).nativeElement.click();
     fixture.detectChanges();
-    expect(component.routeToOrigin).toHaveBeenCalledWith("test");
+    expect(component.navigateTo).toHaveBeenCalledWith(Origin({name: "test"}));
   });
 });

--- a/components/builder-web/app/reducers/origins.ts
+++ b/components/builder-web/app/reducers/origins.ts
@@ -19,6 +19,15 @@ import { Origin } from "../records/Origin";
 
 export default function origins(state = initialState["origins"], action) {
     switch (action.type) {
+
+        case actionTypes.CLEAR_MY_ORIGINS:
+            return state.setIn(["mine"], List())
+                .setIn(["ui", "mine", "errorMessage"], undefined)
+                .setIn(["ui", "mine", "loading"], true);
+
+        case actionTypes.CLEAR_MY_ORIGIN_INVITATIONS:
+            return state.setIn(["myInvitations"], List());
+
         case actionTypes.CLEAR_DOCKER_INTEGRATIONS:
             return state.setIn(["currentIntegrations", "docker"], List());
 

--- a/components/builder-web/app/routes.ts
+++ b/components/builder-web/app/routes.ts
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import { Routes, RouterModule } from "@angular/router";
-import { UserLoggedOutGuard } from "./shared/user/user.guard";
 import { ExploreComponent } from "./explore/explore.component";
 import { SignInPageComponent } from "./sign-in-page/sign-in-page.component";
 
@@ -29,8 +28,7 @@ export const routes: Routes = [
     },
     {
         path: "sign-in",
-        component: SignInPageComponent,
-        canActivate: [UserLoggedOutGuard]
+        component: SignInPageComponent
     },
     {
         path: "*",

--- a/components/builder-web/app/shared/dialog/simple-confirm/simple-confirm.dialog.html
+++ b/components/builder-web/app/shared/dialog/simple-confirm/simple-confirm.dialog.html
@@ -1,0 +1,17 @@
+<div class="dialog invitation-confirm">
+    <section class="heading">
+      <hab-icon symbol="delete"></hab-icon>
+      <h1>{{ heading }}</h1>
+    </section>
+    <section class="body">
+      <p>
+        {{ body }}
+      </p>
+    </section>
+    <section class="controls">
+      <button md-raised-button color="primary" class="button" (click)="ok()">
+          Yes, {{ action }}
+      </button>
+      <a (click)="cancel()">Cancel</a>
+    </section>
+  </div>

--- a/components/builder-web/app/shared/dialog/simple-confirm/simple-confirm.dialog.ts
+++ b/components/builder-web/app/shared/dialog/simple-confirm/simple-confirm.dialog.ts
@@ -1,0 +1,33 @@
+import { Component, Inject } from "@angular/core";
+import { MdDialogRef, MD_DIALOG_DATA } from "@angular/material";
+
+@Component({
+  template: require("./simple-confirm.dialog.html")
+})
+export class SimpleConfirmDialog {
+
+  constructor(
+    private ref: MdDialogRef<SimpleConfirmDialog>,
+    @Inject(MD_DIALOG_DATA) private data: any
+  ) {}
+
+  get heading() {
+    return this.data.heading || "Confirm";
+  }
+
+  get body() {
+    return this.data.body || "Are you sure?";
+  }
+
+  get action() {
+    return this.data.action || "do it";
+  }
+
+  ok() {
+    this.ref.close(true);
+  }
+
+  cancel() {
+    this.ref.close(false);
+  }
+}

--- a/components/builder-web/app/shared/project-settings/dialog/disconnect-confirm/disconnect-confirm.dialog.ts
+++ b/components/builder-web/app/shared/project-settings/dialog/disconnect-confirm/disconnect-confirm.dialog.ts
@@ -1,5 +1,5 @@
 import { Component, Inject } from "@angular/core";
-import { MdDialog, MdDialogRef, MD_DIALOG_DATA } from "@angular/material";
+import { MdDialogRef } from "@angular/material";
 
 @Component({
   template: require("./disconnect-confirm.dialog.html")

--- a/components/builder-web/app/shared/shared.module.ts
+++ b/components/builder-web/app/shared/shared.module.ts
@@ -21,12 +21,13 @@ import { ProgressBarComponent } from "./progress-bar/progress-bar.component";
 import { ProjectSettingsComponent } from "./project-settings/project-settings.component";
 import { PlatformIconComponent } from "./platform-icon/platform-icon.component";
 import { RepoFilterPipe } from "../pipes/repoFilter.pipe";
+import { SimpleConfirmDialog } from "./dialog/simple-confirm/simple-confirm.dialog";
 import { TabsComponent } from "./tabs/TabsComponent";
 import { TabComponent } from "./tabs/TabComponent";
 import { FormProgressComponent } from "./form-progress/form-progress.component";
 import { GitHubRepoPickerComponent } from "./github-repo-picker/github-repo-picker.component";
 import { PackagePlanSelectComponent } from "./plan-select/plan-select.component";
-import { UserLoggedInGuard, UserLoggedOutGuard } from "./user/user.guard";
+import { UserLoggedInGuard } from "./user/user.guard";
 
 @NgModule({
   imports: [
@@ -58,6 +59,7 @@ import { UserLoggedInGuard, UserLoggedOutGuard } from "./user/user.guard";
     ProjectSettingsComponent,
     PlatformIconComponent,
     RepoFilterPipe,
+    SimpleConfirmDialog,
     TabsComponent,
     TabComponent,
     FormProgressComponent,
@@ -66,7 +68,8 @@ import { UserLoggedInGuard, UserLoggedOutGuard } from "./user/user.guard";
     RepoFilterPipe
   ],
   entryComponents: [
-    DisconnectConfirmDialog
+    DisconnectConfirmDialog,
+    SimpleConfirmDialog
   ],
   exports: [
     BreadcrumbsComponent,
@@ -85,6 +88,7 @@ import { UserLoggedInGuard, UserLoggedOutGuard } from "./user/user.guard";
     ProjectSettingsComponent,
     PlatformIconComponent,
     RepoFilterPipe,
+    SimpleConfirmDialog,
     TabsComponent,
     TabComponent,
     FormProgressComponent,
@@ -92,8 +96,7 @@ import { UserLoggedInGuard, UserLoggedOutGuard } from "./user/user.guard";
     GitHubRepoPickerComponent
   ],
   providers: [
-    UserLoggedInGuard,
-    UserLoggedOutGuard
+    UserLoggedInGuard
   ]
 })
 export class SharedModule {

--- a/components/builder-web/app/shared/user/user.guard.ts
+++ b/components/builder-web/app/shared/user/user.guard.ts
@@ -10,31 +10,11 @@ export class UserLoggedInGuard implements CanActivate {
 
   canActivate() {
     const hasToken = !!this.store.getState().gitHub.authToken;
-    const isCodeInQueryString = new URLSearchParams(
-      window.location.search.slice(1)
-    ).has("code");
+    const hasCode = window.location.search.slice(1).split("&").filter((param) => {
+      return !!param.match(/^code=.+/);
+    }).length >= 1;
 
-    if (isCodeInQueryString || hasToken) {
-      return true;
-    }
-
-    window.location.href = config["www_url"];
-    return false;
-  }
-}
-
-@Injectable()
-export class UserLoggedOutGuard implements CanActivate {
-
-  constructor(private store: AppStore, private router: Router) { }
-
-  canActivate() {
-    const hasToken = !!this.store.getState().gitHub.authToken;
-    const isCodeInQueryString = new URLSearchParams(
-      window.location.search.slice(1)
-    ).has("code");
-
-    if (!isCodeInQueryString || !hasToken) {
+    if (hasCode || hasToken) {
       return true;
     }
 

--- a/components/builder-web/app/sign-in-page/sign-in-page.component.html
+++ b/components/builder-web/app/sign-in-page/sign-in-page.component.html
@@ -8,21 +8,9 @@
             <a md-raised-button color="accent" [class.disabled]="isSigningIn || isSignedIn"
                class="button cta" href="{{gitHubLoginUrl}}">
                 <hab-icon symbol="github"></hab-icon>
-                <span *ngIf="isSigningIn">
-                    Signing In&hellip;
-                </span>
-                <span *ngIf="!isSignedIn && !isSigningIn">
+                <span>
                     Sign In with GitHub
                 </span>
-                <span *ngIf="isSignedIn && !isSigningIn">
-                    Signed In with GitHub
-                </span>
-            </a>
-            <a *ngIf="isSignedIn"
-               class="button hab-sign-in--out"
-               (click)="signOut()"
-               href="#">
-               Sign Out
             </a>
             <hr>
         </div>
@@ -34,22 +22,13 @@
             The {{appName}} project is maintained on GitHub and packages are
             built from plan files stored in GitHub repositories. GitHub
             accounts are free.
-            <a href="{{gitHubJoinUrl}}" _target="blank">
-                Create one now
-            </a>.
+            <a href="{{gitHubJoinUrl}}" _target="blank">Create one now</a>.
         </p>
         <p>
             You can still browse the
-            <a href="{{sourceCodeUrl}}">
-                {{appName}} source code
-            </a>,
-            <a [routerLink]="['/pkgs']">
-                public packages
-            </a>,
-            and
-            <a href="{{docsUrl}}">
-                documentation
-            </a>
+            <a href="{{sourceCodeUrl}}">{{appName}} source code</a>,
+            <a [routerLink]="['/pkgs']">public packages</a>,
+            and <a href="{{docsUrl}}">documentation</a>
             without signing in.
         </p>
     </div>

--- a/components/builder-web/app/sign-in-page/sign-in-page.component.ts
+++ b/components/builder-web/app/sign-in-page/sign-in-page.component.ts
@@ -50,10 +50,8 @@ export class SignInPageComponent implements OnInit, OnDestroy {
     }
 
     ngOnInit() {
-        // Populate the GitHub authstate (used to get a token) in SessionStorage
-        // either with what's there already, or with a new UUID.
+        this.store.dispatch(signOut());
         this.store.dispatch(setGitHubAuthState());
-        // Don't show the side nav on this screen
         this.store.dispatch(setLayout("centered"));
     }
 


### PR DESCRIPTION
This change allows users to rescind invitations, ignore invitations and delete members from an origin, with confirmation dialogs. It also adds a new shared component, `SimpleConfirmDialog`, for handling common yes/no situations.

Includes a few additional fixes I encountered while developing this feature:

* Background color no longer flashes in Firefox when opening a dialog
* Data for individual origin tabs is now loaded on demand, rather than everything-up-front, ensuring the data you see reflects the most current
* Clears auth cookies when visiting the sign-in view
* Removes the use of `UrlSearchParams` in `UserLoggedInGuard` (not widely enough supported yet) and removes `UserLoggedOutGuard`

Fixes #2943, #3382 and #3287.

Signed-off-by: Christian Nunciato <cnunciato@chef.io>

![](https://media.tenor.com/images/db1eea319b94b84ef9e25210640c1b79/tenor.gif)