### PR TITLE
Allow butterfly server to start given a corrupted rumor file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -696,6 +696,7 @@ dependencies = [
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempdir 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "threadpool 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/butterfly/Cargo.toml
+++ b/components/butterfly/Cargo.toml
@@ -26,6 +26,7 @@ protobuf = "*"
 rand = "*"
 serde = "*"
 serde_derive = "*"
+tempdir = "*"
 time = "*"
 threadpool = "*"
 toml = { version = "*", default-features = false }

--- a/components/butterfly/src/lib.rs
+++ b/components/butterfly/src/lib.rs
@@ -54,6 +54,8 @@ extern crate rand;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;
+#[cfg(test)]
+extern crate tempdir;
 extern crate time;
 extern crate toml;
 extern crate uuid;

--- a/components/butterfly/src/server/mod.rs
+++ b/components/butterfly/src/server/mod.rs
@@ -1055,6 +1055,9 @@ mod tests {
         use server::{Server, Suitability};
         use std::path::PathBuf;
         use std::sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
+        use std::fs::File;
+        use std::io::prelude::*;
+        use tempdir::TempDir;
         use trace::Trace;
 
         static SWIM_PORT: AtomicUsize = ATOMIC_USIZE_INIT;
@@ -1090,9 +1093,44 @@ mod tests {
             ).unwrap()
         }
 
+        fn start_with_corrupt_rumor_file(tmpdir: &TempDir) -> Server {
+            SWIM_PORT.compare_and_swap(0, 6666, Ordering::Relaxed);
+            GOSSIP_PORT.compare_and_swap(0, 7777, Ordering::Relaxed);
+            let swim_port = SWIM_PORT.fetch_add(1, Ordering::Relaxed);
+            let swim_listen = format!("127.0.0.1:{}", swim_port);
+            let gossip_port = GOSSIP_PORT.fetch_add(1, Ordering::Relaxed);
+            let gossip_listen = format!("127.0.0.1:{}", gossip_port);
+            let mut member = Member::default();
+            member.set_swim_port(swim_port as i32);
+            member.set_gossip_port(gossip_port as i32);
+            let rumor_name = format!("{}{}", member.get_id().to_string(), ".rst");
+            let file_path = tmpdir.path().to_owned().join(rumor_name);
+            let mut rumor_file = File::create(file_path).unwrap();
+            writeln!(rumor_file, "This is not a valid rumor file!").unwrap();
+            Server::new(
+                &swim_listen[..],
+                &gossip_listen[..],
+                member,
+                Trace::default(),
+                None,
+                None,
+                Some(tmpdir.path()),
+                Box::new(ZeroSuitability),
+            ).unwrap()
+        }
+
         #[test]
         fn new() {
             start_server();
+        }
+
+        #[test]
+        fn new_with_corrupt_rumor_file() {
+            let tmpdir = TempDir::new("data").unwrap();
+            let mut server = start_with_corrupt_rumor_file(&tmpdir);
+            server
+                .start(Timing::default())
+                .expect("Server failed to start");
         }
 
         #[test]

--- a/components/butterfly/src/server/mod.rs
+++ b/components/butterfly/src/server/mod.rs
@@ -253,16 +253,14 @@ impl Server {
             }
             let mut file = DatFile::new(&self.member_id, path);
             if file.path().exists() {
-                if let Some(err) = file.read_into(self).err() {
-                    // Display any error and move on, knowing that this is transitory.
-                    // The file will be rewritten shortly and then continually updated.
-                    println!("Error reading rumors from disk: {}", err);
-                } else {
-                    debug!(
-                        "Successfully ingested rumor content from {}",
+                match file.read_into(self) {
+                    Ok(_) => debug!(
+                        "Successfully ingested rumors from {}",
                         file.path().display()
-                    );
-                }
+                    ),
+                    Err(Error::DatFileIO(path, err)) => println!("{}", Error::DatFileIO(path, err)),
+                    Err(err) => return Err(err),
+                };
             }
             let mut dat_file = self.dat_file.write().expect("DatFile lock is poisoned");
             *dat_file = Some(file);

--- a/components/butterfly/src/server/mod.rs
+++ b/components/butterfly/src/server/mod.rs
@@ -259,7 +259,7 @@ impl Server {
                     println!("Error reading rumors from disk: {}", err);
                 } else {
                     debug!(
-                        "Successfully injested rumor content from {}",
+                        "Successfully ingested rumor content from {}",
                         file.path().display()
                     );
                 }


### PR DESCRIPTION
Resolves https://github.com/habitat-sh/habitat/issues/5202

This change allows the butterfly server module to start even if there was an error encountered while reading an existing (but presumably corrupted) rumor file that previously would have caused a hard crash.

## Testing 🔬 

You can see the error that previously would result in a hard crash, this time the server just moves on. You can also see it later continually loop and periodically write out rumors to disk.

```
Error reading rumors from disk: Error reading or writing to DatFile, /hab/sup/default/data/7807eb11c928433caffa0d04c8ae8a13.rst, Invalid argument (os error 22)
...
DEBUG 2018-07-03T17:04:31Z: habitat_butterfly::server: Successfully persisted rumors to disk: /hab/sup/default/data/7807eb11c928433caffa0d04c8ae8a13.rst
```

Here's the whole thing:
```
✔ /home/habitat [jeremymv2/butterfly_come_to_life_after_crash L|⚑ 9]
16:57 $ ls -l /hab/sup/default/data/*rst
-rw-r--r-- 1 root root 65 Jul  3 16:47 /hab/sup/default/data/7807eb11c928433caffa0d04c8ae8a13.rst

✔ /home/habitat [jeremymv2/butterfly_come_to_life_after_crash L|⚑ 9]
16:58 $ sudo cp /dev/random /hab/sup/default/data/7807eb11c928433caffa0d04c8ae8a13.rst
^C
✘-INT /home/habitat [jeremymv2/butterfly_come_to_life_after_crash L|⚑ 9]
16:58 $ ls -l /hab/sup/default/data/*rst
-rw-r--r-- 1 root root 252 Jul  3 16:58 /hab/sup/default/data/7807eb11c928433caffa0d04c8ae8a13.rst

✔ /home/habitat [jeremymv2/butterfly_come_to_life_after_crash L|⚑ 9]
16:58 $ set | grep HAB
HAB_BIN=/home/habitat/target/debug/hab
HAB_BUTTERFLY_BINARY=/home/habitat/target/debug/butterfly
HAB_LAUNCH_BINARY=/home/habitat/target/debug/hab-launch
HAB_ORIGIN=jeremymv2
HAB_SUP_BINARY=/home/habitat/target/debug/hab-sup

✔ /home/habitat [jeremymv2/butterfly_come_to_life_after_crash L|⚑ 9]
16:58 $ sudo -E RUST_LOG=debug target/debug/hab sup run &
[1] 1062
DEBUG 2018-07-03T16:59:15Z: habitat_common::ui: UI { shell: Shell { input: InputStream { isatty: true }, out: OutputStream { coloring: Auto, isatty: true, is_colored(): true, suppor
ts_color(): true }, err: OutputStream { coloring: Auto, isatty: true, is_colored(): true, supports_color(): true } } }
DEBUG 2018-07-03T16:59:15Z: habitat_core::os::process::imp: Calling execvp(): ("/mnt/data/home/habitat/target/debug/hab-launch") ["run"]
DEBUG 2018-07-03T16:59:15Z: habitat_launcher::server: Starting Supervisor...
DEBUG 2018-07-03T16:59:15Z: habitat_sup::manager: Creating data directory: /hab/sup/default/data
DEBUG 2018-07-03T16:59:15Z: habitat_sup::manager: Creating specs directory: /hab/sup/default/specs
DEBUG 2018-07-03T16:59:15Z: habitat_sup::manager: Creating composites directory: /hab/sup/default/composites
DEBUG 2018-07-03T16:59:15Z: habitat_sup::manager: Cleaning cached health checks
hab-sup(MR): Supervisor Member-ID 7807eb11c928433caffa0d04c8ae8a13
DEBUG 2018-07-03T16:59:15Z: habitat_sup::manager::service::spec: Writing service spec to '/hab/sup/default/specs/automate-elasticsearch.spec': ServiceSpec { ident: PackageIdent { origin: "chef", name: "automate-elasticsearch", version: None, release: None }, group: "foobar", application_environment: None, bldr_url: "https://bldr.habitat.sh", channel: "stable", topology: Standalone, update_strategy: None, binds: [], binding_mode: Strict, config_from: None, desired_state: Down, svc_encrypted_password: None, composite: None }
DEBUG 2018-07-03T16:59:15Z: habitat_sup::manager::service::spec: Writing service spec to '/hab/sup/default/specs/redis.spec': ServiceSpec { ident: PackageIdent { origin: "core", name: "redis", version: None, release: None }, group: "default", application_environment: None, bldr_url: "https://bldr.habitat.sh", channel: "stable", topology: Standalone, update_strategy: None, binds: [], binding_mode: Strict, config_from: None, desired_state: Down, svc_encrypted_password: None, composite: None }
DEBUG 2018-07-03T16:59:15Z: habitat_sup::manager::spec_watcher: SpecWatcher(/hab/sup/default/specs) thread starting
DEBUG 2018-07-03T16:59:15Z: habitat_sup::manager::spec_watcher: Service spec for automate-elasticsearch is new, enqueuing AddService(ServiceSpec { ident: PackageIdent { origin: "chef", name: "automate-elasticsearch", version: None, release: None }, group: "foobar", application_environment: None, bldr_url: "https://bldr.habitat.sh", channel: "stable", topology: Standalone, update_strategy: None, binds: [], binding_mode: Strict, config_from: None, desired_state: Down, svc_encrypted_password: None, composite: None }) event
DEBUG 2018-07-03T16:59:15Z: habitat_sup::manager::spec_watcher: Service spec for redis is new, enqueuing AddService(ServiceSpec { ident: PackageIdent { origin: "core", name: "redis", version: None, release: None }, group: "default", application_environment: None, bldr_url: "https://bldr.habitat.sh", channel: "stable", topology: Standalone, update_strategy: None, binds: [], binding_mode: Strict, config_from: None, desired_state: Down, svc_encrypted_password: None, composite: None }) event
hab-sup(MR): Starting gossip-listener on 0.0.0.0:9638
DEBUG 2018-07-03T16:59:15Z: habitat_butterfly::server: entering habitat_butterfly::server::Server::start
DEBUG 2018-07-03T16:59:15Z: habitat_butterfly::rumor::dat_file: Header Version: 196
DEBUG 2018-07-03T16:59:15Z: habitat_butterfly::rumor::dat_file: Header Size: 8241005914613007876
DEBUG 2018-07-03T16:59:15Z: habitat_butterfly::rumor::dat_file: Header: Header { member_len: 11719302829728960995, service_len: 12081837330259530261, service_config_len: 9437507090636132556, service_file_len: 7090797666809851440, election_len: 3922671887378129586, update_len: 116442207599637563, departure_len: 14098129149470582122 }
Error reading rumors from disk: Error reading or writing to DatFile, /hab/sup/default/data/7807eb11c928433caffa0d04c8ae8a13.rst, Invalid argument (os error 22)
DEBUG 2018-07-03T16:59:15Z: habitat_sup::manager: gossip-listener started
DEBUG 2018-07-03T16:59:15Z: habitat_sup::manager: Writing census state to disk
DEBUG 2018-07-03T16:59:15Z: habitat_sup::manager: Writing butterfly state to disk
DEBUG 2018-07-03T16:59:15Z: habitat_sup::manager: Writing services state to disk
DEBUG 2018-07-03T16:59:15Z: habitat_butterfly::server: Successfully persisted rumors to disk: /hab/sup/default/data/7807eb11c928433caffa0d04c8ae8a13.rst
DEBUG 2018-07-03T16:59:15Z: habitat_sup::manager::service::config: 'user.toml' at /hab/user/redis/config/user.toml does not exist

....

DEBUG 2018-07-03T17:04:30Z: tokio_core::reactor: loop process - 0 events, Duration { secs: 0, nanos: 85568 }
DEBUG 2018-07-03T17:04:31Z: habitat_butterfly::server: Successfully persisted rumors to disk: /hab/sup/default/data/7807eb11c928433caffa0d04c8ae8a13.rst
DEBUG 2018-07-03T17:04:31Z: tokio_core::reactor: loop poll - Duration { secs: 1, nanos: 78853 }
```


Signed-off-by: Jeremy J. Miller <jm@chef.io>