### PR TITLE
Remove all the references to bin/haproxy & clarify docs

### DIFF
--- a/components/hab/static/full_template_plan.sh
+++ b/components/hab/static/full_template_plan.sh
@@ -135,7 +135,7 @@ pkg_pconfig_dirs={{ pkg_pconfig_dirs }}
 {{#if pkg_svc_run ~}}
 pkg_svc_run="{{ pkg_svc_run }}"
 {{else ~}}
-# pkg_svc_run="bin/haproxy -f $pkg_svc_config_path/haproxy.conf"
+# pkg_svc_run="haproxy -f $pkg_svc_config_path/haproxy.conf"
 {{/if}}
 
 # Optional.
@@ -420,7 +420,7 @@ pkg_pconfig_dirs={{ pkg_pconfig_dirs }}
 {{#if pkg_svc_run ~}}
 pkg_svc_run="{{ pkg_svc_run }}"
 {{else ~}}
-# pkg_svc_run="bin/haproxy -f $pkg_svc_config_path/haproxy.conf"
+# pkg_svc_run="haproxy -f $pkg_svc_config_path/haproxy.conf"
 {{/if ~}}
 {{#if pkg_exports ~}}
 pkg_exports={{ pkg_exports }}

--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -170,7 +170,7 @@
 # ### pkg_svc_run
 # The command to start the service, if needed. Should not fork!
 # ```
-# pkg_svc_run="bin/haproxy -f $pkg_svc_config_path/haproxy.conf"
+# pkg_svc_run="haproxy -f $pkg_svc_config_path/haproxy.conf"
 # ```
 #
 # ### pkg_exports
@@ -277,7 +277,7 @@
 # pkg_shasum=6648dd7d6b958d83dd7101eab5792178212a66c884bec0ebcd8abc39df83bb78
 # pkg_bin_dirs=(bin)
 # pkg_deps=(glibc pcre openssl zlib)
-# pkg_svc_run="bin/haproxy -f $pkg_svc_config_path/haproxy.conf"
+# pkg_svc_run="haproxy -f $pkg_svc_config_path/haproxy.conf"
 # pkg_exposes=(port)
 # pkg_exports=(
 #   [mode]=mode

--- a/www/source/partials/docs/_reference-basic-settings.html.md.erb
+++ b/www/source/partials/docs/_reference-basic-settings.html.md.erb
@@ -117,7 +117,7 @@ pkg_pconfig_dirs=(lib/pkgconfig)
 : Optional. The command for the Supervisor to execute when starting a service. You can omit this setting if your package is not intended to be run directly by a Supervisor.
 
 ```bash
-pkg_svc_run="bin/haproxy -f $pkg_svc_config_path/haproxy.conf"
+pkg_svc_run="haproxy -f $pkg_svc_config_path/haproxy.conf"
 ```
 
 > Note: You should use a [run hook](#hooks) instead if you have complex start up behavior.

--- a/www/source/partials/docs/_reference-plan-settings.html.md.erb
+++ b/www/source/partials/docs/_reference-plan-settings.html.md.erb
@@ -116,10 +116,11 @@ pkg_pconfig_dirs=(lib/pkgconfig)
 ```
 
 ### pkg\_svc\_run
-**Optional**. The command for the Supervisor to execute when starting a service. You can omit this setting if your package is not intended to be run directly by a Supervisor.
+**Optional**. The command for the Supervisor to execute when starting a service. You can omit this setting if your package is not intended to be run directly by a Supervisor. If you set this you will need to set `pkg_bin_dirs` so that the binaries in your package will be in the
+path
 
 ```bash
-pkg_svc_run="bin/haproxy -f $pkg_svc_config_path/haproxy.conf"
+pkg_svc_run="haproxy -f $pkg_svc_config_path/haproxy.conf"
 ```
 
 > Note: You should use a [run hook](#hooks) instead if you have complex start up behavior.


### PR DESCRIPTION
This hung me up for about a day. The relation between `pkg_svc_run` and `pkg_bin_dirs` could be a bit more explicit to save daft mistakes like the ones I made. I also feel putting the `bin/haproxy` example everywhere helped drive me to my mistakes so I removed that.

having `pkg_svc_run=bin/haproxy` without `pkg_bin_dirs` set did not work for me. But when I was guided to add `pkg_bin_dirs=(bin)` and removed `bin/` from my `pkg_svc_run` all was fixed.

I was considering also adding more notes to the full_template_plan referring to the required relation but I think updating the reference might be enough.

Feedback/thoughts always welcome