### PR TITLE
[plan-build] Fix `PATH` metafile content when `pkg_version()` is used.

### DIFF
--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -1984,9 +1984,10 @@ update_pkg_version() {
   fi
   # Replace the unset placeholders with the computed value
   val="$(echo "$PATH" | sed "s,__pkg__version__unset__,${pkg_version},g")"
-  pkg_env[PATH]="$val"
   PATH="$val"
   build_line "Updating PATH=$PATH"
+  val="$(echo "${pkg_env[PATH]}" | sed "s,__pkg__version__unset__,${pkg_version},g")"
+  pkg_env[PATH]="$val"
 }
 
 # ## Build Phases


### PR DESCRIPTION
This fixes an issue when a Plan uses the `pkg_version()` function to
lazily compute a pacakge version. Plans which use a `pkg_version()`
before this fix would see the combined build and run dependencies
combined as the contents of the `PATH` metafile in the package.

The expected content of `PATH` for a package such as
`core/hab-pkg-aci/0.35.0-dev/20171005070318` with a `pkg_bin_dirs=(bin)`
should always be:

```
/hab/pkgs/core/hab-pkg-aci/0.35.0-dev/20171005070318/bin
```

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>