### PR TITLE
Fix Aliases sections in CLI docs

### DIFF
--- a/www/scripts/generate-cli-docs.js
+++ b/www/scripts/generate-cli-docs.js
@@ -93,7 +93,7 @@ ${parsed.description}
 ${markdownForSubsection('Usage', parsed.usage.join('\n').replace(/^hab-/, 'hab ').replace(/hab butterfly/, 'hab').trim())}
 ${markdownForSubsection('Flags', parsed.flags.join('\n').trim())}
 ${markdownForSubsection('Args', parsed.args.join('\n').trim())}
-${markdownForSubsection('Aliases', parsed.aliases.join('\n'.trim()))}
+${markdownForSubsection('Aliases', parsed.aliases.join('\n').trim())}
 ${markdownForSubcommands(parsed.subcommands)}
 ---
 `;

--- a/www/source/docs/habitat-cli.html.md
+++ b/www/source/docs/habitat-cli.html.md
@@ -9,7 +9,7 @@ The commands for the Habitat CLI (`hab`) are listed below.
 
 | Applies to Version | Last Updated |
 | ------- | ------------ |
-| hab 0.54.0/20180221022026 (linux) | 9 Mar 2018 |
+| hab 0.54.0/20180221022026 (linux) | 10 Mar 2018 |
 
 ## hab
 
@@ -32,7 +32,13 @@ hab [SUBCOMMAND]
 **ALIASES**
 
 ```
-apply      Alias for: 'config apply'install    Alias for: 'pkg install'run        Alias for: 'sup run'setup      Alias for: 'cli setup'start      Alias for: 'svc start'stop       Alias for: 'svc stop'term       Alias for: 'sup term'
+apply      Alias for: 'config apply'
+install    Alias for: 'pkg install'
+run        Alias for: 'sup run'
+setup      Alias for: 'cli setup'
+start      Alias for: 'svc start'
+stop       Alias for: 'svc stop'
+term       Alias for: 'sup term'
 ```
 
 **SUBCOMMANDS**
@@ -1923,7 +1929,11 @@ hab svc [SUBCOMMAND]
 **ALIASES**
 
 ```
-load       Alias for: 'sup load'unload     Alias for: 'sup unload'start      Alias for: 'sup start'stop       Alias for: 'sup stop'status     Alias for: 'sup status'
+load       Alias for: 'sup load'
+unload     Alias for: 'sup unload'
+start      Alias for: 'sup start'
+stop       Alias for: 'sup stop'
+status     Alias for: 'sup status'
 ```
 
 **SUBCOMMANDS**


### PR DESCRIPTION
This fixes a bug in the rendering of the Aliases section.

Signed-off-by: Christian Nunciato <chris@nunciato.org>

![tenor-39325050](https://user-images.githubusercontent.com/274700/37243916-154ac9ec-2436-11e8-995e-d16cbfa9c432.gif)