### PR TITLE
adding `DesiredState` enum to `ServiceStatus` proto type

### DIFF
--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -85,7 +85,7 @@ const HABITAT_USER_ENVVAR: &'static str = "HAB_USER";
 
 lazy_static! {
     static ref STATUS_HEADER: Vec<&'static str> = {
-        vec!["package", "type", "state", "elapsed (s)", "pid", "group"]
+        vec!["package", "type", "desired", "state", "elapsed (s)", "pid", "group"]
     };
 
     /// The default filesystem root path to base all commands from. This is lazily generated on
@@ -1368,6 +1368,9 @@ where
         }
     };
     let svc_type = status.composite.unwrap_or("standalone".to_string());
+    let svc_desired_state = status
+        .desired_state
+        .map_or("unknown".to_string(), |s| s.to_string());
     let (svc_state, svc_pid, svc_elapsed) = {
         match status.process {
             Some(process) => (
@@ -1389,9 +1392,10 @@ where
     }
     write!(
         out,
-        "{}\t{}\t{}\t{}\t{}\t{}\n",
+        "{}\t{}\t{}\t{}\t{}\t{}\t{}\n",
         status.ident,
         svc_type,
+        DesiredState::from_str(&svc_desired_state)?,
         ProcessState::from_str(&svc_state)?,
         svc_elapsed,
         svc_pid,

--- a/components/sup-protocol/protocols/types.proto
+++ b/components/sup-protocol/protocols/types.proto
@@ -14,6 +14,11 @@ enum ProcessState {
   Up = 1;
 }
 
+enum DesiredState {
+  DesiredDown = 0;
+  DesiredUp = 1;
+}
+
 // The relationship of a service with peers in the same service group.
 enum Topology {
   Standalone = 0;
@@ -80,5 +85,6 @@ message ServiceStatus {
   optional ProcessStatus process = 2;
   required ServiceGroup service_group = 3;
   optional string composite = 4;
+  optional DesiredState desired_state = 5;
 }
 

--- a/components/sup-protocol/src/generated/sup.types.rs
+++ b/components/sup-protocol/src/generated/sup.types.rs
@@ -1,87 +1,98 @@
-#[derive(Clone, PartialEq, Message, Serialize, Deserialize, Hash)]
+#[derive(Clone, PartialEq, Message)]
+#[derive(Serialize, Deserialize, Hash)]
 #[serde(rename_all = "kebab-case")]
 pub struct ApplicationEnvironment {
-    #[prost(string, required, tag = "1")]
+    #[prost(string, required, tag="1")]
     pub application: String,
-    #[prost(string, required, tag = "2")]
+    #[prost(string, required, tag="2")]
     pub environment: String,
 }
-#[derive(Clone, PartialEq, Message, Serialize, Deserialize, Hash)]
+#[derive(Clone, PartialEq, Message)]
+#[derive(Serialize, Deserialize, Hash)]
 #[serde(rename_all = "kebab-case")]
 pub struct PackageIdent {
-    #[prost(string, required, tag = "1")]
+    #[prost(string, required, tag="1")]
     pub origin: String,
-    #[prost(string, required, tag = "2")]
+    #[prost(string, required, tag="2")]
     pub name: String,
-    #[prost(string, optional, tag = "3")]
+    #[prost(string, optional, tag="3")]
     pub version: ::std::option::Option<String>,
-    #[prost(string, optional, tag = "4")]
+    #[prost(string, optional, tag="4")]
     pub release: ::std::option::Option<String>,
 }
-#[derive(Clone, PartialEq, Message, Serialize, Deserialize, Hash)]
+#[derive(Clone, PartialEq, Message)]
+#[derive(Serialize, Deserialize, Hash)]
 #[serde(rename_all = "kebab-case")]
 pub struct ProcessStatus {
-    #[prost(int64, optional, tag = "1")]
+    #[prost(int64, optional, tag="1")]
     pub elapsed: ::std::option::Option<i64>,
-    #[prost(uint32, optional, tag = "2")]
+    #[prost(uint32, optional, tag="2")]
     pub pid: ::std::option::Option<u32>,
-    #[prost(enumeration = "ProcessState", required, tag = "3")]
+    #[prost(enumeration="ProcessState", required, tag="3")]
     pub state: i32,
 }
-#[derive(Clone, PartialEq, Message, Serialize, Deserialize, Hash)]
+#[derive(Clone, PartialEq, Message)]
+#[derive(Serialize, Deserialize, Hash)]
 #[serde(rename_all = "kebab-case")]
 pub struct ServiceBind {
-    #[prost(string, required, tag = "1")]
+    #[prost(string, required, tag="1")]
     pub name: String,
-    #[prost(message, required, tag = "2")]
+    #[prost(message, required, tag="2")]
     pub service_group: ServiceGroup,
-    #[prost(string, optional, tag = "3")]
+    #[prost(string, optional, tag="3")]
     pub service_name: ::std::option::Option<String>,
 }
-#[derive(Clone, PartialEq, Message, Serialize, Deserialize, Hash)]
+#[derive(Clone, PartialEq, Message)]
+#[derive(Serialize, Deserialize, Hash)]
 #[serde(rename_all = "kebab-case")]
 pub struct ServiceCfg {
     /// The self describing string format used in each configuration field. This
     /// is present if we ever change from using TOML to represent service configurations
     /// to another self describing type.
-    #[prost(enumeration = "service_cfg::Format", optional, tag = "1", default = "Toml")]
+    #[prost(enumeration="service_cfg::Format", optional, tag="1", default="Toml")]
     pub format: ::std::option::Option<i32>,
-    #[prost(string, optional, tag = "2")]
+    #[prost(string, optional, tag="2")]
     pub default: ::std::option::Option<String>,
 }
 pub mod service_cfg {
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Enumeration, Serialize, Deserialize, Hash)]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Enumeration)]
+    #[derive(Serialize, Deserialize, Hash)]
     #[serde(rename_all = "kebab-case")]
     pub enum Format {
         Toml = 0,
     }
 }
