### PR TITLE
Remove "maintenance window" step from release pipeline

### DIFF
--- a/.buildkite/finish_release_pipeline.yaml
+++ b/.buildkite/finish_release_pipeline.yaml
@@ -1,22 +1,18 @@
 steps:
-  - block: ":raised_hand: Set Maintenance Window"
-    prompt: |
-      Until we sort through a suspected Supervisor bug, releases have
-      the potential to cause instability in Builder. Please declare a
-      maintenance window in Statuspage before proceeding any further.
-
   - label: ":right-facing_fist: :boom: :left-facing_fist: Promote Release for consumption by Builder"
     command: .buildkite/scripts/promote_release_channel.sh builder-live
     agents:
       queue: habitat-release
 
-  - block: ":habicat: Wait until Builder is stabilized"
+  - block: ":habicat: Ensure that Builder is stable on the new release"
     prompt: |
-      Until we sort through a suspected Supervisor bug, it is possible
-      that Builder can get destabilized once the Supervisor has been
-      promoted to the stable channel. This should be less of an issue
-      as our operations and software mature, but until then, it is
-      nice to explicitly factor that into our release process.
+      We do not anticipate any issues updating the Supervisors in
+      Builder, but on the off chance that we discover some terrible
+      bug at the last minute, this allows us one last opportunity to
+      halt the release.
+
+      After this step is unblocked, the new artifacts become available
+      to the world.
 
   - label: ":right-facing_fist: :boom: :left-facing_fist: Promote Release to stable"
     command: .buildkite/scripts/promote_release_channel.sh stable


### PR DESCRIPTION
We had a bug that complicated the rollout of new Supervisors to
Builder. To compensate for that until we were able to track it down,
we would declare maintenance windows for the service, just in case we
had an issue with the release.

Thankfully, that bug is now fixed (see #5588, #5616, and #5673), so we
no longer need to do this!

We'll keep the blocking step between the updating of Builder and the
promotion of release artifacts to the stable channel, as one last
safety valve, just in case. Better to have it and not need it, than to
need it and not have it.

Signed-off-by: Christopher Maier <cmaier@chef.io>