### PR TITLE
Add `hab sup secret` subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -625,6 +625,7 @@ dependencies = [
 name = "habitat-sup-protocol"
 version = "0.0.0"
 dependencies = [
+ "base64 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat_core 0.0.0 (git+https://github.com/habitat-sh/core.git)",
@@ -633,6 +634,7 @@ dependencies = [
  "protobuf 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "protoc 1.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "protoc-rust 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -880,7 +882,6 @@ name = "habitat_sup"
 version = "0.0.0"
 dependencies = [
  "ansi_term 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "base64 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "caps 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -606,6 +606,14 @@ pub fn get() -> App<'static, 'static> {
                 (@arg REMOTE_SUP: --("remote-sup") -r +takes_value {valid_socket_addr}
                     "Address to a remote Supervisor's Control Gateway [default: 127.0.0.1:9632]")
             )
+            (@subcommand secret =>
+                (about: "Commands relating to a Habitat Supervisor's Contorl Gateway secret")
+                (@setting ArgRequiredElseHelp)
+                (@subcommand generate =>
+                    (about: "Generate a secret key to use as a Supervisor's Control Gateway secret")
+                    (aliases: &["g", "gen"])
+                )
+            )
         )
         (@subcommand user =>
             (about: "Commands relating to Habitat users")

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -235,6 +235,10 @@ fn start(ui: &mut UI) -> Result<()> {
         },
         ("sup", Some(m)) => match m.subcommand() {
             ("depart", Some(m)) => sub_sup_depart(m)?,
+            ("secret", Some(m)) => match m.subcommand() {
+                ("generate", _) => sub_sup_secret_generate()?,
+                _ => unreachable!(),
+            },
             _ => unreachable!(),
         },
         ("setup", Some(_)) => sub_cli_setup(ui)?,
@@ -1043,6 +1047,14 @@ fn sub_sup_depart(m: &ArgMatches) -> Result<()> {
         })
         .wait()?;
     ui.end("Departure recorded.")?;
+    Ok(())
+}
+
+fn sub_sup_secret_generate() -> Result<()> {
+    let mut ui = ui();
+    let mut buf = String::new();
+    protocol::generate_secret_key(&mut buf);
+    ui.info(buf)?;
     Ok(())
 }
 

--- a/components/sup-protocol/Cargo.toml
+++ b/components/sup-protocol/Cargo.toml
@@ -6,12 +6,14 @@ build = "./build.rs"
 workspace = "../../"
 
 [dependencies]
+base64 = "*"
 bytes = "*"
 futures = "*"
 habitat_core = { git = "https://github.com/habitat-sh/core.git" }
 lazy_static = "*"
 log = "*"
 protobuf = { version = "*", features = ["bytes"] }
+rand = "*"
 serde = "*"
 tokio = "*"
 tokio-io = "*"

--- a/components/sup-protocol/src/lib.rs
+++ b/components/sup-protocol/src/lib.rs
@@ -40,6 +40,7 @@
 //! *not* by a build server intentionally. This is to ensure we have the source available for
 //! all protocol files.
 
+extern crate base64;
 extern crate bytes;
 extern crate futures;
 extern crate habitat_core as core;
@@ -48,6 +49,7 @@ extern crate lazy_static;
 #[macro_use]
 extern crate log;
 extern crate protobuf;
+extern crate rand;
 extern crate serde;
 extern crate tokio;
 extern crate tokio_io;
@@ -63,10 +65,14 @@ use std::fs::File;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 
+use rand::Rng;
+
 use net::{ErrCode, NetResult};
 
 /// Name of file containing the CtlGateway secret key.
 const CTL_SECRET_FILENAME: &'static str = "CTL_SECRET";
+/// Length of characters in CtlGateway secret key.
+const CTL_SECRET_LEN: usize = 64;
 
 lazy_static! {
     /// The root path containing all runtime service directories and files
@@ -81,6 +87,14 @@ lazy_static! {
     pub static ref DEFAULT_BLDR_CHANNEL: String = {
         core::channel::default()
     };
+}
+
+/// Generate a new secret key used for authenticating clients to the `CtlGateway`.
+pub fn generate_secret_key(out: &mut String) {
+    let mut rng = rand::OsRng::new().unwrap();
+    let mut result = vec![0u8; CTL_SECRET_LEN];
+    rng.fill_bytes(&mut result);
+    *out = base64::encode(&result);
 }
 
 /// Read the secret key used to authenticate connections to the `CtlGateway` from disk and write

--- a/components/sup/Cargo.toml
+++ b/components/sup/Cargo.toml
@@ -16,7 +16,6 @@ doc = false
 [dependencies]
 clippy = { version = "*", optional = true }
 ansi_term = "*"
-base64 = "*"
 bitflags = "*"
 byteorder = "*"
 clap = { version = "*", features = [ "suggestions", "color", "unstable" ] }

--- a/components/sup/src/lib.rs
+++ b/components/sup/src/lib.rs
@@ -40,7 +40,6 @@
 //! * [The Habitat Supervisor Sidecar; http interface to promises](sidecar)
 
 extern crate ansi_term;
-extern crate base64;
 #[macro_use]
 extern crate bitflags;
 extern crate byteorder;


### PR DESCRIPTION
Add a subcommand for interacting with control gateawy secrets. Currently
there is only one subcommand for this subcommand, `generate`. This
command is used for generating a secret key which can then be written to
disk when provisioning a machine with a new Supervisor. This will help
ensure that there is an easy path for sharing a common secret key between all
Supervisors.

Signed-off-by: Jamie Winsor <jamie@vialstudios.com>