### PR TITLE
Enable building of kernel2 docker image as part of release pipeline

### DIFF
--- a/.buildkite/release_pipeline.yaml
+++ b/.buildkite/release_pipeline.yaml
@@ -245,6 +245,13 @@ steps:
       queue: habitat-release
     env:
       BUILD_PKG_TARGET: "x86_64-linux"
+  - label: ":docker: :two: Upload containers to Docker Hub"
+    command: .buildkite/scripts/dockerhub_upload.sh
+    agents:
+      queue: habitat-release
+    env:
+      BUILD_PKG_TARGET: "x86_64-linux-kernel2"
+
   # TODO Create a JFrog emoji
   - label: ":linux: Upload (but don't publish!) artifacts to Bintray"
     command: .buildkite/scripts/bintray_upload.sh


### PR DESCRIPTION
This was omitted from the initial pipeline development, as building of docker images requires a published `hab` cli in order to seed the image and install from the release channel.  Now that we have a published `x86_64-linux-kernel2` cli,  we can enable this for the next release. 

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>