### PR TITLE
Use studio user's home dir for storing private keys in worker

### DIFF
--- a/components/builder-depot-client/src/lib.rs
+++ b/components/builder-depot-client/src/lib.rs
@@ -429,7 +429,7 @@ impl Client {
         &self,
         origin: &str,
         token: &str,
-        dst_path: &P,
+        dst_path: P,
     ) -> Result<PathBuf>
     where
         P: AsRef<Path>,

--- a/components/builder-worker/src/runner/mod.rs
+++ b/components/builder-worker/src/runner/mod.rs
@@ -31,7 +31,7 @@ use bldr_core::job::Job;
 use bldr_core::logger::Logger;
 use chrono::UTC;
 use depot_client;
-use hab_core::crypto;
+use hab_core::fs::CACHE_KEY_PATH;
 use hab_core::package::archive::PackageArchive;
 use hab_net::socket::DEFAULT_CONTEXT;
 use protocol::{message, jobsrv as proto};
@@ -208,7 +208,7 @@ impl Runner {
                 self.depot_cli.fetch_origin_secret_key(
                     self.job().origin(),
                     &self.config.auth_token,
-                    &crypto::default_cache_key_path(None),
+                    &*studio::STUDIO_HOME.lock().unwrap().join(CACHE_KEY_PATH),
                 )
             },
             |res| {

--- a/components/builder-worker/src/runner/studio.rs
+++ b/components/builder-worker/src/runner/studio.rs
@@ -15,6 +15,7 @@
 use std::os::unix::process::CommandExt;
 use std::path::PathBuf;
 use std::process::{Command, ExitStatus, Stdio};
+use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT, Ordering};
 
 use hab_core::channel::{BLDR_CHANNEL_ENVVAR, STABLE_CHANNEL};
@@ -39,6 +40,10 @@ lazy_static! {
         "hab-studio",
         include_str!(concat!(env!("OUT_DIR"), "/STUDIO_PKG_IDENT")),
     );
+
+    pub static ref STUDIO_HOME: Mutex<PathBuf> = {
+        Mutex::new(PathBuf::new())
+    };
 }
 
 pub struct Studio<'a> {

--- a/components/builder-worker/src/server.rs
+++ b/components/builder-worker/src/server.rs
@@ -180,6 +180,10 @@ fn init_users() -> Result<()> {
     let gid = users::get_gid_by_name(studio::STUDIO_GROUP).ok_or(
         Error::NoStudioGroup,
     )?;
+    let mut home = studio::STUDIO_HOME.lock().unwrap();
+    *home = users::get_home_for_user(studio::STUDIO_USER).ok_or(
+        Error::NoStudioGroup,
+    )?;
     studio::set_studio_uid(uid);
     studio::set_studio_gid(gid);
     Ok(())


### PR DESCRIPTION
Prior the worker would download keys into the root user's directory
and those keys would be imported into the studio. By changing which
user is running the studio we need to install the keys into a more
appropriate location