### PR TITLE
include svc_encrypted_password when converting a service to a spec

### DIFF
--- a/components/sup/src/manager/service/mod.rs
+++ b/components/sup/src/manager/service/mod.rs
@@ -367,6 +367,9 @@ impl Service {
         spec.binds = self.binds.clone();
         spec.start_style = self.start_style;
         spec.config_from = self.config_from.clone();
+        if let Some(ref password) = self.svc_encrypted_password {
+            spec.svc_encrypted_password = Some(password.clone())
+        }
         spec
     }
 

--- a/components/sup/src/manager/service/supervisor.rs
+++ b/components/sup/src/manager/service/supervisor.rs
@@ -94,6 +94,7 @@ impl Supervisor {
                 return true;
             }
         }
+        debug!("Could not find a live process with pid {:?}", self.pid);
         self.change_state(ProcessState::Down);
         self.cleanup_pidfile();
         self.pid = None;


### PR DESCRIPTION
Not sure when this regressed but currently one cannot start more than one service when starting services as a windows account different from the supervisor user because the password is not converted to the active spec. So when subsequent services are started and the file watcher looks at the state of existing services against desired specs (which have the password), the active spec appears "different" and then the supervisor attempts to restart the service, terminating the running service.

This simply adds the password to be carried over with `to_spec` and also adds a single bit of `debug!` logging that helped me to debug something else but seems good to keep.

Signed-off-by: mwrock <matt@mattwrock.com>