### PR TITLE
Clean up a variety of leaks

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,6 +26,7 @@ environment:
   CARGO_TARGET_DIR: "c:\\projects\\habitat\\target"
   RUSTUP_USE_HYPER: 1
   CARGO_HTTP_CHECK_REVOKE: false
+  RUST_BACKTRACE: 1
   HAB_WINDOWS_STUDIO: true
   BINTRAY_USER: chef-releng-ops
   BINTRAY_KEY:

--- a/components/sup/src/http_gateway.rs
+++ b/components/sup/src/http_gateway.rs
@@ -161,7 +161,8 @@ impl Server {
             let bind = server::new(move || {
                 let app_state = AppState::new(gateway_state.clone());
                 App::with_state(app_state).configure(routes)
-            }).bind(listen_addr.to_string());
+            }).workers(2)
+            .bind(listen_addr.to_string());
 
             // We need to create this scope on purpose here because if we don't, the lock never
             // releases, and the supervisor will wait forever on cvar. Creating this artifical

--- a/components/sup/src/manager/file_watcher.rs
+++ b/components/sup/src/manager/file_watcher.rs
@@ -1354,7 +1354,7 @@ impl<C: Callbacks, W: Watcher> FileWatcher<C, W> {
         match self.rx.try_recv() {
             Ok(e) => self.handle_event(e),
             Err(TryRecvError::Empty) => Ok(()),
-            Err(e) => Err(sup_error!(Error::TryRecvError(e))),
+            Err(e) => Err(e.into()),
         }
     }
 

