### PR TITLE
Improve "app" configuration for all Builder services

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1267,6 +1267,7 @@ dependencies = [
  "serde 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zmq 0.8.2 (git+https://github.com/erickt/rust-zmq?branch=release/v0.8)",

--- a/components/builder-api/src/github.rs
+++ b/components/builder-api/src/github.rs
@@ -248,7 +248,15 @@ fn read_bldr_config(github: &GitHubClient, token: &str, hook: &GitHubWebhookPush
     match github.contents(token, hook.repository.id, BLDR_CFG) {
         Ok(Some(contents)) => {
             match contents.decode() {
-                Ok(ref bytes) => BuildCfg::from_slice(bytes).unwrap_or_default(),
+                Ok(ref bytes) => {
+                    match BuildCfg::from_slice(bytes) {
+                        Ok(cfg) => cfg,
+                        Err(err) => {
+                            debug!("unable to parse bldr.toml, {}", err);
+                            BuildCfg::default()
+                        }
+                    }
+                }
                 Err(err) => {
                     debug!("unable to read bldr.toml, {}", err);
                     BuildCfg::default()

--- a/components/builder-db/src/config.rs
+++ b/components/builder-db/src/config.rs
@@ -18,7 +18,9 @@ use std::net::{Ipv4Addr, IpAddr};
 use num_cpus;
 use postgres::params::{ConnectParams, Host, IntoConnectParams};
 
-#[derive(Debug, Deserialize)]
+pub use protocol::sharding::ShardId;
+
+#[derive(Clone, Debug, Deserialize)]
 #[serde(default)]
 pub struct DataStoreCfg {
     pub host: IpAddr,

--- a/components/builder-jobsrv/habitat/config/config.toml
+++ b/components/builder-jobsrv/habitat/config/config.toml
@@ -1,5 +1,7 @@
 key_dir = "{{pkg.svc_files_path}}"
 
+[app]
+{{toToml cfg.app}}
 {{~#eachAlive bind.router.members as |member|}}
 [[routers]]
 host = "{{member.sys.ip}}"

--- a/components/builder-jobsrv/habitat/default.toml
+++ b/components/builder-jobsrv/habitat/default.toml
@@ -1,5 +1,8 @@
 log_level = "info"
 
+[app]
+shards = [0]
+
 [net]
 worker_command_listen = "0.0.0.0"
 worker_command_port = 5566

--- a/components/builder-jobsrv/src/data_store.rs
+++ b/components/builder-jobsrv/src/data_store.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 
 use chrono::{DateTime, UTC};
 use db::async::{AsyncServer, EventOutcome};
+use db::config::{DataStoreCfg, ShardId};
 use db::error::{Error as DbError, Result as DbResult};
 use db::migration::Migrator;
 use db::pool::Pool;
@@ -30,7 +31,6 @@ use protocol::{originsrv, jobsrv, scheduler};
 use protocol::originsrv::Pageable;
 use protobuf::ProtobufEnum;
 
-use config::Config;
 use error::{Result, Error};
 
 /// DataStore inherints being Send + Sync by virtue of having only one member, the pool itself.
@@ -51,8 +51,12 @@ impl DataStore {
     ///
     /// * Can fail if the pool cannot be created
     /// * Blocks creation of the datastore on the existince of the pool; might wait indefinetly.
-    pub fn new(config: &Config, router_pipe: Arc<String>) -> Result<DataStore> {
-        let pool = Pool::new(&config.datastore, config.shards.clone())?;
+    pub fn new(
+        cfg: &DataStoreCfg,
+        shards: Vec<ShardId>,
+        router_pipe: Arc<String>,
+    ) -> Result<DataStore> {
+        let pool = Pool::new(cfg, shards)?;
         let ap = pool.clone();
         Ok(DataStore {
             pool: pool,

--- a/components/builder-originsrv/habitat/config/config.toml
+++ b/components/builder-originsrv/habitat/config/config.toml
@@ -1,5 +1,5 @@
-shards = {{toToml cfg.shards}}
-
+[app]
+{{toToml cfg.app}}
 {{~#eachAlive bind.router.members as |member|}}
 [[routers]]
 host = "{{member.sys.ip}}"

--- a/components/builder-originsrv/habitat/default.toml
+++ b/components/builder-originsrv/habitat/default.toml
@@ -1,4 +1,6 @@
 log_level = "info"
+
+[app]
 shards = []
 
 [datastore]

--- a/components/builder-originsrv/src/data_store.rs
+++ b/components/builder-originsrv/src/data_store.rs
@@ -18,10 +18,11 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use bldr_core::helpers::transition_visibility;
-use db::pool::Pool;
 use db::async::{AsyncServer, EventOutcome};
-use db::migration::Migrator;
+use db::config::{DataStoreCfg, ShardId};
 use db::error::{Error as DbError, Result as DbResult};
+use db::migration::Migrator;
+use db::pool::Pool;
 use hab_net::conn::{RouteClient, RouteConn};
 use hab_net::{ErrCode, NetError};
 use hab_core::package::PackageIdent;
@@ -32,7 +33,6 @@ use protocol::originsrv::Pageable;
 use postgres;
 use protobuf;
 
-use config::Config;
 use error::{SrvError, SrvResult};
 use migrations;
 
@@ -49,8 +49,12 @@ impl Drop for DataStore {
 }
 
 impl DataStore {
-    pub fn new(config: &Config, router_pipe: Arc<String>) -> SrvResult<DataStore> {
-        let pool = Pool::new(&config.datastore, config.shards.clone())?;
+    pub fn new(
+        cfg: &DataStoreCfg,
+        shards: Vec<ShardId>,
+        router_pipe: Arc<String>,
+    ) -> SrvResult<DataStore> {
+        let pool = Pool::new(&cfg, shards)?;
         let ap = pool.clone();
         Ok(DataStore {
             pool: pool,

--- a/components/builder-scheduler/habitat/config/config.toml
+++ b/components/builder-scheduler/habitat/config/config.toml
@@ -1,5 +1,7 @@
 log_path = "{{cfg.log_path}}"
 
+[app]
+{{toToml cfg.app}}
 {{~#eachAlive bind.router.members as |member|}}
 [[routers]]
 host = "{{member.sys.ip}}"

--- a/components/builder-scheduler/habitat/default.toml
+++ b/components/builder-scheduler/habitat/default.toml
@@ -1,6 +1,9 @@
 log_level = "info"
 log_path = "/tmp"
 
+[app]
+shards = [0]
+
 [datastore]
 user = "hab"
 password = ""

--- a/components/builder-scheduler/src/data_store.rs
+++ b/components/builder-scheduler/src/data_store.rs
@@ -15,6 +15,7 @@
 use std::sync::Arc;
 
 use chrono::{DateTime, UTC};
+use db::config::DataStoreCfg;
 use db::pool::Pool;
 use db::migration::Migrator;
 use postgres;
@@ -23,7 +24,6 @@ use protocol::jobsrv::{Job, JobState};
 use protocol::scheduler::*;
 use protobuf::RepeatedField;
 
-use config::Config;
 use error::{SrvError, SrvResult};
 
 // DataStore inherits Send + Sync by virtue of having only one member, the pool itself.
@@ -37,8 +37,8 @@ impl DataStore {
     ///
     /// * Can fail if the pool cannot be created
     /// * Blocks creation of the datastore on the existince of the pool; might wait indefinetly.
-    pub fn new(config: &Config) -> SrvResult<DataStore> {
-        let pool = Pool::new(&config.datastore, vec![0])?;
+    pub fn new(config: &DataStoreCfg) -> SrvResult<DataStore> {
+        let pool = Pool::new(config, vec![0])?;
         Ok(DataStore { pool: pool })
     }
 

--- a/components/builder-scheduler/src/migration.rs
+++ b/components/builder-scheduler/src/migration.rs
@@ -54,7 +54,7 @@ impl DataMigrator {
 
 pub fn run(config: Config) -> SrvResult<()> {
     let datastore = {
-        DataStore::new(&config)?
+        DataStore::new(&config.datastore)?
     };
     datastore.setup()?;
 

--- a/components/builder-sessionsrv/habitat/config/config.toml
+++ b/components/builder-sessionsrv/habitat/config/config.toml
@@ -1,4 +1,10 @@
-shards = {{toToml cfg.shards}}
+[app]
+{{toToml cfg.app}}
+{{~#eachAlive bind.router.members as |member|}}
+[[routers]]
+host = "{{member.sys.ip}}"
+port = {{member.cfg.port}}
+{{~/eachAlive}}
 
 [permissions]
 {{toToml cfg.permissions}}
@@ -6,12 +12,6 @@ shards = {{toToml cfg.shards}}
 [github]
 app_private_key = "{{pkg.svc_files_path}}/builder-github-app.pem"
 {{toToml cfg.github}}
-
-{{~#eachAlive bind.router.members as |member|}}
-[[routers]]
-host = "{{member.sys.ip}}"
-port = {{member.cfg.port}}
-{{~/eachAlive}}
 
 [datastore]
 {{toToml cfg.datastore}}

--- a/components/builder-sessionsrv/habitat/default.toml
+++ b/components/builder-sessionsrv/habitat/default.toml
@@ -1,4 +1,6 @@
 log_level = "info"
+
+[app]
 shards = []
 
 [permissions]

--- a/components/builder-sessionsrv/src/data_store.rs
+++ b/components/builder-sessionsrv/src/data_store.rs
@@ -16,13 +16,13 @@
 
 use std::sync::Arc;
 
+use db::config::{DataStoreCfg, ShardId};
 use db::pool::Pool;
 use db::migration::Migrator;
 use protocol::sessionsrv;
 use postgres;
 use protobuf;
 
-use config::Config;
 use error::{SrvError, SrvResult};
 use migrations;
 
@@ -32,8 +32,8 @@ pub struct DataStore {
 }
 
 impl DataStore {
-    pub fn new(config: &Config) -> SrvResult<DataStore> {
-        let pool = Pool::new(&config.datastore, config.shards.clone())?;
+    pub fn new(cfg: &DataStoreCfg, shards: Vec<ShardId>) -> SrvResult<DataStore> {
+        let pool = Pool::new(&cfg, shards)?;
         Ok(DataStore { pool: pool })
     }
 

--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -18,6 +18,7 @@ protobuf = "*"
 serde = "*"
 serde_derive = "*"
 time = "*"
+toml = "*"
 unicase = "*"
 uuid = { version = "*", features = ["v4"] }
 

--- a/components/net/src/lib.rs
+++ b/components/net/src/lib.rs
@@ -31,6 +31,7 @@ extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 extern crate time as simple_time;
+extern crate toml;
 extern crate unicase;
 extern crate uuid;
 extern crate zmq;


### PR DESCRIPTION
This is a lot of general code health updates but they primarily
came from tracking down the socket issues we see under load. I found
that we were locking worker-count to num-cpu and a number of
our instances only have 2 cpus.

* Changed AppCfg from a trait to a struct. It is now the same
  mechanism to configure the app portion of a Builder server config
  as it is the database, net, permissions, etc
* Simplify traits for defining App ServerState and an App Dispatcher
* Set default worker-count to num-cpu * 8. It was previously capped
  at num-cpu due to a very old way we were starting the database
  pool
* worker-count is now a configurable from the plan

![tenor-145140668](https://user-images.githubusercontent.com/54036/31440300-45edc22e-ae44-11e7-89ac-a565ebd4d0cf.gif)

Another attempt at fixing #3561
