### PR TITLE
implement dynamic version setting in powershell plans

### DIFF
--- a/components/launcher/habitat/plan.ps1
+++ b/components/launcher/habitat/plan.ps1
@@ -1,6 +1,5 @@
 $pkg_name = "hab-launcher"
 $pkg_origin = "core"
-$pkg_version = "0"
 $pkg_maintainer = "The Habitat Maintainers <humans@habitat.sh>"
 $pkg_license = @("Apache-2.0")
 $pkg_source = "https://s3-us-west-2.amazonaws.com/habitat-win-deps/hab-win-deps.zip"
@@ -28,8 +27,11 @@ function Invoke-Prepare {
     $env:OPENSSL_INCLUDE_DIR        = "$HAB_CACHE_SRC_PATH/$pkg_dirname/include"
 }
 
+function pkg_version {
+    git rev-list master --count
+}
 function Invoke-Before {
-    $script:pkg_version = (git rev-list master --count)
+    Set-PkgVersion
     $script:pkg_dirname = "${pkg_name}-${pkg_version}"
     $script:pkg_prefix = "$HAB_PKG_PATH\$pkg_origin\$pkg_name\$pkg_version\$pkg_release"
     $script:pkg_artifact="$HAB_CACHE_ARTIFACT_PATH\${pkg_origin}-${pkg_name}-${pkg_version}-${pkg_release}-${pkg_target}.${_artifact_ext}"

--- a/www/source/partials/docs/_reference-utility-functions.html.md.erb
+++ b/www/source/partials/docs/_reference-utility-functions.html.md.erb
@@ -86,15 +86,15 @@ pkg_interpreter_for core/coreutils bin/env
 
 This function will return 0 if the specified package and interpreter were found, and 1 if the package could not be found or the interpreter is not specified for that package.
 
-**pkg_version()**(`plan.sh` only)
-: An optional way to determine the value for `$pkg_version`. The function must print the computed version string to standard output and will be called when the Plan author invokes the `update_pkg_version()` helper.
+**pkg_version()**
+: An optional way to determine the value for `$pkg_version`. The function must print the computed version string to standard output and will be called when the Plan author invokes the `update_pkg_version()` helper in a `plan.sh`` or `Set-PkgVersion` in a `plan.ps1`.
 
-**update\_pkg\_version()**(`plan.sh` only)
-: Updates the value for `$pkg_version` by calling a Plan author-provided `pkg_version()` function. This function must be explicitly called in a Plan in or after the `do_before()` build phase but before the `do_prepare()` build phase. The `$pkg_version` variable will be updated and any other relevant variables will be recomputed. The following examples show how to use `pkg_version()` and `update_pkg_version()` together.
+**update\_pkg\_version()**(`Set-PkgVersion` in a `plan.ps1`)
+: Updates the value for `$pkg_version` by calling a Plan author-provided `pkg_version()` function. This function must be explicitly called in a Plan in or after the `do_before()`/`Invoke-Before` build phase but before the `do_prepare()`/`Invoke-Prepare` build phase. The `$pkg_version` variable will be updated and any other relevant variables will be recomputed. The following examples show how to use these functions to set a dynamic version number.
 
 This plan concatenates a static file in the source root of the
 project to determine the version in the
-`do_before()` phase:
+`before` phase:
 
 ```bash
 pkg_version() {
@@ -107,10 +107,21 @@ do_before() {
 }
 ```
 
-The `pkg_version()` function in this plan uses grep and sed before using the
-date binary to format the final version string to standard output. As
-the downloaded file is required before running the version logic, the
-`update_pkg_version()` helper is called in the `do_download()` build
+```powershell
+function pkg_version {
+  Get-Content "$SRC_PATH/version.txt"
+}
+
+Invoke-Before {
+  Invoke-DefaultBefore
+  Set-PkgVersion
+}
+```
+
+The `pkg_version` function in this plan dynamically creates a version
+with a date stamp to format the final version string to standard output. As
+the downloaded file is required before running the version logic, this
+helper function is called in the `download` build
 phase:
 
 ```bash
@@ -128,6 +139,25 @@ pkg_version() {
 do_download() {
   do_default_download
   update_pkg_version
+}
+```
+
+```powershell
+function pkg_version {
+  # Extract the build date of the certificates file
+  $matchStr = "## Certificate data from Mozilla as of: "
+  foreach($line in (Get-Content "$HAB_CACHE_SRC_PATH/$pkg_filename")) {
+    if($line.StartsWith($matchStr)) {
+      $build_date = $line.Substring($matchStr.Length)
+    }
+  }
+
+  [DateTime]::Parse($build_date).ToString("yyyy.mm.dd")
+}
+
+function Invoke-Download {
+  Invoke-DefaultDownload
+  Set-PkgVersion
 }
 ```
 

--- a/www/source/partials/global/_pkg_version_example.html.md.erb
+++ b/www/source/partials/global/_pkg_version_example.html.md.erb
@@ -1,3 +1,9 @@
+plan.sh
 ```bash
 pkg_version="1.2.8"
+```
+
+plan.ps1
+```powershell
+$pkg_version="1.2.8"
 ```

--- a/www/source/partials/global/_versioning_concepts.html.md.erb
+++ b/www/source/partials/global/_versioning_concepts.html.md.erb
@@ -1,7 +1,7 @@
 Every package needs a version number to use as part of its package identification. The <code>hab plan init</code> subcommand creates a version for you, but in general, you have two options for adding versioning:
 
-* Explicitly add <code>pkg_version</code> to your plan.sh
-* Use the <code>pkg_version()</code> and <code>update_pkg_version()</code> helper functions to compute <code>pkg_version</code>
+* Explicitly add <code>pkg_version</code> to your plan file
+* Use the <code>pkg_version</code> and <code>update_pkg_version</code> (or <code>Set-PkgVersion</code> in a plan.ps1) helper functions to compute <code>pkg_version</code>
 
  The following shows how to set <code>pkg_version</code>:
 


### PR DESCRIPTION
This allows powershell plans to dynamically set a `pkg_version` using the same constructs as bash plans. This became important when we built the windows launcher which needed this same functionality.

Signed-off-by: mwrock <matt@mattwrock.com>