### PR TITLE
Use the correct powershell binary in the windows studio image builder and ensure future errors from image failures fail the appveyor build

### DIFF
--- a/components/bintray-publish/bin/publish-studio.bat
+++ b/components/bintray-publish/bin/publish-studio.bat
@@ -1,2 +1,2 @@
 @echo off
-"powershell.exe" -NoProfile -ExecutionPolicy bypass -NoLogo -Command ". '%~dp0publish-studio.ps1'" %*
+"pwsh.exe" -NoProfile -ExecutionPolicy bypass -NoLogo -Command ". '%~dp0publish-studio.ps1'" %*

--- a/support/ci/appveyor.ps1
+++ b/support/ci/appveyor.ps1
@@ -166,6 +166,7 @@ if (($env:APPVEYOR_REPO_TAG_NAME -eq $version) -or (Test-SourceChanged) -or (tes
                 $env:HAB_BLDR_CHANNEL = $channel
                 & $habExe pkg exec core/hab-bintray-publish publish-studio
                 $env:HAB_BLDR_CHANNEL = $null
+                if ($LASTEXITCODE -ne 0) {exit $LASTEXITCODE}
             }
         }
         else {


### PR DESCRIPTION
Signed-off-by: mwrock <matt@mattwrock.com>