### PR TITLE
Add a command line flag for disabling the HTTP gateway

### DIFF
--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -817,6 +817,8 @@ pub fn sub_sup_run() -> App<'static, 'static> {
         (@arg LISTEN_HTTP: --("listen-http") +takes_value {valid_socket_addr}
             "The listen address for the HTTP Gateway. If not specified, the value will \
             be taken from the HAB_LISTEN_HTTP environment variable if defined. [default: 0.0.0.0:9631]")
+        (@arg HTTP_DISABLE: --("http-disable") -D
+            "Disable the HTTP Gateway completely [default: false]")
         (@arg LISTEN_CTL: --("listen-ctl") +takes_value {valid_socket_addr}
             "The listen address for the Control Gateway. If not specified, the value will \
             be taken from the HAB_LISTEN_CTL environment variable if defined. [default: 127.0.0.1:9632]")

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -242,6 +242,7 @@ fn mgrcfg_from_matches(m: &ArgMatches) -> Result<ManagerConfig> {
     if let Some(addr_str) = m.value_of("LISTEN_HTTP") {
         cfg.http_listen = http_gateway::ListenAddr::from_str(addr_str)?;
     }
+    cfg.http_disable = m.is_present("HTTP_DISABLE");
     if let Some(addr_str) = m.value_of("LISTEN_CTL") {
         cfg.ctl_listen =
             SocketAddr::from_str(addr_str).unwrap_or_else(|_err| protocol::ctl::default_addr());


### PR DESCRIPTION
This should provide an escape hatch for now, until we have more granular auth.

![](https://media.giphy.com/media/BAgdIc07IJVzG/giphy.gif)

Signed-off-by: Josh Black <raskchanky@gmail.com>