### PR TITLE
Spanning ring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -783,7 +783,6 @@ dependencies = [
  "habitat_butterfly_test 0.1.0",
  "habitat_core 0.0.0 (git+https://github.com/habitat-sh/core.git)",
  "heck 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,6 +178,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "cc"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -772,6 +777,7 @@ version = "0.1.0"
 dependencies = [
  "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cast 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy 0.0.212 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat_butterfly_test 0.1.0",
@@ -2976,6 +2982,7 @@ dependencies = [
 "checksum bytes 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "0ce55bd354b095246fc34caf4e9e242f5297a7fd938b090cadfea6eee614aa62"
 "checksum caps 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9c71a98c48851ab3763bf766c4a5129e66a9b355f7ff1e93a68e725bbcd05221"
 "checksum cargo_metadata 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1efca0b863ca03ed4c109fb1c55e0bc4bbeb221d3e103d86251046b06a526bd0"
+"checksum cast 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "926013f2860c46252efceabb19f4a6b308197505082c609025aa6706c011d427"
 "checksum cc 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)" = "c37f0efaa4b9b001fa6f02d4b644dee4af97d3414df07c51e3e4f015f3a3e131"
 "checksum cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0c4e7bb64a8ebb0d856483e1e682ea3422f883c5f5615a90d51a2c82fe87fdd3"
 "checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -806,6 +806,7 @@ dependencies = [
  "clippy 0.0.212 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat_butterfly 0.1.0",
  "habitat_core 0.0.0 (git+https://github.com/habitat-sh/core.git)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/components/butterfly-test/Cargo.toml
+++ b/components/butterfly-test/Cargo.toml
@@ -7,6 +7,7 @@ workspace = "../../"
 [dependencies]
 clippy = {version = "*", optional = true}
 time = "*"
+libc = "*"
 
 [dependencies.habitat_butterfly]
 path = "../butterfly"

--- a/components/butterfly-test/src/lib.rs
+++ b/components/butterfly-test/src/lib.rs
@@ -77,8 +77,10 @@ pub fn start_server(name: &str, ring_key: Option<SymKey>, suitability: u64) -> S
     member.swim_port = swim_port as u16;
     member.gossip_port = gossip_port as u16;
     let network = RealNetwork::new_for_server(listen_swim, listen_gossip);
+    let host_address = localhost_ip();
     let mut server = Server::new(
         network,
+        host_address,
         member,
         Trace::default(),
         ring_key,
@@ -93,8 +95,12 @@ pub fn start_server(name: &str, ring_key: Option<SymKey>, suitability: u64) -> S
 }
 
 fn localhost_addr(port: u16) -> SocketAddr {
-    let ip = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
+    let ip = localhost_ip();
     SocketAddr::new(ip, port)
+}
+
+fn localhost_ip() -> IpAddr {
+    IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))
 }
 
 pub fn member_from_server(server: &Server<RealNetwork>) -> Member {

--- a/components/butterfly-test/src/lib.rs
+++ b/components/butterfly-test/src/lib.rs
@@ -105,7 +105,7 @@ fn localhost_ip() -> IpAddr {
 
 pub fn member_from_server(server: &Server<RealNetwork>) -> Member {
     let mut new_member = Member::default();
-    let server_member = server.member.read().expect("Member lock is poisoned");
+    let server_member = server.read_member();
     new_member.id = server_member.id.to_string();
     new_member.incarnation = server_member.incarnation;
     new_member.address = String::from("127.0.0.1");
@@ -244,13 +244,7 @@ impl SwimNet {
             .get(to_entry)
             .expect("Asked for a network member who is out of bounds");
         trace_it!(TEST: &self.members[from_entry], format!("Blocked {} {}", self.members[to_entry].name(), self.members[to_entry].member_id()));
-        from.add_to_block_list(String::from(
-            to.member
-                .read()
-                .expect("Member lock is poisoned")
-                .id
-                .to_string(),
-        ));
+        from.add_to_block_list(to.read_member().id.to_string());
     }
 
     pub fn unblock(&self, from_entry: usize, to_entry: usize) {
@@ -276,7 +270,7 @@ impl SwimNet {
             .members
             .get(to_entry)
             .expect("Asked for a network member who is out of bounds");
-        let to_member = to.member.read().expect("Member lock is poisoned");
+        let to_member = to.read_member();
         from.member_list.health_of(&to_member)
     }
 

--- a/components/butterfly-test/src/lib.rs
+++ b/components/butterfly-test/src/lib.rs
@@ -287,7 +287,7 @@ impl SwimNet {
     }
 
     pub fn max_rounds(&self) -> isize {
-        4
+        5
     }
 
     pub fn max_gossip_rounds(&self) -> isize {

--- a/components/butterfly-test/src/lib.rs
+++ b/components/butterfly-test/src/lib.rs
@@ -21,6 +21,7 @@ extern crate habitat_core;
 extern crate libc;
 extern crate time;
 
+use std::collections::HashMap;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::ops::{Deref, DerefMut, Range};
 use std::path::PathBuf;
@@ -628,6 +629,7 @@ impl SwimNet {
             sg,
             SysInfo::default(),
             None,
+            HashMap::new(),
         );
         self[member].insert_service(s);
     }

--- a/components/butterfly-test/src/lib.rs
+++ b/components/butterfly-test/src/lib.rs
@@ -59,8 +59,8 @@ pub fn start_server(name: &str, ring_key: Option<SymKey>, suitability: u64) -> S
     let listen_swim = format!("127.0.0.1:{}", swim_port);
     let listen_gossip = format!("127.0.0.1:{}", gossip_port);
     let mut member = Member::default();
-    member.swim_port = swim_port as i32;
-    member.gossip_port = gossip_port as i32;
+    member.swim_port = swim_port as u16;
+    member.gossip_port = gossip_port as u16;
     let mut server = Server::new(
         &listen_swim[..],
         &listen_gossip[..],
@@ -83,8 +83,8 @@ pub fn member_from_server(server: &Server) -> Member {
     new_member.id = server_member.id.to_string();
     new_member.incarnation = server_member.incarnation;
     new_member.address = String::from("127.0.0.1");
-    new_member.swim_port = server.swim_port() as i32;
-    new_member.gossip_port = server.gossip_port() as i32;
+    new_member.swim_port = server.swim_port();
+    new_member.gossip_port = server.gossip_port();
     new_member
 }
 

--- a/components/butterfly-test/src/lib.rs
+++ b/components/butterfly-test/src/lib.rs
@@ -30,8 +30,9 @@ use std::time::Duration;
 
 use time::SteadyTime;
 
+use habitat_butterfly::client::Client;
 use habitat_butterfly::member::{Health, Member};
-use habitat_butterfly::network::RealNetwork;
+use habitat_butterfly::network::{GossipZmqSocket, Network, RealNetwork};
 use habitat_butterfly::rumor::departure::Departure;
 use habitat_butterfly::rumor::election::ElectionStatus;
 use habitat_butterfly::rumor::service::{Service, SysInfo};
@@ -45,6 +46,14 @@ use habitat_core::package::{Identifiable, PackageIdent};
 use habitat_core::service::ServiceGroup;
 
 static SERVER_PORT: AtomicUsize = ATOMIC_USIZE_INIT;
+
+pub fn get_client_for_address(addr: SocketAddr) -> Client<GossipZmqSocket> {
+    let network = RealNetwork::new_for_client();
+    let sender = network
+        .create_gossip_sender(addr)
+        .expect("Cannot create gossip socket");
+    Client::new(sender, None)
+}
 
 #[derive(Debug)]
 struct NSuitability(u64);

--- a/components/butterfly/Cargo.toml
+++ b/components/butterfly/Cargo.toml
@@ -18,7 +18,6 @@ cast = "*"
 env_logger = "*"
 habitat_core = { git = "https://github.com/habitat-sh/core.git" }
 log = "*"
-lazy_static = "*"
 prost = "*"
 prost-derive = "*"
 rand = "*"

--- a/components/butterfly/Cargo.toml
+++ b/components/butterfly/Cargo.toml
@@ -14,6 +14,7 @@ doc = false
 clippy = {version = "*", optional = true}
 byteorder = "*"
 bytes = "*"
+cast = "*"
 env_logger = "*"
 habitat_core = { git = "https://github.com/habitat-sh/core.git" }
 log = "*"

--- a/components/butterfly/protocols/newscast.proto
+++ b/components/butterfly/protocols/newscast.proto
@@ -65,6 +65,7 @@ message Rumor {
     Fake2 = 7;
     ElectionUpdate = 8;
     Departure = 9;
+    Zone = 10;
   }
 
   required Type type = 1;
@@ -77,6 +78,7 @@ message Rumor {
     ServiceFile service_file = 7;
     Election election = 8;
     Departure departure = 9;
+    butterfly.swim.Zone zone = 10;
   }
 }
 

--- a/components/butterfly/protocols/newscast.proto
+++ b/components/butterfly/protocols/newscast.proto
@@ -14,6 +14,16 @@ message Election {
   repeated string votes = 6;
 }
 
+message NamedPort {
+  optional string name = 1;
+  optional int32 port = 2;
+}
+
+message Ports {
+  optional string tag = 1;
+  repeated NamedPort named_ports = 2;
+}
+
 message Service {
   optional string member_id = 1;
   optional string service_group = 2;
@@ -22,6 +32,7 @@ message Service {
   optional string pkg = 9;
   optional bytes cfg = 10;
   optional SysInfo sys = 12;
+  repeated Ports ports = 13;
 }
 
 message ServiceConfig {

--- a/components/butterfly/protocols/swim.proto
+++ b/components/butterfly/protocols/swim.proto
@@ -1,6 +1,15 @@
 syntax = "proto2";
 package butterfly.swim;
 
+message ZoneAddress {
+  optional string zone_id = 1;
+  // really optional
+  optional string address = 2;
+  optional int32 swim_port = 3;
+  optional int32 gossip_port = 4;
+  optional string tag = 5;
+}
+
 message Member {
   optional string id = 1;
   optional uint64 incarnation = 2;
@@ -9,21 +18,43 @@ message Member {
   optional int32 gossip_port = 5;
   optional bool persistent = 6 [default = false];
   optional bool departed = 7 [default = false];
+  optional string zone_id = 8;
+  repeated ZoneAddress additional_addresses = 9;
+}
+
+message Zone {
+  optional string id = 1;
+  optional uint64 incarnation = 2;
+  optional string maintainer_id = 3;
+  // really optional
+  optional string parent_zone_id = 4;
+  repeated string child_zone_ids = 5;
+  // really optional
+  optional string successor = 6;
+  repeated string predecessors = 7;
 }
 
 message Ping {
   optional Member from = 1;
   optional Member forward_to = 2;
+  optional Member to = 3;
 }
 
 message Ack {
   optional Member from = 1;
   optional Member forward_to = 2;
+  optional Member to = 3;
 }
 
 message PingReq {
   optional Member from = 1;
   optional Member target = 2;
+}
+
+message ZoneChange {
+  optional Member from = 1;
+  optional string zone_id = 2;
+  repeated Zone new_aliases = 3;
 }
 
 message Membership {
@@ -34,7 +65,7 @@ message Membership {
 }
 
 message Swim {
-  enum Type { PING = 1; ACK = 2; PINGREQ = 3; };
+  enum Type { PING = 1; ACK = 2; PINGREQ = 3; ZONE_CHANGE = 4; };
 
   // Identifies which field is filled in.
   required Type type = 1;
@@ -42,7 +73,9 @@ message Swim {
     Ping ping = 2;
     Ack ack = 3;
     PingReq pingreq = 4;
+    ZoneChange zone_change = 7;
   }
   repeated Membership membership = 5;
+  repeated Zone zones = 6;
 }
 

--- a/components/butterfly/src/error.rs
+++ b/components/butterfly/src/error.rs
@@ -34,6 +34,11 @@ pub enum Error {
     DatFileIO(PathBuf, io::Error),
     DecodeError(prost::DecodeError),
     EncodeError(prost::EncodeError),
+    GossipChannelSetupError(String),
+    GossipReceiveError(String),
+    GossipReceiveIOError(io::Error),
+    GossipSendError(String),
+    GossipSendIOError(io::Error),
     HabitatCore(habitat_core::error::Error),
     InvalidField(&'static str, String),
     NonExistentRumor(String, String),
@@ -43,6 +48,11 @@ pub enum Error {
     SocketSetReadTimeout(io::Error),
     SocketSetWriteTimeout(io::Error),
     SocketCloneError,
+    SwimChannelSetupError(String),
+    SwimReceiveError(String),
+    SwimReceiveIOError(io::Error),
+    SwimSendError(String),
+    SwimSendIOError(io::Error),
     ZmqConnectError(zmq::Error),
     ZmqSendError(zmq::Error),
 }
@@ -68,6 +78,21 @@ impl fmt::Display for Error {
             ),
             Error::DecodeError(ref err) => format!("Failed to decode protocol message: {}", err),
             Error::EncodeError(ref err) => format!("Failed to encode protocol message: {}", err),
+            Error::GossipChannelSetupError(ref err) => {
+                format!("Error setting up gossip channel: {}", err)
+            }
+            Error::GossipReceiveError(ref err) => {
+                format!("Failed to receive data with gossip receiver: {}", err)
+            }
+            Error::GossipReceiveIOError(ref err) => {
+                format!("Failed to receive data with gossip receiver: {}", err)
+            }
+            Error::GossipSendError(ref err) => {
+                format!("Failed to send data with gossip sender: {}", err)
+            }
+            Error::GossipSendIOError(ref err) => {
+                format!("Failed to send data with gossip sender: {}", err)
+            }
             Error::HabitatCore(ref err) => format!("{}", err),
             Error::InvalidField(ref field, ref err) => {
                 format!("Invalid field '{}' in protocol message: {}", field, err)
@@ -93,6 +118,21 @@ impl fmt::Display for Error {
                 format!("Cannot set UDP socket write timeout: {}", err)
             }
             Error::SocketCloneError => format!("Cannot clone the underlying UDP socket"),
+            Error::SwimChannelSetupError(ref err) => {
+                format!("Error setting up SWIM channel: {}", err)
+            }
+            Error::SwimReceiveError(ref err) => {
+                format!("Failed to receive data from SWIM channel: {}", err)
+            }
+            Error::SwimReceiveIOError(ref err) => {
+                format!("Failed to receive data from SWIM channel: {}", err)
+            }
+            Error::SwimSendError(ref err) => {
+                format!("Failed to send data to SWIM channel: {}", err)
+            }
+            Error::SwimSendIOError(ref err) => {
+                format!("Failed to send data to SWIM channel: {}", err)
+            }
             Error::ZmqConnectError(ref err) => format!("Cannot connect ZMQ socket: {}", err),
             Error::ZmqSendError(ref err) => {
                 format!("Cannot send message through ZMQ socket: {}", err)
@@ -111,6 +151,11 @@ impl error::Error for Error {
             Error::DatFileIO(_, _) => "Error reading or writing to DatFile",
             Error::DecodeError(ref err) => err.description(),
             Error::EncodeError(ref err) => err.description(),
+            Error::GossipChannelSetupError(_) => "Error setting up gossip channel",
+            Error::GossipReceiveError(_) => "Failed to receive data with gossip receiver",
+            Error::GossipReceiveIOError(_) => "Failed to receive data with gossip receiver",
+            Error::GossipSendError(_) => "Failed to send data with gossip sender",
+            Error::GossipSendIOError(_) => "Failed to send data with gossip sender",
             Error::HabitatCore(_) => "Habitat core error",
             Error::InvalidField(_, _) => "Invalid field in protocol message",
             Error::NonExistentRumor(_, _) => {
@@ -124,6 +169,11 @@ impl error::Error for Error {
             Error::SocketSetReadTimeout(_) => "Cannot set UDP socket read timeout",
             Error::SocketSetWriteTimeout(_) => "Cannot set UDP socket write timeout",
             Error::SocketCloneError => "Cannot clone the underlying UDP socket",
+            Error::SwimChannelSetupError(_) => "Error setting up SWIM channel",
+            Error::SwimReceiveError(_) => "Failed to receive data from SWIM channel",
+            Error::SwimReceiveIOError(_) => "Failed to receive data from SWIM channel",
+            Error::SwimSendError(_) => "Failed to send data to SWIM channel",
+            Error::SwimSendIOError(_) => "Failed to send data to SWIM channel",
             Error::ZmqConnectError(_) => "Cannot connect ZMQ socket",
             Error::ZmqSendError(_) => "Cannot send message through ZMQ socket",
         }

--- a/components/butterfly/src/error.rs
+++ b/components/butterfly/src/error.rs
@@ -35,6 +35,7 @@ pub enum Error {
     DecodeError(prost::DecodeError),
     EncodeError(prost::EncodeError),
     HabitatCore(habitat_core::error::Error),
+    InvalidField(&'static str, String),
     NonExistentRumor(String, String),
     ProtocolMismatch(&'static str),
     ServiceConfigDecode(String, toml::de::Error),
@@ -68,6 +69,9 @@ impl fmt::Display for Error {
             Error::DecodeError(ref err) => format!("Failed to decode protocol message: {}", err),
             Error::EncodeError(ref err) => format!("Failed to encode protocol message: {}", err),
             Error::HabitatCore(ref err) => format!("{}", err),
+            Error::InvalidField(ref field, ref err) => {
+                format!("Invalid field '{}' in protocol message: {}", field, err)
+            }
             Error::NonExistentRumor(ref member_id, ref rumor_id) => format!(
                 "Non existent rumor asked to be written to bytes: {} {}",
                 member_id, rumor_id
@@ -108,6 +112,7 @@ impl error::Error for Error {
             Error::DecodeError(ref err) => err.description(),
             Error::EncodeError(ref err) => err.description(),
             Error::HabitatCore(_) => "Habitat core error",
+            Error::InvalidField(_, _) => "Invalid field in protocol message",
             Error::NonExistentRumor(_, _) => {
                 "Cannot write rumor to bytes because it does not exist"
             }

--- a/components/butterfly/src/generated/butterfly.newscast.rs
+++ b/components/butterfly/src/generated/butterfly.newscast.rs
@@ -102,7 +102,7 @@ pub struct Rumor {
     pub tag: ::std::vec::Vec<String>,
     #[prost(string, optional, tag="3")]
     pub from_id: ::std::option::Option<String>,
-    #[prost(oneof="rumor::Payload", tags="4, 5, 6, 7, 8, 9")]
+    #[prost(oneof="rumor::Payload", tags="4, 5, 6, 7, 8, 9, 10")]
     pub payload: ::std::option::Option<rumor::Payload>,
 }
 pub mod rumor {
@@ -118,6 +118,7 @@ pub mod rumor {
         Fake2 = 7,
         ElectionUpdate = 8,
         Departure = 9,
+        Zone = 10,
     }
     #[derive(Clone, Oneof, PartialEq)]
     #[derive(Serialize, Deserialize)]
@@ -134,5 +135,7 @@ pub mod rumor {
         Election(super::Election),
         #[prost(message, tag="9")]
         Departure(super::Departure),
+        #[prost(message, tag="10")]
+        Zone(super::super::swim::Zone),
     }
 }

--- a/components/butterfly/src/generated/butterfly.newscast.rs
+++ b/components/butterfly/src/generated/butterfly.newscast.rs
@@ -25,6 +25,22 @@ pub mod election {
 }
 #[derive(Clone, PartialEq, Message)]
 #[derive(Serialize, Deserialize)]
+pub struct NamedPort {
+    #[prost(string, optional, tag="1")]
+    pub name: ::std::option::Option<String>,
+    #[prost(int32, optional, tag="2")]
+    pub port: ::std::option::Option<i32>,
+}
+#[derive(Clone, PartialEq, Message)]
+#[derive(Serialize, Deserialize)]
+pub struct Ports {
+    #[prost(string, optional, tag="1")]
+    pub tag: ::std::option::Option<String>,
+    #[prost(message, repeated, tag="2")]
+    pub named_ports: ::std::vec::Vec<NamedPort>,
+}
+#[derive(Clone, PartialEq, Message)]
+#[derive(Serialize, Deserialize)]
 pub struct Service {
     #[prost(string, optional, tag="1")]
     pub member_id: ::std::option::Option<String>,
@@ -40,6 +56,8 @@ pub struct Service {
     pub cfg: ::std::option::Option<Vec<u8>>,
     #[prost(message, optional, tag="12")]
     pub sys: ::std::option::Option<SysInfo>,
+    #[prost(message, repeated, tag="13")]
+    pub ports: ::std::vec::Vec<Ports>,
 }
 #[derive(Clone, PartialEq, Message)]
 #[derive(Serialize, Deserialize)]

--- a/components/butterfly/src/generated/butterfly.swim.rs
+++ b/components/butterfly/src/generated/butterfly.swim.rs
@@ -1,5 +1,20 @@
 #[derive(Clone, PartialEq, Message)]
 #[derive(Serialize, Deserialize)]
+pub struct ZoneAddress {
+    #[prost(string, optional, tag="1")]
+    pub zone_id: ::std::option::Option<String>,
+    /// really optional
+    #[prost(string, optional, tag="2")]
+    pub address: ::std::option::Option<String>,
+    #[prost(int32, optional, tag="3")]
+    pub swim_port: ::std::option::Option<i32>,
+    #[prost(int32, optional, tag="4")]
+    pub gossip_port: ::std::option::Option<i32>,
+    #[prost(string, optional, tag="5")]
+    pub tag: ::std::option::Option<String>,
+}
+#[derive(Clone, PartialEq, Message)]
+#[derive(Serialize, Deserialize)]
 pub struct Member {
     #[prost(string, optional, tag="1")]
     pub id: ::std::option::Option<String>,
@@ -15,6 +30,30 @@ pub struct Member {
     pub persistent: ::std::option::Option<bool>,
     #[prost(bool, optional, tag="7", default="false")]
     pub departed: ::std::option::Option<bool>,
+    #[prost(string, optional, tag="8")]
+    pub zone_id: ::std::option::Option<String>,
+    #[prost(message, repeated, tag="9")]
+    pub additional_addresses: ::std::vec::Vec<ZoneAddress>,
+}
+#[derive(Clone, PartialEq, Message)]
+#[derive(Serialize, Deserialize)]
+pub struct Zone {
+    #[prost(string, optional, tag="1")]
+    pub id: ::std::option::Option<String>,
+    #[prost(uint64, optional, tag="2")]
+    pub incarnation: ::std::option::Option<u64>,
+    #[prost(string, optional, tag="3")]
+    pub maintainer_id: ::std::option::Option<String>,
+    /// really optional
+    #[prost(string, optional, tag="4")]
+    pub parent_zone_id: ::std::option::Option<String>,
+    #[prost(string, repeated, tag="5")]
+    pub child_zone_ids: ::std::vec::Vec<String>,
+    /// really optional
+    #[prost(string, optional, tag="6")]
+    pub successor: ::std::option::Option<String>,
+    #[prost(string, repeated, tag="7")]
+    pub predecessors: ::std::vec::Vec<String>,
 }
 #[derive(Clone, PartialEq, Message)]
 #[derive(Serialize, Deserialize)]
@@ -23,6 +62,8 @@ pub struct Ping {
     pub from: ::std::option::Option<Member>,
     #[prost(message, optional, tag="2")]
     pub forward_to: ::std::option::Option<Member>,
+    #[prost(message, optional, tag="3")]
+    pub to: ::std::option::Option<Member>,
 }
 #[derive(Clone, PartialEq, Message)]
 #[derive(Serialize, Deserialize)]
@@ -31,6 +72,8 @@ pub struct Ack {
     pub from: ::std::option::Option<Member>,
     #[prost(message, optional, tag="2")]
     pub forward_to: ::std::option::Option<Member>,
+    #[prost(message, optional, tag="3")]
+    pub to: ::std::option::Option<Member>,
 }
 #[derive(Clone, PartialEq, Message)]
 #[derive(Serialize, Deserialize)]
@@ -39,6 +82,16 @@ pub struct PingReq {
     pub from: ::std::option::Option<Member>,
     #[prost(message, optional, tag="2")]
     pub target: ::std::option::Option<Member>,
+}
+#[derive(Clone, PartialEq, Message)]
+#[derive(Serialize, Deserialize)]
+pub struct ZoneChange {
+    #[prost(message, optional, tag="1")]
+    pub from: ::std::option::Option<Member>,
+    #[prost(string, optional, tag="2")]
+    pub zone_id: ::std::option::Option<String>,
+    #[prost(message, repeated, tag="3")]
+    pub new_aliases: ::std::vec::Vec<Zone>,
 }
 #[derive(Clone, PartialEq, Message)]
 #[derive(Serialize, Deserialize)]
@@ -66,7 +119,9 @@ pub struct Swim {
     pub type_: i32,
     #[prost(message, repeated, tag="5")]
     pub membership: ::std::vec::Vec<Membership>,
-    #[prost(oneof="swim::Payload", tags="2, 3, 4")]
+    #[prost(message, repeated, tag="6")]
+    pub zones: ::std::vec::Vec<Zone>,
+    #[prost(oneof="swim::Payload", tags="2, 3, 4, 7")]
     pub payload: ::std::option::Option<swim::Payload>,
 }
 pub mod swim {
@@ -76,6 +131,7 @@ pub mod swim {
         Ping = 1,
         Ack = 2,
         Pingreq = 3,
+        ZoneChange = 4,
     }
     #[derive(Clone, Oneof, PartialEq)]
     #[derive(Serialize, Deserialize)]
@@ -86,5 +142,7 @@ pub mod swim {
         Ack(super::Ack),
         #[prost(message, tag="4")]
         Pingreq(super::PingReq),
+        #[prost(message, tag="7")]
+        ZoneChange(super::ZoneChange),
     }
 }

--- a/components/butterfly/src/lib.rs
+++ b/components/butterfly/src/lib.rs
@@ -45,6 +45,7 @@
 
 extern crate byteorder;
 extern crate bytes;
+extern crate cast;
 extern crate habitat_core;
 #[macro_use]
 extern crate lazy_static;

--- a/components/butterfly/src/lib.rs
+++ b/components/butterfly/src/lib.rs
@@ -74,5 +74,6 @@ pub mod protocol;
 pub mod rumor;
 pub mod server;
 pub mod swim;
+pub mod zone;
 
 pub use server::Server;

--- a/components/butterfly/src/lib.rs
+++ b/components/butterfly/src/lib.rs
@@ -48,8 +48,6 @@ extern crate bytes;
 extern crate cast;
 extern crate habitat_core;
 #[macro_use]
-extern crate lazy_static;
-#[macro_use]
 extern crate log;
 extern crate prost;
 #[macro_use]
@@ -77,30 +75,4 @@ pub mod rumor;
 pub mod server;
 pub mod swim;
 
-use std::cell::UnsafeCell;
-
 pub use server::Server;
-
-lazy_static! {
-    /// A threadsafe shared ZMQ context for consuming services.
-    ///
-    /// You probably want to use this context to create new ZMQ sockets unless you *do not* want to
-    /// connect them together using an in-proc queue.
-    pub static ref ZMQ_CONTEXT: Box<ServerContext> = {
-        let ctx = ServerContext(UnsafeCell::new(zmq::Context::new()));
-        Box::new(ctx)
-    };
-}
-
-/// This is a wrapper to provide interior mutability of an underlying `zmq::Context` and allows
-/// for sharing/sending of a `zmq::Context` between threads.
-pub struct ServerContext(UnsafeCell<zmq::Context>);
-
-impl ServerContext {
-    pub fn as_mut(&self) -> &mut zmq::Context {
-        unsafe { &mut *self.0.get() }
-    }
-}
-
-unsafe impl Send for ServerContext {}
-unsafe impl Sync for ServerContext {}

--- a/components/butterfly/src/lib.rs
+++ b/components/butterfly/src/lib.rs
@@ -71,6 +71,7 @@ pub mod client;
 pub mod error;
 pub mod member;
 pub mod message;
+pub mod network;
 pub mod protocol;
 pub mod rumor;
 pub mod server;

--- a/components/butterfly/src/main.rs
+++ b/components/butterfly/src/main.rs
@@ -25,6 +25,7 @@ use std::path::PathBuf;
 use std::thread;
 use std::time::Duration;
 
+use habitat_butterfly::network::RealNetwork;
 use habitat_butterfly::server::Suitability;
 use habitat_butterfly::{member, server, trace};
 use habitat_core::service::ServiceGroup;
@@ -56,16 +57,16 @@ fn main() {
     member.swim_port = bind_port;
     member.gossip_port = gport;
 
-    let mut server = server::Server::new(
-        bind_to_addr,
-        gossip_bind_addr,
+    let network = RealNetwork::new_for_server(bind_to_addr, gossip_bind_addr);
+    let mut server = server::Server::<RealNetwork>::new(
+        network,
         member,
         trace::Trace::default(),
         None,
         None,
         None::<PathBuf>,
         Box::new(ZeroSuitability),
-    ).unwrap();
+    );
     println!("Server ID: {}", server.member_id());
 
     let targets: Vec<String> = args.collect();

--- a/components/butterfly/src/main.rs
+++ b/components/butterfly/src/main.rs
@@ -53,8 +53,8 @@ fn main() {
     gossip_bind_addr.set_port(gport);
 
     let mut member = member::Member::default();
-    member.swim_port = bind_port as i32;
-    member.gossip_port = gport as i32;
+    member.swim_port = bind_port;
+    member.gossip_port = gport;
 
     let mut server = server::Server::new(
         bind_to_addr,
@@ -73,8 +73,8 @@ fn main() {
         let addr: SocketAddr = target.parse().unwrap();
         let mut member = member::Member::default();
         member.address = format!("{}", addr.ip());
-        member.swim_port = addr.port() as i32;
-        member.gossip_port = addr.port() as i32;
+        member.swim_port = addr.port();
+        member.gossip_port = addr.port();
         server.member_list.add_initial_member(member);
     }
 

--- a/components/butterfly/src/main.rs
+++ b/components/butterfly/src/main.rs
@@ -25,7 +25,7 @@ use std::path::PathBuf;
 use std::thread;
 use std::time::Duration;
 
-use habitat_butterfly::network::RealNetwork;
+use habitat_butterfly::network::{Network, RealNetwork};
 use habitat_butterfly::server::Suitability;
 use habitat_butterfly::{member, server, trace};
 use habitat_core::service::ServiceGroup;
@@ -58,8 +58,12 @@ fn main() {
     member.gossip_port = gport;
 
     let network = RealNetwork::new_for_server(bind_to_addr, gossip_bind_addr);
+    let host_address = network
+        .get_host_address()
+        .expect("Cannot get the real host address");
     let mut server = server::Server::<RealNetwork>::new(
         network,
+        host_address,
         member,
         trace::Trace::default(),
         None,

--- a/components/butterfly/src/member.rs
+++ b/components/butterfly/src/member.rs
@@ -27,9 +27,9 @@ use rand::{thread_rng, Rng};
 use serde::ser::SerializeStruct;
 use serde::{Serialize, Serializer};
 use time::{Duration, SteadyTime};
-use uuid::Uuid;
 
 use error::{Error, Result};
+use message::BfUuid;
 use network::{AddressAndPort, MyFromStr};
 pub use protocol::swim::Health;
 use protocol::{self, newscast, swim as proto, FromProto};
@@ -91,7 +91,7 @@ impl Member {
 impl Default for Member {
     fn default() -> Self {
         Member {
-            id: Uuid::new_v4().simple().to_string(),
+            id: BfUuid::generate().to_string(),
             incarnation: 0,
             // TODO (CM): DANGER DANGER DANGER
             // This is a lousy default, and suggests that the notion

--- a/components/butterfly/src/member.rs
+++ b/components/butterfly/src/member.rs
@@ -144,20 +144,17 @@ impl Member {
             if zone_address.zone_id != zone_id {
                 continue;
             }
-            match zone_address.address {
-                None => break,
-                Some(ref addr_str) => match T::Address::create_from_str(addr_str) {
-                    Ok(addr) => {
-                        return Some(T::new_from_address_and_port(
-                            addr,
-                            port_getter.get_port_from_zone_address(&zone_address),
-                        ))
-                    }
-                    Err(e) => {
-                        error!("Cannot parse member {:?} additional address: {}", self, e);
-                        break;
-                    }
-                },
+            match T::Address::create_from_str(&zone_address.address) {
+                Ok(addr) => {
+                    return Some(T::new_from_address_and_port(
+                        addr,
+                        port_getter.get_port_from_zone_address(&zone_address),
+                    ))
+                }
+                Err(e) => {
+                    error!("Cannot parse member {:?} additional address: {}", self, e);
+                    break;
+                }
             }
         }
 

--- a/components/butterfly/src/member.rs
+++ b/components/butterfly/src/member.rs
@@ -18,6 +18,7 @@ use std::cmp;
 use std::collections::{hash_map, HashMap};
 use std::iter::IntoIterator;
 use std::net::SocketAddr;
+use std::ops::Deref;
 use std::result;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, RwLock};
@@ -676,6 +677,19 @@ impl MemberList {
                 .read()
                 .expect("Member list lock is poisoned")
                 .values(),
+        );
+    }
+
+    /// Takes a function whose argument is a reference to the member list hashmap.
+    pub fn with_member_list<F>(&self, mut with_closure: F) -> ()
+    where
+        F: FnMut(&HashMap<String, Member>) -> (),
+    {
+        with_closure(
+            self.members
+                .read()
+                .expect("Member list lock is poisoned")
+                .deref(),
         );
     }
 

--- a/components/butterfly/src/network.rs
+++ b/components/butterfly/src/network.rs
@@ -17,13 +17,23 @@
 //! The abstraction provides communication channels for sending SWIM
 //! and gossip messages.
 
+use std::cell::UnsafeCell;
 use std::error::Error as StdError;
-use std::fmt::{Debug, Display};
+use std::fmt::{Debug, Display, Error as FmtError, Formatter};
 use std::marker::Send;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr, UdpSocket};
 use std::result::Result as StdResult;
 use std::str::FromStr;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
-use error::Result;
+use habitat_core::util::sys as core_sys;
+
+use error::{Error, Result};
+
+use zmq;
+
+use ServerContext;
 
 // We can get rid of this trait when constraining an associated type
 // like "type Address: FromStr where <Self as FromStr>::Err: Debug;"
@@ -104,3 +114,264 @@ pub trait Network: Send + Sync + Debug + 'static {
 
 pub type AddressAndPortForNetwork<N> = <N as Network>::AddressAndPort;
 pub type AddressForNetwork<N> = <AddressAndPortForNetwork<N> as AddressAndPort>::Address;
+
+impl MyFromStr for IpAddr {
+    type MyErr = <Self as FromStr>::Err;
+}
+
+impl Address for IpAddr {}
+
+impl MyFromStr for SocketAddr {
+    type MyErr = <Self as FromStr>::Err;
+}
+
+impl AddressAndPort for SocketAddr {
+    type Address = IpAddr;
+
+    fn new_from_address_and_port(addr: IpAddr, port: u16) -> SocketAddr {
+        SocketAddr::new(addr, port)
+    }
+
+    fn get_address(&self) -> IpAddr {
+        self.ip()
+    }
+
+    fn get_port(&self) -> u16 {
+        self.port()
+    }
+}
+
+/// An implementation of the `SwimSender` and `SwimReceiver` traits
+/// that uses UdpSocket.
+#[derive(Debug)]
+pub struct SwimUdpSocket {
+    udp: UdpSocket,
+}
+
+impl SwimSender<SocketAddr> for SwimUdpSocket {
+    fn send(&self, buf: &[u8], addr: SocketAddr) -> Result<usize> {
+        self.udp
+            .send_to(buf, addr)
+            .map_err(|e| Error::SwimSendIOError(e))
+    }
+}
+
+impl SwimReceiver<SocketAddr> for SwimUdpSocket {
+    fn receive(&self, buf: &mut [u8]) -> Result<(usize, SocketAddr)> {
+        self.udp
+            .recv_from(buf)
+            .map_err(|e| Error::SwimReceiveIOError(e))
+    }
+}
+
+/// An implementation of the `GossipSender` and `GossipReceiver`
+/// traits that uses `zmq::Socket`.
+pub struct GossipZmqSocket {
+    zmq: zmq::Socket,
+}
+
+impl GossipSender for GossipZmqSocket {
+    fn send(&self, buf: &[u8]) -> Result<()> {
+        self.zmq
+            .send(buf, 0)
+            .map_err(|e| Error::GossipSendError(e.description().to_owned()))
+    }
+}
+
+impl GossipReceiver for GossipZmqSocket {
+    fn receive(&self) -> Result<Vec<u8>> {
+        self.zmq
+            .recv_bytes(0)
+            .map_err(|e| Error::GossipReceiveError(e.description().to_owned()))
+    }
+}
+
+/// An implementation of the `Network` trait that creates
+/// `SwimUdpSocket` instances for SWIM communication, and
+/// `GossipZmqSocket` instances for gossip communication.
+pub struct RealNetwork {
+    swim_addr: SocketAddr,
+    gossip_addr: SocketAddr,
+    push_socket_linger: i32,
+    zmq_context: ServerContext,
+
+    udp_socket: Arc<Mutex<Option<UdpSocket>>>,
+}
+
+impl RealNetwork {
+    /// Create an instance of `RealNetwork` to be used by clients. It
+    /// sets linger time for push zmq gossip sockets to be
+    /// indefinite. Use this instance to get pull or push gossip
+    /// sockets.
+    ///
+    /// For getting SWIM channels or gossip receivers, get an instance
+    /// with `new_for_server`.
+    pub fn new_for_client() -> Self {
+        // The client only sends rumors through the gossip sender
+        // socket, so we pass some throw away address as arguments for
+        // SWIM socket and gossip receiver socket addresses.
+        Self::new(Self::throw_away_addr(), Self::throw_away_addr(), -1)
+    }
+
+    /// Create an instance of `RealNetwork` to be used by servers.
+    pub fn new_for_server(swim_addr: SocketAddr, gossip_addr: SocketAddr) -> Self {
+        Self::new(swim_addr, gossip_addr, 1000)
+    }
+
+    fn new(swim_addr: SocketAddr, gossip_addr: SocketAddr, push_socket_linger: i32) -> Self {
+        RealNetwork {
+            swim_addr: swim_addr,
+            gossip_addr: gossip_addr,
+            push_socket_linger: push_socket_linger,
+            zmq_context: ServerContext(UnsafeCell::new(zmq::Context::new())),
+            udp_socket: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    fn throw_away_addr() -> SocketAddr {
+        let ip = IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0));
+        SocketAddr::new(ip, 0)
+    }
+
+    fn context_mut(&self) -> &mut zmq::Context {
+        self.zmq_context.as_mut()
+    }
+
+    fn create_udp_socket(addr: &SocketAddr) -> Result<UdpSocket> {
+        let socket = UdpSocket::bind(addr).map_err(|e| Error::CannotBind(e))?;
+        socket
+            .set_read_timeout(Some(Duration::from_millis(1000)))
+            .map_err(|e| {
+                Error::SwimChannelSetupError(format!("Can't set up read timeout, {}", e))
+            })?;
+        socket
+            .set_write_timeout(Some(Duration::from_millis(1000)))
+            .map_err(|e| {
+                Error::SwimChannelSetupError(format!("Can't set up write timeout, {}", e))
+            })?;
+
+        Ok(socket)
+    }
+
+    fn get_swim_socket(&self) -> Result<SwimUdpSocket> {
+        let mut maybe_socket = self.udp_socket.lock().expect("udp socket lock poisoned");
+        if let Some(ref socket) = *maybe_socket {
+            let cloned_socket = Self::clone_udp_socket(socket)?;
+            return Ok(SwimUdpSocket { udp: cloned_socket });
+        }
+        let new_socket = Self::create_udp_socket(&self.swim_addr)?;
+        *maybe_socket = Some(Self::clone_udp_socket(&new_socket)?);
+
+        Ok(SwimUdpSocket { udp: new_socket })
+    }
+
+    fn clone_udp_socket(socket: &UdpSocket) -> Result<UdpSocket> {
+        socket
+            .try_clone()
+            .map_err(|e| Error::SwimChannelSetupError(format!("{}", e)))
+    }
+}
+
+// Implementing Debug trait explicitly to avoid debug output for zmq_context
+impl Debug for RealNetwork {
+    fn fmt(&self, f: &mut Formatter) -> StdResult<(), FmtError> {
+        write!(
+            f,
+            "RealNetwork {{ swim_addr: {:?}, gossip_addr: {:?}, push_socket_linger: {:?}, \
+             zmq_context: <skipped>, udp_socket: {:?} }}",
+            self.swim_addr, self.gossip_addr, self.push_socket_linger, self.udp_socket,
+        )
+    }
+}
+
+impl Network for RealNetwork {
+    type AddressAndPort = SocketAddr;
+    type SwimSender = SwimUdpSocket;
+    type SwimReceiver = SwimUdpSocket;
+    type GossipReceiver = GossipZmqSocket;
+    type GossipSender = GossipZmqSocket;
+
+    fn get_host_address(&self) -> Result<IpAddr> {
+        core_sys::ip().map_err(|e| e.into())
+    }
+
+    fn get_swim_addr(&self) -> SocketAddr {
+        self.swim_addr
+    }
+
+    fn create_swim_sender(&self) -> Result<SwimUdpSocket> {
+        self.get_swim_socket()
+    }
+
+    fn create_swim_receiver(&self) -> Result<SwimUdpSocket> {
+        self.get_swim_socket()
+    }
+
+    fn get_gossip_addr(&self) -> SocketAddr {
+        self.gossip_addr
+    }
+
+    fn create_gossip_sender(&self, addr: SocketAddr) -> Result<GossipZmqSocket> {
+        let socket = self.context_mut().socket(zmq::PUSH).map_err(|e| {
+            Error::GossipChannelSetupError(format!("Failed to create the ZMQ push socket: {}", e))
+        })?;
+        socket.set_linger(self.push_socket_linger).map_err(|e| {
+            Error::GossipChannelSetupError(format!(
+                "Failed to set the ZMQ push socket linger: {}",
+                e
+            ))
+        })?;
+        socket.set_tcp_keepalive(0).map_err(|e| {
+            Error::GossipChannelSetupError(format!(
+                "Failed to set the ZMQ push socket to not use keepalive: {}",
+                e
+            ))
+        })?;
+        socket.set_immediate(true).map_err(|e| {
+            Error::GossipChannelSetupError(format!(
+                "Failed to set the ZMQ push socket to immediate: {}",
+                e
+            ))
+        })?;
+        socket.set_sndhwm(1000).map_err(|e| {
+            Error::GossipChannelSetupError(format!("Failed to set the ZMQ push socket hwm: {}", e))
+        })?;
+        socket.set_sndtimeo(500).map_err(|e| {
+            Error::GossipChannelSetupError(format!(
+                "Failed to set the ZMQ push socket send timeout: {}",
+                e
+            ))
+        })?;
+        socket.connect(&format!("tcp://{}", addr)).map_err(|e| {
+            Error::GossipChannelSetupError(format!("Failed to connect to {:?}: {}", addr, e))
+        })?;
+        Ok(GossipZmqSocket { zmq: socket })
+    }
+
+    fn create_gossip_receiver(&self) -> Result<GossipZmqSocket> {
+        let socket = self.context_mut().socket(zmq::PULL).map_err(|e| {
+            Error::GossipChannelSetupError(format!("Failed to create the ZMQ pull socket: {}", e))
+        })?;
+        socket.set_linger(0).map_err(|e| {
+            Error::GossipChannelSetupError(format!(
+                "Failed to set the ZMQ pull socket to not linger: {}",
+                e
+            ))
+        })?;
+        socket.set_tcp_keepalive(0).map_err(|e| {
+            Error::GossipChannelSetupError(format!(
+                "Failed to set the ZMQ pull socket to not use keepalive: {}",
+                e
+            ))
+        })?;
+        socket
+            .bind(&format!("tcp://{}", self.gossip_addr))
+            .map_err(|e| {
+                Error::GossipChannelSetupError(format!(
+                    "Failed to bind the ZMQ pull socket to the port: {}",
+                    e
+                ))
+            })?;
+        Ok(GossipZmqSocket { zmq: socket })
+    }
+}

--- a/components/butterfly/src/network.rs
+++ b/components/butterfly/src/network.rs
@@ -1,0 +1,106 @@
+// Copyright (c) 2018 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! The Butterfly network abstraction.
+//!
+//! The abstraction provides communication channels for sending SWIM
+//! and gossip messages.
+
+use std::error::Error as StdError;
+use std::fmt::{Debug, Display};
+use std::marker::Send;
+use std::result::Result as StdResult;
+use std::str::FromStr;
+
+use error::Result;
+
+// We can get rid of this trait when constraining an associated type
+// like "type Address: FromStr where <Self as FromStr>::Err: Debug;"
+// is actually implemented.
+pub trait MyFromStr: FromStr {
+    type MyErr: StdError + From<<Self as FromStr>::Err>;
+
+    fn create_from_str(raw: &str) -> StdResult<Self, Self::MyErr> {
+        raw.parse().map_err(|e: Self::Err| e.into())
+    }
+}
+
+pub trait Address: MyFromStr + Debug + Copy + Clone + Display + Send + Sync + PartialEq {}
+
+pub trait AddressAndPort: MyFromStr + Copy + Clone + Debug + Display + Send + Sync {
+    type Address: Address;
+
+    fn new_from_address_and_port(addr: Self::Address, port: u16) -> Self;
+    fn get_address(&self) -> Self::Address;
+    fn get_port(&self) -> u16;
+}
+
+// TODO(krnowak): See a TODO about Debug for Network trait below.
+/// A trait for types used for sending SWIM messages.
+pub trait SwimSender<A: AddressAndPort>: Send + Debug {
+    /// Send a SWIM message (as bytes) to the given address. The
+    /// returned value holds a number of bytes sent.
+    fn send(&self, buf: &[u8], addr: A) -> Result<usize>;
+}
+
+/// A trait for types used for receiving SWIM messages.
+pub trait SwimReceiver<A: AddressAndPort>: Send {
+    /// Receive a SWIM message (as bytes) from the channel. The
+    /// returned value holds the size and an address from where the
+    /// bytes came.
+    fn receive(&self, buf: &mut [u8]) -> Result<(usize, A)>;
+}
+
+/// A trait for types used for sending gossip messages (rumors).
+pub trait GossipSender {
+    /// Send a rumor (as bytes).
+    fn send(&self, buf: &[u8]) -> Result<()>;
+}
+
+/// A trait for types used for receiving gossip messages (rumors).
+pub trait GossipReceiver {
+    /// Receive a rumor (as bytes).
+    fn receive(&self) -> Result<Vec<u8>>;
+}
+
+// TODO(krnowak): Not sure if this static lifetime specifier here is a
+// correct thing to do. It is either here on in several other places
+// where generic type N constrained to being an implementation of the
+// Network trait is used (trace, expire, inbound, outbound and so
+// on). I added it here, because Network is exclusively used by the
+// butterfly component.
+//
+// Same for Debug - Network is used by the butterfly component only so
+// I add it here to save me some typing.
+/// A trait for types used to provide SWIM and gossip communication
+/// channels.
+pub trait Network: Send + Sync + Debug + 'static {
+    type AddressAndPort: AddressAndPort;
+    type SwimSender: SwimSender<Self::AddressAndPort>;
+    type SwimReceiver: SwimReceiver<Self::AddressAndPort>;
+    type GossipSender: GossipSender;
+    type GossipReceiver: GossipReceiver;
+
+    fn get_host_address(&self) -> Result<<Self::AddressAndPort as AddressAndPort>::Address>;
+    fn get_swim_addr(&self) -> Self::AddressAndPort;
+    fn create_swim_sender(&self) -> Result<Self::SwimSender>;
+    fn create_swim_receiver(&self) -> Result<Self::SwimReceiver>;
+
+    fn get_gossip_addr(&self) -> Self::AddressAndPort;
+    fn create_gossip_sender(&self, addr: Self::AddressAndPort) -> Result<Self::GossipSender>;
+    fn create_gossip_receiver(&self) -> Result<Self::GossipReceiver>;
+}
+
+pub type AddressAndPortForNetwork<N> = <N as Network>::AddressAndPort;
+pub type AddressForNetwork<N> = <AddressAndPortForNetwork<N> as AddressAndPort>::Address;

--- a/components/butterfly/src/protocol/newscast.rs
+++ b/components/butterfly/src/protocol/newscast.rs
@@ -76,20 +76,11 @@ impl From<CElectionUpdate> for Rumor {
 
 impl From<CService> for Rumor {
     fn from(value: CService) -> Self {
-        let payload = Service {
-            member_id: Some(value.member_id.clone()),
-            service_group: Some(value.service_group.to_string()),
-            incarnation: Some(value.incarnation),
-            initialized: Some(value.initialized),
-            pkg: Some(value.pkg),
-            cfg: Some(value.cfg),
-            sys: Some(value.sys.into()),
-        };
         Rumor {
             type_: RumorType::Service as i32,
             tag: Vec::default(),
-            from_id: Some(value.member_id),
-            payload: Some(RumorPayload::Service(payload)),
+            from_id: Some(value.member_id.clone()),
+            payload: Some(RumorPayload::Service(value.into())),
         }
     }
 }

--- a/components/butterfly/src/rumor/dat_file.rs
+++ b/components/butterfly/src/rumor/dat_file.rs
@@ -23,6 +23,7 @@ use rand::{thread_rng, Rng};
 
 use error::{Error, Result};
 use member::{MemberList, Membership};
+use network::Network;
 use protocol::{newscast, Message};
 use rumor::{
     Departure, Election, ElectionUpdate, Rumor, RumorStore, Service, ServiceConfig, ServiceFile,
@@ -60,7 +61,7 @@ impl DatFile {
         &self.path
     }
 
-    pub fn read_into(&mut self, server: &Server) -> Result<()> {
+    pub fn read_into<N: Network>(&mut self, server: &Server<N>) -> Result<()> {
         let mut version = [0; 1];
         let mut size_buf = [0; 8];
         // JW: Resizing this buffer is terrible for performance, but it's the easiest way to
@@ -232,7 +233,7 @@ impl DatFile {
         Ok(())
     }
 
-    pub fn write(&self, server: &Server) -> Result<usize> {
+    pub fn write<N: Network>(&self, server: &Server<N>) -> Result<usize> {
         let mut header = Header::default();
         let tmp_path = self.path.with_extension(
             thread_rng()

--- a/components/butterfly/src/rumor/heat.rs
+++ b/components/butterfly/src/rumor/heat.rs
@@ -137,9 +137,9 @@ impl Default for RumorHeat {
 mod tests {
     use super::*;
     use error::Result;
+    use message::BfUuid;
     use protocol::{self, newscast};
     use rumor::{Rumor, RumorKey, RumorType};
-    use uuid::Uuid;
 
     // TODO (CM): This FakeRumor implementation is copied from
     // rumor.rs; factor this helper code better.
@@ -153,7 +153,7 @@ mod tests {
     impl Default for FakeRumor {
         fn default() -> FakeRumor {
             FakeRumor {
-                id: format!("{}", Uuid::new_v4().simple()),
+                id: BfUuid::generate().to_string(),
                 key: String::from("fakerton"),
             }
         }

--- a/components/butterfly/src/rumor/mod.rs
+++ b/components/butterfly/src/rumor/mod.rs
@@ -50,6 +50,7 @@ use error::{Error, Result};
 use member::Membership;
 pub use protocol::newscast::{Rumor as ProtoRumor, RumorPayload, RumorType};
 use protocol::{FromProto, Message};
+use zone::Zone;
 
 #[derive(Debug, Clone, Serialize)]
 pub enum RumorKind {
@@ -60,6 +61,7 @@ pub enum RumorKind {
     Service(Service),
     ServiceConfig(ServiceConfig),
     ServiceFile(ServiceFile),
+    Zone(Zone),
 }
 
 impl From<RumorKind> for RumorPayload {
@@ -74,6 +76,7 @@ impl From<RumorKind> for RumorPayload {
                 RumorPayload::ServiceConfig(service_config.into())
             }
             RumorKind::ServiceFile(service_file) => RumorPayload::ServiceFile(service_file.into()),
+            RumorKind::Zone(zone) => RumorPayload::Zone(zone.into()),
         }
     }
 }
@@ -321,6 +324,7 @@ impl RumorEnvelope {
             RumorType::ServiceConfig => RumorKind::ServiceConfig(ServiceConfig::from_proto(proto)?),
             RumorType::ServiceFile => RumorKind::ServiceFile(ServiceFile::from_proto(proto)?),
             RumorType::Fake | RumorType::Fake2 => panic!("fake rumor"),
+            RumorType::Zone => RumorKind::Zone(Zone::from_proto(proto)?),
         };
         Ok(RumorEnvelope {
             type_: type_,

--- a/components/butterfly/src/rumor/mod.rs
+++ b/components/butterfly/src/rumor/mod.rs
@@ -350,9 +350,8 @@ impl From<RumorEnvelope> for ProtoRumor {
 
 #[cfg(test)]
 mod tests {
-    use uuid::Uuid;
-
     use error::Result;
+    use message::BfUuid;
     use protocol::{self, newscast};
     use rumor::{Rumor, RumorType};
 
@@ -365,7 +364,7 @@ mod tests {
     impl Default for FakeRumor {
         fn default() -> FakeRumor {
             FakeRumor {
-                id: format!("{}", Uuid::new_v4().simple()),
+                id: BfUuid::generate().to_string(),
                 key: String::from("fakerton"),
             }
         }
@@ -420,7 +419,7 @@ mod tests {
     impl Default for TrumpRumor {
         fn default() -> TrumpRumor {
             TrumpRumor {
-                id: format!("{}", Uuid::new_v4().simple()),
+                id: BfUuid::generate().to_string(),
                 key: String::from("fakerton"),
             }
         }

--- a/components/butterfly/src/server/expire.rs
+++ b/components/butterfly/src/server/expire.rs
@@ -19,20 +19,21 @@
 use std::thread;
 use std::time::Duration;
 
+use network::Network;
 use rumor::{RumorKey, RumorType};
 use server::timing::Timing;
 use server::Server;
 
 const LOOP_DELAY_MS: u64 = 500;
 
-pub struct Expire {
-    pub server: Server,
+pub struct Expire<N: Network> {
+    pub server: Server<N>,
     pub timing: Timing,
 }
 
-impl Expire {
-    pub fn new(server: Server, timing: Timing) -> Expire {
-        Expire {
+impl<N: Network> Expire<N> {
+    pub fn new(server: Server<N>, timing: Timing) -> Self {
+        Self {
             server: server,
             timing: timing,
         }

--- a/components/butterfly/src/server/inbound.rs
+++ b/components/butterfly/src/server/inbound.rs
@@ -349,8 +349,6 @@ impl<N: Network> Inbound<N> {
                     self.server.insert_member(our_member_clone, Health::Alive);
                 }
 
-                let mut dbg_sent_zone_change_with_alias_to = Vec::new();
-
                 if !results.aliases_to_inform.is_empty() {
                     let mut zone_ids_and_maintainer_ids = {
                         let zone_list = self.server.read_zone_list();
@@ -395,7 +393,6 @@ impl<N: Network> Inbound<N> {
                         outbound::zone_change(&self.server, &self.swim_sender, &target, msg);
                     }
                 }
-                dbg_data.sent_zone_change_with_alias_to = Some(dbg_sent_zone_change_with_alias_to);
             }
         }
         outbound::ack(&self.server, &self.swim_sender, &from, addr, None);

--- a/components/butterfly/src/server/inbound.rs
+++ b/components/butterfly/src/server/inbound.rs
@@ -342,10 +342,10 @@ impl<N: Network> Inbound<N> {
                 for zone in results.zones_to_insert.drain(..) {
                     self.server.insert_zone(zone);
                 }
-                if let Some(zone_uuid) = results.zone_uuid_for_our_member {
+                if let Some(zone_id) = results.zone_id_for_our_member {
                     let our_member_clone = {
                         let mut our_member = self.server.write_member();
-                        our_member.zone_id = zone_uuid;
+                        our_member.zone_id = zone_id;
                         our_member.incarnation += 1;
 
                         our_member.clone()
@@ -475,17 +475,17 @@ impl<N: Network> Inbound<N> {
             }
         };
 
-        let maybe_successor_clone = if let Some(uuid) = maintained_zone_clone.successor {
-            self.server.read_zone_list().zones.get(&uuid).cloned()
+        let maybe_successor_clone = if let Some(id) = maintained_zone_clone.successor {
+            self.server.read_zone_list().zones.get(&id).cloned()
         } else {
             None
         };
-        let our_member_uuid = self.server.read_member().zone_id;
+        let our_member_id = self.server.read_member().zone_id;
 
         ZoneChangeResultsMsgOrNothing::Results(zones::process_zone_change_internal_state(
             maintained_zone_clone,
             maybe_successor_clone,
-            our_member_uuid,
+            our_member_id,
             zone_change,
             dbg_data,
         ))

--- a/components/butterfly/src/server/inbound.rs
+++ b/components/butterfly/src/server/inbound.rs
@@ -52,9 +52,9 @@ impl<N: Network> Inbound<N> {
         }
     }
 
-    /// Run the thread. Listens for messages up to 1k in size, and then processes them accordingly.
+    /// Run the thread. Listens for messages up to 4k in size, and then processes them accordingly.
     pub fn run(&self) {
-        let mut recv_buffer: Vec<u8> = vec![0; 1024];
+        let mut recv_buffer: Vec<u8> = vec![0; 4096];
         loop {
             if self.server.pause.load(Ordering::Relaxed) {
                 thread::sleep(Duration::from_millis(100));

--- a/components/butterfly/src/server/mod.rs
+++ b/components/butterfly/src/server/mod.rs
@@ -155,8 +155,8 @@ impl Server {
 
         match (maybe_swim_socket_addr, maybe_gossip_socket_addr) {
             (Ok(Some(swim_socket_addr)), Ok(Some(gossip_socket_addr))) => {
-                member.swim_port = swim_socket_addr.port() as i32;
-                member.gossip_port = gossip_socket_addr.port() as i32;
+                member.swim_port = swim_socket_addr.port();
+                member.gossip_port = gossip_socket_addr.port();
                 Ok(Server {
                     name: Arc::new(name.unwrap_or(member.id.clone())),
                     member_id: Arc::new(member.id.clone()),
@@ -1089,8 +1089,8 @@ mod tests {
             let gossip_port = GOSSIP_PORT.fetch_add(1, Ordering::Relaxed);
             let gossip_listen = format!("127.0.0.1:{}", gossip_port);
             let mut member = Member::default();
-            member.swim_port = swim_port as i32;
-            member.gossip_port = gossip_port as i32;
+            member.swim_port = swim_port as u16;
+            member.gossip_port = gossip_port as u16;
             Server::new(
                 &swim_listen[..],
                 &gossip_listen[..],
@@ -1111,8 +1111,8 @@ mod tests {
             let gossip_port = GOSSIP_PORT.fetch_add(1, Ordering::Relaxed);
             let gossip_listen = format!("127.0.0.1:{}", gossip_port);
             let mut member = Member::default();
-            member.swim_port = swim_port as i32;
-            member.gossip_port = gossip_port as i32;
+            member.swim_port = swim_port as u16;
+            member.gossip_port = gossip_port as u16;
             let rumor_name = format!("{}{}", member.id.to_string(), ".rst");
             let file_path = tmpdir.path().to_owned().join(rumor_name);
             let mut rumor_file = File::create(file_path).unwrap();

--- a/components/butterfly/src/server/mod.rs
+++ b/components/butterfly/src/server/mod.rs
@@ -424,11 +424,11 @@ impl<N: Network> Server<N> {
     }
 
     pub fn insert_zone(&self, zone: Zone) {
-        let trace_zone_uuid = zone.id;
+        let trace_zone_id = zone.id;
         let trace_incarnation = zone.incarnation;
 
         for rk in self.write_zone_list().insert(zone) {
-            let trace_zone_id = trace_zone_uuid.to_string();
+            let trace_zone_id = trace_zone_id.to_string();
 
             trace_it!(
                 ZONES: self,

--- a/components/butterfly/src/server/mod.rs
+++ b/components/butterfly/src/server/mod.rs
@@ -986,7 +986,7 @@ impl<N: Network> Serialize for Server<N> {
     where
         S: Serializer,
     {
-        let mut strukt = serializer.serialize_struct("butterfly", 6)?;
+        let mut strukt = serializer.serialize_struct("butterfly", 7)?;
         strukt.serialize_field("member", &self.member_list)?;
         strukt.serialize_field("service", &self.service_store)?;
         strukt.serialize_field("service_config", &self.service_config_store)?;

--- a/components/butterfly/src/server/outbound.rs
+++ b/components/butterfly/src/server/outbound.rs
@@ -282,11 +282,9 @@ pub fn create_to_member<AP: AddressAndPort>(addr: AP, target: &Member) -> Member
         let mut zone_id = BfUuid::nil();
 
         for zone_address in target.additional_addresses.iter() {
-            if let Some(ref zone_address_str) = zone_address.address {
-                if *zone_address_str == address_str && zone_address.swim_port == port {
-                    zone_id = zone_address.zone_id;
-                    break;
-                }
+            if zone_address.address == address_str && zone_address.swim_port == port {
+                zone_id = zone_address.zone_id;
+                break;
             }
         }
 

--- a/components/butterfly/src/server/outbound.rs
+++ b/components/butterfly/src/server/outbound.rs
@@ -362,15 +362,15 @@ pub fn populate_membership_rumors<N: Network>(
         let zone_list = server.read_zone_list();
 
         for ref rkey in zone_rumors.iter() {
-            if let Ok(gossiped_zone_uuid) = rkey.id.parse::<BfUuid>() {
-                if let Some(zone) = zone_list.zones.get(&gossiped_zone_uuid) {
+            if let Ok(gossiped_zone_id) = rkey.id.parse::<BfUuid>() {
+                if let Some(zone) = zone_list.zones.get(&gossiped_zone_id) {
                     swim.zones.push(zone.clone());
-                    if gossiped_zone_uuid == our_zone_id {
+                    if gossiped_zone_id == our_zone_id {
                         our_zone_gossiped = true;
                     }
                 }
                 if let Some(ref maintained_zone_id) = maybe_maintained_zone_id {
-                    if gossiped_zone_uuid == *maintained_zone_id {
+                    if gossiped_zone_id == *maintained_zone_id {
                         maintained_zone_gossiped = true;
                     }
                 }

--- a/components/butterfly/src/server/outbound.rs
+++ b/components/butterfly/src/server/outbound.rs
@@ -96,6 +96,7 @@ impl<N: Network> Outbound<N> {
     /// period to finish before starting the next probe.
     pub fn run(&mut self) {
         let mut have_members = false;
+        let mut first_time = true;
         loop {
             if !have_members {
                 let num_initial = self.server.member_list.len_initial_members();
@@ -103,7 +104,7 @@ impl<N: Network> Outbound<N> {
                     // The minimum that's strictly more than half
                     let min_to_start = num_initial / 2 + 1;
 
-                    if self.server.member_list.len() >= min_to_start {
+                    if !first_time && self.server.member_list.len() >= min_to_start {
                         have_members = true;
                     } else {
                         self.server.member_list.with_initial_members(|member| {
@@ -116,6 +117,7 @@ impl<N: Network> Outbound<N> {
                             );
                         });
                     }
+                    first_time = false;
                 }
             }
 

--- a/components/butterfly/src/server/outbound.rs
+++ b/components/butterfly/src/server/outbound.rs
@@ -193,9 +193,16 @@ impl<N: Network> Outbound<N> {
             return;
         }
 
+        let our_zone_id = self.server.get_settled_zone_id();
+        let filter_zones = self
+            .server
+            .read_zone_list()
+            .gather_all_aliases_of(our_zone_id);
+
         self.server.member_list.with_pingreq_targets(
             self.server.member_id(),
             &member.id,
+            &filter_zones,
             |pingreq_target| {
                 trace_it!(PROBE: &self.server,
                           TraceKind::ProbePingReq,

--- a/components/butterfly/src/server/outbound.rs
+++ b/components/butterfly/src/server/outbound.rs
@@ -118,7 +118,7 @@ impl<N: Network> Outbound<N> {
             let check_list = self
                 .server
                 .member_list
-                .check_list(&self.server.member.read().expect("Member is poisoned").id);
+                .check_list(&self.server.read_member().id);
 
             for member in check_list {
                 if self.server.member_list.pingable(&member) {
@@ -294,7 +294,7 @@ pub fn pingreq<N: Network>(
 ) {
     let pingreq = PingReq {
         membership: vec![],
-        from: server.member.read().unwrap().clone(),
+        from: server.read_member().clone(),
         target: target.clone(),
     };
     let mut swim: Swim = pingreq.into();
@@ -355,7 +355,7 @@ pub fn ping<N: Network>(
     };
     let ping = Ping {
         membership: vec![],
-        from: server.member.read().unwrap().clone(),
+        from: server.read_member().clone(),
         forward_to: forward_to,
     };
     let mut swim: Swim = ping.into();
@@ -435,7 +435,7 @@ pub fn ack<N: Network>(
 ) {
     let ack = Ack {
         membership: vec![],
-        from: server.member.read().unwrap().clone(),
+        from: server.read_member().clone(),
         forward_to: forward_to.map(Into::into),
     };
     let member_id = ack.from.id.clone();

--- a/components/butterfly/src/server/pull.rs
+++ b/components/butterfly/src/server/pull.rs
@@ -101,6 +101,9 @@ impl<N: Network> Pull<N> {
                 RumorKind::Departure(departure) => {
                     self.server.insert_departure(departure);
                 }
+                RumorKind::Zone(zone) => {
+                    self.server.insert_zone(zone);
+                }
             }
         }
     }

--- a/components/butterfly/src/server/push.rs
+++ b/components/butterfly/src/server/push.rs
@@ -371,11 +371,11 @@ impl<N: Network> PushWorker<N> {
 
     /// Given a rumorkey, creates a protobuf rumor for sharing.
     fn create_zone_rumor(&self, rumor_key: &RumorKey) -> Option<RumorEnvelope> {
-        let zone_uuid = match rumor_key.id.parse() {
+        let zone_id = match rumor_key.id.parse() {
             Ok(parsed_key_id) => parsed_key_id,
             Err(_) => return None,
         };
-        let zone = match self.server.read_zone_list().zones.get(&zone_uuid) {
+        let zone = match self.server.read_zone_list().zones.get(&zone_id) {
             Some(zone) => zone.clone(),
             None => return None,
         };

--- a/components/butterfly/src/server/zones.rs
+++ b/components/butterfly/src/server/zones.rs
@@ -71,29 +71,29 @@ pub enum ZoneChangeResultsMsgOrNothing {
 
 #[derive(Debug, Default)]
 struct HandleZoneDbgData {
-    pub to_address: String,
-    pub to_port: u16,
-    pub host_address: String,
-    pub host_port: u16,
-    pub from_zone_id: String,
-    pub from_address: String,
-    pub from_port: u16,
-    pub real_from_address: String,
-    pub real_from_port: u16,
-    pub scenario: String,
-    pub was_settled: bool,
-    pub our_old_zone_id: BfUuid,
-    pub our_new_zone_id: BfUuid,
-    pub sender_zone_warning: Option<String>,
-    pub handle_zone_results: HandleZoneInternalResults,
-    pub sender_in_the_same_zone_as_us: bool,
-    pub from_kind: AddressKind,
-    pub to_kind: AddressKind,
-    pub parse_failures: Vec<String>,
-    pub zone_change_dbg_data: Option<ZoneChangeDbgData>,
-    pub additional_address_update: Option<(String, BfUuid)>,
-    pub additional_address_msgs: Vec<String>,
-    pub msg_and_target: Option<(ZoneChange, Member)>,
+    to_address: String,
+    to_port: u16,
+    host_address: String,
+    host_port: u16,
+    from_zone_id: String,
+    from_address: String,
+    from_port: u16,
+    real_from_address: String,
+    real_from_port: u16,
+    scenario: String,
+    was_settled: bool,
+    our_old_zone_id: BfUuid,
+    our_new_zone_id: BfUuid,
+    sender_zone_warning: Option<String>,
+    handle_zone_results: HandleZoneInternalResults,
+    sender_in_the_same_zone_as_us: bool,
+    from_kind: AddressKind,
+    to_kind: AddressKind,
+    parse_failures: Vec<String>,
+    zone_change_dbg_data: Option<ZoneChangeDbgData>,
+    additional_address_update: Option<(String, BfUuid)>,
+    additional_address_msgs: Vec<String>,
+    msg_and_target: Option<(ZoneChange, Member)>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -111,14 +111,14 @@ impl Default for AddressKind {
 
 #[derive(Debug)]
 struct HandleZoneData<'a, N: Network> {
-    pub zones: &'a [Zone],
-    pub from_member: &'a Member,
-    pub to_member: &'a Member,
-    pub addr: AddressAndPortForNetwork<N>,
-    pub swim_type: SwimType,
-    pub from_address_kind: AddressKind,
-    pub to_address_kind: AddressKind,
-    pub sender_in_the_same_zone_as_us: bool,
+    zones: &'a [Zone],
+    from_member: &'a Member,
+    to_member: &'a Member,
+    addr: AddressAndPortForNetwork<N>,
+    swim_type: SwimType,
+    from_address_kind: AddressKind,
+    to_address_kind: AddressKind,
+    sender_in_the_same_zone_as_us: bool,
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -128,14 +128,14 @@ pub enum ZoneRelative {
 }
 
 #[derive(Clone, Debug, Default)]
-pub struct MemberOrZoneChanges {
-    pub new_maintained_zone: Option<Zone>,
-    pub zone_id_for_our_member: Option<BfUuid>,
-    pub additional_address_for_our_member: Option<(String, BfUuid)>,
-    pub call_ack: bool,
-    pub sender_has_nil_zone: bool,
-    pub msg_and_target: Option<(ZoneChange, Member)>,
-    pub sender_relative: Option<(BfUuid, ZoneRelative)>,
+struct MemberOrZoneChanges {
+    new_maintained_zone: Option<Zone>,
+    zone_id_for_our_member: Option<BfUuid>,
+    additional_address_for_our_member: Option<(String, BfUuid)>,
+    call_ack: bool,
+    sender_has_nil_zone: bool,
+    msg_and_target: Option<(ZoneChange, Member)>,
+    sender_relative: Option<(BfUuid, ZoneRelative)>,
 }
 
 #[derive(Clone, Debug)]

--- a/components/butterfly/src/server/zones.rs
+++ b/components/butterfly/src/server/zones.rs
@@ -364,6 +364,10 @@ pub fn handle_zone_simple<N: Network>(
                 let mut zone_list = server.write_zone_list();
                 zone_list.maintained_zone_id = Some(zone_id);
             }
+            if let Some(uuid) = stuff.zone_uuid_for_our_member {
+                let mut zone_list = server.write_zone_list();
+                zone_list.our_zone_id = uuid;
+            }
             if let Some((sender_uuid, relative)) = stuff.sender_relative {
                 // TODO: update our zone with parent/child stuff
                 // need to take aliases into account!
@@ -481,6 +485,10 @@ pub fn handle_zone_simple<N: Network>(
             }
             for predecessor_id in results.predecessors_to_add_to_maintained_zone {
                 maintained_zone.predecessors.push(predecessor_id);
+            }
+            if let Some(zone_id) = results.zone_uuid_for_our_member {
+                let mut zone_list = server.write_zone_list();
+                zone_list.our_zone_id = zone_id;
             }
             if zone_changed {
                 maintained_zone.incarnation += 1;

--- a/components/butterfly/src/server/zones.rs
+++ b/components/butterfly/src/server/zones.rs
@@ -1,0 +1,1644 @@
+// Copyright (c) 2018 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! This module handles updates to zones and members.
+//!
+//! Used from the inbound thread.
+
+use std::cmp::Ordering as CmpOrdering;
+use std::collections::{hash_map::Entry, HashMap, HashSet};
+use std::mem;
+
+use member::{Health, Member};
+use message::BfUuid;
+use network::{
+    Address, AddressAndPort, AddressAndPortForNetwork, AddressForNetwork, MyFromStr, Network,
+};
+use server::Server;
+use swim::{SwimType, ZoneChange};
+use zone::{Zone, ZoneAddress};
+
+#[derive(Debug)]
+pub struct SimpleHandleZoneResults {
+    pub bail_out: bool,
+    pub sender_has_nil_zone: bool,
+    pub send_ack: bool,
+    pub msgs_and_targets_for_zone_change: Vec<(ZoneChange, Member)>,
+}
+
+#[derive(Debug, Default)]
+pub struct ZoneChangeDbgData {
+    pub zone_found: bool,
+    pub is_a_maintainer: Option<bool>,
+    pub real_maintainer_found: Option<bool>,
+    pub borked_successor_state: Option<bool>,
+    pub available_aliases: Option<Vec<String>>,
+    pub our_old_successor: Option<String>,
+    pub our_new_successor: Option<String>,
+    pub our_old_member_zone_id: Option<String>,
+    pub our_new_member_zone_id: Option<String>,
+    pub added_predecessors: Option<Vec<String>>,
+    pub sent_zone_change_with_alias_to: Option<Vec<(String, String)>>,
+    pub forwarded_to: Option<(String, String)>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct ZoneChangeResults {
+    pub original_maintained_zone: Zone,
+    pub successor_for_maintained_zone: Option<BfUuid>,
+    pub predecessors_to_add_to_maintained_zone: HashSet<BfUuid>,
+    pub zones_to_insert: Vec<Zone>,
+    pub zone_uuid_for_our_member: Option<BfUuid>,
+    pub aliases_to_inform: HashSet<BfUuid>,
+}
+
+#[derive(Debug)]
+pub enum ZoneChangeResultsMsgOrNothing {
+    Nothing,
+    Msg((ZoneChange, Member)),
+    Results(ZoneChangeResults),
+}
+
+#[derive(Debug, Default)]
+struct HandleZoneDbgData {
+    pub to_address: String,
+    pub to_port: u16,
+    pub host_address: String,
+    pub host_port: u16,
+    pub from_zone_id: String,
+    pub from_address: String,
+    pub from_port: u16,
+    pub real_from_address: String,
+    pub real_from_port: u16,
+    pub scenario: String,
+    pub was_settled: bool,
+    pub our_old_zone_id: String,
+    pub our_new_zone_id: String,
+    pub sender_zone_warning: Option<String>,
+    pub handle_zone_results: HandleZoneResults,
+    pub sender_in_the_same_zone_as_us: bool,
+    pub from_kind: AddressKind,
+    pub to_kind: AddressKind,
+    pub parse_failures: Vec<String>,
+    pub zone_change_dbg_data: Option<ZoneChangeDbgData>,
+    pub additional_address_update: Option<(ZoneAddress, ZoneAddress)>,
+    pub additional_address_msgs: Vec<String>,
+    pub msg_and_target: Option<(ZoneChange, Member)>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum AddressKind {
+    Real,
+    Additional,
+    Unknown,
+}
+
+impl Default for AddressKind {
+    fn default() -> Self {
+        AddressKind::Unknown
+    }
+}
+
+#[derive(Debug)]
+struct HandleZoneData<'a, N: Network> {
+    pub zones: &'a [Zone],
+    pub from_member: &'a Member,
+    pub to_member: &'a Member,
+    pub addr: AddressAndPortForNetwork<N>,
+    pub swim_type: SwimType,
+    pub from_address_kind: AddressKind,
+    pub to_address_kind: AddressKind,
+    pub sender_in_the_same_zone_as_us: bool,
+}
+
+#[derive(Copy, Clone, Debug)]
+pub enum ZoneRelative {
+    Child,
+    Parent,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct HandleZoneResultsStuff {
+    pub new_maintained_zone: Option<Zone>,
+    pub zone_uuid_for_our_member: Option<BfUuid>,
+    pub additional_address_for_our_member: Option<(ZoneAddress, ZoneAddress)>,
+    pub call_ack: bool,
+    pub sender_has_nil_zone: bool,
+    pub msg_and_target: Option<(ZoneChange, Member)>,
+    pub sender_relative: Option<(BfUuid, ZoneRelative)>,
+}
+
+#[derive(Clone, Debug)]
+pub enum HandleZoneResults {
+    Nothing,
+    UnknownSenderAddress,
+    SendAck,
+    // naming is hard…
+    Stuff(HandleZoneResultsStuff),
+    ZoneProcessed(ZoneChangeResults),
+}
+
+impl Default for HandleZoneResults {
+    fn default() -> Self {
+        HandleZoneResults::Nothing
+    }
+}
+
+pub fn process_zone_change_internal_state(
+    mut maintained_zone_clone: Zone,
+    mut maybe_successor_of_maintained_zone_clone: Option<Zone>,
+    mut our_zone_uuid: BfUuid,
+    mut zone_change: ZoneChange,
+    _dbg_data: &mut ZoneChangeDbgData,
+) -> ZoneChangeResults {
+    let mut results = ZoneChangeResults::default();
+    let maintained_zone_uuid = maintained_zone_clone.id;
+    let mut aliases_to_maybe_inform = HashMap::new();
+
+    //let mut dbg_available_aliases = Vec::new();
+    //let mut dbg_added_predecessors = Vec::new();
+
+    results.original_maintained_zone = maintained_zone_clone.clone();
+    match (
+        maintained_zone_clone.successor.is_some(),
+        maybe_successor_of_maintained_zone_clone.is_some(),
+    ) {
+        (true, true) | (false, false) => (),
+        (true, false) => {
+            //dbg_data.borked_successor_state = Some(true);
+
+            error!("passed maintained zone has a successor, but the successor was not passed");
+            return results;
+        }
+        (false, true) => {
+            //dbg_data.borked_successor_state = Some(true);
+
+            error!("passed maintained zone has no successor, but some successor was passed");
+            return results;
+        }
+    }
+
+    //dbg_data.borked_successor_state = Some(false);
+    //dbg_data.our_old_successor = Some(maintained_zone_clone.get_successor().to_string());
+    //dbg_data.our_old_member_zone_id = Some(our_zone_uuid.to_string());
+
+    results.zones_to_insert = zone_change.new_aliases.clone();
+    for alias_zone in zone_change.new_aliases.drain(..) {
+        //dbg_available_aliases.push(alias_zone.get_id().to_string());
+
+        let alias_uuid = alias_zone.id;
+        let mut possible_predecessor = None;
+
+        match alias_uuid.cmp(&maintained_zone_uuid) {
+            CmpOrdering::Less => {
+                possible_predecessor = Some(alias_zone);
+            }
+            CmpOrdering::Equal => (),
+            CmpOrdering::Greater => {
+                if let Some(ref successor_uuid) = maintained_zone_clone.successor {
+                    match alias_uuid.cmp(&successor_uuid) {
+                        CmpOrdering::Less => {
+                            possible_predecessor = Some(alias_zone);
+                        }
+                        CmpOrdering::Equal => (),
+                        CmpOrdering::Greater => {
+                            possible_predecessor = maybe_successor_of_maintained_zone_clone;
+                            maybe_successor_of_maintained_zone_clone = Some(alias_zone);
+                        }
+                    }
+                } else {
+                    maybe_successor_of_maintained_zone_clone = Some(alias_zone);
+                }
+            }
+        }
+
+        if let Some(ref new_successor) = &maybe_successor_of_maintained_zone_clone {
+            let has_new_successor = match maintained_zone_clone.successor {
+                Some(ref successor_uuid) => *successor_uuid != new_successor.id,
+                None => true,
+            };
+            if has_new_successor {
+                maintained_zone_clone.successor = Some(new_successor.id);
+                results.successor_for_maintained_zone = Some(new_successor.id);
+                match aliases_to_maybe_inform.entry(alias_uuid) {
+                    Entry::Occupied(_) => (),
+                    Entry::Vacant(ve) => {
+                        let abridged_successor = Zone {
+                            id: alias_uuid,
+                            incarnation: 0,
+                            maintainer_id: String::new(),
+                            parent_zone_id: None,
+                            child_zone_ids: Vec::new(),
+                            successor: Some(new_successor.id),
+                            predecessors: new_successor.predecessors.clone(),
+                        };
+
+                        ve.insert(abridged_successor);
+                    }
+                }
+            }
+
+            let successor_uuid = new_successor.id;
+
+            if our_zone_uuid < successor_uuid {
+                results.zone_uuid_for_our_member = Some(successor_uuid);
+                our_zone_uuid = successor_uuid;
+            }
+        }
+
+        if let Some(predecessor) = possible_predecessor {
+            let mut found = false;
+
+            for zone_id in maintained_zone_clone.predecessors.iter() {
+                if *zone_id == predecessor.id {
+                    found = true;
+                    break;
+                }
+            }
+
+            if !found {
+                //dbg_added_predecessors.push(predecessor.get_id().to_string());
+
+                let predecessor_uuid = predecessor.id;
+
+                results
+                    .predecessors_to_add_to_maintained_zone
+                    .insert(predecessor_uuid);
+                match aliases_to_maybe_inform.entry(predecessor_uuid) {
+                    Entry::Occupied(_) => (),
+                    Entry::Vacant(ve) => {
+                        ve.insert(predecessor);
+                    }
+                };
+            }
+        }
+    }
+
+    //dbg_data.our_new_successor = Some(maintained_zone_clone.get_successor().to_string());
+    //dbg_data.our_new_member_zone_id = Some(our_zone_uuid.to_string());
+    //dbg_data.available_aliases = Some(dbg_available_aliases);
+    //dbg_data.added_predecessors = Some(dbg_added_predecessors);
+
+    for (zone_uuid, zone) in aliases_to_maybe_inform {
+        if let Some(successor_uuid) = zone.successor {
+            if successor_uuid == maintained_zone_clone.id {
+                continue;
+            }
+        }
+
+        let mut found = false;
+
+        for predecessor_id in zone.predecessors.iter() {
+            if *predecessor_id == maintained_zone_clone.id {
+                found = true;
+                break;
+            }
+        }
+
+        if found {
+            continue;
+        }
+
+        results.aliases_to_inform.insert(zone_uuid);
+    }
+
+    results
+}
+
+pub fn handle_zone_simple<N: Network>(
+    server: &Server<N>,
+    zones: &[Zone],
+    swim_type: SwimType,
+    from: &Member,
+    to: &Member,
+    addr: N::AddressAndPort,
+) -> SimpleHandleZoneResults {
+    let mut bail_out = false;
+    let mut send_ack = false;
+    let mut sender_has_nil_zone = false;
+    let mut msgs_and_targets_for_zone_change = Vec::new();
+
+    match handle_zone_for_recipient(server, zones, swim_type, from, to, addr) {
+        HandleZoneResults::Nothing => (),
+        HandleZoneResults::UnknownSenderAddress => {
+            if swim_type == SwimType::Ping {
+                warn!(
+                    "Sender of the PING message does not know its address {}. \
+                     This shouldn't happen - this means that the sender sent a PING message to us \
+                     and we are not directly reachable",
+                    addr,
+                );
+            } else {
+                warn!(
+                    "Sender of the ACK message does not know its address {}. \
+                     This shouldn't happen - this means that we sent a PING message to a server \
+                     that is not directly reachable from us and it wasn't ignored by the receiver \
+                     of the message",
+                    addr,
+                );
+            }
+            bail_out = true;
+        }
+        HandleZoneResults::SendAck => {
+            send_ack = true;
+        }
+        HandleZoneResults::Stuff(stuff) => {
+            if stuff.sender_has_nil_zone {
+                sender_has_nil_zone = true;
+            }
+            send_ack = stuff.call_ack;
+            if let Some(zone) = stuff.new_maintained_zone {
+                let zone_id = zone.id;
+                server.insert_zone(zone);
+                let mut zone_list = server.write_zone_list();
+                zone_list.maintained_zone_id = Some(zone_id);
+            }
+            if let Some((sender_uuid, relative)) = stuff.sender_relative {
+                // TODO: update our zone with parent/child stuff
+                // need to take aliases into account!
+                let zone_id = {
+                    if let Some(uuid) = stuff.zone_uuid_for_our_member {
+                        uuid
+                    } else {
+                        server.read_member().zone_id
+                    }
+                };
+                let zone_to_insert = {
+                    let mut zone_to_insert = None;
+                    let zone_list = server.read_zone_list();
+
+                    if let Some(zone) = zone_list.zones.get(&zone_id) {
+                        match relative {
+                            ZoneRelative::Child => {
+                                let mut found =
+                                    zone.child_zone_ids.iter().any(|id| *id == sender_uuid);
+
+                                if !found {
+                                    for child_zone_id in zone.child_zone_ids.iter() {
+                                        if let Some(child_zone) = zone_list.zones.get(child_zone_id)
+                                        {
+                                            if let Some(ref successor) = child_zone.successor {
+                                                if *successor == sender_uuid {
+                                                    found = true;
+                                                    break;
+                                                }
+                                            }
+
+                                            if child_zone
+                                                .predecessors
+                                                .iter()
+                                                .any(|id| *id == sender_uuid)
+                                            {
+                                                found = true;
+                                                break;
+                                            }
+                                        }
+                                    }
+                                }
+                                if !found {
+                                    let mut zone_clone = zone.clone();
+
+                                    zone_clone.child_zone_ids.push(sender_uuid);
+
+                                    zone_to_insert = Some(zone_clone);
+                                }
+                            }
+                            ZoneRelative::Parent => {
+                                if zone.parent_zone_id.is_none() {
+                                    let mut zone_clone = zone.clone();
+
+                                    zone_clone.parent_zone_id = Some(sender_uuid);
+
+                                    zone_to_insert = Some(zone_clone);
+                                }
+                            }
+                        }
+                    }
+
+                    zone_to_insert
+                };
+
+                if let Some(zone) = zone_to_insert {
+                    server.insert_zone(zone);
+                }
+            }
+            let member_changed = stuff.zone_uuid_for_our_member.is_some()
+                || stuff.additional_address_for_our_member.is_some();
+            if member_changed {
+                let our_member_clone = {
+                    let mut our_member = server.write_member();
+
+                    our_member.incarnation += 1;
+                    if let Some(zone_uuid) = stuff.zone_uuid_for_our_member {
+                        our_member.zone_id = zone_uuid;
+                    }
+                    if let Some((old, new)) = stuff.additional_address_for_our_member {
+                        for zone_address in our_member.additional_addresses.iter_mut() {
+                            if zone_address.address != old.address {
+                                continue;
+                            }
+                            if zone_address.swim_port != old.swim_port {
+                                continue;
+                            }
+                            if zone_address.zone_id != old.zone_id {
+                                continue;
+                            }
+                            zone_address.address = new.address;
+                            zone_address.zone_id = new.zone_id;
+                            break;
+                        }
+                    }
+
+                    our_member.clone()
+                };
+                *server.write_zone_settled() = true;
+                server.insert_member(our_member_clone, Health::Alive);
+            }
+            if let Some(pair) = stuff.msg_and_target {
+                msgs_and_targets_for_zone_change.push(pair);
+            }
+        }
+        HandleZoneResults::ZoneProcessed(mut results) => {
+            let zone_changed = results.successor_for_maintained_zone.is_some()
+                || !results.predecessors_to_add_to_maintained_zone.is_empty();
+            let mut maintained_zone = Zone::default();
+
+            mem::swap(&mut maintained_zone, &mut results.original_maintained_zone);
+
+            if let Some(successor_id) = results.successor_for_maintained_zone.take() {
+                maintained_zone.successor = Some(successor_id);
+            }
+            for predecessor_id in results.predecessors_to_add_to_maintained_zone {
+                maintained_zone.predecessors.push(predecessor_id);
+            }
+            if zone_changed {
+                maintained_zone.incarnation += 1;
+                server.insert_zone(maintained_zone.clone());
+                send_ack = true;
+            }
+            for zone in results.zones_to_insert.drain(..) {
+                server.insert_zone(zone);
+            }
+            if let Some(zone_uuid) = results.zone_uuid_for_our_member {
+                let our_member_clone = {
+                    let mut our_member = server.write_member();
+
+                    our_member.zone_id = zone_uuid;
+                    our_member.incarnation += 1;
+
+                    our_member.clone()
+                };
+                *server.write_zone_settled() = true;
+                server.insert_member(our_member_clone, Health::Alive);
+                send_ack = true;
+            }
+
+            //let mut dbg_sent_zone_change_with_alias_to = Vec::new();
+
+            if !results.aliases_to_inform.is_empty() {
+                send_ack = true;
+                let mut zone_ids_and_maintainer_ids = {
+                    let zone_list = server.read_zone_list();
+
+                    results
+                        .aliases_to_inform
+                        .iter()
+                        .filter_map(|zone_id| {
+                            zone_list
+                                .zones
+                                .get(&zone_id)
+                                .map(|zone| (zone_id, zone.maintainer_id.clone()))
+                        })
+                        .collect::<Vec<_>>()
+                };
+
+                let mut msgs_and_targets = Vec::new();
+
+                {
+                    let mut msgs_and_targets = &mut msgs_and_targets;
+                    let mut zone_ids_and_maintainer_ids = &mut zone_ids_and_maintainer_ids;
+
+                    server.member_list.with_member_list(move |members_map| {
+                        for (zone_id, maintainer_id) in zone_ids_and_maintainer_ids.drain(..) {
+                            if let Some(maintainer) = members_map.get(&maintainer_id) {
+                                let zone_change = ZoneChange {
+                                    membership: Vec::new(),
+                                    zones: Vec::new(),
+                                    // TODO(krnowak): Ew.
+                                    from: Member::default(),
+                                    zone_id: *zone_id,
+                                    new_aliases: vec![maintained_zone.clone()],
+                                };
+
+                                msgs_and_targets.push((zone_change, maintainer.clone()));
+                            }
+                        }
+                    });
+                }
+
+                msgs_and_targets_for_zone_change.extend(msgs_and_targets);
+            }
+            //dbg_data.sent_zone_change_with_alias_to = dbg_sent_zone_change_with_alias_to;
+        }
+    }
+
+    SimpleHandleZoneResults {
+        bail_out,
+        sender_has_nil_zone,
+        send_ack,
+        msgs_and_targets_for_zone_change,
+    }
+}
+
+pub fn handle_zone_for_recipient<N: Network>(
+    server: &Server<N>,
+    zones: &[Zone],
+    swim_type: SwimType,
+    from: &Member,
+    to: &Member,
+    mut addr: N::AddressAndPort,
+) -> HandleZoneResults {
+    let mut dbg_data = HandleZoneDbgData::default();
+    let mut from_address_kind = address_kind(addr.get_address(), from, &mut dbg_data);
+    let mut to_address_kind = address_kind_from_str::<AddressForNetwork<N>>(
+        &to.address,
+        &server.read_member(),
+        &mut dbg_data,
+    );
+    let to_clone: Option<Member>;
+    let mut to_ref = to;
+
+    dbg_data.from_kind = from_address_kind;
+    dbg_data.to_kind = to_address_kind;
+    // we are dealing with several addresses here:
+    //
+    // real from address - can be an address of a mapping on a NAT
+    // or a local one
+    //
+    // member from - contains a real address and additional addresses
+    //
+    // member to - contains an address that can be either local or
+    // a mapping on a NAT
+    //
+    // member us - contains a local address and additional addresses
+    //
+    // address kinds:
+    // 1. real - an address is the same as member's local address
+    // 2. additional - an address is the same as one of member's
+    // additional addresses
+    // 3. unknown - if none of the above applies
+    //
+    // scenarios:
+    // 1. from real to real - message sent between two servers in
+    // the same zone
+    //
+    // 2. from real to additional - message sent from parent zone
+    // to child zone
+    //
+    // 3. from real to unknown - message likely sent from parent
+    // zone to child zone for the first time
+    //
+    // 4. from additional to real - message sent from child zone
+    // to parent zone
+    //
+    // 5. from additional to additional - probably message sent
+    // from a zone to a sibling zone
+    //
+    // 6. from additional to unknown - probably message sent from
+    // a zone to a sibling zone for the first time
+    //
+    // 7. from unknown to real - probably message sent from child
+    // zone to parent zone, but the sender either does not know
+    // that it can be reached with the address the message came
+    // from or it knows it can be reached, but does not know the
+    // exact address (only ports). This likely should not happen -
+    // if the server in child zone is not exposed in the parent
+    // zone, the message should be routed through the gateway
+    //
+    // 8. from unknown to additional - probably message sent from
+    // zone to a sibling zone, but the sender either does not know
+    // that it can be reached with the address the message came
+    // from. This likely should not happen - if the server in
+    // child zone is not exposed in the parent zone, the message
+    // should be routed through the gateway
+    //
+    // 9. from unknown to unknown - probably a message sent from
+    // zone to a sibling zone for the first time, but the sender
+    // either does not know that it can be reached with the
+    // address the message came from. This likely should not
+    // happen - if the server in child zone is not exposed in the
+    // parent zone, the message should be routed through the
+    // gateway
+    let sender_in_the_same_zone_as_us;
+    let mut maybe_result = None;
+    debug!(
+        "address kinds before fix: from {:?}, to {:?}",
+        from_address_kind, to_address_kind
+    );
+    debug!(
+        "before fix, addr: {}, from: {:#?}, to: {:#?}",
+        addr, from, to_ref
+    );
+    match (from_address_kind, to_address_kind) {
+        (AddressKind::Real, AddressKind::Real) => {
+            sender_in_the_same_zone_as_us = true;
+        }
+        (AddressKind::Real, AddressKind::Additional) => {
+            sender_in_the_same_zone_as_us = false;
+        }
+        (AddressKind::Additional, AddressKind::Real) => {
+            sender_in_the_same_zone_as_us = false;
+        }
+        (AddressKind::Additional, AddressKind::Additional) => {
+            sender_in_the_same_zone_as_us = false;
+        }
+        (AddressKind::Additional, AddressKind::Unknown) => {
+            // hack for kubernetes: the host which hosts the k8s
+            // cluster will likely talk to services inside the
+            // cluster using a different network interface than
+            // the one assigned to the IP address we detected
+            sender_in_the_same_zone_as_us = false;
+            let mut tc = to.clone();
+            tc.address = server.host_address.to_string();
+            to_clone = Some(tc);
+            to_ref = to_clone.as_ref().unwrap();
+            to_address_kind = AddressKind::Real;
+        }
+        (AddressKind::Unknown, AddressKind::Additional) => {
+            sender_in_the_same_zone_as_us = false;
+            // hack for kubernetes: kubernetes does the source NAT
+            // on packets coming from outside the cluster to
+            // inside by default.
+            match AddressForNetwork::<N>::create_from_str(&from.address) {
+                Ok(a) => {
+                    addr = N::AddressAndPort::new_from_address_and_port(a, from.swim_port);
+                    from_address_kind = AddressKind::Real;
+                }
+                Err(e) => {
+                    error!("Could not parse from address {}: {}", from.address, e);
+                    maybe_result = Some(HandleZoneResults::UnknownSenderAddress);
+                }
+            }
+        }
+        (AddressKind::Unknown, AddressKind::Real) => {
+            sender_in_the_same_zone_as_us = false;
+            // hack for kubernetes: minikube has some weird
+            // networking stuff, I send ping to one IP and get an
+            // ack from different one…
+            match AddressForNetwork::<N>::create_from_str(&from.address) {
+                Ok(a) => {
+                    addr = N::AddressAndPort::new_from_address_and_port(a, from.swim_port);
+                    from_address_kind = AddressKind::Additional;
+                }
+                Err(e) => {
+                    error!("Could not parse from address {}: {}", from.address, e);
+                    maybe_result = Some(HandleZoneResults::UnknownSenderAddress);
+                }
+            }
+        }
+        (_, _) => {
+            sender_in_the_same_zone_as_us = false;
+        }
+    };
+    debug!(
+        "address kinds after fix: from {:?}, to {:?}",
+        from_address_kind, to_address_kind
+    );
+    debug!(
+        "after fix, addr: {}, from: {:#?}, to: {:#?}",
+        addr, from, to_ref
+    );
+
+    dbg_data.to_address = to_ref.address.to_string();
+    dbg_data.to_port = to_ref.swim_port;
+    dbg_data.host_address = server.host_address.to_string();
+    dbg_data.host_port = server.swim_port();
+    dbg_data.sender_in_the_same_zone_as_us = sender_in_the_same_zone_as_us;
+    dbg_data.from_address = from.address.to_string();
+    dbg_data.from_port = from.swim_port;
+    dbg_data.real_from_address = addr.get_address().to_string();
+    dbg_data.real_from_port = addr.get_port();
+
+    let handle_zone_results = if let Some(result) = maybe_result {
+        result
+    } else {
+        let handle_zone_data = HandleZoneData {
+            zones: zones,
+            from_member: from,
+            to_member: to_ref,
+            addr: addr,
+            swim_type: swim_type,
+            from_address_kind: from_address_kind,
+            to_address_kind: to_address_kind,
+            sender_in_the_same_zone_as_us: sender_in_the_same_zone_as_us,
+        };
+        handle_zone(server, handle_zone_data, &mut dbg_data)
+    };
+    dbg_data.handle_zone_results = handle_zone_results.clone();
+    debug!(
+        "=========={:?}==========\n\
+         dbg:\n\
+         \n\
+         {:#?}\n\
+         \n\
+         member us: {:#?}\n\
+         member from: {:#?}\n\
+         \n\
+         =====================",
+        swim_type,
+        dbg_data,
+        server.read_member(),
+        from,
+    );
+    handle_zone_results
+}
+
+fn handle_zone<N: Network>(
+    server: &Server<N>,
+    hz_data: HandleZoneData<N>,
+    dbg_data: &mut HandleZoneDbgData,
+) -> HandleZoneResults {
+    // scenarios:
+    // - 0 sender has nil zone id
+    //   - 0a. i'm not settled
+    //     - 0aa. sender in the same private network as me
+    //       - generate my own zone
+    //     - 0ab. sender in a different private network than me
+    //       - generate my own zone
+    //       - store the recipient address if not stored (ports
+    //         should already be available)
+    //   - 0b. i'm settled
+    //     - 0ba. sender in the same private network as me
+    //       - do nothing
+    //     - 0bb. sender in a different private network than me
+    //       - store the recipient address if not stored (ports
+    //         should already be available)
+    // - 1 sender has non-nil zone id
+    //   - 1a. i'm not settled
+    //     - 1aa. sender in the same private network as me
+    //       - assume sender's zone
+    //     - 1ab. sender in a different private network than me
+    //       - generate my own zone
+    //       - add sender id as a child/parent of my zone
+    //       - store the recipient address if not stored (ports
+    //         should already be available)
+    //       - store sender zone id? what did i mean by that?
+    //   - 1b. i'm settled
+    //     - 1ba. sender in the same private network as me
+    //       - 1ba<. senders zone id is less than mine
+    //         - if message was ack then send another ack back to
+    //           enlighten the sender about newer and better zone
+    //       - 1ba=. senders zone id is equal to mine
+    //         - do nothing
+    //       - 1ba>. senders zone id is greater than mine
+    //         - use process_zone_change_internal_state
+    //     - 1bb. sender in a different private network than me
+    //       - add sender id as a child/parent of my zone
+    //       - store the recipient address if not stored (ports
+    //         should already be available)
+    //       - store sender zone id? what did i mean by that?
+    //
+    // actions:
+    // - settle zone
+    // - generate my own zone
+    //   - new zone uuid for our member
+    //   - new maintained zone
+    //   - send an ack
+    // - add sender id as a child/parent of my zone
+    //   - if from/to is real/additional then sender is a parent
+    //   - if from/to is additional/real then sender is a child
+    // - store the additional address if not stored (ports should
+    //   already be available)
+    //   - if this is an ack and to zone id is nil and from is additional
+    //     - send ack
+    //   - this should always be an update of an existing address
+    //     entry, never an addition
+    //   - scenarios:
+    //     - 0. nil sender zone id
+    //       - search for fitting port number with no address and no zone
+    //       - if there is only one then update the address, zone is still nil
+    //       - otherwise ignore it
+    //     - 1. non nil sender zone id
+    //       - search for fitting port number with a specific zone
+    //         - if found and address is the same, nothing to add
+    //         - if found and address is different, continue with the other approach
+    //         - if not found, continue with the other approach
+    //       - search for fitting port number with a specific address
+    //         - if found and zone id is the same, nothing to add (should be caught earlier, though)
+    //         - if found and zone id is nil, update the zone id
+    //         - if found and zone id is a child of sender - update the zone
+    //         - if found and zone id is a parent of sender - no
+    //           clue, do nothing, add another entry as a copy of
+    //           this one? or rather warn?
+    //         - if found and zone id is something else - ignore? should not happen?
+    // - assume sender's zone (means that we were not settled yet)
+    //   - new uuid for our member
+    // - store sender zone id? what did i mean by that?
+    // - if message was ack then send another ack back to
+    //   enlighten the sender about newer and better zone
+    // - use process_zone_change_internal_state
+    let maybe_not_nil_sender_zone_and_uuid = {
+        if let Some(zone) = hz_data
+            .zones
+            .iter()
+            .find(|z| z.id == hz_data.from_member.zone_id)
+            .cloned()
+        {
+            let zone_uuid = zone.id;
+            if zone_uuid.is_nil() {
+                dbg_data.sender_zone_warning =
+                    Some("Got a zone with a nil UUID, ignoring it".to_string());
+                warn!("Got a zone with a nil UUID, ignoring it");
+                None
+            } else {
+                Some((zone, zone_uuid))
+            }
+        } else {
+            let uuid = hz_data.from_member.zone_id;
+
+            if !uuid.is_nil() {
+                dbg_data.sender_zone_warning = Some(format!("Got no zone info for {}", uuid));
+                warn!("Got no zone info for {}", uuid,);
+            }
+            None
+        }
+    };
+    let zone_settled = *(server.read_zone_settled());
+    let same_private_network = hz_data.sender_in_the_same_zone_as_us;
+    let our_member_clone = server.read_member().clone();
+    let (
+        maybe_maintained_zone_clone,
+        maybe_successor_of_maintained_zone_clone,
+        maybe_our_zone_clone,
+    ) = {
+        let zone_list = server.read_zone_list();
+        let maybe_our_zone_clone = zone_list.zones.get(&our_member_clone.zone_id).cloned();
+        let zone_pair = if let &Some(ref maintained_zone_id) = &zone_list.maintained_zone_id {
+            if let Some(maintained_zone) = zone_list.zones.get(maintained_zone_id) {
+                if let Some(ref maintained_zone_successor) = maintained_zone.successor {
+                    if let Some(successor) = zone_list.zones.get(maintained_zone_successor) {
+                        (Some(maintained_zone.clone()), Some(successor.clone()))
+                    } else {
+                        warn!(
+                            "Maintained zone {} has successor {}, \
+                             but we don't have it in our zone list",
+                            maintained_zone_id, maintained_zone_successor,
+                        );
+                        (None, None)
+                    }
+                } else {
+                    (Some(maintained_zone.clone()), None)
+                }
+            } else {
+                warn!(
+                    "Maintained zone ID is {}, but we don't have it in our zone list",
+                    maintained_zone_id
+                );
+                (None, None)
+            }
+        } else {
+            (None, None)
+        };
+
+        (zone_pair.0, zone_pair.1, maybe_our_zone_clone)
+    };
+    let maybe_our_zone_maintainer_clone = if let Some(ref our_zone_clone) = maybe_our_zone_clone {
+        let mut maybe_member = None;
+
+        server
+            .member_list
+            .with_member(&our_zone_clone.maintainer_id, |maybe_maintainer| {
+                maybe_member = maybe_maintainer.cloned();
+            });
+
+        maybe_member
+    } else {
+        None
+    };
+
+    dbg_data.was_settled = zone_settled;
+    dbg_data.our_old_zone_id = our_member_clone.zone_id.to_string();
+
+    let results = match (
+        maybe_not_nil_sender_zone_and_uuid,
+        zone_settled,
+        same_private_network,
+    ) {
+        // 0aa.
+        (None, false, true) => {
+            dbg_data.scenario = "0aa".to_string();
+
+            let mut stuff = HandleZoneResultsStuff::default();
+
+            stuff.sender_has_nil_zone = true;
+            generate_my_own_zone(&mut stuff, our_member_clone.id.clone(), dbg_data);
+
+            HandleZoneResults::Stuff(stuff)
+        }
+        // 0ab.
+        (None, false, false) => {
+            dbg_data.scenario = "0ab".to_string();
+
+            let mut stuff = HandleZoneResultsStuff::default();
+
+            stuff.sender_has_nil_zone = true;
+            generate_my_own_zone(&mut stuff, our_member_clone.id.clone(), dbg_data);
+            store_recipient_address_nil_sender_zone(
+                &mut stuff,
+                hz_data.from_address_kind,
+                hz_data.to_address_kind,
+                &our_member_clone,
+                &hz_data.to_member,
+                dbg_data,
+            );
+
+            HandleZoneResults::Stuff(stuff)
+        }
+        // 0ba.
+        (None, true, true) => {
+            dbg_data.scenario = "0ba".to_string();
+
+            let mut stuff = HandleZoneResultsStuff::default();
+
+            stuff.sender_has_nil_zone = true;
+            stuff.call_ack = true;
+
+            HandleZoneResults::Stuff(stuff)
+        }
+        // 0bb.
+        (None, true, false) => {
+            dbg_data.scenario = "0bb".to_string();
+
+            let mut stuff = HandleZoneResultsStuff::default();
+
+            stuff.sender_has_nil_zone = true;
+            store_recipient_address_nil_sender_zone(
+                &mut stuff,
+                hz_data.from_address_kind,
+                hz_data.to_address_kind,
+                &our_member_clone,
+                &hz_data.to_member,
+                dbg_data,
+            );
+
+            HandleZoneResults::Stuff(stuff)
+        }
+        // 1aa.
+        (Some((sender_zone, _sender_zone_uuid)), false, true) => {
+            dbg_data.scenario = "1aa".to_string();
+
+            let mut stuff = HandleZoneResultsStuff::default();
+
+            assume_senders_zone(&mut stuff, sender_zone.id, dbg_data);
+
+            HandleZoneResults::Stuff(stuff)
+        }
+        // 1ab.
+        (Some((sender_zone, _sender_zone_uuid)), false, false) => {
+            dbg_data.scenario = "1ab".to_string();
+
+            let mut stuff = HandleZoneResultsStuff::default();
+
+            generate_my_own_zone(&mut stuff, our_member_clone.id.clone(), dbg_data);
+            add_sender_zone_id_as_relative(
+                &mut stuff,
+                hz_data.from_address_kind,
+                hz_data.to_address_kind,
+                sender_zone.id,
+                dbg_data,
+            );
+            store_recipient_address_valid_sender_zone(
+                &mut stuff,
+                hz_data.from_address_kind,
+                hz_data.to_address_kind,
+                &our_member_clone,
+                &hz_data.to_member,
+                &sender_zone,
+                dbg_data,
+            );
+
+            HandleZoneResults::Stuff(stuff)
+        }
+        // 1ba.
+        (Some((sender_zone, _sender_zone_uuid)), true, true) => {
+            dbg_data.scenario = "1ba".to_string();
+
+            process_zone(
+                our_member_clone,
+                maybe_maintained_zone_clone,
+                maybe_successor_of_maintained_zone_clone,
+                maybe_our_zone_clone,
+                maybe_our_zone_maintainer_clone,
+                sender_zone,
+                dbg_data,
+            )
+        }
+        // 1bb.
+        (Some((sender_zone, _sender_zone_uuid)), true, false) => {
+            dbg_data.scenario = "1bb".to_string();
+
+            let mut stuff = HandleZoneResultsStuff::default();
+
+            add_sender_zone_id_as_relative(
+                &mut stuff,
+                hz_data.from_address_kind,
+                hz_data.to_address_kind,
+                sender_zone.id,
+                dbg_data,
+            );
+            store_recipient_address_valid_sender_zone(
+                &mut stuff,
+                hz_data.from_address_kind,
+                hz_data.to_address_kind,
+                &our_member_clone,
+                &hz_data.to_member,
+                &sender_zone,
+                dbg_data,
+            );
+
+            HandleZoneResults::Stuff(stuff)
+        }
+    };
+
+    results
+}
+
+fn address_kind<A: Address>(
+    addr: A,
+    member: &Member,
+    dbg_data: &mut HandleZoneDbgData,
+) -> AddressKind {
+    let member_real_address = match A::create_from_str(&member.address) {
+        Ok(member_addr) => member_addr,
+        Err(e) => {
+            let msg = format!(
+                "Error parsing member {:?} address {}: {}",
+                member, member.address, e
+            );
+            error!("{}", msg);
+            dbg_data.parse_failures.push(msg);
+            return AddressKind::Unknown;
+        }
+    };
+
+    if member_real_address == addr {
+        return AddressKind::Real;
+    }
+
+    for zone_address in member.additional_addresses.iter() {
+        if let Some(ref zone_addr_str) = zone_address.address {
+            let member_additional_address = match A::create_from_str(zone_addr_str) {
+                Ok(zone_addr) => zone_addr,
+                Err(e) => {
+                    let msg = format!(
+                        "Error parsing member {:?} additional address {}: {}",
+                        member, zone_addr_str, e
+                    );
+                    error!("{}", msg);
+                    dbg_data.parse_failures.push(msg);
+                    continue;
+                }
+            };
+
+            if member_additional_address == addr {
+                return AddressKind::Additional;
+            }
+        }
+    }
+
+    AddressKind::Unknown
+}
+
+fn address_kind_from_str<A: Address>(
+    addr: &str,
+    member: &Member,
+    dbg_data: &mut HandleZoneDbgData,
+) -> AddressKind {
+    let real_address = match A::create_from_str(addr) {
+        Ok(addr) => addr,
+        Err(e) => {
+            error!("Error parsing address {}: {}", addr, e);
+            return AddressKind::Unknown;
+        }
+    };
+
+    address_kind(real_address, member, dbg_data)
+}
+
+fn generate_my_own_zone(
+    stuff: &mut HandleZoneResultsStuff,
+    maintainer_id: String,
+    dbg_data: &mut HandleZoneDbgData,
+) {
+    let new_zone_uuid = BfUuid::generate();
+
+    stuff.new_maintained_zone = Some(Zone::new(new_zone_uuid, maintainer_id));
+    stuff.zone_uuid_for_our_member = Some(new_zone_uuid);
+    stuff.call_ack = true;
+
+    dbg_data.our_new_zone_id = new_zone_uuid.to_string();
+}
+
+fn store_recipient_address_nil_sender_zone(
+    stuff: &mut HandleZoneResultsStuff,
+    from_address_kind: AddressKind,
+    to_address_kind: AddressKind,
+    our_member: &Member,
+    to_member: &Member,
+    dbg_data: &mut HandleZoneDbgData,
+) {
+    if from_address_kind == AddressKind::Additional && to_member.zone_id.is_nil() {
+        stuff.call_ack = true;
+        dbg_data
+            .additional_address_msgs
+            .push("will send an ack".to_string());
+    }
+    dbg_data
+        .additional_address_msgs
+        .push(format!("got message on {:?} address", to_address_kind));
+    if to_address_kind != AddressKind::Real {
+        for zone_address in our_member.additional_addresses.iter() {
+            if zone_address.swim_port != to_member.swim_port {
+                dbg_data.additional_address_msgs.push(format!(
+                    "zone address {:#?} has swim port different than {}, skipping",
+                    zone_address, to_member.swim_port
+                ));
+                continue;
+            }
+
+            let zone_address_uuid = zone_address.zone_id;
+
+            if !zone_address_uuid.is_nil() {
+                dbg_data.additional_address_msgs.push(format!(
+                    "zone address {:#?} has non-nil zone id, skipping",
+                    zone_address
+                ));
+                continue;
+            }
+            if zone_address.address.is_some() {
+                dbg_data.additional_address_msgs.push(format!(
+                    "zone address {:#?} already has an address, skipping",
+                    zone_address
+                ));
+                continue;
+            }
+
+            let mut new_zone_address = zone_address.clone();
+
+            new_zone_address.address = Some(to_member.address.clone());
+            stuff.additional_address_for_our_member =
+                Some((zone_address.clone(), new_zone_address));
+
+            dbg_data.additional_address_update = stuff.additional_address_for_our_member.clone();
+
+            break;
+        }
+    }
+}
+
+fn assume_senders_zone(
+    stuff: &mut HandleZoneResultsStuff,
+    sender_zone_uuid: BfUuid,
+    dbg_data: &mut HandleZoneDbgData,
+) {
+    stuff.zone_uuid_for_our_member = Some(sender_zone_uuid);
+    stuff.call_ack = true;
+
+    dbg_data.our_new_zone_id = sender_zone_uuid.to_string();
+}
+
+fn add_sender_zone_id_as_relative(
+    stuff: &mut HandleZoneResultsStuff,
+    from_address_kind: AddressKind,
+    to_address_kind: AddressKind,
+    sender_zone_uuid: BfUuid,
+    _dbg_data: &mut HandleZoneDbgData,
+) {
+    match (from_address_kind, to_address_kind) {
+        (AddressKind::Additional, AddressKind::Real) => {
+            stuff.sender_relative = Some((sender_zone_uuid, ZoneRelative::Child));
+        }
+        (AddressKind::Real, AddressKind::Additional) => {
+            stuff.sender_relative = Some((sender_zone_uuid, ZoneRelative::Parent));
+        }
+        (AddressKind::Real, AddressKind::Real) => {
+            unreachable!(
+                "sender was detected as being from different private network, \
+                 but we got two real addresses"
+            );
+        }
+        (AddressKind::Additional, AddressKind::Additional) => {
+            unimplemented!("TODO when we implement sibling zones")
+        }
+        (_, _) => warn!(
+            "unhandled relationship case, from {:?} to {:?}",
+            from_address_kind, to_address_kind,
+        ),
+    }
+}
+
+// store the recipient address if not stored (ports
+// should already be available)
+//
+// - 1. non nil sender zone id
+//   - search for a zone address instance with a
+//     variant-fitting zone
+//     - variant-fitting zone means a variant of a
+//       sender zone (successor/predecessor/itself)
+//     - found and both address and port are the
+//       same
+//       - zone in the instance is the same as sender
+//         zone or sender zone successor
+//         - nothing to do
+//       - zone in the instance is the same as one of
+//         the sender zone's predecessors
+//         - update the zone to sender's successor or
+//           to sender zone itself
+//     - not found
+//       - continue with the other approach
+//   - search for a zone address instance with a
+//     relation-fitting zone
+//     - relation-fitting zone means a relative of a
+//       sender zone (child/parent/itself)
+//     - found and both address and port are the
+//       same
+//       - zone in the instance is the same as sender
+//         zone or parent of the sender zone
+//         - do nothing (not sure about doing nothing
+//           for the parent case)
+//       - zone in the instance is the same as one of
+//         the children of the sender zone
+//         - update the zone in some way?
+//     - not found
+//       - continue with the other approach
+//   - search for a zone address instance with a nil zone
+//     - found and both address and port are the
+//       same
+//       - update the zone to sender zone itself
+//     - not found
+//       - continue with the other approach
+//   - search for a zone address instance with a nil
+//     zone and an unset address
+//     - found and ports are the same
+//       - update the zone to sender zone itself
+//       - update the address
+//     - not found
+//       - warn
+fn store_recipient_address_valid_sender_zone(
+    stuff: &mut HandleZoneResultsStuff,
+    from_address_kind: AddressKind,
+    to_address_kind: AddressKind,
+    our_member: &Member,
+    to_member: &Member,
+    sender_zone: &Zone,
+    dbg_data: &mut HandleZoneDbgData,
+) {
+    if from_address_kind == AddressKind::Additional && to_member.zone_id.is_nil() {
+        stuff.call_ack = true;
+        dbg_data
+            .additional_address_msgs
+            .push("will send an ack".to_string());
+    }
+    // this is to ignore messages that arrived to our
+    // real address, not the additional one
+    let mut done = to_address_kind == AddressKind::Real;
+    dbg_data
+        .additional_address_msgs
+        .push(format!("got message on {:?} address", to_address_kind));
+
+    if !done {
+        dbg_data
+            .additional_address_msgs
+            .push("going with the variant-fitting scenario".to_string());
+        for zone_address in our_member.additional_addresses.iter() {
+            if let Some(ref address_str) = zone_address.address {
+                if *address_str != to_member.address {
+                    dbg_data.additional_address_msgs.push(format!(
+                        "zone address {:#?} has different address than {}, skipping",
+                        zone_address, to_member.address
+                    ));
+                    continue;
+                }
+            } else {
+                dbg_data.additional_address_msgs.push(format!(
+                    "zone address {:#?} has no address, skipping",
+                    zone_address
+                ));
+                continue;
+            }
+
+            if zone_address.swim_port != to_member.swim_port {
+                dbg_data.additional_address_msgs.push(format!(
+                    "zone address {:#?} has different swim port than {}, skipping",
+                    zone_address, to_member.swim_port
+                ));
+                continue;
+            }
+
+            let zone_address_uuid = zone_address.zone_id;
+
+            if zone_address_uuid == sender_zone.id {
+                done = true;
+                dbg_data.additional_address_msgs.push(format!(
+                    "zone address {:#?} has the same zone id as sender, done",
+                    zone_address
+                ));
+                break;
+            }
+
+            if let Some(sender_successor_uuid) = sender_zone.successor {
+                if sender_successor_uuid == zone_address_uuid {
+                    dbg_data.additional_address_msgs.push(format!(
+                        "zone address {:#?} has the same zone id as sender's successor, done",
+                        zone_address
+                    ));
+                    done = true;
+                    break;
+                }
+            }
+
+            let mut maybe_new_zone_id = None;
+
+            for predecessor_uuid in sender_zone.predecessors.iter() {
+                if *predecessor_uuid == zone_address_uuid {
+                    dbg_data.additional_address_msgs.push(format!(
+                        "zone address {:#?} has the same zone id as sender's predecessor, done",
+                        zone_address
+                    ));
+                    if let Some(sender_successor_uuid) = sender_zone.successor {
+                        maybe_new_zone_id = Some(sender_successor_uuid);
+                    } else {
+                        maybe_new_zone_id = Some(sender_zone.id);
+                    }
+                }
+            }
+            done = match maybe_new_zone_id {
+                Some(zone_id) => {
+                    let mut new_zone_address = zone_address.clone();
+
+                    new_zone_address.zone_id = zone_id;
+                    new_zone_address.address = Some(to_member.address.clone());
+                    stuff.additional_address_for_our_member =
+                        Some((zone_address.clone(), new_zone_address));
+
+                    dbg_data.additional_address_update =
+                        stuff.additional_address_for_our_member.clone();
+
+                    true
+                }
+                None => {
+                    dbg_data.additional_address_msgs.push(format!(
+                        "zone address {:#?} does not match the sender, skipping",
+                        zone_address
+                    ));
+                    false
+                }
+            };
+            if done {
+                break;
+            }
+        }
+    }
+    if !done {
+        dbg_data
+            .additional_address_msgs
+            .push("going with the relative-fitting scenario".to_string());
+        // TODO: handle parent/child relationships
+        // following the steps written above
+        dbg_data
+            .additional_address_msgs
+            .push("haha not really, not implemented".to_string());
+    }
+    if !done {
+        dbg_data
+            .additional_address_msgs
+            .push("going with the nil-zoned scenario".to_string());
+        for zone_address in our_member.additional_addresses.iter() {
+            if let Some(ref address_str) = zone_address.address {
+                if *address_str != to_member.address {
+                    dbg_data.additional_address_msgs.push(format!(
+                        "zone address {:#?} has different address than {}, skipping",
+                        zone_address, to_member.address
+                    ));
+                    continue;
+                }
+            } else {
+                dbg_data.additional_address_msgs.push(format!(
+                    "zone address {:#?} has no address, skipping",
+                    zone_address
+                ));
+                continue;
+            }
+
+            if zone_address.swim_port != to_member.swim_port {
+                dbg_data.additional_address_msgs.push(format!(
+                    "zone address {:#?} has different swim port than {}, skipping",
+                    zone_address, to_member.swim_port
+                ));
+                continue;
+            }
+
+            let zone_address_uuid = zone_address.zone_id;
+
+            if !zone_address_uuid.is_nil() {
+                dbg_data.additional_address_msgs.push(format!(
+                    "zone address {:#?} has non-nil zone, skipping",
+                    zone_address
+                ));
+                continue;
+            }
+
+            let mut new_zone_address = zone_address.clone();
+
+            new_zone_address.zone_id = sender_zone.id;
+            stuff.additional_address_for_our_member =
+                Some((zone_address.clone(), new_zone_address));
+
+            dbg_data.additional_address_update = stuff.additional_address_for_our_member.clone();
+
+            done = true;
+            break;
+        }
+    }
+    if !done {
+        dbg_data
+            .additional_address_msgs
+            .push("going with the nil-zoned, address-guessing scenario".to_string());
+        for zone_address in our_member.additional_addresses.iter() {
+            if zone_address.address.is_some() {
+                dbg_data.additional_address_msgs.push(format!(
+                    "zone address {:#?} already has an address, skipping",
+                    zone_address
+                ));
+                continue;
+            }
+
+            if zone_address.swim_port != to_member.swim_port {
+                dbg_data.additional_address_msgs.push(format!(
+                    "zone address {:#?} has different swim port than {}, skipping",
+                    zone_address, to_member.swim_port
+                ));
+                continue;
+            }
+
+            let zone_address_uuid = zone_address.zone_id;
+
+            if !zone_address_uuid.is_nil() {
+                dbg_data.additional_address_msgs.push(format!(
+                    "zone address {:#?} has non-nil zone, skipping",
+                    zone_address
+                ));
+                continue;
+            }
+
+            let mut new_zone_address = zone_address.clone();
+
+            new_zone_address.zone_id = sender_zone.id;
+            new_zone_address.address = Some(to_member.address.clone());
+            stuff.additional_address_for_our_member =
+                Some((zone_address.clone(), new_zone_address));
+
+            dbg_data.additional_address_update = stuff.additional_address_for_our_member.clone();
+
+            done = true;
+            break;
+        }
+    }
+    if !done {
+        dbg_data
+            .additional_address_msgs
+            .push("unhandled zone address…".to_string());
+        warn!("Arf")
+    }
+}
+
+// - 0. we maintain a zone
+//   - use process_zone_change_internal_state
+// - 1. we do not maintain a zone
+//   - 1a. sender's zone id is less than ours
+//     - send ack back if this message was ack
+//   - 1b. sender's zone id is equal to ours
+//     - do nothing
+//   - 1c. sender's zone id is greater than ours
+//     - update our member's zone id
+//     - send zone change to the maintainer of the old
+//       zone id if the old zone has no info about the
+//       new successor
+fn process_zone(
+    our_member: Member,
+    maybe_maintained_zone: Option<Zone>,
+    maybe_successor_of_maintained_zone: Option<Zone>,
+    maybe_our_zone: Option<Zone>,
+    maybe_our_zone_maintainer: Option<Member>,
+    sender_zone: Zone,
+    dbg_data: &mut HandleZoneDbgData,
+) -> HandleZoneResults {
+    let our_member_zone_id = our_member.zone_id;
+
+    if let Some(maintained_zone) = maybe_maintained_zone {
+        let mut zone_change_dbg_data = ZoneChangeDbgData::default();
+        let zone_change = ZoneChange {
+            membership: Vec::new(),
+            zones: Vec::new(),
+            // TODO(krnowak): Ew.
+            //
+            // Setting this field is not necessary, it is
+            // used only for checking in the block list
+            from: Member::default(),
+            zone_id: maintained_zone.id,
+            new_aliases: vec![sender_zone],
+        };
+        let zone_change_results = process_zone_change_internal_state(
+            maintained_zone,
+            maybe_successor_of_maintained_zone,
+            our_member_zone_id,
+            zone_change,
+            &mut zone_change_dbg_data,
+        );
+
+        dbg_data.zone_change_dbg_data = Some(zone_change_dbg_data);
+
+        HandleZoneResults::ZoneProcessed(zone_change_results)
+    } else {
+        match sender_zone.id.cmp(&our_member_zone_id) {
+            CmpOrdering::Less => HandleZoneResults::SendAck,
+            CmpOrdering::Equal => HandleZoneResults::Nothing,
+            CmpOrdering::Greater => {
+                let mut stuff = HandleZoneResultsStuff::default();
+                let sender_zone_id = sender_zone.id;
+                let maybe_msg_and_target = if let Some(our_zone) = maybe_our_zone {
+                    let maybe_target = {
+                        dbg_data
+                            .parse_failures
+                            .push(format!("our zone clone: {:#?}", our_zone));
+                        if let Some(successor_uuid) = our_zone.successor {
+                            dbg_data
+                                .parse_failures
+                                .push("our zone clone has successor".to_string());
+
+                            if successor_uuid < sender_zone.id {
+                                dbg_data.parse_failures.push(format!(
+                                    "our zone clone successor {} is less \
+                                     than sender zone {}, targetting {:#?}",
+                                    successor_uuid, sender_zone.id, maybe_our_zone_maintainer
+                                ));
+                                maybe_our_zone_maintainer
+                            } else {
+                                dbg_data.parse_failures.push(format!(
+                                    "our zone clone successor {} is NOT less than sender zone {}",
+                                    successor_uuid, sender_zone.id
+                                ));
+                                None
+                            }
+                        } else {
+                            dbg_data.parse_failures.push(format!(
+                                "our zone clone has no successor, targetting {:#?}",
+                                maybe_our_zone_maintainer
+                            ));
+                            maybe_our_zone_maintainer
+                        }
+                    };
+
+                    if let Some(target) = maybe_target {
+                        let zone_change = ZoneChange {
+                            membership: Vec::new(),
+                            zones: Vec::new(),
+                            from: our_member,
+                            zone_id: our_member_zone_id,
+                            new_aliases: vec![sender_zone],
+                        };
+
+                        Some((zone_change, target))
+                    } else {
+                        None
+                    }
+                } else {
+                    error!(
+                        "We have no information about our current zone {}",
+                        our_member.zone_id
+                    );
+                    None
+                };
+
+                stuff.zone_uuid_for_our_member = Some(sender_zone_id);
+                stuff.msg_and_target = maybe_msg_and_target;
+
+                dbg_data.our_new_zone_id = sender_zone_id.to_string();
+                dbg_data.msg_and_target = stuff.msg_and_target.clone();
+
+                HandleZoneResults::Stuff(stuff)
+            }
+        }
+    }
+}

--- a/components/butterfly/src/server/zones.rs
+++ b/components/butterfly/src/server/zones.rs
@@ -369,8 +369,6 @@ pub fn handle_zone<N: Network>(
                 zone_list.our_zone_id = id;
             }
             if let Some((sender_id, relative)) = changes.sender_relative {
-                // TODO: update our zone with parent/child stuff
-                // need to take aliases into account!
                 let zone_id = {
                     if let Some(id) = changes.zone_id_for_our_member {
                         id

--- a/components/butterfly/src/server/zones.rs
+++ b/components/butterfly/src/server/zones.rs
@@ -140,7 +140,7 @@ pub struct MemberOrZoneChanges {
 }
 
 #[derive(Clone, Debug)]
-pub enum HandleZoneInternalResults {
+enum HandleZoneInternalResults {
     Nothing,
     UnknownSenderAddress,
     SendAck,
@@ -569,7 +569,7 @@ pub fn handle_zone<N: Network>(
     }
 }
 
-pub fn handle_zone_for_recipient<N: Network>(
+fn handle_zone_for_recipient<N: Network>(
     server: &Server<N>,
     zones: &[Zone],
     swim_type: SwimType,

--- a/components/butterfly/src/server/zones.rs
+++ b/components/butterfly/src/server/zones.rs
@@ -856,21 +856,20 @@ fn handle_zone<N: Network>(
     // - if message was ack then send another ack back to
     //   enlighten the sender about newer and better zone
     // - use process_zone_change_internal_state
-    let maybe_not_nil_sender_zone_and_id = {
+    let maybe_not_nil_sender_zone = {
         if let Some(zone) = hz_data
             .zones
             .iter()
             .find(|z| z.id == hz_data.from_member.zone_id)
             .cloned()
         {
-            let zone_id = zone.id;
-            if zone_id.is_nil() {
+            if zone.id.is_nil() {
                 dbg_data.sender_zone_warning =
                     Some("Got a zone with a nil UUID, ignoring it".to_string());
                 warn!("Got a zone with a nil UUID, ignoring it");
                 None
             } else {
-                Some((zone, zone_id))
+                Some(zone)
             }
         } else {
             let id = hz_data.from_member.zone_id;
@@ -939,7 +938,7 @@ fn handle_zone<N: Network>(
     dbg_data.our_old_zone_id = our_member_clone.zone_id.to_string();
 
     let results = match (
-        maybe_not_nil_sender_zone_and_id,
+        maybe_not_nil_sender_zone,
         zone_settled,
         same_private_network,
     ) {
@@ -1003,7 +1002,7 @@ fn handle_zone<N: Network>(
             HandleZoneResults::Stuff(stuff)
         }
         // 1aa.
-        (Some((sender_zone, _sender_zone_id)), false, true) => {
+        (Some(sender_zone), false, true) => {
             dbg_data.scenario = "1aa".to_string();
 
             let mut stuff = HandleZoneResultsStuff::default();
@@ -1013,7 +1012,7 @@ fn handle_zone<N: Network>(
             HandleZoneResults::Stuff(stuff)
         }
         // 1ab.
-        (Some((sender_zone, _sender_zone_id)), false, false) => {
+        (Some(sender_zone), false, false) => {
             dbg_data.scenario = "1ab".to_string();
 
             let mut stuff = HandleZoneResultsStuff::default();
@@ -1039,7 +1038,7 @@ fn handle_zone<N: Network>(
             HandleZoneResults::Stuff(stuff)
         }
         // 1ba.
-        (Some((sender_zone, _sender_zone_id)), true, true) => {
+        (Some(sender_zone), true, true) => {
             dbg_data.scenario = "1ba".to_string();
 
             process_zone(
@@ -1053,7 +1052,7 @@ fn handle_zone<N: Network>(
             )
         }
         // 1bb.
-        (Some((sender_zone, _sender_zone_id)), true, false) => {
+        (Some(sender_zone), true, false) => {
             dbg_data.scenario = "1bb".to_string();
 
             let mut stuff = HandleZoneResultsStuff::default();

--- a/components/butterfly/src/trace.rs
+++ b/components/butterfly/src/trace.rs
@@ -23,6 +23,7 @@ use std::fs;
 use std::io::Write;
 use std::path::PathBuf;
 
+use network::Network;
 use server::Server;
 
 #[derive(Debug, Clone, Copy)]
@@ -161,7 +162,7 @@ impl Default for Trace {
 
 impl Trace {
     /// Initialize the trace object; only happens once.
-    pub fn init(&mut self, server: &Server) {
+    pub fn init<N: Network>(&mut self, server: &Server<N>) {
         if self.file.is_none() {
             let now = time::now_utc();
             let filename = format!("{}-{}.swimtrace", server.name(), now.rfc3339());

--- a/components/butterfly/src/zone.rs
+++ b/components/butterfly/src/zone.rs
@@ -22,6 +22,7 @@ use cast;
 
 use error::{Error, Result};
 use message::BfUuid;
+use network::{Address, AddressAndPort, Network};
 use protocol::{newscast, swim as proto, FromProto};
 use rumor::{RumorKey, RumorPayload, RumorType};
 
@@ -682,3 +683,24 @@ impl ZoneList {
         }
     }
 }
+
+#[derive(Clone, Debug, PartialEq, Deserialize)]
+pub struct AdditionalAddress<A: Address> {
+    pub address: Option<A>,
+    pub swim_port: u16,
+    pub gossip_port: u16,
+}
+
+impl<A: Address> AdditionalAddress<A> {
+    pub fn new(address: Option<A>, swim_port: u16, gossip_port: u16) -> Self {
+        Self {
+            address,
+            swim_port,
+            gossip_port,
+        }
+    }
+}
+
+pub type TaggedAddressesFromAddress<A> = HashMap<String, AdditionalAddress<A>>;
+pub type TaggedAddressesFromNetwork<N> =
+    TaggedAddressesFromAddress<<<N as Network>::AddressAndPort as AddressAndPort>::Address>;

--- a/components/butterfly/src/zone.rs
+++ b/components/butterfly/src/zone.rs
@@ -29,7 +29,7 @@ use rumor::{RumorKey, RumorPayload, RumorType};
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ZoneAddress {
     pub zone_id: BfUuid,
-    pub address: Option<String>,
+    pub address: String,
     pub swim_port: u16,
     pub gossip_port: u16,
     pub tag: String,
@@ -39,7 +39,7 @@ impl From<ZoneAddress> for proto::ZoneAddress {
     fn from(value: ZoneAddress) -> Self {
         Self {
             zone_id: Some(value.zone_id.to_string()),
-            address: value.address,
+            address: Some(value.address),
             swim_port: Some(cast::i32(value.swim_port)),
             gossip_port: Some(cast::i32(value.gossip_port)),
             tag: Some(value.tag),
@@ -55,7 +55,7 @@ impl FromProto<proto::ZoneAddress> for ZoneAddress {
                 .ok_or(Error::ProtocolMismatch("zone_id"))?
                 .parse::<BfUuid>()
                 .map_err(|e| Error::InvalidField("zone_id", e.to_string()))?,
-            address: proto.address,
+            address: proto.address.ok_or(Error::ProtocolMismatch("address"))?,
             swim_port: cast::u16(proto.swim_port.ok_or(Error::ProtocolMismatch("swim_port"))?)
                 .map_err(|e| Error::InvalidField("swim_port", e.to_string()))?,
             gossip_port: cast::u16(
@@ -753,13 +753,13 @@ impl ZoneList {
 
 #[derive(Clone, Debug, PartialEq, Deserialize)]
 pub struct AdditionalAddress<A: Address> {
-    pub address: Option<A>,
+    pub address: A,
     pub swim_port: u16,
     pub gossip_port: u16,
 }
 
 impl<A: Address> AdditionalAddress<A> {
-    pub fn new(address: Option<A>, swim_port: u16, gossip_port: u16) -> Self {
+    pub fn new(address: A, swim_port: u16, gossip_port: u16) -> Self {
         Self {
             address,
             swim_port,

--- a/components/butterfly/src/zone.rs
+++ b/components/butterfly/src/zone.rs
@@ -1,0 +1,684 @@
+// Copyright (c) 2018 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Tracks zones. Contains both the `Zone` struct and the `ZoneList`.
+
+use std::cmp::Ordering;
+use std::collections::{hash_map::Entry, HashMap, HashSet, VecDeque};
+use std::mem;
+
+use cast;
+
+use error::{Error, Result};
+use message::BfUuid;
+use protocol::{newscast, swim as proto, FromProto};
+use rumor::{RumorKey, RumorPayload, RumorType};
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ZoneAddress {
+    pub zone_id: BfUuid,
+    pub address: Option<String>,
+    pub swim_port: u16,
+    pub gossip_port: u16,
+    pub tag: String,
+}
+
+impl From<ZoneAddress> for proto::ZoneAddress {
+    fn from(value: ZoneAddress) -> Self {
+        Self {
+            zone_id: Some(value.zone_id.to_string()),
+            address: value.address,
+            swim_port: Some(cast::i32(value.swim_port)),
+            gossip_port: Some(cast::i32(value.gossip_port)),
+            tag: Some(value.tag),
+        }
+    }
+}
+
+impl FromProto<proto::ZoneAddress> for ZoneAddress {
+    fn from_proto(proto: proto::ZoneAddress) -> Result<Self> {
+        Ok(Self {
+            zone_id: proto
+                .zone_id
+                .ok_or(Error::ProtocolMismatch("zone_id"))?
+                .parse::<BfUuid>()
+                .map_err(|e| Error::InvalidField("zone_id", e.to_string()))?,
+            address: proto.address,
+            swim_port: cast::u16(proto.swim_port.ok_or(Error::ProtocolMismatch("swim_port"))?)
+                .map_err(|e| Error::InvalidField("swim_port", e.to_string()))?,
+            gossip_port: cast::u16(
+                proto
+                    .gossip_port
+                    .ok_or(Error::ProtocolMismatch("gossip_port"))?,
+            ).map_err(|e| Error::InvalidField("gossip_port", e.to_string()))?,
+            tag: proto.tag.ok_or(Error::ProtocolMismatch("tag"))?,
+        })
+    }
+}
+
+/// A zone in the swim group. Passes most of its functionality along
+/// to the internal protobuf representation.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct Zone {
+    pub id: BfUuid,
+    pub incarnation: u64,
+    pub maintainer_id: String,
+    pub parent_zone_id: Option<BfUuid>,
+    pub child_zone_ids: Vec<BfUuid>,
+    pub successor: Option<BfUuid>,
+    pub predecessors: Vec<BfUuid>,
+}
+
+impl Zone {
+    pub fn new(id: BfUuid, maintainer_id: String) -> Self {
+        Self {
+            id: id,
+            incarnation: 0,
+            maintainer_id: maintainer_id,
+            parent_zone_id: None,
+            child_zone_ids: Vec::new(),
+            successor: None,
+            predecessors: Vec::new(),
+        }
+    }
+}
+
+// TODO(krnowak): The Default trait implementation of the zone is
+// rather pointless…
+impl Default for Zone {
+    fn default() -> Self {
+        Self {
+            id: BfUuid::generate(),
+            incarnation: 0,
+            maintainer_id: BfUuid::nil().to_string(),
+            parent_zone_id: None,
+            child_zone_ids: Vec::new(),
+            successor: None,
+            predecessors: Vec::new(),
+        }
+    }
+}
+
+impl From<Zone> for RumorKey {
+    fn from(zone: Zone) -> RumorKey {
+        RumorKey::new(RumorType::Zone, &zone.id, "")
+    }
+}
+
+impl<'a> From<&'a Zone> for RumorKey {
+    fn from(zone: &'a Zone) -> RumorKey {
+        RumorKey::new(RumorType::Zone, zone.id, "")
+    }
+}
+
+impl<'a> From<&'a &'a Zone> for RumorKey {
+    fn from(zone: &'a &'a Zone) -> RumorKey {
+        RumorKey::new(RumorType::Zone, zone.id, "")
+    }
+}
+
+impl From<Zone> for proto::Zone {
+    fn from(value: Zone) -> Self {
+        Self {
+            id: Some(value.id.to_string()),
+            incarnation: Some(value.incarnation),
+            maintainer_id: Some(value.maintainer_id.to_string()),
+            parent_zone_id: value.parent_zone_id.map(|uuid| uuid.to_string()),
+            child_zone_ids: value
+                .child_zone_ids
+                .iter()
+                .map(|uuid| uuid.to_string())
+                .collect(),
+            successor: value.successor.map(|uuid| uuid.to_string()),
+            predecessors: value
+                .predecessors
+                .iter()
+                .map(|uuid| uuid.to_string())
+                .collect(),
+        }
+    }
+}
+
+impl FromProto<proto::Zone> for Zone {
+    fn from_proto(proto: proto::Zone) -> Result<Self> {
+        let parent_zone_id = match proto.parent_zone_id {
+            Some(id) => Some(
+                id.parse::<BfUuid>()
+                    .map_err(|e| Error::InvalidField("parent_zone_id", e.to_string()))?,
+            ),
+            None => None,
+        };
+        let mut child_zone_ids = Vec::with_capacity(proto.child_zone_ids.len());
+        for zone_id in proto.child_zone_ids {
+            child_zone_ids.push(
+                zone_id
+                    .parse::<BfUuid>()
+                    .map_err(|e| Error::InvalidField("child_zone_ids", e.to_string()))?,
+            );
+        }
+        let successor = match proto.successor {
+            Some(id) => Some(
+                id.parse::<BfUuid>()
+                    .map_err(|e| Error::InvalidField("successor", e.to_string()))?,
+            ),
+            None => None,
+        };
+        let mut predecessors = Vec::with_capacity(proto.predecessors.len());
+        for zone_id in proto.predecessors {
+            predecessors.push(
+                zone_id
+                    .parse::<BfUuid>()
+                    .map_err(|e| Error::InvalidField("predecessors", e.to_string()))?,
+            );
+        }
+        Ok(Self {
+            id: proto
+                .id
+                .ok_or(Error::ProtocolMismatch("id"))?
+                .parse::<BfUuid>()
+                .map_err(|e| Error::InvalidField("id", e.to_string()))?,
+            incarnation: proto.incarnation.unwrap_or(0),
+            maintainer_id: proto
+                .maintainer_id
+                .ok_or(Error::ProtocolMismatch("maintainer_id"))?,
+            parent_zone_id: parent_zone_id,
+            child_zone_ids: child_zone_ids,
+            successor: successor,
+            predecessors: predecessors,
+        })
+    }
+}
+
+impl FromProto<newscast::Rumor> for Zone {
+    fn from_proto(proto: newscast::Rumor) -> Result<Self> {
+        match proto.payload.ok_or(Error::ProtocolMismatch("payload"))? {
+            RumorPayload::Zone(zone) => Zone::from_proto(zone),
+            _ => panic!("from-proto payload"),
+        }
+    }
+}
+
+struct ZoneAliasList {
+    vecs: Vec<Vec<BfUuid>>,
+    map: HashMap<BfUuid, usize>,
+}
+
+impl ZoneAliasList {
+    fn new() -> Self {
+        Self {
+            vecs: Vec::new(),
+            map: HashMap::new(),
+        }
+    }
+
+    fn ensure_id(&mut self, uuid: BfUuid) -> usize {
+        match self.map.entry(uuid) {
+            Entry::Occupied(oe) => *(oe.get()),
+            Entry::Vacant(ve) => {
+                let idx = self.vecs.len();
+
+                self.vecs.push(vec![uuid]);
+                ve.insert(idx);
+                idx
+            }
+        }
+    }
+
+    fn is_alias_of(&self, uuid1: BfUuid, uuid2: BfUuid) -> bool {
+        match (self.map.get(&uuid1), self.map.get(&uuid2)) {
+            (Some(idx1), Some(idx2)) => idx1 == idx2,
+            (_, _) => false,
+        }
+    }
+
+    fn take_aliases_from(&mut self, uuid1: BfUuid, uuid2: BfUuid) {
+        let idx1 = self.ensure_id(uuid1);
+        match self.map.entry(uuid2) {
+            Entry::Occupied(mut oe) => {
+                let idx2 = *oe.get();
+                if idx1 == idx2 {
+                    return;
+                }
+                *(oe.get_mut()) = idx1;
+                let old_ids = mem::replace(&mut self.vecs[idx2], Vec::new());
+                self.vecs[idx1].extend(old_ids);
+            }
+            Entry::Vacant(ve) => {
+                self.vecs[idx1].push(uuid2);
+                ve.insert(idx1);
+            }
+        }
+    }
+
+    fn into_max_set(self) -> HashSet<BfUuid> {
+        let mut indices = self.map.values().collect::<Vec<_>>();
+
+        indices.sort_unstable();
+        indices.dedup();
+
+        let mut set = HashSet::with_capacity(indices.len());
+
+        for idx in indices {
+            let max_uuid = self.vecs[*idx].iter().max().unwrap();
+
+            set.insert(*max_uuid);
+        }
+
+        return set;
+    }
+}
+
+pub enum Reachable {
+    Yes,
+    ThroughOtherZone(BfUuid),
+    No,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ZoneList {
+    pub zones: HashMap<BfUuid, Zone>,
+    pub maintained_zone_id: Option<BfUuid>,
+
+    update_counter: usize,
+}
+
+impl ZoneList {
+    pub fn new() -> Self {
+        Self {
+            zones: HashMap::new(),
+            maintained_zone_id: None,
+            update_counter: 0,
+        }
+    }
+
+    pub fn available_zone_ids(&self) -> Vec<BfUuid> {
+        self.zones.keys().cloned().collect()
+    }
+
+    pub fn get_update_counter(&self) -> usize {
+        self.update_counter
+    }
+
+    pub fn insert(&mut self, zone: Zone) -> Vec<RumorKey> {
+        let keys = self.insert_internal(zone);
+
+        if !keys.is_empty() {
+            self.update_counter += 1;
+        }
+
+        keys
+    }
+
+    pub fn gather_all_aliases_of(&self, id: BfUuid) -> HashSet<BfUuid> {
+        let mut aliases = HashSet::new();
+
+        aliases.insert(id);
+        if let Some(zone) = self.zones.get(&id) {
+            if let Some(zone_id) = zone.successor {
+                aliases.insert(zone_id);
+            }
+            for zone_id in zone.predecessors.iter() {
+                aliases.insert(*zone_id);
+            }
+        }
+
+        aliases
+    }
+
+    pub fn directly_reachable(
+        &self,
+        our_zone_id: BfUuid,
+        their_zone_id: BfUuid,
+        our_zone_addresses: &[ZoneAddress],
+        their_zone_addresses: &[ZoneAddress],
+    ) -> Reachable {
+        if our_zone_id == their_zone_id {
+            return Reachable::Yes;
+        }
+
+        let our_ids = self.gather_all_aliases_of(our_zone_id);
+        let their_ids = self.gather_all_aliases_of(their_zone_id);
+
+        if !our_ids.is_disjoint(&their_ids) {
+            return Reachable::Yes;
+        }
+
+        // TODO(krnowak): maybe instead of guessing which zone is
+        // parent or child, take this information from the zone itself
+        // (get_child_zone_ids(), get_parent_zone_id())
+
+        // if this server is in child zone and is a gateway, and
+        // member is in parent zone then this loop may catch that
+        for zone_address in our_zone_addresses {
+            if their_ids.contains(&zone_address.zone_id) {
+                return Reachable::Yes;
+            }
+        }
+
+        // if this server is in parent zone, and member is in child
+        // zone and is a gateway then this loop may catch that
+        for zone_address in their_zone_addresses {
+            if our_ids.contains(&zone_address.zone_id) {
+                return Reachable::ThroughOtherZone(zone_address.zone_id);
+            }
+        }
+
+        Reachable::No
+    }
+
+    fn insert_internal(&mut self, mut zone: Zone) -> Vec<RumorKey> {
+        let zone_uuid = zone.id;
+
+        if zone_uuid.is_nil() {
+            return Vec::new();
+        }
+
+        let current_zone = match self.zones.get(&zone.id).cloned() {
+            Some(cz) => cz,
+            None => {
+                let rk = RumorKey::from(&zone);
+
+                self.zones.insert(zone.id, zone);
+
+                return vec![rk];
+
+                //return self.make_zones_consistent(zone);
+            }
+        };
+
+        match current_zone.incarnation.cmp(&zone.incarnation) {
+            Ordering::Greater => Vec::new(),
+            Ordering::Less => self.make_zones_consistent(zone),
+            Ordering::Equal => {
+                let mut predecessors = HashSet::new();
+                // merge the info from current and new zone, but
+                // do not increment the incarnation…
+                match (zone.successor, current_zone.successor) {
+                    (Some(successor_uuid), Some(current_successor_uuid)) => {
+                        match successor_uuid.cmp(&current_successor_uuid) {
+                            Ordering::Greater => {
+                                predecessors.insert(current_successor_uuid);
+                            }
+                            Ordering::Equal => (),
+                            Ordering::Less => {
+                                predecessors.insert(successor_uuid);
+                                zone.successor = Some(current_successor_uuid);
+                            }
+                        }
+                    }
+                    (Some(_), None) => {}
+                    (None, Some(current_successor_uuid)) => {
+                        zone.successor = Some(current_successor_uuid);
+                    }
+                    (None, None) => {}
+                }
+
+                predecessors.extend(current_zone.predecessors.iter());
+                predecessors.extend(zone.predecessors.iter());
+                zone.predecessors = predecessors.drain().collect();
+
+                match (zone.parent_zone_id, current_zone.parent_zone_id) {
+                    (Some(parent_uuid), Some(current_parent_uuid)) => {
+                        if self.is_alias_of(parent_uuid, current_parent_uuid) {
+                            if current_parent_uuid > parent_uuid {
+                                zone.parent_zone_id = Some(current_parent_uuid);
+                            }
+                        } else {
+                            debug!(
+                                "PARENTS: looks like a new parent ({}) for zone {} is not an alias of {}",
+                                parent_uuid,
+                                zone.id,
+                                current_parent_uuid,
+                            );
+                            zone.parent_zone_id = Some(current_parent_uuid);
+                        }
+                    }
+                    (None, None) => (),
+                    (Some(_), None) => (),
+                    (None, Some(current_parent_uuid)) => {
+                        zone.parent_zone_id = Some(current_parent_uuid);
+                    }
+                }
+                self.make_zones_consistent(zone)
+            }
+        }
+    }
+
+    fn is_alias_of(&self, id1: BfUuid, id2: BfUuid) -> bool {
+        if id1 == id2 {
+            return true;
+        }
+
+        if let Some(zone) = self.zones.get(&id1) {
+            if let Some(successor_uuid) = zone.successor {
+                if successor_uuid == id2 {
+                    return true;
+                }
+            }
+            if zone.predecessors.iter().any(|id| *id == id2) {
+                return true;
+            }
+        }
+        if let Some(zone) = self.zones.get(&id2) {
+            if let Some(successor_uuid) = zone.successor {
+                if successor_uuid == id1 {
+                    return true;
+                }
+            }
+            if zone.predecessors.iter().any(|id| *id == id1) {
+                return true;
+            }
+        }
+
+        false
+    }
+
+    fn make_zones_consistent(&mut self, zone: Zone) -> Vec<RumorKey> {
+        let mut visited = HashSet::new();
+        let mut queue = VecDeque::new();
+        let mut aliases = HashSet::new();
+        let mut original_parent = None;
+        let mut parents = HashSet::new();
+        let mut children = HashSet::new();
+
+        aliases.insert(zone.id);
+        if let Some(successor_uuid) = zone.successor {
+            aliases.insert(successor_uuid);
+        }
+        aliases.extend(zone.predecessors.iter());
+
+        if let Some(parent_uuid) = zone.parent_zone_id {
+            parents.insert(parent_uuid);
+            original_parent = Some(parent_uuid);
+        }
+        children.extend(zone.child_zone_ids.iter());
+        queue.extend(aliases.iter().cloned());
+
+        visited.insert(zone.id);
+        while let Some(uuid) = queue.pop_front() {
+            if visited.contains(&uuid) {
+                continue;
+            }
+            visited.insert(uuid);
+            if let Some(other_zone) = self.zones.get(&uuid) {
+                aliases.insert(uuid);
+                if let Some(successor_uuid) = other_zone.successor {
+                    aliases.insert(successor_uuid);
+                    queue.push_back(successor_uuid);
+                }
+
+                aliases.extend(other_zone.predecessors.iter());
+                queue.extend(other_zone.predecessors.iter());
+                children.extend(other_zone.child_zone_ids.iter());
+            }
+        }
+
+        let successor = match aliases.iter().max() {
+            Some(id) => *id,
+            None => return vec![RumorKey::from(&zone)],
+        };
+        let predecessors = aliases
+            .drain()
+            .filter(|i| *i < successor)
+            .collect::<Vec<BfUuid>>();
+        let parent = {
+            let mut zone_ids = self.filter_aliases(parents);
+
+            match zone_ids.len() {
+                0 => original_parent,
+                1 => zone_ids.drain().next(),
+                _ => {
+                    debug!(
+                        "PARENTS: got some unrelated parents, {:#?}, using the original one {:#?}",
+                        zone_ids, original_parent
+                    );
+                    original_parent
+                }
+            }
+        };
+        let final_children = self.filter_aliases(children);
+        let mut rumor_keys = Vec::new();
+
+        for zone_uuid in visited.drain() {
+            let mut changed = false;
+            let mut other_zone = match self.zones.get(&zone_uuid).cloned() {
+                Some(oz) => oz,
+                None => continue,
+            };
+            let mut new_parent = None;
+
+            let new_successor = if successor != zone_uuid {
+                if let Some(other_successor_uuid) = other_zone.successor {
+                    other_successor_uuid < successor
+                } else {
+                    true
+                }
+            } else {
+                false
+            };
+            if new_successor {
+                other_zone.successor = Some(successor);
+                changed = true;
+            }
+            match (other_zone.parent_zone_id, parent) {
+                (Some(other_parent_uuid), Some(parent_uuid)) => {
+                    if other_parent_uuid < parent_uuid {
+                        new_parent = Some(parent_uuid);
+                    }
+                }
+                (Some(_), None) => {
+                    debug!(
+                        "PARENTS: we had one parent in {:#?}, now we are supposed to have none?",
+                        other_zone
+                    );
+                    // eh?
+                }
+                (None, Some(parent_uuid)) => {
+                    new_parent = Some(parent_uuid);
+                }
+                (None, None) => {}
+            }
+            if let Some(uuid) = new_parent {
+                other_zone.parent_zone_id = Some(uuid);
+                changed = true;
+            }
+
+            let mut filtered_predecessors = predecessors
+                .iter()
+                .filter(|uuid| **uuid != zone_uuid)
+                .cloned()
+                .collect::<HashSet<_>>();
+            let old_predecessors = other_zone
+                .predecessors
+                .iter()
+                .cloned()
+                .collect::<HashSet<_>>();
+
+            // filtered predecessors is either a superset of old
+            // predecessors or it's equal to it, so we can just use
+            // difference instead of symmetric difference
+            if filtered_predecessors
+                .difference(&old_predecessors)
+                .next()
+                .is_some()
+            {
+                other_zone.predecessors = filtered_predecessors.iter().cloned().collect();
+                changed = true;
+            }
+
+            let old_children = other_zone
+                .child_zone_ids
+                .iter()
+                .cloned()
+                .collect::<HashSet<_>>();
+
+            if final_children
+                .symmetric_difference(&old_children)
+                .next()
+                .is_some()
+            {
+                other_zone.child_zone_ids = final_children.iter().cloned().collect();
+                changed = true;
+            }
+
+            if changed {
+                if self.is_maintained_zone(other_zone.id) {
+                    other_zone.incarnation += 1;
+                }
+
+                rumor_keys.push(RumorKey::from(&other_zone));
+                self.zones.insert(zone_uuid, other_zone);
+            }
+        }
+
+        rumor_keys
+    }
+
+    fn filter_aliases(&self, zone_uuids: HashSet<BfUuid>) -> HashSet<BfUuid> {
+        match zone_uuids.len() {
+            0 | 1 => zone_uuids,
+            len => {
+                let ids = zone_uuids.iter().collect::<Vec<_>>();
+                let mut zone_alias_list = ZoneAliasList::new();
+
+                zone_alias_list.ensure_id(*ids[0]);
+                for first_idx in 0..(len - 1) {
+                    let id1 = *ids[first_idx];
+
+                    for second_idx in (first_idx + 1)..len {
+                        let id2 = *ids[second_idx];
+
+                        if zone_alias_list.is_alias_of(id1, id2) {
+                            continue;
+                        }
+                        if self.is_alias_of(id1, id2) {
+                            zone_alias_list.take_aliases_from(id1, id2);
+                        } else {
+                            zone_alias_list.ensure_id(id2);
+                        }
+                    }
+                }
+                zone_alias_list.into_max_set()
+            }
+        }
+    }
+
+    fn is_maintained_zone(&self, zone_id: BfUuid) -> bool {
+        if let Some(ref maintained_zone_id) = self.maintained_zone_id {
+            zone_id == *maintained_zone_id
+        } else {
+            false
+        }
+    }
+}

--- a/components/butterfly/src/zone.rs
+++ b/components/butterfly/src/zone.rs
@@ -305,10 +305,6 @@ impl ZoneList {
         }
     }
 
-    pub fn available_zone_ids(&self) -> Vec<BfUuid> {
-        self.zones.keys().cloned().collect()
-    }
-
     pub fn get_update_counter(&self) -> usize {
         self.update_counter
     }

--- a/components/butterfly/tests/integration.rs
+++ b/components/butterfly/tests/integration.rs
@@ -17,9 +17,12 @@ extern crate habitat_butterfly;
 #[macro_use]
 extern crate habitat_butterfly_test as btest;
 extern crate habitat_core;
+#[macro_use]
+extern crate log;
 extern crate time;
 
 mod encryption;
+mod nat;
 mod rumor;
 
 use habitat_butterfly::member::Health;

--- a/components/butterfly/tests/integration.rs
+++ b/components/butterfly/tests/integration.rs
@@ -107,16 +107,8 @@ fn six_members_unmeshed_partition_and_rejoin_no_persistent_peers() {
 #[test]
 fn six_members_unmeshed_partition_and_rejoin_persistent_peers() {
     let mut net = btest::SwimNet::new(6);
-    net[0]
-        .member
-        .write()
-        .expect("Member lock is poisoned")
-        .persistent = true;
-    net[4]
-        .member
-        .write()
-        .expect("Member lock is poisoned")
-        .persistent = true;
+    net[0].write_member().persistent = true;
+    net[4].write_member().persistent = true;
     net.connect(0, 1);
     net.connect(1, 2);
     net.connect(2, 3);

--- a/components/butterfly/tests/nat/mod.rs
+++ b/components/butterfly/tests/nat/mod.rs
@@ -1,0 +1,2360 @@
+use std::cmp::Ordering;
+use std::collections::hash_map::Entry;
+use std::collections::{BinaryHeap, HashMap, HashSet, VecDeque};
+use std::error::Error as StdError;
+use std::fmt::{Debug, Display, Formatter, Result as FmtResult};
+use std::iter;
+use std::path::PathBuf;
+use std::result::Result as StdResult;
+use std::str::FromStr;
+use std::sync::mpsc::{self, Receiver, SendError, Sender};
+use std::sync::{Arc, Mutex, MutexGuard, RwLock, RwLockReadGuard, RwLockWriteGuard};
+use std::thread;
+use std::time::Duration;
+use std::u8;
+
+use habitat_butterfly::error::{Error, Result};
+use habitat_butterfly::member::{Health, Member};
+use habitat_butterfly::message::{self, BfUuid};
+use habitat_butterfly::network::{
+    Address, AddressAndPort, GossipReceiver, GossipSender, MyFromStr, Network, SwimReceiver,
+    SwimSender,
+};
+use habitat_butterfly::rumor::RumorEnvelope;
+use habitat_butterfly::server::timing::Timing;
+use habitat_butterfly::server::{Server, Suitability};
+use habitat_butterfly::swim::Swim;
+use habitat_butterfly::trace::Trace;
+use habitat_butterfly::zone::{AdditionalAddress, TaggedAddressesFromAddress};
+use habitat_core::crypto::SymKey;
+use habitat_core::service::ServiceGroup;
+
+struct DbgVec {
+    v: Vec<String>,
+}
+
+impl DbgVec {
+    fn new(header: String) -> Self {
+        Self {
+            v: vec![
+                "==============================".to_string(),
+                header,
+                "==============================".to_string(),
+            ],
+        }
+    }
+
+    fn push<S: AsRef<str>>(&mut self, s: S) {
+        for line in s.as_ref().split('\n') {
+            self.v.push(line.to_string())
+        }
+    }
+}
+
+impl Drop for DbgVec {
+    fn drop(&mut self) {
+        self.push("==============================".to_string());
+        debug!("{:#?}", self.v);
+    }
+}
+
+// ZoneID is a number that identifies a zone. Within a zone all the
+// supervisors can talk to each other. For the interzone
+// communication, a parent-child relationship needs to be established
+// first, then supervisors in the child zone can talk to supervisors
+// in the parent zone, but not the other way around.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+struct ZoneID(u8);
+
+impl ZoneID {
+    pub fn new(raw_id: u8) -> Self {
+        assert!(
+            Self::is_raw_valid(raw_id),
+            "zone IDs must be greater than zero"
+        );
+        ZoneID(raw_id)
+    }
+
+    pub fn raw(&self) -> u8 {
+        self.0
+    }
+
+    pub fn is_raw_valid(raw: u8) -> bool {
+        raw > 0
+    }
+}
+
+impl Display for ZoneID {
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        write!(f, "{}", self.raw())
+    }
+}
+
+impl FromStr for ZoneID {
+    type Err = String;
+
+    fn from_str(s: &str) -> StdResult<Self, Self::Err> {
+        let raw_self = s
+            .parse()
+            .map_err(|e| format!("'{}' is not a u8: {}", s, e))?;
+        if !Self::is_raw_valid(raw_self) {
+            return Err(format!("{} is not a valid ZoneID", raw_self));
+        }
+
+        Ok(Self::new(raw_self))
+    }
+}
+
+// ZoneInfo stores the relationship information of a zone.
+#[derive(Debug, Default, Clone)]
+struct ZoneInfo {
+    parent: Option<ZoneID>,
+    children: HashSet<ZoneID>,
+}
+
+struct ZoneMap(HashMap<ZoneID, Mutex<ZoneInfo>>);
+
+#[derive(Copy, Clone, Eq, PartialEq)]
+enum Direction {
+    ParentToChild,
+    ChildToParent,
+}
+
+struct DijkstraData {
+    info: ZoneInfo,
+    distance: usize,
+}
+
+impl DijkstraData {
+    pub fn new_with_max_distance(info: &ZoneInfo) -> Self {
+        Self::new(info, usize::max_value())
+    }
+
+    pub fn new_with_zero_distance(info: &ZoneInfo) -> Self {
+        Self::new(info, 0)
+    }
+
+    fn new(info: &ZoneInfo, distance: usize) -> Self {
+        let info = info.clone();
+        Self { info, distance }
+    }
+}
+
+#[derive(Clone, Eq, PartialEq)]
+struct TraversalInfo {
+    direction: Direction,
+    from: ZoneID,
+    to: ZoneID,
+}
+
+impl TraversalInfo {
+    pub fn new(direction: Direction, from: ZoneID, to: ZoneID) -> Self {
+        Self {
+            direction,
+            from,
+            to,
+        }
+    }
+}
+
+#[derive(Eq, PartialEq)]
+struct DijkstraState {
+    cost: usize,
+    id: ZoneID,
+    route: Vec<TraversalInfo>,
+}
+
+impl DijkstraState {
+    pub fn new_start(start_id: ZoneID) -> Self {
+        Self::new(0, start_id, Vec::new())
+    }
+
+    pub fn new_incremental(old: &Self, new_id: ZoneID, direction: Direction) -> Self {
+        let mut new_route = old.route.clone();
+
+        new_route.push(TraversalInfo::new(direction, old.id, new_id));
+        Self::new(old.cost + 1, new_id, new_route)
+    }
+
+    pub fn steal_route(self) -> Vec<TraversalInfo> {
+        self.route
+    }
+
+    fn new(cost: usize, id: ZoneID, route: Vec<TraversalInfo>) -> Self {
+        Self { cost, id, route }
+    }
+}
+
+// This is to make BinaryHeap a min-heap instead of max-heap.
+impl Ord for DijkstraState {
+    fn cmp(&self, other: &DijkstraState) -> Ordering {
+        other.cost.cmp(&self.cost)
+    }
+}
+
+impl PartialOrd for DijkstraState {
+    fn partial_cmp(&self, other: &DijkstraState) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl ZoneMap {
+    pub fn setup_zone_relationship(&mut self, parent_id: ZoneID, child_id: ZoneID) {
+        assert_ne!(parent_id, child_id);
+        self.ensure_zone(parent_id);
+        self.ensure_zone(child_id);
+        assert!(!self.is_zone_descendant_of_mut(parent_id, child_id));
+        {
+            let parent_zone = self.get_zone_mut(parent_id);
+            parent_zone.children.insert(child_id);
+        }
+        {
+            let child_zone = self.get_zone_mut(child_id);
+            assert!(child_zone.parent.is_none());
+            child_zone.parent = Some(parent_id);
+        }
+    }
+
+    pub fn is_zone_child_of(&self, child_id: ZoneID, parent_id: ZoneID) -> bool {
+        self.get_zone_guard(parent_id).children.contains(&child_id)
+    }
+
+    pub fn is_zone_descendant_of_mut(
+        &mut self,
+        descendant_id: ZoneID,
+        ancestor_id: ZoneID,
+    ) -> bool {
+        let mut queue = VecDeque::new();
+        queue.push_back(ancestor_id);
+        while let Some(id) = queue.pop_front() {
+            let zone = self.get_zone_mut(id);
+            if zone.children.contains(&descendant_id) {
+                return true;
+            }
+            queue.extend(&zone.children);
+        }
+        false
+    }
+
+    // Dijkstra, basically.
+    pub fn get_route(&self, source_id: ZoneID, target_id: ZoneID) -> Option<Vec<TraversalInfo>> {
+        if source_id == target_id {
+            return Some(Vec::new());
+        }
+
+        let mut dd_map = HashMap::with_capacity(self.0.len());
+        let mut heap = BinaryHeap::new();
+
+        for (zone_id, info_lock) in &self.0 {
+            let info = info_lock
+                .lock()
+                .expect(&format!("Zone {} lock is poisoned", zone_id));
+            let dd = if *zone_id == source_id {
+                DijkstraData::new_with_zero_distance(&info)
+            } else {
+                DijkstraData::new_with_max_distance(&info)
+            };
+            dd_map.insert(*zone_id, dd);
+        }
+        heap.push(DijkstraState::new_start(source_id));
+
+        while let Some(ds) = heap.pop() {
+            if ds.id == target_id {
+                return Some(ds.steal_route());
+            }
+
+            let (parent, children) = {
+                let dd = Self::get_dijkstra_data(&dd_map, ds.id);
+                if ds.cost > dd.distance {
+                    continue;
+                }
+
+                (dd.info.parent.clone(), dd.info.children.clone())
+            };
+
+            if let Some(parent_id) = parent {
+                Self::dijkstra_step(
+                    &mut dd_map,
+                    parent_id,
+                    &mut heap,
+                    &ds,
+                    Direction::ChildToParent,
+                );
+            }
+
+            for child_id in children {
+                Self::dijkstra_step(
+                    &mut dd_map,
+                    child_id,
+                    &mut heap,
+                    &ds,
+                    Direction::ParentToChild,
+                );
+            }
+        }
+
+        None
+    }
+
+    fn dijkstra_step(
+        dd_map: &mut HashMap<ZoneID, DijkstraData>,
+        id: ZoneID,
+        heap: &mut BinaryHeap<DijkstraState>,
+        old_ds: &DijkstraState,
+        direction: Direction,
+    ) {
+        let dd = Self::get_dijkstra_data_mut(dd_map, id);
+        if old_ds.cost + 1 < dd.distance {
+            let new_ds = DijkstraState::new_incremental(&old_ds, id, direction);
+
+            dd.distance = new_ds.cost;
+            heap.push(new_ds);
+        }
+    }
+
+    fn get_dijkstra_data<'a>(
+        map: &'a HashMap<ZoneID, DijkstraData>,
+        id: ZoneID,
+    ) -> &'a DijkstraData {
+        map.get(&id)
+            .expect(&format!("zone {} exists in dijkstra data map", id))
+    }
+
+    fn get_dijkstra_data_mut<'a>(
+        map: &'a mut HashMap<ZoneID, DijkstraData>,
+        id: ZoneID,
+    ) -> &'a mut DijkstraData {
+        map.get_mut(&id)
+            .expect(&format!("zone {} exists in dijkstra data map", id))
+    }
+
+    fn ensure_zone(&mut self, zone_id: ZoneID) {
+        if let Entry::Vacant(v) = self.0.entry(zone_id) {
+            v.insert(Mutex::new(ZoneInfo::default()));
+        }
+    }
+
+    fn get_zone_guard(&self, zone_id: ZoneID) -> MutexGuard<ZoneInfo> {
+        self.0
+            .get(&zone_id)
+            .expect(&format!("Zone {} not in zone map", zone_id))
+            .lock()
+            .expect(&format!("Zone {} lock is poisoned", zone_id))
+    }
+
+    fn get_zone_mut(&mut self, zone_id: ZoneID) -> &mut ZoneInfo {
+        self.0
+            .get_mut(&zone_id)
+            .expect(&format!("Zone {} not in zone map", zone_id))
+            .get_mut()
+            .expect(&format!("Zone {} lock is poisoned", zone_id))
+    }
+}
+
+#[derive(Debug)]
+struct TestAddrParseError {
+    failed_string: String,
+    reason: String,
+    idx: usize,
+}
+
+impl TestAddrParseError {
+    fn new<T1, T2>(failed_string: T1, reason: T2, idx: usize) -> Self
+    where
+        T1: Into<String>,
+        T2: Into<String>,
+    {
+        Self {
+            failed_string: failed_string.into(),
+            reason: reason.into(),
+            idx: idx,
+        }
+    }
+}
+
+impl Display for TestAddrParseError {
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        let spaces = iter::repeat(' ').take(self.idx).collect::<String>();
+        write!(
+            f,
+            "failed to parse TestAddr at idx {}: {}\n\
+             {}\n\
+             {}^",
+            self.idx, self.reason, self.failed_string, spaces,
+        )
+    }
+}
+
+impl StdError for TestAddrParseError {
+    fn description(&self) -> &str {
+        "failed to parse TestAddr from some string at some index for some reason"
+    }
+}
+
+#[derive(Debug)]
+struct TestAddrParts {
+    address_type: String,
+    fields: Vec<(String, String)>,
+    port: Option<u16>,
+}
+
+impl FromStr for TestAddrParts {
+    type Err = TestAddrParseError;
+
+    fn from_str(s: &str) -> StdResult<Self, Self::Err> {
+        #[derive(PartialEq)]
+        enum State {
+            Start,
+            OpenBracket,
+            AddressType,
+            CloseBracket,
+            OpenBrace,
+            FieldName,
+            FieldSeparator,
+            FieldValue,
+            CloseBrace,
+            Colon,
+            Port,
+        };
+        let mut state = State::Start;
+        let final_states = vec![State::CloseBrace, State::Port];
+        let mut address_type = String::new();
+        let mut fields = Vec::new();
+        let mut field_name = String::new();
+        let mut field_value = String::new();
+        let mut maybe_port = None;
+
+        for (idx, c) in s.chars().enumerate() {
+            match state {
+                State::Start => match c {
+                    '[' => state = State::OpenBracket,
+                    _ => return Err(Self::Err::new(s, "expected an opening bracket", idx)),
+                },
+                State::OpenBracket => match c {
+                    'a' ... 'z' | '-' => {
+                        address_type.push(c);
+                        state = State::AddressType;
+                    }
+                    _ => return Err(Self::Err::new(s, "expected an alphabetic ASCII char or a dash for the address type", idx)),
+                }
+                State::AddressType => match c {
+                    'a' ... 'z' | '-' => {
+                        address_type.push(c);
+                    }
+                    ']' => state = State::CloseBracket,
+                    _ => return Err(Self::Err::new(s, "expected an alphabetic ASCII char or a dash for the address type, or a closing bracket", idx)),
+                }
+                State::CloseBracket => match c {
+                    '{' => state = State::OpenBrace,
+                    _ => return Err(Self::Err::new(s, "expected an opening brace for address contents", idx)),
+                }
+                State::OpenBrace => match c {
+                    'a' ... 'z' | '0' ... '9' | '-' | '_' => {
+                        field_name.push(c);
+                        state = State::FieldName;
+                    }
+                    '}' => state = State::CloseBrace,
+                    _ => return Err(Self::Err::new(s, "expected either a closing brace or ASCII alphanumeric char for a field", idx))
+                }
+                State::FieldName => match c {
+                    'a' ... 'z' | '0' ... '9' | '-' | '_' => field_name.push(c),
+                    ':' => state = State::FieldSeparator,
+                    _ => return Err(Self::Err::new(s, "expected field name or a colon", idx)),
+                }
+                State::FieldSeparator => match c {
+                    'a' ... 'z' | '0' ... '9' => {
+                        field_value.push(c);
+                        state = State::FieldValue;
+                    }
+                    '}' => {
+                        fields.push((field_name, field_value));
+                        field_name = String::new();
+                        field_value = String::new();
+                        state = State::CloseBrace;
+                    }
+                    _ => return Err(Self::Err::new(s, "expected field name or closing brace", idx)),
+                }
+                State::FieldValue => match c {
+                    'a' ... 'z' | '0' ... '9' => field_value.push(c),
+                    ',' => {
+                        fields.push((field_name, field_value));
+                        field_name = String::new();
+                        field_value = String::new();
+                        state = State::FieldName;
+                    }
+                    '}' => {
+                        fields.push((field_name, field_value));
+                        field_name = String::new();
+                        field_value = String::new();
+                        state = State::CloseBrace;
+                    }
+                    _ => return Err(Self::Err::new(s, "expected field value, field separator (,) or closing brace", idx)),
+                }
+                State::CloseBrace => match c {
+                    ':' => state = State::Colon,
+                    _ => return Err(Self::Err::new(s, "expected a colon after the closing brace", idx)),
+                }
+                State::Colon => match c {
+                    '0' ... '9' => {
+                        let mut port_str = String::new();
+
+                        port_str.push(c);
+                        maybe_port = Some(port_str);
+                        state = State::Port;
+                    }
+                    _ => return Err(Self::Err::new(s, "expected a number after the colon", idx)),
+                }
+                State::Port => match c {
+                    '0' ... '9' => maybe_port.as_mut().unwrap().push(c),
+                    _ => return Err(Self::Err::new(s, "expected a number for a port", idx))
+                }
+            }
+        }
+
+        if !final_states.contains(&state) {
+            let mut len = s.len();
+
+            if len > 0 {
+                len -= 1;
+            }
+            return Err(Self::Err::new(s, "premature end of address string", len));
+        }
+
+        let port = match maybe_port {
+            Some(port_str) => {
+                let parsed_port = match port_str.parse::<u16>() {
+                    Ok(port) => Ok(port),
+                    Err(e) => {
+                        let mut len = s.len();
+
+                        if len > 0 {
+                            len -= 1;
+                        }
+                        Err(Self::Err::new(
+                            s,
+                            format!("still failed to parse port into a u16 number: {}", e),
+                            len,
+                        ))
+                    }
+                }?;
+                Some(parsed_port)
+            }
+            None => None,
+        };
+
+        Ok(Self {
+            address_type,
+            fields,
+            port,
+        })
+    }
+}
+
+fn field_name_check(actual: &str, expected: &str, idx: &str) -> StdResult<(), String> {
+    if actual != expected {
+        Err(format!(
+            "expected {} field to be '{}', got {}",
+            idx, expected, actual
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+struct TestPublicAddr {
+    zone_id: ZoneID,
+    idx: u8,
+}
+
+impl TestPublicAddr {
+    fn new(zone_id: ZoneID, idx: u8) -> Self {
+        Self { zone_id, idx }
+    }
+
+    fn from_parts(parts: TestAddrParts) -> StdResult<Self, String> {
+        if parts.address_type != "public" {
+            return Err(format!(
+                "expected 'public' address type, got '{}'",
+                parts.address_type
+            ));
+        }
+        if let Some(port) = parts.port {
+            return Err(format!("expected no port information, got '{}'", port));
+        }
+
+        if parts.fields.len() != 2 {
+            return Err(format!(
+                "expected exactly 2 fields, got {}",
+                parts.fields.len()
+            ));
+        }
+
+        field_name_check(&parts.fields[0].0, "zone-id", "first")?;
+        let zone_id = parts.fields[0]
+            .1
+            .parse()
+            .map_err(|e| format!("failed to get zone ID from first field: {}", e))?;
+        field_name_check(&parts.fields[1].0, "idx", "second")?;
+        let idx = parts.fields[1]
+            .1
+            .parse()
+            .map_err(|e| format!("failed to get index from second field: {}", e))?;
+
+        Ok(Self::new(zone_id, idx))
+    }
+
+    fn get_zone_id(&self) -> ZoneID {
+        self.zone_id
+    }
+
+    fn get_valid_port() -> u16 {
+        42
+    }
+
+    fn validate_port(port: u16) -> StdResult<u16, String> {
+        let valid_port = Self::get_valid_port();
+        if port == valid_port {
+            Ok(valid_port)
+        } else {
+            Err(format!(
+                "expected port for public address to be '{}', got '{}'",
+                valid_port, port
+            ))
+        }
+    }
+}
+
+impl Display for TestPublicAddr {
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        write!(f, "[public]{{zone-id:{},idx:{}}}", self.zone_id, self.idx)
+    }
+}
+
+impl FromStr for TestPublicAddr {
+    type Err = TestAddrParseError;
+
+    fn from_str(s: &str) -> StdResult<Self, Self::Err> {
+        let parts = s.parse::<TestAddrParts>()?;
+
+        Self::from_parts(parts)
+            .map_err(|e| Self::Err::new(s, format!("badly formed public address: {}", e), 0))
+    }
+}
+
+impl MyFromStr for TestPublicAddr {
+    type MyErr = <Self as FromStr>::Err;
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+struct TestLocalAddr {
+    zone_id: ZoneID,
+    idx: u8,
+}
+
+impl TestLocalAddr {
+    fn new(zone_id: ZoneID, idx: u8) -> Self {
+        Self { zone_id, idx }
+    }
+
+    fn from_parts(parts: TestAddrParts) -> StdResult<Self, String> {
+        if parts.address_type != "local" {
+            return Err(format!(
+                "expected 'local' address type, got '{}'",
+                parts.address_type
+            ));
+        }
+        if let Some(port) = parts.port {
+            return Err(format!("expected no port information, got '{}'", port));
+        }
+
+        if parts.fields.len() != 2 {
+            return Err(format!(
+                "expected exactly 2 fields, got {}",
+                parts.fields.len()
+            ));
+        }
+
+        field_name_check(&parts.fields[0].0, "zone-id", "first")?;
+        let zone_id = parts.fields[0]
+            .1
+            .parse()
+            .map_err(|e| format!("failed to get zone ID from first field: {}", e))?;
+        field_name_check(&parts.fields[1].0, "idx", "second")?;
+        let idx = parts.fields[1]
+            .1
+            .parse()
+            .map_err(|e| format!("failed to get index from second field: {}", e))?;
+
+        Ok(Self::new(zone_id, idx))
+    }
+
+    fn get_zone_id(&self) -> ZoneID {
+        self.zone_id
+    }
+
+    fn get_valid_port() -> u16 {
+        85
+    }
+
+    fn validate_port(port: u16) -> StdResult<u16, String> {
+        let valid_port = Self::get_valid_port();
+        if port == valid_port {
+            Ok(valid_port)
+        } else {
+            Err(format!(
+                "expected port for local address to be '{}', got '{}'",
+                valid_port, port
+            ))
+        }
+    }
+}
+
+impl Display for TestLocalAddr {
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        write!(f, "[local]{{zone-id:{},idx:{}}}", self.zone_id, self.idx)
+    }
+}
+
+impl FromStr for TestLocalAddr {
+    type Err = TestAddrParseError;
+
+    fn from_str(s: &str) -> StdResult<Self, Self::Err> {
+        let parts = s.parse::<TestAddrParts>()?;
+
+        Self::from_parts(parts)
+            .map_err(|e| Self::Err::new(s, format!("badly formed local address: {}", e), 0))
+    }
+}
+
+impl MyFromStr for TestLocalAddr {
+    type MyErr = <Self as FromStr>::Err;
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+struct TestPersistentMappingAddr {
+    parent_zone_id: ZoneID,
+    child_zone_id: ZoneID,
+}
+
+impl TestPersistentMappingAddr {
+    fn new(parent_zone_id: ZoneID, child_zone_id: ZoneID) -> Self {
+        Self {
+            parent_zone_id,
+            child_zone_id,
+        }
+    }
+
+    fn from_parts(parts: TestAddrParts) -> StdResult<Self, String> {
+        if parts.address_type != "perm-map" {
+            return Err(format!(
+                "expected 'perm-map' address type, got '{}'",
+                parts.address_type
+            ));
+        }
+        if let Some(port) = parts.port {
+            return Err(format!("expected no port information, got '{}'", port));
+        }
+
+        if parts.fields.len() != 2 {
+            return Err(format!(
+                "expected exactly 2 fields, got {}",
+                parts.fields.len()
+            ));
+        }
+
+        field_name_check(&parts.fields[0].0, "parent-zone-id", "first")?;
+        let parent_zone_id = parts.fields[0]
+            .1
+            .parse()
+            .map_err(|e| format!("failed to get parent zone ID from first field: {}", e))?;
+        field_name_check(&parts.fields[1].0, "child-zone-id", "second")?;
+        let child_zone_id = parts.fields[1]
+            .1
+            .parse()
+            .map_err(|e| format!("failed to get child zone ID from second field: {}", e))?;
+
+        Ok(Self::new(parent_zone_id, child_zone_id))
+    }
+
+    fn get_parent_zone_id(&self) -> ZoneID {
+        self.parent_zone_id
+    }
+
+    fn get_child_zone_id(&self) -> ZoneID {
+        self.child_zone_id
+    }
+
+    fn validate_port(port: u16) -> StdResult<u16, String> {
+        if port <= u8::MAX.into() {
+            Ok(port)
+        } else {
+            Err(format!("expected port to fit u8, got {}", port))
+        }
+    }
+}
+
+impl Display for TestPersistentMappingAddr {
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        write!(
+            f,
+            "[perm-map]{{parent-zone-id:{},child-zone-id:{}}}",
+            self.parent_zone_id, self.child_zone_id
+        )
+    }
+}
+
+impl FromStr for TestPersistentMappingAddr {
+    type Err = TestAddrParseError;
+
+    fn from_str(s: &str) -> StdResult<Self, Self::Err> {
+        let parts = s.parse::<TestAddrParts>()?;
+
+        Self::from_parts(parts).map_err(|e| {
+            Self::Err::new(
+                s,
+                format!("badly formed persistent mapping address: {}", e),
+                0,
+            )
+        })
+    }
+}
+
+impl MyFromStr for TestPersistentMappingAddr {
+    type MyErr = <Self as FromStr>::Err;
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+struct TestTemporaryMappingAddr {
+    parent_zone_id: ZoneID,
+    parent_server_idx: u8,
+    child_zone_id: ZoneID,
+    child_server_idx: u8,
+    random_value: u16,
+}
+
+impl TestTemporaryMappingAddr {
+    fn new(
+        parent_zone_id: ZoneID,
+        parent_server_idx: u8,
+        child_zone_id: ZoneID,
+        child_server_idx: u8,
+        random_value: u16,
+    ) -> Self {
+        Self {
+            parent_zone_id,
+            parent_server_idx,
+            child_zone_id,
+            child_server_idx,
+            random_value,
+        }
+    }
+
+    fn from_parts(parts: TestAddrParts) -> StdResult<Self, String> {
+        if parts.address_type != "temp-map" {
+            return Err(format!(
+                "expected 'temp-map' address type, got '{}'",
+                parts.address_type
+            ));
+        }
+        if let Some(port) = parts.port {
+            return Err(format!("expected no port information, got '{}'", port));
+        }
+
+        if parts.fields.len() != 5 {
+            return Err(format!(
+                "expected exactly 5 fields, got {}",
+                parts.fields.len()
+            ));
+        }
+
+        field_name_check(&parts.fields[0].0, "parent-zone-id", "first")?;
+        let parent_zone_id = parts.fields[0]
+            .1
+            .parse()
+            .map_err(|e| format!("failed to get parent zone ID from first field: {}", e))?;
+        field_name_check(&parts.fields[1].0, "parent-server-idx", "second")?;
+        let parent_server_idx = parts.fields[1]
+            .1
+            .parse()
+            .map_err(|e| format!("failed to get parent server index from second field: {}", e))?;
+        field_name_check(&parts.fields[2].0, "child-zone-id", "third")?;
+        let child_zone_id = parts.fields[2]
+            .1
+            .parse()
+            .map_err(|e| format!("failed to get child zone ID from third field: {}", e))?;
+        field_name_check(&parts.fields[3].0, "child-server-idx", "fourth")?;
+        let child_server_idx = parts.fields[3]
+            .1
+            .parse()
+            .map_err(|e| format!("failed to get child server index from fourth field: {}", e))?;
+        field_name_check(&parts.fields[4].0, "random-value", "fifth")?;
+        let random_value = parts.fields[4]
+            .1
+            .parse()
+            .map_err(|e| format!("failed to get random u16 value from fifth field: {}", e))?;
+
+        Ok(Self::new(
+            parent_zone_id,
+            parent_server_idx,
+            child_zone_id,
+            child_server_idx,
+            random_value,
+        ))
+    }
+
+    fn get_parent_zone_id(&self) -> ZoneID {
+        self.parent_zone_id
+    }
+
+    fn validate_port(port: u16) -> StdResult<u16, String> {
+        Ok(port)
+    }
+}
+
+impl Display for TestTemporaryMappingAddr {
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        write!(
+            f,
+            "[temp-map]{{parent-zone-id:{},parent-server-idx:{},child-zone-id:{},child-server-idx:{},random-value:{}}}",
+            self.parent_zone_id,
+            self.parent_server_idx,
+            self.child_zone_id,
+            self.child_server_idx,
+            self.random_value
+        )
+    }
+}
+
+impl FromStr for TestTemporaryMappingAddr {
+    type Err = TestAddrParseError;
+
+    fn from_str(s: &str) -> StdResult<Self, Self::Err> {
+        let parts = s.parse::<TestAddrParts>()?;
+
+        Self::from_parts(parts).map_err(|e| {
+            Self::Err::new(
+                s,
+                format!("badly formed temporary mapping address: {}", e),
+                0,
+            )
+        })
+    }
+}
+
+impl MyFromStr for TestTemporaryMappingAddr {
+    type MyErr = <Self as FromStr>::Err;
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+enum TestAddr {
+    Public(TestPublicAddr),
+    Local(TestLocalAddr),
+    PersistentMapping(TestPersistentMappingAddr),
+    TemporaryMapping(TestTemporaryMappingAddr),
+}
+
+impl TestAddr {
+    fn from_parts(parts: TestAddrParts) -> StdResult<Self, String> {
+        match parts.address_type.as_str() {
+            "public" => TestPublicAddr::from_parts(parts).map(|a| TestAddr::Public(a)),
+            "local" => TestLocalAddr::from_parts(parts).map(|a| TestAddr::Local(a)),
+            "perm-map" => {
+                TestPersistentMappingAddr::from_parts(parts).map(|a| TestAddr::PersistentMapping(a))
+            }
+            "temp-map" => {
+                TestTemporaryMappingAddr::from_parts(parts).map(|a| TestAddr::TemporaryMapping(a))
+            }
+            _ => Err(format!("unknown address type '{}'", parts.address_type)),
+        }
+    }
+
+    fn get_zone_id(&self) -> ZoneID {
+        match self {
+            &TestAddr::Public(ref pip) => pip.get_zone_id(),
+            &TestAddr::Local(ref lip) => lip.get_zone_id(),
+            &TestAddr::PersistentMapping(ref pmip) => pmip.get_parent_zone_id(),
+            &TestAddr::TemporaryMapping(ref tmip) => tmip.get_parent_zone_id(),
+        }
+    }
+
+    fn validate_port(&self, port: u16) -> StdResult<u16, String> {
+        match self {
+            TestAddr::Public(_) => TestPublicAddr::validate_port(port),
+            TestAddr::Local(_) => TestLocalAddr::validate_port(port),
+            TestAddr::PersistentMapping(_) => TestPersistentMappingAddr::validate_port(port),
+            TestAddr::TemporaryMapping(_) => TestTemporaryMappingAddr::validate_port(port),
+        }
+    }
+}
+
+impl Display for TestAddr {
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        let disp: &Display = match self {
+            TestAddr::Public(ref addr) => addr,
+            TestAddr::Local(ref addr) => addr,
+            TestAddr::PersistentMapping(ref addr) => addr,
+            TestAddr::TemporaryMapping(ref addr) => addr,
+        };
+
+        disp.fmt(f)
+    }
+}
+
+impl FromStr for TestAddr {
+    type Err = TestAddrParseError;
+
+    fn from_str(s: &str) -> StdResult<Self, Self::Err> {
+        let parts = s.parse::<TestAddrParts>()?;
+        let address_type = parts.address_type.clone();
+
+        Ok(Self::from_parts(parts).map_err(|e| {
+            Self::Err::new(
+                s,
+                format!("badly formed address of type '{}': {}", address_type, e),
+                0,
+            )
+        })?)
+    }
+}
+
+impl MyFromStr for TestAddr {
+    type MyErr = <Self as FromStr>::Err;
+}
+
+impl Address for TestAddr {}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+struct TestAddrAndPort {
+    addr: TestAddr,
+    port: u16,
+}
+
+impl TestAddrAndPort {
+    fn new(addr: TestAddr, port: u16) -> Self {
+        assert!(addr.validate_port(port).is_ok());
+
+        Self { addr, port }
+    }
+
+    pub fn get_zone_id(&self) -> ZoneID {
+        self.addr.get_zone_id()
+    }
+
+    fn from_parts(mut parts: TestAddrParts) -> StdResult<Self, String> {
+        let maybe_port = parts.port.take();
+        let addr = TestAddr::from_parts(parts)?;
+        let port = match maybe_port {
+            Some(port) => addr.validate_port(port),
+            None => Err(format!("missing port information")),
+        }?;
+
+        Ok(Self { addr, port })
+    }
+}
+
+impl Display for TestAddrAndPort {
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        write!(f, "{}:{}", self.addr, self.port)
+    }
+}
+
+impl FromStr for TestAddrAndPort {
+    type Err = TestAddrParseError;
+
+    fn from_str(s: &str) -> StdResult<Self, Self::Err> {
+        let parts = s.parse::<TestAddrParts>()?;
+        let address_type = parts.address_type.clone();
+
+        Ok(Self::from_parts(parts).map_err(|e| {
+            Self::Err::new(
+                s,
+                format!(
+                    "badly formed address and port of type '{}': {}",
+                    address_type, e
+                ),
+                0,
+            )
+        })?)
+    }
+}
+
+impl MyFromStr for TestAddrAndPort {
+    type MyErr = <Self as FromStr>::Err;
+}
+
+impl AddressAndPort for TestAddrAndPort {
+    type Address = TestAddr;
+
+    fn new_from_address_and_port(addr: TestAddr, port: u16) -> Self {
+        Self { addr, port }
+    }
+
+    fn get_address(&self) -> TestAddr {
+        self.addr
+    }
+
+    fn get_port(&self) -> u16 {
+        self.port
+    }
+}
+
+fn create_member_from_addr(addr: TestAddrAndPort) -> Member {
+    let mut member = Member::default();
+    let port = addr.get_port();
+    member.address = format!("{}", addr.get_address());
+    member.swim_port = port;
+    member.gossip_port = port;
+    member
+}
+
+// TalkTarget is a trait used for types that can be talked to. It is
+// basically about establishing a ring with SWIM messages.
+trait TalkTarget {
+    fn create_member_info(&self) -> Member;
+}
+
+// TestServer is a (thin) wrapper around the butterfly server.
+#[derive(Clone)]
+struct TestServer {
+    butterfly: Server<TestNetwork>,
+    addr: TestAddrAndPort,
+    idx: usize,
+    zone_id: ZoneID,
+}
+
+impl TestServer {
+    pub fn talk_to(&self, talk_targets: &[&TalkTarget]) {
+        let members = talk_targets
+            .iter()
+            .map(|tt| tt.create_member_info())
+            .collect();
+
+        self.butterfly.member_list.set_initial_members(members);
+    }
+}
+
+impl TalkTarget for TestServer {
+    fn create_member_info(&self) -> Member {
+        let addr = self.butterfly.read_network().get_swim_addr();
+        create_member_from_addr(addr)
+    }
+}
+
+type ZoneToCountMap = HashMap<ZoneID, u8>;
+
+struct Addresses {
+    server_map: ZoneToCountMap,
+    mapping_map: ZoneToCountMap,
+}
+
+impl Addresses {
+    pub fn new() -> Self {
+        Self {
+            server_map: HashMap::new(),
+            mapping_map: HashMap::new(),
+        }
+    }
+
+    pub fn generate_public_address_for_server(&mut self, zone_id: ZoneID) -> TestAddrAndPort {
+        let idx = self.get_server_idx(zone_id);
+        let addr = TestAddr::Public(TestPublicAddr::new(zone_id, idx));
+
+        TestAddrAndPort::new(addr, TestPublicAddr::get_valid_port())
+    }
+
+    pub fn generate_address_for_server(&mut self, zone_id: ZoneID) -> TestAddrAndPort {
+        let idx = self.get_server_idx(zone_id);
+        let addr = TestAddr::Local(TestLocalAddr::new(zone_id, idx));
+
+        TestAddrAndPort::new(addr, TestLocalAddr::get_valid_port())
+    }
+
+    pub fn generate_persistent_mapping_address(
+        &mut self,
+        parent_zone_id: ZoneID,
+        child_zone_id: ZoneID,
+    ) -> TestAddrAndPort {
+        let idx = self.get_mapping_idx(parent_zone_id);
+        let addr = TestAddr::PersistentMapping(TestPersistentMappingAddr::new(
+            parent_zone_id,
+            child_zone_id,
+        ));
+
+        TestAddrAndPort::new(addr, idx.into())
+    }
+
+    fn get_server_idx(&mut self, zone_id: ZoneID) -> u8 {
+        Self::get_next_idx_for_zone(&mut self.server_map, zone_id)
+    }
+
+    fn get_mapping_idx(&mut self, zone_id: ZoneID) -> u8 {
+        Self::get_next_idx_for_zone(&mut self.mapping_map, zone_id)
+    }
+
+    fn get_next_idx_for_zone(map: &mut ZoneToCountMap, zone_id: ZoneID) -> u8 {
+        match map.entry(zone_id) {
+            Entry::Vacant(v) => {
+                v.insert(1);
+                1
+            }
+            Entry::Occupied(mut o) => {
+                let value = o.get_mut();
+                *value += 1;
+                *value
+            }
+        }
+    }
+}
+
+// TestMessage is a wrapper around the SWIM or gossip message sent by
+// a butterfly server. Contains source and destination addresses used
+// to determine a routing.
+struct TestMessage {
+    source: TestAddrAndPort,
+    target: TestAddrAndPort,
+    bytes: Vec<u8>,
+    dbg_key: Option<SymKey>,
+    channel_type: ChannelType,
+}
+
+impl Debug for TestMessage {
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        let mut debug_struct = f.debug_struct("TestMessage");
+
+        match message::unwrap_wire(&self.bytes, self.dbg_key.as_ref()) {
+            Ok(payload) => match self.channel_type {
+                ChannelType::SWIM => match Swim::decode(&payload) {
+                    Ok(parsed) => debug_struct.field("protobuf", &parsed),
+                    Err(e) => debug_struct
+                        .field("parse_error", &e)
+                        .field("invalid-payload", &payload),
+                },
+                ChannelType::Gossip => match RumorEnvelope::decode(&payload) {
+                    Ok(parsed) => debug_struct.field("protobuf", &parsed),
+                    Err(e) => debug_struct
+                        .field("parse_error", &e)
+                        .field("invalid-payload", &payload),
+                },
+            },
+            Err(e) => debug_struct
+                .field("decrypt_error", &e)
+                .field("bytes", &self.bytes),
+        }.field("source", &self.source)
+            .field("target", &self.target)
+            .field("channel_type", &self.channel_type)
+            .finish()
+    }
+}
+
+// LockedSender is a convenience struct to make mpsc::Sender fulfill
+// the Send + Sync traits.
+#[derive(Debug)]
+struct LockedSender<T> {
+    sender: Mutex<Sender<T>>,
+}
+
+impl<T> LockedSender<T> {
+    pub fn new(sender: Sender<T>) -> Self {
+        Self {
+            sender: Mutex::new(sender),
+        }
+    }
+
+    pub fn send(&self, t: T) -> StdResult<(), SendError<T>> {
+        self.get_sender_guard().send(t)
+    }
+
+    pub fn cloned_sender(&self) -> Sender<T> {
+        self.get_sender_guard().clone()
+    }
+
+    fn get_sender_guard(&self) -> MutexGuard<Sender<T>> {
+        self.sender.lock().expect("Sender lock is poisoned")
+    }
+}
+
+// ChannelMap is a mapping from IP address to an mpsc::Sender.
+type ChannelMap = HashMap<TestAddrAndPort, LockedSender<TestMessage>>;
+
+#[derive(Copy, Clone, Debug)]
+enum ChannelType {
+    SWIM,
+    Gossip,
+}
+
+type AddrToAddrMap = HashMap<TestAddrAndPort, TestAddrAndPort>;
+
+struct Mappings {
+    hole_to_internal: AddrToAddrMap,
+    internal_to_hole: AddrToAddrMap,
+}
+
+impl Mappings {
+    pub fn new() -> Self {
+        Self {
+            hole_to_internal: HashMap::new(),
+            internal_to_hole: HashMap::new(),
+        }
+    }
+
+    pub fn insert_both_ways(&mut self, hole: TestAddrAndPort, internal: TestAddrAndPort) {
+        match self.hole_to_internal.entry(hole) {
+            Entry::Vacant(v) => {
+                v.insert(internal);
+            }
+            Entry::Occupied(_) => {
+                unreachable!("mapping for hole {:?} already taken", hole);
+            }
+        };
+        match self.internal_to_hole.entry(internal) {
+            Entry::Vacant(v) => {
+                v.insert(hole);
+            }
+            Entry::Occupied(_) => {
+                unreachable!("mapping for internal {:?} already taken", internal);
+            }
+        };
+    }
+
+    pub fn hole_to_internal(&self, hole: TestAddrAndPort) -> Option<TestAddrAndPort> {
+        Self::get_from_map(&self.hole_to_internal, hole)
+    }
+
+    pub fn internal_to_hole(&self, internal: TestAddrAndPort) -> Option<TestAddrAndPort> {
+        Self::get_from_map(&self.internal_to_hole, internal)
+    }
+
+    fn get_from_map(map: &AddrToAddrMap, addr: TestAddrAndPort) -> Option<TestAddrAndPort> {
+        map.get(&addr).cloned()
+    }
+}
+
+#[derive(Copy, Clone)]
+struct NatHole {
+    addr: TestAddrAndPort,
+}
+
+impl NatHole {
+    pub fn new(addr: TestAddrAndPort) -> Self {
+        Self { addr }
+    }
+
+    pub fn into_additional_address(self) -> AdditionalAddress<TestAddr> {
+        AdditionalAddress {
+            address: Some(self.addr.addr),
+            swim_port: self.addr.port,
+            gossip_port: self.addr.port,
+        }
+    }
+}
+
+impl TalkTarget for NatHole {
+    fn create_member_info(&self) -> Member {
+        create_member_from_addr(self.addr)
+    }
+}
+
+#[derive(Clone)]
+struct TestNat {
+    parent_id: ZoneID,
+    child_id: ZoneID,
+    addresses: Arc<Mutex<Addresses>>,
+    mappings: Arc<RwLock<Mappings>>,
+}
+
+impl TestNat {
+    pub fn new(
+        parent_id: ZoneID,
+        child_id: ZoneID,
+        addresses: Arc<Mutex<Addresses>>,
+    ) -> Self {
+        let mappings = Arc::new(RwLock::new(Mappings::new()));
+        Self {
+            parent_id,
+            child_id,
+            addresses,
+            mappings,
+        }
+    }
+
+    pub fn punch_hole(&mut self) -> NatHole {
+        NatHole::new(
+            self.get_addresses_guard()
+                .generate_persistent_mapping_address(self.parent_id, self.child_id),
+        )
+    }
+
+    pub fn make_route(&mut self, hole: NatHole, internal: TestAddrAndPort) {
+        assert_eq!(hole.addr.get_zone_id(), self.parent_id);
+        assert_eq!(internal.get_zone_id(), self.child_id);
+
+        self.write_mappings().insert_both_ways(hole.addr, internal);
+    }
+
+    pub fn can_route(&self, msg: &mut TestMessage, ti: &TraversalInfo) -> bool {
+        if ti.direction == Direction::ParentToChild {
+            return false;
+        }
+
+        {
+            let mappings = self.read_mappings();
+            if let Some(hole) = mappings.internal_to_hole(msg.source) {
+                msg.source = hole;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    pub fn route(&self, msg: &mut TestMessage) -> bool {
+        let mappings = self.read_mappings();
+        if let Some(internal) = mappings.hole_to_internal(msg.target) {
+            msg.target = internal;
+            return true;
+        }
+
+        return false;
+    }
+
+    fn get_addresses_guard(&self) -> MutexGuard<Addresses> {
+        self.addresses.lock().expect("Addresses lock is poisoned")
+    }
+
+    fn write_mappings(&self) -> RwLockWriteGuard<Mappings> {
+        self.mappings.write().expect("Mappings lock is poisoned")
+    }
+
+    fn read_mappings(&self) -> RwLockReadGuard<Mappings> {
+        self.mappings.read().expect("Mappings lock is poisoned")
+    }
+}
+
+#[derive(Debug)]
+struct TestSuitability(u64);
+impl Suitability for TestSuitability {
+    fn get(&self, _service_group: &ServiceGroup) -> u64 {
+        self.0
+    }
+}
+
+#[derive(PartialEq, Eq, Hash)]
+struct NatsKey {
+    first: ZoneID,
+    second: ZoneID,
+}
+
+impl NatsKey {
+    pub fn new(z1: ZoneID, z2: ZoneID) -> Self {
+        let (first, second) = if z1.raw() < z2.raw() {
+            (z1, z2)
+        } else {
+            (z2, z1)
+        };
+        Self { first, second }
+    }
+}
+
+type NatsMap = HashMap<NatsKey, TestNat>;
+
+#[derive(Copy, Clone)]
+enum SettledZones {
+    Unique,
+    AllTheSame,
+}
+
+impl SettledZones {
+    fn from_bool(b: bool) -> SettledZones {
+        if b {
+            SettledZones::Unique
+        } else {
+            SettledZones::AllTheSame
+        }
+    }
+}
+
+// TestNetworkSwitchBoard implements the multizone setup for testing
+// the spanning ring.
+#[derive(Clone)]
+struct TestNetworkSwitchBoard {
+    zones: Arc<RwLock<ZoneMap>>,
+    servers: Arc<RwLock<Vec<TestServer>>>,
+    addresses: Arc<Mutex<Addresses>>,
+    swim_channel_map: Arc<RwLock<ChannelMap>>,
+    gossip_channel_map: Arc<RwLock<ChannelMap>>,
+    nats: Arc<RwLock<NatsMap>>,
+}
+
+impl TestNetworkSwitchBoard {
+    pub fn new() -> Self {
+        Self {
+            zones: Arc::new(RwLock::new(ZoneMap(HashMap::new()))),
+            servers: Arc::new(RwLock::new(Vec::new())),
+            addresses: Arc::new(Mutex::new(Addresses::new())),
+            swim_channel_map: Arc::new(RwLock::new(HashMap::new())),
+            gossip_channel_map: Arc::new(RwLock::new(HashMap::new())),
+            nats: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    pub fn setup_nat(
+        &self,
+        parent_id: ZoneID,
+        child_id: ZoneID,
+    ) -> TestNat {
+        {
+            let mut zones = self.write_zones();
+            zones.setup_zone_relationship(parent_id, child_id);
+        }
+        let nat = TestNat::new(
+            parent_id,
+            child_id,
+            Arc::clone(&self.addresses),
+        );
+        let nats_key = NatsKey::new(child_id, parent_id);
+        {
+            let mut nats = self.write_nats();
+            assert!(
+                !nats.contains_key(&nats_key),
+                "nat between zone {} and zone {} was already registered",
+                child_id,
+                parent_id,
+            );
+            nats.insert(nats_key, nat.clone());
+        }
+        nat
+    }
+
+    pub fn start_server_in_zone(&self, zone_id: ZoneID) -> TestServer {
+        self.start_server_in_zone_with_additional_addresses(zone_id, HashMap::new())
+    }
+
+    pub fn start_server_in_zone_with_additional_addresses(
+        &self,
+        zone_id: ZoneID,
+        tagged_additional_addresses: TaggedAddressesFromAddress<TestAddr>,
+    ) -> TestServer {
+        let addr = {
+            let mut addresses = self.get_addresses_guard();
+
+            addresses.generate_address_for_server(zone_id)
+        };
+        self.start_server(addr, tagged_additional_addresses)
+    }
+
+    pub fn start_public_server_in_zone(&self, zone_id: ZoneID) -> TestServer {
+        self.start_public_server_in_zone_with_additional_addresses(zone_id, HashMap::new())
+    }
+
+    pub fn start_public_server_in_zone_with_additional_addresses(
+        &self,
+        zone_id: ZoneID,
+        tagged_additional_addresses: TaggedAddressesFromAddress<TestAddr>,
+    ) -> TestServer {
+        let addr = {
+            let mut addresses = self.get_addresses_guard();
+            addresses.generate_public_address_for_server(zone_id)
+        };
+        self.start_server(addr, tagged_additional_addresses)
+    }
+
+    pub fn wait_for_health_of_all(&self, health: Health) -> bool {
+        let servers = self.read_servers().clone();
+        let rounds = self.gossip_rounds_in(4);
+        let servers_refs = servers.iter().collect::<Vec<_>>();
+
+        self.wait_for_health_of(health, &servers_refs, &rounds)
+    }
+
+    pub fn wait_for_health_of_those<'a, T>(&self, health: Health, servers: T) -> bool
+    where
+        T: AsRef<[&'a TestServer]>,
+    {
+        let rounds = self.gossip_rounds_in(4);
+
+        self.wait_for_health_of(health, servers.as_ref(), &rounds)
+    }
+
+    pub fn wait_for_same_settled_zone(&self, servers: &[&TestServer]) -> bool {
+        self.wait_for_disjoint_settled_zones(&[servers])
+    }
+
+    pub fn wait_for_splitted_same_zone<'a, T: AsRef<[&'a TestServer]>>(
+        &self,
+        disjoint_servers: &[T],
+    ) -> bool {
+        self.wait_for_settled_zones(disjoint_servers, false)
+    }
+
+    pub fn wait_for_disjoint_settled_zones<'a, T: AsRef<[&'a TestServer]>>(
+        &self,
+        disjoint_servers: &[T],
+    ) -> bool {
+        self.wait_for_settled_zones(disjoint_servers, true)
+    }
+
+    fn wait_for_settled_zones<'a, T: AsRef<[&'a TestServer]>>(
+        &self,
+        disjoint_servers: &[T],
+        full: bool,
+    ) -> bool {
+        self.dsz_assert_assumptions(disjoint_servers, SettledZones::from_bool(full));
+        let rounds = self.gossip_rounds_in(4);
+        let all_servers = {
+            let mut all_servers = Vec::new();
+
+            for servers in disjoint_servers {
+                for server in servers.as_ref() {
+                    all_servers.push(*server);
+                }
+            }
+
+            all_servers
+        };
+
+        loop {
+            if self.check_for_disjoint_settled_zones(disjoint_servers, full) {
+                return true;
+            }
+
+            if self.reached_max_rounds(&all_servers, &rounds) {
+                return false;
+            }
+            thread::sleep(Duration::from_millis(500));
+        }
+    }
+
+    fn check_for_disjoint_settled_zones<'a, T: AsRef<[&'a TestServer]>>(
+        &self,
+        disjoint_servers: &[T],
+        with_relationship_checks: bool,
+    ) -> bool {
+        if !self.dsz_check_equal_zones(disjoint_servers) {
+            return false;
+        }
+        if !self.dsz_check_unique_zone_count(disjoint_servers) {
+            return false;
+        }
+        if with_relationship_checks && !self.dsz_check_relationships(disjoint_servers) {
+            return false;
+        }
+
+        true
+    }
+
+    fn dsz_assert_assumptions<'a, T: AsRef<[&'a TestServer]>>(
+        &self,
+        disjoint_servers: &[T],
+        settled_zones: SettledZones,
+    ) {
+        let mut ids = Vec::new();
+        let mut indices = Vec::new();
+
+        assert!(!disjoint_servers.is_empty());
+        for servers_to_ref in disjoint_servers {
+            let servers = servers_to_ref.as_ref();
+
+            assert!(!servers.is_empty());
+
+            let zone_id = servers[0].zone_id;
+
+            match settled_zones {
+                SettledZones::Unique => {
+                    assert!(!ids.contains(&zone_id));
+                    ids.push(zone_id);
+                }
+                SettledZones::AllTheSame => {
+                    if ids.is_empty() {
+                        ids.push(zone_id);
+                    } else {
+                        assert!(ids[0] == zone_id);
+                    }
+                }
+            }
+
+            assert!(!indices.contains(&servers[0].idx));
+            indices.push(servers[0].idx);
+            for server in servers.iter().skip(1) {
+                assert!(server.zone_id == zone_id);
+                assert!(!indices.contains(&server.idx));
+                indices.push(server.idx);
+            }
+        }
+    }
+
+    fn dsz_check_equal_zones<'a, T: AsRef<[&'a TestServer]>>(
+        &self,
+        disjoint_servers: &[T],
+    ) -> bool {
+        for servers in disjoint_servers {
+            for pair in servers.as_ref().windows(2) {
+                let s0 = &pair[0];
+                let s1 = &pair[1];
+
+                assert!(s0.zone_id == s1.zone_id);
+                if !s0.butterfly.is_zone_settled() {
+                    return false;
+                }
+                if !s1.butterfly.is_zone_settled() {
+                    return false;
+                }
+                if s0.butterfly.get_settled_zone_id() != s1.butterfly.get_settled_zone_id() {
+                    return false;
+                }
+            }
+        }
+
+        true
+    }
+
+    fn dsz_check_unique_zone_count<'a, T: AsRef<[&'a TestServer]>>(
+        &self,
+        disjoint_servers: &[T],
+    ) -> bool {
+        let mut zone_uuids = disjoint_servers
+            .iter()
+            .filter_map(|v| {
+                v.as_ref()
+                    .first()
+                    .map(|s| s.butterfly.get_settled_zone_id())
+            })
+            .collect::<Vec<_>>();
+
+        zone_uuids.sort_unstable();
+        zone_uuids.dedup();
+        zone_uuids.len() == disjoint_servers.len()
+    }
+
+    fn dsz_check_relationships<'a, T: AsRef<[&'a TestServer]>>(
+        &self,
+        disjoint_servers: &[T],
+    ) -> bool {
+        let all_test_and_real_zone_id_pairs = disjoint_servers
+            .iter()
+            .map(|servers_to_ref| {
+                let servers = servers_to_ref.as_ref();
+
+                (
+                    servers[0].zone_id,
+                    servers[0].butterfly.get_settled_zone_id(),
+                )
+            })
+            .collect::<Vec<_>>();
+        let mut dbg = DbgVec::new("relationship check".to_string());
+        dbg.push(format!(
+            "test zones and real zones: {:#?}",
+            all_test_and_real_zone_id_pairs
+        ));
+
+        for servers in disjoint_servers {
+            let this_test_zone_id = servers.as_ref()[0].zone_id;
+            let (maybe_real_parent_zone_id, real_my_own_zone_id, real_child_zone_ids) = self
+                .dsz_get_related_real_zone_ids(this_test_zone_id, &all_test_and_real_zone_id_pairs);
+            let set = real_child_zone_ids.iter().cloned().collect::<HashSet<_>>();
+
+            dbg.push(format!(
+                "real ids for test id {}, parent: {:#?}, my own: {:#?}, children: {:#?}",
+                this_test_zone_id,
+                maybe_real_parent_zone_id,
+                real_my_own_zone_id,
+                real_child_zone_ids
+            ));
+
+            for server in servers.as_ref() {
+                let zone_list = server.butterfly.read_zone_list();
+                let zone = match zone_list.zones.get(&real_my_own_zone_id) {
+                    Some(zone) => zone,
+                    None => {
+                        dbg.push(format!("no info about own zone?"));
+                        return false;
+                    }
+                };
+                dbg.push(format!(
+                    "zone for {}({}): {:#?}",
+                    server.idx,
+                    server.butterfly.member_id(),
+                    zone
+                ));
+
+                match (&maybe_real_parent_zone_id, zone.parent_zone_id) {
+                    (&Some(ref id), Some(ref parent_id)) => {
+                        if *id != *parent_id {
+                            dbg.push(format!(
+                                "expected parent zone id to be {}, got {}",
+                                id, parent_id
+                            ));
+                            if let Some(parent_zone) = zone_list.zones.get(id) {
+                                dbg.push(format!("expected parent zone: {:#?}", parent_zone));
+                            } else {
+                                dbg.push("no info about expected parent zone");
+                            }
+                            if let Some(parent_zone) = zone_list.zones.get(parent_id) {
+                                dbg.push(format!("actual parent zone: {:#?}", parent_zone));
+                            } else {
+                                dbg.push("no info about actual parent zone");
+                            }
+                            return false;
+                        }
+                    }
+                    (None, None) => {}
+                    (_, _) => {
+                        dbg.push(format!(
+                            "mismatch between having and not having a parent ({:?} vs {:?})",
+                            maybe_real_parent_zone_id, zone.parent_zone_id
+                        ));
+                        return false;
+                    }
+                }
+
+                let zone_set = zone.child_zone_ids.iter().cloned().collect::<HashSet<_>>();
+
+                if set.symmetric_difference(&zone_set).next().is_some() {
+                    dbg.push("child zones of the server:");
+                    for zone_id in zone_set {
+                        if let Some(child_zone) = zone_list.zones.get(&zone_id) {
+                            dbg.push(format!("{:#?}", child_zone));
+                        } else {
+                            dbg.push(format!("no info about child zone {}", zone_id));
+                        }
+                    }
+
+                    dbg.push("expected child zones:");
+                    for zone_id in set {
+                        if let Some(child_zone) = zone_list.zones.get(&zone_id) {
+                            dbg.push(format!("{:#?}", child_zone));
+                        } else {
+                            dbg.push(format!("no info about child zone {}", zone_id));
+                        }
+                    }
+                    return false;
+                }
+            }
+        }
+
+        true
+    }
+
+    fn dsz_get_related_real_zone_ids(
+        &self,
+        this_test_zone_id: ZoneID,
+        all_test_and_real_zone_id_pairs: &[(ZoneID, BfUuid)],
+    ) -> (Option<BfUuid>, BfUuid, Vec<BfUuid>) {
+        let zone_map = self.read_zones();
+        let mut maybe_parent = None;
+        let mut my_own = BfUuid::nil();
+        let mut children = Vec::new();
+
+        for pair in all_test_and_real_zone_id_pairs {
+            if this_test_zone_id == pair.0 {
+                assert!(my_own.is_nil());
+                my_own = pair.1;
+                continue;
+            }
+            if zone_map.is_zone_child_of(this_test_zone_id, pair.0) {
+                assert!(maybe_parent.is_none());
+                maybe_parent = Some(pair.1);
+                continue;
+            }
+            if zone_map.is_zone_child_of(pair.0, this_test_zone_id) {
+                children.push(pair.1);
+            }
+        }
+
+        (maybe_parent, my_own, children)
+    }
+
+    fn start_server(
+        &self,
+        addr: TestAddrAndPort,
+        tagged_additional_addresses: TaggedAddressesFromAddress<TestAddr>,
+    ) -> TestServer {
+        let network = self.create_test_network(addr);
+        let mut servers = self.write_servers();
+        let idx = servers.len();
+        let server = self.create_test_server(network, idx, tagged_additional_addresses);
+        servers.push(server.clone());
+        server
+    }
+
+    fn create_test_network(&self, addr: TestAddrAndPort) -> TestNetwork {
+        let (swim_in, swim_out) = self.start_routing_thread(addr, ChannelType::SWIM);
+        let (gossip_in, gossip_out) = self.start_routing_thread(addr, ChannelType::Gossip);
+        TestNetwork::new(addr, swim_in, swim_out, gossip_in, gossip_out, None)
+    }
+
+    fn create_test_server(
+        &self,
+        network: TestNetwork,
+        idx: usize,
+        tagged_additional_addresses: TaggedAddressesFromAddress<TestAddr>,
+    ) -> TestServer {
+        let addr = network.get_addr();
+        let member = create_member_from_addr(addr);
+        let trace = Trace::default();
+        let ring_key = None;
+        let name = None;
+        let data_path = None::<PathBuf>;
+        let suitability = Box::new(TestSuitability(idx as u64));
+        let host_address = network
+            .get_host_address()
+            .expect("failed to get host address");
+        let mut butterfly = Server::new(
+            network,
+            host_address,
+            member,
+            trace,
+            ring_key,
+            name,
+            data_path,
+            suitability,
+        );
+        let timing = Timing::default();
+        let zone_id = addr.get_zone_id();
+
+        butterfly.merge_additional_addresses(tagged_additional_addresses);
+        butterfly.start(timing).expect("failed to start server");
+
+        TestServer {
+            butterfly,
+            addr,
+            idx,
+            zone_id,
+        }
+    }
+
+    fn wait_for_health_of(
+        &self,
+        health: Health,
+        servers: &[&TestServer],
+        rounds: &Vec<isize>,
+    ) -> bool {
+        for lserver in servers {
+            for rserver in servers {
+                if lserver.idx == rserver.idx {
+                    continue;
+                }
+                if !self.wait_for_health_of_pair(health, lserver, rserver, &rounds) {
+                    return false;
+                }
+                if !self.wait_for_health_of_pair(health, rserver, lserver, &rounds) {
+                    return false;
+                }
+            }
+        }
+        true
+    }
+
+    fn wait_for_health_of_pair(
+        &self,
+        health: Health,
+        from: &TestServer,
+        to: &TestServer,
+        rounds: &[isize],
+    ) -> bool {
+        loop {
+            if let Some(member_health) = self.health_of_pair(from, to) {
+                if member_health == health {
+                    return true;
+                }
+            }
+            if self.reached_max_rounds(&vec![from, to], rounds) {
+                return false;
+            }
+            thread::sleep(Duration::from_millis(500));
+        }
+    }
+
+    pub fn reached_max_rounds(&self, servers: &[&TestServer], rounds: &[isize]) -> bool {
+        for server in servers {
+            if server.butterfly.paused() || server.butterfly.swim_rounds() > rounds[server.idx] {
+                continue;
+            }
+            return false;
+        }
+        true
+    }
+
+    fn health_of_pair(&self, from: &TestServer, to: &TestServer) -> Option<Health> {
+        let maybe_health = from
+            .butterfly
+            .member_list
+            .health_of(&to.butterfly.read_member());
+
+        debug!("{} sees {} as {:?}", from.addr, to.addr, maybe_health,);
+
+        maybe_health
+    }
+
+    fn gossip_rounds_in(&self, count: isize) -> Vec<isize> {
+        self.gossip_rounds().iter().map(|r| r + count).collect()
+    }
+
+    fn gossip_rounds(&self) -> Vec<isize> {
+        let servers = self.read_servers();
+
+        servers
+            .iter()
+            .map(|s| s.butterfly.gossip_rounds())
+            .collect()
+    }
+
+    fn start_routing_thread(
+        &self,
+        addr: TestAddrAndPort,
+        channel_type: ChannelType,
+    ) -> (Sender<TestMessage>, Receiver<TestMessage>) {
+        let (msg_in, msg_mid_out) = mpsc::channel::<TestMessage>();
+        let (msg_mid_in, msg_out) = mpsc::channel::<TestMessage>();
+        {
+            let mut channel_map = self.write_channel_map(channel_type);
+            channel_map.insert(addr, LockedSender::new(msg_mid_in));
+        }
+        let self_for_thread = self.clone();
+        thread::spawn(move || loop {
+            match msg_mid_out.recv() {
+                Ok(msg) => self_for_thread.process_msg(msg, channel_type),
+                Err(_) => break,
+            }
+        });
+
+        (msg_in, msg_out)
+    }
+
+    fn process_msg(&self, mut msg: TestMessage, channel_type: ChannelType) {
+        let src = msg.source;
+        let tgt = msg.target;
+        let source_zone_id = match &msg.source.addr {
+            &TestAddr::Public(ref pip) => pip.get_zone_id(),
+            &TestAddr::Local(ref lip) => lip.get_zone_id(),
+            _ => {
+                unreachable!(
+                    "expected source address to be either local or public, but it is {:?}",
+                    msg.source,
+                );
+            }
+        };
+
+        let can_route_across_zones = {
+            if let &TestAddr::Public(_) = &msg.target.addr {
+                true
+            } else {
+                let target_zone_id = msg.target.addr.get_zone_id();
+                let zone_map = self.read_zones();
+                let nats = self.read_nats();
+                if let Some(route) = zone_map.get_route(source_zone_id, target_zone_id) {
+                    let mut can_route = true;
+                    for traversal_info in route {
+                        let nats_key = NatsKey::new(traversal_info.from, traversal_info.to);
+                        if let Some(nat) = nats.get(&nats_key) {
+                            if !nat.can_route(&mut msg, &traversal_info) {
+                                can_route = false;
+                                debug!("ROUTING: can't route {:#?} from {} to {}, there is a route, but it's unreachable", msg, src, tgt);
+                                break;
+                            }
+                        } else {
+                            can_route = false;
+                            debug!("ROUTING: can't route {:#?} from {} to {}, there is a route, but no nat registered", msg, src, tgt);
+                            break;
+                        }
+                    }
+                    can_route
+                } else {
+                    debug!(
+                        "ROUTING: can't route {:#?} from {} to {}, no route",
+                        msg, src, tgt
+                    );
+                    false
+                }
+            }
+        };
+        let routed = if can_route_across_zones {
+            let mut routed = true;
+            loop {
+                let nats = self.read_nats();
+                match msg.target.addr {
+                    TestAddr::PersistentMapping(m) => {
+                        let parent_id = m.get_parent_zone_id();
+                        let child_id = m.get_child_zone_id();
+                        let nats_key = NatsKey::new(parent_id, child_id);
+                        if let Some(nat) = nats.get(&nats_key) {
+                            routed = nat.route(&mut msg);
+                            if !routed {
+                                debug!(
+                                    "ROUTING: can't {:#?} route from {} to {}, no mapping",
+                                    msg, src, tgt
+                                );
+                                break;
+                            }
+                        } else {
+                            debug!(
+                                "ROUTING: can't route {:#?} from {} to {}, no registered nat",
+                                msg, src, tgt
+                            );
+                            routed = false;
+                        }
+                    }
+                    TestAddr::TemporaryMapping(_) => {
+                        unreachable!("not implemented yet");
+                    }
+                    _ => break,
+                }
+            }
+            routed
+        } else {
+            false
+        };
+        if routed {
+            let maybe_out = {
+                let map = self.read_channel_map(channel_type);
+                map.get(&msg.target).map(|l| l.cloned_sender())
+            };
+            if let Some(out) = maybe_out {
+                let target = msg.target;
+                if out.send(msg).is_err() {
+                    let mut map = self.write_channel_map(channel_type);
+                    map.remove(&target);
+                }
+            } else {
+                debug!(
+                    "ROUTING: couldn't send a message {:#?} from {} to {}, no out",
+                    msg, src, tgt
+                );
+            }
+        }
+    }
+
+    fn read_zones(&self) -> RwLockReadGuard<ZoneMap> {
+        self.zones.read().expect("Zone map lock is poisoned")
+    }
+
+    fn write_zones(&self) -> RwLockWriteGuard<ZoneMap> {
+        self.zones.write().expect("Zone map lock is poisoned")
+    }
+
+    fn get_addresses_guard(&self) -> MutexGuard<Addresses> {
+        self.addresses.lock().expect("Addresses lock is poisoned")
+    }
+
+    fn read_servers(&self) -> RwLockReadGuard<Vec<TestServer>> {
+        self.servers.read().expect("Servers lock is poisoned")
+    }
+
+    fn write_servers(&self) -> RwLockWriteGuard<Vec<TestServer>> {
+        self.servers.write().expect("Servers lock is poisoned")
+    }
+
+    fn read_channel_map(&self, channel_type: ChannelType) -> RwLockReadGuard<ChannelMap> {
+        self.get_channel_map_lock(channel_type)
+            .read()
+            .expect("Channel map lock is poisoned")
+    }
+
+    fn write_channel_map(&self, channel_type: ChannelType) -> RwLockWriteGuard<ChannelMap> {
+        self.get_channel_map_lock(channel_type)
+            .write()
+            .expect("Channel map lock is poisoned")
+    }
+
+    fn get_channel_map_lock(&self, channel_type: ChannelType) -> &RwLock<ChannelMap> {
+        match channel_type {
+            ChannelType::SWIM => &self.swim_channel_map,
+            ChannelType::Gossip => &self.gossip_channel_map,
+        }
+    }
+
+    fn read_nats(&self) -> RwLockReadGuard<NatsMap> {
+        self.nats.read().expect("Nats lock is poisoned")
+    }
+
+    fn write_nats(&self) -> RwLockWriteGuard<NatsMap> {
+        self.nats.write().expect("Nats lock is poisoned")
+    }
+}
+
+// TestSwimSender is an implementation of a SwimSender trait based on
+// channels.
+#[derive(Debug)]
+struct TestSwimSender {
+    addr: TestAddrAndPort,
+    sender: LockedSender<TestMessage>,
+    dbg_key: Option<SymKey>,
+}
+
+impl SwimSender<TestAddrAndPort> for TestSwimSender {
+    fn send(&self, buf: &[u8], addr: TestAddrAndPort) -> Result<usize> {
+        let msg = TestMessage {
+            source: self.addr,
+            target: addr,
+            bytes: buf.to_owned(),
+            dbg_key: self.dbg_key.clone(),
+            channel_type: ChannelType::SWIM,
+        };
+        self.sender.send(msg).map_err(|_| {
+            Error::SwimSendError("Receiver part of the channel is disconnected".to_owned())
+        })?;
+        Ok(buf.len())
+    }
+}
+
+// TestSwimReceiver is an implementation of a SwimReceiver trait based
+// on channels.
+struct TestSwimReceiver(Receiver<TestMessage>);
+
+impl SwimReceiver<TestAddrAndPort> for TestSwimReceiver {
+    fn receive(&self, buf: &mut [u8]) -> Result<(usize, TestAddrAndPort)> {
+        let msg = self.0.recv().map_err(|_| {
+            Error::SwimReceiveError("Sender part of the channel is disconnected".to_owned())
+        })?;
+        if buf.len() < msg.bytes.len() {
+            panic!(
+                "allowed buffer has length {}, but message from {} to {} is larger ({})",
+                buf.len(),
+                msg.source,
+                msg.target,
+                msg.bytes.len(),
+            );
+        }
+        buf[..msg.bytes.len()].copy_from_slice(&msg.bytes);
+        Ok((msg.bytes.len(), msg.source))
+    }
+}
+
+// TestGossipSender is an implementation of a GossipSender trait based
+// on channels.
+struct TestGossipSender {
+    source: TestAddrAndPort,
+    target: TestAddrAndPort,
+    sender: Sender<TestMessage>,
+    dbg_key: Option<SymKey>,
+}
+
+impl GossipSender for TestGossipSender {
+    fn send(&self, buf: &[u8]) -> Result<()> {
+        let msg = TestMessage {
+            source: self.source,
+            target: self.target,
+            bytes: buf.to_vec(),
+            dbg_key: self.dbg_key.clone(),
+            channel_type: ChannelType::Gossip,
+        };
+        self.sender.send(msg).map_err(|_| {
+            Error::GossipSendError("Receiver part of the channel is disconnected".to_owned())
+        })?;
+        Ok(())
+    }
+}
+
+// TestGossipReceiver is an implementation of a GossipReceiver trait
+// based on channels.
+struct TestGossipReceiver(Receiver<TestMessage>);
+
+impl GossipReceiver for TestGossipReceiver {
+    fn receive(&self) -> Result<Vec<u8>> {
+        let msg = self.0.recv().map_err(|_| {
+            Error::GossipReceiveError("Sender part of the channel is disconnected".to_owned())
+        })?;
+        return Ok(msg.bytes);
+    }
+}
+
+// TestNetwork is an implementation of a Network trait. It provides
+// channel-based senders and receivers.
+#[derive(Debug)]
+struct TestNetwork {
+    addr: TestAddrAndPort,
+    swim_in: LockedSender<TestMessage>,
+    swim_out: Mutex<Option<Receiver<TestMessage>>>,
+    gossip_in: LockedSender<TestMessage>,
+    gossip_out: Mutex<Option<Receiver<TestMessage>>>,
+    dbg_key: Option<SymKey>,
+}
+
+impl TestNetwork {
+    pub fn new(
+        addr: TestAddrAndPort,
+        swim_in: Sender<TestMessage>,
+        swim_out: Receiver<TestMessage>,
+        gossip_in: Sender<TestMessage>,
+        gossip_out: Receiver<TestMessage>,
+        dbg_key: Option<SymKey>,
+    ) -> Self {
+        Self {
+            addr: addr,
+            swim_in: LockedSender::new(swim_in),
+            swim_out: Mutex::new(Some(swim_out)),
+            gossip_in: LockedSender::new(gossip_in),
+            gossip_out: Mutex::new(Some(gossip_out)),
+            dbg_key: dbg_key,
+        }
+    }
+
+    pub fn get_addr(&self) -> TestAddrAndPort {
+        self.addr
+    }
+}
+
+impl Network for TestNetwork {
+    type AddressAndPort = TestAddrAndPort;
+    type SwimSender = TestSwimSender;
+    type SwimReceiver = TestSwimReceiver;
+    type GossipSender = TestGossipSender;
+    type GossipReceiver = TestGossipReceiver;
+
+    fn get_host_address(&self) -> Result<TestAddr> {
+        Ok(self.addr.get_address())
+    }
+
+    fn get_swim_addr(&self) -> TestAddrAndPort {
+        self.addr
+    }
+
+    fn create_swim_sender(&self) -> Result<Self::SwimSender> {
+        Ok(Self::SwimSender {
+            addr: self.addr,
+            sender: LockedSender::new(self.swim_in.cloned_sender()),
+            dbg_key: self.dbg_key.clone(),
+        })
+    }
+
+    fn create_swim_receiver(&self) -> Result<Self::SwimReceiver> {
+        match self
+            .swim_out
+            .lock()
+            .expect("SWIM receiver lock is poisoned")
+            .take()
+        {
+            Some(receiver) => Ok(TestSwimReceiver(receiver)),
+            None => Err(Error::SwimChannelSetupError(format!(
+                "no test swim receiver, should not happen"
+            ))),
+        }
+    }
+
+    fn get_gossip_addr(&self) -> TestAddrAndPort {
+        self.addr
+    }
+
+    fn create_gossip_sender(&self, addr: TestAddrAndPort) -> Result<Self::GossipSender> {
+        Ok(Self::GossipSender {
+            source: self.addr,
+            target: addr,
+            sender: self.gossip_in.cloned_sender(),
+            dbg_key: self.dbg_key.clone(),
+        })
+    }
+
+    fn create_gossip_receiver(&self) -> Result<Self::GossipReceiver> {
+        match self
+            .gossip_out
+            .lock()
+            .expect("Gossip receiver lock is poisoned")
+            .take()
+        {
+            Some(receiver) => Ok(TestGossipReceiver(receiver)),
+            None => Err(Error::SwimChannelSetupError(format!(
+                "no test gossip receiver, should not happen"
+            ))),
+        }
+    }
+}

--- a/components/butterfly/tests/nat/mod.rs
+++ b/components/butterfly/tests/nat/mod.rs
@@ -1756,7 +1756,7 @@ impl TestNetworkSwitchBoard {
         &self,
         disjoint_servers: &[T],
     ) -> bool {
-        let mut zone_uuids = disjoint_servers
+        let mut zone_ids = disjoint_servers
             .iter()
             .filter_map(|v| {
                 v.as_ref()
@@ -1765,9 +1765,9 @@ impl TestNetworkSwitchBoard {
             })
             .collect::<Vec<_>>();
 
-        zone_uuids.sort_unstable();
-        zone_uuids.dedup();
-        zone_uuids.len() == disjoint_servers.len()
+        zone_ids.sort_unstable();
+        zone_ids.dedup();
+        zone_ids.len() == disjoint_servers.len()
     }
 
     fn dsz_check_relationships<'a, T: AsRef<[&'a TestServer]>>(

--- a/components/butterfly/tests/nat/mod.rs
+++ b/components/butterfly/tests/nat/mod.rs
@@ -1393,7 +1393,7 @@ impl NatHole {
 
     pub fn into_additional_address(self) -> AdditionalAddress<TestAddr> {
         AdditionalAddress {
-            address: Some(self.addr.addr),
+            address: self.addr.addr,
             swim_port: self.addr.port,
             gossip_port: self.addr.port,
         }

--- a/components/butterfly/tests/nat/nat.rs
+++ b/components/butterfly/tests/nat/nat.rs
@@ -1,0 +1,311 @@
+use std::collections::HashMap;
+
+use nat::{TestNetworkSwitchBoard, ZoneID};
+
+use habitat_butterfly::member::Health;
+
+// Convenient macro for forcing the coercion of arrays into
+// slices. Useful when creating a slice of AsRef<T>, from a slice of
+// slices. Having a slice of arrays would work only when all the array
+// have the same length.
+macro_rules! slc {
+    ($($x:expr),*) => {
+        &([$($x,)*])[..]
+    };
+    // This is to allow a trailing comma.
+    ($($x:expr),*,) => {
+        slc![$($x),*]
+    }
+}
+
+// Convenient macro for inline creation of hashmaps.
+macro_rules! hm(
+    {$($key:expr => $value:expr),+} => {
+        {
+            [
+                $(
+                    ($key, $value),
+                )+
+            ].iter().cloned().collect::<HashMap<_, _>>()
+        }
+    };
+    // This form of the macro is to allow the leading comma.
+    { $($key:expr => $value:expr),+, } => {
+        hm!{ $($key => $value),+ }
+    };
+);
+
+#[test]
+fn servers_establish_the_same_zone_few() {
+    let switch_board = TestNetworkSwitchBoard::new();
+    let zone = ZoneID::new(1);
+    let server0 = switch_board.start_server_in_zone(zone);
+    let server1 = switch_board.start_server_in_zone(zone);
+
+    server0.talk_to(&[&server1]);
+    assert!(switch_board.wait_for_health_of_all(Health::Alive));
+    assert!(switch_board.wait_for_same_settled_zone(&[&server0, &server1]));
+}
+
+#[test]
+fn servers_establish_the_same_zone_many() {
+    let switch_board = TestNetworkSwitchBoard::new();
+    let zone = ZoneID::new(1);
+    let server0 = switch_board.start_server_in_zone(zone);
+    let server1 = switch_board.start_server_in_zone(zone);
+    let server2 = switch_board.start_server_in_zone(zone);
+    let server3 = switch_board.start_server_in_zone(zone);
+    let server4 = switch_board.start_server_in_zone(zone);
+    let server5 = switch_board.start_server_in_zone(zone);
+
+    server0.talk_to(&[&server1, &server2, &server3]);
+    server2.talk_to(&[&server3, &server4, &server5]);
+    assert!(switch_board.wait_for_health_of_all(Health::Alive));
+    assert!(switch_board.wait_for_same_settled_zone(&[
+        &server0, &server1, &server2, &server3, &server4, &server5,
+    ]));
+}
+
+#[test]
+fn sibling_zones_get_merged() {
+    let switch_board = TestNetworkSwitchBoard::new();
+    let zone = ZoneID::new(1);
+    let server0a = switch_board.start_server_in_zone(zone);
+    let server0b = switch_board.start_server_in_zone(zone);
+    let server1a = switch_board.start_server_in_zone(zone);
+    let server1b = switch_board.start_server_in_zone(zone);
+
+    server0a.talk_to(&[&server0b]);
+    server1a.talk_to(&[&server1b]);
+    assert!(switch_board.wait_for_health_of_those(Health::Alive, &[&server0a, &server0b]));
+    assert!(switch_board.wait_for_health_of_those(Health::Alive, &[&server1a, &server1b]));
+    assert!(
+        switch_board
+            .wait_for_splitted_same_zone(&[&[&server0a, &server0b], &[&server1a, &server1b],])
+    );
+
+    let server2 = switch_board.start_server_in_zone(zone);
+
+    server2.talk_to(&[&server0a, &server1a]);
+    assert!(switch_board.wait_for_health_of_all(Health::Alive));
+    assert!(
+        switch_board
+            .wait_for_same_settled_zone(&[&server0a, &server0b, &server1a, &server1b, &server2])
+    );
+}
+
+#[test]
+fn different_zones_get_different_ids_few() {
+    let switch_board = TestNetworkSwitchBoard::new();
+    let parent_zone = ZoneID::new(1);
+    let child_zone = ZoneID::new(2);
+    let mut nat = switch_board.setup_nat(
+        parent_zone,
+        child_zone,
+        //None,
+    );
+    let hole0 = nat.punch_hole();
+    let parent_server0 = switch_board.start_server_in_zone(parent_zone);
+    let child_server0 = switch_board.start_server_in_zone_with_additional_addresses(
+        child_zone,
+        hm!{
+            "-".to_string() => hole0.into_additional_address(),
+        },
+    );
+
+    nat.make_route(hole0, child_server0.addr);
+    parent_server0.talk_to(&[&hole0]);
+    assert!(switch_board.wait_for_health_of_all(Health::Alive));
+    assert!(switch_board.wait_for_disjoint_settled_zones(&[&[&parent_server0], &[&child_server0]]));
+}
+
+#[test]
+fn different_zones_get_different_ids_many() {
+    let switch_board = TestNetworkSwitchBoard::new();
+    let parent_zone = ZoneID::new(1);
+    let child_zone = ZoneID::new(2);
+    let mut nat = switch_board.setup_nat(
+        parent_zone,
+        child_zone,
+        //None,
+    );
+    let hole0 = nat.punch_hole();
+    let hole1 = nat.punch_hole();
+    let hole2 = nat.punch_hole();
+    let parent_server0 = switch_board.start_server_in_zone(parent_zone);
+    let parent_server1 = switch_board.start_server_in_zone(parent_zone);
+    let parent_server2 = switch_board.start_server_in_zone(parent_zone);
+    let child_server0 = switch_board.start_server_in_zone_with_additional_addresses(
+        child_zone,
+        hm!{
+            "-".to_string() => hole0.into_additional_address(),
+        },
+    );
+    let child_server1 = switch_board.start_server_in_zone_with_additional_addresses(
+        child_zone,
+        hm!{
+            "-".to_string() => hole1.into_additional_address(),
+        },
+    );
+    let child_server2 = switch_board.start_server_in_zone_with_additional_addresses(
+        child_zone,
+        hm!{
+            "-".to_string() => hole2.into_additional_address(),
+        },
+    );
+
+    nat.make_route(hole0, child_server0.addr);
+    nat.make_route(hole1, child_server1.addr);
+    nat.make_route(hole2, child_server2.addr);
+    parent_server0.talk_to(&[&parent_server1, &parent_server2]);
+    child_server0.talk_to(&[&child_server1, &child_server2]);
+    parent_server1.talk_to(&[&hole0, &hole1]);
+    parent_server2.talk_to(&[&hole2]);
+    assert!(switch_board.wait_for_health_of_all(Health::Alive));
+    assert!(switch_board.wait_for_disjoint_settled_zones(&[
+        &[&parent_server0, &parent_server1, &parent_server2],
+        &[&child_server0, &child_server1, &child_server2],
+    ]));
+}
+
+#[test]
+fn different_zones_get_different_ids_with_unexposed_servers() {
+    let switch_board = TestNetworkSwitchBoard::new();
+    let parent_zone = ZoneID::new(1);
+    let child_zone = ZoneID::new(2);
+    let mut nat = switch_board.setup_nat(
+        parent_zone,
+        child_zone,
+        //None,
+    );
+    let hole0 = nat.punch_hole();
+    let hole1 = nat.punch_hole();
+    let hole2 = nat.punch_hole();
+    let parent_server0 = switch_board.start_server_in_zone(parent_zone);
+    let parent_server1 = switch_board.start_server_in_zone(parent_zone);
+    let parent_server2 = switch_board.start_server_in_zone(parent_zone);
+    let child_server0 = switch_board.start_server_in_zone_with_additional_addresses(
+        child_zone,
+        hm!{
+            "-".to_string() => hole0.into_additional_address(),
+        },
+    );
+    let child_server1 = switch_board.start_server_in_zone_with_additional_addresses(
+        child_zone,
+        hm!{
+            "-".to_string() => hole1.into_additional_address(),
+        },
+    );
+    let child_server2 = switch_board.start_server_in_zone_with_additional_addresses(
+        child_zone,
+        hm!{
+            "-".to_string() => hole2.into_additional_address(),
+        },
+    );
+    let child_server3 = switch_board.start_server_in_zone(child_zone);
+    let child_server4 = switch_board.start_server_in_zone(child_zone);
+    let child_server5 = switch_board.start_server_in_zone(child_zone);
+
+    nat.make_route(hole0, child_server0.addr);
+    nat.make_route(hole1, child_server1.addr);
+    nat.make_route(hole2, child_server2.addr);
+
+    parent_server0.talk_to(&[&parent_server1, &parent_server2]);
+    child_server0.talk_to(&[&child_server1, &child_server2, &child_server3]);
+    child_server3.talk_to(&[&child_server4, &child_server5]);
+    parent_server1.talk_to(&[&hole0, &hole1]);
+    parent_server2.talk_to(&[&hole2]);
+    assert!(switch_board.wait_for_health_of_all(Health::Alive));
+    assert!(switch_board.wait_for_disjoint_settled_zones(&[
+        slc![&parent_server0, &parent_server1, &parent_server2],
+        slc![
+            &child_server0,
+            &child_server1,
+            &child_server2,
+            &child_server3,
+            &child_server4,
+            &child_server5,
+        ],
+    ]));
+}
+
+// TODO(krnowak): This needs to wait for sibling handling.
+#[allow(dead_code)]
+fn different_zones_get_different_ids_outcast() {
+    let switch_board = TestNetworkSwitchBoard::new();
+    let parent_zone = ZoneID::new(1);
+    let child_zone = ZoneID::new(2);
+    let mut nat = switch_board.setup_nat(
+        parent_zone,
+        child_zone,
+        //None,
+    );
+    let hole0 = nat.punch_hole();
+    let hole1 = nat.punch_hole();
+    let hole2 = nat.punch_hole();
+    let hole3 = nat.punch_hole();
+    let parent_server0 = switch_board.start_server_in_zone(parent_zone);
+    let parent_server1 = switch_board.start_server_in_zone(parent_zone);
+    let parent_server2 = switch_board.start_server_in_zone(parent_zone);
+    let child_server0 = switch_board.start_server_in_zone_with_additional_addresses(
+        child_zone,
+        hm!{
+            "-".to_string() => hole0.into_additional_address(),
+        },
+    );
+    let child_server1 = switch_board.start_server_in_zone_with_additional_addresses(
+        child_zone,
+        hm!{
+            "-".to_string() => hole1.into_additional_address(),
+        },
+    );
+    let child_server2 = switch_board.start_server_in_zone_with_additional_addresses(
+        child_zone,
+        hm!{
+            "-".to_string() => hole2.into_additional_address(),
+        },
+    );
+    let child_server3 = switch_board.start_server_in_zone_with_additional_addresses(
+        child_zone,
+        hm!{
+            "-".to_string() => hole3.into_additional_address(),
+        },
+    );
+
+    nat.make_route(hole0, child_server0.addr);
+    nat.make_route(hole1, child_server1.addr);
+    nat.make_route(hole2, child_server2.addr);
+    nat.make_route(hole3, child_server3.addr);
+    parent_server0.talk_to(&[&parent_server1, &parent_server2]);
+    child_server0.talk_to(&[&child_server1, &child_server2]);
+    parent_server1.talk_to(&[&hole0, &hole1]);
+    parent_server2.talk_to(&[&hole2]);
+    assert!(switch_board.wait_for_health_of_those(
+        Health::Alive,
+        &[
+            &parent_server0,
+            &parent_server1,
+            &parent_server2,
+            &child_server0,
+            &child_server1,
+            &child_server2
+        ],
+    ));
+    assert!(switch_board.wait_for_disjoint_settled_zones(&[
+        &[&parent_server0, &parent_server1, &parent_server2],
+        &[&child_server0, &child_server1, &child_server2],
+    ]));
+
+    child_server3.talk_to(&[&parent_server0, &parent_server1, &parent_server2]);
+
+    assert!(switch_board.wait_for_health_of_all(Health::Alive));
+    assert!(switch_board.wait_for_disjoint_settled_zones(&[
+        slc![&parent_server0, &parent_server1, &parent_server2],
+        slc![
+            &child_server0,
+            &child_server1,
+            &child_server2,
+            &child_server3
+        ],
+    ]));
+}

--- a/components/butterfly/tests/rumor/departure.rs
+++ b/components/butterfly/tests/rumor/departure.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use btest;
-use habitat_butterfly::client::Client;
 use habitat_butterfly::member::Health;
 
 #[test]
@@ -33,8 +32,7 @@ fn departure_via_client() {
     net.mesh();
 
     net.wait_for_gossip_rounds(1);
-    let mut client =
-        Client::new(net[0].gossip_addr(), None).expect("Cannot create Butterfly Client");
+    let mut client = btest::get_client_for_address(net[0].gossip_addr());
     client
         .send_departure(String::from(net[1].member_id()))
         .expect("Cannot send the departure");

--- a/components/butterfly/tests/rumor/election.rs
+++ b/components/butterfly/tests/rumor/election.rs
@@ -140,16 +140,8 @@ fn five_members_elect_a_new_leader_when_the_old_one_dies() {
 #[test]
 fn five_members_elect_a_new_leader_when_they_are_quorum_partitioned() {
     let mut net = btest::SwimNet::new_with_suitability(vec![1, 0, 0, 0, 0]);
-    net[0]
-        .member
-        .write()
-        .expect("Member lock is poisoned")
-        .persistent = true;
-    net[4]
-        .member
-        .write()
-        .expect("Member lock is poisoned")
-        .persistent = true;
+    net[0].write_member().persistent = true;
+    net[4].write_member().persistent = true;
     net.add_service(0, "core/witcher/1.2.3/20161208121212");
     net.add_service(1, "core/witcher/1.2.3/20161208121212");
     net.add_service(2, "core/witcher/1.2.3/20161208121212");

--- a/components/butterfly/tests/rumor/service_config.rs
+++ b/components/butterfly/tests/rumor/service_config.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use btest;
-use habitat_butterfly::client::Client;
 use habitat_core::service::ServiceGroup;
 
 #[test]
@@ -33,8 +32,7 @@ fn service_config_via_client() {
     net.mesh();
 
     net.wait_for_gossip_rounds(1);
-    let mut client =
-        Client::new(net[0].gossip_addr(), None).expect("Cannot create Butterfly Client");
+    let mut client = btest::get_client_for_address(net[0].gossip_addr());
     let payload = Vec::from("I want to get lost in you, tokyo".as_bytes());
     client
         .send_service_config(

--- a/components/butterfly/tests/rumor/service_file.rs
+++ b/components/butterfly/tests/rumor/service_file.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use btest;
-use habitat_butterfly::client::Client;
 use habitat_core::service::ServiceGroup;
 
 #[test]
@@ -38,8 +37,7 @@ fn service_file_via_client() {
     net.mesh();
 
     net.wait_for_gossip_rounds(1);
-    let mut client =
-        Client::new(net[0].gossip_addr(), None).expect("Cannot create Butterfly Client");
+    let mut client = btest::get_client_for_address(net[0].gossip_addr());
     let payload = Vec::from("I want to get lost in you, tokyo".as_bytes());
     client
         .send_service_file(

--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -828,6 +828,9 @@ pub fn sub_sup_run() -> App<'static, 'static> {
         (@arg PEER_WATCH_FILE: --("peer-watch-file") +takes_value conflicts_with[peer]
             "Watch this file for connecting to the ring"
         )
+        (@arg AA_WATCH_FILE: --("aa-watch-file") +takes_value
+            "Watch this file for exposing the supervisor and services"
+        )
         (@arg RING: --ring -r +takes_value "Ring key name")
         (@arg CHANNEL: --channel +takes_value
             "Receive Supervisor updates from the specified release channel [default: stable]")

--- a/components/sup/src/census.rs
+++ b/components/sup/src/census.rs
@@ -496,12 +496,6 @@ impl CensusGroup {
                         continue;
                     }
 
-                    if zone_address_for_zone.as_ref().unwrap().address.is_none() {
-                        self.population.remove(member_id);
-                        outputln!("Skippping updating census from a service rumor - no zone address for reachable zone");
-                        continue;
-                    }
-
                     zone_address_for_zone
                 }
                 Reachable::No => {
@@ -749,13 +743,9 @@ impl CensusMember {
     fn setup_sys(&mut self, rumor: &ServiceRumor, zone_address: &Option<&ZoneAddress>) {
         self.sys = rumor.sys.clone().into();
         if let Some(ref za) = zone_address {
-            // TODO(krnowak): We won't get here if zone address has no
-            // address, but it would certainly be better if we had a
-            // data structure with a String for address instead of
-            // Option<String>.
-            self.sys.ip = za.address.clone().unwrap();
+            self.sys.ip = za.address.clone();
             // TODO(krnowak): What about hostname? Clear it?
-            self.sys.gossip_ip = za.address.clone().unwrap();
+            self.sys.gossip_ip = za.address.clone();
             self.sys.gossip_port = za.gossip_port as u32;
             // TODO(krnowak): What about http/ctl gateway addresses and ports?
         }
@@ -1045,7 +1035,7 @@ mod tests {
         let mut member_inside = Member::default();
         let zone_address = ZoneAddress {
             zone_id: zone_uuid_outside,
-            address: Some("1.2.3.4".to_string()),
+            address: "1.2.3.4".to_string(),
             swim_port: 33333,
             gossip_port: 44444,
             tag: "tag".to_string(),

--- a/components/sup/src/census.rs
+++ b/components/sup/src/census.rs
@@ -643,6 +643,8 @@ fn service_group_from_str(sg: &str) -> Result<ServiceGroup, hcore::Error> {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use super::*;
     use butterfly::member::{Health, MemberList};
     use butterfly::rumor::election::Election as ElectionRumor;
@@ -679,6 +681,7 @@ mod tests {
             sg_one.clone(),
             sys_info.clone(),
             None,
+            HashMap::new(),
         );
         let sg_two = ServiceGroup::new(None, "shield", "two", None).unwrap();
         let service_two = ServiceRumor::new(
@@ -687,6 +690,7 @@ mod tests {
             sg_two.clone(),
             sys_info.clone(),
             None,
+            HashMap::new(),
         );
         let service_three = ServiceRumor::new(
             "member-a".to_string(),
@@ -694,6 +698,7 @@ mod tests {
             sg_two.clone(),
             sys_info.clone(),
             None,
+            HashMap::new(),
         );
 
         service_store.insert(service_one);

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -283,6 +283,9 @@ fn mgrcfg_from_matches(m: &ArgMatches) -> Result<ManagerConfig> {
     if let Some(watch_peer_file) = m.value_of("PEER_WATCH_FILE") {
         cfg.watch_peer_file = Some(String::from(watch_peer_file));
     }
+    if let Some(aa_watch_file) = m.value_of("AA_WATCH_FILE") {
+        cfg.additional_addresses_file = Some(String::from(aa_watch_file));
+    }
     cfg.ring_key = match m.value_of("RING") {
         Some(val) => Some(SymKey::get_latest_pair_for(
             &val,

--- a/components/sup/src/manager/extra_data.rs
+++ b/components/sup/src/manager/extra_data.rs
@@ -1,0 +1,223 @@
+// Copyright (c) 2018 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+//use std::fs::File;
+use std::io::Read;
+use std::net::IpAddr;
+use std::path::PathBuf;
+//use std::result::Result as StdResult;
+
+use error::{Error, Result};
+use manager::simple_file_watcher::SimpleFileWatcher;
+
+use butterfly::rumor::service::{Tag, TaggedPorts};
+use butterfly::zone::AdditionalAddress;
+
+use toml;
+
+static LOGKEY: &'static str = "AAW";
+
+pub type SupAdditionalAddress = AdditionalAddress<IpAddr>;
+pub type SvcName = String;
+pub type SupAdditionalAddresses = HashMap<Tag, SupAdditionalAddress>;
+pub type SvcPorts = HashMap<SvcName, TaggedPorts>;
+
+#[derive(Debug, PartialEq)]
+pub struct AdditionalAddresses {
+    pub sup: SupAdditionalAddresses,
+    pub svc: SvcPorts,
+}
+
+#[derive(Deserialize)]
+struct AdditionalAddressesToParse {
+    sup: Option<SupAdditionalAddresses>,
+    svc: Option<SvcPorts>,
+}
+
+impl From<AdditionalAddressesToParse> for AdditionalAddresses {
+    fn from(aa: AdditionalAddressesToParse) -> Self {
+        Self {
+            sup: aa.sup.unwrap_or_else(|| HashMap::new()),
+            svc: aa.svc.unwrap_or_else(|| HashMap::new()),
+        }
+    }
+}
+
+impl AdditionalAddresses {
+    pub fn new() -> Self {
+        Self {
+            sup: HashMap::new(),
+            svc: HashMap::new(),
+        }
+    }
+
+    pub fn create_from_toml_string(s: &str) -> Result<Self> {
+        let aa_to_parse: AdditionalAddressesToParse =
+            toml::from_str(s).map_err(|e| sup_error!(Error::TomlParser(e)))?;
+
+        Ok(aa_to_parse.into())
+    }
+}
+
+pub struct AdditionalAddressesWatcher(SimpleFileWatcher);
+
+impl AdditionalAddressesWatcher {
+    pub fn run<P>(path: P) -> Result<Self>
+    where
+        P: Into<PathBuf>,
+    {
+        Ok(AdditionalAddressesWatcher(SimpleFileWatcher::run(
+            "additional-addresses-watcher".to_string(),
+            path,
+        )?))
+    }
+
+    pub fn has_fs_events(&self) -> bool {
+        self.0.has_fs_events()
+    }
+
+    pub fn get_additional_addresses(&self) -> Result<AdditionalAddresses> {
+        let mut file = match self.0.open_file()? {
+            Some(file) => file,
+            None => {
+                self.0.clear_events();
+                return Ok(AdditionalAddresses::new());
+            }
+        };
+        let mut contents = String::new();
+
+        file.read_to_string(&mut contents)
+            .map_err(|e| sup_error!(Error::Io(e)))?;
+
+        let additional_addresses = AdditionalAddresses::create_from_toml_string(&contents)?;
+
+        self.0.clear_events();
+
+        Ok(additional_addresses)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::fs::{File, OpenOptions};
+    use std::io::Write;
+    use std::net::{IpAddr, Ipv4Addr};
+
+    use super::{AdditionalAddresses, AdditionalAddressesWatcher, SupAdditionalAddress};
+
+    use tempdir::TempDir;
+
+    #[test]
+    fn no_file() {
+        let tmpdir = TempDir::new("aawatchertest").unwrap();
+        let path = tmpdir.path().join("no_such_file");
+        let watcher = AdditionalAddressesWatcher::run(path).unwrap();
+
+        assert_eq!(
+            watcher.get_additional_addresses().unwrap(),
+            AdditionalAddresses::new(),
+        );
+    }
+
+    #[test]
+    fn empty_file() {
+        let tmpdir = TempDir::new("aawatchertest").unwrap();
+        let path = tmpdir.path().join("empty_file");
+        File::create(&path).unwrap();
+        let watcher = AdditionalAddressesWatcher::run(path).unwrap();
+
+        assert_eq!(
+            watcher.get_additional_addresses().unwrap(),
+            AdditionalAddresses::new(),
+        );
+    }
+
+    fn ipaddr(a: u8, b: u8, c: u8, d: u8) -> IpAddr {
+        IpAddr::V4(Ipv4Addr::new(a, b, c, d))
+    }
+
+    #[test]
+    fn with_file() {
+        let tmpdir = TempDir::new("aawatchertest").unwrap();
+        let path = tmpdir.path().join("some_file");
+        let mut file = OpenOptions::new()
+            .append(true)
+            .create_new(true)
+            .open(path.clone())
+            .unwrap();
+        let watcher = AdditionalAddressesWatcher::run(path).unwrap();
+
+        writeln!(
+            file,
+            r##"[sup.tag1]
+                address = "1.2.3.4"
+                swim_port = 1234
+                gossip_port = 4321
+
+                [sup.tag2]
+                swim_port = 2345
+                gossip_port = 5432
+
+                [svc.nginx.tag1]
+                port = 3456
+                ssl-port = 3457
+
+                [svc.redis.tag1]
+                port = 4567
+
+                [svc.redis.tag2]
+                port = 7654
+
+            "##
+        ).unwrap();
+        let suptag1 = SupAdditionalAddress::new(Some(ipaddr(1, 2, 3, 4)), 1234, 4321);
+        let suptag2 = SupAdditionalAddress::new(None, 2345, 5432);
+        let mut sup = HashMap::new();
+
+        sup.insert("tag1".to_string(), suptag1);
+        sup.insert("tag2".to_string(), suptag2);
+
+        let mut svcnginxtag1 = HashMap::new();
+        let mut svcnginx = HashMap::new();
+
+        svcnginxtag1.insert("port".to_string(), 3456);
+        svcnginxtag1.insert("ssl-port".to_string(), 3457);
+        svcnginx.insert("tag1".to_string(), svcnginxtag1);
+
+        let mut svcredistag1 = HashMap::new();
+        let mut svcredistag2 = HashMap::new();
+        let mut svcredis = HashMap::new();
+
+        svcredistag1.insert("port".to_string(), 4567);
+        svcredistag2.insert("port".to_string(), 7654);
+        svcredis.insert("tag1".to_string(), svcredistag1);
+        svcredis.insert("tag2".to_string(), svcredistag2);
+
+        let mut svc = HashMap::new();
+
+        svc.insert("nginx".to_string(), svcnginx);
+        svc.insert("redis".to_string(), svcredis);
+
+        let mut expected_aa = AdditionalAddresses::new();
+
+        expected_aa.sup = sup;
+        expected_aa.svc = svc;
+
+        let gotten_aa = watcher.get_additional_addresses().unwrap();
+
+        assert_eq!(expected_aa, gotten_aa);
+    }
+}

--- a/components/sup/src/manager/extra_data.rs
+++ b/components/sup/src/manager/extra_data.rs
@@ -168,6 +168,7 @@ mod tests {
                 gossip_port = 4321
 
                 [sup.tag2]
+                address = "2.3.4.5"
                 swim_port = 2345
                 gossip_port = 5432
 
@@ -183,8 +184,8 @@ mod tests {
 
             "##
         ).unwrap();
-        let suptag1 = SupAdditionalAddress::new(Some(ipaddr(1, 2, 3, 4)), 1234, 4321);
-        let suptag2 = SupAdditionalAddress::new(None, 2345, 5432);
+        let suptag1 = SupAdditionalAddress::new(ipaddr(1, 2, 3, 4), 1234, 4321);
+        let suptag2 = SupAdditionalAddress::new(ipaddr(2, 3, 4, 5), 2345, 5432);
         let mut sup = HashMap::new();
 
         sup.insert("tag1".to_string(), suptag1);

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -21,6 +21,7 @@ mod peer_watcher;
 mod periodic;
 mod self_updater;
 mod service_updater;
+mod simple_file_watcher;
 mod spec_watcher;
 mod sys;
 mod user_config_watcher;

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -42,7 +42,7 @@ use std::time::Duration;
 
 use butterfly;
 use butterfly::member::Member;
-use butterfly::network::RealNetwork;
+use butterfly::network::{Network, RealNetwork};
 use butterfly::server::timing::Timing;
 use butterfly::server::Suitability;
 use butterfly::trace::Trace;
@@ -888,16 +888,7 @@ impl Manager {
             version,
             service_group,
         );
-        let mut client = match butterfly::client::Client::new(
-            mgr.cfg.gossip_listen.local_addr(),
-            mgr.cfg.ring_key.clone(),
-        ) {
-            Ok(client) => client,
-            Err(err) => {
-                outputln!("Failed to connect to own gossip server, {}", err);
-                return Err(net::err(ErrCode::Internal, err.to_string()));
-            }
-        };
+        let mut client = Self::create_butterfly_client(&mgr)?;
         match client.send_service_config(service_group, version, cfg, is_encrypted) {
             Ok(()) => {
                 req.reply_complete(net::ok());
@@ -926,16 +917,7 @@ impl Manager {
             filename,
             service_group,
         );
-        let mut client = match butterfly::client::Client::new(
-            mgr.cfg.gossip_listen.local_addr(),
-            mgr.cfg.ring_key.clone(),
-        ) {
-            Ok(client) => client,
-            Err(err) => {
-                outputln!("Failed to connect to own gossip server, {}", err);
-                return Err(net::err(ErrCode::Internal, err.to_string()));
-            }
-        };
+        let mut client = Self::create_butterfly_client(&mgr)?;
         match client.send_service_file(service_group, filename, version, content, is_encrypted) {
             Ok(()) => {
                 req.reply_complete(net::ok());
@@ -1281,16 +1263,7 @@ impl Manager {
         opts: protocol::ctl::SupDepart,
     ) -> NetResult<()> {
         let member_id = opts.member_id.ok_or(err_update_client())?;
-        let mut client = match butterfly::client::Client::new(
-            mgr.cfg.gossip_listen.local_addr(),
-            mgr.cfg.ring_key.clone(),
-        ) {
-            Ok(client) => client,
-            Err(err) => {
-                outputln!("Failed to connect to own gossip server, {}", err);
-                return Err(net::err(ErrCode::Internal, err.to_string()));
-            }
-        };
+        let mut client = Self::create_butterfly_client(&mgr)?;
         outputln!("Attempting to depart member: {}", member_id);
         match client.send_departure(member_id) {
             Ok(()) => {
@@ -1299,6 +1272,25 @@ impl Manager {
             }
             Err(e) => Err(net::err(ErrCode::Internal, e.to_string())),
         }
+    }
+
+    fn create_butterfly_client(
+        mgr: &ManagerState,
+    ) -> NetResult<butterfly::client::Client<<RealNetwork as Network>::GossipSender>> {
+        let network = RealNetwork::new_for_client();
+        let addr = mgr.cfg.gossip_listen.local_addr();
+        let socket = match network.create_gossip_sender(*addr) {
+            Ok(socket) => socket,
+            Err(err) => {
+                outputln!("Failed to connect to own gossip servier, {}", err);
+                return Err(net::err(ErrCode::Internal, err.to_string()));
+            }
+        };
+
+        Ok(butterfly::client::Client::new(
+            socket,
+            mgr.cfg.ring_key.clone(),
+        ))
     }
 
     fn check_for_updated_supervisor(&mut self) -> Option<PackageInstall> {

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -602,6 +602,7 @@ impl Manager {
             spec.clone(),
             self.fs_cfg.clone(),
             self.organization.as_ref().map(|org| &**org),
+            HashMap::new(),
         ) {
             Ok(service) => service,
             Err(err) => {
@@ -1465,6 +1466,7 @@ impl Manager {
                 down.clone(),
                 self.fs_cfg.clone(),
                 self.organization.as_ref().map(|org| &**org),
+                HashMap::new(),
             ) {
                 Ok(service) => {
                     if let Some(err) = self

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -740,6 +740,7 @@ impl Manager {
                 &self.butterfly.member_list,
                 &self.butterfly.service_config_store,
                 &self.butterfly.service_file_store,
+                &self.butterfly.read_zone_list(),
             );
 
             if self.check_for_changed_services() {

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -358,8 +358,10 @@ impl Manager {
         let member = Self::load_member(&mut sys, &fs_cfg)?;
         let services = Arc::new(RwLock::new(Vec::new()));
         let network = RealNetwork::new_for_server(sys.gossip_listen(), sys.gossip_listen());
+        let host_address = network.get_host_address()?;
         let server = butterfly::Server::new(
             network,
+            host_address,
             member,
             Trace::default(),
             cfg.ring_key,

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -371,8 +371,8 @@ impl Manager {
         for peer_addr in &cfg.gossip_peers {
             let mut peer = Member::default();
             peer.address = format!("{}", peer_addr.ip());
-            peer.swim_port = peer_addr.port() as i32;
-            peer.gossip_port = peer_addr.port() as i32;
+            peer.swim_port = peer_addr.port();
+            peer.gossip_port = peer_addr.port();
             server.member_list.add_initial_member(peer);
         }
         Self::migrate_specs(&fs_cfg);

--- a/components/sup/src/manager/peer_watcher.rs
+++ b/components/sup/src/manager/peer_watcher.rs
@@ -149,8 +149,8 @@ impl PeerWatcher {
                 let addr: SocketAddr = addrs[0];
                 let mut member = Member::default();
                 member.address = format!("{}", addr.ip());
-                member.swim_port = addr.port() as i32;
-                member.gossip_port = addr.port() as i32;
+                member.swim_port = addr.port();
+                member.gossip_port = addr.port();
                 members.push(member);
             }
         }
@@ -208,8 +208,8 @@ mod tests {
         let mut member2 = Member::default();
         member2.id = String::new();
         member2.address = String::from("4.3.2.1");
-        member2.swim_port = GOSSIP_DEFAULT_PORT as i32;
-        member2.gossip_port = GOSSIP_DEFAULT_PORT as i32;
+        member2.swim_port = GOSSIP_DEFAULT_PORT;
+        member2.gossip_port = GOSSIP_DEFAULT_PORT;
         let expected_members = vec![member1, member2];
         let mut members = watcher.get_members().unwrap();
         for mut member in &mut members {

--- a/components/sup/src/manager/service/hooks.rs
+++ b/components/sup/src/manager/service/hooks.rs
@@ -1015,7 +1015,8 @@ mod tests {
     use std::process::{Command, Stdio};
     use std::string::ToString;
 
-    use butterfly::member::MemberList;
+    use butterfly::member::{Health, Member, MemberList};
+    use butterfly::message::BfUuid;
     use butterfly::rumor::election::Election as ElectionRumor;
     use butterfly::rumor::election::ElectionUpdate as ElectionUpdateRumor;
     use butterfly::rumor::service::Service as ServiceRumor;
@@ -1023,6 +1024,7 @@ mod tests {
     use butterfly::rumor::service_config::ServiceConfig as ServiceConfigRumor;
     use butterfly::rumor::service_file::ServiceFile as ServiceFileRumor;
     use butterfly::rumor::RumorStore;
+    use butterfly::zone::{Zone, ZoneList};
     use hcore::package::{PackageIdent, PackageInstall};
     use hcore::service::ServiceGroup;
     use protocol;
@@ -1327,6 +1329,15 @@ echo "The message is Hola Mundo"
         let election_update_store: RumorStore<ElectionUpdateRumor> = RumorStore::default();
 
         let member_list = MemberList::new();
+        let mut zone_list = ZoneList::new();
+        let zone_uuid = BfUuid::generate();
+        let zone = Zone::new(zone_uuid, "member-a".to_string());
+        let mut member_a = Member::default();
+
+        member_a.id = "member-a".to_string();
+        member_a.zone_id = zone_uuid;
+        member_list.insert(member_a, Health::Alive);
+        zone_list.insert(zone);
 
         let service_config_store: RumorStore<ServiceConfigRumor> = RumorStore::default();
         let service_file_store: RumorStore<ServiceFileRumor> = RumorStore::default();
@@ -1339,6 +1350,7 @@ echo "The message is Hola Mundo"
             &member_list,
             &service_config_store,
             &service_file_store,
+            &zone_list,
         );
 
         let bindings = iter::empty::<&ServiceBind>();
@@ -1440,6 +1452,15 @@ echo "The message is Hello"
         let election_update_store: RumorStore<ElectionUpdateRumor> = RumorStore::default();
 
         let member_list = MemberList::new();
+        let mut zone_list = ZoneList::new();
+        let zone_uuid = BfUuid::generate();
+        let zone = Zone::new(zone_uuid, "member-a".to_string());
+        let mut member_a = Member::default();
+
+        member_a.id = "member-a".to_string();
+        member_a.zone_id = zone_uuid;
+        member_list.insert(member_a, Health::Alive);
+        zone_list.insert(zone);
 
         let service_config_store: RumorStore<ServiceConfigRumor> = RumorStore::default();
         let service_file_store: RumorStore<ServiceFileRumor> = RumorStore::default();
@@ -1452,6 +1473,7 @@ echo "The message is Hello"
             &member_list,
             &service_config_store,
             &service_file_store,
+            &zone_list,
         );
 
         let bindings = iter::empty::<&ServiceBind>();

--- a/components/sup/src/manager/service/hooks.rs
+++ b/components/sup/src/manager/service/hooks.rs
@@ -1009,6 +1009,7 @@ impl<'a> HookOutput<'a> {
 #[cfg(test)]
 #[cfg(not(windows))]
 mod tests {
+    use std::collections::HashMap;
     use std::fs::{self, DirBuilder};
     use std::iter;
     use std::process::{Command, Stdio};
@@ -1307,10 +1308,15 @@ echo "The message is Hola Mundo"
         sys_info.http_gateway_port = 9631;
 
         let sg_one = service_group.clone(); // ServiceGroup::new("shield", "one", None).unwrap();
-
         let service_store: RumorStore<ServiceRumor> = RumorStore::default();
-        let service_one =
-            ServiceRumor::new("member-a", &pg_id, sg_one.clone(), sys_info.clone(), None);
+        let service_one = ServiceRumor::new(
+            "member-a",
+            &pg_id,
+            sg_one.clone(),
+            sys_info.clone(),
+            None,
+            HashMap::new(),
+        );
         service_store.insert(service_one);
 
         let election_store: RumorStore<ElectionRumor> = RumorStore::default();
@@ -1415,9 +1421,15 @@ echo "The message is Hello"
         sys_info.http_gateway_port = 9631;
 
         let sg_one = service_group.clone(); // ServiceGroup::new("shield", "one", None).unwrap();
-
         let service_store: RumorStore<ServiceRumor> = RumorStore::default();
-        let service_one = ServiceRumor::new("member-a", &pg_id, sg_one.clone(), sys_info, None);
+        let service_one = ServiceRumor::new(
+            "member-a",
+            &pg_id,
+            sg_one.clone(),
+            sys_info,
+            None,
+            HashMap::new(),
+        );
         service_store.insert(service_one);
 
         let election_store: RumorStore<ElectionRumor> = RumorStore::default();

--- a/components/sup/src/manager/service/mod.rs
+++ b/components/sup/src/manager/service/mod.rs
@@ -22,7 +22,7 @@ pub mod spec;
 mod supervisor;
 
 use std;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::fs::File;
 use std::io::prelude::*;
@@ -650,6 +650,7 @@ impl Service {
             self.service_group.clone(),
             self.sys.as_sys_info().clone(),
             exported.as_ref(),
+            HashMap::new(),
         );
         rumor.incarnation = incarnation;
         rumor

--- a/components/sup/src/manager/service_updater.rs
+++ b/components/sup/src/manager/service_updater.rs
@@ -17,6 +17,7 @@ use std::sync::mpsc::{sync_channel, Receiver, SyncSender, TryRecvError};
 use std::thread;
 
 use butterfly;
+use butterfly::network;
 use common::ui::UI;
 use env;
 use hcore::package::{PackageIdent, PackageInstall, PackageTarget};
@@ -67,11 +68,11 @@ enum FollowerState {
 /// To use an update strategy, the supervisor must be configured to watch a depot for new versions.
 pub struct ServiceUpdater {
     states: UpdaterStateList,
-    butterfly: butterfly::Server,
+    butterfly: butterfly::Server<network::RealNetwork>,
 }
 
 impl ServiceUpdater {
-    pub fn new(butterfly: butterfly::Server) -> Self {
+    pub fn new(butterfly: butterfly::Server<network::RealNetwork>) -> Self {
         ServiceUpdater {
             states: UpdaterStateList::default(),
             butterfly: butterfly,

--- a/components/sup/src/manager/simple_file_watcher.rs
+++ b/components/sup/src/manager/simple_file_watcher.rs
@@ -1,0 +1,222 @@
+// Copyright (c) 2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fs::File;
+use std::io::ErrorKind;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::thread::Builder as ThreadBuilder;
+
+use error::{Error, Result};
+use manager::file_watcher::{default_file_watcher, Callbacks};
+
+static LOGKEY: &'static str = "SFW";
+
+struct SimpleFileWatcherCallbacks {
+    have_events: Arc<AtomicBool>,
+}
+
+impl Callbacks for SimpleFileWatcherCallbacks {
+    fn file_appeared(&mut self, _: &Path) {
+        self.have_events.store(true, Ordering::Relaxed);
+    }
+
+    fn file_modified(&mut self, _: &Path) {
+        self.have_events.store(true, Ordering::Relaxed)
+    }
+
+    fn file_disappeared(&mut self, _: &Path) {
+        self.have_events.store(true, Ordering::Relaxed)
+    }
+}
+
+pub struct SimpleFileWatcher {
+    path: PathBuf,
+    have_events: Arc<AtomicBool>,
+}
+
+impl SimpleFileWatcher {
+    pub fn run<P>(kind: String, path: P) -> Result<Self>
+    where
+        P: Into<PathBuf>,
+    {
+        let path = path.into();
+        let have_events = Self::setup_watcher(kind, path.clone())?;
+
+        Ok(Self {
+            path: path,
+            have_events: have_events,
+        })
+    }
+
+    pub fn has_fs_events(&self) -> bool {
+        self.have_events.load(Ordering::Relaxed)
+    }
+
+    pub fn clear_events(&self) {
+        self.have_events.store(false, Ordering::Relaxed);
+    }
+
+    pub fn open_file(&self) -> Result<Option<File>> {
+        match File::open(&self.path) {
+            Ok(file) => Ok(Some(file)),
+            Err(e) => if e.kind() == ErrorKind::NotFound {
+                Ok(None)
+            } else {
+                Err(sup_error!(Error::Io(e)))
+            },
+        }
+    }
+
+    fn setup_watcher(kind: String, path: PathBuf) -> Result<Arc<AtomicBool>> {
+        let have_events = Arc::new(AtomicBool::new(false));
+        let have_events_for_thread = Arc::clone(&have_events);
+
+        ThreadBuilder::new()
+            .name(format!("simple-file-watcher-[{}:{}]", kind, path.display()))
+            .spawn(move || {
+                outputln!(
+                    "SimpleFileWatcher({}:{}): started thread",
+                    kind,
+                    path.display(),
+                );
+                loop {
+                    let have_events_for_loop = Arc::clone(&have_events_for_thread);
+                    if Self::file_watcher_loop_body(&kind, &path, have_events_for_loop) {
+                        break;
+                    }
+                }
+            })?;
+
+        Ok(have_events)
+    }
+
+    fn file_watcher_loop_body(kind: &str, path: &PathBuf, have_events: Arc<AtomicBool>) -> bool {
+        let callbacks = SimpleFileWatcherCallbacks {
+            have_events: have_events,
+        };
+        let mut file_watcher = match default_file_watcher(&path, callbacks) {
+            Ok(w) => w,
+            Err(sup_err) => match sup_err.err {
+                Error::NotifyError(err) => {
+                    outputln!(
+                        "SimpleFileWatcher({}:{}) failed to start watching the directories ({}), {}",
+                        kind,
+                        path.display(),
+                        err,
+                        "will try again",
+                    );
+                    return false;
+                }
+                _ => {
+                    outputln!(
+                        "SimpleFileWatcher({}:{}) could not create file watcher, ending thread ({})",
+                        kind,
+                        path.display(),
+                        sup_err
+                    );
+                    return true;
+                }
+            },
+        };
+        if let Err(err) = file_watcher.run() {
+            outputln!(
+                "SimpleFileWatcher({}:{}) error during watching ({}), restarting",
+                kind,
+                path.display(),
+                err
+            );
+        }
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs::File;
+    use std::path::PathBuf;
+    use std::thread;
+    use std::time::{Duration, Instant};
+
+    use super::SimpleFileWatcher;
+    use tempdir::TempDir;
+
+    fn run_watcher<P: Into<PathBuf>>(path: P) -> SimpleFileWatcher {
+        SimpleFileWatcher::run("test".to_string(), path).unwrap()
+    }
+
+    #[test]
+    fn no_file() {
+        let tmpdir = TempDir::new("simplefilewatchertest").unwrap();
+        let path = tmpdir.path().join("no_such_file");
+        let watcher = run_watcher(path);
+
+        assert_eq!(false, watcher.has_fs_events());
+    }
+
+    #[test]
+    fn initial_file() {
+        let tmpdir = TempDir::new("simplefilewatchertest").unwrap();
+        let path = tmpdir.path().join("file");
+        File::create(&path).unwrap();
+        let watcher = run_watcher(path);
+        let now = Instant::now();
+        let check_duration = Duration::from_secs(10);
+        let sleep_duration = Duration::from_millis(100);
+        let mut ok = false;
+
+        while now.elapsed() < check_duration {
+            if watcher.has_fs_events() {
+                ok = true;
+                break;
+            }
+            thread::sleep(sleep_duration);
+        }
+
+        assert!(ok);
+    }
+
+    #[test]
+    fn created_file() {
+        let tmpdir = TempDir::new("simplefilewatchertest").unwrap();
+        let path = tmpdir.path().join("file");
+        let watcher = run_watcher(path.clone());
+
+        let sleep_duration = Duration::from_millis(100);
+        let now1 = Instant::now();
+        let check1_duration = Duration::from_secs(2);
+
+        while now1.elapsed() < check1_duration {
+            assert_eq!(false, watcher.has_fs_events());
+            thread::sleep(sleep_duration);
+        }
+
+        File::create(&path).unwrap();
+
+        let now2 = Instant::now();
+        let check2_duration = Duration::from_secs(10);
+        let mut ok = false;
+
+        while now2.elapsed() < check2_duration {
+            if watcher.has_fs_events() {
+                ok = true;
+                break;
+            }
+            thread::sleep(sleep_duration);
+        }
+
+        assert!(ok);
+    }
+}

--- a/components/sup/tests/utils/test_butterfly.rs
+++ b/components/sup/tests/utils/test_butterfly.rs
@@ -20,6 +20,7 @@
 
 extern crate habitat_butterfly;
 use self::habitat_butterfly::client::Client as ButterflyClient;
+use self::habitat_butterfly::network::{GossipZmqSocket, Network, RealNetwork};
 
 extern crate habitat_core;
 use self::habitat_core::service::ServiceGroup;
@@ -30,7 +31,7 @@ use std::net::SocketAddr;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 pub struct Client {
-    butterfly_client: ButterflyClient,
+    butterfly_client: ButterflyClient<GossipZmqSocket>,
     pub package_name: String,
     pub service_group: String,
 }
@@ -44,8 +45,11 @@ impl Client {
         let gossip_addr = format!("127.0.0.1:{}", port)
             .parse::<SocketAddr>()
             .expect("Could not parse Butterfly gossip address!");
-        let c = ButterflyClient::new(&gossip_addr, None)
-            .expect("Could not create Butterfly Client for test!");
+        let network = RealNetwork::new_for_client();
+        let sender = network
+            .create_gossip_sender(gossip_addr)
+            .expect("Could not create gossip sender");
+        let c = ButterflyClient::new(sender, None);
         Client {
             butterfly_client: c,
             package_name: package_name.to_string(),


### PR DESCRIPTION
This work has three areas:

- Zone negotiation.
  - Zone is supervisor's view of a network. So network inside the k8s cluster would be one zone and network outside it could be another zone.
  - Zones currently are organized in a tree-like hierarchy.
  - Normally a service in a child zone can initiate a communication with a service in parent zone, but the converse is false.
  - This might be a simplification, but I think it catches most of the networking cases.
    - This likely is not true in case of local k8s cluster created by minikube, though - the networking minikube sets up is… complicated. There are some hacks to make this scenario work, but I would like to drop them.
- Exposing supervisor (through extended member info in protocol messages) and its services (through extended service gossip messages). This basically is:
  - Watching a TOML file, where we describe how the supervisor and the services it manages are exposed.
  - Applying that information to our member information and to our service information.
    - Member information is usually sent as a part of either gossip messages or SWIM messages.
    - Service information is usually sent as generated service rumors.
- Consuming the extended member and gossip messages to properly bind services across zones.
  - This drops all the service information from census if the service is not reachable (like if it is running inside the k8s cluster and is not exposed outside).

Some things that could be done next:
- Drop address discovery.
  - While this is convenient to have, it may interfere with next point. Also, address discovery in some places looks like heuristics. Would still like to do it. This is something that probably could be done later.
- Add siblings to zones.
  - So zones are in parent-child relationships, but there could be a situation where we two k8s clusters with some supervisors exposed and there is no supervisor we can talk to outside the clusters.
- Add detection if two separate children of a parent zone are actually the same zone
  - That would likely be a thread where we send pings to supervisors in the sibling zone through their private IP to see if we get an ACK. If so, the zones are not siblings but aliases.
- Drop predecessors over time.
  - During zone negotiation we may end up with many aliases for a single zone. Would be nice to phase them out gradually to keep only the zone with the highest ID.
- Limit the number of zone aliases and zone children sent in pings (to avoid breaking the 4k bytes limit in some cases).
- Better debug story for zones code.
  - The debug was done the way it is, because I wanted to have a readable multiline debug messages from a server when running a test that has several servers running and printing messages at the same time.

Fixes #4211