### PR TITLE
Formalize template rendering context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,5 +1,13 @@
 [[package]]
 name = "aho-corasick"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "aho-corasick"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -873,6 +881,7 @@ dependencies = [
  "handlebars 0.28.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "iron 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "json 0.11.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -892,6 +901,7 @@ dependencies = [
  "time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "valico 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1138,6 +1148,20 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "json"
+version = "0.11.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "jsonway"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "kernel32-sys"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1231,6 +1255,14 @@ dependencies = [
 name = "matches"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "memchr"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "memchr"
@@ -1650,6 +1682,18 @@ dependencies = [
 
 [[package]]
 name = "regex"
+version = "0.1.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -1659,6 +1703,11 @@ dependencies = [
  "thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "regex-syntax"
@@ -2036,6 +2085,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread-id"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thread_local"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "thread_local"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2149,6 +2215,11 @@ dependencies = [
 
 [[package]]
 name = "traitobject"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "traitobject"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
@@ -2254,6 +2325,11 @@ dependencies = [
 
 [[package]]
 name = "utf8-ranges"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "utf8-ranges"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
@@ -2280,6 +2356,24 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "valico"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "jsonway 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf 0.7.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf_codegen 0.7.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "traitobject 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2406,6 +2500,7 @@ dependencies = [
 ]
 
 [metadata]
+"checksum aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ca972c2ea5f742bfce5687b9aef75506a764f61d37f8f649047846a9686ddb66"
 "checksum aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d6531d44de723825aa81398a6415283229725a00fa30713812ab9323faa82fc4"
 "checksum ansi_term 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6b3568b48b7cefa6b8ce125f9bb4989e52fbcc29ebea88df04cc7c5f12f70455"
 "checksum antidote 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "34fde25430d87a9388dadbe6e34d7f72a462c8b43ac8d309b42b0a8505d7e2a5"
@@ -2492,6 +2587,8 @@ dependencies = [
 "checksum iron 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d8e17268922834707e1c29e8badbf9c712c9c43378e1b6a3388946baff10be2"
 "checksum itertools 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d3f2be4da1690a039e9ae5fd575f706a63ad5a2120f161b1d653c9da3930dd21"
 "checksum itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8324a32baf01e2ae060e9de58ed0bc2320c9a2833491ee36cd3b4c414de4db8c"
+"checksum json 0.11.13 (registry+https://github.com/rust-lang/crates.io-index)" = "9ad0485404155f45cce53a40d4b2d6ac356418300daed05273d9e26f91c390be"
+"checksum jsonway 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "effcb749443c905fbaef49d214f8b1049c240e0adb7af9baa0e201e625e4f9de"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 "checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
@@ -2506,6 +2603,7 @@ dependencies = [
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "89f010e843f2b1a31dbd316b3b8d443758bc634bed37aabade59c686d644e0a2"
 "checksum matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "100aabe6b8ff4e4a7e32c1c13523379802df0772b82466207ac25b013f193376"
+"checksum memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
 "checksum memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d"
 "checksum metadeps 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "73b122901b3a675fac8cecf68dcb2f0d3036193bc861d1ac0e1c337f7d5254c2"
 "checksum mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
@@ -2552,7 +2650,9 @@ dependencies = [
 "checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
 "checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
+"checksum regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)" = "4fd4ace6a8cf7860714a2c2280d6c1f7e6a413486c13298bbc86fd3da019402f"
 "checksum regex 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "5be5347bde0c48cfd8c3fdc0766cdfe9d8a755ef84d620d6794c778c91de8b2b"
+"checksum regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "f9ec002c35e86791825ed294b50008eea9ddfc8def4420124fbc6b08db834957"
 "checksum regex-syntax 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8e931c58b93d86f080c734bfd2bce7dd0079ae2331235818133c8be7f422e20e"
 "checksum relay 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1576e382688d7e9deecea24417e350d3062d97e32e45d70b1cde65994ff1489a"
 "checksum remove_dir_all 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b5d2f806b0fcdabd98acd380dc8daef485e22bcb7cddc811d1337967f2528cf5"
@@ -2599,6 +2699,8 @@ dependencies = [
 "checksum termcolor 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "56c456352e44f9f91f774ddeeed27c1ec60a2455ed66d692059acfb1d731bda1"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum textwrap 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c0b59b6b4b44d867f1370ef1bd91bfb262bf07bf0ae65c202ea2fbc16153b693"
+"checksum thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9539db560102d1cef46b8b78ce737ff0bb64e7e18d35b2a5688f7d097d0ff03"
+"checksum thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8576dbbfcaef9641452d5cf0df9b0e7eeab7694956dd33bb61515fb8f18cfdd5"
 "checksum thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "279ef31c19ededf577bfd12dfae728040a21f635b06a24cd670ff510edd38963"
 "checksum threadpool 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e2f0c90a5f3459330ac8bc0d2f879c693bb7a2f59689c1083fc4ef83834da865"
 "checksum time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "a15375f1df02096fb3317256ce2cee6a1f42fc84ea5ad5fc8c421cfe40c73098"
@@ -2610,6 +2712,7 @@ dependencies = [
 "checksum tokio-tls 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "772f4b04e560117fe3b0a53e490c16ddc8ba6ec437015d91fa385564996ed913"
 "checksum toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "736b60249cb25337bc196faa43ee12c705e426f3d55c214d73a4e7be06f92cb4"
 "checksum toml 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a7540f4ffc193e0d3c94121edb19b055670d369f77d5804db11ae053a45b6e7e"
+"checksum traitobject 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9dc23794ff47c95882da6f9d15de9a6be14987760a28cc0aafb40b7675ef09d8"
 "checksum traitobject 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
 "checksum typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1410f6f91f21d1612654e7cc69193b0334f909dcf2c790c4826254fbb86f8887"
 "checksum typemap 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "653be63c80a3296da5551e1bfd2cca35227e13cdd08c6668903ae2f4f77aa1f6"
@@ -2625,10 +2728,12 @@ dependencies = [
 "checksum url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f808aadd8cfec6ef90e4a14eb46f24511824d1ac596b9682703c87056c8678b7"
 "checksum userenv-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "71d28ea36bbd9192d75bd9fa9b39f96ddb986eaee824adae5d53b6e51919b2f3"
 "checksum users 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "99ab1b53affc9f75f57da4a8b051a188e84d20d43bea0dd9bd8db71eebbca6da"
+"checksum utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a1ca13c08c41c9c3e04224ed9ff80461d97e121589ff27c753a16cb10830ae0f"
 "checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
 "checksum uuid 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "78c590b5bd79ed10aad8fb75f078a59d8db445af6c743e55c4a53227fc01c13f"
 "checksum uuid 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bcc7e3b898aa6f6c08e5295b6c89258d1331e9ac578cc992fb818759951bdc22"
 "checksum uuid 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2bcacdce7c75ad110c0dba131d6628c64398593e3895025d043ee2fcf97c4b6e"
+"checksum valico 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c3eee81f726de4eb504b378d00c7648a867816869abb7c7e463cfcef628dc611"
 "checksum vcpkg 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9e0a7d8bed3178a8fb112199d466eeca9ed09a14ba8ad67718179b4fd5487d0b"
 "checksum vec_map 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "887b5b631c2ad01628bbbaa7dd4c869f80d3186688f8d0b6f58774fbe324988c"
 "checksum version_check 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6b772017e347561807c1aa192438c5fd74242a670a6cffacc40f2defd1dc069d"

--- a/components/sup/Cargo.toml
+++ b/components/sup/Cargo.toml
@@ -59,6 +59,7 @@ tempdir = "*"
 time = "*"
 toml = { version = "*", default-features = false }
 url = "*"
+valico ="*"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 caps = "*"
@@ -70,6 +71,7 @@ winapi = "0.2"
 
 [dev-dependencies]
 hyper = "0.10"
+json = "*"
 
 [dev-dependencies.habitat_core]
 git = "https://github.com/habitat-sh/core.git"

--- a/components/sup/doc/render_context_schema.json
+++ b/components/sup/doc/render_context_schema.json
@@ -1,0 +1,507 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "Schema for all the data Habitat makes available in rendered templates",
+    "type": "object",
+    "definitions": {
+        "package_identifier": {
+            "type": "object",
+            "description": "A Habitat package identifier, split apart into its constituent components",
+            "properties": {
+                "origin": {
+                    "description": "The origin of the Habitat package",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "The name of the Habitat package",
+                    "type": "string"
+                },
+                "version": {
+                    "description": "The version of the Habitat package",
+                    "type": "string"
+                },
+                "release": {
+                    "description": "The release of the Habitat package",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "origin",
+                "name",
+                "version",
+                "release"
+            ],
+            "additionalProperties": false
+        },
+        "svc_member": {
+            "type": "object",
+            "description": "Represents a member of a service group",
+            "properties": {
+                "member_id": {
+                    "description": "the member's Supervisor id, e.g., 3d1e73ff19464a27aea3cdc5c2243f74",
+                    "type": "string"
+                },
+                "alive": {
+                    "description": "Whether this member is considered alive and connected to the ring, from a network perspective.",
+                    "type": "boolean"
+                },
+                "suspect": {
+                    "description": "Whether this member is considered \"suspect\", or possibly unreachable, from a network perspective.",
+                    "type": "boolean"
+                },
+                "confirmed": {
+                    "description": "Whether this member is confirmed dead / unreachable, from a network perspective.",
+                    "type": "boolean"
+                },
+                "departed": {
+                    "description": "Whether this member has been departed from the ring (i.e., permanently gone, never to return).",
+                    "type": "boolean"
+                },
+                "election_is_running": {
+                    "description": "Whether a leader election is currently running for this service",
+                    "type": "boolean"
+                },
+                "election_is_no_quorum": {
+                    "description": "Whether there is quorum for a leader election for this service",
+                    "type": "boolean"
+                },
+                "election_is_finished": {
+                    "description": "Whether a leader election for this service has finished",
+                    "type": "boolean"
+                },
+                "update_election_is_running": {
+                    "description": "Whether an update leader election is currently running for this service",
+                    "type": "boolean"
+                },
+                "update_election_is_no_quorum": {
+                    "description": "Whether there is quorum for an update leader election for this service",
+                    "type": "boolean"
+                },
+                "update_election_is_finished": {
+                    "description": "Whether an update leader election for this service has finished",
+                    "type": "boolean"
+                },
+                "leader": {
+                    "description": "Whether this member is the leader in the service group (only meaningful in a leader topology)",
+                    "type": "boolean"
+                },
+                "follower": {
+                    "description": "Whether this member is a follower in the service group (only meaningful in a leader topology)",
+                    "type": "boolean"
+                },
+                "update_leader": {
+                    "description": "Whether this member is the update leader in the service group (only meaningful in a leader topology)",
+                    "type": "boolean"
+                },
+                "update_follower": {
+                    "description": "Whether this member is an update follower in the service group (only meaningful in a leader topology)",
+                    "type": "boolean"
+                },
+                "pkg": {
+                    "description": "The identifier of the release the member is running",
+                    "$ref": "#/definitions/package_identifier"
+                },
+                "sys": {
+                    "description": "An abbreviated version of the top-level {{sys}} object, containing networking information for the member.",
+                    "type": "object",
+                    "properties": {
+                        "ip": {
+                            "description": "The IP address of the running service.",
+                            "type": "string"
+                        },
+                        "hostname": {
+                            "description": "The hostname of the running service. Defaults to `localhost`",
+                            "type": "string"
+                        },
+                        "gossip_ip": {
+                            "description": "Listening address for Supervisor's gossip connection.",
+                            "type": "string"
+                        },
+                        "gossip_port": {
+                            "description": "Listening port for Supervisor's gossip connection.",
+                            "type": "integer"
+                        },
+                        "http_gateway_ip": {
+                            "description": "Listening address for Supervisor's HTTP gateway.",
+                            "type": "string"
+                        },
+                        "http_gateway_port": {
+                            "description": "Listening port for Supervisor's HTTP gateway.",
+                            "type": "integer"
+                        }
+                    },
+                    "required": [
+                        "ip",
+                        "hostname",
+                        "gossip_ip",
+                        "gossip_port",
+                        "http_gateway_ip",
+                        "http_gateway_port"
+                    ],
+                    "additionalProperties": false
+                },
+                "cfg": {
+                    "description": "The configuration the member is currently exporting. This is constrained by what is defined in `pkg_exports`, where the values are replaced with the current values (e.g., taking into account things like user.toml, gossiped configuration values, etc.)",
+                    "type": "object"
+                },
+                "persistent": {
+                    "description": "A misspelling of `permanent`; indicates whether a member is a permanent peer or not",
+                    "type": "boolean"
+                },
+                "service": {
+                    "description": "The name of the service. If the service is running from the package `core/redis`, the value will be `redis`.",
+                    "type": "string"
+                },
+                "group": {
+                    "description": "The group portion of the service's complete group name. In the group name `redis.default`, the group's value is `default`.",
+                    "type": "string"
+                },
+                "org": {
+                    "description": "The organization portion of a service group specification. Unused at this time.",
+                    "oneOf": [
+                        { "type": "string" },
+                        { "type": "null" }
+                    ]
+                },
+                "application": {
+                    "description": "The application portion of a service group specification. Unused at this time.",
+                    "oneOf": [
+                        { "type": "string" },
+                        { "type": "null" }
+                    ]
+                },
+                "environment": {
+                    "description": "The environment portion of a service group specification. Unused at this time.",
+                    "oneOf": [
+                        { "type": "string" },
+                        { "type": "null" }
+                    ]
+                }
+            },
+            "required": [
+                "member_id",
+                "alive",
+                "suspect",
+                "confirmed",
+                "departed",
+                "election_is_running",
+                "election_is_no_quorum",
+                "election_is_finished",
+                "update_election_is_running",
+                "update_election_is_no_quorum",
+                "update_election_is_finished",
+                "leader",
+                "follower",
+                "update_leader",
+                "update_follower",
+                "pkg",
+                "sys",
+                "cfg",
+                "persistent",
+                "service",
+                "group",
+                "org",
+                "application",
+                "environment"
+            ]
+        }
+    },
+    "properties": {
+        "sys": {
+            "description": "Describes the details of how this specific Supervisor was started",
+            "type": "object",
+            "properties": {
+                "version": {
+                    "description": "Version of the Habitat Supervisor, e.g., `0.54.0/20180221023448`",
+                    "type": "string"
+                },
+                "member_id": {
+                    "description": "The member's Supervisor ID, e.g., `3d1e73ff19464a27aea3cdc5c2243f74`",
+                    "type": "string"
+                },
+                "ip": {
+                    "description": "The IP address of the running service.",
+                    "type": "string"
+                },
+                "hostname": {
+                    "description": "The hostname of the running service. Defaults to `localhost`",
+                    "type": "string"
+                },
+                "gossip_ip": {
+                    "description": "Listening address for Supervisor's gossip connection.",
+                    "type": "string"
+                },
+                "gossip_port": {
+                    "description": "Listening port for Supervisor's gossip connection.",
+                    "type": "integer"
+                },
+                "http_gateway_ip": {
+                    "description": "Listening address for Supervisor's HTTP gateway.",
+                    "type": "string"
+                },
+                "http_gateway_port": {
+                    "description": "Listening port for Supervisor's HTTP gateway.",
+                    "type": "integer"
+                },
+                "permanent": {
+                    "description": "Set to true if a Supervisor is being used as a permanent peer, to increase Ring network traffic stability.",
+                    "type": "boolean"
+                }
+            },
+            "required": ["version",
+                         "member_id",
+                         "ip",
+                         "hostname",
+                         "gossip_ip",
+                         "gossip_port",
+                         "http_gateway_ip",
+                         "http_gateway_port",
+                         "permanent"],
+            "additionalProperties": false
+        },
+        "pkg": {
+            "description": "Details about the package currently running the service",
+            "type": "object",
+            "properties": {
+                "ident": {
+                    "description": "The fully-qualified identifier of the running package, e.g., `core/redis/3.2.4/20170514150022`",
+                    "type": "string"
+                },
+                "origin": {
+                    "description": "The origin of the Habitat package",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "The name of the Habitat package",
+                    "type": "string"
+                },
+                "version": {
+                    "description": "The version of the Habitat package",
+                    "type": "string"
+                },
+                "release": {
+                    "description": "The release of the Habitat package",
+                    "type": "string"
+                },
+                "deps": {
+                    "description": "An array of runtime dependencies for your package based on the `pkg_deps` setting in a plan",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/package_identifier"
+                    }
+                },
+                "env": {
+                    "description": "The runtime environment of your package, mirroring the contents of the `RUNTIME_ENVIRONMENT` metadata file. The `PATH` variable is set, containing all dependencies of your package, as well as any other runtime environment variables that have been set by the package. Individual variables can be accessed directly, like `{{pkg.env.PATH}}` (the keys are case sensitive).",
+                    "type": "object",
+                    "additionalProperties": { "type": "string" }
+                },
+                "exposes": {
+                    "description": "The array of ports to expose for an application or service. This value is pulled from the pkg_exposes setting in a plan.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "exports": {
+                    "description": "A map of export key to internal configuration value key (i.e., the contents of `pkg_exports` in your plan). The key is what external services consume. The value is a key in your `default.toml` file that corresponds to the data being exported.",
+                    "type": "object",
+                    "additionalProperties": { "type": "string" }
+                },
+                "path" : {
+                    "description": "The location where the package is installed locally, e.g., `/hab/pkgs/core/redis/3.2.4/20170514150022`. Note that this is _not_ a `PATH` environment variable; for that, please see the `env` key above.",
+                    "type": "string"
+                },
+                "svc_path" : {
+                    "description": "The root location of the source files for the Habitat service, e.g., `/hab/svc/redis`.",
+                    "type": "string"
+                },
+                "svc_config_path" : {
+                    "description": "The location of any templated configuration files for the Habitat service, e.g., `/hab/svc/redis/config`.",
+                    "type": "string"
+                },
+                "svc_data_path" : {
+                    "description": "The location of any data files for the Habitat service, e.g., `/hab/svc/redis/data`.",
+                    "type": "string"
+                },
+                "svc_files_path" : {
+                    "description": "The location of any gossiped configuration files for the Habitat service, e.g., `/hab/svc/redis/files`.",
+                    "type": "string"
+                },
+                "svc_static_path" : {
+                    "description": "The location of any static content for the Habitat service, e.g., `/hab/svc/redis/static`.",
+                    "type": "string"
+                },
+                "svc_var_path" : {
+                    "description": "The location of any variable state data for the Habitat service, e.g., `/hab/svc/redis/var`.",
+                    "type": "string"
+                },
+                "svc_pid_file" : {
+                    "description": "The location of the Habitat service pid file, e.g., `/hab/svc/redis/PID`.",
+                    "type": "string"
+                },
+                "svc_run" : {
+                    "description": "The location of the rendered run hook for the Habitat service, e.g., `/hab/svc/redis/run`.",
+                    "type": "string"
+                },
+                "svc_user" : {
+                    "description": "The value of `pkg_svc_user` specified in a plan.",
+                    "type": "string"
+                },
+                "svc_group" : {
+                    "description": "The value of `pkg_svc_group` specified in a plan.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "ident",
+                "origin",
+                "name",
+                "version",
+                "release",
+                "deps",
+                "env",
+                "exposes",
+                "exports",
+                "path",
+                "svc_path",
+                "svc_config_path",
+                "svc_data_path",
+                "svc_files_path",
+                "svc_static_path",
+                "svc_var_path",
+                "svc_pid_file",
+                "svc_run",
+                "svc_user",
+                "svc_group"
+            ],
+            "additionalProperties": false
+        },
+        "cfg": {
+            "description": "These are settings defined in your templatized configuration file. The values for those settings are pulled from the `default.toml` file included in your package.",
+            "type": "object"
+        },
+        "svc": {
+            "description": "Information about the current service's service group",
+            "type": "object",
+            "properties": {
+                "service": {
+                    "description": "The name of the service. If the service is running from the package `core/redis`, the value will be `redis`.",
+                    "type": "string"
+                },
+                "group": {
+                    "description": "The group portion of the service's complete group name. In the group name `redis.default`, the group's value is `default`.",
+                    "type": "string"
+                },
+                "org": {
+                    "description": "The organization portion of a service group specification. Unused at this time.",
+                    "oneOf": [
+                        { "type": "string" },
+                        { "type": "null" }
+                    ]
+                },
+                "election_is_running": {
+                    "description": "Whether a leader election is currently running for this service",
+                    "type": "boolean"
+                },
+                "election_is_no_quorum": {
+                    "description": "Whether there is quorum for a leader election for this service",
+                    "type": "boolean"
+                },
+                "election_is_finished": {
+                    "description": "Whether a leader election for this service has finished",
+                    "type": "boolean"
+                },
+                "update_election_is_running": {
+                    "description": "Whether an update leader election is currently running for this service",
+                    "type": "boolean"
+                },
+                "update_election_is_no_quorum": {
+                    "description": "Whether there is quorum for an update leader election for this service",
+                    "type": "boolean"
+                },
+                "update_election_is_finished": {
+                    "description": "Whether an update leader election for this service has finished",
+                    "type": "boolean"
+                },
+                "me": {
+                    "description": "An object that provides information about the service running on the local Supervisor",
+                    "$ref": "#/definitions/svc_member"
+                },
+                "first": {
+                    "description": "The first member of this service group",
+                    "$ref": "#/definitions/svc_member"
+                },
+                "members": {
+                    "description": "All members of the service group, across the entire ring. Includes all liveness states!",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/svc_member"
+                    }
+                },
+                "leader": {
+                    "description": "The current leader of the service group, if any (`null` otherwise)",
+                    "oneOf": [
+                        { "$ref": "#/definitions/svc_member" },
+                        { "type": "null" }
+                    ]
+                },
+                "update_leader": {
+                    "description": "The current update_leader of the service group, if any (`null` otherwise)",
+                    "oneOf": [
+                        { "$ref": "#/definitions/svc_member" },
+                        { "type": "null" }
+                    ]
+                }
+            },
+            "required": [
+                "service",
+                "group",
+                "org",
+                "election_is_running",
+                "election_is_no_quorum",
+                "election_is_finished",
+                "update_election_is_running",
+                "update_election_is_no_quorum",
+                "update_election_is_finished",
+                "me",
+                "first",
+                "members",
+                "leader",
+                "update_leader"
+            ],
+            "additionalProperties": false
+        },
+        "bind": {
+            "description": "Exposes information about the service groups this service is bound to. Each key is the name of a bind, while each value is one of the objects described below",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "properties": {
+                    "first": {
+                        "description": "The first member of this service group. If the group is running in a leader topology, this will also be the leader.",
+                        "$ref": "#/definitions/svc_member"
+                    },
+                    "members": {
+                        "description": "All members of the service group, across the entire ring. Includes all liveness states!",
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/svc_member"
+                        }
+                    }
+                },
+                "required": [
+                    "first",
+                    "members"
+                ],
+                "additionalProperties": false
+            }
+        }
+    },
+    "required": [
+        "sys",
+        "pkg",
+        "cfg",
+        "svc",
+        "bind"
+    ],
+    "additionalProperties": false
+}

--- a/components/sup/src/lib.rs
+++ b/components/sup/src/lib.rs
@@ -84,6 +84,10 @@ extern crate tempdir;
 extern crate time;
 extern crate toml;
 extern crate url;
+extern crate valico;
+
+#[cfg(test)]
+extern crate json;
 
 #[macro_export]
 /// Creates a new SupError, embedding the current file name, line number, column, and module path.

--- a/components/sup/src/manager/service/config.rs
+++ b/components/sup/src/manager/service/config.rs
@@ -454,7 +454,7 @@ impl CfgRenderer {
                     "Configuration {} does not exist; restarting",
                     cfg_dest.display()
                 );
-                outputln!(preamble ctx.svc.group, "Updated {} {}",
+                outputln!(preamble ctx.group_name(), "Updated {} {}",
                           template.as_str(),
                           compiled_hash);
                 let mut config_file = File::create(&cfg_dest)?;
@@ -479,7 +479,7 @@ impl CfgRenderer {
                         "Configuration {} has changed; restarting",
                         cfg_dest.display()
                     );
-                    outputln!(preamble ctx.svc.group,"Updated {} {}",
+                    outputln!(preamble ctx.group_name(),"Updated {} {}",
                               template.as_str(),
                               compiled_hash);
                     let mut config_file = File::create(&cfg_dest)?;
@@ -510,8 +510,7 @@ fn toml_merge_recurse(
 ) -> Result<()> {
     if depth > TOML_MAX_MERGE_DEPTH {
         return Err(sup_error!(Error::TomlMergeError(format!(
-            "Max recursive merge depth of {} \
-                                                             exceeded.",
+            "Max recursive merge depth of {} exceeded.",
             TOML_MAX_MERGE_DEPTH
         ))));
     }
@@ -521,11 +520,9 @@ fn toml_merge_recurse(
             let mut me_at_key = match *(me.get_mut(key).expect("Key should exist in Table")) {
                 toml::Value::Table(ref mut t) => t,
                 _ => {
-                    return Err(sup_error!(Error::TomlMergeError(format!(
-                        "Value at key {} \
-                                                                         should be a Table",
-                        &key
-                    ))));
+                    return Err(sup_error!(Error::TomlMergeError(
+                        format!("Value at key {} should be a Table", &key),
+                    )));
                 }
             };
             toml_merge_recurse(

--- a/components/sup/src/manager/service/mod.rs
+++ b/components/sup/src/manager/service/mod.rs
@@ -14,7 +14,7 @@
 
 pub mod hooks;
 mod composite_spec;
-mod config;
+pub mod config;
 mod dir;
 mod health;
 mod package;
@@ -57,7 +57,7 @@ use sys::abilities;
 
 pub use self::config::{Cfg, UserConfigPath};
 pub use self::health::{HealthCheck, SmokeCheck};
-pub use self::package::Pkg;
+pub use self::package::{Env, Pkg};
 pub use self::composite_spec::CompositeSpec;
 pub use self::spec::{DesiredState, ServiceBind, ServiceSpec, StartStyle};
 pub use self::supervisor::ProcessState;

--- a/components/sup/src/manager/service/package.rs
+++ b/components/sup/src/manager/service/package.rs
@@ -33,13 +33,22 @@ const PATH_KEY: &'static str = "PATH";
 static LOGKEY: &'static str = "PK";
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct Env(pub HashMap<String, String>);
+pub struct Env(HashMap<String, String>);
 
 impl Deref for Env {
     type Target = HashMap<String, String>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+// Convenience implementation for ease of setting up test instances;
+// real code should use `Env::new`
+#[cfg(test)]
+impl From<HashMap<String, String>> for Env {
+    fn from(inner_map: HashMap<String, String>) -> Self {
+        Env(inner_map)
     }
 }
 

--- a/components/sup/src/manager/service/package.rs
+++ b/components/sup/src/manager/service/package.rs
@@ -33,7 +33,7 @@ const PATH_KEY: &'static str = "PATH";
 static LOGKEY: &'static str = "PK";
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct Env(HashMap<String, String>);
+pub struct Env(pub HashMap<String, String>);
 
 impl Deref for Env {
     type Target = HashMap<String, String>;
@@ -79,16 +79,6 @@ impl Env {
     }
 }
 
-// NOTE: This is exposed to users in templates. Any public member is
-// accessible to users, so change this interface with care.
-//
-// User-facing documentation is available at
-// https://www.habitat.sh/docs/reference/#template-data; update that
-// as required.
-//
-// TODO (CM): move templatable content into a distinct type to
-// separate these concerns; Pkg is currently also used for
-// non-templating purposes, as well.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Pkg {
     #[serde(deserialize_with = "deserialize_using_from_str",

--- a/components/sup/src/manager/sys.rs
+++ b/components/sup/src/manager/sys.rs
@@ -26,12 +26,6 @@ use http_gateway;
 static LOGKEY: &'static str = "SY";
 
 
-// NOTE: This is exposed to users in templates. Any public member is
-// accessible to users, so change this interface with care.
-//
-// User-facing documentation is available at
-// https://www.habitat.sh/docs/reference/#template-data; update that
-// as required.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct Sys {
     pub version: String,

--- a/components/sup/src/sys/unix/users.rs
+++ b/components/sup/src/sys/unix/users.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use hcore::os::users;
-use hcore::package::PackageInstall;
 
 use error::{Result, Error};
 

--- a/components/sup/src/templating/context.rs
+++ b/components/sup/src/templating/context.rs
@@ -141,13 +141,13 @@ impl<'a> RenderContext<'a> {
 struct SystemInfo<'a> {
     version: Cow<'a, String>,
     member_id: Cow<'a, String>,
-    ip: IpAddr,
+    ip: Cow<'a, IpAddr>,
     hostname: Cow<'a, String>,
-    gossip_ip: IpAddr,
-    gossip_port: u16,
-    http_gateway_ip: IpAddr,
-    http_gateway_port: u16,
-    permanent: bool,
+    gossip_ip: Cow<'a, IpAddr>,
+    gossip_port: Cow<'a, u16>,
+    http_gateway_ip: Cow<'a, IpAddr>,
+    http_gateway_port: Cow<'a, u16>,
+    permanent: Cow<'a, bool>,
 }
 
 impl<'a> SystemInfo<'a> {
@@ -155,13 +155,13 @@ impl<'a> SystemInfo<'a> {
         SystemInfo {
             version: Cow::Borrowed(&sys.version),
             member_id: Cow::Borrowed(&sys.member_id),
-            ip: sys.ip,
+            ip: Cow::Borrowed(&sys.ip),
             hostname: Cow::Borrowed(&sys.hostname),
-            gossip_ip: sys.gossip_ip,
-            gossip_port: sys.gossip_port,
-            http_gateway_ip: sys.http_gateway_ip,
-            http_gateway_port: sys.http_gateway_port,
-            permanent: sys.permanent,
+            gossip_ip: Cow::Borrowed(&sys.gossip_ip),
+            gossip_port: Cow::Borrowed(&sys.gossip_port),
+            http_gateway_ip: Cow::Borrowed(&sys.http_gateway_ip),
+            http_gateway_port: Cow::Borrowed(&sys.http_gateway_port),
+            permanent: Cow::Borrowed(&sys.permanent),
         }
     }
 }
@@ -295,7 +295,7 @@ struct Svc<'a> {
     me: Cow<'a, SvcMember<'a>>,
 
     // TODO (CM): this will need to be optional soon
-    first: SvcMember<'a>,
+    first: Cow<'a, SvcMember<'a>>,
 }
 
 impl<'a> Svc<'a> {
@@ -324,7 +324,9 @@ impl<'a> Svc<'a> {
             update_leader: Cow::Owned(census_group.update_leader().map(|m| {
                 SvcMember::from_census_member(m)
             })),
-            first: select_first(census_group).expect("First should always be present on svc"),
+            first: Cow::Owned(select_first(census_group).expect(
+                "First should always be present on svc",
+            )),
         }
     }
 }
@@ -441,22 +443,22 @@ struct SvcMember<'a> {
     service: Cow<'a, String>,
     group: Cow<'a, String>,
     org: Cow<'a, Option<String>>,
-    persistent: bool,
-    leader: bool,
-    follower: bool,
-    update_leader: bool,
-    update_follower: bool,
-    election_is_running: bool,
-    election_is_no_quorum: bool,
-    election_is_finished: bool,
-    update_election_is_running: bool,
-    update_election_is_no_quorum: bool,
-    update_election_is_finished: bool,
+    persistent: Cow<'a, bool>,
+    leader: Cow<'a, bool>,
+    follower: Cow<'a, bool>,
+    update_leader: Cow<'a, bool>,
+    update_follower: Cow<'a, bool>,
+    election_is_running: Cow<'a, bool>,
+    election_is_no_quorum: Cow<'a, bool>,
+    election_is_finished: Cow<'a, bool>,
+    update_election_is_running: Cow<'a, bool>,
+    update_election_is_no_quorum: Cow<'a, bool>,
+    update_election_is_finished: Cow<'a, bool>,
     sys: Cow<'a, SysInfo>,
-    alive: bool,
-    suspect: bool,
-    confirmed: bool,
-    departed: bool,
+    alive: Cow<'a, bool>,
+    suspect: Cow<'a, bool>,
+    confirmed: Cow<'a, bool>,
+    departed: Cow<'a, bool>,
     cfg: Cow<'a, toml::value::Table>,
 }
 
@@ -470,27 +472,27 @@ impl<'a> SvcMember<'a> {
             service: Cow::Borrowed(&c.service),
             group: Cow::Borrowed(&c.group),
             org: Cow::Borrowed(&c.org),
-            persistent: c.persistent,
-            leader: c.leader,
-            follower: c.follower,
-            update_leader: c.update_leader,
-            update_follower: c.update_follower,
-            election_is_running: c.election_is_running,
-            election_is_no_quorum: c.election_is_no_quorum,
-            election_is_finished: c.election_is_finished,
-            update_election_is_running: c.update_election_is_running,
-            update_election_is_no_quorum: c.update_election_is_no_quorum,
-            update_election_is_finished: c.update_election_is_finished,
+            persistent: Cow::Borrowed(&c.persistent),
+            leader: Cow::Borrowed(&c.leader),
+            follower: Cow::Borrowed(&c.follower),
+            update_leader: Cow::Borrowed(&c.update_leader),
+            update_follower: Cow::Borrowed(&c.update_follower),
+            election_is_running: Cow::Borrowed(&c.election_is_running),
+            election_is_no_quorum: Cow::Borrowed(&c.election_is_no_quorum),
+            election_is_finished: Cow::Borrowed(&c.election_is_finished),
+            update_election_is_running: Cow::Borrowed(&c.update_election_is_running),
+            update_election_is_no_quorum: Cow::Borrowed(&c.update_election_is_no_quorum),
+            update_election_is_finished: Cow::Borrowed(&c.update_election_is_finished),
 
             // TODO (CM): unify this with manager::Sys; they're not
             // the same types, but very close as far as templating is
             // concerned.
             sys: Cow::Borrowed(&c.sys),
 
-            alive: c.health == Health::Alive,
-            suspect: c.health == Health::Suspect,
-            confirmed: c.health == Health::Confirmed,
-            departed: c.health == Health::Departed,
+            alive: Cow::Owned(c.health == Health::Alive),
+            suspect: Cow::Owned(c.health == Health::Suspect),
+            confirmed: Cow::Owned(c.health == Health::Confirmed),
+            departed: Cow::Owned(c.health == Health::Departed),
 
             cfg: Cow::Borrowed(&c.cfg),
         }
@@ -745,13 +747,13 @@ two = 2
         let system_info = SystemInfo {
             version: Cow::Owned("I AM A HABITAT VERSION".into()),
             member_id: Cow::Owned("MEMBER_ID".into()),
-            ip: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+            ip: Cow::Owned(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))),
             hostname: Cow::Owned("MY_HOSTNAME".into()),
-            gossip_ip: IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
-            gossip_port: 1234,
-            http_gateway_ip: IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
-            http_gateway_port: 5678,
-            permanent: false,
+            gossip_ip: Cow::Owned(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0))),
+            gossip_port: Cow::Owned(1234),
+            http_gateway_ip: Cow::Owned(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0))),
+            http_gateway_port: Cow::Owned(5678),
+            permanent: Cow::Owned(false),
         };
 
         let ident = PackageIdent::new("core", "test_pkg", Some("1.0.0"), Some("20180321150416"));
@@ -819,22 +821,22 @@ two = 2
             service: Cow::Owned("foo".into()),
             group: Cow::Owned("default".into()),
             org: Cow::Owned(None),
-            persistent: true,
-            leader: false,
-            follower: false,
-            update_leader: false,
-            update_follower: false,
-            election_is_running: false,
-            election_is_no_quorum: false,
-            election_is_finished: false,
-            update_election_is_running: false,
-            update_election_is_no_quorum: false,
-            update_election_is_finished: false,
+            persistent: Cow::Owned(true),
+            leader: Cow::Owned(false),
+            follower: Cow::Owned(false),
+            update_leader: Cow::Owned(false),
+            update_follower: Cow::Owned(false),
+            election_is_running: Cow::Owned(false),
+            election_is_no_quorum: Cow::Owned(false),
+            election_is_finished: Cow::Owned(false),
+            update_election_is_running: Cow::Owned(false),
+            update_election_is_no_quorum: Cow::Owned(false),
+            update_election_is_finished: Cow::Owned(false),
             sys: Cow::Owned(sys_info),
-            alive: true,
-            suspect: false,
-            confirmed: false,
-            departed: false,
+            alive: Cow::Owned(true),
+            suspect: Cow::Owned(false),
+            confirmed: Cow::Owned(false),
+            departed: Cow::Owned(false),
             cfg: Cow::Owned(svc_member_cfg as toml::value::Table),
         };
 
@@ -846,7 +848,7 @@ two = 2
             leader: Cow::Owned(None),
             update_leader: Cow::Owned(None),
             me: Cow::Owned(me.clone()),
-            first: me.clone(),
+            first: Cow::Owned(me.clone()),
         };
 
         let mut bind_map = HashMap::new();

--- a/components/sup/src/templating/context.rs
+++ b/components/sup/src/templating/context.rs
@@ -623,7 +623,6 @@ mod tests {
     use std::collections::BTreeMap;
     use hcore::package::PackageIdent;
     use manager::service::Cfg;
-    use manager::service::Env;
 
     /// Asserts that `json_string` is valid according to our render
     /// context JSON schema.
@@ -789,7 +788,7 @@ two = 2
             version: Cow::Owned(ident.version.clone().unwrap()),
             release: Cow::Owned(ident.release.clone().unwrap()),
             deps: Cow::Owned(deps),
-            env: Cow::Owned(Env(env_hash)),
+            env: Cow::Owned(env_hash.into()),
             exposes: Cow::Owned(vec!["1234".into(), "8000".into(), "2112".into()]),
             exports: Cow::Owned(export_hash),
             path: Cow::Owned("my_path".into()),

--- a/components/sup/src/templating/context.rs
+++ b/components/sup/src/templating/context.rs
@@ -233,7 +233,9 @@ impl<'a> Serialize for Package<'a> {
     where
         S: Serializer,
     {
-        let mut map = serializer.serialize_map(Some(20))?;
+        // Explicitly focusing on JSON serialization, which does not
+        // need a length hint (thus the `None`)
+        let mut map = serializer.serialize_map(None)?;
 
         // This is really the only thing that we need to have a custom
         // `Serialize` implementation for. Alternatively, we could
@@ -336,7 +338,9 @@ impl<'a> Serialize for Svc<'a> {
     where
         S: Serializer,
     {
-        let mut map = serializer.serialize_map(Some(14))?;
+        // Explicitly focusing on JSON serialization, which does not
+        // need a length hint (thus the `None`)
+        let mut map = serializer.serialize_map(None)?;
 
         map.serialize_entry(
             "service",
@@ -504,7 +508,9 @@ impl<'a> Serialize for SvcMember<'a> {
     where
         S: Serializer,
     {
-        let mut map = serializer.serialize_map(Some(24))?;
+        // Explicitly focusing on JSON serialization, which does not
+        // need a length hint (thus the `None`)
+        let mut map = serializer.serialize_map(None)?;
 
         map.serialize_entry("member_id", &self.member_id)?;
 

--- a/components/sup/src/templating/context.rs
+++ b/components/sup/src/templating/context.rs
@@ -12,16 +12,385 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
+//! Defines the data that we provide users in their template files.
+//!
+//! The data structures in this module effectively serve as wrappers
+//! or proxies for other Supervisor-internal data structures. They use
+//! `Cow` types for flexibility; in the normal code flow, they will
+//! just take references to existing data, keeping the memory
+//! footprint low. For tests, however, they can be created directly
+//! with test data, which means you don't need to instantiate a lot of
+//! complex data structures just to verify their behavior.
+//!
+//! Using custom data type proxies like this allows us to decouple the
+//! internal data structures from the needs of the templating
+//! engine. Since the ultimate purpose of the rendering context is to
+//! create a JSON object, we can specify our own custom `Serialize`
+//! implementations, completely separate from any implementations on
+//! the original data structures. This allows us to further decouple
+//! things, giving us the ability to add new fields to the rendering
+//! context at the serialization level (e.g., to add the same data
+//! under a different name, introduce new views on existing data,
+//! etc.), which finally gives us a safe mechanism by which to evolve
+//! our rendering context.
+//!
+//! As such, know that any changes to the `Serialize` implementations
+//! in this module will have an immediate and direct effect on the
+//! data that is available in users' templates. Make changes with care
+//! and deliberation.
+//!
+//! To help guard against this, the entire structure of the rendering
+//! context is also defined in a JSON Schema document, which is used
+//! in tests to validate everything.
+//!
+//! All proxy types and implementations are private, to emphasize
+//! their focused and single-use purpose; they shouldn't be used for
+//! anything else, and so, they _can't_ be used for anything else.
 
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::net::IpAddr;
+use std::path::PathBuf;
+use std::result;
+
+use serde::{Serialize, Serializer};
+use serde::ser::SerializeMap;
+use toml;
+
+use butterfly::member::Health;
+use butterfly::rumor::service::SysInfo;
+use hcore::package::PackageIdent;
 use hcore::service::ServiceGroup;
 
-use census::{CensusGroup, CensusMember, CensusRing, ElectionStatus};
+use census::{CensusGroup, CensusMember, CensusRing, ElectionStatus, MemberId};
+use manager::service::{Cfg, Env, Pkg, ServiceBind};
 use manager::Sys;
-use manager::service::{Cfg, Pkg, ServiceBind};
+
+/// The context of a rendering call, exposing information on the
+/// currently-running Supervisor and service, its service group, and
+/// groups it is bound to. The JSON serialization of this
+/// structure is what is exposed to users in their templates.
+///
+/// NOTE: This public interface of this structure is defined by its
+/// Serde `Serialize` implementation (and those of its members), so
+/// change this with care.
+///
+/// User-facing documentation is available at
+/// https://www.habitat.sh/docs/reference/#template-data; update that
+/// as required.
+#[derive(Clone, Debug, Serialize)]
+pub struct RenderContext<'a> {
+    sys: SystemInfo<'a>,
+    pkg: Package<'a>,
+    cfg: Cow<'a, Cfg>,
+    svc: Svc<'a>,
+    bind: Binds<'a>,
+}
+
+impl<'a> RenderContext<'a> {
+    /// Create a RenderContext that wraps a number of internal data
+    /// structures, safely and selectively exposing the data to users
+    /// in their templates.
+    ///
+    /// Note that we wrap everything except the `Cfg`, to which we
+    /// maintain a direct reference. The serialization logic for this
+    /// is already complex, and exactly what we need. Because of the
+    /// nature of `Cfg`s behavior, we should be safe relying on that
+    /// implementation for the foreseeable future.
+    pub fn new<T>(
+        service_group: &ServiceGroup,
+        sys: &'a Sys,
+        pkg: &'a Pkg,
+        cfg: &'a Cfg,
+        census: &'a CensusRing,
+        bindings: T,
+    ) -> RenderContext<'a>
+    where
+        T: Iterator<Item = &'a ServiceBind>,
+    {
+        let census_group = census.census_group_for(&service_group).expect(
+            "Census Group missing from list!",
+        );
+        RenderContext {
+            sys: SystemInfo::from_sys(sys),
+            pkg: Package::from_pkg(pkg),
+            cfg: Cow::Borrowed(cfg),
+            svc: Svc::new(census_group),
+            bind: Binds::new(bindings, census),
+        }
+    }
+
+    // Exposed only for logging... can probably do this another way.
+    pub fn group_name(&self) -> &str {
+        self.svc.service_group.group()
+    }
+}
+
+////////////////////////////////////////////////////////////////////////
+// PRIVATE CODE BELOW
+////////////////////////////////////////////////////////////////////////
+
+// TODO (CM): Consider renaming this to something like SupInfo, since
+// it really captures information about how the Supervisor is invoked,
+// and consider exposing it under a "sup" key
+
+/// Templating proxy for a `manager::Sys` struct.
+///
+/// Currently exposed to users under the `sys` key.
+#[derive(Clone, Debug, Serialize)]
+struct SystemInfo<'a> {
+    version: Cow<'a, String>,
+    member_id: Cow<'a, String>,
+    ip: IpAddr,
+    hostname: Cow<'a, String>,
+    gossip_ip: IpAddr,
+    gossip_port: u16,
+    http_gateway_ip: IpAddr,
+    http_gateway_port: u16,
+    permanent: bool,
+}
+
+impl<'a> SystemInfo<'a> {
+    fn from_sys(sys: &'a Sys) -> Self {
+        SystemInfo {
+            version: Cow::Borrowed(&sys.version),
+            member_id: Cow::Borrowed(&sys.member_id),
+            ip: sys.ip,
+            hostname: Cow::Borrowed(&sys.hostname),
+            gossip_ip: sys.gossip_ip,
+            gossip_port: sys.gossip_port,
+            http_gateway_ip: sys.http_gateway_ip,
+            http_gateway_port: sys.http_gateway_port,
+            permanent: sys.permanent,
+        }
+    }
+}
+
+////////////////////////////////////////////////////////////////////////
+
+/// Templating proxy fro a `manager::service::Pkg` struct.
+///
+/// Currently exposed to users under the `pkg` key.
+#[derive(Clone, Debug)]
+struct Package<'a> {
+    ident: Cow<'a, PackageIdent>,
+    origin: Cow<'a, String>,
+    name: Cow<'a, String>,
+    version: Cow<'a, String>,
+    release: Cow<'a, String>,
+    deps: Cow<'a, Vec<PackageIdent>>,
+    env: Cow<'a, Env>,
+    // TODO (CM): Ideally, this would be Vec<u16>, since they're ports.
+    exposes: Cow<'a, Vec<String>>,
+    exports: Cow<'a, HashMap<String, String>>,
+    // TODO (CM): Maybe Path instead of Cow<'a PathBuf>?
+    path: Cow<'a, PathBuf>,
+    svc_path: Cow<'a, PathBuf>,
+    svc_config_path: Cow<'a, PathBuf>,
+    svc_data_path: Cow<'a, PathBuf>,
+    svc_files_path: Cow<'a, PathBuf>,
+    svc_static_path: Cow<'a, PathBuf>,
+    svc_var_path: Cow<'a, PathBuf>,
+    svc_pid_file: Cow<'a, PathBuf>,
+    svc_run: Cow<'a, PathBuf>,
+    svc_user: Cow<'a, String>,
+    svc_group: Cow<'a, String>,
+}
+
+impl<'a> Package<'a> {
+    fn from_pkg(pkg: &'a Pkg) -> Self {
+        Package {
+            ident: Cow::Borrowed(&pkg.ident),
+            // TODO (CM): have Pkg use FullyQualifiedPackageIdent, and
+            // get origin, name, version, and release from it, rather
+            // than storing each individually; I suspect that was just
+            // for templating
+            origin: Cow::Borrowed(&pkg.origin),
+            name: Cow::Borrowed(&pkg.name),
+            version: Cow::Borrowed(&pkg.version),
+            release: Cow::Borrowed(&pkg.release),
+            deps: Cow::Borrowed(&pkg.deps),
+            env: Cow::Borrowed(&pkg.env),
+            exposes: Cow::Borrowed(&pkg.exposes),
+            exports: Cow::Borrowed(&pkg.exports),
+            path: Cow::Borrowed(&pkg.path),
+            svc_path: Cow::Borrowed(&pkg.svc_path),
+            svc_config_path: Cow::Borrowed(&pkg.svc_config_path),
+            svc_data_path: Cow::Borrowed(&pkg.svc_data_path),
+            svc_files_path: Cow::Borrowed(&pkg.svc_files_path),
+            svc_static_path: Cow::Borrowed(&pkg.svc_static_path),
+            svc_var_path: Cow::Borrowed(&pkg.svc_var_path),
+            svc_pid_file: Cow::Borrowed(&pkg.svc_pid_file),
+            svc_run: Cow::Borrowed(&pkg.svc_run),
+            svc_user: Cow::Borrowed(&pkg.svc_user),
+            svc_group: Cow::Borrowed(&pkg.svc_group),
+        }
+    }
+}
+
+impl<'a> Serialize for Package<'a> {
+    fn serialize<S>(&self, serializer: S) -> result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut map = serializer.serialize_map(Some(20))?;
+
+        // This is really the only thing that we need to have a custom
+        // `Serialize` implementation for. Alternatively, we could
+        // wrap our ident in a proxy type that has its own Serialize
+        // implementation, but I think we're going to have some other
+        // changes in this serialization format soon (e.g., around
+        // `deps` and `exposes`, and eventually storing a
+        // FullyQualifiedPackageIdent here).
+        map.serialize_entry("ident", &self.ident.to_string())?;
+
+        // Break out the components of the identifier, for easy access
+        // in templates
+        map.serialize_entry("origin", &self.origin)?;
+        map.serialize_entry("name", &self.name)?;
+        map.serialize_entry("version", &self.version)?;
+        map.serialize_entry("release", &self.release)?;
+
+        map.serialize_entry("deps", &self.deps)?;
+        map.serialize_entry("env", &self.env)?;
+
+        map.serialize_entry("exposes", &self.exposes)?;
+        map.serialize_entry("exports", &self.exports)?;
+        map.serialize_entry("path", &self.path)?;
+
+        map.serialize_entry("svc_path", &self.svc_path)?;
+        map.serialize_entry(
+            "svc_config_path",
+            &self.svc_config_path,
+        )?;
+        map.serialize_entry("svc_data_path", &self.svc_data_path)?;
+        map.serialize_entry("svc_files_path", &self.svc_files_path)?;
+        map.serialize_entry(
+            "svc_static_path",
+            &self.svc_static_path,
+        )?;
+        map.serialize_entry("svc_var_path", &self.svc_var_path)?;
+        map.serialize_entry("svc_pid_file", &self.svc_pid_file)?;
+        map.serialize_entry("svc_run", &self.svc_run)?;
+        map.serialize_entry("svc_user", &self.svc_user)?;
+        map.serialize_entry("svc_group", &self.svc_group)?;
+
+        map.end()
+    }
+}
+
+///////////////////////////////////////////////////////////////////////
+
+/// Templating proxy around a `census::CensusGroup`.
+///
+/// Currently exposed to users under the `svc` key.
+#[derive(Clone, Debug)]
+struct Svc<'a> {
+    service_group: Cow<'a, ServiceGroup>,
+    election_status: Cow<'a, ElectionStatus>,
+    update_election_status: Cow<'a, ElectionStatus>,
+    members: Cow<'a, Vec<SvcMember<'a>>>,
+    leader: Cow<'a, Option<SvcMember<'a>>>,
+    update_leader: Cow<'a, Option<SvcMember<'a>>>,
+    me: Cow<'a, SvcMember<'a>>,
+
+    // TODO (CM): this will need to be optional soon
+    first: SvcMember<'a>,
+}
+
+impl<'a> Svc<'a> {
+    // TODO (CM): rename to from_census_group
+    fn new(census_group: &'a CensusGroup) -> Self {
+        Svc {
+            service_group: Cow::Borrowed(&census_group.service_group),
+            election_status: Cow::Borrowed(&census_group.election_status),
+            update_election_status: Cow::Borrowed(&census_group.update_election_status),
+            members: Cow::Owned(
+                census_group
+                    .members()
+                    .iter()
+                    .map(|m| SvcMember::from_census_member(m))
+                    .collect::<Vec<SvcMember<'a>>>(),
+            ),
+            me: Cow::Owned(
+                census_group
+                    .me()
+                    .map(|m| SvcMember::from_census_member(m))
+                    .expect("Missing 'me'"),
+            ),
+            leader: Cow::Owned(census_group.leader().map(
+                |m| SvcMember::from_census_member(m),
+            )),
+            update_leader: Cow::Owned(census_group.update_leader().map(|m| {
+                SvcMember::from_census_member(m)
+            })),
+            first: select_first(census_group).expect("First should always be present on svc"),
+        }
+    }
+}
+
+impl<'a> Serialize for Svc<'a> {
+    fn serialize<S>(&self, serializer: S) -> result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut map = serializer.serialize_map(Some(14))?;
+
+        map.serialize_entry(
+            "service",
+            &self.service_group.service(),
+        )?;
+        map.serialize_entry("group", &self.service_group.group())?;
+        map.serialize_entry("org", &self.service_group.org())?;
+        // TODO (CM): need to add application, environment (to
+        // maintain parity with SvcMember; see below), as well as the
+        // complete service_group as a string.
+
+        map.serialize_entry(
+            "election_is_running",
+            &(self.election_status.as_ref() ==
+                  &ElectionStatus::ElectionInProgress),
+        )?;
+        map.serialize_entry(
+            "election_is_no_quorum",
+            &(self.election_status.as_ref() ==
+                  &ElectionStatus::ElectionNoQuorum),
+        )?;
+        map.serialize_entry(
+            "election_is_finished",
+            &(self.election_status.as_ref() ==
+                  &ElectionStatus::ElectionFinished),
+        )?;
+        map.serialize_entry(
+            "update_election_is_running",
+            &(self.update_election_status.as_ref() ==
+                  &ElectionStatus::ElectionInProgress),
+        )?;
+        map.serialize_entry(
+            "update_election_is_no_quorum",
+            &(self.update_election_status.as_ref() ==
+                  &ElectionStatus::ElectionNoQuorum),
+        )?;
+        map.serialize_entry(
+            "update_election_is_finished",
+            &(self.update_election_status.as_ref() ==
+                  &ElectionStatus::ElectionFinished),
+        )?;
+
+        map.serialize_entry("me", &self.me)?;
+        map.serialize_entry("members", &self.members)?;
+        map.serialize_entry("leader", &self.leader)?;
+        map.serialize_entry("first", &self.first)?;
+        map.serialize_entry("update_leader", &self.update_leader)?;
+
+        map.end()
+    }
+}
+
+////////////////////////////////////////////////////////////////////////
 
 #[derive(Clone, Debug, Serialize)]
-pub struct Binds<'a>(HashMap<String, BindGroup<'a>>);
+struct Binds<'a>(HashMap<String, BindGroup<'a>>);
 
 impl<'a> Binds<'a> {
     fn new<T>(bindings: T, census: &'a CensusRing) -> Self
@@ -38,138 +407,510 @@ impl<'a> Binds<'a> {
     }
 }
 
-// NOTE: This is exposed to users in templates. Any public member is
-// accessible to users, so change this interface with care.
-//
-// User-facing documentation is available at
-// https://www.habitat.sh/docs/reference/#template-data; update that
-// as required.
 #[derive(Clone, Debug, Serialize)]
-pub struct BindGroup<'a> {
-    pub first: Option<SvcMember<'a>>,
-    pub members: Vec<SvcMember<'a>>,
+struct BindGroup<'a> {
+    first: Option<SvcMember<'a>>,
+    members: Vec<SvcMember<'a>>,
 }
 
 impl<'a> BindGroup<'a> {
     fn new(group: &'a CensusGroup) -> Self {
         BindGroup {
             first: select_first(group),
-            members: group.members().iter().map(|m| SvcMember(m)).collect(),
-        }
-    }
-}
-
-/// The context of a render call.
-///
-/// It stores information on a Service and its configuration.
-///
-/// NOTE: This is the entrypoint for all data available to users in
-/// templates. Any public member _that is serialized_ is accessible to
-/// users, so change this interface with care.
-///
-/// User-facing documentation is available at
-/// https://www.habitat.sh/docs/reference/#template-data; update that
-/// as required.
-#[derive(Clone, Debug, Serialize)]
-pub struct RenderContext<'a> {
-    pub sys: &'a Sys,
-    pub pkg: &'a Pkg,
-    pub cfg: &'a Cfg,
-    pub svc: Svc<'a>,
-    pub bind: Binds<'a>,
-}
-
-impl<'a> RenderContext<'a> {
-    pub fn new<T>(
-        service_group: &ServiceGroup,
-        sys: &'a Sys,
-        pkg: &'a Pkg,
-        cfg: &'a Cfg,
-        census: &'a CensusRing,
-        bindings: T,
-    ) -> RenderContext<'a>
-    where
-        T: Iterator<Item = &'a ServiceBind>,
-    {
-        let census_group = census.census_group_for(&service_group).expect(
-            "Census Group missing from list!",
-        );
-        RenderContext {
-            sys: sys,
-            pkg: pkg,
-            cfg: cfg,
-            svc: Svc::new(census_group),
-            bind: Binds::new(bindings, census),
-        }
-    }
-}
-
-#[derive(Clone, Debug, Serialize)]
-pub struct Svc<'a> {
-    pub service: &'a str,
-    pub group: &'a str,
-    pub org: Option<&'a str>,
-    pub election_is_running: bool,
-    pub election_is_no_quorum: bool,
-    pub election_is_finished: bool,
-    pub update_election_is_running: bool,
-    pub update_election_is_no_quorum: bool,
-    pub update_election_is_finished: bool,
-    pub me: SvcMember<'a>,
-    pub first: SvcMember<'a>,
-    pub members: Vec<SvcMember<'a>>,
-    pub leader: Option<SvcMember<'a>>,
-    pub update_leader: Option<SvcMember<'a>>,
-}
-
-impl<'a> Svc<'a> {
-    fn new(census_group: &'a CensusGroup) -> Self {
-        Svc {
-            service: census_group.service_group.service(),
-            group: census_group.service_group.group(),
-            org: census_group.service_group.org(),
-            election_is_running: census_group.election_status == ElectionStatus::ElectionInProgress,
-            election_is_no_quorum: census_group.election_status == ElectionStatus::ElectionNoQuorum,
-            election_is_finished: census_group.election_status == ElectionStatus::ElectionFinished,
-            update_election_is_running: census_group.election_status ==
-                ElectionStatus::ElectionInProgress,
-            update_election_is_no_quorum: census_group.election_status ==
-                ElectionStatus::ElectionNoQuorum,
-            update_election_is_finished: census_group.election_status ==
-                ElectionStatus::ElectionFinished,
-            me: SvcMember(census_group.me().expect("Missing 'me'")),
-            members: census_group
+            members: group
                 .members()
                 .iter()
-                .map(|m| SvcMember(m))
+                .map(|m| SvcMember::from_census_member(m))
                 .collect(),
-            leader: census_group.leader().map(|m| SvcMember(m)),
-            first: select_first(census_group).expect("First should always be present on svc"),
-            update_leader: census_group.update_leader().map(|m| SvcMember(m)),
         }
     }
 }
 
