### PR TITLE
[pkg-export-docker] Only require a registry url with amazon/azure types

### DIFF
--- a/components/pkg-export-docker/src/cli.rs
+++ b/components/pkg-export-docker/src/cli.rs
@@ -15,25 +15,18 @@
 #![cfg_attr(feature="clippy", feature(plugin))]
 #![cfg_attr(feature="clippy", plugin(clippy))]
 
-use clap::{App, Arg};
 use std::path::Path;
 use std::result;
 use std::str::FromStr;
 
+use clap::{App, Arg};
 use hcore::package::PackageIdent;
 use url::Url;
 
+use RegistryType;
+
 /// The version of this library and program when built.
 pub const VERSION: &'static str = include_str!(concat!(env!("OUT_DIR"), "/VERSION"));
-
-arg_enum!{
-    #[derive(Debug)]
-    pub enum RegistryType {
-        Amazon,
-        Docker,
-        Azure
-    }
-}
 
 /// A Docker-specific clap:App wrapper
 #[derive(Clone)]
@@ -227,13 +220,12 @@ impl<'a, 'b> Cli<'a, 'b> {
                  .requires("REGISTRY_USERNAME")
                  .help("Remote registry password, required for pushing image to remote registry"))
             .arg(Arg::with_name("REGISTRY_TYPE")
-                 .possible_values(&RegistryType::variants())
                  .requires("REGISTRY_URL")
-                 .case_insensitive(true)
+                 .possible_values(RegistryType::variants())
                  .long("registry-type")
                  .short("R")
                  .value_name("REGISTRY_TYPE")
-                 .help("Remote registry type, Ex: Amazon, Docker, Azure (default: docker)"))
+                 .help("Remote registry type (default: docker)"))
             .arg(Arg::with_name("REGISTRY_URL")
                  // This is not strictly a requirement but will keep someone from
                  // making a mistake when inputing an ECR URL

--- a/components/pkg-export-docker/src/cli.rs
+++ b/components/pkg-export-docker/src/cli.rs
@@ -220,7 +220,6 @@ impl<'a, 'b> Cli<'a, 'b> {
                  .requires("REGISTRY_USERNAME")
                  .help("Remote registry password, required for pushing image to remote registry"))
             .arg(Arg::with_name("REGISTRY_TYPE")
-                 .requires("REGISTRY_URL")
                  .possible_values(RegistryType::variants())
                  .long("registry-type")
                  .short("R")
@@ -229,7 +228,8 @@ impl<'a, 'b> Cli<'a, 'b> {
             .arg(Arg::with_name("REGISTRY_URL")
                  // This is not strictly a requirement but will keep someone from
                  // making a mistake when inputing an ECR URL
-                 .requires("REGISTRY_TYPE")
+                 .required_if("REGISTRY_TYPE", "amazon")
+                 .required_if("REGISTRY_TYPE", "azure")
                  .long("registry-url")
                  .short("G")
                  .value_name("REGISTRY_URL")

--- a/components/pkg-export-docker/src/error.rs
+++ b/components/pkg-export-docker/src/error.rs
@@ -34,6 +34,8 @@ pub enum Error {
                      Current Docker Server OS is set to: {}",
            _0)]
     DockerNotInWindowsMode(String),
+    #[fail(display = "Invalid registry type: {}", _0)]
+    InvalidRegistryType(String),
     #[fail(display = "{}", _0)]
     InvalidToken(FromUtf8Error),
     #[fail(display = "Docker login failed with exit code: {}", _0)]

--- a/components/pkg-export-docker/src/lib.rs
+++ b/components/pkg-export-docker/src/lib.rs
@@ -48,6 +48,9 @@ pub mod rootfs;
 mod util;
 
 use std::env;
+use std::fmt;
+use std::result;
+use std::str::FromStr;
 
 use common::ui::UI;
 use hcore::{channel, PROGRAM_NAME};
@@ -59,7 +62,7 @@ use rusoto_core::Region;
 use rusoto_core::request::*;
 use rusoto_ecr::{Ecr, EcrClient, GetAuthorizationTokenRequest};
 
-pub use cli::{Cli, PkgIdentArgOptions, RegistryType};
+pub use cli::{Cli, PkgIdentArgOptions};
 pub use build::BuildSpec;
 pub use docker::{DockerImage, DockerBuildRoot};
 pub use error::{Error, Result};
@@ -112,6 +115,43 @@ impl<'a> Naming<'a> {
             registry_url: registry_url,
             registry_type: registry_type,
         }
+    }
+}
+
+#[derive(Debug)]
+pub enum RegistryType {
+    Amazon,
+    Azure,
+    Docker,
+}
+
+impl RegistryType {
+    fn variants() -> &'static [&'static str] {
+        &["amazon", "azure", "docker"]
+    }
+}
+
+impl FromStr for RegistryType {
+    type Err = Error;
+
+    fn from_str(value: &str) -> result::Result<Self, Self::Err> {
+        match value {
+            "amazon" => Ok(RegistryType::Amazon),
+            "azure" => Ok(RegistryType::Azure),
+            "docker" => Ok(RegistryType::Docker),
+            _ => Err(Error::InvalidRegistryType(String::from(value))),
+        }
+    }
+}
+
+impl fmt::Display for RegistryType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let disp = match *self {
+            RegistryType::Amazon => "amazon",
+            RegistryType::Azure => "azure",
+            RegistryType::Docker => "docker",
+        };
+        write!(f, "{}", disp)
     }
 }
 


### PR DESCRIPTION
This change set fixes the above bug but also refactors a CLI-specific type and extracts it to a proper library type which resolves a UX issue in how the CLI interprets the value of `--registry-type`.

## [pkg-export-docker] Extract `RegistryType` to a non-CLI type.

This is a refactoring change which removes the CLI-only enum
`RegistryType` and makes it a proper business logic type in the root of
the `export_docker` module.

The underlying reason for this was twofold:

1) The default `Debug` and `Display` derivations would return the enum
variants as capitalized strings, and not lowercased. This causes the CLI
usage to look incorrect as we're looking for values like `azure` and
not `Azure`. Controlling the `FromStr` and `Display` implementations
yields a much better result.
2) This type was being imported by the rest of the module and used in
the other types and business logic which breaks the CLI/business logic
separation of concerns. If we need a type in non CLI-parsing code, it
shouldn't live in the CLI-parsing code.

## [pkg-export-docker] Only require a registry url with amazon/azure types.
This fixes a bug where if the user provides `--registry-type docker` on
the command line, the CLI parsing demoands that a `--registry-url` be
provided (which it shouldn't).

The only time that `--registry-url` is required is if `--registry-type`
is provided and if the value is either `amazon` or `azure`.