### PR TITLE
Fix Typo in sidebar menu

### DIFF
--- a/www/data/docs_sidebar.yml
+++ b/www/data/docs_sidebar.yml
@@ -126,7 +126,7 @@ sidebar_links:
       link: "/docs/internals/#election-internals"
     - title: Crypto
       link: "/docs/internals/#crypto-internals"
-    - title: Bottstrapping Habitat
+    - title: Bootstrapping Habitat
       link: "/docs/internals/#bootstrap-internals"
   - title: Contribute
     link: "/docs/contribute"


### PR DESCRIPTION
In the docs sidebar, there is a typo.  It currently says "Bottstrapping Habitat" under internals.  This should be "Bootstrapping Habitat."

Signed-off-by: Nathan Cerny <ncerny@gmail.com>