### PR TITLE
[studio] Fix errant path in sup-term command

### DIFF
--- a/components/rootless_studio/default/profile
+++ b/components/rootless_studio/default/profile
@@ -73,7 +73,7 @@ sup-run() {
 }
 
 sup-term() {
-  local pid_file="/hab/sup/default/LOCK "
+  local pid_file="/hab/sup/default/LOCK"
   if [ -f "$pid_file" ]; then
     echo "--> Killing Habitat Supervisor running in the background..."
     kill "$(cat "$pid_file")" \

--- a/components/studio/libexec/hab-studio-type-default.sh
+++ b/components/studio/libexec/hab-studio-type-default.sh
@@ -98,7 +98,7 @@ finish_setup() {
       _hab install "$pkg"
     fi
   done
-  
+
   bash_path=$(_pkgpath_for core/bash)
   coreutils_path=$(_pkgpath_for core/coreutils)
 
@@ -174,7 +174,7 @@ sup-run() {
 }
 
 sup-term() {
-  local pid_file="/hab/sup/default/LOCK "
+  local pid_file="/hab/sup/default/LOCK"
   if [ -f "\$pid_file" ]; then
     echo "--> Killing Habitat Supervisor running in the background..."
     kill "\$(cat "\$pid_file")" \\


### PR DESCRIPTION
The extra space resulted in the pid file never being found.

Opening this to document the error.  I see there are some
cool new tests for the studio, I'll see if I can write one for this
this weekend. But, feel free to merge this if you want if I'm not
quick enough.

Signed-off-by: Steven Danna <steve@chef.io>