### PR TITLE
Group ID defaults to User ID in exported Docker containers

### DIFF
--- a/components/pkg-export-docker/src/lib.rs
+++ b/components/pkg-export-docker/src/lib.rs
@@ -49,9 +49,11 @@ mod util;
 use std::env;
 
 use common::ui::UI;
-use aws_creds::StaticProvider;
-use hcore::channel;
+use hcore::{channel, PROGRAM_NAME};
 use hcore::url as hurl;
+
+use aws_creds::StaticProvider;
+use clap::App;
 use rusoto_core::Region;
 use rusoto_core::request::*;
 use rusoto_ecr::{Ecr, EcrClient, GetAuthorizationTokenRequest};
@@ -224,4 +226,19 @@ pub fn export_for_cli_matches(ui: &mut UI, matches: &clap::ArgMatches) -> Result
     }
 
     Ok(())
+}
+
+/// Create the Clap CLI for the Docker exporter
+pub fn cli<'a, 'b>() -> App<'a, 'b> {
+    let name: &str = &*PROGRAM_NAME;
+    let about = "Creates (an optionally pushes) a Docker image from a set of Habitat packages";
+
+    Cli::new(name, about)
+        .add_base_packages_args()
+        .add_builder_args()
+        .add_image_customization_args()
+        .add_tagging_args()
+        .add_publishing_args()
+        .add_pkg_ident_arg(PkgIdentArgOptions { multiple: true })
+        .app
 }

--- a/components/pkg-export-docker/src/main.rs
+++ b/components/pkg-export-docker/src/main.rs
@@ -25,11 +25,9 @@ extern crate chrono;
 #[macro_use]
 extern crate log;
 
-use clap::App;
 use common::ui::UI;
-use hcore::PROGRAM_NAME;
 
-use export_docker::{Cli, PkgIdentArgOptions, Result};
+use export_docker::Result;
 
 fn main() {
     env_logger::init().unwrap();
@@ -41,23 +39,9 @@ fn main() {
 }
 
 fn start(ui: &mut UI) -> Result<()> {
-    let cli = cli();
+    let cli = export_docker::cli();
     let m = cli.get_matches();
     debug!("clap cli args: {:?}", m);
 
     export_docker::export_for_cli_matches(ui, &m)
-}
-
-fn cli<'a, 'b>() -> App<'a, 'b> {
-    let name: &str = &*PROGRAM_NAME;
-    let about = "Creates (an optionally pushes) a Docker image from a set of Habitat packages";
-
-    Cli::new(name, about)
-        .add_base_packages_args()
-        .add_builder_args()
-        .add_image_customization_args()
-        .add_tagging_args()
-        .add_publishing_args()
-        .add_pkg_ident_arg(PkgIdentArgOptions { multiple: true })
-        .app
 }


### PR DESCRIPTION
Prior to the `--group-id` option (in #4310), the behavior was to have
the `SVC_GROUP`'s GID be the same as the `SVC_USER`'s UID, but that
was broken when the new option was added.

Now, the GID will be the same as the UID, unless specifically
overridden.