### PR TITLE
Refuting an incarnation immediately increments to one-greater

### DIFF
--- a/components/butterfly/src/member.rs
+++ b/components/butterfly/src/member.rs
@@ -20,7 +20,7 @@ use std::fmt;
 use std::iter::IntoIterator;
 use std::net::SocketAddr;
 use std::num::ParseIntError;
-use std::ops::AddAssign;
+use std::ops::Add;
 use std::result;
 use std::str::FromStr;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -45,6 +45,9 @@ const PINGREQ_TARGETS: usize = 5;
 
 /// Wraps a `u64` to represent the "incarnation number" of a
 /// `Member`. Incarnation numbers can only ever be incremented.
+///
+/// Note: we're intentionally deriving `Copy` to be able to treat this
+/// like a "normal" numeric type.
 #[derive(Clone, Debug, Ord, PartialEq, PartialOrd, Eq, Copy)]
 pub struct Incarnation(u64);
 
@@ -72,9 +75,11 @@ impl fmt::Display for Incarnation {
     }
 }
 
-impl AddAssign<u64> for Incarnation {
-    fn add_assign(&mut self, other: u64) {
-        *self = Incarnation(self.0 + other)
+impl Add<u64> for Incarnation {
+    type Output = Incarnation;
+
+    fn add(self, other: u64) -> Incarnation {
+        Incarnation(self.0 + other)
     }
 }
 
@@ -1119,7 +1124,7 @@ mod tests {
 
                 let member_with_higher_incarnation = {
                     let mut m = member.clone();
-                    m.incarnation += 1;
+                    m.incarnation = m.incarnation + 1;
                     m
                 };
 

--- a/components/butterfly/src/server/mod.rs
+++ b/components/butterfly/src/server/mod.rs
@@ -692,12 +692,12 @@ impl Server {
         let rk: RumorKey = RumorKey::from(&member);
         if member.id == self.member_id() {
             if health != Health::Alive {
-                self.member
-                    .write()
-                    .expect("Member lock is poisoned")
-                    .refute_incarnation(member.incarnation);
-                health = Health::Alive;
-                incremented_incarnation = true;
+                let mut me = self.member.write().expect("Member lock is poisoned");
+                if member.incarnation >= me.incarnation() {
+                    me.refute_incarnation(member.incarnation);
+                    health = Health::Alive;
+                    incremented_incarnation = true;
+                }
             }
         }
         // NOTE: This sucks so much right here. Check out how we allocate no matter what, because


### PR DESCRIPTION
Previously, whenever we refuted a rumor that we were anything but
`Alive`, there was an implicit assumption that the incarnation of the
rumor we were refuting was equal to our own. Thus, simply incrementing
our number by 1 would be enough to have a successful refutation.

In general, this *should* be true. However, reality is sometimes different.

In particular, given the Butterfly server's history of not persisting
incarnation numbers, as well as the Supervisor's practice of sending
out Departure health rumors when it shut down for upgrade (fixed
recently in #5588), it can be possible for the overall network to have
one conception of a member's incarnation number, while the member
itself thinks it has a lower value. This can result in several rounds
of refutation, where the member sends out new rumors with
incrementally larger incarnation numbers that are nevertheless smaller
than what the network's version of the incarnation is. This results in
a possibly long wait until the rumor is refuted enough times to
finally be recognized by the network.

This may also happen if a server cannot for some reason persist its
incarnation number to disk. The in-memory (and thus, in-network)
incarnation will continue to increase, while the on-disk version will
stagnate. Absent any additional intervention, upon a restart, a server
will think its incarnation is less than what the network does, leading
to the same scenario described above.

Now, instead of simply incrementing our incarnation by one to refute a
rumor, we'll set our incarnation to _one greater_ than the refuted
rumor. This eliminates the possibly-long wait while we repeatedly
refute the same rumor, and should also reduce overall network
traffic. Additionally, it should reduce "incarnation churn" greatly,
since now we will now send out a single refutation for the entire
network, rather than up to _n_ refutations for every member of the
network.

Implementaion-wise, we introduce a new `refute_incarnation` method
alongside the existing `increment_incarnation` method, to reflect two
subtly different scenarios. When we are shutting down, we send a
Departure health rumor out with an incremented incarnation
number. There is no other rumor we are refuting; we're basically
"refuting ourselves". When we are genuinely refuting some other rumor,
though, we call this out in the name (and signature) of the
`refute_incarnation` method.

To eliminate redundant code paths, `increment_incarnation` is now
implemented in terms of `refute_incarnation`.

We also replace the `AddAssign` implementation for Incarnation with
`Add` to reflect the new operations we are doing. There is no reason
to retain `AddAssign`, so we remove it.

Signed-off-by: Christopher Maier <cmaier@chef.io>