### PR TITLE
Add a feature-flagged `--ignore-local` flag to `hab pkg install`

### DIFF
--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -722,7 +722,7 @@ fn sub_pkg_build() -> App<'static, 'static> {
 }
 
 fn sub_pkg_install() -> App<'static, 'static> {
-    let sub = clap_app!(@subcommand install =>
+    let mut sub = clap_app!(@subcommand install =>
         (about: "Installs a Habitat package from Builder or locally from a Habitat Artifact")
         (@arg BLDR_URL: --url -u +takes_value {valid_url}
             "Specify an alternate Builder endpoint. If not specified, the value will \
@@ -738,14 +738,20 @@ fn sub_pkg_install() -> App<'static, 'static> {
         (@arg AUTH_TOKEN: -z --auth +takes_value "Authentication token for Builder")
     );
     if feat::is_enabled(feat::OfflineInstall) {
-        sub.arg(
+        sub = sub.arg(
             Arg::with_name("OFFLINE")
                 .help("Install packages in offline mode")
                 .long("offline"),
-        )
-    } else {
-        sub
-    }
+        );
+    };
+    if feat::is_enabled(feat::IgnoreLocal) {
+        sub = sub.arg(
+            Arg::with_name("IGNORE_LOCAL")
+                .help("Do not use locally-installed packages when a corresponding package cannot be installed from Builder")
+                .long("ignore-local"),
+        );
+    };
+    sub
 }
 
 fn sub_config_apply() -> App<'static, 'static> {

--- a/components/hab/src/exec.rs
+++ b/components/hab/src/exec.rs
@@ -15,7 +15,7 @@
 use std::path::{Path, PathBuf};
 
 use common;
-use common::command::package::install::InstallMode;
+use common::command::package::install::{InstallMode, LocalPackageUsage};
 use common::ui::{Status, UIWriter, UI};
 use hcore::env as henv;
 use hcore::fs::{self, cache_artifact_path};
@@ -99,6 +99,8 @@ where
                 None,
                 // TODO fn: pass through and enable offline install mode
                 &InstallMode::default(),
+                // TODO (CM): pass through and enable no-local-package mode
+                &LocalPackageUsage::default(),
             )?;
             command_from_min_pkg(ui, &command, &ident, &cache_key_path, retry + 1)
         }

--- a/components/hab/src/lib.rs
+++ b/components/hab/src/lib.rs
@@ -73,6 +73,7 @@ features! {
     pub mod feat {
         const List = 0b00000001,
         const OfflineInstall = 0b00000010,
-        const RootlessStudio = 0b00000100
+        const RootlessStudio = 0b00000100,
+        const IgnoreLocal = 0b00001000
     }
 }

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -48,7 +48,7 @@ use std::str::FromStr;
 use std::thread;
 
 use clap::{ArgMatches, Shell};
-use common::command::package::install::{InstallMode, InstallSource};
+use common::command::package::install::{InstallMode, InstallSource, LocalPackageUsage};
 use common::ui::{Coloring, Status, UIWriter, NONINTERACTIVE_ENVVAR, UI};
 use futures::prelude::*;
 use hcore::binlink::default_binlink_dir;
@@ -594,6 +594,13 @@ fn sub_pkg_install(ui: &mut UI, m: &ArgMatches) -> Result<()> {
         InstallMode::default()
     };
 
