### PR TITLE
Allow `--remote-sup` to take a DNS name as an argument

### DIFF
--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -70,7 +70,7 @@ pub fn get() -> App<'static, 'static> {
                 (aliases: &["sh", "sho"])
                 (@arg PKG_IDENT: +required +takes_value
                     "A package identifier (ex: core/redis, core/busybox-static/1.42.2)")
-                (@arg REMOTE_SUP: --("remote-sup") -r +takes_value {valid_socket_addr}
+                (@arg REMOTE_SUP: --("remote-sup") -r +takes_value
                     "Address to a remote Supervisor's Control Gateway [default: 127.0.0.1:9632]")
             )
         )
@@ -87,7 +87,7 @@ pub fn get() -> App<'static, 'static> {
                     "A version number (positive integer) for this configuration (ex: 42)")
                 (@arg FILE: +required {file_exists} "Path to local file on disk")
                 (@arg USER: -u --user +takes_value "Name of the user key")
-                (@arg REMOTE_SUP: --("remote-sup") -r +takes_value {valid_socket_addr}
+                (@arg REMOTE_SUP: --("remote-sup") -r +takes_value
                     "Address to a remote Supervisor's Control Gateway [default: 127.0.0.1:9632]")
             )
         )
@@ -563,7 +563,7 @@ pub fn get() -> App<'static, 'static> {
                 (aliases: &["u", "un", "unl", "unlo", "unloa"])
                 (@arg PKG_IDENT: +required +takes_value
                     "A Habitat package identifier (ex: core/redis)")
-                (@arg REMOTE_SUP: --("remote-sup") -r +takes_value {valid_socket_addr}
+                (@arg REMOTE_SUP: --("remote-sup") -r +takes_value
                     "Address to a remote Supervisor's Control Gateway [default: 127.0.0.1:9632]")
             )
         )
