### PR TITLE
Print the values of the feature environment variables rather than "true"

### DIFF
--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -1314,8 +1314,12 @@ fn enable_features_from_env(ui: &mut UI) {
         ui.warn("Listing feature flags environment variables:")
             .unwrap();
         for feature in &features {
-            ui.warn(&format!("  * {:?}: HAB_FEAT_{}=true", feature.0, feature.1))
-                .unwrap();
+            ui.warn(&format!(
+                "  * {:?}: HAB_FEAT_{}={}",
+                feature.0,
+                feature.1,
+                henv::var(format!("HAB_FEAT_{}", feature.1)).unwrap_or("".to_string())
+            )).unwrap();
         }
     }
 }

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -552,7 +552,12 @@ fn enable_features_from_env() {
     if feat::is_enabled(feat::List) {
         outputln!("Listing feature flags environment variables:");
         for feature in &features {
-            outputln!("     * {:?}: HAB_FEAT_{}=true", feature.0, feature.1);
+            outputln!(
+                "     * {:?}: HAB_FEAT_{}={}",
+                feature.0,
+                feature.1,
+                henv::var(format!("HAB_FEAT_{}", feature.1)).unwrap_or("".to_string())
+            );
         }
         outputln!("The Supervisor will start now, enjoy!");
     }


### PR DESCRIPTION
This can be useful for features whose env vars take on a meaningful value.
Furthermore, it's already printed which features are enabled.