### PR TITLE
 [builder-worker] Ensure parent network NS directory is created.

### DIFF
--- a/components/builder-worker/src/error.rs
+++ b/components/builder-worker/src/error.rs
@@ -44,6 +44,7 @@ pub enum Error {
     CannotAddCreds,
     Chown(PathBuf, u32, u32, io::Error),
     ChownWait(io::Error),
+    CreateDirectory(PathBuf, io::Error),
     Exporter(io::Error),
     Git(git2::Error),
     GithubAppAuthErr(github_api_client::HubError),
@@ -102,6 +103,9 @@ impl fmt::Display for Error {
                 )
             }
             Error::ChownWait(ref e) => format!("Unable to complete chown process, {}", e),
+            Error::CreateDirectory(ref p, ref e) => {
+                format!("Unable to create directory {}, err={}", p.display(), e)
+            }
             Error::Exporter(ref e) => {
                 format!("Unable to spawn or pipe data from exporter proc, {}", e)
             }
@@ -166,6 +170,7 @@ impl error::Error for Error {
             Error::CannotAddCreds => "Cannot add credentials to url",
             Error::Chown(_, _, _, _) => "Unable to recursively chown path",
             Error::ChownWait(_) => "Unable to complete chown process",
+            Error::CreateDirectory(_, _) => "Unable to create directory",
             Error::Exporter(_) => "IO Error while spawning or piping data from exporter proc",
             Error::Git(ref err) => err.description(),
             Error::GithubAppAuthErr(ref err) => err.description(),

--- a/components/builder-worker/src/server.rs
+++ b/components/builder-worker/src/server.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::collections::HashMap;
+use std::fs;
 use std::iter::FromIterator;
 use std::sync::Arc;
 
@@ -239,8 +240,13 @@ impl Server {
         // directories, files, and bind-mounts can be created for the build user
         let parent_path = self.config.ns_dir_path();
         let parent_path = parent_path.parent().expect(
-            "parent directory for ns_dir should exist",
+            "parent directory path segement for ns_dir should exist",
         );
+        if !parent_path.is_dir() {
+            fs::create_dir_all(parent_path).map_err(|e| {
+                Error::CreateDirectory(parent_path.to_path_buf(), e)
+            })?;
+        }
         perm::set_owner(&parent_path, studio::STUDIO_USER, studio::STUDIO_GROUP)?;
         perm::set_permissions(&parent_path, 0o750)?;
 

--- a/components/core/src/util/perm.rs
+++ b/components/core/src/util/perm.rs
@@ -21,9 +21,10 @@ use error::{Error, Result};
 
 pub fn set_owner<T: AsRef<Path>, X: AsRef<str>>(path: T, owner: X, group: X) -> Result<()> {
     debug!(
-        "Attempting to set owner of {:?} to {:?}",
+        "Attempting to set owner of {:?} to {:?}:{:?}",
         &path.as_ref(),
-        &owner.as_ref()
+        &owner.as_ref(),
+        &group.as_ref()
     );
 
     let uid = match users::get_uid_by_name(&owner.as_ref()) {
@@ -68,9 +69,10 @@ pub fn set_owner<T: AsRef<Path>, X: AsRef<str>>(path: T, owner: X, group: X) -> 
         Ok(0) => Ok(()),
         _ => {
             Err(Error::PermissionFailed(format!(
-                "Can't change owner of {:?} to {:?}",
+                "Can't change owner of {:?} to {:?}:{:?}",
                 &path.as_ref(),
-                &owner.as_ref()
+                &owner.as_ref(),
+                &group.as_ref()
             )))
         }
     }


### PR DESCRIPTION
This fixes an issue present when initially running the service. Before
assigning ownership and permissions to the parent directory of the
network namespace directory (under Habitat, this directory is
`/hab/svc/builder-worker/data/network`), must exist which it didn't.

Closes #4471