### PR TITLE
Set cookie domain to all hostname elements excluding the first

### DIFF
--- a/components/builder-web/app/actions/cookies.ts
+++ b/components/builder-web/app/actions/cookies.ts
@@ -60,10 +60,9 @@ function cookieDomain() {
   let tld = hostname.split(delim).pop();
 
   if (isNaN(Number(tld))) {
-    return hostname
-      .split(delim)
-      .splice(-2)
-      .join(delim);
+    let domain = hostname.split(delim);
+    domain.shift();
+    return domain.join(delim);
   } else {
     return hostname;
   }

--- a/www/source/javascripts/nav.js
+++ b/www/source/javascripts/nav.js
@@ -75,11 +75,10 @@ const stickyVisibleBreakpoint = 300;
     }
 
     function cookieDomain() {
-        let delim = ".";
-        return location.hostname
-            .split(delim)
-            .splice(-2)
-            .join(delim);
+      let delim = ".";
+      let tld = location.hostname.split(delim);
+      tdl.shift();
+      return tdl.join(delim);
     }
   });
 })($, Cookies);


### PR DESCRIPTION
Previously we were setting cookies to always be the last two elements
of a domain so `bldr.habitat.sh` would be `.habitat.sh` and
`bldr.acceptance.habitat.sh` would also be `.habitat.sh`. This change
will leave the former while the latter becomes `.acceptance.habitat.sh`

