### PR TITLE
Only run the service proxy test on linux.

### DIFF
--- a/components/sup/src/manager/service/mod.rs
+++ b/components/sup/src/manager/service/mod.rs
@@ -1105,6 +1105,7 @@ mod tests {
     use http_gateway;
     use test_helpers::*;
 
+    #[cfg(target_os = "linux")]
     #[test]
     fn service_proxy_conforms_to_the_schema() {
         let socket_addr =


### PR DESCRIPTION
Since the TARGET in the test package specifies linux, every other OS
will return a PackageNotFound error.

![](https://media.giphy.com/media/QQZgTehcKrD2w/giphy.gif)

Signed-off-by: Josh Black <raskchanky@gmail.com>