### PR TITLE
Give channel lists some breathing room

### DIFF
--- a/components/builder-web/app/package/package-versions/_package-versions.component.scss
+++ b/components/builder-web/app/package/package-versions/_package-versions.component.scss
@@ -8,14 +8,19 @@
       .release-name {
         display: block;
       }
-
-      hab-channels {
-        margin-right: $default-margin / 4;
-      }
     }
 
     .build-date {
       flex: 3;
+    }
+
+    .channels {
+      margin-top: -$default-margin;
+      margin-bottom: $default-margin;
+
+      hab-channels {
+        margin-right: 2px;
+      }
     }
   }
 }

--- a/components/builder-web/app/package/package-versions/package-versions.component.html
+++ b/components/builder-web/app/package/package-versions/package-versions.component.html
@@ -27,9 +27,6 @@
                 <span class="release-name">
                   <hab-copyable [text]="packageString(pkg)"></hab-copyable>
                 </span>
-                <hab-channels [channels]="pkg.channels"></hab-channels>
-                <hab-package-promote [origin]="pkg.origin" [name]="pkg.name" [version]="pkg.version" [release]="pkg.release" channel="stable"
-                  *ngIf="promotable(pkg)"></hab-package-promote>
               </div>
               <div class="column build-date">
                 {{ releaseToDate(pkg.release) }}
@@ -45,6 +42,17 @@
               </div>
               <hab-icon symbol="chevron-right"></hab-icon>
             </a>
+            <div class="channels">
+              <hab-channels [channels]="pkg.channels"></hab-channels>
+              <hab-package-promote
+                [origin]="pkg.origin"
+                [name]="pkg.name"
+                [version]="pkg.version"
+                [release]="pkg.release"
+                channel="stable"
+                *ngIf="promotable(pkg)">
+              </hab-package-promote>
+            </div>
           </li>
         </ul>
       </div>


### PR DESCRIPTION
In the Versions tab, channel lists are currently confined to the leftmost column, which can cause things to wrap strangely, particularly with the new Promote button. This gives those elements their own row, spanning all columns.

Signed-off-by: Christian Nunciato <chris@nunciato.org>

cc @ryankeairns 

![tenor-62173313](https://user-images.githubusercontent.com/274700/34135522-09c1c5ae-e416-11e7-97f0-af21e29373c5.gif)
