### PR TITLE
Properly honor the `--force` flag

### DIFF
--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -1535,7 +1535,7 @@ fn update_svc_load_from_input(m: &ArgMatches, msg: &mut protocol::ctl::SvcLoad) 
     }
     msg.set_binds(protobuf::RepeatedField::from_vec(get_binds_from_input(m)?));
     msg.set_specified_binds(m.is_present("BIND"));
-    msg.set_force(!m.is_present("FORCE"));
+    msg.set_force(m.is_present("FORCE"));
     if let Some(group) = get_group_from_input(m) {
         msg.set_group(group);
     }

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -564,7 +564,7 @@ fn update_svc_load_from_input(m: &ArgMatches, msg: &mut protocol::ctl::SvcLoad) 
     if let Some(config_from) = get_config_from_input(m) {
         msg.set_config_from(config_from.to_string_lossy().into_owned());
     }
-    msg.set_force(!m.is_present("FORCE"));
+    msg.set_force(m.is_present("FORCE"));
     if let Some(group) = get_group_from_input(m) {
         msg.set_group(group);
     }


### PR DESCRIPTION
The Boolean here was improperly negated; we want to set it to true if
the user specified `--force` on the CLI, not if they didn't.

![tenor-45677267](https://user-images.githubusercontent.com/207178/39333475-04f6c740-4979-11e8-88d6-8f1382ccedf0.gif)

Signed-off-by: Christopher Maier <cmaier@chef.io>