### PR TITLE
do not install and upload launcher in release builds

### DIFF
--- a/support/ci/appveyor.ps1
+++ b/support/ci/appveyor.ps1
@@ -114,12 +114,14 @@ if (($env:APPVEYOR_REPO_TAG_NAME -eq $version) -or (Test-SourceChanged) -or (tes
                 $hart = (Get-Item "$(Get-RepoRoot)\components\$component\results\*.hart")[-1]
                 Write-Host "Copying $hart to artifacts directory..."
                 Copy-Item $hart.FullName results
-                & $habExe pkg install $hart.FullName
-                if ($LASTEXITCODE -ne 0) {exit $LASTEXITCODE}
-
-                if($env:HAB_AUTH_TOKEN -and (!(Test-PullRequest))) {
-                    & $habExe pkg upload $hart --channel $channel
+                if(!(Test-ReleaseBuild -and $env:hab_components -eq "launcher")) {
+                    & $habExe pkg install $hart.FullName
                     if ($LASTEXITCODE -ne 0) {exit $LASTEXITCODE}
+    
+                    if($env:HAB_AUTH_TOKEN -and (!(Test-PullRequest))) {
+                        & $habExe pkg upload $hart --channel $channel
+                        if ($LASTEXITCODE -ne 0) {exit $LASTEXITCODE}
+                    }
                 }
 
                 # Install and extract hab cli bin files for zip


### PR DESCRIPTION
I have narrowed down the launcher build failures on appveyor to release builds. It only fails on release builds and I HAVE NO IDEA WHY. This will turn off the install/upload whic fails and allow the build to succeed. This should allow me to download the built hart file that claims to have no target file.

Since this only seems to happen during release builds, I'll just make sure to examine this on the next release.

Note: that we don't actually need a uploaded launcher during release builds so this should have no adverse effect.

Signed-off-by: mwrock <matt@mattwrock.com>