### PR TITLE
Add -t to support installing alternate PackageTarget cli 

### DIFF
--- a/components/hab/install.sh
+++ b/components/hab/install.sh
@@ -1,5 +1,4 @@
-#!/bin/sh
-# shellcheck disable=SC2039
+#!/bin/bash
 #
 # Copyright (c) 2010-2016 Chef Software, Inc. and/or applicable contributors
 #

--- a/components/hab/install.sh
+++ b/components/hab/install.sh
@@ -265,13 +265,13 @@ extract_archive() {
       need_cmd tar
 
       zcat "${archive}" | tar x -C "${workdir}"
-      archive_dir="$(echo "${archive}" | sed 's/.tar.gz$//')"
+      archive_dir="${archive%.tar.gz}"
       ;;
     zip)
       need_cmd unzip
 
       unzip "${archive}" -d "${workdir}"
-      archive_dir="$(echo "${archive}" | sed 's/.zip$//')"
+      archive_dir="${archive%.zip}"
       ;;
     *)
       exit_with "Unrecognized file extension when extracting: ${ext}" 4


### PR DESCRIPTION
This is a pre-requisite for #5753 

I've tested this on Linux and MacOS with a variety of combinations of target/channel/version and it behaves as expected. As we don't have a release for x86_64-linux-kernel2 I haven't been fully validate the x86_64-linux-kernel2 behavior.

MacOS:
```
~/s/h/habitat ❯❯❯ components/hab/install.sh -t x86_64-linux-kernel2
--> hab-install: Installing Habitat 'hab' program
xxx hab-install: --target is only valid on Linux systems
~/s/h/habitat ❯❯❯ components/hab/install.sh -t x86_64-darwin   
--> hab-install: Installing Habitat 'hab' program
xxx hab-install: --target is only valid on Linux systems
~/s/h/habitat ❯❯❯ components/hab/install.sh -v 0.65.0                                                                                      
--> hab-install: Installing Habitat 'hab' program
--> hab-install: Determining fully qualified version of package for `0.65.0'
--> hab-install: Downloading via wget: https://api.bintray.com/packages/habitat/stable/hab-x86_64-darwin
--> hab-install: Using fully qualified Bintray version string of: 0.65.0-20181004215828
--> hab-install: Downloading via wget: https://api.bintray.com/content/habitat/stable/darwin/x86_64/hab-0.65.0-20181004215828-x86_64-darwin.zip?bt_package=hab-x86_64-darwin
--> hab-install: Downloading via wget: https://api.bintray.com/content/habitat/stable/darwin/x86_64/hab-0.65.0-20181004215828-x86_64-darwin.zip.sha256sum?bt_package=hab-x86_64-darwin
```

Linux:
```
[34][default:/src:8]# components/hab/install.sh -v flipper -c unstable -t x86_64-linux
--> hab-install: Installing Habitat 'hab' program
--> hab-install: Determining fully qualified version of package for `flipper'
--> hab-install: Downloading via wget: https://api.bintray.com/packages/habitat/unstable/hab-x86_64-linux
xxx hab-install: Version `flipper' could not used or version doesn't exist. Please provide a simple version like: "0.15.0" or a fully qualified version like: "0.15.0/20161222203215".
[35][default:/src:8]# components/hab/install.sh -t x86_64-linux-kernel23
--> hab-install: Installing Habitat 'hab' program
xxx hab-install: x86_64-linux-kernel23 is not a valid target. Please specify one of:  ['x86_64-linux', 'x86_64-linux-kernel2']
[36][default:/src:8]# components/hab/install.sh -t x86_64-linux-kernel4
--> hab-install: Installing Habitat 'hab' program
xxx hab-install: x86_64-linux-kernel4 is not a valid target. Please specify one of:  ['x86_64-linux', 'x86_64-linux-kernel2']
[37][default:/src:8]# components/hab/install.sh -t x86_64-linux-kernel
--> hab-install: Installing Habitat 'hab' program
xxx hab-install: x86_64-linux-kernel is not a valid target. Please specify one of:  ['x86_64-linux', 'x86_64-linux-kernel2']
[38][default:/src:8]# components/hab/install.sh -t x86_64-linux
--> hab-install: Installing Habitat 'hab' program
--> hab-install: Downloading via wget: https://api.bintray.com/content/habitat/stable/linux/x86_64/hab-%24latest-x86_64-linux.tar.gz?bt_package=hab-x86_64-linux
--> hab-install: Downloading via wget: https://api.bintray.com/content/habitat/stable/linux/x86_64/hab-%24latest-x86_64-linux.tar.gz.sha256sum?bt_package=hab-x86_64-linux
[38][default:/src:8]# components/hab/install.sh -t x86_64-linux-kernel2
--> hab-install: Installing Habitat 'hab' program
--> hab-install: Downloading via wget: https://api.bintray.com/content/habitat/stable/linux/x86_64/hab-%24latest-x86_64-linux-kernel2.tar.gz?bt_package=hab-x86_64-linux-kernel2
xxx hab-install: wget failed to download file, perhaps wget doesn't have SSL support and/or no CA certificates are present?
--> hab-install: Downloading via curl: https://api.bintray.com/content/habitat/stable/linux/x86_64/hab-%24latest-x86_64-linux-kernel2.tar.gz?bt_package=hab-x86_64-linux-kernel2
curl: (22) The requested URL returned error: 404 Not Found
```

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>