### PR TITLE
Bump to Rust 1.26.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ matrix:
         - COMPONENTS=bin
         - AFFECTED_FILES="Cargo.lock"
         - AFFECTED_DIRS="$_RUST_HAB_BIN_COMPONENTS $_RUST_HAB_LIB_COMPONENTS"
-      rust: 1.25.0
+      rust: 1.26.0
       sudo: false
       services:
         - docker
@@ -73,7 +73,7 @@ matrix:
         - COMPONENTS=lib
         - AFFECTED_FILES="Cargo.lock"
         - AFFECTED_DIRS="$_RUST_HAB_LIB_COMPONENTS"
-      rust: 1.25.0
+      rust: 1.26.0
       sudo: required
       addons:
         apt:

--- a/components/builder-depot-client/src/error.rs
+++ b/components/builder-depot-client/src/error.rs
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 use std::error;
-use std::io;
 use std::fmt;
+use std::io;
 use std::num;
 use std::result;
 

--- a/components/builder-depot-client/src/lib.rs
+++ b/components/builder-depot-client/src/lib.rs
@@ -51,10 +51,10 @@ use chrono::DateTime;
 use hab_core::package::{Identifiable, PackageArchive};
 use hab_http::ApiClient;
 use hab_http::util::decoded_response;
-use hyper::client::{Body, IntoUrl, RequestBuilder, Response};
-use hyper::status::StatusCode;
-use hyper::header::{Accept, Authorization, Bearer, ContentType};
 use hyper::Url;
+use hyper::client::{Body, IntoUrl, RequestBuilder, Response};
+use hyper::header::{Accept, Authorization, Bearer, ContentType};
+use hyper::status::StatusCode;
 use protobuf::core::ProtobufEnum;
 use protocol::{net, originsrv};
 use rand::{thread_rng, Rng};
@@ -560,11 +560,11 @@ impl Client {
         let mut encoded = String::new();
         res.read_to_string(&mut encoded)?;
         debug!("Response body: {:?}", encoded);
-        let revisions: Vec<originsrv::OriginKeyIdent> =
-            serde_json::from_str::<Vec<OriginKeyIdent>>(&encoded)?
-                .into_iter()
-                .map(|m| m.into())
-                .collect();
+        let revisions: Vec<originsrv::OriginKeyIdent> = serde_json::from_str::<Vec<OriginKeyIdent>>(
+            &encoded,
+        )?.into_iter()
+            .map(|m| m.into())
+            .collect();
         Ok(revisions)
     }
 
