### PR TITLE
Add new `/origins/:origin/integrations endpoint

### DIFF
--- a/components/builder-depot/doc/api.raml
+++ b/components/builder-depot/doc/api.raml
@@ -130,6 +130,20 @@ securitySchemes:
                                 description: You are not authorized to send invitations on behalf of this origin
                             500:
                                 description: Internal server error
+
+        /integrations:
+            get:
+                description: Get an object of all integrations
+                securedBy: [oauth_2_0]
+                responses:
+                    200:
+                        body:
+                            application/json:
+                                example: |
+                                    {
+                                        "docker": ["region1", "region2"],
+                                        "google": ["region3"]
+                                    }
         /invitations:
             /{invitationId}:
                 put:

--- a/components/builder-depot/src/handlers/integrations.rs
+++ b/components/builder-depot/src/handlers/integrations.rs
@@ -74,6 +74,31 @@ pub fn validate_params(
     Ok(res)
 }
 
+pub fn fetch_origin_integrations(req: &mut Request) -> IronResult<Response> {
+    let params = match validate_params(req, &["origin"]) {
+        Ok(p) => p,
+        Err(st) => return Ok(Response::with(st)),
+    };
+    let mut request = OriginIntegrationRequest::new();
+    request.set_origin(params["origin"].clone());
+    match route_message::<OriginIntegrationRequest, OriginIntegrationResponse>(req, &request) {
+        Ok(oir) => {
+            let integrations_response: HashMap<String, Vec<String>> = oir.get_integrations()
+                .iter()
+                .fold(HashMap::new(), |mut acc, ref i| {
+                    acc.entry(i.get_integration().to_owned())
+                        .or_insert(Vec::new())
+                        .push(i.get_name().to_owned());
+                    acc
+                });
+            let mut response = render_json(status::Ok, &integrations_response);
+            helpers::dont_cache_response(&mut response);
+            Ok(response)
+        }
+        Err(err) => Ok(render_net_error(&err)),
+    }
+}
+
 pub fn fetch_origin_integration_names(req: &mut Request) -> IronResult<Response> {
     let params = match validate_params(req, &["origin", "integration"]) {
         Ok(p) => p,

--- a/components/builder-depot/src/server.rs
+++ b/components/builder-depot/src/server.rs
@@ -14,7 +14,7 @@
 
 use std::fs::{self, File};
 use std::path::PathBuf;
-use std::io::{Read, Write, BufWriter};
+use std::io::{BufWriter, Read, Write};
 use std::result;
 use std::str::FromStr;
 
@@ -23,8 +23,8 @@ use bldr_core;
 use bldr_core::helpers::transition_visibility;
 use bodyparser;
 use github_api_client::GitHubClient;
-use hab_core::package::{Identifiable, FromArchive, PackageArchive, PackageIdent, PackageTarget,
-                        ident};
+use hab_core::package::{ident, FromArchive, Identifiable, PackageArchive, PackageIdent,
+                        PackageTarget};
 use hab_core::crypto::keys::PairType;
 use hab_core::crypto::{BoxKeyPair, SigKeyPair};
 use hab_core::crypto::PUBLIC_BOX_KEY_VERSION;
@@ -33,16 +33,16 @@ use http_gateway::http::controller::*;
 use http_gateway::http::helpers::{self, dont_cache_response};
 use http_gateway::http::middleware::XRouteClient;
 use hab_net::{privilege, ErrCode, NetOk, NetResult};
-use hyper::header::{Charset, ContentDisposition, DispositionType, DispositionParam};
-use hyper::mime::{Mime, TopLevel, SubLevel, Attr, Value};
+use hyper::header::{Charset, ContentDisposition, DispositionParam, DispositionType};
+use hyper::mime::{Attr, Mime, SubLevel, TopLevel, Value};
 use iron::headers::{ContentType, UserAgent};
 use iron::middleware::BeforeMiddleware;
 use iron::request::Body;
 use persistent;
 use protobuf;
 use protocol::originsrv::*;
-use protocol::scheduler::{Group, GroupCreate, GroupGet, PackageStatsGet, PackageStats,
-                          PackagePreCreate, GroupAbort};
+use protocol::scheduler::{Group, GroupAbort, GroupCreate, GroupGet, PackagePreCreate,
+                          PackageStats, PackageStatsGet};
 use protocol::sessionsrv::{Account, AccountGet, AccountOriginRemove};
 use regex::Regex;
 use router::{Params, Router};
@@ -2262,6 +2262,11 @@ where
         },
         origin_integration_delete: delete "/origins/:origin/integrations/:integration/:name" => {
             XHandler::new(handlers::integrations::delete_origin_integration).before(basic.clone())
+        },
+        origin_integrations: get "/origins/:origin/integrations" => {
+            XHandler::new(
+                handlers::integrations::fetch_origin_integrations).before(basic.clone()
+            )
         },
 
         origin_invitation_create: post "/origins/:origin/users/:username/invitations" => {


### PR DESCRIPTION

![tenor-123263826](https://user-images.githubusercontent.com/1130349/31691912-4fdb5558-b35d-11e7-8507-66dd415cdce1.gif)

This endpoint will return a hash of all integrations by type, then name:

{
"docker": ["foo", "bar", "baz"],
"google": ["asdf"]
}

Signed-off-by: Travis Elliott Davis <edavis@chef.io>