### PR TITLE
Only dispatch build on notify when it's the trigger branch

### DIFF
--- a/components/builder-api/src/github.rs
+++ b/components/builder-api/src/github.rs
@@ -246,7 +246,11 @@ fn handle_push(req: &mut Request, body: &str) -> IronResult<Response> {
 
     if let Some(cfg) = config {
         plans.retain(|plan| match cfg.get(&plan.name) {
-            Some(project) => hook.changed().iter().any(|f| project.triggered_by(f)),
+            Some(project) => {
+                hook.changed().iter().any(|f| {
+                    project.triggered_by(hook.branch(), f)
+                })
+            }
             None => false,
         })
     }

--- a/components/github-api-client/src/types.rs
+++ b/components/github-api-client/src/types.rs
@@ -148,6 +148,14 @@ pub struct GitHubWebhookPush {
 }
 
 impl GitHubWebhookPush {
+    pub fn branch(&self) -> &str {
+        self.git_ref
+            .split("refs/heads/")
+            .collect::<Vec<&str>>()
+            .last()
+            .expect("bad git ref")
+    }
+
     pub fn changed(&self) -> Vec<&String> {
         let mut paths = vec![];
         for commit in self.commits.iter() {
@@ -376,5 +384,17 @@ pub struct TeamMembership {
 impl TeamMembership {
     pub fn active(&self) -> bool {
         self.state == "active"
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn branch_from_hook() {
+        let mut hook = GitHubWebhookPush::default();
+        hook.git_ref = "refs/heads/master".to_string();
+        assert_eq!(hook.branch(), "master");
     }
 }


### PR DESCRIPTION
We're currently dispatching a build whenever we receive a push notification from a GitHub hook. We need to instead look at the ref and compare it to a branch name in the `.bldr.toml` for the given package to ensure it's a push to the branch we care to build for.