### PR TITLE
Improve error message when supervisor unavailable

### DIFF
--- a/components/sup-client/src/lib.rs
+++ b/components/sup-client/src/lib.rs
@@ -100,7 +100,15 @@ impl fmt::Display for SrvClientError {
                 path.display()
             ),
             SrvClientError::Decode(ref err) => format!("{}", err),
-            SrvClientError::Io(ref err) => format!("{}", err),
+            SrvClientError::Io(ref err) => format!(
+                "Unable to contact the Supervisor.\n\n\
+                If the Supervisor you are contacting is local, this probably means it is not running. You can run a Supervisor in the foreground with:\n\n\
+                   hab sup run\n\n\
+                Or try restarting the Supervisor through your oerating systems init process.\n\n\
+                Original error is:\n\n\
+                   {}",
+                err
+            ),
             SrvClientError::NetErr(ref err) => format!("{}", err),
         };
         write!(f, "{}", content)

--- a/components/sup-client/src/lib.rs
+++ b/components/sup-client/src/lib.rs
@@ -104,7 +104,7 @@ impl fmt::Display for SrvClientError {
                 "Unable to contact the Supervisor.\n\n\
                 If the Supervisor you are contacting is local, this probably means it is not running. You can run a Supervisor in the foreground with:\n\n\
                    hab sup run\n\n\
-                Or try restarting the Supervisor through your oerating systems init process.\n\n\
+                Or try restarting the Supervisor through your operating system's init process or Windows service.\n\n\
                 Original error is:\n\n\
                    {}",
                 err


### PR DESCRIPTION
This fixes #5367.

![tenor-57499504](https://user-images.githubusercontent.com/4304/44227962-d949a680-a148-11e8-84c6-4764d96d3dfc.gif)

Previously, when doing a `hab svc (load|unload)`, or any command that
requires remote control of the supervisor, if there was a network issue,
we would simply return the upstream description of the problem (most
often, something like `Connection refused (os error 111)`.

This wasn't a very user friendly error message. Now, on any `SvcClient`
command that returns an `SvcClientError::Io` error, we will print the
following:

```
✗✗✗
✗✗✗ Unable to contact the Supervisor.
✗✗✗
✗✗✗ If the Supervisor you are contacting is local, this probably means it is not running. You can run a Supervisor in the foreground with:
✗✗✗
✗✗✗ hab sup run
✗✗✗
✗✗✗ Or try restarting the Supervisor through your oerating systems init process.
✗✗✗
✗✗✗ Original error is:
✗✗✗
✗✗✗ Connection refused (os error 111)
✗✗✗
```

Which is, I think, much more helpful.

Signed-off-by: Adam Jacob <adam@chef.io>