### PR TITLE
Fix default configuration serialization bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@
 
 ## Bug fixes
 
+- Fix default configuration serialization bug [\#5110](https://github.com/habitat-sh/habitat/pull/5110)
 - Fix panic when an initial service fails to load [\#5096](https://github.com/habitat-sh/habitat/pull/5096)
 - Disable interface validation of config/files [\#5091](https://github.com/habitat-sh/habitat/pull/5091)
 - Disable validation of config/files [\#5090](https://github.com/habitat-sh/habitat/pull/5090)

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -773,7 +773,9 @@ impl Manager {
             if service.pkg.ident.satisfies(&ident) {
                 let mut msg = protocol::types::ServiceCfg::new();
                 if let Some(ref cfg) = service.cfg.default {
-                    msg.set_default(toml::to_string_pretty(cfg).unwrap());
+                    msg.set_default(
+                        toml::to_string_pretty(&toml::value::Value::Table(cfg.clone())).unwrap(),
+                    );
                     req.reply_complete(msg);
                 }
                 return Ok(());


### PR DESCRIPTION
TOML serialization is picky, in that table keys that are themselves
keys must be rendered last in the table.

We have typed our TOML table data as `toml::value::Table`, which is
just an alias for a `BTreeMap`. However, the smarts for serializing
tables are attached to the `toml::value::Value` enum, where
`toml::value::Table` is the payload of the `toml::value::Value::Table`
variant.

I'm not sure that we want to retype everything, though, since you
can't constrain things to a single Enum variant (everything that is
definitely a `Table` right now would end up just being a
`Value`). Longer term, we may want to look at creating our own
concrete types, but for now, we can wrap our default configuration
with `toml::value::Value::Table` to get the correct serialization
logic.

Fixes #5109

Signed-off-by: Christopher Maier <cmaier@chef.io>