### PR TITLE
k8s exporter: Append a random suffix to the name of Habitat object

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1367,6 +1367,7 @@ dependencies = [
  "habitat_core 0.0.0",
  "handlebars 0.26.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/components/pkg-export-kubernetes/Cargo.toml
+++ b/components/pkg-export-kubernetes/Cargo.toml
@@ -17,6 +17,7 @@ habitat_core = { path = "../core" }
 habitat_common = { path = "../common" }
 handlebars = { version = "*", default-features = false }
 log = "*"
+rand = "*"
 serde = "1.0.2"
 serde_json = "1.0.0"
 

--- a/components/pkg-export-kubernetes/defaults/KubernetesManifest.hbs
+++ b/components/pkg-export-kubernetes/defaults/KubernetesManifest.hbs
@@ -15,6 +15,8 @@ kind: Habitat
 metadata:
   ## Name of the Habitat service.
   name: {{metadata_name}}
+  labels:
+    habitat-name: {{habitat_name}}
 spec:
   ## Name of the Habitat service package exported as a Docker image.
   image: {{image}}


### PR DESCRIPTION
Due to changes planned in kinvolk/habitat-operator#126,
we need to add a random suffix on the end of name of the
Habitat CRD object.

That's because we want to be able to deploy applications
with the same name with different channels. We even might
want to deploy multiple instances of the same app with the
same channel. At the same time, objects in Kubernetes API
need to have an unique name.

Fixes #4152 

Signed-off-by: Michal Rostecki <michal@kinvolk.io>