### PR TITLE
[builder-worker] Create network namespace only at server boot.

### DIFF
--- a/components/builder-worker/habitat/config/config.toml
+++ b/components/builder-worker/habitat/config/config.toml
@@ -4,12 +4,12 @@ key_dir = "{{pkg.svc_files_path}}"
 log_path = "{{pkg.svc_path}}/logs"
 bldr_channel = "{{cfg.bldr_channel}}"
 features_enabled = "{{cfg.features_enabled}}"
-airlock_enabled = {{cfg.airlock_enabled}}
 {{~#eachAlive bind.depot.members as |member|}}
 {{~#if @first}}
 bldr_url = "{{member.cfg.url}}"
 {{~/if}}
 {{~/eachAlive}}
+airlock_enabled = {{cfg.airlock_enabled}}
 {{~#if cfg.network_interface}}
 network_interface = "{{cfg.network_interface}}"
 {{~/if}}

--- a/components/builder-worker/habitat/default.toml
+++ b/components/builder-worker/habitat/default.toml
@@ -4,6 +4,7 @@ bldr_channel = "unstable"
 bldr_url = "https://bldr.habitat.sh"
 features_enabled = ""
 airlock_enabled = true
+recreate_ns_dir = false
 
 [github]
 url = "https://api.github.com"

--- a/components/builder-worker/src/config.rs
+++ b/components/builder-worker/src/config.rs
@@ -48,6 +48,8 @@ pub struct Config {
     /// Github application id to use for private repo access
     pub github: GitHubCfg,
     pub airlock_enabled: bool,
+    /// Whether or not to recreate network namespace if one already exists
+    pub recreate_ns_dir: bool,
     pub network_interface: Option<String>,
     pub network_gateway: Option<IpAddr>,
 }
@@ -62,6 +64,10 @@ impl Config {
             addrs.push((hb, queue, log));
         }
         addrs
+    }
+
+    pub fn ns_dir_path(&self) -> PathBuf {
+        self.data_path.join("network").join("airlock-ns")
     }
 }
 
@@ -78,6 +84,7 @@ impl Default for Config {
             features_enabled: "".to_string(),
             github: GitHubCfg::default(),
             airlock_enabled: true,
+            recreate_ns_dir: false,
             network_interface: None,
             network_gateway: None,
         }
@@ -119,6 +126,7 @@ mod tests {
         log_path = "/path/to/logs"
         key_dir = "/path/to/key"
         features_enabled = "FOO,BAR"
+        recreate_ns_dir = true
         network_interface = "eth1"
         network_gateway = "192.168.10.1"
 
@@ -147,6 +155,7 @@ mod tests {
         assert_eq!(&config.features_enabled, "FOO,BAR");
         assert_eq!(config.network_interface, Some(String::from("eth1")));
         assert_eq!(config.airlock_enabled, true);
+        assert_eq!(config.recreate_ns_dir, true);
         assert_eq!(
             config.network_gateway,
             Some(IpAddr::V4(Ipv4Addr::new(192, 168, 10, 1)))

--- a/components/builder-worker/src/lib.rs
+++ b/components/builder-worker/src/lib.rs
@@ -47,6 +47,7 @@ pub mod config;
 pub mod error;
 pub mod heartbeat;
 pub mod log_forwarder;
+mod network;
 pub mod runner;
 pub mod server;
 pub mod vcs;

--- a/components/builder-worker/src/network.rs
+++ b/components/builder-worker/src/network.rs
@@ -1,0 +1,107 @@
+// Copyright (c) 2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::net::IpAddr;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use error::{Error, Result};
+
+#[derive(Debug)]
+pub struct NetworkNamespace(PathBuf);
+
+impl NetworkNamespace {
+    pub fn new(path: PathBuf) -> Self {
+        NetworkNamespace(path)
+    }
+
+    pub fn create(&self, interface: &str, gateway: &IpAddr, user: &str) -> Result<()> {
+        let mut cmd = Command::new("airlock");
+        cmd.arg("netns");
+        cmd.arg("create");
+        cmd.arg("--interface");
+        cmd.arg(interface);
+        cmd.arg("--gateway");
+        cmd.arg(gateway.to_string());
+        cmd.arg("--ns-dir");
+        cmd.arg(&self.0);
+        cmd.arg("--user");
+        cmd.arg(user);
+        debug!("building airlock networking setup command, cmd={:?}", &cmd);
+
+        debug!("spawning airlock networking setup command");
+        let mut child = cmd.spawn().map_err(|e| {
+            Error::AirlockNetworking(self.0.to_path_buf(), e)
+        })?;
+        let exit_status = child.wait().map_err(|e| {
+            Error::AirlockNetworking(self.0.to_path_buf(), e)
+        })?;
+        info!(
+            "completed airlock networking setup command, status={:?}",
+            exit_status
+        );
+
+        if exit_status.success() {
+            Ok(())
+        } else {
+            Err(Error::AirlockFailure(exit_status))
+        }
+    }
+
+    pub fn destroy(&self) -> Result<()> {
+        let mut cmd = Command::new("airlock");
+        cmd.arg("netns");
+        cmd.arg("destroy");
+        cmd.arg("--ns-dir");
+        cmd.arg(&self.0);
+        debug!(
+            "building airlock networking destroy command, cmd={:?}",
+            &cmd
+        );
+
+        debug!("spawning airlock networking destroy command");
+        let mut child = cmd.spawn().map_err(|e| {
+            Error::AirlockNetworking(self.0.to_path_buf(), e)
+        })?;
+        let exit_status = child.wait().map_err(|e| {
+            Error::AirlockNetworking(self.0.to_path_buf(), e)
+        })?;
+        info!(
+            "completed airlock networking destroy command, status={:?}",
+            exit_status
+        );
+
+        if exit_status.success() {
+            Ok(())
+        } else {
+            Err(Error::AirlockFailure(exit_status))
+        }
+    }
+
+    pub fn exists(&self) -> bool {
+        self.0.exists() && self.0.is_dir()
+    }
+
+    pub fn ns_dir(&self) -> &Path {
+        self.0.as_ref()
+    }
+
+    pub fn userns(&self) -> PathBuf {
+        self.0.join("userns")
+    }
+
+    pub fn netns(&self) -> PathBuf {
+        self.0.join("netns")
+    }
+}


### PR DESCRIPTION
This change modifies where and when an optional network namespace is set
up for use when running Studio builds.

Prior to this change a network namespace would be created just before
each `studio build` invocation and destroyed immediately afterwards.
Now, a namespace will be created when the worker service starts and
will, by default, reuse an existing network namespace (the key signal
being the presence of an `airlock-ns/` directory). The network namespace
management continues to be provided by the Airlock program.

If for some reason the existing network namespace needs to destroyed on
each start/restart of the worker service, a new configuration option of:

```toml
recreate_ns_dir = true
```

can be set. The default behavior set to `false` which will reuse any
network namespaces found.

Note that the failure scenarios are different, but hopefully more
desirable:

* On a fresh installation, a network namespace will be created once, at
boot.
* If the network namespace creation fails, this happens at worker boot
and will sent the service in a failed/flapping state, loudly explaining
what is happening. Previously failures of this nature would have been
delayed until build time.
* If a worker is upgraded or restarted, it will reuse an existing
network namespace setup.
* If the network namespace is having issues, an operator can enable
network namespace recreation mode by setting the `recreate_ns_dir =
true` as above. The Supervisor would restart a worker service and the
destroy/create logic would be fired.

Finally, note that one major failure scenario is still unaddressed: if
the network interface's settings are not restored after a network
namespace teardown, then re-creating the namespace will fail. The good
news is that such a failure would effectively bring the worker offline
since it can't finish booting itself and would put itself out of the
ready pool of workers (rather than leaving a pool of dead workers as is
the case now). This final failure scenario can most likely be solved by
restarting the host's networking service. Sadly, this failure is highly
dependant on the cloud platform and operating system combination.

Closes #4264