### PR TITLE
[studio] Ensure that cleanup is performed on `studio new`.

### DIFF
--- a/components/studio/bin/hab-studio.sh
+++ b/components/studio/bin/hab-studio.sh
@@ -257,6 +257,8 @@ subcommand_new() {
   # Shift off all parsed token in `$*` so that the subcommand is now `$1`.
   shift "$((OPTIND - 1))"
 
+  trap cleanup_studio EXIT
+
   new_studio
 }
 
@@ -301,6 +303,8 @@ subcommand_enter() {
   # Shift off all parsed token in `$*` so that the subcommand is now `$1`.
   shift "$((OPTIND - 1))"
 
+  trap cleanup_studio EXIT
+
   new_studio
   enter_studio "$@"
 }
@@ -326,6 +330,8 @@ subcommand_build() {
   done
   # Shift off all parsed token in `$*` so that the subcommand is now `$1`.
   shift "$((OPTIND - 1))"
+
+  trap cleanup_studio EXIT
 
   if [ -z "${reuse:-}" ]; then
     _STUDIO_TYPE="$STUDIO_TYPE"
@@ -355,6 +361,8 @@ subcommand_run() {
   done
   # Shift off all parsed token in `$*` so that the subcommand is now `$1`.
   shift "$((OPTIND - 1))"
+
+  trap cleanup_studio EXIT
 
   new_studio
   run_studio "$@"
@@ -639,8 +647,6 @@ enter_studio() {
     set -x
   fi
 
-  trap cleanup_studio EXIT
-
   # Become the `chroot` process
   # Note: env and studio_enter_command must NOT be quoted
   # shellcheck disable=2086
@@ -667,8 +673,6 @@ build_studio() {
     set -x
   fi
 
-  trap cleanup_studio EXIT
-
   # Run the build command in the `chroot` environment
   # Note: studio_run_command, env and studio_run_command must NOT be quoted
   # shellcheck disable=2086
@@ -687,8 +691,6 @@ run_studio() {
   if [ -n "$VERBOSE" ]; then
     set -x
   fi
-
-  trap cleanup_studio EXIT
 
   # Run the command in the `chroot` environment
   # Note: env and studio_run_command must NOT be quoted


### PR DESCRIPTION
This change addresses a bug where a user runs `hab studio new` and has
mounted filesystems persisting after the command exits. This is unlike
the other commands, namely `hab studio enter`, `hab studio build`, and
`hab studio run`.

The mechanism in the other cases is invoking the `cleanup_studio()`
function in a `trap` statement, but this was missed for the `new`
subcommand. While looking into why, it became clearer that the reason
for this was the trap was being called just before invoking the `chroot`
call to start running the jail. The current call sites also wouldn't
catch any setup issues during the `new_studio()` call, which all of the
above subcommands call. Therefore, it was easier to pull the `trap`
calls up into the subcommand functions consistently which also addresses
the `new` subcommand.

Note that the `rm` subcommand isn't updated here because it calls the
same `cleanup_studio()` function directly.