### PR TITLE
Use the same friendly name for both user and group for studio user

### DIFF
--- a/components/builder-worker/habitat/plan.sh
+++ b/components/builder-worker/habitat/plan.sh
@@ -4,8 +4,10 @@ pkg_origin=core
 pkg_maintainer="Jamie Winsor <reset@chef.io>"
 pkg_license=('Apache-2.0')
 pkg_bin_dirs=(bin)
+# JW: Temporarily depend upon the latest dev studio. This should be removed once we've released
+# 0.39.0. We really need to not release these all in lock step :(
 pkg_deps=(core/airlock core/glibc core/openssl core/gcc-libs core/zeromq core/libsodium
-  core/libarchive core/zlib core/hab-studio core/hab-pkg-export-docker core/docker core/curl)
+  core/libarchive core/zlib core/hab-studio/0.39.0-dev core/hab-pkg-export-docker core/docker core/curl)
 pkg_build_deps=(core/make core/cmake core/protobuf core/protobuf-rust core/coreutils core/cacerts
   core/rust core/gcc core/git core/pkg-config)
 pkg_binds=(

--- a/components/builder-worker/src/runner/studio.rs
+++ b/components/builder-worker/src/runner/studio.rs
@@ -31,8 +31,7 @@ use runner::workspace::Workspace;
 pub static STUDIO_UID: AtomicUsize = ATOMIC_USIZE_INIT;
 pub static STUDIO_GID: AtomicUsize = ATOMIC_USIZE_INIT;
 pub const STUDIO_USER: &'static str = "krangschnak";
-// https://www.youtube.com/watch?v=f-jN3vH26NQ
-pub const STUDIO_GROUP: &'static str = "sparkleparty";
+pub const STUDIO_GROUP: &'static str = "krangschnak";
 
 lazy_static! {
     /// Absolute path to the Studio program

--- a/terraform/scripts/worker_bootstrap.sh
+++ b/terraform/scripts/worker_bootstrap.sh
@@ -3,5 +3,4 @@
 set -eux
 
 # Add a very uniquely named user/group pair for worker builds to run under.
-sudo adduser --group sparkleparty || echo "Group 'sparkleparty' already exists"
-sudo useradd -g sparkleparty --groups=tty --create-home krangschnak || echo "User 'krangschnak' already exists"
+sudo useradd --groups=tty --create-home krangschnak || echo "User 'krangschnak' already exists"


### PR DESCRIPTION
Using a different group would require more code changes and give us very little, if any, advantages