### PR TITLE
Move scheduler log file back to tmp

### DIFF
--- a/components/builder-scheduler/habitat/config/config.toml
+++ b/components/builder-scheduler/habitat/config/config.toml
@@ -1,4 +1,4 @@
-log_path = "{{pkg.svc_var_path}}"
+log_path = "{{cfg.log_path}}"
 
 {{~#eachAlive bind.router.members as |member|}}
 [[routers]]

--- a/components/builder-scheduler/habitat/default.toml
+++ b/components/builder-scheduler/habitat/default.toml
@@ -1,4 +1,5 @@
 log_level = "info"
+log_path = "/tmp"
 
 [datastore]
 user = "hab"

--- a/terraform/files/builder.logrotate
+++ b/terraform/files/builder.logrotate
@@ -1,4 +1,4 @@
-/hab/svc/builder-scheduler/var/builder-scheduler.log
+/tmp/builder-scheduler/var/builder-scheduler.log
 /hab/svc/builder-worker/var/builder-worker.log
 {
         rotate 7


### PR DESCRIPTION
Need more work to get the file permissions issues resolved, so moving the scheduler log file back to /tmp so we can get the jobs dashboard working.

Signed-off-by: Salim Alam <salam@chef.io>