### PR TITLE
Avoid incomplete package installs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -748,7 +748,7 @@ dependencies = [
 [[package]]
 name = "habitat_core"
 version = "0.0.0"
-source = "git+https://github.com/habitat-sh/core.git#a6f0fb04e692d82a2e1c84d596bec09bc3410518"
+source = "git+https://github.com/habitat-sh/core.git#91238adaec5713db8838151bc8be002f8d68dd3c"
 dependencies = [
  "ansi_term 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -804,7 +804,7 @@ dependencies = [
 [[package]]
 name = "habitat_http_client"
 version = "0.0.0"
-source = "git+https://github.com/habitat-sh/core.git#a6f0fb04e692d82a2e1c84d596bec09bc3410518"
+source = "git+https://github.com/habitat-sh/core.git#91238adaec5713db8838151bc8be002f8d68dd3c"
 dependencies = [
  "base64 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat_core 0.0.0 (git+https://github.com/habitat-sh/core.git)",
@@ -963,7 +963,7 @@ dependencies = [
 [[package]]
 name = "habitat_win_users"
 version = "0.0.0"
-source = "git+https://github.com/habitat-sh/core.git#a6f0fb04e692d82a2e1c84d596bec09bc3410518"
+source = "git+https://github.com/habitat-sh/core.git#91238adaec5713db8838151bc8be002f8d68dd3c"
 dependencies = [
  "gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/common/Cargo.toml
+++ b/components/common/Cargo.toml
@@ -14,6 +14,7 @@ libc = "*"
 log = "*"
 pbr = "*"
 regex = "*"
+tempdir = "*"
 retry = "*"
 term = "*"
 time = "*"
@@ -29,9 +30,6 @@ path = "../builder-depot-client"
 [target.'cfg(windows)'.dependencies]
 kernel32-sys = "*"
 winapi = "0.2"
-
-[dev-dependencies]
-tempdir = "*"
 
 [features]
 default = []

--- a/components/common/src/error.rs
+++ b/components/common/src/error.rs
@@ -51,6 +51,7 @@ pub enum Error {
     WireDecode(String),
     EditorEnv(env::VarError),
     PackageNotFound(String),
+    PackageUnpackFailed(String),
 }
 
 impl fmt::Display for Error {
@@ -96,6 +97,7 @@ impl fmt::Display for Error {
             Error::WireDecode(ref m) => format!("Failed to decode wire message: {}", m),
             Error::EditorEnv(ref e) => format!("Missing EDITOR environment variable: {}", e),
             Error::PackageNotFound(ref e) => format!("Package not found. {}", e),
+            Error::PackageUnpackFailed(ref e) => format!("Package could not be unpacked. {}", e),
         };
         write!(f, "{}", msg)
     }
@@ -133,6 +135,7 @@ impl error::Error for Error {
             Error::WireDecode(_) => "Failed to decode wire message",
             Error::EditorEnv(_) => "Missing EDITOR environment variable",
             Error::PackageNotFound(_) => "Package not found",
+            Error::PackageUnpackFailed(_) => "Package could not be unpacked",
         }
     }
 }

--- a/components/common/src/lib.rs
+++ b/components/common/src/lib.rs
@@ -26,7 +26,6 @@ extern crate log;
 extern crate pbr;
 extern crate regex;
 extern crate retry;
-#[cfg(test)]
 extern crate tempdir;
 extern crate term;
 extern crate time;


### PR DESCRIPTION
Resolves #4897 

Previously, `hab pkg install` would unpack a package directly into the
target directory. If `hab pkg install` was killed in the middle of
the installation, the system might be left in state where `hab` would
report the package as installed, even though it was unusable.

This changes the unpack process so that we first unpack into a
temporary directory and then rename the directory into place.

The trade-off here is that a killed install will leave behind a
temporary directory that would take up space on the user's disk.

Signed-off-by: Steven Danna <steve@chef.io>