### PR TITLE
Change builder-worker log path

### DIFF
--- a/components/builder-worker/habitat/config/config.toml
+++ b/components/builder-worker/habitat/config/config.toml
@@ -1,7 +1,7 @@
 auth_token = "{{cfg.auth_token}}"
 auto_publish = {{cfg.auto_publish}}
 data_path = "{{pkg.svc_data_path}}"
-log_path = "{{pkg.svc_var_path}}"
+log_path = "{{pkg.svc_path}}/logs"
 bldr_channel = "{{cfg.bldr_channel}}"
 features_enabled = "{{cfg.features_enabled}}"
 airlock_enabled = {{cfg.airlock_enabled}}


### PR DESCRIPTION
Update the logs path for builder-worker - set it to a location that is open to read for all.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-59688435](https://user-images.githubusercontent.com/13542112/32468189-1e59a660-c302-11e7-902a-36833bf248bb.gif)
