### PR TITLE
Fix installation of non-fully-qualified packages from channels

### DIFF
--- a/components/builder-depot-client/src/lib.rs
+++ b/components/builder-depot-client/src/lib.rs
@@ -553,6 +553,7 @@ impl Client {
         &self,
         package: &I,
         channel: Option<&str>,
+        token: Option<&str>,
     ) -> Result<originsrv::OriginPackage>
     where
         I: Identifiable,
@@ -564,10 +565,12 @@ impl Client {
         } else {
             package_path(package)
         };
+
         if !package.fully_qualified() {
             url.push_str("/latest");
         }
-        let mut res = self.0.get(&url).send()?;
+
+        let mut res = self.maybe_add_authz(self.0.get(&url), token).send()?;
         if res.status != StatusCode::Ok {
             return Err(err_from_response(res));
         }

--- a/components/hab/src/command/pkg/upload.rs
+++ b/components/hab/src/command/pkg/upload.rs
@@ -107,14 +107,14 @@ where
     )?;
     let tdeps = archive.tdeps()?;
     let ident = archive.ident()?;
-    match depot_client.show_package(&ident, None) {
+    match depot_client.show_package(&ident, None, Some(token)) {
         Ok(_) => {
             ui.status(Status::Using, format!("existing {}", &ident))?;
             Ok(())
         }
         Err(depot_client::Error::APIError(StatusCode::NotFound, _)) => {
             for dep in tdeps.into_iter() {
-                match depot_client.show_package(&dep, None) {
+                match depot_client.show_package(&dep, None, Some(token)) {
                     Ok(_) => ui.status(Status::Using, format!("existing {}", &dep))?,
                     Err(depot_client::Error::APIError(StatusCode::NotFound, _)) => {
                         let candidate_path = match archive_path.as_ref().parent() {


### PR DESCRIPTION
It turns out I overlooked installation of a non-fully-qualified package (e.g. `core/redis`) when doing the private package work.  This closes that hole.

![tenor-180597766](https://user-images.githubusercontent.com/947/32401989-1df43bc6-c0d8-11e7-9f80-4bcd55c3f4d3.gif)

Closes https://github.com/habitat-sh/habitat/issues/3986
Signed-off-by: Josh Black <raskchanky@gmail.com>