### PR TITLE
Fixes twitter card image for habitat's website

### DIFF
--- a/www/config.rb
+++ b/www/config.rb
@@ -112,7 +112,7 @@ end
 configure :build do
 
   # Asset hash to defeat caching between builds
-  activate :asset_hash
+  activate :asset_hash, :ignore => [/habitat-social.jpg/]
 end
 
 activate :autoprefixer


### PR DESCRIPTION
> Should fix #2941

This ignores `habitat-social.jpg` when adding a hash to assets filenames.

I'm doing this, instead of trying to modify the layout to accommodate the hash automatically because the same image is used in `components/builder-web/index.html` which is not part of the build and will not benefit from that.