### PR TITLE
remove -w parameter for invoking a local studio in internal calls

### DIFF
--- a/components/hab/src/command/studio/docker.rs
+++ b/components/hab/src/command/studio/docker.rs
@@ -270,7 +270,6 @@ where
     cmd_args.push(image_identifier(&docker_cmd).into());
     cmd_args.extend_from_slice(args.as_slice());
     if is_serving_windows_containers(&docker_cmd) {
-        cmd_args.push("-w".into());
         cmd_args.push("-n".into());
         cmd_args.push("-o".into());
         cmd_args.push("c:/".into());

--- a/support/ci/appveyor.ps1
+++ b/support/ci/appveyor.ps1
@@ -108,7 +108,7 @@ if (($env:APPVEYOR_REPO_TAG_NAME -eq $version) -or (Test-SourceChanged) -or (tes
             foreach ($component in ($env:hab_components -split ';')) {
                 Write-Host "Building plan for $component"
                 Write-Host ""
-                & $habExe pkg build components/$component -w -R
+                & $habExe pkg build components/$component -R
                 if ($LASTEXITCODE -ne 0) {exit $LASTEXITCODE}
 
                 $hart = (Get-Item "$(Get-RepoRoot)\components\$component\habitat\results\*.hart")[-1]


### PR DESCRIPTION
We don't need to pass `-w` now that it is default behavior and also emits a deprecation warning.

Signed-off-by: mwrock <matt@mattwrock.com>