### PR TITLE
[studio] Implement `run` subcommand for `stage1` Studio types.

### DIFF
--- a/components/studio/libexec/hab-studio-type-stage1.sh
+++ b/components/studio/libexec/hab-studio-type-stage1.sh
@@ -10,7 +10,7 @@ studio_enter_command="/tools/bin/bash --login +h"
 studio_build_environment=
 studio_build_command=
 studio_run_environment=
-studio_run_command=
+studio_run_command="/tools/bin/bash --login"
 
 : ${STAGE1_TOOLS_URL:=http://s3-us-west-2.amazonaws.com/habitat-studio-stage1/habitat-studio-stage1-20180312233639.tar.xz}
 : ${TAR_DIR:=/tmp}


### PR DESCRIPTION
This change adds a missing implementation for supporting `hab studio
run` where the Studio type is a `stage1`. Future improvements to the
internals/bootstrapping docs may use this to further simplify and
automate base Plans testing.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>