### PR TITLE
Don't strip Builder binaries

### DIFF
--- a/support/ci/builder-base-plan.sh
+++ b/support/ci/builder-base-plan.sh
@@ -21,7 +21,7 @@ do_install() {
 }
 
 do_strip() {
-  do_builder_strip
+  return 0
 }
 
 do_builder_before() {
@@ -53,10 +53,4 @@ do_builder_prepare() {
   # Used by Cargo to use a pristine, isolated directory for all compilation
   export CARGO_TARGET_DIR="$HAB_CACHE_SRC_PATH/$pkg_dirname"
   build_line "Setting CARGO_TARGET_DIR=$CARGO_TARGET_DIR"
-}
-
-do_builder_strip() {
-  if [[ "$builder_build_type" != "--debug" ]]; then
-    do_default_strip
-  fi
 }


### PR DESCRIPTION
This change will ensure that debugging symbols are left in all
binaries in a Builder hart which are now included in our release
builds

@fnichol I know we discussed using alternative flags to the `strip` command but I think we just don't want to touch any binaries at all since we're not interested in the size of any of the Builder harts