### PR TITLE
Generate template reference docs (and update them)

### DIFF
--- a/www/Makefile
+++ b/www/Makefile
@@ -36,6 +36,12 @@ cli_docs:
 	hab pkg install core/node --binlink && \
 	node scripts/generate-cli-docs > source/docs/habitat-cli.html.md"
 
+template_reference:
+	cp ../components/sup/doc/render_context_schema.json scripts/schema.json.tmp
+	hab studio run "hab pkg install core/node --binlink && \
+	cat scripts/schema.json.tmp | node scripts/generate-template-reference.js > ./source/partials/docs/_reference-template-data.html.md.erb"
+	rm -f scripts/schema.json.tmp
+
 check-env:
 ifndef AWS_ACCESS_KEY_ID
 	$(error AWS_ACCESS_KEY_ID is undefined)

--- a/www/scripts/generate-template-reference.js
+++ b/www/scripts/generate-template-reference.js
@@ -1,0 +1,104 @@
+const stdin = process.stdin;
+const stdout = process.stdout;
+let input = [];
+let lines = [];
+
+function writeHeader() {
+  lines.push(`# Template Data`);
+  lines.push('');
+  lines.push(`The following settings can be used during a Habitat service's lifecycle. This means that you can use these settings in any of the plan hooks, such as \`init\`, or \`run\`, and also in any templatized configuration file for your application or service.`)
+  lines.push('');
+  lines.push(`These configuration settings are referenced using the [Handlebars.js](https://github.com/wycats/handlebars.js/) version of [Mustache-style](https://mustache.github.io/mustache.5.html) tags. For an example on how these settings are used in plan hooks, see [Add Health Monitoring to a Plan](/tutorials/sample-app/mac/add-health-check-hook/) in the Getting Started tutorial.`)
+  lines.push('');
+}
+
+function writeDefinitions() {
+  lines.push(`## Reference Objects`);
+  lines.push('');
+  lines.push(`Some of the template expressions referenced above return objects of a specific shape; for example, the \`svc.me\` and \`svc.first\` expressions return "service member" objects, and the \`pkg\` property of a service member returns a "package identifier" object. These are defined below.`);
+  lines.push('');
+
+  Object.keys(schema.definitions)
+    .map(key => {
+      const p = schema.definitions[key];
+
+      lines.push(`### ${key}`);
+      lines.push('');
+      lines.push(p.description);
+      lines.push('');
+
+      props(p.properties);
+    });
+}
+
+function writeProperties() {
+  Object.keys(schema.properties)
+    .map(key => {
+      const p = schema.properties[key];
+      const properties = p.properties;
+      const additional = p.additionalProperties;
+
+      lines.push(`## ${key}`);
+      lines.push('');
+      lines.push(p.description);
+      lines.push('');
+
+      if (properties) {
+        props(properties);
+      }
+      else if (additional && additional.properties) {
+        props(additional.properties);
+      }
+    });
+}
+
+function props(collection) {
+  lines.push(`| Property | Type | Description |`);
+  lines.push(`| -------- | ---- | ----------- |`);
+
+  Object.keys(collection).map(key => {
+    lines.push(`| ${key} | ${getType(collection[key])} | ${collection[key].description} |`)
+  });
+
+  lines.push('');
+}
+
+function getType(prop) {
+  const type = prop.type;
+  const oneOf = prop.oneOf;
+  const ref = prop.$ref;
+
+  if (type) {
+    return type;
+  }
+
+  if (oneOf && oneOf.length) {
+    if (oneOf[0].type) {
+      return oneOf[0].type;
+    }
+
+    if (oneOf[0].$ref) {
+      const name = oneOf[0].$ref.split('/').pop();
+      return `[${name}](#${name})`;
+    }
+  }
+
+  if (ref) {
+    const name = ref.split('/').pop();
+    return `[${name}](#${name})`;
+  }
+
+  return '--';
+}
+
+stdin.on('data', d => {
+  input.push(d);
+});
+
+stdin.on('end', () => {
+  schema = JSON.parse(input.join());
+  writeHeader();
+  writeProperties();
+  writeDefinitions();
+  stdout.write(lines.join('\n'));
+});

