### PR TITLE
Enforce Linux pids as `pid_t` (or `i32`).

### DIFF
--- a/components/builder-worker/src/runner/docker.rs
+++ b/components/builder-worker/src/runner/docker.rs
@@ -19,7 +19,7 @@ use std::process::{Child, Command, ExitStatus, Stdio};
 
 use hab_core::env;
 use hab_core::fs as hfs;
-use hab_core::os::process::{self, Signal};
+use hab_core::os::process::{self, Pid, Signal};
 
 use error::Result;
 use runner::log_pipe::LogPipe;
@@ -206,7 +206,7 @@ impl<'a> DockerExporter<'a> {
             dockerd.id(),
             Signal::TERM
         );
-        process::signal(dockerd.id(), Signal::TERM)?;
+        process::signal(dockerd.id() as Pid, Signal::TERM)?;
         dockerd.wait()?;
         debug!("terminated dockerd");
         // TODO fn: clean up `self.dockerd_root()` directory

--- a/components/core/src/os/process/linux.rs
+++ b/components/core/src/os/process/linux.rs
@@ -23,6 +23,7 @@ use libc::{self, pid_t};
 use super::{OsSignal, Signal};
 use error::{Error, Result};
 
+pub type Pid = libc::pid_t;
 pub type SignalCode = libc::c_int;
 
 impl OsSignal for Signal {
@@ -62,12 +63,12 @@ pub fn become_command(command: PathBuf, args: Vec<OsString>) -> Result<()> {
 }
 
 /// Get process identifier of calling process.
-pub fn current_pid() -> u32 {
-    unsafe { libc::getpid() as u32 }
+pub fn current_pid() -> Pid {
+    unsafe { libc::getpid() as pid_t }
 }
 
 /// Determines if a process is running with the given process identifier.
-pub fn is_alive(pid: u32) -> bool {
+pub fn is_alive(pid: Pid) -> bool {
     match unsafe { libc::kill(pid as pid_t, 0) } {
         0 => true,
         _ => {
@@ -80,7 +81,7 @@ pub fn is_alive(pid: u32) -> bool {
     }
 }
 
-pub fn signal(pid: u32, signal: Signal) -> Result<()> {
+pub fn signal(pid: Pid, signal: Signal) -> Result<()> {
     unsafe {
         match libc::kill(pid as pid_t, signal.os_signal()) {
             0 => Ok(()),

--- a/components/launcher-client/src/client.rs
+++ b/components/launcher-client/src/client.rs
@@ -16,6 +16,7 @@ use std::collections::HashMap;
 use std::io;
 use std::path::Path;
 
+use core::os::process::Pid;
 use ipc_channel::ipc::{IpcOneShotServer, IpcReceiver, IpcSender};
 use protobuf;
 use protocol;
@@ -105,12 +106,12 @@ impl LauncherCli {
     }
 
     /// Restart a running process with the same arguments
-    pub fn restart(&self, pid: u32) -> Result<u32> {
+    pub fn restart(&self, pid: Pid) -> Result<Pid> {
         let mut msg = protocol::Restart::new();
-        msg.set_pid(pid);
+        msg.set_pid(pid.into());
         Self::send(&self.tx, &msg)?;
         let reply = Self::recv::<protocol::SpawnOk>(&self.rx)?;
-        Ok(reply.get_pid())
+        Ok(reply.get_pid() as Pid)
     }
 
     /// Send a process spawn command to the connected Launcher
@@ -122,7 +123,7 @@ impl LauncherCli {
         group: G,
         password: Option<P>,
         env: Env,
-    ) -> Result<u32>
+    ) -> Result<Pid>
     where
         I: ToString,
         B: AsRef<Path>,
@@ -141,12 +142,12 @@ impl LauncherCli {
         msg.set_id(id.to_string());
         Self::send(&self.tx, &msg)?;
         let reply = Self::recv::<protocol::SpawnOk>(&self.rx)?;
-        Ok(reply.get_pid())
+        Ok(reply.get_pid() as Pid)
     }
 
-    pub fn terminate(&self, pid: u32) -> Result<i32> {
+    pub fn terminate(&self, pid: Pid) -> Result<i32> {
         let mut msg = protocol::Terminate::new();
-        msg.set_pid(pid);
+        msg.set_pid(pid.into());
         Self::send(&self.tx, &msg)?;
         let reply = Self::recv::<protocol::TerminateOk>(&self.rx)?;
         Ok(reply.get_exit_code())

--- a/components/launcher-protocol/protocols/launcher.proto
+++ b/components/launcher-protocol/protocols/launcher.proto
@@ -7,7 +7,7 @@ message Register {
 }
 
 message Restart {
-  optional uint32 pid = 1;
+  optional int64 pid = 1;
 }
 
 message Spawn {
@@ -20,11 +20,11 @@ message Spawn {
 }
 
 message SpawnOk {
-  optional uint32 pid = 1;
+  optional int64 pid = 1;
 }
 
 message Terminate {
-  optional uint32 pid = 1;
+  optional int64 pid = 1;
 }
 
 message TerminateOk {

--- a/components/launcher-protocol/src/message/launcher.rs
+++ b/components/launcher-protocol/src/message/launcher.rs
@@ -210,7 +210,7 @@ impl ::protobuf::reflect::ProtobufValue for Register {
 #[derive(PartialEq,Clone,Default)]
 pub struct Restart {
     // message fields
-    pid: ::std::option::Option<u32>,
+    pid: ::std::option::Option<i64>,
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
     cached_size: ::protobuf::CachedSize,
@@ -234,7 +234,7 @@ impl Restart {
         }
     }
 
-    // optional uint32 pid = 1;
+    // optional int64 pid = 1;
 
     pub fn clear_pid(&mut self) {
         self.pid = ::std::option::Option::None;
@@ -245,19 +245,19 @@ impl Restart {
     }
 
     // Param is passed by value, moved
-    pub fn set_pid(&mut self, v: u32) {
+    pub fn set_pid(&mut self, v: i64) {
         self.pid = ::std::option::Option::Some(v);
     }
 
-    pub fn get_pid(&self) -> u32 {
+    pub fn get_pid(&self) -> i64 {
         self.pid.unwrap_or(0)
     }
 
-    fn get_pid_for_reflect(&self) -> &::std::option::Option<u32> {
+    fn get_pid_for_reflect(&self) -> &::std::option::Option<i64> {
         &self.pid
     }
 
-    fn mut_pid_for_reflect(&mut self) -> &mut ::std::option::Option<u32> {
+    fn mut_pid_for_reflect(&mut self) -> &mut ::std::option::Option<i64> {
         &mut self.pid
     }
 }
@@ -275,7 +275,7 @@ impl ::protobuf::Message for Restart {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
                         return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
                     }
-                    let tmp = is.read_uint32()?;
+                    let tmp = is.read_int64()?;
                     self.pid = ::std::option::Option::Some(tmp);
                 },
                 _ => {
@@ -300,7 +300,7 @@ impl ::protobuf::Message for Restart {
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.pid {
-            os.write_uint32(1, v)?;
+            os.write_int64(1, v)?;
         }
         os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
@@ -346,7 +346,7 @@ impl ::protobuf::MessageStatic for Restart {
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint32>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeInt64>(
                     "pid",
                     Restart::get_pid_for_reflect,
                     Restart::mut_pid_for_reflect,
@@ -854,7 +854,7 @@ impl ::protobuf::reflect::ProtobufValue for Spawn {
 #[derive(PartialEq,Clone,Default)]
 pub struct SpawnOk {
     // message fields
-    pid: ::std::option::Option<u32>,
+    pid: ::std::option::Option<i64>,
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
     cached_size: ::protobuf::CachedSize,
@@ -878,7 +878,7 @@ impl SpawnOk {
         }
     }
 
-    // optional uint32 pid = 1;
+    // optional int64 pid = 1;
 
     pub fn clear_pid(&mut self) {
         self.pid = ::std::option::Option::None;
@@ -889,19 +889,19 @@ impl SpawnOk {
     }
 
     // Param is passed by value, moved
-    pub fn set_pid(&mut self, v: u32) {
+    pub fn set_pid(&mut self, v: i64) {
         self.pid = ::std::option::Option::Some(v);
     }
 
-    pub fn get_pid(&self) -> u32 {
+    pub fn get_pid(&self) -> i64 {
         self.pid.unwrap_or(0)
     }
 
-    fn get_pid_for_reflect(&self) -> &::std::option::Option<u32> {
+    fn get_pid_for_reflect(&self) -> &::std::option::Option<i64> {
         &self.pid
     }
 
-    fn mut_pid_for_reflect(&mut self) -> &mut ::std::option::Option<u32> {
+    fn mut_pid_for_reflect(&mut self) -> &mut ::std::option::Option<i64> {
         &mut self.pid
     }
 }
@@ -919,7 +919,7 @@ impl ::protobuf::Message for SpawnOk {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
                         return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
                     }
-                    let tmp = is.read_uint32()?;
+                    let tmp = is.read_int64()?;
                     self.pid = ::std::option::Option::Some(tmp);
                 },
                 _ => {
@@ -944,7 +944,7 @@ impl ::protobuf::Message for SpawnOk {
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.pid {
-            os.write_uint32(1, v)?;
+            os.write_int64(1, v)?;
         }
         os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
@@ -990,7 +990,7 @@ impl ::protobuf::MessageStatic for SpawnOk {
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint32>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeInt64>(
                     "pid",
                     SpawnOk::get_pid_for_reflect,
                     SpawnOk::mut_pid_for_reflect,
@@ -1027,7 +1027,7 @@ impl ::protobuf::reflect::ProtobufValue for SpawnOk {
 #[derive(PartialEq,Clone,Default)]
 pub struct Terminate {
     // message fields
-    pid: ::std::option::Option<u32>,
+    pid: ::std::option::Option<i64>,
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
     cached_size: ::protobuf::CachedSize,
@@ -1051,7 +1051,7 @@ impl Terminate {
         }
     }
 
-    // optional uint32 pid = 1;
+    // optional int64 pid = 1;
 
     pub fn clear_pid(&mut self) {
         self.pid = ::std::option::Option::None;
@@ -1062,19 +1062,19 @@ impl Terminate {
     }
 
     // Param is passed by value, moved
-    pub fn set_pid(&mut self, v: u32) {
+    pub fn set_pid(&mut self, v: i64) {
         self.pid = ::std::option::Option::Some(v);
     }
 
-    pub fn get_pid(&self) -> u32 {
+    pub fn get_pid(&self) -> i64 {
         self.pid.unwrap_or(0)
     }
 
-    fn get_pid_for_reflect(&self) -> &::std::option::Option<u32> {
+    fn get_pid_for_reflect(&self) -> &::std::option::Option<i64> {
         &self.pid
     }
 
-    fn mut_pid_for_reflect(&mut self) -> &mut ::std::option::Option<u32> {
+    fn mut_pid_for_reflect(&mut self) -> &mut ::std::option::Option<i64> {
         &mut self.pid
     }
 }
@@ -1092,7 +1092,7 @@ impl ::protobuf::Message for Terminate {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
                         return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
                     }
-                    let tmp = is.read_uint32()?;
+                    let tmp = is.read_int64()?;
                     self.pid = ::std::option::Option::Some(tmp);
                 },
                 _ => {
@@ -1117,7 +1117,7 @@ impl ::protobuf::Message for Terminate {
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.pid {
-            os.write_uint32(1, v)?;
+            os.write_int64(1, v)?;
         }
         os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
@@ -1163,7 +1163,7 @@ impl ::protobuf::MessageStatic for Terminate {
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint32>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeInt64>(
                     "pid",
                     Terminate::get_pid_for_reflect,
                     Terminate::mut_pid_for_reflect,
@@ -1472,17 +1472,17 @@ impl ::protobuf::reflect::ProtobufValue for ShutdownMethod {
 static file_descriptor_proto_data: &'static [u8] = b"\
     \n\x18protocols/launcher.proto\x12\x08launcher\"\x1e\n\x08Register\x12\
     \x12\n\x04pipe\x18\x01\x20\x01(\tR\x04pipe\"\x1b\n\x07Restart\x12\x10\n\
-    \x03pid\x18\x01\x20\x01(\rR\x03pid\"\xee\x01\n\x05Spawn\x12\x0e\n\x02id\
-    \x18\x01\x20\x01(\tR\x02id\x12\x16\n\x06binary\x18\x02\x20\x01(\tR\x06bi\
-    nary\x12\x19\n\x08svc_user\x18\x03\x20\x01(\tR\x07svcUser\x12\x1b\n\tsvc\
-    _group\x18\x04\x20\x01(\tR\x08svcGroup\x12!\n\x0csvc_password\x18\x05\
+    \x03pid\x18\x01\x20\x01(\x03R\x03pid\"\xee\x01\n\x05Spawn\x12\x0e\n\x02i\
+    d\x18\x01\x20\x01(\tR\x02id\x12\x16\n\x06binary\x18\x02\x20\x01(\tR\x06b\
+    inary\x12\x19\n\x08svc_user\x18\x03\x20\x01(\tR\x07svcUser\x12\x1b\n\tsv\
+    c_group\x18\x04\x20\x01(\tR\x08svcGroup\x12!\n\x0csvc_password\x18\x05\
     \x20\x01(\tR\x0bsvcPassword\x12*\n\x03env\x18\x06\x20\x03(\x0b2\x18.laun\
     cher.Spawn.EnvEntryR\x03env\x1a6\n\x08EnvEntry\x12\x10\n\x03key\x18\x01\
     \x20\x01(\tR\x03key\x12\x14\n\x05value\x18\x02\x20\x01(\tR\x05value:\x02\
-    8\x01\"\x1b\n\x07SpawnOk\x12\x10\n\x03pid\x18\x01\x20\x01(\rR\x03pid\"\
-    \x1d\n\tTerminate\x12\x10\n\x03pid\x18\x01\x20\x01(\rR\x03pid\"m\n\x0bTe\
-    rminateOk\x12\x1b\n\texit_code\x18\x01\x20\x01(\x05R\x08exitCode\x12A\n\
-    \x0fshutdown_method\x18\x02\x20\x01(\x0e2\x18.launcher.ShutdownMethodR\
+    8\x01\"\x1b\n\x07SpawnOk\x12\x10\n\x03pid\x18\x01\x20\x01(\x03R\x03pid\"\
+    \x1d\n\tTerminate\x12\x10\n\x03pid\x18\x01\x20\x01(\x03R\x03pid\"m\n\x0b\
+    TerminateOk\x12\x1b\n\texit_code\x18\x01\x20\x01(\x05R\x08exitCode\x12A\
+    \n\x0fshutdown_method\x18\x02\x20\x01(\x0e2\x18.launcher.ShutdownMethodR\
     \x0eshutdownMethod*H\n\x0eShutdownMethod\x12\x11\n\rAlreadyExited\x10\0\
     \x12\x17\n\x13GracefulTermination\x10\x01\x12\n\n\x06Killed\x10\x02J\xfc\
     \x08\n\x06\x12\x04\0\0&\x01\n\x08\n\x01\x0c\x12\x03\0\0\x12\n\x08\n\x01\
@@ -1492,10 +1492,10 @@ static file_descriptor_proto_data: &'static [u8] = b"\
     \0\x05\x12\x03\x05\x0b\x11\n\x0c\n\x05\x04\0\x02\0\x01\x12\x03\x05\x12\
     \x16\n\x0c\n\x05\x04\0\x02\0\x03\x12\x03\x05\x19\x1a\n\n\n\x02\x04\x01\
     \x12\x04\x08\0\n\x01\n\n\n\x03\x04\x01\x01\x12\x03\x08\x08\x0f\n\x0b\n\
-    \x04\x04\x01\x02\0\x12\x03\t\x02\x1a\n\x0c\n\x05\x04\x01\x02\0\x04\x12\
-    \x03\t\x02\n\n\x0c\n\x05\x04\x01\x02\0\x05\x12\x03\t\x0b\x11\n\x0c\n\x05\
-    \x04\x01\x02\0\x01\x12\x03\t\x12\x15\n\x0c\n\x05\x04\x01\x02\0\x03\x12\
-    \x03\t\x18\x19\n\n\n\x02\x04\x02\x12\x04\x0c\0\x13\x01\n\n\n\x03\x04\x02\
+    \x04\x04\x01\x02\0\x12\x03\t\x02\x19\n\x0c\n\x05\x04\x01\x02\0\x04\x12\
+    \x03\t\x02\n\n\x0c\n\x05\x04\x01\x02\0\x05\x12\x03\t\x0b\x10\n\x0c\n\x05\
+    \x04\x01\x02\0\x01\x12\x03\t\x11\x14\n\x0c\n\x05\x04\x01\x02\0\x03\x12\
+    \x03\t\x17\x18\n\n\n\x02\x04\x02\x12\x04\x0c\0\x13\x01\n\n\n\x03\x04\x02\
     \x01\x12\x03\x0c\x08\r\n\x0b\n\x04\x04\x02\x02\0\x12\x03\r\x02\x19\n\x0c\
     \n\x05\x04\x02\x02\0\x04\x12\x03\r\x02\n\n\x0c\n\x05\x04\x02\x02\0\x05\
     \x12\x03\r\x0b\x11\n\x0c\n\x05\x04\x02\x02\0\x01\x12\x03\r\x12\x14\n\x0c\
@@ -1519,14 +1519,14 @@ static file_descriptor_proto_data: &'static [u8] = b"\
     \x05\x04\x02\x02\x05\x01\x12\x03\x12\x16\x19\n\x0c\n\x05\x04\x02\x02\x05\
     \x03\x12\x03\x12\x1c\x1d\n\n\n\x02\x04\x03\x12\x04\x15\0\x17\x01\n\n\n\
     \x03\x04\x03\x01\x12\x03\x15\x08\x0f\n\x0b\n\x04\x04\x03\x02\0\x12\x03\
-    \x16\x02\x1a\n\x0c\n\x05\x04\x03\x02\0\x04\x12\x03\x16\x02\n\n\x0c\n\x05\
-    \x04\x03\x02\0\x05\x12\x03\x16\x0b\x11\n\x0c\n\x05\x04\x03\x02\0\x01\x12\
-    \x03\x16\x12\x15\n\x0c\n\x05\x04\x03\x02\0\x03\x12\x03\x16\x18\x19\n\n\n\
+    \x16\x02\x19\n\x0c\n\x05\x04\x03\x02\0\x04\x12\x03\x16\x02\n\n\x0c\n\x05\
+    \x04\x03\x02\0\x05\x12\x03\x16\x0b\x10\n\x0c\n\x05\x04\x03\x02\0\x01\x12\
+    \x03\x16\x11\x14\n\x0c\n\x05\x04\x03\x02\0\x03\x12\x03\x16\x17\x18\n\n\n\
     \x02\x04\x04\x12\x04\x19\0\x1b\x01\n\n\n\x03\x04\x04\x01\x12\x03\x19\x08\
-    \x11\n\x0b\n\x04\x04\x04\x02\0\x12\x03\x1a\x02\x1a\n\x0c\n\x05\x04\x04\
+    \x11\n\x0b\n\x04\x04\x04\x02\0\x12\x03\x1a\x02\x19\n\x0c\n\x05\x04\x04\
     \x02\0\x04\x12\x03\x1a\x02\n\n\x0c\n\x05\x04\x04\x02\0\x05\x12\x03\x1a\
-    \x0b\x11\n\x0c\n\x05\x04\x04\x02\0\x01\x12\x03\x1a\x12\x15\n\x0c\n\x05\
-    \x04\x04\x02\0\x03\x12\x03\x1a\x18\x19\n\n\n\x02\x04\x05\x12\x04\x1d\0\
+    \x0b\x10\n\x0c\n\x05\x04\x04\x02\0\x01\x12\x03\x1a\x11\x14\n\x0c\n\x05\
+    \x04\x04\x02\0\x03\x12\x03\x1a\x17\x18\n\n\n\x02\x04\x05\x12\x04\x1d\0\
     \x20\x01\n\n\n\x03\x04\x05\x01\x12\x03\x1d\x08\x13\n\x0b\n\x04\x04\x05\
     \x02\0\x12\x03\x1e\x02\x1f\n\x0c\n\x05\x04\x05\x02\0\x04\x12\x03\x1e\x02\
     \n\n\x0c\n\x05\x04\x05\x02\0\x05\x12\x03\x1e\x0b\x10\n\x0c\n\x05\x04\x05\

--- a/components/launcher/src/server/handlers/restart.rs
+++ b/components/launcher/src/server/handlers/restart.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::os::process::Pid;
 use protocol;
 
 use super::{Handler, HandleResult};
@@ -24,7 +25,7 @@ impl Handler for RestartHandler {
     type Reply = protocol::SpawnOk;
 
     fn handle(msg: Self::Message, services: &mut ServiceTable) -> HandleResult<Self::Reply> {
-        let mut service = match services.remove(msg.get_pid()) {
+        let mut service = match services.remove(msg.get_pid() as Pid) {
             Some(service) => service,
             None => {
                 let mut reply = protocol::NetErr::new();
@@ -38,7 +39,7 @@ impl Handler for RestartHandler {
                 match service::run(service.take_args()) {
                     Ok(new_service) => {
                         let mut reply = protocol::SpawnOk::new();
-                        reply.set_pid(new_service.id());
+                        reply.set_pid(new_service.id().into());
                         services.insert(new_service);
                         Ok(reply)
                     }

--- a/components/launcher/src/server/handlers/spawn.rs
+++ b/components/launcher/src/server/handlers/spawn.rs
@@ -27,7 +27,7 @@ impl Handler for SpawnHandler {
         match service::run(msg) {
             Ok(service) => {
                 let mut reply = protocol::SpawnOk::new();
-                reply.set_pid(service.id());
+                reply.set_pid(service.id().into());
                 services.insert(service);
                 Ok(reply)
             }

--- a/components/launcher/src/server/handlers/terminate.rs
+++ b/components/launcher/src/server/handlers/terminate.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::os::process::Pid;
 use protocol;
 
 use super::{Handler, HandleResult};
@@ -23,7 +24,7 @@ impl Handler for TerminateHandler {
     type Reply = protocol::TerminateOk;
 
     fn handle(msg: Self::Message, services: &mut ServiceTable) -> HandleResult<Self::Reply> {
-        match services.get_mut(msg.get_pid()) {
+        match services.get_mut(msg.get_pid() as Pid) {
             Some(service) => {
                 debug!("Terminating: {}", service.id());
                 let shutdown_method = service.kill();

--- a/components/launcher/src/service.rs
+++ b/components/launcher/src/service.rs
@@ -21,6 +21,7 @@ use std::thread;
 use ansi_term::Colour;
 #[cfg(windows)]
 use core::os::process::windows_child::{ChildStderr, ChildStdout, ExitStatus};
+use core::os::process::Pid;
 use protocol;
 
 pub use sys::service::*;
@@ -64,7 +65,7 @@ impl Service {
         &self.args
     }
 
-    pub fn id(&self) -> u32 {
+    pub fn id(&self) -> Pid {
         self.process.id()
     }
 

--- a/components/launcher/src/sys/unix/service.rs
+++ b/components/launcher/src/sys/unix/service.rs
@@ -19,7 +19,7 @@ use std::process::{Command, ExitStatus, Stdio};
 use std::result;
 
 use core::os;
-use core::os::process::{signal, Signal};
+use core::os::process::{Pid, signal, Signal};
 use libc::{self, c_int, pid_t};
 use protocol::{self, ShutdownMethod};
 use time::{Duration, SteadyTime};
@@ -40,8 +40,8 @@ impl Process {
         }
     }
 
-    pub fn id(&self) -> u32 {
-        self.pid as u32
+    pub fn id(&self) -> Pid {
+        self.pid
     }
 
     /// Attempt to gracefully terminate a proccess and then forcefully kill it after

--- a/components/launcher/src/sys/unix/service.rs
+++ b/components/launcher/src/sys/unix/service.rs
@@ -47,6 +47,7 @@ impl Process {
     /// Attempt to gracefully terminate a proccess and then forcefully kill it after
     /// 8 seconds if it has not terminated.
     pub fn kill(&mut self) -> ShutdownMethod {
+        let mut pid_to_kill = self.pid;
         // check the group of the process being killed
         // if it is the root process of the process group
         // we send our signals to the entire process group
@@ -59,12 +60,12 @@ impl Process {
             );
             // sending a signal to the negative pid sends it to the
             // entire process group instead just the single pid
-            self.pid = self.pid.neg();
+            pid_to_kill = self.pid.neg();
         }
 
         // JW TODO: Determine if the error represents a case where the process was already
         // exited before we return out and assume so.
-        if signal(self.id(), Signal::TERM).is_err() {
+        if signal(pid_to_kill, Signal::TERM).is_err() {
             return ShutdownMethod::AlreadyExited;
         }
         let stop_time = SteadyTime::now() + Duration::seconds(8);
@@ -77,7 +78,7 @@ impl Process {
             }
             // JW TODO: Determine if the error represents a case where the process was already
             // exited before we return out and assume so.
-            if signal(self.id(), Signal::KILL).is_err() {
+            if signal(pid_to_kill, Signal::KILL).is_err() {
                 return ShutdownMethod::GracefulTermination;
             }
             return ShutdownMethod::Killed;

--- a/components/sup/src/error.rs
+++ b/components/sup/src/error.rs
@@ -55,6 +55,7 @@ use depot_client;
 use glob;
 use handlebars;
 use hcore;
+use hcore::os::process::Pid;
 use hcore::output::StructuredOutput;
 use hcore::package::{self, Identifiable, PackageInstall};
 use launcher_client;
@@ -144,7 +145,7 @@ pub enum Error {
     PidFileCorrupt(PathBuf),
     PidFileIO(PathBuf, io::Error),
     ProcessLockCorrupt,
-    ProcessLocked(u32),
+    ProcessLocked(Pid),
     ProcessLockIO(PathBuf, io::Error),
     RecvError(mpsc::RecvError),
     RenderContextSerialization(serde_json::Error),

--- a/components/sup/src/manager/service/supervisor.rs
+++ b/components/sup/src/manager/service/supervisor.rs
@@ -24,7 +24,7 @@ use std::fs::File;
 use std::io::BufReader;
 use std::io::prelude::*;
 use std::path::{Path, PathBuf};
-use hcore::os::process;
+use hcore::os::process::{self, Pid};
 use std::result;
 
 use hcore::service::ServiceGroup;
@@ -60,7 +60,7 @@ pub struct Supervisor {
     pub preamble: String,
     pub state: ProcessState,
     pub state_entered: Timespec,
-    pid: Option<u32>,
+    pid: Option<Pid>,
     pid_file: PathBuf,
 }
 
@@ -235,7 +235,7 @@ impl Serialize for Supervisor {
     }
 }
 
-fn read_pid<T>(pid_file: T) -> Result<u32>
+fn read_pid<T>(pid_file: T) -> Result<Pid>
 where
     T: AsRef<Path>,
 {
@@ -244,7 +244,7 @@ where
             let reader = BufReader::new(file);
             match reader.lines().next() {
                 Some(Ok(line)) => {
-                    match line.parse::<u32>() {
+                    match line.parse::<Pid>() {
                         Ok(pid) => Ok(pid),
                         Err(_) => Err(sup_error!(
                             Error::PidFileCorrupt(pid_file.as_ref().to_path_buf())


### PR DESCRIPTION
While this doesn't completely solve the Launcher reaping/log issues, it tries to correct the type mismatch with how we think about process ids in Linux.

The main work was to thread though the notion of a `Pid` alias type which was already present in the Windows implementation which helped to keep the calling functions basically generic enough.

One small wrinkle which may not be the best is that I made the protocol level representation an `int64`. Why? Because in Linux we are dealing with an `int32` and this fits in without overflow just fine. On Windows, the pid is a `uint32` which also fits into the `int64`. There are only 2 issues in my mind here: 1) there's a bit of casting going into and out of the wire, but since we only ever communicate with ourselves on the same host/kernel, we always know what we expect to find (this is a bit like generics in Java) and 2) I modified an existing protocol type, but since this only happens in memory on the host, both sides upgrade in lock step.

Thoughts? Is this useful? I was using a Launch and Supervisor with this change for a week in my Builder development container when working on the `builder-worker` and I can confirm that I was seeing negative pid numbers with this change, and the `abs(pid)` was the real, correct pid of the service.