### PR TITLE
Update docs side nav, reference and diagram page

### DIFF
--- a/www/config.rb
+++ b/www/config.rb
@@ -210,7 +210,7 @@ redirect 'docs/reference/utility-functions/index.html', to: '/docs/reference/#ut
 redirect 'docs/reference/environment-vars/index.html', to: '/docs/reference/#environment-variables'
 redirect 'docs/reference/package-contents/index.html', to: '/docs/reference/#package-contents'
 redirect 'docs/reference/log-keys/index.html', to: '/docs/reference/#sup-log-keys'
-redirect 'docs/reference/habitat-infographics/index.html', to: '/docs/reference/#infographics'
+redirect 'docs/reference/habitat-infographics/index.html', to: '/docs/diagrams'
 redirect 'docs/contribute-help-build/index.html', to: '/docs/contribute'
 redirect 'docs/concepts-scaffolding/index.html', to: '/docs/glossary/#glossary-scaffolding'
 redirect 'docs/concepts-supervisor/index.html', to: '/docs/glossary/#glossary-supervisor'

--- a/www/data/docs_sidebar.yml
+++ b/www/data/docs_sidebar.yml
@@ -99,23 +99,23 @@ sidebar_links:
     link: "/docs/diagrams"
     sub_links:
     - title: Architecture Overview
-      link: "/docs/diagrams/#habitat-architecture-overview"
+      link: "/docs/diagrams/#architecture-overview"
     - title: Initial Package Build Flow
-      link: "/docs/diagrams/#habitat-initial-package-build-flow"
+      link: "/docs/diagrams/#initial-package-build-flow"
     - title: Dependency Update Flow
-      link: "/docs/diagrams/#habitat-dependency-update-flow"
+      link: "/docs/diagrams/#dependency-update-flow"
     - title: Application Rebuild Flow
-      link: "/docs/diagrams/#habitat-application-rebuild-flow"
+      link: "/docs/diagrams/#application-rebuild-flow"
     - title: Initial Docker Container Publishing Flow
-      link: "/docs/diagrams/#habitat-initial-docker-container-publishing-flow"
+      link: "/docs/diagrams/#initial-docker-container-publishing-flow"
     - title: Automated Docker Container Publishing Flow
-      link: "/docs/diagrams/#rhabitat-automated-docker-container-publishing-flow"
+      link: "/docs/diagrams/#automated-docker-container-publishing-flow"
     - title: Promote Packages Through Channels
-      link: "/docs/diagrams/#habitat-promote-packages-through-channels"
+      link: "/docs/diagrams/#promote-packages-through-channels"
     - title: Runtime Services Group Binding
-      link: "/docs/diagrams/#habitat-runtime-services-group-binding"
+      link: "/docs/diagrams/#runtime-services-group-binding"
     - title: Builder Architecture
-      link: "/docs/diagrams/#habitat-builder-architecture"
+      link: "/docs/diagrams/#builder-architecture"
     - title: Habitat and Kubernetes
       link: "/docs/diagrams/#habitat-and-kubernetes"
   - title: Best Practice Guides

--- a/www/data/docs_sidebar.yml
+++ b/www/data/docs_sidebar.yml
@@ -95,8 +95,6 @@ sidebar_links:
       link: "/docs/reference/#package-contents"
     - title: Supervisor Log Keys
       link: "/docs/reference/#sup-log-keys"
-    - title: Infographics
-      link: "/docs/reference/#infographics"
   - title: Diagrams
     link: "/docs/diagrams"
     sub_links:

--- a/www/data/docs_sidebar.yml
+++ b/www/data/docs_sidebar.yml
@@ -52,7 +52,7 @@ sidebar_links:
       link: "/docs/using-habitat/#overview"
     - title: Using Habitat Packages
       link: "/docs/using-habitat/#using-packages"
-    - title: Setting up a Ring 
+    - title: Setting up a Ring
       link: "/docs/using-habitat/#setting-up-a-ring"
     - title: Monitor Services
       link: "/docs/using-habitat/#monitor-services"
@@ -97,6 +97,29 @@ sidebar_links:
       link: "/docs/reference/#sup-log-keys"
     - title: Infographics
       link: "/docs/reference/#infographics"
