### PR TITLE
Force rustfmt install

### DIFF
--- a/support/ci/install_rustfmt.sh
+++ b/support/ci/install_rustfmt.sh
@@ -12,4 +12,4 @@ fi
 
 echo "--> Removing rustfmt version $(rustfmt --version) and installing $version"
 cargo uninstall rustfmt || true
-cargo install --vers $version rustfmt
+cargo install --vers $version --force rustfmt


### PR DESCRIPTION
Many open PRs are failing travis tests because travis can't install the version of rustfmt we want. This should fix that.

![tenor-59079840](https://user-images.githubusercontent.com/947/34234948-34eda5ac-e5a3-11e7-8b94-ca89e9edf590.gif)

Signed-off-by: Josh Black <raskchanky@gmail.com>