### PR TITLE
Simplify elections code by replacing ServiceGroup structs with strings

### DIFF
--- a/components/butterfly-test/src/lib.rs
+++ b/components/butterfly-test/src/lib.rs
@@ -51,7 +51,7 @@ lazy_static! {
 #[derive(Debug)]
 struct NSuitability(u64);
 impl Suitability for NSuitability {
-    fn get(&self, _service_group: &ServiceGroup) -> u64 {
+    fn get(&self, _service_group: &str) -> u64 {
         self.0
     }
 }
@@ -518,7 +518,7 @@ impl SwimNet {
     }
 
     pub fn add_election(&mut self, member: usize, service: &str) {
-        self[member].start_election(ServiceGroup::new(None, service, "prod", None).unwrap(), 0);
+        self[member].start_election(&ServiceGroup::new(None, service, "prod", None).unwrap(), 0);
     }
 }
 

--- a/components/butterfly/src/main.rs
+++ b/components/butterfly/src/main.rs
@@ -27,12 +27,11 @@ use std::time::Duration;
 
 use habitat_butterfly::server::Suitability;
 use habitat_butterfly::{member, server, trace};
-use habitat_core::service::ServiceGroup;
 
 #[derive(Debug)]
 struct ZeroSuitability;
 impl Suitability for ZeroSuitability {
-    fn get(&self, _service_group: &ServiceGroup) -> u64 {
+    fn get(&self, _service_group: &str) -> u64 {
         0
     }
 }

--- a/components/sup/src/census.rs
+++ b/components/sup/src/census.rs
@@ -862,12 +862,12 @@ mod tests {
         service_store.insert(service_three);
 
         let election_store: RumorStore<ElectionRumor> = RumorStore::default();
-        let mut election = ElectionRumor::new("member-a", sg_one.clone(), 10);
+        let mut election = ElectionRumor::new("member-a", &sg_one, 10);
         election.finish();
         election_store.insert(election);
 
         let election_update_store: RumorStore<ElectionUpdateRumor> = RumorStore::default();
-        let mut election_update = ElectionUpdateRumor::new("member-b", sg_two.clone(), 10);
+        let mut election_update = ElectionUpdateRumor::new("member-b", &sg_two, 10);
         election_update.finish();
         election_update_store.insert(election_update);
 

--- a/components/sup/src/http_gateway.rs
+++ b/components/sup/src/http_gateway.rs
@@ -404,7 +404,6 @@ mod tests {
         server::{Server, ServerProxy, Suitability},
         trace::Trace,
     };
-    use hcore::service::ServiceGroup;
     use serde_json;
 
     use test_helpers::*;
@@ -471,7 +470,7 @@ mod tests {
         #[derive(Debug)]
         struct ZeroSuitability;
         impl Suitability for ZeroSuitability {
-            fn get(&self, _service_group: &ServiceGroup) -> u64 {
+            fn get(&self, _service_group: &str) -> u64 {
                 0
             }
         }

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -627,8 +627,7 @@ impl Manager {
 
         self.gossip_latest_service_rumor(&service);
         if service.topology == Topology::Leader {
-            self.butterfly
-                .start_election(service.service_group.clone(), 0);
+            self.butterfly.start_election(&service.service_group, 0);
         }
 
         if let Err(e) = self.user_config_watcher.add(&service) {
@@ -1774,12 +1773,12 @@ impl fmt::Display for ServiceStatus {
 struct SuitabilityLookup(Arc<RwLock<HashMap<PackageIdent, Service>>>);
 
 impl Suitability for SuitabilityLookup {
-    fn get(&self, service_group: &ServiceGroup) -> u64 {
+    fn get(&self, service_group: &str) -> u64 {
         self.0
             .read()
             .expect("Services lock is poisoned!")
             .values()
-            .find(|s| s.service_group == *service_group)
+            .find(|s| *s.service_group == service_group)
             .and_then(|s| s.suitability())
             .unwrap_or(u64::min_value())
     }

--- a/components/sup/src/manager/service/hooks.rs
+++ b/components/sup/src/manager/service/hooks.rs
@@ -1328,7 +1328,7 @@ echo "The message is Hola Mundo"
         service_store.insert(service_one);
 
         let election_store: RumorStore<ElectionRumor> = RumorStore::default();
-        let mut election = ElectionRumor::new("member-a", sg_one, 10);
+        let mut election = ElectionRumor::new("member-a", &sg_one, 10);
         election.finish();
         election_store.insert(election);
 
@@ -1435,7 +1435,7 @@ echo "The message is Hello"
         service_store.insert(service_one);
 
         let election_store: RumorStore<ElectionRumor> = RumorStore::default();
-        let mut election = ElectionRumor::new("member-a", sg_one, 10);
+        let mut election = ElectionRumor::new("member-a", &sg_one, 10);
         election.finish();
         election_store.insert(election);
 

--- a/components/sup/src/manager/service_updater.rs
+++ b/components/sup/src/manager/service_updater.rs
@@ -143,7 +143,7 @@ impl ServiceUpdater {
                                     u64::max_value()
                                 };
                                 self.butterfly.start_update_election(
-                                    service.service_group.clone(),
+                                    &service.service_group,
                                     suitability,
                                     0,
                                 );
@@ -154,7 +154,7 @@ impl ServiceUpdater {
                     } else {
                         debug!("Rolling update, using default suitability");
                         self.butterfly
-                            .start_update_election(service.service_group.clone(), 0, 0);
+                            .start_update_election(&service.service_group, 0, 0);
                         *st = RollingState::InElection;
                     }
                 }


### PR DESCRIPTION
This should have no effect on behavior, it's a simplification that came out of
auditing the elections code.

The change is fairly seamless because ServiceGroup is String wrapper, but for
the purpose of elections, it's only used as an opaque identifier. Using a
string directly allows for simplification of code where the complexity is
appropriate for validating user input that's unnecessary for data that either
comes from protocol messages or existing ServiceGroup instances.

See https://github.com/habitat-sh/core/blob/master/components/core/src/service.rs#L85

Signed-off-by: Jon Bauman <5906042+baumanj@users.noreply.github.com>