### PR TITLE
Update `depot` bind to point to builder-api-proxy for builder-worker

### DIFF
--- a/.studiorc
+++ b/.studiorc
@@ -182,7 +182,7 @@ start-sessionsrv() {
 }
 
 start-worker() {
-  hab svc load core/builder-worker --bind jobsrv:builder-jobsrv.default --bind depot:builder-api.default
+  hab svc load core/builder-worker --bind jobsrv:builder-jobsrv.default --bind depot:builder-api-proxy.default
 }
 
 stop-builder() {

--- a/BLDR-Dockerfile
+++ b/BLDR-Dockerfile
@@ -60,7 +60,7 @@ RUN hab svc load core/builder-datastore \
   && hab svc load core/builder-originsrv --bind router:builder-router.default --bind datastore:builder-datastore.default \
   && hab svc load core/builder-scheduler --bind router:builder-router.default --bind datastore:builder-datastore.default \
   && hab svc load core/builder-sessionsrv --bind router:builder-router.default --bind datastore:builder-datastore.default \
-  && hab svc load core/builder-worker --bind jobsrv:builder-jobsrv.default --bind depot:builder-api.default
+  && hab svc load core/builder-worker --bind jobsrv:builder-jobsrv.default --bind depot:builder-api-proxy.default
 
 VOLUME ["/hab/svc", "/hab/cache/keys", "/hab/sup"]
 EXPOSE 80 443 9631 9638

--- a/terraform/instances.tf
+++ b/terraform/instances.tf
@@ -740,7 +740,7 @@ resource "aws_instance" "worker" {
       "sudo systemctl daemon-reload",
       "sudo systemctl start hab-sup",
       "sudo systemctl enable hab-sup",
-      "sudo hab svc load core/builder-worker --group ${var.env} --bind jobsrv:builder-jobsrv.${var.env} --bind depot:builder-api.${var.env} --strategy at-once --url ${var.bldr_url} --channel ${var.release_channel}",
+      "sudo hab svc load core/builder-worker --group ${var.env} --bind jobsrv:builder-jobsrv.${var.env} --bind depot:builder-api-proxy.${var.env} --strategy at-once --url ${var.bldr_url} --channel ${var.release_channel}",
     ]
   }
 


### PR DESCRIPTION
builder-web was moved to builder-api-proxy and so was the bind exposing
app_url. This updates the locations where we were providing a value for
that bind

![tenor-30754917](https://user-images.githubusercontent.com/54036/31473648-c19b5fd8-aeaa-11e7-8d05-fb5e941b9765.gif)
