### PR TITLE
More worker fixes

### DIFF
--- a/components/builder-protocol/src/jobsrv.rs
+++ b/components/builder-protocol/src/jobsrv.rs
@@ -250,6 +250,9 @@ impl Serialize for JobState {
             3 => serializer.serialize_str("Rejected"),
             4 => serializer.serialize_str("Failed"),
             5 => serializer.serialize_str("Dispatched"),
+            6 => serializer.serialize_str("CancelPending"),
+            7 => serializer.serialize_str("CancelProcessing"),
+            8 => serializer.serialize_str("CancelComplete"),
             _ => panic!("Unexpected enum value"),
         }
     }


### PR DESCRIPTION
A couple more fixes for the builder worker - 1) update serialization fields to include the new cancel enums, 2) restrict directory ownership/permission changes to when airlock is enabled (for testing in dev environments).

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-205865182](https://user-images.githubusercontent.com/13542112/32472623-5969ab22-c318-11e7-9e3b-972c96d4d675.gif)
