### PR TITLE
[studio,plan-build] Set ownership on `./results/` to not be root.

### DIFF
--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -2069,6 +2069,10 @@ _write_pre_build_file() {
   build_line "Writing pre_build file"
 
   mkdir -pv "$pkg_output_path"
+  # Attempt to set user/group ownership to the same as the ownership of the
+  # `plan.sh` file. If the `chown` fails, then don't stop the build--this is
+  # only best effort.
+  chown "$plan_owner" "$pkg_output_path" || true
 
   if [ -f "$pre_build_file" ]; then
     rm "$pre_build_file"
@@ -2956,7 +2960,7 @@ _prepare_build_outputs() {
   # At this point, we know it built successfully, so delete the pre_build file
   pre_build_file="$pkg_output_path/pre_build.env"
   if [ -f "$pre_build_file" ]; then
-    rm "$pre_build_file"
+    rm -f "$pre_build_file"
   fi
 
   cat <<-EOF > "$pkg_output_path"/last_build.env

--- a/components/studio/bin/hab-studio.sh
+++ b/components/studio/bin/hab-studio.sh
@@ -673,7 +673,12 @@ record() {
       | $bb tr '\n' ' ')"
     log="${LOGDIR:-/src/results/logs}/${name}.$($bb date -u +%Y-%m-%d-%H%M%S).log"
     $bb mkdir -p $($bb dirname $log)
-    unset BUSYBOX LOGDIR
+    $bb touch $log
+    if [[ "$log" =~ ^/src/results/logs/.* ]]; then
+      ownership=$($bb stat -c '%u:%g' /src)
+      $bb chown -R "$ownership" "/src/results" || true
+    fi
+    unset BUSYBOX LOGDIR name ownership
 
     $bb script -c "$bb env -i $env $cmd $*" -e $log
   ); return $?


### PR DESCRIPTION
This resolves 2 remaining edge cases when performing Studio builds on
Linux systems with native Studios. In both cases, there is no
pre-existing `./results/` directory:

1. [plan-build] When the pre-build report is written to
`./results/pre_build.env`, attempt to update the ownership of the
`./results/` directory to the same owner/group as the Plan file.
2. [studio] When a log file is being written (default behvaior with `hab
studio build`/`hab pkg build`), attempt to update the ownership of the
`./results/` directory recursively, which at that point will include the
`logs/` directory as well as the target log file.

Closes #3445

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>