### PR TITLE
Update bootstrap script in light of installer refactorings

### DIFF
--- a/terraform/scripts/install_base_packages.sh
+++ b/terraform/scripts/install_base_packages.sh
@@ -111,6 +111,15 @@ log "Installing public origin keys"
 mkdir -p /hab/cache/keys
 cp ${tmpdir}/keys/* /hab/cache/keys
 
+# When installing packages (even from a .hart file), we pull
+# dependencies from Builder, but we pull them *through the artifact
+# cache*. If we put all the hart files in the cache first, we should
+# be able to install everything we need. There will be some extra
+# artifacts, but that's a minor concern.
+log "Populating artifact cache"
+mkdir -p /hab/cache/artifacts
+cp ${tmpdir}/artifacts/* /hab/cache/artifacts
+
 for pkg in "${sup_packages[@]}" ${services_to_install[@]:-}
 do
     pkg_name=${pkg##core/} # strip "core/" if it's there


### PR DESCRIPTION
The recent refactoring of our installation logic (#3344) inadvertently
broke our bootstrap installation logic. Apparently, the earlier logic
pulled dependent hart files from the same directory as the hart file
being installed. In the new logic, it does not do this, but pulls
everything from Builder through the artifact cache.

The solution here is simply to place all the artifacts into the cache
before installing the desired packages, just as we do with the public
signing keys. True, we end up with some additional packages in our
artifact cache, but that's fine. Besides, once we implement #3499, we
can even clean those up.

Fixes #3591