### PR TITLE
Miscellaneous TravisCI updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,9 @@ env:
 matrix:
   include:
 
+# Testing Jobs
+########################################################################
+
 #
 # Job for testing Habitat Rust program components
 #
@@ -140,6 +143,9 @@ matrix:
         - ./support/ci/rust_tests.sh
         - ./support/ci/lint.sh
 
+# Web Jobs
+########################################################################
+
 #
 # Job for testing Builder Web components
 #
@@ -195,13 +201,19 @@ matrix:
       before_install: ./support/ci/fast_pass.sh || exit 0
       script: ./support/ci/deploy_website.sh
 
+
+# Packaging / Release Jobs
+########################################################################
+
 #
 # Job for building and publishing Habitat Linux release packages
 #
     - env:
-        # These components will build as Habitat packages in the provided order
-        - COMPONENTS="hab-butterfly hab plan-build backline bintray-publish studio sup"
-        - AFFECTED_DIRS="\.travis\.yml|\.bldr\.toml|support/ci/deploy\.sh|Cargo\.toml|Cargo\.lock|VERSION|components/backline|components/bintray-publish|components/plan-build|components/studio|$_RUST_HAB_BIN_COMPONENTS|$_RUST_HAB_LIB_COMPONENTS"
+        # These Habitat packages will build in the provided order; do
+        # *not* change this order unless you are very sure of what you
+        # are doing! (The dependencies among this group of packages are
+        # sometimes implicit.)
+        - PACKAGES="hab-butterfly hab hab-plan-build hab-backline hab-bintray-publish hab-studio hab-sup"
         # HAB_AUTH_TOKEN
         - secure: "OCq9oDAEP3Cc0BiGrnZHE0FoNdyqsAy2LPTwEoOKvgiZdrw5o2bvpN1Kl+DKpw2auKtkeAS1aVSE/CMrglxrDs+VolvK9ttW3kj8c7+AeuCYjBsyWqdnZ1/24u6P+20fKanYrsMsnFb2r9OWwxZVlFnfmks81LWToOlGFJpL5KnmSPrB2vlWPbiaH9+yg8aslrmCq0reSoSVSnoZHoTolWtjzx2WdPYqA4gu0HHASVbH5qP+PoQSGIWvwbBaU4xhwkp1K8rWCjI8lre2YpBMOdfZv+9arMjc3Xg/kgD9oGU9DN7Q3UzAWxTSJv/3Cm4LArwiI57rXMLDKf8N1MhvGMHP1xgbuN8JWFKqFuWpqCf6qJkYG8+VZkruKYOo/2tXtBY4hpbR2abcWvYU/S9AQFHKGJQ2vcArnp5SKO+Oq/fNVneeHli4RbGMRQCMVq+X0SSC148F0zEVVwkNM5eq4askfc/2y4asySrH0MT/5T3yBp8fr3zXpnj82h2ytCZOUs0o+La9+wt5gSDUJHdY/BwSSPrgnKSp7ixslM/g7lMy3nAOs6qLql8/vW543CXBurCACWTqwKcy3/wRparTkmZcs1d7vUrbcfYv7XJzh0pw2P1hCjWD9BtkowbuLVo8K9ndPl2rbFY9XljqFXMTcHxp4ETeCc23azHCs+SYFb0="
         # HAB_ORIGIN_KEY
@@ -220,6 +232,7 @@ matrix:
             - ca-certificates
             - curl
             - wget
+            - jq
       cache:
         apt: true
         cargo: true
@@ -228,8 +241,8 @@ matrix:
           - /hab/studios/home--travis--build--habitat-sh
           - /root/.cargo
       before_install:
-        - ./support/ci/fast_pass.sh || exit 0
         - ./support/ci/only_master_or_release.sh || exit 0
+        - sudo ./support/ci/install_rq.sh
         - if [[ ! -x ./support/ci/deploy.sh ]]; then chmod +x ./support/ci/deploy.sh; fi
         - openssl aes-256-cbc -K $encrypted_50e90ce07941_key -iv $encrypted_50e90ce07941_iv -in ./support/ci/habitat-srv-admin.enc -out /tmp/habitat-srv-admin -d
       script:
