### PR TITLE
Plumb auth token into the studio, correct regression with private packages

### DIFF
--- a/components/builder-depot/src/server.rs
+++ b/components/builder-depot/src/server.rs
@@ -31,7 +31,7 @@ use hab_core::crypto::PUBLIC_BOX_KEY_VERSION;
 use hab_core::event::*;
 use http_gateway::http::controller::*;
 use http_gateway::http::helpers::{self, check_origin_access, check_origin_owner,
-                                  dont_cache_response, get_param};
+                                  dont_cache_response, get_param, visibility_for_optional_session};
 use http_gateway::http::middleware::XRouteClient;
 use hab_net::{privilege, ErrCode, NetOk, NetResult};
 use hyper::header::{Charset, ContentDisposition, DispositionParam, DispositionType};
@@ -2008,21 +2008,6 @@ fn target_from_headers(user_agent_header: &UserAgent) -> result::Result<PackageT
         Ok(t) => Ok(t),
         Err(_) => Err(Response::with(status::BadRequest)),
     }
-}
-
-fn visibility_for_optional_session(
-    req: &mut Request,
-    optional_session_id: Option<u64>,
-    origin: &str,
-) -> Vec<OriginPackageVisibility> {
-    let mut v = Vec::new();
-    v.push(OriginPackageVisibility::Public);
-
-    if optional_session_id.is_some() && check_origin_access(req, origin).unwrap_or(false) {
-        v.push(OriginPackageVisibility::Private);
-    }
-
-    v
 }
 
 fn is_a_service<T>(req: &mut Request, ident: &T) -> bool

--- a/components/builder-worker/src/runner/mod.rs
+++ b/components/builder-worker/src/runner/mod.rs
@@ -238,9 +238,11 @@ impl Runner {
     fn build(&mut self) -> Result<PackageArchive> {
         let mut log_pipe = LogPipe::new(&self.workspace);
         log_pipe.pipe_stdout(b"\n--- BEGIN: Studio build ---\n")?;
-        let mut status = Studio::new(&self.workspace, &self.config.bldr_url).build(
-            &mut log_pipe,
-        )?;
+        let mut status = Studio::new(
+            &self.workspace,
+            &self.config.bldr_url,
+            &self.config.auth_token,
+        ).build(&mut log_pipe)?;
         log_pipe.pipe_stdout(b"\n--- END: Studio build ---\n")?;
 
         if fs::rename(self.workspace.src().join("results"), self.workspace.out()).is_err() {
@@ -310,7 +312,11 @@ impl Runner {
     }
 
     fn teardown(&mut self) -> Result<()> {
-        let exit_status = Studio::new(&self.workspace, &self.config.bldr_url).rm()?;
+        let exit_status = Studio::new(
+            &self.workspace,
+            &self.config.bldr_url,
+            &self.config.auth_token,
+        ).rm()?;
 
         if exit_status.success() {
             if let Some(err) = fs::remove_dir_all(self.workspace.src()).err() {

--- a/components/builder-worker/src/runner/studio.rs
+++ b/components/builder-worker/src/runner/studio.rs
@@ -19,6 +19,7 @@ use hab_core::channel::{BLDR_CHANNEL_ENVVAR, STABLE_CHANNEL};
 use hab_core::env;
 use hab_core::fs;
 use hab_core::url::BLDR_URL_ENVVAR;
+use hab_core::AUTH_TOKEN_ENVVAR;
 
 use error::Result;
 use runner::log_pipe::LogPipe;
@@ -36,14 +37,16 @@ lazy_static! {
 pub struct Studio<'a> {
     workspace: &'a Workspace,
     bldr_url: &'a str,
+    auth_token: &'a str,
 }
 
 impl<'a> Studio<'a> {
     /// Creates a new Studio runner for a given `Workspace` and Builder URL.
-    pub fn new(workspace: &'a Workspace, bldr_url: &'a str) -> Self {
+    pub fn new(workspace: &'a Workspace, bldr_url: &'a str, auth_token: &'a str) -> Self {
         Studio {
             workspace,
             bldr_url,
+            auth_token,
         }
     }
 
@@ -80,6 +83,7 @@ impl<'a> Studio<'a> {
             self.bldr_url
         );
         cmd.env(BLDR_URL_ENVVAR, self.bldr_url);
+        cmd.env(AUTH_TOKEN_ENVVAR, self.auth_token);
 
         debug!("spawning studio build command");
         let mut child = cmd.spawn()?;


### PR DESCRIPTION
We were incorrectly requiring origin access to retrieve channels and platforms for a package.  Additionally, `is_worker` shouldn't panic if there's no session.  Finally, we inject the auth token into the studio as an env var.

![tenor-158695358](https://user-images.githubusercontent.com/947/31796556-f0db1ef2-b4de-11e7-912a-7dd74689d429.gif)

Signed-off-by: Josh Black <raskchanky@gmail.com>