### PR TITLE
Validate Docker credentials

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -850,6 +850,7 @@ dependencies = [
  "habitat-builder-protocol 0.0.0",
  "habitat_core 0.0.0",
  "habitat_depot 0.0.0",
+ "habitat_http_client 0.0.0",
  "habitat_net 0.0.0",
  "hex 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/builder-api/Cargo.toml
+++ b/components/builder-api/Cargo.toml
@@ -55,5 +55,8 @@ path = "../builder-core"
 [dependencies.habitat_depot]
 path = "../builder-depot"
 
+[dependencies.habitat_http_client]
+path = "../http-client"
+
 [dependencies.habitat_net]
 path = "../net"

--- a/components/builder-api/src/lib.rs
+++ b/components/builder-api/src/lib.rs
@@ -25,6 +25,7 @@ extern crate habitat_builder_protocol as protocol;
 #[macro_use]
 extern crate habitat_core as hab_core;
 extern crate habitat_depot as depot;
+extern crate habitat_http_client as http_client;
 extern crate habitat_net as hab_net;
 extern crate hex;
 #[macro_use]

--- a/components/builder-api/src/server/handlers.rs
+++ b/components/builder-api/src/server/handlers.rs
@@ -132,17 +132,17 @@ pub fn validate_docker_credentials(req: &mut Request) -> IronResult<Response> {
         Ok(Some(b)) => b,
         Ok(None) => {
             debug!("Error: Missing request body");
-            return Ok(Response::with(status::BadRequest))
-        },
+            return Ok(Response::with(status::BadRequest));
+        }
         Err(err) => {
             debug!("Error: {:?}", err);
-            return Ok(Response::with(status::BadRequest))
+            return Ok(Response::with(status::BadRequest));
         }
     };
 
     if !body["username"].is_string() || !body["password"].is_string() {
         debug!("Error: Missing username or password");
-        return Ok(Response::with(status::BadRequest))
+        return Ok(Response::with(status::BadRequest));
     }
 
     // There's probably a better way to do this. Suggestions?
@@ -150,7 +150,7 @@ pub fn validate_docker_credentials(req: &mut Request) -> IronResult<Response> {
         Ok(c) => c,
         Err(e) => {
             debug!("Error: Unable to create HTTP client: {}", e);
-            return Ok(Response::with(status::InternalServerError))
+            return Ok(Response::with(status::InternalServerError));
         }
     };
 
@@ -165,15 +165,13 @@ pub fn validate_docker_credentials(req: &mut Request) -> IronResult<Response> {
     match result {
         Ok(response) => {
             match response.status {
-                StatusCode::Ok => {
-                    Ok(Response::with(status::NoContent))
-                },
+                StatusCode::Ok => Ok(Response::with(status::NoContent)),
                 _ => {
                     debug!("Non-OK Response: {}", &response.status);
                     Ok(Response::with(response.status))
                 }
             }
-        },
+        }
         Err(e) => {
             debug!("Error sending request: {:?}", e);
             Ok(Response::with(status::Forbidden))

--- a/components/builder-api/src/server/mod.rs
+++ b/components/builder-api/src/server/mod.rs
@@ -111,6 +111,9 @@ impl HttpGateway for ApiSrv {
             ext_repo_content: get "/ext/installations/:install_id/repos/:repo/contents/:path" => {
                 XHandler::new(github::repo_file_content).before(basic.clone())
             },
+            ext_credentials_docker: post "/ext/integrations/docker/credentials/validate" => {
+                XHandler::new(validate_docker_credentials).before(basic.clone())
+            },
         )
     }
 }

--- a/components/builder-web/app/BuilderApiClient.ts
+++ b/components/builder-web/app/BuilderApiClient.ts
@@ -620,6 +620,25 @@ export class BuilderApiClient {
     });
   }
 
