### PR TITLE
Pin everything to use pre-refresh core plans

### DIFF
--- a/components/backline/plan.sh
+++ b/components/backline/plan.sh
@@ -6,16 +6,14 @@ pkg_license=('Apache-2.0')
 pkg_source=nosuchfile.tar.gz
 pkg_build_deps=()
 
-pkg_deps=(
-  core/hab-plan-build
-  core/diffutils
-  core/less
-  core/make
-  core/mg
-  core/util-linux
-  core/vim
-  core/ncurses
-)
+pkg_deps=(core/hab-plan-build
+          core/diffutils/3.3/20170513214227
+          core/less/481/20170513213936
+          core/make/4.2.1/20170513214620
+          core/mg/20160118/20170513220846
+          core/util-linux/2.27.1/20170513214732
+          core/vim/8.0.0004/20170513220742
+          core/ncurses/6.0/20170513213009)
 
 do_download() {
   return 0

--- a/components/bintray-publish/plan.sh
+++ b/components/bintray-publish/plan.sh
@@ -4,8 +4,19 @@ pkg_origin=core
 pkg_version=$(cat "$PLAN_CONTEXT/../../VERSION")
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('apachev2')
-pkg_deps=(core/coreutils core/util-linux core/bash core/zip core/tar core/xz core/gzip core/jfrog-cli
-          core/grep core/findutils core/gawk core/hab core/docker)
+pkg_deps=(core/coreutils/8.25/20170513213226
+          core/util-linux/2.27.1/20170513214732
+          core/bash/4.3.42/20170513213519
+          core/zip/3.0/20170514214344
+          core/tar/1.29/20170513213607
+          core/xz/5.2.2/20170513214327
+          core/gzip/1.6/20170513214605
+          core/jfrog-cli/1.7.1/20171014213633
+          core/grep/2.22/20170513213444
+          core/findutils/4.4.2/20170513214305
+          core/gawk/4.1.3/20170513213646
+          core/hab
+          core/docker/18.03.0/20180403182455)
 pkg_bin_dirs=(bin)
 programs=(publish-hab publish-studio)
 

--- a/components/eventsrv/habitat/plan.sh
+++ b/components/eventsrv/habitat/plan.sh
@@ -5,8 +5,15 @@ pkg_origin=core
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_bin_dirs=(bin)
-pkg_deps=(core/glibc core/gcc-libs core/zeromq core/libsodium core/libarchive)
-pkg_build_deps=(core/rust core/gcc core/pkg-config core/git)
+pkg_deps=(core/glibc/2.22/20170513201042
+          core/gcc-libs/5.2.0/20170513212920
+          core/zeromq/4.2.5/20180407102804
+          core/libsodium/1.0.13/20170905223149
+          core/libarchive/3.3.2/20171018164107)
+pkg_build_deps=(core/rust/1.26.2/20180606182054
+                core/gcc/5.2.0/20170513202244
+                core/pkg-config/0.29/20170513212944
+                core/git/2.14.2/20180416203520)
 pkg_exports=(
   [consumer_port]=consumer_port
   [producer_port]=producer_port

--- a/components/hab/plan.sh
+++ b/components/hab/plan.sh
@@ -8,11 +8,16 @@ pkg_license=('Apache-2.0')
 pkg_source=nosuchfile.tar.gz
 # The result is a portable, static binary in a zero-dependency package.
 pkg_deps=()
-pkg_build_deps=(
-  core/musl core/zlib-musl core/xz-musl core/bzip2-musl core/libarchive-musl
-  core/openssl-musl core/libsodium-musl
-  core/coreutils core/rust core/gcc
-)
+pkg_build_deps=(core/musl/1.1.18/20180310000919
+                core/zlib-musl/1.2.8/20180310002650
+                core/xz-musl/5.2.2/20180310002650
+                core/bzip2-musl/1.0.6/20180310002649
+                core/libarchive-musl/3.3.2/20180310020328
+                core/openssl-musl/1.0.2l/20180310010254
+                core/libsodium-musl/1.0.13/20180310002622
+                core/coreutils/8.25/20170513213226
+                core/rust/1.26.2/20180606182054
+                core/gcc/5.2.0/20170513202244)
 pkg_bin_dirs=(bin)
 
 bin=$_pkg_distname
@@ -27,7 +32,7 @@ _common_prepare() {
   # Used by the `build.rs` program to set the version of the binaries
   export PLAN_VERSION="${pkg_version}/${pkg_release}"
   build_line "Setting PLAN_VERSION=$PLAN_VERSION"
-  
+
   if [ -z "$HAB_CARGO_TARGET_DIR" ]; then
     # Used by Cargo to use a pristine, isolated directory for all compilation
     export CARGO_TARGET_DIR="$HAB_CACHE_SRC_PATH/$pkg_dirname"

--- a/components/launcher/habitat/plan.sh
+++ b/components/launcher/habitat/plan.sh
@@ -3,8 +3,15 @@ pkg_name=hab-launcher
 pkg_origin=core
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
-pkg_deps=(core/glibc core/gcc-libs core/libarchive core/libsodium core/openssl)
-pkg_build_deps=(core/coreutils core/rust core/gcc core/git)
+pkg_deps=(core/glibc/2.22/20170513201042
+          core/gcc-libs/5.2.0/20170513212920
+          core/libarchive/3.3.2/20171018164107
+          core/libsodium/1.0.13/20170905223149
+          core/openssl/1.0.2l/20171014213633)
+pkg_build_deps=(core/coreutils/8.25/20170513213226
+                core/rust/1.26.2/20180606182054
+                core/gcc/5.2.0/20170513202244
+                core/git/2.14.2/20180416203520)
 pkg_bin_dirs=(bin)
 bin="hab-launch"
 

--- a/components/pkg-aci/plan.sh
+++ b/components/pkg-aci/plan.sh
@@ -5,7 +5,13 @@ pkg_version=$(cat "$PLAN_CONTEXT/../../VERSION")
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("Apache-2.0")
 pkg_source=nosuchfile.tar.gz
-pkg_deps=(core/coreutils core/findutils core/gawk core/grep core/bash core/acbuild core/hab-studio)
+pkg_deps=(core/coreutils/8.25/20170513213226
+          core/findutils/4.4.2/20170513214305
+          core/gawk/4.1.3/20170513213646
+          core/grep/2.22/20170513213444
+          core/bash/4.3.42/20170513213519
+          core/acbuild/0.4.0/20171109161533
+          core/hab-studio)
 pkg_build_deps=()
 pkg_bin_dirs=(bin)
 

--- a/components/pkg-cfize/plan.sh
+++ b/components/pkg-cfize/plan.sh
@@ -5,10 +5,12 @@ pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_description="Habitat Cloud Foundry image exporter"
 pkg_upstream_url="https://github.com/habitat-sh/habitat"
-pkg_deps=(
-  core/coreutils core/findutils core/grep core/gawk
-  core/hab-pkg-export-docker core/docker
-)
+pkg_deps=(core/coreutils/8.25/20170513213226
+          core/findutils/4.4.2/20170513214305
+          core/grep/2.22/20170513213444
+          core/gawk/4.1.3/20170513213646
+          core/hab-pkg-export-docker
+          core/docker/18.03.0/20180403182455)
 pkg_bin_dirs=(bin)
 
 _bins=($pkg_name)

--- a/components/pkg-export-docker/plan.sh
+++ b/components/pkg-export-docker/plan.sh
@@ -7,12 +7,18 @@ pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 # The result is a portable, static binary. However, we shell out to the
 # Docker command which we need at runtime.
-pkg_deps=(core/docker)
-pkg_build_deps=(
-  core/musl core/zlib-musl core/xz-musl core/bzip2-musl core/libarchive-musl
-  core/openssl-musl core/libsodium-musl
-  core/coreutils core/rust core/gcc core/make
-)
+pkg_deps=(core/docker/18.03.0/20180403182455)
+pkg_build_deps=(core/musl/1.1.18/20180310000919
+                core/zlib-musl/1.2.8/20180310002650
+                core/xz-musl/5.2.2/20180310002650
+                core/bzip2-musl/1.0.6/20180310002649
+                core/libarchive-musl/3.3.2/20180310020328
+                core/openssl-musl/1.0.2l/20180310010254
+                core/libsodium-musl/1.0.13/20180310002622
+                core/coreutils/8.25/20170513213226
+                core/rust/1.26.2/20180606182054
+                core/gcc/5.2.0/20170513202244
+                core/make/4.2.1/20170513214620)
 pkg_bin_dirs=(bin)
 
 bin=$_pkg_distname

--- a/components/pkg-export-helm/plan.sh
+++ b/components/pkg-export-helm/plan.sh
@@ -5,12 +5,19 @@ pkg_origin=core
 pkg_version=$(cat "$PLAN_CONTEXT/../../VERSION")
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
-pkg_deps=(core/docker core/helm)
-pkg_build_deps=(
-  core/musl core/zlib-musl core/xz-musl core/bzip2-musl core/libarchive-musl
-  core/openssl-musl core/libsodium-musl
-  core/coreutils core/rust core/gcc core/make
-)
+pkg_deps=(core/docker/18.03.0/20180403182455
+          core/helm/2.7.2/20180310001821)
+pkg_build_deps=(core/musl/1.1.18/20180310000919
+                core/zlib-musl/1.2.8/20180310002650
+                core/xz-musl/5.2.2/20180310002650
+                core/bzip2-musl/1.0.6/20180310002649
+                core/libarchive-musl/3.3.2/20180310020328
+                core/openssl-musl/1.0.2l/20180310010254
+                core/libsodium-musl/1.0.13/20180310002622
+                core/coreutils/8.25/20170513213226
+                core/rust/1.26.2/20180606182054
+                core/gcc/5.2.0/20170513202244
+                core/make/4.2.1/20170513214620)
 pkg_bin_dirs=(bin)
 
 bin=$_pkg_distname

--- a/components/pkg-export-kubernetes/plan.sh
+++ b/components/pkg-export-kubernetes/plan.sh
@@ -5,12 +5,18 @@ pkg_origin=core
 pkg_version=$(cat "$PLAN_CONTEXT/../../VERSION")
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
-pkg_deps=(core/docker)
-pkg_build_deps=(
-  core/musl core/zlib-musl core/xz-musl core/bzip2-musl core/libarchive-musl
-  core/openssl-musl core/libsodium-musl
-  core/coreutils core/rust core/gcc core/make
-)
+pkg_deps=(core/docker/18.03.0/20180403182455)
+pkg_build_deps=(core/musl/1.1.18/20180310000919
+                core/zlib-musl/1.2.8/20180310002650
+                core/xz-musl/5.2.2/20180310002650
+                core/bzip2-musl/1.0.6/20180310002649
+                core/libarchive-musl/3.3.2/20180310020328
+                core/openssl-musl/1.0.2l/20180310010254
+                core/libsodium-musl/1.0.13/20180310002622
+                core/coreutils/8.25/20170513213226
+                core/rust/1.26.2/20180606182054
+                core/gcc/5.2.0/20170513202244
+                core/make/4.2.1/20170513214620)
 pkg_bin_dirs=(bin)
 
 bin=$_pkg_distname

--- a/components/pkg-export-tar/plan.sh
+++ b/components/pkg-export-tar/plan.sh
@@ -5,13 +5,25 @@ pkg_origin=core
 pkg_version=$(cat "$PLAN_CONTEXT/../../VERSION")
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
-pkg_deps=(core/coreutils core/findutils core/gawk core/grep core/bash core/tar core/gzip core/hab)
-pkg_build_deps=(
-  core/musl core/zlib-musl core/xz-musl core/bzip2-musl core/libarchive-musl
-  core/openssl-musl core/libsodium-musl
-  core/coreutils core/rust core/gcc core/make
-)
-
+pkg_deps=(core/coreutils/8.25/20170513213226
+          core/findutils/4.4.2/20170513214305
+          core/gawk/4.1.3/20170513213646
+          core/grep/2.22/20170513213444
+          core/bash/4.3.42/20170513213519
+          core/tar/1.29/20170513213607
+          core/gzip/1.6/20170513214605
+          core/hab)
+pkg_build_deps=(core/musl/1.1.18/20180310000919
+                core/zlib-musl/1.2.8/20180310002650
+                core/xz-musl/5.2.2/20180310002650
+                core/bzip2-musl/1.0.6/20180310002649
+                core/libarchive-musl/3.3.2/20180310020328
+                core/openssl-musl/1.0.2l/20180310010254
+                core/libsodium-musl/1.0.13/20180310002622
+                core/coreutils/8.25/20170513213226
+                core/rust/1.26.2/20180606182054
+                core/gcc/5.2.0/20170513202244
+                core/make/4.2.1/20170513214620)
 pkg_bin_dirs=(bin)
 
 bin=$_pkg_distname

--- a/components/pkg-mesosize/plan.sh
+++ b/components/pkg-mesosize/plan.sh
@@ -5,7 +5,14 @@ pkg_version=$(cat "$PLAN_CONTEXT/../../VERSION")
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_source=nosuchfile.tar.gz
-pkg_deps=(core/coreutils core/findutils core/gawk core/grep core/bash core/tar core/gzip core/hab)
+pkg_deps=(core/coreutils/8.25/20170513213226
+          core/findutils/4.4.2/20170513214305
+          core/gawk/4.1.3/20170513213646
+          core/grep/2.22/20170513213444
+          core/bash/4.3.42/20170513213519
+          core/tar/1.29/20170513213607
+          core/gzip/1.6/20170513214605
+          core/hab)
 pkg_build_deps=()
 pkg_bin_dirs=(bin)
 

--- a/components/plan-build/plan.sh
+++ b/components/plan-build/plan.sh
@@ -6,28 +6,23 @@ pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_bin_dirs=(bin)
 
-pkg_deps=(
-  core/bash
-  core/binutils
-  core/bzip2
-  core/coreutils
-  core/file
-  core/findutils
-  core/gawk
-  core/grep
-  core/gzip
-  core/hab
-  core/rq
-  core/sed
-  core/tar
-  core/unzip
-  core/wget
-  core/xz
-)
-
-pkg_build_deps=(
-  core/bats
-)
+pkg_deps=(core/bash/4.3.42/20170513213519
+          core/binutils/2.25.1/20170513201927
+          core/bzip2/1.0.6/20170513212938
+          core/coreutils/8.25/20170513213226
+          core/file/5.24/20170513201915
+          core/findutils/4.4.2/20170513214305
+          core/gawk/4.1.3/20170513213646
+          core/grep/2.22/20170513213444
+          core/gzip/1.6/20170513214605
+          core/hab
+          core/rq/0.9.2/20170612005822
+          core/sed/4.2.2/20170513213123
+          core/tar/1.29/20170513213607
+          core/unzip/6.0/20180310001951
+          core/wget/1.19.1/20171024102323
+          core/xz/5.2.2/20170513214327)
+pkg_build_deps=(core/bats/0.4.0/20170514013659)
 
 program=$pkg_name
 

--- a/components/studio/plan.sh
+++ b/components/studio/plan.sh
@@ -6,7 +6,12 @@ pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_source=nosuchfile.tar.gz
 pkg_deps=()
-pkg_build_deps=(core/coreutils core/tar core/xz core/wget core/busybox-static core/hab)
+pkg_build_deps=(core/coreutils/8.25/20170513213226
+                core/tar/1.29/20170513213607
+                core/xz/5.2.2/20170513214327
+                core/wget/1.19.1/20171024102323
+                core/busybox-static/1.24.2/20170513215502
+                core/hab)
 pkg_bin_dirs=(bin)
 
 do_build() {

--- a/components/sup/plan.sh
+++ b/components/sup/plan.sh
@@ -5,11 +5,18 @@ pkg_origin=core
 pkg_version=$(cat "$PLAN_CONTEXT/../../VERSION")
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
-pkg_deps=(
-  core/busybox-static
-  core/glibc core/gcc-libs core/libarchive core/libsodium core/openssl core/zeromq
-)
-pkg_build_deps=(core/coreutils core/cacerts core/rust core/gcc core/raml2html)
+pkg_deps=(core/busybox-static/1.24.2/20170513215502
+          core/glibc/2.22/20170513201042
+          core/gcc-libs/5.2.0/20170513212920
+          core/libarchive/3.3.2/20171018164107
+          core/libsodium/1.0.13/20170905223149
+          core/openssl/1.0.2l/20171014213633
+          core/zeromq/4.2.5/20180407102804)
+pkg_build_deps=(core/coreutils/8.25/20170513213226
+                core/cacerts/2017.09.20/20171014212239
+                core/rust/1.26.2/20180606182054
+                core/gcc/5.2.0/20170513202244
+                core/raml2html/6.3.0/20180409195740)
 pkg_bin_dirs=(bin)
 
 bin=$_pkg_distname


### PR DESCRIPTION
The refresh brought in a version of glibc that dropped support for
older 2.6 Linux kernels. That is currently being sorted out, but until
then, this pins all core dependencies to the pre-refresh versions to
ensure that our next release continues to run on older kernels.

While some dependencies could have been pinned at the version level, I
felt it prudent to be a pinning maximalist in this case. As a result,
everything except dependencies on actual Habitat packages is pinned
with a fully-qualified identifier. (If we pinned those, we wouldn't be
able to make a release!)

Signed-off-by: Christopher Maier <cmaier@chef.io>