### PR TITLE
Sort origin projects alphabetically by package name

### DIFF
--- a/components/builder-originsrv/src/data_store.rs
+++ b/components/builder-originsrv/src/data_store.rs
@@ -279,7 +279,7 @@ impl DataStore {
         let conn = self.pool.get(opl)?;
         let origin = opl.get_origin();
 
-        let rows = conn.query("SELECT * FROM get_origin_project_list_v1($1)", &[&origin])
+        let rows = conn.query("SELECT * FROM get_origin_project_list_v2($1)", &[&origin])
             .map_err(SrvError::OriginProjectListGet)?;
 
         let mut response = originsrv::OriginProjectList::new();

--- a/components/builder-originsrv/src/migrations/origin_projects.rs
+++ b/components/builder-originsrv/src/migrations/origin_projects.rs
@@ -600,5 +600,15 @@ pub fn migrate(migrator: &mut Migrator) -> SrvResult<()> {
             END
         $$ LANGUAGE plpgsql VOLATILE"#,
     )?;
+    migrator.migrate(
+        "originsrv",
+        r#"CREATE OR REPLACE FUNCTION get_origin_project_list_v2 (
+                        in_origin text
+                 ) RETURNS SETOF origin_projects AS $$
+                        SELECT * FROM origin_projects
+                        WHERE origin_name = in_origin
+                        ORDER BY package_name;
+                    $$ LANGUAGE SQL STABLE"#,
+    )?;
     Ok(())
 }


### PR DESCRIPTION
This change adds a function revision that sorts by the `package_name` column in `origin_projects`.

Fixes #3916.

Signed-off-by: Christian Nunciato <chris@nunciato.org>

![tenor-160103882](https://user-images.githubusercontent.com/274700/34221581-62bd84c4-e56d-11e7-9967-397c22c14593.gif)
