### PR TITLE
[studio] Show that `HAB_AUTH_TOKEN` is set, but redact value on output.

### DIFF
--- a/components/studio/bin/hab-studio.sh
+++ b/components/studio/bin/hab-studio.sh
@@ -1013,6 +1013,9 @@ report_env_vars() {
   if [ -n "${HAB_CONFIG_EXCLUDE:-}" ]; then
     info "Exported: HAB_CONFIG_EXCLUDE=$HAB_CONFIG_EXCLUDE"
   fi
+  if [ -n "${HAB_AUTH_TOKEN:-}" ]; then
+    info "Exported: HAB_AUTH_TOKEN=[redacted]"
+  fi
   if [ -n "${HAB_ORIGIN:-}" ]; then
     info "Exported: HAB_ORIGIN=$HAB_ORIGIN"
   fi


### PR DESCRIPTION
This change adds the environment variable outputing for `HAB_AUTH_TOKEN`
that happens for other supported environment variables, however the
value is not displayed as its contents are sensitive. This provides a
postitive confirmation that the value was picked up and set.

References #3772

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>