### PR TITLE
Share `hab-sup` CLAP config with `hab` so alias behavior is consistent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -728,6 +728,7 @@ dependencies = [
  "habitat_core 0.0.0",
  "habitat_depot_client 0.0.0",
  "habitat_http_client 0.0.0",
+ "habitat_sup 0.0.0",
  "handlebars 0.26.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/hab/Cargo.toml
+++ b/components/hab/Cargo.toml
@@ -38,6 +38,9 @@ path = "../core"
 [dependencies.habitat_common]
 path = "../common"
 
+[dependencies.habitat_sup]
+path = "../sup"
+
 [dependencies.habitat_depot_client]
 path = "../builder-depot-client"
 

--- a/components/hab/src/lib.rs
+++ b/components/hab/src/lib.rs
@@ -21,6 +21,7 @@ extern crate habitat_common as common;
 extern crate habitat_depot_client as depot_client;
 extern crate habitat_api_client as api_client;
 extern crate habitat_http_client as http_client;
+extern crate habitat_sup as sup;
 extern crate handlebars;
 
 extern crate ansi_term;

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -21,6 +21,7 @@ extern crate env_logger;
 extern crate hab;
 extern crate habitat_core as hcore;
 extern crate habitat_common as common;
+extern crate habitat_sup as sup;
 extern crate handlebars;
 #[macro_use]
 extern crate lazy_static;
@@ -187,6 +188,19 @@ fn start(ui: &mut UI) -> Result<()> {
                 _ => unreachable!(),
             }
         }
+        ("run", Some(_)) => command::launcher::start(ui, env::args_os().skip(1).collect())?,
+        ("start", Some(_)) => command::launcher::start(ui, env::args_os().skip(1).collect())?,
+        ("stop", Some(_)) |
+        ("term", Some(_)) => command::sup::start(ui, env::args_os().skip(1).collect())?,
+        ("sup", Some(matches)) => {
+            match matches.subcommand() {
+                ("run", Some(_)) |
+                ("start", Some(_)) => {
+                    command::launcher::start(ui, env::args_os().skip(2).collect())?
+                }
+                _ => command::sup::start(ui, env::args_os().skip(2).collect())?,
+            }
+        }
         ("svc", Some(matches)) => {
             match matches.subcommand() {
                 ("key", Some(m)) => {
@@ -194,6 +208,10 @@ fn start(ui: &mut UI) -> Result<()> {
                         ("generate", Some(sc)) => sub_service_key_generate(ui, sc)?,
                         _ => unreachable!(),
                     }
+                }
+                ("start", _) => command::launcher::start(ui, env::args_os().skip(2).collect())?,
+                ("load", _) | ("unload", _) | ("status", _) | ("stop", _) => {
+                    command::sup::start(ui, env::args_os().skip(2).collect())?
                 }
                 _ => unreachable!(),
             }
@@ -677,21 +695,9 @@ fn exec_subcommand_if_called(ui: &mut UI) -> Result<()> {
         ("pkg", "export", "kubernetes") => {
             command::pkg::export::kubernetes::start(ui, env::args_os().skip(4).collect())
         }
-        ("run", _, _) => command::launcher::start(ui, env::args_os().skip(1).collect()),
         ("stu", _, _) | ("stud", _, _) | ("studi", _, _) | ("studio", _, _) => {
             command::studio::enter::start(ui, env::args_os().skip(2).collect())
         }
-        ("sup", "run", _) |
-        ("sup", "start", _) => command::launcher::start(ui, env::args_os().skip(2).collect()),
-        ("sup", _, _) => command::sup::start(ui, env::args_os().skip(2).collect()),
-        ("start", _, _) => command::launcher::start(ui, env::args_os().skip(1).collect()),
-        ("stop", _, _) => command::sup::start(ui, env::args_os().skip(1).collect()),
-        ("svc", "start", _) => command::launcher::start(ui, env::args_os().skip(2).collect()),
-        ("svc", "load", _) |
-        ("svc", "unload", _) |
-        ("svc", "status", _) |
-        ("svc", "stop", _) => command::sup::start(ui, env::args_os().skip(2).collect()),
-        ("term", _, _) => command::sup::start(ui, env::args_os().skip(1).collect()),
         _ => Ok(()),
     }
 }

