### PR TITLE
[ci] Purge pre-existing origin keys before building.

### DIFF
--- a/support/ci/deploy.sh
+++ b/support/ci/deploy.sh
@@ -45,7 +45,10 @@ rm ./core.sig.key
 COMPONENTS=($COMPONENTS)
 for component in "${COMPONENTS[@]}"
 do
-  echo "Building $component"
+  echo "--> Clearing any pre-exisiting $HAB_ORIGIN secret keys from the Studio"
+  env HAB_ORIGIN= ${TRAVIS_HAB} studio run sh -c \'rm -f /hab/cache/keys/*-*.sig.key\'
+
+  echo "--> Building $component"
   ${TRAVIS_HAB} studio run HAB_CARGO_TARGET_DIR=/src/target build components/${component}
 
   HART=$(find ./results -name *${component}*.hart)
@@ -65,6 +68,8 @@ do
 
   rm $HART
 done
+echo "--> Removing origin secret keys from Studio"
+env HAB_ORIGIN= ${TRAVIS_HAB} studio run sh -c \'rm -f /hab/cache/keys/*-*.sig.key\'
 
 echo "Publishing hab to $BINTRAY_REPO"
 ${TRAVIS_HAB} pkg exec core/hab-bintray-publish publish-studio

--- a/support/ci/deploy_mac.sh
+++ b/support/ci/deploy_mac.sh
@@ -11,7 +11,7 @@ set -eu
 
 var_file="$HOME/tmp/our-awesome-vars"
 if [[ -f ${var_file} ]]; then
-  echo "Located the file with the magic environment variables."
+  echo "--> Located the file with the magic environment variables."
   source ${var_file}
   rm ${var_file}
 else
@@ -21,6 +21,9 @@ fi
 
 hab_src_dir="$HOME/code/$TRAVIS_BUILD_NUMBER/habitat"
 function cleanup {
+  echo "--> Removing origin secret keys from cache"
+  rm -f /hab/cache/keys/*-*.sig.key
+  echo "--> Purging directory '$hab_src_dir'"
   rm -rf "$hab_src_dir"
 }
 trap cleanup EXIT
@@ -59,8 +62,11 @@ core-20160810182414
 ${HAB_ORIGIN_KEY}
 EOF
 
+echo "--> Clearing any pre-exisiting origin secret keys from cache"
+rm -f /hab/cache/keys/*-*.sig.key
+echo "--> Importing origin secret key into cache"
 ${mac_hab} origin key import < ./core.sig.key
-rm ./core.sig.key
+rm -f ./core.sig.key
 
 # since this is running on a headless mac, we can't use docker/studio,
 # so we need to resort to this hackery


### PR DESCRIPTION
This ensures that: a) the origin key is always fresh, b) there is only
one present, c) and import errors colliding with existing files should
be avoided.

This should allow us to publish build artifacts again more consistently.