### PR TITLE
Expose only "active" members in RenderContext

### DIFF
--- a/components/sup/doc/render_context_schema.json
+++ b/components/sup/doc/render_context_schema.json
@@ -447,7 +447,8 @@
                     "$ref": "#/definitions/svc_member"
                 },
                 "first": {
-                    "description": "The first member of this service group",
+                    "description": "The first member of this service group, or the leader, if running in a leader topology",
+                    "$deprecated": "Since 0.56.0; if you want the leader, use `leader` explicitly. 'first' isn't deterministic, either, so you can just use `members[0]` instead",
                     "$ref": "#/definitions/svc_member"
                 },
                 "members": {
@@ -499,7 +500,10 @@
                     "first": {
                         "description": "The first member of this service group. If the group is running in a leader topology, this will also be the leader.",
                         "$deprecated": "Since 0.56.0; if you want the leader, use `leader` explicitly. 'first' isn't deterministic, either, so you can just use `members[0]` instead",
-                        "$ref": "#/definitions/svc_member"
+                        "oneOf": [
+                            { "$ref": "#/definitions/svc_member" },
+                            { "type": "null" }
+                        ]
                     },
                     "leader": {
                         "description": "The current leader of this service group, if running in a leader topology",

--- a/components/sup/doc/render_context_schema.json
+++ b/components/sup/doc/render_context_schema.json
@@ -451,7 +451,7 @@
                     "$ref": "#/definitions/svc_member"
                 },
                 "members": {
-                    "description": "All members of the service group, across the entire ring. Includes all liveness states!",
+                    "description": "All active members (`alive` and `suspect`) of the service group, across the entire ring. As of 0.56.0, does _not_ include `departed` or `confirmed` members",
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/svc_member"
@@ -510,7 +510,7 @@
                         ]
                     },
                     "members": {
-                        "description": "All members of the service group, across the entire ring. Includes all liveness states!",
+                        "description": "All active members (`alive` and `suspect`) of the service group, across the entire ring. As of 0.56.0, does _not_ include `departed` or `confirmed` members",
                         "type": "array",
                         "items": {
                             "$ref": "#/definitions/svc_member"

--- a/components/sup/src/templating/context.rs
+++ b/components/sup/src/templating/context.rs
@@ -310,7 +310,7 @@ impl<'a> Svc<'a> {
             update_election_status: Cow::Borrowed(&census_group.update_election_status),
             members: Cow::Owned(
                 census_group
-                    .members()
+                    .active_members()
                     .iter()
                     .map(|m| SvcMember::from_census_member(m))
                     .collect(),
@@ -427,7 +427,7 @@ impl<'a> BindGroup<'a> {
             first: select_first(group),
             leader: group.leader().map(|m| SvcMember::from_census_member(m)),
             members: group
-                .members()
+                .active_members()
                 .iter()
                 .map(|m| SvcMember::from_census_member(m))
                 .collect(),


### PR DESCRIPTION
Instead of showing *all* members of a service group in the rendering context, we'll now just return only the live and suspect members (filtering out all confirmed-dead and departed members). This is really what users want when they access the `svc.members` and `bind.<SERVICE>.members` fields.

Please read the individual commit messages for further detail.

See #4872 for the "big picture" behind this change.