### PR TITLE
[habitat.sh] Reverts breaking commits and removes footer images

### DIFF
--- a/www/source/blog/index.html.slim
+++ b/www/source/blog/index.html.slim
@@ -3,7 +3,10 @@ pageable: true
 per_page: 10
 ---
 .row
-  .main-content__has-sidebar.columns.small-12.medium-push-3.medium-9
+  .main-sidebar
+    = partial("/partials/blog/blog_sidebar")
+
+  .main-content__has-sidebar
     - page_articles.each_with_index do |article, i|
       .blog-index--post-summary
         .blog-index--post-summary--header.heading class=(['orange','blue','green'].sample)
@@ -34,5 +37,3 @@ per_page: 10
       - if next_page
         p.pagination-link
           = link_to 'Next page >>', next_page
-  .main-sidebar.columns.small-12.medium-3.medium-pull-9
-    = partial("/partials/blog/blog_sidebar")

--- a/www/source/layouts/_footer.slim
+++ b/www/source/layouts/_footer.slim
@@ -8,14 +8,6 @@ footer#main-footer class="#{layout_class}"
   /         a.footer--cta-button.outline href="/tutorials/download/" Download Habitat
   .footer--decor
     .row
-      .columns.large-6.small-4.footer--decor-item.footer--decor-clam
-        img src="/images/decor/habs-in-clams.svg" alt="Habitat in your enviroments!"/
-      .columns.large-2.small-4.footer--decor-item.footer--decor-trees
-        img src="/images/decor/tree-pair.svg"/
-      .columns.large-2.footer--decor-item.hide-small.footer--decor-cube
-        img src="/images/decor/hab-cube.svg"/
-      .columns.large-2.small-4.footer--decor-item.footer--decor-snorkel
-        img src="/images/decor/snorkelling-habicat.svg"/
 
   .footer--sitemap
     .row

--- a/www/source/stylesheets/_blog.scss
+++ b/www/source/stylesheets/_blog.scss
@@ -5,10 +5,6 @@
   .main-content__has-sidebar {
     background: transparent;
     padding: 0 !important;
-    
-    @include breakpoint(small only) {
-      margin-top: 15px;
-    }
   }
 }
 

--- a/www/source/stylesheets/_layout.scss
+++ b/www/source/stylesheets/_layout.scss
@@ -41,6 +41,9 @@ body.body-article {
 }
 
 .main-sidebar {
+  @include grid-column(12);
+  padding: rem-calc(20);
+
   a {
     display: block;
     position: relative;
@@ -64,15 +67,15 @@ body.body-article {
     font-weight: bold;
     color: $hab-primary;
   }
-  
+
+  @include breakpoint(medium) {
+    @include grid-column(3);
+    padding: rem-calc(20) 0;
+  }
+
   .sticky {
     width: rem-calc(260);
 
-    &.is-at-top, &.is-anchored {
-      max-height: 100%;
-      overflow-y: scroll;
-      padding: 100px;
-    }
   }
 }
 
@@ -139,6 +142,7 @@ body.body-article {
 }
 
 .main-content__has-sidebar {
+  @include grid-column(12);
   background-color: $hab-white; // fallback
   background: url("/images/graphics/article-watermark.png") no-repeat right bottom $white-slightly-transparent;
   background: url("/images/graphics/article-watermark.svg") no-repeat right bottom $white-slightly-transparent;
@@ -146,4 +150,9 @@ body.body-article {
   height: 100%;
   min-height: 70vh;
   padding: rem-calc(30) rem-calc(20) rem-calc(90);
+
+  @include breakpoint(medium) {
+    @include grid-column(9);
+    padding: rem-calc(40) rem-calc(30) rem-calc(120) !important;
+  }
 }


### PR DESCRIPTION
This PR is hopefully temporary but the website is in an incredibly broken state right now. All of the styles are boogered on most pages. This PR should be viewed as an interrim to correct the production instance of the website. It reverts the last two styles changes and removes the footer images that cause the download button to be unclickable when you scroll to the very bottom of a docs page.

This also corrects the broken article view once you've loaded a blog article page.

Signed-off-by: eeyun <ihenry@chef.io>