### PR TITLE
Skip Appveyor if only the docs are updated

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,6 +19,12 @@ init:
 
 clone_folder: c:\projects\habitat
 
+# Avoid running tests if only the docs are modofied
+skip_commits:
+  files:
+    - '*.md'
+    - docs/*.md
+
 environment:
   CI: true
   CARGO_HOME: "c:\\cargo"


### PR DESCRIPTION
We've had some periods of builds queueing up on Appveyor lately.
This change will keep Appveyor from running if only docs are modified.
This will also avoid running against the Expeditor commits against the
`CHANGELOG.md` that happens with every merge.

Signed-off-by: Bryan McLellan <btm@loftninjas.org>