### PR TITLE
Fix handling of environment-level configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -915,6 +915,7 @@ dependencies = [
  "router 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde-transcode 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1927,6 +1928,14 @@ version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "serde-transcode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2722,6 +2731,7 @@ dependencies = [
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)" = "db99f3919e20faa51bb2996057f5031d8685019b5a06139b1ce761da671b8526"
+"checksum serde-transcode 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "749b7fac35f05313d1b3986c0bee75472614aeeb428eec30d18dc66858fb52cc"
 "checksum serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)" = "f4ba7591cfe93755e89eeecdbcc668885624829b020050e6aec99c2a03bd3fd0"
 "checksum serde_derive_internals 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6e03f1c9530c3fb0a0a5c9b826bdd9246a5921ae995d75f512ac917fc4dd55b5"
 "checksum serde_json 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)" = "57781ed845b8e742fc2bf306aba8e3b408fe8c366b900e3769fbc39f49eb8b39"

--- a/components/sup/Cargo.toml
+++ b/components/sup/Cargo.toml
@@ -55,6 +55,7 @@ serde = { version = "*", features = ["rc"] }
 serde_derive = "*"
 serde_json = "*"
 serde_yaml = "*"
+serde-transcode = "*"
 tempdir = "*"
 time = "*"
 toml = { version = "*", default-features = false }

--- a/components/sup/src/lib.rs
+++ b/components/sup/src/lib.rs
@@ -81,6 +81,7 @@ extern crate serde_derive;
 #[allow(unused_imports)]
 #[macro_use]
 extern crate serde_json;
+extern crate serde_transcode;
 extern crate serde_yaml;
 extern crate tempdir;
 extern crate time;


### PR DESCRIPTION
When we were trying to parse TOML from an environment variable, we
weren't properly type-hinting the result of that operation, which
meant Rust derived the type from the return value of our function. As
a result, we ended up with an error, because Serde was trying to
decode directly to an `Option<toml::value::Table>`. We now type things
correctly.

(By the way, the code was all completely valid Rust before; it's just
that Serde is such a flexible framework that can parse into arbitrary
types!)

Additionally, parsing JSON as a fall-back wasn't working because we
were expecting `serde_json` to parse a string into a TOML table
directly, which it can't do. Now, we transcode the JSON string into a
TOML string, and from there use the `toml` crate to parse into a
`toml::value::Table`.

Fixes #4439

Signed-off-by: Christopher Maier <cmaier@chef.io>