### PR TITLE
[hab-sup] Exit 0 when given --help or --version

### DIFF
--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -114,7 +114,16 @@ fn start() -> Result<()> {
         Err(err) => {
             let out = io::stdout();
             writeln!(&mut out.lock(), "{}", err.message).expect("Error writing Error to stdout");
-            process::exit(ERR_NO_RETRY_EXCODE);
+            match launcher {
+                Some(_) => process::exit(ERR_NO_RETRY_EXCODE),
+                // If we weren't started by a launcher, exit 0 for
+                // help and version
+                None => match err.kind {
+                    clap::ErrorKind::HelpDisplayed => process::exit(0),
+                    clap::ErrorKind::VersionDisplayed => process::exit(0),
+                    _ => process::exit(ERR_NO_RETRY_EXCODE),
+                },
+            }
         }
     };
     match app_matches.subcommand() {


### PR DESCRIPTION
Previously, hab-sup --version would exit with 86. Now, we exit 0 for
both --version and --help.

Note, however, we will still exit with an error if the help is
displayed because of an error such as a bad subcommand or bad option.

You may ask, "Do we need to print the error in the case of
HelpDisplayed or VersionDisplayed?" In the case of HelpDisplayed the
answer is yes because the help output isn't actually output to stdout
but rather to a buffer that is contained in the error. In the case of
VersionDisplay the answer is "kinda". The version is printed to
stdout but without a newline, so printing the empty error prints a
newline, which is a bit dirty but kept the function simple.