### PR TITLE
Remove unnecessary crate version pins, fix typo and add comments for hyper pins

### DIFF
--- a/components/builder-api-client/Cargo.toml
+++ b/components/builder-api-client/Cargo.toml
@@ -8,8 +8,9 @@ workspace = "../../"
 broadcast = "*"
 chrono = "*"
 clippy = {version = "*", optional = true}
+# Pending upgrade activities in https://github.com/habitat-sh/core/issues/72
 hyper = "0.10"
-hyper-openssl = ""
+hyper-openssl = "*"
 log = "*"
 pbr = "*"
 rand = "*"

--- a/components/butterfly/Cargo.toml
+++ b/components/butterfly/Cargo.toml
@@ -36,7 +36,7 @@ mktemp = "*"
 
 [build-dependencies]
 heck = "*"
-pkg-config = "0.3"
+pkg-config = "*"
 prost = "*"
 prost-build = "*"
 tempdir = "*"

--- a/components/common/Cargo.toml
+++ b/components/common/Cargo.toml
@@ -8,6 +8,7 @@ workspace = "../../"
 clippy = {version = "*", optional = true}
 ansi_term = "*"
 glob = "*"
+# Pending upgrade activities in https://github.com/habitat-sh/core/issues/72
 hyper = "0.10"
 libc = "*"
 log = "*"

--- a/components/eventsrv-client/Cargo.toml
+++ b/components/eventsrv-client/Cargo.toml
@@ -24,7 +24,7 @@ git = "https://github.com/erickt/rust-zmq"
 branch = "release/v0.8"
 
 [build-dependencies]
-pkg-config = "0.3"
+pkg-config = "*"
 
 [features]
 default = []

--- a/components/eventsrv/Cargo.toml
+++ b/components/eventsrv/Cargo.toml
@@ -28,7 +28,7 @@ git = "https://github.com/erickt/rust-zmq"
 branch = "release/v0.8"
 
 [build-dependencies]
-pkg-config = "0.3"
+pkg-config = "*"
 
 [features]
 default = []

--- a/components/hab/Cargo.toml
+++ b/components/hab/Cargo.toml
@@ -18,6 +18,7 @@ dirs = "*"
 env_logger = "*"
 features = "*"
 futures = "*"
+# Pending upgrade activities in https://github.com/habitat-sh/core/issues/72
 hyper = "0.10"
 habitat-sup-client = { path = "../sup-client" }
 habitat-sup-protocol = { path = "../sup-protocol", default-features = false }
@@ -32,7 +33,7 @@ retry = "*"
 serde = "*"
 serde_json = "*"
 serde_derive = "*"
-tabwriter = "1"
+tabwriter = "*"
 toml = { version = "*", default-features = false }
 url = "*"
 walkdir = "*"

--- a/components/launcher-protocol/Cargo.toml
+++ b/components/launcher-protocol/Cargo.toml
@@ -10,7 +10,7 @@ serde = "*"
 serde_derive = "*"
 
 [build-dependencies]
-pkg-config = "0.3"
+pkg-config = "*"
 
 [features]
 protocols = []

--- a/components/pkg-export-helm/Cargo.toml
+++ b/components/pkg-export-helm/Cargo.toml
@@ -21,8 +21,8 @@ habitat_pkg_export_kubernetes = { path = "../pkg-export-kubernetes" }
 handlebars = { version = "0.29.1", default-features = false }
 lazy_static = "*"
 log = "*"
-serde = "1.0.2"
-serde_json = "1.0.0"
+serde = "*"
+serde_json = "*"
 failure = "*"
 failure_derive = "*"
 url = "*"

--- a/components/pkg-export-kubernetes/Cargo.toml
+++ b/components/pkg-export-kubernetes/Cargo.toml
@@ -24,8 +24,8 @@ habitat_pkg_export_docker = { path = "../pkg-export-docker" }
 # We need to lock here since v0.30.0 bumps to a version of pest that fails to build on Windows.
 handlebars = { version = "0.29.1", default-features = false }
 log = "*"
-serde = "1.0.2"
-serde_json = "1.0.0"
+serde = "*"
+serde_json = "*"
 failure = "*"
 failure_derive = "*"
 

--- a/components/pkg-export-tar/Cargo.toml
+++ b/components/pkg-export-tar/Cargo.toml
@@ -24,8 +24,8 @@ handlebars = { version = "0.29.1", default-features = false }
 lazy_static = "*"
 log = "*"
 mktemp = "*"
-serde = { version = "1.0", features = ["rc"] }
-serde_json = "1.0"
+serde = { version = "*", features = ["rc"] }
+serde_json = "*"
 url = "*"
 failure = "*"
 failure_derive = "*"

--- a/components/sup/Cargo.toml
+++ b/components/sup/Cargo.toml
@@ -75,6 +75,7 @@ ctrlc = "*"
 winapi = "*"
 
 [dev-dependencies]
+# Pending upgrade activities in https://github.com/habitat-sh/core/issues/72
 hyper = "0.10"
 json = "*"
 


### PR DESCRIPTION
Relaxes pins on pkg-config, tabwriter, serde and serde-json

Running `cargo update` didn't result in any changes to Cargo.lock, so these should be totally safe.