### PR TITLE
Fixes secondary button styles

### DIFF
--- a/www/source/blog/index.html.slim
+++ b/www/source/blog/index.html.slim
@@ -28,11 +28,10 @@ per_page: 10
                   onerror="this.src='/images/icons/icon-calendar.png'" alt="calendar icon"]
                 | #{article.date.strftime('%b %e, %Y')}
     - if paginate
-      - if prev_page
-        p.pagination-link
-          = link_to '<< Previous page', prev_page
-      - if next_page
-        p.pagination-link
-          = link_to 'Next page >>', next_page
+      p.pagination-link
+        - if prev_page
+          = link_to 'Newer posts', prev_page, class: 'button cta'
+        - if next_page
+          = link_to 'Older posts', next_page, class: 'button cta'
   .main-sidebar.columns.small-12.medium-3.medium-pull-9
     = partial("/partials/blog/blog_sidebar")

--- a/www/source/blog/tag.html.slim
+++ b/www/source/blog/tag.html.slim
@@ -37,9 +37,8 @@ layout: blog_index
                   onerror="this.src='/images/icons/icon-calendar.png'" alt="calendar icon"]
                 | #{article.date.strftime('%b %e, %Y')}
     - if paginate
-      - if prev_page
-        p.pagination-link
-          = link_to '<< Previous page', prev_page
-      - if next_page
-        p.pagination-link
-          = link_to 'Next page >>', next_page
+      p.pagination-link
+        - if prev_page
+          = link_to 'Newer posts', prev_page, class: 'button cta'
+        - if next_page
+          = link_to 'Older posts', next_page, class: 'button cta'

--- a/www/source/community.html.slim
+++ b/www/source/community.html.slim
@@ -59,7 +59,7 @@ section.community--roadmap
               li
                 a.button.cta href="https://portal.prodpad.com/24539" Request New Features
               li
-                a.button.outline href="https://ext.prodpad.com/ext/roadmap/d2938aed0d0ad1dd62669583e108357efd53b3a6" View Complete Roadmap
+                a.button.outline.contrast href="https://ext.prodpad.com/ext/roadmap/d2938aed0d0ad1dd62669583e108357efd53b3a6" View Complete Roadmap
         .row.roadmap-headings
           .columns.medium-4
             h5 Current
@@ -86,7 +86,7 @@ section.community--tracker
                 li
                   a.button.cta href="/docs/contribute/" target="_blank" Become a Contributor
                 li
-                  a.button.outline href="https://github.com/habitat-sh/habitat/projects/1" View Tracker on GitHub
+                  a.button.outline.contrast href="https://github.com/habitat-sh/habitat/projects/1" View Tracker on GitHub
 
 section.community--cta
   .row

--- a/www/source/pricing/index.html.slim
+++ b/www/source/pricing/index.html.slim
@@ -45,19 +45,13 @@ section.pricing--faq-section
     .columns.large-8.large-offset-2.faq-box.text-gray-dark
       = partial "partials/faq"
 section.pricing--contact-us
-  .row
-    .columns.large-8.large-offset-2.contact-box.background-white.text-align-center
-      h3.h4 Can't find what you're looking for?
-      p.mb-2 Contact us to get in touch or ask a question.
-      .columns.large-6.text-align-right
-        a.button.outline.text-link href="https://github.com/habitat-sh/habitat/" target="_blank" Find us on GitHub
-      .columns.large-6.text-align-left
-        a.button.outline.text-link href="http://slack.habitat.sh/" target="_blank" Join Our Slack Chat
+
 section.pricing--open-source
   .row
     .columns.large-8.large-offset-2.text-align-center.text-white
       h3 Habitat Open Source Community
-      p Habitat is supported by a passionate group of people.
-      a.button.cta href="http://slack.habitat.sh/" target="_blank" Join the Community
+      p Find people with answers through the Habitat project on GitHub or Slack.
+      a.button.cta href="https://github.com/habitat-sh/habitat/" target="_blank" View Habitat on GitHub
+      a.button.cta href="http://slack.habitat.sh/" target="_blank" Join Habitat on Slack
     .stars-left
     .stars-right

--- a/www/source/stylesheets/_global.scss
+++ b/www/source/stylesheets/_global.scss
@@ -325,6 +325,10 @@ code {
 
   &.outline {
     @include button;
+
+    &.contrast {
+      color: $hab-navy;
+    }    
   }
 
   &.download {

--- a/www/source/stylesheets/_pricing.scss
+++ b/www/source/stylesheets/_pricing.scss
@@ -127,8 +127,6 @@
   .button {
     @include breakpoint(small only) { width: 100%; }
   }
-
-  .button.outline { color: $hab-orange; }
 }
 
 .pricing {


### PR DESCRIPTION
Fixes #4374 

Buttons cleaned up on /community, /pricing, and /blog.

**Community page (2 fixes)**
![screenshot 2017-12-22 08 56 27](https://user-images.githubusercontent.com/446285/34302397-394f8e90-e6f6-11e7-9087-50fea0182ebf.png)
![screenshot 2017-12-22 08 56 34](https://user-images.githubusercontent.com/446285/34302400-3dcf2548-e6f6-11e7-9ef7-eb0a5d36c026.png)


**Pricing page**
![screenshot 2017-12-22 08 54 23](https://user-images.githubusercontent.com/446285/34302377-2cf1f2dc-e6f6-11e7-9f67-6f5685f08ecd.png)

**Blog index page (and tags)**
![screenshot 2017-12-22 08 56 56](https://user-images.githubusercontent.com/446285/34302406-4646175e-e6f6-11e7-81c2-2025919671c5.png)



Signed-off-by: Ryan Keairns <rkeairns@chef.io>