### PR TITLE
Generate keys on origin create

### DIFF
--- a/components/builder-web/app/actions/origins.ts
+++ b/components/builder-web/app/actions/origins.ts
@@ -139,6 +139,7 @@ export function createOrigin(body: object, token: string, isFirstOrigin = false,
                 type: SUCCESS,
             }));
 
+            dispatch(generateOriginKeys(origin["name"], token));
             callback(origin);
         }).catch(error => {
             dispatch(setCurrentOriginCreatingFlag(false));


### PR DESCRIPTION
With #3746, I removed the UI element that made key generation optional, but then forgot the part about actually generating the keys. This fixes that oversight.

Signed-off-by: Christian Nunciato <cnunciato@chef.io>

![](https://media.tenor.com/images/6fc3f25be58e0464f7496c75382c550e/tenor.gif)