+  public validateDockerCredentials(username: string, password: string) {
+    return new Promise((resolve, reject) => {
+      fetch(`${this.urlPrefix}/ext/integrations/docker/credentials/validate`, {
+        headers: this.headers,
+        method: 'POST',
+        body: JSON.stringify({ username, password })
+      })
+        .then(response => {
+          if (response.ok) {
+            resolve();
+          }
+          else {
+            reject(new Error(response.statusText));
+          }
+        })
+        .catch(error => reject(error));
+    });
+  }
+
   private handleError(error, reject) {
     const store = this.store;
     const state = store.getState();

--- a/components/builder-web/app/actions/index.ts
+++ b/components/builder-web/app/actions/index.ts
@@ -66,6 +66,7 @@ export const SET_ORIGIN_PRIVATE_KEY_UPLOAD_ERROR_MESSAGE = originActions.SET_ORI
 export const SET_ORIGIN_PUBLIC_KEY_UPLOAD_ERROR_MESSAGE = originActions.SET_ORIGIN_PUBLIC_KEY_UPLOAD_ERROR_MESSAGE;
 export const SET_ORIGIN_USER_INVITE_ERROR_MESSAGE = originActions.SET_ORIGIN_USER_INVITE_ERROR_MESSAGE;
 export const SET_ORIGIN_INTEGRATION_SAVE_ERROR_MESSAGE = originActions.SET_ORIGIN_INTEGRATION_SAVE_ERROR_MESSAGE;
+export const SET_INTEGRATION_CREDS_VALIDATION = originActions.SET_INTEGRATION_CREDS_VALIDATION;
 export const TOGGLE_ORIGIN_PICKER = originActions.TOGGLE_ORIGIN_PICKER;
 export const UPDATE_ORIGIN = originActions.UPDATE_ORIGIN;
 
@@ -137,6 +138,7 @@ export const removeNotification = notificationActions.removeNotification;
 
 export const acceptOriginInvitation = originActions.acceptOriginInvitation;
 export const createOrigin = originActions.createOrigin;
+export const clearIntegrationCredsValidation = originActions.clearIntegrationCredsValidation;
 export const deleteOriginInvitation = originActions.deleteOriginInvitation;
 export const deleteOriginMember = originActions.deleteOriginMember;
 export const deleteDockerIntegration = originActions.deleteDockerIntegration;
@@ -156,6 +158,7 @@ export const updateOrigin = originActions.updateOrigin;
 export const uploadOriginPrivateKey = originActions.uploadOriginPrivateKey;
 export const uploadOriginPublicKey = originActions.uploadOriginPublicKey;
 export const setDockerIntegration = originActions.setDockerIntegration;
+export const validateDockerCredentials = originActions.validateDockerCredentials;
 
 export const fetchDashboardRecent = packageActions.fetchDashboardRecent;
 export const fetchExplore = packageActions.fetchExplore;

--- a/components/builder-web/app/actions/origins.ts
+++ b/components/builder-web/app/actions/origins.ts
@@ -33,6 +33,7 @@ export const SET_CURRENT_ORIGIN_CREATING_FLAG = 'SET_CURRENT_ORIGIN_CREATING_FLA
 export const SET_CURRENT_ORIGIN_LOADING = 'SET_CURRENT_ORIGIN_LOADING';
 export const SET_CURRENT_ORIGIN_ADDING_PRIVATE_KEY = 'SET_CURRENT_ORIGIN_ADDING_PRIVATE_KEY';
 export const SET_CURRENT_ORIGIN_ADDING_PUBLIC_KEY = 'SET_CURRENT_ORIGIN_ADDING_PUBLIC_KEY';
+export const SET_INTEGRATION_CREDS_VALIDATION = 'SET_INTEGRATION_CREDS_VALIDATION';
 export const SET_ORIGIN_PRIVATE_KEY_UPLOAD_ERROR_MESSAGE = 'SET_ORIGIN_PRIVATE_KEY_UPLOAD_ERROR_MESSAGE';
 export const SET_ORIGIN_PUBLIC_KEY_UPLOAD_ERROR_MESSAGE = 'SET_ORIGIN_PUBLIC_KEY_UPLOAD_ERROR_MESSAGE';
 export const SET_ORIGIN_USER_INVITE_ERROR_MESSAGE = 'SET_ORIGIN_USER_INVITE_ERROR_MESSAGE';
@@ -313,6 +314,47 @@ export function updateOrigin(origin: any, token: string) {
   };
 }
 