@@ -239,9 +252,8 @@ matrix:
 # Job for building and publishing Habitat exporter release packages
 #
     - env:
-        # These components will build as Habitat packages in the provided order
-        - COMPONENTS="pkg-aci pkg-cfize pkg-export-docker pkg-export-kubernetes pkg-mesosize pkg-tarize"
-        - AFFECTED_DIRS="\.travis\.yml|\.bldr\.toml|support/ci/deploy\.sh|Cargo\.toml|Cargo\.lock|VERSION|components/pkg-aci|components/pkg-cfize|components/pkg-mesosize|components/pkg-tarize|components/pkg-export-docker|components/pkg-export-kubernetes|$_RUST_HAB_LIB_COMPONENTS"
+        # These Habitat packages will build in the provided order
+        - PACKAGES ="hab-pkg-aci hab-pkg-cfize hab-pkg-export-docker hab-pkg-export-kubernetes hab-pkg-mesosize hab-pkg-tarize"
         # HAB_AUTH_TOKEN
         - secure: "OCq9oDAEP3Cc0BiGrnZHE0FoNdyqsAy2LPTwEoOKvgiZdrw5o2bvpN1Kl+DKpw2auKtkeAS1aVSE/CMrglxrDs+VolvK9ttW3kj8c7+AeuCYjBsyWqdnZ1/24u6P+20fKanYrsMsnFb2r9OWwxZVlFnfmks81LWToOlGFJpL5KnmSPrB2vlWPbiaH9+yg8aslrmCq0reSoSVSnoZHoTolWtjzx2WdPYqA4gu0HHASVbH5qP+PoQSGIWvwbBaU4xhwkp1K8rWCjI8lre2YpBMOdfZv+9arMjc3Xg/kgD9oGU9DN7Q3UzAWxTSJv/3Cm4LArwiI57rXMLDKf8N1MhvGMHP1xgbuN8JWFKqFuWpqCf6qJkYG8+VZkruKYOo/2tXtBY4hpbR2abcWvYU/S9AQFHKGJQ2vcArnp5SKO+Oq/fNVneeHli4RbGMRQCMVq+X0SSC148F0zEVVwkNM5eq4askfc/2y4asySrH0MT/5T3yBp8fr3zXpnj82h2ytCZOUs0o+La9+wt5gSDUJHdY/BwSSPrgnKSp7ixslM/g7lMy3nAOs6qLql8/vW543CXBurCACWTqwKcy3/wRparTkmZcs1d7vUrbcfYv7XJzh0pw2P1hCjWD9BtkowbuLVo8K9ndPl2rbFY9XljqFXMTcHxp4ETeCc23azHCs+SYFb0="
         # HAB_ORIGIN_KEY
@@ -255,6 +267,7 @@ matrix:
             - ca-certificates
             - curl
             - wget
+            - jq
       cache:
         apt: true
         cargo: true
@@ -263,8 +276,8 @@ matrix:
           - /hab/studios/home--travis--build--habitat-sh
           - /root/.cargo
       before_install:
-        - ./support/ci/fast_pass.sh || exit 0
         - ./support/ci/only_master_or_release.sh || exit 0
+        - sudo ./support/ci/install_rq.sh
         - if [[ ! -x ./support/ci/deploy.sh ]]; then chmod +x ./support/ci/deploy.sh; fi
         - openssl aes-256-cbc -K $encrypted_50e90ce07941_key -iv $encrypted_50e90ce07941_iv -in ./support/ci/habitat-srv-admin.enc -out /tmp/habitat-srv-admin -d
       script:
@@ -274,7 +287,6 @@ matrix:
 # Job for building and publishing Habitat Mac release packages
 #
     - env:
