### PR TITLE
Update builder log location, add log rotation

### DIFF
--- a/components/builder-scheduler/habitat/config/config.toml
+++ b/components/builder-scheduler/habitat/config/config.toml
@@ -1,4 +1,4 @@
-log_dir = "{{pkg.svc_var_path}}"
+log_path = "{{pkg.svc_path}}/logs"
 
 {{~#eachAlive bind.router.members as |member|}}
 [[routers]]

--- a/components/builder-worker/habitat/config/config.toml
+++ b/components/builder-worker/habitat/config/config.toml
@@ -1,7 +1,7 @@
 auth_token = "{{cfg.auth_token}}"
 auto_publish = {{cfg.auto_publish}}
 data_path = "{{pkg.svc_data_path}}"
-log_path = "{{pkg.svc_var_path}}"
+log_path = "{{pkg.svc_path}}/logs"
 bldr_channel = "{{cfg.bldr_channel}}"
 bldr_url = "{{bind.depot.first.cfg.url}}"
 features_enabled = "{{cfg.features_enabled}}"

--- a/terraform/files/builder.logrotate
+++ b/terraform/files/builder.logrotate
@@ -1,0 +1,14 @@
+/hab/svc/builder-scheduler/logs/builder-scheduler.log
+/hab/svc/builder-worker/logs/builder-worker.log
+{
+        rotate 7
+        weekly
+        size 10M
+        missingok
+        notifempty
+        delaycompress
+        compress
+        postrotate
+                /bin/systemctl restart hab-sup 2>/dev/null || true
+        endscript
+}

--- a/terraform/instances.tf
+++ b/terraform/instances.tf
@@ -550,12 +550,18 @@ resource "aws_instance" "scheduler" {
     destination = "/tmp/sch_log_parser.py"
   }
 
+  provisioner "file" {
+    source = "${path.module}/files/builder.logrotate"
+    destination = "/tmp/builder.logrotate"
+  }
+
   provisioner "remote-exec" {
     inline = [
       "DD_INSTALL_ONLY=true DD_API_KEY=${var.datadog_api_key} /bin/bash -c \"$(curl -L https://raw.githubusercontent.com/DataDog/dd-agent/master/packaging/datadog-agent/source/install_agent.sh)\"",
       "sudo sed -i \"$ a dogstreams: /tmp/builder-scheduler.log:/etc/dd-agent/sch_log_parser.py:my_log_parser\" /etc/dd-agent/datadog.conf",
       "sudo sed -i \"$ a tags: env:${var.env}, role:scheduler\" /etc/dd-agent/datadog.conf",
       "sudo cp /tmp/sch_log_parser.py /etc/dd-agent/sch_log_parser.py",
+      "sudo cp /tmp/builder.logrotate /etc/logrotate.d/builder",
       "sudo /etc/init.d/datadog-agent start"
     ]
   }
@@ -706,10 +712,16 @@ resource "aws_instance" "worker" {
     ]
   }
 
+  provisioner "file" {
+    source = "${path.module}/files/builder.logrotate"
+    destination = "/tmp/builder.logrotate"
+  }
+
   provisioner "remote-exec" {
     inline = [
       "DD_INSTALL_ONLY=true DD_API_KEY=${var.datadog_api_key} /bin/bash -c \"$(curl -L https://raw.githubusercontent.com/DataDog/dd-agent/master/packaging/datadog-agent/source/install_agent.sh)\"",
       "sudo sed -i \"$ a tags: env:${var.env}, role:worker\" /etc/dd-agent/datadog.conf",
+      "sudo cp /tmp/builder.logrotate /etc/logrotate.d/builder",
       "sudo /etc/init.d/datadog-agent stop"
     ]
   }


### PR DESCRIPTION
Update the log location for builder scheduler and worker, and add a log rotation capability.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-212676774](https://user-images.githubusercontent.com/13542112/31310050-d7e66f2a-ab45-11e7-87d7-2765b7fded95.gif)
