### PR TITLE
Workaround to auth with github token

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1170,6 +1170,7 @@ dependencies = [
  "clap 2.25.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy 0.0.144 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "github-api-client 0.0.0",
  "habitat-builder-protocol 0.0.0",
  "habitat_core 0.0.0",
  "habitat_net 0.0.0",

--- a/components/builder-depot/Cargo.toml
+++ b/components/builder-depot/Cargo.toml
@@ -12,6 +12,7 @@ bodyparser = "*"
 env_logger = "*"
 habitat-builder-protocol = { path = "../builder-protocol" }
 builder-http-gateway = { path = "../builder-http-gateway" }
+github-api-client = { path = "../github-api-client" }
 hyper = "*"
 iron = "*"
 iron-test = "*"

--- a/components/builder-depot/src/lib.rs
+++ b/components/builder-depot/src/lib.rs
@@ -50,6 +50,7 @@ extern crate walkdir;
 extern crate zmq;
 extern crate uuid;
 extern crate base64;
+extern crate github_api_client;
 
 pub mod config;
 pub mod error;

--- a/components/builder-depot/src/server.rs
+++ b/components/builder-depot/src/server.rs
@@ -22,6 +22,7 @@ use base64;
 use bldr_core;
 use bldr_core::helpers::transition_visibility;
 use bodyparser;
+use github_api_client::GitHubClient;
 use hab_core::package::{Identifiable, FromArchive, PackageArchive, PackageIdent, PackageTarget,
                         ident};
 use hab_core::crypto::keys::PairType;
@@ -2382,6 +2383,9 @@ pub fn router(depot: DepotUtil) -> Result<Chain> {
         &depot.config.log_dir,
         depot.config.events_enabled,
     )));
+    chain.link(persistent::Read::<GitHubCli>::both(
+        GitHubClient::new(depot.config.github.clone()),
+    ));
     chain.link(persistent::State::<DepotUtil>::both(depot));
     chain.link_before(XRouteClient);
     chain.link_after(Cors);


### PR DESCRIPTION
A temporary fix to enable auth to continue to work with github personal access tokens, while we complete the migration to our own personal access tokens.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-156346466](https://user-images.githubusercontent.com/13542112/31256639-c007b840-a9e8-11e7-9b01-626e8e7f4520.gif)
