### PR TITLE
Remove expired Sessions on SessionGet and strict match on token

### DIFF
--- a/components/builder-sessionsrv/src/server/mod.rs
+++ b/components/builder-sessionsrv/src/server/mod.rs
@@ -108,6 +108,10 @@ impl Session {
     pub fn expired(&self) -> bool {
         self.created_at.elapsed() >= *SESSION_DURATION
     }
+
+    pub fn validate_token(&self, token: &proto::SessionToken) -> bool {
+        self.token.get_token() == token.get_token()
+    }
 }
 
 impl Borrow<SessionKey> for Session {
@@ -143,7 +147,7 @@ impl Hash for Session {
 
 impl PartialEq for Session {
     fn eq(&self, other: &Session) -> bool {
-        self.key == other.key
+        self.key == other.key && self.token == other.token
     }
 }
 


### PR DESCRIPTION
* When we get an expired Session in SessionGet we now remove it
  before returning the handler
* Additionally check if the user's given token matches in entirity
  and return session expired if they do not match

![tenor-4172597](https://user-images.githubusercontent.com/54036/31312646-7c34d9d6-ab7d-11e7-9656-85294a937512.gif)
