### PR TITLE
Skip migrations if BLDR_NO_MIGRATIONS is set.

### DIFF
--- a/support/run-server
+++ b/support/run-server
@@ -23,5 +23,8 @@ if [ "$#" -eq "2" ]; then
   start+=" --config $2"
 fi
 
-eval $migrate
+if [ -z "$BLDR_NO_MIGRATIONS" ]; then
+  eval $migrate
+fi
+
 eval $start


### PR DESCRIPTION
Running migrations is really time consuming and generates a huge amount
of noise. Unless the change you're working on requires adding
migrations, you don't need to run them all the time. Setting this
environment variable lets you skip the migrations completely, resulting
in much faster boot times for the Builder cluster.

![tenor-224610221](https://user-images.githubusercontent.com/947/33694313-4dc1af30-daac-11e7-9b18-6c54a0aee725.gif)

Signed-off-by: Josh Black <raskchanky@gmail.com>