### PR TITLE
Ignores sudo requirement for docker studio if user is member of "docker"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -685,7 +685,7 @@ dependencies = [
 [[package]]
 name = "habitat_core"
 version = "0.0.0"
-source = "git+https://github.com/habitat-sh/core.git#f2e35c323c8ffe8a0b8cbceb1007eb114c22ba58"
+source = "git+https://github.com/habitat-sh/core.git#8a00bc79e75397755264f9945d0134bdb2f6d0b3"
 dependencies = [
  "ansi_term 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -743,7 +743,7 @@ dependencies = [
 [[package]]
 name = "habitat_http_client"
 version = "0.0.0"
-source = "git+https://github.com/habitat-sh/core.git#f2e35c323c8ffe8a0b8cbceb1007eb114c22ba58"
+source = "git+https://github.com/habitat-sh/core.git#8a00bc79e75397755264f9945d0134bdb2f6d0b3"
 dependencies = [
  "base64 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat_core 0.0.0 (git+https://github.com/habitat-sh/core.git)",
@@ -894,7 +894,7 @@ dependencies = [
 [[package]]
 name = "habitat_win_users"
 version = "0.0.0"
-source = "git+https://github.com/habitat-sh/core.git#f2e35c323c8ffe8a0b8cbceb1007eb114c22ba58"
+source = "git+https://github.com/habitat-sh/core.git#8a00bc79e75397755264f9945d0134bdb2f6d0b3"
 dependencies = [
  "gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/hab/src/command/studio/enter.rs
+++ b/components/hab/src/command/studio/enter.rs
@@ -76,6 +76,7 @@ mod inner {
     use hcore::env as henv;
     use hcore::fs::{am_i_root, find_command};
     use hcore::os::process;
+    use hcore::users::linux as group;
     use hcore::package::PackageIdent;
 
     use error::{Error, Result};
@@ -87,7 +88,7 @@ mod inner {
     const SUDO_CMD: &'static str = "sudo";
 
     pub fn start(ui: &mut UI, args: Vec<OsString>) -> Result<()> {
-        rerun_with_sudo_if_needed(ui)?;
+        rerun_with_sudo_if_needed(ui, &args)?;
         if is_docker_studio(&args) {
             docker::start_docker_studio(ui, args)
         } else {
@@ -132,10 +133,21 @@ mod inner {
         return false;
     }
 
-    fn rerun_with_sudo_if_needed(ui: &mut UI) -> Result<()> {
-        // If I have root permissions, early return, we are done.
+    fn has_docker_group() -> bool {
+        let current_user = group::get_current_username().unwrap();
+        let docker_members = group::get_members_by_groupname("docker");
+        docker_members.map_or(false, |d| d.contains(&current_user))
+    }
+
+    fn rerun_with_sudo_if_needed(ui: &mut UI, args: &Vec<OsString>) -> Result<()> {
+        // If I have root permissions or if I am executing a docker studio
+        // and have the appropriate group - early return, we are done.
         if am_i_root() {
             return Ok(());
+        } else if is_docker_studio(&args) {
+            if has_docker_group() {
+                return Ok(());
+            }
         }
 
         // Otherwise we will try to re-run this program using `sudo`


### PR DESCRIPTION
Fixes #4716 but requires https://github.com/habitat-sh/core/pull/16 to be merged as well.
Signed-off-by: Ian Henry <ihenry@chef.io>