### PR TITLE
Add the possible values for --topology into the online help

### DIFF
--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -856,7 +856,7 @@ pub fn sub_sup_run() -> App<'static, 'static> {
             "Environment name; [default: not set].")
         (@arg GROUP: --group +takes_value
             "The service group; shared config and topology [default: default].")
-        (@arg TOPOLOGY: --topology -t +takes_value {valid_topology}
+        (@arg TOPOLOGY: --topology -t +takes_value possible_value[standalone leader]
             "Service topology; [default: none]")
         (@arg STRATEGY: --strategy -s +takes_value {valid_update_strategy}
             "The update strategy; [default: none] [values: none, at-once, rolling]")
@@ -943,7 +943,7 @@ fn sub_svc_load() -> App<'static, 'static> {
             "Specify an alternate Builder endpoint. If not specified, the value will \
              be taken from the HAB_BLDR_URL environment variable if defined. (default: \
              https://bldr.habitat.sh)")
-        (@arg TOPOLOGY: --topology -t +takes_value {valid_topology}
+        (@arg TOPOLOGY: --topology -t +takes_value possible_value[standalone leader]
             "Service topology; [default: none]")
         (@arg STRATEGY: --strategy -s +takes_value {valid_update_strategy}
             "The update strategy; [default: none] [values: none, at-once, rolling]")
@@ -979,7 +979,7 @@ fn sub_svc_load() -> App<'static, 'static> {
             "Specify an alternate Builder endpoint. If not specified, the value will \
              be taken from the HAB_BLDR_URL environment variable if defined. (default: \
              https://bldr.habitat.sh)")
-        (@arg TOPOLOGY: --topology -t +takes_value {valid_topology}
+        (@arg TOPOLOGY: --topology -t +takes_value possible_value[standalone leader]
             "Service topology; [default: none]")
         (@arg STRATEGY: --strategy -s +takes_value {valid_update_strategy}
             "The update strategy; [default: none] [values: none, at-once, rolling]")
@@ -1063,13 +1063,6 @@ fn valid_numeric<T: FromStr>(val: String) -> result::Result<(), String> {
     match val.parse::<T>() {
         Ok(_) => Ok(()),
         Err(_) => Err(format!("'{}' is not a valid number", &val)),
-    }
-}
-
-fn valid_topology(val: String) -> result::Result<(), String> {
-    match protocol::types::Topology::from_str(&val) {
-        Ok(_) => Ok(()),
-        Err(_) => Err(format!("Service topology: '{}' is not valid", &val)),
     }
 }
 


### PR DESCRIPTION
CLI help before:

    -t, --topology <TOPOLOGY>                  Service topology; [default: none]

After:

    -t, --topology <TOPOLOGY>                  Service topology; [default: none] [possible values: standalone, leader]

With bad input such as `hab sup run --topology foobar` before:
```
error: Invalid value for '--topology <TOPOLOGY>': Service topology: 'foobar' is not valid
```
After:
```
error: 'foobar' isn't a valid value for '--topology <TOPOLOGY>'
	[possible values: leader, standalone]
```
Also, as long as clap is validating the topology argument, we can remove the
redundant validator function. This decouples the CLI from the code a bit, but
it's hard to do better unless we move away from the macro-based approach to
clap.

Signed-off-by: Jon Bauman <5906042+baumanj@users.noreply.github.com>