### PR TITLE
Add habitat_http_client to example core crate override

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,4 +28,5 @@ members = [
 # habitat repo, you may need to adjust the paths.
 # [patch."https://github.com/habitat-sh/core.git"]
 # habitat_core = {path = "../core/components/core"}
+# habitat_http_client = {path = "../core/components/http-client"}
 # habitat_win_users = {path = "../core/components/win-users"}


### PR DESCRIPTION
This crate was inadvertently left out of the example.

Signed-off-by: Christopher Maier <cmaier@chef.io>