### PR TITLE
Add macro for cli testing

### DIFF
--- a/components/sup/src/cli.rs
+++ b/components/sup/src/cli.rs
@@ -1,0 +1,77 @@
+use clap::App;
+
+use hab::cli::{
+    sub_sup_bash, sub_sup_depart, sub_sup_run, sub_sup_secret, sub_sup_sh, sub_sup_term,
+    sub_svc_status,
+};
+use VERSION;
+
+pub fn cli<'a, 'b>() -> App<'a, 'b> {
+    clap_app!(("hab-sup") =>
+        (about: "The Habitat Supervisor")
+        (version: VERSION)
+        (author: "\nAuthors: The Habitat Maintainers <humans@habitat.sh>\n")
+        // set custom usage string, otherwise the binary
+        // is displayed confusingly as `hab-sup`
+        // see: https://github.com/kbknapp/clap-rs/blob/2724ec5399c500b12a1a24d356f4090f4816f5e2/src/app/mod.rs#L373-L394
+        (usage: "hab sup <SUBCOMMAND>")
+        (@setting VersionlessSubcommands)
+        (@setting SubcommandRequiredElseHelp)
+        // this is the _full_ list of supervisor related cmds
+        // they are all enumerated here so that the entire help menu
+        // can be displayed from `hab sup --help`
+        (subcommand: sub_sup_bash().aliases(&["b", "ba", "bas"]))
+        (subcommand: sub_sup_depart().aliases(&["d", "de", "dep", "depa", "depart"]))
+        (subcommand: sub_sup_run().aliases(&["r", "ru"]))
+        (subcommand: sub_sup_secret().aliases(&["sec", "secr"]))
+        (subcommand: sub_sup_sh().aliases(&[]))
+        (subcommand: sub_svc_status().aliases(&["stat", "statu"]))
+        (subcommand: sub_sup_term().aliases(&["ter"]))
+    )
+}
+
+#[cfg(test)]
+mod test {
+    use super::cli;
+
+    macro_rules! assert_cli_cmd {
+        ($test:ident, $cmd:expr, $( $key:expr => $value:tt ),+) => {
+            #[test]
+            fn $test() {
+                assert_cmd!(cli(), $cmd, $( $key => $value ),+ );
+            }
+        }
+    }
+
+    mod sup_run {
+        use super::*;
+
+        assert_cli_cmd!(should_handle_multiple_peer_flags,
+                        "hab-sup run --peer 1.1.1.1 --peer 2.2.2.2",
+                        "PEER" => ["1.1.1.1", "2.2.2.2"]);
+
+        assert_cli_cmd!(should_handle_single_peer_flag_with_multiple_values,
+                        "hab-sup run --peer 1.1.1.1 2.2.2.2",
+                        "PEER" => ["1.1.1.1", "2.2.2.2"]);
+
+        assert_cli_cmd!(should_handle_peer_flag_with_arguments,
+                        "hab-sup run --peer 1.1.1.1 2.2.2.2 -- core/redis",
+                        "PEER" => ["1.1.1.1", "2.2.2.2"],
+                        "PKG_IDENT_OR_ARTIFACT" => "core/redis");
+
+        assert_cli_cmd!(should_handle_multiple_bind_flags,
+                        "hab-sup run --bind service.group1 --bind service.group2",
+                        "BIND" => ["service.group1", "service.group2"]);
+
+        assert_cli_cmd!(should_handle_single_bind_flag_with_multiple_values,
+                        "hab-sup run --bind service.group1 service.group2",
+                        "BIND" => ["service.group1", "service.group2"]);
+
+        assert_cli_cmd!(should_handle_bind_flag_with_arguments,
+                        "hab-sup run --bind service.group1 service.group2 -- core/redis",
+                        "BIND" => ["service.group1", "service.group2"],
+                        "PKG_IDENT_OR_ARTIFACT" => "core/redis");
+
+    }
+
+}