-#[derive(Clone, PartialEq, Message, Serialize, Deserialize, Hash)]
+#[derive(Clone, PartialEq, Message)]
+#[derive(Serialize, Deserialize, Hash)]
 #[serde(rename_all = "kebab-case")]
 pub struct ServiceGroup {
-    #[prost(string, required, tag = "1")]
+    #[prost(string, required, tag="1")]
     pub service: String,
-    #[prost(string, required, tag = "2")]
+    #[prost(string, required, tag="2")]
     pub group: String,
-    #[prost(message, optional, tag = "3")]
+    #[prost(message, optional, tag="3")]
     pub application_environment: ::std::option::Option<ApplicationEnvironment>,
-    #[prost(string, optional, tag = "4")]
+    #[prost(string, optional, tag="4")]
     pub organization: ::std::option::Option<String>,
 }
-#[derive(Clone, PartialEq, Message, Serialize, Deserialize, Hash)]
+#[derive(Clone, PartialEq, Message)]
+#[derive(Serialize, Deserialize, Hash)]
 #[serde(rename_all = "kebab-case")]
 pub struct ServiceStatus {
-    #[prost(message, required, tag = "1")]
+    #[prost(message, required, tag="1")]
     pub ident: PackageIdent,
-    #[prost(message, optional, tag = "2")]
+    #[prost(message, optional, tag="2")]
     pub process: ::std::option::Option<ProcessStatus>,
-    #[prost(message, required, tag = "3")]
+    #[prost(message, required, tag="3")]
     pub service_group: ServiceGroup,
-    #[prost(string, optional, tag = "4")]
+    #[prost(string, optional, tag="4")]
     pub composite: ::std::option::Option<String>,
+    #[prost(enumeration="DesiredState", optional, tag="5")]
+    pub desired_state: ::std::option::Option<i32>,
 }
 /// Encapsulate all possible sources we can install packages from.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Enumeration, Serialize, Deserialize, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Enumeration)]
+#[derive(Serialize, Deserialize, Hash)]
 #[serde(rename_all = "kebab-case")]
 pub enum InstallSource {
     /// Install from a remote hosting the package
@@ -89,27 +100,38 @@ pub enum InstallSource {
     /// Install from a local archive file
     Archive = 1,
 }
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Enumeration, Serialize, Deserialize, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Enumeration)]
+#[derive(Serialize, Deserialize, Hash)]
 #[serde(rename_all = "kebab-case")]
 pub enum ProcessState {
     Down = 0,
     Up = 1,
 }
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Enumeration)]
+#[derive(Serialize, Deserialize, Hash)]
+#[serde(rename_all = "kebab-case")]
+pub enum DesiredState {
+    DesiredDown = 0,
+    DesiredUp = 1,
+}
 /// The relationship of a service with peers in the same service group.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Enumeration, Serialize, Deserialize, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Enumeration)]
+#[derive(Serialize, Deserialize, Hash)]
 #[serde(rename_all = "kebab-case")]
 pub enum Topology {
     Standalone = 0,
     Leader = 1,
 }
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Enumeration, Serialize, Deserialize, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Enumeration)]
+#[derive(Serialize, Deserialize, Hash)]
 #[serde(rename_all = "kebab-case")]
 pub enum UpdateStrategy {
     None = 0,
     AtOnce = 1,
     Rolling = 2,
 }
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Enumeration, Serialize, Deserialize, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Enumeration)]
+#[derive(Serialize, Deserialize, Hash)]
 #[serde(rename_all = "kebab-case")]
 pub enum BindingMode {
     /// Services may start whether binds are available or not

--- a/components/sup-protocol/src/types.rs
+++ b/components/sup-protocol/src/types.rs
@@ -88,6 +88,16 @@ impl fmt::Display for ProcessState {
     }
 }
 
