### PR TITLE
Update sup-protocol protocol generation process

### DIFF
--- a/components/sup-protocol/build.rs
+++ b/components/sup-protocol/build.rs
@@ -26,7 +26,7 @@ fn main() {
 
 fn generate_protocols() {
     let mut config = prost_build::Config::new();
-    config.type_attribute(".", "#[derive(Serialize, Deserialize, Hash)]");
+    config.type_attribute(".", "#[derive(Serialize, Deserialize)]");
     config.type_attribute(".", "#[serde(rename_all = \"kebab-case\")]");
     config
         .compile_protos(&protocol_files(), &protocol_includes())

--- a/components/sup-protocol/src/generated/sup.ctl.rs
+++ b/components/sup-protocol/src/generated/sup.ctl.rs
@@ -1,6 +1,6 @@
 /// Networked progress bar for displaying a remote request's operation status over time.
 #[derive(Clone, PartialEq, Message)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct NetProgress {
     /// Number of total units until bar is complete.
@@ -16,7 +16,7 @@ pub struct NetProgress {
 /// If the `secret_key` provided matches with what the server has then the client may continue
 /// sending requests. Connections will be aborted by the server if there is no match.
 #[derive(Clone, PartialEq, Message)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct Handshake {
     /// A shared secret between the destination server and the calling client.
@@ -25,21 +25,21 @@ pub struct Handshake {
 }
 /// Wrapper type for a list of ServiceBinds.
 #[derive(Clone, PartialEq, Message)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct ServiceBindList {
     #[prost(message, repeated, tag="1")]
     pub binds: ::std::vec::Vec<super::types::ServiceBind>,
 }
 #[derive(Clone, PartialEq, Message)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct SupDepart {
     #[prost(string, optional, tag="1")]
     pub member_id: ::std::option::Option<String>,
 }
 #[derive(Clone, PartialEq, Message)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct SvcFilePut {
     #[prost(message, optional, tag="1")]
@@ -55,7 +55,7 @@ pub struct SvcFilePut {
 }
 /// Request for retrieving the default configuration for a given service.
 #[derive(Clone, PartialEq, Message)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct SvcGetDefaultCfg {
     /// Package identifier to target running service.
@@ -63,7 +63,7 @@ pub struct SvcGetDefaultCfg {
     pub ident: ::std::option::Option<super::types::PackageIdent>,
 }
 #[derive(Clone, PartialEq, Message)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct SvcValidateCfg {
     /// Service group of a running service to validate a configuration change against.
@@ -78,7 +78,7 @@ pub struct SvcValidateCfg {
 }
 /// Request to set a running service's configuration to the given values.
 #[derive(Clone, PartialEq, Message)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct SvcSetCfg {
     /// Service group of a running service to set a new configuration for.
@@ -96,7 +96,7 @@ pub struct SvcSetCfg {
 }
 /// Request to load a new service.
 #[derive(Clone, PartialEq, Message)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct SvcLoad {
     /// Package identifier for the service to load. Using a more qualified identifier will load a
@@ -145,7 +145,7 @@ pub struct SvcLoad {
 }
 /// Request to unload a loaded service.
 #[derive(Clone, PartialEq, Message)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct SvcUnload {
     #[prost(message, optional, tag="1")]
@@ -153,7 +153,7 @@ pub struct SvcUnload {
 }
 /// Request to start a loaded and stopped service.
 #[derive(Clone, PartialEq, Message)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct SvcStart {
     #[prost(message, optional, tag="1")]
@@ -161,7 +161,7 @@ pub struct SvcStart {
 }
 /// Request to stop a loaded and started service.
 #[derive(Clone, PartialEq, Message)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct SvcStop {
     #[prost(message, optional, tag="1")]
@@ -169,7 +169,7 @@ pub struct SvcStop {
 }
 /// Request to retrieve the service status of one or all services.
 #[derive(Clone, PartialEq, Message)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct SvcStatus {
     /// If specified, the reply will contain only the service status for the requested service. If
@@ -179,7 +179,7 @@ pub struct SvcStatus {
 }
 /// A reply to various requests which contains a pre-formatted console line.
 #[derive(Clone, PartialEq, Message)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct ConsoleLine {
     #[prost(string, required, tag="1")]

--- a/components/sup-protocol/src/generated/sup.net.rs
+++ b/components/sup-protocol/src/generated/sup.net.rs
@@ -1,7 +1,7 @@
 /// Returned when a transactional request is successful but no entities are returned. Useful
 /// when making a request which requires no response but the caller wants to block for completion.
 #[derive(Clone, PartialEq, Message)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct NetOk {
 }
