### PR TITLE
compression love for pkg-export-tar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -379,6 +379,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "flate2"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "miniz-sys 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -863,6 +872,7 @@ dependencies = [
  "env_logger 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 1.0.0 (git+https://github.com/withoutboats/failure.git)",
  "failure_derive 0.1.1 (git+https://github.com/withoutboats/failure_derive.git)",
+ "flate2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hab 0.0.0",
  "habitat_common 0.0.0",
  "habitat_core 0.0.0 (git+https://github.com/habitat-sh/core.git)",
@@ -1332,6 +1342,15 @@ dependencies = [
  "phf 0.7.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "phf_codegen 0.7.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "miniz-sys"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2605,6 +2624,7 @@ dependencies = [
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum features 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "45d496bf4d9e25b7509388b3ba8abe3af35b78b39f0f32e326253856eb11f5bc"
 "checksum filetime 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "714653f3e34871534de23771ac7b26e999651a0a228f47beb324dfdf1dd4b10f"
+"checksum flate2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9fac2277e84e5e858483756647a9d0aa8d9a2b7cba517fd84325a0aaa69a0909"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 "checksum foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
@@ -2665,6 +2685,7 @@ dependencies = [
 "checksum mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
 "checksum mime 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e2e00e17be181010a91dbfefb01660b17311059dc8c7f48b9017677721e732bd"
 "checksum mime_guess 1.8.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b7e2b09d08313f84e0fb82d13a4d859109a17543fe9af3b6d941dc1431f7de79"
+"checksum miniz-sys 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "609ce024854aeb19a0ef7567d348aaa5a746b32fb72e336df7fcc16869d7e2b4"
 "checksum mio 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a637d1ca14eacae06296a008fa7ad955347e34efcb5891cfd8ba05491a37907e"
 "checksum mio 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "7da01a5e23070d92d99b1ecd1cd0af36447c6fd44b0fe283c2db199fa136724f"
 "checksum miow 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3e690c5df6b2f60acd45d56378981e827ff8295562fc8d34f573deb267a59cd1"

--- a/components/pkg-export-tar/Cargo.toml
+++ b/components/pkg-export-tar/Cargo.toml
@@ -31,3 +31,4 @@ failure = { git = "https://github.com/withoutboats/failure.git" }
 failure_derive = { git = "https://github.com/withoutboats/failure_derive.git" }
 tempdir = "*"
 tar = "*"
+flate2 = "*"

--- a/components/pkg-export-tar/src/lib.rs
+++ b/components/pkg-export-tar/src/lib.rs
@@ -11,6 +11,7 @@ extern crate handlebars;
 extern crate failure;
 #[macro_use]
 extern crate failure_derive;
+extern crate flate2;
 extern crate lazy_static;
 #[macro_use]
 extern crate log;
@@ -34,6 +35,8 @@ use hcore::url as hurl;
 use hcore::package::{PackageIdent, PackageInstall};
 use tar::Builder;
 use std::str::FromStr;
+use flate2::Compression;
+use flate2::write::GzEncoder;
 
 pub use build::BuildSpec;
 
@@ -66,7 +69,8 @@ fn tar_command(temp_dir_path: &Path, pkg_ident: PackageIdent, hab_pkg: &str) {
     let tarball_name = format_tar_name(pkg_ident);
 
     let tarball = File::create(tarball_name).unwrap();
-    let mut tar_builder = Builder::new(tarball);
+    let enc = GzEncoder::new(tarball, Compression::default());
+    let mut tar_builder = Builder::new(enc);
     tar_builder.follow_symlinks(false);
 
     let root_fs = temp_dir_path.clone().join("rootfs");


### PR DESCRIPTION
![cool-bear-hug-2](https://user-images.githubusercontent.com/1991696/39578474-e2f65a76-4ea9-11e8-9432-7406edb8bc76.gif)


### :nut_and_bolt: Description

Currently, the exporter creates a `.tar.gz` file but the file is not compressed.
This introduces file compression to `hab pkg export tar ..`  and addresses #5011

### :athletic_shoe: Demo Script

```bash
✔ /mnt/data/home/habitat/components/pkg-export-tar [jeremymv2/gzip_hab_pkg_export_tar L|…1]
13:06 $ cargo run -- /mnt/data/home/artifacts/core-hab-butterfly-0.50.3-20171201190636-x86_64-linux.hart
   Compiling habitat_pkg_export_tar v0.0.0 (file:///mnt/data/home/habitat/components/pkg-export-tar)
    Finished dev [unoptimized + debuginfo] target(s) in 7.11 secs
     Running `/mnt/data/home/habitat/target/debug/hab-pkg-export-tar /mnt/data/home/artifacts/core-hab-butterfly-0.50.3-20171201190636-x86_64-linux.hart`
Ω Creating build root in /tmp/hab-pkg-export-tar.ZEYW1a4kf1Uk
Ω Creating root filesystem
Ω Creating artifact cache symlink
Ω Creating key cache symlink
» Installing core/hab
☁ Determining latest version of core/hab in the 'stable' channel
...

★ Install of core/hab-butterfly/0.50.3/20171201190636 complete with 1 new packages installed.
☒ Deleting artifact key symlink
☒ Deleting artifact cache symlink

✔ /mnt/data/home/habitat/components/pkg-export-tar [jeremymv2/gzip_hab_pkg_export_tar L|…1]
13:07 $ ls -l *gz
-rw-rw-r-- 1 jmiller jmiller 50717273 May  3 13:07 core-hab-butterfly-0.50.3-20171201190636.tar.gz

✔ /mnt/data/home/habitat/components/pkg-export-tar [jeremymv2/gzip_hab_pkg_export_tar L|…1]
13:08 $ file core-hab-butterfly-0.50.3-20171201190636.tar.gz
core-hab-butterfly-0.50.3-20171201190636.tar.gz: gzip compressed data

✔ /mnt/data/home/habitat/components/pkg-export-tar [jeremymv2/gzip_hab_pkg_export_tar L|…1]
13:08 $ gunzip core-hab-butterfly-0.50.3-20171201190636.tar.gz

✔ /mnt/data/home/habitat/components/pkg-export-tar [jeremymv2/gzip_hab_pkg_export_tar L|…1]
13:08 $ file core-hab-butterfly-0.50.3-20171201190636.tar
core-hab-butterfly-0.50.3-20171201190636.tar: POSIX tar archive (GNU)

✔ /mnt/data/home/habitat/components/pkg-export-tar [jeremymv2/gzip_hab_pkg_export_tar L|…1]
13:08 $ tar tvf core-hab-butterfly-0.50.3-20171201190636.tar
drwxrwxr-x 1001/1001         0 2018-05-03 13:07 hab/
drwxrwxr-x 1001/1001         0 2018-05-03 13:07 hab/pkgs
drwxrwxr-x 1001/1001         0 2018-05-03 13:07 hab/pkgs/core
drwxrwxr-x 1001/1001         0 2018-05-03 13:07 hab/pkgs/core/linux-headers
drwxrwxr-x 1001/1001         0 2018-05-03 13:07 hab/pkgs/core/linux-headers/4.3
drwxr-xr-x 1001/1001         0 2017-05-13 20:10 hab/pkgs/core/linux-headers/4.3/20170513200956
-rw-r--r-- 1001/1001       487 2017-05-13 20:10 hab/pkgs/core/linux-headers/4.3/20170513200956/BUILD_TDEPS
-rw-r--r-- 1001/1001      2476 2017-05-13 20:10 hab/pkgs/core/linux-headers/4.3/20170513200956/MANIFEST
...

```

### :white_check_mark: Checklist

- [x] Code actually executed?

Signed-off-by: Jeremy J. Miller <jm@chef.io>