### PR TITLE
fix asp.net tutorial based on recent changes

### DIFF
--- a/www/source/demo/windows/steps/8.html.slim
+++ b/www/source/demo/windows/steps/8.html.slim
@@ -22,7 +22,7 @@ section
  = code(:shell) do
    | 
      PS C:\contosouniversity> $env:HAB_DOCKER_OPTS="--memory 2gb -p 80:8099"
-     PS C:\contosouniversity> hab studio enter
+     PS C:\contosouniversity> hab studio enter -D
 
  p Assuming you are on a Windows host with Docker for Windows running in Windows container mode, this will enter a Powershell based Studio inside of a Windows container. We also set the <code>HAB_DOCKER_OPTS</code> variable which is forwarded to <code>docker run</code> when the Studio spawns its container. This will forward port 8099 which is what our application listens to in the container to port 80 locally. It also ensures that the Container is given 2 GB of ram. This is only important on a Windows 10 host which will run containers in #{link_to 'Hyper-V Isolation mode', 'https://docs.microsoft.com/en-us/virtualization/windowscontainers/manage-containers/hyperv-container'} where containers are spawned in their own minimal VM and allocated 1GB of memory by default. For many scenarios, including ours, 1 GB is simply not enough and can lead to odd and surprising results - not the good kind of surprise!
 

--- a/www/source/demo/windows/steps/9.html.slim
+++ b/www/source/demo/windows/steps/9.html.slim
@@ -84,12 +84,28 @@ section
       <add name="SchoolContext" connectionString="Data Source={{bind.database.first.sys.ip}},{{bind.database.first.cfg.port}};Initial Catalog=ContosoUniversity2;User ID={{bind.database.first.cfg.username}};Password={{bind.database.first.cfg.password}};" providerName="System.Data.SqlClient" />
     </connectionStrings>
 
- p One last thing to be done in order for our templatized <code>web.config</code> to be seen by the ASP.NET runtime is to link the Supervisor rendered file to the root of our application which is where ASP.NET expects it to be. We can do this by adding the following to our <code>init</code> hook:
+ p In order for our templatized <code>web.config</code> to be seen by the ASP.NET runtime, we need to link the Supervisor rendered file to the root of our application which is where ASP.NET expects it to be. We can do this by adding the following to our <code>init</code> hook:
 
  = code(:bash) do
    |
     Set-Location {{pkg.svc_path}}\var
     New-Item -Name Web.config -ItemType SymbolicLink -target "{{pkg.svc_config_path}}/Web.config" -Force | Out-Null
+
+ p Lastly we need to edit the permissions of the Habitat rendered <code>web.config</code> template so that the IIS app pool user has the rights to access it. When Habitat renders the template files in out plan's <code>config</code> and <code>hooks</code> directories, the permissions granted to the rendered files include <code>Full Control</code> access for <code>Administrators</code>, <code>SYSTEM</code>, and the user running the Supervisor process. Because these rendered files could possibly include sensitive values, we do not want to grant access to all users. By default, IIS will run our application using a user named after its application pool and this user will not have rightrs to view the rendered <code>web.config</code> which will cause our application to fail. So lets edit our <code>run</code> hook after we apply the <code>DSC</code> configuration that creates and starts our application pool:
+
+ = code(:bash) do
+   |
+    Import-Module "{{pkgPathFor "core/dsc-core"}}/Modules/DscCore"
+    Start-DscCore (Join-Path {{pkg.svc_config_path}} website.ps1) NewWebsite
+
+    $pool = "{{cfg.app_pool}}"
+    $access = New-Object System.Security.AccessControl.FileSystemAccessRule "IIS APPPOOL\$pool", "ReadAndExecute", "Allow"
+    $acl = Get-Acl "{{pkg.svc_config_path}}/Web.config"
+    $acl.SetAccessRule($access)
+    $acl | Set-Acl "{{pkg.svc_config_path}}/Web.config"
+
+    try {
+    ...
 
  h2 <a name="connect-studio">Connecting to a database running inside the studio</a>
 


### PR DESCRIPTION
Just noticed that the recent permissions changes to the Supervisor on Windows broke my contosouniversity demo and the asp.net tutorial. This fixes that.

Signed-off-by: mwrock <matt@mattwrock.com>