### PR TITLE
[ci] Update `compile_libsodium.sh` to 1.0.13.

### DIFF
--- a/support/ci/compile_libsodium.sh
+++ b/support/ci/compile_libsodium.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eu
 
-version=1.0.12
+version=1.0.13
 nv=libsodium-$version
 source=https://download.libsodium.org/libsodium/releases/${nv}.tar.gz
 prefix=$HOME/pkgs/libsodium/$version

--- a/support/ci/rust_env.sh
+++ b/support/ci/rust_env.sh
@@ -1,5 +1,5 @@
 # This version corresponds to the build in `support/ci/compile_libsodium.sh`
-export LIBSODIUM_PREFIX="$HOME/pkgs/libsodium/1.0.12"
+export LIBSODIUM_PREFIX="$HOME/pkgs/libsodium/1.0.13"
 echo "--> Setting LIBSODIUM_PREFIX='$LIBSODIUM_PREFIX'"
 # This version corresponds to the build in `support/ci/compile_libarchive.sh`
 export LIBARCHIVE_PREFIX="$HOME/pkgs/libarchive/3.2.0"


### PR DESCRIPTION
Turns out that the source location of the 1.0.12 release was moved,
leading to a failed build of this software (grrr). In the process of
updating, I noticed that the version we build our software with is
currently 1.0.13, so that felt like a better fix.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>