### PR TITLE
Fix TDEPS PATH leaking into package ENVIRONMENT metadata in plan-build.

### DIFF
--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -1982,10 +1982,16 @@ update_pkg_version() {
   if [[ "${update_src_path:-}" == true ]]; then
     SRC_PATH="$CACHE_PATH"
   fi
+  
   # Replace the unset placeholders with the computed value
-  val="$(echo "$PATH" | sed "s,__pkg__version__unset__,${pkg_version},g")"
-  pkg_env[PATH]="$val"
+  if [[ "${pkg_env[PATH]+abc}" ]]; then
+    val="$(echo "${pkg_env[PATH]}" | sed "s,__pkg__version__unset__,${pkg_version},g")"
+    pkg_env[PATH]="$val"
+  fi
+
+  val="$(echo "${PATH}" | sed "s,__pkg__version__unset__,${pkg_version},g")"
   PATH="$val"
+
   build_line "Updating PATH=$PATH"
 }
 


### PR DESCRIPTION
Packages that utilized the `update_pkg_version` function were leaking their build time PATH into the final package.  You can see an example of this in core/aws-cli:

```bash
cat /hab/pkgs/core/aws-cli/1.11.158/20170925185218/ENVIRONMENT
PATH=/hab/pkgs/core/aws-cli/1.11.158/20170925185218/bin:/hab/pkgs/core/groff/1.22.3/20170514000731/bin:/hab/pkgs/core/python/3.6.0/20170514005805/bin:/hab/pkgs/core/gawk/4.1.3/20170513213646/bin:/hab/pkgs/core/sed/4.2.2/20170513213123/bin:/hab/pkgs/core/glibc/2.22/20170513201042/bin:/hab/pkgs/core/bzip2/1.0.6/20170513212938/bin:/hab/pkgs/core/gdbm/1.11/20170513213716/bin:/hab/pkgs/core/ncurses/6.0/20170513213009/bin:/hab/pkgs/core/openssl/1.0.2j/20170513215106/bin:/hab/pkgs/core/sqlite/3130000/20170514005747/bin:/hab/pkgs/core/acl/2.2.52/20170513213108/bin:/hab/pkgs/core/attr/2.4.47/20170513213059/bin:/hab/pkgs/core/hab-plan-build/0.33.0/20170922231314/bin:/hab/pkgs/core/bash/4.3.42/20170513213519/bin:/hab/pkgs/core/binutils/2.25.1/20170513201927/bin:/hab/pkgs/core/bzip2/1.0.6/20170513212938/bin:/hab/pkgs/core/coreutils/8.25/20170513213226/bin:/hab/pkgs/core/file/5.24/20170513201915/bin:/hab/pkgs/core/findutils/4.4.2/20170513214305/bin:/hab/pkgs/core/gawk/4.1.3/20170513213646/bin:/hab/pkgs/core/grep/2.22/20170513213444/bin:/hab/pkgs/core/gzip/1.6/20170513214605/bin:/hab/pkgs/core/hab/0.33.0/20170922230356/bin:/hab/pkgs/core/rq/0.9.2/20170612005822/bin:/hab/pkgs/core/sed/4.2.2/20170513213123/bin:/hab/pkgs/core/tar/1.29/20170513213607/bin:/hab/pkgs/core/unzip/6.0/20170513215357/bin:/hab/pkgs/core/wget/1.18/20170513215322/bin:/hab/pkgs/core/xz/5.2.2/20170513214327/bin:/hab/pkgs/core/acl/2.2.52/20170513213108/bin:/hab/pkgs/core/attr/2.4.47/20170513213059/bin:::/hab/pkgs/core/glibc/2.22/20170513201042/bin::/hab/pkgs/core/less/481/20170513213936/bin:/hab/pkgs/core/libcap/2.24/20170513213120/bin:/hab/pkgs/core/libidn/1.32/20170513215043/bin:::/hab/pkgs/core/ncurses/6.0/20170513213009/bin:/hab/pkgs/core/openssl/1.0.2j/20170513215106/bin:/hab/pkgs/core/pcre/8.38/20170513213423/bin::
```

This would result in errors when running `hab pkg install origin/package -b`,  and allow you to binlink to your runtime dependencies.

```bash
[32][default:/src:134]# hab pkg binlink core/aws-cli groff
» Symlinking groff from core/aws-cli into /hab/bin
★ Symlinked groff from core/aws-cli/1.11.158/20170925185218 to /hab/bin/groff
[33][default:/src:0]# ls -la /hab/bin/groff
lrwxrwxrwx 1 root root 52 Oct  5 14:23 /hab/bin/groff -> /hab/pkgs/core/groff/1.22.3/20170514000731/bin/groff
```

Rebuilding core/aws-cli with this change results in the expected behavior

