### PR TITLE
Add hook to update folder permissions

### DIFF
--- a/components/builder-api-proxy/hooks/init
+++ b/components/builder-api-proxy/hooks/init
@@ -1,4 +1,4 @@
 #!/bin/sh
 set -e
 mkdir -p {{pkg.svc_var_path}}/nginx
-chown hab:hab {{pkg.svc_var_path}}
+chown -R hab:hab {{pkg.svc_var_path}}

--- a/components/builder-api-proxy/hooks/run
+++ b/components/builder-api-proxy/hooks/run
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+pkg_svc_run="nginx -c {{pkg.svc_config_path}}/nginx.conf"
+
+if [ "\$(whoami)" = "root" ]; then
+  chown -R hab:hab {{pkg.svc_var_path}}
+  exec chpst \
+    -U {{pkg.svc_user}}:{{pkg.svc_group}} \
+    -u {{pkg.svc_user}}:{{pkg.svc_group}} \
+    ${pkg_svc_run} 2>&1
+else
+  exec ${pkg_svc_run} 2>&1
+fi

--- a/components/builder-api-proxy/plan.sh
+++ b/components/builder-api-proxy/plan.sh
@@ -6,7 +6,6 @@ pkg_maintainer="The Habitat Maintainers <humans@habitat.sh"
 pkg_license=("Apache-2.0")
 pkg_deps=(core/nginx core/curl)
 pkg_build_deps=(core/git)
-pkg_svc_run="nginx -c ${pkg_svc_config_path}/nginx.conf"
 pkg_svc_user="root"
 pkg_svc_group="root"
 pkg_exports=(


### PR DESCRIPTION
This is a workaround to fix the folder permissions that can get reset back to root for the builder-api-proxy.  Since the proxy runs as the hab user, it needs the directory owner to be hab.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-22843257](https://user-images.githubusercontent.com/13542112/31304456-e9cc98c4-aad5-11e7-8bd2-132d5e4e4d17.gif)
