### PR TITLE
Allow hyphens in origin key names

### DIFF
--- a/components/builder-web/app/util.ts
+++ b/components/builder-web/app/util.ts
@@ -90,8 +90,9 @@ export function parseKey(key) {
   const lines = key.trim().split('\n');
   const type = lines[0];
   const name = lines[1] || '';
-  const origin = name.split('-')[0]; // TODO: make work for non-origin keys
-  const revision = name.split('-')[1];
+  const delim = name.lastIndexOf('-');
+  const origin = name.slice(0, delim);
+  const revision = name.slice(delim + 1);
   const blankLine = lines[2];
   const body = lines[3];
 


### PR DESCRIPTION
This fixes a bug preventing upload of keys whose origin names contain hyphens.

Signed-off-by: Christian Nunciato <chris@nunciato.org>

Fixes #2856.

![tenor-184076209](https://user-images.githubusercontent.com/274700/34133762-7a3a0e3c-e40b-11e7-8c68-dbef79de64bf.gif)
