### PR TITLE
[4027] Redirect stderr to stdout fd to avoid filling up stderr buffer

### DIFF
--- a/components/builder-worker/src/runner/log_pipe.rs
+++ b/components/builder-worker/src/runner/log_pipe.rs
@@ -70,13 +70,6 @@ impl LogPipe {
             self.stream_lines(reader)?;
         }
         self.logger.log("Finished logging stdout");
-        self.logger.log("About to log stderr");
-        if let Some(ref mut stderr) = process.stderr {
-            let reader = BufReader::new(stderr);
-            self.stream_lines(reader)?;
-        }
-        self.logger.log("Finished logging stderr");
-
         Ok(())
     }
 

--- a/components/builder-worker/src/runner/studio.rs
+++ b/components/builder-worker/src/runner/studio.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::net::IpAddr;
+use std::os::unix::io::FromRawFd;
 use std::os::unix::process::CommandExt;
 use std::path::PathBuf;
 use std::process::{Command, ExitStatus, Stdio};
@@ -110,7 +111,10 @@ impl<'a> Studio<'a> {
             }
         }
         cmd.stdout(Stdio::piped());
-        cmd.stderr(Stdio::piped());
+        // TED TODO: This will not work on windows. A more robust threading solution will be required for log_pipe
+        // to support consuming stderr and stdout.
+        // This manifests when a child starts (studio) and has an error (often unseen) then suddenly stops all execution.
+        cmd.stderr(unsafe { Stdio::from_raw_fd(1) }); // Log stderr to stdout
         cmd.arg("-k"); // Origin key
         cmd.arg(self.workspace.job.origin());
         cmd.arg("build");


### PR DESCRIPTION
This is a stop-gap measure to avoid stopping the worker main thread when stderr fills up the pipe buffer.

Closes #4027 

Signed-off-by: Travis Elliott Davis <edavis@chef.io>
![tenor-17019287](https://user-images.githubusercontent.com/1130349/32569780-c060a662-c487-11e7-94c8-8a21434cf137.gif)
