### PR TITLE
Run the best local candidate of a service first

### DIFF
--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -960,8 +960,13 @@ impl Manager {
             None => {
                 // We don't have any record of this thing; let's set it up!
                 //
-                // This will install the latest version from Builder
-                let installed = util::pkg::install(req, bldr_url, &source, bldr_channel)?;
+                // If a package exists on disk that satisfies the
+                // desired package identifier, it will be used;
+                // otherwise, we'll install the latest suitable
+                // version from the specified Builder channel.
+                let installed =
+                    util::pkg::satisfy_or_install(req, &source, &bldr_url, &bldr_channel)?;
+
                 let mut specs = Self::generate_new_specs_from_package(&installed, &opts)?;
 
                 for spec in specs.iter_mut() {


### PR DESCRIPTION
This is the previous behavior, inadvertently undone in the recent
Supervisor refactoring.

When a service is loaded, locally-installed packages are consulted
first, and the most suitable one is run if it exists. Otherwise, we'll
install the latest from Builder and run that.

Without this, you can get unexpectedly updating services, or attempts
to reach out to Builder when you may neither be able to, nor want
to. Docker containers are particularly important here, as without this
change, any exported container would always update itself to whatever
is latest in Builder whenever it starts.

Signed-off-by: Christopher Maier <cmaier@chef.io>