### PR TITLE
Add target to Docker image names for studio

### DIFF
--- a/.buildkite/scripts/dockerhub_upload.sh
+++ b/.buildkite/scripts/dockerhub_upload.sh
@@ -10,7 +10,9 @@ set -euo pipefail
 source .buildkite/scripts/shared.sh
 version=$(buildkite-agent meta-data get "version")
 channel=$(buildkite-agent meta-data get "release-channel")
-image_name="habitat/default-studio"
+target="${BUILD_PKG_TARGET:=x86_64-linux}"
+image_name="habitat/default-studio-${target}"
+image_name_with_tag="${image_name}:${version}"
 
 if is_fake_release; then
   image_name="habitat/fakey-mc-fake-face-studio"
@@ -23,14 +25,14 @@ docker login \
 trap 'rm -f $HOME/.docker/config.json' INT TERM EXIT
 
 pushd ./components/rootless_studio >/dev/null
-docker build -t habitat:hab-base .
-docker build --build-arg BLDR_CHANNEL="${channel}" --no-cache --tag "${image_name}:${version}" ./default
-docker push "${image_name}:${version}"
+docker build --build-arg PACKAGE_TARGET="${target}" -t habitat-${target}:hab-base .
+docker build --build-arg BLDR_CHANNEL="${channel}" --no-cache --tag "${image_name_with_tag}" ./default
+docker push "${image_name_with_tag}"
 popd >/dev/null
 
 cat << EOF | buildkite-agent annotate --style=success --context=docker-studio	
 <h3>DockerHub Studio Image (Linux)</h3>	
 <ul>	
-  <li><code>${image_name:?}:${version:?}</code></li>	
+  <li><code>${image_name_with_tag:?}</code></li>	
 </ul>	
 EOF

--- a/.buildkite/scripts/dockerhub_upload.sh
+++ b/.buildkite/scripts/dockerhub_upload.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 source .buildkite/scripts/shared.sh
 version=$(buildkite-agent meta-data get "version")
 channel=$(buildkite-agent meta-data get "release-channel")
-target="${BUILD_PKG_TARGET:=x86_64-linux}"
+target="${BUILD_PKG_TARGET:-x86_64-linux}"
 image_name="habitat/default-studio-${target}"
 image_name_with_tag="${image_name}:${version}"
 

--- a/.buildkite/scripts/dockerhub_upload.sh
+++ b/.buildkite/scripts/dockerhub_upload.sh
@@ -33,6 +33,6 @@ popd >/dev/null
 cat << EOF | buildkite-agent annotate --style=success --context=docker-studio	
 <h3>DockerHub Studio Image (Linux)</h3>	
 <ul>	
-  <li><code>${image_name_with_tag:?}</code></li>	
+  <li><code>${image_name_with_tag}</code></li>	
 </ul>	
 EOF

--- a/.buildkite/scripts/dockerhub_upload.sh
+++ b/.buildkite/scripts/dockerhub_upload.sh
@@ -25,7 +25,7 @@ docker login \
 trap 'rm -f $HOME/.docker/config.json' INT TERM EXIT
 
 pushd ./components/rootless_studio >/dev/null
-docker build --build-arg PACKAGE_TARGET="${target}" -t habitat-${target}:hab-base .
+docker build --build-arg PACKAGE_TARGET="${target}" -t "habitat-${target}:hab-base" .
 docker build --build-arg BLDR_CHANNEL="${channel}" --no-cache --tag "${image_name_with_tag}" ./default
 docker push "${image_name_with_tag}"
 popd >/dev/null

--- a/components/hab/src/command/pkg/binlink.rs
+++ b/components/hab/src/command/pkg/binlink.rs
@@ -253,6 +253,7 @@ impl Binlink {
 }
 
 #[cfg(test)]
