### PR TITLE
run studio in a windows container when in window container mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,8 @@ matrix:
         - AFFECTED_DIRS="$_RUST_HAB_BIN_COMPONENTS|$_RUST_HAB_LIB_COMPONENTS"
       rust: stable
       sudo: false
+      services:
+        - docker
       addons:
         apt:
           sources:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,6 +25,9 @@ environment:
   RUSTUP_USE_HYPER: 1
   CARGO_HTTP_CHECK_REVOKE: false
   HAB_WINDOWS_STUDIO: true
+  BINTRAY_USER: chef-releng-ops
+  BINTRAY_KEY:
+    secure: KGpNfhM18alwGRviNGcMUStNMw3W2u002bf38+fs+mt9wf+4BGGuiUMKtu7Nrs8i
   HAB_AUTH_TOKEN:
     secure: il1kqjDtQSFOoD12nDaJhCBntC905Q8T9jRzyTZtqlJPxc3vCoS1bBeNbB55J82M
   ORIGIN_KEY:
@@ -38,7 +41,7 @@ environment:
 
     - hab_build_action: "package"
       hab_exe_version: "%24latest"
-      hab_components: "hab;plan-build-ps1;studio;sup;hab-butterfly"
+      hab_components: "hab;plan-build-ps1;studio;sup;hab-butterfly;bintray-publish"
 
 build_script:
   - ps: Update-AppveyorBuild -Version "$((gc -raw ./VERSION).trim())-$((Get-Date).ToString('yyyyMMddHHmmss'))"

--- a/components/bintray-publish/bin/publish-studio.bat
+++ b/components/bintray-publish/bin/publish-studio.bat
@@ -1,0 +1,2 @@
+@echo off
+"powershell.exe" -NoProfile -ExecutionPolicy bypass -NoLogo -Command ". '%~dp0publish-studio.ps1'" %*

--- a/components/bintray-publish/bin/publish-studio.ps1
+++ b/components/bintray-publish/bin/publish-studio.ps1
@@ -1,0 +1,48 @@
+$ErrorActionPreference = "Stop"
+
+function info($message) {
+    Write-Host -ForegroundColor Cyan -NoNewline "build-docker-image: "
+    Write-Host $message
+}
+
+function Assert-Docker {
+  if ((get-command docker -ErrorAction SilentlyContinue) -eq $null) {
+      Write-Error "We require docker to push the image"
+  }
+}
+
+function Push-Image {
+    & "$PSScriptRoot\build-docker-image.ps1"
+    if (!(Test-Path ./results/last_image.ps1)) {
+      Write-error "Image build report ./results/last_image.ps1 missing, aborting"
+  }
+  . ./results/last_image.ps1
+
+  try {
+    info "Logging in to Bintray Docker repo"
+    docker login -u="$env:BINTRAY_USER" -p="$env:BINTRAY_KEY" habitat-docker-registry.bintray.io
+    info "Pushing ${docker_image}:$docker_image_version"
+    docker push "${docker_image}:$docker_image_version"
+    info "Pushing ${docker_image}:$docker_image_short_version tag for $docker_image_version"
+    docker push "${docker_image}:$docker_image_short_version"
+    info "Pushing latest tag for $docker_image_version"
+    docker push "${docker_image}:latest"
+  }
+  finally {
+      Remove-Item $HOME/.docker/config.json -Recurse -Force -ErrorAction SilentlyContinue
+  }
+
+  info
+  info "Docker Image: docker pull $docker_image"
+  info
+}
+
+if($env:BINTRAY_USER -eq $null) {
+    Write-Error "Required environment variable: BINTRAY_USER"
+}
+if($env:BINTRAY_KEY -eq $null) {
+    Write-Error "Required environment variable: BINTRAY_KEY"
+}
+
+Assert-Docker
+Push-Image

--- a/components/bintray-publish/plan.ps1
+++ b/components/bintray-publish/plan.ps1
@@ -1,0 +1,24 @@
+$pkg_name = "hab-bintray-publish"
+$pkg_origin = "core"
+$pkg_version = "$(Get-Content $PLAN_CONTEXT/../../VERSION)"
+$pkg_maintainer = "The Habitat Maintainers <humans@habitat.sh>"
+$pkg_license = @("Apache-2.0")
+$pkg_source = "nosuchfile.tar.gz"
+$pkg_deps=@("core/powershell", "core/docker", "core/hab", "core/docker-credential-helper")
+$pkg_bin_dirs = @("bin")
+
+function Invoke-Build {
+    Get-Content "$PLAN_CONTEXT/bin/publish-studio.ps1" | % {
+        $_.Replace("@author@", $pkg_maintainer).Replace("@version@", "$pkg_version/$pkg_release")
+      } | Add-Content -Path publish-studio.ps1
+}
+
+function Invoke-Install {
+    Copy-Item "$PLAN_CONTEXT/../studio/build-docker-image.ps1" "$pkg_prefix/bin"
+    Copy-Item publish-studio.ps1 "$pkg_prefix/bin"
+    Copy-Item $PLAN_CONTEXT/bin/publish-studio.bat "$pkg_prefix/bin"
+}
+
+function Invoke-Download {}
+function Invoke-Verify {}
+function Invoke-Unpack {}

