### PR TITLE
Introduce network abstraction for butterfly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,7 +651,6 @@ dependencies = [
  "env_logger 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat_butterfly_test 0.1.0",
  "habitat_core 0.0.0 (git+https://github.com/habitat-sh/core.git)",
- "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -672,6 +672,7 @@ dependencies = [
  "env_logger 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat_butterfly 0.1.0",
  "habitat_core 0.0.0 (git+https://github.com/habitat-sh/core.git)",
+ "libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -672,7 +672,7 @@ dependencies = [
  "env_logger 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat_butterfly 0.1.0",
  "habitat_core 0.0.0 (git+https://github.com/habitat-sh/core.git)",
- "libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/components/butterfly-test/Cargo.toml
+++ b/components/butterfly-test/Cargo.toml
@@ -8,6 +8,7 @@ workspace = "../../"
 clippy = {version = "*", optional = true}
 env_logger = "*"
 time = "*"
+libc = "*"
 
 [dependencies.habitat_butterfly]
 path = "../butterfly"

--- a/components/butterfly-test/src/lib.rs
+++ b/components/butterfly-test/src/lib.rs
@@ -141,7 +141,14 @@ impl SwimNet {
 
     pub fn connect(&mut self, from_entry: usize, to_entry: usize) {
         let to = member_from_server(&self.members[to_entry]);
-        trace_it!(TEST: &self.members[from_entry], format!("Connected {} {}", self.members[to_entry].name(), self.members[to_entry].member_id()));
+        trace_it!(
+            TEST: &self.members[from_entry],
+            format!(
+                "Connected {} {}",
+                self.members[to_entry].name(),
+                self.members[to_entry].member_id()
+            )
+        );
         self.members[from_entry].insert_member(to, Health::Alive);
     }
 
@@ -178,7 +185,14 @@ impl SwimNet {
         let to = self.members.get(to_entry).expect(
             "Asked for a network member who is out of bounds",
         );
-        trace_it!(TEST: &self.members[from_entry], format!("Blacklisted {} {}", self.members[to_entry].name(), self.members[to_entry].member_id()));
+        trace_it!(
+            TEST: &self.members[from_entry],
+            format!(
+                "Blacklisted {} {}",
+                self.members[to_entry].name(),
+                self.members[to_entry].member_id()
+            )
+        );
         from.add_to_blacklist(String::from(
             to.member.read().expect("Member lock is poisoned").get_id(),
         ));
@@ -191,7 +205,14 @@ impl SwimNet {
         let to = self.members.get(to_entry).expect(
             "Asked for a network member who is out of bounds",
         );
-        trace_it!(TEST: &self.members[from_entry], format!("Un-Blacklisted {} {}", self.members[to_entry].name(), self.members[to_entry].member_id()));
+        trace_it!(
+            TEST: &self.members[from_entry],
+            format!(
+                "Un-Blacklisted {} {}",
+                self.members[to_entry].name(),
+                self.members[to_entry].member_id()
+            )
+        );
         from.remove_from_blacklist(to.member_id());
     }
 
@@ -405,12 +426,28 @@ impl SwimNet {
         loop {
             if let Some(real_health) = self.health_of(from_entry, to_check) {
                 if real_health == health {
-                    trace_it!(TEST: &self.members[from_entry], format!("Health {} {} as {}", self.members[to_check].name(), self.members[to_check].member_id(), health));
+                    trace_it!(
+                        TEST: &self.members[from_entry],
+                        format!(
+                            "Health {} {} as {}",
+                            self.members[to_check].name(),
+                            self.members[to_check].member_id(),
+                            health
+                        )
+                    );
                     return true;
                 }
             }
             if self.check_rounds(&rounds_in) {
-                trace_it!(TEST: &self.members[from_entry], format!("Health failed {} {} as {}", self.members[to_check].name(), self.members[to_check].member_id(), health));
+                trace_it!(
+                    TEST: &self.members[from_entry],
+                    format!(
+                        "Health failed {} {} as {}",
+                        self.members[to_check].name(),
+                        self.members[to_check].member_id(),
+                        health
+                    )
+                );
                 println!("MEMBERS: {:#?}", self.members);
                 println!(
                     "Failed health check for\n***FROM***{:#?}\n***TO***\n{:#?}",
@@ -447,7 +484,15 @@ impl SwimNet {
                     match some_health {
                         &Some(ref health) => {
                             println!("{}: {:?}", i, health);
-                            trace_it!(TEST: &self.members[i], format!("Health failed {} {} as {}", self.members[to_check].name(), self.members[to_check].member_id(), health));
+                            trace_it!(
+                                TEST: &self.members[i],
+                                format!(
+                                    "Health failed {} {} as {}",
+                                    self.members[to_check].name(),
+                                    self.members[to_check].member_id(),
+                                    health
+                                )
+                            );
                         }
                         &None => {}
                     }
@@ -520,10 +565,21 @@ impl SwimNet {
 #[macro_export]
 macro_rules! assert_health_of {
     ($network:expr, $to:expr, $health:expr) => {
-        assert!($network.network_health_of($to).into_iter().all(|x| x == $health), "Member {} does not always have health {}", $to, $health)
+        assert!(
+            $network.network_health_of($to).into_iter().all(|x| x == $health),
+            "Member {} does not always have health {}",
+            $to,
+            $health
+        )
     };
     ($network:expr, $from: expr, $to:expr, $health:expr) => {
-        assert!($network.health_of($from, $to) == $health, "Member {} does not see {} as {}", $from, $to, $health)
+        assert!(
+            $network.health_of($from, $to) == $health,
+            "Member {} does not see {} as {}",
+            $from,
+            $to,
+            $health
+        )
     }
 }
 
@@ -537,16 +593,39 @@ macro_rules! assert_wait_for_health_of {
                 if l == r {
                     continue;
                 }
-                assert!($network.wait_for_health_of(*l, *r, $health), "Member {} does not see {} as {}", l, r, $health);
-                assert!($network.wait_for_health_of(*r, *l, $health), "Member {} does not see {} as {}", r, l, $health);
+                assert!(
+                    $network.wait_for_health_of(*l, *r, $health),
+                    "Member {} does not see {} as {}",
+                    l,
+                    r,
+                    $health
+                );
+                assert!(
+                    $network.wait_for_health_of(*r, *l, $health),
+                    "Member {} does not see {} as {}",
+                    r,
+                    l,
+                    $health
+                );
             }
         }
     };
     ($network:expr, $to:expr, $health:expr) => {
-        assert!($network.wait_for_network_health_of($to, $health), "Member {} does not always have health {}", $to, $health);
+        assert!(
+            $network.wait_for_network_health_of($to, $health),
+            "Member {} does not always have health {}",
+            $to,
+            $health
+        );
     };
     ($network:expr, $from: expr, $to:expr, $health:expr) => {
-        assert!($network.wait_for_health_of($from, $to, $health), "Member {} does not see {} as {}", $from, $to, $health);
+        assert!(
+            $network.wait_for_health_of($from, $to, $health),
+            "Member {} does not see {} as {}",
+            $from,
+            $to,
+            $health
+        );
     };
 }
 
@@ -575,7 +654,12 @@ macro_rules! assert_wait_for_equal_election {
                 if l == r {
                     continue;
                 }
-                assert!($network.wait_for_equal_election(*l, *r, $key), "Member {} is not equal to {}", l, r);
+                assert!(
+                    $network.wait_for_equal_election(*l, *r, $key),
+                    "Member {} is not equal to {}",
+                    l,
+                    r
+                );
             }
         }
     };

--- a/components/butterfly-test/src/lib.rs
+++ b/components/butterfly-test/src/lib.rs
@@ -30,6 +30,7 @@ use std::str::FromStr;
 
 use time::SteadyTime;
 
+use habitat_butterfly::client::Client;
 use habitat_butterfly::server::{Server, Suitability};
 use habitat_butterfly::member::{Member, Health};
 use habitat_butterfly::server::timing::Timing;
@@ -41,10 +42,18 @@ use habitat_butterfly::message::swim::Election_Status;
 use habitat_core::service::ServiceGroup;
 use habitat_core::package::{Identifiable, PackageIdent};
 use habitat_core::crypto::keys::sym_key::SymKey;
-use habitat_butterfly::network::RealNetwork;
+use habitat_butterfly::network::{Network, GossipZmqSocket, RealNetwork};
 use habitat_butterfly::trace::Trace;
 
 static SERVER_PORT: AtomicUsize = ATOMIC_USIZE_INIT;
+
+pub fn get_client_for_address(addr: SocketAddr) -> Client<GossipZmqSocket> {
+    let network = RealNetwork::new_for_client();
+    let socket = network.get_gossip_sender(addr).expect(
+        "Cannot create gossip socket",
+    );
+    Client::new(socket, None)
+}
 
 #[derive(Debug)]
 struct NSuitability(u64);

--- a/components/butterfly-test/src/lib.rs
+++ b/components/butterfly-test/src/lib.rs
@@ -49,10 +49,10 @@ static SERVER_PORT: AtomicUsize = ATOMIC_USIZE_INIT;
 
 pub fn get_client_for_address(addr: SocketAddr) -> Client<GossipZmqSocket> {
     let network = RealNetwork::new_for_client();
-    let socket = network.get_gossip_sender(addr).expect(
+    let sender = network.get_gossip_sender(addr).expect(
         "Cannot create gossip socket",
     );
-    Client::new(socket, None)
+    Client::new(sender, None)
 }
 
 #[derive(Debug)]

--- a/components/butterfly-test/src/lib.rs
+++ b/components/butterfly-test/src/lib.rs
@@ -16,6 +16,7 @@
 
 extern crate env_logger;
 extern crate time;
+extern crate libc;
 #[macro_use]
 extern crate habitat_butterfly;
 extern crate habitat_core;
@@ -25,6 +26,7 @@ use std::sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
 use std::thread;
 use std::ops::{Deref, DerefMut, Range};
 use std::path::PathBuf;
+use std::sync::{Once, ONCE_INIT};
 use std::time::Duration;
 use std::str::FromStr;
 
@@ -54,6 +56,8 @@ pub fn get_client_for_address(addr: SocketAddr) -> Client<GossipZmqSocket> {
     );
     Client::new(sender, None)
 }
+
+static RLIMIT_ONCE: Once = ONCE_INIT;
 
 #[derive(Debug)]
 struct NSuitability(u64);
@@ -124,6 +128,48 @@ impl DerefMut for SwimNet {
     }
 }
 
+#[cfg(target_os = "linux")]
+mod rlimitset {
+    use libc;
+    pub fn run() {
+        let mut rlim = libc::rlimit {
+            rlim_cur: 0,
+            rlim_max: 0,
+        };
+        if !get_files_no_limit(&mut rlim) {
+            println!("Failed to get open file descriptors limit");
+            return;
+        }
+        if rlim.rlim_cur == rlim.rlim_max {
+            println!("Files limit is already at its max ({})", rlim.rlim_cur);
+            return;
+        }
+        println!(
+            "Setting current files limit ({}) to the max ({})",
+            rlim.rlim_cur,
+            rlim.rlim_max
+        );
+        rlim.rlim_cur = rlim.rlim_max;
+        if !set_files_no_limit(&rlim) {
+            println!("Failed to set open file descriptors limit");
+            return;
+        }
+    }
+
+    fn get_files_no_limit(rlim: &mut libc::rlimit) -> bool {
+        unsafe { libc::getrlimit(libc::RLIMIT_NOFILE, rlim) == 0 }
+    }
+
+    fn set_files_no_limit(rlim: &libc::rlimit) -> bool {
+        unsafe { libc::setrlimit(libc::RLIMIT_NOFILE, rlim) == 0 }
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+mod rlimitset {
+    pub fn run() {}
+}
+
 impl SwimNet {
     pub fn new_with_suitability(suitabilities: Vec<u64>) -> SwimNet {
         let count = suitabilities.len();
@@ -131,7 +177,7 @@ impl SwimNet {
         for x in 0..count {
             members.push(start_server(&format!("{}", x), None, suitabilities[x]));
         }
-        SwimNet { members: members }
+        Self::new_with_members(members)
     }
 
     pub fn new(count: usize) -> SwimNet {
@@ -145,7 +191,12 @@ impl SwimNet {
             let rk = ring_key.clone();
             members.push(start_server(&format!("{}", x), rk, 0));
         }
-        SwimNet { members: members }
+        Self::new_with_members(members)
+    }
+
+    fn new_with_members(members: Vec<Server<RealNetwork>>) -> Self {
+        RLIMIT_ONCE.call_once(rlimitset::run);
+        Self { members }
     }
 
     pub fn connect(&mut self, from_entry: usize, to_entry: usize) {

--- a/components/butterfly-test/src/lib.rs
+++ b/components/butterfly-test/src/lib.rs
@@ -51,7 +51,7 @@ static SERVER_PORT: AtomicUsize = ATOMIC_USIZE_INIT;
 
 pub fn get_client_for_address(addr: SocketAddr) -> Client<GossipZmqSocket> {
     let network = RealNetwork::new_for_client();
-    let sender = network.get_gossip_sender(addr).expect(
+    let sender = network.create_gossip_sender(addr).expect(
         "Cannot create gossip socket",
     );
     Client::new(sender, None)

--- a/components/butterfly/Cargo.toml
+++ b/components/butterfly/Cargo.toml
@@ -21,7 +21,6 @@ clippy = {version = "*", optional = true}
 byteorder = "*"
 env_logger = "*"
 log = "*"
-lazy_static = "*"
 protobuf = "*"
 rand = "*"
 serde = "*"

--- a/components/butterfly/src/client.rs
+++ b/components/butterfly/src/client.rs
@@ -18,52 +18,28 @@
 
 use habitat_core::crypto::SymKey;
 use habitat_core::service::ServiceGroup;
-use zmq;
 
-use ZMQ_CONTEXT;
 use message;
 use rumor::Rumor;
 use rumor::departure::Departure;
 use rumor::service_config::ServiceConfig;
 use rumor::service_file::ServiceFile;
-use error::{Result, Error};
+use error::Result;
+use network::GossipSender;
 
-/// Holds a ZMQ Push socket, and an optional ring encryption key.
-pub struct Client {
-    socket: zmq::Socket,
+/// Holds a gossip push socket, and an optional ring encryption key.
+pub struct Client<GS: GossipSender> {
+    socket: GS,
     ring_key: Option<SymKey>,
 }
 
-impl Client {
+impl<GS: GossipSender> Client<GS> {
     /// Connect this client to the address, and optionally encrypt the traffic.
-    pub fn new<A>(addr: A, ring_key: Option<SymKey>) -> Result<Client>
-    where
-        A: ToString,
-    {
-        let socket = (**ZMQ_CONTEXT).as_mut().socket(zmq::PUSH).expect(
-            "Failure to create the ZMQ push socket",
-        );
-        socket.set_linger(-1).expect(
-            "Failure to set the ZMQ push socket to not linger",
-        );
-        socket.set_tcp_keepalive(0).expect(
-            "Failure to set the ZMQ push socket to not use keepalive",
-        );
-        socket.set_immediate(true).expect(
-            "Failure to set the ZMQ push socket to immediate",
-        );
-        socket.set_sndhwm(1000).expect(
-            "Failure to set the ZMQ push socket hwm",
-        );
-        socket.set_sndtimeo(500).expect(
-            "Failure to set the ZMQ send timeout",
-        );
-        let to_addr = format!("tcp://{}", addr.to_string());
-        socket.connect(&to_addr).map_err(Error::ZmqConnectError)?;
-        Ok(Client {
+    pub fn new(socket: GS, ring_key: Option<SymKey>) -> Self {
+        Self {
             socket: socket,
             ring_key: ring_key,
-        })
+        }
     }
 
     /// Create a departure notification and send it to the server.
@@ -108,6 +84,6 @@ impl Client {
     pub fn send<T: Rumor>(&mut self, rumor: T) -> Result<()> {
         let bytes = rumor.write_to_bytes()?;
         let wire_msg = message::generate_wire(bytes, self.ring_key.as_ref())?;
-        self.socket.send(&wire_msg, 0).map_err(Error::ZmqSendError)
+        self.socket.send(&wire_msg)
     }
 }

--- a/components/butterfly/src/client.rs
+++ b/components/butterfly/src/client.rs
@@ -29,15 +29,15 @@ use network::GossipSender;
 
 /// Holds a gossip push socket, and an optional ring encryption key.
 pub struct Client<GS: GossipSender> {
-    socket: GS,
+    sender: GS,
     ring_key: Option<SymKey>,
 }
 
 impl<GS: GossipSender> Client<GS> {
     /// Connect this client to the address, and optionally encrypt the traffic.
-    pub fn new(socket: GS, ring_key: Option<SymKey>) -> Self {
+    pub fn new(sender: GS, ring_key: Option<SymKey>) -> Self {
         Self {
-            socket: socket,
+            sender: sender,
             ring_key: ring_key,
         }
     }
@@ -84,6 +84,6 @@ impl<GS: GossipSender> Client<GS> {
     pub fn send<T: Rumor>(&mut self, rumor: T) -> Result<()> {
         let bytes = rumor.write_to_bytes()?;
         let wire_msg = message::generate_wire(bytes, self.ring_key.as_ref())?;
-        self.socket.send(&wire_msg)
+        self.sender.send(&wire_msg)
     }
 }

--- a/components/butterfly/src/error.rs
+++ b/components/butterfly/src/error.rs
@@ -22,15 +22,12 @@ use std::str;
 use habitat_core;
 use protobuf;
 use toml;
-use zmq;
 
 pub type Result<T> = result::Result<T, Error>;
 
 #[derive(Debug)]
 pub enum Error {
     BadDataPath(PathBuf, io::Error),
-    BadDatFile(PathBuf, io::Error),
-    BadMessage(String),
     CannotBind(io::Error),
     DatFileIO(PathBuf, io::Error),
     GossipChannelSetupError(String),
@@ -43,16 +40,11 @@ pub enum Error {
     ProtobufError(protobuf::ProtobufError),
     ServiceConfigDecode(String, toml::de::Error),
     ServiceConfigNotUtf8(String, str::Utf8Error),
-    SocketSetReadTimeout(io::Error),
-    SocketSetWriteTimeout(io::Error),
-    SwimChannelCloneError,
     SwimChannelSetupError(String),
     SwimReceiveError(String),
     SwimReceiveIOError(io::Error),
     SwimSendError(String),
     SwimSendIOError(io::Error),
-    ZmqConnectError(zmq::Error),
-    ZmqSendError(zmq::Error),
 }
 
 impl fmt::Display for Error {
@@ -65,14 +57,6 @@ impl fmt::Display for Error {
                     err
                 )
             }
-            Error::BadDatFile(ref path, ref err) => {
-                format!(
-                    "Unable to decode contents of DatFile, {}, {}",
-                    path.display(),
-                    err
-                )
-            }
-            Error::BadMessage(ref err) => format!("Bad Message: {:?}", err),
             Error::CannotBind(ref err) => format!("Cannot bind to port: {:?}", err),
             Error::DatFileIO(ref path, ref err) => {
                 format!(
@@ -111,13 +95,6 @@ impl fmt::Display for Error {
             Error::ServiceConfigNotUtf8(ref sg, ref err) => {
                 format!("Cannot read service configuration: group={}, {}", sg, err)
             }
-            Error::SocketSetReadTimeout(ref err) => {
-                format!("Cannot set UDP socket read timeout: {}", err)
-            }
-            Error::SocketSetWriteTimeout(ref err) => {
-                format!("Cannot set UDP socket write timeout: {}", err)
-            }
-            Error::SwimChannelCloneError => format!("Cannot clone the SWIM channel"),
             Error::SwimChannelSetupError(ref err) => {
                 format!("Error setting up SWIM channel: {}", err)
             }
@@ -133,10 +110,6 @@ impl fmt::Display for Error {
             Error::SwimSendIOError(ref err) => {
                 format!("Failed to send data to SWIM channel: {}", err)
             }
-            Error::ZmqConnectError(ref err) => format!("Cannot connect ZMQ socket: {}", err),
-            Error::ZmqSendError(ref err) => {
-                format!("Cannot send message through ZMQ socket: {}", err)
-            }
         };
         write!(f, "{}", msg)
     }
@@ -146,8 +119,6 @@ impl error::Error for Error {
     fn description(&self) -> &str {
         match *self {
             Error::BadDataPath(_, _) => "Unable to read or write to data directory",
-            Error::BadDatFile(_, _) => "Unable to decode contents of DatFile",
-            Error::BadMessage(_) => "Bad Protobuf Message; should be Ping/Ack/PingReq",
             Error::CannotBind(_) => "Cannot bind to port",
             Error::DatFileIO(_, _) => "Error reading or writing to DatFile",
             Error::GossipChannelSetupError(_) => "Error setting up gossip channel",
@@ -162,16 +133,11 @@ impl error::Error for Error {
             Error::ProtobufError(ref err) => err.description(),
             Error::ServiceConfigDecode(_, _) => "Cannot decode service config into TOML",
             Error::ServiceConfigNotUtf8(_, _) => "Cannot read service config bytes to UTF-8",
-            Error::SocketSetReadTimeout(_) => "Cannot set UDP socket read timeout",
-            Error::SocketSetWriteTimeout(_) => "Cannot set UDP socket write timeout",
-            Error::SwimChannelCloneError => "Cannot clone the SWIM channel",
             Error::SwimChannelSetupError(_) => "Error setting up SWIM channel",
             Error::SwimReceiveError(_) => "Failed to receive data from SWIM channel",
             Error::SwimReceiveIOError(_) => "Failed to receive data from SWIM channel",
             Error::SwimSendError(_) => "Failed to send data to SWIM channel",
             Error::SwimSendIOError(_) => "Failed to send data to SWIM channel",
-            Error::ZmqConnectError(_) => "Cannot connect ZMQ socket",
-            Error::ZmqSendError(_) => "Cannot send message through ZMQ socket",
         }
     }
 }

--- a/components/butterfly/src/error.rs
+++ b/components/butterfly/src/error.rs
@@ -33,6 +33,11 @@ pub enum Error {
     BadMessage(String),
     CannotBind(io::Error),
     DatFileIO(PathBuf, io::Error),
+    GossipChannelSetupError(String),
+    GossipReceiveError(String),
+    GossipReceiveIOError(io::Error),
+    GossipSendError(String),
+    GossipSendIOError(io::Error),
     HabitatCore(habitat_core::error::Error),
     NonExistentRumor(String, String),
     ProtobufError(protobuf::ProtobufError),
@@ -41,6 +46,11 @@ pub enum Error {
     SocketSetReadTimeout(io::Error),
     SocketSetWriteTimeout(io::Error),
     SocketCloneError,
+    SwimChannelSetupError(String),
+    SwimReceiveError(String),
+    SwimReceiveIOError(io::Error),
+    SwimSendError(String),
+    SwimSendIOError(io::Error),
     ZmqConnectError(zmq::Error),
     ZmqSendError(zmq::Error),
 }
@@ -71,6 +81,21 @@ impl fmt::Display for Error {
                     err
                 )
             }
+            Error::GossipChannelSetupError(ref err) => {
+                format!("Error setting up gossip channel: {}", err)
+            }
+            Error::GossipReceiveError(ref err) => {
+                format!("Failed to receive data with gossip receiver: {}", err)
+            }
+            Error::GossipReceiveIOError(ref err) => {
+                format!("Failed to receive data with gossip receiver: {}", err)
+            }
+            Error::GossipSendError(ref err) => {
+                format!("Failed to send data with gossip sender: {}", err)
+            }
+            Error::GossipSendIOError(ref err) => {
+                format!("Failed to send data with gossip sender: {}", err)
+            }
             Error::HabitatCore(ref err) => format!("{}", err),
             Error::NonExistentRumor(ref member_id, ref rumor_id) => {
                 format!(
@@ -93,11 +118,25 @@ impl fmt::Display for Error {
                 format!("Cannot set UDP socket write timeout: {}", err)
             }
             Error::SocketCloneError => format!("Cannot clone the underlying UDP socket"),
+            Error::SwimChannelSetupError(ref err) => {
+                format!("Error setting up SWIM channel: {}", err)
+            }
+            Error::SwimReceiveError(ref err) => {
+                format!("Failed to receive data from SWIM channel: {}", err)
+            }
+            Error::SwimReceiveIOError(ref err) => {
+                format!("Failed to receive data from SWIM channel: {}", err)
+            }
+            Error::SwimSendError(ref err) => {
+                format!("Failed to send data to SWIM channel: {}", err)
+            }
+            Error::SwimSendIOError(ref err) => {
+                format!("Failed to send data to SWIM channel: {}", err)
+            }
             Error::ZmqConnectError(ref err) => format!("Cannot connect ZMQ socket: {}", err),
             Error::ZmqSendError(ref err) => {
                 format!("Cannot send message through ZMQ socket: {}", err)
             }
-
         };
         write!(f, "{}", msg)
     }
@@ -111,6 +150,11 @@ impl error::Error for Error {
             Error::BadMessage(_) => "Bad Protobuf Message; should be Ping/Ack/PingReq",
             Error::CannotBind(_) => "Cannot bind to port",
             Error::DatFileIO(_, _) => "Error reading or writing to DatFile",
+            Error::GossipChannelSetupError(_) => "Error setting up gossip channel",
+            Error::GossipReceiveError(_) => "Failed to receive data with gossip receiver",
+            Error::GossipReceiveIOError(_) => "Failed to receive data with gossip receiver",
+            Error::GossipSendError(_) => "Failed to send data with gossip sender",
+            Error::GossipSendIOError(_) => "Failed to send data with gossip sender",
             Error::HabitatCore(_) => "Habitat core error",
             Error::NonExistentRumor(_, _) => {
                 "Cannot write rumor to bytes because it does not exist"
@@ -121,6 +165,11 @@ impl error::Error for Error {
             Error::SocketSetReadTimeout(_) => "Cannot set UDP socket read timeout",
             Error::SocketSetWriteTimeout(_) => "Cannot set UDP socket write timeout",
             Error::SocketCloneError => "Cannot clone the underlying UDP socket",
+            Error::SwimChannelSetupError(_) => "Error setting up SWIM channel",
+            Error::SwimReceiveError(_) => "Failed to receive data from SWIM channel",
+            Error::SwimReceiveIOError(_) => "Failed to receive data from SWIM channel",
+            Error::SwimSendError(_) => "Failed to send data to SWIM channel",
+            Error::SwimSendIOError(_) => "Failed to send data to SWIM channel",
             Error::ZmqConnectError(_) => "Cannot connect ZMQ socket",
             Error::ZmqSendError(_) => "Cannot send message through ZMQ socket",
         }

--- a/components/butterfly/src/error.rs
+++ b/components/butterfly/src/error.rs
@@ -45,7 +45,7 @@ pub enum Error {
     ServiceConfigNotUtf8(String, str::Utf8Error),
     SocketSetReadTimeout(io::Error),
     SocketSetWriteTimeout(io::Error),
-    SocketCloneError,
+    SwimChannelCloneError,
     SwimChannelSetupError(String),
     SwimReceiveError(String),
     SwimReceiveIOError(io::Error),
@@ -117,7 +117,7 @@ impl fmt::Display for Error {
             Error::SocketSetWriteTimeout(ref err) => {
                 format!("Cannot set UDP socket write timeout: {}", err)
             }
-            Error::SocketCloneError => format!("Cannot clone the underlying UDP socket"),
+            Error::SwimChannelCloneError => format!("Cannot clone the SWIM channel"),
             Error::SwimChannelSetupError(ref err) => {
                 format!("Error setting up SWIM channel: {}", err)
             }
@@ -164,7 +164,7 @@ impl error::Error for Error {
             Error::ServiceConfigNotUtf8(_, _) => "Cannot read service config bytes to UTF-8",
             Error::SocketSetReadTimeout(_) => "Cannot set UDP socket read timeout",
             Error::SocketSetWriteTimeout(_) => "Cannot set UDP socket write timeout",
-            Error::SocketCloneError => "Cannot clone the underlying UDP socket",
+            Error::SwimChannelCloneError => "Cannot clone the SWIM channel",
             Error::SwimChannelSetupError(_) => "Error setting up SWIM channel",
             Error::SwimReceiveError(_) => "Failed to receive data from SWIM channel",
             Error::SwimReceiveIOError(_) => "Failed to receive data from SWIM channel",

--- a/components/butterfly/src/lib.rs
+++ b/components/butterfly/src/lib.rs
@@ -46,8 +46,6 @@
 extern crate byteorder;
 extern crate habitat_core;
 #[macro_use]
-extern crate lazy_static;
-#[macro_use]
 extern crate log;
 extern crate protobuf;
 extern crate rand;
@@ -69,30 +67,4 @@ pub mod message;
 pub mod rumor;
 pub mod server;
 
-use std::cell::UnsafeCell;
-
 pub use server::Server;
-
-lazy_static! {
-    /// A threadsafe shared ZMQ context for consuming services.
-    ///
-    /// You probably want to use this context to create new ZMQ sockets unless you *do not* want to
-    /// connect them together using an in-proc queue.
-    pub static ref ZMQ_CONTEXT: Box<ServerContext> = {
-        let ctx = ServerContext(UnsafeCell::new(zmq::Context::new()));
-        Box::new(ctx)
-    };
-}
-
-/// This is a wrapper to provide interior mutability of an underlying `zmq::Context` and allows
-/// for sharing/sending of a `zmq::Context` between threads.
-pub struct ServerContext(UnsafeCell<zmq::Context>);
-
-impl ServerContext {
-    pub fn as_mut(&self) -> &mut zmq::Context {
-        unsafe { &mut *self.0.get() }
-    }
-}
-
-unsafe impl Send for ServerContext {}
-unsafe impl Sync for ServerContext {}

--- a/components/butterfly/src/lib.rs
+++ b/components/butterfly/src/lib.rs
@@ -63,6 +63,7 @@ extern crate zmq;
 pub mod trace;
 pub mod client;
 pub mod error;
+pub mod network;
 pub mod member;
 pub mod message;
 pub mod rumor;

--- a/components/butterfly/src/main.rs
+++ b/components/butterfly/src/main.rs
@@ -25,6 +25,7 @@ use std::time::Duration;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 
+use habitat_butterfly::network::RealNetwork;
 use habitat_butterfly::{server, member, trace};
 use habitat_butterfly::server::Suitability;
 use habitat_core::service::ServiceGroup;
@@ -56,16 +57,16 @@ fn main() {
     member.set_swim_port(bind_port as i32);
     member.set_gossip_port(gport as i32);
 
-    let mut server = server::Server::new(
-        bind_to_addr,
-        gossip_bind_addr,
+    let network = RealNetwork::new_for_server(bind_to_addr, gossip_bind_addr);
+    let mut server = server::Server::<RealNetwork>::new(
+        network,
         member,
         trace::Trace::default(),
         None,
         None,
         None::<PathBuf>,
         Box::new(ZeroSuitability),
-    ).unwrap();
+    );
     println!("Server ID: {}", server.member_id());
 
     let targets: Vec<String> = args.collect();

--- a/components/butterfly/src/member.rs
+++ b/components/butterfly/src/member.rs
@@ -135,8 +135,9 @@ impl Member {
     ///
     /// # Panics
     ///
-    /// This function panics if the address is un-parseable. In practice, it shouldn't be
-    /// un-parseable, since its set from the inbound socket directly.
+    /// This function panics if the address is unparsable. In
+    /// practice, it shouldn't be unparsable, since its set from the
+    /// inbound socket directly.
     pub fn swim_socket_address(&self) -> SocketAddr {
         self.socket_address(self.get_swim_port())
     }
@@ -145,8 +146,9 @@ impl Member {
     ///
     /// # Panics
     ///
-    /// This function panics if the address is un-parseable. In practice, it shouldn't be
-    /// un-parseable, since its set from the inbound socket directly.
+    /// This function panics if the address is unparsable. In
+    /// practice, it shouldn't be unparsable, since its set from the
+    /// inbound socket directly.
     pub fn gossip_socket_address(&self) -> SocketAddr {
         self.socket_address(self.get_gossip_port())
     }

--- a/components/butterfly/src/member.rs
+++ b/components/butterfly/src/member.rs
@@ -131,14 +131,28 @@ pub struct Member {
 }
 
 impl Member {
-    /// Returns the socket address of this member.
+    /// Returns the swim socket address of this member.
     ///
     /// # Panics
     ///
     /// This function panics if the address is un-parseable. In practice, it shouldn't be
     /// un-parseable, since its set from the inbound socket directly.
     pub fn swim_socket_address(&self) -> SocketAddr {
-        let address_str = format!("{}:{}", self.get_address(), self.get_swim_port());
+        self.socket_address(self.get_swim_port())
+    }
+
+    /// Returns the gossip socket address of this member.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if the address is un-parseable. In practice, it shouldn't be
+    /// un-parseable, since its set from the inbound socket directly.
+    pub fn gossip_socket_address(&self) -> SocketAddr {
+        self.socket_address(self.get_gossip_port())
+    }
+
+    fn socket_address(&self, port: i32) -> SocketAddr {
+        let address_str = format!("{}:{}", self.get_address(), port);
         match address_str.parse() {
             Ok(addr) => addr,
             Err(e) => {

--- a/components/butterfly/src/network.rs
+++ b/components/butterfly/src/network.rs
@@ -1,0 +1,80 @@
+// Copyright (c) 2018 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! The Butterfly network abstraction.
+//!
+//! The abstraction provides communication channels for sending SWIM
+//! and gossip messages.
+
+use std::fmt::Debug;
+use std::marker::Send;
+use std::net::SocketAddr;
+
+use error::Result;
+
+// TODO(krnowak): See a TODO about Debug for Network trait below.
+/// A trait for types used for sending SWIM messages.
+pub trait SwimSender: Send + Debug {
+    /// Send a SWIM message (as bytes) to the given address. The
+    /// returned value holds a number of bytes sent.
+    fn send(&self, buf: &[u8], addr: SocketAddr) -> Result<usize>;
+}
+
+/// A trait for types used for receiving SWIM messages.
+pub trait SwimReceiver: Send {
+    /// Receive a SWIM message (as bytes) from the channel. The
+    /// returned value holds the size and an address from where the
+    /// bytes came.
+    fn receive(&self, buf: &mut [u8]) -> Result<(usize, SocketAddr)>;
+}
+
+/// A trait for types used for sending gossip messages (rumors).
+pub trait GossipSender {
+    /// Send a rumor (as bytes).
+    fn send(&self, buf: &[u8]) -> Result<()>;
+}
+
+/// A trait for types used for receiving gossip messages (rumors).
+pub trait GossipReceiver {
+    /// Receive a rumor (as bytes).
+    fn receive(&self) -> Result<Vec<u8>>;
+}
+
+// TODO(krnowak): Not sure if this static lifetime specifier here is a
+// correct thing to do. It is either here on in several other places
+// where generic type N constrained to being an implementation of the
+// Network trait is used (trace, expire, inbound, outbound and so
+// on). I added it here, because Network is exclusively used by the
+// butterfly component.
+//
+// Same for Debug - Network is used by the butterfly component only so
+// I add it here to save me some typing.
+/// A trait for types used to provide SWIM and gossip communication
+/// channels.
+pub trait Network: Send + Sync + Debug + 'static {
+    type SwimSender: SwimSender;
+    type SwimReceiver: SwimReceiver;
+    type GossipSender: GossipSender;
+    type GossipReceiver: GossipReceiver;
+
+    fn get_swim_addr(&self) -> SocketAddr;
+    fn get_swim_port(&self) -> u16;
+    fn get_swim_sender(&self) -> Result<Self::SwimSender>;
+    fn get_swim_receiver(&self) -> Result<Self::SwimReceiver>;
+
+    fn get_gossip_addr(&self) -> SocketAddr;
+    fn get_gossip_port(&self) -> u16;
+    fn get_gossip_sender(&self, addr: SocketAddr) -> Result<Self::GossipSender>;
+    fn get_gossip_receiver(&self) -> Result<Self::GossipReceiver>;
+}

--- a/components/butterfly/src/network.rs
+++ b/components/butterfly/src/network.rs
@@ -17,11 +17,20 @@
 //! The abstraction provides communication channels for sending SWIM
 //! and gossip messages.
 
-use std::fmt::Debug;
+use std::cell::UnsafeCell;
+use std::fmt::{Debug, Error as FmtError, Formatter};
+use std::error::Error as StdError;
 use std::marker::Send;
-use std::net::SocketAddr;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr, UdpSocket};
+use std::result::Result as StdResult;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
-use error::Result;
+use error::{Result, Error};
+
+use zmq;
+
+use ServerContext;
 
 // TODO(krnowak): See a TODO about Debug for Network trait below.
 /// A trait for types used for sending SWIM messages.
@@ -77,4 +86,244 @@ pub trait Network: Send + Sync + Debug + 'static {
     fn get_gossip_port(&self) -> u16;
     fn get_gossip_sender(&self, addr: SocketAddr) -> Result<Self::GossipSender>;
     fn get_gossip_receiver(&self) -> Result<Self::GossipReceiver>;
+}
+
+/// An implementation of the `SwimSender` and `SwimReceiver` traits
+/// that uses UdpSocket.
+#[derive(Debug)]
+pub struct SwimUdpSocket {
+    udp: UdpSocket,
+}
+
+impl SwimSender for SwimUdpSocket {
+    fn send(&self, buf: &[u8], addr: SocketAddr) -> Result<usize> {
+        self.udp.send_to(buf, addr).map_err(
+            |e| Error::SwimSendIOError(e),
+        )
+    }
+}
+
+impl SwimReceiver for SwimUdpSocket {
+    fn receive(&self, buf: &mut [u8]) -> Result<(usize, SocketAddr)> {
+        self.udp.recv_from(buf).map_err(
+            |e| Error::SwimReceiveIOError(e),
+        )
+    }
+}
+
+/// An implementation of the `GossipSender` and `GossipReceiver`
+/// traits that uses `zmq::Socket`.
+pub struct GossipZmqSocket {
+    zmq: zmq::Socket,
+}
+
+impl GossipSender for GossipZmqSocket {
+    fn send(&self, buf: &[u8]) -> Result<()> {
+        self.zmq.send(buf, 0).map_err(|e| {
+            Error::GossipSendError(e.description().to_owned())
+        })
+    }
+}
+
+impl GossipReceiver for GossipZmqSocket {
+    fn receive(&self) -> Result<Vec<u8>> {
+        self.zmq.recv_bytes(0).map_err(|e| {
+            Error::GossipReceiveError(e.description().to_owned())
+        })
+    }
+}
+
+/// An implementation of the `Network` trait that creates
+/// `SwimUdpSocket` instances for SWIM communication, and
+/// `GossipZmqSocket` instances for gossip communication.
+pub struct RealNetwork {
+    swim_addr: SocketAddr,
+    gossip_addr: SocketAddr,
+    push_socket_linger: i32,
+    zmq_context: ServerContext,
+
+    udp_socket: Arc<Mutex<Option<UdpSocket>>>,
+}
+
+impl RealNetwork {
+    /// Create an instance of `RealNetwork` to be used by clients. It
+    /// sets linger time for push zmq gossip sockets to be
+    /// indefinite. Use this instance to get pull or push gossip
+    /// sockets.
+    ///
+    /// For getting SWIM channels or gossip receivers, get an instance
+    /// with `new_for_server`.
+    pub fn new_for_client() -> Self {
+        // The client only sends rumors through the gossip sender
+        // socket, so we pass some throw away address as arguments for
+        // SWIM socket and gossip receiver socket addresses.
+        Self::new(Self::throw_away_addr(), Self::throw_away_addr(), -1)
+    }
+
+    /// Create an instance of `RealNetwork` to be used by servers.
+    pub fn new_for_server(swim_addr: SocketAddr, gossip_addr: SocketAddr) -> Self {
+        Self::new(swim_addr, gossip_addr, 1000)
+    }
+
+    fn new(swim_addr: SocketAddr, gossip_addr: SocketAddr, push_socket_linger: i32) -> Self {
+        RealNetwork {
+            swim_addr: swim_addr,
+            gossip_addr: gossip_addr,
+            push_socket_linger: push_socket_linger,
+            zmq_context: ServerContext(UnsafeCell::new(zmq::Context::new())),
+            udp_socket: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    fn throw_away_addr() -> SocketAddr {
+        let ip = IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0));
+        SocketAddr::new(ip, 0)
+    }
+
+    fn context_mut(&self) -> &mut zmq::Context {
+        self.zmq_context.as_mut()
+    }
+
+    fn create_udp_socket(addr: &SocketAddr) -> Result<UdpSocket> {
+        let socket = UdpSocket::bind(addr).map_err(|e| Error::CannotBind(e))?;
+        socket
+            .set_read_timeout(Some(Duration::from_millis(1000)))
+            .map_err(|e| {
+                Error::SwimChannelSetupError(format!("Can't set up read timeout, {}", e))
+            })?;
+        socket
+            .set_write_timeout(Some(Duration::from_millis(1000)))
+            .map_err(|e| {
+                Error::SwimChannelSetupError(format!("Can't set up write timeout, {}", e))
+            })?;
+
+        Ok(socket)
+    }
+
+    fn get_swim_socket(&self) -> Result<SwimUdpSocket> {
+        let mut maybe_socket = self.udp_socket.lock().expect("udp socket lock poisoned");
+        if let Some(ref socket) = *maybe_socket {
+            let cloned_socket = Self::clone_udp_socket(socket)?;
+            return Ok(SwimUdpSocket { udp: cloned_socket });
+        }
+        let new_socket = Self::create_udp_socket(&self.swim_addr)?;
+        *maybe_socket = Some(Self::clone_udp_socket(&new_socket)?);
+
+        Ok(SwimUdpSocket { udp: new_socket })
+    }
+
+    fn clone_udp_socket(socket: &UdpSocket) -> Result<UdpSocket> {
+        socket.try_clone().map_err(|e| {
+            Error::SwimChannelSetupError(format!("{}", e))
+        })
+    }
+}
+
+// Implementing Debug trait explicitly to avoid debug output for zmq_context
+impl Debug for RealNetwork {
+    fn fmt(&self, f: &mut Formatter) -> StdResult<(), FmtError> {
+        write!(
+            f,
+            "RealNetwork {{ swim_addr: {:?}, gossip_addr: {:?}, push_socket_linger: {:?}, \
+             zmq_context: <skipped>, udp_socket: {:?} }}",
+            self.swim_addr,
+            self.gossip_addr,
+            self.push_socket_linger,
+            self.udp_socket,
+        )
+    }
+}
+
+impl Network for RealNetwork {
+    type SwimSender = SwimUdpSocket;
+    type SwimReceiver = SwimUdpSocket;
+    type GossipReceiver = GossipZmqSocket;
+    type GossipSender = GossipZmqSocket;
+
+    fn get_swim_addr(&self) -> SocketAddr {
+        self.swim_addr.clone()
+    }
+
+    fn get_swim_port(&self) -> u16 {
+        self.swim_addr.port()
+    }
+
+    fn get_swim_sender(&self) -> Result<SwimUdpSocket> {
+        self.get_swim_socket()
+    }
+
+    fn get_swim_receiver(&self) -> Result<SwimUdpSocket> {
+        self.get_swim_socket()
+    }
+
+    fn get_gossip_addr(&self) -> SocketAddr {
+        self.gossip_addr.clone()
+    }
+
+    fn get_gossip_port(&self) -> u16 {
+        self.gossip_addr.port()
+    }
+
+    fn get_gossip_sender(&self, addr: SocketAddr) -> Result<GossipZmqSocket> {
+        let socket = self.context_mut().socket(zmq::PUSH).map_err(|e| {
+            Error::GossipChannelSetupError(format!("Failed to create the ZMQ push socket: {}", e))
+        })?;
+        socket.set_linger(self.push_socket_linger).map_err(|e| {
+            Error::GossipChannelSetupError(
+                format!("Failed to set the ZMQ push socket linger: {}", e),
+            )
+        })?;
+        socket.set_tcp_keepalive(0).map_err(|e| {
+            Error::GossipChannelSetupError(format!(
+                "Failed to set the ZMQ push socket to not use keepalive: {}",
+                e
+            ))
+        })?;
+        socket.set_immediate(true).map_err(|e| {
+            Error::GossipChannelSetupError(format!(
+                "Failed to set the ZMQ push socket to immediate: {}",
+                e
+            ))
+        })?;
+        socket.set_sndhwm(1000).map_err(|e| {
+            Error::GossipChannelSetupError(format!("Failed to set the ZMQ push socket hwm: {}", e))
+        })?;
+        socket.set_sndtimeo(500).map_err(|e| {
+            Error::GossipChannelSetupError(format!(
+                "Failed to set the ZMQ push socket send timeout: {}",
+                e
+            ))
+        })?;
+        socket.connect(&format!("tcp://{}", addr)).map_err(|e| {
+            Error::GossipChannelSetupError(format!("Failed to connect to {:?}: {}", addr, e))
+        })?;
+        Ok(GossipZmqSocket { zmq: socket })
+    }
+
+    fn get_gossip_receiver(&self) -> Result<GossipZmqSocket> {
+        let socket = self.context_mut().socket(zmq::PULL).map_err(|e| {
+            Error::GossipChannelSetupError(format!("Failed to create the ZMQ pull socket: {}", e))
+        })?;
+        socket.set_linger(0).map_err(|e| {
+            Error::GossipChannelSetupError(format!(
+                "Failed to set the ZMQ pull socket to not linger: {}",
+                e
+            ))
+        })?;
+        socket.set_tcp_keepalive(0).map_err(|e| {
+            Error::GossipChannelSetupError(format!(
+                "Failed to set the ZMQ pull socket to not use keepalive: {}",
+                e
+            ))
+        })?;
+        socket
+            .bind(&format!("tcp://{}", self.gossip_addr))
+            .map_err(|e| {
+                Error::GossipChannelSetupError(format!(
+                    "Failed to bind the ZMQ pull socket to the port: {}",
+                    e
+                ))
+            })?;
+        Ok(GossipZmqSocket { zmq: socket })
+    }
 }

--- a/components/butterfly/src/network.rs
+++ b/components/butterfly/src/network.rs
@@ -251,7 +251,7 @@ impl Network for RealNetwork {
     type GossipSender = GossipZmqSocket;
 
     fn get_swim_addr(&self) -> SocketAddr {
-        self.swim_addr.clone()
+        self.swim_addr
     }
 
     fn get_swim_sender(&self) -> Result<SwimUdpSocket> {
@@ -263,7 +263,7 @@ impl Network for RealNetwork {
     }
 
     fn get_gossip_addr(&self) -> SocketAddr {
-        self.gossip_addr.clone()
+        self.gossip_addr
     }
 
     fn get_gossip_sender(&self, addr: SocketAddr) -> Result<GossipZmqSocket> {

--- a/components/butterfly/src/network.rs
+++ b/components/butterfly/src/network.rs
@@ -76,12 +76,12 @@ pub trait Network: Send + Sync + Debug + 'static {
     type GossipReceiver: GossipReceiver;
 
     fn get_swim_addr(&self) -> SocketAddr;
-    fn get_swim_sender(&self) -> Result<Self::SwimSender>;
-    fn get_swim_receiver(&self) -> Result<Self::SwimReceiver>;
+    fn create_swim_sender(&self) -> Result<Self::SwimSender>;
+    fn create_swim_receiver(&self) -> Result<Self::SwimReceiver>;
 
     fn get_gossip_addr(&self) -> SocketAddr;
-    fn get_gossip_sender(&self, addr: SocketAddr) -> Result<Self::GossipSender>;
-    fn get_gossip_receiver(&self) -> Result<Self::GossipReceiver>;
+    fn create_gossip_sender(&self, addr: SocketAddr) -> Result<Self::GossipSender>;
+    fn create_gossip_receiver(&self) -> Result<Self::GossipReceiver>;
 }
 
 /// An implementation of the `SwimSender` and `SwimReceiver` traits
@@ -254,11 +254,11 @@ impl Network for RealNetwork {
         self.swim_addr
     }
 
-    fn get_swim_sender(&self) -> Result<SwimUdpSocket> {
+    fn create_swim_sender(&self) -> Result<SwimUdpSocket> {
         self.get_swim_socket()
     }
 
-    fn get_swim_receiver(&self) -> Result<SwimUdpSocket> {
+    fn create_swim_receiver(&self) -> Result<SwimUdpSocket> {
         self.get_swim_socket()
     }
 
@@ -266,7 +266,7 @@ impl Network for RealNetwork {
         self.gossip_addr
     }
 
-    fn get_gossip_sender(&self, addr: SocketAddr) -> Result<GossipZmqSocket> {
+    fn create_gossip_sender(&self, addr: SocketAddr) -> Result<GossipZmqSocket> {
         let socket = self.context_mut().socket(zmq::PUSH).map_err(|e| {
             Error::GossipChannelSetupError(format!("Failed to create the ZMQ push socket: {}", e))
         })?;
@@ -302,7 +302,7 @@ impl Network for RealNetwork {
         Ok(GossipZmqSocket { zmq: socket })
     }
 
-    fn get_gossip_receiver(&self) -> Result<GossipZmqSocket> {
+    fn create_gossip_receiver(&self) -> Result<GossipZmqSocket> {
         let socket = self.context_mut().socket(zmq::PULL).map_err(|e| {
             Error::GossipChannelSetupError(format!("Failed to create the ZMQ pull socket: {}", e))
         })?;

--- a/components/butterfly/src/network.rs
+++ b/components/butterfly/src/network.rs
@@ -76,12 +76,10 @@ pub trait Network: Send + Sync + Debug + 'static {
     type GossipReceiver: GossipReceiver;
 
     fn get_swim_addr(&self) -> SocketAddr;
-    fn get_swim_port(&self) -> u16;
     fn get_swim_sender(&self) -> Result<Self::SwimSender>;
     fn get_swim_receiver(&self) -> Result<Self::SwimReceiver>;
 
     fn get_gossip_addr(&self) -> SocketAddr;
-    fn get_gossip_port(&self) -> u16;
     fn get_gossip_sender(&self, addr: SocketAddr) -> Result<Self::GossipSender>;
     fn get_gossip_receiver(&self) -> Result<Self::GossipReceiver>;
 }
@@ -256,10 +254,6 @@ impl Network for RealNetwork {
         self.swim_addr.clone()
     }
 
-    fn get_swim_port(&self) -> u16 {
-        self.swim_addr.port()
-    }
-
     fn get_swim_sender(&self) -> Result<SwimUdpSocket> {
         self.get_swim_socket()
     }
@@ -270,10 +264,6 @@ impl Network for RealNetwork {
 
     fn get_gossip_addr(&self) -> SocketAddr {
         self.gossip_addr.clone()
-    }
-
-    fn get_gossip_port(&self) -> u16 {
-        self.gossip_addr.port()
     }
 
     fn get_gossip_sender(&self, addr: SocketAddr) -> Result<GossipZmqSocket> {

--- a/components/butterfly/src/rumor/dat_file.rs
+++ b/components/butterfly/src/rumor/dat_file.rs
@@ -27,6 +27,7 @@ use message::swim::Membership as ProtoMembership;
 use rumor::{Election, ElectionUpdate, Rumor, RumorStore, Service, ServiceConfig, ServiceFile,
             Departure};
 use server::Server;
+use network::Network;
 
 const HEADER_VERSION: u8 = 2;
 
@@ -60,7 +61,7 @@ impl DatFile {
         &self.path
     }
 
-    pub fn read_into(&mut self, server: &Server) -> Result<()> {
+    pub fn read_into<N: Network>(&mut self, server: &Server<N>) -> Result<()> {
         let mut version = [0; 1];
         let mut size_buf = [0; 8];
         // JW: Resizing this buffer is terrible for performance, but it's the easiest way to
@@ -238,7 +239,7 @@ impl DatFile {
         Ok(())
     }
 
-    pub fn write(&self, server: &Server) -> Result<usize> {
+    pub fn write<N: Network>(&self, server: &Server<N>) -> Result<usize> {
         let mut header = Header::default();
         let tmp_path = self.path.with_extension(
             thread_rng()

--- a/components/butterfly/src/server/expire.rs
+++ b/components/butterfly/src/server/expire.rs
@@ -28,16 +28,17 @@ use rumor::RumorKey;
 use server::Server;
 use server::timing::Timing;
 use trace::TraceKind;
+use network::Network;
 
-pub struct Expire {
-    pub server: Server,
+pub struct Expire<N: Network> {
+    pub server: Server<N>,
     pub timing: Timing,
 }
 
-impl Expire {
+impl<N: Network> Expire<N> {
     /// Takes a reference to a server, and a `Timing`, returns you an Expire struct.
-    pub fn new(server: Server, timing: Timing) -> Expire {
-        Expire {
+    pub fn new(server: Server<N>, timing: Timing) -> Self {
+        Self {
             server: server,
             timing: timing,
         }

--- a/components/butterfly/src/server/inbound.rs
+++ b/components/butterfly/src/server/inbound.rs
@@ -18,34 +18,39 @@
 
 use std::sync::mpsc;
 use std::sync::atomic::Ordering;
-use std::net::{SocketAddr, UdpSocket};
+use std::net::SocketAddr;
 use std::thread;
 use std::time::Duration;
 
 use protobuf;
 
+use error::Error;
 use member::{Member, Health};
 use message::swim::{Swim, Swim_Type};
 use server::{Server, outbound};
 use trace::TraceKind;
+use network::{Network, SwimReceiver};
 
 /// Takes the Server and a channel to send received Acks to the outbound thread.
-pub struct Inbound {
-    pub server: Server,
-    pub socket: UdpSocket,
+pub struct Inbound<N: Network> {
+    pub server: Server<N>,
+    pub swim_receiver: N::SwimReceiver,
+    pub swim_sender: N::SwimSender,
     pub tx_outbound: mpsc::Sender<(SocketAddr, Swim)>,
 }
 
-impl Inbound {
+impl<N: Network> Inbound<N> {
     /// Create a new Inbound.
     pub fn new(
-        server: Server,
-        socket: UdpSocket,
+        server: Server<N>,
+        swim_receiver: N::SwimReceiver,
+        swim_sender: N::SwimSender,
         tx_outbound: mpsc::Sender<(SocketAddr, Swim)>,
-    ) -> Inbound {
-        Inbound {
+    ) -> Self {
+        Self {
             server: server,
-            socket: socket,
+            swim_receiver: swim_receiver,
+            swim_sender: swim_sender,
             tx_outbound: tx_outbound,
         }
     }
@@ -58,7 +63,7 @@ impl Inbound {
                 thread::sleep(Duration::from_millis(100));
                 continue;
             }
-            match self.socket.recv_from(&mut recv_buffer[..]) {
+            match self.swim_receiver.receive(&mut recv_buffer[..]) {
                 Ok((length, addr)) => {
                     let swim_payload = match self.server.unwrap_wire(&recv_buffer[0..length]) {
                         Ok(swim_payload) => swim_payload,
@@ -122,19 +127,22 @@ impl Inbound {
                         }
                     }
                 }
-                Err(e) => {
+                Err(Error::SwimReceiveIOError(e)) => {
                     match e.raw_os_error() {
                         Some(35) | Some(11) | Some(10035) | Some(10060) => {
                             // This is the normal non-blocking result, or a timeout
                         }
                         Some(_) => {
-                            error!("UDP Receive error: {}", e);
-                            debug!("UDP Receive error debug: {:?}", e);
+                            error!("SWIM Receive error: {}", e);
+                            debug!("SWIM Receive error debug: {:?}", e);
                         }
                         None => {
-                            error!("UDP Receive error: {}", e);
+                            error!("SWIM Receive error: {}", e);
                         }
                     }
+                }
+                Err(e) => {
+                    error!("SWIM Receive error: {}", e);
                 }
             }
         }
@@ -163,7 +171,7 @@ impl Inbound {
             from.set_address(format!("{}", addr.ip()));
             outbound::ping(
                 &self.server,
-                &self.socket,
+                &self.swim_sender,
                 target,
                 target.swim_socket_address(),
                 Some(from.into()),
@@ -206,7 +214,7 @@ impl Inbound {
                 msg.mut_ack().mut_from().set_address(
                     format!("{}", addr.ip()),
                 );
-                outbound::forward_ack(&self.server, &self.socket, forward_to_addr, msg);
+                outbound::forward_ack(&self.server, &self.swim_sender, forward_to_addr, msg);
                 return;
             }
         }
@@ -237,13 +245,13 @@ impl Inbound {
         if msg.get_ping().has_forward_to() {
             outbound::ack(
                 &self.server,
-                &self.socket,
+                &self.swim_sender,
                 &target,
                 addr,
                 Some(msg.mut_ping().take_forward_to().into()),
             );
         } else {
-            outbound::ack(&self.server, &self.socket, &target, addr, None);
+            outbound::ack(&self.server, &self.swim_sender, &target, addr, None);
         }
         // Populate the member for this sender with its remote address
         let from = {

--- a/components/butterfly/src/server/mod.rs
+++ b/components/butterfly/src/server/mod.rs
@@ -138,8 +138,8 @@ impl<N: Network> Server<N> {
     where
         P: Into<PathBuf> + AsRef<ffi::OsStr>,
     {
-        member.set_swim_port(network.get_swim_port() as i32);
-        member.set_gossip_port(network.get_gossip_port() as i32);
+        member.set_swim_port(network.get_swim_addr().port() as i32);
+        member.set_gossip_port(network.get_gossip_addr().port() as i32);
         Self {
             name: Arc::new(name.unwrap_or(String::from(member.get_id()))),
             member_id: Arc::new(String::from(member.get_id())),
@@ -354,7 +354,7 @@ impl<N: Network> Server<N> {
 
     /// Return the port number of the swim socket we are bound to.
     pub fn swim_port(&self) -> u16 {
-        self.read_network().get_swim_port()
+        self.read_network().get_swim_addr().port()
     }
 
     /// Return the gossip address we are bound to
@@ -364,7 +364,7 @@ impl<N: Network> Server<N> {
 
     /// Return the port number of the gossip socket we are bound to.
     pub fn gossip_port(&self) -> u16 {
-        self.read_network().get_gossip_port()
+        self.read_network().get_gossip_addr().port()
     }
 
     pub fn read_network(&self) -> RwLockReadGuard<N> {

--- a/components/butterfly/src/server/mod.rs
+++ b/components/butterfly/src/server/mod.rs
@@ -242,9 +242,9 @@ impl<N: Network> Server<N> {
         }
 
         let server_a = self.clone();
-        let swim_sender = self.read_network().get_swim_sender()?;
-        let swim_sender_a = self.read_network().get_swim_sender()?;
-        let swim_receiver = self.read_network().get_swim_receiver()?;
+        let swim_sender = self.read_network().create_swim_sender()?;
+        let swim_sender_a = self.read_network().create_swim_sender()?;
+        let swim_receiver = self.read_network().create_swim_receiver()?;
         self.swim_sender = Some(swim_sender);
 
         let _ = thread::Builder::new()
@@ -255,7 +255,7 @@ impl<N: Network> Server<N> {
             });
 
         let server_b = self.clone();
-        let swim_sender_b = self.read_network().get_swim_sender()?;
+        let swim_sender_b = self.read_network().create_swim_sender()?;
         let timing_b = timing.clone();
         let _ = thread::Builder::new()
             .name(format!("outbound-{}", self.name()))

--- a/components/butterfly/src/server/pull.rs
+++ b/components/butterfly/src/server/pull.rs
@@ -21,45 +21,35 @@ use std::thread;
 use std::time::Duration;
 
 use protobuf;
-use zmq;
 
-use ZMQ_CONTEXT;
 use server::Server;
 use message::swim::{Rumor, Rumor_Type};
 use trace::TraceKind;
+use network::{Network, GossipReceiver};
 
 /// Takes a reference to the server itself
-pub struct Pull {
-    pub server: Server,
+pub struct Pull<N: Network> {
+    pub server: Server<N>,
 }
 
-impl Pull {
+impl<N: Network> Pull<N> {
     /// Create a new Pull
-    pub fn new(server: Server) -> Pull {
-        Pull { server: server }
+    pub fn new(server: Server<N>) -> Self {
+        Self { server: server }
     }
 
     /// Run this thread. Creates a socket, binds to the `gossip_addr`, then processes messages as
     /// they are received. Uses a ZMQ pull socket, so inbound messages are fair-queued.
     pub fn run(&mut self) {
-        let socket = (**ZMQ_CONTEXT).as_mut().socket(zmq::PULL).expect(
-            "Failure to create the ZMQ pull socket",
+        let socket = self.server.read_network().get_gossip_receiver().expect(
+            "Failed to get gossip pull socket",
         );
-        socket.set_linger(0).expect(
-            "Failure to set the ZMQ Pull socket to not linger",
-        );
-        socket.set_tcp_keepalive(0).expect(
-            "Failure to set the ZMQ Pull socket to not use keepalive",
-        );
-        socket
-            .bind(&format!("tcp://{}", self.server.gossip_addr()))
-            .expect("Failure to bind the ZMQ Pull socket to the port");
         'recv: loop {
             if self.server.pause.load(Ordering::Relaxed) {
                 thread::sleep(Duration::from_millis(100));
                 continue;
             }
-            let msg = match socket.recv_msg(0) {
+            let msg = match socket.receive() {
                 Ok(msg) => msg,
                 Err(e) => {
                     error!("Error receiving message: {:?}", e);

--- a/components/butterfly/src/server/pull.rs
+++ b/components/butterfly/src/server/pull.rs
@@ -41,7 +41,7 @@ impl<N: Network> Pull<N> {
     /// Run this thread. Creates a socket, binds to the `gossip_addr`, then processes messages as
     /// they are received. Uses a ZMQ pull socket, so inbound messages are fair-queued.
     pub fn run(&mut self) {
-        let socket = self.server.read_network().get_gossip_receiver().expect(
+        let receiver = self.server.read_network().get_gossip_receiver().expect(
             "Failed to get gossip pull socket",
         );
         'recv: loop {
@@ -49,7 +49,7 @@ impl<N: Network> Pull<N> {
                 thread::sleep(Duration::from_millis(100));
                 continue;
             }
-            let msg = match socket.receive() {
+            let msg = match receiver.receive() {
                 Ok(msg) => msg,
                 Err(e) => {
                     error!("Error receiving message: {:?}", e);

--- a/components/butterfly/src/server/pull.rs
+++ b/components/butterfly/src/server/pull.rs
@@ -41,7 +41,7 @@ impl<N: Network> Pull<N> {
     /// Run this thread. Creates a socket, binds to the `gossip_addr`, then processes messages as
     /// they are received. Uses a ZMQ pull socket, so inbound messages are fair-queued.
     pub fn run(&mut self) {
-        let receiver = self.server.read_network().get_gossip_receiver().expect(
+        let receiver = self.server.read_network().create_gossip_receiver().expect(
             "Failed to get gossip pull socket",
         );
         'recv: loop {

--- a/components/butterfly/src/server/push.rs
+++ b/components/butterfly/src/server/push.rs
@@ -150,7 +150,7 @@ impl<N: Network> PushWorker<N> {
     /// connection and socket open for 1 second longer - so it is possible, but unlikely, that this
     /// method can loose messages.
     fn send_rumors(&self, member: Member, rumors: Vec<RumorKey>) {
-        let socket = match self.server.read_network().get_gossip_sender(
+        let sender = match self.server.read_network().get_gossip_sender(
             member.gossip_socket_address(),
         ) {
             Ok(s) => s,
@@ -308,7 +308,7 @@ impl<N: Network> PushWorker<N> {
                     continue 'rumorlist;
                 }
             };
-            match socket.send(&payload) {
+            match sender.send(&payload) {
                 Ok(()) => debug!("Sent rumor {:?} to {:?}", rumor_key, member),
                 Err(e) => {
                     println!(

--- a/components/butterfly/src/server/push.rs
+++ b/components/butterfly/src/server/push.rs
@@ -150,7 +150,7 @@ impl<N: Network> PushWorker<N> {
     /// connection and socket open for 1 second longer - so it is possible, but unlikely, that this
     /// method can loose messages.
     fn send_rumors(&self, member: Member, rumors: Vec<RumorKey>) {
-        let sender = match self.server.read_network().get_gossip_sender(
+        let sender = match self.server.read_network().create_gossip_sender(
             member.gossip_socket_address(),
         ) {
             Ok(s) => s,

--- a/components/butterfly/src/trace.rs
+++ b/components/butterfly/src/trace.rs
@@ -24,6 +24,7 @@ use std::fs;
 use std::path::PathBuf;
 use std::io::Write;
 
+use network::Network;
 use server::Server;
 
 #[derive(Debug, Clone, Copy)]
@@ -162,7 +163,7 @@ impl Default for Trace {
 
 impl Trace {
     /// Initialize the trace object; only happens once.
-    pub fn init(&mut self, server: &Server) {
+    pub fn init<N: Network>(&mut self, server: &Server<N>) {
         if self.file.is_none() {
             let now = time::now_utc();
             let filename = format!("{}-{}.swimtrace", server.name(), now.rfc3339());

--- a/components/butterfly/tests/rumor/departure.rs
+++ b/components/butterfly/tests/rumor/departure.rs
@@ -14,7 +14,6 @@
 
 use btest;
 use habitat_butterfly::member::Health;
-use habitat_butterfly::client::Client;
 
 #[test]
 fn two_members_share_departures() {
@@ -35,8 +34,7 @@ fn departure_via_client() {
     net.mesh();
 
     net.wait_for_gossip_rounds(1);
-    let mut client =
-        Client::new(net[0].gossip_addr(), None).expect("Cannot create Butterfly Client");
+    let mut client = btest::get_client_for_address(net[0].gossip_addr());
     client
         .send_departure(String::from(net[1].member_id()))
         .expect("Cannot send the departure");

--- a/components/butterfly/tests/rumor/service_config.rs
+++ b/components/butterfly/tests/rumor/service_config.rs
@@ -14,7 +14,6 @@
 
 use btest;
 use habitat_core::service::ServiceGroup;
-use habitat_butterfly::client::Client;
 
 #[test]
 fn two_members_share_service_config() {
@@ -35,8 +34,7 @@ fn service_config_via_client() {
     net.mesh();
 
     net.wait_for_gossip_rounds(1);
-    let mut client =
-        Client::new(net[0].gossip_addr(), None).expect("Cannot create Butterfly Client");
+    let mut client = btest::get_client_for_address(net[0].gossip_addr());
     let payload = Vec::from("I want to get lost in you, tokyo".as_bytes());
     client
         .send_service_config(

--- a/components/butterfly/tests/rumor/service_file.rs
+++ b/components/butterfly/tests/rumor/service_file.rs
@@ -14,7 +14,6 @@
 
 use btest;
 use habitat_core::service::ServiceGroup;
-use habitat_butterfly::client::Client;
 
 #[test]
 fn two_members_share_service_files() {
@@ -40,8 +39,7 @@ fn service_file_via_client() {
     net.mesh();
 
     net.wait_for_gossip_rounds(1);
-    let mut client =
-        Client::new(net[0].gossip_addr(), None).expect("Cannot create Butterfly Client");
+    let mut client = btest::get_client_for_address(net[0].gossip_addr());
     let payload = Vec::from("I want to get lost in you, tokyo".as_bytes());
     client
         .send_service_file(

--- a/components/hab-butterfly/src/command/config.rs
+++ b/components/hab-butterfly/src/command/config.rs
@@ -19,12 +19,12 @@ pub mod apply {
     use std::thread;
     use std::time;
 
-    use butterfly::client::Client;
     use common::ui::{Status, UI};
     use hcore::crypto::{SymKey, BoxKeyPair};
     use hcore::service::ServiceGroup;
     use toml;
 
+    use command;
     use error::{Error, Result};
 
     pub fn start(
@@ -93,11 +93,7 @@ pub mod apply {
 
         for peer in peers.iter() {
             ui.status(Status::Applying, format!("to peer {}", peer))?;
-            let mut client = Client::new(peer, ring_key.map(|k| k.clone())).map_err(
-                |e| {
-                    Error::ButterflyError(format!("{}", e))
-                },
-            )?;
+            let mut client = command::get_client(peer, ring_key.map(|k| k.clone()))?;
             client
                 .send_service_config(sg.clone(), number, body.clone(), encrypted)
                 .map_err(|e| Error::ButterflyError(format!("{}", e)))?;

--- a/components/hab-butterfly/src/command/depart.rs
+++ b/components/hab-butterfly/src/command/depart.rs
@@ -15,10 +15,10 @@
 use std::thread;
 use std::time;
 
-use butterfly::client::Client;
 use common::ui::{Status, UI};
 use hcore::crypto::SymKey;
 
+use command;
 use error::{Error, Result};
 
 pub fn run(
@@ -36,9 +36,7 @@ pub fn run(
     )?;
     for peer in peers.into_iter() {
         ui.status(Status::Applying, format!("to peer {}", peer))?;
-        let mut client = Client::new(peer, ring_key.clone()).map_err(|e| {
-            Error::ButterflyError(e.to_string())
-        })?;
+        let mut client = command::get_client(&peer, ring_key.clone())?;
         client.send_departure(member_id).map_err(|e| {
             Error::ButterflyError(e.to_string())
         })?;

--- a/components/hab-butterfly/src/command/file.rs
+++ b/components/hab-butterfly/src/command/file.rs
@@ -19,11 +19,11 @@ pub mod upload {
     use std::thread;
     use std::time;
 
-    use butterfly::client::Client;
     use common::ui::{Status, UI};
     use hcore::crypto::{SymKey, BoxKeyPair};
     use hcore::service::ServiceGroup;
 
+    use command;
     use error::{Error, Result};
 
     pub fn start(
@@ -74,11 +74,7 @@ pub mod upload {
 
         for peer in peers.iter() {
             ui.status(Status::Applying, format!("to peer {}", peer))?;
-            let mut client = Client::new(peer, ring_key.map(|k| k.clone())).map_err(
-                |e| {
-                    Error::ButterflyError(format!("{}", e))
-                },
-            )?;
+            let mut client = command::get_client(peer, ring_key.map(|k| k.clone()))?;
             client
                 .send_service_file(
                     sg.clone(),

--- a/components/hab-butterfly/src/command/mod.rs
+++ b/components/hab-butterfly/src/command/mod.rs
@@ -29,8 +29,8 @@ fn get_client(peer: &str, ring_key: Option<SymKey>) -> Result<Client<GossipZmqSo
         |e| Error::ButterflyError(format!("{}", e)),
     )?;
     let network = RealNetwork::new_for_client();
-    let socket = network.get_gossip_sender(addr).map_err(|e| {
+    let sender = network.get_gossip_sender(addr).map_err(|e| {
         Error::ButterflyError(format!("{}", e))
     })?;
-    Ok(Client::new(socket, ring_key))
+    Ok(Client::new(sender, ring_key))
 }

--- a/components/hab-butterfly/src/command/mod.rs
+++ b/components/hab-butterfly/src/command/mod.rs
@@ -15,3 +15,22 @@
 pub mod config;
 pub mod depart;
 pub mod file;
+
+use std::net::SocketAddr;
+
+use hcore::crypto::SymKey;
+use butterfly::client::Client;
+use butterfly::network::{GossipZmqSocket, Network, RealNetwork};
+
+use error::{Error, Result};
+
+fn get_client(peer: &str, ring_key: Option<SymKey>) -> Result<Client<GossipZmqSocket>> {
+    let addr: SocketAddr = peer.parse().map_err(
+        |e| Error::ButterflyError(format!("{}", e)),
+    )?;
+    let network = RealNetwork::new_for_client();
+    let socket = network.get_gossip_sender(addr).map_err(|e| {
+        Error::ButterflyError(format!("{}", e))
+    })?;
+    Ok(Client::new(socket, ring_key))
+}

--- a/components/hab-butterfly/src/command/mod.rs
+++ b/components/hab-butterfly/src/command/mod.rs
@@ -29,7 +29,7 @@ fn get_client(peer: &str, ring_key: Option<SymKey>) -> Result<Client<GossipZmqSo
         |e| Error::ButterflyError(format!("{}", e)),
     )?;
     let network = RealNetwork::new_for_client();
-    let sender = network.get_gossip_sender(addr).map_err(|e| {
+    let sender = network.create_gossip_sender(addr).map_err(|e| {
         Error::ButterflyError(format!("{}", e))
     })?;
     Ok(Client::new(sender, ring_key))

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -40,6 +40,7 @@ use std::mem;
 use std::ops::DerefMut;
 
 use butterfly;
+use butterfly::network::RealNetwork;
 use butterfly::member::Member;
 use butterfly::trace::Trace;
 use butterfly::server::timing::Timing;
@@ -143,7 +144,7 @@ pub struct ManagerConfig {
 }
 
 pub struct Manager {
-    butterfly: butterfly::Server,
+    butterfly: butterfly::Server<RealNetwork>,
     census_ring: CensusRing,
     events_group: Option<ServiceGroup>,
     fs_cfg: Arc<FsCfg>,
@@ -291,16 +292,16 @@ impl Manager {
             None => None,
         };
         let services = Arc::new(RwLock::new(Vec::new()));
+        let network = RealNetwork::new_for_server(sys.gossip_listen(), sys.gossip_listen());
         let server = butterfly::Server::new(
-            sys.gossip_listen(),
-            sys.gossip_listen(),
+            network,
             member,
             Trace::default(),
             ring_key,
             None,
             Some(&fs_cfg.data_path),
             Box::new(SuitabilityLookup(services.clone())),
-        )?;
+        );
         outputln!("Supervisor Member-ID {}", sys.member_id);
         for peer_addr in &cfg.gossip_peers {
             let mut peer = Member::default();

--- a/components/sup/src/manager/service/hooks.rs
+++ b/components/sup/src/manager/service/hooks.rs
@@ -661,7 +661,11 @@ impl Hook for SuitabilityHook {
                             Ok(line) => {
                                 match line.trim().parse::<u64>() {
                                     Ok(suitability) => {
-                                        outputln!(preamble service_group, "Reporting suitability of: {}", suitability);
+                                        outputln!(
+                                            preamble service_group,
+                                            "Reporting suitability of: {}",
+                                            suitability
+                                        );
                                         return Some(suitability);
                                     }
                                     Err(err) => {

--- a/components/sup/src/manager/service/mod.rs
+++ b/components/sup/src/manager/service/mod.rs
@@ -394,13 +394,15 @@ impl Service {
             let (reload, reconfigure) = {
                 let ctx = self.render_context(census_ring);
 
-                // If any hooks have changed, execute the `reload` hook (if present) or restart the
-                // service.
+                // If any hooks have changed, execute the `reload`
+                // hook (if present) or restart the service.
                 let reload = self.compile_hooks(&ctx);
 
-                // If the configuration has changed, execute the `reload` and `reconfigure` hooks.
-                // Note that the configuration does not necessarily change every time the user config has (e.g.
-                // when only a comment has been added to the latter)
+                // If the configuration has changed, execute the
+                // `reload` and `reconfigure` hooks.  Note that the
+                // configuration does not necessarily change every
+                // time the user config has (e.g.  when only a comment
+                // has been added to the latter)
                 let reconfigure = self.compile_configuration(&ctx);
 
                 (reload, reconfigure)

--- a/components/sup/src/manager/service/supervisor.rs
+++ b/components/sup/src/manager/service/supervisor.rs
@@ -71,7 +71,7 @@ struct UserInfo {
     username: Option<String>,
     uid: Option<u32>,
     groupname: Option<String>,
-    gid: Option<u32>
+    gid: Option<u32>,
 }
 
 #[derive(Debug)]
@@ -127,18 +127,25 @@ impl Supervisor {
         if abilities::can_run_services_as_svc_user() {
             // We have the ability to run services as a user / group other
             // than ourselves, so they better exist
-            let uid = users::get_uid_by_name(&pkg.svc_user).ok_or(
-                sup_error!(Error::UserNotFound(pkg.svc_user.to_string())),
-            )?;
-            let gid = users::get_gid_by_name(&pkg.svc_group).ok_or(
-                sup_error!(Error::GroupNotFound(pkg.svc_group.to_string())),
-            )?;
+            let uid = users::get_uid_by_name(&pkg.svc_user).ok_or(sup_error!(
+                Error::UserNotFound(
+                    pkg.svc_user
+                        .to_string(),
+                )
+            ))?;
+            let gid = users::get_gid_by_name(&pkg.svc_group).ok_or(sup_error!(
+                Error::GroupNotFound(
+                    pkg.svc_group
+                        .to_string(),
+                )
+            ))?;
 
-            Ok(UserInfo{
+            Ok(UserInfo {
                 username: Some(pkg.svc_user.clone()),
                 uid: Some(uid),
                 groupname: Some(pkg.svc_group.clone()),
-                gid: Some(gid)})
+                gid: Some(gid),
+            })
         } else {
             // We DO NOT have the ability to run as other users!  Also
             // note that we legitimately may not have a username or
@@ -148,17 +155,24 @@ impl Supervisor {
             let groupname = users::get_effective_groupname();
             let gid = users::get_effective_gid();
 
-            let name_for_logging = username
-                .as_ref()
-                .map(|name| name.clone())
-                .unwrap_or_else(|| format!("anonymous [UID={}]", uid));
-            outputln!(preamble self.preamble, "Current user ({}) lacks sufficient capabilites to run services as a different user; running as self!", name_for_logging);
+            let name_for_logging = username.as_ref().map(|name| name.clone()).unwrap_or_else(
+                || {
+                    format!("anonymous [UID={}]", uid)
+                },
+            );
+            outputln!(
+                preamble self.preamble,
+                "Current user ({}) lacks sufficient capabilites to run services \
+                 as a different user; running as self!",
+                name_for_logging
+            );
 
-            Ok(UserInfo{
+            Ok(UserInfo {
                 username: username,
                 uid: Some(uid),
                 groupname: groupname,
-                gid: Some(gid)})
+                gid: Some(gid),
+            })
         }
     }
 
@@ -170,8 +184,10 @@ impl Supervisor {
         // Note that the Windows Supervisor does not yet have a
         // corresponding "non-root" behavior, as the Linux version
         // does; services run as the service user.
-        Ok(UserInfo{username: Some(pkg.svc_user.clone()),
-                    .. Default::default()})
+        Ok(UserInfo {
+            username: Some(pkg.svc_user.clone()),
+            ..Default::default()
+        })
     }
 
     pub fn start<T>(
@@ -184,10 +200,12 @@ impl Supervisor {
     where
         T: ToString,
     {
-        let UserInfo{username: service_user,
-                     uid: service_user_id,
-                     groupname: service_group,
-                     gid: service_group_id} = self.user_info(&pkg)?;
+        let UserInfo {
+            username: service_user,
+            uid: service_user_id,
+            groupname: service_group,
+            gid: service_group_id,
+        } = self.user_info(&pkg)?;
 
         outputln!(preamble self.preamble,
                   "Starting service as user={}, group={}",

--- a/components/sup/src/manager/service_updater.rs
+++ b/components/sup/src/manager/service_updater.rs
@@ -17,6 +17,7 @@ use std::sync::mpsc::{sync_channel, Receiver, SyncSender, TryRecvError};
 use std::thread;
 
 use butterfly;
+use butterfly::network;
 use common::ui::UI;
 use env;
 use hcore::package::{PackageIdent, PackageInstall};
@@ -67,11 +68,11 @@ enum FollowerState {
 /// To use an update strategy, the supervisor must be configured to watch a depot for new versions.
 pub struct ServiceUpdater {
     states: UpdaterStateList,
-    butterfly: butterfly::Server,
+    butterfly: butterfly::Server<network::RealNetwork>,
 }
 
 impl ServiceUpdater {
-    pub fn new(butterfly: butterfly::Server) -> Self {
+    pub fn new(butterfly: butterfly::Server<network::RealNetwork>) -> Self {
         ServiceUpdater {
             states: UpdaterStateList::default(),
             butterfly: butterfly,

--- a/components/sup/tests/utils/test_butterfly.rs
+++ b/components/sup/tests/utils/test_butterfly.rs
@@ -19,6 +19,7 @@
 //! No ring key or encryption abilities are currently supported.
 
 extern crate habitat_butterfly;
+use self::habitat_butterfly::network::{Network, RealNetwork, GossipZmqSocket};
 use self::habitat_butterfly::client::Client as ButterflyClient;
 
 extern crate habitat_core;
@@ -30,7 +31,7 @@ use std::net::SocketAddr;
 use std::time::{UNIX_EPOCH, SystemTime};
 
 pub struct Client {
-    butterfly_client: ButterflyClient,
+    butterfly_client: ButterflyClient<GossipZmqSocket>,
     pub package_name: String,
     pub service_group: String,
 }
@@ -45,9 +46,11 @@ impl Client {
         let gossip_addr = format!("127.0.0.1:{}", port).parse::<SocketAddr>().expect(
             "Could not parse Butterfly gossip address!",
         );
-        let c = ButterflyClient::new(&gossip_addr, None).expect(
-            "Could not create Butterfly Client for test!",
+        let network = RealNetwork::new_for_client();
+        let socket = network.get_gossip_sender(gossip_addr).expect(
+            "Could not create gossip sender",
         );
+        let c = ButterflyClient::new(socket, None);
         Client {
             butterfly_client: c,
             package_name: package_name.to_string(),

--- a/components/sup/tests/utils/test_butterfly.rs
+++ b/components/sup/tests/utils/test_butterfly.rs
@@ -47,10 +47,10 @@ impl Client {
             "Could not parse Butterfly gossip address!",
         );
         let network = RealNetwork::new_for_client();
-        let socket = network.get_gossip_sender(gossip_addr).expect(
+        let sender = network.get_gossip_sender(gossip_addr).expect(
             "Could not create gossip sender",
         );
-        let c = ButterflyClient::new(socket, None);
+        let c = ButterflyClient::new(sender, None);
         Client {
             butterfly_client: c,
             package_name: package_name.to_string(),

--- a/components/sup/tests/utils/test_butterfly.rs
+++ b/components/sup/tests/utils/test_butterfly.rs
@@ -47,7 +47,7 @@ impl Client {
             "Could not parse Butterfly gossip address!",
         );
         let network = RealNetwork::new_for_client();
-        let sender = network.get_gossip_sender(gossip_addr).expect(
+        let sender = network.create_gossip_sender(gossip_addr).expect(
             "Could not create gossip sender",
         );
         let c = ButterflyClient::new(sender, None);


### PR DESCRIPTION
This PR adds a network abstraction to be used by butterfly server and client. The reason for introducing it is to be able to add a different implementation of the abstraction for testing purposes. That testing implementation should make mocking some scenarios way easier than it is currently possible. One of those scenarios would be talking to the butterfly server which is behind a NAT.

The PR also contains some cleanups I had to make for rustfmt to stop complaining.