### PR TITLE
Remove unused `web` section of builder-api config

### DIFF
--- a/components/builder-api/habitat/config/config.toml
+++ b/components/builder-api/habitat/config/config.toml
@@ -6,9 +6,6 @@ root = "{{pkg.svc_static_path}}"
 [http]
 {{toToml cfg.http}}
 
-[web]
-{{toToml cfg.web}}
-
 [github]
 app_private_key = "{{pkg.svc_files_path}}/builder-github-app.pem"
 {{toToml cfg.github}}


### PR DESCRIPTION
The web configuration is specific to `habitat.conf.js` and does not
need to be present in the configuration of the api-server