### PR TITLE
Clarify template configuration documentation

### DIFF
--- a/www/source/partials/docs/_dev-pkgs-add-configuration.html.md.erb
+++ b/www/source/partials/docs/_dev-pkgs-add-configuration.html.md.erb
@@ -16,20 +16,20 @@ We can make this user tunable like this:
 recv_buffer {{cfg.recv_buffer}}
 ```
 
-Habitat can read values that it will use to render the templatize
-config files in three ways:
+Habitat can read values that it will use to render the templatize config files in three ways:
 
 1. `default.toml` - Each plan includes a `default.toml` file that specifies the default values to use in the absence of any user provided inputs. These files are written in [TOML](https://github.com/toml-lang/toml), a simple config format.
-2. Environment variable - At start up, tunable config values can be passed to Habitat using environment variables.
-3. At runtime - Users can alter config at runtime using `hab config
-apply`. The input for this command also uses the TOML format.
+2. At runtime - Users can alter config at runtime using `hab config apply`. The input for this command also uses the TOML format.
+3. Environment variable - At start up, tunable config values can be passed to Habitat using environment variables; this most over-riding way of setting these but require you to restart the supervisor to change them.
 
-Here's what we'd add to our project's `default.toml` file to provide a
-default value for the `recv_buffer` tunable:
+Here's what we'd add to our project's `default.toml` file to provide a default value for the `recv_buffer` tunable:
 
 ```toml
 recv_buffer = 128
 ```
+
+Where is this template written to?
+How do I sourse it?
 
 <%= partial '/partials/global/helpers' %>
 

--- a/www/source/partials/docs/_dev-pkgs-add-configuration.html.md.erb
+++ b/www/source/partials/docs/_dev-pkgs-add-configuration.html.md.erb
@@ -16,7 +16,7 @@ We can make this user tunable like this:
 recv_buffer {{cfg.recv_buffer}}
 ```
 
-Habitat can read values that it will use to render the templatize config files in three ways:
+Habitat can read values that it will use to render the templatized config files in three ways:
 
 1. `default.toml` - Each plan includes a `default.toml` file that specifies the default values to use in the absence of any user provided inputs. These files are written in [TOML](https://github.com/toml-lang/toml), a simple config format.
 2. At runtime - Users can alter config at runtime using `hab config apply`. The input for this command also uses the TOML format.

--- a/www/source/partials/docs/_dev-pkgs-add-configuration.html.md.erb
+++ b/www/source/partials/docs/_dev-pkgs-add-configuration.html.md.erb
@@ -28,8 +28,8 @@ Here's what we'd add to our project's `default.toml` file to provide a default v
 recv_buffer = 128
 ```
 
-Where is this template written to?
-How do I sourse it?
+All templates are written to a config directory, `/hab/svc/<pkg_name>/config`, for the running service. The templates are re-written whenever configuration values change.
+The path to this directory is available at build time in the plan as the variable `$pkg_svc_config_path` and available at runtime in templates and hooks as `{{pkg.svc_config_path}}`
 
 <%= partial '/partials/global/helpers' %>
 

--- a/www/source/partials/docs/_reference-template-data.html.md.erb
+++ b/www/source/partials/docs/_reference-template-data.html.md.erb
@@ -9,34 +9,34 @@ The following settings can be used during a Habitat service's lifecycle. This me
 These configuration settings are referenced using the [Handlebars.js](https://github.com/wycats/handlebars.js/) version of [mustache-style](https://mustache.github.io/mustache.5.html) tags. For an example on how these settings are used in plan hooks, see [Add Health Monitoring to a Plan](/tutorials/sample-app/mac/add-health-check-hook/) in the getting started tutorial.
 
 ## sys
-These are service settings specified by Habitat and correspond to the network information of the running Habitat service. You can also query these values on a running Supervisor via the Supervisor HTTP API. 
+These are service settings specified by Habitat and correspond to the network information of the running Habitat service. You can also query these values on a running Supervisor via the Supervisor HTTP API.
 
 **version**
-: Version of the Habitat Supervisor. 
+: Version of the Habitat Supervisor.
 
-**member_id** 
-: Supervisor's member id. 
+**member_id**
+: Supervisor's member id.
 
 **ip**
-: The IP address of the running service.  
+: The IP address of the running service.
 
 **hostname**
-: The hostname of the running service. Defaults to `localhost`. 
+: The hostname of the running service. Defaults to `localhost`.
 
-**gossip_ip** 
-: Listening address for Supervisor's gossip connection.  
+**gossip_ip**
+: Listening address for Supervisor's gossip connection.
 
-**gossip_port** 
-: Listening port for Supervisor's gossip connection. 
+**gossip_port**
+: Listening port for Supervisor's gossip connection.
 
-**http_gateway_ip** 
-: Listening address for Supervisor's http gateway. 
+**http_gateway_ip**
+: Listening address for Supervisor's http gateway.
 
-**http_gateway_port** 
+**http_gateway_port**
 : Listening port for Supervisor's http gateway
 
 **permanent**
-: This is set to `true` if a Supervisor is being used as a permanent peer, to increase Ring network traffic stability. 
+: This is set to `true` if a Supervisor is being used as a permanent peer, to increase Ring network traffic stability.
 
 ## pkg
 These are package settings specified by Habitat and correspond to the the settings of the package when it was built and installed.
@@ -59,13 +59,13 @@ These are package settings specified by Habitat and correspond to the the settin
 **deps**
 : An array of runtime dependencies for your package based on the pkg_deps setting in a plan.
 
-**env** 
-: You package's system path that is set with all of your dependent binaries. 
+**env**
+: You package's system path that is set with all of your dependent binaries.
 
 **exposes**
 : The port(s) to expose for an application or service. This value is pulled from the pkg_exposes setting in a plan.
 
-**exports** 
+**exports**
 : A key value pair where the key is what external services consume. The value is stored in your `default.toml` to be provided when called.
 
 **path**
@@ -75,7 +75,7 @@ These are package settings specified by Habitat and correspond to the the settin
 : The root location of the source files for the Habitat service.
 
 **svc\_config\_path**
-: The location of any configuration files for the Habitat service.
+: The location of any [templated configuration files](/docs/developing-packages/#add-configuration) for the Habitat service.
 
 **svc\_data\_path**
 : The location of any data files for the Habitat service.
@@ -92,8 +92,8 @@ These are package settings specified by Habitat and correspond to the the settin
 **svc\_pid_file**
 : The location of the Habitat service pid file.
 
-**svc_run** 
-: The location of the run data for the Habitat service. 
+**svc_run**
+: The location of the run data for the Habitat service.
 
 **svc_user**
 : The value of `pkg_svc_user` specified in a plan (if not specified, "hab").


### PR DESCRIPTION
I couldn't figure out how to use templates and where they were written. This makes how they are written, when they are written, and how to use them much clearer in the reference documentation. This was a major annoying hurdle for me until @robbkidd showed me how it works and then helped document it.