### PR TITLE
Handle the absence of origin keys in Builder UI

### DIFF
--- a/components/builder-web/app/actions/origins.ts
+++ b/components/builder-web/app/actions/origins.ts
@@ -121,7 +121,7 @@ export function deleteOriginMember(origin: string, member: string, token: string
     };
 }
 
-export function createOrigin(body: object, token: string, generateKeys: boolean, isFirstOrigin = false, callback: Function = (origin) => {}) {
+export function createOrigin(body: object, token: string, isFirstOrigin = false, callback: Function = (origin) => {}) {
     return dispatch => {
         dispatch(setCurrentOriginCreatingFlag(true));
 
@@ -138,10 +138,6 @@ export function createOrigin(body: object, token: string, generateKeys: boolean,
                 body: origin["default"] ? `'${origin["name"]}' is now the default origin` : "",
                 type: SUCCESS,
             }));
-
-            if (generateKeys) {
-                dispatch(generateOriginKeys(origin["name"], token));
-            }
 
             callback(origin);
         }).catch(error => {
@@ -234,7 +230,7 @@ export function generateOriginKeys(origin: string, token: string) {
                 dispatch(fetchOriginPublicKeys(origin, token));
                 dispatch(addNotification({
                     title: "Origin keys generated",
-                    body: "Your public and private keys have been created and can be downloaded now.",
+                    body: "Your public and private keys have been created and are available for download.",
                     type: SUCCESS
                 }));
             }).catch(error => {

--- a/components/builder-web/app/origin/origin-create-page/_origin-create-page.component.scss
+++ b/components/builder-web/app/origin/origin-create-page/_origin-create-page.component.scss
@@ -31,14 +31,10 @@
     font-size: rem(12);
   }
 
-  p, md-checkbox {
+  p {
     display: block;
     font-size: rem(14);
     margin-bottom: 12px;
-  }
-
-  label {
-    text-transform: none;
   }
 
   hab-checking-input {
@@ -54,5 +50,10 @@
         margin-left: 0;
       }
     }
+  }
+
+  hab-icon[symbol="info-outline"] {
+    color: $hab-blue;
+    margin-right: 4px;
   }
 }

--- a/components/builder-web/app/origin/origin-create-page/origin-create-page.component.html
+++ b/components/builder-web/app/origin/origin-create-page/origin-create-page.component.html
@@ -33,9 +33,10 @@
         <p>
           Required for signing .hart files. Available for download once origin is created.
         </p>
-        <md-checkbox checked="true" formControlName="generateKeys">
-          Yes, generate an origin key pair for me now
-        </md-checkbox>
+        <p>
+          <hab-icon symbol="info-outline"></hab-icon>
+          A key pair will be generated automatically and stored under the Keys tab.
+        </p>
       </section>
       <section>
         <button md-raised-button color="primary" [disabled]="!form.valid || creating" (click)="createOrigin">

