### PR TITLE
[common] Updates due to PackageTarget changes in habitat-sh/core#37.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -741,7 +741,7 @@ dependencies = [
 [[package]]
 name = "habitat_core"
 version = "0.0.0"
-source = "git+https://github.com/habitat-sh/core.git#979c7df8d70e7bf58747620054131020e401fa76"
+source = "git+https://github.com/habitat-sh/core.git#190e03c432b230baee2ccda7406e5f0e84b1c91a"
 dependencies = [
  "ansi_term 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -799,7 +799,7 @@ dependencies = [
 [[package]]
 name = "habitat_http_client"
 version = "0.0.0"
-source = "git+https://github.com/habitat-sh/core.git#979c7df8d70e7bf58747620054131020e401fa76"
+source = "git+https://github.com/habitat-sh/core.git#190e03c432b230baee2ccda7406e5f0e84b1c91a"
 dependencies = [
  "base64 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat_core 0.0.0 (git+https://github.com/habitat-sh/core.git)",
@@ -958,7 +958,7 @@ dependencies = [
 [[package]]
 name = "habitat_win_users"
 version = "0.0.0"
-source = "git+https://github.com/habitat-sh/core.git#979c7df8d70e7bf58747620054131020e401fa76"
+source = "git+https://github.com/habitat-sh/core.git#190e03c432b230baee2ccda7406e5f0e84b1c91a"
 dependencies = [
  "gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/hab/src/command/pkg/binlink.rs
+++ b/components/hab/src/command/pkg/binlink.rs
@@ -269,7 +269,7 @@ mod test {
         }
         let prefix = hcore::fs::pkg_install_path(&ident, Some(rootfs));
         write_file(prefix.join("IDENT"), &ident.to_string());
-        write_file(prefix.join("TARGET"), &PackageTarget::default().to_string());
+        write_file(prefix.join("TARGET"), PackageTarget::active_target());
         let mut paths = Vec::new();
         for (path, bins) in binaries {
             let abspath = hcore::fs::pkg_install_path(&ident, None::<&Path>).join(path);

--- a/components/pkg-export-docker/src/build.rs
+++ b/components/pkg-export-docker/src/build.rs
@@ -828,7 +828,7 @@ mod test {
             }
             let prefix = hcore::fs::pkg_install_path(&ident, Some(self.rootfs.as_path()));
             util::write_file(prefix.join("IDENT"), &ident.to_string()).unwrap();
-            util::write_file(prefix.join("TARGET"), &PackageTarget::default().to_string()).unwrap();
+            util::write_file(prefix.join("TARGET"), PackageTarget::active_target()).unwrap();
 
             util::write_file(prefix.join("SVC_USER"), &self.svc_user).unwrap();
             util::write_file(prefix.join("SVC_GROUP"), &self.svc_group).unwrap();


### PR DESCRIPTION
There are 2 primary changes:

* Account for the return type update on `PackageIdent.archive_name()` to
return a `Result<String>` rather than an `Option<String>`. You can see
with this update that we were hiding an error which was around passing a
non-fully qualified ident.
* Drop the `Target.validate()` implementation and rather compare
`PackageTarget` to `PackageTarget::is_active()` when verifying a
downloaded artifact.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>