### PR TITLE
Disable integration name check since we removed the db column it was checking

### DIFF
--- a/components/builder-worker/src/runner/util.rs
+++ b/components/builder-worker/src/runner/util.rs
@@ -57,12 +57,6 @@ pub fn validate_integrations(workspace: &Workspace) -> Result<()> {
 
         let prj_integration = prj_integrations.first().unwrap();
 
-        if prj_integration.get_integration_name() != "default" {
-            return Err(Error::InvalidIntegrations(format!(
-                "integration name '{}' not supported",
-                prj_integration.get_integration_name()
-            )));
-        }
         // TODO fn: use a struct and serde to do heavy lifting
         let opts: JsonValue = match serde_json::from_str(prj_integration.get_body()) {
             Ok(json) => json,


### PR DESCRIPTION

![tenor-251163135](https://user-images.githubusercontent.com/1130349/33743596-3197983e-db73-11e7-9dc0-403267e11f27.gif)

Signed-off-by: Travis Elliott Davis <edavis@chef.io>