--- a/components/studio/build-docker-image.ps1
+++ b/components/studio/build-docker-image.ps1
@@ -1,0 +1,70 @@
+$ErrorActionPreference = "Stop"
+
+function info($message) {
+    Write-Host -ForegroundColor Cyan -NoNewline "build-docker-image: "
+    Write-Host $message
+}
+  
+if((Get-Command hab -ErrorAction SilentlyContinue) -eq $null) {
+  Write-Error "   'hab' command must be present on PATH, aborting"
+}
+
+$imageName = "habitat-docker-registry.bintray.io/win-studio"
+
+$startDir="$pwd"
+$tmpRoot = mkdir (Join-Path $env:TEMP ([System.IO.Path]::GetRandomFileName()))
+Push-Location $tmpRoot
+try {
+    $env:FS_ROOT="$tmpRoot/rootfs"
+    # Ensure that no existing `HAB_BINLINK_DIR` environment variable is present,
+    # like it would if executed in a Studio instance.
+    $env:HAB_BINLINK_DIR = $null
+    
+    info "Installing and extracting initial Habitat packages"
+    hab pkg install core/hab-studio
+    $studioPath = hab pkg path core/hab-studio
+    if ($LASTEXITCODE -ne 0) {
+      Write-Error "core/hab-studio must be installed, aborting"
+    }
+    
+    info "Purging container hab cache"
+    Remove-Item "$env:FS_ROOT/hab/cache" -Recurse -Force
+    
+    $pathParts = $studioPath.Replace("\", "/").Split("/")
+    $ident = [String]::Join("/", $pathParts[-4..-1])
+    $shortVersion = $pathParts[-2]
+    $version = "$($pathParts[-2])-$($pathParts[-1])"
+    
+@"
+FROM microsoft/windowsservercore
+MAINTAINER The Habitat Maintainers <humans@habitat.sh>
+ADD rootfs /
+WORKDIR /src
+ENTRYPOINT ["/hab/pkgs/$ident/bin/powershell/powershell.exe", "-ExecutionPolicy", "bypass", "-NoLogo", "-file", "/hab/pkgs/$ident/bin/hab-studio.ps1"]
+"@ | Out-File "$tmpRoot/Dockerfile" -Encoding ascii
+    
+    info "Building Docker image ${imageName}:$version'"
+    docker build --no-cache -t ${imageName}:$version .
+    
+    info "Tagging latest image to ${imageName}:$version"
+    docker tag ${imageName}:$version ${imageName}:latest
+    
+    info "Tagging latest image to ${imageName}:$shortVersion"
+    docker tag ${imageName}:$version ${imageName}:$shortVersion
+    
+@"
+`$docker_image="$imageName"
+`$docker_image_version="$version"
+`$docker_image_short_version="$shortVersion"
+"@ | Out-File "$startDir/results/last_image.ps1" -Encoding ascii
+    
+    info ""
+    info "Docker Image: ${imageName}:$version"
+    info "Build Report: $startDir/results/last_image.ps1"
+    info ""
+}
+finally {
+    Pop-Location
+    $env:FS_ROOT = $null
+    Remove-Item $tmpRoot -Recurse -Force
+}

--- a/support/ci/appveyor.ps1
+++ b/support/ci/appveyor.ps1
@@ -151,6 +151,9 @@ if (($env:APPVEYOR_REPO_TAG_NAME -eq "$(Get-Content VERSION)") -or (Test-SourceC
                     Copy-Item "/hab/pkgs/core/hab/*/*/bin/*" (Split-Path $habExe -Parent) -Force
                 }
             }
+            if(!(Test-PullRequest)) {
+                & $habExe pkg exec core/hab-bintray-publish publish-studio
+            }
         }
         else {
             Write-Warning "Unsupported Build Action: $BuildAction."


### PR DESCRIPTION
This changes `hab studio` if your docker client is running in "windows container mode" which is only available on windows 10 and 2016 servers. In such a case, the command will launch a windows container instead of a linux container.

The base container is `microsoft/windowsservercore` which is the most minimal windows container other than nano but nano will fail to work in many scenarios. In the future we may consider building a nano studio via a switch if users would like a nano based studio. Note that `microsoft/windowsservercore` is about 10GB so the very first pull will take quite some time.

This also includes adding a windows plan for the bintray-publish package but we only cover the studio publish since we already publish the cli via our appveyor script. While having that done via bintry-publish would be ideal, its out of scope for this PR.

The only thing that has not actually been tested here is the final appveyor publish. I have locally run `hab pkg exec core/hab-bintray-publish publish-studio` from a locally build bintray-publish and it succesfully published to our bintray registry.

Signed-off-by: mwrock <matt@mattwrock.com>