### PR TITLE
Don't spam the Supervisor logs quite so much

### DIFF
--- a/components/sup/src/manager/service/config.rs
+++ b/components/sup/src/manager/service/config.rs
@@ -504,6 +504,9 @@ impl CfgRenderer {
         // error resulting in the end-user not knowing what the fuck happned at all. We need to go
         // through this and pipe the service group through to let people know which service is
         // having issues and be more descriptive about what happened.
+
+        let service_group_name = ctx.service_group_name();
+
         let mut changed = false;
         for (template, _) in self.0.get_templates() {
             let compiled = self.0.render(&template, ctx)?;
@@ -521,11 +524,14 @@ impl CfgRenderer {
                     "Configuration {} does not exist; restarting",
                     cfg_dest.display()
                 );
-                outputln!(preamble ctx.group_name(), "Updated {} {}",
-                          template.as_str(),
-                          compiled_hash);
+
                 let mut config_file = File::create(&cfg_dest)?;
                 config_file.write_all(&compiled.into_bytes())?;
+                outputln!(
+                    preamble service_group_name,
+                    "Created configuration file {}",
+                    cfg_dest.display()
+                );
 
                 if cfg!(not(windows)) {
                     if abilities::can_run_services_as_svc_user() {
@@ -557,9 +563,12 @@ impl CfgRenderer {
                         "Configuration {} has changed; restarting",
                         cfg_dest.display()
                     );
-                    outputln!(preamble ctx.group_name(),"Updated {} {}",
-                              template.as_str(),
-                              compiled_hash);
+                    outputln!(
+                        preamble service_group_name,
+                        "Modified configuration content in {}",
+                        cfg_dest.display()
+                    );
+
                     let mut config_file = File::create(&cfg_dest)?;
                     config_file.write_all(&compiled.into_bytes())?;
 

--- a/components/sup/src/manager/service/hooks.rs
+++ b/components/sup/src/manager/service/hooks.rs
@@ -103,8 +103,9 @@ pub trait Hook: fmt::Debug + Sized {
     fn compile(&self, service_group: &ServiceGroup, ctx: &RenderContext) -> Result<bool> {
         let content = self.renderer().render(Self::file_name(), ctx)?;
         if write_hook(&content, self.path())? {
-            outputln!(preamble service_group, "{}, compiled to {}", Self::file_name(),
-                self.path().display());
+            outputln!(preamble service_group,
+                      "Modified hook content in {}",
+                      self.path().display());
             if cfg!(not(windows)) {
                 hcore::util::perm::set_permissions(self.path(), HOOK_PERMISSIONS)?;
             }
@@ -887,7 +888,6 @@ impl HookTable {
         if let Some(ref hook) = self.post_stop {
             changed = self.compile_one(hook, service_group, ctx) || changed;
         }
-        outputln!(preamble service_group, "Hooks compiled");
         changed
     }
 

--- a/components/sup/src/manager/service/mod.rs
+++ b/components/sup/src/manager/service/mod.rs
@@ -755,10 +755,7 @@ impl Service {
     /// Returns `true` if the configuration has changed.
     fn compile_configuration(&self, ctx: &RenderContext) -> bool {
         match self.config_renderer.compile(&self.pkg, ctx) {
-            Ok(true) => {
-                outputln!(preamble self.service_group, "Configuration recompiled");
-                true
-            }
+            Ok(true) => true,
             Ok(false) => false,
             Err(e) => {
                 outputln!(preamble self.service_group,

--- a/components/sup/src/manager/service/mod.rs
+++ b/components/sup/src/manager/service/mod.rs
@@ -445,11 +445,12 @@ impl Service {
                                   unsatisfied);
                 }
                 BindStatus::Satisfied => {
-                    outputln!(preamble self.service_group,
-                                  "The group '{}' satisfies the `{}` bind",
-                                  bind.service_group,
-                                  bind.name);
-
+                    // Since this function is currently called any
+                    // time the census changes, and this is the
+                    // expected steady-state of a properly running
+                    // service, we won't log anything here. Otherwise
+                    // we'd just spam the logs. Instead, log only on a
+                    // state change (see below).
                     bind_is_unsatisfied = false;
                 }
                 BindStatus::Unknown(ref e) => {
@@ -465,7 +466,17 @@ impl Service {
                 // TODO (CM): use Entry API to clone only when necessary
                 self.unsatisfied_binds.insert((*bind).clone())
             } else {
-                self.unsatisfied_binds.remove(*bind)
+                if self.unsatisfied_binds.remove(*bind) {
+                    // We'll log if the bind was previously
+                    // unsatisfied, but now it is satisfied.
+                    outputln!(preamble self.service_group,
+                              "The group '{}' satisfies the `{}` bind",
+                              bind.service_group,
+                              bind.name);
+                    true
+                } else {
+                    false
+                }
             };
         }
     }

--- a/components/sup/src/templating/context.rs
+++ b/components/sup/src/templating/context.rs
@@ -120,8 +120,8 @@ impl<'a> RenderContext<'a> {
     }
 
     // Exposed only for logging... can probably do this another way.
-    pub fn group_name(&self) -> &str {
-        self.svc.service_group.group()
+    pub fn service_group_name(&self) -> String {
+        format!("{}", self.svc.service_group)
     }
 }
 


### PR DESCRIPTION
This brings a little bit of sanity to our logging.

Two large "spam" offenders are the "Hooks compiled" and "The group X satisfies the Y bind" lines. The former was emitted any time we processed hook files, and not just when a hook file actually changed. Similarly, the bind satisfaction line was emitted every time the census changed and bind satisfaction was re-evaluated, whether they changed or not.

Now we only log about these things when something actually changes.

Additionally, the content of the logging around these has been modified a bit for clarity. As always, see the commit messages for further details.

![tenor-37136541](https://user-images.githubusercontent.com/207178/46555553-ae124680-c8b1-11e8-8c7d-3dee4f75e1ca.gif)
