### PR TITLE
rename powershell binary to new pwsh.exe

### DIFF
--- a/components/launcher/src/sys/windows/service.rs
+++ b/components/launcher/src/sys/windows/service.rs
@@ -124,7 +124,7 @@ pub fn run(mut msg: protocol::Spawn) -> Result<Service> {
         Some(msg.take_svc_password())
     };
     match Child::spawn(
-        "powershell.exe",
+        "pwsh.exe",
         vec!["-NonInteractive", "-command", ps_cmd.as_str()],
         msg.get_env(),
         msg.get_svc_user(),

--- a/components/studio/bin/hab-studio.bat
+++ b/components/studio/bin/hab-studio.bat
@@ -1,2 +1,2 @@
 @echo off
-"%~dp0powershell/powershell.exe" -NoProfile -ExecutionPolicy bypass -NoLogo -Command ". '%~dp0hab-studio.ps1'" %*
+"%~dp0powershell/pwsh.exe" -NoProfile -ExecutionPolicy bypass -NoLogo -Command ". '%~dp0hab-studio.ps1'" %*

--- a/components/studio/bin/hab-studio.ps1
+++ b/components/studio/bin/hab-studio.ps1
@@ -280,7 +280,7 @@ function Enter-Studio {
   New-Studio
   Write-HabInfo "Entering Studio at $HAB_STUDIO_ROOT"
   $env:STUDIO_SCRIPT_ROOT = $PSScriptRoot
-  & "$PSScriptRoot\powershell\powershell.exe" -NoProfile -ExecutionPolicy bypass -NoLogo -NoExit -Command {
+  & "$PSScriptRoot\powershell\pwsh.exe" -NoProfile -ExecutionPolicy bypass -NoLogo -NoExit -Command {
     function prompt {
       Write-Host "[HAB-STUDIO]" -NoNewLine -ForegroundColor Green
       " $($executionContext.SessionState.Path.CurrentLocation)$('>' * ($nestedPromptLevel +1)) "
@@ -298,7 +298,7 @@ function Enter-Studio {
       # from powershell so the ctrl+c issue is not a problem so we can do
       # a simple tail
       if ((Get-Service -Name cexecsvc -ErrorAction SilentlyContinue) -eq $null) {
-        Start-Process "$env:STUDIO_SCRIPT_ROOT\powershell\powershell.exe" -ArgumentList "-Command `"& {Get-Content $env:HAB_STUDIO_ENTER_ROOT\hab\sup\default\out.log -Tail 100 -Wait}`""
+        Start-Process "$env:STUDIO_SCRIPT_ROOT\powershell\pwsh.exe" -ArgumentList "-Command `"& {Get-Content $env:HAB_STUDIO_ENTER_ROOT\hab\sup\default\out.log -Tail 100 -Wait}`""
       }
       else {
         Get-Content $env:HAB_STUDIO_ENTER_ROOT\hab\sup\default\out.log -Tail 100 -Wait

--- a/components/studio/build-docker-image.ps1
+++ b/components/studio/build-docker-image.ps1
@@ -40,7 +40,7 @@ FROM microsoft/windowsservercore
 MAINTAINER The Habitat Maintainers <humans@habitat.sh>
 ADD rootfs /
 WORKDIR /src
-ENTRYPOINT ["/hab/pkgs/$ident/bin/powershell/powershell.exe", "-ExecutionPolicy", "bypass", "-NoLogo", "-file", "/hab/pkgs/$ident/bin/hab-studio.ps1"]
+ENTRYPOINT ["/hab/pkgs/$ident/bin/powershell/pwsh.exe", "-ExecutionPolicy", "bypass", "-NoLogo", "-file", "/hab/pkgs/$ident/bin/hab-studio.ps1"]
 "@ | Out-File "$tmpRoot/Dockerfile" -Encoding ascii
     
     info "Building Docker image ${imageName}:$version'"

--- a/components/sup/src/sys/windows/exec.rs
+++ b/components/sup/src/sys/windows/exec.rs
@@ -27,7 +27,7 @@ where
     let ps_cmd = format!("iex $(gc {} | out-string)", path.as_ref().to_string_lossy());
     let args = vec!["-NonInteractive", "-command", ps_cmd.as_str()];
     Ok(Child::spawn(
-        "powershell.exe",
+        "pwsh.exe",
         args,
         &pkg.env,
         &pkg.svc_user,


### PR DESCRIPTION
The RTM'd Powershell Core 6.0.0 released 2 weeks ago and is now in the core stable channel. One breaking change was renaming the powershell binary executable to `pwsh.exe`.  This PR will need to be released prior to the next hab release or else habitat will end up launching the system Windows powershell.exe.

Signed-off-by: mwrock <matt@mattwrock.com>