### PR TITLE
Don't quote HAB_STUDIO_SUP

### DIFF
--- a/components/rootless_studio/default/profile.enter
+++ b/components/rootless_studio/default/profile.enter
@@ -13,7 +13,8 @@ case "${HAB_STUDIO_SUP:-}" in
     # If false, we don't run the Supervisor
     ;;
   *)
-    sup-run "${HAB_STUDIO_SUP:-}"
+    # shellcheck disable=2086
+    sup-run ${HAB_STUDIO_SUP:-}
     echo "--> To prevent a Supervisor from running automatically in your"
     echo "    Studio, export 'HAB_STUDIO_SUP=false' before running"
     echo "    'hab studio enter'."

--- a/components/studio/libexec/hab-studio-type-default.sh
+++ b/components/studio/libexec/hab-studio-type-default.sh
@@ -219,7 +219,8 @@ case "\${HAB_STUDIO_SUP:-}" in
     # If false, we don't run the Supervisor
     ;;
   *)
-    sup-run "\${HAB_STUDIO_SUP:-}"
+    # shellcheck disable=2086
+    sup-run \${HAB_STUDIO_SUP:-}
     echo "--> To prevent a Supervisor from running automatically in your"
     echo "    Studio, export 'HAB_STUDIO_SUP=false' before running"
     echo "    'hab studio enter'."


### PR DESCRIPTION
If the variable isn't set, we end up passing "" as an argument, which
is interpreted by the Supervisor as a package identifier, which is not
legal.

This results in the Supervisor not being able to start properly when
entering a Studio. Manually running `sup-run` afterward starts things
up with no issues, though.

Signed-off-by: Christopher Maier <cmaier@chef.io>