### PR TITLE
Ignore non UTF-8 files while looking for key pairs

### DIFF
--- a/components/core/src/crypto/keys/mod.rs
+++ b/components/core/src/crypto/keys/mod.rs
@@ -290,7 +290,11 @@ where
         let file = File::open(dir_entry.path())?;
         let mut reader = BufReader::new(file);
         let mut buf = String::new();
-        reader.read_line(&mut buf)?;
+
+        if let Err(e) = reader.read_line(&mut buf) {
+            debug!("Invalid content: {}", e);
+            continue;
+        }
 
         if !buf.starts_with(&key_type.to_string().to_uppercase()) {
             debug!(


### PR DESCRIPTION
I chose to go with ignoring hidden files to fix #3833