### PR TITLE
Update demo instructions to match current flow

### DIFF
--- a/www/source/demo/steps/10.html.slim
+++ b/www/source/demo/steps/10.html.slim
@@ -39,9 +39,7 @@ classes: demo_step
             strong  Commit changes
             '  button to update the master branch.
           p
-            ' In the Habitat Builder app, click on the
-            strong Build latest version
-            '  button.
+            ' Habitat Builder will detect the change and start a new build automatically. You can view the resulting output in the Habitat Builder web app.
             ' Once the build job completes, re-run the docker commands to verify the updated container:
           p.code $ docker pull your-docker-org/your-docker-repo
           p.code $ docker run -it -p 8000:8000 your-docker-org/your-docker-repo


### PR DESCRIPTION
To match the recent change in GitHub callback, remove the instruction in Step 10 that asks the user to click the build button, add instruction about the auto-detection.