### PR TITLE
[studio] Attempt to import public origin keys into Studios.

### DIFF
--- a/components/studio/libexec/hab-studio-type-stage1.sh
+++ b/components/studio/libexec/hab-studio-type-stage1.sh
@@ -14,33 +14,40 @@ studio_run_command=
 finish_setup() {
   if [ -n "$HAB_ORIGIN_KEYS" ]; then
     for key in $(echo $HAB_ORIGIN_KEYS | $bb tr ',' ' '); do
-      info "Importing $key secret origin key"
-      # There's a method to this madness: `$hab` is the raw path to `hab`
-      # will use the outside cache key path, whereas the `_hab` function has
-      # the `$FS_ROOT` set for the inside of the Studio. We're copying from
-      # the outside in, using `hab` twice. I love my job.
-
-      # if we don't set +e here, then the subshell exits upon
-      # error without any output
-      set +e
-      key_text=$($hab origin key export --type secret $key)
-      # capture the result now before calling other commands
-      # that will overwrite the result
-      local result=$?
-      # reenable exit upon error
-      set -e
-
-      # NOTE: quotes MUST appear around ${key_text} to preserve
-      # newlines in the hab export output
-      if [ $result -eq 0 ]; then
-        echo "${key_text}" | _hab origin key import
+      local key_text
+      # Import the secret origin key, required for signing packages
+      info "Importing '$key' secret origin key"
+      if key_text=$($hab origin key export --type secret $key); then
+        printf -- "${key_text}" | _hab origin key import
       else
         echo "Error exporting $key key"
         # key_text will contain an error message
         echo "${key_text}"
+        echo "Habitat was unable to export your secret signing key. Please"
+        echo "verify that you have a signing key for $key present in either"
+        echo "~/.hab/cache/keys (if running via sudo) or /hab/cache/keys"
+        echo "(if running as root). You can test this by running:"
+        echo ""
+        echo "    hab origin key export --type secret $key"
+        echo ""
+        echo "This test will print your signing key to the console or error"
+        echo "if it cannot find the key. To create a signing key, you can run: "
+        echo ""
+        echo "    hab origin key generate $key"
+        echo ""
+        echo "You'll also be prompted to create an origin signing key when "
+        echo "you run 'hab setup'."
+        echo ""
         exit 1
       fi
-
+      # Attempt to import the public origin key, which can be used for local
+      # package installations where the key may not yet be uploaded.
+      if key_text=$($hab origin key export --type public $key 2> /dev/null); then
+        info "Importing '$key' public origin key"
+        printf -- "${key_text}" | _hab origin key import
+      else
+        info "Tried to import '$key' public origin key, but key was not found"
+      fi
     done
   fi
 


### PR DESCRIPTION
This change will optimistically import the public origin key if found in
the external key cache. The public origin key is not strictly required
in order to build and sign a package, but there are some uses cases
where having the public origin key is convenient such as a user who is
building their first Habitat package locally, even before creating an
origin and uploading their key to Builder.

A failure to import the public origin key will show an informational
message but will not cause the Studio to fail or abort--this is best
effort and a nice-to-have.

References #3524
Closes #3495

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>