### PR TITLE
Make logging around user.toml changes more specific

### DIFF
--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -1699,10 +1699,9 @@ impl Manager {
             .services
             .write()
             .expect("Services lock is poisoned");
-
         for service in services.values_mut() {
             if self.user_config_watcher.have_events_for(service) {
-                outputln!("Reloading service {}", &service.spec_ident);
+                outputln!("user.toml changes detected for {}", &service.spec_ident);
                 service.user_config_updated = true;
             }
         }


### PR DESCRIPTION
Previously, no indication was given as to *why* a service was
restarting here. Additionally, the service doesn't necessarily have to
restart; that will only if the `user.toml` changes result in any
changes to templated files.

Signed-off-by: Christopher Maier <cmaier@chef.io>