### PR TITLE
Put profile.release in proper Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
+[profile.release]
+debug = true
+
 [workspace]
 members = [
   "components/builder-admin",

--- a/components/builder-admin/Cargo.toml
+++ b/components/builder-admin/Cargo.toml
@@ -11,9 +11,6 @@ name = "bldr-admin"
 path = "src/main.rs"
 doc = false
 
-[profile.release]
-debug = true
-
 [dependencies]
 clippy = {version = "*", optional = true}
 bodyparser = "*"


### PR DESCRIPTION
Since we're using Cargo workspaces we need to put our profiles in the root Cargo.toml