-        - COMPONENTS="hab"
         - AFFECTED_DIRS="\.travis\.yml|\.bldr\.toml|support/ci/deploy\.sh|Cargo\.toml|Cargo\.lock|VERSION|components/hab|$_RUST_HAB_LIB_COMPONENTS"
         # HAB_ORIGIN_KEY
         - secure: "uZ70GE8qK3GBgs7ZIsoy5DhPlHNs2hoLxLBGKq+u+0XrE017pOnW6mNHsn7J7i2r8CPtd4KFsFEN52wZSA+Sf96MFIL2w9E+geykBgbRMZzv4icuCf0xSGwm4iRMgZ9A08TfurMX6y6N+4JNsrCv9syVNuGq09EL2wLHPXOQhesMpodijQLcFikxfEXXbaWla1xHnYxJk+fbvYDoXVCbdqnpdeLTmGuQHFaaNI7jm1B3L/dl+IGZxwFdvqBT3G9mHiXBdyi8bALs7rcZNdV7PqtFFpp98zIeqwNHtHPd5cBRmqDRTRxucRSACS/lurrz9J+001a9RjPvUkYlLrn0hQY9pN6oo+kCpN/1r0bc17i4FbGx7R73FnFgPK/cno0ENBFygNZn7/jg6cENgjkBlHsZhc1+L1xhILo46nQU9XbWJrwelVYUOOGXI76tECOkGhkglx1vYK8fcMVLJMhL7psgPpbGbDJQDuAKhHS+75txNK+356ompNL+YUzeWZc4KSGZCNTQsPK+rsGttmA+JXtAaquFaY5xwSgyKHwETiSVg4dYXb3xh6goNxf2JTOZOosWaypyykHqcqsqCu2fzIDdmkgCx6I5/5q8I/7Z0es0jlUpHamlihZwe4E5YdYFCSouaDoeTnVdJKVI1p9fnAjpFqjivFgqLE/Z504vCNU="

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ branches:
     - /^test_development-.*$/
     - /^\d+\.\d+\.\d+$/
 
+os: linux
+
 env:
   global:
     - PATH=$HOME/.cargo/bin:$PATH
@@ -24,8 +26,7 @@ matrix:
 #
 # Job for testing Habitat Rust program components
 #
-    - os: linux
-      language: rust
+    - language: rust
       env:
         - COMPONENTS=bin
         - AFFECTED_DIRS="$_RUST_HAB_BIN_COMPONENTS|$_RUST_HAB_LIB_COMPONENTS"
@@ -66,8 +67,7 @@ matrix:
 #
 # Job for testing Habitat  and Builder Rust crate components
 #
-    - os: linux
-      language: rust
+    - language: rust
       env:
         - COMPONENTS=lib
         - AFFECTED_DIRS="$_RUST_HAB_LIB_COMPONENTS|$_RUST_BLDR_LIB_COMPONENTS"
@@ -105,8 +105,7 @@ matrix:
 #
 # Job for testing Builder Rust program components
 #
-    - os: linux
-      language: rust
+    - language: rust
       env:
         - COMPONENTS=srv
         - AFFECTED_DIRS="$_RUST_BLDR_BIN_COMPONENTS|$_RUST_BLDR_LIB_COMPONENTS"
@@ -144,8 +143,7 @@ matrix:
 #
 # Job for testing Builder Web components
 #
-    - os: linux
-      language: node_js
+    - language: node_js
       node_js: 8.7.0
       sudo: false
       env:
@@ -174,8 +172,7 @@ matrix:
 #
 # Job for building and deploying the web site
 #
-    - os: linux
-      language: ruby
+    - language: ruby
       rvm: 2.3.1
       sudo: false
       cache:
@@ -201,8 +198,7 @@ matrix:
 #
 # Job for building and publishing Habitat Linux release packages
 #
-    - os: linux
-      env:
+    - env:
         # These components will build as Habitat packages in the provided order
         - COMPONENTS="hab-butterfly hab plan-build backline bintray-publish studio sup"
         - AFFECTED_DIRS="\.travis\.yml|\.bldr\.toml|support/ci/deploy\.sh|Cargo\.toml|Cargo\.lock|VERSION|components/backline|components/bintray-publish|components/plan-build|components/studio|$_RUST_HAB_BIN_COMPONENTS|$_RUST_HAB_LIB_COMPONENTS"
