### PR TITLE
Store port values as u16 in Member struct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -759,6 +759,7 @@ dependencies = [
  "clippy 0.0.302 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat_butterfly 0.1.0",
  "habitat_core 0.0.0 (git+https://github.com/habitat-sh/core.git)",
+ "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/components/butterfly-test/Cargo.toml
+++ b/components/butterfly-test/Cargo.toml
@@ -6,6 +6,7 @@ workspace = "../../"
 
 [dependencies]
 clippy = {version = "*", optional = true}
+lazy_static = "*"
 time = "*"
 
 [dependencies.habitat_butterfly]

--- a/components/butterfly-test/src/lib.rs
+++ b/components/butterfly-test/src/lib.rs
@@ -62,8 +62,8 @@ pub fn start_server(name: &str, ring_key: Option<SymKey>, suitability: u64) -> S
     {
         let mut port_guard = SERVER_PORT.lock().expect("SERVER_PORT mutex poisoned");
         swim_port = *port_guard;
-        gossip_port = *port_guard;
         *port_guard += 1;
+        gossip_port = *port_guard;
         *port_guard += 1;
     }
     let listen_swim = format!("127.0.0.1:{}", swim_port);

--- a/components/butterfly/protocols/swim.proto
+++ b/components/butterfly/protocols/swim.proto
@@ -5,6 +5,7 @@ message Member {
   optional string id = 1;
   optional uint64 incarnation = 2;
   optional string address = 3;
+  // protobuf has no 16-bit ints; see habitat_butterfly::member::as_port
   optional int32 swim_port = 4;
   optional int32 gossip_port = 5;
   optional bool persistent = 6 [default = false];

--- a/components/butterfly/src/generated/butterfly.swim.rs
+++ b/components/butterfly/src/generated/butterfly.swim.rs
@@ -7,6 +7,7 @@ pub struct Member {
     pub incarnation: ::std::option::Option<u64>,
     #[prost(string, optional, tag="3")]
     pub address: ::std::option::Option<String>,
+    /// protobuf has no 16-bit ints; see habitat_butterfly::member::as_port
     #[prost(int32, optional, tag="4")]
     pub swim_port: ::std::option::Option<i32>,
     #[prost(int32, optional, tag="5")]

--- a/components/butterfly/src/main.rs
+++ b/components/butterfly/src/main.rs
@@ -53,8 +53,8 @@ fn main() {
     gossip_bind_addr.set_port(gport);
 
     let mut member = member::Member::default();
-    member.swim_port = bind_port as i32;
-    member.gossip_port = gport as i32;
+    member.swim_port = bind_port;
+    member.gossip_port = gport;
 
     let mut server = server::Server::new(
         bind_to_addr,
@@ -73,8 +73,8 @@ fn main() {
         let addr: SocketAddr = target.parse().unwrap();
         let mut member = member::Member::default();
         member.address = format!("{}", addr.ip());
-        member.swim_port = addr.port() as i32;
-        member.gossip_port = addr.port() as i32;
+        member.swim_port = addr.port();
+        member.gossip_port = addr.port();
         server.member_list.add_initial_member(member);
     }
 

--- a/components/sup/src/http_gateway.rs
+++ b/components/sup/src/http_gateway.rs
@@ -366,12 +366,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::{
-        fs::File,
-        io::Read,
-        path::PathBuf,
-        sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT},
-    };
+    use std::{fs::File, io::Read, path::PathBuf, sync::Mutex};
 
     use butterfly::{
         member::Member,
@@ -437,8 +432,10 @@ mod tests {
 
     #[test]
     fn butterfly_server_proxy_is_valid() {
-        static SWIM_PORT: AtomicUsize = ATOMIC_USIZE_INIT;
-        static GOSSIP_PORT: AtomicUsize = ATOMIC_USIZE_INIT;
+        lazy_static! {
+            static ref SWIM_PORT: Mutex<u16> = Mutex::new(6666);
+            static ref GOSSIP_PORT: Mutex<u16> = Mutex::new(7777);
+        }
 
         #[derive(Debug)]
         struct ZeroSuitability;
@@ -449,15 +446,23 @@ mod tests {
         }
 
         fn start_server() -> Server {
-            SWIM_PORT.compare_and_swap(0, 6666, Ordering::Relaxed);
-            GOSSIP_PORT.compare_and_swap(0, 7777, Ordering::Relaxed);
-            let swim_port = SWIM_PORT.fetch_add(1, Ordering::Relaxed);
+            let swim_port;
+            {
+                let mut swim_port_guard = SWIM_PORT.lock().expect("SWIM_PORT poisoned");
+                swim_port = *swim_port_guard;
+                *swim_port_guard += 1;
+            }
             let swim_listen = format!("127.0.0.1:{}", swim_port);
-            let gossip_port = GOSSIP_PORT.fetch_add(1, Ordering::Relaxed);
+            let gossip_port;
+            {
+                let mut gossip_port_guard = GOSSIP_PORT.lock().expect("GOSSIP_PORT poisoned");
+                gossip_port = *gossip_port_guard;
+                *gossip_port_guard += 1;
+            }
             let gossip_listen = format!("127.0.0.1:{}", gossip_port);
             let mut member = Member::default();
-            member.swim_port = swim_port as i32;
-            member.gossip_port = gossip_port as i32;
+            member.swim_port = swim_port;
+            member.gossip_port = gossip_port;
             Server::new(
                 &swim_listen[..],
                 &gossip_listen[..],

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -371,8 +371,8 @@ impl Manager {
         for peer_addr in &cfg.gossip_peers {
             let mut peer = Member::default();
             peer.address = format!("{}", peer_addr.ip());
-            peer.swim_port = peer_addr.port() as i32;
-            peer.gossip_port = peer_addr.port() as i32;
+            peer.swim_port = peer_addr.port();
+            peer.gossip_port = peer_addr.port();
             server.member_list.add_initial_member(peer);
         }
         Self::migrate_specs(&fs_cfg);

--- a/components/sup/src/manager/peer_watcher.rs
+++ b/components/sup/src/manager/peer_watcher.rs
@@ -149,8 +149,8 @@ impl PeerWatcher {
                 let addr: SocketAddr = addrs[0];
                 let mut member = Member::default();
                 member.address = format!("{}", addr.ip());
-                member.swim_port = addr.port() as i32;
-                member.gossip_port = addr.port() as i32;
+                member.swim_port = addr.port();
+                member.gossip_port = addr.port();
                 members.push(member);
             }
         }
@@ -208,8 +208,8 @@ mod tests {
         let mut member2 = Member::default();
         member2.id = String::new();
         member2.address = String::from("4.3.2.1");
-        member2.swim_port = GOSSIP_DEFAULT_PORT as i32;
-        member2.gossip_port = GOSSIP_DEFAULT_PORT as i32;
+        member2.swim_port = GOSSIP_DEFAULT_PORT;
+        member2.gossip_port = GOSSIP_DEFAULT_PORT;
         let expected_members = vec![member1, member2];
         let mut members = watcher.get_members().unwrap();
         for mut member in &mut members {


### PR DESCRIPTION
This is more consistent with the rest of the local representations. Since
protobuf doesn't support 16-bit ints, we have to convert on that boundary, but
we should be checking values there and avoiding unsafe casting elsewhere.

AtomicUsize instances would be converted to AtomicU16s, but integer_atomics
isn't stable yet, so we use Mutex<u16>.
See https://github.com/rust-lang/rust/issues/32976

Signed-off-by: Jon Bauman <5906042+baumanj@users.noreply.github.com>