### PR TITLE
fix windows studiobinlink regression

### DIFF
--- a/components/studio/bin/hab-studio.ps1
+++ b/components/studio/bin/hab-studio.ps1
@@ -245,7 +245,7 @@ function New-Studio {
     "$PSScriptRoot",
     "$env:WINDIR\system32",
     "$env:WINDIR",
-    (Join-Path $env:FS_ROOT "hab\bin")
+    (Join-Path $HAB_STUDIO_ROOT "hab\bin")
   )
 
   $env:PATH = [String]::Join(";", $pathArray)


### PR DESCRIPTION
This fixes a studio regression introduced by the binlink pr. I ad used the FS_ROOT before it was defined. I just tested and validated this in a local studio.

Signed-off-by: mwrock <matt@mattwrock.com>