### PR TITLE
Increase Network Stability across Supervisor Restarts

### DIFF
--- a/components/butterfly/src/protocol/mod.rs
+++ b/components/butterfly/src/protocol/mod.rs
@@ -23,9 +23,7 @@ use error::Result;
 
 include!("../generated/butterfly.common.rs");
 
-pub trait Message<T: ProstMessage + Default>:
-    FromProto<T> + Clone + Into<T> + Serialize + Sized
-{
+pub trait Message<T: ProstMessage + Default>: FromProto<T> + Clone + Into<T> + Serialize {
     fn from_bytes(bytes: &[u8]) -> Result<Self> {
         let decoded = T::decode(bytes)?;
         Self::from_proto(decoded)

--- a/support/ci/compile_libsodium.sh
+++ b/support/ci/compile_libsodium.sh
@@ -3,7 +3,7 @@ set -eu
 
 version=1.0.13
 nv=libsodium-$version
-source=https://download.libsodium.org/libsodium/releases/${nv}.tar.gz
+source=https://download.libsodium.org/libsodium/releases/old/${nv}.tar.gz
 prefix=$HOME/pkgs/libsodium/$version
 echo "LIBSODIUM PREFIX = ${prefix}"
 


### PR DESCRIPTION
Fixes two bugs that were contributing to general network instability when restarting a Supervisor (especially when restarting for Supervisor upgrades).

Further details are present in the individual commits, but the high-level summary is:

* Only send a Departed Membership rumor when the Supervisor is really shutting down (including all services).
* Properly serialize Membership rumors to ensure they are appropriately reconstituted on restart, providing a consistent view of the gossip network.