### PR TITLE
[studio] Redirect stderr to sup.log.

### DIFF
--- a/components/studio/libexec/hab-studio-type-default.sh
+++ b/components/studio/libexec/hab-studio-type-default.sh
@@ -128,7 +128,7 @@ sup-run() {
   mkdir -p /hab/sup/default
   echo "--> Launching the Habitat Supervisor in the background..."
   echo "    Running: hab sup run \$*"
-  hab sup run \$* > /hab/sup/default/sup.log &
+  hab sup run \$* > /hab/sup/default/sup.log 2>&1 &
   echo "    * Use 'hab svc start' & 'hab svc stop' to start and stop services"
   echo "    * Use 'sup-log' to tail the Supervisor's output (Ctrl+c to stop)"
   echo "    * Use 'sup-term' to terminate the Supervisor"


### PR DESCRIPTION
This change addresses an issue where the stderr output of the Supervisor
wasn't redirected to the log file in the Studio.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>