### PR TITLE
Enable feature flags with any value except the empty string

### DIFF
--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -1297,9 +1297,11 @@ fn enable_features_from_env(ui: &mut UI) {
         (feat::IgnoreLocal, "IGNORE_LOCAL"),
     ];
 
+    // If the environment variable for a flag is set to _anything_ but
+    // the empty string, it is activated.
     for feature in &features {
         match henv::var(format!("HAB_FEAT_{}", feature.1)) {
-            Ok(ref val) if ["true", "TRUE"].contains(&val.as_str()) => {
+            Ok(_) => {
                 feat::enable(feature.0);
                 ui.warn(&format!("Enabling feature: {:?}", feature.0))
                     .unwrap();

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -537,9 +537,11 @@ fn valid_url(val: String) -> result::Result<(), String> {
 fn enable_features_from_env() {
     let features = vec![(feat::List, "LIST")];
 
+    // If the environment variable for a flag is set to _anything_ but
+    // the empty string, it is activated.
     for feature in &features {
         match henv::var(format!("HAB_FEAT_{}", feature.1)) {
-            Ok(ref val) if ["true", "TRUE"].contains(&val.as_str()) => {
+            Ok(_) => {
                 feat::enable(feature.0);
                 outputln!("Enabling feature: {:?}", feature.0);
             }


### PR DESCRIPTION
Previously, a feature flag could only be enabled if its corresponding
environment variable was set to the literal string `"true"` or
`"TRUE"`.

In general, this is too restrictive, since you really only need the
existence of the variable to toggle the feature.

Now, if the environment variable is set to anything except the empty
string, it will be enabled.

That is,

``` sh
HAB_FEAT_IGNORE_LOCAL=yup hab pkg install core/redis --ignore-local
HAB_FEAT_IGNORE_LOCAL=true hab pkg install core/redis --ignore-local
HAB_FEAT_IGNORE_LOCAL=false hab pkg install core/redis --ignore-local
HAB_FEAT_IGNORE_LOCAL=1 hab pkg install core/redis --ignore-local
HAB_FEAT_IGNORE_LOCAL=0 hab pkg install core/redis --ignore-local
```

will all activate the `IGNORE_LOCAL` option for `hab pkg install`, but

``` sh
HAB_FEAT_IGNORE_LOCAL="" hab pkg install core/redis --ignore-local
HAB_FEAT_IGNORE_LOCAL= hab pkg install core/redis --ignore-local
```

will all fail, because the feature will _not_ be enabled.

This is consistent with our use of environment variables elsewhere, in
that the empty string is not considered to be a valid value for an
environment variable.

Fixes #5275

Signed-off-by: Christopher Maier <cmaier@chef.io>