### PR TITLE
hab svc status: adding DesiredState

### DIFF
--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -84,7 +84,7 @@ const HABITAT_USER_ENVVAR: &'static str = "HAB_USER";
 
 lazy_static! {
     static ref STATUS_HEADER: Vec<&'static str> = {
-        vec!["package", "type", "state", "uptime (s)", "pid", "group"]
+        vec!["package", "type", "desired", "state", "elapsed (s)", "pid", "group"]
     };
 
     /// The default filesystem root path to base all commands from. This is lazily generated on
@@ -1349,9 +1349,10 @@ where
     }
     write!(
         out,
-        "{}\t{}\t{}\t{}\t{}\t{}\n",
+        "{}\t{}\t{}\t{}\t{}\t{}\t{}\n",
         status.get_ident(),
         svc_type,
+        status.get_desired_state(),
         status.get_process().get_state(),
         status.get_process().get_elapsed(),
         svc_pid,

--- a/components/sup-protocol/protocols/types.proto
+++ b/components/sup-protocol/protocols/types.proto
@@ -13,6 +13,13 @@ enum ProcessState {
   Up = 1;
 }
 
+enum DesiredState {
+  // enum values must be unique within global scope
+  // therefore we cannot re-use Down/Up
+  DesiredDown = 0;
+  DesiredUp = 1;
+}
+
 // The relationship of a service with peers in the same service group.
 enum Topology {
   Standalone = 0;
@@ -79,5 +86,5 @@ message ServiceStatus {
   optional ProcessStatus process = 2;
   optional ServiceGroup service_group = 3;
   optional string composite = 4;
+  optional DesiredState desired_state = 5;
 }
-

--- a/components/sup-protocol/src/generated/types.rs
+++ b/components/sup-protocol/src/generated/types.rs
@@ -1872,6 +1872,7 @@ pub struct ServiceStatus {
     process: ::protobuf::SingularPtrField<ProcessStatus>,
     service_group: ::protobuf::SingularPtrField<ServiceGroup>,
     composite: ::protobuf::SingularField<::std::string::String>,
+    desired_state: ::std::option::Option<DesiredState>,
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
     cached_size: ::protobuf::CachedSize,
@@ -2061,6 +2062,33 @@ impl ServiceStatus {
     fn mut_composite_for_reflect(&mut self) -> &mut ::protobuf::SingularField<::std::string::String> {
         &mut self.composite
     }
+
+    // optional .DesiredState desired_state = 5;
+
+    pub fn clear_desired_state(&mut self) {
+        self.desired_state = ::std::option::Option::None;
+    }
+
+    pub fn has_desired_state(&self) -> bool {
+        self.desired_state.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_desired_state(&mut self, v: DesiredState) {
+        self.desired_state = ::std::option::Option::Some(v);
+    }
+
+    pub fn get_desired_state(&self) -> DesiredState {
+        self.desired_state.unwrap_or(DesiredState::DesiredDown)
+    }
+
+    fn get_desired_state_for_reflect(&self) -> &::std::option::Option<DesiredState> {
+        &self.desired_state
+    }
+
+    fn mut_desired_state_for_reflect(&mut self) -> &mut ::std::option::Option<DesiredState> {
+        &mut self.desired_state
+    }
 }
 
 impl ::protobuf::Message for ServiceStatus {
@@ -2099,6 +2127,9 @@ impl ::protobuf::Message for ServiceStatus {
                 4 => {
                     ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.composite)?;
                 },
+                5 => {
+                    ::protobuf::rt::read_proto2_enum_with_unknown_fields_into(wire_type, is, &mut self.desired_state, 5, &mut self.unknown_fields)?
+                },
                 _ => {
                     ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
                 },
@@ -2126,6 +2157,9 @@ impl ::protobuf::Message for ServiceStatus {
         if let Some(ref v) = self.composite.as_ref() {
             my_size += ::protobuf::rt::string_size(4, &v);
         }
+        if let Some(v) = self.desired_state {
+            my_size += ::protobuf::rt::enum_size(5, v);
+        }
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
         self.cached_size.set(my_size);
         my_size
@@ -2149,6 +2183,9 @@ impl ::protobuf::Message for ServiceStatus {
         }
         if let Some(ref v) = self.composite.as_ref() {
             os.write_string(4, &v)?;
+        }
+        if let Some(v) = self.desired_state {
+            os.write_enum(5, v.value())?;
         }
         os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
@@ -2214,6 +2251,11 @@ impl ::protobuf::MessageStatic for ServiceStatus {
                     ServiceStatus::get_composite_for_reflect,
                     ServiceStatus::mut_composite_for_reflect,
                 ));
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeEnum<DesiredState>>(
+                    "desired_state",
+                    ServiceStatus::get_desired_state_for_reflect,
+                    ServiceStatus::mut_desired_state_for_reflect,
+                ));
                 ::protobuf::reflect::MessageDescriptor::new::<ServiceStatus>(
                     "ServiceStatus",
                     fields,
@@ -2230,6 +2272,7 @@ impl ::protobuf::Clear for ServiceStatus {
         self.clear_process();
         self.clear_service_group();
         self.clear_composite();
+        self.clear_desired_state();
         self.unknown_fields.clear();
     }
 }
@@ -2339,6 +2382,55 @@ impl ::std::marker::Copy for ProcessState {
 }
 
 impl ::protobuf::reflect::ProtobufValue for ProcessState {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Enum(self.descriptor())
+    }
+}
+
+#[derive(Clone,PartialEq,Eq,Debug,Hash)]
+pub enum DesiredState {
+    DesiredDown = 0,
+    DesiredUp = 1,
+}
+
+impl ::protobuf::ProtobufEnum for DesiredState {
+    fn value(&self) -> i32 {
+        *self as i32
+    }
+
+    fn from_i32(value: i32) -> ::std::option::Option<DesiredState> {
+        match value {
+            0 => ::std::option::Option::Some(DesiredState::DesiredDown),
+            1 => ::std::option::Option::Some(DesiredState::DesiredUp),
+            _ => ::std::option::Option::None
+        }
+    }
+
+    fn values() -> &'static [Self] {
+        static values: &'static [DesiredState] = &[
+            DesiredState::DesiredDown,
+            DesiredState::DesiredUp,
+        ];
+        values
+    }
+
+    fn enum_descriptor_static(_: ::std::option::Option<DesiredState>) -> &'static ::protobuf::reflect::EnumDescriptor {
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> = ::protobuf::lazy::Lazy {
+            lock: ::protobuf::lazy::ONCE_INIT,
+            ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
+        };
+        unsafe {
+            descriptor.get(|| {
+                ::protobuf::reflect::EnumDescriptor::new("DesiredState", file_descriptor_proto())
+            })
+        }
+    }
+}
+
+impl ::std::marker::Copy for DesiredState {
+}
+
+impl ::protobuf::reflect::ProtobufValue for DesiredState {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Enum(self.descriptor())
     }
