### PR TITLE
Fix dev and acceptance URLs for Builder

### DIFF
--- a/support/ci/deploy_website.sh
+++ b/support/ci/deploy_website.sh
@@ -10,6 +10,6 @@ else
   if [[ "${TRAVIS_PULL_REQUEST}" = "false" ]] && [[ "${TRAVIS_BRANCH}" =~ ^acceptance_deploy ]]; then
     echo "We are on a PR or against the master branch. Deploying to Acceptance."
     cd www
-    make acceptance
+    BUILDER_WEB_URL="https://bldr.acceptance.habitat.sh" make acceptance
   fi
 fi

--- a/www/Makefile
+++ b/www/Makefile
@@ -7,7 +7,7 @@ clean:
 	rm -rf build
 
 run: build
-	bundle exec middleman serve
+	BUILDER_WEB_URL="http://localhost:3000" bundle exec middleman serve
 
 sync: build check-env
 	bundle exec middleman s3_sync


### PR DESCRIPTION
This allows you to navigate to www.acceptance.habitat.sh for both website- and Builder-related activities.

Signed-off-by: Christian Nunciato <cnunciato@chef.io>

![](https://media.tenor.com/images/5928958c42329cf6e101dda2ad295393/tenor.gif)