### PR TITLE
Makes hooks file names consistent regarding _ or -

### DIFF
--- a/components/sup/src/manager/service/hooks.rs
+++ b/components/sup/src/manager/service/hooks.rs
@@ -66,30 +66,60 @@ pub trait Hook: fmt::Debug + Sized {
 
     fn file_name() -> &'static str;
 
+    /// Tries to load a hook if a (deprecated) hook file exists.
+    ///
+    /// Returns the hook if template file (deprecated or not) is found
     fn load<C, T>(service_group: &ServiceGroup, concrete_path: C, template_path: T) -> Option<Self>
     where
         C: AsRef<Path>,
         T: AsRef<Path>,
     {
-        let concrete = concrete_path.as_ref().join(Self::file_name());
-        let template = template_path.as_ref().join(Self::file_name());
-        match std::fs::metadata(&template) {
-            Ok(_) => {
-                let pair = match RenderPair::new(concrete, &template) {
-                    Ok(pair) => pair,
-                    Err(err) => {
-                        outputln!(preamble service_group, "Failed to load hook: {}", err);
-                        return None;
-                    }
-                };
-                Some(Self::new(service_group, pair))
-            }
-            Err(_) => {
-                debug!(
-                    "{} not found at {}, not loading",
-                    Self::file_name(),
-                    template.display()
+        let file_name = Self::file_name();
+        let deprecated_file_name = if Self::file_name().contains("-") {
+            Some(Self::file_name().replace("-", "_"))
+        } else {
+            None
+        };
+
+        let concrete = concrete_path.as_ref().join(&file_name);
+        let template = template_path.as_ref().join(&file_name);
+        let deprecated_template = deprecated_file_name
+            .as_ref()
+            .map(|n| template_path.as_ref().join(n));
+
+        let has_template = template.exists();
+        let has_deprecated_template = deprecated_template.as_ref().map_or(false, |t| t.exists());
+
+        let template_to_use = if has_template {
+            if has_deprecated_template {
+                outputln!(preamble service_group,
+                    "Deprecated hook file detected along with expected one. \
+                     You should remove {} and keep only {}.",
+                    deprecated_file_name.unwrap(),
+                    &file_name
                 );
+            }
+            template
+        } else if has_deprecated_template {
+            outputln!(preamble service_group,
+                "Deprecated hook file detected: {}. You should use {} instead.",
+                deprecated_file_name.unwrap(),
+                &file_name
+            );
+            deprecated_template.unwrap()
+        } else {
+            debug!(
+                "{} not found at {}, not loading",
+                &file_name,
+                template.display()
+            );
+            return None;
+        };
+
+        match RenderPair::new(concrete, &template_to_use, Self::file_name()) {
+            Ok(pair) => Some(Self::new(service_group, pair)),
+            Err(err) => {
+                outputln!(preamble service_group, "Failed to load hook: {}", err);
                 None
             }
         }
@@ -102,17 +132,19 @@ pub trait Hook: fmt::Debug + Sized {
     /// Returns `true` if the hook has changed.
     fn compile(&self, service_group: &ServiceGroup, ctx: &RenderContext) -> Result<bool> {
         let content = self.renderer().render(Self::file_name(), ctx)?;
-        if write_hook(&content, self.path())? {
+        // We make sure we don't use a deprecated file name
+        let path = self.path().with_file_name(Self::file_name());
+        if write_hook(&content, &path)? {
             outputln!(preamble service_group,
                       "Modified hook content in {}",
-                      self.path().display());
-            Self::set_permissions(self.path())?;
+                      &path.display());
+            Self::set_permissions(&path)?;
             Ok(true)
         } else {
             debug!(
                 "{}, already compiled to {}",
                 Self::file_name(),
-                self.path().display()
+                &path.display()
             );
             Ok(false)
         }
@@ -189,7 +221,7 @@ impl Hook for FileUpdatedHook {
     type ExitValue = bool;
 
     fn file_name() -> &'static str {
-        "file_updated"
+        "file-updated"
     }
 
     fn new(service_group: &ServiceGroup, pair: RenderPair) -> Self {
@@ -237,7 +269,7 @@ impl Hook for HealthCheckHook {
     type ExitValue = health::HealthCheck;
 
     fn file_name() -> &'static str {
-        "health_check"
+        "health-check"
     }
 
     fn new(service_group: &ServiceGroup, pair: RenderPair) -> Self {
@@ -595,7 +627,7 @@ impl Hook for SmokeTestHook {
     type ExitValue = health::SmokeCheck;
 
     fn file_name() -> &'static str {
-        "smoke_test"
+        "smoke-test"
     }
 
     fn new(service_group: &ServiceGroup, pair: RenderPair) -> Self {
@@ -923,18 +955,12 @@ pub struct RenderPair {
 }
 
 impl RenderPair {
-    pub fn new<C, T>(concrete_path: C, template_path: T) -> Result<Self>
+    pub fn new<C, T>(concrete_path: C, template_path: T, name: &'static str) -> Result<Self>
     where
         C: Into<PathBuf>,
         T: AsRef<Path>,
     {
         let mut renderer = TemplateRenderer::new();
-        let name = template_path
-            .as_ref()
-            .file_name()
-            .unwrap()
-            .to_string_lossy()
-            .into_owned();
         renderer.register_template_file(&name, template_path.as_ref())?;
         Ok(RenderPair {
             path: concrete_path.into(),

--- a/components/sup/tests/compilation.rs
+++ b/components/sup/tests/compilation.rs
@@ -97,13 +97,13 @@ fn hook_only_packages_restart_on_config_application() {
     utils::sleep_seconds(3);
 
     let pid_before_apply = hab_root.pid_of(package_name);
-    let hook_before_apply = hab_root.compiled_hook_contents(&package_name, "health_check");
+    let hook_before_apply = hab_root.compiled_hook_contents(&package_name, "health-check");
 
     test_sup.apply_config(r#"hook_value = "something new and different""#);
     utils::sleep_seconds(2);
 
     let pid_after_apply = hab_root.pid_of(package_name);
-    let hook_after_apply = hab_root.compiled_hook_contents(&package_name, "health_check");
+    let hook_after_apply = hab_root.compiled_hook_contents(&package_name, "health-check");
 
     assert_ne!(hook_before_apply, hook_after_apply);
     assert_ne!(pid_before_apply, pid_after_apply);
@@ -136,7 +136,7 @@ fn config_files_change_but_hooks_do_not_still_restarts() {
     utils::sleep_seconds(3);
 
     let pid_before_apply = hab_root.pid_of(package_name);
-    let hook_before_apply = hab_root.compiled_hook_contents(&package_name, "health_check");
+    let hook_before_apply = hab_root.compiled_hook_contents(&package_name, "health-check");
     let config_before_apply = hab_root.compiled_config_contents(&package_name, "config.toml");
 
     test_sup.apply_config(
@@ -148,7 +148,7 @@ hook_value = "default"
     utils::sleep_seconds(2);
 
     let pid_after_apply = hab_root.pid_of(package_name);
-    let hook_after_apply = hab_root.compiled_hook_contents(&package_name, "health_check");
+    let hook_after_apply = hab_root.compiled_hook_contents(&package_name, "health-check");
     let config_after_apply = hab_root.compiled_config_contents(&package_name, "config.toml");
 
     assert_ne!(config_before_apply, config_after_apply);
@@ -183,7 +183,7 @@ fn hooks_change_but_config_files_do_not_still_restarts() {
     utils::sleep_seconds(3);
 
     let pid_before_apply = hab_root.pid_of(package_name);
-    let hook_before_apply = hab_root.compiled_hook_contents(&package_name, "health_check");
+    let hook_before_apply = hab_root.compiled_hook_contents(&package_name, "health-check");
     let config_before_apply = hab_root.compiled_config_contents(&package_name, "config.toml");
 
     test_sup.apply_config(
@@ -195,7 +195,7 @@ hook_value = "applied"
     utils::sleep_seconds(2);
 
     let pid_after_apply = hab_root.pid_of(package_name);
-    let hook_after_apply = hab_root.compiled_hook_contents(&package_name, "health_check");
+    let hook_after_apply = hab_root.compiled_hook_contents(&package_name, "health-check");
     let config_after_apply = hab_root.compiled_config_contents(&package_name, "config.toml");
 
     assert_eq!(config_before_apply, config_after_apply);
@@ -232,7 +232,7 @@ fn applying_identical_configuration_results_in_no_changes_and_no_restart() {
     utils::sleep_seconds(3);
 
     let pid_before_apply = hab_root.pid_of(package_name);
-    let hook_before_apply = hab_root.compiled_hook_contents(&package_name, "health_check");
+    let hook_before_apply = hab_root.compiled_hook_contents(&package_name, "health-check");
     let config_before_apply = hab_root.compiled_config_contents(&package_name, "config.toml");
 
     test_sup.apply_config(
@@ -244,7 +244,7 @@ hook_value = "default"
     utils::sleep_seconds(2);
 
     let pid_after_apply = hab_root.pid_of(package_name);
-    let hook_after_apply = hab_root.compiled_hook_contents(&package_name, "health_check");
+    let hook_after_apply = hab_root.compiled_hook_contents(&package_name, "health-check");
     let config_after_apply = hab_root.compiled_config_contents(&package_name, "config.toml");
 
     assert_eq!(config_before_apply, config_after_apply);


### PR DESCRIPTION
> Closes #4986

This is a first implementation. It's not been tested yet. Thus the WIP flag on the PR.

I'm creating the PR sooner rather than later to get feedback :) Still quite new to rust, even if I start to get used to it.

There's a thing that bothers me, about having to recompute this: 

```rust
// this:
let deprecated_template =
            Self::deprecated_file_name().map(|file_name| template_path.as_ref().join(file_name));

        let has_template = std::fs::metadata(&template).is_ok();
// deprecated_template is moved here with `and_then` call.
        let has_deprecated_template = deprecated_template
            .and_then(|t| std::fs::metadata(&t).ok())
            .is_some();

        let template_to_use = if has_deprecated_template && !has_template {
            warn!(
                "Deprecated hook file detected: {}. You should use {} instead.",
                Self::deprecated_file_name().unwrap(),
                Self::file_name()
            );
// HERE is the duplicate:
            Self::deprecated_file_name().map(|file_name| template_path.as_ref().join(file_name))
        } else if has_template {
```

I think next step would be to add tests!