### PR TITLE
Properly find plan file in GH Hook from plan_path

### DIFF
--- a/components/builder-api/src/github.rs
+++ b/components/builder-api/src/github.rs
@@ -271,7 +271,7 @@ fn read_plans(
 ) -> Vec<Plan> {
     let mut plans = Vec::with_capacity(config.projects().len());
     for project in config.triggered_by(hook.branch(), hook.changed().as_slice()) {
-        if let Some(plan) = read_plan(github, token, hook, project.plan_path.as_str()) {
+        if let Some(plan) = read_plan(github, token, hook, &project.plan_file().to_string_lossy()) {
             plans.push(plan)
         }
     }

--- a/components/github-api-client/src/client.rs
+++ b/components/github-api-client/src/client.rs
@@ -296,7 +296,7 @@ where
     let mut payload = jwt::Payload::new();
     let header = jwt::Header::new(jwt::Algorithm::RS256);
     let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
-    let expiration = now + Duration::from_secs(10 * 60);
+    let expiration = now + Duration::from_secs(10 * 10);
     payload.insert("iat".to_string(), now.as_secs().to_string());
     payload.insert("exp".to_string(), expiration.as_secs().to_string());
     payload.insert("iss".to_string(), app_id.to_string());


### PR DESCRIPTION
My recent change for allowing a `plan_path` to be configured in
the `.bldr.toml` was missing one important piece: how to find from
there the plan file. This commit adds a public function that the
github hook handler leverages to find the appropriate file

![tenor-140778512](https://user-images.githubusercontent.com/54036/31427013-a19eccbe-ae1a-11e7-95ea-0077fb5c8d79.gif)
