### PR TITLE
Handle 403s from the /jobs/:id endpoint

### DIFF
--- a/components/builder-web/app/package/build-detail/build-detail.component.html
+++ b/components/builder-web/app/package/build-detail/build-detail.component.html
@@ -1,9 +1,9 @@
 <div class="build-detail-component">
-  <div class="summary" *ngIf="info.state">
+  <div class="summary" *ngIf="buildState">
     <div class="status {{ statusClass }}">
       <div>
-        <hab-icon [symbol]="statusIcon" [class]="statusClass" [title]="info.state | titlecase"></hab-icon>
-        Build {{ info.state }}
+        <hab-icon [symbol]="statusIcon" [class]="statusClass" [title]="buildState | titlecase"></hab-icon>
+        Build {{ buildState }}
       </div>
     </div>
     <div class="detail">

--- a/components/builder-web/app/package/build-detail/build-detail.component.ts
+++ b/components/builder-web/app/package/build-detail/build-detail.component.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Component, HostListener, Input, OnChanges, OnDestroy, ElementRef } from '@angular/core';
+import { Component, HostListener, Input, OnChanges, OnDestroy, ElementRef, SimpleChanges } from '@angular/core';
 import { Subscription } from 'rxjs';
 import * as AnsiUp from 'ansi_up';
 import * as moment from 'moment';
@@ -38,11 +38,11 @@ export class BuildDetailComponent implements OnChanges, OnDestroy {
     private elementRef: ElementRef) {
   }
 
-  ngOnChanges(change) {
-    let id = change.build.currentValue.id;
+  ngOnChanges(changes: SimpleChanges) {
+    const build = changes['build'];
 
-    if (id) {
-      this.fetch(id);
+    if (build && build.currentValue && build.currentValue.id) {
+      this.fetch(build.currentValue.id);
     }
   }
 
@@ -92,12 +92,20 @@ export class BuildDetailComponent implements OnChanges, OnDestroy {
     return props;
   }
 
+  get buildState() {
+    return this.info ? this.info.state : '';
+  }
+
   get statusIcon() {
-    return iconForBuildState(this.info.state);
+    if (this.buildState) {
+      return iconForBuildState(this.buildState);
+    }
   }
 
   get statusClass() {
-    return this.info.state ? this.info.state.toLowerCase() : '';
+    if (this.buildState) {
+      return this.buildState.toLowerCase();
+    }
   }
 
   toggleFollow() {
@@ -113,28 +121,32 @@ export class BuildDetailComponent implements OnChanges, OnDestroy {
   }
 
   get elapsed() {
-    let started = this.build.build_started_at;
-    let finished = this.build.build_finished_at;
-    let e;
+    if (this.build) {
+      let started = this.build.build_started_at;
+      let finished = this.build.build_finished_at;
+      let e;
 
-    if (started && finished) {
-      let s = +moment.utc(started);
-      let f = +moment.utc(finished);
-      e = moment.utc(f - s).format('m [min], s [sec]');
+      if (started && finished) {
+        let s = +moment.utc(started);
+        let f = +moment.utc(finished);
+        e = moment.utc(f - s).format('m [min], s [sec]');
+      }
+
+      return e;
     }
-
-    return e;
   }
 
   get completed() {
-    let finished = this.build.build_finished_at;
-    let f;
+    if (this.build) {
+      let finished = this.build.build_finished_at;
+      let f;
 
-    if (finished) {
-      f = moment.utc(finished).format('dddd, MMMM D, YYYY [at] h:mm:ss A');
+      if (finished) {
+        f = moment.utc(finished).format('dddd, MMMM D, YYYY [at] h:mm:ss A');
+      }
+
+      return f;
     }
-
-    return f;
   }
 
   get info() {


### PR DESCRIPTION
A recent change (mine) modified this code path to return a 403 for non-origin members, but the UI isn’t handling that scenario. (It breaks.) This fixes that.

Signed-off-by: Christian Nunciato <chris@nunciato.org>

![tenor-5689323](https://user-images.githubusercontent.com/274700/34021950-5288e8f8-e0f1-11e7-86ac-f7fbcdd73f5c.gif)
