### PR TITLE
fix studio error emitted due to bad key import

### DIFF
--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -272,7 +272,12 @@ fn sub_origin_key_import(ui: &mut UI) -> Result<()> {
     io::stdin().read_to_string(&mut content)?;
     init();
 
-    command::origin::key::import::start(ui, &content, &default_cache_key_path(Some(&*FS_ROOT)))
+    // Trim the content to lose line feeds added by Powershell pipeline
+    command::origin::key::import::start(
+        ui,
+        content.trim(),
+        &default_cache_key_path(Some(&*FS_ROOT)),
+    )
 }
 
 fn sub_origin_key_upload(ui: &mut UI, m: &ArgMatches) -> Result<()> {
@@ -623,7 +628,8 @@ fn sub_ring_key_import(ui: &mut UI) -> Result<()> {
     io::stdin().read_to_string(&mut content)?;
     init();
 
-    command::ring::key::import::start(ui, &content, &default_cache_key_path(Some(&*FS_ROOT)))
+    // Trim the content to lose line feeds added by Powershell pipeline
+    command::ring::key::import::start(ui, content.trim(), &default_cache_key_path(Some(&*FS_ROOT)))
 }
 
 fn sub_service_key_generate(ui: &mut UI, m: &ArgMatches) -> Result<()> {

--- a/components/studio/bin/hab-studio.ps1
+++ b/components/studio/bin/hab-studio.ps1
@@ -252,7 +252,9 @@ function New-Studio {
   if($env:HAB_ORIGIN_KEYS) {
     $keys = @()
     $env:HAB_ORIGIN_KEYS.Split(" ") | % {
-      $keys += & hab origin key export $_ --type=secret | Out-String
+      $k = & hab origin key export $_ --type=secret | Out-String
+      # hab key import does not like carriage returns
+      $keys += $k.Replace("`r", "")
     }
 
     $env:FS_ROOT=$HAB_STUDIO_ROOT


### PR DESCRIPTION
fixes #4305 

Sometimes depending on how a studio mounts outside directories, it may try to export a key and import it to the same target directory. If there is any transformation to the key content like an extra line feed, the file shacheck fails.

When exporting a key on windows, carriage returns may be injected into the key content and also when importing on windows, the Powershell pipeline will add a linefeed to the end. This causes the import/overwrite to fail.

Signed-off-by: mwrock <matt@mattwrock.com>