### PR TITLE
Remove the dev-setup check for Ubuntu 16.10

### DIFF
--- a/support/linux/install_dev_9_linux.sh
+++ b/support/linux/install_dev_9_linux.sh
@@ -15,10 +15,6 @@ if [ -f /etc/arch-release ]; then
   # According to https://docs.docker.com/engine/installation/linux/archlinux/
   # the Docker package is managed by the Arch Linux community
   sudo -E pacman -S --noconfirm docker
-elif [ -f /etc/lsb-release ] \
-    && [ "$(. /etc/lsb-release; echo $DISTRIB_DESCRIPTION)" = "Ubuntu 16.10" ]; then
-  # Until there is a 1.13 release, there is no stable Docker package for Yakkety :/
-  curl -sSL https://test.docker.com | sudo -E sh
 else
   curl -sSL https://get.docker.io | sudo -E sh
 fi


### PR DESCRIPTION
This no longer seems to be necessary (and is causing provisioning errors).

Signed-off-by: Christian Nunciato <cnunciato@chef.io>

![tenor-168136730](https://user-images.githubusercontent.com/274700/31920267-ab81da12-b81c-11e7-93a2-12f0615c7295.gif)

