### PR TITLE
Fixes annoying warn during hab-butterfly compilation

### DIFF
--- a/components/hab-butterfly/src/command/config.rs
+++ b/components/hab-butterfly/src/command/config.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 pub mod apply {
-    use std::str;
     use std::path::Path;
     use std::io::{self, Read};
     use std::fs::File;


### PR DESCRIPTION
![](https://media.tenor.com/images/7323331ef33f732fb9fbf53ce29e4cbd/tenor.gif)
