### PR TITLE
Update demo instructions to match current UI

### DIFF
--- a/www/source/demo/steps/10.html.slim
+++ b/www/source/demo/steps/10.html.slim
@@ -3,7 +3,7 @@ title: Habitat Demo - Step 10
 layout: layout
 classes: demo_step
 ---
-#demo-step
+#demo-step.demo--page
   .row
     .columns.large-12.demo-step--content
       .demo-step--indicators
@@ -39,7 +39,9 @@ classes: demo_step
             strong  Commit changes
             '  button to update the master branch.
           p
-            ' Habitat Builder will detect the change and start a new build automatically. You can view the resulting output in the Habitat Builder web app.
+            ' In the Habitat Builder app, click on the
+            strong Build latest version
+            '  button.
             ' Once the build job completes, re-run the docker commands to verify the updated container:
           p.code $ docker pull your-docker-org/your-docker-repo
           p.code $ docker run -it -p 8000:8000 your-docker-org/your-docker-repo

--- a/www/source/demo/steps/2.html.slim
+++ b/www/source/demo/steps/2.html.slim
@@ -3,7 +3,7 @@ title: Habitat Demo - Step 2
 layout: layout
 classes: demo_step
 ---
-#demo-step
+#demo-step.demo--page
   .row
     .columns.large-12.demo-step--content
       .demo-step--indicators

--- a/www/source/demo/steps/3.html.slim
+++ b/www/source/demo/steps/3.html.slim
@@ -3,7 +3,7 @@ title: Habitat Demo - Step 3
 layout: layout
 classes: demo_step
 ---
-#demo-step
+#demo-step.demo--page
   .row
     .columns.large-12.demo-step--content
       .demo-step--indicators

--- a/www/source/demo/steps/4.html.slim
+++ b/www/source/demo/steps/4.html.slim
@@ -3,7 +3,7 @@ title: Habitat Demo - Step 4
 layout: layout
 classes: demo_step
 ---
-#demo-step
+#demo-step.demo--page
   .row
     .columns.large-12.demo-step--content
       .demo-step--indicators

--- a/www/source/demo/steps/5.html.slim
+++ b/www/source/demo/steps/5.html.slim
@@ -3,7 +3,7 @@ title: Habitat Demo - Step 5
 layout: layout
 classes: demo_step
 ---
-#demo-step
+#demo-step.demo--page
   .row
     .columns.large-12.demo-step--content
       .demo-step--indicators

--- a/www/source/demo/steps/6.html.slim
+++ b/www/source/demo/steps/6.html.slim
@@ -3,7 +3,7 @@ title: Habitat Demo - Step 6
 layout: layout
 classes: demo_step
 ---
-#demo-step
+#demo-step.demo--page
   .row
     .columns.large-12.demo-step--content
       .demo-step--indicators

--- a/www/source/demo/steps/7.html.slim
+++ b/www/source/demo/steps/7.html.slim
@@ -3,7 +3,7 @@ title: Habitat Demo - Step 7
 layout: layout
 classes: demo_step
 ---
-#demo-step
+#demo-step.demo--page
   .row
     .columns.large-12.demo-step--content
       .demo-step--indicators
@@ -28,7 +28,7 @@ classes: demo_step
             '  tab and click the
             strong Connect a plan
             '  button.
-          p Select the GitHub org and repo where you forked the sample app. Next, you will see the plan file for the sample app listed (see image).
+          p Enter the GitHub org and repo where you forked the sample app. Next, you will see the plan file for the sample app listed (see image).
           p
             ' Switch the
             strong Publish to Docker Hub

--- a/www/source/demo/steps/8.html.slim
+++ b/www/source/demo/steps/8.html.slim
@@ -3,7 +3,7 @@ title: Habitat Demo - Step 8
 layout: layout
 classes: demo_step
 ---
-#demo-step
+#demo-step.demo--page
   .row
     .columns.large-12.demo-step--content
       .demo-step--indicators
@@ -27,19 +27,18 @@ classes: demo_step
             strong Build Jobs
             '  tab, click the
             strong Build latest version
-            '  button. You'll see a mesage when a new build job kicks off (see image below).
+            '  button. You'll see a message when a new build job kicks off (see image below).
           p
             ' Once the message appears,
             ' click the
             strong View build output
             '  link to see streaming logs as your job completes.
-          img src="/images/demo/screen-start-build.png"
-        .columns.large-6
           p
-            ' When the job is complete, click the
-            strong Published to
-            '  link to see the new container in your Docker Hub account!
-          img src="/images/demo/screen-build-output.png"
+            ' When the build job is complete, head over to
+            a.link-external href="https://hub.docker.com/" target="_blank" Docker Hub
+            '  and find your new container images under Tags.
+        .columns.large-6
+          img src="/images/demo/screen-start-build.png"
       .row.mt-1.step-bottom-nav
         .columns.large-6
           a.previous-step-link href="/demo/steps/7" Previous Step

--- a/www/source/demo/steps/9.html.slim
+++ b/www/source/demo/steps/9.html.slim
@@ -3,7 +3,7 @@ title: Habitat Demo - Step 9
 layout: layout
 classes: demo_step
 ---
-#demo-step
+#demo-step.demo--page
   .row
     .columns.large-12.demo-step--content
       .demo-step--indicators


### PR DESCRIPTION
Changes include:
- remove copy and screenshot referring to *Published to* link on build output screen
- instruct user to manually build after changing version number
- fix font size on headings for steps 2-10
- change copy for entering your org/repo vs selecting it

Signed-off-by: Ryan Keairns <rkeairns@chef.io>