### PR TITLE
Fix platform icons in Versions tab

### DIFF
--- a/components/builder-web/app/package/package-versions/package-versions.component.html
+++ b/components/builder-web/app/package/package-versions/package-versions.component.html
@@ -15,7 +15,7 @@
         <span class="column">{{ version.release_count }}</span>
         <span class="column">{{ releaseToDate(version.latest) }}</span>
         <span class="column">
-          <hab-platform-icon [platform]="platform" *ngFor="let platform of platforms"></hab-platform-icon>
+          <hab-platform-icon [platform]="platform" *ngFor="let platform of platformsFor(version)"></hab-platform-icon>
         </span>
         <hab-icon class="toggle" [symbol]="toggleFor(version)"></hab-icon>
       </li>

--- a/components/builder-web/app/package/package-versions/package-versions.component.ts
+++ b/components/builder-web/app/package/package-versions/package-versions.component.ts
@@ -69,15 +69,13 @@ export class PackageVersionsComponent implements OnDestroy {
     }
   }
 
-  get platforms() {
+  platformsFor(version) {
     let targets = [];
 
-    this.versions.forEach((v) => {
-      v.platforms.forEach((p) => {
-        if (targets.indexOf(p) === -1) {
-          targets.push(p);
-        }
-      });
+    version.platforms.forEach((p) => {
+      if (targets.indexOf(p) === -1) {
+        targets.push(p);
+      }
     });
 
     return targets.sort();


### PR DESCRIPTION
This adds a filter based on the current version, rather than on all of them.

Fixes #4252.

Signed-off-by: Christian Nunciato <chris@nunciato.org>

![tenor-243982283](https://user-images.githubusercontent.com/274700/34187724-a4c2fa9c-e4e7-11e7-845e-dcced2878baa.gif)
