### PR TITLE
Implement docker exporter for windows containers

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,11 +37,11 @@ environment:
 
   matrix:
     - hab_build_action: "test;build"
-      hab_components: "core;http-client;builder-protocol;builder-depot-client;common;win-users;sup;hab-butterfly"
+      hab_components: "core;http-client;builder-protocol;builder-depot-client;common;win-users;sup;hab-butterfly;pkg-export-docker"
 
     - hab_build_action: "package"
       hab_exe_version: "%24latest"
-      hab_components: "hab;plan-build-ps1;studio;sup;hab-butterfly;bintray-publish"
+      hab_components: "hab;plan-build-ps1;studio;sup;hab-butterfly;pkg-export-docker;bintray-publish"
 
 build_script:
   - ps: Update-AppveyorBuild -Version "$((gc -raw ./VERSION).trim())-$((Get-Date).ToString('yyyyMMddHHmmss'))"

--- a/components/hab/src/command/pkg/export/docker.rs
+++ b/components/hab/src/command/pkg/export/docker.rs
@@ -24,7 +24,7 @@ pub fn start(ui: &mut UI, args: Vec<OsString>) -> Result<()> {
     inner::start(ui, args)
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(not(target_os = "macos"))]
 mod inner {
     use std::ffi::OsString;
     use std::path::PathBuf;
@@ -76,7 +76,7 @@ mod inner {
     }
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(target_os = "macos")]
 mod inner {
     use std::ffi::OsString;
 

--- a/components/pkg-export-docker/defaults/Dockerfile_win.hbs
+++ b/components/pkg-export-docker/defaults/Dockerfile_win.hbs
@@ -1,0 +1,5 @@
+FROM microsoft/windowsservercore
+ADD {{rootfs}} /
+VOLUME {{volumes}}
+EXPOSE 9631 {{exposes}}
+ENTRYPOINT ["{{hab_path}}", "sup", "start", "{{primary_svc_ident}}"]

--- a/components/pkg-export-docker/plan.ps1
+++ b/components/pkg-export-docker/plan.ps1
@@ -1,0 +1,51 @@
+$pkg_name = "hab-pkg-export-docker"
+$pkg_origin = "core"
+$pkg_version = "$(Get-Content $PLAN_CONTEXT/../../VERSION)"
+$pkg_maintainer = "The Habitat Maintainers <humans@habitat.sh>"
+$pkg_license = @("Apache-2.0")
+$pkg_source = "https://s3-us-west-2.amazonaws.com/habitat-win-deps/hab-win-deps.zip"
+$pkg_shasum = "0a99b1e171ff1075cca139cf9f695685f7a04b122f1704f82f2b852561847710"
+$pkg_bin_dirs = @("bin")
+$pkg_deps = @("core/docker")
+$pkg_build_deps = @("core/visual-cpp-redist-2013", "core/rust", "core/cacerts")
+
+function Invoke-Prepare {
+    if($env:HAB_CARGO_TARGET_DIR) {
+        $env:CARGO_TARGET_DIR           = "$env:HAB_CARGO_TARGET_DIR"
+    }
+    else {
+        $env:CARGO_TARGET_DIR           = "$HAB_CACHE_SRC_PATH/$pkg_dirname"
+    }
+
+    $env:SSL_CERT_FILE              = "$(Get-HabPackagePath "cacerts")/ssl/certs/cacert.pem"
+    $env:PLAN_VERSION               = "$pkg_version/$pkg_release"
+    $env:LIB                        += ";$HAB_CACHE_SRC_PATH/$pkg_dirname/lib"
+    $env:INCLUDE                    += ";$HAB_CACHE_SRC_PATH/$pkg_dirname/include"
+    $env:SODIUM_LIB_DIR             = "$HAB_CACHE_SRC_PATH/$pkg_dirname/lib"
+    $env:LIBARCHIVE_INCLUDE_DIR     = "$HAB_CACHE_SRC_PATH/$pkg_dirname/include"
+    $env:LIBARCHIVE_LIB_DIR         = "$HAB_CACHE_SRC_PATH/$pkg_dirname/lib"
+    $env:OPENSSL_LIBS               = 'ssleay32:libeay32'
+    $env:OPENSSL_LIB_DIR            = "$HAB_CACHE_SRC_PATH/$pkg_dirname/lib"
+    $env:OPENSSL_INCLUDE_DIR        = "$HAB_CACHE_SRC_PATH/$pkg_dirname/include"
+}
+
+function Invoke-Unpack {
+  Expand-Archive -Path "$HAB_CACHE_SRC_PATH/hab-win-deps.zip" -DestinationPath "$HAB_CACHE_SRC_PATH/$pkg_dirname"
+}
+
+function Invoke-Build {
+    Push-Location "$PLAN_CONTEXT"
+    try {
+        cargo build --release
+        if($LASTEXITCODE -ne 0) {
+            Write-Error "Cargo build failed!"
+        }
+    }
+    finally { Pop-Location }
+}
+
+function Invoke-Install {
+    Copy-Item "$env:CARGO_TARGET_DIR/release/hab-pkg-export-docker.exe" "$pkg_prefix/bin/hab-pkg-export-docker.exe"
+    Copy-Item "$HAB_CACHE_SRC_PATH/$pkg_dirname/bin/*" "$pkg_prefix/bin"
+    Copy-Item "$(Get-HabPackagePath "visual-cpp-redist-2013")/bin/*" "$pkg_prefix/bin"
+}

--- a/components/pkg-export-docker/src/error.rs
+++ b/components/pkg-export-docker/src/error.rs
@@ -32,6 +32,7 @@ pub enum Error {
     Base64DecodeError(DecodeError),
     BuildFailed(ExitStatus),
     DockerImageIdNotFound(String),
+    DockerNotInWindowsMode(String),
     InvalidToken(FromUtf8Error),
     Hab(hab::error::Error),
     HabitatCommon(common::Error),
@@ -56,6 +57,13 @@ impl fmt::Display for Error {
                 format!(
                     "Could not determine Docker image ID for image: {}",
                     image_tag
+                )
+            }
+            Error::DockerNotInWindowsMode(ref server_os) => {
+                format!(
+                    "Switch to Windows containers to export Docker images on Windows. \
+                    Current Docker Server OS is set to: {}",
+                    server_os
                 )
             }
             Error::Hab(ref err) => format!("{}", err),

--- a/components/pkg-export-docker/src/rootfs.rs
+++ b/components/pkg-export-docker/src/rootfs.rs
@@ -58,6 +58,7 @@ where
     Ok(())
 }
 
+#[cfg(target_os = "linux")]
 #[cfg(test)]
 mod test {
     use std::fs::File;


### PR DESCRIPTION
This will cause `hab pkg export docker <ident>` to build a windows based docker image when run on windows. The `<ident>` will need to be a windows targeted package. Also the docker server running on the Windows machine will need to be in "windows container mode" otherwise we throw an error asking the user to switch to that mode.

Note this PR fixes an edge case supervisor bug that is not an edge case in a container. More on that later.

There are a couple key differences in the image creation for windows:

1. We do not wrap the `entrypoint` in a separate script but instead run `hab` as the entrypoint. We do this because the script is essentially unnecesary and we remove a process layer by doing so.
2. We do not need to add file entries for users, groups and networking because our base windows image defaults should be what we want.

### Supervisor fix

The supervisor will panic if it starts within 30 seconds of system boot. This is because rust's `Instance` struct is based on a counter that starts at 0 from boot time. When the supervisor initializes `last_health_check` to 30 seconds prior to `Now()` that will cause an overflow if `Now()` is less than 30 seconds from boot. To fix this we change `last_health_check` to an `option` and initialize it to `None`.

Besides the supervisor fix, this code should have no effect on Linux exports.