+#[cfg(any(linux, windows))]
 mod test {
     use std::collections::HashMap;
     use std::env;

--- a/components/hab/src/command/pkg/binlink.rs
+++ b/components/hab/src/command/pkg/binlink.rs
@@ -253,7 +253,7 @@ impl Binlink {
 }
 
 #[cfg(test)]
-#[cfg(any(linux, windows))]
+#[cfg(any(target_os = "linux", target_os = "windows"))]
 mod test {
     use std::collections::HashMap;
     use std::env;

--- a/components/hab/src/command/studio/docker.rs
+++ b/components/hab/src/command/studio/docker.rs
@@ -23,12 +23,14 @@ use hcore::crypto::default_cache_key_path;
 use hcore::env as henv;
 use hcore::fs::{find_command, CACHE_ARTIFACT_PATH, CACHE_KEY_PATH};
 use hcore::os::process;
+use hcore::package::target;
 
 use error::{Error, Result};
 use VERSION;
 
 const DOCKER_CMD: &'static str = "docker";
 const DOCKER_CMD_ENVVAR: &'static str = "HAB_DOCKER_BINARY";
+
 const DOCKER_IMAGE: &'static str = "habitat/default-studio";
 const DOCKER_WINDOWS_IMAGE: &'static str = "habitat-docker-registry.bintray.io/win-studio";
 const DOCKER_IMAGE_ENVVAR: &'static str = "HAB_DOCKER_STUDIO_IMAGE";
@@ -129,9 +131,13 @@ fn find_docker_cmd() -> Result<PathBuf> {
 
 fn is_image_present(docker_cmd: &Path) -> bool {
     let mut cmd = Command::new(docker_cmd);
-    cmd.arg("images")
-        .arg(&image_identifier(docker_cmd))
-        .arg("-q");
+    let using_windows_containers = is_serving_windows_containers(&docker_cmd);
+    let image = image_identifier(
+        using_windows_containers,
+        target::PackageTarget::active_target(),
+    );
+
+    cmd.arg("images").arg(&image).arg("-q");
     debug!("Running command: {:?}", cmd);
     let result = cmd.output().expect("Docker command failed to spawn");
 
@@ -147,7 +153,11 @@ fn is_serving_windows_containers(docker_cmd: &Path) -> bool {
 }
 
 fn pull_image(docker_cmd: &Path) -> Result<()> {
-    let image = image_identifier(docker_cmd);
+    let using_windows_containers = is_serving_windows_containers(&docker_cmd);
+    let image = image_identifier(
+        using_windows_containers,
+        target::PackageTarget::active_target(),
+    );
     let mut cmd = Command::new(docker_cmd);
     cmd.arg("pull")
         .arg(&image)
@@ -171,15 +181,11 @@ fn pull_image(docker_cmd: &Path) -> Result<()> {
         let err_output = String::from_utf8_lossy(&result.stderr);
 
         if err_output.contains("image") && err_output.contains("not found") {
-            return Err(Error::DockerImageNotFound(
-                image_identifier(docker_cmd).to_string(),
-            ));
+            return Err(Error::DockerImageNotFound(image.to_string()));
         } else if err_output.contains("Cannot connect to the Docker daemon") {
             return Err(Error::DockerDaemonDown);
         } else {
-            return Err(Error::DockerNetworkDown(
-                image_identifier(docker_cmd).to_string(),
-            ));
+            return Err(Error::DockerNetworkDown(image.to_string()));
         }
     }
 
@@ -198,11 +204,17 @@ where
     S: AsRef<OsStr>,
 {
     let mut cmd_args: Vec<OsString> = vec!["run".into(), "--rm".into()];
+    let using_windows_containers = is_serving_windows_containers(&docker_cmd);
+    let image = image_identifier(
+        using_windows_containers,
+        target::PackageTarget::active_target(),
+    );
+
     for vol in volumes {
         cmd_args.push("--volume".into());
         cmd_args.push(vol.as_ref().into());
     }
-    cmd_args.push(image_identifier(docker_cmd).into());
+    cmd_args.push(image.into());
     cmd_args.push("-V".into());
     let version_output = Command::new(docker_cmd)
         .args(&cmd_args)
@@ -231,8 +243,13 @@ where
     S: AsRef<OsStr>,
     T: AsRef<str>,
 {
+    let using_windows_containers = is_serving_windows_containers(&docker_cmd);
+    let image = image_identifier(
+        using_windows_containers,
+        target::PackageTarget::active_target(),
+    );
     let mut cmd_args: Vec<OsString> = vec!["run".into(), "--rm".into()];
-    if !is_serving_windows_containers(&docker_cmd) {
+    if !using_windows_containers {
         cmd_args.push("--privileged".into());
     }
     match args.first().map(|f| f.to_str().unwrap_or_default()) {
@@ -243,11 +260,12 @@ where
         }
     }
     if let Ok(opts) = henv::var(DOCKER_OPTS_ENVVAR) {
-        let opts = opts.split(" ")
-                .map(|v| v.into())
-                // Ensure we're not passing something like `--tty` again here.
-                .filter(|v| !cmd_args.contains(v))
-                .collect::<Vec<_>>();
+        let opts = opts
+            .split(" ")
+            .map(|v| v.into())
+            // Ensure we're not passing something like `--tty` again here.
+            .filter(|v| !cmd_args.contains(v))
+            .collect::<Vec<_>>();
         if !opts.is_empty() {
             debug!(
                 "Adding extra Docker options from {} = {:?}",
@@ -267,9 +285,9 @@ where
         cmd_args.push("--volume".into());
         cmd_args.push(vol.as_ref().into());
     }
-    cmd_args.push(image_identifier(&docker_cmd).into());
+    cmd_args.push(image.into());
     cmd_args.extend_from_slice(args.as_slice());
-    if is_serving_windows_containers(&docker_cmd) {
+    if using_windows_containers {
         cmd_args.push("-n".into());
         cmd_args.push("-o".into());
         cmd_args.push("c:/".into());
@@ -289,27 +307,55 @@ fn unset_proxy_env_vars() {
 
 /// Returns the Docker Studio image with tag for the desired version which corresponds to the
 /// same version (minus release) as this program.
-fn image_identifier(docker_cmd: &Path) -> String {
+fn image_identifier(using_windows_containers: bool, target: &target::PackageTarget) -> String {
     let version: Vec<&str> = VERSION.split("/").collect();
-    let img = match is_serving_windows_containers(docker_cmd) {
-        true => DOCKER_WINDOWS_IMAGE,
-        false => DOCKER_IMAGE,
+    let (img, studio_target) = match using_windows_containers {
+        true => (DOCKER_WINDOWS_IMAGE, target::X86_64_WINDOWS.as_ref()),
+        false => {
+            let t = match *target {
+                target::X86_64_LINUX_KERNEL2 => target::X86_64_LINUX_KERNEL2.as_ref(),
+                _ => target::X86_64_LINUX.as_ref(),
+            };
+            (DOCKER_IMAGE, t)
+        }
     };
-    henv::var(DOCKER_IMAGE_ENVVAR).unwrap_or(format!("{}:{}", img, version[0]))
+
+    henv::var(DOCKER_IMAGE_ENVVAR).unwrap_or(format!("{}-{}:{}", img, studio_target, version[0]))
 }
 
 #[cfg(test)]
-#[cfg(target_os = "linux")]
 mod tests {
-    use super::{find_docker_cmd, image_identifier, DOCKER_IMAGE};
+    use super::{image_identifier, DOCKER_IMAGE, DOCKER_WINDOWS_IMAGE};
     use VERSION;
+
+    use hcore::package::target;
 
     #[test]
     fn retrieve_image_identifier() {
-        let docker_cmd = find_docker_cmd().unwrap();
+        let windows_container = true;
         assert_eq!(
-            image_identifier(&docker_cmd),
-            format!("{}:{}", DOCKER_IMAGE, VERSION)
+            image_identifier(!windows_container, &target::X86_64_DARWIN),
+            format!("{}-{}:{}", DOCKER_IMAGE, "x86_64-linux", VERSION)
+        );
+        assert_eq!(
+            image_identifier(!windows_container, &target::X86_64_LINUX),
+            format!("{}-{}:{}", DOCKER_IMAGE, "x86_64-linux", VERSION)
+        );
+        assert_eq!(
+            image_identifier(!windows_container, &target::X86_64_LINUX_KERNEL2),
+            format!("{}-{}:{}", DOCKER_IMAGE, "x86_64-linux-kernel2", VERSION)
+        );
+        assert_eq!(
+            image_identifier(!windows_container, &target::X86_64_WINDOWS),
+            format!("{}-{}:{}", DOCKER_IMAGE, "x86_64-linux", VERSION)
+        );
+        assert_eq!(
+            image_identifier(windows_container, &target::X86_64_WINDOWS),
+            format!("{}-{}:{}", DOCKER_WINDOWS_IMAGE, "x86_64-windows", VERSION)
+        );
+        assert_eq!(
+            image_identifier(windows_container, &target::X86_64_LINUX),
+            format!("{}-{}:{}", DOCKER_WINDOWS_IMAGE, "x86_64-windows", VERSION)
         );
     }
 }

--- a/components/hab/src/command/studio/docker.rs
+++ b/components/hab/src/command/studio/docker.rs
@@ -131,11 +131,7 @@ fn find_docker_cmd() -> Result<PathBuf> {
 
 fn is_image_present(docker_cmd: &Path) -> bool {
     let mut cmd = Command::new(docker_cmd);
-    let using_windows_containers = is_serving_windows_containers(&docker_cmd);
-    let image = image_identifier(
-        using_windows_containers,
-        target::PackageTarget::active_target(),
-    );
+    let image = image_identifier_for_active_target(&docker_cmd);
 
     cmd.arg("images").arg(&image).arg("-q");
     debug!("Running command: {:?}", cmd);
@@ -153,11 +149,7 @@ fn is_serving_windows_containers(docker_cmd: &Path) -> bool {
 }
 
 fn pull_image(docker_cmd: &Path) -> Result<()> {
-    let using_windows_containers = is_serving_windows_containers(&docker_cmd);
-    let image = image_identifier(
-        using_windows_containers,
-        target::PackageTarget::active_target(),
-    );
+    let image = image_identifier_for_active_target(&docker_cmd);
     let mut cmd = Command::new(docker_cmd);
     cmd.arg("pull")
         .arg(&image)
@@ -204,11 +196,7 @@ where
     S: AsRef<OsStr>,
 {
     let mut cmd_args: Vec<OsString> = vec!["run".into(), "--rm".into()];
-    let using_windows_containers = is_serving_windows_containers(&docker_cmd);
-    let image = image_identifier(
-        using_windows_containers,
-        target::PackageTarget::active_target(),
-    );
+    let image = image_identifier_for_active_target(&docker_cmd);
 
     for vol in volumes {
         cmd_args.push("--volume".into());
@@ -244,10 +232,7 @@ where
     T: AsRef<str>,
 {
     let using_windows_containers = is_serving_windows_containers(&docker_cmd);
-    let image = image_identifier(
-        using_windows_containers,
-        target::PackageTarget::active_target(),
-    );
+    let image = image_identifier_for_active_target(&docker_cmd);
     let mut cmd_args: Vec<OsString> = vec!["run".into(), "--rm".into()];
     if !using_windows_containers {
         cmd_args.push("--privileged".into());
@@ -303,6 +288,13 @@ fn unset_proxy_env_vars() {
             env::remove_var(var);
         }
     }
+}
+
+fn image_identifier_for_active_target(docker_cmd: &Path) -> String {
+    image_identifier(
+        is_serving_windows_containers(docker_cmd),
+        target::PackageTarget::active_target(),
+    )
 }
 
 /// Returns the Docker Studio image with tag for the desired version which corresponds to the

--- a/components/rootless_studio/Dockerfile
+++ b/components/rootless_studio/Dockerfile
@@ -1,6 +1,7 @@
 FROM alpine
 MAINTAINER Elliott Davis <elliott@excellent.io>
 ARG HAB_VERSION=
+ARG PACKAGE_TARGET
 RUN set -ex \
   && apk add --no-cache --virtual .build-deps \
     ca-certificates \
@@ -10,6 +11,6 @@ RUN set -ex \
   \
   && cd /tmp \
   && wget https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh \
-  && sh install.sh \
+  && sh install.sh -t ${PACKAGE_TARGET} \
   && rm -rf install.sh /hab/cache /root/.wget-hsts /root/.gnupg \
   && apk del .build-deps

--- a/components/rootless_studio/default/Dockerfile
+++ b/components/rootless_studio/default/Dockerfile
@@ -1,4 +1,5 @@
-FROM habitat:hab-base as hab
+ARG PACKAGE_TARGET
+FROM habitat-${PACKAGE_TARGET}:hab-base as hab
 ENV PATH=${PATH}:/hab/bin
 ARG BLDR_CHANNEL=stable
 RUN hab pkg install -c ${BLDR_CHANNEL} core/hab-backline \

--- a/components/studio/build-docker-image.ps1
+++ b/components/studio/build-docker-image.ps1
@@ -12,7 +12,7 @@ if((Get-Command hab -ErrorAction SilentlyContinue) -eq $null) {
 }
 
 If (-not (Test-Path env:IMAGE_NAME)) {
-   $imageName = "habitat-docker-registry.bintray.io/win-studio"
+   $imageName = "habitat-docker-registry.bintray.io/win-studio-x86_64-windows"
 } Else {
    $imageName = $env:IMAGE_NAME
 }
@@ -55,7 +55,7 @@ try {
     
     $pathParts = $studioPath.Replace("\", "/").Split("/")
     $ident = [String]::Join("/", $pathParts[-4..-1])
-    $shortVersion = $pathParts[-2]
+    $shortVersion = "${pathParts[-2]}"
     $version = "$($pathParts[-2])-$($pathParts[-1])"
     
 @"


### PR DESCRIPTION
closes #5752 
ref #5753 

This adds support for an linux docker studio based on the x86-64-linux-kernel2 Target, by encoding the ActiveTarget of the contained hab cli in the docker image name.  It also makes the necessary changed to the `hab studio` cli subcommand to allow the correct studio image to be downloaded and run.  

There is some 'state of the world' encoded in the logic. By this I mean that currently you should always get the `x86_64-linux` image, unless you are on windows with windows containers enabled in which case you will get the `x86_64-windows` container, OR you are on a linux system with a hab cli that has an ActiveTarget of `x86_64-linux-kernel2` and will get a `x86_64-linux-kernel2` container.  This is _hopefully_ covered in additional tests. 

@mwrock  For consistency the windows studio image received the same updates,  but I'm not as familiar with the windows release process to know if I hit all the places where we reference the image name.   

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>