### PR TITLE
ensure unstable builds are entirely unstable

### DIFF
--- a/components/plan-build/plan.sh
+++ b/components/plan-build/plan.sh
@@ -27,18 +27,18 @@ pkg_deps=(
 program=$pkg_name
 
 do_build() {
-  cp -v $PLAN_CONTEXT/bin/${program}.sh $program
+  cp -v $PLAN_CONTEXT/bin/${program}.sh "$CACHE_PATH/$program"
 
   # Use the bash from our dependency list as the shebang. Also, embed the
   # release version of the program.
   sed \
     -e "s,#!/bin/bash$,#!$(pkg_path_for bash)/bin/bash," \
     -e "s,^HAB_PLAN_BUILD=.*$,HAB_PLAN_BUILD=$pkg_version/$pkg_release," \
-    -i $program
+    -i "$CACHE_PATH/$program"
 }
 
 do_install() {
-  install -D $program $pkg_prefix/bin/$program
+  install -D "$CACHE_PATH/$program" $pkg_prefix/bin/$program
   install -D $PLAN_CONTEXT/bin/shared.sh $pkg_prefix/bin/
   install -D $PLAN_CONTEXT/bin/public.sh $pkg_prefix/bin/
   install -D $PLAN_CONTEXT/bin/composite_build_functions.sh $pkg_prefix/bin/

--- a/components/studio/build-docker-image.sh
+++ b/components/studio/build-docker-image.sh
@@ -93,7 +93,7 @@ FROM busybox:latest
 MAINTAINER The Habitat Maintainers <humans@habitat.sh>
 ADD rootfs /
 WORKDIR /src
-RUN env NO_MOUNT=true hab studio new \
+RUN env NO_MOUNT=true HAB_BLDR_CHANNEL=$HAB_BLDR_CHANNEL hab studio new \
   && rm -rf /hab/studios/src/hab/cache/artifacts
 ENTRYPOINT ["/bin/hab", "studio"]
 EOF

--- a/components/studio/libexec/hab-studio-type-default.sh
+++ b/components/studio/libexec/hab-studio-type-default.sh
@@ -203,7 +203,7 @@ PROFILE_ENTER
 
 _hab() {
   # We remove a couple of env vars we do not want for this instance of the studio
-  $bb env FS_ROOT=$HAB_STUDIO_ROOT HAB_CACHE_KEY_PATH= HAB_BLDR_CHANNEL= $hab $*
+  $bb env FS_ROOT=$HAB_STUDIO_ROOT HAB_CACHE_KEY_PATH= $hab $*
 }
 
 _pkgpath_for() {

--- a/support/ci/deploy.sh
+++ b/support/ci/deploy.sh
@@ -3,9 +3,11 @@
 set -e
 
 # fail fast if we aren't on the desired branch or if this is a pull request
-if  [[ "${TRAVIS_BRANCH}" != "$(cat VERSION)" && ("${TRAVIS_PULL_REQUEST}" != "false" || "${TRAVIS_BRANCH}" != "master") ]]; then
-    echo "We only publish on successful builds of master."
-    exit 0
+if [ -n "$TRAVIS_BRANCH" || -n "$TRAVIS_PULL_REQUEST" ]; then
+  if  [[ "${TRAVIS_BRANCH}" != "$(cat VERSION)" && ("${TRAVIS_PULL_REQUEST}" != "false" || "${TRAVIS_BRANCH}" != "master") ]]; then
+      echo "We only publish on successful builds of master."
+      exit 0
+  fi
 fi
 
 # now do the linux unstable build
@@ -27,19 +29,23 @@ mkdir -p ${BOOTSTRAP_DIR}
 wget -O hab.tar.gz "${HAB_DOWNLOAD_URL}"
 # install it in a custom location
 tar xvzf ./hab.tar.gz --strip 1 -C ${BOOTSTRAP_DIR}
+rm hab.tar.gz
 
 # so key stuff doesn't get funky
 unset SUDO_USER
 
 # create our origin key
- cat << EOF > core.sig.key
+cat << EOF > core.sig.key
 SIG-SEC-1
 core-20160810182414
 
 ${HAB_ORIGIN_KEY}
 EOF
 
-${TRAVIS_HAB} origin key import < ./core.sig.key
+if [ -n "$HAB_ORIGIN_KEY" ]; then
+  ${TRAVIS_HAB} origin key import < ./core.sig.key
+fi
+
 rm ./core.sig.key
 
 COMPONENTS=($COMPONENTS)
@@ -51,12 +57,13 @@ do
   echo "--> Building $component"
   ${TRAVIS_HAB} studio run HAB_CARGO_TARGET_DIR=/src/target build components/${component}
 
-  HART=$(find ./results -name *${component}*.hart)
+  source ./results/last_build.env
+  HART="./results/$pkg_artifact"
   ${TRAVIS_HAB} pkg install $HART
 
   # once we have built the stuio, switch over to bits built here
   if [[ "${component}" == "studio" ]]; then
-    TRAVIS_HAB=$(find /hab/pkgs/core/hab -type f -name hab)
+    TRAVIS_HAB=$(find /hab/pkgs/core/hab -type f -name hab | tail -1)
   elif [[ "${component}" == "hab" ]]; then
     RELEASE="${HART}_keep"
     cp $HART $RELEASE
@@ -73,6 +80,6 @@ env HAB_ORIGIN= ${TRAVIS_HAB} studio run sh -c \'rm -f /hab/cache/keys/*-*.sig.k
 
 if [ -n "$BINTRAY_USER" ]; then
   echo "Publishing hab to $BINTRAY_REPO"
-  ${TRAVIS_HAB} pkg exec core/hab-bintray-publish publish-studio
-  ${TRAVIS_HAB} pkg exec core/hab-bintray-publish publish-hab -r $BINTRAY_REPO $RELEASE
+  env  HAB_BLDR_CHANNEL=$CHANNEL ${TRAVIS_HAB} pkg exec core/hab-bintray-publish publish-studio
+  env  HAB_BLDR_CHANNEL=$CHANNEL ${TRAVIS_HAB} pkg exec core/hab-bintray-publish publish-hab -r $BINTRAY_REPO $RELEASE
 fi


### PR DESCRIPTION
This PR makes sure that travis and appveyor builds of a particular channel remain comprised of binaries that are all in the same channel. This also makes it easier to run the travis and appveyor deployment scripts locally.

Signed-off-by: mwrock <matt@mattwrock.com>