### PR TITLE
Bump marked to 0.3.9

### DIFF
--- a/components/builder-web/package-lock.json
+++ b/components/builder-web/package-lock.json
@@ -5919,9 +5919,9 @@
       }
     },
     "marked": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
-      "integrity": "sha1-ssbGGPzOzk74bE/Gy4p8v1rtqNc="
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.9.tgz",
+      "integrity": "sha512-nW5u0dxpXxHfkHzzrveY45gCbi+R4PaO4WRZYqZNl+vB0hVGeqlFn0aOg1c8AKL63TrNFn9Bm2UP4AdiZ9TPLw=="
     },
     "media-typer": {
       "version": "0.3.0",

--- a/components/builder-web/package.json
+++ b/components/builder-web/package.json
@@ -55,7 +55,7 @@
     "immutable": "^3.8.1",
     "js-cookie": "^2.1.4",
     "lodash": "^4.17.4",
-    "marked": "^0.3.6",
+    "marked": "^0.3.9",
     "moment": "^2.18.1",
     "parse-link-header": "^0.4.1",
     "redux": "^3.6.0",


### PR DESCRIPTION
In response to:

https://nvd.nist.gov/vuln/detail/CVE-2017-1000427

![tenor-237636534](https://user-images.githubusercontent.com/274700/34586884-c42ae226-f15a-11e7-8dc9-d3956b7c1ba3.gif)

Signed-off-by: Christian Nunciato <chris@nunciato.org>