### PR TITLE
If there is a query string, let's use it instead of dropping it silently

### DIFF
--- a/components/github-api-client/src/client.rs
+++ b/components/github-api-client/src/client.rs
@@ -354,7 +354,10 @@ where
     }
 
     let client = http_client(endpoint.as_str())?;
-    let req = client.get(path);
+    let req = client.get_with_custom_url(path, |url| if u.query().is_some() {
+        url.set_query(Some(u.query().unwrap()))
+    });
+
     let req = req.header(Accept(vec![
         qitem(
             Mime(TopLevel::Application, SubLevel::Json, vec![])
@@ -387,7 +390,10 @@ where
     }
 
     let client = http_client(endpoint.as_str())?;
-    let req = client.post(path);
+    let req = client.post_with_custom_url(path, |url| if u.query().is_some() {
+        url.set_query(Some(u.query().unwrap()))
+    });
+
     let req = req.header(Accept(vec![
         qitem(
             Mime(TopLevel::Application, SubLevel::Json, vec![])


### PR DESCRIPTION
This fixes the issue where you can't sign into GitHub, because before we were just silently ignoring any query parameters that may have been present.

![](https://media.giphy.com/media/HNEmXQz7A0lDq/giphy.gif)

Signed-off-by: Josh Black <raskchanky@gmail.com>