### PR TITLE
Use busybox commands directly in studio setup

### DIFF
--- a/components/studio/habitat/plan.sh
+++ b/components/studio/habitat/plan.sh
@@ -35,13 +35,20 @@ do_install() {
     install -v -D "$f" "$pkg_prefix"/libexec/"$f"
   done
 
+  # Busybox allows us to link each command busybox includes to the statically
+  # built busybox binary and it will behave as if the command was called. By
+  # installing copies of all busybox commands under `libexec` we will have
+  # access to them while we build up the studio in the studio scripts instead
+  # of prefixing commands with $bb.
   lbb="$pkg_prefix/libexec/busybox"
 
-  # Install a copy of a statically built busybox under `libexec/`
   install -v -D "$(pkg_path_for busybox-static)"/bin/busybox "$lbb"
+  for i in $("$pkg_prefix"/libexec/busybox --list); do
+    ln -sv busybox "$pkg_prefix"/libexec/"$i"
+  done
 
+  # shellcheck disable=2154
   hab_dir=$(tr '/' '-' < "$(pkg_path_for hab)"/IDENT)
   install -v -D "$(pkg_path_for hab)"/bin/hab \
-    "$pkg_prefix"/libexec/"$hab_dir"/bin/hab
-  ln -sv "$hab_dir"/bin/hab "$pkg_prefix"/libexec/hab
+    "$pkg_prefix"/libexec/hab
 }

--- a/components/studio/libexec/hab-studio-profile.sh
+++ b/components/studio/libexec/hab-studio-profile.sh
@@ -49,20 +49,19 @@ record() {
     : "${name:=unknown}"
     shift
     cmd="${1:-${SHELL:-sh} -l}"; shift
-    bb=${BUSYBOX:-}
-    env="$($bb env \
-      | $bb sed -e "s,^,'," -e "s,$,'," -e 's,0;32m,0;31m,g' \
-      | $bb tr '\n' ' ')"
-    log="${LOGDIR:-/src/results/logs}/${name}.$($bb date -u +%Y-%m-%d-%H%M%S).log"
-    $bb mkdir -p "$($bb dirname "$log")"
-    $bb touch "$log"
+    env="$(env \
+      | sed -e "s,^,'," -e "s,$,'," -e 's,0;32m,0;31m,g' \
+      | tr '\n' ' ')"
+    log="${LOGDIR:-/src/results/logs}/${name}.$(date -u +%Y-%m-%d-%H%M%S).log"
+    mkdir -p "$(dirname "$log")"
+    touch "$log"
     if [[ "$log" =~ ^/src/results/logs/.* ]]; then
-      ownership=$($bb stat -c '%u:%g' /src)
-      $bb chown -R "$ownership" "/src/results" || true
+      ownership=$(stat -c '%u:%g' /src)
+      chown -R "$ownership" "/src/results" || true
     fi
-    unset BUSYBOX LOGDIR name ownership
+    unset LOGDIR name ownership
 
-    $bb script -c "$bb env -i $env $cmd $*" -e "$log"
+    script -c "env -i $env $cmd $*" -e "$log"
   ); return $?
 }
 

