### PR TITLE
checksum the right zip for chocolatey

### DIFF
--- a/support/ci/appveyor.ps1
+++ b/support/ci/appveyor.ps1
@@ -131,7 +131,7 @@ if (($env:APPVEYOR_REPO_TAG_NAME -eq "$(Get-Content VERSION)") -or (Test-SourceC
                         mkdir "results/prod" -Force
                         Compress-Archive -Path ./windows -DestinationPath "results/prod/$zip"
                         $nuspec_version = $env:APPVEYOR_BUILD_VERSION.substring(0, $env:APPVEYOR_BUILD_VERSION.IndexOf('-'))
-                        $checksum = (Get-FileHash "results/prod/$zip" -Algorithm SHA256).Hash
+                        $checksum = (Get-FileHash "$stagingZipDir/$zip" -Algorithm SHA256).Hash
                         $choco_install = "c:/projects/habitat/components/hab/win/chocolateyinstall.ps1"
 
                         (Get-Content $choco_install) |


### PR DESCRIPTION
Bumped into a problem in yesterday's deployment where the checksum was wrong in the final choco install (fortunately chocolatey catchs this before publicizing the update). We were checksuming the wrong artifact.

Signed-off-by: mwrock <matt@mattwrock.com>