### PR TITLE
More complete Helm exporter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -800,6 +800,7 @@ dependencies = [
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/components/pkg-export-helm/Cargo.toml
+++ b/components/pkg-export-helm/Cargo.toml
@@ -25,6 +25,7 @@ serde = "1.0.2"
 serde_json = "1.0.0"
 failure = { git = "https://github.com/withoutboats/failure.git" }
 failure_derive = { git = "https://github.com/withoutboats/failure_derive.git" }
+url = "*"
 
 [features]
 default = []

--- a/components/pkg-export-helm/defaults/HelmChartFile.hbs
+++ b/components/pkg-export-helm/defaults/HelmChartFile.hbs
@@ -9,3 +9,6 @@ appVersion: {{appVersion}}
 {{~ #if home}}
 home: {{home}}
 {{~ /if ~}}
+{{~ #if icon}}
+icon: {{icon}}
+{{~ /if ~}}

--- a/components/pkg-export-helm/defaults/HelmChartFile.hbs
+++ b/components/pkg-export-helm/defaults/HelmChartFile.hbs
@@ -3,3 +3,6 @@ version: {{version}}
 {{~ #if description}}
 description: {{description}}
 {{~/if ~}}
+{{~ #if appVersion}}
+appVersion: {{appVersion}}
+{{~ /if ~}}

--- a/components/pkg-export-helm/defaults/HelmChartFile.hbs
+++ b/components/pkg-export-helm/defaults/HelmChartFile.hbs
@@ -6,3 +6,6 @@ description: {{description}}
 {{~ #if appVersion}}
 appVersion: {{appVersion}}
 {{~ /if ~}}
+{{~ #if home}}
+home: {{home}}
+{{~ /if ~}}

--- a/components/pkg-export-helm/defaults/HelmChartFile.hbs
+++ b/components/pkg-export-helm/defaults/HelmChartFile.hbs
@@ -7,6 +7,12 @@ description: {{description}}
 {{~ #if appVersion}}
 appVersion: {{appVersion}}
 {{~ /if ~}}
+{{~ #if keywords}}
+keywords:
+{{~ #each keywords}}
+  - {{this}}
+{{~ /each ~}}
+{{~ /if ~}}
 {{~ #if home}}
 home: {{home}}
 {{~ /if ~}}

--- a/components/pkg-export-helm/defaults/HelmChartFile.hbs
+++ b/components/pkg-export-helm/defaults/HelmChartFile.hbs
@@ -12,3 +12,6 @@ home: {{home}}
 {{~ #if icon}}
 icon: {{icon}}
 {{~ /if ~}}
+{{~ #if deprecated}}
+deprecated: yes
+{{~ /if ~}}

--- a/components/pkg-export-helm/defaults/HelmChartFile.hbs
+++ b/components/pkg-export-helm/defaults/HelmChartFile.hbs
@@ -19,6 +19,12 @@ home: {{home}}
 {{~ #if icon}}
 icon: {{icon}}
 {{~ /if ~}}
+{{~ #if sources}}
+sources:
+{{~ #each sources}}
+  - {{this}}
+{{~ /each ~}}
+{{~ /if ~}}
 {{~ #if deprecated}}
 deprecated: yes
 {{~ /if ~}}

--- a/components/pkg-export-helm/defaults/HelmChartFile.hbs
+++ b/components/pkg-export-helm/defaults/HelmChartFile.hbs
@@ -2,4 +2,4 @@ name: {{name}}
 version: {{version}}
 {{~ #if description}}
 description: {{description}}
-{{/if ~}}
+{{~/if ~}}

--- a/components/pkg-export-helm/defaults/HelmChartFile.hbs
+++ b/components/pkg-export-helm/defaults/HelmChartFile.hbs
@@ -1,5 +1,6 @@
 name: {{name}}
 version: {{version}}
+tillerVersion: ">=2.7.2"
 {{~ #if description}}
 description: {{description}}
 {{~/if ~}}

--- a/components/pkg-export-helm/defaults/HelmChartFile.hbs
+++ b/components/pkg-export-helm/defaults/HelmChartFile.hbs
@@ -25,6 +25,18 @@ sources:
   - {{this}}
 {{~ /each ~}}
 {{~ /if ~}}
+{{~ #if maintainers}}
+maintainers:
+{{~ #each maintainers}}
+  - name: {{this.name}}
+  {{~ #if this.email}}
+    email: {{this.email}}
+  {{~ /if ~}}
+  {{~ #if this.url}}
+    url: {{this.url}}
+  {{~ /if ~}}
+{{~ /each ~}}
+{{~ /if ~}}
 {{~ #if deprecated}}
 deprecated: yes
 {{~ /if ~}}

--- a/components/pkg-export-helm/src/chart.rs
+++ b/components/pkg-export-helm/src/chart.rs
@@ -43,7 +43,7 @@ impl<'a> Chart<'a> {
             None
         };
         let manifest = Manifest::new_from_cli_matches(ui, &matches, image)?;
-        let chartfile = ChartFile::new_from_cli_matches(&matches, &manifest.pkg_ident);
+        let chartfile = ChartFile::new_from_cli_matches(&matches, &manifest.pkg_ident)?;
         let deps = Deps::new_for_cli_matches(&matches);
 
         let mut chartdir = PathBuf::new();

--- a/components/pkg-export-helm/src/chart.rs
+++ b/components/pkg-export-helm/src/chart.rs
@@ -43,26 +43,14 @@ impl<'a> Chart<'a> {
             None
         };
         let manifest = Manifest::new_from_cli_matches(ui, &matches, image)?;
-
-        let name = matches
-            .value_of("CHART")
-            .unwrap_or(&manifest.pkg_ident.name)
-            .to_string();
-        let pkg_version = manifest.pkg_ident.version.clone();
-        let version = matches.value_of("VERSION").or(
-            pkg_version.as_ref().map(|s| {
-                s.as_ref()
-            }),
-        );
-        let description = matches.value_of("DESCRIPTION");
-        let chartfile = ChartFile::new(&name, version, description);
+        let chartfile = ChartFile::new_from_cli_matches(&matches, &manifest.pkg_ident);
         let deps = Deps::new_for_cli_matches(&matches);
 
         let mut chartdir = PathBuf::new();
         if let Some(o) = matches.value_of_os("OUTPUTDIR") {
             chartdir.push(o);
         }
-        chartdir.push(&name);
+        chartdir.push(&chartfile.name);
 
         Ok(Self::new_for_manifest(
             manifest,

--- a/components/pkg-export-helm/src/chartfile.rs
+++ b/components/pkg-export-helm/src/chartfile.rs
@@ -31,6 +31,7 @@ pub struct ChartFile {
     pub app_version: Option<String>,
     pub home: Option<String>,
     pub icon: Option<String>,
+    pub deprecated: bool,
 }
 
 impl ChartFile {
@@ -55,6 +56,7 @@ impl ChartFile {
         let description = matches.value_of("DESCRIPTION").map(|s| s.to_owned());
         let home = matches.value_of("HOME").map(|s| s.to_owned());
         let icon = matches.value_of("ICON").map(|s| s.to_owned());
+        let deprecated = matches.is_present("DEPRECATED");
 
         ChartFile {
             name,
@@ -63,6 +65,7 @@ impl ChartFile {
             app_version,
             home,
             icon,
+            deprecated,
         }
     }
 
@@ -75,6 +78,7 @@ impl ChartFile {
             "appVersion": self.app_version,
             "home": self.home,
             "icon": self.icon,
+            "deprecated": self.deprecated,
         });
 
         Handlebars::new()

--- a/components/pkg-export-helm/src/chartfile.rs
+++ b/components/pkg-export-helm/src/chartfile.rs
@@ -32,6 +32,7 @@ pub struct ChartFile {
     pub home: Option<String>,
     pub icon: Option<String>,
     pub deprecated: bool,
+    pub keywords: Vec<String>,
 }
 
 impl ChartFile {
@@ -57,6 +58,10 @@ impl ChartFile {
         let home = matches.value_of("HOME").map(|s| s.to_owned());
         let icon = matches.value_of("ICON").map(|s| s.to_owned());
         let deprecated = matches.is_present("DEPRECATED");
+        let keywords = matches
+            .values_of("KEYWORD")
+            .map(|args| args.map(|k| k.to_owned()).collect())
+            .unwrap_or(vec![]);
 
         ChartFile {
             name,
@@ -66,6 +71,7 @@ impl ChartFile {
             home,
             icon,
             deprecated,
+            keywords,
         }
     }
 
@@ -79,6 +85,7 @@ impl ChartFile {
             "home": self.home,
             "icon": self.icon,
             "deprecated": self.deprecated,
+            "keywords": self.keywords,
         });
 
         Handlebars::new()

--- a/components/pkg-export-helm/src/chartfile.rs
+++ b/components/pkg-export-helm/src/chartfile.rs
@@ -12,10 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use clap;
 use failure::SyncFailure;
 use handlebars::Handlebars;
 
 use export_docker::Result;
+use hcore::package::PackageIdent;
 
 pub const DEFAULT_VERSION: &'static str = "0.0.1";
 
@@ -23,17 +25,29 @@ pub const DEFAULT_VERSION: &'static str = "0.0.1";
 const CHARTFILE: &'static str = include_str!("../defaults/HelmChartFile.hbs");
 
 pub struct ChartFile {
-    name: String,
-    version: String,
-    description: Option<String>,
+    pub name: String,
+    pub version: String,
+    pub description: Option<String>,
 }
 
 impl ChartFile {
-    pub fn new(name: &str, version: Option<&str>, description: Option<&str>) -> Self {
+    pub fn new_from_cli_matches(matches: &clap::ArgMatches, pkg_ident: &PackageIdent) -> Self {
+        let name = matches
+            .value_of("CHART")
+            .unwrap_or(&pkg_ident.name)
+            .to_string();
+        let pkg_version = pkg_ident.version.as_ref();
+        let version = matches
+            .value_of("VERSION")
+            .or(pkg_version.map(|s| s.as_ref()))
+            .unwrap_or(DEFAULT_VERSION)
+            .to_owned();
+        let description = matches.value_of("DESCRIPTION").map(|s| s.to_owned());
+
         ChartFile {
-            name: name.to_owned(),
-            version: version.unwrap_or(DEFAULT_VERSION).to_owned(),
-            description: description.map(|s| s.to_owned()),
+            name,
+            version,
+            description,
         }
     }
 

--- a/components/pkg-export-helm/src/chartfile.rs
+++ b/components/pkg-export-helm/src/chartfile.rs
@@ -33,6 +33,7 @@ pub struct ChartFile {
     pub icon: Option<String>,
     pub deprecated: bool,
     pub keywords: Vec<String>,
+    pub sources: Vec<String>,
 }
 
 impl ChartFile {
@@ -62,6 +63,10 @@ impl ChartFile {
             .values_of("KEYWORD")
             .map(|args| args.map(|k| k.to_owned()).collect())
             .unwrap_or(vec![]);
+        let sources = matches
+            .values_of("SOURCE")
+            .map(|args| args.map(|k| k.to_owned()).collect())
+            .unwrap_or(vec![]);
 
         ChartFile {
             name,
@@ -72,6 +77,7 @@ impl ChartFile {
             icon,
             deprecated,
             keywords,
+            sources,
         }
     }
 
@@ -86,6 +92,7 @@ impl ChartFile {
             "icon": self.icon,
             "deprecated": self.deprecated,
             "keywords": self.keywords,
+            "sources": self.sources,
         });
 
         Handlebars::new()

--- a/components/pkg-export-helm/src/chartfile.rs
+++ b/components/pkg-export-helm/src/chartfile.rs
@@ -28,6 +28,7 @@ pub struct ChartFile {
     pub name: String,
     pub version: String,
     pub description: Option<String>,
+    pub app_version: Option<String>,
 }
 
 impl ChartFile {
@@ -42,12 +43,20 @@ impl ChartFile {
             .or(pkg_version.map(|s| s.as_ref()))
             .unwrap_or(DEFAULT_VERSION)
             .to_owned();
+        let app_version = pkg_version.map(|v| {
+            pkg_ident
+                .release
+                .as_ref()
+                .map(|r| format!("{}-{}", v, r))
+                .unwrap_or(v.to_string())
+        });
         let description = matches.value_of("DESCRIPTION").map(|s| s.to_owned());
 
         ChartFile {
             name,
             version,
             description,
+            app_version,
         }
     }
 
@@ -57,6 +66,7 @@ impl ChartFile {
             "name": self.name,
             "version": self.version,
             "description": self.description,
+            "appVersion": self.app_version,
         });
 
         Handlebars::new()

--- a/components/pkg-export-helm/src/chartfile.rs
+++ b/components/pkg-export-helm/src/chartfile.rs
@@ -29,6 +29,7 @@ pub struct ChartFile {
     pub version: String,
     pub description: Option<String>,
     pub app_version: Option<String>,
+    pub home: Option<String>,
 }
 
 impl ChartFile {
@@ -51,12 +52,14 @@ impl ChartFile {
                 .unwrap_or(v.to_string())
         });
         let description = matches.value_of("DESCRIPTION").map(|s| s.to_owned());
+        let home = matches.value_of("HOME").map(|s| s.to_owned());
 
         ChartFile {
             name,
             version,
             description,
             app_version,
+            home,
         }
     }
 
@@ -67,6 +70,7 @@ impl ChartFile {
             "version": self.version,
             "description": self.description,
             "appVersion": self.app_version,
+            "home": self.home,
         });
 
         Handlebars::new()

--- a/components/pkg-export-helm/src/chartfile.rs
+++ b/components/pkg-export-helm/src/chartfile.rs
@@ -30,6 +30,7 @@ pub struct ChartFile {
     pub description: Option<String>,
     pub app_version: Option<String>,
     pub home: Option<String>,
+    pub icon: Option<String>,
 }
 
 impl ChartFile {
@@ -53,6 +54,7 @@ impl ChartFile {
         });
         let description = matches.value_of("DESCRIPTION").map(|s| s.to_owned());
         let home = matches.value_of("HOME").map(|s| s.to_owned());
+        let icon = matches.value_of("ICON").map(|s| s.to_owned());
 
         ChartFile {
             name,
@@ -60,6 +62,7 @@ impl ChartFile {
             description,
             app_version,
             home,
+            icon,
         }
     }
 
@@ -71,6 +74,7 @@ impl ChartFile {
             "description": self.description,
             "appVersion": self.app_version,
             "home": self.home,
+            "icon": self.icon,
         });
 
         Handlebars::new()

--- a/components/pkg-export-helm/src/error.rs
+++ b/components/pkg-export-helm/src/error.rs
@@ -20,4 +20,10 @@ pub enum Error {
                       please run `helm init -c`.",
            _0)]
     HelmNotSetup(String),
+    #[fail(display = "Invalid maintainer specification '{}', must be of the form \
+                      NAME[,EMAIL[,URL]]",
+           _0)]
+    InvalidMaintainer(String),
+    #[fail(display = "Invalid URL '{}': {}", _0, _1)]
+    InvalidUrl(String, String),
 }

--- a/components/pkg-export-helm/src/main.rs
+++ b/components/pkg-export-helm/src/main.rs
@@ -25,6 +25,7 @@ extern crate lazy_static;
 extern crate log;
 #[macro_use]
 extern crate serde_json;
+extern crate url;
 
 extern crate failure;
 #[macro_use]
@@ -44,6 +45,7 @@ use common::ui::UI;
 use export_docker::Result;
 use export_k8s::Cli;
 use hcore::PROGRAM_NAME;
+use url::Url;
 
 use chart::Chart;
 
@@ -107,6 +109,13 @@ fn cli<'a, 'b>() -> clap::App<'a, 'b> {
                 .help("A single-sentence description"),
         )
         .arg(
+            Arg::with_name("HOME")
+                .value_name("URL")
+                .long("home")
+                .validator(valid_url)
+                .help("The URL of the project's home page"),
+        )
+        .arg(
             Arg::with_name("OPERATOR_VERSION")
                 .value_name("OPERATOR_VERSION")
                 .long("operator-version")
@@ -145,6 +154,13 @@ fn valid_version(val: String) -> result::Result<(), String> {
     }
 
     Ok(())
+}
+
+fn valid_url(val: String) -> result::Result<(), String> {
+    match Url::parse(&val) {
+        Ok(_) => Ok(()),
+        Err(_) => Err(format!("URL: '{}' is not valid", &val)),
+    }
 }
 
 #[cfg(test)]

--- a/components/pkg-export-helm/src/main.rs
+++ b/components/pkg-export-helm/src/main.rs
@@ -130,6 +130,15 @@ fn cli<'a, 'b>() -> clap::App<'a, 'b> {
                 .validator(valid_url)
                 .help("A URL of an SVG or PNG image to be used as an icon"),
         )
+        .arg(
+            Arg::with_name("SOURCE")
+                .value_name("URL")
+                .long("source")
+                .short("s")
+                .multiple(true)
+                .validator(valid_url)
+                .help("A URL to the source code for the project"),
+        )
         .arg(Arg::with_name("DEPRECATED").long("depr").help(
             "Mark this chart as deprecated",
         ))

--- a/components/pkg-export-helm/src/main.rs
+++ b/components/pkg-export-helm/src/main.rs
@@ -114,6 +114,16 @@ fn cli<'a, 'b>() -> clap::App<'a, 'b> {
                 .help("Version of the Habitat operator to set as dependency")
                 .default_value(deps::DEFAULT_OPERATOR_VERSION),
         )
+        .arg(
+            Arg::with_name("OUTPUTDIR")
+                .value_name("OUTPUTDIR")
+                .short("o")
+                .long("output-dir")
+                .help(
+                    "The directory to put the chart directory under (default: current working \
+                       directory)",
+                ),
+        )
         .arg(Arg::with_name("DOWNLOAD_DEPS").long("download-deps").help(
             "Whether to download dependencies. The Kubernetes Habitat Operator is the only \
              dependancy currently. (default: no)",

--- a/components/pkg-export-helm/src/main.rs
+++ b/components/pkg-export-helm/src/main.rs
@@ -122,6 +122,9 @@ fn cli<'a, 'b>() -> clap::App<'a, 'b> {
                 .validator(valid_url)
                 .help("A URL of an SVG or PNG image to be used as an icon"),
         )
+        .arg(Arg::with_name("DEPRECATED").long("depr").help(
+            "Mark this chart as deprecated",
+        ))
         .arg(
             Arg::with_name("OPERATOR_VERSION")
                 .value_name("OPERATOR_VERSION")

--- a/components/pkg-export-helm/src/main.rs
+++ b/components/pkg-export-helm/src/main.rs
@@ -116,6 +116,13 @@ fn cli<'a, 'b>() -> clap::App<'a, 'b> {
                 .help("The URL of the project's home page"),
         )
         .arg(
+            Arg::with_name("ICON")
+                .value_name("URL")
+                .long("icon")
+                .validator(valid_url)
+                .help("A URL of an SVG or PNG image to be used as an icon"),
+        )
+        .arg(
             Arg::with_name("OPERATOR_VERSION")
                 .value_name("OPERATOR_VERSION")
                 .long("operator-version")

--- a/components/pkg-export-helm/src/main.rs
+++ b/components/pkg-export-helm/src/main.rs
@@ -109,6 +109,14 @@ fn cli<'a, 'b>() -> clap::App<'a, 'b> {
                 .help("A single-sentence description"),
         )
         .arg(
+            Arg::with_name("KEYWORD")
+                .value_name("KEYWORD")
+                .long("keyword")
+                .short("k")
+                .multiple(true)
+                .help("A keyword for this project"),
+        )
+        .arg(
             Arg::with_name("HOME")
                 .value_name("URL")
                 .long("home")

--- a/components/pkg-export-helm/src/maintainer.rs
+++ b/components/pkg-export-helm/src/maintainer.rs
@@ -1,0 +1,85 @@
+// Copyright (c) 2018 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::str::FromStr;
+use std::string::ToString;
+use std::result;
+use clap::ArgMatches;
+use serde_json;
+use url::Url;
+
+use export_docker::Result;
+
+use error::Error;
+
+#[derive(Clone, Debug)]
+pub struct Maintainer {
+    name: String,
+    email: Option<String>,
+    url: Option<String>,
+}
+
+impl Maintainer {
+    pub fn from_args(matches: &ArgMatches) -> Result<Vec<Self>> {
+        let mut maintainers = Vec::new();
+
+        if let Some(args) = matches.values_of("MAINTAINER") {
+            for arg in args {
+                let m = arg.parse::<Self>()?;
+
+                maintainers.push(m);
+            }
+        };
+
+        Ok(maintainers)
+    }
+
+    pub fn to_json(&self) -> serde_json::Value {
+        json!({
+            "name": self.name,
+            "email": self.email,
+            "url": self.url,
+        })
+    }
+}
+
+impl FromStr for Maintainer {
+    type Err = Error;
+
+    /// Creates a `Maintainer` struct from a string representation, which must be of the format
+    /// `NAME[,EMAIL[,URL]]`.
+    ///
+    /// # Errors
+    ///
+    /// * `maintainer_str` is not of the format `NAME[,EMAIL[,URL]`
+    /// * An invalid URL is specified
+    fn from_str(maintainer_str: &str) -> result::Result<Self, Self::Err> {
+        let values: Vec<&str> = maintainer_str.split(',').collect();
+        if values.len() < 1 || values.len() > 3 {
+            return Err(Error::InvalidMaintainer(maintainer_str.to_owned()));
+        }
+
+        let name = values[0].to_string();
+        // FIXME: Check validity of email address
+        let email = values.get(1).map(|&s| s.to_owned());
+        let url = values.get(2).map(|&s| s.to_owned());
+        if let Some(ref u) = url {
+            Url::parse(&u).map_err(|e| {
+                Error::InvalidUrl(u.to_owned(), format!("{}", e))
+            })?;
+        };
+
+        Ok(Maintainer { name, email, url })
+    }
+}


### PR DESCRIPTION
This PR aims to make Helm exporter as complete as possible so that it's actually useful. Using the now-added various CLI options, users can compose a commandline to export a particular habitat package and not have to hand-edit the generated chart directory, and then keep using the same commandline to create a chart for each new version and/or release.