### PR TITLE
Generate FILES metadata file again

### DIFF
--- a/components/plan-build/bin/composite_build_functions.sh
+++ b/components/plan-build/bin/composite_build_functions.sh
@@ -205,7 +205,6 @@ _render_composite_metadata() {
     # NOTE: These come from the shared.sh library
     _render_metadata_IDENT
     _render_metadata_TARGET
-    _render_metadata_FILES
     _render_metadata_TYPE
 }
 

--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -2456,6 +2456,10 @@ esac
 
 # Common processing for both composite and standalone packages
 
+# The FILES file must be the last metadata file generated, as it lists
+# all the other metadata files within it.
+_render_metadata_FILES
+
 # Write the manifest
 _build_manifest
 


### PR DESCRIPTION
This was inadvertently removed in a previous commit.

Now, it is pulled into the common package generation flow, and after
any other metadata files have been generated, in order to ensure that
all generated files are reflected in its contents.

Signed-off-by: Christopher Maier <cmaier@chef.io>

Fixes #4100 