### PR TITLE
Fix some release issues

### DIFF
--- a/.buildkite/scripts/bintray_upload.sh
+++ b/.buildkite/scripts/bintray_upload.sh
@@ -11,7 +11,7 @@ source .buildkite/scripts/shared.sh
 if is_fake_release; then
     bintray_repository=unstable
 else
-    bintray_reposiory=stable
+    bintray_repository=stable
 fi
 echo "--- Preparing to push artifacts to the ${bintray_repository} Bintray repository"
 

--- a/.buildkite/scripts/dockerhub_publish.sh
+++ b/.buildkite/scripts/dockerhub_publish.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 source .buildkite/scripts/shared.sh
 version=$(buildkite-agent meta-data get "version")
 
-if [[ "${FAKE_RELEASE_TAG}" ]]; then
+if is_fake_release; then
   # This overrides IMAGE_NAME in docker-base.sh
   export IMAGE_NAME="habitat/fakey-mc-fake-face-studio"
 fi

--- a/.buildkite/scripts/dockerhub_upload.sh
+++ b/.buildkite/scripts/dockerhub_upload.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 source .buildkite/scripts/shared.sh
 version=$(buildkite-agent meta-data get "version")
 
-if [[ "${FAKE_RELEASE_TAG}" ]]; then
+if is_fake_release; then
   # This overrides IMAGE_NAME in docker-base.sh
   export IMAGE_NAME="habitat/fakey-mc-fake-face-studio"
 fi


### PR DESCRIPTION
- It turns out that "repository" has a "t" in it; who knew?
- Use the `is_fake_release` helper function in the DockerHub scripts
  These were failing because the check for the `FAKE_RELEASE_TAG`
  variable would fail if the variable was completely unset.

![tenor-21441224](https://user-images.githubusercontent.com/207178/44060674-66218e2e-9f23-11e8-8d0b-1f6a7b076d84.gif)

Signed-off-by: Christopher Maier <cmaier@chef.io>