--- a/www/source/partials/docs/_reference-template-data.html.md.erb
+++ b/www/source/partials/docs/_reference-template-data.html.md.erb
@@ -1,255 +1,128 @@
-# <a name="template-data" id="template-data" data-magellan-target="template-data">Template Data</a>
----
+# Template Data
 
-# Runtime settings
-The following settings can be used during a Habitat service's lifecycle. This means that you can use these settings in any of the plan hooks, such as init, or run, and also in any templatized configuration file for your application or service.
+The following settings can be used during a Habitat service's lifecycle. This means that you can use these settings in any of the plan hooks, such as `init`, or `run`, and also in any templatized configuration file for your application or service.
 
-These configuration settings are referenced using the [Handlebars.js](https://github.com/wycats/handlebars.js/) version of [mustache-style](https://mustache.github.io/mustache.5.html) tags. For an example on how these settings are used in plan hooks, see [Add Health Monitoring to a Plan](/tutorials/sample-app/mac/add-health-check-hook/) in the getting started tutorial.
+These configuration settings are referenced using the [Handlebars.js](https://github.com/wycats/handlebars.js/) version of [Mustache-style](https://mustache.github.io/mustache.5.html) tags. For an example on how these settings are used in plan hooks, see [Add Health Monitoring to a Plan](/tutorials/sample-app/mac/add-health-check-hook/) in the Getting Started tutorial.
 
 ## sys
-These are service settings specified by Habitat and correspond to the network information of the running Habitat service. You can also query these values on a running Supervisor via the Supervisor HTTP API.
 
-**version**
-: (string) Version of the Habitat Supervisor, e.g., `0.54.0/20180221023448`
+Describes the details of how this specific Supervisor was started
 
-**member_id**
-: (string) Supervisor's member id, e.g., `3d1e73ff19464a27aea3cdc5c2243f74`
-
-**ip**
-: (string) The IP address of the running service.
-
-**hostname**
-: (string) The hostname of the running service. Defaults to `localhost`.
-
-**gossip_ip**
-: (string) Listening address for Supervisor's gossip connection.
-
-**gossip_port**
-: (number) Listening port for Supervisor's gossip connection.
-
-**http_gateway_ip**
-: (string) Listening address for Supervisor's http gateway.
-
-**http_gateway_port**
-: (number) Listening port for Supervisor's http gateway
-
-**permanent**
-: (bool) This is set to `true` if a Supervisor is being used as a permanent peer, to increase Ring network traffic stability.
+| Property | Type | Description |
+| -------- | ---- | ----------- |
+| version | string | Version of the Habitat Supervisor, e.g., `0.54.0/20180221023448` |
+| member_id | string | The member's Supervisor ID, e.g., `3d1e73ff19464a27aea3cdc5c2243f74` |
+| ip | string | The IP address of the running service. |
+| hostname | string | The hostname of the running service. Defaults to `localhost` |
+| gossip_ip | string | Listening address for Supervisor's gossip connection. |
+| gossip_port | integer | Listening port for Supervisor's gossip connection. |
+| http_gateway_ip | string | Listening address for Supervisor's HTTP gateway. |
+| http_gateway_port | integer | Listening port for Supervisor's HTTP gateway. |
+| permanent | boolean | Set to true if a Supervisor is being used as a permanent peer, to increase Ring network traffic stability. |
 
 ## pkg
-These are package settings specified by Habitat and correspond to the the settings of the package when it was built and installed.
 
-**ident**
-: (string) The fully-qualified identifier of the running package, e.g., `core/redis/3.2.4/20170514150022`
+Details about the package currently running the service
 
-**origin**
-: (string) Denotes a particular upstream of a package. This value is pulled from the `pkg_origin` setting in a plan.
-
-**name**
-: (string) The name of the package. This value is pulled from the `pkg_name` setting in a plan.
-
-**version**
-: (string) The version of a package. This value is pulled from the `pkg_version` setting in a plan.
-
-**release**
-: (string) The UTC datetime stamp when the package was built. This value is specified in _YYYYMMDDhhmmss_ format.
-
-**deps**
-: (object array) An array of runtime dependencies for your package based on the pkg_deps setting in a plan. Each item is an object with `origin`, `name`, `version`, and `release` keys, like so:
-
-```
-{
-  "origin": "core",
-  "name": "git",
-  "version": "2.14.2",
-  "release": "20171016215544"
-}
-```
-
-**env**
-: (object) The runtime environment of your package, mirroring the contents of the `RUNTIME_ENVIRONMENT` metadata file. The `PATH` variable is set, containing all dependencies of your package, as well as any other runtime environment variables that have been set by the package. Individual variables can be accessed directly, like ``{{pkg.env.PATH}}`` (the keys are case sensitive).
-
-**exposes**
-: (string array) The array of ports (as strings) to expose for an application or service. This value is pulled from the `pkg_exposes` setting in a plan.
-
-**exports**
-: (object) A map of export key to internal configuration value key (i.e., the contents of `pkg_exports` in your plan). The key is what external services consume. The value is a key in your `default.toml` file that corresponds to the data being exported.
-
-**path**
-: (string) The location where the package is installed locally, e.g., `/hab/pkgs/core/redis/3.2.4/20170514150022`. Note that this is _not_ a `PATH` environment variable; for that, please see the `env` key above.
-
-**svc\_path**
-: (string) The root location of the source files for the Habitat service, e.g., `/hab/svc/redis`.
-
-**svc\_config\_path**
-: (string) The location of any [templated configuration files](/docs/developing-packages/#add-configuration) for the Habitat service, e.g., `/hab/svc/redis/config`.
-
-**svc\_data\_path**
-: (string) The location of any data files for the Habitat service, e.g., `/hab/svc/redis/data`.
-
-**svc\_files\_path**
-: (string) The location of any gossiped configuration files for the Habitat service, e.g., `/hab/svc/redis/files`.
-
-**svc\_static\_path**
-: (string) The location of any static content for the Habitat service, e.g., `/hab/svc/redis/static`.
-
-**svc\_var\_path**
-: (string) The location of any variable state data for the Habitat service, e.g., `/hab/svc/redis/var`.
-
-**svc\_pid_file**
-: (string) The location of the Habitat service pid file, e.g., `/hab/svc/redis/PID`.
-
-**svc_run**
-: (string) The location of the rendered run hook for the Habitat service, e.g., `/hab/svc/redis/run`.
-
-**svc_user**
-: (string) The value of `pkg_svc_user` specified in a plan (if not specified, "hab").
-
-**svc_group**
-: (string) The value of `pkg_svc_group` specified in a plan (if not specified, "hab").
+| Property | Type | Description |
+| -------- | ---- | ----------- |
+| ident | string | The fully-qualified identifier of the running package, e.g., `core/redis/3.2.4/20170514150022` |
+| origin | string | The origin of the Habitat package |
+| name | string | The name of the Habitat package |
+| version | string | The version of the Habitat package |
+| release | string | The release of the Habitat package |
+| deps | array | An array of runtime dependencies for your package based on the `pkg_deps` setting in a plan |
+| env | object | The runtime environment of your package, mirroring the contents of the `RUNTIME_ENVIRONMENT` metadata file. The `PATH` variable is set, containing all dependencies of your package, as well as any other runtime environment variables that have been set by the package. Individual variables can be accessed directly, like `{{pkg.env.PATH}}` (the keys are case sensitive). |
+| exposes | array | The array of ports to expose for an application or service. This value is pulled from the pkg_exposes setting in a plan. |
+| exports | object | A map of export key to internal configuration value key (i.e., the contents of `pkg_exports` in your plan). The key is what external services consume. The value is a key in your `default.toml` file that corresponds to the data being exported. |
+| path | string | The location where the package is installed locally, e.g., `/hab/pkgs/core/redis/3.2.4/20170514150022`. Note that this is _not_ a `PATH` environment variable; for that, please see the `env` key above. |
+| svc_path | string | The root location of the source files for the Habitat service, e.g., `/hab/svc/redis`. |
+| svc_config_path | string | The location of any templated configuration files for the Habitat service, e.g., `/hab/svc/redis/config`. |
+| svc_data_path | string | The location of any data files for the Habitat service, e.g., `/hab/svc/redis/data`. |
+| svc_files_path | string | The location of any gossiped configuration files for the Habitat service, e.g., `/hab/svc/redis/files`. |
+| svc_static_path | string | The location of any static content for the Habitat service, e.g., `/hab/svc/redis/static`. |
+| svc_var_path | string | The location of any variable state data for the Habitat service, e.g., `/hab/svc/redis/var`. |
+| svc_pid_file | string | The location of the Habitat service pid file, e.g., `/hab/svc/redis/PID`. |
+| svc_run | string | The location of the rendered run hook for the Habitat service, e.g., `/hab/svc/redis/run`. |
+| svc_user | string | The value of `pkg_svc_user` specified in a plan. |
+| svc_group | string | The value of `pkg_svc_group` specified in a plan. |
 
 ## cfg
-These are settings defined in your templatized configuration file. The values for those settings are pulled from the `default.toml` file included in your package. For example, if you had a `default.toml` file like this:
 
-```
-[foo]
-bar = "baz"
-```
-you could access the `"bar"` value using the templating expression `{{cfg.foo.bar}}`.
+These are settings defined in your templatized configuration file. The values for those settings are pulled from the `default.toml` file included in your package.
 
 ## svc
 
-**service**
-: (string) The name of the service. If the service is running from the package `core/redis`, the value will be `redis`.
+Information about the current service's service group
 
-**group**
-: (string) The group portion of the service's complete group name. In the group name `redis.default`, the group's value is `default`.
-
-**org**
-: (optional string) The `organization` portion of a service group specification. Unused at this time.
-
-**election_is_running**
-: (bool) whether a leader election is currently running for this service
-
-**election_is_no_quorum**
-: (bool) whether there is quorum for a leader election for this service
-
-**election_is_finished**
-: (bool) whether a leader election for this service has finished
-
-**update_election_is_running**
-: (bool) whether an update leader election is currently running for this service
-
-**update_election_is_no_quorum**
-: (bool) whether there is quorum for an update leader election for this service
-
-**update_election_is_finished**
-: (bool) whether an update leader election for this service has finished
-
-**me**
-: (service member) A object that provides information about the service running on the local Supervisor. See below for details.
-
-**first**
-: (service member) The first member of this service group
-
-**members**
-: (service member) All members of the service group, across the entire ring.
-
-**leader**
-: (service member) The current leader of the service group, if any (`null` otherwise)
-
-**update_leader**
-: (service member) The current update leader of the service group, if any (`null` otherwise)
+| Property | Type | Description |
+| -------- | ---- | ----------- |
+| service | string | The name of the service. If the service is running from the package `core/redis`, the value will be `redis`. |
+| group | string | The group portion of the service's complete group name. In the group name `redis.default`, the group's value is `default`. |
+| org | string | The organization portion of a service group specification. Unused at this time. |
+| election_is_running | boolean | Whether a leader election is currently running for this service |
+| election_is_no_quorum | boolean | Whether there is quorum for a leader election for this service |
+| election_is_finished | boolean | Whether a leader election for this service has finished |
+| update_election_is_running | boolean | Whether an update leader election is currently running for this service |
+| update_election_is_no_quorum | boolean | Whether there is quorum for an update leader election for this service |
+| update_election_is_finished | boolean | Whether an update leader election for this service has finished |
+| me | [svc_member](#svc_member) | An object that provides information about the service running on the local Supervisor |
+| first | [svc_member](#svc_member) | The first member of this service group |
+| members | array | All members of the service group, across the entire ring. Includes all liveness states! |
+| leader | [svc_member](#svc_member) | The current leader of the service group, if any (`null` otherwise) |
+| update_leader | [svc_member](#svc_member) | The current update_leader of the service group, if any (`null` otherwise) |
 
 ## bind
 
-The `bind` object maps the name of a bind to information about the ring members that are currently bound to it. The value is itself an object with `first` and `members` keys, which have the same meaning and construction as those keys on the `{{svc}}` object
+Exposes information about the service groups this service is bound to. Each key is the name of a bind, while each value is one of the objects described below
 
-## Service Member object
+| Property | Type | Description |
+| -------- | ---- | ----------- |
+| first | [svc_member](#svc_member) | The first member of this service group. If the group is running in a leader topology, this will also be the leader. |
+| members | array | All members of the service group, across the entire ring. Includes all liveness states! |
 
-The `{{svc.me}}`, `{{svc.first}}`, `{{svc.members}}`, `{{svc.leader}}`, `{{svc.update_leader}}`, `{{bind.<BIND>.first}}` and `{{bind.<BIND>.members}}` template variables all return "service member" objects, which is described here.
+## Reference Objects
 
-**member_id**
-: (string) the member's Supervisor id, e.g., `3d1e73ff19464a27aea3cdc5c2243f74`
+Some of the template expressions referenced above return objects of a specific shape; for example, the `svc.me` and `svc.first` expressions return "service member" objects, and the `pkg` property of a service member returns a "package identifier" object. These are defined below.
 
-**alive**
-: (bool) whether this member is considered alive and connected to the ring, from a network perspective.
+### package_identifier
 
-**suspect**
-: (bool) whether this member is considered "suspect", or possibly unreachable, from a network perspective.
+A Habitat package identifier, split apart into its constituent components
 
-**confirmed**
-: (bool) whether this member is confirmed dead / unreachable, from a network perspective.
+| Property | Type | Description |
+| -------- | ---- | ----------- |
+| origin | string | The origin of the Habitat package |
+| name | string | The name of the Habitat package |
+| version | string | The version of the Habitat package |
+| release | string | The release of the Habitat package |
 
-**departed**
-: (bool) whether this member has been departed from the ring (i.e., permanently gone, never to return).
+### svc_member
 
-Only one of `alive`, `suspect`, `confirmed`, or `departed` should be `true` at a time, with all others being `false`.
+Represents a member of a service group
 
-**election_is_running**
-: (bool) whether a leader election is currently running for this service
-
-**election_is_no_quorum**
-: (bool) whether there is quorum for a leader election for this service
-
-**election_is_finished**
-: (bool) whether a leader election for this service has finished
-
-**update_election_is_running**
-: (bool) whether an update leader election is currently running for this service
-
-**update_election_is_no_quorum**
-: (bool) whether there is quorum for an update leader election for this service
-
-**update_election_is_finished**
-: (bool) whether an update leader election for this service has finished
-
-These election flags convey the same information as the ones available from `{{svc}}`.
-
-**leader**
-: (bool) whether this member is the leader in the service group (only meaningful in a `leader` topology)
-
-**follower**
-: (bool) whether this member is a follower in the service group (only meaningful in a `leader` topology)
-
-**update_leader**
-: (bool) whether this member is the update leader in the service group (only meaningful in a `leader` topology)
-
-**update_follower**
-: (bool) whether this member is an update follower in the service group (only meaningful in a `leader` topology)
-
-**pkg**
-: (object) the release the member is running, with `origin`, `name`, `version`, and `release` keys, like so:
-
-```
-{
-  "origin": "core",
-  "name": "git",
-  "version": "2.14.2",
-  "release": "20171016215544"
-}
-```
-
-**sys**
-: (object) An abbreviated version of the top-level `{{sys}}` object, containing networking information for the member. It contains `hostname`, `ip`, `http_gateway_ip`, `http_gateway_port`, `gossip_ip`, and `gossip_port` keys, with the same meaning as those from `{{sys}}`.
-
-**cfg**
-: (object) The configuration the member is currently exporting. This is constrained by what is defined in `pkg_exports`, where the values are replaced with the current values (e.g., taking into account things like `user.toml`, gossiped configuration values, etc.)
-
-**persistent**
-: (bool) A misspelling of `permanent`; indicates whether a member is a permanent peer or not
-
-**service**
-: (string) The name of the service. If the service is running from the package `core/redis`, the value will be `redis`.
-
-**group**
-: (string) The group portion of the service's complete group name. In the group name `redis.default`, the group's value is `default`.
-
-**org**
-: (optional string) The `organization` portion of a service group specification. Unused at this time.
-
-**application**
-: (optional string) The `application` portion of a service group specification. Unused at this time.
-
-**environment**
-: (optional string) The `environment` portion of a service group specification. Unused at this time.
+| Property | Type | Description |
+| -------- | ---- | ----------- |
+| member_id | string | the member's Supervisor id, e.g., 3d1e73ff19464a27aea3cdc5c2243f74 |
+| alive | boolean | Whether this member is considered alive and connected to the ring, from a network perspective. |
+| suspect | boolean | Whether this member is considered "suspect", or possibly unreachable, from a network perspective. |
+| confirmed | boolean | Whether this member is confirmed dead / unreachable, from a network perspective. |
+| departed | boolean | Whether this member has been departed from the ring (i.e., permanently gone, never to return). |
+| election_is_running | boolean | Whether a leader election is currently running for this service |
+| election_is_no_quorum | boolean | Whether there is quorum for a leader election for this service |
+| election_is_finished | boolean | Whether a leader election for this service has finished |
+| update_election_is_running | boolean | Whether an update leader election is currently running for this service |
+| update_election_is_no_quorum | boolean | Whether there is quorum for an update leader election for this service |
+| update_election_is_finished | boolean | Whether an update leader election for this service has finished |
+| leader | boolean | Whether this member is the leader in the service group (only meaningful in a leader topology) |
+| follower | boolean | Whether this member is a follower in the service group (only meaningful in a leader topology) |
+| update_leader | boolean | Whether this member is the update leader in the service group (only meaningful in a leader topology) |
+| update_follower | boolean | Whether this member is an update follower in the service group (only meaningful in a leader topology) |
+| pkg | [package_identifier](#package_identifier) | The identifier of the release the member is running |
+| sys | object | An abbreviated version of the top-level {{sys}} object, containing networking information for the member. |
+| cfg | object | The configuration the member is currently exporting. This is constrained by what is defined in `pkg_exports`, where the values are replaced with the current values (e.g., taking into account things like user.toml, gossiped configuration values, etc.) |
+| persistent | boolean | A misspelling of `permanent`; indicates whether a member is a permanent peer or not |
+| service | string | The name of the service. If the service is running from the package `core/redis`, the value will be `redis`. |
+| group | string | The group portion of the service's complete group name. In the group name `redis.default`, the group's value is `default`. |
+| org | string | The organization portion of a service group specification. Unused at this time. |
+| application | string | The application portion of a service group specification. Unused at this time. |
+| environment | string | The environment portion of a service group specification. Unused at this time. |


### PR DESCRIPTION
This change adds a script for generating the template rendering context based on its JSON schema. To run it, install Habitat, then:

```
cd www
make template_reference
```

It also changes the layout of this section to use tables, for scannability, but I also think we could do some work to improve the usability of this page in general; it's pretty huge, and it feels like breaking things out into individual pages might actually be a better solution. 

Signed-off-by: Christian Nunciato <chris@nunciato.org>

![](https://i.giphy.com/media/NWlBEcDW5evFS/200w.gif)