+////////////////////////////////////////////////////////////////////////
 
-// NOTE: This is exposed to users in templates. Any public member is
-// accessible to users, so change this interface with care.
-//
-// User-facing documentation is available at
-// https://www.habitat.sh/docs/reference/#template-data; update that
-// as required.
-/// A friendly representation of a `CensusMember` to the templating system.
-#[derive(Clone, Debug, Serialize)]
-pub struct SvcMember<'a>(&'a CensusMember);
+/// Templating proxy for a `census::CensusMember` struct.
+///
+/// Not exposed via a top-level key, but ultimately available through
+/// the `svc` and `bind` keys.
+#[derive(Clone, Debug)]
+struct SvcMember<'a> {
+    member_id: Cow<'a, MemberId>,
+    pkg: Cow<'a, Option<PackageIdent>>,
+    application: Cow<'a, Option<String>>,
+    environment: Cow<'a, Option<String>>,
+    service: Cow<'a, String>,
+    group: Cow<'a, String>,
+    org: Cow<'a, Option<String>>,
+    persistent: bool,
+    leader: bool,
+    follower: bool,
+    update_leader: bool,
+    update_follower: bool,
+    election_is_running: bool,
+    election_is_no_quorum: bool,
+    election_is_finished: bool,
+    update_election_is_running: bool,
+    update_election_is_no_quorum: bool,
+    update_election_is_finished: bool,
+    sys: Cow<'a, SysInfo>,
+    alive: bool,
+    suspect: bool,
+    confirmed: bool,
+    departed: bool,
+    cfg: Cow<'a, toml::value::Table>,
+}
+
+impl<'a> SvcMember<'a> {
+    fn from_census_member(c: &'a CensusMember) -> Self {
+        SvcMember {
+            member_id: Cow::Borrowed(&c.member_id),
+            pkg: Cow::Borrowed(&c.pkg),
+            application: Cow::Borrowed(&c.application),
+            environment: Cow::Borrowed(&c.environment),
+            service: Cow::Borrowed(&c.service),
+            group: Cow::Borrowed(&c.group),
+            org: Cow::Borrowed(&c.org),
+            persistent: c.persistent,
+            leader: c.leader,
+            follower: c.follower,
+            update_leader: c.update_leader,
+            update_follower: c.update_follower,
+            election_is_running: c.election_is_running,
+            election_is_no_quorum: c.election_is_no_quorum,
+            election_is_finished: c.election_is_finished,
+            update_election_is_running: c.update_election_is_running,
+            update_election_is_no_quorum: c.update_election_is_no_quorum,
+            update_election_is_finished: c.update_election_is_finished,
+
+            // TODO (CM): unify this with manager::Sys; they're not
+            // the same types, but very close as far as templating is
+            // concerned.
+            sys: Cow::Borrowed(&c.sys),
+
+            alive: c.health == Health::Alive,
+            suspect: c.health == Health::Suspect,
+            confirmed: c.health == Health::Confirmed,
+            departed: c.health == Health::Departed,
+
+            cfg: Cow::Borrowed(&c.cfg),
+        }
+    }
+}
+
+impl<'a> Serialize for SvcMember<'a> {
+    fn serialize<S>(&self, serializer: S) -> result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut map = serializer.serialize_map(Some(24))?;
+
+        map.serialize_entry("member_id", &self.member_id)?;
+
+        // TODO (CM): pkg is currently serialized as a map with
+        // origin, name, version, and release keys. We should also add
+        // another field (e.g. "pkg_ident"?) that exposes a single
+        // string.
+        //
+        // We should also normalize this pattern across our templating data.
+
+        // TODO (CM): assuming these are all meant to be Some and
+        // fully-qualified once we get to this point, right?
+        map.serialize_entry("pkg", &self.pkg)?;
+
+        // TODO (CM): add entry for entire service_group name in a
+        // single string
+        map.serialize_entry("service", &self.service)?;
+        map.serialize_entry("group", &self.group)?;
+        map.serialize_entry("application", &self.application)?;
+        map.serialize_entry("environment", &self.environment)?;
+        map.serialize_entry("org", &self.org)?;
+
+        // TODO (CM): add an "is_permanent" field to make it clear
+        // it's a boolean ("permanent", because this is actually the
+        // permanent peer status of this member)
+        map.serialize_entry("persistent", &self.persistent)?;
+        // TODO (CM): add an "is_leader" field to make it clear it's a boolean
+        map.serialize_entry("leader", &self.leader)?;
+        // TODO (CM): is_follower
+        map.serialize_entry("follower", &self.follower)?;
+        // TODO (CM): is_update_leader
+        map.serialize_entry("update_leader", &self.update_leader)?;
+        // TODO (CM): is_update_follower
+        map.serialize_entry(
+            "update_follower",
+            &self.update_follower,
+        )?;
+
+        map.serialize_entry(
+            "election_is_running",
+            &self.election_is_running,
+        )?;
+        map.serialize_entry(
+            "election_is_no_quorum",
+            &self.election_is_no_quorum,
+        )?;
+        map.serialize_entry(
+            "election_is_finished",
+            &self.election_is_finished,
+        )?;
+        map.serialize_entry(
+            "update_election_is_running",
+            &self.update_election_is_running,
+        )?;
+        map.serialize_entry(
+            "update_election_is_no_quorum",
+            &self.update_election_is_no_quorum,
+        )?;
+        map.serialize_entry(
+            "update_election_is_finished",
+            &self.update_election_is_finished,
+        )?;
+
+        // TODO (CM): this is a SysInfo, not a Sys or
+        // SystemInfo... ugh; NORMALIZE IT ALL
+        map.serialize_entry("sys", &self.sys)?;
+
+        map.serialize_entry("alive", &self.alive)?;
+        map.serialize_entry("suspect", &self.suspect)?;
+        map.serialize_entry("confirmed", &self.confirmed)?;
+        map.serialize_entry("departed", &self.departed)?;
+
+        map.serialize_entry("cfg", &self.cfg)?;
+
+        map.end()
+    }
+}
+
+////////////////////////////////////////////////////////////////////////
 
 /// Helper for pulling the leader or first member from a census group. This is used to populate the
 /// `.first` field in `bind` and `svc`.
 fn select_first(census_group: &CensusGroup) -> Option<SvcMember> {
     match census_group.leader() {
-        Some(member) => Some(SvcMember(member)),
+        Some(member) => Some(SvcMember::from_census_member(member)),
         None => {
-            census_group.members().first().and_then(
-                |m| Some(SvcMember(m)),
-            )
+            census_group.members().first().and_then(|m| {
+                Some(SvcMember::from_census_member(m))
+            })
         }
     }
+}
+
+////////////////////////////////////////////////////////////////////////
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use std::io::Read;
+    use json;
+    use serde_json;
+    use std::fs;
+    use valico::json_schema;
+    use std::path::PathBuf;
+    use tempdir::TempDir;
+    use manager::service::config::PackageConfigPaths;
+    use std::net::IpAddr;
+    use std::net::Ipv4Addr;
+    use std::collections::BTreeMap;
+    use hcore::package::PackageIdent;
+    use manager::service::Cfg;
+    use manager::service::Env;
+
+    /// Asserts that `json_string` is valid according to our render
+    /// context JSON schema.
+    ///
+    /// In the case of invalid input, all validation errors are neatly
+    /// rendered, along with a pretty-printed formatting of the
+    /// offending JSON.
+    fn assert_valid(json_string: &str) {
+        let result = validate_string(json_string);
+        if !result.is_valid() {
+            let error_string = result
+                .errors
+                .into_iter()
+                .map(|x| format!("  {:?}", x))
+                .collect::<Vec<String>>()
+                .join("\n");
+            let pretty_json =
+                json::stringify_pretty(
+                    json::parse(json_string).expect("JSON should parse if we get this far"),
+                    2,
+                );
+            assert!(
+                false,
+                r#"
+JSON does not validate!
+Errors:
+{}
+
+JSON:
+{}
+"#,
+                error_string,
+                pretty_json
+            );
+        }
+    }
+
+    /// Compares the incoming JSON string against the render context
+    /// JSON schema and returns the resulting `ValidationState`.
+    ///
+    /// In general, you should prefer using `assert_valid` directly.
+    fn validate_string(input: &str) -> json_schema::ValidationState {
+        let raw_schema = include_str!("../../doc/render_context_schema.json");
+        let parsed_schema: serde_json::Value =
+            serde_json::from_str(&raw_schema).expect("Could not parse schema as JSON");
+        let mut scope = json_schema::scope::Scope::new();
+        // NOTE: using `false` instead of `true` allows us to use
+        // `$comment` keys
+        let schema = scope.compile_and_return(parsed_schema, false).expect(
+            "Could not compile the schema",
+        );
+
+        let input_json: serde_json::Value =
+            serde_json::from_str(input).expect("Could not parse input as JSON");
+        schema.validate(&input_json)
+    }
+
+    ////////////////////////////////////////////////////////////////////////
+
+    // These structs, functions, and impls are copied from
+    // manager::service::config::test, and are used to create a
+    // suitable `Cfg` struct for these tests.
+
+    struct TestPkg {
+        base_path: PathBuf,
+    }
+
+    impl TestPkg {
+        fn new(tmp: &TempDir) -> Self {
+            let pkg = Self { base_path: tmp.path().to_owned() };
+
+            fs::create_dir_all(pkg.default_config_dir()).expect(
+                "create deprecated user config dir",
+            );
+            fs::create_dir_all(pkg.recommended_user_config_dir())
+                .expect("create recommended user config dir");
+            fs::create_dir_all(pkg.deprecated_user_config_dir())
+                .expect("create default config dir");
+            pkg
+        }
+    }
+
+    impl PackageConfigPaths for TestPkg {
+        fn name(&self) -> String {
+            String::from("testing")
+        }
+        fn default_config_dir(&self) -> PathBuf {
+            self.base_path.join("root")
+        }
+        fn recommended_user_config_dir(&self) -> PathBuf {
+            self.base_path.join("user")
+        }
+        fn deprecated_user_config_dir(&self) -> PathBuf {
+            self.base_path.join("svc")
+        }
+    }
+
+    fn new_test_pkg() -> (TempDir, TestPkg) {
+        let tmp = TempDir::new("habitat_config_test").expect("create temp dir");
+        let pkg = TestPkg::new(&tmp);
+
+        let default_toml = pkg.default_config_dir().join("default.toml");
+        let mut buffer = fs::File::create(default_toml).expect("couldn't write file");
+        buffer
+            .write_all(
+                r#"
+foo = "bar"
+baz = "boo"
+
+[foobar]
+one = 1
+two = 2
+"#
+                    .as_bytes(),
+            )
+            .expect("Couldn't write default.toml");
+        (tmp, pkg)
+    }
+
+    ////////////////////////////////////////////////////////////////////////
+
+    /// Just create a basic RenderContext that could be used in tests.
+    ///
+    /// If you want to modify parts of it, it's easier to change
+    /// things on a mutable reference.
+    fn default_render_context<'a>() -> RenderContext<'a> {
+        let system_info = SystemInfo {
+            version: Cow::Owned("I AM A HABITAT VERSION".into()),
+            member_id: Cow::Owned("MEMBER_ID".into()),
+            ip: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+            hostname: Cow::Owned("MY_HOSTNAME".into()),
+            gossip_ip: IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
+            gossip_port: 1234,
+            http_gateway_ip: IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
+            http_gateway_port: 5678,
+            permanent: false,
+        };
+
+        let ident = PackageIdent::new("core", "test_pkg", Some("1.0.0"), Some("20180321150416"));
+
+        let deps = vec![
+            PackageIdent::new("test", "pkg1", Some("1.0.0"), Some("20180321150416")),
+            PackageIdent::new("test", "pkg2", Some("2.0.0"), Some("20180321150416")),
+            PackageIdent::new("test", "pkg3", Some("3.0.0"), Some("20180321150416")),
+        ];
+
+        let mut env_hash = HashMap::new();
+        env_hash.insert("PATH".into(), "/foo:/bar:/baz".into());
+        env_hash.insert("SECRET".into(), "sooperseekrit".into());
+
+        let mut export_hash = HashMap::new();
+        export_hash.insert("blah".into(), "stuff.thing".into());
+        export_hash.insert("port".into(), "test_port".into());
+
+        let pkg = Package {
+            ident: Cow::Owned(ident.clone()),
+            // TODO (CM): have Pkg use FullyQualifiedPackageIdent, and
+            // get origin, name, version, and release from it, rather
+            // than storing each individually; I suspect that was just
+            // for templating
+            origin: Cow::Owned(ident.origin.clone()),
+            name: Cow::Owned(ident.name.clone()),
+            version: Cow::Owned(ident.version.clone().unwrap()),
+            release: Cow::Owned(ident.release.clone().unwrap()),
+            deps: Cow::Owned(deps),
+            env: Cow::Owned(Env(env_hash)),
+            exposes: Cow::Owned(vec!["1234".into(), "8000".into(), "2112".into()]),
+            exports: Cow::Owned(export_hash),
+            path: Cow::Owned("my_path".into()),
+            svc_path: Cow::Owned("svc_path".into()),
+            svc_config_path: Cow::Owned("config_path".into()),
+            svc_data_path: Cow::Owned("data_path".into()),
+            svc_files_path: Cow::Owned("files_path".into()),
+            svc_static_path: Cow::Owned("static_path".into()),
+            svc_var_path: Cow::Owned("var_path".into()),
+            svc_pid_file: Cow::Owned("pid_file".into()),
+            svc_run: Cow::Owned("svc_run".into()),
+            svc_user: Cow::Owned("hab".into()),
+            svc_group: Cow::Owned("hab".into()),
+        };
+
+        let group: ServiceGroup = "foo.default".parse().unwrap();
+
+        // Not using _tmp_dir, but need it to prevent it from being
+        // dropped before we make the Cfg
+        let (_tmp_dir, test_pkg) = new_test_pkg();
+        let cfg = Cfg::new(&test_pkg, None).expect("create config");
+
+        use butterfly::rumor::service::SysInfo;
+        let sys_info = SysInfo::new();
+
+        // TODO (CM): just create a toml table directly
+        let mut svc_member_cfg = BTreeMap::new();
+        svc_member_cfg.insert("foo".into(), "bar".into());
+
+        let me = SvcMember {
+            member_id: Cow::Owned("MEMBER_ID".into()),
+            pkg: Cow::Owned(Some(ident.clone())),
+            application: Cow::Owned(None),
+            environment: Cow::Owned(None),
+            service: Cow::Owned("foo".into()),
+            group: Cow::Owned("default".into()),
+            org: Cow::Owned(None),
+            persistent: true,
+            leader: false,
+            follower: false,
+            update_leader: false,
+            update_follower: false,
+            election_is_running: false,
+            election_is_no_quorum: false,
+            election_is_finished: false,
+            update_election_is_running: false,
+            update_election_is_no_quorum: false,
+            update_election_is_finished: false,
+            sys: Cow::Owned(sys_info),
+            alive: true,
+            suspect: false,
+            confirmed: false,
+            departed: false,
+            cfg: Cow::Owned(svc_member_cfg as toml::value::Table),
+        };
+
+        let svc = Svc {
+            service_group: Cow::Owned(group),
+            election_status: Cow::Owned(ElectionStatus::ElectionInProgress),
+            update_election_status: Cow::Owned(ElectionStatus::ElectionFinished),
+            members: Cow::Owned(vec![me.clone()]),
+            leader: Cow::Owned(None),
+            update_leader: Cow::Owned(None),
+            me: Cow::Owned(me.clone()),
+            first: me.clone(),
+        };
+
+        let mut bind_map = HashMap::new();
+        let bind_group = BindGroup {
+            first: Some(me.clone()),
+            members: vec![me.clone()],
+        };
+        bind_map.insert("foo".into(), bind_group);
+        let binds = Binds(bind_map);
+
+        RenderContext {
+            sys: system_info,
+            pkg: pkg,
+            cfg: Cow::Owned(cfg),
+            svc: svc,
+            bind: binds,
+        }
+    }
+
+    ////////////////////////////////////////////////////////////////////////
+
+    /// Reads a file containing real rendering context output from an
+    /// actual Supervisor, prior to the refactoring to separate the
+    /// serialization logic from the internal data structures.
+    #[test]
+    fn sample_context_is_valid() {
+        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests")
+            .join("fixtures")
+            .join("sample_render_context.json");
+
+        let mut f = fs::File::open(path).expect("could not open sample_render_context.json");
+        let mut json = String::new();
+        f.read_to_string(&mut json).expect(
+            "could not read sample_render_context.json",
+        );
+
+        assert_valid(&json);
+    }
+
+    #[test]
+    fn trivial_failure() {
+        let state = validate_string(r#"{"svc":{},"pkg":{},"cfg":{},"svc":{},"bind":{}}"#);
+        assert!(
+            !state.is_valid(),
+            "Expected schema validation to fail, but it succeeded!"
+        );
+    }
+
+    #[test]
+    fn default_render_context_is_valid() {
+        let render_context = default_render_context();
+        let j = serde_json::to_string(&render_context).expect("can't serialize to JSON");
+        assert_valid(&j);
+    }
+
+    // This mainly exists to show how you could modify the default
+    // context for easily testing different scenarios.
+    #[test]
+    fn no_binds_are_valid() {
+        let mut render_context = default_render_context();
+        render_context.bind = Binds(HashMap::new());
+        let j = serde_json::to_string(&render_context).expect("can't serialize to JSON");
+        assert_valid(&j);
+    }
+
 }

