### PR TITLE
Download on-demand packages from the `stable` channel.

### DIFF
--- a/www/source/partials/docs/_reference-environment-vars.html.md.erb
+++ b/www/source/partials/docs/_reference-environment-vars.html.md.erb
@@ -10,6 +10,7 @@ This is a list of all environment variables that can be used to modify the opera
 | `HAB_BLDR_CHANNEL` | build system, Supervisor | `stable` | Set the Habitat Builder channel you are subscribing to, to a specific channel. Defaults to `stable`.
 | `HAB_BLDR_URL` | build system, Supervisor | `https://bldr.habitat.sh` | Sets an alternate default endpoint for communicating with Builder. Used by the Habitat build system and the Supervisor |
 | `HAB_DOCKER_OPTS` | build system | no default | When running a studio on a platform that uses Docker (MacOS), additional command line options to pass to the `docker` command. |
+| `HAB_INTERNAL_BLDR_CHANNEL` | build system, Supervisor, exporters | `stable` | Channel from which Habitat-specific packages (e.g., `core/hab-sup`, `core/hab-launcher`, etc.) are downloaded on-demand when first called. Generally of use only for those developing Habitat. Only applies to Habitat-specific packages, and nothing else. |
 | `HAB_NOCOLORING` | build system | no default | If set to the lowercase string `"true"` this environment variable will unconditionally disable text coloring where possible |
 | `HAB_NONINTERACTIVE` | build system | no default | If set to the lowercase string `"true"` this environment variable will unconditionally disable interactive progress bars (i.e. "spinners") where possible |
 | `HAB_ORG` | Supervisor | no default | Organization to use when running with [service group encryption](/docs/using-habitat#using-encryption)


### PR DESCRIPTION
The functionality of the `hab` binary is split across several Habitat
packages, each of which are downloaded on-demand as needed when not
already found on disk.

As originally coded, however, there was no channel restriction applied
to this download operation. This meant that if no package was already
installed on disk, then the most recently built package was
downloaded, rather than the most recent _stable_ package. The original
code likely predated the introduction of channels. Because most
packages downloaded in this way were using an `origin/package/version`
identifier, and because they were only downloaded when not already
present, this behavior escaped notice until recently.

Now, we pull these on-demand packages from the `stable` channel.

Because the version is included in almost all these on-demand package
downloads (`core/hab-launcher` is the sole exception), and because we
currently tie all versions together based on the version of the `hab`
binary itself, this can cause issues for people developing Habitat. In
particular, there won't ever be `stable` releases of anything with a
`*-dev` version. In this case, an environment variable escape hatch is
provided with `HAB_INTERNAL_BLDR_CHANNEL`, which can be set to
`unstable` to gain access to development packages. This override will
_only_ apply to these Habitat-specific packages, and will not apply to
e.g., services you're trying to run or packages you're trying to
export. For those, the existing `HAB_BLDR_CHANNEL` environment
variable still applies.

This override should only be needed by Habitat developers, and should
ideally remain unknown and unnecessary for everyday uses.

Fixes #4539

Signed-off-by: Christopher Maier <cmaier@chef.io>