### PR TITLE
fix pkg_svc_run behavior in powershell plans

### DIFF
--- a/components/plan-build-ps1/bin/hab-plan-build.ps1
+++ b/components/plan-build-ps1/bin/hab-plan-build.ps1
@@ -1117,13 +1117,15 @@ function Invoke-DefaultBuildService {
         Write-BuildLine "Using run hook $PLAN_CONTEXT/hooks/run"
     }
     else {
-        if ($pkg_svc_run -ne "" -and (Test-Path $pkg_svc_run)) {
+        if ($pkg_svc_run -ne "") {
           Write-BuildLine "Writing $pkg_prefix/run script to run $pkg_svc_run"
           Set-Content -Path "$pkg_prefix/run" -Value @"
 cd "$pkg_svc_path"
 
-& "$pkg_svc_run" 2>&1
-exit `$LASTEXITCODE
+`$cmd = @"
+$pkg_svc_run
+"`@
+Invoke-Expression -Command `$cmd 2>&1
 "@
         }
     }


### PR DESCRIPTION
This fixes #4479 

I have tested this with the aspnet sample:

```
$pkg_svc_run="cd '$pkg_svc_var_path';`$env:HAB_CONFIG_PATH='$pkg_svc_config_path';dotnet $pkg_name.dll"
```

and it works.

Signed-off-by: mwrock <matt@mattwrock.com>