### PR TITLE
Update cookie-setting logic on www

### DIFF
--- a/www/source/javascripts/nav.js
+++ b/www/source/javascripts/nav.js
@@ -19,10 +19,10 @@ const stickyVisibleBreakpoint = 300;
     var username = dropdown.find(".username");
     var signOutLink = dropdown.find(".sign-out");
 
-    if (token()) {
+    if (signedIn()) {
       $.get("https://api.github.com/user?access_token=" + token())
         .then(function(p) {
-          signIn(p);
+          showAvatar(p);
         }, function(err) {
           console.error(err);
           signOut();
@@ -57,10 +57,10 @@ const stickyVisibleBreakpoint = 300;
     }
 
     function signedIn() {
-      return !!token();
+      return !!token() && !!cookies.get("bldrSessionToken");
     }
 
-    function signIn(profile) {
+    function showAvatar(profile) {
       avatar.find("img").attr("src", profile.avatar_url);
       username.text(profile.login);
       signedInElements.css("display", "inline-block");
@@ -69,16 +69,23 @@ const stickyVisibleBreakpoint = 300;
     function signOut() {
       cookies.remove("gitHubAuthState", { domain: cookieDomain() });
       cookies.remove("gitHubAuthToken", { domain: cookieDomain() });
-      cookies.remove("featureFlags", { domain: cookieDomain() });
+      cookies.remove("bldrSessionToken", { domain: cookieDomain() });
       signedOutElements.css("display", "inline-block");
       signedInElements.hide();
     }
 
     function cookieDomain() {
-      var delim = ".";
-      var tld = location.hostname.split(delim);
-      tld.shift();
-      return tld.join(delim);
+      let delim = '.';
+      let hostname = location.hostname;
+      let tld = hostname.split(delim).pop();
+
+      if (isNaN(Number(tld))) {
+        let domain = hostname.split(delim);
+        domain.shift();
+        return domain.join(delim) || hostname;
+      } else {
+        return hostname;
+      }
     }
   });
 })($, Cookies);


### PR DESCRIPTION
This brings the cookie-setting logic on www.habitat.sh more in line with [how we’re doing it on Builder](https://github.com/habitat-sh/habitat/blob/28859c52c6bafdd94ee00c8036250cc2fba9b28d/components/builder-web/app/browser.ts#L5-L17). It also removes a no-longer-used `featureFlags` cookie.

Signed-off-by: Christian Nunciato <chris@nunciato.org>

![tenor-211090555](https://user-images.githubusercontent.com/274700/34130486-d2d22a2a-e3fc-11e7-9707-0f951db1deb5.gif)


