### PR TITLE
Update project creation tools

### DIFF
--- a/BUILDER_DEV.md
+++ b/BUILDER_DEV.md
@@ -133,21 +133,30 @@ The web UI should be running at http://localhost:3000/#/pkgs. (If you need to br
 ## Create the project(s) you want to build
 In order to build a package, there needs to be a project created in the database.
 If the DB has been newly created, there will initially not be any projects available.
+There are two ways that a project can be created - either via the web UI, or via the command line - both options are documented below:
 
-Create a project for the package you want to build:
+### Option A: Create a project using the web UI
 
+1. Go the web UI that you used in the last step
+2. Go to the origins page, and select your origin
+3. Click on the 'Connect a plan file' button
+4. Click on 'Install Github App' button to install the Builder Dev app on your github account
+5. Go back to the Packages page (from Step 3), and follow the instructions to link the plan you want to build
+
+### Option B: Create a project using the command line
 1. Create a project file (eg, `project.json`) on your local filesystem (see example below for core/nginx):
 
     ```
     {
         "origin": "core",
         "plan_path": "nginx/plan.sh",
-        "github": {
-            "organization": "habitat-sh",
-            "repo": "core-plans"
-        }
+        "installation_id": 56940,
+        "repo_id": 46349776
     }
     ```
+
+Note: the `installation_id` above is for the Habitat Builder Dev app, and the
+`repo_id` is for the 'core-plans' repo.
 
 1. Issue the following command:
 

--- a/tools/project_create/README.md
+++ b/tools/project_create/README.md
@@ -6,7 +6,8 @@ builder to recognize and be able to kick off automated builds.
 
 This tool is targeted to creating ```core``` origin projects. It takes as
 input parameters a local path to the core-plans repo, an API endpoint URL,
-and a Github auth token.
+an installation id (for an installed Habitat Builder app), and a Github auth
+token.
 
 ### Usage
 
@@ -14,11 +15,36 @@ You need to have a recent Ruby installed.
 
 To run:
 ```
-ruby project_create.rb <core-plans-dir> <projects-url> [<auth-token>]
+ruby project_create.rb <core-plans-dir> <projects-url> <installation-id> [<auth-token>]
 ```
 
 The projects-url should be in this form (replace the URL appropriately):
-http://app.acceptance.habitat.sh/v1/projects
+https://bldr.acceptance.habitat.sh
+
+For a development environment, the URL will be:
+http://localhost:9636
 
 If `<auth-token>` is not specified, the script will default to looking for
 the `HAB_AUTH_TOKEN` environment variable.
+
+### Extras
+
+This directory also contains some helper tools for querying installations
+and repositories from Github using Github App authentication. These
+require nodejs to be installed (any recent version should be fine).
+
+The tools are:
+* app.js - gets basic app info (for sanity validation)
+* installations.js - get a list of installation ids and names
+* repos.js - gets a list of repo ids and repo names
+
+In order to use these tools, you need to know the Github app id, and have
+the PEM file available on the machine. For reference, the Habitat Builder
+Dev app id is 5629.
+
+Example usage (assumes the pem file is in the current folder):
+```
+node app.js 5629 builder-github-app.pem
+node installations.js 5629 builder-github-app.pem
+node repos.js 5629 56940 builder-github-app.pem
+```

--- a/tools/project_create/app.js
+++ b/tools/project_create/app.js
@@ -1,0 +1,27 @@
+//
+// Usage: Usage: node app.js <app id> <path to PEM file>
+//
+// Note: The Habitat Dev App Id is 5629
+//
+
+const createApp = require('github-app');
+
+if (process.argv.length < 4) {
+    console.log("Usage: node app.js <app id> <path to PEM file>");
+    process.exit(-1);
+}
+
+var app_id = process.argv[2];
+var pem_path = process.argv[3];
+
+const app = createApp({
+  id: app_id,
+  cert: require('fs').readFileSync(pem_path)
+});
+
+
+app.asApp().then(github => {
+  github.apps.get({}).then(result => {
+    console.log(result.data.id + ':' + result.data.name + ' (' + result.data.owner.login + ')');
+  });
+});

--- a/tools/project_create/installations.js
+++ b/tools/project_create/installations.js
@@ -1,0 +1,29 @@
+//
+// Usage: Usage: node installations.js <app id> <path to PEM file>
+//
+// Note: The Habitat Dev App Id is 5629
+//
+
+const createApp = require('github-app');
+
+if (process.argv.length < 4) {
+    console.log("Usage: node installations.js <app id> <path to PEM file>");
+    process.exit(-1);
+}
+
+var app_id = process.argv[2];
+var pem_path = process.argv[3];
+
+const app = createApp({
+  id: app_id,
+  cert: require('fs').readFileSync(pem_path)
+});
+
+app.asApp().then(github => {
+  github.apps.getInstallations({}).then(installations => {
+    var i;
+    for (i in installations.data) {
+      console.log(installations.data[i].id + ':' + installations.data[i].account.login);
+    }
+  });
+});

