### PR TITLE
Add user profile feature

### DIFF
--- a/components/builder-web/app/BuilderApiClient.ts
+++ b/components/builder-web/app/BuilderApiClient.ts
@@ -429,6 +429,42 @@ export class BuilderApiClient {
     });
   }
 
+  public getProfile() {
+    return new Promise((resolve, reject) => {
+      fetch(`${this.urlPrefix}/profile`, {
+        headers: this.headers,
+      })
+        .then(response => this.handleUnauthorized(response, reject))
+        .then(response => {
+          if (response.ok) {
+            resolve(response.json());
+          } else {
+            reject(new Error(response.statusText));
+          }
+        })
+        .catch(error => this.handleError(error, reject));
+    });
+  }
+
+  public saveProfile(profile: any) {
+    return new Promise((resolve, reject) => {
+      fetch(`${this.urlPrefix}/profile`, {
+        headers: this.headers,
+        method: 'PATCH',
+        body: JSON.stringify(profile)
+      })
+        .then(response => this.handleUnauthorized(response, reject))
+        .then(response => {
+          if (response.ok) {
+            resolve();
+          } else {
+            reject(new Error(response.statusText));
+          }
+        })
+        .catch(error => this.handleError(error, reject));
+    });
+  }
+
   public inviteUserToOrigin(username: string, origin: string) {
     return new Promise((resolve, reject) => {
       fetch(`${this.urlPrefix}/depot/origins/${origin}/users/${username}/invitations`, {

--- a/components/builder-web/app/actions/gitHub.ts
+++ b/components/builder-web/app/actions/gitHub.ts
@@ -17,7 +17,7 @@ import { URLSearchParams } from '@angular/http';
 import * as cookies from 'js-cookie';
 import config from '../config';
 import {
-  attemptSignIn, addNotification, goHome, fetchMyOrigins, fetchMyOriginInvitations, requestRoute, setPrivileges,
+  attemptSignIn, addNotification, goHome, fetchMyOrigins, fetchMyOriginInvitations, fetchProfile, requestRoute, setPrivileges,
   signOut, setSigningInFlag
 } from './index';
 import { DANGER, WARNING } from './notifications';
@@ -73,6 +73,7 @@ export function authenticateWithGitHub(oauth_token = undefined, session_token = 
       setCookie('bldrSessionToken', session_token);
       dispatch(fetchMyOrigins(session_token));
       dispatch(fetchMyOriginInvitations(session_token));
+      dispatch(fetchProfile(session_token));
     }
   };
 }

--- a/components/builder-web/app/actions/index.ts
+++ b/components/builder-web/app/actions/index.ts
@@ -99,6 +99,7 @@ export const ROUTE_REQUESTED = routerActions.ROUTE_REQUESTED;
 export const SET_REDIRECT_ROUTE = routerActions.SET_REDIRECT_ROUTE;
 export const RESET_REDIRECT_ROUTE = routerActions.RESET_REDIRECT_ROUTE;
 
+export const POPULATE_PROFILE = usersActions.POPULATE_PROFILE;
 export const SET_PRIVILEGES = usersActions.SET_PRIVILEGES;
 export const SIGN_IN_ATTEMPT = usersActions.SIGN_IN_ATTEMPT;
 export const SET_SIGNING_IN_FLAG = usersActions.SET_SIGNING_IN_FLAG;
@@ -187,6 +188,8 @@ export const requestRoute = routerActions.requestRoute;
 export const setRedirectRoute = routerActions.setRedirectRoute;
 export const resetRedirectRoute = routerActions.resetRedirectRoute;
 
+export const fetchProfile = usersActions.fetchProfile;
+export const saveProfile = usersActions.saveProfile;
 export const setPrivileges = usersActions.setPrivileges;
 export const setSigningInFlag = usersActions.setSigningInFlag;
 export const attemptSignIn = usersActions.attemptSignIn;

--- a/components/builder-web/app/app.component.html
+++ b/components/builder-web/app/app.component.html
@@ -1,12 +1,19 @@
+<hab-banner></hab-banner>
 <div id="main-nav">
-  <hab-notifications [notifications]="state.notifications.all" [removeNotification]="removeNotification">
-  </hab-notifications>
-  <hab-header [appName]="state.app.name" [isUserNavOpen]="user.isUserNavOpen" [isSignedIn]="user.isSignedIn" [username]="user.username"
-    [avatarUrl]="user.gitHub.get('avatar_url')" [signOut]="signOut" [toggleUserNavMenu]="toggleUserNavMenu"></hab-header>
+  <hab-notifications
+    [notifications]="state.notifications.all"
+    [removeNotification]="removeNotification"></hab-notifications>
+  <hab-header
+    [appName]="state.app.name"
+    [isUserNavOpen]="user.isUserNavOpen"
+    [isSignedIn]="user.isSignedIn"
+    [username]="user.username"
+    [avatarUrl]="user.gitHub.get('avatar_url')"
+    [signOut]="signOut"
+    [toggleUserNavMenu]="toggleUserNavMenu"></hab-header>
 </div>
 <div class="hab-container" [class.full]="fullView">
-  <hab-side-nav [isSignedIn]="user.isSignedIn" *ngIf="!hideNav">
-  </hab-side-nav>
+  <hab-side-nav [isSignedIn]="user.isSignedIn" *ngIf="!hideNav"></hab-side-nav>
   <section class="hab-main" [class.centered]="hideNav">
     <router-outlet></router-outlet>
   </section>

--- a/components/builder-web/app/app.module.ts
+++ b/components/builder-web/app/app.module.ts
@@ -21,6 +21,7 @@ import { MatIconModule, MatRadioModule, MatTabsModule } from '@angular/material'
 import { routing } from './routes';
 import { AppStore } from './app.store';
 import { AppComponent } from './app.component';
+import { BannerComponent } from './banner/banner.component';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { ExploreComponent } from './explore/explore.component';
 import { FooterComponent } from './footer/footer.component';
@@ -33,6 +34,7 @@ import { UserNavComponent } from './header/user-nav/user-nav.component';
 
 import { OriginModule } from './origin/origin.module';
 import { PackageModule } from './package/package.module';
+import { ProfileModule } from './profile/profile.module';
 import { SearchModule } from './search/search.module';
 import { SharedModule } from './shared/shared.module';
 
@@ -47,6 +49,7 @@ import { SharedModule } from './shared/shared.module';
     MatButtonModule,
     OriginModule,
     PackageModule,
+    ProfileModule,
     ReactiveFormsModule,
     SearchModule,
     SharedModule,
@@ -54,6 +57,7 @@ import { SharedModule } from './shared/shared.module';
   ],
   declarations: [
     AppComponent,
+    BannerComponent,
     ExploreComponent,
     FooterComponent,
     GravatarComponent,

--- a/components/builder-web/app/app.scss
+++ b/components/builder-web/app/app.scss
@@ -24,6 +24,7 @@ $output-bourbon-deprecation-warnings: false !default;
 @import "item-list";
 @import "tabs";
 
+@import "banner/banner.component";
 @import "explore/explore";
 @import "footer/footer";
 @import "header/header";
@@ -33,6 +34,7 @@ $output-bourbon-deprecation-warnings: false !default;
 @import "origin/origin.module";
 @import "shared/shared.module";
 @import "package/package.module";
+@import "profile/profile.module";
 
 @import "search/results/results.component";
 @import "search/search/search.component";

--- a/components/builder-web/app/banner/_banner.component.scss
+++ b/components/builder-web/app/banner/_banner.component.scss
@@ -1,0 +1,27 @@
+hab-banner {
+
+  .banner {
+    padding: 14px 0;
+    position: relative;
+    background-color: $hab-blue;
+    color: $white;
+    text-align: center;
+    font-size: rem(14);
+
+    a {
+      color: $white;
+      text-decoration: underline;
+    }
+
+    .dismiss {
+      width: 16px;
+      height: 16px;
+      display: block;
+      position: absolute;
+      top: 50%;
+      right: 32px;
+      transform: translateY(-50%);
+      cursor: pointer;
+    }
+  }
+}

--- a/components/builder-web/app/banner/banner.component.html
+++ b/components/builder-web/app/banner/banner.component.html
@@ -1,0 +1,8 @@
+<div class="banner" *ngIf="hidden">
+  <span>
+    New Habitat features and content are never far away.
+    <a [routerLink]="['/profile']">Add your email address</a>
+    to your profile for timely updates.
+  </span>
+  <hab-icon symbol="cancel" class="dismiss" (click)="dismiss()"></hab-icon>
+</div>

--- a/components/builder-web/app/banner/banner.component.ts
+++ b/components/builder-web/app/banner/banner.component.ts
@@ -1,0 +1,24 @@
+import { Component } from '@angular/core';
+import { AppStore } from '../app.store';
+
+@Component({
+  selector: 'hab-banner',
+  template: require('./banner.component.html')
+})
+export class BannerComponent {
+  dismissed: boolean = false;
+
+  constructor(private store: AppStore) {}
+
+  get hidden() {
+    return this.profile.id && !this.profile.email && !this.dismissed;
+  }
+
+  get profile() {
+    return this.store.getState().users.current.profile;
+  }
+
+  dismiss() {
+    this.dismissed = true;
+  }
+}

--- a/components/builder-web/app/header/user-nav/_user-nav.scss
+++ b/components/builder-web/app/header/user-nav/_user-nav.scss
@@ -53,12 +53,17 @@
   right: 0;
   top: 52px;
   z-index: 9999;
+  font-size: rem(14);
 
   li {
     display: block;
     min-width: 8em;
     padding-bottom: rem(10);
     text-align: left;
+
+    &.username {
+      color: $hab-gray-dark;
+    }
 
     &:last-child {
       border-top: 1px solid $light-gray;

--- a/components/builder-web/app/header/user-nav/user-nav.component.html
+++ b/components/builder-web/app/header/user-nav/user-nav.component.html
@@ -6,7 +6,13 @@
     <img src="{{avatarUrl}}" />
   </span>
   <ul class="main-nav--dropdown" *ngIf="isOpen">
-    <li>{{username}}</li>
+    <li class="username">
+      <hab-icon symbol="github"></hab-icon>
+      {{ username }}
+    </li>
+    <li>
+      <a [routerLink]="['/profile']" (click)="toggleUserNavMenu()">Profile</a>
+    </li>
     <li>
       <a href="#" (click)="signOut()">
         Sign Out

--- a/components/builder-web/app/initialState.ts
+++ b/components/builder-web/app/initialState.ts
@@ -65,45 +65,6 @@ export default Record({
   notifications: Record({
     all: List(),
   })(),
-  orgs: Record({
-    added: List(),
-    all: List(),
-    current: Record({
-      namespace: undefined,
-      name: undefined,
-      email: undefined,
-      website: undefined,
-      members: List(),
-      availableMemberSearchResults: List([
-        Record({
-          username: 'testUser',
-          name: 'Test User',
-          email: 'smith+chef-logo@getchef.com',
-          status: '',
-          canBeAdded: true,
-          ui: Record({
-            isActionsMenuOpen: false
-          })(),
-        })(),
-        Record({
-          username: 'testUser2',
-          name: 'Test User 2',
-          email: 'nlloyds@gmail.com',
-          status: '',
-          canBeAdded: true,
-          ui: Record({
-            isActionsMenuOpen: false
-          })(),
-        })(),
-      ]),
-      memberSearchResults: List(),
-    })(),
-    ui: Record({
-      create: Record({
-        saved: false,
-      })(),
-    })(),
-  })(),
   origins: Record({
     current: Origin(),
     currentPublicKeys: List(),
@@ -234,6 +195,11 @@ export default Record({
       username: undefined,
       flags: 0,
       gitHub: Map(),
+      profile: Record({
+        id: undefined,
+        name: undefined,
+        email: undefined
+      })()
     })(),
   })(),
 })();

--- a/components/builder-web/app/profile/_profile.module.scss
+++ b/components/builder-web/app/profile/_profile.module.scss
@@ -1,0 +1,1 @@
+@import "profile/profile.component";

--- a/components/builder-web/app/profile/profile-routing.module.ts
+++ b/components/builder-web/app/profile/profile-routing.module.ts
@@ -1,0 +1,30 @@
+// Copyright (c) 2016-2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { NgModule } from '@angular/core';
+import { Routes, RouterModule } from '@angular/router';
+import { ProfileComponent } from './profile/profile.component';
+
+const routes: Routes = [
+  {
+    path: 'profile',
+    component: ProfileComponent
+  }
+];
+
+@NgModule({
+  imports: [ RouterModule.forChild(routes) ],
+  exports: [ RouterModule ]
+})
+export class ProfileRoutingModule {}

--- a/components/builder-web/app/profile/profile.module.ts
+++ b/components/builder-web/app/profile/profile.module.ts
@@ -1,0 +1,36 @@
+// Copyright (c) 2016-2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { RouterModule } from '@angular/router';
+import { MatButtonModule } from '@angular/material';
+import { SharedModule } from '../shared/shared.module';
+import { ProfileRoutingModule } from './profile-routing.module';
+import { ProfileComponent } from './profile/profile.component';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    FormsModule,
+    MatButtonModule,
+    SharedModule,
+    ProfileRoutingModule
+  ],
+  declarations: [
+    ProfileComponent
+  ]
+})
+export class ProfileModule {}

--- a/components/builder-web/app/profile/profile/_profile.component.scss
+++ b/components/builder-web/app/profile/profile/_profile.component.scss
@@ -1,0 +1,28 @@
+.profile {
+
+  .page-body {
+    font-size: rem(14);
+
+    h3 {
+      font-size: rem(12);
+      text-transform: uppercase;
+    }
+
+    hr {
+      margin: 26px 0;
+    }
+
+    p {
+      margin-bottom: inherit;
+
+      hab-icon {
+        margin-right: 4px;
+      }
+    }
+
+    input {
+      margin: 16px 0;
+      max-width: 50%;
+    }
+  }
+}

--- a/components/builder-web/app/profile/profile/profile.component.html
+++ b/components/builder-web/app/profile/profile/profile.component.html
@@ -1,0 +1,31 @@
+<div class="profile">
+  <div class="page-title">
+    <h2>Profile</h2>
+    <h4>{{ profile.name }}</h4>
+  </div>
+  <div class="page-body">
+    <section>
+      <h3>GitHub Username</h3>
+      <p>The GitHub account under which you are currently signed in.</p>
+      <p>
+        <hab-icon symbol="github"></hab-icon>
+        {{ profile.name }}
+      </p>
+    </section>
+    <hr>
+    <form #f="ngForm" (submit)="save(f.value)">
+      <section>
+        <h3>Email Address</h3>
+        <p>Receive periodic updates about new Habitat features, tips and tutorials.</p>
+        <input type="email" name="email" autocomplete="off" [ngModel]="profile.email" email>
+      </section>
+      <hr>
+      <section>
+        <button mat-raised-button color="primary" [disabled]="!f.valid">
+          <span>Save</span>
+        </button>
+      </section>
+    </form>
+  </div>
+</div>
+

--- a/components/builder-web/app/profile/profile/profile.component.ts
+++ b/components/builder-web/app/profile/profile/profile.component.ts
@@ -1,0 +1,40 @@
+// Copyright (c) 2016-2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Component, OnInit } from '@angular/core';
+import { AppStore } from '../../app.store';
+import { fetchProfile, saveProfile } from '../../actions/index';
+
+@Component({
+  template: require('./profile.component.html')
+})
+export class ProfileComponent implements OnInit {
+  constructor(private store: AppStore) {}
+
+  ngOnInit() {
+    this.store.dispatch(fetchProfile(this.token));
+  }
+
+  save(form) {
+    this.store.dispatch(saveProfile({ email: form.email }, this.token));
+  }
+
+  get profile() {
+    return this.store.getState().users.current.profile;
+  }
+
+  get token() {
+    return this.store.getState().session.token;
+  }
+}

--- a/components/builder-web/app/reducers/users.ts
+++ b/components/builder-web/app/reducers/users.ts
@@ -19,6 +19,9 @@ import initialState from '../initialState';
 export default function users(state = initialState['users'], action) {
   switch (action.type) {
 
+    case actionTypes.POPULATE_PROFILE:
+      return state.setIn(['current', 'profile'], action.payload);
+
     case actionTypes.POPULATE_GITHUB_USER_DATA:
       return state.setIn(['current', 'gitHub'], fromJS(action.payload));
 

--- a/components/builder-web/app/shared/shared.module.ts
+++ b/components/builder-web/app/shared/shared.module.ts
@@ -50,7 +50,6 @@ import { UserLoggedInGuard } from './user/user.guard';
     MatRadioModule,
     MatSlideToggleModule,
     MatTooltipModule,
-    MatRadioModule,
     MatButtonModule,
     ReactiveFormsModule,
     RouterModule


### PR DESCRIPTION
This change adds a new Profile view, accessible from the account menu, allowing Builder users to provide their email addresses. Also adds a banner component for displaying global dismissable messaging and removes a no-longer-used section of initial state (orgs).

Closes #3351.

Signed-off-by: Christian Nunciato <cnunciato@chef.io>

![tenor-179676870](https://user-images.githubusercontent.com/274700/31975657-98f028ba-b8e7-11e7-818a-9ae4e8c057aa.gif)
