### PR TITLE
Replace plan selection with a text field

### DIFF
--- a/components/builder-api/habitat/config/habitat.conf.js
+++ b/components/builder-api/habitat/config/habitat.conf.js
@@ -7,6 +7,8 @@ habitatConfig({
     github_client_id: "{{cfg.github.client_id}}",
     github_api_url: "{{cfg.github.url}}",
     github_web_url: "{{cfg.github.web_url}}",
+    github_app_url: "{{cfg.web.github_app_url}}",
+    github_app_id: "{{cfg.web.github_app_id}}",
     source_code_url: "{{cfg.web.source_code_url}}",
     tutorials_url: "{{cfg.web.tutorials_url}}",
     version: "{{pkg.ident}}",

--- a/components/builder-api/habitat/default.toml
+++ b/components/builder-api/habitat/default.toml
@@ -27,7 +27,9 @@ roadmap_url           = "https://ext.prodpad.com/ext/roadmap/d2938aed0d0ad1dd626
 feature_requests_url  = "https://portal.prodpad.com/24539"
 slack_url             = "http://slack.habitat.sh/"
 youtube_url           = "https://www.youtube.com/playlist?list=PL11cZfNdwNyOxlvI1Kq6ae8eVBl5S3IKk"
-demo_app_url          = "#"
+demo_app_url          = "https://www.habitat.sh/demo"
+github_app_url        = "https://github.com/apps/habitat-builder"
+github_app_id         = "5565"
 
 [depot]
 builds_enabled = true

--- a/components/builder-web/app/BuilderApiClient.ts
+++ b/components/builder-web/app/BuilderApiClient.ts
@@ -142,9 +142,9 @@ export class BuilderApiClient {
         });
     }
 
