### PR TITLE
Add some missing env_logger initialization calls and remove unused deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -557,7 +557,6 @@ version = "0.0.0"
 dependencies = [
  "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy 0.0.187 (registry+https://github.com/rust-lang/crates.io-index)",
- "env_logger 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat-eventsrv-protocol 0.0.0 (git+https://github.com/habitat-sh/protocols.git)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -664,7 +663,6 @@ name = "habitat_butterfly_test"
 version = "0.1.0"
 dependencies = [
  "clippy 0.0.187 (registry+https://github.com/rust-lang/crates.io-index)",
- "env_logger 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat_butterfly 0.1.0",
  "habitat_core 0.0.0 (git+https://github.com/habitat-sh/core.git)",
  "time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/butterfly-test/Cargo.toml
+++ b/components/butterfly-test/Cargo.toml
@@ -6,7 +6,6 @@ workspace = "../../"
 
 [dependencies]
 clippy = {version = "*", optional = true}
-env_logger = "*"
 time = "*"
 
 [dependencies.habitat_butterfly]

--- a/components/butterfly-test/src/lib.rs
+++ b/components/butterfly-test/src/lib.rs
@@ -14,7 +14,6 @@
 #![cfg_attr(feature="clippy", feature(plugin))]
 #![cfg_attr(feature="clippy", plugin(clippy))]
 
-extern crate env_logger;
 extern crate time;
 #[macro_use]
 extern crate habitat_butterfly;

--- a/components/butterfly/tests/integration.rs
+++ b/components/butterfly/tests/integration.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-extern crate env_logger;
 extern crate time;
 #[macro_use]
 extern crate habitat_butterfly;

--- a/components/eventsrv-client/Cargo.toml
+++ b/components/eventsrv-client/Cargo.toml
@@ -12,7 +12,6 @@ workspace = "../../"
 [dependencies]
 clippy = {version = "*", optional = true}
 byteorder = "*"
-env_logger = "*"
 habitat-eventsrv-protocol = { git = "https://github.com/habitat-sh/protocols.git" }
 lazy_static = "*"
 log = "*"

--- a/components/eventsrv-client/src/lib.rs
+++ b/components/eventsrv-client/src/lib.rs
@@ -15,7 +15,6 @@
 #![cfg_attr(feature="clippy", feature(plugin))]
 #![cfg_attr(feature="clippy", plugin(clippy))]
 
-extern crate env_logger;
 extern crate habitat_eventsrv_protocol as protocol;
 extern crate protobuf;
 extern crate time;

--- a/components/eventsrv/src/subscriber.rs
+++ b/components/eventsrv/src/subscriber.rs
@@ -33,6 +33,7 @@ use protocol::{EventEnvelope, EventEnvelope_Type, ServiceUpdate as ServiceUpdate
 use zmq::{Context, SUB};
 
 fn main() {
+    env_logger::init();
     let ctx = Context::new();
     let socket = ctx.socket(SUB).unwrap();
 

--- a/components/pkg-export-tar/src/main.rs
+++ b/components/pkg-export-tar/src/main.rs
@@ -20,6 +20,7 @@ fn main() {
 }
 
 fn start(ui: &mut UI) -> Result<()> {
+    env_logger::init();
     let cli = cli();
     let m = cli.get_matches();
     debug!("clap cli args: {:?}", m);


### PR DESCRIPTION
Without the env_logger::init() call, debug! et al calls won't print anything

Signed-off-by: Jon Bauman <5906042+baumanj@users.noreply.github.com>