### PR TITLE
Fix link for SWIM paper

### DIFF
--- a/components/butterfly/src/lib.rs
+++ b/components/butterfly/src/lib.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Butterfly is the [SWIM](https://www.cs.cornell.edu/~asdas/research/dsn02-swim.pdf)
+//! Butterfly is the [SWIM](http://www.cs.cornell.edu/projects/Quicksilver/public_pdfs/SWIM.pdf)
 //! implementation for Habitat, along with a ZeroMQ based gossip protocol.
 //!
 //! It implements SWIM+Susp+Inf. It uses Newscast-style "heat" tracking to share membership rumors,

--- a/www/source/partials/docs/_internals-supervisor.html.md.erb
+++ b/www/source/partials/docs/_internals-supervisor.html.md.erb
@@ -93,5 +93,5 @@ Whats good about this system:
 
 ## Papers
 
-* Many more details about the operation of SWIM can be found in its [paper](https://www.cs.cornell.edu/~asdas/research/dsn02-swim.pdf).
+* Many more details about the operation of SWIM can be found in its [paper](http://www.cs.cornell.edu/projects/Quicksilver/public_pdfs/SWIM.pdf).
 * For information about the newscast approach to rumor dissemination, please refer to the [paper](http://www.cs.unibo.it/bison/publications/ap2pc03.pdf).

--- a/www/source/partials/docs/_using-hab-topologies.html.md.erb
+++ b/www/source/partials/docs/_using-hab-topologies.html.md.erb
@@ -36,7 +36,7 @@ $ hab start yourname/yourdb --topology leader --group production --permanent-pee
 
 When this is used we will attempt to ping the permanent peer and achieve quorum, even if they are confirmed dead.
 
-The notion of a permanent peer is an extension to the original [SWIM](https://www.cs.cornell.edu/~asdas/research/dsn02-swim.pdf) gossip protocol. It can add robustness provided everyone has a permanent member on both sides of the split.
+The notion of a permanent peer is an extension to the original [SWIM](http://www.cs.cornell.edu/projects/Quicksilver/public_pdfs/SWIM.pdf) gossip protocol. It can add robustness provided everyone has a permanent member on both sides of the split.
 
 ### Defining Leader and Follower Behavior in Plans
 


### PR DESCRIPTION
https://www.cs.cornell.edu/~asdas/research/dsn02-swim.pdf is broken. Update it to http://www.cs.cornell.edu/projects/Quicksilver/public_pdfs/SWIM.pdf, which seems to be the same content based on https://web.archive.org/web/20171215141844/https://www.cs.cornell.edu/~asdas/research/dsn02-swim.pdf
