### PR TITLE
Use the service name for the Helm chart name

### DIFF
--- a/components/pkg-export-helm/src/chart.rs
+++ b/components/pkg-export-helm/src/chart.rs
@@ -45,7 +45,7 @@ impl<'a> Chart<'a> {
 
         let name = matches
             .value_of("CHART")
-            .unwrap_or(&manifest.metadata_name)
+            .unwrap_or(&manifest.service_name)
             .to_string();
         let version = matches.value_of("VERSION");
         let description = matches.value_of("DESCRIPTION");


### PR DESCRIPTION
Don't use metadata name, so as not to run afoul of Helm conventions.

Signed-off-by: Christopher Maier <cmaier@chef.io>