### PR TITLE
Remove health check data when a service is unloaded

### DIFF
--- a/components/sup/src/http_gateway.rs
+++ b/components/sup/src/http_gateway.rs
@@ -313,6 +313,7 @@ fn health(
         Ok(sg) => sg,
         Err(_) => return HttpResponse::BadRequest().finish(),
     };
+
     let gateway_state = &req
         .state()
         .gateway_state

--- a/components/sup/src/manager/service/mod.rs
+++ b/components/sup/src/manager/service/mod.rs
@@ -725,6 +725,13 @@ impl Service {
                 self.svc_encrypted_password.as_ref(),
             );
         }
+
+        &self
+            .gateway_state
+            .write()
+            .expect("GatewayState lock is poisoned")
+            .health_check_data
+            .remove(&self.service_group);
     }
 
     pub fn suitability(&self) -> Option<u64> {


### PR DESCRIPTION
![](https://media.giphy.com/media/3o7WIPwTqzyk6O3dqU/giphy.gif)

Closes https://github.com/habitat-sh/habitat/issues/5791
Signed-off-by: Josh Black <raskchanky@gmail.com>