### PR TITLE
windows defaults to local studio

### DIFF
--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -686,8 +686,8 @@ fn sub_pkg_build() -> App<'static, 'static> {
         (@arg SRC_PATH: -s --src +takes_value
             "Sets the source path (default: $PWD)")
         (@arg PLAN_CONTEXT: +required +takes_value
-            "A directory containing a `plan.sh` file \
-            or a `habitat/` directory which contains the `plan.sh` file")
+            "A directory containing a plan file \
+            or a `habitat/` directory which contains the plan file")
     );
     // Only a truly native/local Studio can be reused--the Docker implementation will always be
     // ephemeral
@@ -697,22 +697,18 @@ fn sub_pkg_build() -> App<'static, 'static> {
                 .help("Reuses a previous Studio for the build (default: clean up before building)")
                 .short("R")
                 .long("reuse"),
+        ).arg(
+            Arg::with_name("DOCKER")
+                .help("Uses a Dockerized Studio for the build")
+                .short("D")
+                .long("docker"),
         );
     }
 
-    if cfg!(target_os = "linux") {
-        sub.arg(
-            Arg::with_name("DOCKER")
-                .help(
-                    "Uses a Dockerized Studio for the build (default: Studio uses a chroot on \
-                     linux)",
-                ).short("D")
-                .long("docker"),
-        )
-    } else if cfg!(target_os = "windows") {
+    if cfg!(target_os = "windows") {
         sub.arg(
             Arg::with_name("WINDOWS")
-                .help("Use a Windows Studio instead of a Docker Studio")
+                .help("Use a local Windows Studio instead of a Docker Studio")
                 .short("w")
                 .long("windows"),
         )

--- a/components/hab/src/command/pkg/build.rs
+++ b/components/hab/src/command/pkg/build.rs
@@ -50,7 +50,7 @@ pub fn start(
     if cfg!(target_os = "windows") && windows {
         args.push("-w".into());
     }
-    if cfg!(target_os = "linux") && docker {
+    if studio::native_studio_support() && docker {
         args.push("-D".into());
     }
     studio::enter::start(ui, args)

--- a/components/hab/src/command/studio/enter.rs
+++ b/components/hab/src/command/studio/enter.rs
@@ -241,12 +241,20 @@ mod inner {
         }
 
         for arg in args.iter() {
+            let str_arg = arg.to_string_lossy();
+            if str_arg == String::from("-D") {
+                return false;
+            }
+        }
+
+        // -w/--windows is deprecated and should be removed in a post 0.64.0 release
+        for arg in args.iter() {
             let str_arg = arg.to_string_lossy().to_lowercase();
             if str_arg == String::from("--windows") || str_arg == String::from("-w") {
                 return true;
             }
         }
 
-        return false;
+        return true;
     }
 }

--- a/components/studio/bin/hab-studio.ps1
+++ b/components/studio/bin/hab-studio.ps1
@@ -37,6 +37,7 @@ param (
     [switch]$q,
     [switch]$v,
     [switch]$R,
+    [switch]$D,
     [switch]$w,
     [string]$command,
     [string]$commandVal,
@@ -66,7 +67,9 @@ COMMON FLAGS:
     -n  Do not mount the source path into the Studio (default: mount the path)
     -q  Prints less output for better use in scripts
     -v  Prints more verbose output
-    -w  Use a Windows studio instead of a Docker Studio (only available on windows)
+    -D  Use a Docker Studio instead of a native Studio
+DEPRECATED FLAG:
+    -w  Use a local Windows studio instead of a Docker Studio
 
 COMMON OPTIONS:
     -k <HAB_ORIGIN_KEYS>  Installs secret origin keys (default:\$HAB_ORIGIN )
@@ -304,7 +307,7 @@ function Enter-Studio {
       # new windows but thats ok because docker run launched the studio directly
       # from powershell so the ctrl+c issue is not a problem so we can do
       # a simple tail
-      if ((Get-Service -Name cexecsvc -ErrorAction SilentlyContinue) -eq $null) {
+      if (!(Test-InContainer)) {
         Start-Process "$env:STUDIO_SCRIPT_ROOT\powershell\pwsh.exe" -ArgumentList "-Command `"& {Get-Content $env:HAB_STUDIO_ENTER_ROOT\hab\sup\default\out.log -Tail 100 -Wait}`""
       }
       else {
@@ -408,6 +411,10 @@ function Remove-Studio {
   if(Test-Path $HAB_STUDIO_ROOT) { Remove-Item $HAB_STUDIO_ROOT -Recurse -Force }
 }
 
+function Test-InContainer {
+  (Get-Service -Name cexecsvc -ErrorAction SilentlyContinue) -ne $null
+}
+
 $ErrorActionPreference="stop"
 
 # The current version of Habitat Studio
@@ -455,6 +462,16 @@ if($q) { $script:quiet = $true }
 
 $currentVerbose = $VerbosePreference
 if($v) { $VerbosePreference = "Continue" }
+
+if($w) {
+  Write-Warning "The -w argument has been deprecated."
+  Write-Warning "A local Studio is now the default on Windows."
+  Write-Warning "Alternatively you may use the -D argument to use a Docker Studio."
+}
+
+if(!$w -and !(Test-InContainer)) {
+  Write-Warning "Using a local Studio. To use a Docker studio, use the -D argument."
+}
 
 try {
   switch ($command) {

--- a/components/studio/bin/hab-studio.sh
+++ b/components/studio/bin/hab-studio.sh
@@ -84,8 +84,7 @@ COMMON FLAGS:
     -q  Prints less output for better use in scripts
     -v  Prints more verbose output
     -V  Prints version information
-    -D  Use a Docker Studio instead of a chroot Studio (only available on Linux)
-    -w  Use a Windows Studio instead of a Docker Studio (only available on Windows)
+    -D  Use a Docker Studio instead of a chroot Studio
 
 COMMON OPTIONS:
     -a <ARTIFACT_PATH>    Sets the source artifact cache path (default: /hab/cache/artifacts)


### PR DESCRIPTION
Fixes #5464

This makes the local studio the default on Windows. To run a dockerized container, `-D` must be passed. This applies to both `hab studio` and `hab pkg build` commands.

For now, we will still honor `-w` but state that it is deprecated and emit a warning when it is used. We will alo emit a warning when entering the studio without `-w` or `-D` that advises how to enter a dockerized studio (the former default).

Signed-off-by: mwrock <matt@mattwrock.com>