### PR TITLE
Set a sensible default for `archive.backend` config option in JobSrv

### DIFF
--- a/components/builder-jobsrv/src/config.rs
+++ b/components/builder-jobsrv/src/config.rs
@@ -146,7 +146,7 @@ impl Default for NetCfg {
 #[derive(Debug, Clone, Deserialize)]
 #[serde(default)]
 pub struct ArchiveCfg {
-    pub backend: Option<ArchiveBackend>,
+    pub backend: ArchiveBackend,
 
     // These are for S3 archiving
     pub key: Option<String>,
@@ -162,7 +162,7 @@ pub struct ArchiveCfg {
 impl Default for ArchiveCfg {
     fn default() -> Self {
         ArchiveCfg {
-            backend: None,
+            backend: ArchiveBackend::Local,
 
             key: None,
             secret: None,
@@ -242,7 +242,7 @@ mod tests {
         assert_eq!(config.datastore.connection_test, true);
         assert_eq!(config.datastore.pool_size, 1);
 
-        assert_eq!(config.archive.backend, Some(ArchiveBackend::S3));
+        assert_eq!(config.archive.backend, ArchiveBackend::S3);
         assert_eq!(config.archive.key, Some("THIS_IS_THE_KEY".to_string()));
         assert_eq!(
             config.archive.secret,

--- a/components/builder-jobsrv/src/server/log_archiver/mod.rs
+++ b/components/builder-jobsrv/src/server/log_archiver/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2017 Chef Software Inc. and/or applicable contributors
+// Copyright (c) 2016 Chef Software Inc. and/or applicable contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -48,8 +48,7 @@ pub trait LogArchiver: Send {
 /// Create appropriate LogArchiver variant based on configuration values.
 pub fn from_config(config: &ArchiveCfg) -> Result<Box<LogArchiver>> {
     match config.backend {
-        Some(ArchiveBackend::Local) => Ok(Box::new(local::LocalArchiver::new(config)?)),
-        Some(ArchiveBackend::S3) => Ok(Box::new(s3::S3Archiver::new(config)?)),
-        None => panic!("Did not specify an archive backend!"),
+        ArchiveBackend::Local => Ok(Box::new(local::LocalArchiver::new(config)?)),
+        ArchiveBackend::S3 => Ok(Box::new(s3::S3Archiver::new(config)?)),
     }
 }


### PR DESCRIPTION
`archive.backend` is a required configuration setting which we
currently catch at runtime if it isn't set appropriately immediately
after running migrations. This change will ensure that it's assigned
a default value at compile time to prevent a runtime failure

![tenor-202159630](https://user-images.githubusercontent.com/54036/31297098-96412fbc-aa99-11e7-8404-805369f6e0b6.gif)
