### PR TITLE
plan.sh - Wrap license value in double quotes

### DIFF
--- a/components/hab/static/full_template_plan.sh
+++ b/components/hab/static/full_template_plan.sh
@@ -35,7 +35,7 @@ pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 {{#if pkg_license ~}}
 pkg_license={{ pkg_license }}
 {{else ~}}
-pkg_license=('Apache-2.0')
+pkg_license=("Apache-2.0")
 {{/if}}
 
 # Optional.
@@ -367,7 +367,7 @@ pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 {{#if pkg_license ~}}
 pkg_license={{ pkg_license }}
 {{else ~}}
-pkg_license=('Apache-2.0')
+pkg_license=("Apache-2.0")
 {{/if ~}}
 {{#if scaffolding_ident ~}}
 pkg_scaffolding="{{ scaffolding_ident }}"


### PR DESCRIPTION
Every other string value in the default template uses double-quoted strings.  This updates the `pkg_license` to a value of `("Apache-2.0")` instead of `('Apache-2.0')`
