### PR TITLE
Bump habitat_core dependency to pick up HTTP client changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -727,7 +727,7 @@ dependencies = [
 [[package]]
 name = "habitat_core"
 version = "0.0.0"
-source = "git+https://github.com/habitat-sh/core.git#6a7cc6b5be2e13c55737eca4765ba35dc580d8bd"
+source = "git+https://github.com/habitat-sh/core.git#979c7df8d70e7bf58747620054131020e401fa76"
 dependencies = [
  "ansi_term 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -785,7 +785,7 @@ dependencies = [
 [[package]]
 name = "habitat_http_client"
 version = "0.0.0"
-source = "git+https://github.com/habitat-sh/core.git#6a7cc6b5be2e13c55737eca4765ba35dc580d8bd"
+source = "git+https://github.com/habitat-sh/core.git#979c7df8d70e7bf58747620054131020e401fa76"
 dependencies = [
  "base64 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat_core 0.0.0 (git+https://github.com/habitat-sh/core.git)",
@@ -943,7 +943,7 @@ dependencies = [
 [[package]]
 name = "habitat_win_users"
 version = "0.0.0"
-source = "git+https://github.com/habitat-sh/core.git#6a7cc6b5be2e13c55737eca4765ba35dc580d8bd"
+source = "git+https://github.com/habitat-sh/core.git#979c7df8d70e7bf58747620054131020e401fa76"
 dependencies = [
  "gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
This is to pick up https://github.com/habitat-sh/core/pull/31

Signed-off-by: Christopher Maier <cmaier@chef.io>