### PR TITLE
Pin core/docker to 17.09.9 for cfize and dockerize

### DIFF
--- a/components/pkg-cfize/plan.sh
+++ b/components/pkg-cfize/plan.sh
@@ -6,7 +6,7 @@ pkg_description="Habitat Cloud Foundry image exporter"
 pkg_upstream_url="https://github.com/habitat-sh/habitat"
 pkg_deps=(
   core/coreutils core/findutils core/grep core/sed core/gawk core/bash
-  core/hab-pkg-dockerize core/docker
+  core/hab-pkg-dockerize core/docker/17.09.0
 )
 pkg_bin_dirs=(bin)
 

--- a/components/pkg-dockerize/plan.sh
+++ b/components/pkg-dockerize/plan.sh
@@ -4,7 +4,7 @@ pkg_version=$(cat "$PLAN_CONTEXT/../../VERSION")
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_source=nosuchfile.tar.gz
-pkg_deps=(core/coreutils core/findutils core/gawk core/grep core/bash core/docker core/hab-studio)
+pkg_deps=(core/coreutils core/findutils core/gawk core/grep core/bash core/docker/17.09.0 core/hab-studio)
 pkg_build_deps=()
 pkg_bin_dirs=(bin)
 


### PR DESCRIPTION
We must pin here since these two packages are dependent. If Cfize builds, it pulls a newer version of core/docker than the current hab-pkg-dockerize has so we get a dep conflict.

![](https://media2.giphy.com/media/3owypf6HrM3J7UTvAA/200w.gif)

Signed-off-by: Elliott Davis <elliott@excellent.io>