### PR TITLE
Fix the ability to disable non-core builds

### DIFF
--- a/components/builder-api/src/config.rs
+++ b/components/builder-api/src/config.rs
@@ -22,6 +22,7 @@ use std::option::IntoIter;
 use depot;
 use http_gateway::config::prelude::*;
 use segment_api_client::SegmentCfg;
+use typemap;
 
 use error::Error;
 
@@ -80,6 +81,10 @@ impl GatewayCfg for Config {
     fn route_addrs(&self) -> &[RouterAddr] {
         self.routers.as_slice()
     }
+}
+
+impl typemap::Key for Config {
+    type Value = Self;
 }
 
 /// Public listening net address for HTTP requests

--- a/components/builder-api/src/server/handlers.rs
+++ b/components/builder-api/src/server/handlers.rs
@@ -39,6 +39,7 @@ use protocol::sessionsrv::{Account, AccountGetId, AccountInvitationListRequest,
 use serde_json;
 use typemap;
 
+use config::Config;
 use github;
 use headers::*;
 use types::*;
@@ -696,6 +697,13 @@ pub fn project_show(req: &mut Request) -> IronResult<Response> {
         Some(o) => o,
         None => return Ok(Response::with(status::BadRequest)),
     };
+
+    let cfg = req.get::<persistent::Read<Config>>().unwrap();
+    if !cfg.depot.non_core_builds_enabled {
+        if origin != "core" {
+            return Ok(Response::with(status::Forbidden));
+        }
+    }
 
     let name = match get_param(req, "name") {
         Some(n) => n,

--- a/components/builder-api/src/server/mod.rs
+++ b/components/builder-api/src/server/mod.rs
@@ -36,6 +36,7 @@ impl HttpGateway for ApiSrv {
     type Config = Config;
 
     fn add_middleware(config: Arc<Self::Config>, chain: &mut iron::Chain) {
+        chain.link(persistent::Read::<Self::Config>::both(config.clone()));
         chain.link(persistent::Read::<GitHubCli>::both(
             GitHubClient::new(config.github.clone()),
         ));
@@ -106,10 +107,12 @@ impl HttpGateway for ApiSrv {
             project_privacy_toggle: patch "/projects/:origin/:name/:visibility" => {
                 XHandler::new(project_privacy_toggle).before(basic.clone())
             },
-            project_integration_get: get "/projects/:origin/:name/integrations/:integration/default" => {
+            project_integration_get: get
+                "/projects/:origin/:name/integrations/:integration/default" => {
                 XHandler::new(get_project_integration).before(basic.clone())
             },
-            project_integration_put: put "/projects/:origin/:name/integrations/:integration/default" => {
+            project_integration_put: put
+                "/projects/:origin/:name/integrations/:integration/default" => {
                 XHandler::new(create_project_integration).before(basic.clone())
             },
 

--- a/components/builder-depot/src/server.rs
+++ b/components/builder-depot/src/server.rs
@@ -954,6 +954,15 @@ fn schedule(req: &mut Request) -> IronResult<Response> {
         Some(origin) => origin,
         None => return Ok(Response::with(status::BadRequest)),
     };
+    {
+        let lock = req.get::<persistent::State<DepotUtil>>().unwrap();
+        let depot = lock.read().unwrap();
+        if !depot.config.builds_enabled ||
+            (origin_name != "core" && !depot.config.non_core_builds_enabled)
+        {
+            return Ok(Response::with(status::Forbidden));
+        }
+    }
     let package = match get_param(req, "pkg") {
         Some(pkg) => pkg,
         None => return Ok(Response::with(status::BadRequest)),


### PR DESCRIPTION
This commit ensures that the `non_core_builds_enabled` config field
for the builder-api disables the ability to build and will hide the
build button when disabled