### PR TITLE
Fix notification deadlock in jobsrv

### DIFF
--- a/components/builder-jobsrv/src/server/scheduler.rs
+++ b/components/builder-jobsrv/src/server/scheduler.rs
@@ -54,10 +54,6 @@ impl ScheduleClient {
 impl Default for ScheduleClient {
     fn default() -> ScheduleClient {
         let socket = (**DEFAULT_CONTEXT).as_mut().socket(zmq::DEALER).unwrap();
-        socket.set_sndhwm(1).unwrap();
-        socket.set_linger(0).unwrap();
-        socket.set_immediate(true).unwrap();
-
         ScheduleClient { socket: socket }
     }
 }
@@ -77,10 +73,7 @@ impl ScheduleMgr {
     where
         T: AsRef<Path>,
     {
-        let socket = (**DEFAULT_CONTEXT).as_mut().socket(zmq::ROUTER)?;
-        socket.set_rcvhwm(1)?;
-        socket.set_linger(0)?;
-        socket.set_immediate(true)?;
+        let socket = (**DEFAULT_CONTEXT).as_mut().socket(zmq::DEALER)?;
 
         let mut schedule_cli = ScheduleClient::default();
         schedule_cli.connect()?;

--- a/components/builder-jobsrv/src/server/worker_manager.rs
+++ b/components/builder-jobsrv/src/server/worker_manager.rs
@@ -59,9 +59,6 @@ impl WorkerMgrClient {
 impl Default for WorkerMgrClient {
     fn default() -> WorkerMgrClient {
         let socket = (**DEFAULT_CONTEXT).as_mut().socket(zmq::DEALER).unwrap();
-        socket.set_sndhwm(1).unwrap();
-        socket.set_linger(0).unwrap();
-        socket.set_immediate(true).unwrap();
         WorkerMgrClient { socket: socket }
     }
 }
@@ -158,12 +155,9 @@ impl WorkerMgr {
     pub fn new(cfg: &Config, datastore: DataStore, route_conn: RouteClient) -> Result<Self> {
         let hb_sock = (**DEFAULT_CONTEXT).as_mut().socket(zmq::SUB)?;
         let rq_sock = (**DEFAULT_CONTEXT).as_mut().socket(zmq::ROUTER)?;
-        let work_mgr_sock = (**DEFAULT_CONTEXT).as_mut().socket(zmq::ROUTER)?;
+        let work_mgr_sock = (**DEFAULT_CONTEXT).as_mut().socket(zmq::DEALER)?;
         rq_sock.set_router_mandatory(true)?;
         hb_sock.set_subscribe(&[])?;
-        work_mgr_sock.set_rcvhwm(1)?;
-        work_mgr_sock.set_linger(0)?;
-        work_mgr_sock.set_immediate(true)?;
 
         let mut schedule_cli = ScheduleClient::default();
         schedule_cli.connect()?;


### PR DESCRIPTION
This change fixes a deadlock that could occur with the internal notifications between the worker manager and scheduler threads in the job server. It also reverts the bind socket back to DEALER.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-102395951](https://user-images.githubusercontent.com/13542112/31909419-e95ebe00-b7ee-11e7-9ba4-4bfebb8b9805.gif)
