### PR TITLE
Add 'remove' subcommand to hab pkg 

### DIFF
--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -239,6 +239,10 @@ pub fn get() -> App<'static, 'static> {
                     (ex: core/busybox-static/1.24.2/20160708162350)")
                 (@arg FULL_PATHS: -p "Show full path to file")
             )
+            (@subcommand remove => 
+                (about: "Remove a package from the system")
+                (@arg PKG_IDENT: +required +takes_value "Package to remove")
+            )
             (@subcommand search =>
                 (about: "Search for a package in Builder")
                 (@arg SEARCH_TERM: +required +takes_value "Search term")

--- a/components/hab/src/command/pkg/remove.rs
+++ b/components/hab/src/command/pkg/remove.rs
@@ -12,20 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod binlink;
-pub mod build;
-pub mod channels;
-pub mod demote;
-pub mod env;
-pub mod exec;
-pub mod export;
-pub mod hash;
-pub mod header;
-pub mod path;
-pub mod promote;
-pub mod provides;
-pub mod search;
-pub mod sign;
-pub mod upload;
-pub mod verify;
-pub mod remove;
+use std::collections::HashSet;
+use std::path::Path;
+
+use walkdir::WalkDir;
+
+use error::{Error, Result};
+use hcore::fs::PKG_PATH;
+use hcore::package::PackageIdent;
+use common::ui::{Status, UI};
+
+pub fn start(ui: &mut UI, pkg_name: &PackageIdent, fs_root_path: &Path ) -> Result<()> {
+  Ok(())
+} 

--- a/components/hab/src/command/pkg/remove.rs
+++ b/components/hab/src/command/pkg/remove.rs
@@ -14,14 +14,66 @@
 
 use std::collections::HashSet;
 use std::path::Path;
+use std::fs;
+use std::fs::File;
+use std::io::prelude::*;
+use std::str::FromStr;
+use std::cmp::Ordering;
 
 use walkdir::WalkDir;
 
-use error::{Error, Result};
+use error::Result;
 use hcore::fs::PKG_PATH;
-use hcore::package::PackageIdent;
+use hcore::package::{PackageIdent, PackageInstall};
 use common::ui::{Status, UI};
 
-pub fn start(ui: &mut UI, pkg_name: &PackageIdent, fs_root_path: &Path ) -> Result<()> {
-  Ok(())
-} 
+pub fn start(ui: &mut UI, pkg_name: &PackageIdent, fs_root_path: &Path) -> Result<()> {
+    let package_install = PackageInstall::load(pkg_name, Some(fs_root_path))?;
+    let package_ident = package_install.ident();
+    let pkg_root = fs_root_path.join(PKG_PATH);
+
+    let mut dependent_packages = HashSet::new();
+
+    ui.begin(format!(
+        "Checking for installed packages that depend on {}",
+        package_install
+    ))?;
+
+    for entry in WalkDir::new(pkg_root).into_iter().filter_map(|e| e.ok()) {
+        if let Some(e) = entry.path().file_name().and_then(|e| e.to_str()) {
+            if e == "IDENT" {
+                let mut f = File::open(entry.path().to_str().unwrap())?;
+                let mut ident_str = String::new();
+
+                f.read_to_string(&mut ident_str)?;
+
+                let pkg_ident = PackageIdent::from_str(&ident_str.trim())?;
+                let pkg_install = PackageInstall::load(&pkg_ident, Some(fs_root_path))?;
+
+                for tdep in pkg_install.tdeps().unwrap() {
+                    if package_ident.cmp(&tdep) == Ordering::Equal {
+                        dependent_packages.insert(pkg_install.ident().clone());
+                    }
+                }
+            }
+        }
+    }
+
+    if dependent_packages.is_empty() {
+        ui.status(
+            Status::Deleting,
+            format!("{:?}", package_install.installed_path()),
+        )?;
+        fs::remove_dir_all(package_install.installed_path()).expect("Unable to remove package");
+    } else {
+        println!(
+            "Unable to delete {}.  The following packages depend on it:",
+            package_ident
+        );
+        for pkg in dependent_packages {
+            println!("  {}", pkg);
+        }
+    }
+
+    Ok(())
+}

--- a/components/hab/src/error.rs
+++ b/components/hab/src/error.rs
@@ -37,6 +37,7 @@ pub enum Error {
     ArgumentError(&'static str),
     ButterflyError(String),
     CannotRemoveFromChannel((String, String)),
+    CannotRemovePackage((String, Vec<String>)),
     CommandNotFoundInPkg((String, String)),
     CryptoCLI(String),
     DepotClient(depot_client::Error),
@@ -74,6 +75,13 @@ impl fmt::Display for Error {
             Error::ButterflyError(ref e) => format!("{}", e),
             Error::CannotRemoveFromChannel((ref p, ref c)) => {
                 format!("{} cannot be removed from the {} channel.", p, c)
+            }
+            Error::CannotRemovePackage((ref p, ref d)) => {
+                format!(
+                    "{} cannot be removed, the following packages depend on it:\n\n{}",
+                    p,
+                    d.join("\n")
+                )
             }
             Error::CommandNotFoundInPkg((ref p, ref c)) => {
                 format!(
@@ -169,6 +177,7 @@ impl error::Error for Error {
             Error::CannotRemoveFromChannel(_) => {
                 "Package cannot be removed from the specified channel"
             }
+            Error::CannotRemovePackage(_) => "Package cannot be removed",
             Error::CommandNotFoundInPkg(_) => {
                 "Command was not found under any 'PATH' directories in the package"
             }

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -162,6 +162,7 @@ fn start(ui: &mut UI) -> Result<()> {
                 ("header", Some(m)) => sub_pkg_header(ui, m)?,
                 ("promote", Some(m)) => sub_pkg_promote(ui, m)?,
                 ("demote", Some(m)) => sub_pkg_demote(ui, m)?,
+                ("remove", Some(m)) => sub_pkg_remove(ui, m)?,
                 _ => unreachable!(),
             }
         }
@@ -383,6 +384,12 @@ fn sub_pkg_hash(m: &ArgMatches) -> Result<()> {
             Ok(())
         }
     }
+}
+
+fn sub_pkg_remove(ui: &mut UI, m: &ArgMatches) -> Result<()> {
+    let ident = PackageIdent::from_str(m.value_of("PKG_IDENT").unwrap())?;
+
+    command::pkg::remove::start(ui, &ident, &*FS_ROOT)
 }
 
 fn sub_bldr_encrypt(ui: &mut UI, m: &ArgMatches) -> Result<()> {


### PR DESCRIPTION
This is a first pass at adding a `pkg remove` subcommand to hab.  It's functional in its current state, so I wanted to get additional :eyes: on it.  

The approach I took is to first verify the package is installed. If more than one matches the identifier given, I assume the user meant the latest. I chose to walk all installed packages, using the IDENT file to identify a package. I then iterate on that packages TDEPS to see if it references the specific version/release of the package we're trying to remove.  If any are found, then the user is notified what packages depend on the package they tried to delete. 

A few questions I have are:
Is this the right flow and experience for the user?
Are there edge cases I haven't thought of?
Is there a better way to identify/get installed packages? 
How do I test the behavior? 

TODO:
* [x] Should return non-zero exit status if remove fails.
