### PR TITLE
Fix compile warning

### DIFF
--- a/components/sup/src/lib.rs
+++ b/components/sup/src/lib.rs
@@ -74,7 +74,6 @@ extern crate prost;
 extern crate protobuf;
 extern crate rand;
 extern crate regex;
-#[macro_use]
 extern crate router;
 extern crate serde;
 #[macro_use]


### PR DESCRIPTION
```
warning: unused `#[macro_use]` import
  --> components/sup/src/lib.rs:77:1
```