@@ -580,7 +580,7 @@ pub fn get() -> App<'static, 'static> {
                     from joining again with the same member-id")
                 (aliases: &["d", "de", "dep", "depa", "depart"])
                 (@arg MEMBER_ID: +required +takes_value "The member-id of the Supervisor to depart")
-                (@arg REMOTE_SUP: --("remote-sup") -r +takes_value {valid_socket_addr}
+                (@arg REMOTE_SUP: --("remote-sup") -r +takes_value
                     "Address to a remote Supervisor's Control Gateway [default: 127.0.0.1:9632]")
             )
             (@subcommand secret =>
@@ -752,7 +752,7 @@ fn sub_config_apply() -> App<'static, 'static> {
         (@arg FILE: {file_exists_or_stdin}
             "Path to local file on disk (ex: /tmp/config.toml, default: <stdin>)")
         (@arg USER: -u --user +takes_value "Name of a user key to use for encryption")
-        (@arg REMOTE_SUP: --("remote-sup") -r +takes_value {valid_socket_addr}
+        (@arg REMOTE_SUP: --("remote-sup") -r +takes_value
             "Address to a remote Supervisor's Control Gateway [default: 127.0.0.1:9632]")
     )
 }
@@ -762,7 +762,7 @@ fn sub_svc_start() -> App<'static, 'static> {
         (about: "Start a loaded, but stopped, Habitat service.")
         (@arg PKG_IDENT: +required +takes_value
             "A Habitat package identifier (ex: core/redis)")
-        (@arg REMOTE_SUP: --("remote-sup") -r +takes_value {valid_socket_addr}
+        (@arg REMOTE_SUP: --("remote-sup") -r +takes_value
             "Address to a remote Supervisor's Control Gateway [default: 127.0.0.1:9632]")
     )
 }
@@ -773,7 +773,7 @@ fn sub_svc_status() -> App<'static, 'static> {
     clap_app!(@subcommand status =>
         (about: "Query the status of Habitat services.")
         (@arg PKG_IDENT: +takes_value "A Habitat package identifier (ex: core/redis)")
-        (@arg REMOTE_SUP: --("remote-sup") -r +takes_value {valid_socket_addr}
+        (@arg REMOTE_SUP: --("remote-sup") -r +takes_value
         "Address to a remote Supervisor's Control Gateway [default: 127.0.0.1:9632]")
     )
 }
@@ -783,7 +783,7 @@ fn sub_svc_stop() -> App<'static, 'static> {
         (about: "Stop a running Habitat service.")
         (@arg PKG_IDENT: +required +takes_value
             "A Habitat package identifier (ex: core/redis)")
-        (@arg REMOTE_SUP: --("remote-sup") -r +takes_value {valid_socket_addr}
+        (@arg REMOTE_SUP: --("remote-sup") -r +takes_value
             "Address to a remote Supervisor's Control Gateway [default: 127.0.0.1:9632]")
     )
 }
@@ -818,7 +818,7 @@ fn sub_svc_load() -> App<'static, 'static> {
               startup until all binds are present. [default: strict] [values: relaxed, strict]")
         (@arg FORCE: --force -f "Load or reload an already loaded service. If the service \
             was previously loaded and running this operation will also restart the service")
-        (@arg REMOTE_SUP: --("remote-sup") -r +takes_value {valid_socket_addr}
+        (@arg REMOTE_SUP: --("remote-sup") -r +takes_value
             "Address to a remote Supervisor's Control Gateway [default: 127.0.0.1:9632]")
     )
 }
@@ -854,7 +854,7 @@ fn sub_svc_load() -> App<'static, 'static> {
         (@arg FORCE: --force -f "Load or reload an already loaded service. If the service \
             was previously loaded and running this operation will also restart the service")
         (@arg PASSWORD: --password +takes_value "Password of the service user")
-        (@arg REMOTE_SUP: --("remote-sup") -r +takes_value {valid_socket_addr}
+        (@arg REMOTE_SUP: --("remote-sup") -r +takes_value
             "Address to a remote Supervisor's Control Gateway [default: 127.0.0.1:9632]")
     )
 }
@@ -919,15 +919,6 @@ fn valid_topology(val: String) -> result::Result<(), String> {
     match protocol::types::Topology::from_str(&val) {
         Ok(_) => Ok(()),
         Err(_) => Err(format!("Service topology: '{}' is not valid", &val)),
-    }
-}
-
-fn valid_socket_addr(val: String) -> result::Result<(), String> {
-    match SocketAddr::from_str(&val) {
-        Ok(_) => Ok(()),
-        Err(_) => Err(format!(
-            "Socket address should include both IP and port, eg: '0.0.0.0:9700'"
-        )),
     }
 }
 

--- a/components/hab/src/error.rs
+++ b/components/hab/src/error.rs
@@ -63,6 +63,7 @@ pub enum Error {
     ParseIntError(num::ParseIntError),
     PathPrefixError(path::StripPrefixError),
     ProvidesError(String),
+    RemoteSupResolutionError(String, io::Error),
     RootRequired,
     ScheduleStatus(depot_client::Error),
     SubcommandNotSupported(String),
@@ -146,6 +147,10 @@ impl fmt::Display for Error {
             Error::ParseIntError(ref err) => format!("{}", err),
             Error::PathPrefixError(ref err) => format!("{}", err),
             Error::ProvidesError(ref err) => format!("Can't find {}", err),
+            Error::RemoteSupResolutionError(ref sup_addr, ref err) => format!(
+                "Failed to resolve remote supervisor '{}': {}",
+                sup_addr, err,
+            ),
             Error::RootRequired => {
                 "Root or administrator permissions required to complete operation".to_string()
             }
@@ -206,6 +211,7 @@ impl error::Error for Error {
             Error::ProvidesError(_) => {
                 "Can't find a package that provides the given search parameter"
             }
+            Error::RemoteSupResolutionError(_, ref err) => err.description(),
             Error::RootRequired => {
                 "Root or administrator permissions required to complete operation"
             }


### PR DESCRIPTION
When wiring up Supervisors, the `--peer` option will accept DNS names
as well as bare IP addresses. Additionally, it will add the default
gossip port if a port is not supplied. The new `--remote-sup` option,
however, would _not_ do this; instead, it required a bare IP address
_and_ port, even if it was the default control port.

This commit gives the same flexibility of the `--peer` option to the
`--remote-sup` option.

Now, each of the following are possible:

    hab svc load core/redis --remote-sup=alpha.habitat.dev
    hab svc load core/redis --remote-sup=alpha.habitat.dev:9632
    hab svc load core/redis --remote-sup=172.18.0.2
    hab svc load core/redis --remote-sup=172.18.0.2:9632

Leaving the `--remote-sup` option off results in connecting to a
Supervisor running on the local host, as before.

If you supply something that doesn't resolve, you get an error message like this:

    hab svc load core/redis --remote-sup=300.300.300.300 # not a real IP address
    ✗✗✗
    ✗✗✗ Failed to resolve remote supervisor '300.300.300.300:9632': failed to lookup address information: Name or service not known
    ✗✗✗

Supplying a DNS name that doesn't resolve gives the same error, but it
takes a bit longer (a few seconds) to return, since it has to query
DNS.

Signed-off-by: Christopher Maier <cmaier@chef.io>