### PR TITLE
Make sup-run launch the supervisor in its own session, detached from the TTY

### DIFF
--- a/components/rootless_studio/default/profile
+++ b/components/rootless_studio/default/profile
@@ -57,7 +57,8 @@ sup-run() {
   mkdir -p /hab/sup/default
   echo "--> Launching the Habitat Supervisor in the background..."
   echo "    Running: hab sup run $*"
-  hab sup run "$@" > /hab/sup/default/sup.log 2>&1 &
+  setsid hab sup run "$@" > /hab/sup/default/sup.log 2>&1 &
+  disown $!
   echo "    * Use 'hab svc start' & 'hab svc stop' to start and stop services"
   echo "    * Use 'sup-log' to tail the Supervisor's output (Ctrl+c to stop)"
   echo "    * Use 'sup-term' to terminate the Supervisor"

--- a/components/studio/libexec/hab-studio-type-default.sh
+++ b/components/studio/libexec/hab-studio-type-default.sh
@@ -159,7 +159,8 @@ sup-run() {
   mkdir -p /hab/sup/default
   echo "--> Launching the Habitat Supervisor in the background..."
   echo "    Running: hab sup run \$@"
-  hab sup run "\$@" > /hab/sup/default/sup.log 2>&1 &
+  setsid hab sup run "\$@" > /hab/sup/default/sup.log 2>&1 &
+  disown \$!
   echo "    * Use 'hab svc start' & 'hab svc stop' to start and stop services"
   echo "    * Use 'sup-log' to tail the Supervisor's output (Ctrl+c to stop)"
   echo "    * Use 'sup-term' to terminate the Supervisor"


### PR DESCRIPTION
1. Use setsid to start the supervisor in its own session and process group.
   It's the process group that's important, though since that prevents it from
   being killed by a stray ^c on the CLI. That SIGINT goes to the entire
   process group, and when sup-run is executed as part of the profile startup,
   the hab-launch process will share the same process group.

2. Use disown to remove the supervisor jobspec from the list of active jobs.
   This prevents it from showing up in `jobs` output and from being brought
   to the foreground. There's no need to do that since, `sup-log` and
   `sup-term` still work to view logs and stop the supervisor.

Revolves https://github.com/habitat-sh/habitat/issues/5312
Resolves https://github.com/habitat-sh/habitat/issues/4397
Resolves https://github.com/habitat-sh/habitat/issues/5271

Signed-off-by: Jon Bauman <5906042+baumanj@users.noreply.github.com>