### PR TITLE
update hab pkg promote example cli text

### DIFF
--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -276,7 +276,7 @@ pub fn get() -> App<'static, 'static> {
                 (@arg BLDR_URL: -u --url +takes_value {valid_url}
                     "Specify an alternate Builder endpoint (default: https://bldr.habitat.sh)")
                 (@arg PKG_IDENT: +required +takes_value
-                    "A package identifier (ex: core/redis, core/busybox-static/1.42.2)")
+                    "A package identifier (ex: core/redis/3.2.1/20160729052715)")
                 (@arg CHANNEL: +required +takes_value
                     "Promote to the specified release channel")
                 (@arg AUTH_TOKEN: -z --auth +takes_value "Authentication token for Builder")


### PR DESCRIPTION
Builder requires a fully qualified package identifier in the form of `origin/package/version/release` and this updates the cli example for promote to use the correct fully qualified package identifier example.

Signed-off-by: echohack <echohack@users.noreply.github.com>