### PR TITLE
Add Search Packages link to global website nav

### DIFF
--- a/www/source/layouts/_footer.slim
+++ b/www/source/layouts/_footer.slim
@@ -38,7 +38,7 @@ footer#main-footer class="#{layout_class}"
               li
                 h4.footer--subheader Habitat Builder
               li.footer--sitemap--link
-                a href="#{builder_web_url}/#/pkgs/core" Find Packages
+                a href="#{builder_web_url}/#/pkgs/core" Search Packages
               li.footer--sitemap--link
                 a href="#{builder_web_url}/#/sign-in" Sign In
               li.footer--sitemap--link

--- a/www/source/layouts/_nav.slim
+++ b/www/source/layouts/_nav.slim
@@ -30,6 +30,8 @@
           a.pricing href="/pricing" Pricing
         li.main-nav--link
           a.blog href="/blog" Blog
+        li.main-nav--link
+          a.search-pkgs href="#{builder_web_url}/#/pkgs" Search Packages
         li.main-nav--link.signed-in
           = link_to 'Builder', "#{builder_web_url}/#/pkgs"
           .avatar


### PR DESCRIPTION
There's currently no easy way to access the Search Packages feature without being signed in. When we added the new Learn link it was moved to the first position so as to help first-time/new users find the best 'getting started' content. 

The Explore page leads into the Search Packages page inside Builder, but it lacks the typeahead features, does not show core packages by default, and the curated packages on the Explore page seem stale (are hardcoded). For those reasons, this PR adds a Search Packages link to the global website nav and we have an idea in ProdPad to revisit the Explore concept and either bring it back or combine its good parts with other pages.

![screenshot 2018-01-22 14 43 15](https://user-images.githubusercontent.com/446285/35243471-a1346860-ff82-11e7-8e10-294db2a3d635.png)


Signed-off-by: Ryan Keairns <rkeairns@chef.io>