### PR TITLE
Add variants support to plan-build

### DIFF
--- a/components/plan-build-ps1/bin/hab-plan-build.ps1
+++ b/components/plan-build-ps1/bin/hab-plan-build.ps1
@@ -2070,27 +2070,51 @@ if (-Not (Test-Path "$Context")) {
 }
 $script:PLAN_CONTEXT = (Get-Item $Context).FullName
 
-# Now to ensure a `plan.ps1` exists where we expect it. There are 2 possible
-# candidate locations relative to the `$PLAN_CONTEXT` directory: a `./plan.ps1`
-# or a `./habitat/plan.ps1`. Only one or the other location is allowed so that
-# a Plan author isn't confused if they edit one to have this program read
-# the other.
+# Now to ensure a `plan.ps1` exists where we expect it. There are 4 possible
+# candidate locations relative to the `$PLAN_CONTEXT` directory: 
+#   `./plan.ps1`
+#   `./habitat/plan.ps1`
+#   `./$pkg_target/plan.ps1`
+#   `./habitat/$pkg_target/plan.ps1`
+# In most cases, Plan authors should use the default location of `./plan.ps1`
+# or `./habitat/plan.ps1`.  The exception to this is when the $pkg_target 
+# requires variations to the default `plan.ps1`. Plan authors can create these 
+# variants by placing a plan file in the appropriate $pkg_target directory 
+# relative to the default plan.ps1.
+#
+# With plan variants, plans can exist in 4 places per $pkg_target relative to 
+# the `$PLAN_CONTEXT` directory. Only two combinations are allowed:
+#
+#   `./plan.ps1` AND `./$pkg_target/plan.ps1` 
+#   OR 
+#   `./habitat/plan.ps1` AND `./habitat/$pkg_target/plan.ps1`
+# Consider all other combination of two plans invalid and abort if found.
 
-# We'll make sure that both are not present, and if so abort.
-if ((Test-Path "$PLAN_CONTEXT\plan.ps1") -and (Test-Path "$PLAN_CONTEXT\habitat\plan.ps1")) {
-    $places = "$PLAN_CONTEXT\plan.ps1 and $PLAN_CONTEXT\habitat\plan.ps1"
-    _Exit-With "A Plan file was found at $places. Only one is allowed at a time" 42
+# ** Internal ** Relative to the current plan context,  check for a variant
+#   that matches the current $pkg_target, and update $PLAN_CONTEXT if found.
+function _Check-For-Plan-Variant {
+  if (Test-Path "$PLAN_CONTEXT\$pkg_target\plan.ps1") {
+    $PLAN_CONTEXT = "$PLAN_CONTEXT\$pkg_target" 
+  }
 }
-# We check if the provided path has a `plan.ps1` in it in either location. If
-# not, we'll quickly bail.
-if (-Not (Test-Path "$PLAN_CONTEXT\plan.ps1")) {
+
+# Look for a plan.ps1 relative to the $PLAN_CONTEXT. If we find an invalid 
+#   combination or are unable to find a plan.ps1,  abort with a message to the 
+#   user with the failure case. 
+if (Test-Path "$PLAN_CONTEXT\plan.ps1") {
     if (Test-Path "$PLAN_CONTEXT\habitat\plan.ps1") {
-        $PLAN_CONTEXT = "$PLAN_CONTEXT\habitat"
-    } else {
-        $places = "$PLAN_CONTEXT\plan.ps1 or $PLAN_CONTEXT\habitat\plan.ps1"
-        _Exit-With "Plan file not found at $places" 42
+        $places = "$PLAN_CONTEXT\plan.ps1 and $PLAN_CONTEXT\habitat\plan.ps1"
+        _Exit-With "A Plan file was found at $places. Only one is allowed at a time" 42
     }
+    _Check-For-Plan-Variant
+} elseif (Test-Path "$PLAN_CONTEXT\habitat\plan.ps1") {
+    PLAN_CONTEXT = "$PLAN_CONTEXT\habitat"
+    _Check-For-Plan-Variant
+} else
+    $places = "$PLAN_CONTEXT\plan.ps1 or $PLAN_CONTEXT\habitat\plan.ps1"
+    _Exit-With "Plan file not found at $places" 42
 }
+
 
 # We want to fail the build for both termionating and non terminating errors
 $ErrorActionPreference = "Stop"

--- a/components/plan-build-ps1/bin/hab-plan-build.ps1
+++ b/components/plan-build-ps1/bin/hab-plan-build.ps1
@@ -2094,7 +2094,9 @@ $script:PLAN_CONTEXT = (Get-Item $Context).FullName
 #   that matches the current $pkg_target, and update $PLAN_CONTEXT if found.
 function _Check-For-Plan-Variant {
   if (Test-Path "$PLAN_CONTEXT\$pkg_target\plan.ps1") {
-    $PLAN_CONTEXT = "$PLAN_CONTEXT\$pkg_target" 
+    Write-BuildLine "Detected Plan Variant!"
+    $script:PLAN_CONTEXT = "$PLAN_CONTEXT\$pkg_target"
+    Write-BuildLine "$PLAN_CONTEXT"
   }
 }
 
@@ -2108,9 +2110,9 @@ if (Test-Path "$PLAN_CONTEXT\plan.ps1") {
     }
     _Check-For-Plan-Variant
 } elseif (Test-Path "$PLAN_CONTEXT\habitat\plan.ps1") {
-    PLAN_CONTEXT = "$PLAN_CONTEXT\habitat"
+    $script:PLAN_CONTEXT = "$PLAN_CONTEXT\habitat"
     _Check-For-Plan-Variant
-} else
+} else {
     $places = "$PLAN_CONTEXT\plan.ps1 or $PLAN_CONTEXT\habitat\plan.ps1"
     _Exit-With "Plan file not found at $places" 42
 }

