### PR TITLE
Improve Kubernetes documentation

### DIFF
--- a/www/source/partials/docs/_bp-kubernetes.html.md.erb
+++ b/www/source/partials/docs/_bp-kubernetes.html.md.erb
@@ -1,17 +1,25 @@
 # <a name="kubernetes" id="kubernetes" data-magellan-target="kubernetes">Kubernetes</a>
 [Kubernetes](http://kubernetes.io/) is an open source container cluster manager that is available as a stand-alone platform or embedded in several distributed platforms including [Google's Container Engine](https://cloud.google.com/container-engine/), [Tectonic](https://tectonic.com/) by [CoreOS](https://coreos.com/), and [OpenShift](https://openshift.com/) by [RedHat](https://redhat.com). Habitat and Kubernetes are complementary: Kubernetes focuses on providing a platform for deployment, scaling, and operations of application containers across clusters of hosts while Habitat manages the build pipeline and lifecycle of those application containers.
 
-## Habitat Kubernetes Operator
+## Habitat Operator
 
-The [Habitat Kubernetes Operator](https://github.com/kinvolk/habitat-operator) is on-going work to create an operator that leverages Kubernetes API services to create a native and robust integration between the two technologies. Follow along on [github](https://github.com/kinvolk/habitat-operator), and join us in our #kubernetes channel in the [Habitat Slack Channel](https://slack.habitat.sh) for more information.
+The [Habitat Kubernetes Operator](https://github.com/kinvolk/habitat-operator) is on-going work to create an operator that leverages Kubernetes API services to create a native and robust integration between the two technologies.
 
-## Docker and ACI
+By using the Habitat Operator, you can abstract from many of the low level details of running a Habitat package in Kubernetes, and jump straight to deploying your application, with support for Habitat features like [service configuration](https://github.com/kinvolk/habitat-operator/tree/master/examples/config), [binding](https://github.com/kinvolk/habitat-operator/tree/master/examples/bind), [topologies](https://github.com/kinvolk/habitat-operator/tree/master/examples/leader) and more.
 
-Habitat packages can be exported in both Docker and ACI formats (as well as others). Kubernetes currently supports the Docker runtime and integration of the rkt container runtime (an implementation of the App Container spec) is under active development.
+For more details on the Habitat Operator, please refer to the [introductory blogpost](https://kinvolk.io/blog/2017/10/habitat-operator---running-habitat-services-with-kubernetes/), follow along on [github](https://github.com/kinvolk/habitat-operator), and join us in our [#kubernetes](https://habitat-sh.slack.com/messages/kubernetes/) channel in the [Habitat Slack](https://slack.habitat.sh).
 
-## kubectl
+### Kubernetes exporter
 
-Habitat packages exported as containers may be deployed into Kubernetes through the [`kubectl` command](http://kubernetes.io/docs/user-guide/pods/single-container/). Using the [Docker exporter](/docs/developing-packages#pkg-exports) to create a containerized application, the container may be launched like this example:
+When using the Habitat Operator, you can easily convert packages and run them on your Kubernetes cluster using the [Kubernetes exporter](https://kinvolk.io/blog/2017/12/introducing-the-habitat-kubernetes-exporter/):
+
+```shell
+$ hab pkg export kubernetes ORIGIN/NAME
+```
+
+## Bare Kubernetes
+
+Users are not required to use the Habitat Operator. Habitat packages exported as containers may be deployed to Kubernetes through the [`kubectl` command](http://kubernetes.io/docs/user-guide/pods/single-container/). Using the [Docker exporter](/docs/developing-packages#pkg-exports) to create a containerized application, the container may be launched like this example:
 
 ```shell
 $ kubectl run mytutorial --image=myorigin/mytutorial --port=8080
@@ -23,9 +31,13 @@ Assuming the Docker image is pulled from `myorigin/mytutorial` we are exposing p
 $ kubectl get pods -l run=mytutorial
 ```
 
+## Docker and ACI
+
+Habitat packages can be exported in both Docker and ACI formats (as well as others). Kubernetes currently supports the Docker runtime and integration of the rkt container runtime (an implementation of the App Container spec) is under active development.
+
 ## Environment variables and Networking
 
-Kubernetes supports passing [environment variables](http://kubernetes.io/docs/user-guide/environment-guide/) into containers, which can be done via the Habitat Operator.
+Kubernetes supports passing [environment variables](http://kubernetes.io/docs/user-guide/environment-guide/) into containers, which can be done [via the Habitat Operator](https://github.com/kinvolk/habitat-operator/tree/master/examples/env-vars).
 
 ## Multi-container Pods
 


### PR DESCRIPTION
This improves the [Kubernetes documentation](https://www.habitat.sh/docs/best-practices/#kubernetes) in several ways:

* Adds details about the Operator
* Adds Helm examples
* Explains how to work without the operator

/cc @LiliC @zeenix @krnowak