@@ -2513,16 +2605,18 @@ static file_descriptor_proto_data: &'static [u8] = b"\
     \x18\x02\x20\x01(\t:\x07defaultR\x05group\x12P\n\x17application_environm\
     ent\x18\x03\x20\x01(\x0b2\x17.ApplicationEnvironmentR\x16applicationEnvi\
     ronment\x12\"\n\x0corganization\x18\x04\x20\x01(\tR\x0corganization\"\
-    \xb0\x01\n\rServiceStatus\x12#\n\x05ident\x18\x01\x20\x01(\x0b2\r.Packag\
+    \xe4\x01\n\rServiceStatus\x12#\n\x05ident\x18\x01\x20\x01(\x0b2\r.Packag\
     eIdentR\x05ident\x12(\n\x07process\x18\x02\x20\x01(\x0b2\x0e.ProcessStat\
     usR\x07process\x122\n\rservice_group\x18\x03\x20\x01(\x0b2\r.ServiceGrou\
-    pR\x0cserviceGroup\x12\x1c\n\tcomposite\x18\x04\x20\x01(\tR\tcomposite*'\
-    \n\rInstallSource\x12\t\n\x05Ident\x10\0\x12\x0b\n\x07Archive\x10\x01*\
-    \x20\n\x0cProcessState\x12\x08\n\x04Down\x10\0\x12\x06\n\x02Up\x10\x01*&\
-    \n\x08Topology\x12\x0e\n\nStandalone\x10\0\x12\n\n\x06Leader\x10\x01*3\n\
-    \x0eUpdateStrategy\x12\x08\n\x04None\x10\0\x12\n\n\x06AtOnce\x10\x01\x12\
-    \x0b\n\x07Rolling\x10\x02*&\n\x0bBindingMode\x12\x0b\n\x07Relaxed\x10\0\
-    \x12\n\n\x06Strict\x10\x01\
+    pR\x0cserviceGroup\x12\x1c\n\tcomposite\x18\x04\x20\x01(\tR\tcomposite\
+    \x122\n\rdesired_state\x18\x05\x20\x01(\x0e2\r.DesiredStateR\x0cdesiredS\
+    tate*'\n\rInstallSource\x12\t\n\x05Ident\x10\0\x12\x0b\n\x07Archive\x10\
+    \x01*\x20\n\x0cProcessState\x12\x08\n\x04Down\x10\0\x12\x06\n\x02Up\x10\
+    \x01*.\n\x0cDesiredState\x12\x0f\n\x0bDesiredDown\x10\0\x12\r\n\tDesired\
+    Up\x10\x01*&\n\x08Topology\x12\x0e\n\nStandalone\x10\0\x12\n\n\x06Leader\
+    \x10\x01*3\n\x0eUpdateStrategy\x12\x08\n\x04None\x10\0\x12\n\n\x06AtOnce\
+    \x10\x01\x12\x0b\n\x07Rolling\x10\x02*&\n\x0bBindingMode\x12\x0b\n\x07Re\
+    laxed\x10\0\x12\n\n\x06Strict\x10\x01\
 ";
 
 static mut file_descriptor_proto_lazy: ::protobuf::lazy::Lazy<::protobuf::descriptor::FileDescriptorProto> = ::protobuf::lazy::Lazy {

--- a/components/sup-protocol/src/types.rs
+++ b/components/sup-protocol/src/types.rs
@@ -84,6 +84,16 @@ impl fmt::Display for ProcessState {
     }
 }
 
+impl fmt::Display for DesiredState {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let state = match *self {
+            DesiredState::DesiredDown => "down",
+            DesiredState::DesiredUp => "up",
+        };
+        write!(f, "{}", state)
+    }
+}
+
 impl FromStr for BindingMode {
     type Err = NetErr;
 

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -1688,6 +1688,7 @@ pub struct ServiceStatus {
     pub process: ProcessStatus,
     pub service_group: ServiceGroup,
     pub composite: Option<String>,
+    pub desired_state: DesiredState,
 }
 
 impl fmt::Display for ServiceStatus {
@@ -1892,6 +1893,15 @@ impl Future for CtlHandler {
     }
 }
 
+impl From<service::DesiredState> for protocol::types::DesiredState {
+    fn from(other: service::DesiredState) -> Self {
+        match other {
+            service::DesiredState::Down => protocol::types::DesiredState::DesiredDown,
+            service::DesiredState::Up => protocol::types::DesiredState::DesiredUp,
+        }
+    }
+}
+
 impl From<service::ProcessState> for protocol::types::ProcessState {
     fn from(other: service::ProcessState) -> Self {
         match other {
@@ -1928,6 +1938,7 @@ impl From<ServiceStatus> for protocol::types::ServiceStatus {
         proto.set_ident(other.pkg.ident.into());
         proto.set_process(other.process.into());
         proto.set_service_group(other.service_group.into());
+        proto.set_desired_state(other.desired_state.into());
         if let Some(composite) = other.composite {
             proto.set_composite(composite);
         }

--- a/components/sup/src/manager/service/mod.rs
+++ b/components/sup/src/manager/service/mod.rs
@@ -95,6 +95,7 @@ pub struct Service {
     pub service_group: ServiceGroup,
     pub bldr_url: String,
     pub channel: String,
+    pub desired_state: DesiredState,
     pub spec_file: PathBuf,
     pub spec_ident: PackageIdent,
     pub topology: Topology,
@@ -179,6 +180,7 @@ impl Service {
             config_renderer: CfgRenderer::new(&config_root)?,
             bldr_url: spec.bldr_url,
             channel: spec.channel,
+            desired_state: spec.desired_state,
             health_check: HealthCheck::default(),
             hooks: HookTable::load(
                 &service_group,


### PR DESCRIPTION
## 🔩 Description:
This PR changes the `hab svc status` output by:
* replacing the `uptime` column header with the word `elapsed` to more accurately convey the column intent (the time elapsed since supervisor tracked current state or service)
* adding a new column header: `desired` to reflect the `desired_state` from the Service's `.spec` file

In doing so, it address https://github.com/habitat-sh/habitat/issues/5063

## 👟 Test It:
![cat05](https://user-images.githubusercontent.com/1991696/40580373-7dfc220c-6102-11e8-840b-3f53882ee55a.jpg)

```bash
root@4eaba54ae0b6:/src# ./target/debug/hab svc status
package                          type        desired  state  elapsed (s)  pid  group
core/redis/3.2.4/20170514150022  standalone  up       up     2            258  redis.default
root@4eaba54ae0b6:/src# ./target/debug/hab svc stop core/redis
hab-sup(AG): Supervisor stopping core/redis. See the Supervisor output for more details.
Supervisor stopping core/redis. See the Supervisor output for more details.
root@4eaba54ae0b6:/src#
root@4eaba54ae0b6:/src# redis.default(O): 258:signal-handler (1527369019) Received SIGTERM scheduling shutdown...
redis.default(O): 258:M 26 May 21:10:19.113 # User requested shutdown...
redis.default(O): 258:M 26 May 21:10:19.114 * Saving the final RDB snapshot before exiting.
redis.default(O): 258:M 26 May 21:10:19.118 * DB saved on disk
redis.default(O): 258:M 26 May 21:10:19.118 * Removing the pid file.
redis.default(O): 258:M 26 May 21:10:19.118 # Redis is now ready to exit, bye bye...
hab-launch(SV): Child for service 'redis.default' with PID 258 exited with code exit code: 0

root@4eaba54ae0b6:/src# ./target/debug/hab svc status
package                          type        desired  state  elapsed (s)  pid     group
core/redis/3.2.4/20170514150022  standalone  down     down   5            <none>  redis.default
root@4eaba54ae0b6:/src#
```

Signed-off-by: Jeremy J. Miller <jm@chef.io>