### PR TITLE
Ensure permissions are set on the config directory

### DIFF
--- a/components/builder-api-proxy/hooks/run
+++ b/components/builder-api-proxy/hooks/run
@@ -4,6 +4,7 @@ pkg_svc_run="nginx -c {{pkg.svc_config_path}}/nginx.conf"
 
 if [ "\$(whoami)" = "root" ]; then
   chown -R hab:hab {{pkg.svc_var_path}}
+  chown -R hab:hab {{pkg.svc_config_path}}
   exec chpst \
     -U {{pkg.svc_user}}:{{pkg.svc_group}} \
     -u {{pkg.svc_user}}:{{pkg.svc_group}} \


### PR DESCRIPTION
NOTE: This is a temporary bandaid for the micro-outages we've been
having with the API server every time the service restarts. The real
fix lies in how the Supervisor starts services (and more specifically,
which user they are started by). Addressing that should (partially)
unlock new behaviors for the Supervisor (like the ability to more
sanely run as a non-root user).

Fixes: #3521

Signed-off-by: Christopher Maier <cmaier@chef.io>