### PR TITLE
Make header more consistent in reference docs

### DIFF
--- a/www/source/partials/global/_helpers.html.md.erb
+++ b/www/source/partials/global/_helpers.html.md.erb
@@ -1,4 +1,4 @@
-## <a name="helpers" id="helpers" data-magellan-target="helpers" class="anchor">Handlebars Helpers</a>
+# <a name="helpers" id="helpers" data-magellan-target="helpers" class="anchor">Handlebars Helpers</a>
 
 Habitat not only allows you to use [Handlebars-based](http://handlebarsjs.com) tunables in your plan, but you can also use both built-in Handlebars helpers as well as Habitat-specific helpers to define your configuration logic. 
 


### PR DESCRIPTION
This looks really odd on https://www.habitat.sh/docs/reference/#helpers compared to the rest

Signed-off-by: David Aronsohn <WagThatTail@Me.com>