### PR TITLE
ensure RUNTIME_ENVIRONMENT does not include studio prefix

### DIFF
--- a/components/plan-build-ps1/bin/hab-plan-build.ps1
+++ b/components/plan-build-ps1/bin/hab-plan-build.ps1
@@ -503,7 +503,7 @@ function _Assemble-RuntimePath() {
               foreach($entry in $varval[1].split(";")) {
                 # Filter out entries that are not related to the `$dep_prefix`
                 if ("$entry" -Like "$strippedPrefix\*") {
-                  $paths = @(_return_or_append_to_set (_Resolve-Path $entry) $paths)
+                  $paths = @(_return_or_append_to_set $entry $paths)
                 }
               }
               break;


### PR DESCRIPTION
This is a regression that snuck in to 0.56.0 that prepends the full studio path to the runtime dependency paths. So the deps can't be located in a supervisor because it will be rooted to `c:\`.

Signed-off-by: mwrock <matt@mattwrock.com>