### PR TITLE
Fix GH Hook timeouts and auto-build with a forked repo

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -1,7 +1,8 @@
 [builder-admin-proxy]
-paths = ["components/builder-admin-proxy/*"]
+plan_path = "components/builder-admin-proxy"
 
 [builder-admin]
+plan_path = "components/builder-admin/habitat"
 paths = [
   "components/builder-admin/*",
   "components/builder-http-gateway/*",
@@ -12,12 +13,13 @@ paths = [
 ]
 
 [builder-api-proxy]
+plan_path = "components/builder-api-proxy"
 paths = [
-  "components/builder-api-proxy/*",
   "components/builder-web/*",
 ]
 
 [builder-api]
+plan_path = "components/builder-api/habitat"
 paths = [
   "components/builder-api/*",
   "components/builder-core/*",
@@ -30,11 +32,10 @@ paths = [
 ]
 
 [builder-datastore]
-paths = [
-  "components/builder-datastore"
-]
+plan_path = "components/builder-datastore"
 
 [builder-jobsrv]
+plan_path = "components/builder-jobsrv/habitat"
 paths = [
   "components/builder-jobsrv/*",
   "components/builder-core/*",
@@ -45,6 +46,7 @@ paths = [
 ]
 
 [builder-originsrv]
+plan_path = "components/builder-originsrv/habitat"
 paths = [
   "components/builder-originsrv/*",
   "components/builder-protocol/*",
@@ -54,6 +56,7 @@ paths = [
 ]
 
 [builder-router]
+plan_path = "components/builder-router/habitat"
 paths = [
   "components/builder-router/*",
   "components/builder-protocol/*",
@@ -62,6 +65,7 @@ paths = [
 ]
 
 [builder-scheduler]
+plan_path = "components/builder-scheduler/habitat"
 paths = [
   "components/builder-scheduler/*",
   "components/builder-core/*",
@@ -72,6 +76,7 @@ paths = [
 ]
 
 [builder-sessionsrv]
+plan_path = "components/builder-sessionsrv/habitat"
 paths = [
   "components/builder-sessionsrv/*",
   "components/builder-protocol/*",
@@ -82,6 +87,7 @@ paths = [
 ]
 
 [builder-worker]
+plan_path = "components/builder-worker/habitat"
 paths = [
   "components/builder-worker/*",
   "components/builder-core/*",
@@ -93,6 +99,7 @@ paths = [
 ]
 
 [hab]
+plan_path = "components/hab"
 paths = [
   "components/hab/*",
   "components/builder-api-client/*",
@@ -103,12 +110,13 @@ paths = [
 ]
 
 [hab-backline]
-paths = ["components/backline/*"]
+plan_path = "components/backline"
 
 [hab-bintray-publish]
-paths = ["components/hab-bintray-publish/*"]
+plan_path = "components/bintray-publish"
 
 [hab-butterfly]
+plan_path = "components/hab-butterfly"
 paths = [
   "components/hab-butterfly/*",
   "components/butterfly/*",
@@ -118,6 +126,7 @@ paths = [
 ]
 
 [hab-eventsrv]
+plan_path = "components/eventsrv/habitat"
 paths = [
   "components/eventsrv/*",
   "components/eventsrv-protocol/*",
@@ -125,15 +134,17 @@ paths = [
 ]
 
 [hab-launcher]
+plan_path = "components/launcher/habitat"
 paths = [
   "components/launcher/*",
   "components/launcher-protocol/*",
 ]
 
 [hab-studio]
-paths = ["components/studio/*"]
+plan_path = "components/studio"
 
 [hab-sup]
+plan_path = "components/sup"
 paths = [
   "components/sup/*",
   "components/eventsrv-client/*",
@@ -144,18 +155,18 @@ paths = [
 ]
 
 [hab-pkg-aci]
-paths = ["components/pkg-aci/*"]
+plan_path = "components/pkg-aci"
 
 [hab-pkg-export-docker]
+plan_path = "components/pkg-export-docker"
 paths = [
-  "components/pkg-export-docker/*",
   "components/core/*",
   "components/common/*",
   "components/hab/*",
 ]
 
 [hab-pkg-mesosize]
-paths = ["components/pkg-mesosize/*"]
+plan_path = "components/pkg-mesosize"
 
 [hab-pkg-tarize]
-paths = ["components/pkg-tarize/*"]
+plan_path = "components/pkg-tarize"

--- a/components/builder-api/src/github.rs
+++ b/components/builder-api/src/github.rs
@@ -52,11 +52,6 @@ impl FromStr for GitHubEvent {
     }
 }
 
-enum HandleResult<T> {
-    Ok(T),
-    Err(Response),
-}
-
 pub fn handle_event(req: &mut Request) -> IronResult<Response> {
     let event = match req.headers.get::<XGitHubEvent>() {
         Some(&XGitHubEvent(ref event)) => {
@@ -203,36 +198,10 @@ fn handle_push(req: &mut Request, body: &str) -> IronResult<Response> {
         }
     };
 
-    let query = format!("q={}+in:path+repo:{}", "plan.sh", hook.repository.full_name);
-    let plans = match github.search_code(&token, &query) {
-        Ok(plans) => plans,
-        Err(err) => return Ok(Response::with((status::BadGateway, err.to_string()))),
-    };
-
-    if plans.is_empty() {
-        return Ok(Response::with(status::Ok));
-    }
-
-    let config = match read_bldr_config(&*github, &token, &hook) {
-        HandleResult::Ok(config) => config,
-        HandleResult::Err(err) => return Ok(err),
-    };
+    let config = read_bldr_config(&*github, &token, &hook);
     debug!("Config, {:?}", config);
-
-    let mut plans = match read_plans(&github, &token, &hook, plans) {
-        HandleResult::Ok(plans) => plans,
-        HandleResult::Err(err) => return Ok(err),
-    };
-    debug!("Plans, {:?}", plans);
-
-    if let Some(cfg) = config {
-        plans.retain(|plan| match cfg.get(&plan.name) {
-            Some(project) => project.triggered_by(hook.branch(), hook.changed().as_slice()),
-            None => false,
-        })
-    }
-
-    debug!("Filtered Plans, {:?}", plans);
+    let plans = read_plans(&github, &token, &hook, &config);
+    debug!("Triggered Plans, {:?}", plans);
     build_plans(req, &hook.repository.clone_url, plans)
 }
 
@@ -275,31 +244,22 @@ fn build_plans(req: &mut Request, repo_url: &str, plans: Vec<Plan>) -> IronResul
     Ok(render_json(status::Ok, &plans))
 }
 
-fn read_bldr_config(
-    github: &GitHubClient,
-    token: &str,
-    hook: &GitHubWebhookPush,
-) -> HandleResult<Option<BuildCfg>> {
+fn read_bldr_config(github: &GitHubClient, token: &str, hook: &GitHubWebhookPush) -> BuildCfg {
     match github.contents(token, hook.repository.id, BLDR_CFG) {
         Ok(Some(contents)) => {
             match contents.decode() {
-                Ok(ref bytes) => {
-                    match BuildCfg::from_slice(bytes) {
-                        Ok(cfg) => HandleResult::Ok(Some(cfg)),
-                        Err(err) => HandleResult::Err(Response::with(
-                            (status::UnprocessableEntity, err.to_string()),
-                        )),
-                    }
-                }
+                Ok(ref bytes) => BuildCfg::from_slice(bytes).unwrap_or_default(),
                 Err(err) => {
-                    HandleResult::Err(Response::with(
-                        (status::UnprocessableEntity, err.to_string()),
-                    ))
+                    debug!("unable to read bldr.toml, {}", err);
+                    BuildCfg::default()
                 }
             }
         }
-        Ok(None) => HandleResult::Ok(None),
-        Err(err) => HandleResult::Err(Response::with((status::BadGateway, err.to_string()))),
+        Ok(None) => BuildCfg::default(),
+        Err(err) => {
+            warn!("unable to retrieve bldr.toml, {}", err);
+            BuildCfg::default()
+        }
     }
 }
 
@@ -307,34 +267,45 @@ fn read_plans(
     github: &GitHubClient,
     token: &str,
     hook: &GitHubWebhookPush,
-    plans: Vec<SearchItem>,
-) -> HandleResult<Vec<Plan>> {
-    let mut parsed = Vec::with_capacity(plans.len());
-    for plan in plans {
-        match github.contents(token, hook.repository.id, &plan.path) {
-            Ok(Some(contents)) => {
-                match contents.decode() {
-                    Ok(bytes) => {
-                        match Plan::from_bytes(bytes.as_slice()) {
-                            Ok(plan) => parsed.push(plan),
-                            Err(err) => debug!("{}, {}", plan.path, err),
-                        }
-                    }
-                    Err(err) => {
-                        return HandleResult::Err(Response::with((
-                            status::UnprocessableEntity,
-                            format!("{}, {}", plan.path, err),
-                        )))
-                    }
-                }
-            }
-            Ok(None) => (),
-            Err(err) => {
-                return HandleResult::Err(Response::with(
-                    (status::BadGateway, format!("{}, {}", plan.path, err)),
-                ))
-            }
+    config: &BuildCfg,
+) -> Vec<Plan> {
+    let mut plans = Vec::with_capacity(config.projects().len());
+    for project in config.triggered_by(hook.branch(), hook.changed().as_slice()) {
+        if let Some(plan) = read_plan(github, token, hook, &project.plan_path) {
+            plans.push(plan)
         }
     }
-    HandleResult::Ok(parsed)
+    plans
+}
+
+fn read_plan(
+    github: &GitHubClient,
+    token: &str,
+    hook: &GitHubWebhookPush,
+    path: &str,
+) -> Option<Plan> {
+    match github.contents(token, hook.repository.id, path) {
+        Ok(Some(contents)) => {
+            match contents.decode() {
+                Ok(bytes) => {
+                    match Plan::from_bytes(bytes.as_slice()) {
+                        Ok(plan) => Some(plan),
+                        Err(err) => {
+                            debug!("unable to read plan, {}, {}", path, err);
+                            None
+                        }
+                    }
+                }
+                Err(err) => {
+                    debug!("unable to read plan, {}, {}", path, err);
+                    None
+                }
+            }
+        }
+        Ok(None) => None,
+        Err(err) => {
+            warn!("unable to retrieve plan, {}, {}", path, err);
+            None
+        }
+    }
 }

--- a/components/builder-api/src/github.rs
+++ b/components/builder-api/src/github.rs
@@ -271,7 +271,7 @@ fn read_plans(
 ) -> Vec<Plan> {
     let mut plans = Vec::with_capacity(config.projects().len());
     for project in config.triggered_by(hook.branch(), hook.changed().as_slice()) {
-        if let Some(plan) = read_plan(github, token, hook, &project.plan_path) {
+        if let Some(plan) = read_plan(github, token, hook, project.plan_path.as_str()) {
             plans.push(plan)
         }
     }

--- a/components/builder-core/src/build_config.rs
+++ b/components/builder-core/src/build_config.rs
@@ -39,22 +39,26 @@ impl BuildCfg {
         vec!["master".to_string()]
     }
 
-    pub fn default_plan_path() -> String {
-        String::from("habitat/plan.sh")
+    pub fn default_plan_path() -> Pattern {
+        Pattern::from_str("habitat/*").unwrap()
     }
 
     pub fn from_slice(bytes: &[u8]) -> Result<Self> {
-        let value = toml::from_slice::<HashMap<String, ProjectCfg>>(bytes)
+        let mut inner = toml::from_slice::<HashMap<String, ProjectCfg>>(bytes)
             .map_err(|e| Error::DecryptError(e.to_string()))?;
-        Ok(BuildCfg(value))
+        for value in inner.values_mut() {
+            value.plan_path.dir_expand();
+        }
+        Ok(BuildCfg(inner))
     }
 
+    /// List of all registered projects for this `BuildCfg`.
     pub fn projects(&self) -> Vec<&ProjectCfg> {
         self.0.values().collect()
     }
 
     /// Returns true if the given branch & file path combination should result in a new build
-    /// being automatically triggered by a GitHub Push notification
+    /// being automatically triggered by a GitHub Push notification.
     pub fn triggered_by<T>(&self, branch: &str, paths: &[T]) -> Vec<&ProjectCfg>
     where
         T: AsRef<str>,
@@ -91,9 +95,9 @@ pub struct ProjectCfg {
     /// notification to determine if an automatic rebuild should occur.
     #[serde(default)]
     pub paths: Vec<Pattern>,
-    /// Relative filepath to the project's Plan File (default: "habitat/plan.sh").
+    /// Relative filepath to the project's Plan (default: "habitat").
     #[serde(default = "BuildCfg::default_plan_path")]
-    pub plan_path: String,
+    pub plan_path: Pattern,
 }
 
 impl ProjectCfg {
@@ -107,7 +111,7 @@ impl ProjectCfg {
             return false;
         }
         paths.iter().any(|p| {
-            self.paths.iter().any(|i| i.matches(p.as_ref()))
+            self.plan_path.matches(p.as_ref()) || self.paths.iter().any(|i| i.matches(p.as_ref()))
         })
     }
 }
@@ -129,19 +133,33 @@ pub struct Pattern {
 }
 
 impl Pattern {
-    pub fn matches<T>(&self, value: T) -> bool
-    where
-        T: AsRef<str>,
-    {
-        self.inner.matches_with(value.as_ref(), &self.options)
-    }
-
     fn default_options() -> glob::MatchOptions {
         glob::MatchOptions {
             case_sensitive: false,
             require_literal_separator: false,
             require_literal_leading_dot: false,
         }
+    }
+
+    pub fn as_str(&self) -> &str {
+        self.inner.as_str()
+    }
+
+    /// Mutate the pattern match to encompass the entire directory if not already present. This is
+    /// useful for allowing a user to specify a directory name like "habitat" in their configuration
+    /// and we'll check the contents.
+    pub fn dir_expand(&mut self) {
+        if self.inner.as_str().ends_with("/*") {
+            return;
+        }
+        self.inner = glob::Pattern::from_str(&format!("{}/*", self.inner.as_str())).unwrap();
+    }
+
+    pub fn matches<T>(&self, value: T) -> bool
+    where
+        T: AsRef<str>,
+    {
+        self.inner.matches_with(value.as_ref(), &self.options)
     }
 }
 
@@ -151,17 +169,25 @@ impl<'de> Deserialize<'de> for Pattern {
         D: Deserializer<'de>,
     {
         let s = String::deserialize(deserializer)?;
-        let inner: glob::Pattern = FromStr::from_str(&s).map_err(de::Error::custom)?;
-        Ok(Pattern {
-            inner: inner,
-            options: Pattern::default_options(),
-        })
+        Pattern::from_str(&s).map_err(de::Error::custom)
     }
 }
 
 impl fmt::Debug for Pattern {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.inner)
+    }
+}
+
+impl FromStr for Pattern {
+    type Err = glob::PatternError;
+
+    fn from_str(value: &str) -> result::Result<Self, Self::Err> {
+        let inner: glob::Pattern = FromStr::from_str(value)?;
+        Ok(Pattern {
+            inner: inner,
+            options: Pattern::default_options(),
+        })
     }
 }
 
@@ -178,77 +204,62 @@ impl Serialize for Pattern {
 mod test {
     use super::*;
 
-    #[test]
-    fn from_contents() {
-        let raw = r#"
-        [hab-sup]
-        branches = [
-          "master",
-          "dev",
-        ]
-        channels = [
-          "stable"
-        ]
-        paths = [
-          "components/hab-sup/*"
-        ]
+    const CONFIG: &'static str = r#"
+    [hab-sup]
+    plan_path = "components/hab-sup"
+    branches = [
+      "master",
+      "dev",
+    ]
+    channels = [
+      "stable"
+    ]
+    paths = [
+      "components/net/*"
+    ]
 
-        [builder-api]
-        plan_path = "components/builder-api/habitat/plan.sh"
-        paths = [
-          "components/builder-api/*"
-        ]
-        "#;
-        let cfg = BuildCfg::from_slice(raw.as_bytes()).unwrap();
-        assert_eq!(cfg.len(), 2);
-        assert_eq!(&cfg.get("hab-sup").unwrap().plan_path, "habitat/plan.sh");
-        assert_eq!(
-            &cfg.get("builder-api").unwrap().plan_path,
-            "components/builder-api/habitat/plan.sh"
-        );
-        assert_eq!(
-            cfg.get("hab-sup").unwrap().triggered_by(
-                "master",
-                &[
-                    "components/hab-sup/Cargo.toml",
-                ],
-            ),
-            true
-        );
-        assert_eq!(
-            cfg.get("hab-sup").unwrap().triggered_by(
-                "master",
-                &[
-                    "components/hAb-Sup/Cargo.toml",
-                ],
-            ),
-            true
-        );
-        assert_eq!(
-            cfg.get("hab-sup").unwrap().triggered_by(
-                "dev",
-                &[
-                    "components/hab-sup/Cargo.toml",
-                ],
-            ),
-            true
-        );
-        assert_eq!(
-            cfg.get("hab-sup").unwrap().triggered_by(
-                "master",
-                &["components"],
-            ),
-            false
-        );
-        assert_eq!(
-            cfg.get("builder-api").unwrap().triggered_by(
-                "master",
-                &[
-                    "components/builder-api/Cargo.toml",
-                ],
-            ),
-            true
-        );
-        assert_eq!(cfg.get("hab-sup").unwrap().branches, &["master", "dev"]);
+    [builder-api]
+    plan_path = "components/builder-api/habitat"
+    paths = [
+      "components/net/*"
+    ]
+
+    [default]
+    "#;
+
+    #[test]
+    fn triggered_by() {
+        let cfg = BuildCfg::from_slice(CONFIG.as_bytes()).unwrap();
+        let hab_sup = cfg.get("hab-sup").unwrap();
+        let bldr_api = cfg.get("builder-api").unwrap();
+        let default = cfg.get("default").unwrap();
+
+        assert!(hab_sup.triggered_by(
+            "master",
+            &["components/hab-sup/Cargo.toml"],
+        ));
+        assert!(hab_sup.triggered_by(
+            "master",
+            &["components/hAb-Sup/Cargo.toml"],
+        ));
+        assert!(hab_sup.triggered_by(
+            "dev",
+            &["components/hab-sup/Cargo.toml"],
+        ));
+        assert_eq!(hab_sup.triggered_by("master", &["components"]), false);
+
+        assert!(bldr_api.triggered_by(
+            "master",
+            &["components/builder-api/habitat/plan.sh"],
+        ));
+        assert!(bldr_api.triggered_by(
+            "master",
+            &["components/net/Cargo.toml"],
+        ));
+
+        assert!(default.triggered_by("master", &["habitat/plan.sh"]));
+        assert!(default.triggered_by("master", &["habitat/hooks/init"]));
+        assert_eq!(default.triggered_by("dev", &["habitat/plan.sh"]), false);
+        assert_eq!(default.triggered_by("master", &["components"]), false);
     }
 }

--- a/tools/bldr_toml_create/toml.erb
+++ b/tools/bldr_toml_create/toml.erb
@@ -1,2 +1,2 @@
 [<%= plan %>]
-paths = ["<%= plan %>/*"]
+plan_path = ["<%= plan %>"]

--- a/tools/bldr_toml_create/toml_create.rb
+++ b/tools/bldr_toml_create/toml_create.rb
@@ -1,3 +1,5 @@
+#!/usr/bin/env ruby
+
 #############################################################################
 #
 # Script to auto-create bldr.tom file for the core plan repo
@@ -16,13 +18,13 @@ if ARGV.length < 2
   exit
 end
 
-source_dir = ARGV[0]
-dest_dir = ARGV[1]
+source_dir = File.expand_path(ARGV[0])
+dest_dir = File.expand_path(ARGV[1])
 
-template = File.read('toml.erb')
+template = File.read(File.join(File.dirname(__FILE__), 'toml.erb'))
 renderer = ERB.new(template)
 
-destfile = File.open(File.join(dest_dir, 'bldr.toml'), 'w')
+destfile = File.open(File.join(dest_dir, '.bldr.toml'), 'w')
 
 Dir.chdir source_dir
 Dir.open '.' do |root|


### PR DESCRIPTION
It is impossible to guarantee that we can search a repository for
all of it's Plan Files so we must pivot to a mechanism where we
best guess where a plan file is and then ask the user to provide
a configuration file (`.bldr.toml`) which provides us a mapping of
plan file locations and any additional files/directories which, when
modified, will cause an auto-build for a project.

With this commit we no longer search the contents of a repository to
find all plan files and then attempt to read them in. We will now
look for a `.bldr.toml` and if one isn't found fallback to a default.

* With this change we now auto-build not only if a file at a trigger
  path is changed but also if the project's value for plan_path changes
* Don't sarch for `.bldr.toml`. It will only ever be available at
  the root of a repo so we shouldn't/don't need to search for it.
  If it's not in the root theres no config.
* Gather paginated results when searching for code and return them
  as a list of search items.

Closes #3637
