### PR TITLE
use join for x-plat friendly root paths

### DIFF
--- a/components/sup/src/fs.rs
+++ b/components/sup/src/fs.rs
@@ -18,11 +18,11 @@ use hcore::fs::FS_ROOT_PATH;
 lazy_static! {
     /// The root path containing all runtime service directories and files
     pub static ref SVC_ROOT: PathBuf = {
-        Path::new(&*FS_ROOT_PATH).join("hab/svc")
+        Path::new(&*FS_ROOT_PATH).join("hab").join("svc")
     };
 
     pub static ref USER_ROOT: PathBuf = {
-        Path::new(&*FS_ROOT_PATH).join("hab/user")
+        Path::new(&*FS_ROOT_PATH).join("hab").join("user")
     };
 }
 


### PR DESCRIPTION
This ensures that `SVC_ROOT` and `SVC_USER` file path slashes are OS native. Specifically making them backslashes on Windows.

While almost all apps on windows handle forward slashes just as well as backslashes there are a few (like SQL Server 2016 (unlike 2017)) that may not understand forward slashes. This should fix those cases.

Related to https://github.com/habitat-sh/core/pull/12

Signed-off-by: mwrock <matt@mattwrock.com>