+impl fmt::Display for DesiredState {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let state = match *self {
+            DesiredState::DesiredDown => "down",
+            DesiredState::DesiredUp => "up",
+        };
+        write!(f, "{}", state)
+    }
+}
+
 impl FromStr for BindingMode {
     type Err = NetErr;
 
@@ -112,7 +122,22 @@ impl FromStr for ProcessState {
             "1" => Ok(ProcessState::Up),
             _ => Err(net::err(
                 ErrCode::InvalidPayload,
-                format!("Invalid process state \"{}\"", value),
+                format!("Invalid process state \"{:?}\"", value),
+            )),
+        }
+    }
+}
+
+impl FromStr for DesiredState {
+    type Err = NetErr;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.to_lowercase().as_ref() {
+            "0" => Ok(DesiredState::DesiredDown),
+            "1" => Ok(DesiredState::DesiredUp),
+            _ => Err(net::err(
+                ErrCode::InvalidPayload,
+                format!("Invalid desired state \"{:?}\"", value),
             )),
         }
     }

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -79,6 +79,7 @@ use config::GossipListenAddr;
 use ctl_gateway::{self, CtlRequest};
 use error::{Error, Result, SupError};
 use http_gateway;
+use manager::service::spec::DesiredState as SpecDesiredState;
 use util;
 use ShutdownReason;
 use VERSION;
@@ -1686,6 +1687,7 @@ pub struct ServiceStatus {
     pub process: ProcessStatus,
     pub service_group: ServiceGroup,
     pub composite: Option<String>,
+    pub desired_state: DesiredState,
 }
 
 impl fmt::Display for ServiceStatus {
@@ -1924,6 +1926,7 @@ impl From<ServiceStatus> for protocol::types::ServiceStatus {
         if let Some(composite) = other.composite {
             proto.composite = Some(composite);
         }
+        proto.desired_state = Some(other.desired_state.into());
         proto
     }
 }
@@ -1934,6 +1937,15 @@ impl Into<service::ServiceBind> for protocol::types::ServiceBind {
             name: self.name,
             service_group: self.service_group.into(),
             service_name: self.service_name,
+        }
+    }
+}
+
+impl From<SpecDesiredState> for i32 {
+    fn from(other: SpecDesiredState) -> Self {
+        match other {
+            DesiredState::Down => 0,
+            DesiredState::Up => 1,
         }
     }
 }

--- a/components/sup/src/manager/service/mod.rs
+++ b/components/sup/src/manager/service/mod.rs
@@ -18,7 +18,7 @@ mod dir;
 mod health;
 pub mod hooks;
 mod package;
-mod spec;
+pub mod spec;
 mod supervisor;
 
 use std;
