### PR TITLE
Release 0.56.0 (take 6).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@
 
 ## Bug fixes
 
+- \[hab\] Fix missing invocation matches for {apply,start,stop}. [\#5082](https://github.com/habitat-sh/habitat/pull/5082) ([fnichol](https://github.com/fnichol))
 - \[hab\] Fix {apply, start, stop} aliases. [\#5078](https://github.com/habitat-sh/habitat/pull/5078) ([fnichol](https://github.com/fnichol))
 - \[studio\] Fix building the Windows Docker image when installing pkgs. [\#5072](https://github.com/habitat-sh/habitat/pull/5072) ([fnichol](https://github.com/fnichol))
 - \[plan-build.ps1]\ Use `RUNTIME_ENVIRONMENT` if necessary for run path. [\#5070](https://github.com/habitat-sh/habitat/pull/5070) ([fnichol](https://github.com/fnichol))


### PR DESCRIPTION
This change adds #5082 which came up in the process of testing the build
release candidates. The prior commits and CHANGELOG.md entries are still
in effect.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>