### PR TITLE
Bump socket send/recv timeout from 10_000ms to 15_000ms

### DIFF
--- a/components/net/src/conn/mod.rs
+++ b/components/net/src/conn/mod.rs
@@ -31,9 +31,9 @@ use error::{ErrCode, NetError, NetResult};
 use socket::DEFAULT_CONTEXT;
 
 /// Time to wait before timing out a message receive for a `RouteConn`.
-pub const RECV_TIMEOUT_MS: i32 = 10_000;
+pub const RECV_TIMEOUT_MS: i32 = 15_000;
 /// Time to wait before timing out a message send for a `RouteBroker` to a router.
-pub const SEND_TIMEOUT_MS: i32 = 10_000;
+pub const SEND_TIMEOUT_MS: i32 = 15_000;
 
 static TXN_ID: AtomicUsize = ATOMIC_USIZE_INIT;
 


### PR DESCRIPTION
The bump from 5s to 10s alleviated issues in acceptance and production. Let's kick it up just a bit more to be safe.

![tenor-155051621](https://user-images.githubusercontent.com/54036/31361726-92f3e63e-ad09-11e7-944a-5d651925be27.gif)
