### PR TITLE
Post-run only runs after a successful health check + runs till success

### DIFF
--- a/components/sup/src/manager/service/health.rs
+++ b/components/sup/src/manager/service/health.rs
@@ -28,6 +28,12 @@ impl Default for HealthCheck {
     }
 }
 
+impl HealthCheck {
+    pub fn success(&self) -> bool {
+        return self == &HealthCheck::Ok;
+    }
+}
+
 impl From<i8> for HealthCheck {
     fn from(value: i8) -> HealthCheck {
         match value {

--- a/components/sup/src/manager/service/hooks.rs
+++ b/components/sup/src/manager/service/hooks.rs
@@ -53,12 +53,18 @@ where
     fs::svc_logs_path(service_group.service()).join(format!("{}.stderr.log", T::file_name()))
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, Serialize)]
 pub struct ExitCode(i32);
 
 impl Default for ExitCode {
     fn default() -> ExitCode {
         ExitCode(-1)
+    }
+}
+
+impl ExitCode {
+    pub fn success(&self) -> bool {
+        return self.0 == 0;
     }
 }
 

--- a/components/sup/src/manager/service/mod.rs
+++ b/components/sup/src/manager/service/mod.rs
@@ -44,7 +44,7 @@ use time::Timespec;
 
 use super::Sys;
 use self::config::CfgRenderer;
-use self::hooks::{HOOK_PERMISSIONS, Hook, HookTable};
+use self::hooks::{HOOK_PERMISSIONS, Hook, HookTable, ExitCode};
 use self::supervisor::Supervisor;
 use error::{Error, Result, SupError};
 use fs;
@@ -85,6 +85,7 @@ pub struct Service {
     #[serde(skip_serializing)]
     config_renderer: CfgRenderer,
     health_check: HealthCheck,
+    post_run_exit_code: ExitCode,
     last_election_status: ElectionStatus,
     needs_reload: bool,
     needs_reconfiguration: bool,
@@ -132,6 +133,7 @@ impl Service {
                 fs::svc_hooks_path(&service_group.service()),
             ),
             initialized: false,
+            post_run_exit_code: ExitCode::default(),
             last_election_status: ElectionStatus::None,
             needs_reload: false,
             needs_reconfiguration: false,
@@ -495,11 +497,11 @@ impl Service {
 
     fn post_run(&mut self) {
         if let Some(ref hook) = self.hooks.post_run {
-            hook.run(
+            self.post_run_exit_code = hook.run(
                 &self.service_group,
                 &self.pkg,
                 self.svc_encrypted_password.as_ref(),
-            );
+            )
         }
     }
 
@@ -628,8 +630,9 @@ impl Service {
             self.initialize();
             if self.initialized {
                 self.start(launcher);
-                self.post_run();
             }
+        } else if self.health_check.success() && !self.post_run_exit_code.success() {
+            self.post_run();
         } else {
             self.check_process();
             if Instant::now().duration_since(self.last_health_check) >= *HEALTH_CHECK_INTERVAL {
@@ -721,6 +724,7 @@ impl Service {
             }
         };
         self.last_health_check = Instant::now();
+        self.health_check = check_result;
         self.cache_health_check(check_result);
     }
 


### PR DESCRIPTION
Also fixes the health_check flag, which is never updated (updates only go to the cache previously)

Please note that if there is no post-run hook the post-run hook function
will still get hit once per tick - is this a bad thing?

This was originally started in PR [3001](https://github.com/habitat-sh/habitat/pull/3001)

Signed-off-by: James Sewell <james.sewell@gmail.com>