### PR TITLE
add curlbash to linux install options + cleanup faq

### DIFF
--- a/www/source/partials/docs/_using-hab-install-faq.html.md.erb
+++ b/www/source/partials/docs/_using-hab-install-faq.html.md.erb
@@ -15,10 +15,10 @@ A: We've got you covered! The script we provide for doing curlbash installations
 
 **Q: Oh! A curlbash I (love||hate) those.**
 
-A: Indeed they are divisive, we know, that's why we provide a few different ways for you to download. If you'd like to take a look at the script in advance of running it, you can find it in [the core habitat repo](https://github.com/habitat-sh/habitat/blob/master/components/hab/install.sh).
+A: Indeed they are divisive, we know, that's why we provide a few different ways for you to download. If you'd like to take a look at the script before running it, you can find it in [the core habitat repo](https://github.com/habitat-sh/habitat/blob/master/components/hab/install.sh).
 
 If you're staunchly in the anti-curlbash camp, you can get the latest packages from the [download links](/docs/install-habitat/#install-habitat) listed previously, or via releases on our [Bintray page](https://bintray.com/habitat).
 
 **Q: How do I install `hab` across my server fleet?**
 
-A: for the most part, we leave that up to you. You could just use the aforementioned curl-bash with your provisioner of choice. If your app was dockerized with Habitat then you won't even need to ask this question, because you'll have everything you need inside your container. We are working on first class Mesosphere DC/OS, Cloud Foundry, and Kubernetes integrations - which you can keep up to date on in [our best practices section](/docs/best-practices/) and [blog](/blog).
+A: For the most part, we leave that up to you. You could just use the aforementioned curl-bash with your provisioner of choice. If your app was dockerized with Habitat then you won't even need to ask this question, because you'll have everything you need inside your container. We are working on first class Mesosphere DC/OS, Cloud Foundry, and Kubernetes integrations - which you can keep up to date on in [our best practices section](/docs/best-practices/) and [blog](/blog).

--- a/www/source/partials/docs/_using-hab-install-faq.html.md.erb
+++ b/www/source/partials/docs/_using-hab-install-faq.html.md.erb
@@ -1,7 +1,7 @@
 ## <a name="install-faq" id="install-faq" data-magellan-target="install-faq">Download and Install FAQ</a>
 This section tracks some questions that are frequently encountered when downloading and installing the `hab` binary.
 
-**Q: Can I just download a GitHub release of habitat?**
+**Q: Can I just download a GitHub release of Habitat?**
 
 A: While we do cut releases in GitHub as part of our release process those archives are going to be a tar'ed point in time of our source code. As the `hab` cli is written rust if you follow this approach you'll need to compile the source for your platform.
 
@@ -11,14 +11,14 @@ A: We publish compiled packages for OSX, Linux, and Windows. `hab` has a require
 
 **Q: What if I need an old version of `hab`?**
 
-A: We've got you covered! The script we provide for doing curlbash installations will allow you to specify a `-v` flag to pull down a specific version of habitat.
+A: We've got you covered! The script we provide for doing curlbash installations will allow you to specify a `-v` flag to pull down a specific version of Habitat.
 
 **Q: Oh! A curlbash I (love||hate) those.**
 
 A: Indeed they are divisive, we know, that's why we provide a few different ways for you to download. If you'd like to take a look at the script in advance of running it, you can find it in [the core habitat repo](https://github.com/habitat-sh/habitat/blob/master/components/hab/install.sh).
 
-If you're staunchly in the anti-curlbash camp, you can get the latest packages from the [download links](/docs/install-habitat/#install-habitat) listed previously, or via releases on our [bintray page](https://bintray.com/habitat)
+If you're staunchly in the anti-curlbash camp, you can get the latest packages from the [download links](/docs/install-habitat/#install-habitat) listed previously, or via releases on our [Bintray page](https://bintray.com/habitat).
 
 **Q: How do I install `hab` across my server fleet?**
 
-A: for the most part, we leave that up to you. You could just use the aforementioned curl-bash with your provisioner of choice. If your app was dockerized with habitat then you won't even need to ask this question, because you'll have everything you need inside your container. We are working on first class mesos dc/os, cloudfoundry and kubernetes integrations - which you can keep up to date on in [our best practices section](/docs/best-practices/) and [blog](/blog).
+A: for the most part, we leave that up to you. You could just use the aforementioned curl-bash with your provisioner of choice. If your app was dockerized with Habitat then you won't even need to ask this question, because you'll have everything you need inside your container. We are working on first class Mesosphere DC/OS, Cloud Foundry, and Kubernetes integrations - which you can keep up to date on in [our best practices section](/docs/best-practices/) and [blog](/blog).

--- a/www/source/partials/docs/_using-hab-install-faq.html.md.erb
+++ b/www/source/partials/docs/_using-hab-install-faq.html.md.erb
@@ -1,5 +1,5 @@
 ## <a name="install-faq" id="install-faq" data-magellan-target="install-faq">Download and Install FAQ</a>
-This section tracks some frequently encountered questions around downloading and installing the `hab` binary.
+This section tracks some questions that are frequently encountered when downloading and installing the `hab` binary.
 
 **Q: Can I just download a GitHub release of habitat?**
 
@@ -17,14 +17,7 @@ A: We've got you covered! The script we provide for doing curlbash installations
 
 A: Indeed they are divisive, we know, that's why we provide a few different ways for you to download. If you'd like to take a look at the script in advance of running it, you can find it in [the core habitat repo](https://github.com/habitat-sh/habitat/blob/master/components/hab/install.sh).
 
-Install Habitat via curlbash using the following command:
-`curl https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh | sudo bash`
-
-If you're staunchly in the anti-curlbash camp you can get the latest packages from our [download page](https://habitat.sh/downloads) or via releases on [our bintray page](https://bintray.com/habitat)
-
-**Q: Er, how do I install habitat?**
-
-A: You'll need to download the `hab` package. Extract the binary to somewhere on your $PATH (or somewhere that you can execute the binary from a command line). If you're installing on a workstation we would strongly recommend running `hab setup` after youve extracted the binary. Read our [step by step docs here](/docs/using-habitat/#install-habitat).
+If you're staunchly in the anti-curlbash camp, you can get the latest packages from the [download links](/docs/install-habitat/#install-habitat) listed previously, or via releases on our [bintray page](https://bintray.com/habitat)
 
 **Q: How do I install `hab` across my server fleet?**
 

--- a/www/source/partials/global/_download-and-install.slim
+++ b/www/source/partials/global/_download-and-install.slim
@@ -9,6 +9,10 @@ hr
       blockquote Requires 64-bit processor with kernel 2.6.32 or later
       p Once you have downloaded the package, extract the hab binary with tar to <code>/usr/local/bin</code> or add its location to your <code>PATH</code> (e.g. <code>tar -xvzf hab.tgz -C /usr/local/bin --strip-components 1</code>).
       = link_to 'Download Habitat for Linux', 'https://api.bintray.com/content/habitat/stable/linux/x86_64/hab-%24latest-x86_64-linux.tar.gz?bt_package=hab-x86_64-linux', class: 'button cta'
+      p Alternatively, you can install Habitat via the command line by downloading and running the installation script:
+      = code(:shell) do
+          |
+           curl https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh | sudo bash
 hr
 .hab-cli-os.mac.mb-2
   .row

--- a/www/source/partials/global/_download-and-install.slim
+++ b/www/source/partials/global/_download-and-install.slim
@@ -9,6 +9,8 @@ hr
       blockquote Requires 64-bit processor with kernel 2.6.32 or later
       p Once you have downloaded the package, extract the hab binary with tar to <code>/usr/local/bin</code> or add its location to your <code>PATH</code> (e.g. <code>tar -xvzf hab.tgz -C /usr/local/bin --strip-components 1</code>).
       = link_to 'Download Habitat for Linux', 'https://api.bintray.com/content/habitat/stable/linux/x86_64/hab-%24latest-x86_64-linux.tar.gz?bt_package=hab-x86_64-linux', class: 'button cta'
+
+      h4.mt-2 Install Habitat from the Command Line
       p Alternatively, you can install Habitat via the command line by downloading and running the installation script:
       = code(:shell) do
           |


### PR DESCRIPTION
Signed-off-by: brewn <nbrewer@chef.io>

Not sure if we want to list the curlbash method as an option for macos as well, or if we'd prefer to favor package manager options where they're available. 