### PR TITLE
consistently use softwrapping on paragraphs

### DIFF
--- a/www/source/partials/docs/_reference-basic-settings.html.md.erb
+++ b/www/source/partials/docs/_reference-basic-settings.html.md.erb
@@ -78,36 +78,28 @@ pkg_build_deps=(core/gcc core/linux-headers)
 ```
 
 **pkg\_lib\_dirs**
-: Optional. An array of paths, relative to the final install of the software,
-where libraries can be found. Used to populate `LD_FLAGS` and
-`LD_RUN_PATH` for software that depends on your package.
+: Optional. An array of paths, relative to the final install of the software, where libraries can be found. Used to populate `LD_FLAGS` and `LD_RUN_PATH` for software that depends on your package.
 
 ```bash
 pkg_lib_dirs=(lib)
 ```
 
 **pkg\_include\_dirs**
-: Optional. An array of paths, relative to the final install of the software,
-where headers can be found. Used to populate `CFLAGS` for software
-that depends on your package.
+: Optional. An array of paths, relative to the final install of the software, where headers can be found. Used to populate `CFLAGS` for software that depends on your package.
 
 ```bash
 pkg_include_dirs=(include)
 ```
 
 **pkg\_bin\_dirs**
-: Optional. An array of paths, relative to the final install of the software,
-where binaries can be found. Used to populate `PATH` for software
-that depends on your package.
+: Optional. An array of paths, relative to the final install of the software, where binaries can be found. Used to populate `PATH` for software that depends on your package.
 
 ```bash
 pkg_bin_dirs=(bin)
 ```
 
 **pkg\_pconfig\_dirs**
-: Optional. An array of paths, relative to the final install of the
-software, where pkg-config metadata (.pc files) can be found. Used to
-populate `PKG_CONFIG_PATH` for software that depends on your package.
+: Optional. An array of paths, relative to the final install of the software, where pkg-config metadata (.pc files) can be found. Used to populate `PKG_CONFIG_PATH` for software that depends on your package.
 
 ```bash
 pkg_pconfig_dirs=(lib/pkgconfig)

--- a/www/source/partials/docs/_reference-plan-settings.html.md.erb
+++ b/www/source/partials/docs/_reference-plan-settings.html.md.erb
@@ -80,36 +80,28 @@ pkg_build_deps=(core/gcc core/linux-headers)
 ```
 
 ### pkg\_lib\_dirs
-**Optional**. An array of paths, relative to the final install of the software,
-where libraries can be found. Used to populate `LD_FLAGS` and
-`LD_RUN_PATH` for software that depends on your package.
+**Optional**. An array of paths, relative to the final install of the software, where libraries can be found. Used to populate `LD_FLAGS` and `LD_RUN_PATH` for software that depends on your package.
 
 ```bash
 pkg_lib_dirs=(lib)
 ```
 
 ### pkg\_include\_dirs
-**Optional**. An array of paths, relative to the final install of the software,
-where headers can be found. Used to populate `CFLAGS` for software
-that depends on your package.
+**Optional**. An array of paths, relative to the final install of the software, where headers can be found. Used to populate `CFLAGS` for software that depends on your package.
 
 ```bash
 pkg_include_dirs=(include)
 ```
 
 ### pkg\_bin\_dirs
-**Optional**. An array of paths, relative to the final install of the software,
-where binaries can be found. Used to populate `PATH` for software
-that depends on your package.
+**Optional**. An array of paths, relative to the final install of the software, where binaries can be found. Used to populate `PATH` for software that depends on your package.
 
 ```bash
 pkg_bin_dirs=(bin)
 ```
 
 ### pkg\_pconfig\_dirs
-**Optional**. An array of paths, relative to the final install of the
-software, where pkg-config metadata (.pc files) can be found. Used to
-populate `PKG_CONFIG_PATH` for software that depends on your package.
+**Optional**. An array of paths, relative to the final install of the software, where pkg-config metadata (.pc files) can be found. Used to populate `PKG_CONFIG_PATH` for software that depends on your package.
 
 ```bash
 pkg_pconfig_dirs=(lib/pkgconfig)


### PR DESCRIPTION
I touched these two last night and noticed there is an inconsistent mix of soft-wrap and various lengths of a hard wrap. I let it go then, but after a fresh sleep, I still couldn't have it stand.

I've moved it to soft wrap all around because it's far easier for new contributors to edit if you don't have to rebalance things manually. This can be a barrier for entry for people, especially if things are inconsistent and they have to think about if they should try to manually hard wrap, or they can just type on one line and let the editor flow it naturally.

This is only updating the things I touched but I am happy to this to the REST of the file if useful/desired.

Signed-off-by: David Aronsohn <WagThatTail@Me.com>