### PR TITLE
Get builds working again

### DIFF
--- a/components/builder-worker/src/runner/studio.rs
+++ b/components/builder-worker/src/runner/studio.rs
@@ -113,7 +113,6 @@ impl<'a> Studio<'a> {
         // TED TODO: This will not work on windows. A more robust threading solution will be required for log_pipe
         // to support consuming stderr and stdout.
         // This manifests when a child starts (studio) and has an error (often unseen) then suddenly stops all execution.
-        cmd.stderr(Stdio::null()); // Log stderr to stdout
         cmd.arg("-k"); // Origin key
         cmd.arg(self.workspace.job.origin());
         cmd.arg("build");


### PR DESCRIPTION
Remove setting stderr explicitly to Stdio::null on studio build - it is suppressing some of the error logging, and may be causing failed builds in acceptance/prod.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-18514851](https://user-images.githubusercontent.com/13542112/33297464-fa401238-d395-11e7-9746-82a679429fcc.gif)
