### PR TITLE
Change components/sup owners to include all all supervisor components

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,7 +11,7 @@ components/pkg-* @fnichol @christophermaier @eeyun
 components/plan-build @fnichol @christophermaier @elliott-davis @scotthain
 components/rootless_studio @elliott-davis
 components/studio @fnichol @baumanj @elliott-davis @eeyun
-components/sup @christophermaier @reset @fnichol @baumanj
+components/sup* @christophermaier @reset @fnichol @baumanj
 support @fnichol @baumanj @elliott-davis @raskchanky
 tools @baumanj @chefsalim @christophermaier @eeyun @raskchanky @fnichol
 www @cnunciato @mgamini @raskchanky


### PR DESCRIPTION
I noticed https://github.com/habitat-sh/habitat/pull/5465 didn't include the regular supervisor code owners, which is probably not the intent.

Signed-off-by: Jon Bauman <5906042+baumanj@users.noreply.github.com>