--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -2340,8 +2340,8 @@ THIS_PROGRAM=$(abspath "$0")
 # candidate locations relative to the `$PLAN_CONTEXT` directory: 
 #   `./plan.sh`
 #   `./habitat/plan.sh`
-#   `./$pkg_target/plan.sh
-#   `./habitat/$pkg_target/plan.sh 
+#   `./$pkg_target/plan.sh`
+#   `./habitat/$pkg_target/plan.sh`
 # In most cases, Plan authors should use the default location of `./plan.sh`
 # or `./habitat/plan.sh`.  The exception to this is when the $pkg_target 
 # requires variations to the default `plan.sh`. Plan authors can create these 


### PR DESCRIPTION
@fnichol @nellshamrell @scotthain  This is the implementation of "plan variants" support for shell.    

I've captured the inline docs below as a point of reference for the 'why' of what we're doing.   If the logic and implementation are sound, I think it would be worth including the powershell version in this PR as well to keep consistency between the two. 

Word-smithing for clarity would be appreciated as well 😸 

```
Now to ensure a `plan.sh` exists where we expect it. There are 4 possible
candidate locations relative to the `$PLAN_CONTEXT` directory:
  `./plan.sh`
  `./habitat/plan.sh`
  `./$pkg_target/plan.sh
  `./habitat/$pkg_target/plan.sh
In most cases, only one location is allowed so that a Plan author isn't
confused if they edit one to have this program read the other.
The exception to this is when the $pkg_target requires variations to
the default `plan.sh`. Plan authors can create these variants by placeing
Plan contents in a subdirectory named the same as the intended $pkg_target.
In this case, we want to check if there is a variant `plan.sh` available
for the $pkg_target, and prefer loading that one. Alternate $pkg_target
are not considered as part of this load logic.

With plan variants, plans can exist in 4 places per $pkg_target relative to
the `$PLAN_CONTEXT` directory. Only two combinations are allowed:

  `./plan.sh` AND `./$pkg_target/plan.sh`
  OR
  `./habitat/plan.sh` AND `./habitat/$pkg_target/plan.sh`
Consider all other combination of two plans and abort if found.
All combinations of 3 and 4 plans are covered by a 2 plan case, so we don't
need to consider those scenarios.
```
![plan-gif](https://media1.tenor.com/images/ad1a52a0c5645e11001341018519b7bb/tenor.gif?itemid=4859983)

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>