### PR TITLE
Support package promotion in Builder UI

### DIFF
--- a/components/builder-web/app/actions/packages.ts
+++ b/components/builder-web/app/actions/packages.ts
@@ -14,6 +14,7 @@
 
 import { groupBy } from 'lodash';
 import * as depotApi from '../client/depot-api';
+import { addNotification, SUCCESS, DANGER } from './notifications';
 
 export const CLEAR_PACKAGES = 'CLEAR_PACKAGES';
 export const CLEAR_LATEST_IN_CHANNEL = 'CLEAR_LATEST_IN_CHANNEL';
@@ -197,6 +198,28 @@ export function populateExploreStats(data) {
   return {
     type: POPULATE_EXPLORE_STATS,
     payload: data,
+  };
+}
+
+export function promotePackage(origin: string, name: string, version: string, release: string, channel: string, token: string) {
+  return dispatch => {
+    depotApi.promotePackage(origin, name, version, release, channel, token)
+      .then(response => {
+        dispatch(addNotification({
+          title: 'Package promoted',
+          body: `${origin}/${name}/${version}/${release} has been promoted to the ${channel} channel.`,
+          type: SUCCESS
+        }));
+        dispatch(fetchPackageVersions(origin, name));
+      })
+      .catch(error => {
+        dispatch(addNotification({
+          title: 'Failed to promote package',
+          body: `There was an error promoting ${origin}/${name}/${version}/${release}
+            to the ${channel} channel. The message was ${error.message}.`,
+          type: DANGER
+        }));
+      });
   };
 }
 

--- a/components/builder-web/app/client/depot-api.ts
+++ b/components/builder-web/app/client/depot-api.ts
@@ -196,13 +196,35 @@ export function getPackageVersions(origin: string, pkg: string) {
   });
 }
 