+export function validateDockerCredentials(username: string, password: string, token: string) {
+  return dispatch => {
+
+    dispatch(setIntegrationCredsValidation({
+      validating: true,
+      validated: false,
+      valid: false,
+      message: 'Verifying...'
+    }));
+
+    new BuilderApiClient(token).validateDockerCredentials(username, password)
+      .then(response => {
+        dispatch(setIntegrationCredsValidation({
+          validating: false,
+          validated: true,
+          valid: true,
+          message: 'Verified'
+        }));
+      })
+      .catch(error => {
+        dispatch(setIntegrationCredsValidation({
+          validating: false,
+          validated: true,
+          valid: false,
+          message: 'Username and password combination is not valid.'
+        }));
+      });
+  };
+}
+
+export function clearIntegrationCredsValidation() {
+  return dispatch => {
+    dispatch(setIntegrationCredsValidation({
+      validating: false,
+      validated: false,
+      valid: false,
+      message: undefined
+    }));
+  };
+}
+
 export function fetchOriginsPackageCount(origins) {
   return dispatch => {
     origins.forEach(origin => {
@@ -442,6 +484,13 @@ function setOriginIntegrationSaveErrorMessage(payload: string) {
   return {
     type: SET_ORIGIN_INTEGRATION_SAVE_ERROR_MESSAGE,
     payload,
+  };
+}
+
+function setIntegrationCredsValidation(payload: any) {
+  return {
+    type: SET_INTEGRATION_CREDS_VALIDATION,
+    payload
   };
 }
 

--- a/components/builder-web/app/app.store.ts
+++ b/components/builder-web/app/app.store.ts
@@ -45,6 +45,6 @@ export class AppStore {
   }
 
   subscribe(listener: Function) {
-    this.store.subscribe(() => listener(this.getState()));
+    return this.store.subscribe(() => listener(this.getState()));
   }
 }

--- a/components/builder-web/app/initialState.ts
+++ b/components/builder-web/app/initialState.ts
@@ -112,7 +112,15 @@ export default Record({
     mine: List(),
     myInvitations: List(),
     currentIntegrations: Record({
-      docker: List()
+      docker: List(),
+      ui: Record({
+        creds: Record({
+          validating: false,
+          validated: false,
+          valid: false,
+          message: undefined
+        })()
+      })()
     })(),
     ui: Record({
       current: Record({

--- a/components/builder-web/app/origin/origin-page/docker-credentials-form/_docker-credentials-form.dialog.scss
+++ b/components/builder-web/app/origin/origin-page/docker-credentials-form/_docker-credentials-form.dialog.scss
@@ -10,7 +10,7 @@ hab-docker-credentials-dialog {
 
     .form-input-full-width {
       width: 100%;
-      margin-bottom: 22px;
+      margin-bottom: 18px;
 
       label {
         font-size: rem(12);
@@ -32,7 +32,22 @@ hab-docker-credentials-dialog {
       }
     }
 
+    p {
+      font-size: rem(13);
+      margin: 18px 0;
+
+      &.validating {
+        color: $medium-gray;
+      }
+
+      &.success {
+        color: $success-color;
+      }
+    }
+
     .controls {
+      margin-top: 22px;
+
       a {
         margin-left: 12px;
         cursor: pointer;

--- a/components/builder-web/app/origin/origin-page/docker-credentials-form/docker-credentials-form.dialog.html
+++ b/components/builder-web/app/origin/origin-page/docker-credentials-form/docker-credentials-form.dialog.html
@@ -16,6 +16,12 @@
         required>
     </div>
   </div>
+  <div *ngIf="creds.validating || creds.validated">
+    <p [class]="status.className">
+      <hab-icon [symbol]="status.icon" [class.spinning]="creds.validating"></hab-icon>
+      {{ creds.message }}
+    </p>
+  </div>
   <div class="controls">
     <button mat-raised-button tabindex="1" color="primary" type="submit" [disabled]="!dockerForm.form.valid">Save Account</button>
     <a (click)="close()">Cancel</a>

--- a/components/builder-web/app/reducers/origins.ts
+++ b/components/builder-web/app/reducers/origins.ts
@@ -116,6 +116,9 @@ export default function origins(state = initialState['origins'], action) {
       return state.setIn(['ui', 'current', 'loading'],
         action.payload);
 
+    case actionTypes.SET_INTEGRATION_CREDS_VALIDATION:
+      return state.setIn(['currentIntegrations', 'ui', 'creds'], action.payload);
+
     case actionTypes.SET_ORIGIN_PRIVATE_KEY_UPLOAD_ERROR_MESSAGE:
       return state.setIn(['ui', 'current', 'privateKeyErrorMessage'],
         action.payload);


### PR DESCRIPTION
This change adds a new API endpoint and associated UI support for validating Docker credentials. Also adds a mechanism for unsubscribing to updates on the Redux store.

Signed-off-by: Christian Nunciato <cnunciato@chef.io>

Fixes #3625 and #3677.

![](https://media.tenor.com/images/1d9b8a782cd182e8c0f59f7ecc9969c8/tenor.gif)