### PR TITLE
Fix pacakge typo to package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4989,7 +4989,7 @@
 - Update `make gpg` instructions in README. [\#239](https://github.com/habitat-sh/habitat/pull/239) ([fnichol](https://github.com/fnichol))
 - build deps in a post studio world [\#238](https://github.com/habitat-sh/habitat/pull/238) ([jtimberman](https://github.com/jtimberman))
 - \[plan\] Add diffutils to the backline plan. [\#237](https://github.com/habitat-sh/habitat/pull/237) ([fnichol](https://github.com/fnichol))
-- \[bpm\] Allow `bpm install` to complete if no remote pacakge is found. [\#236](https://github.com/habitat-sh/habitat/pull/236) ([fnichol](https://github.com/fnichol))
+- \[bpm\] Allow `bpm install` to complete if no remote package is found. [\#236](https://github.com/habitat-sh/habitat/pull/236) ([fnichol](https://github.com/fnichol))
 - Fix node plan, add python plans [\#235](https://github.com/habitat-sh/habitat/pull/235) ([jtimberman](https://github.com/jtimberman))
 - \[bldr-build\] need quoting for wildcards [\#234](https://github.com/habitat-sh/habitat/pull/234) ([jtimberman](https://github.com/jtimberman))
 - Remove etcd container from compose [\#233](https://github.com/habitat-sh/habitat/pull/233) ([juliandunn](https://github.com/juliandunn))

--- a/components/pkg-export-docker/src/build.rs
+++ b/components/pkg-export-docker/src/build.rs
@@ -400,7 +400,7 @@ impl BuildRoot {
     }
 }
 
-/// The file system contents, location, Habitat pacakges, and other context for a build root.
+/// The file system contents, location, Habitat packages, and other context for a build root.
 #[derive(Debug)]
 pub struct BuildRootContext {
     /// A list of all Habitat service and library packages which were determined from the original

--- a/components/plan-build-ps1/bin/hab-plan-build.ps1
+++ b/components/plan-build-ps1/bin/hab-plan-build.ps1
@@ -368,7 +368,7 @@ function _Set-BuildPath {
 # At this phase of the build, all dependencies are downloaded, the build
 # environment is set, but this is just before any source downloading would
 # occur (if `$pkg_source` is set). This could be a suitable phase in which to
-# compute a dynamic version of a pacakge given the state of a Git repository,
+# compute a dynamic version of a package given the state of a Git repository,
 # fire an API call, start timing something, etc.
 function Invoke-Before {
   Invoke-DefaultBefore
@@ -1871,7 +1871,7 @@ $(Get-Content "$PLAN_CONTEXT\plan.ps1" -Raw)
 # * `$pkg_prefix/LD_RUN_PATH` - The LD_RUN_PATH for things that link against us
 # * `$pkg_prefix/PATH` - Any PATH entries for things that link against us
 function _Write-Metadata {
-    Write-BuildLine "Building pacakge metadata"
+    Write-BuildLine "Building package metadata"
 
     $prefixDrive = (Resolve-Path $originalPath).Drive.Root
     $strippedPrefix = $pkg_prefix.Substring($prefixDrive.length)

--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -1534,7 +1534,7 @@ EOF
 # At this phase of the build, all dependencies are downloaded, the build
 # environment is set, but this is just before any source downloading would
 # occur (if `$pkg_source` is set). This could be a suitable phase in which to
-# compute a dynamic version of a pacakge given the state of a Git repository,
+# compute a dynamic version of a package given the state of a Git repository,
 # fire an API call, start timing something, etc.
 do_before() {
   do_default_before

--- a/www/source/partials/docs/_reference-callbacks.html.md.erb
+++ b/www/source/partials/docs/_reference-callbacks.html.md.erb
@@ -80,7 +80,7 @@ In all cases, when Habitat is assuming a default strategy, it will emit log mess
 > **Note** If you discover common environment variables that Habitat doesn't currently treat appropriately, feel free to request an addition to the codebase, or even to submit a pull request yourself.
 
 **do_before()/Invoke-Before**
-: At this phase of the build, the origin key has been checked for, all package dependencies have been resolved and downloaded, and the `$PATH` and environment are set, but this is just before any source downloading would occur (if `$pkg_source` is set). This could be a suitable phase in which to compute a dynamic version of a pacakge given the state of a Git repository, fire an API call, start timing something, etc.
+: At this phase of the build, the origin key has been checked for, all package dependencies have been resolved and downloaded, and the `$PATH` and environment are set, but this is just before any source downloading would occur (if `$pkg_source` is set). This could be a suitable phase in which to compute a dynamic version of a package given the state of a Git repository, fire an API call, start timing something, etc.
 
 **do_before_default()/Invoke-BeforeDefault**
 : There is an empty default implementation of this callback.


### PR DESCRIPTION
Typo is most visible in Windows plans which outputs

> Building pacakge metadata

at the end of every build. Fixed all occurrences in master for completeness. 