### PR TITLE
ensure pkg build and appveyor hard fails if any powershell error occurs

### DIFF
--- a/components/studio/bin/hab-studio.ps1
+++ b/components/studio/bin/hab-studio.ps1
@@ -383,6 +383,10 @@ function Invoke-StudioRun($cmd) {
 }
 
 function Invoke-StudioBuild($location, $reuse) {
+  # This trap will cause powershell to return an exit code of 1
+  hab 
+  trap { "An error occured in the build!" }
+  
   if($printHelp -or ($location -eq $null)) {
     Write-BuildHelp
     return
@@ -404,6 +408,8 @@ function Remove-Studio {
 
   if(Test-Path $HAB_STUDIO_ROOT) { Remove-Item $HAB_STUDIO_ROOT -Recurse -Force }
 }
+
+$ErrorActionPreference="stop"
 
 # The current version of Habitat Studio
 $script:version='@version@'

--- a/support/ci/appveyor.ps1
+++ b/support/ci/appveyor.ps1
@@ -42,6 +42,8 @@ function Test-SourceChanged {
     ).count -ge 1
 }
 
+$ErrorActionPreference="stop"
+
 pushd (Get-RepoRoot)
 Write-Host "Configuring build environment"
 ./build.ps1 -Configure -SkipBuild


### PR DESCRIPTION
fixes #5273 

This makes sure than any powershell error in both studio logic and the appveyor script result in a "Terminating" exception. That means it will halt execution where some powershell errors are merely reported to the console but processing continues. In the context of setting up a studio or our appveyor build, any error whatsoever should be considered a failure. Note that plan-build already had this set.

Also we always want `hab pkg build` to emit a positive exit code if such a failure occurs. This will cause our appveyor script (or anyone else's habitat based CI) to fail when it checks the result of `hab pkg build`.

Signed-off-by: mwrock <matt@mattwrock.com>