### PR TITLE
[plan-build] Extract tar with ownership of current user.

### DIFF
--- a/components/plan-build/bin/public.sh
+++ b/components/plan-build/bin/public.sh
@@ -474,7 +474,7 @@ unpack_file() {
     pushd $HAB_CACHE_SRC_PATH > /dev/null
     case $unpack_file in
       *.tar.bz2|*.tbz2|*.tar.gz|*.tgz|*.tar|*.xz)
-        $_tar_cmd xf $unpack_file
+        $_tar_cmd xf $unpack_file --no-same-owner
         ;;
       *.bz2)  bunzip2 $unpack_file    ;;
       *.rar)  rar x $unpack_file      ;;


### PR DESCRIPTION
This change will ignore user and group metadata in source tarballs when
extracting them in `do_unpack()` or when using `unpack_file()`. Trying
to set unknown uid and gid numbers to files can cause issues and
shouldn't be required when building the software.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>