### PR TITLE
Link origin names to origin-packages view

### DIFF
--- a/components/builder-web/app/origin/origin-page/origin-keys-tab/origin-keys-tab.component.ts
+++ b/components/builder-web/app/origin/origin-page/origin-keys-tab/origin-keys-tab.component.ts
@@ -42,8 +42,8 @@ export class OriginKeysTabComponent implements OnInit, OnDestroy {
   ngOnInit() {
     this.sub = this.route.parent.params.subscribe((params) => {
       this.origin = params['origin'];
-      this.store.dispatch(fetchMyOrigins(this.token));
-      this.store.dispatch(fetchOriginPublicKeys(this.origin, this.token));
+      this.fetchMyOrigins();
+      this.fetchPublicKeys();
     });
   }
 
@@ -131,5 +131,15 @@ export class OriginKeysTabComponent implements OnInit, OnDestroy {
       a.click();
       setTimeout(() => { document.body.removeChild(a); }, 100);
     }
+  }
+
+  private fetchMyOrigins() {
+    if (this.token) {
+      this.store.dispatch(fetchMyOrigins(this.token));
+    }
+  }
+
+  private fetchPublicKeys() {
+    this.store.dispatch(fetchOriginPublicKeys(this.origin, this.token));
   }
 }

--- a/components/builder-web/app/origin/origin-page/origin-packages-tab/origin-packages-tab.component.html
+++ b/components/builder-web/app/origin/origin-page/origin-packages-tab/origin-packages-tab.component.html
@@ -1,6 +1,6 @@
 <div class="body">
   <div class="content">
-    <section>
+    <section *ngIf="memberOfOrigin">
       <hab-project-settings
         [origin]="origin"
         [integrations]="integrations"

--- a/components/builder-web/app/origin/origin-page/origin-packages-tab/origin-packages-tab.component.ts
+++ b/components/builder-web/app/origin/origin-page/origin-packages-tab/origin-packages-tab.component.ts
@@ -30,6 +30,10 @@ export class OriginPackagesTabComponent {
     return this.store.getState().origins.currentIntegrations.integrations;
   }
 
+  get memberOfOrigin() {
+    return !!this.store.getState().origins.mine.find(origin => origin['name'] === this.origin);
+  }
+
   get origin() {
     return this.store.getState().origins.current.name;
   }

--- a/components/builder-web/app/origin/origin-page/origin-page-routing.module.ts
+++ b/components/builder-web/app/origin/origin-page/origin-page-routing.module.ts
@@ -20,13 +20,13 @@ import { OriginMembersTabComponent } from './origin-members-tab/origin-members-t
 import { OriginPackagesTabComponent } from './origin-packages-tab/origin-packages-tab.component';
 import { OriginSettingsTabComponent } from './origin-settings-tab/origin-settings-tab.component';
 import { OriginIntegrationsTabComponent } from './origin-integrations-tab/origin-integrations-tab.component';
