### PR TITLE
Authenticate web hooks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,6 +321,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "constant_time_eq"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "copperline"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -836,16 +841,19 @@ dependencies = [
  "builder_core 0.0.0",
  "clap 2.25.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy 0.0.144 (registry+https://github.com/rust-lang/crates.io-index)",
+ "constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "github-api-client 0.0.0",
  "habitat-builder-protocol 0.0.0",
  "habitat_core 0.0.0",
  "habitat_depot 0.0.0",
  "habitat_net 0.0.0",
+ "hex 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "iron 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "mount 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.9.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "params 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "persistent 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2851,6 +2859,7 @@ dependencies = [
 "checksum clock_ticks 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "da9bd98fefcf1904a3f80ead86d366d9373c34db7b8a8e48c1fdcaac4787800d"
 "checksum cmake 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)" = "d18d68987ed4c516dcc3e7913659bfa4076f5182eea4a7e0038bb060953e76ac"
 "checksum conduit-mime-types 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "95ca30253581af809925ef68c2641cc140d6183f43e12e0af4992d53768bd7b8"
+"checksum constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8ff012e225ce166d4422e0e78419d901719760f62ae2b7969ca6b564d1b54a9e"
 "checksum copperline 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3e80a6471b77449d3bd5c2192441ee3138184f69a2bba233c036ca21dcd626f3"
 "checksum crypt32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e34988f7e069e0b2f3bfc064295161e489b2d4e04a2e4248fb94360cdf00b4ec"
 "checksum ctrlc 3.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f26287fa3893461876a4851d1bee53b82f04954f85e2d7cd30ae053d0edefd72"

--- a/components/builder-api/Cargo.toml
+++ b/components/builder-api/Cargo.toml
@@ -13,16 +13,19 @@ doc = false
 
 [dependencies]
 clippy = {version = "*", optional = true}
+constant_time_eq = "*"
 base64 = "*"
 bodyparser = "*"
 builder-http-gateway = { path = "../builder-http-gateway" }
 env_logger = "*"
 github-api-client = { path = "../github-api-client" }
 habitat-builder-protocol = { path = "../builder-protocol" }
+hex = "*"
 hyper = "*"
 iron = "*"
 log = "*"
 mount = "*"
+openssl = "*"
 params = "*"
 persistent = "*"
 protobuf = "*"

--- a/components/builder-api/src/lib.rs
+++ b/components/builder-api/src/lib.rs
@@ -19,18 +19,21 @@ extern crate base64;
 extern crate bodyparser;
 extern crate builder_core as bldr_core;
 extern crate builder_http_gateway as http_gateway;
+extern crate constant_time_eq;
 extern crate github_api_client;
 extern crate habitat_builder_protocol as protocol;
 #[macro_use]
 extern crate habitat_core as hab_core;
 extern crate habitat_depot as depot;
 extern crate habitat_net as hab_net;
+extern crate hex;
 #[macro_use]
 extern crate hyper;
 extern crate iron;
 #[macro_use]
 extern crate log;
 extern crate mount;
+extern crate openssl;
 extern crate params;
 extern crate persistent;
 extern crate protobuf;

--- a/components/github-api-client/src/client.rs
+++ b/components/github-api-client/src/client.rs
@@ -41,6 +41,7 @@ pub struct GitHubClient {
     pub client_secret: String,
     app_id: u32,
     app_private_key: String,
+    pub webhook_secret_token: String,
 }
 
 impl GitHubClient {
@@ -52,6 +53,7 @@ impl GitHubClient {
             client_secret: config.client_secret,
             app_id: config.app_id,
             app_private_key: config.app_private_key,
+            webhook_secret_token: config.webhook_secret_token,
         }
     }
 

--- a/components/github-api-client/src/config.rs
+++ b/components/github-api-client/src/config.rs
@@ -26,6 +26,8 @@ pub const DEV_GITHUB_CLIENT_ID: &'static str = "Iv1.732260b62f84db15";
 pub const DEV_GITHUB_CLIENT_SECRET: &'static str = "fc7654ed8c65ccfe014cd339a55e3538f935027a";
 /// Default github application id created in the habitat-sh org
 pub const DEFAULT_GITHUB_APP_ID: u32 = 5629;
+/// Webhook secret token
+pub const DEV_GITHUB_WEBHOOK_SECRET_TOKEN: &'static str = "58d4afaf5e5617ab0f8c39e505605e78a054d003";
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(default)]
@@ -42,6 +44,8 @@ pub struct GitHubCfg {
     pub client_secret: String,
     /// App Id used for builder integration
     pub app_id: u32,
+    /// Webhook secret token
+    pub webhook_secret_token: String,
 }
 
 impl Default for GitHubCfg {
@@ -53,6 +57,7 @@ impl Default for GitHubCfg {
             client_id: DEV_GITHUB_CLIENT_ID.to_string(),
             client_secret: DEV_GITHUB_CLIENT_SECRET.to_string(),
             app_id: DEFAULT_GITHUB_APP_ID,
+            webhook_secret_token: DEV_GITHUB_WEBHOOK_SECRET_TOKEN.to_string(),
         }
     }
 }


### PR DESCRIPTION
I've added a new piece of configuration to github-api-client, which is the web hook secret key.

The process itself is fairly straightforward:  pull GH's token out of the headers, compute an HMAC from the body contents, convert it to a hex string, prepend `sha1=` to it because GH wants us to, and compare that to what GH sent us.  We do the comparison using the `constant_time_eq` crate to theoretically avoid timing attacks.  If they match, everything's awesome.  Otherwise, return a bad request.

![tenor-21543791](https://user-images.githubusercontent.com/947/31258866-3a007250-a9f7-11e7-840d-380f33300df4.gif)

Closes https://github.com/habitat-sh/habitat/issues/3489
Signed-off-by: Josh Black <raskchanky@gmail.com>