### PR TITLE
fix a compile warning on windows

### DIFF
--- a/components/common/src/command/package/install.rs
+++ b/components/common/src/command/package/install.rs
@@ -740,8 +740,9 @@ impl<'a> InstallTask<'a> {
                 let temp_install_path = &pkg_install_path(ident, Some(temp_dir.path()));
                 artifact.unpack(Some(temp_dir.path()))?;
                 fs::rename(temp_install_path, real_install_path)?;
-                #[cfg(unix)]
-                fs::File::open(real_install_base).and_then(|f| f.sync_all())?;
+                if cfg!(unix) {
+                    fs::File::open(real_install_base).and_then(|f| f.sync_all())?;
+                }
                 ui.status(Status::Installed, ident)?;
                 Ok(())
             }


### PR DESCRIPTION
This just does away with a compiler warning on windows complaining that `real_install_base` was not used because the line using it only compiles on unix. So this switches from the `ifdef` style check to a runtime check.

Signed-off-by: mwrock <matt@mattwrock.com>