### PR TITLE
Document the env file pattern to show off @key

### DIFF
--- a/www/source/partials/docs/_built-in-helpers.html.md.erb
+++ b/www/source/partials/docs/_built-in-helpers.html.md.erb
@@ -69,6 +69,12 @@ Here's an example using `each` to render multiple server entries:
     }
     {{/each ~}}
 
+You can also use `each` with `@key` and `this`. Here is an example that takes the `[env]` section of your default.toml and makes an env file you can source from your run hook:
+
+    {{#each cfg.env ~}}
+      export {{ toUppercase @key}}={{this}}
+    {{/each ~}}
+
 You would specify the corresponding values in a TOML file using an
 [array of tables](https://github.com/toml-lang/toml#array-of-tables)
 like this:

--- a/www/source/partials/docs/_built-in-helpers.html.md.erb
+++ b/www/source/partials/docs/_built-in-helpers.html.md.erb
@@ -72,7 +72,7 @@ Here's an example using `each` to render multiple server entries:
 You can also use `each` with `@key` and `this`. Here is an example that takes the `[env]` section of your default.toml and makes an env file you can source from your run hook:
 
     {{#each cfg.env ~}}
-      export {{ toUppercase @key}}={{this}}
+      export {{toUppercase @key}}={{this}}
     {{/each ~}}
 
 You would specify the corresponding values in a TOML file using an


### PR DESCRIPTION
The env file pattern is very common for sharing ro sourcing runtime setting and the `@key` & `this` pattern of `each` is so useful I think it's worth including directly in the docs

When I was discussing how to set up environment varibles for runtime settings of my application with @robbkidd neither of us could see an easy solution to the problem. A bunch of digging on other do cites about handlebars showed off how simple this is. I wanted to document the ENV file pattern as well as `@key` and `this` with each directly because it's a super useful feature that new users would liekly want to see without having to go digging into other docs.

Signed-off-by: David Aronsohn <WagThatTail@Me.com>