### PR TITLE
explicitly error when attempting to remove a docker studio

### DIFF
--- a/components/hab/src/command/studio/docker.rs
+++ b/components/hab/src/command/studio/docker.rs
@@ -37,6 +37,10 @@ const DOCKER_SOCKET: &'static str = "/var/run/docker.sock";
 const HAB_STUDIO_SECRET: &'static str = "HAB_STUDIO_SECRET_";
 
 pub fn start_docker_studio(_ui: &mut UI, mut args: Vec<OsString>) -> Result<()> {
+    if args.get(0) == Some(&OsString::from("rm")) {
+        return Err(Error::CannotRemoveDockerStudio);
+    }
+
     let docker_cmd = find_docker_cmd()?;
 
     if is_image_present(&docker_cmd) {

--- a/components/hab/src/error.rs
+++ b/components/hab/src/error.rs
@@ -37,6 +37,7 @@ pub enum Error {
     APIClient(api_client::Error),
     ArgumentError(&'static str),
     ButterflyError(String),
+    CannotRemoveDockerStudio,
     CannotRemoveFromChannel((String, String)),
     CommandNotFoundInPkg((String, String)),
     CryptoCLI(String),
@@ -78,6 +79,9 @@ impl fmt::Display for Error {
             Error::APIClient(ref err) => format!("{}", err),
             Error::ArgumentError(ref e) => format!("{}", e),
             Error::ButterflyError(ref e) => format!("{}", e),
+            Error::CannotRemoveDockerStudio => {
+                format!("Docker Studios are not persistent and cannot be removed")
+            }
             Error::CannotRemoveFromChannel((ref p, ref c)) => {
                 format!("{} cannot be removed from the {} channel.", p, c)
             }
@@ -174,6 +178,9 @@ impl error::Error for Error {
             Error::ButterflyError(_) => "Butterfly has had an error",
             Error::CannotRemoveFromChannel(_) => {
                 "Package cannot be removed from the specified channel"
+            }
+            Error::CannotRemoveDockerStudio => {
+                "Docker Studios are not persistent and cannot be removed"
             }
             Error::CommandNotFoundInPkg(_) => {
                 "Command was not found under any 'PATH' directories in the package"


### PR DESCRIPTION
fixes #5155. The Windows Docker studio will try to delete `c:\` which fails but the fact is that removing an ephemeral studio is pointless and this just makes that more explicit.

Signed-off-by: mwrock <matt@mattwrock.com>