### PR TITLE
Expose pkg_target in post-build environment files

### DIFF
--- a/components/plan-build-ps1/bin/hab-plan-build.ps1
+++ b/components/plan-build-ps1/bin/hab-plan-build.ps1
@@ -2025,6 +2025,7 @@ pkg_origin=$pkg_origin
 pkg_name=$pkg_name
 pkg_version=$pkg_version
 pkg_release=$pkg_release
+pkg_target=$pkg_target
 pkg_ident=${pkg_origin}/${pkg_name}/${pkg_version}/${pkg_release}
 pkg_artifact=$(Split-Path $pkg_artifact -Leaf)
 pkg_sha256sum=$_pkg_sha256sum

--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -2200,6 +2200,7 @@ pkg_origin=$pkg_origin
 pkg_name=$pkg_name
 pkg_version=$pkg_version
 pkg_release=$pkg_release
+pkg_target=$pkg_target
 pkg_ident=${pkg_origin}/${pkg_name}/${pkg_version}/${pkg_release}
 pkg_artifact=$(basename "$pkg_artifact")
 pkg_sha256sum=$_pkg_sha256sum


### PR DESCRIPTION
Ultimately I'd like to incorporate package target into our release
process; exposing it in the post-build environment file is a simple
way to do this.

Signed-off-by: Christopher Maier <cmaier@chef.io>