### PR TITLE
Add missing dev app_id for dev studio

### DIFF
--- a/support/builder/config.sh
+++ b/support/builder/config.sh
@@ -10,6 +10,7 @@ url = "$GITHUB_API_URL"
 web_url = "$GITHUB_WEB_URL"
 client_id = "$GITHUB_CLIENT_ID"
 client_secret = "$GITHUB_CLIENT_SECRET"
+app_id = 5629
 
 [web]
 app_url          = "http://$APP_HOSTNAME"
@@ -316,6 +317,7 @@ early_access_teams = [$GITHUB_ADMIN_TEAM]
 url = "$GITHUB_API_URL"
 client_id = "$GITHUB_CLIENT_ID"
 client_secret = "$GITHUB_CLIENT_SECRET"
+app_id = 5629
 EOT
 
 mkdir -p /hab/svc/builder-worker


### PR DESCRIPTION

![tenor-218908592](https://user-images.githubusercontent.com/1130349/32197395-0d720a42-bd92-11e7-8041-47cd1a842080.gif)

** This will require you to destroy your studio or apply the change manually with 
`echo "github = { app_id = 5629}" | hab config apply builder-api.default 43`

Signed-off-by: Travis Elliott Davis <edavis@chef.io>