### PR TITLE
Enable non-core builds by default

### DIFF
--- a/BUILDER_DEV.md
+++ b/BUILDER_DEV.md
@@ -30,8 +30,6 @@ Create the following files somewhere on your local filesystem (Note: the client_
 `config_api.toml`
 ```toml
 [depot]
-builds_enabled = true
-non_core_builds_enabled = true
 key_dir = "/path/to/bldr-key-pair"
 ```
 

--- a/components/builder-api/src/config.rs
+++ b/components/builder-api/src/config.rs
@@ -51,7 +51,7 @@ impl Default for Config {
             ui: UiCfg::default(),
             depot: depot::config::Config::default(),
             events_enabled: false,
-            non_core_builds_enabled: false,
+            non_core_builds_enabled: true,
             log_dir: env::temp_dir().to_string_lossy().into_owned(),
         }
     }
@@ -136,7 +136,6 @@ mod tests {
 
         [depot]
         path = "/hab/svc/hab-depot/data"
-        builds_enabled = true
         events_enabled = true
         log_dir = "/hab/svc/hab-depot/var/log"
 
@@ -183,7 +182,7 @@ mod tests {
 
         let config = Config::from_raw(&content).unwrap();
         assert_eq!(config.events_enabled, false);
-        assert_eq!(config.non_core_builds_enabled, false);
+        assert_eq!(config.non_core_builds_enabled, true);
         assert_eq!(config.http.port, 9000);
     }
 }

--- a/support/builder/config.sh
+++ b/support/builder/config.sh
@@ -20,9 +20,6 @@ friends_only     = false
 source_code_url  = "https://github.com/habitat-sh/habitat"
 tutorials_url    = "https://www.habitat.sh/tutorials"
 www_url          = "http://$APP_HOSTNAME/#/sign-in"
-
-[depot]
-builds_enabled = true
 EOT
 
 mkdir -p /hab/svc/builder-jobsrv


### PR DESCRIPTION
* Enable non-core builds by default in both api and depot config
* Update dev docs
* Update container config

Signed-off-by: Jamie Winsor <jamie@vialstudios.com>