### PR TITLE
[common] Remove a now unused dependency in `habitat-sh/builder`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -522,22 +522,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "habitat-builder-protocol"
-version = "0.0.0"
-source = "git+https://github.com/habitat-sh/builder.git#d0336bd26026cd47b02094ed6ffec1fdc53f2253"
-dependencies = [
- "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "habitat_core 0.0.0 (git+https://github.com/habitat-sh/core.git)",
- "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "habitat-eventsrv"
 version = "0.0.0"
 dependencies = [
@@ -731,7 +715,6 @@ dependencies = [
  "ansi_term 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy 0.0.187 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "habitat-builder-protocol 0.0.0 (git+https://github.com/habitat-sh/builder.git)",
  "habitat_api_client 0.0.0",
  "habitat_core 0.0.0 (git+https://github.com/habitat-sh/core.git)",
  "hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2761,7 +2744,6 @@ dependencies = [
 "checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
 "checksum getopts 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)" = "b900c08c1939860ce8b54dc6a89e26e00c04c380fd0e09796799bd7f12861e05"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
-"checksum habitat-builder-protocol 0.0.0 (git+https://github.com/habitat-sh/builder.git)" = "<none>"
 "checksum habitat_core 0.0.0 (git+https://github.com/habitat-sh/core.git)" = "<none>"
 "checksum habitat_http_client 0.0.0 (git+https://github.com/habitat-sh/core.git)" = "<none>"
 "checksum habitat_win_users 0.0.0 (git+https://github.com/habitat-sh/core.git)" = "<none>"

--- a/components/common/Cargo.toml
+++ b/components/common/Cargo.toml
@@ -8,7 +8,6 @@ workspace = "../../"
 clippy = {version = "*", optional = true}
 ansi_term = "*"
 glob = "*"
-habitat-builder-protocol = { git = "https://github.com/habitat-sh/builder.git" }
 hyper = "0.10"
 libc = "*"
 log = "*"

--- a/components/common/src/lib.rs
+++ b/components/common/src/lib.rs
@@ -18,7 +18,6 @@
 extern crate ansi_term;
 extern crate glob;
 extern crate habitat_api_client as api_client;
-extern crate habitat_builder_protocol as protocol;
 extern crate habitat_core as hcore;
 extern crate hyper;
 #[macro_use]


### PR DESCRIPTION
This change removes what appears to now be an orphaned dependency on
`habitat-builder-protocol` in the Builder repository. Sadly, this has
extended the dependency graph solving space enormously, so hopefully
removing this will help resolve dependency updates in
`habitat-sh/habitat`.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>