### PR TITLE
Fix permissions errors on api proxy by adding a reconfigure hook

### DIFF
--- a/components/builder-api-proxy/hooks/reconfigure
+++ b/components/builder-api-proxy/hooks/reconfigure
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+chown -R hab:hab {{pkg.svc_var_path}}
+chown -R hab:hab {{pkg.svc_config_path}}


### PR DESCRIPTION

![tenor-145040962](https://user-images.githubusercontent.com/1130349/32966540-af2ec85a-cb9f-11e7-9a08-7abca786956c.gif)

Closes #3521
Signed-off-by: Travis Elliott Davis <edavis@chef.io>