### PR TITLE
Rearrange lines again, because I'm dumb

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,17 +3,18 @@
 components/backline @fnichol @baumanj
 components/builder* @chefsalim @raskchanky
 components/butterfly* @christophermaier @reset @baumanj @fnichol @raskchanky
-components/common/src/command @apriofrost
 components/common @fnichol @baumanj @raskchanky
-components/eventsrv/src/main.rs @apriofrost
+components/common/src/command @apriofrost
 components/eventsrv* @reset @raskchanky
+components/eventsrv/src/main.rs @apriofrost
+components/hab* @reset @fnichol @christophermaier @chefsalim @baumanj @elliott-davis @raskchanky @eeyun
 components/hab/src/analytics.rs @apriofrost
 components/hab/src/cli.rs @apriofrost
 components/hab/src/main.rs @apriofrost
 components/hab/src/command @apriofrost
-components/hab* @reset @fnichol @christophermaier @chefsalim @baumanj @elliott-davis @raskchanky @eeyun
-components/launcher/src/main.rs @apriofrost
 components/launcher* @christophermaier @reset @baumanj @raskchanky
+components/launcher/src/main.rs @apriofrost
+components/pkg-* @fnichol @christophermaier @eeyun
 components/pkg-export-docker/src/cli.rs @apriofrost
 components/pkg-export-docker/src/lib.rs @apriofrost
 components/pkg-export-helm/src/chart.rs @apriofrost
@@ -32,18 +33,17 @@ components/pkg-export-tar/src/build.rs @apriofrost
 components/pkg-export-tar/src/cli.rs @apriofrost
 components/pkg-export-tar/src/lib.rs @apriofrost
 components/pkg-export-tar/src/main.rs @apriofrost
-components/pkg-* @fnichol @christophermaier @eeyun
+components/plan-build @fnichol @christophermaier @elliott-davis @scotthain
 components/plan-build/bin/hab-plan-build.sh @apriofrost
 components/plan-build-ps1/bin/hab-plan-build.ps1 @apriofrost
-components/plan-build @fnichol @christophermaier @elliott-davis @scotthain
 components/rootless_studio @elliott-davis
-components/studio/bin/hab-studio.sh @apriofrost
 components/studio @fnichol @baumanj @elliott-davis @eeyun
+components/studio/bin/hab-studio.sh @apriofrost
+components/sup* @christophermaier @reset @fnichol @baumanj @raskchanky
 components/sup/src/main.rs @apriofrost
 components/sup/src/command @apriofrost
-components/sup* @christophermaier @reset @fnichol @baumanj @raskchanky
 support @fnichol @baumanj @elliott-davis @raskchanky
 tools @baumanj @chefsalim @christophermaier @eeyun @raskchanky @fnichol
-www/site/content @kagarmoe @mjingle
 www @cnunciato @mgamini @raskchanky
+www/site/content @kagarmoe @mjingle
 UX_PRINCIPLES.md @apriofrost


### PR DESCRIPTION
Awhile back, I submitted a PR to rearrange these lines so that the most specific ones (for UX and docs people) went first, and the most generic ones went last.  I did that because [the GH docs for the CODEOWNERS file](https://help.github.com/articles/about-codeowners/) mentions that the last match wins.  With the most specific lines last, PRs were requiring review from e.g. @apriofrost, simply because one of the files she's tagged on had a change, even though there was no UX related change in the file.  The only way to merge a PR in that state was to use admin privs to override it.

I thought this was a bad idea and set about to rectify it by making the most generic tagging the last one.  Those of you that are smarter than me have already realized the flaw in this logic, though, which is that the last match wins, so the generic tag always won, and @apriofrost would never get tagged on any PR.

The truth is that the logic around how GH treats CODEOWNERS file doesn't _exactly_ fit what we need it to do, but it seems better to have it notify people that it should and have a small minority of PRs require admin privs for merging, than not ping anyone on the UX or docs team.

I'll have matching PRs for the rest of the repos that have CODEOWNERS files.  Sorry for the noise.

![](https://media.giphy.com/media/HyCxJErg9jTCU/giphy.gif)

Signed-off-by: Josh Black <raskchanky@gmail.com>