### PR TITLE
Fix push notifications when no branches are explicitly specified

### DIFF
--- a/components/builder-api/src/github.rs
+++ b/components/builder-api/src/github.rs
@@ -236,25 +236,20 @@ fn handle_push(req: &mut Request, body: &str) -> IronResult<Response> {
     };
 
     debug!("Config, {:?}", config);
-
     let mut plans = match read_plans(&github, &token, &hook, plans) {
         HandleResult::Ok(plans) => plans,
         HandleResult::Err(err) => return Ok(err),
     };
 
     debug!("Plans, {:?}", plans);
-
     if let Some(cfg) = config {
         plans.retain(|plan| match cfg.get(&plan.name) {
-            Some(project) => {
-                hook.changed().iter().any(|f| {
-                    project.triggered_by(hook.branch(), f)
-                })
-            }
+            Some(project) => project.triggered_by(hook.branch(), hook.changed().as_slice()),
             None => false,
         })
     }
 
+    debug!("Filtered Plans, {:?}", plans);
     build_plans(req, &hook.repository.clone_url, plans)
 }
 


### PR DESCRIPTION
The default value for `branches` in a `.bldr.toml` was being
evaluated as a blank vector due to how the serde library determines
default (it's by type, not by what you defined as default in your
impl). We now properly set the default branch list to `["master"]`

![tenor-159610574](https://user-images.githubusercontent.com/54036/31354607-caff441a-aceb-11e7-8a5a-90888ec36b7b.gif)
