### PR TITLE
Don't segfault `plan init` on io::Error

### DIFF
--- a/components/hab/src/scaffolding.rs
+++ b/components/hab/src/scaffolding.rs
@@ -71,6 +71,7 @@ pub fn scaffold_check(ui: &mut UI, maybe_scaffold: Option<&str>) -> Result<Optio
         None => autodiscover_scaffolding(ui),
     }
 }
+
 fn autodiscover_scaffolding(ui: &mut UI) -> Result<Option<PackageIdent>> {
     // Determine if the current dir has an app that can use
     // one of our scaffoldings and use it by default
@@ -123,7 +124,7 @@ where
         || path.as_ref().join("Godeps/Godeps.json").is_file()
         || path.as_ref().join("vendor/vendor.json").is_file()
         || path.as_ref().join("glide.yaml").is_file()
-        || project_uses_gb(path.as_ref()).expect("Result<bool> not returned from .go file check")
+        || project_uses_gb(path.as_ref()).unwrap_or(false)
     {
         return true;
     }


### PR DESCRIPTION
Fixes #5194.

Short story - we have some code that checks for what kind of project you
are building, and attempts to auto-detect the right scaffold for you.
Hiding in there is a check for any file that has a `.go` extension; and
it's signature is `io::Result<bool>`.

The calling method expects to return just a bool - but rather than
handle the `io::Error`, we called an `expect` on it. Since the right
behavior would be to simply return `false` if we can't read the file
(because, clearly, we couldn't detect what kind of file it is), this
patch simply changes from `expect` to `or_else(false)`.

In the original bug report, it is noted that no backtrace is produced.
For future humans, you can find things like this with gdb pretty easily
if you know round-about where the source is:

```shell
$ rust-gdb --args /home/adam/src/habitat/target/debug/hab plan init foo
[gdb] break scaffolding.rs:83
[gdb] r
.. step through the code ..
```

Of course, you could also just grep for the expect string. But where is
the fun in that?

Love,
Adam

![tenor-264906049](https://user-images.githubusercontent.com/4304/44225435-61787d80-a142-11e8-9976-b4023676e677.gif)

Signed-off-by: Adam Jacob <adam@chef.io>