### PR TITLE
Select a plan by text field

### DIFF
--- a/components/builder-web/app/actions/gitHub.ts
+++ b/components/builder-web/app/actions/gitHub.ts
@@ -28,20 +28,12 @@ const parseLinkHeader = require("parse-link-header");
 const uuid = require("uuid").v4;
 const gitHubTokenAuthUrl = `${config["habitat_api_url"]}/v1/authenticate`;
 
-export const CLEAR_GITHUB_FILES = "CLEAR_GITHUB_FILES";
 export const CLEAR_GITHUB_INSTALLATIONS = "CLEAR_GITHUB_INSTALLATIONS";
-export const CLEAR_GITHUB_REPOS = "CLEAR_GITHUB_REPOS";
 export const LOAD_GITHUB_SESSION_STATE = "LOAD_GITHUB_SESSION_STATE";
-export const POPULATE_GITHUB_FILES = "POPULATE_GITHUB_FILES";
 export const POPULATE_GITHUB_INSTALLATIONS = "POPULATE_GITHUB_INSTALLATIONS";
-export const POPULATE_GITHUB_INSTALLATION_REPOSITORIES = "POPULATE_GITHUB_INSTALLATION_REPOSITORIES";
-export const POPULATE_GITHUB_REPOS = "POPULATE_GITHUB_REPOS";
 export const POPULATE_GITHUB_USER_DATA = "POPULATE_GITHUB_USER_DATA";
 export const SET_GITHUB_AUTH_STATE = "SET_GITHUB_AUTH_STATE";
 export const SET_GITHUB_AUTH_TOKEN = "SET_GITHUB_AUTH_TOKEN";
-export const SET_GITHUB_ORGS_LOADING_FLAG = "SET_GITHUB_ORGS_LOADING_FLAG";
-export const SET_GITHUB_REPOS_LOADING_FLAG = "SET_GITHUB_REPOS_LOADING_FLAG";
-export const SET_SELECTED_GITHUB_ORG = "SET_SELECTED_GITHUB_ORG";
 
 export function authenticateWithGitHub(oauth_token = undefined, session_token = undefined) {
     const wasInitializedWithToken = !!oauth_token;
@@ -84,27 +76,12 @@ export function authenticateWithGitHub(oauth_token = undefined, session_token = 
     };
 }
 
-export function fetchGitHubFiles(installationId: string, owner: string, repo: string, filename: string) {
-    const token = cookies.get("bldrSessionToken");
-
-    return dispatch => {
-        dispatch(clearGitHubFiles());
-        const client = new BuilderApiClient(token);
-
-        client.findFileInRepo(installationId, owner, repo, filename)
-            .then((results) => {
-                dispatch(populateGitHubFiles(results));
-            });
-    };
-};
-
 export function fetchGitHubInstallations() {
     const token = cookies.get("gitHubAuthToken");
 
     return dispatch => {
         const client = new GitHubApiClient(token);
         dispatch(clearGitHubInstallations());
-        dispatch(clearGitHubRepos());
 
         client.getUserInstallations()
             .then((results) => {
@@ -112,20 +89,6 @@ export function fetchGitHubInstallations() {
             })
             .catch((error) => {
                 console.error(error);
-            });
-    };
-};
-
-
-export function fetchGitHubInstallationRepositories(installationId: string, page: number = 1) {
-    const token = cookies.get("gitHubAuthToken");
-
-    return dispatch => {
-        dispatch(clearGitHubRepos());
-
-        new GitHubApiClient(token).getUserInstallationRepositories(installationId, page)
-            .then((results) => {
-                dispatch(populateGitHubInstallationRepositories(results));
             });
     };
 };
@@ -140,12 +103,6 @@ export function loadGitHubSessionState() {
     };
 }
 
