### PR TITLE
User-config Watcher

### DIFF
--- a/components/core/src/fs.rs
+++ b/components/core/src/fs.rs
@@ -43,6 +43,8 @@ pub const PKG_PATH: &'static str = "hab/pkgs";
 /// be used with extreme caution.
 pub const FS_ROOT_ENVVAR: &'static str = "FS_ROOT";
 pub const SYSTEMDRIVE_ENVVAR: &'static str = "SYSTEMDRIVE";
+/// The file where user-defined configuration for each service is found.
+pub const USER_CONFIG_FILE: &'static str = "user.toml";
 
 lazy_static! {
     /// The default filesystem root path.

--- a/components/sup/src/manager/file_watcher.rs
+++ b/components/sup/src/manager/file_watcher.rs
@@ -27,7 +27,7 @@ use notify::{DebouncedEvent, RecommendedWatcher, RecursiveMode, Watcher};
 
 use manager::debug::{IndentedStructFormatter, IndentedToString};
 
-const WATCHER_DELAY_MS: u64 = 2_000;
+pub const WATCHER_DELAY_MS: u64 = 2_000;
 static LOGKEY: &'static str = "FW";
 
 /// A set of callbacks for the watched file events.

--- a/components/sup/src/manager/file_watcher.rs
+++ b/components/sup/src/manager/file_watcher.rs
@@ -1223,16 +1223,54 @@ where
     return FileWatcher::<C, RecommendedWatcher>::create(path, callbacks);
 }
 
