### PR TITLE
Replace launcher's Process struct's unsafe implementations with rust stdlib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Don't show ident for incomplete jobs [#5676](https://github.com/habitat-sh/habitat/pull/5676) ([chefsalim](https://github.com/chefsalim))
 
 #### Bug Fixes
+- Don&#39;t change svc directory permissions except when the directory is created [#5720](https://github.com/habitat-sh/habitat/pull/5720) ([jaym](https://github.com/jaym))
 - Remove unnecessary crate version pins, fix typo and add comments for hyper pins [#5729](https://github.com/habitat-sh/habitat/pull/5729) ([baumanj](https://github.com/baumanj))
 - Tokio deprecation fixes [#5727](https://github.com/habitat-sh/habitat/pull/5727) ([baumanj](https://github.com/baumanj))
 - Don&#39;t abandon service processes after a Supervisor restart [#5697](https://github.com/habitat-sh/habitat/pull/5697) ([christophermaier](https://github.com/christophermaier))

--- a/components/launcher/src/server/handlers/restart.rs
+++ b/components/launcher/src/server/handlers/restart.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use core::os::process::Pid;
 use protocol;
 
 use super::{HandleResult, Handler};
@@ -25,7 +24,7 @@ impl Handler for RestartHandler {
     type Reply = protocol::SpawnOk;
 
     fn handle(msg: Self::Message, services: &mut ServiceTable) -> HandleResult<Self::Reply> {
-        let mut service = match services.remove(msg.get_pid() as Pid) {
+        let mut service = match services.remove(msg.get_pid() as u32) {
             Some(service) => service,
             None => {
                 let mut reply = protocol::NetErr::new();
@@ -44,7 +43,11 @@ impl Handler for RestartHandler {
                 }
                 Err(err) => Err(protocol::error(err)),
             },
-            Err(err) => Err(protocol::error(err)),
+            Err(_) => {
+                let mut reply = protocol::NetErr::new();
+                reply.set_code(protocol::ErrCode::ExecWait);
+                Err(reply)
+            }
         }
     }
 }

--- a/components/launcher/src/server/mod.rs
+++ b/components/launcher/src/server/mod.rs
@@ -341,14 +341,14 @@ impl Server {
 }
 
 #[derive(Debug, Default)]
-pub struct ServiceTable(HashMap<Pid, Service>);
+pub struct ServiceTable(HashMap<u32, Service>);
 
 impl ServiceTable {
-    pub fn get(&self, pid: Pid) -> Option<&Service> {
+    pub fn get(&self, pid: u32) -> Option<&Service> {
         self.0.get(&pid)
     }
 
-    pub fn get_mut(&mut self, pid: Pid) -> Option<&mut Service> {
+    pub fn get_mut(&mut self, pid: u32) -> Option<&mut Service> {
         self.0.get_mut(&pid)
     }
 
@@ -356,7 +356,7 @@ impl ServiceTable {
         self.0.insert(service.id(), service);
     }
 
-    pub fn remove(&mut self, pid: Pid) -> Option<Service> {
+    pub fn remove(&mut self, pid: u32) -> Option<Service> {
         self.0.remove(&pid)
     }
 
@@ -369,7 +369,7 @@ impl ServiceTable {
     }
 
     fn reap_services(&mut self) {
-        let mut dead: Vec<Pid> = vec![];
+        let mut dead: Vec<u32> = vec![];
         for service in self.0.values_mut() {
             match service.try_wait() {
                 Ok(None) => (),

--- a/components/launcher/src/service.rs
+++ b/components/launcher/src/service.rs
@@ -20,16 +20,13 @@ use std::thread;
 
 #[cfg(windows)]
 use core::os::process::windows_child::{ChildStderr, ChildStdout, ExitStatus};
-use core::os::process::Pid;
 use protocol;
 
-use error::Result;
 pub use sys::service::*;
 
 pub struct Service {
     args: protocol::Spawn,
     process: Process,
-    status: Option<ExitStatus>,
 }
 
 impl Service {
@@ -56,7 +53,6 @@ impl Service {
         Service {
             args: spawn,
             process: process,
-            status: None,
         }
     }
 
@@ -64,7 +60,7 @@ impl Service {
         &self.args
     }
 
-    pub fn id(&self) -> Pid {
+    pub fn id(&self) -> u32 {
         self.process.id()
     }
 
@@ -82,23 +78,18 @@ impl Service {
         self.args
     }
 
-    pub fn try_wait(&mut self) -> Result<Option<ExitStatus>> {
+    pub fn try_wait(&mut self) -> io::Result<Option<ExitStatus>> {
         self.process.try_wait()
     }
 
-    pub fn wait(&mut self) -> Result<ExitStatus> {
+    pub fn wait(&mut self) -> io::Result<ExitStatus> {
         self.process.wait()
     }
 }
 
 impl fmt::Debug for Service {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "Service {{ status: {:?}, pid: {:?} }}",
-            self.status,
-            self.process.id()
-        )
+        write!(f, "Service {{ pid: {:?} }}", self.process.id())
     }
 }
 

--- a/components/launcher/src/sys/windows/service.rs
+++ b/components/launcher/src/sys/windows/service.rs
@@ -52,6 +52,8 @@ impl Process {
         unsafe { processthreadsapi::GetProcessId(self.handle.raw()) as u32 }
     }
 
+    /// Attempt to gracefully terminate a process and then forcefully kill it after
+    /// 8 seconds if it has not terminated.
     pub fn kill(&mut self) -> ShutdownMethod {
         if self.status().is_some() {
             return ShutdownMethod::AlreadyExited;


### PR DESCRIPTION
Now that try and try_wait exist, Process can be a thin wrapper around
std::process::Child on unix. Unfortunately, the same isn't currently feasible
on Windows, since the process spawning depends on additional features not
available in the rust stdlib currently.

Also, fix some typos.

Resolves https://github.com/habitat-sh/habitat/issues/5361