### PR TITLE
Don't change svc directory permissions except when the directory is created

### DIFF
--- a/components/sup/src/manager/service/dir.rs
+++ b/components/sup/src/manager/service/dir.rs
@@ -116,6 +116,13 @@ impl<'a> SvcDir<'a> {
     where
         P: AsRef<Path>,
     {
+        // We do not want to change the permissions of an already
+        // existing directory
+        // See https://github.com/habitat-sh/habitat/issues/4475
+        if path.as_ref().exists() {
+            return Ok(());
+        }
+
         Self::create_dir_all(&path)?;
         if cfg!(not(windows)) {
             if abilities::can_run_services_as_svc_user() {

--- a/test/integration/sup-hup.bats
+++ b/test/integration/sup-hup.bats
@@ -1,0 +1,54 @@
+#!/usr/bin/env bats
+
+load 'helpers'
+
+setup() {
+    reset_hab_root
+}
+
+teardown() {
+    stop_supervisor
+}
+
+sup_restarted() {
+    local old_pid="${1}"
+    local new_pid="$(pgrep 'hab-sup')"
+    if [[ "$old_pid" -eq "$new_pid" ]]; then
+        return 0
+    fi
+    return 1
+}
+
+@test "supervisor: restart does not chown directories" {
+    background ${hab} run
+    sleep 2 # give it a sec to come up
+
+    ${hab} pkg install core/runit --binlink
+
+    # start up nginx
+    ${hab} pkg install core/nginx
+    ${hab} svc load core/nginx
+    wait_for_service_to_run nginx
+
+    # create an index.html so there is a page to fetch
+    echo "test" > /hab/svc/nginx/data/index.html
+
+    # the nginx children (running as hab) should all have access 
+    # to the index.html at this point
+    run curl -s -o /dev/null -w "%{http_code}" http://localhost
+    [ "$output" = "200" ]
+
+    # remove permissions for the hab user to access the nginx data
+    # directory. All index.html requests will now return 403
+    chmod g-rwx /hab/svc/nginx/data/
+    run curl -s -o /dev/null -w "%{http_code}" http://localhost
+    [ "$output" = "403" ]
+
+    local sup_pid="$(pgrep 'hab-sup')"
+    kill -s SIGHUP "$sup_pid"
+
+    retry 5 1 sup_restarted "$sup_pid"
+    run curl -s -o /dev/null -w "%{http_code}" http://localhost
+    [ "$output" = "403" ]
+}
+


### PR DESCRIPTION
When hab-sup is restarted, it used to change the directory permissions
to the default ones that it expected. This is problematic for things
like nginx because nginx itself runs as root, however the hooks set up
permissions so that the children don't have to run as root. If hab-sup
was restarted, these directory permissions would be reset and the hooks
themselves don't necessarily run.

Fixes #4475