### PR TITLE
Put some guard rails around hab pkg uninstall

### DIFF
--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -18,6 +18,7 @@ use std::result;
 use std::str::FromStr;
 
 use clap::{App, AppSettings, Arg};
+use hcore::package::PackageIdent;
 use hcore::{crypto::keys::PairType, service::ServiceGroup};
 use protocol;
 use url::Url;
@@ -436,7 +437,7 @@ pub fn get() -> App<'static, 'static> {
                 (@arg PKG_IDENT: +required +takes_value
                     "A package identifier (ex: core/redis, core/busybox-static/1.42.2/21120102031201)")
                 (@arg DRYRUN: -d --dryrun "Just show what would be uninstalled, don't actually do it")
-                (@arg EXCLUDE: --exclude +takes_value +multiple
+                (@arg EXCLUDE: --exclude +takes_value +multiple {valid_ident}
                     "Identifier of one or more packages that should not be uninstalled. \
                     (ex: core/redis, core/busybox-static/1.42.2/21120102031201)")
                 (@arg NO_DEPS: --("no-deps") "Don't uninstall dependencies")
@@ -1081,6 +1082,16 @@ fn valid_update_strategy(val: String) -> result::Result<(), String> {
     match protocol::types::UpdateStrategy::from_str(&val) {
         Ok(_) => Ok(()),
         Err(_) => Err(format!("Update strategy: '{}' is not valid", &val)),
+    }
+}
+
+fn valid_ident(val: String) -> result::Result<(), String> {
+    match PackageIdent::from_str(&val) {
+        Ok(_) => Ok(()),
+        Err(_) => Err(format!(
+            "'{}' is not valid. Package identifiers have the form origin/name[/version[/release]]",
+            &val
+        )),
     }
 }
 ////////////////////////////////////////////////////////////////////////

--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -431,11 +431,14 @@ pub fn get() -> App<'static, 'static> {
                     (ex: /home/acme-redis-3.0.7-21120102031201-x86_64-linux.hart)")
             )
             (@subcommand uninstall =>
-                (about: "Uninstall a package and dependencies from the local filesystem")
+                (about: "Safely uninstall a package and dependencies from the local filesystem")
                 (aliases: &["un", "unin"])
                 (@arg PKG_IDENT: +required +takes_value
-                    "A package identifier (ex: core/busybox-static/1.42.2/21120102031201)")
+                    "A package identifier (ex: core/redis, core/busybox-static/1.42.2/21120102031201)")
                 (@arg DRYRUN: -d --dryrun "Just show what would be uninstalled, don't actually do it")
+                (@arg EXCLUDE: --exclude +takes_value +multiple
+                    "Identifier of one or more packages that should not be uninstalled. \
+                    (ex: core/redis, core/busybox-static/1.42.2/21120102031201)")
                 (@arg NO_DEPS: --("no-deps") "Don't uninstall dependencies")
             )
             (@subcommand upload =>

--- a/components/hab/src/command/pkg/mod.rs
+++ b/components/hab/src/command/pkg/mod.rs
@@ -37,7 +37,7 @@ pub enum ExecutionStrategy {
     /// Don't actually run commands that mutate the state of the system,
     /// simply print their output
     DryRun,
-    /// Run commands which mutuate state
+    /// Run commands which mutate state
     Run,
 }
 

--- a/components/hab/src/command/pkg/uninstall.rs
+++ b/components/hab/src/command/pkg/uninstall.rs
@@ -14,6 +14,7 @@
 
 use std::fs;
 use std::path::Path;
+use std::str::FromStr;
 
 use super::{ExecutionStrategy, Scope};
 use common::package_graph::PackageGraph;
@@ -151,6 +152,15 @@ fn maybe_delete(
 ) -> Result<bool> {
     let ident = install.ident();
     let pkg_root_path = hfs::pkg_root_path(Some(fs_root_path));
+    let hab = PackageIdent::from_str("core/hab")?;
+
+    if ident.satisfies(&hab) {
+        ui.status(
+            Status::Skipping,
+            format!("{}. You can't uninstall core/hab", &ident),
+        )?;
+        return Ok(false);
+    }
 
     // The excludes list could be looser than the fully qualified idents.  E.g. if core/redis is on the
     // exclude list then we should exclude core/redis/1.1.0/20180608091936.  We use the `Identifiable`

--- a/components/hab/src/command/pkg/uninstall.rs
+++ b/components/hab/src/command/pkg/uninstall.rs
@@ -152,8 +152,8 @@ fn maybe_delete(
 ) -> Result<bool> {
     let ident = install.ident();
     let pkg_root_path = hfs::pkg_root_path(Some(fs_root_path));
-    let hab = PackageIdent::from_str("core/hab")?;
 
+    let hab = PackageIdent::from_str("core/hab")?;
     if ident.satisfies(&hab) {
         ui.status(
             Status::Skipping,
@@ -165,22 +165,15 @@ fn maybe_delete(
     // The excludes list could be looser than the fully qualified idents.  E.g. if core/redis is on the
     // exclude list then we should exclude core/redis/1.1.0/20180608091936.  We use the `Identifiable`
     // trait which supplies this logic for PackageIdents
-    let should_exclude = excludes
-        .iter()
-        .filter(|i| i.satisfies(ident))
-        .cloned()
-        .count()
-        > 0;
-
-    match should_exclude {
-        true => {
-            ui.status(
-                Status::Skipping,
-                format!("{}. It is on the exclusion list", &ident),
-            )?;
-            Ok(false)
-        }
-        false => match strategy {
+    let should_exclude = excludes.iter().any(|i| i.satisfies(ident));
+    if should_exclude {
+        ui.status(
+            Status::Skipping,
+            format!("{}. It is on the exclusion list", &ident),
+        )?;
+        Ok(false)
+    } else {
+        match strategy {
             ExecutionStrategy::DryRun => {
                 ui.status(Status::DryRunDeleting, &ident)?;
                 Ok(false)
@@ -190,7 +183,7 @@ fn maybe_delete(
                 let pkg_dir = install.installed_path();
                 do_clean_delete(&pkg_root_path, &pkg_dir)
             }
-        },
+        }
     }
 }
 

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -523,7 +523,8 @@ fn sub_pkg_uninstall(ui: &mut UI, m: &ArgMatches) -> Result<()> {
         true => command::pkg::Scope::Package,
         false => command::pkg::Scope::PackageAndDependencies,
     };
-    command::pkg::uninstall::start(ui, &ident, &*FS_ROOT, execute_strategy, scope)
+    let excludes = excludes_from_matches(&m)?;
+    command::pkg::uninstall::start(ui, &ident, &*FS_ROOT, execute_strategy, scope, excludes)
 }
 fn sub_bldr_channel_create(ui: &mut UI, m: &ArgMatches) -> Result<()> {
     let url = bldr_url_from_matches(&m)?;
@@ -1345,10 +1346,24 @@ fn binlink_dest_dir_from_matches(matches: &ArgMatches) -> PathBuf {
 }
 
 fn install_sources_from_matches(matches: &ArgMatches) -> Result<Vec<InstallSource>> {
-    matches.values_of("PKG_IDENT_OR_ARTIFACT")
+    matches
+        .values_of("PKG_IDENT_OR_ARTIFACT")
         .unwrap() // Required via clap
         .map(|t| t.parse().map_err(Error::from))
         .collect()
+}
+
+fn excludes_from_matches(matches: &ArgMatches) -> Result<Vec<PackageIdent>> {
+    match matches.values_of("EXCLUDE") {
+        Some(idents) => {
+            let mut list = Vec::with_capacity(idents.len());
+            for ident in idents {
+                list.push(PackageIdent::from_str(ident)?);
+            }
+            Ok(list)
+        }
+        None => Ok(vec![]),
+    }
 }
 
 fn enable_features_from_env(ui: &mut UI) {

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -523,7 +523,7 @@ fn sub_pkg_uninstall(ui: &mut UI, m: &ArgMatches) -> Result<()> {
         true => command::pkg::Scope::Package,
         false => command::pkg::Scope::PackageAndDependencies,
     };
-    let excludes = excludes_from_matches(&m)?;
+    let excludes = excludes_from_matches(&m);
     command::pkg::uninstall::start(ui, &ident, &*FS_ROOT, execute_strategy, scope, excludes)
 }
 fn sub_bldr_channel_create(ui: &mut UI, m: &ArgMatches) -> Result<()> {
@@ -1353,17 +1353,12 @@ fn install_sources_from_matches(matches: &ArgMatches) -> Result<Vec<InstallSourc
         .collect()
 }
 
-fn excludes_from_matches(matches: &ArgMatches) -> Result<Vec<PackageIdent>> {
-    match matches.values_of("EXCLUDE") {
-        Some(idents) => {
-            let mut list = Vec::with_capacity(idents.len());
-            for ident in idents {
-                list.push(PackageIdent::from_str(ident)?);
-            }
-            Ok(list)
-        }
-        None => Ok(vec![]),
-    }
+fn excludes_from_matches(matches: &ArgMatches) -> Vec<PackageIdent> {
+    matches
+        .values_of("EXCLUDE")
+        .unwrap() // Required via clap
+        .map(|i| PackageIdent::from_str(i).unwrap()) // unwrap safe as we've validated the input
+        .collect()
 }
 
 fn enable_features_from_env(ui: &mut UI) {


### PR DESCRIPTION
Makes `hab pkg uninstall` somewhat safer:

* Adds a `--exclude PKG_IDENT` option which allows you to specify packages you don't want deleted as part of an uninstall
* Never allow us to delete `core/hab` as that would be bad

Signed-off-by: James Casey <james@chef.io>