### PR TITLE
Scrub secure info from job logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,6 +187,8 @@ dependencies = [
  "base64 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy 0.0.144 (registry+https://github.com/rust-lang/crates.io-index)",
+ "git2 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "github-api-client 0.0.0",
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat-builder-protocol 0.0.0",
  "habitat_core 0.0.0",
@@ -202,6 +204,7 @@ dependencies = [
  "statsd 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/components/builder-core/Cargo.toml
+++ b/components/builder-core/Cargo.toml
@@ -10,6 +10,8 @@ chrono = { version = "*", features = ["serde"] }
 clippy = { version = "*", optional = true }
 glob = "*"
 habitat-builder-protocol = { path = "../builder-protocol" }
+github-api-client = { path = "../github-api-client" }
+git2 = "*"
 iron = "*"
 libarchive = "*"
 log = "*"
@@ -22,6 +24,7 @@ statsd = "*"
 time = "*"
 toml = { version = "*", features = ["serde"], default-features = false }
 walkdir = "*"
+url = "*"
 
 [dependencies.habitat_core]
 path = "../core"

--- a/components/builder-core/src/error.rs
+++ b/components/builder-core/src/error.rs
@@ -19,14 +19,22 @@ use std::string;
 
 use base64;
 use hab_core;
+use github_api_client;
+use git2;
+use url;
 
 #[derive(Debug)]
 pub enum Error {
     Base64Error(base64::DecodeError),
+    CannotAddCreds,
     DecryptError(String),
     EncryptError(String),
     FromUtf8Error(string::FromUtf8Error),
     HabitatCore(hab_core::Error),
+    Git(git2::Error),
+    GithubAppAuthErr(github_api_client::HubError),
+    NotHTTPSCloneUrl(url::Url),
+    UrlParseError(url::ParseError),
 }
 
 pub type Result<T> = result::Result<T, Error>;
@@ -35,10 +43,20 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let msg = match *self {
             Error::Base64Error(ref e) => format!("{}", e),
+            Error::CannotAddCreds => format!("Cannot add credentials to url"),
             Error::DecryptError(ref e) => format!("{}", e),
             Error::EncryptError(ref e) => format!("{}", e),
             Error::FromUtf8Error(ref e) => format!("{}", e),
+            Error::Git(ref e) => format!("{}", e),
+            Error::GithubAppAuthErr(ref e) => format!("{}", e),
             Error::HabitatCore(ref e) => format!("{}", e),
+            Error::NotHTTPSCloneUrl(ref e) => {
+                format!(
+                    "Attempted to clone {}. Only HTTPS clone urls are supported",
+                    e
+                )
+            }
+            Error::UrlParseError(ref e) => format!("{}", e),
         };
         write!(f, "{}", msg)
     }
@@ -48,10 +66,15 @@ impl error::Error for Error {
     fn description(&self) -> &str {
         match *self {
             Error::Base64Error(ref e) => e.description(),
+            Error::CannotAddCreds => "Cannot add credentials to url",
             Error::DecryptError(_) => "Error decrypting integration",
             Error::EncryptError(_) => "Error encrypting integration",
             Error::FromUtf8Error(ref e) => e.description(),
+            Error::Git(ref err) => err.description(),
+            Error::GithubAppAuthErr(ref err) => err.description(),
             Error::HabitatCore(ref err) => err.description(),
+            Error::NotHTTPSCloneUrl(_) => "Only HTTPS clone urls are supported",
+            Error::UrlParseError(ref err) => err.description(),
         }
     }
 }

--- a/components/builder-core/src/job.rs
+++ b/components/builder-core/src/job.rs
@@ -1,0 +1,110 @@
+// Copyright (c) 2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt;
+use std::ops::{Deref, DerefMut};
+use protocol::jobsrv;
+use protocol::originsrv;
+use github_api_client::GitHubCfg;
+use vcs;
+
+pub struct Job(jobsrv::Job);
+
+impl Job {
+    pub fn new(job: jobsrv::Job) -> Self {
+        Job(job)
+    }
+
+    pub fn vcs(&self, config: GitHubCfg) -> vcs::VCS {
+        match self.0.get_project().get_vcs_type() {
+            "git" => {
+                let installation_id: Option<u32> = {
+                    if self.0.get_project().has_vcs_installation_id() {
+                        Some(self.0.get_project().get_vcs_installation_id())
+                    } else {
+                        None
+                    }
+                };
+                vcs::VCS::new(
+                    String::from(self.0.get_project().get_vcs_type()),
+                    String::from(self.0.get_project().get_vcs_data()),
+                    config,
+                    installation_id,
+                )
+            }
+            _ => panic!("unknown vcs associated with jobs project"),
+        }
+    }
+
+    pub fn origin(&self) -> &str {
+        let items = self.0
+            .get_project()
+            .get_name()
+            .split("/")
+            .collect::<Vec<&str>>();
+        assert!(
+            items.len() == 2,
+            format!(
+                "Invalid project identifier - {}",
+                self.0.get_project().get_id()
+            )
+        );
+        items[0]
+    }
+}
+
+impl Deref for Job {
+    type Target = jobsrv::Job;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for Job {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl fmt::Debug for Job {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let integrations: Vec<originsrv::OriginIntegration> = self.0
+            .get_integrations()
+            .into_iter()
+            .map(|i| {
+                let mut r = originsrv::OriginIntegration::new();
+                r.set_origin(i.get_origin().to_string());
+                r.set_integration(i.get_integration().to_string());
+                r.set_name(i.get_name().to_string());
+                r.set_body("[secure]".to_string());
+                r
+            })
+            .collect();
+
+        f.debug_struct("Job")
+            .field("id", &self.0.get_id())
+            .field("owner_id", &self.0.get_owner_id())
+            .field("state", &self.0.get_owner_id())
+            .field("project", &self.0.get_project())
+            .field("created_at", &self.0.get_created_at())
+            .field("channel", &self.0.get_channel())
+            .field("build_started_at", &self.0.get_build_started_at())
+            .field("build_finished_at", &self.0.get_build_finished_at())
+            .field("package_ident", &self.0.get_package_ident())
+            .field("integrations", &integrations)
+            .field("project_integrations", &self.0.get_project_integrations())
+            .finish()
+    }
+}

--- a/components/builder-core/src/lib.rs
+++ b/components/builder-core/src/lib.rs
@@ -19,6 +19,7 @@ extern crate glob;
 extern crate habitat_builder_protocol as protocol;
 extern crate habitat_core as hab_core;
 extern crate habitat_net as hab_net;
+extern crate github_api_client;
 extern crate iron;
 #[macro_use]
 extern crate log;
@@ -34,6 +35,8 @@ extern crate serde;
 extern crate serde_derive;
 extern crate serde_json;
 extern crate toml;
+extern crate url;
+extern crate git2;
 
 pub mod build_config;
 pub mod data_structures;
@@ -47,5 +50,7 @@ pub mod metrics;
 pub mod package_graph;
 pub mod rdeps;
 pub mod target_graph;
+pub mod vcs;
+pub mod job;
 
 pub use error::Error;

--- a/components/builder-core/src/vcs.rs
+++ b/components/builder-core/src/vcs.rs
@@ -58,7 +58,8 @@ impl VCS {
                     self.url(token.clone())?,
                     path
                 );
-                git2::Repository::clone(&(self.url(token)?).as_str(), path)?;
+                git2::Repository::clone(&(self.url(token)?).as_str(), path)
+                    .map_err(|e| Error::Git(e))?;
                 Ok(())
             }
             _ => panic!("Unknown vcs type"),

--- a/components/builder-jobsrv/src/server/worker_manager.rs
+++ b/components/builder-jobsrv/src/server/worker_manager.rs
@@ -19,6 +19,7 @@ use std::time::{Duration, Instant};
 use std::thread::{self, JoinHandle};
 
 use bldr_core;
+use bldr_core::job::Job;
 use hab_net::{ErrCode, NetError};
 use hab_net::conn::RouteClient;
 use hab_net::socket::DEFAULT_CONTEXT;
@@ -211,7 +212,7 @@ impl WorkerMgr {
                 break;
             }
             // This unwrap is fine, because we just checked our length
-            let mut job = jobs.pop().unwrap();
+            let mut job = Job::new(jobs.pop().unwrap());
             self.add_integrations_to_job(&mut job);
             self.add_project_integrations_to_job(&mut job);
 
@@ -437,7 +438,7 @@ impl WorkerMgr {
         self.rq_sock.recv(&mut self.msg, 0)?;
         // Pop message body
         self.rq_sock.recv(&mut self.msg, 0)?;
-        let job: jobsrv::Job = parse_from_bytes(&self.msg)?;
+        let job = Job::new(parse_from_bytes::<jobsrv::Job>(&self.msg)?);
         debug!("job_status={:?}", job);
         self.datastore.update_job(&job)?;
 

--- a/components/builder-worker/src/error.rs
+++ b/components/builder-worker/src/error.rs
@@ -18,13 +18,10 @@ use std::io;
 use std::result;
 
 use bldr_core;
-use git2;
-use github_api_client;
 use hab_core;
 use protobuf;
 use protocol;
 use retry;
-use url;
 use zmq;
 
 pub type Result<T> = result::Result<T, Error>;
@@ -32,20 +29,14 @@ pub type Result<T> = result::Result<T, Error>;
 #[derive(Debug)]
 pub enum Error {
     BuildFailure(i32),
-    CannotAddCreds,
-    Git(git2::Error),
     BuilderCore(bldr_core::Error),
-    GithubAppAuthErr(github_api_client::HubError),
     HabitatCore(hab_core::Error),
     IO(io::Error),
     InvalidIntegrations(String),
     NoAuthTokenError,
-    NotHTTPSCloneUrl(url::Url),
     Protobuf(protobuf::ProtobufError),
     Protocol(protocol::ProtocolError),
     Retry(retry::RetryError),
-    UnknownVCS,
-    UrlParseError(url::ParseError),
     WorkspaceSetup(String, io::Error),
     WorkspaceTeardown(String, io::Error),
     Zmq(zmq::Error),
@@ -57,25 +48,14 @@ impl fmt::Display for Error {
             Error::BuildFailure(ref e) => {
                 format!("Build studio exited with non-zero exit code, {}", e)
             }
-            Error::Git(ref e) => format!("{}", e),
-            Error::GithubAppAuthErr(ref e) => format!("{}", e),
             Error::BuilderCore(ref e) => format!("{}", e),
-            Error::CannotAddCreds => format!("Cannot add credentials to url"),
             Error::HabitatCore(ref e) => format!("{}", e),
             Error::IO(ref e) => format!("{}", e),
             Error::InvalidIntegrations(ref s) => format!("Invalid integration: {}", s),
             Error::NoAuthTokenError => format!("No auth_token config specified"),
-            Error::NotHTTPSCloneUrl(ref e) => {
-                format!(
-                    "Attempted to clone {}. Only HTTPS clone urls are supported",
-                    e
-                )
-            }
             Error::Protobuf(ref e) => format!("{}", e),
             Error::Protocol(ref e) => format!("{}", e),
             Error::Retry(ref e) => format!("{}", e),
-            Error::UnknownVCS => format!("Job requires an unknown VCS"),
-            Error::UrlParseError(ref e) => format!("{}", e),
             Error::Zmq(ref e) => format!("{}", e),
             Error::WorkspaceSetup(ref p, ref e) => {
                 format!("Error while setting up workspace at {}, err={:?}", p, e)
@@ -92,30 +72,18 @@ impl error::Error for Error {
     fn description(&self) -> &str {
         match *self {
             Error::BuildFailure(_) => "Build studio exited with a non-zero exit code",
-            Error::Git(ref err) => err.description(),
-            Error::GithubAppAuthErr(ref err) => err.description(),
             Error::BuilderCore(ref err) => err.description(),
-            Error::CannotAddCreds => "Cannot add credentials to url",
             Error::HabitatCore(ref err) => err.description(),
             Error::IO(ref err) => err.description(),
             Error::InvalidIntegrations(_) => "Invalid integrations detected",
             Error::NoAuthTokenError => "No auth_token config specified",
-            Error::NotHTTPSCloneUrl(_) => "Only HTTPS clone urls are supported",
             Error::Protobuf(ref err) => err.description(),
             Error::Protocol(ref err) => err.description(),
             Error::Retry(ref err) => err.description(),
-            Error::UrlParseError(ref err) => err.description(),
-            Error::UnknownVCS => "Job requires an unknown VCS",
             Error::WorkspaceSetup(_, _) => "IO Error while creating workspace on disk",
             Error::WorkspaceTeardown(_, _) => "IO Error while destroying workspace on disk",
             Error::Zmq(ref err) => err.description(),
         }
-    }
-}
-
-impl From<git2::Error> for Error {
-    fn from(err: git2::Error) -> Error {
-        Error::Git(err)
     }
 }
 
@@ -152,17 +120,5 @@ impl From<protocol::ProtocolError> for Error {
 impl From<zmq::Error> for Error {
     fn from(err: zmq::Error) -> Error {
         Error::Zmq(err)
-    }
-}
-
-impl From<url::ParseError> for Error {
-    fn from(err: url::ParseError) -> Error {
-        Error::UrlParseError(err)
-    }
-}
-
-impl From<github_api_client::HubError> for Error {
-    fn from(err: github_api_client::HubError) -> Error {
-        Error::GithubAppAuthErr(err)
     }
 }

--- a/components/builder-worker/src/lib.rs
+++ b/components/builder-worker/src/lib.rs
@@ -49,7 +49,6 @@ pub mod heartbeat;
 pub mod log_forwarder;
 pub mod runner;
 pub mod server;
-pub mod vcs;
 
 pub use self::config::Config;
 pub use self::error::{Error, Result};


### PR DESCRIPTION
This change adds a custom debug formatter for the Job object, which scrubs the OriginIntegration body from being printed out. The core change is fairly small, however a bunch of code needed to be moved around so that the wrapper Job type could be shared between the worker and job server.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-10458490](https://user-images.githubusercontent.com/13542112/31205609-520bf03e-a927-11e7-8cbe-2a41194a6355.gif)
