### PR TITLE
Remove multiple supervisors on single host support (--override-name option)

### DIFF
--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -822,8 +822,6 @@ pub fn sub_sup_run() -> App<'static, 'static> {
         (@arg LISTEN_CTL: --("listen-ctl") +takes_value {valid_socket_addr}
             "The listen address for the Control Gateway. If not specified, the value will \
             be taken from the HAB_LISTEN_CTL environment variable if defined. [default: 127.0.0.1:9632]")
-        (@arg NAME: --("override-name") +takes_value
-            "The name of the Supervisor if launching more than one [default: default]")
         (@arg ORGANIZATION: --org +takes_value
             "The organization that the Supervisor and its subsequent services are part of \
              [default: default]")
@@ -891,8 +889,6 @@ pub fn sub_sup_term() -> App<'static, 'static> {
         // is displayed confusingly as `hab-sup`
         // see: https://github.com/kbknapp/clap-rs/blob/2724ec5399c500b12a1a24d356f4090f4816f5e2/src/app/mod.rs#L373-L394
         (usage: "hab sup term [OPTIONS]")
-        (@arg NAME: --("override-name") +takes_value
-            "The name of the Supervisor if more than one is running [default: default]")
     )
 }
 

--- a/components/sup-client/src/lib.rs
+++ b/components/sup-client/src/lib.rs
@@ -183,7 +183,7 @@ impl SrvClient {
 
     pub fn read_secret_key() -> Result<String, SrvClientError> {
         let mut buf = String::new();
-        protocol::read_secret_key(protocol::sup_root(None::<String>, None::<String>), &mut buf)
+        protocol::read_secret_key(protocol::sup_root(None::<String>), &mut buf)
             .map_err(SrvClientError::from)?;
         Ok(buf)
     }

--- a/components/sup-protocol/src/lib.rs
+++ b/components/sup-protocol/src/lib.rs
@@ -145,17 +145,18 @@ where
     sup_root.as_ref().join(CTL_SECRET_FILENAME)
 }
 
-pub fn sup_root<T, U>(name: Option<T>, custom_state_path: Option<U>) -> PathBuf
+pub fn sup_root<U>(custom_state_path: Option<U>) -> PathBuf
 where
-    T: AsRef<Path>,
     U: AsRef<Path>,
 {
     match custom_state_path {
         Some(ref custom) => custom.as_ref().to_path_buf(),
-        None => match name {
-            Some(ref name) => STATE_PATH_PREFIX.join(name),
-            None => STATE_PATH_PREFIX.join("default"),
-        },
+        // TODO: /hab/sup/default is legacy from when we allowed multiple
+        // supervisors on the same host with --override-name. The sup dir
+        // should really be /hab/sup now, but it would be an awkward change
+        // since the assumption of /hab/sup/default is pervasive.
+        // See https://github.com/habitat-sh/habitat/issues/5266
+        None => STATE_PATH_PREFIX.join("default"),
     }
 }
 

