### PR TITLE
#3993 - Docs sidebar scrolling

### DIFF
--- a/www/source/stylesheets/_layout.scss
+++ b/www/source/stylesheets/_layout.scss
@@ -75,6 +75,12 @@ body.body-article {
 
   .sticky {
     width: rem-calc(260);
+
+    &.is-at-top, &.is-anchored {
+      max-height: 100%;
+      overflow-y: scroll;
+      padding: 100px;
+    }
   }
 }
 


### PR DESCRIPTION
![tenor-267113219](https://user-images.githubusercontent.com/223407/32623569-a3fecdaa-c554-11e7-9915-acdafca864dc.gif)

Signed-off-by: Garrett Amini <kadjar@gmail.com>

https://github.com/habitat-sh/habitat/issues/3993