### PR TITLE
Add --reverse option to hab pkg dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,6 +227,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "bimap"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "bincode"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1026,6 +1031,7 @@ name = "habitat_common"
 version = "0.0.0"
 dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bimap 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy 0.0.302 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat_api_client 0.0.0",
@@ -3444,6 +3450,7 @@ dependencies = [
 "checksum backtrace-sys 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)" = "c66d56ac8dabd07f6aacdaf633f4b8262f5b3601a810a0dcddffd5c22c69daa0"
 "checksum base64 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "621fc7ecb8008f86d7fb9b95356cd692ce9514b80a86d85b397f32a22da7b9e2"
 "checksum base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
+"checksum bimap 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6b282b982237078bfac61a948a2198f185aceea8b9a6e794b70b96fd31923d3d"
 "checksum bincode 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9a6301db0b49fb63551bc15b5ae348147101cdf323242b93ec7546d5002ff1af"
 "checksum bincode 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9f2fb9e29e72fd6bc12071533d5dc7664cb01480c59406f656d7ac25c7bd8ff7"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"

--- a/components/common/Cargo.toml
+++ b/components/common/Cargo.toml
@@ -7,6 +7,7 @@ workspace = "../../"
 [dependencies]
 clippy = {version = "*", optional = true}
 ansi_term = "*"
+bimap = "*"
 glob = "*"
 # Pending upgrade activities in https://github.com/habitat-sh/core/issues/72
 hyper = "0.10"

--- a/components/common/src/lib.rs
+++ b/components/common/src/lib.rs
@@ -16,6 +16,7 @@
 #![cfg_attr(feature = "clippy", plugin(clippy))]
 
 extern crate ansi_term;
+extern crate bimap;
 extern crate glob;
 extern crate habitat_api_client as api_client;
 extern crate habitat_core as hcore;

--- a/components/common/src/package_graph.rs
+++ b/components/common/src/package_graph.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use bimap::BiMap;
 use error::Result;
 use hcore::fs as hfs;
 use hcore::package;
@@ -20,19 +21,18 @@ use hcore::package::PackageInstall;
 use petgraph;
 use petgraph::graph::NodeIndex;
 use petgraph::stable_graph::StableGraph;
-use petgraph::visit::Bfs;
-use std::collections::HashMap;
+use petgraph::visit::{Bfs, Reversed};
 use std::path::Path;
 
 pub struct PackageGraph {
-    nodes: HashMap<PackageIdent, NodeIndex>,
+    nodes: BiMap<PackageIdent, NodeIndex>,
     graph: StableGraph<PackageIdent, usize, petgraph::Directed>,
 }
 
 impl PackageGraph {
     pub fn new() -> Self {
         PackageGraph {
-            nodes: HashMap::<PackageIdent, NodeIndex>::new(),
+            nodes: BiMap::<PackageIdent, NodeIndex>::new(),
             graph: StableGraph::<PackageIdent, usize>::new(),
         }
     }
@@ -49,17 +49,21 @@ impl PackageGraph {
             self.extend(&ident, &deps);
         }
 
-        Ok((self.node_count(), self.edge_count()))
+        Ok((self.graph.node_count(), self.graph.edge_count()))
     }
 
     /// Return (and possibly create) a NodeIndex for a given PackageIdent.
     /// Upon returning, the node will be guaranteed to be in the graph
     fn node_idx(&mut self, package: &PackageIdent) -> NodeIndex {
-        match self.nodes.get(package) {
+        match self.nodes.get_by_left(package) {
             Some(&idx) => idx,
             None => {
                 let idx = self.graph.add_node(package.clone());
-                self.nodes.insert(package.clone(), idx);
+                let inserted = self.nodes.insert(package.clone(), idx);
+
+                // We're sure that we never try to insert the same PackageIdent twice,
+                // and also all Nodeindexes are unique.  Let's assert! just to be sure
+                assert_eq!(false, inserted.did_overwrite());
                 idx
             }
         }
@@ -79,11 +83,11 @@ impl PackageGraph {
         (self.graph.node_count(), self.graph.edge_count())
     }
 
-    /// Return the dependencies in a topological order (ie. packages will appear before their dependencies)
+    /// Return the dependencies of a given Package Identifier.
     pub fn ordered_deps(&self, package: &PackageIdent) -> Vec<PackageIdent> {
-        let mut result = Vec::<PackageIdent>::new();
-        match self.nodes.get(package) {
+        match self.nodes.get_by_left(package) {
             Some(&idx) => {
+                let mut result = Vec::new();
                 let mut bfs = Bfs::new(&self.graph, idx);
 
                 // BFS returns the original node on first call to next()
@@ -98,10 +102,35 @@ impl PackageGraph {
                         result.push(child_pkg.clone());
                     }
                 }
+                result
             }
-            None => (),
+            None => vec![],
         }
-        result
+    }
+
+    /// Return the reverse dependencies of a given pacakge identifier
+    pub fn ordered_reverse_deps(&self, package: &PackageIdent) -> Vec<PackageIdent> {
+        match self.nodes.get_by_left(package) {
+            Some(&idx) => {
+                let mut result = Vec::new();
+                let mut bfs = Bfs::new(Reversed(&self.graph), idx);
+
+                // BFS returns the original node on first call to next()
+                // consume it here so it's not in the result Vec
+                match bfs.next(Reversed(&self.graph)) {
+                    Some(n) => assert_eq!(&n, &idx),
+                    None => unreachable!("package is always in BFS from itself"),
+                }
+
+                while let Some(child) = bfs.next(Reversed(&self.graph)) {
+                    if let Some(child_pkg) = self.graph.node_weight(child) {
+                        result.push(child_pkg.clone());
+                    }
+                }
+                result
+            }
+            None => vec![],
+        }
     }
 
     /// Remove a package from a graph
@@ -124,8 +153,8 @@ impl PackageGraph {
     /// Returns None if package was not in graph
     /// Returns Some(true) if package is removed
     fn do_remove(&mut self, package: &PackageIdent) -> Option<bool> {
-        match self.nodes.remove(&package) {
-            Some(idx) => {
+        match self.nodes.remove_by_left(&package) {
+            Some((_, idx)) => {
                 // And remove from graph
                 match self.graph.remove_node(idx) {
                     Some(ident) => assert_eq!(&ident, package),
@@ -143,11 +172,11 @@ impl PackageGraph {
     /// does a specific PackageIdent appear in the graph
     ///
     pub fn has_package(&self, package: &PackageIdent) -> bool {
-        self.nodes.contains_key(package)
+        self.nodes.contains_left(package)
     }
 
     fn count_edges(&self, package: &PackageIdent, direction: petgraph::Direction) -> Option<usize> {
-        match self.nodes.get(package) {
+        match self.nodes.get_by_left(package) {
             Some(&idx) => {
                 let deps: Vec<NodeIndex> = self.graph.neighbors_directed(idx, direction).collect();
                 Some(deps.len())
@@ -156,25 +185,59 @@ impl PackageGraph {
         }
     }
 
-    /// Returns the number of dependancies for a package
+    /// Returns the number of dependencies for a package
     ///
-    /// Returns None if the package is not in the graph
+    /// Returns `None` if the package is not in the graph
     pub fn count_deps(&self, ident: &PackageIdent) -> Option<usize> {
         self.count_edges(ident, petgraph::Outgoing)
     }
 
     /// Returns the number of package which have this package as a dependency
     ///
-    /// Returns None if the package is not in the graph
+    /// Returns `None` if the package is not in the graph
     pub fn count_rdeps(&self, ident: &PackageIdent) -> Option<usize> {
         self.count_edges(ident, petgraph::Incoming)
     }
 
+    fn neighbours(
+        &self,
+        package: &PackageIdent,
+        direction: petgraph::Direction,
+    ) -> Option<Vec<PackageIdent>> {
+        match self.nodes.get_by_left(&package) {
+            Some(&idx) => {
+                let deps = self
+                    .graph
+                    .neighbors_directed(idx, direction)
+                    .map(|n| self.nodes.get_by_right(&n).cloned().unwrap()) // unwrap ok as we have consistency between `graph` and `nodes`
+                    .collect();
+                Some(deps)
+            }
+            None => None,
+        }
+    }
+
+    /// Returns the direct dependencies for a package.
+    ///
+    /// Returns `None` if the package is not in the graph
+    pub fn deps(&self, package: &PackageIdent) -> Option<Vec<PackageIdent>> {
+        self.neighbours(package, petgraph::Outgoing)
+    }
+
+    /// Returns the direct reverse dependencies for a package.
+    ///
+    /// Returns `None` if the package is not in the graph
+    pub fn rdeps(&self, package: &PackageIdent) -> Option<Vec<PackageIdent>> {
+        self.neighbours(package, petgraph::Incoming)
+    }
+
+    #[cfg(test)]
     /// Returns the number of packages in the package graph
     fn node_count(&self) -> usize {
         self.graph.node_count()
     }
 
+    #[cfg(test)]
     /// Returns the number of edges (dependencies) in the package graph
     fn edge_count(&self) -> usize {
         self.graph.edge_count()
@@ -252,6 +315,20 @@ mod test {
     }
 
     #[test]
+    fn different_origins_graph() {
+        // We have non-standard implementations of `Ord`, `PartialOrd` for `PackageIdent`.  Make sure this
+        // doesn't mess with the requirements of `BiMap`
+        let packages = vec![
+            empty_package_deps(PackageIdent::from_str("core/redis/2.1.0/20180704142101").unwrap()),
+            empty_package_deps(PackageIdent::from_str("mine/redis/2.1.0/20180704142101").unwrap()),
+        ];
+
+        let graph = build(packages);
+        assert_eq!(graph.node_count(), 2);
+        assert_eq!(graph.edge_count(), 0);
+    }
+
+    #[test]
     fn count_deps_non_existent_package() {
         let a = PackageIdent::from_str("core/redis/2.1.0/20180704142101").unwrap();
         let b = PackageIdent::from_str("core/foo/1.0/20180704142702").unwrap();
@@ -297,6 +374,31 @@ mod test {
     }
 
     #[test]
+    fn deps() {
+        let a = PackageIdent::from_str("core/redis/2.1.0/20180704142101").unwrap();
+        let b = PackageIdent::from_str("core/foo/1.0/20180704142702").unwrap();
+        let c = PackageIdent::from_str("core/foo/1.0/20180704142805").unwrap();
+        let d = PackageIdent::from_str("core/bar/1.0/20180704142805").unwrap();
+        let packages = vec![
+            empty_package_deps(a.clone()),
+            package_deps(b.clone(), &vec![a.clone()]),
+            package_deps(c.clone(), &vec![a.clone()]),
+            package_deps(d.clone(), &vec![b.clone(), c.clone()]),
+        ];
+
+        let graph = build(packages);
+        assert_eq!(graph.node_count(), 4);
+        assert_eq!(graph.edge_count(), 4);
+
+        assert_eq!(graph.deps(&a), Some(vec![]));
+        assert_eq!(graph.deps(&b), Some(vec![a.clone()]));
+        assert_eq!(graph.deps(&c), Some(vec![a.clone()]));
+        let result = graph.deps(&d).unwrap();
+        assert!(result.contains(&b));
+        assert!(result.contains(&c));
+    }
+
+    #[test]
     fn count_rdeps() {
         let a = PackageIdent::from_str("core/redis/2.1.0/20180704142101").unwrap();
         let b = PackageIdent::from_str("core/foo/1.0/20180704142702").unwrap();
@@ -317,6 +419,31 @@ mod test {
         assert_eq!(graph.count_rdeps(&b).unwrap(), 1);
         assert_eq!(graph.count_rdeps(&c).unwrap(), 1);
         assert_eq!(graph.count_rdeps(&d).unwrap(), 0);
+    }
+
+    #[test]
+    fn rdeps() {
+        let a = PackageIdent::from_str("core/redis/2.1.0/20180704142101").unwrap();
+        let b = PackageIdent::from_str("core/foo/1.0/20180704142702").unwrap();
+        let c = PackageIdent::from_str("core/foo/1.0/20180704142805").unwrap();
+        let d = PackageIdent::from_str("core/bar/1.0/20180704142805").unwrap();
+        let packages = vec![
+            empty_package_deps(a.clone()),
+            package_deps(b.clone(), &vec![a.clone()]),
+            package_deps(c.clone(), &vec![a.clone()]),
+            package_deps(d.clone(), &vec![b.clone(), c.clone()]),
+        ];
+
+        let graph = build(packages);
+        assert_eq!(graph.node_count(), 4);
+        assert_eq!(graph.edge_count(), 4);
+
+        let rdeps = graph.rdeps(&a).unwrap();
+        assert!(rdeps.contains(&b));
+        assert!(rdeps.contains(&c));
+        assert_eq!(graph.rdeps(&b), Some(vec![d.clone()]));
+        assert_eq!(graph.rdeps(&c), Some(vec![d.clone()]));
+        assert_eq!(graph.rdeps(&d), Some(vec![]));
     }
 
     #[test]
@@ -399,6 +526,41 @@ mod test {
 
         let odeps = graph.ordered_deps(&d);
         let expected = vec![c, b, a];
+        assert_eq!(expected, odeps);
+    }
+
+    #[test]
+    fn ordered_reverse_deps_of_empty_deps() {
+        let a = PackageIdent::from_str("core/redis/2.1.0/20180704142101").unwrap();
+        let packages = vec![empty_package_deps(a.clone())];
+
+        let graph = build(packages);
+        assert_eq!(graph.node_count(), 1);
+        assert_eq!(graph.edge_count(), 0);
+
+        let odeps = graph.ordered_reverse_deps(&a);
+        assert_eq!(&Vec::<PackageIdent>::new(), &odeps);
+    }
+
+    #[test]
+    fn ordered_reverse_deps_are_in_order() {
+        let a = PackageIdent::from_str("core/redis/2.1.0/20180704142101").unwrap();
+        let b = PackageIdent::from_str("core/foo/1.0/20180704142702").unwrap();
+        let c = PackageIdent::from_str("core/bar/1.0/20180704142805").unwrap();
+        let d = PackageIdent::from_str("core/baz/1.0/20180704142805").unwrap();
+        let packages = vec![
+            empty_package_deps(a.clone()),
+            package_deps(b.clone(), &vec![a.clone()]),
+            package_deps(c.clone(), &vec![b.clone()]),
+            package_deps(d.clone(), &vec![c.clone()]),
+        ];
+
+        let graph = build(packages);
+        assert_eq!(graph.node_count(), 4);
+        assert_eq!(graph.edge_count(), 3);
+
+        let odeps = graph.ordered_reverse_deps(&a);
+        let expected = vec![b, c, d];
         assert_eq!(expected, odeps);
     }
 }

--- a/components/common/src/package_graph.rs
+++ b/components/common/src/package_graph.rs
@@ -21,7 +21,8 @@ use hcore::package::PackageInstall;
 use petgraph;
 use petgraph::graph::NodeIndex;
 use petgraph::stable_graph::StableGraph;
-use petgraph::visit::{Bfs, Reversed};
+use petgraph::visit::{Bfs, Reversed, Walker};
+
 use std::path::Path;
 
 pub struct PackageGraph {
@@ -30,40 +31,52 @@ pub struct PackageGraph {
 }
 
 impl PackageGraph {
-    pub fn new() -> Self {
+    fn empty() -> Self {
         PackageGraph {
-            nodes: BiMap::<PackageIdent, NodeIndex>::new(),
-            graph: StableGraph::<PackageIdent, usize>::new(),
+            nodes: BiMap::new(),
+            graph: StableGraph::new(),
         }
     }
 
-    // Load a set of packages that are stored in a package_path under a habitat
-    // root directory
-    pub fn load(&mut self, fs_root_path: &Path) -> Result<(usize, usize)> {
+    /// Construct a `PackageGraph` from all the packages stored in in the habitat `pkgs`
+    /// directory
+    pub fn from_root_path(fs_root_path: &Path) -> Result<Self> {
+        let mut pg = Self::empty();
+        pg.load(fs_root_path)?;
+        Ok(pg)
+    }
+
+    /// Load a set of packages that are stored in a package_path under a habitat
+    /// root directory
+    fn load(&mut self, fs_root_path: &Path) -> Result<()> {
         let package_path = hfs::pkg_root_path(Some(&fs_root_path));
         let idents = package::all_packages(&package_path)?;
 
-        for ident in &idents {
+        for ident in idents {
             let p = PackageInstall::load(&ident, Some(fs_root_path))?;
             let deps = p.deps()?;
             self.extend(&ident, &deps);
         }
 
-        Ok((self.graph.node_count(), self.graph.edge_count()))
+        Ok(())
     }
 
     /// Return (and possibly create) a NodeIndex for a given PackageIdent.
     /// Upon returning, the node will be guaranteed to be in the graph
+    ///
     fn node_idx(&mut self, package: &PackageIdent) -> NodeIndex {
         match self.nodes.get_by_left(package) {
             Some(&idx) => idx,
             None => {
                 let idx = self.graph.add_node(package.clone());
-                let inserted = self.nodes.insert(package.clone(), idx);
 
-                // We're sure that we never try to insert the same PackageIdent twice,
-                // and also all Nodeindexes are unique.  Let's assert! just to be sure
-                assert_eq!(false, inserted.did_overwrite());
+                // BiMap only allows a value to appear one time in the left
+                // and right hand sides of the map.  Let's assert that we're not going to
+                // move the `idx` from one package to another.
+                assert!(!self.nodes.contains_right(&idx));
+
+                self.nodes.insert(package.clone(), idx);
+
                 idx
             }
         }
@@ -83,79 +96,76 @@ impl PackageGraph {
         (self.graph.node_count(), self.graph.edge_count())
     }
 
-    /// Return the dependencies of a given Package Identifier.
-    pub fn ordered_deps(&self, package: &PackageIdent) -> Vec<PackageIdent> {
-        match self.nodes.get_by_left(package) {
-            Some(&idx) => {
-                let mut result = Vec::new();
-                let mut bfs = Bfs::new(&self.graph, idx);
+    /// Return the dependencies of a given Package Identifier
+    ///
+    /// Returns `None` if the package identifier is not in the graph
+    pub fn ordered_deps(&self, package: &PackageIdent) -> Vec<&PackageIdent> {
+        self.nodes
+            .get_by_left(package)
+            .map(|&idx| {
+                // BFS returns the original node as the first node
+                // `skip` it here so it's not in the result Vec
+                let bfs = Bfs::new(&self.graph, idx).iter(&self.graph).skip(1);
 
-                // BFS returns the original node on first call to next()
-                // consume it here so it's not in the result Vec
-                match bfs.next(&self.graph) {
-                    Some(n) => assert_eq!(&n, &idx),
-                    None => unreachable!("package is always in BFS from itself"),
-                }
-
-                while let Some(child) = bfs.next(&self.graph) {
-                    if let Some(child_pkg) = self.graph.node_weight(child) {
-                        result.push(child_pkg.clone());
-                    }
-                }
-                result
-            }
-            None => vec![],
-        }
+                bfs.into_iter()
+                    .map(|child| self.graph.node_weight(child).unwrap())
+                    .collect()
+            }).unwrap_or(vec![])
     }
 
-    /// Return the reverse dependencies of a given pacakge identifier
-    pub fn ordered_reverse_deps(&self, package: &PackageIdent) -> Vec<PackageIdent> {
-        match self.nodes.get_by_left(package) {
-            Some(&idx) => {
-                let mut result = Vec::new();
-                let mut bfs = Bfs::new(Reversed(&self.graph), idx);
+    /// Return the dependencies of a given Package Identifier as `PackageIdent`s. This
+    /// allows you to modify the underlying graph (via `PackageGraph::remove`) while traversing the
+    /// dependencies
+    ///
+    /// Returns `None` if the package identifier is not in the graph
 
-                // BFS returns the original node on first call to next()
-                // consume it here so it's not in the result Vec
-                match bfs.next(Reversed(&self.graph)) {
-                    Some(n) => assert_eq!(&n, &idx),
-                    None => unreachable!("package is always in BFS from itself"),
-                }
+    pub fn owned_ordered_deps(&self, package: &PackageIdent) -> Vec<PackageIdent> {
+        self.ordered_deps(&package)
+            .iter()
+            .map(|&p| p.clone())
+            .collect()
+    }
+    /// Return the reverse dependencies of a given Package Identifier
+    ///
+    /// Returns `None` if the package identifier is not in the graph
+    pub fn ordered_reverse_deps(&self, package: &PackageIdent) -> Vec<&PackageIdent> {
+        self.nodes
+            .get_by_left(package)
+            .map(|&idx| {
+                // BFS returns the original node as the first node
+                // `skip` it here so it's not in the result Vec
+                let bfs = Bfs::new(&self.graph, idx)
+                    .iter(Reversed(&self.graph))
+                    .skip(1);
 
-                while let Some(child) = bfs.next(Reversed(&self.graph)) {
-                    if let Some(child_pkg) = self.graph.node_weight(child) {
-                        result.push(child_pkg.clone());
-                    }
-                }
-                result
-            }
-            None => vec![],
-        }
+                bfs.into_iter()
+                    .map(|child| self.graph.node_weight(child).unwrap())
+                    .collect()
+            }).unwrap_or(vec![])
     }
 
     /// Remove a package from a graph
     ///
     /// This will not remove the package if it is a dependency of any package
     ///
-    /// Returns None if package was not in graph
-    /// Returns Some(true) if package is removed
-    /// Return  Some(false) if package is a dependency
-    pub fn remove(&mut self, package: &PackageIdent) -> Option<bool> {
-        match self.count_rdeps(package) {
-            Some(0) => self.do_remove(package),
-            Some(_) => Some(false),
-            None => None,
+    /// Returns true if package is removed
+    /// Return  false if package was not removed
+    pub fn remove(&mut self, package: &PackageIdent) -> bool {
+        if let Some(0) = self.count_rdeps(package) {
+            self.do_remove(package)
+        } else {
+            false
         }
     }
 
     /// Cleanly remove the node from both the node list and the graph
     ///
-    /// Returns None if package was not in graph
-    /// Returns Some(true) if package is removed
-    fn do_remove(&mut self, package: &PackageIdent) -> Option<bool> {
-        match self.nodes.remove_by_left(&package) {
-            Some((_, idx)) => {
-                // And remove from graph
+    /// Returns true if package is removed
+    /// Returns false if package was not in graph
+    fn do_remove(&mut self, package: &PackageIdent) -> bool {
+        self.nodes
+            .remove_by_left(package)
+            .map(|(_, idx)| {
                 match self.graph.remove_node(idx) {
                     Some(ident) => assert_eq!(&ident, package),
                     None => panic!(
@@ -163,10 +173,8 @@ impl PackageGraph {
                         package
                     ),
                 }
-                Some(true)
-            }
-            None => None,
-        }
+                true
+            }).unwrap_or(false)
     }
 
     /// does a specific PackageIdent appear in the graph
@@ -176,20 +184,9 @@ impl PackageGraph {
     }
 
     fn count_edges(&self, package: &PackageIdent, direction: petgraph::Direction) -> Option<usize> {
-        match self.nodes.get_by_left(package) {
-            Some(&idx) => {
-                let deps: Vec<NodeIndex> = self.graph.neighbors_directed(idx, direction).collect();
-                Some(deps.len())
-            }
-            None => None,
-        }
-    }
-
-    /// Returns the number of dependencies for a package
-    ///
-    /// Returns `None` if the package is not in the graph
-    pub fn count_deps(&self, ident: &PackageIdent) -> Option<usize> {
-        self.count_edges(ident, petgraph::Outgoing)
+        self.nodes
+            .get_by_left(package)
+            .map(|&idx| self.graph.neighbors_directed(idx, direction).count())
     }
 
     /// Returns the number of package which have this package as a dependency
@@ -203,44 +200,29 @@ impl PackageGraph {
         &self,
         package: &PackageIdent,
         direction: petgraph::Direction,
-    ) -> Option<Vec<PackageIdent>> {
-        match self.nodes.get_by_left(&package) {
-            Some(&idx) => {
-                let deps = self
-                    .graph
+    ) -> Vec<&PackageIdent> {
+        self.nodes
+            .get_by_left(package)
+            .map(|&idx| {
+                self.graph
                     .neighbors_directed(idx, direction)
-                    .map(|n| self.nodes.get_by_right(&n).cloned().unwrap()) // unwrap ok as we have consistency between `graph` and `nodes`
-                    .collect();
-                Some(deps)
-            }
-            None => None,
-        }
+                    .map(|n| self.nodes.get_by_right(&n).unwrap()) //  unwrap here is ok as we have consistency between `self.graph` and `self.nodes`
+                    .collect()
+            }).unwrap_or(vec![])
     }
 
     /// Returns the direct dependencies for a package.
     ///
     /// Returns `None` if the package is not in the graph
-    pub fn deps(&self, package: &PackageIdent) -> Option<Vec<PackageIdent>> {
+    pub fn deps(&self, package: &PackageIdent) -> Vec<&PackageIdent> {
         self.neighbours(package, petgraph::Outgoing)
     }
 
     /// Returns the direct reverse dependencies for a package.
     ///
     /// Returns `None` if the package is not in the graph
-    pub fn rdeps(&self, package: &PackageIdent) -> Option<Vec<PackageIdent>> {
+    pub fn rdeps(&self, package: &PackageIdent) -> Vec<&PackageIdent> {
         self.neighbours(package, petgraph::Incoming)
-    }
-
-    #[cfg(test)]
-    /// Returns the number of packages in the package graph
-    fn node_count(&self) -> usize {
-        self.graph.node_count()
-    }
-
-    #[cfg(test)]
-    /// Returns the number of edges (dependencies) in the package graph
-    fn edge_count(&self) -> usize {
-        self.graph.edge_count()
     }
 }
 
@@ -249,13 +231,32 @@ mod test {
     use super::*;
     use std::str::FromStr;
 
+    impl PackageGraph {
+        /// Returns the number of dependencies for a package
+        ///
+        /// Returns `None` if the package is not in the graph
+        pub fn count_deps(&self, ident: &PackageIdent) -> Option<usize> {
+            self.count_edges(ident, petgraph::Outgoing)
+        }
+
+        /// Returns the number of packages in the package graph
+        fn node_count(&self) -> usize {
+            self.graph.node_count()
+        }
+
+        /// Returns the number of edges (dependencies) in the package graph
+        fn edge_count(&self) -> usize {
+            self.graph.edge_count()
+        }
+    }
+
     struct PackageDeps {
         ident: PackageIdent,
         deps: Vec<PackageIdent>,
     }
 
     fn build(packages: Vec<PackageDeps>) -> PackageGraph {
-        let mut graph = PackageGraph::new();
+        let mut graph = PackageGraph::empty();
         for p in &packages {
             graph.extend(&p.ident, &p.deps);
         }
@@ -274,6 +275,10 @@ mod test {
             ident: ident,
             deps: deps.to_vec(),
         }
+    }
+
+    fn empty_vec() -> Vec<&'static PackageIdent> {
+        vec![]
     }
 
     #[test]
@@ -390,12 +395,12 @@ mod test {
         assert_eq!(graph.node_count(), 4);
         assert_eq!(graph.edge_count(), 4);
 
-        assert_eq!(graph.deps(&a), Some(vec![]));
-        assert_eq!(graph.deps(&b), Some(vec![a.clone()]));
-        assert_eq!(graph.deps(&c), Some(vec![a.clone()]));
-        let result = graph.deps(&d).unwrap();
-        assert!(result.contains(&b));
-        assert!(result.contains(&c));
+        assert_eq!(graph.deps(&a), empty_vec());
+        assert_eq!(graph.deps(&b), vec![&a]);
+        assert_eq!(graph.deps(&c), vec![&a]);
+        let result = graph.deps(&d);
+        assert!(result.contains(&b.as_ref()));
+        assert!(result.contains(&c.as_ref()));
     }
 
     #[test]
@@ -438,12 +443,12 @@ mod test {
         assert_eq!(graph.node_count(), 4);
         assert_eq!(graph.edge_count(), 4);
 
-        let rdeps = graph.rdeps(&a).unwrap();
-        assert!(rdeps.contains(&b));
-        assert!(rdeps.contains(&c));
-        assert_eq!(graph.rdeps(&b), Some(vec![d.clone()]));
-        assert_eq!(graph.rdeps(&c), Some(vec![d.clone()]));
-        assert_eq!(graph.rdeps(&d), Some(vec![]));
+        let rdeps = graph.rdeps(&a);
+        assert!(rdeps.contains(&b.as_ref()));
+        assert!(rdeps.contains(&c.as_ref()));
+        assert_eq!(graph.rdeps(&b), vec![&d]);
+        assert_eq!(graph.rdeps(&c), vec![&d]);
+        assert_eq!(graph.rdeps(&d), empty_vec());
     }
 
     #[test]
@@ -465,7 +470,7 @@ mod test {
 
         assert_eq!(graph.count_rdeps(&d).unwrap(), 0);
 
-        assert!(graph.remove(&d).unwrap());
+        assert!(graph.remove(&d));
         // package count decremented on remove
         assert_eq!(graph.has_package(&d), false);
         assert_eq!(graph.node_count(), 3);
@@ -490,7 +495,7 @@ mod test {
 
         assert_eq!(graph.count_rdeps(&a).unwrap(), 1);
 
-        assert_eq!(graph.remove(&a).unwrap(), false);
+        assert_eq!(graph.remove(&a), false);
         assert_eq!(graph.node_count(), 2);
     }
 
@@ -504,7 +509,29 @@ mod test {
         assert_eq!(graph.edge_count(), 0);
 
         let odeps = graph.ordered_deps(&a);
-        assert_eq!(&Vec::<PackageIdent>::new(), &odeps);
+        assert_eq!(odeps, empty_vec());
+    }
+
+    #[test]
+    fn ordered_deps_non_existent_package() {
+        let a = PackageIdent::from_str("core/redis/2.1.0/20180704142101").unwrap();
+        let b = PackageIdent::from_str("core/foo/1.0/20180704142702").unwrap();
+        let c = PackageIdent::from_str("core/foo/1.0/20180704142805").unwrap();
+        let d = PackageIdent::from_str("core/bar/1.0/20180704142805").unwrap();
+        let packages = vec![
+            empty_package_deps(a.clone()),
+            package_deps(b.clone(), &vec![a.clone()]),
+            package_deps(c.clone(), &vec![a.clone()]),
+            package_deps(d.clone(), &vec![b.clone(), c.clone()]),
+        ];
+
+        let graph = build(packages);
+        assert_eq!(graph.node_count(), 4);
+        assert_eq!(graph.edge_count(), 4);
+
+        let does_not_exist = PackageIdent::from_str("core/baz").unwrap();
+        assert_eq!(graph.ordered_deps(&does_not_exist), empty_vec());
+        assert_eq!(graph.ordered_reverse_deps(&does_not_exist), empty_vec());
     }
 
     #[test]
@@ -525,10 +552,31 @@ mod test {
         assert_eq!(graph.edge_count(), 3);
 
         let odeps = graph.ordered_deps(&d);
-        let expected = vec![c, b, a];
+        let expected = vec![&c, &b, &a];
         assert_eq!(expected, odeps);
     }
 
+    #[test]
+    fn owned_ordered_deps_are_in_order() {
+        let a = PackageIdent::from_str("core/redis/2.1.0/20180704142101").unwrap();
+        let b = PackageIdent::from_str("core/foo/1.0/20180704142702").unwrap();
+        let c = PackageIdent::from_str("core/bar/1.0/20180704142805").unwrap();
+        let d = PackageIdent::from_str("core/baz/1.0/20180704142805").unwrap();
+        let packages = vec![
+            empty_package_deps(a.clone()),
+            package_deps(b.clone(), &vec![a.clone()]),
+            package_deps(c.clone(), &vec![b.clone()]),
+            package_deps(d.clone(), &vec![c.clone()]),
+        ];
+
+        let graph = build(packages);
+        assert_eq!(graph.node_count(), 4);
+        assert_eq!(graph.edge_count(), 3);
+
+        let odeps = graph.owned_ordered_deps(&d);
+        let expected = vec![c, b, a];
+        assert_eq!(expected, odeps);
+    }
     #[test]
     fn ordered_reverse_deps_of_empty_deps() {
         let a = PackageIdent::from_str("core/redis/2.1.0/20180704142101").unwrap();
@@ -539,7 +587,7 @@ mod test {
         assert_eq!(graph.edge_count(), 0);
 
         let odeps = graph.ordered_reverse_deps(&a);
-        assert_eq!(&Vec::<PackageIdent>::new(), &odeps);
+        assert_eq!(odeps, empty_vec());
     }
 
     #[test]
@@ -560,7 +608,7 @@ mod test {
         assert_eq!(graph.edge_count(), 3);
 
         let odeps = graph.ordered_reverse_deps(&a);
-        let expected = vec![b, c, d];
+        let expected = vec![&b, &c, &d];
         assert_eq!(expected, odeps);
     }
 }

--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -537,6 +537,7 @@ pub fn get() -> App<'static, 'static> {
                     the direct dependencies of the package")
                 (aliases: &["dep", "deps"])
                 (@arg TRANSITIVE: -t --transitive "Show transitive dependencies")
+                (@arg REVERSE: --reverse "Show packages which are dependant on this one")
                 (@arg PKG_IDENT: +required +takes_value {valid_ident}
                     "A package identifier (ex: core/redis, core/busybox-static/1.42.2)")
             )

--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -537,7 +537,7 @@ pub fn get() -> App<'static, 'static> {
                     the direct dependencies of the package")
                 (aliases: &["dep", "deps"])
                 (@arg TRANSITIVE: -t --transitive "Show transitive dependencies")
-                (@arg REVERSE: --reverse "Show packages which are dependant on this one")
+                (@arg REVERSE: -r --reverse "Show packages which are dependant on this one")
                 (@arg PKG_IDENT: +required +takes_value {valid_ident}
                     "A package identifier (ex: core/redis, core/busybox-static/1.42.2)")
             )

--- a/components/hab/src/command/pkg/mod.rs
+++ b/components/hab/src/command/pkg/mod.rs
@@ -48,3 +48,8 @@ pub enum Scope {
     Package,
     PackageAndDependencies,
 }
+
+pub enum DependencyDirection {
+    Up,
+    Down,
+}

--- a/components/hab/src/command/pkg/mod.rs
+++ b/components/hab/src/command/pkg/mod.rs
@@ -49,7 +49,10 @@ pub enum Scope {
     PackageAndDependencies,
 }
 
-pub enum DependencyDirection {
-    Up,
-    Down,
+/// Express the relationship between two packages
+/// `Requires`: a dependency from a package to one it depends on
+/// `Supports`: a dependency from a package to one that depends on it
+pub enum DependencyRelation {
+    Requires,
+    Supports,
 }

--- a/components/hab/src/command/pkg/uninstall.rs
+++ b/components/hab/src/command/pkg/uninstall.rs
@@ -22,7 +22,7 @@ use common::ui::{Status, UIWriter, UI};
 use error::{Error, Result};
 use hcore::error as herror;
 use hcore::fs as hfs;
-use hcore::package::{all_packages, Identifiable, PackageIdent, PackageInstall};
+use hcore::package::{Identifiable, PackageIdent, PackageInstall};
 
 use hcore::package::list::temp_package_directory;
 
@@ -72,9 +72,8 @@ pub fn start(
     }
 
     // 2.
-    let packages = load_all_packages(&fs_root_path)?;
     let mut graph = PackageGraph::new();
-    graph.build(&packages)?;
+    graph.load(&fs_root_path)?;
 
     // 3.
     let deps = graph.ordered_deps(&ident);
@@ -119,7 +118,8 @@ pub fn start(
                         ui.warn(format!("Tried to find dependant packages of {} but it wasn't in graph.  Maybe another uninstall command was run at the same time?", &p))?;
                     }
                     Some(0) => {
-                        let install = packages.iter().find(|&i| i.ident() == p).unwrap();
+                        let install = PackageInstall::load(&p, Some(fs_root_path))?;
+                        //packages.iter().find(|&i| i.ident() == p).unwrap();
                         maybe_delete(
                             ui,
                             &fs_root_path,
@@ -251,16 +251,4 @@ fn do_clean_delete(pkg_root_path: &Path, real_install_path: &Path) -> Result<boo
         }
         None => unreachable!("Install path doesn't have a parent"),
     }
-}
-
-fn load_all_packages(fs_root_path: &Path) -> Result<Vec<PackageInstall>> {
-    let package_path = hfs::pkg_root_path(Some(&fs_root_path));
-    let idents = all_packages(&package_path)?;
-
-    let mut result = Vec::with_capacity(idents.len());
-    for i in idents {
-        let pkg_install = PackageInstall::load(&i, Some(fs_root_path))?;
-        result.push(pkg_install);
-    }
-    Ok(result)
 }

--- a/components/hab/src/command/pkg/uninstall.rs
+++ b/components/hab/src/command/pkg/uninstall.rs
@@ -72,11 +72,10 @@ pub fn start(
     }
 
     // 2.
-    let mut graph = PackageGraph::new();
-    graph.load(&fs_root_path)?;
+    let mut graph = PackageGraph::from_root_path(fs_root_path)?;
 
     // 3.
-    let deps = graph.ordered_deps(&ident);
+    let deps = graph.owned_ordered_deps(&ident);
 
     // 4.
     match graph.count_rdeps(&ident) {
@@ -119,7 +118,6 @@ pub fn start(
                     }
                     Some(0) => {
                         let install = PackageInstall::load(&p, Some(fs_root_path))?;
-                        //packages.iter().find(|&i| i.ident() == p).unwrap();
                         maybe_delete(
                             ui,
                             &fs_root_path,

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -476,8 +476,8 @@ fn sub_pkg_dependencies(m: &ArgMatches) -> Result<()> {
     };
 
     let direction = match m.is_present("REVERSE") {
-        true => command::pkg::DependencyDirection::Up,
-        false => command::pkg::DependencyDirection::Down,
+        true => command::pkg::DependencyRelation::Supports,
+        false => command::pkg::DependencyRelation::Requires,
     };
     command::pkg::dependencies::start(&ident, &scope, &direction, &*FS_ROOT)
 }

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -475,7 +475,11 @@ fn sub_pkg_dependencies(m: &ArgMatches) -> Result<()> {
         command::pkg::Scope::Package
     };
 
-    command::pkg::dependencies::start(&ident, &scope, &*FS_ROOT)
+    let direction = match m.is_present("REVERSE") {
+        true => command::pkg::DependencyDirection::Up,
+        false => command::pkg::DependencyDirection::Down,
+    };
+    command::pkg::dependencies::start(&ident, &scope, &direction, &*FS_ROOT)
 }
 
 fn sub_pkg_env(m: &ArgMatches) -> Result<()> {


### PR DESCRIPTION
This adds `--reverse` option to the `hab pkg dependencies` command:

* `--reverse`: Show all packages which depend on this one

It adds a new dependency, `bimap` which implements a simple bijective map which is used inside `PackageGraph` to make all lookups in both directions O(1).