### PR TITLE
Allow for running containers as a non-root user

### DIFF
--- a/components/pkg-export-docker/defaults/Dockerfile.hbs
+++ b/components/pkg-export-docker/defaults/Dockerfile.hbs
@@ -1,7 +1,32 @@
 FROM scratch
 ENV PATH {{path}}
 ADD {{rootfs}} /
-VOLUME {{volumes}}
+
+# if primary_user_id != 0, chown!
+#
+# We can do this because a primary_user_id of 0 (i.e., root) is
+# "falsy".  There's no reason to do this if the primary user is root,
+# because root already owns all of /hab (because that's how ADD always
+# works)
+#
+# (Also, sorry for `-R` instead of `--recursive`; Busybox doesn't
+# recognize the latter :'(
+{{#if primary_user_id }}
+RUN chown -R {{primary_user_id}}:{{primary_user_id}} /hab
+
+# This environment variable disables certain checks around installing
+# packages (important for upgrade scenarios!). It is a short-term fix;
+# long-term, we should just check to see if the user can write to the
+# various directories under /hab that it needs.
+ENV HAB_NON_ROOT=1
+{{/if}}
+
+USER {{primary_user_id}}:{{primary_group_id}}
+
+{{#each volumes}}
+RUN mkdir -p {{this}}
+VOLUME {{this}}
+{{/each}}
 EXPOSE 9631 {{exposes}}
 ENTRYPOINT ["/init.sh"]
 CMD ["start", "{{primary_svc_ident}}"]

--- a/components/pkg-export-docker/defaults/Dockerfile_win.hbs
+++ b/components/pkg-export-docker/defaults/Dockerfile_win.hbs
@@ -1,5 +1,7 @@
 FROM microsoft/windowsservercore
 ADD {{rootfs}} /
-VOLUME {{volumes}}
+{{#each volumes}}
+VOLUME {{this}}
+{{/each}}
 EXPOSE 9631 {{exposes}}
 ENTRYPOINT ["{{hab_path}}", "sup", "start", "{{primary_svc_ident}}"]

--- a/components/pkg-export-docker/src/cli.rs
+++ b/components/pkg-export-docker/src/cli.rs
@@ -144,6 +144,24 @@ impl<'a, 'b> Cli<'a, 'b> {
         Cli { app: app }
     }
 
+    pub fn add_image_customization_args(self) -> Self {
+        let app = self.app
+            .arg(
+                Arg::with_name("USER_ID")
+                    .long("user-id")
+                    .short("i")
+                    .value_name("USER_ID")
+                    .validator(valid_user_id)
+                    .help("Specify the numeric ID of the service user and group (default: 42)")
+            )
+            .arg(
+                Arg::with_name("NON_ROOT")
+                    .long("non-root")
+                    .help("Run the container as a non-root user (default: false)")
+            );
+        Cli { app: app }
+    }
+
     pub fn add_tagging_args(self) -> Self {
         let app = self.app
             .arg(
@@ -262,5 +280,16 @@ fn valid_url(val: String) -> result::Result<(), String> {
     match Url::parse(&val) {
         Ok(_) => Ok(()),
         Err(_) => Err(format!("URL: '{}' is not valid", &val)),
+    }
+}
+
+fn valid_user_id(val: String) -> result::Result<(), String> {
+    match val.parse::<u32>() {
+        Ok(_) => {
+            // TODO (CM): need to filter out problematic
+            // values (e.g., 0, existing user/group IDs)
+            Ok(())
+        }
+        Err(_) => Err(format!("User ID: '{}' is not valid", &val)),
     }
 }

--- a/components/pkg-export-docker/src/docker.rs
+++ b/components/pkg-export-docker/src/docker.rs
@@ -390,7 +390,7 @@ impl DockerBuildRoot {
 
     fn add_users_and_groups(&self, ui: &mut UI) -> Result<()> {
         let ctx = self.0.ctx();
-        let (users, groups) = ctx.svc_users_and_groups();
+        let (users, groups) = ctx.svc_users_and_groups()?;
         {
             let file = "etc/passwd";
             let mut f = OpenOptions::new().append(true).open(
@@ -451,13 +451,13 @@ impl DockerBuildRoot {
                 .to_string_lossy()
                 .as_ref(),
             "path": ctx.env_path(),
-            "hab_path": util::pkg_path_for(
-                &PackageIdent::from_str("core/hab")?,
-                ctx.rootfs()
-                        )?.join("bin/hab").to_string_lossy().replace("\\", "/"),
-            "volumes": ctx.svc_volumes().join(" "),
+            "hab_path": util::pkg_path_for(&PackageIdent::from_str("core/hab")?, ctx.rootfs())?.join("bin/hab").to_string_lossy().replace("\\", "/"),
+            "volumes": ctx.svc_volumes(),
             "exposes": ctx.svc_exposes().join(" "),
             "primary_svc_ident": ctx.primary_svc_ident().to_string(),
+            "primary_user_id": ctx.primary_user_id(),
+            // Yup, the group is the same as the user for now.
+            "primary_group_id": ctx.primary_user_id(),
         });
         util::write_file(
             self.0.workdir().join("Dockerfile"),

--- a/components/pkg-export-docker/src/main.rs
+++ b/components/pkg-export-docker/src/main.rs
@@ -81,6 +81,7 @@ fn cli<'a, 'b>() -> App<'a, 'b> {
     let app = Cli::new(name, about)
         .add_base_packages_args()
         .add_builder_args()
+        .add_image_customization_args()
         .add_tagging_args()
         .add_publishing_args()
         .app;


### PR DESCRIPTION
In some situations, it can be useful to generate a customized Docker
container with control over the user ID of a service's main user, as
well as whether or not the Supervisor itself should run as root, or as
the service user.

This is motivated by a need to run in certain OpenShift environments.
Note, however, that this does not (yet?) make it possible to run in
_any_ OpenShift environment. In particular, this allows running in
environments where the user ID of the container user is defined (and
not random, as is the default for OpenShift Online, for
instance). Further work is needed to unlock *that* use case.

This commit introduces a number of changes in container generation to
make this possible:

1.) By specifying a value for the `--user-id` option, you can control
the ID for the service user. Previously, this was a hardcoded value of
`42`, which remains the default.

2.) By specifying the flag `--non-root`, the Supervisor will be run as
the service user. This may be used with or without `--user-id`, as
necessary.

3.) In order to support non-root user cases, the `/hab` directory tree
is no longer unconditionally owned by `root`. Instead, if `--non-root`
is specified, the service user owns the directory. The
`/hab/svc/SERVICE/{data,config}` volumes are also owned by this user,
as appropriate.

Be aware that because of this change of permissions, non-root
containers will be larger, due to the additional layer the `chown`
command creates.

4.) To support running as the service user, we no longer
unconditionally create a `hab` user and group. Instead, we consult the
service's `SVC_USER` and `SVC_GROUP` metadata. This allows services to
be run as their appropriate owner.

As an example, if you would like to generate a `core/redis` container
image with the Supervisor running as a non-root service user with a
UID of `12345`, you would run:

    hab pkg export docker core/redis --user-id=12345 --non-root

Fixes #4137

Signed-off-by: Christopher Maier <cmaier@chef.io>