### PR TITLE
 studio run should not be interactive

### DIFF
--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -680,7 +680,6 @@ fn sub_cli_completers() -> App<'static, 'static> {
 fn sub_pkg_build() -> App<'static, 'static> {
     let sub = clap_app!(@subcommand build =>
         (about: "Builds a Plan using a Studio")
-        (aliases: &["bu", "bui", "buil"])
         (@arg HAB_ORIGIN_KEYS: -k --keys +takes_value
             "Installs secret origin keys (ex: \"unicorn\", \"acme,other,acme-ops\")")
         (@arg HAB_STUDIO_ROOT: -r --root +takes_value

--- a/components/hab/src/command/studio/docker.rs
+++ b/components/hab/src/command/studio/docker.rs
@@ -278,9 +278,7 @@ where
     cmd_args.push("--name".into());
     cmd_args.push(name.into());
     match args.first().map(|f| f.to_str().unwrap_or_default()) {
-        Some("build") | Some("run") => {
-            cmd_args.push("--rm".into());
-        }
+        Some("build") | Some("run") => {}
         _ => {
             cmd_args.push("--tty".into());
             cmd_args.push("--interactive".into());

--- a/components/hab/src/command/studio/docker.rs
+++ b/components/hab/src/command/studio/docker.rs
@@ -278,7 +278,9 @@ where
     cmd_args.push("--name".into());
     cmd_args.push(name.into());
     match args.first().map(|f| f.to_str().unwrap_or_default()) {
-        Some("build") => {}
+        Some("build") | Some("run") => {
+            cmd_args.push("--rm".into());
+        }
         _ => {
             cmd_args.push("--tty".into());
             cmd_args.push("--interactive".into());

--- a/components/studio/bin/hab-studio.ps1
+++ b/components/studio/bin/hab-studio.ps1
@@ -378,8 +378,6 @@ function Invoke-StudioRun($cmd) {
   }
   New-Studio
   Write-HabInfo "Running '$cmd' in Studio at $HAB_STUDIO_ROOT"
-  New-PSDrive -Name "Habitat" -PSProvider FileSystem -Root $HAB_STUDIO_ROOT | Out-Null
-  Set-Location "Habitat:\src"
   Invoke-Expression $cmd
 }
 


### PR DESCRIPTION
This partially fixes #5459 and also fixes #5289. Note that while 5289 is directed at Windows, it is an issue for linux containers as well. We currently ensure that `pkg build` does not add `--tty` or `--interactive` and this adds the same for `studio run`.

Also, this includes a fix for Windows local `studio run` commands (run with `-w`). The local windows studio run was utterly broken previously.