--- a/components/sup/src/cli.rs
+++ b/components/sup/src/cli.rs
@@ -1,0 +1,309 @@
+// Copyright (c) 2016-2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::path::Path;
+use std::result;
+use std::str::FromStr;
+
+use clap::{App, Arg};
+use hcore::service::ServiceGroup;
+use url::Url;
+
+use config::GossipListenAddr;
+use http_gateway::ListenAddr;
+use manager::service::{Topology, UpdateStrategy};
+
+use super::VERSION;
+
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+pub fn get<'a, 'b>(command_name: &'static str) -> App<'a, 'b> {
+    let base =
+        clap_app!((command_name) =>
+        (about: "The Habitat Supervisor")
+        (version: VERSION)
+        (author: "\nAuthors: The Habitat Maintainers <humans@habitat.sh>\n")
+        (@setting VersionlessSubcommands)
+        (@setting SubcommandRequiredElseHelp)
+        (@arg VERBOSE: -v +global "Verbose output; shows line numbers")
+        (@arg NO_COLOR: --("no-color") +global "Turn ANSI color off")
+        (@subcommand bash =>
+            (about: "Start an interactive Bash-like shell")
+            (aliases: &["b", "ba", "bas"])
+        )
+        (@subcommand config =>
+            (about: "Displays the default configuration options for a service")
+            (aliases: &["c", "co", "con", "conf", "confi"])
+            (@arg PKG_IDENT: +required +takes_value
+                "A package identifier (ex: core/redis, core/busybox-static/1.42.2)")
+        )
+        (subcommand: load())
+        (subcommand: unload())
+        (subcommand: run(&["r", "ru"]))
+        (@subcommand sh =>
+            (about: "Start an interactive Bourne-like shell")
+            (aliases: &[])
+        )
+        (subcommand: start())
+        (subcommand: status())
+        (subcommand: stop())
+    );
+
+    maybe_add_term_subcommand(base)
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+pub fn load<'a, 'b>() -> App<'a, 'b> {
+    let base = clap_app!(@subcommand load =>
+        (about: "Load a service to be started and supervised by Habitat from a package or \
+            artifact. Services started in this manner will persist through Supervisor \
+            restarts.")
+        (aliases: &["lo", "loa"])
+        (@arg PKG_IDENT_OR_ARTIFACT: +required +takes_value
+            "A Habitat package identifier (ex: core/redis) or filepath to a Habitat Artifact \
+            (ex: /home/core-redis-3.0.7-21120102031201-x86_64-linux.hart)")
+        (@arg NAME: --("override-name") +takes_value
+            "The name for the state directory if there is more than one Supervisor running \
+            [default: default]")
+        (@arg APPLICATION: --application -a +takes_value requires[ENVIRONMENT]
+            "Application name; [default: not set].")
+        (@arg ENVIRONMENT: --environment -e +takes_value requires[APPLICATION]
+            "Environment name; [default: not set].")
+        (@arg CHANNEL: --channel +takes_value
+            "Receive package updates from the specified release channel [default: stable]")
+        (@arg GROUP: --group +takes_value
+            "The service group; shared config and topology [default: default].")
+        (@arg BLDR_URL: --url -u +takes_value {valid_url}
+            "Receive package updates from Builder at the specified URL \
+            [default: https://bldr.habitat.sh]")
+        (@arg TOPOLOGY: --topology -t +takes_value {valid_topology}
+            "Service topology; [default: none]")
+        (@arg STRATEGY: --strategy -s +takes_value {valid_update_strategy}
+            "The update strategy; [default: none] [values: none, at-once, rolling]")
+        (@arg BIND: --bind +takes_value +multiple
+            "One or more service groups to bind to a configuration")
+        (@arg FORCE: --force -f "Load or reload an already loaded service. If the service was \
+            previously loaded and running this operation will also restart the service")
+    );
+
+    maybe_add_password_arg(base)
+}
+
+pub fn unload<'a, 'b>() -> App<'a, 'b> {
+    clap_app!(@subcommand unload =>
+        (about: "Unload a persistent or transient service started by the Habitat \
+            Supervisor. If the Supervisor is running when the service is unloaded the \
+            service will be stopped.")
+        (aliases: &["un", "unl", "unlo", "unloa"])
+        (@arg PKG_IDENT: +required +takes_value "A Habitat package identifier (ex: core/redis)")
+        (@arg NAME: --("override-name") +takes_value
+            "The name for the state directory if there is more than one Supervisor running \
+            [default: default]")
+    )
+}
+
+pub fn run<'a, 'b>(aka: &'static [&'static str]) -> App<'a, 'b> {
+    clap_app!(@subcommand run =>
+        (about: "Run the Habitat Supervisor")
+        (aliases: aka)
+        // (aliases: &["r", "ru"])
+        (@arg LISTEN_GOSSIP: --("listen-gossip") +takes_value {valid_listen_gossip}
+            "The listen address for the gossip system [default: 0.0.0.0:9638]")
+        (@arg LISTEN_HTTP: --("listen-http") +takes_value {valid_listen_http}
+            "The listen address for the HTTP gateway [default: 0.0.0.0:9631]")
+        (@arg NAME: --("override-name") +takes_value
+            "The name of the Supervisor if launching more than one [default: default]")
+        (@arg ORGANIZATION: --org +takes_value
+            "The organization that the Supervisor and it's subsequent services are part of \
+            [default: default]")
+        (@arg PEER: --peer +takes_value +multiple
+            "The listen address of an initial peer (IP[:PORT])")
+        (@arg PERMANENT_PEER: --("permanent-peer") -I "If this Supervisor is a permanent peer")
+        (@arg PEER_WATCH_FILE: --("peer-watch-file") +takes_value conflicts_with[peer]
+            "Watch this file for connecting to the ring"
+        )
+        (@arg RING: --ring -r +takes_value "Ring key name")
+        (@arg CHANNEL: --channel +takes_value
+            "Receive Supervisor updates from the specified release channel [default: stable]")
+        (@arg BLDR_URL: --url -u +takes_value {valid_url}
+            "Receive Supervisor updates from Builder at the specified URL \
+            [default: https://bldr.habitat.sh]")
+        (@arg AUTO_UPDATE: --("auto-update") -A "Enable automatic updates for the Supervisor \
+            itself")
+        (@arg EVENTS: --events -n +takes_value {valid_service_group} "Name of the service \
+            group running a Habitat EventSrv to forward Supervisor and service event data to")
+    )
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+pub fn start<'a, 'b>() -> App<'a, 'b> {
+    let base = clap_app!(@subcommand start =>
+        (about: "Start a loaded, but stopped, Habitat service or a transient service from \
+            a package or artifact. If the Habitat Supervisor is not already running this \
+            will additionally start one for you.")
+        (aliases: &["sta", "star"])
+        (@arg LISTEN_GOSSIP: --("listen-gossip") +takes_value {valid_listen_gossip}
+            "The listen address for the gossip system [default: 0.0.0.0:9638]")
+        (@arg LISTEN_HTTP: --("listen-http") +takes_value {valid_listen_http}
+            "The listen address for the HTTP gateway [default: 0.0.0.0:9631]")
+        (@arg NAME: --("override-name") +takes_value
+            "The name for the state directory if launching more than one Supervisor \
+            [default: default]")
+        (@arg ORGANIZATION: --org +takes_value
+            "The organization that the Supervisor and it's subsequent services are part of \
+            [default: default]")
+        (@arg PEER: --peer +takes_value +multiple
+            "The listen address of an initial peer (IP[:PORT])")
+        (@arg PERMANENT_PEER: --("permanent-peer") -I "If this Supervisor is a permanent peer")
+        (@arg PEER_WATCH_FILE: --("peer-watch-file") +takes_value conflicts_with[peer]
+            "Watch this file for connecting to the ring"
+        )
+        (@arg RING: --ring -r +takes_value "Ring key name")
+        (@arg PKG_IDENT_OR_ARTIFACT: +required +takes_value
+            "A Habitat package identifier (ex: core/redis) or filepath to a Habitat Artifact \
+            (ex: /home/core-redis-3.0.7-21120102031201-x86_64-linux.hart)")
+        (@arg APPLICATION: --application -a +takes_value requires[ENVIRONMENT]
+            "Application name; [default: not set].")
+        (@arg ENVIRONMENT: --environment -e +takes_value requires[APPLICATION]
+            "Environment name; [default: not set].")
+        (@arg CHANNEL: --channel +takes_value
+            "Receive package updates from the specified release channel [default: stable]")
+        (@arg GROUP: --group +takes_value
+            "The service group; shared config and topology [default: default]")
+        (@arg BLDR_URL: --url -u +takes_value {valid_url}
+            "Receive package updates from Builder at the specified URL \
+            [default: https://bldr.habitat.sh]")
+        (@arg TOPOLOGY: --topology -t +takes_value {valid_topology}
+            "Service topology; [default: none]")
+        (@arg STRATEGY: --strategy -s +takes_value {valid_update_strategy}
+            "The update strategy; [default: none] [values: none, at-once, rolling]")
+        (@arg BIND: --bind +takes_value +multiple
+            "One or more service groups to bind to a configuration")
+        (@arg CONFIG_DIR: --("config-from") +takes_value {dir_exists}
+            "Use package config from this path, rather than the package itself")
+        (@arg AUTO_UPDATE: --("auto-update") -A "Enable automatic updates for the Supervisor \
+            itself")
+        (@arg EVENTS: --events -n +takes_value {valid_service_group} "Name of the service \
+            group running a Habitat EventSrv to forward Supervisor and service event data to")
+    );
+
+    maybe_add_password_arg(base)
+}
+
+pub fn status<'a, 'b>() -> App<'a, 'b> {
+    clap_app!(@subcommand status =>
+        (about: "Query the status of Habitat services.")
+        (aliases: &["stat", "statu", "status"])
+        (@arg PKG_IDENT: +takes_value "A Habitat package identifier (ex: core/redis)")
+        (@arg NAME: --("override-name") +takes_value
+            "The name for the state directory if there is more than one Supervisor running \
+            [default: default]")
+    )
+}
+
+pub fn stop<'a, 'b>() -> App<'a, 'b> {
+    clap_app!(@subcommand stop =>
+        (about: "Stop a running Habitat service.")
+        (aliases: &["sto"])
+        (@arg PKG_IDENT: +required +takes_value "A Habitat package identifier (ex: core/redis)")
+        (@arg NAME: --("override-name") +takes_value
+            "The name for the state directory if there is more than one Supervisor running \
+            [default: default]")
+    )
+}
+
+pub fn maybe_add_term_subcommand<'a, 'b>(base: App<'a, 'b>) -> App<'a, 'b> {
+    if cfg!(any(target_os = "linux", target_os = "macos")) {
+        base.subcommand(
+            clap_app!(("term") =>
+                (about: "Gracefully terminate the Habitat Supervisor and all of it's running services")
+                (@arg NAME: --("override-name") +takes_value
+                    "The name of the Supervisor if more than one is running [default: default]")
+            )
+        )
+    } else {
+        base
+    }
+}
+
+fn maybe_add_password_arg<'a, 'b>(base: App<'a, 'b>) -> App<'a, 'b> {
+    if cfg!(target_os = "windows") {
+        base.arg(
+            Arg::with_name("PASSWORD")
+                .long("password")
+                .takes_value(true)
+                .help("Password of the service user"),
+        )
+    } else {
+        base
+    }
+}
+
+// CLAP Validation Functions
+////////////////////////////////////////////////////////////////////////
+
+fn dir_exists(val: String) -> result::Result<(), String> {
+    if Path::new(&val).is_dir() {
+        Ok(())
+    } else {
+        Err(format!("Directory: '{}' cannot be found", &val))
+    }
+}
+
+fn valid_service_group(val: String) -> result::Result<(), String> {
+    match ServiceGroup::validate(&val) {
+        Ok(()) => Ok(()),
+        Err(err) => Err(err.to_string()),
+    }
+}
+
+fn valid_topology(val: String) -> result::Result<(), String> {
+    match Topology::from_str(&val) {
+        Ok(_) => Ok(()),
+        Err(_) => Err(format!("Service topology: '{}' is not valid", &val)),
+    }
+}
+
+fn valid_listen_gossip(val: String) -> result::Result<(), String> {
+    match GossipListenAddr::from_str(&val) {
+        Ok(_) => Ok(()),
+        Err(_) => Err(format!(
+            "Listen gossip address should include both IP and port, eg: '0.0.0.0:9700'"
+        )),
+    }
+}
+
+fn valid_listen_http(val: String) -> result::Result<(), String> {
+    match ListenAddr::from_str(&val) {
+        Ok(_) => Ok(()),
+        Err(_) => Err(format!(
+            "Listen http address should include both IP and port, eg: '0.0.0.0:9700'"
+        )),
+    }
+}
+
+fn valid_update_strategy(val: String) -> result::Result<(), String> {
+    match UpdateStrategy::from_str(&val) {
+        Ok(_) => Ok(()),
+        Err(_) => Err(format!("Update strategy: '{}' is not valid", &val)),
+    }
+}
+
+fn valid_url(val: String) -> result::Result<(), String> {
+    match Url::parse(&val) {
+        Ok(_) => Ok(()),
+        Err(_) => Err(format!("URL: '{}' is not valid", &val)),
+    }
+}
+
+////////////////////////////////////////////////////////////////////////

--- a/components/sup/src/lib.rs
+++ b/components/sup/src/lib.rs
@@ -43,6 +43,8 @@ extern crate ansi_term;
 #[macro_use]
 extern crate bitflags;
 extern crate byteorder;
+#[macro_use]
+extern crate clap;
 #[cfg(windows)]
 extern crate ctrlc;
 #[macro_use]
@@ -94,6 +96,7 @@ macro_rules! sup_error {
     }
 }
 
