### PR TITLE
Fix the --no-color flag, add a --json flag

### DIFF
--- a/components/core/src/lib.rs
+++ b/components/core/src/lib.rs
@@ -34,6 +34,7 @@ extern crate regex;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;
+#[macro_use]
 extern crate serde_json;
 extern crate sodiumoxide;
 extern crate libsodium_sys;

--- a/components/launcher/src/server/mod.rs
+++ b/components/launcher/src/server/mod.rs
@@ -237,6 +237,17 @@ where
 }
 
 pub fn run(args: Vec<String>) -> Result<i32> {
+    // This feels pretty ugly, but not sure if it's worth putting clap in here just for this?
+    if args.iter().any(|x| x == "-v") {
+        core::output::set_verbose(true);
+    }
+    if args.iter().any(|x| x == "--no-color") {
+        core::output::set_no_color(true);
+    }
+    if args.iter().any(|x| x == "--json") {
+        core::output::set_json(true);
+    }
+
     let mut server = Server::new(args)?;
     signals::init();
     loop {

--- a/components/launcher/src/service.rs
+++ b/components/launcher/src/service.rs
@@ -18,11 +18,12 @@ use std::io::{self, BufRead, BufReader, Read, Write};
 use std::process::{ChildStderr, ChildStdout, ExitStatus};
 use std::thread;
 
-use ansi_term::Colour;
 #[cfg(windows)]
 use core::os::process::windows_child::{ChildStderr, ChildStdout, ExitStatus};
 use core::os::process::Pid;
 use protocol;
+
+use ansi_term::Colour;
 
 pub use sys::service::*;
 use error::Result;
@@ -111,8 +112,7 @@ where
     let mut reader = BufReader::new(out);
     let mut buffer = String::new();
     while reader.read_line(&mut buffer).unwrap() > 0 {
-        let mut line = output_format!(preamble &id, logkey "O");
-        line.push_str(&buffer);
+        let line = output_format!(preamble &id, logkey "O", content &buffer );
         write!(&mut io::stdout(), "{}", line).expect("unable to write to stdout");
         buffer.clear();
     }
@@ -126,9 +126,8 @@ where
     let mut reader = BufReader::new(err);
     let mut buffer = String::new();
     while reader.read_line(&mut buffer).unwrap() > 0 {
-        let mut line = output_format!(preamble &id, logkey "E");
         let c = format!("{}", Colour::Red.bold().paint(buffer.clone()));
-        line.push_str(c.as_str());
+        let line = output_format!(preamble &id, logkey "E", content &c);
         write!(&mut io::stderr(), "{}", line).expect("unable to write to stderr");
         buffer.clear();
     }


### PR DESCRIPTION
Currently this covers the following:
- all launcher output (uses raw arg processing, should this use clap?)
- all hap-sup run output

--no-color and --json are only allowed for `hab sup run` (--no-color
was on all hab sup previously, which let colour leak in from other
components which were called)

My thinking is that this is only really for sending actual sup output
to a logging system / file. Happy to change if needed.

no-color does two things (probably up for debate):
- no color in preamble etc..
- strip all color from output (could be hab messages, could be service output)

The JSON output currently has these fields:
- content
- logkey
- preamble
- file (verbose only)
- line (verbose only)
- column (verbose only)

Potentially preamble could be split to service and group?

Signed-off-by: James Sewell <james.sewell@gmail.com>