### PR TITLE
Add auto-build info to docs

### DIFF
--- a/www/source/partials/docs/_using-builder-automated-builds.html.md.erb
+++ b/www/source/partials/docs/_using-builder-automated-builds.html.md.erb
@@ -1,5 +1,5 @@
 ## <a name="automated-builds" id="automated-builds" data-magellan-target="automated-builds">Set up Automated Builds</a>
-By connecting a plan file in <a href="https://bldr.habitat.sh/#/sign-in" class="link-external" target="_blank">Habitat Builder</a>, you can trigger automated package rebuilds whenever a change is merged into the `master` branch of the repository containing your Habitat plan.
+By connecting a plan file in <a href="https://bldr.habitat.sh/#/sign-in" class="link-external" target="_blank">Habitat Builder</a>, you can trigger both manual (via the web UI, or via the `hab` command line) as well as automated package rebuilds whenever a change is merged into the `master` branch of the repository containing your Habitat plan, or when a dependent package updates (rebuilds).
 
 ### Connect a Plan
 To connect a plan to Builder, view one of your origins (while signed in), click the **Connect a plan file** button, and complete the following steps:
@@ -8,3 +8,10 @@ To connect a plan to Builder, view one of your origins (while signed in), click 
   - Choose the GitHub organization and repository containing your Habitat plan
   - Choose a privacy setting for the package
   - Specify container-registry publishing settings (optional)
+  - Specify auto-build option (default is off)
+
+#### Auto-build option
+
+The auto-build option controls whether or not your package will get automatically re-built. This option is a useful capability to have - for example, if you have a demo app that doesn’t need to be kept constantly up to date when some underlying dependency updates. Auto-build encompasss both builds that are triggered by Github web hooks (on commits to master), as well as builds that are triggered by a dependency updating.
+
+By default, new plan connections will have auto-build turned off.


### PR DESCRIPTION
Update docs to add info on the new auto-build option available in the plan connection page.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-71111307](https://user-images.githubusercontent.com/13542112/43605132-57f1dc80-964c-11e8-90fb-b2358711c9a5.gif)
