### PR TITLE
[Cargo.lock] Temporarily pin ipc-channel to pre-upgrade commit.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1594,7 +1594,7 @@ dependencies = [
 [[package]]
 name = "ipc-channel"
 version = "0.8.0"
-source = "git+https://github.com/habitat-sh/ipc-channel?branch=hbt-windows#2d085faf5bc053fb321e0d375b7328d023ea3436"
+source = "git+https://github.com/habitat-sh/ipc-channel?branch=hbt-windows#1323563890f0b01f376e9c277dd7c26cd34ca01d"
 dependencies = [
  "bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
This change will be updated/removed once our Cargo dependency update
changeset is merged. The commit sha is updated to the commit immediately
prior to the ipc-channel update commit in the `hbt-windows` branch of
the Habitat fork. In this way, master should be buildable in the
meantime.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>