### PR TITLE
Fix ipc-channel dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,6 +131,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bincode"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "bitflags"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1594,9 +1603,9 @@ dependencies = [
 [[package]]
 name = "ipc-channel"
 version = "0.8.0"
-source = "git+https://github.com/habitat-sh/ipc-channel?branch=hbt-windows#2d085faf5bc053fb321e0d375b7328d023ea3436"
+source = "git+https://github.com/habitat-sh/ipc-channel?branch=hbt-windows#10db66846b47671a789c7c4517766b92a5afc992"
 dependencies = [
- "bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bincode 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3290,6 +3299,7 @@ dependencies = [
 "checksum backtrace-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "44585761d6161b0f57afc49482ab6bd067e4edef48c12a152c237eb0203f7661"
 "checksum base64 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6c902f607515b17ee069f2757c58a6d4b2afa7411b8995f96c4a3c19247b5fcf"
 "checksum bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e103c8b299b28a9c6990458b7013dc4a8356a9b854c51b9883241f5866fac36e"
+"checksum bincode 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9a6301db0b49fb63551bc15b5ae348147101cdf323242b93ec7546d5002ff1af"
 "checksum bitflags 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "32866f4d103c4e438b1db1158aa1b1a80ee078e5d77a59a2f906fd62a577389c"
 "checksum bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dead7461c1127cf637931a1e50934eb6eee8bff2f74433ac7909e9afcee04a3"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,15 +131,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bincode"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "bitflags"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -912,7 +903,7 @@ dependencies = [
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat-launcher-protocol 0.0.0",
  "habitat_core 0.0.0",
- "ipc-channel 0.8.0 (git+https://github.com/habitat-sh/ipc-channel?branch=hbt-windows)",
+ "ipc-channel 0.8.0 (git+https://github.com/habitat-sh/ipc-channel?rev=1323563890f0b01f376e9c277dd7c26cd34ca01d)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -928,7 +919,7 @@ dependencies = [
  "bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat-launcher-protocol 0.0.0",
  "habitat_core 0.0.0",
- "ipc-channel 0.8.0 (git+https://github.com/habitat-sh/ipc-channel?branch=hbt-windows)",
+ "ipc-channel 0.8.0 (git+https://github.com/habitat-sh/ipc-channel?rev=1323563890f0b01f376e9c277dd7c26cd34ca01d)",
  "libc 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1603,9 +1594,9 @@ dependencies = [
 [[package]]
 name = "ipc-channel"
 version = "0.8.0"
-source = "git+https://github.com/habitat-sh/ipc-channel?branch=hbt-windows#10db66846b47671a789c7c4517766b92a5afc992"
+source = "git+https://github.com/habitat-sh/ipc-channel?rev=1323563890f0b01f376e9c277dd7c26cd34ca01d#1323563890f0b01f376e9c277dd7c26cd34ca01d"
 dependencies = [
- "bincode 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3299,7 +3290,6 @@ dependencies = [
 "checksum backtrace-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "44585761d6161b0f57afc49482ab6bd067e4edef48c12a152c237eb0203f7661"
 "checksum base64 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6c902f607515b17ee069f2757c58a6d4b2afa7411b8995f96c4a3c19247b5fcf"
 "checksum bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e103c8b299b28a9c6990458b7013dc4a8356a9b854c51b9883241f5866fac36e"
-"checksum bincode 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9a6301db0b49fb63551bc15b5ae348147101cdf323242b93ec7546d5002ff1af"
 "checksum bitflags 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "32866f4d103c4e438b1db1158aa1b1a80ee078e5d77a59a2f906fd62a577389c"
 "checksum bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dead7461c1127cf637931a1e50934eb6eee8bff2f74433ac7909e9afcee04a3"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
@@ -3385,7 +3375,7 @@ dependencies = [
 "checksum if_chain 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "61bb90bdd39e3af69b0172dfc6130f6cd6332bf040fbb9bdd4401d37adbd48b8"
 "checksum inotify 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "887fcc180136e77a85e6a6128579a719027b1bab9b1c38ea4444244fe262c20c"
 "checksum iovec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "29d062ee61fccdf25be172e70f34c9f6efc597e1fb8f6526e8437b2046ab26be"
-"checksum ipc-channel 0.8.0 (git+https://github.com/habitat-sh/ipc-channel?branch=hbt-windows)" = "<none>"
+"checksum ipc-channel 0.8.0 (git+https://github.com/habitat-sh/ipc-channel?rev=1323563890f0b01f376e9c277dd7c26cd34ca01d)" = "<none>"
 "checksum ipnetwork 0.12.7 (registry+https://github.com/rust-lang/crates.io-index)" = "2134e210e2a024b5684f90e1556d5f71a1ce7f8b12e9ac9924c67fb36f63b336"
 "checksum iron 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2440ae846e7a8c7f9b401db8f6e31b4ea5e7d3688b91761337da7e054520c75b"
 "checksum iron-test 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "865d519985bc0a4fb64b5c44b8538b5252d716c6a6369ea3fc3bd035a15b6a16"

--- a/components/launcher-client/Cargo.toml
+++ b/components/launcher-client/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Jamie Winsor <reset@habitat.sh>"]
 bincode = "*"
 habitat_core = { path = "../core" }
 habitat-launcher-protocol = { path = "../launcher-protocol" }
-ipc-channel = { git = "https://github.com/habitat-sh/ipc-channel", branch = "hbt-windows" }
+ipc-channel = { git = "https://github.com/habitat-sh/ipc-channel", rev = "1323563890f0b01f376e9c277dd7c26cd34ca01d" }
 libc = "*"
 protobuf = "*"
 serde = "*"

--- a/components/launcher/Cargo.toml
+++ b/components/launcher/Cargo.toml
@@ -16,7 +16,7 @@ env_logger = "*"
 # put these things behind a feature flag so we can statically compile the launcher.
 habitat_core = { path = "../core" }
 habitat-launcher-protocol = { path = "../launcher-protocol" }
-ipc-channel = { git = "https://github.com/habitat-sh/ipc-channel", branch = "hbt-windows" }
+ipc-channel = { git = "https://github.com/habitat-sh/ipc-channel", rev = "1323563890f0b01f376e9c277dd7c26cd34ca01d" }
 libc = "*"
 log = "*"
 protobuf = "*"


### PR DESCRIPTION
The previously referenced commit doesn't exist in the `ipc-channel`
repo, resulting in an error when building:

```
root@vagrant:/src# cargo build --verbose
    Updating git repository `https://github.com/habitat-sh/ipc-channel`
error: failed to load source for a dependency on `ipc-channel`
Caused by:
  Unable to update https://github.com/habitat-sh/ipc-channel?branch=hbt-windows#2d085faf
Caused by:
  [4/-3] revspec '2d085faf5bc053fb321e0d375b7328d023ea3436' not found
```

Ran this with `cargo update -p ipc-channel` from the root of the repo.

--

## Update

Just using the latest commit didn't work, a it introduced a newer version of a dependency, with its own incompatibilities.

I instead opted for hard-coding the second-to-last commit.

It might be better to just fix the errors and use the latest version though, but since this is breaking builds today, I thought a quickfix might be useful.

Let me know if I should squash this.

Signed-off-by: Lorenzo Manacorda <lorenzo@kinvolk.io>