### PR TITLE
Temporarily disable skipping commits for documentation changes

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,11 +19,11 @@ init:
 
 clone_folder: c:\projects\habitat
 
-# Avoid running tests if only the docs are modofied
-skip_commits:
-  files:
-    - '*.md'
-    - docs/*.md
+# Avoid running tests if only the docs are modified
+# skip_commits:
+#   files:
+#     - '*.md'
+#     - docs/*.md
 
 environment:
   CI: true


### PR DESCRIPTION
This currently blocks our ability to build releases, since we tag on
Expeditor-authored commits that only change `CHANGELOG.md`. We'll
re-enable after the 0.66.0 release and sort out a suitable skipping
strategy that works for everyone.

Signed-off-by: Christopher Maier <cmaier@chef.io>

![tenor-144018968](https://user-images.githubusercontent.com/207178/47228411-25a4a300-d393-11e8-84d2-041db3ea3cce.gif)
