### PR TITLE
provide env var o appveyor can force build studio reuse

### DIFF
--- a/components/studio/bin/hab-studio.ps1
+++ b/components/studio/bin/hab-studio.ps1
@@ -390,7 +390,7 @@ function Invoke-StudioBuild($location, $reuse) {
     Write-BuildHelp
     return
   }
-  if(!$reuse) { Remove-Studio}
+  if(!$reuse -and !$env:HAB_WINDOWS_STUDIO_REUSE) { Remove-Studio}
 
   New-Studio
   Write-HabInfo "Building '$location' in Studio at $HAB_STUDIO_ROOT"

--- a/support/ci/appveyor.ps1
+++ b/support/ci/appveyor.ps1
@@ -94,7 +94,7 @@ if (($env:APPVEYOR_REPO_TAG_NAME -eq $version) -or (Test-SourceChanged) -or (tes
 
             # This will override plan's CARGO_TARGET_DIR so we do not have to build each clean
             $env:HAB_CARGO_TARGET_DIR = "$(Get-RepoRoot)\target"
-
+            $env:HAB_WINDOWS_STUDIO_REUSE = $true
             $env:HAB_ORIGIN="core"
             if($env:ORIGIN_KEY) {
                 "SIG-SEC-1`ncore-20170318210306`n`n$($env:ORIGIN_KEY)" | & $habExe origin key import
@@ -110,6 +110,11 @@ if (($env:APPVEYOR_REPO_TAG_NAME -eq $version) -or (Test-SourceChanged) -or (tes
                 Write-Host "Building plan for $component"
                 Write-Host ""
                 if($(& $habExe --version) -lt "hab 0.63") {
+                    # THIS SHOULD BE DELETED AFTER 0.63 RELEASE
+                    # We MUST build with the new studio so copy
+                    # master to the one we just got from stable
+                    & $habExe pkg install core/hab-studio
+                    Copy-Item "$(Get-RepoRoot)\components\studio\bin\hab-studio.ps1" (Resolve-Path /hab/pkgs/core/hab-studio/*/*/bin)[-1]
                     & $habExe pkg build components/$component -w
                 } else {
                     & $habExe pkg build components/$component -w -R


### PR DESCRIPTION
This is a horrible horrible PR.

In 0.61.0 and prior, a local windows studio always passed `-R` to reuse the studio. This is actually desirable for appveyor. As components are being built, we order them so that if one component depends on another habitat component, it will use the one that was built in this same studio. That is only possible if we reuse the studio. Otherwise, each build will destroy the studio and whatever component was built before is gone.

0.62.0 included a change that fixed an ssue on the linux rootless studio but stopped passing `-R` to a local windows studio.

0.63.0 has a final fx that will pass `-R` if it was passed on the cli in windows. It also changed the appveyor script to pass `-R` if it's hab binary was 0.63.0 or higher. Unfortunately because we build with the latest stable version 0.62.1, we cannot pass `-R`. So the studio s destroyed on each build and when a new studio is built, it retrieves hab from `--stable` which is not the one we want.

So this hack gives us a back door in the appveyor build to reuse the studio. We should remove this after the release.

Signed-off-by: mwrock <matt@mattwrock.com>