### PR TITLE
Binlink to /usr/local/bin by default

### DIFF
--- a/components/core/src/binlink.rs
+++ b/components/core/src/binlink.rs
@@ -14,8 +14,10 @@
 
 use env;
 
-/// Default Binlink Dir
-pub const DEFAULT_BINLINK_DIR: &'static str = "/bin";
+/// Default Binlink Dirs
+pub const DEFAULT_BINLINK_DIR_1: &'static str = "/usr/local/bin";
+pub const DEFAULT_BINLINK_DIR_2: &'static str = "/usr/bin";
+pub const DEFAULT_BINLINK_DIR_3: &'static str = "/bin";
 
 /// Binlink Dir Environment variable
 pub const BINLINK_DIR_ENVVAR: &'static str = "HAB_BINLINK_DIR";
@@ -23,6 +25,22 @@ pub const BINLINK_DIR_ENVVAR: &'static str = "HAB_BINLINK_DIR";
 pub fn default_binlink_dir() -> String {
     match env::var(BINLINK_DIR_ENVVAR) {
         Ok(val) => val,
-        Err(_) => DEFAULT_BINLINK_DIR.to_string(),
+        Err(_) => fallback_binlib_dir(),
+    }
+}
+
+fn fallback_binlib_dir() -> String {
+    match env::var("PATH") {
+        Ok(path) => {
+            let path_members: Vec<&str> = path.split(':').collect();
+            if path_members.contains(&DEFAULT_BINLINK_DIR_1) {
+                DEFAULT_BINLINK_DIR_1.to_string()
+            } else if path_members.contains(&DEFAULT_BINLINK_DIR_2) {
+                DEFAULT_BINLINK_DIR_2.to_string()
+            } else {
+                DEFAULT_BINLINK_DIR_3.to_string()
+            }
+        }
+        Err(_) => DEFAULT_BINLINK_DIR_3.to_string(),
     }
 }

--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -216,7 +216,7 @@ pub fn get() -> App<'static, 'static> {
                 (@arg BINARY: +takes_value
                     "The command to binlink (ex: bash)")
                 (@arg DEST_DIR: -d --dest +takes_value
-                    "Sets the destination directory (default: /bin)")
+                    "Sets the destination directory (default: /usr/local/bin or /usr/bin or /bin)")
                 (@arg FORCE: -f --force "Overwrite existing binlinks")
             )
             (@subcommand config =>


### PR DESCRIPTION
If it is not in path, then try /usr/bin and if not, use /bin in last resort

Should close #1920

Signed-off-by: Romain Sertelon <romain@sertelon.fr>