### PR TITLE
Fix syntax error in builder-api-proxy config

### DIFF
--- a/components/builder-api-proxy/config/nginx.conf
+++ b/components/builder-api-proxy/config/nginx.conf
@@ -69,7 +69,6 @@ http {
     listen       *:{{cfg.http.listen_port}};
     server_name  {{sys.hostname}};
     root {{pkgPathFor "core/builder-web"}}/app;
-;
 
     if ($http_x_forwarded_proto = "http") {
       rewrite ^(.*)$ https://$host$1 permanent;


### PR DESCRIPTION
![tenor-55258965](https://user-images.githubusercontent.com/54036/31363469-23bbf07c-ad13-11e7-9dbe-f1f22546e10a.gif)