+pub mod cli;
 pub mod command;
 pub mod config;
 pub mod census;

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -22,7 +22,6 @@ extern crate log;
 extern crate env_logger;
 extern crate ansi_term;
 extern crate libc;
-#[macro_use]
 extern crate clap;
 extern crate time;
 extern crate url;
@@ -33,7 +32,6 @@ use std::io::{self, Write};
 use std::net::{SocketAddr, ToSocketAddrs};
 use std::path::{Path, PathBuf};
 use std::process;
-use std::result;
 use std::str::FromStr;
 
 use ansi_term::Colour::{Red, Yellow};
@@ -52,15 +50,12 @@ use hcore::package::metadata::{BindMapping, PackageType};
 use hcore::service::{ApplicationEnvironment, ServiceGroup};
 use hcore::url::{bldr_url_from_env, default_bldr_url};
 use launcher_client::{LauncherCli, ERR_NO_RETRY_EXCODE, OK_NO_RETRY_EXCODE};
-use url::Url;
 
-use sup::VERSION;
 use sup::config::{GossipListenAddr, GOSSIP_DEFAULT_PORT};
 use sup::error::{Error, Result, SupError};
 use sup::feat;
 use sup::command;
 use sup::http_gateway;
-use sup::http_gateway::ListenAddr;
 use sup::manager::{Manager, ManagerConfig};
 use sup::manager::service::{DesiredState, ServiceBind, Topology, UpdateStrategy};
 use sup::manager::service::{CompositeSpec, ServiceSpec, StartStyle};