+  - title: Diagrams
+    link: "/docs/diagrams"
+    sub_links:
+    - title: Architecture Overview
+      link: "/docs/diagrams/#habitat-architecture-overview"
+    - title: Initial Package Build Flow
+      link: "/docs/diagrams/#habitat-initial-package-build-flow"
+    - title: Dependency Update Flow
+      link: "/docs/diagrams/#habitat-dependency-update-flow"
+    - title: Application Rebuild Flow
+      link: "/docs/diagrams/#habitat-application-rebuild-flow"
+    - title: Initial Docker Container Publishing Flow
+      link: "/docs/diagrams/#habitat-initial-docker-container-publishing-flow"
+    - title: Automated Docker Container Publishing Flow
+      link: "/docs/diagrams/#rhabitat-automated-docker-container-publishing-flow"
+    - title: Promote Packages Through Channels
+      link: "/docs/diagrams/#habitat-promote-packages-through-channels"
+    - title: Runtime Services Group Binding
+      link: "/docs/diagrams/#habitat-runtime-services-group-binding"
+    - title: Builder Architecture
+      link: "/docs/diagrams/#habitat-builder-architecture"
+    - title: Habitat and Kubernetes
+      link: "/docs/diagrams/#habitat-and-kubernetes"
   - title: Best Practice Guides
     link: "/docs/best-practices"
     sub_links:

