### PR TITLE
Tar Exporter - The Next Generation

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -91,6 +91,14 @@ paths = [
   "components/sup/*",
 ]
 
+[hab-pkg-export-tar]
+plan_path = "components/pkg-export-tar"
+paths = [
+  "components/common/*",
+  "components/hab/*",
+  "components/pkg-export-tar/*"
+]
+
 # NOTE: cfize has a dependency on hab-pkg-dockerize, but we are
 # *explicitly not building* `hab-pkg-dockerize` any more. Read more at
 # components/pkg-dockerize/README.md

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
   global:
     - PATH=$HOME/.cargo/bin:$PATH
     # Habitat Rust program components
-    - _RUST_HAB_BIN_COMPONENTS="components/hab|components/hab-butterfly|components/launcher|components/pkg-export-docker|components/pkg-export-kubernetes|components/pkg-export-helm|components/sup|components/eventsrv
+    - _RUST_HAB_BIN_COMPONENTS="components/hab|components/hab-butterfly|components/launcher|components/pkg-export-docker|components/pkg-export-kubernetes|components/pkg-export-helm|components/sup|components/eventsrv|components/pkg-export-tar
     # Habitat Rust crate components
     - _RUST_HAB_LIB_COMPONENTS="components/builder-api-client|components/builder-depot-client|components/butterfly|components/common|components/eventsrv-client|components/launcher-client|components/github-api-client|components/segment-api-client
 
@@ -182,7 +182,7 @@ matrix:
 #
     - env:
         # These Habitat packages will build in the provided order
