### PR TITLE
Set builder-worker to run as root/root

### DIFF
--- a/components/builder-worker/habitat/plan.sh
+++ b/components/builder-worker/habitat/plan.sh
@@ -12,6 +12,8 @@ pkg_binds=(
   [jobsrv]="worker_port worker_heartbeat log_port"
   [depot]="url"
 )
+pkg_svc_user="root"
+pkg_svc_group="root"
 bin="bldr-worker"
 
 do_prepare() {


### PR DESCRIPTION
Worker is required to run as root but it will drop privileges when the studio is spawned