### PR TITLE
On repo fetch failure, return an object with empty array

### DIFF
--- a/components/builder-web/app/GitHubApiClient.ts
+++ b/components/builder-web/app/GitHubApiClient.ts
@@ -98,7 +98,11 @@ export class GitHubApiClient {
 
                                             async.parallel(pages, (err, additionalPages) => {
                                                 if (err) {
-                                                    done(null, []);
+                                                    done(null, {
+                                                        id: install.id,
+                                                        app_id: install.app_id,
+                                                        repos: []
+                                                    });
                                                 }
                                                 else {
                                                     additionalPages.forEach((p) => {
@@ -122,7 +126,11 @@ export class GitHubApiClient {
                                         }
                                     })
                                     .catch((err) => {
-                                        done(null, []);
+                                        done(null, {
+                                            id: install.id,
+                                            app_id: install.app_id,
+                                            repos: []
+                                        });
                                     });
                             });
                         });


### PR DESCRIPTION
We were returning only an array, so the code that expects to loop through the results of the `repos` property was failing.

Signed-off-by: Christian Nunciato <cnunciato@chef.io>

![](https://media.tenor.com/images/d08ca0d229bf5368a0047a50aa37513a/tenor.gif)