### PR TITLE
Deprecate the confusing sup-log command in favor of directly accessing logs

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -115,7 +115,7 @@ Then you can actually exercise the software as follows:
 
 1. It pulls down the correct studio image
 1. That studio's `hab` is at the correct version
-1. A `sup-log` shows a running supervisor (if `sup-log` does not show a supervisor running, run `hab install core/hab-sup --channel release_channel` then `hab sup run`)
+1. A `hab sup status` shows a running supervisor (if it does not show a supervisor running, run `hab install core/hab-sup --channel release_channel` then `hab sup run`)
 1. Verify that the supervisor is the correct version by running `ls /hab/pkgs/core/hab-sup`
 
 When testing the linux studio, you will need to `export CI_OVERRIDE_CHANNEL` to the rc channel of the release. So if you are releasing 0.75.2, the channel would be `rc-0.75.2`.

--- a/components/rootless_studio/default/profile
+++ b/components/rootless_studio/default/profile
@@ -55,11 +55,15 @@ if [[ -n "${HAB_STUDIO_SUP}" ]]; then
   HAB_STUDIO_SUP="$(echo "$HAB_STUDIO_SUP" | sed 's/__sp__/ /g')"
 fi
 
+export SUP_LOG_FILE=/hab/sup/default/sup.log
+
 sup-run() {
   mkdir -p /hab/sup/default
+  touch $SUP_LOG_FILE
   echo "--> Launching the Habitat Supervisor in the background..."
   echo "    Running: hab sup run $*"
-  setsid hab sup run "$@" > /hab/sup/default/sup.log 2>&1 &
+  echo "    Logging to $SUP_LOG_FILE"
+  setsid hab sup run "$@" > $SUP_LOG_FILE 2>&1 &
   disown $!
   echo "    * Use 'hab svc start' & 'hab svc stop' to start and stop services"
   echo "    * Use 'sup-log' to tail the Supervisor's output (Ctrl+c to stop)"
@@ -85,10 +89,7 @@ sup-term() {
 }
 
 sup-log() {
-  mkdir -p /hab/sup/default
-  touch /hab/sup/default/sup.log
-  echo "--> Tailing the Habitat Supervisor's output (use 'Ctrl+c' to stop)"
-  tail -f /hab/sup/default/sup.log
+  echo "This command is deprecated. View Supervisor logs directly at \$SUP_LOG_FILE ($SUP_LOG_FILE)"
 }
 
 alias sr='sup-run'

--- a/components/rootless_studio/default/profile
+++ b/components/rootless_studio/default/profile
@@ -66,7 +66,6 @@ sup-run() {
   setsid hab sup run "$@" > $SUP_LOG_FILE 2>&1 &
   disown $!
   echo "    * Use 'hab svc start' & 'hab svc stop' to start and stop services"
-  echo "    * Use 'sup-log' to tail the Supervisor's output (Ctrl+c to stop)"
   echo "    * Use 'sup-term' to terminate the Supervisor"
   if [[ -z "${HAB_STUDIO_SUP:-}" ]]; then
     echo "    * To pass custom arguments to run the Supervisor, export"

--- a/components/studio/libexec/hab-studio-type-default.sh
+++ b/components/studio/libexec/hab-studio-type-default.sh
@@ -167,7 +167,6 @@ sup-run() {
   setsid hab sup run "\$@" > \$SUP_LOG_FILE 2>&1 &
   disown \$!
   echo "    * Use 'hab svc start' & 'hab svc stop' to start and stop services"
-  echo "    * Use 'sup-log' to tail the Supervisor's output (Ctrl+c to stop)"
   echo "    * Use 'sup-term' to terminate the Supervisor"
   if [[ -z "\${HAB_STUDIO_SUP:-}" ]]; then
     echo "    * To pass custom arguments to run the Supervisor, export"

--- a/components/studio/libexec/hab-studio-type-default.sh
+++ b/components/studio/libexec/hab-studio-type-default.sh
@@ -156,11 +156,15 @@ if [[ -n "\${HAB_STUDIO_SUP}" ]]; then
   HAB_STUDIO_SUP="\$(echo "\$HAB_STUDIO_SUP" | sed 's/__sp__/ /g')"
 fi
 
+export SUP_LOG_FILE=/hab/sup/default/sup.log
+
 sup-run() {
   mkdir -p /hab/sup/default
+  touch \$SUP_LOG_FILE
   echo "--> Launching the Habitat Supervisor in the background..."
   echo "    Running: hab sup run \$@"
-  setsid hab sup run "\$@" > /hab/sup/default/sup.log 2>&1 &
+  echo "    Logging to \$SUP_LOG_FILE"
+  setsid hab sup run "\$@" > \$SUP_LOG_FILE 2>&1 &
   disown \$!
   echo "    * Use 'hab svc start' & 'hab svc stop' to start and stop services"
   echo "    * Use 'sup-log' to tail the Supervisor's output (Ctrl+c to stop)"
@@ -186,10 +190,7 @@ sup-term() {
 }
 
 sup-log() {
-  mkdir -p /hab/sup/default
-  touch /hab/sup/default/sup.log
-  echo "--> Tailing the Habitat Supervisor's output (use 'Ctrl+c' to stop)"
-  tail -f /hab/sup/default/sup.log
+  echo "This command is deprecated. View Supervisor logs directly at \\\$SUP_LOG_FILE (\$SUP_LOG_FILE)"
 }
 
 alias sr='sup-run'

--- a/www/source/demo/process-supervisor/steps/10.html.slim
+++ b/www/source/demo/process-supervisor/steps/10.html.slim
@@ -59,7 +59,7 @@ classes: demo_step
         p
           ' Next, tail the Supervisor log for the running application using the following command:
         = code(:shell) do
-          | [1][default:/src:0]# sup-log
+          | [1][default:/src:0]# tail $SUP_LOG_FILE
         p
           ' Keep the log open as we'll be using it in the next step.
         img alt="CLI screenshot after running build" src="/images/demo/sup-step-10.png"

--- a/www/source/partials/docs/_dev-pkgs-plan-builds.html.md.erb
+++ b/www/source/partials/docs/_dev-pkgs-plan-builds.html.md.erb
@@ -37,7 +37,7 @@ The directory where your plan is located is known as the plan context.
     $ hab studio enter
     ```
 
-    The directory you were in is now mounted as `/src` inside the Studio. By default, a Supervisor runs in the background for iterative testing. You can see the streaming output by running <code>sup-log</code>. Type <code>Ctrl-C</code> to exit the streaming output and <code>sup-term</code> to terminate the background Supervisor. If you terminate the background Supervisor, then running <code>sup-run</code> will restart it along with every service that was previously loaded. You have to explicitly run <code>hab svc unload origin/package</code> to remove a package from the "loaded" list.
+    The directory you were in is now mounted as `/src` inside the Studio. By default, a Supervisor runs in the background for iterative testing. You can see the streaming output by running <code>tail $SUP_LOG_FILE</code>. Type <code>Ctrl-C</code> to exit the streaming output and <code>sup-term</code> to terminate the background Supervisor. If you terminate the background Supervisor, then running <code>sup-run</code> will restart it along with every service that was previously loaded. You have to explicitly run <code>hab svc unload origin/package</code> to remove a package from the "loaded" list.
 
 3. Enter the following command to create the package.
 

--- a/www/source/partials/docs/_using-hab-packages.html.md.erb
+++ b/www/source/partials/docs/_using-hab-packages.html.md.erb
@@ -43,7 +43,7 @@ When entering an interactive studio, a Supervisor is started for you in the back
 1. [Build your package](/docs/developing-packages/#plan-builds) inside an interactive studio. Do not exit the studio after it is built.
 2. To start your service in the running Supervisor, type `hab svc load yourorigin/yourname`, substituting the name and origin of the package you built in Step 1. Your service should now be running.
 
-Because the Supervisor is running in the background, you will not see the Supervisor output as you start your service. However you can use the `sup-log` (or `Get-SupervisorLog` on Windows) command that will stream the tail of the Supervisor output (you can also look at the contents of `/hab/sup/default/sup.log`, which is where the Studio directs its Supervisor output).
+Because the Supervisor is running in the background, you will not see the Supervisor output as you start your service. However you can use the `tail $SUP_LOG_FILE` (or `Get-SupervisorLog` on Windows) command that will stream the tail of the Supervisor output (you can also look at the contents of `/hab/sup/default/sup.log`, which is where the Studio directs its Supervisor output).
 
 If your host machine is running Linux, do the following to run your packages for one-off evaluations (not production uses!):
 


### PR DESCRIPTION
This command seems to have caused more confusion about accessing logs than it has created convenience.

This adds a `$SUP_LOG_FILE` environment variable and the command prints out
information necessary for accessing the log directly.

New behavior:
```
[1][HAB_STUDIO_BINARY][default:/src:0]# sup-log
This command is deprecated. View Supervisor logs directly at $SUP_LOG_FILE (/hab/sup/default/sup.log)

[2][HAB_STUDIO_BINARY][default:/src:0]# tail $SUP_LOG_FILE
→ Using core/openssl/1.0.2l/20171014213633
→ Using core/xz/5.2.2/20170513214327
→ Using core/zlib/1.2.8/20170513201911
✓ Installed core/hab-launcher/8744/20181016214636
★ Install of core/hab-launcher/8744/20181016214636 complete with 1 new packages installed.
hab-sup(MR): core/hab-sup (core/hab-sup/0.65.0/20181004221503)
hab-sup(MR): Supervisor Member-ID 842df9dabdc74b67b86846e508d601ec
hab-sup(MR): Starting gossip-listener on 0.0.0.0:9638
hab-sup(MR): Starting ctl-gateway on 127.0.0.1:9632
hab-sup(MR): Starting http-gateway on 0.0.0.0:9631

[3][HAB_STUDIO_BINARY][default:/src:0]# tail /hab/sup/default/sup.log
… [same as above]
```
