### PR TITLE
Convert github-api-client to use http-client, which respects proxies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -459,6 +459,7 @@ version = "0.0.0"
 dependencies = [
  "base64 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "frank_jwt 2.5.1 (git+https://github.com/habitat-sh/frank_jwt?branch=habitat)",
+ "habitat_http_client 0.0.0",
  "hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-openssl 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/github-api-client/Cargo.toml
+++ b/components/github-api-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "github-api-client"
 version = "0.0.0"
-authors = ["Jamie Winsor <reset@habitat.sh>"]
+authors = ["Jamie Winsor <reset@habitat.sh>", "Josh Black <raskchanky@gmail.com>"]
 workspace = "../../"
 
 [dependencies]
@@ -16,3 +16,6 @@ serde = "*"
 serde_derive = "*"
 serde_json = "*"
 time = "*"
+
+[dependencies.habitat_http_client]
+path = "../http-client"

--- a/components/github-api-client/src/error.rs
+++ b/components/github-api-client/src/error.rs
@@ -20,6 +20,7 @@ use std::io;
 use base64;
 use hyper;
 use serde_json;
+use hab_http;
 
 use types;
 
@@ -27,6 +28,7 @@ pub type HubResult<T> = Result<T, HubError>;
 
 #[derive(Debug)]
 pub enum HubError {
+    ApiClient(hab_http::Error),
     ApiError(hyper::status::StatusCode, HashMap<String, String>),
     AppAuth(types::AppAuthErr),
     Auth(types::AuthErr),
@@ -41,6 +43,7 @@ pub enum HubError {
 impl fmt::Display for HubError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let msg = match *self {
+            HubError::ApiClient(ref e) => format!("{}", e),
             HubError::ApiError(ref code, ref response) => {
                 format!(
                     "Received a non-200 response, status={}, response={:?}",
@@ -64,6 +67,7 @@ impl fmt::Display for HubError {
 impl error::Error for HubError {
     fn description(&self) -> &str {
         match *self {
+            HubError::ApiClient(ref err) => err.description(),
             HubError::ApiError(_, _) => "Response returned a non-200 status code.",
             HubError::AppAuth(_) => "GitHub App authorization error.",
             HubError::Auth(_) => "GitHub authorization error.",

--- a/components/github-api-client/src/lib.rs
+++ b/components/github-api-client/src/lib.rs
@@ -14,6 +14,7 @@
 
 extern crate base64;
 extern crate frank_jwt as jwt;
+extern crate habitat_http_client as hab_http;
 extern crate hyper;
 extern crate hyper_openssl;
 #[macro_use]

--- a/components/http-client/src/api_client.rs
+++ b/components/http-client/src/api_client.rs
@@ -204,11 +204,12 @@ impl ApiClient {
             return url;
         }
 
-        if url.path().ends_with("/") {
+        if url.path().ends_with("/") || path.starts_with("/") {
             url.set_path(&format!("{}{}", self.endpoint.path(), path));
         } else {
             url.set_path(&format!("{}/{}", self.endpoint.path(), path));
         }
+
         url
     }
 }


### PR DESCRIPTION
We need the GitHub API Client to honor proxies in environment variables because many enterprises will have proxies in place.  Luckily, our own `http-client` crate already does this.  This PR changes the `github-api-client` crate to use `http-client` internally.

![tenor-182828683](https://user-images.githubusercontent.com/947/36325037-3efb08ba-130b-11e8-8de2-d3ff673821d0.gif)

Closes https://github.com/habitat-sh/builder/issues/207
Signed-off-by: Josh Black <raskchanky@gmail.com>