### PR TITLE
Improve asset compilation in Builder UI

### DIFF
--- a/components/builder-web/bin/build-css
+++ b/components/builder-web/bin/build-css
@@ -1,7 +1,6 @@
 #!/bin/sh
 set -x
 
-npm run lint-css && \
 node-sass \
   --include-path=node_modules/bourbon-neat/app/assets/stylesheets \
   --include-path=node_modules/bourbon/app/assets/stylesheets \
@@ -13,6 +12,5 @@ node-sass \
   --recursive=true \
   --output=assets \
   --output-style=compressed \
-  --source-map=true \
-  "$@" \
+  $@ \
   app/app.scss

--- a/components/builder-web/bin/dist
+++ b/components/builder-web/bin/dist
@@ -14,11 +14,9 @@ cp habitat.conf.sample.js dist/habitat.conf.js
 
 css_sha=$(openssl dgst -sha256 assets/app.css | cut -d ' ' -f 2)
 cp assets/app.css "dist/assets/app-${css_sha}.css"
-cp assets/app.css.map "dist/assets/app-${css_sha}.css.map"
 
 js_sha=$(openssl dgst -sha256 assets/app.js | cut -d ' ' -f 2)
 cp assets/app.js "dist/assets/app-${js_sha}.js"
-cp assets/app.js.map "dist/assets/app-${js_sha}.js.map"
 sed -e "/id=\"hab-css\"/ s/app\.css/app-${css_sha}\.css/" \
     -e "/id=\"hab-js\"/ s/app\.js/app-${js_sha}\.js/" \
     index.html > dist/index.html

--- a/components/builder-web/bin/start
+++ b/components/builder-web/bin/start
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -x
 
+npm run build-css -- --source-map=true
+
 concurrently \
   "npm run build-css-watch" \
   "npm run build-js-watch" \

--- a/components/builder-web/package.json
+++ b/components/builder-web/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "concurrently \"npm run build-js\" \"npm run build-css\"",
     "build-css": "bin/build-css",
-    "build-css-watch": "npm run build-css -- --watch",
+    "build-css-watch": "npm run build-css -- --source-map=true --watch",
     "build-js": "npm run lint-js && webpack --config webpack.conf.js",
     "build-js-watch": "npm run build-js -- --watch",
     "clean": "concurrently \"npm run clean-js\" \"npm run clean-css\"",

--- a/components/builder-web/webpack.conf.js
+++ b/components/builder-web/webpack.conf.js
@@ -1,19 +1,21 @@
-"use strict";
+'use strict';
 
-const webpack = require("webpack");
-const isProduction = process.env.NODE_ENV == "production";
+const webpack = require('webpack');
+const isProduction = process.env.NODE_ENV === 'production';
 
 let loaders = [
-    { test: /\.ts$/, loader: "awesome-typescript-loader" },
-    { test: /\.html$/, loader: "raw-loader" }
+    { test: /\.ts$/, loader: 'awesome-typescript-loader' },
+    { test: /\.html$/, loader: 'raw-loader' }
 ];
 
 let plugins = [];
+let devtool = 'source-map';
 
 if (isProduction) {
+    devtool = false;
 
     // Set up compression to only happen if NODE_ENV = production
-    loaders.push({ test: "app.js", loader: "uglify" });
+    loaders.push({ test: 'app.js', loader: 'uglify' });
     plugins.push(
         new webpack.optimize.UglifyJsPlugin({
             compress: {
@@ -21,23 +23,23 @@ if (isProduction) {
                 warnings: false
             },
             mangle: false,
-            sourceMap: true
+            sourceMap: false
         })
     );
 }
 
 module.exports = {
-    devtool: "source-map",
-    entry: "./app/main.ts",
+    devtool: devtool,
+    entry: './app/main.ts',
     output: {
-        filename: "assets/app.js"
+        filename: 'assets/app.js'
     },
     resolve: {
-        extensions: ["", ".webpack.js", ".web.js", ".ts", ".js"]
+        extensions: ['', '.webpack.js', '.web.js', '.ts', '.js']
     },
     module: {
         preLoaders: [
-            { test: /\.ts$/, loader: "tslint" }
+            { test: /\.ts$/, loader: 'tslint' }
         ],
         loaders: loaders
     },


### PR DESCRIPTION
This change makes a few minor improvements to asset compilation in Builder:

* Removes CSS linting from compilation (we have a separate task for that)
* Builds CSS once before watching in the development environment (as passing `--watch` suppresses initial compilation)
* Removes CSS and JS source maps from production builds
* Single quotes in the Webpack config

Signed-off-by: Christian Nunciato <cnunciato@chef.io>

Fixes #3526.

![tenor-243878721](https://user-images.githubusercontent.com/274700/32027373-84c30f18-b99d-11e7-84ed-fecbc96fc9f5.gif)
