### PR TITLE
Fix an erroneous shellcheck fix

### DIFF
--- a/components/studio/build-docker-image.sh
+++ b/components/studio/build-docker-image.sh
@@ -68,8 +68,9 @@ export FS_ROOT="$tmp_root/rootfs"
 unset HAB_BINLINK_DIR
 
 info "Installing and extracting initial Habitat packages"
-default_pkgs="core/hab core/hab-studio"
-hab pkg install "${*:-$default_pkgs}"
+default_pkgs=(core/hab core/hab-studio)
+hab pkg install "${@:-${default_pkgs[@]}}"
+
 if ! hab pkg path core/hab >/dev/null 2>&1; then
   >&2 echo "   $(basename "$0"): WARN core/hab must be installed, aborting"
   exit 1


### PR DESCRIPTION
Quoting the string made `hab`try to install a single package named
`"core/hab core/hab-studio"`, which subsequently fails.
    
The proper fix here is to use an array variable to store the package
identifiers. We also use `$@` instead of `$*` to make the
corresponding change for any arguments passed in.

Signed-off-by: Christopher Maier <cmaier@chef.io>