@@ -242,8 +238,7 @@ matrix:
 #
 # Job for building and publishing Habitat exporter release packages
 #
-    - os: linux
-      env:
+    - env:
         # These components will build as Habitat packages in the provided order
         - COMPONENTS="pkg-aci pkg-cfize pkg-export-docker pkg-export-kubernetes pkg-mesosize pkg-tarize"
         - AFFECTED_DIRS="\.travis\.yml|\.bldr\.toml|support/ci/deploy\.sh|Cargo\.toml|Cargo\.lock|VERSION|components/pkg-aci|components/pkg-cfize|components/pkg-mesosize|components/pkg-tarize|components/pkg-export-docker|components/pkg-export-kubernetes|$_RUST_HAB_LIB_COMPONENTS"
@@ -278,8 +273,7 @@ matrix:
 #
 # Job for building and publishing Habitat Mac release packages
 #
-    - os: linux
-      env:
+    - env:
         - COMPONENTS="hab"
         - AFFECTED_DIRS="\.travis\.yml|\.bldr\.toml|support/ci/deploy\.sh|Cargo\.toml|Cargo\.lock|VERSION|components/hab|$_RUST_HAB_LIB_COMPONENTS"
         # HAB_ORIGIN_KEY

--- a/support/ci/deploy.sh
+++ b/support/ci/deploy.sh
@@ -13,14 +13,6 @@ CHANNEL=unstable
 
 export HAB_ORIGIN=core
 
-# fail fast if we aren't on the desired branch or if this is a pull request
-if [ -n "$TRAVIS_BRANCH" || -n "$TRAVIS_PULL_REQUEST" ]; then
-  if  [[ "${TRAVIS_BRANCH}" != "$HAB_VERSION" && ("${TRAVIS_PULL_REQUEST}" != "false" || "${TRAVIS_BRANCH}" != "master") ]]; then
-      echo "We only publish on successful builds of master."
-      exit 0
-  fi
-fi
-
 if [ "$HAB_VERSION" == "$TRAVIS_TAG" ]; then
   BINTRAY_REPO=stable
   CHANNEL=rc-$HAB_VERSION

--- a/support/ci/deploy.sh
+++ b/support/ci/deploy.sh
@@ -8,15 +8,33 @@ BOOTSTRAP_DIR=/root/travis_bootstrap
 TEST_BIN_DIR=/root/hab_bins
 TRAVIS_HAB=${BOOTSTRAP_DIR}/hab
 HAB_DOWNLOAD_URL="https://api.bintray.com/content/habitat/stable/linux/x86_64/hab-%24latest-x86_64-linux.tar.gz?bt_package=hab-x86_64-linux"
-BINTRAY_REPO=unstable
-CHANNEL=unstable
 
 export HAB_ORIGIN=core
 
-if [ "$HAB_VERSION" == "$TRAVIS_TAG" ]; then
-  BINTRAY_REPO=stable
-  CHANNEL=rc-$HAB_VERSION
-  export HAB_BLDR_CHANNEL=$CHANNEL
+if [ "${HAB_VERSION}" == "${TRAVIS_TAG}" ]; then
+    IS_RELEASE_BUILD=1
+fi
+
+if [ -n "${IS_RELEASE_BUILD}" ]; then
+    # We'll upload to the stable repo, but not *publish* until we've
+    # validated it
+    BINTRAY_REPO=stable
+
+    # Similarly, we'll promote Habitat packages to a release-specific
+    # channel; once we've validated them outside of Travis, we'll
+    # promote to stable
+    CHANNEL="rc-${HAB_VERSION}"
+
+    # By exporting this, package builds will preferentially pull in
+    # dependencies from this release. For dependencies that aren't
+    # part of the release, Habitat will fall back to the stable
+    # channel by design.
+    export HAB_BLDR_CHANNEL="${CHANNEL}"
+else
+    # Not a release build, just a normal build from the master
+    # branch. It's all unstable, all the time.
+    BINTRAY_REPO=unstable
+    CHANNEL=unstable
 fi
 
 mkdir -p ${BOOTSTRAP_DIR}
