### PR TITLE
supervisor and svc pkg versions in sup log output

### DIFF
--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -603,14 +603,14 @@ impl Manager {
                         .pkg
                         .ident
                         .version
-                        .clone()
-                        .unwrap_or("UNKNOWN".to_string()),
+                        .as_ref()
+                        .unwrap_or(&"UNKNOWN".to_string()),
                     service
                         .pkg
                         .ident
                         .release
-                        .clone()
-                        .unwrap_or("UNKNOWN".to_string())
+                        .as_ref()
+                        .unwrap_or(&"UNKNOWN".to_string())
                 );
                 service
             }

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -335,7 +335,7 @@ impl Manager {
     fn new(cfg: ManagerConfig, fs_cfg: FsCfg, launcher: LauncherCli) -> Result<Manager> {
         debug!("new(cfg: {:?}, fs_cfg: {:?}", cfg, fs_cfg);
         let current = PackageIdent::from_str(&format!("{}/{}", SUP_PKG_IDENT, VERSION)).unwrap();
-        outputln!("version {}", current);
+        outputln!("{} ({})", SUP_PKG_IDENT, current);
         let cfg_static = cfg.clone();
         let self_updater = if cfg.auto_update {
             if current.fully_qualified() {
@@ -582,7 +582,6 @@ impl Manager {
     }
 
     fn add_service(&mut self, spec: ServiceSpec) {
-        outputln!("Starting {}", &spec.ident);
         // JW TODO: This clone sucks, but our data structures are a bit messy here. What we really
         // want is the service to hold the spec and, on failure, return an error with the spec
         // back to us. Since we consume and deconstruct the spec in `Service::new()` which
@@ -595,23 +594,7 @@ impl Manager {
             self.organization.as_ref().map(|org| &**org),
         ) {
             Ok(service) => {
-                outputln!(
-                    "pkg version {}/{}/{}/{}",
-                    service.pkg.ident.origin,
-                    service.pkg.ident.name,
-                    service
-                        .pkg
-                        .ident
-                        .version
-                        .as_ref()
-                        .unwrap_or(&"UNKNOWN".to_string()),
-                    service
-                        .pkg
-                        .ident
-                        .release
-                        .as_ref()
-                        .unwrap_or(&"UNKNOWN".to_string())
-                );
+                outputln!("Starting {} ({})", &spec.ident, service.pkg.ident);
                 service
             }
             Err(err) => {

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -335,7 +335,7 @@ impl Manager {
     fn new(cfg: ManagerConfig, fs_cfg: FsCfg, launcher: LauncherCli) -> Result<Manager> {
         debug!("new(cfg: {:?}, fs_cfg: {:?}", cfg, fs_cfg);
         let current = PackageIdent::from_str(&format!("{}/{}", SUP_PKG_IDENT, VERSION)).unwrap();
-        debug!("current: {}", current);
+        outputln!("version {}", current);
         let cfg_static = cfg.clone();
         let self_updater = if cfg.auto_update {
             if current.fully_qualified() {
@@ -594,7 +594,26 @@ impl Manager {
             self.fs_cfg.clone(),
             self.organization.as_ref().map(|org| &**org),
         ) {
-            Ok(service) => service,
+            Ok(service) => {
+                outputln!(
+                    "pkg version {}/{}/{}/{}",
+                    service.pkg.ident.origin,
+                    service.pkg.ident.name,
+                    service
+                        .pkg
+                        .ident
+                        .version
+                        .clone()
+                        .unwrap_or("UNKNOWN".to_string()),
+                    service
+                        .pkg
+                        .ident
+                        .release
+                        .clone()
+                        .unwrap_or("UNKNOWN".to_string())
+                );
+                service
+            }
             Err(err) => {
                 outputln!("Unable to start {}, {}", &spec.ident, err);
                 return;


### PR DESCRIPTION
This change is targeted to humans reading Habitat Supervisor
logs whom wish to know the precise version of the Supervisor
and the Services that are managed.

```
17:48 $ sudo -E ./target/debug/hab sup run &
[1] 16618
hab-sup(MR): version core/hab-sup/0.64.0-dev <--
hab-sup(MR): Supervisor Member-ID 7807eb11c928433caffa0d04c8ae8a13
hab-sup(MR): Starting chef/automate-elasticsearch
hab-sup(MR): pkg version chef/automate-elasticsearch/6.2.2/20180527141927 <--
automate-elasticsearch.default(UCW): Watching user.toml
hab-sup(MR): Starting core/redis
hab-sup(MR): pkg version core/redis/3.2.4/20170514150022 <--
redis.default(UCW): Watching user.toml
...
```

Signed-off-by: Jeremy J. Miller <jm@chef.io>