### PR TITLE
Expose builder-web feature flag configuration

### DIFF
--- a/components/builder-api/habitat/config/habitat.conf.js
+++ b/components/builder-api/habitat/config/habitat.conf.js
@@ -21,4 +21,5 @@ habitatConfig({
     slack_url: "{{cfg.web.slack_url}}",
     youtube_url: "{{cfg.web.youtube_url}}",
     demo_app_url: "{{cfg.web.demo_app_url}}",
+    feature_flags: {{toJson cfg.web_feature_flags}},
 });

--- a/components/builder-api/habitat/default.toml
+++ b/components/builder-api/habitat/default.toml
@@ -31,6 +31,9 @@ youtube_url           = "https://www.youtube.com/playlist?list=PL11cZfNdwNyOxlvI
 demo_app_url          = "https://www.habitat.sh/demo"
 github_app_url        = "https://github.com/apps/habitat-builder"
 
+[web_feature_flags]
+project = true
+
 [depot]
 builds_enabled = true
 non_core_builds_enabled = true


### PR DESCRIPTION
Add a new toml map `web_feature_flags` which can be used to set
feature flags for the UI. In the future, we should hook the feature
flags up to the contents of the session's feature flags. This is
good enough for now.

Signed-off-by: Jamie Winsor <jamie@vialstudios.com>