### PR TITLE
Election code cleanup

### DIFF
--- a/components/butterfly/src/rumor/election.rs
+++ b/components/butterfly/src/rumor/election.rs
@@ -53,7 +53,13 @@ pub struct Election {
 impl Election {
     /// Create a new election, voting for the given member id, for the given service group, and
     /// with the given suitability.
-    pub fn new<S1>(member_id: S1, service_group: &str, term: u64, suitability: u64) -> Election
+    pub fn new<S1>(
+        member_id: S1,
+        service_group: &str,
+        term: u64,
+        suitability: u64,
+        has_quorum: bool,
+    ) -> Election
     where
         S1: Into<String>,
     {
@@ -63,7 +69,11 @@ impl Election {
             service_group: service_group.into(),
             term: term,
             suitability: suitability,
-            status: ElectionStatus::Running,
+            status: if has_quorum {
+                ElectionStatus::Running
+            } else {
+                ElectionStatus::NoQuorum
+            },
             votes: vec![from_id],
         }
     }
@@ -227,11 +237,12 @@ impl ElectionUpdate {
         service_group: &str,
         term: u64,
         suitability: u64,
+        has_quorum: bool,
     ) -> ElectionUpdate
     where
         S1: Into<String>,
     {
-        let election = Election::new(member_id, service_group, term, suitability);
+        let election = Election::new(member_id, service_group, term, suitability, has_quorum);
         ElectionUpdate(election)
     }
 }
@@ -324,6 +335,7 @@ mod tests {
             &ServiceGroup::new(None, "tdep", "prod", None).unwrap(),
             Term::default(),
             suitability,
+            true, // has_quorum
         )
     }
 
@@ -333,6 +345,7 @@ mod tests {
             &ServiceGroup::new(None, "tdep", "prod", None).unwrap(),
             Term::default(),
             suitability,
+            true, // has_quorum
         )
     }
 

--- a/components/butterfly/src/rumor/election.rs
+++ b/components/butterfly/src/rumor/election.rs
@@ -38,6 +38,8 @@ pub trait ElectionRumor {
     fn term(&self) -> u64;
 }
 
