### PR TITLE
[plan-build] Avoid early creation of `$CACHE_PATH` & `$pkg_prefix` dirs.

### DIFF
--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -2365,12 +2365,12 @@ pkg_artifact="$HAB_CACHE_ARTIFACT_PATH/${pkg_origin}-${pkg_name}-${pkg_version}-
 _find_system_commands
 _determine_hab_bin
 
-mkdir -pv "$CACHE_PATH"
-mkdir -pv "$pkg_prefix"
-
 case "${pkg_type}" in
     "composite")
         source "${source_dir}/composite_build_functions.sh"
+
+        mkdir -pv "$CACHE_PATH"
+        mkdir -pv "$pkg_prefix"
 
         # Preliminaries
         _setup_composite_build_global_variables


### PR DESCRIPTION
This change fixes an issue when building a normal package that uses
`pkg_version()`. The `$CACHE_PATH` and `$pkg_prefix` directories were
being created too early and would therefore not have correct
`$pkg_version` values.

References #3452
Closes #3832

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>