### PR TITLE
strip $ suffix when looking up the SID of an account name

### DIFF
--- a/components/win-users/src/account.rs
+++ b/components/win-users/src/account.rs
@@ -52,9 +52,19 @@ impl Account {
 }
 
 fn lookup_account(name: &str, system_name: Option<String>) -> Option<Account> {
+
+    // if this is a machine account, strip the terminating '$'
+    // LookupAccountName will return the sid of the computer account
+    // given the computer name. Windows forbids usernames to match the
+    // computer name
+    let stripped_name = if name.ends_with("$") {
+        &name[..name.len() - 1]
+    } else {
+        name
+    };
     let mut sid_size: u32 = 0;
     let mut domain_size: u32 = 0;
-    let wide = WideCString::from_str(name).unwrap();
+    let wide = WideCString::from_str(stripped_name).unwrap();
     unsafe {
         LookupAccountNameW(
             null_mut(),


### PR DESCRIPTION
This is one step towards running the hab launcher/supervisor as a service. A common practice is to run a windows service under the local service account. To habitat, this user would look like `COMPUTERNAME$`. However the win32 API to lookup accounts by name does not understand the trailing `$`. It does understand `COMPUTERNAME`. We do not need to worry about a user account with the same name as the computer because windows simply will not allow that. So this just strips any trailing `$` from a user name before a lookup so that we can identify a machine account as a valid account.

Signed-off-by: mwrock <matt@mattwrock.com>