### PR TITLE
Update .bldr.toml paths to reflect current reality

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -1,11 +1,11 @@
 [hab]
 plan_path = "components/hab"
 paths = [
-  "components/hab/*",
   "components/builder-api-client/*",
   "components/builder-depot-client/*",
   "components/common/*",
-  "components/core/*",
+  "components/sup-client/*",
+  "components/sup-protocol/*",
 ]
 
 [hab-backline]
@@ -13,13 +13,15 @@ plan_path = "components/backline"
 
 [hab-bintray-publish]
 plan_path = "components/bintray-publish"
+paths = [
+  "studio/build-docker-image.sh",
+]
 
 [hab-eventsrv]
 plan_path = "components/eventsrv/habitat"
 paths = [
-  "components/eventsrv/*",
   "components/eventsrv-protocol/*",
-  "components/core/*",
+  "components/eventsrv/*",
   "support/ci/builder-base-plan.sh",
 ]
 
@@ -40,12 +42,12 @@ plan_path = "components/studio"
 [hab-sup]
 plan_path = "components/sup"
 paths = [
-  "components/sup/*",
+  "components/builder-depot-client/*",
+  "components/butterfly/*",
+  "components/common/*",
   "components/eventsrv-client/*",
   "components/launcher-client/*",
-  "components/butterfly/*",
-  "components/core/*",
-  "components/builder-depot-client/*",
+  "components/sup-protocol/*",
 ]
 
 [hab-pkg-aci]
@@ -54,7 +56,6 @@ plan_path = "components/pkg-aci"
 [hab-pkg-export-docker]
 plan_path = "components/pkg-export-docker"
 paths = [
-  "components/core/*",
   "components/common/*",
   "components/hab/*",
 ]
@@ -62,18 +63,16 @@ paths = [
 [hab-pkg-export-kubernetes]
 plan_path = "components/pkg-export-kubernetes"
 paths = [
-  "components/core/*",
   "components/common/*",
-  "components/hab/*",
+  "components/hab/*", # because pkg-export-docker depends on it
   "components/pkg-export-docker/*",
 ]
 
 [hab-pkg-export-helm]
 plan_path = "components/pkg-export-helm"
 paths = [
-  "components/core/*",
   "components/common/*",
-  "components/hab/*",
+  "components/hab/*", # because pkg-export-docker depends on it
   "components/pkg-export-docker/*",
   "components/pkg-export-kubernetes/*",
 ]
@@ -83,7 +82,6 @@ plan_path = "components/pkg-export-tar"
 paths = [
   "components/common/*",
   "components/hab/*",
-  "components/pkg-export-tar/*"
 ]
 
 # NOTE: cfize has a dependency on hab-pkg-dockerize, but we are


### PR DESCRIPTION
This commit updates our `.bldr.toml` file to reflect recent changes to
our code, and does a little housekeeping besides. Some highlights:

* Remove `components/core/*` path; this code is on longer in this repository
* Remove `paths` entries that duplicate the `plan_path`
  `plan_path` is automatically globbed for us, so `plan_path = foo` is
  the same as a `paths` entry of `foo/*`.
* Ensure the `sup-protocol` and `sup-client` crates are wired up properly
* Alphabetize `paths` entries.
* Ensure file dependencies in plan.sh files are reflected
  Some plans source other files external to their own source
  directories, such as `hab-bintray-publish` and `hab-launcher`.

  I intentionally left the `VERSION` file out of all `paths` entries,
  even though nearly all packages use the contents of this file to
  determine their versions. I did not want there to be any unintended
  mixups between release artifacts built by Builder and those built
  "manually" in our Travis CI release pipeline, which is our current
  official way to build Habitat releases.

Signed-off-by: Christopher Maier <cmaier@chef.io>