### PR TITLE
Update Vagrant dev env to 18.04 and cleanup dev steps

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,10 +1,10 @@
 # Setting up the environment
 
-## Officially supported environment: Ubuntu Latest (17.10/Artful)
+## Officially supported environment: Ubuntu Latest (18.04/Bionic)
 
 ([Other environments](#Unsupported-environments) work, but are not officially supported)
 
-You can run this environment natively or in VM. [ISOs for both server and desktop versions are available here](http://releases.ubuntu.com/17.10/).
+You can run this environment natively or in VM. [ISOs for both server and desktop versions are available here](http://releases.ubuntu.com/18.04/).
 This installation method uses as many packages from Ubuntu as possible.
 If you don't have it, you'll first need to install `git`:
 ```
@@ -26,17 +26,10 @@ sh support/linux/install_dev_0_ubuntu_latest.sh
 sh support/linux/install_dev_9_linux.sh
 ```
 
-Ubuntu-Server 17.10 has an issue that prevents update from working because it
-tries to read from a CD-ROM that's almost certainly not there. If you get an
-error like this:
-```
-E: The repository 'cdrom://Ubuntu-Server 17.10 _Artful Aardvark_ - Release amd64 (20171017.1) artful Release' does not have a Release file.
-N: Updating from such a repository can't be done securely, and is therefore disabled by default.
-N: See apt-secure(8) manpage for repository creation and user configuration details.
-```
-You can run this command to comment out the problematic line in the sources list:
-```
-sudo sed -i.bak '/deb cdrom/s/^/#/g' /etc/apt/sources.list
+If you want to run the BATS based integration tests you also need docker installed:
+
+``` sh
+sh support/linux/install_dev_8_docker.sh
 ```
 
 Then, make sure rust's `cargo` command is working. You'll need to add `$HOME/.cargo/bin` to your `$PATH`.
@@ -106,7 +99,7 @@ Changes to the exporters can be tested once the exporter package has been built 
 ```
 ➤ hab studio enter
 …
-[1][default:/src:0]# build components/pkg-cfize 
+[1][default:/src:0]# build components/pkg-cfize
 …
    hab-pkg-cfize: Installed Path: /hab/pkgs/jbauman/hab-pkg-cfize/0.56.0-dev/20180410205025
 ```

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # 17.10 (artful) will be EOL July 2018; update FROM directive before then
-FROM ubuntu:17.10
+FROM ubuntu:18.04
 MAINTAINER The Habitat Maintainers <humans@habitat.sh>
 
 ENV CARGO_HOME /cargo-cache

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 Vagrant.configure("2") do |config|
-  config.vm.box = "bento/ubuntu-17.10"
+  config.vm.box = "bento/ubuntu-18.04"
 
   config.vm.provider "virtualbox" do |vb|
     vb.memory = "4096"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,5 +15,6 @@ Vagrant.configure("2") do |config|
 
   config.vm.provision "file", source: "components/hab/install.sh", destination: "/tmp/install.sh"
   config.vm.provision "shell", path: "support/linux/install_dev_0_ubuntu_latest.sh"
+  config.vm.provision "shell", path: "support/linux/install_dev_8_docker.sh"
   config.vm.provision "shell", path: "support/linux/install_dev_9_linux.sh"
 end

--- a/support/linux/install_dev_8_docker.sh
+++ b/support/linux/install_dev_8_docker.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+set -eux
+
+# Install Docker to run bats tests
+# From: https://docs.docker.com/install/linux/docker-ce/ubuntu/#install-using-the-repository
+#
+sudo apt-get install -y --no-install-recommends \
+    apt-transport-https \
+    ca-certificates \
+    curl \
+    software-properties-common
+
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+sudo add-apt-repository \
+  "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+  $(lsb_release -cs) \
+  stable"
+
+sudo -E apt-get install -y --no-install-recommends \
+  docker-ce
+
+# if running on a Vagrantbox, add the vagrant user
+# as well as the current user
+if getent passwd vagrant > /dev/null 2>&1; then
+  sudo -E usermod -aG docker vagrant
+fi
+sudo -E usermod -aG docker "${USER}"

--- a/support/linux/install_dev_9_linux.sh
+++ b/support/linux/install_dev_9_linux.sh
@@ -1,13 +1,34 @@
 #!/bin/sh
 set -eux
 
-# Install Rust and musl libc target
-curl -sSf https://sh.rustup.rs \
-  | env -u CARGO_HOME sh -s -- -y --default-toolchain stable
-. "$HOME/.cargo/env"
-env -u CARGO_HOME rustup target add x86_64-unknown-linux-musl
-env -u CARGO_HOME cargo install --force protobuf
-env -u CARGO_HOME cargo install diesel_cli --no-default-features --features postgres
+# Install Rust and musl libc target.
+# If running as root, put it in a generic location
+# and share across all users
+# (https://github.com/rust-lang-nursery/rustup.rs/issues/1085#issuecomment-296604244)
+if [ "$(whoami)" = "root" ]; then
+  export RUSTUP_HOME=/opt/rust
+  export CARGO_HOME=/opt/rust
+  curl -sSf https://sh.rustup.rs \
+    | sh -s -- -y --no-modify-path --default-toolchain stable
+
+  cat <<EOF > /usr/local/bin/rustc
+  #!/bin/sh
+
+  RUSTUP_HOME=/opt/rust exec /opt/rust/bin/\${0##*/} "\$@"
+EOF
+  chmod +x  /usr/local/bin/rustc
+
+  cd "${RUSTUP_HOME}/bin" && \
+    find ! -name rustc -type f \
+      -exec ln -s "/usr/local/bin/rustc" "/usr/local/bin/{}" \;
+  rustup target add x86_64-unknown-linux-musl
+else # non-root user, install in user directory
+  curl -sSf https://sh.rustup.rs \
+    | env -u CARGO_HOME sh -s -- -y --default-toolchain stable
+  . "$HOME/.cargo/env"
+  env -u CARGO_HOME rustup target add x86_64-unknown-linux-musl
+fi
+
 rustc --version
 cargo --version
 

--- a/test/integration/Dockerfile
+++ b/test/integration/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:xenial
+FROM ubuntu:18.04
 
 # Minimal Docker container for running Habitat's BATS integration
 #  tests.


### PR DESCRIPTION
Update of vagrant based dev environment so you can build hab as non-root without having to do manual setup sets (like install rust for your user). Also allows to run BATS tests inside Vagrant environment

* Update to use Ubuntu 18.04 in Vagrant, Docker and also test docker container
* Add docker installation script to allow to run `make bats`
* Update BUILDING.md to reflect changes

Signed-off-by: James Casey <james@chef.io>