### PR TITLE
Miscellaneous Buildkite Tweaks

### DIFF
--- a/.buildkite/Brewfile
+++ b/.buildkite/Brewfile
@@ -1,5 +1,5 @@
 # This Brewfile is for setting up and managing the small amount of
-# Homebrew-related infrastructure we need. As our MacOS build process
+# Homebrew-related infrastructure we need. As our macOS build process
 # matures, we can whittle this down.
 
 # Though our builders will already have this installed, we can take
@@ -19,7 +19,7 @@ brew "hab"
 brew "bash"
 
 # Eventually we'll get wget in our Omnibus toolchain, but it's rather
-# finickly to get compiled for MacOS. Until that time, we'll pull it
+# finickly to get compiled for macOS. Until that time, we'll pull it
 # in from Homebrew.
 brew "wget"
 

--- a/.buildkite/env
+++ b/.buildkite/env
@@ -6,8 +6,8 @@
 set -euo pipefail
 
 # Use this to specify a toolchain for Rustup on platforms where that's
-# how we get Rust (e.g., MacOS)
-if [ -z "${RUST_TOOLCHAIN:-}" ]; then
+# how we get Rust (e.g., macOS)
+if [[ -z "${RUST_TOOLCHAIN:-}" ]]; then
     export RUST_TOOLCHAIN="1.28.0"
 else
     echo "--- :warning: Using RUST_TOOLCHAIN=\"${RUST_TOOLCHAIN}\", previously set in the environment"

--- a/.buildkite/finish_release_pipeline.yaml
+++ b/.buildkite/finish_release_pipeline.yaml
@@ -5,8 +5,8 @@ steps:
       the potential to cause instability in Builder. Please declare a
       maintenance window in Statuspage before proceeding any further.
 
-  - label: ":right-facing_fist: :boom: :left-facing_fist: Promote Release in Builder"
-    command: .buildkite/scripts/promote_release_channel.sh
+  - label: ":right-facing_fist: :boom: :left-facing_fist: Promote Release for consumption by Builder"
+    command: .buildkite/scripts/promote_release_channel.sh $(buildkite-agent meta-data get "release-channel") builder-live
     agents:
       queue: habitat-release
 
@@ -17,6 +17,13 @@ steps:
       promoted to the stable channel. This should be less of an issue
       as our operations and software mature, but until then, it is
       nice to explicitly factor that into our release process.
+
+  - label: ":right-facing_fist: :boom: :left-facing_fist: Promote Release to stable"
+    command: .buildkite/scripts/promote_release_channel.sh builder-live stable
+    agents:
+      queue: habitat-release
+
+  - wait
 
   - label: "Publish DockerHub Release"
     command: .buildkite/scripts/dockerhub_publish.sh
@@ -65,6 +72,8 @@ steps:
     skip: Not implemented yet
     agents:
       queue: habitat-release
+
+  - wait
 
   - label: ":habicat: :boom: Destroy release channel"
     command: .buildkite/scripts/destroy_release_channel.sh

--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -2,12 +2,15 @@
 
 set -euo pipefail
 
+source .buildkite/scripts/shared.sh
+
 if [[ "${FAKE_RELEASE_TAG:-}" || "${BUILDKITE_TAG}" ]]; then
     # Our releases are currently triggered by the existence of a tag
     echo -e "--- :sparkles: Preparing for a release! :sparkles:"
 
     if [[ "${FAKE_RELEASE_TAG:-}" ]]; then
         echo "Using fake release tag '${FAKE_RELEASE_TAG}'"
+        set_fake_release "${FAKE_RELEASE_TAG}"
         release="${FAKE_RELEASE_TAG}"
     elif [[ "${BUILDKITE_TAG}" ]]; then
         echo "Using release tag '${BUILDKITE_TAG}'"

--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -6,7 +6,7 @@ source .buildkite/scripts/shared.sh
 
 if [[ "${FAKE_RELEASE_TAG:-}" || "${BUILDKITE_TAG}" ]]; then
     # Our releases are currently triggered by the existence of a tag
