### PR TITLE
adding all tdeps to be direct deps of hab-backline to fix studio chroot

### DIFF
--- a/components/backline/plan.sh
+++ b/components/backline/plan.sh
@@ -7,14 +7,45 @@ pkg_source=nosuchfile.tar.gz
 pkg_build_deps=()
 
 pkg_deps=(
-  core/hab-plan-build
+  core/acl
+  core/attr
+  core/bash
+  core/binutils
+  core/bzip2
+  core/cacerts
+  core/coreutils
   core/diffutils
+  core/file
+  core/findutils
+  core/gawk
+  core/gcc-libs
+  core/glibc
+  core/gmp
+  core/grep
+  core/gzip
+  core/hab-plan-build
+  core/hab
   core/less
+  core/libbsd
+  core/libcap
+  core/libidn
+  core/linux-headers
   core/make
   core/mg
+  core/mpfr
+  core/ncurses
+  core/openssl
+  core/pcre
+  core/readline
+  core/rq
+  core/sed
+  core/tar
+  core/unzip
   core/util-linux
   core/vim
-  core/ncurses
+  core/wget
+  core/xz
+  core/zlib
 )
 
 do_download() {


### PR DESCRIPTION
This fixes the studio chroot where `hab pkg exec` is failing to run bash. The new environment variable resolution does not include tdeps in `pkg exec` which leaves out bash from the `hab-backline` package used by the studio.

To at least get things running again, this adds all deps as direct deps.

Signed-off-by: mwrock <matt@mattwrock.com>