### PR TITLE
Revert "Revert "Fix existing lints and automate running shellcheck""

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,13 @@ matrix:
 ########################################################################
 
 #
+# Job for linting Habitat shell program components
+#
+    - sudo: false
+      script:
+        - ./test/shellcheck.sh
+
+#
 # Job for testing Habitat Rust program components
 #
     - language: rust

--- a/components/bintray-publish/bin/publish-studio.sh
+++ b/components/bintray-publish/bin/publish-studio.sh
@@ -46,7 +46,7 @@ fi
 
 # **Internal** Prints help and usage information. Straight forward, no?
 print_help() {
-  printf -- "$program $version
+  echo -- "$program $version
 
 $author
 
@@ -60,7 +60,6 @@ COMMON FLAGS:
     -o  Specify the Bintray organization to publish to (default: habitat)
     -r  Specify the Bintray repo to publish to (default: stable)
     -V  Prints version information
-
 "
 }
 
@@ -73,7 +72,7 @@ COMMON FLAGS:
 #
 # Would return 0 if gsha256sum exists, 1 if it does not.
 exists() {
-  if command -v $1 >/dev/null 2>&1
+  if command -v "$1" >/dev/null 2>&1
   then
     return 0
   else
@@ -95,7 +94,7 @@ exit_with() {
       echo "ERROR: $1"
       ;;
   esac
-  exit $2
+  exit "$2"
 }
 
 # **Internal** Ensures that the correct versions of key system commands are
@@ -132,18 +131,19 @@ _find_system_commands() {
 info() {
   case "${TERM:-}" in
     *term | xterm-* | rxvt | screen | screen-*)
-      printf -- "   \033[1;36m${program:-unknown}: \033[1;37m${1:-}\033[0m\n"
+      printf -- "   \033[1;36m%s: \033[1;37m%s\033[0m\n" "${program:-unknown}" "${1:-}"
       ;;
     *)
-      printf -- "   ${program:-unknown}: ${1:-}\n"
+      printf -- "   %s: %s\n" "${program:-unknown}" "${1:-}"
       ;;
   esac
   return 0
 }
 
 # **Internal** Main program.
+# shellcheck disable=2120,2154
 _main() {
-  build-docker-image $@
+  build-docker-image
   if [[ ! -f ./results/last_image.env ]]; then
     exit_with "Image build report ./results/last_image.env missing, aborting" 5
   fi
@@ -172,6 +172,7 @@ _main() {
 
 BINTRAY_ORG=habitat
 BINTRAY_REPO=stable
+# shellcheck disable=2123
 PATH=@path@
 
 # The current version of this program
@@ -179,7 +180,7 @@ version='@version@'
 # The author of this program
 author='@author@'
 # The short version of the program name which is used in logging output
-program=$(basename $0)
+program=$(basename "$0")
 
 # ## CLI Argument Parsing
 
@@ -219,4 +220,5 @@ if [[ -z "${BINTRAY_KEY:-}" ]]; then
 fi
 
 _find_system_commands
+# shellcheck disable=2119
 _main

--- a/components/bintray-publish/plan.sh
+++ b/components/bintray-publish/plan.sh
@@ -1,3 +1,4 @@
+# shellcheck disable=2154
 pkg_name=hab-bintray-publish
 pkg_origin=core
 pkg_version=$(cat "$PLAN_CONTEXT/../../VERSION")
@@ -9,20 +10,20 @@ pkg_bin_dirs=(bin)
 programs=(publish-hab publish-studio)
 
 do_build() {
-  cp -v $PLAN_CONTEXT/../studio/build-docker-image.sh \
-    $CACHE_PATH/build-docker-image
+  cp -v "$PLAN_CONTEXT"/../studio/build-docker-image.sh \
+    "$CACHE_PATH"/build-docker-image
 
   local run_path=""
   for dep in "${pkg_deps[@]}"; do
     if [[ -z $run_path ]]; then
-      run_path="$(pkg_path_for $dep)/bin"
+      run_path="$(pkg_path_for "$dep")/bin"
     else
-      run_path="$(pkg_path_for $dep)/bin:$run_path"
+      run_path="$(pkg_path_for "$dep")/bin:$run_path"
     fi
   done
 
   for program in "${programs[@]}"; do
-    cp -v $PLAN_CONTEXT/bin/${program}.sh $CACHE_PATH/${program}
+    cp -v "$PLAN_CONTEXT"/bin/"${program}".sh "$CACHE_PATH"/"${program}"
 
     # Use the bash from our dependency list as the shebang. Also, embed the
     # release version of the program.
@@ -31,12 +32,12 @@ do_build() {
       -e "s,@author@,$pkg_maintainer,g" \
       -e "s,@path@,$pkg_prefix/bin:$run_path,g" \
       -e "s,@version@,$pkg_version/$pkg_release,g" \
-      -i $CACHE_PATH/$program
+      -i "$CACHE_PATH"/"$program"
   done
 }
 
 do_install() {
   for program in "${programs[@]}" build-docker-image; do
-    install -v -D $CACHE_PATH/$program $pkg_prefix/bin/$program
+    install -v -D "$CACHE_PATH"/"$program" "$pkg_prefix"/bin/"$program"
   done
 }

--- a/components/eventsrv/habitat/plan.sh
+++ b/components/eventsrv/habitat/plan.sh
@@ -1,3 +1,4 @@
+# shellcheck disable=2154
 source "../../../support/ci/builder-base-plan.sh"
 pkg_name=hab-eventsrv
 pkg_origin=core

--- a/components/hab/mac/mac-build.sh
+++ b/components/hab/mac/mac-build.sh
@@ -13,10 +13,10 @@ fi
 info() {
   case "${TERM:-}" in
     *term | xterm-* | rxvt | screen | screen-*)
-      printf -- "   \033[1;33m$(basename $0): \033[1;37m$1\033[0m\n"
+      printf -- "   \033[1;33m%s: \033[1;37m%s\033[0m\n" "$(basename "$0")" "$1"
       ;;
     *)
-      printf -- "   $(basename $0): $1\n"
+      printf -- "   %s: %s\n" "$(basename "$0")" "$1"
       ;;
   esac
   return 0
@@ -30,15 +30,15 @@ install_if_missing() {
     local formula="$pkg"
   fi
 
-  echo $(sudo -u ${SUDO_USER} brew list --versions ${pkg})
+  sudo -u "${SUDO_USER}" brew list --versions "${pkg}"
 
-  if [[ $(sudo -u ${SUDO_USER} brew list --versions $pkg | wc -l) -eq 0 ]]; then
+  if [[ $(sudo -u "${SUDO_USER}" brew list --versions "$pkg" | wc -l) -eq 0 ]]; then
     info "Installing missing Homebrew package $formula"
-    sudo -u $SUDO_USER brew install $formula
+    sudo -u "$SUDO_USER" brew install "$formula"
   fi
 }
 
-if (( $EUID != 0 )); then
+if (( EUID != 0 )); then
   info "Please run as root (with \`sudo $0 $*\`)"
   exit 1
 fi
@@ -46,17 +46,18 @@ fi
 if [[ ! -f /usr/local/bin/hab ]]; then
   info "Habitat CLI missing, attempting to install latest release"
   mkdir -p /usr/local/bin
-  sh $(dirname $0)/../install.sh
+  sh "$(dirname "$0")"/../install.sh
 fi
 
 while true; do
-  if [[ $(ls -1 /hab/cache/keys/core-*.sig.key 2> /dev/null | wc -l) -gt 0 ]]; then
+  # shellcheck disable=2012
+  if [[ $(find /hab/cache/keys/ -name "core-*.sig.key") ]]; then
     break
   elif [[ -f /tmp/hab.sig.key ]]; then
-    cat /tmp/hab.sig.key | hab origin key import
+    hab origin key import < /tmp/hab.sig.key
     rm -f /tmp/hab.sig.key
   else
-    printf ${ORIGIN_KEY} | hab origin key import
+    hab origin key import <<< "${ORIGIN_KEY}"
   fi
 done
 
@@ -76,7 +77,7 @@ fi
 
 if ! command -v brew >/dev/null; then
   info "Homebrew missing, attempting to install"
-  sudo -u $SUDO_USER /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)" < /dev/null
+  sudo -u "$SUDO_USER" /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)" < /dev/null
 fi
 
 # Homebrew packages required to run `hab-plan-build.sh
@@ -84,7 +85,7 @@ install_if_missing coreutils
 install_if_missing gnu-tar
 install_if_missing wget
 install_if_missing bash
-install_if_missing hab-rq $(dirname $0)/homebrew/hab-rq.rb
+install_if_missing hab-rq "$(dirname "$0")"/homebrew/hab-rq.rb
 
 # Homebrew packages required to build `hab`
 install_if_missing zlib homebrew/dupes/zlib
@@ -93,8 +94,8 @@ install_if_missing bzip2 homebrew/dupes/bzip2
 install_if_missing expat
 install_if_missing openssl
 install_if_missing libsodium
-install_if_missing hab-libiconv $(dirname $0)/homebrew/hab-libiconv.rb
-install_if_missing hab-libarchive $(dirname $0)/homebrew/hab-libarchive.rb
+install_if_missing hab-libiconv "$(dirname "$0")"/homebrew/hab-libiconv.rb
+install_if_missing hab-libarchive "$(dirname "$0")"/homebrew/hab-libarchive.rb
 
 if ! command -v rustc >/dev/null; then
   info "Rust missing, attempting to install"
@@ -112,7 +113,7 @@ gnu_path="$gnu_path:$(brew --prefix bash)/bin"
 export PATH="$gnu_path:$PATH"
 info "Setting PATH=$PATH"
 
-program="$(dirname $0)/../../plan-build/bin/hab-plan-build.sh"
+program="$(dirname "$0")/../../plan-build/bin/hab-plan-build.sh"
 info "Executing: $program $*"
 echo
-exec $(brew --prefix bash)/bin/bash $program $*
+exec "$(brew --prefix bash)"/bin/bash "$program" "$@"

--- a/components/hab/mac/plan.sh
+++ b/components/hab/mac/plan.sh
@@ -1,3 +1,4 @@
+# shellcheck disable=2154
 PLAN_CONTEXT=$(dirname "$PLAN_CONTEXT") source ../plan.sh
 
 pkg_name=hab
@@ -15,6 +16,7 @@ do_begin() {
   PLAN_CONTEXT="$(abspath ..)"
 }
 
