### PR TITLE
Update build dependencies for pkg-export-docker

### DIFF
--- a/components/pkg-export-docker/plan.sh
+++ b/components/pkg-export-docker/plan.sh
@@ -10,7 +10,7 @@ pkg_deps=(core/docker)
 pkg_build_deps=(
   core/musl core/zlib-musl core/xz-musl core/bzip2-musl core/libarchive-musl
   core/openssl-musl core/libsodium-musl
-  core/coreutils core/rust core/gcc
+  core/coreutils core/rust core/gcc core/make
 )
 pkg_bin_dirs=(bin)
 

--- a/components/pkg-export-kubernetes/plan.sh
+++ b/components/pkg-export-kubernetes/plan.sh
@@ -7,7 +7,7 @@ pkg_license=('Apache-2.0')
 pkg_build_deps=(
   core/musl core/zlib-musl core/xz-musl core/bzip2-musl core/libarchive-musl
   core/openssl-musl core/libsodium-musl
-  core/coreutils core/rust core/gcc
+  core/coreutils core/rust core/gcc core/make
 )
 pkg_bin_dirs=(bin)
 


### PR DESCRIPTION
The code from #4041 (and later, #4201) introduced `backtrace-sys` as a
dependency for the `pkg-export-docker` crate. This needs `make` as a
build dependency, which we add here to the Habitat plans for both
`core/hab-pkg-export-docker` and
`core/hab-pkg-export-kubernetes` (which has a library dependency on
the `pkg-export-docker` crate)

This was uncovered only in Travis, likely because most development on
Habitat is done on Linux systems, and thus using the default Linux
chroot-based studios. This ends up reusing compiled Rust artifacts in
`/src/target`, which will have included the `backtrace-sys` artifact
compiled by the Linux host system. As a result, package builds in
those studios ran without an issue. Running the build in a
Docker-based studio (e.g., on MacOS) immediately revealed the issue.

Signed-off-by: Christopher Maier <cmaier@chef.io>