### PR TITLE
quick fix for download buttons

### DIFF
--- a/www/source/partials/global/_download-and-install.slim
+++ b/www/source/partials/global/_download-and-install.slim
@@ -11,7 +11,7 @@ p From building packages to running services, everything in Habitat is done thro
       p Once you have downloaded the CLI, unzip it onto your machine. Unzipping to <code>/usr/local/bin</code> should place the <code>hab</code> command on your <code>PATH</code>.
 
     .buttons.small-12.large-4.columns
-      = link_to 'Download Habitat for Linux', 'https://api.bintray.com/content/habitat/stable/linux/x86_64/hab-%24latest-x86_64-linux.tar.gz?bt_package=hab-x86_64-linux', class: 'button outline'
+      = link_to 'Download Habitat for Linux', 'https://api.bintray.com/content/habitat/stable/linux/x86_64/hab-%24latest-x86_64-linux.tar.gz?bt_package=hab-x86_64-linux', class: 'button cta'
 
 .hab-cli-os.mac
   .row
@@ -24,8 +24,8 @@ p From building packages to running services, everything in Habitat is done thro
       p Once you have downloaded the <code>hab</code> CLI, unzip it onto your machine. Unzipping to <code>/usr/local/bin</code> should place it on your <code>PATH</code>.
 
     .buttons.small-12.large-4.columns
-      = link_to 'Download Habitat for Mac', 'https://api.bintray.com/content/habitat/stable/darwin/x86_64/hab-%24latest-x86_64-darwin.zip?bt_package=hab-x86_64-darwin', class: 'button outline'
-      = link_to 'Download Docker for Mac', 'https://store.docker.com/editions/community/docker-ce-desktop-mac', class: 'button outline', target: '_blank'
+      = link_to 'Download Habitat for Mac', 'https://api.bintray.com/content/habitat/stable/darwin/x86_64/hab-%24latest-x86_64-darwin.zip?bt_package=hab-x86_64-darwin', class: 'button cta'
+      = link_to 'Download Docker for Mac', 'https://store.docker.com/editions/community/docker-ce-desktop-mac', class: 'button cta', target: '_blank'
 
 .hab-cli-os.windows
   .row
@@ -41,5 +41,5 @@ p From building packages to running services, everything in Habitat is done thro
         code $env:PATH += ";C:\habitat"
 
     .buttons.small-12.large-4.columns
-      = link_to 'Download Habitat for Windows', 'https://api.bintray.com/content/habitat/stable/windows/x86_64/hab-%24latest-x86_64-windows.zip?bt_package=hab-x86_64-windows', class: 'button outline'
-      = link_to 'Download Docker for Windows', 'https://store.docker.com/editions/community/docker-ce-desktop-windows', class: 'button outline', target: '_blank'
+      = link_to 'Download Habitat for Windows', 'https://api.bintray.com/content/habitat/stable/windows/x86_64/hab-%24latest-x86_64-windows.zip?bt_package=hab-x86_64-windows', class: 'button cta'
+      = link_to 'Download Docker for Windows', 'https://store.docker.com/editions/community/docker-ce-desktop-windows', class: 'button cta', target: '_blank'


### PR DESCRIPTION
The download buttons currently are not very visible. This change moves them from the `button outline` class to the `button cta` class which makes the buttons and text visible.

Before:


![Before](https://i.imgur.com/Q8yfhr5.png)

After:


![After](https://i.imgur.com/ZfsVuJw.png)


Signed-off-by: echohack <echohack@users.noreply.github.com>