### PR TITLE
Add back check that was inadvertently removed

### DIFF
--- a/components/builder-depot/src/server.rs
+++ b/components/builder-depot/src/server.rs
@@ -1041,7 +1041,11 @@ fn upload_package(req: &mut Request) -> IronResult<Response> {
         // Schedule re-build of dependent packages (if requested)
         // Don't schedule builds if the upload is being done by the builder
         if depot.config.builds_enabled &&
-            (ident.get_origin() == "core" || depot.config.non_core_builds_enabled)
+            (ident.get_origin() == "core" || depot.config.non_core_builds_enabled) &&
+            !match helpers::extract_query_value("builder", req) {
+                Some(_) => true,
+                None => false,
+            }
         {
             let mut request = GroupCreate::new();
             request.set_origin(ident.get_origin().to_string());


### PR DESCRIPTION
Quick fix to add back a check that got inadvertently removed. This will prevent Builder from needlessly re-building packages that were uploaded by itself.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-52414658](https://user-images.githubusercontent.com/13542112/31262937-9646da6a-aa13-11e7-9704-d475fbc14daa.gif)
