### PR TITLE
Don't require `protoc` in package builds

### DIFF
--- a/components/sup/Cargo.toml
+++ b/components/sup/Cargo.toml
@@ -24,7 +24,7 @@ features = "*"
 futures = "*"
 glob = "*"
 hab = { path = "../hab" }
-habitat_butterfly = { path = "../butterfly" }
+habitat_butterfly = { path = "../butterfly", default-features = false }
 habitat_common = { path = "../common" }
 habitat_core = { git = "https://github.com/habitat-sh/core.git" }
 habitat_api_client = { path = "../builder-api-client" }
@@ -81,9 +81,6 @@ json = "*"
 
 [dev-dependencies.habitat_core]
 git = "https://github.com/habitat-sh/core.git"
-
-[dev-dependencies.habitat_butterfly]
-path = "../butterfly"
 
 [features]
 default = []

--- a/components/sup/plan.sh
+++ b/components/sup/plan.sh
@@ -16,8 +16,7 @@ pkg_build_deps=(core/coreutils/8.25/20170513213226
                 core/cacerts/2017.09.20/20171014212239
                 core/rust
                 core/gcc/5.2.0/20170513202244
-                core/raml2html/6.3.0/20180409195740
-                core/protobuf)
+                core/raml2html/6.3.0/20180409195740)
 pkg_bin_dirs=(bin)
 
 bin=$_pkg_distname
@@ -74,14 +73,6 @@ do_prepare() {
   # package proper--it won't find its way into the final binaries.
   export LD_LIBRARY_PATH=$(pkg_path_for gcc)/lib
   build_line "Setting LD_LIBRARY_PATH=$LD_LIBRARY_PATH"
-
-  # Prost (our Rust protobuf library) embeds a `protoc` binary, but
-  # it's dynamically linked, which means it won't work in a
-  # Studio. Prost does allow us to override that, though, so we can
-  # just use our Habitat package by setting these two environment
-  # variables.
-  export PROTOC="$(pkg_path_for protobuf)/bin/protoc"
-  export PROTOC_INCLUDE="$(pkg_path_for protobuf)/include"
 }
 
 do_build() {


### PR DESCRIPTION
As things currently stand, we shouldn't actually need a `protoc`
binary in the `core/hab-sup` package build because we shouldn't
actually be generating protobuf code in those builds.

This was done in
https://github.com/habitat-sh/habitat/pull/5179/commits/b167369c5ac4a69ef1e0f7731076f28e6de9d0c0,
but it turns out that we actually had misconfigured our
`habitat_butterfly` dependency. We should not have built with any
default features (of which protocol generation is one), and we
shouldn't have duplicated `habitat_butterfly` in our
dev-dependencies.

(I'm unsure why, but both of these changes seem to be required to
successfully build without a `protoc` binary. In any event,
duplicating the dev-dependency doesn't make sense and should be
removed anyway.)

Signed-off-by: Christopher Maier <cmaier@chef.io>