### PR TITLE
Allow configurable compression level during build

### DIFF
--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -2063,13 +2063,10 @@ do_default_end() {
 
 # Parse depot flag (-u)
 OPTIND=2
-while getopts "u:z:" opt; do
+while getopts "u:" opt; do
   case "${opt}" in
     u)
       HAB_BLDR_URL=$OPTARG
-      ;;
-    z)
-      HART_COMPRESSION_LEVEL=$OPTARG
       ;;
     \?)
       echo "Invalid option: -$OPTARG" >&2

--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -379,6 +379,8 @@ export HAB_BLDR_CHANNEL
 FALLBACK_CHANNEL="stable"
 # The value of `pwd` on initial start of this program
 INITIAL_PWD="$(pwd)"
+# The compression level to use when compression harts (0..9)
+: ${HART_COMPRESSION_LEVEL:=6}
 # The target architecture this plan will be built for
 pkg_arch=$(uname -m | tr '[:upper:]' '[:lower:]')
 # The target system (i.e. operating system variant) this plan will be built for
@@ -2006,7 +2008,7 @@ _generate_artifact() {
   mkdir -pv "$(dirname "$pkg_artifact")"
   rm -fv $tarf $xzf $pkg_artifact
   $_tar_cmd -cf $tarf $pkg_prefix
-  $_xz_cmd --compress -6 --threads=0 $tarf
+  $_xz_cmd --compress -${HART_COMPRESSION_LEVEL} --threads=0 $tarf
   $HAB_BIN pkg sign --origin $pkg_origin $xzf $pkg_artifact
   rm -f $tarf $xzf
 }
@@ -2061,10 +2063,13 @@ do_default_end() {
 
 # Parse depot flag (-u)
 OPTIND=2
-while getopts "u:" opt; do
+while getopts "u:z:" opt; do
   case "${opt}" in
     u)
       HAB_BLDR_URL=$OPTARG
+      ;;
+    z)
+      HART_COMPRESSION_LEVEL=$OPTARG
       ;;
     \?)
       echo "Invalid option: -$OPTARG" >&2

--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -380,7 +380,7 @@ FALLBACK_CHANNEL="stable"
 # The value of `pwd` on initial start of this program
 INITIAL_PWD="$(pwd)"
 # The compression level to use when compression harts (0..9)
-: ${HART_COMPRESSION_LEVEL:=6}
+: ${HAB_HART_COMPRESSION_LEVEL:=6}
 # The target architecture this plan will be built for
 pkg_arch=$(uname -m | tr '[:upper:]' '[:lower:]')
 # The target system (i.e. operating system variant) this plan will be built for
@@ -2008,7 +2008,7 @@ _generate_artifact() {
   mkdir -pv "$(dirname "$pkg_artifact")"
   rm -fv $tarf $xzf $pkg_artifact
   $_tar_cmd -cf $tarf $pkg_prefix
-  $_xz_cmd --compress -${HART_COMPRESSION_LEVEL} --threads=0 $tarf
+  $_xz_cmd --compress -${HAB_HART_COMPRESSION_LEVEL} --threads=0 $tarf
   $HAB_BIN pkg sign --origin $pkg_origin $xzf $pkg_artifact
   rm -f $tarf $xzf
 }


### PR DESCRIPTION
This patch adds a new flag to plan-build to allow setting the
compression level used by xz. This is helpful when using the
studio as a dev environment as it cuts off 10 seconds on a
simple package with just a go binary

To use in the studio:
```
build . -z 0
```

Fixes #1522