### PR TITLE
fix the changed files returned in a merge commit

### DIFF
--- a/support/ci/appveyor.ps1
+++ b/support/ci/appveyor.ps1
@@ -22,14 +22,14 @@ function Test-SentinelBuild() {
 }
 
 function Get-ChangedFiles {
-    if (Test-PullRequest -or Test-SentinelBuild) {
-        # for pull requests or sentinel builds diff
-        # against master
-        git diff master --name-only
-    } else {
-        # for master builds, check against the last merge
-        git show :/^Merge --pretty=format:%H -m --name-only
+    $sha = (git rev-parse HEAD)
+    $lastMerge = (git log --merges --max-count=1 --pretty=format:%H)
+    
+    if($sha -eq $lastMerge) {
+        $lastMerge=(git log --merges --max-count=1 --skip=1 --pretty=format:%H)
     }
+
+    git diff master --name-only $lastMerge
 }
 
 function Test-SourceChanged {


### PR DESCRIPTION
This replecates the same logic in travis. Currently merge commits are adding extra files and also include the SHAs in the output causing docs changes to appear to have more than just doc changes.

Signed-off-by: mwrock <matt@mattwrock.com>