### PR TITLE
Fix the ChefConf CFP blog post

### DIFF
--- a/www/source/blog/2017-12-11-chefconf-2018-cfp.html.md
+++ b/www/source/blog/2017-12-11-chefconf-2018-cfp.html.md
@@ -12,7 +12,7 @@ ChefConf is the largest Chef community reunion and educational event for teams o
 
 ChefConf will cover topics across the entire Chef ecosystem.  This includes [Chef Automate](https://www.chef.io/automate/), [Chef](https://www.chef.io/chef/), [InSpec](https://www.inspec.io/), and, of course, [Habitat](https://www.habitat.sh/)!
 
-One of the tracks you might consider proposing a session for is the Automation Automation track.
+One of the tracks you might consider proposing a session for is the Application Automation track.
 
 ## Application Automation
 
@@ -71,7 +71,7 @@ The ChefConf CFP is open for the following tracks:
 * [Infrastructure Automation](https://blog.chef.io/2017/11/21/chefconf-2018-cfp-infrastructure-automation-track/)
 * [Compliance Automation](https://blog.chef.io/2017/11/29/chefconf-2018-cfp-compliance-automation-track/)
 * Application Automation
-* People, Process, and Team
+* [People, Process, and Teams](https://blog.chef.io/2017/12/13/chefconf-2018-cfp-people-process-and-teams/)
 * Delivering Delight
 * Chaos Engineering
 * Don't Label Me!


### PR DESCRIPTION
* `Application Automation`, not `Automation Automation` ;)
* Add a link to the People, Process, and Teams CFP post

Signed-off-by: Nathen Harvey <nharvey@chef.io>