### PR TITLE
Add JSON structured logging to the Supervisor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -727,7 +727,7 @@ dependencies = [
 [[package]]
 name = "habitat_core"
 version = "0.0.0"
-source = "git+https://github.com/habitat-sh/core.git#0e296163684e6f2ea7d9e692355107dab5b51188"
+source = "git+https://github.com/habitat-sh/core.git#6a7cc6b5be2e13c55737eca4765ba35dc580d8bd"
 dependencies = [
  "ansi_term 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -785,7 +785,7 @@ dependencies = [
 [[package]]
 name = "habitat_http_client"
 version = "0.0.0"
-source = "git+https://github.com/habitat-sh/core.git#0e296163684e6f2ea7d9e692355107dab5b51188"
+source = "git+https://github.com/habitat-sh/core.git#6a7cc6b5be2e13c55737eca4765ba35dc580d8bd"
 dependencies = [
  "base64 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat_core 0.0.0 (git+https://github.com/habitat-sh/core.git)",
@@ -943,7 +943,7 @@ dependencies = [
 [[package]]
 name = "habitat_win_users"
 version = "0.0.0"
-source = "git+https://github.com/habitat-sh/core.git#0e296163684e6f2ea7d9e692355107dab5b51188"
+source = "git+https://github.com/habitat-sh/core.git#6a7cc6b5be2e13c55737eca4765ba35dc580d8bd"
 dependencies = [
  "gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -41,8 +41,6 @@ pub fn get() -> App<'static, 'static> {
         (author: "\nAuthors: The Habitat Maintainers <humans@habitat.sh>\n")
         (@setting VersionlessSubcommands)
         (@setting ArgRequiredElseHelp)
-        (@arg VERBOSE: -v +global "Verbose output; shows line numbers")
-        (@arg NO_COLOR: --("no-color") +global "Turn ANSI color off")
         (@subcommand cli =>
             (about: "Commands relating to Habitat runtime config")
             (aliases: &["cl"])

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -722,8 +722,6 @@ fn sub_pkg_channels(ui: &mut UI, m: &ArgMatches) -> Result<()> {
 }
 
 fn sub_svc_set(m: &ArgMatches) -> Result<()> {
-    toggle_verbosity(m);
-    toggle_color(m);
     let cfg = config::load()?;
     let sup_addr = sup_addr_from_input(m);
     let secret_key = ctl_secret_key(&cfg)?;
@@ -818,8 +816,6 @@ fn sub_svc_set(m: &ArgMatches) -> Result<()> {
 }
 
 fn sub_svc_config(m: &ArgMatches) -> Result<()> {
-    toggle_verbosity(m);
-    toggle_color(m);
     let ident = PackageIdent::from_str(m.value_of("PKG_IDENT").unwrap())?;
     let cfg = config::load()?;
     let sup_addr = sup_addr_from_input(m);
@@ -848,8 +844,6 @@ fn sub_svc_config(m: &ArgMatches) -> Result<()> {
 }
 
 fn sub_svc_load(m: &ArgMatches) -> Result<()> {
-    toggle_verbosity(m);
-    toggle_color(m);
     let cfg = config::load()?;
     let sup_addr = sup_addr_from_input(m);
     let secret_key = ctl_secret_key(&cfg)?;
@@ -864,8 +858,6 @@ fn sub_svc_load(m: &ArgMatches) -> Result<()> {
 }
 
 fn sub_svc_unload(m: &ArgMatches) -> Result<()> {
-    toggle_verbosity(m);
-    toggle_color(m);
     let ident = PackageIdent::from_str(m.value_of("PKG_IDENT").unwrap())?;
     let cfg = config::load()?;
     let sup_addr = sup_addr_from_input(m);
@@ -879,8 +871,6 @@ fn sub_svc_unload(m: &ArgMatches) -> Result<()> {
 }
 
 fn sub_svc_start(m: &ArgMatches) -> Result<()> {
-    toggle_verbosity(m);
-    toggle_color(m);
     let ident = PackageIdent::from_str(m.value_of("PKG_IDENT").unwrap())?;
     let cfg = config::load()?;
     let sup_addr = sup_addr_from_input(m);
@@ -894,8 +884,6 @@ fn sub_svc_start(m: &ArgMatches) -> Result<()> {
 }
 
 fn sub_svc_status(m: &ArgMatches) -> Result<()> {
-    toggle_verbosity(m);
-    toggle_color(m);
     let cfg = config::load()?;
     let sup_addr = sup_addr_from_input(m);
     let secret_key = ctl_secret_key(&cfg)?;
@@ -930,8 +918,6 @@ fn sub_svc_status(m: &ArgMatches) -> Result<()> {
 }
 
 fn sub_svc_stop(m: &ArgMatches) -> Result<()> {
-    toggle_verbosity(m);
-    toggle_color(m);
     let ident = PackageIdent::from_str(m.value_of("PKG_IDENT").unwrap())?;
     let cfg = config::load()?;
     let sup_addr = sup_addr_from_input(m);
@@ -945,8 +931,6 @@ fn sub_svc_stop(m: &ArgMatches) -> Result<()> {
 }
 
 fn sub_file_put(m: &ArgMatches) -> Result<()> {
-    toggle_verbosity(m);
-    toggle_color(m);
     let service_group = ServiceGroup::from_str(m.value_of("SERVICE_GROUP").unwrap())?;
     let cfg = config::load()?;
     let sup_addr = sup_addr_from_input(m);
@@ -1018,8 +1002,6 @@ fn sub_file_put(m: &ArgMatches) -> Result<()> {
 }
 
 fn sub_sup_depart(m: &ArgMatches) -> Result<()> {
-    toggle_verbosity(m);
-    toggle_color(m);
     let cfg = config::load()?;
     let sup_addr = sup_addr_from_input(m);
     let secret_key = ctl_secret_key(&cfg)?;
@@ -1494,18 +1476,6 @@ fn user_param_or_env(m: &ArgMatches) -> Option<String> {
             Ok(v) => Some(v),
             Err(_) => None,
         },
-    }
-}
-
-fn toggle_verbosity(m: &ArgMatches) {
-    if m.is_present("VERBOSE") {
-        hcore::output::set_verbose(true);
-    }
-}
-
-fn toggle_color(m: &ArgMatches) {
-    if m.is_present("NO_COLOR") {
-        hcore::output::set_no_color(true);
     }
 }
 

--- a/components/launcher/src/service.rs
+++ b/components/launcher/src/service.rs
@@ -110,9 +110,8 @@ where
     let mut reader = BufReader::new(out);
     let mut buffer = String::new();
     while reader.read_line(&mut buffer).unwrap() > 0 {
-        let mut line = output_format!(preamble &id, logkey "O");
-        line.push_str(&buffer);
-        write!(&mut io::stdout(), "{}", line).expect("unable to write to stdout");
+        let line = output_format!(preamble &id, logkey "O", buffer);
+        writeln!(&mut io::stdout(), "{}", line).expect("unable to write to stdout");
         buffer.clear();
     }
 }
@@ -125,9 +124,8 @@ where
     let mut reader = BufReader::new(err);
     let mut buffer = String::new();
     while reader.read_line(&mut buffer).unwrap() > 0 {
-        let mut line = output_format!(preamble &id, logkey "E");
-        line.push_str(&buffer);
-        write!(&mut io::stderr(), "{}", line).expect("unable to write to stderr");
+        let line = output_format!(preamble &id, logkey "E", buffer);
+        writeln!(&mut io::stderr(), "{}", line).expect("unable to write to stderr");
         buffer.clear();
     }
 }


### PR DESCRIPTION
TL;DR - add `--json-logging` when you start your Supervisor and each
log line will be a JSON object.

While the core of this implementation is in the `habitat_core` crate,
governing how a `StructuredOutput` struct is emitted, there are some
interesting follow-on changes that were needed here, along with
several housekeeping tasks.

First, we had `-v` and `--no-color` as global options, which are no
longer necessary. Previously, there were several ways that a
Supervisor could start up, but now there is only one: `hab sup
run`. We also simply had these on commands where they simply were not
needed. These options ONLY govern how the Supervisor's output is
formatted, and not any client-side output.

Secondly, the Launcher is now "eavesdropping" on all the log
formatting flags. Previously, it was only paying attention to
`--no-color`, but not `-v`. This means that the `-v` flag for verbose
logging was effectively only half-implemented, since output from the
Launcher itself was never configured with it.

Most interestingly, the `CtlRequest` struct performs an interesting
double-duty; it's output is sent to both the client that issued the
request, as well as to the Supervisor's output streams. The
`CtlRequest` is currently configured to _always_ use color (as well as
to behave as though it is always connected to a terminal), but this
will result in ANSI color codes being output to the Supervisor logs,
regardlss of how the Supervisor itself is configured. The
implementation here continues to do double-duty, but strips the ANSI
codes out of the string it sends to the Supervisor, when
necessary. It's not yet clear that additional refactoring is
necessary, given that this is the only place in the code where we have
this situation. This at least makes the two output destinations
explicit, whereas before it was not very obvious.
