### PR TITLE
Add core/docker dependency to Kubernetes exporter

### DIFF
--- a/components/pkg-export-kubernetes/plan.sh
+++ b/components/pkg-export-kubernetes/plan.sh
@@ -4,6 +4,7 @@ pkg_origin=core
 pkg_version="0.1.0"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
+pkg_deps=(core/docker)
 pkg_build_deps=(
   core/musl core/zlib-musl core/xz-musl core/bzip2-musl core/libarchive-musl
   core/openssl-musl core/libsodium-musl


### PR DESCRIPTION
The Docker exporter does the same, but the Kubernetes exporter has a
Rust code dependency on that crate, not a Hab dependency on its
package.

Signed-off-by: Christopher Maier <cmaier@chef.io>