### PR TITLE
Remove incorrect documentation for applying config with a ring key

### DIFF
--- a/www/source/partials/docs/_using-hab-encryption.html.md.erb
+++ b/www/source/partials/docs/_using-hab-encryption.html.md.erb
@@ -35,10 +35,6 @@ Supervisors running in a ring can be configured to encrypt all traffic between t
     $ hab svc load <ORIGIN>/<NAME>
     ```
 
-### Using a Ring Key When Applying Configuration Changes
-
-Users utilizing `hab config apply` or `hab file upload` will also need to supply the name of the ring key with the `-r` or `--ring` parameter, or supervisors will reject this communication.
-
 ## Service Group Encryption
 
 Supervisors in a service group can be configured to require key-based authorization prior to allowing configuration changes. In this scenario, the Supervisor in a named service group starts up with a key for that group bound to an _organization_. This allows for multiple service groups with the same name in different organizations.


### PR DESCRIPTION
This functionality was removed in 0.56 and is no longer available.

```
hab-config-apply 0.62.1/20180905002018
Sets a configuration to be shared by members of a Service Group

USAGE:
    hab config apply [OPTIONS] <SERVICE_GROUP> <VERSION_NUMBER> [FILE]

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
    -r, --remote-sup <REMOTE_SUP>    Address to a remote Supervisor's Control Gateway [default: 127.0.0.1:9632]
    -u, --user <USER>                Name of a user key to use for encryption

ARGS:
    <SERVICE_GROUP>     Target service group service.group[@organization] (ex: redis.default or foo.default@bazcorp)
    <VERSION_NUMBER>    A version number (positive integer) for this configuration (ex: 42)
    <FILE>              Path to local file on disk (ex: /tmp/config.toml, default: <stdin>)
```

This may come back in the future, and this should be re-added at that time. See https://github.com/habitat-sh/habitat/issues/5609 for tracking that work.

Signed-off-by: Scott Macfarlane <macfarlane.scott@gmail.com>