### PR TITLE
Refactor ManagerConfig generation from ArgMatches

### DIFF
--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -835,8 +835,7 @@ pub fn sub_sup_run() -> App<'static, 'static> {
             "The listen address for the Control Gateway. If not specified, the value will \
             be taken from the HAB_LISTEN_CTL environment variable if defined. [default: 127.0.0.1:9632]")
         (@arg ORGANIZATION: --org +takes_value
-            "The organization that the Supervisor and its subsequent services are part of \
-             [default: default]")
+            "The organization that the Supervisor and its subsequent services are part of.")
         (@arg PEER: --peer +takes_value +multiple
             "The listen address of one or more initial peers (IP[:PORT])")
         (@arg PERMANENT_PEER: --("permanent-peer") -I "If this Supervisor is a permanent peer")

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -30,6 +30,9 @@ extern crate time;
 extern crate tokio_core;
 extern crate url;
 
+#[cfg(test)]
+extern crate tempdir;
+
 use std::env;
 use std::io::{self, Write};
 use std::net::{SocketAddr, ToSocketAddrs};
@@ -44,13 +47,12 @@ use hcore::channel;
 use hcore::crypto::dpapi::encrypt;
 use hcore::crypto::{self, default_cache_key_path, SymKey};
 use hcore::env as henv;
+use hcore::service::ServiceGroup;
 use hcore::url::{bldr_url_from_env, default_bldr_url};
 use launcher_client::{LauncherCli, ERR_NO_RETRY_EXCODE};
 use protocol::{
     ctl::ServiceBindList,
-    types::{
-        ApplicationEnvironment, BindingMode, ServiceBind, ServiceGroup, Topology, UpdateStrategy,
-    },
+    types::{ApplicationEnvironment, BindingMode, ServiceBind, Topology, UpdateStrategy},
 };
 
 use sup::cli::cli;
