### PR TITLE
Specify runtime environments for packages

### DIFF
--- a/components/core/src/error.rs
+++ b/components/core/src/error.rs
@@ -109,6 +109,8 @@ pub enum Error {
     InvalidServiceGroup(String),
     /// Occurs when an origin is in an invalid format
     InvalidOrigin(String),
+    /// Occurs when an OsString path cannot be converted to a String
+    InvalidPathString(ffi::OsString),
     /// Occurs when making lower level IO calls.
     IO(io::Error),
     /// Errors when joining paths :)
@@ -130,8 +132,6 @@ pub enum Error {
     NoOutboundAddr,
     /// Occurs when a call to OpenDesktopW fails
     OpenDesktopFailed(String),
-    /// Occurs when dealing an OsString cannot be converted to a String
-    OsString(ffi::OsString),
     /// Occurs when a suitable installed package cannot be found.
     PackageNotFound(package::PackageIdent),
     /// When an error occurs parsing an integer.
@@ -328,6 +328,9 @@ impl fmt::Display for Error {
                     origin
                 )
             }
+            Error::InvalidPathString(ref s) => {
+                format!("Could not generate String from path: {:?}", s)
+            }
             Error::IO(ref err) => format!("{}", err),
             Error::JoinPathsError(ref err) => format!("{}", err),
             Error::LogonTypeNotGranted => {
@@ -347,7 +350,6 @@ impl fmt::Display for Error {
             Error::MetaFileIO(ref e) => format!("IO error while accessing MetaFile: {:?}", e),
             Error::NoOutboundAddr => format!("Failed to discover this hosts outbound IP address"),
             Error::OpenDesktopFailed(ref e) => format!("{}", e),
-            Error::OsString(ref s) => format!("Failed to convert to String: {:?}", s),
             Error::PackageNotFound(ref pkg) => {
                 if pkg.fully_qualified() {
                     format!("Cannot find package: {}", pkg)
@@ -476,6 +478,7 @@ impl error::Error for Error {
                 "Origins must begin with a lowercase letter or number.  \
                     Allowed characters include a - z, 0 - 9, _, and -. No more than 255 characters."
             }
+            Error::InvalidPathString(_) => "Failed to convert an OsString Path to a String",
             Error::IO(ref err) => err.description(),
             Error::JoinPathsError(ref err) => err.description(),
             Error::LogonTypeNotGranted => {
@@ -490,7 +493,6 @@ impl error::Error for Error {
             Error::MetaFileIO(_) => "MetaFile could not be read or written to",
             Error::NoOutboundAddr => "Failed to discover the outbound IP address",
             Error::OpenDesktopFailed(_) => "OpenDesktopW failed",
-            Error::OsString(_) => "Failed to convert an OsString to a String",
             Error::PackageNotFound(_) => "Cannot find a package",
             Error::ParseIntError(_) => "Failed to parse an integer from a string!",
             Error::PermissionFailed(_) => "Failed to set permissions",
@@ -514,12 +516,6 @@ impl error::Error for Error {
 impl From<env::JoinPathsError> for Error {
     fn from(err: env::JoinPathsError) -> Self {
         Error::JoinPathsError(err)
-    }
-}
-
-impl From<ffi::OsString> for Error {
-    fn from(s: ffi::OsString) -> Self {
-        Error::OsString(s)
     }
 }
 

--- a/components/core/src/package/install.rs
+++ b/components/core/src/package/install.rs
@@ -515,7 +515,8 @@ impl PackageInstall {
                 // If there was no RUNTIME_ENVIRONMENT, we can at
                 // least return a proper PATH
                 let path = env::join_paths(self.full_legacy_path()?.iter())?
-                    .into_string()?;
+                    .into_string()
+                    .map_err(|os_string| Error::InvalidPathString(os_string))?;
 
                 let mut env = HashMap::new();
                 env.insert(String::from("PATH"), path);

--- a/components/core/src/package/metadata.rs
+++ b/components/core/src/package/metadata.rs
@@ -180,6 +180,7 @@ pub enum MetaFile {
     Manifest,
     Path,
     ResolvedServices, // Composite-only
+    RuntimeEnvironment,
     Services, // Composite-only
     SvcGroup,
     SvcUser,
@@ -207,6 +208,7 @@ impl fmt::Display for MetaFile {
             MetaFile::Manifest => "MANIFEST",
             MetaFile::Path => "PATH",
             MetaFile::ResolvedServices => "RESOLVED_SERVICES",
+            MetaFile::RuntimeEnvironment => "RUNTIME_ENVIRONMENT",
             MetaFile::Services => "SERVICES",
             MetaFile::SvcGroup => "SVC_GROUP",
             MetaFile::SvcUser => "SVC_USER",

--- a/components/plan-build/bin/composite_build_functions.sh
+++ b/components/plan-build/bin/composite_build_functions.sh
@@ -92,19 +92,6 @@ _assert_package_is_a_service() {
     fi
 }
 
-# Given a path to a package's directory on disk and the name of a package
-# metadata file, returns the contents of that file on standard output.
-_read_metadata_file_for() {
-  local pkg_path="${1}"
-  local filename="${2}"
-  local full_path="${pkg_path}/${filename}"
-  if [[ -f "${full_path}" ]]; then
-    cat "${full_path}"
-  else
-    echo
-  fi
-}
-
 # Assemble a list of all the exports from a given package and return the list on
 # standard output.
 _exports_for_pkg() {

--- a/components/plan-build/bin/environment.sh
+++ b/components/plan-build/bin/environment.sh
@@ -1,0 +1,467 @@
+# Functions for resolving the runtime environment of a package.
+
+declare -A __runtime_environment
+declare -A __buildtime_environment
+
+declare -A __runtime_environment_provenance
+declare -A __buildtime_environment_provenance
+
+# Layer all direct dependencies' environment together.
+#
+# Priority is last-one-wins, based on the order in which you define
+# the dependencies in your plan file.
+#
+# (I'm sure there are many other common variables we could add here;
+# PRs welcome!)
+declare -A -g __well_known_aggregate_env_vars=(
+    # Shell
+    [PATH]=":"
+
+    # Go
+    [GOPATH]=":"
+
+    # Java
+    [CLASSPATH]=";"
+
+    # NodeJS
+    [NODE_PATH]=":"
+
+    # Python
+    [PYTHONHOME]=":"
+    [PYTHONPATH]=":"
+
+    # Ruby
+    [BUNDLE_PATH]=":"
+    [BUNDLE_WITHOUT]=":"
+    [GEM_PATH]=":"
+    [RUBYLIB]=":"
+    [RUBYPATH]=":"
+)
+
+# Purely internal implementation function to ensure we are operating
+# on the correct data structures. See call sites for further context.
+__fail_on_unrecognized_env() {
+    local env_name=${1}
+    if [ "${env_name}" != "__runtime_environment" ] &&
+           [ "${env_name}" != "__buildtime_environment" ]; then
+        exit_with "INTERNAL CODE ERROR: ${FUNCNAME[1]} was called at ${BASH_SOURCE[2]}:${BASH_LINENO[1]} with unrecognized environment variable name: ${env_name}"
+    fi
+}
+
+__fail_on_protected_env_var_manipulation() {
+    declare -A protected=(
+        [PATH]="pkg_deps"
+        [LD_RUN_PATH]="pkg_lib_dirs"
+        [LDFLAGS]="pkg_lib_dirs"
+        [CFLAGS]="pkg_include_dirs"
+        [CPPFLAGS]="pkg_include_dirs"
+        [CXXFLAGS]="pkg_include_dirs"
+        [PKG_CONFIG_PATH]="pkg_pconfig_dirs"
+    )
+    local var=${1}
+    for p in "${!protected[@]}"; do
+        if [ "${var}" == "${p}" ]; then
+            exit_with "Cannot directly manipulate environment variable ${var}! Add appropriate entries to the '${protected[${var}]}' variable in plan.sh instead!"
+        fi
+    done
+}
+
+# Each environment we deal with is populated using a different list of
+# dependencies. Given an environment, return the name of the proper
+# dependency list to use.
+#
+# Note: inputs and outputs of this function are Bash data structure
+# *names*.
+__dep_array_for_environment() {
+    local env_name=${1}
+    __fail_on_unrecognized_env "${env_name}"
+
+    local dep_array_name
+    case "${env_name}" in
+        "__runtime_environment")
+            dep_array_name="pkg_deps"
+            ;;
+        "__buildtime_environment")
+            dep_array_name="pkg_build_deps"
+            ;;
+    esac
+    echo "${dep_array_name}"
+}
+
+__provenance_for_environment() {
+    declare -A map=(
+        [__runtime_environment]="__runtime_environment_provenance"
+        [__buildtime_environment]="__buildtime_environment_provenance"
+    )
+    local env_name=${1}
+    __fail_on_unrecognized_env "${env_name}"
+    echo "${map[${env_name}]}"
+}
+
+# Determine whether a given environment variable is a primitive or
+# aggregate (i.e., PATH-style) variable.
+__env_var_type() {
+    local var_name="${1}"
+    declare -n hint_var="HAB_ENV_${var_name}_TYPE"
+
+    if [ -n "${hint_var}" ]; then
+        # Look for user-specified hints first
+        echo "${hint_var}"
+    elif [ -n "${__well_known_aggregate_env_vars[${var_name}]}" ]; then
+        # Look in our built-in map to see if we know anything about it
+        echo "aggregate"
+    else
+        # We know nothing about it; treat it as a primitive
+        warn "Treating \$${var_name} as a primitive type. If you would like to change this, add \`HAB_ENV_${var_name}_TYPE=aggregate\` to your plan."
+        echo "primitive"
+    fi
+}
+
+# Given that a variable is an aggregate (i.e., PATH-style) variable,
+# return the separator character used to delimit items in the value.
+__env_aggregate_separator() {
+    local var_name="${1}"
+    declare -n hint_var="HAB_ENV_${var_name}_SEPARATOR"
+
+    if [ -n "${hint_var}" ]; then
+        # Look for user-specified hints first
+        echo "${hint_var}"
+    elif [ -n "${__well_known_aggregate_env_vars[${var_name}]}" ]; then
+        # Look in our built-in map to see if we know anything about it
+        echo "${__well_known_aggregate_env_vars[${var_name}]}"
+    else
+        # Just assume it's the default
+        warn "Using \`:\` as a separator for \$${var_name}. If you would like to change this, add \`HAB_ENV_${var_name}_SEPARATOR=<YOUR_SEPARATOR>\` to your plan."
+        echo ":"
+    fi
+}
+
+# Read in the RUNTIME_ENVIRONMENT files from all direct dependencies
+# (in `pkg_deps` / `pkg_build_deps` order!) and layer them as appropriate.
+__populate_environment_from_deps() {
+    local path_to_dep
+    local env_file
+
+    local env_name=${1}
+    __fail_on_unrecognized_env "${env_name}"
+    declare -n env="${env_name}"
+    declare -n provenance="$(__provenance_for_environment ${env_name})"
+
+    local dep_array_name="$(__dep_array_for_environment ${env_name})"
+    declare -n dep_array="${dep_array_name}"
+
+
+    for dep in "${dep_array[@]}"; do
+
+        case "${env_name}" in
+            "__runtime_environment")
+                path_to_dep=$(_pkg_path_for_deps "${dep}")
+                ;;
+            "__buildtime_environment")
+                path_to_dep=$(_pkg_path_for_build_deps "${dep}")
+                ;;
+        esac
+
+        local dep_ident=$(cat "${path_to_dep}/IDENT")
+
+        if [ -f "${path_to_dep}/RUNTIME_ENVIRONMENT" ]; then
+            while read -r line; do
+                IFS== read var val <<< "${line}"
+
+                if [ -n env["${var}"] ]; then
+                    # There was a previous value; need to figure out
+                    # how to proceed
+
+                    # Where did the value come from originally?
+                    local source="${provenance[${var}]}"
+                    local current_value="${env[${var}]}"
+
+                    if [ "${val}" == "${current_value}" ]; then
+                        # If the value is the same as what we've got,
+                        # there's nothing to do
+                        continue
+                    fi
+
+                    case $(__env_var_type "${var}") in
+                        primitive)
+                            if [ -n "${current_value}" ]; then
+                                warn "Overwriting \$${var} originally set from ${source}"
+                            fi
+                            __set_env "${env_name}" "${var}" "${val}" "${dep_ident}"
+                        ;;
+                        aggregate)
+                            if [ -n "${current_value}" ]; then
+                                warn "Prepending to \$${var} originally set from ${source}"
+                            fi
+
+                            # if aggregate, push to front with separator
+                            local separator=$(__env_aggregate_separator "${var}")
+                            __push_env "${env_name}" "${var}" "${val}" "${separator}" "${dep_ident}"
+                            ;;
+                    esac
+                else
+                    # There was no previous value; just add this one
+                    env["${var}"]="${val}"
+                    provenance["${var}"]="${dep_ident}"
+                fi
+            done < <(_read_metadata_file_for "${path_to_dep}" RUNTIME_ENVIRONMENT)
+        else
+            # Versions of Habitat prior to the introduction of
+            # RUNTIME_ENVIRONMENT have a PATH file. Let's pull that in
+            # to assemble a PATH for our environment going forward.
+            #
+            # This will (in time) fix the issues in the old PATH data,
+            # which included build-time dependencies and system
+            # directories from the Studio. As older,
+            # lower-down-the-stack packages are rebuilt, they'll get
+            # the correct PATH, which will cascade outward.
+            #
+            # The old PATH also would include duplicate entries, as
+            # well as empty entries sometimes. The current resolution
+            # algorithm should filter these out immediately.
+            warn "No RUNTIME_ENVIRONMENT metadata file found for ${dep_ident}; falling back to PATH metadata"
+
+            local old_path=$(_read_metadata_file_for "${path_to_dep}" "PATH")
+            if [ -n "${old_path}" ]; then
+                __push_env "${env_name}" "PATH" "${old_path}" ":" "${dep_ident}"
+            fi
+        fi
+    done
+
+    # NB: This adds any local binaries to the build-time environment;
+    # strictly speaking, not necessary
+
+    # Push new PATH entries in from this package. We currently
+    # disallow users from directly manipulating PATH themselves.
+    local path="$(__process_path)"
+    if [ -n "${path}" ]; then
+        __push_env "${env_name}" "PATH" "${path}" ":" "${pkg_origin}/${pkg_name}/${pkg_version}/${pkg_release}"
+    fi
+}
+
+set_buildtime_env() {
+    set_env $* "__buildtime_environment"
+}
+
+set_runtime_env() {
+    set_env $* "__runtime_environment"
+}
+
+set_env(){
+    local force=false
+    local option
+
+    OPTIND=1
+    while getopts ":f" option; do
+        case "${option}" in
+            f) force=true
+               ;;
+        esac
+    done
+    shift "$((OPTIND - 1))"
+
+    local key="${1}"
+    __fail_on_protected_env_var_manipulation "${key}"
+
+    local value="${2}"
+
+    local env_name=${3}
+    __fail_on_unrecognized_env "${env_name}"
+    declare -n env="${env_name}"
+    declare -n provenance="$(__provenance_for_environment ${env_name})"
+
+    if [ -n "${env[${key}]}" ]; then
+        if [ "${force}" == "false" ]; then
+            exit_with "Already have a value for \$${key}, set by ${provenance[${key}]}: ${env[${key}]}. If you really wish to overwrite this value, pass the '-f' (\"force\") option when setting it."
+        else
+            warn "Already have a value for \$${key}, set by ${provenance[${key}]}: ${env[${key}]}. Overwriting value because the '-f' flag was passed"
+        fi
+    fi
+
+    __set_env "$env_name" "${key}" "${value}" "${pkg_origin}/${pkg_name}/${pkg_version}/${pkg_release}"
+}
+
+# Internal function implementing core "set" logic for environment variables.
+__set_env(){
+    local env_name=${1}
+    local var_name=${2}
+    local value=${3}
+    local ident=${4}
+
+    __fail_on_unrecognized_env "${env_name}"
+    declare -n env="${env_name}"
+
+    declare -n provenance="$(__provenance_for_environment ${env_name})"
+
+    env["${var_name}"]="${value}"
+    provenance["${var_name}"]="${ident}"
+}
+
+push_buildtime_env() {
+    build_line "PUSH TO BUILD"
+    do_push_env "__buildtime_environment" $*
+}
+
+push_runtime_env() {
+    build_line "PUSH TO RUN"
+    do_push_env "__runtime_environment" $*
+}
+
+do_push_env() {
+    local env_name=${1}
+    __fail_on_unrecognized_env "${env_name}"
+
+    local key=${2}
+    __fail_on_protected_env_var_manipulation "${key}"
+
+    local value=${3}
+
+    local sep="$(__env_aggregate_separator ${key})"
+
+    __push_env "${env_name}" "${key}" "${value}" "${sep}" "${pkg_origin}/${pkg_name}/${pkg_version}/${pkg_release}"
+}
+
+# Internal function implementing core "push" logic for environment variables.
+__push_env() {
+
+    local env_name=${1}
+    local var_name=${2}
+    local value=${3}
+    local separator=${4}
+    local ident=${5}
+
+    __fail_on_unrecognized_env "${env_name}"
+    declare -n env="${env_name}"
+
+    declare -n provenance="$(__provenance_for_environment ${env_name})"
+
+    # If there is no current value (that is, $current_value == ""), we
+    # can still push onto that with no loss of generality. Because
+    # push_to_path also dedupes the result, this allows us to take
+    # $value inputs that are themselves paths, which may have
+    # duplicate or blank entries (as is the case with some existing
+    # Habitat metadata files) and this will effectively "clean" them
+    # for us!
+    local current_value="${env[${var_name}]}"
+    local new_value=$(push_to_path "${value}" "${current_value}" "${separator}")
+    env["${var_name}"]="${new_value}"
+
+    local existing_provenance="${provenance[${var_name}]}"
+    provenance["${var_name}"]="$(push_to_path "${ident}" "${existing_provenance}" " ")"
+}
+
+dedupe_path(){
+    local separator=${2:-:}
+    local original_path=${1}${separator}
+
+    local new_path
+    local path_item
+
+    if [ -n "${original_path}" ]; then
+      while [ -n "${original_path}" ]; do
+        path_item="${original_path%%${separator}*}"       # the first remaining entry
+        case "${new_path}" in
+            *${separator}${path_item})
+              ;&
+            ${path_item}${separator}*)
+              ;&
+            *${separator}${path_item}${separator}*)
+              ;;         # already there
+            *)
+              new_path="${new_path}${separator}${path_item}"
+              ;;    # not there yet
+        esac
+        original_path="${original_path#*${separator}}"
+      done
+      new_path="${new_path#${separator}}"
+    fi
+
+    echo "${new_path}"
+}
+
+# Pushes $ITEM onto $PATH (using optional $SEPARATOR) and then
+# deduplicates entries.
+#
+# push_to_path "foo" "bar:foo:baz"
+#   -> "foo:bar:baz"
+#
+# push_to_path "foo" ""
+#   -> "foo"
+#
+# push_to_path "foo" "bar;baz" ";"
+#   -> "foo;bar;baz"
+#
+push_to_path() {
+    local item=${1}
+    local path=${2}
+    local separator=${3:-:}
+
+    local temp
+
+    if [ "" == "${path}" ]; then
+        temp="${item}"
+    else
+        temp="${item}${separator}${path}"
+    fi
+
+    dedupe_path "${temp}" "${separator}"
+}
+
+do_setup_environment_wrapper() {
+    build_line "Setting up environment"
+    build_line "Populating runtime environment from dependencies"
+    __populate_environment_from_deps "__runtime_environment"
+    build_line "Populating buildtime environment from dependencies"
+    __populate_environment_from_deps "__buildtime_environment"
+
+    do_setup_environment
+
+    build_line "Layering runtime environment on top of system environment"
+    # Export everything from our collected runtime environment into
+    # the real environment, except for PATH; for that, push the
+    # runtime path onto the front of the system path
+    for k in ${!__runtime_environment[@]}; do
+        local v="${__runtime_environment[${k}]}"
+        if [ "${k}" == "PATH" ]; then
+            build_line "Value of ${k} is ${!k}"
+            export "${k}"="$(push_to_path ${v} ${!k})"
+        else
+            export "${k}"="${v}"
+        fi
+    done
+
+    build_line "Layering buildtime environment on top of system environment"
+    # Layer buildtime environment values into the system environment,
+    # which has already had the runtime values merged in. This is a
+    # stripped-down version of the logic used to layer environments
+    # from dependencies in the first place.
+    for k in ${!__buildtime_environment[@]}; do
+        local v="${__buildtime_environment[${k}]}"
+        if [ -n "${!k}" ]; then
+            # There was a previous value; need to figure out
+            # how to proceed
+            if [ "${!k}" == "${v}" ]; then
+                # If the value is the same as what we've got,
+                # there's nothing to do
+                continue
+            fi
+
+            case $(__env_var_type "${k}") in
+                primitive)
+                    export "${k}"="${v}"
+                    ;;
+                aggregate)
+                    local separator=$(__env_aggregate_separator "${k}")
+                    export "${k}"="$(push_to_path ${v} ${!k} ${separator})"
+                    ;;
+            esac
+        else
+            # There was no previous value; just set this one
+            export "${k}"="${v}"
+        fi
+    done
+}
+
+do_setup_environment() {
+    return 0
+}

