### PR TITLE
[plan-build-ps1] Restore generation of package `PATH` metafile.

### DIFF
--- a/components/plan-build-ps1/bin/hab-plan-build.ps1
+++ b/components/plan-build-ps1/bin/hab-plan-build.ps1
@@ -1695,6 +1695,15 @@ $(Get-Content "$PLAN_CONTEXT\plan.ps1" -Raw)
 function _Write-Metadata {
     Write-BuildLine "Building pacakge metadata"
 
+    $prefixDrive = (Resolve-Path $originalPath).Drive.Root
+    $strippedPrefix = $pkg_prefix.Substring($prefixDrive.length)
+    if(!$strippedPrefix.StartsWith('\')) { $strippedPrefix = "\$strippedPrefix" }
+
+    if ($pkg_bin_dirs.Length -gt 0) {
+        $($pkg_bin_dirs | % { "$strippedPrefix\$_" }) -join ';' |
+            Out-File "$pkg_prefix\PATH" -Encoding ascii
+    }
+
     if ($pkg_expose.Length -gt 0) {
         "$($pkg_expose -join ' ')" |
             Out-File "$pkg_prefix\EXPOSES" -Encoding ascii


### PR DESCRIPTION
This change relates to habitat-sh/builder#240 and restores the creation
of a `PATH` metafile with the original semantics of containing path
entries that are expressed in a Plan by setting `$pkg_bin_dirs`.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>