### PR TITLE
Some cleanup and additional debugging to jobsrv

### DIFF
--- a/components/builder-graph/README.md
+++ b/components/builder-graph/README.md
@@ -32,7 +32,7 @@ Example run:
 ```
 $ bldr-graph
 
-Connecting to builder_scheduler
+Connecting to builder_jobsrv
 Building graph... please wait.
 OK: 1224 nodes, 3537 edges (PT1.758762699S sec)
 

--- a/components/builder-graph/src/data_store.rs
+++ b/components/builder-graph/src/data_store.rs
@@ -27,7 +27,7 @@ pub struct DataStore {
     pool: Pool,
 }
 
-// Sample connection_url: "postgresql://hab@127.0.0.1/builder_scheduler"
+// Sample connection_url: "postgresql://hab@127.0.0.1/builder_jobsrv"
 
 impl DataStore {
     /// Create a new DataStore.

--- a/components/builder-jobsrv/src/data_store.rs
+++ b/components/builder-jobsrv/src/data_store.rs
@@ -637,7 +637,7 @@ impl DataStore {
             jobsrv::JobGroupProjectState::Skipped => "Skipped",
         };
         conn.execute(
-            "SELECT set_job_group_project_name_state_v1($1, $2, $3)",
+            "SELECT set_group_project_name_state_v1($1, $2, $3)",
             &[&(group_id as i64), &project_name, &state],
         ).map_err(Error::JobGroupProjectSetState)?;
         Ok(())

--- a/support/db/start.sh
+++ b/support/db/start.sh
@@ -32,7 +32,7 @@ while [ $running -eq 0 ]; do
   sleep 2
 done
 
-for dbname in builder_sessionsrv builder_jobsrv builder_originsrv builder_scheduler; do
+for dbname in builder_sessionsrv builder_jobsrv builder_originsrv; do
   if sudo -E TERM=vt100 hab pkg exec core/postgresql psql -lqt --host 127.0.0.1 -U hab | cut -d \| -f 1 | grep -qw $dbname; then
     echo "Database $dbname exists"
   else


### PR DESCRIPTION
This change has some fixes and cleanup for the builder job server:
1. Change the ZMQ server socket for the worker manager and scheduler from DEALER to ROUTER. This is because a DEALER-DEALER can only work if there is a single client peer, but with the the worker-manager and scheduler becoming peers to each other, the DEALER-DEALER was causing deadlocks.

2. Fix a case where a stored procedure was being called with an incorrect name.

3. Fix a case where skipping a project was incorrectly erroring out the entire group status.

4. Add some additional debugging statements and clean up some left over cases where we were still referring to the scheduler database.

5. Clean up the main thread loops to ensure we don't inadvertently exit the main loop if an error is encountered.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-205865182](https://user-images.githubusercontent.com/13542112/31858428-3b9429ba-b6ac-11e7-9c02-e60ad06ff986.gif)
