### PR TITLE
[ci] Add a `.buildkite` entry to `CODEOWNERS`.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,5 @@
 * @reset @fnichol @christophermaier
+.buildkite @christophermaier @fnichol
 components/backline @fnichol @baumanj
 components/builder* @chefsalim @raskchanky
 components/butterfly* @christophermaier @reset @baumanj
@@ -11,5 +12,5 @@ components/plan-build @fnichol @christophermaier @elliott-davis
 components/studio @fnichol @baumanj @elliott-davis
 components/sup @christophermaier @reset @fnichol @baumanj
 support @fnichol @baumanj @elliott-davis @raskchanky
-tools @baumanj @chefsalim @christophermaier @eeyun @raskchanky
+tools @baumanj @chefsalim @christophermaier @eeyun @raskchanky @fnichol
 www @cnunciato @mgamini @raskchanky


### PR DESCRIPTION
While not strictly necessary, I suspect those who are more keen on
our release mechanics might want this called out specifically.

Additionally, I added myself to the `tools/` directory.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>