### PR TITLE
Web: Fix incorrect imports

### DIFF
--- a/components/builder-web/app/package/package-builds/package-builds.component.ts
+++ b/components/builder-web/app/package/package-builds/package-builds.component.ts
@@ -14,7 +14,7 @@
 
 import { Component, OnDestroy } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { Subscription } from 'rxjs/subscription';
+import { Subscription } from 'rxjs/Subscription';
 import { AppStore } from '../../app.store';
 
 @Component({

--- a/components/builder-web/app/package/package-readme/package-readme.component.ts
+++ b/components/builder-web/app/package/package-readme/package-readme.component.ts
@@ -14,7 +14,7 @@
 
 import { Component, OnDestroy } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { Subscription } from 'rxjs/subscription';
+import { Subscription } from 'rxjs/Subscription';
 
 @Component({
   template: require('./package-readme.component.html')

--- a/components/builder-web/app/package/package-release/package-release.component.ts
+++ b/components/builder-web/app/package/package-release/package-release.component.ts
@@ -14,7 +14,7 @@
 
 import { Component, OnDestroy } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { Subscription } from 'rxjs/subscription';
+import { Subscription } from 'rxjs/Subscription';
 import { AppStore } from '../../app.store';
 import { fetchPackage } from '../../actions/index';
 

--- a/components/builder-web/app/package/package-settings/package-settings.component.ts
+++ b/components/builder-web/app/package/package-settings/package-settings.component.ts
@@ -15,7 +15,7 @@
 import { Component, OnDestroy } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { MatDialog } from '@angular/material';
-import { Subscription } from 'rxjs/subscription';
+import { Subscription } from 'rxjs/Subscription';
 import { AppStore } from '../../app.store';
 
 @Component({

--- a/components/builder-web/app/package/package-versions/package-versions.component.ts
+++ b/components/builder-web/app/package/package-versions/package-versions.component.ts
@@ -14,7 +14,7 @@
 
 import { Component, OnDestroy } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { Subscription } from 'rxjs/subscription';
+import { Subscription } from 'rxjs/Subscription';
 import { AppStore } from '../../app.store';
 import { packageString, releaseToDate } from '../../util';
 import { fetchPackageVersions, filterPackagesBy } from '../../actions/index';


### PR DESCRIPTION
This commit fixes the incorrect import of `rxjs/Subscription` which
throws the following error at the moment when running
`support/builder_web.sh`:

```
[0] ERROR in [at-loader] ./app/package/package-builds/package-builds.component.ts:17:28
[0]     TS2307: Cannot find module 'rxjs/subscription'.
[0]
[0] ERROR in [at-loader] ./app/package/package-readme/package-readme.component.ts:17:28
[0]     TS2307: Cannot find module 'rxjs/subscription'.
[0]
[0] ERROR in [at-loader] ./app/package/package-release/package-release.component.ts:17:28
[0]     TS2307: Cannot find module 'rxjs/subscription'.
[0]
[0] ERROR in [at-loader] ./app/package/package-settings/package-settings.component.ts:18:28
[0]     TS2307: Cannot find module 'rxjs/subscription'.
[0]
[0] ERROR in [at-loader] ./app/package/package-versions/package-versions.component.ts:17:28
[0]     TS2307: Cannot find module 'rxjs/subscription'.
[0] npm run build-js exited with code 0
```

Signed-off-by: Indradhanush Gupta <indra@kinvolk.io>