### PR TITLE
Udpate the home-page video

### DIFF
--- a/www/source/index.html.slim
+++ b/www/source/index.html.slim
@@ -16,7 +16,7 @@ section.home--hero
         = link_to 'View on GitHub', 'http://github.com/habitat-sh/habitat', class: 'button github with-icon'
     .columns.small-12.medium-6.video-cat-container
       .video-with-cat
-        <iframe width="560" height="315" src="https://www.youtube.com/embed/VW1DwDezlqM?rel=0" frameborder="0" allow="autoplay; encrypted-media" wmode="transparent" allowfullscreen></iframe>
+        <iframe width="560" height="315" src="https://www.youtube.com/embed/lR7m1XzDHHg?rel=0" frameborder="0" allow="autoplay; encrypted-media" wmode="transparent" allowfullscreen></iframe>
 
   .home--hero-cards.row.mt-4
     .columns.small-12.medium-4.get-started--boxes--item


### PR DESCRIPTION
This change replaces the home-page video in order to update some Habitat logos.

Signed-off-by: Christian Nunciato <chris@nunciato.org>

![](https://media0.giphy.com/media/61orxp3N7KTx6/200w.gif)