### PR TITLE
Update homebrew release to utilize metadata helper functions

### DIFF
--- a/.buildkite/scripts/bump_homebrew_release.sh
+++ b/.buildkite/scripts/bump_homebrew_release.sh
@@ -27,8 +27,8 @@ ensure_files_changed() {
     fi
 }
 
-new_version=$(buildkite-agent meta-data get version)
-new_release=$(buildkite-agent meta-data get hab-release-macos)
+new_version=$(get_version)
+new_release=$(get_hab_release x86_64-darwin)
 new_sha256=$(buildkite-agent meta-data get hab-macos-bintray-sha256)
 
 echo "--- :github: Cloning habitat-sh/homebrew-habitat"


### PR DESCRIPTION
This is a follow-on PR to #5753 to update the release automation around Homebrew to utilize helper functions that were introduced.


Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>