### PR TITLE
k8s exporter: Add bind options & some cleanups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,6 +85,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "backtrace"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-demangle 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "backtrace-sys"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "base64"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -252,6 +275,11 @@ dependencies = [
  "serde_derive 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "cc"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cfg-if"
@@ -442,6 +470,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dbghelp-sys"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "digest"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -581,6 +618,24 @@ dependencies = [
 name = "error-chain"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "failure"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "failure_derive"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synstructure 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "fake-simd"
@@ -1333,6 +1388,8 @@ dependencies = [
  "clap 2.25.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy 0.0.144 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hab 0.0.0",
  "habitat_common 0.0.0",
  "habitat_core 0.0.0",
@@ -2447,6 +2504,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "rustc-serialize"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2761,6 +2823,15 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3181,6 +3252,8 @@ dependencies = [
 "checksum antidote 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "34fde25430d87a9388dadbe6e34d7f72a462c8b43ac8d309b42b0a8505d7e2a5"
 "checksum atty 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d912da0db7fa85514874458ca3651fe2cddace8d0b0505571dbdcd41ab490159"
 "checksum aws-sdk-rust 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "f14b02cfea32eabf6c568c94c7ef485414fd464a35433017ee4a8014b1e57ae2"
+"checksum backtrace 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8709cc7ec06f6f0ae6c2c7e12f6ed41540781f72b488d83734978295ceae182e"
+"checksum backtrace-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "44585761d6161b0f57afc49482ab6bd067e4edef48c12a152c237eb0203f7661"
 "checksum base64 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6c902f607515b17ee069f2757c58a6d4b2afa7411b8995f96c4a3c19247b5fcf"
 "checksum bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e103c8b299b28a9c6990458b7013dc4a8356a9b854c51b9883241f5866fac36e"
 "checksum bitflags 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "32866f4d103c4e438b1db1158aa1b1a80ee078e5d77a59a2f906fd62a577389c"
@@ -3198,6 +3271,7 @@ dependencies = [
 "checksum byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff81738b726f5d099632ceaffe7fb65b90212e8dce59d518729e7e8634032d3d"
 "checksum bytes 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c129aff112dcc562970abb69e2508b40850dd24c274761bb50fb8a0067ba6c27"
 "checksum cargo_metadata 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8b006ecc642d64bb8414734e2d57f14cbfddb11cd3cbd32392c0a4db58fdb8c4"
+"checksum cc 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a9b13a57efd6b30ecd6598ebdb302cca617930b5470647570468a65d12ef9719"
 "checksum cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de1e760d7b6535af4241fca8bd8adf68e2e7edacc6b29f5d399050c5e48cf88c"
 "checksum chrono 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)" = "9213f7cd7c27e95c2b57c49f0e69b1ea65b27138da84a170133fd21b07659c00"
 "checksum chrono 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d9123be86fd2a8f627836c235ecdf331fdd067ecf7ac05aa1a68fbcf2429f056"
@@ -3218,6 +3292,7 @@ dependencies = [
 "checksum crypt32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e34988f7e069e0b2f3bfc064295161e489b2d4e04a2e4248fb94360cdf00b4ec"
 "checksum ctrlc 3.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f26287fa3893461876a4851d1bee53b82f04954f85e2d7cd30ae053d0edefd72"
 "checksum curl-sys 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)" = "23e7e544dc5e1ba42c4a4a678bd47985e84b9c3f4d3404c29700622a029db9c3"
+"checksum dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97590ba53bcb8ac28279161ca943a924d1fd4a8fb3fa63302591647c4fc5b850"
 "checksum digest 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7a68d759d7a66a4f63d5bd2a2b14ad7e8cf93fe8c9be227031cd4e72ab0e9ee8"
 "checksum digest-buffer 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4eb92364e9f6d3da159257250532d448b218406d2acb149f724e8f48e9f5cb9a"
 "checksum dtoa 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0dd841b58510c9618291ffa448da2e4e0f699d984d436122372f446dae62263d"
@@ -3236,6 +3311,8 @@ dependencies = [
 "checksum errno 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b2c858c42ac0b88532f48fca88b0ed947cad4f1f64d904bcd6c9f138f7b95d70"
 "checksum error 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "a6e606f14042bb87cc02ef6a14db6c90ab92ed6f62d87e69377bc759fd7987cc"
 "checksum error-chain 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "318cb3c71ee4cdea69fdc9e15c173b245ed6063e1709029e8fd32525a881120f"
+"checksum failure 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "76aa046667594883228b6c1f55c260425950a5cdc66d3aa09c30472d5ac6e70c"
+"checksum failure_derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7223de85610caf0791730aa6f23360f9826ff570a03aa295f3f58bcf7e050f05"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum fallible-iterator 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "5d48ab1bc11a086628e8cc0cc2c2dc200b884ac05c4b48fb71d6036b6999ff1d"
 "checksum features 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b64b2e49155f3b9a3bd08d9a7432c11ea5910f3a2a4ea23d68ec89eadf2e52e1"
@@ -3361,6 +3438,7 @@ dependencies = [
 "checksum rusoto_credential 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "79be5ba8b6a099306d4862556b98ddc21bf0ca518aef77e091c7abeb50f5cb07"
 "checksum rusoto_ecr 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)" = "63a8089e871c927ea55a8aa08bf0ff26a7b8e86457c226bb42aa41616890f0b8"
 "checksum rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)" = "f76d05d3993fd5f4af9434e8e436db163a12a9d40e1a58a726f27a01dfd12a2a"
+"checksum rustc-demangle 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "aee45432acc62f7b9a108cc054142dac51f979e69e71ddce7d6fc7adf29e817e"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "c5f5376ea5e30ce23c03eb77cbe4962b988deead10910c372b226388b594c084"
 "checksum rustc_version 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b9743a7670d88d5d52950408ecdb7c71d8986251ab604d4689dd2ca25c9bca69"
@@ -3398,6 +3476,7 @@ dependencies = [
 "checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
+"checksum synstructure 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3a761d12e6d8dcb4dcf952a7a89b475e3a9d69e4a69307e01a470977642914bd"
 "checksum tee 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "37c12559dba7383625faaff75be24becf35bfc885044375bcab931111799a3da"
 "checksum tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "87974a6f5c1dfb344d733055601650059a3363de2a6104819293baff662132d6"
 "checksum tempfile 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3213fd2b7ed87e39306737ccfac04b1233b57a33ca64cfbf52f2ffaa2b765e2f"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1411,6 +1411,8 @@ version = "0.0.0"
 dependencies = [
  "clap 2.25.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat_common 0.0.0",
  "habitat_core 0.0.0",
  "habitat_pkg_export_docker 0.0.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1356,6 +1356,7 @@ dependencies = [
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat_common 0.0.0",
  "habitat_core 0.0.0",
+ "habitat_pkg_export_docker 0.0.0",
  "handlebars 0.26.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/pkg-export-docker/Cargo.toml
+++ b/components/pkg-export-docker/Cargo.toml
@@ -32,6 +32,8 @@ serde = { version = "*", features = ["rc"] }
 serde_json = "*"
 tempdir = "*"
 url = "*"
+failure = "0.1"
+failure_derive = "0.1"
 
 [features]
 default = []

--- a/components/pkg-export-docker/src/build.rs
+++ b/components/pkg-export-docker/src/build.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use clap;
 use std::fs as stdfs;
 use std::os::unix::fs::symlink;
 use std::path::{Path, PathBuf};
@@ -31,6 +32,10 @@ use fs;
 use rootfs;
 use super::{VERSION, BUSYBOX_IDENT, CACERTS_IDENT};
 use util;
+
+const DEFAULT_HAB_IDENT: &'static str = "core/hab";
+const DEFAULT_LAUNCHER_IDENT: &'static str = "core/hab-launcher";
+const DEFAULT_SUP_IDENT: &'static str = "core/hab-sup";
 
 /// The specification for creating a temporary file system build root, based on Habitat packages.
 ///
@@ -59,6 +64,26 @@ pub struct BuildSpec<'a> {
 }
 
 impl<'a> BuildSpec<'a> {
+    /// Creates a `BuildSpec` from cli arguments.
+    pub fn new_from_cli_matches(
+        m: &'a clap::ArgMatches,
+        default_channel: &'a str,
+        default_url: &'a str,
+    ) -> Self {
+        BuildSpec {
+            hab: m.value_of("HAB_PKG").unwrap_or(DEFAULT_HAB_IDENT),
+            hab_launcher: m.value_of("HAB_LAUNCHER_PKG").unwrap_or(
+                DEFAULT_LAUNCHER_IDENT,
+            ),
+            hab_sup: m.value_of("HAB_SUP_PKG").unwrap_or(DEFAULT_SUP_IDENT),
+            url: m.value_of("BLDR_URL").unwrap_or(&default_url),
+            channel: m.value_of("CHANNEL").unwrap_or(&default_channel),
+            base_pkgs_url: m.value_of("BASE_PKGS_BLDR_URL").unwrap_or(&default_url),
+            base_pkgs_channel: m.value_of("BASE_PKGS_CHANNEL").unwrap_or(&default_channel),
+            idents_or_archives: m.values_of("PKG_IDENT_OR_ARTIFACT").unwrap().collect(),
+        }
+    }
+
     /// Creates a `BuildRoot` for the given specification.
     ///
     /// # Errors

--- a/components/pkg-export-docker/src/build.rs
+++ b/components/pkg-export-docker/src/build.rs
@@ -513,7 +513,7 @@ impl BuildRootContext {
         if let None = self.svc_idents().first().map(|e| *e) {
             return Err(Error::PrimaryServicePackageNotFound(
                 self.idents.iter().map(|e| e.ident().to_string()).collect(),
-            ));
+            ))?;
         }
 
         Ok(())

--- a/components/pkg-export-docker/src/build.rs
+++ b/components/pkg-export-docker/src/build.rs
@@ -510,13 +510,13 @@ impl BuildRootContext {
     fn validate(&self) -> Result<()> {
         // A valid context for a build root will contain at least one service package, called the
         // primary service package.
-        if let None = self.svc_idents().first().map(|e| *e) {
-            return Err(Error::PrimaryServicePackageNotFound(
+        self.svc_idents()
+            .first()
+            .map(|e| *e)
+            .ok_or(Err(Error::PrimaryServicePackageNotFound(
                 self.idents.iter().map(|e| e.ident().to_string()).collect(),
-            ))?;
-        }
-
-        Ok(())
+            ))?)
+            .and(Ok(()))
     }
 }
 

--- a/components/pkg-export-docker/src/cli.rs
+++ b/components/pkg-export-docker/src/cli.rs
@@ -1,0 +1,251 @@
+// Copyright (c) 2016-2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![cfg_attr(feature="clippy", feature(plugin))]
+#![cfg_attr(feature="clippy", plugin(clippy))]
+
+use clap::{App, Arg};
+use std::path::Path;
+use std::result;
+use std::str::FromStr;
+
+use hcore::package::PackageIdent;
+use url::Url;
+
+/// The version of this library and program when built.
+pub const VERSION: &'static str = include_str!(concat!(env!("OUT_DIR"), "/VERSION"));
+
+/// A Docker-specific clap:App wrapper
+#[derive(Clone)]
+pub struct Cli<'a, 'b>
+where
+    'a: 'b,
+{
+    pub app: App<'a, 'b>,
+}
+
+impl<'a, 'b> Cli<'a, 'b> {
+    pub fn new(name: &str, about: &'a str) -> Self {
+        Cli {
+            app: clap_app!(
+            (name) =>
+            (about: about)
+            (version: VERSION)
+            (author: "\nAuthors: The Habitat Maintainers <humans@habitat.sh>\n\n")
+            (@arg IMAGE_NAME: --("image-name") -i +takes_value
+                "Image name (default: \"{{pkg_origin}}/{{pkg_name}}\" supports: \
+                 {{pkg_origin}}, {{pkg_name}}, {{pkg_version}}, {{pkg_release}}, {{channel}})")
+            ),
+        }
+    }
+
+    pub fn add_base_packages_args(self) -> Self {
+        let app = self.app
+            .arg(
+                Arg::with_name("HAB_PKG")
+                    .long("hab-pkg")
+                    .value_name("HAB_PKG")
+                    .validator(valid_ident_or_hart)
+                    .help(
+                        "Habitat CLI package identifier (ex: acme/redis) or filepath to a Habitat \
+                        artifact (ex: /home/acme-redis-3.0.7-21120102031201-x86_64-linux.hart) to \
+                        install (default: core/hab)",
+                    ),
+            )
+            .arg(
+                Arg::with_name("HAB_LAUNCHER_PKG")
+                    .long("launcher-pkg")
+                    .value_name("HAB_LAUNCHER_PKG")
+                    .validator(valid_ident_or_hart)
+                    .help(
+                        "Launcher package identifier (ex: acme/redis) or filepath to a Habitat \
+                        artifact (ex: /home/acme-redis-3.0.7-21120102031201-x86_64-linux.hart) to \
+                        install (default: core/hab-launcher)",
+                    ),
+            )
+            .arg(
+                Arg::with_name("HAB_SUP_PKG")
+                    .long("sup-pkg")
+                    .value_name("HAB_SUP_PKG")
+                    .validator(valid_ident_or_hart)
+                    .help(
+                        "Supervisor package identifier (ex: acme/redis) or filepath to a Habitat \
+                        artifact (ex: /home/acme-redis-3.0.7-21120102031201-x86_64-linux.hart) to \
+                        install (default: core/hab-sup)",
+                    ),
+            );
+
+        Cli { app: app }
+    }
+
+    pub fn add_builder_args(self) -> Self {
+        let app = self.app
+            .arg(
+                Arg::with_name("BLDR_URL")
+                    .long("url")
+                    .short("u")
+                    .value_name("BLDR_URL")
+                    .validator(valid_url)
+                    .help(
+                        "Install packages from Builder at the specified URL \
+                        (default: https://bldr.habitat.sh)",
+                    ),
+            )
+            .arg(
+                Arg::with_name("CHANNEL")
+                    .long("channel")
+                    .short("c")
+                    .value_name("CHANNEL")
+                    .help(
+                        "Install packages from the specified release channel (default: stable)",
+                    ),
+            )
+            .arg(
+                Arg::with_name("BASE_PKGS_BLDR_URL")
+                    .long("base-pkgs-url")
+                    .value_name("BASE_PKGS_BLDR_URL")
+                    .validator(valid_url)
+                    .help(
+                        "Install base packages from Builder at the specified URL \
+                        (default: https://bldr.habitat.sh)",
+                    ),
+            )
+            .arg(
+                Arg::with_name("BASE_PKGS_CHANNEL")
+                    .long("base-pkgs-channel")
+                    .value_name("BASE_PKGS_CHANNEL")
+                    .help(
+                        "Install base packages from the specified release channel \
+                        (default: stable)",
+                    ),
+            );
+
+        Cli { app: app }
+    }
+
+    pub fn add_tagging_args(self) -> Self {
+        let app = self.app
+            .arg(
+                Arg::with_name("TAG_VERSION_RELEASE")
+                    .long("tag-version-release")
+                    .conflicts_with("NO_TAG_VERSION_RELEASE")
+                    .help(
+                        "Tag image with :\"{{pkg_version}}-{{pkg_release}}\" (default: yes)",
+                    ),
+            )
+            .arg(
+                Arg::with_name("NO_TAG_VERSION_RELEASE")
+                    .long("no-tag-version-release")
+                    .conflicts_with("TAG_VERSION_RELEASE")
+                    .help(
+                        "Do not tag image with :\"{{pkg_version}}-{{pkg_release}}\" (default: no)",
+                    ),
+            )
+            .arg(
+                Arg::with_name("TAG_VERSION")
+                    .long("tag-version")
+                    .conflicts_with("NO_TAG_VERSION")
+                    .help("Tag image with :\"{{pkg_version}}\" (default: yes)"),
+            )
+            .arg(
+                Arg::with_name("NO_TAG_VERSION")
+                    .long("no-tag-version")
+                    .conflicts_with("TAG_VERSION")
+                    .help("Do not tag image with :\"{{pkg_version}}\" (default: no)"),
+            )
+            .arg(
+                Arg::with_name("TAG_LATEST")
+                    .long("tag-latest")
+                    .conflicts_with("NO_TAG_LATEST")
+                    .help("Tag image with :\"latest\" (default: yes)"),
+            )
+            .arg(
+                Arg::with_name("NO_TAG_LATEST")
+                    .long("no-tag-latest")
+                    .conflicts_with("TAG_LATEST")
+                    .help("Do not tag image with :\"latest\" (default: no)"),
+            )
+            .arg(
+                Arg::with_name("TAG_CUSTOM")
+                    .long("tag-custom")
+                    .value_name("TAG_CUSTOM")
+                    .help(
+                        "Tag image with additional custom tag (supports: {{pkg_origin}}, \
+                        {{pkg_name}}, {{pkg_version}}, {{pkg_release}}, {{channel}})",
+                    ),
+            );
+
+        Cli { app: app }
+    }
+
+    pub fn add_publishing_args(self) -> Self {
+        let app = self.app.arg(Arg::with_name("PUSH_IMAGE")
+                 .long("push-image")
+                 .conflicts_with("NO_PUSH_IMAGE")
+                 .requires_all(&["REGISTRY_USERNAME", "REGISTRY_PASSWORD"])
+                 .help("Push image to remote registry (default: no)"))
+            .arg(Arg::with_name("NO_PUSH_IMAGE")
+                 .long("no-push-image")
+                 .conflicts_with("PUSH_IMAGE")
+                 .help("Do not push image to remote registry (default: yes)"))
+            .arg(Arg::with_name("REGISTRY_USERNAME")
+                 .long("username")
+                 .short("U")
+                 .value_name("REGISTRY_USERNAME")
+                 .requires("REGISTRY_PASSWORD")
+                 .help("Remote registry username, required for pushing image to remote registry"))
+            .arg(Arg::with_name("REGISTRY_PASSWORD")
+                 .long("password")
+                 .short("P")
+                 .value_name("REGISTRY_PASSWORD")
+                 .requires("REGISTRY_USERNAME")
+                 .help("Remote registry password, required for pushing image to remote registry"))
+            .arg(Arg::with_name("REGISTRY_TYPE")
+                 .long("registry-type")
+                 .short("R")
+                 .value_name("REGISTRY_TYPE")
+                 .help("Remote registry type, Ex: Amazon, Docker, Google (default: docker)"))
+            .arg(Arg::with_name("REGISTRY_URL")
+                 .long("registry-url")
+                 .short("G")
+                 .value_name("REGISTRY_URL")
+                 .help("Remote registry url"))
+            // Cleanup
+            .arg(Arg::with_name("RM_IMAGE")
+                 .long("rm-image")
+                 .help("Remove local image from engine after build and/or push (default: no)"));
+
+        Cli { app: app }
+    }
+}
+
+fn valid_ident_or_hart(val: String) -> result::Result<(), String> {
+    if Path::new(&val).is_file() {
+        Ok(())
+    } else if val.ends_with(".hart") {
+        Err(format!("Habitat artifact file: '{}' not found", &val))
+    } else {
+        match PackageIdent::from_str(&val) {
+            Ok(_) => Ok(()),
+            Err(e) => Err(format!("{}", e)),
+        }
+    }
+}
+
+fn valid_url(val: String) -> result::Result<(), String> {
+    match Url::parse(&val) {
+        Ok(_) => Ok(()),
+        Err(_) => Err(format!("URL: '{}' is not valid", &val)),
+    }
+}

--- a/components/pkg-export-docker/src/docker.rs
+++ b/components/pkg-export-docker/src/docker.rs
@@ -96,7 +96,7 @@ impl<'a> DockerBuilder<'a> {
         debug!("Running: {:?}", &cmd);
         let exit_status = cmd.spawn()?.wait()?;
         if !exit_status.success() {
-            return Err(Error::BuildFailed(exit_status));
+            return Err(Error::BuildFailed(exit_status))?;
         }
 
         let id = match self.tags.first() {
@@ -120,7 +120,7 @@ impl<'a> DockerBuilder<'a> {
 
         match stdout.lines().next() {
             Some(id) => Ok(id.to_string()),
-            None => Err(Error::DockerImageIdNotFound(image_tag.to_string())),
+            None => Err(Error::DockerImageIdNotFound(image_tag.to_string()))?,
         }
     }
 }
@@ -281,7 +281,7 @@ impl<'a> DockerImage {
         );
         let exit_status = cmd.spawn()?.wait()?;
         if !exit_status.success() {
-            return Err(Error::LoginFailed(exit_status));
+            return Err(Error::LoginFailed(exit_status))?;
         }
 
         Ok(())
@@ -301,7 +301,7 @@ impl<'a> DockerImage {
         debug!("Running: {:?}", &cmd);
         let exit_status = cmd.spawn()?.wait()?;
         if !exit_status.success() {
-            return Err(Error::LogoutFailed(exit_status));
+            return Err(Error::LogoutFailed(exit_status))?;
         }
 
         Ok(())
@@ -321,7 +321,7 @@ impl<'a> DockerImage {
         debug!("Running: {:?}", &cmd);
         let exit_status = cmd.spawn()?.wait()?;
         if !exit_status.success() {
-            return Err(Error::PushImageFailed(exit_status));
+            return Err(Error::PushImageFailed(exit_status))?;
         }
         ui.status(
             Status::Uploaded,
@@ -345,7 +345,7 @@ impl<'a> DockerImage {
         debug!("Running: {:?}", &cmd);
         let exit_status = cmd.spawn()?.wait()?;
         if !exit_status.success() {
-            return Err(Error::RemoveImageFailed(exit_status));
+            return Err(Error::RemoveImageFailed(exit_status))?;
         }
 
         Ok(())

--- a/components/pkg-export-docker/src/docker.rs
+++ b/components/pkg-export-docker/src/docker.rs
@@ -265,9 +265,9 @@ impl<'a> DockerImage {
         let mut cmd = docker_cmd();
         cmd.arg("login")
             .arg("--username")
-            .arg(credentials.username)
+            .arg(&credentials.username)
             .arg("--password")
-            .arg(credentials.password);
+            .arg(&credentials.password);
 
         if let Some(arg) = registry_url {
             cmd.arg(arg);
@@ -276,8 +276,8 @@ impl<'a> DockerImage {
         debug!(
             "Running: {}",
             format!("{:?}", &cmd)
-                .replace(credentials.username, "<username-redacted>")
-                .replace(credentials.password, "<password-redacted>")
+                .replace(&credentials.username, "<username-redacted>")
+                .replace(&credentials.password, "<password-redacted>")
         );
         let exit_status = cmd.spawn()?.wait()?;
         if !exit_status.success() {

--- a/components/pkg-export-docker/src/docker.rs
+++ b/components/pkg-export-docker/src/docker.rs
@@ -452,7 +452,9 @@ impl DockerBuildRoot {
         ui.status(Status::Creating, "image Dockerfile")?;
         let ctx = self.0.ctx();
         let json = json!({
-            "rootfs": ctx.rootfs().file_name().expect("file_name exists").to_string_lossy().as_ref(),
+            "rootfs": ctx.rootfs().file_name().expect("file_name exists")
+                .to_string_lossy()
+                .as_ref(),
             "path": ctx.env_path(),
             "volumes": ctx.svc_volumes().join(" "),
             "exposes": ctx.svc_exposes().join(" "),

--- a/components/pkg-export-docker/src/error.rs
+++ b/components/pkg-export-docker/src/error.rs
@@ -14,7 +14,6 @@
 
 use base64::DecodeError;
 use std::process::ExitStatus;
-use std::fmt;
 use std::io;
 use std::result;
 use std::string::FromUtf8Error;
@@ -24,99 +23,44 @@ use common;
 use hab;
 use handlebars;
 use hcore;
+use failure;
 
-pub type Result<T> = result::Result<T, Error>;
+pub type Result<T> = result::Result<T, failure::Error>;
 
-#[derive(Debug)]
+#[derive(Debug, Fail)]
 pub enum Error {
+    #[fail(display = "{}", _0)]
     Base64DecodeError(DecodeError),
+    #[fail(display = "Docker build failed with exit code: {}", _0)]
     BuildFailed(ExitStatus),
+    #[fail(display = "Could not determine Docker image ID for image: {}", _0)]
     DockerImageIdNotFound(String),
+    #[fail(display = "{}", _0)]
     InvalidToken(FromUtf8Error),
+    #[fail(display = "{}", _0)]
     Hab(hab::error::Error),
+    #[fail(display = "{}", _0)]
     HabitatCommon(common::Error),
+    #[fail(display = "{}", _0)]
     HabitatCore(hcore::Error),
+    #[fail(display = "Docker login failed with exit code: {}", _0)]
     LoginFailed(ExitStatus),
+    #[fail(display = "Docker logout failed with exit code: {}", _0)]
     LogoutFailed(ExitStatus),
+    #[fail(display = "No ECR Tokens returned")]
     NoECRTokensReturned,
+    #[fail(display = "{}", _0)]
     TokenFetchFailed(GetAuthorizationTokenError),
+    #[fail(display = "A primary service package could not be determined from: {:?}. \
+                     At least one package with a run hook must be provided.",
+           _0)]
     PrimaryServicePackageNotFound(Vec<String>),
+    #[fail(display = "Docker image push failed with exit code: {}", _0)]
     PushImageFailed(ExitStatus),
+    #[fail(display = "Removing Docker local images failed with exit code: {}", _0)]
     RemoveImageFailed(ExitStatus),
+    #[fail(display = "{}", _0)]
     TemplateRenderError(handlebars::TemplateRenderError),
+    #[fail(display = "{}", _0)]
     IO(io::Error),
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let msg = match *self {
-            Error::Base64DecodeError(ref err) => format!("{}", err),
-            Error::BuildFailed(status) => format!("Docker build failed with exit code: {}", status),
-            Error::DockerImageIdNotFound(ref image_tag) => {
-                format!(
-                    "Could not determine Docker image ID for image: {}",
-                    image_tag
-                )
-            }
-            Error::Hab(ref err) => format!("{}", err),
-            Error::HabitatCommon(ref err) => format!("{}", err),
-            Error::HabitatCore(ref err) => format!("{}", err),
-            Error::LoginFailed(status) => format!("Docker login failed with exit code: {}", status),
-            Error::TokenFetchFailed(ref err) => format!("{}", err),
-            Error::NoECRTokensReturned => format!("No ECR Tokens returned"),
-            Error::InvalidToken(ref err) => format!("{}", err),
-            Error::LogoutFailed(status) => {
-                format!("Docker logout failed with exit code: {}", status)
-            }
-            Error::PrimaryServicePackageNotFound(ref idents) => {
-                format!(
-                    "A primary service package could not be determined from: {}. \
-                    At least one package with a run hook must be provided.",
-                    idents.join(", ")
-                )
-            }
-            Error::PushImageFailed(status) => {
-                format!("Docker image push failed with exit code: {}", status)
-            }
-            Error::RemoveImageFailed(status) => {
-                format!(
-                    "Removing Docker local images failed with exit code: {}",
-                    status
-                )
-            }
-            Error::TemplateRenderError(ref err) => format!("{}", err),
-            Error::IO(ref err) => format!("{}", err),
-        };
-        write!(f, "{}", msg)
-    }
-}
-
-impl From<common::Error> for Error {
-    fn from(err: common::Error) -> Self {
-        Error::HabitatCommon(err)
-    }
-}
-
-impl From<hab::error::Error> for Error {
-    fn from(err: hab::error::Error) -> Self {
-        Error::Hab(err)
-    }
-}
-
-impl From<handlebars::TemplateRenderError> for Error {
-    fn from(err: handlebars::TemplateRenderError) -> Self {
-        Error::TemplateRenderError(err)
-    }
-}
-
-impl From<hcore::Error> for Error {
-    fn from(err: hcore::Error) -> Self {
-        Error::HabitatCore(err)
-    }
-}
-
-impl From<io::Error> for Error {
-    fn from(err: io::Error) -> Self {
-        Error::IO(err)
-    }
 }

--- a/components/pkg-export-docker/src/lib.rs
+++ b/components/pkg-export-docker/src/lib.rs
@@ -15,6 +15,8 @@
 #![cfg_attr(feature="clippy", feature(plugin))]
 #![cfg_attr(feature="clippy", plugin(clippy))]
 
+#[macro_use]
+extern crate clap;
 extern crate hab;
 extern crate habitat_core as hcore;
 extern crate habitat_common as common;
@@ -28,8 +30,10 @@ extern crate log;
 extern crate serde_json;
 extern crate tempdir;
 extern crate base64;
+extern crate url;
 
 mod build;
+pub mod cli;
 mod docker;
 mod error;
 mod fs;
@@ -38,6 +42,7 @@ mod util;
 
 use common::ui::UI;
 
+pub use cli::Cli;
 pub use build::BuildSpec;
 pub use docker::{DockerImage, DockerBuildRoot};
 pub use error::{Error, Result};
@@ -72,6 +77,24 @@ pub struct Naming<'a> {
     pub registry_url: Option<&'a str>,
     /// The type of registry we're publishing to. Ex: Amazon, Docker, Google, Azure.
     pub registry_type: &'a str,
+}
+
+impl<'a> Naming<'a> {
+    /// Creates a `Naming` from cli arguments.
+    pub fn new_from_cli_matches(m: &'a clap::ArgMatches) -> Self {
+        let registry_type = m.value_of("REGISTRY_TYPE").unwrap_or("docker");
+        let registry_url = m.value_of("REGISTRY_URL");
+
+        Naming {
+            custom_image_name: m.value_of("IMAGE_NAME"),
+            latest_tag: !m.is_present("NO_TAG_LATEST"),
+            version_tag: !m.is_present("NO_TAG_VERSION"),
+            version_release_tag: !m.is_present("NO_TAG_VERSION_RELEASE"),
+            custom_tag: m.value_of("TAG_CUSTOM"),
+            registry_url: registry_url,
+            registry_type: registry_type,
+        }
+    }
 }
 
 /// A credentials username and password pair.

--- a/components/pkg-export-docker/src/lib.rs
+++ b/components/pkg-export-docker/src/lib.rs
@@ -34,6 +34,10 @@ extern crate tempdir;
 extern crate base64;
 extern crate url;
 
+extern crate failure;
+#[macro_use]
+extern crate failure_derive;
+
 mod build;
 pub mod cli;
 mod docker;
@@ -127,20 +131,20 @@ impl Credentials {
                     Ok(resp) => {
                         match resp.authorization_data {
                             Some(auth_data) => auth_data[0].clone().authorization_token.unwrap(),
-                            None => return Err(Error::NoECRTokensReturned),
+                            None => return Err(Error::NoECRTokensReturned)?,
                         }
                     }
-                    Err(e) => return Err(Error::TokenFetchFailed(e)),
+                    Err(e) => return Err(Error::TokenFetchFailed(e))?,
                 };
 
                 let creds: Vec<String> = match base64::decode(&token) {
                     Ok(decoded_token) => {
                         match String::from_utf8(decoded_token) {
                             Ok(dts) => dts.split(':').map(String::from).collect(),
-                            Err(err) => return Err(Error::InvalidToken(err)),
+                            Err(err) => return Err(Error::InvalidToken(err))?,
                         }
                     }
-                    Err(err) => return Err(Error::Base64DecodeError(err)),
+                    Err(err) => return Err(Error::Base64DecodeError(err))?,
                 };
 
                 Ok(Credentials {

--- a/components/pkg-export-kubernetes/Cargo.toml
+++ b/components/pkg-export-kubernetes/Cargo.toml
@@ -20,6 +20,8 @@ handlebars = { version = "*", default-features = false }
 log = "*"
 serde = "1.0.2"
 serde_json = "1.0.0"
+failure = "0.1"
+failure_derive = "0.1"
 
 [features]
 default = []

--- a/components/pkg-export-kubernetes/Cargo.toml
+++ b/components/pkg-export-kubernetes/Cargo.toml
@@ -15,6 +15,7 @@ clap = { version = "*", features = ["suggestions", "color", "unstable"] }
 env_logger = "*"
 habitat_core = { path = "../core" }
 habitat_common = { path = "../common" }
+habitat_pkg_export_docker = { path = "../pkg-export-docker" }
 handlebars = { version = "*", default-features = false }
 log = "*"
 serde = "1.0.2"

--- a/components/pkg-export-kubernetes/defaults/KubernetesBind.hbs
+++ b/components/pkg-export-kubernetes/defaults/KubernetesBind.hbs
@@ -1,0 +1,6 @@
+      # Name is the name of the bind specified in the Habitat configuration files.
+      - name: {{name}}
+        # Service is the name of the service this bind refers to.
+        service: {{service}}
+        # Group is the group of the service this bind refers to.
+        group: {{group}}

--- a/components/pkg-export-kubernetes/defaults/KubernetesManifest.hbs
+++ b/components/pkg-export-kubernetes/defaults/KubernetesManifest.hbs
@@ -40,3 +40,6 @@ spec:
     ## encrypts the communication between Habitat supervisors.
     ringSecretName: {{ring_secret_name}}
 {{/if}}
+{{#if bind}}
+    bind:
+{{/if}}

--- a/components/pkg-export-kubernetes/src/main.rs
+++ b/components/pkg-export-kubernetes/src/main.rs
@@ -109,15 +109,15 @@ fn start(_ui: &mut UI) -> result::Result<(), String> {
 
     match Handlebars::new().template_render(MANIFESTFILE, &json) {
         Ok(r) => {
-            let out = r.lines().filter(|l| {
-                *l != ""
-            }).collect::<Vec<_>>().join("\n") + "\n";
+            let out = r.lines().filter(|l| *l != "").collect::<Vec<_>>().join(
+                "\n",
+            ) + "\n";
 
             match write.write(out.as_bytes()) {
                 Ok(_) => Ok(()),
                 Err(e) => Err(format!("{}", e)),
             }
-        },
+        }
 
         Err(e) => Err(format!("{}", e)),
     }

--- a/components/pkg-export-kubernetes/src/main.rs
+++ b/components/pkg-export-kubernetes/src/main.rs
@@ -12,30 +12,34 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[macro_use]
 extern crate clap;
 extern crate env_logger;
 extern crate habitat_core as hcore;
 extern crate habitat_common as common;
+extern crate habitat_pkg_export_docker as export_docker;
 extern crate handlebars;
 #[macro_use]
 extern crate serde_json;
 #[macro_use]
 extern crate log;
 
-use clap::App;
+use clap::{App, Arg};
 use handlebars::Handlebars;
-use std::fmt;
+use std::env;
 use std::result;
 use std::str::FromStr;
 use std::io::prelude::*;
 use std::io;
 use std::fs::File;
 
+use hcore::channel;
 use hcore::PROGRAM_NAME;
+use hcore::url as hurl;
 use hcore::env as henv;
 use hcore::package::PackageIdent;
 use common::ui::{Coloring, UI, NOCOLORING_ENVVAR, NONINTERACTIVE_ENVVAR};
+
+use export_docker::{Cli, BuildSpec, Error, Naming};
 
 // Synced with the version of the Habitat operator.
 pub const VERSION: &'static str = "0.1.0";
@@ -45,14 +49,14 @@ const MANIFESTFILE: &'static str = include_str!("../defaults/KubernetesManifest.
 
 fn main() {
     env_logger::init().unwrap();
-    let mut ui = ui();
+    let mut ui = get_ui();
     if let Err(e) = start(&mut ui) {
         let _ = ui.fatal(e);
         std::process::exit(1)
     }
 }
 
-fn ui() -> UI {
+fn get_ui() -> UI {
     let isatty = if henv::var(NONINTERACTIVE_ENVVAR)
         .map(|val| val == "true")
         .unwrap_or(false)
@@ -76,7 +80,25 @@ fn start(ui: &mut UI) -> result::Result<(), Error> {
     let m = cli().get_matches();
     debug!("clap cli args: {:?}", m);
 
+    if !m.is_present("NO_DOCKER_IMAGE") {
+        gen_docker_img(ui, &m)?;
+    }
     gen_k8s_manifest(ui, &m)
+}
+
+fn gen_docker_img(ui: &mut UI, matches: &clap::ArgMatches) -> result::Result<(), Error> {
+    let default_channel = channel::default();
+    let default_url = hurl::default_bldr_url();
+    let spec = BuildSpec::new_from_cli_matches(&matches, &default_channel, &default_url);
+    let naming = Naming::new_from_cli_matches(&matches);
+
+    let docker_image = export_docker::export(ui, spec, &naming)?;
+    docker_image.create_report(
+        ui,
+        env::current_dir()?.join("results"),
+    )?;
+
+    Ok(())
 }
 
 fn gen_k8s_manifest(_ui: &mut UI, matches: &clap::ArgMatches) -> result::Result<(), Error> {
@@ -85,10 +107,10 @@ fn gen_k8s_manifest(_ui: &mut UI, matches: &clap::ArgMatches) -> result::Result<
     let group = matches.value_of("GROUP");
     let config_secret_name = matches.value_of("CONFIG_SECRET_NAME");
     let ring_secret_name = matches.value_of("RING_SECRET_NAME");
-    // clap_app!() ensures that we do have the mandatory args so unwrap() is fine here
-    let pkg_ident_str = matches.value_of("PKG_IDENT").unwrap();
+    // clap ensures that we do have the mandatory args so unwrap() is fine here
+    let pkg_ident_str = matches.value_of("PKG_IDENT_OR_ARTIFACT").unwrap();
     let pkg_ident = PackageIdent::from_str(pkg_ident_str)?;
-    let image = matches.value_of("IMAGE").unwrap_or(pkg_ident_str);
+    let image = matches.value_of("IMAGE_NAME").unwrap_or(pkg_ident_str);
 
     let json = json!({
         "metadata_name": pkg_ident.name,
@@ -117,77 +139,93 @@ fn gen_k8s_manifest(_ui: &mut UI, matches: &clap::ArgMatches) -> result::Result<
 
 fn cli<'a, 'b>() -> App<'a, 'b> {
     let name: &str = &*PROGRAM_NAME;
-    clap_app!((name) =>
-        (about: "Creates a Kubernetes manifest for a Habitat package. Habitat \
-                 operator must be deployed within the Kubernetes cluster to \
-                 intercept the created objects.")
-        (version: VERSION)
-        (author: "\nAuthors: The Habitat Maintainers <humans@habitat.sh>\n\n")
-        (@arg IMAGE: --("image") +takes_value
-            "Image of the Habitat service exported as a Docker image")
-        (@arg OUTPUT: -o --("output") +takes_value
-            "Name of manifest file to create. Pass '-' for stdout (default: -)")
-        (@arg COUNT: --("count") +takes_value {valid_natural_number}
-            "Count is the number of desired instances")
-        (@arg TOPOLOGY: -t --("service-topology") +takes_value
-            "A topology describes the intended relationship between peers \
-             within a service group. Specify either standalone or leader \
-             topology (default: standalone)")
-        (@arg GROUP: -g --("service-group") +takes_value
-            "group is a logical grouping of services with the same package and \
-             topology type connected together in a ring (default: default)")
-        (@arg CONFIG_SECRET_NAME: -n --("config-secret-name") +takes_value
-            "name of the Kubernetes Secret containing the config file - \
-             user.toml - that the user has previously created. Habitat will \
-             use it for initial configuration of the service")
-        (@arg RING_SECRET_NAME: -r --("ring-secret-name") +takes_value
-             "name of the Kubernetes Secret that contains the ring key, which \
-              encrypts the communication between Habitat supervisors")
-        (@arg PKG_IDENT: +required
-            "Habitat package identifier (ex: acme/redis)")
-    )
+    let about = "Creates a docker image and Kubernetes manifest for a Habitat package. Habitat \
+                 operator must be deployed within the Kubernetes cluster to intercept the created \
+                 objects.";
+
+    let app = Cli::new(name, about)
+        .add_base_packages_args()
+        .add_builder_args()
+        .add_tagging_args()
+        .app;
+
+    app.arg(
+        Arg::with_name("OUTPUT")
+            .value_name("OUTPUT")
+            .long("output")
+            .short("o")
+            .help(
+                "Name of manifest file to create. Pass '-' for stdout (default: -)",
+            ),
+    ).arg(
+            Arg::with_name("COUNT")
+                .value_name("COUNT")
+                .long("count")
+                .validator(valid_natural_number)
+                .help("Count is the number of desired instances"),
+        )
+        .arg(
+            Arg::with_name("TOPOLOGY")
+                .value_name("TOPOLOGY")
+                .long("topology")
+                .short("t")
+                .possible_values(&["standalone", "leader"])
+                .help(
+                    "A topology describes the intended relationship between peers \
+                    within a service group. Specify either standalone or leader \
+                    topology (default: standalone)",
+                ),
+        )
+        .arg(
+            Arg::with_name("GROUP")
+                .value_name("GROUP")
+                .long("service-group")
+                .short("g")
+                .help(
+                    "group is a logical grouping of services with the same package and \
+                    topology type connected together in a ring (default: default)",
+                ),
+        )
+        .arg(
+            Arg::with_name("CONFIG_SECRET_NAME")
+                .value_name("CONFIG_SECRET_NAME")
+                .long("config-secret-name")
+                .short("n")
+                .help(
+                    "name of the Kubernetes Secret containing the config file - \
+                    user.toml - that the user has previously created. Habitat will \
+                    use it for initial configuration of the service",
+                ),
+        )
+        .arg(
+            Arg::with_name("RING_SECRET_NAME")
+                .value_name("RING_SECRET_NAME")
+                .long("ring-secret-name")
+                .short("r")
+                .help(
+                    "name of the Kubernetes Secret that contains the ring key, which \
+                    encrypts the communication between Habitat supervisors",
+                ),
+        )
+        .arg(
+            Arg::with_name("NO_DOCKER_IMAGE")
+                .long("no-docker-image")
+                .short("d")
+                .help(
+                    "Disable creation of docker image and only create Kubernetes manifest",
+                ),
+        )
+        .arg(
+            Arg::with_name("PKG_IDENT_OR_ARTIFACT")
+                .value_name("PKG_IDENT_OR_ARTIFACT")
+                .required(true)
+                .help("Habitat package identifier (ex: acme/redis)"),
+        )
 }
 
 fn valid_natural_number(val: String) -> result::Result<(), String> {
     match val.parse::<u32>() {
         Ok(_) => Ok(()),
         Err(_) => Err(format!("{} is not a natural number", val)),
-    }
-}
-
-// TODO: We should remove this Error & all impl below after we start using docker crate
-#[derive(Debug)]
-pub enum Error {
-    HabitatCore(hcore::Error),
-    TemplateRenderError(handlebars::TemplateRenderError),
-    IO(io::Error),
-}
-
-impl From<hcore::Error> for Error {
-    fn from(err: hcore::Error) -> Self {
-        Error::HabitatCore(err)
-    }
-}
-
-impl From<handlebars::TemplateRenderError> for Error {
-    fn from(err: handlebars::TemplateRenderError) -> Self {
-        Error::TemplateRenderError(err)
-    }
-}
-
-impl From<io::Error> for Error {
-    fn from(err: io::Error) -> Self {
-        Error::IO(err)
-    }
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let msg = match *self {
-            Error::HabitatCore(ref err) => format!("{}", err),
-            Error::TemplateRenderError(ref err) => format!("{}", err),
-            Error::IO(ref err) => format!("{}", err),
-        };
-        write!(f, "{}", msg)
     }
 }


### PR DESCRIPTION
This is on top of my existing PR for docker image export:

https://github.com/habitat-sh/habitat/pull/4041

I think this: https://github.com/habitat-sh/habitat/commit/0ecc51aa5f57379fa5baf0fd99a24bc979931811 should provide a very good demo/justification for https://github.com/habitat-sh/habitat/issues/4052 .