### PR TITLE
Remove the note about handling non-master merges

### DIFF
--- a/www/source/partials/docs/_using-builder-automated-builds.html.md.erb
+++ b/www/source/partials/docs/_using-builder-automated-builds.html.md.erb
@@ -1,12 +1,10 @@
 ## <a name="automated-builds" id="automated-builds" data-magellan-target="automated-builds">Set up Automated Builds</a>
-By connecting a plan file in <a href="https://bldr.habitat.sh/#/sign-in" class="link-external" target="_blank">Habitat Builder</a>, you can trigger automated package rebuilds any time your repo (containing the plan file) is updated.
+By connecting a plan file in <a href="https://bldr.habitat.sh/#/sign-in" class="link-external" target="_blank">Habitat Builder</a>, you can trigger automated package rebuilds whenever a change is merged into the `master` branch of the repository containing your Habitat plan.
 
-> **Note** Builder will watch for merges to the Master branch by default, but you can override this behanior using a `.bldr.toml` file as seen in the previous section.
-
-### Connect a Plan File
-To connect a Plan, view one of your origins (while signed in), click on the **Connect a plan file** button, and complete the following steps:
+### Connect a Plan
+To connect a plan to Builder, view one of your origins (while signed in), click the **Connect a plan file** button, and complete the following steps:
 
   - Install the Builder GitHub App
-  - Enter the GitHub Repo (that contains your plan.sh file)
-  - Choose your privacy setting
-  - (optional) Publish to container registries
+  - Choose the GitHub organization and repository containing your Habitat plan
+  - Choose a privacy setting for the package
+  - Specify container-registry publishing settings (optional)


### PR DESCRIPTION
This change removes the note suggesting we support triggered builds based on branches other than master, and tweaks a bit of wording for clarity and correctness as of today.

Signed-off-by: Christian Nunciato <chris@nunciato.org>

![](https://i.giphy.com/media/l1IY5J4Cfw8JLi40M/200w.gif)