### PR TITLE
Update bldr.toml doc to update and consolidate information

### DIFF
--- a/www/source/partials/docs/_dev-pkgs-multiple-plans-builder.html.md.erb
+++ b/www/source/partials/docs/_dev-pkgs-multiple-plans-builder.html.md.erb
@@ -1,8 +1,8 @@
 ## <a name="multiple-plans-builder" id="multiple-plans-builder" data-magellan-target="multiple-plans-builder">Using Multiple Plans</a>
 
-If you have a large GitHub repository with multiple components inside, you will most likely also have individual plans for those components. When using Builder to build your packages, the default behavior is for Builder to build all packages whenever any file is updated in that repository, regardless of what component it is. This is because Builder does not know which file is associated with which package.
+If you have a GitHub repository with multiple components inside, you will most likely also have individual plans for those components that are located inside of component subfolders. By default, Builder will only look for a package plan in either the root of the repository, or in a `habitat` subfolder at the root. If it does not find a plan file in those locations, it will not automatically issue builds when it detects file changes in the repository.
 
-To provide more fine-grained control over when component packages are built, you can programatically customize how and when Builder will build your plans by specifying build behavior in a `.bldr.toml` file at the root of the repository that you connect to Builder.
+In order to tell Builder about the location of the individual plan files, and in order provide more fine-grained control over when component packages are built, you can programatically customize how and when Builder will build your plans by specifying build behavior in a `.bldr.toml` file at the root of the repository that you connect to Builder.
 
 Using this file, Builder only builds packages when source files or directories are updated in paths specified in `.bldr.toml`. This allows you to configure the building, publishing, and post-processing phases of a plan build in Builder.
 
@@ -66,9 +66,3 @@ To enable this functionality, do the following:
       "components/butterfly/[0-9]*"       # matches any file inside the 'butterfly' directory that begins with a number
     ]
     ```
-
-### Special case where **.bldr.toml** does not exist
-
-In the default case, where the `.bldr.toml` does not exist, there is one other condition that can impact builds. If the `plan.sh` file is not at the root (e.g., it is located in a `habitat` folder), then Builder infers that the plan files are all underneath the `habitat` folder, and will not kick off a build if files are committed that are outside of that folder.
-
-In order to have automated builds kick off in this case, either move your `plan.sh` file to the root of the repo, or add a `.bldr.toml` file to specify the paths more explicitly.


### PR DESCRIPTION
This change updates the documentation for using .bldr.toml files. The information at the top of the "Using Multiple Plans" section seemed to indicate the builds would be issued for any file change, even if the plan files were not in the default location(s). This change updates that wording, and removes the (now redundant) Special Case section at the end.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-36586297](https://user-images.githubusercontent.com/13542112/39450335-cdedb056-4c7f-11e8-99ab-e9f44249310f.gif)
