### PR TITLE
Generate a txn-id when generating new synchronous requests

### DIFF
--- a/components/builder-protocol/src/message/mod.rs
+++ b/components/builder-protocol/src/message/mod.rs
@@ -362,6 +362,10 @@ impl Txn {
         self.0.set_complete(value);
     }
 
+    pub fn set_id(&mut self, value: u64) {
+        self.0.set_id(value);
+    }
+
     pub fn to_bytes(&self) -> Result<Vec<u8>, ProtocolError> {
         encode(&self.0)
     }


### PR DESCRIPTION
This change activates the usage of the `id` field in a network
message's TXN message part. We generate a non-zero transaction id
and include it as part of the message. When we receive a response
to our message we ensure that the txn-id is what we sent.

We should never receive messages out of order or a response for
somebody else's request, but if we do, this will prevent any data
corruption.

![tenor-42229730](https://user-images.githubusercontent.com/54036/31296952-1648f376-aa99-11e7-8edc-6b90f483813e.gif)
