### PR TITLE
[studio] Install the same `a.b.c` version of backline as Studio.

### DIFF
--- a/components/hab/src/command/studio/docker.rs
+++ b/components/hab/src/command/studio/docker.rs
@@ -65,6 +65,7 @@ pub fn start_docker_studio(_ui: &mut UI, mut args: Vec<OsString>) -> Result<()> 
         "HAB_BLDR_CHANNEL",
         "HAB_ORIGIN",
         "HAB_ORIGIN_KEYS",
+        "HAB_STUDIO_BACKLINE_PKG",
         "HAB_STUDIO_NOSTUDIORC",
         "HAB_STUDIO_SUP",
         "HAB_UPDATE_STRATEGY_FREQUENCY_MS",

--- a/components/studio/libexec/hab-studio-type-default.sh
+++ b/components/studio/libexec/hab-studio-type-default.sh
@@ -7,7 +7,8 @@ studio_build_command="record \${1:-} $HAB_ROOT_PATH/bin/build"
 studio_run_environment=
 studio_run_command="$HAB_ROOT_PATH/bin/hab pkg exec core/hab-backline bash --login"
 
-pkgs="${HAB_BACKLINE_PKG:-core/hab-backline}"
+pkgs="${HAB_STUDIO_BACKLINE_PKG:-core/hab-backline/$(
+  echo "$version" | $bb cut -d / -f 1)}"
 
 run_user="hab"
 run_group="$run_user"

--- a/www/source/partials/docs/_reference-environment-vars.html.md.erb
+++ b/www/source/partials/docs/_reference-environment-vars.html.md.erb
@@ -18,6 +18,7 @@ This is a list of all environment variables that can be used to modify the opera
 | `HAB_RING` | Supervisor | no default | The ring used by the Supervisor when running with [wire encryption](/docs/using-habitat#using-encryption) |
 | `HAB_RING_KEY` | Supervisor | no default | The name of the ring key when running with [wire encryption](/docs/using-habitat#using-encryption) |
 | `HAB_STUDIOS_HOME` | build system | `/hab/studios` if running as root; `$HOME/.hab/studios` if running as non-root | Directory in which to create build studios |
+| `HAB_STUDIO_BACKLINE_PKG` | build system | `core/hab-backline/{{studio_version}}` | Overrides the default package identifier for the "backline" package which installs the Studio basline package set. |
 | `HAB_STUDIO_ROOT` | build system | no default | Root of the current studio under `$HAB_STUDIOS_HOME`. Infrequently overridden. |
 | `HAB_STUDIO_NOSTUDIORC` | build system | no default | When set to a non-empty value, a `.studiorc` will not be sourced when entering an interactive Studio via `hab studio enter`. |
 | `HAB_STUDIO_SUP` | build system | no default | Used to customize the arguments passed to an automatically launched Supervisor, or to disable the automatic launching by setting it to `false`, `no`, or `0`. |


### PR DESCRIPTION
This change ensures that the same `a.b.c` version of the Studio's
backline package gets installed as the version of Studio that's running.
In other words, if you are running
`core/hab-studio/0.78.0/20171015010203`, then the version of backline
that will be installed would be `core/hab-backline/0.78.0`.

New Environment Variable
------------------------

While working on this change, I found an environment that I left in the
Studio code to override the package identifier default for backline.
This ended up being really useful for working on the solution, but the
naming of the environment variable was less consistent with the set of
variables we have now that relate to the Studio. So, I renamed this
variable to `HAB_STUDIO_BACKLINE_PKG`.

Closes #3712

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>