### PR TITLE
Fix mispelling of bldrSessionToken

### DIFF
--- a/components/builder-web/app/actions/gitHub.ts
+++ b/components/builder-web/app/actions/gitHub.ts
@@ -77,7 +77,7 @@ export function authenticateWithGitHub(oauth_token = undefined, session_token = 
             });
         }
         if (session_token) {
-            setCookie("bldrAuthSessionToken", session_token);
+            setCookie("bldrSessionToken", session_token);
             dispatch(fetchMyOrigins(session_token));
             dispatch(fetchMyOriginInvitations(session_token));
         }
@@ -85,7 +85,7 @@ export function authenticateWithGitHub(oauth_token = undefined, session_token = 
 }
 
 export function fetchGitHubFiles(installationId: string, owner: string, repo: string, filename: string) {
-    const token = cookies.get("bldrAuthSessionToken");
+    const token = cookies.get("bldrSessionToken");
 
     return dispatch => {
         dispatch(clearGitHubFiles());


### PR DESCRIPTION
It was my intent for us to have one session cookie for authenticating
with Builder: bldrSessionToken. I accidentally keyed this token in as
bldrAuthSessionToken in two places. Oops!

![tenor-66037929](https://user-images.githubusercontent.com/54036/31301465-fc0f3252-aaae-11e7-9a99-0d92dc70b209.gif)
