### PR TITLE
Specify group ID for service group in exported containers

### DIFF
--- a/components/pkg-export-docker/defaults/Dockerfile.hbs
+++ b/components/pkg-export-docker/defaults/Dockerfile.hbs
@@ -12,7 +12,7 @@ ADD {{rootfs}} /
 # (Also, sorry for `-R` instead of `--recursive`; Busybox doesn't
 # recognize the latter :'(
 {{#if primary_user_id }}
-RUN chown -R {{primary_user_id}}:{{primary_user_id}} /hab
+RUN chown -R {{primary_user_id}}:{{primary_group_id}} /hab
 
 # This environment variable disables certain checks around installing
 # packages (important for upgrade scenarios!). It is a short-term fix;

--- a/components/pkg-export-docker/src/cli.rs
+++ b/components/pkg-export-docker/src/cli.rs
@@ -153,11 +153,17 @@ impl<'a, 'b> Cli<'a, 'b> {
             .arg(
                 Arg::with_name("USER_ID")
                     .long("user-id")
-                    .short("s")
                     .value_name("USER_ID")
                     .validator(valid_user_id)
+                    .help("Specify the numeric ID of the service user (default: 42)"),
+            )
+            .arg(
+                Arg::with_name("GROUP_ID")
+                    .long("group-id")
+                    .value_name("GROUP_ID")
+                    .validator(valid_group_id)
                     .help(
-                        "Specify the numeric ID of the service user and group (default: 42)",
+                        "Specify the numeric ID of the service group (default: same as user-id)",
                     ),
             )
             .arg(Arg::with_name("NON_ROOT").long("non-root").help(
@@ -315,5 +321,16 @@ fn valid_user_id(val: String) -> result::Result<(), String> {
             Ok(())
         }
         Err(_) => Err(format!("User ID: '{}' is not valid", &val)),
+    }
+}
+
+fn valid_group_id(val: String) -> result::Result<(), String> {
+    match val.parse::<u32>() {
+        Ok(_) => {
+            // TODO (CM): need to filter out problematic
+            // values (e.g., 0, existing user/group IDs)
+            Ok(())
+        }
+        Err(_) => Err(format!("Group ID: '{}' is not valid", &val)),
     }
 }

--- a/components/pkg-export-docker/src/docker.rs
+++ b/components/pkg-export-docker/src/docker.rs
@@ -460,8 +460,7 @@ impl DockerBuildRoot {
             "exposes": ctx.svc_exposes().join(" "),
             "primary_svc_ident": ctx.primary_svc_ident().to_string(),
             "primary_user_id": ctx.primary_user_id(),
-            // Yup, the group is the same as the user for now.
-            "primary_group_id": ctx.primary_user_id(),
+            "primary_group_id": ctx.primary_group_id(),
         });
         util::write_file(
             self.0.workdir().join("Dockerfile"),


### PR DESCRIPTION
Previously, we allowed users with specific needs to customize the user
ID of the service user when exporting a container. Now, we also allow
customization of the group ID of the service group as well, instead of
having it always be the same as the user ID.

The short option flag for `--user-id` was also removed (and none was
added for `--group-id`); these are special-use options, and should
only be needed in special cases. There's no reason to claim valuable
short flags for this.

Signed-off-by: Christopher Maier <cmaier@chef.io>