### PR TITLE
minor binlink doc changes

### DIFF
--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -171,15 +171,15 @@ pub fn get() -> App<'static, 'static> {
             (aliases: &["p", "pk", "package"])
             (@setting ArgRequiredElseHelp)
             (@subcommand binlink =>
-                (about: "Creates a symlink for a package binary in a common 'PATH' location")
+                (about: "Creates a binlink for a package binary in a common 'PATH' location")
                 (aliases: &["bi", "bin", "binl", "binli", "binlin"])
                 (@arg PKG_IDENT: +required +takes_value
                     "A package identifier (ex: core/redis, core/busybox-static/1.42.2)")
                 (@arg BINARY: +takes_value
-                    "The command to symlink (ex: bash)")
+                    "The command to binlink (ex: bash)")
                 (@arg DEST_DIR: -d --dest +takes_value
                     "Sets the destination directory (default: /bin)")
-                (@arg FORCE: -f --force "Overwrite existing symlinks")
+                (@arg FORCE: -f --force "Overwrite existing binlinks")
             )
             (@subcommand config =>
                 (about: "Displays the default configuration options for a service")
@@ -587,7 +587,7 @@ fn sub_pkg_install() -> App<'static, 'static> {
             "One or more Habitat package identifiers (ex: acme/redis) and/or filepaths \
             to a Habitat Artifact (ex: /home/acme-redis-3.0.7-21120102031201-x86_64-linux.hart)")
         (@arg BINLINK: -b --binlink "Binlink all binaries from installed package(s)")
-        (@arg FORCE: -f --force "When using binlink, overwrite existing symlinks")
+        (@arg FORCE: -f --force "Overwrite existing binlinks")
     )
 }
 

--- a/components/hab/src/command/pkg/binlink.rs
+++ b/components/hab/src/command/pkg/binlink.rs
@@ -33,7 +33,7 @@ pub fn start(
     let dst_path = fs_root_path.join(dest_path.strip_prefix("/")?);
     let dst = dst_path.join(&binary);
     ui.begin(format!(
-        "Symlinking {} from {} into {}",
+        "Binlinking {} from {} into {}",
         &binary,
         &ident,
         dst_path.display()
@@ -54,9 +54,9 @@ pub fn start(
         )?;
         fs::create_dir_all(&dst_path)?
     }
-    let ui_symlinked =
+    let ui_binlinked =
         format!(
-        "Symlinked {} from {} to {}",
+        "Binlinked {} from {} to {}",
         &binary,
         &pkg_install.ident(),
         &dst.display(),
@@ -66,21 +66,21 @@ pub fn start(
             if force && path != src {
                 fs::remove_file(&dst)?;
                 filesystem::symlink(&src, &dst)?;
-                ui.end(&ui_symlinked)?;
+                ui.end(&ui_binlinked)?;
             } else if path != src {
                 ui.warn(
-                    format!("Skipping symlink because {} already exists at {}. Use --force to overwrite",
+                    format!("Skipping binlink because {} already exists at {}. Use --force to overwrite",
                 &binary,
                 &dst.display(),
                 ),
                 )?;
             } else {
-                ui.end(&ui_symlinked)?;
+                ui.end(&ui_binlinked)?;
             }
         }
         Err(_) => {
             filesystem::symlink(&src, &dst)?;
-            ui.end(&ui_symlinked)?;
+            ui.end(&ui_binlinked)?;
         }
     }
     Ok(())

--- a/www/source/partials/docs/_commands-cli.html.md.erb
+++ b/www/source/partials/docs/_commands-cli.html.md.erb
@@ -405,6 +405,7 @@ Creates a symlink for a package binary in a common 'PATH' location
 
 **FLAGS** 
 
+    -f, --force      Overwrite existing binlinks
     -h, --help       Prints help information
     -V, --version    Prints version information
 
@@ -583,6 +584,7 @@ Installs a Habitat package from Habitat Builder or locally from a Habitat Artifa
 **FLAGS** 
 
     -b, --binlink    Binlink all binaries from installed package(s)
+    -f, --force      Overwrite existing binlinks
     -h, --help       Prints help information
     -V, --version    Prints version information
 


### PR DESCRIPTION
This makes sure we use the term `binlink` in the docs and cli help output consistently. Even though binlink functions off of using `std::os::unix::fs::symlink` right now (and the windows one is unimplemented), that doesn't mean it will work that way in the future, and the abstraction we provide should use `binlink` terminology to reflect that.

Signed-off-by: echohack <echohack@users.noreply.github.com>

@davidwrede 