### PR TITLE
`HAB\_ORIGIN\_KEYS` → `HAB_ORIGIN_KEYS`

### DIFF
--- a/www/source/partials/docs/_dev-pkgs-plan-builds.html.md.erb
+++ b/www/source/partials/docs/_dev-pkgs-plan-builds.html.md.erb
@@ -31,7 +31,7 @@ An interactive build is one in which you enter a Habitat Studio to perform the b
 The directory where your plan is located is known as the plan context.
 
 1. Change to the parent directory of the plan context.
-2. Create and enter a new Habitat Studio. If you have defined an origin and origin key during `hab setup` or by explicitly setting the `HAB_ORIGIN` and `HAB\_ORIGIN\_KEYS` environment variables, then type the following:
+2. Create and enter a new Habitat Studio. If you have defined an origin and origin key during `hab setup` or by explicitly setting the `HAB_ORIGIN` and `HAB_ORIGIN_KEYS` environment variables, then type the following:
 
     ```shell
     $ hab studio enter


### PR DESCRIPTION
Underscores need escaping in other contexts, but between back tics, they cause the backslashes themselves to be rendered