+export function promotePackage(origin: string, name: string, version: string, release: string, channel: string, token: string) {
+  const url = `${urlPrefix}/depot/channels/${origin}/${channel}/pkgs/${name}/${version}/${release}/promote`;
+
+  return new Promise((resolve, reject) => {
+    fetch(url, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+      method: 'PUT',
+    })
+      .then(response => handleUnauthorized(response, reject))
+      .then(response => {
+        if (response.ok) {
+          resolve(true);
+        } else {
+          reject(new Error(response.statusText));
+        }
+      })
+      .catch(error => handleError(error, reject));
+  });
+}
+
 export function submitJob(origin: string, pkg: string, token: string) {
   const url = `${urlPrefix}/depot/pkgs/schedule/${origin}/${pkg}`;
 
   return new Promise((resolve, reject) => {
     fetch(url, {
       headers: {
-        'Authorization': `Bearer ${token}`,
+        Authorization: `Bearer ${token}`,
       },
       method: 'POST',
     })

--- a/components/builder-web/app/package/_package.module.scss
+++ b/components/builder-web/app/package/_package.module.scss
@@ -4,5 +4,6 @@
 @import "build-status/build-status.component";
 @import "package-latest/package-latest.component";
 @import "package-detail/package-detail.component";
+@import "package-promote/package-promote.component";
 @import "package-sidebar/package-sidebar.component";
 @import "package-versions/package-versions.component";

--- a/components/builder-web/app/package/package-promote/_package-promote.component.scss
+++ b/components/builder-web/app/package/package-promote/_package-promote.component.scss
@@ -1,0 +1,16 @@
+.package-promote-component {
+  font-size: $smaller-font-size;
+  font-weight: 500;
+  border-radius: 11px;
+  color: $hab-blue;
+  padding: 2px 8px 4px 8px;
+  cursor: pointer;
+
+  &:hover {
+    @include shadow;
+  }
+
+  .promoting {
+    color: map-get($status-colors, processing);
+  }
+}

--- a/components/builder-web/app/package/package-promote/package-promote.component.html
+++ b/components/builder-web/app/package/package-promote/package-promote.component.html
@@ -1,0 +1,10 @@
+<span class="package-promote-component" (click)="prompt($event)">
+  <span *ngIf="!promoting">
+    <hab-icon symbol="star-circle"></hab-icon>
+    Promote to stable
+  </span>
+  <span class="promoting" *ngIf="promoting">
+    <hab-icon symbol="loading" class="spinning"></hab-icon>
+    Promoting...
+  </span>
+</span>

--- a/components/builder-web/app/package/package-promote/package-promote.component.ts
+++ b/components/builder-web/app/package/package-promote/package-promote.component.ts
@@ -1,0 +1,50 @@
+import { Component, Input } from '@angular/core';
+import { MatDialog } from '@angular/material';
+import { AppStore } from '../../app.store';
+import { promotePackage } from '../../actions/packages';
+import { SimpleConfirmDialog } from '../../shared/dialog/simple-confirm/simple-confirm.dialog';
+
+@Component({
+  selector: 'hab-package-promote',
+  template: require('./package-promote.component.html')
+})
+export class PackagePromoteComponent {
+  @Input() origin: string;
+  @Input() name: string;
+  @Input() version: string;
+  @Input() release: string;
+  @Input() channel: string;
+
+  promoting: boolean = false;
+
+  constructor(
+    private confirmDialog: MatDialog,
+    private store: AppStore
+  ) { }
+
+  prompt(evt) {
+    evt.stopPropagation();
+
+    this.confirmDialog
+      .open(SimpleConfirmDialog, {
+        width: '480px',
+        data: {
+          heading: 'Confirm promote',
+          body: `Are you sure you want to promote this artifact? Doing so will add the artifact to the ${this.channel} channel.`,
+          action: 'promote it'
+        }
+      })
+      .afterClosed()
+      .subscribe((confirmed) => {
+        if (confirmed) {
+          this.promoting = true;
+
+          setTimeout(() => {
+            this.store.dispatch(
+              promotePackage(this.origin, this.name, this.version, this.release, this.channel, this.store.getState().session.token)
+            );
+          }, 1000);
+        }
+      });
+  }
+}

--- a/components/builder-web/app/package/package-versions/_package-versions.component.scss
+++ b/components/builder-web/app/package/package-versions/_package-versions.component.scss
@@ -1,9 +1,17 @@
 .package-versions-component {
-  
+
   .nav-list {
-  
+
     .name {
       flex: 6;
+
+      .release-name {
+        display: block;
+      }
+
+      .package-promote-component {
+        margin-left: $default-margin / 4;
+      }
     }
 
     .build-date {

--- a/components/builder-web/app/package/package-versions/package-versions.component.html
+++ b/components/builder-web/app/package/package-versions/package-versions.component.html
@@ -26,6 +26,8 @@
               <div class="column name release">
                 <span class="release-name">{{ packageString(pkg) }}</span>
                 <hab-channels [channels]="pkg.channels"></hab-channels>
+                <hab-package-promote [origin]="pkg.origin" [name]="pkg.name" [version]="pkg.version" [release]="pkg.release" channel="stable"
+                  *ngIf="promotable(pkg)"></hab-package-promote>
               </div>
               <div class="column build-date">
                 {{ releaseToDate(pkg.release) }}
@@ -47,4 +49,3 @@
     </div>
   </ul>
 </div>
-

--- a/components/builder-web/app/package/package-versions/package-versions.component.spec.ts
+++ b/components/builder-web/app/package/package-versions/package-versions.component.spec.ts
@@ -14,8 +14,7 @@
 
 import { TestBed, ComponentFixture } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
-import { Component, DebugElement } from '@angular/core';
-import { By } from '@angular/platform-browser';
+import { DebugElement } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { Observable } from 'rxjs';
 import { MockComponent } from 'ng2-mock-component';
@@ -66,7 +65,8 @@ describe('PackageVersionsComponent', () => {
         PackageVersionsComponent,
         MockComponent({ selector: 'hab-icon', inputs: ['symbol', 'title'] }),
         MockComponent({ selector: 'hab-platform-icon', inputs: ['platform'] }),
-        MockComponent({ selector: 'hab-channels', inputs: ['channels'] })
+        MockComponent({ selector: 'hab-channels', inputs: ['channels'] }),
+        MockComponent({ selector: 'hab-package-promote', inputs: ['origin', 'name', 'version', 'release', 'channel'] })
       ],
       providers: [
         { provide: AppStore, useValue: store },

--- a/components/builder-web/app/package/package-versions/package-versions.component.ts
+++ b/components/builder-web/app/package/package-versions/package-versions.component.ts
@@ -87,6 +87,14 @@ export class PackageVersionsComponent implements OnDestroy {
     this.store.dispatch(filterPackagesBy(params, null, false));
   }
 
+  promotable(pkg) {
+    return this.memberOfOrigin && pkg.channels.indexOf('stable') === -1;
+  }
+
+  get memberOfOrigin() {
+    return !!this.store.getState().origins.mine.find(origin => origin['name'] === this.origin);
+  }
+
   packageString(pkg) {
     return packageString(pkg);
   }

--- a/components/builder-web/app/package/package.module.ts
+++ b/components/builder-web/app/package/package.module.ts
@@ -24,8 +24,9 @@ import { BuildStatusComponent } from './build-status/build-status.component';
 import { PackageBuildComponent } from './package-build/package-build.component';
 import { PackageComponent } from './package/package.component';
 import { PackageBuildsComponent } from './package-builds/package-builds.component';
-import { PackageLatestComponent } from './package-latest/package-latest.component';
 import { PackageDetailComponent } from './package-detail/package-detail.component';
+import { PackageLatestComponent } from './package-latest/package-latest.component';
+import { PackagePromoteComponent } from './package-promote/package-promote.component';
 import { PackageSettingsComponent } from './package-settings/package-settings.component';
 import { PackageReleaseComponent } from './package-release/package-release.component';
 import { PackageSidebarComponent } from './package-sidebar/package-sidebar.component';
@@ -57,6 +58,7 @@ import { PackageRoutingModule } from './package-routing.module';
     PackageBuildsComponent,
     PackageLatestComponent,
     PackageDetailComponent,
+    PackagePromoteComponent,
     PackageReleaseComponent,
     PackageSidebarComponent,
     PackageSettingsComponent,

--- a/components/builder-web/app/shared/channels/_channels.component.scss
+++ b/components/builder-web/app/shared/channels/_channels.component.scss
@@ -1,13 +1,14 @@
 .channels-component {
-  
+  display: inline-block;
+
   ul {
+    display: inline-block;
     margin-top: $small-margin;
     line-height: 16.5px;
-  
+
     li {
       display: inline-block;
-      margin-right: $default-margin / 4;
-      font-size: 11px;
+      font-size: $smaller-font-size;
       font-weight: 600;
       font-family: $base-font-family;
       padding: 2px 10px;
@@ -15,17 +16,21 @@
       color: $hab-blue;
       background-color: $light-blue;
       border: 1px solid $light-blue;
-  
+
       &.unstable {
         background-color: $white;
         border: 1px solid $very-light-gray;
         color: $hab-blue;
       }
-  
+
       &.stable {
         background-color: $hab-blue;
         border: 1px solid $hab-blue;
         color: $white;
+      }
+
+      &:not(:last-child) {
+        margin-right: $default-margin / 4;
       }
     }
   }

--- a/components/builder-web/assets/images/icons/all.svg
+++ b/components/builder-web/assets/images/icons/all.svg
@@ -165,5 +165,9 @@
       <!-- https://material.io/icons/#ic_menu -->
       <path d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"/>
     </g>
+    <g id="icon-star-circle">
+      <!-- https://material.io/icons/#ic_stars -->
+      <path d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zm4.24 16L12 15.45 7.77 18l1.12-4.81-3.73-3.23 4.92-.42L12 5l1.92 4.53 4.92.42-3.73 3.23L16.23 18z"/>
+    <g>
   </defs>
 </svg>


### PR DESCRIPTION
This change adds a Promote button that allows origin members to promote a release to the stable channel.

Signed-off-by: Christian Nunciato <chris@nunciato.org>

Fixes #4046.

![tenor-77832220](https://user-images.githubusercontent.com/274700/33631329-19e17e4a-d9bf-11e7-8560-501c5ad365fa.gif)
