### PR TITLE
Enable provision.sh to be run without sudo

### DIFF
--- a/support/linux/install_dev_9_linux.sh
+++ b/support/linux/install_dev_9_linux.sh
@@ -21,6 +21,6 @@ else
   sudo -E addgroup --system hab || true
 fi
 
-sudo -E sh /tmp/install.sh
-sudo -E hab install core/busybox-static core/hab-studio
-sudo -E rm -rf /tmp/install.sh
+sudo sh /tmp/install.sh
+sudo hab install core/busybox-static core/hab-studio
+sudo rm -rf /tmp/install.sh

--- a/support/linux/setup_keys.sh
+++ b/support/linux/setup_keys.sh
@@ -1,20 +1,26 @@
 #!/bin/bash
 set -euo pipefail
 
+builder_github_app_pem="/src/.secrets/builder-github-app.pem"
+
 # GitHub secret keys
-if [[ -f "/src/.secrets/builder-github-app.pem" ]]; then
+if [[ -f $builder_github_app_pem ]]; then
   for svc in sessionsrv worker api; do
-    mkdir -p /hab/svc/builder-${svc}/files
-    cp /src/.secrets/builder-github-app.pem /hab/svc/builder-${svc}/files/
+    sudo mkdir -p /hab/svc/builder-${svc}/files
+    sudo cp $builder_github_app_pem /hab/svc/builder-${svc}/files/
   done
 else
-  echo "Please follow instruction #6 here: https://github.com/habitat-sh/habitat/blob/master/BUILDER_DEV.md#pre-reqs"
+  echo "Please install $builder_github_app_pem. and rerun $0 $*"
+  echo "See https://github.com/habitat-sh/habitat/blob/master/BUILDER_DEV.md"
+  exit 1
 fi
 
 # Bulder key generation
-KEY_NAME=$(hab user key generate bldr | grep -Po "bldr-\d+")
+# key generate is done as root so the results end up in /hab rather than ~/.hab
+# regardless of whether this script is run as root
+KEY_NAME=$(sudo hab user key generate bldr | grep -Po "bldr-\d+")
 for svc in api jobsrv worker ; do
-  mkdir -p "/hab/svc/builder-${svc}/files"
-  cp "/hab/cache/keys/${KEY_NAME}.pub" "/hab/svc/builder-${svc}/files/"
-  cp "/hab/cache/keys/${KEY_NAME}.box.key" "/hab/svc/builder-${svc}/files/"
+  sudo mkdir -p "/hab/svc/builder-${svc}/files"
+  sudo cp "/hab/cache/keys/${KEY_NAME}.pub" "/hab/svc/builder-${svc}/files/"
+  sudo cp "/hab/cache/keys/${KEY_NAME}.box.key" "/hab/svc/builder-${svc}/files/"
 done


### PR DESCRIPTION
This avoids the situation where the user's cargo directory is owned by root,
necessitating excessive sudo usage. Instead, add sudo to the specific commands
which require it.

Signed-off-by: Jon Bauman <5906042+baumanj@users.noreply.github.com>