### PR TITLE
[studio] Fix building the Windows Docker image when installing pkgs.

### DIFF
--- a/components/studio/build-docker-image.ps1
+++ b/components/studio/build-docker-image.ps1
@@ -36,7 +36,7 @@ try {
         )
     }
     $InstallHarts | % {
-        hab pkg install $_
+        Invoke-Expression "hab pkg install $_"
         if ($LASTEXITCODE -ne 0) {
             Write-Error "hab install failed for $_, aborting"
         }


### PR DESCRIPTION
Prior to this fix, the `core/windows-service --channel stable` item was
being passed to `hab pkg install` as a single argument, rather than
multiple arguments. iex ftw.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>