### PR TITLE
Revert to boolean-based health in CensusMember

### DIFF
--- a/components/sup/src/census.rs
+++ b/components/sup/src/census.rs
@@ -349,7 +349,7 @@ impl CensusGroup {
     /// you have no alive peers.
     pub fn previous_peer(&self) -> Option<&CensusMember> {
         let alive_members: Vec<&CensusMember> =
-            self.population.values().filter(|cm| cm.alive).collect();
+            self.population.values().filter(|cm| cm.alive()).collect();
         if alive_members.len() <= 1 || self.me().is_none() {
             return None;
         }
@@ -505,14 +505,6 @@ pub struct CensusMember {
     pub update_election_is_finished: bool,
     pub sys: SysInfo,
 
-    // TODO (CM): Skipping serialization to avoid rippling to other
-    // places unnecessarily right now.
-    #[serde(skip_serializing)]
-    pub health: Health,
-
-    // TODO (CM): I *think* all these four booleans can disappear
-    // now... not sure if their serialization affects anything yet,
-    // though.
     alive: bool,
     suspect: bool,
     confirmed: bool,
@@ -593,12 +585,23 @@ impl CensusMember {
             Health::Confirmed => self.confirmed = true,
             Health::Departed => self.departed = true,
         }
-        self.health = health
     }
 
     /// Is this member currently considered to be alive or not?
     pub fn alive(&self) -> bool {
-        self.health == Health::Alive
+        self.alive
+    }
+
+    pub fn suspect(&self) -> bool {
+        self.suspect
+    }
+
+    pub fn confirmed(&self) -> bool {
+        self.confirmed
+    }
+
+    pub fn departed(&self) -> bool {
+        self.departed
     }
 }
 

--- a/components/sup/src/templating/context.rs
+++ b/components/sup/src/templating/context.rs
@@ -57,7 +57,6 @@ use serde::{Serialize, Serializer};
 use serde::ser::SerializeMap;
 use toml;
 
-use butterfly::member::Health;
 use butterfly::rumor::service::SysInfo;
 use hcore::package::PackageIdent;
 use hcore::service::ServiceGroup;
@@ -493,10 +492,10 @@ impl<'a> SvcMember<'a> {
             // concerned.
             sys: Cow::Borrowed(&c.sys),
 
-            alive: Cow::Owned(c.health == Health::Alive),
-            suspect: Cow::Owned(c.health == Health::Suspect),
-            confirmed: Cow::Owned(c.health == Health::Confirmed),
-            departed: Cow::Owned(c.health == Health::Departed),
+            alive: Cow::Owned(c.alive()),
+            suspect: Cow::Owned(c.suspect()),
+            confirmed: Cow::Owned(c.confirmed()),
+            departed: Cow::Owned(c.departed()),
 
             cfg: Cow::Borrowed(&c.cfg),
         }


### PR DESCRIPTION
This fixes a subtlety introduced with the addition of a `Health` field
to the `CensusMember` struct (PR #4823). Previously, there was a small
window where the health of a `CensusMember` was in an indeterminate
state, before it's health was reconciled with Butterfly data. By using
the `Health` enum, all new `CensusMember`s were created as `Alive`.

Arguments could be made for the correctness or incorrectness of this
decision, and we're all agreed that having four booleans to represent
this data is not what we ultimately want. However, since we don't want
to introduce subtle bugs into this part of the code in the course of
solidifying our template data structures, we're backing this change
out for now.

Signed-off-by: Christopher Maier <cmaier@chef.io>