### PR TITLE
Allow services to start in the absence of their binds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -727,7 +727,7 @@ dependencies = [
 [[package]]
 name = "habitat_core"
 version = "0.0.0"
-source = "git+https://github.com/habitat-sh/core.git#40451521e357548e68a2b3d845da850dcecd2a74"
+source = "git+https://github.com/habitat-sh/core.git#0e296163684e6f2ea7d9e692355107dab5b51188"
 dependencies = [
  "ansi_term 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -785,7 +785,7 @@ dependencies = [
 [[package]]
 name = "habitat_http_client"
 version = "0.0.0"
-source = "git+https://github.com/habitat-sh/core.git#40451521e357548e68a2b3d845da850dcecd2a74"
+source = "git+https://github.com/habitat-sh/core.git#0e296163684e6f2ea7d9e692355107dab5b51188"
 dependencies = [
  "base64 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat_core 0.0.0 (git+https://github.com/habitat-sh/core.git)",
@@ -943,7 +943,7 @@ dependencies = [
 [[package]]
 name = "habitat_win_users"
 version = "0.0.0"
-source = "git+https://github.com/habitat-sh/core.git#40451521e357548e68a2b3d845da850dcecd2a74"
+source = "git+https://github.com/habitat-sh/core.git#0e296163684e6f2ea7d9e692355107dab5b51188"
 dependencies = [
  "gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -809,6 +809,9 @@ fn sub_svc_load() -> App<'static, 'static> {
             "The update strategy; [default: none] [values: none, at-once, rolling]")
         (@arg BIND: --bind +takes_value +multiple
             "One or more service groups to bind to a configuration")
+        (@arg BINDING_MODE: --("binding-mode") +takes_value {valid_binding_mode}
+             "Governs how the presence or absence of binds affects service startup. `strict` blocks \
+              startup until all binds are present. [default: strict] [values: relaxed, strict]")
         (@arg FORCE: --force -f "Load or reload an already loaded service. If the service \
             was previously loaded and running this operation will also restart the service")
         (@arg REMOTE_SUP: --("remote-sup") -r +takes_value {valid_socket_addr}
@@ -842,6 +845,9 @@ fn sub_svc_load() -> App<'static, 'static> {
             "The update strategy; [default: none] [values: none, at-once, rolling]")
         (@arg BIND: --bind +takes_value +multiple
             "One or more service groups to bind to a configuration")
+        (@arg BINDING_MODE: --("binding-mode") +takes_value {valid_binding_mode}
+             "Governs how the presence or absence of binds affects service startup. `strict` blocks \
+              startup until all binds are present. [default: strict] [values: relaxed, strict]")
         (@arg FORCE: --force -f "Load or reload an already loaded service. If the service \
             was previously loaded and running this operation will also restart the service")
         (@arg PASSWORD: --password +takes_value "Password of the service user")
@@ -863,6 +869,13 @@ fn file_exists_or_stdin(val: String) -> result::Result<(), String> {
         Ok(())
     } else {
         file_exists(val)
+    }
+}
+
+fn valid_binding_mode(val: String) -> result::Result<(), String> {
+    match protocol::types::BindingMode::from_str(&val) {
+        Ok(_) => Ok(()),
+        Err(_) => Err(format!("Binding mode: '{}' is not valid", &val)),
     }
 }
 

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -1443,6 +1443,13 @@ fn get_binds_from_input(m: &ArgMatches) -> Result<Vec<protocol::types::ServiceBi
     Ok(binds)
 }
 
+fn get_binding_mode_from_input(m: &ArgMatches) -> Option<protocol::types::BindingMode> {
+    // There won't be errors, because we validate with `valid_binding_mode`
+    m.value_of("BINDING_MODE")
+        .and_then(|b| BindingMode::from_str(b).ok())
+        .map(|b| b.into())
+}
+
 fn get_group_from_input(m: &ArgMatches) -> Option<String> {
     m.value_of("GROUP").map(ToString::to_string)
 }
@@ -1535,6 +1542,9 @@ fn update_svc_load_from_input(m: &ArgMatches, msg: &mut protocol::ctl::SvcLoad) 
     }
     msg.set_binds(protobuf::RepeatedField::from_vec(get_binds_from_input(m)?));
     msg.set_specified_binds(m.is_present("BIND"));
+    if let Some(binding_mode) = get_binding_mode_from_input(m) {
+        msg.set_binding_mode(binding_mode);
+    }
     msg.set_force(m.is_present("FORCE"));
     if let Some(group) = get_group_from_input(m) {
         msg.set_group(group);

--- a/components/sup-protocol/protocols/ctl.proto
+++ b/components/sup-protocol/protocols/ctl.proto
@@ -76,6 +76,8 @@ message SvcLoad {
   // Set to true if any binds were set by the caller. This field is needed because a blank list
   // and map will be present in a case when no binds were set *and* when binds are removed.
   optional bool specified_binds = 5;
+  // Indicate how bind availability affects service start-up
+  optional BindingMode binding_mode = 14;
   // Remote http URL for the Builder service to receive package updates from.
   optional string bldr_url = 6;
   // Remote channel on the Builder service to receive package updates from.

--- a/components/sup-protocol/protocols/types.proto
+++ b/components/sup-protocol/protocols/types.proto
@@ -25,6 +25,13 @@ enum UpdateStrategy {
   Rolling = 2;
 }
 
+enum BindingMode {
+  // Services may start whether binds are available or not
+  Relaxed = 0;
+  // Service start-up is blocked until all binds are available
+  Strict = 1;
+}
+
 message ApplicationEnvironment {
   required string application = 1;
   optional string environment = 2 [default = "default"];

--- a/components/sup-protocol/src/generated/ctl.rs
+++ b/components/sup-protocol/src/generated/ctl.rs
@@ -2038,6 +2038,7 @@ pub struct SvcLoad {
     application_environment: ::protobuf::SingularPtrField<super::types::ApplicationEnvironment>,
     binds: ::protobuf::RepeatedField<super::types::ServiceBind>,
     specified_binds: ::std::option::Option<bool>,
+    binding_mode: ::std::option::Option<super::types::BindingMode>,
     bldr_url: ::protobuf::SingularField<::std::string::String>,
     bldr_channel: ::protobuf::SingularField<::std::string::String>,
     config_from: ::protobuf::SingularField<::std::string::String>,
@@ -2209,6 +2210,33 @@ impl SvcLoad {
 
     fn mut_specified_binds_for_reflect(&mut self) -> &mut ::std::option::Option<bool> {
         &mut self.specified_binds
+    }
+
+    // optional .BindingMode binding_mode = 14;
+
+    pub fn clear_binding_mode(&mut self) {
+        self.binding_mode = ::std::option::Option::None;
+    }
+
+    pub fn has_binding_mode(&self) -> bool {
+        self.binding_mode.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_binding_mode(&mut self, v: super::types::BindingMode) {
+        self.binding_mode = ::std::option::Option::Some(v);
+    }
+
+    pub fn get_binding_mode(&self) -> super::types::BindingMode {
+        self.binding_mode.unwrap_or(super::types::BindingMode::Relaxed)
+    }
+
+    fn get_binding_mode_for_reflect(&self) -> &::std::option::Option<super::types::BindingMode> {
+        &self.binding_mode
+    }
+
+    fn mut_binding_mode_for_reflect(&mut self) -> &mut ::std::option::Option<super::types::BindingMode> {
+        &mut self.binding_mode
     }
 
     // optional string bldr_url = 6;
@@ -2553,6 +2581,9 @@ impl ::protobuf::Message for SvcLoad {
                     let tmp = is.read_bool()?;
                     self.specified_binds = ::std::option::Option::Some(tmp);
                 },
+                14 => {
+                    ::protobuf::rt::read_proto2_enum_with_unknown_fields_into(wire_type, is, &mut self.binding_mode, 14, &mut self.unknown_fields)?
+                },
                 6 => {
                     ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.bldr_url)?;
                 },
@@ -2608,6 +2639,9 @@ impl ::protobuf::Message for SvcLoad {
         if let Some(v) = self.specified_binds {
             my_size += 2;
         }
+        if let Some(v) = self.binding_mode {
+            my_size += ::protobuf::rt::enum_size(14, v);
+        }
         if let Some(ref v) = self.bldr_url.as_ref() {
             my_size += ::protobuf::rt::string_size(6, &v);
         }
@@ -2655,6 +2689,9 @@ impl ::protobuf::Message for SvcLoad {
         };
         if let Some(v) = self.specified_binds {
             os.write_bool(5, v)?;
+        }
+        if let Some(v) = self.binding_mode {
+            os.write_enum(14, v.value())?;
         }
         if let Some(ref v) = self.bldr_url.as_ref() {
             os.write_string(6, &v)?;
@@ -2744,6 +2781,11 @@ impl ::protobuf::MessageStatic for SvcLoad {
                     SvcLoad::get_specified_binds_for_reflect,
                     SvcLoad::mut_specified_binds_for_reflect,
                 ));
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeEnum<super::types::BindingMode>>(
+                    "binding_mode",
+                    SvcLoad::get_binding_mode_for_reflect,
+                    SvcLoad::mut_binding_mode_for_reflect,
+                ));
                 fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
                     "bldr_url",
                     SvcLoad::get_bldr_url_for_reflect,
@@ -2800,6 +2842,7 @@ impl ::protobuf::Clear for SvcLoad {
         self.clear_application_environment();
         self.clear_binds();
         self.clear_specified_binds();
+        self.clear_binding_mode();
         self.clear_bldr_url();
         self.clear_bldr_channel();
         self.clear_config_from();
@@ -3793,23 +3836,24 @@ static file_descriptor_proto_data: &'static [u8] = b"\
     ice_group\x18\x01\x20\x01(\x0b2\r.ServiceGroupR\x0cserviceGroup\x12\x10\
     \n\x03cfg\x18\x02\x20\x01(\x0cR\x03cfg\x12\x18\n\x07version\x18\x03\x20\
     \x01(\x04R\x07version\x12(\n\x0cis_encrypted\x18\x04\x20\x01(\x08:\x05fa\
-    lseR\x0bisEncrypted\"\xf6\x03\n\x07SvcLoad\x12#\n\x05ident\x18\x01\x20\
+    lseR\x0bisEncrypted\"\xa7\x04\n\x07SvcLoad\x12#\n\x05ident\x18\x01\x20\
     \x01(\x0b2\r.PackageIdentR\x05ident\x12P\n\x17application_environment\
     \x18\x02\x20\x01(\x0b2\x17.ApplicationEnvironmentR\x16applicationEnviron\
     ment\x12\"\n\x05binds\x18\x03\x20\x03(\x0b2\x0c.ServiceBindR\x05binds\
-    \x12'\n\x0fspecified_binds\x18\x05\x20\x01(\x08R\x0especifiedBinds\x12\
-    \x19\n\x08bldr_url\x18\x06\x20\x01(\tR\x07bldrUrl\x12!\n\x0cbldr_channel\
-    \x18\x07\x20\x01(\tR\x0bbldrChannel\x12\x1f\n\x0bconfig_from\x18\x08\x20\
-    \x01(\tR\nconfigFrom\x12\x1b\n\x05force\x18\t\x20\x01(\x08:\x05falseR\
-    \x05force\x12\x14\n\x05group\x18\n\x20\x01(\tR\x05group\x124\n\x16svc_en\
-    crypted_password\x18\x0b\x20\x01(\tR\x14svcEncryptedPassword\x12%\n\x08t\
-    opology\x18\x0c\x20\x01(\x0e2\t.TopologyR\x08topology\x128\n\x0fupdate_s\
-    trategy\x18\r\x20\x01(\x0e2\x0f.UpdateStrategyR\x0eupdateStrategy\"0\n\t\
-    SvcUnload\x12#\n\x05ident\x18\x01\x20\x01(\x0b2\r.PackageIdentR\x05ident\
-    \"/\n\x08SvcStart\x12#\n\x05ident\x18\x01\x20\x01(\x0b2\r.PackageIdentR\
-    \x05ident\".\n\x07SvcStop\x12#\n\x05ident\x18\x01\x20\x01(\x0b2\r.Packag\
-    eIdentR\x05ident\"0\n\tSvcStatus\x12#\n\x05ident\x18\x01\x20\x01(\x0b2\r\
-    .PackageIdentR\x05ident\"!\n\x0bConsoleLine\x12\x12\n\x04line\x18\x01\
+    \x12'\n\x0fspecified_binds\x18\x05\x20\x01(\x08R\x0especifiedBinds\x12/\
+    \n\x0cbinding_mode\x18\x0e\x20\x01(\x0e2\x0c.BindingModeR\x0bbindingMode\
+    \x12\x19\n\x08bldr_url\x18\x06\x20\x01(\tR\x07bldrUrl\x12!\n\x0cbldr_cha\
+    nnel\x18\x07\x20\x01(\tR\x0bbldrChannel\x12\x1f\n\x0bconfig_from\x18\x08\
+    \x20\x01(\tR\nconfigFrom\x12\x1b\n\x05force\x18\t\x20\x01(\x08:\x05false\
+    R\x05force\x12\x14\n\x05group\x18\n\x20\x01(\tR\x05group\x124\n\x16svc_e\
+    ncrypted_password\x18\x0b\x20\x01(\tR\x14svcEncryptedPassword\x12%\n\x08\
+    topology\x18\x0c\x20\x01(\x0e2\t.TopologyR\x08topology\x128\n\x0fupdate_\
+    strategy\x18\r\x20\x01(\x0e2\x0f.UpdateStrategyR\x0eupdateStrategy\"0\n\
+    \tSvcUnload\x12#\n\x05ident\x18\x01\x20\x01(\x0b2\r.PackageIdentR\x05ide\
+    nt\"/\n\x08SvcStart\x12#\n\x05ident\x18\x01\x20\x01(\x0b2\r.PackageIdent\
+    R\x05ident\".\n\x07SvcStop\x12#\n\x05ident\x18\x01\x20\x01(\x0b2\r.Packa\
+    geIdentR\x05ident\"0\n\tSvcStatus\x12#\n\x05ident\x18\x01\x20\x01(\x0b2\
+    \r.PackageIdentR\x05ident\"!\n\x0bConsoleLine\x12\x12\n\x04line\x18\x01\
     \x20\x01(\tR\x04line\
 ";
 

--- a/components/sup-protocol/src/generated/types.rs
+++ b/components/sup-protocol/src/generated/types.rs
@@ -2445,6 +2445,55 @@ impl ::protobuf::reflect::ProtobufValue for UpdateStrategy {
     }
 }
 
+#[derive(Clone,PartialEq,Eq,Debug,Hash)]
+pub enum BindingMode {
+    Relaxed = 0,
+    Strict = 1,
+}
+
+impl ::protobuf::ProtobufEnum for BindingMode {
+    fn value(&self) -> i32 {
+        *self as i32
+    }
+
+    fn from_i32(value: i32) -> ::std::option::Option<BindingMode> {
+        match value {
+            0 => ::std::option::Option::Some(BindingMode::Relaxed),
+            1 => ::std::option::Option::Some(BindingMode::Strict),
+            _ => ::std::option::Option::None
+        }
+    }
+
+    fn values() -> &'static [Self] {
+        static values: &'static [BindingMode] = &[
+            BindingMode::Relaxed,
+            BindingMode::Strict,
+        ];
+        values
+    }
+
+    fn enum_descriptor_static(_: ::std::option::Option<BindingMode>) -> &'static ::protobuf::reflect::EnumDescriptor {
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> = ::protobuf::lazy::Lazy {
+            lock: ::protobuf::lazy::ONCE_INIT,
+            ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
+        };
+        unsafe {
+            descriptor.get(|| {
+                ::protobuf::reflect::EnumDescriptor::new("BindingMode", file_descriptor_proto())
+            })
+        }
+    }
+}
+
+impl ::std::marker::Copy for BindingMode {
+}
+
+impl ::protobuf::reflect::ProtobufValue for BindingMode {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Enum(self.descriptor())
+    }
+}
+
 static file_descriptor_proto_data: &'static [u8] = b"\
     \n\x0btypes.proto\"e\n\x16ApplicationEnvironment\x12\x20\n\x0bapplicatio\
     n\x18\x01\x20\x02(\tR\x0bapplication\x12)\n\x0benvironment\x18\x02\x20\
@@ -2472,7 +2521,8 @@ static file_descriptor_proto_data: &'static [u8] = b"\
     \x20\n\x0cProcessState\x12\x08\n\x04Down\x10\0\x12\x06\n\x02Up\x10\x01*&\
     \n\x08Topology\x12\x0e\n\nStandalone\x10\0\x12\n\n\x06Leader\x10\x01*3\n\
     \x0eUpdateStrategy\x12\x08\n\x04None\x10\0\x12\n\n\x06AtOnce\x10\x01\x12\
-    \x0b\n\x07Rolling\x10\x02\
+    \x0b\n\x07Rolling\x10\x02*&\n\x0bBindingMode\x12\x0b\n\x07Relaxed\x10\0\
+    \x12\n\n\x06Strict\x10\x01\
 ";
 
 static mut file_descriptor_proto_lazy: ::protobuf::lazy::Lazy<::protobuf::descriptor::FileDescriptorProto> = ::protobuf::lazy::Lazy {

--- a/components/sup-protocol/src/types.rs
+++ b/components/sup-protocol/src/types.rs
@@ -84,6 +84,21 @@ impl fmt::Display for ProcessState {
     }
 }
 
+impl FromStr for BindingMode {
+    type Err = NetErr;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.to_lowercase().as_ref() {
+            "relaxed" => Ok(BindingMode::Relaxed),
+            "strict" => Ok(BindingMode::Strict),
+            _ => Err(net::err(
+                ErrCode::InvalidPayload,
+                format!("Invalid binding mode \"{}\"", value),
+            )),
+        }
+    }
+}
+
 impl FromStr for ServiceBind {
     type Err = NetErr;
 
@@ -188,6 +203,24 @@ impl fmt::Display for ServiceCfg_Format {
             ServiceCfg_Format::TOML => "TOML",
         };
         write!(f, "{}", state)
+    }
+}
+
+impl From<core::service::BindingMode> for BindingMode {
+    fn from(mode: core::service::BindingMode) -> Self {
+        match mode {
+            core::service::BindingMode::Strict => BindingMode::Strict,
+            core::service::BindingMode::Relaxed => BindingMode::Relaxed,
+        }
+    }
+}
+
+impl Into<core::service::BindingMode> for BindingMode {
+    fn into(self) -> core::service::BindingMode {
+        match self {
+            BindingMode::Strict => core::service::BindingMode::Strict,
+            BindingMode::Relaxed => core::service::BindingMode::Relaxed,
+        }
     }
 }
 

--- a/components/sup/src/error.rs
+++ b/components/sup/src/error.rs
@@ -139,7 +139,9 @@ pub enum Error {
     MissingRequiredIdent,
     NameLookup(io::Error),
     NetParseError(net::AddrParseError),
+    NoActiveMembers(hcore::service::ServiceGroup),
     NoLauncher,
+    NoSuchBind(String),
     NotifyCreateError(notify::Error),
     NotifyError(notify::Error),
     NulError(ffi::NulError),
@@ -259,7 +261,9 @@ impl fmt::Display for SupError {
             }
             Error::NameLookup(ref e) => format!("Error resolving a name or IP address: {}", e),
             Error::NetParseError(ref e) => format!("Can't parse ip:port: {}", e),
+            Error::NoActiveMembers(ref g) => format!("No active members in service group {}", g),
             Error::NoLauncher => format!("Supervisor must be run from `hab-launch`"),
+            Error::NoSuchBind(ref b) => format!("No such bind: {}", b),
             Error::NotifyCreateError(ref e) => format!("Notify create error: {}", e),
             Error::NotifyError(ref e) => format!("Notify error: {}", e),
             Error::NulError(ref e) => format!("{}", e),
@@ -385,7 +389,9 @@ impl error::Error for SupError {
             }
             Error::NetParseError(_) => "Can't parse IP:port",
             Error::NameLookup(_) => "Error resolving a name or IP address",
+            Error::NoActiveMembers(_) => "Group has no active members",
             Error::NoLauncher => "Supervisor must be run from `hab-launch`",
+            Error::NoSuchBind(_) => "No such bind found for this service",
             Error::NotifyCreateError(_) => "Notify create error",
             Error::NotifyError(_) => "Notify error",
             Error::NulError(_) => {


### PR DESCRIPTION
Previously, a service would not start until all service groups it was
bound to were present and alive in the census. In general, though,
well-behaved distributed services should be able to gracefully deal
with the absence of any of their dependencies. This behavior makes it
difficult to do that.

Here, we introduce a new `--binding-mode` option, which affects how
the absence of a bind influences service start up. The current
behavior, where start-up is blocked until all binds are present, is
used with `--binding-mode=strict`. For now, this will be the default
mode, to retain consistent behavior with currently-running services,
but eventually this will _not_ be the default, in favor of
`--binding-mode=relaxed`, described below.

A service starting in the relaxed binding mode can start even if none
of its binds are present. Plan authors should account for this in
their templated configuration and hook scripts by looking for the
presence of a particular bind in the templating data. As an example,
if your service can operate in the absence of its `database` bind, you
could have the following in a template:

```
{{ #if bind.database }}
  // database-specific configuration
{{ else }}
  // fallback configuration when no database is present
{{ /if }}
```

The `bind.database` structure will be empty until there are
active (live or suspect) census members present in the bound service
group.

In a change from previous behavior, should the number of active
members in the service group drop to 0, the bind will _not_ be present
in the templating data. In this way, your application can reconfigure
itself when a group goes away.

This change also introduces bind validation when determining if a bind
has been satisfied or not. Previously, mere presence was enough for a
bind to be considered satisfied. Now, the exports of the bound service
group are compared to what the bind expects. Only when all exports are
present is the bind considered satisfied. This is also reevaluated as
the census is updated. In order to achieve this, we need some idea of
what "the group" is exporting. In the absence of structures to
formally expose that, we simply ask either the leader or first active
member of the group what they export, and use that as a proxy for what
the group as a whole exports. #4909 has been suggested as a mechanism
to do this properly.

It should be noted that, just as in all other releases of Habitat to
date, no special action is taken when the bind of a service starting
in "strict" mode disappears. That is, the Supervisor does not halt the
service or do anything else, but the information would be reflected in
the census, and thus available when templating files. The removal of
the `bind.<MY_BIND>` map when the `<MY_BIND>` bind goes away should
make it easier to write templates that can react to this, however.