### PR TITLE
Change the name of command line flags to make more sense

### DIFF
--- a/components/op/src/config.rs
+++ b/components/op/src/config.rs
@@ -16,18 +16,15 @@
 pub struct Config {
     // file to hash
     pub file: Option<String>,
-    // origin to get the shard of
-    pub origin: Option<String>,
-    // account to get the shard of
-    pub account: Option<u64>,
+    // shard
+    pub shard: Option<String>,
 }
 
 impl Default for Config {
     fn default() -> Self {
         Config {
             file: None,
-            origin: None,
-            account: None,
+            shard: None,
         }
     }
 }

--- a/components/op/src/error.rs
+++ b/components/op/src/error.rs
@@ -20,8 +20,6 @@ use hcore;
 
 #[derive(Debug)]
 pub enum Error {
-    NoFile,
-    NoParam,
     HabitatCore(hcore::Error),
 }
 
@@ -30,10 +28,6 @@ pub type Result<T> = result::Result<T, Error>;
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let msg = match *self {
-            Error::NoFile => format!("No file was specified to hash"),
-            Error::NoParam => {
-                format!("No parameter was specified to get a shard from: try --origin or --account")
-            }
             Error::HabitatCore(ref e) => format!("{}", e),
         };
         write!(f, "{}", msg)
@@ -43,10 +37,6 @@ impl fmt::Display for Error {
 impl error::Error for Error {
     fn description(&self) -> &str {
         match *self {
-            Error::NoFile => "No file was specified to hash",
-            Error::NoParam => {
-                "No parameter was specified to get a shard from: try --origin or --account"
-            }
             Error::HabitatCore(ref err) => err.description(),
         }
     }


### PR DESCRIPTION
Back when I wrote this tool originally, the only thing it was used for was origin names and account ids, so that's what the command line flags were called.  Turns out that wasn't the best way to do things.  Now there's no more flags, because that's just unnecessary.  Now you can pass it a string or a number and it will just Do The Right Thing™.  I also deleted some errors because I updated clap to validate the command line args.

![tenor-209644849](https://user-images.githubusercontent.com/947/35120675-c617bed0-fc4d-11e7-9a87-8c446c5c61a8.gif)

Signed-off-by: Josh Black <raskchanky@gmail.com>