### PR TITLE
Fix panic when an initial service fails to loaded

### DIFF
--- a/components/sup/src/manager/debug.rs
+++ b/components/sup/src/manager/debug.rs
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 use std::collections::{HashMap, HashSet};
+use std::ffi::OsString;
 use std::fmt::Debug;
 use std::path::PathBuf;
-use std::ffi::OsString;
 
 pub trait IndentedToString {
     fn indented_to_string(&self, spaces: &str, repeat: usize) -> String;

--- a/components/sup/src/manager/events.rs
+++ b/components/sup/src/manager/events.rs
@@ -18,10 +18,10 @@ use std::sync::mpsc::{self, Receiver, RecvError, Sender, SyncSender};
 use std::thread;
 
 use byteorder::{ByteOrder, LittleEndian};
-use eventsrv_client::{EventSrvAddr, EventSrvClient};
 use eventsrv_client::message::{EventEnvelope, EventEnvelope_Type,
                                PackageIdent as PackageIdentProto,
                                ServiceUpdate as ServiceUpdateProto, SysInfo as SysInfoProto};
+use eventsrv_client::{EventSrvAddr, EventSrvClient};
 use hcore::service::ServiceGroup;
 use protobuf::Message;
 use toml;

--- a/components/sup/src/manager/file_watcher.rs
+++ b/components/sup/src/manager/file_watcher.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::env;
-use std::collections::{HashMap, HashSet, VecDeque};
 use std::collections::hash_map::Entry;
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::env;
 use std::ffi::OsString;
 use std::mem::swap;
 use std::path::{Component, Path, PathBuf};

--- a/components/sup/src/manager/peer_watcher.rs
+++ b/components/sup/src/manager/peer_watcher.rs
@@ -161,12 +161,12 @@ impl PeerWatcher {
 
 #[cfg(test)]
 mod tests {
-    use std::fs::{File, OpenOptions};
-    use tempdir::TempDir;
     use super::PeerWatcher;
     use butterfly::member::Member;
     use config::GOSSIP_DEFAULT_PORT;
+    use std::fs::{File, OpenOptions};
     use std::io::Write;
+    use tempdir::TempDir;
 
     #[test]
     fn no_file() {

--- a/components/sup/src/manager/service/composite_spec.rs
+++ b/components/sup/src/manager/service/composite_spec.rs
@@ -16,20 +16,20 @@
 //! about the current composite definition that is in play. A
 //! `CompositeSpec` plays this role.
 
-use std::str::FromStr;
+use std::fs::{self, File};
 use std::io::{BufReader, Read, Write};
 use std::path::Path;
-use std::fs::{self, File};
 use std::result;
+use std::str::FromStr;
 
 use hcore::error::Error as HCoreError;
-use hcore::package::{Identifiable, PackageIdent, PackageInstall};
 use hcore::package::metadata::PackageType;
+use hcore::package::{Identifiable, PackageIdent, PackageInstall};
 use hcore::util::{deserialize_using_from_str, serialize_using_to_string};
 
 use error::{Error, Result, SupError};
-use toml;
 use rand::{thread_rng, Rng};
+use toml;
 
 const SPEC_FILE_EXT: &'static str = "spec";
 

--- a/components/sup/src/manager/service/config.rs
+++ b/components/sup/src/manager/service/config.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 /// Collect all the configuration data that is exposed to users, and render it.
-
 use std;
 use std::borrow::Cow;
 use std::env;
@@ -23,10 +22,10 @@ use std::path::{Path, PathBuf};
 use std::result;
 
 use fs;
-use hcore::{crypto, util};
 use hcore::fs::USER_CONFIG_FILE;
-use serde::{Serialize, Serializer};
+use hcore::{crypto, util};
 use serde::ser::SerializeMap;
+use serde::{Serialize, Serializer};
 use serde_json;
 use serde_transcode;
 use toml;
@@ -624,8 +623,8 @@ mod test {
     use std::fs;
     use std::fs::OpenOptions;
 
-    use toml;
     use tempdir::TempDir;
+    use toml;
 
     use super::*;
     use error::Error;

--- a/components/sup/src/manager/service/dir.rs
+++ b/components/sup/src/manager/service/dir.rs
@@ -15,8 +15,8 @@
 //! Encapsulate operations for creating a supervised service's service
 //! directories (i.e., `/hab/svc/$NAME`).
 
-use std::fs as stdfs;
 use std::convert::From;
+use std::fs as stdfs;
 use std::path::Path;
 
 use error::{Error, Result};

--- a/components/sup/src/manager/service/hooks.rs
+++ b/components/sup/src/manager/service/hooks.rs
@@ -12,16 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[cfg(windows)]
+use hcore::os::process::windows_child::{Child, ExitStatus};
 use std;
 use std::fmt;
+use std::fs::File;
 use std::io::BufReader;
 use std::io::prelude::*;
-use std::fs::File;
 use std::path::{Path, PathBuf};
 #[cfg(not(windows))]
 use std::process::{Child, ExitStatus};
-#[cfg(windows)]
-use hcore::os::process::windows_child::{Child, ExitStatus};
 use std::result;
 
 use hcore;
@@ -1011,29 +1011,29 @@ impl<'a> HookOutput<'a> {
 mod tests {
     use std::fs::{self, DirBuilder};
     use std::iter;
-    use std::string::ToString;
     use std::process::{Command, Stdio};
+    use std::string::ToString;
 
-    use hcore::package::{PackageIdent, PackageInstall};
-    use hcore::service::ServiceGroup;
     use butterfly::member::MemberList;
-    use butterfly::rumor::service::Service as ServiceRumor;
-    use butterfly::rumor::service_config::ServiceConfig as ServiceConfigRumor;
-    use butterfly::rumor::service_file::ServiceFile as ServiceFileRumor;
+    use butterfly::rumor::RumorStore;
     use butterfly::rumor::election::Election as ElectionRumor;
     use butterfly::rumor::election::ElectionUpdate as ElectionUpdateRumor;
+    use butterfly::rumor::service::Service as ServiceRumor;
     use butterfly::rumor::service::SysInfo;
-    use butterfly::rumor::RumorStore;
+    use butterfly::rumor::service_config::ServiceConfig as ServiceConfigRumor;
+    use butterfly::rumor::service_file::ServiceFile as ServiceFileRumor;
+    use hcore::package::{PackageIdent, PackageInstall};
+    use hcore::service::ServiceGroup;
     use protocol;
     use tempdir::TempDir;
 
-    use super::*;
     use super::fs as supfs;
+    use super::*;
     use census::CensusRing;
     use config::GossipListenAddr;
     use http_gateway;
-    use manager::service::{Cfg, Pkg};
     use manager::service::spec::ServiceBind;
+    use manager::service::{Cfg, Pkg};
     use manager::sys::Sys;
 
     // Turns out it's useful for Hooks to implement AsRef<Path>, at

--- a/components/sup/src/manager/service/mod.rs
+++ b/components/sup/src/manager/service/mod.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod hooks;
 mod composite_spec;
 pub mod config;
 mod dir;
 mod health;
+pub mod hooks;
 mod package;
 mod spec;
 mod supervisor;
@@ -31,43 +31,41 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-pub use protocol::types::{Topology, UpdateStrategy};
 use butterfly::rumor::service::Service as ServiceRumor;
 use hcore::crypto::hash;
 use hcore::fs::FS_ROOT_PATH;
-use hcore::package::{PackageIdent, PackageInstall};
 use hcore::package::metadata::Bind;
+use hcore::package::{PackageIdent, PackageInstall};
 use hcore::service::{BindingMode, ServiceGroup};
 use hcore::util::perm::{set_owner, set_permissions};
 use launcher_client::LauncherCli;
+pub use protocol::types::{Topology, UpdateStrategy};
 use time::Timespec;
 
-pub use self::config::{Cfg, UserConfigPath};
-pub use self::health::{HealthCheck, SmokeCheck};
-pub use self::package::{Env, Pkg};
 pub use self::composite_spec::CompositeSpec;
+use self::config::CfgRenderer;
+pub use self::config::{Cfg, UserConfigPath};
+use self::dir::SvcDir;
+pub use self::health::{HealthCheck, SmokeCheck};
+use self::hooks::{Hook, HookTable, HOOK_PERMISSIONS};
+pub use self::package::{Env, Pkg};
 pub use self::spec::{BindMap, DesiredState, IntoServiceSpec, ServiceBind, ServiceSpec, Spec};
 pub use self::supervisor::ProcessState;
-use super::Sys;
-use self::config::CfgRenderer;
-use self::hooks::{Hook, HookTable, HOOK_PERMISSIONS};
 use self::supervisor::Supervisor;
-use self::dir::SvcDir;
+use super::Sys;
+use census::{CensusGroup, CensusRing, ElectionStatus, ServiceFile};
 use error::{Error, Result, SupError};
 use fs;
 use manager;
-use census::{CensusGroup, CensusRing, ElectionStatus, ServiceFile};
-use templating::RenderContext;
 use sys::abilities;
+use templating::RenderContext;
 
 static LOGKEY: &'static str = "SR";
 
 pub const GOSSIP_FILE_PERMISSIONS: u32 = 0o640;
 
 lazy_static! {
-    static ref HEALTH_CHECK_INTERVAL: Duration = {
-        Duration::from_millis(30_000)
-    };
+    static ref HEALTH_CHECK_INTERVAL: Duration = { Duration::from_millis(30_000) };
 }
 
 /// When evaluating whether a particular service group can satisfy a

--- a/components/sup/src/manager/service/spec.rs
+++ b/components/sup/src/manager/service/spec.rs
@@ -23,8 +23,8 @@ use std::str::FromStr;
 
 use hcore;
 use hcore::channel::STABLE_CHANNEL;
-use hcore::package::{PackageIdent, PackageInstall};
 use hcore::package::metadata::BindMapping;
+use hcore::package::{PackageIdent, PackageInstall};
 use hcore::service::{ApplicationEnvironment, BindingMode, ServiceGroup};
 use hcore::url::DEFAULT_BLDR_URL;
 use hcore::util::{deserialize_using_from_str, serialize_using_to_string};
@@ -33,8 +33,8 @@ use rand::{thread_rng, Rng};
 use serde::{self, Deserialize};
 use toml;
 
-use super::{Topology, UpdateStrategy};
 use super::composite_spec::CompositeSpec;
+use super::{Topology, UpdateStrategy};
 use error::{Error, Result, SupError};
 
 static LOGKEY: &'static str = "SS";
@@ -566,8 +566,8 @@ fn set_composite_binds(spec: &mut ServiceSpec, bind_map: &mut BindMap, binds: &V
 mod test {
     use std::fs::{self, File};
     use std::io::{BufReader, Read, Write};
-    use std::str::FromStr;
     use std::path::{Path, PathBuf};
+    use std::str::FromStr;
 
     use hcore::error::Error as HError;
     use hcore::package::PackageIdent;

--- a/components/sup/src/manager/service/supervisor.rs
+++ b/components/sup/src/manager/service/supervisor.rs
@@ -12,27 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use hcore::os::process::{self, Pid};
 /// Supervise a service.
 ///
 /// The Supervisor is responsible for running any services we are asked to start. It handles
 /// spawning the new process, watching for failure, and ensuring the service is either up or down.
 /// If the process dies, the Supervisor will restart it.
-
 use std;
 use std::fmt;
 use std::fs::File;
 use std::io::BufReader;
 use std::io::prelude::*;
 use std::path::{Path, PathBuf};
-use hcore::os::process::{self, Pid};
 use std::result;
 
 #[cfg(unix)]
 use hcore::os::users;
 use hcore::service::ServiceGroup;
 use launcher_client::LauncherCli;
-use serde::{Serialize, Serializer};
 use serde::ser::SerializeStruct;
+use serde::{Serialize, Serializer};
 use time::{self, Timespec};
 
 use error::{Error, Result};


### PR DESCRIPTION
Allow errors when loading an initial service via `hab sup run` fails to
propagate to the CLI instead of panicking.