### PR TITLE
Make package identifiers more easily copyable

### DIFF
--- a/components/builder-web/app/package/package-detail/_package-detail.component.scss
+++ b/components/builder-web/app/package/package-detail/_package-detail.component.scss
@@ -2,7 +2,7 @@
 
   h3 {
     font-family: $base-font-family;
-    font-size: 18px;
+    font-size: 16px;
     text-transform: none;
   }
 
@@ -12,7 +12,7 @@
       margin-left: 8px;
       @include icon-size(18);
     }
-    
+
     > div {
       display: flex;
 
@@ -59,11 +59,11 @@
   @include desktop-up {
     .deps {
       display: flex;
-  
+
       .direct-deps {
         flex: 6;
       }
-  
+
       .transitive-deps {
         flex: 6;
       }

--- a/components/builder-web/app/package/package-detail/package-detail.component.html
+++ b/components/builder-web/app/package/package-detail/package-detail.component.html
@@ -1,6 +1,6 @@
 <div class="package-detail-component">
   <h3 *ngIf="fullName">
-    {{ fullName }}
+    <hab-copyable [text]="fullName"></hab-copyable>
   </h3>
   <section class="metadata">
     <dl>

--- a/components/builder-web/app/package/package-detail/package-detail.component.spec.ts
+++ b/components/builder-web/app/package/package-detail/package-detail.component.spec.ts
@@ -43,6 +43,7 @@ describe('PackageDetailComponent', () => {
         MockComponent({ selector: 'hab-platform-icon', inputs: ['platform'] }),
         MockComponent({ selector: 'hab-channels', inputs: ['channels'] }),
         MockComponent({ selector: 'hab-package-list', inputs: ['currentPackage', 'packages'] }),
+        MockComponent({ selector: 'hab-copyable', inputs: ['text', 'style'] })
       ]
     });
 
@@ -74,7 +75,6 @@ describe('PackageDetailComponent', () => {
         return element.query(By.css(`.package-detail-component ${selector}`)).nativeElement.textContent;
       }
 
-      expect(textOf('h3')).toContain('core/nginx');
       expect(textOf('.metadata')).toContain('1.11.10');
       expect(textOf('.metadata')).toContain('20170829004822');
       expect(textOf('.metadata')).toContain('some-checksum');

--- a/components/builder-web/app/package/package-detail/package-detail.component.ts
+++ b/components/builder-web/app/package/package-detail/package-detail.component.ts
@@ -27,13 +27,15 @@ export class PackageDetailComponent {
   }
 
   get fullName() {
-    let ident = this.package['ident'];
-    let name = '';
+    const ident = this.package['ident'];
+    let props = [];
 
-    if (ident.origin && ident.name) {
-      name = `${ident.origin}/${ident.name}`;
-    }
+    ['origin', 'name', 'version', 'release'].forEach(prop => {
+      if (ident[prop]) {
+        props.push(ident[prop]);
+      }
+    });
 
-    return name;
+    return props.join('/');
   }
 }

--- a/components/builder-web/app/package/package-sidebar/package-sidebar.component.html
+++ b/components/builder-web/app/package/package-sidebar/package-sidebar.component.html
@@ -28,11 +28,11 @@
   <ng-container *ngIf="isAService">
     <section>
       <h3>Run Command</h3>
-      <hab-copyable [command]="runCommand"></hab-copyable>
+      <hab-copyable style="input" [text]="runCommand"></hab-copyable>
     </section>
     <section>
       <h3>Export Command</h3>
-      <hab-copyable [command]="exportCommand"></hab-copyable>
+      <hab-copyable style="input" [text]="exportCommand"></hab-copyable>
     </section>
   </ng-container>
 </div>

--- a/components/builder-web/app/package/package-sidebar/package-sidebar.component.spec.ts
+++ b/components/builder-web/app/package/package-sidebar/package-sidebar.component.spec.ts
@@ -47,7 +47,7 @@ describe('PackageSidebarComponent', () => {
       ],
       declarations: [
         PackageSidebarComponent,
-        MockComponent({ selector: 'hab-copyable', inputs: ['command'] }),
+        MockComponent({ selector: 'hab-copyable', inputs: ['style', 'text'] }),
         MockComponent({ selector: 'hab-platform-icon', inputs: ['platform'] })
       ],
       providers: [

--- a/components/builder-web/app/package/package-versions/package-versions.component.html
+++ b/components/builder-web/app/package/package-versions/package-versions.component.html
@@ -24,7 +24,9 @@
           <li class="item" *ngFor="let pkg of packagesFor(version)" (click)="navigateTo(pkg)">
             <a>
               <div class="column name release">
-                <span class="release-name">{{ packageString(pkg) }}</span>
+                <span class="release-name">
+                  <hab-copyable [text]="packageString(pkg)"></hab-copyable>
+                </span>
                 <hab-channels [channels]="pkg.channels"></hab-channels>
                 <hab-package-promote [origin]="pkg.origin" [name]="pkg.name" [version]="pkg.version" [release]="pkg.release" channel="stable"
                   *ngIf="promotable(pkg)"></hab-package-promote>

--- a/components/builder-web/app/package/package-versions/package-versions.component.spec.ts
+++ b/components/builder-web/app/package/package-versions/package-versions.component.spec.ts
@@ -66,7 +66,8 @@ describe('PackageVersionsComponent', () => {
         MockComponent({ selector: 'hab-icon', inputs: ['symbol', 'title'] }),
         MockComponent({ selector: 'hab-platform-icon', inputs: ['platform'] }),
         MockComponent({ selector: 'hab-channels', inputs: ['channels'] }),
-        MockComponent({ selector: 'hab-package-promote', inputs: ['origin', 'name', 'version', 'release', 'channel'] })
+        MockComponent({ selector: 'hab-package-promote', inputs: ['origin', 'name', 'version', 'release', 'channel'] }),
+        MockComponent({ selector: 'hab-copyable', inputs: ['text', 'style'] })
       ],
       providers: [
         { provide: AppStore, useValue: store },

--- a/components/builder-web/app/package/package/package.component.html
+++ b/components/builder-web/app/package/package/package.component.html
@@ -1,5 +1,7 @@
 <header>
-  <h1><hab-package-breadcrumbs [ident]="ident"></hab-package-breadcrumbs></h1>
+  <h1>
+    <hab-package-breadcrumbs [ident]="ident"></hab-package-breadcrumbs>
+  </h1>
   <h2>package</h2>
 </header>
 <nav class="tabs" mat-tab-nav-bar>
@@ -12,8 +14,7 @@
   <a mat-tab-link routerLink="builds" routerLinkActive #jobs="routerLinkActive" [active]="jobs.isActive">
     Build Jobs
   </a>
-  <a mat-tab-link *ngIf="isOriginMember" routerLink="settings" routerLinkActive #settings="routerLinkActive"
-    [active]="settings.isActive">
+  <a mat-tab-link *ngIf="isOriginMember" routerLink="settings" routerLinkActive #settings="routerLinkActive" [active]="settings.isActive">
     Settings
   </a>
 </nav>

--- a/components/builder-web/app/shared/copyable/_copyable.component.scss
+++ b/components/builder-web/app/shared/copyable/_copyable.component.scss
@@ -4,61 +4,77 @@
   $button-width: 40px;
   $button-height: 36px;
 
-  span {
-    display: block;
-    font-weight: 600;
-    padding: 6px 8px;
-    border: $default-border;
-    border-radius: $default-radius 0 0 $default-radius;
-    overflow-x: auto;
-    margin-right: $button-width;
-    white-space: nowrap;
-    height: $button-height;
+  &.input {
+
+    span {
+      display: block;
+      font-weight: 600;
+      padding: 6px 8px;
+      border: $default-border;
+      border-radius: $default-radius 0 0 $default-radius;
+      overflow-x: auto;
+      margin-right: $button-width;
+      white-space: nowrap;
+      height: $button-height;
+    }
+
+    button {
+      position: absolute;
+      padding: 6px 10px 10px 10px;
+      border-radius: 0 $default-radius $default-radius 0;
+      background-color: $very-light-gray;
+      background-image: unset;
+      color: $dark-gray;
+      width: $button-width;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      height: $button-height;
+      vertical-align: middle;
+      display: inline-block;
+      border: none;
+      outline: none;
+
+      &:hover, &:focus {
+        box-shadow: none;
+        background-color: $very-light-gray;
+      }
+
+      hab-icon {
+        @include icon-size(20);
+      }
+    }
   }
 
   button {
-    position: absolute;
-    padding: 6px 10px 10px 10px;
-    border-radius: 0 $default-radius $default-radius 0;
-    background-color: $very-light-gray;
-    background-image: unset;
-    color: $dark-gray;
-    cursor: pointer;
-    width: $button-width;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    height: $button-height;
-    vertical-align: middle;
-    display: inline-block;
     border: none;
+    background-color: transparent;
+    color: $medium-gray;
+    cursor: pointer;
     outline: none;
+    transition: color 200ms;
 
-    &:hover, &:focus {
-      box-shadow: none;
-      background-color: $very-light-gray;
-      color: shade($dark-gray, 20%);
+    &:hover {
+      color: $very-dark-gray;
     }
 
     &.copied {
       color: $hab-green;
     }
+  }
 
-    hab-icon {
-      @include icon-size(20);
-
-      svg {
-        animation: fade 300ms linear;
-      }
+  hab-icon {
+    svg {
+      animation: fade 200ms linear;
     }
+  }
 
-    @keyframes fade {
-      0% {
-        opacity: 0;
-      }
-      100% {
-        opacity: 1;
-      }
+  @keyframes fade {
+    0% {
+      opacity: 0;
+    }
+    100% {
+      opacity: 1;
     }
   }
 }

--- a/components/builder-web/app/shared/copyable/copyable.component.html
+++ b/components/builder-web/app/shared/copyable/copyable.component.html
@@ -1,6 +1,6 @@
-<div class="copyable-component">
-  <span>{{ command }}</span>
-  <button (click)="copy()" [class.copied]="copied" [matTooltip]="title" matTooltipPosition="above">
+<div class="copyable-component" [ngClass]="style">
+  <span>{{ text }}</span>
+  <button (click)="copy($event)" [class.copied]="copied" [matTooltip]="title" matTooltipPosition="above">
     <hab-icon [symbol]="symbol"></hab-icon>
   </button>
 </div>

--- a/components/builder-web/app/shared/copyable/copyable.component.ts
+++ b/components/builder-web/app/shared/copyable/copyable.component.ts
@@ -21,14 +21,17 @@ import { MatTooltip } from '@angular/material';
 })
 export class CopyableComponent {
 
-  @Input() command: string = '';
+  @Input() text: string = '';
+  @Input() style: string = 'unstyled';
 
   public copied: boolean = false;
 
   @ViewChild(MatTooltip)
   tooltip: MatTooltip;
 
-  copy(text) {
+  copy(event) {
+    event.stopPropagation();
+
     let el = document.createElement('input');
 
     Object.assign(el.style, {
@@ -38,7 +41,7 @@ export class CopyableComponent {
     });
 
     document.body.appendChild(el);
-    el.value = this.command;
+    el.value = this.text;
     el.select();
     document.execCommand('copy');
     document.body.removeChild(el);

--- a/components/builder-web/stylesheets/base/_colors.scss
+++ b/components/builder-web/stylesheets/base/_colors.scss
@@ -14,6 +14,7 @@ $light-slate-gray: #dce6ed;
 $medium-gray: #C3C6C8;
 $dim-slate-gray: #7D868E;
 $dark-gray: #5C6670;
+$very-dark-gray: #444;
 
 $hab-red: #EB6852;
 $hab-yellow: #EBE269;


### PR DESCRIPTION
This change adds copy icons to the versions list and manifest views to make it easier to obtain package identifiers in Builder UI.

Signed-off-by: Christian Nunciato <chris@nunciato.org>

![tenor-145101038](https://user-images.githubusercontent.com/274700/33689015-995ab00a-da92-11e7-90ad-678d28c216aa.gif)