-function clearGitHubFiles() {
-    return {
-        type: CLEAR_GITHUB_FILES
-    };
-}
-
 function clearGitHubInstallations() {
     return {
         type: CLEAR_GITHUB_INSTALLATIONS
@@ -156,27 +113,6 @@ function populateGitHubInstallations(payload) {
     return {
         type: POPULATE_GITHUB_INSTALLATIONS,
         payload,
-    };
-}
-
-function populateGitHubInstallationRepositories(payload) {
-    return {
-        type: POPULATE_GITHUB_INSTALLATION_REPOSITORIES,
-        payload,
-    };
-}
-
-function populateGitHubRepos(data) {
-    return {
-        type: POPULATE_GITHUB_REPOS,
-        payload: data,
-    };
-}
-
-function populateGitHubFiles(data) {
-    return {
-        type: POPULATE_GITHUB_FILES,
-        payload: data,
     };
 }
 
@@ -229,12 +165,6 @@ export function requestGitHubAuthToken(params, stateKey = "") {
     };
 }
 
-function clearGitHubRepos() {
-    return {
-        type: CLEAR_GITHUB_REPOS,
-    };
-}
-
 // Return up to two trailing segments of the current hostname
 // for purposes of setting the cookie domain unless the domain
 // is an IP address.
@@ -280,26 +210,5 @@ export function setGitHubAuthToken(payload) {
     return {
         type: SET_GITHUB_AUTH_TOKEN,
         payload
-    };
-}
-
-function setGitHubOrgsLoadingFlag(payload) {
-    return {
-        type: SET_GITHUB_ORGS_LOADING_FLAG,
-        payload,
-    };
-}
-
-function setGitHubReposLoadingFlag(payload) {
-    return {
-        type: SET_GITHUB_REPOS_LOADING_FLAG,
-        payload,
-    };
-}
-
-export function setSelectedGitHubOrg(org) {
-    return {
-        type: SET_SELECTED_GITHUB_ORG,
-        payload: org,
     };
 }

--- a/components/builder-web/app/actions/index.ts
+++ b/components/builder-web/app/actions/index.ts
@@ -26,20 +26,12 @@ import * as featureFlagActions from "./feature-flags";
 import * as sessionActions from "./sessions";
 
 // Action types
-export const CLEAR_GITHUB_FILES = gitHubActions.CLEAR_GITHUB_FILES;
 export const CLEAR_GITHUB_INSTALLATIONS = gitHubActions.CLEAR_GITHUB_INSTALLATIONS;
-export const CLEAR_GITHUB_REPOS = gitHubActions.CLEAR_GITHUB_REPOS;
 export const LOAD_GITHUB_SESSION_STATE = gitHubActions.LOAD_GITHUB_SESSION_STATE;
-export const POPULATE_GITHUB_FILES = gitHubActions.POPULATE_GITHUB_FILES;
 export const POPULATE_GITHUB_INSTALLATIONS = gitHubActions.POPULATE_GITHUB_INSTALLATIONS;
-export const POPULATE_GITHUB_INSTALLATION_REPOSITORIES = gitHubActions.POPULATE_GITHUB_INSTALLATION_REPOSITORIES;
-export const POPULATE_GITHUB_REPOS = gitHubActions.POPULATE_GITHUB_REPOS;
 export const POPULATE_GITHUB_USER_DATA = gitHubActions.POPULATE_GITHUB_USER_DATA;
-export const SET_GITHUB_ORGS_LOADING_FLAG = gitHubActions.SET_GITHUB_ORGS_LOADING_FLAG;
-export const SET_GITHUB_REPOS_LOADING_FLAG = gitHubActions.SET_GITHUB_REPOS_LOADING_FLAG;
 export const SET_GITHUB_AUTH_STATE = gitHubActions.SET_GITHUB_AUTH_STATE;
 export const SET_GITHUB_AUTH_TOKEN = gitHubActions.SET_GITHUB_AUTH_TOKEN;
-export const SET_SELECTED_GITHUB_ORG = gitHubActions.SET_SELECTED_GITHUB_ORG;
 
 export const SET_BLDR_SESSION_TOKEN = sessionActions.SET_BLDR_SESSION_TOKEN;
 export const LOAD_BLDR_SESSION_STATE = sessionActions.LOAD_BLDR_SESSION_STATE;
@@ -124,14 +116,11 @@ export const RESET = "RESET";
 
 // Actions
 export const authenticateWithGitHub = gitHubActions.authenticateWithGitHub;
-export const fetchGitHubFiles = gitHubActions.fetchGitHubFiles;
 export const fetchGitHubInstallations = gitHubActions.fetchGitHubInstallations;
-export const fetchGitHubInstallationRepositories = gitHubActions.fetchGitHubInstallationRepositories;
 export const loadGitHubSessionState = gitHubActions.loadGitHubSessionState;
 export const removeSessionStorage = gitHubActions.removeSessionStorage;
 export const requestGitHubAuthToken = gitHubActions.requestGitHubAuthToken;
 export const setGitHubAuthState = gitHubActions.setGitHubAuthState;
-export const setSelectedGitHubOrg = gitHubActions.setSelectedGitHubOrg;
 
 export const loadBldrSessionState = sessionActions.loadBldrSessionState;
 

--- a/components/builder-web/app/actions/projects.ts
+++ b/components/builder-web/app/actions/projects.ts
@@ -107,6 +107,8 @@ export function fetchProject(origin: string, name: string, token: string, alert:
 export function fetchProjects(origin: string, token: string) {
   return dispatch => {
     dispatch(clearProjects());
+    dispatch(clearCurrentProject());
+    dispatch(clearCurrentProjectIntegration());
 
     new BuilderApiClient(token).getProjects(origin).then(response => {
         if (Array.isArray(response) && response.length > 0) {

--- a/components/builder-web/app/initialState.ts
+++ b/components/builder-web/app/initialState.ts
@@ -31,18 +31,10 @@ export default Record({
     authState: undefined,
     authToken: undefined,
     installations: List(),
-    installationRepositories: List(),
-    orgs: List(),
-    repos: List(),
-    files: List(),
-    selectedOrg: undefined,
     username: undefined,
     ui: Record({
-      orgs: Record({
-        loading: false,
-      })(),
-      repos: Record({
-        loading: false,
+      installations: Record({
+        loading: false
       })()
     })()
   })(),

--- a/components/builder-web/app/origin/origin-page/origin-packages-tab/origin-packages-tab.component.html
+++ b/components/builder-web/app/origin/origin-page/origin-packages-tab/origin-packages-tab.component.html
@@ -20,7 +20,7 @@
         <div *ngIf="projectsEnabled">
           <li class="heading" *ngIf="projectsExist">
             <div class="pkg-col-1">
-              <h3>Connected plans</h3>
+              <h3>Connected Plans</h3>
             </div>
           </li>
           <li *ngFor="let proj of projects">
@@ -34,10 +34,9 @@
             </div>
           </li>
         </div>
-
         <li class="heading">
           <div class="pkg-col-1">
-            <h3>Package</h3>
+            <h3>Packages</h3>
           </div>
         </li>
         <li *ngIf="noPackages">

--- a/components/builder-web/app/package/build-list/_build-list.component.scss
+++ b/components/builder-web/app/package/build-list/_build-list.component.scss
@@ -17,7 +17,7 @@
       }
 
       &.item {
-        line-height: rem(60);
+        padding: 18px 12px;
         color: $dim-slate-gray;
 
         &:hover {
@@ -28,6 +28,7 @@
 
             hab-icon {
               width: 20px;
+              height: 20px;
 
               &[symbol="chevron-right"] {
                 display: block;
@@ -44,11 +45,11 @@
       }
 
       .version {
-        @include span-columns(3);
+        @include span-columns(2);
       }
 
       .count {
-        @include span-columns(3);
+        @include span-columns(4);
       }
 
       .created {
@@ -60,6 +61,7 @@
 
         hab-icon {
           width: 20px;
+          height: 20px;
           position: absolute;
           right: 0;
           top: 50%;

--- a/components/builder-web/app/package/package-settings/package-settings.component.ts
+++ b/components/builder-web/app/package/package-settings/package-settings.component.ts
@@ -6,8 +6,7 @@ import { GitHubApiClient } from "../../GitHubApiClient";
 import { GitHubRepo } from "../../github/repo/shared/github-repo.model";
 import { requireSignIn } from "../../util";
 import { AppStore } from "../../AppStore";
-import { addNotification, addProject, updateProject, setProjectIntegrationSettings, deleteProject,
-    fetchGitHubFiles, fetchProject } from "../../actions/index";
+import { addNotification, addProject, updateProject, setProjectIntegrationSettings, deleteProject, fetchProject } from "../../actions/index";
 import config from "../../config";
 
 @Component({

--- a/components/builder-web/app/package/package/package.component.html
+++ b/components/builder-web/app/package/package/package.component.html
@@ -13,12 +13,6 @@
       Latest
     </a>
     <a md-tab-link
-       routerLink="readme"
-       routerLinkActive #rla="routerLinkActive"
-       [active]="rla.isActive">
-      Readme
-    </a>
-    <a md-tab-link
       routerLink="./"
       [routerLinkActiveOptions]="{exact: true}"
       routerLinkActive #rla="routerLinkActive"

--- a/components/builder-web/app/reducers/gitHub.ts
+++ b/components/builder-web/app/reducers/gitHub.ts
@@ -20,56 +20,27 @@ import config from "../config";
 export default function gitHub(state = initialState["gitHub"], action) {
     switch (action.type) {
 
-        case actionTypes.CLEAR_GITHUB_FILES:
-            return state.set("files", List());
-
         case actionTypes.CLEAR_GITHUB_INSTALLATIONS:
-            return state.set("installations", List());
-
-        case actionTypes.CLEAR_GITHUB_REPOS:
-            return state.set("installationRepositories", List());
+            return state.set("installations", List()).
+                setIn(["ui", "installations", "loading"], true);
 
         case actionTypes.LOAD_GITHUB_SESSION_STATE:
             return state.set("authState", action.payload.gitHubAuthState).
                 set("authToken", action.payload.gitHubAuthToken);
 
         case actionTypes.POPULATE_GITHUB_INSTALLATIONS:
-
-            const filtered = action.payload.installations.filter((i) => {
-                return i.integration_id.toString() === config["github_app_id"];
+            const filtered = action.payload.filter((i) => {
+                return i.app_id.toString() === config["github_app_id"];
             });
 
-            return state.set("installations", fromJS(filtered));
-
-        case actionTypes.POPULATE_GITHUB_INSTALLATION_REPOSITORIES:
-            return state.set("installationRepositories", fromJS(action.payload.repositories));
-
-        case actionTypes.POPULATE_GITHUB_REPOS:
-            return state.set("repos",
-                state.get("repos").concat(fromJS(action.payload)).
-                    sortBy(repo => repo.get("name")));
-
-        case actionTypes.POPULATE_GITHUB_FILES:
-            return state.set("files", fromJS(action.payload.items.sort((a, b) => {
-                if (a.path < b.path) { return -1; }
-                if (a.path > b.path) { return 1; }
-                return 0;
-            })));
+            return state.set("installations", fromJS(filtered)).
+                setIn(["ui", "installations", "loading"], false);
 
         case actionTypes.SET_GITHUB_AUTH_STATE:
             return state.set("authState", action.payload);
 
         case actionTypes.SET_GITHUB_AUTH_TOKEN:
             return state.set("authToken", action.payload);
-
-        case actionTypes.SET_GITHUB_ORGS_LOADING_FLAG:
-            return state.setIn(["ui", "orgs", "loading"], action.payload);
-
-        case actionTypes.SET_GITHUB_REPOS_LOADING_FLAG:
-            return state.setIn(["ui", "repos", "loading"], action.payload);
-
-        case actionTypes.SET_SELECTED_GITHUB_ORG:
-            return state.set("selectedOrg", action.payload);
 
         default:
             return state;

--- a/components/builder-web/app/shared/checking-input/checking-input.component.html
+++ b/components/builder-web/app/shared/checking-input/checking-input.component.html
@@ -17,7 +17,7 @@
     <span *ngIf="!control.valid"
       class="hab-checking-input--input-msg invalid">
       <span *ngIf="control.errors.invalidFormat">
-        {{displayName}} must match correct format
+        {{displayName}} {{unmatchedMessage}}
       </span>
       <span *ngIf="control.errors.required">
         {{displayName}} is required

--- a/components/builder-web/app/shared/checking-input/checking-input.component.ts
+++ b/components/builder-web/app/shared/checking-input/checking-input.component.ts
@@ -31,6 +31,7 @@ export class CheckingInputComponent implements OnInit {
     @Input() maxLength;
     @Input() name: string;
     @Input() notAvailableMessage: string;
+    @Input() unmatchedMessage: string;
     @Input() pattern;
     @Input() placeholder;
     @Input() value: string;
@@ -59,9 +60,9 @@ export class CheckingInputComponent implements OnInit {
             this.pattern = this.pattern || this.defaultPattern;
         }
 
-        this.notAvailableMessage = this.notAvailableMessage ||
-            "is already in use";
+        this.notAvailableMessage = this.notAvailableMessage || "is already in use";
         this.availableMessage = this.availableMessage || "is available";
+        this.unmatchedMessage = this.unmatchedMessage || "must match the correct format";
 
         this.control = new FormControl(
             this.value,

--- a/components/builder-web/app/shared/docker-export-settings/_docker-export-settings.component.scss
+++ b/components/builder-web/app/shared/docker-export-settings/_docker-export-settings.component.scss
@@ -7,9 +7,16 @@
 
   .unconfigured {
     font-style: italic;
+    margin-left: 18px;
+    font-size: rem(13);
+  }
+
+  .integrations {
+    @include row;
   }
 
   .fields {
+    @include row;
     margin-top: 18px;
 
     label {
@@ -23,8 +30,18 @@
     }
   }
 
-  md-slide-toggle {
+  .toggle {
+    @include row;
     margin-bottom: 12px;
+
+    md-slide-toggle {
+      @include span-columns(1.5);
+    }
+
+    span {
+      @include span-columns(6);
+      @include omega;
+    }
   }
 
   md-radio-group {
@@ -57,6 +74,8 @@
   }
 
   input[type="text"] {
+    font-family: $monospace-font-family;
+    font-size: rem(12);
 
     &::placeholder {
       color: $medium-gray;

--- a/components/builder-web/app/shared/docker-export-settings/docker-export-settings.component.html
+++ b/components/builder-web/app/shared/docker-export-settings/docker-export-settings.component.html
@@ -7,12 +7,14 @@
     Export the resulting .hart file as a Docker container and publish it to your
     Docker Hub account. Integration settings are managed under the origin Settings tab.
   </p>
-  <md-slide-toggle [(ngModel)]="enabled" [disabled]="!configured">
-    {{ enabled ? "On" : "Off" }}
-  </md-slide-toggle>
-  <span class="unconfigured" *ngIf="!configured">
-    You can configure this integration in the origin Integrations tab.
-  </span>
+  <div class="toggle">
+      <md-slide-toggle [(ngModel)]="enabled" [disabled]="!configured">
+        {{ enabled ? "On" : "Off" }}
+      </md-slide-toggle>
+      <span class="unconfigured" *ngIf="!configured">
+        You can configure this integration in the origin Integrations tab.
+      </span>
+  </div>
   <div *ngIf="enabled && configured">
     <div class="integrations">
       <md-radio-group [(ngModel)]="name">
@@ -24,9 +26,9 @@
     </div>
     <div class="fields">
       <label>Docker Organization and Repository</label>
-      <input type="text" [(ngModel)]="repoName" placeholder="your-docker-org/your-docker-repo">
+      <input type="text" [(ngModel)]="repoName" placeholder="{{ repoPlaceholder }}">
       <label>Custom Tag (Optional)</label>
-      <input type="text" [(ngModel)]="customTag">
+      <input type="text" [(ngModel)]="customTag" [placeholder]="'yourtag or \{\{ channel \}\}'">
       <label>Additional Tags</label>
       <md-checkbox [(ngModel)]="latestTag">:latest</md-checkbox>
       <md-checkbox [(ngModel)]="versionTag">:pkg_version</md-checkbox>

--- a/components/builder-web/app/shared/docker-export-settings/docker-export-settings.component.ts
+++ b/components/builder-web/app/shared/docker-export-settings/docker-export-settings.component.ts
@@ -1,5 +1,6 @@
 import { Component, Input, Output, EventEmitter, OnChanges } from "@angular/core";
 import { FormControl } from "@angular/forms";
+import { AppStore } from "../../AppStore";
 
 @Component({
   selector: "hab-docker-export-settings",
@@ -7,14 +8,17 @@ import { FormControl } from "@angular/forms";
 })
 export class DockerExportSettingsComponent implements OnChanges  {
   @Input() integrations: any;
+  @Input() current: any;
+  @Input() enabled: boolean = false;
 
-  private enabled: boolean = false;
   private name: string;
   private repoName: string = "";
   private customTag: string;
   private latestTag: boolean = true;
   private versionTag: boolean = true;
   private releaseTag: boolean = true;
+
+  constructor(private store: AppStore) {}
 
   get configured() {
     return this.integrations.size > 0;
@@ -35,6 +39,14 @@ export class DockerExportSettingsComponent implements OnChanges  {
     };
   }
 
+  get repoPlaceholder() {
+    return this.store.getState().projects.current.name || `${this.username}/example-repo`;
+  }
+
+  get username() {
+    return this.store.getState().users.current.username;
+  }
+
   get valid() {
 
     if (this.repoName.trim() !== "") {
@@ -45,8 +57,21 @@ export class DockerExportSettingsComponent implements OnChanges  {
   }
 
   ngOnChanges(changes) {
+
     if (changes.integrations) {
       this.name = changes.integrations.currentValue.get(0);
+    }
+
+    if (changes.current) {
+      const value = changes.current.currentValue;
+
+      if (value) {
+        this.repoName = value.docker_hub_repo_name;
+        this.customTag = value.custom_tag;
+        this.latestTag = value.latest_tag;
+        this.versionTag = value.version_tag;
+        this.releaseTag = value.version_release_tag;
+      }
     }
   }
 }

--- a/components/builder-web/app/shared/github-repo-picker/github-repo-picker.component.ts
+++ b/components/builder-web/app/shared/github-repo-picker/github-repo-picker.component.ts
@@ -16,7 +16,7 @@ import { Component, Input, OnInit, Output, EventEmitter } from "@angular/core";
 import { List, Map, OrderedSet } from "immutable";
 import { AppStore } from "../../AppStore";
 import { GitHubRepo } from "../../github/repo/shared/github-repo.model";
-import { setSelectedGitHubOrg, resetRedirectRoute } from "../../actions/index";
+import { resetRedirectRoute } from "../../actions/index";
 
 @Component({
   selector: "hab-github-repo-picker",

--- a/components/builder-web/app/shared/project-settings/_project-settings.component.scss
+++ b/components/builder-web/app/shared/project-settings/_project-settings.component.scss
@@ -5,252 +5,204 @@ hab-project-settings {
     font-size: rem(12);
   }
 
-  .plan {
-    @include row;
+  p {
+    font-size: rem(14);
+    margin: 8px 0 12px;
 
-    p {
-      font-size: rem(14);
-      margin-bottom: 0;
+    &.note {
+      position: relative;
+      margin-top: 0;
+      padding: 14px 14px 14px 48px;
+      background-color: $very-light-gray;
+      border-radius: $global-radius;
+      color: $dark-blue;
+      margin-bottom: 18px;
 
-      &.note {
-        position: relative;
-        margin-top: 0;
-        padding: 14px 14px 14px 48px;
-        background-color: $very-light-gray;
-        border-radius: $global-radius;
-        color: $dark-blue;
-        margin-bottom: 18px;
-
-        hab-icon {
-          position: absolute;
-          left: 14px;
-          top: 16px;
-          width: 24px;
-          height: 24px;
-          color: $dark-gray;
-        }
-
-        a {
-          color: $dark-blue;
-          text-decoration: underline;
-        }
-      }
-    }
-
-    .connect {
-      margin-bottom: 14px;
-    }
-
-    .installations {
-      @include span-columns(4.5 of 9);
-
-      img {
+      hab-icon {
+        position: absolute;
+        left: 14px;
+        top: 16px;
         width: 24px;
         height: 24px;
-        border-radius: 2px;
-        margin-right: 8px;
-        vertical-align: middle;
+        color: $dark-gray;
+      }
+
+      a {
+        color: $dark-blue;
+        text-decoration: underline;
       }
     }
 
-    .repos {
-      @include span-columns(4.5 of 9);
-
-      input {
-        margin-bottom: 8px;
-      }
+    code {
+      font-family: $monospace-font-family;
+      font-size: rem(12);
     }
+  }
 
-    .browser {
+  .connect {
+    margin-bottom: 14px;
+
+    button {
+      margin-bottom: 12px;
+    }
+  }
+
+  .connected-plans {
+
+    li {
       @include row;
-    }
 
-    .installations, .repos {
-
-      li {
-        line-height:  40px;
-        padding: 0 4px;
+      &.heading {
         border-bottom: 1px solid $very-light-gray;
+      }
 
-        a {
-          display: block;
-          position: relative;
-          font-size: rem(14);
-          font-weight: 600;
-          color: $hab-gray-dark;
+      &.item {
+        font-size: rem(12);
+        padding: 12px 0;
+      }
+
+      .plan-path {
+        @include span-columns(6);
+
+        hab-icon {
+          margin-right: 12px;
+        }
+      }
+
+      .plan-exports, .plan-status, .plan-actions {
+        @include span-columns(2);
+      }
+
+      .plan-actions {
+
+        hab-icon {
+          width: 16px;
+          color: $hab-blue;
+          margin-right: 22px;
           cursor: pointer;
+          transition: color .2s linear;
 
-          hab-icon {
-            display: none;
-            width: 20px;
-            height: 20px;
-            @include chevron-right;
+          &:hover {
+            color: darken($hab-blue, 10%);
           }
 
-          &:hover, &.active {
-            background-color: rgba($medium-gray, 0.05);
-
-            hab-icon {
-              display: block;
-            }
+          &:active {
+            color: $hab-blue;
           }
         }
       }
-    }
 
-    .plans {
+      .plan-status {
+
+        hab-icon {
+          width: 18px;
+
+          &.success {
+            color: $hab-green-light;
+          }
+        }
+
+        span {
+          color: $medium-gray;
+        }
+      }
+    }
+  }
+
+  .connecting {
+    @include span-columns(9);
+    @include omega;
+
+    ol {
+      background-color: $hab-blue;
+      border-radius: $global-radius;
+      color: $hab-white;
+      font-size: rem(14);
+      padding: 4px 14px;
+      margin-bottom: 28px;
 
       li {
-        @include row;
+        display: inline-block;
+        margin-right: 8px;
 
-        &.heading {
-          border-bottom: 1px solid $very-light-gray;
+        &.active {
+          font-weight: 600;
         }
 
-        &.item {
-          font-size: rem(12);
-          padding: 12px 0;
+        &:first-child {
+          cursor: pointer;
         }
 
-        .plan-path {
-          @include span-columns(6);
-
-          hab-icon {
+        &:not(:first-child) {
+          &:before {
+            content: '→';
             margin-right: 12px;
           }
         }
-
-        .plan-exports, .plan-status, .plan-actions {
-          @include span-columns(2);
-        }
-
-        .plan-actions {
-
-          hab-icon {
-            width: 16px;
-            color: $hab-blue;
-            margin-right: 22px;
-            cursor: pointer;
-            transition: color .2s linear;
-
-            &:hover {
-              color: darken($hab-blue, 10%);
-            }
-
-            &:active {
-              color: $hab-blue;
-            }
-          }
-        }
-
-        .plan-status {
-
-          hab-icon {
-            width: 18px;
-
-            &.success {
-              color: $hab-green-light;
-            }
-          }
-
-          span {
-            color: $medium-gray;
-          }
-        }
       }
     }
 
-    .connecting {
-      @include span-columns(9);
-      @include omega;
+    hab-checking-input {
 
-      ol {
-        background-color: $hab-blue;
-        border-radius: $global-radius;
-        color: $hab-white;
-        font-size: rem(14);
-        padding: 4px 14px;
-        margin-bottom: 28px;
-
-        li {
-          display: inline-block;
-          margin-right: 8px;
-
-          &.active {
-            font-weight: 600;
-          }
-
-          &:first-child {
-            cursor: pointer;
-          }
-
-          &:not(:first-child) {
-            &:before {
-              content: '→';
-              margin-right: 12px;
-            }
-          }
-        }
-      }
-
-      .select {
-
-        p {
-          font-size: rem(14);
-          margin-bottom: 12px;
-
-          code {
-            font-family: $monospace-font-family;
-            font-size: rem(12);
-          }
-        }
-
-        form {
-          margin-bottom: 20px;
-        }
-
-        input {
-          font-family: $monospace-font-family;
-          font-size: rem(12);
-          margin-bottom: 16px;
-        }
-
-        small {
-          display: block;
-          margin-bottom: 10px;
-          font-size: rem(12);
-        }
-
-        hab-icon {
-          top: 7px;
-          right: 6px;
-          width: 16px;
-          height: 16px;
-        }
-      }
-
-      .docker-export-settings {
-        margin-top: 28px;
-      }
-
-      .repo-link {
+      input {
+        font-family: $monospace-font-family;
         font-size: rem(12);
-        float: right;
-        display: block;
+        margin-bottom: 16px;
+
+        &::placeholder {
+          color: $medium-gray;
+        }
       }
 
-      .controls {
-        margin-top: 12px;
+      small {
+        text-align: left;
+        display: block;
+        margin-bottom: 12px;
+        font-size: rem(12);
 
-        a {
-          cursor: pointer;
+        span {
+          margin-left: 0;
         }
+      }
 
-        button, a {
-          display: inline-block;
-          font-size: rem(14);
-          margin-right: 16px;
-        }
+      hab-icon {
+        top: 7px;
+        right: 6px;
+        width: 16px;
+        height: 16px;
+      }
+    }
+
+    .try-again {
+      cursor: pointer;
+
+      hab-icon {
+        width: 0.9em;
+        margin-right: 1px;
+      }
+    }
+
+    .docker-export-settings {
+      margin-top: 28px;
+    }
+
+    .repo-link {
+      font-size: rem(12);
+      float: right;
+      display: block;
+    }
+
+    .controls {
+      margin: 24px 0;
+
+      a {
+        cursor: pointer;
+      }
+
+      button, a {
+        display: inline-block;
+        font-size: rem(14);
+        margin-right: 16px;
       }
     }
   }

--- a/components/builder-web/app/shared/project-settings/project-settings.component.html
+++ b/components/builder-web/app/shared/project-settings/project-settings.component.html
@@ -1,5 +1,5 @@
-<section class="plan" *ngIf="projectsEnabled">
-    <div class="connect" *ngIf="!project && !connecting && !loading">
+<section *ngIf="projectsEnabled">
+    <div class="connect" *ngIf="!project && !connecting">
         <button md-raised-button color="primary" class="button" (click)="connect()">
             Connect a plan file
         </button>
@@ -15,8 +15,8 @@
             </p>
         </div>
     </div>
-    <div *ngIf="project && !connecting">
-        <ul class="plans">
+    <div class="connected-plans" *ngIf="project && !connecting">
+        <ul>
             <li class="heading">
                 <h3 class="plan-path">Plan</h3>
                 <h3 class="plan-exports">&nbsp;</h3>
@@ -43,71 +43,69 @@
         </ul>
     </div>
     <div class="connecting" *ngIf="connecting">
-        <p class="note">
-            <hab-icon symbol="github"></hab-icon>
-            GitHub organizations and repositories with the <a href="{{ config['github_app_url'] }}" target="_blank">Habitat GitHub app</a>
-            installed are listed below. You can install the app
-            <a href="https://help.github.com/articles/installing-an-app-in-your-personal-account/" target="_blank">on your personal account</a>
-            or <a href="https://help.github.com/articles/installing-an-app-in-your-organization/" target="_blank">on an organization</a> of which
-            <em>you are the owner</em>.
-        </p>
-        <ol>
-            <li [class.active]="!selectedRepo" (click)="deselect()">Select a GitHub repo</li>
-            <li [class.active]="selectedRepo">Set path to Habitat plan file</li>
-        </ol>
-        <div class="browser" *ngIf="!selectedRepo">
-            <div class="installations">
+        <form [formGroup]="form" #formValues="ngForm">
+            <p class="note">
+                <hab-icon symbol="github"></hab-icon>
+                To connect a plan, first install the <a href="{{ config['github_app_url'] }}" target="_blank">Habitat Builder GitHub app</a>
+                on your <a href="https://help.github.com/articles/installing-an-app-in-your-personal-account/" target="_blank">personal account</a>
+                or on any <a href="https://help.github.com/articles/installing-an-app-in-your-organization/" target="_blank">organization</a> of which
+                <em>you are the owner</em>.
+            </p>
+            <ol>
+                <li [class.active]="!selectedInstallation" (click)="clearConnection()">Select a GitHub repo</li>
+                <li [class.active]="selectedInstallation">Set path to Habitat plan file</li>
+            </ol>
+            <div class="installation" *ngIf="!selectedInstallation">
                 <h3>
                     <hab-icon symbol="github"></hab-icon>
-                    GitHub Orgs for {{ username }}
+                    Select a GitHub Repository
                 </h3>
-                <ul>
-                    <li *ngIf="installations.size === 0">
-                        None.
-                    </li>
-                    <li *ngFor="let installation of installations">
-                        <a (click)="selectInstallation(installation)" [class.active]="installation === selectedInstallation">
-                            {{ installation.getIn(["account", "login"]) }}
-                            <hab-icon symbol="chevron-right"></hab-icon>
-                        </a>
-                    </li>
-                </ul>
-            </div>
-            <div class="repos">
-                <div *ngIf="selectedInstallation">
-                    <h3>GitHub Repos for Selected Org</h3>
-                    <input [(ngModel)]="filter.name" placeholder="Filter by name">
-                    <ul>
-                        <li *ngIf="repos.size === 0">
-                            None.
-                        </li>
-                        <li *ngFor="let repo of repos | habGitHubRepoFilter:filter:'name'">
-                            <a (click)="selectRepo(repo)">
-                                {{ repo.get("name") }}
-                                <hab-icon symbol="chevron-right"></hab-icon>
-                            </a>
-                        </li>
-                    </ul>
+                <div *ngIf="loading">
+                    <hab-icon symbol="loading" class="spinning"></hab-icon>
+                </div>
+                <div *ngIf="!loading">
+                    <p *ngIf="installations.size === 0">
+                        It looks like you haven't yet installed the Habitat Builder app.
+                        <a href="{{ config['github_app_url'] }}" target="_blank">Install it on GitHub</a>, then come back here and
+                        <a class="try-again" (click)="connect()"><hab-icon symbol="loading"></hab-icon>try again</a>.
+                    </p>
+                    <p *ngIf="installations.size > 0">
+                        Enter the name of the GitHub organization and repository containing the Habitat plan you'd like to connect.
+                    </p>
+                    <div *ngIf="installations.size > 0">
+                        <hab-checking-input
+                            id="repo_path"
+                            name="repo_path"
+                            availableMessage="found!"
+                            notAvailableMessage="not found. Make sure the repo is named correctly that Habitat Builder has permissions to read it."
+                            displayName="Repository"
+                            [form]="form"
+                            [pattern]="false"
+                            [maxLength]="false"
+                            [isAvailable]="doesRepoExist"
+                            [value]="selectedRepo"
+                            placeholder="{{username}}/example-app">
+                        </hab-checking-input>
+                    </div>
                 </div>
             </div>
-        </div>
-        <div class="select" *ngIf="selectedRepo">
-            <a class="repo-link" href="{{ repoUrl }}" target="_blank">
-                <hab-icon symbol="open-in-new"></hab-icon>
-                Go to your repo
-            </a>
-            <h3>Path to Plan File</h3>
-            <p>
-                Enter the path to your plan file from the root of your repo. By default,
-                we check for <code>habitat/plan.sh</code>.
-            </p>
-            <div class="files">
-                <form [formGroup]="form" #formValues="ngForm">
+            <div *ngIf="selectedInstallation">
+                <a class="repo-link" href="{{ repoUrl }}" target="_blank">
+                    <hab-icon symbol="open-in-new"></hab-icon>
+                    Go to your repo
+                </a>
+                <h3>Path to Plan File</h3>
+                <p>
+                    Enter the path to your plan file from the root of your repo. By default,
+                    we check for <code>habitat/plan.sh</code>.
+                </p>
+                <div class="files">
                     <hab-checking-input
                         id="plan_path"
                         name="plan_path"
                         availableMessage="found!"
                         notAvailableMessage="does not exist in the repository."
+                        unmatchedMessage="must be named either plan.sh or plan.ps1."
                         displayName="Plan file"
                         [form]="form"
                         [pattern]="false"
@@ -115,22 +113,27 @@
                         [isAvailable]="doesFileExist"
                         [value]="selectedPath">
                     </hab-checking-input>
-                </form>
+                </div>
+                <hab-visibility-selector
+                    [setting]="visibility"
+                    (changed)="settingChanged($event)">
+                </hab-visibility-selector>
+                <hab-docker-export-settings #docker
+                    *ngIf="selectedInstallation"
+                    [integrations]="integrations"
+                    [current]="dockerSettings"
+                    [enabled]="dockerEnabled">
+                </hab-docker-export-settings>
             </div>
-            <hab-visibility-selector
-                [setting]="visibility"
-                (changed)="settingChanged($event)">
-            </hab-visibility-selector>
-            <hab-docker-export-settings #docker
-                *ngIf="selectedRepo"
-                [integrations]="integrations">
-            </hab-docker-export-settings>
-        </div>
-        <div class="controls">
-            <button md-raised-button color="primary" class="button" (click)="saveConnection()" [disabled]="!valid">
-                {{ connectButtonLabel }} Connection
-            </button>
-            <a (click)="clearConnection()">Cancel</a>
-        </div>
+            <div class="controls">
+                <button *ngIf="!selectedInstallation" md-raised-button color="primary" class="button" (click)="selectRepo()" [disabled]="!validRepo">
+                    Next &raquo;
+                </button>
+                <button *ngIf="selectedInstallation" md-raised-button color="primary" class="button" (click)="saveConnection()" [disabled]="!validProject">
+                    {{ connectButtonLabel }} Connection
+                </button>
+                <a (click)="clearConnection()">Cancel</a>
+            </div>
+        </form>
     </div>
 </section>

--- a/components/builder-web/npm-shrinkwrap.json
+++ b/components/builder-web/npm-shrinkwrap.json
@@ -16,12 +16,12 @@
     },
     "@angular/cdk": {
       "version": "2.0.0-beta.10",
-      "from": "@angular/cdk@>=2.0.0-beta.10 <3.0.0",
+      "from": "https://registry.npmjs.org/@angular/cdk/-/cdk-2.0.0-beta.10.tgz",
       "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-2.0.0-beta.10.tgz",
       "dependencies": {
         "tslib": {
           "version": "1.7.1",
-          "from": "tslib@>=1.7.1 <2.0.0",
+          "from": "https://registry.npmjs.org/tslib/-/tslib-1.7.1.tgz",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.7.1.tgz"
         }
       }
@@ -88,12 +88,12 @@
     },
     "@angular/material": {
       "version": "2.0.0-beta.10",
-      "from": "@angular/material@>=2.0.0-beta.10 <3.0.0",
+      "from": "https://registry.npmjs.org/@angular/material/-/material-2.0.0-beta.10.tgz",
       "resolved": "https://registry.npmjs.org/@angular/material/-/material-2.0.0-beta.10.tgz",
       "dependencies": {
         "tslib": {
           "version": "1.7.1",
-          "from": "tslib@>=1.7.1 <2.0.0",
+          "from": "https://registry.npmjs.org/tslib/-/tslib-1.7.1.tgz",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.7.1.tgz"
         }
       }
@@ -138,6 +138,11 @@
       "version": "1.3.0",
       "from": "https://registry.npmjs.org/ansi_up/-/ansi_up-1.3.0.tgz",
       "resolved": "https://registry.npmjs.org/ansi_up/-/ansi_up-1.3.0.tgz"
+    },
+    "async": {
+      "version": "2.5.0",
+      "from": "async@>=2.5.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz"
     },
     "blueimp-md5": {
       "version": "2.10.0",

--- a/components/builder-web/package.json
+++ b/components/builder-web/package.json
@@ -43,6 +43,7 @@
     "@angular/platform-browser-dynamic": "^4.3.4",
     "@angular/router": "^4.3.4",
     "ansi_up": "^1.3.0",
+    "async": "^2.5.0",
     "blueimp-md5": "^2.7.0",
     "bourbon": "^4.2.6",
     "bourbon-neat": "^1.7.2",


### PR DESCRIPTION
This change modifies the project-selection component to use a text field for selecting a repository rather than by clicking list items. It also shows configured plan settings when they exist and handles repositories spanning multiple pages of the GitHub API. Also removes some dead code.

Signed-off-by: Christian Nunciato <cnunciato@chef.io>

![](https://media.tenor.com/images/5b85f33dde3c7021405287eb2f53d062/tenor.gif)