### PR TITLE
prefix pkgPathFor with FS_ROOT

### DIFF
--- a/components/sup/src/templating/helpers/pkg_path_for.rs
+++ b/components/sup/src/templating/helpers/pkg_path_for.rs
@@ -39,7 +39,7 @@ impl HelperDef for PkgPathForHelper {
             .find(|ident| ident.satisfies(&param))
             .and_then(|i| {
                 Some(
-                    fs::pkg_install_path(&i, None::<String>)
+                    fs::pkg_install_path(&i, Some(&*fs::FS_ROOT_PATH))
                         .to_string_lossy()
                         .into_owned(),
                 )


### PR DESCRIPTION
I have never had to use `pkgPathFor` in a windows hook but ran accross a scenario where I need it. Without `FS_ROOT`, non studio supervisors and containerized studios work fine. However, a local studio simply emits a path beginning with `/hab/pkg...` and the local studio is rooted in `c:\hab\studios\...` so the path is not valid. We have managed to catch most scenarios where this is a problem (for example https://github.com/habitat-sh/habitat/blob/master/components/sup/src/manager/service/package.rs#L83) but this one slipped.

This should not have any negative side effects for Linux because in Linux studios, the `FS_ROOT` is always `/`.

Signed-off-by: mwrock <matt@mattwrock.com>