### PR TITLE
adds status link to footer

### DIFF
--- a/www/source/layouts/_footer.slim
+++ b/www/source/layouts/_footer.slim
@@ -16,11 +16,13 @@ footer#main-footer class="#{layout_class}" data-swiftype-index="false"
         li.footer--sitemap--link
           =link_to 'Community', '/community'
         li.footer--sitemap--link
+            a href="#{builder_web_url}/#/pkgs" Builder
+        li.footer--sitemap--link
           =link_to 'Enterprise', '/enterprise'
         li.footer--sitemap--link
           =link_to 'Blog', '/blog'
         li.footer--sitemap--link
-            a href="#{builder_web_url}/#/" Habitat Builder
+            a href="https://status.habitat.sh/" target="_blank" Status
     .columns.large-2.small-12.footer--social-links
       ul.footer--links.social.inline
         li.footer--socials--link


### PR DESCRIPTION
I mistakenly removed the status link from the footer during a recent redesign. This adds it back, slightly re-orders the footer links to match the top nav order, and points the Builder link to the Search Packages page (as opposed to redirecting to Sign In).

Fixes https://github.com/habitat-sh/builder/issues/414

![screenshot 2018-05-03 16 23 36](https://user-images.githubusercontent.com/446285/39603520-60421670-4eee-11e8-9b9b-579fcc31cebd.png)



Signed-off-by: Ryan Keairns <rkeairns@chef.io>