### PR TITLE
Re-add Vagrantfile.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,19 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+Vagrant.configure("2") do |config|
+  config.vm.box = "bento/ubuntu-17.10"
+
+  config.vm.provider "virtualbox" do |vb|
+    vb.memory = "4096"
+    vb.cpus = "4"
+  end
+
+  config.vm.provider "vmware_fusion" do |v|
+    v.vmx["memsize"] = "4096"
+    v.vmx["numvcpus"] = "4"
+  end
+
+  config.vm.provision "file", source: "components/hab/install.sh", destination: "/tmp/install.sh"
+  config.vm.provision "shell", path: "support/linux/install_dev_0_ubuntu_latest.sh"
+  config.vm.provision "shell", path: "support/linux/install_dev_9_linux.sh"
+end


### PR DESCRIPTION
https://github.com/habitat-sh/habitat/blob/master/BUILDING.md#vm-vs-docker-development refers to using the Vagrantfile in the project root, however it appears the Vagrantfile was removed by a revert: 69b9d2dbb8e31eea9048fd9cfeec25601749bc73

This just re-adds the Vagrantfile that was removed in that revert (which, to my eye, looks to have been an accident (because the bulk of the commit was not Vagrant related)).