### PR TITLE
tutorial: fix link to "Explore"

### DIFF
--- a/www/source/partials/tutorials/_web_guide_define_dependencies.slim
+++ b/www/source/partials/tutorials/_web_guide_define_dependencies.slim
@@ -19,7 +19,7 @@ section
 
  h2 Use the Habitat Builder UI to search for dependencies
 
- p By going to #{link_to 'Explore','#{builder_web_url}/#/explore'} on the Habitat website, you can search for packages built by the Habitat team and members of the community, and use them in your own applications and services.
+ p By going to #{link_to 'Explore',"#{builder_web_url}/#/explore"} on the Habitat website, you can search for packages built by the Habitat team and members of the community, and use them in your own applications and services.
 
  .screenshot
     img src="/images/screenshots/explore-tab-main-screen.png"


### PR DESCRIPTION
On https://www.habitat.sh/tutorials/build-your-own/gradle/define-dependencies/
the link to "Explore" in the "Use the Habitat Builder UI to search for
dependencies" section before pointed at

    https://www.habitat.sh/tutorials/build-your-own/gradle/define-dependencies/#{builder_web_url}/#/explore

Now, it's properly interpolated.