### PR TITLE
Configure project settings

### DIFF
--- a/components/builder-originsrv/src/data_store.rs
+++ b/components/builder-originsrv/src/data_store.rs
@@ -299,7 +299,7 @@ impl DataStore {
         let conn = self.pool.get(opic)?;
 
         let rows = conn.query(
-            "SELECT * FROM upsert_origin_project_integration_v2($1, $2, $3, $4)",
+            "SELECT * FROM upsert_origin_project_integration_v3($1, $2, $3, $4)",
             &[
                 &opic.get_integration().get_origin(),
                 &opic.get_integration().get_name(),
@@ -341,9 +341,6 @@ impl DataStore {
     ) -> originsrv::OriginProjectIntegration {
         let mut opi = originsrv::OriginProjectIntegration::new();
         opi.set_origin(row.get("origin"));
-        opi.set_name(row.get("name"));
-        opi.set_integration(row.get("integration"));
-        opi.set_integration_name(row.get("integration_name"));
         opi.set_body(row.get("body"));
         opi
     }

--- a/components/builder-web/app/actions/projects.ts
+++ b/components/builder-web/app/actions/projects.ts
@@ -91,12 +91,10 @@ export function setProjectVisibility(origin: string, name: string, setting: stri
 export function fetchProject(origin: string, name: string, token: string, alert: boolean) {
   return dispatch => {
     dispatch(clearCurrentProject());
-    dispatch(clearCurrentProjectIntegration());
 
     new BuilderApiClient(token).getProject(origin, name)
       .then(response => {
         dispatch(setCurrentProject(response, null));
-        dispatch(fetchProjectIntegration(origin, name, 'docker', token));
       })
       .catch((error) => {
         dispatch(setCurrentProject(null, error));
@@ -108,7 +106,6 @@ export function fetchProjects(origin: string, token: string) {
   return dispatch => {
     dispatch(clearProjects());
     dispatch(clearCurrentProject());
-    dispatch(clearCurrentProjectIntegration());
 
     new BuilderApiClient(token).getProjects(origin).then(response => {
       if (Array.isArray(response) && response.length > 0) {
@@ -120,11 +117,12 @@ export function fetchProjects(origin: string, token: string) {
 
 export function fetchProjectIntegration(origin: string, name: string, integration: string, token: string) {
   return dispatch => {
-    dispatch(clearCurrentProjectIntegration());
-
     new BuilderApiClient(token).getProjectIntegration(origin, name, integration)
       .then(response => {
-        dispatch(setCurrentProjectIntegration(response));
+        dispatch(setCurrentProjectIntegration({
+          name: integration,
+          settings: response
+        }));
       })
       .catch(error => { });
   };
@@ -170,12 +168,6 @@ export function updateProject(projectId: string, project: Object, token: string,
 function clearCurrentProject() {
   return {
     type: CLEAR_CURRENT_PROJECT
-  };
-}
-
-function clearCurrentProjectIntegration() {
-  return {
-    type: CLEAR_CURRENT_PROJECT_INTEGRATION
   };
 }
 

--- a/components/builder-web/app/origin/origin-page/origin-integrations-tab/origin-integrations-tab.component.html
+++ b/components/builder-web/app/origin/origin-page/origin-integrations-tab/origin-integrations-tab.component.html
@@ -3,7 +3,7 @@
     <section>
       <h3>
         <hab-icon symbol="docker"></hab-icon>
-          Container Registries
+        Container Registries
       </h3>
       <p>
         When connecting a plan file to the Habitat Build Service, you can optionally export the result of your package build jobs
@@ -40,7 +40,7 @@
           <li class="item" *ngFor="let integration of integrations[type]">
             <span class="column name">
               <hab-icon [symbol]="type"></hab-icon>
-              <span>{{ integration }}</span>
+              <span>{{ decode(integration) }}</span>
             </span>
             <span class="column actions">
               <hab-icon symbol="cancel" title="Delete this integration" (click)="deleteIntegration(integration, type)"></hab-icon>

--- a/components/builder-web/app/origin/origin-page/origin-integrations-tab/origin-integrations-tab.component.ts
+++ b/components/builder-web/app/origin/origin-page/origin-integrations-tab/origin-integrations-tab.component.ts
@@ -80,6 +80,10 @@ export class OriginIntegrationsTabComponent implements OnInit {
       });
   }
 
+  decode(s) {
+    return decodeURIComponent(s);
+  }
+
   deleteIntegration(name, type) {
     this.confirmDialog
       .open(IntegrationDeleteConfirmDialog, { width: '480px' })

--- a/components/builder-web/app/records/Project.ts
+++ b/components/builder-web/app/records/Project.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Record } from 'immutable';
+import { Map, Record } from 'immutable';
 
 export const Project = Record({
   id: undefined,
@@ -26,6 +26,6 @@ export const Project = Record({
   vcs_data: undefined,
   vcs_type: undefined,
   vcs_username: undefined,
-  settings: undefined,
+  settings: Map(),
   visibility: undefined
 });

--- a/components/builder-web/app/reducers/projects.ts
+++ b/components/builder-web/app/reducers/projects.ts
@@ -32,9 +32,6 @@ export default function projects(state = initialState['projects'], action) {
         setIn(['ui', 'current', 'exists'], false).
         setIn(['ui', 'current', 'loading'], true);
 
-    case actionTypes.CLEAR_CURRENT_PROJECT_INTEGRATION:
-      return state.setIn(['current', 'settings'], undefined);
-
     case actionTypes.SET_CURRENT_PROJECT:
       if (action.error) {
         return state.setIn(['current'], Project()).
@@ -51,7 +48,7 @@ export default function projects(state = initialState['projects'], action) {
       }
 
     case actionTypes.SET_CURRENT_PROJECT_INTEGRATION:
-      return state.setIn(['current', 'settings'], action.payload);
+      return state.setIn(['current', 'settings', action.payload.name], action.payload.settings);
 
     case actionTypes.SET_PROJECTS:
       if (action.error) {

--- a/components/builder-web/app/shared/docker-export-settings/dialog/docker-export-settings.dialog.html
+++ b/components/builder-web/app/shared/docker-export-settings/dialog/docker-export-settings.dialog.html
@@ -1,0 +1,22 @@
+<div class="dialog invitation-confirm">
+  <form (ngSubmit)="ok()" #settingsForm="ngForm">
+    <section class="heading">
+      <hab-icon symbol="delete"></hab-icon>
+      <h1>Configure container registry</h1>
+    </section>
+    <section class="body">
+      <label for="repo_name">Organization and Repository</label>
+      <input type="text" name="repo_name" [(ngModel)]="docker_hub_repo_name" placeholder="{{ repoPlaceholder }}">
+      <label for="custom_tag">Custom Tag (Optional)</label>
+      <input type="text" name="custom_tag" [(ngModel)]="custom_tag" [placeholder]="'yourtag or \{\{ channel \}\}'">
+      <label>Additional Tags</label>
+      <mat-checkbox name="latest_tag" [(ngModel)]="latest_tag">:latest</mat-checkbox>
+      <mat-checkbox name="version_tag" [(ngModel)]="version_tag">:pkg_version</mat-checkbox>
+      <mat-checkbox name="version_release_tag" [(ngModel)]="version_release_tag">:pkg_version-pkg_release</mat-checkbox>
+    </section>
+    <section class="controls">
+      <button mat-raised-button tabindex="1" color="primary" type="submit" [disabled]="!settingsForm.form.valid">Save settings</button>
+      <a (click)="cancel()">Cancel</a>
+    </section>
+  </form>
+</div>

--- a/components/builder-web/app/shared/docker-export-settings/dialog/docker-export-settings.dialog.ts
+++ b/components/builder-web/app/shared/docker-export-settings/dialog/docker-export-settings.dialog.ts
@@ -1,0 +1,58 @@
+// Copyright (c) 2016-2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Component, Inject } from '@angular/core';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material';
+
+@Component({
+  template: require('./docker-export-settings.dialog.html')
+})
+export class DockerExportSettingsDialog {
+  private repoPlaceholder: string;
+  private docker_hub_repo_name: string;
+  private custom_tag: string;
+  private latest_tag: boolean;
+  private version_tag: boolean;
+  private version_release_tag: boolean;
+
+  constructor(
+    private ref: MatDialogRef<DockerExportSettingsDialog>,
+    @Inject(MAT_DIALOG_DATA) private data: any
+  ) {
+    this.repoPlaceholder = data.repoPlaceholder;
+    this.docker_hub_repo_name = data.docker_hub_repo_name;
+    this.custom_tag = data.custom_tag;
+    this.latest_tag = !!data.latest_tag;
+    this.version_tag = !!data.version_tag;
+    this.version_release_tag = !!data.version_release_tag;
+  }
+
+  get settings() {
+    return {
+      docker_hub_repo_name: this.docker_hub_repo_name,
+      custom_tag: this.custom_tag,
+      latest_tag: this.latest_tag,
+      version_tag: this.version_tag,
+      version_release_tag: this.version_release_tag
+    };
+  }
+
+  ok() {
+    this.ref.close(this.settings);
+  }
+
+  cancel() {
+    this.ref.close(null);
+  }
+}

--- a/components/builder-web/app/shared/docker-export-settings/docker-export-settings.component.html
+++ b/components/builder-web/app/shared/docker-export-settings/docker-export-settings.component.html
@@ -1,40 +1,39 @@
 <div class="docker-export-settings-component">
   <h3>
     <hab-icon symbol="docker"></hab-icon>
-    Publish to Docker Hub
+    Publish to Container Registries
   </h3>
   <p>
-    Export the resulting .hart file as a Docker container and publish it to your Docker Hub account. Integration settings are
-    managed under the origin Settings tab.
+    Export the resulting .hart file as a Docker container and publish it to your registry account(s). Registry account settings
+    are managed in the
+    <a [routerLink]="['/origins', origin, 'integrations']">Integrations tab for this origin</a>.
   </p>
   <section class="toggle">
     <mat-slide-toggle [(ngModel)]="enabled" [disabled]="!configured">
       {{ enabled ? "On" : "Off" }}
     </mat-slide-toggle>
     <span class="unconfigured" *ngIf="!configured">
-      You can configure this integration in the origin Integrations tab.
+      You can configure this integration in the
+      <a [routerLink]="['/origins', origin, 'integrations']">origin Integrations tab</a>.
     </span>
   </section>
   <ng-container *ngIf="enabled && configured">
     <section class="integrations">
-      <mat-radio-group [(ngModel)]="name">
-        <ng-container *ngFor="let type of integrations | habKeysPipe">
-          <mat-radio-button *ngFor="let integration of integrations[type]" [value]="integration">
-            <hab-icon [symbol]="type"></hab-icon>
-            <span>{{ integration }}</span>
-          </mat-radio-button>
-        </ng-container>
+      <mat-radio-group [(ngModel)]="name" (change)="onChange(name)">
+        <ul class="action-list">
+          <ng-container *ngFor="let type of integrations | habKeysPipe">
+            <li class="item" *ngFor="let integration of integrations[type]">
+              <mat-radio-button class="column" [value]="integration" [checked]="settingsFor(integration)">
+                <hab-icon [symbol]="type"></hab-icon>
+                <span>{{ decode(integration) }}</span>
+              </mat-radio-button>
+              <span class="actions column">
+                <hab-icon *ngIf="settingsFor(integration)" symbol="settings" title="Edit publish settings" (click)="configure(integration)"></hab-icon>
+              </span>
+            </li>
+          </ng-container>
+        </ul>
       </mat-radio-group>
-    </section>
-    <section class="fields">
-      <label for="repo_name" >Docker Organization and Repository</label>
-      <input type="text" name="repo_name" [(ngModel)]="repoName" placeholder="{{ repoPlaceholder }}">
-      <label for="custom_tag">Custom Tag (Optional)</label>
-      <input type="text" name="custom_tag" [(ngModel)]="customTag" [placeholder]="'yourtag or \{\{ channel \}\}'">
-      <label>Additional Tags</label>
-      <mat-checkbox [(ngModel)]="latestTag">:latest</mat-checkbox>
-      <mat-checkbox [(ngModel)]="versionTag">:pkg_version</mat-checkbox>
-      <mat-checkbox [(ngModel)]="releaseTag">:pkg_version-pkg_release</mat-checkbox>
     </section>
   </ng-container>
 </div>

--- a/components/builder-web/app/shared/docker-export-settings/docker-export-settings.component.ts
+++ b/components/builder-web/app/shared/docker-export-settings/docker-export-settings.component.ts
@@ -12,26 +12,35 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Component, Input, OnChanges } from '@angular/core';
+import { Component, Input, OnChanges, OnDestroy, SimpleChanges } from '@angular/core';
+import { MatDialog } from '@angular/material';
+import { DockerExportSettingsDialog } from './dialog/docker-export-settings.dialog';
+import { fetchProjectIntegration } from '../../actions/projects';
 import { AppStore } from '../../app.store';
 
 @Component({
   selector: 'hab-docker-export-settings',
   template: require('./docker-export-settings.component.html')
 })
-export class DockerExportSettingsComponent implements OnChanges {
+export class DockerExportSettingsComponent implements OnChanges, OnDestroy {
+  @Input() origin: string;
+  @Input() package: string;
   @Input() integrations: any;
   @Input() current: any;
   @Input() enabled: boolean = false;
 
   private name: string;
-  private repoName: string = '';
-  private customTag: string;
-  private latestTag: boolean = true;
-  private versionTag: boolean = true;
-  private releaseTag: boolean = true;
+  private docker_hub_repo_name: string = '';
+  private custom_tag: string;
+  private latest_tag: boolean = true;
+  private version_tag: boolean = true;
+  private version_release_tag: boolean = true;
+  private unsubscribe: Function;
 
-  constructor(private store: AppStore) { }
+  constructor(
+    private store: AppStore,
+    private dialog: MatDialog
+  ) { }
 
   get configured() {
     return Object.keys(this.integrations).length > 0;
@@ -43,11 +52,11 @@ export class DockerExportSettingsComponent implements OnChanges {
       name: this.name,
       enabled: this.enabled,
       settings: {
-        docker_hub_repo_name: this.repoName,
-        custom_tag: this.customTag,
-        latest_tag: this.latestTag,
-        version_tag: this.versionTag,
-        version_release_tag: this.releaseTag
+        docker_hub_repo_name: this.docker_hub_repo_name,
+        custom_tag: this.custom_tag,
+        latest_tag: this.latest_tag,
+        version_tag: this.version_tag,
+        version_release_tag: this.version_release_tag
       }
     };
   }
@@ -56,35 +65,99 @@ export class DockerExportSettingsComponent implements OnChanges {
     return this.store.getState().projects.current.name || `${this.username}/example-repo`;
   }
 
+  get token() {
+    return this.store.getState().session.token;
+  }
+
   get username() {
     return this.store.getState().users.current.username;
   }
 
   get valid() {
 
-    if (this.repoName.trim() !== '') {
+    if (this.docker_hub_repo_name && this.docker_hub_repo_name.trim() !== '') {
       return true;
     }
 
     return false;
   }
 
-  ngOnChanges(changes) {
+  applySettings(name, settings) {
+    this.name = name;
+    this.docker_hub_repo_name = settings.docker_hub_repo_name;
+    this.custom_tag = settings.custom_tag;
+    this.latest_tag = settings.latest_tag;
+    this.version_tag = settings.version_tag;
+    this.version_release_tag = settings.version_release_tag;
+  }
 
-    if (changes.integrations) {
-      this.name = changes.integrations.currentValue;
+  configure(integration) {
+    this.name = integration;
+    const integrations = this.store.getState().projects.current.settings;
+    const settings = integrations.get(integration) || {};
+
+    this.dialog
+      .open(DockerExportSettingsDialog, {
+        data: {
+          repoPlaceholder: this.repoPlaceholder,
+          docker_hub_repo_name: settings.docker_hub_repo_name,
+          custom_tag: settings.custom_tag,
+          latest_tag: settings.latest_tag,
+          version_tag: settings.version_tag,
+          version_release_tag: settings.version_release_tag
+        },
+        width: '480px'
+      })
+      .afterClosed()
+      .subscribe((result) => {
+        if (result) {
+          this.applySettings(integration, result);
+        }
+      });
+  }
+
+  decode(s) {
+    return decodeURIComponent(s);
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    const i: any = changes['integrations'];
+
+    if (i && i.currentValue) {
+      const integrations = i.currentValue;
+
+      Object.keys(integrations).forEach(key => {
+        integrations[key].forEach(name => {
+          this.store.dispatch(fetchProjectIntegration(this.origin, this.package, name, this.token));
+        });
+      });
+
+      this.unsubscribe = this.store.subscribe(state => {
+        state.projects.current.settings.forEach((v, k) => {
+          this.applySettings(k, v);
+          this.unsubscribe();
+          return false;
+        });
+      });
     }
+  }
 
-    if (changes.current) {
-      const value = changes.current.currentValue;
-
-      if (value) {
-        this.repoName = value.docker_hub_repo_name;
-        this.customTag = value.custom_tag;
-        this.latestTag = value.latest_tag;
-        this.versionTag = value.version_tag;
-        this.releaseTag = value.version_release_tag;
-      }
+  ngOnDestroy() {
+    if (this.unsubscribe) {
+      this.unsubscribe();
     }
+  }
+
+  onChange(name) {
+    const settings = this.settingsFor(name);
+    this.applySettings(name, settings || {});
+
+    if (!settings) {
+      this.configure(name);
+    }
+  }
+
+  settingsFor(integration) {
+    return this.store.getState().projects.current.settings.get(integration);
   }
 }

--- a/components/builder-web/app/shared/project-settings/project-settings.component.html
+++ b/components/builder-web/app/shared/project-settings/project-settings.component.html
@@ -108,8 +108,8 @@
         </div>
         <hab-visibility-selector [setting]="visibility" (changed)="settingChanged($event)">
         </hab-visibility-selector>
-        <hab-docker-export-settings #docker *ngIf="selectedInstallation" [integrations]="integrations" [current]="dockerSettings"
-          [enabled]="dockerEnabled">
+        <hab-docker-export-settings #docker *ngIf="selectedInstallation" [origin]="origin" [package]="name" [integrations]="integrations"
+          [current]="dockerSettings" [enabled]="dockerEnabled">
         </hab-docker-export-settings>
       </div>
       <div class="controls">
@@ -122,5 +122,5 @@
         <a (click)="clearConnection()">Cancel</a>
       </div>
     </form>
-  </div>  
+  </div>
 </div>

--- a/components/builder-web/app/shared/project-settings/project-settings.component.ts
+++ b/components/builder-web/app/shared/project-settings/project-settings.component.ts
@@ -101,7 +101,7 @@ export class ProjectSettingsComponent implements OnChanges {
   }
 
   get dockerEnabled() {
-    return this.dockerSettings && this.dockerSettings.docker_hub_repo_name !== '';
+    return this.dockerSettings && this.dockerSettings.size > 0;
   }
 
   get dockerSettings() {
@@ -277,7 +277,6 @@ export class ProjectSettingsComponent implements OnChanges {
 
   private saveIntegration(origin, name) {
     const settings = this.docker.settings;
-
     if (settings.enabled) {
       this.store.dispatch(
         setProjectIntegrationSettings(

--- a/components/builder-web/app/shared/shared.module.ts
+++ b/components/builder-web/app/shared/shared.module.ts
@@ -28,6 +28,7 @@ import { ChannelsComponent } from './channels/channels.component';
 import { CheckingInputComponent } from './checking-input/checking-input.component';
 import { CopyableComponent } from './copyable/copyable.component';
 import { DockerExportSettingsComponent } from './docker-export-settings/docker-export-settings.component';
+import { DockerExportSettingsDialog } from './docker-export-settings/dialog/docker-export-settings.dialog';
 import { DisconnectConfirmDialog } from './project-settings/dialog/disconnect-confirm/disconnect-confirm.dialog';
 import { IconComponent } from './icon/icon.component';
 import { PackageListComponent } from './package-list/package-list.component';
@@ -60,6 +61,7 @@ import { SignedInGuard } from './guards/signed-in.guard';
     CopyableComponent,
     DisconnectConfirmDialog,
     DockerExportSettingsComponent,
+    DockerExportSettingsDialog,
     IconComponent,
     PackageListComponent,
     ProjectSettingsComponent,
@@ -70,6 +72,7 @@ import { SignedInGuard } from './guards/signed-in.guard';
   ],
   entryComponents: [
     DisconnectConfirmDialog,
+    DockerExportSettingsDialog,
     SimpleConfirmDialog
   ],
   exports: [


### PR DESCRIPTION
This change adds proper support to Builder UI for selecting among multiple publishing integrations within an origin.

Signed-off-by: Christian Nunciato <chris@nunciato.org>

Fixes #4140.

![tenor-133501961](https://user-images.githubusercontent.com/274700/33577911-90f9b978-d8f9-11e7-8d1e-7cecea2b978c.gif)
