### PR TITLE
ensure appveyor version matches hab cli so bintray releases also havethat version

### DIFF
--- a/support/ci/appveyor.ps1
+++ b/support/ci/appveyor.ps1
@@ -128,6 +128,7 @@ if (($env:APPVEYOR_REPO_TAG_NAME -eq $version) -or (Test-SourceChanged) -or (tes
                     $binPath = (Resolve-Path "/hab/pkgs/core/hab/*/*/bin").Path
                     $pathParts = $binPath.Split("\")
                     $versionStamp = "$($pathParts[-3])-$($pathParts[-2])"
+                    Update-AppveyorBuild -Version $versionStamp
                     $zip = "hab-$versionStamp-x86_64-windows.zip"
                     $zipDir = $zip.Replace(".zip", "")
                     $stagingZipDir = "$(Get-RepoRoot)/windows/x86_64"


### PR DESCRIPTION
Currently Appveyor uploads the cli to bintray using an arbitrary release (computed when appveyor begins) which does not match up with the release stamp calculated by hab's plan build. This causes the bintray release version to mismatch the embedded download file and breaks the "latest" bintray endpoint.

This was introduced fairly recently when we changed the uploaded zip file name to match up with the hab release. I had thought that would cause the bintray release to match up. While it was a step in the right direction, we ultimately need hab, the zip file and the bintray version all to line up in order for a smooth release.

Signed-off-by: mwrock <matt@mattwrock.com>