### PR TITLE
Add force option to hab bldr job cancel

### DIFF
--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -121,6 +121,8 @@ pub fn get() -> App<'static, 'static> {
                         "Specify an alternate Builder endpoint. If not specified, the value will \
                          be taken from the HAB_BLDR_URL environment variable if defined. (default: \
                          https://bldr.habitat.sh)")
+                    (@arg FORCE: -f --force
+                     "Don't prompt for confirmation")
                     (@arg AUTH_TOKEN: -z --auth +takes_value "Authentication token for Builder")
                 )
                 (@subcommand promote =>

--- a/components/hab/src/command/bldr/job/cancel.rs
+++ b/components/hab/src/command/bldr/job/cancel.rs
@@ -18,15 +18,17 @@ use common::ui::{Status, UIReader, UIWriter, UI};
 use error::{Error, Result};
 use {PRODUCT, VERSION};
 
-pub fn start(ui: &mut UI, bldr_url: &str, group_id: &str, token: &str) -> Result<()> {
-    // TODO (SA): Show all the in-progress builds that will get canceled
-    let question =
-        "If you choose to cancel a group build, \
-         all of the builds that are in progress will be canceled. Is this what you want?";
+pub fn start(ui: &mut UI, bldr_url: &str, group_id: &str, token: &str, force: bool) -> Result<()> {
+    if !force {
+        // TODO (SA): Show all the in-progress builds that will get canceled
+        let question =
+            "If you choose to cancel a group build, \
+             all of the builds that are in progress will be canceled. Is this what you want?";
 
-    if !ui.prompt_yes_no(question, Some(true))? {
-        ui.fatal("Aborted")?;
-        return Ok(());
+        if !ui.prompt_yes_no(question, Some(true))? {
+            ui.fatal("Aborted")?;
+            return Ok(());
+        }
     }
 
     let api_client =

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -517,7 +517,8 @@ fn sub_bldr_job_cancel(ui: &mut UI, m: &ArgMatches) -> Result<()> {
     let url = bldr_url_from_matches(m);
     let group_id = m.value_of("GROUP_ID").unwrap(); // Required via clap
     let token = auth_token_param_or_env(&m)?;
-    command::bldr::job::cancel::start(ui, &url, &group_id, &token)
+    let force = m.is_present("FORCE");
+    command::bldr::job::cancel::start(ui, &url, &group_id, &token, force)
 }
 
 fn sub_bldr_job_promote_or_demote(ui: &mut UI, m: &ArgMatches, promote: bool) -> Result<()> {


### PR DESCRIPTION
This adds a force option to 'hab bldr job cancel' command, that will let us more easily script cancels (for example, if we are in a situation where we need to do bulk cancels).

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-114597218](https://user-images.githubusercontent.com/13542112/41629868-c6f51612-73e0-11e8-98aa-6a3d7997f9eb.gif)