+import { OriginMemberGuard } from '../../shared/guards/origin-member.guard';
 import { SignedInGuard } from '../../shared/guards/signed-in.guard';
 
 const routes: Routes = [
   {
     path: 'origins/:origin',
     component: OriginPageComponent,
-    canActivate: [SignedInGuard],
     children: [
       {
         path: '',
@@ -43,15 +43,18 @@ const routes: Routes = [
       },
       {
         path: 'members',
-        component: OriginMembersTabComponent
+        component: OriginMembersTabComponent,
+        canActivate: [SignedInGuard, OriginMemberGuard],
       },
       {
         path: 'settings',
-        component: OriginSettingsTabComponent
+        component: OriginSettingsTabComponent,
+        canActivate: [SignedInGuard, OriginMemberGuard],
       },
       {
         path: 'integrations',
-        component: OriginIntegrationsTabComponent
+        component: OriginIntegrationsTabComponent,
+        canActivate: [SignedInGuard, OriginMemberGuard]
       },
       {
         path: '**',

--- a/components/builder-web/app/origin/origin-page/origin-page.component.ts
+++ b/components/builder-web/app/origin/origin-page/origin-page.component.ts
@@ -36,11 +36,11 @@ export class OriginPageComponent implements OnInit, OnDestroy {
 
   ngOnInit() {
     this.store.dispatch(fetchOrigin(this.origin.name));
-    this.store.dispatch(fetchMyOrigins(this.token));
-    this.store.dispatch(fetchIntegrations(this.origin.name, this.token));
-    this.getPackages();
-    this.getProjects();
-    this.loadPackages = this.getPackages.bind(this);
+    this.fetchIntegrations();
+    this.fetchMyOrigins();
+    this.fetchPackages();
+    this.fetchProjects();
+    this.loadPackages = this.fetchPackages.bind(this);
   }
 
   ngOnDestroy() {
@@ -91,11 +91,25 @@ export class OriginPageComponent implements OnInit, OnDestroy {
     return visibility === 'private' ? 'ON' : 'OFF';
   }
 
-  getProjects() {
-    this.store.dispatch(fetchProjects(this.origin.name, this.token));
+  private fetchIntegrations() {
+    if (this.token) {
+      this.store.dispatch(fetchIntegrations(this.origin.name, this.token));
+    }
   }
 
-  getPackages() {
+  private fetchMyOrigins() {
+    if (this.token) {
+      this.store.dispatch(fetchMyOrigins(this.token));
+    }
+  }
+
+  private fetchProjects() {
+    if (this.token) {
+      this.store.dispatch(fetchProjects(this.origin.name, this.token));
+    }
+  }
+
+  private fetchPackages() {
     this.store.dispatch(getUniquePackages(this.origin.name, 0, this.token));
   }
 }

--- a/components/builder-web/app/package/package-routing.module.ts
+++ b/components/builder-web/app/package/package-routing.module.ts
@@ -21,6 +21,7 @@ import { PackageLatestComponent } from './package-latest/package-latest.componen
 import { PackageSettingsComponent } from './package-settings/package-settings.component';
 import { PackageReleaseComponent } from './package-release/package-release.component';
 import { PackageVersionsComponent } from './package-versions/package-versions.component';
+import { OriginMemberGuard } from '../shared/guards/origin-member.guard';
 import { SignedInGuard } from '../shared/guards/signed-in.guard';
 
 const routes: Routes = [
@@ -38,16 +39,18 @@ const routes: Routes = [
       },
       {
         path: 'builds',
-        component: PackageBuildsComponent
+        component: PackageBuildsComponent,
+        canActivate: [SignedInGuard, OriginMemberGuard]
       },
       {
         path: 'builds/:id',
-        component: PackageBuildComponent
+        component: PackageBuildComponent,
+        canActivate: [SignedInGuard, OriginMemberGuard]
       },
       {
         path: 'settings',
         component: PackageSettingsComponent,
-        canActivate: [SignedInGuard]
+        canActivate: [SignedInGuard, OriginMemberGuard]
       },
       {
         path: ':version',

--- a/components/builder-web/app/shared/breadcrumbs/breadcrumbs.component.html
+++ b/components/builder-web/app/shared/breadcrumbs/breadcrumbs.component.html
@@ -1,4 +1,4 @@
-<a [routerLink]="['/pkgs', ident.origin]">
+<a [routerLink]="['/origins', ident.origin]">
   {{ident.origin}}
 </a>
 <span *ngIf="ident.name">/</span>

--- a/components/builder-web/app/shared/shared.module.ts
+++ b/components/builder-web/app/shared/shared.module.ts
@@ -37,6 +37,7 @@ import { PlatformIconComponent } from './platform-icon/platform-icon.component';
 import { VisibilitySelectorComponent } from './visibility-selector/visibility-selector.component';
 import { KeysPipe } from './pipes/keys.pipe';
 import { SimpleConfirmDialog } from './dialog/simple-confirm/simple-confirm.dialog';
+import { OriginMemberGuard } from './guards/origin-member.guard';
 import { SignedInGuard } from './guards/signed-in.guard';
 
 @NgModule({
@@ -95,6 +96,7 @@ import { SignedInGuard } from './guards/signed-in.guard';
     SimpleConfirmDialog,
   ],
   providers: [
+    OriginMemberGuard,
     SignedInGuard
   ]
 })


### PR DESCRIPTION
Additionally, this change adds an Angular guard to restrict access to routes requiring origin membership (e.g., Members, Settings, Integrations, Package Builds & Jobs, Package Settings).

Signed-off-by: Christian Nunciato <chris@nunciato.org>

Fixes #3899, related to #3404.

![tenor-35493645](https://user-images.githubusercontent.com/274700/34183100-f35429b6-e4cd-11e7-837e-7e397d9c2047.gif)
