### PR TITLE
Create the directory for traces

### DIFF
--- a/components/butterfly/src/trace.rs
+++ b/components/butterfly/src/trace.rs
@@ -166,14 +166,25 @@ impl Trace {
         if self.file.is_none() {
             let now = time::now_utc();
             let filename = format!("{}-{}.swimtrace", server.name(), now.rfc3339());
-            match fs::File::create(self.directory.join(&filename)) {
-                Ok(f) => self.file = Some(f),
+            match fs::create_dir_all(&self.directory) {
+                Ok(_) => {
+                    match fs::File::create(self.directory.join(&filename)) {
+                        Ok(f) => self.file = Some(f),
+                        Err(e) => {
+                            panic!(
+                                "Trace requested, but cannot create file {:?}: {}",
+                                self.directory.join(&filename),
+                                e
+                            )
+                        }
+                    }
+                }
                 Err(e) => {
                     panic!(
-                        "Trace requested, but cannot create file {:?}: {}",
-                        self.directory.join(&filename),
+                        "Trace requested, but cannot create directory {:?}: {}",
+                        self.directory,
                         e
-                    )
+                    );
                 }
             }
         }


### PR DESCRIPTION
Without that, tracing usually fails, because it expects that the
`/tmp/habitat-swim-trace` directory already exists.

Signed-off-by: Krzesimir Nowak <krzesimir@kinvolk.io>