### PR TITLE
Update ssh config creation script

### DIFF
--- a/tools/ssh_helpers/update-habitat-ssh
+++ b/tools/ssh_helpers/update-habitat-ssh
@@ -26,6 +26,7 @@ do
     name=${l#*;}
     echo "Host ${name}" >> ~/.ssh/config
     echo "  HostName ${dns}" >> ~/.ssh/config
+    echo "  StrictHostKeyChecking no" >> ~/.ssh/config
     echo "  User ubuntu" >> ~/.ssh/config
     echo "  IdentitiesOnly yes" >> ~/.ssh/config
     echo "  IdentityFile ~/.ssh/habitat-srv-admin" >> ~/.ssh/config


### PR DESCRIPTION
Update Ssh helper to add config to not validate the SSH fingerprint when encountering new hosts - this avoids having to log in manually at least once to each host before running something like a parallel ssh command.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-200898683](https://user-images.githubusercontent.com/13542112/33347866-2bdc489e-d449-11e7-817d-ad868d003c85.gif)
