### PR TITLE
Create /usr/bin when running the studio

### DIFF
--- a/components/rootless_studio/default/entrypoint.sh
+++ b/components/rootless_studio/default/entrypoint.sh
@@ -2,6 +2,7 @@
 
 hab pkg exec core/hab-backline mkdir -m 1777 -p /tmp
 hab pkg exec core/hab-backline mkdir -m 0750 -p /root
+hab pkg exec core/hab-backline mkdir -m 0755 -p /usr/bin
 
 source /etc/habitat-studio/import_keys.sh
 source /etc/habitat-studio/environment.sh


### PR DESCRIPTION
Resolves #5646 
Ref: habitat-sh/core-plans#1857

This may need to move into the image creation if we accumulate any more of these mkdirs,  but I think for now it's ok to do it at runtime. 

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>