### PR TITLE
studio build and run should check for empty commands

### DIFF
--- a/components/studio/bin/hab-studio.ps1
+++ b/components/studio/bin/hab-studio.ps1
@@ -373,7 +373,7 @@ function Enter-Studio {
 }
 
 function Invoke-StudioRun($cmd) {
-  if($printHelp -or ($cmd -eq $null)) {
+  if($printHelp -or ([String]::IsNullOrEmpty($cmd))) {
     Write-RunHelp
     return
   }
@@ -383,7 +383,7 @@ function Invoke-StudioRun($cmd) {
 }
 
 function Invoke-StudioBuild($location, $reuse) {
-  if($printHelp -or ($location -eq $null)) {
+  if($printHelp -or ([String]::IsNullOrEmpty($location))) {
     Write-BuildHelp
     return
   }


### PR DESCRIPTION
A user noticed toay that passing no build location to `hab studio build` was throwing an unfriendly powershell error. This ensures we instead return the appropriate command help and plugs the same hole in `hab studio run`.

Signed-off-by: mwrock <matt@mattwrock.com>