### PR TITLE
Make querying an unloaded service status always exit nonzero

### DIFF
--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -270,22 +270,20 @@ impl Manager {
         opts: protocol::ctl::SvcStatus,
     ) -> NetResult<()> {
         let statuses = Self::status(&mgr.cfg)?;
-        if statuses.is_empty() {
-            req.reply_complete(net::ok());
-            return Ok(());
-        }
         if let Some(ident) = opts.ident {
             for status in statuses {
                 if status.pkg.ident.satisfies(&ident) {
                     let mut msg: protocol::types::ServiceStatus = status.into();
                     req.reply_complete(msg);
-                    break;
+                    return Ok(());
                 }
             }
             return Err(net::err(
                 ErrCode::NotFound,
                 format!("Service not loaded, {}", ident),
             ));
+        } else if statuses.is_empty() {
+            req.reply_complete(net::ok());
         } else {
             let mut list = statuses.into_iter().peekable();
             while let Some(status) = list.next() {


### PR DESCRIPTION
Resolves https://github.com/habitat-sh/habitat/issues/5172

Previously, an early exit in the case of no loaded services caused a successful
exit even if there was an <IDENT> argument. This undermined the value of
`hab svc status <IDENT>` as a check on a service being loaded.

Also, this eliminates one cause of the crash avoided by
https://github.com/habitat-sh/habitat/pull/5166.
Calling CtlRequest::reply_complete multiple times resulted in an inconsistent
state for the request. That fix should remain, since it's preferable to not
crash, but it illustrates why the CtlRequest.tx debug output was confusing.

Signed-off-by: Jon Bauman <5906042+baumanj@users.noreply.github.com>