@@ -43,42 +61,98 @@ fi
 
 rm ./core.sig.key
 
-COMPONENTS=($COMPONENTS)
-for component in "${COMPONENTS[@]}"
+PACKAGES=($PACKAGES)
+for package in "${PACKAGES[@]}"
 do
-  echo "--> Clearing any pre-exisiting $HAB_ORIGIN secret keys from the Studio"
-  env HAB_ORIGIN= ${TRAVIS_HAB} studio run sh -c \'rm -f /hab/cache/keys/*-*.sig.key\'
+  # Always build the package if it's a release; otherwise, only build a
+  # package if there are relevant code changes.
+  if [ -n "${IS_RELEASE_BUILD}" ] || ./support/ci/should_we_build.sh "${package}" ; then
 
-  echo "--> Building $component"
-  ${TRAVIS_HAB} studio run HAB_CARGO_TARGET_DIR=/src/target build components/${component}
+     echo "Building ${package}..."
 
-  source ./results/last_build.env
-  HART="./results/$pkg_artifact"
-  ${TRAVIS_HAB} pkg install $HART
+     echo "--> Clearing any pre-exisiting $HAB_ORIGIN secret keys from the Studio"
+     env HAB_ORIGIN= ${TRAVIS_HAB} studio run sh -c \'rm -f /hab/cache/keys/*-*.sig.key\'
 
