### PR TITLE
Remove/replace set_{permissions,owner} calls which aren't supported on windows

### DIFF
--- a/components/sup/src/ctl_gateway/mod.rs
+++ b/components/sup/src/ctl_gateway/mod.rs
@@ -279,7 +279,7 @@ where
             f.write_all(out.as_bytes())?;
             f.sync_all()?;
         }
-        if cfg!(linux) {
+        if cfg!(not(windows)) {
             perm::set_permissions(&secret_key_path, CTL_SECRET_PERMISSIONS)?;
         }
         // TODO: Implement permissions FFI for windows

--- a/components/sup/src/ctl_gateway/mod.rs
+++ b/components/sup/src/ctl_gateway/mod.rs
@@ -279,7 +279,10 @@ where
             f.write_all(out.as_bytes())?;
             f.sync_all()?;
         }
-        perm::set_permissions(&secret_key_path, CTL_SECRET_PERMISSIONS)?;
+        if cfg!(linux) {
+            perm::set_permissions(&secret_key_path, CTL_SECRET_PERMISSIONS)?;
+        }
+        // TODO: Implement permissions FFI for windows
         Ok(out)
     }
 }

--- a/components/sup/src/manager/service/config.rs
+++ b/components/sup/src/manager/service/config.rs
@@ -527,10 +527,21 @@ impl CfgRenderer {
                 let mut config_file = File::create(&cfg_dest)?;
                 config_file.write_all(&compiled.into_bytes())?;
 
-                if abilities::can_run_services_as_svc_user() {
-                    util::perm::set_owner(&cfg_dest, &pkg.svc_user, &pkg.svc_group)?;
+                if cfg!(linux) {
+                    if abilities::can_run_services_as_svc_user() {
+                        util::perm::set_owner(&cfg_dest, &pkg.svc_user, &pkg.svc_group)?;
+                    }
+                    util::perm::set_permissions(&cfg_dest, CONFIG_PERMISSIONS)?;
+                } else if cfg!(windows) {
+                    if !Path::new(&cfg_dest).exists() {
+                        return Err(sup_error!(Error::FileNotFound(format!(
+                            "Invalid path {:?}",
+                            &cfg_dest
+                        ))));
+                    }
+                } else {
+                    unreachable!();
                 }
-                util::perm::set_permissions(&cfg_dest, CONFIG_PERMISSIONS)?;
 
                 changed = true
             } else {
@@ -552,10 +563,21 @@ impl CfgRenderer {
                     let mut config_file = File::create(&cfg_dest)?;
                     config_file.write_all(&compiled.into_bytes())?;
 
-                    if abilities::can_run_services_as_svc_user() {
-                        util::perm::set_owner(&cfg_dest, &pkg.svc_user, &pkg.svc_group)?;
+                    if cfg!(linux) {
+                        if abilities::can_run_services_as_svc_user() {
+                            util::perm::set_owner(&cfg_dest, &pkg.svc_user, &pkg.svc_group)?;
+                        }
+                        util::perm::set_permissions(&cfg_dest, CONFIG_PERMISSIONS)?;
+                    } else if cfg!(windows) {
+                        if !Path::new(&cfg_dest).exists() {
+                            return Err(sup_error!(Error::FileNotFound(format!(
+                                "Invalid path {:?}",
+                                &cfg_dest
+                            ))));
+                        }
+                    } else {
+                        unreachable!();
                     }
-                    util::perm::set_permissions(&cfg_dest, CONFIG_PERMISSIONS)?;
 
                     changed = true;
                 }

--- a/components/sup/src/manager/service/config.rs
+++ b/components/sup/src/manager/service/config.rs
@@ -527,7 +527,7 @@ impl CfgRenderer {
                 let mut config_file = File::create(&cfg_dest)?;
                 config_file.write_all(&compiled.into_bytes())?;
 
-                if cfg!(linux) {
+                if cfg!(not(windows)) {
                     if abilities::can_run_services_as_svc_user() {
                         util::perm::set_owner(&cfg_dest, &pkg.svc_user, &pkg.svc_group)?;
                     }
@@ -563,7 +563,7 @@ impl CfgRenderer {
                     let mut config_file = File::create(&cfg_dest)?;
                     config_file.write_all(&compiled.into_bytes())?;
 
-                    if cfg!(linux) {
+                    if cfg!(not(windows)) {
                         if abilities::can_run_services_as_svc_user() {
                             util::perm::set_owner(&cfg_dest, &pkg.svc_user, &pkg.svc_group)?;
                         }

--- a/components/sup/src/manager/service/dir.rs
+++ b/components/sup/src/manager/service/dir.rs
@@ -117,7 +117,7 @@ impl<'a> SvcDir<'a> {
         P: AsRef<Path>,
     {
         Self::create_dir_all(&path)?;
-        if cfg!(linux) {
+        if cfg!(not(windows)) {
             if abilities::can_run_services_as_svc_user() {
                 perm::set_owner(&path, &self.svc_user, &self.svc_group)?;
             }

--- a/components/sup/src/manager/service/dir.rs
+++ b/components/sup/src/manager/service/dir.rs
@@ -117,10 +117,23 @@ impl<'a> SvcDir<'a> {
         P: AsRef<Path>,
     {
         Self::create_dir_all(&path)?;
-        if abilities::can_run_services_as_svc_user() {
-            perm::set_owner(&path, &self.svc_user, &self.svc_group)?;
+        if cfg!(linux) {
+            if abilities::can_run_services_as_svc_user() {
+                perm::set_owner(&path, &self.svc_user, &self.svc_group)?;
+            }
+            perm::set_permissions(&path, SVC_DIR_PERMISSIONS).map_err(From::from)
+        } else if cfg!(windows) {
+            if path.as_ref().exists() {
+                Ok(())
+            } else {
+                Err(sup_error!(Error::FileNotFound(format!(
+                    "Invalid path {:?}",
+                    path.as_ref().display()
+                ))))
+            }
+        } else {
+            unreachable!();
         }
-        perm::set_permissions(&path, SVC_DIR_PERMISSIONS).map_err(From::from)
     }
 
     fn create_dir_all<P: AsRef<Path>>(path: P) -> Result<()> {

--- a/components/sup/src/manager/service/hooks.rs
+++ b/components/sup/src/manager/service/hooks.rs
@@ -105,7 +105,7 @@ pub trait Hook: fmt::Debug + Sized {
         if write_hook(&content, self.path())? {
             outputln!(preamble service_group, "{}, compiled to {}", Self::file_name(),
                 self.path().display());
-            if cfg!(linux) {
+            if cfg!(not(windows)) {
                 hcore::util::perm::set_permissions(self.path(), HOOK_PERMISSIONS)?;
             }
             // TODO: Implement permissions FFI for windows

--- a/components/sup/src/manager/service/hooks.rs
+++ b/components/sup/src/manager/service/hooks.rs
@@ -105,7 +105,10 @@ pub trait Hook: fmt::Debug + Sized {
         if write_hook(&content, self.path())? {
             outputln!(preamble service_group, "{}, compiled to {}", Self::file_name(),
                 self.path().display());
-            hcore::util::perm::set_permissions(self.path(), HOOK_PERMISSIONS)?;
+            if cfg!(linux) {
+                hcore::util::perm::set_permissions(self.path(), HOOK_PERMISSIONS)?;
+            }
+            // TODO: Implement permissions FFI for windows
             Ok(true)
         } else {
             debug!(

--- a/components/sup/src/manager/service/mod.rs
+++ b/components/sup/src/manager/service/mod.rs
@@ -789,7 +789,7 @@ impl Service {
         match self.hooks.run {
             Some(ref hook) => {
                 std::fs::copy(hook.path(), &svc_run)?;
-                if cfg!(linux) {
+                if cfg!(not(windows)) {
                     set_permissions(&svc_run.to_str().unwrap(), HOOK_PERMISSIONS)?;
                 }
                 // TODO: Implement permissions FFI for windows
@@ -799,7 +799,7 @@ impl Service {
                 match std::fs::metadata(&run) {
                     Ok(_) => {
                         std::fs::copy(&run, &svc_run)?;
-                        if cfg!(linux) {
+                        if cfg!(not(windows)) {
                             set_permissions(&svc_run, HOOK_PERMISSIONS)?;
                         }
                         // TODO: Implement permissions FFI for windows
@@ -964,7 +964,7 @@ impl Service {
         }
 
         if abilities::can_run_services_as_svc_user() {
-            let result = if cfg!(linux) {
+            let result = if cfg!(not(windows)) {
                 set_owner(&file, &self.pkg.svc_user, &self.pkg.svc_group)
             } else if cfg!(windows) {
                 if file.as_ref().exists() {


### PR DESCRIPTION
(NB: This will be easier to review with whitespace changes hidden)

These are misleading since the core implementation doesn't actually do what the
function names imply, so replace with more illustrative code on a per-platform
basis. Long-term, we should implement the appropriate windows FFI calls, but
the current situation is dangerously misleading.

See https://github.com/habitat-sh/core/blob/master/components/core/src/os/filesystem/windows.rs#L28-L34

Signed-off-by: Jon Bauman <5906042+baumanj@users.noreply.github.com>