### PR TITLE
Sometimes you feel like a bind, sometimes ya don't

### DIFF
--- a/components/plan-build/bin/composite_build_functions.sh
+++ b/components/plan-build/bin/composite_build_functions.sh
@@ -152,10 +152,21 @@ _validate_bind_mappings() {
 
     resolved="${resolved_services[$pkg]}"
 
-    while read -r line; do
-      IFS== read bind_name exports <<< "${line}"
-      all_binds_for_pkg[$bind_name]="${exports[@]}"
-    done < <(_read_metadata_file_for "${resolved}" BINDS)
+    if [[ -f "${resolved}/BINDS" ]]; then
+      while read -r line; do
+        IFS== read bind_name exports <<< "${line}"
+        all_binds_for_pkg[$bind_name]="${exports[@]}"
+      done < <(_read_metadata_file_for "${resolved}" BINDS)
+    fi
+    if [[ -f "${resolved}/BINDS_OPTIONAL" ]]; then
+      while read -r line; do
+        IFS== read bind_name exports <<< "${line}"
+        if [[ -n "${all_binds_for_pkg[$bind_name]}" ]]; then
+          exit_with "The bind ${bind_name} has already been declared in pkg_binds for package ${pkg}, it cannot also be declared in pkg_binds_optional"
+        fi
+        all_binds_for_pkg[$bind_name]="${exports[@]}"
+      done < <(_read_metadata_file_for "${resolved}" BINDS_OPTIONAL)
+    fi
 
     unset bind_mappings
     bind_mappings=("${pkg_bind_map[$pkg]}")


### PR DESCRIPTION
When resolving binds in composite plans, the current code has issues when all your binds have been defined as optional (there's no BINDS file at all).  This PR fixes that by conditionally looking at either the BINDS or BINDS_OPTIONAL files

![sometimes you feel like a nut](https://media1.tenor.com/images/3e6e4e8fdb3200413c5a2f7ab2739242/tenor.gif?itemid=4775545)