### PR TITLE
Revert "Revert "k8s exporter: Add docker image generation""

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -174,6 +174,7 @@ plan_path = "components/pkg-export-kubernetes"
 paths = [
   "components/core/*",
   "components/common/*",
+  "components/pkg-export-docker/*"
 ]
 
 [hab-pkg-mesosize]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,6 +85,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "backtrace"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-demangle 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "backtrace-sys"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "base64"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -252,6 +275,11 @@ dependencies = [
  "serde_derive 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "cc"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cfg-if"
@@ -446,6 +474,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dbghelp-sys"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "digest"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -585,6 +622,24 @@ dependencies = [
 name = "error-chain"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "failure"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "failure_derive"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synstructure 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "fake-simd"
@@ -1342,6 +1397,8 @@ dependencies = [
  "clap 2.25.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy 0.0.172 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hab 0.0.0",
  "habitat_common 0.0.0",
  "habitat_core 0.0.0",
@@ -1363,8 +1420,11 @@ version = "0.0.0"
 dependencies = [
  "clap 2.25.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat_common 0.0.0",
  "habitat_core 0.0.0",
+ "habitat_pkg_export_docker 0.0.0",
  "handlebars 0.26.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2476,6 +2536,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "rustc-serialize"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2790,6 +2855,15 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3219,6 +3293,8 @@ dependencies = [
 "checksum antidote 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "34fde25430d87a9388dadbe6e34d7f72a462c8b43ac8d309b42b0a8505d7e2a5"
 "checksum atty 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d912da0db7fa85514874458ca3651fe2cddace8d0b0505571dbdcd41ab490159"
 "checksum aws-sdk-rust 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "f14b02cfea32eabf6c568c94c7ef485414fd464a35433017ee4a8014b1e57ae2"
+"checksum backtrace 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8709cc7ec06f6f0ae6c2c7e12f6ed41540781f72b488d83734978295ceae182e"
+"checksum backtrace-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "44585761d6161b0f57afc49482ab6bd067e4edef48c12a152c237eb0203f7661"
 "checksum base64 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6c902f607515b17ee069f2757c58a6d4b2afa7411b8995f96c4a3c19247b5fcf"
 "checksum bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e103c8b299b28a9c6990458b7013dc4a8356a9b854c51b9883241f5866fac36e"
 "checksum bitflags 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "32866f4d103c4e438b1db1158aa1b1a80ee078e5d77a59a2f906fd62a577389c"
@@ -3236,6 +3312,7 @@ dependencies = [
 "checksum byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff81738b726f5d099632ceaffe7fb65b90212e8dce59d518729e7e8634032d3d"
 "checksum bytes 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c129aff112dcc562970abb69e2508b40850dd24c274761bb50fb8a0067ba6c27"
 "checksum cargo_metadata 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8b006ecc642d64bb8414734e2d57f14cbfddb11cd3cbd32392c0a4db58fdb8c4"
+"checksum cc 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a9b13a57efd6b30ecd6598ebdb302cca617930b5470647570468a65d12ef9719"
 "checksum cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de1e760d7b6535af4241fca8bd8adf68e2e7edacc6b29f5d399050c5e48cf88c"
 "checksum chrono 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)" = "9213f7cd7c27e95c2b57c49f0e69b1ea65b27138da84a170133fd21b07659c00"
 "checksum chrono 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d9123be86fd2a8f627836c235ecdf331fdd067ecf7ac05aa1a68fbcf2429f056"
@@ -3256,6 +3333,7 @@ dependencies = [
 "checksum crypt32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e34988f7e069e0b2f3bfc064295161e489b2d4e04a2e4248fb94360cdf00b4ec"
 "checksum ctrlc 3.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f26287fa3893461876a4851d1bee53b82f04954f85e2d7cd30ae053d0edefd72"
 "checksum curl-sys 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)" = "23e7e544dc5e1ba42c4a4a678bd47985e84b9c3f4d3404c29700622a029db9c3"
+"checksum dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97590ba53bcb8ac28279161ca943a924d1fd4a8fb3fa63302591647c4fc5b850"
 "checksum digest 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7a68d759d7a66a4f63d5bd2a2b14ad7e8cf93fe8c9be227031cd4e72ab0e9ee8"
 "checksum digest-buffer 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4eb92364e9f6d3da159257250532d448b218406d2acb149f724e8f48e9f5cb9a"
 "checksum dtoa 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0dd841b58510c9618291ffa448da2e4e0f699d984d436122372f446dae62263d"
@@ -3274,6 +3352,8 @@ dependencies = [
 "checksum errno 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b2c858c42ac0b88532f48fca88b0ed947cad4f1f64d904bcd6c9f138f7b95d70"
 "checksum error 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "a6e606f14042bb87cc02ef6a14db6c90ab92ed6f62d87e69377bc759fd7987cc"
 "checksum error-chain 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "318cb3c71ee4cdea69fdc9e15c173b245ed6063e1709029e8fd32525a881120f"
+"checksum failure 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "76aa046667594883228b6c1f55c260425950a5cdc66d3aa09c30472d5ac6e70c"
+"checksum failure_derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7223de85610caf0791730aa6f23360f9826ff570a03aa295f3f58bcf7e050f05"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum fallible-iterator 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "5d48ab1bc11a086628e8cc0cc2c2dc200b884ac05c4b48fb71d6036b6999ff1d"
 "checksum features 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b64b2e49155f3b9a3bd08d9a7432c11ea5910f3a2a4ea23d68ec89eadf2e52e1"
@@ -3403,6 +3483,7 @@ dependencies = [
 "checksum rusoto_credential 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "79be5ba8b6a099306d4862556b98ddc21bf0ca518aef77e091c7abeb50f5cb07"
 "checksum rusoto_ecr 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)" = "63a8089e871c927ea55a8aa08bf0ff26a7b8e86457c226bb42aa41616890f0b8"
 "checksum rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)" = "f76d05d3993fd5f4af9434e8e436db163a12a9d40e1a58a726f27a01dfd12a2a"
+"checksum rustc-demangle 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "aee45432acc62f7b9a108cc054142dac51f979e69e71ddce7d6fc7adf29e817e"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "c5f5376ea5e30ce23c03eb77cbe4962b988deead10910c372b226388b594c084"
 "checksum rustc_version 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b9743a7670d88d5d52950408ecdb7c71d8986251ab604d4689dd2ca25c9bca69"
@@ -3440,6 +3521,7 @@ dependencies = [
 "checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
+"checksum synstructure 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3a761d12e6d8dcb4dcf952a7a89b475e3a9d69e4a69307e01a470977642914bd"
 "checksum tabwriter 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3b7810162bc0a2eb2dc9a9bfd16ddb2d1f6022df3236d1478937bfadcb12385e"
 "checksum tee 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "37c12559dba7383625faaff75be24becf35bfc885044375bcab931111799a3da"
 "checksum tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "87974a6f5c1dfb344d733055601650059a3363de2a6104819293baff662132d6"

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -686,6 +686,7 @@ fn exec_subcommand_if_called(ui: &mut UI) -> Result<()> {
         ("pkg", "export", "cf") => {
             command::pkg::export::cf::start(ui, env::args_os().skip(4).collect())
         }
+        ("pkg", "export", "k8s") |
         ("pkg", "export", "kubernetes") => {
             command::pkg::export::kubernetes::start(ui, env::args_os().skip(4).collect())
         }

--- a/components/pkg-export-docker/Cargo.toml
+++ b/components/pkg-export-docker/Cargo.toml
@@ -32,6 +32,8 @@ serde = { version = "*", features = ["rc"] }
 serde_json = "*"
 tempdir = "*"
 url = "*"
+failure = "0.1"
+failure_derive = "0.1"
 
 [features]
 default = []

--- a/components/pkg-export-docker/src/build.rs
+++ b/components/pkg-export-docker/src/build.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use clap;
 use std::fs as stdfs;
 #[cfg(target_os = "linux")]
 use std::os::unix::fs::symlink;
@@ -34,6 +35,10 @@ use fs;
 use rootfs;
 use super::{VERSION, BUSYBOX_IDENT, CACERTS_IDENT};
 use util;
+
+const DEFAULT_HAB_IDENT: &'static str = "core/hab";
+const DEFAULT_LAUNCHER_IDENT: &'static str = "core/hab-launcher";
+const DEFAULT_SUP_IDENT: &'static str = "core/hab-sup";
 
 /// The specification for creating a temporary file system build root, based on Habitat packages.
 ///
@@ -62,6 +67,26 @@ pub struct BuildSpec<'a> {
 }
 
 impl<'a> BuildSpec<'a> {
+    /// Creates a `BuildSpec` from cli arguments.
+    pub fn new_from_cli_matches(
+        m: &'a clap::ArgMatches,
+        default_channel: &'a str,
+        default_url: &'a str,
+    ) -> Self {
+        BuildSpec {
+            hab: m.value_of("HAB_PKG").unwrap_or(DEFAULT_HAB_IDENT),
+            hab_launcher: m.value_of("HAB_LAUNCHER_PKG").unwrap_or(
+                DEFAULT_LAUNCHER_IDENT,
+            ),
+            hab_sup: m.value_of("HAB_SUP_PKG").unwrap_or(DEFAULT_SUP_IDENT),
+            url: m.value_of("BLDR_URL").unwrap_or(&default_url),
+            channel: m.value_of("CHANNEL").unwrap_or(&default_channel),
+            base_pkgs_url: m.value_of("BASE_PKGS_BLDR_URL").unwrap_or(&default_url),
+            base_pkgs_channel: m.value_of("BASE_PKGS_CHANNEL").unwrap_or(&default_channel),
+            idents_or_archives: m.values_of("PKG_IDENT_OR_ARTIFACT").unwrap().collect(),
+        }
+    }
+
     /// Creates a `BuildRoot` for the given specification.
     ///
     /// # Errors
@@ -500,7 +525,7 @@ impl BuildRootContext {
         if let None = self.svc_idents().first().map(|e| *e) {
             return Err(Error::PrimaryServicePackageNotFound(
                 self.idents.iter().map(|e| e.ident().to_string()).collect(),
-            ));
+            ))?;
         }
 
         Ok(())

--- a/components/pkg-export-docker/src/cli.rs
+++ b/components/pkg-export-docker/src/cli.rs
@@ -1,0 +1,253 @@
+// Copyright (c) 2016-2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![cfg_attr(feature="clippy", feature(plugin))]
+#![cfg_attr(feature="clippy", plugin(clippy))]
+
+use clap::{App, Arg};
+use std::path::Path;
+use std::result;
+use std::str::FromStr;
+
+use hcore::package::PackageIdent;
+use url::Url;
+
+/// The version of this library and program when built.
+pub const VERSION: &'static str = include_str!(concat!(env!("OUT_DIR"), "/VERSION"));
+
+/// A Docker-specific clap:App wrapper
+#[derive(Clone)]
+pub struct Cli<'a, 'b>
+where
+    'a: 'b,
+{
+    pub app: App<'a, 'b>,
+}
+
+impl<'a, 'b> Cli<'a, 'b> {
+    pub fn new(name: &str, about: &'a str) -> Self {
+        Cli {
+            app: clap_app!(
+            (name) =>
+            (about: about)
+            (version: VERSION)
+            (author: "\nAuthors: The Habitat Maintainers <humans@habitat.sh>\n\n")
+            (@arg IMAGE_NAME: --("image-name") -i +takes_value
+                "Image name (default: \"{{pkg_origin}}/{{pkg_name}}\" supports: \
+                 {{pkg_origin}}, {{pkg_name}}, {{pkg_version}}, {{pkg_release}}, {{channel}})")
+            ),
+        }
+    }
+
+    pub fn add_base_packages_args(self) -> Self {
+        let app = self.app
+            .arg(
+                Arg::with_name("HAB_PKG")
+                    .long("hab-pkg")
+                    .value_name("HAB_PKG")
+                    .validator(valid_ident_or_hart)
+                    .help(
+                        "Habitat CLI package identifier (ex: acme/redis) or filepath to a Habitat \
+                        artifact (ex: /home/acme-redis-3.0.7-21120102031201-x86_64-linux.hart) to \
+                        install (default: core/hab)",
+                    ),
+            )
+            .arg(
+                Arg::with_name("HAB_LAUNCHER_PKG")
+                    .long("launcher-pkg")
+                    .value_name("HAB_LAUNCHER_PKG")
+                    .validator(valid_ident_or_hart)
+                    .help(
+                        "Launcher package identifier (ex: core/hab-launcher) or filepath to a \
+                        Habitat artifact (ex: \
+                        /home/core-hab-launcher-6083-20171101045646-x86_64-linux.hart) to install \
+                        (default: core/hab-launcher)",
+                    ),
+            )
+            .arg(
+                Arg::with_name("HAB_SUP_PKG")
+                    .long("sup-pkg")
+                    .value_name("HAB_SUP_PKG")
+                    .validator(valid_ident_or_hart)
+                    .help(
+                        "Supervisor package identifier (ex: core/hab-sup) or filepath to a Habitat \
+                        artifact (ex: \
+                        /home/ore-hab-sup-0.39.1-20171118011657-x86_64-linux.hart) to install \
+                        (default: core/hab-sup)",
+                    ),
+            );
+
+        Cli { app: app }
+    }
+
+    pub fn add_builder_args(self) -> Self {
+        let app = self.app
+            .arg(
+                Arg::with_name("BLDR_URL")
+                    .long("url")
+                    .short("u")
+                    .value_name("BLDR_URL")
+                    .validator(valid_url)
+                    .help(
+                        "Install packages from Builder at the specified URL \
+                        (default: https://bldr.habitat.sh)",
+                    ),
+            )
+            .arg(
+                Arg::with_name("CHANNEL")
+                    .long("channel")
+                    .short("c")
+                    .value_name("CHANNEL")
+                    .help(
+                        "Install packages from the specified release channel (default: stable)",
+                    ),
+            )
+            .arg(
+                Arg::with_name("BASE_PKGS_BLDR_URL")
+                    .long("base-pkgs-url")
+                    .value_name("BASE_PKGS_BLDR_URL")
+                    .validator(valid_url)
+                    .help(
+                        "Install base packages from Builder at the specified URL \
+                        (default: https://bldr.habitat.sh)",
+                    ),
+            )
+            .arg(
+                Arg::with_name("BASE_PKGS_CHANNEL")
+                    .long("base-pkgs-channel")
+                    .value_name("BASE_PKGS_CHANNEL")
+                    .help(
+                        "Install base packages from the specified release channel \
+                        (default: stable)",
+                    ),
+            );
+
+        Cli { app: app }
+    }
+
+    pub fn add_tagging_args(self) -> Self {
+        let app = self.app
+            .arg(
+                Arg::with_name("TAG_VERSION_RELEASE")
+                    .long("tag-version-release")
+                    .conflicts_with("NO_TAG_VERSION_RELEASE")
+                    .help(
+                        "Tag image with :\"{{pkg_version}}-{{pkg_release}}\" (default: yes)",
+                    ),
+            )
+            .arg(
+                Arg::with_name("NO_TAG_VERSION_RELEASE")
+                    .long("no-tag-version-release")
+                    .conflicts_with("TAG_VERSION_RELEASE")
+                    .help(
+                        "Do not tag image with :\"{{pkg_version}}-{{pkg_release}}\" (default: no)",
+                    ),
+            )
+            .arg(
+                Arg::with_name("TAG_VERSION")
+                    .long("tag-version")
+                    .conflicts_with("NO_TAG_VERSION")
+                    .help("Tag image with :\"{{pkg_version}}\" (default: yes)"),
+            )
+            .arg(
+                Arg::with_name("NO_TAG_VERSION")
+                    .long("no-tag-version")
+                    .conflicts_with("TAG_VERSION")
+                    .help("Do not tag image with :\"{{pkg_version}}\" (default: no)"),
+            )
+            .arg(
+                Arg::with_name("TAG_LATEST")
+                    .long("tag-latest")
+                    .conflicts_with("NO_TAG_LATEST")
+                    .help("Tag image with :\"latest\" (default: yes)"),
+            )
+            .arg(
+                Arg::with_name("NO_TAG_LATEST")
+                    .long("no-tag-latest")
+                    .conflicts_with("TAG_LATEST")
+                    .help("Do not tag image with :\"latest\" (default: no)"),
+            )
+            .arg(
+                Arg::with_name("TAG_CUSTOM")
+                    .long("tag-custom")
+                    .value_name("TAG_CUSTOM")
+                    .help(
+                        "Tag image with additional custom tag (supports: {{pkg_origin}}, \
+                        {{pkg_name}}, {{pkg_version}}, {{pkg_release}}, {{channel}})",
+                    ),
+            );
+
+        Cli { app: app }
+    }
+
+    pub fn add_publishing_args(self) -> Self {
+        let app = self.app.arg(Arg::with_name("PUSH_IMAGE")
+                 .long("push-image")
+                 .conflicts_with("NO_PUSH_IMAGE")
+                 .requires_all(&["REGISTRY_USERNAME", "REGISTRY_PASSWORD"])
+                 .help("Push image to remote registry (default: no)"))
+            .arg(Arg::with_name("NO_PUSH_IMAGE")
+                 .long("no-push-image")
+                 .conflicts_with("PUSH_IMAGE")
+                 .help("Do not push image to remote registry (default: yes)"))
+            .arg(Arg::with_name("REGISTRY_USERNAME")
+                 .long("username")
+                 .short("U")
+                 .value_name("REGISTRY_USERNAME")
+                 .requires("REGISTRY_PASSWORD")
+                 .help("Remote registry username, required for pushing image to remote registry"))
+            .arg(Arg::with_name("REGISTRY_PASSWORD")
+                 .long("password")
+                 .short("P")
+                 .value_name("REGISTRY_PASSWORD")
+                 .requires("REGISTRY_USERNAME")
+                 .help("Remote registry password, required for pushing image to remote registry"))
+            .arg(Arg::with_name("REGISTRY_TYPE")
+                 .long("registry-type")
+                 .short("R")
+                 .value_name("REGISTRY_TYPE")
+                 .help("Remote registry type, Ex: Amazon, Docker, Google (default: docker)"))
+            .arg(Arg::with_name("REGISTRY_URL")
+                 .long("registry-url")
+                 .short("G")
+                 .value_name("REGISTRY_URL")
+                 .help("Remote registry url"))
+            // Cleanup
+            .arg(Arg::with_name("RM_IMAGE")
+                 .long("rm-image")
+                 .help("Remove local image from engine after build and/or push (default: no)"));
+
+        Cli { app: app }
+    }
+}
+
+fn valid_ident_or_hart(val: String) -> result::Result<(), String> {
+    if Path::new(&val).is_file() {
+        Ok(())
+    } else if val.ends_with(".hart") {
+        Err(format!("Habitat artifact file: '{}' not found", &val))
+    } else {
+        match PackageIdent::from_str(&val) {
+            Ok(_) => Ok(()),
+            Err(e) => Err(format!("{}", e)),
+        }
+    }
+}
+
+fn valid_url(val: String) -> result::Result<(), String> {
+    match Url::parse(&val) {
+        Ok(_) => Ok(()),
+        Err(_) => Err(format!("URL: '{}' is not valid", &val)),
+    }
+}

--- a/components/pkg-export-docker/src/error.rs
+++ b/components/pkg-export-docker/src/error.rs
@@ -14,7 +14,6 @@
 
 use base64::DecodeError;
 use std::process::ExitStatus;
-use std::fmt;
 use std::io;
 use std::result;
 use std::string::FromUtf8Error;
@@ -24,107 +23,48 @@ use common;
 use hab;
 use handlebars;
 use hcore;
+use failure;
 
-pub type Result<T> = result::Result<T, Error>;
+pub type Result<T> = result::Result<T, failure::Error>;
 
-#[derive(Debug)]
+#[derive(Debug, Fail)]
 pub enum Error {
+    #[fail(display = "{}", _0)]
     Base64DecodeError(DecodeError),
+    #[fail(display = "Docker build failed with exit code: {}", _0)]
     BuildFailed(ExitStatus),
+    #[fail(display = "Could not determine Docker image ID for image: {}", _0)]
     DockerImageIdNotFound(String),
+    #[fail(display = "Switch to Windows containers to export Docker images on Windows. \
+                     Current Docker Server OS is set to: {}",
+           _0)]
     DockerNotInWindowsMode(String),
+    #[fail(display = "{}", _0)]
     InvalidToken(FromUtf8Error),
+    #[fail(display = "{}", _0)]
     Hab(hab::error::Error),
+    #[fail(display = "{}", _0)]
     HabitatCommon(common::Error),
+    #[fail(display = "{}", _0)]
     HabitatCore(hcore::Error),
+    #[fail(display = "Docker login failed with exit code: {}", _0)]
     LoginFailed(ExitStatus),
+    #[fail(display = "Docker logout failed with exit code: {}", _0)]
     LogoutFailed(ExitStatus),
+    #[fail(display = "No ECR Tokens returned")]
     NoECRTokensReturned,
+    #[fail(display = "{}", _0)]
     TokenFetchFailed(GetAuthorizationTokenError),
+    #[fail(display = "A primary service package could not be determined from: {:?}. \
+                     At least one package with a run hook must be provided.",
+           _0)]
     PrimaryServicePackageNotFound(Vec<String>),
+    #[fail(display = "Docker image push failed with exit code: {}", _0)]
     PushImageFailed(ExitStatus),
+    #[fail(display = "Removing Docker local images failed with exit code: {}", _0)]
     RemoveImageFailed(ExitStatus),
+    #[fail(display = "{}", _0)]
     TemplateRenderError(handlebars::TemplateRenderError),
+    #[fail(display = "{}", _0)]
     IO(io::Error),
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let msg = match *self {
-            Error::Base64DecodeError(ref err) => format!("{}", err),
-            Error::BuildFailed(status) => format!("Docker build failed with exit code: {}", status),
-            Error::DockerImageIdNotFound(ref image_tag) => {
-                format!(
-                    "Could not determine Docker image ID for image: {}",
-                    image_tag
-                )
-            }
-            Error::DockerNotInWindowsMode(ref server_os) => {
-                format!(
-                    "Switch to Windows containers to export Docker images on Windows. \
-                    Current Docker Server OS is set to: {}",
-                    server_os
-                )
-            }
-            Error::Hab(ref err) => format!("{}", err),
-            Error::HabitatCommon(ref err) => format!("{}", err),
-            Error::HabitatCore(ref err) => format!("{}", err),
-            Error::LoginFailed(status) => format!("Docker login failed with exit code: {}", status),
-            Error::TokenFetchFailed(ref err) => format!("{}", err),
-            Error::NoECRTokensReturned => format!("No ECR Tokens returned"),
-            Error::InvalidToken(ref err) => format!("{}", err),
-            Error::LogoutFailed(status) => {
-                format!("Docker logout failed with exit code: {}", status)
-            }
-            Error::PrimaryServicePackageNotFound(ref idents) => {
-                format!(
-                    "A primary service package could not be determined from: {}. \
-                    At least one package with a run hook must be provided.",
-                    idents.join(", ")
-                )
-            }
-            Error::PushImageFailed(status) => {
-                format!("Docker image push failed with exit code: {}", status)
-            }
-            Error::RemoveImageFailed(status) => {
-                format!(
-                    "Removing Docker local images failed with exit code: {}",
-                    status
-                )
-            }
-            Error::TemplateRenderError(ref err) => format!("{}", err),
-            Error::IO(ref err) => format!("{}", err),
-        };
-        write!(f, "{}", msg)
-    }
-}
-
-impl From<common::Error> for Error {
-    fn from(err: common::Error) -> Self {
-        Error::HabitatCommon(err)
-    }
-}
-
-impl From<hab::error::Error> for Error {
-    fn from(err: hab::error::Error) -> Self {
-        Error::Hab(err)
-    }
-}
-
-impl From<handlebars::TemplateRenderError> for Error {
-    fn from(err: handlebars::TemplateRenderError) -> Self {
-        Error::TemplateRenderError(err)
-    }
-}
-
-impl From<hcore::Error> for Error {
-    fn from(err: hcore::Error) -> Self {
-        Error::HabitatCore(err)
-    }
-}
-
-impl From<io::Error> for Error {
-    fn from(err: io::Error) -> Self {
-        Error::IO(err)
-    }
 }

--- a/components/pkg-export-docker/src/lib.rs
+++ b/components/pkg-export-docker/src/lib.rs
@@ -15,11 +15,15 @@
 #![cfg_attr(feature="clippy", feature(plugin))]
 #![cfg_attr(feature="clippy", plugin(clippy))]
 
+#[macro_use]
+extern crate clap;
 extern crate hab;
 extern crate habitat_core as hcore;
 extern crate habitat_common as common;
 extern crate handlebars;
+extern crate rusoto_core;
 extern crate rusoto_ecr;
+extern crate rusoto_credential as aws_creds;
 #[macro_use]
 extern crate lazy_static;
 #[macro_use]
@@ -28,8 +32,14 @@ extern crate log;
 extern crate serde_json;
 extern crate tempdir;
 extern crate base64;
+extern crate url;
+
+extern crate failure;
+#[macro_use]
+extern crate failure_derive;
 
 mod build;
+pub mod cli;
 mod docker;
 mod error;
 mod fs;
@@ -37,7 +47,12 @@ pub mod rootfs;
 mod util;
 
 use common::ui::UI;
+use aws_creds::StaticProvider;
+use rusoto_core::Region;
+use rusoto_core::request::*;
+use rusoto_ecr::{Ecr, EcrClient, GetAuthorizationTokenRequest};
 
+pub use cli::Cli;
 pub use build::BuildSpec;
 pub use docker::{DockerImage, DockerBuildRoot};
 pub use error::{Error, Result};
@@ -74,13 +89,77 @@ pub struct Naming<'a> {
     pub registry_type: &'a str,
 }
 
+impl<'a> Naming<'a> {
+    /// Creates a `Naming` from cli arguments.
+    pub fn new_from_cli_matches(m: &'a clap::ArgMatches) -> Self {
+        let registry_type = m.value_of("REGISTRY_TYPE").unwrap_or("docker");
+        let registry_url = m.value_of("REGISTRY_URL");
+
+        Naming {
+            custom_image_name: m.value_of("IMAGE_NAME"),
+            latest_tag: !m.is_present("NO_TAG_LATEST"),
+            version_tag: !m.is_present("NO_TAG_VERSION"),
+            version_release_tag: !m.is_present("NO_TAG_VERSION_RELEASE"),
+            custom_tag: m.value_of("TAG_CUSTOM"),
+            registry_url: registry_url,
+            registry_type: registry_type,
+        }
+    }
+}
+
 /// A credentials username and password pair.
 ///
 /// This is a value struct which references username and password values.
 #[derive(Debug)]
-pub struct Credentials<'a> {
-    pub username: &'a str,
-    pub password: &'a str,
+pub struct Credentials {
+    pub username: String,
+    pub password: String,
+}
+
+impl Credentials {
+    pub fn new(registry_type: &str, username: &str, password: &str) -> Result<Self> {
+        match registry_type {
+            "amazon" => {
+                // The username and password should be valid IAM credentials
+                let provider =
+                    StaticProvider::new_minimal(username.to_string(), password.to_string());
+                // TODO TED: Make the region configurable
+                let client = EcrClient::new(default_tls_client()?, provider, Region::UsWest2);
+                let auth_token_req = GetAuthorizationTokenRequest { registry_ids: None };
+                let token = client
+                    .get_authorization_token(&auth_token_req)
+                    .map_err(|e| Error::TokenFetchFailed(e))
+                    .and_then(|resp| {
+                        resp.authorization_data
+                            .ok_or(Error::NoECRTokensReturned)
+                            .and_then(|auth_data| {
+                                auth_data[0].clone().authorization_token.ok_or(
+                                    Error::NoECRTokensReturned,
+                                )
+                            })
+                    })?;
+
+                let creds: Vec<String> = base64::decode(&token)
+                    .map_err(|e| Error::Base64DecodeError(e))
+                    .and_then(|decoded_token| {
+                        String::from_utf8(decoded_token)
+                            .map_err(|e| Error::InvalidToken(e))
+                            .and_then(|dts| Ok(dts.split(':').map(String::from).collect()))
+                    })?;
+
+                Ok(Credentials {
+                    username: creds[0].to_string(),
+                    password: creds[1].to_string(),
+                })
+            }
+            _ => {
+                Ok(Credentials {
+                    username: username.to_string(),
+                    password: password.to_string(),
+                })
+            }
+        }
+    }
 }
 
 /// Exports a Docker image to a Docker engine from a build specification and naming policy.

--- a/components/pkg-export-docker/src/main.rs
+++ b/components/pkg-export-docker/src/main.rs
@@ -16,43 +16,25 @@
 #![cfg_attr(feature="clippy", plugin(clippy))]
 
 extern crate base64;
-#[macro_use]
 extern crate clap;
 extern crate env_logger;
 extern crate habitat_core as hcore;
 extern crate habitat_common as common;
 extern crate habitat_pkg_export_docker as export_docker;
-extern crate rusoto_core;
-extern crate rusoto_credential as aws_creds;
-extern crate rusoto_ecr;
 extern crate chrono;
 #[macro_use]
 extern crate log;
-extern crate url;
 
 use std::env;
-use std::path::Path;
-use std::result;
-use std::str::FromStr;
 
-use clap::App;
-use common::ui::{Coloring, UI, NOCOLORING_ENVVAR, NONINTERACTIVE_ENVVAR};
+use clap::{App, Arg};
 use hcore::channel;
+use common::ui::{Coloring, UI, NOCOLORING_ENVVAR, NONINTERACTIVE_ENVVAR};
 use hcore::env as henv;
 use hcore::PROGRAM_NAME;
-use hcore::package::PackageIdent;
 use hcore::url as hurl;
-use url::Url;
 
-use aws_creds::StaticProvider;
-use rusoto_core::Region;
-use rusoto_core::request::*;
-use rusoto_ecr::{Ecr, EcrClient, GetAuthorizationTokenRequest};
-use export_docker::{BuildSpec, Credentials, Error, Result, Naming};
-
-const DEFAULT_HAB_IDENT: &'static str = "core/hab";
-const DEFAULT_LAUNCHER_IDENT: &'static str = "core/hab-launcher";
-const DEFAULT_SUP_IDENT: &'static str = "core/hab-sup";
+use export_docker::{Cli, BuildSpec, Credentials, Result, Naming};
 
 fn main() {
     env_logger::init().unwrap();
@@ -64,34 +46,13 @@ fn main() {
 }
 
 fn start(ui: &mut UI) -> Result<()> {
-    let m = cli().get_matches();
+    let cli = cli();
+    let m = cli.get_matches();
     debug!("clap cli args: {:?}", m);
     let default_channel = channel::default();
     let default_url = hurl::default_bldr_url();
-    let registry_type = m.value_of("REGISTRY_TYPE").unwrap_or("docker");
-    let registry_url = m.value_of("REGISTRY_URL");
-
-    let spec = BuildSpec {
-        hab: m.value_of("HAB_PKG").unwrap_or(DEFAULT_HAB_IDENT),
-        hab_launcher: m.value_of("HAB_LAUNCHER_PKG").unwrap_or(
-            DEFAULT_LAUNCHER_IDENT,
-        ),
-        hab_sup: m.value_of("HAB_SUP_PKG").unwrap_or(DEFAULT_SUP_IDENT),
-        url: m.value_of("BLDR_URL").unwrap_or(&default_url),
-        channel: m.value_of("CHANNEL").unwrap_or(&default_channel),
-        base_pkgs_url: m.value_of("BASE_PKGS_BLDR_URL").unwrap_or(&default_url),
-        base_pkgs_channel: m.value_of("BASE_PKGS_CHANNEL").unwrap_or(&default_channel),
-        idents_or_archives: m.values_of("PKG_IDENT_OR_ARTIFACT").unwrap().collect(),
-    };
-    let naming = Naming {
-        custom_image_name: m.value_of("IMAGE_NAME"),
-        latest_tag: !m.is_present("NO_TAG_LATEST"),
-        version_tag: !m.is_present("NO_TAG_VERSION"),
-        version_release_tag: !m.is_present("NO_TAG_VERSION_RELEASE"),
-        custom_tag: m.value_of("TAG_CUSTOM"),
-        registry_url: registry_url,
-        registry_type: registry_type,
-    };
+    let spec = BuildSpec::new_from_cli_matches(&m, &default_channel, &default_url);
+    let naming = Naming::new_from_cli_matches(&m);
 
     let docker_image = export_docker::export(ui, spec, &naming)?;
     docker_image.create_report(
@@ -99,51 +60,12 @@ fn start(ui: &mut UI) -> Result<()> {
         env::current_dir()?.join("results"),
     )?;
     if m.is_present("PUSH_IMAGE") {
-        match registry_type {
-            "amazon" => {
-                // The username and password should be valid IAM credentials
-                let provider = StaticProvider::new_minimal(
-                    m.value_of("REGISTRY_USERNAME").unwrap().to_string(),
-                    m.value_of("REGISTRY_PASSWORD").unwrap().to_string(),
-                );
-                // TODO TED: Make the region configurable
-                let client =
-                    EcrClient::new(default_tls_client().unwrap(), provider, Region::UsWest2);
-                let auth_token_req = GetAuthorizationTokenRequest { registry_ids: None };
-                let token = match client.get_authorization_token(&auth_token_req) {
-                    Ok(resp) => {
-                        match resp.authorization_data {
-                            Some(auth_data) => auth_data[0].clone().authorization_token.unwrap(),
-                            None => return Err(Error::NoECRTokensReturned),
-                        }
-                    }
-                    Err(e) => return Err(Error::TokenFetchFailed(e)),
-                };
-
-                let creds: Vec<String> = match base64::decode(&token) {
-                    Ok(decoded_token) => {
-                        match String::from_utf8(decoded_token) {
-                            Ok(dts) => dts.split(':').map(String::from).collect(),
-                            Err(err) => return Err(Error::InvalidToken(err)),
-                        }
-                    }
-                    Err(err) => return Err(Error::Base64DecodeError(err)),
-                };
-
-                let credentials = Credentials {
-                    username: &creds[0],
-                    password: &creds[1],
-                };
-                docker_image.push(ui, &credentials, registry_url)?;
-            }
-            _ => {
-                let credentials = Credentials {
-                    username: m.value_of("REGISTRY_USERNAME").unwrap(),
-                    password: m.value_of("REGISTRY_PASSWORD").unwrap(),
-                };
-                docker_image.push(ui, &credentials, registry_url)?;
-            }
-        }
+        let credentials = Credentials::new(
+            naming.registry_type,
+            m.value_of("REGISTRY_USERNAME").unwrap(),
+            m.value_of("REGISTRY_PASSWORD").unwrap(),
+        )?;
+        docker_image.push(ui, &credentials, naming.registry_url)?;
     }
     if m.is_present("RM_IMAGE") {
         docker_image.rm(ui)?;
@@ -154,82 +76,24 @@ fn start(ui: &mut UI) -> Result<()> {
 
 fn cli<'a, 'b>() -> App<'a, 'b> {
     let name: &str = &*PROGRAM_NAME;
-    clap_app!((name) =>
-        (about: "Creates (an optionally pushes) a Docker image from a set of Habitat packages")
-        (version: export_docker::VERSION)
-        (author: "\nAuthors: The Habitat Maintainers <humans@habitat.sh>\n\n")
-        (@arg IMAGE_NAME: --("image-name") -n +takes_value
-            "Image name (default: \"{{pkg_origin}}/{{pkg_name}}\" supports: \
-            {{pkg_origin}}, {{pkg_name}}, {{pkg_version}}, {{pkg_release}}, {{channel}})")
-        (@arg PKG_IDENT_OR_ARTIFACT: +required +multiple
-            "One or more Habitat package identifiers (ex: acme/redis) and/or filepaths \
-            to a Habitat Artifact (ex: /home/acme-redis-3.0.7-21120102031201-x86_64-linux.hart)")
+    let about = "Creates (an optionally pushes) a Docker image from a set of Habitat packages";
 
-        // Builder
-        (@arg BLDR_URL: --url -u +takes_value {valid_url}
-            "Install packages from Builder at the specified URL \
-            (default: https://bldr.habitat.sh)")
-        (@arg CHANNEL: --channel -c +takes_value
-            "Install packages from the specified release channel \
-            (default: stable)")
-        (@arg BASE_PKGS_BLDR_URL: --("base-pkgs-url") +takes_value {valid_url}
-            "Install base packages from Builder at the specified URL \
-            (default: https://bldr.habitat.sh)")
-        (@arg BASE_PKGS_CHANNEL: --("base-pkgs-channel") +takes_value
-            "Install base packages from the specified release channel \
-            (default: stable)")
+    let app = Cli::new(name, about)
+        .add_base_packages_args()
+        .add_builder_args()
+        .add_tagging_args()
+        .add_publishing_args()
+        .app;
 
-        // Base packages
-        (@arg HAB_PKG: --("hab-pkg") +takes_value {valid_ident_or_hart}
-            "Habitat CLI package identifier (ex: acme/redis) or filepath to a Habitat artifact \
-            (ex: /home/acme-redis-3.0.7-21120102031201-x86_64-linux.hart) to install \
-            (default: core/hab)")
-        (@arg HAB_LAUNCHER_PKG: --("launcher-pkg") +takes_value {valid_ident_or_hart}
-            "Launcher package identifier (ex: acme/redis) or filepath to a Habitat artifact \
-            (ex: /home/acme-redis-3.0.7-21120102031201-x86_64-linux.hart) to install \
-            (default: core/hab-launcher)")
-        (@arg HAB_SUP_PKG: --("sup-pkg") +takes_value {valid_ident_or_hart}
-            "Supervisor package identifier (ex: acme/redis) or filepath to a Habitat artifact \
-            (ex: /home/acme-redis-3.0.7-21120102031201-x86_64-linux.hart) to install \
-            (default: core/hab-sup)")
-
-        // Tagging
-        (@arg TAG_VERSION_RELEASE: --("tag-version-release")
-            conflicts_with[NO_TAG_VERSION_RELEASE]
-            "Tag image with :\"{{pkg_version}}-{{pkg_release}}\" (default: yes)")
-        (@arg NO_TAG_VERSION_RELEASE: --("no-tag-version-release")
-            conflicts_with[TAG_VERSION_RELEASE]
-            "Do not tag image with :\"{{pkg_version}}-{{pkg_release}}\" (default: no)")
-        (@arg TAG_VERSION: --("tag-version") conflicts_with[NO_TAG_VERSION]
-            "Tag image with :\"{{pkg_version}}\" (default: yes)")
-        (@arg NO_TAG_VERSION: --("no-tag-version") conflicts_with[TAG_VERSION]
-            "Do not tag image with :\"{{pkg_version}}\" (default: no)")
-        (@arg TAG_LATEST: --("tag-latest") conflicts_with[NO_TAG_LATEST]
-            "Tag image with :\"latest\" (default: yes)")
-        (@arg NO_TAG_LATEST: --("no-tag-latest") conflicts_with[TAG_LATEST]
-            "Do not tag image with :\"latest\" (default: no)")
-        (@arg TAG_CUSTOM: --("tag-custom") +takes_value
-            "Tag image with additional custom tag (supports: \
-            {{pkg_origin}}, {{pkg_name}}, {{pkg_version}}, {{pkg_release}}, {{channel}})")
-
-        // Publishing
-        (@arg PUSH_IMAGE: --("push-image")
-            conflicts_with[NO_PUSH_IMAGE] requires[REGISTRY_USERNAME] requires[REGISTRY_PASSWORD]
-            "Push image to remote registry (default: no)")
-        (@arg NO_PUSH_IMAGE: --("no-push-image") conflicts_with[PUSH_IMAGE]
-            "Do not push image to remote registry (default: yes)")
-        (@arg REGISTRY_USERNAME: --("username") -U +takes_value requires[REGISTRY_PASSWORD]
-            "Remote registry username, required for pushing image to remote registry")
-        (@arg REGISTRY_PASSWORD: --("password") -P +takes_value requires[REGISTRY_USERNAME]
-            "Remote registry password, required for pushing image to remote registry")
-        (@arg REGISTRY_TYPE: --("registry-type") -R +takes_value
-            "Remote registry type, Ex: Amazon, Docker, Google (default: docker)")
-        (@arg REGISTRY_URL: --("registry-url") -G +takes_value
-            "Remote registry url")
-        // Cleanup
-        (@arg RM_IMAGE: --("rm-image")
-            "Remove local image from engine after build and/or push (default: no)")
-
+    app.arg(
+        Arg::with_name("PKG_IDENT_OR_ARTIFACT")
+            .value_name("PKG_IDENT_OR_ARTIFACT")
+            .required(true)
+            .multiple(true)
+            .help(
+                "One or more Habitat package identifiers (ex: acme/redis) and/or filepaths to a \
+                Habitat Artifact (ex: /home/acme-redis-3.0.7-21120102031201-x86_64-linux.hart)",
+            ),
     )
 }
 
@@ -251,24 +115,4 @@ fn ui() -> UI {
         Coloring::Auto
     };
     UI::default_with(coloring, isatty)
-}
-
-fn valid_ident_or_hart(val: String) -> result::Result<(), String> {
-    if Path::new(&val).is_file() {
-        Ok(())
-    } else if val.ends_with(".hart") {
-        Err(format!("Habitat artifact file: '{}' not found", &val))
-    } else {
-        match PackageIdent::from_str(&val) {
-            Ok(_) => Ok(()),
-            Err(e) => Err(format!("{}", e)),
-        }
-    }
-}
-
-fn valid_url(val: String) -> result::Result<(), String> {
-    match Url::parse(&val) {
-        Ok(_) => Ok(()),
-        Err(_) => Err(format!("URL: '{}' is not valid", &val)),
-    }
 }

--- a/components/pkg-export-kubernetes/Cargo.toml
+++ b/components/pkg-export-kubernetes/Cargo.toml
@@ -15,11 +15,14 @@ clap = { version = "*", features = ["suggestions", "color", "unstable"] }
 env_logger = "*"
 habitat_core = { path = "../core" }
 habitat_common = { path = "../common" }
+habitat_pkg_export_docker = { path = "../pkg-export-docker" }
 handlebars = { version = "*", default-features = false }
 log = "*"
 rand = "*"
 serde = "1.0.2"
 serde_json = "1.0.0"
+failure = "0.1"
+failure_derive = "0.1"
 
 [features]
 default = []

--- a/components/pkg-export-kubernetes/defaults/KubernetesBind.hbs
+++ b/components/pkg-export-kubernetes/defaults/KubernetesBind.hbs
@@ -1,0 +1,6 @@
+      # Name is the name of the bind specified in the Habitat configuration files.
+      - name: {{name}}
+        # Service is the name of the service this bind refers to.
+        service: {{service}}
+        # Group is the group of the service this bind refers to.
+        group: {{group}}

--- a/components/pkg-export-kubernetes/defaults/KubernetesManifest.hbs
+++ b/components/pkg-export-kubernetes/defaults/KubernetesManifest.hbs
@@ -42,3 +42,6 @@ spec:
     ## encrypts the communication between Habitat supervisors.
     ringSecretName: {{ring_secret_name}}
 {{/if}}
+{{#if bind}}
+    bind:
+{{/if}}

--- a/components/pkg-export-kubernetes/src/main.rs
+++ b/components/pkg-export-kubernetes/src/main.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[macro_use]
 extern crate clap;
 extern crate env_logger;
 extern crate habitat_core as hcore;
 extern crate habitat_common as common;
+extern crate habitat_pkg_export_docker as export_docker;
 extern crate handlebars;
 extern crate rand;
 #[macro_use]
@@ -24,36 +24,53 @@ extern crate serde_json;
 #[macro_use]
 extern crate log;
 
-use clap::App;
+extern crate failure;
+#[macro_use]
+extern crate failure_derive;
+
+use clap::{App, Arg};
 use handlebars::Handlebars;
+use std::env;
 use std::result;
 use std::str::FromStr;
 use std::io::prelude::*;
 use std::io;
 use std::fs::File;
+use std::path::Path;
 
+use hcore::channel;
 use hcore::PROGRAM_NAME;
+use hcore::url as hurl;
 use hcore::env as henv;
-use hcore::package::PackageIdent;
+use hcore::package::{PackageArchive, PackageIdent};
 use common::ui::{Coloring, UI, NOCOLORING_ENVVAR, NONINTERACTIVE_ENVVAR};
 use rand::Rng;
+
+use export_docker::{Cli, Credentials, BuildSpec, Naming, Result};
 
 // Synced with the version of the Habitat operator.
 pub const VERSION: &'static str = "0.1.0";
 
 // Kubernetes manifest template
 const MANIFESTFILE: &'static str = include_str!("../defaults/KubernetesManifest.hbs");
+const BINDFILE: &'static str = include_str!("../defaults/KubernetesBind.hbs");
+
+#[derive(Debug, Fail)]
+enum Error {
+    #[fail(display = "Invalid bind specification '{}'", _0)]
+    InvalidBindSpec(String),
+}
 
 fn main() {
     env_logger::init().unwrap();
-    let mut ui = ui();
+    let mut ui = get_ui();
     if let Err(e) = start(&mut ui) {
         let _ = ui.fatal(e);
         std::process::exit(1)
     }
 }
 
-fn ui() -> UI {
+fn get_ui() -> UI {
     let isatty = if henv::var(NONINTERACTIVE_ENVVAR)
         .map(|val| val == "true")
         .unwrap_or(false)
@@ -73,20 +90,59 @@ fn ui() -> UI {
     UI::default_with(coloring, isatty)
 }
 
-fn start(_ui: &mut UI) -> result::Result<(), String> {
+fn start(ui: &mut UI) -> Result<()> {
     let m = cli().get_matches();
     debug!("clap cli args: {:?}", m);
-    let count = m.value_of("COUNT").unwrap_or("1");
-    let topology = m.value_of("TOPOLOGY").unwrap_or("standalone");
-    let group = m.value_of("GROUP");
-    let config_secret_name = m.value_of("CONFIG_SECRET_NAME");
-    let ring_secret_name = m.value_of("RING_SECRET_NAME");
-    // clap_app!() ensures that we do have the mandatory args so unwrap() is fine here
-    let pkg_ident_str = m.value_of("PKG_IDENT").unwrap();
-    let pkg_ident = match PackageIdent::from_str(pkg_ident_str) {
-        Ok(pi) => pi,
-        Err(e) => return Err(format!("{}", e)),
+
+    if !m.is_present("NO_DOCKER_IMAGE") {
+        gen_docker_img(ui, &m)?;
+    }
+    gen_k8s_manifest(ui, &m)
+}
+
+fn gen_docker_img(ui: &mut UI, matches: &clap::ArgMatches) -> Result<()> {
+    let default_channel = channel::default();
+    let default_url = hurl::default_bldr_url();
+    let spec = BuildSpec::new_from_cli_matches(&matches, &default_channel, &default_url);
+    let naming = Naming::new_from_cli_matches(&matches);
+
+    let docker_image = export_docker::export(ui, spec, &naming)?;
+    docker_image.create_report(
+        ui,
+        env::current_dir()?.join("results"),
+    )?;
+
+    if matches.is_present("PUSH_IMAGE") {
+        let credentials = Credentials::new(
+            naming.registry_type,
+            matches.value_of("REGISTRY_USERNAME").unwrap(),
+            matches.value_of("REGISTRY_PASSWORD").unwrap(),
+        )?;
+        docker_image.push(ui, &credentials, naming.registry_url)?;
+    }
+    if matches.is_present("RM_IMAGE") {
+        docker_image.rm(ui)?;
+    }
+
+    Ok(())
+}
+
+fn gen_k8s_manifest(_ui: &mut UI, matches: &clap::ArgMatches) -> Result<()> {
+    let count = matches.value_of("COUNT").unwrap_or("1");
+    let topology = matches.value_of("TOPOLOGY").unwrap_or("standalone");
+    let group = matches.value_of("GROUP");
+    let config_secret_name = matches.value_of("CONFIG_SECRET_NAME");
+    let ring_secret_name = matches.value_of("RING_SECRET_NAME");
+    // clap ensures that we do have the mandatory args so unwrap() is fine here
+    let pkg_ident_str = matches.value_of("PKG_IDENT_OR_ARTIFACT").unwrap();
+    let pkg_ident = if Path::new(pkg_ident_str).is_file() {
+        // We're going to use the `$pkg_origin/$pkg_name`, fuzzy form of a package
+        // identifier to ensure that update strategies will work if desired
+        PackageArchive::new(pkg_ident_str).ident()?
+    } else {
+        PackageIdent::from_str(pkg_ident_str)?
     };
+
     // To allow multiple instances of Habitat application in Kubernetes,
     // random suffix in metadata_name is needed.
     let metadata_name = format!(
@@ -97,7 +153,12 @@ fn start(_ui: &mut UI) -> result::Result<(), String> {
             .take(5)
             .collect::<String>()
     );
-    let image = m.value_of("IMAGE").unwrap_or(pkg_ident_str);
+
+    let image = match matches.value_of("IMAGE_NAME") {
+        Some(i) => i.to_string(),
+        None => pkg_ident.origin + "/" + &pkg_ident.name,
+    };
+    let bind = matches.value_of("BIND");
 
     let json = json!({
         "metadata_name": metadata_name,
@@ -108,65 +169,138 @@ fn start(_ui: &mut UI) -> result::Result<(), String> {
         "service_group": group,
         "config_secret_name": config_secret_name,
         "ring_secret_name": ring_secret_name,
+        "bind": bind,
     });
 
-    let mut write: Box<Write> = match m.value_of("OUTPUT") {
-        Some(o) if o != "-" => {
-            match File::create(o) {
-                Ok(f) => Box::new(f),
-                Err(e) => return Err(format!("{}", e)),
-            }
-        }
+    let mut write: Box<Write> = match matches.value_of("OUTPUT") {
+        Some(o) if o != "-" => Box::new(File::create(o)?),
         _ => Box::new(io::stdout()),
     };
 
-    match Handlebars::new().template_render(MANIFESTFILE, &json) {
-        Ok(r) => {
-            let out = r.lines().filter(|l| *l != "").collect::<Vec<_>>().join(
-                "\n",
-            ) + "\n";
+    let r = Handlebars::new().template_render(MANIFESTFILE, &json)?;
+    let mut out = r.lines().filter(|l| *l != "").collect::<Vec<_>>().join(
+        "\n",
+    ) + "\n";
 
-            match write.write(out.as_bytes()) {
-                Ok(_) => Ok(()),
-                Err(e) => Err(format!("{}", e)),
+    if let Some(binds) = matches.values_of("BIND") {
+        for bind in binds {
+            let split: Vec<&str> = bind.split(":").collect();
+            if split.len() < 3 {
+                return Err(Error::InvalidBindSpec(bind.to_string()).into());
             }
-        }
 
-        Err(e) => Err(format!("{}", e)),
+            let json = json!({
+                "name": split[0],
+                "service": split[1],
+                "group": split[2],
+            });
+
+            out += &Handlebars::new().template_render(BINDFILE, &json)?;
+        }
     }
+
+    write.write(out.as_bytes())?;
+
+    Ok(())
 }
 
 fn cli<'a, 'b>() -> App<'a, 'b> {
     let name: &str = &*PROGRAM_NAME;
-    clap_app!((name) =>
-        (about: "Creates a Kubernetes manifest for a Habitat package. Habitat \
-                 operator must be deployed within the Kubernetes cluster to \
-                 intercept the created objects.")
-        (version: VERSION)
-        (author: "\nAuthors: The Habitat Maintainers <humans@habitat.sh>\n\n")
-        (@arg IMAGE: --("image") +takes_value
-            "Image of the Habitat service exported as a Docker image")
-        (@arg OUTPUT: -o --("output") +takes_value
-            "Name of manifest file to create. Pass '-' for stdout (default: -)")
-        (@arg COUNT: --("count") +takes_value {valid_natural_number}
-            "Count is the number of desired instances")
-        (@arg TOPOLOGY: -t --("service-topology") +takes_value
-            "A topology describes the intended relationship between peers \
-             within a service group. Specify either standalone or leader \
-             topology (default: standalone)")
-        (@arg GROUP: -g --("service-group") +takes_value
-            "group is a logical grouping of services with the same package and \
-             topology type connected together in a ring (default: default)")
-        (@arg CONFIG_SECRET_NAME: -n --("config-secret-name") +takes_value
-            "name of the Kubernetes Secret containing the config file - \
-             user.toml - that the user has previously created. Habitat will \
-             use it for initial configuration of the service")
-        (@arg RING_SECRET_NAME: -r --("ring-secret-name") +takes_value
-             "name of the Kubernetes Secret that contains the ring key, which \
-              encrypts the communication between Habitat supervisors")
-        (@arg PKG_IDENT: +required
-            "Habitat package identifier (ex: acme/redis)")
-    )
+    let about = "Creates a Docker image and Kubernetes manifest for a Habitat package. Habitat \
+                 operator must be deployed within the Kubernetes cluster before the generated \
+                 manifest can be applied to this cluster.";
+
+    let app = Cli::new(name, about)
+        .add_base_packages_args()
+        .add_builder_args()
+        .add_tagging_args()
+        .add_publishing_args()
+        .app;
+
+    app.arg(
+        Arg::with_name("OUTPUT")
+            .value_name("OUTPUT")
+            .long("output")
+            .short("o")
+            .help(
+                "Name of manifest file to create. Pass '-' for stdout (default: -)",
+            ),
+    ).arg(
+            Arg::with_name("COUNT")
+                .value_name("COUNT")
+                .long("count")
+                .validator(valid_natural_number)
+                .help("Count is the number of desired instances"),
+        )
+        .arg(
+            Arg::with_name("TOPOLOGY")
+                .value_name("TOPOLOGY")
+                .long("topology")
+                .short("t")
+                .possible_values(&["standalone", "leader"])
+                .help(
+                    "A topology describes the intended relationship between peers \
+                    within a Habitat service group. Specify either standalone or leader \
+                    topology (default: standalone)",
+                ),
+        )
+        .arg(
+            Arg::with_name("GROUP")
+                .value_name("GROUP")
+                .long("service-group")
+                .short("g")
+                .help(
+                    "group is a logical grouping of services with the same package and \
+                    topology type connected together in a ring (default: default)",
+                ),
+        )
+        .arg(
+            Arg::with_name("CONFIG_SECRET_NAME")
+                .value_name("CONFIG_SECRET_NAME")
+                .long("config-secret-name")
+                .short("n")
+                .help(
+                    "name of the Kubernetes Secret containing the config file - \
+                    user.toml - that the user has previously created. Habitat will \
+                    use it for initial configuration of the service",
+                ),
+        )
+        .arg(
+            Arg::with_name("RING_SECRET_NAME")
+                .value_name("RING_SECRET_NAME")
+                .long("ring-secret-name")
+                .short("r")
+                .help(
+                    "name of the Kubernetes Secret that contains the ring key, which \
+                    encrypts the communication between Habitat supervisors",
+                ),
+        )
+        .arg(
+            Arg::with_name("BIND")
+                .value_name("BIND")
+                .long("bind")
+                .short("b")
+                .multiple(true)
+                .number_of_values(1)
+                .help(
+                    "Bind to another service to form a producer/consumer relationship, \
+                    specified as name:service:group",
+                ),
+        )
+        .arg(
+            Arg::with_name("NO_DOCKER_IMAGE")
+                .long("no-docker-image")
+                .short("d")
+                .help(
+                    "Disable creation of the Docker image and only create a Kubernetes manifest",
+                ),
+        )
+        .arg(
+            Arg::with_name("PKG_IDENT_OR_ARTIFACT")
+                .value_name("PKG_IDENT_OR_ARTIFACT")
+                .required(true)
+                .help("Habitat package identifier (ex: acme/redis)"),
+        )
 }
 
 fn valid_natural_number(val: String) -> result::Result<(), String> {


### PR DESCRIPTION
This reverts commit 06778b480831503e0d40761f375cc12c08ee195c.

It was taken out during the unfortunate release problems surrounding
0.50.3; we're replacing it to get the functionality back.