### PR TITLE
Loosen up pins on Docker exporter.

### DIFF
--- a/components/pkg-export-docker/plan.sh
+++ b/components/pkg-export-docker/plan.sh
@@ -7,18 +7,18 @@ pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 # The result is a portable, static binary. However, we shell out to the
 # Docker command which we need at runtime.
-pkg_deps=(core/docker/18.03.0/20180403182455)
-pkg_build_deps=(core/musl/1.1.18/20180310000919
-                core/zlib-musl/1.2.8/20180310002650
-                core/xz-musl/5.2.2/20180310002650
-                core/bzip2-musl/1.0.6/20180310002649
-                core/libarchive-musl/3.3.2/20180310020328
-                core/openssl-musl/1.0.2l/20180310010254
-                core/libsodium-musl/1.0.13/20180310002622
-                core/coreutils/8.25/20170513213226
-                core/rust/1.26.2/20180606182054
-                core/gcc/5.2.0/20170513202244
-                core/make/4.2.1/20170513214620)
+pkg_deps=(core/docker)
+pkg_build_deps=(core/musl
+                core/zlib-musl
+                core/xz-musl
+                core/bzip2-musl
+                core/libarchive-musl
+                core/openssl-musl
+                core/libsodium-musl
+                core/coreutils
+                core/rust
+                core/gcc
+                core/make)
 pkg_bin_dirs=(bin)
 
 bin=$_pkg_distname


### PR DESCRIPTION
Initially, we locked everything in this repository back to pre-"base
plans refresh" dependencies when it was discovered that the new
`glibc` dropped support for older kernels.

In hindsight, that was more conservative than we needed to be. In
particular, locking down the Docker exporter ended up unnecessarily
breaking our Builder development environment. The exporter is
statically compiled, and in any case, Docker doesn't run on older
kernels anyway.

Additional packages can be relaxed in future PRs, but this will
unblock additional work in Builder right now.

Signed-off-by: Christopher Maier <cmaier@chef.io>