### PR TITLE
fix rootless studio issues with reuse and key exporting

### DIFF
--- a/components/hab/src/command/pkg/build.rs
+++ b/components/hab/src/command/pkg/build.rs
@@ -43,7 +43,7 @@ pub fn start(
         args.push(keys.into());
     }
     args.push("build".into());
-    if cfg!(not(target_os = "linux")) || reuse {
+    if cfg!(target_os = "linux") && reuse {
         args.push("-R".into());
     }
     args.push(plan_context.into());

--- a/components/rootless_studio/default/etc/habitat-studio/import_keys.sh
+++ b/components/rootless_studio/default/etc/habitat-studio/import_keys.sh
@@ -2,6 +2,8 @@
 
 source /etc/habitat-studio/logging.sh
 
+: "${HAB_ORIGIN_KEYS:=${HAB_ORIGIN:-}}"
+
 if [ -n "$HAB_ORIGIN_KEYS" ]; then
   # There's a method to this madness: `hab` is the raw path to `hab`
   # will use the outside cache key path, whereas the `hab` function has


### PR DESCRIPTION
This should fix:

1. `-R` getting passed to `plan-build` in a rootless studio
1. keys not defaulting to origin in a rootless studio.

Signed-off-by: mwrock <matt@mattwrock.com>