### PR TITLE
Output final stderr for build in streaming web log.

### DIFF
--- a/components/builder-worker/src/runner/docker.rs
+++ b/components/builder-worker/src/runner/docker.rs
@@ -149,7 +149,7 @@ impl<'a> DockerExporter<'a> {
 
         debug!("spawning docker export command");
         let mut child = cmd.spawn().map_err(Error::Exporter)?;
-        log_pipe.pipe(&mut child)?;
+        log_pipe.pipe_process(&mut child)?;
         let exit_status = child.wait().map_err(Error::Exporter)?;
         debug!("completed docker export command, status={:?}", exit_status);
         Ok(exit_status)

--- a/components/builder-worker/src/runner/log_pipe.rs
+++ b/components/builder-worker/src/runner/log_pipe.rs
@@ -63,7 +63,7 @@ impl LogPipe {
     ///
     /// Contents of STDOUT are streamed before any from STDERR (if
     /// any).
-    pub fn pipe(&mut self, process: &mut process::Child) -> Result<()> {
+    pub fn pipe_process(&mut self, process: &mut process::Child) -> Result<()> {
         self.logger.log("About to log stdout");
         if let Some(ref mut stdout) = process.stdout {
             let reader = BufReader::new(stdout);
@@ -73,7 +73,7 @@ impl LogPipe {
         Ok(())
     }
 
-    pub fn pipe_stdout(&mut self, content: &[u8]) -> Result<()> {
+    pub fn pipe_buffer(&mut self, content: &[u8]) -> Result<()> {
         self.logger.log("About to log stdout");
         self.stream_lines(BufReader::new(content))?;
         self.logger.log("Finished logging stdout");

--- a/components/builder-worker/src/runner/mod.rs
+++ b/components/builder-worker/src/runner/mod.rs
@@ -356,7 +356,7 @@ impl Runner {
 
     fn build(&mut self) -> Result<PackageArchive> {
         let mut log_pipe = LogPipe::new(&self.workspace);
-        log_pipe.pipe_stdout(b"\n--- BEGIN: Studio build ---\n")?;
+        log_pipe.pipe_buffer(b"\n--- BEGIN: Studio build ---\n")?;
         let networking = match (
             self.config.network_interface.as_ref(),
             self.config.network_gateway.as_ref(),
@@ -373,7 +373,7 @@ impl Runner {
             self.config.airlock_enabled,
             networking,
         ).build(&mut log_pipe)?;
-        log_pipe.pipe_stdout(b"\n--- END: Studio build ---\n")?;
+        log_pipe.pipe_buffer(b"\n--- END: Studio build ---\n")?;
 
         if fs::rename(self.workspace.src().join("results"), self.workspace.out()).is_err() {
             return Err(Error::BuildFailure(status.code().unwrap_or(-2)));
@@ -389,13 +389,13 @@ impl Runner {
             // TODO fn: This check should be updated in PackageArchive is check for run hooks.
             if self.workspace.last_built()?.is_a_service() {
                 debug!("Found runnable package, running docker export");
-                log_pipe.pipe_stdout(b"\n--- BEGIN: Docker export ---\n")?;
+                log_pipe.pipe_buffer(b"\n--- BEGIN: Docker export ---\n")?;
                 status = DockerExporter::new(
                     util::docker_exporter_spec(&self.workspace),
                     &self.workspace,
                     &self.config.bldr_url,
                 ).export(&mut log_pipe)?;
-                log_pipe.pipe_stdout(b"\n--- END: Docker export ---\n")?;
+                log_pipe.pipe_buffer(b"\n--- END: Docker export ---\n")?;
             } else {
                 debug!("Package not runnable, skipping docker export");
             }


### PR DESCRIPTION
This was removed previously due to a pipe hangup.
I have added it back and ensured that we consume the stderr pipe

Closes: #4332

![tenor-152978497](https://user-images.githubusercontent.com/1130349/34535679-488f4b20-f088-11e7-86ab-2fb04420c66f.gif)

Signed-off-by: Travis Elliott Davis <edavis@chef.io>