### PR TITLE
Updates build-a-sample app next steps

### DIFF
--- a/www/source/tutorials/sample-app/next-steps.html.slim
+++ b/www/source/tutorials/sample-app/next-steps.html.slim
@@ -16,10 +16,10 @@ section
     li Update configuration values dynamically to start the services up successfully
     li Upload your sample package to the depot
 
+  p If you want to extend the tutorial experience, dive into the #{link_to 'Using Habitat', '/docs/using-habitat/'} section of the docs to start playing with the many runtime features of Habitat. Or if you have a different web application that you would like to package, then we recommend you read through the #{link_to 'Build your Web App','/tutorials/build-your-own/'} guide. The guide is currently targeted at Ruby web applications and Node.js; however, if you are building with another framework such as Java web apps with Gradle, read #{link_to 'Scaffolding','/docs/glossary#glossary-scaffolding'} to find a scaffolding that can be used with your application type.
+
   p There are many more great features to explore in Habitat! As you venture out, we recommend you keep the following resources at your side. The docs are always being updated and we've got a great community that is ready and willing to help.
 
   ul
     li = link_to 'Habitat Docs', '/docs/'
     li = link_to 'Habitat Open Source Community', '/community/'
-
-  p If you have a web application that you would like to try and package, then we recommend you read through the #{link_to 'Build your Web App','/tutorials/build-your-own/'} guide. The guide is currently targeted at Ruby web applications; however, if you are building with another framework such as Node.js, read #{link_to 'Scaffolding','/docs/glossary#glossary-scaffolding/'} to find a scaffolding that can be used with your application type. And if you want to extend the tutorial experience, dive into the #{link_to 'Using Habitat', '/docs/using-habitat/'} section of the docs to start playing with the many runtime features of Habitat.


### PR DESCRIPTION
* Fixed the link to the scaffolding content in the glossary
* Added Node.js to the Build Your Web App guide as that is now an option
* Suggested they read the scaffolding if they are using a Java Gradle app
* Moved the 'There are many great features...' to use as a summary

Signed-off-by: Franklin Webber <franklin@chef.io>