-  # once we have built the stuio, switch over to bits built here
-  if [[ "${component}" == "studio" ]]; then
-    TRAVIS_HAB=$(find /hab/pkgs/core/hab -type f -name hab | tail -1)
-  elif [[ "${component}" == "hab" ]]; then
-    RELEASE="${HART}_keep"
-    cp $HART $RELEASE
+     # The names of the Habitat packages we create are often different
+     # from the directories in which they reside; specifically, we
+     # often add the prefix "hab-" to the name of the package, but
+     # leave this off of the directory for ease of navigation. Here,
+     # we normalize this.
+     if [ -d "components/${package}" ]; then
+         directory_name=${package}
+     else
+         truncated_name=${package##hab-}
+         if [ -d "components/${truncated_name}" ] ; then
+             directory_name=${truncated_name}
+         else
+             echo "Cannot find code directory for package '${package}' after looking in the following locations:"
+             echo
+             echo "    components/${package}"
+             echo "    components/${truncated_name}"
+             echo
+             exit 1
+         fi
+     fi
+
+     ${TRAVIS_HAB} studio run HAB_CARGO_TARGET_DIR=/src/target build components/${directory_name}
+
+     source ./results/last_build.env
+     HART="./results/$pkg_artifact"
+     ${TRAVIS_HAB} pkg install $HART
+
+     # Once we have built the studio, switch over to bits built here
+     if [[ "${package}" == "hab-studio" ]]; then
+         # Marker variable that indicates we have a studio artifact to upload.
+         PUBLISH_HAB_STUDIO=true
+         # We switch the Hab binary we use here, rather than when we
+         # build the hab package, because the version of hab
+         # determines the version of the studio we use. Thus, we have
+         # to wait to make the switch until there is a studio artifact
+         # for us to use.
+         TRAVIS_HAB=$(find /hab/pkgs/core/hab -type f -name hab | tail -1)
+     elif [[ "${package}" == "hab" ]]; then
+         HAB_RELEASE_ARTIFACT="${HART}_keep"
+         cp $HART $HAB_RELEASE_ARTIFACT
+     fi
+
+     if [ -n "$HAB_AUTH_TOKEN" ]; then
+         ${TRAVIS_HAB} pkg upload $HART --channel $CHANNEL
+     fi
+
+     rm $HART
+  else
+     echo "Skipping build of ${package}; no relevant code changes"
   fi
-
-  if [ -n "$HAB_AUTH_TOKEN" ]; then
-    ${TRAVIS_HAB} pkg upload $HART --channel $CHANNEL
-  fi
-
-  rm $HART
 done
+
 echo "--> Removing origin secret keys from Studio"
 env HAB_ORIGIN= ${TRAVIS_HAB} studio run sh -c \'rm -f /hab/cache/keys/*-*.sig.key\'
 
 if [ -n "$BINTRAY_USER" ]; then
-  echo "Publishing hab to $BINTRAY_REPO"
-  env  HAB_BLDR_CHANNEL=$CHANNEL ${TRAVIS_HAB} pkg exec core/hab-bintray-publish publish-studio
-  if [ "$HAB_VERSION" == "$TRAVIS_TAG" ]; then
-    env  HAB_BLDR_CHANNEL=$CHANNEL ${TRAVIS_HAB} pkg exec core/hab-bintray-publish publish-hab -s -r $BINTRAY_REPO $RELEASE
-  else
-    env  HAB_BLDR_CHANNEL=$CHANNEL ${TRAVIS_HAB} pkg exec core/hab-bintray-publish publish-hab -r $BINTRAY_REPO $RELEASE
+  if [ ! -d "/hab/pkgs/core/hab-bintray-publish" ] ; then
+      # If we didn't build core/hab-bintray-publish and subsequently
+      # install it on this run (which is possible on master branch
+      # builds), let's ensure that we can still publish things to
+      # Bintray, shall we?
+      echo "Installing core/hab-bintray-publish from Builder..."
+      ${TRAVIS_HAB} pkg install core/hab-bintray-publish
+  fi
+
+  # On 'master' branch builds, we might not build hab-studio. Only
+  # publish if we do.
+  if [ -n "${PUBLISH_HAB_STUDIO}" ]; then
+      echo "Publishing hab-studio to Bintray"
+      env HAB_BLDR_CHANNEL=$CHANNEL ${TRAVIS_HAB} pkg exec core/hab-bintray-publish publish-studio
+  fi
+
+  # On 'master' branch builds, we might not build a hab artifact to
+  # publish. It'll always be there on release builds, though.
+  if [ -n "${HAB_RELEASE_ARTIFACT}" ]; then
+      echo "Publishing hab to $BINTRAY_REPO"
+      if [ -n "${IS_RELEASE_BUILD}" ]; then
+          env HAB_BLDR_CHANNEL=$CHANNEL ${TRAVIS_HAB} pkg exec core/hab-bintray-publish publish-hab -s -r $BINTRAY_REPO $HAB_RELEASE_ARTIFACT
+      else
+          env HAB_BLDR_CHANNEL=$CHANNEL ${TRAVIS_HAB} pkg exec core/hab-bintray-publish publish-hab -r $BINTRAY_REPO $HAB_RELEASE_ARTIFACT
+      fi
   fi
 fi

--- a/support/ci/fast_pass.sh
+++ b/support/ci/fast_pass.sh
@@ -21,12 +21,10 @@ else
   # If $AFFECTED_DIRS (a "|" separated list of directories) is set, see if we have
   # any changes. To make this determination, we can always use the most recent merge
   # commit on the target branch, since Travis will have created one for us.
-
-  LATEST_MERGE_COMMIT="$(git log --merges --max-count=1 --pretty=format:%H)"
-  CHANGED_FILES="$(git log -m --max-count=1 --name-only --pretty=format: $LATEST_MERGE_COMMIT)"
+  CHANGED_FILES="$(support/ci/what_changed.sh)"
 
   echo
-  echo "Checking for changed files:"
+  echo "Checking for changed files since last merge commit:"
   echo
   echo "$CHANGED_FILES" | sed 's,^,    ,g'
   echo

--- a/support/ci/install_rq.sh
+++ b/support/ci/install_rq.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -eu
+
+echo "Installing rq"
+curl -o /usr/local/bin/rq https://s3-eu-west-1.amazonaws.com/record-query/record-query/x86_64-unknown-linux-musl/rq
+chmod +x /usr/local/bin/rq

--- a/support/ci/only_master_or_release.sh
+++ b/support/ci/only_master_or_release.sh
@@ -1,8 +1,25 @@
 #!/bin/bash
 #
-# fail fast if we aren't on the desired branch or if this is a pull request
+# Use to stop a job early if we aren't on master or on a release tag.
 
-if  [[ "${TRAVIS_BRANCH}" != "$(cat VERSION)" && ("${TRAVIS_PULL_REQUEST}" != "false" || "${TRAVIS_BRANCH}" != "master") ]]; then
-    echo "We only deploy on successful builds of master or release builds."
+echo "Habitat VERSION File Contents: $(cat VERSION)"
+echo "TRAVIS_TAG: ${TRAVIS_TAG}"
+echo "TRAVIS_BRANCH: ${TRAVIS_BRANCH}"
+echo "TRAVIS_PULL_REQUEST_BRANCH: ${TRAVIS_PULL_REQUEST_BRANCH}"
+
+# From https://docs.travis-ci.com/user/environment-variables
+#     TRAVIS_BRANCH:
+#       for push builds, or builds not triggered by a pull request, this is the name of the branch.
+#       for builds triggered by a pull request this is the name of the branch targeted by the pull request.
+#       for builds triggered by a tag, this is the same as the name of the tag (TRAVIS_TAG).
+#     TRAVIS_PULL_REQUEST:
+#       The pull request number if the current job is a pull request, “false” if it’s not a pull request.
+
+if [ "${TRAVIS_TAG}" == "$(cat VERSION)" ]; then
+    echo "Building a release for ${TRAVIS_TAG}"
+elif [ "${TRAVIS_BRANCH}" == "master" ] && [ "${TRAVIS_PULL_REQUEST}" == "false" ] ; then
+    echo "Building on the master branch"
+else
+    echo "Neither a release nor a master build; exiting!"
     exit 1
 fi

--- a/support/ci/rust_tests.sh
+++ b/support/ci/rust_tests.sh
@@ -13,8 +13,4 @@ echo "--> Running $0"
 source $(dirname $0)/rust_env.sh
 
 set -e
-if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
-  make unit-${COMPONENTS:-all}
-else
-  make unit-${COMPONENTS:-all}
-fi
+make unit-${COMPONENTS:-all}

--- a/support/ci/should_we_build.sh
+++ b/support/ci/should_we_build.sh
@@ -23,8 +23,7 @@ if [ $? != 0 ]; then
     exit 1
 fi
 
-MERGE_BASE="$(git merge-base origin/master HEAD)"
-CHANGED_FILES=$(git diff --name-only ${MERGE_BASE})
+CHANGED_FILES="$(support/ci/what_changed.sh)"
 
 # Consult `.bldr.toml` to figure out which files we care about for the
 # given package.
@@ -71,7 +70,7 @@ search_expression=$(cat .bldr.toml | \
        join("|")')
 
 echo
-echo "The following files have changes since ${MERGE_BASE:0:8}:"
+echo "The following files have changes since the last merge commit:"
 echo
 echo "$CHANGED_FILES" | sed 's,^,    ,g'
 echo

--- a/support/ci/should_we_build.sh
+++ b/support/ci/should_we_build.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+#
+# Given the name of a Habitat package in this repository, consult Git
+# to determine if any files that are used by that package have
+# changed. If so, exit with 0 (meaning that we should build), or with
+# 1 (meaning we should not build).
+
+set -u
+
+# e.g., "builder-api", "hab-pkg-export-docker", etc.
+package_name="${1}"
+
+echo "======================================================="
+echo "Testing whether or not we need to build ${package_name}"
+echo "======================================================="
+
+cat .bldr.toml | \
+    rq --input-toml | \
+    jq --exit-status '.["'${package_name}'"]' &>/dev/null
+
+if [ $? != 0 ]; then
+    echo "No project named ${package_name} in .bldr.toml!"
+    exit 1
+fi
+
+MERGE_BASE="$(git merge-base origin/master HEAD)"
+CHANGED_FILES=$(git diff --name-only ${MERGE_BASE})
+
+# Consult `.bldr.toml` to figure out which files we care about for the
+# given package.
+
+# Requires `rq` and `jq` to be installed for TOML parsing
+
+# Given input TOML like this:
+#
+#    [hab-sup]
+#    plan_path = "components/sup"
+#    paths = [
+#      "components/sup/*",
+#      "components/eventsrv-client/*",
+#      "components/launcher-client/*",
+#      "components/butterfly/*",
+#      "components/core/*",
+#      "components/builder-depot-client/*",
+#    ]
+#
+# we extract the plan path and turn it into a regex that matches that
+# root directory (i.e., given `components/sup`, create
+# `components/sup/*`), then merge that in with all the other paths we
+# care about. Then, we ensure they're all unique, and then create one
+# big regex by joining it all together with `|`
+#
+# Thus we are left with:
+#
+#    components/builder-depot-client/*|components/butterfly/*|components/core/*|components/eventsrv-client/*|components/launcher-client/*|components/sup/*
+#
+# (Note: I wanted to do this with just `rq`, but I couldn't find a way
+# to join the *modified* `plan_path` together with the contents of
+# `path. Thus, all it's doing here is converting TOML to JSON so we
+# can use `jq`'s more flexible language to process the data. `jq` can
+# also output raw strings, so we don't need a `tr -d '"'` tacked on to
+# the end.)
+
+search_expression=$(cat .bldr.toml | \
+    rq --input-toml | \
+    # All entries should have a `plan_path` key; not all will have `paths`
+    jq -r '[.["'${package_name}'"]["plan_path"] + "/*", .["'${package_name}'"]["paths"] // empty] |
+       flatten |
+       sort |
+       unique |
+       join("|")')
+
+echo
+echo "The following files have changes since ${MERGE_BASE:0:8}:"
+echo
+echo "$CHANGED_FILES" | sed 's,^,    ,g'
+echo
+
+# If any of these "master files" change, it will affect the build of EVERY package.
+# (Note: this is a regular expression, and should be escaped as such)
+master_files="\.travis\.yml|\.bldr\.toml|support/ci/*|Cargo\.toml|Cargo\.lock|VERSION"
+
+echo "Performing a preliminary check for changes in the following \"master\" files:"
+echo
+# All this sed is to get the individual regex options to print nicely
+echo "    $master_files" | sed "s,|,\n    ,g" | sed 's,\\,,g'
+echo
+
+if echo "${CHANGED_FILES}" | grep --quiet --extended-regexp "^(${master_files})" ; then
+    echo "A master file has changed; we should build ${package_name} regardless"
+    exit 0
+fi
+
+echo "No master files changed; checking for changes in the following paths from .bldr.toml for ${package_name}:"
+echo
+# This sed is to get the individual paths to print nicely; nothing
+# is escaped, though, so it's simpler than last time
+echo "    $search_expression" | sed "s,|,\n    ,g"
+echo
+
+if echo "$CHANGED_FILES" | grep --quiet --extended-regexp "^(${search_expression})" ; then
+    echo "Files for ${package_name} have changed; we should build the package"
+    exit 0
+fi
+
+echo "No files for ${package_name} have changed; we should *not* build the package"
+exit 1

--- a/support/ci/what_changed.sh
+++ b/support/ci/what_changed.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Determine what changed since our last merge commit.
+#
+# Any time we merge code, we use a merge commit. If we're running this
+# on a PR branch, we'll just grab the most recent merge commit as the
+# base from which to perform our diffs.
+#
+# However, if we're building from master, then we'll actually be
+# sitting on the last merge commit. In that case, we want to diff from
+# the merge commit before that.
+
+CURRENT_SHA="$(git rev-parse HEAD)"
+LATEST_MERGE_COMMIT="$(git log --merges --max-count=1 --pretty=format:%H)"
+
+if [ "${CURRENT_SHA}" == "${LATEST_MERGE_COMMIT}" ] ; then
+    LATEST_MERGE_COMMIT="$(git log --merges --max-count=1 --skip=1 --pretty=format:%H)"
+fi
+
+git diff --name-only ${LATEST_MERGE_COMMIT}


### PR DESCRIPTION
Reworked package build steps to only build habitat packages when necessary, driven off the contents of `.bldr.toml`. While this won't decrease release build times (we build all packages then anyway), it will shorten post-merge builds on the master branch, building only packages whose code changed.