### PR TITLE
Fix log following

### DIFF
--- a/components/builder-web/app/package/build-detail/build-detail.component.spec.ts
+++ b/components/builder-web/app/package/build-detail/build-detail.component.spec.ts
@@ -171,14 +171,13 @@ describe('BuildDetailComponent', () => {
 
             spyOn(window, 'scrollTo');
             spyOn(document, 'querySelector').and.returnValues(
-              { getBoundingClientRect: () => { return { height: 100 }; } }, // contentHeight
-              { getBoundingClientRect: () => { return { height: 50 }; } },  // footerHeight
-              { getBoundingClientRect: () => { return { height: 10 }; } }   // navHeight
+              { getBoundingClientRect: () => { return { height: 54 }; } }, // bannerHeight
+              { getBoundingClientRect: () => { return { height: 1200 }; } },  // appHeight
             );
 
             element.query(By.css('button.jump-to-end')).triggerEventHandler('click', {});
 
-            expect(window.scrollTo).toHaveBeenCalledWith(0, 30);
+            expect(window.scrollTo).toHaveBeenCalledWith(0, 954);
             expect(component.followLog).toBe(true);
           });
         });

--- a/components/builder-web/app/package/build-detail/build-detail.component.ts
+++ b/components/builder-web/app/package/build-detail/build-detail.component.ts
@@ -181,14 +181,19 @@ export class BuildDetailComponent implements OnChanges, OnDestroy {
   }
 
   private scrollToEnd() {
-    let contentHeight = heightOf('.hab-container');
-    let footerHeight = heightOf('.hab-footer');
-    let navHeight = heightOf('#main-nav');
+    let appHeight = heightOf('.app');
+    let bannerHeight = heightOf('.banner-component');
 
-    window.scrollTo(0, contentHeight - footerHeight - navHeight * 2);
+    window.scrollTo(0, appHeight + bannerHeight - window.innerHeight);
 
     function heightOf(selector) {
-      return document.querySelector(selector).getBoundingClientRect().height;
+      let el = document.querySelector(selector);
+
+      if (el) {
+        return el.getBoundingClientRect().height;
+      }
+
+      return 0;
     }
   }
 }


### PR DESCRIPTION
The CSS refactor changed some class names needed by the build-detail component to make the Follow Log button work properly. This lines things back up again.

Signed-off-by: Christian Nunciato <chris@nunciato.org>

![tenor-42382953](https://user-images.githubusercontent.com/274700/33296138-a5a3be84-d38e-11e7-80f2-36f84ecd258c.gif)
