### PR TITLE
Adds a redirect to the env vars for people looking for scaffolding help

### DIFF
--- a/www/source/partials/docs/_reference-environment-vars.html.md.erb
+++ b/www/source/partials/docs/_reference-environment-vars.html.md.erb
@@ -1,13 +1,13 @@
 # <a name="environment-variables" id="environment-variables" data-magellan-target="environment-variables">Environment Variables</a>
 
-This is a list of all environment variables that can be used to modify the operation of Habitat.
+This is a list of all environment variables that can be used to modify the operation of the Habitat Studio and Supervisor. For information on defining environment variables with the scaffoldings, check out the "Define Environment Variables" section of <a href="/tutorials/build-your-own/">Build your web application with Habitat</a>!
 
 | Variable | Context | Default | Description |
 |----------|---------|---------|-------------|
 | `HAB_AUTH_TOKEN` | build system | no default | Authorization token used to perform privileged operations against the depot, e.g. uploading packages or keys.
 | `HAB_BINLINK_DIR` | build system | `/hab/bin` | Allows you to change the target directory for the symlink created when you run `hab pkg binlink`. The default value is already included in the `$PATH` variable inside the studio. |
 | `HAB_CACHE_KEY_PATH` | build system, Supervisor | `/hab/cache/keys` if running as root; `$HOME/.hab/cache/keys` if running as non-root | Cache directory for origin signing keys |
-| `HAB_BLDR_CHANNEL` | build system, Supervisor | `stable` | Set the Habitat Builder channel you are subscribing to, to a specific channel. Defaults to `stable`. 
+| `HAB_BLDR_CHANNEL` | build system, Supervisor | `stable` | Set the Habitat Builder channel you are subscribing to, to a specific channel. Defaults to `stable`.
 | `HAB_BLDR_URL` | build system, Supervisor | `https://bldr.habitat.sh` | Sets an alternate default endpoint for communicating with Builder. Used by the Habitat build system and the Supervisor |
 | `HAB_DOCKER_OPTS` | build system | no default | When running a studio on a platform that uses Docker (MacOS), additional command line options to pass to the `docker` command. |
 | `HAB_NOCOLORING` | build system | no default | If set to the lowercase string `"true"` this environment variable will unconditionally disable text coloring where possible |


### PR DESCRIPTION
A user was trying to figure out the information about how to use env vars
but they could not find anything in the plan file or scaffolding output.
There is no mention of it in the docs but it is in the learn/tutorials part.

Signed-off-by: Franklin Webber <franklin@chef.io>