--- a/components/sup/src/error.rs
+++ b/components/sup/src/error.rs
@@ -287,9 +287,7 @@ impl fmt::Display for SupError {
             Error::ProcessLockCorrupt => format!("Unable to decode contents of process lock"),
             Error::ProcessLocked(ref pid) => format!(
                 "Unable to start Habitat Supervisor because another instance is already \
-                 running with the pid {}. If your intention was to run multiple Supervisors - \
-                 that can be done by setting a value for `--override-name` at startup - but \
-                 it is not recommended.",
+                 running with the pid {}.",
                 pid
             ),
             Error::ProcessLockIO(ref path, ref err) => format!(

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -247,16 +247,6 @@ fn mgrcfg_from_matches(m: &ArgMatches) -> Result<ManagerConfig> {
         cfg.ctl_listen =
             SocketAddr::from_str(addr_str).unwrap_or_else(|_err| protocol::ctl::default_addr());
     }
-    if let Some(name_str) = m.value_of("NAME") {
-        cfg.name = Some(String::from(name_str));
-        outputln!("");
-        outputln!("CAUTION: Running more than one Habitat Supervisor is not recommended for most");
-        outputln!("CAUTION: users in most use cases. Using one Supervisor per host for multiple");
-        outputln!("CAUTION: services in one ring will yield much better performance.");
-        outputln!("");
-        outputln!("CAUTION: If you know what you're doing, carry on!");
-        outputln!("");
-    }
     cfg.organization = m.value_of("ORGANIZATION").map(|org| org.to_string());
     cfg.gossip_permanent = m.is_present("PERMANENT_PEER");
     // TODO fn: Clean this up--using a for loop doesn't feel good however an iterator was

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -2040,18 +2040,6 @@ mod test {
     }
 
     #[test]
-    fn manager_state_path_with_name() {
-        let mut cfg = ManagerConfig::default();
-        cfg.name = Some(String::from("peanuts"));
-        let path = cfg.sup_root();
-
-        assert_eq!(
-            PathBuf::from(format!("{}/peanuts", STATE_PATH_PREFIX.to_string_lossy())),
-            path
-        );
-    }
-
-    #[test]
     fn manager_state_path_custom() {
         let mut cfg = ManagerConfig::default();
         cfg.custom_state_path = Some(PathBuf::from("/tmp/peanuts-and-cake"));
@@ -2064,7 +2052,6 @@ mod test {
     fn manager_state_path_custom_beats_name() {
         let mut cfg = ManagerConfig::default();
         cfg.custom_state_path = Some(PathBuf::from("/tmp/partay"));
-        cfg.name = Some(String::from("nope"));
         let path = cfg.sup_root();
 
         assert_eq!(PathBuf::from("/tmp/partay"), path);

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -150,14 +150,13 @@ pub struct ManagerConfig {
     pub gossip_peers: Vec<SocketAddr>,
     pub gossip_permanent: bool,
     pub ring_key: Option<SymKey>,
-    pub name: Option<String>,
     pub organization: Option<String>,
     pub watch_peer_file: Option<String>,
 }
 
 impl ManagerConfig {
     pub fn sup_root(&self) -> PathBuf {
-        protocol::sup_root(self.name.as_ref(), self.custom_state_path.as_ref())
+        protocol::sup_root(self.custom_state_path.as_ref())
     }
 }
 
@@ -176,7 +175,6 @@ impl Default for ManagerConfig {
             gossip_peers: vec![],
             gossip_permanent: false,
             ring_key: None,
-            name: None,
             organization: None,
             watch_peer_file: None,
         }

--- a/components/sup/tests/utils/test_sup.rs
+++ b/components/sup/tests/utils/test_sup.rs
@@ -26,7 +26,7 @@ use std::time::Duration;
 
 use hcore::url::BLDR_URL_ENVVAR;
 use rand;
-use rand::distributions::{IndependentSample, Range};
+use rand::distributions::{Distribution, Uniform};
 
 use super::test_butterfly;
 
@@ -100,9 +100,9 @@ fn unclaimed_port(tries: u16) -> u16 {
 /// Return a random unprivileged, unregistered TCP port number.
 fn random_port() -> u16 {
     // IANA port registrations go to 49151
-    let between = Range::new(49152, ::std::u16::MAX);
+    let between = Uniform::new_inclusive(49152, ::std::u16::MAX);
     let mut rng = rand::thread_rng();
-    between.ind_sample(&mut rng)
+    between.sample(&mut rng)
 }
 
 /// Find an executable relative to the current integration testing


### PR DESCRIPTION
The sup directory remains at /hab/sup/default despite /hab/sup now being more
logical since changing that would be fairly disruptive for little gain.

Resolves https://github.com/habitat-sh/habitat/issues/5266

Signed-off-by: Jon Bauman <5906042+baumanj@users.noreply.github.com>