### PR TITLE
Update protocol generation for new version of Prost

### DIFF
--- a/components/sup-protocol/src/generated/sup.ctl.rs
+++ b/components/sup-protocol/src/generated/sup.ctl.rs
@@ -1,6 +1,7 @@
 /// Networked progress bar for displaying a remote request's operation status over time.
 #[derive(Clone, PartialEq, Message)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Hash)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct NetProgress {
     /// Number of total units until bar is complete.
@@ -16,7 +17,8 @@ pub struct NetProgress {
 /// If the `secret_key` provided matches with what the server has then the client may continue
 /// sending requests. Connections will be aborted by the server if there is no match.
 #[derive(Clone, PartialEq, Message)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Hash)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct Handshake {
     /// A shared secret between the destination server and the calling client.
@@ -25,21 +27,24 @@ pub struct Handshake {
 }
 /// Wrapper type for a list of ServiceBinds.
 #[derive(Clone, PartialEq, Message)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Hash)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct ServiceBindList {
     #[prost(message, repeated, tag="1")]
     pub binds: ::std::vec::Vec<super::types::ServiceBind>,
 }
 #[derive(Clone, PartialEq, Message)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Hash)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct SupDepart {
     #[prost(string, optional, tag="1")]
     pub member_id: ::std::option::Option<String>,
 }
 #[derive(Clone, PartialEq, Message)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Hash)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct SvcFilePut {
     #[prost(message, optional, tag="1")]
@@ -55,7 +60,8 @@ pub struct SvcFilePut {
 }
 /// Request for retrieving the default configuration for a given service.
 #[derive(Clone, PartialEq, Message)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Hash)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct SvcGetDefaultCfg {
     /// Package identifier to target running service.
@@ -63,7 +69,8 @@ pub struct SvcGetDefaultCfg {
     pub ident: ::std::option::Option<super::types::PackageIdent>,
 }
 #[derive(Clone, PartialEq, Message)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Hash)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct SvcValidateCfg {
     /// Service group of a running service to validate a configuration change against.
@@ -78,7 +85,8 @@ pub struct SvcValidateCfg {
 }
 /// Request to set a running service's configuration to the given values.
 #[derive(Clone, PartialEq, Message)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Hash)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct SvcSetCfg {
     /// Service group of a running service to set a new configuration for.
@@ -96,7 +104,8 @@ pub struct SvcSetCfg {
 }
 /// Request to load a new service.
 #[derive(Clone, PartialEq, Message)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Hash)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct SvcLoad {
     /// Package identifier for the service to load. Using a more qualified identifier will load a
@@ -145,7 +154,8 @@ pub struct SvcLoad {
 }
 /// Request to unload a loaded service.
 #[derive(Clone, PartialEq, Message)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Hash)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct SvcUnload {
     #[prost(message, optional, tag="1")]
@@ -153,7 +163,8 @@ pub struct SvcUnload {
 }
 /// Request to start a loaded and stopped service.
 #[derive(Clone, PartialEq, Message)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Hash)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct SvcStart {
     #[prost(message, optional, tag="1")]
@@ -161,7 +172,8 @@ pub struct SvcStart {
 }
 /// Request to stop a loaded and started service.
 #[derive(Clone, PartialEq, Message)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Hash)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct SvcStop {
     #[prost(message, optional, tag="1")]
@@ -169,7 +181,8 @@ pub struct SvcStop {
 }
 /// Request to retrieve the service status of one or all services.
 #[derive(Clone, PartialEq, Message)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Hash)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct SvcStatus {
     /// If specified, the reply will contain only the service status for the requested service. If
@@ -179,7 +192,8 @@ pub struct SvcStatus {
 }
 /// A reply to various requests which contains a pre-formatted console line.
 #[derive(Clone, PartialEq, Message)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Hash)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct ConsoleLine {
     #[prost(string, required, tag="1")]

--- a/components/sup-protocol/src/generated/sup.net.rs
+++ b/components/sup-protocol/src/generated/sup.net.rs
@@ -1,7 +1,8 @@
 /// Returned when a transactional request is successful but no entities are returned. Useful
 /// when making a request which requires no response but the caller wants to block for completion.
 #[derive(Clone, PartialEq, Message)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Hash)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct NetOk {
 }
