### PR TITLE
Use common configuration values in release pipeline

### DIFF
--- a/.buildkite/scripts/build_component.sh
+++ b/.buildkite/scripts/build_component.sh
@@ -100,5 +100,5 @@ echo "<br>* ${pkg_ident} (Linux)" | buildkite-agent annotate --append --context 
 echo "--- :habicat: Uploading ${pkg_ident} to Builder in the '${channel}' channel"
 ${hab_binary} pkg upload \
     --channel="${channel}" \
-    --auth="${HAB_TEAM_AUTH_TOKEN}" \
+    --auth="${HAB_AUTH_TOKEN}" \
     "results/${pkg_artifact}"

--- a/.buildkite/scripts/destroy_release_channel.sh
+++ b/.buildkite/scripts/destroy_release_channel.sh
@@ -10,6 +10,6 @@ channel="$(buildkite-agent meta-data get release-channel)"
 echo "--- Destroying release channel '${channel}'"
 
 # TODO (CM): Once this command takes an --auth token, use that instead
-HAB_AUTH_TOKEN="${HAB_TEAM_AUTH_TOKEN}" hab bldr channel destroy \
+HAB_AUTH_TOKEN="${HAB_AUTH_TOKEN}" hab bldr channel destroy \
     --origin=core \
     "${channel}"

--- a/.buildkite/scripts/promote_launchers.sh
+++ b/.buildkite/scripts/promote_launchers.sh
@@ -27,7 +27,7 @@ windows_launcher="$(resolve_launcher windows-launcher x86_64-windows)"
 channel=$(buildkite-agent meta-data get "release-channel")
 
 echo "--- :linux: :habicat: Promoting ${linux_launcher} for Linux to ${channel}"
-hab pkg promote --auth="${HAB_TEAM_AUTH_TOKEN}" "${linux_launcher}" "${channel}"
+hab pkg promote --auth="${HAB_AUTH_TOKEN}" "${linux_launcher}" "${channel}"
 
 echo "--- :windows: :habicat: Promoting ${windows_launcher} for Windows to ${channel}"
-hab pkg promote --auth="${HAB_TEAM_AUTH_TOKEN}" "${windows_launcher}" "${channel}"
+hab pkg promote --auth="${HAB_AUTH_TOKEN}" "${windows_launcher}" "${channel}"

--- a/.buildkite/scripts/promote_release_channel.sh
+++ b/.buildkite/scripts/promote_release_channel.sh
@@ -70,13 +70,13 @@ supervisor_packages=($(echo "${channel_pkgs_json}" | \
 
 for pkg in "${non_supervisor_packages[@]}"; do
     echo "--- :habicat: Promoting '$pkg' to '$to_channel'"
-    hab pkg promote --auth="${HAB_TEAM_AUTH_TOKEN}" "${pkg}" "${to_channel}"
+    hab pkg promote --auth="${HAB_AUTH_TOKEN}" "${pkg}" "${to_channel}"
 done
 
 echo "--- :warning: PROMOTING SUPERVISORS TO '$to_channel' :warning:"
 for pkg in "${supervisor_packages[@]}"; do
     echo "--- :habicat: Promoting $pkg to $to_channel"
-    hab pkg promote --auth="${HAB_TEAM_AUTH_TOKEN}" "${pkg}" "${to_channel}"
+    hab pkg promote --auth="${HAB_AUTH_TOKEN}" "${pkg}" "${to_channel}"
 done
 
 buildkite-agent annotate --style="success" --context="release-manifest"

--- a/.buildkite/scripts/shared.sh
+++ b/.buildkite/scripts/shared.sh
@@ -11,7 +11,7 @@ import_keys() {
     ${hab_binary:?} origin key download core
     echo "--- :closed_lock_with_key: Downloading latest 'core' secret key from Builder"
     ${hab_binary:?} origin key download \
-        --auth="${HAB_TEAM_AUTH_TOKEN}" \
+        --auth="${HAB_AUTH_TOKEN}" \
         --secret \
         core
     # TODO (CM): delete the secret key later?


### PR DESCRIPTION
In initial versions of the Buildkite pipeline, we used a custom
`HAB_TEAM_AUTH_TOKEN` value. How that we're formalizing things more,
we can use the `HAB_AUTH_TOKEN` that is loaded in by our common
Release Engineering infrastructure.

Signed-off-by: Christopher Maier <cmaier@chef.io>