### PR TITLE
Pass the account id to segment instead of the account name.

### DIFF
--- a/components/builder-api/src/server/handlers.rs
+++ b/components/builder-api/src/server/handlers.rs
@@ -85,7 +85,10 @@ pub fn github_authenticate(req: &mut Request) -> IronResult<Response> {
 
             // We don't really want to abort anything just because a call to segment failed. Let's
             // just log it and move on.
-            if let Err(e) = segment.identify(session.get_name()) {
+            // TODO JB: this likely needs to change after we switch to our own internal session
+            // tokens
+            let id_str = session.get_id().to_string();
+            if let Err(e) = segment.identify(&id_str) {
                 warn!("Error identifying a user in segment, {}", e);
             }
 


### PR DESCRIPTION
![tenor-126917624](https://user-images.githubusercontent.com/947/32122136-2ed1180c-bb14-11e7-9100-e06240429087.gif)

Closes https://github.com/habitat-sh/habitat/issues/3939
Signed-off-by: Josh Black <raskchanky@gmail.com>