### PR TITLE
Add secrets link to the docs sidebar

### DIFF
--- a/www/data/docs_sidebar.yml
+++ b/www/data/docs_sidebar.yml
@@ -39,6 +39,8 @@ sidebar_links:
       link: "/docs/using-builder/#builder-origin"
     - title: Generate an Access Token
       link: "/docs/using-builder/#builder-token"
+    - title: Working with Origin Secrets
+      link: "/docs/using-builder/#origin-secrets"
     - title: Upload and Promote
       link: "/docs/using-builder/#sharing-pkgs"
     - title: Using Multiple Plans


### PR DESCRIPTION
A previous PR added a link to this section in the page-level table of contents, but missed adding a link for it in the sidebar.

Signed-off-by: Christian Nunciato <chris@nunciato.org>

![](https://i.giphy.com/media/bFpivMTykBhoj7gWmr/200w.gif)