### PR TITLE
Fix `hab/install.sh -h` to print SSL_CERT_FILE, not $SSL_CERT_FILE

### DIFF
--- a/components/hab/install.sh
+++ b/components/hab/install.sh
@@ -85,7 +85,7 @@ FLAGS:
     -v    Specifies a version (ex: 0.15.0, 0.15.0/20161222215311)
 
 ENVIRONMENT VARIABLES:
-    $SSL_CERT_FILE   allows you to verify against a custom cert such as one
+     SSL_CERT_FILE   allows you to verify against a custom cert such as one
                      generated from a corporate firewall
 
 USAGE


### PR DESCRIPTION
Before:
```➤ sudo bash install.sh -h
install.sh: line 72: SSL_CERT_FILE: unbound variable
```

After:
```➤ sudo bash habitat/components/hab/install.sh -h
install.sh

Authors: The Habitat Maintainers <humans@habitat.sh>

Installs the Habitat 'hab' program.

USAGE:
    install.sh [FLAGS]

FLAGS:
    -c    Specifies a channel [values: stable, unstable] [default: stable]
    -h    Prints help information
    -v    Specifies a version (ex: 0.15.0, 0.15.0/20161222215311)

ENVIRONMENT VARIABLES:
     SSL_CERT_FILE   allows you to verify against a custom cert such as one
                     generated from a corporate firewall
```