### PR TITLE
fix local windows studio regressions

### DIFF
--- a/components/studio/bin/hab-studio.ps1
+++ b/components/studio/bin/hab-studio.ps1
@@ -295,6 +295,9 @@ function Enter-Studio {
     function build {
       & "$env:STUDIO_SCRIPT_ROOT\hab-plan-build.ps1" @args
     }
+    function Test-InContainer {
+      (Get-Service -Name cexecsvc -ErrorAction SilentlyContinue) -ne $null
+    }
 
     function Get-SupervisorLog {
       # If we are not running in a container then the powershell studio was

--- a/components/sup/src/util/path.rs
+++ b/components/sup/src/util/path.rs
@@ -19,7 +19,7 @@ use std::io::BufReader;
 use std::path::PathBuf;
 use std::str::FromStr;
 
-use hcore::fs::find_command;
+use hcore::fs::{find_command, FS_ROOT_PATH};
 use hcore::package::{PackageIdent, PackageInstall};
 
 use error::{Error, Result};
@@ -87,14 +87,14 @@ pub fn interpreter_paths() -> Result<Vec<PathBuf>> {
         // We've found the specific release that our Supervisor was built with. Get its path
         // metadata.
         Some(ident) => {
-            let pkg_install = PackageInstall::load(&ident, None)?;
+            let pkg_install = PackageInstall::load(&ident, Some(FS_ROOT_PATH.as_ref()))?;
             pkg_install.paths()?
         }
         // If we're not running out of a package, then see if any package of the interpreter is
         // installed.
         None => {
             let ident = PackageIdent::from_str(INTERPRETER_IDENT)?;
-            match PackageInstall::load(&ident, None) {
+            match PackageInstall::load(&ident, Some(FS_ROOT_PATH.as_ref())) {
                 // We found a version of the interpreter. Get its path metadata.
                 Ok(pkg_install) => pkg_install.paths()?,
                 // Nope, no packages of the interpreter installed. Now we're going to see if the


### PR DESCRIPTION
This fixes 2 local windows studio regressions.

1. This was released in 0.63.0 and fails to find `powershell` when invoking hooks because it is not looking in the `FS_ROOT`. This works in a docker studio, outside the studio or if powershell has been installed outside the studio root. However on a clean machine a local studio will fail to run any hook.
2. Recently commited but not yet released, `Get-SupervisorLog` in a local studio fails because it cannot find the `Test-InContainer` function which is out of scope.

Signed-off-by: mwrock <matt@mattwrock.com>