--- a/components/sup/src/templating/context.rs
+++ b/components/sup/src/templating/context.rs
@@ -310,7 +310,7 @@ impl<'a> Svc<'a> {
                     .members()
                     .iter()
                     .map(|m| SvcMember::from_census_member(m))
-                    .collect::<Vec<SvcMember<'a>>>(),
+                    .collect(),
             ),
             me: Cow::Owned(
                 census_group

--- a/components/sup/tests/fixtures/sample_render_context.json
+++ b/components/sup/tests/fixtures/sample_render_context.json
@@ -1,0 +1,425 @@
+{
+  "sys": {
+    "gossip_ip": "0.0.0.0",
+    "gossip_port": 9638,
+    "hostname": "yokai",
+    "http_gateway_ip": "0.0.0.0",
+    "http_gateway_port": 9631,
+    "ip": "192.168.67.207",
+    "member_id": "a4e47d4aece849cd948afbd9bda3a22a",
+    "permanent": false,
+    "version": "0.54.0/20180221023448"
+  },
+  "pkg": {
+    "deps": [
+      {
+        "name": "acl",
+        "origin": "core",
+        "release": "20170513213108",
+        "version": "2.2.52"
+      },
+      {
+        "name": "attr",
+        "origin": "core",
+        "release": "20170513213059",
+        "version": "2.4.47"
+      },
+      {
+        "name": "bzip2",
+        "origin": "core",
+        "release": "20170513212938",
+        "version": "1.0.6"
+      },
+      {
+        "name": "cacerts",
+        "origin": "core",
+        "release": "20171014212239",
+        "version": "2017.09.20"
+      },
+      {
+        "name": "coreutils",
+        "origin": "core",
+        "release": "20170513213226",
+        "version": "8.25"
+      },
+      {
+        "name": "curl",
+        "origin": "core",
+        "release": "20171014214153",
+        "version": "7.54.1"
+      },
+      {
+        "name": "db",
+        "origin": "core",
+        "release": "20170513213734",
+        "version": "5.3.28"
+      },
+      {
+        "name": "expat",
+        "origin": "core",
+        "release": "20171015103808",
+        "version": "2.2.2"
+      },
+      {
+        "name": "gcc-libs",
+        "origin": "core",
+        "release": "20170513212920",
+        "version": "5.2.0"
+      },
+      {
+        "name": "gdbm",
+        "origin": "core",
+        "release": "20170513213716",
+        "version": "1.11"
+      },
+      {
+        "name": "gettext",
+        "origin": "core",
+        "release": "20170513214354",
+        "version": "0.19.6"
+      },
+      {
+        "name": "git",
+        "origin": "core",
+        "release": "20171016215544",
+        "version": "2.14.2"
+      },
+      {
+        "name": "glibc",
+        "origin": "core",
+        "release": "20170513201042",
+        "version": "2.22"
+      },
+      {
+        "name": "gmp",
+        "origin": "core",
+        "release": "20170513202112",
+        "version": "6.1.0"
+      },
+      {
+        "name": "less",
+        "origin": "core",
+        "release": "20170513213936",
+        "version": "481"
+      },
+      {
+        "name": "libcap",
+        "origin": "core",
+        "release": "20170513213120",
+        "version": "2.24"
+      },
+      {
+        "name": "linux-headers",
+        "origin": "core",
+        "release": "20170513200956",
+        "version": "4.3"
+      },
+      {
+        "name": "ncurses",
+        "origin": "core",
+        "release": "20170513213009",
+        "version": "6.0"
+      },
+      {
+        "name": "nghttp2",
+        "origin": "core",
+        "release": "20170830163632",
+        "version": "1.24.0"
+      },
+      {
+        "name": "openssh",
+        "origin": "core",
+        "release": "20171014214153",
+        "version": "7.5p1"
+      },
+      {
+        "name": "openssl",
+        "origin": "core",
+        "release": "20171014213633",
+        "version": "1.0.2l"
+      },
+      {
+        "name": "pcre",
+        "origin": "core",
+        "release": "20170513213423",
+        "version": "8.38"
+      },
+      {
+        "name": "perl",
+        "origin": "core",
+        "release": "20170513213942",
+        "version": "5.22.1"
+      },
+      {
+        "name": "xz",
+        "origin": "core",
+        "release": "20170513214327",
+        "version": "5.2.2"
+      },
+      {
+        "name": "zlib",
+        "origin": "core",
+        "release": "20170513201911",
+        "version": "1.2.8"
+      }
+    ],
+    "env": {
+      "BAZ": "QUUX",
+      "FOO": "BAR",
+      "PATH": "/hab/pkgs/core/git/2.14.2/20171016215544/bin:/hab/pkgs/core/xz/5.2.2/20170513214327/bin:/hab/pkgs/core/perl/5.22.1/20170513213942/bin:/hab/pkgs/core/pcre/8.38/20170513213423/bin:/hab/pkgs/core/openssl/1.0.2l/20171014213633/bin:/hab/pkgs/core/openssh/7.5p1/20171014214153/bin:/hab/pkgs/core/openssh/7.5p1/20171014214153/sbin:/hab/pkgs/core/openssh/7.5p1/20171014214153/libexec:/hab/pkgs/core/ncurses/6.0/20170513213009/bin:/hab/pkgs/core/libcap/2.24/20170513213120/bin:/hab/pkgs/core/less/481/20170513213936/bin:/hab/pkgs/core/glibc/2.22/20170513201042/bin:/hab/pkgs/core/gettext/0.19.6/20170513214354/bin:/hab/pkgs/core/gdbm/1.11/20170513213716/bin:/hab/pkgs/core/expat/2.2.2/20171015103808/bin:/hab/pkgs/core/db/5.3.28/20170513213734/bin:/hab/pkgs/core/curl/7.54.1/20171014214153/bin:/hab/pkgs/core/coreutils/8.25/20170513213226/bin:/hab/pkgs/core/bzip2/1.0.6/20170513212938/bin:/hab/pkgs/core/attr/2.4.47/20170513213059/bin:/hab/pkgs/core/acl/2.2.52/20170513213108/bin:/hab/pkgs/core/busybox-static/1.24.2/20170513215502/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin"
+    },
+    "exports": {
+      "blah": "stuff.thing",
+      "port": "test_port"
+    },
+    "exposes": [
+      "2112"
+    ],
+    "ident": "core/template-probe/0.1.0/20180315155739",
+    "name": "template-probe",
+    "origin": "core",
+    "path": "/hab/pkgs/core/template-probe/0.1.0/20180315155739",
+    "release": "20180315155739",
+    "svc_config_path": "/hab/svc/template-probe/config",
+    "svc_data_path": "/hab/svc/template-probe/data",
+    "svc_files_path": "/hab/svc/template-probe/files",
+    "svc_group": "hab",
+    "svc_path": "/hab/svc/template-probe",
+    "svc_pid_file": "/hab/svc/template-probe/PID",
+    "svc_run": "/hab/svc/template-probe/run",
+    "svc_static_path": "/hab/svc/template-probe/static",
+    "svc_user": "hab",
+    "svc_var_path": "/hab/svc/template-probe/var",
+    "version": "0.1.0"
+  },
+  "cfg": {
+    "stuff": {
+      "thing": "foo"
+    },
+    "test_port": 2112
+  },
+  "svc": {
+    "election_is_finished": false,
+    "election_is_no_quorum": false,
+    "election_is_running": false,
+    "first": {
+      "alive": true,
+      "application": null,
+      "cfg": {
+        "blah": "foo",
+        "port": 2112
+      },
+      "confirmed": false,
+      "departed": false,
+      "election_is_finished": false,
+      "election_is_no_quorum": false,
+      "election_is_running": false,
+      "environment": null,
+      "follower": false,
+      "group": "default",
+      "leader": false,
+      "member_id": "a4e47d4aece849cd948afbd9bda3a22a",
+      "org": null,
+      "persistent": false,
+      "pkg": {
+        "name": "template-probe",
+        "origin": "core",
+        "release": "20180315155739",
+        "version": "0.1.0"
+      },
+      "service": "template-probe",
+      "suspect": false,
+      "sys": {
+        "gossip_ip": "0.0.0.0",
+        "gossip_port": 9638,
+        "hostname": "yokai",
+        "http_gateway_ip": "0.0.0.0",
+        "http_gateway_port": 9631,
+        "ip": "192.168.67.207"
+      },
+      "update_election_is_finished": false,
+      "update_election_is_no_quorum": false,
+      "update_election_is_running": false,
+      "update_follower": false,
+      "update_leader": false
+    },
+    "group": "default",
+    "leader": null,
+    "me": {
+      "alive": true,
+      "application": null,
+      "cfg": {
+        "blah": "foo",
+        "port": 2112
+      },
+      "confirmed": false,
+      "departed": false,
+      "election_is_finished": false,
+      "election_is_no_quorum": false,
+      "election_is_running": false,
+      "environment": null,
+      "follower": false,
+      "group": "default",
+      "leader": false,
+      "member_id": "a4e47d4aece849cd948afbd9bda3a22a",
+      "org": null,
+      "persistent": false,
+      "pkg": {
+        "name": "template-probe",
+        "origin": "core",
+        "release": "20180315155739",
+        "version": "0.1.0"
+      },
+      "service": "template-probe",
+      "suspect": false,
+      "sys": {
+        "gossip_ip": "0.0.0.0",
+        "gossip_port": 9638,
+        "hostname": "yokai",
+        "http_gateway_ip": "0.0.0.0",
+        "http_gateway_port": 9631,
+        "ip": "192.168.67.207"
+      },
+      "update_election_is_finished": false,
+      "update_election_is_no_quorum": false,
+      "update_election_is_running": false,
+      "update_follower": false,
+      "update_leader": false
+    },
+    "members": [
+      {
+        "alive": true,
+        "application": null,
+        "cfg": {
+          "blah": "foo",
+          "port": 2112
+        },
+        "confirmed": false,
+        "departed": false,
+        "election_is_finished": false,
+        "election_is_no_quorum": false,
+        "election_is_running": false,
+        "environment": null,
+        "follower": false,
+        "group": "default",
+        "leader": false,
+        "member_id": "a4e47d4aece849cd948afbd9bda3a22a",
+        "org": null,
+        "persistent": false,
+        "pkg": {
+          "name": "template-probe",
+          "origin": "core",
+          "release": "20180315155739",
+          "version": "0.1.0"
+        },
+        "service": "template-probe",
+        "suspect": false,
+        "sys": {
+          "gossip_ip": "0.0.0.0",
+          "gossip_port": 9638,
+          "hostname": "yokai",
+          "http_gateway_ip": "0.0.0.0",
+          "http_gateway_port": 9631,
+          "ip": "192.168.67.207"
+        },
+        "update_election_is_finished": false,
+        "update_election_is_no_quorum": false,
+        "update_election_is_running": false,
+        "update_follower": false,
+        "update_leader": false
+      }
+    ],
+    "org": null,
+    "service": "template-probe",
+    "update_election_is_finished": false,
+    "update_election_is_no_quorum": false,
+    "update_election_is_running": false,
+    "update_leader": null
+  },
+  "bind": {
+    "router": {
+      "first": {
+        "alive": true,
+        "application": null,
+        "cfg": {
+          "port": 5562
+        },
+        "confirmed": false,
+        "departed": false,
+        "election_is_finished": false,
+        "election_is_no_quorum": false,
+        "election_is_running": false,
+        "environment": null,
+        "follower": false,
+        "group": "default",
+        "leader": false,
+        "member_id": "a4e47d4aece849cd948afbd9bda3a22a",
+        "org": null,
+        "persistent": false,
+        "pkg": {
+          "name": "builder-router",
+          "origin": "habitat",
+          "release": "20180302152133",
+          "version": "7114"
+        },
+        "service": "builder-router",
+        "suspect": false,
+        "sys": {
+          "gossip_ip": "0.0.0.0",
+          "gossip_port": 9638,
+          "hostname": "yokai",
+          "http_gateway_ip": "0.0.0.0",
+          "http_gateway_port": 9631,
+          "ip": "192.168.67.207"
+        },
+        "update_election_is_finished": false,
+        "update_election_is_no_quorum": false,
+        "update_election_is_running": false,
+        "update_follower": false,
+        "update_leader": false
+      },
+      "members": [
+        {
+          "alive": true,
+          "application": null,
+          "cfg": {
+            "port": 5562
+          },
+          "confirmed": false,
+          "departed": false,
+          "election_is_finished": false,
+          "election_is_no_quorum": false,
+          "election_is_running": false,
+          "environment": null,
+          "follower": false,
+          "group": "default",
+          "leader": false,
+          "member_id": "a4e47d4aece849cd948afbd9bda3a22a",
+          "org": null,
+          "persistent": false,
+          "pkg": {
+            "name": "builder-router",
+            "origin": "habitat",
+            "release": "20180302152133",
+            "version": "7114"
+          },
+          "service": "builder-router",
+          "suspect": false,
+          "sys": {
+            "gossip_ip": "0.0.0.0",
+            "gossip_port": 9638,
+            "hostname": "yokai",
+            "http_gateway_ip": "0.0.0.0",
+            "http_gateway_port": 9631,
+            "ip": "192.168.67.207"
+          },
+          "update_election_is_finished": false,
+          "update_election_is_no_quorum": false,
+          "update_election_is_running": false,
+          "update_follower": false,
+          "update_leader": false
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Previously, the data we made available to users in Habitat templates
was based directly on the JSON serialization of several internal data
structures. This needlessly coupled internal workings of Habitat with
the public interface we expose to users. This often made it difficult
to know exactly what data was presented to users, and made it
difficult to safely change that data.

Here, we explicitly decouple the internal data structures of the
Supervisor from what is exposed to users. To do this in an efficient
and clear way, we introduce a number of "templating proxies", which
effectively wrap internal data structures, holding on to their
relevant data using `Cow` types to reduce memory footprint (this also
makes it easier to instantiate the templating proxies in tests, since
we can simply provide owned copies of the important data). Not only
does this give us a clear, typed way to refer to the data, but it
allows us to implement `Serialize` on these types, which lets us
control what is exposed to users in a very fine-grained and targeted
way. For instance, `{{svc.me.persistent}}` should really be
`{{svc.me.permanent}}`; before this change, we would need to introduce
another field to `census::CensusMember` named `permanent`, and it
would be unclear why. Now, however, we can simply modify the
templating proxy's `Serialize` implementation to render that same
field multiple times under different names, making schema evolution
and deprecation much easier to reason about. Note, however, that no
user-facing changes are introduced in this commit; it is a pure
refactoring.

By clearly separating out the templating data, we now have an
opportunity to revisit some of the internal data structures that were
previously serving "double duty"; it may be possible to simplify them
now.

Additionally, this commit introduces a JSON Schema definition of the
entire render context. This is currently used in tests to validate our
code, but could be used in the future as a source for generated
documentation on the website, and possibly as part of a future
template validation tool.

Fixes #4761