### PR TITLE
Add a blog about the ChefConf CFP

### DIFF
--- a/www/data/author_bios.yml
+++ b/www/data/author_bios.yml
@@ -37,7 +37,7 @@ authors:
     name: "Tasha Drew"
     email: "tasha@habitat.sh"
     twitter: "@tashadrew"
-    bio: "Product @ [habitat.sh](https://www.habitat.sh/), previously of Rentlytics & Engine Yard."
+    bio: "Product @ <a href=\"https://www.habitat.sh/\">habitat.sh</a>, previously of Rentlytics & Engine Yard."
   mattwrock:
     name: "Matt Wrock"
     email: "mwrock@habitat.sh"
@@ -57,7 +57,7 @@ authors:
     name: "Nathen Harvey"
     email: "nharvey@chef.io"
     twitter: "@nathenharvey"
-    bio: "Nathen Harvey, VP of Community Development at Chef, helps the community whip up an awesome ecosystem built around the Chef platform. Nathen also spends much of his time helping people learn about the practices, processes, and technologies that support DevOps, continuous delivery, and high velocity organizations. Nathen is a co-host of the Food Fight Show, a podcast about Chef and DevOps.  He is also an occasional farmer who loves eggs and actively supports #hugops."
+    bio: "Nathen Harvey, VP of Community Development at Chef, helps the community create and adopt tools and processes for Continuous Automation and building communities. He is focused on the community and ecosystem around Chef, Habitat, and InSpec. Nathen is a co-host of the <a href=\"http://foodfightshow.org\">Food Fight Show</a>, a podcast about Chef and DevOps. He is also an occasional <a href=\"http://ei.chef.io\">farmer</a> who loves <a href=\"http://eggs.chef.io\">eggs</a> and <a href=\"http://hugops.chef.io\">#hugops</a>."
   irvingpopovetsky:
     name: "Irving Popovetsky"
     email: "irving@chef.io"

--- a/www/source/blog/2017-04-11-Hello-World.html.md
+++ b/www/source/blog/2017-04-11-Hello-World.html.md
@@ -21,7 +21,7 @@ title: Hello World!
 date: 2017-04-11
 author: Ian Henry
 tags: community
