### PR TITLE
`hab sup help` no longer attempts to install 'core/hab-sup' if not present

### DIFF
--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -1203,21 +1203,23 @@ fn exec_subcommand_if_called(ui: &mut UI) -> Result<()> {
         ("stu", _, _) | ("stud", _, _) | ("studi", _, _) | ("studio", _, _) => {
             command::studio::enter::start(ui, env::args_os().skip(2).collect())
         }
-        // Delegate remaining Supervisor subcommands to `hab-sup *`
+        // Skip invoking the `hab-sup` binary for sup cli help messages;
+        // handle these from within `hab`
+        ("help", "sup", _)
+        | ("sup", _, "help")
+        | ("sup", "help", _)
+        | ("sup", _, "-h")
+        | ("sup", "-h", _)
+        | ("sup", _, "--help")
+        | ("sup", "--help", _) => Ok(()),
+        // Delegate remaining Supervisor subcommands to `hab-sup`
         ("sup", "", "")
-        | ("sup", "run", "-h")
-        | ("sup", "run", "--help")
         | ("sup", "term", _)
         | ("sup", "bash", _)
         | ("sup", "sh", _)
-        | ("sup", "-h", _)
-        | ("sup", "--help", _)
-        | ("sup", "help", _)
         | ("sup", "-V", _)
         | ("sup", "--version", _) => command::sup::start(ui, env::args_os().skip(2).collect()),
         ("term", _, _) => command::sup::start(ui, env::args_os().skip(1).collect()),
-        // Delegate `hab help sup *` to `hab-sup`, passing only "help"
-        ("help", "sup", _) => command::sup::start(ui, env::args_os().skip(1).take(1).collect()),
         // Delegate `hab sup run *` to the Launcher
         ("sup", "run", _) => command::launcher::start(ui, env::args_os().skip(2).collect()),
         _ => Ok(()),

--- a/components/sup/src/lib.rs
+++ b/components/sup/src/lib.rs
@@ -47,7 +47,6 @@ extern crate bitflags;
 extern crate byteorder;
 #[cfg(target_os = "linux")]
 extern crate caps;
-#[macro_use]
 extern crate clap;
 extern crate crypto;
 #[cfg(windows)]

--- a/test/end-to-end/test_hab_help_doesnt_install_hab_sup.sh
+++ b/test/end-to-end/test_hab_help_doesnt_install_hab_sup.sh
@@ -28,7 +28,7 @@ simply 'hab'). In the latter case when just passing the binary name, the shell w
 if [[ $# -eq 0 ]] ; then
   print_help
   echo
-  echo "<path-to-hab-binary> must be specified"
+  echo "<path-to-hab-binary> must be specified!"
   exit 1
 else
   HAB_BINARY="$1"

--- a/test/end-to-end/test_hab_help_doesnt_install_hab_sup.sh
+++ b/test/end-to-end/test_hab_help_doesnt_install_hab_sup.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# A simple test assertion that running `hab sup --help` will not
+# attempt to install `core/hab-sup` if that pkg is not present.
+
+set -ou pipefail
+
+export TESTING_FS_ROOT
+TESTING_FS_ROOT=$(mktemp -d)
+export HAB_SUP_BINARY
+HAB_SUP_BINARY=''
+
+print_help() {
+  program=$(basename "$0")
+  echo "$program
+
+Test \`hab sup --help\` will not install core/hab-sup.
+
+USAGE:
+  $program <path-to-hab-binary>
+
+ARGS:
+  <path-to-hab-binary>  The name or path of the hab binary under test (eg: './target/debug/hab' or
+simply 'hab'). In the latter case when just passing the binary name, the shell will search in \$PATH.
+"
+}
+
+if [[ $# -eq 0 ]] ; then
+  print_help
+  echo
+  echo "<path-to-hab-binary> must be specified"
+  exit 1
+else
+  HAB_BINARY="$1"
+fi
+
+echo "Running \`$HAB_BINARY sup --help\` - which should NOT attempt an install of core/hab-sup"
+
+if [ -z "$($HAB_BINARY sup --help)" ]; then
+  echo
+  echo "ERROR: $HAB_BINARY was not the proper executable hab binary!"
+  exit 1
+elif [ -d "$TESTING_FS_ROOT/hab/pkgs/core/hab-sup" ]; then
+  echo
+  echo "ERROR: detected an installation of core/hab-sup"
+  exit 1
+fi
+
+echo "Success!"


### PR DESCRIPTION
Resolves https://github.com/habitat-sh/habitat/issues/5343

This PR introduces the following changes:

- Taking advantage of the one-way dependency of `hab-sup` on `hab`; we
 delcare the Supervisor clap commands in _one_ place, within the `hab`
 package. This keeps us DRY and allows for the next change below.
- All help commands for `hab sup` no longer will be routed to `hab-sup`
 but are handled by clap-rs within the `hab` package. This removes the odd behavior
 that has always existed where running any variation of `hab sup --help`
 would attempt to install `core/hab-sup` if not found; often requiring
 elevated or admin privileges.

The desired behavior can be tested manually:
1. remove any installation of `core/hab-sup`
2. compile then remove `./target/debug/hab-sup`
3. run `HAB_SUP_BINARY= ./target/debug/hab sup --help` or any help variation thereof under sup subcommand(s)
4. observe the help menu displayed without any of the previous messages like
```
∵ Missing package for core/hab-sup/0.65.0
» Installing core/hab-sup/0.65.0
☁ Determining latest version of core/hab-sup/0.65.0 in the 'stable' channel
...
```
Are there any ideas how we can build a test for this? I would be happy to write some tests. 

Signed-off-by: Jeremy J. Miller <jm@chef.io>