### PR TITLE
Updated default path for HAB_STUDIOS_HOME

### DIFF
--- a/www/source/partials/docs/_reference-environment-vars.html.md.erb
+++ b/www/source/partials/docs/_reference-environment-vars.html.md.erb
@@ -17,7 +17,7 @@ This is a list of all environment variables that can be used to modify the opera
 | `HAB_ORIGIN_KEYS` | build system | no default | Comma-separated list of origin keys to automatically share with the build system |
 | `HAB_RING` | Supervisor | no default | The ring used by the Supervisor when running with [wire encryption](/docs/using-habitat#using-encryption) |
 | `HAB_RING_KEY` | Supervisor | no default | The name of the ring key when running with [wire encryption](/docs/using-habitat#using-encryption) |
-| `HAB_STUDIOS_HOME` | build system | `/hab/studios` if running as root; `$HOME/.hab/studios` if running as non-root | Directory in which to create build studios |
+| `HAB_STUDIOS_HOME` | build system | `/hab/studios` | Directory in which to create build studios |
 | `HAB_STUDIO_BACKLINE_PKG` | build system | `core/hab-backline/{{studio_version}}` | Overrides the default package identifier for the "backline" package which installs the Studio basline package set. |
 | `HAB_STUDIO_ROOT` | build system | no default | Root of the current studio under `$HAB_STUDIOS_HOME`. Infrequently overridden. |
 | `HAB_STUDIO_NOSTUDIORC` | build system | no default | When set to a non-empty value, a `.studiorc` will not be sourced when entering an interactive Studio via `hab studio enter`. |


### PR DESCRIPTION
Removes root/non-root filepath description for HAB_STUDIOS_HOME env var as the default is simply `/hab/studios`.

Closes #1131. 

Signed-off-by: David Wrede <dwrede@chef.io>