+pub fn default_file_watcher_with_no_initial_event<P, C>(
+    path: P,
+    callbacks: C,
+) -> Result<FileWatcher<C, RecommendedWatcher>>
+where
+    P: Into<PathBuf>,
+    C: Callbacks,
+{
+    return FileWatcher::<C, RecommendedWatcher>::create_with_no_initial_event(path, callbacks);
+}
+
 impl<C: Callbacks, W: Watcher> FileWatcher<C, W> {
     /// Creates a new `FileWatcher`.
     ///
     /// This will create an instance of `W` and start watching the
-    /// paths.
+    /// paths. When looping the file watcher, it will emit an initial
+    /// "file appeared" event if the watched file existed when the
+    /// file watcher was created.
     ///
     /// Will return `Error::NotifyCreateError` if creating the watcher
     /// fails. In case of watching errors, it returns
     /// `Error::NotifyError`.
     pub fn create<P>(path: P, callbacks: C) -> Result<Self>
+    where
+        P: Into<PathBuf>,
+    {
+        Self::create_instance(path, callbacks, true)
+    }
+
+    /// Creates a new `FileWatcher`.
+    ///
+    /// This will create an instance of `W` and start watching the
+    /// paths. When looping the file watcher, it will not emit any
+    /// initial "file appeared" event even if the watched file existed
+    /// when the file watcher was created.
+    ///
+    /// Will return `Error::NotifyCreateError` if creating the watcher
+    /// fails. In case of watching errors, it returns
+    /// `Error::NotifyError`.
+    pub fn create_with_no_initial_event<P>(path: P, callbacks: C) -> Result<Self>
+    where
+        P: Into<PathBuf>,
+    {
+        Self::create_instance(path, callbacks, false)
+    }
+
+    // Creates an instance of the FileWatcher.
+    fn create_instance<P>(path: P, callbacks: C, send_initial_event: bool) -> Result<Self>
     where
         P: Into<PathBuf>,
     {
@@ -1253,7 +1291,11 @@ impl<C: Callbacks, W: Watcher> FileWatcher<C, W> {
                 .watch(&directory, RecursiveMode::NonRecursive)
                 .map_err(|err| sup_error!(Error::NotifyError(err)))?;
         }
-        let initial_real_file = paths.real_file.clone();
+        let initial_real_file = if send_initial_event {
+            paths.real_file.clone()
+        } else {
+            None
+        };
 
         Ok(Self {
             callbacks: callbacks,

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -146,12 +146,12 @@ pub struct Manager {
     launcher: LauncherCli,
     services: Arc<RwLock<Vec<Service>>>,
     updater: ServiceUpdater,
-    watcher: SpecWatcher,
+    peer_watcher: Option<PeerWatcher>,
+    spec_watcher: SpecWatcher,
     organization: Option<String>,
     self_updater: Option<SelfUpdater>,
     service_states: HashMap<PackageIdent, Timespec>,
     sys: Arc<Sys>,
-    peer_watcher: Option<PeerWatcher>,
 }
 
 impl Manager {
@@ -318,12 +318,12 @@ impl Manager {
             events_group: cfg.eventsrv_group,
             launcher: launcher,
             services: services,
-            watcher: SpecWatcher::run(&fs_cfg.specs_path)?,
+            peer_watcher: peer_watcher,
+            spec_watcher: SpecWatcher::run(&fs_cfg.specs_path)?,
             fs_cfg: Arc::new(fs_cfg),
             organization: cfg.organization,
             service_states: HashMap::new(),
             sys: Arc::new(sys),
-            peer_watcher: peer_watcher,
         })
     }
 
@@ -528,7 +528,7 @@ impl Manager {
     }
 
     pub fn run(&mut self) -> Result<()> {
-        self.start_initial_services_from_watcher()?;
+        self.start_initial_services_from_spec_watcher()?;
 
         outputln!(
             "Starting gossip-listener on {}",
@@ -564,7 +564,7 @@ impl Manager {
                 self.shutdown();
                 return Ok(());
             }
-            self.update_running_services_from_watcher()?;
+            self.update_running_services_from_spec_watcher()?;
             self.update_peers_from_watch_file()?;
             self.check_for_updated_packages();
             self.restart_elections();
@@ -682,7 +682,7 @@ impl Manager {
             active_services.push(service.spec_ident.clone());
         }
 
-        for loaded in self.watcher
+        for loaded in self.spec_watcher
             .specs_from_watch_path()
             .unwrap()
             .values()
@@ -790,7 +790,7 @@ impl Manager {
         // add services that are not active but are being watched for changes
         // These would include stopped persistent services or other
         // persistent services that failed to load
-        for down in self.watcher
+        for down in self.spec_watcher
             .specs_from_watch_path()
             .unwrap()
             .values()
@@ -891,8 +891,8 @@ impl Manager {
         release_process_lock(&self.fs_cfg);
     }
 
-    fn start_initial_services_from_watcher(&mut self) -> Result<()> {
-        for service_event in self.watcher.initial_events()? {
+    fn start_initial_services_from_spec_watcher(&mut self) -> Result<()> {
+        for service_event in self.spec_watcher.initial_events()? {
             match service_event {
                 SpecWatcherEvent::AddService(spec) => {
                     if spec.desired_state == DesiredState::Up {
@@ -906,7 +906,7 @@ impl Manager {
         Ok(())
     }
 
-    fn update_running_services_from_watcher(&mut self) -> Result<()> {
+    fn update_running_services_from_spec_watcher(&mut self) -> Result<()> {
         let mut active_specs = HashMap::new();
         for service in self.services
             .read()
@@ -917,7 +917,7 @@ impl Manager {
             active_specs.insert(spec.ident.name.clone(), spec);
         }
 
-        for service_event in self.watcher.new_events(active_specs)? {
+        for service_event in self.spec_watcher.new_events(active_specs)? {
             match service_event {
                 SpecWatcherEvent::AddService(spec) => {
                     if spec.desired_state == DesiredState::Up {

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -22,6 +22,7 @@ mod service_updater;
 mod spec_watcher;
 mod file_watcher;
 mod peer_watcher;
+mod user_config_watcher;
 mod sys;
 
 use std::collections::HashMap;
@@ -35,6 +36,8 @@ use std::thread;
 use std::str::FromStr;
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
+use std::mem;
+use std::ops::DerefMut;
 
 use butterfly;
 use butterfly::member::Member;
@@ -59,6 +62,7 @@ use self::service::{DesiredState, Pkg, ProcessState, StartStyle};
 use self::service_updater::ServiceUpdater;
 use self::spec_watcher::{SpecWatcher, SpecWatcherEvent};
 use self::peer_watcher::PeerWatcher;
+use self::user_config_watcher::UserConfigWatcher;
 use VERSION;
 use error::{Error, Result, SupError};
 use config::GossipListenAddr;
@@ -148,6 +152,7 @@ pub struct Manager {
     updater: ServiceUpdater,
     peer_watcher: Option<PeerWatcher>,
     spec_watcher: SpecWatcher,
+    user_config_watcher: UserConfigWatcher,
     organization: Option<String>,
     self_updater: Option<SelfUpdater>,
     service_states: HashMap<PackageIdent, Timespec>,
@@ -320,6 +325,7 @@ impl Manager {
             services: services,
             peer_watcher: peer_watcher,
             spec_watcher: SpecWatcher::run(&fs_cfg.specs_path)?,
+            user_config_watcher: UserConfigWatcher::new(),
             fs_cfg: Arc::new(fs_cfg),
             organization: cfg.organization,
             service_states: HashMap::new(),
@@ -520,6 +526,16 @@ impl Manager {
                 0,
             );
         }
+
+        if let Err(e) = self.user_config_watcher.add(&service) {
+            outputln!(
+                "Unable to start UserConfigWatcher for {}: {}",
+                service.spec_ident,
+                e
+            );
+            return;
+        }
+
         self.updater.add(&service);
         self.services
             .write()
@@ -566,6 +582,7 @@ impl Manager {
             }
             self.update_running_services_from_spec_watcher()?;
             self.update_peers_from_watch_file()?;
+            self.update_running_services_from_user_config_watcher();
             self.check_for_updated_packages();
             self.restart_elections();
             self.census_ring.update_from_rumors(
@@ -831,7 +848,7 @@ impl Manager {
     /// service. Passing a value of `false` will let the Launcher keep the service running. This
     /// useful if you want the Supervisor to shutdown temporarily and then come back and re-attach
     /// to all running processes.
-    fn remove_service(&self, service: &mut Service, term: bool) {
+    fn remove_service(&mut self, service: &mut Service, term: bool) {
         // JW TODO: Update service rumor to remove service from cluster
         if term {
             service.stop(&self.launcher);
@@ -853,6 +870,13 @@ impl Manager {
                 "Unable to cleanup service health cache, {}, {}",
                 service,
                 err
+            );
+        }
+
+        if let Err(_) = self.user_config_watcher.remove(service) {
+            debug!(
+                "Error stopping user-config watcher thread for service {}",
+                service
             );
         }
     }
@@ -879,13 +903,23 @@ impl Manager {
         self.butterfly.restart_elections();
     }
 
-    fn shutdown(&self) {
+    fn shutdown(&mut self) {
         outputln!("Gracefully departing from butterfly network.");
         self.butterfly.set_departed();
 
-        let mut services = self.services.write().expect("Services lock is poisend!");
+        let mut svcs = Vec::new();
 
-        for mut service in services.drain(..) {
+        // The problem we're trying to work around here by adding this block is that `write`
+        // creates an immutable borrow on `self`, and `self.remove_service` needs `&mut self`.
+        // The solution is to introduce the block to drop the immutable borrow before the call to
+        // `self.remove_service`, and use `mem::swap` to move the services to a variable defined
+        // outside the block while we have the lock.
+        {
+            let mut services = self.services.write().expect("Services lock is poisoned!");
+            mem::swap(services.deref_mut(), &mut svcs);
+        }
+
+        for mut service in svcs.drain(..) {
             self.remove_service(&mut service, false);
         }
         release_process_lock(&self.fs_cfg);
@@ -947,21 +981,38 @@ impl Manager {
         }
     }
 
-    fn remove_service_for_spec(&mut self, spec: &ServiceSpec) -> Result<()> {
+    fn update_running_services_from_user_config_watcher(&mut self) {
         let mut services = self.services.write().expect("Services lock is poisoned");
-        // TODO fn: storing services as a `Vec` is a bit crazy when you have to do these
-        // shenanigans--maybe we want to consider changing the data structure in the future?
-        let services_idx = match services.iter().position(|ref s| s.spec_ident == spec.ident) {
-            Some(i) => i,
-            None => {
-                outputln!(
-                    "Tried to remove service for {} but could not find it running, skipping",
-                    &spec.ident
-                );
-                return Ok(());
+
+        for service in services.iter_mut() {
+            if self.user_config_watcher.have_events_for(service) {
+                outputln!("Reloading service {}", &service.spec_ident);
+                service.user_config_updated = true;
             }
-        };
-        let mut service = services.remove(services_idx);
+        }
+    }
+
+    fn remove_service_for_spec(&mut self, spec: &ServiceSpec) -> Result<()> {
+        let mut service: Service;
+
+        {
+            let mut services = self.services.write().expect("Services lock is poisoned");
+            // TODO fn: storing services as a `Vec` is a bit crazy when you have to do these
+            // shenanigans--maybe we want to consider changing the data structure in the future?
+            let services_idx = match services.iter().position(|ref s| s.spec_ident == spec.ident) {
+                Some(i) => i,
+                None => {
+                    outputln!(
+                        "Tried to remove service for {} but could not find it running, skipping",
+                        &spec.ident
+                    );
+                    return Ok(());
+                }
+            };
+
+            service = services.remove(services_idx);
+        }
+
         self.remove_service(&mut service, true);
         Ok(())
     }

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -667,6 +667,7 @@ impl Manager {
         }
     }
 
+    // Creates a rumor for the specified service.
     fn gossip_latest_service_rumor(&self, service: &Service) {
         let mut incarnation = 1;
         {

--- a/components/sup/src/manager/service/config.rs
+++ b/components/sup/src/manager/service/config.rs
@@ -24,6 +24,7 @@ use std::result;
 
 use fs;
 use hcore::{crypto, util};
+use hcore::fs::USER_CONFIG_FILE;
 use serde::{Serialize, Serializer};
 use serde::ser::SerializeMap;
 use serde_json;
@@ -197,16 +198,17 @@ impl Cfg {
 
     fn determine_user_config_path<P: PackageConfigPaths>(package: &P) -> PathBuf {
         let recommended_dir = package.recommended_user_config_dir();
-        let recommended_path = recommended_dir.join("user.toml");
+        let recommended_path = recommended_dir.join(USER_CONFIG_FILE);
         if recommended_path.exists() {
             return recommended_dir;
         }
         debug!(
-            "'user.toml' at {} does not exist",
+            "'{}' at {} does not exist",
+            USER_CONFIG_FILE,
             recommended_path.display()
         );
         let deprecated_dir = package.deprecated_user_config_dir();
-        let deprecated_path = deprecated_dir.join("user.toml");
+        let deprecated_path = deprecated_dir.join(USER_CONFIG_FILE);
         if deprecated_path.exists() {
             outputln!(
                 "The user configuration location at {} is deprecated, \
@@ -217,14 +219,15 @@ impl Cfg {
             return deprecated_dir;
         }
         debug!(
-            "'user.toml' at {} does not exist",
+            "'{}' at {} does not exist",
+            USER_CONFIG_FILE,
             deprecated_path.display()
         );
         recommended_dir
     }
 
     fn load_user<T: AsRef<Path>>(path: T) -> Result<Option<toml::Value>> {
-        Self::load_toml_file(path, "user.toml")
+        Self::load_toml_file(path, USER_CONFIG_FILE)
     }
 
     fn load_environment<P: PackageConfigPaths>(package: &P) -> Result<Option<toml::Value>> {
@@ -708,8 +711,8 @@ mod test {
         fn new() -> Self {
             let tmp = TempDir::new("habitat_config_test").expect("create temp dir");
             let pkg = TestPkg::new(&tmp);
-            let rucp = pkg.recommended_user_config_dir().join("user.toml");
-            let ducp = pkg.deprecated_user_config_dir().join("user.toml");
+            let rucp = pkg.recommended_user_config_dir().join(USER_CONFIG_FILE);
+            let ducp = pkg.deprecated_user_config_dir().join(USER_CONFIG_FILE);
             Self {
                 tmp: tmp,
                 pkg: pkg,

--- a/components/sup/src/manager/service/config.rs
+++ b/components/sup/src/manager/service/config.rs
@@ -139,7 +139,7 @@ impl Cfg {
     /// Updates the service configuration with data from a census group if the census group has
     /// newer data than the current configuration.
     ///
-    /// Returns true if the configuration was updated.
+    /// Returns `true` if the configuration was updated.
     pub fn update(&mut self, census_group: &CensusGroup) -> bool {
         match census_group.service_config {
             Some(ref config) => {
@@ -260,6 +260,7 @@ impl Cfg {
         Self::load_toml_file(path, USER_CONFIG_FILE)
     }
 
+    /// Reloads the user configuration file.
     pub fn reload_user(&mut self) -> Result<()> {
         let user = Self::load_user(self.user_config_path.get_path())?;
         self.user = user;
@@ -351,6 +352,7 @@ impl Serialize for Cfg {
 }
 
 #[derive(Debug)]
+/// Renders configuration templates into config files.
 pub struct CfgRenderer(TemplateRenderer);
 
 impl CfgRenderer {
@@ -388,6 +390,8 @@ impl CfgRenderer {
     }
 
     /// Compile and write all configuration files to the configuration directory.
+    ///
+    /// Returns `true` if the configuration has changed.
     pub fn compile(&self, pkg: &Pkg, ctx: &RenderContext) -> Result<bool> {
         // JW TODO: This function is loaded with IO errors that will be converted a Supervisor
         // error resulting in the end-user not knowing what the fuck happned at all. We need to go

--- a/components/sup/src/manager/service/hooks.rs
+++ b/components/sup/src/manager/service/hooks.rs
@@ -98,6 +98,8 @@ pub trait Hook: fmt::Debug + Sized {
     fn new(service_group: &ServiceGroup, render_pair: RenderPair) -> Self;
 
     /// Compile a hook into its destination service directory.
+    ///
+    /// Returns `true` if the hook has changed.
     fn compile(&self, service_group: &ServiceGroup, ctx: &RenderContext) -> Result<bool> {
         let content = self.renderer().render(Self::file_name(), ctx)?;
         if write_hook(&content, self.path())? {

--- a/components/sup/src/manager/service/mod.rs
+++ b/components/sup/src/manager/service/mod.rs
@@ -53,7 +53,7 @@ use census::{ServiceFile, CensusRing, ElectionStatus};
 use templating::RenderContext;
 use util;
 
-pub use self::config::Cfg;
+pub use self::config::{Cfg, UserConfigPath};
 pub use self::health::{HealthCheck, SmokeCheck};
 pub use self::package::Pkg;
 pub use self::composite_spec::CompositeSpec;

--- a/components/sup/src/manager/service_updater.rs
+++ b/components/sup/src/manager/service_updater.rs
@@ -62,6 +62,9 @@ enum FollowerState {
     Updating(Receiver<PackageInstall>),
 }
 
+/// The ServiceUpdater is in charge of updating a Service when a more recent version of a package
+/// has been published to a depot or installed to the local package cache.
+/// To use an update strategy, the supervisor must be configured to watch a depot for new versions.
 pub struct ServiceUpdater {
     states: UpdaterStateList,
     butterfly: butterfly::Server,

--- a/components/sup/src/manager/user_config_watcher.rs
+++ b/components/sup/src/manager/user_config_watcher.rs
@@ -1,0 +1,395 @@
+// Copyright (c) 2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::sync::mpsc::{channel, sync_channel, Sender, SendError, SyncSender, Receiver,
+                      TrySendError, TryRecvError};
+use std::thread::Builder as ThreadBuilder;
+
+use super::file_watcher::{Callbacks, default_file_watcher_with_no_initial_event};
+
+use hcore::fs::USER_CONFIG_FILE;
+use hcore::service::ServiceGroup;
+use manager::service::Service;
+use manager::service::UserConfigPath;
+
+static LOGKEY: &'static str = "UCW";
+
+// This trait exists to ease the testing of functions that receive a Service. Creating Services
+// requires a lot of ceremony, so we work around this with this trait.
+pub trait Serviceable {
+    fn name(&self) -> &str;
+    fn user_config_path(&self) -> &UserConfigPath;
+    fn service_group(&self) -> &ServiceGroup;
+}
+
+impl Serviceable for Service {
+    fn name(&self) -> &str {
+        &self.pkg.name
+    }
+
+    fn user_config_path(&self) -> &UserConfigPath {
+        &self.cfg.user_config_path
+    }
+
+    fn service_group(&self) -> &ServiceGroup {
+        &self.service_group
+    }
+}
+
+
+// WorkerState contains the channels the worker uses to communicate
+// with the Watcher.
+struct WorkerState {
+    // This receiver is used by the watcher to be notified when a
+    // worker has events.  The channel is a SyncChannel with buffer
+    // size 1, as we are only interested in the fact that there were
+    // events, not how many there were.
+    have_events: Receiver<()>,
+    // This sender is used by the watcher to notify a worker to stop
+    // running.  It is an async channel because we never want the
+    // UserConfigWatcher to block, even if the receiver end of the
+    // channel somehow dies and/or fails to consume the message.
+    stop_running: Sender<()>,
+    // This receiver is used by the watcher tests to be notified when
+    // a worker finished setting up the watcher and is about to
+    // starting looping it.
+    //
+    // Silence the dead code warnings from rustc, because it is only
+    // used in tests for synchronization purposes.
+    #[allow(dead_code)]
+    started_watching: Receiver<()>,
+}
+
+type ServiceName = String;
+pub struct UserConfigWatcher {
+    states: HashMap<ServiceName, WorkerState>,
+}
+
+impl UserConfigWatcher {
+    pub fn new() -> Self {
+        Self { states: HashMap::new() }
+    }
+
+    /// Adds a service to the User Config Watcher, thereby starting a watcher thread.
+    pub fn add<T: Serviceable>(&mut self, service: &T) -> io::Result<()> {
+        // It isn't possible to use the `or_insert_with` function here because it can't have a
+        // return value, which we need to return the error from `Worker::run`.
+        if self.states.get(service.name()).is_none() {
+            let user_toml_path = match service.user_config_path() {
+                &UserConfigPath::Recommended(ref p) => p.join(USER_CONFIG_FILE),
+                &UserConfigPath::Deprecated(ref p) => {
+                    outputln!(
+                        preamble service.service_group(),
+                        "Not watching {}, because it is located in deprecated path ({}).",
+                        USER_CONFIG_FILE,
+                        p.display(),
+                    );
+                    return Ok(());
+                }
+            };
+            // Establish bi-directional communication with the worker by creating two channels.
+            // The sync_channel's buffer size is 1 because we want to use it as a boolean, i.e. we
+            // are not interested in the events themselves, but only whether at least one has
+            // happened.
+            let (events_tx, events_rx) = sync_channel(1);
+            let (running_tx, running_rx) = channel();
+            let (watching_tx, watching_rx) = sync_channel(1);
+
+            Worker::run(user_toml_path, events_tx, running_rx, watching_tx)?;
+
+            outputln!(preamble service.service_group(), "Watching {}", USER_CONFIG_FILE);
+
+            let state = WorkerState {
+                have_events: events_rx,
+                stop_running: running_tx,
+                started_watching: watching_rx,
+            };
+
+            self.states.insert(service.name().to_owned(), state);
+        }
+
+        Ok(())
+    }
+
+    /// Removes a service from the User Config Watcher, and sends a message to the watcher thread
+    /// to stop running.
+    pub fn remove<T: Serviceable>(&mut self, service: &T) -> Result<(), SendError<()>> {
+        if let Some(state) = self.states.remove(service.name()) {
+            state.stop_running.send(())?;
+        }
+
+        Ok(())
+    }
+
+    /// Checks whether the watcher for the specified service has observed any events.
+    ///
+    /// This also consumes the events.
+    pub fn have_events_for<T: Serviceable>(&self, service: &T) -> bool {
+        if let Some(state) = self.states.get(service.name()) {
+            let rx = &state.have_events;
+
+            match rx.try_recv() {
+                Ok(_) => {
+                    return true;
+                }
+                Err(TryRecvError::Empty) => return false,
+                Err(TryRecvError::Disconnected) => {
+                    debug!("UserConfigWatcher worker has died!");
+                    return false;
+                }
+            }
+        }
+
+        false
+    }
+}
+
+struct UserConfigCallbacks {
+    have_events: SyncSender<()>,
+}
+
+impl Callbacks for UserConfigCallbacks {
+    fn file_appeared(&mut self, _: &Path) {
+        self.perform();
+    }
+
+    fn file_modified(&mut self, _: &Path) {
+        self.perform();
+    }
+
+    fn file_disappeared(&mut self, _: &Path) {
+        self.perform();
+    }
+}
+
+impl UserConfigCallbacks {
+    fn perform(&self) {
+        if let Err(TrySendError::Disconnected(_)) = self.have_events.try_send(()) {
+            debug!("Worker could not notify Manager of event");
+        }
+    }
+}
+
+struct Worker;
+
+impl Worker {
+    // starts a new thread with the file watcher tracking the service's user-config file
+    pub fn run(
+        path: PathBuf,
+        have_events: SyncSender<()>,
+        stop_running: Receiver<()>,
+        started_watching: SyncSender<()>,
+    ) -> io::Result<()> {
+        ThreadBuilder::new()
+            .name(format!("user-config-watcher-{}", path.display()))
+            .spawn(move || {
+                debug!(
+                    "UserConfigWatcher({}) worker thread starting",
+                    path.display(),
+                );
+                let callbacks = UserConfigCallbacks { have_events: have_events };
+                let mut file_watcher =
+                    match default_file_watcher_with_no_initial_event(&path, callbacks) {
+                        Ok(w) => w,
+                        Err(e) => {
+                            outputln!(
+                                "UserConfigWatcher({}) could not start notifier, \
+                                 ending thread ({})",
+                                path.display(),
+                                e,
+                            );
+                            return;
+                        }
+                    };
+
+                let _ = started_watching.try_send(());
+
+                loop {
+                    match stop_running.try_recv() {
+                        // As long as the `stop_running` channel is
+                        // empty, this branch will execute on every
+                        // iteration.
+                        Err(TryRecvError::Empty) => {
+                            if let Err(e) = file_watcher.single_iteration() {
+                                outputln!(
+                                    "UserConfigWatcher({}) could not run notifier, \
+                                     ending thread ({})",
+                                    path.display(),
+                                    e,
+                                );
+                                return;
+                            };
+                        }
+
+                        // If we receive a message on the channel, we stop.
+                        Ok(_) => break,
+
+                        // If the channel is disconnected, we stop as well.
+                        Err(TryRecvError::Disconnected) => {
+                            debug!(
+                                "UserConfigWatcher({}) worker thread failed to receive on channel",
+                                path.display(),
+                            );
+                            break;
+                        }
+                    }
+                }
+            })?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::fs::{remove_file, File};
+    use std::io::Write;
+    use std::str::FromStr;
+    use std::thread;
+    use std::time::{Duration, Instant};
+
+    use manager::file_watcher::WATCHER_DELAY_MS;
+
+    use tempdir::TempDir;
+
+    #[test]
+    fn no_events_at_first() {
+        let service = TestService::default();
+        let mut ucm = UserConfigWatcher::new();
+        ucm.add(&service).expect("adding service");
+
+        assert!(!ucm.have_events_for(&service));
+    }
+
+    #[test]
+    fn events_present_after_adding_config() {
+        let service = TestService::default();
+        let mut ucm = UserConfigWatcher::new();
+        ucm.add(&service).expect("adding service");
+        assert!(wait_for_watcher(&ucm, &service));
+
+        File::create(service.user_config_path().get_path().join(USER_CONFIG_FILE))
+            .expect("creating file");
+
+        assert!(wait_for_events(&ucm, &service));
+    }
+
+    #[test]
+    fn events_present_after_changing_config() {
+        let service = TestService::default();
+        let file_path = service.user_config_path().get_path().join(USER_CONFIG_FILE);
+        let mut ucm = UserConfigWatcher::new();
+
+        ucm.add(&service).expect("adding service");
+        assert!(wait_for_watcher(&ucm, &service));
+        let mut file = File::create(&file_path).expect("creating file");
+
+        file.write_all(b"42").expect(USER_CONFIG_FILE);
+
+        assert!(wait_for_events(&ucm, &service));
+    }
+
+    #[test]
+    fn events_present_after_removing_config() {
+        let service = TestService::default();
+        let file_path = service.user_config_path().get_path().join(USER_CONFIG_FILE);
+        let mut ucm = UserConfigWatcher::new();
+
+        ucm.add(&service).expect("adding service");
+        assert!(wait_for_watcher(&ucm, &service));
+        File::create(&file_path).expect("creating file");
+
+        // Allow the watcher to notice that a file was created.
+        wait_for_events(&ucm, &service);
+
+        remove_file(&file_path).expect("removing file");
+
+        assert!(wait_for_events(&ucm, &service));
+    }
+
+    fn wait_for_watcher<T: Serviceable>(ucm: &UserConfigWatcher, service: &T) -> bool {
+        let start = Instant::now();
+        let timeout = Duration::from_millis(1000);
+
+        while start.elapsed() < timeout {
+            let state = ucm.states.get(service.name()).expect("service added");
+            match state.started_watching.try_recv() {
+                Ok(_) => return true,
+                Err(TryRecvError::Empty) => (),
+                Err(TryRecvError::Disconnected) => return false,
+            }
+
+            thread::sleep(Duration::from_millis(10));
+        }
+
+        false
+    }
+
+    fn wait_for_events<T: Serviceable>(ucm: &UserConfigWatcher, service: &T) -> bool {
+        let start = Instant::now();
+        let timeout = Duration::from_millis(WATCHER_DELAY_MS * 2);
+
+        while start.elapsed() < timeout {
+            if ucm.have_events_for(service) {
+                return true;
+            }
+
+            thread::sleep(Duration::from_millis(10));
+        }
+
+        false
+    }
+
+    struct TestService {
+        // It is only used as a way to remove the temporary directory
+        // when the test finishes. Not used otherwise.
+        #[allow(dead_code)]
+        tmp: TempDir,
+        name: String,
+        user_config_path: UserConfigPath,
+        service_group: ServiceGroup,
+    }
+
+    impl Serviceable for TestService {
+        fn name(&self) -> &str {
+            &self.name
+        }
+
+        fn user_config_path(&self) -> &UserConfigPath {
+            &self.user_config_path
+        }
+
+        fn service_group(&self) -> &ServiceGroup {
+            &self.service_group
+        }
+    }
+
+    impl Default for TestService {
+        fn default() -> Self {
+            let tmp = TempDir::new("user-config-watcher").expect("creating temp dir");
+            let path = UserConfigPath::Recommended(tmp.path().to_path_buf());
+            Self {
+                tmp: tmp,
+                name: String::from("foo"),
+                user_config_path: path,
+                service_group: ServiceGroup::from_str("foo.bar@yoyodine").unwrap(),
+            }
+        }
+    }
+}

--- a/components/sup/src/templating/context.rs
+++ b/components/sup/src/templating/context.rs
@@ -53,6 +53,9 @@ impl<'a> BindGroup<'a> {
     }
 }
 
+/// The context of a render call.
+///
+/// It stores information on a Service and its configuration.
 #[derive(Clone, Debug, Serialize)]
 pub struct RenderContext<'a> {
     pub sys: &'a Sys,

--- a/www/source/partials/docs/_reference-hooks.html.md.erb
+++ b/www/source/partials/docs/_reference-hooks.html.md.erb
@@ -73,7 +73,7 @@ For processes that can update their configuration without requiring a restart a 
 ###reconfigure
 File location: `<plan>/hooks/reconfigure`
 
-This hook is run when service configuration information has changed through a set of Habitat services that are peers with each other. Before the `reconfigure` hook the config files are re-rendered and the process is either restarted or the `reload` hook is called if present.
+This hook is run when service configuration has changed due to updates coming from the gossip protocol or from the `user.toml` file. Before the `reconfigure` hook the config files are re-rendered and the process is either restarted or the `reload` hook is called if present.
 
 ###suitability
 File location: `<plan>/hooks/suitability`

--- a/www/source/partials/docs/_reference-supervisor-log-keys.html.md.erb
+++ b/www/source/partials/docs/_reference-supervisor-log-keys.html.md.erb
@@ -41,5 +41,6 @@ The meanings of the keys are as follows:
 | SU | Service updater |
 | SV | Supervisor |
 | SY | "sys" utility |
+| UCW | User-config watcher |
 | UR | Users utility |
 | UT | Utilities |


### PR DESCRIPTION
The User-config Watcher uses the FileWatcher to keep track of the `user.toml` file.

When a service is started, the UCW starts a worker thread that watches the file for changes, removal or creation. When either of those events happen, the worker notifies the Watcher via a channel.

The Manager can signal the Worker to stop running by using another channel.

Closes #2805.