--- a/components/builder-web/app/origin/origin-create-page/origin-create-page.component.ts
+++ b/components/builder-web/app/origin/origin-create-page/origin-create-page.component.ts
@@ -35,10 +35,7 @@ export class OriginCreatePageComponent implements AfterViewInit, OnInit {
 
     constructor(private formBuilder: FormBuilder, private store: AppStore, private router: Router) {
         this.api = new BuilderApiClient(this.token);
-
-        this.form = formBuilder.group({
-            generateKeys: true
-        });
+        this.form = formBuilder.group({});
 
         this.isOriginAvailable = origin => {
             return this.api.isOriginAvailable(origin);
@@ -75,7 +72,7 @@ export class OriginCreatePageComponent implements AfterViewInit, OnInit {
     createOrigin(origin) {
         origin.default_package_visibility = this.visibility;
 
-        this.store.dispatch(createOrigin(origin, this.token, this.form.get("generateKeys").value, this.isFirstOrigin, (origin) => {
+        this.store.dispatch(createOrigin(origin, this.token, this.isFirstOrigin, (origin) => {
             this.router.navigate(["/origins", origin.name]);
         }));
     }

--- a/components/builder-web/app/origin/origin-page/origin-keys-tab/_origin-keys-tab.component.scss
+++ b/components/builder-web/app/origin/origin-page/origin-keys-tab/_origin-keys-tab.component.scss
@@ -1,16 +1,35 @@
 .origin-keys-tab {
+  @include row;
+
+  .page-content {
+    @include span-columns(9);
+  }
+
+  .page-sidebar {
+    @include span-columns(3);
+    padding-left: 20px;
+    border-left: 1px solid $very-light-gray;
+
+    p {
+      margin-bottom: 0;
+    }
+
+    a {
+      color: inherit;
+      text-decoration: underline;
+    }
+  }
+
+  h3 {
+    font-size: rem(12);
+    text-transform: uppercase;
+  }
 
   section {
     margin-bottom: 28px;
 
     &.generate {
       margin-bottom: 18px;
-    }
-
-    h3 {
-      margin-bottom: 0;
-      font-size: rem(12);
-      text-transform: uppercase;
     }
 
     button {

--- a/components/builder-web/app/origin/origin-page/origin-keys-tab/origin-keys-tab.component.html
+++ b/components/builder-web/app/origin/origin-page/origin-keys-tab/origin-keys-tab.component.html
@@ -1,63 +1,81 @@
 <div class="page-body origin-keys-tab">
-  <section class="generate" *ngIf="memberOfOrigin">
-    <button md-raised-button color="primary" (click)="generateKeys()">
-      Generate a key pair
-    </button>
-  </section>
-  <section class="private" *ngIf="memberOfOrigin">
-    <ul>
-      <li>
-        <h3 class="key">Private Key</h3>
-        <h3 class="actions">Actions</h3>
-      </li>
-      <li *ngIf="!privateKey">
-        <span class="none">
-          No private key found.
-        </span>
-      </li>
-      <li *ngIf="privateKey">
-        <span class="key">
-          <hab-icon symbol="visibility-off"></hab-icon>
-          <span>{{ privateKey }}</span>
-        </span>
-        <span class="actions">
-          <a (click)="downloadPrivateKey()">
-            <hab-icon symbol="file-download" title="Download this key"></hab-icon>
-          </a>
-        </span>
-      </li>
-    </ul>
-    <button md-raised-button color="basic" (click)="openKeyAddForm('private')" *ngIf="memberOfOrigin">
-      <hab-icon symbol="file-upload"></hab-icon>
-      Upload a private key
-    </button>
-  </section>
-  <section class="public">
-    <ul>
-      <li>
-        <h3 class="key">Public Keys</h3>
-        <h3 class="actions">Actions</h3>
-      </li>
-      <li class="none" *ngIf="publicKeys.size === 0">
+  <div class="page-content">
+    <section class="generate" *ngIf="memberOfOrigin">
+      <button md-raised-button color="primary" (click)="generateKeys()">
+        Generate a key pair
+      </button>
+    </section>
+    <section class="private" *ngIf="memberOfOrigin">
+      <ul>
+        <li>
+          <h3 class="key">Private Key</h3>
+          <h3 class="actions">Actions</h3>
+        </li>
+        <li *ngIf="!privateKey">
           <span class="none">
-            No public keys found.
+            <strong>No private key found</strong>.
+            You can generate a key pair above.
           </span>
-      </li>
-      <li *ngFor="let key of publicKeys">
-        <span class="key">
-          <hab-icon symbol="visibility"></hab-icon>
-          <span>{{ key.origin }}-{{ key.revision }}</span>
-        </span>
-        <span class="actions">
-          <a href="{{ urlFor(key) }}">
-            <hab-icon symbol="file-download" title="Download this key"></hab-icon>
-          </a>
-        </span>
-      </li>
-    </ul>
-    <button md-raised-button color="basic" *ngIf="memberOfOrigin" (click)="openKeyAddForm('public')">
-      <hab-icon symbol="file-upload"></hab-icon>
-      Upload a public key
-    </button>
-  </section>
+        </li>
+        <li *ngIf="privateKey">
+          <span class="key">
+            <hab-icon symbol="visibility-off"></hab-icon>
+            <span>{{ privateKey }}</span>
+          </span>
+          <span class="actions">
+            <a (click)="downloadPrivateKey()">
+              <hab-icon symbol="file-download" title="Download this key"></hab-icon>
+            </a>
+          </span>
+        </li>
+      </ul>
+      <button md-raised-button color="basic" (click)="openKeyAddForm('private')" *ngIf="memberOfOrigin">
+        <hab-icon symbol="file-upload"></hab-icon>
+        Upload a private key
+      </button>
+    </section>
+    <section class="public">
+      <ul>
+        <li>
+          <h3 class="key">Public Keys</h3>
+          <h3 class="actions">Actions</h3>
+        </li>
+        <li class="none" *ngIf="publicKeys.size === 0">
+            <span class="none">
+              <strong>No public key found</strong>.
+              You can generate a key pair above.
+            </span>
+        </li>
+        <li *ngFor="let key of publicKeys">
+          <span class="key">
+            <hab-icon symbol="visibility"></hab-icon>
+            <span>{{ key.origin }}-{{ key.revision }}</span>
+          </span>
+          <span class="actions">
+            <a href="{{ urlFor(key) }}">
+              <hab-icon symbol="file-download" title="Download this key"></hab-icon>
+            </a>
+          </span>
+        </li>
+      </ul>
+      <button md-raised-button color="basic" *ngIf="memberOfOrigin" (click)="openKeyAddForm('public')">
+        <hab-icon symbol="file-upload"></hab-icon>
+        Upload a public key
+      </button>
+    </section>
+  </div>
+  <div class="page-sidebar">
+    <h3>About Origin Keys</h3>
+    <p>
+      Origin keys are used to sign .hart files, providing the capability to
+      verify their authenticity at both build and runtime.
+    </p>
+    <p>
+      Only one <strong>private key</strong> exists for an origin at any given time.
+    </p>
+    <p>
+      Read the docs for more information on
+      <a href="{{ config['docs_url'] }}/glossary/#sts=Origin Keys" target="_blank">Origin Keys</a>.
+    </p>
+  </div>
 </div>

--- a/components/builder-web/app/origin/origin-page/origin-keys-tab/origin-keys-tab.component.ts
+++ b/components/builder-web/app/origin/origin-page/origin-keys-tab/origin-keys-tab.component.ts
@@ -52,6 +52,10 @@ export class OriginKeysTabComponent implements OnInit, OnDestroy {
         this.sub.unsubscribe();
     }
 
+    get config() {
+        return config;
+    }
+
     get memberOfOrigin() {
         return !!this.origins.find(origin => origin["name"] === this.origin);
     }

--- a/components/builder-web/app/origin/origin-page/origin-members-tab/_origin-members-tab.component.scss
+++ b/components/builder-web/app/origin/origin-page/origin-members-tab/_origin-members-tab.component.scss
@@ -98,5 +98,11 @@
   .members-sidebar {
     @include span-columns(3);
     font-size: rem(14);
+    padding-left: 20px;
+    border-left: 1px solid $very-light-gray;
+
+    p {
+      margin-bottom: 0;
+    }
   }
 }

--- a/components/builder-web/app/shared/project-settings/_project-settings.component.scss
+++ b/components/builder-web/app/shared/project-settings/_project-settings.component.scss
@@ -32,6 +32,7 @@ hab-project-settings {
 
         &.cta {
           @include span-columns(3);
+          text-align: center;
         }
       }
     }
@@ -44,9 +45,24 @@ hab-project-settings {
 
   .connect {
     margin-bottom: 14px;
+    font-size: rem(14);
 
     button {
       margin-bottom: 12px;
+    }
+
+    .no-keys {
+      color: $hab-blue;
+      margin-left: 8px;
+
+      hab-icon {
+        margin-right: 4px;
+      }
+
+      a {
+        color: $hab-blue;
+        text-decoration: underline;
+      }
     }
   }
 

--- a/components/builder-web/app/shared/project-settings/project-settings.component.html
+++ b/components/builder-web/app/shared/project-settings/project-settings.component.html
@@ -1,9 +1,13 @@
 <div *ngIf="projectsEnabled">
     <div class="content">
         <div class="connect" *ngIf="!project && !connecting">
-            <button md-raised-button color="primary" class="button" (click)="connect()">
+            <button md-raised-button color="primary" class="button" (click)="connect()" [disabled]="!hasPrivateKey">
                 Connect a plan file
             </button>
+            <span class="no-keys" *ngIf="!hasPrivateKey">
+                <hab-icon symbol="add-circle"></hab-icon>
+                <a [routerLink]="['/origins', origin, 'keys']">Add required origin keys</a>
+            </span>
             <div *ngIf="name">
                 <p><strong>There are currently no Habitat plan files connected.</strong></p>
                 <p>If you have a plan file in a GitHub repo, connect it here for automated build jobs.</p>

--- a/components/builder-web/app/shared/project-settings/project-settings.component.ts
+++ b/components/builder-web/app/shared/project-settings/project-settings.component.ts
@@ -97,6 +97,11 @@ export class ProjectSettingsComponent implements OnChanges {
         return this.store.getState().gitHub.files;
     }
 
+    get hasPrivateKey() {
+        const currentOrigin = this.store.getState().origins.current;
+        return currentOrigin.name === this.origin && !!currentOrigin.private_key_name;
+    }
+
     get installations() {
         return this.store.getState().gitHub.installations;
     }

--- a/components/builder-web/assets/images/icons/all.svg
+++ b/components/builder-web/assets/images/icons/all.svg
@@ -56,6 +56,10 @@
       <!-- https://material.io/icons/#ic_add -->
       <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/>
     </g>
+    <g id="icon-add-circle">
+      <!-- https://material.io/icons/#ic_add_circle -->
+      <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm5 11h-4v4h-2v-4H7v-2h4V7h2v4h4v2z"/>
+    </g>
     <g id="icon-add-box">
       <!-- https://material.io/icons/#ic_add_box -->
       <path d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-2 10h-4v4h-2v-4H7v-2h4V7h2v4h4v2z"/>
@@ -139,6 +143,10 @@
     <g id="icon-open-in-new">
       <!-- https://material.io/icons/#ic_open_in_new -->
       <path d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"/>
+    </g>
+    <g id="icon-info-outline">
+      <!-- https://material.io/icons/#ic_info_outline -->
+      <path d="M11 17h2v-6h-2v6zm1-15C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zM11 9h2V7h-2v2z"/>
     </g>
   </defs>
 </svg>


### PR DESCRIPTION
This change disables the connect-a-plan button when the selected origin has no private key, provides a link to generate new keys, and submits a request to generate new keys whenever an origin is created.

Signed-off-by: Christian Nunciato <cnunciato@chef.io>

Fixes #3678.

![](https://media.tenor.com/images/54bbb26f1ab54fb841405f8846d7c556/tenor.gif)