### PR TITLE
Switch logs back to var path

### DIFF
--- a/components/builder-scheduler/habitat/config/config.toml
+++ b/components/builder-scheduler/habitat/config/config.toml
@@ -1,4 +1,4 @@
-log_path = "{{pkg.svc_path}}/logs"
+log_path = "{{pkg.svc_var_path}}"
 
 {{~#eachAlive bind.router.members as |member|}}
 [[routers]]

--- a/components/builder-worker/habitat/config/config.toml
+++ b/components/builder-worker/habitat/config/config.toml
@@ -1,7 +1,7 @@
 auth_token = "{{cfg.auth_token}}"
 auto_publish = {{cfg.auto_publish}}
 data_path = "{{pkg.svc_data_path}}"
-log_path = "{{pkg.svc_path}}/logs"
+log_path = "{{pkg.svc_var_path}}"
 bldr_channel = "{{cfg.bldr_channel}}"
 bldr_url = "{{bind.depot.first.cfg.url}}"
 features_enabled = "{{cfg.features_enabled}}"

--- a/terraform/files/builder.logrotate
+++ b/terraform/files/builder.logrotate
@@ -1,5 +1,5 @@
-/hab/svc/builder-scheduler/logs/builder-scheduler.log
-/hab/svc/builder-worker/logs/builder-worker.log
+/hab/svc/builder-scheduler/var/builder-scheduler.log
+/hab/svc/builder-worker/var/builder-worker.log
 {
         rotate 7
         weekly


### PR DESCRIPTION
Go back to var path for builder service logs as the logs directory permission is root by default.

Signed-off-by: Salim Alam <salam@chef.io>