### PR TITLE
Enable reopening of publish-settings dialog

### DIFF
--- a/components/builder-web/app/shared/checking-input/_checking-input.component.scss
+++ b/components/builder-web/app/shared/checking-input/_checking-input.component.scss
@@ -5,7 +5,7 @@
     position: relative;
 
     input {
-      margin-bottom: $small-margin;
+      margin-bottom: $default-margin;
     }
 
     hab-icon {
@@ -15,20 +15,7 @@
     }
   }
 
-  .validation-message {
-    font-size: $small-font-size;
-    line-height: $small-line-height;
-  }
-
   .spinning {
     color: $waiting;
-  }
-
-  .invalid {
-    color: $error;
-  }
-
-  .valid {
-    color: $success;
   }
 }

--- a/components/builder-web/app/shared/checking-input/checking-input.component.html
+++ b/components/builder-web/app/shared/checking-input/checking-input.component.html
@@ -1,21 +1,13 @@
 <div class="checking-input-component">
   <div class="wrapper">
-    <hab-icon [symbol]="symbolForState(control)"
-      [class.spinning]="control.pending"
-      [class.invalid]="control.dirty && !control.pending && !control.valid"
+    <hab-icon [symbol]="symbolForState(control)" [class.spinning]="control.pending" [class.invalid]="control.dirty && !control.pending && !control.valid"
       [class.valid]="!control.pending && control.valid">
     </hab-icon>
-    <input
-      type="text"
-      [class.loading]="control.pending"
-      autocomplete="off"
-      autofocus="{{autofocus}}"
-      id="{{id}}"
-      [formControl]="form.controls[name]"
+    <input type="text" [class.loading]="control.pending" autocomplete="off" autofocus="{{autofocus}}" id="{{id}}" [formControl]="form.controls[name]"
       placeholder="{{placeholder}}">
   </div>
   <div class="validation-message" *ngIf="control.dirty && !control.pending ">
-    <span *ngIf="!control.valid" class="hab-checking-input--input-msg invalid">
+    <span *ngIf="!control.valid" class="invalid">
       <span *ngIf="control.errors.invalidFormat">
         {{displayName}} {{unmatchedMessage}}
       </span>
@@ -29,7 +21,7 @@
         Cannot be longer than {{maxLength}} characters
       </span>
     </span>
-    <span *ngIf="control.valid" class="hab-checking-input--input-msg valid">
+    <span *ngIf="control.valid" class="valid">
       {{displayName}} {{availableMessage}}
     </span>
   </div>

--- a/components/builder-web/app/shared/docker-export-settings/dialog/docker-export-settings.dialog.html
+++ b/components/builder-web/app/shared/docker-export-settings/dialog/docker-export-settings.dialog.html
@@ -6,7 +6,12 @@
     </section>
     <section class="body">
       <label for="repo_name">Organization and Repository</label>
-      <input type="text" name="repo_name" [(ngModel)]="docker_hub_repo_name" placeholder="{{ repoPlaceholder }}" autocomplete="off">
+
+      <input type="text" name="repo_name" #repo_name="ngModel" [(ngModel)]="docker_hub_repo_name" placeholder="{{ repoPlaceholder }}"
+        autocomplete="off" required>
+      <div class="validation-message" *ngIf="repo_name.dirty && repo_name.invalid && repo_name.errors.required">
+        <span class="invalid">Organization and repository name are required.</span>
+      </div>
       <label for="custom_tag">Custom Tag (Optional)</label>
       <input type="text" name="custom_tag" [(ngModel)]="custom_tag" [placeholder]="'yourtag or \{\{ channel \}\}'" autocomplete="off">
       <label>Additional Tags</label>

--- a/components/builder-web/app/shared/docker-export-settings/docker-export-settings.component.ts
+++ b/components/builder-web/app/shared/docker-export-settings/docker-export-settings.component.ts
@@ -113,6 +113,9 @@ export class DockerExportSettingsComponent implements OnChanges, OnDestroy {
         if (result) {
           this.applySettings(integration, result);
         }
+        else if (!this.settingsFor(integration)) {
+          this.name = null;
+        }
       });
   }
 

--- a/components/builder-web/stylesheets/base/_forms.scss
+++ b/components/builder-web/stylesheets/base/_forms.scss
@@ -115,3 +115,18 @@ select {
 mat-checkbox {
   display: block;
 }
+
+.validation-message {
+  margin-top: -$small-margin;
+  margin-bottom: $default-margin;
+  font-size: $small-font-size;
+  line-height: $small-line-height;
+}
+
+.invalid {
+  color: $error;
+}
+
+.valid {
+  color: $success;
+}


### PR DESCRIPTION
This fixes a bug that prevents reopening the publish-settings dialog after it’s closed without data.

Signed-off-by: Christian Nunciato <chris@nunciato.org>

Fixes #4263.

![tenor-28402023](https://user-images.githubusercontent.com/274700/33751880-c76d6e82-db92-11e7-86c6-635f8dbe9583.gif)