--- a/components/sup/src/cli_test_helpers.rs
+++ b/components/sup/src/cli_test_helpers.rs
@@ -1,0 +1,167 @@
+use clap::{App, ArgMatches};
+use std::fmt;
+use std::iter::FromIterator;
+
+#[derive(Debug)]
+pub enum Expectation<'a> {
+    Value(&'a str),
+    Values(Vec<String>),
+    Boolean(bool),
+}
+
+use self::Expectation::{Boolean, Value, Values};
+
+#[derive(Debug)]
+enum CliTestError {
+    ValueMismatch(String, String, String),
+    MultiValueMismatch(String, Vec<String>, Vec<String>),
+    MissingFlag(String),
+    MissingSubcmd(),
+    ClapError(String),
+}
+
+impl fmt::Display for CliTestError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let content = match self {
+            CliTestError::ValueMismatch(flag, expected, actual) => format!(
+                r#"
+'{}' validation failed:
+  Expected: '{}'
+  Actual:   '{}'
+"#,
+                flag, expected, actual
+            ),
+            CliTestError::MultiValueMismatch(flag, expected, actual) => format!(
+                r#"
+'{}' validation failed:
+  Expected: '{:#?}'
+  Actual:   '{:#?}'
+"#,
+                flag, expected, actual,
+            ),
+            CliTestError::MissingFlag(flag) => format!("Expected {} flag was missing.", flag),
+            CliTestError::MissingSubcmd() => {
+                format!("Expected a subcommand, but none was specified")
+            }
+            CliTestError::ClapError(err) => format!(
+                r#"
+Command Parse error:
+****************************************
+{}
+****************************************
+"#,
+                err.to_string()
+            ),
+        };
+        write!(f, "{}", content)
+    }
+}
+
+pub fn assert_command(app: App, cmd: &str, assertions: Vec<(&str, Expectation)>) {
+    let cmd_vec = Vec::from_iter(cmd.split_whitespace());
+    let errors = match app.get_matches_from_safe(cmd_vec) {
+        Ok(matches) => match matches.subcommand() {
+            (_, Some(matches)) => assert_matches(matches, assertions),
+            (_, None) => vec![CliTestError::MissingSubcmd()],
+        },
+        Err(err) => vec![CliTestError::ClapError(err.to_string())],
+    };
+
+    if !errors.is_empty() {
+        let error_string = errors
+            .into_iter()
+            .map(|error| format!("{}", error))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        panic!(
+            r#"
+
+Failed assertions for command: '{}'
+
+{}
+
+"#,
+            cmd, error_string
+        );
+    }
+}
+
+fn assert_matches(matches: &ArgMatches, assertions: Vec<(&str, Expectation)>) -> Vec<CliTestError> {
+    let mut errs = Vec::new();
+
+    for (flag, expected_value) in assertions {
+        match expected_value {
+            Value(expected) => match matches.value_of(flag) {
+                Some(actual) => {
+                    if actual != expected.to_string() {
+                        errs.push(CliTestError::ValueMismatch(
+                            flag.to_string(),
+                            expected.to_string(),
+                            actual.to_string(),
+                        ));
+                    }
+                }
+                None => {
+                    errs.push(CliTestError::MissingFlag(flag.to_string()));
+                }
+            },
+            Values(expected) => match matches.values_of(flag) {
+                Some(actual_values) => {
+                    let actual = actual_values.map(|v| v.to_string()).collect();
+                    if actual != expected {
+                        errs.push(CliTestError::MultiValueMismatch(
+                            flag.to_string(),
+                            expected,
+                            actual,
+                        ));
+                    }
+                }
+                None => {
+                    errs.push(CliTestError::MissingFlag(flag.to_string()));
+                }
+            },
+            Boolean(expected) => {
+                if matches.is_present(flag) != expected {
+                    errs.push(CliTestError::ValueMismatch(
+                        flag.to_string(),
+                        expected.to_string(),
+                        (!expected).to_string(),
+                    ));
+                }
+            }
+        }
+    }
+
+    errs
+}
+
+#[macro_export]
+macro_rules! assertion {
+    ($flag:expr, true) => {
+        ($flag, $crate::cli_test_helpers::Expectation::Boolean(true))
+    };
+    ($flag:expr, false) => {
+        ($flag, $crate::cli_test_helpers::Expectation::Boolean(false))
+    };
+    ($flag:expr, [ $( $value:expr ),+ ]) => {
+        ($flag, $crate::cli_test_helpers::Expectation::Values(vec![ $( $value.to_string() ),* ]))
+    };
+    ($flag:expr, $value:expr) => {
+        ($flag, $crate::cli_test_helpers::Expectation::Value($value))
+    };
+}
+
+#[macro_export]
+macro_rules! assert_cmd {
+    ($app:expr, $cmd:expr) => {
+        $crate::cli_test_helpers::assert_command($app, $cmd, Vec::new());
+    };
+    ($app:expr, $cmd:expr, $($key:expr => $value:tt),* ) => ({
+        let mut assertions = Vec::new();
+
+        $( assertions.push(assertion!($key, $value)); )+
+
+            $crate::cli_test_helpers::assert_command($app, $cmd, assertions);
+    });
+}

