### PR TITLE
corrects kubernetes docs

### DIFF
--- a/www/source/partials/docs/_dev-pkgs-exports.html.md.erb
+++ b/www/source/partials/docs/_dev-pkgs-exports.html.md.erb
@@ -133,7 +133,7 @@ The Kubernetes exporter is an additional command line subcommand to the standard
     ```shell
     $ hab pkg export kubernetes ./results/<hart-filename>.hart -o my_app.yaml
     ```
-5. Additionally, you can also push the Docker image the exporter creates to Docker Hub (or another container registry) with:
+5. To push the Docker image created by the Kubernetes exporter to Docker Hub or another container registry, use:
 
     ```shell
     $ hab pkg export kubernetes --push-image --username <your_docker_hub_username> --password <your_docker_hub_password> -o my_app.yaml

--- a/www/source/partials/docs/_dev-pkgs-exports.html.md.erb
+++ b/www/source/partials/docs/_dev-pkgs-exports.html.md.erb
@@ -123,12 +123,21 @@ The Kubernetes exporter is an additional command line subcommand to the standard
 3. Run the Kubernetes exporter on the package.
 
     ```shell
-    $ hab pkg export kubernetes <ORIGIN>/<NAME>
+    $ hab pkg export kubernetes ./results/<hart-filename>.hart
     ```
 
     You can run `hab pkg export kubernetes --help` to see the full list of available options and general help.
 
-4. More information and a demo video is available on the [announcement blog](https://kinvolk.io/blog/2017/12/introducing-the-habitat-kubernetes-exporter/)
+4. The Kubernetes exporter outputs a Kubernetes manifest yaml file. You can redirect the output to a file like this:
+
+    ```shell
+    $ hab pkg export kubernetes ./results/<hart-filename>.hart -o my_app.yaml
+    ```
+5. Additionally, you can also push the Docker image the exporter creates to Docker Hub (or another container registry) with:
+
+    ```shell
+    $ hab pkg export kubernetes --push-image --username <your_docker_hub_username> --password <your_docker_hub_password> -o my_app.yaml
+    ```
 
 ## Export to a Helm chart
 


### PR DESCRIPTION
I noticed that the Kubernetes exporter (at least when it comes to pushing the Docker image to Docker hub) does not work the way our docs indicate it does.

This corrects and adds to those docs to make using this exporter easier for all.

Signed-off-by: Nell Shamrell <nellshamrell@gmail.com>