### PR TITLE
fix linux resolution of FS_ROOT_ENVVAR in hab commands and the splitting and joining of PATH dirs in setup

### DIFF
--- a/components/hab/src/command/cli/setup.rs
+++ b/components/hab/src/command/cli/setup.rs
@@ -379,12 +379,10 @@ fn set_binlink_path(binlink_path: &Path) -> Result<()> {
             r"System\CurrentControlSet\Control\Session Manager\Environment",
             KEY_ALL_ACCESS,
         )?;
+        let mut paths = vec![binlink_path.to_path_buf()];
         let path: String = env.get_value("path")?;
-        let new_paths = [binlink_path, Path::new(&path)];
-        env.set_value(
-            "path",
-            &env::join_paths(new_paths.iter())?.to_str().unwrap(),
-        )?;
+        paths.append(&mut env::split_paths(&path).collect());
+        env.set_value("path", &env::join_paths(paths)?.to_str().unwrap())?;
 
         // After altering the machine environment, we must broadcast
         // a WM_SETTINGCHANGE message to all windows so the user


### PR DESCRIPTION
This fixes a regression introduced in the Windows binlinking pr (#5513) by reverting the `FS_ROOT` static variable ommision to the `hab` `main.rs`.

The original implementatiion of `FS_ROOT` here at first lance seemed like a duplication of `FS_ROOT_PATH` in https://github.com/habitat-sh/core/blob/2cd4b0c03e2b2ce6238fded35d1738ae41d8d94f/components/core/src/fs.rs#L59. For Windows, the `core` implementation is superior because it properly roots the fs_root into the `systemdrive` - usually `c:\`. So to reduce repetition and to get the desired Windows behavior, I swaped in the `core` implementation.

The key problem here is that the `core` implementation for Linux does not ever draw from `FS_ROOT_ENVVAR` which causes havoc in a chrooted studio.

Now I believe that the truly correct way forward is to make the `core` implementation take `FS_ROOT_ENVVAR` into account for linux because as it stands we treat this foundational variable (FS_ROOT) in different ways in these 2 areas - hab and core. I am holding off on that change to discuss with @fnichol since there were some strong concerns he had to honoring `FS_ROOT_ENVVAR`.

So this PR at least gets us over the hump and returns the `fs_root` resolution in hab commands to what it was and adds root drive resolution for Windows.

Signed-off-by: mwrock <matt@mattwrock.com>