### PR TITLE
Refactor SpecWatcher

### DIFF
--- a/components/sup/src/error.rs
+++ b/components/sup/src/error.rs
@@ -170,7 +170,8 @@ pub enum Error {
     ServiceSpecParse(toml::de::Error),
     ServiceSpecRender(toml::ser::Error),
     SignalFailed,
-    SpecWatcherDirNotFound(String),
+    SpecWatcherNotCreated,
+    SpecDirNotFound(String),
     SpecWatcherGlob(glob::PatternError),
     StrFromUtf8Error(str::Utf8Error),
     StringFromUtf8Error(string::FromUtf8Error),
@@ -335,7 +336,8 @@ impl fmt::Display for SupError {
                 format!("Service spec could not be rendered successfully: {}", err)
             }
             Error::SignalFailed => format!("Failed to send a signal to the child process"),
-            Error::SpecWatcherDirNotFound(ref path) => format!(
+            Error::SpecWatcherNotCreated => format!("Failed to create a SpecWatcher"),
+            Error::SpecDirNotFound(ref path) => format!(
                 "Spec directory '{}' not created or is not a directory",
                 path
             ),
@@ -442,7 +444,8 @@ impl error::Error for SupError {
             Error::ServiceSpecParse(_) => "Service spec could not be parsed successfully",
             Error::ServiceSpecRender(_) => "Service spec TOML could not be rendered successfully",
             Error::SignalFailed => "Failed to send a signal to the child process",
-            Error::SpecWatcherDirNotFound(_) => "Spec directory not created or is not a directory",
+            Error::SpecWatcherNotCreated => "Failed to create a SpecWatcher",
+            Error::SpecDirNotFound(_) => "Spec directory not created or is not a directory",
             Error::SpecWatcherGlob(_) => "Spec watcher file globbing error",
             Error::StrFromUtf8Error(_) => "Failed to convert a str from a &[u8] as UTF-8",
             Error::StringFromUtf8Error(_) => "Failed to convert a string from a Vec<u8> as UTF-8",

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -21,6 +21,7 @@ mod peer_watcher;
 mod periodic;
 mod self_updater;
 mod service_updater;
+mod spec_dir;
 mod spec_watcher;
 mod sys;
 mod user_config_watcher;
@@ -76,7 +77,9 @@ pub use self::service::{
     Topology, UpdateStrategy,
 };
 use self::service_updater::ServiceUpdater;
-use self::spec_watcher::{SpecWatcher, SpecWatcherEvent};
+use self::spec_dir::SpecDir;
+use self::spec_watcher::SpecWatcher;
+
 pub use self::sys::Sys;
 use self::user_config_watcher::UserConfigWatcher;
 use super::feat;
@@ -94,6 +97,19 @@ const MEMBER_ID_FILE: &'static str = "MEMBER_ID";
 const PROC_LOCK_FILE: &'static str = "LOCK";
 
 static LOGKEY: &'static str = "MR";
+
+/// Captures the different operations that can be performed on a
+/// service.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ServiceOperation {
+    /// Start the indicated service.
+    Start(ServiceSpec),
+    /// Stop the indicated service.
+    Stop(ServiceSpec),
+    /// Stop a service that is currently running, and start it again
+    /// with a different spec.
+    Restart(ServiceSpec, ServiceSpec),
+}
 
 /// FileSystem paths that the Manager uses to persist data to disk.
 ///
@@ -224,6 +240,7 @@ pub struct Manager {
     peer_watcher: Option<PeerWatcher>,
     spec_watcher: SpecWatcher,
     user_config_watcher: UserConfigWatcher,
+    spec_dir: SpecDir,
     organization: Option<String>,
     self_updater: Option<SelfUpdater>,
     service_states: HashMap<PackageIdent, Timespec>,
@@ -323,39 +340,6 @@ impl Manager {
         }
     }
 
-    /// Read all spec files and rewrite them to disk migrating their format from a previous
-    /// Supervisor's to the one currently running.
-    fn migrate_specs(fs_cfg: &FsCfg) {
-        // JW: In the future we should write spec files to the Supervisor's DAT file in a more
-        // appropriate machine readable format. We'll need to wait until we modify how we load and
-        // unload services, though. Right now we watch files on disk and communicate with the
-        // Supervisor asynchronously. We need to move to communicating directly with the
-        // Supervisor's main loop through IPC.
-        match SpecWatcher::spec_files(&fs_cfg.specs_path) {
-            Ok(specs) => for spec_file in specs {
-                match ServiceSpec::from_file(&spec_file) {
-                    Ok(spec) => {
-                        if let Err(err) = spec.to_file(&spec_file) {
-                            outputln!(
-                                "Unable to migrate service spec, {}, {}",
-                                spec_file.display(),
-                                err
-                            );
-                        }
-                    }
-                    Err(err) => {
-                        outputln!(
-                            "Unable to migrate service spec, {}, {}",
-                            spec_file.display(),
-                            err
-                        );
-                    }
-                }
-            },
-            Err(err) => outputln!("Unable to migrate service specs, {}", err),
-        }
-    }
-
     fn new(cfg: ManagerConfig, fs_cfg: FsCfg, launcher: LauncherCli) -> Result<Manager> {
         debug!("new(cfg: {:?}, fs_cfg: {:?}", cfg, fs_cfg);
         let current = PackageIdent::from_str(&format!("{}/{}", SUP_PKG_IDENT, VERSION)).unwrap();
@@ -406,12 +390,18 @@ impl Manager {
             peer.gossip_port = peer_addr.port();
             server.member_list.add_initial_member(peer);
         }
-        Self::migrate_specs(&fs_cfg);
+
         let peer_watcher = if let Some(path) = cfg.watch_peer_file {
             Some(PeerWatcher::run(path)?)
         } else {
             None
         };
+
+        let spec_dir = SpecDir::new(&fs_cfg.specs_path)?;
+        spec_dir.migrate_specs();
+
+        let spec_watcher = SpecWatcher::run(&spec_dir)?;
+
         Ok(Manager {
             state: Arc::new(ManagerState {
                 cfg: cfg_static,
@@ -425,8 +415,9 @@ impl Manager {
             events_group: cfg.eventsrv_group,
             launcher: launcher,
             peer_watcher: peer_watcher,
-            spec_watcher: SpecWatcher::run(&fs_cfg.specs_path)?,
+            spec_watcher: spec_watcher,
             user_config_watcher: UserConfigWatcher::new(),
+            spec_dir: spec_dir,
             fs_cfg: Arc::new(fs_cfg),
             organization: cfg.organization,
             service_states: HashMap::new(),
@@ -694,7 +685,8 @@ impl Manager {
         if let Some(svc_load) = svc {
             Self::service_load(&self.state, &mut CtlRequest::default(), svc_load)?;
         }
-        self.start_initial_services_from_spec_watcher()?;
+        // This serves to start up any services that need starting
+        self.take_action_on_services()?;
 
         outputln!(
             "Starting gossip-listener on {}",
@@ -832,7 +824,11 @@ impl Manager {
                 self.shutdown(ShutdownReason::PkgUpdating);
                 return Ok(());
             }
-            self.update_running_services_from_spec_watcher()?;
+
+            if self.spec_watcher.has_events() {
+                self.take_action_on_services()?;
+            }
+
             self.update_peers_from_watch_file()?;
             self.update_running_services_from_user_config_watcher();
             self.check_for_updated_packages();
@@ -1492,10 +1488,10 @@ impl Manager {
         }
 
         for loaded in self
-            .spec_watcher
-            .specs_from_watch_path()
+            .spec_dir
+            .specs()
             .unwrap()
-            .values()
+            .iter()
             .filter(|s| !active_services.contains(&s.ident))
         {
             service_states.insert(loaded.ident.clone(), Timespec::new(0, 0));
@@ -1557,10 +1553,10 @@ impl Manager {
         // These would include stopped persistent services or other
         // persistent services that failed to load
         let watched_services: Vec<Service> = self
-            .spec_watcher
-            .specs_from_watch_path()
+            .spec_dir
+            .specs()
             .unwrap()
-            .values()
+            .iter()
             .filter(|spec| !existing_idents.contains(&spec.ident))
             .flat_map(|spec| {
                 Service::load(
@@ -1686,46 +1682,108 @@ impl Manager {
         self.butterfly.persist_data();
     }
 
-    fn start_initial_services_from_spec_watcher(&mut self) -> Result<()> {
-        for service_event in self.spec_watcher.initial_events()? {
-            match service_event {
-                SpecWatcherEvent::AddService(spec) => {
-                    if spec.desired_state == DesiredState::Up {
-                        // JW TODO: Should we retry starting services which we failed to add?
-                        self.add_service(spec);
-                    }
+    /// Start, stop, or restart services to bring what's running in
+    /// line with what our spec files say.
+    fn take_action_on_services(&mut self) -> Result<()> {
+        for op in self.reconcile_spec_files()? {
+            match op {
+                ServiceOperation::Stop(spec) => {
+                    self.remove_service_for_spec(&spec)?;
                 }
-                _ => warn!("Skipping unexpected watcher event: {:?}", service_event),
+                ServiceOperation::Start(spec) => {
+                    self.add_service(spec);
+                }
+                ServiceOperation::Restart(running, desired) => {
+                    self.remove_service_for_spec(&running)?;
+                    self.add_service(desired);
+                }
             }
         }
         Ok(())
     }
 
-    fn update_running_services_from_spec_watcher(&mut self) -> Result<()> {
-        let mut active_specs = HashMap::new();
-        for service in self
+    /// Determine what services we need to start, stop, or restart in
+    /// order to be running what our on-disk spec files tell us we
+    /// should be running.
+    ///
+    /// See `specs_to_operations` for the real logic.
+    fn reconcile_spec_files(&mut self) -> Result<Vec<ServiceOperation>> {
+        let services = self
             .state
             .services
             .read()
-            .expect("Services lock is poisoned!")
-            .values()
-        {
-            let spec = service.to_spec();
-            active_specs.insert(spec.ident.name.clone(), spec);
-        }
+            .expect("Services lock is poisoned");
+        let currently_running_specs = services.values().map(|s| s.to_spec());
+        let on_disk_specs = self.spec_dir.specs()?;
+        Ok(Self::specs_to_operations(
+            currently_running_specs,
+            on_disk_specs,
+        ))
+    }
 
-        for service_event in self.spec_watcher.new_events(active_specs)? {
-            match service_event {
-                SpecWatcherEvent::AddService(spec) => {
-                    if spec.desired_state == DesiredState::Up {
-                        self.add_service(spec);
+    /// Pure utility function to generate a list of operations to
+    /// perform to bring what's currently running with what _should_ be
+    /// running, based on the current on-disk spec files.
+    fn specs_to_operations<C, D>(
+        currently_running_specs: C,
+        on_disk_specs: D,
+    ) -> Vec<ServiceOperation>
+    where
+        C: IntoIterator<Item = ServiceSpec>,
+        D: IntoIterator<Item = ServiceSpec>,
+    {
+        let mut running_specs = currently_running_specs
+            .into_iter()
+            .map(|s| (s.ident.clone(), s))
+            .collect::<HashMap<_, _>>();
+        let disk_specs = on_disk_specs
+            .into_iter()
+            .map(|s| (s.ident.clone(), s))
+            .collect::<HashMap<_, _>>();
+
+        let mut operations = vec![];
+
+        for (ident, disk_spec) in disk_specs.into_iter() {
+            match disk_spec.desired_state {
+                DesiredState::Up => {
+                    if let Some(running_spec) = running_specs.remove(&ident) {
+                        if running_spec != disk_spec {
+                            // TODO (CM): In the future, this
+                            // would be the place where we can
+                            // evaluate what has changed between
+                            // the spec-on-disk and our in-memory
+                            // representation and potentially just
+                            // bring our in-memory representation
+                            // in line without having to restart
+                            // the entire service.
+                            debug!("Reconciliation: '{}' queued for restart", ident);
+                            operations.push(ServiceOperation::Restart(running_spec, disk_spec));
+                        } else {
+                            debug!("Reconciliation: '{}' unchanged", ident);
+                        }
+                    } else {
+                        debug!("Reconciliation: '{}' queued for start", ident);
+                        operations.push(ServiceOperation::Start(disk_spec));
                     }
                 }
-                SpecWatcherEvent::RemoveService(spec) => self.remove_service_for_spec(&spec)?,
+                DesiredState::Down => {
+                    if let Some(running_spec) = running_specs.remove(&ident) {
+                        debug!("Reconciliation: '{}' queued for stop", ident);
+                        operations.push(ServiceOperation::Stop(running_spec));
+                    } else {
+                        debug!("Reconciliation: '{}' should be down, and is", ident);
+                    }
+                }
             }
         }
+        // Anything left is something not present in our on-disk
+        // specs, so we should shut them all down
+        for (ident, running_spec) in running_specs.into_iter() {
+            debug!("Reconciliation: '{}' queued for shutdown", ident);
+            operations.push(ServiceOperation::Stop(running_spec));
+        }
 
-        Ok(())
+        operations
     }
 
     fn update_peers_from_watch_file(&mut self) -> Result<()> {
@@ -2200,4 +2258,195 @@ mod test {
 
     }
 
+    mod specs_to_operations {
+        //! Testing out the reconciliation of on-disk spec files with
+        //! what is currently running.
+
+        use super::super::*;
+
+        /// Helper function for generating a basic spec from an
+        /// identifier string
+        fn new_spec(ident: &str) -> ServiceSpec {
+            ServiceSpec::default_for(
+                PackageIdent::from_str(ident).expect("couldn't parse ident str"),
+            )
+        }
+
+        #[test]
+        fn no_specs_yield_no_changes() {
+            assert!(Manager::specs_to_operations(vec![], vec![]).is_empty());
+        }
+
+        /// If all the currently running services match all the
+        /// current specs, we shouldn't have anything to change.
+        #[test]
+        fn identical_specs_yield_no_changes() {
+            let specs = vec![new_spec("core/foo"), new_spec("core/bar")];
+            assert!(Manager::specs_to_operations(specs.clone(), specs.clone()).is_empty());
+        }
+
+        #[test]
+        fn missing_spec_on_disk_means_stop() {
+            let running = vec![new_spec("core/foo")];
+            let on_disk = vec![];
+
+            let operations = Manager::specs_to_operations(running, on_disk);
+            assert_eq!(operations.len(), 1);
+            assert_eq!(operations[0], ServiceOperation::Stop(new_spec("core/foo")));
+        }
+
+        #[test]
+        fn missing_active_spec_means_start() {
+            let running = vec![];
+            let on_disk = vec![new_spec("core/foo")];
+
+            let operations = Manager::specs_to_operations(running, on_disk);
+            assert_eq!(operations.len(), 1);
+            assert_eq!(operations[0], ServiceOperation::Start(new_spec("core/foo")));
+        }
+
+        #[test]
+        fn down_spec_on_disk_means_stop_running_service() {
+            let spec = new_spec("core/foo");
+
+            let running = vec![spec.clone()];
+
+            let down_spec = {
+                let mut s = spec.clone();
+                s.desired_state = DesiredState::Down;
+                s
+            };
+
+            let on_disk = vec![down_spec];
+
+            let operations = Manager::specs_to_operations(running, on_disk);
+            assert_eq!(operations.len(), 1);
+            assert_eq!(operations[0], ServiceOperation::Stop(spec));
+        }
+
+        #[test]
+        fn down_spec_on_disk_with_no_running_service_yields_no_changes() {
+            let running = vec![];
+            let down_spec = {
+                let mut s = new_spec("core/foo");
+                s.desired_state = DesiredState::Down;
+                s
+            };
+            let on_disk = vec![down_spec];
+
+            let operations = Manager::specs_to_operations(running, on_disk);
+            assert!(operations.is_empty());
+        }
+
+        #[test]
+        fn modified_spec_on_disk_means_restart() {
+            let running_spec = new_spec("core/foo");
+
+            let on_disk_spec = {
+                let mut s = running_spec.clone();
+                s.update_strategy = UpdateStrategy::AtOnce;
+                s
+            };
+            assert_ne!(running_spec.update_strategy, on_disk_spec.update_strategy);
+
+            let running = vec![running_spec];
+            let on_disk = vec![on_disk_spec];
+
+            let operations = Manager::specs_to_operations(running, on_disk);
+            assert_eq!(operations.len(), 1);
+
+            match operations[0] {
+                ServiceOperation::Restart(ref old, ref new) => {
+                    assert_eq!(old.ident, new.ident);
+                    assert_eq!(old.update_strategy, UpdateStrategy::None);
+                    assert_eq!(new.update_strategy, UpdateStrategy::AtOnce);
+                }
+                ref other => {
+                    panic!("Should have been a restart operation: got {:?}", other);
+                }
+            }
+        }
+
+        #[test]
+        fn multiple_operations_can_be_determined_at_once() {
+            // Nothing should happen with this; it's already how it
+            // needs to be.
+            let svc_1_running = new_spec("core/foo");
+            let svc_1_on_disk = svc_1_running.clone();
+
+            // Should get shut down.
+            let svc_2_running = new_spec("core/bar");
+            let svc_2_on_disk = {
+                let mut s = svc_2_running.clone();
+                s.desired_state = DesiredState::Down;
+                s
+            };
+
+            // Should get restarted.
+            let svc_3_running = new_spec("core/baz");
+            let svc_3_on_disk = {
+                let mut s = svc_3_running.clone();
+                s.update_strategy = UpdateStrategy::AtOnce;
+                s
+            };
+
+            // Nothing should happen with this; it's already down.
+            let svc_4_on_disk = {
+                let mut s = new_spec("core/quux");
+                s.desired_state = DesiredState::Down;
+                s
+            };
+
+            // This should get started
+            let svc_5_on_disk = new_spec("core/wat");
+
+            // This should get shut down
+            let svc_6_running = new_spec("core/lolwut");
+
+            let running = vec![
+                svc_1_running.clone(),
+                svc_2_running.clone(),
+                svc_3_running.clone(),
+                svc_6_running.clone(),
+            ];
+
+            let on_disk = vec![
+                svc_1_on_disk.clone(),
+                svc_2_on_disk.clone(),
+                svc_3_on_disk.clone(),
+                svc_4_on_disk.clone(),
+                svc_5_on_disk.clone(),
+            ];
+
+            let operations = Manager::specs_to_operations(running, on_disk);
+
+            let expected_operations = vec![
+                ServiceOperation::Stop(svc_2_running.clone()),
+                ServiceOperation::Restart(svc_3_running.clone(), svc_3_on_disk.clone()),
+                ServiceOperation::Start(svc_5_on_disk.clone()),
+                ServiceOperation::Stop(svc_6_running.clone()),
+            ];
+
+            // Ideally, we'd just sort `operations` and
+            // `expected_operations`, but we can't, since that would
+            // mean we'd need a total ordering on `PackageIdent`,
+            // which we can't do, since identifiers of different
+            // packages (say, `core/foo` and `core/bar`) are not
+            // comparable.
+            //
+            // Instead, we'll just do the verification one at a time.
+            assert_eq!(
+                operations.len(),
+                expected_operations.len(),
+                "Didn't generate the expected number of operations"
+            );
+            for op in expected_operations {
+                assert!(
+                    operations.contains(&op),
+                    "Should have expected operation: {:?}",
+                    op
+                );
+            }
+        }
+    }
 }

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -1688,13 +1688,13 @@ impl Manager {
         for op in self.reconcile_spec_files()? {
             match op {
                 ServiceOperation::Stop(spec) => {
-                    self.remove_service_for_spec(&spec)?;
+                    self.remove_service_for_spec(&spec);
                 }
                 ServiceOperation::Start(spec) => {
                     self.add_service(spec);
                 }
                 ServiceOperation::Restart(running, desired) => {
-                    self.remove_service_for_spec(&running)?;
+                    self.remove_service_for_spec(&running);
                     self.add_service(desired);
                 }
             }
@@ -1816,7 +1816,7 @@ impl Manager {
         }
     }
 
-    fn remove_service_for_spec(&mut self, spec: &ServiceSpec) -> Result<()> {
+    fn remove_service_for_spec(&mut self, spec: &ServiceSpec) {
         let svc = self
             .state
             .services
@@ -1834,7 +1834,6 @@ impl Manager {
                 );
             }
         }
-        Ok(())
     }
 }
 

--- a/components/sup/src/manager/service/spec.rs
+++ b/components/sup/src/manager/service/spec.rs
@@ -43,7 +43,7 @@ const SPEC_FILE_EXT: &'static str = "spec";
 
 pub type BindMap = HashMap<PackageIdent, Vec<BindMapping>>;
 
-#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[derive(Copy, Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub enum DesiredState {
     Down,
     Up,

--- a/components/sup/src/manager/spec_dir.rs
+++ b/components/sup/src/manager/spec_dir.rs
@@ -1,0 +1,141 @@
+use std::error::Error as StdErr;
+use std::ffi::OsStr;
+use std::path::Path;
+use std::path::PathBuf;
+
+use glob::glob;
+
+use super::service::spec::ServiceSpec;
+use error::{Error, Result};
+
+static LOGKEY: &'static str = "SD";
+const SPEC_FILE_EXT: &'static str = "spec";
+const SPEC_FILE_GLOB: &'static str = "*.spec";
+
+#[derive(Debug, Clone)]
+pub struct SpecDir(PathBuf);
+
+impl AsRef<Path> for SpecDir {
+    fn as_ref(&self) -> &Path {
+        self.0.as_ref()
+    }
+}
+
+impl SpecDir {
+    pub fn new<P>(path: P) -> Result<SpecDir>
+    where
+        P: AsRef<Path>,
+    {
+        let path: PathBuf = path.as_ref().into();
+        if !path.is_dir() {
+            return Err(sup_error!(Error::SpecDirNotFound(
+                path.display().to_string()
+            )));
+        }
+        Ok(SpecDir(path))
+    }
+
+    /// Read all spec files and rewrite them to disk migrating their format from a previous
+    /// Supervisor's to the one currently running.
+    pub fn migrate_specs(&self) {
+        // JW: In the future we should write spec files to the Supervisor's DAT file in a more
+        // appropriate machine readable format. We'll need to wait until we modify how we load and
+        // unload services, though. Right now we watch files on disk and communicate with the
+        // Supervisor asynchronously. We need to move to communicating directly with the
+        // Supervisor's main loop through IPC.
+
+        for spec_file in self.spec_files() {
+            match ServiceSpec::from_file(&spec_file) {
+                Ok(spec) => {
+                    if let Err(err) = spec.to_file(&spec_file) {
+                        outputln!(
+                            "Unable to migrate service spec, {}, {}",
+                            spec_file.display(),
+                            err
+                        );
+                    }
+                }
+                Err(err) => {
+                    outputln!(
+                        "Unable to migrate service spec, {}, {}",
+                        spec_file.display(),
+                        err
+                    );
+                }
+            }
+        }
+    }
+
+    /// Return a list of all the specs as currently found on disk.
+    pub fn specs(&self) -> Result<Vec<ServiceSpec>> {
+        let mut specs = vec![];
+
+        for spec_file in self.spec_files() {
+            let spec = match ServiceSpec::from_file(&spec_file) {
+                Ok(s) => s,
+                Err(e) => {
+                    match e.err {
+                        // If the error is related to loading a `ServiceSpec`, emit a warning
+                        // message and continue on to the next spec file. The best we can do to
+                        // fail-safe is report and skip.
+                        Error::ServiceSpecParse(_) | Error::MissingRequiredIdent => {
+                            outputln!(
+                                "Error when loading service spec file '{}' ({}). \
+                                 This file will be skipped.",
+                                spec_file.display(),
+                                e.description()
+                            );
+                            continue;
+                        }
+                        // All other errors are unexpected and should be dealt with up the calling
+                        // stack.
+
+                        // TODO (CM): This is the only way this
+                        // function could fail.
+                        _ => return Err(e),
+                    }
+                }
+            };
+
+            let file_stem = match spec_file.file_stem().and_then(OsStr::to_str) {
+                Some(s) => s,
+                None => {
+                    outputln!(
+                        "Error when loading service spec file '{}' \
+                         (File stem could not be determined). \
+                         This file will be skipped.",
+                        spec_file.display()
+                    );
+                    continue;
+                }
+            };
+
+            if file_stem != &spec.ident.name {
+                outputln!(
+                    "Error when loading service spec file '{}' \
+                     (File name does not match ident name '{}' from ident = \"{}\", \
+                     it should be called '{}.{}'). \
+                     This file will be skipped.",
+                    spec_file.display(),
+                    &spec.ident.name,
+                    &spec.ident,
+                    &spec.ident.name,
+                    SPEC_FILE_EXT
+                );
+                continue;
+            }
+            specs.push(spec);
+        }
+
+        Ok(specs)
+    }
+
+    /// Return the list of all spec files in the directory
+    fn spec_files(&self) -> Vec<PathBuf> {
+        glob(&self.0.join(SPEC_FILE_GLOB).display().to_string())
+            .expect("Invalid spec file glob pattern!")
+            .filter_map(|p| p.ok())
+            .filter(|p| p.is_file())
+            .collect()
+    }
+}

--- a/components/sup/src/manager/spec_watcher.rs
+++ b/components/sup/src/manager/spec_watcher.rs
@@ -12,659 +12,298 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::{HashMap, HashSet};
-use std::error::Error as StdErr;
-use std::ffi::OsStr;
-use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::mpsc::channel;
-use std::sync::Arc;
-use std::thread;
-use std::time::Duration;
+//! Provides facilities for notifying when any spec files have changed
+//! on disk. This is how we know when to start, stop, or restart
+//! services in response to the various `hab svc` commands.
 
-use glob::glob;
-use notify::{RecommendedWatcher, RecursiveMode, Watcher};
+use std::{
+    num::ParseIntError,
+    str::FromStr,
+    sync::mpsc::{channel, Receiver},
+    thread::Builder,
+    time::Duration,
+};
 
+use notify::{DebouncedEvent, RecommendedWatcher, RecursiveMode, Watcher};
+
+use super::spec_dir::SpecDir;
+use config::EnvConfig;
 use error::{Error, Result};
-use manager::service::ServiceSpec;
 
 static LOGKEY: &'static str = "SW";
-const WATCHER_DELAY_MS: u64 = 2_000;
-const SPEC_FILE_EXT: &'static str = "spec";
-const SPEC_FILE_GLOB: &'static str = "*.spec";
 
-#[derive(Debug, PartialEq)]
-pub enum SpecWatcherEvent {
-    AddService(ServiceSpec),
-    RemoveService(ServiceSpec),
+/// How long should we wait to consolidate filesystem events?
+///
+/// This should strike a balance between responsiveness and
+/// too-granular a series of events.
+///
+/// See https://docs.rs/notify/4.0.6/notify/trait.Watcher.html#tymethod.new
+struct SpecWatcherDelay(Duration);
+
+impl From<Duration> for SpecWatcherDelay {
+    fn from(d: Duration) -> SpecWatcherDelay {
+        SpecWatcherDelay(d)
+    }
 }
 
+impl Default for SpecWatcherDelay {
+    fn default() -> Self {
+        // There's nothing particularly magical about 2000ms,
+        // particularly since we're monitoring at such a coarse level
+        // ("something happened in this directory").
+        //
+        // Smaller is probably fine, but you wouldn't want to go much
+        // higher, as this could extend the amount of time you'd need
+        // to wait before realizing you need to take action on a
+        // service.
+        Duration::from_millis(2_000).into()
+    }
+}
+
+impl FromStr for SpecWatcherDelay {
+    type Err = ParseIntError;
+    fn from_str(s: &str) -> ::std::result::Result<Self, Self::Err> {
+        // u16 ~= 65 seconds, which is _more_ than enough
+        let raw = s.parse::<u16>()?;
+        Ok(Duration::from_millis(raw as u64).into())
+    }
+}
+
+impl EnvConfig for SpecWatcherDelay {
+    const ENVVAR: &'static str = "HAB_SPEC_WATCHER_DELAY_MS";
+}
+
+// TODO (CM): A strong argument could be made for folding the
+// SpecWatcher functionality into SpecDir itself.
+
+/// Provides an abstraction layer over filesystem notifications for
+/// spec files.
 pub struct SpecWatcher {
-    watch_path: PathBuf,
-    have_events: Arc<AtomicBool>,
+    // Not actually used; only holding onto it for lifetime / Drop
+    // purposes (`Drop` kills the threads that the watcher spawns to do
+    // its work).
+    _watcher: RecommendedWatcher,
+    channel: Receiver<DebouncedEvent>,
 }
 
 impl SpecWatcher {
-    pub fn run<P>(path: P) -> Result<Self>
-    where
-        P: Into<PathBuf>,
-    {
-        Self::run_with::<RecommendedWatcher, _>(path)
+    /// Start up a separate thread to listen for filesystem
+    /// events.
+    pub fn run(spec_dir: &SpecDir) -> Result<SpecWatcher> {
+        // The act of creating a `notify::Watcher` creates threads on
+        // its own. It does not, however, allow you to set the _names_
+        // of those threads.
+        //
+        // We're creating a SpecWatcher in a thread just so we can get
+        // some control over the name of the threads that the
+        // underlying `notify::Watcher` creates (_that_ is what this
+        // function's documentation is referring to), which makes
+        // monitoring and reasoning about the overall Supervisor
+        // process easier. There's no other reason than that; if the
+        // `notify` crate allowed us to name the threads, we could
+        // just use a slightly modified version of `SpecWatcher::new`
+        // instead.
+
+        // I'd rather not have to do this clone, but it's a side
+        // effect of this thread business. Better to eat it here
+        // rather than at the callsite; having this function take a
+        // reference is the true API we want.
+        let dir = spec_dir.clone();
+
+        Builder::new()
+            .name(String::from("spec-watcher"))
+            .spawn(move || Self::new(&dir))?
+            .join()
+            .map_err(|_| {
+                error!("SpecWatcher spawning thread panicked!");
+                sup_error!(Error::SpecWatcherNotCreated)
+            })?
     }
 
-    pub fn spec_files<T>(watch_path: T) -> Result<Vec<PathBuf>>
-    where
-        T: AsRef<Path>,
-    {
-        Ok(glob(
-            &watch_path
-                .as_ref()
-                .join(SPEC_FILE_GLOB)
-                .display()
-                .to_string(),
-        )?.filter_map(|p| p.ok())
-        .filter(|p| p.is_file())
-        .collect())
-    }
-
-    pub fn initial_events(&mut self) -> Result<Vec<SpecWatcherEvent>> {
-        self.generate_events(HashMap::new())
-    }
-
-    pub fn new_events(
-        &mut self,
-        active_specs: HashMap<String, ServiceSpec>,
-    ) -> Result<Vec<SpecWatcherEvent>> {
-        if self.have_fs_events() {
-            self.generate_events(active_specs)
-        } else {
-            Ok(vec![])
-        }
-    }
-
-    fn run_with<W, P>(path: P) -> Result<Self>
-    where
-        P: Into<PathBuf>,
-        W: Watcher,
-    {
-        let path = path.into();
-        if !path.is_dir() {
-            return Err(sup_error!(Error::SpecWatcherDirNotFound(
-                path.display().to_string()
-            )));
-        }
-        let have_events = Arc::new(AtomicBool::new(false));
-        Self::setup_watcher::<W>(path.clone(), have_events.clone())?;
-
+    /// Isolates the pure creation logic of a `SpecWatcher`, separate
+    /// from the thread-based creation we use in `SpecWatcher::run` to
+    /// get control over the names of the resulting threads. If we
+    /// didn't care what the resulting watcher threads were named,
+    /// we'd just use this directly.
+    fn new(spec_dir: &SpecDir) -> Result<SpecWatcher> {
+        let (tx, rx) = channel();
+        let delay = SpecWatcherDelay::configured_value();
+        let mut watcher = RecommendedWatcher::new(tx, delay.0)?;
+        watcher.watch(spec_dir, RecursiveMode::NonRecursive)?;
         Ok(SpecWatcher {
-            watch_path: path,
-            have_events: have_events,
+            _watcher: watcher,
+            channel: rx,
         })
     }
 
-    fn setup_watcher<W>(watch_path: PathBuf, have_events: Arc<AtomicBool>) -> Result<()>
-    where
-        W: Watcher,
-    {
-        thread::Builder::new()
-            .name(format!("spec-watcher-{}", watch_path.display()))
-            .spawn(move || {
-                debug!("SpecWatcher({}) thread starting", watch_path.display());
-                let (tx, rx) = channel();
-                let mut watcher = match W::new(tx, Duration::from_millis(WATCHER_DELAY_MS)) {
-                    Ok(w) => w,
-                    Err(err) => {
-                        outputln!(
-                            "SpecWatcher({}) could not start notifier, ending thread ({})",
-                            watch_path.display(),
-                            err
-                        );
-                        return;
-                    }
-                };
-                if let Err(err) = watcher.watch(&watch_path, RecursiveMode::NonRecursive) {
-                    outputln!(
-                        "SpecWatcher({}) could not start fs watching, ending thread ({})",
-                        watch_path.display(),
-                        err
-                    );
-                    return;
-                }
-                while let Ok(event) = rx.recv() {
-                    debug!(
-                        "SpecWatcher({}) file system event: {:?}",
-                        watch_path.display(),
-                        event
-                    );
-                    have_events.store(true, Ordering::Relaxed);
-                }
-                outputln!(
-                    "SpecWatcher({}) fs watching died, restarting thread",
-                    watch_path.display()
-                );
-                drop(watcher);
-                Self::setup_watcher::<W>(watch_path.clone(), have_events.clone()).unwrap();
-            })?;
-        Ok(())
-    }
-
-    fn have_fs_events(&mut self) -> bool {
-        self.have_events.load(Ordering::Relaxed)
-    }
-
-    fn generate_events(
-        &mut self,
-        mut active_specs: HashMap<String, ServiceSpec>,
-    ) -> Result<Vec<SpecWatcherEvent>> {
-        let mut desired_specs = self.specs_from_watch_path()?;
-        // Reset the "have events" flag to false, now that we've loaded specs off disk
-        self.have_events.store(false, Ordering::Relaxed);
-        let desired_names: HashSet<_> = desired_specs.keys().map(|n| n.clone()).collect();
-        let active_names: HashSet<_> = active_specs.keys().map(|n| n.clone()).collect();
-
-        let mut events = Vec::new();
-
-        // Eneueue a `RemoveService` for all services that no longer have a spec on disk.
-        for name in active_names.difference(&desired_names) {
-            let remove_spec = active_specs
-                .remove(name)
-                .expect("value should exist for key");
-            let event = SpecWatcherEvent::RemoveService(remove_spec);
-            debug!(
-                "Service spec for {} is gone, enqueuing {:?} event",
-                &name, &event
-            );
-            events.push(event);
+    /// Returns `true` if _any_ filesystem events were detected in the
+    /// watched directory.
+    ///
+    /// We are opting for this coarse granularity because it is
+    /// difficult, if not impossible, to rely on the resulting stream
+    /// of notification events as a 100% complete and accurate record
+    /// of everything that takes place in the specs directory. For
+    /// example, because of how we write files to temporary locations,
+    /// then rename in order to achieve "atomic writes", it is
+    /// possible to miss the events that would cause you to see this
+    /// as a "rename"; instead, you would see a "new" file (even with
+    /// a debounce time of 0 ms!)
+    ///
+    /// In any event, we would _still_ need to examine on-disk state
+    /// of the directory and compare to our in-memory state to know
+    /// exactly what to do in order to reconcile the two (i.e., you
+    /// can't know whether to start, stop, or restart a service just
+    /// by knowing that the spec file changed; you have to actually
+    /// look at the current contents to figure that out).
+    ///
+    /// As a result, we're just using this as a coarse "something
+    /// changed in the directory" signal. We are not filtering events
+    /// to receive only those that affect `*.spec` files, so we may
+    /// respond to modifications to temporary files, or indeed any
+    /// file, within the specs directory (e.g., running `touch
+    /// /hab/sup/default/specs/blahblah` would count as an event). It
+    /// is possible to perform this filtering, of course, but it's not
+    /// clear that the extra code would be worth it.
+    pub fn has_events(&self) -> bool {
+        let events = self.channel.try_iter().collect::<Vec<_>>();
+        if events.is_empty() {
+            false
+        } else {
+            trace!("SpecWatcher events: {:?}", events);
+            true
         }
-
-        // Eneueue an `AddService` for all new specs on disk without a corresponding service.
-        for name in desired_names.difference(&active_names) {
-            let add_spec = desired_specs
-                .remove(name)
-                .expect("value should exist for key");
-            let event = SpecWatcherEvent::AddService(add_spec);
-            debug!(
-                "Service spec for {} is new, enqueuing {:?} event",
-                &name, &event
-            );
-            events.push(event);
-        }
-
-        // Ensure each running service doesn't have a different spec on disk. If a difference is
-        // found we're going to do the simple thing and remove, then add the service. In the future
-        // we should attempt to update a service in-place, if possible.
-        for name in active_names.intersection(&desired_names) {
-            let active_spec = active_specs
-                .remove(name)
-                .expect("value should exist for key");
-            let desired_spec = desired_specs
-                .remove(name)
-                .expect("value should exist for key");
-            if active_spec != desired_spec {
-                let remove_event = SpecWatcherEvent::RemoveService(active_spec);
-                let add_event = SpecWatcherEvent::AddService(desired_spec);
-                debug!(
-                    "Service spec for {} is different on disk than loaded state, \
-                     enqueuing {:?} for existing and {:?} event for updated spec",
-                    &name, &remove_event, &add_event
-                );
-                events.push(remove_event);
-                events.push(add_event);
-            }
-        }
-
-        // Both maps should be empty, meaning we've processed them all
-        assert!(active_specs.is_empty());
-        assert!(desired_specs.is_empty());
-
-        Ok(events)
-    }
-
-    pub fn specs_from_watch_path<'a>(&self) -> Result<HashMap<String, ServiceSpec>> {
-        let mut specs = HashMap::new();
-        for spec_file in Self::spec_files(&self.watch_path)? {
-            let spec = match ServiceSpec::from_file(&spec_file) {
-                Ok(s) => s,
-                Err(e) => {
-                    match e.err {
-                        // If the error is related to loading a `ServiceSpec`, emit a warning
-                        // message and continue on to the next spec file. The best we can do to
-                        // fail-safe is report and skip.
-                        Error::ServiceSpecParse(_) | Error::MissingRequiredIdent => {
-                            outputln!(
-                                "Error when loading service spec file '{}' ({}). \
-                                 This file will be skipped.",
-                                spec_file.display(),
-                                e.description()
-                            );
-                            continue;
-                        }
-                        // All other errors are unexpected and should be dealt with up the calling
-                        // stack.
-                        _ => return Err(e),
-                    }
-                }
-            };
-            let file_stem = match spec_file.file_stem().and_then(OsStr::to_str) {
-                Some(s) => s,
-                None => {
-                    outputln!(
-                        "Error when loading service spec file '{}' \
-                         (File stem could not be determined). \
-                         This file will be skipped.",
-                        spec_file.display()
-                    );
-                    continue;
-                }
-            };
-            if file_stem != &spec.ident.name {
-                outputln!(
-                    "Error when loading service spec file '{}' \
-                     (File name does not match ident name '{}' from ident = \"{}\", \
-                     it should be called '{}.{}'). \
-                     This file will be skipped.",
-                    spec_file.display(),
-                    &spec.ident.name,
-                    &spec.ident,
-                    &spec.ident.name,
-                    SPEC_FILE_EXT
-                );
-                continue;
-            }
-            specs.insert(spec.ident.name.clone(), spec);
-        }
-        Ok(specs)
     }
 }
 
 #[cfg(test)]
-mod test {
-    use std::collections::HashMap;
-    use std::fs;
-    use std::io::Write;
-    use std::path::Path;
-    use std::str::FromStr;
-    use std::sync::mpsc::Sender;
-    use std::thread;
-    use std::time::{Duration, Instant};
-
-    use hcore::package::PackageIdent;
-    use notify;
+mod tests {
+    use super::*;
+    use std::{
+        fs::File,
+        io::{Error as IoError, Write},
+        result::Result as StdResult,
+        thread,
+    };
     use tempfile::TempDir;
 
-    use super::{SpecWatcher, SpecWatcherEvent};
-    use error::Error::*;
-    use manager::service::ServiceSpec;
+    locked_env_var!(HAB_SPEC_WATCHER_DELAY_MS, lock_delay_var);
 
-    #[test]
-    fn run_watch_dir_not_created() {
-        let tmpdir = TempDir::new().unwrap();
-        let not_a_dir = tmpdir.path().join("i-dont-exist");
+    fn file_with_content<C>(dir: &TempDir, filename: &str, contents: C) -> StdResult<(), IoError>
+    where
+        C: Into<String>,
+    {
+        let path = dir.path().join(filename);
+        let mut buffer = File::create(&path)?;
+        buffer.write_all(contents.into().as_bytes())
+    }
 
-        match SpecWatcher::run(&not_a_dir) {
-            Err(e) => match e.err {
-                SpecWatcherDirNotFound(dir) => assert_eq!(dir, not_a_dir.display().to_string()),
-                wrong => panic!("Unexpected error returned: {:?}", wrong),
-            },
-            Ok(_) => panic!("Watcher should fail to run"),
-        }
+    /// Sleep for the currently-configured debounce interval, plus a
+    /// few milliseconds more, just to be certain our filesystem
+    /// events have had plenty of time to process.
+    fn wait_for_debounce_interval() {
+        thread::sleep(SpecWatcherDelay::configured_value().0 + Duration::from_millis(2));
     }
 
     #[test]
-    fn run_with_notify_error() {
-        let tmpdir = TempDir::new().unwrap();
-        let path = tmpdir.path().join("throw_error");
-        fs::create_dir(&path).unwrap();
+    fn can_be_created() {
+        let _delay = lock_delay_var();
 
-        match SpecWatcher::run_with::<TestWatcher, _>(&path) {
-            Ok(_) => assert!(true),
-            Err(e) => panic!("This should not fail: {:?}", e.err),
-        }
-    }
-
-    #[test]
-    fn inital_events() {
-        let tmpdir = TempDir::new().unwrap();
-        let alpha = new_saved_spec(tmpdir.path(), "acme/alpha");
-        let beta = new_saved_spec(tmpdir.path(), "acme/beta");
-        let mut watcher = SpecWatcher::run(tmpdir.path()).unwrap();
-
-        let events = watcher.initial_events().unwrap();
-
-        assert_eq!(2, events.len());
-        assert!(events.contains(&SpecWatcherEvent::AddService(alpha)));
-        assert!(events.contains(&SpecWatcherEvent::AddService(beta)));
-    }
-
-    #[test]
-    fn inital_events_no_specs() {
-        let tmpdir = TempDir::new().unwrap();
-        let mut watcher = SpecWatcher::run(tmpdir.path()).unwrap();
-
-        let events = watcher.initial_events().unwrap();
-
-        assert_eq!(events, vec![]);
-    }
-
-    #[test]
-    fn new_events_no_change_with_no_active_specs() {
-        let tmpdir = TempDir::new().unwrap();
-        let path = tmpdir.path().join("no_events");
-        fs::create_dir(&path).unwrap();
-
-        let active_specs = map_for_specs(vec![]);
-        let mut watcher = SpecWatcher::run_with::<TestWatcher, _>(&path).unwrap();
-        let events = watcher.new_events(active_specs).unwrap();
-
-        assert_eq!(events, vec![]);
-    }
-
-    #[test]
-    fn new_events_no_change_with_active_specs() {
-        let tmpdir = TempDir::new().unwrap();
-        let path = tmpdir.path().join("no_events");
-        fs::create_dir(&path).unwrap();
-        new_saved_spec(&path, "acme/alpha");
-        new_saved_spec(&path, "acme/beta");
-
-        let active_specs = map_for_specs(vec!["acme/alpha", "acme/beta"]);
-        let mut watcher = SpecWatcher::run_with::<TestWatcher, _>(&path).unwrap();
-        let events = watcher.new_events(active_specs).unwrap();
-
-        assert_eq!(events, vec![]);
-    }
-
-    #[test]
-    fn new_events_new_spec_with_no_active_specs() {
-        let tmpdir = TempDir::new().unwrap();
-        let path = tmpdir.path().join("new_spec");
-        fs::create_dir(&path).unwrap();
-        let newbie = new_spec("acme/newbie");
-
-        let active_specs = map_for_specs(vec![]);
-        let mut watcher = SpecWatcher::run_with::<TestWatcher, _>(&path).unwrap();
-        let events = waiting_for_new_events(&mut watcher, active_specs);
-
-        assert_eq!(1, events.len());
-        assert!(events.contains(&SpecWatcherEvent::AddService(newbie)));
-    }
-
-    #[test]
-    fn new_events_new_spec_with_active_specs() {
-        let tmpdir = TempDir::new().unwrap();
-        let path = tmpdir.path().join("new_spec");
-        fs::create_dir(&path).unwrap();
-        new_saved_spec(&path, "acme/alpha");
-        new_saved_spec(&path, "acme/beta");
-        let newbie = new_spec("acme/newbie");
-
-        let active_specs = map_for_specs(vec!["acme/alpha", "acme/beta"]);
-        let mut watcher = SpecWatcher::run_with::<TestWatcher, _>(&path).unwrap();
-        let events = waiting_for_new_events(&mut watcher, active_specs);
-
-        assert_eq!(1, events.len());
-        assert!(events.contains(&SpecWatcherEvent::AddService(newbie)));
-    }
-
-    #[test]
-    fn new_events_removed_spec_with_active_specs() {
-        let tmpdir = TempDir::new().unwrap();
-        let path = tmpdir.path().join("removed_spec");
-        fs::create_dir(&path).unwrap();
-        new_saved_spec(&path, "acme/alpha");
-        new_saved_spec(&path, "acme/beta");
-        let oldie = new_saved_spec(&path, "acme/oldie");
-
-        let active_specs = map_for_specs(vec!["acme/alpha", "acme/beta", "acme/oldie"]);
-        let mut watcher = SpecWatcher::run_with::<TestWatcher, _>(&path).unwrap();
-        let events = waiting_for_new_events(&mut watcher, active_specs);
-
-        assert_eq!(1, events.len());
-        assert!(events.contains(&SpecWatcherEvent::RemoveService(oldie)));
-    }
-
-    #[test]
-    fn new_events_add_and_removed_spec_with_active_specs() {
-        let tmpdir = TempDir::new().unwrap();
-        let path = tmpdir.path().join("new_and_removed_spec");
-        fs::create_dir(&path).unwrap();
-        new_saved_spec(&path, "acme/alpha");
-        new_saved_spec(&path, "acme/beta");
-        let oldie = new_saved_spec(&path, "acme/oldie");
-        let newbie = new_spec("acme/newbie");
-
-        let active_specs = map_for_specs(vec!["acme/alpha", "acme/beta", "acme/oldie"]);
-        let mut watcher = SpecWatcher::run_with::<TestWatcher, _>(&path).unwrap();
-        let events = waiting_for_new_events(&mut watcher, active_specs);
-
-        assert_eq!(2, events.len());
-        assert!(events.contains(&SpecWatcherEvent::RemoveService(oldie)));
-        assert!(events.contains(&SpecWatcherEvent::AddService(newbie)));
-    }
-
-    #[test]
-    fn new_events_changed_spec_with_active_specs() {
-        let tmpdir = TempDir::new().unwrap();
-        let path = tmpdir.path().join("changed_spec");
-        fs::create_dir(&path).unwrap();
-        new_saved_spec(&path, "acme/alpha");
-        new_saved_spec(&path, "acme/beta");
-        let transformer_before = new_saved_spec(&path, "acme/transformer");
-        let mut transformer_after = new_spec("acme/transformer");
-        transformer_after.group = String::from("autobots");
-
-        let active_specs = map_for_specs(vec!["acme/alpha", "acme/beta", "acme/transformer"]);
-        let mut watcher = SpecWatcher::run_with::<TestWatcher, _>(&path).unwrap();
-        let events = waiting_for_new_events(&mut watcher, active_specs);
-
-        assert_eq!(2, events.len());
-        assert_eq!(
-            events[0],
-            SpecWatcherEvent::RemoveService(transformer_before)
+        let dir = TempDir::new().expect("Could not create directory");
+        let spec_dir = SpecDir::new(dir.path()).expect("Couldn't make SpecDir");
+        assert!(
+            SpecWatcher::run(&spec_dir).is_ok(),
+            "Couldn't create a SpecWatcher!"
         );
-        assert_eq!(events[1], SpecWatcherEvent::AddService(transformer_after));
     }
 
     #[test]
-    fn new_events_crazytown_with_active_specs() {
-        let tmpdir = TempDir::new().unwrap();
-        let path = tmpdir.path().join("crazytown");
-        fs::create_dir(&path).unwrap();
-        new_saved_spec(&path, "acme/alpha");
-        new_saved_spec(&path, "acme/beta");
-        let oldie = new_saved_spec(&path, "acme/oldie");
-        let newbie = new_spec("acme/newbie");
-        let transformer_before = new_saved_spec(&path, "acme/transformer");
-        let mut transformer_after = new_spec("acme/transformer");
-        transformer_after.group = String::from("autobots");
+    fn can_get_events_for_spec_files() {
+        let _delay = lock_delay_var();
 
-        let active_specs = map_for_specs(vec![
-            "acme/alpha",
-            "acme/beta",
-            "acme/oldie",
-            "acme/transformer",
-        ]);
-        let mut watcher = SpecWatcher::run_with::<TestWatcher, _>(&path).unwrap();
-        let events = waiting_for_new_events(&mut watcher, active_specs);
+        let dir = TempDir::new().expect("Could not create directory");
+        let spec_dir = SpecDir::new(dir.path()).expect("Couldn't make SpecDir");
+        let sw = SpecWatcher::run(&spec_dir).expect("Couldn't create a SpecWatcher!");
 
-        assert_eq!(4, events.len());
-        assert!(events.contains(&SpecWatcherEvent::RemoveService(oldie)));
-        assert!(events.contains(&SpecWatcherEvent::AddService(newbie)));
-        assert!(events.contains(&SpecWatcherEvent::RemoveService(transformer_before),));
-        assert!(events.contains(&SpecWatcherEvent::AddService(transformer_after),));
+        assert!(!sw.has_events(), "There should be no events to start");
+
+        file_with_content(&dir, "foo.spec", "fooooooo").expect("couldn't create file");
+
+        assert!(
+            !sw.has_events(),
+            "Need to allow for the debounce interval to pass before you can expect events"
+        );
+
+        wait_for_debounce_interval();
+
+        assert!(sw.has_events(), "There should be an event now");
+        assert!(
+            !sw.has_events(),
+            "Should be no more events after you've checked"
+        );
+    }
+
+    /// Currently, the spec watcher will respond to changes to any
+    /// file in the directory, whether it's a `*.spec` file or not.
+    ///
+    /// This would, for instance, pick up the temp files that
+    /// operations like `hab svc stop` lay down before renaming them
+    /// to their final `*.spec` form.
+    #[test]
+    fn can_get_events_for_non_spec_files() {
+        let _delay = lock_delay_var();
+
+        let dir = TempDir::new().expect("Could not create directory");
+        let spec_dir = SpecDir::new(dir.path()).expect("Couldn't make SpecDir");
+        let sw = SpecWatcher::run(&spec_dir).expect("Couldn't create a SpecWatcher!");
+
+        assert!(!sw.has_events(), "There should be no events to start");
+
+        file_with_content(&dir, "foo.abc123xyz", "fooooooo").expect("couldn't create file");
+
+        assert!(
+            !sw.has_events(),
+            "Need to allow for the debounce interval to pass before you can expect events"
+        );
+
+        wait_for_debounce_interval();
+
+        assert!(sw.has_events(), "There should be an event now");
+        assert!(
+            !sw.has_events(),
+            "Should be no more events after you've checked"
+        );
     }
 
     #[test]
-    fn loading_spec_missing_ident_doesnt_impact_others() {
-        let tmpdir = TempDir::new().unwrap();
-        let alpha = new_saved_spec(tmpdir.path(), "acme/alpha");
-        fs::File::create(tmpdir.path().join(format!("beta.spec"))).expect("can't create file");
+    fn short_debounce_delays_also_work() {
+        let delay = lock_delay_var();
+        delay.set("1");
 
-        let mut watcher = SpecWatcher::run(tmpdir.path()).unwrap();
+        // Just verifying that our delay variable works correctly
+        assert_eq!(
+            SpecWatcherDelay::configured_value().0,
+            Duration::from_millis(1)
+        );
 
-        let events = watcher.initial_events().unwrap();
+        let dir = TempDir::new().expect("Could not create directory");
+        let spec_dir = SpecDir::new(dir.path()).expect("Couldn't make SpecDir");
+        let sw = SpecWatcher::run(&spec_dir).expect("Couldn't create a SpecWatcher!");
 
-        assert_eq!(1, events.len());
-        assert!(events.contains(&SpecWatcherEvent::AddService(alpha)));
-    }
+        assert!(!sw.has_events(), "There should be no events to start");
 
-    #[test]
-    fn loading_spec_bad_content_doesnt_impact_others() {
-        let tmpdir = TempDir::new().unwrap();
-        let alpha = new_saved_spec(tmpdir.path(), "acme/alpha");
-        {
-            let mut bad = fs::File::create(tmpdir.path().join(format!("beta.spec")))
-                .expect("can't create file");
-            bad.write_all(
-                r#"ident = "acme/beta"
-                          I am a bad bad file."#
-                    .as_bytes(),
-            ).expect("can't write file content");
-        }
+        file_with_content(&dir, "foo.spec", "fooooooo").expect("couldn't create file");
 
-        let mut watcher = SpecWatcher::run(tmpdir.path()).unwrap();
+        assert!(
+            !sw.has_events(),
+            "Need to allow for the debounce interval to pass before you can expect events"
+        );
 
-        let events = watcher.initial_events().unwrap();
+        wait_for_debounce_interval();
 
-        assert_eq!(1, events.len());
-        assert!(events.contains(&SpecWatcherEvent::AddService(alpha)));
-    }
-
-    #[test]
-    fn loading_spec_ident_name_mismatch_doesnt_impact_others() {
-        let tmpdir = TempDir::new().unwrap();
-        let alpha = new_saved_spec(tmpdir.path(), "acme/alpha");
-        {
-            let mut bad = fs::File::create(tmpdir.path().join(format!("beta.spec")))
-                .expect("can't create file");
-            bad.write_all(r#"ident = "acme/NEAL_MORSE_BAND""#.as_bytes())
-                .expect("can't write file content");
-        }
-
-        let mut watcher = SpecWatcher::run(tmpdir.path()).unwrap();
-
-        let events = watcher.initial_events().unwrap();
-
-        assert_eq!(1, events.len());
-        assert!(events.contains(&SpecWatcherEvent::AddService(alpha)));
-    }
-
-    struct TestWatcher {
-        tx: Sender<notify::DebouncedEvent>,
-    }
-
-    impl TestWatcher {
-        fn behavior_new_spec<P: AsRef<Path>>(&mut self, path: P) {
-            new_saved_spec(path.as_ref(), "acme/newbie");
-            self.tx
-                .send(notify::DebouncedEvent::Write(
-                    path.as_ref().join("newbie.spec"),
-                )).expect("couldn't send event");
-        }
-
-        fn behavior_removed_spec<P: AsRef<Path>>(&mut self, path: P) {
-            let toml_path = path.as_ref().join("oldie.spec");
-            fs::remove_file(&toml_path).expect("couldn't delete spec toml");
-            self.tx
-                .send(notify::DebouncedEvent::Remove(toml_path))
-                .expect("couldn't send event");
-        }
-
-        fn behavior_changed_spec<P: AsRef<Path>>(&mut self, path: P) {
-            let toml_path = path.as_ref().join("transformer.spec");
-            let mut spec = ServiceSpec::from_file(&toml_path).expect("couldn't load spec file");
-            spec.group = String::from("autobots");
-            spec.to_file(&toml_path).expect("couldn't write spec file");
-            self.tx
-                .send(notify::DebouncedEvent::Write(toml_path))
-                .expect("couldn't send event");
-        }
-    }
-
-    impl notify::Watcher for TestWatcher {
-        fn new(tx: Sender<notify::DebouncedEvent>, _delay: Duration) -> notify::Result<Self> {
-            Ok(TestWatcher { tx: tx })
-        }
-
-        fn watch<P: AsRef<Path>>(
-            &mut self,
-            path: P,
-            _recursive_mode: notify::RecursiveMode,
-        ) -> notify::Result<()> {
-            let behavior = path
-                .as_ref()
-                .file_name()
-                .expect("file name is ..")
-                .to_str()
-                .expect("path isn't utf-8 valid");
-
-            match behavior {
-                "no_events" => {}
-                "new_spec" => self.behavior_new_spec(path.as_ref()),
-                "removed_spec" => self.behavior_removed_spec(path.as_ref()),
-                "new_and_removed_spec" => {
-                    self.behavior_new_spec(path.as_ref());
-                    self.behavior_removed_spec(path.as_ref());
-                }
-                "changed_spec" => self.behavior_changed_spec(path.as_ref()),
-                "crazytown" => {
-                    self.behavior_changed_spec(path.as_ref());
-                    self.behavior_new_spec(path.as_ref());
-                    self.behavior_removed_spec(path.as_ref());
-                }
-                "throw_error" => {
-                    return Err(notify::Error::Generic(String::from("we failed you, noes!")));
-                }
-                unknown => panic!("unknown fixture behavior: {}", unknown),
-            }
-
-            Ok(())
-        }
-
-        fn new_raw(_tx: Sender<notify::RawEvent>) -> notify::Result<Self> {
-            unimplemented!()
-        }
-
-        fn unwatch<P: AsRef<Path>>(&mut self, _path: P) -> notify::Result<()> {
-            unimplemented!()
-        }
-    }
-
-    fn new_spec(ident: &str) -> ServiceSpec {
-        ServiceSpec::default_for(PackageIdent::from_str(ident).expect("couldn't parse ident str"))
-    }
-
-    fn new_saved_spec(tmpdir: &Path, ident: &str) -> ServiceSpec {
-        let spec = new_spec(ident);
-        spec.to_file(tmpdir.join(format!("{}.spec", &spec.ident.name)))
-            .expect("couldn't save spec to disk");
-        spec
-    }
-
-    fn map_for_specs(idents: Vec<&str>) -> HashMap<String, ServiceSpec> {
-        let mut map = HashMap::new();
-        for ident in idents {
-            let spec = ServiceSpec::default_for(
-                PackageIdent::from_str(ident).expect("couldn't parse ident str"),
-            );
-            map.insert(spec.ident.name.clone(), spec);
-        }
-        map
-    }
-
-    fn waiting_for_new_events(
-        watcher: &mut SpecWatcher,
-        active_specs: HashMap<String, ServiceSpec>,
-    ) -> Vec<SpecWatcherEvent> {
-        let start = Instant::now();
-        let timeout = Duration::from_millis(1000);
-        while start.elapsed() < timeout {
-            let events = watcher.new_events(active_specs.clone()).unwrap();
-            if !events.is_empty() {
-                return events;
-            }
-            thread::sleep(Duration::from_millis(1));
-        }
-        panic!("Waited for events but found none");
+        assert!(sw.has_events(), "There should be an event now");
+        assert!(
+            !sw.has_events(),
+            "Should be no more events after you've checked"
+        );
     }
 }


### PR DESCRIPTION
This attempts to simplify and streamline the functionality around
keeping the running services in agreement with the specs that define
them on disk.

An important component of this is pulling the logic that determines
what should start, stop, and restart out of the SpecWatcher itself,
and into the Manager. Here, the distinction is not incredibly
important, but it will become important as we make more operations
asynchronous, and need to be aware of which services may be in the
process of, say, shutting down for a restart so that we do not try to
start them again too soon.

This "reconciliation" logic was also extracted into a pure function
for ease of testability.

We also introduce a new `SpecDir` type to model the spec directory
itself, as well as operations on it and the files within. Previously,
this functionality was split between the `SpecWatcher` and the
`Manager`. In particular, this obscured some of the core logic carried
out by the `SpecWatcher`.

The overall structure of the `SpecWatcher` was also simplified, and
removes an extra thread; there were three, now there are two. Two are
from the underlying `notify` crate, while the extra one was one of our
own creation that turned out to not be strictly necessary. Rather than
keeping a thread around to poll the notifier thread and store the
result in an atomic boolean, now we just keep ownership of the other
side of the notification channel and ask it if it has any events.