### PR TITLE
Create root's $HOME, /root

### DIFF
--- a/components/rootless_studio/default/entrypoint.sh
+++ b/components/rootless_studio/default/entrypoint.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 hab pkg exec core/hab-backline mkdir -m 1777 -p /tmp
+hab pkg exec core/hab-backline mkdir -m 0750 -p /root
 
 source /etc/habitat-studio/import_keys.sh
 source /etc/habitat-studio/environment.sh


### PR DESCRIPTION
Fixes #5569

This creates root's $HOME, /root, with permissions as it was done in
ages past.