### PR TITLE
[hab] Fix the subcommand delegation to `hab-sup`.

### DIFF
--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -1114,8 +1114,18 @@ fn exec_subcommand_if_called(ui: &mut UI) -> Result<()> {
         ("stu", _, _) | ("stud", _, _) | ("studi", _, _) | ("studio", _, _) => {
             command::studio::enter::start(ui, env::args_os().skip(2).collect())
         }
+        // Delegate `hab sup run *` to the Launcher
         ("sup", "run", _) => command::launcher::start(ui, env::args_os().skip(2).collect()),
-        ("sup", "term", _) => command::sup::start(ui, env::args_os().skip(2).collect()),
+        // Delegate remaining Supervisor subcommands to `hab-sup *`
+        ("sup", "", "")
+        | ("sup", "term", _)
+        | ("sup", "bash", _)
+        | ("sup", "sh", _)
+        | ("sup", "-h", _)
+        | ("sup", "--help", _)
+        | ("sup", "help", _)
+        | ("sup", "-V", _)
+        | ("sup", "--version", _) => command::sup::start(ui, env::args_os().skip(2).collect()),
         ("term", _, _) => command::sup::start(ui, env::args_os().skip(1).collect()),
         _ => Ok(()),
     }


### PR DESCRIPTION
This change ensures that all commands on the Supervisor such as `hab sup
sh` get properly delegated to the `hab-sup` program.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>