### PR TITLE
Added README generation for hab plan init

### DIFF
--- a/components/hab/src/command/plan/init.rs
+++ b/components/hab/src/command/plan/init.rs
@@ -41,6 +41,10 @@ const GITIGNORE_TEMPLATE: &'static str = include_str!(concat!(
     env!("CARGO_MANIFEST_DIR"),
     "/static/template_gitignore"
 ));
+const README_TEMPLATE: &'static str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/static/template_README.md"
+));
 
 const DEFAULT_PKG_VERSION: &'static str = "0.1.0";
 
@@ -124,6 +128,16 @@ pub fn start(
     )?;
     ui.para(
         "`default.toml` contains default values for `cfg` prefixed variables.",
+    )?;
+
+    let rendered_readme_md = handlebars.template_render(README_TEMPLATE, &data)?;
+    create_with_template(
+        ui,
+        &format!("{}/README.md", root),
+        &rendered_readme_md,
+    )?;
+    ui.para(
+        "`README.md` contains a basic README document which you should update.",
     )?;
 
     let config_path = format!("{}/config/", root);

--- a/components/hab/src/command/plan/init.rs
+++ b/components/hab/src/command/plan/init.rs
@@ -131,11 +131,7 @@ pub fn start(
     )?;
 
     let rendered_readme_md = handlebars.template_render(README_TEMPLATE, &data)?;
-    create_with_template(
-        ui,
-        &format!("{}/README.md", root),
-        &rendered_readme_md,
-    )?;
+    create_with_template(ui, &format!("{}/README.md", root), &rendered_readme_md)?;
     ui.para(
         "`README.md` contains a basic README document which you should update.",
     )?;

--- a/components/hab/static/template_README.md
+++ b/components/hab/static/template_README.md
@@ -1,0 +1,9 @@
+# Habitat package: {{ pkg_name }}
+
+## Description
+
+Provide a brief description of the `{{ pkg_name }}` plan / purpose.
+
+## Usage
+
+Describe the general usage for the `{{ pkg_name }}` plan


### PR DESCRIPTION
![tenor-204627436](https://user-images.githubusercontent.com/24568/32930141-147bcdde-cba0-11e7-8c9f-69d3fca7500a.gif)

Signed-off-by: Graham Weldon <graham@grahamweldon.com>