-        - PACKAGES="hab-pkg-aci hab-pkg-cfize hab-pkg-export-docker hab-pkg-export-kubernetes hab-pkg-export-helm hab-pkg-mesosize hab-pkg-tarize"
+        - PACKAGES="hab-pkg-aci hab-pkg-cfize hab-pkg-export-docker hab-pkg-export-kubernetes hab-pkg-export-helm hab-pkg-export-tar hab-pkg-mesosize hab-pkg-tarize"
         # HAB_AUTH_TOKEN
         - secure: "OCq9oDAEP3Cc0BiGrnZHE0FoNdyqsAy2LPTwEoOKvgiZdrw5o2bvpN1Kl+DKpw2auKtkeAS1aVSE/CMrglxrDs+VolvK9ttW3kj8c7+AeuCYjBsyWqdnZ1/24u6P+20fKanYrsMsnFb2r9OWwxZVlFnfmks81LWToOlGFJpL5KnmSPrB2vlWPbiaH9+yg8aslrmCq0reSoSVSnoZHoTolWtjzx2WdPYqA4gu0HHASVbH5qP+PoQSGIWvwbBaU4xhwkp1K8rWCjI8lre2YpBMOdfZv+9arMjc3Xg/kgD9oGU9DN7Q3UzAWxTSJv/3Cm4LArwiI57rXMLDKf8N1MhvGMHP1xgbuN8JWFKqFuWpqCf6qJkYG8+VZkruKYOo/2tXtBY4hpbR2abcWvYU/S9AQFHKGJQ2vcArnp5SKO+Oq/fNVneeHli4RbGMRQCMVq+X0SSC148F0zEVVwkNM5eq4askfc/2y4asySrH0MT/5T3yBp8fr3zXpnj82h2ytCZOUs0o+La9+wt5gSDUJHdY/BwSSPrgnKSp7ixslM/g7lMy3nAOs6qLql8/vW543CXBurCACWTqwKcy3/wRparTkmZcs1d7vUrbcfYv7XJzh0pw2P1hCjWD9BtkowbuLVo8K9ndPl2rbFY9XljqFXMTcHxp4ETeCc23azHCs+SYFb0="
         # HAB_ORIGIN_KEY

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -803,6 +803,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "habitat_pkg_export_tar"
+version = "0.0.0"
+dependencies = [
+ "base64 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.29.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.1 (git+https://github.com/withoutboats/failure.git)",
+ "failure_derive 0.1.1 (git+https://github.com/withoutboats/failure_derive.git)",
+ "hab 0.0.0",
+ "habitat_common 0.0.0",
+ "habitat_core 0.0.0 (git+https://github.com/habitat-sh/core.git)",
+ "handlebars 0.29.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mktemp 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tar 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "habitat_sup"
 version = "0.0.0"
 dependencies = [
@@ -1242,6 +1265,14 @@ dependencies = [
  "net2 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "mktemp"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "uuid 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1898,6 +1929,17 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "tar"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "filetime 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xattr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "tee"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2169,6 +2211,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "uuid"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "uuid"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -2253,6 +2304,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "xattr"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2389,6 +2448,7 @@ dependencies = [
 "checksum mio 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "75f72a93f046f1517e3cfddc0a096eb756a2ba727d36edc8227dee769a50a9b0"
 "checksum miow 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3e690c5df6b2f60acd45d56378981e827ff8295562fc8d34f573deb267a59cd1"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
+"checksum mktemp 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "77001ceb9eed65439f3dc2a2543f9ba1417d912686bf224a7738d0966e6dcd69"
 "checksum modifier 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "41f5c9112cb662acd3b204077e0de5bc66305fa8df65c8019d5adb10e9ab6e58"
 "checksum native-tls 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f74dbadc8b43df7864539cedb7bc91345e532fdd913cfdc23ad94f4d2d40fbc0"
 "checksum net2 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)" = "3a80f842784ef6c9a958b68b7516bc7e35883c614004dd94959a4dca1b716c09"
@@ -2466,6 +2526,7 @@ dependencies = [
 "checksum synstructure 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3a761d12e6d8dcb4dcf952a7a89b475e3a9d69e4a69307e01a470977642914bd"
 "checksum tabwriter 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3b7810162bc0a2eb2dc9a9bfd16ddb2d1f6022df3236d1478937bfadcb12385e"
 "checksum take 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b157868d8ac1f56b64604539990685fa7611d8fa9e5476cf0c02cf34d32917c5"
+"checksum tar 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)" = "1605d3388ceb50252952ffebab4b5dc43017ead7e4481b175961c283bb951195"
 "checksum tee 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "37c12559dba7383625faaff75be24becf35bfc885044375bcab931111799a3da"
 "checksum tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "87974a6f5c1dfb344d733055601650059a3363de2a6104819293baff662132d6"
 "checksum term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "fa63644f74ce96fbeb9b794f66aff2a52d601cbd5e80f4b97123e3899f4570f1"
@@ -2499,6 +2560,7 @@ dependencies = [
 "checksum userenv-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "71d28ea36bbd9192d75bd9fa9b39f96ddb986eaee824adae5d53b6e51919b2f3"
 "checksum users 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "99ab1b53affc9f75f57da4a8b051a188e84d20d43bea0dd9bd8db71eebbca6da"
 "checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
+"checksum uuid 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "78c590b5bd79ed10aad8fb75f078a59d8db445af6c743e55c4a53227fc01c13f"
 "checksum uuid 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bcc7e3b898aa6f6c08e5295b6c89258d1331e9ac578cc992fb818759951bdc22"
 "checksum vcpkg 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9e0a7d8bed3178a8fb112199d466eeca9ed09a14ba8ad67718179b4fd5487d0b"
 "checksum vec_map 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "887b5b631c2ad01628bbbaa7dd4c869f80d3186688f8d0b6f58774fbe324988c"
@@ -2513,6 +2575,7 @@ dependencies = [
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 "checksum wincolor 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a39ee4464208f6430992ff20154216ab2357772ac871d994c51628d60e58b8b0"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
+"checksum xattr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "5f04de8a1346489a2f9e9bd8526b73d135ec554227b17568456e86aa35b6f3fc"
 "checksum xml-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c1cb601d29fe2c2ac60a2b2e5e293994d87a1f6fa9687a31a15270f909be9c2"
 "checksum yaml-rust 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "57ab38ee1a4a266ed033496cf9af1828d8d6e6c1cfa5f643a2809effcae4d628"
 "checksum zmq 0.8.2 (git+https://github.com/erickt/rust-zmq?branch=release/v0.8)" = "<none>"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
   "components/pkg-export-docker",
   "components/pkg-export-helm",
   "components/pkg-export-kubernetes",
+  "components/pkg-export-tar",
   "components/segment-api-client",
   "components/sup"
 ]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,11 +37,11 @@ environment:
 
   matrix:
     - hab_build_action: "test;build"
-      hab_components: "http-client;builder-depot-client;common;sup;hab-butterfly;pkg-export-docker"
+      hab_components: "http-client;builder-depot-client;common;sup;hab-butterfly;pkg-export-docker;pkg-export-tar"
 
     - hab_build_action: "package"
       hab_exe_version: "%24latest"
-      hab_components: "hab;plan-build-ps1;studio;sup;hab-butterfly;pkg-export-docker;bintray-publish"
+      hab_components: "hab;plan-build-ps1;studio;sup;hab-butterfly;pkg-export-docker;pkg-export-tar;bintray-publish"
 
 build_script:
   - ps: Update-AppveyorBuild -Version "$((gc -raw ./VERSION).trim())-$((Get-Date).ToString('yyyyMMddHHmmss'))"

--- a/components/hab/src/command/pkg/export/mod.rs
+++ b/components/hab/src/command/pkg/export/mod.rs
@@ -21,6 +21,7 @@ pub mod docker;
 pub mod cf;
 pub mod helm;
 pub mod kubernetes;
+pub mod tar;
 
 mod export_common;
 
@@ -90,15 +91,6 @@ mod inner {
                         &format!("core/hab-pkg-mesosize/{}", version[0]),
                     )?,
                     cmd: "hab-pkg-mesosize".to_string(),
-                };
-                Ok(format)
-            }
-            "tar" => {
-                let format = ExportFormat {
-                    pkg_ident: PackageIdent::from_str(
-                        &format!("core/hab-pkg-tarize/{}", version[0]),
-                    )?,
-                    cmd: "hab-pkg-tarize".to_string(),
                 };
                 Ok(format)
             }

--- a/components/hab/src/command/pkg/export/tar.rs
+++ b/components/hab/src/command/pkg/export/tar.rs
@@ -1,0 +1,98 @@
+// Copyright (c) 2016-2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::ffi::OsString;
+
+use common::ui::UI;
+
+use error::Result;
+
+const EXPORT_CMD: &'static str = "hab-pkg-export-tar";
+
+pub fn start(ui: &mut UI, args: Vec<OsString>) -> Result<()> {
+    inner::start(ui, args)
+}
+
+#[cfg(not(target_os = "macos"))]
+mod inner {
+    use std::ffi::OsString;
+    use std::path::PathBuf;
+    use std::str::FromStr;
+
+    use common::ui::UI;
+    use hcore::crypto::{init, default_cache_key_path};
+    use hcore::env as henv;
+    use hcore::fs::find_command;
+    use hcore::os::process;
+    use hcore::package::PackageIdent;
+
+    use error::{Error, Result};
+    use exec;
+    use VERSION;
+    use super::EXPORT_CMD;
+
+    const EXPORT_CMD_ENVVAR: &'static str = "HAB_PKG_EXPORT_TAR_BINARY";
+    const EXPORT_PKG_IDENT: &'static str = "core/hab-pkg-export-tar";
+    const EXPORT_PKG_IDENT_ENVVAR: &'static str = "HAB_PKG_EXPORT_TAR_PKG_IDENT";
+
+    pub fn start(ui: &mut UI, args: Vec<OsString>) -> Result<()> {
+        let command = match henv::var(EXPORT_CMD_ENVVAR) {
+            Ok(command) => PathBuf::from(command),
+            Err(_) => {
+                init();
+                let ident = match henv::var(EXPORT_PKG_IDENT_ENVVAR) {
+                    Ok(ref ident_str) => PackageIdent::from_str(ident_str)?,
+                    Err(_) => {
+                        let version: Vec<&str> = VERSION.split("/").collect();
+                        PackageIdent::from_str(&format!("{}/{}", EXPORT_PKG_IDENT, version[0]))?
+                    }
+                };
+                let cmd = exec::command_from_min_pkg(
+                    ui,
+                    EXPORT_CMD,
+                    &ident,
+                    &default_cache_key_path(None),
+                    0,
+                )?;
+                PathBuf::from(cmd)
+            }
+        };
+        if let Some(cmd) = find_command(&command) {
+            Ok(process::become_command(cmd, args)?)
+        } else {
+            Err(Error::ExecCommandNotFound(command))
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+mod inner {
+    use std::ffi::OsString;
+
+    use common::ui::UI;
+
+    use error::{Error, Result};
+    use super::EXPORT_CMD;
+
+    pub fn start(ui: &mut UI, _args: Vec<OsString>) -> Result<()> {
+        let cmd = EXPORT_CMD.replace("hab", "").replace("-", " ");
+        ui.warn(format!(
+            "Running 'hab {}' on this operating system is not yet supported. \
+            Try running this command again on 64-bit Linux.",
+            &cmd
+        ))?;
+        ui.br()?;
+        Err(Error::SubcommandNotSupported(cmd.to_string()))
+    }
+}

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -720,6 +720,9 @@ fn exec_subcommand_if_called(ui: &mut UI) -> Result<()> {
         ("pkg", "export", "kubernetes") => {
             command::pkg::export::kubernetes::start(ui, env::args_os().skip(4).collect())
         }
+        ("pkg", "export", "tar") => {
+            command::pkg::export::tar::start(ui, env::args_os().skip(4).collect())
+        }
         ("run", _, _) => command::launcher::start(ui, env::args_os().skip(1).collect()),
         ("stu", _, _) | ("stud", _, _) | ("studi", _, _) | ("studio", _, _) => {
             command::studio::enter::start(ui, env::args_os().skip(2).collect())

--- a/components/pkg-export-docker/src/build.rs
+++ b/components/pkg-export-docker/src/build.rs
@@ -38,6 +38,11 @@ use error::{Error, Result};
 use rootfs;
 use util;
 
+// Much of this functionality is duplicated (or slightly modified)
+// in the tar exporter. This needs to be abstacted out in
+// the future for use with further exporters.
+// https://github.com/habitat-sh/habitat/issues/4522
+
 const DEFAULT_HAB_IDENT: &'static str = "core/hab";
 const DEFAULT_LAUNCHER_IDENT: &'static str = "core/hab-launcher";
 const DEFAULT_SUP_IDENT: &'static str = "core/hab-sup";

--- a/components/pkg-export-tar/Cargo.toml
+++ b/components/pkg-export-tar/Cargo.toml
@@ -1,23 +1,20 @@
 [package]
-name = "habitat_pkg_export_docker"
+name = "habitat_pkg_export_tar"
 version = "0.0.0"
-authors = ["Fletcher Nichol <fnichol@habitat.sh>"]
-build = "build.rs"
+authors = ["Nell Shamrell <nellshamrell@gmail.com>"]
 workspace = "../../"
 
 [lib]
-name = "habitat_pkg_export_docker"
+name = "habitat_pkg_export_tar"
 
-[[bin]]
-name = "hab-pkg-export-docker"
-path = "src/main.rs"
-doc = false
+[[bin]]                                                                
+name = "hab-pkg-export-tar"                                        
+path = "src/main.rs"                                  
+doc = false  
 
 [dependencies]
 base64 = "*"
 clap = { version = "*", features = ["suggestions", "color", "unstable"] }
-clippy = { version = "*", optional = true }
-chrono = "*"
 env_logger = "*"
 hab = { path = "../hab" }
 habitat_common = { path = "../common" }
@@ -25,16 +22,11 @@ habitat_core = { git = "https://github.com/habitat-sh/core.git" }
 handlebars = { version = "*", default-features = false }
 lazy_static = "*"
 log = "*"
-rusoto_core = "*"
-rusoto_credential = "*"
-rusoto_ecr = "*"
-serde = { version = "*", features = ["rc"] }
-serde_json = "*"
-tempdir = "*"
+mktemp = "*"
+serde = { version = "1.0", features = ["rc"] }
+serde_json = "1.0"
 url = "*"
 failure = { git = "https://github.com/withoutboats/failure.git" }
 failure_derive = { git = "https://github.com/withoutboats/failure_derive.git" }
-
-[features]
-default = []
-functional = []
+tempdir = "*"
+tar = "*"

--- a/components/pkg-export-tar/build.rs
+++ b/components/pkg-export-tar/build.rs
@@ -1,0 +1,6 @@
+// Inline common build behavior
+include!("../libbuild.rs");
+
+fn main() {
+    habitat::common();
+}

--- a/components/pkg-export-tar/plan.ps1
+++ b/components/pkg-export-tar/plan.ps1
@@ -1,0 +1,50 @@
+$pkg_name = "hab-pkg-export-tar"
+$pkg_origin = "core"
+$pkg_version = "$(Get-Content $PLAN_CONTEXT/../../VERSION)"
+$pkg_maintainer = "The Habitat Maintainers <humans@habitat.sh>"
+$pkg_license = @("Apache-2.0")
+$pkg_source = "https://s3-us-west-2.amazonaws.com/habitat-win-deps/hab-win-deps.zip"
+$pkg_shasum = "00b34fb983ebc43bfff9e8e2220d23db200cb45494a4971a5e2e733f1d73d04b"
+$pkg_bin_dirs = @("bin")
+$pkg_build_deps = @("core/visual-cpp-redist-2013", "core/rust", "core/cacerts")
+
+function Invoke-Prepare {
+    if($env:HAB_CARGO_TARGET_DIR) {
+        $env:CARGO_TARGET_DIR           = "$env:HAB_CARGO_TARGET_DIR"
+    }
+    else {
+        $env:CARGO_TARGET_DIR           = "$HAB_CACHE_SRC_PATH/$pkg_dirname"
+    }
+
+    $env:SSL_CERT_FILE              = "$(Get-HabPackagePath "cacerts")/ssl/certs/cacert.pem"
+    $env:PLAN_VERSION               = "$pkg_version/$pkg_release"
+    $env:LIB                        += ";$HAB_CACHE_SRC_PATH/$pkg_dirname/lib"
+    $env:INCLUDE                    += ";$HAB_CACHE_SRC_PATH/$pkg_dirname/include"
+    $env:SODIUM_LIB_DIR             = "$HAB_CACHE_SRC_PATH/$pkg_dirname/lib"
+    $env:LIBARCHIVE_INCLUDE_DIR     = "$HAB_CACHE_SRC_PATH/$pkg_dirname/include"
+    $env:LIBARCHIVE_LIB_DIR         = "$HAB_CACHE_SRC_PATH/$pkg_dirname/lib"
+    $env:OPENSSL_LIBS               = 'ssleay32:libeay32'
+    $env:OPENSSL_LIB_DIR            = "$HAB_CACHE_SRC_PATH/$pkg_dirname/lib"
+    $env:OPENSSL_INCLUDE_DIR        = "$HAB_CACHE_SRC_PATH/$pkg_dirname/include"
+}
+
+function Invoke-Unpack {
+  Expand-Archive -Path "$HAB_CACHE_SRC_PATH/hab-win-deps.zip" -DestinationPath "$HAB_CACHE_SRC_PATH/$pkg_dirname"
+}
+
+function Invoke-Build {
+    Push-Location "$PLAN_CONTEXT"
+    try {
+        cargo build --release
+        if($LASTEXITCODE -ne 0) {
+            Write-Error "Cargo build failed!"
+        }
+    }
+    finally { Pop-Location }
+}
+
+function Invoke-Install {
+    Copy-Item "$env:CARGO_TARGET_DIR/release/hab-pkg-export-tar.exe" "$pkg_prefix/bin/hab-pkg-export-tar.exe"
+    Copy-Item "$HAB_CACHE_SRC_PATH/$pkg_dirname/bin/*" "$pkg_prefix/bin"
+    Copy-Item "$(Get-HabPackagePath "visual-cpp-redist-2013")/bin/*" "$pkg_prefix/bin"
+}

--- a/components/pkg-export-tar/plan.sh
+++ b/components/pkg-export-tar/plan.sh
@@ -1,0 +1,79 @@
+pkg_name=hab-pkg-export-tar
+_pkg_distname=$pkg_name
+pkg_origin=core
+pkg_version=$(cat "$PLAN_CONTEXT/../../VERSION")
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=('Apache-2.0')
+pkg_deps=(core/coreutils core/findutils core/gawk core/grep core/bash core/tar core/gzip core/hab)
+pkg_build_deps=(
+  core/musl core/zlib-musl core/xz-musl core/bzip2-musl core/libarchive-musl
+  core/openssl-musl core/libsodium-musl
+  core/coreutils core/rust core/gcc core/make
+)
+
+pkg_bin_dirs=(bin)
+
+bin=$_pkg_distname
+
+_common_prepare() {
+  do_default_prepare
+
+  # Can be either `--release` or `--debug` to determine cargo build strategy
+  build_type="--release"
+  build_line "Building artifacts with \`${build_type#--}' mode"
+
+  # Used by the `build.rs` program to set the version of the binaries
+  export PLAN_VERSION="${pkg_version}/${pkg_release}"
+  build_line "Setting PLAN_VERSION=$PLAN_VERSION"
+
+  if [ -z "$HAB_CARGO_TARGET_DIR" ]; then
+    # Used by Cargo to use a pristine, isolated directory for all compilation
+    export CARGO_TARGET_DIR="$HAB_CACHE_SRC_PATH/$pkg_dirname"
+  else
+    export CARGO_TARGET_DIR="$HAB_CARGO_TARGET_DIR"
+  fi
+  build_line "Setting CARGO_TARGET_DIR=$CARGO_TARGET_DIR"
+}
+
+do_prepare() {
+  _common_prepare
+
+  export rustc_target="x86_64-unknown-linux-musl"
+  build_line "Setting rustc_target=$rustc_target"
+
+  la_ldflags="-L$(pkg_path_for zlib-musl)/lib -lz"
+  la_ldflags="$la_ldflags -L$(pkg_path_for xz-musl)/lib -llzma"
+  la_ldflags="$la_ldflags -L$(pkg_path_for bzip2-musl)/lib -lbz2"
+  la_ldflags="$la_ldflags -L$(pkg_path_for openssl-musl)/lib -lssl -lcrypto"
+
+  export LIBARCHIVE_LIB_DIR=$(pkg_path_for libarchive-musl)/lib
+  export LIBARCHIVE_INCLUDE_DIR=$(pkg_path_for libarchive-musl)/include
+  export LIBARCHIVE_LDFLAGS="$la_ldflags"
+  export LIBARCHIVE_STATIC=true
+  export OPENSSL_LIB_DIR=$(pkg_path_for openssl-musl)/lib
+  export OPENSSL_INCLUDE_DIR=$(pkg_path_for openssl-musl)/include
+  export OPENSSL_STATIC=true
+  export SODIUM_LIB_DIR=$(pkg_path_for libsodium-musl)/lib
+  export SODIUM_STATIC=true
+
+  # Used to find libgcc_s.so.1 when compiling `build.rs` in dependencies. Since
+  # this used only at build time, we will use the version found in the gcc
+  # package proper--it won't find its way into the final binaries.
+  export LD_LIBRARY_PATH=$(pkg_path_for gcc)/lib
+  build_line "Setting LD_LIBRARY_PATH=$LD_LIBRARY_PATH"
+
+  PLAN_TAR_PKG_IDENT=$(pkg_path_for tar | sed "s,^$HAB_PKG_PATH/,,")
+  export PLAN_TAR_PKG_IDENT
+  build_line "Setting PLAN_TAR_PKG_IDENT=$PLAN_TAR_PKG_IDENT"
+}
+
+do_build() {
+  pushd $PLAN_CONTEXT > /dev/null
+  cargo build ${build_type#--debug} --target=$rustc_target --verbose
+  popd > /dev/null
+}
+
+do_install() {
+  install -v -D $CARGO_TARGET_DIR/$rustc_target/${build_type#--}/$bin \
+    $pkg_prefix/bin/$bin
+}

--- a/components/pkg-export-tar/src/build.rs
+++ b/components/pkg-export-tar/src/build.rs
@@ -1,0 +1,254 @@
+// Copyright (c) 2016-2018 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fs as stdfs;
+#[cfg(target_os = "linux")]
+use std::os::unix::fs::symlink;
+#[cfg(target_os = "windows")]
+use std::os::windows::fs::symlink_dir as symlink;
+use clap;
+use common;
+use common::command::package::install::InstallSource;
+use common::ui::{UI, Status};
+use tempdir::TempDir;
+use std::path::Path;
+use hcore::package::PackageIdent;
+use error::Result;
+use hcore::PROGRAM_NAME;
+use hcore::fs::{CACHE_ARTIFACT_PATH, CACHE_KEY_PATH, cache_artifact_path, cache_key_path};
+
+use super::{VERSION, BUSYBOX_IDENT};
+
+use rootfs;
+
+// Much of this functionality is duplicated (or slightly modified)
+// from the Docker exporter. This needs to be abstacted out in
+// the future for use with further exporters.
+// https://github.com/habitat-sh/habitat/issues/4522
+const DEFAULT_HAB_IDENT: &'static str = "core/hab";
+const DEFAULT_LAUNCHER_IDENT: &'static str = "core/hab-launcher";
+const DEFAULT_SUP_IDENT: &'static str = "core/hab-sup";
+
+/// The specification for creating a temporary file system build root, based on Habitat packages.
+///
+/// When a `BuildSpec` is created, a `BuildRoot` is returned which can be used to produce exported
+/// images, archives, etc.
+#[derive(Debug)]
+pub struct BuildSpec<'a> {
+    /// A string representation of a Habitat Package Identifer for the Habitat CLI package.
+    pub hab: &'a str,
+    /// A string representation of a Habitat Package Identifer for the Habitat Launcher package.
+    pub hab_launcher: &'a str,
+    /// A string representation of a Habitat Package Identifer for the Habitat Supervisor package.
+    pub hab_sup: &'a str,
+    /// The Builder URL which is used to install all service and extra Habitat packages.
+    pub url: &'a str,
+    /// The Habitat release channel which is used to install all service and extra Habitat
+    /// packages.
+    pub channel: &'a str,
+    /// The Builder URL which is used to install all base Habitat packages.
+    pub base_pkgs_url: &'a str,
+    /// The Habitat release channel which is used to install all base Habitat packages.
+    pub base_pkgs_channel: &'a str,
+    /// A Habitat Package Identifer or local path to a Habitat Artifact file which
+    /// will be installed.
+    pub ident_or_archive: &'a str,
+}
+
+impl<'a> BuildSpec<'a> {
+    /// Creates a `BuildSpec` from cli arguments.
+    pub fn new_from_cli_matches(
+        m: &'a clap::ArgMatches,
+        default_channel: &'a str,
+        default_url: &'a str,
+    ) -> Self {
+
+        BuildSpec {
+            hab: m.value_of("HAB_PKG").unwrap_or(DEFAULT_HAB_IDENT),
+            hab_launcher: m.value_of("HAB_LAUNCHER_PKG").unwrap_or(
+                DEFAULT_LAUNCHER_IDENT,
+            ),
+            hab_sup: m.value_of("HAB_SUP_PKG").unwrap_or(DEFAULT_SUP_IDENT),
+            url: m.value_of("BLDR_URL").unwrap_or(&default_url),
+            channel: m.value_of("CHANNEL").unwrap_or(&default_channel),
+            base_pkgs_url: m.value_of("BASE_PKGS_BLDR_URL").unwrap_or(&default_url),
+            base_pkgs_channel: m.value_of("BASE_PKGS_CHANNEL").unwrap_or(&default_channel),
+            ident_or_archive: m.value_of("PKG_IDENT_OR_ARTIFACT").unwrap(),
+        }
+    }
+
+    /// Creates a `BuildRoot` for the given specification.
+    ///
+    /// # Errors
+    ///
+    /// * If a temporary directory cannot be created
+    /// * If the root file system cannot be created
+    /// * If the `BuildRootContext` cannot be created
+    pub fn create(self, ui: &mut UI) -> Result<(TempDir, PackageIdent)> {
+        let workdir = TempDir::new(&*PROGRAM_NAME)?;
+        let rootfs = workdir.path().join("rootfs");
+
+        ui.status(
+            Status::Creating,
+            format!("build root in {}", workdir.path().display()),
+        )?;
+
+        let created_ident = self.prepare_rootfs(ui, &rootfs)?;
+
+        Ok((workdir, created_ident))
+    }
+
+    fn prepare_rootfs<P: AsRef<Path>>(&self, ui: &mut UI, rootfs: P) -> Result<(PackageIdent)> {
+        ui.status(Status::Creating, "root filesystem")?;
+        if cfg!(target_os = "linux") {
+            rootfs::create(&rootfs)?;
+        }
+        self.create_symlink_to_artifact_cache(ui, &rootfs)?;
+        self.create_symlink_to_key_cache(ui, &rootfs)?;
+        self.install_base_pkgs(ui, &rootfs)?;
+        let ident = self.install_user_pkg(ui, self.ident_or_archive, &rootfs)?;
+        self.remove_symlink_to_key_cache(ui, &rootfs)?;
+        self.remove_symlink_to_artifact_cache(ui, &rootfs)?;
+
+        Ok(ident)
+    }
+
+    fn create_symlink_to_artifact_cache<P: AsRef<Path>>(
+        &self,
+        ui: &mut UI,
+        rootfs: P,
+    ) -> Result<()> {
+        ui.status(Status::Creating, "artifact cache symlink")?;
+        let src = cache_artifact_path(None::<P>);
+        let dst = rootfs.as_ref().join(CACHE_ARTIFACT_PATH);
+        stdfs::create_dir_all(dst.parent().expect("parent directory exists"))?;
+        debug!(
+            "Symlinking src: {} to dst: {}",
+            src.display(),
+            dst.display()
+        );
+
+        Ok(symlink(src, dst)?)
+    }
+
+    fn create_symlink_to_key_cache<P: AsRef<Path>>(&self, ui: &mut UI, rootfs: P) -> Result<()> {
+        ui.status(Status::Creating, "key cache symlink")?;
+        let src = cache_key_path(None::<P>);
+        let dst = rootfs.as_ref().join(CACHE_KEY_PATH);
+        stdfs::create_dir_all(dst.parent().expect("parent directory exists"))?;
+        debug!(
+            "Symlinking src: {} to dst: {}",
+            src.display(),
+            dst.display()
+        );
+
+        Ok(symlink(src, dst)?)
+    }
+
+    fn install_base_pkgs<P: AsRef<Path>>(&self, ui: &mut UI, rootfs: P) -> Result<BasePkgIdents> {
+        let hab = self.install_base_pkg(ui, self.hab, &rootfs)?;
+        let sup = self.install_base_pkg(ui, self.hab_sup, &rootfs)?;
+        let launcher = self.install_base_pkg(ui, self.hab_launcher, &rootfs)?;
+        let busybox = if cfg!(target_os = "linux") {
+            Some(self.install_base_pkg(ui, BUSYBOX_IDENT, &rootfs)?)
+        } else {
+            None
+        };
+
+        Ok(BasePkgIdents {
+            hab,
+            sup,
+            launcher,
+            busybox,
+        })
+    }
+
+    fn install_base_pkg<P: AsRef<Path>>(
+        &self,
+        ui: &mut UI,
+        ident_or_archive: &str,
+        fs_root_path: P,
+    ) -> Result<PackageIdent> {
+        self.install(
+            ui,
+            ident_or_archive,
+            self.base_pkgs_url,
+            self.base_pkgs_channel,
+            fs_root_path,
+        )
+    }
+
+    fn install_user_pkg<P: AsRef<Path>>(
+        &self,
+        ui: &mut UI,
+        ident_or_archive: &str,
+        fs_root_path: P,
+    ) -> Result<PackageIdent> {
+        self.install(ui, ident_or_archive, self.url, self.channel, fs_root_path)
+    }
+
+    fn install<P: AsRef<Path>>(
+        &self,
+        ui: &mut UI,
+        ident_or_archive: &str,
+        url: &str,
+        channel: &str,
+        fs_root_path: P,
+    ) -> Result<PackageIdent> {
+
+        let install_source: InstallSource = ident_or_archive.parse()?;
+        let package_install = common::command::package::install::start(
+            ui,
+            url,
+            Some(channel),
+            &install_source,
+            &*PROGRAM_NAME,
+            VERSION,
+            &fs_root_path,
+            &cache_artifact_path(Some(&fs_root_path)),
+            None,
+        )?;
+        Ok(package_install.into())
+    }
+
+    fn remove_symlink_to_artifact_cache<P: AsRef<Path>>(
+        &self,
+        ui: &mut UI,
+        rootfs: P,
+    ) -> Result<()> {
+        ui.status(Status::Deleting, "artifact cache symlink")?;
+        stdfs::remove_dir_all(rootfs.as_ref().join(CACHE_ARTIFACT_PATH))?;
+        Ok(())
+    }
+
+    fn remove_symlink_to_key_cache<P: AsRef<Path>>(&self, ui: &mut UI, rootfs: P) -> Result<()> {
+        ui.status(Status::Deleting, "artifact key symlink")?;
+        stdfs::remove_dir_all(rootfs.as_ref().join(CACHE_KEY_PATH))?;
+
+        Ok(())
+    }
+}
+
+/// The package identifiers for installed base packages.
+#[derive(Debug)]
+struct BasePkgIdents {
+    /// Installed package identifer for the Habitat CLI package.
+    pub hab: PackageIdent,
+    /// Installed package identifer for the Supervisor package.
+    pub sup: PackageIdent,
+    /// Installed package identifer for the Launcher package.
+    pub launcher: PackageIdent,
+    /// Installed package identifer for the Busybox package.
+    pub busybox: Option<PackageIdent>,
+}

--- a/components/pkg-export-tar/src/cli.rs
+++ b/components/pkg-export-tar/src/cli.rs
@@ -1,0 +1,143 @@
+use clap::{App, Arg};
+use std::result;
+use std::str::FromStr;
+
+use url::Url;
+use common::command::package::install::InstallSource;
+
+/// The version of this library and program when built.
+pub const VERSION: &'static str = include_str!(concat!(env!("OUT_DIR"), "/VERSION"));
+
+#[derive(Clone)]
+pub struct Cli<'a, 'b>
+where
+    'a: 'b,
+{
+    pub app: App<'a, 'b>,
+}
+
+impl<'a, 'b> Cli<'a, 'b> {
+    pub fn new(name: &str, about: &'a str) -> Self {
+        Cli {
+            app: clap_app!(
+            (name) =>
+            (about: about)
+            (version: VERSION)
+            (author: "\nAuthors: The Habitat Maintainers <humans@habitat.sh>\n\n")
+            ),
+        }
+    }
+
+    pub fn add_base_packages_args(self) -> Self {
+        let app = self.app
+            .arg(
+                Arg::with_name("HAB_PKG")
+                    .long("hab-pkg")
+                    .value_name("HAB_PKG")
+                    .validator(valid_ident_or_hart)
+                    .help(
+                        "Habitat CLI package identifier (ex: acme/redis) or filepath to a Habitat \
+                        artifact (ex: /home/acme-redis-3.0.7-21120102031201-x86_64-linux.hart) to \
+                        install (default: core/hab)",
+                    ),
+            )
+            .arg(
+                Arg::with_name("HAB_LAUNCHER_PKG")
+                    .long("launcher-pkg")
+                    .value_name("HAB_LAUNCHER_PKG")
+                    .validator(valid_ident_or_hart)
+                    .help(
+                        "Launcher package identifier (ex: core/hab-launcher) or filepath to a \
+                        Habitat artifact (ex: \
+                        /home/core-hab-launcher-6083-20171101045646-x86_64-linux.hart) to install \
+                        (default: core/hab-launcher)",
+                    ),
+            )
+            .arg(
+                Arg::with_name("HAB_SUP_PKG")
+                    .long("sup-pkg")
+                    .value_name("HAB_SUP_PKG")
+                    .validator(valid_ident_or_hart)
+                    .help(
+                        "Supervisor package identifier (ex: core/hab-sup) or filepath to a Habitat \
+                        artifact (ex: \
+                        /home/ore-hab-sup-0.39.1-20171118011657-x86_64-linux.hart) to install \
+                        (default: core/hab-sup)",
+                    ),
+            );
+
+        Cli { app: app }
+    }
+
+    pub fn add_builder_args(self) -> Self {
+        let app = self.app
+            .arg(
+                Arg::with_name("BLDR_URL")
+                    .long("url")
+                    .short("u")
+                    .value_name("BLDR_URL")
+                    .validator(valid_url)
+                    .help(
+                        "Install packages from Builder at the specified URL \
+                        (default: https://bldr.habitat.sh)",
+                    ),
+            )
+            .arg(
+                Arg::with_name("CHANNEL")
+                    .long("channel")
+                    .short("c")
+                    .value_name("CHANNEL")
+                    .help(
+                        "Install packages from the specified release channel (default: stable)",
+                    ),
+            )
+            .arg(
+                Arg::with_name("BASE_PKGS_BLDR_URL")
+                    .long("base-pkgs-url")
+                    .value_name("BASE_PKGS_BLDR_URL")
+                    .validator(valid_url)
+                    .help(
+                        "Install base packages from Builder at the specified URL \
+                        (default: https://bldr.habitat.sh)",
+                    ),
+            )
+            .arg(
+                Arg::with_name("BASE_PKGS_CHANNEL")
+                    .long("base-pkgs-channel")
+                    .value_name("BASE_PKGS_CHANNEL")
+                    .help(
+                        "Install base packages from the specified release channel \
+                        (default: stable)",
+                    ),
+            );
+
+        Cli { app: app }
+    }
+    pub fn add_pkg_ident_arg(self) -> Self {
+        let help = "A Habitat package identifier (ex: acme/redis) and/or filepath to \
+            a Habitat Artifact (ex: /home/acme-redis-3.0.7-21120102031201-x86_64-linux.hart)";
+
+        let app = self.app.arg(
+            Arg::with_name("PKG_IDENT_OR_ARTIFACT")
+                .value_name("PKG_IDENT_OR_ARTIFACT")
+                .required(true)
+                .help(help),
+        );
+
+        Cli { app: app }
+    }
+}
+
+fn valid_ident_or_hart(val: String) -> result::Result<(), String> {
+    match InstallSource::from_str(&val) {
+        Ok(_) => Ok(()),
+        Err(e) => Err(format!("{}", e)),
+    }
+}
+
+fn valid_url(val: String) -> result::Result<(), String> {
+    match Url::parse(&val) {
+        Ok(_) => Ok(()),
+        Err(_) => Err(format!("URL: '{}' is not valid", &val)),
+    }
+}

--- a/components/pkg-export-tar/src/error.rs
+++ b/components/pkg-export-tar/src/error.rs
@@ -1,0 +1,15 @@
+use base64::DecodeError;
+use std::result;
+use failure;
+
+pub type Result<T> = result::Result<T, failure::Error>;
+
+#[derive(Debug, Fail)]
+pub enum Error {
+    #[fail(display = "{}", _0)]
+    Base64DecodeError(DecodeError),
+    #[fail(display = "A primary service package could not be determined from: {:?}. \
+                     At least one package with a run hook must be provided.",
+           _0)]
+    PrimaryServicePackageNotFound(Vec<String>),
+}

--- a/components/pkg-export-tar/src/lib.rs
+++ b/components/pkg-export-tar/src/lib.rs
@@ -1,0 +1,112 @@
+#[macro_use]
+extern crate clap;
+extern crate habitat_core as hcore;
+extern crate url;
+extern crate habitat_common as common;
+extern crate base64;
+
+extern crate hab;
+extern crate handlebars;
+
+extern crate mktemp;
+extern crate tempdir;
+extern crate failure;
+#[macro_use]
+extern crate failure_derive;
+extern crate lazy_static;
+#[macro_use]
+extern crate log;
+extern crate serde_json;
+extern crate tar;
+
+mod build;
+pub mod cli;
+mod error;
+mod rootfs;
+
+use std::path::{Path, PathBuf};
+use std::fs::File;
+pub use cli::Cli;
+pub use error::{Error, Result};
+use common::ui::UI;
+use hcore::channel;
+use hcore::url as hurl;
+use hcore::package::{PackageIdent, PackageInstall};
+use tar::Builder;
+use std::str::FromStr;
+
+pub use build::BuildSpec;
+
+/// The version of this library and program when built.
+pub const VERSION: &'static str = include_str!(concat!(env!("OUT_DIR"), "/VERSION"));
+/// The Habitat Package Identifier string for a Busybox package.
+const BUSYBOX_IDENT: &'static str = "core/busybox-static";
+
+pub fn export_for_cli_matches(ui: &mut UI, matches: &clap::ArgMatches) -> Result<()> {
+    let default_channel = channel::default();
+    let default_url = hurl::default_bldr_url();
+    let spec = BuildSpec::new_from_cli_matches(&matches, &default_channel, &default_url);
+    export(ui, spec)?;
+
+    Ok(())
+}
+
+pub fn export(ui: &mut UI, build_spec: BuildSpec) -> Result<()> {
+    let hab_pkg = build_spec.hab;
+    let build_result = build_spec.create(ui).unwrap();
+    let builder_dir_path = build_result.0.path();
+    let pkg_ident = build_result.1;
+
+    tar_command(builder_dir_path, pkg_ident, hab_pkg);
+    Ok(())
+}
+
+#[allow(unused_must_use)]
+fn tar_command(temp_dir_path: &Path, pkg_ident: PackageIdent, hab_pkg: &str) {
+    let tarball_name = format_tar_name(pkg_ident);
+
+    let tarball = File::create(tarball_name).unwrap();
+    let mut tar_builder = Builder::new(tarball);
+    tar_builder.follow_symlinks(false);
+
+    let root_fs = temp_dir_path.clone().join("rootfs");
+    let hab_pkgs_path = temp_dir_path.clone().join("rootfs/hab");
+
+    // Although this line of code DOES work (it adds the required directories
+    // and subdirectories to the tarball), it also returns an error
+    // thread 'main' panicked at 'could not export.: "Is a directory (os error 21)"'
+    // , /checkout/src/libcore/result.rs:906:4
+    // An issue re: this error has been opened in the github repo of tar-rs
+    // https://github.com/alexcrichton/tar-rs/issues/147
+    // Until this is sorted out, I am not doing anything with the result
+    // that is returned by this command -NSH
+    tar_builder.append_dir_all("hab", hab_pkgs_path);
+
+    // Find the path to the hab binary
+    let mut hab_pkg_binary_path = hab_install_path(hab_package_ident(hab_pkg), root_fs);
+    hab_pkg_binary_path.push("bin");
+
+    // Append the hab binary to the tar ball
+    tar_builder.append_dir_all("hab/bin", hab_pkg_binary_path);
+}
+
+fn format_tar_name(ident: PackageIdent) -> String {
+    format!(
+        "{}-{}-{}-{}.tar.gz",
+        ident.origin,
+        ident.name,
+        ident.version.unwrap(),
+        ident.release.unwrap()
+    )
+}
+
+fn hab_package_ident(hab_pkg: &str) -> PackageIdent {
+    PackageIdent::from_str(hab_pkg).unwrap()
+}
+
+fn hab_install_path(hab_ident: PackageIdent, root_fs_path: PathBuf) -> PathBuf {
+    let root_fs_path = Path::new(&root_fs_path);
+    PackageInstall::load(&hab_ident, Some(root_fs_path))
+        .unwrap()
+        .installed_path
+}

--- a/components/pkg-export-tar/src/main.rs
+++ b/components/pkg-export-tar/src/main.rs
@@ -1,0 +1,38 @@
+extern crate clap;
+extern crate env_logger;
+extern crate habitat_core as hcore;
+extern crate habitat_common as common;
+extern crate habitat_pkg_export_tar as export_tar;
+#[macro_use]
+extern crate log;
+
+use clap::App;
+use common::ui::UI;
+use hcore::PROGRAM_NAME;
+use export_tar::{Cli, Result};
+
+fn main() {
+    let mut ui = UI::default_with_env();
+    if let Err(e) = start(&mut ui) {
+        ui.fatal(e).unwrap();
+        std::process::exit(1)
+    }
+}
+
+fn start(ui: &mut UI) -> Result<()> {
+    let cli = cli();
+    let m = cli.get_matches();
+    debug!("clap cli args: {:?}", m);
+
+    export_tar::export_for_cli_matches(ui, &m)
+}
+
+fn cli<'a, 'b>() -> App<'a, 'b> {
+    let name: &str = &*PROGRAM_NAME;
+    let about = "Creates a tar package from a Habitat package";
+    Cli::new(name, about)
+        .add_base_packages_args()
+        .add_builder_args()
+        .add_pkg_ident_arg()
+        .app
+}

--- a/components/pkg-export-tar/src/rootfs.rs
+++ b/components/pkg-export-tar/src/rootfs.rs
@@ -1,0 +1,36 @@
+// Copyright (c) 2016-2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fs;
+use std::path::Path;
+
+use hcore::os::filesystem;
+
+use error::Result;
+
+/// Creates a root file system under the given path.
+///
+/// # Errors
+///
+/// * If files and/or directories cannot be created
+/// * If permissions for files and/or directories cannot be set
+pub fn create<T>(root: T) -> Result<()>
+where
+    T: AsRef<Path>,
+{
+    let root = root.as_ref();
+    fs::create_dir_all(root)?;
+    filesystem::chmod(root.to_str().unwrap(), 0o0750)?;
+    Ok(())
+}

--- a/www/source/partials/docs/_dev-pkgs-exports.html.md.erb
+++ b/www/source/partials/docs/_dev-pkgs-exports.html.md.erb
@@ -47,6 +47,29 @@ For an example of using Docker Compose to run multiple Habitat containers togeth
 
 4. Your package in a tar file exists locally on your computer in the format `origin-package-version-timestamp.tar.gz` and can be deployed and run on a target machine.
 
+5. If you wish to run this tar file on a remote machine (i.e. a virtual machine in a cloud environment), scp (or whatever transfer protocol you prefer) the file to whatever you wish to run it
+
+6. SSH into the virtual machine
+
+7. Run these commands to set up the required user and group
+
+    ```shell
+    $ sudo adduser --group hab
+    $ sudo useradd -g hab hab
+    ```
+
+8. Next, unpack the tar file
+
+    ```shell
+    $ sudo tar xf your-origin-package-version-timestamp.tar.gz
+    ```
+
+9. Now, start your package using the hab binary which is included in the tar archive
+
+    ```shell
+    $ sudo /hab/bin/hab start yourorigin/yourpackage
+    ```
+
 ## Exporting to an Application Container Image (ACI)
 
 You can create an Application Container Image (ACI) for any package by performing the following steps:


### PR DESCRIPTION
This is a partial fix for #4172, rewriting the tar exporter in Rust.  #4172 also requests some new functionality.  I prefer to separate refactoring and new behavior so this PR just focuses on re-writing the exporter in Rust.  I will follow this one up with a separate PR that adds the new behavior.