### PR TITLE
Move VCS related code back to worker crate from bldr core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,8 +187,6 @@ dependencies = [
  "base64 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy 0.0.144 (registry+https://github.com/rust-lang/crates.io-index)",
- "git2 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "github-api-client 0.0.0",
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat-builder-protocol 0.0.0",
  "habitat_core 0.0.0",
@@ -204,7 +202,6 @@ dependencies = [
  "statsd 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/components/builder-core/Cargo.toml
+++ b/components/builder-core/Cargo.toml
@@ -10,8 +10,6 @@ chrono = { version = "*", features = ["serde"] }
 clippy = { version = "*", optional = true }
 glob = "*"
 habitat-builder-protocol = { path = "../builder-protocol" }
-github-api-client = { path = "../github-api-client" }
-git2 = "*"
 iron = "*"
 libarchive = "*"
 log = "*"
@@ -24,7 +22,6 @@ statsd = "*"
 time = "*"
 toml = { version = "*", features = ["serde"], default-features = false }
 walkdir = "*"
-url = "*"
 
 [dependencies.habitat_core]
 path = "../core"

--- a/components/builder-core/src/error.rs
+++ b/components/builder-core/src/error.rs
@@ -19,22 +19,14 @@ use std::string;
 
 use base64;
 use hab_core;
-use github_api_client;
-use git2;
-use url;
 
 #[derive(Debug)]
 pub enum Error {
     Base64Error(base64::DecodeError),
-    CannotAddCreds,
     DecryptError(String),
     EncryptError(String),
     FromUtf8Error(string::FromUtf8Error),
     HabitatCore(hab_core::Error),
-    Git(git2::Error),
-    GithubAppAuthErr(github_api_client::HubError),
-    NotHTTPSCloneUrl(url::Url),
-    UrlParseError(url::ParseError),
 }
 
 pub type Result<T> = result::Result<T, Error>;
@@ -43,20 +35,10 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let msg = match *self {
             Error::Base64Error(ref e) => format!("{}", e),
-            Error::CannotAddCreds => format!("Cannot add credentials to url"),
             Error::DecryptError(ref e) => format!("{}", e),
             Error::EncryptError(ref e) => format!("{}", e),
             Error::FromUtf8Error(ref e) => format!("{}", e),
-            Error::Git(ref e) => format!("{}", e),
-            Error::GithubAppAuthErr(ref e) => format!("{}", e),
             Error::HabitatCore(ref e) => format!("{}", e),
-            Error::NotHTTPSCloneUrl(ref e) => {
-                format!(
-                    "Attempted to clone {}. Only HTTPS clone urls are supported",
-                    e
-                )
-            }
-            Error::UrlParseError(ref e) => format!("{}", e),
         };
         write!(f, "{}", msg)
     }
@@ -66,15 +48,10 @@ impl error::Error for Error {
     fn description(&self) -> &str {
         match *self {
             Error::Base64Error(ref e) => e.description(),
-            Error::CannotAddCreds => "Cannot add credentials to url",
             Error::DecryptError(_) => "Error decrypting integration",
             Error::EncryptError(_) => "Error encrypting integration",
             Error::FromUtf8Error(ref e) => e.description(),
-            Error::Git(ref err) => err.description(),
-            Error::GithubAppAuthErr(ref err) => err.description(),
             Error::HabitatCore(ref err) => err.description(),
-            Error::NotHTTPSCloneUrl(_) => "Only HTTPS clone urls are supported",
-            Error::UrlParseError(ref err) => err.description(),
         }
     }
 }

--- a/components/builder-core/src/job.rs
+++ b/components/builder-core/src/job.rs
@@ -14,37 +14,15 @@
 
 use std::fmt;
 use std::ops::{Deref, DerefMut};
+
 use protocol::jobsrv;
 use protocol::originsrv;
-use github_api_client::GitHubCfg;
-use vcs;
 
 pub struct Job(jobsrv::Job);
 
 impl Job {
     pub fn new(job: jobsrv::Job) -> Self {
         Job(job)
-    }
-
-    pub fn vcs(&self, config: GitHubCfg) -> vcs::VCS {
-        match self.0.get_project().get_vcs_type() {
-            "git" => {
-                let installation_id: Option<u32> = {
-                    if self.0.get_project().has_vcs_installation_id() {
-                        Some(self.0.get_project().get_vcs_installation_id())
-                    } else {
-                        None
-                    }
-                };
-                vcs::VCS::new(
-                    String::from(self.0.get_project().get_vcs_type()),
-                    String::from(self.0.get_project().get_vcs_data()),
-                    config,
-                    installation_id,
-                )
-            }
-            _ => panic!("unknown vcs associated with jobs project"),
-        }
     }
 
     pub fn origin(&self) -> &str {

--- a/components/builder-core/src/lib.rs
+++ b/components/builder-core/src/lib.rs
@@ -19,7 +19,6 @@ extern crate glob;
 extern crate habitat_builder_protocol as protocol;
 extern crate habitat_core as hab_core;
 extern crate habitat_net as hab_net;
-extern crate github_api_client;
 extern crate iron;
 #[macro_use]
 extern crate log;
@@ -35,8 +34,6 @@ extern crate serde;
 extern crate serde_derive;
 extern crate serde_json;
 extern crate toml;
-extern crate url;
-extern crate git2;
 
 pub mod build_config;
 pub mod data_structures;
@@ -50,7 +47,6 @@ pub mod metrics;
 pub mod package_graph;
 pub mod rdeps;
 pub mod target_graph;
-pub mod vcs;
 pub mod job;
 
 pub use error::Error;

--- a/components/builder-worker/Cargo.toml
+++ b/components/builder-worker/Cargo.toml
@@ -17,9 +17,9 @@ clippy = {version = "*", optional = true}
 chrono = { version = "*", features = ["serde"] }
 env_logger = "*"
 features = "*"
+git2 = "*"
 github-api-client = { path = "../github-api-client" }
 habitat-builder-protocol = { path = "../builder-protocol" }
-git2 = "*"
 hyper = "*"
 lazy_static = "*"
 log = "*"

--- a/components/builder-worker/src/lib.rs
+++ b/components/builder-worker/src/lib.rs
@@ -20,12 +20,12 @@ extern crate bitflags;
 extern crate chrono;
 #[macro_use]
 extern crate features;
+extern crate git2;
 extern crate github_api_client;
 extern crate habitat_builder_protocol as protocol;
 extern crate habitat_core as hab_core;
 extern crate habitat_depot_client as depot_client;
 extern crate habitat_net as hab_net;
-extern crate git2;
 #[macro_use]
 extern crate lazy_static;
 #[macro_use]
@@ -49,6 +49,7 @@ pub mod heartbeat;
 pub mod log_forwarder;
 pub mod runner;
 pub mod server;
+pub mod vcs;
 
 pub use self::config::Config;
 pub use self::error::{Error, Result};

--- a/components/builder-worker/src/runner/mod.rs
+++ b/components/builder-worker/src/runner/mod.rs
@@ -48,6 +48,7 @@ use self::workspace::Workspace;
 use config::Config;
 use error::{Error, Result};
 use retry::retry;
+use vcs::VCS;
 
 // TODO fn: copied from `components/common/src/ui.rs`. As this component doesn't currently depend
 // on habitat_common it didnt' seem worth it to add a dependency for only this constant. Probably
@@ -112,11 +113,8 @@ impl Runner {
             error!("failed to retrieve secret key, err={:?}", err);
             return self.fail(net::err(ErrCode::SECRET_KEY_FETCH, "wk:run:3"));
         }
-        if let Some(err) = self.job()
-            .vcs((*self.config).github.clone())
-            .clone(&self.workspace.src())
-            .err()
-        {
+        let vcs = VCS::from_job(&self.job(), self.config.github.clone());
+        if let Some(err) = vcs.clone(&self.workspace.src()).err() {
             error!("failed to clone remote source repository, err={:?}", err);
             return self.fail(net::err(ErrCode::VCS_CLONE, "wk:run:4"));
         }

--- a/components/builder-worker/src/vcs.rs
+++ b/components/builder-worker/src/vcs.rs
@@ -14,6 +14,7 @@
 
 use std::path::Path;
 
+use bldr_core::job::Job;
 use git2;
 use github_api_client::{GitHubClient, GitHubCfg};
 use url::Url;
@@ -28,6 +29,27 @@ pub struct VCS {
 }
 
 impl VCS {
+    pub fn from_job(job: &Job, config: GitHubCfg) -> Self {
+        match job.get_project().get_vcs_type() {
+            "git" => {
+                let installation_id: Option<u32> = {
+                    if job.get_project().has_vcs_installation_id() {
+                        Some(job.get_project().get_vcs_installation_id())
+                    } else {
+                        None
+                    }
+                };
+                Self::new(
+                    String::from(job.get_project().get_vcs_type()),
+                    String::from(job.get_project().get_vcs_data()),
+                    config,
+                    installation_id,
+                )
+            }
+            _ => panic!("unknown vcs associated with jobs project"),
+        }
+    }
+
     pub fn new(
         vcs_type: String,
         data: String,


### PR DESCRIPTION
Moving the VCS module into the bldr core crate caused a libgit
dependency on each Builder server which isn't necessary. This change
decouples the VCS and Job modules and moves the VCS module back to
the worker crate

Signed-off-by: Jamie Winsor <jamie@vialstudios.com>