### PR TITLE
Make `sed -i` work on both linux and Mac OS

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -52,10 +52,10 @@ If you happen to be aware of features or bugs and feel there are user impacting 
     $ git checkout -b <branch>
     ```
 
-1. Remove the `-dev` suffix from the version number found in the `VERSION` file
+1. Remove the `-dev` suffix from the version number found in the `VERSION` file. *Note*: there must not be a space after the `-i`.
 
     ```
-    $ sed -i '' -e 's/-dev//' VERSION
+    $ sed -i'' -e 's/-dev//' VERSION
     ```
 
 1. Generate a new `CHANGELOG.md`

--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -1592,7 +1592,7 @@ _build_environment() {
 _fix_libtool() {
   find "$SRC_PATH" -iname "ltmain.sh" | while read file; do
     build_line "Fixing libtool script $file"
-    sed -i -e 's^eval sys_lib_.*search_path=.*^^' "$file"
+    sed -i'' -e 's^eval sys_lib_.*search_path=.*^^' "$file"
   done
 }
 

--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -1592,7 +1592,7 @@ _build_environment() {
 _fix_libtool() {
   find "$SRC_PATH" -iname "ltmain.sh" | while read file; do
     build_line "Fixing libtool script $file"
-    sed -i'' -e 's^eval sys_lib_.*search_path=.*^^' "$file"
+    sed -i -e 's^eval sys_lib_.*search_path=.*^^' "$file"
   done
 }
 

--- a/components/plan-build/bin/public.bash
+++ b/components/plan-build/bin/public.bash
@@ -165,7 +165,7 @@ pkg_path_for() {
 #
 #     56:
 #     57:   # Modify the ldd rewrite script to remove lib64 and libx32
-#     58:   sed -i '/RTLDLIST/d' sysdeps/unix/sysv/linux/*/ldd-rewrite.sed
+#     58:   sed -i'' '/RTLDLIST/d' sysdeps/unix/sysv/linux/*/ldd-rewrite.sed
 #     59:
 #     60:   rm -rf ../${pkg_name}-build
 #     61:   mkdir ../${pkg_name}-build

--- a/www/Makefile
+++ b/www/Makefile
@@ -17,7 +17,7 @@ purge_cache: check-env
 	curl -H "Fastly-Key: ${FASTLY_API_KEY}" -X POST "https://api.fastly.com/service/${FASTLY_SERVICE_KEY}/purge_all"
 
 prep:
-	sed -i '/^Disallow:/ s/$$/ \//' build/robots.txt
+	sed -i'' '/^Disallow:/ s/$$/ \//' build/robots.txt
 	zip -r website.zip build
 
 deploy: build sync purge_cache


### PR DESCRIPTION
Because the Mac OS version of sed's -i option requires an argument but linux's
does not, the way to get inline ovewrite behavior on both is to supply a zero-
length argument with no spaces after the -i.

Signed-off-by: Jon Bauman <5906042+baumanj@users.noreply.github.com>