### PR TITLE
Fix checks to skip travis test runs when there are no relevant changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,9 @@ env:
   global:
     - PATH=$HOME/.cargo/bin:$PATH
     # Habitat Rust program components
-    - _RUST_HAB_BIN_COMPONENTS="components/hab|components/hab-butterfly|components/launcher|components/pkg-export-docker|components/pkg-export-kubernetes|components/pkg-export-helm|components/sup|components/eventsrv|components/pkg-export-tar
+    - _RUST_HAB_BIN_COMPONENTS="components/hab components/hab-butterfly components/launcher components/pkg-export-docker components/pkg-export-kubernetes components/pkg-export-helm components/sup components/eventsrv components/pkg-export-tar"
     # Habitat Rust crate components
-    - _RUST_HAB_LIB_COMPONENTS="components/builder-api-client|components/builder-depot-client|components/butterfly|components/common|components/eventsrv-client|components/launcher-client
+    - _RUST_HAB_LIB_COMPONENTS="components/builder-api-client components/builder-depot-client components/butterfly components/common components/eventsrv-client components/launcher-client"
 
 matrix:
   include:
@@ -28,7 +28,8 @@ matrix:
     - language: rust
       env:
         - COMPONENTS=bin
-        - AFFECTED_DIRS="Cargo\.lock|$_RUST_HAB_BIN_COMPONENTS|$_RUST_HAB_LIB_COMPONENTS"
+        - AFFECTED_FILES="Cargo.lock"
+        - AFFECTED_DIRS="$_RUST_HAB_BIN_COMPONENTS $_RUST_HAB_LIB_COMPONENTS"
       rust: stable
       sudo: false
       services:
@@ -69,7 +70,8 @@ matrix:
     - language: rust
       env:
         - COMPONENTS=lib
-        - AFFECTED_DIRS="Cargo\.lock|$_RUST_HAB_LIB_COMPONENTS
+        - AFFECTED_FILES="Cargo.lock"
+        - AFFECTED_DIRS="$_RUST_HAB_LIB_COMPONENTS"
       rust: stable
       sudo: required
       addons:
@@ -115,6 +117,7 @@ matrix:
         directories:
           - www/build
       env:
+        - AFFECTED_FILES=""
         - AFFECTED_DIRS="www"
         - AWS_BUCKET=habitat-www
         - AWS_DEFAULT_REGION=us-west-2
@@ -216,7 +219,8 @@ matrix:
 # Job for building and publishing Habitat Mac release packages
 #
     - env:
-        - AFFECTED_DIRS="\.travis\.yml|\.bldr\.toml|support/ci/deploy\.sh|Cargo\.toml|Cargo\.lock|VERSION|components/hab|$_RUST_HAB_LIB_COMPONENTS"
+        - AFFECTED_FILES=".travis.yml .bldr.toml support/ci/deploy.sh Cargo.toml Cargo.lock VERSION"
+        - AFFECTED_DIRS="components/hab $_RUST_HAB_LIB_COMPONENTS"
         # HAB_ORIGIN_KEY
         - secure: "uZ70GE8qK3GBgs7ZIsoy5DhPlHNs2hoLxLBGKq+u+0XrE017pOnW6mNHsn7J7i2r8CPtd4KFsFEN52wZSA+Sf96MFIL2w9E+geykBgbRMZzv4icuCf0xSGwm4iRMgZ9A08TfurMX6y6N+4JNsrCv9syVNuGq09EL2wLHPXOQhesMpodijQLcFikxfEXXbaWla1xHnYxJk+fbvYDoXVCbdqnpdeLTmGuQHFaaNI7jm1B3L/dl+IGZxwFdvqBT3G9mHiXBdyi8bALs7rcZNdV7PqtFFpp98zIeqwNHtHPd5cBRmqDRTRxucRSACS/lurrz9J+001a9RjPvUkYlLrn0hQY9pN6oo+kCpN/1r0bc17i4FbGx7R73FnFgPK/cno0ENBFygNZn7/jg6cENgjkBlHsZhc1+L1xhILo46nQU9XbWJrwelVYUOOGXI76tECOkGhkglx1vYK8fcMVLJMhL7psgPpbGbDJQDuAKhHS+75txNK+356ompNL+YUzeWZc4KSGZCNTQsPK+rsGttmA+JXtAaquFaY5xwSgyKHwETiSVg4dYXb3xh6goNxf2JTOZOosWaypyykHqcqsqCu2fzIDdmkgCx6I5/5q8I/7Z0es0jlUpHamlihZwe4E5YdYFCSouaDoeTnVdJKVI1p9fnAjpFqjivFgqLE/Z504vCNU="
         - BINTRAY_USER=chef-releng-ops

