### PR TITLE
Make one of group ID or origin arguments required for `hab bldr job status`

### DIFF
--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -161,6 +161,7 @@ pub fn get() -> App<'static, 'static> {
                     (about: "Get the status of one or more job groups")
                     (aliases: &["stat", "statu"])
                     (@group status =>
+                        (@attributes +required)
                         (@arg GROUP_ID: +takes_value
                             "The group id that was returned from \"hab bldr job start\" \
                             (ex: 771100000000000000)")


### PR DESCRIPTION
Resolves https://github.com/habitat-sh/habitat/issues/5163

Signed-off-by: Jon Bauman <5906042+baumanj@users.noreply.github.com>