### PR TITLE
Use stable packages except for when installing builder specifics

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,5 +1,5 @@
 export HAB_DOCKER_OPTS="-p 9636:80 -p 9631:9631 -p 9638:9638"
-export HAB_STUDIO_SUP="--channel unstable --auto-update"
+export HAB_STUDIO_SUP="--auto-update"
 export HAB_ORIGIN_KEYS
 HAB_CONFIG=~/.hab/etc/cli.toml
 if [ -e "$HAB_CONFIG" ]; then
@@ -12,4 +12,3 @@ fi
 if [ -n $HAB_ORIGIN ]; then
   HAB_ORIGIN_KEYS="${HAB_ORIGIN_KEYS},${HAB_ORIGIN}"
 fi
-export HAB_BLDR_CHANNEL=unstable

--- a/.studiorc
+++ b/.studiorc
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-export HAB_DEPOT_CHANNEL
 export APP_HOSTNAME
 export GITHUB_API_URL
 export GITHUB_WEB_URL
@@ -319,7 +318,6 @@ install-packages
 
 # NOTE: these are dev secrets (not for the actual Builder services);
 # it's OK
-HAB_DEPOT_CHANNEL=unstable
 APP_HOSTNAME=localhost:3000
 GITHUB_API_URL=https://api.github.com
 GITHUB_WEB_URL=https://github.com
@@ -339,6 +337,9 @@ init-datastore
 configure
 start-builder
 fi
+
+hab pkg exec core/busybox-static addgroup sparkleparty
+hab pkg exec core/busybox-static addgroup krangschnak -G sparkleparty -D
 
 # Print out the docs
 dev_docs


### PR DESCRIPTION
We want to use the stable package channel except for when we're
installing the builder packages themselves.

Additionally this installs a required user for the builder-worker
to run
