### PR TITLE
Update to allow postrun to only run after a successful HealthCheck

### DIFF
--- a/components/sup/src/manager/service/mod.rs
+++ b/components/sup/src/manager/service/mod.rs
@@ -103,6 +103,7 @@ pub struct Service {
     pub pkg: Pkg,
     pub sys: Arc<Sys>,
     pub initialized: bool,
+    pub postrun: bool,
     pub user_config_updated: bool,
 
     #[serde(skip_serializing)]
@@ -186,6 +187,7 @@ impl Service {
                 fs::svc_hooks_path(&service_group.service()),
             ),
             initialized: false,
+            postrun: false,
             last_election_status: ElectionStatus::None,
             needs_reload: false,
             needs_reconfiguration: false,
@@ -259,6 +261,7 @@ impl Service {
         } else {
             self.needs_reload = false;
             self.needs_reconfiguration = false;
+            self.postrun = false;
         }
     }
 
@@ -680,7 +683,12 @@ impl Service {
     }
 
     fn post_run(&mut self) {
+        if self.postrun {
+            return;
+        }
+        self.postrun = true;
         if let Some(ref hook) = self.hooks.post_run {
+            outputln!(preamble self.service_group, "Execute Postrun hook");
             hook.run(
                 &self.service_group,
                 &self.pkg,
@@ -812,9 +820,11 @@ impl Service {
             self.initialize();
             if self.initialized {
                 self.start(launcher);
-                self.post_run();
             }
         } else {
+            if !self.postrun && self.health_check == HealthCheck::Ok {
+                self.post_run();
+            }
             self.check_process();
             match self.last_health_check {
                 Some(last_check) => {
@@ -902,6 +912,7 @@ impl Service {
             }
         };
         self.last_health_check = Some(Instant::now());
+        self.health_check=check_result;
         self.cache_health_check(check_result);
     }
 


### PR DESCRIPTION
Three changes:

- postrun removed from run on init to run exactly once after HealthCheck is OK
- re-run postrun after each service Start
- changed self.health_check so it gets assigned (it didn't before)

This does somewhat change the behaviour of postrun, which used to only
run at init - this part can be backed out if needed.