--- a/components/sup/src/manager/file_watcher.rs
+++ b/components/sup/src/manager/file_watcher.rs
@@ -3184,6 +3184,11 @@ mod tests {
 
         fn spin_watcher(&self, setup: &mut WatcherSetup, iterations: u32) {
             let mut iteration = 0;
+
+            // After switching single_iteration() from recv() to try_recv(), this sleep is required
+            // for these tests to pass.
+            ::std::thread::sleep(Duration::from_secs(3));
+
             while iteration < iterations {
                 setup.watcher.single_iteration().expect(&format!(
                     "iteration failed, debug info:\n{}",

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -1549,15 +1549,19 @@ impl Manager {
             ShutdownReason::LauncherStopping | ShutdownReason::SvcStopCmd => true,
             _ => false,
         };
+
         if term {
             service.stop(&self.launcher, cause);
         }
+
         if let Err(_) = self.user_config_watcher.remove(service) {
             debug!(
                 "Error stopping user-config watcher thread for service {}",
                 service
             );
         }
+
+        self.updater.remove(service);
     }
 
     /// Check if any elections need restarting.

--- a/components/sup/src/manager/service_updater.rs
+++ b/components/sup/src/manager/service_updater.rs
@@ -460,7 +460,7 @@ impl Worker {
                 }
                 Err(TryRecvError::Empty) => {}
                 Err(TryRecvError::Disconnected) => {
-                    info!("Service updater has gone away, yikes!");
+                    error!("Service updater has gone away, yikes!");
                     break;
                 }
             }
@@ -500,7 +500,7 @@ impl Worker {
                 }
                 Err(TryRecvError::Empty) => {}
                 Err(TryRecvError::Disconnected) => {
-                    info!("Service updater has gone away, yikes!");
+                    error!("Service updater has gone away, yikes!");
                     break;
                 }
             }

--- a/components/sup/src/manager/service_updater.rs
+++ b/components/sup/src/manager/service_updater.rs
@@ -450,7 +450,7 @@ impl Worker {
         // scenario, where `ident` is always a fully-qualified identifier
         outputln!("Updating from {} to {}", self.current, ident);
         let install_source = (ident, *PackageTarget::active_target()).into();
-        let mut next_time = None::<SteadyTime>;
+        let mut next_time = SteadyTime::now();
 
         loop {
             match kill_rx.try_recv() {
@@ -465,7 +465,7 @@ impl Worker {
                 }
             }
 
-            if next_time.is_none() || SteadyTime::now() >= next_time.unwrap() {
+            if SteadyTime::now() >= next_time {
                 match util::pkg::install(
                     // We don't want anything in here to print
                     &mut UI::with_sinks(),
@@ -481,7 +481,7 @@ impl Worker {
                     Err(e) => warn!("Failed to install updated package: {:?}", e),
                 }
 
-                next_time = Some(self.next_period_start());
+                next_time = self.next_period_start();
             }
         }
     }
@@ -490,7 +490,7 @@ impl Worker {
     /// when found.
     fn run_poll(&mut self, sender: Sender<PackageInstall>, kill_rx: Receiver<()>) {
         let install_source = (self.spec_ident.clone(), *PackageTarget::active_target()).into();
-        let mut next_time = None::<SteadyTime>;
+        let mut next_time = SteadyTime::now();
 
         loop {
             match kill_rx.try_recv() {
@@ -505,7 +505,7 @@ impl Worker {
                 }
             }
 
-            if next_time.is_none() || SteadyTime::now() >= next_time.unwrap() {
+            if SteadyTime::now() >= next_time {
                 match util::pkg::install(
                     // We don't want anything in here to print
                     &mut UI::with_sinks(),
@@ -532,7 +532,7 @@ impl Worker {
                     Err(e) => warn!("Updater failed to get latest package: {:?}", e),
                 }
 
-                next_time = Some(self.next_period_start());
+                next_time = self.next_period_start();
             }
         }
     }

--- a/components/sup/src/manager/service_updater.rs
+++ b/components/sup/src/manager/service_updater.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use std::collections::HashMap;
-use std::sync::mpsc::{sync_channel, Receiver, SyncSender, TryRecvError};
+use std::sync::mpsc::{channel, Receiver, Sender, TryRecvError};
 use std::thread;
 
 use butterfly;
@@ -26,6 +26,7 @@ use launcher_client::LauncherCli;
 use census::CensusRing;
 use manager::periodic::Periodic;
 use manager::service::{Service, Topology, UpdateStrategy};
+use time::SteadyTime;
 use util;
 
 static LOGKEY: &'static str = "SU";
@@ -37,7 +38,7 @@ const DEFAULT_FREQUENCY: i64 = MIN_ALLOWED_FREQUENCY;
 type UpdaterStateList = HashMap<ServiceGroup, UpdaterState>;
 
 enum UpdaterState {
-    AtOnce(Receiver<PackageInstall>),
+    AtOnce(Receiver<PackageInstall>, Sender<bool>),
     Rolling(RollingState),
 }
 
@@ -49,7 +50,7 @@ enum RollingState {
 }
 
 enum LeaderState {
-    Polling(Receiver<PackageInstall>),
+    Polling(Receiver<PackageInstall>, Sender<bool>),
     Waiting,
 }
 
@@ -59,7 +60,7 @@ enum FollowerState {
     /// Waiting to be told to update
     Waiting,
     /// Currently updating
-    Updating(Receiver<PackageInstall>),
+    Updating(Receiver<PackageInstall>, Sender<bool>),
 }
 
 /// The ServiceUpdater is in charge of updating a Service when a more recent version of a package
@@ -88,8 +89,9 @@ impl ServiceUpdater {
                 self.states
                     .entry(service.service_group.clone())
                     .or_insert_with(|| {
-                        let rx = Worker::new(service).start(&service.service_group, None);
-                        UpdaterState::AtOnce(rx)
+                        let (kill_tx, kill_rx) = channel();
+                        let rx = Worker::new(service).start(&service.service_group, None, kill_rx);
+                        UpdaterState::AtOnce(rx, kill_tx)
                     });
                 true
             }
@@ -102,8 +104,46 @@ impl ServiceUpdater {
         }
     }
 
-    // TODO (CM): How do we remove something from the updater? e.g.,
-    // when we stop or unload a service?
+    /// Remove a `Service` from updates, e.g. if the service was unloaded.
+    pub fn remove(&mut self, service: &Service) {
+        let updater_state = self.states.remove(&service.service_group);
+
+        if updater_state.is_none() {
+            warn!(
+                "Tried to remove {} from the ServiceUpdater, but it wasn't found.",
+                service
+            );
+            return;
+        }
+
+        match updater_state {
+            Some(UpdaterState::AtOnce(_rx, kill_tx)) => {
+                if kill_tx.send(true).is_err() {
+                    debug!("Tried to kill the updater thread but it's already dead.");
+                }
+            }
+            Some(UpdaterState::Rolling(rs)) => match rs {
+                RollingState::Leader(ls) => match ls {
+                    LeaderState::Polling(_rx, kill_tx) => {
+                        if kill_tx.send(true).is_err() {
+                            debug!("Tried to kill the updater thread but it's already dead.");
+                        }
+                    }
+                    LeaderState::Waiting => {}
+                },
+                RollingState::Follower(fs) => match fs {
+                    FollowerState::Updating(_rx, kill_tx) => {
+                        if kill_tx.send(true).is_err() {
+                            debug!("Tried to kill the updater thread but it's already dead.");
+                        }
+                    }
+                    FollowerState::Waiting => {}
+                },
+                _ => {}
+            },
+            None => {}
+        }
+    }
 
     /// See if the given service has an update. Returns `true` if a
     /// new version was installed, thus signalling that the service
@@ -116,7 +156,7 @@ impl ServiceUpdater {
     ) -> bool {
         let mut updated = false;
         match self.states.get_mut(&service.service_group) {
-            Some(&mut UpdaterState::AtOnce(ref mut rx)) => match rx.try_recv() {
+            Some(&mut UpdaterState::AtOnce(ref mut rx, ref mut kill_tx)) => match rx.try_recv() {
                 Ok(package) => {
                     service.update_package(package, launcher);
                     return true;
@@ -124,7 +164,9 @@ impl ServiceUpdater {
                 Err(TryRecvError::Empty) => return false,
                 Err(TryRecvError::Disconnected) => {
                     debug!("Service Updater worker has died; restarting...");
-                    *rx = Worker::new(service).start(&service.service_group, None);
+                    let (ktx, krx) = channel();
+                    *rx = Worker::new(service).start(&service.service_group, None, krx);
+                    *kill_tx = ktx;
                 }
             },
 
@@ -180,7 +222,7 @@ impl ServiceUpdater {
             }
             Some(&mut UpdaterState::Rolling(RollingState::Leader(ref mut state))) => {
                 match *state {
-                    LeaderState::Polling(ref mut rx) => match rx.try_recv() {
+                    LeaderState::Polling(ref mut rx, ref mut kill_tx) => match rx.try_recv() {
                         Ok(package) => {
                             debug!("Rolling Update, polling found a new package");
                             service.update_package(package, launcher);
@@ -189,28 +231,32 @@ impl ServiceUpdater {
                         Err(TryRecvError::Empty) => return false,
                         Err(TryRecvError::Disconnected) => {
                             debug!("Service Updater worker has died; restarting...");
-                            *rx = Worker::new(service).start(&service.service_group, None);
+                            let (ktx, krx) = channel();
+                            *rx = Worker::new(service).start(&service.service_group, None, krx);
+                            *kill_tx = ktx;
                         }
                     },
-                    LeaderState::Waiting => {
-                        match census_ring.census_group_for(&service.service_group) {
-                            Some(census_group) => {
-                                if census_group.members().iter().any(|cm| {
-                                    cm.pkg.as_ref().unwrap()
-                                        != census_group.me().unwrap().pkg.as_ref().unwrap()
-                                }) {
-                                    debug!("Update leader still waiting for followers...");
-                                    return false;
-                                }
-                                let rx = Worker::new(service).start(&service.service_group, None);
-                                *state = LeaderState::Polling(rx);
+                    LeaderState::Waiting => match census_ring
+                        .census_group_for(&service.service_group)
+                    {
+                        Some(census_group) => {
+                            if census_group.members().iter().any(|cm| {
+                                cm.pkg.as_ref().unwrap()
+                                    != census_group.me().unwrap().pkg.as_ref().unwrap()
+                            }) {
+                                debug!("Update leader still waiting for followers...");
+                                return false;
                             }
-                            None => panic!(
-                                "Expected census list to have service group '{}'!",
-                                &*service.service_group
-                            ),
+                            let (kill_tx, kill_rx) = channel();
+                            let rx =
+                                Worker::new(service).start(&service.service_group, None, kill_rx);
+                            *state = LeaderState::Polling(rx, kill_tx);
                         }
-                    }
+                        None => panic!(
+                            "Expected census list to have service group '{}'!",
+                            &*service.service_group
+                        ),
+                    },
                 }
                 if updated {
                     *state = LeaderState::Waiting;
@@ -235,9 +281,13 @@ impl ServiceUpdater {
                                         return false;
                                     }
                                     debug!("We're in an update and it's our turn");
-                                    let rx = Worker::new(service)
-                                        .start(&service.service_group, leader.pkg.clone());
-                                    *state = FollowerState::Updating(rx);
+                                    let (kill_tx, kill_rx) = channel();
+                                    let rx = Worker::new(service).start(
+                                        &service.service_group,
+                                        leader.pkg.clone(),
+                                        kill_rx,
+                                    );
+                                    *state = FollowerState::Updating(rx, kill_tx);
                                 }
                                 _ => return false,
                             },
@@ -247,26 +297,32 @@ impl ServiceUpdater {
                             ),
                         }
                     }
-                    FollowerState::Updating(ref mut rx) => match census_ring
-                        .census_group_for(&service.service_group)
-                    {
-                        Some(census_group) => match rx.try_recv() {
-                            Ok(package) => {
-                                service.update_package(package, launcher);
-                                updated = true
-                            }
-                            Err(TryRecvError::Empty) => return false,
-                            Err(TryRecvError::Disconnected) => {
-                                debug!("Service Updater worker has died; restarting...");
-                                let package = census_group.update_leader().unwrap().pkg.clone();
-                                *rx = Worker::new(service).start(&service.service_group, package);
-                            }
-                        },
-                        None => panic!(
-                            "Expected census list to have service group '{}'!",
-                            &*service.service_group
-                        ),
-                    },
+                    FollowerState::Updating(ref mut rx, ref mut kill_tx) => {
+                        match census_ring.census_group_for(&service.service_group) {
+                            Some(census_group) => match rx.try_recv() {
+                                Ok(package) => {
+                                    service.update_package(package, launcher);
+                                    updated = true
+                                }
+                                Err(TryRecvError::Empty) => return false,
+                                Err(TryRecvError::Disconnected) => {
+                                    debug!("Service Updater worker has died; restarting...");
+                                    let package = census_group.update_leader().unwrap().pkg.clone();
+                                    let (ktx, krx) = channel();
+                                    *rx = Worker::new(service).start(
+                                        &service.service_group,
+                                        package,
+                                        krx,
+                                    );
+                                    *kill_tx = ktx;
+                                }
+                            },
+                            None => panic!(
+                                "Expected census list to have service group '{}'!",
+                                &*service.service_group
+                            ),
+                        }
+                    }
                 }
                 if updated {
                     *state = FollowerState::Waiting;
@@ -350,13 +406,18 @@ impl Worker {
     /// Passing an optional package identifier will make the worker perform a run-once update to
     /// retrieve a specific version from Builder. If no package identifier is specified,
     /// then the updater will poll until a newer more suitable package is found.
-    fn start(mut self, sg: &ServiceGroup, ident: Option<PackageIdent>) -> Receiver<PackageInstall> {
-        let (tx, rx) = sync_channel(0);
+    fn start(
+        mut self,
+        sg: &ServiceGroup,
+        ident: Option<PackageIdent>,
+        kill_rx: Receiver<bool>,
+    ) -> Receiver<PackageInstall> {
+        let (tx, rx) = channel();
         thread::Builder::new()
             .name(format!("service-updater-{}", sg))
             .spawn(move || match ident {
-                Some(latest) => self.run_once(tx, latest),
-                None => self.run_poll(tx),
+                Some(latest) => self.run_once(tx, latest, kill_rx),
+                None => self.run_poll(tx, kill_rx),
             }).expect("unable to start service-updater thread");
         rx
     }
@@ -384,67 +445,100 @@ impl Worker {
     /// Polls until a newer version of the specified package is
     /// available. When such a package is found, it is installed, and
     /// the function exits.
-    fn run_once(&mut self, sender: SyncSender<PackageInstall>, ident: PackageIdent) {
+    fn run_once(
+        &mut self,
+        sender: Sender<PackageInstall>,
+        ident: PackageIdent,
+        kill_rx: Receiver<bool>,
+    ) {
         // Fairly certain that this only gets called in a rolling update
         // scenario, where `ident` is always a fully-qualified identifier
         outputln!("Updating from {} to {}", self.current, ident);
         let install_source = (ident, *PackageTarget::active_target()).into();
-        loop {
-            let next_time = self.next_period_start();
+        let mut next_time = None::<SteadyTime>;
 
-            match util::pkg::install(
-                // We don't want anything in here to print
-                &mut UI::with_sinks(),
-                &self.builder_url,
-                &install_source,
-                &self.channel,
-            ) {
-                Ok(package) => {
-                    self.current = package.ident().clone();
-                    sender.send(package).expect("Main thread has gone away!");
+        loop {
+            match kill_rx.try_recv() {
+                Ok(_) => {
+                    info!("Received some data on the kill channel. Letting this thread die.");
                     break;
                 }
-                Err(e) => warn!("Failed to install updated package: {:?}", e),
+                Err(TryRecvError::Empty) => {}
+                Err(TryRecvError::Disconnected) => {
+                    info!("Service updater has gone away, yikes!");
+                    break;
+                }
             }
 
-            self.sleep_until(next_time);
+            if next_time.is_none() || SteadyTime::now() >= next_time.unwrap() {
+                match util::pkg::install(
+                    // We don't want anything in here to print
+                    &mut UI::with_sinks(),
+                    &self.builder_url,
+                    &install_source,
+                    &self.channel,
+                ) {
+                    Ok(package) => {
+                        self.current = package.ident().clone();
+                        sender.send(package).expect("Main thread has gone away!");
+                        break;
+                    }
+                    Err(e) => warn!("Failed to install updated package: {:?}", e),
+                }
+
+                next_time = Some(self.next_period_start());
+            }
         }
     }
 
     /// Continually poll for a new version of a package, installing it
     /// when found.
-    fn run_poll(&mut self, sender: SyncSender<PackageInstall>) {
+    fn run_poll(&mut self, sender: Sender<PackageInstall>, kill_rx: Receiver<bool>) {
         let install_source = (self.spec_ident.clone(), *PackageTarget::active_target()).into();
-        loop {
-            let next_time = self.next_period_start();
+        let mut next_time = None::<SteadyTime>;
 
-            match util::pkg::install(
-                // We don't want anything in here to print
-                &mut UI::with_sinks(),
-                &self.builder_url,
-                &install_source,
-                &self.channel,
-            ) {
-                Ok(maybe_newer_package) => {
-                    if self.current < *maybe_newer_package.ident() {
-                        outputln!(
-                            "Updating from {} to {}",
-                            self.current,
-                            maybe_newer_package.ident()
-                        );
-                        self.current = maybe_newer_package.ident().clone();
-                        sender
-                            .send(maybe_newer_package)
-                            .expect("Main thread has gone away!");
-                        break;
-                    } else {
-                        debug!("Package found is not newer than ours");
-                    }
+        loop {
+            match kill_rx.try_recv() {
+                Ok(_) => {
+                    info!("Received some data on the kill channel. Letting this thread die.");
+                    break;
                 }
-                Err(e) => warn!("Updater failed to get latest package: {:?}", e),
+                Err(TryRecvError::Empty) => {}
+                Err(TryRecvError::Disconnected) => {
+                    info!("Service updater has gone away, yikes!");
+                    break;
+                }
             }
 
-            self.sleep_until(next_time);
+            if next_time.is_none() || SteadyTime::now() >= next_time.unwrap() {
+                match util::pkg::install(
+                    // We don't want anything in here to print
+                    &mut UI::with_sinks(),
+                    &self.builder_url,
+                    &install_source,
+                    &self.channel,
+                ) {
+                    Ok(maybe_newer_package) => {
+                        if self.current < *maybe_newer_package.ident() {
+                            outputln!(
+                                "Updating from {} to {}",
+                                self.current,
+                                maybe_newer_package.ident()
+                            );
+                            self.current = maybe_newer_package.ident().clone();
+                            sender
+                                .send(maybe_newer_package)
+                                .expect("Main thread has gone away!");
+                            break;
+                        } else {
+                            debug!("Package found is not newer than ours");
+                        }
+                    }
+                    Err(e) => warn!("Updater failed to get latest package: {:?}", e),
+                }
+
+                next_time = Some(self.next_period_start());
+            }
         }
     }
 }

--- a/components/sup/src/manager/service_updater.rs
+++ b/components/sup/src/manager/service_updater.rs
@@ -106,17 +106,7 @@ impl ServiceUpdater {
 
     /// Remove a `Service` from updates, e.g. if the service was unloaded.
     pub fn remove(&mut self, service: &Service) {
-        let updater_state = self.states.remove(&service.service_group);
-
-        if updater_state.is_none() {
-            warn!(
-                "Tried to remove {} from the ServiceUpdater, but it wasn't found.",
-                service
-            );
-            return;
-        }
-
-        match updater_state {
+        match self.states.remove(&service.service_group) {
             Some(UpdaterState::AtOnce(_rx, kill_tx)) => {
                 if kill_tx.send(()).is_err() {
                     debug!("Tried to kill the updater thread but it's already dead.");
@@ -141,7 +131,12 @@ impl ServiceUpdater {
                 },
                 _ => {}
             },
-            None => {}
+            None => {
+                warn!(
+                    "Tried to remove {} from the ServiceUpdater, but it wasn't found.",
+                    service
+                );
+            }
         }
     }
 

--- a/components/sup/src/manager/user_config_watcher.rs
+++ b/components/sup/src/manager/user_config_watcher.rs
@@ -329,17 +329,26 @@ mod tests {
 
     fn wait_for_watcher<T: Serviceable>(ucm: &UserConfigWatcher, service: &T) -> bool {
         let start = Instant::now();
-        let timeout = Duration::from_millis(1000);
+        let timeout = Duration::from_secs(10);
 
         while start.elapsed() < timeout {
             let state = ucm.states.get(service.name()).expect("service added");
             match state.started_watching.try_recv() {
-                Ok(_) => return true,
-                Err(TryRecvError::Empty) => (),
-                Err(TryRecvError::Disconnected) => return false,
+                Ok(_) => {
+                    println!("Received data on the start_watching channel. Returning true.");
+                    return true;
+                }
+                Err(TryRecvError::Empty) => {
+                    println!("Received nothing on the start_watching channel. Returning ().");
+                    ()
+                }
+                Err(TryRecvError::Disconnected) => {
+                    println!("The start_watching channel was disconnected. Returning false.");
+                    return false;
+                }
             }
 
-            thread::sleep(Duration::from_millis(10));
+            thread::sleep(Duration::from_millis(100));
         }
 
         false
@@ -354,7 +363,7 @@ mod tests {
                 return true;
             }
 
-            thread::sleep(Duration::from_millis(10));
+            thread::sleep(Duration::from_millis(100));
         }
 
         false

--- a/support/ci/appveyor.bat
+++ b/support/ci/appveyor.bat
@@ -1,1 +1,1 @@
-powershell -nologo -noprofile -executionpolicy bypass -file c:\projects\habitat\support\ci\appveyor.ps1 
+powershell -nologo -noprofile -executionpolicy bypass -file c:\projects\habitat\support\ci\appveyor.ps1

--- a/support/ci/appveyor.ps1
+++ b/support/ci/appveyor.ps1
@@ -45,7 +45,7 @@ function Test-SourceChanged {
 }
 
 function Test-DocsOnlyChanged {
-    (Get-ChangedFiles | 
+    (Get-ChangedFiles |
         Where-Object {
             !($_ -like '*.md') -and !($_ -like 'docs\*.md')
         }
@@ -89,7 +89,7 @@ if(Test-DocsOnlyChanged -and !(Test-ReleaseBuild)) {
                 pushd "$(Get-RepoRoot)/components/$component"
                 Write-Host "Testing $component"
                 Write-Host ""
-                cargo test --verbose
+                cargo test --verbose -- --nocapture
                 if ($LASTEXITCODE -ne 0) {exit $LASTEXITCODE}
                 popd
             }


### PR DESCRIPTION
The aim of this PR is to plug as many of the thread/file descriptor/pipe leaks as we reasonably can, and generally reduce thread usage if possible.

The number of HTTP gateway threads has been capped at 2. I could be way off base here, but the supervisor's HTTP gateway doesn't seem like a high traffic server. The default number of threads for the HTTP gateway is equal to the number of logical CPU cores for the machine it's running on. I capped it at 2, thinking that given its low usage, that's probably enough.

The thread that watches user.toml for changes now uses `try_recv` instead of `recv`, meaning that 2 out of the 3 threads now shutdown properly when a service is unloaded, without needing any extra shenanigans regarding `touch`ing files.

The final thread is part of the `DebouncedEvent` API of the notify crate. After much discussion, investigation, wringing of hands and gnashing of teeth, it was decided that converting the [file watcher](https://github.com/habitat-sh/habitat/blob/master/components/sup/src/manager/file_watcher.rs) abstraction and all of its associated files to use the `RawEvent` API of the notify crate was too much of an investment to make at this time. Therefore, we're still leaking 1 thread for watching user.toml files. From the sound of various issues on the notify crate's repo, the author is preparing a new release that should theoretically solve a lot of the threading and performance issues with the current `DebouncedEvent` API.

Finally, the service updater thread now dies correctly when a service is removed via `hab svc unload`.

All in all, while this doesn't solve the problem 100%, it's a dramatic improvement over the current state of affairs. I will open an issue to track the final thread leak.

Closes https://github.com/habitat-sh/habitat/issues/5416

![](https://media.giphy.com/media/xT5LMXBrV5NkVZHKms/giphy.gif)