### PR TITLE
Add an alternative path for user.toml

### DIFF
--- a/components/sup/src/fs.rs
+++ b/components/sup/src/fs.rs
@@ -20,6 +20,10 @@ lazy_static! {
     pub static ref SVC_ROOT: PathBuf = {
         Path::new(&*FS_ROOT_PATH).join("hab/svc")
     };
+
+    pub static ref USER_ROOT: PathBuf = {
+        Path::new(&*FS_ROOT_PATH).join("hab/user")
+    };
 }
 
 /// Returns the root path for a given service's configuration, files, and data.
@@ -65,4 +69,16 @@ pub fn svc_logs_path<T: AsRef<Path>>(service_name: T) -> PathBuf {
 /// Returns the path to a given service's pid file.
 pub fn svc_pid_file<T: AsRef<Path>>(service_name: T) -> PathBuf {
     svc_path(service_name).join("PID")
+}
+
+/// Returns the root path for a given service's user configuration,
+/// files, and data.
+pub fn user_path<T: AsRef<Path>>(service_name: T) -> PathBuf {
+    USER_ROOT.join(service_name)
+}
+
+/// Returns the path to a given service's user configuration
+/// directory.
+pub fn user_config_path<T: AsRef<Path>>(service_name: T) -> PathBuf {
+    user_path(service_name).join("config")
 }

--- a/components/sup/src/manager/service/config.rs
+++ b/components/sup/src/manager/service/config.rs
@@ -467,8 +467,6 @@ mod test {
     use toml;
     use tempdir::TempDir;
 
-    use hcore::package::{PackageIdent, PackageInstall};
-
     use super::*;
     use error::Error;
 
@@ -763,20 +761,14 @@ mod test {
 
     #[test]
     fn serialize_config() {
-        let pkg_id = PackageIdent::new("testing", "testing", Some("1.0.0"), Some("20170712000000"));
-        let pkg_install = PackageInstall::new_from_parts(
-            pkg_id.clone(),
-            PathBuf::from("/tmp"),
-            PathBuf::from("/tmp"),
-            PathBuf::from("/tmp"),
-        );
-        let pkg = Pkg::from_install(pkg_install).expect("Could not create package!");
         let concrete_path = TempDir::new("habitat_config_test").expect("create temp dir");
-
-        let mut cfg = Cfg::new(&pkg, Some(&concrete_path.as_ref().to_path_buf()))
-            .expect("Could not create config");
-
-        let default_toml = "shards = []\n\n[datastore]\ndatabase = \"builder_originsrv\"\npassword = \"\"\nuser = \"hab\"\n";
+        let pkg = TestPkg::new(&concrete_path);
+        let mut cfg = Cfg::new(&pkg, None).expect("Could not create config");
+        let default_toml = "shards = []\n\n\
+                            [datastore]\n\
+                            database = \"builder_originsrv\"\n\
+                            password = \"\"\n\
+                            user = \"hab\"\n";
 
         cfg.default = Some(toml::Value::Table(
             toml::de::from_str(default_toml).unwrap(),


### PR DESCRIPTION
This commit makes the supervisor to look for user configuration in two
locations: `/hab/svc/<pkgname>/user.toml` and
`/hab/user/<pkgname>/config/user.toml`. If the first path is missing, it
will try to load the configuration from the second one.

The reason is to work around an issue in Kubernetes/Docker/Linux
kernel.

In the Habitat operator we use the Kubernetes Secret feature for
putting user configuration as an initial configuration and as a source
of configuration updates. Initially it worked fine, until we
discovered that Kubernetes actually mounts a directory at
`/hab/svc/<pkgname>` to put `user.toml` there, so all the previous
contents there were effectively hidden.

We worked it around with a SubPath feature of Kubernetes, which
basically instead of mounting a directory at `/hab/svc/<pkgname>`,
bind-mounts some file on the host to the `/hab/svc/<pkgname>/user.toml`
path inside the Kubernetes pod.

This unfortunately breaks updating the configuration via the
Kubernetes Secret. This is because Kubernetes tries hard to make the
change of the Secret atomic. The atomicity of the change is achieved
with renaming. Doing the rename changes the inode of the target file
and since the bind mounts are based on inodes, the change is not
reflected in the pod.

It may take some time before we come up with a solution for this
problem and the solution to be released, so for now we would like to
add the second path for the user configuration. The new
`/hab/user/<pkgname>/config` directory can only contain `user.toml` file,
so it is safe to mount a directory here with our own copy of the file,
and we can stop using SubPath feature, so the updates should work
again.

Signed-off-by: Krzesimir Nowak <krzesimir@kinvolk.io>


Also, there seem to be an agreement that this file should be moved out of the `/hab/svc` directory, so users do not need to mess with the service specific files there.