### PR TITLE
Update hab bldr job status

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -484,6 +484,7 @@ dependencies = [
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tabwriter 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/hab/Cargo.toml
+++ b/components/hab/Cargo.toml
@@ -28,6 +28,7 @@ retry = "*"
 serde = "*"
 serde_json = "*"
 serde_derive = "*"
+tabwriter = "1"
 toml = { version = "*", default-features = false }
 url = "*"
 walkdir = "*"

--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -149,16 +149,20 @@ pub fn get() -> App<'static, 'static> {
                     (@arg AUTH_TOKEN: -z --auth +takes_value "Authentication token for Builder")
                 )
                 (@subcommand status =>
+                    (about: "Get the status of one or more job groups")
+                    (aliases: &["stat", "statu"])
                     (@group status =>
                         (@attributes +required)
-                        (@arg GROUP_ID: +required +takes_value
+                        (@arg GROUP_ID: +takes_value
                             "The group id that was returned from \"hab bldr job start\" \
                             (ex: 771100000000000000)")
                         (@arg ORIGIN: -o --origin +takes_value
-                            "You can see the status of every group in an origin by providing this value")
+                            "Show the status of recent job groups created in this origin (default: 10 most recent)")
                     )
-                    (about: "Get the status of a job group")
-                    (aliases: &["stat", "statu"])
+                    (@arg LIMIT: -l --limit +takes_value {valid_numeric::<usize>}
+                        "Limit how many job groups to retrieve, ordered by most recent (default: 10)")
+                    (@arg SHOW_JOBS: -s --showjobs
+                        "Show the status of all build jobs for a retrieved job group")
                     (@arg BLDR_URL: -u --url +takes_value {valid_url}
                         "Specify an alternate Builder endpoint. If not specified, the value will \
                          be taken from the HAB_BLDR_URL environment variable if defined. (default: \
@@ -801,5 +805,12 @@ fn valid_url(val: String) -> result::Result<(), String> {
     match Url::parse(&val) {
         Ok(_) => Ok(()),
         Err(_) => Err(format!("URL: '{}' is not valid", &val)),
+    }
+}
+
+fn valid_numeric<T: FromStr>(val: String) -> result::Result<(), String> {
+    match val.parse::<T>() {
+        Ok(_) => Ok(()),
+        Err(_) => Err(format!("'{}' is not a valid number", &val)),
     }
 }

--- a/components/hab/src/command/bldr/job/promote.rs
+++ b/components/hab/src/command/bldr/job/promote.rs
@@ -76,9 +76,11 @@ fn get_group_status(bldr_url: &str, group_id: u64) -> Result<SchedulerResponse> 
     let depot_client = depot_client::Client::new(bldr_url, PRODUCT, VERSION, None)
         .map_err(Error::DepotClient)?;
 
-    let group_status = depot_client.get_schedule(group_id as i64).map_err(|e| {
-        Error::ScheduleStatus(e)
-    })?;
+    let group_status = depot_client.get_schedule(group_id as i64, true).map_err(
+        |e| {
+            Error::ScheduleStatus(e)
+        },
+    )?;
 
     Ok(group_status)
 }

--- a/components/hab/src/lib.rs
+++ b/components/hab/src/lib.rs
@@ -47,6 +47,7 @@ extern crate walkdir;
 extern crate base64;
 #[cfg(test)]
 extern crate tempdir;
+extern crate tabwriter;
 
 pub mod analytics;
 pub mod cli;

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -523,7 +523,13 @@ fn sub_bldr_job_status(ui: &mut UI, m: &ArgMatches) -> Result<()> {
     let url = bldr_url_from_matches(m);
     let group_id = m.value_of("GROUP_ID");
     let origin = m.value_of("ORIGIN");
-    command::bldr::job::status::start(ui, &url, group_id, origin)
+    let limit = m.value_of("LIMIT")
+        .unwrap_or("10")
+        .parse::<usize>()
+        .unwrap();
+    let show_jobs = m.is_present("SHOW_JOBS");
+
+    command::bldr::job::status::start(ui, &url, group_id, origin, limit, show_jobs)
 }
 
 fn sub_plan_init(ui: &mut UI, m: &ArgMatches) -> Result<()> {


### PR DESCRIPTION
This change fixes a break in the 'hab bldr job status' command, where it was not possible to query the job groups for an origin because we were always making the group id required, and also getting status for large groups was timing out.

In addition, it adds some other improvements:
* Default job group status for origins to a sane (small) number (10) 
* Add a --limit parameter for when querying all the job groups in an origin
* Add a --showjobs flag for when querying by group id 
* Job groups for origins will not show detailed job status (perf feature. Use the group id and --showjobs flag to get the details)
* Update the display to show tab-aligned tabular format

These changes are backward compatible with the current services, however there is also a corresponding PR for the builder services where we will see the perf improvements.  

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-155810919](https://user-images.githubusercontent.com/13542112/38118676-55808aa2-3371-11e8-9a1e-b89e8346b3f9.gif)
