### PR TITLE
proper process state type on hab svc status

### DIFF
--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -85,7 +85,7 @@ const HABITAT_USER_ENVVAR: &'static str = "HAB_USER";
 
 lazy_static! {
     static ref STATUS_HEADER: Vec<&'static str> = {
-        vec!["package", "type", "state", "uptime (s)", "pid", "group"]
+        vec!["package", "type", "state", "elapsed (s)", "pid", "group"]
     };
 
     /// The default filesystem root path to base all commands from. This is lazily generated on
@@ -1377,7 +1377,12 @@ where
     write!(
         out,
         "{}\t{}\t{}\t{}\t{}\t{}\n",
-        status.ident, svc_type, svc_state, svc_elapsed, svc_pid, status.service_group,
+        status.ident,
+        svc_type,
+        ProcessState::from_str(&svc_state)?,
+        svc_elapsed,
+        svc_pid,
+        status.service_group,
     )?;
     out.flush()?;
     return Ok(());

--- a/components/sup-protocol/src/types.rs
+++ b/components/sup-protocol/src/types.rs
@@ -103,6 +103,21 @@ impl FromStr for BindingMode {
     }
 }
 
+impl FromStr for ProcessState {
+    type Err = NetErr;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.to_lowercase().as_ref() {
+            "0" => Ok(ProcessState::Down),
+            "1" => Ok(ProcessState::Up),
+            _ => Err(net::err(
+                ErrCode::InvalidPayload,
+                format!("Invalid process state \"{}\"", value),
+            )),
+        }
+    }
+}
+
 impl FromStr for ServiceBind {
     type Err = NetErr;
 


### PR DESCRIPTION
This change:
* partially addresses #5063 by changing one of the column headings of `hab svc status` from `uptime` to `elapsed`
* addresses #5196 by converting the i32 type of the `SvcStatus` message response to `ProcessState` and adding a `FromStr` implementation for the conversion to "**up**"  or "**down**" as per sup proto [spec](https://github.com/habitat-sh/habitat/blob/master/components/sup-protocol/protocols/types.proto#L13-L14) 

![still-jumping-up-and-down-mtoll-10965853-222-275](https://user-images.githubusercontent.com/1991696/41562692-013feb72-7313-11e8-8e9f-4face53ec344.gif)

 ```
jmiller@alamos:/habitat$ sudo -E ./target/debug/hab svc status
package                          type        state  elapsed (s)  pid    group
core/redis/3.2.4/20170514150022  standalone  up     13           15766  redis.default
chef/automate-elasticsearch/6.2.2/20180527141927  standalone  down  13  0   automate-elasticsearch.default
jmiller@alamos:/habitat$
```

Signed-off-by: Jeremy J. Miller <jm@chef.io>