### PR TITLE
Introduce alpha feature to hide cfg values in http gateway and dat files on disk

### DIFF
--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -18,7 +18,7 @@ use std::result;
 use std::str::FromStr;
 
 use clap::{App, AppSettings, Arg};
-use hcore::{crypto::keys::PairType, service::ServiceGroup};
+use hcore::{crypto::keys::PairType, env, service::ServiceGroup};
 use protocol;
 use url::Url;
 

--- a/components/hab/src/lib.rs
+++ b/components/hab/src/lib.rs
@@ -82,6 +82,6 @@ features! {
     pub mod feat {
         const List = 0b00000001,
         const OfflineInstall = 0b00000010,
-        const IgnoreLocal = 0b00001000
+        const IgnoreLocal = 0b00000100
     }
 }

--- a/components/sup/src/lib.rs
+++ b/components/sup/src/lib.rs
@@ -140,7 +140,8 @@ features! {
     pub mod feat {
         const List         = 0b00000001,
         const TestExit     = 0b00000010,
-        const TestBootFail = 0b00000100
+        const TestBootFail = 0b00000100,
+        const RedactHTTP   = 0b00001000
     }
 }
 

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -420,6 +420,7 @@ fn enable_features_from_env() {
         (feat::List, "LIST"),
         (feat::TestExit, "TEST_EXIT"),
         (feat::TestBootFail, "BOOT_FAIL"),
+        (feat::RedactHTTP, "REDACT_HTTP"),
     ];
 
     // If the environment variable for a flag is set to _anything_ but


### PR DESCRIPTION
set FEAT_HIDE_HTTP_SECRETS=true and --hide-http-secrets to hide secrets from the http gateway and not serialize those secrets to disk

* also hide census and butterfly endpoints if HideHTTPSecrets is enabled

![](https://media1.giphy.com/media/CcEzlICOfLfoY/200w.gif)

Signed-off-by: Elliott Davis <elliott@excellent.io>