@@ -95,6 +95,7 @@ pub struct Service {
     pub service_group: ServiceGroup,
     pub bldr_url: String,
     pub channel: String,
+    pub desired_state: DesiredState,
     pub spec_file: PathBuf,
     pub spec_ident: PackageIdent,
     pub topology: Topology,
@@ -179,6 +180,7 @@ impl Service {
             config_renderer: CfgRenderer::new(&config_root)?,
             bldr_url: spec.bldr_url,
             channel: spec.channel,
+            desired_state: spec.desired_state,
             health_check: HealthCheck::default(),
             hooks: HookTable::load(
                 &service_group,


### PR DESCRIPTION
Resolves https://github.com/habitat-sh/habitat/issues/5063

## Description 🔩 

![desired](https://user-images.githubusercontent.com/1991696/42549732-5a9fa978-8493-11e8-82ef-e7c6c5207bc5.gif)

This PR adds the `DesiredState` type to the `ServiceStatus` proto
message, with variants `DesiredDown` and `DesiredUp` since `Up` and
`Down` variants were already used by `ProcessStatus` enum.

The manifestation of the new type is seen as an additional column
`desired` added to the output of `hab svc status`, displaying
up/down reflecting the value from the service spec field
`desired_state`.

## Demo ⚙️ 
```
✔ /home/habitat [jeremymv2/desired_state_for_svc_status L|✚ 2⚑ 11]
03:38 $ set | grep HAB
HAB_BIN=/home/habitat/target/debug/hab
HAB_BUTTERFLY_BINARY=/home/habitat/target/debug/butterfly
HAB_LAUNCH_BINARY=/home/habitat/target/debug/hab-launch
HAB_ORIGIN=jeremymv2
HAB_SUP_BINARY=/home/habitat/target/debug/hab-sup

✔ /home/habitat [jeremymv2/desired_state_for_svc_status L|✚ 2⚑ 11]
03:39 $ sudo -E RUST_LOG=info target/debug/hab --version
hab 0.59.0-dev

✔ /home/habitat [jeremymv2/desired_state_for_svc_status L|✚ 2⚑ 11]
03:39 $ sudo -E RUST_LOG=info target/debug/hab sup run &
[1] 11240
hab-sup(MR): Supervisor Member-ID 7807eb11c928433caffa0d04c8ae8a13
hab-sup(MR): Starting core/redis

✔ /home/habitat [jeremymv2/desired_state_for_svc_status L|✚ 2⚑ 11]
03:39 $ redis.default(UCW): Watching user.toml
hab-sup(MR): Starting gossip-listener on 0.0.0.0:9638
hab-sup(MR): Starting ctl-gateway on 127.0.0.1:9632
hab-sup(MR): Starting http-gateway on 0.0.0.0:9631
redis.default(HK): Hooks compiled
redis.default(SR): Initializing
redis.default(SV): Starting service as user=hab, group=hab
redis.default(O): 11329:M 11 Jul 03:39:16.036 * Increased maximum number of open files to 10032 (it was originally set to 1024).
redis.default(O):                 _._
redis.default(O):            _.-``__ ''-._
redis.default(O):       _.-``    `.  `_.  ''-._           Redis 3.2.4 (00000000/0) 64 bit
redis.default(O):   .-`` .-```.  ```\/    _.,_ ''-._
redis.default(O):  (    '      ,       .-`  | `,    )     Running in standalone mode
redis.default(O):  |`-._`-...-` __...-.``-._|'` _.-'|     Port: 6379
redis.default(O):  |    `-._   `._    /     _.-'    |     PID: 11329
redis.default(O):   `-._    `-._  `-./  _.-'    _.-'
redis.default(O):  |`-._`-._    `-.__.-'    _.-'_.-'|
redis.default(O):  |    `-._`-._        _.-'_.-'    |           http://redis.io
redis.default(O):   `-._    `-._`-.__.-'_.-'    _.-'
redis.default(O):  |`-._`-._    `-.__.-'    _.-'_.-'|
redis.default(O):  |    `-._`-._        _.-'_.-'    |
redis.default(O):   `-._    `-._`-.__.-'_.-'    _.-'
redis.default(O):       `-._    `-.__.-'    _.-'
redis.default(O):           `-._        _.-'
redis.default(O):               `-.__.-'
redis.default(O):
redis.default(O): 11329:M 11 Jul 03:39:16.036 # WARNING: The TCP backlog setting of 511 cannot be enforced because /proc/sys/net/core/somaxconn is set to the lower value of 128.
redis.default(O): 11329:M 11 Jul 03:39:16.037 # Server started, Redis version 3.2.4
redis.default(O): 11329:M 11 Jul 03:39:16.037 # WARNING overcommit_memory is set to 0! Background save may fail under low memory condition. To fix this issue add 'vm.overcommit_memory = 1' to /etc/sysctl.conf and then reboot or run the command 'sysctl vm.overcommit_memory=1' for this to take effect.
redis.default(O): 11329:M 11 Jul 03:39:16.037 # WARNING you have Transparent Huge Pages (THP) support enabled in your kernel. This will create latency and memory usage issues with Redis. To fix this issue run the command 'echo never > /sys/kernel/mm/transparent_hugepage/enabled' as root, and add it to your /etc/rc.local in order to retain the setting after a reboot. Redis must be restarted after THP is disabled.
redis.default(O): 11329:M 11 Jul 03:39:16.037 * DB loaded from disk: 0.000 seconds
redis.default(O): 11329:M 11 Jul 03:39:16.037 * The server is now ready to accept connections on port 6379

✔ /home/habitat [jeremymv2/desired_state_for_svc_status L|✚ 2⚑ 11]
03:39 $ sudo -E RUST_LOG=info target/debug/hab svc status
package                          type        desired  state  elapsed (s)  pid    group
core/redis/3.2.4/20170514150022  standalone  up       up     9            11329  redis.default
chef/automate-elasticsearch/6.2.2/20180527141927  standalone  down  down  9   <none>  automate-elasticsearch.foobar

✔ /home/habitat [jeremymv2/desired_state_for_svc_status L|✚ 2⚑ 11]
03:39 $ grep desired /hab/sup/default/specs/*
/hab/sup/default/specs/automate-elasticsearch.spec:desired_state = "down"
/hab/sup/default/specs/redis.spec:desired_state = "up"
```

Signed-off-by: Jeremy J. Miller <jm@chef.io>