### PR TITLE
Add build-run function and alias to studio

### DIFF
--- a/components/studio/libexec/hab-studio-type-default.sh
+++ b/components/studio/libexec/hab-studio-type-default.sh
@@ -152,6 +152,7 @@ sup-run() {
   echo "    Running: hab sup run \$*"
   hab sup run \$* > /hab/sup/default/sup.log 2>&1 &
   echo "    * Use 'hab svc start' & 'hab svc stop' to start and stop services"
+  echo "    * Use 'build-run' to build and start the service"
   echo "    * Use 'sup-log' to tail the Supervisor's output (Ctrl+c to stop)"
   echo "    * Use 'sup-term' to terminate the Supervisor"
   if [[ -z "\${HAB_STUDIO_SUP:-}" ]]; then
@@ -181,9 +182,22 @@ sup-log() {
   tail -f /hab/sup/default/sup.log
 }
 
+build-run() {
+  build
+  if [ $? -eq 0 ];
+    . /src/results/last_build.env
+    hab svc stop "$pkg_origin/$pkg_name" || true
+    hab svc unload "$pkg_origin/$pkg_name" || true
+    hab svc start "results/$pkg_artifact"
+    echo "--> Use sup-log to see supervisor output"
+  fi
+}
+
+
 alias sr='sup-run'
 alias st='sup-term'
 alias sl='sup-log'
+alias br='build-run'
 
 if [[ -n "\${STUDIO_ENTER:-}" ]]; then
   unset STUDIO_ENTER

--- a/components/studio/libexec/hab-studio-type-default.sh
+++ b/components/studio/libexec/hab-studio-type-default.sh
@@ -184,7 +184,7 @@ sup-log() {
 
 build-run() {
   build
-  if [ $? -eq 0 ];
+  if [ $? -eq 0 ]; then
     . /src/results/last_build.env
     hab svc stop "$pkg_origin/$pkg_name" || true
     hab svc unload "$pkg_origin/$pkg_name" || true


### PR DESCRIPTION
One thing I find myself doing a lot when testing habitat and services in the studio is the constant unloading and starting of packages after a fresh build. This could be far more efficent and the env file generated was pointed out to me so I built a spike on adding a function to make this far easier in the studio.

I think this improved dev cycle makes testing more approachabe and delightful to someone already not having a good time figuring out why a thing doesn't work well.

I'm not a huge fan of the name `build-run` but I figure we can pick a color once the bikeshed was built.

Signed-off-by: David Aronsohn <WagThatTail@Me.com>