### PR TITLE
Keep environment when executing Studio from within worker

### DIFF
--- a/components/builder-worker/src/runner/studio.rs
+++ b/components/builder-worker/src/runner/studio.rs
@@ -128,7 +128,6 @@ impl<'a> Studio<'a> {
         let mut cmd = Command::new("airlock");
         cmd.uid(studio_uid());
         cmd.gid(studio_gid());
-        cmd.env_clear();
         if let Some(val) = env::var_os(RUNNER_DEBUG_ENVVAR) {
             cmd.env("DEBUG", val);
         }


### PR DESCRIPTION
We should keep the environment when running the Studio from the
worker so we are able to keep the important bits setup by Habitat's
packaging. The environment will be clean once the program is being
built in the Studio, so there is no specific reason to clear the env
in the first place
