### PR TITLE
Launcher now reaps orphaned zombie processes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -704,7 +704,7 @@ dependencies = [
 [[package]]
 name = "habitat_core"
 version = "0.0.0"
-source = "git+https://github.com/habitat-sh/core.git#a2ee9f2118240eaadbb1cb39763f049a603568ed"
+source = "git+https://github.com/habitat-sh/core.git#f1d4109c651b52dfc00016f9e4cf7fba6d3222ae"
 dependencies = [
  "ansi_term 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -912,7 +912,7 @@ dependencies = [
 [[package]]
 name = "habitat_win_users"
 version = "0.0.0"
-source = "git+https://github.com/habitat-sh/core.git#a2ee9f2118240eaadbb1cb39763f049a603568ed"
+source = "git+https://github.com/habitat-sh/core.git#f1d4109c651b52dfc00016f9e4cf7fba6d3222ae"
 dependencies = [
  "gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
![tenor-4706015](https://user-images.githubusercontent.com/207178/36744082-e50ba3a2-1bb9-11e8-9d40-b69045f16a0a.gif)
![tenor-10240249](https://user-images.githubusercontent.com/207178/36744077-e1798c90-1bb9-11e8-90f6-7a9d2efee82a.gif)
![tenor-25218364](https://user-images.githubusercontent.com/207178/36744083-e7c51574-1bb9-11e8-82f6-aecaa945a295.gif)

For details, read the commit messages.

⚠️ Alert! ⚠️ 
Requires habitat-sh/core#9 to merge first! DO NOT MERGE BEFORE THAT! Until then, if you want to test this locally, follow the instructions in the second commit; sorry.

Closes #4412 
