### PR TITLE
[ci] Pin rustfmt by pinning to Rust 1.25.0.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ matrix:
         - COMPONENTS=bin
         - AFFECTED_FILES="Cargo.lock"
         - AFFECTED_DIRS="$_RUST_HAB_BIN_COMPONENTS $_RUST_HAB_LIB_COMPONENTS"
-      rust: stable
+      rust: 1.25.0
       sudo: false
       services:
         - docker
@@ -73,7 +73,7 @@ matrix:
         - COMPONENTS=lib
         - AFFECTED_FILES="Cargo.lock"
         - AFFECTED_DIRS="$_RUST_HAB_LIB_COMPONENTS"
-      rust: stable
+      rust: 1.25.0
       sudo: required
       addons:
         apt:


### PR DESCRIPTION
When we upgrade to Rust 1.26.0 (most likely after the next Habitat
release) we can drop these pins back to `stable` which will revert us
back to using Rust 1.26.0 and *also* `rustfmt` 0.4.1.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>