@@ -11,7 +11,7 @@ pub struct NetOk {
 /// Failure reasons are ideally unique and should be user readable. Localization doesn't matter at
 /// this time.
 #[derive(Clone, PartialEq, Message)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct NetErr {
     #[prost(enumeration="ErrCode", required, tag="1")]
@@ -20,8 +20,8 @@ pub struct NetErr {
     pub msg: String,
 }
 /// Error codes mapping to a high level failure reason for a `NetErr`.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Enumeration)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Enumeration)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum ErrCode {
     Internal = 0,

--- a/components/sup-protocol/src/generated/sup.types.rs
+++ b/components/sup-protocol/src/generated/sup.types.rs
@@ -1,5 +1,5 @@
 #[derive(Clone, PartialEq, Message)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct ApplicationEnvironment {
     #[prost(string, required, tag="1")]
@@ -8,7 +8,7 @@ pub struct ApplicationEnvironment {
     pub environment: String,
 }
 #[derive(Clone, PartialEq, Message)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct PackageIdent {
     #[prost(string, required, tag="1")]
@@ -21,7 +21,7 @@ pub struct PackageIdent {
     pub release: ::std::option::Option<String>,
 }
 #[derive(Clone, PartialEq, Message)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct ProcessStatus {
     #[prost(int64, optional, tag="1")]
@@ -32,7 +32,7 @@ pub struct ProcessStatus {
     pub state: i32,
 }
 #[derive(Clone, PartialEq, Message)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct ServiceBind {
     #[prost(string, required, tag="1")]
@@ -43,7 +43,7 @@ pub struct ServiceBind {
     pub service_name: ::std::option::Option<String>,
 }
 #[derive(Clone, PartialEq, Message)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct ServiceCfg {
     /// The self describing string format used in each configuration field. This
@@ -55,15 +55,15 @@ pub struct ServiceCfg {
     pub default: ::std::option::Option<String>,
 }
 pub mod service_cfg {
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Enumeration)]
-    #[derive(Serialize, Deserialize, Hash)]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Enumeration)]
+    #[derive(Serialize, Deserialize)]
     #[serde(rename_all = "kebab-case")]
     pub enum Format {
         Toml = 0,
     }
 }
 #[derive(Clone, PartialEq, Message)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct ServiceGroup {
     #[prost(string, required, tag="1")]
@@ -76,7 +76,7 @@ pub struct ServiceGroup {
     pub organization: ::std::option::Option<String>,
 }
 #[derive(Clone, PartialEq, Message)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct ServiceStatus {
     #[prost(message, required, tag="1")]
@@ -91,8 +91,8 @@ pub struct ServiceStatus {
     pub desired_state: ::std::option::Option<i32>,
 }
 /// Encapsulate all possible sources we can install packages from.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Enumeration)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Enumeration)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum InstallSource {
     /// Install from a remote hosting the package
@@ -100,38 +100,38 @@ pub enum InstallSource {
     /// Install from a local archive file
     Archive = 1,
 }
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Enumeration)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Enumeration)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum ProcessState {
     Down = 0,
     Up = 1,
 }
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Enumeration)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Enumeration)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum DesiredState {
     DesiredDown = 0,
     DesiredUp = 1,
 }
 /// The relationship of a service with peers in the same service group.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Enumeration)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Enumeration)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum Topology {
     Standalone = 0,
     Leader = 1,
 }
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Enumeration)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Enumeration)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum UpdateStrategy {
     None = 0,
     AtOnce = 1,
     Rolling = 2,
 }
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Enumeration)]
-#[derive(Serialize, Deserialize, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Enumeration)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum BindingMode {
     /// Services may start whether binds are available or not


### PR DESCRIPTION
Looks like these tweaks got left off #5501 accidentally.

(The new version of Prost automatically derives `Hash` for Enums, and
apparently none of the other types needed it.)

Signed-off-by: Christopher Maier <cmaier@chef.io>