### PR TITLE
Don't log status check

### DIFF
--- a/components/builder-api-proxy/config/nginx.conf
+++ b/components/builder-api-proxy/config/nginx.conf
@@ -106,6 +106,13 @@ http {
       break;
     }
 
+    location /v1/status {
+      add_header Cache-Control "private, no-cache, no-store";
+      proxy_pass http://backend;
+      access_log off;
+      break;
+    }
+
     location ~* ^/v1/depot/.*/latest$ {
       add_header Cache-Control "private, no-cache, no-store";
       proxy_pass http://backend;


### PR DESCRIPTION
Update the API proxy nginx conf to not log the status check calls into the access log.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-25284020](https://user-images.githubusercontent.com/13542112/31973634-f3493754-b8db-11e7-8b41-dc721e6ef4d4.gif)