--- a/www/source/blog/2017-06-28-Happy-Birthday-Habitat.html.md
+++ b/www/source/blog/2017-06-28-Happy-Birthday-Habitat.html.md
@@ -30,7 +30,7 @@ ChefConf in May 2017 saw several major launches from the Habitat team, including
   * **Scaffoldings**: are a high level way for a developer to declare their application type in their plan.sh and then have Habitat’s automation build out your application from there. They are currently available for Ruby and Node.js applications, with more in the works as communities request and collaborate with the core team on them. [Read all about Scaffolding](/blog/2017/05/Scaffolding/), and
 [get step by step instructions on using the Node.js Scaffolding.](/blog/2017/05/Scaffolding-App-From-Scratch/)
   * **Enterprise ready core plan push**: Habitat’s partners released a series of big data and enterprise grade core plans to extend and enhance the ecosystem for our users. [Get more details.](https://blog.chef.io/2017/05/23/enterprise-ready-Habitat-plans-now-available/)
-  * **Architecture infographics released**: a picture is worth 10,000 words, and our amazing designer [Liz’s](https://twitter.com/lizchen_uw) architectural diagrams of the systems we have built help quickly communicate how the different components interact with one another. [Check them out!](/docs/reference#infographics)
+  * **Architecture infographics released**: a picture is worth 10,000 words, and our amazing designer [Liz’s](https://twitter.com/lizchen_uw) architectural diagrams of the systems we have built help quickly communicate how the different components interact with one another. [Check them out!](/docs/diagrams)
 
 Tomorrow’s regularly scheduled Thursday release will continue the cadence of capability leaps, with both a new Go Scaffolding for our Go development enthusiasts, and the release of the launcher capability.
 

--- a/www/source/docs/diagrams.html.md.erb
+++ b/www/source/docs/diagrams.html.md.erb
@@ -1,7 +1,25 @@
+---
+title: Diagrams
+---
 
-# <a name="infographics" id="infographics" data-magellan-target="infographics">Habitat Infographics</a>
+# Diagrams
+
 With Habitat comes a number of concepts - some you may be familiar with, some you may not. Not to worry, here you'll find a set of graphics that will help you and your team better understand the concepts and how they fit together into the larger Habitat ecosystem.
 
+## Table of Contents
+
+- [Habitat Architecture Overview](#habitat-architecture-overview)
+- [Habitat Initial Package Build Flow](#habitat-initial-package-build-flow)
+- [Habitat Dependency Update Flow](#habitat-dependency-update-flow)
+- [Habitat Application Rebuild Flow](#habitat-application-rebuild-flow)
+- [Habitat Initial Docker Container Publishing Flow](#habitat-initial-docker-container-publishing-flow)
+- [Habitat Automated Docker Container Publishing Flow](#habitat-automated-docker-container-publishing-flow)
+- [Habitat Promote Packages Through Channels](#habitat-promote-packages-through-channels)
+- [Habitat Runtime Services Group Binding](#habitat-runtime-services-group-binding)
+- [Habitat Builder Architecture](#habitat-builder-architecture)
+- [Habitat and Kubernetes](#habitat-and-kubernetes)
+
+---
 ### Habitat Architecture Overview
 <a target="_blank" href="/images/infographics/habitat-architecture-overview.png">
 ![Habitat Architecture Overview infographic](/images/infographics/habitat-architecture-overview.png)

--- a/www/source/docs/diagrams.html.md.erb
+++ b/www/source/docs/diagrams.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Diagrams
+title: Habitat Docs - Diagrams
 ---
 
 # Diagrams
@@ -8,67 +8,67 @@ With Habitat comes a number of concepts - some you may be familiar with, some yo
 
 ## Table of Contents
 
-- [Habitat Architecture Overview](#habitat-architecture-overview)
-- [Habitat Initial Package Build Flow](#habitat-initial-package-build-flow)
-- [Habitat Dependency Update Flow](#habitat-dependency-update-flow)
-- [Habitat Application Rebuild Flow](#habitat-application-rebuild-flow)
-- [Habitat Initial Docker Container Publishing Flow](#habitat-initial-docker-container-publishing-flow)
-- [Habitat Automated Docker Container Publishing Flow](#habitat-automated-docker-container-publishing-flow)
-- [Habitat Promote Packages Through Channels](#habitat-promote-packages-through-channels)
-- [Habitat Runtime Services Group Binding](#habitat-runtime-services-group-binding)
-- [Habitat Builder Architecture](#habitat-builder-architecture)
+- [Architecture Overview](#architecture-overview)
+- [Initial Package Build Flow](#initial-package-build-flow)
+- [Dependency Update Flow](#dependency-update-flow)
+- [Application Rebuild Flow](#application-rebuild-flow)
+- [Initial Docker Container Publishing Flow](#initial-docker-container-publishing-flow)
+- [Automated Docker Container Publishing Flow](#automated-docker-container-publishing-flow)
+- [Promote Packages Through Channels](#promote-packages-through-channels)
+- [Runtime Services Group Binding](#runtime-services-group-binding)
+- [Builder Architecture](#builder-architecture)
 - [Habitat and Kubernetes](#habitat-and-kubernetes)
 
 ---
-### Habitat Architecture Overview
+### Architecture Overview
 <a target="_blank" href="/images/infographics/habitat-architecture-overview.png">
 ![Habitat Architecture Overview infographic](/images/infographics/habitat-architecture-overview.png)
 </a>
 <small>Click image to view full size in new tab</small>
 
-### Habitat Initial Package Build Flow
+### Initial Package Build Flow
 <a target="_blank" href="/images/infographics/habitat-initial-package-build-flow.png">
 ![Habitat Initial Package Build Flow infographic](/images/infographics/habitat-initial-package-build-flow.png)
 </a>
 <small>Click image to view full size in new tab</small>
 
-### Habitat Dependency Update Flow
+### Dependency Update Flow
 <a target="_blank" href="/images/infographics/habitat-dependency-update-flow.png">
 ![Habitat Dependency Update Flow infographic](/images/infographics/habitat-dependency-update-flow.png)
 </a>
 <small>Click image to view full size in new tab</small>
 
-### Habitat Application Rebuild Flow
+### Application Rebuild Flow
 <a target="_blank" href="/images/infographics/habitat-application-rebuild-flow.png">
 ![Habitat Application Rebuild Flow infographic](/images/infographics/habitat-application-rebuild-flow.png)
 </a>
 <small>Click image to view full size in new tab</small>
 
-### Habitat Initial Docker Container Publishing Flow
+### Initial Docker Container Publishing Flow
 <a target="_blank" href="/images/infographics/habitat-initial-docker-container-publishing-flow.png">
 ![Habitat Initial Docker Container Publishing Flow infographic](/images/infographics/habitat-initial-docker-container-publishing-flow.png)
 </a>
 <small>Click image to view full size in new tab</small>
 
-### Habitat Automated Docker Container Publishing Flow
+### Automated Docker Container Publishing Flow
 <a target="_blank" href="/images/infographics/habitat-automated-docker-container-publishing-flow.png">
 ![Habitat Automated Docker Container Publishing Flow infographic](/images/infographics/habitat-automated-docker-container-publishing-flow.png)
 </a>
 <small>Click image to view full size in new tab</small>
 
-### Habitat Promote Packages Through Channels
+### Promote Packages Through Channels
 <a target="_blank" href="/images/infographics/habitat-promote-packages-through-channels.png">
 ![Habitat Promote Packages Through Channels infographic](/images/infographics/habitat-promote-packages-through-channels.png)
 </a>
 <small>Click image to view full size in new tab</small>
 
-### Habitat Runtime Services Group Binding
+### Runtime Services Group Binding
 <a target="_blank" href="/images/infographics/habitat-runtime-service-group-binding.png">
 ![Habitat Runtime Services Group Binding infographic](/images/infographics/habitat-runtime-service-group-binding.png)
 </a>
 <small>Click image to view full size in new tab</small>
 
-### Habitat Builder Architecture
+### Builder Architecture
 <a target="_blank" href="/images/infographics/habitat-builder-architecture.png">
 ![Habitat Builder Architecture infographic](/images/infographics/habitat-builder-architecture.png)
 </a>

--- a/www/source/docs/glossary.html.md.erb
+++ b/www/source/docs/glossary.html.md.erb
@@ -6,7 +6,7 @@ Habitat is a framework comprised of multiple components: Habitat Builder; the Su
 
 This section will delve into each of these major components to give a shared vocabulary on what they are, what they do, and how they work together. For information about the underlying design goals that motivated these components, see [Why Habitat?](/about/).
 
-You can also check out Habitat's [reference architectures](/docs/reference/#infographics).
+You can also check out Habitat's [reference architectures](/docs/diagrams).
 
 ## Table of Contents
 

--- a/www/source/docs/index.html.slim
+++ b/www/source/docs/index.html.slim
@@ -37,7 +37,7 @@ section.docs--get-started
   section.get-started--boxes
       div.row
         div.columns.medium-12
-          a.get-started--boxes--item.card href="/docs/reference/#infographics"
+          a.get-started--boxes--item.card href="/docs/diagrams"
             div.columns.medium-6
               h3.h3 Habitat in Pictures
               p

--- a/www/source/docs/reference.html.md.erb
+++ b/www/source/docs/reference.html.md.erb
@@ -20,7 +20,6 @@ This section will cover as many of the modules and APIs that Habitat is built up
 - [Template Data](#template-data)
 - [Package Contents](#package-contents)
 - [Supervisor Log Keys](#sup-log-keys)
-- [Infographics](#infographics)
 
 ---
 <%= partial "/partials/docs/reference-environment-vars"%>
@@ -42,5 +41,3 @@ This section will cover as many of the modules and APIs that Habitat is built up
 <%= partial "/partials/docs/reference-package-contents"%>
 ---
 <%= partial "/partials/docs/reference-supervisor-log-keys"%>
----
-<%= partial "/partials/docs/reference-infographics"%>

--- a/www/source/learn/index.html.slim
+++ b/www/source/learn/index.html.slim
@@ -81,6 +81,6 @@ classes: demo_index
           h3.h3 Habitat in Pictures
           p="For the visual learners and those simply curious about the overall system, take a high-level look at the entire Habitat landscape using this set of infographics."
           .button-bar
-            a.button.cta href="/docs/reference/#infographics" View the diagrams
+            a.button.cta href="/docs/diagrams" View the diagrams
         .demo--callout-content--clip.columns.large-6
           img src="/images/infographics/habitat-diagrams-thumb.png" alt="Thumbnail of Habitat system diagrams."

--- a/www/source/partials/tutorials/_web_guide_next_steps.slim
+++ b/www/source/partials/tutorials/_web_guide_next_steps.slim
@@ -8,7 +8,7 @@ section
  ul
   li #{link_to 'Share packages','/docs/developing-packages#sharing-pkgs'}
   li #{link_to 'Plan syntax guide','/docs/reference'}
-  li #{link_to 'Habitat Infographics','/docs/reference#infographics'}
+  li #{link_to 'Habitat Infographics','/docs/diagrams'}
   li #{link_to 'Using Habitat','/docs/using-habitat/'}
 
  p <b>Blog Posts</b>


### PR DESCRIPTION
fix #4809 

TODO:
Because the URL of the infographics (currently called **diagrams**) will be changing, from `/docs/reference#infographics` to `/docs/diagrams`. We need to update the existing URLs that contains `infographics`.

cc @cnunciato 