### PR TITLE
Handle expired session tokens in Builder UI

### DIFF
--- a/components/builder-web/app/package/package/package.component.ts
+++ b/components/builder-web/app/package/package/package.component.ts
@@ -117,13 +117,15 @@ export class PackageComponent implements OnInit, OnDestroy {
     }
 
     private fetchProject() {
-        if (this.origin && this.name && this.isOriginMember) {
+        if (this.token && this.origin && this.name && this.isOriginMember) {
             this.store.dispatch(fetchProject(this.origin, this.name, this.token, false));
             this.store.dispatch(fetchDockerIntegration(this.origin, this.token));
         }
     }
 
     private fetchBuilds() {
-        this.store.dispatch(fetchBuilds(this.origin, this.name, this.token));
+        if (this.token) {
+            this.store.dispatch(fetchBuilds(this.origin, this.name, this.token));
+        }
     }
 }


### PR DESCRIPTION
This change handles expired Builder session tokens by catching errors and redirecting the user to sign-in.

Signed-off-by: Christian Nunciato <cnunciato@chef.io>

Fixes #3557.

![](https://media.tenor.com/images/b1a84c54063bad605973fc9eb39b4429/tenor.gif)