@@ -202,27 +204,43 @@ fn sub_term(m: &ArgMatches) -> Result<()> {
 ////////////////////////////////////////////////////////////////////////
 
 fn mgrcfg_from_matches(m: &ArgMatches) -> Result<ManagerConfig> {
-    let mut cfg = ManagerConfig::default();
-    cfg.auto_update = m.is_present("AUTO_UPDATE");
-    cfg.update_url = bldr_url(m);
-    cfg.update_channel = channel(m);
+    let mut cfg = ManagerConfig {
+        auto_update: m.is_present("AUTO_UPDATE"),
+        update_url: bldr_url(m),
+        update_channel: channel(m),
+        http_disable: m.is_present("HTTP_DISABLE"),
+        organization: m.value_of("ORGANIZATION").map(|org| org.to_string()),
+        gossip_permanent: m.is_present("PERMANENT_PEER"),
+        ring_key: get_ring_key(m)?,
+        gossip_peers: get_peers(m)?,
+        ..Default::default()
+    };
     if let Some(addr_str) = m.value_of("LISTEN_GOSSIP") {
         cfg.gossip_listen = GossipListenAddr::from_str(addr_str)?;
     }
     if let Some(addr_str) = m.value_of("LISTEN_HTTP") {
         cfg.http_listen = http_gateway::ListenAddr::from_str(addr_str)?;
     }
-    cfg.http_disable = m.is_present("HTTP_DISABLE");
     if let Some(addr_str) = m.value_of("LISTEN_CTL") {
-        cfg.ctl_listen =
-            SocketAddr::from_str(addr_str).unwrap_or_else(|_err| protocol::ctl::default_addr());
+        cfg.ctl_listen = SocketAddr::from_str(addr_str)?;
     }
-    cfg.organization = m.value_of("ORGANIZATION").map(|org| org.to_string());
-    cfg.gossip_permanent = m.is_present("PERMANENT_PEER");
+    if let Some(watch_peer_file) = m.value_of("PEER_WATCH_FILE") {
+        cfg.watch_peer_file = Some(String::from(watch_peer_file));
+    }
+    if let Some(events) = m.value_of("EVENTS") {
+        cfg.eventsrv_group = ServiceGroup::from_str(events).ok();
+    }
+    Ok(cfg)
+}
+
+// Various CLI Parsing Functions
+////////////////////////////////////////////////////////////////////////
+
+fn get_peers(matches: &ArgMatches) -> Result<Vec<SocketAddr>> {
     // TODO fn: Clean this up--using a for loop doesn't feel good however an iterator was
     // causing a lot of developer/compiler type confusion
-    let mut gossip_peers: Vec<SocketAddr> = Vec::new();
-    if let Some(peers) = m.values_of("PEER") {
+    let mut gossip_peers = Vec::new();
+    if let Some(peers) = matches.values_of("PEER") {
         for peer in peers {
             let peer_addr = if peer.find(':').is_some() {
                 peer.to_string()
@@ -236,41 +254,39 @@ fn mgrcfg_from_matches(m: &ArgMatches) -> Result<ManagerConfig> {
                     return Err(sup_error!(Error::NameLookup(e)));
                 }
             };
-            let addr: SocketAddr = addrs[0];
-            gossip_peers.push(addr);
+            if let Some(addr) = addrs.get(0) {
+                gossip_peers.push(*addr);
+            }
         }
     }
-    cfg.gossip_peers = gossip_peers;
-    if let Some(watch_peer_file) = m.value_of("PEER_WATCH_FILE") {
-        cfg.watch_peer_file = Some(String::from(watch_peer_file));
-    }
-    cfg.ring_key = match m.value_of("RING") {
-        Some(val) => Some(SymKey::get_latest_pair_for(
-            &val,
-            &default_cache_key_path(None),
-        )?),
+    Ok(gossip_peers)
+}
+
+// TODO: Make this more testable.
+// The use of env variables here makes it difficult to unit test. Since tests are run in parallel, setting an env var in one test
+// can adversely effect the results in another test. We need some additional abstractions written around env vars in order to make
+// them more testable.
+fn get_ring_key(m: &ArgMatches) -> Result<Option<SymKey>> {
+    match m.value_of("RING") {
+        Some(val) => {
+            let key = SymKey::get_latest_pair_for(&val, &default_cache_key_path(None))?;
+            Ok(Some(key))
+        }
         None => match henv::var(RING_KEY_ENVVAR) {
             Ok(val) => {
                 let (key, _) = SymKey::write_file_from_str(&val, &default_cache_key_path(None))?;
-                Some(key)
+                Ok(Some(key))
             }
             Err(_) => match henv::var(RING_ENVVAR) {
-                Ok(val) => Some(SymKey::get_latest_pair_for(
-                    &val,
-                    &default_cache_key_path(None),
-                )?),
-                Err(_) => None,
+                Ok(val) => {
+                    let key = SymKey::get_latest_pair_for(&val, &default_cache_key_path(None))?;
+                    Ok(Some(key))
+                }
+                Err(_) => Ok(None),
             },
         },
-    };
-    if let Some(events) = m.value_of("EVENTS") {
-        cfg.eventsrv_group = ServiceGroup::from_str(events).ok().map(Into::into);
     }
-    Ok(cfg)
 }
-
-// Various CLI Parsing Functions
-////////////////////////////////////////////////////////////////////////
 
 /// Resolve a Builder URL. Taken from CLI args, the environment, or
 /// (failing those) a default value.
@@ -463,4 +479,174 @@ fn update_svc_load_from_input(m: &ArgMatches, msg: &mut protocol::ctl::SvcLoad) 
     msg.topology = get_topology_from_input(m).map(|v| v as i32);
     msg.update_strategy = get_strategy_from_input(m).map(|v| v as i32);
     Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    mod manager_config {
+
+        use super::*;
+        use std::iter::FromIterator;
+
+        fn config_from_cmd_str(cmd: &str) -> ManagerConfig {
+            let cmd_vec = Vec::from_iter(cmd.split_whitespace());
+            let matches = cli()
+                .get_matches_from_safe(cmd_vec)
+                .expect("Error while getting matches");
+            let (_, sub_matches) = matches.subcommand();
+            let sub_matches = sub_matches.expect("Error getting sub command matches");
+
+            mgrcfg_from_matches(&sub_matches).expect("Could not get config")
+        }
+
+        #[test]
+        fn auto_update_should_be_set() {
+            let config = config_from_cmd_str("hab-sup run --auto-update");
+            assert_eq!(config.auto_update, true);
+
+            let config = config_from_cmd_str("hab-sup run");
+            assert_eq!(config.auto_update, false);
+        }
+
+        #[test]
+        fn update_url_should_be_set() {
+            let config = config_from_cmd_str("hab-sup run -u http://fake.example.url");
+            assert_eq!(config.update_url, "http://fake.example.url");
+        }
+
+        #[test]
+        fn update_url_is_set_to_default_when_not_specified() {
+            let config = config_from_cmd_str("hab-sup run");
+            assert_eq!(config.update_url, default_bldr_url());
+        }
+
+        #[test]
+        fn update_channel_should_be_set() {
+            let config = config_from_cmd_str("hab-sup run --channel unstable");
+            assert_eq!(config.update_channel, "unstable");
+        }
+
+        #[test]
+        fn update_channel_is_set_to_default_when_not_specified() {
+            let config = config_from_cmd_str("hab-sup run");
+            assert_eq!(config.update_channel, "stable");
+        }
+
+        #[test]
+        fn gossip_listen_should_be_set() {
+            let config = config_from_cmd_str("hab-sup run --listen-gossip 1.1.1.1:1111");
+            let expected_addr = GossipListenAddr::from_str("1.1.1.1:1111")
+                .expect("Could not create GossipListenAddr");
+            assert_eq!(config.gossip_listen, expected_addr);
+        }
+
+        #[test]
+        fn gossip_listen_is_set_to_default_when_not_specified() {
+            let config = config_from_cmd_str("hab-sup run");
+            let expected_addr = GossipListenAddr::from_str("0.0.0.0:9638")
+                .expect("Could not create GossipListenAddr");
+            assert_eq!(config.gossip_listen, expected_addr);
+        }
+
+        #[test]
+        fn http_listen_should_be_set() {
+            let config = config_from_cmd_str("hab-sup run --listen-http 2.2.2.2:2222");
+            let expected_addr = http_gateway::ListenAddr::from_str("2.2.2.2:2222")
+                .expect("Could not create http listen addr");
+            assert_eq!(config.http_listen, expected_addr);
+        }
+
+        #[test]
+        fn http_listen_is_set_default_when_not_specified() {
+            let config = config_from_cmd_str("hab-sup run");
+            let expected_addr = http_gateway::ListenAddr::from_str("0.0.0.0:9631")
+                .expect("Could not create http listen addr");
+            assert_eq!(config.http_listen, expected_addr);
+        }
+
+        #[test]
+        fn http_disable_should_be_set() {
+            let config = config_from_cmd_str("hab-sup run --http-disable");
+            assert_eq!(config.http_disable, true);
+
+            let config = config_from_cmd_str("hab-sup run");
+            assert_eq!(config.http_disable, false);
+        }
+
+        #[test]
+        fn ctl_listen_should_be_set() {
+            let config = config_from_cmd_str("hab-sup run --listen-ctl 3.3.3.3:3333");
+            let expected_addr =
+                SocketAddr::from_str("3.3.3.3:3333").expect("Could not create ctl listen addr");
+            assert_eq!(config.ctl_listen, expected_addr);
+
+            let config = config_from_cmd_str("hab-sup run");
+            let expected_addr = protocol::ctl::default_addr();
+            assert_eq!(config.ctl_listen, expected_addr);
+        }
+
+        #[test]
+        fn organization_should_be_set() {
+            let config = config_from_cmd_str("hab-sup run --org foobar");
+            assert_eq!(config.organization, Some("foobar".to_string()));
+
+            let config = config_from_cmd_str("hab-sup run");
+            assert_eq!(config.organization, None);
+        }
+
+        #[test]
+        fn gossip_permanent_should_be_set() {
+            let config = config_from_cmd_str("hab-sup run --permanent-peer");
+            assert_eq!(config.gossip_permanent, true);
+
+            let config = config_from_cmd_str("hab-sup run");
+            assert_eq!(config.gossip_permanent, false);
+        }
+
+        #[test]
+        fn peers_should_be_set() {
+            let config = config_from_cmd_str("hab-sup run --peer 1.1.1.1:1 2.2.2.2:1 3.3.3.3:1");
+            let expected_peers: Vec<SocketAddr> = vec!["1.1.1.1:1", "2.2.2.2:1", "3.3.3.3:1"]
+                .into_iter()
+                .flat_map(|peer| peer.to_socket_addrs().expect("Failed getting addrs"))
+                .collect();
+            assert_eq!(config.gossip_peers, expected_peers);
+
+            let config = config_from_cmd_str("hab-sup run");
+            assert_eq!(config.gossip_peers, Vec::new());
+        }
+
+        #[test]
+        fn peers_should_have_a_default_port_set() {
+            let config = config_from_cmd_str("hab-sup run --peer 1.1.1.1 2.2.2.2 3.3.3.3");
+            let expected_peers: Vec<SocketAddr> = vec!["1.1.1.1", "2.2.2.2", "3.3.3.3"]
+                .into_iter()
+                .map(|peer| format!("{}:{}", peer, GOSSIP_DEFAULT_PORT))
+                .flat_map(|peer| peer.to_socket_addrs().expect("Failed getting addrs"))
+                .collect();
+            assert_eq!(config.gossip_peers, expected_peers);
+        }
+
+        #[test]
+        fn watch_peer_file_should_be_set() {
+            let config = config_from_cmd_str("hab-sup run --peer-watch-file foobar");
+            assert_eq!(config.watch_peer_file, Some("foobar".to_string()));
+
+            let config = config_from_cmd_str("hab-sup run");
+            assert_eq!(config.watch_peer_file, None);
+        }
+
+        #[test]
+        fn events_is_set() {
+            let config = config_from_cmd_str("hab-sup run --events event.service");
+            let eventsrv_group = config.eventsrv_group;
+            let expected_group: Option<hcore::service::ServiceGroup> =
+                ServiceGroup::from_str("event.service").ok().map(Into::into);
+
+            assert_eq!(eventsrv_group, expected_group);
+        }
+
+    }
 }


### PR DESCRIPTION
Refactors generating a ManagerConfig from ArgMatches and adds some tests around it. 