### PR TITLE
adding hab pkg info subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -483,6 +483,7 @@ dependencies = [
  "retry 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/hab/Cargo.toml
+++ b/components/hab/Cargo.toml
@@ -26,6 +26,7 @@ pbr = "*"
 regex = "*"
 retry = "*"
 serde = "*"
+serde_json = "*"
 serde_derive = "*"
 toml = { version = "*", default-features = false }
 url = "*"

--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -474,6 +474,15 @@ pub fn get() -> App<'static, 'static> {
                     "A path to a Habitat Artifact \
                     (ex: /home/acme-redis-3.0.7-21120102031201-x86_64-linux.hart)")
             )
+            (@subcommand info =>
+                (about: "Returns the Habitat Artifact information")
+                (aliases: &["inf", "info"])
+                (@arg TO_JSON: -j --json
+                    "Output will be rendered in json")
+                (@arg SOURCE: +required {file_exists}
+                    "A path to a Habitat Artifact \
+                    (ex: /home/acme-redis-3.0.7-21120102031201-x86_64-linux.hart)")
+            )
         )
         (@subcommand plan =>
             (about: "Commands relating to plans and other app-specific configuration.")

--- a/components/hab/src/command/pkg/info.rs
+++ b/components/hab/src/command/pkg/info.rs
@@ -1,0 +1,72 @@
+// Copyright (c) 2016 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::path::Path;
+use common::ui::UI;
+use std::io::{self, Write};
+use hcore::package::PackageArchive;
+use error::Result;
+use serde::Serialize;
+use serde_json::{self, Value as Json};
+
+fn convert_to_json<T>(src: &T) -> Json
+where
+    T: Serialize,
+{
+    serde_json::to_value(src).unwrap_or(Json::Null)
+}
+
+
+pub fn start(ui: &mut UI, src: &Path, to_json: bool) -> Result<()> {
+    let ident = PackageArchive::new(src).ident()?;
+
+    if to_json {
+        println!("{}", convert_to_json(&ident));
+    } else {
+        ui.begin(
+            format!("Reading PackageIdent from {}", &src.display()),
+        )?;
+        ui.para("")?;
+
+        io::stdout().write(
+            format!("Package Path   : {}\n", &src.display())
+                .as_bytes(),
+        )?;
+        io::stdout().write(
+            format!(
+                "Origin         : {}\n",
+                &ident.origin
+            ).as_bytes(),
+        )?;
+        io::stdout().write(
+            format!(
+                "Name           : {}\n",
+                &ident.name
+            ).as_bytes(),
+        )?;
+        io::stdout().write(
+            format!(
+                "Version        : {}\n",
+                &ident.version.unwrap()
+            ).as_bytes(),
+        )?;
+        io::stdout().write(
+            format!(
+                "Release        : {}\n",
+                &ident.release.unwrap()
+            ).as_bytes(),
+        )?;
+    }
+    Ok(())
+}

--- a/components/hab/src/command/pkg/mod.rs
+++ b/components/hab/src/command/pkg/mod.rs
@@ -21,6 +21,7 @@ pub mod exec;
 pub mod export;
 pub mod hash;
 pub mod header;
+pub mod info;
 pub mod path;
 pub mod promote;
 pub mod provides;

--- a/components/hab/src/lib.rs
+++ b/components/hab/src/lib.rs
@@ -39,6 +39,7 @@ extern crate retry;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;
+extern crate serde_json;
 extern crate toml;
 extern crate url;
 extern crate uuid;

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -186,6 +186,7 @@ fn start(ui: &mut UI) -> Result<()> {
                 ("upload", Some(m)) => sub_pkg_upload(ui, m)?,
                 ("verify", Some(m)) => sub_pkg_verify(ui, m)?,
                 ("header", Some(m)) => sub_pkg_header(ui, m)?,
+                ("info", Some(m)) => sub_pkg_info(ui, m)?,
                 ("promote", Some(m)) => sub_pkg_promote(ui, m)?,
                 ("demote", Some(m)) => sub_pkg_demote(ui, m)?,
                 _ => unreachable!(),
@@ -676,6 +677,14 @@ fn sub_pkg_header(ui: &mut UI, m: &ArgMatches) -> Result<()> {
     init();
 
     command::pkg::header::start(ui, &src)
+}
+
+fn sub_pkg_info(ui: &mut UI, m: &ArgMatches) -> Result<()> {
+    let src = Path::new(m.value_of("SOURCE").unwrap()); // Required via clap
+    let to_json = m.is_present("TO_JSON");
+    init();
+
+    command::pkg::info::start(ui, &src, to_json)
 }
 
 fn sub_pkg_promote(ui: &mut UI, m: &ArgMatches) -> Result<()> {


### PR DESCRIPTION

![giphy](https://user-images.githubusercontent.com/1991696/37988127-b39673de-31c5-11e8-8961-f5719caf6370.gif)

### :nut_and_bolt: Description

This adds an `info` subcommand to `hab pkg` such that
when given a file path to a `.hart` archive, it will
extract and display the Package Identifying information.

`json` output can be specified with the `-j` or `--json` flag.

### 🎆  Issues Resolved
#4309

### :athletic_shoe: Demo

```
$ ./target/debug/hab pkg info --help
hab-pkg-info
Returns the Habitat Artifact information

USAGE:
    hab pkg info [FLAGS] <SOURCE>

FLAGS:
    -j, --json       Output will be rendered in json
    -h, --help       Prints help information
    -V, --version    Prints version information

ARGS:
    <SOURCE>    A path to a Habitat Artifact (ex: /home/acme-redis-3.0.7-21120102031201-x86_64-linux.hart)

$ ./target/debug/hab pkg info /tmp/foo.hart
» Reading PackageIdent from /tmp/foo.hart

Package Path   : /tmp/foo.hart
Origin         : jeremymv2
Name           : workflow-server
Version        : 1.7.0-dev
Release        : 20180201223728

$ ./target/debug/hab pkg info -j /tmp/foo.hart
{"name":"workflow-server","origin":"jeremymv2","release":"20180201223728","version":"1.7.0-dev"}
$
```

Signed-off-by: Jeremy J. Miller <jm@chef.io>