### PR TITLE
Return None/Empty Vec when remote GitHub entity is not found

### DIFF
--- a/components/builder-api/src/server/handlers.rs
+++ b/components/builder-api/src/server/handlers.rs
@@ -392,7 +392,8 @@ pub fn project_create(req: &mut Request) -> IronResult<Response> {
             project.set_vcs_installation_id(body.installation_id);
 
             match github.repo(&token, body.repo_id) {
-                Ok(repo) => project.set_vcs_data(repo.clone_url),
+                Ok(Some(repo)) => project.set_vcs_data(repo.clone_url),
+                Ok(None) => return Ok(Response::with((status::NotFound, "rg:pc:2"))),
                 Err(e) => {
                     debug!("Error finding github repo. e = {:?}", e);
                     return Ok(Response::with((status::UnprocessableEntity, "rg:pc:1")));
@@ -532,7 +533,8 @@ pub fn project_update(req: &mut Request) -> IronResult<Response> {
             project.set_plan_path(body.plan_path);
             project.set_vcs_installation_id(body.installation_id);
             match github.repo(&token, body.repo_id) {
-                Ok(repo) => project.set_vcs_data(repo.clone_url),
+                Ok(Some(repo)) => project.set_vcs_data(repo.clone_url),
+                Ok(None) => return Ok(Response::with((status::NotFound, "rg:pu:2"))),
                 Err(e) => {
                     debug!("Error finding GH repo. e = {:?}", e);
                     return Ok(Response::with((status::UnprocessableEntity, "rg:pu:1")));

--- a/components/builder-http-gateway/src/http/helpers.rs
+++ b/components/builder-http-gateway/src/http/helpers.rs
@@ -357,7 +357,7 @@ pub fn promote_job_group_to_channel(
         if project.get_state() == ProjectState::Success {
             let ident = OriginPackageIdent::from_str(project.get_ident()).unwrap();
 
-            let mut project_list = origin_map.entry(ident.get_origin().to_string()).or_insert(
+            let project_list = origin_map.entry(ident.get_origin().to_string()).or_insert(
                 Vec::new(),
             );
             project_list.push(project);

--- a/components/builder-http-gateway/src/http/middleware.rs
+++ b/components/builder-http-gateway/src/http/middleware.rs
@@ -129,7 +129,7 @@ impl Authenticated {
     fn authenticate(&self, req: &mut Request, token: SessionToken) -> IronResult<Session> {
         let mut request = SessionGet::new();
         request.set_token(token);
-        let mut conn = req.extensions.get_mut::<XRouteClient>().unwrap();
+        let conn = req.extensions.get_mut::<XRouteClient>().unwrap();
         match conn.route::<SessionGet, Session>(&request) {
             Ok(session) => {
                 self.validate_session(&session)?;
@@ -215,7 +215,7 @@ impl AfterMiddleware for Cors {
 
 pub fn session_create_github(req: &mut Request, token: String) -> IronResult<Session> {
     let github = req.get::<persistent::Read<GitHubCli>>().unwrap();
-    let mut conn = req.extensions.get_mut::<XRouteClient>().expect(
+    let conn = req.extensions.get_mut::<XRouteClient>().expect(
         "no XRouteClient extension in request",
     );
     match github.user(&token) {
@@ -268,7 +268,7 @@ pub fn session_create_github(req: &mut Request, token: String) -> IronResult<Ses
 }
 
 pub fn session_create_short_circuit(req: &mut Request, token: &str) -> IronResult<Session> {
-    let mut conn = req.extensions.get_mut::<XRouteClient>().expect(
+    let conn = req.extensions.get_mut::<XRouteClient>().expect(
         "no XRouteClient extension in request",
     );
     let request = match token.as_ref() {

--- a/components/builder-sessionsrv/src/server/handlers.rs
+++ b/components/builder-sessionsrv/src/server/handlers.rs
@@ -316,35 +316,38 @@ fn assign_permissions(name: &str, flags: &mut FeatureFlags, state: &ServerState)
                 state.permissions.admin_team,
                 name,
             ) {
-                Ok(membership) => {
+                Ok(Some(membership)) => {
                     if membership.active() {
                         debug!("Granting feature flag={:?}", privilege::ADMIN);
                         flags.set(privilege::ADMIN, true);
                     }
                 }
+                Ok(None) => (),
                 Err(err) => warn!("Failed to check team membership, {}", err),
             }
             for team in state.permissions.early_access_teams.iter() {
                 match state.github.check_team_membership(&token, *team, name) {
-                    Ok(membership) => {
+                    Ok(Some(membership)) => {
                         if membership.active() {
                             debug!("Granting feature flag={:?}", privilege::EARLY_ACCESS);
                             flags.set(privilege::EARLY_ACCESS, true);
                             break;
                         }
                     }
+                    Ok(None) => (),
                     Err(err) => warn!("Failed to check team membership, {}", err),
                 }
             }
             for team in state.permissions.build_worker_teams.iter() {
                 match state.github.check_team_membership(&token, *team, name) {
-                    Ok(membership) => {
+                    Ok(Some(membership)) => {
                         if membership.active() {
                             debug!("Granting feature flag={:?}", privilege::BUILD_WORKER);
                             flags.set(privilege::BUILD_WORKER, true);
                             break;
                         }
                     }
+                    Ok(None) => (),
                     Err(err) => warn!("Failed to check team membership, {}", err),
                 }
             }


### PR DESCRIPTION
Return None or an empty vector when GitHub returns a 404 response on
retrieving an entity or set of entities. Previously we would consider
this an error and we would warn/error spam our server output when there
was actually nothing wrong.

![tenor-44784701](https://user-images.githubusercontent.com/54036/31568071-66df1f0c-b027-11e7-97b3-2b77c9d3d45e.gif)
