### PR TITLE
Update to current master of habitat-sh/core repository

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -718,7 +718,7 @@ dependencies = [
 [[package]]
 name = "habitat_core"
 version = "0.0.0"
-source = "git+https://github.com/habitat-sh/core.git#f51c3d8f87564ce0c9286864d57bfc4401259ddd"
+source = "git+https://github.com/habitat-sh/core.git#40451521e357548e68a2b3d845da850dcecd2a74"
 dependencies = [
  "ansi_term 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -776,7 +776,7 @@ dependencies = [
 [[package]]
 name = "habitat_http_client"
 version = "0.0.0"
-source = "git+https://github.com/habitat-sh/core.git#f51c3d8f87564ce0c9286864d57bfc4401259ddd"
+source = "git+https://github.com/habitat-sh/core.git#40451521e357548e68a2b3d845da850dcecd2a74"
 dependencies = [
  "base64 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat_core 0.0.0 (git+https://github.com/habitat-sh/core.git)",
@@ -933,7 +933,7 @@ dependencies = [
 [[package]]
 name = "habitat_win_users"
 version = "0.0.0"
-source = "git+https://github.com/habitat-sh/core.git#f51c3d8f87564ce0c9286864d57bfc4401259ddd"
+source = "git+https://github.com/habitat-sh/core.git#40451521e357548e68a2b3d845da850dcecd2a74"
 dependencies = [
  "gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/hab/src/command/pkg/env.rs
+++ b/components/hab/src/command/pkg/env.rs
@@ -21,7 +21,7 @@ use error::Result;
 // TODO: This needs a windows compatible version
 pub fn start(ident: &PackageIdent, fs_root_path: &Path) -> Result<()> {
     let pkg_install = PackageInstall::load(ident, Some(fs_root_path))?;
-    let env = pkg_install.runtime_environment()?;
+    let env = pkg_install.environment_for_command()?;
     for (key, value) in env.into_iter() {
         println!("export {}=\"{}\"", key, value);
     }

--- a/components/hab/src/command/pkg/exec.rs
+++ b/components/hab/src/command/pkg/exec.rs
@@ -28,7 +28,7 @@ where
 {
     let command = command.into();
     let pkg_install = PackageInstall::load(&ident, Some(&*FS_ROOT_PATH))?;
-    let mut run_env = pkg_install.runtime_environment()?;
+    let mut run_env = pkg_install.environment_for_command()?;
 
     let mut paths: Vec<PathBuf> = match run_env.get("PATH") {
         Some(path) => env::split_paths(&path).collect(),

--- a/components/sup/src/manager/service/package.rs
+++ b/components/sup/src/manager/service/package.rs
@@ -60,7 +60,7 @@ impl Env {
     /// This means we work on any operating system, as long as you can invoke the Supervisor,
     /// without having to worry much about context.
     pub fn new(package: &PackageInstall) -> Result<Self> {
-        let mut env = package.runtime_environment()?;
+        let mut env = package.environment_for_command()?;
         let path = Self::transform_path(env.get(PATH_KEY))?;
         env.insert(PATH_KEY.to_string(), path);
         Ok(Env(env))


### PR DESCRIPTION
Some changes were merged in to the core repository
recently (https://github.com/habitat-sh/core/pull/25), with the
anticipation that corresponding changes in this repository would be
merged shortly thereafter. However, those changes are still
outstanding (See #4962).

In the meantime, any additional changes here that require changes to
the `habitat-sh/core` repository will not work until this repository
is updated to deal with the initial changes.

This change updates `Cargo.lock` to point to the current master branch
of `habitat-sh/core`, and makes the necessary compatibility changes to
the `hab` and Supervisor code.

Signed-off-by: Christopher Maier <cmaier@chef.io>