### PR TITLE
Handle return case of Ok(None) for pkg.svc_user() and pkg.svc_group()

### DIFF
--- a/components/pkg-export-docker/src/build.rs
+++ b/components/pkg-export-docker/src/build.rs
@@ -770,8 +770,8 @@ mod test {
         bins: Vec<String>,
         is_svc: bool,
         rootfs: PathBuf,
-        svc_user: String,
-        svc_group: String,
+        svc_user: Option<String>,
+        svc_group: Option<String>,
     }
     impl FakePkg {
         pub fn new<I, P>(ident: I, rootfs: P) -> FakePkg
@@ -784,8 +784,8 @@ mod test {
                 bins: Vec::new(),
                 is_svc: false,
                 rootfs: rootfs.as_ref().to_path_buf(),
-                svc_user: "my_user".to_string(),
-                svc_group: "my_group".to_string(),
+                svc_user: None,
+                svc_group: None,
             }
         }
 
@@ -798,7 +798,14 @@ mod test {
         }
 
         pub fn set_svc(&mut self, is_svc: bool) -> &mut FakePkg {
-            self.is_svc = is_svc;
+            self.is_svc = is_svc; 
+            if self.is_svc == true {
+                self.set_svc_user("my_user");
+                self.set_svc_group("my_group");
+            } else {
+                self.svc_user = None;
+                self.svc_group = None;
+            }
             self
         }
 
@@ -806,7 +813,7 @@ mod test {
         where
             S: ToString,
         {
-            self.svc_user = svc_user.to_string();
+            self.svc_user = Some(svc_user.to_string());
             self
         }
 
@@ -814,7 +821,7 @@ mod test {
         where
             S: ToString,
         {
-            self.svc_group = svc_group.to_string();
+            self.svc_group = Some(svc_group.to_string());
             self
         }
 
@@ -830,8 +837,12 @@ mod test {
             util::write_file(prefix.join("IDENT"), &ident.to_string()).unwrap();
             util::write_file(prefix.join("TARGET"), PackageTarget::active_target()).unwrap();
 
-            util::write_file(prefix.join("SVC_USER"), &self.svc_user).unwrap();
-            util::write_file(prefix.join("SVC_GROUP"), &self.svc_group).unwrap();
+            if let Some(svc_user) = &self.svc_user {
+                util::write_file(prefix.join("SVC_USER"), svc_user).unwrap();
+            }
+            if let Some(svc_group) = &self.svc_group {
+                util::write_file(prefix.join("SVC_GROUP"), svc_group).unwrap();
+            }
 
             if !self.bins.is_empty() {
                 util::write_file(

--- a/components/pkg-export-docker/src/build.rs
+++ b/components/pkg-export-docker/src/build.rs
@@ -524,11 +524,14 @@ impl BuildRootContext {
         let gid = DEFAULT_USER_AND_GROUP_ID;
 
         let pkg = self.primary_svc()?;
-        let user_name = pkg.svc_user().unwrap_or(Some(String::from("hab"))).unwrap();
-        let group_name = pkg
-            .svc_group()
-            .unwrap_or(Some(String::from("hab")))
-            .unwrap();
+        let user_name = match pkg.svc_user() {
+            Ok(Some(user)) => user, 
+            _ => String::from("hab")
+        };
+        let group_name = match pkg.svc_group() {
+            Ok(Some(group)) => group, 
+            _ => String::from("hab")
+        };
 
         // TODO: In some cases, packages based on core/nginx and
         // core/httpd (and possibly others) will not work, because


### PR DESCRIPTION
When troubleshooting habitat-sh/core-plans#1656 I discovered that the docker exporter isn't handling the case where a package is considered a service, but the SVC_USER / SVC_GROUP metadata isn't present.   In this case the return value is `Ok(None)`,  which is then unwrapped twice causing a panic.  

I chose to treat the `Ok(None)` case the same as the `Error` case, which is to turn it into the default user of "hab".  

I tested this by running the export against a package with known issues `core/postgresql95`,  a known good package `core/postgresql` and a combination of a non-service package with a service package `core/gcc-libs core/postgresql`.


Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>