### PR TITLE
Update dev config script

### DIFF
--- a/support/builder/dev-config.sh
+++ b/support/builder/dev-config.sh
@@ -345,7 +345,7 @@ EOT
 
 mkdir -p /hab/svc/builder-worker
 cat <<EOT > /hab/svc/builder-worker/config.toml
-auth_token = "${HAB_AUTH_TOKEN}"
+key_dir = "/hab/svc/builder-worker/files"
 auto_publish = true
 log_level = "debug"
 airlock_enabled = false


### PR DESCRIPTION
This updates the config script for the dev environment by adding a new key_dir config, and removing the deprecated auth_token config for the builder-worker.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-123459764](https://user-images.githubusercontent.com/13542112/34626037-f27e34c4-f20f-11e7-9177-10025ea6d063.gif)
