### PR TITLE
[plan-build] Set `$pkg_target` at build time for build programs.

### DIFF
--- a/components/hab/plan.ps1
+++ b/components/hab/plan.ps1
@@ -17,7 +17,6 @@ function Invoke-Prepare {
     }
 
     $env:SSL_CERT_FILE              = "$(Get-HabPackagePath "cacerts")/ssl/certs/cacert.pem"
-    $env:PLAN_VERSION               = "$pkg_version/$pkg_release"
     $env:LIB                        += ";$HAB_CACHE_SRC_PATH/$pkg_dirname/lib"
     $env:INCLUDE                    += ";$HAB_CACHE_SRC_PATH/$pkg_dirname/include"
     $env:SODIUM_LIB_DIR             = "$HAB_CACHE_SRC_PATH/$pkg_dirname/lib"
@@ -26,6 +25,14 @@ function Invoke-Prepare {
     $env:OPENSSL_LIBS               = 'ssleay32:libeay32'
     $env:OPENSSL_LIB_DIR            = "$HAB_CACHE_SRC_PATH/$pkg_dirname/lib"
     $env:OPENSSL_INCLUDE_DIR        = "$HAB_CACHE_SRC_PATH/$pkg_dirname/include"
+
+    # Used by the `build.rs` program to set the version of the binaries
+    $env:PLAN_VERSION = "$pkg_version/$pkg_release"
+    Write-BuildLine "Setting env:PLAN_VERSION=$env:PLAN_VERSION"
+
+    # Used to set the active package target for the binaries at build time
+    $env:PLAN_PACKAGE_TARGET = "$pkg_target"
+    Write-BuildLine "Setting env:PLAN_PACKAGE_TARGET=$env:PLAN_PACKAGE_TARGET"
 }
 
 function Invoke-Unpack {

--- a/components/hab/plan.sh
+++ b/components/hab/plan.sh
@@ -33,6 +33,10 @@ _common_prepare() {
   export PLAN_VERSION="${pkg_version}/${pkg_release}"
   build_line "Setting PLAN_VERSION=$PLAN_VERSION"
 
+  # Used to set the active package target for the binaries at build time
+  export PLAN_PACKAGE_TARGET="$pkg_target"
+  build_line "Setting PLAN_PACKAGE_TARGET=$PLAN_PACKAGE_TARGET"
+
   if [ -z "$HAB_CARGO_TARGET_DIR" ]; then
     # Used by Cargo to use a pristine, isolated directory for all compilation
     export CARGO_TARGET_DIR="$HAB_CACHE_SRC_PATH/$pkg_dirname"

--- a/components/pkg-export-docker/plan.ps1
+++ b/components/pkg-export-docker/plan.ps1
@@ -18,7 +18,6 @@ function Invoke-Prepare {
     }
 
     $env:SSL_CERT_FILE              = "$(Get-HabPackagePath "cacerts")/ssl/certs/cacert.pem"
-    $env:PLAN_VERSION               = "$pkg_version/$pkg_release"
     $env:LIB                        += ";$HAB_CACHE_SRC_PATH/$pkg_dirname/lib"
     $env:INCLUDE                    += ";$HAB_CACHE_SRC_PATH/$pkg_dirname/include"
     $env:SODIUM_LIB_DIR             = "$HAB_CACHE_SRC_PATH/$pkg_dirname/lib"
@@ -27,6 +26,14 @@ function Invoke-Prepare {
     $env:OPENSSL_LIBS               = 'ssleay32:libeay32'
     $env:OPENSSL_LIB_DIR            = "$HAB_CACHE_SRC_PATH/$pkg_dirname/lib"
     $env:OPENSSL_INCLUDE_DIR        = "$HAB_CACHE_SRC_PATH/$pkg_dirname/include"
+
+    # Used by the `build.rs` program to set the version of the binaries
+    $env:PLAN_VERSION = "$pkg_version/$pkg_release"
+    Write-BuildLine "Setting env:PLAN_VERSION=$env:PLAN_VERSION"
+
+    # Used to set the active package target for the binaries at build time
+    $env:PLAN_PACKAGE_TARGET = "$pkg_target"
+    Write-BuildLine "Setting env:PLAN_PACKAGE_TARGET=$env:PLAN_PACKAGE_TARGET"
 }
 
 function Invoke-Unpack {

--- a/components/pkg-export-docker/plan.sh
+++ b/components/pkg-export-docker/plan.sh
@@ -34,6 +34,10 @@ _common_prepare() {
   export PLAN_VERSION="${pkg_version}/${pkg_release}"
   build_line "Setting PLAN_VERSION=$PLAN_VERSION"
 
+  # Used to set the active package target for the binaries at build time
+  export PLAN_PACKAGE_TARGET="$pkg_target"
+  build_line "Setting PLAN_PACKAGE_TARGET=$PLAN_PACKAGE_TARGET"
+
   if [ -z "$HAB_CARGO_TARGET_DIR" ]; then
     # Used by Cargo to use a pristine, isolated directory for all compilation
     export CARGO_TARGET_DIR="$HAB_CACHE_SRC_PATH/$pkg_dirname"

--- a/components/pkg-export-helm/plan.sh
+++ b/components/pkg-export-helm/plan.sh
@@ -33,6 +33,10 @@ _common_prepare() {
   export PLAN_VERSION="${pkg_version}/${pkg_release}"
   build_line "Setting PLAN_VERSION=$PLAN_VERSION"
 
+  # Used to set the active package target for the binaries at build time
+  export PLAN_PACKAGE_TARGET="$pkg_target"
+  build_line "Setting PLAN_PACKAGE_TARGET=$PLAN_PACKAGE_TARGET"
+
   if [ -z "$HAB_CARGO_TARGET_DIR" ]; then
     # Used by Cargo to use a pristine, isolated directory for all compilation
     export CARGO_TARGET_DIR="$HAB_CACHE_SRC_PATH/$pkg_dirname"

--- a/components/pkg-export-kubernetes/plan.sh
+++ b/components/pkg-export-kubernetes/plan.sh
@@ -32,6 +32,10 @@ _common_prepare() {
   export PLAN_VERSION="${pkg_version}/${pkg_release}"
   build_line "Setting PLAN_VERSION=$PLAN_VERSION"
 
+  # Used to set the active package target for the binaries at build time
+  export PLAN_PACKAGE_TARGET="$pkg_target"
+  build_line "Setting PLAN_PACKAGE_TARGET=$PLAN_PACKAGE_TARGET"
+
   if [ -z "$HAB_CARGO_TARGET_DIR" ]; then
     # Used by Cargo to use a pristine, isolated directory for all compilation
     export CARGO_TARGET_DIR="$HAB_CACHE_SRC_PATH/$pkg_dirname"

--- a/components/pkg-export-tar/plan.ps1
+++ b/components/pkg-export-tar/plan.ps1
@@ -17,7 +17,6 @@ function Invoke-Prepare {
     }
 
     $env:SSL_CERT_FILE              = "$(Get-HabPackagePath "cacerts")/ssl/certs/cacert.pem"
-    $env:PLAN_VERSION               = "$pkg_version/$pkg_release"
     $env:LIB                        += ";$HAB_CACHE_SRC_PATH/$pkg_dirname/lib"
     $env:INCLUDE                    += ";$HAB_CACHE_SRC_PATH/$pkg_dirname/include"
     $env:SODIUM_LIB_DIR             = "$HAB_CACHE_SRC_PATH/$pkg_dirname/lib"
@@ -26,6 +25,14 @@ function Invoke-Prepare {
     $env:OPENSSL_LIBS               = 'ssleay32:libeay32'
     $env:OPENSSL_LIB_DIR            = "$HAB_CACHE_SRC_PATH/$pkg_dirname/lib"
     $env:OPENSSL_INCLUDE_DIR        = "$HAB_CACHE_SRC_PATH/$pkg_dirname/include"
+
+    # Used by the `build.rs` program to set the version of the binaries
+    $env:PLAN_VERSION = "$pkg_version/$pkg_release"
+    Write-BuildLine "Setting env:PLAN_VERSION=$env:PLAN_VERSION"
+
+    # Used to set the active package target for the binaries at build time
+    $env:PLAN_PACKAGE_TARGET = "$pkg_target"
+    Write-BuildLine "Setting env:PLAN_PACKAGE_TARGET=$env:PLAN_PACKAGE_TARGET"
 }
 
 function Invoke-Unpack {

--- a/components/pkg-export-tar/plan.sh
+++ b/components/pkg-export-tar/plan.sh
@@ -32,6 +32,10 @@ _common_prepare() {
   export PLAN_VERSION="${pkg_version}/${pkg_release}"
   build_line "Setting PLAN_VERSION=$PLAN_VERSION"
 
+  # Used to set the active package target for the binaries at build time
+  export PLAN_PACKAGE_TARGET="$pkg_target"
+  build_line "Setting PLAN_PACKAGE_TARGET=$PLAN_PACKAGE_TARGET"
+
   if [ -z "$HAB_CARGO_TARGET_DIR" ]; then
     # Used by Cargo to use a pristine, isolated directory for all compilation
     export CARGO_TARGET_DIR="$HAB_CACHE_SRC_PATH/$pkg_dirname"

--- a/components/plan-build-ps1/plan.ps1
+++ b/components/plan-build-ps1/plan.ps1
@@ -14,9 +14,16 @@ $bin = "hab-plan-build.ps1"
 
 function Invoke-Build {
     # Embed the release version of the program.
-    (Get-Content "$PLAN_CONTEXT\bin\${bin}" -Encoding Ascii) -replace
-        "@VERSION@", "$pkg_version/$pkg_release" |
-        Out-File "$bin" -Encoding ascii
+    (Get-Content "$PLAN_CONTEXT\bin\${bin}" -Encoding Ascii) | ForEach-Object {
+      $_.replace(
+        "@VERSION@",
+        "$pkg_version/$pkg_release"
+      ).
+      replace(
+        "`$script:pkg_target = `"@@pkg_target@@`"",
+        "`$script:pkg_target = `"$pkg_target`""
+      )
+    } | Out-File "$bin" -Encoding ascii
 }
 
 function Invoke-Install {

--- a/components/plan-build/plan.sh
+++ b/components/plan-build/plan.sh
@@ -33,8 +33,9 @@ do_build() {
   # release version of the program.
   # shellcheck disable=2154
   sed \
-    -e "s,#!/bin/bash$,#!$(pkg_path_for bash)/bin/bash," \
-    -e "s,^HAB_PLAN_BUILD=.*$,HAB_PLAN_BUILD=$pkg_version/$pkg_release," \
+    -e "s,#!/bin/bash\$,#!$(pkg_path_for bash)/bin/bash," \
+    -e "s,^HAB_PLAN_BUILD=0\.0\.1\$,HAB_PLAN_BUILD=$pkg_version/$pkg_release," \
+    -e "s,^pkg_target='@@pkg_target@@'\$,pkg_target='$pkg_target'," \
     -i "$CACHE_PATH/$program"
 }
 

--- a/components/sup/plan.ps1
+++ b/components/sup/plan.ps1
@@ -18,7 +18,6 @@ function Invoke-Prepare {
     }
 
     $env:SSL_CERT_FILE              = "$(Get-HabPackagePath "cacerts")/ssl/certs/cacert.pem"
-    $env:PLAN_VERSION               = "$pkg_version/$pkg_release"
     $env:LIB                        += ";$HAB_CACHE_SRC_PATH/$pkg_dirname/lib"
     $env:INCLUDE                    += ";$HAB_CACHE_SRC_PATH/$pkg_dirname/include"
     $env:SODIUM_LIB_DIR             = "$HAB_CACHE_SRC_PATH/$pkg_dirname/lib"
@@ -28,6 +27,14 @@ function Invoke-Prepare {
     $env:OPENSSL_LIB_DIR            = "$HAB_CACHE_SRC_PATH/$pkg_dirname/lib"
     $env:OPENSSL_INCLUDE_DIR        = "$HAB_CACHE_SRC_PATH/$pkg_dirname/include"
     $env:LIBZMQ_PREFIX              = "$HAB_CACHE_SRC_PATH/$pkg_dirname"
+
+    # Used by the `build.rs` program to set the version of the binaries
+    $env:PLAN_VERSION = "$pkg_version/$pkg_release"
+    Write-BuildLine "Setting env:PLAN_VERSION=$env:PLAN_VERSION"
+
+    # Used to set the active package target for the binaries at build time
+    $env:PLAN_PACKAGE_TARGET = "$pkg_target"
+    Write-BuildLine "Setting env:PLAN_PACKAGE_TARGET=$env:PLAN_PACKAGE_TARGET"
 }
 
 function Invoke-Unpack {

--- a/components/sup/plan.sh
+++ b/components/sup/plan.sh
@@ -32,6 +32,10 @@ _common_prepare() {
   export PLAN_VERSION="${pkg_version}/${pkg_release}"
   build_line "Setting PLAN_VERSION=$PLAN_VERSION"
 
+  # Used to set the active package target for the binaries at build time
+  export PLAN_PACKAGE_TARGET="$pkg_target"
+  build_line "Setting PLAN_PACKAGE_TARGET=$PLAN_PACKAGE_TARGET"
+
   if [ -z "$HAB_CARGO_TARGET_DIR" ]; then
     # Used by Cargo to use a pristine, isolated directory for all compilation
     export CARGO_TARGET_DIR="$HAB_CACHE_SRC_PATH/$pkg_dirname"


### PR DESCRIPTION
There are 2 changes at work here: the first to setup up the injection behavior and the second to use it in relevant Habitat Plans.

## [plan-build] Set `$pkg_target` at build time for build programs.

This change updates the build program (both the Bash and PowerShell
implementations) to inject a static package target value into the source
code at Habitat package build time. This means that a built
`core/hab-plan-build*` package will have a pre-determined,
non-overridable package target.

The build time injection of the package target is fed by the package's
Plan by setting the build program's `pkg_target` value to its value of
`$pkg_target`. Make sense? No? Think of it as a pass-through: my build
program's `$pkg_target` will be set into my program's `pkg_target`
value. This means that in the Bash implementation, you would see
something like the following in the built package:

```sh
pkg_target='x86_64-linux'
```

and similarily with the PowerShell implementation:

```powershell
$script:pkg_target = "x86_64-windows"
```

### Bootstrapping Escape Hatch

While the above strategy works for all normal Habitat build use cases,
there's one place where we might need full control over the value of
`pkg_target`, namely when bootstrapping new package targets or
re-bootstrapping existing ones.

In order to support the bootstrapping case, a specialized behavior is
available when either build program is run directly out of the source
tree (i.e. not run from a built Habitat package). When run like this,
the value of `$pkg_target` will still contain the build time replacement
token `@@pkg_target@@`. There is a check right after build program boot
that checks if the value of `$pkg_target` is `@@pkg_target@@`. If so,
there are 2 possible behaviors:

1. If an environment variable of
`$BUILD_PKG_TARGET`/`$env:BUILD_PKG_TARGET` is present, then its value
will be set for the value of `$pkg_target`, with a message printed for
the user. Bootstrapping new package targets or the initial seeded value
use cases will use this environment variable.
2. If the above environment variable isn't present, then the prior
behavior is used. On Bash, `uname -s`/`uname -m` is used and on
PowerShell a predefined string is used. This preserves prior behavior
and allows users to run the build programs directly out of the source
tree without having to remember to set a new variable for little to no
gain.

It should be noted that these 2 bootstrapping cases are not available if
running either build program from a built Habitat package, which is by
design. The intention being that we don't want an errant environment
variable accidentally infecting the build process once we're past any
bootstrapping phase.

### Soft Deprecation of `pkg_arch` and `pkg_sys` Build Variables

In the process of working this change, I found 2 variables that were set
in each build program that are not only no longer necessary but could be
dangerous if a Plan author was to rely on these variables. Those are:

* `pkg_arch`
* `pkg_sys`

As the initial author of package target support on the build side, I
will admit to being overly ambitious and adding these variables without
thinking them through. Looking back, they should never have been set up
in the form of public build variables. If there is good news here, I
have since determined that:

* `pkg_arch`, `pkg_sys`, and `pkg_target` are not currently nor were
ever documented formally in our docs.
* `pkg_arch` and `pkg_sys` aren't used anywhere internally in the build
program (other than in service of determining `pkg_target`)
* `pkg_arch` and `pkg_sys` aren't referenced anywhere in the
`habitat-sh/core-plans` repo
* `pkg_arch` and `pkg_sys` aren't referenced in any Plans that I could
reasonably find searching GitHub

Given all of the above, I've chosen to remove `pkg_arch` and `pkg_sys`
and have a note to formally document `pkg_target` in our reference docs.

## Update relevant Habitat Plans to set PLAN_PACKAGE_TARGET.

This change explicitly injects a package target value for Rust software
components that deal with Habitat packages. The `PLAN_PACKAGE_TARGET`
environment variable is consumed *at build time* by an
`active_package_target` function in the `habitat_core::package::target`
module (which is used once to set a static value at runtime). This is
the mechanism to "bake in" a package target for our tooling.

It should be noted that the `PLAN_PACKAGE_TARGET` is **not** a public,
Habitat environment variable. It is an internal Habitat source
code-consuming variable that is not referenced or used anywhere else in
our system (by design).

Additionally, this approach of setting `PLAN_PACKAGE_TARGET` will not be
used for Builder software components **unless** we plan to build Builder
packages for platform targets other than `x86_64-linux`.