### PR TITLE
Fix up and clarify issue templates made confusing by adding release template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,6 +1,6 @@
 ---
-name: Feature Request
-about: Suggest new functionality for Habitat
+name: Bug Report
+about: Explain a defect discovered in Habitat
 labels: C-bug
 
 ---

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,3 +1,10 @@
+---
+name: Feature Request
+about: Suggest new functionality for Habitat
+labels: C-bug
+
+---
+
 Hello - thanks for reporting an issue with Habitat.
 
 In order to help us troubleshoot the issue, please be sure to include the following information if applicable:

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,7 @@
+---
+name: Feature Request
+about: Suggest new functionality for Habitat
+labels: C-feature
+
+---
+

--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -1,7 +1,7 @@
 ---
 name: Release Checklist
 about: Track the status of a release
-labels: 
+labels: C-release
 
 ---
 


### PR DESCRIPTION
When the release template was added, the standard issue template became hard
to find:

![screen shot 2018-11-15 at 12 19 28 pm](https://user-images.githubusercontent.com/5906042/48569842-d63d8e00-e8d0-11e8-8b6b-3d68746ba5a3.png)

Fix that up by adding metadata to the bug template as well as a feature request template and labels for all 3 templates.