### PR TITLE
[pkg-export-docker] Restore latest tag options.

### DIFF
--- a/components/pkg-export-docker/src/cli.rs
+++ b/components/pkg-export-docker/src/cli.rs
@@ -179,6 +179,18 @@ impl<'a, 'b> Cli<'a, 'b> {
                     .help("Do not tag image with :\"{{pkg_version}}\" (default: no)"),
             )
             .arg(
+                Arg::with_name("TAG_LATEST")
+                    .long("tag-latest")
+                    .conflicts_with("NO_TAG_LATEST")
+                    .help("Tag image with :\"latest\" (default: yes)"),
+            )
+            .arg(
+                Arg::with_name("NO_TAG_LATEST")
+                    .long("no-tag-latest")
+                    .conflicts_with("TAG_LATEST")
+                    .help("Do not tag image with :\"latest\" (default: no)"),
+            )
+            .arg(
                 Arg::with_name("TAG_CUSTOM")
                     .long("tag-custom")
                     .value_name("TAG_CUSTOM")

--- a/components/pkg-export-docker/src/docker.rs
+++ b/components/pkg-export-docker/src/docker.rs
@@ -88,8 +88,12 @@ impl<'a> DockerBuilder<'a> {
             .arg("build")
             .arg("--force-rm")
             .arg("--no-cache");
-        for tag in &self.tags {
-            cmd.arg("--tag").arg(format!("{}:{}", &self.name, tag));
+        if self.tags.is_empty() {
+            cmd.arg("--tag").arg(&self.name);
+        } else {
+            for tag in &self.tags {
+                cmd.arg("--tag").arg(format!("{}:{}", &self.name, tag));
+            }
         }
         cmd.arg(".");
         debug!("Running: {:?}", &cmd);
@@ -495,7 +499,9 @@ impl DockerBuildRoot {
         if naming.version_tag {
             image = image.tag(version.clone());
         }
-        image = image.tag("latest".to_string());
+        if naming.latest_tag {
+            image = image.tag("latest".to_string());
+        }
         if let Some(ref custom) = naming.custom_tag {
             image = image.tag(
                 Handlebars::new()

--- a/components/pkg-export-docker/src/lib.rs
+++ b/components/pkg-export-docker/src/lib.rs
@@ -79,6 +79,8 @@ const CACERTS_IDENT: &'static str = "core/cacerts";
 pub struct Naming<'a> {
     /// An optional custom image name which would override a computed default value.
     pub custom_image_name: Option<&'a str>,
+    /// Whether or not to tag the image with a latest value.
+    pub latest_tag: bool,
     /// Whether or not to tag the image with a value containing a version from a Package
     /// Identifier.
     pub version_tag: bool,
@@ -103,6 +105,7 @@ impl<'a> Naming<'a> {
 
         Naming {
             custom_image_name: m.value_of("IMAGE_NAME"),
+            latest_tag: !m.is_present("NO_TAG_LATEST"),
             version_tag: !m.is_present("NO_TAG_VERSION"),
             version_release_tag: !m.is_present("NO_TAG_VERSION_RELEASE"),
             custom_tag: m.value_of("TAG_CUSTOM"),


### PR DESCRIPTION
The `--tag-latest` (and associated `--no-tag-latest`) help to control
which tags are pushed remotely, in addition to local tagging in the
Docker engine at build time. Furthermore, these flags are used and
relied upon in the Builder worker service.

---

Revert "pkg-export-docker: Drop noop 'latest' tag options"

This reverts commit 47d0b2b1c337c9b7ab77a301a7390138276cebd1.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>