### PR TITLE
Remove nested feature-flags toml

### DIFF
--- a/components/builder-api/habitat/config/habitat.conf.js
+++ b/components/builder-api/habitat/config/habitat.conf.js
@@ -21,5 +21,4 @@ habitatConfig({
     slack_url: "{{cfg.web.slack_url}}",
     youtube_url: "{{cfg.web.youtube_url}}",
     demo_app_url: "{{cfg.web.demo_app_url}}",
-    feature_flags: {{toJson cfg.web.feature_flags}}
 });

--- a/components/builder-api/habitat/default.toml
+++ b/components/builder-api/habitat/default.toml
@@ -31,9 +31,6 @@ youtube_url           = "https://www.youtube.com/playlist?list=PL11cZfNdwNyOxlvI
 demo_app_url          = "https://www.habitat.sh/demo"
 github_app_url        = "https://github.com/apps/habitat-builder"
 
-[web.feature_flags]
-project = false
-
 [depot]
 builds_enabled = true
 non_core_builds_enabled = true


### PR DESCRIPTION
This change doesn't remove any actual feature flagging in the UI -- it just removes the Habitat-configured support for it.

Signed-off-by: Christian Nunciato <cnunciato@chef.io>