### PR TITLE
Use GitHub token to read files from remote instead of our own token

### DIFF
--- a/components/builder-api/src/github.rs
+++ b/components/builder-api/src/github.rs
@@ -98,7 +98,7 @@ pub fn repo_file_content(req: &mut Request) -> IronResult<Response> {
             Some(repo) => repo,
             None => return Ok(Response::with(status::BadRequest)),
         };
-        let repos = match github.repositories(session.get_token(), install_id) {
+        let repos = match github.repositories(session.get_auth_token(), install_id) {
             Ok(repos) => repos,
             Err(err) => return Ok(Response::with((status::BadGateway, err.to_string()))),
         };


### PR DESCRIPTION
Signed-off-by: Jamie Winsor <jamie@vialstudios.com>