### PR TITLE
Update Dockerfile to use `FROM ubuntu:17.10` since yakkety is EOL.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM ubuntu:yakkety
+# 17.10 (artful) will be EOL July 2018; update FROM directive before then
+FROM ubuntu:17.10
 MAINTAINER The Habitat Maintainers <humans@habitat.sh>
 
 ENV CARGO_HOME /cargo-cache

--- a/support/linux/install_dev_9_linux.sh
+++ b/support/linux/install_dev_9_linux.sh
@@ -16,7 +16,14 @@ if [ -f /etc/arch-release ]; then
   # the Docker package is managed by the Arch Linux community
   sudo -E pacman -S --noconfirm docker
 else
-  curl -sSL https://get.docker.io | sudo -E sh
+  if ! curl -sSL https://get.docker.io | sudo -E sh; then
+    echo "Docker install from https://get.docker.io failed"
+    if command -v lsb_release >/dev/null 2>&1; then
+      echo "Check that this release version is still supported:"
+      lsb_release -a
+    fi
+    exit 1
+  fi
 fi
 docker --version
 


### PR DESCRIPTION
Also, add more informative error message when docker install fails due to an
unsupported ubuntu version.

Resolves https://github.com/habitat-sh/habitat/issues/3984

Signed-off-by: Jon Bauman <5906042+baumanj@users.noreply.github.com>