### PR TITLE
Fail build if CR+LF endings exist in hooks

### DIFF
--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -1773,7 +1773,8 @@ _verify_hook_line_endings() {
     e="Incorrect CR+LF line ending detected in package hook file(s)."
     e="$e For the Plan to build, you must first convert these to Unix LF."
     e="$e See https://en.wikipedia.org/wiki/Newline#Conversion_between_newline_formats"
-    e="$e\n$files"
+    e="$e
+$files"
     exit_with "$e" 1
   fi
 }

--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -1764,6 +1764,19 @@ _verify_vars() {
   _verify_vars=true
 }
 
+# **Internal** Verifies that hook files do not contain invalid (CR+LF) line endings
+# and fails the build if any are found.
+_verify_hook_line_endings() {
+  find "$PLAN_CONTEXT/hooks" -type f | while read -r file; do
+    if file "$file" | grep -q CRLF; then
+      local e
+      e="Incorrect CR+LF line ending(s) in $file"
+      e="$e Please convert to Unix LF. https://en.wikipedia.org/wiki/Newline#Conversion_between_newline_formats"
+      exit_with "$e" 1
+    fi
+  done
+}
+
 # This function simply makes sure that the working directory for the prepare
 # step is correct, that is inside the extracted source directory.
 do_prepare_wrapper() {
@@ -2568,6 +2581,9 @@ case "${pkg_type}" in
 
         # Make sure all required variables are set
         _verify_vars
+
+        # Check for invalid (CRLF) line endings in hooks
+        _verify_hook_line_endings
 
         # Prepare the source
         do_prepare_wrapper

--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -1767,10 +1767,13 @@ _verify_vars() {
 # **Internal** Verifies that hook files do not contain invalid (CR+LF) line endings
 # and fails the build if any are found.
 _verify_hook_line_endings() {
-  if grep --files-with-matches $'\r' "$PLAN_CONTEXT"/hooks/* 2>/dev/null; then
+  local files
+  if files=$(grep --files-with-matches $'\r' "$PLAN_CONTEXT"/hooks/* 2>/dev/null); then
     local e
-    e="Incorrect CR+LF line ending detected in the above file(s)."
-    e="$e For the Plan to build, you must first convert these to Unix LF. https://en.wikipedia.org/wiki/Newline#Conversion_between_newline_formats"
+    e="Incorrect CR+LF line ending detected in package hook file(s)."
+    e="$e For the Plan to build, you must first convert these to Unix LF."
+    e="$e See https://en.wikipedia.org/wiki/Newline#Conversion_between_newline_formats"
+    e="$e\n$files"
     exit_with "$e" 1
   fi
 }

--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -1769,12 +1769,10 @@ _verify_vars() {
 _verify_hook_line_endings() {
   local files
   if files=$(grep --files-with-matches $'\r' "$PLAN_CONTEXT"/hooks/* 2>/dev/null); then
-    local e
-    e="Incorrect CR+LF line ending detected in package hook file(s)."
+    local e="Incorrect CR+LF line ending detected in package hook file(s)."
     e="$e For the Plan to build, you must first convert these to Unix LF."
     e="$e See https://en.wikipedia.org/wiki/Newline#Conversion_between_newline_formats"
-    e="$e
-$files"
+    e=$(printf "%s\n%s" "$e" "$files")
     exit_with "$e" 1
   fi
 }

--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -2582,7 +2582,7 @@ case "${pkg_type}" in
         # Make sure all required variables are set
         _verify_vars
 
-        # Check for invalid (CRLF) line endings in hooks
+        # Check for invalid (CR+LF) line endings in hooks
         _verify_hook_line_endings
 
         # Prepare the source

--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -1767,7 +1767,7 @@ _verify_vars() {
 # **Internal** Verifies that hook files do not contain invalid (CR+LF) line endings
 # and fails the build if any are found.
 _verify_hook_line_endings() {
-  if grep --files-with-matches $'\r' "$PLAN_CONTEXT"/hooks/*; then
+  if grep --files-with-matches $'\r' "$PLAN_CONTEXT"/hooks/* 2>/dev/null; then
     local e
     e="Incorrect CR+LF line ending detected in the above file(s)."
     e="$e For the Plan to build, you must first convert these to Unix LF. https://en.wikipedia.org/wiki/Newline#Conversion_between_newline_formats"

--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -1767,14 +1767,12 @@ _verify_vars() {
 # **Internal** Verifies that hook files do not contain invalid (CR+LF) line endings
 # and fails the build if any are found.
 _verify_hook_line_endings() {
-  find "$PLAN_CONTEXT/hooks" -type f | while read -r file; do
-    if file "$file" | grep -q CRLF; then
-      local e
-      e="Incorrect CR+LF line ending(s) in $file"
-      e="$e Please convert to Unix LF. https://en.wikipedia.org/wiki/Newline#Conversion_between_newline_formats"
-      exit_with "$e" 1
-    fi
-  done
+  if grep --files-with-matches $'\r' "$PLAN_CONTEXT"/hooks/*; then
+    local e
+    e="Incorrect CR+LF line ending detected in the above file(s)."
+    e="$e For the Plan to build, you must first convert these to Unix LF. https://en.wikipedia.org/wiki/Newline#Conversion_between_newline_formats"
+    exit_with "$e" 1
+  fi
 }
 
 # This function simply makes sure that the working directory for the prepare


### PR DESCRIPTION
Resolves https://github.com/habitat-sh/habitat/issues/5004

## Description 🔩 
This change uses the `file` command to determine if any pkg hook
files contain invalid line endings (CR+LF) aka (\r\n).

## Demo 👟 
```
[18][default:/src:1]# file hooks/run
hooks/run: Bourne-Again shell script, ASCII text executable, with CRLF, LF line terminators
[19][default:/src:0]# build
   : Loading /src/plan.sh
   mypkg: Plan loaded
   mypkg: Validating plan metadata
   mypkg: Using HAB_BIN=/hab/pkgs/core/hab/0.63.0/20180914025124/bin/hab for installs, signing, and hashing
   mypkg: hab-plan-build setup
   mypkg: Writing pre_build file
   mypkg: Resolving build dependencies
   mypkg: Resolving run dependencies
   mypkg: Setting up environment
   mypkg: Populating runtime environment from dependencies
   mypkg: Populating buildtime environment from dependencies
   mypkg: Layering runtime environment on top of system environment
   mypkg: Layering buildtime environment on top of system environment
   mypkg: Setting PATH=/hab/pkgs/core/hab-plan-build/0.63.0/20180914030231/bin:/hab/pkgs/core/bash/4.3.42/20170513213519/bin:/hab/pkgs/core/binutils/2.25.1/20170513201927/bin:/hab/pkgs/core/bzip2/1.0.6/20170513212938/bin:/hab/pkgs/core/coreutils/8.25/20170513213226/bin:/hab/pkgs/core/file/5.24/20170513201915/bin:/hab/pkgs/core/findutils/4.4.2/20170513214305/bin:/hab/pkgs/core/gawk/4.1.3/20170513213646/bin:/hab/pkgs/core/grep/2.22/20170513213444/bin:/hab/pkgs/core/gzip/1.6/20170513214605/bin:/hab/pkgs/core/hab/0.63.0/20180914025124/bin:/hab/pkgs/core/rq/0.9.2/20170612005822/bin:/hab/pkgs/core/sed/4.2.2/20170513213123/bin:/hab/pkgs/core/tar/1.29/20170513213607/bin:/hab/pkgs/core/unzip/6.0/20180310001951/bin:/hab/pkgs/core/wget/1.19.1/20171024102323/bin:/hab/pkgs/core/xz/5.2.2/20170513214327/bin:/hab/pkgs/core/glibc/2.22/20170513201042/bin:/hab/pkgs/core/ncurses/6.0/20170513213009/bin:/hab/pkgs/core/acl/2.2.52/20170513213108/bin:/hab/pkgs/core/attr/2.4.47/20170513213059/bin:/hab/pkgs/core/libcap/2.24/20170513213120/bin:/hab/pkgs/core/pcre/8.38/20170513213423/bin:/hab/pkgs/core/less/481/20170513213936/bin:/hab/pkgs/core/libidn/1.32/20170513215043/bin:/hab/pkgs/core/openssl/1.0.2l/20171014213633/bin
   mypkg: Clean the cache
   mypkg: Setting build environment
mkdir: created directory '/hab/cache/src/mypkg-0.1.0'
   mypkg: Setting PREFIX=/hab/pkgs/jeremymv2/mypkg/0.1.0/20180918164918
   mypkg: Setting LD_RUN_PATH=
   mypkg: Setting CFLAGS=
   mypkg: Setting CXXFLAGS=
   mypkg: Setting CPPFLAGS=
   mypkg: Setting LDFLAGS=
   mypkg: Setting PKG_CONFIG_PATH=
   mypkg: ERROR: Incorrect CR+LF line ending(s) in /src/hooks/run Please convert to Unix LF. https://en.wikipedia.org/wiki/Newline#Conversion_between_newline_formats
   mypkg: Build time: 0m0s
   mypkg: Exiting on error
[20][default:/src:1]#
```

Removing the CRLF in the `hooks/run` file above allows the plan to build successfully.



Signed-off-by: Jeremy J. Miller <jm@chef.io>