### PR TITLE
If the supervisor terminates with an error result, don't restart it

### DIFF
--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -74,13 +74,12 @@ static RING_KEY_ENVVAR: &'static str = "HAB_RING_KEY";
 
 fn main() {
     let result = start();
-    let exit_code;
-    match result {
+    let exit_code = match result {
+        Ok(_) => 0,
         Err(ref err) => {
             println!("{}", err);
-            exit_code = ERR_NO_RETRY_EXCODE;
+            ERR_NO_RETRY_EXCODE
         }
-        Ok(_) => exit_code = 0,
     };
     debug!("start() returned {:?}; Exiting {}", result, exit_code);
     process::exit(exit_code);

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -73,24 +73,17 @@ static RING_ENVVAR: &'static str = "HAB_RING";
 static RING_KEY_ENVVAR: &'static str = "HAB_RING_KEY";
 
 fn main() {
-    if let Err(err) = start() {
-        println!("{}", err);
-        match err {
-            SupError {
-                err: Error::ProcessLocked(_),
-                ..
-            }
-            | SupError {
-                err: Error::Departed,
-                ..
-            }
-            | SupError {
-                err: Error::ButterflyError(_),
-                ..
-            } => process::exit(ERR_NO_RETRY_EXCODE),
-            _ => process::exit(1),
+    let result = start();
+    let exit_code;
+    match result {
+        Err(ref err) => {
+            println!("{}", err);
+            exit_code = ERR_NO_RETRY_EXCODE;
         }
-    }
+        Ok(_) => exit_code = 0,
+    };
+    debug!("start() returned {:?}; Exiting {}", result, exit_code);
+    process::exit(exit_code);
 }
 
 fn boot() -> Option<LauncherCli> {

--- a/test/end-to-end/test_launcher_exits_on_supervisor_startup_failure.sh
+++ b/test/end-to-end/test_launcher_exits_on_supervisor_startup_failure.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# A simple test that the launcher doesn't go into a tight loop restarting the
+# supervisor if the supervisor fails to start up. To override and test
+# locally-built code, set overrides in the environment of the script.
+# See https://github.com/habitat-sh/habitat/blob/master/BUILDING.md#testing-changes
+
+set -eou pipefail
+
+wait_for_sup_to_start() {
+	until pgrep hab-sup &>/dev/null; do
+		echo -n .
+		sleep 1
+	done
+	echo
+}
+
+if pgrep hab-launch &>/dev/null; then
+	echo "Error: launcher process is already running"
+	exit 1
+fi
+
+TESTING_FS_ROOT=$(mktemp -d)
+export TESTING_FS_ROOT
+sup_log=$(mktemp)
+
+echo "Setting $TESTING_FS_ROOT to read-only to induce supervisor start failure"
+chmod -R a-w "$TESTING_FS_ROOT"
+echo -n "Starting launcher with root $TESTING_FS_ROOT (logging to $sup_log)..."
+
+hab sup run &> "$sup_log" &
+launcher_pid=$!
+trap 'pgrep hab-launch &>/dev/null && pkill -9 hab-launch' INT TERM EXIT
+
+retries=0
+max_retries=5
+while ps -p "$launcher_pid" &>/dev/null; do
+	echo -n .
+	if [[ $((retries++)) -gt $max_retries ]]; then
+		echo
+		echo "Failure! Launcher failed to exit before timeout"
+		exit 2
+	else
+		sleep 1
+	fi
+done
+
+echo
+echo "Success! Launcher cleanly exited"


### PR DESCRIPTION
Resolves https://github.com/habitat-sh/habitat/issues/3060

Exit ERR_NO_RETRY_EXCODE to communicate to the launcher that it shouldn't be
restarted. Otherwise errors on startup can lead to a tight loop of perpetual
restarts.

Abrupt exits due to panics and graceful supervisor exit for update will still
exit 0 and be restarted by the launcher.

Before:
```
➤ ./test/end-to-end/test_launcher_exits_on_supervisor_startup_failure.sh 
Setting /tmp/tmp.SGOnFKb6FC to read-only to induce supervisor start failure
Starting launcher with root /tmp/tmp.SGOnFKb6FC (logging to /tmp/tmp.n7NidR5L14)..........
Failure! Launcher failed to exit before timeout
```
After:
```
➤ env HAB_SUP_BINARY=(pwd)/target/debug/hab-sup ./test/end-to-end/test_launcher_exits_on_supervisor_startup_failure.sh 
Setting /tmp/tmp.Ci34qa8zrd to read-only to induce supervisor start failure
Starting launcher with root /tmp/tmp.Ci34qa8zrd (logging to /tmp/tmp.fDjHViBah9)....
Success! Launcher cleanly exited
```