```bash
[default:/src:0]# build aws-cli
   aws-cli: Setting PATH=/hab/pkgs/core/aws-cli/__pkg__version__unset__/20171005143105/bin:/hab/pkgs/core/groff/1.22.3/20170514000731/bin:/hab/pkgs/core/python/3.6.0/20170514005805/bin:/hab/pkgs/core/gawk/4.1.3/20170513213646/bin:/hab/pkgs/core/sed/4.2.2/20170513213123/bin:/hab/pkgs/core/glibc/2.22/20170513201042/bin:/hab/pkgs/core/bzip2/1.0.6/20170513212938/bin:/hab/pkgs/core/gdbm/1.11/20170513213716/bin:/hab/pkgs/core/ncurses/6.0/20170513213009/bin:/hab/pkgs/core/openssl/1.0.2j/20170513215106/bin:/hab/pkgs/core/sqlite/3130000/20170514005747/bin:/hab/pkgs/core/acl/2.2.52/20170513213108/bin:/hab/pkgs/core/attr/2.4.47/20170513213059/bin:/hab/pkgs/core/hab-plan-build/0.35.0-dev/20171005135646/bin:/hab/pkgs/core/bash/4.3.42/20170513213519/bin:/hab/pkgs/core/binutils/2.25.1/20170513201927/bin:/hab/pkgs/core/bzip2/1.0.6/20170513212938/bin:/hab/pkgs/core/coreutils/8.25/20170513213226/bin:/hab/pkgs/core/file/5.24/20170513201915/bin:/hab/pkgs/core/findutils/4.4.2/20170513214305/bin:/hab/pkgs/core/gawk/4.1.3/20170513213646/bin:/hab/pkgs/core/grep/2.22/20170513213444/bin:/hab/pkgs/core/gzip/1.6/20170513214605/bin:/hab/pkgs/core/hab/0.34.1/20171002002928/bin:/hab/pkgs/core/rq/0.9.2/20170612005822/bin:/hab/pkgs/core/sed/4.2.2/20170513213123/bin:/hab/pkgs/core/tar/1.29/20170513213607/bin:/hab/pkgs/core/unzip/6.0/20170513215357/bin:/hab/pkgs/core/wget/1.18/20170513215322/bin:/hab/pkgs/core/xz/5.2.2/20170513214327/bin:/hab/pkgs/core/acl/2.2.52/20170513213108/bin:/hab/pkgs/core/attr/2.4.47/20170513213059/bin:::/hab/pkgs/core/glibc/2.22/20170513201042/bin::/hab/pkgs/core/less/481/20170513213936/bin:/hab/pkgs/core/libcap/2.24/20170513213120/bin:/hab/pkgs/core/libidn/1.32/20170513215043/bin:::/hab/pkgs/core/ncurses/6.0/20170513213009/bin:/hab/pkgs/core/openssl/1.0.2j/20170513215106/bin:/hab/pkgs/core/pcre/8.38/20170513213423/bin::
   aws-cli: Version updated to '1.11.165'
   aws-cli: Updating PATH=/hab/pkgs/core/aws-cli/1.11.165/20171005143105/bin:/hab/pkgs/core/groff/1.22.3/20170514000731/bin:/hab/pkgs/core/python/3.6.0/20170514005805/bin:/hab/pkgs/core/gawk/4.1.3/20170513213646/bin:/hab/pkgs/core/sed/4.2.2/20170513213123/bin:/hab/pkgs/core/glibc/2.22/20170513201042/bin:/hab/pkgs/core/bzip2/1.0.6/20170513212938/bin:/hab/pkgs/core/gdbm/1.11/20170513213716/bin:/hab/pkgs/core/ncurses/6.0/20170513213009/bin:/hab/pkgs/core/openssl/1.0.2j/20170513215106/bin:/hab/pkgs/core/sqlite/3130000/20170514005747/bin:/hab/pkgs/core/acl/2.2.52/20170513213108/bin:/hab/pkgs/core/attr/2.4.47/20170513213059/bin:/hab/pkgs/core/hab-plan-build/0.35.0-dev/20171005135646/bin:/hab/pkgs/core/bash/4.3.42/20170513213519/bin:/hab/pkgs/core/binutils/2.25.1/20170513201927/bin:/hab/pkgs/core/bzip2/1.0.6/20170513212938/bin:/hab/pkgs/core/coreutils/8.25/20170513213226/bin:/hab/pkgs/core/file/5.24/20170513201915/bin:/hab/pkgs/core/findutils/4.4.2/20170513214305/bin:/hab/pkgs/core/gawk/4.1.3/20170513213646/bin:/hab/pkgs/core/grep/2.22/20170513213444/bin:/hab/pkgs/core/gzip/1.6/20170513214605/bin:/hab/pkgs/core/hab/0.34.1/20171002002928/bin:/hab/pkgs/core/rq/0.9.2/20170612005822/bin:/hab/pkgs/core/sed/4.2.2/20170513213123/bin:/hab/pkgs/core/tar/1.29/20170513213607/bin:/hab/pkgs/core/unzip/6.0/20170513215357/bin:/hab/pkgs/core/wget/1.18/20170513215322/bin:/hab/pkgs/core/xz/5.2.2/20170513214327/bin:/hab/pkgs/core/acl/2.2.52/20170513213108/bin:/hab/pkgs/core/attr/2.4.47/20170513213059/bin:::/hab/pkgs/core/glibc/2.22/20170513201042/bin::/hab/pkgs/core/less/481/20170513213936/bin:/hab/pkgs/core/libcap/2.24/20170513213120/bin:/hab/pkgs/core/libidn/1.32/20170513215043/bin:::/hab/pkgs/core/ncurses/6.0/20170513213009/bin:/hab/pkgs/core/openssl/1.0.2j/20170513215106/bin:/hab/pkgs/core/pcre/8.38/20170513213423/bin::
```

```bash
[36][default:/src:0]# cat /hab/pkgs/core/aws-cli/1.11.165/20171005143105/ENVIRONMENT
PATH=/hab/pkgs/core/aws-cli/1.11.165/20171005143105/bin
```


I looked for similar functionality in plan-build-ps1 but was unable to locate it.

Signed-off-by: Scott Macfarlane <macfarlane.scott@gmail.com>