### PR TITLE
Add LD_LIBRARY_PATH hack for Supervisor package

### DIFF
--- a/components/sup/plan.sh
+++ b/components/sup/plan.sh
@@ -45,6 +45,22 @@ do_prepare() {
   export OPENSSL_INCLUDE_DIR=$(pkg_path_for openssl)/include
   export SODIUM_LIB_DIR=$(pkg_path_for libsodium)/lib
   export LIBZMQ_PREFIX=$(pkg_path_for zeromq)
+
+
+  # TODO (CM, FN): This is not needed to build the supervisor,
+  # strictly speaking, but is instead a work-around for how we are
+  # currently building packages in Travis; we hypothesize that the
+  # build.rs program for habitat_http_client, built during a static
+  # hab package build, is being inadvertently used here. Without gcc
+  # libs on the LD_LIBRARY_PATH, the program can't find
+  # libgcc_s.so.1. This is merely a bandaid until we can overhaul our
+  # CI pipeline properly.
+  #
+  # Used to find libgcc_s.so.1 when compiling `build.rs` in dependencies. Since
+  # this used only at build time, we will use the version found in the gcc
+  # package proper--it won't find its way into the final binaries.
+  export LD_LIBRARY_PATH=$(pkg_path_for gcc)/lib
+  build_line "Setting LD_LIBRARY_PATH=$LD_LIBRARY_PATH"
 }
 
 do_build() {


### PR DESCRIPTION
This is not needed to build the supervisor, strictly speaking, but is
instead a work-around for how we are currently building packages in
Travis; we hypothesize that the `build.rs` program for
`habitat_http_client`, built during a static hab package build, is
being inadvertently used here. Without gcc libs on the
`LD_LIBRARY_PATH`, the program can't find `libgcc_s.so.1`. This is
merely a bandaid until we can overhaul our CI pipeline properly.

![tenor-90155542](https://user-images.githubusercontent.com/207178/39216533-129e3bf2-47ea-11e8-84dd-1f9846ef6d7c.gif)

Signed-off-by: Christopher Maier <cmaier@chef.io>