### PR TITLE
Add timeout for launcher waiting for IPC connection to supervisor

### DIFF
--- a/components/launcher-client/src/lib.rs
+++ b/components/launcher-client/src/lib.rs
@@ -23,8 +23,9 @@ extern crate protobuf;
 mod client;
 pub mod error;
 
-pub use protocol::{ERR_NO_RETRY_EXCODE, LAUNCHER_LOCK_CLEAN_ENV, LAUNCHER_PID_ENV,
-                   OK_NO_RETRY_EXCODE};
+pub use protocol::{
+    ERR_NO_RETRY_EXCODE, LAUNCHER_LOCK_CLEAN_ENV, LAUNCHER_PID_ENV, OK_NO_RETRY_EXCODE,
+};
 
 pub use client::LauncherCli;
 pub use error::Error;

--- a/components/launcher/src/server/mod.rs
+++ b/components/launcher/src/server/mod.rs
@@ -43,6 +43,7 @@ use service::Service;
 use {SUP_CMD, SUP_PACKAGE_IDENT};
 
 const IPC_CONNECT_TIMEOUT_SECS: &'static str = "HAB_LAUNCH_SUP_CONNECT_TIMEOUT_SECS";
+const DEFAULT_IPC_CONNECT_TIMEOUT_SECS: u64 = 5;
 const SUP_CMD_ENVVAR: &'static str = "HAB_SUP_BINARY";
 static LOGKEY: &'static str = "SV";
 
