### PR TITLE
Improve error message when acting on a service that isn't loaded

### DIFF
--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -284,7 +284,7 @@ impl Manager {
             }
             return Err(net::err(
                 ErrCode::NotFound,
-                format!("{} not loaded.", ident),
+                format!("Service not loaded, {}", ident),
             ));
         } else {
             let mut list = statuses.into_iter().peekable();
@@ -786,7 +786,7 @@ impl Manager {
         }
         Err(net::err(
             ErrCode::NotFound,
-            format!("{} not loaded.", ident),
+            format!("Service not loaded, {}", ident),
         ))
     }
 
@@ -847,7 +847,7 @@ impl Manager {
         // }
         // Err(net::err(
         //     ErrCode::NotFound,
-        //     format!("{} not loaded.", service_group),
+        //     format!("Service not loaded, {}", service_group),
         // ))
     }
 
@@ -1183,7 +1183,7 @@ impl Manager {
             None => {
                 return Err(net::err(
                     ErrCode::NotFound,
-                    format!("Failed to locate service, {}", &ident),
+                    format!("Service not loaded, {}", &ident),
                 ));
             }
         };
@@ -1231,7 +1231,7 @@ impl Manager {
             None => {
                 return Err(net::err(
                     ErrCode::NotFound,
-                    format!("Failed to locate service, {}", &ident),
+                    format!("Service not loaded, {}", &ident),
                 ));
             }
         };


### PR DESCRIPTION
This will clarify the error message returned when you attempt to start
or stop a service which is not loaded. The previous error didn't contain
any messaging around `loaded` vs `unloaded` state and just messaged that
a service could not be located.

In addition, all other messages have been updated to reflect the same
messaging when attempting to act on a service which has not been loaded.