### PR TITLE
Don't abandon service processes after a Supervisor restart

### DIFF
--- a/components/launcher/src/server/mod.rs
+++ b/components/launcher/src/server/mod.rs
@@ -45,10 +45,7 @@ use service::Service;
 use {SUP_CMD, SUP_PACKAGE_IDENT};
 
 const IPC_CONNECT_TIMEOUT_SECS: &'static str = "HAB_LAUNCH_SUP_CONNECT_TIMEOUT_SECS";
-const SUP_RESTART_SLEEP_SECS: &'static str = "HAB_LAUNCH_SUP_RESTART_SLEEP_SECS";
 const DEFAULT_IPC_CONNECT_TIMEOUT_SECS: u64 = 5;
-const DEFAULT_SUP_RESTART_SLEEP_SECS: u64 = 5;
-
 const SUP_CMD_ENVVAR: &'static str = "HAB_SUP_BINARY";
 static LOGKEY: &'static str = "SV";
 
@@ -72,35 +69,25 @@ pub struct Server {
     rx: Receiver,
     pipe: String,
     supervisor: Child,
+    args: Vec<String>,
 }
 
 impl Drop for Server {
     fn drop(&mut self) {
-        // We should never get here unless the supervisor process has exited, but
-        // since std::process::Child doesn't implement Drop, we should be sure
-        // See https://doc.rust-lang.org/std/process/struct.Child.html
-        self.supervisor.kill().ok();
-        self.supervisor.try_wait().ok();
-
-        if fs::remove_file(&self.pipe).is_err() {
-            error!("Could not remove old pipe to supervisor {}", self.pipe);
-        } else {
-            debug!("Removed old pipe to supervisor {}", self.pipe);
-        }
+        self.remove_pipe();
     }
 }
 
 impl Server {
-    // TODO: After https://github.com/habitat-sh/habitat/issues/5382, the
-    // `restart` argument can be removed from here and called functions
-    pub fn new(args: &Vec<String>, restart: bool) -> Result<Self> {
-        let ((rx, tx), supervisor, pipe) = Self::init(args, restart)?;
+    pub fn new(args: Vec<String>) -> Result<Self> {
+        let ((rx, tx), supervisor, pipe) = Self::init(&args, false)?;
         Ok(Server {
             services: ServiceTable::default(),
             tx: tx,
             rx: rx,
             pipe: pipe,
             supervisor: supervisor,
+            args: args,
         })
     }
 
@@ -114,6 +101,29 @@ impl Server {
         let supervisor = spawn_supervisor(&pipe, args, clean)?;
         let channel = setup_connection(server)?;
         Ok((channel, supervisor, pipe))
+    }
+
+    fn remove_pipe(&self) {
+        if fs::remove_file(&self.pipe).is_err() {
+            error!("Could not remove old pipe to supervisor {}", self.pipe);
+        } else {
+            debug!("Removed old pipe to supervisor {}", self.pipe);
+        }
+    }
+
+    #[allow(unused_must_use)]
+    fn reload(&mut self) -> Result<()> {
+        self.supervisor.kill();
+        self.supervisor.wait();
+        let ((rx, tx), supervisor, pipe) = Self::init(&self.args, true)?;
+        self.tx = tx;
+        self.rx = rx;
+        self.supervisor = supervisor;
+        // We're connecting to a new supervisor instance, so we need to remove
+        // the socket files for the old pipe to avoid https://github.com/habitat-sh/habitat/issues/4673
+        self.remove_pipe();
+        self.pipe = pipe;
+        Ok(())
     }
 
     fn forward_signal(&self, signal: Signal) {
@@ -402,31 +412,18 @@ where
 }
 
 pub fn run(args: Vec<String>) -> Result<i32> {
-    let mut restart = false;
-    let restart_sleep_secs = core::env::var(SUP_RESTART_SLEEP_SECS)
-        .unwrap_or("".to_string())
-        .parse()
-        .unwrap_or(DEFAULT_SUP_RESTART_SLEEP_SECS);
-
+    let mut server = Server::new(args)?;
     signals::init();
     loop {
-        let mut server = Server::new(&args, restart)?;
-        restart = true;
-        loop {
-            match server.tick() {
-                Ok(TickState::Continue) => thread::sleep(Duration::from_millis(100)),
-                Ok(TickState::Exit(code)) => return Ok(code),
-                Err(e) => {
-                    debug!("tick() returned error {}. Attempting to restart server", e);
-                    break;
-                }
+        match server.tick() {
+            Ok(TickState::Continue) => thread::sleep(Duration::from_millis(100)),
+            Ok(TickState::Exit(code)) => {
+                return Ok(code);
             }
+            Err(_) => while server.reload().is_err() {
+                thread::sleep(Duration::from_millis(1_000));
+            },
         }
-        error!(
-            "Supervisor exited; will restart in {} seconds...",
-            restart_sleep_secs
-        );
-        thread::sleep(Duration::from_secs(restart_sleep_secs));
     }
 }
 

--- a/test/end-to-end/hup-does-not-abandon-services.exp
+++ b/test/end-to-end/hup-does-not-abandon-services.exp
@@ -1,0 +1,140 @@
+#!/usr/bin/env expect
+
+# Run a Supervisor locally and verify that HUPping the Supervisor does
+# not result in the Launcher losing track of services, manifested by
+# leaving services running after stopping the Supervisor
+#
+# Run under sudo (for now, at least)
+#
+# TODO: This currently depends on a bit of state
+#
+# - Which launcher version is used
+# - Which sup version is used
+# - Having write access to the filesystem
+# - There are no other services running
+#
+# We might be able to concoct a Docker container that things could run
+# in, but we'd need to start the container with something other than
+# the Launcher as PID 1, because otherwise, there's no way to verify
+# that the services are actually cleaned up properly.
+
+# TODO: make this work on Windows
+
+# TODO: Find a real test assertion library for TCL
+proc assert {cond {msg "assertion failed"}} {
+    if {![uplevel 1 expr $cond]} {error $msg}
+}
+
+# Find the parent PID of the given PID.
+proc parent_pid {my_pid} {
+    set ppid [exec ps --format=ppid --no-headers -p $my_pid]
+    return [string trim $ppid]
+}
+
+# Determine if the given PID is still around.
+proc is_alive {my_pid} {
+    set exit_code [catch { exec kill -0 $my_pid } ]
+    return [expr $exit_code == 0]
+}
+
+# TODO: This is gross, but it seems that negating a procedure result is more gross
+proc is_not_alive {my_pid} {
+    set exit_code [catch { exec kill -0 $my_pid } ]
+    return [expr $exit_code == 1]
+}
+
+# Print out some helpful tracing messages in the test output.
+proc log {message} {
+    puts "LOG >>> $message"
+}
+
+# Cleanup after the test
+exit -onexit {
+    exec hab sup term
+    exec rm -Rf /hab/sup/default/specs/redis.spec
+    exec pkill redis-server ;# Just in case the test fails
+}
+
+# Begin the test!
+
+# Start up a Supervisor
+set launcher_pid [spawn hab sup run]
+set launcher_spawn_id $spawn_id
+expect {
+    "Starting http-gateway on 0.0.0.0:9631" {
+        log "Supervisor started normally"
+    }
+    "Unable to start Habitat Supervisor because another instance is already running" {
+        error "Another Supervisor is running; leftover state?"
+    }
+    timeout {
+        error "Supervisor appears not to have started, correctly"
+    }
+}
+
+# Load up Redis on that Supervisor
+spawn hab svc load core/redis
+expect {
+    "The core/redis service was successfully loaded" {}
+    "Service already loaded, unload 'core/redis' and try again" {
+        error "Service was already loaded; leftover state?"
+    }
+    timeout {
+        error "Timed out waiting for core/redis to load";
+    }
+}
+expect eof wait
+
+# Wait until Redis is running
+set spawn_id $launcher_spawn_id
+expect {
+    "Ready to accept connections" {
+        log "Redis is accepting connections"
+    }
+    timeout {
+        error "Redis not ready to accept connections!"
+    }
+}
+set redis_pid [exec pgrep redis-server]
+assert { [is_alive $redis_pid] } "Redis PID isn't alive!"
+
+set redis_parent [parent_pid $redis_pid]
+assert { $redis_parent == $launcher_pid } "Didn't do that right!"
+
+# HUP the Supervisor (through the Launcher). This will restart the
+# Supervisor, but should leave the Redis service untouched. More
+# importantly, we shouldn't "lose track" of the service process when
+# we shut down.
+exec kill -HUP $launcher_pid
+expect {
+    "Supervisor shutting down for signal" {
+        log "Supervisor got HUPped"
+    }
+    timeout {
+        error "Didn't see the Supervisor go away when the Launcher was HUPped!"
+    }
+}
+expect {
+    "Reattached to redis.default" {
+        log "Supervisor reattached"
+    }
+    timeout {
+        error "Should have reattached to redis process!"
+    }
+}
+
+assert { [is_alive $redis_pid] } "Redis PID isn't alive!"
+assert { [is_alive $launcher_pid] } "Launcher PID isn't alive!"
+
+exec hab sup term
+expect {
+    eof {
+        wait
+    }
+    timeout {
+        error "Supervisor should have shut down!"
+    }
+}
+
+assert { [is_not_alive $launcher_pid] } "Launcher PID is still alive!"
+assert { [is_not_alive $redis_pid] } "Redis PID is still alive!"


### PR DESCRIPTION
This is largely a reversion of #5404. Once shutdown logic is moved into the Supervisor, we may be able to add that code back again, but as long as the Launcher keeps state on the services that are running, we need to preserve that state across Supervisor restarts.

It also adds a regression test to cover this scenario in future refactorings.

Fixes #5687