-category: Community
+category: community
 classes: body-article
 ---
 ```

--- a/www/source/blog/2017-12-11-chefconf-2018-cfp.html.md
+++ b/www/source/blog/2017-12-11-chefconf-2018-cfp.html.md
@@ -1,0 +1,82 @@
+---
+title: ChefConf 2018 CFP - Application Automation Track
+date: 2017-12-11
+author: Nathen Harvey
+tags: community, events, ChefConf
+category: community
+classes: body-article
+---
+ChefConf is the largest Chef community reunion and educational event for teams on the journey to becoming fast, efficient, and innovative software-driven organizations. In other words, you and your team!
+
+[ChefConf 2018](https://chefconf.chef.io/) will take place May 23-26 in Chicago, Illinois and we want you to present! [The ChefConf call for presenters (CFP) is now open](https://chefconf.chef.io/cfp/).
+
+ChefConf will cover topics across the entire Chef ecosystem.  This includes [Chef Automate](https://www.chef.io/automate/), [Chef](https://www.chef.io/chef/), [InSpec](https://www.inspec.io/), and, of course, [Habitat](https://www.habitat.sh/)!
+
+One of the tracks you might consider proposing a session for is the Automation Automation track.
+
+## Application Automation
+
+The cries for digital and cultural transformation can be heard from every corner of the business world. Everyday technologists are becoming more concerned with delivering customer and business value. How are your teams empowered to deliver this value to production? Teams are adopting the tooling and practices necessary embrace cloud-native technologies, move into the brave new world of containers, orchestrations, cloud infrastructure, and serverless solutions. In the meantime, some legacy applications are being lifted out of the data center and shifted to the cloud. Habitat is a simple, flexible way to build, deploy, and manage modern distributed applications.
+
+Application automation is the term we use to describe the processes used to build, deploy, and manage these applications.
+
+Share your story of using Habitat and related technologies to manage the lifecycle of your team's applications. Below are some ideas and questions to consider.
+
+### Understanding distributed systems
+
+Topologies, service discovery, consistency, availability, partitioning, and more! Working with distributed systems means learning about new concepts and terms. The Habitat ecosystem addresses many of these concerns making it easier to implement and leverage them within applications.
+
+* What does everyone getting started with distributed systems need to know?
+* How does Habitat address and enable each of these concepts?
+* Can you demonstrate how your application uses one or more of these?
+
+### Containers, containers, containers!
+
+Containers provide many benefits to modern application teams. Being able to run the same artifact in many different environments simplifies delivery pipelines, increases confidence, and allows teams to deliver value faster. But containers alone may not be enough. Scaling out containers and running production workloads often requires additional technologies like a container scheduler or platform as a service. Habitat provides the capability to export artifacts into a number of different formats including Docker images, Cloud Foundry images, and more. Using the Habitat builder service, you can automatically publish these containers to Docker Hub or Amazon's Container Registry.
+
+* How has Habitat's application-first approach changed your container build process? The size and shape of your container?
+* How are you understanding the provenance and lineage of your containers? In other words, “what's in the container?”
+* Which export formats are you utilizing for Habitat? Why and how?
+* What container orchestrators, schedulers, or platforms are you utilizing? Why and how?
+* Have you considered building a custom export format? What formats would you add? How would you approach building that?
+
+### A better habitat for ...
+
+Many applications frameworks have mature notions of packaging applications. Java applications, for example, are often packaged as .jar or .war files that are ready to be run inside of a java runtime. In other frameworks, such as Ruby on Rails, the idea of building an artifact is foreign to most of the community. Habitat allows you to create packages and simplify the deployment and management of any application framework. Not everything we build or run is an application framework, either. What about persistent data stores or other services?
+
+* Share your story of packing specific application frameworks with Habitat (Java, Rails, Node, PHP, Python, etc).
+* Share your story of packaging and running distributed databases with Habitat (PostgreSQL, MySQL, MongoDB, etc).
+* How has a common packaging format impacted your delivery platforms across various application frameworks?
+
+### Putting the “Dev” in DevOps
+
+The word “DevOps” has always started with “Dev” yet many participants in the community have a deep background in operations.  Habitat aims to bring better automation capabilities to developers and make the DevOps tent larger so that everyone has a place. This also means more and closer collaboration between teams!
+
+* How is Habitat impacting your development process?
+* How has Habitat improved collaboration between dev and ops?
+* As a developer, what are the things you love, or hate, about Habitat?
+
+### Getting Started
+
+Application automation with Habitat is a relatively new practice and the tools available are quickly evolving. How are you getting started with Habitat? Have you started with core packages or are you building your own? You do not need to be an expert to help others get started. Your experiences getting started with Habitat are worth sharing, even if as cautionary tales. ChefConf is a great place to help fellow community members get started on the right foot.
+
+* What do you wish you knew when you first got started?
+* How are you helping people across your organization get started with application automation?
+* Which use cases are well-suited for getting started with application automation?
+
+### Other Tracks
+
+The ChefConf CFP is open for the following tracks:
+
+* [Infrastructure Automation](https://blog.chef.io/2017/11/21/chefconf-2018-cfp-infrastructure-automation-track/)
+* [Compliance Automation](https://blog.chef.io/2017/11/29/chefconf-2018-cfp-compliance-automation-track/)
+* Application Automation
+* People, Process, and Team
+* Delivering Delight
+* Chaos Engineering
+* Don't Label Me!
+* Share Your Story
+
+Your story and experiences are worth sharing with the community. Help others learn and further your own knowledge through sharing. The ChefConf CFP is open now. Use some of the questions posed here to help form a talk proposal for the application automation track.
+
+[Submit your talk proposal now](https://chefconf.chef.io/cfp/)! The deadline is Wednesday, January 10, 2018 at 11:59 PM Pacific time.

--- a/www/source/stylesheets/_blog.scss
+++ b/www/source/stylesheets/_blog.scss
@@ -144,6 +144,11 @@ a.icon-back {
     height: 2px;
     background-image: linear-gradient(to right, rgba(86,111,132, 0), rgba(86,111,132, 0.75), rgba(86,111,132, 0));
   }
+
+  a {
+    color: $hab-white;
+    text-decoration: underline;
+  }
 }
 
 .article-detail--footer {


### PR DESCRIPTION
This adds a blog post about submitting talks to the application
automation track of the ChefConf CFP.

It also includes a few related updates:

* Update bio for Nathen Harvey
* Fix link in @tashimi's bio
* Fix color of hyperlinks in blog bios

Additionally, blog categories should be lower case

Update the example code in the Hello World to reflect lower case
category names

Signed-off-by: Nathen Harvey <nharvey@chef.io>