--- a/tools/project_create/jwt.rb
+++ b/tools/project_create/jwt.rb
@@ -1,0 +1,33 @@
+#
+# Usage: jwt <app id> <path to PEM file>
+#
+# Note: Do a 'gem install jwt' before using this
+#
+
+require 'openssl'
+require 'jwt'  # https://rubygems.org/gems/jwt
+
+if ARGV.length < 2
+  puts "Usage: jwt <app id> <path to PEM file>"
+  exit
+end
+
+app_id = ARGV[0]
+pem_path = ARGV[1]
+
+# Private key contents
+private_pem = File.read(pem_path)
+private_key = OpenSSL::PKey::RSA.new(private_pem)
+
+# Generate the JWT
+payload = {
+  # issued at time
+  iat: Time.now.to_i,
+  # JWT expiration time (10 minute maximum)
+  exp: Time.now.to_i + (10 * 60),
+  # GitHub App's identifier
+  iss: app_id
+}
+
+jwt = JWT.encode(payload, private_key, "RS256")
+puts jwt

--- a/tools/project_create/project.erb
+++ b/tools/project_create/project.erb
@@ -1,8 +1,6 @@
 {
     "origin": "core",
     "plan_path": "<%= plan %>/plan.sh",
-    "github": {
-        "organization": "habitat-sh",
-        "repo": "core-plans"
-    }
+    "installation_id": <%= installation_id %>,
+    "repo_id": <%= repo_id %>
 }

--- a/tools/project_create/project_create.rb
+++ b/tools/project_create/project_create.rb
@@ -1,11 +1,15 @@
-#############################################################################
+##############################################################################
 #
 # Script to auto-create habitat core plan projects in a specified depot
 #
-# Usage: ruby project_create.rb <core-plans-dir> <projects-url> [<auth-token>]
+# Usage: ruby project_create.rb <core-plans-dir> <bldr-api-url> \
+#                               <installation-id> [<auth-token>]
 #
-# The projects-url should be in this form:
-# http://app.acceptance.habitat.sh/v1/projects
+# The bldr-api-url should be in this form:
+# http://bldr.acceptance.habitat.sh
+#
+# For a development environment, the URL will be:
+# http://localhost:9636
 #
 # If <auth-token> is not specified, the script will default to looking for
 # the HAB_AUTH_TOKEN environment variable.
@@ -17,16 +21,20 @@ require 'net/http'
 require 'uri'
 require 'json'
 
-if ARGV.length < 2
-  puts "Usage: project_create <core-plans-dir> <projects-url> [<auth-token>]"
+if ARGV.length < 3
+  puts "Usage: project_create <core-plans-dir> <projects-url> <installation-id> [<auth-token>]"
   exit
 end
 
-source_dir = ARGV[0]
-url = ARGV[1]
+# The core-plans repo id
+repo_id = 46349776
 
-if ARGV.length > 2
-  auth_token = ARGV[2]
+source_dir = ARGV[0]
+url = ARGV[1] + '/v1/projects'
+installation_id = ARGV[2]
+
+if ARGV.length > 3
+  auth_token = ARGV[3]
 else
   auth_token = ENV['HAB_AUTH_TOKEN']
 end

--- a/tools/project_create/repos.js
+++ b/tools/project_create/repos.js
@@ -1,0 +1,33 @@
+//
+// Usage: Usage: node repos.js <app id> <installation id> <path to PEM file>
+//
+// Note: The Habitat Dev App Id is 5629
+// Note: The Habitat-Sh Installation Id is 56940
+//
+
+const createApp = require('github-app');
+
+if (process.argv.length < 5) {
+    console.log("Usage: node repos.js <app id> <installation id> <path to PEM file>");
+    process.exit(-1);
+}
+
+var app_id = process.argv[2];
+var installation_id = process.argv[3];
+var pem_path = process.argv[4];
+
+const app = createApp({
+  id: app_id,
+  cert: require('fs').readFileSync(pem_path)
+});
+
+app.asInstallation(installation_id).then(github => {
+  github.apps.getInstallationRepositories({})
+  .then((repos) => {
+    var i;
+    for (i in repos.data.repositories) {
+      console.log(repos.data.repositories[i].id + ':' + repos.data.repositories[i].name);
+    }
+  })
+  .catch((reason) => {console.log('Error:'+reason);});
+});


### PR DESCRIPTION
This change fixes up the bulk project creation tool to use the current project creation API. It also adds some helper tools for querying Github installations using Github app  auth. It also updates the BUILDER_DEV.md instructions for project creation.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-57659441](https://user-images.githubusercontent.com/13542112/34025698-3155d334-e106-11e7-9605-2373444f89f1.gif)
