### PR TITLE
Fix issue where all socket errors were reported as generic errors

### DIFF
--- a/components/net/src/conn/error.rs
+++ b/components/net/src/conn/error.rs
@@ -130,6 +130,8 @@ impl From<zmq::Error> for ConnErr {
     fn from(err: zmq::Error) -> Self {
         match err {
             zmq::Error::EHOSTUNREACH => ConnErr::HostUnreachable,
+            zmq::Error::EAGAIN => ConnErr::Timeout,
+            zmq::Error::EINTR | zmq::Error::ETERM => ConnErr::Shutdown(err),
             _ => ConnErr::Socket(err),
         }
     }


### PR DESCRIPTION
Improve `From<zmq::Error> for ConnErr` trait implementation to map
more known socket errors to a high level ConnErr. This should make
it much easier to determine what errors are happening at the socket
level, specifically when a shutdown or a timeout occurs.

![tenor-188249703](https://user-images.githubusercontent.com/54036/31710211-352a4524-b3a9-11e7-8c0a-051ddcb58f2c.gif)
