### PR TITLE
Resurrect enough of the old macOS build to work in TravisCI

### DIFF
--- a/components/hab/mac/travis/README.md
+++ b/components/hab/mac/travis/README.md
@@ -1,0 +1,10 @@
+IMPORTANT
+=========
+
+The contents of this directory are ONLY of interest for building macOS
+packages in TravisCI after merges to the master branch.
+
+As soon as we're off of TravisCI, this directory goes away.
+
+Unless you know you have a reason to care about this code, look
+elsewhere.

--- a/components/hab/mac/travis/homebrew/hab-libarchive.rb
+++ b/components/hab/mac/travis/homebrew/hab-libarchive.rb
@@ -1,0 +1,42 @@
+# Forked from https://raw.githubusercontent.com/Homebrew/homebrew-core/master/Formula/libarchive.rb
+# On 2016-05-25
+
+class HabLibarchive < Formula
+  desc "Multi-format archive and compression library"
+  homepage "http://www.libarchive.org"
+  url "http://www.libarchive.org/downloads/libarchive-3.2.0.tar.gz"
+  mirror "https://github.com/libarchive/libarchive/archive/v3.2.0.tar.gz"
+  sha256 "7bce45fd71ff01dc20d19edd78322d4965583d81b8bed8e26cacb65d6f5baa87"
+
+  keg_only :provided_by_osx
+
+  depends_on "xz" => :recommended
+  depends_on "lz4" => :optional
+  depends_on "lzop" => :optional
+
+  def install
+    system "./configure",
+           "--prefix=#{prefix}",
+           "--without-lzo2",    # Use lzop binary instead of lzo2 due to GPL
+           "--without-nettle",  # xar hashing option but GPLv3
+           "--without-xml2",    # xar hashing option but tricky dependencies
+           "--without-openssl", # mtree hashing now possible without OpenSSL
+           "--with-expat",      # best xar hashing option
+           "--with-libiconv-prefix=/usr/local/opt/hab-libiconv",
+           "--enable-shared=no"
+
+    system "make", "install"
+
+    # Just as apple does it.
+    ln_s bin/"bsdtar", bin/"tar"
+    ln_s bin/"bsdcpio", bin/"cpio"
+    ln_s man1/"bsdtar.1", man1/"tar.1"
+    ln_s man1/"bsdcpio.1", man1/"cpio.1"
+  end
+
+  test do
+    (testpath/"test").write("test")
+    system bin/"bsdtar", "-czvf", "test.tar.gz", "test"
+    assert_match /test/, shell_output("#{bin}/bsdtar -xOzf test.tar.gz")
+  end
+end

