### PR TITLE
Fix missing router config from services

### DIFF
--- a/components/builder-jobsrv/habitat/config/config.toml
+++ b/components/builder-jobsrv/habitat/config/config.toml
@@ -2,11 +2,11 @@ key_dir = "{{pkg.svc_files_path}}"
 
 [app]
 {{toToml cfg.app}}
-{{~#eachAlive bind.router.members as |member|}}
-[[routers]]
-host = "{{member.sys.ip}}"
-port = {{member.cfg.port}}
-{{~/eachAlive}}
+routers = [
+  {{~#eachAlive bind.router.members as |member|}}
+  { host = "{{member.sys.ip}}", port = {{member.cfg.port}} },
+  {{~/eachAlive}}
+]
 
 [datastore]
 {{toToml cfg.datastore}}

--- a/components/builder-originsrv/habitat/config/config.toml
+++ b/components/builder-originsrv/habitat/config/config.toml
@@ -1,10 +1,10 @@
 [app]
 {{toToml cfg.app}}
-{{~#eachAlive bind.router.members as |member|}}
-[[routers]]
-host = "{{member.sys.ip}}"
-port = {{member.cfg.port}}
-{{~/eachAlive}}
+routers = [
+  {{~#eachAlive bind.router.members as |member|}}
+  { host = "{{member.sys.ip}}", port = {{member.cfg.port}} },
+  {{~/eachAlive}}
+]
 
 [datastore]
 {{toToml cfg.datastore}}

--- a/components/builder-scheduler/habitat/config/config.toml
+++ b/components/builder-scheduler/habitat/config/config.toml
@@ -2,11 +2,11 @@ log_path = "{{cfg.log_path}}"
 
 [app]
 {{toToml cfg.app}}
-{{~#eachAlive bind.router.members as |member|}}
-[[routers]]
-host = "{{member.sys.ip}}"
-port = {{member.cfg.port}}
-{{~/eachAlive}}
+routers = [
+  {{~#eachAlive bind.router.members as |member|}}
+  { host = "{{member.sys.ip}}", port = {{member.cfg.port}} },
+  {{~/eachAlive}}
+]
 
 [datastore]
 {{toToml cfg.datastore}}

--- a/components/builder-sessionsrv/habitat/config/config.toml
+++ b/components/builder-sessionsrv/habitat/config/config.toml
@@ -1,10 +1,10 @@
 [app]
 {{toToml cfg.app}}
-{{~#eachAlive bind.router.members as |member|}}
-[[routers]]
-host = "{{member.sys.ip}}"
-port = {{member.cfg.port}}
-{{~/eachAlive}}
+routers = [
+  {{~#eachAlive bind.router.members as |member|}}
+  { host = "{{member.sys.ip}}", port = {{member.cfg.port}} },
+  {{~/eachAlive}}
+]
 
 [permissions]
 {{toToml cfg.permissions}}


### PR DESCRIPTION
Change the [[routers]] syntax for configuring an array of hashes under
the app config key for all Builder services. This syntax isn't valid when
used in conjunction with a map itself