### PR TITLE
 fixes pkg_svc_run when FS_ROOT is set

### DIFF
--- a/components/plan-build-ps1/bin/hab-plan-build.ps1
+++ b/components/plan-build-ps1/bin/hab-plan-build.ps1
@@ -1609,12 +1609,12 @@ function Invoke-DefaultBuildService {
         if ($pkg_svc_run -ne "") {
           Write-BuildLine "Writing $pkg_prefix/run script to run $pkg_svc_run"
           Set-Content -Path "$pkg_prefix/run" -Value @"
-cd "$pkg_svc_path"
+cd (Join-Path "`$env:FS_ROOT" "$pkg_svc_path")
 
 `$cmd = @"
 $pkg_svc_run
 "`@
-Invoke-Expression -Command `$cmd 2>&1
+Invoke-Expression -Command `$cmd
 "@
         }
     }


### PR DESCRIPTION
In addition to correctly rooting the `svc` path used, this also fixes errors from getting lost in the streams. Honestly it seems like `2>&1` should work but I'm not seeing actual errors and now that we handle stderr properly in the supervisor code, its unnecessary even if it did work. I confirmed that removing that redirection fixed the error swallowing.

Signed-off-by: mwrock <matt@mattwrock.com>