### PR TITLE
Don't show ident for incomplete jobs

### DIFF
--- a/components/hab/src/command/bldr/job/status.rs
+++ b/components/hab/src/command/bldr/job/status.rs
@@ -77,10 +77,13 @@ fn do_job_group_status(
                 tw = TabWriter::new(vec![]);
                 write!(&mut tw, "NAME\tSTATUS\tJOB ID\tIDENT\n").unwrap();
                 for p in sr.projects {
+                    // Don't show ident if the build did not succeed
+                    // TODO: This will be fixed at the API level eventually
+                    let ident = if p.state == "Success" { &p.ident } else { "" };
                     write!(
                         &mut tw,
                         "{}\t{}\t{}\t{}\n",
-                        p.name, p.state, p.job_id, p.ident,
+                        p.name, p.state, p.job_id, ident,
                     ).unwrap();
                 }
                 written = String::from_utf8(tw.into_inner().unwrap()).unwrap();


### PR DESCRIPTION
Currently when getting job status, we show an ident even if the job is not successful.  This is an idiosyncrasy of the API that will be fixed in the API eventually, but for now we can patch it on the client side.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-229905964](https://user-images.githubusercontent.com/13542112/46100367-0fce0480-c17e-11e8-8dd7-76499e5f8b73.gif)

