### PR TITLE
Add 'app' table back to jobsrv and sessionsrv so toToml doesn't break

### DIFF
--- a/components/builder-jobsrv/habitat/default.toml
+++ b/components/builder-jobsrv/habitat/default.toml
@@ -9,6 +9,8 @@ publisher_listen = "0.0.0.0"
 log_ingestion_listen = "0.0.0.0"
 log_ingestion_port = 5568
 
+[app]
+
 [datastore]
 user = "hab"
 password = ""

--- a/components/builder-scheduler/habitat/default.toml
+++ b/components/builder-scheduler/habitat/default.toml
@@ -1,6 +1,8 @@
 log_level = "info"
 log_path = "/tmp"
 
+[app]
+
 [datastore]
 user = "hab"
 password = ""


### PR DESCRIPTION
If the app table doesn't exist in the census jobsrv and sessionsrv fail to start.

Signed-off-by: Travis Elliott Davis <edavis@chef.io>