### PR TITLE
add cloudfoundary to cli docs + fully qualified package ident fixes

### DIFF
--- a/components/builder-depot-client/src/error.rs
+++ b/components/builder-depot-client/src/error.rs
@@ -65,8 +65,8 @@ impl fmt::Display for Error {
             }
             Error::IdentNotFullyQualified => {
                 format!(
-                    "Cannot perform the specified operation on a package identifier that is not \
-                    fully qualified; please include the package version and release"
+                    "Cannot perform the specified operation. \
+                    Specify a fully qualifed package identifier (ex: core/busybox-static/1.42.2/20170513215502)"
                 )
             }
             Error::UploadFailed(ref s) => format!("Upload failed: {}", s),
@@ -94,8 +94,8 @@ impl error::Error for Error {
             }
             Error::NoXFilename => "Invalid download from Builder - missing X-Filename header",
             Error::IdentNotFullyQualified => {
-                "Cannot perform the specified operation on a package identifier that is not fully \
-                qualified"
+                "Cannot perform the specified operation. \
+                Specify a fully qualifed package identifier (ex: core/busybox-static/1.42.2/20170513215502)"
             }
             Error::UploadFailed(_) => "Upload failed",
             Error::UrlParseError(ref err) => err.description(),

--- a/components/builder-depot-client/src/lib.rs
+++ b/components/builder-depot-client/src/lib.rs
@@ -664,6 +664,9 @@ impl Client {
     where
         I: Identifiable,
     {
+        if !ident.fully_qualified() {
+            return Err(Error::IdentNotFullyQualified);
+        }
         let path = channel_package_demote(channel, ident);
         debug!("Demoting package {}", ident);
 

--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -207,9 +207,10 @@ pub fn get() -> App<'static, 'static> {
                 (about: "Exports the package to the specified format")
                 (aliases: &["exp"])
                 (@arg FORMAT: +required +takes_value
-                    "The export format (ex: docker, aci, mesos, or tar)")
+                    "The export format (ex: aci, cf, docker, mesos, or tar)")
                 (@arg PKG_IDENT: +required +takes_value
-                    "A package identifier (ex: core/redis, core/busybox-static/1.42.2)")
+                    "A package identifier (ex: core/redis, core/busybox-static/1.42.2) or \
+                    filepath to a Habitat Artifact (ex: /home/acme-redis-3.0.7-21120102031201-x86_64-linux.hart)")
                 (@arg BLDR_URL: --url -u +takes_value {valid_url}
                     "Retrieve the container's package from the specified Builder \
                     (default: https://bldr.habitat.sh)")
@@ -273,11 +274,11 @@ pub fn get() -> App<'static, 'static> {
             )
             (@subcommand promote =>
                 (about: "Promote a package to a specified channel")
-                (aliases: &["pr", "pro"])
+                (aliases: &["pr", "pro", "promo", "promot"])
                 (@arg BLDR_URL: -u --url +takes_value {valid_url}
                     "Specify an alternate Builder endpoint (default: https://bldr.habitat.sh)")
                 (@arg PKG_IDENT: +required +takes_value
-                    "A package identifier (ex: core/redis/3.2.1/20160729052715)")
+                    "A fully qualifed package identifier (ex: core/busybox-static/1.42.2/20170513215502)")
                 (@arg CHANNEL: +required +takes_value
                     "Promote to the specified release channel")
                 (@arg AUTH_TOKEN: -z --auth +takes_value "Authentication token for Builder")
@@ -288,7 +289,7 @@ pub fn get() -> App<'static, 'static> {
                 (@arg BLDR_URL: -u --url +takes_value {valid_url}
                     "Specify an alternate Builder endpoint (default: https://bldr.habitat.sh)")
                 (@arg PKG_IDENT: +required +takes_value
-                    "A package identifier (ex: core/redis, core/busybox-static/1.42.2)")
+                    "A fully qualified package identifier (ex: core/busybox-static/1.42.2/20170513215502)")
                 (@arg CHANNEL: +required +takes_value
                     "Demote from the specified release channel")
                 (@arg AUTH_TOKEN: -z --auth +takes_value "Authentication token for Builder")
@@ -299,7 +300,7 @@ pub fn get() -> App<'static, 'static> {
                 (@arg BLDR_URL: -u --url +takes_value {valid_url}
                     "Specify an alternate Builder endpoint (default: https://bldr.habitat.sh)")
                 (@arg PKG_IDENT: +required +takes_value
-                    "A fully qualified package identifier (ex: core/redis/3.2.1/20160729052715)")
+                    "A fully qualified package identifier (ex: core/busybox-static/1.42.2/20170513215502)")
                 (@arg AUTH_TOKEN: -z --auth +takes_value "Authentication token for Builder")
             )
             (@subcommand verify =>

--- a/www/source/partials/docs/_commands-cli.html.md.erb
+++ b/www/source/partials/docs/_commands-cli.html.md.erb
@@ -462,7 +462,7 @@ Find out what channels a package belongs to
 
 **ARGS** 
 
-    <PKG_IDENT>    A fully qualified package identifier (ex: core/redis/3.2.1/20160729052715)
+    <PKG_IDENT>    A fully qualified package identifier (ex: core/busybox-static/1.42.2/20170513215502)
 
 <h2 id="hab-pkg-config" class="anchor">hab pkg config</h2>
 Displays the default configuration options for a service
@@ -499,7 +499,7 @@ Demote a package from a specified channel
 
 **ARGS** 
 
-    <PKG_IDENT>    A package identifier (ex: core/redis, core/busybox-static/1.42.2)
+    <PKG_IDENT>    A fully qualified package identifier (ex: core/busybox-static/1.42.2/20170513215502)
     <CHANNEL>      Demote from the specified release channel
 
 <h2 id="hab-pkg-env" class="anchor">hab pkg env</h2>
@@ -555,8 +555,9 @@ Exports the package to the specified format
 
 **ARGS** 
 
-    <FORMAT>       The export format (ex: docker, aci, mesos, or tar)
-    <PKG_IDENT>    A package identifier (ex: core/redis, core/busybox-static/1.42.2)
+    <FORMAT>       The export format (ex: aci, cf, docker, mesos, or tar)
+    <PKG_IDENT>    A package identifier (ex: core/redis, core/busybox-static/1.42.2) or
+                   filepath to a Habitat Artifact (ex: /home/acme-redis-3.0.7-21120102031201-x86_64-linux.hart)
 
 <h2 id="hab-pkg-hash" class="anchor">hab pkg hash</h2>
 Generates a blake2b hashsum from a target at any given filepath
@@ -633,7 +634,7 @@ Promote a package to a specified channel
 
 **ARGS** 
 
-    <PKG_IDENT>    A package identifier (ex: core/redis, core/busybox-static/1.42.2)
+    <PKG_IDENT>    A fully qualifed package identifier (ex: core/busybox-static/1.42.2/20170513215502)
     <CHANNEL>      Promote to the specified release channel
 
 <h2 id="hab-pkg-provides" class="anchor">hab pkg provides</h2>
@@ -710,7 +711,7 @@ Uploads a local Habitat Artifact to Habitat Builder
 **OPTIONS** 
 
     -z, --auth <AUTH_TOKEN>    Authentication token for Habitat Builder
-    -c, --channel <CHANNEL>    Additional release channel to upload package to. Packages are always uploaded to `unstable`, regardless of the   value of this option. (default: none)
+    -c, --channel <CHANNEL>    Additional release channel to upload package to. Packages are always uploaded to `unstable`, regardless of the value of this option. (default: none)
     -u, --url <BUILDER_URL>    Use a specific Habitat Builder URL (ex: https://bldr.habitat.sh)
 
 **ARGS** 


### PR DESCRIPTION
This PR adds a check for a fully qualified path for `hab pkg demote` and fixes the CLI help, docs, and error messages to be more helpful and accurate concerning fully qualified packages and package paths.

In addition, this alphabetizes the example list of export formats in `hab pkg export` and adds `cf` to the list.

Signed-off-by: echohack <echohack@users.noreply.github.com>