### PR TITLE
 Allow a crashed supervisor to be restarted by the launcher

### DIFF
--- a/components/sup/src/lib.rs
+++ b/components/sup/src/lib.rs
@@ -133,6 +133,9 @@ lazy_static! {
 }
 
 features! {
+    /// List enables printing out the list features which can be dynamically enabled
+    /// TestExit enables triggering an abrupt exit to simulate failures
+    /// Search for feat::is_enabled(feat::FeatureName) to learn more
     pub mod feat {
         const List     = 0b00000001,
         const TestExit = 0b00000010

--- a/components/sup/src/lib.rs
+++ b/components/sup/src/lib.rs
@@ -132,10 +132,10 @@ lazy_static! {
     };
 }
 
+/// List enables printing out the list features which can be dynamically enabled
+/// TestExit enables triggering an abrupt exit to simulate failures
+/// Search for feat::is_enabled(feat::FeatureName) to learn more
 features! {
-    /// List enables printing out the list features which can be dynamically enabled
-    /// TestExit enables triggering an abrupt exit to simulate failures
-    /// Search for feat::is_enabled(feat::FeatureName) to learn more
     pub mod feat {
         const List     = 0b00000001,
         const TestExit = 0b00000010

--- a/components/sup/src/lib.rs
+++ b/components/sup/src/lib.rs
@@ -134,7 +134,8 @@ lazy_static! {
 
 features! {
     pub mod feat {
-        const List = 0b00000001
+        const List     = 0b00000001,
+        const TestExit = 0b00000010
     }
 }
 

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -48,7 +48,7 @@ use hcore::crypto::dpapi::encrypt;
 use hcore::crypto::{self, default_cache_key_path, SymKey};
 use hcore::env as henv;
 use hcore::url::{bldr_url_from_env, default_bldr_url};
-use launcher_client::{LauncherCli, ERR_NO_RETRY_EXCODE, OK_NO_RETRY_EXCODE};
+use launcher_client::{LauncherCli, ERR_NO_RETRY_EXCODE};
 use protocol::{
     ctl::ServiceBindList,
     types::{
@@ -233,44 +233,41 @@ fn sub_run(m: &ArgMatches, launcher: LauncherCli) -> Result<()> {
     set_supervisor_logging_options(m);
 
     let cfg = mgrcfg_from_matches(m)?;
-    if Manager::is_running(&cfg)? {
-        process::exit(OK_NO_RETRY_EXCODE);
-    } else {
-        let manager = Manager::load(cfg, launcher)?;
-        // We need to determine if we have an initial service to start
-        let svc = if let Some(pkg) = m.value_of("PKG_IDENT_OR_ARTIFACT") {
-            let mut msg = protocol::ctl::SvcLoad::default();
-            update_svc_load_from_input(m, &mut msg)?;
-            // Always force - running with a package ident is a "do what I mean" operation. You
-            // don't care if a service was loaded previously or not and with what options. You
-            // want one loaded right now and in this way.
-            msg.force = Some(true);
-            let ident = match pkg.parse::<InstallSource>()? {
-                source @ InstallSource::Archive(_) => {
-                    // Install the archive manually then explicitly set the pkg ident to the
-                    // version found in the archive. This will lock the software to this
-                    // specific version.
-                    let install = util::pkg::install(
-                        &mut ui(),
-                        msg.bldr_url
-                            .as_ref()
-                            .unwrap_or(&*protocol::DEFAULT_BLDR_URL),
-                        &source,
-                        msg.bldr_channel
-                            .as_ref()
-                            .unwrap_or(&*protocol::DEFAULT_BLDR_CHANNEL),
-                    )?;
-                    install.ident.into()
-                }
-                InstallSource::Ident(ident) => ident.into(),
-            };
-            msg.ident = Some(ident);
-            Some(msg)
-        } else {
-            None
+    let manager = Manager::load(cfg, launcher)?;
+
+    // We need to determine if we have an initial service to start
+    let svc = if let Some(pkg) = m.value_of("PKG_IDENT_OR_ARTIFACT") {
+        let mut msg = protocol::ctl::SvcLoad::default();
+        update_svc_load_from_input(m, &mut msg)?;
+        // Always force - running with a package ident is a "do what I mean" operation. You
+        // don't care if a service was loaded previously or not and with what options. You
+        // want one loaded right now and in this way.
+        msg.force = Some(true);
+        let ident = match pkg.parse::<InstallSource>()? {
+            source @ InstallSource::Archive(_) => {
+                // Install the archive manually then explicitly set the pkg ident to the
+                // version found in the archive. This will lock the software to this
+                // specific version.
+                let install = util::pkg::install(
+                    &mut ui(),
+                    msg.bldr_url
+                        .as_ref()
+                        .unwrap_or(&*protocol::DEFAULT_BLDR_URL),
+                    &source,
+                    msg.bldr_channel
+                        .as_ref()
+                        .unwrap_or(&*protocol::DEFAULT_BLDR_CHANNEL),
+                )?;
+                install.ident.into()
+            }
+            InstallSource::Ident(ident) => ident.into(),
         };
-        manager.run(svc)
-    }
+        msg.ident = Some(ident);
+        Some(msg)
+    } else {
+        None
+    };
+    manager.run(svc)
 }
 
 fn sub_sh() -> Result<()> {

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -535,7 +535,7 @@ fn valid_url(val: String) -> result::Result<(), String> {
 
 ////////////////////////////////////////////////////////////////////////
 fn enable_features_from_env() {
-    let features = vec![(feat::List, "LIST")];
+    let features = vec![(feat::List, "LIST"), (feat::TestExit, "TEST_EXIT")];
 
     // If the environment variable for a flag is set to _anything_ but
     // the empty string, it is activated.

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -675,7 +675,7 @@ impl Manager {
                             .read_to_string(&mut buffer)
                             .expect("couldn't read");
                         if let Ok(exit_code) = buffer.lines().next().unwrap_or("").parse::<i32>() {
-                            fs::remove_file(&exit_file_path).expect("foo");
+                            fs::remove_file(&exit_file_path).expect("couldn't remove");
                             outputln!("Simulating abrupt, unexpected exit with code {}", exit_code);
                             std::process::exit(exit_code);
                         }

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -205,30 +205,6 @@ pub struct Manager {
 }
 
 impl Manager {
-    /// Determines if there is already a Habitat Supervisor running on the host system.
-    pub fn is_running(cfg: &ManagerConfig) -> Result<bool> {
-        let fs_cfg = FsCfg::new(cfg.sup_root());
-
-        match read_process_lock(&fs_cfg.proc_lock_file) {
-            Ok(pid) => Ok(process::is_alive(pid)),
-            Err(SupError {
-                err: Error::ProcessLockCorrupt,
-                ..
-            }) => Ok(false),
-            Err(SupError {
-                err: Error::ProcessLockIO(_, _),
-                ..
-            }) => {
-                // JW TODO: We need to check the raw OS error and translate it to a "file not found"
-                // case. This is an acceptable reason to assume that another manager is not running
-                // but other IO errors are an actual problem. For now, let's just assume an IO
-                // error here is a file not found.
-                Ok(false)
-            }
-            Err(err) => Err(err),
-        }
-    }
-
     /// Load a Manager with the given configuration.
     ///
     /// The returned Manager will be pre-populated with any cached data from disk from a previous

--- a/test/end-to-end/test_launcher_restarts_supervisor.sh
+++ b/test/end-to-end/test_launcher_restarts_supervisor.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# A simple test that the launcher restarts a supervisor when it exits abruptly
+# The one optional argument set the exit code of the supervisor (default: 1).
+# By default this runs against the installed habitat binaries. To override and
+# test locally-built code, set overrides in the environment of the script.
+# See https://github.com/habitat-sh/habitat/blob/master/BUILDING.md#testing-changes
+
 set -eou pipefail
 
 wait_for_sup_to_start() {

--- a/test/end-to-end/test_launcher_restarts_supervisor.sh
+++ b/test/end-to-end/test_launcher_restarts_supervisor.sh
@@ -24,6 +24,7 @@ exit_code=${1:-1}
 mkdir -p "$(dirname "$sup_log")"
 echo -n "Starting launcher with root $TESTING_FS_ROOT (logging to $sup_log)..."
 env HAB_FEAT_TEST_EXIT="$exit_file" hab sup run &> "$sup_log" &
+trap 'hab sup term' INT TERM EXIT
 
 wait_for_sup_to_start
 read -r launcher_pid < <(pgrep hab-launch)
@@ -59,5 +60,3 @@ elif [[ $launcher_pid != "$new_launcher_pid" ]]; then
 else
 	echo "Success! Launcher restarted supervisor process"
 fi
-
-hab sup term

--- a/test/end-to-end/test_launcher_restarts_supervisor.sh
+++ b/test/end-to-end/test_launcher_restarts_supervisor.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+set -eou pipefail
+
+wait_for_sup_to_start() {
+	until pgrep hab-sup &>/dev/null; do
+		echo -n .
+		sleep 1
+	done
+	echo
+}
+
+if pgrep hab-launch &>/dev/null; then
+	echo "Error: launcher process is already running"
+	exit 1
+fi
+
+TESTING_FS_ROOT=$(mktemp -d)
+export TESTING_FS_ROOT
+sup_log="$TESTING_FS_ROOT/hab/sup/default/sup.log"
+exit_file=$(mktemp)
+exit_code=${1:-1}
+
+mkdir -p "$(dirname "$sup_log")"
+echo -n "Starting launcher with root $TESTING_FS_ROOT (logging to $sup_log)..."
+env HAB_FEAT_TEST_EXIT="$exit_file" hab sup run &> "$sup_log" &
+
+wait_for_sup_to_start
+read -r launcher_pid < <(pgrep hab-launch)
+read -r supervisor_pid < <(pgrep hab-sup)
+
+echo "Launcher is process $launcher_pid, supervisor is process $supervisor_pid"
+echo "Forcing supervisor to exit $exit_file..."
+echo "$exit_code" >> "$exit_file"
+
+echo -n "Waiting for old supervisor process to exit..."
+while ps -p "$supervisor_pid" &>/dev/null; do
+	echo -n .
+	sleep 1
+done
+echo
+
+if ! pgrep hab-launch &>/dev/null; then
+	echo "Failure! Launcher process exited"
+	exit 2
+fi
+
+echo "Waiting for new supervisor process to start..."
+wait_for_sup_to_start
+read -r new_launcher_pid < <(pgrep hab-launch)
+read -r new_supervisor_pid < <(pgrep hab-sup)
+
+if [[ $supervisor_pid == "$new_supervisor_pid" ]]; then
+	echo "Failure! Supervisor process did not change"
+	exit 3
+elif [[ $launcher_pid != "$new_launcher_pid" ]]; then
+	echo "Failure! Launcher process changed unexpectedly"
+	exit 4
+else
+	echo "Success! Launcher restarted supervisor process"
+fi
+
+hab sup term


### PR DESCRIPTION
The first commit just adds testability, so you can confirm what was broken and that the second commit fixes it.

There's some additional follow-up work to do, as I don't think we should endlessly loop for failures to start such as:
```
hab-sup(MR)[components/sup/src/manager/mod.rs:533:24]: Unable to read or write to data directory, /hab/sup/default/data, Permission denied (os error 13)
```
but that can come separately.

This PR is best viewed [with whitespace changes hidden](https://github.com/habitat-sh/habitat/pull/5384/files?w=1).