### PR TITLE
Start studio process in builder-worker with `airlock` 

### DIFF
--- a/components/builder-worker/habitat/config/config.toml
+++ b/components/builder-worker/habitat/config/config.toml
@@ -1,7 +1,7 @@
 auth_token = "{{cfg.auth_token}}"
 auto_publish = {{cfg.auto_publish}}
 data_path = "{{pkg.svc_data_path}}"
-log_path = "{{cfg.log_path}}"
+log_path = "{{cfg.svc_var_path}}"
 bldr_channel = "{{cfg.bldr_channel}}"
 features_enabled = "{{cfg.features_enabled}}"
 {{~#eachAlive bind.depot.members as |member|}}

--- a/components/builder-worker/habitat/default.toml
+++ b/components/builder-worker/habitat/default.toml
@@ -1,5 +1,4 @@
 log_level = "info"
-log_path = "/tmp"
 auth_token = ""
 auto_publish = true
 bldr_channel = "unstable"

--- a/components/builder-worker/habitat/plan.sh
+++ b/components/builder-worker/habitat/plan.sh
@@ -4,12 +4,10 @@ pkg_origin=core
 pkg_maintainer="Jamie Winsor <reset@chef.io>"
 pkg_license=('Apache-2.0')
 pkg_bin_dirs=(bin)
-pkg_deps=(core/glibc core/openssl core/gcc-libs core/zeromq core/libsodium core/libarchive
-  core/zlib core/hab-studio core/hab-pkg-export-docker core/docker core/curl)
+pkg_deps=(core/airlock core/glibc core/openssl core/gcc-libs core/zeromq core/libsodium
+  core/libarchive core/zlib core/hab-studio core/hab-pkg-export-docker core/docker core/curl)
 pkg_build_deps=(core/make core/cmake core/protobuf core/protobuf-rust core/coreutils core/cacerts
   core/rust core/gcc core/git core/pkg-config)
-pkg_svc_user="root"
-pkg_svc_group="root"
 pkg_binds=(
   [jobsrv]="worker_port worker_heartbeat log_port"
   [depot]="url"

--- a/components/builder-worker/src/error.rs
+++ b/components/builder-worker/src/error.rs
@@ -27,6 +27,8 @@ use retry;
 use url;
 use zmq;
 
+use runner::studio;
+
 pub type Result<T> = result::Result<T, Error>;
 
 #[derive(Debug)]
@@ -41,6 +43,8 @@ pub enum Error {
     InvalidIntegrations(String),
     NoAuthTokenError,
     NotHTTPSCloneUrl(url::Url),
+    NoStudioGroup,
+    NoStudioUser,
     Protobuf(protobuf::ProtobufError),
     Protocol(protocol::ProtocolError),
     Retry(retry::RetryError),
@@ -69,6 +73,12 @@ impl fmt::Display for Error {
                     "Attempted to clone {}. Only HTTPS clone urls are supported",
                     e
                 )
+            }
+            Error::NoStudioGroup => {
+                format!("System is missing studio group, {}", studio::STUDIO_GROUP)
+            }
+            Error::NoStudioUser => {
+                format!("System is missing studio user, {}", studio::STUDIO_USER)
             }
             Error::Protobuf(ref e) => format!("{}", e),
             Error::Protocol(ref e) => format!("{}", e),
@@ -99,6 +109,8 @@ impl error::Error for Error {
             Error::InvalidIntegrations(_) => "Invalid integrations detected",
             Error::NoAuthTokenError => "No auth_token config specified",
             Error::NotHTTPSCloneUrl(_) => "Only HTTPS clone urls are supported",
+            Error::NoStudioGroup => "System missing group to run studio",
+            Error::NoStudioUser => "System missing user to run studio",
             Error::Protobuf(ref err) => err.description(),
             Error::Protocol(ref err) => err.description(),
             Error::Retry(ref err) => err.description(),

--- a/components/builder-worker/src/runner/mod.rs
+++ b/components/builder-worker/src/runner/mod.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub mod studio;
 mod docker;
 mod log_pipe;
 mod postprocessor;
 mod publisher;
-mod studio;
 mod toml_builder;
 mod util;
 mod workspace;


### PR DESCRIPTION
Studios will be started in a more difficult to escape jail by using
the airlock program. The studio is also now given it's own user and
group for the airlock.

Companion to #3925