### PR TITLE
Refactor logging statements in builder-depot crate

### DIFF
--- a/components/builder-depot/src/lib.rs
+++ b/components/builder-depot/src/lib.rs
@@ -87,10 +87,7 @@ impl DepotUtil {
         let file = self.archive_path(ident, target);
         match fs::metadata(&file) {
             Ok(_) => Some(PackageArchive::new(file)),
-            Err(_) => {
-                warn!("Package not found at {:?}", file);
-                None
-            }
+            Err(_) => None,
         }
     }
 


### PR DESCRIPTION
This is some of the oldest code we've got and it's about time we take
a pass and refresh the logging output. All logs that you want to wake
you up in the middle of the night are set to `error`. Anything you want
an hourly aggregate on are set to `warn`. Anything that's interesting
is set to `info`. All else is `debug` or `trace` for network messages

![tenor-101149005](https://user-images.githubusercontent.com/54036/31360272-66752566-ad02-11e7-8699-0ff16297fc03.gif)
