### PR TITLE
Firmly establish role of PATH, RUNTIME_ENVIRONMENT, & RUNTIME_PATH metadata files

### DIFF
--- a/components/hab/src/command/pkg/exec.rs
+++ b/components/hab/src/command/pkg/exec.rs
@@ -28,9 +28,9 @@ where
 {
     let command = command.into();
     let pkg_install = PackageInstall::load(&ident, Some(&*FS_ROOT_PATH))?;
-    let mut run_env = pkg_install.environment_for_command()?;
+    let mut cmd_env = pkg_install.environment_for_command()?;
 
-    let mut paths: Vec<PathBuf> = match run_env.get("PATH") {
+    let mut paths: Vec<PathBuf> = match cmd_env.get("PATH") {
         Some(path) => env::split_paths(&path).collect(),
         None => vec![],
     };
@@ -40,14 +40,14 @@ where
         }
     }
     let joined = env::join_paths(paths)?;
-    run_env.insert(
+    cmd_env.insert(
         String::from("PATH"),
         joined
             .into_string()
             .expect("Unable to convert OsStr path to string!"),
     );
 
-    for (key, value) in run_env.into_iter() {
+    for (key, value) in cmd_env.into_iter() {
         debug!("Setting: {}='{}'", key, value);
         env::set_var(key, value);
     }

--- a/components/plan-build/bin/shared.bash
+++ b/components/plan-build/bin/shared.bash
@@ -143,26 +143,26 @@ _render_metadata_LD_RUN_PATH() {
     fi
 }
 
-# Simply converts contents of pkg_bin_dirs into a PATH variable
-__process_path() {
-    local path=()
-
-    # Contents of `pkg_bin_dirs` are relative to the plan root;
-    # prepend the full path to this release so everything resolves
-    # properly once the package is installed.
-    for bin in "${pkg_bin_dirs[@]}"; do
-        path+=("${pkg_prefix}/${bin}")
-    done
-
-    echo "$(join_by ':' ${path[@]})"
-}
-
 # The PATH metadata file contains ONLY the bins contained in your package
 # for `pkg_bin_dirs`
 #
 _render_metadata_PATH() {
+  if [[ ${#pkg_bin_dirs[@]} -gt 0 ]]; then
+    local paths=()
+    local dir
+
     debug "Rendering PATH metadata file"
-    echo "$(__process_path)" > "${pkg_prefix}/PATH"
+    # Contents of `pkg_bin_dirs` are relative to the plan root;
+    # prepend the full path to this release so everything resolves
+    # properly once the package is installed.
+    for dir in "${pkg_bin_dirs[@]}"; do
+        paths+=("${pkg_prefix}/${dir}")
+    done
+
+    echo "$(join_by ':' ${paths[@]})" > "${pkg_prefix}/PATH"
+  else
+    debug "Would have rendered PATH, but there was no data for it"
+  fi
 }
 
 _render_metadata_PKG_CONFIG_PATH() {

--- a/components/plan-build/bin/shared.bash
+++ b/components/plan-build/bin/shared.bash
@@ -202,6 +202,25 @@ _render_metadata_RUNTIME_ENVIRONMENT_PROVENANCE(){
     _render_associative_array_file ${pkg_prefix} RUNTIME_ENVIRONMENT_PROVENANCE __runtime_environment_provenance
 }
 
+_render_metadata_RUNTIME_PATH(){
+  local runtime_path
+
+  runtime_path="$(_assemble_runtime_path)"
+  if [[ -n "$runtime_path" ]]; then
+    debug "Rendering RUNTIME_PATH metadata file"
+    echo "$runtime_path" > "${pkg_prefix}/RUNTIME_PATH"
+
+    # **Internal**  Backwards Compatibility: Set the `PATH` key for the runtime
+    # environment if a computed runtime path is necessary which will be used by
+    # Habitat releases between 0.50.0 (released 2017-11-30) and up to including
+    # 0.55.0 (released 2018-03-20). All future releases will ignore the `PATH`
+    # entry in favor of using the `RUNTIME_PATH` metadata file.
+    __runtime_environment["PATH"]="$runtime_path"
+  else
+    debug "Would have rendered RUNTIME_PATH, but there was no data for it"
+  fi
+}
+
 _render_metadata_SVC_GROUP() {
   debug "Rendering SVC_GROUP metadata file"
   echo "$pkg_svc_group" > $pkg_prefix/SVC_GROUP

--- a/www/source/partials/docs/_reference-package-contents.html.md.erb
+++ b/www/source/partials/docs/_reference-package-contents.html.md.erb
@@ -40,13 +40,16 @@ Additional switches to be passed to the compiler when this package is used as a 
 A file containing package information, such as checksum, maintainer, build variables, and other metadata specified in plan.sh as well as the contents of the plan.sh itself.
 
 ## PATH
-An absolute path to the `bin` folder for the package. A fully-qualified package identifier is used, so version and release information is included in the path.
+A file that contains all directories in the package which contain program binaries. The directories are seperated with the target platform's path seperator character (i.e. either `:` or `;`).
 
 ## RUNTIME_ENVIRONMENT
-A file containing the result of the layering operation of the current package's runtime environment variables on top of those of its dependencies. This is what the build process consults when it processes dependencies, and this is what the Supervisor consults when generating the runtime environment for a supervised process.
+A file containing the result of the layering operation of the current package's runtime environment variables on top of those of its dependencies. This is what the build process consults when it processes dependencies, and this is what the Supervisor consults in concert with `RUNTIME_PATH` when generating the full set of environment variables that should be added to an environment before running a supervised process.
 
 ## RUNTIME_ENVIRONMENT_PROVENANCE
 A file that provides information on which specific dependencies have influenced the final value of a given variable in the RUNTIME_ENVIRONMENT file. This file is not currently consumed by any other software in the Habitat ecosystem, but can be used for troubleshooting and informative purposes.
+
+## RUNTIME_PATH
+A file that contains all directories that need to be prepended to an environment's `$PATH` before a program in this package can be expected to run correctly. The order of the elements are precise and meaningful so should not be altered. This file is used in concert with `RUNTIME_ENVIRONMENT` to compute the full set of environment variables that should be added to an environment before running a program in this package.
 
 ## TARGET
 The CPU architecture and platform for the package. The format is `architecture-platform`. For example, x86_64-linux.


### PR DESCRIPTION
This changeset is a bit broad, but all related to the usage and interpretation of 3 metadata files in a pacakge:

* `PATH`
* `RUNTIME_ENVIRONMENT`
* `RUNTIME_PATH`

In the case of PATH, we introduced this really nice-to-have pre-computed runtime `$PATH` value which the Supervisor and other tooling can use without have to re-compute this statically-knowable answer at runtime. This leaves us with 2 notions of PATH: one is used by the build system and some tooling to answer the question: "where are the programs for this package?" and the other is used by runtime tools to answer the question: "what should I prepend to my $PATH before running a program
out of this package?". Notice that these 2 notions are independent of any other runtime environment variables that a Plan author could introduce such as `JAVA_HOME`, `PYTHONPATH`, `CA_CERT_FILE`, etc.

As a result, we split this notion of `PATH` into 3 parts:

1. Re-assert the role of the `PATH` metadata file which represents "where are the programs for this package?".
2. Build and export a value for the `$PATH` (`$env:PATH` on Windows) environment variable that is deprived from using the `$pkg_bin_dirs` Plan variable and the `PATH` metadata files of package dependencies.
3. Build a static "runtime path" value that gets written into a net-new `RUNTIME_PATH` metadata file and also gets written into a `PATH` entry in the `RUNTIME_ENVIRONMENT` metadata file only for backwards compatibility.

The following inlined commit messages add more context and detail:

## [plan-build] Treat PATH distinctly from RUNTIME_ENVIRONMENT.

This change further re-asserts how the PATH environment variable is used
and interpreted in difference places. In the context of the build
program, there are 3 primary places where we care about something called
`$PATH`:

1. The path elements in a package which contain programs, declared by a
Plan author in `$pkg_bin_dirs[@]` and written out to a `PATH` metadata
file.
2. The "runtime" value for `$PATH` which the Supervisor (and others) use
when starting a service. This is a combination of a package's own path
elements, and those of its direct and indirect runtime dependencies
(ordered in a particular way). It is written out to a `PATH` key in a
`RUNTIME_ENVIRONMENT` metadata file.
3. The value of `$PATH` which is exported for the build program to use
when building the package. This is only used in the running context of
the build program and contains build dependencies as well as runtime
dependencies.

This change deals with cases 2 and 3 and leaves 1 as-is.

2. Runtime Environment PATH
---------------------------

Prior to this change, the value of the `PATH` key in the
`RUNTIME_ENVIRONMENT` metadata file was calculated by pulling in the
`RUNTIME_ENVIRONMENT` from dependencies and layering them on themselves.
The issue was it was to use this information to derive a clearly ordered
path array that is in the following order:

1. All directories in this package which have program binaries (set by
the Plan author in `${pkg_bin_dirs[@]}`), in declared order
2. All path elements for each *direct* runtime dependency which has a
`PATH` metadata file, in the order present in `PATH`
3. All remaining path elements for each *indirect* (i.e. transitive)
dependency which has a `PATH` metadata file, in the order present in
`PATH`

Ideally, this collection should be a unique ordered set with no
duplicated path elements.

It ended up being easier to re-compute this runtime PATH ordering by
querying the direct and indirect dependencies directly and derive the
result without using the `RUNTIME_ENVIRONMENT` metadata files. This
seemed to suggest that the notion of "PATH" is more like the `CFLAGS`
and `LDFLAGS` metadata and less like the runtime environment
capabilities in that there are explicit Plan variables
(`$pkg_bin_dirs[@]`, `$pkg_lib_dirs[@]`, etc.) that map directly to
corresponding metadata files (`PATH`, `LDFLAGS`, etc.) which are used by
the build system to assemble environment variables to be used when
building a package.

This change changes how that `PATH` entry is computed--separately from
the values `RUNTIME_ENVIRONMENT` metadata files. Instead this value is
computed on its own (via `_set_runtime_env_path()`) after all other
environment variable loading is complete and set in the runtime
environment hash which will ultimately be written to the package's
`RUNTIME_ENVIRONMENT` metadata file.

As a result, most of the PATH-related code associated with reading these
environment metadata files was removed, and any `PATH` key entries are
skipped when loading in other package dependencies.

3. Build time value of `$PATH`
------------------------------

In a similar line of reasoning the case 2 above, the build time value of
`$PATH` which gets exported by the build program is calculated
independently of any `RUNTIME_ENVIRONMENT` metadata file values and is
created in the following specific order:

1. All directories in this package which have program binaries (set by
the Plan author in `${pkg_bin_dirs[@]}`), in declared order
2. All path elements for each *direct run* dependency which has a `PATH`
metadata file, in the order present in `PATH`
3. All path elements for each *direct build* dependency which has a
`PATH` metadata file, in the order present in `PATH`
4. All remaining path elements for each *indirect run* dependency which
has a `PATH` metadata file, in the order present in `PATH`
5. All remaining path elements for each *indirect build* dependency
which has a `PATH` metadata file, in the order present in `PATH`
6. The initial/original value of `$PATH` when the program started to
ensure that build program-related programs can still be found

As above, this collection should be a unique ordered set with no
duplicated path elements. The only exception is that we preserve the
initial/original value of `$PATH` to append it as-is (i.e. we don't
de-duplicate the original `$PATH`).

Finally, this task is broken out into a dedicated private phase in the
build (`_set_build_path()`) which happens directly after
`do_setup_environment_wrapper()` and before the `do_before()` build
phase to ensure that `do_before()` implementations have a correctly set
`$PATH`.

## [plan-build] Only create `PATH` metadata file if non-empty.

This change fixes an issue where all built packages contained a `PATH`
metadata file. If no program directories were present, then this file
would be empty. While not technically a bug (all code consuming these
metadata files should know how to deal with a non-existant or empty
file), it is much more intention-revealing to skip creating files if
they are empty.

The refactoring in the previous commit meant that the internal
`__process_path()` function was only used by `_render_metadata_PATH()`,
and so its implementation was inlined, removing this extra function.

## [hab,sup] Update to call `PackageInstall#environment_for_command()`.

References habitat-sh/core#25

## [plan-build] Generate `RUNTIME_PATH` metadata files where appropriate.

This change makes the build program produce `RUNTIME_PATH` metadata
files if a non-empty runtime path is computed.

As this change builds on previous work, part of this change involves
moving some functions and renaming them to further clarify their
responsibilities.

## [plan-build-ps1] Treat PATH distinctly from RUNTIME_ENVIRONMENT.

This change updates the PowerShell implementation of the build system to
re-assert how the PATH environment variable is used and interpreted in
different places. Additionally, this change brings back the `LIB_DIRS`
and `INCLUDE_DIRS` metadata files which a package will contain if it has
`$pkg_lib_dirs`/`$pkg_include_dirs` values. Lastly, there is fallback
logic to look in the `RUNTIME_ENVIRONMENT` for `LIB`/`INCLUDE` entries
if the corresponding `LIB_DIRS`/`INCLUDE_DIRS` metadata files aren't
present (this is to handle older built packages which are used as
dependencies in a build).

See the previous change to the Bash implementation for more details and
rationale. The changes here are designed to bring both implementations
in line with each other and continue to produce similar results.



![tenor-4846503](https://user-images.githubusercontent.com/261548/38964180-abb4afcc-4332-11e8-86ce-61802ea48214.gif)
