### PR TITLE
Fix invalid desired state when using new hab with < 0.61 sup

### DIFF
--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -1395,7 +1395,7 @@ where
     let svc_type = status.composite.unwrap_or("standalone".to_string());
     let svc_desired_state = status
         .desired_state
-        .map_or("unknown".to_string(), |s| s.to_string());
+        .map_or("<none>".to_string(), |s| s.to_string());
     let (svc_state, svc_pid, svc_elapsed) = {
         match status.process {
             Some(process) => (

--- a/components/sup-protocol/protocols/types.proto
+++ b/components/sup-protocol/protocols/types.proto
@@ -15,6 +15,9 @@ enum ProcessState {
 }
 
 enum DesiredState {
+  // The DesiredNone variant allows backwards compatibility of current hab binaries
+  // with older (< 0.61) Supervisors.
+  DesiredNone = -1;
   DesiredDown = 0;
   DesiredUp = 1;
 }

--- a/components/sup-protocol/src/generated/sup.types.rs
+++ b/components/sup-protocol/src/generated/sup.types.rs
@@ -111,6 +111,9 @@ pub enum ProcessState {
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum DesiredState {
+    /// The DesiredNone variant allows backwards compatibility of current hab binaries
+    /// with older (< 0.61) Supervisors.
+    DesiredNone = -1,
     DesiredDown = 0,
     DesiredUp = 1,
 }

--- a/components/sup-protocol/src/types.rs
+++ b/components/sup-protocol/src/types.rs
@@ -93,6 +93,7 @@ impl fmt::Display for DesiredState {
         let state = match *self {
             DesiredState::DesiredDown => "down",
             DesiredState::DesiredUp => "up",
+            DesiredState::DesiredNone => "<none>",
         };
         write!(f, "{}", state)
     }
@@ -107,7 +108,10 @@ impl FromStr for BindingMode {
             "strict" => Ok(BindingMode::Strict),
             _ => Err(net::err(
                 ErrCode::InvalidPayload,
-                format!("Invalid binding mode \"{}\"", value),
+                format!(
+                    "Invalid binding mode \"{}\", must be `relaxed` or `strict`.",
+                    value
+                ),
             )),
         }
     }
@@ -122,7 +126,10 @@ impl FromStr for ProcessState {
             "1" => Ok(ProcessState::Up),
             _ => Err(net::err(
                 ErrCode::InvalidPayload,
-                format!("Invalid process state \"{:?}\"", value),
+                format!(
+                    "Invalid process state \"{:?}\", must be `up` or `down`.",
+                    value
+                ),
             )),
         }
     }
@@ -135,9 +142,15 @@ impl FromStr for DesiredState {
         match value.to_lowercase().as_ref() {
             "0" => Ok(DesiredState::DesiredDown),
             "1" => Ok(DesiredState::DesiredUp),
+            // The DesiredNone variant allows for backwards compatibility with < 0.61 Supervisors,
+            // prior to when DesiredState was introduced.
+            "<none>" => Ok(DesiredState::DesiredNone),
             _ => Err(net::err(
                 ErrCode::InvalidPayload,
-                format!("Invalid desired state \"{:?}\"", value),
+                format!(
+                    "Invalid desired state \"{:?}\", must be `up`, `down` or `<none>`.",
+                    value
+                ),
             )),
         }
     }


### PR DESCRIPTION
Resolves https://github.com/habitat-sh/habitat/issues/5470
Resolves https://github.com/habitat-sh/habitat/issues/5508

### Description 🔩 
This change addresses the use case where hab binaries of version >= 0.61 result in
a `[Err: 7] Invalid desired state ""unknown""` error when `hab svc
status` is run with supervisors < 0.61.

This change also partially addresses https://github.com/habitat-sh/habitat/issues/5508 by improving the error messaging.

It requires https://github.com/habitat-sh/habitat/pull/5506 in order to build successfully.

### Running it 👟 
```
13:31 $ sudo /hab/pkgs/core/hab/0.59.0/20180712155441/bin/hab sup run &
[1] 8102
hab-sup(MR): Supervisor Member-ID 7807eb11c928433caffa0d04c8ae8a13
hab-sup(MR): Starting core/redis
redis.default(UCW): Watching user.toml
hab-sup(MR): Starting gossip-listener on 0.0.0.0:9638
hab-sup(MR): Starting ctl-gateway on 127.0.0.1:9632
hab-sup(MR): Starting http-gateway on 0.0.0.0:9631
redis.default(HK): Hooks compiled
redis.default(SR): Initializing
redis.default(SV): Starting service as user=hab, group=hab
redis.default(O): 8191:M 29 Aug 13:31:59.612 * Increased maximum number of open files to 10032 (it was originally set to 1024).
redis.default(O):                 _._
redis.default(O):            _.-``__ ''-._
redis.default(O):       _.-``    `.  `_.  ''-._           Redis 3.2.4 (00000000/0) 64 bit
redis.default(O):   .-`` .-```.  ```\/    _.,_ ''-._
redis.default(O):  (    '      ,       .-`  | `,    )     Running in standalone mode
redis.default(O):  |`-._`-...-` __...-.``-._|'` _.-'|     Port: 6379
redis.default(O):  |    `-._   `._    /     _.-'    |     PID: 8191
redis.default(O):   `-._    `-._  `-./  _.-'    _.-'
redis.default(O):  |`-._`-._    `-.__.-'    _.-'_.-'|
redis.default(O):  |    `-._`-._        _.-'_.-'    |           http://redis.io
redis.default(O):   `-._    `-._`-.__.-'_.-'    _.-'
redis.default(O):  |`-._`-._    `-.__.-'    _.-'_.-'|
redis.default(O):  |    `-._`-._        _.-'_.-'    |
redis.default(O):   `-._    `-._`-.__.-'_.-'    _.-'
redis.default(O):       `-._    `-.__.-'    _.-'
redis.default(O):           `-._        _.-'
redis.default(O):               `-.__.-'
redis.default(O):
redis.default(O): 8191:M 29 Aug 13:31:59.613 # WARNING: The TCP backlog setting of 511 cannot be enforced because /proc/sys/net/core/somaxconn is set to the lower value of 128.
redis.default(O): 8191:M 29 Aug 13:31:59.613 # Server started, Redis version 3.2.4
redis.default(O): 8191:M 29 Aug 13:31:59.613 # WARNING overcommit_memory is set to 0! Background save may fail under low memory condition. To fix this issue add 'vm.overcommit_memory = 1' to /etc/sysctl.conf and then reboot or run the command 'sysctl vm.overcommit_memory=1' for this to take effect.
redis.default(O): 8191:M 29 Aug 13:31:59.613 # WARNING you have Transparent Huge Pages (THP) support enabled in your kernel. This will create latency and memory usage issues with Redis. To fix this issue run the command 'echo never > /sys/kernel/mm/transparent_hugepage/enabled' as root, and add it to your /etc/rc.local in order to retain the setting after a reboot. Redis must be restarted after THP is disabled.
redis.default(O): 8191:M 29 Aug 13:31:59.613 * DB loaded from disk: 0.000 seconds
redis.default(O): 8191:M 29 Aug 13:31:59.613 * The server is now ready to accept connections on port 6379

✔ ~/habitat [jeremymv2/desirednone L|✚ 1…1⚑ 15]
13:33 $ sudo -E ./target/debug/hab --version
hab 0.62.0-dev
✔ ~/habitat [jeremymv2/desirednone L|✚ 1…2⚑ 15]
13:35 $

✔ ~/habitat [jeremymv2/desirednone L|✚ 1…2⚑ 15]
13:35 $ sudo -E ./target/debug/hab svc status
package                                           type        desired  state  elapsed (s)  pid     group
core/redis/3.2.4/20170514150022                   standalone  <none>   up     414          8191    redis.default
chef/automate-elasticsearch/6.2.2/20180527141927  standalone  <none>   down   414          <none>  automate-elasticsearch.foobar
✔ ~/habitat [jeremymv2/desirednone L|✚ 1…2⚑ 15]
13:38 $
```

Signed-off-by: Jeremy J. Miller <jm@chef.io>