### PR TITLE
Added a `hab pkg dependencies <PKG_IDENT>` command

### DIFF
--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -500,6 +500,12 @@ pub fn get() -> App<'static, 'static> {
                 (@arg SOURCE: +required {file_exists} "A path to a Habitat Artifact \
                     (ex: /home/acme-redis-3.0.7-21120102031201-x86_64-linux.hart)")
             )
+            (@subcommand dependencies =>
+                (about: "Returns the Habitat Artifact dependencies")
+                (aliases: &["dep", "deps"])
+                (@arg PKG_IDENT: +required +takes_value
+                    "A package identifier (ex: core/redis, core/busybox-static/1.42.2)")
+            )
         )
         (@subcommand plan =>
             (about: "Commands relating to plans and other app-specific configuration.")

--- a/components/hab/src/command/pkg/dependencies.rs
+++ b/components/hab/src/command/pkg/dependencies.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Chef Software Inc. and/or applicable contributors
+// Copyright (c) 2018 Chef Software Inc. and/or applicable contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,21 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod binlink;
-pub mod build;
-pub mod channels;
-pub mod demote;
-pub mod dependencies;
-pub mod env;
-pub mod exec;
-pub mod export;
-pub mod hash;
-pub mod header;
-pub mod info;
-pub mod path;
-pub mod promote;
-pub mod provides;
-pub mod search;
-pub mod sign;
-pub mod upload;
-pub mod verify;
+use std::path::Path;
+
+use hcore::package::{PackageIdent, PackageInstall};
+
+use error::Result;
+
+pub fn start(ident: &PackageIdent, fs_root_path: &Path) -> Result<()> {
+    let pkg_install = PackageInstall::load(ident, Some(fs_root_path))?;
+
+    let deps = pkg_install.tdeps()?;
+
+    for dep in &deps {
+        println!("{}", dep);
+    }
+
+    Ok(())
+}

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -213,6 +213,7 @@ fn start(ui: &mut UI) -> Result<()> {
             ("build", Some(m)) => sub_pkg_build(ui, m)?,
             ("channels", Some(m)) => sub_pkg_channels(ui, m)?,
             ("config", Some(m)) => sub_pkg_config(m)?,
+            ("dependencies", Some(m)) => sub_pkg_dependencies(m)?,
             ("env", Some(m)) => sub_pkg_env(m)?,
             ("exec", Some(m)) => sub_pkg_exec(m, remaining_args)?,
             ("export", Some(m)) => sub_pkg_export(ui, m)?,
@@ -460,6 +461,11 @@ fn sub_pkg_binds(m: &ArgMatches) -> Result<()> {
 
     common::command::package::binds::start(&ident, &*FS_ROOT)?;
     Ok(())
+}
+
+fn sub_pkg_dependencies(m: &ArgMatches) -> Result<()> {
+    let ident = PackageIdent::from_str(m.value_of("PKG_IDENT").unwrap())?;
+    command::pkg::dependencies::start(&ident, &*FS_ROOT)
 }
 
 fn sub_pkg_env(m: &ArgMatches) -> Result<()> {


### PR DESCRIPTION
First step towards better dependency management and cleanup.  Add
a CLI command to show the dependencies for an installed package

Signed-off-by: James Casey <james@chef.io>