### PR TITLE
BLDR-Dockerfile: Add missing worker bootstrap

### DIFF
--- a/BLDR-Dockerfile
+++ b/BLDR-Dockerfile
@@ -21,7 +21,8 @@ COPY support/builder/init-datastore.sh /tmp/init-datastore.sh
 COPY terraform/scripts/install_base_packages.sh /tmp/install_base_packages.sh
 COPY terraform/scripts/foundation.sh /tmp/foundation.sh
 
-RUN addgroup -S hab && adduser -S -G hab hab \
+RUN adduser -g tty -h /home/krangschnak -D krangschnak \
+  && addgroup -S hab && adduser -S -G hab hab \
   && apk add --no-cache \
   bash \
   curl \


### PR DESCRIPTION
In `terraform/scripts/worker_bootstrap.sh` the user `krngschnak` is
created. However no such user exists under docker leading to the
following error on `docker run`:

```
builder-worker.default(O): System is missing studio user, krangschnak
```

This commit fixes the error.

Signed-off-by: Indradhanush Gupta <indra@kinvolk.io>