### PR TITLE
Fix array access regression in template rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -881,7 +881,7 @@ dependencies = [
  "habitat_common 0.0.0",
  "habitat_core 0.0.0 (git+https://github.com/habitat-sh/core.git)",
  "habitat_depot_client 0.0.0",
- "handlebars 0.29.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "handlebars 0.28.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "iron 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -915,6 +915,20 @@ dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "widestring 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "handlebars"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pest 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quick-error 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2439,6 +2453,7 @@ dependencies = [
 "checksum habitat-eventsrv-protocol 0.0.0 (git+https://github.com/habitat-sh/protocols.git)" = "<none>"
 "checksum habitat_core 0.0.0 (git+https://github.com/habitat-sh/core.git)" = "<none>"
 "checksum habitat_win_users 0.0.0 (git+https://github.com/habitat-sh/core.git)" = "<none>"
+"checksum handlebars 0.28.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1bed53dfb11098ec893ed54aa8b9828ffb98d28acbe56a49419935e5a8688ca9"
 "checksum handlebars 0.29.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fb04af2006ea09d985fef82b81e0eb25337e51b691c76403332378a53d521edc"
 "checksum hex 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d6a22814455d41612f41161581c2883c0c6a1c41852729b17d5ed88f01e153aa"
 "checksum hex 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "459d3cf58137bb02ad4adeef5036377ff59f066dbb82517b7192e3a5462a2abc"

--- a/components/sup/Cargo.toml
+++ b/components/sup/Cargo.toml
@@ -29,8 +29,16 @@ habitat_core = { git = "https://github.com/habitat-sh/core.git" }
 habitat_depot_client = { path = "../builder-depot-client" }
 habitat-eventsrv-client = { path = "../eventsrv-client" }
 habitat-launcher-client = { path = "../launcher-client" }
-# We need to lock here since v0.30.0 bumps to a version of pest that fails to build on Windows.
-handlebars = { version = "0.29.1", default-features = false }
+# The handlebars crate has a few issues that require us to lock at 0.28.3
+# until further notice.
+#
+# - 0.30.0 bumps to a version of the `pest` crate that fails to build
+#   on Windows.
+# - 0.29.0 makes a change to array processing that is incompatible
+#   with our templating syntax; we use "foo[0]", but it now requires
+#   "foo.[0]"
+#   See https://github.com/sunng87/handlebars-rust/commit/707f05442ef6f441a1cfc6b13ac180b78cb296db
+handlebars = { version = "= 0.28.3", default-features = false }
 iron = "*"
 lazy_static = "*"
 libc = "*"

--- a/components/sup/src/templating/mod.rs
+++ b/components/sup/src/templating/mod.rs
@@ -232,6 +232,18 @@ test: something"#
     }
 
     #[test]
+    fn bind_variable() {
+        let content = "{{bind.foo.members[0].sys.ip}}";
+        let mut renderer = TemplateRenderer::new();
+        let data = service_config_json_from_toml_file("complex_config.toml");
+
+        renderer.register_template_string("t", content).unwrap();
+
+        let rendered = renderer.render("t", &data).unwrap();
+        assert_eq!(rendered, "172.17.0.5");
+    }
+
+    #[test]
     fn pkg_path_for_helper() {
         let content = "{{pkgPathFor \"core/acl\"}}".to_string();
         let mut renderer = TemplateRenderer::new();

--- a/components/sup/tests/fixtures/sample_configs/complex_config.toml
+++ b/components/sup/tests/fixtures/sample_configs/complex_config.toml
@@ -1,4 +1,8 @@
 [bind]
+[bind.foo]
+[[bind.foo.members]]
+[bind.foo.members.sys]
+ip = "172.17.0.5"
 
 [cfg]
 


### PR DESCRIPTION
Recent versions of `handlebars` change array index access syntax, breaking that feature in Habitat templates. This pins to the last known-good version of `handlebars`.

Read commits for further details.

Fixes #4615 