### PR TITLE
Vagrantfile: fix forwarded ports

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,7 +10,7 @@ Vagrant.configure("2") do |config|
   config.vm.synced_folder "~/.hab/cache/keys", "/hab/cache/keys"
   config.vm.synced_folder "~/.hab/etc", "/hab/etc"
 
-  config.vm.network "forwarded_port", guest: 80, host: 9636
+  config.vm.network "forwarded_port", guest: 3000, host: 3000
   config.vm.network "forwarded_port", guest: 9631, host: 9631
   config.vm.network "forwarded_port", guest: 9636, host: 9636
 


### PR DESCRIPTION
Currently both the port 80 and 9636 on the guest are mapped to the port 9636 on the host, which looks like an obvious bug.

Also forward the port 3000 from the guest to the host for the web interface.

Fixes https://github.com/habitat-sh/habitat/issues/4107