### PR TITLE
Hide tabs for non-origin members

### DIFF
--- a/components/builder-web/app/origin/origin-page/origin-keys-tab/origin-keys-tab.component.html
+++ b/components/builder-web/app/origin/origin-page/origin-keys-tab/origin-keys-tab.component.html
@@ -1,37 +1,39 @@
 <div class="origin-keys-tab-component body">
   <div class="content">
-    <section class="generate" *ngIf="memberOfOrigin">
-      <button mat-raised-button color="primary" (click)="generateKeys()">
-        Generate a key pair
-      </button>
-    </section>
-    <section class="private" *ngIf="memberOfOrigin">
-      <ul class="action-list">
-        <li class="heading">
-          <h4>Private Key</h4>
-          <h4>Actions</h4>
-        </li>
-        <li class="none" *ngIf="!privateKey">
-          <span>No private key found. You can generate a key pair above.</span>
-        </li>
-        <li class="item" *ngIf="privateKey">
-          <span class="column name">
-            <hab-icon symbol="visibility-off"></hab-icon>
-            <span>{{ privateKey }}</span>
-          </span>
-          <span class="column actions">
-            <a (click)="downloadPrivateKey()">
-              <hab-icon symbol="file-download" title="Download this key"></hab-icon>
-            </a>
-          </span>
-        </li>
-      </ul>
-      <button mat-raised-button color="basic" (click)="openKeyAddForm('private')" *ngIf="memberOfOrigin">
-        <hab-icon symbol="file-upload"></hab-icon>
-        Upload a private key
-      </button>
-    </section>
-    <hr>
+    <ng-container *ngIf="memberOfOrigin">
+      <section class="generate">
+        <button mat-raised-button color="primary" (click)="generateKeys()">
+          Generate a key pair
+        </button>
+      </section>
+      <section class="private">
+        <ul class="action-list">
+          <li class="heading">
+            <h4>Private Key</h4>
+            <h4>Actions</h4>
+          </li>
+          <li class="none" *ngIf="!privateKey">
+            <span>No private key found. You can generate a key pair above.</span>
+          </li>
+          <li class="item" *ngIf="privateKey">
+            <span class="column name">
+              <hab-icon symbol="visibility-off"></hab-icon>
+              <span>{{ privateKey }}</span>
+            </span>
+            <span class="column actions">
+              <a (click)="downloadPrivateKey()">
+                <hab-icon symbol="file-download" title="Download this key"></hab-icon>
+              </a>
+            </span>
+          </li>
+        </ul>
+        <button mat-raised-button color="basic" (click)="openKeyAddForm('private')" *ngIf="memberOfOrigin">
+          <hab-icon symbol="file-upload"></hab-icon>
+          Upload a private key
+        </button>
+      </section>
+      <hr>
+    </ng-container>
     <section class="public">
       <ul class="action-list">
         <li class="heading">
@@ -76,4 +78,3 @@
     </p>
   </aside>
 </div>
-

--- a/components/builder-web/app/origin/origin-page/origin-page.component.html
+++ b/components/builder-web/app/origin/origin-page/origin-page.component.html
@@ -8,9 +8,34 @@
     </div>
   </header>
   <nav class="tabs" mat-tab-nav-bar>
-    <a mat-tab-link *ngFor="let link of navLinks" [routerLink]="link" routerLinkActive #rla="routerLinkActive" [active]="rla.isActive">
-      {{link}}
-    </a>
+    <a mat-tab-link
+      routerLink="packages"
+      routerLinkActive
+      #packages="routerLinkActive"
+      [active]="packages.isActive">Packages</a>
+    <a mat-tab-link
+      routerLink="keys"
+      routerLinkActive
+      #keys="routerLinkActive"
+      [active]="keys.isActive">Keys</a>
+    <a mat-tab-link
+      routerLink="members"
+      routerLinkActive
+      #members="routerLinkActive"
+      [active]="members.isActive"
+      *ngIf="memberOfOrigin">Members</a>
+    <a mat-tab-link
+      routerLink="settings"
+      routerLinkActive
+      #settings="routerLinkActive"
+      [active]="settings.isActive"
+      *ngIf="memberOfOrigin">Settings</a>
+    <a mat-tab-link
+      routerLink="integrations"
+      routerLinkActive
+      #integrations="routerLinkActive"
+      [active]="integrations.isActive"
+      *ngIf="memberOfOrigin">Integrations</a>
   </nav>
   <router-outlet></router-outlet>
 </div>

--- a/components/builder-web/app/origin/origin-page/origin-page.component.ts
+++ b/components/builder-web/app/origin/origin-page/origin-page.component.ts
@@ -57,10 +57,6 @@ export class OriginPageComponent implements OnInit, OnDestroy {
     return Origin({ name: this.originName });
   }
 
-  get navLinks() {
-    return ['packages', 'keys', 'members', 'settings', 'integrations'];
-  }
-
   get features() {
     return this.store.getState().users.current.flags;
   }
@@ -81,7 +77,7 @@ export class OriginPageComponent implements OnInit, OnDestroy {
     return this.store.getState().origins.mine;
   }
 
-  get iAmPartOfThisOrigin() {
+  get memberOfOrigin() {
     return !!this.myOrigins.find(org => {
       return org['name'] === this.origin.name;
     });


### PR DESCRIPTION
This change hides the Members, Settings and Integrations tabs for signed-in users who don’t belong to the selected origin.

Signed-off-by: Christian Nunciato <chris@nunciato.org>

Fixes #3404.

![tenor-127194520](https://user-images.githubusercontent.com/274700/34179480-ecbb52ae-e4bf-11e7-8a23-193efb23f977.gif)

