### PR TITLE
Fix reading config file for builder-api-proxy

### DIFF
--- a/components/builder-api-proxy/config/habitat.conf.js
+++ b/components/builder-api-proxy/config/habitat.conf.js
@@ -7,7 +7,7 @@ habitatConfig({
     github_client_id: "{{cfg.github.client_id}}",
     github_api_url: "{{cfg.github.url}}",
     github_web_url: "{{cfg.github.web_url}}",
-    github_app_url: "{{cfg.github_app_url}}",
+    github_app_url: "{{cfg.github.app_url}}",
     github_app_id: "{{cfg.github.app_id}}",
     source_code_url: "{{cfg.source_code_url}}",
     tutorials_url: "{{cfg.tutorials_url}}",

--- a/components/builder-api-proxy/config/nginx.conf
+++ b/components/builder-api-proxy/config/nginx.conf
@@ -102,7 +102,7 @@ http {
 
     location /habitat.conf.js {
       add_header Cache-Control "private, no-cache, no-store";
-      alias {{pkg.svc_config_path}};
+      root {{pkg.svc_config_path}};
       break;
     }
 

--- a/components/builder-api-proxy/default.toml
+++ b/components/builder-api-proxy/default.toml
@@ -1,32 +1,38 @@
-app_url               = "https://bldr.habitat.sh"
-community_url         = "https://www.habitat.sh/community"
-docs_url              = "https://www.habitat.sh/docs"
-environment           = "production"
-friends_only          = false
-source_code_url       = "https://github.com/habitat-sh/habitat"
-tutorials_url         = "https://www.habitat.sh/tutorials"
-www_url               = "https://www.habitat.sh"
-status_url            = "https://status.habitat.sh/"
-forums_url            = "https://forums.habitat.sh/"
-events_url            = "https://events.chef.io/events/categories/habitat/"
-roadmap_url           = "https://ext.prodpad.com/ext/roadmap/d2938aed0d0ad1dd62669583e108357efd53b3a6"
-feature_requests_url  = "https://portal.prodpad.com/24539"
-slack_url             = "http://slack.habitat.sh/"
-youtube_url           = "https://www.youtube.com/playlist?list=PL11cZfNdwNyOxlvI1Kq6ae8eVBl5S3IKk"
-demo_app_url          = "https://www.habitat.sh/demo"
-github_app_url        = "https://github.com/apps/habitat-builder"
+app_url              = "https://bldr.habitat.sh"
+community_url        = "https://www.habitat.sh/community"
+docs_url             = "https://www.habitat.sh/docs"
+environment          = "production"
+friends_only         = false
+source_code_url      = "https://github.com/habitat-sh/habitat"
+tutorials_url        = "https://www.habitat.sh/tutorials"
+www_url              = "https://www.habitat.sh"
+status_url           = "https://status.habitat.sh/"
+forums_url           = "https://forums.habitat.sh/"
+events_url           = "https://events.chef.io/events/categories/habitat/"
+roadmap_url          = "https://ext.prodpad.com/ext/roadmap/d2938aed0d0ad1dd62669583e108357efd53b3a6"
+feature_requests_url = "https://portal.prodpad.com/24539"
+slack_url            = "http://slack.habitat.sh/"
+youtube_url          = "https://www.youtube.com/playlist?list=PL11cZfNdwNyOxlvI1Kq6ae8eVBl5S3IKk"
+demo_app_url         = "https://www.habitat.sh/demo"
 
 [feature_flags]
 project = true
 
+[github]
+url       = "https://api.github.com"
+web_url   = "https://github.com"
+app_url   = "https://github.com/apps/habitat-builder"
+client_id = ""
+app_id    = 5565
+
 [nginx]
 worker_rlimit_nofile = 8192
-worker_processes = "auto"
-worker_connections = 8000
+worker_processes     = "auto"
+worker_connections   = 8000
 
 [http]
-listen_port = 80
-sendfile = "on"
-tcp_nopush = "on"
-tcp_nodelay = "on"
+listen_port       = 80
+sendfile          = "on"
+tcp_nopush        = "on"
+tcp_nodelay       = "on"
 keepalive_timeout = "20s"

--- a/components/builder-api-proxy/hooks/init
+++ b/components/builder-api-proxy/hooks/init
@@ -2,3 +2,4 @@
 set -e
 mkdir -p {{pkg.svc_var_path}}/nginx
 chown -R hab:hab {{pkg.svc_var_path}}
+chown -R hab:hab {{pkg.svc_config_path}}

--- a/components/builder-api/habitat/default.toml
+++ b/components/builder-api/habitat/default.toml
@@ -2,17 +2,17 @@ log_level = "info"
 
 [http]
 listen = "0.0.0.0"
-port = 9636
+port   = 9636
 
 [github]
-url = "https://api.github.com"
-web_url = "https://github.com"
-client_id = ""
-client_secret = ""
-app_id = 5565
+url            = "https://api.github.com"
+web_url        = "https://github.com"
+client_id      = ""
+client_secret  = ""
+app_id         = 5565
 webhook_secret = ""
 
 [depot]
-builds_enabled = true
+builds_enabled          = true
 non_core_builds_enabled = true
-events_enabled = false
+events_enabled          = false


### PR DESCRIPTION
* chown the config directory so the nginx user can serve the config
* set sensible default settings for builder-api-proxy

![tenor-92778419](https://user-images.githubusercontent.com/54036/31366413-97434d44-ad25-11e7-9244-8ccf844f88d3.gif)
