### PR TITLE
Fix indent in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,9 +165,9 @@ distclean: ## fully cleans up project tree and any associated Docker images and 
 .PHONY: distclean
 
 image: ## create an image
-	ifeq ($(HAS_DOCKER),)
-		$(error "Docker does not seem installed, please install docker first.")
-	endif
+ifeq ($(HAS_DOCKER),)
+	$(error "Docker does not seem installed, please install docker first.")
+endif
 	@if [ -n "${force}" -o -n "${refresh}" -o -z "`$(docker_cmd) images -q $(dimage)`" ]; then \
 		if [ -n "${force}" ]; then \
 		  $(docker_cmd) build --no-cache $(build_args) -t $(dimage) .; \


### PR DESCRIPTION
`ifeq` statements are not commands and should not have a tab before them. If they do, they cause an error condition.

In this case, the user will be misled that docker is not installed, when in fact, there is a syntax error in the makefile.

Signed-off-by: echohack <echohack@users.noreply.github.com>