--- a/components/hab/mac/travis/homebrew/hab-libiconv.rb
+++ b/components/hab/mac/travis/homebrew/hab-libiconv.rb
@@ -1,0 +1,60 @@
+# Forked from https://raw.githubusercontent.com/Homebrew/homebrew-dupes/master/libiconv.rb
+# On 2016-05-25
+#
+class HabLibiconv < Formula
+  desc "Conversion library"
+  homepage "https://www.gnu.org/software/libiconv/"
+  url "http://ftpmirror.gnu.org/libiconv/libiconv-1.14.tar.gz"
+  mirror "https://ftp.gnu.org/gnu/libiconv/libiconv-1.14.tar.gz"
+  sha256 "72b24ded17d687193c3366d0ebe7cde1e6b18f0df8c55438ac95be39e8a30613"
+
+  bottle do
+    sha256 "64d8a9383ba42ba3e41422bb8548ebc8f296f67fdda6e6d6a324f990b03c6db0" => :el_capitan
+    sha256 "a0d9ff36269bc908fde4a039d2083152202055a2e053b6582ad2c9063c85ebc2" => :yosemite
+    sha256 "456a816a94427c963fa3cb90257830aa33268f22443cf5a8a4cf1be3e3ed3bb9" => :mavericks
+  end
+
+  keg_only :provided_by_osx
+
+  option :universal
+
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/patches/9be2793af/libiconv/patch-Makefile.devel"
+    sha256 "ad9b6da1a82fc4de27d6f7086a3382993a0b16153bc8e8a23d7b5f9334ca0a42"
+  end
+
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/patches/9be2793af/libiconv/patch-utf8mac.diff"
+    sha256 "e8128732f22f63b5c656659786d2cf76f1450008f36bcf541285268c66cabeab"
+  end
+
+  patch :DATA
+
+  def install
+    ENV.universal_binary if build.universal?
+    ENV.j1
+
+    system "./configure", "--disable-debug",
+                          "--disable-dependency-tracking",
+                          "--prefix=#{prefix}",
+                          "--enable-extra-encodings",
+                          "--enable-static"
+    system "make", "-f", "Makefile.devel", "CFLAGS=#{ENV.cflags}", "CC=#{ENV.cc}"
+    system "make", "install"
+  end
+end
+
+
+__END__
+diff --git a/lib/flags.h b/lib/flags.h
+index d7cda21..4cabcac 100644
+--- a/lib/flags.h
++++ b/lib/flags.h
+@@ -14,6 +14,7 @@
+ 
+ #define ei_ascii_oflags (0)
+ #define ei_utf8_oflags (HAVE_ACCENTS | HAVE_QUOTATION_MARKS | HAVE_HANGUL_JAMO)
++#define ei_utf8mac_oflags (HAVE_ACCENTS | HAVE_QUOTATION_MARKS | HAVE_HANGUL_JAMO)
+ #define ei_ucs2_oflags (HAVE_ACCENTS | HAVE_QUOTATION_MARKS | HAVE_HANGUL_JAMO)
+ #define ei_ucs2be_oflags (HAVE_ACCENTS | HAVE_QUOTATION_MARKS | HAVE_HANGUL_JAMO)
+ #define ei_ucs2le_oflags (HAVE_ACCENTS | HAVE_QUOTATION_MARKS | HAVE_HANGUL_JAMO)

--- a/components/hab/mac/travis/homebrew/hab-rq.rb
+++ b/components/hab/mac/travis/homebrew/hab-rq.rb
@@ -1,0 +1,15 @@
+class HabRq < Formula
+  desc "Record Query - A tool for doing record analysis and transformation"
+  homepage "https://github.com/dflemstr/rq"
+  url "https://github.com/dflemstr/rq/releases/download/v0.9.2/rq-x86_64-apple-darwin"
+  sha256 "fbc9347d83ee575c10251ad2fff9c31a78c42d4cedc14bbb9be72739ed619496"
+
+  def install
+    mv "rq-x86_64-apple-darwin", "rq", verbose: true
+    bin.install "rq"
+  end
+
+  test do
+    system "#{bin}/rq", "--version"
+  end
+end

--- a/components/hab/mac/travis/mac-build.sh
+++ b/components/hab/mac/travis/mac-build.sh
@@ -49,7 +49,7 @@ fi
 if [[ ! -f /usr/local/bin/hab ]]; then
   info "Habitat CLI missing, attempting to install latest release"
   mkdir -p /usr/local/bin
-  sh "$(dirname "$0")"/../install.sh
+  sh "$(dirname "$0")"/../../install.sh
 fi
 
 while true; do
@@ -116,7 +116,7 @@ gnu_path="$gnu_path:$(brew --prefix bash)/bin"
 export PATH="$gnu_path:$PATH"
 info "Setting PATH=$PATH"
 
-program="$(dirname "$0")/../../plan-build/bin/hab-plan-build.sh"
+program="$(dirname "$0")/../../../plan-build/bin/hab-plan-build.sh"
 info "Executing: $program $*"
 echo
 exec "$(brew --prefix bash)"/bin/bash "$program" "$@"

