### PR TITLE
Reduce excessive disk I/O when persisting rumors

### DIFF
--- a/components/butterfly/src/server/mod.rs
+++ b/components/butterfly/src/server/mod.rs
@@ -1174,15 +1174,12 @@ impl Server {
         message::unwrap_wire(payload, (*self.ring_key).as_ref())
     }
 
-    fn persist_data(&self) {
+    pub fn persist_data(&self) {
         if let Some(ref dat_file) = *self.dat_file.write().expect("DatFile lock poisoned") {
             if let Some(err) = dat_file.write(self).err() {
                 error!("Error persisting rumors to disk, {}", err);
             } else {
-                debug!(
-                    "Successfully persisted rumors to disk: {}",
-                    dat_file.path().display()
-                );
+                info!("Rumors persisted to disk: {}", dat_file.path().display());
             }
         }
     }
@@ -1219,12 +1216,6 @@ impl fmt::Display for Server {
             self.swim_port(),
             self.gossip_port()
         )
-    }
-}
-
-impl Drop for Server {
-    fn drop(&mut self) {
-        self.persist_data();
     }
 }
 

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -1626,6 +1626,8 @@ impl Manager {
             self.remove_service(&mut service, cause);
         }
         release_process_lock(&self.fs_cfg);
+
+        self.butterfly.persist_data();
     }
 
     fn start_initial_services_from_spec_watcher(&mut self) -> Result<()> {


### PR DESCRIPTION
The Butterfly server writes all rumors to disk periodically for
durability. It also writes rumors to disk in the `Drop` implementation
of the `Server` struct. While this could be used to implement a "save
on shutdown" behavior, it also ended up causing a worst-case behavior
of writing the rumors out five times _per second_. This is because a
copy of the Butterfly server is passed into each of the five
short-lived worker threads that are spawned every second for pushing
rumors out to network members. When these threads exit, they drop
their copy of the Butterfly server struct, triggering a write.

These worker threads are started when there are new rumors to send
out, so the more active the network, the more frequently these writes
would happen. With larger networks, there are both more members to
send rumors to, as well as a larger number of rumors to persist. Thus,
large and active networks would generate scenarios of excessive disk
load.

Here, we simply remove the offending `Drop` implementation, thereby
eliminating the 5x/s worst case scenario. For persistence, we instead
rely on the existing periodic write of once every 30s. Additionally,
we add an explicit call to persist the data at Supervisor shutdown
time.

Finally, the logging message for a successful disk write is now
`info`, rather than `debug`, since this is an important event to
notify about.

Signed-off-by: Christopher Maier <cmaier@chef.io>