### PR TITLE
Builder Worker airlock fixes

### DIFF
--- a/components/builder-worker/habitat/hooks/run
+++ b/components/builder-worker/habitat/hooks/run
@@ -3,6 +3,7 @@
 export HOME={{pkg.svc_data_path}}
 export RUST_LOG={{cfg.log_level}}
 export RUST_BACKTRACE=1
+export HAB_STUDIO_BACKLINE_PKG=core/hab-backline
 pkg_svc_run="bldr-worker start -c {{pkg.svc_config_path}}/config.toml"
 
 exec ${pkg_svc_run} 2>&1

--- a/components/builder-worker/src/runner/studio.rs
+++ b/components/builder-worker/src/runner/studio.rs
@@ -126,6 +126,7 @@ impl<'a> Studio<'a> {
     /// Builds and returns a `Command` for spawning a Habitat Studio process.
     fn studio_command(&self) -> Command {
         let mut cmd = Command::new("airlock");
+        cmd.current_dir(self.workspace.src());
         cmd.uid(studio_uid());
         cmd.gid(studio_gid());
         if let Some(val) = env::var_os(RUNNER_DEBUG_ENVVAR) {
@@ -135,8 +136,6 @@ impl<'a> Studio<'a> {
         cmd.env("TERM", "xterm-256color"); // Emits ANSI color codes
         cmd.arg("run");
         cmd.arg(&*STUDIO_PROGRAM);
-        cmd.arg("-s"); // Source path
-        cmd.arg(self.workspace.src());
         cmd.arg("-r"); // Studio root
         cmd.arg(self.workspace.studio());
         cmd.stdout(Stdio::piped());


### PR DESCRIPTION
* Fix the chance that the src directory will fall outside of the airlock by first changing directory to the src tree before entering the studio
* Studio is locked to the version of backline it was built against at runtime. This change will allow us to use whatever version of backline is located on the machine instead when starting a studio from withint he Worker