### PR TITLE
use a custom habitat useragent for powershell plan downloads

### DIFF
--- a/components/plan-build-ps1/bin/hab-plan-build.ps1
+++ b/components/plan-build-ps1/bin/hab-plan-build.ps1
@@ -885,7 +885,7 @@ function _download_file($url, $dst, $sha) {
       }
 
       Write-BuildLine "Downloading '$url' to '$dst'"
-      Invoke-WebRequest $url -OutFile $dst
+      Invoke-WebRequest $url -OutFile $dst -UserAgent "Habitat"
       Write-BuildLine "Downloaded '$dst'"
   }
   finally {


### PR DESCRIPTION
The default user agent string for powershell's `invoke-webrequest` looks like a real browser agent and causes sourceforge to render the "ad baited" download experience. By using an alternate string (like "Habitat"), sourceforge will send to a direct download link.

Signed-off-by: mwrock <matt@mattwrock.com>