### PR TITLE
Adds force upload flag to cli

### DIFF
--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -440,6 +440,9 @@ pub fn get() -> App<'static, 'static> {
                     "Additional release channel to upload package to. \
                      Packages are always uploaded to `unstable`, regardless \
                      of the value of this option. (default: none)")
+                (@arg FORCE: --force "Skips checking availability of package and \
+                    force uploads, potentially overwriting a stored copy of a package. \
+                    (default: false)")
                 (@arg HART_FILE: +required +multiple {file_exists}
                     "One or more filepaths to a Habitat Artifact \
                     (ex: /home/acme-redis-3.0.7-21120102031201-x86_64-linux.hart)")

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -679,6 +679,10 @@ fn sub_pkg_upload(ui: &mut UI, m: &ArgMatches) -> Result<()> {
     // they can optionally get added to another channel, too.
     let additional_release_channel: Option<&str> = m.value_of("CHANNEL");
 
+    // When packages are uploaded we check if they exist in the db
+    // before allowing a write to the backend, this bypasses the check
+    let force_upload = m.is_present("FORCE");
+
     let token = auth_token_param_or_env(&m)?;
     let artifact_paths = m.values_of("HART_FILE").unwrap(); // Required via clap
     for artifact_path in artifact_paths {
@@ -688,6 +692,7 @@ fn sub_pkg_upload(ui: &mut UI, m: &ArgMatches) -> Result<()> {
             additional_release_channel,
             &token,
             &artifact_path,
+            force_upload,
             &key_path,
         )?;
     }


### PR DESCRIPTION
This has not yet been tested nor have any tests yet been written for it but more or less the functionality is in. Relatively trivial change - adds a new flag to `hab pkg upload` that allows users to `--force` and override whatever package is or is not stored in minio. 

Planning to test this with another PR inbound to builder shortly.

Signed-off-by: Ian Henry <ihenry@chef.io>