### PR TITLE
fixing default value for pid display in hab svc status

### DIFF
--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -1372,7 +1372,9 @@ where
         match status.process {
             Some(process) => (
                 process.state.to_string(),
-                process.pid.unwrap_or_default().to_string(),
+                process
+                    .pid
+                    .map_or_else(|| "<none>".to_string(), |p| p.to_string()),
                 process.elapsed.unwrap_or_default().to_string(),
             ),
             None => (


### PR DESCRIPTION
This PR changes the `hab svc status` pid column output to `<none>` when the process is not running which I think is more appropriate and the way it had been prior to 0.57.0

In doing so, it addresses #5260 

The `pid` value here is a [uint32](https://github.com/habitat-sh/habitat/blob/master/components/sup-protocol/protocols/types.proto#L50) with a Default of `0`

```
✔ /home/habitat [jeremymv2/fix_svc_status_pid_column L|✚ 3⚑ 8]
22:38 $ sudo -E ./target/debug/hab svc status
package                                           type        state  elapsed (s)  pid   group
chef/automate-elasticsearch/6.2.2/20180527141927  standalone  up     989          2276  automate-elasticsearch.foobar
core/redis/3.2.4/20170514150022  standalone  down  988  <none>  redis.default

✔ /home/habitat [jeremymv2/fix_svc_status_pid_column L|✚ 3⚑ 8]
22:38 $
```


Signed-off-by: Jeremy J. Miller <jm@chef.io>