### PR TITLE
CI: Update rustfmt to latest nightly: 0.3.4

### DIFF
--- a/support/ci/install_rustfmt.sh
+++ b/support/ci/install_rustfmt.sh
@@ -1,15 +1,16 @@
 #!/bin/bash
 set -eu
 
-version=0.9.0
+version=0.3.4
 
 if command -v rustfmt >/dev/null; then
-  if [[ $(rustfmt --version | cut -d ' ' -f 1) = "$version-nightly" ]]; then
+  if [[ $(cargo +nightly fmt -- --version | cut -d ' ' -f 1) = "$version-nightly" ]]; then
     echo "--> Detected rustfmt version $version, skipping install"
     exit 0
   fi
 fi
 
-echo "--> Removing rustfmt version $(rustfmt --version) and installing $version"
+echo "--> Removing rustfmt version $(cargo +nightly fmt -- --version) and installing $version"
 cargo uninstall rustfmt || true
-cargo install --vers $version --force rustfmt
+cargo uninstall rustfmt-nightly || true
+cargo +nightly install --vers $version --force rustfmt-nightly

--- a/support/ci/lint.sh
+++ b/support/ci/lint.sh
@@ -47,7 +47,7 @@ exit_with() {
 }
 
 program=$(basename $0)
-rf_version="0.9.0"
+rf_version="0.3.4"
 
 # Fix commit range in Travis, if set.
 # See: https://github.com/travis-ci/travis-ci/issues/4596
@@ -61,7 +61,7 @@ if ! command -v rustfmt >/dev/null; then
 fi
 
 info "Checking for version $rf_version of rustfmt"
-actual="$(rustfmt --version | cut -d ' ' -f 1)"
+actual="$(cargo +nightly fmt -- --version | cut -d ' ' -f 1)"
 if [[ "$actual" != "$rf_version-nightly" ]]; then
   exit_with "\`rustfmt' version $actual doesn't match expected: $rf_version" 2
 fi
@@ -97,7 +97,7 @@ eval "$cmd" | while read file; do
       fi
       info "Running rustfmt on $file"
       set +e
-      output="$(rustfmt --skip-children --write-mode diff "$file" 2>&1)"
+      output="$(cargo +nightly fmt -- --skip-children --write-mode diff "$file" 2>&1)"
       rf_exit="$?"
       set -e
       case $rf_exit in


### PR DESCRIPTION
Version 0.9.0 is already pretty old, considering that rustfmt tool
improves very fast. This will mean having to change formatting in a lot of
files but the sooner we update the lesser the needed changes. We don't
need to fix formatting of all files right away but leave that as a
homework for contributors to fix formatting in the files they touch with
their PR.

Signed-off-by: Zeeshan Ali <zeeshan@kinvolk.io>