### PR TITLE
Add Windows-friendly behavior to `hab pkg env`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1028,7 +1028,7 @@ dependencies = [
 [[package]]
 name = "habitat_core"
 version = "0.0.0"
-source = "git+https://github.com/habitat-sh/core.git#0f02f3a87bc6cf70c80a7086b9d8480518b14317"
+source = "git+https://github.com/habitat-sh/core.git#c94625e54ead18821e2a0a14b69ee68867e93406"
 dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1063,7 +1063,7 @@ dependencies = [
 [[package]]
 name = "habitat_http_client"
 version = "0.0.0"
-source = "git+https://github.com/habitat-sh/core.git#0f02f3a87bc6cf70c80a7086b9d8480518b14317"
+source = "git+https://github.com/habitat-sh/core.git#c94625e54ead18821e2a0a14b69ee68867e93406"
 dependencies = [
  "base64 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat_core 0.0.0 (git+https://github.com/habitat-sh/core.git)",
@@ -1221,7 +1221,7 @@ dependencies = [
 [[package]]
 name = "habitat_win_users"
 version = "0.0.0"
-source = "git+https://github.com/habitat-sh/core.git#0f02f3a87bc6cf70c80a7086b9d8480518b14317"
+source = "git+https://github.com/habitat-sh/core.git#c94625e54ead18821e2a0a14b69ee68867e93406"
 dependencies = [
  "gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/hab/src/command/pkg/env.rs
+++ b/components/hab/src/command/pkg/env.rs
@@ -12,18 +12,30 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
 use std::path::Path;
 
 use hcore::package::{PackageIdent, PackageInstall};
 
 use error::Result;
 
-// TODO: This needs a windows compatible version
 pub fn start(ident: &PackageIdent, fs_root_path: &Path) -> Result<()> {
     let pkg_install = PackageInstall::load(ident, Some(fs_root_path))?;
     let env = pkg_install.environment_for_command()?;
+    render_environment(env);
+    Ok(())
+}
+
+#[cfg(unix)]
+fn render_environment(env: HashMap<String, String>) {
     for (key, value) in env.into_iter() {
         println!("export {}=\"{}\"", key, value);
     }
-    Ok(())
+}
+
+#[cfg(windows)]
+fn render_environment(env: HashMap<String, String>) {
+    for (key, value) in env.into_iter() {
+        println!("$env:{}=\"{}\"", key, value);
+    }
 }

--- a/components/hab/src/command/pkg/exec.rs
+++ b/components/hab/src/command/pkg/exec.rs
@@ -14,7 +14,7 @@
 
 use std::env;
 use std::ffi::OsString;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use hcore::fs::{find_command, FS_ROOT_PATH};
 use hcore::os::process;
@@ -28,24 +28,7 @@ where
 {
     let command = command.into();
     let pkg_install = PackageInstall::load(&ident, Some(&*FS_ROOT_PATH))?;
-    let mut cmd_env = pkg_install.environment_for_command()?;
-
-    let mut paths: Vec<PathBuf> = match cmd_env.get("PATH") {
-        Some(path) => env::split_paths(&path).collect(),
-        None => vec![],
-    };
-    for i in 0..paths.len() {
-        if paths[i].starts_with("/") {
-            paths[i] = Path::new(&*FS_ROOT_PATH).join(paths[i].strip_prefix("/").unwrap());
-        }
-    }
-    let joined = env::join_paths(paths)?;
-    cmd_env.insert(
-        String::from("PATH"),
-        joined
-            .into_string()
-            .expect("Unable to convert OsStr path to string!"),
-    );
+    let cmd_env = pkg_install.environment_for_command()?;
 
     for (key, value) in cmd_env.into_iter() {
         debug!("Setting: {}='{}'", key, value);

--- a/components/sup/src/manager/service/package.rs
+++ b/components/sup/src/manager/service/package.rs
@@ -15,10 +15,9 @@
 use std::collections::HashMap;
 use std::env;
 use std::ops::Deref;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::result;
 
-use hcore::fs::FS_ROOT_PATH;
 use hcore::os::users;
 use hcore::package::{PackageIdent, PackageInstall};
 use hcore::util::{deserialize_using_from_str, serialize_using_to_string};
@@ -74,18 +73,6 @@ impl Env {
             Some(path) => env::split_paths(&path).collect(),
             None => vec![],
         };
-
-        // Lets join the run paths to the FS_ROOT
-        // In most cases, this does nothing and should only mutate
-        // the paths in a windows studio where FS_ROOT_PATH will
-        // be the studio root path (ie c:\hab\studios\...). In any other
-        // environment FS_ROOT will be "/" and this will not make any
-        // meaningful change.
-        for i in 0..paths.len() {
-            if paths[i].starts_with("/") {
-                paths[i] = Path::new(&*FS_ROOT_PATH).join(paths[i].strip_prefix("/").unwrap());
-            }
-        }
 
         util::path::append_interpreter_and_path(&mut paths)
     }


### PR DESCRIPTION
This PR depends on https://github.com/habitat-sh/core/pull/86

This makes `hab pkg env` windows friendly:

```
[HAB-STUDIO] Habitat:\src> hab pkg env core/powershell
$env:PATH="C:\hab\studios\dev--blank\hab\pkgs\core\powershell\6.0.0\20180124123643\bin"
```

This will be necessary for the upcoming "package updater" service.

Signed-off-by: mwrock <matt@mattwrock.com>