### PR TITLE
Remove exporter dependencies on Supervisor in `.bldr.toml`.

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -76,7 +76,6 @@ paths = [
   "components/common/*",
   "components/hab/*",
   "components/pkg-export-docker/*",
-  "components/sup/*",
 ]
 
 [hab-pkg-export-helm]
@@ -87,7 +86,6 @@ paths = [
   "components/hab/*",
   "components/pkg-export-docker/*",
   "components/pkg-export-kubernetes/*",
-  "components/sup/*",
 ]
 
 [hab-pkg-export-tar]


### PR DESCRIPTION
Introduced in habitat-sh/habitat#4448 but no longer needed.

This will eliminate rebuilding of `core/hab-pkg-export-kubernetes` and `core/hab-pkg-export-helm` every time the Supervisor code is modified.