### PR TITLE
Stop manually manipulating the PATH in bintray-publish package

### DIFF
--- a/components/bintray-publish/bin/publish-hab.sh
+++ b/components/bintray-publish/bin/publish-hab.sh
@@ -333,8 +333,6 @@ EOF
 
 BINTRAY_ORG=habitat
 BINTRAY_REPO=stable
-# shellcheck disable=2123
-PATH=@path@
 
 # The current version of this program
 version='@version@'

--- a/components/bintray-publish/plan.sh
+++ b/components/bintray-publish/plan.sh
@@ -26,7 +26,6 @@ do_build() {
     sed \
       -e "s,#!/bin/bash$,#!$(pkg_path_for bash)/bin/bash," \
       -e "s,@author@,$pkg_maintainer,g" \
-      -e "s,@path@,$pkg_prefix/bin:$run_path,g" \
       -e "s,@version@,$pkg_version/$pkg_release,g" \
       -i "${CACHE_PATH}/publish-hab"
 }


### PR DESCRIPTION
This package was initially built long ago, before `hab pkg exec` would
manage your `PATH`  contents based on `pkg_deps` on your  behalf. As a
result, this package did that by hand.

The recent removal of studio image uploading from this package (#5560)
removed a portion of this `PATH` management, but inadvertently left
part behind. As a result, the script was overwriting the correct,
`hab`-managed `PATH` with an incomplete one from package build
time. This manifested as an inability to find the `basename` command.

This commit completes the removal of the custom `PATH` management
code, letting `hab pkg exec` do all the heavy lifting for us.

Signed-off-by: Christopher Maier <cmaier@chef.io>