### PR TITLE
Fix issue configuring worker bldr_url when first bind member is dead

### DIFF
--- a/components/builder-jobsrv/src/server/worker_manager.rs
+++ b/components/builder-jobsrv/src/server/worker_manager.rs
@@ -97,19 +97,9 @@ impl Worker {
     pub fn busy(&mut self, job_id: u64) {
         self.state = jobsrv::WorkerState::Busy;
         self.expiry = Instant::now() + Duration::from_millis(WORKER_TIMEOUT_MS);
-
-        if self.job_id.is_none() {
-            self.job_id = Some(job_id);
-            self.job_expiry = Some(Instant::now() + Duration::from_millis(JOB_TIMEOUT_MS));
-        } else {
-            assert!(self.job_id.unwrap() == job_id);
-        }
-
+        self.job_id = Some(job_id);
+        self.job_expiry = Some(Instant::now() + Duration::from_millis(JOB_TIMEOUT_MS));
         self.quarantined = false;
-    }
-
-    pub fn refresh(&mut self) {
-        self.expiry = Instant::now() + Duration::from_millis(WORKER_TIMEOUT_MS);
     }
 
     pub fn quarantine(&mut self) {
@@ -319,14 +309,13 @@ impl WorkerMgr {
                     );
                     job.set_state(jobsrv::JobState::Pending);
                     self.datastore.update_job(&job)?;
-                    return Ok(()); // Exit instead of re-trying immediately
                 }
             }
         }
         Ok(())
     }
 
-    fn dispatch_job(&mut self, job: &Job, worker_ident: &str) -> Result<()> {
+    fn dispatch_job(&mut self, job: &jobsrv::Job, worker_ident: &str) -> Result<()> {
         debug!("Dispatching job to worker {:?}: {:?}", worker_ident, job);
 
         self.rq_sock.send_str(&worker_ident, zmq::SNDMORE)?;
@@ -336,7 +325,7 @@ impl WorkerMgr {
         Ok(())
     }
 
-    fn add_integrations_to_job(&mut self, job: &mut Job) {
+    fn add_integrations_to_job(&mut self, job: &mut jobsrv::Job) {
         let mut integrations = RepeatedField::new();
         let mut integration_request = OriginIntegrationRequest::new();
         let origin = job.get_project().get_origin_name().to_string();
@@ -370,7 +359,7 @@ impl WorkerMgr {
         }
     }
 
-    fn add_project_integrations_to_job(&mut self, job: &mut Job) {
+    fn add_project_integrations_to_job(&mut self, job: &mut jobsrv::Job) {
         let mut integrations = RepeatedField::new();
         let mut req = OriginProjectIntegrationRequest::new();
         let origin = job.get_project().get_origin_name().to_string();
@@ -462,33 +451,6 @@ impl WorkerMgr {
         Ok(())
     }
 
-    fn is_job_complete(&mut self, job_id: u64) -> Result<bool> {
-        let mut req = jobsrv::JobGet::new();
-        req.set_id(job_id);
-
-        let ret = match self.datastore.get_job(&req)? {
-            Some(job) => {
-                match job.get_state() {
-                    jobsrv::JobState::Pending |
-                    jobsrv::JobState::Processing |
-                    jobsrv::JobState::Dispatched => false,
-                    jobsrv::JobState::Complete |
-                    jobsrv::JobState::Failed |
-                    jobsrv::JobState::Rejected => true,
-                }
-            }
-            None => {
-                warn!(
-                    "Unable to check job completeness {:?} (not found)",
-                    job_id,
-                );
-                false
-            }
-        };
-
-        Ok(ret)
-    }
-
     fn process_heartbeat(&mut self) -> Result<()> {
         self.hb_sock.recv(&mut self.msg, 0)?;
         let heartbeat: jobsrv::Heartbeat = parse_from_bytes(&self.msg)?;
@@ -529,18 +491,12 @@ impl WorkerMgr {
                     };
                     worker.quarantine();
                 } else {
-                    worker.refresh();
+                    worker.busy(job_id);
                 }
             }
             (jobsrv::WorkerState::Busy, jobsrv::WorkerState::Ready) => {
-                if !self.is_job_complete(worker.job_id.unwrap())? {
-                    // Handle potential race condition where a Ready heartbeat
-                    // is received right *after* the job has been dispatched
-                    worker.refresh();
-                } else {
-                    self.delete_worker(&worker)?;
-                    worker.ready();
-                }
+                self.delete_worker(&worker)?;
+                worker.ready()
             }
             _ => worker.ready(),
         };

--- a/components/builder-worker/habitat/config/config.toml
+++ b/components/builder-worker/habitat/config/config.toml
@@ -3,8 +3,12 @@ auto_publish = {{cfg.auto_publish}}
 data_path = "{{pkg.svc_data_path}}"
 log_path = "{{cfg.log_path}}"
 bldr_channel = "{{cfg.bldr_channel}}"
-bldr_url = "{{bind.depot.first.cfg.url}}"
 features_enabled = "{{cfg.features_enabled}}"
+{{~#eachAlive bind.depot.members as |member|}}
+{{~#if @first}}
+bldr_url = "{{member.cfg.url}}"
+{{~/if}}
+{{~/eachAlive}}
 
 [github]
 app_private_key = "{{pkg.svc_files_path}}/builder-github-app.pem"

--- a/components/builder-worker/src/heartbeat.rs
+++ b/components/builder-worker/src/heartbeat.rs
@@ -212,7 +212,7 @@ impl HeartbeatMgr {
 
     // Broadcast to subscribers the HeartbeatMgr health and state
     fn pulse(&mut self) -> Result<()> {
-        debug!("heartbeat pulsed: {:?}", self.heartbeat);
+        debug!("heartbeat pulsed: {:?}", self.heartbeat.get_state());
         self.pub_sock.send(&message::encode(&self.heartbeat)?, 0)?;
         Ok(())
     }


### PR DESCRIPTION
This commit is two fold, first it reverts a previous change to fix a race condition when communicating with the worker. This change appears to cause the worker to not pull jobs from the job server.

Second, `.first` doesn't guarantee it will return an alive member. Only alive members have gossip configuration applied in a service group. Using the `.first` helper with a bind can result in a stale value. This commit ensures that we find an alive member to pull our depot configuration from for the worker.