### PR TITLE
Fix hab bldr job start failure

### DIFF
--- a/components/builder-depot-client/src/lib.rs
+++ b/components/builder-depot-client/src/lib.rs
@@ -345,7 +345,7 @@ impl Client {
     ///
     /// * Key cannot be found
     /// * Remote Builder is not available
-    pub fn schedule_job<I>(&self, ident: &I, package_only: bool, token: &str) -> Result<(i64)>
+    pub fn schedule_job<I>(&self, ident: &I, package_only: bool, token: &str) -> Result<(String)>
     where
         I: Identifiable,
     {
@@ -363,10 +363,7 @@ impl Client {
             Ok(response) => {
                 if response.status == StatusCode::Ok {
                     let sr: SchedulerResponse = decoded_response(response)?;
-                    match sr.id.parse::<i64>() {
-                        Ok(s) => Ok(s),
-                        Err(e) => Err(Error::ParseIntError(e)),
-                    }
+                    Ok(sr.id)
                 } else {
                     Err(err_from_response(response))
                 }

--- a/components/hab/src/command/bldr/job/start.rs
+++ b/components/hab/src/command/bldr/job/start.rs
@@ -65,7 +65,7 @@ pub fn start(
 
     ui.status(
         Status::Created,
-        format!("build job, the id is {}", id),
+        format!("build job. The id is {}", id),
     )?;
 
     Ok(())


### PR DESCRIPTION
This was introduced with my recent addition of `hab bldr job status`.

![tenor-25444109](https://user-images.githubusercontent.com/947/32569073-ec6ab6fc-c474-11e7-80dc-68b654e5ea49.gif)

Closes https://github.com/habitat-sh/habitat/issues/4026
Signed-off-by: Josh Black <raskchanky@gmail.com>