### PR TITLE
pkg-export-helm: Correct name of manifest template

### DIFF
--- a/components/pkg-export-helm/src/chart.rs
+++ b/components/pkg-export-helm/src/chart.rs
@@ -162,7 +162,7 @@ impl<'a> Chart<'a> {
         )?;
         fs::create_dir_all(&template_path)?;
 
-        let manifest_path = format!("{}/{}.yaml", template_path, self.name);
+        let manifest_path = format!("{}/habitat.yaml", template_path);
         self.ui.status(
             Status::Creating,
             format!("file `{}`", manifest_path),


### PR DESCRIPTION
The manifest file of the Habitat resource kind should be named after its
resource kind, "habitat" and not the chart's name. Not only this is
consistent with conventions but with the version and release info in the
chart name, we end up with needless redundancy.

Signed-off-by: Zeeshan Ali <zeeshan@kinvolk.io>