### PR TITLE
Allow origin members to download signing keys

### DIFF
--- a/components/builder-depot/src/server.rs
+++ b/components/builder-depot/src/server.rs
@@ -572,6 +572,10 @@ fn download_latest_origin_secret_key(req: &mut Request) -> IronResult<Response> 
         None => return Ok(Response::with(status::BadRequest)),
     };
 
+    if !check_origin_access(req, &origin).unwrap_or(false) {
+        return Ok(Response::with(status::Forbidden));
+    }
+
     let mut request = OriginSecretKeyGet::new();
     match helpers::get_origin(req, origin) {
         Ok(mut origin) => {
@@ -2158,7 +2162,7 @@ where
             XHandler::new(upload_origin_secret_key).before(basic.clone())
         },
         origin_secret_key_latest: get "/origins/:origin/secret_keys/latest" => {
-            XHandler::new(download_latest_origin_secret_key).before(worker.clone())
+            XHandler::new(download_latest_origin_secret_key).before(basic.clone())
         },
 
         builder_key_latest: get "/builder/keys/latest" => download_latest_builder_key,


### PR DESCRIPTION
These had previously been restricted to users with BUILD_WORKER privileges, but should be accessible to any member of the specified origin.

Signed-off-by: Christian Nunciato <cnunciato@chef.io>

Fixes #3869.

![tenor-59322585](https://user-images.githubusercontent.com/274700/32113993-edd65528-baf6-11e7-9a15-ca27651a32fa.gif)

