### PR TITLE
pkg-export-k8s: Use versioned tag when '-d' is passed

### DIFF
--- a/components/pkg-export-kubernetes/src/manifest.rs
+++ b/components/pkg-export-kubernetes/src/manifest.rs
@@ -114,7 +114,7 @@ impl Manifest {
                     None => {
                         (
                             format!("{}/{}", pkg_ident.origin, pkg_ident.name),
-                            "latest".to_owned(),
+                            version_suffix,
                         )
                     }
                 };


### PR DESCRIPTION
Currently when docker image generation is disabled, the exporter uses `latest` tag for docker image even if version information is available. This patch fixes this issue.