### PR TITLE
Updates for migration to Habitat access tokens

### DIFF
--- a/components/hab/src/command/cli/setup.rs
+++ b/components/hab/src/command/cli/setup.rs
@@ -110,20 +110,19 @@ pub fn start(ui: &mut UI, cache_path: &Path, analytics_path: &Path) -> Result<()
     } else {
         ui.para("Okay, maybe another time.")?;
     }
-    ui.heading("GitHub Access Token")?;
+    ui.heading("Habitat Personal Access Token")?;
     ui.para(
         "While you can build and run Habitat packages without sharing them on the public \
                depot, doing so allows you to collaborate with the Habitat community. In \
                addition, it is how you can perform continuous deployment with Habitat.",
     )?;
     ui.para(
-        "The GitHub personal access token needs the user:email and read:org OAuth scopes. \
-               Habitat uses the information provided through these scopes for \
-               authentication and to determine features based on team membership. You can \
-               set this up at https://github.com/settings/tokens",
+        "The Habitat personal access token can be generated via the Habitat Builder web \
+               site Profile page (https://bldr.habitat.sh/#/profile). Once you have \
+               generated your token, you can enter it here.",
     )?;
     ui.para(
-        "If you would like to share your packages on the depot, please enter your GitHub \
+        "If you would like to share your packages on the depot, please enter your Habitat \
                access token. Otherwise, just enter No.",
     )?;
     ui.para(
@@ -132,7 +131,7 @@ pub fn start(ui: &mut UI, cache_path: &Path, analytics_path: &Path) -> Result<()
     )?;
     if ask_default_auth_token(ui)? {
         ui.br()?;
-        ui.para("Enter your GitHub access token.")?;
+        ui.para("Enter your Habitat personal access token.")?;
         let auth_token = prompt_auth_token(ui)?;
         write_cli_config_auth_token(&auth_token)?;
     } else {
@@ -226,7 +225,7 @@ fn prompt_origin(ui: &mut UI) -> Result<String> {
 
 fn ask_default_auth_token(ui: &mut UI) -> Result<bool> {
     Ok(ui.prompt_yes_no(
-        "Set up a default GitHub access token?",
+        "Set up a default Habitat personal access token?",
         Some(true),
     )?)
 }
@@ -244,7 +243,7 @@ fn prompt_auth_token(ui: &mut UI) -> Result<String> {
         None => env::var(AUTH_TOKEN_ENVVAR).ok(),
     };
     Ok(ui.prompt_ask(
-        "GitHub access token",
+        "Habitat personal access token",
         default.as_ref().map(|x| &**x),
     )?)
 }

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -167,7 +167,7 @@ fn start(ui: &mut UI) -> Result<()> {
                 ("install", Some(m)) => sub_pkg_install(ui, m)?,
                 ("path", Some(m)) => sub_pkg_path(m)?,
                 ("provides", Some(m)) => sub_pkg_provides(m)?,
-                ("search", Some(m)) => sub_pkg_search(m)?,
+                ("search", Some(m)) => sub_pkg_search(ui, m)?,
                 ("sign", Some(m)) => sub_pkg_sign(ui, m)?,
                 ("upload", Some(m)) => sub_pkg_upload(ui, m)?,
                 ("verify", Some(m)) => sub_pkg_verify(ui, m)?,
@@ -247,7 +247,7 @@ fn sub_origin_key_download(ui: &mut UI, m: &ArgMatches) -> Result<()> {
     let revision = m.value_of("REVISION");
     let with_secret = m.is_present("WITH_SECRET");
     let with_encryption = m.is_present("WITH_ENCRYPTION");
-    let token = maybe_auth_token(&m);
+    let token = maybe_auth_token(ui, &m);
     let url = bldr_url_from_matches(m);
 
     command::origin::key::download::start(
@@ -292,7 +292,7 @@ fn sub_origin_key_import(ui: &mut UI) -> Result<()> {
 
 fn sub_origin_key_upload(ui: &mut UI, m: &ArgMatches) -> Result<()> {
     let url = bldr_url_from_matches(m);
-    let token = auth_token_param_or_env(&m)?;
+    let token = auth_token_param_or_env(ui, &m)?;
 
     init();
 
@@ -429,7 +429,7 @@ fn sub_bldr_channel_create(ui: &mut UI, m: &ArgMatches) -> Result<()> {
     let url = bldr_url_from_matches(m);
     let origin = origin_param_or_env(&m)?;
     let channel = m.value_of("CHANNEL").unwrap(); // Required via clap
-    let token = auth_token_param_or_env(&m)?;
+    let token = auth_token_param_or_env(ui, &m)?;
     command::bldr::channel::create::start(ui, &url, &token, &origin, &channel)
 }
 
@@ -437,7 +437,7 @@ fn sub_bldr_channel_destroy(ui: &mut UI, m: &ArgMatches) -> Result<()> {
     let url = bldr_url_from_matches(m);
     let origin = origin_param_or_env(&m)?;
     let channel = m.value_of("CHANNEL").unwrap(); // Required via clap
-    let token = auth_token_param_or_env(&m)?;
+    let token = auth_token_param_or_env(ui, &m)?;
     command::bldr::channel::destroy::start(ui, &url, &token, &origin, &channel)
 }
 
@@ -451,14 +451,14 @@ fn sub_bldr_job_start(ui: &mut UI, m: &ArgMatches) -> Result<()> {
     let ident = PackageIdent::from_str(m.value_of("PKG_IDENT").unwrap())?; // Required via clap
     let url = bldr_url_from_matches(m);
     let group = m.is_present("GROUP");
-    let token = auth_token_param_or_env(&m)?;
+    let token = auth_token_param_or_env(ui, &m)?;
     command::bldr::job::start::start(ui, &url, &ident, &token, group)
 }
 
 fn sub_bldr_job_cancel(ui: &mut UI, m: &ArgMatches) -> Result<()> {
     let url = bldr_url_from_matches(m);
     let group_id = m.value_of("GROUP_ID").unwrap(); // Required via clap
-    let token = auth_token_param_or_env(&m)?;
+    let token = auth_token_param_or_env(ui, &m)?;
     command::bldr::job::cancel::start(ui, &url, &group_id, &token)
 }
 
@@ -469,7 +469,7 @@ fn sub_bldr_job_promote_or_demote(ui: &mut UI, m: &ArgMatches, promote: bool) ->
     let origin = m.value_of("ORIGIN");
     let interactive = m.is_present("INTERACTIVE");
     let verbose = m.is_present("VERBOSE");
-    let token = auth_token_param_or_env(&m)?;
+    let token = auth_token_param_or_env(ui, &m)?;
     command::bldr::job::promote::start(
         ui,
         &url,
@@ -522,7 +522,7 @@ fn sub_pkg_install(ui: &mut UI, m: &ArgMatches) -> Result<()> {
     let url = bldr_url_from_matches(m);
     let channel = channel_from_matches(m);
     let install_sources = install_sources_from_matches(m)?;
-    let token = maybe_auth_token(&m);
+    let token = maybe_auth_token(ui, &m);
 
     init();
 
@@ -569,10 +569,10 @@ fn sub_pkg_provides(m: &ArgMatches) -> Result<()> {
     command::pkg::provides::start(&filename, &*FS_ROOT, full_releases, full_paths)
 }
 
-fn sub_pkg_search(m: &ArgMatches) -> Result<()> {
+fn sub_pkg_search(ui: &mut UI, m: &ArgMatches) -> Result<()> {
     let url = bldr_url_from_matches(m);
     let search_term = m.value_of("SEARCH_TERM").unwrap(); // Required via clap
-    let token = maybe_auth_token(&m);
+    let token = maybe_auth_token(ui, &m);
     command::pkg::search::start(&search_term, &url, token.as_ref().map(String::as_str))
 }
 
@@ -597,7 +597,7 @@ fn sub_pkg_upload(ui: &mut UI, m: &ArgMatches) -> Result<()> {
     // they can optionally get added to another channel, too.
     let additional_release_channel: Option<&str> = m.value_of("CHANNEL");
 
-    let token = auth_token_param_or_env(&m)?;
+    let token = auth_token_param_or_env(ui, &m)?;
     let artifact_paths = m.values_of("HART_FILE").unwrap(); // Required via clap
     for artifact_path in artifact_paths {
         command::pkg::upload::start(
@@ -629,7 +629,7 @@ fn sub_pkg_header(ui: &mut UI, m: &ArgMatches) -> Result<()> {
 fn sub_pkg_promote(ui: &mut UI, m: &ArgMatches) -> Result<()> {
     let url = bldr_url_from_matches(m);
     let channel = m.value_of("CHANNEL").unwrap();
-    let token = auth_token_param_or_env(&m)?;
+    let token = auth_token_param_or_env(ui, &m)?;
     let ident = PackageIdent::from_str(m.value_of("PKG_IDENT").unwrap())?; // Required via clap
     command::pkg::promote::start(ui, &url, &ident, &channel, &token)
 }
@@ -637,7 +637,7 @@ fn sub_pkg_promote(ui: &mut UI, m: &ArgMatches) -> Result<()> {
 fn sub_pkg_demote(ui: &mut UI, m: &ArgMatches) -> Result<()> {
     let url = bldr_url_from_matches(m);
     let channel = m.value_of("CHANNEL").unwrap();
-    let token = auth_token_param_or_env(&m)?;
+    let token = auth_token_param_or_env(ui, &m)?;
     let ident = PackageIdent::from_str(m.value_of("PKG_IDENT").unwrap())?; // Required via clap
     command::pkg::demote::start(ui, &url, &ident, &channel, &token)
 }
@@ -645,7 +645,7 @@ fn sub_pkg_demote(ui: &mut UI, m: &ArgMatches) -> Result<()> {
 fn sub_pkg_channels(ui: &mut UI, m: &ArgMatches) -> Result<()> {
     let url = bldr_url_from_matches(m);
     let ident = PackageIdent::from_str(m.value_of("PKG_IDENT").unwrap())?; // Required via clap
-    let token = maybe_auth_token(&m);
+    let token = maybe_auth_token(ui, &m);
 
     command::pkg::channels::start(ui, &url, &ident, token.as_ref().map(String::as_str))
 }
@@ -771,12 +771,20 @@ fn raw_parse_args() -> (Vec<OsString>, Vec<OsString>) {
 /// Check to see if the user has passed in an AUTH_TOKEN param. If not, check the
 /// HAB_AUTH_TOKEN env var. If not, check the CLI config to see if there is a default auth
 /// token set. If that's empty too, then error.
-fn auth_token_param_or_env(m: &ArgMatches) -> Result<String> {
+fn auth_token_param_or_env(ui: &mut UI, m: &ArgMatches) -> Result<String> {
     match m.value_of("AUTH_TOKEN") {
         Some(o) => Ok(o.to_string()),
         None => {
             match henv::var(AUTH_TOKEN_ENVVAR) {
-                Ok(v) => Ok(v),
+                Ok(v) => {
+                    // Temporary warning until we deprecate Github tokens completely
+                    if !v.starts_with("_") {
+                        ui.warn(
+                            "WARNING: Github tokens are being deprecated, please migrate to a Habitat Personal Access Token instead."
+                        ).unwrap();
+                    }
+                    Ok(v)
+                }
                 Err(_) => {
                     let config = config::load()?;
                     match config.auth_token {
@@ -792,9 +800,17 @@ fn auth_token_param_or_env(m: &ArgMatches) -> Result<String> {
 /// Check to see if an auth token exists and convert it to a string slice if it does. Unlike
 /// auth_token_param_or_env, it's ok for no auth token to be present here. This is useful for
 /// commands that can optionally take an auth token for operating on private packages.
-fn maybe_auth_token(m: &ArgMatches) -> Option<String> {
-    match auth_token_param_or_env(&m) {
-        Ok(t) => Some(t),
+fn maybe_auth_token(ui: &mut UI, m: &ArgMatches) -> Option<String> {
+    match auth_token_param_or_env(ui, &m) {
+        Ok(t) => {
+            // Temporary warning until we deprecate Github tokens completely
+            if !t.starts_with("_") {
+                ui.warn(
+                    "WARNING: Github tokens are being deprecated, please migrate to a Habitat Personal Access Token instead."
+                ).unwrap();
+            }
+            Some(t)
+        }
         Err(_) => None,
     }
 }

--- a/www/source/partials/docs/_dev-pkgs-share.html.md.erb
+++ b/www/source/partials/docs/_dev-pkgs-share.html.md.erb
@@ -27,7 +27,7 @@ You can create your own origin in Builder or be invited to join an existing one.
 
 ### Set up hab to authenticate to Builder
 
-When you upload a package to Builder, you are required to supply an OAuth token as part of the `hab pkg upload` subcommand. Because Builder uses GitHub to authenticate, you must generate a [GitHub access token](https://help.github.com/articles/creating-an-access-token-for-command-line-use/) for use with the `hab` command-line utility.
+When you upload a package to Builder, you are required to supply an auth token as part of the `hab pkg upload` subcommand. You can generate a Habitat personal access token via the Builder site [Profile page](https://bldr.habitat.sh/#/profile) for use with the `hab` command-line utility.
 
 Once you have this token, you can set the `HAB_AUTH_TOKEN` [environment variable](/docs/reference#environment-variables) to this value, so that any commands requiring authentication will use it.
 

--- a/www/source/partials/tutorials/_upload_package.html.md.erb
+++ b/www/source/partials/tutorials/_upload_package.html.md.erb
@@ -6,7 +6,7 @@ If you built your package locally, you need to upload it to Builder for others t
 
 ## Set Up hab to Authenticate with Builder
 
-Whether you upload a package to Builder or promote a package for CI/CD scenarios in Builder, you are required to supply an OAuth token as part of those operations. Because Builder uses GitHub to authenticate, follow the steps to generate a [GitHub access token](https://help.github.com/articles/creating-an-access-token-for-command-line-use/). Save that token value and/or set the `HAB_AUTH_TOKEN` [environment variable](/docs/reference#environment-variables) to it. You will need it later.
+Whether you upload a package to Builder or promote a package for CI/CD scenarios in Builder, you are required to supply an access token as part of those operations. You can generate a Habitat personal access token via the Builder site [Profile page](https://bldr.habitat.sh/#/profile). Save that token value and/or set the `HAB_AUTH_TOKEN` [environment variable](/docs/reference#environment-variables) to it. You will need it later.
 
 Once you have created this token, you can either skip down to [promoting your package to the stable channel](#promote) if you built your package with Builder, or proceed to the next section to learn how to upload your public key and package to Builder.
 


### PR DESCRIPTION
This change makes a few updates for the transition to Habitat personal access tokens:
* Changes hab setup to refer to Habitat tokens
* Updates doc & tutorials to refer to Habitat tokens and point to the builder site
* Adds a temporary warning regarding migration when the hab cli uses a Github auth token

Signed-off-by: Salim Alam <salam@chef.io>

Closes: #4709

![tenor-220574380](https://user-images.githubusercontent.com/13542112/37068610-69c28ea8-2164-11e8-9243-6e02fbd3ea84.gif)
