### PR TITLE
Add builder-base-plan back

### DIFF
--- a/support/ci/builder-base-plan.sh
+++ b/support/ci/builder-base-plan.sh
@@ -1,0 +1,61 @@
+# Despite the naming of this file and these functions, this file is
+# not inherently related to Builder; that is simply an artifact of the
+# history of this repository. This file should ultimately be used by
+# all the Rust-based packages in this repository, since many of them
+# duplicate the code here.
+
+pkg_version() {
+  echo "$(git rev-list master --count)"
+}
+
+do_before() {
+  do_builder_before
+}
+
+do_prepare() {
+  do_builder_prepare
+}
+
+do_build() {
+  do_builder_build
+}
+
+do_install() {
+  do_builder_install
+}
+
+do_strip() {
+  return 0
+}
+
+do_builder_before() {
+  update_pkg_version
+}
+
+do_builder_build() {
+  pushd "$PLAN_CONTEXT"/.. > /dev/null
+  cargo build "${builder_build_type#--debug}" --target="$rustc_target" --verbose
+  popd > /dev/null
+}
+
+do_builder_install() {
+  install -v -D "$CARGO_TARGET_DIR/$rustc_target/${builder_build_type#--}/$bin" \
+    "$pkg_prefix/bin/$bin"
+}
+
+do_builder_prepare() {
+  export builder_build_type="${builder_build_type:---release}"
+  # Can be either `--release` or `--debug` to determine cargo build strategy
+  build_line "Building artifacts with \`${builder_build_type#--}' mode"
+
+  export rustc_target="x86_64-unknown-linux-gnu"
+  build_line "Setting rustc_target=$rustc_target"
+
+  # Used by the `build.rs` program to set the version of the binaries
+  export PLAN_VERSION="${pkg_version}/${pkg_release}"
+  build_line "Setting PLAN_VERSION=$PLAN_VERSION"
+
+  # Used by Cargo to use a pristine, isolated directory for all compilation
+  export CARGO_TARGET_DIR="$HAB_CACHE_SRC_PATH/$pkg_dirname"
+  build_line "Setting CARGO_TARGET_DIR=$CARGO_TARGET_DIR"
+}


### PR DESCRIPTION
This file was initially removed when Builder itself was removed from
this repository. It contains common plan callback implementations used
by many of our Rust-based packages. In particular, it is required by
`eventsrv` and `launcher`, two packages that remain in this
repository.

Adding the file back allows us to build these packages again. Longer
term, however, the rest of the packages in this repository should take
advantage of it (many of them duplicate this code unnecessarily), and
functions and variables should be renamed to reflect the fact that
they are not Builder-specific.

Signed-off-by: Christopher Maier <cmaier@chef.io>