### PR TITLE
Move worker logs to tmp

### DIFF
--- a/components/builder-worker/habitat/config/config.toml
+++ b/components/builder-worker/habitat/config/config.toml
@@ -1,7 +1,7 @@
 auth_token = "{{cfg.auth_token}}"
 auto_publish = {{cfg.auto_publish}}
 data_path = "{{pkg.svc_data_path}}"
-log_path = "{{pkg.svc_var_path}}"
+log_path = "{{cfg.log_path}}"
 bldr_channel = "{{cfg.bldr_channel}}"
 bldr_url = "{{bind.depot.first.cfg.url}}"
 features_enabled = "{{cfg.features_enabled}}"

--- a/components/builder-worker/habitat/default.toml
+++ b/components/builder-worker/habitat/default.toml
@@ -1,4 +1,5 @@
 log_level = "info"
+log_path = "/tmp"
 auth_token = ""
 auto_publish = true
 bldr_channel = "unstable"

--- a/terraform/files/builder.logrotate
+++ b/terraform/files/builder.logrotate
@@ -1,5 +1,5 @@
-/tmp/builder-scheduler/var/builder-scheduler.log
-/hab/svc/builder-worker/var/builder-worker.log
+/tmp/builder-scheduler.log
+/tmp/builder-worker.log
 {
         rotate 7
         weekly


### PR DESCRIPTION
Moves the builder worker log files to /tmp for easier retrieval and analysis. Eventually they will be likely moved to a different location.

Signed-off-by: Salim Alam <salam@chef.io>