### PR TITLE
`hab config show` now shows active service group configuration and individual config layers

### DIFF
--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -72,7 +72,7 @@ pub fn get() -> App<'static, 'static> {
                 (@arg SERVICE_GROUP: +required +takes_value {valid_service_group_not_ident}
                     "Target service group service.group[@organization] (ex: redis.default or foo.default@bazcorp)")
                 (@arg CFG_TYPE: -t --type +takes_value {valid_cfg_type}
-                    "The configuration layer to display [values: default, environment, user, gossip, merged]")
+                    "The configuration layer to display (values: default, environment, user, gossip, merged) [default: merged]")
                 (@arg REMOTE_SUP: --("remote-sup") -r +takes_value
                     "Address to a remote Supervisor's Control Gateway [default: 127.0.0.1:9632]")
             )

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -872,8 +872,8 @@ fn sub_svc_set(m: &ArgMatches) -> Result<()> {
 
 fn sub_svc_config(m: &ArgMatches) -> Result<()> {
     let service_group = ServiceGroup::from_str(m.value_of("SERVICE_GROUP").unwrap())?;
-    let cfg_type = ServiceCfgType::from_str(m.value_of("CFG_TYPE").unwrap_or(&"".to_string()))
-        .unwrap_or_default();
+    let cfg_type =
+        ServiceCfgType::from_str(m.value_of("CFG_TYPE").unwrap_or_default()).unwrap_or_default();
     let cfg = config::load()?;
     let sup_addr = sup_addr_from_input(m)?;
     let secret_key = ctl_secret_key(&cfg)?;
@@ -885,7 +885,7 @@ fn sub_svc_config(m: &ArgMatches) -> Result<()> {
             conn.call(msg).for_each(|reply| match reply.message_id() {
                 "ServiceCfg" => {
                     let m = reply.parse::<protocol::types::ServiceCfg>().unwrap();
-                    println!("{}", m.default.unwrap_or_default());
+                    println!("{}", m.config.unwrap_or_default());
                     Ok(())
                 }
                 "NetErr" => {

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -871,12 +871,15 @@ fn sub_svc_set(m: &ArgMatches) -> Result<()> {
 }
 
 fn sub_svc_config(m: &ArgMatches) -> Result<()> {
-    let ident = PackageIdent::from_str(m.value_of("PKG_IDENT").unwrap())?;
+    let service_group = ServiceGroup::from_str(m.value_of("SERVICE_GROUP").unwrap())?;
+    let cfg_type = ServiceCfgType::from_str(m.value_of("CFG_TYPE").unwrap_or(&"".to_string()))
+        .unwrap_or_default();
     let cfg = config::load()?;
     let sup_addr = sup_addr_from_input(m)?;
     let secret_key = ctl_secret_key(&cfg)?;
-    let mut msg = protocol::ctl::SvcGetDefaultCfg::default();
-    msg.ident = Some(ident.into());
+    let mut msg = protocol::ctl::SvcGetCfg::default();
+    msg.service_group = Some(service_group.into());
+    msg.cfg_type = Some(cfg_type.into());
     SrvClient::connect(&sup_addr, secret_key)
         .and_then(|conn| {
             conn.call(msg).for_each(|reply| match reply.message_id() {

--- a/components/sup-client/src/lib.rs
+++ b/components/sup-client/src/lib.rs
@@ -92,7 +92,13 @@ impl error::Error for SrvClientError {
 impl fmt::Display for SrvClientError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let content = match *self {
-            SrvClientError::ConnectionClosed => format!("Connection closed"),
+            SrvClientError::ConnectionClosed => format!(
+                "Connection closed.\n\n\
+                The remote Supervisor unexpectedly closed the connection. If this occurs\n\
+                consistently it may be a symptom of a protocol mismatch. In that case\n\
+                the client likely has new features, requiring an upgrade of the Supervisor\n\
+                in order for it to respond appropriately to this request type.",
+            ),
             SrvClientError::CtlSecretNotFound(ref path) => format!(
                 "No Supervisor CtlGateway secret set in `cli.toml` or found at {}. Run \
                  `hab setup` or run the Supervisor for the first time before attempting to \

--- a/components/sup-protocol/protocols/ctl.proto
+++ b/components/sup-protocol/protocols/ctl.proto
@@ -44,6 +44,13 @@ message SvcGetDefaultCfg {
   optional sup.types.PackageIdent ident = 1;
 }
 
+// Request for retrieving the various configuration layers for a given service.
+message SvcGetCfg {
+  // Service group of a loaded service to target.
+  optional sup.types.ServiceGroup service_group = 1;
+  optional sup.types.ServiceCfgType cfg_type = 2 [default = Merged];
+}
+
 message SvcValidateCfg {
   // Service group of a running service to validate a configuration change against.
   optional sup.types.ServiceGroup service_group = 1;

--- a/components/sup-protocol/protocols/types.proto
+++ b/components/sup-protocol/protocols/types.proto
@@ -41,6 +41,14 @@ enum BindingMode {
   Strict = 1;
 }
 
+enum ServiceCfgType {
+  Merged = 0;
+  Default = 1;
+  Environment = 2;
+  User = 3;
+  Gossip = 4;
+}
+
 message ApplicationEnvironment {
   required string application = 1;
   required string environment = 2;

--- a/components/sup-protocol/protocols/types.proto
+++ b/components/sup-protocol/protocols/types.proto
@@ -81,7 +81,8 @@ message ServiceCfg {
   // is present if we ever change from using TOML to represent service configurations
   // to another self describing type.
   optional Format format = 1 [default = Toml];
-  optional string default = 2;
+  optional string config = 2;
+  optional ServiceCfgType config_type = 3;
 }
 
 message ServiceGroup {

--- a/components/sup-protocol/src/generated/sup.ctl.impl.rs
+++ b/components/sup-protocol/src/generated/sup.ctl.impl.rs
@@ -18,6 +18,9 @@ impl message::MessageStatic for SvcFilePut {
 impl message::MessageStatic for SvcGetDefaultCfg {
     const MESSAGE_ID: &'static str = "SvcGetDefaultCfg";
 }
+impl message::MessageStatic for SvcGetCfg {
+    const MESSAGE_ID: &'static str = "SvcGetCfg";
+}
 impl message::MessageStatic for SvcValidateCfg {
     const MESSAGE_ID: &'static str = "SvcValidateCfg";
 }

--- a/components/sup-protocol/src/generated/sup.ctl.rs
+++ b/components/sup-protocol/src/generated/sup.ctl.rs
@@ -62,6 +62,17 @@ pub struct SvcGetDefaultCfg {
     #[prost(message, optional, tag="1")]
     pub ident: ::std::option::Option<super::types::PackageIdent>,
 }
+/// Request for retrieving the various configuration layers for a given service.
+#[derive(Clone, PartialEq, Message)]
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct SvcGetCfg {
+    /// Service group of a loaded service to target.
+    #[prost(message, optional, tag="1")]
+    pub service_group: ::std::option::Option<super::types::ServiceGroup>,
+    #[prost(enumeration="super::types::ServiceCfgType", optional, tag="2", default="Merged")]
+    pub cfg_type: ::std::option::Option<i32>,
+}
 #[derive(Clone, PartialEq, Message)]
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]

--- a/components/sup-protocol/src/generated/sup.types.rs
+++ b/components/sup-protocol/src/generated/sup.types.rs
@@ -142,3 +142,13 @@ pub enum BindingMode {
     /// Service start-up is blocked until all binds are available
     Strict = 1,
 }
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Enumeration)]
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ServiceCfgType {
+    Merged = 0,
+    Default = 1,
+    Environment = 2,
+    User = 3,
+    Gossip = 4,
+}

--- a/components/sup-protocol/src/generated/sup.types.rs
+++ b/components/sup-protocol/src/generated/sup.types.rs
@@ -52,7 +52,9 @@ pub struct ServiceCfg {
     #[prost(enumeration="service_cfg::Format", optional, tag="1", default="Toml")]
     pub format: ::std::option::Option<i32>,
     #[prost(string, optional, tag="2")]
-    pub default: ::std::option::Option<String>,
+    pub config: ::std::option::Option<String>,
+    #[prost(enumeration="ServiceCfgType", optional, tag="3")]
+    pub config_type: ::std::option::Option<i32>,
 }
 pub mod service_cfg {
     #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Enumeration)]

--- a/components/sup-protocol/src/types.rs
+++ b/components/sup-protocol/src/types.rs
@@ -99,6 +99,19 @@ impl fmt::Display for DesiredState {
     }
 }
 
+impl fmt::Display for ServiceCfgType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let value = match *self {
+            ServiceCfgType::Merged => "merged",
+            ServiceCfgType::Default => "default",
+            ServiceCfgType::Environment => "environment",
+            ServiceCfgType::User => "user",
+            ServiceCfgType::Gossip => "gossip",
+        };
+        write!(f, "{}", value)
+    }
+}
+
 impl FromStr for BindingMode {
     type Err = NetErr;
 
@@ -183,6 +196,27 @@ impl FromStr for ServiceBind {
             bind.service_group = ServiceGroup::from_str(values[1])?;
         }
         Ok(bind)
+    }
+}
+
+impl FromStr for ServiceCfgType {
+    type Err = NetErr;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.to_lowercase().as_ref() {
+            "merged" => Ok(ServiceCfgType::Merged),
+            "default" => Ok(ServiceCfgType::Default),
+            "environment" => Ok(ServiceCfgType::Environment),
+            "user" => Ok(ServiceCfgType::User),
+            "gossip" => Ok(ServiceCfgType::Gossip),
+            _ => Err(net::err(
+                ErrCode::InvalidPayload,
+                format!(
+                    "Invalid service cfg type \"{:?}\", must be one of: `default`, `environment`, `user`, `gossip` or `merged`.",
+                    value
+                ),
+            )),
+        }
     }
 }
 

--- a/components/sup/src/ctl_gateway/server.rs
+++ b/components/sup/src/ctl_gateway/server.rs
@@ -290,6 +290,18 @@ impl Future for SrvHandler {
                                     move |state, req| Manager::service_cfg(state, req, m.clone()),
                                 )
                             }
+                            "SvcGetCfg" => {
+                                let m = msg
+                                    .parse::<protocol::ctl::SvcGetCfg>()
+                                    .map_err(HandlerError::from)?;
+                                CtlCommand::new(
+                                    Some(self.tx.clone()),
+                                    msg.transaction(),
+                                    move |state, req| {
+                                        Manager::service_group_cfg(state, req, m.clone())
+                                    },
+                                )
+                            }
                             "SvcFilePut" => {
                                 let m = msg
                                     .parse::<protocol::ctl::SvcFilePut>()


### PR DESCRIPTION
### Description
This PR extends the capabilities of the `hab config show` command by:
* Replacing the PKG_IDENT argument with SERVICE_GROUP to target loaded services
* Displaying the active configuration of the merged cfg layers: default, user, environment and gossip 
* Introducing the ability to display each individual configuration layer

While it does change the argument list for `hab config show`, it only does so knowing that:
* `hab config show PKG_IDENT` is not particularly useful and therefore not likely going to "break" anyone.  (`hab pkg config PKG_IDENT` is a current equivalent for showing the default package configuration)
* The `hab config *` namespace feels like a natural intuitive choice for _all_ service group configuration operations.  `hab config apply` has already staked an important flag claiming the hill.

Related https://github.com/habitat-sh/habitat/issues/5055

Signed-off-by: Jeremy J. Miller <jm@chef.io>