### PR TITLE
Remove generic io

### DIFF
--- a/components/common/src/command/package/install.rs
+++ b/components/common/src/command/package/install.rs
@@ -620,10 +620,10 @@ impl<'a> InstallTask<'a> {
                 |res| res.is_ok(),
             ).is_err()
             {
-                return Err(Error::from(depot_client::Error::DownloadFailed(format!(
+                return Err(Error::DownloadFailed(format!(
                     "We tried {} times but could not download {}. Giving up.",
                     RETRIES, ident
-                ))));
+                )));
             }
         }
 

--- a/components/common/src/error.rs
+++ b/components/common/src/error.rs
@@ -35,6 +35,7 @@ pub enum Error {
     CryptoKeyError(String),
     GossipFileRelativePath(String),
     DepotClient(depot_client::Error),
+    DownloadFailed(String),
     EditStatus,
     FileNameError,
     HabitatCore(hcore::Error),
@@ -69,6 +70,7 @@ impl fmt::Display for Error {
                 s
             ),
             Error::DepotClient(ref err) => format!("{}", err),
+            Error::DownloadFailed(ref msg) => format!("{}", msg),
             Error::EditStatus => format!("Failed edit text command"),
             Error::FileNameError => format!("Failed to extract a filename"),
             Error::HabitatCore(ref e) => format!("{}", e),
@@ -108,6 +110,7 @@ impl error::Error for Error {
             Error::CantUploadGossipToml => "Can't upload gossip.toml, it's a reserved filename",
             Error::ChannelNotFound => "Channel not found",
             Error::CryptoKeyError(_) => "Missing or invalid key",
+            Error::DownloadFailed(_) => "Failed to download from remote",
             Error::GossipFileRelativePath(_) => {
                 "Path for gossip file cannot have relative components (eg: ..)"
             }

--- a/components/hab/src/command/origin/key/download.rs
+++ b/components/hab/src/command/origin/key/download.rs
@@ -14,9 +14,10 @@
 
 use std::path::Path;
 
+use common;
 use common::command::package::install::{RETRIES, RETRY_WAIT};
 use common::ui::{Status, UIWriter, UI};
-use depot_client::{self, Client};
+use depot_client::Client;
 use hcore::crypto::SigKeyPair;
 
 use error::{Error, Result};
@@ -167,7 +168,7 @@ pub fn download_public_encryption_key(
         res.is_ok()
     }).is_err()
     {
-        return Err(Error::from(depot_client::Error::DownloadFailed(format!(
+        return Err(Error::from(common::error::Error::DownloadFailed(format!(
             "We tried {} \
              times but \
              could not \
@@ -202,7 +203,7 @@ fn download_secret_key(
         res.is_ok()
     }).is_err()
     {
-        return Err(Error::from(depot_client::Error::DownloadFailed(format!(
+        return Err(Error::from(common::error::Error::DownloadFailed(format!(
             "We tried {} \
              times but \
              could not \
@@ -238,7 +239,7 @@ fn download_key(
                 res.is_ok()
             }).is_err()
             {
-                return Err(Error::from(depot_client::Error::DownloadFailed(format!(
+                return Err(Error::from(common::error::Error::DownloadFailed(format!(
                     "We tried {} \
                      times but \
                      could not \


### PR DESCRIPTION
Generate more descriptive errors on IO failures when reading and writing
responses to and from the Builder Depot. This is the first of many
commits which will remove `From<io::Error> for X` from our codebase.