### PR TITLE
Relax a few explicit dependency pins

### DIFF
--- a/components/hab/plan.sh
+++ b/components/hab/plan.sh
@@ -8,16 +8,16 @@ pkg_license=('Apache-2.0')
 pkg_source=nosuchfile.tar.gz
 # The result is a portable, static binary in a zero-dependency package.
 pkg_deps=()
-pkg_build_deps=(core/musl/1.1.18/20180310000919
-                core/zlib-musl/1.2.8/20180310002650
-                core/xz-musl/5.2.2/20180310002650
-                core/bzip2-musl/1.0.6/20180310002649
-                core/libarchive-musl/3.3.2/20180310020328
-                core/openssl-musl/1.0.2l/20180310010254
-                core/libsodium-musl/1.0.13/20180310002622
-                core/coreutils/8.25/20170513213226
-                core/rust/1.26.2/20180606182054
-                core/gcc/5.2.0/20170513202244)
+pkg_build_deps=(core/musl
+                core/zlib-musl
+                core/xz-musl
+                core/bzip2-musl
+                core/libarchive-musl
+                core/openssl-musl
+                core/libsodium-musl
+                core/coreutils
+                core/rust
+                core/gcc)
 pkg_bin_dirs=(bin)
 
 bin=$_pkg_distname

--- a/components/pkg-cfize/plan.sh
+++ b/components/pkg-cfize/plan.sh
@@ -5,12 +5,24 @@ pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_description="Habitat Cloud Foundry image exporter"
 pkg_upstream_url="https://github.com/habitat-sh/habitat"
+
+# Docker is actually also pulled in by hab-pkg-export-docker, but we
+# explicitly call it here, so it's a dependency. Docker doesn't have
+# any dependencies, so we can unpin here without worrying about
+# getting dependency conflicts.
+#
+# We're pinning the other dependencies to their pre base-plans refresh
+# versions for the time being for explicitness, due to a bug in how
+# `hab pkg install` works in the context of our release pipeline.
+#
+# It's a bit of a moot point, though, since Docker's not going to run
+# on older kernels anyway.
 pkg_deps=(core/coreutils/8.25/20170513213226
           core/findutils/4.4.2/20170513214305
           core/grep/2.22/20170513213444
           core/gawk/4.1.3/20170513213646
           core/hab-pkg-export-docker
-          core/docker/18.03.0/20180403182455)
+          core/docker)
 pkg_bin_dirs=(bin)
 
 _bins=($pkg_name)

--- a/components/pkg-export-helm/plan.sh
+++ b/components/pkg-export-helm/plan.sh
@@ -5,19 +5,19 @@ pkg_origin=core
 pkg_version=$(cat "$PLAN_CONTEXT/../../VERSION")
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
-pkg_deps=(core/docker/18.03.0/20180403182455
-          core/helm/2.7.2/20180310001821)
-pkg_build_deps=(core/musl/1.1.18/20180310000919
-                core/zlib-musl/1.2.8/20180310002650
-                core/xz-musl/5.2.2/20180310002650
-                core/bzip2-musl/1.0.6/20180310002649
-                core/libarchive-musl/3.3.2/20180310020328
-                core/openssl-musl/1.0.2l/20180310010254
-                core/libsodium-musl/1.0.13/20180310002622
-                core/coreutils/8.25/20170513213226
-                core/rust/1.26.2/20180606182054
-                core/gcc/5.2.0/20170513202244
-                core/make/4.2.1/20170513214620)
+pkg_deps=(core/docker
+          core/helm)
+pkg_build_deps=(core/musl
+                core/zlib-musl
+                core/xz-musl
+                core/bzip2-musl
+                core/libarchive-musl
+                core/openssl-musl
+                core/libsodium-musl
+                core/coreutils
+                core/rust
+                core/gcc
+                core/make)
 pkg_bin_dirs=(bin)
 
 bin=$_pkg_distname

--- a/components/pkg-export-kubernetes/plan.sh
+++ b/components/pkg-export-kubernetes/plan.sh
@@ -5,18 +5,18 @@ pkg_origin=core
 pkg_version=$(cat "$PLAN_CONTEXT/../../VERSION")
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
-pkg_deps=(core/docker/18.03.0/20180403182455)
-pkg_build_deps=(core/musl/1.1.18/20180310000919
-                core/zlib-musl/1.2.8/20180310002650
-                core/xz-musl/5.2.2/20180310002650
-                core/bzip2-musl/1.0.6/20180310002649
-                core/libarchive-musl/3.3.2/20180310020328
-                core/openssl-musl/1.0.2l/20180310010254
-                core/libsodium-musl/1.0.13/20180310002622
-                core/coreutils/8.25/20170513213226
-                core/rust/1.26.2/20180606182054
-                core/gcc/5.2.0/20170513202244
-                core/make/4.2.1/20170513214620)
+pkg_deps=(core/docker)
+pkg_build_deps=(core/musl
+                core/zlib-musl
+                core/xz-musl
+                core/bzip2-musl
+                core/libarchive-musl
+                core/openssl-musl
+                core/libsodium-musl
+                core/coreutils
+                core/rust
+                core/gcc
+                core/make)
 pkg_bin_dirs=(bin)
 
 bin=$_pkg_distname

--- a/components/studio/plan.sh
+++ b/components/studio/plan.sh
@@ -6,11 +6,11 @@ pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_source=nosuchfile.tar.gz
 pkg_deps=()
-pkg_build_deps=(core/coreutils/8.25/20170513213226
-                core/tar/1.29/20170513213607
-                core/xz/5.2.2/20170513214327
-                core/wget/1.19.1/20171024102323
-                core/busybox-static/1.24.2/20170513215502
+pkg_build_deps=(core/coreutils
+                core/tar
+                core/xz
+                core/wget
+                core/busybox-static
                 core/hab)
 pkg_bin_dirs=(bin)
 


### PR DESCRIPTION
Read commit messages for further details. TL;DR - Remove unnecessary dependency pins, while still allowing as much as possible to run on older Linux kernels.

![tenor-142071623](https://user-images.githubusercontent.com/207178/41978207-5208da9a-79ef-11e8-81fd-3bb904b64454.gif)
