### PR TITLE
[ci] Update Buildkite to Rust 1.29.1

### DIFF
--- a/.buildkite/env
+++ b/.buildkite/env
@@ -8,7 +8,7 @@ set -euo pipefail
 # Use this to specify a toolchain for Rustup on platforms where that's
 # how we get Rust (e.g., macOS)
 if [[ -z "${RUST_TOOLCHAIN:-}" ]]; then
-    export RUST_TOOLCHAIN="1.29.0"
+    export RUST_TOOLCHAIN="1.29.1"
 else
     echo "--- :warning: Using RUST_TOOLCHAIN=\"${RUST_TOOLCHAIN}\", previously set in the environment"
 fi


### PR DESCRIPTION
https://blog.rust-lang.org/2018/09/25/Rust-1.29.1.html

Note that the TravisCI setup was updated in b7d26e3b5 which is why it
isn't included here.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>