### PR TITLE
Remove commit version for http-client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -785,7 +785,7 @@ dependencies = [
 [[package]]
 name = "habitat_http_client"
 version = "0.0.0"
-source = "git+https://github.com/habitat-sh/core.git#6a7cc6b5be2e13c55737eca4765ba35dc580d8bd"
+source = "git+https://github.com/habitat-sh/core.git"
 dependencies = [
  "base64 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat_core 0.0.0 (git+https://github.com/habitat-sh/core.git)",


### PR DESCRIPTION
This lets us automatically pick up latest changes to http-client from the core repo, instead of having to update to specific commits manually.

Signed-off-by: Salim Alam <salam@chef.io>