### PR TITLE
Helm exporter to add operator to exported charts

### DIFF
--- a/components/pkg-export-helm/defaults/HelmDeps.hbs
+++ b/components/pkg-export-helm/defaults/HelmDeps.hbs
@@ -1,0 +1,4 @@
+dependencies:
+  - name: habitat-operator
+    version: {{operator_version}}
+    repository: {{operator_repo_url}}

--- a/components/pkg-export-helm/src/chart.rs
+++ b/components/pkg-export-helm/src/chart.rs
@@ -126,7 +126,7 @@ impl<'a> Chart<'a> {
     pub fn generate(mut self) -> Result<()> {
         self.ui.status(
             Status::Creating,
-            format!("chart directory `{}`", self.name),
+            format!("directory `{}`", self.name),
         )?;
         fs::create_dir_all(&self.name)?;
 
@@ -135,7 +135,7 @@ impl<'a> Chart<'a> {
         let template_path = format!("{}/{}", self.name, "templates");
         self.ui.status(
             Status::Creating,
-            format!("templates directory `{}`", template_path),
+            format!("directory `{}`", template_path),
         )?;
 
         self.generate_values()?;
@@ -146,10 +146,7 @@ impl<'a> Chart<'a> {
 
     pub fn generate_chartfile(&mut self) -> Result<()> {
         let path = format!("{}/Chart.yaml", self.name);
-        self.ui.status(
-            Status::Creating,
-            format!("chart file `{}`", path),
-        )?;
+        self.ui.status(Status::Creating, format!("file `{}`", path))?;
         let mut write = fs::File::create(path)?;
         let out = self.chartfile.into_string()?;
 
@@ -162,7 +159,7 @@ impl<'a> Chart<'a> {
         let manifest_path = format!("{}/{}.yaml", template_path, self.name);
         self.ui.status(
             Status::Creating,
-            format!("manifest template `{}`", manifest_path),
+            format!("file `{}`", manifest_path),
         )?;
         let mut write = fs::File::create(manifest_path)?;
         let out: String = self.manifest_template.into();
@@ -174,10 +171,7 @@ impl<'a> Chart<'a> {
 
     pub fn generate_values(&mut self) -> Result<()> {
         let path = format!("{}/values.yaml", self.name);
-        self.ui.status(
-            Status::Creating,
-            format!("values file `{}`", path),
-        )?;
+        self.ui.status(Status::Creating, format!("file `{}`", path))?;
         let mut write = fs::File::create(path)?;
 
         self.values.generate(&mut write)?;

--- a/components/pkg-export-helm/src/chart.rs
+++ b/components/pkg-export-helm/src/chart.rs
@@ -132,16 +132,9 @@ impl<'a> Chart<'a> {
 
         self.generate_chartfile()?;
 
-        let template_path = format!("{}/{}", self.name, "templates");
-        self.ui.status(
-            Status::Creating,
-            format!("directory `{}`", template_path),
-        )?;
-
         self.generate_values()?;
 
-        fs::create_dir_all(&template_path)?;
-        self.generate_manifest_template(&template_path)
+        self.generate_manifest_template()
     }
 
     pub fn generate_chartfile(&mut self) -> Result<()> {
@@ -155,7 +148,14 @@ impl<'a> Chart<'a> {
         Ok(())
     }
 
-    pub fn generate_manifest_template(self, template_path: &str) -> Result<()> {
+    pub fn generate_manifest_template(self) -> Result<()> {
+        let template_path = format!("{}/{}", self.name, "templates");
+        self.ui.status(
+            Status::Creating,
+            format!("directory `{}`", template_path),
+        )?;
+        fs::create_dir_all(&template_path)?;
+
         let manifest_path = format!("{}/{}.yaml", template_path, self.name);
         self.ui.status(
             Status::Creating,

--- a/components/pkg-export-helm/src/chart.rs
+++ b/components/pkg-export-helm/src/chart.rs
@@ -137,7 +137,7 @@ impl<'a> Chart<'a> {
         self.generate_manifest_template()
     }
 
-    pub fn generate_chartfile(&mut self) -> Result<()> {
+    fn generate_chartfile(&mut self) -> Result<()> {
         let path = format!("{}/Chart.yaml", self.name);
         self.ui.status(Status::Creating, format!("file `{}`", path))?;
         let mut write = fs::File::create(path)?;
@@ -148,7 +148,7 @@ impl<'a> Chart<'a> {
         Ok(())
     }
 
-    pub fn generate_manifest_template(self) -> Result<()> {
+    fn generate_manifest_template(self) -> Result<()> {
         let template_path = format!("{}/{}", self.name, "templates");
         self.ui.status(
             Status::Creating,
@@ -169,7 +169,7 @@ impl<'a> Chart<'a> {
         Ok(())
     }
 
-    pub fn generate_values(&mut self) -> Result<()> {
+    fn generate_values(&mut self) -> Result<()> {
         let path = format!("{}/values.yaml", self.name);
         self.ui.status(Status::Creating, format!("file `{}`", path))?;
         let mut write = fs::File::create(path)?;

--- a/components/pkg-export-helm/src/chart.rs
+++ b/components/pkg-export-helm/src/chart.rs
@@ -27,7 +27,7 @@ use values::Values;
 pub struct Chart<'a> {
     name: String,
     chartfile: ChartFile,
-    manifest_template: ManifestJson,
+    manifest_template: Option<ManifestJson>,
     values: Values,
     ui: &'a mut UI,
 }
@@ -109,10 +109,10 @@ impl<'a> Chart<'a> {
             binds.push(json);
         }
 
-        let manifest_template = ManifestJson {
+        let manifest_template = Some(ManifestJson {
             main: main,
             binds: binds,
-        };
+        });
 
         Chart {
             name,
@@ -146,7 +146,7 @@ impl<'a> Chart<'a> {
         Ok(())
     }
 
-    fn generate_manifest_template(self) -> Result<()> {
+    fn generate_manifest_template(&mut self) -> Result<()> {
         let template_path = format!("{}/{}", self.name, "templates");
         self.ui.status(
             Status::Creating,
@@ -160,7 +160,10 @@ impl<'a> Chart<'a> {
             format!("file `{}`", manifest_path),
         )?;
         let mut write = fs::File::create(manifest_path)?;
-        let out: String = self.manifest_template.into();
+        let out: String = self.manifest_template
+            .take()
+            .expect("generate_manifest_template() called more than once")
+            .into();
 
         write.write(out.as_bytes())?;
 

--- a/components/pkg-export-helm/src/chart.rs
+++ b/components/pkg-export-helm/src/chart.rs
@@ -138,9 +138,7 @@ impl<'a> Chart<'a> {
     }
 
     fn generate_chartfile(&mut self) -> Result<()> {
-        let path = format!("{}/Chart.yaml", self.name);
-        self.ui.status(Status::Creating, format!("file `{}`", path))?;
-        let mut write = fs::File::create(path)?;
+        let mut write = self.create_file("chart.yaml")?;
         let out = self.chartfile.into_string()?;
 
         write.write(out.as_bytes())?;
@@ -170,12 +168,16 @@ impl<'a> Chart<'a> {
     }
 
     fn generate_values(&mut self) -> Result<()> {
-        let path = format!("{}/values.yaml", self.name);
-        self.ui.status(Status::Creating, format!("file `{}`", path))?;
-        let mut write = fs::File::create(path)?;
-
+        let mut write = self.create_file("values.yaml")?;
         self.values.generate(&mut write)?;
 
         Ok(())
+    }
+
+    fn create_file(&mut self, name: &str) -> Result<fs::File> {
+        let path = format!("{}/{}", self.name, name);
+        self.ui.status(Status::Creating, format!("file `{}`", path))?;
+
+        fs::File::create(path).map_err(From::from)
     }
 }

--- a/components/pkg-export-helm/src/deps.rs
+++ b/components/pkg-export-helm/src/deps.rs
@@ -1,0 +1,98 @@
+// Copyright (c) 2018 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use failure::SyncFailure;
+use handlebars::Handlebars;
+use clap;
+use std::io::Write;
+use std::path::Path;
+use std::process::Command;
+
+use common::ui::{UI, Status};
+use export_docker::Result;
+
+// Keep the default operator version in main::cli() in sync with this one
+pub const DEFAULT_OPERATOR_VERSION: &'static str = "0.4.0";
+pub const OPERATOR_REPO_URL: &'static str = "https://kinvolk.github.io/habitat-operator\
+                                             /helm/charts/stable/";
+
+// Helm requirements.yaml template
+const DEPSFILE: &'static str = include_str!("../defaults/HelmDeps.hbs");
+
+pub struct Deps {
+    operator_version: String,
+    update: bool,
+}
+
+impl Deps {
+    pub fn new_for_cli_matches(matches: &clap::ArgMatches) -> Self {
+        Deps {
+            operator_version: matches
+                .value_of("OPERATOR_VERSION")
+                .unwrap_or(DEFAULT_OPERATOR_VERSION)
+                .to_owned(),
+            update: matches.is_present("DOWNLOAD_DEPS"),
+        }
+    }
+
+    pub fn generate(&mut self, write: &mut Write) -> Result<()> {
+        let out = self.into_string()?;
+        write.write(out.as_bytes())?;
+
+        Ok(())
+    }
+
+    pub fn download<P: AsRef<Path>>(&self, dir: P, ui: &mut UI) -> Result<()> {
+        if !self.update {
+            return Ok(());
+        }
+        ui.status(Status::Downloading, "dependencies")?;
+
+        // Ignore the results cause it's not a problem if this execution fails.
+        Command::new("helm")
+            .arg("repo")
+            .arg("add")
+            .arg("habitat-operator")
+            .arg(OPERATOR_REPO_URL)
+            .spawn()?
+            .wait()
+            .ok();
+
+        Command::new("helm")
+            .arg("dep")
+            .arg("up")
+            .arg(dir.as_ref().as_os_str())
+            .spawn()?
+            .wait()
+            .map(|_| ())
+            .map_err(From::from)
+    }
+
+    // TODO: Implement TryInto trait instead when it's in stable std crate
+    fn into_string(&self) -> Result<String> {
+        let json = json!({
+            "operator_version": self.operator_version,
+            "operator_repo_url": OPERATOR_REPO_URL,
+        });
+
+        let r = Handlebars::new().template_render(DEPSFILE, &json).map_err(
+            SyncFailure::new,
+        )?;
+        let s = r.lines().filter(|l| *l != "").collect::<Vec<_>>().join(
+            "\n",
+        ) + "\n";
+
+        Ok(s)
+    }
+}

--- a/components/pkg-export-helm/src/main.rs
+++ b/components/pkg-export-helm/src/main.rs
@@ -29,6 +29,7 @@ extern crate failure;
 mod chart;
 mod chartfile;
 mod values;
+mod deps;
 
 use std::result;
 
@@ -63,8 +64,7 @@ fn export_for_cli_matches(ui: &mut UI, matches: &clap::ArgMatches) -> Result<()>
 fn cli<'a, 'b>() -> clap::App<'a, 'b> {
     let name: &str = &*PROGRAM_NAME;
     let about = "Creates a Docker image and generates a Helm chart for the specified Habitat \
-                 package. Habitat operator must be deployed within the Kubernetes cluster before \
-                 the generated chart can be installed.";
+                 package.";
 
     Cli::new(name, about)
         .add_docker_args()
@@ -95,6 +95,17 @@ fn cli<'a, 'b>() -> clap::App<'a, 'b> {
                 .long("desc")
                 .help("A single-sentence description"),
         )
+        .arg(
+            Arg::with_name("OPERATOR_VERSION")
+                .value_name("OPERATOR_VERSION")
+                .long("operator-version")
+                .validator(valid_version)
+                // Keep the default version here in sync with deps::DEFAULT_OPERATOR_VERSION
+                .help("Version of the Habitat operator to set as dependency (default: 0.4.0)"),
+        )
+        .arg(Arg::with_name("DOWNLOAD_DEPS").long("download-deps").help(
+            "Whether to download dependencies (default: no)",
+        ))
 }
 
 fn valid_version(val: String) -> result::Result<(), String> {


### PR DESCRIPTION
From the last commit's log:

    Add dependency to the Habitat operator chart in the generated charts. This
    automates the installation of the operator into the Kubernetes cluster and
    is installed as part of the generated chart for the user.
    
    Unless '--download-deps' CLI option is passed to the exporter, user of the
    exporter has to manually run
    
    $ helm repo add habitat-operator \
      https://kinvolk.github.io/habitat-operator/helm/charts/stable/
    $ helm dep up PATH_OF_GENERATED_CHART_DIR
    
    before they can install the chart or package it.
    
    Before the first time the exporter is run, Helm needs to be setup, which
    is just a matter of `helm init -c` if one needs to setup Helm for the
    purpose of creating charts only and not actually installing them on a
    Kubernetes cluster.
