### PR TITLE
Provide a way to communicate with one's own Butterfly server

### DIFF
--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -869,7 +869,7 @@ impl Manager {
             service_group,
         );
         let mut client = match butterfly::client::Client::new(
-            format!("127.0.0.1:{}", mgr.cfg.gossip_listen.port()),
+            mgr.cfg.gossip_listen.local_addr(),
             mgr.cfg.ring_key.clone(),
         ) {
             Ok(client) => client,
@@ -907,7 +907,7 @@ impl Manager {
             service_group,
         );
         let mut client = match butterfly::client::Client::new(
-            format!("127.0.0.1:{}", mgr.cfg.gossip_listen.port()),
+            mgr.cfg.gossip_listen.local_addr(),
             mgr.cfg.ring_key.clone(),
         ) {
             Ok(client) => client,
@@ -1257,7 +1257,7 @@ impl Manager {
     ) -> NetResult<()> {
         let member_id = opts.member_id.ok_or(err_update_client())?;
         let mut client = match butterfly::client::Client::new(
-            format!("127.0.0.1:{}", mgr.cfg.gossip_listen.port()),
+            mgr.cfg.gossip_listen.local_addr(),
             mgr.cfg.ring_key.clone(),
         ) {
             Ok(client) => client,


### PR DESCRIPTION
Previously, when attempting to apply configuration, add files, or
depart a Supervisor (i.e., any command needing to interact directly
with the gossip layer), the operations would only work if the
Supervisor was listening on the default gossip address, which is
`0.0.0.0`. This is listening on _all_ interfaces, and thus, the
hard-coded loopback address `127.0.0.1` worked fine.

However, when listening on a non-default address, using
`--listen-gossip`, this would fail, since Butterfly would no longer be
listening at `127.0.0.1`.

Here, we provide a new `local_addr` function for the
`GossipListenAddr` struct. This function provides an address at which
the Butterfly server may be contacted locally, taking into account the
address it is listening at. If it is using the default `0.0.0.0` (the
"unspecified address"), it will return an address at `127.0.0.1`. On
the other hand, if a user has configured a different address, that
will be used directly.

Fixes #5257

Signed-off-by: Christopher Maier <cmaier@chef.io>