### PR TITLE
remove svc PID files on hab sup term

### DIFF
--- a/components/sup/src/lib.rs
+++ b/components/sup/src/lib.rs
@@ -142,7 +142,7 @@ pub const PRODUCT: &'static str = "hab-sup";
 pub const VERSION: &'static str = include_str!(concat!(env!("OUT_DIR"), "/VERSION"));
 
 #[derive(Copy, Clone)]
-pub enum ReasonCode {
+pub enum ShutdownReason {
     Departed,
     LauncherStopping,
     PkgUpdating,

--- a/components/sup/src/lib.rs
+++ b/components/sup/src/lib.rs
@@ -140,3 +140,11 @@ features! {
 
 pub const PRODUCT: &'static str = "hab-sup";
 pub const VERSION: &'static str = include_str!(concat!(env!("OUT_DIR"), "/VERSION"));
+
+#[derive(Copy, Clone)]
+pub enum ReasonCode {
+    Departed,
+    LauncherStopping,
+    PkgUpdating,
+    SvcStopCmd,
+}

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -80,6 +80,7 @@ use ctl_gateway::{self, CtlRequest};
 use error::{Error, Result, SupError};
 use http_gateway;
 use util;
+use ReasonCode;
 use VERSION;
 
 const MEMBER_ID_FILE: &'static str = "MEMBER_ID";
@@ -689,11 +690,11 @@ impl Manager {
         loop {
             let next_check = time::get_time() + TimeDuration::milliseconds(1000);
             if self.launcher.is_stopping() {
-                self.shutdown();
+                self.shutdown(ReasonCode::LauncherStopping);
                 return Ok(());
             }
             if self.check_for_departure() {
-                self.shutdown();
+                self.shutdown(ReasonCode::Departed);
                 return Err(sup_error!(Error::Departed));
             }
             if let Some(package) = self.check_for_updated_supervisor() {
@@ -701,7 +702,7 @@ impl Manager {
                     "Supervisor shutting down for automatic update to {}",
                     package
                 );
-                self.shutdown();
+                self.shutdown(ReasonCode::PkgUpdating);
                 return Ok(());
             }
             self.update_running_services_from_spec_watcher()?;
@@ -1488,10 +1489,14 @@ impl Manager {
     /// service. Passing a value of `false` will let the Launcher keep the service running. This
     /// useful if you want the Supervisor to shutdown temporarily and then come back and re-attach
     /// to all running processes.
-    fn remove_service(&mut self, service: &mut Service, term: bool) {
+    fn remove_service(&mut self, service: &mut Service, cause: ReasonCode) {
         // JW TODO: Update service rumor to remove service from cluster
+        let term = match cause {
+            ReasonCode::LauncherStopping | ReasonCode::SvcStopCmd => true,
+            _ => false,
+        };
         if term {
-            service.stop(&self.launcher);
+            service.stop(&self.launcher, cause);
         }
         if let Err(err) = fs::remove_file(self.fs_cfg.health_check_cache(&service.service_group)) {
             outputln!(
@@ -1529,7 +1534,7 @@ impl Manager {
         self.butterfly.restart_elections();
     }
 
-    fn shutdown(&mut self) {
+    fn shutdown(&mut self, cause: ReasonCode) {
         outputln!("Gracefully departing from butterfly network.");
         self.butterfly.set_departed();
 
@@ -1549,7 +1554,7 @@ impl Manager {
         }
 
         for mut service in svcs.drain(..) {
-            self.remove_service(&mut service, false);
+            self.remove_service(&mut service, cause);
         }
         release_process_lock(&self.fs_cfg);
     }
@@ -1649,7 +1654,7 @@ impl Manager {
             service = services.remove(services_idx);
         }
 
-        self.remove_service(&mut service, true);
+        self.remove_service(&mut service, ReasonCode::SvcStopCmd);
         Ok(())
     }
 }

--- a/components/sup/src/manager/service/mod.rs
+++ b/components/sup/src/manager/service/mod.rs
@@ -51,6 +51,7 @@ use self::hooks::{Hook, HookTable, HOOK_PERMISSIONS};
 pub use self::package::{Env, Pkg};
 pub use self::spec::{BindMap, DesiredState, IntoServiceSpec, ServiceBind, ServiceSpec, Spec};
 use self::supervisor::Supervisor;
+use super::ReasonCode;
 use super::Sys;
 use census::{CensusGroup, CensusRing, ElectionStatus, ServiceFile};
 use error::{Error, Result, SupError};
@@ -261,8 +262,8 @@ impl Service {
         }
     }
 
-    pub fn stop(&mut self, launcher: &LauncherCli) {
-        match self.supervisor.stop(launcher) {
+    pub fn stop(&mut self, launcher: &LauncherCli, cause: ReasonCode) {
+        match self.supervisor.stop(launcher, cause) {
             Ok(_) => self.post_stop(),
             Err(err) => outputln!(preamble self.service_group, "Service stop failed: {}", err),
         }
@@ -611,7 +612,7 @@ impl Service {
                 return;
             }
         }
-        if let Err(err) = self.supervisor.stop(launcher) {
+        if let Err(err) = self.supervisor.stop(launcher, ReasonCode::PkgUpdating) {
             outputln!(preamble self.service_group,
                       "Error stopping process while updating package: {}", err);
         }

--- a/components/sup/src/manager/service/mod.rs
+++ b/components/sup/src/manager/service/mod.rs
@@ -51,7 +51,7 @@ use self::hooks::{Hook, HookTable, HOOK_PERMISSIONS};
 pub use self::package::{Env, Pkg};
 pub use self::spec::{BindMap, DesiredState, IntoServiceSpec, ServiceBind, ServiceSpec, Spec};
 use self::supervisor::Supervisor;
-use super::ReasonCode;
+use super::ShutdownReason;
 use super::Sys;
 use census::{CensusGroup, CensusRing, ElectionStatus, ServiceFile};
 use error::{Error, Result, SupError};
@@ -262,7 +262,7 @@ impl Service {
         }
     }
 
-    pub fn stop(&mut self, launcher: &LauncherCli, cause: ReasonCode) {
+    pub fn stop(&mut self, launcher: &LauncherCli, cause: ShutdownReason) {
         match self.supervisor.stop(launcher, cause) {
             Ok(_) => self.post_stop(),
             Err(err) => outputln!(preamble self.service_group, "Service stop failed: {}", err),
@@ -612,7 +612,7 @@ impl Service {
                 return;
             }
         }
-        if let Err(err) = self.supervisor.stop(launcher, ReasonCode::PkgUpdating) {
+        if let Err(err) = self.supervisor.stop(launcher, ShutdownReason::PkgUpdating) {
             outputln!(preamble self.service_group,
                       "Error stopping process while updating package: {}", err);
         }

--- a/components/sup/src/manager/service/supervisor.rs
+++ b/components/sup/src/manager/service/supervisor.rs
@@ -34,7 +34,7 @@ use serde::{Serialize, Serializer};
 use time::{self, Timespec};
 
 use super::ProcessState;
-use super::ReasonCode;
+use super::ShutdownReason;
 use error::{Error, Result};
 use fs;
 use manager::service::Pkg;
@@ -234,11 +234,11 @@ impl Supervisor {
         (healthy, status)
     }
 
-    pub fn stop(&mut self, launcher: &LauncherCli, cause: ReasonCode) -> Result<()> {
+    pub fn stop(&mut self, launcher: &LauncherCli, cause: ShutdownReason) -> Result<()> {
         if self.pid.is_none() {
             return Ok(());
         }
-        if let ReasonCode::LauncherStopping = cause {
+        if let ShutdownReason::LauncherStopping = cause {
             // sending any cmds to launcher will block while it is shutting down
             // we'll avoid this knowing that launcher will gratuitously kill off
             // all services as part of its shutdown routine

--- a/components/sup/src/manager/service/supervisor.rs
+++ b/components/sup/src/manager/service/supervisor.rs
@@ -34,6 +34,7 @@ use serde::{Serialize, Serializer};
 use time::{self, Timespec};
 
 use super::ProcessState;
+use super::ReasonCode;
 use error::{Error, Result};
 use fs;
 use manager::service::Pkg;
@@ -233,11 +234,17 @@ impl Supervisor {
         (healthy, status)
     }
 
-    pub fn stop(&mut self, launcher: &LauncherCli) -> Result<()> {
+    pub fn stop(&mut self, launcher: &LauncherCli, cause: ReasonCode) -> Result<()> {
         if self.pid.is_none() {
             return Ok(());
         }
-        launcher.terminate(self.pid.unwrap())?;
+        if let ReasonCode::LauncherStopping = cause {
+            // sending any cmds to launcher will block while it is shutting down
+            // we'll avoid this knowing that launcher will gratuitously kill off
+            // all services as part of its shutdown routine
+        } else {
+            launcher.terminate(self.pid.unwrap())?;
+        }
         self.cleanup_pidfile();
         self.change_state(ProcessState::Down);
         Ok(())


### PR DESCRIPTION
## Summary 🔩 

This is a minimalist change to launcher's `ServiceTable` `kill_all` function impl that is called as a result of `hab sup term`. 

It addresses #5045 by removing the `PID` file for each service, after each has already been shut down gracefully.

While working on this, I decided not to utilize sup's [fs.rs](https://github.com/habitat-sh/habitat/blob/master/components/sup/src/fs.rs) `svc_pid_file` function as this would introduce a new dependency on sup.  It might be a good idea in the future to move `fs.rs` into habitat core so that all components can utilize these without introducing unwanted deps?

## Running it 👟 

```
✔ /home/habitat [jeremymv2/term_remove_svc_pids L|✚ 3…1⚑ 3]
16:32 $ sudo -E ./target/debug/hab --version
hab 0.58.0-dev

✔ /home/habitat [jeremymv2/term_remove_svc_pids L|✚ 3…1⚑ 3]
16:32 $ sudo -E ./target/debug/hab svc status
package                                           type        state  elapsed (s)  pid    group
chef/automate-elasticsearch/6.2.2/20180527141927  standalone  up     37           11224  automate-elasticsearch.foobar
core/redis/3.2.4/20170514150022  standalone  up  36  11260  redis.default

✔ /home/habitat [jeremymv2/term_remove_svc_pids L|✚ 3…1⚑ 3]
16:32 $ ls -l /hab/svc/*/PID
-rw-r--r-- 1 root root 5 Jun 21 16:32 /hab/svc/automate-elasticsearch/PID
-rw-r--r-- 1 root root 5 Jun 21 16:32 /hab/svc/redis/PID

✔ /home/habitat [jeremymv2/term_remove_svc_pids L|✚ 3…1⚑ 3]
16:32 $ sudo -E ./target/debug/hab sup term

✔ /home/habitat [jeremymv2/term_remove_svc_pids L|✚ 3…1⚑ 3]
16:33 $ hab-sup(MR): Gracefully departing from butterfly network.
redis.default(SV): Stopping...
redis.default(O): 11260:signal-handler (1529598808) Received SIGTERM scheduling shutdown...
redis.default(O): 11260:M 21 Jun 16:33:28.548 # User requested shutdown...
redis.default(O): 11260:M 21 Jun 16:33:28.548 * Saving the final RDB snapshot before exiting.
redis.default(O): 11260:M 21 Jun 16:33:28.550 * DB saved on disk
redis.default(O): 11260:M 21 Jun 16:33:28.550 * Removing the pid file.
redis.default(O): 11260:M 21 Jun 16:33:28.551 # Redis is now ready to exit, bye bye...
redis.default(SV): Shutdown OK: Graceful Termination
redis.default(SV): Removing PID file: /hab/svc/redis/PID
automate-elasticsearch.foobar(SV): Stopping...
automate-elasticsearch.foobar(O): [2018-06-21T16:33:28,553][INFO ][o.e.n.Node               ] [TpMCZqs] stopping ...
automate-elasticsearch.foobar(O): [2018-06-21T16:33:28,580][INFO ][o.e.n.Node               ] [TpMCZqs] stopped
automate-elasticsearch.foobar(O): [2018-06-21T16:33:28,580][INFO ][o.e.n.Node               ] [TpMCZqs] closing ...
automate-elasticsearch.foobar(O): [2018-06-21T16:33:28,589][INFO ][o.e.n.Node               ] [TpMCZqs] closed
automate-elasticsearch.foobar(SV): Shutdown OK: Graceful Termination
automate-elasticsearch.foobar(SV): Removing PID file: /hab/svc/automate-elasticsearch/PID
hab-launch(SV): Hasta la vista, services.

[1]+  Done                    sudo -E ./target/debug/hab sup run

✔ /home/habitat [jeremymv2/term_remove_svc_pids L|✚ 3…1⚑ 3]
16:33 $ ls -l /hab/svc/*/PID
ls: cannot access '/hab/svc/*/PID': No such file or directory
✘-2 /home/habitat [jeremymv2/term_remove_svc_pids L|✚ 3…1⚑ 3]
16:33 $
```

Signed-off-by: Jeremy J. Miller <jm@chef.io>