### PR TITLE
Fix job server race condition

### DIFF
--- a/components/builder-worker/src/heartbeat.rs
+++ b/components/builder-worker/src/heartbeat.rs
@@ -212,7 +212,7 @@ impl HeartbeatMgr {
 
     // Broadcast to subscribers the HeartbeatMgr health and state
     fn pulse(&mut self) -> Result<()> {
-        debug!("heartbeat pulsed: {:?}", self.heartbeat.get_state());
+        debug!("heartbeat pulsed: {:?}", self.heartbeat);
         self.pub_sock.send(&message::encode(&self.heartbeat)?, 0)?;
         Ok(())
     }


### PR DESCRIPTION
This change fixes a race condition that can cause the job server to not properly handle busy worker state, and can get into a condition where it loses track of a busy worker. Subsequently if that busy worker is re-started in the middle of a job, it's interrupted job will not get restarted.  There are also a couple of other minor tweaks.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-228551396](https://user-images.githubusercontent.com/13542112/31530646-ca37a6aa-af96-11e7-9096-ab631f93b460.gif)
