### PR TITLE
add launcher appveyor build and always publish to unstable

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,6 +44,10 @@ environment:
       hab_exe_version: "%24latest"
       hab_components: "hab;plan-build-ps1;studio;sup;pkg-export-docker;pkg-export-tar;bintray-publish"
 
+    - hab_build_action: "package"
+      hab_exe_version: "%24latest"
+      hab_components: "launcher"
+
 build_script:
   - ps: Update-AppveyorBuild -Version "$((gc -raw ./VERSION).trim())-$((Get-Date).ToString('yyyyMMddHHmmss'))"
   - c:\projects\habitat\support\ci\appveyor.bat

--- a/support/ci/appveyor.ps1
+++ b/support/ci/appveyor.ps1
@@ -50,7 +50,7 @@ $version = $(Get-Content VERSION)
 write-host "TAG: $env:APPVEYOR_REPO_TAG_NAME"
 Write-Host "VERSION: $version"
 if (($env:APPVEYOR_REPO_TAG_NAME -eq $version) -or (Test-SourceChanged) -or (test-path env:HAB_FORCE_TEST)) {
-    if(Test-ReleaseBuild) {
+    if(Test-ReleaseBuild -and $env:hab_components -ne "launcher") {
         $channel = "rc-$version"
     }
     else {


### PR DESCRIPTION
We currently manually build the windows launcher on a developer laptop. The laptop is pretty nice but we want the build to come from CI. This will ensure that all launcher merges will produce an unstable build on builder. It will never include it in our RC channel so it does not get promoted to stable in every release. We will just promote manually on an as needed basis.

Signed-off-by: mwrock <matt@mattwrock.com>