### PR TITLE
Don’t wrap the promote button

### DIFF
--- a/components/builder-web/app/package/package-promote/_package-promote.component.scss
+++ b/components/builder-web/app/package/package-promote/_package-promote.component.scss
@@ -6,6 +6,10 @@
   padding: 2px 8px 4px 8px;
   cursor: pointer;
 
+  span {
+    white-space: nowrap;
+  }
+
   &:hover {
     @include shadow;
   }

--- a/components/builder-web/app/package/package-versions/_package-versions.component.scss
+++ b/components/builder-web/app/package/package-versions/_package-versions.component.scss
@@ -9,8 +9,8 @@
         display: block;
       }
 
-      .package-promote-component {
-        margin-left: $default-margin / 4;
+      hab-channels {
+        margin-right: $default-margin / 4;
       }
     }
 


### PR DESCRIPTION
Minor CSS fix to make things lay out properly with long channel lists, names, on mobile, &c.

Signed-off-by: Christian Nunciato <chris@nunciato.org>

![tenor-220708905](https://user-images.githubusercontent.com/274700/33682672-12343016-da7d-11e7-8556-28440e9f2037.gif)