### PR TITLE
[builder-worker] Redact Docker creds from debug logging.

### DIFF
--- a/components/builder-worker/src/runner/docker.rs
+++ b/components/builder-worker/src/runner/docker.rs
@@ -116,7 +116,12 @@ impl<'a> DockerExporter<'a> {
         cmd.arg(&self.spec.password);
         cmd.arg("--rm-image");
         cmd.arg(self.workspace.last_built()?.path); // Locally built artifact
-        debug!("building docker export command, cmd={:?}", &cmd);
+        debug!(
+            "building docker export command, cmd={}",
+            format!("building docker export command, cmd={:?}", &cmd)
+                .replace(&self.spec.username, "<username-redacted>")
+                .replace(&self.spec.password, "<password-redacted>")
+        );
 
         cmd.env_clear();
         if let Some(_) = env::var_os(RUNNER_DEBUG_ENVVAR) {


### PR DESCRIPTION
This change ensures that a user's Docker credentials are not logged at
any level when invoking the `hab pkg export docker` command, by
replacing the actual values with `<username-redacted>` and
`<password-redacted>`.

References #3520

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>