### PR TITLE
Remove deprecated error message

### DIFF
--- a/components/common/src/command/package/install.rs
+++ b/components/common/src/command/package/install.rs
@@ -571,11 +571,7 @@ impl<'a> InstallTask<'a> {
                             local.as_ref(),
                             &ident,
                         ))?;
-                        Err(Error::PackageNotFound(
-                            "If you are attempting to install from a local depot with an upstream \
-                             configured, try again in a few seconds."
-                                .to_string(),
-                        ))
+                        Err(Error::PackageNotFound("".to_string()))
                     } else {
                         ui.status(
                             Status::Missing,
@@ -593,11 +589,7 @@ impl<'a> InstallTask<'a> {
                 (Err(_), Some(remote)) => Ok(remote),
                 (Err(_), None) => {
                     self.recommend_channels(ui, &ident, target, token)?;
-                    Err(Error::PackageNotFound(
-                        "If you are attempting to install from a local depot with an upstream \
-                         configured, try again in a few seconds."
-                            .to_string(),
-                    ))
+                    Err(Error::PackageNotFound("".to_string()))
                 }
             }
         }


### PR DESCRIPTION
Since we deprecated the trickle-in upstream design, we need to remove the related error message from the hab cli.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-177171914](https://user-images.githubusercontent.com/13542112/49399739-fbb30000-f6f6-11e8-90ac-a563cd4df33a.gif)
