### PR TITLE
Release 0.56.0 (take 8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,8 @@
 
 ## Bug fixes
 
+- Disable interface validation of config/files [\#5091](https://github.com/habitat-sh/habitat/pull/5091)
+- Disable validation of config/files [\#5090](https://github.com/habitat-sh/habitat/pull/5090)
 - Run the best local candidate of a service first [\#5087](https://github.com/habitat-sh/habitat/pull/5087) ([christophermaier](https://github.com/christophermaier))
 - \[hab\] Fix the subcommand delegation to `hab-sup`. [\#5086](https://github.com/habitat-sh/habitat/pull/5086) ([fnichol](https://github.com/fnichol))
 - \[hab\] Fix missing invocation matches for {apply,start,stop}. [\#5082](https://github.com/habitat-sh/habitat/pull/5082) ([fnichol](https://github.com/fnichol))


### PR DESCRIPTION
This change adds #5090 and #5091 to address some `hab config apply`
bus in the release candidate. The prior commits and CHANGELOG.md
entries are still in effect.

Signed-off-by: Christopher Maier <cmaier@chef.io>