-    public findFileInRepo(installationId: string, owner: string, repo: string, filename: string, page: number = 1, per_page: number = 100) {
+    public findFileInRepo(installationId: string, owner: string, repo: string, path: string, page: number = 1, per_page: number = 100) {
         return new Promise((resolve, reject) => {
-            fetch(`${this.urlPrefix}/ext/installations/${installationId}/search/code?q=repo:${owner}/${repo}+filename:${filename}&page=${page}&per_page=${per_page}`, {
+            fetch(`${this.urlPrefix}/ext/installations/${installationId}/repos/${repo}/contents/${encodeURIComponent(path)}`, {
                 method: "GET",
                 headers: this.headers,
             }).then(response => {

--- a/components/builder-web/app/GitHubApiClient.ts
+++ b/components/builder-web/app/GitHubApiClient.ts
@@ -77,9 +77,9 @@ export class GitHubApiClient {
         });
     }
 
-    public getUserInstallationRepositories(installationId: string) {
+    public getUserInstallationRepositories(installationId: string, page: number) {
         return new Promise((resolve, reject) => {
-            fetch(`${config["github_api_url"]}/user/installations/${installationId}/repositories?access_token=${this.token}`, {
+            fetch(`${config["github_api_url"]}/user/installations/${installationId}/repositories?access_token=${this.token}&page=${page}`, {
                 method: "GET",
                 headers: {
                     "Accept": [

--- a/components/builder-web/app/actions/gitHub.ts
+++ b/components/builder-web/app/actions/gitHub.ts
@@ -117,13 +117,13 @@ export function fetchGitHubInstallations() {
 };
 
 
-export function fetchGitHubInstallationRepositories(installationId: string) {
+export function fetchGitHubInstallationRepositories(installationId: string, page: number = 1) {
     const token = cookies.get("gitHubAuthToken");
 
     return dispatch => {
         dispatch(clearGitHubRepos());
 
-        new GitHubApiClient(token).getUserInstallationRepositories(installationId)
+        new GitHubApiClient(token).getUserInstallationRepositories(installationId, page)
             .then((results) => {
                 dispatch(populateGitHubInstallationRepositories(results));
             });

--- a/components/builder-web/app/origin/origins-page/origins-page.component.html
+++ b/components/builder-web/app/origin/origins-page/origins-page.component.html
@@ -12,16 +12,12 @@
         Failed to load origins: {{ui.errorMessage}}
       </p>
       <div class="origin-create-intro" *ngIf="origins.size === 0 && !ui.errorMessage">
-        <p><strong>You don't currently have any origins. Let's add one now.</strong></p>
+        <p><strong>You are not currently an owner or member of any origins.</strong></p>
         <p>
-          In order to begin uploading and distributing your packages, you'll first need to <a [routerLink]="['/origins/create']">create an origin</a>. If you would like to join an existing origin, then you'll need to request an invite from a current member.
+          Note: If you've already created an origin with the Habitat CLI tool, then you'll need to create it here, too, using the same name.
         </p>
         <p>
-          If you've already created an origin locally via the Habitat CLI tool, then you'll need to create it here too
-          using the same name.
-        </p>
-        <p>
-          <em>Not sure how to get started? <a href="{{ config['demo_app_url'] }}">Try the demo app</a> for a hands-on walkthrough.</em>
+          <em>New to Habitat? <a href="{{ config['demo_app_url'] }}">Try the demo app</a>.</em>
         </p>
       </div>
       <div *ngIf="origins.size > 0">

--- a/components/builder-web/app/reducers/gitHub.ts
+++ b/components/builder-web/app/reducers/gitHub.ts
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {fromJS, List} from "immutable";
-import * as actionTypes from "../actions/index";
+import { fromJS, List } from "immutable";
 import initialState from "../initialState";
+import * as actionTypes from "../actions/index";
+import config from "../config";
 
 export default function gitHub(state = initialState["gitHub"], action) {
     switch (action.type) {
@@ -33,7 +34,12 @@ export default function gitHub(state = initialState["gitHub"], action) {
                 set("authToken", action.payload.gitHubAuthToken);
 
         case actionTypes.POPULATE_GITHUB_INSTALLATIONS:
-            return state.set("installations", fromJS(action.payload.installations));
+
+            const filtered = action.payload.installations.filter((i) => {
+                return i.integration_id.toString() === config["github_app_id"];
+            });
+
+            return state.set("installations", fromJS(filtered));
 
         case actionTypes.POPULATE_GITHUB_INSTALLATION_REPOSITORIES:
             return state.set("installationRepositories", fromJS(action.payload.repositories));

--- a/components/builder-web/app/shared/docker-export-settings/_docker-export-settings.component.scss
+++ b/components/builder-web/app/shared/docker-export-settings/_docker-export-settings.component.scss
@@ -22,4 +22,44 @@
       display: block;
     }
   }
+
+  md-slide-toggle {
+    margin-bottom: 12px;
+  }
+
+  md-radio-group {
+    display: block;
+    border-top: 1px solid $very-light-gray;
+    margin-bottom: 18px;
+
+    md-radio-button {
+      display: block;
+      line-height: rem(40);
+      border-bottom: 1px solid $very-light-gray;
+
+      .mat-radio-container {
+        margin-right: 40px;
+      }
+
+      label {
+        margin-bottom: 2px;
+      }
+
+      hab-icon {
+        margin-right: 12px;
+      }
+
+      span {
+        font-size: rem(12);
+        text-transform: none;
+      }
+    }
+  }
+
+  input[type="text"] {
+
+    &::placeholder {
+      color: $medium-gray;
+    }
+  }
 }

--- a/components/builder-web/app/shared/project-settings/_project-settings.component.scss
+++ b/components/builder-web/app/shared/project-settings/_project-settings.component.scss
@@ -11,6 +11,30 @@ hab-project-settings {
     p {
       font-size: rem(14);
       margin-bottom: 0;
+
+      &.note {
+        position: relative;
+        margin-top: 0;
+        padding: 14px 14px 14px 48px;
+        background-color: $very-light-gray;
+        border-radius: $global-radius;
+        color: $dark-blue;
+        margin-bottom: 18px;
+
+        hab-icon {
+          position: absolute;
+          left: 14px;
+          top: 16px;
+          width: 24px;
+          height: 24px;
+          color: $dark-gray;
+        }
+
+        a {
+          color: $dark-blue;
+          text-decoration: underline;
+        }
+      }
     }
 
     .connect {
@@ -146,7 +170,7 @@ hab-project-settings {
         color: $hab-white;
         font-size: rem(14);
         padding: 4px 14px;
-        margin-bottom: 36px;
+        margin-bottom: 28px;
 
         li {
           display: inline-block;
@@ -174,6 +198,34 @@ hab-project-settings {
         p {
           font-size: rem(14);
           margin-bottom: 12px;
+
+          code {
+            font-family: $monospace-font-family;
+            font-size: rem(12);
+          }
+        }
+
+        form {
+          margin-bottom: 20px;
+        }
+
+        input {
+          font-family: $monospace-font-family;
+          font-size: rem(12);
+          margin-bottom: 16px;
+        }
+
+        small {
+          display: block;
+          margin-bottom: 10px;
+          font-size: rem(12);
+        }
+
+        hab-icon {
+          top: 7px;
+          right: 6px;
+          width: 16px;
+          height: 16px;
         }
       }
 
@@ -181,39 +233,14 @@ hab-project-settings {
         margin-top: 28px;
       }
 
-      .files {
-
-        md-radio-group {
-          display: block;
-          margin-bottom: 18px;
-
-          md-radio-button {
-            display: block;
-            line-height: rem(40);
-            border-bottom: 1px solid $very-light-gray;
-
-            .mat-radio-container {
-              margin-right: 40px;
-            }
-
-            label {
-              margin-bottom: 2px;
-            }
-
-            hab-icon {
-              margin-right: 12px;
-            }
-
-            span {
-              font-size: rem(12);
-              text-transform: none;
-            }
-          }
-        }
+      .repo-link {
+        font-size: rem(12);
+        float: right;
+        display: block;
       }
 
       .controls {
-        margin-top: 30px;
+        margin-top: 12px;
 
         a {
           cursor: pointer;

--- a/components/builder-web/app/shared/project-settings/project-settings.component.html
+++ b/components/builder-web/app/shared/project-settings/project-settings.component.html
@@ -43,6 +43,14 @@
         </ul>
     </div>
     <div class="connecting" *ngIf="connecting">
+        <p class="note">
+            <hab-icon symbol="github"></hab-icon>
+            GitHub organizations and repositories with the <a href="{{ config['github_app_url'] }}" target="_blank">Habitat GitHub app</a>
+            installed are listed below. You can install the app
+            <a href="https://help.github.com/articles/installing-an-app-in-your-personal-account/" target="_blank">on your personal account</a>
+            or <a href="https://help.github.com/articles/installing-an-app-in-your-organization/" target="_blank">on an organization</a> of which
+            <em>you are the owner</em>.
+        </p>
         <ol>
             <li [class.active]="!selectedRepo" (click)="deselect()">Select a GitHub repo</li>
             <li [class.active]="selectedRepo">Set path to Habitat plan file</li>
@@ -51,9 +59,12 @@
             <div class="installations">
                 <h3>
                     <hab-icon symbol="github"></hab-icon>
-                    Installed Apps
+                    GitHub Orgs for {{ username }}
                 </h3>
                 <ul>
+                    <li *ngIf="installations.size === 0">
+                        None.
+                    </li>
                     <li *ngFor="let installation of installations">
                         <a (click)="selectInstallation(installation)" [class.active]="installation === selectedInstallation">
                             {{ installation.getIn(["account", "login"]) }}
@@ -63,38 +74,55 @@
                 </ul>
             </div>
             <div class="repos">
-                <h3>Repositories for App</h3>
-                <input [(ngModel)]="filter.name" placeholder="Filter by name">
-                <ul>
-                    <li *ngFor="let repo of repos | habGitHubRepoFilter:filter:'name'">
-                        <a (click)="selectRepo(repo)">
-                            {{ repo.get("name") }}
-                            <hab-icon symbol="chevron-right"></hab-icon>
-                        </a>
-                    </li>
-                </ul>
+                <div *ngIf="selectedInstallation">
+                    <h3>GitHub Repos for Selected Org</h3>
+                    <input [(ngModel)]="filter.name" placeholder="Filter by name">
+                    <ul>
+                        <li *ngIf="repos.size === 0">
+                            None.
+                        </li>
+                        <li *ngFor="let repo of repos | habGitHubRepoFilter:filter:'name'">
+                            <a (click)="selectRepo(repo)">
+                                {{ repo.get("name") }}
+                                <hab-icon symbol="chevron-right"></hab-icon>
+                            </a>
+                        </li>
+                    </ul>
+                </div>
             </div>
         </div>
         <div class="select" *ngIf="selectedRepo">
-            <h3>Select a Plan File</h3>
-            <p *ngIf="files.size > 0">
-                If the selected repo contains any plan files, they will be listed below. When repo changes are detected,
-                the Build Service will create a new .hart file from the selected plan.
+            <a class="repo-link" href="{{ repoUrl }}" target="_blank">
+                <hab-icon symbol="open-in-new"></hab-icon>
+                Go to your repo
+            </a>
+            <h3>Path to Plan File</h3>
+            <p>
+                Enter the path to your plan file from the root of your repo. By default,
+                we check for <code>habitat/plan.sh</code>.
             </p>
-            <div *ngIf="files.size === 0">
-                <p><em>No plan files were found in this GitHub repo.</em></p>
-            </div>
             <div class="files">
-                <md-radio-group [(ngModel)]="selectedPath">
-                    <md-radio-button *ngFor="let file of files" [value]="file.get('path')" [disabled]="isWindows(file.get('path'))">
-                        <hab-icon [symbol]="iconFor(file.get('path'))"></hab-icon>
-                        <span>{{ file.get("path") }}</span>
-                    </md-radio-button>
-                </md-radio-group>
+                <form [formGroup]="form" #formValues="ngForm">
+                    <hab-checking-input
+                        id="plan_path"
+                        name="plan_path"
+                        availableMessage="found!"
+                        notAvailableMessage="does not exist in the repository."
+                        displayName="Plan file"
+                        [form]="form"
+                        [pattern]="false"
+                        [maxLength]="false"
+                        [isAvailable]="doesFileExist"
+                        [value]="selectedPath">
+                    </hab-checking-input>
+                </form>
             </div>
-            <hab-visibility-selector [setting]="visibility" (changed)="settingChanged($event)"></hab-visibility-selector>
+            <hab-visibility-selector
+                [setting]="visibility"
+                (changed)="settingChanged($event)">
+            </hab-visibility-selector>
             <hab-docker-export-settings #docker
-                *ngIf="files.size > 0"
+                *ngIf="selectedRepo"
                 [integrations]="integrations">
             </hab-docker-export-settings>
         </div>

--- a/components/builder-web/assets/images/icons/all.svg
+++ b/components/builder-web/assets/images/icons/all.svg
@@ -136,5 +136,9 @@
       <!-- https://material.io/icons/#ic_delete -->
       <path d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"/>
     </g>
+    <g id="icon-open-in-new">
+      <!-- https://material.io/icons/#ic_open_in_new -->
+      <path d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"/>
+    </g>
   </defs>
 </svg>

--- a/components/builder-web/habitat.conf.sample.js
+++ b/components/builder-web/habitat.conf.sample.js
@@ -18,6 +18,10 @@ habitatConfig({
     github_api_url: "https://api.github.com",
     // The Web URL for GitHub
     github_web_url: "https://github.com",
+    // The Habitat Builder GitHub app
+    github_app_url: "https://github.com/apps/habitat-builder-dev",
+    // The Habitat Builder GitHub app ID
+    github_app_id: "5629",
     // The URL for the Habitat source code
     source_code_url: "https://github.com/habitat-sh/habitat",
     // The URL for tutorials
@@ -37,7 +41,7 @@ habitatConfig({
     // The URL for status
     status_url: "https://status.habitat.sh/",
     // The URL for the demo app
-    demo_app_url: "#",
+    demo_app_url: "https://www.habitat.sh/demo",
     // The version of the software we're running. In production, this should
     // be automatically populated by Habitat
     version: "",


### PR DESCRIPTION
This change replaces the plan-file selection functionality we were using to choose plans from GitHub repositories with a text field, validated on change. Verified with forked repos as well. 

Fixes #3510.

Signed-off-by: Christian Nunciato <cnunciato@chef.io>

![](https://media.tenor.com/images/a77256ca6779f58b7d5334d83a1b0a75/tenor.gif)