### PR TITLE
Relax the version pins for the various `prost` crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,7 +95,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.73 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.74 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -104,7 +104,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.73 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.74 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -182,8 +182,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.73 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.73 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.74 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.74 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -250,8 +250,8 @@ dependencies = [
  "quine-mc_cluskey 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.73 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.73 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.74 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.74 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-normalization 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -622,8 +622,8 @@ dependencies = [
  "pbr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "retry 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.73 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.73 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.74 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.74 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "tabwriter 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tar 0.4.16 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -647,8 +647,8 @@ dependencies = [
  "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.73 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.73 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.74 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.74 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "zmq 0.8.2 (git+https://github.com/erickt/rust-zmq?branch=release/v0.8)",
 ]
@@ -676,8 +676,8 @@ dependencies = [
  "protobuf 1.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "protoc 1.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "protoc-rust 1.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.73 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.73 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.74 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.74 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -710,7 +710,7 @@ dependencies = [
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.73 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.74 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -719,8 +719,8 @@ version = "0.0.0"
 dependencies = [
  "pkg-config 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.73 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.73 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.74 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.74 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -754,8 +754,8 @@ dependencies = [
  "prost-derive 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.73 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.73 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.74 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.74 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -777,8 +777,8 @@ dependencies = [
  "pbr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.73 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.73 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.74 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.74 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "tee 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -802,8 +802,8 @@ dependencies = [
  "prost-build 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-derive 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.73 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.73 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.74 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.74 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "threadpool 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -849,7 +849,7 @@ dependencies = [
 [[package]]
 name = "habitat_core"
 version = "0.0.0"
-source = "git+https://github.com/habitat-sh/core.git#63462d7c7974560170cf694dad059ab80006dd68"
+source = "git+https://github.com/habitat-sh/core.git#58a003c0254d9adfc61309714107faeda07e0731"
 dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -867,8 +867,8 @@ dependencies = [
  "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.73 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.73 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.74 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.74 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "sodiumoxide 0.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -884,7 +884,7 @@ dependencies = [
 [[package]]
 name = "habitat_http_client"
 version = "0.0.0"
-source = "git+https://github.com/habitat-sh/core.git#63462d7c7974560170cf694dad059ab80006dd68"
+source = "git+https://github.com/habitat-sh/core.git#58a003c0254d9adfc61309714107faeda07e0731"
 dependencies = [
  "base64 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat_core 0.0.0 (git+https://github.com/habitat-sh/core.git)",
@@ -893,7 +893,7 @@ dependencies = [
  "hyper-openssl 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.9.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.73 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.74 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -918,7 +918,7 @@ dependencies = [
  "rusoto_core 0.33.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_credential 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_ecr 0.33.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.73 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.74 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -939,7 +939,7 @@ dependencies = [
  "handlebars 0.29.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.73 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.74 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -958,7 +958,7 @@ dependencies = [
  "habitat_pkg_export_docker 0.0.0",
  "handlebars 0.29.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.73 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.74 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -979,7 +979,7 @@ dependencies = [
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "mktemp 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.73 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.74 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "tar 0.4.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1025,9 +1025,9 @@ dependencies = [
  "regex 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "router 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.73 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.74 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-transcode 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.73 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.74 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1044,7 +1044,7 @@ dependencies = [
 [[package]]
 name = "habitat_win_users"
 version = "0.0.0"
-source = "git+https://github.com/habitat-sh/core.git#63462d7c7974560170cf694dad059ab80006dd68"
+source = "git+https://github.com/habitat-sh/core.git#58a003c0254d9adfc61309714107faeda07e0731"
 dependencies = [
  "gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1062,7 +1062,7 @@ dependencies = [
  "pest 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.73 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.74 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1076,7 +1076,7 @@ dependencies = [
  "pest 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.73 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.74 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1258,7 +1258,7 @@ dependencies = [
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.73 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.74 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1301,7 +1301,7 @@ name = "jsonway"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.73 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.74 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2031,7 +2031,7 @@ dependencies = [
  "md5 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_credential 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.73 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.74 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2062,8 +2062,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_core 0.33.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.73 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.73 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.74 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.74 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2099,7 +2099,7 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -2160,7 +2160,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.73 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.74 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2170,7 +2170,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "1.0.73"
+version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -2178,12 +2178,12 @@ name = "serde-transcode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.73 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.74 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.73"
+version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2197,8 +2197,8 @@ version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "itoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "ryu 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.73 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ryu 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.74 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2208,7 +2208,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dtoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.73 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.74 (registry+https://github.com/rust-lang/crates.io-index)",
  "yaml-rust 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2245,7 +2245,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsodium-sys 0.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.73 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.74 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2566,7 +2566,7 @@ name = "toml"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.73 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.74 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2724,7 +2724,7 @@ dependencies = [
  "phf 0.7.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "phf_codegen 0.7.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.73 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.74 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "traitobject 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3055,7 +3055,7 @@ dependencies = [
 "checksum rustc-demangle 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "bcfe5b13211b4d78e5c2cadfebd7769197d95c639c35a50057eb4c05de811395"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-"checksum ryu 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "fd0568787116e13c652377b6846f5931454a363a8fdf8ae50463ee40935b278b"
+"checksum ryu 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e7c066b8e2923f05d4718a06d2622f189ff362bc642bfade6c6629f0440f3827"
 "checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
 "checksum same-file 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "cfb6eded0b06a0b512c8ddbcf04089138c9b4362c2f696f3c3d76039d68f3637"
 "checksum schannel 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "dc1fabf2a7b6483a141426e1afd09ad543520a77ac49bd03c286e7696ccfd77f"
@@ -3065,9 +3065,9 @@ dependencies = [
 "checksum security-framework-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "5421621e836278a0b139268f36eee0dc7e389b784dc3f79d8f11aabadf41bead"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-"checksum serde 1.0.73 (registry+https://github.com/rust-lang/crates.io-index)" = "672d47c054c8aaeea272f8bb3793ebbdb793f7b0ab879a55229a4576cb2e137d"
+"checksum serde 1.0.74 (registry+https://github.com/rust-lang/crates.io-index)" = "f218becd0d51dd24297ef804cb9b2de179dcdc2a3ddf8a73b04b4d595d9e6338"
 "checksum serde-transcode 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "749b7fac35f05313d1b3986c0bee75472614aeeb428eec30d18dc66858fb52cc"
-"checksum serde_derive 1.0.73 (registry+https://github.com/rust-lang/crates.io-index)" = "bf27cb4c5cc0565f28cf097c76d4cbb8e51cee945df7162c57e34bff11ca1ee9"
+"checksum serde_derive 1.0.74 (registry+https://github.com/rust-lang/crates.io-index)" = "47e3375b02728fa6f8c53cb8c1ad3dea7689e12793b6af399ad1e0e202f91c18"
 "checksum serde_json 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)" = "44dd2cfde475037451fa99b7e5df77aa3cfd1536575fa8e7a538ab36dcde49ae"
 "checksum serde_yaml 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "034654d5cd9f4c52bdf3a829da0811bff74a4b61c35784409124fb3b44f0674f"
 "checksum sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9eb6be24e4c23a84d7184280d2722f7f2731fcdd4a9d886efbfe4413e4847ea0"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -730,7 +730,7 @@ dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat-sup-protocol 0.0.0",
  "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "prost 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protoc 1.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "protoc-rust 1.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -749,10 +749,10 @@ dependencies = [
  "heck 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "prost 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "prost-build 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "prost-derive 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "prost-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost-build 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost-derive 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost-types 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.74 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.74 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -798,9 +798,9 @@ dependencies = [
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "prost 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "prost-build 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "prost-derive 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost-build 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost-derive 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.74 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.74 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1019,7 +1019,7 @@ dependencies = [
  "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "notify 4.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "persistent 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "prost 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1754,14 +1754,6 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "proc-macro2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -1770,7 +1762,7 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1779,7 +1771,7 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1789,31 +1781,32 @@ dependencies = [
  "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "multimap 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "petgraph 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "prost 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "prost-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost-types 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "which 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "prost-derive"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.12.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "prost-types"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "prost 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "prost-derive 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost-derive 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1860,14 +1853,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "quine-mc_cluskey"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "quote"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "quote"
@@ -2257,16 +2242,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "strsim"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "syn"
-version = "0.12.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "syn"
@@ -2772,6 +2747,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "widestring"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3018,19 +3002,17 @@ dependencies = [
 "checksum phf_shared 0.7.22 (registry+https://github.com/rust-lang/crates.io-index)" = "c2261d544c2bb6aa3b10022b0be371b9c7c64f762ef28c6f5d4f1ef6d97b5930"
 "checksum pkg-config 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)" = "104630aa1c83213cbc76db0703630fcb0421dac3585063be4ce9a8a2feeaa745"
 "checksum plugin 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "1a6a0dc3910bc8db877ffed8e457763b317cf880df4ae19109b9f77d277cf6e0"
-"checksum proc-macro2 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cd07deb3c6d1d9ff827999c7f9b04cdfd66b1b17ae508e14fe47b620f2282ae0"
 "checksum proc-macro2 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)" = "ee5697238f0d893c7f0ecc59c0999f18d2af85e424de441178bcacc9f9e6cf67"
-"checksum prost 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e5a92e500b2c925e5a6638a9523ce84bee02a4f64a8a3a0fab6062cda21e6ae4"
-"checksum prost-build 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "835da55b61e69c87eeab48f15eb3fc0dfade71f0908bb1a64e731abc46b3184f"
-"checksum prost-derive 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f5f076576836a88ee2f68198b5f02672f18697072b6ebd08ba8dbe02cf222bae"
-"checksum prost-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "49b4fc1adae913fff99daa455ca43750f90cbec6846369fb78b7ed8d3e727758"
+"checksum prost 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b9f36c478cd43382388dfc3a3679af175c03d19ed8039e79a3e4447e944cd3f3"
+"checksum prost-build 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b6325275b85605f58f576456a47af44417edf5956a6f670bb59fbe12aff69597"
+"checksum prost-derive 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9787d1977ea72e8066d58e46ae66100324a2815e677897fe78dfe54958f48252"
+"checksum prost-types 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5644c57d56bc085f9570e113495c1f08d7185beca700dcc296cb4672f380a679"
 "checksum protobuf 1.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "52fbc45bf6709565e44ef31847eb7407b3c3c80af811ee884a04da071dcca12b"
 "checksum protoc 1.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ad0f6d6911ee5a10a078099476f1c573894a8b90e86701a6a7a3bd66bfe75749"
 "checksum protoc-rust 1.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "31e894f64966af9641e9c2b2bfa3a4c00216eea2a226034f6bc609d23d6df740"
 "checksum pulldown-cmark 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d6fdf85cda6cadfae5428a54661d431330b312bc767ddbc57adbedc24da66e32"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quine-mc_cluskey 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "07589615d719a60c8dd8a4622e7946465dfef20d1a428f969e3443e7386d5f45"
-"checksum quote 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1eca14c727ad12702eb4b6bfb5a232287dcf8385cb8ca83a3eeaf6519c44c408"
 "checksum quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "dd636425967c33af890042c483632d33fa7a18f19ad1d7ea72e8998c6ef8dea5"
 "checksum rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "15a732abf9d20f0ad8eeb6f909bf6868722d9a06e1e50802b6a70351f40b4eb1"
 "checksum rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8356f47b32624fef5b3301c1be97e5944ecdd595409cc5da11d05f211db6cfbd"
@@ -3077,7 +3059,6 @@ dependencies = [
 "checksum sodiumoxide 0.0.16 (registry+https://github.com/rust-lang/crates.io-index)" = "eb5cb2f14f9a51352ad65e59257a0a9459d5a36a3615f3d53a974c82fdaaa00a"
 "checksum string 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00caf261d6f90f588f8450b8e1230fa0d5be49ee6140fdfbcb55335aff350970"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
-"checksum syn 0.12.15 (registry+https://github.com/rust-lang/crates.io-index)" = "c97c05b8ebc34ddd6b967994d5c6e9852fa92f8b82b3858c39451f97346dcce5"
 "checksum syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)" = "261ae9ecaa397c42b960649561949d69311f08eeaea86a65696e6e46517cf741"
 "checksum synstructure 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "85bb9b7550d063ea184027c9b8c20ac167cd36d3e06b3a40bceb9d746dc1a7b7"
 "checksum tabwriter 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9128e3a9149e51494cad59712a286e149fcb74e443d2298d69bd6eaa42cc4ebb"
@@ -3137,6 +3118,7 @@ dependencies = [
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum walkdir 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "419601ffa0ee0aa9e63163092ad7f825973a1859d6bc894e969f6df52f4c4209"
 "checksum want 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "797464475f30ddb8830cc529aaaae648d581f99e2036a928877dfde027ddf6b3"
+"checksum which 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49c4f580e93079b70ac522e7bdebbe1568c8afa7d8d05ee534ee737ca37d2f51"
 "checksum widestring 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "effc0e4ff8085673ea7b9b2e3c73f6bd4d118810c9009ed8f1e16bd96c331db6"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "773ef9dcc5f24b7d850d0ff101e542ff24c3b090a9768e03ff889fdef41f00fd"

--- a/components/butterfly/Cargo.toml
+++ b/components/butterfly/Cargo.toml
@@ -18,8 +18,8 @@ env_logger = "*"
 habitat_core = { git = "https://github.com/habitat-sh/core.git" }
 log = "*"
 lazy_static = "*"
-prost = "0.3.2"
-prost-derive = "0.3.2"
+prost = "*"
+prost-derive = "*"
 rand = "*"
 serde = "*"
 serde_derive = "*"
@@ -36,8 +36,8 @@ habitat_butterfly_test = { path = "../butterfly-test" }
 [build-dependencies]
 heck = "*"
 pkg-config = "0.3"
-prost = "0.3.2"
-prost-build = "0.3.2"
+prost = "*"
+prost-build = "*"
 tempdir = "*"
 
 [features]

--- a/components/butterfly/build.rs
+++ b/components/butterfly/build.rs
@@ -14,7 +14,7 @@ fn main() {
 
 fn generate_protocols() {
     let mut config = prost_build::Config::new();
-    config.type_attribute(".", "#[derive(Serialize, Deserialize, Hash)]");
+    config.type_attribute(".", "#[derive(Serialize, Deserialize)]");
     config
         .compile_protos(&protocol_files(), &protocol_includes())
         .expect("Error compiling protobuf definitions");

--- a/components/butterfly/src/generated/butterfly.common.rs
+++ b/components/butterfly/src/generated/butterfly.common.rs
@@ -1,5 +1,5 @@
 #[derive(Clone, PartialEq, Message)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Serialize, Deserialize)]
 pub struct Wire {
     #[prost(bool, optional, tag="1", default="false")]
     pub encrypted: ::std::option::Option<bool>,

--- a/components/butterfly/src/generated/butterfly.newscast.rs
+++ b/components/butterfly/src/generated/butterfly.newscast.rs
@@ -1,5 +1,5 @@
 #[derive(Clone, PartialEq, Message)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Serialize, Deserialize)]
 pub struct Election {
     #[prost(string, optional, tag="1")]
     pub member_id: ::std::option::Option<String>,
@@ -15,8 +15,8 @@ pub struct Election {
     pub votes: ::std::vec::Vec<String>,
 }
 pub mod election {
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Enumeration)]
-    #[derive(Serialize, Deserialize, Hash)]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Enumeration)]
+    #[derive(Serialize, Deserialize)]
     pub enum Status {
         Running = 1,
         NoQuorum = 2,
@@ -24,7 +24,7 @@ pub mod election {
     }
 }
 #[derive(Clone, PartialEq, Message)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Serialize, Deserialize)]
 pub struct Service {
     #[prost(string, optional, tag="1")]
     pub member_id: ::std::option::Option<String>,
@@ -42,7 +42,7 @@ pub struct Service {
     pub sys: ::std::option::Option<SysInfo>,
 }
 #[derive(Clone, PartialEq, Message)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Serialize, Deserialize)]
 pub struct ServiceConfig {
     #[prost(string, optional, tag="1")]
     pub service_group: ::std::option::Option<String>,
@@ -54,7 +54,7 @@ pub struct ServiceConfig {
     pub config: ::std::option::Option<Vec<u8>>,
 }
 #[derive(Clone, PartialEq, Message)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Serialize, Deserialize)]
 pub struct ServiceFile {
     #[prost(string, optional, tag="1")]
     pub service_group: ::std::option::Option<String>,
@@ -68,7 +68,7 @@ pub struct ServiceFile {
     pub body: ::std::option::Option<Vec<u8>>,
 }
 #[derive(Clone, PartialEq, Message)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Serialize, Deserialize)]
 pub struct SysInfo {
     #[prost(string, optional, tag="1", default="127.0.0.1")]
     pub ip: ::std::option::Option<String>,
@@ -88,13 +88,13 @@ pub struct SysInfo {
     pub ctl_gateway_port: ::std::option::Option<u32>,
 }
 #[derive(Clone, PartialEq, Message)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Serialize, Deserialize)]
 pub struct Departure {
     #[prost(string, optional, tag="1")]
     pub member_id: ::std::option::Option<String>,
 }
 #[derive(Clone, PartialEq, Message)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Serialize, Deserialize)]
 pub struct Rumor {
     #[prost(enumeration="rumor::Type", required, tag="1")]
     pub type_: i32,
@@ -106,8 +106,8 @@ pub struct Rumor {
     pub payload: ::std::option::Option<rumor::Payload>,
 }
 pub mod rumor {
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Enumeration)]
-    #[derive(Serialize, Deserialize, Hash)]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Enumeration)]
+    #[derive(Serialize, Deserialize)]
     pub enum Type {
         Member = 1,
         Service = 2,
@@ -120,7 +120,7 @@ pub mod rumor {
         Departure = 9,
     }
     #[derive(Clone, Oneof, PartialEq)]
-    #[derive(Serialize, Deserialize, Hash)]
+    #[derive(Serialize, Deserialize)]
     pub enum Payload {
         #[prost(message, tag="4")]
         Member(super::super::swim::Membership),

--- a/components/butterfly/src/generated/butterfly.swim.rs
+++ b/components/butterfly/src/generated/butterfly.swim.rs
@@ -1,5 +1,5 @@
 #[derive(Clone, PartialEq, Message)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Serialize, Deserialize)]
 pub struct Member {
     #[prost(string, optional, tag="1")]
     pub id: ::std::option::Option<String>,
@@ -17,7 +17,7 @@ pub struct Member {
     pub departed: ::std::option::Option<bool>,
 }
 #[derive(Clone, PartialEq, Message)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Serialize, Deserialize)]
 pub struct Ping {
     #[prost(message, optional, tag="1")]
     pub from: ::std::option::Option<Member>,
@@ -25,7 +25,7 @@ pub struct Ping {
     pub forward_to: ::std::option::Option<Member>,
 }
 #[derive(Clone, PartialEq, Message)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Serialize, Deserialize)]
 pub struct Ack {
     #[prost(message, optional, tag="1")]
     pub from: ::std::option::Option<Member>,
@@ -33,7 +33,7 @@ pub struct Ack {
     pub forward_to: ::std::option::Option<Member>,
 }
 #[derive(Clone, PartialEq, Message)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Serialize, Deserialize)]
 pub struct PingReq {
     #[prost(message, optional, tag="1")]
     pub from: ::std::option::Option<Member>,
@@ -41,7 +41,7 @@ pub struct PingReq {
     pub target: ::std::option::Option<Member>,
 }
 #[derive(Clone, PartialEq, Message)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Serialize, Deserialize)]
 pub struct Membership {
     #[prost(message, optional, tag="1")]
     pub member: ::std::option::Option<Member>,
@@ -49,8 +49,8 @@ pub struct Membership {
     pub health: ::std::option::Option<i32>,
 }
 pub mod membership {
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Enumeration)]
-    #[derive(Serialize, Deserialize, Hash)]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Enumeration)]
+    #[derive(Serialize, Deserialize)]
     pub enum Health {
         Alive = 1,
         Suspect = 2,
@@ -59,7 +59,7 @@ pub mod membership {
     }
 }
 #[derive(Clone, PartialEq, Message)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Serialize, Deserialize)]
 pub struct Swim {
     /// Identifies which field is filled in.
     #[prost(enumeration="swim::Type", required, tag="1")]
@@ -70,15 +70,15 @@ pub struct Swim {
     pub payload: ::std::option::Option<swim::Payload>,
 }
 pub mod swim {
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Enumeration)]
-    #[derive(Serialize, Deserialize, Hash)]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Enumeration)]
+    #[derive(Serialize, Deserialize)]
     pub enum Type {
         Ping = 1,
         Ack = 2,
         Pingreq = 3,
     }
     #[derive(Clone, Oneof, PartialEq)]
-    #[derive(Serialize, Deserialize, Hash)]
+    #[derive(Serialize, Deserialize)]
     pub enum Payload {
         #[prost(message, tag="2")]
         Ping(super::Ping),

--- a/components/sup-client/Cargo.toml
+++ b/components/sup-client/Cargo.toml
@@ -8,7 +8,7 @@ workspace = "../../"
 futures = "*"
 habitat-sup-protocol = { path = "../sup-protocol", default-features = false }
 log = "*"
-prost = "0.3.2"
+prost = "*"
 tokio = "*"
 tokio-core = "*"
 tokio-io = "*"

--- a/components/sup-protocol/Cargo.toml
+++ b/components/sup-protocol/Cargo.toml
@@ -12,8 +12,8 @@ futures = "*"
 habitat_core = { git = "https://github.com/habitat-sh/core.git" }
 lazy_static = "*"
 log = "*"
-prost = "0.3.2"
-prost-derive = "0.3.2"
+prost = "*"
+prost-derive = "*"
 rand = "*"
 serde = "*"
 serde_derive = "*"
@@ -22,9 +22,9 @@ tokio-io = "*"
 
 [build-dependencies]
 heck = "*"
-prost = "0.3.2"
-prost-build = "0.3.2"
-prost-types = "0.3.2"
+prost = "*"
+prost-build = "*"
+prost-types = "*"
 tempdir = "*"
 
 [dev-dependencies]

--- a/components/sup/Cargo.toml
+++ b/components/sup/Cargo.toml
@@ -47,7 +47,7 @@ libc = "*"
 log = "*"
 notify = "*"
 persistent = "*"
-prost = "0.3.2"
+prost = "*"
 protobuf = { version = "1.5.1", features = ["bytes"] }
 rand = "*"
 regex = "*"


### PR DESCRIPTION
Specifically `prost`, `prost-types`, `prost-build` and `prost-derive`.

This makes the minor fix in components/butterfly/build.rs to support the new
version and updates Cargo.lock.

See https://github.com/habitat-sh/habitat/issues/5467