### PR TITLE
Handle missing error messages

### DIFF
--- a/components/builder-web/app/reducers/origins.ts
+++ b/components/builder-web/app/reducers/origins.ts
@@ -68,10 +68,10 @@ export default function origins(state = initialState["origins"], action) {
                 List(action.payload));
 
         case actionTypes.POPULATE_ORIGIN_DOCKER_INTEGRATIONS:
-            if (action.error) {
-                return state.setIn(["currentIntegrations", "docker"], List());
-            } else {
+            if (action.payload) {
                 return state.setIn(["currentIntegrations", "docker"], List(action.payload.names));
+            } else {
+                return state.setIn(["currentIntegrations", "docker"], List());
             }
 
         case actionTypes.POPULATE_ORIGIN_PUBLIC_KEYS:


### PR DESCRIPTION
Slight logic error here — what we should be doing is acting on the presence of a payload, rather than looking for an error message; in development, 404s are resolved with a message of `"Not Found"`, but in prod, 404 messages are `""`, which is falsy in JavaScript.

Signed-off-by: Christian Nunciato <cnunciato@chef.io>

![](https://media.tenor.com/images/2946d53fae77726c863e486f0de1f341/tenor.gif)