### PR TITLE
Fix some warnings appearing with rust 1.21.0

### DIFF
--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -1218,7 +1218,7 @@ fn composite_binds_from_input(m: &ArgMatches) -> Result<HashMap<String, Vec<Serv
                 // It's a composite bind
                 let service_name = parts[0];
                 let bind = format!("{}:{}", parts[1], parts[2]);
-                let mut binds = map.entry(service_name.to_string()).or_insert(vec![]);
+                let binds = map.entry(service_name.to_string()).or_insert(vec![]);
                 binds.push(ServiceBind::from_str(&bind)?);
             } else {
                 // You supplied a 2-part (i.e., standalone service)

--- a/components/sup/src/manager/file_watcher.rs
+++ b/components/sup/src/manager/file_watcher.rs
@@ -3416,10 +3416,10 @@ mod tests {
             real_first_expected: PathBuf,
         ) -> HashMap<PathBuf, PathState> {
             // link last additional path state with the first expected one
-            if let Some(mut last) = additional_paths.last_mut() {
+            if let Some(last) = additional_paths.last_mut() {
                 // The existence of this path in the map is checked in
                 // get_real_first_expected_path.
-                let mut first_item = expected_paths.get_mut(&real_first_expected).unwrap();
+                let first_item = expected_paths.get_mut(&real_first_expected).unwrap();
 
                 last.1.next = Some(real_first_expected);
                 first_item.prev = Some(last.0.clone());

--- a/components/sup/src/manager/file_watcher.rs
+++ b/components/sup/src/manager/file_watcher.rs
@@ -2465,7 +2465,7 @@ mod tests {
                             },
                         },
                         events: vec![NotifyEvent::disappeared(pb!("/a/b/c"))],
-                    }
+                    },
                 ],
             },
         ]
@@ -2732,7 +2732,10 @@ mod tests {
 
         fn pop_level(&mut self) {
             self.logs_per_level.pop();
-            assert!(!self.logs_per_level.is_empty(), "too many pops on DebugInfo");
+            assert!(
+                !self.logs_per_level.is_empty(),
+                "too many pops on DebugInfo"
+            );
         }
 
         fn add(&mut self, str: String) {

--- a/components/sup/src/manager/peer_watcher.rs
+++ b/components/sup/src/manager/peer_watcher.rs
@@ -212,7 +212,7 @@ mod tests {
         member2.set_gossip_port(GOSSIP_DEFAULT_PORT as i32);
         let expected_members = vec![member1, member2];
         let mut members = watcher.get_members().unwrap();
-        for mut member in &mut members {
+        for member in &mut members {
             member.set_id(String::new());
         }
         assert_eq!(expected_members, members);


### PR DESCRIPTION
I'm rather surprised that these variables do not need to be
mutable.

Signed-off-by: Krzesimir Nowak <krzesimir@kinvolk.io>