### PR TITLE
Fix search

### DIFF
--- a/components/builder-web/app/explore/explore.component.spec.ts
+++ b/components/builder-web/app/explore/explore.component.spec.ts
@@ -198,7 +198,7 @@ describe("ExploreComponent", () => {
         input.value = " g++ ";
         button.click();
 
-        expect(router.navigate).toHaveBeenCalledWith(["pkgs", "search", "g++"]);
+        expect(router.navigate).toHaveBeenCalledWith(["search", { q: "g++" }]);
       });
     });
   });

--- a/components/builder-web/app/explore/explore.component.ts
+++ b/components/builder-web/app/explore/explore.component.ts
@@ -15,7 +15,7 @@
 import { AppStore } from "../AppStore";
 import { Component, OnInit, OnDestroy } from "@angular/core";
 import { Router } from "@angular/router";
-import { fetchExplore, setLayout } from "../actions/index";
+import { fetchExplore, setLayout, setPackagesSearchQuery } from "../actions/index";
 
 @Component({
     selector: "hab-explore",
@@ -38,6 +38,6 @@ export class ExploreComponent implements OnInit, OnDestroy {
     }
 
     search(term) {
-        this.router.navigate(["pkgs", "search", term.trim()]);
+        this.router.navigate(["search", { q: term.trim() }]);
     }
 }

--- a/components/builder-web/app/reducers/packages.ts
+++ b/components/builder-web/app/reducers/packages.ts
@@ -125,13 +125,11 @@ export default function packages(state = initialState["packages"], action) {
         case actionTypes.SET_VISIBLE_PACKAGES:
             if (action.error) {
                 return state.set("visible", List()).
-                    setIn(["ui", "visible", "errorMessage"],
-                    action.error.message).
+                    setIn(["ui", "visible", "errorMessage"], action.error.message).
                     setIn(["ui", "visible", "exists"], false).
                     setIn(["ui", "visible", "loading"], false);
             } else {
-                return state.set("visible",
-                    state.get("visible").concat(List(action.payload))).
+                return state.set("visible", state.get("visible").concat(List(action.payload))).
                     setIn(["ui", "visible", "errorMessage"], undefined).
                     setIn(["ui", "visible", "exists"], true).
                     setIn(["ui", "visible", "loading"], false);

--- a/components/builder-web/app/search/search-routing.module.ts
+++ b/components/builder-web/app/search/search-routing.module.ts
@@ -4,8 +4,8 @@ import { SearchComponent } from "./search/search.component";
 
 const routes: Routes = [
   {
-    path: "pkgs/search/:query",
-    component: SearchComponent,
+      path: "search",
+      component: SearchComponent,
   },
   {
       path: "pkgs/:origin",

--- a/components/builder-web/app/search/search/search.component.html
+++ b/components/builder-web/app/search/search/search.component.html
@@ -1,13 +1,15 @@
 <div class="hab-search">
     <div class="page-title">
         <h2>Search Packages</h2>
-        <h4>
-            <span *ngIf="searchQuery || query">Search Results</span>
-        </h4>
+        <h4><span *ngIf="searchQuery || query">Search Results</span></h4>
         <hab-icon symbol="loading" [class.spinning]="ui.loading"></hab-icon>
     </div>
     <div class="page-body">
-        <input type="search" autofocus [formControl]="searchBox" placeholder="Search Packages&hellip;">
+        <input type="search" #query autofocus
+            [formControl]="searchBox"
+            [value]="searchQuery"
+            (keyup.enter)="submit(query.value)"
+            placeholder="Search Packages&hellip;">
 
         <hab-search-results
             [noPackages]="(!ui.exists || packages.size === 0) && !ui.loading"
@@ -16,10 +18,8 @@
 
         <div *ngIf="packages.size < totalCount">
             Showing {{packages.size}} of {{totalCount}} packages.
-            <a href="#" (click)="fetchMorePackages()">
-                Load
-                {{(totalCount - packages.size) > perPage ? perPage : totalCount - packages.size }}
-                more</a>.
+            <a href="#" (click)="fetchMorePackages()">Load
+                {{(totalCount - packages.size) > perPage ? perPage : totalCount - packages.size }} more</a>.
         </div>
     </div>
 </div>

--- a/components/builder-web/app/search/search/search.component.spec.ts
+++ b/components/builder-web/app/search/search/search.component.spec.ts
@@ -108,15 +108,15 @@ describe("SearchResultsComponent", () => {
         expect(element.query(By.css(".page-body input[type='search']"))).not.toBeNull();
       });
 
-      describe("fetch", () => {
+      describe("fetchPackages", () => {
 
         it ("fetches with the distinct parameter", () => {
           spyOn(actions, "filterPackagesBy");
 
-          component.fetch();
+          component.fetchPackages();
 
           expect(actions.filterPackagesBy).toHaveBeenCalledWith(
-            { origin: undefined }, "foo", true
+            { origin: "core" }, "foo", true, 0
           );
         });
       });

--- a/components/builder-web/app/side-nav/SideNavComponent.ts
+++ b/components/builder-web/app/side-nav/SideNavComponent.ts
@@ -22,12 +22,10 @@ import config from "../config";
         <h4>Builder</h4>
         <ul class="hab-side-nav--list">
             <li *ngIf="isSignedIn">
-                <a [routerLink]="['/origins']"
-                    routerLinkActive="active">My Origins</a>
+                <a [routerLink]="['/origins']">My Origins</a>
             </li>
             <li>
-                <a [routerLink]="['/pkgs']"
-                    routerLinkActive="active">Search Packages</a>
+                <a [routerLink]="['/pkgs']">Search Packages</a>
             </li>
         </ul>
         <h4>Quick Links</h4>

--- a/components/builder-web/stylesheets/base/_forms.scss
+++ b/components/builder-web/stylesheets/base/_forms.scss
@@ -59,6 +59,13 @@ select {
   font-size: $base-font-size;
 }
 
+input {
+
+  &[type="text"], &[type="search"], &[type="password"] {
+    -webkit-appearance: textfield
+  }
+}
+
 #{$all-text-inputs},
 select,
 select[multiple] {


### PR DESCRIPTION
This fixes searches run from the Explore view and supports linking to search results by querystring.

Also fixes the way text fields are displayed in Safari.

Signed-off-by: Christian Nunciato <cnunciato@chef.io>

Fixes #3435.

![](https://media.tenor.com/images/c4e0690ee70c84ff4e1fb7370eda5fec/tenor.gif)