@@ -11,7 +12,8 @@ pub struct NetOk {
 /// Failure reasons are ideally unique and should be user readable. Localization doesn't matter at
 /// this time.
 #[derive(Clone, PartialEq, Message)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Hash)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct NetErr {
     #[prost(enumeration="ErrCode", required, tag="1")]
@@ -20,8 +22,8 @@ pub struct NetErr {
     pub msg: String,
 }
 /// Error codes mapping to a high level failure reason for a `NetErr`.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Enumeration)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Enumeration)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum ErrCode {
     Internal = 0,

--- a/components/sup-protocol/src/generated/sup.types.rs
+++ b/components/sup-protocol/src/generated/sup.types.rs
@@ -1,5 +1,6 @@
 #[derive(Clone, PartialEq, Message)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Hash)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct ApplicationEnvironment {
     #[prost(string, required, tag="1")]
@@ -8,7 +9,8 @@ pub struct ApplicationEnvironment {
     pub environment: String,
 }
 #[derive(Clone, PartialEq, Message)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Hash)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct PackageIdent {
     #[prost(string, required, tag="1")]
@@ -21,7 +23,8 @@ pub struct PackageIdent {
     pub release: ::std::option::Option<String>,
 }
 #[derive(Clone, PartialEq, Message)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Hash)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct ProcessStatus {
     #[prost(int64, optional, tag="1")]
@@ -32,7 +35,8 @@ pub struct ProcessStatus {
     pub state: i32,
 }
 #[derive(Clone, PartialEq, Message)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Hash)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct ServiceBind {
     #[prost(string, required, tag="1")]
@@ -43,7 +47,8 @@ pub struct ServiceBind {
     pub service_name: ::std::option::Option<String>,
 }
 #[derive(Clone, PartialEq, Message)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Hash)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct ServiceCfg {
     /// The self describing string format used in each configuration field. This
@@ -55,15 +60,16 @@ pub struct ServiceCfg {
     pub default: ::std::option::Option<String>,
 }
 pub mod service_cfg {
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Enumeration)]
-    #[derive(Serialize, Deserialize, Hash)]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Enumeration)]
+    #[derive(Serialize, Deserialize)]
     #[serde(rename_all = "kebab-case")]
     pub enum Format {
         Toml = 0,
     }
 }
 #[derive(Clone, PartialEq, Message)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Hash)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct ServiceGroup {
     #[prost(string, required, tag="1")]
@@ -76,7 +82,8 @@ pub struct ServiceGroup {
     pub organization: ::std::option::Option<String>,
 }
 #[derive(Clone, PartialEq, Message)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Hash)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct ServiceStatus {
     #[prost(message, required, tag="1")]
@@ -91,8 +98,8 @@ pub struct ServiceStatus {
     pub desired_state: ::std::option::Option<i32>,
 }
 /// Encapsulate all possible sources we can install packages from.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Enumeration)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Enumeration)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum InstallSource {
     /// Install from a remote hosting the package
@@ -100,38 +107,38 @@ pub enum InstallSource {
     /// Install from a local archive file
     Archive = 1,
 }
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Enumeration)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Enumeration)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum ProcessState {
     Down = 0,
     Up = 1,
 }
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Enumeration)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Enumeration)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum DesiredState {
     DesiredDown = 0,
     DesiredUp = 1,
 }
 /// The relationship of a service with peers in the same service group.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Enumeration)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Enumeration)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum Topology {
     Standalone = 0,
     Leader = 1,
 }
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Enumeration)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Enumeration)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum UpdateStrategy {
     None = 0,
     AtOnce = 1,
     Rolling = 2,
 }
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Enumeration)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Enumeration)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum BindingMode {
     /// Services may start whether binds are available or not


### PR DESCRIPTION
As of version 0.4.0 or so, Prost automatically derives the `Hash`
trait (along with `Ord`, `PartialOrd`, and `Enumeration`) for all Enum
types.

This means that our previous usage of

``` rust
config.type_attribute(".", "#[derive(Serialize, Deserialize, Hash)]");
```

was no longer working, because the manually-added Hash was conflicting
with the Prost-generated one.

There does not seem to be away to negate the arguments for
`config#type_attribute` (i.e. "don't add this attribute to this
type"), or constrain the types to which it applies (i.e. "apply this
only to struct types"), so a work-around is to explicitly list the
names of all non-`Enum` types here, so we can add the `Hash` derivation
ourselves.

This is functionally the same as it was before (_all_ our types
still derive `Hash`)... it's just a little more verbose 😦 

![tenor-60501127](https://user-images.githubusercontent.com/207178/44609129-82854200-a7c4-11e8-8a7f-eae0fb231765.gif)


Signed-off-by: Christopher Maier <cmaier@chef.io>