### PR TITLE
Allow Docker studio image name to be overridden

### DIFF
--- a/components/studio/build-docker-image.ps1
+++ b/components/studio/build-docker-image.ps1
@@ -11,7 +11,11 @@ if((Get-Command hab -ErrorAction SilentlyContinue) -eq $null) {
   Write-Error "   'hab' command must be present on PATH, aborting"
 }
 
-$imageName = "habitat-docker-registry.bintray.io/win-studio"
+If (-not (Test-Path env:IMAGE_NAME)) {
+   $imageName = "habitat-docker-registry.bintray.io/win-studio"
+} Else {
+   $imageName = $env:IMAGE_NAME
+}
 
 $startDir="$pwd"
 $tmpRoot = mkdir (Join-Path $env:TEMP ([System.IO.Path]::GetRandomFileName()))

--- a/components/studio/build-docker-image.sh
+++ b/components/studio/build-docker-image.sh
@@ -56,7 +56,7 @@ if ! command -v hab >/dev/null; then
   exit 9
 fi
 
-IMAGE_NAME=habitat-docker-registry.bintray.io/studio
+: "${IMAGE_NAME:=habitat-docker-registry.bintray.io/studio}"
 
 start_dir="$(pwd)"
 tmp_root="$(mktemp -d -t "$(basename "$0")-XXXX")"


### PR DESCRIPTION
Previously, the image was always created based on our Bintray
repository. This makes it more complicated than it should be to, say,
generate development images and push them to a separate
repository (yes, yes, you could always retag if you really wanted to).

This change allows us to set `IMAGE_NAME` in the environment if we
wish to generate the image with a different image name. If that
variable is not set, we'll continue to use the standard Bintray
repository.

Before:
``` sh
$ IMAGE_NAME=chuckleheads/studio HAB_BLDR_CHANNEL=stable ./build-docker-image.sh
...
Successfully tagged habitat-docker-registry.bintray.io/studio:0.59.0-20180712161521
--    build-docker-image.sh: Tagging latest image to habitat-docker-registry.bintray.io/studio:0.59.0-20180712161521
--    build-docker-image.sh: Tagging latest image to habitat-docker-registry.bintray.io/studio:0.59.0
--    build-docker-image.sh:
--    build-docker-image.sh: Docker Image: habitat-docker-registry.bintray.io/studio:0.59.0-20180712161521
--    build-docker-image.sh: Build Report: /home/maier/src/habitat-sh/habitat/components/studio/results/last_image.env
--    build-docker-image.sh:
```

After:
``` sh
$ IMAGE_NAME=chuckleheads/studio HAB_BLDR_CHANNEL=stable ./build-docker-image.sh
...
Successfully tagged chuckleheads/studio:0.59.0-20180712161521
--    build-docker-image.sh: Tagging latest image to chuckleheads/studio:0.59.0-20180712161521
--    build-docker-image.sh: Tagging latest image to chuckleheads/studio:0.59.0
--    build-docker-image.sh:
--    build-docker-image.sh: Docker Image: chuckleheads/studio:0.59.0-20180712161521
--    build-docker-image.sh: Build Report: /home/maier/src/habitat-sh/habitat/components/studio/results/last_image.env
--    build-docker-image.sh:
```

Signed-off-by: Christopher Maier <cmaier@chef.io>