### PR TITLE
Add a supervisor version requirement checked by the launcher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -680,6 +680,7 @@ dependencies = [
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/components/launcher/Cargo.toml
+++ b/components/launcher/Cargo.toml
@@ -20,6 +20,7 @@ ipc-channel = { git = "https://github.com/habitat-sh/ipc-channel", branch = "hbt
 libc = "*"
 log = "*"
 protobuf = "1.5.1"
+semver = "*"
 time = "*"
 
 [target.'cfg(windows)'.dependencies]

--- a/components/launcher/src/error.rs
+++ b/components/launcher/src/error.rs
@@ -34,6 +34,7 @@ pub enum Error {
     Send(ipc_channel::Error),
     Serialize(protobuf::ProtobufError),
     Spawn(io::Error),
+    SupBinaryVersion,
     SupBinaryNotFound,
     SupPackageNotFound,
     SupShutdown,
@@ -59,6 +60,7 @@ impl fmt::Display for Error {
             Error::Send(ref e) => format!("Unable to send to Launcher's comm channel, {}", e),
             Error::Serialize(ref e) => format!("Unable to serialize message to Supervisor, {}", e),
             Error::Spawn(ref e) => format!("Unable to spawn process, {}", e),
+            Error::SupBinaryVersion => format!("Unsupported Supervisor binary version"),
             Error::SupBinaryNotFound => {
                 format!("Supervisor package didn't contain '{}' binary", SUP_CMD)
             }
@@ -85,6 +87,7 @@ impl error::Error for Error {
             Error::Send(_) => "Unable to send to Launcher's pipe",
             Error::Serialize(_) => "Unable to serialize message to Supervisor",
             Error::Spawn(_) => "Unable to spawn process",
+            Error::SupBinaryVersion => "Unsupported Supervisor binary version",
             Error::SupBinaryNotFound => "Unable to locate Supervisor binary in package",
             Error::SupPackageNotFound => "Unable to locate Supervisor package on disk",
             Error::SupShutdown => "Error waiting for Supervisor to shutdown",
@@ -102,5 +105,11 @@ impl From<Error> for protocol::ErrCode {
             Error::UserNotFound(_) => protocol::ErrCode::UserNotFound,
             _ => protocol::ErrCode::Unknown,
         }
+    }
+}
+
+impl From<io::Error> for Error {
+    fn from(err: io::Error) -> Error {
+        Error::SupSpawn(err)
     }
 }

--- a/components/launcher/src/lib.rs
+++ b/components/launcher/src/lib.rs
@@ -23,6 +23,7 @@ extern crate libc;
 #[macro_use]
 extern crate log;
 extern crate protobuf;
+extern crate semver;
 extern crate time;
 #[cfg(windows)]
 extern crate winapi;

--- a/test/end-to-end/test_launcher_checks_supervisor_version.sh
+++ b/test/end-to-end/test_launcher_checks_supervisor_version.sh
@@ -54,7 +54,7 @@ launcher_exits_with_error() {
 trap 'pgrep hab-launch &>/dev/null && pkill -9 hab-launch' INT TERM EXIT
 
 incompatible_version="0.55.0/20180321222338"
-if HAB_LAUNCH_NO_SUP_VERSION_CHECK= launcher_exits_with_error "$incompatible_version"; then
+if HAB_LAUNCH_NO_SUP_VERSION_CHECK='' launcher_exits_with_error "$incompatible_version"; then
     echo "Success! Launcher exited with error"
     echo
 else
@@ -71,7 +71,7 @@ else
 fi
 
 compatible_version="0.56.0/20180530235935"
-if HAB_LAUNCH_NO_SUP_VERSION_CHECK= launcher_exits_with_error "$compatible_version"; then
+if HAB_LAUNCH_NO_SUP_VERSION_CHECK='' launcher_exits_with_error "$compatible_version"; then
     echo "Failure! Expected launcher remain running"
     exit 1
 else
@@ -80,7 +80,7 @@ else
 fi
 
 dev_version="0.62.0-dev"
-if HAB_LAUNCH_NO_SUP_VERSION_CHECK= launcher_exits_with_error "$dev_version"; then
+if HAB_LAUNCH_NO_SUP_VERSION_CHECK='' launcher_exits_with_error "$dev_version"; then
     echo "Failure! Expected launcher remain running"
     exit 1
 else
@@ -89,7 +89,7 @@ else
 fi
 
 invalid_version="one-point-twenty-one"
-if HAB_LAUNCH_NO_SUP_VERSION_CHECK= launcher_exits_with_error "$invalid_version"; then
+if HAB_LAUNCH_NO_SUP_VERSION_CHECK='' launcher_exits_with_error "$invalid_version"; then
     echo "Success! Launcher exited with error"
     echo
 else

--- a/test/end-to-end/test_launcher_checks_supervisor_version.sh
+++ b/test/end-to-end/test_launcher_checks_supervisor_version.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+
+# A simple test that the launcher correctly checks the version of the
+# supervisor binary is compatible.
+#
+# To override and test locally-built code, set overrides in the environment of
+# the script.
+# See https://github.com/habitat-sh/habitat/blob/master/BUILDING.md#testing-changes
+
+set -eou pipefail
+
+create_sup_binary_stub() {
+    version=${1?}
+    binary=$(mktemp)
+
+    cat <<EOF > "$binary"
+#!/bin/bash
+echo "hab-sup $version"
+EOF
+
+    chmod +x "$binary"
+    echo "$binary"
+}
+
+launcher_exits_with_error() {
+    version=${1?}
+    sup_binary=$(create_sup_binary_stub "$version")
+
+    TESTING_FS_ROOT=$(mktemp -d)
+    export TESTING_FS_ROOT
+    sup_log=$(mktemp)
+
+    echo -n "Starting launcher with supervisor version \"$version\" (logging to $sup_log)..."
+    HAB_SUP_BINARY="$sup_binary" hab sup run &> "$sup_log" &
+    launcher_pid=$!
+
+    retries=0
+    max_retries=3
+    while ps -p "$launcher_pid" &>/dev/null; do
+        echo -n .
+        if [[ $((retries++)) -gt $max_retries ]]; then
+            echo
+            kill "$launcher_pid"
+            return 1
+        else
+            sleep 1
+        fi
+    done
+    echo
+
+    ! wait "$launcher_pid"
+}
+
+trap 'pgrep hab-launch &>/dev/null && pkill -9 hab-launch' INT TERM EXIT
+
+incompatible_version="0.55.0/20180321222338"
+if HAB_LAUNCH_NO_SUP_VERSION_CHECK= launcher_exits_with_error "$incompatible_version"; then
+    echo "Success! Launcher exited with error"
+    echo
+else
+    echo "Failure! Expected launcher to exit with error"
+    exit 1
+fi
+
+if HAB_LAUNCH_NO_SUP_VERSION_CHECK=1 launcher_exits_with_error "$incompatible_version"; then
+    echo "Failure! Expected launcher remain running"
+    exit 1
+else
+    echo "Success! Setting HAB_LAUNCH_NO_SUP_VERSION_CHECK skips version check"
+    echo
+fi
+
+compatible_version="0.56.0/20180530235935"
+if HAB_LAUNCH_NO_SUP_VERSION_CHECK= launcher_exits_with_error "$compatible_version"; then
+    echo "Failure! Expected launcher remain running"
+    exit 1
+else
+    echo "Success! Supervisor passed version check"
+    echo
+fi
+
+dev_version="0.62.0-dev"
+if HAB_LAUNCH_NO_SUP_VERSION_CHECK= launcher_exits_with_error "$dev_version"; then
+    echo "Failure! Expected launcher remain running"
+    exit 1
+else
+    echo "Success! Supervisor passed version check"
+    echo
+fi
+
+invalid_version="one-point-twenty-one"
+if HAB_LAUNCH_NO_SUP_VERSION_CHECK= launcher_exits_with_error "$invalid_version"; then
+    echo "Success! Launcher exited with error"
+    echo
+else
+    echo "Failure! Expected launcher to exit with error"
+    exit 1
+fi


### PR DESCRIPTION
The launcher needs to make assumptions about the supervisor binary's behavior,
so now it can be tied to a semantic version test that is part of the launcher
binary. In case this code is broken, an escape valve is provided in the form of
the HAB_LAUNCH_NO_SUP_VERSION_CHECK environment variable.

Resolves https://github.com/habitat-sh/habitat/issues/5388

Signed-off-by: Jon Bauman <5906042+baumanj@users.noreply.github.com>