### PR TITLE
Disable validation of config/files

### DIFF
--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -854,42 +854,33 @@ impl Manager {
             ));
         }
         let service_group: ServiceGroup = opts.take_service_group().into();
-        for service in mgr.services.read().unwrap().iter() {
-            if service.service_group != service_group {
-                continue;
+        outputln!(
+            "Setting new configuration version {} for {}",
+            opts.get_version(),
+            service_group,
+        );
+        let mut client = match butterfly::client::Client::new(
+            format!("127.0.0.1:{}", mgr.cfg.gossip_listen.port()),
+            mgr.cfg.ring_key.clone(),
+        ) {
+            Ok(client) => client,
+            Err(err) => {
+                outputln!("Failed to connect to own gossip server, {}", err);
+                return Err(net::err(ErrCode::Internal, err.to_string()));
             }
-            outputln!(
-                "Setting new configuration version {} for {}",
-                opts.get_version(),
-                service_group,
-            );
-            let mut client = match butterfly::client::Client::new(
-                format!("127.0.0.1:{}", mgr.cfg.gossip_listen.port()),
-                mgr.cfg.ring_key.clone(),
-            ) {
-                Ok(client) => client,
-                Err(err) => {
-                    outputln!("Failed to connect to own gossip server, {}", err);
-                    return Err(net::err(ErrCode::Internal, err.to_string()));
-                }
-            };
-            match client.send_service_config(
-                service_group,
-                opts.get_version(),
-                opts.take_cfg(),
-                opts.get_is_encrypted(),
-            ) {
-                Ok(()) => {
-                    req.reply_complete(net::ok());
-                    return Ok(());
-                }
-                Err(e) => return Err(net::err(ErrCode::Internal, e.to_string())),
+        };
+        match client.send_service_config(
+            service_group,
+            opts.get_version(),
+            opts.take_cfg(),
+            opts.get_is_encrypted(),
+        ) {
+            Ok(()) => {
+                req.reply_complete(net::ok());
+                return Ok(());
             }
+            Err(e) => return Err(net::err(ErrCode::Internal, e.to_string())),
         }
-        Err(net::err(
-            ErrCode::NotFound,
-            format!("{} not loaded.", service_group),
-        ))
     }
 
     pub fn service_file_put(
@@ -901,44 +892,35 @@ impl Manager {
             return Err(net::err(ErrCode::EntityTooLarge, "File content too large."));
         }
         let service_group: ServiceGroup = opts.take_service_group().into();
-        for service in mgr.services.read().unwrap().iter() {
-            if service.service_group != service_group {
-                continue;
+        outputln!(
+            "Receiving new version {} of file {} for {}",
+            opts.get_version(),
+            opts.get_filename(),
+            service_group,
+        );
+        let mut client = match butterfly::client::Client::new(
+            format!("127.0.0.1:{}", mgr.cfg.gossip_listen.port()),
+            mgr.cfg.ring_key.clone(),
+        ) {
+            Ok(client) => client,
+            Err(err) => {
+                outputln!("Failed to connect to own gossip server, {}", err);
+                return Err(net::err(ErrCode::Internal, err.to_string()));
             }
-            outputln!(
-                "Receiving new version {} of file {} for {}",
-                opts.get_version(),
-                opts.get_filename(),
-                service_group,
-            );
-            let mut client = match butterfly::client::Client::new(
-                format!("127.0.0.1:{}", mgr.cfg.gossip_listen.port()),
-                mgr.cfg.ring_key.clone(),
-            ) {
-                Ok(client) => client,
-                Err(err) => {
-                    outputln!("Failed to connect to own gossip server, {}", err);
-                    return Err(net::err(ErrCode::Internal, err.to_string()));
-                }
-            };
-            match client.send_service_file(
-                service_group,
-                opts.take_filename(),
-                opts.get_version(),
-                opts.take_content(),
-                opts.get_is_encrypted(),
-            ) {
-                Ok(()) => {
-                    req.reply_complete(net::ok());
-                    return Ok(());
-                }
-                Err(e) => return Err(net::err(ErrCode::Internal, e.to_string())),
+        };
+        match client.send_service_file(
+            service_group,
+            opts.take_filename(),
+            opts.get_version(),
+            opts.take_content(),
+            opts.get_is_encrypted(),
+        ) {
+            Ok(()) => {
+                req.reply_complete(net::ok());
+                return Ok(());
             }
+            Err(e) => return Err(net::err(ErrCode::Internal, e.to_string())),
         }
-        Err(net::err(
-            ErrCode::NotFound,
-            format!("{} not loaded.", service_group),
-        ))
     }
     pub fn service_load(
         mgr: &ManagerState,


### PR DESCRIPTION
Disable (for now) validation of configuration and files when applying
configuration or uploading to a Supervisor. We aren't quite there just
yet - we need to be storing all loaded services in memory at all times
(not just when they are running).