### PR TITLE
removes line causing unset PS1 errors in Vagrant bashrc

### DIFF
--- a/support/linux/provision.sh
+++ b/support/linux/provision.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euo pipefail
+#set -euo pipefail
 
 export APP_HOSTNAME=localhost:3000
 export GITHUB_API_URL=https://api.github.com


### PR DESCRIPTION
Signed-off-by: Nell Shamrell <nellshamrell@gmail.com>

When this line is in the script, it causes this error when using it with a Vagrant box

```
==> default: ★ Install of core/hab-studio/0.50.3/20171202005455 complete with 1 new packages installed.
==> default: + sudo -E rm -rf /tmp/install.sh
==> default: /root/.bashrc: line 6: PS1: unbound variable
The SSH command responded with a non-zero exit status. Vagrant
assumes that this means the command failed. The output for this command
should be in the log above. Please read the output to determine what
went wrong.
```

At the suggestion of @elliott-davis, I removed this line from the provision.sh script and the script worked with my Vagrant box.