### PR TITLE
Adds hab pkg binds command to list package bindings

### DIFF
--- a/components/common/src/command/package/binds.rs
+++ b/components/common/src/command/package/binds.rs
@@ -1,0 +1,67 @@
+// Copyright (c) 2016-2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Prints the binds for a service.
+//!
+//! # Examples
+//!
+//! ```bash
+//! $ hab pkg binds core/redis
+//! ```
+//!
+//! Will show all available binds.
+
+use std::io::{self, Write};
+use std::path::Path;
+
+use hcore;
+use hcore::package::{PackageIdent, PackageInstall};
+use hcore::package::metadata::Bind;
+
+use error::Result;
+
+pub fn start<P>(ident: &PackageIdent, fs_root_path: P) -> Result<()>
+where
+    P: AsRef<Path>,
+{
+    let package = PackageInstall::load(ident, Some(fs_root_path.as_ref()))?;
+    println!("Showing binds for {}", package.ident());
+    print_binds(package.binds(), true, package.ident());
+    print_binds(package.binds_optional(), false, package.ident());
+    Ok(())
+}
+
+fn print_binds(package_binds: hcore::error::Result<Vec<Bind>>, required: bool, package_ident: &PackageIdent) {
+     let bind_type = if required { "required" } else { "optional" };
+     match package_binds {
+        Ok(binds) => {
+            let binds_as_strings = binds.iter()
+                                        .map(ToString::to_string)
+                                        .collect::<Vec<String>>();
+            if !binds_as_strings.is_empty() {
+                println!("{}:\n    {}", bind_type, binds_as_strings.join("    \n"))
+            } else {
+                println!("{}: none", bind_type)
+            }
+        },
+        Err(_) => {
+            writeln!(
+                &mut io::stderr(),
+                "Error while querying {} binds for {}",
+                bind_type,
+                package_ident
+            ).expect("Failed printing to stderr")
+        }
+    }
+}

--- a/components/common/src/command/package/mod.rs
+++ b/components/common/src/command/package/mod.rs
@@ -12,5 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub mod binds;
 pub mod config;
 pub mod install;

--- a/components/core/src/package/metadata.rs
+++ b/components/core/src/package/metadata.rs
@@ -63,6 +63,13 @@ impl FromStr for Bind {
     }
 }
 
+impl fmt::Display for Bind {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let formatted_exports = self.exports.join(" ");
+        write!(f, "[{}]={}", self.service, formatted_exports)
+    }
+}
+
 /// Describes a bind mapping in a composite package.
 #[derive(Debug, PartialEq)]
 pub struct BindMapping {

--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -170,6 +170,11 @@ pub fn get() -> App<'static, 'static> {
             (about: "Commands relating to Habitat packages")
             (aliases: &["p", "pk", "package"])
             (@setting ArgRequiredElseHelp)
+            (@subcommand binds =>
+                (about: "Displays the binds for a service")
+                (@arg PKG_IDENT: +required +takes_value
+                    "A package identifier (ex: core/redis, core/busybox-statis/1.42.2")
+            )
             (@subcommand binlink =>
                 (about: "Creates a binlink for a package binary in a common 'PATH' location")
                 (aliases: &["bi", "bin", "binl", "binli", "binlin"])

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -144,6 +144,7 @@ fn start(ui: &mut UI) -> Result<()> {
         }
         ("pkg", Some(matches)) => {
             match matches.subcommand() {
+                ("binds", Some(m)) => sub_pkg_binds(m)?,
                 ("binlink", Some(m)) => sub_pkg_binlink(ui, m)?,
                 ("build", Some(m)) => sub_pkg_build(ui, m)?,
                 ("channels", Some(m)) => sub_pkg_channels(ui, m)?,
@@ -339,6 +340,13 @@ fn sub_pkg_config(m: &ArgMatches) -> Result<()> {
     let ident = PackageIdent::from_str(m.value_of("PKG_IDENT").unwrap())?;
 
     common::command::package::config::start(&ident, &*FS_ROOT)?;
+    Ok(())
+}
+
+fn sub_pkg_binds(m: &ArgMatches) -> Result<()> {
+    let ident = PackageIdent::from_str(m.value_of("PKG_IDENT").unwrap())?;
+
+    common::command::package::binds::start(&ident, &*FS_ROOT)?;
     Ok(())
 }
 


### PR DESCRIPTION
This new command prints the binds of a package. Here's a sample output:

```
$ target/debug/hab pkg binds core/kafka
Showing binds for core/kafka/0.10.1.0/20170622181219
required:
    [zookeeper]=port
optional: none
```

I replicated the `hab pkg config` command and adapted it for bindings.

Inspired by and closes #2021

Signed-off-by: Romain Sertelon <romain@sertelon.fr>