### PR TITLE
Improve error messaging in fail to route and increase socket timeouts

### DIFF
--- a/components/net/src/conn/error.rs
+++ b/components/net/src/conn/error.rs
@@ -101,6 +101,31 @@ impl error::Error for ConnErr {
     }
 }
 
+impl<'a> From<&'a ConnErr> for protocol::net::ErrCode {
+    fn from(err: &ConnErr) -> protocol::net::ErrCode {
+        match *err {
+            ConnErr::BadIdentity(_) |
+            ConnErr::BadHeader(_) |
+            ConnErr::BadRouteInfo(_) |
+            ConnErr::BadTxn(_) |
+            ConnErr::HostUnreachable |
+            ConnErr::MultipleSender |
+            ConnErr::NoBody |
+            ConnErr::NoHeader |
+            ConnErr::NoIdentity |
+            ConnErr::NoRouteInfo |
+            ConnErr::NoTxn |
+            ConnErr::Protocol(_) |
+            ConnErr::TxnNotComplete => protocol::net::ErrCode::BUG,
+
+            ConnErr::Shutdown(_) |
+            ConnErr::Socket(_) => protocol::net::ErrCode::SOCK,
+
+            ConnErr::Timeout => protocol::net::ErrCode::TIMEOUT,
+        }
+    }
+}
+
 impl From<zmq::Error> for ConnErr {
     fn from(err: zmq::Error) -> Self {
         match err {

--- a/components/net/src/conn/mod.rs
+++ b/components/net/src/conn/mod.rs
@@ -95,14 +95,13 @@ impl RouteClient {
         let txn_id = next_txn_id();
         self.msg_buf.txn_mut().unwrap().set_id(txn_id);
         if let Err(e) = route(&self.socket, &self.msg_buf) {
-            let err = NetError::new(ErrCode::SOCK, "net:route:2");
+            let err = NetError::new(ErrCode::from(&e), "net:route:2");
             error!("{}, {}", err, e);
             return Err(err);
         }
         self.msg_buf.reset();
-        // JW TODO: Handle socket errors more correctly here. Socket should be Timeout for example
         if let Err(e) = read_header(&self.socket, &mut self.msg_buf, &mut self.recv_buf) {
-            let err = NetError::new(ErrCode::BUG, "net:route:3");
+            let err = NetError::new(ErrCode::from(&e), "net:route:3");
             error!("{}, {}", err, e);
             return Err(err);
         }
@@ -113,20 +112,20 @@ impl RouteClient {
                 &mut self.recv_buf,
             )
             {
-                let err = NetError::new(ErrCode::BUG, "net:route:4");
+                let err = NetError::new(ErrCode::from(&e), "net:route:4");
                 error!("{}, {}", err, e);
                 return Err(err);
             }
         }
         if self.msg_buf.header().has_txn() {
             if let Err(e) = try_read_txn(&self.socket, &mut self.msg_buf, &mut self.recv_buf) {
-                let err = NetError::new(ErrCode::BUG, "net:route:5");
+                let err = NetError::new(ErrCode::from(&e), "net:route:5");
                 error!("{}, {}", err, e);
                 return Err(err);
             }
         }
         if let Err(e) = try_read_body(&self.socket, &mut self.msg_buf, &mut self.recv_buf) {
-            let err = NetError::new(ErrCode::BUG, "net:route:6");
+            let err = NetError::new(ErrCode::from(&e), "net:route:6");
             error!("{}, {}", err, e);
             return Err(err);
         }

--- a/components/net/src/conn/mod.rs
+++ b/components/net/src/conn/mod.rs
@@ -31,9 +31,9 @@ use error::{ErrCode, NetError, NetResult};
 use socket::DEFAULT_CONTEXT;
 
 /// Time to wait before timing out a message receive for a `RouteConn`.
-pub const RECV_TIMEOUT_MS: i32 = 5_000;
+pub const RECV_TIMEOUT_MS: i32 = 10_000;
 /// Time to wait before timing out a message send for a `RouteBroker` to a router.
-pub const SEND_TIMEOUT_MS: i32 = 5_000;
+pub const SEND_TIMEOUT_MS: i32 = 10_000;
 
 static TXN_ID: AtomicUsize = ATOMIC_USIZE_INIT;
 


### PR DESCRIPTION
* Transform ConnErr into a more accurate ErrCode instead of converting
it into a catch all ErrCode::BUG when routing messages with a
RouteClient. This will help us identify better on the client side
what went wrong without reading the logs.
* We're seeing a lot of socket timeouts under load and I'm not sure
if it's caused by network latency, waiting on remote replies (GitHub),
or an issue with our networking code in general. Let's increase the
timeouts and see if this helps us identify a root cause

![tenor-23747333](https://user-images.githubusercontent.com/54036/31350756-37b66944-acdd-11e7-8e34-39d16895f190.gif)