@@ -1240,8 +1240,8 @@ where
 
 #[cfg(test)]
 mod tests {
-    use serde_json;
     use super::*;
+    use serde_json;
 
     #[test]
     fn json_round_trip_u64_fields() {

--- a/components/butterfly/src/client.rs
+++ b/components/butterfly/src/client.rs
@@ -21,12 +21,12 @@ use habitat_core::service::ServiceGroup;
 use zmq;
 
 use ZMQ_CONTEXT;
+use error::{Error, Result};
 use message;
 use rumor::Rumor;
 use rumor::departure::Departure;
 use rumor::service_config::ServiceConfig;
 use rumor::service_file::ServiceFile;
-use error::{Error, Result};
 
 /// Holds a ZMQ Push socket, and an optional ring encryption key.
 pub struct Client {

--- a/components/butterfly/src/main.rs
+++ b/components/butterfly/src/main.rs
@@ -20,13 +20,13 @@ extern crate habitat_core;
 extern crate log;
 
 use std::env;
-use std::thread;
-use std::time::Duration;
 use std::net::SocketAddr;
 use std::path::PathBuf;
+use std::thread;
+use std::time::Duration;
 
-use habitat_butterfly::{member, server, trace};
 use habitat_butterfly::server::Suitability;
+use habitat_butterfly::{member, server, trace};
 use habitat_core::service::ServiceGroup;
 
 #[derive(Debug)]

--- a/components/butterfly/src/member.rs
+++ b/components/butterfly/src/member.rs
@@ -21,15 +21,15 @@ use std::net::SocketAddr;
 use std::ops::{Deref, DerefMut};
 use std::result;
 use std::str::FromStr;
-use std::sync::{Arc, RwLock};
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, RwLock};
 
 use protobuf::ProtobufEnum;
 use rand::{thread_rng, Rng};
+use serde::ser::SerializeStruct;
+use serde::{Serialize, Serializer};
 use time::SteadyTime;
 use uuid::Uuid;
-use serde::{Serialize, Serializer};
-use serde::ser::SerializeStruct;
 
 use error::Error;
 use message::swim::{Member as ProtoMember, Membership as ProtoMembership,
@@ -698,9 +698,9 @@ impl MemberList {
 #[cfg(test)]
 mod tests {
     mod member {
-        use uuid::Uuid;
-        use message::swim;
         use member::Member;
+        use message::swim;
+        use uuid::Uuid;
 
         // Sets the uuid to simple, and the incarnation to zero.
         #[test]

--- a/components/butterfly/src/message/mod.rs
+++ b/components/butterfly/src/message/mod.rs
@@ -18,8 +18,8 @@ use std::result;
 use std::str;
 
 use habitat_core::crypto::SymKey;
-use serde::{Serialize, Serializer};
 use serde::ser::SerializeStruct;
+use serde::{Serialize, Serializer};
 use toml;
 
 use error::Result;

--- a/components/butterfly/src/rumor/dat_file.rs
+++ b/components/butterfly/src/rumor/dat_file.rs
@@ -488,8 +488,8 @@ impl Header {
 mod tests {
     use std::mem;
 
-    use rand;
     use super::*;
+    use rand;
 
     #[test]
     fn read_write_header() {

--- a/components/butterfly/src/rumor/election.rs
+++ b/components/butterfly/src/rumor/election.rs
@@ -27,8 +27,8 @@ use std::ops::{Deref, DerefMut};
 use habitat_core::service::ServiceGroup;
 use protobuf::{self, Message, RepeatedField};
 
-pub use message::swim::Election_Status;
 use error::Result;
+pub use message::swim::Election_Status;
 use message::swim::{Election as ProtoElection, Rumor as ProtoRumor, Rumor_Type as ProtoRumor_Type};
 use rumor::Rumor;
 
@@ -288,9 +288,9 @@ impl Rumor for ElectionUpdate {
 
 #[cfg(test)]
 mod tests {
+    use habitat_core::service::ServiceGroup;
     use rumor::Rumor;
     use rumor::election::Election;
-    use habitat_core::service::ServiceGroup;
 
     fn create_election(member_id: &str, suitability: u64) -> Election {
         Election::new(

--- a/components/butterfly/src/rumor/mod.rs
+++ b/components/butterfly/src/rumor/mod.rs
@@ -22,31 +22,31 @@
 
 pub mod dat_file;
 pub mod departure;
-pub mod heat;
 pub mod election;
+pub mod heat;
 pub mod service;
 pub mod service_config;
 pub mod service_file;
 
+pub use self::departure::Departure;
 pub use self::election::{Election, ElectionUpdate};
 pub use self::service::Service;
 pub use self::service_config::ServiceConfig;
 pub use self::service_file::ServiceFile;
-pub use self::departure::Departure;
 
 use std::collections::HashMap;
 use std::collections::hash_map::Entry;
 use std::default::Default;
 use std::ops::Deref;
 use std::result;
-use std::sync::{Arc, RwLock};
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, RwLock};
 
-use serde::{Serialize, Serializer};
 use serde::ser::SerializeStruct;
+use serde::{Serialize, Serializer};
 
-use message::swim::Rumor_Type;
 use error::{Error, Result};
+use message::swim::Rumor_Type;
 
 /// The description of a `RumorKey`.
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
@@ -258,9 +258,9 @@ impl<T: Rumor> RumorStore<T> {
 mod tests {
     use uuid::Uuid;
 
-    use rumor::Rumor;
-    use message::swim::Rumor_Type;
     use error::Result;
+    use message::swim::Rumor_Type;
+    use rumor::Rumor;
 
     #[derive(Clone, Debug, Serialize)]
     struct FakeRumor {
@@ -346,8 +346,8 @@ mod tests {
 
     mod rumor_store {
         use super::FakeRumor;
-        use rumor::RumorStore;
         use rumor::Rumor;
+        use rumor::RumorStore;
         use std::usize;
 
         fn create_rumor_store() -> RumorStore<FakeRumor> {

--- a/components/butterfly/src/rumor/service.rs
+++ b/components/butterfly/src/rumor/service.rs
@@ -20,13 +20,13 @@ use std::cmp::Ordering;
 use std::mem;
 use std::ops::{Deref, DerefMut};
 
-use habitat_core::service::ServiceGroup;
 use habitat_core::package::Identifiable;
+use habitat_core::service::ServiceGroup;
 use protobuf::{self, Message};
 use toml;
 
-pub use message::swim::SysInfo;
 use error::Result;
+pub use message::swim::SysInfo;
 use message::swim::{Rumor as ProtoRumor, Rumor_Type as ProtoRumor_Type, Service as ProtoService};
 use rumor::Rumor;
 
@@ -162,8 +162,8 @@ mod tests {
     use std::cmp::Ordering;
     use std::str::FromStr;
 
-    use habitat_core::service::ServiceGroup;
     use habitat_core::package::{Identifiable, PackageIdent};
+    use habitat_core::service::ServiceGroup;
 
     use super::Service;
     use rumor::Rumor;

--- a/components/butterfly/src/server/expire.rs
+++ b/components/butterfly/src/server/expire.rs
@@ -22,8 +22,8 @@ use std::time::Duration;
 
 use time::SteadyTime;
 
-use message::swim::Rumor_Type;
 use member::Health;
+use message::swim::Rumor_Type;
 use rumor::RumorKey;
 use server::Server;
 use server::timing::Timing;

--- a/components/butterfly/src/server/inbound.rs
+++ b/components/butterfly/src/server/inbound.rs
@@ -16,9 +16,9 @@
 //!
 //! This module handles all the inbound SWIM messages.
 
-use std::sync::mpsc;
-use std::sync::atomic::Ordering;
 use std::net::{SocketAddr, UdpSocket};
+use std::sync::atomic::Ordering;
+use std::sync::mpsc;
 use std::thread;
 use std::time::Duration;
 

--- a/components/butterfly/src/server/mod.rs
+++ b/components/butterfly/src/server/mod.rs
@@ -35,28 +35,28 @@ use std::net::{SocketAddr, ToSocketAddrs, UdpSocket};
 use std::path::PathBuf;
 use std::result;
 use std::str::FromStr;
-use std::sync::{Arc, RwLock};
 use std::sync::atomic::{AtomicBool, AtomicIsize, Ordering};
 use std::sync::mpsc::channel;
-use std::time::{Duration, Instant};
+use std::sync::{Arc, RwLock};
 use std::thread;
+use std::time::{Duration, Instant};
 
-use habitat_core::service::ServiceGroup;
 use habitat_core::crypto::SymKey;
-use serde::{Serialize, Serializer};
+use habitat_core::service::ServiceGroup;
 use serde::ser::SerializeStruct;
+use serde::{Serialize, Serializer};
 
 use error::{Error, Result};
 use member::{Health, Member, MemberList};
 use message;
-use rumor::{Rumor, RumorKey, RumorStore};
-use rumor::heat::RumorHeat;
 use rumor::dat_file::DatFile;
 use rumor::departure::Departure;
+use rumor::election::{Election, ElectionUpdate};
+use rumor::heat::RumorHeat;
 use rumor::service::Service;
 use rumor::service_config::ServiceConfig;
 use rumor::service_file::ServiceFile;
-use rumor::election::{Election, ElectionUpdate};
+use rumor::{Rumor, RumorKey, RumorStore};
 use trace::{Trace, TraceKind};
 
 pub trait Suitability: Debug + Send + Sync {
@@ -1037,12 +1037,12 @@ fn persist_loop(server: Server) {
 mod tests {
     mod server {
         use habitat_core::service::ServiceGroup;
-        use server::{Server, Suitability};
-        use server::timing::Timing;
         use member::Member;
-        use trace::Trace;
+        use server::timing::Timing;
+        use server::{Server, Suitability};
         use std::path::PathBuf;
         use std::sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
+        use trace::Trace;
 
         static SWIM_PORT: AtomicUsize = ATOMIC_USIZE_INIT;
         static GOSSIP_PORT: AtomicUsize = ATOMIC_USIZE_INIT;

--- a/components/butterfly/src/server/outbound.rs
+++ b/components/butterfly/src/server/outbound.rs
@@ -16,21 +16,21 @@
 //!
 //! This module handles the implementation of the swim probe protocol.
 
+use std::fmt;
+use std::net::{SocketAddr, UdpSocket};
 use std::sync::atomic::Ordering;
 use std::sync::mpsc;
-use std::net::{SocketAddr, UdpSocket};
 use std::thread;
 use std::time::Duration;
-use std::fmt;
 
-use time::SteadyTime;
 use protobuf::{Message, RepeatedField};
+use time::SteadyTime;
 
+use member::{Health, Member};
 use message::swim::{Ack, Ping, PingReq, Rumor_Type, Swim, Swim_Type};
 use rumor::RumorKey;
 use server::Server;
 use server::timing::Timing;
-use member::{Health, Member};
 use trace::TraceKind;
 
 /// How long to sleep between calls to `recv`.

--- a/components/butterfly/src/server/pull.rs
+++ b/components/butterfly/src/server/pull.rs
@@ -24,8 +24,8 @@ use protobuf;
 use zmq;
 
 use ZMQ_CONTEXT;
-use server::Server;
 use message::swim::{Rumor, Rumor_Type};
+use server::Server;
 use trace::TraceKind;
 
 /// Takes a reference to the server itself

--- a/components/butterfly/src/server/push.rs
+++ b/components/butterfly/src/server/push.rs
@@ -26,10 +26,10 @@ use time::SteadyTime;
 use zmq;
 
 use ZMQ_CONTEXT;
+use member::Member;
 use message::swim::{Member as ProtoMember, Membership as ProtoMembership, Rumor as ProtoRumor,
                     Rumor_Type as ProtoRumor_Type};
 use rumor::RumorKey;
-use member::Member;
 use server::Server;
 use server::timing::Timing;
 use trace::TraceKind;

--- a/components/butterfly/tests/integration.rs
+++ b/components/butterfly/tests/integration.rs
@@ -19,8 +19,8 @@ extern crate habitat_butterfly_test as btest;
 extern crate habitat_core;
 extern crate time;
 
-mod rumor;
 mod encryption;
+mod rumor;
 
 use habitat_butterfly::member::Health;
 

--- a/components/butterfly/tests/rumor/departure.rs
+++ b/components/butterfly/tests/rumor/departure.rs
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 use btest;
-use habitat_butterfly::member::Health;
 use habitat_butterfly::client::Client;
+use habitat_butterfly::member::Health;
 
 #[test]
 fn two_members_share_departures() {

--- a/components/butterfly/tests/rumor/mod.rs
+++ b/components/butterfly/tests/rumor/mod.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub mod departure;
+pub mod election;
 pub mod service;
 pub mod service_config;
 pub mod service_file;
-pub mod election;
-pub mod departure;

--- a/components/butterfly/tests/rumor/service_config.rs
+++ b/components/butterfly/tests/rumor/service_config.rs
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 use btest;
-use habitat_core::service::ServiceGroup;
 use habitat_butterfly::client::Client;
+use habitat_core::service::ServiceGroup;
 
 #[test]
 fn two_members_share_service_config() {

--- a/components/butterfly/tests/rumor/service_file.rs
+++ b/components/butterfly/tests/rumor/service_file.rs
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 use btest;
-use habitat_core::service::ServiceGroup;
 use habitat_butterfly::client::Client;
+use habitat_core::service::ServiceGroup;
 
 #[test]
 fn two_members_share_service_files() {

--- a/components/common/src/command/package/binds.rs
+++ b/components/common/src/command/package/binds.rs
@@ -26,8 +26,8 @@ use std::io::{self, Write};
 use std::path::Path;
 
 use hcore;
-use hcore::package::{PackageIdent, PackageInstall};
 use hcore::package::metadata::Bind;
+use hcore::package::{PackageIdent, PackageInstall};
 
 use error::Result;
 

--- a/components/common/src/command/package/config.rs
+++ b/components/common/src/command/package/config.rs
@@ -25,8 +25,8 @@
 use std::io::{self, Write};
 use std::path::Path;
 
-use hcore::package::{PackageIdent, PackageInstall};
 use hcore::package::install::DEFAULT_CFG_FILE;
+use hcore::package::{PackageIdent, PackageInstall};
 use toml;
 
 use error::Result;

--- a/components/common/src/command/package/install.rs
+++ b/components/common/src/command/package/install.rs
@@ -39,18 +39,18 @@ use std::borrow::Cow;
 use std::fmt;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::str::FromStr;
 use std::result::Result as StdResult;
+use std::str::FromStr;
 
-use depot_client::{self, Client};
 use depot_client::Error::APIError;
+use depot_client::{self, Client};
 use glob;
 use hcore;
-use hcore::fs::cache_key_path;
-use hcore::crypto::{artifact, SigKeyPair};
 use hcore::crypto::keys::parse_name_with_rev;
-use hcore::package::{Identifiable, PackageArchive, PackageIdent, PackageInstall, Target};
+use hcore::crypto::{artifact, SigKeyPair};
+use hcore::fs::cache_key_path;
 use hcore::package::metadata::PackageType;
+use hcore::package::{Identifiable, PackageArchive, PackageIdent, PackageInstall, Target};
 use hyper::status::StatusCode;
 
 use error::{Error, Result};

--- a/components/common/src/error.rs
+++ b/components/common/src/error.rs
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::env;
 use std::error;
-use std::io;
 use std::fmt;
+use std::io;
 use std::result;
 use std::str;
 use std::string;
-use std::env;
 use toml;
 
 use depot_client;

--- a/components/common/src/ui.rs
+++ b/components/common/src/ui.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::env;
 use std::fmt;
 use std::fs::{self, File};
 use std::io::{self, BufRead, BufReader, Read, Stdout, Write};
 use std::process::{self, Command};
-use std::env;
 use uuid::Uuid;
 
 use ansi_term::Colour;
@@ -25,8 +25,8 @@ use pbr;
 use term::terminfo::TermInfo;
 use term::{Terminal, TerminfoTerminal};
 
-use error::{Error, Result};
 use self::tty::StdStream;
+use error::{Error, Result};
 
 pub const NONINTERACTIVE_ENVVAR: &'static str = "HAB_NONINTERACTIVE";
 
@@ -138,7 +138,7 @@ pub trait UIWriter {
                 "{}\n",
                 Colour::Yellow
                     .bold()
-                    .paint(format!("{} {}", symbol, message),)
+                    .paint(format!("{} {}", symbol, message))
             )
         } else {
             format!("{} {}\n", symbol, message)

--- a/components/eventsrv-client/src/lib.rs
+++ b/components/eventsrv-client/src/lib.rs
@@ -22,9 +22,9 @@ extern crate zmq;
 
 pub mod message;
 
-pub use protocol::EventSrvAddr;
 use protobuf::Message;
 use protocol::EventEnvelope;
+pub use protocol::EventSrvAddr;
 
 pub struct EventSrvClient(zmq::Socket);
 

--- a/components/eventsrv-protocol/src/lib.rs
+++ b/components/eventsrv-protocol/src/lib.rs
@@ -19,8 +19,8 @@ extern crate serde_derive;
 
 mod message;
 
-use std::net::{IpAddr, Ipv4Addr};
 pub use message::event::*;
+use std::net::{IpAddr, Ipv4Addr};
 
 pub const DEFAULT_CONSUMER_PORT: u16 = 9689;
 pub const DEFAULT_PRODUCER_PORT: u16 = 9688;

--- a/components/hab/src/command/bldr/channel/create.rs
+++ b/components/hab/src/command/bldr/channel/create.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use depot_client::Client as DepotClient;
 use common::ui::{Status, UIWriter, UI};
+use depot_client::Client as DepotClient;
 
-use {PRODUCT, VERSION};
 use error::{Error, Result};
+use {PRODUCT, VERSION};
 
 pub fn start(ui: &mut UI, bldr_url: &str, token: &str, origin: &str, channel: &str) -> Result<()> {
     let depot_client =

--- a/components/hab/src/command/bldr/channel/destroy.rs
+++ b/components/hab/src/command/bldr/channel/destroy.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use depot_client::Client as DepotClient;
 use common::ui::{Status, UIWriter, UI};
+use depot_client::Client as DepotClient;
 
-use {PRODUCT, VERSION};
 use error::{Error, Result};
+use {PRODUCT, VERSION};
 
 pub fn start(ui: &mut UI, bldr_url: &str, token: &str, origin: &str, channel: &str) -> Result<()> {
     let depot_client =

--- a/components/hab/src/command/bldr/channel/list.rs
+++ b/components/hab/src/command/bldr/channel/list.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use depot_client::Client as DepotClient;
 use common::ui::{Status, UIWriter, UI};
+use depot_client::Client as DepotClient;
 
-use {PRODUCT, VERSION};
 use error::{Error, Result};
+use {PRODUCT, VERSION};
 
 pub fn start(ui: &mut UI, bldr_url: &str, origin: &str) -> Result<()> {
     let depot_client =

--- a/components/hab/src/command/bldr/job/cancel.rs
+++ b/components/hab/src/command/bldr/job/cancel.rs
@@ -15,8 +15,8 @@
 use api_client;
 use common::ui::{Status, UIReader, UIWriter, UI};
 
-use {PRODUCT, VERSION};
 use error::{Error, Result};
+use {PRODUCT, VERSION};
 
 pub fn start(ui: &mut UI, bldr_url: &str, group_id: &str, token: &str) -> Result<()> {
     // TODO (SA): Show all the in-progress builds that will get canceled

--- a/components/hab/src/command/bldr/job/promote.rs
+++ b/components/hab/src/command/bldr/job/promote.rs
@@ -12,16 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use hyper::status::StatusCode;
 use hcore::package::PackageIdent;
+use hyper::status::StatusCode;
 use std::str::FromStr;
 
 use api_client;
-use depot_client::{self, SchedulerResponse};
 use common::ui::{Status, UIReader, UIWriter, UI};
+use depot_client::{self, SchedulerResponse};
 
-use {PRODUCT, VERSION};
 use error::{Error, Result};
+use {PRODUCT, VERSION};
 
 fn is_ident(s: &str) -> bool {
     PackageIdent::from_str(s).is_ok()
@@ -177,9 +177,9 @@ mod test {
     use std::io::{self, Cursor, Write};
     use std::sync::{Arc, RwLock};
 
+    use super::get_ident_list;
     use common::ui::{Coloring, UI};
     use depot_client::{Project, SchedulerResponse};
-    use super::get_ident_list;
 
     fn sample_project_list() -> Vec<Project> {
         let project1 = Project {

--- a/components/hab/src/command/bldr/job/start.rs
+++ b/components/hab/src/command/bldr/job/start.rs
@@ -13,12 +13,12 @@
 // limitations under the License.
 
 use api_client::Client as ApiClient;
-use depot_client::Client as DepotClient;
 use common::ui::{Status, UIReader, UIWriter, UI};
+use depot_client::Client as DepotClient;
 use hcore::package::PackageIdent;
 
-use {PRODUCT, VERSION};
 use error::{Error, Result};
+use {PRODUCT, VERSION};
 
 pub fn start(
     ui: &mut UI,

--- a/components/hab/src/command/bldr/job/status.rs
+++ b/components/hab/src/command/bldr/job/status.rs
@@ -18,8 +18,8 @@ use common::ui::{Status, UIWriter, UI};
 use depot_client;
 use tabwriter::TabWriter;
 
-use {PRODUCT, VERSION};
 use error::{Error, Result};
+use {PRODUCT, VERSION};
 
 pub fn start(
     ui: &mut UI,

--- a/components/hab/src/command/cli/setup.rs
+++ b/components/hab/src/command/cli/setup.rs
@@ -15,16 +15,16 @@
 use std::path::Path;
 
 use common::ui::{UIReader, UIWriter, UI};
+use hcore::Error::InvalidOrigin;
 use hcore::crypto::SigKeyPair;
 use hcore::env;
 use hcore::package::ident;
-use hcore::Error::InvalidOrigin;
 
-use {AUTH_TOKEN_ENVVAR, CTL_SECRET_ENVVAR, ORIGIN_ENVVAR};
 use analytics;
 use command;
 use config;
 use error::Result;
+use {AUTH_TOKEN_ENVVAR, CTL_SECRET_ENVVAR, ORIGIN_ENVVAR};
 
 pub fn start(ui: &mut UI, cache_path: &Path, analytics_path: &Path) -> Result<()> {
     let mut generated_origin = false;

--- a/components/hab/src/command/launcher.rs
+++ b/components/hab/src/command/launcher.rs
@@ -36,9 +36,9 @@ mod inner {
     use hcore::package::PackageIdent;
 
     use super::super::sup::{SUP_CMD, SUP_CMD_ENVVAR, SUP_PKG_IDENT};
+    use VERSION;
     use error::{Error, Result};
     use exec;
-    use VERSION;
 
     const LAUNCH_CMD: &'static str = "hab-launch";
     const LAUNCH_CMD_ENVVAR: &'static str = "HAB_LAUNCH_BINARY";

--- a/components/hab/src/command/mod.rs
+++ b/components/hab/src/command/mod.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub mod bldr;
 pub mod cli;
 pub mod launcher;
 pub mod origin;
@@ -22,4 +23,3 @@ pub mod service;
 pub mod studio;
 pub mod sup;
 pub mod user;
-pub mod bldr;

--- a/components/hab/src/command/origin/key/download.rs
+++ b/components/hab/src/command/origin/key/download.rs
@@ -14,13 +14,13 @@
 
 use std::path::Path;
 
+use common::command::package::install::{RETRIES, RETRY_WAIT};
 use common::ui::{Status, UIWriter, UI};
 use depot_client::{self, Client};
 use hcore::crypto::SigKeyPair;
-use common::command::package::install::{RETRIES, RETRY_WAIT};
 
-use {PRODUCT, VERSION};
 use error::{Error, Result};
+use {PRODUCT, VERSION};
 
 use retry::retry;
 

--- a/components/hab/src/command/origin/key/export.rs
+++ b/components/hab/src/command/origin/key/export.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::io;
 use std::fs::File;
+use std::io;
 use std::path::Path;
 
 use hcore::crypto::SigKeyPair;

--- a/components/hab/src/command/origin/key/generate.rs
+++ b/components/hab/src/command/origin/key/generate.rs
@@ -15,9 +15,9 @@
 use std::path::Path;
 
 use common::ui::{UIWriter, UI};
+use hcore::Error::InvalidOrigin;
 use hcore::crypto::SigKeyPair;
 use hcore::package::ident;
-use hcore::Error::InvalidOrigin;
 
 use error::{Error, Result};
 

--- a/components/hab/src/command/origin/key/mod.rs
+++ b/components/hab/src/command/origin/key/mod.rs
@@ -16,8 +16,8 @@ pub mod download;
 pub mod export;
 pub mod generate;
 pub mod import;
-pub mod upload_latest;
 pub mod upload;
+pub mod upload_latest;
 
 use std::fs::File;
 use std::io::{BufRead, BufReader};

--- a/components/hab/src/command/origin/key/upload.rs
+++ b/components/hab/src/command/origin/key/upload.rs
@@ -14,8 +14,8 @@
 
 use std::path::Path;
 
-use common::ui::{Status, UIWriter, UI};
 use common::command::package::install::{RETRIES, RETRY_WAIT};
+use common::ui::{Status, UIWriter, UI};
 use depot_client::{self, Client};
 use hcore::crypto::keys::parse_name_with_rev;
 use hcore::crypto::{PUBLIC_SIG_KEY_VERSION, SECRET_SIG_KEY_VERSION};
@@ -23,8 +23,8 @@ use hyper::status::StatusCode;
 use retry::retry;
 
 use super::get_name_with_rev;
-use {PRODUCT, VERSION};
 use error::{Error, Result};
+use {PRODUCT, VERSION};
 
 pub fn start(
     ui: &mut UI,

--- a/components/hab/src/command/origin/secret/delete.rs
+++ b/components/hab/src/command/origin/secret/delete.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use depot_client::Client as DepotClient;
 use common::ui::{Status, UIWriter, UI};
+use depot_client::Client as DepotClient;
 
-use {PRODUCT, VERSION};
 use error::{Error, Result};
+use {PRODUCT, VERSION};
 
 pub fn start(ui: &mut UI, bldr_url: &str, token: &str, origin: &str, key: &str) -> Result<()> {
     let depot_client =

--- a/components/hab/src/command/origin/secret/list.rs
+++ b/components/hab/src/command/origin/secret/list.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use depot_client::Client as DepotClient;
 use common::ui::{Status, UIWriter, UI};
+use depot_client::Client as DepotClient;
 
-use {PRODUCT, VERSION};
 use error::{Error, Result};
+use {PRODUCT, VERSION};
 
 pub fn start(ui: &mut UI, bldr_url: &str, token: &str, origin: &str) -> Result<()> {
     let depot_client =

--- a/components/hab/src/command/origin/secret/mod.rs
+++ b/components/hab/src/command/origin/secret/mod.rs
@@ -12,6 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod upload;
 pub mod delete;
 pub mod list;
+pub mod upload;

--- a/components/hab/src/command/origin/secret/upload.rs
+++ b/components/hab/src/command/origin/secret/upload.rs
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use depot_client::Client as DepotClient;
-use common::ui::{Status, UIWriter, UI};
 use super::super::key::download::download_public_encryption_key;
+use common::ui::{Status, UIWriter, UI};
+use depot_client::Client as DepotClient;
 
-use hcore::crypto::BoxKeyPair;
-use {PRODUCT, VERSION};
 use error::{Error, Result};
+use hcore::crypto::BoxKeyPair;
 use std::path::Path;
+use {PRODUCT, VERSION};
 
 pub fn start(
     ui: &mut UI,

--- a/components/hab/src/command/pkg/binlink.rs
+++ b/components/hab/src/command/pkg/binlink.rs
@@ -16,9 +16,9 @@ use std::fs;
 use std::path::Path;
 
 use common::ui::{Status, UIWriter, UI};
-use hcore::package::{PackageIdent, PackageInstall};
-use hcore::os::filesystem;
 use hcore::fs as hfs;
+use hcore::os::filesystem;
+use hcore::package::{PackageIdent, PackageInstall};
 
 use error::{Error, Result};
 
@@ -129,10 +129,10 @@ where
 #[cfg(test)]
 mod test {
     use std::collections::HashMap;
-    use std::io::{self, Cursor, Write};
     use std::fs::{self, File};
-    use std::str::{self, FromStr};
+    use std::io::{self, Cursor, Write};
     use std::path::Path;
+    use std::str::{self, FromStr};
     use std::sync::{Arc, RwLock};
 
     use common::ui::{Coloring, UI};

--- a/components/hab/src/command/pkg/build.rs
+++ b/components/hab/src/command/pkg/build.rs
@@ -16,8 +16,8 @@ use std::ffi::OsString;
 
 use common::ui::UI;
 
-use error::Result;
 use command::studio;
+use error::Result;
 
 pub fn start(
     ui: &mut UI,

--- a/components/hab/src/command/pkg/channels.rs
+++ b/components/hab/src/command/pkg/channels.rs
@@ -31,8 +31,8 @@ use common::ui::{UIWriter, UI};
 use depot_client::Client;
 use hcore::package::PackageIdent;
 
-use {PRODUCT, VERSION};
 use error::Result;
+use {PRODUCT, VERSION};
 
 /// Return a list of channels that a package is in.
 ///

--- a/components/hab/src/command/pkg/demote.rs
+++ b/components/hab/src/command/pkg/demote.rs
@@ -30,8 +30,8 @@ use common::ui::{Status, UIWriter, UI};
 use depot_client::Client;
 use hcore::package::PackageIdent;
 
-use {PRODUCT, VERSION};
 use error::{Error, Result};
+use {PRODUCT, VERSION};
 
 /// Demote a package from the specified channel.
 ///

--- a/components/hab/src/command/pkg/exec.rs
+++ b/components/hab/src/command/pkg/exec.rs
@@ -16,9 +16,9 @@ use std::env;
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 
+use hcore::fs::{find_command, FS_ROOT_PATH};
 use hcore::os::process;
 use hcore::package::{PackageIdent, PackageInstall};
-use hcore::fs::{find_command, FS_ROOT_PATH};
 
 use error::{Error, Result};
 

--- a/components/hab/src/command/pkg/export/export_common.rs
+++ b/components/hab/src/command/pkg/export/export_common.rs
@@ -49,9 +49,9 @@ mod inner {
     use hcore::os::process;
     use hcore::package::PackageIdent;
 
+    use VERSION;
     use error::{Error, Result};
     use exec;
-    use VERSION;
 
     pub fn start(
         ui: &mut UI,

--- a/components/hab/src/command/pkg/export/mod.rs
+++ b/components/hab/src/command/pkg/export/mod.rs
@@ -17,8 +17,8 @@ use hcore::package::PackageIdent;
 
 use error::Result;
 
-pub mod docker;
 pub mod cf;
+pub mod docker;
 pub mod helm;
 pub mod kubernetes;
 pub mod tar;
@@ -63,17 +63,17 @@ mod inner {
     use std::str::FromStr;
 
     use common::ui::UI;
-    use hcore::crypto::{default_cache_key_path, init};
-    use hcore::url::BLDR_URL_ENVVAR;
     use hcore::channel::BLDR_CHANNEL_ENVVAR;
+    use hcore::crypto::{default_cache_key_path, init};
     use hcore::fs::find_command;
     use hcore::package::PackageIdent;
+    use hcore::url::BLDR_URL_ENVVAR;
 
+    use super::ExportFormat;
     use VERSION;
     use command;
     use error::{Error, Result};
     use exec;
-    use super::ExportFormat;
 
     pub fn format_for(_ui: &mut UI, value: &str) -> Result<ExportFormat> {
         let version: Vec<_> = VERSION.split("/").collect();
@@ -132,11 +132,11 @@ mod inner {
 
 #[cfg(not(target_os = "linux"))]
 mod inner {
-    use error::{Error, Result};
+    use super::ExportFormat;
     use common::ui::{UIWriter, UI};
+    use error::{Error, Result};
     use hcore::package::PackageIdent;
     use std::env;
-    use super::ExportFormat;
 
     pub fn format_for(ui: &mut UI, value: &str) -> Result<ExportFormat> {
         ui.warn(format!(

--- a/components/hab/src/command/pkg/export/tar.rs
+++ b/components/hab/src/command/pkg/export/tar.rs
@@ -37,10 +37,10 @@ mod inner {
     use hcore::os::process;
     use hcore::package::PackageIdent;
 
+    use super::EXPORT_CMD;
+    use VERSION;
     use error::{Error, Result};
     use exec;
-    use VERSION;
-    use super::EXPORT_CMD;
 
     const EXPORT_CMD_ENVVAR: &'static str = "HAB_PKG_EXPORT_TAR_BINARY";
     const EXPORT_PKG_IDENT: &'static str = "core/hab-pkg-export-tar";
@@ -82,8 +82,8 @@ mod inner {
 
     use common::ui::{UIWriter, UI};
 
-    use error::{Error, Result};
     use super::EXPORT_CMD;
+    use error::{Error, Result};
 
     pub fn start(ui: &mut UI, _args: Vec<OsString>) -> Result<()> {
         let cmd = EXPORT_CMD.replace("hab", "").replace("-", " ");

--- a/components/hab/src/command/pkg/info.rs
+++ b/components/hab/src/command/pkg/info.rs
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::path::Path;
 use common::ui::{UIWriter, UI};
-use std::io::{self, Write};
-use hcore::package::PackageArchive;
 use error::Result;
+use hcore::package::PackageArchive;
 use serde::Serialize;
 use serde_json::{self, Value as Json};
+use std::io::{self, Write};
+use std::path::Path;
 
 fn convert_to_json<T>(src: &T) -> Json
 where

--- a/components/hab/src/command/pkg/promote.rs
+++ b/components/hab/src/command/pkg/promote.rs
@@ -31,8 +31,8 @@ use depot_client::{self, Client};
 use hcore::package::PackageIdent;
 use hyper::status::StatusCode;
 
-use {PRODUCT, VERSION};
 use error::{Error, Result};
+use {PRODUCT, VERSION};
 
 /// Promote a package to the specified channel.
 ///

--- a/components/hab/src/command/pkg/search.rs
+++ b/components/hab/src/command/pkg/search.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use error::Result;
 use depot_client::Client;
+use error::Result;
 use {PRODUCT, VERSION};
 
 pub fn start(st: &str, url: &str, token: Option<&str>) -> Result<()> {

--- a/components/hab/src/command/plan/init.rs
+++ b/components/hab/src/command/plan/init.rs
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
 use std::env;
 use std::fs::create_dir_all;
 use std::fs::{canonicalize, File, OpenOptions};
 use std::io::{BufRead, BufReader, Write};
 use std::path::Path;
-use std::collections::HashMap;
 
 use handlebars::Handlebars;
 use hcore::package::PackageIdent;

--- a/components/hab/src/command/ring/key/export.rs
+++ b/components/hab/src/command/ring/key/export.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::io;
 use std::fs::File;
+use std::io;
 use std::path::Path;
 
 use hcore::crypto::SymKey;

--- a/components/hab/src/command/studio/docker.rs
+++ b/components/hab/src/command/studio/docker.rs
@@ -17,15 +17,15 @@ use std::ffi::{OsStr, OsString};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
+use command::studio::enter::ARTIFACT_PATH_ENVVAR;
 use common::ui::UI;
 use hcore::crypto::default_cache_key_path;
 use hcore::env as henv;
 use hcore::fs::{find_command, CACHE_ARTIFACT_PATH, CACHE_KEY_PATH};
 use hcore::os::process;
-use command::studio::enter::ARTIFACT_PATH_ENVVAR;
 
-use error::{Error, Result};
 use VERSION;
+use error::{Error, Result};
 
 const DOCKER_CMD: &'static str = "docker";
 const DOCKER_CMD_ENVVAR: &'static str = "HAB_DOCKER_BINARY";

--- a/components/hab/src/command/studio/enter.rs
+++ b/components/hab/src/command/studio/enter.rs
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 use std::env;
-use std::fs as stdfs;
 use std::ffi::OsString;
+use std::fs as stdfs;
 use std::path::PathBuf;
 
 use common::ui::UI;
@@ -76,12 +76,12 @@ mod inner {
     use hcore::env as henv;
     use hcore::fs::{am_i_root, find_command};
     use hcore::os::process;
-    use hcore::users::linux as group;
     use hcore::package::PackageIdent;
+    use hcore::users::linux as group;
 
+    use VERSION;
     use error::{Error, Result};
     use exec;
-    use VERSION;
 
     use command::studio::docker;
 
@@ -193,10 +193,10 @@ mod inner {
     use hcore::os::process;
     use hcore::package::PackageIdent;
 
-    use error::{Error, Result};
-    use exec;
     use VERSION;
     use command::studio::docker;
+    use error::{Error, Result};
+    use exec;
 
     pub fn start(_ui: &mut UI, args: Vec<OsString>) -> Result<()> {
         if is_windows_studio(&args) {

--- a/components/hab/src/command/studio/mod.rs
+++ b/components/hab/src/command/studio/mod.rs
@@ -12,5 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod enter;
 pub mod docker;
+pub mod enter;

--- a/components/hab/src/command/sup.rs
+++ b/components/hab/src/command/sup.rs
@@ -40,9 +40,9 @@ mod inner {
     use hcore::package::PackageIdent;
 
     use super::{SUP_CMD, SUP_CMD_ENVVAR, SUP_PKG_IDENT};
+    use VERSION;
     use error::{Error, Result};
     use exec;
-    use VERSION;
 
     pub fn start(ui: &mut UI, args: Vec<OsString>) -> Result<()> {
         let command = match henv::var(SUP_CMD_ENVVAR) {

--- a/components/hab/src/error.rs
+++ b/components/hab/src/error.rs
@@ -22,13 +22,13 @@ use std::path::{self, PathBuf};
 use std::result;
 
 use api_client;
-use depot_client;
 use common;
-use hcore;
+use depot_client;
 use handlebars;
-use toml;
+use hcore;
 use protocol::net;
 use sup_client::SrvClientError;
+use toml;
 
 pub type Result<T> = result::Result<T, Error>;
 

--- a/components/hab/src/exec.rs
+++ b/components/hab/src/exec.rs
@@ -15,16 +15,16 @@
 use std::path::{Path, PathBuf};
 
 use common;
-use common::ui::{Status, UIWriter, UI};
 use common::command::package::install::InstallMode;
-use hcore::{self, channel};
+use common::ui::{Status, UIWriter, UI};
 use hcore::env as henv;
 use hcore::fs::{self, cache_artifact_path};
 use hcore::package::{PackageIdent, PackageInstall};
 use hcore::url::default_bldr_url;
+use hcore::{self, channel};
 
-use {PRODUCT, VERSION};
 use error::{Error, Result};
+use {PRODUCT, VERSION};
 
 const MAX_RETRIES: u8 = 4;
 const INTERNAL_TOOLING_CHANNEL_ENVVAR: &'static str = "HAB_INTERNAL_BLDR_CHANNEL";

--- a/components/hab/src/lib.rs
+++ b/components/hab/src/lib.rs
@@ -56,8 +56,8 @@ pub mod cli;
 pub mod command;
 pub mod config;
 pub mod error;
-pub mod scaffolding;
 mod exec;
+pub mod scaffolding;
 
 pub const PRODUCT: &'static str = "hab";
 pub const VERSION: &'static str = include_str!(concat!(env!("OUT_DIR"), "/VERSION"));

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -38,8 +38,8 @@ extern crate tabwriter;
 use std::env;
 use std::ffi::OsString;
 use std::fs::File;
-use std::io::{self, Read};
 use std::io::prelude::*;
+use std::io::{self, Read};
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::process;
@@ -51,31 +51,31 @@ use clap::{ArgMatches, Shell};
 use common::command::package::install::{InstallMode, InstallSource};
 use common::ui::{Coloring, Status, UIWriter, NONINTERACTIVE_ENVVAR, UI};
 use futures::prelude::*;
+use hcore::binlink::default_binlink_dir;
 use hcore::channel;
-use hcore::crypto::{default_cache_key_path, init, BoxKeyPair, SigKeyPair};
-use hcore::crypto::keys::PairType;
 #[cfg(windows)]
 use hcore::crypto::dpapi::encrypt;
+use hcore::crypto::keys::PairType;
+use hcore::crypto::{default_cache_key_path, init, BoxKeyPair, SigKeyPair};
 use hcore::env as henv;
 use hcore::fs::{cache_analytics_path, cache_artifact_path, cache_key_path};
 use hcore::package::PackageIdent;
 use hcore::service::ServiceGroup;
 use hcore::url::{bldr_url_from_env, default_bldr_url};
-use hcore::binlink::default_binlink_dir;
-use sup_client::{SrvClient, SrvClientError};
 use protocol::codec::*;
 use protocol::net::ErrCode;
 use protocol::types::*;
+use sup_client::{SrvClient, SrvClientError};
 use tabwriter::TabWriter;
 
-use hab::{AUTH_TOKEN_ENVVAR, CTL_SECRET_ENVVAR, ORIGIN_ENVVAR, PRODUCT, VERSION};
 use hab::analytics;
 use hab::cli;
 use hab::command;
 use hab::config::{self, Config};
+use hab::error::{Error, Result};
 use hab::feat;
 use hab::scaffolding;
-use hab::error::{Error, Result};
+use hab::{AUTH_TOKEN_ENVVAR, CTL_SECRET_ENVVAR, ORIGIN_ENVVAR, PRODUCT, VERSION};
 
 /// Makes the --org CLI param optional when this env var is set
 const HABITAT_ORG_ENVVAR: &'static str = "HAB_ORG";

--- a/components/hab/src/scaffolding.rs
+++ b/components/hab/src/scaffolding.rs
@@ -11,16 +11,16 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-use std::str::FromStr;
-use std::path::Path;
-use std::io;
 use std::fs;
+use std::io;
+use std::path::Path;
+use std::str::FromStr;
 
 use error::Result;
 
+use common::ui::{Status, UIWriter, UI};
 use hcore::crypto::init;
 use hcore::package::PackageIdent;
-use common::ui::{Status, UIWriter, UI};
 
 const SCAFFOLDING_GO_IDENT: &'static str = "core/scaffolding-go";
 const SCAFFOLDING_GRADLE_IDENT: &'static str = "core/scaffolding-gradle";

--- a/components/launcher-client/src/lib.rs
+++ b/components/launcher-client/src/lib.rs
@@ -17,8 +17,8 @@ extern crate habitat_launcher_protocol as protocol;
 extern crate ipc_channel;
 extern crate protobuf;
 
-pub mod error;
 mod client;
+pub mod error;
 
 pub use protocol::{ERR_NO_RETRY_EXCODE, LAUNCHER_LOCK_CLEAN_ENV, LAUNCHER_PID_ENV,
                    OK_NO_RETRY_EXCODE};

--- a/components/launcher-protocol/src/lib.rs
+++ b/components/launcher-protocol/src/lib.rs
@@ -22,8 +22,8 @@ use protobuf::Message;
 
 pub use message::error::*;
 pub use message::launcher::*;
-pub use message::supervisor::*;
 use message::net::*;
+pub use message::supervisor::*;
 
 pub const LAUNCHER_PIPE_ENV: &'static str = "HAB_LAUNCHER_PIPE";
 pub const LAUNCHER_PID_ENV: &'static str = "HAB_LAUNCHER_PID";

--- a/components/launcher/src/server/mod.rs
+++ b/components/launcher/src/server/mod.rs
@@ -22,23 +22,23 @@ use std::thread;
 use std::time::Duration;
 
 #[cfg(unix)]
-use std::process::ExitStatus;
-#[cfg(unix)]
 use std::os::unix::process::ExitStatusExt;
+#[cfg(unix)]
+use std::process::ExitStatus;
 
 use core;
-use core::package::{PackageIdent, PackageInstall};
 use core::os::process::{self, Pid, Signal};
 use core::os::signals::{self, SignalEvent};
+use core::package::{PackageIdent, PackageInstall};
 use ipc_channel::ipc::{IpcOneShotServer, IpcReceiver, IpcSender};
 use libc;
 use protobuf;
 use protocol::{self, ERR_NO_RETRY_EXCODE, OK_NO_RETRY_EXCODE};
 
 use self::handlers::Handler;
-use {SUP_CMD, SUP_PACKAGE_IDENT};
 use error::{Error, Result};
 use service::Service;
+use {SUP_CMD, SUP_PACKAGE_IDENT};
 
 const SUP_CMD_ENVVAR: &'static str = "HAB_SUP_BINARY";
 static LOGKEY: &'static str = "SV";

--- a/components/launcher/src/service.rs
+++ b/components/launcher/src/service.rs
@@ -18,13 +18,13 @@ use std::io::{self, BufRead, BufReader, Read, Write};
 use std::process::{ChildStderr, ChildStdout, ExitStatus};
 use std::thread;
 
+use core::os::process::Pid;
 #[cfg(windows)]
 use core::os::process::windows_child::{ChildStderr, ChildStdout, ExitStatus};
-use core::os::process::Pid;
 use protocol;
 
-pub use sys::service::*;
 use error::Result;
+pub use sys::service::*;
 
 pub struct Service {
     args: protocol::Spawn,

--- a/components/pkg-export-docker/src/build.rs
+++ b/components/pkg-export-docker/src/build.rs
@@ -26,8 +26,8 @@ use common::command::package::install::{InstallMode, InstallSource};
 use common::ui::{Status, UIWriter, UI};
 use failure::SyncFailure;
 use hab;
-use hcore::fs::{cache_artifact_path, cache_key_path, CACHE_ARTIFACT_PATH, CACHE_KEY_PATH};
 use hcore::PROGRAM_NAME;
+use hcore::fs::{cache_artifact_path, cache_key_path, CACHE_ARTIFACT_PATH, CACHE_KEY_PATH};
 use hcore::package::{PackageArchive, PackageIdent, PackageInstall};
 use tempdir::TempDir;
 

--- a/components/pkg-export-docker/src/docker.rs
+++ b/components/pkg-export-docker/src/docker.rs
@@ -20,10 +20,10 @@ use std::str::FromStr;
 
 use common::ui::{Status, UIWriter, UI};
 use failure::SyncFailure;
-use hcore::os::filesystem;
-use hcore::fs as hfs;
-use hcore::package::PackageIdent;
 use handlebars::Handlebars;
+use hcore::fs as hfs;
+use hcore::os::filesystem;
+use hcore::package::PackageIdent;
 
 use super::{Credentials, Naming};
 use build::BuildRoot;

--- a/components/pkg-export-docker/src/error.rs
+++ b/components/pkg-export-docker/src/error.rs
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 use base64::DecodeError;
+use rusoto_ecr::GetAuthorizationTokenError;
 use std::process::ExitStatus;
 use std::result;
 use std::string::FromUtf8Error;
-use rusoto_ecr::GetAuthorizationTokenError;
 
 use failure;
 

--- a/components/pkg-export-docker/src/lib.rs
+++ b/components/pkg-export-docker/src/lib.rs
@@ -53,8 +53,8 @@ use std::result;
 use std::str::FromStr;
 
 use common::ui::{UIWriter, UI};
-use hcore::{channel, PROGRAM_NAME};
 use hcore::url as hurl;
+use hcore::{channel, PROGRAM_NAME};
 
 use aws_creds::StaticProvider;
 use clap::App;
@@ -62,8 +62,8 @@ use rusoto_core::Region;
 use rusoto_core::request::*;
 use rusoto_ecr::{Ecr, EcrClient, GetAuthorizationTokenRequest};
 
-pub use cli::{Cli, PkgIdentArgOptions};
 pub use build::BuildSpec;
+pub use cli::{Cli, PkgIdentArgOptions};
 pub use docker::{DockerBuildRoot, DockerImage};
 pub use error::{Error, Result};
 

--- a/components/pkg-export-docker/src/util.rs
+++ b/components/pkg-export-docker/src/util.rs
@@ -19,8 +19,8 @@ use std::str::FromStr;
 
 use hcore::package::{PackageIdent, PackageInstall};
 
-use error::Result;
 use super::BUSYBOX_IDENT;
+use error::Result;
 
 const BIN_PATH: &'static str = "/bin";
 

--- a/components/pkg-export-helm/src/chart.rs
+++ b/components/pkg-export-helm/src/chart.rs
@@ -23,8 +23,8 @@ use export_docker::Result;
 use export_k8s::{Manifest, ManifestJson};
 
 use chartfile::ChartFile;
-use values::Values;
 use deps::Deps;
+use values::Values;
 
 pub struct Chart<'a> {
     chartdir: PathBuf,

--- a/components/pkg-export-helm/src/deps.rs
+++ b/components/pkg-export-helm/src/deps.rs
@@ -12,16 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use clap;
 use failure::SyncFailure;
 use handlebars::Handlebars;
-use clap;
 use std::io::Write;
 use std::path::Path;
 use std::process::Command;
 
 use common::ui::{Status, UIWriter, UI};
-use export_docker::Result;
 use error::Error;
+use export_docker::Result;
 
 pub const DEFAULT_OPERATOR_VERSION: &'static str = "0.5.1";
 pub const OPERATOR_REPO_URL: &'static str = "https://habitat-sh.github.io/\

--- a/components/pkg-export-helm/src/main.rs
+++ b/components/pkg-export-helm/src/main.rs
@@ -33,10 +33,10 @@ extern crate failure_derive;
 
 mod chart;
 mod chartfile;
-mod values;
 mod deps;
 mod error;
 mod maintainer;
+mod values;
 
 use std::result;
 use std::str::FromStr;
@@ -71,9 +71,10 @@ fn export_for_cli_matches(ui: &mut UI, matches: &clap::ArgMatches) -> Result<()>
 }
 
 lazy_static! {
-    pub static ref VERSION_HELP: String =
-        format!("Version of the chart to create (default: {{pkg_version}} if available, or {})",
-                chartfile::DEFAULT_VERSION);
+    pub static ref VERSION_HELP: String = format!(
+        "Version of the chart to create (default: {{pkg_version}} if available, or {})",
+        chartfile::DEFAULT_VERSION
+    );
 }
 
 fn cli<'a, 'b>() -> clap::App<'a, 'b> {

--- a/components/pkg-export-helm/src/maintainer.rs
+++ b/components/pkg-export-helm/src/maintainer.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::str::FromStr;
-use std::string::ToString;
-use std::result;
 use clap::ArgMatches;
 use serde_json;
+use std::result;
+use std::str::FromStr;
+use std::string::ToString;
 use url::Url;
 
 use export_docker::Result;

--- a/components/pkg-export-kubernetes/src/lib.rs
+++ b/components/pkg-export-kubernetes/src/lib.rs
@@ -31,12 +31,12 @@ use std::io::prelude::*;
 
 use common::ui::{Status, UIWriter, UI};
 
+pub mod cli;
 pub mod error;
 pub mod manifest;
 pub mod manifestjson;
 pub mod service_bind;
 pub mod topology;
-pub mod cli;
 
 use export_docker::Result;
 

--- a/components/pkg-export-kubernetes/src/main.rs
+++ b/components/pkg-export-kubernetes/src/main.rs
@@ -21,8 +21,8 @@ extern crate habitat_pkg_export_kubernetes as export_k8s;
 #[macro_use]
 extern crate log;
 
-use hcore::PROGRAM_NAME;
 use common::ui::{UIWriter, UI};
+use hcore::PROGRAM_NAME;
 
 fn main() {
     env_logger::init();

--- a/components/pkg-export-kubernetes/src/manifest.rs
+++ b/components/pkg-export-kubernetes/src/manifest.rs
@@ -12,15 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::str::FromStr;
 use std::fs::File;
 use std::io::prelude::*;
 use std::path::Path;
+use std::str::FromStr;
 
 use base64;
 use clap::ArgMatches;
-use hcore::package::{PackageArchive, PackageIdent};
 use common::ui::UI;
+use hcore::package::{PackageArchive, PackageIdent};
 
 use export_docker::{DockerImage, Result};
 

--- a/components/pkg-export-kubernetes/src/service_bind.rs
+++ b/components/pkg-export-kubernetes/src/service_bind.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::str::FromStr;
-use std::result;
 use clap::ArgMatches;
 use serde_json;
+use std::result;
+use std::str::FromStr;
 
 use export_docker::Result;
 use hcore::service::ServiceGroup;

--- a/components/pkg-export-kubernetes/src/topology.rs
+++ b/components/pkg-export-kubernetes/src/topology.rs
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 use std::fmt;
-use std::str::FromStr;
 use std::result;
+use std::str::FromStr;
 
 use error::Error;
 

--- a/components/pkg-export-tar/src/build.rs
+++ b/components/pkg-export-tar/src/build.rs
@@ -12,21 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use clap;
+use common;
+use common::command::package::install::{InstallMode, InstallSource};
+use common::ui::{Status, UIWriter, UI};
+use error::Result;
+use hcore::PROGRAM_NAME;
+use hcore::fs::{cache_artifact_path, cache_key_path, CACHE_ARTIFACT_PATH, CACHE_KEY_PATH};
+use hcore::package::PackageIdent;
 use std::fs as stdfs;
 #[cfg(target_os = "linux")]
 use std::os::unix::fs::symlink;
 #[cfg(target_os = "windows")]
 use std::os::windows::fs::symlink_dir as symlink;
-use clap;
-use common;
-use common::command::package::install::{InstallMode, InstallSource};
-use common::ui::{Status, UIWriter, UI};
-use tempdir::TempDir;
 use std::path::Path;
-use hcore::package::PackageIdent;
-use error::Result;
-use hcore::PROGRAM_NAME;
-use hcore::fs::{cache_artifact_path, cache_key_path, CACHE_ARTIFACT_PATH, CACHE_KEY_PATH};
+use tempdir::TempDir;
 
 use super::{BUSYBOX_IDENT, VERSION};
 

--- a/components/pkg-export-tar/src/cli.rs
+++ b/components/pkg-export-tar/src/cli.rs
@@ -2,8 +2,8 @@ use clap::{App, Arg};
 use std::result;
 use std::str::FromStr;
 
-use url::Url;
 use common::command::package::install::InstallSource;
+use url::Url;
 
 /// The version of this library and program when built.
 pub const VERSION: &'static str = include_str!(concat!(env!("OUT_DIR"), "/VERSION"));

--- a/components/pkg-export-tar/src/error.rs
+++ b/components/pkg-export-tar/src/error.rs
@@ -1,6 +1,6 @@
 use base64::DecodeError;
-use std::result;
 use failure;
+use std::result;
 
 pub type Result<T> = result::Result<T, failure::Error>;
 

--- a/components/pkg-export-tar/src/lib.rs
+++ b/components/pkg-export-tar/src/lib.rs
@@ -25,18 +25,18 @@ pub mod cli;
 mod error;
 mod rootfs;
 
-use std::path::{Path, PathBuf};
-use std::fs::File;
 pub use cli::Cli;
-pub use error::{Error, Result};
 use common::ui::UI;
-use hcore::channel;
-use hcore::url as hurl;
-use hcore::package::{PackageIdent, PackageInstall};
-use tar::Builder;
-use std::str::FromStr;
+pub use error::{Error, Result};
 use flate2::Compression;
 use flate2::write::GzEncoder;
+use hcore::channel;
+use hcore::package::{PackageIdent, PackageInstall};
+use hcore::url as hurl;
+use std::fs::File;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+use tar::Builder;
 
 pub use build::BuildSpec;
 

--- a/components/pkg-export-tar/src/main.rs
+++ b/components/pkg-export-tar/src/main.rs
@@ -8,8 +8,8 @@ extern crate log;
 
 use clap::App;
 use common::ui::{UIWriter, UI};
-use hcore::PROGRAM_NAME;
 use export_tar::{Cli, Result};
+use hcore::PROGRAM_NAME;
 
 fn main() {
     let mut ui = UI::default_with_env();

--- a/components/sup-client/src/lib.rs
+++ b/components/sup-client/src/lib.rs
@@ -53,8 +53,8 @@ use std::io;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 
-use futures::sink;
 use futures::prelude::*;
+use futures::sink;
 use protocol::codec::*;
 use protocol::net::NetErr;
 use tokio::net::TcpStream;

--- a/components/sup-protocol/src/generated/mod.rs
+++ b/components/sup-protocol/src/generated/mod.rs
@@ -14,7 +14,6 @@
 
 ///! Module definitions for all generated protocol files. A new module must be defined here when a
 ///! new Protobuf package is added. See the notes in [`protocols`] for more details.
-
 pub mod ctl;
 pub mod net;
 pub mod types;

--- a/components/sup-protocol/src/lib.rs
+++ b/components/sup-protocol/src/lib.rs
@@ -57,9 +57,9 @@ extern crate tokio_io;
 pub mod butterfly;
 pub mod codec;
 pub mod ctl;
+mod generated;
 pub mod net;
 pub mod types;
-mod generated;
 
 use std::fs::File;
 use std::io::Read;

--- a/components/sup/src/census.rs
+++ b/components/sup/src/census.rs
@@ -18,16 +18,16 @@ use std::str::FromStr;
 
 use butterfly::member::{Health, Member, MemberList};
 use butterfly::rumor::RumorStore;
-use butterfly::rumor::service::Service as ServiceRumor;
-use butterfly::rumor::service_file::ServiceFile as ServiceFileRumor;
-use butterfly::rumor::service_config::ServiceConfig as ServiceConfigRumor;
 use butterfly::rumor::election::Election as ElectionRumor;
-use butterfly::rumor::election::Election_Status as ElectionStatusRumor;
 use butterfly::rumor::election::ElectionUpdate as ElectionUpdateRumor;
+use butterfly::rumor::election::Election_Status as ElectionStatusRumor;
+use butterfly::rumor::service::Service as ServiceRumor;
 use butterfly::rumor::service::SysInfo;
+use butterfly::rumor::service_config::ServiceConfig as ServiceConfigRumor;
+use butterfly::rumor::service_file::ServiceFile as ServiceFileRumor;
 use hcore;
-use hcore::service::ServiceGroup;
 use hcore::package::PackageIdent;
+use hcore::service::ServiceGroup;
 use toml;
 
 use error::{Error, SupError};
@@ -640,16 +640,16 @@ fn service_group_from_str(sg: &str) -> Result<ServiceGroup, hcore::Error> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use hcore::package::ident::PackageIdent;
-    use hcore::service::ServiceGroup;
     use butterfly::member::{Health, MemberList};
-    use butterfly::rumor::service::Service as ServiceRumor;
-    use butterfly::rumor::service_config::ServiceConfig as ServiceConfigRumor;
-    use butterfly::rumor::service_file::ServiceFile as ServiceFileRumor;
+    use butterfly::rumor::RumorStore;
     use butterfly::rumor::election::Election as ElectionRumor;
     use butterfly::rumor::election::ElectionUpdate as ElectionUpdateRumor;
+    use butterfly::rumor::service::Service as ServiceRumor;
     use butterfly::rumor::service::SysInfo;
-    use butterfly::rumor::RumorStore;
+    use butterfly::rumor::service_config::ServiceConfig as ServiceConfigRumor;
+    use butterfly::rumor::service_file::ServiceFile as ServiceFileRumor;
+    use hcore::package::ident::PackageIdent;
+    use hcore::service::ServiceGroup;
 
     #[test]
     fn update_from_rumors() {

--- a/components/sup/src/command/shell.rs
+++ b/components/sup/src/command/shell.rs
@@ -14,8 +14,8 @@
 
 use std::env;
 use std::ffi::CString;
-use std::ptr;
 use std::path::PathBuf;
+use std::ptr;
 
 use hcore::fs::find_command;
 use libc;

--- a/components/sup/src/ctl_gateway/mod.rs
+++ b/components/sup/src/ctl_gateway/mod.rs
@@ -24,8 +24,8 @@ pub mod server;
 
 use std::borrow::Cow;
 use std::fmt;
-use std::io::{self, Write};
 use std::fs::{self, File};
+use std::io::{self, Write};
 use std::path::Path;
 
 use regex::Regex;
@@ -33,8 +33,8 @@ use regex::Regex;
 use common::ui::UIWriter;
 use depot_client::DisplayProgress;
 use futures::prelude::*;
-use hcore::util::perm;
 use hcore::output;
+use hcore::util::perm;
 use protocol;
 
 use error::{Error, Result};

--- a/components/sup/src/fs.rs
+++ b/components/sup/src/fs.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::path::{Path, PathBuf};
 use hcore::fs::FS_ROOT_PATH;
+use std::path::{Path, PathBuf};
 
 lazy_static! {
     /// The root path containing all runtime service directories and files

--- a/components/sup/src/http_gateway.rs
+++ b/components/sup/src/http_gateway.rs
@@ -25,9 +25,9 @@ use std::sync::Arc;
 use std::thread::{self, JoinHandle};
 
 use hcore::service::{ApplicationEnvironment, ServiceGroup};
+use iron::modifiers::Header;
 use iron::prelude::*;
 use iron::{headers, status, typemap};
-use iron::modifiers::Header;
 use persistent;
 use router::Router;
 use serde_json::{self, Value as Json};

--- a/components/sup/src/lib.rs
+++ b/components/sup/src/lib.rs
@@ -99,33 +99,35 @@ extern crate json;
 #[macro_export]
 /// Creates a new SupError, embedding the current file name, line number, column, and module path.
 macro_rules! sup_error {
-    ($p: expr) => {
-        {
-            use $crate::error::SupError;
-            SupError::new($p, LOGKEY, file!(), line!(), column!())
-        }
-    }
+    ($p:expr) => {{
+        use $crate::error::SupError;
+        SupError::new($p, LOGKEY, file!(), line!(), column!())
+    }};
 }
 
+pub mod census;
 pub mod command;
 pub mod config;
-pub mod census;
 pub mod ctl_gateway;
 pub mod error;
 pub mod fs;
 pub mod http_gateway;
 pub mod manager;
+mod sys;
 pub mod templating;
 pub mod util;
-mod sys;
 
 use std::env;
 use std::path::PathBuf;
 
-lazy_static!{
+lazy_static! {
     pub static ref PROGRAM_NAME: String = {
         let arg0 = env::args().next().map(|p| PathBuf::from(p));
-        arg0.as_ref().and_then(|p| p.file_stem()).and_then(|p| p.to_str()).unwrap().to_string()
+        arg0.as_ref()
+            .and_then(|p| p.file_stem())
+            .and_then(|p| p.to_str())
+            .unwrap()
+            .to_string()
     };
 }
 

--- a/components/sup/src/sys/unix/exec.rs
+++ b/components/sup/src/sys/unix/exec.rs
@@ -42,10 +42,9 @@ where
         // If we can SETUID/SETGID, then run the script as the service
         // user; otherwise, we'll just run it as ourselves.
 
-        let uid =
-            os::users::get_uid_by_name(&pkg.svc_user).ok_or(sup_error!(Error::Permissions(
-                format!("No uid for user '{}' could be found", &pkg.svc_user)
-            )))?;
+        let uid = os::users::get_uid_by_name(&pkg.svc_user).ok_or(sup_error!(Error::Permissions(
+            format!("No uid for user '{}' could be found", &pkg.svc_user)
+        )))?;
         let gid =
             os::users::get_gid_by_name(&pkg.svc_group).ok_or(sup_error!(Error::Permissions(
                 format!("No gid for group '{}' could be found", &pkg.svc_group)

--- a/components/sup/src/sys/unix/mod.rs
+++ b/components/sup/src/sys/unix/mod.rs
@@ -12,6 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub mod abilities;
 pub mod exec;
 pub mod users;
-pub mod abilities;

--- a/components/sup/src/templating/context.rs
+++ b/components/sup/src/templating/context.rs
@@ -53,8 +53,8 @@ use std::net::IpAddr;
 use std::path::PathBuf;
 use std::result;
 
-use serde::{Serialize, Serializer};
 use serde::ser::SerializeMap;
+use serde::{Serialize, Serializer};
 use toml;
 
 use butterfly::rumor::service::SysInfo;
@@ -62,8 +62,8 @@ use hcore::package::PackageIdent;
 use hcore::service::ServiceGroup;
 
 use census::{CensusGroup, CensusMember, CensusRing, ElectionStatus, MemberId};
-use manager::service::{Cfg, Env, Pkg, ServiceBind};
 use manager::Sys;
+use manager::service::{Cfg, Env, Pkg, ServiceBind};
 
 /// The context of a rendering call, exposing information on the
 /// currently-running Supervisor and service, its service group, and
@@ -603,8 +603,8 @@ mod tests {
     use std::net::{IpAddr, Ipv4Addr};
     use std::path::PathBuf;
 
-    use serde_json;
     use json;
+    use serde_json;
     use tempdir::TempDir;
     use valico::json_schema;
 

--- a/components/sup/src/templating/mod.rs
+++ b/components/sup/src/templating/mod.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod helpers;
 mod context;
+pub mod helpers;
 
 use std::fmt;
 use std::ops::{Deref, DerefMut};
@@ -90,11 +90,11 @@ fn never_escape(data: &str) -> String {
 
 #[cfg(test)]
 mod test {
+    use serde_json;
+    use std::collections::BTreeMap;
     use std::fs::File;
     use std::io::Read;
     use std::path::PathBuf;
-    use std::collections::BTreeMap;
-    use serde_json;
     use toml;
 
     use super::*;

--- a/components/sup/src/util/pkg.rs
+++ b/components/sup/src/util/pkg.rs
@@ -17,13 +17,13 @@ use std::path::Path;
 use common;
 use common::command::package::install::{InstallMode, InstallSource};
 use common::ui::UIWriter;
-use hcore::env as henv;
 use hcore::AUTH_TOKEN_ENVVAR;
+use hcore::env as henv;
 use hcore::fs::{self, FS_ROOT_PATH};
 use hcore::package::{PackageIdent, PackageInstall};
 
-use {PRODUCT, VERSION};
 use error::{Result, SupError};
+use {PRODUCT, VERSION};
 
 /// Helper function for use in the Supervisor to handle lower-level
 /// arguments needed for installing a package.

--- a/components/sup/tests/compilation.rs
+++ b/components/sup/tests/compilation.rs
@@ -28,8 +28,7 @@ mod utils;
 // The fixture location is derived from the name of this test
 // suite. By convention, it is the same as the file name.
 lazy_static! {
-    static ref FIXTURE_ROOT: utils::FixtureRoot =
-        utils::FixtureRoot::new("compilation");
+    static ref FIXTURE_ROOT: utils::FixtureRoot = utils::FixtureRoot::new("compilation");
 }
 
 #[test]

--- a/support/ci/lint.sh
+++ b/support/ci/lint.sh
@@ -47,7 +47,7 @@ exit_with() {
 }
 
 program=$(basename $0)
-rf_version="0.3.8"
+rf_version="0.4.1"
 
 # Fix commit range in Travis, if set.
 # See: https://github.com/travis-ci/travis-ci/issues/4596
@@ -58,12 +58,6 @@ fi
 info "Checking for rustfmt"
 if ! command -v rustfmt >/dev/null; then
   exit_with "Program \`rustfmt' not found on PATH, aborting" 1
-fi
-
-info "Checking for version $rf_version of rustfmt"
-actual="$(rustfmt --version | cut -d ' ' -f 1)"
-if [[ "$actual" != "$rf_version-nightly" ]]; then
-  exit_with "\`rustfmt' version $actual doesn't match expected: $rf_version" 2
 fi
 
 failed="$(mktemp -t "$(basename $0)-failed-XXXX")"


### PR DESCRIPTION
* Lock travis build to use Rust 1.26.0
* Reformat code for rustfmt contained with 1.26.0

https://github.com/habitat-sh/core-plans/pull/1535