### PR TITLE
Handle trailing spaces in repo names

### DIFF
--- a/components/builder-web/app/shared/project-settings/project-settings.component.ts
+++ b/components/builder-web/app/shared/project-settings/project-settings.component.ts
@@ -233,7 +233,7 @@ export class ProjectSettingsComponent implements OnChanges {
     }
 
     selectRepo() {
-        this.selectedInstallation = this.installations.find(i => i.get("full_name") === this.repoField.value);
+        this.selectedInstallation = this.installations.find(i => i.get("full_name") === this.repoField.value.trim());
         setTimeout(() => {
             if (this.planField) {
                 this.planField.markAsDirty();


### PR DESCRIPTION
Currently, the field validation succeeds based on a trimmed value, but the selection isn't, so selecting a matching installation fails. This fixes that.

Signed-off-by: Christian Nunciato <cnunciato@chef.io>

Fixes #3688.

![](https://media.tenor.com/images/aa12bd63dff7ed1c0816b2e8235e9944/tenor.gif)