### PR TITLE
Add more detail to error output when supervisor version is too old

### DIFF
--- a/components/launcher/src/server/mod.rs
+++ b/components/launcher/src/server/mod.rs
@@ -568,6 +568,10 @@ fn spawn_supervisor(pipe: &str, args: &[String], clean: bool) -> Result<Child> {
         let version_check = Command::new(&binary).arg("--version").output()?;
         let sup_version = String::from_utf8_lossy(&version_check.stdout);
         if !is_supported_supervisor_version(sup_version.trim().to_string()) {
+            error!("This Launcher requires Habitat version {}", SUP_VERSION_REQ);
+            error!("This check can be disabled by setting the {} environment variable to a non-empty string when starting the supervisor", SUP_VERSION_CHECK_DISABLE);
+            error!("Disabling this check may result in undefined behavior; please update to a newer Habitat version");
+            error!("For more information see https://github.com/habitat-sh/habitat/pull/5484");
             return Err(Error::SupBinaryVersion);
         }
     }


### PR DESCRIPTION
See https://github.com/habitat-sh/habitat/issues/5388

Output now like:
```
ERROR 2018-09-11T20:00:23Z: habitat_launcher::server: This Launcher requires Habitat version >= 0.56
ERROR 2018-09-11T20:00:23Z: habitat_launcher::server: This check can be disabled by setting the HAB_LAUNCH_NO_SUP_VERSION_CHECK environment variable to a non-empty string when starting the supervisor
ERROR 2018-09-11T20:00:23Z: habitat_launcher::server: Disabling this check may result in undefined behavior; please update to a newer Habitat version
ERROR 2018-09-11T20:00:23Z: habitat_launcher::server: For more information see https://github.com/habitat-sh/habitat/pull/5484
ERROR 2018-09-11T20:00:23Z: hab_launch: Launcher exiting with 1 due to err: Unsupported Supervisor binary version
```