### PR TITLE
Add on-prem docs

### DIFF
--- a/www/source/docs/using-builder.html.md.erb
+++ b/www/source/docs/using-builder.html.md.erb
@@ -3,7 +3,7 @@ title: Habitat Docs - Working with Builder
 description: Documentation for Habitat uploading, auto-building, and deploying application packages with Habitat Builder.
 ---
 # <a name="using-builder" id="using-builder" data-magellan-target="using-builder">Working with Builder</a>
-<a target="_blank" href="https://bldr.habitat.sh/#/sign-in">Habitat Builder</a> allows you to store, automatically build, and deploy your Habitat packages. The documention below covers everything from creating an account to setting up automated build and exporting them to a variety of registries.
+<a target="_blank" href="https://bldr.habitat.sh/#/sign-in">Habitat Builder</a> allows you to store, automatically build, and deploy your Habitat packages. The documention below covers everything from creating an account to setting up automated builds and exporting packages to a variety of container registries.
 
 > For a guided walkthrough of this process, try the [Build System demo](/demo/build-system/steps/1/).
 
@@ -16,6 +16,7 @@ description: Documentation for Habitat uploading, auto-building, and deploying a
   - [Upload and Promote Packages](#sharing-pkgs)
   - [Using Multiple Plans](#multiple-plans-builder)
   - [Set up Automated Builds](#automated-builds)
+  - [Install and Use Builder On-Premises](#on-prem)
 
 ---
 <%= partial "/partials/docs/using-builder-create-account"%>
@@ -49,3 +50,5 @@ Replacing `<token>` with the contents of your generated token.
 <%= partial "/partials/docs/dev-pkgs-multiple-plans-builder"%>
 ---
 <%= partial "/partials/docs/using-builder-automated-builds"%>
+---
+<%= partial "/partials/docs/using-builder-on-prem"%>

--- a/www/source/partials/docs/_using-builder-on-prem.html.md.erb
+++ b/www/source/partials/docs/_using-builder-on-prem.html.md.erb
@@ -1,0 +1,5 @@
+## <a name="on-prem" id="on-prem" data-magellan-target="on-prem">Install and Use Builder On-Premises</a>
+
+In addition to our hosted service, we also support installing and running Habitat Builder on-premises, using your own network and infrastructure, which allows you to choose from a wider selection of authentication providers and to manage how Builder fits into your existing CI/CD processes.
+
+For a detailed explanation of features, requirements and setup instructions, [see the GitHub repository](https://github.com/habitat-sh/on-prem-builder).


### PR DESCRIPTION
This change adds a bit about running Builder on-prem, and points users over to the GitHub repository for details.

Signed-off-by: Christian Nunciato <chris@nunciato.org>

Fixes #5076.

![](https://i.giphy.com/media/3o7aCTPPm4OHfRLSH6/200w.gif)