### PR TITLE
Fix Helm chart naming

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -815,6 +815,7 @@ dependencies = [
  "habitat_pkg_export_docker 0.0.0",
  "habitat_pkg_export_kubernetes 0.0.0",
  "handlebars 0.29.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/pkg-export-helm/Cargo.toml
+++ b/components/pkg-export-helm/Cargo.toml
@@ -19,6 +19,7 @@ habitat_pkg_export_docker = { path = "../pkg-export-docker" }
 habitat_pkg_export_kubernetes = { path = "../pkg-export-kubernetes" }
 # We need to lock here since v0.30.0 bumps to a version of pest that fails to build on Windows.
 handlebars = { version = "0.29.1", default-features = false }
+lazy_static = "*"
 log = "*"
 serde = "1.0.2"
 serde_json = "1.0.0"

--- a/components/pkg-export-helm/src/chart.rs
+++ b/components/pkg-export-helm/src/chart.rs
@@ -45,7 +45,7 @@ impl<'a> Chart<'a> {
 
         let name = matches
             .value_of("CHART")
-            .unwrap_or(&manifest.metadata_name)
+            .unwrap_or(&manifest.pkg_ident.name)
             .to_string();
         let version = matches.value_of("VERSION");
         let description = matches.value_of("DESCRIPTION");

--- a/components/pkg-export-helm/src/chart.rs
+++ b/components/pkg-export-helm/src/chart.rs
@@ -80,7 +80,7 @@ impl<'a> Chart<'a> {
 
         let mut values = Values::new();
         values.add_entry("metadataName", &manifest.metadata_name);
-        values.add_entry("serviceName", &manifest.service_name);
+        values.add_entry("serviceName", &manifest.pkg_ident.name);
         values.add_entry("imageName", &manifest.image);
         values.add_entry("instanceCount", &manifest.count.to_string());
         values.add_entry("serviceTopology", &manifest.service_topology.to_string());

--- a/components/pkg-export-helm/src/chart.rs
+++ b/components/pkg-export-helm/src/chart.rs
@@ -47,7 +47,12 @@ impl<'a> Chart<'a> {
             .value_of("CHART")
             .unwrap_or(&manifest.pkg_ident.name)
             .to_string();
-        let version = matches.value_of("VERSION");
+        let pkg_version = manifest.pkg_ident.version.clone();
+        let version = matches.value_of("VERSION").or(
+            pkg_version.as_ref().map(|s| {
+                s.as_ref()
+            }),
+        );
         let description = matches.value_of("DESCRIPTION");
         let chartfile = ChartFile::new(&name, version, description);
         let deps = Deps::new_for_cli_matches(&matches);

--- a/components/pkg-export-helm/src/main.rs
+++ b/components/pkg-export-helm/src/main.rs
@@ -20,6 +20,8 @@ extern crate habitat_pkg_export_docker as export_docker;
 extern crate habitat_pkg_export_kubernetes as export_k8s;
 extern crate handlebars;
 #[macro_use]
+extern crate lazy_static;
+#[macro_use]
 extern crate log;
 #[macro_use]
 extern crate serde_json;

--- a/components/pkg-export-helm/src/main.rs
+++ b/components/pkg-export-helm/src/main.rs
@@ -66,6 +66,12 @@ fn export_for_cli_matches(ui: &mut UI, matches: &clap::ArgMatches) -> Result<()>
     Ok(())
 }
 
+lazy_static! {
+    pub static ref VERSION_HELP: String =
+        format!("Version of the chart to create (default: {{pkg_version}} if available, or {})",
+                chartfile::DEFAULT_VERSION);
+}
+
 fn cli<'a, 'b>() -> clap::App<'a, 'b> {
     let name: &str = &*PROGRAM_NAME;
     let about = "Creates a Docker image and generates a Helm chart for the specified Habitat \
@@ -92,8 +98,7 @@ fn cli<'a, 'b>() -> clap::App<'a, 'b> {
                 .short("V")
                 .long("version")
                 .validator(valid_version)
-                .help("Version of the chart to create")
-                .default_value(chartfile::DEFAULT_VERSION),
+                .help(&VERSION_HELP),
         )
         .arg(
             Arg::with_name("DESCRIPTION")

--- a/components/pkg-export-kubernetes/src/manifestjson.rs
+++ b/components/pkg-export-kubernetes/src/manifestjson.rs
@@ -42,7 +42,7 @@ impl ManifestJson {
     pub fn new(manifest: &Manifest) -> Self {
         let main = json!({
             "metadata_name": manifest.metadata_name,
-            "service_name": manifest.service_name,
+            "service_name": manifest.pkg_ident.name,
             "image": manifest.image,
             "count": manifest.count,
             "service_topology": manifest.service_topology.to_string(),


### PR DESCRIPTION
Please read https://github.com/habitat-sh/habitat/pull/4638 for rationale for these changes, especially https://github.com/habitat-sh/habitat/pull/4638#issuecomment-367686986.

*WARNING:* This changes the behavior of the Helm exporter. After these changes, the generated chart source directory will no longer have version and release suffix in the name. e.g if before these changes, the exporter produced a directory named `nginx-1.11.10-20180216165808`, it will now create it as `nginx`.