### PR TITLE
Add hab-pkg-cfize to .bldr.toml, stop building hab-pkg-dockerize

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -177,6 +177,12 @@ paths = [
   "components/pkg-export-docker/*"
 ]
 
+# NOTE: cfize has a dependency on hab-pkg-dockerize, but we are
+# *explicitly not building* `hab-pkg-dockerize` any more. Read more at
+# components/pkg-dockerize/README.md
+[hab-pkg-cfize]
+plan_path = "components/pkg-cfize"
+
 [hab-pkg-mesosize]
 plan_path = "components/pkg-mesosize"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -245,8 +245,8 @@ matrix:
     - os: linux
       env:
         # These components will build as Habitat packages in the provided order
-        - COMPONENTS="pkg-aci pkg-dockerize pkg-cfize pkg-export-docker pkg-export-kubernetes pkg-mesosize pkg-tarize"
-        - AFFECTED_DIRS="\.travis\.yml|\.bldr\.toml|support/ci/deploy\.sh|Cargo\.toml|Cargo\.lock|VERSION|components/pkg-aci|components/pkg-cfize|components/pkg-dockerize|components/pkg-mesosize|components/pkg-tarize|components/pkg-export-docker|components/pkg-export-kubernetes|$_RUST_HAB_LIB_COMPONENTS"
+        - COMPONENTS="pkg-aci pkg-cfize pkg-export-docker pkg-export-kubernetes pkg-mesosize pkg-tarize"
+        - AFFECTED_DIRS="\.travis\.yml|\.bldr\.toml|support/ci/deploy\.sh|Cargo\.toml|Cargo\.lock|VERSION|components/pkg-aci|components/pkg-cfize|components/pkg-mesosize|components/pkg-tarize|components/pkg-export-docker|components/pkg-export-kubernetes|$_RUST_HAB_LIB_COMPONENTS"
         # HAB_AUTH_TOKEN
         - secure: "OCq9oDAEP3Cc0BiGrnZHE0FoNdyqsAy2LPTwEoOKvgiZdrw5o2bvpN1Kl+DKpw2auKtkeAS1aVSE/CMrglxrDs+VolvK9ttW3kj8c7+AeuCYjBsyWqdnZ1/24u6P+20fKanYrsMsnFb2r9OWwxZVlFnfmks81LWToOlGFJpL5KnmSPrB2vlWPbiaH9+yg8aslrmCq0reSoSVSnoZHoTolWtjzx2WdPYqA4gu0HHASVbH5qP+PoQSGIWvwbBaU4xhwkp1K8rWCjI8lre2YpBMOdfZv+9arMjc3Xg/kgD9oGU9DN7Q3UzAWxTSJv/3Cm4LArwiI57rXMLDKf8N1MhvGMHP1xgbuN8JWFKqFuWpqCf6qJkYG8+VZkruKYOo/2tXtBY4hpbR2abcWvYU/S9AQFHKGJQ2vcArnp5SKO+Oq/fNVneeHli4RbGMRQCMVq+X0SSC148F0zEVVwkNM5eq4askfc/2y4asySrH0MT/5T3yBp8fr3zXpnj82h2ytCZOUs0o+La9+wt5gSDUJHdY/BwSSPrgnKSp7ixslM/g7lMy3nAOs6qLql8/vW543CXBurCACWTqwKcy3/wRparTkmZcs1d7vUrbcfYv7XJzh0pw2P1hCjWD9BtkowbuLVo8K9ndPl2rbFY9XljqFXMTcHxp4ETeCc23azHCs+SYFb0="
         # HAB_ORIGIN_KEY

--- a/components/pkg-dockerize/README.md
+++ b/components/pkg-dockerize/README.md
@@ -1,0 +1,21 @@
+This is the *old* Docker export code, which is no longer being
+developed. To make changes to Docker export code, please look in
+[components/pkg-build-docker](../pkg-build-docker) instead.
+
+Changes to this package *will not be built* by either TravisCI or
+Habitat Builder.
+
+The code still exists in the repository because `hab-pkg-cfize` has a
+runtime dependency on `hab-pkg-dockerize`. The `hab-pkg-cfize`
+exporter was written around the same time (but before)
+`hab-pkg-export-docker` was rewritten. As a result, it uses the older
+code.
+
+Long term, `hab-pkg-cfize` should be rewritten in Rust, following the
+basic pattern laid out by `hab-pkg-export-docker`. If changes need to
+be made to `hab-pkg-cfize` in the meantime, and if those changes
+should also require changes to `hab-pkg-dockerize`, try and make the
+changes in `hab-pkg-cfize` instead of requiring new builds of old
+packages. Newcomers to Habitat shouldn't need to be confused by having
+"current" packages of `hab-pkg-dockerize` alongside
+`hab-pkg-export-docker`.

--- a/www/source/partials/docs/_bp-binary-wrapper-packages.html.md.erb
+++ b/www/source/partials/docs/_bp-binary-wrapper-packages.html.md.erb
@@ -26,7 +26,7 @@ do_install() {
 
 ## Relocate Hard-Coded Library Dependencies If Possible
 
-Many binaries hardcode library dependencies to `/lib` or `/lib64` inside their ELF symbol table. Unfortunately, this means that Habitat is unable to provide dependency isolation guarantees if packages are dependent on any operating system's libraries in those directories. These Habitat packages will also fail to run in minimal environments like containers built using `hab-pkg-dockerize`, because there will not be a `glibc` inside `/lib` or `/lib64`.
+Many binaries hardcode library dependencies to `/lib` or `/lib64` inside their ELF symbol table. Unfortunately, this means that Habitat is unable to provide dependency isolation guarantees if packages are dependent on any operating system's libraries in those directories. These Habitat packages will also fail to run in minimal environments like containers built using `hab-pkg-export-docker`, because there will not be a `glibc` inside `/lib` or `/lib64`.
 
 Most binaries compiled in a full Linux environment have a hard dependency on `/lib/ld-linux.so` or `/lib/ld-linux-x86_64.so`. In order to relocate this dependency to the Habitat-provided variant, which is provided by `core/glibc`, use the `patchelf(1)` utility within your plan:
 


### PR DESCRIPTION
Signed-off-by: Christopher Maier <cmaier@chef.io>