### PR TITLE
Add x86_64-linux-kernel2 validation to release checklist

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -18,6 +18,7 @@ Here are all the steps for the release process. Create a new issue at the beginn
 - [ ] [Buildkite](https://buildkite.com/chef/habitat-sh-habitat-master-release) run success
 - [ ] [Validate](https://github.com/habitat-sh/habitat/blob/master/RELEASE.md#validate-the-release) [darwin binaries](https://bintray.com/habitat/stable/hab-x86_64-darwin)
 - [ ] [Validate](https://github.com/habitat-sh/habitat/blob/master/RELEASE.md#validate-the-release) [linux binaries](https://bintray.com/habitat/stable/hab-x86_64-linux)
+- [ ] [Validate](https://github.com/habitat-sh/habitat/blob/master/RELEASE.md#validate-the-release) [linux-kernel2 binaries](https://bintray.com/habitat/stable/hab-x86_64-linux-kernel2)
 - [ ] [Validate](https://github.com/habitat-sh/habitat/blob/master/RELEASE.md#validate-the-release) [windows binaries](https://bintray.com/habitat/stable/hab-x86_64-windows)
 - [ ] Declare merge thaw and update slack status
 - [ ] Merge blog announcement PR


### PR DESCRIPTION
Now that the x86_64-linux-kernel2 packages are built and promoted as part of the release, we also need to validate them as we do with linux,darwin and windows packages. 


Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>