### PR TITLE
[prototype] Selector binds

### DIFF
--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -64,8 +64,8 @@ use sup::command;
 use sup::http_gateway;
 use sup::http_gateway::ListenAddr;
 use sup::manager::{Manager, ManagerConfig, ServiceStatus};
-use sup::manager::service::{DesiredState, ServiceBind, Topology, UpdateStrategy};
-use sup::manager::service::{CompositeSpec, ServiceSpec, StartStyle};
+use sup::manager::service::{DesiredState, ServiceBind, Topology, UpdateStrategy, };
+use sup::manager::service::{CompositeSpec, ServiceSpec, StartStyle, SpecifiedServiceBind};
 use sup::util;
 
 /// Our output key
@@ -1398,11 +1398,11 @@ fn set_composite_binds(
                 &spec.group,
                 None, // <-- organization
             )?;
-            let bind = ServiceBind {
+            let bind = ServiceBind::Specified(SpecifiedServiceBind {
                 name: bind_mapping.bind_name.clone(),
                 service_group: group,
-            };
-            final_binds.insert(bind.name.clone(), bind);
+            });
+            final_binds.insert(bind.name(), bind);
         }
     }
 
@@ -1414,7 +1414,7 @@ fn set_composite_binds(
     if let Entry::Occupied(b) = cli_binds.entry(spec.ident.name.clone()) {
         let binds = b.remove();
         for bind in binds {
-            final_binds.insert(bind.name.clone(), bind);
+            final_binds.insert(bind.name(), bind);
         }
     }
 


### PR DESCRIPTION
This is a crack at seeing if #4586 would work the way I wanted.

In hab master, you can specify a binding by `--bind name:service_group`.
This PR introduces a new way, `--bind name:[selector]`. A selector can
select multiple service groups based on labels, which I currently
emulated by using the exported config values. There are problems with
doing that in that I wanted the select service groups and not individual
members, so it doesn't quite fit. Also because it means members within
the same service group could have different labels.

Below is an example of how I use it:

```bash
echo "Starting prometheus with selector binding:"
echo 'hab svc start jaym/prometheus --channel unstable --bind "targets:[metric-http-port]"'
hab svc start jaym/prometheus --channel unstable --bind "targets:[metric-http-port]" > /dev/null

echo "Starting hello-service"
hab svc start jaym/hello-service --channel unstable > /dev/null

echo "Starting world-service"
hab svc start jaym/world-service --channel unstable > /dev/null
```

In this example, there are 3 services: prometheus, hello-service, and
world-service. hello-service and world-service expose metrics endpoints.
Prometheus is started with a selector binding that says find me
everything with the label `metric-http-port`. So, prometheus comes up...
nothing is monitored. `hello-service` then comes up, and hab matches
`[metric-http-port]` the the `hello-service.default` service group,
rerendering the prometheus config. Then world-service comes up, hab sees
that `[metric-http-port]` also matches world-service. It adds the member
to the bind group, and the prometheus config gets rerendered. It now has
targets for both the hello-service member and world-service member

https://github.com/jaym/habitat-selector-binds has a studiorc that can run this demo