### PR TITLE
do not check for running supervisor in windows container studio

### DIFF
--- a/components/studio/bin/hab-studio.ps1
+++ b/components/studio/bin/hab-studio.ps1
@@ -338,7 +338,7 @@ function Enter-Studio {
     New-PSDrive -Name "Habitat" -PSProvider FileSystem -Root $env:HAB_STUDIO_ENTER_ROOT | Out-Null
     mkdir $env:HAB_STUDIO_ENTER_ROOT\hab\sup\default -Force | Out-Null
     
-    if(Get-Process -Name hab-sup -ErrorAction SilentlyContinue) {
+    if(!(Test-InContainer) -and (Get-Process -Name hab-sup -ErrorAction SilentlyContinue)) {
       Write-Warning "A Habitat Supervisor is already running on this machine."
       Write-Warning "Only one Supervisor can run at a time."
       Write-Warning "A Supervisor will not be started in this Studio."


### PR DESCRIPTION
This fixes an issue where we are emitting a warning in a container windows studio because the docker windows studio starts the supervisor immediately. The warning states that we will not start a supervisor which is simply not true.

Signed-off-by: mwrock <matt@mattwrock.com>