### PR TITLE
Persist Incarnation Numbers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -779,6 +779,7 @@ dependencies = [
  "heck 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mktemp 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-build 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/butterfly-test/src/lib.rs
+++ b/components/butterfly-test/src/lib.rs
@@ -80,8 +80,8 @@ pub fn start_server(name: &str, ring_key: Option<SymKey>, suitability: u64) -> S
 pub fn member_from_server(server: &Server) -> Member {
     let mut new_member = Member::default();
     let server_member = server.member.read().expect("Member lock is poisoned");
-    new_member.id = server_member.id.to_string();
-    new_member.incarnation = server_member.incarnation;
+    new_member.id = server_member.as_ref().id.to_string();
+    new_member.incarnation = server_member.incarnation();
     new_member.address = String::from("127.0.0.1");
     new_member.swim_port = server.swim_port() as i32;
     new_member.gossip_port = server.gossip_port() as i32;
@@ -176,6 +176,7 @@ impl SwimNet {
             to.member
                 .read()
                 .expect("Member lock is poisoned")
+                .as_ref()
                 .id
                 .to_string(),
         ));
@@ -205,7 +206,7 @@ impl SwimNet {
             .get(to_entry)
             .expect("Asked for a network member who is out of bounds");
         let to_member = to.member.read().expect("Member lock is poisoned");
-        from.member_list.health_of(&to_member)
+        from.member_list.health_of(to_member.as_ref())
     }
 
     pub fn network_health_of(&self, to_check: usize) -> Vec<Option<Health>> {

--- a/components/butterfly/Cargo.toml
+++ b/components/butterfly/Cargo.toml
@@ -32,6 +32,7 @@ zmq = { git = "https://github.com/erickt/rust-zmq", branch = "release/v0.8" }
 
 [dev-dependencies]
 habitat_butterfly_test = { path = "../butterfly-test" }
+mktemp = "*"
 
 [build-dependencies]
 heck = "*"

--- a/components/butterfly/src/error.rs
+++ b/components/butterfly/src/error.rs
@@ -39,9 +39,9 @@ pub enum Error {
     ProtocolMismatch(&'static str),
     ServiceConfigDecode(String, toml::de::Error),
     ServiceConfigNotUtf8(String, str::Utf8Error),
+    SocketCloneError,
     SocketSetReadTimeout(io::Error),
     SocketSetWriteTimeout(io::Error),
-    SocketCloneError,
     ZmqConnectError(zmq::Error),
     ZmqSendError(zmq::Error),
 }
@@ -82,13 +82,13 @@ impl fmt::Display for Error {
             Error::ServiceConfigNotUtf8(ref sg, ref err) => {
                 format!("Cannot read service configuration: group={}, {}", sg, err)
             }
+            Error::SocketCloneError => format!("Cannot clone the underlying UDP socket"),
             Error::SocketSetReadTimeout(ref err) => {
                 format!("Cannot set UDP socket read timeout: {}", err)
             }
             Error::SocketSetWriteTimeout(ref err) => {
                 format!("Cannot set UDP socket write timeout: {}", err)
             }
-            Error::SocketCloneError => format!("Cannot clone the underlying UDP socket"),
             Error::ZmqConnectError(ref err) => format!("Cannot connect ZMQ socket: {}", err),
             Error::ZmqSendError(ref err) => {
                 format!("Cannot send message through ZMQ socket: {}", err)
@@ -116,9 +116,9 @@ impl error::Error for Error {
             }
             Error::ServiceConfigDecode(_, _) => "Cannot decode service config into TOML",
             Error::ServiceConfigNotUtf8(_, _) => "Cannot read service config bytes to UTF-8",
+            Error::SocketCloneError => "Cannot clone the underlying UDP socket",
             Error::SocketSetReadTimeout(_) => "Cannot set UDP socket read timeout",
             Error::SocketSetWriteTimeout(_) => "Cannot set UDP socket write timeout",
-            Error::SocketCloneError => "Cannot clone the underlying UDP socket",
             Error::ZmqConnectError(_) => "Cannot connect ZMQ socket",
             Error::ZmqSendError(_) => "Cannot send message through ZMQ socket",
         }

--- a/components/butterfly/src/error.rs
+++ b/components/butterfly/src/error.rs
@@ -15,6 +15,7 @@
 use std::error;
 use std::fmt;
 use std::io;
+use std::num;
 use std::path::PathBuf;
 use std::result;
 use std::str;
@@ -35,6 +36,8 @@ pub enum Error {
     DecodeError(prost::DecodeError),
     EncodeError(prost::EncodeError),
     HabitatCore(habitat_core::error::Error),
+    IncarnationIO(PathBuf, io::Error),
+    IncarnationParse(PathBuf, num::ParseIntError),
     NonExistentRumor(String, String),
     ProtocolMismatch(&'static str),
     ServiceConfigDecode(String, toml::de::Error),
@@ -68,6 +71,16 @@ impl fmt::Display for Error {
             Error::DecodeError(ref err) => format!("Failed to decode protocol message: {}", err),
             Error::EncodeError(ref err) => format!("Failed to encode protocol message: {}", err),
             Error::HabitatCore(ref err) => format!("{}", err),
+            Error::IncarnationIO(ref path, ref err) => format!(
+                "Error reading or writing incarnation store file {}: {}",
+                path.display(),
+                err
+            ),
+            Error::IncarnationParse(ref path, ref err) => format!(
+                "Error parsing value from incarnation store file {}: {}",
+                path.display(),
+                err
+            ),
             Error::NonExistentRumor(ref member_id, ref rumor_id) => format!(
                 "Non existent rumor asked to be written to bytes: {} {}",
                 member_id, rumor_id
@@ -108,6 +121,8 @@ impl error::Error for Error {
             Error::DecodeError(ref err) => err.description(),
             Error::EncodeError(ref err) => err.description(),
             Error::HabitatCore(_) => "Habitat core error",
+            Error::IncarnationIO(_, _) => "Error reading or writing incarnation store file",
+            Error::IncarnationParse(_, _) => "Error parsing value from incarnation store file",
             Error::NonExistentRumor(_, _) => {
                 "Cannot write rumor to bytes because it does not exist"
             }

--- a/components/butterfly/src/error.rs
+++ b/components/butterfly/src/error.rs
@@ -38,6 +38,7 @@ pub enum Error {
     HabitatCore(habitat_core::error::Error),
     IncarnationIO(PathBuf, io::Error),
     IncarnationParse(PathBuf, num::ParseIntError),
+    InvalidIncarnationSynchronization,
     NonExistentRumor(String, String),
     ProtocolMismatch(&'static str),
     ServiceConfigDecode(String, toml::de::Error),
@@ -81,6 +82,9 @@ impl fmt::Display for Error {
                 path.display(),
                 err
             ),
+            Error::InvalidIncarnationSynchronization => format!(
+                "Tried to synchronize own member incarnation from non-existent incarnation store"
+            ),
             Error::NonExistentRumor(ref member_id, ref rumor_id) => format!(
                 "Non existent rumor asked to be written to bytes: {} {}",
                 member_id, rumor_id
@@ -123,6 +127,9 @@ impl error::Error for Error {
             Error::HabitatCore(_) => "Habitat core error",
             Error::IncarnationIO(_, _) => "Error reading or writing incarnation store file",
             Error::IncarnationParse(_, _) => "Error parsing value from incarnation store file",
+            Error::InvalidIncarnationSynchronization => {
+                "Tried to synchronize own member incarnation from non-existent incarnation store"
+            }
             Error::NonExistentRumor(_, _) => {
                 "Cannot write rumor to bytes because it does not exist"
             }

--- a/components/butterfly/src/lib.rs
+++ b/components/butterfly/src/lib.rs
@@ -58,6 +58,8 @@ extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 #[cfg(test)]
+extern crate mktemp;
+#[cfg(test)]
 extern crate tempdir;
 extern crate time;
 extern crate toml;

--- a/components/butterfly/src/member.rs
+++ b/components/butterfly/src/member.rs
@@ -36,6 +36,9 @@ use rumor::{RumorKey, RumorPayload, RumorType};
 /// How many nodes do we target when we need to run PingReq.
 const PINGREQ_TARGETS: usize = 5;
 
+// TODO (CM): Consider making Incarnation a real type.
+pub const DEFAULT_INCARNATION: u64 = 0;
+
 // This is a Uuid type turned to a string
 pub type UuidSimple = String;
 
@@ -74,7 +77,7 @@ impl Default for Member {
     fn default() -> Self {
         Member {
             id: Uuid::new_v4().to_simple_ref().to_string(),
-            incarnation: 0,
+            incarnation: DEFAULT_INCARNATION,
             // TODO (CM): DANGER DANGER DANGER
             // This is a lousy default, and suggests that the notion
             // of a "default Member" doesn't make much sense.

--- a/components/butterfly/src/server/incarnation_store.rs
+++ b/components/butterfly/src/server/incarnation_store.rs
@@ -1,0 +1,204 @@
+// Copyright (c) 2018 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Provide the means to persist a Supervisor's own incarnation
+//! number across restarts.
+
+use std::fs::{self, File};
+use std::io::{BufWriter, Read, Write};
+use std::path::PathBuf;
+
+use error::{Error, Result};
+use member::DEFAULT_INCARNATION;
+use std::io;
+use std::num;
+
+/// Provide storage of an incarnation number that can persist across
+/// Supervisor restarts.
+#[derive(Clone, Debug)]
+pub struct IncarnationStore {
+    path: PathBuf,
+}
+
+impl From<PathBuf> for IncarnationStore {
+    fn from(path: PathBuf) -> Self {
+        IncarnationStore { path: path }
+    }
+}
+
+impl IncarnationStore {
+    /// Ensure that the `IncarnationStore` is backed by a suitable
+    /// file on disk. If the file does not already exist, create it
+    /// with an initial incarnation number of 0. If the file does
+    /// exist, an error will be returned if the contents cannot be
+    /// parsed.
+    ///
+    /// Returns the incarnation that is currently stored in the
+    /// backing file (even if we just created it, in which case we
+    /// return `0`).
+    pub fn initialize(&self) -> Result<u64> {
+        if !self.path.exists() {
+            let initial_value = DEFAULT_INCARNATION;
+            self.store(initial_value)?;
+            // TODO (CM): set appropriate file permissions here
+            Ok(initial_value)
+        } else {
+            self.retrieve()
+        }
+    }
+
+    /// Returns the incarnation value found within the file.
+    ///
+    /// Returns an error if the file cannot be read or parsed for any
+    /// reason.
+    pub fn retrieve(&self) -> Result<u64> {
+        File::open(&self.path)
+            .map_err(|e: io::Error| Error::IncarnationIO(self.path.clone(), e))
+            .and_then(|mut file| {
+                let mut incarnation = String::new();
+                file.read_to_string(&mut incarnation)
+                    .map_err(|e: io::Error| Error::IncarnationIO(self.path.clone(), e))
+                    .and_then(|_| {
+                        incarnation.trim().parse().map_err(|e: num::ParseIntError| {
+                            Error::IncarnationParse(self.path.clone(), e)
+                        })
+                    })
+            })
+    }
+
+    /// Store the given `new_incarnation` to disk.
+    pub fn store(&self, new_incarnation: u64) -> Result<()> {
+        let tmp = self.path.with_extension("tmp");
+        let f =
+            File::create(&tmp).map_err(|e: io::Error| Error::IncarnationIO(self.path.clone(), e))?;
+        let mut buf = BufWriter::new(f);
+        buf.write(new_incarnation.to_string().as_bytes())
+            .map_err(|e: io::Error| Error::IncarnationIO(self.path.clone(), e))?;
+        buf.flush()
+            .map_err(|e: io::Error| Error::IncarnationIO(self.path.clone(), e))?;
+        fs::rename(&tmp, &self.path)
+            .map_err(|e: io::Error| Error::IncarnationIO(self.path.clone(), e))?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mktemp::Temp;
+    use std::path::Path;
+
+    #[test]
+    fn happy_path() {
+        let dir = Temp::new_dir().expect("Could not create temp dir");
+        let path = dir.to_path_buf().join("my_incarnation_store");
+        assert!(!path.exists());
+
+        let incarnation_store = IncarnationStore::from(path);
+        let initial_value = incarnation_store
+            .initialize()
+            .expect("couldn't initialize incarnation store");
+        assert_eq!(initial_value, DEFAULT_INCARNATION);
+
+        incarnation_store.store(100).expect("Couldn't store value");
+        let i = incarnation_store
+            .retrieve()
+            .expect("Couldn't retrieve value");
+        assert_eq!(i, 100);
+    }
+
+    #[test]
+    fn retrieving_from_a_nonexistent_file_is_an_error() {
+        let path = Path::new("/omg/wtf/this-is-not-a-real-file");
+        assert!(
+            !path.exists(),
+            "The path {:?} shouldn't exist, but it does",
+            path
+        );
+
+        let i: IncarnationStore = path.to_path_buf().into();
+        assert!(i.retrieve().is_err());
+    }
+
+    #[test]
+    fn unparseable_incarnation_file_is_an_error() {
+        let tmpfile = Temp::new_file().expect("Could not create temp file");
+        let path = tmpfile.to_path_buf();
+        let mut buffer = File::create(&path).expect("could not create file");
+        buffer
+            .write_all(b"this is not a u64")
+            .expect("could not write file");
+
+        let i: IncarnationStore = path.into();
+        assert!(i.retrieve().is_err());
+    }
+
+    #[test]
+    fn can_retrieve_valid_values_from_disk() {
+        let tmpfile = Temp::new_file().expect("Could not create temp file");
+        let path = tmpfile.to_path_buf();
+
+        let mut buffer = File::create(&path).expect("could not create file");
+        buffer.write_all(b"42").expect("could not write file");
+
+        let i: IncarnationStore = path.into();
+        assert_eq!(i.retrieve().unwrap(), 42);
+    }
+
+    #[test]
+    fn can_store_a_new_incarnation_number() {
+        let tmpfile = Temp::new_file().expect("Could not create temp file");
+        let path = tmpfile.to_path_buf();
+
+        let i: IncarnationStore = path.into();
+        i.store(2112).expect("Should be able to store the number");
+
+        assert_eq!(i.retrieve().unwrap(), 2112);
+    }
+
+    #[test]
+    fn initialize_creates_file_with_the_default_incarnation_if_file_does_not_exist() {
+        let dir = Temp::new_dir().expect("Could not create temp dir");
+
+        let path = dir.to_path_buf().join("my_incarnation_store");
+        assert!(!path.exists());
+
+        let i: IncarnationStore = path.clone().into();
+        let initial_value = i
+            .initialize()
+            .expect("`initialize` should return the initial value");
+
+        assert!(
+            path.exists(),
+            "The incarnation file should have been created by calling `initialize`"
+        );
+
+        assert_eq!(initial_value, DEFAULT_INCARNATION);
+    }
+
+    #[test]
+    fn initialize_returns_an_error_if_file_exists_but_is_unparseable() {
+        let tmpfile = Temp::new_file().expect("Could not create temp file");
+        let path = tmpfile.to_path_buf();
+        let mut buffer = File::create(&path).expect("could not create file");
+        buffer
+            .write_all(b"this, also, is not a u64")
+            .expect("could not write file");
+
+        assert!(path.exists());
+
+        let i: IncarnationStore = path.into();
+        assert!(i.initialize().is_err());
+    }
+}

--- a/components/butterfly/src/server/mod.rs
+++ b/components/butterfly/src/server/mod.rs
@@ -88,6 +88,19 @@ impl AsRef<Member> for Myself {
     }
 }
 
+// This is ONLY provided for some tests that depend on being able to
+// mutate the member. Ideally, the only think that should be mutable,
+// once you actually have a fully set-up Butterfly server, is the
+// incarnation number, which is accounted for in
+// `Myself::increment_incarnation`.
+//
+// Once the tests are refactored, this implementation should go away.
+impl AsMut<Member> for Myself {
+    fn as_mut(&mut self) -> &mut Member {
+        &mut self.0
+    }
+}
+
 impl Myself {
     /// Increments the incarnation by 1. A `Member`'s incarnation
     /// number can *only* be incremented by itself.

--- a/components/butterfly/src/server/mod.rs
+++ b/components/butterfly/src/server/mod.rs
@@ -85,12 +85,6 @@ pub struct Myself {
     incarnation_store: Option<incarnation_store::IncarnationStore>,
 }
 
-impl AsRef<Member> for Myself {
-    fn as_ref(&self) -> &Member {
-        &self.member
-    }
-}
-
 // This is ONLY provided for some tests that depend on being able to
 // mutate the member. Ideally, the only think that should be mutable,
 // once you actually have a fully set-up Butterfly server, is the
@@ -165,6 +159,11 @@ impl Myself {
 
     pub fn mark_departed(&mut self) {
         self.member.departed = true
+    }
+
+    /// Return a copy of the underlying `Member`.
+    pub fn as_member(&self) -> Member {
+        self.member.clone()
     }
 }
 

--- a/components/butterfly/src/server/mod.rs
+++ b/components/butterfly/src/server/mod.rs
@@ -85,19 +85,6 @@ pub struct Myself {
     incarnation_store: Option<incarnation_store::IncarnationStore>,
 }
 
-// This is ONLY provided for some tests that depend on being able to
-// mutate the member. Ideally, the only think that should be mutable,
-// once you actually have a fully set-up Butterfly server, is the
-// incarnation number, which is accounted for in
-// `Myself::increment_incarnation`.
-//
-// Once the tests are refactored, this implementation should go away.
-impl AsMut<Member> for Myself {
-    fn as_mut(&mut self) -> &mut Member {
-        &mut self.member
-    }
-}
-
 impl Myself {
     /// Create a new `Myself` for the given `Member`. If `store_dir`
     /// is provided, a file named `INCARNATION` will be created in
@@ -164,6 +151,15 @@ impl Myself {
     /// Return a copy of the underlying `Member`.
     pub fn as_member(&self) -> Member {
         self.member.clone()
+    }
+
+    // This is ONLY provided for some tests that depend on being able to
+    // mutate the member. Ideally, the only think that should be mutable,
+    // once you actually have a fully set-up Butterfly server, is the
+    // incarnation number, which is accounted for in
+    // `Myself::increment_incarnation`.
+    pub fn set_persistent(&mut self) {
+        self.member.persistent = true;
     }
 }
 

--- a/components/butterfly/src/server/outbound.rs
+++ b/components/butterfly/src/server/outbound.rs
@@ -115,15 +115,7 @@ impl Outbound {
 
             let long_wait = self.timing.next_protocol_period();
 
-            let check_list = self.server.member_list.check_list(
-                &self
-                    .server
-                    .member
-                    .read()
-                    .expect("Member is poisoned")
-                    .as_ref()
-                    .id,
-            );
+            let check_list = self.server.member_list.check_list(&self.server.member_id);
 
             for member in check_list {
                 if self.server.member_list.pingable(&member) {
@@ -290,7 +282,7 @@ pub fn populate_membership_rumors(server: &Server, target: &Member, swim: &mut S
 pub fn pingreq(server: &Server, socket: &UdpSocket, pingreq_target: &Member, target: &Member) {
     let pingreq = PingReq {
         membership: vec![],
-        from: server.member.read().unwrap().as_ref().clone(),
+        from: server.member.read().unwrap().as_member(),
         target: target.clone(),
     };
     let mut swim: Swim = pingreq.into();
@@ -351,7 +343,7 @@ pub fn ping(
     };
     let ping = Ping {
         membership: vec![],
-        from: server.member.read().unwrap().as_ref().clone(),
+        from: server.member.read().unwrap().as_member(),
         forward_to: forward_to,
     };
     let mut swim: Swim = ping.into();
@@ -424,7 +416,7 @@ pub fn ack(
 ) {
     let ack = Ack {
         membership: vec![],
-        from: server.member.read().unwrap().as_ref().clone(),
+        from: server.member.read().unwrap().as_member(),
         forward_to: forward_to.map(Into::into),
     };
     let member_id = ack.from.id.clone();

--- a/components/butterfly/src/server/outbound.rs
+++ b/components/butterfly/src/server/outbound.rs
@@ -115,10 +115,15 @@ impl Outbound {
 
             let long_wait = self.timing.next_protocol_period();
 
-            let check_list = self
-                .server
-                .member_list
-                .check_list(&self.server.member.read().expect("Member is poisoned").id);
+            let check_list = self.server.member_list.check_list(
+                &self
+                    .server
+                    .member
+                    .read()
+                    .expect("Member is poisoned")
+                    .as_ref()
+                    .id,
+            );
 
             for member in check_list {
                 if self.server.member_list.pingable(&member) {
@@ -285,7 +290,7 @@ pub fn populate_membership_rumors(server: &Server, target: &Member, swim: &mut S
 pub fn pingreq(server: &Server, socket: &UdpSocket, pingreq_target: &Member, target: &Member) {
     let pingreq = PingReq {
         membership: vec![],
-        from: server.member.read().unwrap().clone(),
+        from: server.member.read().unwrap().as_ref().clone(),
         target: target.clone(),
     };
     let mut swim: Swim = pingreq.into();
@@ -346,7 +351,7 @@ pub fn ping(
     };
     let ping = Ping {
         membership: vec![],
-        from: server.member.read().unwrap().clone(),
+        from: server.member.read().unwrap().as_ref().clone(),
         forward_to: forward_to,
     };
     let mut swim: Swim = ping.into();
@@ -419,7 +424,7 @@ pub fn ack(
 ) {
     let ack = Ack {
         membership: vec![],
-        from: server.member.read().unwrap().clone(),
+        from: server.member.read().unwrap().as_ref().clone(),
         forward_to: forward_to.map(Into::into),
     };
     let member_id = ack.from.id.clone();

--- a/components/butterfly/tests/integration.rs
+++ b/components/butterfly/tests/integration.rs
@@ -111,11 +111,13 @@ fn six_members_unmeshed_partition_and_rejoin_persistent_peers() {
         .member
         .write()
         .expect("Member lock is poisoned")
+        .as_mut()
         .persistent = true;
     net[4]
         .member
         .write()
         .expect("Member lock is poisoned")
+        .as_mut()
         .persistent = true;
     net.connect(0, 1);
     net.connect(1, 2);

--- a/components/butterfly/tests/integration.rs
+++ b/components/butterfly/tests/integration.rs
@@ -111,14 +111,12 @@ fn six_members_unmeshed_partition_and_rejoin_persistent_peers() {
         .member
         .write()
         .expect("Member lock is poisoned")
-        .as_mut()
-        .persistent = true;
+        .set_persistent();
     net[4]
         .member
         .write()
         .expect("Member lock is poisoned")
-        .as_mut()
-        .persistent = true;
+        .set_persistent();
     net.connect(0, 1);
     net.connect(1, 2);
     net.connect(2, 3);

--- a/components/butterfly/tests/rumor/election.rs
+++ b/components/butterfly/tests/rumor/election.rs
@@ -144,11 +144,13 @@ fn five_members_elect_a_new_leader_when_they_are_quorum_partitioned() {
         .member
         .write()
         .expect("Member lock is poisoned")
+        .as_mut()
         .persistent = true;
     net[4]
         .member
         .write()
         .expect("Member lock is poisoned")
+        .as_mut()
         .persistent = true;
     net.add_service(0, "core/witcher/1.2.3/20161208121212");
     net.add_service(1, "core/witcher/1.2.3/20161208121212");

--- a/components/butterfly/tests/rumor/election.rs
+++ b/components/butterfly/tests/rumor/election.rs
@@ -144,14 +144,12 @@ fn five_members_elect_a_new_leader_when_they_are_quorum_partitioned() {
         .member
         .write()
         .expect("Member lock is poisoned")
-        .as_mut()
-        .persistent = true;
+        .set_persistent();
     net[4]
         .member
         .write()
         .expect("Member lock is poisoned")
-        .as_mut()
-        .persistent = true;
+        .set_persistent();
     net.add_service(0, "core/witcher/1.2.3/20161208121212");
     net.add_service(1, "core/witcher/1.2.3/20161208121212");
     net.add_service(2, "core/witcher/1.2.3/20161208121212");

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -411,6 +411,11 @@ impl Manager {
     ///
     /// The mutable ref to `Sys` will be configured with Butterfly Member details and will also
     /// populate the initial Member.
+    // TODO (CM): This functionality can / should be pulled into
+    // Butterfly itself; we're already setting the incarnation number
+    // in there, so splitting the initialization is needlessly
+    // confusing. It's also blurs the lines between the manager and
+    // Butterfly.
     fn load_member(sys: &mut Sys, fs_cfg: &FsCfg) -> Result<Member> {
         let mut member = Member::default();
         match File::open(&fs_cfg.member_id_file) {


### PR DESCRIPTION
We should persist incarnation numbers across restarts! Now we can!

Read the commit messages for further details.

Partially addresses #5581