### PR TITLE
Add documentation team to habitat repo maintainers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -44,5 +44,5 @@ components/sup/src/command @apriofrost
 components/sup* @christophermaier @reset @fnichol @baumanj @raskchanky
 support @fnichol @baumanj @elliott-davis @raskchanky
 tools @baumanj @chefsalim @christophermaier @eeyun @raskchanky @fnichol
-www @cnunciato @mgamini @raskchanky
+www @cnunciato @mgamini @raskchanky @kagarmoe @mjingle
 UX_PRINCIPLES.md @apriofrost

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -86,7 +86,7 @@ tutorials and reference materials.
 
 #### Lieutenant
 
-* [Nick Brewer](https://github.com/brewn)
+* [Garrett Amini](https://github.com/mgamini)
 
 #### Maintainers
 
@@ -99,6 +99,8 @@ tutorials and reference materials.
 * [Nell Shamrell-Harrington](https://github.com/nellshamrell)
 * [Robb Kidd](https://github.com/robbkidd)
 * [Tasha Drew](https://github.com/tashimi)
+* [Kimberly Garmoe](https://github.com/kagarmoe)
+* [Mary Jinglewski](https://github.com/mjingle)
 
 ### Core Plans
 


### PR DESCRIPTION
Signed-off-by: Scott Hain <shain@chef.io>