### PR TITLE
pause between starting out and err pipes

### DIFF
--- a/components/studio/bin/hab-studio.ps1
+++ b/components/studio/bin/hab-studio.ps1
@@ -330,6 +330,12 @@ function Enter-Studio {
     } | Out-Null
     $pr.start() | Out-Null
     $pr.BeginErrorReadLine()
+    
+    # As an industry, this should make us all feel bad
+    # without this stdin never seems to come back and the PS prompt
+    # fails to appear and things look like they are hung
+    Start-Sleep -Milliseconds 100
+
     $pr.BeginOutputReadLine()
     
     Write-Host  "** The Habitat Supervisor has been started in the background." -ForegroundColor Cyan


### PR DESCRIPTION
In a container, without this sleep, the PS prompt never comes back although execution does continue. Either removing the read on one of the pipes or pausing in between resolves this. Its not related to the fact that both write to the same file, it occurs even if the handlers are removes and if the studio is closed and reentered, subsequent reentries handle the subsequent reads just fine.

Signed-off-by: mwrock <matt@mattwrock.com>