@@ -137,336 +132,9 @@ fn start() -> Result<()> {
     }
 }
 
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
 fn cli<'a, 'b>() -> App<'a, 'b> {
-    clap_app!(("hab-sup") =>
-        (about: "The Habitat Supervisor")
-        (version: VERSION)
-        (author: "\nAuthors: The Habitat Maintainers <humans@habitat.sh>\n")
-        (@setting VersionlessSubcommands)
-        (@setting SubcommandRequiredElseHelp)
-        (@arg VERBOSE: -v +global "Verbose output; shows line numbers")
-        (@arg NO_COLOR: --("no-color") +global "Turn ANSI color off")
-        (@subcommand bash =>
-            (about: "Start an interactive Bash-like shell")
-            (aliases: &["b", "ba", "bas"])
-        )
-        (@subcommand config =>
-            (about: "Displays the default configuration options for a service")
-            (aliases: &["c", "co", "con", "conf", "confi"])
-            (@arg PKG_IDENT: +required +takes_value
-                "A package identifier (ex: core/redis, core/busybox-static/1.42.2)")
-        )
-        (@subcommand load =>
-            (about: "Load a service to be started and supervised by Habitat from a package or \
-                artifact. Services started in this manner will persist through Supervisor \
-                restarts.")
-            (aliases: &["lo", "loa"])
-            (@arg PKG_IDENT_OR_ARTIFACT: +required +takes_value
-                "A Habitat package identifier (ex: core/redis) or filepath to a Habitat Artifact \
-                (ex: /home/core-redis-3.0.7-21120102031201-x86_64-linux.hart)")
-            (@arg NAME: --("override-name") +takes_value
-                "The name for the state directory if there is more than one Supervisor running \
-                [default: default]")
-            (@arg APPLICATION: --application -a +takes_value requires[ENVIRONMENT]
-                "Application name; [default: not set].")
-            (@arg ENVIRONMENT: --environment -e +takes_value requires[APPLICATION]
-                "Environment name; [default: not set].")
-            (@arg CHANNEL: --channel +takes_value
-                "Receive package updates from the specified release channel [default: stable]")
-            (@arg GROUP: --group +takes_value
-                "The service group; shared config and topology [default: default].")
-            (@arg BLDR_URL: --url -u +takes_value {valid_url}
-                "Receive package updates from Builder at the specified URL \
-                [default: https://bldr.habitat.sh]")
-            (@arg TOPOLOGY: --topology -t +takes_value {valid_topology}
-                "Service topology; [default: none]")
-            (@arg STRATEGY: --strategy -s +takes_value {valid_update_strategy}
-                "The update strategy; [default: none] [values: none, at-once, rolling]")
-            (@arg BIND: --bind +takes_value +multiple
-                "One or more service groups to bind to a configuration")
-            (@arg FORCE: --force -f "Load or reload an already loaded service. If the service was \
-                previously loaded and running this operation will also restart the service")
-        )
-        (@subcommand unload =>
-            (about: "Unload a persistent or transient service started by the Habitat \
-                Supervisor. If the Supervisor is running when the service is unloaded the \
-                service will be stopped.")
-            (aliases: &["un", "unl", "unlo", "unloa"])
-            (@arg PKG_IDENT: +required +takes_value "A Habitat package identifier (ex: core/redis)")
-            (@arg NAME: --("override-name") +takes_value
-                "The name for the state directory if there is more than one Supervisor running \
-                [default: default]")
-        )
-        (@subcommand run =>
-            (about: "Run the Habitat Supervisor")
-            (aliases: &["r", "ru"])
-            (@arg LISTEN_GOSSIP: --("listen-gossip") +takes_value {valid_listen_gossip}
-                "The listen address for the gossip system [default: 0.0.0.0:9638]")
-            (@arg LISTEN_HTTP: --("listen-http") +takes_value {valid_listen_http}
-                "The listen address for the HTTP gateway [default: 0.0.0.0:9631]")
-            (@arg NAME: --("override-name") +takes_value
-                "The name of the Supervisor if launching more than one [default: default]")
-            (@arg ORGANIZATION: --org +takes_value
-                "The organization that the Supervisor and it's subsequent services are part of \
-                [default: default]")
-            (@arg PEER: --peer +takes_value +multiple
-                "The listen address of an initial peer (IP[:PORT])")
-            (@arg PERMANENT_PEER: --("permanent-peer") -I "If this Supervisor is a permanent peer")
-            (@arg PEER_WATCH_FILE: --("peer-watch-file") +takes_value conflicts_with[peer]
-                "Watch this file for connecting to the ring"
-            )
-            (@arg RING: --ring -r +takes_value "Ring key name")
-            (@arg CHANNEL: --channel +takes_value
-                "Receive Supervisor updates from the specified release channel [default: stable]")
-            (@arg BLDR_URL: --url -u +takes_value {valid_url}
-                "Receive Supervisor updates from Builder at the specified URL \
-                [default: https://bldr.habitat.sh]")
-            (@arg AUTO_UPDATE: --("auto-update") -A "Enable automatic updates for the Supervisor \
-                itself")
-            (@arg EVENTS: --events -n +takes_value {valid_service_group} "Name of the service \
-                group running a Habitat EventSrv to forward Supervisor and service event data to")
-        )
-        (@subcommand sh =>
-            (about: "Start an interactive Bourne-like shell")
-            (aliases: &[])
-        )
-        (@subcommand start =>
-            (about: "Start a loaded, but stopped, Habitat service or a transient service from \
-                a package or artifact. If the Habitat Supervisor is not already running this \
-                will additionally start one for you.")
-            (aliases: &["sta", "star"])
-            (@arg LISTEN_GOSSIP: --("listen-gossip") +takes_value {valid_listen_gossip}
-                "The listen address for the gossip system [default: 0.0.0.0:9638]")
-            (@arg LISTEN_HTTP: --("listen-http") +takes_value {valid_listen_http}
-                "The listen address for the HTTP gateway [default: 0.0.0.0:9631]")
-            (@arg NAME: --("override-name") +takes_value
-                "The name for the state directory if launching more than one Supervisor \
-                [default: default]")
-            (@arg ORGANIZATION: --org +takes_value
-                "The organization that the Supervisor and it's subsequent services are part of \
-                [default: default]")
-            (@arg PEER: --peer +takes_value +multiple
-                "The listen address of an initial peer (IP[:PORT])")
-            (@arg PERMANENT_PEER: --("permanent-peer") -I "If this Supervisor is a permanent peer")
-            (@arg PEER_WATCH_FILE: --("peer-watch-file") +takes_value conflicts_with[peer]
-                "Watch this file for connecting to the ring"
-            )
-            (@arg RING: --ring -r +takes_value "Ring key name")
-            (@arg PKG_IDENT_OR_ARTIFACT: +required +takes_value
-                "A Habitat package identifier (ex: core/redis) or filepath to a Habitat Artifact \
-                (ex: /home/core-redis-3.0.7-21120102031201-x86_64-linux.hart)")
-            (@arg APPLICATION: --application -a +takes_value requires[ENVIRONMENT]
-                "Application name; [default: not set].")
-            (@arg ENVIRONMENT: --environment -e +takes_value requires[APPLICATION]
-                "Environment name; [default: not set].")
-            (@arg CHANNEL: --channel +takes_value
-                "Receive package updates from the specified release channel [default: stable]")
-            (@arg GROUP: --group +takes_value
-                "The service group; shared config and topology [default: default]")
-            (@arg BLDR_URL: --url -u +takes_value {valid_url}
-                "Receive package updates from Builder at the specified URL \
-                [default: https://bldr.habitat.sh]")
-            (@arg TOPOLOGY: --topology -t +takes_value {valid_topology}
-                "Service topology; [default: none]")
-            (@arg STRATEGY: --strategy -s +takes_value {valid_update_strategy}
-                "The update strategy; [default: none] [values: none, at-once, rolling]")
-            (@arg BIND: --bind +takes_value +multiple
-                "One or more service groups to bind to a configuration")
-            (@arg CONFIG_DIR: --("config-from") +takes_value {dir_exists}
-                "Use package config from this path, rather than the package itself")
-            (@arg AUTO_UPDATE: --("auto-update") -A "Enable automatic updates for the Supervisor \
-                itself")
-            (@arg EVENTS: --events -n +takes_value {valid_service_group} "Name of the service \
-                group running a Habitat EventSrv to forward Supervisor and service event data to")
-        )
-        (@subcommand status =>
-            (about: "Query the status of Habitat services.")
-            (aliases: &["stat", "statu", "status"])
-            (@arg PKG_IDENT: +takes_value "A Habitat package identifier (ex: core/redis)")
-            (@arg NAME: --("override-name") +takes_value
-                "The name for the state directory if there is more than one Supervisor running \
-                [default: default]")
-        )
-        (@subcommand stop =>
-            (about: "Stop a running Habitat service.")
-            (aliases: &["sto"])
-            (@arg PKG_IDENT: +required +takes_value "A Habitat package identifier (ex: core/redis)")
-            (@arg NAME: --("override-name") +takes_value
-                "The name for the state directory if there is more than one Supervisor running \
-                [default: default]")
-        )
-        (@subcommand term =>
-            (about: "Gracefully terminate the Habitat Supervisor and all of it's running services")
-            (@arg NAME: --("override-name") +takes_value
-                "The name of the Supervisor if more than one is running [default: default]")
-        )
-    )
-}
-
-#[cfg(target_os = "windows")]
-fn cli<'a, 'b>() -> App<'a, 'b> {
-    clap_app!(("hab-sup") =>
-        (about: "The Habitat Supervisor")
-        (version: VERSION)
-        (author: "\nAuthors: The Habitat Maintainers <humans@habitat.sh>\n")
-        (@setting VersionlessSubcommands)
-        (@setting SubcommandRequiredElseHelp)
-        (@arg VERBOSE: -v +global "Verbose output; shows line numbers")
-        (@arg NO_COLOR: --("no-color") +global "Turn ANSI color off")
-        (@subcommand bash =>
-            (about: "Start an interactive Bash-like shell")
-            (aliases: &["b", "ba", "bas"])
-        )
-        (@subcommand config =>
-            (about: "Displays the default configuration options for a service")
-            (aliases: &["c", "co", "con", "conf", "confi"])
-            (@arg PKG_IDENT: +required +takes_value
-                "A package identifier (ex: core/redis, core/busybox-static/1.42.2)")
-        )
-        (@subcommand load =>
-            (about: "Load a service to be started and supervised by Habitat from a package or \
-                artifact. Services started in this manner will persist through Supervisor \
-                restarts.")
-            (aliases: &["lo", "loa"])
-            (@arg PKG_IDENT_OR_ARTIFACT: +required +takes_value
-                "A Habitat package identifier (ex: core/redis) or filepath to a Habitat Artifact \
-                (ex: /home/core-redis-3.0.7-21120102031201-x86_64-linux.hart)")
-            (@arg NAME: --("override-name") +takes_value
-                "The name for the state directory if there is more than one Supervisor running \
-                [default: default]")
-            (@arg APPLICATION: --application -a +takes_value requires[ENVIRONMENT]
-                "Application name; [default: not set].")
-            (@arg ENVIRONMENT: --environment -e +takes_value requires[APPLICATION]
-                "Environment name; [default: not set].")
-            (@arg CHANNEL: --channel +takes_value
-                "Receive package updates from the specified release channel [default: stable]")
-            (@arg GROUP: --group +takes_value
-                "The service group; shared config and topology [default: default].")
-            (@arg BLDR_URL: --url -u +takes_value {valid_url}
-                "Receive package updates from Builder at the specified URL \
-                [default: https://bldr.habitat.sh]")
-            (@arg TOPOLOGY: --topology -t +takes_value {valid_topology}
-                "Service topology; [default: none]")
-            (@arg STRATEGY: --strategy -s +takes_value {valid_update_strategy}
-                "The update strategy; [default: none] [values: none, at-once, rolling]")
-            (@arg BIND: --bind +takes_value +multiple
-                "One or more service groups to bind to a configuration")
-            (@arg FORCE: --force -f "Load or reload an already loaded service. If the service was \
-                previously loaded and running this operation will also restart the service")
-                (@arg PASSWORD: --password +takes_value
-                    "Password of the service user")
-        )
-        (@subcommand unload =>
-            (about: "Unload a persistent or transient service started by the Habitat \
-                Supervisor. If the Supervisor is running when the service is unloaded the \
-                service will be stopped.")
-            (aliases: &["un", "unl", "unlo", "unloa"])
-            (@arg PKG_IDENT: +required +takes_value "A Habitat package identifier (ex: core/redis)")
-            (@arg NAME: --("override-name") +takes_value
-                "The name for the state directory if there is more than one Supervisor running \
-                [default: default]")
-        )
-        (@subcommand run =>
-            (about: "Run the Habitat Supervisor")
-            (aliases: &["r", "ru"])
-            (@arg LISTEN_GOSSIP: --("listen-gossip") +takes_value {valid_listen_gossip}
-                "The listen address for the gossip system [default: 0.0.0.0:9638]")
-            (@arg LISTEN_HTTP: --("listen-http") +takes_value {valid_listen_http}
-                "The listen address for the HTTP gateway [default: 0.0.0.0:9631]")
-            (@arg NAME: --("override-name") +takes_value
-                "The name of the Supervisor if launching more than one [default: default]")
-            (@arg ORGANIZATION: --org +takes_value
-                "The organization that the Supervisor and it's subsequent services are part of \
-                [default: default]")
-            (@arg PEER: --peer +takes_value +multiple
-                "The listen address of an initial peer (IP[:PORT])")
-            (@arg PERMANENT_PEER: --("permanent-peer") -I "If this Supervisor is a permanent peer")
-            (@arg PEER_WATCH_FILE: --("peer-watch-file") +takes_value conflicts_with[peer]
-                "Watch this file for connecting to the ring"
-            )
-            (@arg RING: --ring -r +takes_value "Ring key name")
-            (@arg CHANNEL: --channel +takes_value
-                "Receive Supervisor updates from the specified release channel [default: stable]")
-            (@arg BLDR_URL: --url -u +takes_value {valid_url}
-                "Receive Supervisor updates from Builder at the specified URL \
-                [default: https://bldr.habitat.sh]")
-            (@arg AUTO_UPDATE: --("auto-update") -A "Enable automatic updates for the Supervisor \
-                itself")
-            (@arg EVENTS: --events -n +takes_value {valid_service_group} "Name of the service \
-                group running a Habitat EventSrv to forward Supervisor and service event data to")
-        )
-        (@subcommand sh =>
-            (about: "Start an interactive Bourne-like shell")
-            (aliases: &[])
-        )
-        (@subcommand start =>
-            (about: "Start a loaded, but stopped, Habitat service or a transient service from \
-                a package or artifact. If the Habitat Supervisor is not already running this \
-                will additionally start one for you.")
-            (aliases: &["sta", "star"])
-            (@arg LISTEN_GOSSIP: --("listen-gossip") +takes_value {valid_listen_gossip}
-                "The listen address for the gossip system [default: 0.0.0.0:9638]")
-            (@arg LISTEN_HTTP: --("listen-http") +takes_value {valid_listen_http}
-                "The listen address for the HTTP gateway [default: 0.0.0.0:9631]")
-            (@arg NAME: --("override-name") +takes_value
-                "The name for the state directory if launching more than one Supervisor \
-                [default: default]")
-            (@arg ORGANIZATION: --org +takes_value
-                "The organization that the Supervisor and it's subsequent services are part of \
-                [default: default]")
-            (@arg PEER: --peer +takes_value +multiple
-                "The listen address of an initial peer (IP[:PORT])")
-            (@arg PERMANENT_PEER: --("permanent-peer") -I "If this Supervisor is a permanent peer")
-            (@arg PEER_WATCH_FILE: --("peer-watch-file") +takes_value conflicts_with[peer]
-                "Watch this file for connecting to the ring"
-            )
-            (@arg RING: --ring -r +takes_value "Ring key name")
-            (@arg PKG_IDENT_OR_ARTIFACT: +required +takes_value
-                "A Habitat package identifier (ex: core/redis) or filepath to a Habitat Artifact \
-                (ex: /home/core-redis-3.0.7-21120102031201-x86_64-linux.hart)")
-            (@arg APPLICATION: --application -a +takes_value requires[ENVIRONMENT]
-                "Application name; [default: not set].")
-            (@arg ENVIRONMENT: --environment -e +takes_value requires[APPLICATION]
-                "Environment name; [default: not set].")
-            (@arg CHANNEL: --channel +takes_value
-                "Receive package updates from the specified release channel [default: stable]")
-            (@arg GROUP: --group +takes_value
-                "The service group; shared config and topology [default: default]")
-            (@arg BLDR_URL: --url -u +takes_value {valid_url}
-                "Receive package updates from Builder at the specified URL \
-                [default: https://bldr.habitat.sh]")
-            (@arg TOPOLOGY: --topology -t +takes_value {valid_topology}
-                "Service topology; [default: none]")
-            (@arg STRATEGY: --strategy -s +takes_value {valid_update_strategy}
-                "The update strategy; [default: none] [values: none, at-once, rolling]")
-            (@arg BIND: --bind +takes_value +multiple
-                "One or more service groups to bind to a configuration")
-            (@arg CONFIG_DIR: --("config-from") +takes_value {dir_exists}
-                "Use package config from this path, rather than the package itself")
-            (@arg AUTO_UPDATE: --("auto-update") -A "Enable automatic updates for the Supervisor \
-                itself")
-            (@arg EVENTS: --events -n +takes_value {valid_service_group} "Name of the service \
-                group running a Habitat EventSrv to forward Supervisor and service event data to")
-            (@arg PASSWORD: --password +takes_value "Password of the service user")
-        )
-        (@subcommand status =>
-            (about: "Query the status of Habitat services.")
-            (aliases: &["stat", "statu", "status"])
-            (@arg PKG_IDENT: +takes_value "A Habitat package identifier (ex: core/redis)")
-            (@arg NAME: --("override-name") +takes_value
-                "The name for the state directory if there is more than one Supervisor running \
-                [default: default]")
-        )
-        (@subcommand stop =>
-            (about: "Stop a running Habitat service.")
-            (aliases: &["sto"])
-            (@arg PKG_IDENT: +required +takes_value "A Habitat package identifier (ex: core/redis)")
-            (@arg NAME: --("override-name") +takes_value
-                "The name for the state directory if there is more than one Supervisor running \
-                [default: default]")
-        )
-    )
+    sup::cli::get("hab-sup")
 }
 
 fn sub_bash(m: &ArgMatches) -> Result<()> {
@@ -1435,61 +1103,6 @@ fn set_composite_binds(
     spec.binds = final_binds.drain().map(|(_, v)| v).collect();
     Ok(())
 }
-
-// CLAP Validation Functions
-////////////////////////////////////////////////////////////////////////
-
-fn dir_exists(val: String) -> result::Result<(), String> {
-    if Path::new(&val).is_dir() {
-        Ok(())
-    } else {
-        Err(format!("Directory: '{}' cannot be found", &val))
-    }
-}
-
-fn valid_service_group(val: String) -> result::Result<(), String> {
-    match ServiceGroup::validate(&val) {
-        Ok(()) => Ok(()),
-        Err(err) => Err(err.to_string()),
-    }
-}
-
-fn valid_topology(val: String) -> result::Result<(), String> {
-    match Topology::from_str(&val) {
-        Ok(_) => Ok(()),
-        Err(_) => Err(format!("Service topology: '{}' is not valid", &val)),
-    }
-}
-
-fn valid_listen_gossip(val: String) -> result::Result<(), String> {
-    match GossipListenAddr::from_str(&val) {
-        Ok(_) => Ok(()),
-        Err(_) => Err(format!("Listen gossip address should include both IP and port, eg: '0.0.0.0:9700'"))
-    }
-}
-
-fn valid_listen_http(val: String) -> result::Result<(), String> {
-    match ListenAddr::from_str(&val) {
-        Ok(_) => Ok(()),
-        Err(_) => Err(format!("Listen http address should include both IP and port, eg: '0.0.0.0:9700'"))
-    }
-}
-
-fn valid_update_strategy(val: String) -> result::Result<(), String> {
-    match UpdateStrategy::from_str(&val) {
-        Ok(_) => Ok(()),
-        Err(_) => Err(format!("Update strategy: '{}' is not valid", &val)),
-    }
-}
-
-fn valid_url(val: String) -> result::Result<(), String> {
-    match Url::parse(&val) {
-        Ok(_) => Ok(()),
-        Err(_) => Err(format!("URL: '{}' is not valid", &val)),
-    }
-}
-
-////////////////////////////////////////////////////////////////////////
 
 fn enable_features_from_env() {
     let features = vec![(feat::List, "LIST")];


### PR DESCRIPTION
This fixes https://github.com/habitat-sh/habitat/issues/3130, but further work
can be done to make it more general and address all similar alias-related
issues and reduce duplication of CLAP code.