### PR TITLE
Replace deprecated gen_ascii_chars() with sample_iter(&Alphanumeric)

### DIFF
--- a/components/sup/src/manager/service/composite_spec.rs
+++ b/components/sup/src/manager/service/composite_spec.rs
@@ -28,6 +28,7 @@ use hcore::package::{Identifiable, PackageIdent, PackageInstall};
 use hcore::util::{deserialize_using_from_str, serialize_using_to_string};
 
 use error::{Error, Result, SupError};
+use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};
 use toml;
 
@@ -127,9 +128,12 @@ impl CompositeSpec {
             .as_ref()
             .parent()
             .expect("Cannot determine parent directory for composite spec");
-        let tmpfile = path
-            .as_ref()
-            .with_extension(thread_rng().gen_ascii_chars().take(8).collect::<String>());
+        let tmpfile = path.as_ref().with_extension(
+            thread_rng()
+                .sample_iter(&Alphanumeric)
+                .take(8)
+                .collect::<String>(),
+        );
         fs::create_dir_all(dst_path).map_err(|err| {
             sup_error!(Error::ServiceSpecFileIO(path.as_ref().to_path_buf(), err))
         })?;

--- a/components/sup/src/manager/service/spec.rs
+++ b/components/sup/src/manager/service/spec.rs
@@ -28,6 +28,7 @@ use hcore::service::{ApplicationEnvironment, ServiceGroup};
 use hcore::url::DEFAULT_BLDR_URL;
 use hcore::util::{deserialize_using_from_str, serialize_using_to_string};
 use protocol;
+use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};
 use serde::{self, Deserialize};
 use toml;
@@ -315,9 +316,12 @@ impl ServiceSpec {
             .as_ref()
             .parent()
             .expect("Cannot determine parent directory for service spec");
-        let tmpfile = path
-            .as_ref()
-            .with_extension(thread_rng().gen_ascii_chars().take(8).collect::<String>());
+        let tmpfile = path.as_ref().with_extension(
+            thread_rng()
+                .sample_iter(&Alphanumeric)
+                .take(8)
+                .collect::<String>(),
+        );
         fs::create_dir_all(dst_path).map_err(|err| {
             sup_error!(Error::ServiceSpecFileIO(path.as_ref().to_path_buf(), err))
         })?;


### PR DESCRIPTION
This should merge *after* https://github.com/habitat-sh/habitat/pull/5656 to minimize Cargo.lock conflicts.

This obviates https://github.com/habitat-sh/habitat/pull/5598. Upon further thought, the use case isn't really a temporary file (which should be removed), but generating a temporary name.

I'll be partially reverting https://github.com/habitat-sh/habitat/pull/5562 as well and taking this approach.