### PR TITLE
Fix serialization problem where defaults were injected

### DIFF
--- a/components/sup-protocol/protocols/types.proto
+++ b/components/sup-protocol/protocols/types.proto
@@ -35,7 +35,7 @@ enum BindingMode {
 
 message ApplicationEnvironment {
   required string application = 1;
-  required string environment = 2 [default = "default"];
+  required string environment = 2;
 }
 
 message PackageIdent {
@@ -70,7 +70,7 @@ message ServiceCfg {
 
 message ServiceGroup {
   required string service = 1;
-  required string group = 2 [default = "default"];
+  required string group = 2;
   optional ApplicationEnvironment application_environment = 3;
   optional string organization = 4;
 }

--- a/components/sup-protocol/src/generated/sup.types.rs
+++ b/components/sup-protocol/src/generated/sup.types.rs
@@ -3,7 +3,7 @@
 pub struct ApplicationEnvironment {
     #[prost(string, required, tag = "1")]
     pub application: String,
-    #[prost(string, required, tag = "2", default = "default")]
+    #[prost(string, required, tag = "2")]
     pub environment: String,
 }
 #[derive(Clone, PartialEq, Message, Serialize, Deserialize, Hash)]
@@ -61,7 +61,7 @@ pub mod service_cfg {
 pub struct ServiceGroup {
     #[prost(string, required, tag = "1")]
     pub service: String,
-    #[prost(string, required, tag = "2", default = "default")]
+    #[prost(string, required, tag = "2")]
     pub group: String,
     #[prost(message, optional, tag = "3")]
     pub application_environment: ::std::option::Option<ApplicationEnvironment>,


### PR DESCRIPTION
Prost will incorrectly concat the default value specified in a protocol
file to the value of a field if the field is marked as required. This
change removes the default values that were placed in the protocol file
for `types.proto` to side step the issue, but we should follow up with
the creators of Prost to get this solved for real. We weren't using the
default value in the protocol file anyway, so this isn't much of a
change.