--- a/components/studio/libexec/hab-studio-type-bare.sh
+++ b/components/studio/libexec/hab-studio-type-bare.sh
@@ -27,12 +27,13 @@ finish_setup() {
       echo "> Using local package for $embed"
       embed_path=$(_outside_pkgpath_for $embed)
       # shellcheck disable=2154
-      $bb mkdir -p "$HAB_STUDIO_ROOT"/"$embed_path"
-      $bb cp -ra "$embed_path"/* "$HAB_STUDIO_ROOT"/"$embed_path"
-      for tdep in $($bb cat "$embed_path"/TDEPS); do
+      mkdir -p "$HAB_STUDIO_ROOT"/"$embed_path"
+      cp -ra "$embed_path"/* "$HAB_STUDIO_ROOT"/"$embed_path"
+      # shellcheck disable=2013
+      for tdep in $(cat "$embed_path"/TDEPS); do
         echo "> Using local package for $tdep via $embed"
-        $bb mkdir -p "$HAB_STUDIO_ROOT""$HAB_PKG_PATH"/"$tdep"
-        $bb cp -ra "$HAB_PKG_PATH"/"$tdep"/* "$HAB_STUDIO_ROOT""$HAB_PKG_PATH"/"$tdep"
+        mkdir -p "$HAB_STUDIO_ROOT""$HAB_PKG_PATH"/"$tdep"
+        cp -ra "$HAB_PKG_PATH"/"$tdep"/* "$HAB_STUDIO_ROOT""$HAB_PKG_PATH"/"$tdep"
       done
     else
       _hab install $embed
@@ -56,20 +57,21 @@ finish_setup() {
     path_file="$HAB_STUDIO_ROOT/$(_pkgpath_for $path_pkg)/PATH"
     if [ -f "$path_file" ]; then
       if [ -z "$full_path" ]; then
-        full_path="$($bb cat "$path_file")"
+        full_path="$(cat "$path_file")"
       else
-        full_path="$full_path:$($bb cat "$path_file")"
+        full_path="$full_path:$(cat "$path_file")"
       fi
     fi
 
     local tdeps_file
     tdeps_file="$HAB_STUDIO_ROOT/$(_pkgpath_for $path_pkg)/TDEPS"
     if [ -f "$tdeps_file" ]; then
-      for tdep in $($bb cat "$tdeps_file"); do
+      # shellcheck disable=2013
+      for tdep in $(cat "$tdeps_file"); do
         local tdep_path_file
         tdep_path_file="$HAB_STUDIO_ROOT/$(_pkgpath_for "$tdep")/PATH"
         if [ -f "$tdep_path_file" ]; then
-          full_path="$full_path:$($bb cat "$tdep_path_file")"
+          full_path="$full_path:$(cat "$tdep_path_file")"
         fi
       done
     fi
@@ -80,7 +82,7 @@ finish_setup() {
   studio_enter_command="${busybox_path}/bin/sh --login"
 
   # shellcheck disable=2086,2154
-  $bb mkdir -p $v "$HAB_STUDIO_ROOT""$HAB_ROOT_PATH"/bin
+  mkdir -p $v "$HAB_STUDIO_ROOT""$HAB_ROOT_PATH"/bin
 
   # Put `hab` on the default `$PATH`
   _hab pkg binlink --dest "$HAB_ROOT_PATH"/bin core/hab hab
@@ -90,14 +92,14 @@ finish_setup() {
   _hab pkg binlink --dest=/bin core/busybox-static sh
 
   # Set the login shell for any relevant user to be `/bin/bash`
-  $bb sed -e "s,/bin/sh,$busybox_path/bin/bash,g" -i "$HAB_STUDIO_ROOT"/etc/passwd
+  sed -e "s,/bin/sh,$busybox_path/bin/bash,g" -i "$HAB_STUDIO_ROOT"/etc/passwd
 
   echo "${run_user}:x:42:42:root:/:/bin/sh" >> "$HAB_STUDIO_ROOT"/etc/passwd
   echo "${run_group}:x:42:${run_user}" >> "$HAB_STUDIO_ROOT"/etc/group
 
   local sup="$HAB_ROOT_PATH/bin/hab sup"
-  $bb touch "$HAB_STUDIO_ROOT"/.hab_pkg
-  $bb cat <<EOT > "$HAB_STUDIO_ROOT"/init.sh
+  touch "$HAB_STUDIO_ROOT"/.hab_pkg
+  cat <<EOT > "$HAB_STUDIO_ROOT"/init.sh
 #!$busybox_path/bin/sh
 export PATH=$full_path
 case \$1 in
@@ -106,23 +108,23 @@ case \$1 in
   *) exec $sup "\$@";;
 esac
 EOT
-  $bb chmod a+x "$HAB_STUDIO_ROOT"/init.sh
+  chmod a+x "$HAB_STUDIO_ROOT"/init.sh
 
   # remove the unnecessary supporting filesystem
-  $bb rm -rf "$HAB_STUDIO_ROOT"/home "$HAB_STUDIO_ROOT"/lib "$HAB_STUDIO_ROOT"/lib64 "$HAB_STUDIO_ROOT"/mnt "$HAB_STUDIO_ROOT"/opt "$HAB_STUDIO_ROOT"/root "$HAB_STUDIO_ROOT"/run "$HAB_STUDIO_ROOT"/sbin "$HAB_STUDIO_ROOT"/src "$HAB_STUDIO_ROOT"/usr
+  rm -rf "${HAB_STUDIO_ROOT:?}"/home "${HAB_STUDIO_ROOT:?}"/lib "${HAB_STUDIO_ROOT:?}"/lib64 "${HAB_STUDIO_ROOT:?}"/mnt "${HAB_STUDIO_ROOT:?}"/opt "${HAB_STUDIO_ROOT:?}"/root "${HAB_STUDIO_ROOT:?}"/run "${HAB_STUDIO_ROOT:?}"/sbin "${HAB_STUDIO_ROOT:?}"/src "${HAB_STUDIO_ROOT:?}"/usr
 
   studio_env_command="$busybox_path/bin/env"
 }
 
 _hab() {
   # shellcheck disable=2154
-  $bb env FS_ROOT="$HAB_STUDIO_ROOT" HAB_CACHE_KEY_PATH= "$hab" "$@"
+  env FS_ROOT="$HAB_STUDIO_ROOT" HAB_CACHE_KEY_PATH= hab "$@"
 }
 
 _pkgpath_for() {
-  _hab pkg path "$1" | $bb sed -e "s,^$HAB_STUDIO_ROOT,,g"
+  _hab pkg path "$1" | sed -e "s,^$HAB_STUDIO_ROOT,,g"
 }
 
 _outside_pkgpath_for() {
-  $hab pkg path "$1"
+  hab pkg path "$1"
 }

--- a/components/studio/libexec/hab-studio-type-baseimage.sh
+++ b/components/studio/libexec/hab-studio-type-baseimage.sh
@@ -27,12 +27,13 @@ finish_setup() {
       echo "> Using local package for $embed"
       embed_path=$(_outside_pkgpath_for $embed)
       # shellcheck disable=2154
-      $bb mkdir -p "$HAB_STUDIO_ROOT"/"$embed_path"
-      $bb cp -ra "$embed_path"/* "$HAB_STUDIO_ROOT"/"$embed_path"
-      for tdep in $($bb cat "$embed_path"/TDEPS); do
+      mkdir -p "$HAB_STUDIO_ROOT"/"$embed_path"
+      cp -ra "$embed_path"/* "$HAB_STUDIO_ROOT"/"$embed_path"
+      # shellcheck disable=2013
+      for tdep in $(cat "$embed_path"/TDEPS); do
         echo "> Using local package for $tdep via $embed"
-        $bb mkdir -p "$HAB_STUDIO_ROOT""$HAB_PKG_PATH"/"$tdep"
-        $bb cp -ra "$HAB_PKG_PATH"/"$tdep"/* "$HAB_STUDIO_ROOT""$HAB_PKG_PATH"/"$tdep"
+        mkdir -p "$HAB_STUDIO_ROOT""$HAB_PKG_PATH"/"$tdep"
+        cp -ra "$HAB_PKG_PATH"/"$tdep"/* "$HAB_STUDIO_ROOT""$HAB_PKG_PATH"/"$tdep"
       done
     else
       _hab install $embed
@@ -56,20 +57,21 @@ finish_setup() {
     path_file="$HAB_STUDIO_ROOT/$(_pkgpath_for $path_pkg)/PATH"
     if [ -f "$path_file" ]; then
       if [ -z "$full_path" ]; then
-        full_path="$($bb cat "$path_file")"
+        full_path="$(cat "$path_file")"
       else
-        full_path="$full_path:$($bb cat "$path_file")"
+        full_path="$full_path:$(cat "$path_file")"
       fi
     fi
 
     local tdeps_file
     tdeps_file="$HAB_STUDIO_ROOT/$(_pkgpath_for $path_pkg)/TDEPS"
     if [ -f "$tdeps_file" ]; then
-      for tdep in $($bb cat "$tdeps_file"); do
+      # shellcheck disable=2013
+      for tdep in $(cat "$tdeps_file"); do
         local tdep_path_file
         tdep_path_file="$HAB_STUDIO_ROOT/$(_pkgpath_for "$tdep")/PATH"
         if [ -f "$tdep_path_file" ]; then
-          full_path="$full_path:$($bb cat "$tdep_path_file")"
+          full_path="$full_path:$(cat "$tdep_path_file")"
         fi
       done
     fi
@@ -80,7 +82,7 @@ finish_setup() {
   studio_enter_command="${busybox_path}/bin/sh --login"
 
   # shellcheck disable=2086,2154
-  $bb mkdir -p $v "$HAB_STUDIO_ROOT""$HAB_ROOT_PATH"/bin
+  mkdir -p $v "$HAB_STUDIO_ROOT""$HAB_ROOT_PATH"/bin
 
   # Put `hab` on the default `$PATH`
   _hab pkg binlink --dest "$HAB_ROOT_PATH"/bin core/hab hab
@@ -90,9 +92,9 @@ finish_setup() {
   _hab pkg binlink --dest=/bin core/busybox-static sh
 
   # Set the login shell for any relevant user to be `/bin/bash`
-  $bb sed -e "s,/bin/sh,$busybox_path/bin/bash,g" -i "$HAB_STUDIO_ROOT"/etc/passwd
+  sed -e "s,/bin/sh,$busybox_path/bin/bash,g" -i "$HAB_STUDIO_ROOT"/etc/passwd
 
-  $bb cat <<PROFILE > "$HAB_STUDIO_ROOT"/etc/profile
+  cat <<PROFILE > "$HAB_STUDIO_ROOT"/etc/profile
 # Add hab to the default \$PATH at the front so any wrapping scripts will
 # be found and called first
 export PATH=$full_path:\$PATH
@@ -106,12 +108,12 @@ alias fgrep='fgrep --color=auto'
 source <(hab cli completers --shell bash)
 PROFILE
 
-  $bb cat <<EOT > "$HAB_STUDIO_ROOT"/etc/resolv.conf
+  cat <<EOT > "$HAB_STUDIO_ROOT"/etc/resolv.conf
 nameserver 8.8.8.8
 nameserver 8.8.4.4
 EOT
 
-  $bb cat <<EOT > "$HAB_STUDIO_ROOT"/etc/nsswitch.conf
+  cat <<EOT > "$HAB_STUDIO_ROOT"/etc/nsswitch.conf
 passwd:     files
 group:      files
 shadow:     files
@@ -126,8 +128,8 @@ EOT
   echo "${run_group}:x:42:${run_user}" >> "$HAB_STUDIO_ROOT"/etc/group
 
   local sup="$HAB_ROOT_PATH/bin/hab sup"
-  $bb touch "$HAB_STUDIO_ROOT"/.hab_pkg
-  $bb cat <<EOT > "$HAB_STUDIO_ROOT"/init.sh
+  touch "$HAB_STUDIO_ROOT"/.hab_pkg
+  cat <<EOT > "$HAB_STUDIO_ROOT"/init.sh
 #!$busybox_path/bin/sh
 export PATH=$full_path
 case \$1 in
@@ -136,20 +138,19 @@ case \$1 in
   *) exec $sup "\$@";;
 esac
 EOT
-  $bb chmod a+x "$HAB_STUDIO_ROOT"/init.sh
+  chmod a+x "$HAB_STUDIO_ROOT"/init.sh
 
   studio_env_command="$busybox_path/bin/env"
 }
 
 _hab() {
-  # shellcheck disable=2154
-  $bb env FS_ROOT="$HAB_STUDIO_ROOT" HAB_CACHE_KEY_PATH= "$hab" "$@"
+  env FS_ROOT="$HAB_STUDIO_ROOT" HAB_CACHE_KEY_PATH= hab "$@"
 }
 
 _pkgpath_for() {
-  _hab pkg path "$1" | $bb sed -e "s,^$HAB_STUDIO_ROOT,,g"
+  _hab pkg path "$1" | sed -e "s,^$HAB_STUDIO_ROOT,,g"
 }
 
 _outside_pkgpath_for() {
-  $hab pkg path "$1"
+  hab pkg path "$1"
 }

--- a/components/studio/libexec/hab-studio-type-busybox.sh
+++ b/components/studio/libexec/hab-studio-type-busybox.sh
@@ -16,18 +16,18 @@ studio_run_command="/opt/busybox/busybox sh -l"
 finish_setup() {
   # Copy in the busybox binary under `/opt/busybox`
   # shellcheck disable=2154,2086
-  $bb mkdir -p $v "$HAB_STUDIO_ROOT"/opt/busybox
+  mkdir -p $v "$HAB_STUDIO_ROOT"/opt/busybox
   # shellcheck disable=2154,2086
-  $bb cp $v "$libexec_path"/busybox "$HAB_STUDIO_ROOT"/opt/busybox/
+  cp $v "$libexec_path"/busybox "$HAB_STUDIO_ROOT"/opt/busybox/
 
   if [ ! -f "$HAB_STUDIO_ROOT/opt/busybox/sh" ]; then
     # Symlink all tools to busybox under `/opt/busybox`
     for c in $("$HAB_STUDIO_ROOT"/opt/busybox/busybox --list); do
       # shellcheck disable=2086
-      $bb ln -sf $v busybox "$HAB_STUDIO_ROOT"/opt/busybox/$c
+      ln -sf $v busybox "$HAB_STUDIO_ROOT"/opt/busybox/$c
     done
   fi
 
   # Set the login shell for any relevant user to be busybox's `sh`
-  $bb sed -e 's,/bin/sh,/opt/busybox/sh,g' -i "$HAB_STUDIO_ROOT"/etc/passwd
+  sed -e 's,/bin/sh,/opt/busybox/sh,g' -i "$HAB_STUDIO_ROOT"/etc/passwd
 }


### PR DESCRIPTION
    * Adds simlinks for all busybox commands in libexec/bin
      so that we can remove the $bb leader from commands when
      setting up studios.
    * Removes Busybox from record function since this env var
      will never be set after executing chroot.
    * Uses functions in set_libexec_path to avoid needing $bb
    * Updates set_libexec_path canonicalization logic to use
      pwd -P which should be more portable.
    * Use hab from PATH (libexec_path) instead of hardcoded
      binary.

    This pr is starting work to make habitat work on mac or other
    platforms that don't have busybox.

    Signed-off-by: Jon Morrow <jmorrow@chef.io>