### PR TITLE
Fix the GitHub button styling

### DIFF
--- a/www/source/stylesheets/_nav.scss
+++ b/www/source/stylesheets/_nav.scss
@@ -402,13 +402,22 @@ $main-nav-breakpoint: 769px;
   left: 0;
   background: linear-gradient(180deg, $hab-navy-light 0%, $hab-navy 100%);
   font-size: 12px;
-  height: 30px;
   line-height: 30px;
   color: $hab-white;
   box-shadow: 0 2px 6px 0 rgba(35,39,39,0.49);
+  padding: 0 10px 0 4px;
+
+  &:hover, &:visited {
+    color: $hab-white;
+  }
+
+  img {
+    width: 30px;
+    height: 30px;
+  }
 
   > span {
-    padding: 0px 5px;
+    vertical-align: middle
   }
 
   @media (min-width: 1150px) {


### PR DESCRIPTION
Currently the GitHub icon is spilling out of its container, which looks … not so good. This fixes that.

Signed-off-by: Christian Nunciato <chris@nunciato.org>

![image](https://user-images.githubusercontent.com/274700/35295717-b8916baa-002e-11e8-8722-5f73e6277193.png)
