### PR TITLE
[hab-sup] Copy binding_mode when transforming Service to ServiceSpec

### DIFF
--- a/components/sup/src/manager/service/mod.rs
+++ b/components/sup/src/manager/service/mod.rs
@@ -400,6 +400,7 @@ impl Service {
         spec.topology = self.topology;
         spec.update_strategy = self.update_strategy;
         spec.binds = self.binds.clone();
+        spec.binding_mode = self.binding_mode;
         spec.config_from = self.config_from.clone();
         if let Some(ref password) = self.svc_encrypted_password {
             spec.svc_encrypted_password = Some(password.clone())


### PR DESCRIPTION
Failing to copy the binding mode leads the spec_watcher to erroneously
detect changes for binding_mode-relaxed services.

Fixes #5703

Signed-off-by: Steven Danna <steve@chef.io>