### PR TITLE
git must be binlinked to use github_changelog_generator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,6 +191,7 @@ bundle: image
 
 changelog: image
 	@$(run) sh -c 'hab pkg install core/github_changelog_generator && \
+		hab pkg binlink core/git git --force && \
 		hab pkg binlink core/github_changelog_generator github_changelog_generator --force && \
 		github_changelog_generator --future-release $(VERSION) --token $(GITHUB_TOKEN)' --max-issues=1000
 


### PR DESCRIPTION
github_changelog_generator needs git `binlinked` so that it can run it from the path.

https://github.com/skywinder/github-changelog-generator/blob/v1.14.3/lib/github_changelog_generator/parser.rb#L250

Otherwise you'll encounter an error when `github_changelog_generator` attempts to shell out to call `git`.

Signed-off-by: echohack <echohack@users.noreply.github.com>