### PR TITLE
Share app-id config between web and api in Habitat plan

### DIFF
--- a/components/builder-api/habitat/config/habitat.conf.js
+++ b/components/builder-api/habitat/config/habitat.conf.js
@@ -8,7 +8,7 @@ habitatConfig({
     github_api_url: "{{cfg.github.url}}",
     github_web_url: "{{cfg.github.web_url}}",
     github_app_url: "{{cfg.web.github_app_url}}",
-    github_app_id: "{{cfg.web.github_app_id}}",
+    github_app_id: "{{cfg.github.app_id}}",
     source_code_url: "{{cfg.web.source_code_url}}",
     tutorials_url: "{{cfg.web.tutorials_url}}",
     version: "{{pkg.ident}}",

--- a/components/builder-api/habitat/default.toml
+++ b/components/builder-api/habitat/default.toml
@@ -29,7 +29,6 @@ slack_url             = "http://slack.habitat.sh/"
 youtube_url           = "https://www.youtube.com/playlist?list=PL11cZfNdwNyOxlvI1Kq6ae8eVBl5S3IKk"
 demo_app_url          = "https://www.habitat.sh/demo"
 github_app_url        = "https://github.com/apps/habitat-builder"
-github_app_id         = "5565"
 
 [depot]
 builds_enabled = true


### PR DESCRIPTION
Share the app-id setting between the api and web configurations in
the builder-api plan. This will ensure they don't get out of sync
from misconfiguration.

![tenor-194018837](https://user-images.githubusercontent.com/54036/31310462-897dc3a8-ab4d-11e7-95f1-513a7b4f7464.gif)
