### PR TITLE
Use project.origin_name for origin-membership check

### DIFF
--- a/components/builder-api/src/server/handlers.rs
+++ b/components/builder-api/src/server/handlers.rs
@@ -405,7 +405,7 @@ pub fn job_show(req: &mut Request) -> IronResult<Response> {
     match route_message::<JobGet, Job>(req, &request) {
         Ok(job) => {
 
-            if !check_origin_access(req, job.get_package_ident().get_origin()).unwrap_or(false) {
+            if !check_origin_access(req, job.get_project().get_origin_name()).unwrap_or(false) {
                 return Ok(Response::with(status::Forbidden));
             }
 


### PR DESCRIPTION
To determine origin membership in the `/jobs/:id` API handler, we currently compare using the `origin` property from the job’s `package_ident`, which may or may not be populated while a job is running (preventing origin members from being able to view running logs). This change uses the project’s origin name instead, which should always be available.

Signed-off-by: Christian Nunciato <chris@nunciato.org>

![tenor-18450999](https://user-images.githubusercontent.com/274700/34064336-0eebdce2-e1ad-11e7-828f-47ecddc782d3.gif)

cc @elliott-davis @baumanj 