### PR TITLE
Fix handler crash on account creation when duplicate email is present

### DIFF
--- a/components/builder-sessionsrv/src/migrations/accounts.rs
+++ b/components/builder-sessionsrv/src/migrations/accounts.rs
@@ -134,5 +134,7 @@ pub fn migrate(migrator: &mut Migrator) -> SrvResult<()> {
                             RETURN;
                           END;
                           $$ LANGUAGE plpgsql STABLE"#)?;
+    migrator.migrate("accountsrv",
+        r#"ALTER TABLE IF EXISTS accounts DROP CONSTRAINT IF EXISTS accounts_email_key"#)?;
     Ok(())
 }


### PR DESCRIPTION
We key on account name and not email. A long while ago when the account table
was first created it wasn't clear if we would key on email or account because
we weren't sure which we could be guaranteed to get. It's now clear that name
is what we can guarantee and we will perform email verification steps to try
our best to obtain an email.

This change fixes a crash in the session server when a user without an email
tries to create an account in a shard where another user has already created
an account without an email.

![tenor-125031684](https://user-images.githubusercontent.com/54036/31566295-c74e297c-b01e-11e7-8b23-2df16f37d77a.gif)
