### PR TITLE
Move env var and default value to clap layer for listen http

### DIFF
--- a/components/common/src/defaults.rs
+++ b/components/common/src/defaults.rs
@@ -14,9 +14,8 @@
 
 //! This file contains the string defaults values as well as environment variable strings
 //! for use in the clap layer of the application. This is not the final form for defaults.
-//! Eventually this will likely reside in it's own crate and be composed of fully typed
-//! default values. But as a first step we need a spot to consolidate those values and help simplify
-//! some of the logic around them.
+//! Eventually this will be composed of fully typed default values. But as a first step we
+//! need a spot to consolidate those values and help simplify some of the logic around them.
 
 pub const GOSSIP_DEFAULT_IP: &'static str = "0.0.0.0";
 pub const GOSSIP_DEFAULT_PORT: u16 = 9638;

--- a/components/common/src/lib.rs
+++ b/components/common/src/lib.rs
@@ -22,7 +22,6 @@ extern crate habitat_core as hcore;
 extern crate hyper;
 #[macro_use]
 extern crate log;
-#[cfg(test)]
 #[macro_use]
 extern crate lazy_static;
 extern crate pbr;
@@ -40,6 +39,7 @@ extern crate winapi;
 pub use self::error::{Error, Result};
 
 pub mod command;
+pub mod defaults;
 pub mod error;
 pub mod locked_env_var;
 pub mod package_graph;

--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -25,7 +25,7 @@ use protocol;
 use url::Url;
 
 use command::studio;
