### PR TITLE
Loosen Rust build dependency pin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ matrix:
         - COMPONENTS=bin
         - AFFECTED_FILES="Cargo.lock"
         - AFFECTED_DIRS="$_RUST_HAB_BIN_COMPONENTS $_RUST_HAB_LIB_COMPONENTS"
-      rust: 1.26.2
+      rust: 1.27.0
       sudo: false
       services:
         - docker
@@ -80,7 +80,7 @@ matrix:
         - COMPONENTS=lib
         - AFFECTED_FILES="Cargo.lock"
         - AFFECTED_DIRS="$_RUST_HAB_LIB_COMPONENTS"
-      rust: 1.26.1
+      rust: 1.27.0
       sudo: required
       addons:
         apt:

--- a/components/eventsrv/habitat/plan.sh
+++ b/components/eventsrv/habitat/plan.sh
@@ -10,7 +10,7 @@ pkg_deps=(core/glibc/2.22/20170513201042
           core/zeromq/4.2.5/20180407102804
           core/libsodium/1.0.13/20170905223149
           core/libarchive/3.3.2/20171018164107)
-pkg_build_deps=(core/rust/1.26.2/20180606182054
+pkg_build_deps=(core/rust
                 core/gcc/5.2.0/20170513202244
                 core/pkg-config/0.29/20170513212944
                 core/git/2.14.2/20180416203520)

--- a/components/launcher/habitat/plan.sh
+++ b/components/launcher/habitat/plan.sh
@@ -9,7 +9,7 @@ pkg_deps=(core/glibc/2.22/20170513201042
           core/libsodium/1.0.13/20170905223149
           core/openssl/1.0.2l/20171014213633)
 pkg_build_deps=(core/coreutils/8.25/20170513213226
-                core/rust/1.26.2/20180606182054
+                core/rust
                 core/gcc/5.2.0/20170513202244
                 core/git/2.14.2/20180416203520)
 pkg_bin_dirs=(bin)

--- a/components/sup/plan.sh
+++ b/components/sup/plan.sh
@@ -14,7 +14,7 @@ pkg_deps=(core/busybox-static/1.24.2/20170513215502
           core/zeromq/4.2.5/20180407102804)
 pkg_build_deps=(core/coreutils/8.25/20170513213226
                 core/cacerts/2017.09.20/20171014212239
-                core/rust/1.26.2/20180606182054
+                core/rust
                 core/gcc/5.2.0/20170513202244
                 core/raml2html/6.3.0/20180409195740)
 pkg_bin_dirs=(bin)


### PR DESCRIPTION
This will allow us to use Rust 1.27.0 (and future releases)

Also update Travis build to use 1.27.0

Signed-off-by: Christopher Maier <cmaier@chef.io>