### PR TITLE
Add testing exclusions for Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,20 @@ cache:
   - c:\cargo\git
   - c:\projects\habitat\target
 
+skip_commits:
+  # version bumps by Expeditor happen as a separate commit after the merge, we can skip
+  author: Chef Expeditor
+  # if ONLY the files listed below are changed in a commit, skip
+  files:
+    - BUILDING.MD
+    - MAINTAINERS.md
+    - CHANGELOG.md
+    - RELEASE.md
+    - maintenance-policy.md
+    - UX_PRINCIPLES.md
+    - CONTRIBUTING.md
+    - CODE_OF_CONDUCT.md
+
 branches:
   only:
     - master


### PR DESCRIPTION
Habitat builds are taking up all the available Appveyor slots for Chef
Inc. This adds a similar change to Habitat that we've added to our Chef
projects to conserve available slots. Otherwise we're going to need to
move Habitat to its own account.

Signed-off-by: Tim Smith <tsmith@chef.io>