+pub type Term = u64;
+
 #[derive(Debug, Clone, Serialize)]
 pub struct Election {
     pub member_id: String,
@@ -51,7 +53,7 @@ pub struct Election {
 impl Election {
     /// Create a new election, voting for the given member id, for the given service group, and
     /// with the given suitability.
-    pub fn new<S1>(member_id: S1, service_group: &str, suitability: u64) -> Election
+    pub fn new<S1>(member_id: S1, service_group: &str, term: u64, suitability: u64) -> Election
     where
         S1: Into<String>,
     {
@@ -59,7 +61,7 @@ impl Election {
         Election {
             member_id: from_id.clone(),
             service_group: service_group.into(),
-            term: 0,
+            term: term,
             suitability: suitability,
             status: ElectionStatus::Running,
             votes: vec![from_id],
@@ -220,11 +222,16 @@ impl Rumor for Election {
 pub struct ElectionUpdate(Election);
 
 impl ElectionUpdate {
-    pub fn new<S1>(member_id: S1, service_group: &str, suitability: u64) -> ElectionUpdate
+    pub fn new<S1>(
+        member_id: S1,
+        service_group: &str,
+        term: u64,
+        suitability: u64,
+    ) -> ElectionUpdate
     where
         S1: Into<String>,
     {
-        let election = Election::new(member_id, service_group, suitability);
+        let election = Election::new(member_id, service_group, term, suitability);
         ElectionUpdate(election)
     }
 }
@@ -299,7 +306,7 @@ impl Rumor for ElectionUpdate {
 mod tests {
     use habitat_core::service::ServiceGroup;
     use rumor::{
-        election::{Election, ElectionUpdate},
+        election::{Election, ElectionUpdate, Term},
         Rumor, RumorStore,
     };
 
@@ -315,6 +322,7 @@ mod tests {
         Election::new(
             member_id,
             &ServiceGroup::new(None, "tdep", "prod", None).unwrap(),
+            Term::default(),
             suitability,
         )
     }
@@ -323,6 +331,7 @@ mod tests {
         ElectionUpdate::new(
             member_id,
             &ServiceGroup::new(None, "tdep", "prod", None).unwrap(),
+            Term::default(),
             suitability,
         )
     }

--- a/components/butterfly/src/rumor/election.rs
+++ b/components/butterfly/src/rumor/election.rs
@@ -40,7 +40,6 @@ pub trait ElectionRumor {
 
 #[derive(Debug, Clone, Serialize)]
 pub struct Election {
-    pub from_id: String,
     pub member_id: String,
     pub service_group: String,
     pub term: u64,
@@ -58,7 +57,6 @@ impl Election {
     {
         let from_id = member_id.into();
         Election {
-            from_id: from_id.clone(),
             member_id: from_id.clone(),
             service_group: service_group.into(),
             term: 0,
@@ -134,7 +132,6 @@ impl FromProto<ProtoRumor> for Election {
         };
         let from_id = rumor.from_id.ok_or(Error::ProtocolMismatch("from-id"))?;
         Ok(Election {
-            from_id: from_id.clone(),
             member_id: from_id.clone(),
             service_group: payload
                 .service_group

--- a/components/butterfly/src/server/mod.rs
+++ b/components/butterfly/src/server/mod.rs
@@ -874,8 +874,7 @@ impl Server {
     /// term for the election.
     pub fn start_election(&self, service_group: &str, term: u64) {
         let suitability = self.suitability_lookup.get(&service_group);
-        let mut e = Election::new(self.member_id(), service_group, suitability);
-        e.term = term;
+        let mut e = Election::new(self.member_id(), service_group, term, suitability);
         let ek = RumorKey::from(&e);
         if !self.check_quorum(e.key()) {
             warn!("start_election check_quorum failed: {:?}", e);
@@ -887,8 +886,7 @@ impl Server {
     }
 
     pub fn start_update_election(&self, service_group: &str, suitability: u64, term: u64) {
-        let mut e = ElectionUpdate::new(self.member_id(), service_group, suitability);
-        e.term = term;
+        let mut e = ElectionUpdate::new(self.member_id(), service_group, term, suitability);
         let ek = RumorKey::from(&e);
         if !self.check_quorum(e.key()) {
             warn!("start_election check_quorum failed: {:?}", e);
@@ -1258,6 +1256,7 @@ impl<'a> Serialize for ServerProxy<'a> {
 mod tests {
     use super::*;
     use habitat_core::service::ServiceGroup;
+    use rumor::election::Term;
 
     fn get_mock_service(member_id: String, service_group: ServiceGroup) -> Service {
         Service {
@@ -1284,8 +1283,12 @@ mod tests {
         let check_quorum = |_: &str| true;
         let member_list = MemberList::new();
 
-        let mut election_with_unknown_leader =
-            Election::new(unknown_leader_member_id, &service_group, suitability);
+        let mut election_with_unknown_leader = Election::new(
+            unknown_leader_member_id,
+            &service_group,
+            Term::default(),
+            suitability,
+        );
         election_with_unknown_leader.finish();
         elections.insert(election_with_unknown_leader);
 
@@ -1316,8 +1319,12 @@ mod tests {
         let check_quorum = |_: &str| true;
         let member_list = MemberList::new();
 
-        let mut election_with_unknown_leader =
-            Election::new(departed_leader.id.clone(), &service_group, suitability);
+        let mut election_with_unknown_leader = Election::new(
+            departed_leader.id.clone(),
+            &service_group,
+            Term::default(),
+            suitability,
+        );
         election_with_unknown_leader.finish();
         elections.insert(election_with_unknown_leader);
 

--- a/components/sup/src/census.rs
+++ b/components/sup/src/census.rs
@@ -863,13 +863,24 @@ mod tests {
         service_store.insert(service_three);
 
         let election_store: RumorStore<ElectionRumor> = RumorStore::default();
-        let mut election = ElectionRumor::new("member-a", &sg_one, election::Term::default(), 10);
+        let mut election = ElectionRumor::new(
+            "member-a",
+            &sg_one,
+            election::Term::default(),
+            10,
+            true, // has_quorum
+        );
         election.finish();
         election_store.insert(election);
 
         let election_update_store: RumorStore<ElectionUpdateRumor> = RumorStore::default();
-        let mut election_update =
-            ElectionUpdateRumor::new("member-b", &sg_two, election::Term::default(), 10);
+        let mut election_update = ElectionUpdateRumor::new(
+            "member-b",
+            &sg_two,
+            election::Term::default(),
+            10,
+            true, // has_quorum
+        );
         election_update.finish();
         election_update_store.insert(election_update);
 

--- a/components/sup/src/census.rs
+++ b/components/sup/src/census.rs
@@ -775,6 +775,7 @@ mod tests {
     use serde_json;
 
     use butterfly::member::{Health, MemberList};
+    use butterfly::rumor::election;
     use butterfly::rumor::election::Election as ElectionRumor;
     use butterfly::rumor::election::ElectionUpdate as ElectionUpdateRumor;
     use butterfly::rumor::service::Service as ServiceRumor;
@@ -862,12 +863,13 @@ mod tests {
         service_store.insert(service_three);
 
         let election_store: RumorStore<ElectionRumor> = RumorStore::default();
-        let mut election = ElectionRumor::new("member-a", &sg_one, 10);
+        let mut election = ElectionRumor::new("member-a", &sg_one, election::Term::default(), 10);
         election.finish();
         election_store.insert(election);
 
         let election_update_store: RumorStore<ElectionUpdateRumor> = RumorStore::default();
-        let mut election_update = ElectionUpdateRumor::new("member-b", &sg_two, 10);
+        let mut election_update =
+            ElectionUpdateRumor::new("member-b", &sg_two, election::Term::default(), 10);
         election_update.finish();
         election_update_store.insert(election_update);
 

--- a/components/sup/src/manager/service/hooks.rs
+++ b/components/sup/src/manager/service/hooks.rs
@@ -1071,6 +1071,7 @@ mod tests {
     use std::string::ToString;
 
     use butterfly::member::MemberList;
+    use butterfly::rumor::election;
     use butterfly::rumor::election::Election as ElectionRumor;
     use butterfly::rumor::election::ElectionUpdate as ElectionUpdateRumor;
     use butterfly::rumor::service::Service as ServiceRumor;
@@ -1370,7 +1371,7 @@ echo "The message is Hola Mundo"
         service_store.insert(service_one);
 
         let election_store: RumorStore<ElectionRumor> = RumorStore::default();
-        let mut election = ElectionRumor::new("member-a", &sg_one, 10);
+        let mut election = ElectionRumor::new("member-a", &sg_one, election::Term::default(), 10);
         election.finish();
         election_store.insert(election);
 
@@ -1477,7 +1478,7 @@ echo "The message is Hello"
         service_store.insert(service_one);
 
         let election_store: RumorStore<ElectionRumor> = RumorStore::default();
-        let mut election = ElectionRumor::new("member-a", &sg_one, 10);
+        let mut election = ElectionRumor::new("member-a", &sg_one, election::Term::default(), 10);
         election.finish();
         election_store.insert(election);
 

--- a/components/sup/src/manager/service/hooks.rs
+++ b/components/sup/src/manager/service/hooks.rs
@@ -1371,7 +1371,13 @@ echo "The message is Hola Mundo"
         service_store.insert(service_one);
 
         let election_store: RumorStore<ElectionRumor> = RumorStore::default();
-        let mut election = ElectionRumor::new("member-a", &sg_one, election::Term::default(), 10);
+        let mut election = ElectionRumor::new(
+            "member-a",
+            &sg_one,
+            election::Term::default(),
+            10,
+            true, // has_quorum
+        );
         election.finish();
         election_store.insert(election);
 
@@ -1478,7 +1484,13 @@ echo "The message is Hello"
         service_store.insert(service_one);
 
         let election_store: RumorStore<ElectionRumor> = RumorStore::default();
-        let mut election = ElectionRumor::new("member-a", &sg_one, election::Term::default(), 10);
+        let mut election = ElectionRumor::new(
+            "member-a",
+            &sg_one,
+            election::Term::default(),
+            10,
+            true, // has_quorum
+        );
         election.finish();
         election_store.insert(election);
 


### PR DESCRIPTION
Some general cleanup and simplification motivated by the close reading of the elections code. This is probably best reviewed as the separate commits.