### PR TITLE
Uses tabwriter to format hab svc status output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1400,6 +1400,7 @@ dependencies = [
  "serde_derive 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tabwriter 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2763,6 +2764,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "tabwriter"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "tee"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3397,6 +3406,7 @@ dependencies = [
 "checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
+"checksum tabwriter 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3b7810162bc0a2eb2dc9a9bfd16ddb2d1f6022df3236d1478937bfadcb12385e"
 "checksum tee 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "37c12559dba7383625faaff75be24becf35bfc885044375bcab931111799a3da"
 "checksum tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "87974a6f5c1dfb344d733055601650059a3363de2a6104819293baff662132d6"
 "checksum tempfile 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3213fd2b7ed87e39306737ccfac04b1233b57a33ca64cfbf52f2ffaa2b765e2f"

--- a/components/sup/Cargo.toml
+++ b/components/sup/Cargo.toml
@@ -45,6 +45,7 @@ serde = { version = "*", features = ["rc"] }
 serde_derive = "*"
 serde_json = "*"
 serde_yaml = "*"
+tabwriter = "*"
 tempdir = "*"
 time = "*"
 toml = { version = "*", default-features = false }


### PR DESCRIPTION
> Should close #3859

This pull request leverages crate tabwriter to output `hab svc status` with nice columns:

```
rsertelon@rsertelon-desktop:~/sources/habitat (formatted-output-hab-svc-status=)$ hab svc status
core/redis/3.2.4/20170514150022, state:up, time:PT1366.889919553S, pid:9813, group:redis.default, style:transient
rsertelon/monit/5.24.0/20171022142238, state:up, time:PT1060.891684845S, pid:10744, group:monit.default, style:transient
rsertelon/mosquitto/1.4.14/20171027184938, state:up, time:PT930.893769325S, pid:11315, group:mosquitto.default, style:transient
```
becomes
```
rsertelon@rsertelon-desktop:~/sources/habitat (formatted-output-hab-svc-status *)$ target/debug/hab-sup status
core/redis/3.2.4/20170514150022            standalone  state:up  time:PT597.121500061S  pid:9813   group:redis.default      style:transient
rsertelon/monit/5.24.0/20171022142238      standalone  state:up  time:PT291.124764752S  pid:10744  group:monit.default      style:transient
rsertelon/mosquitto/1.4.14/20171027184938  standalone  state:up  time:PT161.128453720S  pid:11315  group:mosquitto.default  style:transient
```

The code has been modified in place for this particular command. It might be interesting to try to use tabwriter with the `outputln!` macro (or new equivalent one) so that we can use its column output almost anywhere "for free". If you think it might be worth it, I'm keen on opening a new issue to track this.