### PR TITLE
Return 404 when a plan file isn’t found

### DIFF
--- a/components/builder-api/src/github.rs
+++ b/components/builder-api/src/github.rs
@@ -141,6 +141,7 @@ pub fn repo_file_content(req: &mut Request) -> IronResult<Response> {
         }
     };
     match github.contents(&token, repo.id, path) {
+        Ok(None) => Ok(Response::with(status::NotFound)),
         Ok(search) => Ok(render_json(status::Ok, &search)),
         Err(err) => Ok(Response::with((status::BadGateway, err.to_string()))),
     }


### PR DESCRIPTION
This adds a handler for `None` that returns 404 when GitHub reports the requested path doesn’t exist, allowing the UI to reflect that back to the user.

Signed-off-by: Christian Nunciato <cnunciato@chef.io>

Fixes #3875.

![tenor-263472782](https://user-images.githubusercontent.com/274700/32075845-d80cd2d4-ba52-11e7-8630-cbff1dace175.gif)