-use default_values::{
+use common::defaults::{
     GOSSIP_DEFAULT_ADDR, GOSSIP_LISTEN_ADDRESS_ENVVAR, LISTEN_HTTP_ADDRESS_ENVVAR,
     LISTEN_HTTP_DEFAULT_ADDR, RING_ENVVAR, RING_KEY_ENVVAR,
 };

--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -26,7 +26,8 @@ use url::Url;
 
 use command::studio;
 use default_values::{
-    GOSSIP_DEFAULT_ADDR, GOSSIP_LISTEN_ADDRESS_ENVVAR, RING_ENVVAR, RING_KEY_ENVVAR,
+    GOSSIP_DEFAULT_ADDR, GOSSIP_LISTEN_ADDRESS_ENVVAR, LISTEN_HTTP_ADDRESS_ENVVAR,
+    LISTEN_HTTP_DEFAULT_ADDR, RING_ENVVAR, RING_KEY_ENVVAR,
 };
 use feat;
 
@@ -862,9 +863,8 @@ pub fn sub_sup_run() -> App<'static, 'static> {
         (usage: "hab sup run [FLAGS] [OPTIONS] [--] [PKG_IDENT_OR_ARTIFACT]")
               (@arg LISTEN_GOSSIP: --("listen-gossip") env(GOSSIP_LISTEN_ADDRESS_ENVVAR) default_value(&GOSSIP_DEFAULT_ADDR) {valid_socket_addr}
             "The listen address for the Gossip System Gateway.")
-        (@arg LISTEN_HTTP: --("listen-http") +takes_value {valid_socket_addr}
-            "The listen address for the HTTP Gateway. If not specified, the value will \
-            be taken from the HAB_LISTEN_HTTP environment variable if defined. [default: 0.0.0.0:9631]")
+        (@arg LISTEN_HTTP: --("listen-http") env(LISTEN_HTTP_ADDRESS_ENVVAR) default_value(&LISTEN_HTTP_DEFAULT_ADDR) {valid_socket_addr}
+            "The listen address for the HTTP Gateway.")
         (@arg HTTP_DISABLE: --("http-disable") -D
             "Disable the HTTP Gateway completely [default: false]")
         (@arg LISTEN_CTL: --("listen-ctl") +takes_value {valid_socket_addr}

--- a/components/hab/src/default_values.rs
+++ b/components/hab/src/default_values.rs
@@ -27,3 +27,11 @@ lazy_static! {
 pub const GOSSIP_LISTEN_ADDRESS_ENVVAR: &'static str = "HAB_LISTEN_GOSSIP";
 pub const RING_ENVVAR: &'static str = "HAB_RING";
 pub const RING_KEY_ENVVAR: &'static str = "HAB_RING_KEY";
+
+pub const LISTEN_HTTP_DEFAULT_PORT: u16 = 9631;
+pub const LISTEN_HTTP_DEFAULT_IP: &'static str = "0.0.0.0";
+lazy_static! {
+    pub static ref LISTEN_HTTP_DEFAULT_ADDR: String =
+        { format!("{}:{}", LISTEN_HTTP_DEFAULT_IP, LISTEN_HTTP_DEFAULT_PORT) };
+}
+pub const LISTEN_HTTP_ADDRESS_ENVVAR: &'static str = "HAB_LISTEN_HTTP";

--- a/components/hab/src/lib.rs
+++ b/components/hab/src/lib.rs
@@ -37,8 +37,6 @@ extern crate features;
 extern crate flate2;
 extern crate hyper;
 #[macro_use]
-extern crate lazy_static;
-#[macro_use]
 extern crate log;
 extern crate pbr;
 extern crate retry;
@@ -66,7 +64,6 @@ pub mod analytics;
 pub mod cli;
 pub mod command;
 pub mod config;
-pub mod default_values;
 pub mod error;
 mod exec;
 pub mod scaffolding;

--- a/components/sup/src/config.rs
+++ b/components/sup/src/config.rs
@@ -29,8 +29,8 @@ use std::option;
 use std::result;
 use std::str::FromStr;
 
+use common::defaults::{GOSSIP_DEFAULT_IP, GOSSIP_DEFAULT_PORT, GOSSIP_LISTEN_ADDRESS_ENVVAR};
 use error::{Result, SupError};
-use hab::default_values::{GOSSIP_DEFAULT_IP, GOSSIP_DEFAULT_PORT, GOSSIP_LISTEN_ADDRESS_ENVVAR};
 use hcore::env as henv;
 
 /// Enable the creation of a value based on an environment variable

--- a/components/sup/src/http_gateway.rs
+++ b/components/sup/src/http_gateway.rs
@@ -31,11 +31,11 @@ use actix_web::{
     pred::Predicate,
     server, App, FromRequest, HttpRequest, HttpResponse, Path, Request,
 };
-use config::EnvConfig;
-use crypto;
-use hab::default_values::{
+use common::defaults::{
     LISTEN_HTTP_ADDRESS_ENVVAR, LISTEN_HTTP_DEFAULT_IP, LISTEN_HTTP_DEFAULT_PORT,
 };
+use config::EnvConfig;
+use crypto;
 use hcore::{env as henv, service::ServiceGroup};
 use rustls::ServerConfig;
 use serde_json::{self, Value as Json};

--- a/components/sup/src/http_gateway.rs
+++ b/components/sup/src/http_gateway.rs
@@ -16,7 +16,7 @@ use std::{
     fmt,
     fs::File,
     io::{self, Read},
-    net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4, ToSocketAddrs},
+    net::{IpAddr, SocketAddr, SocketAddrV4, ToSocketAddrs},
     ops::{Deref, DerefMut},
     option, result,
     str::FromStr,
@@ -31,29 +31,28 @@ use actix_web::{
     pred::Predicate,
     server, App, FromRequest, HttpRequest, HttpResponse, Path, Request,
 };
+use config::EnvConfig;
 use crypto;
+use hab::default_values::{
+    LISTEN_HTTP_ADDRESS_ENVVAR, LISTEN_HTTP_DEFAULT_IP, LISTEN_HTTP_DEFAULT_PORT,
+};
 use hcore::{env as henv, service::ServiceGroup};
-use protocol::socket_addr_env_or_default;
 use rustls::ServerConfig;
 use serde_json::{self, Value as Json};
 
-use error::{Error, Result, SupError};
+use error::{Result, SupError};
 use manager;
 use manager::service::hooks::{self, HealthCheckHook};
 use manager::service::HealthCheck;
 
 use feat;
 
-static LOGKEY: &'static str = "HG";
 const APIDOCS: &'static str = include_str!(concat!(env!("OUT_DIR"), "/api.html"));
 pub const HTTP_THREADS_ENVVAR: &'static str = "HAB_SUP_HTTP_THREADS";
 pub const HTTP_THREAD_COUNT: usize = 2;
 
 /// Default listening port for the HTTPGateway listener.
 pub const DEFAULT_PORT: u16 = 9631;
-
-/// Default environment variable override for HTTPGateway listener address.
-pub const DEFAULT_ADDRESS_ENVVAR: &'static str = "HAB_LISTEN_HTTP";
 
 #[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ListenAddr(SocketAddr);
@@ -66,11 +65,17 @@ impl ListenAddr {
 
 impl Default for ListenAddr {
     fn default() -> ListenAddr {
-        ListenAddr(socket_addr_env_or_default(
-            DEFAULT_ADDRESS_ENVVAR,
-            SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(0, 0, 0, 0), DEFAULT_PORT)),
-        ))
+        ListenAddr(SocketAddr::V4(SocketAddrV4::new(
+            LISTEN_HTTP_DEFAULT_IP
+                .parse()
+                .expect("LISTEN_HTTP_DEFAULT_IP can not be parsed."),
+            LISTEN_HTTP_DEFAULT_PORT,
+        )))
     }
+}
+
+impl EnvConfig for ListenAddr {
+    const ENVVAR: &'static str = LISTEN_HTTP_ADDRESS_ENVVAR;
 }
 
 impl Deref for ListenAddr {
@@ -91,17 +96,7 @@ impl FromStr for ListenAddr {
     type Err = SupError;
 
     fn from_str(val: &str) -> Result<Self> {
-        match SocketAddr::from_str(val) {
-            Ok(addr) => Ok(ListenAddr(addr)),
-            Err(_) => match IpAddr::from_str(val) {
-                Ok(ip) => {
-                    let mut addr = ListenAddr::default();
-                    addr.set_ip(ip);
-                    Ok(addr)
-                }
-                Err(_) => Err(sup_error!(Error::IPFailed)),
-            },
-        }
+        Ok(ListenAddr(SocketAddr::from_str(val)?))
     }
 }
 

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -225,12 +225,12 @@ fn mgrcfg_from_matches(m: &ArgMatches) -> Result<ManagerConfig> {
             m.value_of("LISTEN_GOSSIP")
                 .expect("LISTEN_GOSSIP should always have a value."),
         )?,
+        http_listen: http_gateway::ListenAddr::from_str(
+            m.value_of("LISTEN_HTTP")
+                .expect("LISTEN_HTTP should always have a value"),
+        )?,
         ..Default::default()
     };
-
-    if let Some(addr_str) = m.value_of("LISTEN_HTTP") {
-        cfg.http_listen = http_gateway::ListenAddr::from_str(addr_str)?;
-    }
 
     if let Some(addr_str) = m.value_of("LISTEN_CTL") {
         cfg.ctl_listen = SocketAddr::from_str(addr_str)?;

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -62,7 +62,7 @@ use protocol::{
     types::{ApplicationEnvironment, BindingMode, ServiceBind, Topology, UpdateStrategy},
 };
 
-use hab::default_values::GOSSIP_DEFAULT_PORT;
+use common::defaults::GOSSIP_DEFAULT_PORT;
 use sup::cli::cli;
 use sup::command;
 use sup::config::GossipListenAddr;

--- a/components/sup/src/manager/peer_watcher.rs
+++ b/components/sup/src/manager/peer_watcher.rs
@@ -21,8 +21,8 @@ use std::sync::Arc;
 use std::thread::Builder as ThreadBuilder;
 
 use butterfly::member::Member;
+use common::defaults::GOSSIP_DEFAULT_PORT;
 use error::{Error, Result};
-use hab::default_values::GOSSIP_DEFAULT_PORT;
 use manager::file_watcher::{default_file_watcher, Callbacks};
 
 static LOGKEY: &'static str = "PW";
@@ -163,7 +163,7 @@ impl PeerWatcher {
 mod tests {
     use super::PeerWatcher;
     use butterfly::member::Member;
-    use hab::default_values::GOSSIP_DEFAULT_PORT;
+    use common::defaults::GOSSIP_DEFAULT_PORT;
     use std::fs::{File, OpenOptions};
     use std::io::Write;
     use tempfile::TempDir;


### PR DESCRIPTION
Moves env var and default value handling to the clap layer for listen http. This is a continuation of the work started in https://github.com/habitat-sh/habitat/pull/5884