### PR TITLE
revert change windows docker studio creation assigning shortVersion

### DIFF
--- a/components/studio/build-docker-image.ps1
+++ b/components/studio/build-docker-image.ps1
@@ -55,7 +55,7 @@ try {
     
     $pathParts = $studioPath.Replace("\", "/").Split("/")
     $ident = [String]::Join("/", $pathParts[-4..-1])
-    $shortVersion = "${pathParts[-2]}"
+    $shortVersion = $pathParts[-2]
     $version = "$($pathParts[-2])-$($pathParts[-1])"
     
 @"


### PR DESCRIPTION
This reverts [this change](https://github.com/habitat-sh/habitat/commit/14b94bc713924df8dfbf567a5f755bef369679ca#diff-a39a01256b6690fc0e836e58a4ea8031R58) which was bash friendly but powershell hostile.

Signed-off-by: mwrock <matt@mattwrock.com>