### PR TITLE
Enable build of kernel2 launcher as part of release pipeline

### DIFF
--- a/.buildkite/release_pipeline.yaml
+++ b/.buildkite/release_pipeline.yaml
@@ -159,6 +159,14 @@ steps:
 
   - wait
 
+  - label: ":linux: :two: core/hab-launcher"
+    command: .buildkite/scripts/build_component.sh launcher
+    agents:
+      queue: habitat-release
+    env:
+      BUILD_PKG_TARGET: "x86_64-linux-kernel2"
+  
+  - wait
   # Exporters
 
   # TODO: Create an ACI emoji
@@ -280,16 +288,6 @@ steps:
       to Builder and Bintray. Please ensure those artifacts have been
       uploaded before continuing with the release.
   
-  - block: ":dango: :linux: :two: Build x86_64-linux-kernel2 Launcher"
-    prompt: |
-      x86_64-linux-kernel2 launcher will need to be built by hand.  If 
-      you are promoting launchers in the following step, please build 
-      and upload and x86_64-linux-kernel2 launcher before continuing.
-      Instructions for building an x86_64-linux-kernel2 launcher can be
-      found in the launcher README.
-      
-      https://github.com/habitat-sh/habitat/tree/master/components/launcher#building-an-x86_64-linux-kernel2-release
-
   - block: ":thumbsup: Select Launcher Versions to Promote to Release Channel"
     prompt: |
       Which `core/hab-launcher` versions should be in the release

--- a/components/launcher/habitat/plan.sh
+++ b/components/launcher/habitat/plan.sh
@@ -25,6 +25,10 @@ do_prepare() {
   export OPENSSL_LIB_DIR=$(pkg_path_for openssl)/lib
   export OPENSSL_INCLUDE_DIR=$(pkg_path_for openssl)/include
   export SODIUM_LIB_DIR=$(pkg_path_for libsodium)/lib
+  
+  # Used to set the active package target for the binaries at build time
+  export PLAN_PACKAGE_TARGET="$pkg_target"
+  build_line "Setting PLAN_PACKAGE_TARGET=$PLAN_PACKAGE_TARGET"
 }
 
 do_build() {


### PR DESCRIPTION
This enables building of the `x86_64-linux-kernel2 launcher` as part of the release pipeline, to be optionally promoted at a later step.  

It also sets `PLAN_PACKAGE_TARGET` in the plan.sh of the launcher, to ensure that `PackageTarget::active_package_target()` returns the correct value at run time. Without this it will default to `x86_64-linux` and when the launcher attempts to determine what hab-sup package to use it will reject the `x86_64-linux-kernel2` supervisor as having an invalid target.   

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>