### PR TITLE
Replace launcher's Process struct's unsafe implementations with rust stdlib

### DIFF
--- a/components/launcher/src/server/handlers/restart.rs
+++ b/components/launcher/src/server/handlers/restart.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use core::os::process::Pid;
 use protocol;
 
 use super::{HandleResult, Handler};
@@ -25,7 +24,7 @@ impl Handler for RestartHandler {
     type Reply = protocol::SpawnOk;
 
     fn handle(msg: Self::Message, services: &mut ServiceTable) -> HandleResult<Self::Reply> {
-        let mut service = match services.remove(msg.get_pid() as Pid) {
+        let mut service = match services.remove(msg.get_pid() as u32) {
             Some(service) => service,
             None => {
                 let mut reply = protocol::NetErr::new();
@@ -44,7 +43,11 @@ impl Handler for RestartHandler {
                 }
                 Err(err) => Err(protocol::error(err)),
             },
-            Err(err) => Err(protocol::error(err)),
+            Err(_) => {
+                let mut reply = protocol::NetErr::new();
+                reply.set_code(protocol::ErrCode::ExecWait);
+                Err(reply)
+            }
         }
     }
 }

--- a/components/launcher/src/server/mod.rs
+++ b/components/launcher/src/server/mod.rs
@@ -341,14 +341,14 @@ impl Server {
 }
 
 #[derive(Debug, Default)]
-pub struct ServiceTable(HashMap<Pid, Service>);
+pub struct ServiceTable(HashMap<u32, Service>);
 
 impl ServiceTable {
-    pub fn get(&self, pid: Pid) -> Option<&Service> {
+    pub fn get(&self, pid: u32) -> Option<&Service> {
         self.0.get(&pid)
     }
 
-    pub fn get_mut(&mut self, pid: Pid) -> Option<&mut Service> {
+    pub fn get_mut(&mut self, pid: u32) -> Option<&mut Service> {
         self.0.get_mut(&pid)
     }
 
@@ -356,7 +356,7 @@ impl ServiceTable {
         self.0.insert(service.id(), service);
     }
 
-    pub fn remove(&mut self, pid: Pid) -> Option<Service> {
+    pub fn remove(&mut self, pid: u32) -> Option<Service> {
         self.0.remove(&pid)
     }
 
@@ -369,7 +369,7 @@ impl ServiceTable {
     }
 
     fn reap_services(&mut self) {
-        let mut dead: Vec<Pid> = vec![];
+        let mut dead: Vec<u32> = vec![];
         for service in self.0.values_mut() {
             match service.try_wait() {
                 Ok(None) => (),

--- a/components/launcher/src/server/mod.rs
+++ b/components/launcher/src/server/mod.rs
@@ -34,6 +34,7 @@ use core::os::process::{self, Pid, Signal};
 use core::os::signals::{self, SignalEvent};
 use core::package::{PackageIdent, PackageInstall};
 use ipc_channel::ipc::{IpcOneShotServer, IpcReceiver, IpcSender};
+#[cfg(unix)]
 use libc;
 use protobuf;
 use protocol::{self, ERR_NO_RETRY_EXCODE, OK_NO_RETRY_EXCODE};

--- a/components/launcher/src/service.rs
+++ b/components/launcher/src/service.rs
@@ -20,16 +20,13 @@ use std::thread;
 
 #[cfg(windows)]
 use core::os::process::windows_child::{ChildStderr, ChildStdout, ExitStatus};
-use core::os::process::Pid;
 use protocol;
 
-use error::Result;
 pub use sys::service::*;
 
 pub struct Service {
     args: protocol::Spawn,
     process: Process,
-    status: Option<ExitStatus>,
 }
 
 impl Service {
@@ -56,7 +53,6 @@ impl Service {
         Service {
             args: spawn,
             process: process,
-            status: None,
         }
     }
 
@@ -64,7 +60,7 @@ impl Service {
         &self.args
     }
 
-    pub fn id(&self) -> Pid {
+    pub fn id(&self) -> u32 {
         self.process.id()
     }
 
@@ -82,23 +78,18 @@ impl Service {
         self.args
     }
 
-    pub fn try_wait(&mut self) -> Result<Option<ExitStatus>> {
+    pub fn try_wait(&mut self) -> io::Result<Option<ExitStatus>> {
         self.process.try_wait()
     }
 
-    pub fn wait(&mut self) -> Result<ExitStatus> {
+    pub fn wait(&mut self) -> io::Result<ExitStatus> {
         self.process.wait()
     }
 }
 
 impl fmt::Debug for Service {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "Service {{ status: {:?}, pid: {:?} }}",
-            self.status,
-            self.process.id()
-        )
+        write!(f, "Service {{ pid: {:?} }}", self.process.id())
     }
 }
 

--- a/components/launcher/src/sys/windows/service.rs
+++ b/components/launcher/src/sys/windows/service.rs
@@ -52,6 +52,8 @@ impl Process {
         unsafe { processthreadsapi::GetProcessId(self.handle.raw()) as u32 }
     }
 
+    /// Attempt to gracefully terminate a process and then forcefully kill it after
+    /// 8 seconds if it has not terminated.
     pub fn kill(&mut self) -> ShutdownMethod {
         if self.status().is_some() {
             return ShutdownMethod::AlreadyExited;

--- a/components/launcher/src/sys/windows/service.rs
+++ b/components/launcher/src/sys/windows/service.rs
@@ -85,13 +85,13 @@ impl Process {
         unsafe {
             let res = synchapi::WaitForSingleObject(self.handle.raw(), INFINITE);
             if res != WAIT_OBJECT_0 {
-                return Err(Error::ExecWait(io::Error::last_os_error()));
+                return Err(io::Error::last_os_error());
             }
             let mut status = 0;
             cvt(processthreadsapi::GetExitCodeProcess(
                 self.handle.raw(),
                 &mut status,
-            )).map_err(Error::ExecWait)?;
+            )?;
             Ok(ExitStatus::from(status))
         }
     }
@@ -101,13 +101,13 @@ impl Process {
             match synchapi::WaitForSingleObject(self.handle.raw(), 0) {
                 WAIT_OBJECT_0 => {}
                 WAIT_TIMEOUT => return Ok(None),
-                _ => return Err(Error::ExecWait(io::Error::last_os_error())),
+                _ => return Err(io::Error::last_os_error()),
             }
             let mut status = 0;
             cvt(processthreadsapi::GetExitCodeProcess(
                 self.handle.raw(),
                 &mut status,
-            )).map_err(Error::ExecWait)?;
+            )?;
             Ok(Some(ExitStatus::from(status)))
         }
     }

--- a/components/launcher/src/sys/windows/service.rs
+++ b/components/launcher/src/sys/windows/service.rs
@@ -91,7 +91,7 @@ impl Process {
             cvt(processthreadsapi::GetExitCodeProcess(
                 self.handle.raw(),
                 &mut status,
-            )?;
+            ))?;
             Ok(ExitStatus::from(status))
         }
     }
@@ -107,7 +107,7 @@ impl Process {
             cvt(processthreadsapi::GetExitCodeProcess(
                 self.handle.raw(),
                 &mut status,
-            )?;
+            ))?;
             Ok(Some(ExitStatus::from(status)))
         }
     }

--- a/components/launcher/src/sys/windows/service.rs
+++ b/components/launcher/src/sys/windows/service.rs
@@ -81,7 +81,7 @@ impl Process {
         }
     }
 
-    pub fn wait(&mut self) -> Result<ExitStatus> {
+    pub fn wait(&mut self) -> io::Result<ExitStatus> {
         unsafe {
             let res = synchapi::WaitForSingleObject(self.handle.raw(), INFINITE);
             if res != WAIT_OBJECT_0 {
@@ -96,7 +96,7 @@ impl Process {
         }
     }
 
-    pub fn try_wait(&mut self) -> Result<Option<ExitStatus>> {
+    pub fn try_wait(&mut self) -> io::Result<Option<ExitStatus>> {
         unsafe {
             match synchapi::WaitForSingleObject(self.handle.raw(), 0) {
                 WAIT_OBJECT_0 => {}


### PR DESCRIPTION
Now that try and try_wait exist, Process can be a thin wrapper around
std::process::Child on unix. Unfortunately, the same isn't currently feasible
on Windows, since the process spawning depends on additional features not
available in the rust stdlib currently.

Also, fix some typos.

Resolves https://github.com/habitat-sh/habitat/issues/5361