### PR TITLE
Set appropriate default log_path for jobsrv in Habitat plan

### DIFF
--- a/components/builder-jobsrv/habitat/config/config.toml
+++ b/components/builder-jobsrv/habitat/config/config.toml
@@ -1,5 +1,5 @@
 key_dir = "{{pkg.svc_files_path}}"
-log_path = "{{cfg.log_path}}"
+log_path = "{{pkg.svc_var_path}}"
 job_timeout = {{cfg.job_timeout}}
 
 [app]

--- a/components/builder-jobsrv/habitat/default.toml
+++ b/components/builder-jobsrv/habitat/default.toml
@@ -1,5 +1,4 @@
 log_level = "info"
-log_path = "/tmp"
 job_timeout = 60
 
 [net]


### PR DESCRIPTION
Set log_path to the service's var directory which the jobsrv user will have access to read and write from