### PR TITLE
Ignore Err result in send_msg rather than panicking

### DIFF
--- a/components/sup/src/ctl_gateway/mod.rs
+++ b/components/sup/src/ctl_gateway/mod.rs
@@ -124,7 +124,7 @@ impl CtlRequest {
         }
         let mut wire: protocol::codec::SrvMessage = msg.into();
         wire.reply_for(self.transaction.unwrap(), complete);
-        self.tx.as_ref().unwrap().start_send(wire).unwrap();
+        self.tx.as_ref().unwrap().start_send(wire).ok(); // ignore Err return
     }
 }
 


### PR DESCRIPTION
Why we're getting an error from protocol::codec::SrvMessage::start_send is
not clear, but since we can't do much, it's better to silently ignore the error

Resolves https://github.com/habitat-sh/habitat/issues/5148
Resolves https://github.com/habitat-sh/habitat/issues/5151

Signed-off-by: Jon Bauman <5906042+baumanj@users.noreply.github.com>