### PR TITLE
Correct typographical issues in CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -12,7 +12,7 @@ The Habitat community contains a diverse group of professionals and volunteers w
 
 Be careful in the words that you choose. Be kind to others. Practice empathy. Don't insult or put down others. Remember that sexist, racist, ableist and other exclusionary jokes can be offensive to those around you. If you think your conversation is making another community member uncomfortable _or_ if they tell you so, stop immediately, make amends, and move forward.
 
-As you are working with other members of the community, please keep in mind the following guidelines, which apply equally to founders, mentors, those whom submit new features/pull requests, and to anyone who is seeking help and guidance.
+As you are working with other members of the community, please keep in mind the following guidelines, which apply equally to founders, mentors, those who submit new features/pull requests, and to anyone who is seeking help and guidance.
 
 The following list isn’t exhaustive; but these few examples can help all of us communicate well so that the community can work better together:
   * Use welcoming and inclusive language

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,101 +1,108 @@
 # Contributor Covenant Code of Conduct
 
 ## Our Pledge
+
 Diversity is one of the greatest strengths a community can have and many times that strength is born from the friction that can only come through sharing of differing perspectives.
 
 In the interest of fostering an open, welcoming, and encouraging environment, we as contributors, maintainers, and community members pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
 
 ## Our Standards
-Habitat is a diverse community of professionals and volunteers who come from all over the world to make Habitat better. Community members may fulfill many roles including mentoring, teaching, and connecting with other members of the community.
+
+The Habitat community contains a diverse group of professionals and volunteers who come from all over the world to make Habitat better. Community members may fulfill many roles including mentoring, teaching, and connecting with other members of the community.
 
 Be careful in the words that you choose. Be kind to others. Practice empathy. Don't insult or put down others. Remember that sexist, racist, ableist and other exclusionary jokes can be offensive to those around you. If you think your conversation is making another community member uncomfortable _or_ if they tell you so, stop immediately, make amends, and move forward.
 
-As you are working with other members of the community, please keep in mind the following guidelines, which apply equally to founders, mentors, those who submit new features and pull requests, and to anyone who is seeking help and guidance.
+As you are working with other members of the community, please keep in mind the following guidelines, which apply equally to founders, mentors, those whom submit new features/pull requests, and to anyone who is seeking help and guidance.
 
 The following list isn’t exhaustive; but these few examples can help all of us communicate well so that the community can work better together:
-* Use welcoming and inclusive language
-* Exercise patience and friendliness
-* Be respectful of differing viewpoints and experiences
-* Gracefully accept constructive criticism
-* Focus on what is best for the community
-* Show empathy towards other community members
+  * Use welcoming and inclusive language
+  * Exercise patience and friendliness
+  * Be respectful of differing viewpoints and experiences
+  * Gracefully accept constructive criticism
+  * Focus on what is best for the community
+  * Show empathy towards other community members
 
 The previous list applies to all forms of communication: Slack (or any web chat), discourse, the issue tracker, and any other forum that is used by the community.
 
 Please keep in mind that:
-  * Your work will be used by other people, and you, in turn, will depend on the work of others.
-  * Decisions that you make will often affect others in the community.
-  * Disagreements happen, but should not be an excuse for poor behavior and bad manners. When disagreements do happen, let’s work together to solve them effectively and in a way that ensures that everyone understands what the disagreement was.
-  * Our community spans languages, cultures, perspectives (and continents!), and as such people may not understand jokes, sarcasm, and oblique references in the same way that you do. So remember that and be kind to the other members of the community.
-  * Sexist, racist, ableist and other prejudicial or exclusionary comments are not welcome in the community.
+  * Your work will be used by other people, and you, in turn, will depend on the work of others
+  * Decisions that you make will often affect others in the community
+  * Disagreements happen, but should not be an excuse for poor behavior and bad manners. When disagreements do happen, let’s work together to solve them effectively and in a way that ensures that everyone understands what the disagreements were
+  * Our community spans languages, cultures, perspectives (and continents!), and as such people may not understand jokes, sarcasm, and oblique references in the same way that you do. So remember that and be kind to the other members of the community
+  * Sexist, racist, ableist and other prejudicial or exclusionary comments are not welcome in the community
 
 ## Unacceptable Behavior
