### PR TITLE
Cleanup warning and other text

### DIFF
--- a/components/hab/src/command/cli/setup.rs
+++ b/components/hab/src/command/cli/setup.rs
@@ -112,26 +112,27 @@ pub fn start(ui: &mut UI, cache_path: &Path, analytics_path: &Path) -> Result<()
     }
     ui.heading("Habitat Personal Access Token")?;
     ui.para(
-        "While you can build and run Habitat packages without sharing them on the public \
-               depot, doing so allows you to collaborate with the Habitat community. In \
-               addition, it is how you can perform continuous deployment with Habitat.",
+        "While you can perform tasks like building and running Habitat packages without needing \
+            to authenticate with Builder, some operations like uploading your packages to \
+            Builder, or checking status of your build jobs from the Habitat client will require \
+            you to use an access token.",
     )?;
     ui.para(
-        "The Habitat personal access token can be generated via the Habitat Builder web \
-               site Profile page (https://bldr.habitat.sh/#/profile). Once you have \
+        "The Habitat Personal Access Token can be generated via the Builder  \
+               Profile page (https://bldr.habitat.sh/#/profile). Once you have \
                generated your token, you can enter it here.",
     )?;
     ui.para(
-        "If you would like to share your packages on the depot, please enter your Habitat \
-               access token. Otherwise, just enter No.",
+        "If you would like to save your token for use by the Habitat client, please enter \
+               your access token. Otherwise, just enter No.",
     )?;
     ui.para(
-        "For more information on sharing packages on the depot, please read the \
-          documentation at https://www.habitat.sh/docs/share-packages-overview/",
+        "For more information on using Builder, please read the \
+          documentation at https://www.habitat.sh/docs/using-builder/",
     )?;
     if ask_default_auth_token(ui)? {
         ui.br()?;
-        ui.para("Enter your Habitat personal access token.")?;
+        ui.para("Enter your Habitat Personal Access Token.")?;
         let auth_token = prompt_auth_token(ui)?;
         write_cli_config_auth_token(&auth_token)?;
     } else {

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -768,6 +768,25 @@ fn raw_parse_args() -> (Vec<OsString>, Vec<OsString>) {
     }
 }
 
+// Temporary warning function
+fn warn_accesss_token(token: &str, ui: &mut UI) {
+    if !token.starts_with("_") {
+        ui.warn("WARNING:").unwrap();
+        ui.warn(
+            "Github tokens are being deprecated, please migrate to a Habitat Personal \
+                 Access Token instead.",
+        ).unwrap();
+        ui.warn(
+            "To generate a Habitat Personal Access token, please visit the Builder Profile \
+                page (https://bldr.habitat.sh/#/profile).",
+        ).unwrap();
+        ui.warn(
+            "For more information, please read the documentation at \
+                https://www.habitat.sh/docs/using-builder/",
+        ).unwrap();
+    }
+}
+
 /// Check to see if the user has passed in an AUTH_TOKEN param. If not, check the
 /// HAB_AUTH_TOKEN env var. If not, check the CLI config to see if there is a default auth
 /// token set. If that's empty too, then error.
@@ -778,11 +797,7 @@ fn auth_token_param_or_env(ui: &mut UI, m: &ArgMatches) -> Result<String> {
             match henv::var(AUTH_TOKEN_ENVVAR) {
                 Ok(v) => {
                     // Temporary warning until we deprecate Github tokens completely
-                    if !v.starts_with("_") {
-                        ui.warn(
-                            "WARNING: Github tokens are being deprecated, please migrate to a Habitat Personal Access Token instead."
-                        ).unwrap();
-                    }
+                    warn_accesss_token(&v, ui);
                     Ok(v)
                 }
                 Err(_) => {
@@ -804,11 +819,7 @@ fn maybe_auth_token(ui: &mut UI, m: &ArgMatches) -> Option<String> {
     match auth_token_param_or_env(ui, &m) {
         Ok(t) => {
             // Temporary warning until we deprecate Github tokens completely
-            if !t.starts_with("_") {
-                ui.warn(
-                    "WARNING: Github tokens are being deprecated, please migrate to a Habitat Personal Access Token instead."
-                ).unwrap();
-            }
+            warn_accesss_token(&t, ui);
             Some(t)
         }
         Err(_) => None,


### PR DESCRIPTION
A few more tweaks to clean up the text relating to access tokens in hab setup and update the warning for github tokens.

Signed-off-by: Salim Alam <salam@chef.io>