### PR TITLE
[common] Restore UI begin/end coloring and debugging capability.

### DIFF
--- a/components/sup/src/ctl_gateway/mod.rs
+++ b/components/sup/src/ctl_gateway/mod.rs
@@ -131,16 +131,24 @@ impl UIWriter for CtlRequest {
         self
     }
 
-    fn is_colored(&self) -> bool {
+    fn is_out_colored(&self) -> bool {
         true
     }
 
-    fn is_a_terminal(&self) -> bool {
+    fn is_err_colored(&self) -> bool {
+        true
+    }
+
+    fn is_out_a_terminal(&self) -> bool {
+        true
+    }
+
+    fn is_err_a_terminal(&self) -> bool {
         true
     }
 
     fn progress(&self) -> Option<Self::ProgressBar> {
-        if self.is_a_terminal() {
+        if self.is_out_a_terminal() {
             Some(Self::ProgressBar::new(self.clone()))
         } else {
             None


### PR DESCRIPTION
This change fixes a few issues from the refactoring in
habitat-sh/habitat#4805, namely:

* Fixes the lack of coloring with `#begin()`, `#end()`, `#warn()`,
`#fatal()`.
* Fixes the coloring of `#end()` from Yellow back to Blue.
* Adds back UI debugging by implementing `Debug` trait on several inner
types, allowing a default `Debug` impl to be derived on `UI`. This
allows for better debugging in the future when running in various
environments.
* Exposes per-stream coloring and terminal detection so that display
methods can query the specific output stream's capabilities.

Additionally, several issues were also addressed:

* Fixes coloring on multiple lines in `#fatal()` (introduced in
habitat-sh/habitat#1322).
* Fixes a potential coloring issue that arises in the Builder's job
streams where an ANSI reset sequence is not printed before certain
newlines in `#fatal()` (used to print error messages when various CLI
commands fail). This change ensures that each line up to, but not
including the newline is colored.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>