### PR TITLE
Dont add host if dns is missing

### DIFF
--- a/tools/ssh_helpers/hab-instances
+++ b/tools/ssh_helpers/hab-instances
@@ -5,5 +5,6 @@ set -euo pipefail
 HAB_ENV=${1}
 
 aws ec2 describe-instances \
-    --filter Name=tag:X-Environment,Values=${HAB_ENV} \
+    --filter "Name=tag:X-Environment,Values=${HAB_ENV}" \
+             "Name=instance-state-name,Values=running" \
     --region=us-west-2


### PR DESCRIPTION
Minor tweak to the hab-instances script to only pick up running instances

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-223413531](https://user-images.githubusercontent.com/13542112/34064071-3b625492-e1ab-11e7-8d8a-46a374f2f234.gif)