-    echo -e "--- :sparkles: Preparing for a release! :sparkles:"
+    echo "--- :sparkles: Preparing for a release! :sparkles:"
 
     if [[ "${FAKE_RELEASE_TAG:-}" ]]; then
         echo "Using fake release tag '${FAKE_RELEASE_TAG}'"
@@ -18,7 +18,7 @@ if [[ "${FAKE_RELEASE_TAG:-}" || "${BUILDKITE_TAG}" ]]; then
     fi
     channel="rc-${release}"
     echo "Release channel is '${channel}'"
-    echo -e "## Habitat Release _${release}_" | buildkite-agent annotate --context "release-manifest"
+    echo "## Habitat Release _${release}_" | buildkite-agent annotate --context "release-manifest"
 
     buildkite-agent meta-data set "release-channel" "${channel}"
 
@@ -30,7 +30,7 @@ if [[ "${FAKE_RELEASE_TAG:-}" || "${BUILDKITE_TAG}" ]]; then
 
     buildkite-agent pipeline upload .buildkite/release_pipeline.yaml
 else
-    echo -e "--- :sparkles: Preparing for a CI run! :sparkles:"
+    echo "--- :sparkles: Preparing for a CI run! :sparkles:"
     echo "TODO"
     exit 1
 fi

--- a/.buildkite/scripts/bintray_publish.sh
+++ b/.buildkite/scripts/bintray_publish.sh
@@ -29,10 +29,10 @@ echo "--- :linux: Publishing Linux 'hab' ${version}-${release} on Bintray"
 publish "https://api.bintray.com/content/habitat/$PROMOTE_CHANNEL/hab-x86_64-linux/${version}-${release}/publish"
 
 ########################################################################
-# MacOS Publish
+# macOS Publish
 
 release=$(buildkite-agent meta-data get "hab-release-macos")
-echo "--- :mac: Publishing MacOS 'hab' ${version}-${release} to Bintray"
+echo "--- :mac: Publishing macOS 'hab' ${version}-${release} to Bintray"
 publish "https://api.bintray.com/content/habitat/$PROMOTE_CHANNEL/hab-x86_64-darwin/${version}-${release}/publish"
 
 ########################################################################

--- a/.buildkite/scripts/bintray_publish.sh
+++ b/.buildkite/scripts/bintray_publish.sh
@@ -4,17 +4,16 @@ set -euo pipefail
 
 source .buildkite/scripts/shared.sh
 
-if [[ "${FAKE_RELEASE_TAG:-}" ]]; then
-    echo "--- :warning: FAKE_RELEASE_TAG was found in the environment! This isn't a \"real\" release!"
-    fake_release=1
+if is_fake_release; then
+    echo "--- :warning: This isn't a \"real\" release!"
 fi
 
 publish(){
     url=${1}
-    if [ -z "${fake_release}" ]; then
-        curl -u "${BINTRAY_USER}:${BINTRAY_KEY}" -X POST "${url}"
-    else
+    if is_fake_release; then
         echo "--- :warning: If this were a real release, we would have hit ${url}"
+    else
+        curl -u "${BINTRAY_USER}:${BINTRAY_KEY}" -X POST "${url}"
     fi
 }
 

--- a/.buildkite/scripts/bintray_publish.sh
+++ b/.buildkite/scripts/bintray_publish.sh
@@ -5,8 +5,12 @@ set -euo pipefail
 source .buildkite/scripts/shared.sh
 
 if is_fake_release; then
-    echo "--- :warning: This isn't a \"real\" release!"
+    bintray_repository=unstable
+else
+    bintray_repository=stable
 fi
