### PR TITLE
[hab] Support -V (--version) flag on subcommands

### DIFF
--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -51,7 +51,7 @@ pub fn get() -> App<'static, 'static> {
         (about: "\"A Habitat is the natural environment for your services\" - Alan Turing")
         (version: super::VERSION)
         (author: "\nAuthors: The Habitat Maintainers <humans@habitat.sh>\n")
-        (@setting VersionlessSubcommands)
+        (@setting GlobalVersion)
         (@setting ArgRequiredElseHelp)
         (@subcommand cli =>
             (about: "Commands relating to Habitat runtime config")


### PR DESCRIPTION
Subcommand version output looks like:

```
> ../../target/debug/hab pkg --version
hab-pkg 0.62.0-dev
```

`hab sup --version` still outputs the version of the underlying
hab-sup binary:

```
> HAB_SUP_BINARY=/hab/pkgs/core/hab-sup/0.59.0/20180712161546/bin/hab-sup ../../target/debug/hab sup --version
hab-sup 0.59.0/20180712161546
```

Fixes #5370

Signed-off-by: Steven Danna <steve@chef.io>