+
 Harassment comes in many forms, including but not limited to: offensive verbal or written comments related to gender, sexual orientation, disability, physical appearance, body size, race, religion, and sexual images.
 
 As a community that meets in physical public spaces, harassment also includes: stalking, persistent following, intrusive or otherwise unwanted photography or recording, sustained disruption of talks or other events, inappropriate physical contact, and unwelcome sexual attention.
 
 Examples of other unacceptable behaviors by participants include but are not limited to:
-  * The use of sexualized language or imagery and unwelcome sexual attention or
-advances.
-  * Threats or violent language directed against another person.
-  * Posting sexually explicit or violent material.
-  * Sexist, racist, homophobic, transphobic, ableist, or otherwise discriminatory jokes and language.
-  * Trolling, insulting/derogatory comments, and personal or political attacks particulary those related to gender, sexual orientation, race, religion or disability.
-  * Public or private harassment.
+  * The use of sexualized language or imagery and unwelcome sexual attention or advances
+  * Threats or violent language directed against another person
+  * Posting sexually explicit or violent material
+  * Sexist, racist, homophobic, transphobic, ableist, or otherwise discriminatory jokes and language
+  * Trolling, insulting/derogatory comments, and personal or political attacks particularly those related to gender, sexual orientation, race, religion or disability
+  * Public or private harassment
   * Publishing others' private information, such as a physical or electronic address, without explicit permission ("doxing")
   * Other conduct which could reasonably be considered inappropriate in a professional setting
 
 If you have any lack of clarity about behaviors we include in the definition of "harassment", please read the [Citizen Code of Conduct](http://citizencodeofconduct.org/). In particular, we don’t tolerate behavior that excludes people in socially marginalized groups.
 
 ## Enforcement/Getting Help
-Instances of abusive, harassing, or otherwise unacceptable should be reported by contacting any of the Community Advocates or the Community Manager directly. Each person's contact information and role is listed below. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior should be reported by contacting any of the Community Advocates or the Community Manager directly. Each person's contact information and role is listed below. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Community Organizers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 
 ## Roles
+
 The following are the various roles of our <b>Community Organizers</b> and the person(s) assigned to each role:
   * The <b>Decider</b> has final say on community guidelines and final authority on correct actions and appeals. The top-level decider is [Adam Jacob](mailto:adam@habitat.sh), [@adamhjk](https://twitter.com/adamhjk)
-  * The <b>Community Manager</b> guides and meets regularly with community advocates, helps enforce corrective actions, hears appeals, is responsible for maintaining a list of incidents, and ensures incident responders have support in incident documentation as outlined below. The Community Manager is [Ian Henry](mailto:ian@habitat.sh), [@eeyun___](https://twitter.com/eeyun___).
+  * The <b>Community Manager</b> guides and meets regularly with community advocates, helps enforce corrective actions, hears appeals, is responsible for maintaining a list of incidents, and ensures incident responders have support in incident documentation as outlined below. The Community Manager is [Ian Henry](mailto:ian@habitat.sh), [@eeyun\_\_\_](https://twitter.com/eeyun\_\_\_)
   * <b>Community Advocates</b> may be assigned for each area where the community convenes online (IRC, email list, GitHub, etc.). Community Advocates are volunteers who have the best interests of our community in mind. They act in good faith to help enforce our community guidelines and respond to incidents when they occur. Our Community Advocates are
     - [Tasha Drew](mailto:tasha@habitat.sh), [@tashadrew](https://twitter.com/tashadrew)
     - [Nell Shamrell-Harrington](mailto:nshamrell@habitat.sh), [@nellshamrell](https://twitter.com/nellshamrell)
     - [Ben Dang](mailto:me@bdang.it), [@bdangit](https://twitter.com/bdangit)
-  * The <b>Project Maintainers</b> are likewise expected to conduct their behavior in line with the Code of Conduct and are individually responsible for both escalating to a <b>Community Advocate</b> in case of witnessing an incident and helping to foster the community and it's members.
-  * A <b>Community Member</b> is anyone who participates with the community whether in-person or via online channels. Community members are responsible for following the community guidelines, suggesting updates to the guidelines when warranted, and helping enforce community guidelines.
+  * The <b>Project Maintainers</b> are likewise expected to conduct their behavior in line with the Code of Conduct and are individually responsible for both escalating to a <b>Community Advocate</b> in case of witnessing an incident and helping to foster the community and it's members
+  * A <b>Community Member</b> is anyone who participates with the community whether in-person or via online channels. Community members are responsible for following the community guidelines, suggesting updates to the guidelines when warranted, and helping enforce community guidelines
 
 ## Consequences of Unacceptable Behavior
+
 Unacceptable behavior from any community member, including sponsors and those with decision-making authority, will *not* be tolerated.
 
 Anyone asked to stop unacceptable behavior is expected to comply immediately.
 
-If a community member engages in unacceptable behavior, the community organizers may take action they deem appropriate, up to and including temporary ban or permanent expulsion from the community _without warning_ (and without refund in the case of a paid event). If you have been involved in unacceptable behavior with current Habitat community members outside the boundaries of the Habitat Community, the Community Organizers retain the right to treat those external incidents in the same manner as internal incidents.
+If a community member engages in unacceptable behavior, the community organizers may take action they deem appropriate, up to and including a temporary ban or permanent expulsion from the community _without warning_ (and without refund in the case of a paid event). If you have been involved in unacceptable behavior with current Habitat community members outside the boundaries of the Habitat Community, the Community Organizers retain the right to treat those external incidents in the same manner as internal incidents.
 
 Any physical violence _or_ intimidation, threatened or acted on, is a serious offense and will result in immediate exclusion from the community and appropriate follow up with law enforcement (no, we're not kidding).
 
 ## Procedure for Handling Disagreements and Incidents
+
 Disagreements are inherent to a group of impassioned people. When they occur, we seek to resolve disagreements and differing views constructively and with the help of the community and community processes. When disagreements escalate, we ask our community advocates to step in to moderate, mediate, and help resolve tense situations.
 
-The Habitat Community advocates are well informed on how to deal with incidents. Report the incident (preferably in writing) to one of the community advocates listed above. See the "Roles" section for details on each role.
+The Habitat Community advocates are well informed on how to deal with incidents. Report the incident (preferably in writing) to one of the community advocates listed above. See the [Roles](#roles) section for details on each role.
 
 ### Handling Incidents
 
-When a Community Organizer or Project Maintainer notices someone behaving in a way that is outside of our guidelines (a violator) the Advocate should make every reasonable attempt to help curtail that behavior.  The Advocate may:
+When a Community Organizer or Project Maintainer notices someone behaving in a way that is outside of our guidelines (a violator) the Advocate should make every reasonable attempt to help curtail that behavior. The Advocate may:
 
-  * Remind the violator about our Community Code of Conduct and provide a link to this document.
-  * Ask the violator to stop the unacceptable behavior.
-  * Raise the issue with a maintainer, the community manager, or any member of the core project team.
-  * Allow time for the violator to correct the behavior.
+  * Remind the violator about our Community Code of Conduct and provide a link to this document
+  * Ask the violator to stop the unacceptable behavior
+  * Raise the issue with a maintainer, the community manager, or any member of the core project team
+  * Allow time for the violator to correct the behavior
 
-The Advocate should take the following steps if the behavior is not brought inline with our guidelines or the incident is not resolved.
+The Advocate should take the following steps if the behavior is not brought inline with our guidelines or the incident is not resolved:
 
-  * Consult with another Community Organizer to make a judgement call about what reasonable corrective actions are warranted.
-  * In the case that no conclusion can be made, escalate to include the next level of Community Organizer
-  * If still no conclusion can be made, report the incident to the <b>Decider</b> listed above.
-  * Apply the corrective action.
-  * Document the incident as described below.
+  * Consult with another Community Organizer to make a judgement call about what reasonable corrective actions are warranted
+  * In the case that no conclusion can be made, escalate to include the next level of Community Organizers
+  * If still no conclusion can be made, report the incident to the <b>Decider</b> listed above
+  * Apply the corrective action
+  * Document the incident as described below
 
 #### Documenting Incidents
-All incident reports will be kept in a private repository that is shared with the aforementioned Community Advocates, Community Manager and Decider under the *Roles* section. No other individuals or project contributors will be given access to these incident reports. <b>This repo will hold no personal information on the victim of an incident</b>. On the displacement of any Community Organizer in the *Roles* list above, that individual will immediately lose access to this repository and will terminate any local copies of the repository.
+
+All incident reports will be kept in a private repository that is shared with the aforementioned Community Advocates, Community Manager and Decider under the [Roles](#roles) section. No other individuals or project contributors will be given access to these incident reports. <b>This repo will hold no personal information on the victim of an incident</b>. On the displacement of any Community Organizer in the [Roles](#roles) list above, that individual will immediately lose access to this repository and will terminate any local copies of the repository.
 
 The important information to report consists of:
 
@@ -103,7 +110,7 @@ The important information to report consists of:
   * The behavior that was in violation
   * The approximate time of the behavior
   * The circumstances surrounding the incident
-  * Where applicaple, contextual information/proof (email body, chat log, GH Issue)
+  * Where applicable, contextual information/proof (email body, chat log, GitHub Issue)
   * Contact information for witnesses to the incident
 
 If you feel your safety is in jeopardy please do not hesitate to contact local law enforcement.
@@ -115,14 +122,14 @@ If you feel your safety is in jeopardy please do not hesitate to contact local l
 
 Community Organizers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
 
-Community Organizers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, messages, tweets and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+Community Organizers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, messages, tweets, and other contributions that are not aligned with this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
 
 ## Scope
+
 Our community will convene in both physical and virtual spaces and this Code of Conduct applies within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers and community organizers.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version] and leans on both the [Rust Code of Conduct](https://www.rust-lang.org/en-US/conduct.html) and the [Citizen Code of Conduct](http://citizencodeofconduct.org/). This document has also been inspired and adapted from the [Chef Community Guidelines](https://github.com/chef/chef-rfc/blob/master/rfc020-community-guidelines.md).
+This Code of Conduct is adapted from the [Contributor Covenant](http://contributor-covenant.org), version 1.4, available at [http://contributor-covenant.org/version/1/4](http://contributor-covenant.org/version/1/4/) and leans on both the [Rust Code of Conduct](https://www.rust-lang.org/en-US/conduct.html) and the [Citizen Code of Conduct](http://citizencodeofconduct.org/).
 
-[homepage]: http://contributor-covenant.org
-[version]: http://contributor-covenant.org/version/1/4/
+This document has also been inspired and adapted from the [Chef Community Guidelines](https://github.com/chef/chef-rfc/blob/master/rfc020-community-guidelines.md).


### PR DESCRIPTION
This does the following:
  - Adds newlines under each heading
  - Corrects some spelling/grammar errors
  - Makes several (admittedly subjective) style changes (e.g. removing periods from line endings in bullets)
  - Adds internal links for the `Roles` section

Please feel free to disregard/reject any changes. I can revert or you can modify the PR. Up to you.