### PR TITLE
Rearrange for correct precedence order

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,18 +3,17 @@
 components/backline @fnichol @baumanj
 components/builder* @chefsalim @raskchanky
 components/butterfly* @christophermaier @reset @baumanj @fnichol @raskchanky
-components/common @fnichol @baumanj @raskchanky
 components/common/src/command @apriofrost
-components/eventsrv* @reset @raskchanky
+components/common @fnichol @baumanj @raskchanky
 components/eventsrv/src/main.rs @apriofrost
-components/hab* @reset @fnichol @christophermaier @chefsalim @baumanj @elliott-davis @raskchanky @eeyun
+components/eventsrv* @reset @raskchanky
 components/hab/src/analytics.rs @apriofrost
 components/hab/src/cli.rs @apriofrost
 components/hab/src/main.rs @apriofrost
 components/hab/src/command @apriofrost
-components/launcher* @christophermaier @reset @baumanj @raskchanky
+components/hab* @reset @fnichol @christophermaier @chefsalim @baumanj @elliott-davis @raskchanky @eeyun
 components/launcher/src/main.rs @apriofrost
-components/pkg-* @fnichol @christophermaier @eeyun
+components/launcher* @christophermaier @reset @baumanj @raskchanky
 components/pkg-export-docker/src/cli.rs @apriofrost
 components/pkg-export-docker/src/lib.rs @apriofrost
 components/pkg-export-helm/src/chart.rs @apriofrost
@@ -33,15 +32,16 @@ components/pkg-export-tar/src/build.rs @apriofrost
 components/pkg-export-tar/src/cli.rs @apriofrost
 components/pkg-export-tar/src/lib.rs @apriofrost
 components/pkg-export-tar/src/main.rs @apriofrost
-components/plan-build @fnichol @christophermaier @elliott-davis @scotthain
+components/pkg-* @fnichol @christophermaier @eeyun
 components/plan-build/bin/hab-plan-build.sh @apriofrost
 components/plan-build-ps1/bin/hab-plan-build.ps1 @apriofrost
+components/plan-build @fnichol @christophermaier @elliott-davis @scotthain
 components/rootless_studio @elliott-davis
-components/studio @fnichol @baumanj @elliott-davis @eeyun
 components/studio/bin/hab-studio.sh @apriofrost
-components/sup* @christophermaier @reset @fnichol @baumanj @raskchanky
+components/studio @fnichol @baumanj @elliott-davis @eeyun
 components/sup/src/main.rs @apriofrost
 components/sup/src/command @apriofrost
+components/sup* @christophermaier @reset @fnichol @baumanj @raskchanky
 support @fnichol @baumanj @elliott-davis @raskchanky
 tools @baumanj @chefsalim @christophermaier @eeyun @raskchanky @fnichol
 www @cnunciato @mgamini @raskchanky


### PR DESCRIPTION
The last match has the highest precedence. Without this change, @apriofrost is required to approve many PRs that may not have any UX changes, simply because of the ordering of lines in the file. See https://help.github.com/articles/about-codeowners/ for full details.

![](https://media.giphy.com/media/fyaPlEYM1gLIc/giphy.gif)

Signed-off-by: Josh Black <raskchanky@gmail.com>