### PR TITLE
Fix sorting of versions in the :pkg/:name/versions API call

### DIFF
--- a/components/builder-depot/src/server.rs
+++ b/components/builder-depot/src/server.rs
@@ -1318,21 +1318,16 @@ fn list_package_versions(req: &mut Request) -> IronResult<Response> {
         None => return Ok(Response::with(status::BadRequest)),
     };
 
-    let packages: NetResult<OriginPackageVersionListResponse>;
-
     let mut request = OriginPackageVersionListRequest::new();
     request.set_visibilities(visibility_for_optional_session(req, session_id, &origin));
     request.set_origin(origin);
     request.set_name(name);
 
-    packages = route_message::<OriginPackageVersionListRequest, OriginPackageVersionListResponse>(
+    match route_message::<OriginPackageVersionListRequest, OriginPackageVersionListResponse>(
         req,
         &request,
-    );
-
-    match packages {
+    ) {
         Ok(packages) => {
-            debug!("packages = {:?}", &packages);
             let body = serde_json::to_string(&packages.get_versions().to_vec()).unwrap();
             let mut response = Response::with((status::Ok, body));
 


### PR DESCRIPTION
The main change here is implementing `PartialOrd` and `Ord` traits for `OriginPackageVersion` which makes the packages in the `/v1/depot/:pkg/:name/version` API call sort correctly.

Also a little bit of minor cleanup and a test for the sorting.

![tenor-73906825](https://user-images.githubusercontent.com/947/32083369-eefcab94-ba76-11e7-971a-96c360b74bc7.gif)

Closes https://github.com/habitat-sh/habitat/issues/3288
Signed-off-by: Josh Black <raskchanky@gmail.com>