### PR TITLE
comment pkg_source in init template to prevent build error

### DIFF
--- a/components/hab/static/full_template_plan.ps1
+++ b/components/hab/static/full_template_plan.ps1
@@ -46,7 +46,7 @@ $pkg_license=@("Apache-2.0")
 {{#if pkg_source ~}}
 $pkg_source="{{ pkg_source }}"
 {{else ~}}
-$pkg_source="http://some_source_url/releases/$pkg_name-$pkg_version.zip"
+# $pkg_source="http://some_source_url/releases/$pkg_name-$pkg_version.zip"
 {{/if}}
 
 # Optional.

--- a/components/hab/static/full_template_plan.sh
+++ b/components/hab/static/full_template_plan.sh
@@ -46,7 +46,7 @@ pkg_license=("Apache-2.0")
 {{#if pkg_source ~}}
 pkg_source="{{ pkg_source }}"
 {{else ~}}
-pkg_source="http://some_source_url/releases/${pkg_name}-${pkg_version}.tar.gz"
+# pkg_source="http://some_source_url/releases/${pkg_name}-${pkg_version}.tar.gz"
 {{/if}}
 
 # Optional.


### PR DESCRIPTION
Ideally, you should be able to run `build` against a freshly initialized plan without error. Currently because `pkg_source` is set to a dummy URL by default, `build` will break. This comments that line like we do for other "non buildable" settings.

Signed-off-by: mwrock <matt@mattwrock.com>