### PR TITLE
Add some sleeps to try_recv loops so we don't peg the CPU.

### DIFF
--- a/components/sup/src/manager/file_watcher.rs
+++ b/components/sup/src/manager/file_watcher.rs
@@ -19,6 +19,7 @@ use std::ffi::OsString;
 use std::mem::swap;
 use std::path::{Component, Path, PathBuf};
 use std::sync::mpsc::{channel, Receiver, TryRecvError};
+use std::thread;
 use std::time::Duration;
 
 use error::{Error, Result};
@@ -1341,6 +1342,7 @@ impl<C: Callbacks, W: Watcher> FileWatcher<C, W> {
     pub fn run(&mut self) -> Result<()> {
         loop {
             self.single_iteration()?;
+            thread::sleep(Duration::from_secs(1));
         }
     }
 
@@ -1680,6 +1682,7 @@ mod tests {
     use std::os::unix::fs as unix_fs;
     use std::path::{Component, Path, PathBuf};
     use std::sync::mpsc::Sender;
+    use std::thread;
     use std::time::Duration;
 
     use notify;
@@ -3187,7 +3190,7 @@ mod tests {
 
             // After switching single_iteration() from recv() to try_recv(), this sleep is required
             // for these tests to pass.
-            ::std::thread::sleep(Duration::from_secs(3));
+            thread::sleep(Duration::from_secs(3));
 
             while iteration < iterations {
                 setup.watcher.single_iteration().expect(&format!(

--- a/components/sup/src/manager/service_updater.rs
+++ b/components/sup/src/manager/service_updater.rs
@@ -19,6 +19,7 @@ use std::result;
 use std::str::FromStr;
 use std::sync::mpsc::{channel, Receiver, Sender, TryRecvError};
 use std::thread;
+use std::time;
 
 use time::Duration;
 
@@ -505,6 +506,8 @@ impl Worker {
 
                 next_time = self.next_period_start();
             }
+
+            thread::sleep(time::Duration::from_secs(1));
         }
     }
 
@@ -556,6 +559,8 @@ impl Worker {
 
                 next_time = self.next_period_start();
             }
+
+            thread::sleep(time::Duration::from_secs(1));
         }
     }
 }

--- a/components/sup/src/manager/user_config_watcher.rs
+++ b/components/sup/src/manager/user_config_watcher.rs
@@ -21,7 +21,8 @@ use std::sync::{
     },
     Arc, Mutex,
 };
-use std::thread::Builder as ThreadBuilder;
+use std::thread::{self, Builder as ThreadBuilder};
+use std::time::Duration;
 
 use super::file_watcher::{default_file_watcher_with_no_initial_event, Callbacks};
 
@@ -269,6 +270,8 @@ impl Worker {
                             break;
                         }
                     }
+
+                    thread::sleep(Duration::from_secs(1));
                 }
             })?;
 


### PR DESCRIPTION
It turns out that when you switch from using recv() (which blocks the
current thread) to using try_recv() (which doesn't block) in a loop, you
need to add a little sleep after the try_recv(). Failure to do this
means the CPU gets pegged as the process just loops at a terrific speed.

![](https://media.giphy.com/media/ZLxRWG0vhzpiE/giphy.gif)

Signed-off-by: Josh Black <raskchanky@gmail.com>