+# shellcheck disable=2155
 do_prepare() {
   # Can be either `--release` or `--debug` to determine cargo build strategy
   build_type="--release"

--- a/components/hab/plan.sh
+++ b/components/hab/plan.sh
@@ -1,3 +1,4 @@
+# shellcheck disable=2154
 pkg_name=hab
 _pkg_distname=$pkg_name
 pkg_origin=core
@@ -36,6 +37,7 @@ _common_prepare() {
   build_line "Setting CARGO_TARGET_DIR=$CARGO_TARGET_DIR"
 }
 
+# shellcheck disable=2155
 do_prepare() {
   _common_prepare
 
@@ -71,8 +73,8 @@ do_build() {
 }
 
 do_install() {
-  install -v -D $CARGO_TARGET_DIR/$rustc_target/${build_type#--}/$bin \
-    $pkg_prefix/bin/$bin
+  install -v -D "$CARGO_TARGET_DIR"/$rustc_target/${build_type#--}/$bin \
+    "$pkg_prefix"/bin/$bin
 }
 
 do_strip() {

--- a/components/launcher/habitat/plan.sh
+++ b/components/launcher/habitat/plan.sh
@@ -8,6 +8,7 @@ pkg_build_deps=(core/coreutils core/rust core/gcc core/git)
 pkg_bin_dirs=(bin)
 bin="hab-launch"
 
+# shellcheck disable=2155
 do_prepare() {
   do_builder_prepare
 

--- a/components/pkg-aci/bin/hab-pkg-aci.sh
+++ b/components/pkg-aci/bin/hab-pkg-aci.sh
@@ -56,7 +56,7 @@ fi
 
 # **Internal** Prints help
 print_help() {
-  printf -- "$program $version
+  echo -- "$program $version
 
 $author
 
@@ -74,25 +74,25 @@ USAGE:
 # ```
 exit_with() {
   if [ "${HAB_NOCOLORING:-}" = "true" ]; then
-    printf -- "ERROR: $1\n"
+    echo -- "ERROR: $1"
   else
     case "${TERM:-}" in
       *term | xterm-* | rxvt | screen | screen-*)
-        printf -- "\033[1;31mERROR: \033[1;37m$1\033[0m\n"
+        printf -- "\033[1;31mERROR: \033[1;37m%s\033[0m\n" "$1"
         ;;
       *)
-        printf -- "ERROR: $1\n"
+        printf -- "ERROR: %s\n" "$1"
         ;;
     esac
   fi
-  exit $2
+  exit "$2"
 }
 
 find_system_commands() {
-  if $(mktemp --version 2>&1 | grep -q 'GNU coreutils'); then
+  if mktemp --version 2>&1 | grep -q 'GNU coreutils'; then
     _mktemp_cmd=$(command -v mktemp)
   else
-    if $(/bin/mktemp --version 2>&1 | grep -q 'GNU coreutils'); then
+    if /bin/mktemp --version 2>&1 | grep -q 'GNU coreutils'; then
       _mktemp_cmd=/bin/mktemp
     else
       exit_with "We require GNU mktemp to build docker images; aborting" 1
@@ -102,44 +102,48 @@ find_system_commands() {
 
 package_name_for() {
   local pkg="$1"
-  echo $(echo $pkg | cut -d "/" -f 2)
+  echo "$pkg" | cut -d "/" -f 2
 }
 
 package_exposes() {
   local pkg="$1"
-  local expose_file=$(find $ACI_CONTEXT/rootfs/$HAB_ROOT_PATH/pkgs/$pkg -name EXPOSES)
+  local expose_file
+  expose_file=$(find "$ACI_CONTEXT"/rootfs/"$HAB_ROOT_PATH"/pkgs/"$pkg" -name EXPOSES)
   if [ -f "$expose_file" ]; then
-    cat $expose_file
+    cat "$expose_file"
   fi
 }
 
 package_version_tag() {
   local pkg="$1"
-  local ident_file=$(find $ACI_CONTEXT/rootfs/$HAB_ROOT_PATH/pkgs/$pkg -name IDENT)
-  cat $ident_file | awk 'BEGIN { FS = "/" }; { print $1 "-" $2 "-" $3 "-" $4 }'
+  local ident_file
+  ident_file=$(find "$ACI_CONTEXT"/rootfs/"$HAB_ROOT_PATH"/pkgs/"$pkg" -name IDENT)
+  awk 'BEGIN { FS = "/" }; { print $1 "-" $2 "-" $3 "-" $4 }' < "$ident_file"
 }
 
 build_aci() {
   ACI_CONTEXT="$($_mktemp_cmd -t -d "${program}-XXXX")"
   BUILD_DIR="$($_mktemp_cmd -t -d "${program}-XXXX")"
   pushd "$BUILD_DIR" > /dev/null
-  env PKGS="$@" NO_MOUNT=1 hab-studio -r $ACI_CONTEXT/rootfs -t baseimage new
-  local pkg_name=$(package_name_for $1)
-  local version_tag=$(package_version_tag $1)
-  echo "$1" > $ACI_CONTEXT/rootfs/.hab_pkg
-  $ACBUILD begin $ACI_CONTEXT/rootfs
-  $ACBUILD set-name $1
+  env PKGS="$*" NO_MOUNT=1 hab-studio -r "$ACI_CONTEXT"/rootfs -t baseimage new
+  local pkg_name
+  pkg_name=$(package_name_for "$1")
+  local version_tag
+  version_tag=$(package_version_tag "$1")
+  echo "$1" > "$ACI_CONTEXT"/rootfs/.hab_pkg
+  $ACBUILD begin "$ACI_CONTEXT"/rootfs
+  $ACBUILD set-name "$1"
   # expose the habitat status endpoint by default
   $ACBUILD port add habitat tcp 9631
-  while read expose; do
-    $ACBUILD port add ${pkg_name}-${expose} tcp ${expose}
-  done < <(package_exposes $1)
+  while read -r expose; do
+    $ACBUILD port add "${pkg_name}"-"${expose}" tcp "${expose}"
+  done < <(package_exposes "$1")
   # mount habitat's data and config
-  $ACBUILD mount add hab-data $HAB_ROOT_PATH/svc/${pkg_name}/data
-  $ACBUILD mount add hab-config $HAB_ROOT_PATH/svc/${pkg_name}/config
-  $ACBUILD environment add $(grep PATH $ACI_CONTEXT/rootfs/init.sh)
+  $ACBUILD mount add hab-data "$HAB_ROOT_PATH"/svc/"${pkg_name}"/data
+  $ACBUILD mount add hab-config "$HAB_ROOT_PATH"/svc/"${pkg_name}"/config
+  $ACBUILD environment add "$(grep PATH "$ACI_CONTEXT"/rootfs/init.sh)"
   $ACBUILD set-exec "/init.sh" start "$1"
-  $ACBUILD write "$version_tag.aci" ${ACI_SIGN}
+  $ACBUILD write "$version_tag.aci" "${ACI_SIGN}"
   $ACBUILD end
   cp -a "$version_tag.aci" "$HAB_RESULTS_DIR"
   [ -f "$version_tag.aci.asc" ] && cp -a "$version_tag.aci.asc" "$HAB_RESULTS_DIR"
@@ -150,28 +154,28 @@ build_aci() {
 # The root of the filesystem. If the program is running on a separate
 # filesystem or chroot environment, this environment variable may need to be
 # set.
-: ${FS_ROOT:=}
+: "${FS_ROOT:=}"
 # The root path of the Habitat file system. If the `$HAB_ROOT_PATH` environment
 # variable is set, this value is overridden, otherwise it is set to its default
-: ${HAB_ROOT_PATH:=$FS_ROOT/hab}
+: "${HAB_ROOT_PATH:=$FS_ROOT/hab}"
 # Directory to write ACIs to. If $HAB_RESULTS_DIR environment variable
 # is set, this value is overridden
-: ${HAB_RESULTS_DIR:=/src/results}
+: "${HAB_RESULTS_DIR:=/src/results}"
 
 # The current version of Habitat Studio
 version='@version@'
 # The author of this program
 author='@author@'
 # The short version of the program name which is used in logging output
-program=$(basename $0)
+program=$(basename "$0")
 
 find_system_commands
 
-if [ -z "$@" ]; then
+if [ -z "$*" ]; then
   print_help
   exit_with "You must specify one or more Habitat packages to create an ACI from." 1
-elif [ "$@" == "--help" ]; then
+elif [ "$*" == "--help" ]; then
   print_help
 else
-  build_aci $@
+  build_aci "$@"
 fi

--- a/components/pkg-aci/plan.sh
+++ b/components/pkg-aci/plan.sh
@@ -1,3 +1,4 @@
+# shellcheck disable=2154
 pkg_origin=core
 pkg_name=hab-pkg-aci
 pkg_version=$(cat "$PLAN_CONTEXT/../../VERSION")
@@ -11,7 +12,8 @@ pkg_bin_dirs=(bin)
 program=$pkg_name
 
 do_build() {
-  cp -v $PLAN_CONTEXT/bin/${program}.sh ${program}
+  cp -v "${PLAN_CONTEXT}/bin/${program}.sh" "${program}"
+
 
   # Use the bash from our dependency list as the shebang. Also, embed the
   # release version of the program.
@@ -23,7 +25,7 @@ do_build() {
 }
 
 do_install() {
-  install -v -D $program $pkg_prefix/bin/$program
+  install -v -D "$program" "$pkg_prefix/bin/$program"
 }
 
 # Turn the remaining default phases into no-ops

--- a/components/pkg-cfize/plan.sh
+++ b/components/pkg-cfize/plan.sh
@@ -1,3 +1,4 @@
+# shellcheck disable=2154
 pkg_name=hab-pkg-cfize
 pkg_origin=core
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"

--- a/components/pkg-dockerize/plan.sh
+++ b/components/pkg-dockerize/plan.sh
@@ -1,3 +1,4 @@
+# shellcheck disable=2154
 pkg_name=hab-pkg-dockerize
 pkg_origin=core
 pkg_version=$(cat "$PLAN_CONTEXT/../../VERSION")
@@ -11,7 +12,7 @@ pkg_bin_dirs=(bin)
 program=$pkg_name
 
 do_build() {
-  cp -v $PLAN_CONTEXT/bin/${program}.sh ${program}
+  cp -v "$PLAN_CONTEXT"/bin/${program}.sh ${program}
 
   # Use the bash from our dependency list as the shebang. Also, embed the
   # release version of the program.
@@ -23,7 +24,7 @@ do_build() {
 }
 
 do_install() {
-  install -v -D $program $pkg_prefix/bin/$program
+  install -v -D $program "$pkg_prefix"/bin/$program
 }
 
 # Turn the remaining default phases into no-ops

--- a/components/pkg-export-docker/plan.sh
+++ b/components/pkg-export-docker/plan.sh
@@ -1,3 +1,4 @@
+# shellcheck disable=2154
 pkg_name=hab-pkg-export-docker
 _pkg_distname=$pkg_name
 pkg_origin=core
@@ -36,6 +37,7 @@ _common_prepare() {
   build_line "Setting CARGO_TARGET_DIR=$CARGO_TARGET_DIR"
 }
 
+# shellcheck disable=2155
 do_prepare() {
   _common_prepare
 
@@ -69,14 +71,14 @@ do_prepare() {
 }
 
 do_build() {
-  pushd $PLAN_CONTEXT > /dev/null
+  pushd "$PLAN_CONTEXT" > /dev/null
   cargo build ${build_type#--debug} --target=$rustc_target --verbose
   popd > /dev/null
 }
 
 do_install() {
-  install -v -D $CARGO_TARGET_DIR/$rustc_target/${build_type#--}/$bin \
-    $pkg_prefix/bin/$bin
+  install -v -D "$CARGO_TARGET_DIR"/$rustc_target/${build_type#--}/$bin \
+    "$pkg_prefix"/bin/$bin
 }
 
 do_strip() {

--- a/components/pkg-export-helm/plan.sh
+++ b/components/pkg-export-helm/plan.sh
@@ -1,3 +1,4 @@
+# shellcheck disable=2154
 pkg_name=hab-pkg-export-helm
 _pkg_distname=$pkg_name
 pkg_origin=core
@@ -34,6 +35,7 @@ _common_prepare() {
   build_line "Setting CARGO_TARGET_DIR=$CARGO_TARGET_DIR"
 }
 
+# shellcheck disable=2155
 do_prepare() {
   _common_prepare
 
@@ -63,14 +65,14 @@ do_prepare() {
 }
 
 do_build() {
-  pushd $PLAN_CONTEXT > /dev/null
+  pushd "$PLAN_CONTEXT" > /dev/null
   cargo build ${build_type#--debug} --target=$rustc_target --verbose
   popd > /dev/null
 }
 
 do_install() {
-  install -v -D $CARGO_TARGET_DIR/$rustc_target/${build_type#--}/$bin \
-    $pkg_prefix/bin/$bin
+  install -v -D "$CARGO_TARGET_DIR"/$rustc_target/${build_type#--}/$bin \
+    "$pkg_prefix"/bin/$bin
 }
 
 do_strip() {

--- a/components/pkg-export-kubernetes/plan.sh
+++ b/components/pkg-export-kubernetes/plan.sh
@@ -1,3 +1,4 @@
+# shellcheck disable=2154
 pkg_name=hab-pkg-export-kubernetes
 _pkg_distname=$pkg_name
 pkg_origin=core
@@ -34,6 +35,7 @@ _common_prepare() {
   build_line "Setting CARGO_TARGET_DIR=$CARGO_TARGET_DIR"
 }
 
+# shellcheck disable=2155
 do_prepare() {
   _common_prepare
 
@@ -63,14 +65,14 @@ do_prepare() {
 }
 
 do_build() {
-  pushd $PLAN_CONTEXT > /dev/null
+  pushd "$PLAN_CONTEXT" > /dev/null
   cargo build ${build_type#--debug} --target=$rustc_target --verbose
   popd > /dev/null
 }
 
 do_install() {
-  install -v -D $CARGO_TARGET_DIR/$rustc_target/${build_type#--}/$bin \
-    $pkg_prefix/bin/$bin
+  install -v -D "$CARGO_TARGET_DIR"/$rustc_target/${build_type#--}/$bin \
+    "$pkg_prefix"/bin/$bin
 }
 
 do_strip() {

--- a/components/pkg-export-tar/plan.sh
+++ b/components/pkg-export-tar/plan.sh
@@ -1,3 +1,4 @@
+# shellcheck disable=2154
 pkg_name=hab-pkg-export-tar
 _pkg_distname=$pkg_name
 pkg_origin=core
@@ -35,6 +36,7 @@ _common_prepare() {
   build_line "Setting CARGO_TARGET_DIR=$CARGO_TARGET_DIR"
 }
 
+# shellcheck disable=2155
 do_prepare() {
   _common_prepare
 
@@ -68,12 +70,12 @@ do_prepare() {
 }
 
 do_build() {
-  pushd $PLAN_CONTEXT > /dev/null
+  pushd "$PLAN_CONTEXT" > /dev/null
   cargo build ${build_type#--debug} --target=$rustc_target --verbose
   popd > /dev/null
 }
 
 do_install() {
-  install -v -D $CARGO_TARGET_DIR/$rustc_target/${build_type#--}/$bin \
-    $pkg_prefix/bin/$bin
+  install -v -D "$CARGO_TARGET_DIR"/$rustc_target/${build_type#--}/$bin \
+    "$pkg_prefix"/bin/$bin
 }

--- a/components/pkg-mesosize/bin/hab-pkg-mesosize.sh
+++ b/components/pkg-mesosize/bin/hab-pkg-mesosize.sh
@@ -30,11 +30,11 @@
 # ```
 
 # defaults for the application
-: ${CPU:="0.5"}
-: ${DISK:="0"}
-: ${INSTANCES:="1"}
-: ${MEM:="256"}
-: ${PKG:="unknown"}
+: "${CPU:="0.5"}"
+: "${DISK:="0"}"
+: "${INSTANCES:="1"}"
+: "${MEM:="256"}"
+: "${PKG:="unknown"}"
 
 # Fail if there are any unset variables and whenever a command returns a
 # non-zero exit code.
@@ -50,7 +50,7 @@ fi
 
 # **Internal** Prints help
 print_help() {
-  printf -- "$program $version
+  echo -- "$program $version
 
 $author
 
@@ -80,25 +80,25 @@ ARGS:
 # ```
 exit_with() {
   if [ "${HAB_NOCOLORING:-}" = "true" ]; then
-    printf -- "ERROR: $1\n"
+    printf -- "ERROR: %s\n" "$1"
   else
     case "${TERM:-}" in
       *term | xterm-* | rxvt | screen | screen-*)
-        printf -- "\033[1;31mERROR: \033[1;37m$1\033[0m\n"
+        printf -- "\033[1;31mERROR: \033[1;37m%s\033[0m\n" "$1"
         ;;
       *)
-        printf -- "ERROR: $1\n"
+        printf -- "ERROR: %s\n" "$1"
         ;;
     esac
   fi
-  exit $2
+  exit "$2"
 }
 
 find_system_commands() {
-  if $(mktemp --version 2>&1 | grep -q 'GNU coreutils'); then
+  if mktemp --version 2>&1 | grep -q 'GNU coreutils'; then
     _mktemp_cmd=$(command -v mktemp)
   else
-    if $(/bin/mktemp --version 2>&1 | grep -q 'GNU coreutils'); then
+    if /bin/mktemp --version 2>&1 | grep -q 'GNU coreutils'; then
       _mktemp_cmd=/bin/mktemp
     else
       exit_with "We require GNU mktemp to build Mesos applications; aborting" 1
@@ -145,16 +145,17 @@ parse_options() {
 # Create a hab studio baseimage and populate it with the application
 build_tarball_image() {
   TARBALL_CONTEXT="$($_mktemp_cmd -t -d "${program}-XXXX")"
-  pushd $TARBALL_CONTEXT > /dev/null
-  env PKGS="$PKG" NO_MOUNT=1 hab studio -r $TARBALL_CONTEXT -t bare new
-  echo $PKG > $TARBALL_CONTEXT/.hab_pkg
+  pushd "$TARBALL_CONTEXT" > /dev/null
+  env PKGS="$PKG" NO_MOUNT=1 hab studio -r "$TARBALL_CONTEXT" -t bare new
+  echo "$PKG" > "$TARBALL_CONTEXT"/.hab_pkg
   popd > /dev/null
-  tar -czpf $(package_name_with_version $PKG).tgz -C $TARBALL_CONTEXT ./
+  tar -czpf "$(package_name_with_version "$PKG")".tgz -C "$TARBALL_CONTEXT" ./
 }
 
 package_name_with_version() {
-  local ident_file=$(find $TARBALL_CONTEXT/$HAB_ROOT_PATH/pkgs/$PKG -name IDENT)
-  cat $ident_file | awk 'BEGIN { FS = "/" }; { print $1 "-" $2 "-" $3 "-" $4 }'
+  local ident_file
+  ident_file=$(find "$TARBALL_CONTEXT"/"$HAB_ROOT_PATH"/pkgs/"$PKG" -name IDENT)
+  awk 'BEGIN { FS = "/" }; { print $1 "-" $2 "-" $3 "-" $4 }' < "$ident_file"
 }
 
 # https://mesosphere.github.io/marathon/docs/application-basics.html
@@ -167,7 +168,7 @@ create_application_definition() {
    \"disk\": $DISK,
    \"mem\": $MEM,
    \"instances\": $INSTANCES,
-   \"uris\": [ \"URL_TO_$(package_name_with_version $PKG).tgz\" ]
+   \"uris\": [ \"URL_TO_$(package_name_with_version "$PKG").tgz\" ]
   }
 "
   # what about exposing ports?
@@ -176,22 +177,22 @@ create_application_definition() {
 # The root of the filesystem. If the program is running on a separate
 # filesystem or chroot environment, this environment variable may need to be
 # set.
-: ${FS_ROOT:=}
+: "${FS_ROOT:=}"
 # The root path of the Habitat file system. If the `$HAB_ROOT_PATH` environment
 # variable is set, this value is overridden, otherwise it is set to its default
-: ${HAB_ROOT_PATH:=$FS_ROOT/hab}
+: "${HAB_ROOT_PATH:=$FS_ROOT/hab}"
 
 # The current version of Habitat Studio
 version='@version@'
 # The author of this program
 author='@author@'
 # The short version of the program name which is used in logging output
-program=$(basename $0)
+program=$(basename "$0")
 
 find_system_commands
 
-parse_options $@
+parse_options "$@"
 build_tarball_image
 # publish the tarball somewhere? upload_tarball_to_artifact_store?
 create_application_definition
-rm -rf $TARBALL_CONTEXT
+rm -rf "$TARBALL_CONTEXT"

--- a/components/pkg-mesosize/plan.sh
+++ b/components/pkg-mesosize/plan.sh
@@ -1,3 +1,4 @@
+# shellcheck disable=2154
 pkg_name=hab-pkg-mesosize
 pkg_origin=core
 pkg_version=$(cat "$PLAN_CONTEXT/../../VERSION")
@@ -11,7 +12,7 @@ pkg_bin_dirs=(bin)
 program=$pkg_name
 
 do_build() {
-  cp -v $PLAN_CONTEXT/bin/${program}.sh ${program}
+  cp -v "$PLAN_CONTEXT"/bin/${program}.sh ${program}
 
   # Use the bash from our dependency list as the shebang. Also, embed the
   # release version of the program.
@@ -23,7 +24,7 @@ do_build() {
 }
 
 do_install() {
-  install -v -D $program $pkg_prefix/bin/$program
+  install -v -D $program "$pkg_prefix"/bin/$program
 }
 
 # Turn the remaining default phases into no-ops

--- a/components/plan-build/bin/composite_build_functions.bash
+++ b/components/plan-build/bin/composite_build_functions.bash
@@ -1,3 +1,6 @@
+#!/bin/bash
+# shellcheck disable=2086,2124,2154,2162,1097,2068,2180
+# ^ FIXME, see https://github.com/habitat-sh/habitat/pull/4974#issuecomment-395916191
 # These functions are used when building a composite package.
 
 # Ensure that a composite package is internally consistent.

--- a/components/plan-build/bin/environment.bash
+++ b/components/plan-build/bin/environment.bash
@@ -1,4 +1,7 @@
+#!/bin/bash
 # Functions for resolving the runtime environment of a package.
+# shellcheck disable=SC1097,SC2034,SC2048,SC2068,SC2086,SC2148,SC2154,SC2155,SC2162,SC2178,SC2220
+# ^ FIXME, see https://github.com/habitat-sh/habitat/pull/4974#issuecomment-395916191
 
 declare -A __runtime_environment
 declare -A __buildtime_environment
@@ -175,7 +178,7 @@ __populate_environment_from_deps() {
                   continue;
                 fi
 
-                if [ -n env["${var}"] ]; then
+                if [ -n "${env["${var}"]}" ]; then
                     # There was a previous value; need to figure out
                     # how to proceed
 

--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -348,7 +348,7 @@ _program=$(basename "$0")
 HAB_PLAN_BUILD=0.0.1
 # The root path of the Habitat file system. If the `$HAB_ROOT_PATH` environment
 # variable is set, this value is overridden, otherwise it is set to its default
-: ${HAB_ROOT_PATH:=/hab}
+: "${HAB_ROOT_PATH:=/hab}"
 # The default path where source artifacts are downloaded, extracted, & compiled
 HAB_CACHE_SRC_PATH=$HAB_ROOT_PATH/cache/src
 # The default download root path for package artifacts, used on package
@@ -357,7 +357,7 @@ HAB_CACHE_ARTIFACT_PATH=$HAB_ROOT_PATH/cache/artifacts
 # The default path where cryptographic keys are stored. If the
 # `$HAB_CACHE_KEY_PATH` environment variable is set, this value is overridden,
 # otherwise it is set to its default.
-: ${HAB_CACHE_KEY_PATH:=$HAB_ROOT_PATH/cache/keys}
+: "${HAB_CACHE_KEY_PATH:=$HAB_ROOT_PATH/cache/keys}"
 # Export the key path for other programs and subshells to use
 export HAB_CACHE_KEY_PATH
 # The root path containing all locally installed packages
@@ -367,12 +367,12 @@ HAB_PKG_PATH=$HAB_ROOT_PATH/pkgs
 PLAN_CONTEXT=${1:-.}
 # The default Habitat Depot from where to download dependencies. If
 # `HAB_BLDR_URL` is set, this value is overridden.
-: ${HAB_BLDR_URL:=https://bldr.habitat.sh}
+: "${HAB_BLDR_URL:=https://bldr.habitat.sh}"
 # Export the Builder URL so all other programs and subshells use this same one
 export HAB_BLDR_URL
 # The default Habitat channel from where to download dependencies. If
 # `HAB_BLDR_CHANNEL` is set, this value is overridden.
-: ${HAB_BLDR_CHANNEL:=stable}
+: "${HAB_BLDR_CHANNEL:=stable}"
 # Export Builder channel so all other programs and subshells use this same one
 export HAB_BLDR_CHANNEL
 # Fall back here if package can't be installed from $HAB_BLDR_CHANNEL
@@ -382,7 +382,7 @@ INITIAL_PATH="$PATH"
 # The value of `pwd` on initial start of this program
 INITIAL_PWD="$(pwd)"
 # The compression level to use when compression harts (0..9)
-: ${HAB_HART_COMPRESSION_LEVEL:=6}
+: "${HAB_HART_COMPRESSION_LEVEL:=6}"
 # The target architecture this plan will be built for
 pkg_arch=$(uname -m | tr '[:upper:]' '[:lower:]')
 # The target system (i.e. operating system variant) this plan will be built for
@@ -473,9 +473,9 @@ _artifact_ext="hart"
 _on_exit() {
   local exit_status=${1:-$?}
   if [[ $BASH_SUBSHELL -gt 0 ]]; then
-    exit $exit_status
+    exit "$exit_status"
   fi
-  : ${pkg_name:=unknown}
+  : "${pkg_name:=unknown}"
   elapsed=$SECONDS
   elapsed=$(echo $elapsed | awk '{printf "%dm%ds", $1/60, $1%60}')
   if [[ "${HAB_NOCOLORING:-}" == "true" ]]; then
@@ -504,7 +504,7 @@ _on_exit() {
       esac
     fi
   fi
-  exit $exit_status
+  exit "$exit_status"
 }
 
 # Call the `_on_exit()` function above on:
@@ -549,7 +549,7 @@ _assemble_runtime_path() {
       data="$(trim "$data")"
       while read -r entry; do
         paths=($(_return_or_append_to_set "$entry" "${paths[@]}"))
-      done <<< $(echo "$data" | tr ':' '\n' | grep "^$dep_prefix")
+      done <<< "$(echo "$data" | tr ':' '\n' | grep "^$dep_prefix")"
     fi
   done
 
@@ -559,7 +559,8 @@ _assemble_runtime_path() {
 
 _ensure_origin_key_present() {
   local cache="$HAB_CACHE_KEY_PATH"
-  local keys_found="$(find $cache -name "${pkg_origin}-*.sig.key" | wc -l)"
+  local keys_found
+  keys_found="$(find $cache -name "${pkg_origin}-*.sig.key" | wc -l)"
   if [[ $keys_found -eq 0 ]]; then
     exit_with "Signing origin key '$pkg_origin' not found in $cache, aborting" 35
   fi
@@ -608,10 +609,10 @@ _find_system_commands() {
   fi
   debug "Setting _shasum_cmd=$_shasum_cmd"
 
-  if $(tar --version 2>&1 | grep -q 'GNU tar'); then
+  if tar --version 2>&1 | grep -q 'GNU tar'; then
     _tar_cmd=$(command -v tar)
   else
-    if $(/bin/tar --version 2>&1 | grep -q 'GNU tar'); then
+    if /bin/tar --version 2>&1 | grep -q 'GNU tar'; then
       _tar_cmd=/bin/tar
     else
       exit_with "We require GNU tar for long path support; aborting" 1
@@ -745,7 +746,7 @@ _install_dependency() {
 _get_tdeps_for() {
   local pkg_path="$1"
   if [[ -f "$pkg_path/TDEPS" ]]; then
-    cat $pkg_path/TDEPS
+    cat "$pkg_path"/TDEPS
   else
     # No file, meaning an empty set
     echo
@@ -772,7 +773,7 @@ _get_tdeps_for() {
 _get_deps_for() {
   local pkg_path="$1"
   if [[ -f "$pkg_path/DEPS" ]]; then
-    cat $pkg_path/DEPS
+    cat "$pkg_path"/DEPS
   else
     # No file, meaning an empty set
     echo
@@ -846,9 +847,9 @@ _attach_whereami() {
   echo "From: $src @ line $lnum :"
   echo
   awk '{printf "%d: %s\n", NR, $0}' "$src" \
-    | sed -e "$((${lnum}-${context})),$((${lnum}+${context}))!d" \
+    | sed -e "$((lnum - context)),$((lnum + context))!d" \
       -e 's,^,    ,g' \
-    | sed -e "$((${context}+1))s/^   / =>/"
+    | sed -e "$((context +1))s/^   / =>/"
   echo
 }
 
@@ -922,11 +923,12 @@ _resolve_scaffolding_dependencies() {
   scaff_build_deps=()
   scaff_build_deps_resolved=()
 
+  # shellcheck disable=2066
   for dep in "${pkg_scaffolding}"; do
-    _install_dependency $dep
+    _install_dependency "$dep"
     # Add scaffolding package to the list of scaffolding build deps
     scaff_build_deps+=($dep)
-    if resolved="$(_resolve_dependency $dep)"; then
+    if resolved="$(_resolve_dependency "$dep")"; then
       build_line "Resolved scaffolding dependency '$dep' to $resolved"
       scaff_build_deps_resolved+=($resolved)
       # Add each (fully qualified) direct run dependency of the scaffolding
@@ -981,8 +983,8 @@ _resolve_build_dependencies() {
   # Append to `${pkg_build_deps_resolved[@]}` all resolved direct build
   # dependencies.
   for dep in "${pkg_build_deps[@]}"; do
-    _install_dependency $dep
-    if resolved="$(_resolve_dependency $dep)"; then
+    _install_dependency "$dep"
+    if resolved="$(_resolve_dependency "$dep")"; then
       build_line "Resolved build dependency '$dep' to $resolved"
       pkg_build_deps_resolved+=($resolved)
     else
@@ -1006,7 +1008,7 @@ _set_build_tdeps_resolved() {
   # dependency could pull in `acme/binutils` for us, as an example. Any
   # duplicate entries are dropped to produce a proper set.
   for dep in "${pkg_build_deps_resolved[@]}"; do
-    tdeps=($(_get_tdeps_for $dep))
+    tdeps=($(_get_tdeps_for "$dep"))
     for tdep in "${tdeps[@]}"; do
       tdep="$HAB_PKG_PATH/$tdep"
       pkg_build_tdeps_resolved=(
@@ -1026,7 +1028,7 @@ _load_scaffolding() {
     return 0
   fi
 
-  lib="$(_pkg_path_for_build_deps $pkg_scaffolding)/lib/scaffolding.sh"
+  lib="$(_pkg_path_for_build_deps "$pkg_scaffolding")/lib/scaffolding.sh"
   build_line "Loading Scaffolding $lib"
   if ! source "$lib"; then
     exit_with "Failed to load Scaffolding from $lib" 17
@@ -1052,8 +1054,8 @@ _resolve_run_dependencies() {
 
   # Append to `${pkg_deps_resolved[@]}` all resolved direct run dependencies.
   for dep in "${pkg_deps[@]}"; do
-    _install_dependency $dep
-    if resolved="$(_resolve_dependency $dep)"; then
+    _install_dependency "$dep"
+    if resolved="$(_resolve_dependency "$dep")"; then
       build_line "Resolved dependency '$dep' to $resolved"
       pkg_deps_resolved+=($resolved)
     else
@@ -1069,7 +1071,7 @@ _resolve_run_dependencies() {
   # Append all non-direct (transitive) run dependencies for each direct run
   # dependency. Any duplicate entries are dropped to produce a proper set.
   for dep in "${pkg_deps_resolved[@]}"; do
-    tdeps=($(_get_tdeps_for $dep))
+    tdeps=($(_get_tdeps_for "$dep"))
     for tdep in "${tdeps[@]}"; do
       tdep="$HAB_PKG_PATH/$tdep"
       pkg_tdeps_resolved=(
@@ -1123,12 +1125,14 @@ _populate_dependency_arrays() {
 _validate_deps() {
   # Build the list of full runtime deps (one per line) without the
   # `$HAB_PKG_PATH` prefix.
-  local tdeps=$(echo ${pkg_tdeps_resolved[@]} \
+  local tdeps
+  tdeps=$(echo "${pkg_tdeps_resolved[@]}" \
     | tr ' ' '\n' \
     | sed "s,^${HAB_PKG_PATH}/,,")
   # Build the list of any runtime deps that appear more than once. That is,
   # `ORIGIN/NAME` token duplicates.
-  local dupes=$(echo "$tdeps" \
+  local dupes
+  dupes=$(echo "$tdeps" \
     | awk -F/ '{print $1"/"$2}' \
     | sort \
     | uniq -d)
@@ -1139,34 +1143,34 @@ _validate_deps() {
     # of the duplicated `ORIGIN/NAME` tokens. This will be used to star the
     # problematic dependencies in the graph.
     _dupes_qualified=$(echo "$tdeps" \
-      | egrep "($(echo "$dupes" | tr '\n' '|' | sed 's,|$,,'))")
+      | grep -E "($(echo "$dupes" | tr '\n' '|' | sed 's,|$,,'))")
 
     warn
     warn "The following runtime dependencies have more than one version"
     warn "release in the full dependency chain:"
     warn
-    echo "$dupes" | while read dupe; do
+    echo "$dupes" | while read -r dupe; do
       warn "  * $dupe ( $(echo "$tdeps" | grep "^${dupe}/" | tr '\n' ' '))"
     done
     warn
-    warn 'The current situation usually arises when a Plan has a direct '
-    warn 'dependency on one version of a package (`acme/A/7.0/20160101200001`)'
-    warn 'and has a direct dependency on another package which itself depends'
-    warn 'on another version of the same package (`acme/A/2.0/20151201060001`).'
-    warn 'If this package (`acme/A`) contains shared libraries which are'
-    warn 'loaded at runtime by the current Plan, then both versions of'
-    warn '`acme/A` could be loaded into the same process in a potentially'
-    warn 'surprising order. Worse, if both versions of `acme/A` are'
-    warn 'ABI-incompatible, runtime segmentation faults are more than likely.'
+    warn "The current situation usually arises when a Plan has a direct "
+    warn "dependency on one version of a package (\`acme/A/7.0/20160101200001\`)"
+    warn "and has a direct dependency on another package which itself depends"
+    warn "on another version of the same package (\`acme/A/2.0/20151201060001\`)."
+    warn "If this package (\`acme/A\`) contains shared libraries which are"
+    warn "loaded at runtime by the current Plan, then both versions of"
+    warn "\`acme/A\` could be loaded into the same process in a potentially"
+    warn "surprising order. Worse, if both versions of \`acme/A\` are"
+    warn "ABI-incompatible, runtime segmentation faults are more than likely."
     warn
-    warn 'In order to preserve reliability at runtime the duplicate dependency'
-    warn 'entries will need to be resolved before this Plan can be built.'
-    warn 'Below is an expanded graph of all `$pkg_deps` and their dependencies'
-    warn 'with the problematic lines noted.'
+    warn "In order to preserve reliability at runtime the duplicate dependency"
+    warn "entries will need to be resolved before this Plan can be built."
+    warn "Below is an expanded graph of all \`\$pkg_deps\` and their dependencies"
+    warn "with the problematic lines noted."
     warn
     warn "Computed dependency graph (Lines with '*' denote a problematic entry):"
-    printf "\n${pkg_origin}/${pkg_name}/${pkg_version}/${pkg_release}\n"
-    echo ${pkg_deps_resolved[@]} \
+    echo -e "\n${pkg_origin}/${pkg_name}/${pkg_version}/${pkg_release}"
+    echo "${pkg_deps_resolved[@]}" \
       | tr ' ' '\n' \
       | sed -e "s,^${HAB_PKG_PATH}/,," \
       | _print_recursive_deps 1
@@ -1229,8 +1233,8 @@ _print_recursive_deps() {
   local dep
   # Compute the amount of leading whitespace when display this line and any
   # child dependencies.
-  local padn=$(($level * 4))
-  while read dep; do
+  local padn=$((level * 4))
+  while read -r dep; do
     # If this dependency is a member of the duplicated set, then add an
     # asterisk at the end of the line, otherwise print the dependency.
     if echo "$_dupes_qualified" | grep -q "$dep" > /dev/null; then
@@ -1241,7 +1245,7 @@ _print_recursive_deps() {
     # If this dependency itself has direct dependencies, then recursively print
     # them.
     if [[ -f $HAB_PKG_PATH/$dep/DEPS ]]; then
-      cat $HAB_PKG_PATH/$dep/DEPS | _print_recursive_deps $(($level + 1))
+      _print_recursive_deps $((level + 1)) < "$HAB_PKG_PATH"/"$dep"/DEPS
     fi
   done
 }
@@ -1273,7 +1277,7 @@ _pkg_path_for_build_deps() {
   local e
   local cutn="$(($(echo $HAB_PKG_PATH | grep -o '/' | wc -l)+2))"
   for e in "${pkg_build_deps_resolved[@]}"; do
-    if echo $e | cut -d "/" -f ${cutn}- | egrep -q "(^|/)${dep}(/|$)"; then
+    if echo "$e" | cut -d "/" -f ${cutn}- | grep -E -q "(^|/)${dep}(/|$)"; then
       echo "$e"
       return 0
     fi
@@ -1308,7 +1312,7 @@ _pkg_path_for_deps() {
   local e
   local cutn="$(($(echo $HAB_PKG_PATH | grep -o '/' | wc -l)+2))"
   for e in "${pkg_deps_resolved[@]}"; do
-    if echo $e | cut -d "/" -f ${cutn}- | egrep -q "(^|/)${dep}(/|$)"; then
+    if echo "$e" | cut -d "/" -f ${cutn}- | grep -E -q "(^|/)${dep}(/|$)"; then
       echo "$e"
       return 0
     fi
@@ -1345,8 +1349,9 @@ _to_int() {
 # ```
 _port_is_valid() {
     local port="$1"
-    local -i port_num=$(_to_int $port 2>/dev/null)
-    if (( $port_num < 1 || $port_num > 65535 )) ; then
+    local -i port_num
+    port_num=$(_to_int "$port" 2>/dev/null)
+    if (( port_num < 1 || port_num > 65535 )) ; then
         return 1
     fi
     return 0
@@ -1448,7 +1453,7 @@ _set_build_path() {
       data="$(trim "$data")"
       while read -r entry; do
         paths=($(_return_or_append_to_set "$entry" "${paths[@]}"))
-      done <<< $(echo "$data" | tr ':' '\n' | grep "^$dep_prefix")
+      done <<< "$(echo "$data" | tr ':' '\n' | grep "^$dep_prefix")"
     fi
   done
 
@@ -1525,7 +1530,8 @@ do_default_download() {
     return 0
   fi
 
-  download_file $pkg_source $pkg_filename $pkg_shasum
+  # shellcheck disable=2154
+  download_file "$pkg_source" "$pkg_filename" "$pkg_shasum"
 }
 
 # If `$pkg_source` is being used, verify that the package we have in
@@ -1539,7 +1545,7 @@ do_verify() {
 # Default implementation for the `do_verify()` phase.
 do_default_verify() {
   if [[ -n "${pkg_filename:-}" ]]; then
-    verify_file $pkg_filename $pkg_shasum
+    verify_file "$pkg_filename" "$pkg_shasum"
   fi
 }
 
@@ -1573,7 +1579,7 @@ do_unpack() {
 # Default implementation for the `do_unpack()` phase.
 do_default_unpack() {
   if [[ -n "${pkg_filename:-}" ]]; then
-    unpack_file $pkg_filename
+    unpack_file "$pkg_filename"
   fi
 }
 
@@ -1598,13 +1604,16 @@ _build_environment() {
   done
   for dep_path in "${pkg_deps_resolved[@]}"; do
     if [[ -f "$dep_path/LD_RUN_PATH" ]]; then
-      local data=$(cat $dep_path/LD_RUN_PATH)
-      local trimmed=$(trim $data)
+      local data
+      data=$(cat "$dep_path"/LD_RUN_PATH)
+      local trimmed
+      trimmed=$(trim "$data")
       ld_run_path_part+=("$trimmed")
     fi
   done
-  if [[ -n $ld_run_path_part ]]; then
-    export LD_RUN_PATH=$(join_by ':' ${ld_run_path_part[@]})
+  if [[ -n "${ld_run_path_part[*]}" ]]; then
+    export LD_RUN_PATH
+    LD_RUN_PATH=$(join_by ':' "${ld_run_path_part[@]}")
   fi
 
   # Build `$CFLAGS`, `$CPPFLAGS`, `$CXXFLAGS` and `$LDFLAGS` containing any
@@ -1614,8 +1623,10 @@ _build_environment() {
   # transitive.
   for dep_path in "${pkg_all_deps_resolved[@]}"; do
     if [[ -f "$dep_path/CFLAGS" ]]; then
-      local data=$(cat $dep_path/CFLAGS)
-      local trimmed=$(trim $data)
+      local data
+      data=$(cat "$dep_path"/CFLAGS)
+      local trimmed
+      trimmed=$(trim "$data")
       if [[ -n "$CFLAGS" ]]; then
         export CFLAGS="$CFLAGS $trimmed"
       else
@@ -1638,8 +1649,10 @@ _build_environment() {
     fi
 
     if [[ -f "$dep_path/CPPFLAGS" ]]; then
-      local data=$(cat $dep_path/CPPFLAGS)
-      local trimmed=$(trim $data)
+      local data
+      data=$(cat "$dep_path"/CPPFLAGS)
+      local trimmed
+      trimmed=$(trim "$data")
       if [[ -n "$CPPFLAGS" ]]; then
         export CPPFLAGS="$CPPFLAGS $trimmed"
       else
@@ -1648,8 +1661,10 @@ _build_environment() {
     fi
 
     if [[ -f "$dep_path/CXXFLAGS" ]]; then
-      local data=$(cat $dep_path/CXXFLAGS)
-      local trimmed=$(trim $data)
+      local data
+      data=$(cat "$dep_path"/CXXFLAGS)
+      local trimmed
+      trimmed=$(trim "$data")
       if [[ -n "$CXXFLAGS" ]]; then
         export CXXFLAGS="$CXXFLAGS $trimmed"
       else
@@ -1658,8 +1673,10 @@ _build_environment() {
     fi
 
     if [[ -f "$dep_path/LDFLAGS" ]]; then
-      local data=$(cat $dep_path/LDFLAGS)
-      local trimmed=$(trim $data)
+      local data
+      data=$(cat "$dep_path"/LDFLAGS)
+      local trimmed
+      trimmed=$(trim "$data")
       if [[ -n "$LDFLAGS" ]]; then
         export LDFLAGS="$LDFLAGS $trimmed"
       else
@@ -1668,8 +1685,10 @@ _build_environment() {
     fi
 
     if [[ -f "$dep_path/PKG_CONFIG_PATH" ]]; then
-      local data=$(cat ${dep_path}/PKG_CONFIG_PATH)
-      local trimmed=$(trim $data)
+      local data
+      data=$(cat "${dep_path}"/PKG_CONFIG_PATH)
+      local trimmed
+      trimmed=$(trim "$data")
       if [[ -n "$PKG_CONFIG_PATH" ]]; then
         export PKG_CONFIG_PATH="${PKG_CONFIG_PATH}:${trimmed}"
       else
@@ -1697,7 +1716,7 @@ _build_environment() {
 # source to remove the default system search path of `/usr/lib`, etc. when
 # looking for shared libraries.
 _fix_libtool() {
-  find "$SRC_PATH" -iname "ltmain.sh" | while read file; do
+  find "$SRC_PATH" -iname "ltmain.sh" | while read -r file; do
     build_line "Fixing libtool script $file"
     sed -i -e 's^eval sys_lib_.*search_path=.*^^' "$file"
   done
@@ -1757,7 +1776,7 @@ do_build() {
 
 # Default implementation for the `do_build()` phase.
 do_default_build() {
-  ./configure --prefix=$pkg_prefix
+  ./configure --prefix="$pkg_prefix"
   make
 }
 
@@ -1893,13 +1912,13 @@ do_default_build_config() {
       # HAB_CONFIG_EXCLUDE not set, use defaults
       config_exclude_exts=("*.sw?" "*~" "*.bak")
     else
-      IFS=',' read -a config_exclude_exts <<< "$HAB_CONFIG_EXCLUDE"
+      IFS=',' read -r -a config_exclude_exts <<< "$HAB_CONFIG_EXCLUDE"
     fi
     find_exclusions=""
     for ext in "${config_exclude_exts[@]}"; do
       find_exclusions+=" ! -name $ext"
     done
-    find "$PLAN_CONTEXT/config" $find_exclusions | while read FILE
+    find "$PLAN_CONTEXT/config" "$find_exclusions" | while read -r FILE
     do
       if [[ -d "$FILE" ]]; then
         mkdir -p "$pkg_prefix${FILE#$PLAN_CONTEXT}"
@@ -1907,14 +1926,14 @@ do_default_build_config() {
         cp "$FILE" "$pkg_prefix${FILE#$PLAN_CONTEXT}"
       fi
     done
-    chmod 755 $pkg_prefix/config
+    chmod 755 "$pkg_prefix"/config
   fi
   if [[ -d "$PLAN_CONTEXT/hooks" ]]; then
-    cp -r "$PLAN_CONTEXT/hooks" $pkg_prefix
-    chmod 755 $pkg_prefix/hooks
+    cp -r "$PLAN_CONTEXT/hooks" "$pkg_prefix"
+    chmod 755 "$pkg_prefix"/hooks
   fi
   if [[ -f "$PLAN_CONTEXT/default.toml" ]]; then
-    cp "$PLAN_CONTEXT/default.toml" $pkg_prefix
+    cp "$PLAN_CONTEXT/default.toml" "$pkg_prefix"
   fi
   return 0
 }
@@ -1946,7 +1965,7 @@ do_default_build_service() {
       # We use chpst to ensure that the script works outside `hab-sup`
       # for debugging purposes
       build_line "Writing ${pkg_prefix}/run script to run ${pkg_svc_run} as ${pkg_svc_user}:${pkg_svc_group}"
-      cat <<EOT >> $pkg_prefix/run
+      cat <<EOT >> "$pkg_prefix"/run
 #!/bin/sh
 export HOME=$pkg_svc_data_path
 cd $pkg_svc_path
@@ -1975,7 +1994,7 @@ do_strip() {
 # Default implementation for the `do_strip()` phase.
 do_default_strip() {
   build_line "Stripping unneeded symbols from binaries and libraries"
-  find $pkg_prefix -type f -perm -u+w -print0 2> /dev/null \
+  find "$pkg_prefix" -type f -perm -u+w -print0 2> /dev/null \
     | while read -rd '' f; do
       case "$(file -bi "$f")" in
         *application/x-executable*) strip --strip-all "$f";;
@@ -2002,6 +2021,7 @@ do_default_after() {
 # **Internal** Write the `$pkg_prefix/MANIFEST`.
 _build_manifest() {
   build_line "Creating manifest"
+  # shellcheck disable=2154
   if [[ -z $pkg_upstream_url ]]; then
     local _upstream_url_string="upstream project's website or home page is not defined"
   else
@@ -2020,22 +2040,26 @@ _build_manifest() {
     local _sha_string="\`$pkg_shasum\`"
   fi
 
-  if [[ -z "$(echo ${pkg_build_deps[@]})" ]]; then
-    local _build_deps_string="no build dependencies or undefined"
+  local _build_deps_string
+  if [[ -z "${pkg_build_deps[*]}" ]]; then
+    _build_deps_string="no build dependencies or undefined"
   else
-    local _build_deps_string="\`$(printf "%s " ${pkg_build_deps[@]})\`"
+    _build_deps_string="\`$(printf "%s " "${pkg_build_deps[@]}")\`"
   fi
 
-  if [[ -z "$(echo ${pkg_deps[@]})" ]]; then
-    local _deps_string="no runtime dependencies or undefined"
+  local _deps_string
+  if [[ -z "${pkg_deps[*]}" ]]; then
+    _deps_string="no runtime dependencies or undefined"
   else
-    local _deps_string="\`$(printf "%s " ${pkg_deps[@]})\`"
+    _deps_string="\`$(printf "%s " "${pkg_deps[@]}")\`"
   fi
 
-  if [[ -z "$(echo ${pkg_interpreters[@]})" ]]; then
-    local _interpreters_string="no interpreters or undefined"
+  local _interpreters_string
+  # shellcheck disable=2154
+  if [[ -z "${pkg_interpreters[*]}" ]]; then
+    _interpreters_string="no interpreters or undefined"
   else
-    local _interpreters_string="\`$(printf "%s " ${pkg_interpreters[@]})\`"
+    _interpreters_string="\`$(printf "%s " "${pkg_interpreters[@]}")\`"
   fi
 
   if [[ -z "$CFLAGS" ]]; then
@@ -2068,7 +2092,8 @@ _build_manifest() {
     local _ldrunpath_string="$LD_RUN_PATH"
   fi
 
-  cat <<-EOT >> $pkg_prefix/MANIFEST
+  # shellcheck disable=2154
+  cat <<-EOT >> "$pkg_prefix"/MANIFEST
 # $pkg_origin / $pkg_name
 $pkg_description
 
@@ -2079,7 +2104,7 @@ $pkg_description
 * __System__: $pkg_sys
 * __Target__: $pkg_target
 * __Upstream URL__: $_upstream_url_string
-* __License__: $(printf "%s " ${pkg_license[@]})
+* __License__: $(printf "%s " "${pkg_license[@]}")
 * __Source__: $_source_url_string
 * __SHA__: $_sha_string
 * __Path__: \`$pkg_prefix\`
@@ -2102,7 +2127,7 @@ LD_RUN_PATH: $_ldrunpath_string
 ## Plan Source
 
 \`\`\`bash
-$(cat $PLAN_CONTEXT/plan.sh)
+$(cat "$PLAN_CONTEXT"/plan.sh)
 \`\`\`
 EOT
   return 0
@@ -2111,21 +2136,22 @@ EOT
 # **Internal** Create the package artifact with `tar`/`hab pkg sign`
 _generate_artifact() {
   build_line "Generating package artifact"
-  local tarf="$(dirname $pkg_artifact)/.$(basename ${pkg_artifact/%.${_artifact_ext}/.tar})"
+  local tarf
+  tarf="$(dirname "$pkg_artifact")/.$(basename "${pkg_artifact/%.${_artifact_ext}/.tar}")"
   local xzf="${tarf}.xz"
 
   mkdir -pv "$(dirname "$pkg_artifact")"
-  rm -fv $tarf $xzf $pkg_artifact
-  $_tar_cmd -cf $tarf $pkg_prefix
-  $_xz_cmd --compress -${HAB_HART_COMPRESSION_LEVEL} --threads=0 $tarf
-  $HAB_BIN pkg sign --origin $pkg_origin $xzf $pkg_artifact
-  rm -f $tarf $xzf
+  rm -fv "$tarf" "$xzf" "$pkg_artifact"
+  $_tar_cmd -cf "$tarf" "$pkg_prefix"
+  $_xz_cmd --compress -${HAB_HART_COMPRESSION_LEVEL} --threads=0 "$tarf"
+  $HAB_BIN pkg sign --origin $pkg_origin "$xzf" "$pkg_artifact"
+  rm -f "$tarf" "$xzf"
 }
 
 _prepare_build_outputs() {
   local plan_owner
-  _pkg_sha256sum=$($_shasum_cmd $pkg_artifact | cut -d " " -f 1)
-  _pkg_blake2bsum=$($HAB_BIN pkg hash $pkg_artifact | cut -d " " -f 1)
+  _pkg_sha256sum=$($_shasum_cmd "$pkg_artifact" | cut -d " " -f 1)
+  _pkg_blake2bsum=$($HAB_BIN pkg hash "$pkg_artifact" | cut -d " " -f 1)
   plan_owner="$(stat -c '%u:%g' "$PLAN_CONTEXT/plan.sh")"
 
   mkdir -pv "$pkg_output_path"
@@ -2148,7 +2174,7 @@ pkg_name=$pkg_name
 pkg_version=$pkg_version
 pkg_release=$pkg_release
 pkg_ident=${pkg_origin}/${pkg_name}/${pkg_version}/${pkg_release}
-pkg_artifact=$(basename $pkg_artifact)
+pkg_artifact=$(basename "$pkg_artifact")
 pkg_sha256sum=$_pkg_sha256sum
 pkg_blake2bsum=$_pkg_blake2bsum
 EOF
@@ -2272,6 +2298,7 @@ done
 # Pass over `$pkg_svc_run` to replace any `$pkg_name` placeholder tokens
 # from prior pkg_svc_* variables that were set before the Plan was loaded.
 if [[ -n "${pkg_svc_run+xxx}" ]]; then
+    # shellcheck disable=2001
     pkg_svc_run="$(echo $pkg_svc_run | sed "s|@__pkg_name__@|$pkg_name|g")"
 fi
 

--- a/components/plan-build/bin/public.bash
+++ b/components/plan-build/bin/public.bash
@@ -11,7 +11,7 @@
 #
 # Would return 0 if gsha256sum exists, 1 if it does not.
 exists() {
-  if command -v $1 >/dev/null 2>&1
+  if command -v "$1" >/dev/null 2>&1
   then
     return 0
   else
@@ -27,6 +27,7 @@ exists() {
 # ```
 build_line() {
   if [[ "${HAB_NOCOLORING:-}" == "true" ]]; then
+    # shellcheck disable=2154
     echo "   ${pkg_name}: $1"
   else
     case "${TERM:-}" in
@@ -98,7 +99,7 @@ exit_with() {
         ;;
     esac
   fi
-  exit ${2:-1}
+  exit "${2:-1}"
 }
 
 # Trim leading and trailing whitespace.  [Thanks to these
@@ -139,9 +140,11 @@ trim() {
 pkg_path_for() {
   local dep="$1"
   local e
-  local cutn="$(($(echo $HAB_PKG_PATH | grep -o '/' | wc -l)+2))"
+  local cutn
+  cutn="$(($(echo "$HAB_PKG_PATH" | grep -o '/' | wc -l)+2))"
+  # shellcheck disable=2154
   for e in "${pkg_all_deps_resolved[@]}"; do
-    if echo $e | cut -d "/" -f ${cutn}- | egrep -q "(^|/)${dep}(/|$)"; then
+    if echo "$e" | cut -d "/" -f ${cutn}- | grep -E -q "(^|/)${dep}(/|$)"; then
       echo "$e"
       return 0
     fi
@@ -205,17 +208,17 @@ attach() {
   # Loop through input, REPL-style until either `"exit"` or `"quit"` is found
   while [[ "$cmd" != "exit" && "$cmd" != "quit" ]]; do
     read -e -r -p "[$replno] ${pkg_name}($fname)> " cmd
-    history -s $cmd
+    history -s "$cmd"
     case "$cmd" in
       vars) (set -o posix; set);;
       whereami*|\@*)
-        _attach_whereami "$(echo $cmd \
+        _attach_whereami "$(echo "$cmd" \
          | awk '{if (NF == 2) print $2; else print "10"}')"
         ;;
       exit|quit) ;;
       exit-program|quit-program) exit $?;;
       help)
-        printf "
+        echo "
 Help
   help          Show a list of command or information about a specific command.
 
@@ -234,13 +237,12 @@ Aliases
   @             Alias for \`whereami\`.
   quit          Alias for \`exit\`.
   quit-program  Alias for \`exit-program\`.
-
 "
         ;;
-      *) eval $cmd;;
+      *) eval "$cmd";;
     esac
     # Increment our REPL command line count, cause that's helpful
-    replno=$((${replno}+1))
+    replno=$((replno + 1))
   done
   # Re-enable on exit trap and restore exit-on-non-zero behavior
   trap _on_exit 1 2 3 15 ERR
@@ -337,20 +339,21 @@ download_file() {
   local dst="$2"
   local sha="$3"
 
-  pushd $HAB_CACHE_SRC_PATH > /dev/null
+  pushd "$HAB_CACHE_SRC_PATH" > /dev/null
   if [[ -f $dst && -n "$sha" ]]; then
     build_line "Found previous file '$dst', attempting to re-use"
-    if verify_file $dst $sha; then
+    if verify_file "$dst" "$sha"; then
       build_line "Using cached and verified '$dst'"
       return 0
     else
       build_line "Clearing previous '$dst' file and re-attempting download"
-      rm -fv $dst
+      rm -fv "$dst"
     fi
   fi
 
   build_line "Downloading '$url' to '$dst'"
-  $_wget_cmd $url -O $dst
+  # shellcheck disable=2154
+  $_wget_cmd "$url" -O "$dst"
   build_line "Downloaded '$dst'";
   popd > /dev/null
 }
@@ -367,8 +370,10 @@ download_file() {
 # will be printed to stderr with the expected and computed shasum values.
 verify_file() {
   build_line "Verifying $1"
-  local checksum=($($_shasum_cmd $HAB_CACHE_SRC_PATH/$1))
-  if [[ $2 = $checksum ]]; then
+  local checksum
+  # shellcheck disable=2154
+  read -r checksum _ < <($_shasum_cmd "$HAB_CACHE_SRC_PATH"/"$1")
+  if [[ $2 = "$checksum" ]]; then
     build_line "Checksum verified for $1"
   else
     warn "Checksum invalid for $1:"
@@ -394,17 +399,18 @@ unpack_file() {
   # Thanks to:
   # http://stackoverflow.com/questions/17420994/bash-regex-match-string
   if [[ -f $unpack_file ]]; then
-    pushd $HAB_CACHE_SRC_PATH > /dev/null
+    pushd "$HAB_CACHE_SRC_PATH" > /dev/null
     case $unpack_file in
       *.tar.bz2|*.tbz2|*.tar.gz|*.tgz|*.tar|*.xz)
-        $_tar_cmd xf $unpack_file --no-same-owner
+        # shellcheck disable=2154
+        $_tar_cmd xf "$unpack_file" --no-same-owner
         ;;
-      *.bz2)  bunzip2 $unpack_file    ;;
-      *.rar)  rar x $unpack_file      ;;
-      *.gz)   gunzip $unpack_file     ;;
-      *.zip)  unzip -o $unpack_file   ;;
-      *.Z)    uncompress $unpack_file ;;
-      *.7z)   7z x $unpack_file       ;;
+      *.bz2)  bunzip2 "$unpack_file"    ;;
+      *.rar)  rar x "$unpack_file"      ;;
+      *.gz)   gunzip "$unpack_file"     ;;
+      *.zip)  unzip -o "$unpack_file"   ;;
+      *.Z)    uncompress "$unpack_file" ;;
+      *.7z)   7z x "$unpack_file"       ;;
       *)
         warn "Error: unknown archive format '.${unpack_file##*.}'"
         return 1
@@ -452,8 +458,9 @@ fix_interpreter() {
     local pkg=$2
     local int=$3
     local interpreter_old=".*${int}"
-    local interpreter_new="$(pkg_interpreter_for ${pkg} ${int})"
-    if [[ -z $interpreter_new || $? -ne 0 ]]; then
+    local interpreter_new
+    # shellcheck disable=2154
+    if ! interpreter_new="$(pkg_interpreter_for "${pkg}" "${int}")" || [[ -z $interpreter_new ]]; then
       warn "fix_interpreter() '$pkg' is not a runtime dependency"
       warn "Only runtime packages may be used as your interpreter must travel"
       warn "with the '$pkg_name' in order to run."
@@ -473,7 +480,7 @@ fix_interpreter() {
       fi
 
       build_line "Replacing '${interpreter_old}' with '${interpreter_new}' in '${t}'"
-      sed -e "s#\#\!${interpreter_old}#\#\!${interpreter_new}#" -i $t
+      sed -e "s#\#\!${interpreter_old}#\#\!${interpreter_new}#" -i "$t"
     done
 }
 
@@ -492,13 +499,14 @@ fix_interpreter() {
 pkg_interpreter_for() {
     local pkg=$1
     local int=$2
-    local path=$(_pkg_path_for_deps $pkg)
-    if [[ -z $path || $? -ne 0 ]]; then
+    local path
+    if ! path=$(_pkg_path_for_deps "$pkg") || [[ -z $path ]]; then
       warn "Could not resolve the path for ${pkg}, is it specified in 'pkg_deps'?"
       return 1
     fi
 
-   local int_path=$(grep -x ".*${int}" ${path}/INTERPRETERS)
+   local int_path
+   int_path=$(grep -x ".*${int}" "${path}"/INTERPRETERS)
     if [[ -n "$int_path" ]]; then
       echo "$int_path"
       return 0
@@ -530,7 +538,7 @@ pkg_interpreter_for() {
 # }
 # ```
 update_pkg_version() {
-  local update_src_path val
+  local update_src_path
 
   if [[ "${_verify_vars:-}" == true ]]; then
     local e
@@ -552,7 +560,9 @@ update_pkg_version() {
   if [[ "${_pkg_dirname_initially_unset:-}" == true ]]; then
     pkg_dirname="${pkg_name}-${pkg_version}"
   fi
+  # shellcheck disable=2034,2154
   pkg_prefix=$HAB_PKG_PATH/${pkg_origin}/${pkg_name}/${pkg_version}/${pkg_release}
+  # shellcheck disable=2034,2154
   pkg_artifact="$HAB_CACHE_ARTIFACT_PATH/${pkg_origin}-${pkg_name}-${pkg_version}-${pkg_release}-${pkg_target}.${_artifact_ext}"
   # If the `$CACHE_PATH` and `$SRC_PATH` are the same, then we are building
   # third party software using `$pkg_source` and
@@ -588,6 +598,7 @@ update_pkg_version() {
 __resolve_version_placeholder(){
     local original=${1}
     local real_version=${2}
+    # shellcheck disable=2001
     echo "${original}" | sed "s,__pkg__version__unset__,${real_version},g"
 }
 

--- a/components/plan-build/bin/shared.bash
+++ b/components/plan-build/bin/shared.bash
@@ -8,61 +8,63 @@
 # Common Metadata Rendering functions
 
 _render_metadata_BINDS() {
-    _render_associative_array_file ${pkg_prefix} BINDS pkg_binds
+    # shellcheck disable=2154
+    _render_associative_array_file "${pkg_prefix}" BINDS pkg_binds
 }
 
 _render_metadata_BINDS_OPTIONAL() {
-    _render_associative_array_file ${pkg_prefix} BINDS_OPTIONAL pkg_binds_optional
+    _render_associative_array_file "${pkg_prefix}" BINDS_OPTIONAL pkg_binds_optional
 }
 
 _render_metadata_BUILD_DEPS() {
-  _render_dependency_metadata_file ${pkg_prefix} BUILD_DEPS pkg_build_deps_resolved
+  _render_dependency_metadata_file "${pkg_prefix}" BUILD_DEPS pkg_build_deps_resolved
 }
 
 _render_metadata_BUILD_TDEPS() {
-  _render_dependency_metadata_file ${pkg_prefix} BUILD_TDEPS pkg_build_tdeps_resolved
+  _render_dependency_metadata_file "${pkg_prefix}" BUILD_TDEPS pkg_build_tdeps_resolved
 }
 
 _render_metadata_CFLAGS() {
-    _render_c_includes_metadata_file ${pkg_prefix} CFLAGS pkg_include_dirs
+    _render_c_includes_metadata_file "${pkg_prefix}" CFLAGS pkg_include_dirs
 }
 
 _render_metadata_CPPFLAGS() {
-    _render_c_includes_metadata_file ${pkg_prefix} CPPFLAGS pkg_include_dirs
+    _render_c_includes_metadata_file "${pkg_prefix}" CPPFLAGS pkg_include_dirs
 }
 
 _render_metadata_CXXFLAGS() {
-    _render_c_includes_metadata_file ${pkg_prefix} CXXFLAGS pkg_include_dirs
+    _render_c_includes_metadata_file "${pkg_prefix}" CXXFLAGS pkg_include_dirs
 }
 
 _render_metadata_BUILDTIME_ENVIRONMENT(){
     debug "Rendering BUILDTIME_ENVIRONMENT metadata file"
-    _render_associative_array_file ${pkg_prefix} BUILDTIME_ENVIRONMENT __buildtime_environment
+    _render_associative_array_file "${pkg_prefix}" BUILDTIME_ENVIRONMENT __buildtime_environment
 }
 
 _render_metadata_BUILDTIME_ENVIRONMENT_PROVENANCE(){
     debug "Rendering BUILDTIME_ENVIRONMENT_PROVENANCE metadata file"
-    _render_associative_array_file ${pkg_prefix} BUILDTIME_ENVIRONMENT_PROVENANCE __buildtime_environment_provenance
+    _render_associative_array_file "${pkg_prefix}" BUILDTIME_ENVIRONMENT_PROVENANCE __buildtime_environment_provenance
 }
 
 _render_metadata_DEPS() {
-  _render_dependency_metadata_file ${pkg_prefix} DEPS pkg_deps_resolved
+  _render_dependency_metadata_file "${pkg_prefix}" DEPS pkg_deps_resolved
 }
 
 _render_metadata_EXPORTS() {
-    _render_associative_array_file ${pkg_prefix} EXPORTS pkg_exports
+    _render_associative_array_file "${pkg_prefix}" EXPORTS pkg_exports
 }
 
 _render_metadata_EXPOSES() {
   # TODO (CM): rename port_part and make it an array
   local port_part=""
+  # shellcheck disable=2154
   for export in "${pkg_exposes[@]}"; do
     if [[ ! ${pkg_exports[$export]+abc} ]]; then
       exit_with "Bad value in pkg_exposes; No pkg_export found matching key: ${export}"
     fi
     key=${pkg_exports[$export]}
-    port=$($_rq_cmd -t < $PLAN_CONTEXT/default.toml "at \"${key}\"" | tr -d '"')
-    if ! _port_is_valid $port; then
+    port=$($_rq_cmd -t < "$PLAN_CONTEXT"/default.toml "at \"${key}\"" | tr -d '"')
+    if ! _port_is_valid "$port"; then
       exit_with "Bad pkg_export in pkg_exposes; Value of key \"${key}\" does not contain a valid TCP or UDP port number: ${port}"
     fi
 
@@ -75,7 +77,7 @@ _render_metadata_EXPOSES() {
 
   if [[ -n "${port_part}" ]]; then
     debug "Rendering EXPOSES metadata file"
-    echo $port_part > $pkg_prefix/EXPOSES
+    echo "$port_part" > "$pkg_prefix"/EXPOSES
   fi
 }
 
@@ -86,28 +88,34 @@ _render_metadata_FILES() {
   pushd "$CACHE_PATH" > /dev/null
   build_line "Generating blake2b hashes of all files in the package"
 
-  find $pkg_prefix -type f \
+  # shellcheck disable=2154
+  find "$pkg_prefix" -type f \
     | sort \
-    | hab pkg hash > ${pkg_name}_blake2bsums
+    | hab pkg hash > "${pkg_name}"_blake2bsums
 
   build_line "Generating signed metadata FILES"
-  $HAB_BIN pkg sign --origin $pkg_origin ${pkg_name}_blake2bsums $pkg_prefix/FILES
+  # shellcheck disable=2154
+  $HAB_BIN pkg sign --origin "$pkg_origin" "${pkg_name}"_blake2bsums "$pkg_prefix"/FILES
   popd > /dev/null
 }
 
 _render_metadata_IDENT() {
   debug "Rendering IDENT metadata file"
-  echo "${pkg_origin}/${pkg_name}/${pkg_version}/${pkg_release}" >> $pkg_prefix/IDENT
+  # shellcheck disable=2154
+  echo "${pkg_origin}/${pkg_name}/${pkg_version}/${pkg_release}" >> "$pkg_prefix"/IDENT
 }
 
 _render_metadata_INTERPRETERS() {
     local metadata_file_name="INTERPRETERS"
 
+    # shellcheck disable=2154
     if [[ ${#pkg_interpreters[@]} -gt 0 ]]; then
         debug "Rendering ${metadata_file_name} metadata file"
-        local interpreters="$(printf "${pkg_prefix}/%s\n" ${pkg_interpreters[@]})"
-        printf "%s\n" ${pkg_interpreters[@]} \
-            | sed "s|^|${pkg_prefix}/|" > $pkg_prefix/${metadata_file_name}
+        local interpreters
+        # shellcheck disable=2034
+        interpreters="$(printf "${pkg_prefix}/%s\n" "${pkg_interpreters[@]}")"
+        printf "%s\n" "${pkg_interpreters[@]}" \
+            | sed "s|^|${pkg_prefix}/|" > "$pkg_prefix"/${metadata_file_name}
     else
         debug "Would have rendered ${metadata_file_name}, but there was no data for it"
     fi
@@ -117,12 +125,13 @@ _render_metadata_LDFLAGS(){
     local metadata_file_name="LDFLAGS"
 
     local ld_lib_part=()
-    for lib in ${pkg_lib_dirs[@]}; do
+    # shellcheck disable=2154
+    for lib in "${pkg_lib_dirs[@]}"; do
         ld_lib_part+=("-L${pkg_prefix}/$lib")
     done
-    if [[ -n ${ld_lib_part} ]]; then
+    if [[ -n ${ld_lib_part[*]} ]]; then
         debug "Rendering LDFLAGS metadata file"
-        echo $(join_by ' ' ${ld_lib_part[@]}) > "$pkg_prefix/${metadata_file_name}"
+        join_by ' ' "${ld_lib_part[@]}" > "$pkg_prefix/${metadata_file_name}"
     else
         debug "Would have rendered ${metadata_file_name}, but there was no data for it"
     fi
@@ -132,12 +141,12 @@ _render_metadata_LD_RUN_PATH() {
     local metadata_file_name="LD_RUN_PATH"
 
     local ld_run_path_part=()
-    for lib in ${pkg_lib_dirs[@]}; do
+    for lib in "${pkg_lib_dirs[@]}"; do
         ld_run_path_part+=("${pkg_prefix}/$lib")
     done
-    if [[ -n ${ld_run_path_part} ]]; then
+    if [[ -n ${ld_run_path_part[*]} ]]; then
         debug "Rendering ${metadata_file_name} metadata file"
-        echo $(join_by ':' ${ld_run_path_part[@]}) > "$pkg_prefix/${metadata_file_name}"
+        join_by ':' "${ld_run_path_part[@]}" > "$pkg_prefix/${metadata_file_name}"
     else
         debug "Would have rendered ${metadata_file_name}, but there was no data for it"
     fi
@@ -147,6 +156,7 @@ _render_metadata_LD_RUN_PATH() {
 # for `pkg_bin_dirs`
 #
 _render_metadata_PATH() {
+  # shellcheck disable=2154
   if [[ ${#pkg_bin_dirs[@]} -gt 0 ]]; then
     local paths=()
     local dir
@@ -159,7 +169,7 @@ _render_metadata_PATH() {
         paths+=("${pkg_prefix}/${dir}")
     done
 
-    echo "$(join_by ':' ${paths[@]})" > "${pkg_prefix}/PATH"
+    join_by ':' "${paths[@]}" > "${pkg_prefix}/PATH"
   else
     debug "Would have rendered PATH, but there was no data for it"
   fi
@@ -169,6 +179,7 @@ _render_metadata_PKG_CONFIG_PATH() {
     local pconfig_path_part=()
     local metadata_file_name="PKG_CONFIG_PATH"
 
+  # shellcheck disable=2154
   if [[ ${#pkg_pconfig_dirs[@]} -eq 0 ]]; then
     # Plan doesn't define pkg-config paths so let's try to find them in the conventional locations
     local locations=(lib/pkgconfig share/pkgconfig)
@@ -184,9 +195,9 @@ _render_metadata_PKG_CONFIG_PATH() {
     done
   fi
 
-  if [[ -n ${pconfig_path_part} ]]; then
+  if [[ -n ${pconfig_path_part[*]} ]]; then
     debug "Rendering ${metadata_file_name} metadata file"
-    echo $(join_by ':' ${pconfig_path_part[@]}) > "$pkg_prefix/${metadata_file_name}"
+    join_by ':' "${pconfig_path_part[@]}" > "$pkg_prefix/${metadata_file_name}"
   else
       debug "Would have rendered ${metadata_file_name}, but there was no data for it"
   fi
@@ -194,12 +205,12 @@ _render_metadata_PKG_CONFIG_PATH() {
 
 _render_metadata_RUNTIME_ENVIRONMENT(){
     debug "Rendering RUNTIME_ENVIRONMENT metadata file"
-    _render_associative_array_file ${pkg_prefix} RUNTIME_ENVIRONMENT __runtime_environment
+    _render_associative_array_file "${pkg_prefix}" RUNTIME_ENVIRONMENT __runtime_environment
 }
 
 _render_metadata_RUNTIME_ENVIRONMENT_PROVENANCE(){
     debug "Rendering RUNTIME_ENVIRONMENT_PROVENANCE metadata file"
-    _render_associative_array_file ${pkg_prefix} RUNTIME_ENVIRONMENT_PROVENANCE __runtime_environment_provenance
+    _render_associative_array_file "${pkg_prefix}" RUNTIME_ENVIRONMENT_PROVENANCE __runtime_environment_provenance
 }
 
 _render_metadata_RUNTIME_PATH(){
@@ -215,6 +226,7 @@ _render_metadata_RUNTIME_PATH(){
     # Habitat releases between 0.50.0 (released 2017-11-30) and up to including
     # 0.55.0 (released 2018-03-20). All future releases will ignore the `PATH`
     # entry in favor of using the `RUNTIME_PATH` metadata file.
+    # shellcheck disable=2034
     __runtime_environment["PATH"]="$runtime_path"
   else
     debug "Would have rendered RUNTIME_PATH, but there was no data for it"
@@ -223,26 +235,30 @@ _render_metadata_RUNTIME_PATH(){
 
 _render_metadata_SVC_GROUP() {
   debug "Rendering SVC_GROUP metadata file"
-  echo "$pkg_svc_group" > $pkg_prefix/SVC_GROUP
+  # shellcheck disable=2154
+  echo "$pkg_svc_group" > "$pkg_prefix"/SVC_GROUP
 }
 
 _render_metadata_SVC_USER() {
   debug "Rendering SVC_USER metadata file"
-  echo "$pkg_svc_user" > $pkg_prefix/SVC_USER
+  # shellcheck disable=2154
+  echo "$pkg_svc_user" > "$pkg_prefix"/SVC_USER
 }
 
 _render_metadata_TARGET() {
   debug "Rendering TARGET metadata file"
-  echo "$pkg_target" > $pkg_prefix/TARGET
+  # shellcheck disable=2154
+  echo "$pkg_target" > "$pkg_prefix"/TARGET
 }
 
 _render_metadata_TDEPS() {
-  _render_dependency_metadata_file ${pkg_prefix} TDEPS pkg_tdeps_resolved
+  _render_dependency_metadata_file "${pkg_prefix}" TDEPS pkg_tdeps_resolved
 }
 
 _render_metadata_TYPE() {
     debug "Rendering TYPE metadata file"
-    echo "$pkg_type" > $pkg_prefix/TYPE
+    # shellcheck disable=2154
+    echo "$pkg_type" > "$pkg_prefix"/TYPE
 }
 
 # Metadata-rendering Helper Functions
@@ -263,7 +279,7 @@ _render_associative_array_file() {
   if [[ ${#assoc_arr[@]} -gt 0 ]]; then
     debug "Rendering ${metadata_file_name} metadata file"
     for key in "${!assoc_arr[@]}"; do
-      echo "${key}=${assoc_arr[${key}]}" >> ${prefix}/${metadata_file_name}
+      echo "${key}=${assoc_arr[${key}]}" >> "${prefix}"/"${metadata_file_name}"
     done
   else
     debug "Would have rendered ${metadata_file_name}, but there was no data for it"
@@ -287,7 +303,7 @@ _render_c_includes_metadata_file() {
     done
     if [[ ${#flags[@]} -gt 0 ]]; then
         debug "Rendering ${metadata_file_name} metadata file"
-        echo $(join_by ' ' ${flags[@]}) > "$pkg_prefix/${metadata_file_name}"
+        join_by ' ' "${flags[@]}" > "$pkg_prefix/${metadata_file_name}"
     else
         debug "Would have rendered ${metadata_file_name}, but there was no data for it"
     fi
@@ -301,14 +317,14 @@ _render_dependency_metadata_file() {
   local metadata_file_name=${2}
   declare -n arr=${3}
 
-  local cutn="$(($(echo $HAB_PKG_PATH | grep -o '/' | wc -l)+2))"
+  local cutn="$(($(echo "$HAB_PKG_PATH" | grep -o '/' | wc -l)+2))"
   local deps
 
   deps="$(printf '%s\n' "${arr[@]}" \
     | cut -d "/" -f ${cutn}- | sort)"
   if [[ -n "$deps" ]]; then
     debug "Rendering ${metadata_file_name} metadata file"
-    echo "$deps" > ${prefix}/${metadata_file_name}
+    echo "$deps" > "${prefix}"/"${metadata_file_name}"
   else
       debug "Would have rendered ${metadata_file_name}, but there was no data for it"
   fi

--- a/components/plan-build/plan.sh
+++ b/components/plan-build/plan.sh
@@ -1,3 +1,4 @@
+# shellcheck disable=2034
 pkg_name=hab-plan-build
 pkg_origin=core
 pkg_version=$(cat "$PLAN_CONTEXT/../../VERSION")
@@ -31,10 +32,11 @@ pkg_build_deps=(
 program=$pkg_name
 
 do_build() {
-  cp -v $PLAN_CONTEXT/bin/${program}.sh "$CACHE_PATH/$program"
+  cp -v "$PLAN_CONTEXT"/bin/${program}.sh "$CACHE_PATH/$program"
 
   # Use the bash from our dependency list as the shebang. Also, embed the
   # release version of the program.
+  # shellcheck disable=2154
   sed \
     -e "s,#!/bin/bash$,#!$(pkg_path_for bash)/bin/bash," \
     -e "s,^HAB_PLAN_BUILD=.*$,HAB_PLAN_BUILD=$pkg_version/$pkg_release," \
@@ -46,9 +48,10 @@ do_check() {
 }
 
 do_install() {
-  install -D "$CACHE_PATH/$program" $pkg_prefix/bin/$program
-  install -D $PLAN_CONTEXT/bin/shared.bash $pkg_prefix/bin/
-  install -D $PLAN_CONTEXT/bin/public.bash $pkg_prefix/bin/
-  install -D $PLAN_CONTEXT/bin/composite_build_functions.bash $pkg_prefix/bin/
-  install -D $PLAN_CONTEXT/bin/environment.bash $pkg_prefix/bin/
+  # shellcheck disable=2154
+  install -D "$CACHE_PATH/$program" "$pkg_prefix"/bin/$program
+  install -D "$PLAN_CONTEXT"/bin/shared.bash "$pkg_prefix"/bin/
+  install -D "$PLAN_CONTEXT"/bin/public.bash "$pkg_prefix"/bin/
+  install -D "$PLAN_CONTEXT"/bin/composite_build_functions.bash "$pkg_prefix"/bin/
+  install -D "$PLAN_CONTEXT"/bin/environment.bash "$pkg_prefix"/bin/
 }

--- a/components/studio/bin/hab-studio.sh
+++ b/components/studio/bin/hab-studio.sh
@@ -816,8 +816,8 @@ load_secrets() {
 # **Internal** Builds up the environment set to pass to an `env(1)` command for
 # use in a `chroot` environment which is printed on stdout.
 chroot_env() {
-  local studio_path="$1"
-  local extra_env="$2"
+  studio_path="$1"
+  extra_env="$2"
 
   # Set the environment which will be passed to `env(1)` to initialize the
   # session.
@@ -874,7 +874,7 @@ chroot_env() {
   if [ -n "${HAB_STUDIO_SUP:-}" ]; then
     # We want to pass a value that contains spaces, so we'll encode the spaces
     # for unpacking inside the Studio. Sorry world, but it's after 11pm.
-    env="$env HAB_STUDIO_SUP=$(echo $HAB_STUDIO_SUP | $bb sed 's/ /__sp__/g')"
+    env="$env HAB_STUDIO_SUP=$(echo "$HAB_STUDIO_SUP" | $bb sed 's/ /__sp__/g')"
   fi
   # If a Habitat update strategy frequency is set, then propagate it into the
   # Studio's environment.
@@ -901,7 +901,7 @@ chroot_env() {
     # and take care of that little whitespace problem for you.
     #
     # Thanks, Docker, for passing unnecessary spaces. You're a peach.
-    env="$env no_proxy=$(echo $no_proxy | $bb sed 's/, /,/g')"
+    env="$env no_proxy=$(echo "$no_proxy" | $bb sed 's/, /,/g')"
   fi
 
   env="$env $(load_secrets)"

--- a/components/studio/libexec/hab-studio-type-bare.sh
+++ b/components/studio/libexec/hab-studio-type-bare.sh
@@ -2,6 +2,7 @@
 # Documentation on testing local changes to this lives here:
 # https://github.com/habitat-sh/habitat/blob/master/BUILDING.md#testing-changes
 
+# shellcheck disable=2034
 studio_type="bare"
 studio_path="$HAB_ROOT_PATH/bin"
 studio_enter_environment=
@@ -11,7 +12,7 @@ studio_run_environment=
 studio_run_command=
 
 base_pkgs="core/hab core/hab-sup"
-: ${PKGS:=}
+: "${PKGS:=}"
 
 run_user="hab"
 run_group="$run_user"
@@ -25,12 +26,13 @@ finish_setup() {
     if [ -d "$HAB_PKG_PATH/$embed" ]; then
       echo "> Using local package for $embed"
       embed_path=$(_outside_pkgpath_for $embed)
-      $bb mkdir -p $HAB_STUDIO_ROOT/$embed_path
-      $bb cp -ra $embed_path/* $HAB_STUDIO_ROOT/$embed_path
-      for tdep in $($bb cat $embed_path/TDEPS); do
+      # shellcheck disable=2154
+      $bb mkdir -p "$HAB_STUDIO_ROOT"/"$embed_path"
+      $bb cp -ra "$embed_path"/* "$HAB_STUDIO_ROOT"/"$embed_path"
+      for tdep in $($bb cat "$embed_path"/TDEPS); do
         echo "> Using local package for $tdep via $embed"
-        $bb mkdir -p $HAB_STUDIO_ROOT$HAB_PKG_PATH/$tdep
-        $bb cp -ra $HAB_PKG_PATH/$tdep/* $HAB_STUDIO_ROOT$HAB_PKG_PATH/$tdep
+        $bb mkdir -p "$HAB_STUDIO_ROOT""$HAB_PKG_PATH"/"$tdep"
+        $bb cp -ra "$HAB_PKG_PATH"/"$tdep"/* "$HAB_STUDIO_ROOT""$HAB_PKG_PATH"/"$tdep"
       done
     else
       _hab install $embed
@@ -38,30 +40,36 @@ finish_setup() {
   done
 
   for pkg in $base_pkgs; do
-    _hab install $pkg
+    _hab install "$pkg"
   done
 
-  local hab_path=$(_pkgpath_for core/hab)
-  local sup_path=$(_pkgpath_for core/hab-sup)
-  local busybox_path=$(_pkgpath_for core/busybox-static)
+  local hab_path
+  hab_path=$(_pkgpath_for core/hab)
+  local sup_path
+  sup_path=$(_pkgpath_for core/hab-sup)
+  local busybox_path
+  busybox_path=$(_pkgpath_for core/busybox-static)
 
   local full_path=""
   for path_pkg in $PKGS core/hab-sup core/busybox-static; do
-    local path_file="$HAB_STUDIO_ROOT/$(_pkgpath_for $path_pkg)/PATH"
+    local path_file
+    path_file="$HAB_STUDIO_ROOT/$(_pkgpath_for $path_pkg)/PATH"
     if [ -f "$path_file" ]; then
       if [ -z "$full_path" ]; then
-        full_path="$($bb cat $path_file)"
+        full_path="$($bb cat "$path_file")"
       else
-        full_path="$full_path:$($bb cat $path_file)"
+        full_path="$full_path:$($bb cat "$path_file")"
       fi
     fi
 
-    local tdeps_file="$HAB_STUDIO_ROOT/$(_pkgpath_for $path_pkg)/TDEPS"
+    local tdeps_file
+    tdeps_file="$HAB_STUDIO_ROOT/$(_pkgpath_for $path_pkg)/TDEPS"
     if [ -f "$tdeps_file" ]; then
-      for tdep in $($bb cat $tdeps_file); do
-        local tdep_path_file="$HAB_STUDIO_ROOT/$(_pkgpath_for $tdep)/PATH"
+      for tdep in $($bb cat "$tdeps_file"); do
+        local tdep_path_file
+        tdep_path_file="$HAB_STUDIO_ROOT/$(_pkgpath_for "$tdep")/PATH"
         if [ -f "$tdep_path_file" ]; then
-          full_path="$full_path:$($bb cat $tdep_path_file)"
+          full_path="$full_path:$($bb cat "$tdep_path_file")"
         fi
       done
     fi
@@ -71,24 +79,25 @@ finish_setup() {
   studio_path="$full_path"
   studio_enter_command="${busybox_path}/bin/sh --login"
 
-  $bb mkdir -p $v $HAB_STUDIO_ROOT$HAB_ROOT_PATH/bin
+  # shellcheck disable=2086,2154
+  $bb mkdir -p $v "$HAB_STUDIO_ROOT""$HAB_ROOT_PATH"/bin
 
   # Put `hab` on the default `$PATH`
-  _hab pkg binlink --dest $HAB_ROOT_PATH/bin core/hab hab
+  _hab pkg binlink --dest "$HAB_ROOT_PATH"/bin core/hab hab
 
   # Create `/bin/{sh,bash}` for software that hardcodes these shells
   _hab pkg binlink --dest=/bin core/busybox-static bash
   _hab pkg binlink --dest=/bin core/busybox-static sh
 
   # Set the login shell for any relevant user to be `/bin/bash`
-  $bb sed -e "s,/bin/sh,$busybox_path/bin/bash,g" -i $HAB_STUDIO_ROOT/etc/passwd
+  $bb sed -e "s,/bin/sh,$busybox_path/bin/bash,g" -i "$HAB_STUDIO_ROOT"/etc/passwd
 
-  echo "${run_user}:x:42:42:root:/:/bin/sh" >> $HAB_STUDIO_ROOT/etc/passwd
-  echo "${run_group}:x:42:${run_user}" >> $HAB_STUDIO_ROOT/etc/group
+  echo "${run_user}:x:42:42:root:/:/bin/sh" >> "$HAB_STUDIO_ROOT"/etc/passwd
+  echo "${run_group}:x:42:${run_user}" >> "$HAB_STUDIO_ROOT"/etc/group
 
   local sup="$HAB_ROOT_PATH/bin/hab sup"
-  $bb touch $HAB_STUDIO_ROOT/.hab_pkg
-  $bb cat <<EOT > $HAB_STUDIO_ROOT/init.sh
+  $bb touch "$HAB_STUDIO_ROOT"/.hab_pkg
+  $bb cat <<EOT > "$HAB_STUDIO_ROOT"/init.sh
 #!$busybox_path/bin/sh
 export PATH=$full_path
 case \$1 in
@@ -97,22 +106,23 @@ case \$1 in
   *) exec $sup "\$@";;
 esac
 EOT
-  $bb chmod a+x $HAB_STUDIO_ROOT/init.sh
+  $bb chmod a+x "$HAB_STUDIO_ROOT"/init.sh
 
   # remove the unnecessary supporting filesystem
-  $bb rm -rf $HAB_STUDIO_ROOT/home $HAB_STUDIO_ROOT/lib $HAB_STUDIO_ROOT/lib64 $HAB_STUDIO_ROOT/mnt $HAB_STUDIO_ROOT/opt $HAB_STUDIO_ROOT/root $HAB_STUDIO_ROOT/run $HAB_STUDIO_ROOT/sbin $HAB_STUDIO_ROOT/src $HAB_STUDIO_ROOT/usr
+  $bb rm -rf "$HAB_STUDIO_ROOT"/home "$HAB_STUDIO_ROOT"/lib "$HAB_STUDIO_ROOT"/lib64 "$HAB_STUDIO_ROOT"/mnt "$HAB_STUDIO_ROOT"/opt "$HAB_STUDIO_ROOT"/root "$HAB_STUDIO_ROOT"/run "$HAB_STUDIO_ROOT"/sbin "$HAB_STUDIO_ROOT"/src "$HAB_STUDIO_ROOT"/usr
 
   studio_env_command="$busybox_path/bin/env"
 }
 
 _hab() {
-  $bb env FS_ROOT=$HAB_STUDIO_ROOT HAB_CACHE_KEY_PATH= $hab "$@"
+  # shellcheck disable=2154
+  $bb env FS_ROOT="$HAB_STUDIO_ROOT" HAB_CACHE_KEY_PATH= "$hab" "$@"
 }
 
 _pkgpath_for() {
-  _hab pkg path $1 | $bb sed -e "s,^$HAB_STUDIO_ROOT,,g"
+  _hab pkg path "$1" | $bb sed -e "s,^$HAB_STUDIO_ROOT,,g"
 }
 
 _outside_pkgpath_for() {
-  $hab pkg path $1
+  $hab pkg path "$1"
 }

--- a/components/studio/libexec/hab-studio-type-baseimage.sh
+++ b/components/studio/libexec/hab-studio-type-baseimage.sh
@@ -2,6 +2,7 @@
 # Documentation on testing local changes to this lives here:
 # https://github.com/habitat-sh/habitat/blob/master/BUILDING.md#testing-changes
 
+# shellcheck disable=2034
 studio_type="baseimage"
 studio_path="$HAB_ROOT_PATH/bin"
 studio_enter_environment=
@@ -11,7 +12,7 @@ studio_run_environment=
 studio_run_command=
 
 base_pkgs="core/hab core/hab-launcher core/hab-sup"
-: ${PKGS:=}
+: "${PKGS:=}"
 
 run_user="hab"
 run_group="$run_user"
@@ -25,12 +26,13 @@ finish_setup() {
     if [ -d "$HAB_PKG_PATH/$embed" ]; then
       echo "> Using local package for $embed"
       embed_path=$(_outside_pkgpath_for $embed)
-      $bb mkdir -p $HAB_STUDIO_ROOT/$embed_path
-      $bb cp -ra $embed_path/* $HAB_STUDIO_ROOT/$embed_path
-      for tdep in $($bb cat $embed_path/TDEPS); do
+      # shellcheck disable=2154
+      $bb mkdir -p "$HAB_STUDIO_ROOT"/"$embed_path"
+      $bb cp -ra "$embed_path"/* "$HAB_STUDIO_ROOT"/"$embed_path"
+      for tdep in $($bb cat "$embed_path"/TDEPS); do
         echo "> Using local package for $tdep via $embed"
-        $bb mkdir -p $HAB_STUDIO_ROOT$HAB_PKG_PATH/$tdep
-        $bb cp -ra $HAB_PKG_PATH/$tdep/* $HAB_STUDIO_ROOT$HAB_PKG_PATH/$tdep
+        $bb mkdir -p "$HAB_STUDIO_ROOT""$HAB_PKG_PATH"/"$tdep"
+        $bb cp -ra "$HAB_PKG_PATH"/"$tdep"/* "$HAB_STUDIO_ROOT""$HAB_PKG_PATH"/"$tdep"
       done
     else
       _hab install $embed
@@ -38,30 +40,36 @@ finish_setup() {
   done
 
   for pkg in $base_pkgs; do
-    _hab install $pkg
+    _hab install "$pkg"
   done
 
-  local hab_path=$(_pkgpath_for core/hab)
-  local sup_path=$(_pkgpath_for core/hab-sup)
-  local busybox_path=$(_pkgpath_for core/busybox-static)
+  local hab_path
+  hab_path=$(_pkgpath_for core/hab)
+  local sup_path
+  sup_path=$(_pkgpath_for core/hab-sup)
+  local busybox_path
+  busybox_path=$(_pkgpath_for core/busybox-static)
 
   local full_path=""
   for path_pkg in $PKGS core/hab-launcher core/hab-sup core/busybox-static; do
-    local path_file="$HAB_STUDIO_ROOT/$(_pkgpath_for $path_pkg)/PATH"
+    local path_file
+    path_file="$HAB_STUDIO_ROOT/$(_pkgpath_for $path_pkg)/PATH"
     if [ -f "$path_file" ]; then
       if [ -z "$full_path" ]; then
-        full_path="$($bb cat $path_file)"
+        full_path="$($bb cat "$path_file")"
       else
-        full_path="$full_path:$($bb cat $path_file)"
+        full_path="$full_path:$($bb cat "$path_file")"
       fi
     fi
 
-    local tdeps_file="$HAB_STUDIO_ROOT/$(_pkgpath_for $path_pkg)/TDEPS"
+    local tdeps_file
+    tdeps_file="$HAB_STUDIO_ROOT/$(_pkgpath_for $path_pkg)/TDEPS"
     if [ -f "$tdeps_file" ]; then
-      for tdep in $($bb cat $tdeps_file); do
-        local tdep_path_file="$HAB_STUDIO_ROOT/$(_pkgpath_for $tdep)/PATH"
+      for tdep in $($bb cat "$tdeps_file"); do
+        local tdep_path_file
+        tdep_path_file="$HAB_STUDIO_ROOT/$(_pkgpath_for "$tdep")/PATH"
         if [ -f "$tdep_path_file" ]; then
-          full_path="$full_path:$($bb cat $tdep_path_file)"
+          full_path="$full_path:$($bb cat "$tdep_path_file")"
         fi
       done
     fi
@@ -71,19 +79,20 @@ finish_setup() {
   studio_path="$full_path"
   studio_enter_command="${busybox_path}/bin/sh --login"
 
-  $bb mkdir -p $v $HAB_STUDIO_ROOT$HAB_ROOT_PATH/bin
+  # shellcheck disable=2086,2154
+  $bb mkdir -p $v "$HAB_STUDIO_ROOT""$HAB_ROOT_PATH"/bin
 
   # Put `hab` on the default `$PATH`
-  _hab pkg binlink --dest $HAB_ROOT_PATH/bin core/hab hab
+  _hab pkg binlink --dest "$HAB_ROOT_PATH"/bin core/hab hab
 
   # Create `/bin/{sh,bash}` for software that hardcodes these shells
   _hab pkg binlink --dest=/bin core/busybox-static bash
   _hab pkg binlink --dest=/bin core/busybox-static sh
 
   # Set the login shell for any relevant user to be `/bin/bash`
-  $bb sed -e "s,/bin/sh,$busybox_path/bin/bash,g" -i $HAB_STUDIO_ROOT/etc/passwd
+  $bb sed -e "s,/bin/sh,$busybox_path/bin/bash,g" -i "$HAB_STUDIO_ROOT"/etc/passwd
 
-  $bb cat <<PROFILE > $HAB_STUDIO_ROOT/etc/profile
+  $bb cat <<PROFILE > "$HAB_STUDIO_ROOT"/etc/profile
 # Add hab to the default \$PATH at the front so any wrapping scripts will
 # be found and called first
 export PATH=$full_path:\$PATH
@@ -97,12 +106,12 @@ alias fgrep='fgrep --color=auto'
 source <(hab cli completers --shell bash)
 PROFILE
 
-  $bb cat <<EOT > $HAB_STUDIO_ROOT/etc/resolv.conf
+  $bb cat <<EOT > "$HAB_STUDIO_ROOT"/etc/resolv.conf
 nameserver 8.8.8.8
 nameserver 8.8.4.4
 EOT
 
-  $bb cat <<EOT > $HAB_STUDIO_ROOT/etc/nsswitch.conf
+  $bb cat <<EOT > "$HAB_STUDIO_ROOT"/etc/nsswitch.conf
 passwd:     files
 group:      files
 shadow:     files
@@ -113,12 +122,12 @@ networks:   files
 rpc:        files
 services:   files
 EOT
-  echo "${run_user}:x:42:42:root:/:/bin/sh" >> $HAB_STUDIO_ROOT/etc/passwd
-  echo "${run_group}:x:42:${run_user}" >> $HAB_STUDIO_ROOT/etc/group
+  echo "${run_user}:x:42:42:root:/:/bin/sh" >> "$HAB_STUDIO_ROOT"/etc/passwd
+  echo "${run_group}:x:42:${run_user}" >> "$HAB_STUDIO_ROOT"/etc/group
 
   local sup="$HAB_ROOT_PATH/bin/hab sup"
-  $bb touch $HAB_STUDIO_ROOT/.hab_pkg
-  $bb cat <<EOT > $HAB_STUDIO_ROOT/init.sh
+  $bb touch "$HAB_STUDIO_ROOT"/.hab_pkg
+  $bb cat <<EOT > "$HAB_STUDIO_ROOT"/init.sh
 #!$busybox_path/bin/sh
 export PATH=$full_path
 case \$1 in
@@ -127,19 +136,20 @@ case \$1 in
   *) exec $sup "\$@";;
 esac
 EOT
-  $bb chmod a+x $HAB_STUDIO_ROOT/init.sh
+  $bb chmod a+x "$HAB_STUDIO_ROOT"/init.sh
 
   studio_env_command="$busybox_path/bin/env"
 }
 
 _hab() {
-  $bb env FS_ROOT=$HAB_STUDIO_ROOT HAB_CACHE_KEY_PATH= $hab "$@"
+  # shellcheck disable=2154
+  $bb env FS_ROOT="$HAB_STUDIO_ROOT" HAB_CACHE_KEY_PATH= "$hab" "$@"
 }
 
 _pkgpath_for() {
-  _hab pkg path $1 | $bb sed -e "s,^$HAB_STUDIO_ROOT,,g"
+  _hab pkg path "$1" | $bb sed -e "s,^$HAB_STUDIO_ROOT,,g"
 }
 
 _outside_pkgpath_for() {
-  $hab pkg path $1
+  $hab pkg path "$1"
 }

--- a/components/studio/libexec/hab-studio-type-busybox.sh
+++ b/components/studio/libexec/hab-studio-type-busybox.sh
@@ -2,6 +2,7 @@
 # Documentation on testing local changes to this lives here:
 # https://github.com/habitat-sh/habitat/blob/master/BUILDING.md#testing-changes
 
+# shellcheck disable=2034
 studio_type="busybox"
 studio_path="/opt/busybox"
 studio_env_command="/opt/busybox/busybox env"
@@ -14,16 +15,19 @@ studio_run_command="/opt/busybox/busybox sh -l"
 
 finish_setup() {
   # Copy in the busybox binary under `/opt/busybox`
-  $bb mkdir -p $v $HAB_STUDIO_ROOT/opt/busybox
-  $bb cp $v $libexec_path/busybox $HAB_STUDIO_ROOT/opt/busybox/
+  # shellcheck disable=2154,2086
+  $bb mkdir -p $v "$HAB_STUDIO_ROOT"/opt/busybox
+  # shellcheck disable=2154,2086
+  $bb cp $v "$libexec_path"/busybox "$HAB_STUDIO_ROOT"/opt/busybox/
 
   if [ ! -f "$HAB_STUDIO_ROOT/opt/busybox/sh" ]; then
     # Symlink all tools to busybox under `/opt/busybox`
-    for c in $($HAB_STUDIO_ROOT/opt/busybox/busybox --list); do
-      $bb ln -sf $v busybox $HAB_STUDIO_ROOT/opt/busybox/$c
+    for c in $("$HAB_STUDIO_ROOT"/opt/busybox/busybox --list); do
+      # shellcheck disable=2086
+      $bb ln -sf $v busybox "$HAB_STUDIO_ROOT"/opt/busybox/$c
     done
   fi
 
   # Set the login shell for any relevant user to be busybox's `sh`
-  $bb sed -e 's,/bin/sh,/opt/busybox/sh,g' -i $HAB_STUDIO_ROOT/etc/passwd
+  $bb sed -e 's,/bin/sh,/opt/busybox/sh,g' -i "$HAB_STUDIO_ROOT"/etc/passwd
 }

--- a/components/studio/libexec/hab-studio-type-stage1.sh
+++ b/components/studio/libexec/hab-studio-type-stage1.sh
@@ -2,6 +2,7 @@
 # Documentation on testing local changes to this lives here:
 # https://github.com/habitat-sh/habitat/blob/master/BUILDING.md#testing-changes
 
+# shellcheck disable=2034
 studio_type="stage1"
 studio_path="/bin:/tools/bin"
 studio_env_command="/tools/bin/env"
@@ -12,23 +13,25 @@ studio_build_command=
 studio_run_environment=
 studio_run_command="/tools/bin/bash --login"
 
-: ${STAGE1_TOOLS_URL:=http://s3-us-west-2.amazonaws.com/habitat-studio-stage1/habitat-studio-stage1-20180312233639.tar.xz}
-: ${TAR_DIR:=/tmp}
+: "${STAGE1_TOOLS_URL:=http://s3-us-west-2.amazonaws.com/habitat-studio-stage1/habitat-studio-stage1-20180312233639.tar.xz}"
+: "${TAR_DIR:=/tmp}"
 
 finish_setup() {
   if [ -n "$HAB_ORIGIN_KEYS" ]; then
-    for key in $(echo $HAB_ORIGIN_KEYS | $bb tr ',' ' '); do
+    # shellcheck disable=2154
+    for key in $(echo "$HAB_ORIGIN_KEYS" | $bb tr ',' ' '); do
       local key_text
       # Import the secret origin key, required for signing packages
       info "Importing '$key' secret origin key"
-      if key_text=$($hab origin key export --type secret $key); then
-        printf -- "${key_text}" | _hab origin key import
+      if key_text=$($hab origin key export --type secret "$key"); then
+        printf -- "%s" "${key_text}" | _hab origin key import
       else
         echo "Error exporting $key key"
         # key_text will contain an error message
         echo "${key_text}"
         echo "Habitat was unable to export your secret signing key. Please"
         echo "verify that you have a signing key for $key present in either"
+        # shellcheck disable=2088
         echo "~/.hab/cache/keys (if running via sudo) or /hab/cache/keys"
         echo "(if running as root). You can test this by running:"
         echo ""
@@ -46,9 +49,9 @@ finish_setup() {
       fi
       # Attempt to import the public origin key, which can be used for local
       # package installations where the key may not yet be uploaded.
-      if key_text=$($hab origin key export --type public $key 2> /dev/null); then
+      if key_text=$($hab origin key export --type public "$key" 2> /dev/null); then
         info "Importing '$key' public origin key"
-        printf -- "${key_text}" | _hab origin key import
+        printf -- "%s" "${key_text}" | _hab origin key import
       else
         info "Tried to import '$key' public origin key, but key was not found"
       fi
@@ -61,44 +64,49 @@ finish_setup() {
 
   tar_file="$TAR_DIR/$($bb basename $STAGE1_TOOLS_URL)"
 
-  if [ ! -f $tar_file ]; then
+  if [ ! -f "$tar_file" ]; then
     trap '$bb rm -f $tar_file; exit $?' INT TERM EXIT
     info "Downloading $STAGE1_TOOLS_URL"
-    $bb wget $STAGE1_TOOLS_URL -O $tar_file
+    $bb wget $STAGE1_TOOLS_URL -O "$tar_file"
     trap - INT TERM EXIT
   fi
 
-  info "Extracting $($bb basename $tar_file)"
-  $bb xzcat $tar_file | $bb tar xf - -C $HAB_STUDIO_ROOT
+  info "Extracting $($bb basename "$tar_file")"
+  $bb xzcat "$tar_file" | $bb tar xf - -C "$HAB_STUDIO_ROOT"
 
   # Create symlinks from the minimal toolchain installed under `/tools` into
   # the root of the chroot environment. This is done to satisfy tools such as
   # `make(1)` which expect `/bin/sh` to exist.
 
-  $bb ln -sf $v /tools/bin/bash $HAB_STUDIO_ROOT/bin
-  $bb ln -sf $v /tools/bin/cat $HAB_STUDIO_ROOT/bin
-  $bb ln -sf $v /tools/bin/echo $HAB_STUDIO_ROOT/bin
-  $bb ln -sf $v /tools/bin/pwd $HAB_STUDIO_ROOT/bin
-  $bb ln -sf $v /tools/bin/stty $HAB_STUDIO_ROOT/bin
+  # shellcheck disable=2086
+  {
+  # shellcheck disable=2154
+  $bb ln -sf $v /tools/bin/bash "$HAB_STUDIO_ROOT"/bin
+  $bb ln -sf $v /tools/bin/cat "$HAB_STUDIO_ROOT"/bin
+  $bb ln -sf $v /tools/bin/echo "$HAB_STUDIO_ROOT"/bin
+  $bb ln -sf $v /tools/bin/pwd "$HAB_STUDIO_ROOT"/bin
+  $bb ln -sf $v /tools/bin/stty "$HAB_STUDIO_ROOT"/bin
 
-  $bb ln -sf $v /tools/bin/perl $HAB_STUDIO_ROOT/usr/bin
-  $bb ln -sf $v /tools/lib/libgcc_s.so $HAB_STUDIO_ROOT/usr/lib
-  $bb ln -sf $v /tools/lib/libgcc_s.so.1 $HAB_STUDIO_ROOT/usr/lib
-  $bb ln -sf $v /tools/lib/libstdc++.so $HAB_STUDIO_ROOT/usr/lib
-  $bb ln -sf $v /tools/lib/libstdc++.so.6 $HAB_STUDIO_ROOT/usr/lib
+  $bb ln -sf $v /tools/bin/perl "$HAB_STUDIO_ROOT"/usr/bin
+  $bb ln -sf $v /tools/lib/libgcc_s.so "$HAB_STUDIO_ROOT"/usr/lib
+  $bb ln -sf $v /tools/lib/libgcc_s.so.1 "$HAB_STUDIO_ROOT"/usr/lib
+  $bb ln -sf $v /tools/lib/libstdc++.so "$HAB_STUDIO_ROOT"/usr/lib
+  $bb ln -sf $v /tools/lib/libstdc++.so.6 "$HAB_STUDIO_ROOT"/usr/lib    
+  } # end shellcheck disable
   # TODO fn: Used for older versions of the stage1 tarball, so this check can
   # eventually be removed as newer tarballs will most likely always skip this
   # step.
   if [ -f "$HAB_STUDIO_ROOT/tools/lib/libstdc++.la" ]; then
-    $bb sed 's/tools/usr/' $HAB_STUDIO_ROOT/tools/lib/libstdc++.la \
-      > $HAB_STUDIO_ROOT/usr/lib/libstdc++.la
+    $bb sed 's/tools/usr/' "$HAB_STUDIO_ROOT"/tools/lib/libstdc++.la \
+      > "$HAB_STUDIO_ROOT"/usr/lib/libstdc++.la
   fi
-  $bb ln -sf $v bash $HAB_STUDIO_ROOT/bin/sh
+  # shellcheck disable=2086
+  $bb ln -sf $v bash "$HAB_STUDIO_ROOT"/bin/sh
 
   # Set the login shell for any relevant user to be `/bin/bash`
-  $bb sed -e 's,/bin/sh,/bin/bash,g' -i $HAB_STUDIO_ROOT/etc/passwd
+  $bb sed -e 's,/bin/sh,/bin/bash,g' -i "$HAB_STUDIO_ROOT"/etc/passwd
 
-  $bb cat >> $HAB_STUDIO_ROOT/etc/profile <<'PROFILE'
+  $bb cat >> "$HAB_STUDIO_ROOT"/etc/profile <<'PROFILE'
 # Colorize grep/egrep/fgrep by default
 alias grep='grep --color=auto'
 alias egrep='egrep --color=auto'
@@ -108,5 +116,5 @@ PROFILE
 }
 
 _hab() {
-  $bb env FS_ROOT=$HAB_STUDIO_ROOT HAB_CACHE_KEY_PATH= $hab "$@"
+  $bb env FS_ROOT="$HAB_STUDIO_ROOT" HAB_CACHE_KEY_PATH= "$hab" "$@"
 }

--- a/components/sup/plan.sh
+++ b/components/sup/plan.sh
@@ -1,3 +1,4 @@
+# shellcheck disable=2034,2154
 pkg_name=hab-sup
 _pkg_distname=$pkg_name
 pkg_origin=core
@@ -33,6 +34,7 @@ _common_prepare() {
   build_line "Setting CARGO_TARGET_DIR=$CARGO_TARGET_DIR"
 }
 
+# shellcheck disable=2155
 do_prepare() {
   _common_prepare
 
@@ -65,15 +67,15 @@ do_prepare() {
 
 do_build() {
   export LIBRARY_PATH=$LIBZMQ_PREFIX/lib
-  pushd $PLAN_CONTEXT > /dev/null
+  pushd "$PLAN_CONTEXT" > /dev/null
   cargo build ${build_type#--debug} --target=$rustc_target --verbose --no-default-features \
     --features apidocs
   popd > /dev/null
 }
 
 do_install() {
-  install -v -D $CARGO_TARGET_DIR/$rustc_target/${build_type#--}/$bin \
-    $pkg_prefix/bin/$bin
+  install -v -D "$CARGO_TARGET_DIR"/$rustc_target/${build_type#--}/$bin \
+    "$pkg_prefix"/bin/$bin
 }
 
 do_strip() {

--- a/components/sup/static/plan.sh
+++ b/components/sup/static/plan.sh
@@ -1,4 +1,5 @@
-PLAN_CONTEXT=$(dirname $PLAN_CONTEXT) source ../plan.sh
+# shellcheck disable=2034
+PLAN_CONTEXT=$(dirname "$PLAN_CONTEXT") source ../plan.sh
 
 pkg_name=hab-sup-static
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
@@ -14,6 +15,7 @@ do_begin() {
   PLAN_CONTEXT=$(abspath ..)
 }
 
+# shellcheck disable=2155
 do_prepare() {
   _common_prepare
 

--- a/run-bats.sh
+++ b/run-bats.sh
@@ -4,7 +4,7 @@
 # executes the tests in that container, mounting the tests and Habitat
 # binaries as needed.
 
-docker build -t hab-bats-cleanroom $(pwd)/test/integration
+docker build -t hab-bats-cleanroom "$(pwd)"/test/integration
 
 docker run -it --rm \
        --mount type=bind,source="$(pwd)/test/integration",target=/test \

--- a/support/account_creation_report.sh
+++ b/support/account_creation_report.sh
@@ -11,9 +11,7 @@ fi
 
 # Note that although the query below specifies shard_0, the function itself queries and aggregates results across all shards
 if command -v hab > /dev/null 2>&1; then
-  hab pkg exec core/postgresql psql -U hab -q -c "COPY (SELECT * FROM shard_0.account_creation_report('$1')) TO '$output' WITH (FORMAT CSV, HEADER TRUE, FORCE_QUOTE *)" builder_sessionsrv
-
-  if [ $? -eq 0 ]; then
+  if hab pkg exec core/postgresql psql -U hab -q -c "COPY (SELECT * FROM shard_0.account_creation_report('$1')) TO '$output' WITH (FORMAT CSV, HEADER TRUE, FORCE_QUOTE *)" builder_sessionsrv; then
     echo "The report ran successfully. The CSV file can be found at $output"
   else
     echo "There was an error running the report. Make sure you're passing a date as the sole argument to this script, e.g. 2017-09-01"

--- a/support/bash_completion.sh
+++ b/support/bash_completion.sh
@@ -1,3 +1,4 @@
+# shellcheck disable=2086,2128,2207
 # Copyright:: Copyright (c) 2015-2016 The Habitat Maintainers
 #
 # The terms of the Evaluation Agreement (Habitat) between Chef Software Inc.

--- a/support/ci/builder-base-plan.sh
+++ b/support/ci/builder-base-plan.sh
@@ -5,7 +5,7 @@
 # duplicate the code here.
 
 pkg_version() {
-  echo "$(git rev-list master --count)"
+  git rev-list master --count
 }
 
 do_before() {
@@ -39,10 +39,12 @@ do_builder_build() {
 }
 
 do_builder_install() {
+  # shellcheck disable=2154
   install -v -D "$CARGO_TARGET_DIR/$rustc_target/${builder_build_type#--}/$bin" \
     "$pkg_prefix/bin/$bin"
 }
 
+# shellcheck disable=2154
 do_builder_prepare() {
   export builder_build_type="${builder_build_type:---release}"
   # Can be either `--release` or `--debug` to determine cargo build strategy

--- a/support/ci/compile_libarchive.sh
+++ b/support/ci/compile_libarchive.sh
@@ -13,12 +13,12 @@ if [ -d "$prefix" ]; then
   exit 0
 fi
 
-source $(dirname $0)/rust_env.sh
+source "$(dirname "$0")/rust_env.sh"
 
 echo "--> Compiling $nv"
 trap 'rm -rf /tmp/${nv}*; exit $?' INT TERM EXIT
-(cd /tmp && wget $source && tar xf /tmp/$(basename $source))
+(cd /tmp && wget $source && tar xf "/tmp/$(basename $source)")
 cd /tmp/$nv
-./configure --prefix=$prefix --without-xml2 --without-lzo2
+./configure --prefix="$prefix" --without-xml2 --without-lzo2
 make
 make install

--- a/support/ci/compile_libsodium.sh
+++ b/support/ci/compile_libsodium.sh
@@ -13,12 +13,12 @@ if [ -d "$prefix" ]; then
   exit 0
 fi
 
-source $(dirname $0)/rust_env.sh
+source "$(dirname "$0")"/rust_env.sh
 
 echo "--> Compiling $nv"
 trap 'rm -rf /tmp/${nv}*; exit $?' INT TERM EXIT
-(cd /tmp && wget $source && tar xf /tmp/$(basename $source))
+(cd /tmp && wget $source && tar xf /tmp/"$(basename $source)")
 cd /tmp/$nv
-./configure --prefix=$prefix
+./configure --prefix="$prefix"
 make
 make install

--- a/support/ci/compile_zmq.sh
+++ b/support/ci/compile_zmq.sh
@@ -12,12 +12,12 @@ if [ -d "$prefix" ]; then
   exit 0
 fi
 
-source $(dirname $0)/rust_env.sh
+source "$(dirname "$0")"/rust_env.sh
 
 echo "--> Compiling $nv"
 trap 'rm -rf /tmp/${nv}*; exit $?' INT TERM EXIT
-(cd /tmp && wget --no-check-certificate $source && tar xf /tmp/$(basename $source))
+(cd /tmp && wget --no-check-certificate $source && tar xf /tmp/"$(basename $source)")
 cd /tmp/$nv
-./autogen.sh && ./configure --prefix=$prefix --with-libsodium
+./autogen.sh && ./configure --prefix="$prefix" --with-libsodium
 make
 make install

--- a/support/ci/deploy_mac.sh
+++ b/support/ci/deploy_mac.sh
@@ -12,8 +12,8 @@ set -eu
 var_file="$HOME/tmp/our-awesome-vars"
 if [[ -f ${var_file} ]]; then
   echo "--> Located the file with the magic environment variables."
-  source ${var_file}
-  rm ${var_file}
+  source "${var_file}"
+  rm "${var_file}"
 else
   echo "${var_file} does not appear to exist or at least not pass the -f test."
   echo "This script will likely abort shortly."
@@ -38,9 +38,9 @@ export HAB_ORIGIN=core
 export PATH="${our_path}"
 
 # start fresh
-rm -fr ${bootstrap_dir}
-mkdir -p ${bootstrap_dir}
-cd ${bootstrap_dir}
+rm -fr "${bootstrap_dir}"
+mkdir -p "${bootstrap_dir}"
+cd "${bootstrap_dir}"
 
 # this removes the link that was setup below, just in case it exists.
 # if we don't do this, then lots of tar related things fail
@@ -52,7 +52,7 @@ fi
 wget -O hab.tar.gz "${hab_download_url}"
 
 # install it in a custom location
-tar xvzf ./hab.tar.gz --strip 1 -C ${bootstrap_dir}
+tar xvzf ./hab.tar.gz --strip 1 -C "${bootstrap_dir}"
 
 # create our origin key
 cat << EOF > core.sig.key
@@ -71,7 +71,7 @@ rm -f ./core.sig.key
 # since this is running on a headless mac, we can't use docker/studio,
 # so we need to resort to this hackery
 echo "Customizing bintray-publish"
-cp -v $hab_src_dir/components/bintray-publish/bin/publish-hab.sh $bootstrap_dir
+cp -v "$hab_src_dir"/components/bintray-publish/bin/publish-hab.sh "$bootstrap_dir"
 program=$bootstrap_dir/publish-hab.sh
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 our_version=$($mac_hab --version | cut -d ' ' -f 2)
@@ -83,10 +83,10 @@ sed \
   -e "s,@version@,$our_version,g" \
   -e "s,tr --delete,tr -d,g" \
   -e "s,sha256sum ,shasum -a 256 ,g" \
-  -i "" $program
+  -i "" "$program"
 
 echo "Building hab"
-cd $mac_dir
+cd "$mac_dir"
 ./mac-build.sh
 echo "Built new version of hab"
 
@@ -95,14 +95,15 @@ echo "Built new version of hab"
 ln -sf /usr/local/bin/gtar /usr/local/bin/tar
 hash -r
 
-cd ${bootstrap_dir}
+cd "${bootstrap_dir}"
 
 echo "Publishing hab to $BINTRAY_REPO"
-release=$(find $mac_dir/results -name core-hab-0*.hart | sort -n | tail -n 1)
+# shellcheck disable=2061
+release=$(find "$mac_dir"/results -name "core-hab-0*.hart" | sort -n | tail -n 1)
 if [ "$BINTRAY_REPO" == "stable" ]; then
-  $program -s -r $BINTRAY_REPO $release
+  $program -s -r "$BINTRAY_REPO" "$release"
 else
-  $program -r $BINTRAY_REPO $release
+  $program -r "$BINTRAY_REPO" "$release"
 fi
-rm $release
-rm -rf $bootstrap_dir
+rm "$release"
+rm -rf "$bootstrap_dir"

--- a/support/ci/deploy_mac_launcher.sh
+++ b/support/ci/deploy_mac_launcher.sh
@@ -8,14 +8,14 @@ version="$(cat VERSION)"
 mac_builder=admin@74.80.245.236
 
 BINTRAY_REPO=unstable
-if [ $version == "$TRAVIS_TAG" ]; then
+if [ "$version" == "$TRAVIS_TAG" ]; then
   BINTRAY_REPO=stable
 fi
 
 # kick off the mac unstable build
 echo "Kicking off the $BINTRAY_REPO mac build"
 var_file=/tmp/our-awesome-vars
-ssh_args="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i /tmp/habitat-srv-admin"
+ssh_args=(-o "StrictHostKeyChecking=no" -o "UserKnownHostsFile=/dev/null" -i /tmp/habitat-srv-admin)
 
 if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
   co="FETCH_HEAD"
@@ -26,7 +26,8 @@ else
 fi
 
 # first update the copy of the habitat code stored on the mac server to the latest
-ssh ${ssh_args} ${mac_builder} << EOF
+# shellcheck disable=2087
+ssh "${ssh_args[@]}" ${mac_builder} << EOF
     hab_src_dir="\$HOME/code/$TRAVIS_BUILD_NUMBER"
     mkdir -p \${hab_src_dir}
     cd \${hab_src_dir}
@@ -48,9 +49,10 @@ export BINTRAY_PASSPHRASE=$BINTRAY_PASSPHRASE
 export TRAVIS_BUILD_NUMBER=$TRAVIS_BUILD_NUMBER
 EOF
 
-scp ${ssh_args} ${var_file} ${mac_builder}:~/tmp
+scp "${ssh_args[@]}" ${var_file} ${mac_builder}:~/tmp
 rm ${var_file}
 
 # kick off the build
-ssh ${ssh_args} ${mac_builder} \
+# shellcheck disable=2029
+ssh "${ssh_args[@]}" ${mac_builder} \
   "sudo ~/code/$TRAVIS_BUILD_NUMBER/habitat/support/ci/deploy_mac.sh"

--- a/support/ci/fast_pass.sh
+++ b/support/ci/fast_pass.sh
@@ -36,16 +36,19 @@ else
   echo
   echo "Checking for changed files since last merge commit:"
   echo
+  # shellcheck disable=2086
   echo_indented $CHANGED_FILES
   echo
 
   echo "Among the affected files:"
   echo
+  # shellcheck disable=2086
   echo_indented $AFFECTED_FILES
   echo
 
   echo "And in the affected directories:"
   echo
+  # shellcheck disable=2086
   echo_indented $AFFECTED_DIRS
   echo
 

--- a/support/ci/macos-pkg.sh
+++ b/support/ci/macos-pkg.sh
@@ -4,16 +4,18 @@
 # non-zero exit code.
 set -eu
 
-src_root=$(dirname $0)/../../
+src_root=$(dirname "$0")/../../
 
 if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
-  sudo -E $src_root/components/hab/mac/mac-build.sh $src_root/components/hab/mac
-  mkdir -p $src_root/out/hab-x86_64-darwin
-  source $src_root/results/last_build.env
-  cp /hab/pkgs/$pkg_ident/bin/hab $src_root/out/hab-x86_64-darwin/hab
-  zip -9 -r $src_root/out/hab-x86_64-darwin.zip $src_root/out/hab-x86_64-darwin
+  sudo -E "$src_root"/components/hab/mac/mac-build.sh "$src_root"/components/hab/mac
+  mkdir -p "$src_root"/out/hab-x86_64-darwin
+  source "$src_root"/results/last_build.env
+  # shellcheck disable=2154
+  cp /hab/pkgs/"$pkg_ident"/bin/hab "$src_root"/out/hab-x86_64-darwin/hab
+  zip -9 -r "$src_root"/out/hab-x86_64-darwin.zip "$src_root"/out/hab-x86_64-darwin
 
-cat <<- EOF > $src_root/out/hab-bintray.json
+# shellcheck disable=2154
+cat <<- EOF > "$src_root"/out/hab-bintray.json
 {
   "package": {
     "name": "hab-x86_64-darwin",

--- a/support/ci/promote_rc.sh
+++ b/support/ci/promote_rc.sh
@@ -2,15 +2,15 @@
 
 set -e
 
-if [ -z ${HAB_AUTH_TOKEN+x} ]; then
+if [ -z "${HAB_AUTH_TOKEN+x}" ]; then
   echo "HAB_AUTH_TOKEN var is unset"
   exit 1
 fi
-if [ -z ${BINTRAY_USER+x} ]; then
+if [ -z "${BINTRAY_USER+x}" ]; then
   echo "BINTRAY_USER var is unset"
   exit 1
 fi
-if [ -z ${BINTRAY_KEY+x} ]; then
+if [ -z "${BINTRAY_KEY+x}" ]; then
   echo "BINTRAY_KEY var is unset"
   exit 1
 fi
@@ -18,17 +18,17 @@ fi
 HAB_VERSION=$(cat VERSION)
 PROMOTE_CHANNEL=stable
 RC_CHANNEL=rc-$HAB_VERSION
-RC_PKGS_JSON=$(curl https://bldr.habitat.sh/v1/depot/channels/core/$RC_CHANNEL/pkgs)
-RC_PKGS_JSON_DATA=$(echo $RC_PKGS_JSON | jq -c -r '.data | .[]')
-TOTAL_COUNT=$(echo $RC_PKGS_JSON | jq -r '.total_count')
-END=$(echo $RC_PKGS_JSON | jq -r '.range_end')
+RC_PKGS_JSON=$(curl https://bldr.habitat.sh/v1/depot/channels/core/"$RC_CHANNEL"/pkgs)
+RC_PKGS_JSON_DATA=$(echo "$RC_PKGS_JSON" | jq -c -r '.data | .[]')
+TOTAL_COUNT=$(echo "$RC_PKGS_JSON" | jq -r '.total_count')
+END=$(echo "$RC_PKGS_JSON" | jq -r '.range_end')
 
 # We limit results to 50 items. While it is unlikely, it is possible
 # after building several releases that we may exceed 50 packages in
 # the rc channel. We could get all fancy and complicated here to
 # aggregate multiple pages but I'd rather tear my eyes out of their
 # sockets. Instead, we suggest a workaround in the failure message.
-if [ $(($END+1)) !=  $TOTAL_COUNT ]; then
+if [ $((END+1)) !=  TOTAL_COUNT ]; then
   echo "There are multipe pages of releases. Consider deleting the channel and then rebuild."
   exit 1
 fi
@@ -38,11 +38,11 @@ fi
 declare -A pkg_releases
 for pkg in $RC_PKGS_JSON_DATA
 do
-    ORIGIN=$(echo $pkg | jq -r ".origin")
-    NAME=$(echo $pkg | jq -r ".name")
-    VERSION=$(echo $pkg | jq -r ".version")
-    RELEASE=$(echo $pkg | jq -r ".release")
-    TARGET=$(echo $pkg | jq -r ".platforms[0]")
+    ORIGIN=$(echo "$pkg" | jq -r ".origin")
+    NAME=$(echo "$pkg" | jq -r ".name")
+    VERSION=$(echo "$pkg" | jq -r ".version")
+    RELEASE=$(echo "$pkg" | jq -r ".release")
+    TARGET=$(echo "$pkg" | jq -r ".platforms[0]")
     IDENT=$ORIGIN/$NAME/$VERSION/$RELEASE
     if [[ -z ${pkg_releases[$NAME-$TARGET]+x} || "${pkg_releases[$NAME-$TARGET]}" < "$IDENT" ]]; then
         pkg_releases[$NAME-$TARGET]=$IDENT
@@ -60,34 +60,34 @@ do
     fi
 done
 
-for rel_target in ${!pkg_releases[@]}
+for rel_target in "${!pkg_releases[@]}"
 do
     rel=${pkg_releases[$rel_target]}
     echo "Promoting $rel_target-$rel to $PROMOTE_CHANNEL"
-    hab pkg promote $rel $PROMOTE_CHANNEL
+    hab pkg promote "$rel" $PROMOTE_CHANNEL
 done
 
-if [ -z ${LINUX_RELEASE+x} ]; then
+if [ -z "${LINUX_RELEASE+x}" ]; then
   echo "Could not find hab package for linux platform in $RC_CHANNEL channel"
   exit 1
 fi
-if [ -z ${WINDOWS_RELEASE+x} ]; then
+if [ -z "${WINDOWS_RELEASE+x}" ]; then
   echo "Could not find hab package for windows platform in $RC_CHANNEL channel"
   exit 1
 fi
 
 echo "Publishing Linux CLI $HAB_VERSION-$LINUX_RELEASE to bintray"
-curl -u $BINTRAY_USER:$BINTRAY_KEY -X POST https://api.bintray.com/content/habitat/$PROMOTE_CHANNEL/hab-x86_64-linux/$HAB_VERSION-$LINUX_RELEASE/publish
+curl -u "$BINTRAY_USER":"$BINTRAY_KEY" -X POST https://api.bintray.com/content/habitat/$PROMOTE_CHANNEL/hab-x86_64-linux/"$HAB_VERSION"-"$LINUX_RELEASE"/publish
 echo "Publishing Windows CLI $HAB_VERSION-$WINDOWS_RELEASE to bintray"
-curl -u $BINTRAY_USER:$BINTRAY_KEY -X POST https://api.bintray.com/content/habitat/$PROMOTE_CHANNEL/hab-x86_64-windows/$HAB_VERSION-$WINDOWS_RELEASE/publish
+curl -u "$BINTRAY_USER":"$BINTRAY_KEY" -X POST https://api.bintray.com/content/habitat/$PROMOTE_CHANNEL/hab-x86_64-windows/"$HAB_VERSION"-"$WINDOWS_RELEASE"/publish
 
 # We do not store darwin packages on builder so we will get
 # the latest version on bintray
-DARWIN_RELEASE=$(curl -u $BINTRAY_USER:$BINTRAY_KEY https://api.bintray.com/packages/habitat/stable/hab-x86_64-darwin | jq -r '.versions[0]')
-IFS='-' read -r -a version_release <<< $DARWIN_RELEASE
+DARWIN_RELEASE=$(curl -u "$BINTRAY_USER":"$BINTRAY_KEY" https://api.bintray.com/packages/habitat/stable/hab-x86_64-darwin | jq -r '.versions[0]')
+IFS='-' read -r -a version_release <<< "$DARWIN_RELEASE"
 if [ "${version_release[0]}" != "$HAB_VERSION" ]; then
   echo "Could not find a darwin release for $HAB_VERSION on bintray"
   exit 1
 fi
 echo "Publishing Mac CLI $DARWIN_RELEASE to bintray"
-curl -u $BINTRAY_USER:$BINTRAY_KEY -X POST https://api.bintray.com/content/habitat/$PROMOTE_CHANNEL/hab-x86_64-darwin/$DARWIN_RELEASE/publish
+curl -u "$BINTRAY_USER":"$BINTRAY_KEY" -X POST https://api.bintray.com/content/habitat/$PROMOTE_CHANNEL/hab-x86_64-darwin/"$DARWIN_RELEASE"/publish

--- a/support/ci/publish-builder.sh
+++ b/support/ci/publish-builder.sh
@@ -10,13 +10,14 @@
 set -eu
 src_root=$(cd "$(dirname "$0")/../../"; pwd)
 
-if [ -z ${HAB_AUTH_TOKEN+x} ]; then
+if [ -z "${HAB_AUTH_TOKEN+x}" ]; then
   echo "HAB_AUTH_TOKEN var is unset"
   exit 1
 fi
 
-for crate in `find components/builder-* | grep plan.sh | xargs dirname`; do
-  hab pkg build -k core -s $src_root -R $crate
-  source $src_root/results/last_build.env
-  hab pkg upload $src_root/results/$pkg_artifact -z $HAB_AUTH_TOKEN
+for crate in $(find components/builder-* | grep plan.sh | xargs dirname); do
+  hab pkg build -k core -s "$src_root" -R "$crate"
+  source "$src_root"/results/last_build.env
+  # shellcheck disable=2154
+  hab pkg upload "$src_root"/results/"$pkg_artifact" -z "$HAB_AUTH_TOKEN"
 done

--- a/support/ci/rust_tests.sh
+++ b/support/ci/rust_tests.sh
@@ -10,7 +10,7 @@ fi
 
 echo "--> Running $0"
 
-source $(dirname $0)/rust_env.sh
+source "$(dirname "$0")"/rust_env.sh
 
 set -e
-make unit-${COMPONENTS:-all}
+make unit-"${COMPONENTS:-all}"

--- a/support/ci/what_changed.sh
+++ b/support/ci/what_changed.sh
@@ -17,4 +17,4 @@ if [ "${CURRENT_SHA}" == "${LATEST_MERGE_COMMIT}" ] ; then
     LATEST_MERGE_COMMIT="$(git log --merges --max-count=1 --skip=1 --pretty=format:%H)"
 fi
 
-git diff --name-only ${LATEST_MERGE_COMMIT}
+git diff --name-only "${LATEST_MERGE_COMMIT}"

--- a/support/devshell_profile.sh
+++ b/support/devshell_profile.sh
@@ -1,10 +1,10 @@
 info() {
   case "${TERM:-}" in
     *term | xterm-* | rxvt | screen | screen-*)
-      printf -- "   \033[1;36mHabitat devshell: \033[1;37m$1\033[0m\n"
+      printf -- "   \033[1;36mHabitat devshell: \033[1;37m%s\033[0m\n" "$1"
       ;;
     *)
-      printf -- "   devshell: $1\n"
+      printf -- "   devshell: %s\n" "$1"
       ;;
   esac
   return 0
@@ -19,9 +19,11 @@ fi
 if [[ -n "$HAB_BLDR_URL" ]]; then
   info "Exported: HAB_BLDR_URL=$HAB_BLDR_URL"
 fi
+# shellcheck disable=2154
 if [[ -n "$http_proxy" ]]; then
   info "Exported: http_proxy=$http_proxy"
 fi
+# shellcheck disable=2154
 if [[ -n "$https_proxy" ]]; then
   info "Exported: https_proxy=$https_proxy"
 fi

--- a/support/linux/install_dev_9_linux.sh
+++ b/support/linux/install_dev_9_linux.sh
@@ -4,7 +4,7 @@ set -eux
 # Install Rust and musl libc target
 curl -sSf https://sh.rustup.rs \
   | env -u CARGO_HOME sh -s -- -y --default-toolchain stable
-. $HOME/.cargo/env
+. "$HOME/.cargo/env"
 env -u CARGO_HOME rustup target add x86_64-unknown-linux-musl
 env -u CARGO_HOME cargo install --force protobuf
 env -u CARGO_HOME cargo install diesel_cli --no-default-features --features postgres

--- a/support/mac/install_dev_9_mac.sh
+++ b/support/mac/install_dev_9_mac.sh
@@ -3,7 +3,7 @@ set -eux
 
 # Install Rust
 curl -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
-. $HOME/.cargo/env
+. "$HOME"/.cargo/env
 # cargo install protobuf
 rustc --version
 cargo --version

--- a/test/end-to-end/test_tar_export
+++ b/test/end-to-end/test_tar_export
@@ -32,13 +32,13 @@ else
 fi
 
 # Remove tarball if already present
-[ -e *.tar.gz ] && rm *.tar.gz
+rm -f ./*.tar.gz
 
 /src/target/debug/hab pkg export tar "$pkg_ident" 
 
 # Check if tarball is present
 
-if [ -f *tar.gz ] ; then
+if [ "$(find . -maxdepth 1 -type f -name "*.tar.gz")" ] ; then
     echo "Package was successfully exported to a tarball"
 else
     echo "Package was NOT successfully exported" 

--- a/test/integration/helpers.bash
+++ b/test/integration/helpers.bash
@@ -26,7 +26,7 @@ export HAB_LAUNCH_BINARY="${HAB_BIN_DIR}/hab-launch"
 
 # Ensure required utilities are present
 find_if_exists() {
-    command -v ${1} || { log "Required utility '${1}' cannot be found!  Aborting."; exit 1; }
+    command -v "${1}" || { log "Required utility '${1}' cannot be found!  Aborting."; exit 1; }
 }
 awk=$(find_if_exists awk)
 curl=$(find_if_exists curl)
@@ -37,12 +37,12 @@ jq=$(find_if_exists jq)
 
 assert_spec_exists_for() {
     local service_name=${1}
-    assert_file_exist $(spec_file_for ${service_name})
+    assert_file_exist "$(spec_file_for "${service_name}")"
 }
 
 assert_spec_not_exists_for() {
     local service_name=${1}
-    assert_file_not_exist $(spec_file_for ${service_name})
+    assert_file_not_exist "$(spec_file_for "${service_name}")"
 }
 
 # Given a fully-qualified package identifer, assert that the package has been
@@ -57,11 +57,12 @@ assert_spec_not_exists_for() {
 # assertion. For that, see `assert_package_and_deps_installed` below.
 assert_package_installed() {
     local ident=${1}
-    local cached_hart_file=$(cached_artifact_for "${ident}")
+    local cached_hart_file
+    cached_hart_file=$(cached_artifact_for "${ident}")
 
     assert_file_exist "${cached_hart_file}"
-    assert_file_exist $(cached_signing_key_for "${cached_hart_file}")
-    assert_file_exist $(installation_directory_for "${ident}")
+    assert_file_exist "$(cached_signing_key_for "${cached_hart_file}")"
+    assert_file_exist "$(installation_directory_for "${ident}")"
 }
 
 # Given a fully-qualified package identifer, assert that it and all
@@ -72,9 +73,9 @@ assert_package_and_deps_installed() {
 
     tdeps_file="/hab/pkgs/${ident}/TDEPS"
     if [ -e "${tdeps_file}" ]; then
-        for dep in $(cat "${tdeps_file}"); do
+        while IFS= read -r dep; do
             assert_package_installed "${dep}"
-        done
+        done < "${tdeps_file}"
     fi
 }
 
@@ -88,9 +89,9 @@ assert_service_running() {
     local service_name="${parsed[1]}"
     echo "ASR: ${service_name}" >&2
 
-    assert_file_exist "$(spec_file_for ${service_name})"
-    assert_file_exist "$(service_directory_for ${service_name})"
-    assert_equal $(current_running_version_for "${service_name}") "${ident}"
+    assert_file_exist "$(spec_file_for "${service_name}")"
+    assert_file_exist "$(service_directory_for "${service_name}")"
+    assert_equal "$(current_running_version_for "${service_name}")" "${ident}"
 }
 
 # Extracts a value from the given service's spec file and asserts that
@@ -106,8 +107,9 @@ assert_spec_value() {
     local key=${2}
     local expected=${3}
 
-    local spec=$(spec_file_for ${service})
-    run grep "${key} = " ${spec}
+    local spec
+    spec=$(spec_file_for "${service}")
+    run grep "${key} = " "${spec}"
     assert_success
 
     if [ "${key}" = "binds" ]; then
@@ -123,9 +125,11 @@ assert_spec_value() {
 # the composite.
 assert_composite_spec() {
     local composite_ident=${1} # fully-qualified
-    local composite_name=$(name_from_ident "${composite_ident}")
+    local composite_name
+    composite_name=$(name_from_ident "${composite_ident}")
 
-    local composite_spec=$(composite_spec_file_for "${composite_name}")
+    local composite_spec
+    composite_spec=$(composite_spec_file_for "${composite_name}")
     assert_file_exist "${composite_spec}"
     assert_composite_spec_value "${composite_name}" package_ident "${composite_ident}"
 }
@@ -137,8 +141,9 @@ assert_composite_spec_value() {
     local key=${2}
     local expected=${3}
 
-    local spec=$(composite_spec_file_for ${composite})
-    run grep "${key} = " ${spec}
+    local spec
+    spec=$(composite_spec_file_for "${composite}")
+    run grep "${key} = " "${spec}"
     assert_success
     assert_line "${key} = \"${expected}\""
 }
@@ -153,9 +158,9 @@ assert_composite_and_services_are_installed() {
     local resolved_services_file="/hab/pkgs/${composite_ident}/RESOLVED_SERVICES"
     assert_file_exist "${resolved_services_file}"
 
-    for service in $(cat "${resolved_services_file}"); do
+    while IFS= read -r service; do
         assert_package_and_deps_installed "${service}"
-    done
+    done < "${resolved_services_file}"
 }
 
 # Useful Setup / Teardown Functions
@@ -233,7 +238,7 @@ run_only_test() {
 # Stop a test with the given message output to standard error for
 # debugging.
 fail_with_msg() {
-    echo ${1} >&2
+    echo "${1}" >&2
     exit 1
 }
 
@@ -248,13 +253,15 @@ retry() {
 
     for ((i=0; i < attempts; i++)); do
         run "$@"
+        # shellcheck disable=2154
         if [[ "$status" -eq 0 ]] ; then
             return 0
         fi
-        sleep $delay
+        sleep "$delay"
     done
 
-    echo "Command \"$@\" failed $attempts times. Output: $output"
+    # shellcheck disable=2154
+    echo "Command \"$*\" failed $attempts times. Output: $output"
     false
 }
 
@@ -289,15 +296,13 @@ pid_of_service() {
 
 service_is_alive() {
     local service_name="${1}"
-    local pid=$(pid_of_service "${service_name}")
+    local pid
+    pid=$(pid_of_service "${service_name}")
     ps -p "${pid}" > /dev/null 2>&1
 }
 
 service_is_not_alive() {
-    local service_name="${1}"
-    local pid=$(pid_of_service "${service_name}")
-    ps -p "${pid}" > /dev/null 2>&1
-    [ $? -ne 0 ]
+    ! service_is_alive "$@"
 }
 
 # Checks once a second to see if the Habitat-supervised service
@@ -317,7 +322,8 @@ wait_for_service_to_die() {
 pid_has_changed() {
     local service_name="${1}"
     local original_pid="${2}"
-    local current_pid=$(pid_of_service "${service_name}")
+    local current_pid
+    current_pid=$(pid_of_service "${service_name}")
     [ "${current_pid}" -ne "${original_pid}" ]
 }
 
@@ -331,7 +337,7 @@ current_running_version_for() {
     service_name=${1}
     member_id=$(cat /hab/sup/default/MEMBER_ID)
 
-    ${jq} -r '.census_groups."redis.default".population."'${member_id}'".pkg | (.origin + "/" +.name + "/" + .version + "/" + .release)' /hab/sup/default/data/census.dat
+    ${jq} -r '.census_groups."redis.default".population."'"${member_id}"'".pkg | (.origin + "/" +.name + "/" + .version + "/" + .release)' /hab/sup/default/data/census.dat
 }
 
 # Given a package identifier and a channel name, query Builder to discover the
@@ -391,7 +397,7 @@ latest_from_builder() {
         *)
             fail_with_msg "Invalid package identifier given: '${ident}'"
     esac
-    echo ${url} >&2
+    echo "${url}" >&2
 
     # TODO (CM): If there is no version in the specified channel, this is
     # going to return nothing... should we fail?
@@ -405,7 +411,7 @@ latest_from_builder() {
 signing_key_name() {
     local hart_archive=${1}
     # The key name is the second line of the file
-    ${awk} 'NR==2' ${hart_archive}
+    ${awk} 'NR==2' "${hart_archive}"
 }
 
 # Given a fully-qualified package identifier, return the path to the
@@ -431,7 +437,8 @@ cached_artifact_for() {
 # Return the path to the cached signing key for a given hart file
 cached_signing_key_for() {
     local hart_file=${1}
-    local key_name=$(signing_key_name "${hart_file}")
+    local key_name
+    key_name=$(signing_key_name "${hart_file}")
 
     echo "/hab/cache/keys/${key_name}.pub"
 }
@@ -449,13 +456,13 @@ installation_directory_for() {
 download_hart_for() {
     ident=${1}
 
-    run ${hab} pkg install "${ident}"
+    run "${hab}" pkg install "${ident}"
     assert_success
 
     cached_artifact=$(cached_artifact_for "${ident}")
     file_name=$(basename "${cached_artifact}")
 
-    cp ${cached_artifact} "${BATS_TMPDIR}"
+    cp "${cached_artifact}" "${BATS_TMPDIR}"
     echo "${BATS_TMPDIR}/${file_name}"
 }
 

--- a/test/shellcheck.sh
+++ b/test/shellcheck.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -euo pipefail
+
+shellcheck --version
+
+# Run shellcheck against any files that appear to be shell script based on
+# filename or `file` output
+#
+# Exclude the handlebars template files since their syntax confuses shellcheck
+# There's not much bash in them anyway.
+#
+# Exclude *.sample files because they are automatically created by git
+#
+# Exclude *.ps1 files because shellcheck doesn't support them
+#
+# Exclude the bats submodules since we don't own that code.
+#
+# Exclude the following shellcheck issues since they're pervasive and innocuous:
+# https://github.com/koalaman/shellcheck/wiki/SC1090
+# https://github.com/koalaman/shellcheck/wiki/SC1091
+# https://github.com/koalaman/shellcheck/wiki/SC1117
+# https://github.com/koalaman/shellcheck/wiki/SC2148
+# https://github.com/koalaman/shellcheck/wiki/SC2034
+find . -type f \
+  -and \( -name "*.*sh" \
+      -or -exec sh -c 'file -b "$1" | grep -q "shell script"' {} \; \) \
+  -and \! -path "*_template_plan.sh" \
+  -and \! -path "*.sample" \
+  -and \! -path "*.ps1" \
+  -and \! -path "./test/integration/helpers.bash" \
+  -and \! -path "./test/integration/test_helper/bats-assert/*" \
+  -and \! -path "./test/integration/test_helper/bats-file/*" \
+  -and \! -path "./test/integration/test_helper/bats-support/*" \
+  -print \
+  | xargs shellcheck --external-sources --exclude=1090,1091,1117,2148,2034
+
+# This is a BATS file, so we need to override the interpreter
+# See: https://github.com/koalaman/shellcheck/issues/709
+shellcheck --shell=bash --exclude=1008 test/integration/helpers.bash
+
+echo "shellcheck found no errors"

--- a/tools/bulk_promote/promote.sh
+++ b/tools/bulk_promote/promote.sh
@@ -21,7 +21,7 @@ select yn in "Yes" "No"; do
     esac
 done
 
-list=$(cat $1)
+list=$(cat "$1")
 for ident in $list; do
-  hab pkg promote $ident $2
+  hab pkg promote "$ident" "$2"
 done

--- a/tools/hab-channel-list-pkgs/hab-channel-list-pkgs.sh
+++ b/tools/hab-channel-list-pkgs/hab-channel-list-pkgs.sh
@@ -12,18 +12,18 @@ main() {
   need_cmd jq
 
   # Set the default Builder URL
-  : ${HAB_BLDR_URL:=https://bldr.habitat.sh}
+  : "${HAB_BLDR_URL:=https://bldr.habitat.sh}"
   # Origin name is required
   origin="${1:-}"
   if [[ -z "$origin" ]]; then
-    echo "Usage: $(basename $0) <ORIGIN> <CHANNEL>" >&2
+    echo "Usage: $(basename "$0") <ORIGIN> <CHANNEL>" >&2
     exit 1
   fi
   shift
   # Channel name is required
   channel="${1:-}"
   if [[ -z "$channel" ]]; then
-    echo "Usage: $(basename $0) <ORIGIN> <CHANNEL>" >&2
+    echo "Usage: $(basename "$0") <ORIGIN> <CHANNEL>" >&2
     exit 1
   fi
   # Calculate the channel URL from which to fetch
@@ -43,8 +43,8 @@ main() {
 
   # Fetch each page and output a fully qualified package identifier, one per
   # line
-  for (( n=0; n<$num_pages; n+=1 )) do
-    curl -s "${url}?range=$(( ${n}*${npp} ))" \
+  for (( n=0; n<num_pages; n+=1 )) do
+    curl -s "${url}?range=$(( n * npp ))" \
       | jq --raw-output '.data[] | "\(.origin)/\(.name)/\(.version)/\(.release)"'
   done
 }


### PR DESCRIPTION
Reverts habitat-sh/habitat#5211

This is really fun.

Now that we're confident that the changes introduced in https://github.com/habitat-sh/habitat/pull/4974 were not part of the outage today, let's put them back by reverting the revert.

Signed-off-by: Josh Black <raskchanky@gmail.com>