+    let local_package_usage = if feat::is_enabled(feat::IgnoreLocal) && m.is_present("IGNORE_LOCAL")
+    {
+        LocalPackageUsage::Ignore
+    } else {
+        LocalPackageUsage::default()
+    };
+
     init();
 
     for install_source in install_sources.iter() {
@@ -608,6 +615,7 @@ fn sub_pkg_install(ui: &mut UI, m: &ArgMatches) -> Result<()> {
             &cache_artifact_path(Some(&*FS_ROOT)),
             token.as_ref().map(String::as_str),
             &install_mode,
+            &local_package_usage,
         )?;
 
         if m.is_present("BINLINK") {
@@ -1286,6 +1294,7 @@ fn enable_features_from_env(ui: &mut UI) {
         (feat::List, "LIST"),
         (feat::OfflineInstall, "OFFLINE_INSTALL"),
         (feat::RootlessStudio, "ROOTLESS_STUDIO"),
+        (feat::IgnoreLocal, "IGNORE_LOCAL"),
     ];
 
     for feature in &features {

--- a/components/pkg-export-docker/src/build.rs
+++ b/components/pkg-export-docker/src/build.rs
@@ -22,7 +22,7 @@ use std::str::FromStr;
 
 use clap;
 use common;
-use common::command::package::install::{InstallMode, InstallSource};
+use common::command::package::install::{InstallMode, InstallSource, LocalPackageUsage};
 use common::ui::{Status, UIWriter, UI};
 use failure::SyncFailure;
 use hab;
@@ -344,6 +344,8 @@ impl<'a> BuildSpec<'a> {
             None,
             // TODO fn: pass through and enable offline install mode
             &InstallMode::default(),
+            // TODO (CM): pass through and enable ignore-local mode
+            &LocalPackageUsage::default(),
         )?;
         Ok(package_install.into())
     }

--- a/components/pkg-export-tar/src/build.rs
+++ b/components/pkg-export-tar/src/build.rs
@@ -14,7 +14,7 @@
 
 use clap;
 use common;
-use common::command::package::install::{InstallMode, InstallSource};
+use common::command::package::install::{InstallMode, InstallSource, LocalPackageUsage};
 use common::ui::{Status, UIWriter, UI};
 use error::Result;
 use hcore::fs::{cache_artifact_path, cache_key_path, CACHE_ARTIFACT_PATH, CACHE_KEY_PATH};
@@ -217,6 +217,8 @@ impl<'a> BuildSpec<'a> {
             None,
             // TODO fn: pass through and enable offline install mode
             &InstallMode::default(),
+            // TODO (CM): pass through and enable ignore-local mode
+            &LocalPackageUsage::default(),
         )?;
         Ok(package_install.into())
     }

--- a/components/plan-build-ps1/bin/hab-plan-build.ps1
+++ b/components/plan-build-ps1/bin/hab-plan-build.ps1
@@ -390,10 +390,14 @@ function _Set-HabBin {
 
 function _install-dependency($dependency) {
   if (!$env:NO_INSTALL_DEPS) {
-    & $HAB_BIN install -u $env:HAB_BLDR_URL --channel $env:HAB_BLDR_CHANNEL $dependency
+    $cmd = "$HAB_BIN install -u $env:HAB_BLDR_URL --channel $env:HAB_BLDR_CHANNEL $dependency"
+    if($env:HAB_FEAT_IGNORE_LOCAL -eq "true") { $cmd += " --ignore-local" }
+    Invoke-Expression $cmd
     if ($LASTEXITCODE -ne 0 -and ($env:HAB_BLDR_URL -ne $FALLBACK_CHANNEL)) {
       Write-BuildLine "Trying to install '$dependency' from '$FALLBACK_CHANNEL'"
-      & $HAB_BIN install -u $env:HAB_BLDR_URL --channel $FALLBACK_CHANNEL $dependency
+      $cmd = "$HAB_BIN install -u $env:HAB_BLDR_URL --channel $FALLBACK_CHANNEL $dependency"
+      if($env:HAB_FEAT_IGNORE_LOCAL -eq "true") { $cmd += " --ignore-local" }
+      Invoke-Expression $cmd
     }
   }
 }

--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -716,10 +716,18 @@ _resolve_dependency() {
 _install_dependency() {
     local dep="${1}"
     if [[ -z "${NO_INSTALL_DEPS:-}" ]]; then
-    $HAB_BIN install -u $HAB_BLDR_URL --channel $HAB_BLDR_CHANNEL "$dep" || {
+
+    # Enable --ignore-local if invoked with HAB_FEAT_IGNORE_LOCAL in
+    # the environment, set to either "true" or "TRUE" (features are
+    # not currently enabled by the mere presence of an environment variable)
+    if [[ "${HAB_FEAT_IGNORE_LOCAL:-}" = "true" ||
+              "${HAB_FEAT_IGNORE_LOCAL:-}" = "TRUE" ]]; then
+        IGNORE_LOCAL="--ignore-local"
+    fi
+    $HAB_BIN install -u $HAB_BLDR_URL --channel $HAB_BLDR_CHANNEL ${IGNORE_LOCAL:-} "$dep" || {
       if [[ "$HAB_BLDR_CHANNEL" != "$FALLBACK_CHANNEL" ]]; then
         build_line "Trying to install '$dep' from '$FALLBACK_CHANNEL'"
-        $HAB_BIN install -u $HAB_BLDR_URL --channel "$FALLBACK_CHANNEL" "$dep" || true
+        $HAB_BIN install -u $HAB_BLDR_URL --channel "$FALLBACK_CHANNEL" ${IGNORE_LOCAL:-} "$dep" || true
       fi
     }
   fi

--- a/components/sup/src/util/pkg.rs
+++ b/components/sup/src/util/pkg.rs
@@ -15,7 +15,7 @@
 use std::path::Path;
 
 use common;
-use common::command::package::install::{InstallMode, InstallSource};
+use common::command::package::install::{InstallMode, InstallSource, LocalPackageUsage};
 use common::ui::UIWriter;
 use hcore::env as henv;
 use hcore::fs::{self, FS_ROOT_PATH};
@@ -59,6 +59,8 @@ where
         auth_token.as_ref().map(String::as_str),
         // TODO fn: pass through and enable offline install mode
         &InstallMode::default(),
+        // TODO (CM): pass through and enable ignore-local mode
+        &LocalPackageUsage::default(),
     ).map_err(SupError::from)
 }
 


### PR DESCRIPTION
Following the base plans refresh of June 2018, we discovered a small
bug in how our package installation logic could resolve dependencies
that are part of the Studio. In particular, this can occur when using
the `HAB_BLDR_CHANNEL` environment variable to specify an
other-than-stable channel to pull packages from.

There is logic in the Rust code that will end up using a
locally-installed package if something cannot be found in the
specified channel in Builder. If this is the case, the plan build
software will not fall back to look in the `stable` channel. This
would be an issue for us when building the next Habitat release,
because the first parts of our release are built with the
currently-stable Habitat, which was built before the base plans
refresh. Because of how we build using a release channel, we would end
up pulling in some dependencies based on what is installed in the
Studio, rather than allowing the build logic to fall back to pull from
stable. We can then run into issues later in the release process
building later packages that do end up pulling in newer dependencies;
we end up with multiple versions and thus cannot build.

For the next release, we will have these dependencies pinned
explicitly to ensure we get pre-refresh packages.

That brings us to this commit.

This introduces an `--ignore-local` flag for `hab pkg install` that
disables this "fallback to a local package" logic. Once this is
present in a stable `hab` release, we'll be able to build using
packages exclusively from Builder, as `hab-plan-build` has been
modified to use it.

This issue probably only shows up when you "straddle" a base plans
refresh like this.

Additionally, there may be better ways to ultimately handle this,
which is why this capability is currently behind a feature-flag. To
use it, you must set the environment variable `HAB_FEAT_IGNORE_LOCAL`
to `true`, which makes the `--ignore-local` option available on the
`hab pkg install` command. As such, this behavior *IS NOT* guaranteed
to remain in the `hab` CLI, pending a solidification of the desired
behavior.

Signed-off-by: Christopher Maier <cmaier@chef.io>