### PR TITLE
Fix broken link

### DIFF
--- a/www/source/partials/tutorials/_web_guide_build_test.slim
+++ b/www/source/partials/tutorials/_web_guide_build_test.slim
@@ -138,7 +138,7 @@ section
 
  p For information on what endpoint information you can query, see #{link_to 'Monitoring services','https://www.habitat.sh/docs/run-packages-monitoring/'}.
 
-- if "#{current_page.data.platform_short}" == "ruby"
+- if ["ruby", "node"].include? "#{current_page.data.platform_short}"
   = link_to 'Next: Connect to Database', "/tutorials/build-your-own/#{current_page.data.platform_short}/connect-database/", class: 'button cta'
 
 - else


### PR DESCRIPTION
At the page https://www.habitat.sh/tutorials/build-your-own/node/build-test/
the Next: Connect to Nginx button should bring user to the Connect to Database section.
For now it will redirect user to the last section, namely Connect to Nginx

Signed-off-by: Alex Bender <axbndr@gmail.com>