### PR TITLE
Allow Supervisor to receive messages from <= 0.59.0 Supervisors

### DIFF
--- a/components/butterfly/src/server/inbound.rs
+++ b/components/butterfly/src/server/inbound.rs
@@ -59,7 +59,7 @@ impl Inbound {
                         Err(e) => {
                             // NOTE: In the future, we might want to block people who send us
                             // garbage all the time.
-                            error!("Error decoding protocol message, {}", e);
+                            error!("Error unwrapping protocol message, {}", e);
                             continue;
                         }
                     };


### PR DESCRIPTION
This fixes a bug that snuck in during the `rust-protobuf` => `prost`
migration of Butterfly (see #5179). Networks of Supervisors all
running that code worked fine, as did networks of Supervisors running
earlier versions, but mixed networks had trouble. In particular, the
newer Supervisors were treating all messages from older Supervisors as
invalid because it was being too strict in its new validation of
messages.

Further research revealed that our `Member` protobuf is actually
playing two roles in the system, and have different fields set
depending on that role. Read the inline comments for further detail.

Ultimately we need to tease these roles apart more clearly so we can
perform meaningful validation once again.

Note: though we are effectively disabling validation on one field,
that validation was only added in the above PR, and it was not taking
into account the actual (arguably hidden) usage of the `Member`
protobuf. Thus, nothing is really being removed in this code.

Additionally, this fixes a regression of our serialization logic for
the `/services` endpoint of the Supervisor's HTTP gateway, also
introduced in #5179. The `cfg` key of a Service was being rendered as
an byte array, instead of the JSON object it has always been.

Finally, an error message was made unique in order to assist in future
debugging sessions. With repeated error messages, it was difficult to
initially pinpoint where in the code the regression actually was.

Signed-off-by: Christopher Maier <cmaier@chef.io>