### PR TITLE
add 2013 C runtime to hab binaries

### DIFF
--- a/components/hab/plan.ps1
+++ b/components/hab/plan.ps1
@@ -6,7 +6,7 @@ $pkg_license = @("Apache-2.0")
 $pkg_source = "https://s3-us-west-2.amazonaws.com/habitat-win-deps/hab-win-deps.zip"
 $pkg_shasum="00b34fb983ebc43bfff9e8e2220d23db200cb45494a4971a5e2e733f1d73d04b"
 $pkg_bin_dirs = @("bin")
-$pkg_build_deps = @("core/rust", "core/cacerts")
+$pkg_build_deps = @("core/visual-cpp-redist-2013", "core/rust", "core/cacerts")
 
 function Invoke-Prepare {
     if($env:HAB_CARGO_TARGET_DIR) {
@@ -46,4 +46,5 @@ function Invoke-Build {
 function Invoke-Install {
     Copy-Item "$env:CARGO_TARGET_DIR/release/hab.exe" "$pkg_prefix/bin/hab.exe"
     Copy-Item "$HAB_CACHE_SRC_PATH/$pkg_dirname/bin/*" "$pkg_prefix/bin"
+    Copy-Item "$(Get-HabPackagePath "visual-cpp-redist-2013")/bin/*" "$pkg_prefix/bin"
 }


### PR DESCRIPTION
We are currently unable to run the hab.exe binary on a clean windows machine because it now has a dep on the 2013 C runtime likely brought in by an upgraded crate.

Signed-off-by: mwrock <matt@mattwrock.com>