+
+echo "--- Preparing to publish artifacts to the ${bintray_repository} Bintray repository"
 
 publish(){
     url=${1}
@@ -17,7 +21,6 @@ publish(){
     fi
 }
 
-PROMOTE_CHANNEL="stable"
 echo "--- :habicat: Publishing all Habitat CLI artifacts in Bintray"
 
 version=$(buildkite-agent meta-data get "version")
@@ -26,14 +29,14 @@ version=$(buildkite-agent meta-data get "version")
 # Linux Publish
 release=$(buildkite-agent meta-data get "hab-release-linux")
 echo "--- :linux: Publishing Linux 'hab' ${version}-${release} on Bintray"
-publish "https://api.bintray.com/content/habitat/$PROMOTE_CHANNEL/hab-x86_64-linux/${version}-${release}/publish"
+publish "https://api.bintray.com/content/habitat/${bintray_repository}/hab-x86_64-linux/${version}-${release}/publish"
 
 ########################################################################
 # macOS Publish
 
 release=$(buildkite-agent meta-data get "hab-release-macos")
 echo "--- :mac: Publishing macOS 'hab' ${version}-${release} to Bintray"
-publish "https://api.bintray.com/content/habitat/$PROMOTE_CHANNEL/hab-x86_64-darwin/${version}-${release}/publish"
+publish "https://api.bintray.com/content/habitat/${bintray_repository}/hab-x86_64-darwin/${version}-${release}/publish"
 
 ########################################################################
 # Windows Publish
@@ -45,4 +48,4 @@ channel=$(buildkite-agent meta-data get "release-channel")
 windows_ident=$(latest_from_builder x86_64-windows "${channel}" hab "${version}")
 release=$(echo "${windows_ident}" | awk 'BEGIN { FS = "/" } ; { print $4 }')
 echo "--- :windows: Publishing Windows 'hab' ${version}-${release}"
-publish "https://api.bintray.com/content/habitat/$PROMOTE_CHANNEL/hab-x86_64-windows/${version}-${release}/publish"
+publish "https://api.bintray.com/content/habitat/${bintray_repository}/hab-x86_64-windows/${version}-${release}/publish"

--- a/.buildkite/scripts/bintray_upload.sh
+++ b/.buildkite/scripts/bintray_upload.sh
@@ -69,15 +69,26 @@ SHA256: <code>${shasum}</code>
 EOF
 
 echo "--- :habicat: Uploading core/hab-studio to Bintray"
+
+# Set the IMAGE_NAME environment variable which influences the name of
+# the image that gets generated. Anything we make in the course of
+# doing a "fake release" goes into the dev repository so we don't
+# pollute the stable repository.
+if is_fake_release; then
+    image_name="habitat-docker-registry.bintray.io/studio-dev"
+else
+    image_name="habitat-docker-registry.bintray.io/studio"
+fi
+
 # again, override just for backline
 sudo HAB_BLDR_CHANNEL="${channel}" \
      CI_OVERRIDE_CHANNEL="${channel}" \
      BINTRAY_USER="${BINTRAY_USER}" \
      BINTRAY_KEY="${BINTRAY_KEY}" \
      BINTRAY_PASSPHRASE="${BINTRAY_PASSPHRASE}" \
+     IMAGE_NAME="${image_name}" \
      hab pkg exec core/hab-bintray-publish \
-         publish-studio \
-         -r "${bintray_repository}"
+         publish-studio
 
 # The logic for the creation of this image is spread out over soooo
 # many places :/

--- a/.buildkite/scripts/bintray_upload.sh
+++ b/.buildkite/scripts/bintray_upload.sh
@@ -4,7 +4,16 @@
 
 set -euo pipefail
 
+source .buildkite/scripts/shared.sh
+
 # TODO: bintray user = chef-releng-ops!
+
+if is_fake_release; then
+    bintray_repository=unstable
+else
+    bintray_reposiory=stable
+fi
+echo "--- Preparing to push artifacts to the ${bintray_repository} Bintray repository"
 
 channel=$(buildkite-agent meta-data get "release-channel")
 
@@ -47,7 +56,7 @@ sudo HAB_BLDR_CHANNEL="${channel}" \
      hab pkg exec core/hab-bintray-publish \
          publish-hab \
          -s \
-         -r stable \
+         -r "${bintray_repository}" \
          "/hab/cache/artifacts/${hab_artifact}"
 
 source results/last_build.env
@@ -68,7 +77,7 @@ sudo HAB_BLDR_CHANNEL="${channel}" \
      BINTRAY_PASSPHRASE="${BINTRAY_PASSPHRASE}" \
      hab pkg exec core/hab-bintray-publish \
          publish-studio \
-         -r stable
+         -r "${bintray_repository}"
 
 # The logic for the creation of this image is spread out over soooo
 # many places :/

--- a/.buildkite/scripts/bintray_upload.sh
+++ b/.buildkite/scripts/bintray_upload.sh
@@ -40,12 +40,15 @@ hab_artifact=$(buildkite-agent meta-data get "hab-artifact")
 #
 # -s = skip publishing
 # -r = the repository to upload to
-sudo -E HAB_BLDR_CHANNEL="${channel}" \
-                hab pkg exec core/hab-bintray-publish \
-                publish-hab \
-                -s \
-                -r stable \
-                "/hab/cache/artifacts/${hab_artifact}"
+sudo HAB_BLDR_CHANNEL="${channel}" \
+     BINTRAY_USER="${BINTRAY_USER}" \
+     BINTRAY_KEY="${BINTRAY_KEY}" \
+     BINTRAY_PASSPHRASE="${BINTRAY_PASSPHRASE}" \
+     hab pkg exec core/hab-bintray-publish \
+         publish-hab \
+         -s \
+         -r stable \
+         "/hab/cache/artifacts/${hab_artifact}"
 
 source results/last_build.env
 shasum=$(awk '{print $1}' "results/${pkg_artifact:?}.sha256sum")
@@ -58,11 +61,14 @@ EOF
 
 echo "--- :habicat: Uploading core/hab-studio to Bintray"
 # again, override just for backline
-sudo -E HAB_BLDR_CHANNEL="${channel}" \
-CI_OVERRIDE_CHANNEL="${channel}" \
-                hab pkg exec core/hab-bintray-publish \
-                publish-studio \
-                -r stable
+sudo HAB_BLDR_CHANNEL="${channel}" \
+     CI_OVERRIDE_CHANNEL="${channel}" \
+     BINTRAY_USER="${BINTRAY_USER}" \
+     BINTRAY_KEY="${BINTRAY_KEY}" \
+     BINTRAY_PASSPHRASE="${BINTRAY_PASSPHRASE}" \
+     hab pkg exec core/hab-bintray-publish \
+         publish-studio \
+         -r stable
 
 # The logic for the creation of this image is spread out over soooo
 # many places :/

--- a/.buildkite/scripts/bintray_upload_macos.sh
+++ b/.buildkite/scripts/bintray_upload_macos.sh
@@ -2,7 +2,15 @@
 
 set -euo pipefail
 
+source .buildkite/scripts/shared.sh
+
 # TODO: bintray user = chef-releng-ops!
+if is_fake_release; then
+    bintray_repository=unstable
+else
+    bintray_reposiory=stable
+fi
+echo "--- Preparing to push artifacts to the ${bintray_repository} Bintray repository"
 
 # We need to upload (but not publish) artifacts to Bintray right now.
 channel=$(buildkite-agent meta-data get "release-channel")
@@ -34,7 +42,7 @@ sudo HAB_BLDR_CHANNEL="${channel}" \
      hab pkg exec core/hab-bintray-publish \
          publish-hab \
          -s \
-         -r stable \
+         -r "${bintray_repository}" \
          "${hab_artifact}"
 
 source results/last_build.env

--- a/.buildkite/scripts/bintray_upload_macos.sh
+++ b/.buildkite/scripts/bintray_upload_macos.sh
@@ -15,11 +15,11 @@ sudo hab pkg install \
      --channel="${channel}" \
      core/hab-bintray-publish
 
-echo "--- :buildkite: Retrieving MacOS core/hab artifact"
+echo "--- :buildkite: Retrieving macOS core/hab artifact"
 hab_artifact=$(buildkite-agent meta-data get "hab-artifact-macos")
 buildkite-agent artifact download "${hab_artifact}" .
 
-echo "--- :habicat: Uploading MacOS core/hab to Bintray"
+echo "--- :habicat: Uploading macOS core/hab to Bintray"
 # We upload to the stable channel, but we don't *publish* until
 # later.
 #

--- a/.buildkite/scripts/bintray_upload_macos.sh
+++ b/.buildkite/scripts/bintray_upload_macos.sh
@@ -27,12 +27,15 @@ echo "--- :habicat: Uploading macOS core/hab to Bintray"
 # -r = the repository to upload to
 
 # TODO (CM): why do we need the HAB_BLDR_CHANNEL here?
-sudo -E HAB_BLDR_CHANNEL="${channel}" \
-                hab pkg exec core/hab-bintray-publish \
-                publish-hab \
-                -s \
-                -r stable \
-                "${hab_artifact}"
+sudo HAB_BLDR_CHANNEL="${channel}" \
+     BINTRAY_USER="${BINTRAY_USER}" \
+     BINTRAY_KEY="${BINTRAY_KEY}" \
+     BINTRAY_PASSPHRASE="${BINTRAY_PASSPHRASE}" \
+     hab pkg exec core/hab-bintray-publish \
+         publish-hab \
+         -s \
+         -r stable \
+         "${hab_artifact}"
 
 source results/last_build.env
 shasum=$(awk '{print $1}' "results/${pkg_artifact:?}.sha256sum")

--- a/.buildkite/scripts/build_component.sh
+++ b/.buildkite/scripts/build_component.sh
@@ -96,7 +96,7 @@ esac
 
 # TODO (CM): Replace "Linux" below with ${pkg_target:?} once that's in
 # hab-plan-build (see https://github.com/habitat-sh/habitat/pull/5373)
-echo -e "<br>* ${pkg_ident} (Linux)" | buildkite-agent annotate --append --context "release-manifest"
+echo "<br>* ${pkg_ident} (Linux)" | buildkite-agent annotate --append --context "release-manifest"
 
 echo "--- :habicat: Uploading ${pkg_ident} to Builder in the '${channel}' channel"
 ${hab_binary} pkg upload \

--- a/.buildkite/scripts/build_component.sh
+++ b/.buildkite/scripts/build_component.sh
@@ -30,12 +30,11 @@ set_hab_binary() {
         sudo hab pkg install "${hab_ident}"
         sudo hab pkg install "$(buildkite-agent meta-data get studio-version)"
         declare -g hab_binary="/hab/pkgs/${hab_ident}/bin/hab"
-        declare -g new_studio="true"
+        declare -g new_studio=1
     else
         echo "Buildkite metadata NOT found; using previously-installed hab binary"
         hab_binary="$(which hab)"
         declare -g hab_binary
-        declare -g new_studio="false"
     fi
     echo "--- :habicat: Using $(${hab_binary} --version)"
 }
@@ -69,7 +68,7 @@ export HAB_ORIGIN=core
 #
 # CI_OVERRIDE_CHANNEL is basically used to tell the studio which
 # hab/backline to grab
-if [[ "${new_studio}" == "true" ]]; then
+if [[ "${new_studio:-}" ]]; then
     CI_OVERRIDE_CHANNEL="${channel}" HAB_BLDR_CHANNEL="${channel}" ${hab_binary} pkg build "components/${component}"
 else
     HAB_BLDR_CHANNEL="${channel}" ${hab_binary} pkg build "components/${component}"

--- a/.buildkite/scripts/build_mac_release.sh
+++ b/.buildkite/scripts/build_mac_release.sh
@@ -49,14 +49,14 @@ rm -Rf "${HOME}/.cargo/{git,registry}"
 
 echo "--- :habicat: :hammer_and_wrench: Building 'hab'"
 
-# Ensure that all our Omnibus toolchain binaries are available
-export PATH=/opt/hab-bundle/embedded/bin:${PATH}
-
 # NOTE: This does *not* need the CI_OVERRIDE_CHANNEL /
 # HAB_BLDR_CHANNEL variables that builds for other supported platforms
 # need, because we're not pulling anything from Builder. Once we do,
 # we'll need to make sure we pull from the right channels.
-sudo -E "$(brew --prefix bash)/bin/bash" components/plan-build/bin/hab-plan-build.sh components/hab/mac
+sudo PATH="/opt/hab-bundle/embedded/bin:${PATH}" \
+     "$(brew --prefix bash)/bin/bash" \
+     components/plan-build/bin/hab-plan-build.sh \
+     components/hab/mac
 source results/last_build.env
 
 echo "--- :buildkite: Annotating build"

--- a/.buildkite/scripts/build_mac_release.sh
+++ b/.buildkite/scripts/build_mac_release.sh
@@ -61,13 +61,13 @@ source results/last_build.env
 
 echo "--- :buildkite: Annotating build"
 
-# TODO (CM): Replace "MacOS" below with ${pkg_target:?} once that's in
+# TODO (CM): Replace "macOS" below with ${pkg_target:?} once that's in
 # hab-plan-build (see https://github.com/habitat-sh/habitat/pull/5373)
-echo "<br>* ${pkg_ident:?} (MacOS)" | buildkite-agent annotate --append --context "release-manifest"
+echo "<br>* ${pkg_ident:?} (macOS)" | buildkite-agent annotate --append --context "release-manifest"
 
-# Since we can't store MacOS packages in Builder yet, we'll store it
+# Since we can't store macOS packages in Builder yet, we'll store it
 # in Buildkite until we grab it later for upload to Bintray
-echo "--- :buildkite: Storing MacOS 'hab' artifact ${pkg_artifact:?}"
+echo "--- :buildkite: Storing macOS 'hab' artifact ${pkg_artifact:?}"
 buildkite-agent meta-data set "hab-artifact-macos" "${pkg_artifact:?}"
 buildkite-agent meta-data set "hab-release-macos" "${pkg_release:?}"
 (

--- a/.buildkite/scripts/build_mac_release.sh
+++ b/.buildkite/scripts/build_mac_release.sh
@@ -63,7 +63,7 @@ echo "--- :buildkite: Annotating build"
 
 # TODO (CM): Replace "MacOS" below with ${pkg_target:?} once that's in
 # hab-plan-build (see https://github.com/habitat-sh/habitat/pull/5373)
-echo -e "<br>* ${pkg_ident:?} (MacOS)" | buildkite-agent annotate --append --context "release-manifest"
+echo "<br>* ${pkg_ident:?} (MacOS)" | buildkite-agent annotate --append --context "release-manifest"
 
 # Since we can't store MacOS packages in Builder yet, we'll store it
 # in Buildkite until we grab it later for upload to Bintray

--- a/.buildkite/scripts/promote_launchers.sh
+++ b/.buildkite/scripts/promote_launchers.sh
@@ -15,11 +15,10 @@ resolve_launcher() {
     local target="${2}"
 
     if buildkite-agent meta-data exists "${metadata_key}"; then
-        launcher_ident=$(buildkite-agent meta-data get "${metadata_key}")
+        buildkite-agent meta-data get "${metadata_key}"
     else
-        launcher_ident=$(latest_from_builder "${target}" stable hab-launcher)
+        latest_from_builder "${target}" stable hab-launcher
     fi
-    echo "${launcher_ident}"
 }
 
 linux_launcher="$(resolve_launcher linux-launcher x86_64-linux)"

--- a/.buildkite/scripts/promote_release_channel.sh
+++ b/.buildkite/scripts/promote_release_channel.sh
@@ -5,9 +5,9 @@ set -euo pipefail
 channel=$(buildkite-agent meta-data get "release-channel")
 
 echo "--- :thinking_face: Determining which channel to promote to"
-if [[ "${FAKE_RELEASE_TAG:-}" ]]; then
-    echo "FAKE_RELEASE_TAG was found in the environment! This isn't a \"real\" release!"
-    PROMOTE_CHANNEL="fakestable-${FAKE_RELEASE_TAG}"
+if is_fake_release; then
+    echo "This isn't a \"real\" release!"
+    PROMOTE_CHANNEL="fakestable-$(get_fake_release)"
 else
     PROMOTE_CHANNEL="stable"
 fi

--- a/.buildkite/scripts/promote_release_channel.sh
+++ b/.buildkite/scripts/promote_release_channel.sh
@@ -2,20 +2,42 @@
 
 set -euo pipefail
 
-channel=$(buildkite-agent meta-data get "release-channel")
+source .buildkite/scripts/shared.sh
+
+# Given a FROM channel and a TO channel, take the contents of FROM and
+# promote to TO
+#
+# "release-channel" -> builder-live
+# builder-live -> stable
+#
+# Assumes that the only contents of the channel are going to be
+# Habitat Supervisor release artifacts
+#
+# TODO: It'd be nice to have this be an API function.
+
+from_channel=${1}
+to_channel=${2}
 
 echo "--- :thinking_face: Determining which channel to promote to"
 if is_fake_release; then
     echo "This isn't a \"real\" release!"
-    PROMOTE_CHANNEL="fakestable-$(get_fake_release)"
-else
-    PROMOTE_CHANNEL="stable"
+    to_channel="fake-${to_channel}-$(get_fake_release)"
+
+    # Yeah, this is kinda gross, but it'll allow us to test the whole
+    # thing (otherwise we wouldn't get the behavior we're after when
+    # doing the "second stage" promotion, since the name wouldn't match).
+    #
+    # Other suggestions welcome!
+    if [[ "${from_channel}" == "builder-live" ]]; then
+        from_channel="fake-builder-live-$(get_fake_release)"
+    fi
 fi
-echo "--- Promoting packages from '${channel}' to '${PROMOTE_CHANNEL}'"
+
+echo "--- Promoting packages from '${from_channel}' to '${to_channel}'"
 
 echo "--- :habicat: Retrieving package list from Builder"
 
-channel_pkgs_json=$(curl "https://bldr.habitat.sh/v1/depot/channels/core/${channel}/pkgs")
+channel_pkgs_json=$(curl "https://bldr.habitat.sh/v1/depot/channels/core/${from_channel}/pkgs")
 
 # TODO (CM): consider ordering these somehow (e.g., save the
 # supervisor for absolute last. If it goes out first, Builder itself
@@ -39,14 +61,14 @@ supervisor_packages=($(echo "${channel_pkgs_json}" | \
                          | .[]'))
 
 for pkg in "${non_supervisor_packages[@]}"; do
-    echo "--- :habicat: Promoting '$pkg' to '$PROMOTE_CHANNEL'"
-    hab pkg promote --auth="${HAB_TEAM_AUTH_TOKEN}" "${pkg}" "${PROMOTE_CHANNEL}"
+    echo "--- :habicat: Promoting '$pkg' to '$to_channel'"
+    hab pkg promote --auth="${HAB_TEAM_AUTH_TOKEN}" "${pkg}" "${to_channel}"
 done
 
-echo "--- :warning: PROMOTING SUPERVISORS TO '$PROMOTE_CHANNEL' :warning:"
+echo "--- :warning: PROMOTING SUPERVISORS TO '$to_channel' :warning:"
 for pkg in "${supervisor_packages[@]}"; do
-    echo "--- :habicat: Promoting $pkg to $PROMOTE_CHANNEL"
-    hab pkg promote --auth="${HAB_TEAM_AUTH_TOKEN}" "${pkg}" "${PROMOTE_CHANNEL}"
+    echo "--- :habicat: Promoting $pkg to $to_channel"
+    hab pkg promote --auth="${HAB_TEAM_AUTH_TOKEN}" "${pkg}" "${to_channel}"
 done
 
 buildkite-agent annotate --style="success" --context="release-manifest"

--- a/.buildkite/scripts/shared.sh
+++ b/.buildkite/scripts/shared.sh
@@ -43,3 +43,19 @@ latest_from_builder() {
     ident=$(curl -s "${url}" | jq -r '.ident | .origin + "/" + .name + "/" + .version + "/" + .release')
     echo "${ident}"
 }
+
+# Abstracts the logic (such as it is) for whether we're doing a "fake"
+# release or not.
+
+set_fake_release() {
+    local release=${1}
+    buildkite-agent meta-data set fake-release "${release}"
+}
+
+is_fake_release() {
+    buildkite-agent meta-data exists fake-release
+}
+
+get_fake_release() {
+    buildkite-agent meta-data get fake-release
+}

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ You can download Habitat from the [Habitat downloads page](https://www.habitat.s
 
 Once you have downloaded it, follow the instructions on the page for your specific operating system.
 
-If you are running MacOS and use [Homebrew](https://brew.sh), you can use our official [Homebrew tap](https://github.com/habitat-sh/homebrew-habitat).
+If you are running macOS and use [Homebrew](https://brew.sh), you can use our official [Homebrew tap](https://github.com/habitat-sh/homebrew-habitat).
 ```
 $ brew tap habitat-sh/habitat
 $ brew install hab

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -148,7 +148,7 @@ NOTE: Do this step from either a Linux VM or in a studio.
 ## Update Homebrew Tap
 
 We have our own [Homebrew tap](https://github.com/habitat-sh/homebrew-habitat) that will need
-updating. You will need the following bits of information for the latest stable MacOS Bintray artifact:
+updating. You will need the following bits of information for the latest stable macOS Bintray artifact:
 
 * the new version number
 * the new release

--- a/components/hab/mac/README.md
+++ b/components/hab/mac/README.md
@@ -1,6 +1,6 @@
-# Building a `hab` MacOS Binary
+# Building a `hab` macOS Binary
 
-As Habitat currently does not have first class support for the Mac platform, a pragmatic approach has been taken to build a `hab` binary for MacOS. This details the steps to build a release on MacOS. It is also currently codified in [.buildkite/scripts/build_mac_release.sh](habitat-sh/habitat/.buildkite/scripts/build_mac_release.sh)
+As Habitat currently does not have first class support for the Mac platform, a pragmatic approach has been taken to build a `hab` binary for macOS. This details the steps to build a release on macOS. It is also currently codified in [.buildkite/scripts/build_mac_release.sh](habitat-sh/habitat/.buildkite/scripts/build_mac_release.sh)
 
 ## Prerequisites
 
@@ -13,7 +13,7 @@ xcode-select --install
 
 ### Install Omnibus Bootstrap Toolchain package
 
-Since there is not yet a complete Habitat build toolchain available for MacOS, we provide the minimal set of binaries and static libraries needed to compile a `hab` binary using Chef's Omnibus tooling platform. This effectively takes the place of the packages we would add to a `pkg_build_deps` entry in a Habitat plan file.
+Since there is not yet a complete Habitat build toolchain available for macOS, we provide the minimal set of binaries and static libraries needed to compile a `hab` binary using Chef's Omnibus tooling platform. This effectively takes the place of the packages we would add to a `pkg_build_deps` entry in a Habitat plan file.
 
 TODO: Where can this package be retrieved from?
 

--- a/www/source/partials/docs/_reference-environment-vars.html.md.erb
+++ b/www/source/partials/docs/_reference-environment-vars.html.md.erb
@@ -10,7 +10,7 @@ This is a list of all environment variables that can be used to modify the opera
 | `HAB_CTL_SECRET` | Supervisor | no default | Shared secret used for [communicating with a Supervisor](/docs/using-habitat/#remote-control). |
 | `HAB_BLDR_CHANNEL` | build system, Supervisor | `stable` | Set the Habitat Builder channel you are subscribing to, to a specific channel. Defaults to `stable`.
 | `HAB_BLDR_URL` | build system, Supervisor | `https://bldr.habitat.sh` | Sets an alternate default endpoint for communicating with Builder. Used by the Habitat build system and the Supervisor |
-| `HAB_DOCKER_OPTS` | build system | no default | When running a Studio on a platform that uses Docker (MacOS), additional command line options to pass to the `docker` command. |
+| `HAB_DOCKER_OPTS` | build system | no default | When running a Studio on a platform that uses Docker (macOS), additional command line options to pass to the `docker` command. |
 | `HAB_INTERNAL_BLDR_CHANNEL` | build system, Supervisor, exporters | `stable` | Channel from which Habitat-specific packages (e.g., `core/hab-sup`, `core/hab-launcher`, etc.) are downloaded on-demand when first called. Generally of use only for those developing Habitat. Only applies to Habitat-specific packages, and nothing else. |
 | `HAB_NOCOLORING` | build system | no default | If set to the lowercase string `"true"` this environment variable will unconditionally disable text coloring where possible |
 | `HAB_NONINTERACTIVE` | build system | no default | If set to the lowercase string `"true"` this environment variable will unconditionally disable interactive progress bars (i.e. "spinners") where possible |


### PR DESCRIPTION
Mostly just little things around the edges. The most interesting / significant is that instead of promoting packages directly to `stable`, we first promote to `builder-live`, a new channel that Builder would be consuming from. Once a new Supervisor rolls out there, we then promote the same packages to `stable` for others to consume.

As always, read the commit messages for further details.