--- a/components/plan-build/bin/environment.sh
+++ b/components/plan-build/bin/environment.sh
@@ -27,7 +27,6 @@ declare -A -g __well_known_aggregate_env_vars=(
     [NODE_PATH]=":"
 
     # Python
-    [PYTHONHOME]=":"
     [PYTHONPATH]=":"
 
     # Ruby

--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -328,8 +328,7 @@
 source_dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 source "${source_dir}/public.sh"
 source "${source_dir}/shared.sh"
-
-
+source "${source_dir}/environment.sh"
 
 # Fail when commands return a non-zero return code.
 set -e
@@ -1883,6 +1882,9 @@ _build_metadata() {
   _render_metadata_CXXFLAGS
   _render_metadata_PKG_CONFIG_PATH
   _render_metadata_BUILD_ENVIRONMENT
+
+  _render_metadata_BUILDTIME_ENVIRONMENT
+  _render_metadata_BUILDTIME_ENVIRONMENT_PROVENANCE
   _render_metadata_ENVIRONMENT
   _render_metadata_ENVIRONMENT_SEP
   _render_metadata_PATH
@@ -1898,6 +1900,8 @@ _build_metadata() {
   _render_metadata_TARGET
   _render_metadata_TYPE
   _render_metadata_IDENT
+  _render_metadata_RUNTIME_ENVIRONMENT
+  _render_metadata_RUNTIME_ENVIRONMENT_PROVENANCE
 
   # Only generate `SVC_USER` & `SVC_GROUP` files if this package is a service.
   # We determine this by checking if there is a `hooks/run` script and/or
@@ -2393,8 +2397,22 @@ case "${pkg_type}" in
 
         _resolve_dependencies
 
-        # Set up runtime environment
-        _set_environment
+        # Set up runtime and buildtime environments
+        #
+        # Alas, this does not actually do *all* the environment setup;
+        # there are other places which must be accounted for. They
+        # are:
+        #
+        # * before `do_prepare`, but generally in `do_before`
+        #   This is where it is recommended that authors call
+        #   `update_plan_version` if they have a dynamic version.
+        # *_build_environment
+        #   This is where CFLAGS & Co. are set. At the moment, we
+        #   don't pull those into __runtime_environment and
+        #   __buildtime_environment because they are dealt with as
+        #   their own Special Thing (they've got their own metadata
+        #   files, etc.)
+        do_setup_environment_wrapper
 
         mkdir -pv "$HAB_CACHE_SRC_PATH"
 

--- a/components/plan-build/bin/public.sh
+++ b/components/plan-build/bin/public.sh
@@ -289,101 +289,20 @@ join_by() {
   echo "$*"
 }
 
-# Sets environment variable for package
-#
-# ```sh
-# add_env PATH 'bin' 'sbin'
-# add_env SETTINGS_MODULE 'app.settings'
-# ```
 add_env() {
-  local -u key=$1
-  shift
-  local values=($*)
-
-  if [[ ${pkg_env[$key]+abc} ]]; then
-    exit_with "Cannot add $key to pkg_env once the value is already set"
-  fi
-
-  if [[ -n ${values} ]]; then
-    # Set a default separator if none is defined
-    if [[ ! ${pkg_env_sep[$key]+abc} && ${_env_default_sep[$key]+abc} ]]; then
-      pkg_env_sep[$key]=${_env_default_sep[$key]}
-    fi
-
-    if [[ ${#values[@]} -gt 1 ]]; then
-      if [[ ${pkg_env_sep[$key]+abc} ]]; then
-        pkg_env[$key]=$(join_by ${pkg_env_sep[$key]} ${values[@]})
-      else
-        exit_with "Cannot add multiple values without setting a separator for $key"
-      fi
-    else
-      pkg_env[$key]=${values[0]}
-    fi
-  fi
+    exit_with "DEPRECATED: use 'set_runtime_env' instead!"
 }
 
-# Adds `$pkg_prefix` to supplied paths
-#
-# ```sh
-# add_path_env PATH 'bin' 'sbin'
-# ```
 add_path_env() {
-  local key=$1
-  shift
-  local paths=()
-  for path in $*; do
-    paths+=("${pkg_prefix}/${path}")
-  done
-  add_env ${key} ${paths[@]}
+    exit_with "DEPRECATED: use 'push_runtime_env' instead!"
 }
 
-# TODO: Make `add_build_env` and `add_build_path_env` more generic
-# Sets build environment variable for package
-#
-# ```sh
-# add_build_env PATH 'bin' 'sbin'
-# add_build_env SETTINGS_MODULE 'app.settings'
-# ```
 add_build_env() {
-  local -u key=$1
-  shift
-  local values=($*)
-
-  if [[ ${pkg_build_env[$key]+abc} ]]; then
-    exit_with "Cannot add $key to pkg_build_env once the value is already set"
-  fi
-
-  if [[ -n ${values} ]]; then
-    # Set a default separator if none is defined
-    if [[ ! ${pkg_env_sep[$key]+abc} && ${_env_default_sep[$key]+abc} ]]; then
-      pkg_env_sep[$key]=${_env_default_sep[$key]}
-    fi
-
-    if [[ ${#values[@]} -gt 1 ]]; then
-      if [[ ${pkg_env_sep[$key]+abc} ]]; then
-        pkg_build_env[$key]=$(join_by ${pkg_env_sep[$key]} ${values[@]})
-      else
-        exit_with "Cannot add multiple values without setting a separator for $key"
-      fi
-    else
-      pkg_build_env[$key]=${values[0]}
-    fi
-  fi
+    exit_with "DEPRECATED: use 'set_buildtime_env' instead!"
 }
 
-# Adds `$pkg_prefix` to supplied paths
-#
-# ```sh
-# add_build_path_env PATH 'bin' 'sbin'
-# ```
 add_build_path_env() {
-  local key=$1
-  shift
-  local paths=()
-  for path in $*; do
-    paths+=("${pkg_prefix}/${path}")
-  done
-  add_build_env ${key} ${paths[@]}
+    exit_with "DEPRECATED: use 'push_buildtime_env' instead!"
 }
 
 # Downloads a file from a source URL to a local file and uses an optional

--- a/components/plan-build/bin/shared.sh
+++ b/components/plan-build/bin/shared.sh
@@ -272,3 +272,18 @@ _render_dependency_metadata_file() {
       debug "Would have rendered ${metadata_file_name}, but there was no data for it"
   fi
 }
+
+########################################################################
+
+# Given a path to a package's directory on disk and the name of a package
+# metadata file, returns the contents of that file on standard output.
+_read_metadata_file_for() {
+  local pkg_path="${1}"
+  local filename="${2}"
+  local full_path="${pkg_path}/${filename}"
+  if [[ -f "${full_path}" ]]; then
+    cat "${full_path}"
+  else
+    echo
+  fi
+}

--- a/components/plan-build/bin/shared.sh
+++ b/components/plan-build/bin/shared.sh
@@ -35,10 +35,6 @@ _render_metadata_CXXFLAGS() {
     _render_c_includes_metadata_file ${pkg_prefix} CXXFLAGS pkg_include_dirs
 }
 
-_render_metadata_BUILD_ENVIRONMENT() {
-    _render_associative_array_file ${pkg_prefix} BUILD_ENVIRONMENT pkg_build_env
-}
-
 _render_metadata_BUILDTIME_ENVIRONMENT(){
     debug "Rendering BUILDTIME_ENVIRONMENT metadata file"
     _render_associative_array_file ${pkg_prefix} BUILDTIME_ENVIRONMENT __buildtime_environment
@@ -51,14 +47,6 @@ _render_metadata_BUILDTIME_ENVIRONMENT_PROVENANCE(){
 
 _render_metadata_DEPS() {
   _render_dependency_metadata_file ${pkg_prefix} DEPS pkg_deps_resolved
-}
-
-_render_metadata_ENVIRONMENT() {
-    _render_associative_array_file ${pkg_prefix} ENVIRONMENT pkg_env
-}
-
-_render_metadata_ENVIRONMENT_SEP() {
-    _render_associative_array_file ${pkg_prefix} ENVIRONMENT_SEP pkg_env_sep
 }
 
 _render_metadata_EXPORTS() {

--- a/components/plan-build/bin/shared.sh
+++ b/components/plan-build/bin/shared.sh
@@ -39,6 +39,16 @@ _render_metadata_BUILD_ENVIRONMENT() {
     _render_associative_array_file ${pkg_prefix} BUILD_ENVIRONMENT pkg_build_env
 }
 
+_render_metadata_BUILDTIME_ENVIRONMENT(){
+    debug "Rendering BUILDTIME_ENVIRONMENT metadata file"
+    _render_associative_array_file ${pkg_prefix} BUILDTIME_ENVIRONMENT __buildtime_environment
+}
+
+_render_metadata_BUILDTIME_ENVIRONMENT_PROVENANCE(){
+    debug "Rendering BUILDTIME_ENVIRONMENT_PROVENANCE metadata file"
+    _render_associative_array_file ${pkg_prefix} BUILDTIME_ENVIRONMENT_PROVENANCE __buildtime_environment_provenance
+}
+
 _render_metadata_DEPS() {
   _render_dependency_metadata_file ${pkg_prefix} DEPS pkg_deps_resolved
 }
@@ -145,12 +155,27 @@ _render_metadata_LD_RUN_PATH() {
     fi
 }
 
-# Create PATH metadata for older versions of Habitat
+# Simply converts contents of pkg_bin_dirs into a PATH variable
+__process_path() {
+    local path=()
+
+    # Contents of `pkg_bin_dirs` are relative to the plan root;
+    # prepend the full path to this release so everything resolves
+    # properly once the package is installed.
+    for bin in "${pkg_bin_dirs[@]}"; do
+        path+=("${pkg_prefix}/${bin}")
+    done
+
+    echo "$(join_by ":" ${path[@]})"
+}
+
+# The PATH metadata file contains full paths to every directory listed
+# in `pkg_bin_dirs`, as well as all dependencies.
+#
+# NOTE: This is to support older Habitat supervisors (pre-0.50.0).
 _render_metadata_PATH() {
-  if [[ ${pkg_env[PATH]+abc} ]]; then
     debug "Rendering PATH metadata file"
-    echo "${pkg_env[PATH]}" > "$pkg_prefix/PATH"
-  fi
+    echo "${__runtime_environment[PATH]}" > "${pkg_prefix}/PATH"
 }
 
 _render_metadata_PKG_CONFIG_PATH() {
@@ -178,6 +203,16 @@ _render_metadata_PKG_CONFIG_PATH() {
   else
       debug "Would have rendered ${metadata_file_name}, but there was no data for it"
   fi
+}
+
+_render_metadata_RUNTIME_ENVIRONMENT(){
+    debug "Rendering RUNTIME_ENVIRONMENT metadata file"
+    _render_associative_array_file ${pkg_prefix} RUNTIME_ENVIRONMENT __runtime_environment
+}
+
+_render_metadata_RUNTIME_ENVIRONMENT_PROVENANCE(){
+    debug "Rendering RUNTIME_ENVIRONMENT_PROVENANCE metadata file"
+    _render_associative_array_file ${pkg_prefix} RUNTIME_ENVIRONMENT_PROVENANCE __runtime_environment_provenance
 }
 
 _render_metadata_SVC_GROUP() {

--- a/components/plan-build/plan.sh
+++ b/components/plan-build/plan.sh
@@ -42,4 +42,5 @@ do_install() {
   install -D $PLAN_CONTEXT/bin/shared.sh $pkg_prefix/bin/
   install -D $PLAN_CONTEXT/bin/public.sh $pkg_prefix/bin/
   install -D $PLAN_CONTEXT/bin/composite_build_functions.sh $pkg_prefix/bin/
+  install -D $PLAN_CONTEXT/bin/environment.sh $pkg_prefix/bin/
 }

--- a/components/sup/src/manager/service/package.rs
+++ b/components/sup/src/manager/service/package.rs
@@ -14,7 +14,7 @@
 
 use std::collections::HashMap;
 use std::env;
-use std::ops::{Deref, DerefMut};
+use std::ops::Deref;
 use std::path::{Path, PathBuf};
 
 use hcore::fs::FS_ROOT_PATH;
@@ -36,12 +36,6 @@ impl Deref for Env {
 
     fn deref(&self) -> &Self::Target {
         &self.0
-    }
-}
-
-impl DerefMut for Env {
-    fn deref_mut(&mut self) -> &mut HashMap<String, String> {
-        &mut self.0
     }
 }
 

--- a/components/sup/src/util/path.rs
+++ b/components/sup/src/util/path.rs
@@ -141,14 +141,14 @@ pub fn interpreter_paths() -> Result<Vec<PathBuf>> {
     Ok(interpreter_paths)
 }
 
-pub fn append_interpreter_and_path(orig_paths: &mut Vec<PathBuf>) -> Result<String> {
-    let mut paths = interpreter_paths()?.to_owned();
-    orig_paths.append(&mut paths);
+pub fn append_interpreter_and_path(path_entries: &mut Vec<PathBuf>) -> Result<String> {
+    let mut paths = interpreter_paths()?;
+    path_entries.append(&mut paths);
     if let Some(val) = env::var_os("PATH") {
-        let mut os_paths = env::split_paths(&val).collect::<Vec<PathBuf>>();
-        orig_paths.append(&mut os_paths);
+        let mut os_paths = env::split_paths(&val).collect();
+        path_entries.append(&mut os_paths);
     }
-    let joined = env::join_paths(orig_paths)?;
+    let joined = env::join_paths(path_entries)?;
     let path_str = joined.into_string().expect(
         "Unable to convert OsStr path to string!",
     );


### PR DESCRIPTION
This PR allows plan authors to specify additional runtime and buildtime environment variables for their plans, using the new `set_runtime_env`, `push_runtime_env`, `set_buildtime_env`, and `push_buildtime_env` helper functions inside the new `do_setup_environment` plan callback function.

Runtime environments are layered together from direct dependencies, allowing (for example) the automatic generation of `PYTHONPATH`, `GEM_PATH`, etc., based on a package's dependencies. This generated runtime environment (generated at buildtime) is used by the Supervisor when running services, so authors will have less manual environment management to do in their hooks. Provenance of environment values is tracked in the new `RUNTIME_ENVIRONMENT_PROVENANCE` and `BUILDTIME_ENVIRONMENT_PROVENANCE` metadata files, which can aid in debugging any environment-related issues.

Buildtime environments function in a similar way, but are composed of the runtime environments of any build dependencies. They are not incorporated into the runtime environment seen by the Supervisor.

Read individual commit comments for further details.

Closes #949
Closes #1579
Closes #1830

cc: @georgemarshall @robbkidd @bixu 