### PR TITLE
correct RAML doc for the organization routes

### DIFF
--- a/components/sup/doc/api.raml
+++ b/components/sup/doc/api.raml
@@ -242,18 +242,6 @@ types:
                     description: Service not loaded
                 503:
                     description: Supervisor hasn't fully started. Try again later.
-    /{name}/{group}/{org}:
-        get:
-            description: Show information of a single loaded service
-            responses:
-                200:
-                    body:
-                        application/json:
-                            type: service
-                404:
-                    description: Service not loaded
-                503:
-                    description: Supervisor hasn't fully started. Try again later.
     /{name}/{group}/config:
         get:
             description: Get last configuration for the given service group
@@ -281,6 +269,18 @@ types:
                     description: Health Check - Unknown
                 503:
                     description: Health Check - Critical
+    /{name}/{group}/{organization}:
+        get:
+            description: Show information of a single loaded service scoped to an organization
+            responses:
+                200:
+                    body:
+                        application/json:
+                            type: service
+                404:
+                    description: Service not loaded
+                503:
+                    description: Supervisor hasn't fully started. Try again later.
     /{name}/{group}/{organization}/config:
         get:
             description: Get last configuration for the given service group


### PR DESCRIPTION

<img width="870" alt="screen shot 2018-10-03 at 12 51 52 pm" src="https://user-images.githubusercontent.com/517302/46437450-3b1d9a00-c710-11e8-99da-4e6396c881f6.png">


`/services/{name}/{group}/{org}` confused a couple of us who were exploring writing a client library for the supervisor API. We suspect—along with @fnichol —that `{org}` should be `{organization}`. That the answer is scoped to a service group in a particular organization is a guess on our part.
