### PR TITLE
Update show_package to always use a channel

### DIFF
--- a/components/builder-api-client/src/lib.rs
+++ b/components/builder-api-client/src/lib.rs
@@ -877,16 +877,10 @@ impl Client {
         &self,
         package: &PackageIdent,
         target: &PackageTarget,
-        channel: Option<&str>,
+        channel: &str,
         token: Option<&str>,
     ) -> Result<PackageIdent> {
-        // TODO: When channels are fully rolled out, we may want to make
-        //       the channel specifier mandatory instead of being an Option
-        let mut url = if let Some(channel) = channel {
-            channel_package_path(channel, package)
-        } else {
-            package_path(package)
-        };
+        let mut url = channel_package_path(channel, package);
 
         if !package.fully_qualified() {
             url.push_str("/latest");

--- a/components/common/src/command/package/install.rs
+++ b/components/common/src/command/package/install.rs
@@ -880,7 +880,7 @@ impl<'a> InstallTask<'a> {
     ) -> Result<FullyQualifiedPackageIdent> {
         let origin_package = self
             .api_client
-            .show_package(ident, target, Some(channel.0), token)?;
+            .show_package(ident, target, channel.0, token)?;
         FullyQualifiedPackageIdent::from(origin_package)
     }
 

--- a/components/hab/src/command/pkg/upload.rs
+++ b/components/hab/src/command/pkg/upload.rs
@@ -108,14 +108,14 @@ where
     let ident = archive.ident()?;
     let target = archive.target()?;
 
-    match api_client.show_package(&ident, &target, None, Some(token)) {
+    match api_client.show_package(&ident, &target, UNSTABLE_CHANNEL, Some(token)) {
         Ok(_) if !force_upload => {
             ui.status(Status::Using, format!("existing {}", &ident))?;
             Ok(())
         }
         Err(api_client::Error::APIError(StatusCode::NotFound, _)) | Ok(_) => {
             for dep in tdeps.into_iter() {
-                match api_client.show_package(&dep, &target, None, Some(token)) {
+                match api_client.show_package(&dep, &target, UNSTABLE_CHANNEL, Some(token)) {
                     Ok(_) => ui.status(Status::Using, format!("existing {}", &dep))?,
                     Err(api_client::Error::APIError(StatusCode::NotFound, _)) => {
                         let candidate_path = match archive_path.as_ref().parent() {


### PR DESCRIPTION
This change removes the use of 'non-channel' package path when querying package metadata. This will help deprecate old API usage, and make better use of the caching that has been added for the channel paths.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-96480608](https://user-images.githubusercontent.com/13542112/46037661-a5558f80-c0bd-11e8-95d5-305117afa7df.gif)
