### PR TITLE
Turns out URL parameters and query parameters aren't the same thing.

### DIFF
--- a/components/builder-api/src/server/handlers.rs
+++ b/components/builder-api/src/server/handlers.rs
@@ -432,18 +432,11 @@ pub fn job_show(req: &mut Request) -> IronResult<Response> {
 }
 
 pub fn job_log(req: &mut Request) -> IronResult<Response> {
-    let start = match get_param(req, "start") {
-        Some(start) => {
-            match start.parse::<u64>() {
-                Ok(s) => s,
-                Err(e) => {
-                    debug!("Error parsing start. e = {:?}", e);
-                    return Ok(Response::with(status::BadRequest));
-                }
-            }
-        }
-        None => 0,
-    };
+    let start = req.get_ref::<Params>()
+        .unwrap()
+        .find(&["start"])
+        .and_then(FromValue::from_value)
+        .unwrap_or(0);
 
     let include_color = req.get_ref::<Params>()
         .unwrap()


### PR DESCRIPTION
This will correctly parse "start" out of the query parameters and fix
job log streaming.

![tenor-131912083](https://user-images.githubusercontent.com/947/34314942-730e11d2-e72e-11e7-8b94-60c49d4ce499.gif)

Signed-off-by: Josh Black <raskchanky@gmail.com>