--- a/components/sup/src/lib.rs
+++ b/components/sup/src/lib.rs
@@ -47,6 +47,8 @@ extern crate bitflags;
 extern crate byteorder;
 #[cfg(target_os = "linux")]
 extern crate caps;
+#[macro_use]
+extern crate clap;
 extern crate crypto;
 #[cfg(windows)]
 extern crate ctrlc;
@@ -55,6 +57,7 @@ extern crate features;
 #[macro_use]
 extern crate futures;
 extern crate glob;
+extern crate hab;
 extern crate habitat_butterfly as butterfly;
 extern crate habitat_common as common;
 #[macro_use]
@@ -104,7 +107,11 @@ macro_rules! sup_error {
     }};
 }
 
+#[cfg(test)]
+#[macro_use]
+pub mod cli_test_helpers;
 pub mod census;
+pub mod cli;
 pub mod command;
 pub mod config;
 pub mod ctl_gateway;

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -13,10 +13,8 @@
 // limitations under the License.
 
 extern crate ansi_term;
-#[macro_use]
 extern crate clap;
 extern crate env_logger;
-extern crate hab;
 extern crate habitat_common as common;
 #[macro_use]
 extern crate habitat_core as hcore;
@@ -38,7 +36,7 @@ use std::net::{SocketAddr, ToSocketAddrs};
 use std::process;
 use std::str::{self, FromStr};
 
-use clap::{App, ArgMatches};
+use clap::ArgMatches;
 use common::command::package::install::InstallSource;
 use common::ui::{Coloring, NONINTERACTIVE_ENVVAR, UI};
 use hcore::channel;
@@ -55,10 +53,7 @@ use protocol::{
     },
 };
 
-use hab::cli::{
-    sub_sup_bash, sub_sup_depart, sub_sup_run, sub_sup_secret, sub_sup_sh, sub_sup_term,
-    sub_svc_status,
-};
+use sup::cli::cli;
 use sup::command;
 use sup::config::{GossipListenAddr, GOSSIP_DEFAULT_PORT};
 use sup::error::{Error, Result, SupError};
@@ -66,7 +61,6 @@ use sup::feat;
 use sup::http_gateway;
 use sup::manager::{Manager, ManagerConfig};
 use sup::util;
-use sup::VERSION;
 
 /// Our output key
 static LOGKEY: &'static str = "MN";
@@ -139,30 +133,6 @@ fn start() -> Result<()> {
         ("term", Some(m)) => sub_term(m),
         _ => unreachable!(),
     }
-}
-
-fn cli<'a, 'b>() -> App<'a, 'b> {
-    clap_app!(("hab-sup") =>
-        (about: "The Habitat Supervisor")
-        (version: VERSION)
-        (author: "\nAuthors: The Habitat Maintainers <humans@habitat.sh>\n")
-        // set custom usage string, otherwise the binary
-        // is displayed confusingly as `hab-sup`
-        // see: https://github.com/kbknapp/clap-rs/blob/2724ec5399c500b12a1a24d356f4090f4816f5e2/src/app/mod.rs#L373-L394
-        (usage: "hab sup <SUBCOMMAND>")
-        (@setting VersionlessSubcommands)
-        (@setting SubcommandRequiredElseHelp)
-        // this is the _full_ list of supervisor related cmds
-        // they are all enumerated here so that the entire help menu
-        // can be displayed from `hab sup --help`
-        (subcommand: sub_sup_bash().aliases(&["b", "ba", "bas"]))
-        (subcommand: sub_sup_depart().aliases(&["d", "de", "dep", "depa", "depart"]))
-        (subcommand: sub_sup_run().aliases(&["r", "ru"]))
-        (subcommand: sub_sup_secret().aliases(&["sec", "secr"]))
-        (subcommand: sub_sup_sh().aliases(&[]))
-        (subcommand: sub_svc_status().aliases(&["stat", "statu"]))
-        (subcommand: sub_sup_term().aliases(&["ter"]))
-    )
 }
 
 fn sub_bash() -> Result<()> {


### PR DESCRIPTION
Adds a macro to help with verifying that cli commands are being parsed as expected.

Signed-off-by: Matthew Peck <mpeck@chef.io>