### PR TITLE
Abstract the logging of terminated hook processes

### DIFF
--- a/components/sup/src/manager/service/hooks.rs
+++ b/components/sup/src/manager/service/hooks.rs
@@ -136,18 +136,23 @@ pub trait Hook: fmt::Debug + Sized {
 
     /// Output a message that a hook process was terminated by a
     /// signal.
-    ///
-    /// This should only be called when `ExitStatus#code()` returns
-    /// `None`, and this only happens on non-Windows machines.
     #[cfg(unix)]
     fn output_termination_message(service_group: &ServiceGroup, status: &ExitStatus) {
         outputln!(preamble service_group, "{} was terminated by signal {:?}",
                   Self::file_name(),
                   status.signal());
     }
+
+    /// This should only be called when `ExitStatus#code()` returns
+    /// `None`, and this can only happen on non-Windows machines.
+    ///
+    /// Thus, if this code is ever called on Windows, something has
+    /// fundamentally changed in the Rust standard library.
+    ///
+    /// See https://doc.rust-lang.org/1.30.1/std/process/struct.ExitStatus.html#method.code
     #[cfg(windows)]
-    fn output_termination_message(&self, _: &ServiceGroup, _: &ExitStatus) {
-        // No-op
+    fn output_termination_message(_: &ServiceGroup, _: &ExitStatus) {
+        panic!("ExitStatus::code should never return None on Windows; please report this to the Habitat core developers");
     }
 
     /// Run a compiled hook.


### PR DESCRIPTION
When `ExitStatus#code()` returns `None`, it doesn't _just_ mean the
process exited without a status code, it means it was terminated by a
signal.

Since this can only happen on Unix platforms, we can use the
`ExitStatusExt` trait to extract _which_ signal the process was
terminated by.

To capture the platform-dependence of this behavior, and to not have
to repeat ourselves everywhere, there's a new
`output_termination_message` function in the `Hook` trait that we can
use throughout the code.

See the following for reference:

- [Documentation of ExitStatus#code](https://doc.rust-lang.org/1.30.1/std/process/struct.ExitStatus.html#method.code)
- [Unix implementation of ExitStatus#code](https://github.com/rust-lang/rust/blob/25a42b2ceb46887e9941cec667eac99844dd7ad0/src/libstd/sys/unix/process/process_common.rs#L374-L380)
- [Windows implementation of ExitStatus#code](https://github.com/rust-lang/rust/blob/25a42b2ceb46887e9941cec667eac99844dd7ad0/src/libstd/sys/windows/process.rs#L393-L395)

Signed-off-by: Christopher Maier <cmaier@chef.io>