### PR TITLE
[api-client] Always set package target when making package API calls.

### DIFF
--- a/components/hab/src/command/pkg/upload.rs
+++ b/components/hab/src/command/pkg/upload.rs
@@ -108,14 +108,14 @@ where
     let ident = archive.ident()?;
     let target = archive.target()?;
 
-    match api_client.show_package(&ident, None, Some(token), Some(&target.to_string())) {
+    match api_client.show_package(&ident, &target, None, Some(token)) {
         Ok(_) if !force_upload => {
             ui.status(Status::Using, format!("existing {}", &ident))?;
             Ok(())
         }
         Err(api_client::Error::APIError(StatusCode::NotFound, _)) | Ok(_) => {
             for dep in tdeps.into_iter() {
-                match api_client.show_package(&dep, None, Some(token), Some(&target.to_string())) {
+                match api_client.show_package(&dep, &target, None, Some(token)) {
                     Ok(_) => ui.status(Status::Using, format!("existing {}", &dep))?,
                     Err(api_client::Error::APIError(StatusCode::NotFound, _)) => {
                         let candidate_path = match archive_path.as_ref().parent() {

--- a/components/hab/src/exec.rs
+++ b/components/hab/src/exec.rs
@@ -19,7 +19,7 @@ use common::command::package::install::{InstallMode, LocalPackageUsage};
 use common::ui::{Status, UIWriter, UI};
 use hcore::env as henv;
 use hcore::fs::{self, cache_artifact_path};
-use hcore::package::{PackageIdent, PackageInstall};
+use hcore::package::{PackageIdent, PackageInstall, PackageTarget};
 use hcore::url::default_bldr_url;
 use hcore::{self, channel};
 
@@ -91,7 +91,7 @@ where
                 ui,
                 &default_bldr_url(),
                 Some(&internal_tooling_channel()),
-                &ident.clone().into(),
+                &(ident.clone(), *PackageTarget::active_target()).into(),
                 PRODUCT,
                 VERSION,
                 fs_root_path,

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -200,7 +200,7 @@ fn sub_run(m: &ArgMatches, launcher: LauncherCli) -> Result<()> {
                 )?;
                 install.ident.into()
             }
-            InstallSource::Ident(ident) => ident.into(),
+            InstallSource::Ident(ident, _) => ident.into(),
         };
         msg.ident = Some(ident);
         Some(msg)

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -55,7 +55,7 @@ use hcore::fs::FS_ROOT_PATH;
 use hcore::os::process::{self, Pid, Signal};
 use hcore::os::signals::{self, SignalEvent};
 use hcore::package::metadata::PackageType;
-use hcore::package::{Identifiable, PackageIdent, PackageInstall};
+use hcore::package::{Identifiable, PackageIdent, PackageInstall, PackageTarget};
 use hcore::service::ServiceGroup;
 use launcher_client::{LauncherCli, LAUNCHER_LOCK_CLEAN_ENV, LAUNCHER_PID_ENV};
 use protocol;
@@ -949,7 +949,7 @@ impl Manager {
             .clone()
             .unwrap_or(protocol::DEFAULT_BLDR_CHANNEL.to_string());
         let force = opts.force.clone().unwrap_or(false);
-        let source = InstallSource::Ident(ident.clone());
+        let source = InstallSource::Ident(ident.clone(), *PackageTarget::active_target());
         match Self::existing_specs_for_ident(&mgr.cfg, source.as_ref())? {
             None => {
                 // We don't have any record of this thing; let's set it up!

--- a/components/sup/src/manager/service_updater.rs
+++ b/components/sup/src/manager/service_updater.rs
@@ -19,7 +19,7 @@ use std::thread;
 use butterfly;
 use common::ui::UI;
 use env;
-use hcore::package::{PackageIdent, PackageInstall};
+use hcore::package::{PackageIdent, PackageInstall, PackageTarget};
 use hcore::service::ServiceGroup;
 use launcher_client::LauncherCli;
 
@@ -389,7 +389,7 @@ impl Worker {
         // Fairly certain that this only gets called in a rolling update
         // scenario, where `ident` is always a fully-qualified identifier
         outputln!("Updating from {} to {}", self.current, ident);
-        let install_source = ident.into();
+        let install_source = (ident, *PackageTarget::active_target()).into();
         loop {
             let next_time = self.next_period_start();
 
@@ -415,7 +415,7 @@ impl Worker {
     /// Continually poll for a new version of a package, installing it
     /// when found.
     fn run_poll(&mut self, sender: SyncSender<PackageInstall>) {
-        let install_source = self.spec_ident.clone().into(); // UGH clone
+        let install_source = (self.spec_ident.clone(), *PackageTarget::active_target()).into();
         loop {
             let next_time = self.next_period_start();
 


### PR DESCRIPTION
This change starts in the Builder API client and flows out from there
with the goal of always providing an appropriate package target when
calling package-related API endpoints. This means for these calls
(namely, `fetch_package` and `show_package`) a non-optional
`PackageTarget` is required. Depending on the calling code, this value
could be provided upstream (i.e. user-provided value, reading from a
config file, etc.) or the compiled program's
`PackageTarget::active_target()` should be used. In all cases, the
derived value will always be clear.

As mentioned before, this work started in `builder-api-client`, and
rippled up (in a good way) into the common install logic and then
minimally into the `hab` CLI, Supervisor call sites. Except for one
remaining location (a `FromStr` implementation in the common/install
logic), there is no longer any magically derived implicit default value
for a `PackageTarget`.

This work surfaced a few takeaways:

* For a lot of installation-related operations, a `PackageIdent` and
`PackageTarget` are tightly coupled and should appear together. This
reinforces a previous suspicion that we're missing new a type which
represents these 2 concepts in one place. This refactoring work has an
eye towards that future work by always placing `ident` and `target`
together in function calls.
* Most correct values for the package target end up being
`PackageTarget::active_target()` in the various call sites surfaced in
this work. This makes sense, in that the Supervisor must only ever deal
with packages matching its compiled in `PackageTarget` value. In a
similar fashion, a lot of CLI operations follow the same reasoning when
it installs supporting software such as the Studio, package exporters,
the Launcher, and the Supervisor.
* Moving implied defaults out to the edges allows the inner business
logic to be less `Option` obsessed and timid (i.e. constantly checking
whether or not a value has been provided).

Closes #5516
References habitat-sh/builder#612

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>