--- a/components/hab/mac/travis/plan.sh
+++ b/components/hab/mac/travis/plan.sh
@@ -1,0 +1,51 @@
+# shellcheck disable=2154
+PLAN_CONTEXT=$(dirname "$PLAN_CONTEXT") source ../../plan.sh
+
+pkg_name=hab
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+# There is no true equivalent here (yet), so dependency arrays will be empty.
+pkg_deps=()
+pkg_build_deps=()
+
+pkg_version=$(cat "$PLAN_CONTEXT/../../../../VERSION")
+
+do_begin() {
+  # Set the real hab component directory as the "root" of this plan.
+  PLAN_CONTEXT="$(abspath ../..)"
+}
+
+# shellcheck disable=2155
+do_prepare() {
+  # Can be either `--release` or `--debug` to determine cargo build strategy
+  build_type="--release"
+  build_line "Building artifacts with \`${build_type#--}' mode"
+
+  export rustc_target="x86_64-apple-darwin"
+  build_line "Setting rustc_target=$rustc_target"
+
+  # Used by the `build.rs` program to set the version of the binaries
+  export PLAN_VERSION="${pkg_version}/${pkg_release}"
+  build_line "Setting PLAN_VERSION=$PLAN_VERSION"
+
+  # Used by Cargo to use a pristine, isolated directory for all compilation
+  export CARGO_TARGET_DIR="$HAB_CACHE_SRC_PATH/$pkg_dirname"
+  build_line "Setting CARGO_TARGET_DIR=$CARGO_TARGET_DIR"
+
+  formulas="$PLAN_CONTEXT/mac/travis/homebrew"
+
+  la_ldflags="-L$(brew --prefix zlib)/lib -lz"
+  la_ldflags="$la_ldflags -L$(brew --prefix xz)/lib -llzma"
+  la_ldflags="$la_ldflags -L$(brew --prefix bzip2)/lib -lbz2"
+  la_ldflags="$la_ldflags -L$(brew --prefix expat)/lib -lexpat"
+  la_ldflags="$la_ldflags -L$(brew --prefix "$formulas"/hab-libiconv.rb)/lib -liconv"
+
+  export LIBARCHIVE_LIB_DIR=$(brew --prefix "$formulas"/hab-libarchive.rb)/lib
+  export LIBARCHIVE_INCLUDE_DIR=$(brew --prefix "$formulas"/hab-libarchive.rb)/include
+  export LIBARCHIVE_LDFLAGS="$la_ldflags"
+  export LIBARCHIVE_STATIC=true
+  export OPENSSL_LIB_DIR=$(brew --prefix openssl)/lib
+  export OPENSSL_INCLUDE_DIR=$(brew --prefix openssl)/include
+  export OPENSSL_STATIC=true
+  export SODIUM_LIB_DIR=$(brew --prefix libsodium)/lib
+  export SODIUM_STATIC=true
+}

--- a/support/ci/deploy_mac.sh
+++ b/support/ci/deploy_mac.sh
@@ -28,7 +28,7 @@ function cleanup {
 trap cleanup EXIT
 
 bootstrap_dir="$HOME/mac_unstable/$TRAVIS_BUILD_NUMBER"
-mac_dir="${hab_src_dir}/components/hab/mac"
+mac_dir="${hab_src_dir}/components/hab/mac/travis"
 mac_hab="${bootstrap_dir}/hab"
 gnu_tar=/usr/local/bin/tar
 hab_download_url="https://api.bintray.com/content/habitat/stable/darwin/x86_64/hab-%24latest-x86_64-darwin.zip?bt_package=hab-x86_64-darwin"


### PR DESCRIPTION
We removed too much! In order to continue getting macOS builds of
`hab` when we merge code to master, we still need to have this code
around.

I've consolidated things into a `travis` subdirectory, though, which
should make it easy to extract once we're completely in Buildkite.

Paths have been modified where necessary to account for the additional
level of directory structure.

Signed-off-by: Christopher Maier <cmaier@chef.io>