### PR TITLE
Report the correct number of packages to be loaded

### DIFF
--- a/components/builder-web/app/initial-state.ts
+++ b/components/builder-web/app/initial-state.ts
@@ -216,6 +216,7 @@ export default Record({
     visible: List(),
     versions: undefined,
     nextRange: 0,
+    perPage: 50,
     searchQuery: '',
     totalCount: 0,
     ui: Record({

--- a/components/builder-web/app/origin/origin-page/origin-packages-tab/origin-packages-tab.component.html
+++ b/components/builder-web/app/origin/origin-page/origin-packages-tab/origin-packages-tab.component.html
@@ -36,9 +36,9 @@
       </ul>
       <div *ngIf="packages.size < totalCount">
         Showing {{packages.size}} of {{totalCount}} packages.
-        <a href="#" (click)="fetchMorePackages()">
-          Load {{(totalCount - packages.size) > perPage ? perPage : totalCount - packages.size }} more
-        </a>.
+        <a (click)="fetchMorePackages()">
+          Load {{(totalCount - packages.size) > perPage ? perPage : totalCount - packages.size }} more.
+        </a>
       </div>
     </section>
   </div>

--- a/components/builder-web/app/origin/origin-page/origin-packages-tab/origin-packages-tab.component.ts
+++ b/components/builder-web/app/origin/origin-page/origin-packages-tab/origin-packages-tab.component.ts
@@ -15,6 +15,7 @@
 import { Component } from '@angular/core';
 import { Router } from '@angular/router';
 import { AppStore } from '../../../app.store';
+import { getUniquePackages } from '../../../actions/index';
 
 @Component({
   selector: 'hab-origin-packages-tab',
@@ -37,6 +38,10 @@ export class OriginPackagesTabComponent {
     return this.store.getState().packages.ui.visible;
   }
 
+  get perPage() {
+    return this.store.getState().packages.perPage;
+  }
+
   get projectsUi() {
     return this.store.getState().projects.ui.visible;
   }
@@ -53,8 +58,22 @@ export class OriginPackagesTabComponent {
     return this.store.getState().packages.visible;
   }
 
+  get token() {
+    return this.store.getState().session.token;
+  }
+
+  get totalCount() {
+    return this.store.getState().packages.totalCount;
+  }
+
   get noPackages() {
     return (!this.packagesUi.exists || this.packages.size === 0) && !this.packagesUi.loading;
+  }
+
+  fetchMorePackages() {
+    this.store.dispatch(
+      getUniquePackages(this.origin, this.store.getState().packages.nextRange, this.token)
+    );
   }
 
   saved(project) {

--- a/components/builder-web/app/origin/origin-page/origin-page.component.ts
+++ b/components/builder-web/app/origin/origin-page/origin-page.component.ts
@@ -102,13 +102,4 @@ export class OriginPageComponent implements OnInit, OnDestroy {
   getPackages() {
     this.store.dispatch(getUniquePackages(this.origin.name, 0, this.token));
   }
-
-  fetchMorePackages() {
-    this.store.dispatch(getUniquePackages(
-      this.origin.name,
-      this.store.getState().packages.nextRange,
-      this.token
-    ));
-    return false;
-  }
 }

--- a/components/builder-web/app/search/search/_search.component.scss
+++ b/components/builder-web/app/search/search/_search.component.scss
@@ -26,9 +26,5 @@
 
   .more {
     margin-top: $default-margin;
-
-    a {
-      cursor: pointer;
-    }
   }
 }

--- a/components/builder-web/app/search/search/search.component.ts
+++ b/components/builder-web/app/search/search/search.component.ts
@@ -71,6 +71,10 @@ export class SearchComponent implements OnInit, OnDestroy {
     return this.store.getState().packages.visible;
   }
 
+  get perPage() {
+    return this.store.getState().packages.perPage;
+  }
+
   get searchQuery() {
     return this.store.getState().packages.searchQuery;
   }

--- a/components/builder-web/stylesheets/base/_base.scss
+++ b/components/builder-web/stylesheets/base/_base.scss
@@ -109,6 +109,7 @@ hr {
 }
 
 a {
+  cursor: pointer;
   color: $hab-green;
   text-decoration: none;
   transition: color 0.2s;


### PR DESCRIPTION
This fixes a bug in the paging of search results and origin packages stemming from missing values (`totalCount` and `perPage` in both cases).

Signed-off-by: Christian Nunciato <chris@nunciato.org>

![tenor-212188356](https://user-images.githubusercontent.com/274700/33790980-6e2b0dc2-dc3a-11e7-83b3-42f0ad2c753c.gif)