@@ -483,7 +484,7 @@ fn setup_connection(server: IpcOneShotServer<Vec<u8>>) -> Result<(Receiver, Send
     let timeout_secs = core::env::var(IPC_CONNECT_TIMEOUT_SECS)
         .unwrap_or("".to_string())
         .parse()
-        .unwrap_or(5);
+        .unwrap_or(DEFAULT_IPC_CONNECT_TIMEOUT_SECS);
 
     debug!("Waiting on connect thread for {} secs", timeout_secs);
     let (started, wait_result) = cvar.wait_timeout(

--- a/components/sup/src/error.rs
+++ b/components/sup/src/error.rs
@@ -114,6 +114,7 @@ pub enum Error {
     BadSpecsPath(PathBuf, io::Error),
     BadStartStyle(String),
     BadEnvConfig(String),
+    BootFail,
     ButterflyError(butterfly::error::Error),
     CtlSecretIo(PathBuf, io::Error),
     DepotClient(depot_client::Error),
@@ -218,6 +219,7 @@ impl fmt::Display for SupError {
             Error::BadEnvConfig(ref varname) => {
                 format!("Unable to find valid TOML or JSON in {} ENVVAR", varname)
             }
+            Error::BootFail => format!("Simulated boot failure"),
             Error::ButterflyError(ref err) => format!("Butterfly error: {}", err),
             Error::CtlSecretIo(ref path, ref err) => format!(
                 "IoError while reading or writing ctl secret, {}, {}",
@@ -360,6 +362,7 @@ impl error::Error for SupError {
             Error::BadSpecsPath(_, _) => "Unable to create the specs directory",
             Error::BadStartStyle(_) => "Unknown start style in service spec",
             Error::BadEnvConfig(_) => "Unknown syntax in Env Configuration",
+            Error::BootFail => "Simulated boot failure",
             Error::ButterflyError(ref err) => err.description(),
             Error::CtlSecretIo(_, _) => "IoError while reading ctl secret",
             Error::ExecCommandNotFound(_) => "Exec command was not found on filesystem or in PATH",

--- a/components/sup/src/error.rs
+++ b/components/sup/src/error.rs
@@ -114,7 +114,7 @@ pub enum Error {
     BadSpecsPath(PathBuf, io::Error),
     BadStartStyle(String),
     BadEnvConfig(String),
-    BootFail,
+    TestBootFail,
     ButterflyError(butterfly::error::Error),
     CtlSecretIo(PathBuf, io::Error),
     DepotClient(depot_client::Error),
@@ -219,7 +219,7 @@ impl fmt::Display for SupError {
             Error::BadEnvConfig(ref varname) => {
                 format!("Unable to find valid TOML or JSON in {} ENVVAR", varname)
             }
-            Error::BootFail => format!("Simulated boot failure"),
+            Error::TestBootFail => format!("Simulated boot failure"),
             Error::ButterflyError(ref err) => format!("Butterfly error: {}", err),
             Error::CtlSecretIo(ref path, ref err) => format!(
                 "IoError while reading or writing ctl secret, {}, {}",
@@ -362,7 +362,7 @@ impl error::Error for SupError {
             Error::BadSpecsPath(_, _) => "Unable to create the specs directory",
             Error::BadStartStyle(_) => "Unknown start style in service spec",
             Error::BadEnvConfig(_) => "Unknown syntax in Env Configuration",
-            Error::BootFail => "Simulated boot failure",
+            Error::TestBootFail => "Simulated boot failure",
             Error::ButterflyError(ref err) => err.description(),
             Error::CtlSecretIo(_, _) => "IoError while reading ctl secret",
             Error::ExecCommandNotFound(_) => "Exec command was not found on filesystem or in PATH",

--- a/components/sup/src/lib.rs
+++ b/components/sup/src/lib.rs
@@ -134,13 +134,13 @@ lazy_static! {
 
 /// List enables printing out the list features which can be dynamically enabled
 /// TestExit enables triggering an abrupt exit to simulate failures
-/// BootFail exits with a fatal error before even calling boot()
+/// TestBootFail exits with a fatal error before even calling boot()
 /// Search for feat::is_enabled(feat::FeatureName) to learn more
 features! {
     pub mod feat {
-        const List     = 0b00000001,
-        const TestExit = 0b00000010,
-        const BootFail = 0b00000100
+        const List         = 0b00000001,
+        const TestExit     = 0b00000010,
+        const TestBootFail = 0b00000100
     }
 }
 

--- a/components/sup/src/lib.rs
+++ b/components/sup/src/lib.rs
@@ -134,11 +134,13 @@ lazy_static! {
 
 /// List enables printing out the list features which can be dynamically enabled
 /// TestExit enables triggering an abrupt exit to simulate failures
+/// BootFail exits with a fatal error before even calling boot()
 /// Search for feat::is_enabled(feat::FeatureName) to learn more
 features! {
     pub mod feat {
         const List     = 0b00000001,
-        const TestExit = 0b00000010
+        const TestExit = 0b00000010,
+        const BootFail = 0b00000100
     }
 }
 

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -105,9 +105,9 @@ fn boot() -> Option<LauncherCli> {
 }
 
 fn start() -> Result<()> {
-    if feat::is_enabled(feat::BootFail) {
+    if feat::is_enabled(feat::TestBootFail) {
         outputln!("Simulating boot failure");
-        return Err(sup_error!(Error::BootFail));
+        return Err(sup_error!(Error::TestBootFail));
     }
     let launcher = boot();
     let app_matches = match cli().get_matches_safe() {
@@ -531,7 +531,7 @@ fn enable_features_from_env() {
     let features = vec![
         (feat::List, "LIST"),
         (feat::TestExit, "TEST_EXIT"),
-        (feat::BootFail, "BOOT_FAIL"),
+        (feat::TestBootFail, "BOOT_FAIL"),
     ];
 
     // If the environment variable for a flag is set to _anything_ but

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -73,6 +73,8 @@ static RING_ENVVAR: &'static str = "HAB_RING";
 static RING_KEY_ENVVAR: &'static str = "HAB_RING_KEY";
 
 fn main() {
+    env_logger::init();
+    enable_features_from_env();
     let result = start();
     let exit_code = match result {
         Ok(_) => 0,
@@ -86,8 +88,6 @@ fn main() {
 }
 
 fn boot() -> Option<LauncherCli> {
-    env_logger::init();
-    enable_features_from_env();
     if !crypto::init() {
         println!("Crypto initialization failed!");
         process::exit(1);
@@ -105,6 +105,10 @@ fn boot() -> Option<LauncherCli> {
 }
 
 fn start() -> Result<()> {
+    if feat::is_enabled(feat::BootFail) {
+        outputln!("Simulating boot failure");
+        return Err(sup_error!(Error::BootFail));
+    }
     let launcher = boot();
     let app_matches = match cli().get_matches_safe() {
         Ok(matches) => matches,
@@ -524,7 +528,11 @@ fn valid_url(val: String) -> result::Result<(), String> {
 
 ////////////////////////////////////////////////////////////////////////
 fn enable_features_from_env() {
-    let features = vec![(feat::List, "LIST"), (feat::TestExit, "TEST_EXIT")];
+    let features = vec![
+        (feat::List, "LIST"),
+        (feat::TestExit, "TEST_EXIT"),
+        (feat::BootFail, "BOOT_FAIL"),
+    ];
 
     // If the environment variable for a flag is set to _anything_ but
     // the empty string, it is activated.

--- a/test/end-to-end/test_launcher_exits_on_supervisor_connection_failure.sh
+++ b/test/end-to-end/test_launcher_exits_on_supervisor_connection_failure.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# A simple test that the launcher doesn't hang if the IPC connection to the
+# supervisor doesn't complete in a timely manner. To override and test
+# locally-built code, set overrides in the environment of the script.
+# See https://github.com/habitat-sh/habitat/blob/master/BUILDING.md#testing-changes
+
+set -eou pipefail
+
+if pgrep hab-launch &>/dev/null; then
+	echo "Error: launcher process is already running"
+	exit 1
+fi
+
+TESTING_FS_ROOT=$(mktemp -d)
+export TESTING_FS_ROOT
+export HAB_LAUNCH_SUP_CONNECT_TIMEOUT_SECS=2
+export HAB_FEAT_BOOT_FAIL=1
+sup_log=$(mktemp)
+
+echo -n "Starting launcher with root $TESTING_FS_ROOT (logging to $sup_log)..."
+hab sup run &> "$sup_log" &
+launcher_pid=$!
+trap 'pgrep hab-launch &>/dev/null && pkill -9 hab-launch' INT TERM EXIT
+
+retries=0
+max_retries=5
+while ps -p "$launcher_pid" &>/dev/null; do
+	echo -n .
+	if [[ $((retries++)) -gt $max_retries ]]; then
+		echo
+		echo "Failure! Launcher failed to exit before timeout"
+		exit 2
+	else
+		sleep 1
+	fi
+done
+echo
+
+if wait "$launcher_pid"; then
+	echo "Failure! Launcher exited success; error expected"
+else
+	echo "Success! Launcher exited with error"
+fi


### PR DESCRIPTION
Without this, if the supervisor doesn't establish a successful IPC connection
back to the launcher (due to exiting or blocking), the launcher will hang.

Also, add a test and make some other minor cleanups.

See https://github.com/habitat-sh/habitat/issues/5300

Signed-off-by: Jon Bauman <5906042+baumanj@users.noreply.github.com>