### PR TITLE
Remove debug() implementation; log `try()` messages to STDERR

### DIFF
--- a/components/studio/bin/hab-studio.sh
+++ b/components/studio/bin/hab-studio.sh
@@ -858,23 +858,6 @@ info() {
   return 0
 }
 
-# Prints a line only if the `$RUST_LOG` environment value is set to "debug".
-#
-# ```sh
-# RUST_LOG=debug
-# debug "Only if things are set"
-# # "DEBUG: Only if things are set"
-# unset RUST_LOG
-# debug "Not so much anymore"
-# ```
-#
-debug() {
-  if [ "${RUST_LOG:-}" = "debug" ]; then
-    echo "DEBUG: $1"
-  fi
-  return 0
-}
-
 # **Internal** Exit if current user is not root.
 ensure_root() {
   # Early return if we are root, yay!
@@ -1069,12 +1052,11 @@ cleanup_studio() {
 
 # **Internal**  Run a command which may fail without aborting whole script
 try() {
-  debug "TRYing '$*'"
   if "$@"; then
     status=$?
   else
     status=$?
-    debug "Warning: '$*' failed with status $status"
+    >&2 echo "Warning: '$*' failed with status $status"
   fi
 }
 


### PR DESCRIPTION
By emitting messages to `STDOUT`, the original implementation would
break anything that tried to capture the output of a call to `try`,
which we do in one place.

Furthermore, we already have a debug mechanism (based off the `$DEBUG`
environment variable, and using `set -x`). More refined log levels can
be work for the future.

Fixes #4380

Signed-off-by: Christopher Maier <cmaier@chef.io>