### PR TITLE
[common] Fix artifact install canonicalizing when dst doesn't exist.

### DIFF
--- a/components/common/src/command/package/install.rs
+++ b/components/common/src/command/package/install.rs
@@ -816,8 +816,9 @@ impl<'a> InstallTask<'a> {
         // Canonicalize both paths to ensure that there aren't any symlinks when comparing them
         // later.
         let artifact_path = artifact_path.canonicalize()?;
-        let cache_path = self.cached_artifact_path(ident).canonicalize()?;
         fs::create_dir_all(self.artifact_cache_path)?;
+        let artifact_cache_path = self.artifact_cache_path.canonicalize()?;
+        let cache_path = artifact_cache_path.join(ident.archive_name());
 
         // Handle the pathological case where you're trying to install
         // an artifact file directly from the cache. Otherwise, you'd


### PR DESCRIPTION
This fixes an issue when installing an artifact directly from disk, for
example:

hab pkg install /path/to/artifact.hart

A previous refactoring dereferenced all relative paths and symlinks when
copying the source (in the above exaple `/path/to/artifact.hart`) into
the artifact cache (i.e. `/hab/cache/artifacts/artifact.hart`). This
refactoring used `PathBuf#canonicalize` from the Rust stdlib, which
returns an error when the file representing the `PathBuf` does not exist
on disk (and also if the file cannot be read due to permissions, etc.).

This change first creates the artifact cache directory, then
canonicalizes the artifact cache *directory* `PathBuf` before appending
on the file name, which allows us to still canonicalize a path that we
know exists.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>