### PR TITLE
Handle repository fetch errors

### DIFF
--- a/components/builder-web/app/GitHubApiClient.ts
+++ b/components/builder-web/app/GitHubApiClient.ts
@@ -91,14 +91,14 @@ export class GitHubApiClient {
                                                             done(null, pageResults.repositories);
                                                         })
                                                         .catch((err) => {
-                                                            done(err);
+                                                            done(null, []);
                                                         });
                                                 });
                                             }
 
                                             async.parallel(pages, (err, additionalPages) => {
                                                 if (err) {
-                                                    done(err);
+                                                    done(null, []);
                                                 }
                                                 else {
                                                     additionalPages.forEach((p) => {
@@ -122,7 +122,7 @@ export class GitHubApiClient {
                                         }
                                     })
                                     .catch((err) => {
-                                        done(err);
+                                        done(null, []);
                                     });
                             });
                         });


### PR DESCRIPTION
Instead of exiting with an error, handle fetch failures by excluding their expected results from the assembled list.

Signed-off-by: Christian Nunciato <cnunciato@chef.io>

![](https://media.tenor.com/images/06bfece0ab5cec2ea53231af66e8f3e5/tenor.gif)