### PR TITLE
Use `cargo clippy` instead of the clippy plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -203,7 +203,7 @@ unit-sup: build-launcher-for-supervisor-tests
 
 define LINT
 lint-$1: image ## executes the $1 component's linter checks
-	$(run) sh -c 'cd components/$1 && cargo build --features clippy $(CARGO_FLAGS)'
+	$(run) sh -c 'cd components/$1 && (cargo install clippy || 1) cargo clippy $(CARGO_FLAGS)'
 .PHONY: lint-$1
 endef
 $(foreach component,$(ALL),$(eval $(call LINT,$(component))))


### PR DESCRIPTION
We don't know how long rustc will keep supporting plugins. So we are removing clippy plugin support in favour of the clippy subcommand