### PR TITLE
updates documentation for builder dev environments with officially su…

### DIFF
--- a/BUILDER_DEV.md
+++ b/BUILDER_DEV.md
@@ -18,7 +18,7 @@ This Dev Environment involves spinning up a virtual machine (most of the core co
 
 ### Pre-Reqs
 
-* Ubuntu 17.10 Desktop Virtual Machine
+* Ubuntu 17.10 Desktop or Ubuntu 17.10 Server Virtual Machine
 * Access to the "core" origin in [Production Builder](https://bldr.habitat.sh). Ask a core maintainer (or in the [Habitat Slack](http://slack.habitat.sh/)) if you do not have access.
 * Access to the Habitat 1Password account (NOTE - we are working on a solution to make this not required, but it is necessary for the time being)
 * All of the following steps should be run within your Virtual Machine

--- a/BUILDER_DEV.md
+++ b/BUILDER_DEV.md
@@ -1,5 +1,9 @@
 # Builder Services Development Environment
 
+## NOTE
+
+This is currently only meant for the Habitat internal team. There is work in progress to support builder dev environments that do not require Habitat internal team secrets - stay tuned!
+
 ## Overview
 
 This document captures the steps to start and run a Builder environment for development. The builder environment includes the builder services, as well as the depot web site.

--- a/BUILDER_DEV.md
+++ b/BUILDER_DEV.md
@@ -24,7 +24,9 @@ This Dev Environment involves spinning up a virtual machine (most of the core co
 * All of the following steps should be run within your Virtual Machine
 * A [Github Personal Access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) with all repo and all user permissions.
 * The [Habitat Builder App](https://github.com/apps/habitat-builder) installed on your Github account.
-* On your VM - remove the "secure_path" section from your sudoers file (this is required for the make scripts to run correctly)
+* Remove the "secure_path" section from your sudoers file (this is required for the make scripts to run correctly)
+* Some of the sample commands below use the 'httpie' tool. Install it if not present on your system (https://github.com/jkbrzt/httpie).
+
 
 ```
 $ sudo sed -i.bak '/secure_path/s/^/#/' /etc/sudoers
@@ -106,12 +108,34 @@ $ sudo -E make bldr-run-no-build
 
 ### Creating an Origin
 
+### Option A: Create an origin using the web UI
+
 * Navigate to http://localhost:3000/#/pkgs
 * Log in
 * You may need to accept the Habitat Builder Dev Githhub app in your Github account.
 * Click on "Create New Origin"
 * Fill out form (call the origin "core"), click "Save & Continue"
 
+### Option B: Create an origin using the command line
+
+1. Create an origin in the DB by issuing the following command:
+
+```
+$ http POST http://localhost:9636/v1/depot/origins Content-Type:application/json Authorization:Bearer:${HAB_AUTH_TOKEN} name=${HAB_ORIGIN}
+```
+
+The response should be something like:
+
+```
+HTTP/1.1 201 Created
+
+{
+"id": 151409091187589122,
+"name": "core",
+"owner_id": "133508078967455744",
+"private_key_name": ""
+}
+```
 ### Install Dependencies in your local Builder Env
 
 * On your VM, go to the production instance of Builder (the one at habitat.sh)

--- a/BUILDER_DEV.md
+++ b/BUILDER_DEV.md
@@ -97,26 +97,6 @@ $ source $HOME/.cargo/env
 $ make build-srv
 ```
 
-* Open up the builder-worker file
-
-```
-$ sudo vim /hab/svc/builder-worker
-```
-
-* Add your Github Auth Key:
-
-**/hab/svc/builder-worker/config.toml**
-```
-auth_token = ""
-```
-
-Should become:
-
-**/hab/svc/builder-worker/config.toml**
-```
-auth_token = "<your github token>"
-```
-
 * Run this command (it may take awhile) to start all the Builder services
 
 ```

--- a/BUILDER_DEV.md
+++ b/BUILDER_DEV.md
@@ -1,134 +1,198 @@
 # Builder Services Development Environment
 
 ## Overview
-This document outlines the steps to start and run a Builder environment for development. The builder environment includes the builder services, as well as the depot web site.
 
-## Pre-Reqs
-1. Use a Linux OS - either native or VM.
-1. Clone the habitat repo to your local filesystem. (If using a VM, you should use the local filesystem for the hab repo instead of using a mounted filesystem, otherwise things may fail later when running services).
-1. The sample commands below use the 'httpie' tool. Install it if not present on your system (https://github.com/jkbrzt/httpie).
-1. A recent version of the habitat cli should also be installed in your dev environment (https://www.habitat.sh/docs/get-habitat/)
-1. Ensure that `sudo -E` functions correctly. Some OSes don't respect the -E flag. If this is the case, remove the `secure_path` section of your sudoers file.
-1. Copy `habitat-builder-dev.2017-10-02.private-key.pem` from 1Password into `/src/.secrets/builder-github-app.pem`
+This document captures the steps to start and run a Builder environment for development. The builder environment includes the builder services, as well as the depot web site.
 
-## Bootstrap the OS with required packages
-You need to make sure you have the required packages installed.
-Run the appropriate shell script under the `support/linux` folder to install the packages.
-Refer to [BUILDING.md](./BUILDING.md) doc for the detailed steps.
+There are several ways of creating a Builder dev environment - but supporting all operating systems and environments has proven to be untenable. This document includes one officially supported way of creating a Builder dev environment, and links to unsupported ways of creating the dev environment that you may use at your own risk.
 
-## Create Builder encryption key pair
-If you haven't already done this earlier, you'll need to create a key pair for builder to encrypt credentials.
-Do this via the `hab user key generate bldr` command. This will generate a key pair with the prefix `bldr`
-in your local `hab/cache/keys` directory. Copy the key pair over to some location that is accessible by the running services.
-You will need to specify that location in the config files below.
+Eventually, we will want to harness the power of the Habitat studio to automate a builder dev environment, but this serves as a stop gap for now.
 
-## Create configuration files
-Some capabilities (such as allowing builder permissions, and turning on auto-building when new packages are uploaded to the depot) require passing in a custom config to the Builder services.
+## Officially Supported Dev Environment
 
-Create the following files somewhere on your local filesystem:
+This Dev Environment involves spinning up a virtual machine (most of the core contributors use VMWare, but Virtual Box should work as well) running Ubuntu 17.10 desktop.
 
-`config_api.toml`
-```toml
-[depot]
-path = "/hab/svc/builder-api/data"
-key_dir = "/path/to/bldr-key-pair"
+### Pre-Reqs
+
+* Ubuntu 17.10 Desktop Virtual Machine
+* Access to the "core" origin in [Production Builder](https://bldr.habitat.sh). Ask a core maintainer (or in the [Habitat Slack](http://slack.habitat.sh/)) if you do not have access.
+* Access to the Habitat 1Password account
+* All of the following steps should be run within your Virtual Machine
+* A [Github Personal Access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) with all repo and all user permissions.
+* The [Habitat Builder App](https://github.com/apps/habitat-builder) installed on your Github account.
+* Open your Sudoers file at /etc/sudoers and remove the "secure_path" section (this is required for the make scripts to run correctly)
+
+### Builder Setup
+* Update your system
+```
+$ sudo apt-get update
 ```
 
-`config_jobsrv.toml`
-```toml
-key_dir = "/path/to/bldr-key-pair"
-
-[archive]
-backend = "local"
-local_dir = "/tmp"
+* Install git
+```
+$ sudo apt-get install git
 ```
 
-`config_sessionsrv.toml`
-```toml
-[permissions]
-admin_team = 1995301
-build_worker_teams = [2555389]
-early_access_teams = [1995301]
+* Clone the [Habitat repo](https://github.com/habitat-sh/habitat)
+```
+$ git clone https://github.com/habitat-sh/habitat.git
 ```
 
-`config_worker.toml`
-```toml
+* Install the [Habitat CLI](https://www.habitat.sh/docs/get-habitat/)
+* Copy habitat-builder-dev.2017-10-02.private-key.pem from 1Password into path/to/habitat/repo/.secrets/builder-github-app.pem
+* Set up some environmental variables (I put these in my .bashrc)
+
+```
+export HAB_AUTH_TOKEN="<your github token>"
+export HAB_BLDR_URL="http://localhost:9636"
+export HAB_ORIGIN="core"
+```
+
+* symlink /src to path/to/your/habitat/repo
+
+```
+$ sudo ln -s ~/habitat /src
+```
+
+* Cd into your Habitat repo
+
+```
+$ cd path/to/your/habitat/repo
+```
+
+* Run the provision script
+
+```
+$ sudo ./support/linux/provision.sh
+```
+
+* After the script completes, source cargo/rust
+```
+$ source $HOME/.cargo/env
+```
+
+* Run the build-srv makefile (NOTE - if you receive an error about cargo not being found, make sure you have removed the "secure_path" section of /etc/sudoers)
+
+```
+$ sudo make build-srv
+```
+
+* Open up the builder-worker file
+
+```
+$ sudo vim /hab/svc/builder-worker
+```
+
+* Add your Github Auth Key:
+
+**/hab/svc/builder-worker**
+```
+auth_token = ""
+```
+
+Should become:
+
+**/hab/svc/builder-worker**
+```
 auth_token = "<your github token>"
-bldr_url = "http://localhost:9636"
-auto_publish = true
-airlock_enabled = false
 ```
 
-
-(Note: If you want your log files to persist across restarts of your development machine, replace `/tmp` with some other directory. It *must* exist and be writable before you start the job server).
-
-Now, modify the `Procfile` (located in your hab repo in the `support` folder) to point the api, sessionsrv, jobsrv and worker services to the previously created config files, e.g.
+* Run this command (it may take awhile) to start all the Builder services
 
 ```
-api: target/debug/bldr-api start --config /home/your_alias/habitat/config_api.toml
-sessionsrv: target/debug/bldr-sessionsrv start --config /home/your_alias/habitat/config_sessionsrv.toml
-worker: target/debug/bldr-worker start --config /home/your_alias/habitat/config_worker.toml
-jobsrv: target/debug/bldr-jobsrv start --config /home/your_alias/habitat/config_jobsrv.toml
+$ sudo -E make bldr-run
 ```
 
-## Build the Builder services for the first time
-1. Open a new terminal window.
-1. Run `make build-srv`
+### UI Setup
 
-Note: this only needs to be done the first time to get the pieces in place. If you clean the project, make sure to unset the variables show below when you do a clean build, otherwise the build will look for packages on your local build service!
-
-## Run the Builder services
-1. Open a new terminal window.
-1. Export the following environment variables:
+* Open a separate shell on your VM
+* Install npm
 
 ```
-export HAB_AUTH_TOKEN=<your github token>
-export HAB_BLDR_URL=http://localhost:9636
-export HAB_ORIGIN=<your origin>
+$ sudo apt-get install npm
 ```
 
-Now run `sudo -E make bldr-run` from the root of your hab repo.
+* Cd into the builder-web component
 
-The first time this command runs, it will create the required databases. Let it run for a while, and then re-start it if there are errors (this is normal for the first time setup).
+```
+$ cd path/to/your/habitat/repo/components/builder-web
+```
 
-When `make bldr-run` can proceed with all the services up and running, you are ready to proceed to the next step.
+* Install all dependencies
 
-## Create your origin
-There are a couple of ways to do this.
+```
+$ npm install
+```
 
-### From the command line
-1. Open a new terminal window.
-1. Export the `HAB_ORIGIN` and `HAB_AUTH_TOKEN` as above
-1. Create an origin in the DB by issuing the following command:
+* Create the habitat.conf.js file
 
-    ```
-    http POST http://localhost:9636/v1/depot/origins Content-Type:application/json Authorization:Bearer:${HAB_AUTH_TOKEN} name=${HAB_ORIGIN}
-    ```
+```
+$ cp habitat.conf.sample.js habitat.conf.js
+```
 
-    The response should be something like:
+* Start the UI
 
-    ```
-    HTTP/1.1 201 Created
+```
+$ sudo npm start
+```
 
-    {
-        "id": 151409091187589122,
-        "name": "core",
-        "owner_id": "133508078967455744",
-        "private_key_name": ""
-    }
-    ```
+* Open up a browser and navigate to http://localhost:3000/#/pkgs - you should see the Habitat UI running locally.
 
-### In the browser
-The `make bldr-run` command you ran above also starts the Builder Web UI, which should be listening on port 3000. If that process is running in a container or VM, and you've forwarded port 3000 to your host, you should be able to browse to http://localhost:3000/#/pkgs, sign in with GitHub, and click My Origins in the sidebar to create an origin.
+### Creating an Origin
 
-## Import origin keys to Builder
-This can be done via the Builder Web UI. Make sure you have both the public and private keys available for your origin.
+* Navigate to http://localhost:3000/#/pkgs
+* Log in
+* Click on "Create New Origin"
+* Fill out form (call the origin "core"), click "Save & Continue"
+* Click on "Keys"
+* Download the public and private key
+* Copy the public key contents
+* From a terminal, run
 
-The web UI should be running at http://localhost:3000/#/pkgs. (If you need to bring up the UI at a different address or port, please refer to the builder-web [README](./components/builder-web/README.md) for setting up a custom OAuth app).
+```
+$ hab origin key import
+```
 
-1. Log into the web UI via your GitHub account
-1. Go to the origins page, and select your origin
-1. Go to the keys tab, and follow the instructions for uploading the public and private keys.
+* Paste the public key contents
+* Hit Ctrl + D twice to close the stream
+* Run this again:
+
+```
+$ hab origin key import
+```
+
+* Paste the private key contents
+* Hit Ctrl + D twice to close the stream
+
+### Install Dependencies in your local Builder Env
+
+* on your VM, go to the production instance of Builder (the one at habitat.sh)
+* Click on "My origins"
+* Click on "core"
+* Download public and private keys for the "core" origin (make sure the timestamp on the public key matches the one on the private key!) - we currently need the keys for the core production origin in order to upload some dependencies to our local Builder env)
+* From a terminal, run
+
+```
+$ hab origin key import
+```
+
+* Paste the production core origin public key contents
+* Hit Ctrl + D twice
+* Run this again:
+
+```
+$ hab origin key import
+```
+
+* Paste the production core origin private key contents
+* Hit Ctrl + D twice
+* Run
+```
+$ hab install core/hab-backline
+$ cd /hab/cache/artifacts
+$ hab pkg upload -c stable core-hab-backline...hart
+```
+* You will need to follow this same process for any dependencies of anything you want to build locally - the sample app I will use below depends on [core/scaffolding-node](https://bldr.habitat.sh/#/pkgs/core/scaffolding-node/latest), [core/git](https://bldr.habitat.sh/#/pkgs/core/git/latest), [core/node](https://bldr.habitat.sh/#/pkgs/core/node/latest), [core/busybox-static](https://bldr.habitat.sh/#/pkgs/core/busybox-static/latest) - so I will follow the same procedure to download them from production builder, then upload them to my local builder.
 
 ## Create the project(s) you want to build
 In order to build a package, there needs to be a project created in the database.
@@ -159,48 +223,44 @@ Note: the `installation_id` above is for the Habitat Builder Dev app, and the
 `repo_id` is for the 'core-plans' repo.
 
 1. Issue the following command:
-
-    ```
-    http POST http://localhost:9636/v1/projects Authorization:Bearer:${HAB_AUTH_TOKEN} < project.json
-    ```
+	```
+	http POST http://localhost:9636/v1/projects Authorization:Bearer:${HAB_AUTH_TOKEN} < project.json
+	```
 
 The response should be something like this:
 
-    ```
-    HTTP/1.1 201 Created
+	```
+	HTTP/1.1 201 Created
 
-    {
-        "id": "730634033288978462",
-        "name": "core/nginx",
-        "origin_id": "730632763933204510",
-        "origin_name": "core",
-        "owner_id": "730632479777497215",
-        "package_name": "nginx",
-        "plan_path": "nginx/plan.sh",
-        "vcs_data": "https://github.com/habitat-sh/core-plans.git",
-        "vcs_type": "git"
-    }
-    ```
-
-Repeat the above steps for any other projects that you want to build.
-
-## Upload any dependent packages to disk
-
-During a build, the hab studio will look to download dependent packages from
-your local machine. If the package metadata is present, but the on-disk
-archive is not accessible, the builds will fail.
-
-Make sure you do a `hab pkg upload` to your environment
-```
-export HAB_BLDR_URL=http://localhost:9636/v1/depot
-hab pkg upload <package>
-```
-
-You can get the packages from the production or acceptance environments
-by pointing `HAB_BLDR_URL` to https://app.habitat.sh or
-http://app.acceptance.habitat.sh, and then doing a ```hab pkg install <package>```.
+	{
+	"id": "730634033288978462",
+	"name": "core/nginx",
+	"origin_id": "730632763933204510",
+	"origin_name": "core",
+	"owner_id": "730632479777497215",
+	"package_name": "nginx",
+	"plan_path": "nginx/plan.sh",
+	"vcs_data": "https://github.com/habitat-sh/core-plans.git",
+	"vcs_type": "git"
+	}
+	```
 
 ## Run a build
+
+### Option A: From the Web UI
+* Navigate to http://localhost:3000/#/pkgs
+* If you are not already logged in, log in.
+* Click on "My origins"
+* Click on "core"
+* Click on the package you wish to build
+* Click on "Latest"
+* Click on "Build latest version"
+* Click on "Build Jobs" and "View the output" to see the job in progress
+* The job should complete successfully! Congrats, you have a working build!
+
+
+
+### Option B: From the Command Line
 
 Issue the following command (replace `core/nginx` with your origin and package names):
 
@@ -216,184 +276,90 @@ You should see a response similar to the following:
 HTTP/1.1 201 Created
 
 {
-    "created_at": "",
-    "id": "0",
-    "name": "nginx",
-    "origin": "core",
-    "state": "Pending"
+"created_at": "",
+"id": "0",
+"name": "nginx",
+"origin": "core",
+"state": "Pending"
 }
 ```
 
-## Habitat Studio Based Development Environment
-This will start everything to run builder in a studio except the web app.
+## Unsupported Dev Environments
 
-#### Prerequisites
-1. Ensure you have a copy of the [package archive](http://nunciato-shared-files.s3.amazonaws.com/pkgs.zip) in the habitat directory
-1. Copy `habitat-builder-dev.2017-10-02.private-key.pem` from 1Password into `/src/.secrets/builder-github-app.pem`
+Maintainers have historically been able to use alternative development environment setups. If you would like to explore using other OS's or Docker or Vagrant - please check out these links. **Do remember that these are NOT officially supported by the Habitat maintainers - use at your own risk!**
 
-#### Notes for OS X
-* Enusre you have direnv installed and configured
-* The `.envrc` file will override several Habitat environment variables based on what is in your `cli.toml` file
+* [Other Operating Systems](BUILDING.md)
+* [Container Dev Environment](BUILDER_CONTAINER.md)
 
-#### Notes for Vagrant VM
-* `cd /vagrant`
-* `direnv allow`
+## General build notes
 
-1. `hab studio enter` (This will download and install and start the builder service)
-1. `sl` Wait until you see the origin service start
-1. `origin`
-1. `keys`
-1. `load_packages`
+- Once make has finished, executables will exist in `/src/target/debug/foo`,
+  where `foo` is the name of an executable (`hab`, `hab-sup`, `hab-depot`,
+  etc).
+- Executable names are specified in each components `Cargo.toml` file in a TOML
+  table like this:
+    ```
+	  [[bin]]
+	  name = "hab-depot"
+    ````
 
-### Web development
-This is a great environment to use for development on builder-web. Just make sure you're running builder-web locally.
-Everything should follow the [standard web setup](https://github.com/habitat-sh/habitat/tree/master/components/builder-web#builder-web).
-## Other Commands
-Here are some other sample commands to experiment with:
+## Windows build notes
 
-* Package Search:
-`http GET http://localhost:9636/v1/depot/pkgs/search/foo Authorization:Bearer:${HAB_AUTH_TOKEN}
-`
-* Scheduling:
-`
-http POST http://localhost:9636/v1/depot/pkgs/schedule/core/nginx Authorization:Bearer:${HAB_AUTH_TOKEN}
-`
-* Get Scheduled Group status:
-`
-http GET http://localhost:9636/v1/depot/pkgs/schedule/15986865821137185538 Authorization:Bearer:${HAB_AUTH_TOKEN}
-`
-* Retrieve Secret Keys:
-`
-http GET http://app.acceptance.habitat.sh/v1/depot/origins/core/secret_keys/latest Authorization:Bearer:${HAB_AUTH_TOKEN}
-`
-* Retrieve Channels:
-`
-http GET http://localhost:9636/v1/depot/channels/core Authorization:Bearer:${HAB_AUTH_TOKEN}
-`
-* List Channel Packages:
-`
-http GET http://localhost:9636/v1/depot/channels/core/unstable/pkgs Authorization:Bearer:${HAB_AUTH_TOKEN}
-`
-* Promote Package:
-`http PUT http://localhost:9636/v1/depot/channels/core/unstable/pkgs/hab/0.18.0/20170302204108/promote Authorization:Bearer:${HAB_AUTH_TOKEN}
-`
-* Upload a Package:
-`
-http POST http://localhost:9636/v1/depot/pkgs/core/nginx/version/release Authorization:Bearer:${HAB_AUTH_TOKEN}
-`
-or
-`
-hab pkg upload -u http://localhost:9636/v1/depot ./core-hab-0.18.0-20170302204108-x86_64-darwin.hart
-`
-* Look up origin users
-`
-http GET http://localhost:9636/v1/depot/origins/core/users Authorization:Bearer:${HAB_AUTH_TOKEN}
-`
+The `-configure` switch will make sure you have all the necessary dependencies to build the `hab` CLI tool, including Rust, the Visual Studio Build Tools, and all the native dependencies.
 
-## Troubleshooting
-1. If you get the following error when building, check to make sure you have imported the origin keys, and that the `HAB_BLDR_URL` export was done correctly in the terminal session that ran `make bldr-run`:
-`ERROR:habitat_builder_worker::runner: Unable to retrieve secret key, err=[404 Not Found]`
+Not all crates have been fully ported to Windows.
 
-1. If you get a build failing with a `401 Unauthorized`, make sure the builder worker is pointed to a valid Github token (via a config.toml in the Procfile)
+Currently the `hab` command will build (as well as the dependent crates).
 
-1. If you get a `NOSPC` error when starting depot UI, see the following:
-http://stackoverflow.com/questions/22475849/node-js-error-enospc
+Work is in progress on the Supervisor and other parts of the toolchain.
 
-1. If you get a `404 Not Found` error during a build, make sure that you
-have uploaded any dependent packages locally.
+# Running all builder components
 
+Run this command:
 ```
-hab-studio: Destroying Studio at /tmp/739078532143013888/studio (unknown)
-hab-studio: Creating Studio at /tmp/739078532143013888/studio (default)
-hab-studio: Importing core secret origin key
-» Importing origin key from standard input
-★ Imported secret origin key core-20160810182414.
-» Installing core/hab-backline
-✗✗✗
-✗✗✗ [404 Not Found]
-✗✗✗
+make bldr-run
 ```
 
-### Postgres troubleshooting:
-1. If you are not able to connect at all, check the `pg_hba.conf` file in `/hab/svc/postgresql` or `/hab/svc/postgres/config`.
-Add the following line if not present to see if it resolves your issue:
-    ```
-    local all all trust
-    ```
+# Building and running individual components
 
-1. If you are not seeing any persistent data in the DB, check the `user.toml` file in `/hab/svc/postgresql`. Make sure the search_path is not set to `pg_temp` (the DB tests create this setting explicitly in order to set the DB to be in ephemeral mode for each connection, so that it resets after every test).
+When you are working on an individual component in the /components directory, you may wish to build, install, then use that individual component.
 
-1. If Postgres is not starting with `make bldr-run`, see if you can start it in a separate terminal windows with `hab start core/postgresql` or `sudo hab start core/postgresql`
+Let's say you want to do this with the Supervisor (which lives in the components/sup directory).
 
-1. In order to connect to Postgres (to examine the DB, etc), you can do the following from a separate terminal window (the version and release portions of the path may be different):
-    ```
-    su - hab
-    /hab/pkgs/core/postgresql/9.6.1/20170215221136/bin/psql -h 127.0.0.1 <db_name>
-    ```
-1. If Postgres dies when you run `make bldr-run` with an error message that
-   says `WARNING: out of shared memory`, edit the `postgresql.conf` file in
-   `/hab/pkgs/core/postgresql/$VERSION/$RELEASE/config` and add
-   `max_locks_per_transaction=128` to it.
+## Building
 
-### Node troubleshooting
+Change directories into the component you want to build
 
-If you are seeing an error similar to this:
+```
+cd components/sup
+```
 
-   ```
-      web.1       | /home/nell/habitat/support/builder_web.sh: line 38: ./node_modules/.bin/lite-server: No such file or directory
-   ```
+Then run
 
-Check what version of node that builder-web expects
+```
+cargo build
+```
 
-   ```
-     cd components/builder-web
-     cat .nvmrc
-   ```
+Once it is finished compiling, you can find the new build in root hab_repo/target/debug
 
-Then check which one you are running:
+Head back to the root of the Habitat repo
 
-   ```
-     node -v
-   ```
+```
+cd ../..
+```
 
-If they are not the same, then you will need to run nvm install within the components/builder-web directory.
+And you will find your build in target/debug
 
-   ```
-     nvm install
-   ```
+If you built the sup component, this is where you would find the new build
 
-If you get this error "No command 'nvm' found, did you mean:", you will need to re-run your $HOME/.nvm/nvm.sh script
+```
+target/debug/hab-sup
+```
 
-   ```
-     $HOME/.nvm/nvm.sh
-   ```
+## Running
 
-Then try running builder again
+You can now run this newly built component with
 
-   ```
-     make bldr-run
-   ```
-
-If you see errors along these lines:
-
-   ```
-	web.1       | npm ERR! npm  v2.15.1
-	web.1       | npm ERR! file sh
-	web.1       | npm ERR! code ELIFECYCLE
-	web.1       | npm ERR! errno ENOENT
-	web.1       | npm ERR! syscall spawn
-	web.1       | npm ERR! habitat@0.8.0 build: `concurrently "npm run build-js" "npm run build-css"`
-	web.1       | npm ERR! spawn ENOENT
-	web.1       | npm ERR!
-	web.1       | npm ERR! Failed at the habitat@0.8.0 build script 'concurrently "npm run build-js" "npm run build-css"'.
-	web.1       | npm ERR! This is most likely a problem with the habitat package,
-	web.1       | npm ERR! not with npm itself.
-   ```
-
-Then you will need to remove your node_modules directory, then run npm install:
-
-   ```
-     cd path/to/habitat/repo/components/builder-web
-     rm -rf node_modules
-     npm install
-   ```
+```
+./target/debug/hab-sup
+```

--- a/BUILDER_DEV.md
+++ b/BUILDER_DEV.md
@@ -24,7 +24,7 @@ This Dev Environment involves spinning up a virtual machine (most of the core co
 * All of the following steps should be run within your Virtual Machine
 * A [Github Personal Access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) with all repo and all user permissions.
 * The [Habitat Builder App](https://github.com/apps/habitat-builder) installed on your Github account.
-* On your VM - Open your Sudoers file at /etc/sudoers and remove the "secure_path" section (this is required for the make scripts to run correctly)
+* On your VM - remove the "secure_path" section from your sudoers file (this is required for the make scripts to run correctly)
 
 ```
 $ sudo sed -i.bak '/secure_path/s/^/#/' /etc/sudoers
@@ -83,11 +83,6 @@ $ cd path/to/your/habitat/repo
 
 ```
 $ sudo ./support/linux/provision.sh
-```
-
-* After the script completes, source cargo/rust
-```
-$ source $HOME/.cargo/env
 ```
 
 * Run the build-srv makefile (NOTE - if you receive an error about cargo not being found, make sure you have removed the "secure_path" section of /etc/sudoers)

--- a/BUILDER_DEV.md
+++ b/BUILDER_DEV.md
@@ -153,25 +153,6 @@ $ sudo npm start
 * Log in
 * Click on "Create New Origin"
 * Fill out form (call the origin "core"), click "Save & Continue"
-* Click on "Keys"
-* Download the public and private key
-* Copy the public key contents
-* From a terminal, run
-
-```
-$ hab origin key import
-```
-
-* Paste the public key contents
-* Hit Ctrl + D twice to close the stream
-* Run this again:
-
-```
-$ hab origin key import
-```
-
-* Paste the private key contents
-* Hit Ctrl + D twice to close the stream
 
 ### Install Dependencies in your local Builder Env
 

--- a/BUILDER_DEV.md
+++ b/BUILDER_DEV.md
@@ -16,11 +16,15 @@ This Dev Environment involves spinning up a virtual machine (most of the core co
 
 * Ubuntu 17.10 Desktop Virtual Machine
 * Access to the "core" origin in [Production Builder](https://bldr.habitat.sh). Ask a core maintainer (or in the [Habitat Slack](http://slack.habitat.sh/)) if you do not have access.
-* Access to the Habitat 1Password account
+* Access to the Habitat 1Password account (NOTE - we are working on a solution to make this not required, but it is necessary for the time being)
 * All of the following steps should be run within your Virtual Machine
 * A [Github Personal Access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) with all repo and all user permissions.
 * The [Habitat Builder App](https://github.com/apps/habitat-builder) installed on your Github account.
 * Open your Sudoers file at /etc/sudoers and remove the "secure_path" section (this is required for the make scripts to run correctly)
+
+```
+$ sudo visudo -f /etc/sudoers
+```
 
 ### Builder Setup
 * Update your system
@@ -33,13 +37,18 @@ $ sudo apt-get update
 $ sudo apt-get install git
 ```
 
+* Install curl
+```
+$ sudo apt-get install curl
+```
+
 * Clone the [Habitat repo](https://github.com/habitat-sh/habitat)
 ```
 $ git clone https://github.com/habitat-sh/habitat.git
 ```
 
 * Install the [Habitat CLI](https://www.habitat.sh/docs/get-habitat/)
-* Copy habitat-builder-dev.2017-10-02.private-key.pem from 1Password into path/to/habitat/repo/.secrets/builder-github-app.pem
+* Copy habitat-builder-dev.2017-10-02.private-key.pem from 1Password into path/to/habitat/repo/.secrets/builder-github-app.pem (NOTE - this is required as of 12/11/17 - we are working on a solution to make access to the Habitat 1Password vault not required for dev environment setup).
 * Set up some environmental variables (I put these in my .bashrc)
 
 ```
@@ -51,7 +60,7 @@ export HAB_ORIGIN="core"
 * symlink /src to path/to/your/habitat/repo
 
 ```
-$ sudo ln -s ~/habitat /src
+$ sudo ln -s path/to/your/habitat/repo /src
 ```
 
 * Cd into your Habitat repo
@@ -85,14 +94,14 @@ $ sudo vim /hab/svc/builder-worker
 
 * Add your Github Auth Key:
 
-**/hab/svc/builder-worker**
+**/hab/svc/builder-worker/config.toml**
 ```
 auth_token = ""
 ```
 
 Should become:
 
-**/hab/svc/builder-worker**
+**/hab/svc/builder-worker/config.toml**
 ```
 auth_token = "<your github token>"
 ```

--- a/BUILDER_DEV.md
+++ b/BUILDER_DEV.md
@@ -151,14 +151,18 @@ $ sudo -E make bldr-run-no-build
 * Click on "My origins"
 * Click on "core"
 * Download the public key for the "core" origin
-* From a terminal, run
+* Next, install the public key for the core origin on the Production builder (the one at habitat.sh). You need this in order to upload some packages to your local builder.
 
 ```
-$ hab origin key import
-```
+$ hab origin key import <<EOT
+SIG-PUB-1
+core-20160810182414
 
-* Paste the production core origin public key contents
-* Hit Ctrl + D twice
+vQqVVhUTW9ABKzoi9W+LP14GL2MrYRmL8FGETjwNANQ=
+EOT
+```
+(This core public key is current as of 12/18/2017)
+
 * Run
 ```
 $ sudo hab install core/hab-backline

--- a/BUILDER_DEV.md
+++ b/BUILDER_DEV.md
@@ -47,17 +47,11 @@ $ sudo sed -i.bak '/deb cdrom/s/^/#/g' /etc/apt/sources.list
 $ sudo apt-get install git
 ```
 
-* Install curl
-```
-$ sudo apt-get install curl
-```
-
 * Clone the [Habitat repo](https://github.com/habitat-sh/habitat)
 ```
 $ git clone https://github.com/habitat-sh/habitat.git
 ```
 
-* Install the [Habitat CLI](https://www.habitat.sh/docs/get-habitat/)
 * Copy habitat-builder-dev.2017-10-02.private-key.pem from 1Password into path/to/habitat/repo/.secrets/builder-github-app.pem (NOTE - this is required as of 12/11/17 - we are working on a solution to make access to the Habitat 1Password vault not required for dev environment setup).
 * Set up some environmental variables (I put these in my .bashrc)
 

--- a/BUILDER_DEV.md
+++ b/BUILDER_DEV.md
@@ -24,7 +24,7 @@ This Dev Environment involves spinning up a virtual machine (most of the core co
 * All of the following steps should be run within your Virtual Machine
 * A [Github Personal Access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) with all repo and all user permissions.
 * The [Habitat Builder App](https://github.com/apps/habitat-builder) installed on your Github account.
-* Open your Sudoers file at /etc/sudoers and remove the "secure_path" section (this is required for the make scripts to run correctly)
+* On your VM - Open your Sudoers file at /etc/sudoers and remove the "secure_path" section (this is required for the make scripts to run correctly)
 
 ```
 $ sudo sed -i.bak '/secure_path/s/^/#/' /etc/sudoers
@@ -96,6 +96,14 @@ $ source $HOME/.cargo/env
 $ make build-srv
 ```
 
+* Note: If you receive an error along the lines of "error: failed to load source for a dependency on `urlencoded`", you will need to change the owner of the ~/.cargo/ directory from root to your VM username.
+
+i.e. - if your username is jbauman:
+
+```
+$ sudo chown -R jbauman:jbauman /home/jbauman/.cargo/
+```
+
 * Open up the builder-worker file
 
 ```
@@ -142,7 +150,7 @@ $ sudo -E make bldr-run-no-build
 * On your VM, go to the production instance of Builder (the one at habitat.sh)
 * Click on "My origins"
 * Click on "core"
-* Download public and private keys for the "core" origin (make sure the timestamp on the public key matches the one on the private key!) - we currently need the keys for the core production origin in order to upload some dependencies to our local Builder env)
+* Download the public key for the "core" origin
 * From a terminal, run
 
 ```
@@ -150,14 +158,6 @@ $ hab origin key import
 ```
 
 * Paste the production core origin public key contents
-* Hit Ctrl + D twice
-* Run this again:
-
-```
-$ hab origin key import
-```
-
-* Paste the production core origin private key contents
 * Hit Ctrl + D twice
 * Run
 ```

--- a/BUILDER_DEV.md
+++ b/BUILDER_DEV.md
@@ -82,21 +82,19 @@ $ cd path/to/your/habitat/repo
 * Run the provision script
 
 ```
-$ sudo ./support/linux/provision.sh
+$ ./support/linux/provision.sh
+```
+
+* Source cargo
+
+```
+$ source $HOME/.cargo/env
 ```
 
 * Run the build-srv makefile (NOTE - if you receive an error about cargo not being found, make sure you have removed the "secure_path" section of /etc/sudoers)
 
 ```
 $ make build-srv
-```
-
-* Note: If you receive an error along the lines of "error: failed to load source for a dependency on `urlencoded`", you will need to change the owner of the ~/.cargo/ directory from root to your VM username.
-
-i.e. - if your username is jbauman:
-
-```
-$ sudo chown -R jbauman:jbauman /home/jbauman/.cargo/
 ```
 
 * Open up the builder-worker file

--- a/BUILDER_DEV.md
+++ b/BUILDER_DEV.md
@@ -168,8 +168,7 @@ $ hab pkg upload -c stable core-hab-backline...hart
 
 * NOTE - if you receive this error: "No auth token specified" - make sure you have set HAB_AUTH_TOKEN="<your github token>"  in your environment.z:
 * NOTE - if you receive this error: "No such file or directory (os error 2)" It means that the public key from bldr.habitat.sh (that corresponds to the private key the hart file was signed with) wasn't installed.
-
-* You will need to follow this same process for any dependencies of anything you want to build locally - the sample app I will use below depends on [core/scaffolding-node](https://bldr.habitat.sh/#/pkgs/core/scaffolding-node/latest), [core/git](https://bldr.habitat.sh/#/pkgs/core/git/latest), [core/node](https://bldr.habitat.sh/#/pkgs/core/node/latest), [core/busybox-static](https://bldr.habitat.sh/#/pkgs/core/busybox-static/latest) - so I will follow the same procedure to download them from production builder, then upload them to my local builder.
+* You will need to follow this same process for any dependencies of anything you want to build locally
 
 ## Create the project(s) you want to build
 In order to build a package, there needs to be a project created in the database.
@@ -278,7 +277,7 @@ Maintainers have historically been able to use alternative development environme
     ```
 	  [[bin]]
 	  name = "hab-depot"
-    ````
+    ```
 
 ## Windows build notes
 

--- a/BUILDER_DEV.md
+++ b/BUILDER_DEV.md
@@ -156,7 +156,7 @@ EOT
 
 * Run
 ```
-$ sudo hab install core/hab-backline
+$ sudo hab install core/hab-backline --url https://bldr.habitat.sh
 $ cd /hab/cache/artifacts
 $ hab pkg upload -c stable core-hab-backline...hart
 ```
@@ -253,6 +253,12 @@ HTTP/1.1 201 Created
 "origin": "core",
 "state": "Pending"
 }
+```
+
+Additionally, you could also run
+
+```
+$ hab bldr job start core/nginx
 ```
 
 ## Unsupported Dev Environments

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,5 +1,11 @@
 # Building Habitat from source
 
+## Not officially supported
+
+**These setups are NOT officially supported by the Habitat maintainers - use at your own risk!**
+
+**The officially supported setup can be found in the [Builder Dev](BUILDER_DEV.md) file.**
+
 ## Mac OS X for Linux Development
 
 These install instructions assume you want to develop, build, and run the
@@ -240,77 +246,4 @@ git clone https://github.com/habitat-sh/habitat.git
 
 cd habitat
 ./build.ps1 components/hab -configure
-```
-
-
-## General build notes
-
-- Once make has finished, executables will exist in `/src/target/debug/foo`,
-  where `foo` is the name of an executable (`hab`, `hab-sup`, `hab-depot`,
-  etc).
-- Executable names are specified in each components `Cargo.toml` file in a TOML
-  table like this:
-
-	  [[bin]]
-	  name = "hab-depot"
-
-## Windows build notes
-
-The `-configure` switch will make sure you have all the necessary dependencies to build the `hab` CLI tool, including Rust, the Visual Studio Build Tools, and all the native dependencies.
-
-Not all crates have been fully ported to Windows.
-
-Currently the `hab` command will build (as well as the dependent crates).
-
-Work is in progress on the Supervisor and other parts of the toolchain.
-
-# Running all builder components
-
-Run this command:
-```
-make bldr-run
-```
-
-# Building and running individual components
-
-When you are working on an individual component in the /components directory, you may wish to build, install, then use that individual component.
-
-Let's say you want to do this with the Supervisor (which lives in the components/sup directory).
-
-## Building
-
-Change directories into the component you want to build
-
-```
-cd components/sup
-```
-
-Then run
-
-```
-cargo build
-```
-
-Once it is finished compiling, you can find the new build in root hab_repo/target/debug
-
-Head back to the root of the Habitat repo
-
-```
-cd ../..
-```
-
-And you will find your build in target/debug
-
-If you built the sup component, this is where you would find the new build
-
-```
-target/debug/hab-sup
-```
-
-## Running
-
-You can now run this newly built component with
-
-```
-./target/debug/hab-sup
 ```

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ $ curl https://raw.githubusercontent.com/habitat-sh/habitat/master/components/ha
 
 ## Contribute
 
-We are always looking for more opportunities for community involvement. Interested in contributing? Check out our [CONTRIBUTING.md](CONTRIBUTING.md) to get started! 
+We are always looking for more opportunities for community involvement. Interested in contributing? Check out our [CONTRIBUTING.md](CONTRIBUTING.md) to get started!
 
 ## Documentation
 
@@ -73,7 +73,7 @@ The Habitat plans that are built and maintained by Habitat's Core Team are in [t
 
 ### Habitat Supervisor, Builder, and other core components
 
-The code for the Habitat Supervisor, Builder, and other core components are in the [components directory](https://github.com/habitat-sh/habitat/tree/master/components). 
+The code for the Habitat Supervisor, Builder, and other core components are in the [components directory](https://github.com/habitat-sh/habitat/tree/master/components).
 
 ### Web Application
 
@@ -85,15 +85,19 @@ Habitat's website and documentation source is located in the `www` directory of 
 
 ## Roadmap
 
-The Habitat project's roadmap is public and is on our [community page](https://www.habitat.sh/community/). 
+The Habitat project's roadmap is public and is on our [community page](https://www.habitat.sh/community/).
 
 The Habitat core team's project tracker is also public and on [Github.](https://github.com/habitat-sh/habitat/projects/1)
 
-## Community and support 
+## Community and support
 
 * [Habitat Slack](http://slack.habitat.sh)
 * [Forums]()
 * Community triage is every Tuesday at 10am Pacific. The link to participate is shared in the [Habitat Slack channel](http://slack.habitat.sh), and videos are posted on the [Habitat YouTube channel](https://youtube.com/channel/UC0wJZeP2dfPZaDUPgvpVpSg).
+
+## Builder Dev Env
+
+See [BUILDER_DEV.md](BUILDER_DEV.md) for information on setting up a Builder Dev Environment
 
 ## Building
 See [BUILDING.md](BUILDING.md) for platform specific info on building Habitat from source.


### PR DESCRIPTION
…pported path

I want to start off this pull request with yes, we should automate this process and harness the habitat studio to do so.  That has not been done yet, though, and there is enormous pain associated with setting up a Builder Dev environment in the meantime.  This documentation is meant to be a stop gap until we have a better dev environment setup - it provides one, officially supported path that definitely works right now.  People are free to use other setups at their own risk, but this provides a "happy path" - one way which will work.

There are definitely more improvements we can make to this process - I think some of the scripts need some additions - but again, this documentation is supposed to capture the state of setting up a builder dev environment right now.

When #4161 is complete - which provides a vagrant setup - we should discuss whether we want to officially support that workflow, or include it as another "at your own risk" workflow, I am open to either.

Signed-off-by: Nell Shamrell <nellshamrell@gmail.com>