### PR TITLE
Emphasize GitHub App installation

### DIFF
--- a/components/builder-web/app/package/package-sidebar/_package-sidebar.component.scss
+++ b/components/builder-web/app/package/package-sidebar/_package-sidebar.component.scss
@@ -8,7 +8,7 @@
     margin-bottom: 30px;
   }
 
-  .latest-stable {
+  .platforms, .latest-stable {
 
     p {
       font-size: rem(14);

--- a/components/builder-web/app/package/package-sidebar/package-sidebar.component.html
+++ b/components/builder-web/app/package/package-sidebar/package-sidebar.component.html
@@ -11,6 +11,9 @@
   </div>
   <div class="platforms">
     <h3>Supported Platforms</h3>
+    <p *ngIf="platforms.length === 0">
+      None.
+    </p>
     <hab-platform-icon [platform]="platform" *ngFor="let platform of platforms"></hab-platform-icon>
   </div>
   <div class="latest-stable">

--- a/components/builder-web/app/shared/project-settings/_project-settings.component.scss
+++ b/components/builder-web/app/shared/project-settings/_project-settings.component.scss
@@ -1,4 +1,5 @@
 hab-project-settings {
+  @include row;
 
   h3 {
     text-transform: uppercase;
@@ -10,26 +11,28 @@ hab-project-settings {
     margin: 8px 0 12px;
 
     &.note {
+      @include row;
       position: relative;
       margin-top: 0;
-      padding: 14px 14px 14px 48px;
+      padding: 14px;
       background-color: $very-light-gray;
       border-radius: $global-radius;
       color: $dark-blue;
       margin-bottom: 18px;
 
       hab-icon {
-        position: absolute;
-        left: 14px;
-        top: 16px;
+        @include span-columns(1);
         width: 24px;
         height: 24px;
         color: $dark-gray;
       }
 
-      a {
-        color: $dark-blue;
-        text-decoration: underline;
+      span {
+        @include span-columns(8);
+
+        &.cta {
+          @include span-columns(3);
+        }
       }
     }
 
@@ -110,8 +113,6 @@ hab-project-settings {
   }
 
   .connecting {
-    @include span-columns(9);
-    @include omega;
 
     ol {
       background-color: $hab-blue;
@@ -204,6 +205,25 @@ hab-project-settings {
         font-size: rem(14);
         margin-right: 16px;
       }
+    }
+  }
+
+  .content {
+    @include span-columns(9);
+  }
+
+  .sidebar {
+    @include span-columns(3);
+    padding-left: 20px;
+    border-left: 1px solid $very-light-gray;
+
+    h3 {
+      margin-bottom: 16px;
+    }
+
+    a {
+      color: inherit;
+      text-decoration: underline;
     }
   }
 }

--- a/components/builder-web/app/shared/project-settings/project-settings.component.html
+++ b/components/builder-web/app/shared/project-settings/project-settings.component.html
@@ -1,139 +1,159 @@
-<section *ngIf="projectsEnabled">
-    <div class="connect" *ngIf="!project && !connecting">
-        <button md-raised-button color="primary" class="button" (click)="connect()">
-            Connect a plan file
-        </button>
-        <div *ngIf="name">
-            <p><strong>There are currently no Habitat plan files connected.</strong></p>
-            <p>If you have a plan file in a GitHub repo, connect it here for automated build jobs.</p>
-            <p>
-                <em>
-                    Don't have a plan file? Learn more about
-                    <a href="https://www.habitat.sh/docs/create-plans/">creating plan files</a> or
-                    <a href="{{ config['demo_app_url'] }}">try the demo app</a>.
-                </em>
-            </p>
+<div *ngIf="projectsEnabled">
+    <div class="content">
+        <div class="connect" *ngIf="!project && !connecting">
+            <button md-raised-button color="primary" class="button" (click)="connect()">
+                Connect a plan file
+            </button>
+            <div *ngIf="name">
+                <p><strong>There are currently no Habitat plan files connected.</strong></p>
+                <p>If you have a plan file in a GitHub repo, connect it here for automated build jobs.</p>
+                <p>
+                    <em>
+                        Don't have a plan file? Learn more about
+                        <a href="https://www.habitat.sh/docs/create-plans/">creating plan files</a> or
+                        <a href="{{ config['demo_app_url'] }}">try the demo app</a>.
+                    </em>
+                </p>
+            </div>
         </div>
-    </div>
-    <div class="connected-plans" *ngIf="project && !connecting">
-        <ul>
-            <li class="heading">
-                <h3 class="plan-path">Plan</h3>
-                <h3 class="plan-exports">&nbsp;</h3>
-                <h3 class="plan-status">Status</h3>
-                <h3 class="plan-actions">Actions</h3>
-            </li>
-            <li class="item">
-                <div class="plan-path">
-                    <hab-icon [symbol]="iconFor(project.plan_path)"></hab-icon>
-                    <span>{{ project.plan_path }}</span>
-                </div>
-                <div class="plan-exports">
-                    &nbsp;
-                </div>
-                <div class="plan-status">
-                    <hab-icon symbol="check" class="success"></hab-icon>
-                    <span>connected</span>
-                </div>
-                <div class="plan-actions">
-                    <hab-icon symbol="cancel" (click)="disconnect()"></hab-icon>
-                    <hab-icon symbol="settings" (click)="editConnection()"></hab-icon>
-                </div>
-            </li>
-        </ul>
-    </div>
-    <div class="connecting" *ngIf="connecting">
-        <form [formGroup]="form" #formValues="ngForm">
-            <p class="note">
-                <hab-icon symbol="github"></hab-icon>
-                To connect a plan, first install the <a href="{{ config['github_app_url'] }}" target="_blank">Habitat Builder GitHub app</a>
-                on your <a href="https://help.github.com/articles/installing-an-app-in-your-personal-account/" target="_blank">personal account</a>
-                or on any <a href="https://help.github.com/articles/installing-an-app-in-your-organization/" target="_blank">organization</a> of which
-                <em>you are the owner</em>.
-            </p>
-            <ol>
-                <li [class.active]="!selectedInstallation" (click)="clearConnection()">Select a GitHub repo</li>
-                <li [class.active]="selectedInstallation">Set path to Habitat plan file</li>
-            </ol>
-            <div class="installation" *ngIf="!selectedInstallation">
-                <h3>
+        <div class="connected-plans" *ngIf="project && !connecting">
+            <ul>
+                <li class="heading">
+                    <h3 class="plan-path">Plan</h3>
+                    <h3 class="plan-exports">&nbsp;</h3>
+                    <h3 class="plan-status">Status</h3>
+                    <h3 class="plan-actions">Actions</h3>
+                </li>
+                <li class="item">
+                    <div class="plan-path">
+                        <hab-icon [symbol]="iconFor(project.plan_path)"></hab-icon>
+                        <span>{{ project.plan_path }}</span>
+                    </div>
+                    <div class="plan-exports">
+                        &nbsp;
+                    </div>
+                    <div class="plan-status">
+                        <hab-icon symbol="check" class="success"></hab-icon>
+                        <span>connected</span>
+                    </div>
+                    <div class="plan-actions">
+                        <hab-icon symbol="cancel" (click)="disconnect()"></hab-icon>
+                        <hab-icon symbol="settings" (click)="editConnection()"></hab-icon>
+                    </div>
+                </li>
+            </ul>
+        </div>
+        <div class="connecting" *ngIf="connecting">
+            <form [formGroup]="form" #formValues="ngForm">
+                <p class="note">
                     <hab-icon symbol="github"></hab-icon>
-                    Select a GitHub Repository
-                </h3>
-                <div *ngIf="loading">
-                    <hab-icon symbol="loading" class="spinning"></hab-icon>
+                    <span class="info">
+                        In order to connect a plan file in your repo, you must first install the Habitat
+                        Builder GitHub app and allow access to that repository.
+                    </span>
+                    <span class="cta">
+                        <a href="{{ config['github_app_url'] }}" md-raised-button color="accent" class="button" target="_blank">
+                            Install GitHub App
+                        </a>
+                    </span>
+                </p>
+                <ol>
+                    <li [class.active]="!selectedInstallation" (click)="clearConnection()">Select a GitHub repo</li>
+                    <li [class.active]="selectedInstallation">Set path to Habitat plan file</li>
+                </ol>
+                <div class="installation" *ngIf="!selectedInstallation">
+                    <h3>
+                        GitHub Org / Repo
+                    </h3>
+                    <div *ngIf="loading">
+                        <hab-icon symbol="loading" class="spinning"></hab-icon>
+                    </div>
+                    <div *ngIf="!loading">
+                        <p *ngIf="installations.size === 0">
+                            It looks like you haven't yet installed the Habitat Builder app.
+                            <a href="{{ config['github_app_url'] }}" target="_blank">Install it on GitHub</a>, then come back here and
+                            <a class="try-again" (click)="connect()"><hab-icon symbol="loading"></hab-icon>try again</a>. (It may take a
+                            few minutes for the changes to be recognized.)
+                        </p>
+                        <div *ngIf="installations.size > 0">
+                            <p>
+                                Enter the name of the GitHub organization and repository that
+                                <strong>contains your Habitat plan file</strong>.
+                            </p>
+                            <hab-checking-input
+                                id="repo_path"
+                                name="repo_path"
+                                availableMessage="found."
+                                notAvailableMessage="not found. Please verify you've entered the name correctly and that the Habitat Builder GitHub app has been installed."
+                                displayName="GitHub installation"
+                                [form]="form"
+                                [pattern]="false"
+                                [maxLength]="false"
+                                [isAvailable]="doesRepoExist"
+                                [value]="selectedRepo"
+                                placeholder="{{username}}/example-app">
+                            </hab-checking-input>
+                        </div>
+                    </div>
                 </div>
-                <div *ngIf="!loading">
-                    <p *ngIf="installations.size === 0">
-                        It looks like you haven't yet installed the Habitat Builder app.
-                        <a href="{{ config['github_app_url'] }}" target="_blank">Install it on GitHub</a>, then come back here and
-                        <a class="try-again" (click)="connect()"><hab-icon symbol="loading"></hab-icon>try again</a>.
+                <div *ngIf="selectedInstallation">
+                    <a class="repo-link" href="{{ repoUrl }}" target="_blank">
+                        <hab-icon symbol="open-in-new"></hab-icon>
+                        Go to your repo
+                    </a>
+                    <h3>Path to Plan File</h3>
+                    <p>
+                        Enter the path to your plan file from the root of your repo. By default,
+                        we check for <code>habitat/plan.sh</code>.
                     </p>
-                    <p *ngIf="installations.size > 0">
-                        Enter the name of the GitHub organization and repository containing the Habitat plan you'd like to connect.
-                    </p>
-                    <div *ngIf="installations.size > 0">
+                    <div class="files">
                         <hab-checking-input
-                            id="repo_path"
-                            name="repo_path"
-                            availableMessage="found!"
-                            notAvailableMessage="not found. Make sure the repo is named correctly that Habitat Builder has permissions to read it."
-                            displayName="Repository"
+                            id="plan_path"
+                            name="plan_path"
+                            availableMessage="found."
+                            notAvailableMessage="does not exist in the repository."
+                            unmatchedMessage="must be named either plan.sh or plan.ps1."
+                            displayName="Plan file"
                             [form]="form"
                             [pattern]="false"
                             [maxLength]="false"
-                            [isAvailable]="doesRepoExist"
-                            [value]="selectedRepo"
-                            placeholder="{{username}}/example-app">
+                            [isAvailable]="doesFileExist"
+                            [value]="selectedPath">
                         </hab-checking-input>
                     </div>
+                    <hab-visibility-selector
+                        [setting]="visibility"
+                        (changed)="settingChanged($event)">
+                    </hab-visibility-selector>
+                    <hab-docker-export-settings #docker
+                        *ngIf="selectedInstallation"
+                        [integrations]="integrations"
+                        [current]="dockerSettings"
+                        [enabled]="dockerEnabled">
+                    </hab-docker-export-settings>
                 </div>
-            </div>
-            <div *ngIf="selectedInstallation">
-                <a class="repo-link" href="{{ repoUrl }}" target="_blank">
-                    <hab-icon symbol="open-in-new"></hab-icon>
-                    Go to your repo
-                </a>
-                <h3>Path to Plan File</h3>
-                <p>
-                    Enter the path to your plan file from the root of your repo. By default,
-                    we check for <code>habitat/plan.sh</code>.
-                </p>
-                <div class="files">
-                    <hab-checking-input
-                        id="plan_path"
-                        name="plan_path"
-                        availableMessage="found!"
-                        notAvailableMessage="does not exist in the repository."
-                        unmatchedMessage="must be named either plan.sh or plan.ps1."
-                        displayName="Plan file"
-                        [form]="form"
-                        [pattern]="false"
-                        [maxLength]="false"
-                        [isAvailable]="doesFileExist"
-                        [value]="selectedPath">
-                    </hab-checking-input>
+                <div class="controls">
+                    <button *ngIf="!selectedInstallation" md-raised-button color="primary" class="button" (click)="selectRepo()" [disabled]="!validRepo">
+                        Next &raquo;
+                    </button>
+                    <button *ngIf="selectedInstallation" md-raised-button color="primary" class="button" (click)="saveConnection()" [disabled]="!validProject">
+                        {{ connectButtonLabel }} Connection
+                    </button>
+                    <a (click)="clearConnection()">Cancel</a>
                 </div>
-                <hab-visibility-selector
-                    [setting]="visibility"
-                    (changed)="settingChanged($event)">
-                </hab-visibility-selector>
-                <hab-docker-export-settings #docker
-                    *ngIf="selectedInstallation"
-                    [integrations]="integrations"
-                    [current]="dockerSettings"
-                    [enabled]="dockerEnabled">
-                </hab-docker-export-settings>
-            </div>
-            <div class="controls">
-                <button *ngIf="!selectedInstallation" md-raised-button color="primary" class="button" (click)="selectRepo()" [disabled]="!validRepo">
-                    Next &raquo;
-                </button>
-                <button *ngIf="selectedInstallation" md-raised-button color="primary" class="button" (click)="saveConnection()" [disabled]="!validProject">
-                    {{ connectButtonLabel }} Connection
-                </button>
-                <a (click)="clearConnection()">Cancel</a>
-            </div>
-        </form>
+            </form>
+        </div>
     </div>
-</section>
+    <div class="sidebar" *ngIf="connecting">
+        <h3>About Packages</h3>
+        <p>
+            In order to connect a plan, you will need to have a Habitat plan file in a GitHub
+            repo and install the <a href="{{ config['github_app_url'] }}" target="_blank">Habitat GitHub app</a>.
+        </p>
+        <p>
+            Don't have a plan file? Learn about
+            <a href="{{config['docs_url']}}/developing-packages/" target="_blank">developing packages</a> or
+            <a href="{{ config['demo_app_url'] }}" target="_blank">try the demo app</a>.
+        </p>
+    </div>
+</div>

--- a/components/builder-web/stylesheets/_checking-input.scss
+++ b/components/builder-web/stylesheets/_checking-input.scss
@@ -17,10 +17,13 @@
 input.hab-checking-input--input {
   padding-right: $base-spacing * 1.2;
 
+  &:focus {
+    box-shadow: none !important;
+  }
+
   &.loading {
     &:focus {
       border-color: $light-gray;
-      box-shadow: $form-box-shadow-focus-loading;
     }
   }
 }


### PR DESCRIPTION
This updates some copy and makes the call to action clearer. Also adds a sidebar with instructions and handy links and includes a fix for handling plans without any packages (so no “Supported Platforms”) yet.

Signed-off-by: Christian Nunciato <cnunciato@chef.io>

Fixes #3664.

![](https://media.tenor.com/images/e491b9843e45edaf27bda8773d20855b/tenor.gif)