### PR TITLE
supervisor should not init signals on windows

### DIFF
--- a/components/sup/src/lib.rs
+++ b/components/sup/src/lib.rs
@@ -137,10 +137,11 @@ lazy_static! {
 /// Search for feat::is_enabled(feat::FeatureName) to learn more
 features! {
     pub mod feat {
-        const List         = 0b00000001,
-        const TestExit     = 0b00000010,
-        const TestBootFail = 0b00000100,
-        const RedactHTTP   = 0b00001000
+        const List          = 0b00000001,
+        const TestExit      = 0b00000010,
+        const TestBootFail  = 0b00000100,
+        const RedactHTTP    = 0b00001000,
+        const IgnoreSignals = 0b00010000
     }
 }
 

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -421,6 +421,7 @@ fn enable_features_from_env() {
         (feat::TestExit, "TEST_EXIT"),
         (feat::TestBootFail, "BOOT_FAIL"),
         (feat::RedactHTTP, "REDACT_HTTP"),
+        (feat::IgnoreSignals, "IGNORE_SIGNALS"),
     ];
 
     // If the environment variable for a flag is set to _anything_ but


### PR DESCRIPTION
0.62 is currently breaking some customers that have long running `init` hooks. Killing a supervisor via ctrl+c or stopping the windows service simply hangs because 0.62.0 turns off the default ctrl+c handler for the supervisor.

This exposes some potential snags when we get to moving service termination from the launcher to the supervisor. We can work those out when we get there but this should unbreak windows supervisor consumers for now.

Signed-off-by: mwrock <matt@mattwrock.com>