--- a/support/ci/fast_pass.sh
+++ b/support/ci/fast_pass.sh
@@ -7,35 +7,77 @@
 # .travis.yml in the `before_install`, we exit non-zero if we want the build to
 # be skipped, so we can do `|| exit 0` in the YAML.
 
-echo "TAG: $TRAVIS_TAG"
+set -euo pipefail
+
+echo "TAG: ${TRAVIS_TAG:=None}"
 echo "VERSION: $(cat VERSION)"
 
-if [ -n "$STEAM_ROLLER" ]; then
-  echo 'STEAM_ROLLER is set. Not exiting and running everything.'
-elif [ -z "$AFFECTED_DIRS" ]; then
-  # Don't do anything if $AFFECTED_DIRS is not set
-  echo 'AFFECTED_DIRS is not set. Not exiting and running everything.'
+if [ -n "${STEAM_ROLLER:-}" ]; then
+  echo 'STEAM_ROLLER is set. Running tests unconditionally.'
+elif [ -z "${AFFECTED_DIRS+x}" ]; then
+  echo 'AFFECTED_DIRS is not set. Running tests unconditionally.'
+elif [ -z "${AFFECTED_FILES+x}" ]; then
+  echo 'AFFECTED_FILES is not set. Running tests unconditionally.'
 elif [ "$(cat VERSION)" == "$TRAVIS_TAG" ]; then
   echo "This is a release tag. Congrats on the new  $TRAVIS_TAG release!!"
 else
-  # If $AFFECTED_DIRS (a "|" separated list of directories) is set, see if we have
+  # If $AFFECTED_DIRS and $AFFECTED_FILES is set, see if we have
   # any changes. To make this determination, we can always use the most recent merge
   # commit on the target branch, since Travis will have created one for us.
   CHANGED_FILES="$(support/ci/what_changed.sh)"
 
+  echo_indented() {
+    local x
+    for x in "$@"; do
+      echo "    $x"
+    done
+  }
+
   echo
   echo "Checking for changed files since last merge commit:"
   echo
-  echo "$CHANGED_FILES" | sed 's,^,    ,g'
+  echo_indented $CHANGED_FILES
   echo
 
-  echo "In the affected directories:"
+  echo "Among the affected files:"
   echo
-  echo "$AFFECTED_DIRS" | tr '|' '\n' | sed 's,^,    ,'
+  echo_indented $AFFECTED_FILES
   echo
 
-  echo "$CHANGED_FILES" | grep -qE "^($AFFECTED_DIRS)" || {
-    echo "No files in affected directories have changed. Skipping CI run."
-    exit 1
+  echo "And in the affected directories:"
+  echo
+  echo_indented $AFFECTED_DIRS
+  echo
+
+  check_affected() {
+    local changed_file=$1
+
+    for dir in $AFFECTED_DIRS; do
+      if [[ $changed_file = $dir* ]]; then
+        echo "$changed_file in affected dir $dir"
+        return 0
+      fi
+    done
+
+    for affected_file in $AFFECTED_FILES; do
+      if [ "$changed_file" = "$affected_file" ]; then
+        echo "$changed_file is an affected file"
+        return 0
+      fi
+    done
+
+    return 1
   }
+
+  CHANGED_AFFECTED_FILES=()
+  for f in $CHANGED_FILES; do
+    if check_affected "$f"; then
+      CHANGED_AFFECTED_FILES+=($f)
+    fi
+  done
+
+  if [ ${#CHANGED_AFFECTED_FILES[@]} -eq 0 ]; then
+    echo "No files in affected directories or files have changed. Skipping CI run."
+    exit 1
+  fi
 fi


### PR DESCRIPTION
This is similar to https://github.com/habitat-sh/builder/pull/208. The
fast_pass.sh script is identical, but the changes to .travis.yml are specific
to the repo.

Also, fix up some instances where variables in the .travis.yml were missing
their closing quotes.

Resolves https://github.com/habitat-sh/builder/issues/323