### PR TITLE
support/linux/helpers: rm unnecessary dir check

### DIFF
--- a/support/linux/helpers.sh
+++ b/support/linux/helpers.sh
@@ -1,16 +1,14 @@
 #!/bin/bash
 
+load_package() {
+  hab pkg upload --url http://localhost:9636/v1 --auth "${HAB_AUTH_TOKEN}" "$@" --channel stable
+}
+
 load_packages() {
   if [[ -d /src/pkgs ]]; then
     for pkg in /src/pkgs/core*.hart ; do
-      hab pkg upload --url http://localhost:9636/v1 --auth "${HAB_AUTH_TOKEN}" "${pkg}" --channel stable
+      load_package "${pkg}"
     done
-  fi
-}
-
-load_package() {
-  if [[ -d /src/pkgs ]]; then
-    hab pkg upload --url http://localhost:9636/v1 --auth "${HAB_AUTH_TOKEN}" "$@" --channel stable
   fi
 }
 


### PR DESCRIPTION
`load_package` is helpful w/o `/src/pkgs`, don't expect the directory to
exist.

Signed-off-by: Michael Schubert <michael@kinvolk.io>