### PR TITLE
Extract unnecessary code from manager module

### DIFF
--- a/components/sup/src/ctl_gateway/server.rs
+++ b/components/sup/src/ctl_gateway/server.rs
@@ -44,7 +44,7 @@ use tokio_codec::Framed;
 use tokio_core::reactor;
 
 use super::{CtlRequest, REQ_TIMEOUT};
-use manager::{Manager, ManagerState};
+use manager::{commands, ManagerState};
 
 /// Sending half of an mpsc unbounded channel used for sending replies for a transactional message
 /// from the main thread back to the CtlGateway. This half is stored in a
@@ -287,7 +287,7 @@ impl Future for SrvHandler {
                                 CtlCommand::new(
                                     Some(self.tx.clone()),
                                     msg.transaction(),
-                                    move |state, req| Manager::service_cfg(state, req, m.clone()),
+                                    move |state, req| commands::service_cfg(state, req, m.clone()),
                                 )
                             }
                             "SvcFilePut" => {
@@ -298,7 +298,7 @@ impl Future for SrvHandler {
                                     Some(self.tx.clone()),
                                     msg.transaction(),
                                     move |state, req| {
-                                        Manager::service_file_put(state, req, m.clone())
+                                        commands::service_file_put(state, req, m.clone())
                                     },
                                 )
                             }
@@ -310,7 +310,7 @@ impl Future for SrvHandler {
                                     Some(self.tx.clone()),
                                     msg.transaction(),
                                     move |state, req| {
-                                        Manager::service_cfg_set(state, req, m.clone())
+                                        commands::service_cfg_set(state, req, m.clone())
                                     },
                                 )
                             }
@@ -322,7 +322,7 @@ impl Future for SrvHandler {
                                     Some(self.tx.clone()),
                                     msg.transaction(),
                                     move |state, req| {
-                                        Manager::service_cfg_validate(state, req, m.clone())
+                                        commands::service_cfg_validate(state, req, m.clone())
                                     },
                                 )
                             }
@@ -333,7 +333,7 @@ impl Future for SrvHandler {
                                 CtlCommand::new(
                                     Some(self.tx.clone()),
                                     msg.transaction(),
-                                    move |state, req| Manager::service_load(state, req, m.clone()),
+                                    move |state, req| commands::service_load(state, req, m.clone()),
                                 )
                             }
                             "SvcUnload" => {
@@ -344,7 +344,7 @@ impl Future for SrvHandler {
                                     Some(self.tx.clone()),
                                     msg.transaction(),
                                     move |state, req| {
-                                        Manager::service_unload(state, req, m.clone())
+                                        commands::service_unload(state, req, m.clone())
                                     },
                                 )
                             }
@@ -355,7 +355,9 @@ impl Future for SrvHandler {
                                 CtlCommand::new(
                                     Some(self.tx.clone()),
                                     msg.transaction(),
-                                    move |state, req| Manager::service_start(state, req, m.clone()),
+                                    move |state, req| {
+                                        commands::service_start(state, req, m.clone())
+                                    },
                                 )
                             }
                             "SvcStop" => {
@@ -365,7 +367,7 @@ impl Future for SrvHandler {
                                 CtlCommand::new(
                                     Some(self.tx.clone()),
                                     msg.transaction(),
-                                    move |state, req| Manager::service_stop(state, req, m.clone()),
+                                    move |state, req| commands::service_stop(state, req, m.clone()),
                                 )
                             }
                             "SvcStatus" => {
@@ -376,7 +378,7 @@ impl Future for SrvHandler {
                                     Some(self.tx.clone()),
                                     msg.transaction(),
                                     move |state, req| {
-                                        Manager::service_status(state, req, m.clone())
+                                        commands::service_status(state, req, m.clone())
                                     },
                                 )
                             }
@@ -388,7 +390,7 @@ impl Future for SrvHandler {
                                     Some(self.tx.clone()),
                                     msg.transaction(),
                                     move |state, req| {
-                                        Manager::supervisor_depart(state, req, m.clone())
+                                        commands::supervisor_depart(state, req, m.clone())
                                     },
                                 )
                             }

--- a/components/sup/src/manager/commands.rs
+++ b/components/sup/src/manager/commands.rs
@@ -1,0 +1,816 @@
+// Copyright (c) 2018 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! All the code for responding to Supervisor commands
+
+use std::{
+    collections::HashSet,
+    fmt, fs,
+    path::{Path, PathBuf},
+    result,
+};
+
+use serde_json;
+use time::{self, Duration as TimeDuration, Timespec};
+use toml;
+
+use butterfly;
+use common::{command::package::install::InstallSource, ui::UIWriter};
+use ctl_gateway::CtlRequest;
+use error::{Error, Result};
+use hcore::{
+    fs::FS_ROOT_PATH,
+    package::metadata::PackageType,
+    package::{Identifiable, PackageIdent, PackageInstall, PackageTarget},
+    service::ServiceGroup,
+};
+use manager::{
+    service::{
+        spec::{IntoServiceSpec, ServiceSpec},
+        CompositeSpec, DesiredState, Pkg, ProcessState, Spec,
+    },
+    ManagerConfig, ManagerState,
+};
+use protocol::{
+    self,
+    net::{self, ErrCode, NetResult},
+};
+use util;
+
+static LOGKEY: &'static str = "CMD";
+
+pub fn service_cfg(
+    mgr: &ManagerState,
+    req: &mut CtlRequest,
+    opts: protocol::ctl::SvcGetDefaultCfg,
+) -> NetResult<()> {
+    let ident: PackageIdent = opts.ident.ok_or(err_update_client())?.into();
+    let mut msg = protocol::types::ServiceCfg {
+        format: Some(protocol::types::service_cfg::Format::Toml as i32),
+        default: None,
+    };
+    for service in mgr
+        .services
+        .read()
+        .expect("Services lock is poisoned")
+        .values()
+    {
+        if service.pkg.ident.satisfies(&ident) {
+            if let Some(ref cfg) = service.cfg.default {
+                msg.default =
+                    Some(toml::to_string_pretty(&toml::value::Value::Table(cfg.clone())).unwrap());
+                req.reply_complete(msg);
+            }
+            return Ok(());
+        }
+    }
+    Err(net::err(
+        ErrCode::NotFound,
+        format!("Service not loaded, {}", ident),
+    ))
+}
+
+pub fn service_cfg_validate(
+    _mgr: &ManagerState,
+    req: &mut CtlRequest,
+    opts: protocol::ctl::SvcValidateCfg,
+) -> NetResult<()> {
+    let cfg = opts.cfg.ok_or(err_update_client())?;
+    let format = opts
+        .format
+        .and_then(protocol::types::service_cfg::Format::from_i32)
+        .unwrap_or_default();
+    if cfg.len() > protocol::butterfly::MAX_SVC_CFG_SIZE {
+        return Err(net::err(
+            ErrCode::EntityTooLarge,
+            "Configuration too large.",
+        ));
+    }
+    if format != protocol::types::service_cfg::Format::Toml {
+        return Err(net::err(
+            ErrCode::NotSupported,
+            format!("Configuration format {} not available.", format),
+        ));
+    }
+    let _new_cfg: toml::value::Table = toml::from_slice(&cfg).map_err(|e| {
+        net::err(
+            ErrCode::BadPayload,
+            format!("Unable to decode configuration as {}, {}", format, e),
+        )
+    })?;
+    req.reply_complete(net::ok());
+    Ok(())
+    // JW TODO: Hold off on validation until we can validate services which aren't currently
+    // loaded in the Supervisor but are known through rumor propagation.
+    // let service_group: ServiceGroup = opts.service_group.into();
+    // for service in mgr.services.read().unwrap().iter() {
+    //     if service.service_group != service_group {
+    //         continue;
+    //     }
+    //     if let Some(interface) = service.cfg.interface() {
+    //         match Cfg::validate(interface, &new_cfg) {
+    //             None => req.reply_complete(net::ok()),
+    //             Some(errors) => {
+    //                 for error in errors {
+    //                     req.reply_partial(net::err(ErrCode::InvalidPayload, error));
+    //                 }
+    //                 req.reply_complete(net::ok());
+    //             }
+    //         }
+    //         return Ok(());
+    //     } else {
+    //         // No interface, this service can't be configured.
+    //         return Err(net::err(
+    //             ErrCode::NotFound,
+    //             "Service has no configurable attributes.",
+    //         ));
+    //     }
+    // }
+    // Err(net::err(
+    //     ErrCode::NotFound,
+    //     format!("Service not loaded, {}", service_group),
+    // ))
+}
+
+pub fn service_cfg_set(
+    mgr: &ManagerState,
+    req: &mut CtlRequest,
+    opts: protocol::ctl::SvcSetCfg,
+) -> NetResult<()> {
+    let cfg = opts.cfg.ok_or(err_update_client())?;
+    let is_encrypted = opts.is_encrypted.unwrap_or(false);
+    let version = opts.version.ok_or(err_update_client())?;
+    let service_group: ServiceGroup = opts.service_group.ok_or(err_update_client())?.into();
+    if cfg.len() > protocol::butterfly::MAX_SVC_CFG_SIZE {
+        return Err(net::err(
+            ErrCode::EntityTooLarge,
+            "Configuration too large.",
+        ));
+    }
+    outputln!(
+        "Setting new configuration version {} for {}",
+        version,
+        service_group,
+    );
+    let mut client = match butterfly::client::Client::new(
+        mgr.cfg.gossip_listen.local_addr(),
+        mgr.cfg.ring_key.clone(),
+    ) {
+        Ok(client) => client,
+        Err(err) => {
+            outputln!("Failed to connect to own gossip server, {}", err);
+            return Err(net::err(ErrCode::Internal, err.to_string()));
+        }
+    };
+    match client.send_service_config(service_group, version, cfg, is_encrypted) {
+        Ok(()) => {
+            req.reply_complete(net::ok());
+            return Ok(());
+        }
+        Err(e) => return Err(net::err(ErrCode::Internal, e.to_string())),
+    }
+}
+
+pub fn service_file_put(
+    mgr: &ManagerState,
+    req: &mut CtlRequest,
+    opts: protocol::ctl::SvcFilePut,
+) -> NetResult<()> {
+    let content = opts.content.ok_or(err_update_client())?;
+    let filename = opts.filename.ok_or(err_update_client())?;
+    let is_encrypted = opts.is_encrypted.unwrap_or(false);
+    let version = opts.version.ok_or(err_update_client())?;
+    let service_group: ServiceGroup = opts.service_group.ok_or(err_update_client())?.into();
+    if content.len() > protocol::butterfly::MAX_FILE_PUT_SIZE_BYTES {
+        return Err(net::err(ErrCode::EntityTooLarge, "File content too large."));
+    }
+    outputln!(
+        "Receiving new version {} of file {} for {}",
+        version,
+        filename,
+        service_group,
+    );
+    let mut client = match butterfly::client::Client::new(
+        mgr.cfg.gossip_listen.local_addr(),
+        mgr.cfg.ring_key.clone(),
+    ) {
+        Ok(client) => client,
+        Err(err) => {
+            outputln!("Failed to connect to own gossip server, {}", err);
+            return Err(net::err(ErrCode::Internal, err.to_string()));
+        }
+    };
+    match client.send_service_file(service_group, filename, version, content, is_encrypted) {
+        Ok(()) => {
+            req.reply_complete(net::ok());
+            return Ok(());
+        }
+        Err(e) => return Err(net::err(ErrCode::Internal, e.to_string())),
+    }
+}
+
+pub fn service_load(
+    mgr: &ManagerState,
+    req: &mut CtlRequest,
+    opts: protocol::ctl::SvcLoad,
+) -> NetResult<()> {
+    let ident: PackageIdent = opts.ident.clone().ok_or(err_update_client())?.into();
+    let bldr_url = opts
+        .bldr_url
+        .clone()
+        .unwrap_or(protocol::DEFAULT_BLDR_URL.to_string());
+    let bldr_channel = opts
+        .bldr_channel
+        .clone()
+        .unwrap_or(protocol::DEFAULT_BLDR_CHANNEL.to_string());
+    let force = opts.force.clone().unwrap_or(false);
+    let source = InstallSource::Ident(ident.clone(), *PackageTarget::active_target());
+    match existing_specs_for_ident(&mgr.cfg, source.as_ref())? {
+        None => {
+            // We don't have any record of this thing; let's set it up!
+            //
+            // If a package exists on disk that satisfies the
+            // desired package identifier, it will be used;
+            // otherwise, we'll install the latest suitable
+            // version from the specified Builder channel.
+            let installed = util::pkg::satisfy_or_install(req, &source, &bldr_url, &bldr_channel)?;
+
+            let mut specs = generate_new_specs_from_package(&installed, &opts)?;
+
+            for spec in specs.iter_mut() {
+                save_spec_for(&mgr.cfg, spec)?;
+                req.info(format!(
+                    "The {} service was successfully loaded",
+                    spec.ident
+                ))?;
+            }
+
+            // Only saves a composite spec if it's, well, a composite
+            if let Ok(composite_spec) =
+                CompositeSpec::from_package_install(source.as_ref(), &installed)
+            {
+                save_composite_spec_for(&mgr.cfg, &composite_spec)?;
+                req.info(format!(
+                    "The {} composite was successfully loaded",
+                    composite_spec.ident()
+                ))?;
+            }
+        }
+        Some(spec) => {
+            // We've seen this service / composite before. Thus `load`
+            // basically acts as a way to edit spec files on the
+            // command line. As a result, we a) check that you
+            // *really* meant to change an existing spec, and b) DO
+            // NOT download a potentially new version of the package
+            // in question
+
+            if !force {
+                // TODO (CM): make this error reflect composites
+                return Err(net::err(
+                    ErrCode::Conflict,
+                    format!("Service already loaded, unload '{}' and try again", ident),
+                ));
+            }
+
+            match spec {
+                Spec::Service(mut service_spec) => {
+                    opts.into_spec(&mut service_spec);
+
+                    // Only install if we don't have something
+                    // locally; otherwise you could potentially
+                    // upgrade each time you load.
+                    //
+                    // Also make sure you're pulling from where you're
+                    // supposed to be pulling from!
+                    util::pkg::satisfy_or_install(
+                        req,
+                        &source,
+                        &service_spec.bldr_url,
+                        &service_spec.channel,
+                    )?;
+
+                    save_spec_for(&mgr.cfg, &service_spec)?;
+                    req.info(format!(
+                        "The {} service was successfully loaded",
+                        service_spec.ident
+                    ))?;
+                }
+                Spec::Composite(composite_spec, mut existing_service_specs) => {
+                    if source.as_ref() == composite_spec.ident() {
+                        let mut bind_map =
+                            match util::pkg::installed(composite_spec.package_ident()) {
+                                Some(package) => package.bind_map()?,
+                                // TODO (CM): this should be a proper error
+                                None => unreachable!(),
+                            };
+
+                        for mut service_spec in existing_service_specs.iter_mut() {
+                            opts.update_composite(&mut bind_map, &mut service_spec);
+                            save_spec_for(&mgr.cfg, service_spec)?;
+                            req.info(format!(
+                                "The {} service was successfully loaded",
+                                service_spec.ident
+                            ))?;
+                        }
+                        req.info(format!(
+                            "The {} composite was successfully loaded",
+                            composite_spec.ident()
+                        ))?;
+                    } else {
+                        // It changed!
+                        // OK, here's the deal.
+                        //
+                        // We're going to install a new composite if
+                        // we need to in order to satisfy the spec
+                        // we've now got. That also means that the
+                        // services that are currently running may get
+                        // unloaded (because they are no longer in the
+                        // composite), and new services may start
+                        // (because they were added to the composite).
+
+                        let installed_package = util::pkg::satisfy_or_install(
+                            req,
+                            &source,
+                            // This (updating from the command-line
+                            // args) is a difference from
+                            // force-loading a spec, because
+                            // composites don't auto-update themselves
+                            // like services can.
+                            &bldr_url,
+                            &bldr_channel,
+                        )?;
+
+                        // Generate new specs from the new composite package and
+                        // CLI inputs
+                        let new_service_specs =
+                            generate_new_specs_from_package(&installed_package, &opts)?;
+
+                        // Delete any specs that are not in the new
+                        // composite
+                        let mut old_spec_names = HashSet::new();
+                        for s in existing_service_specs.iter() {
+                            old_spec_names.insert(s.ident.name.clone());
+                        }
+                        let mut new_spec_names = HashSet::new();
+                        for s in new_service_specs.iter() {
+                            new_spec_names.insert(s.ident.name.clone());
+                        }
+
+                        let specs_to_delete: HashSet<_> =
+                            old_spec_names.difference(&new_spec_names).collect();
+                        for spec in existing_service_specs.iter() {
+                            if specs_to_delete.contains(&spec.ident.name) {
+                                let file = spec_path_for(&mgr.cfg, spec);
+                                req.info(format!("Unloading {:?}", file))?;
+                                fs::remove_file(&file).map_err(|err| {
+                                    sup_error!(Error::ServiceSpecFileIO(file, err))
+                                })?;
+                            }
+                        }
+                        // <-- end of deletion
+
+                        // Save all the new specs. If there are
+                        // services that exist in both composites,
+                        // their service spec files will have the same
+                        // name, so they'll be taken care of here (we
+                        // don't need to treat them differently)
+                        for spec in new_service_specs.iter() {
+                            save_spec_for(&mgr.cfg, spec)?;
+                            req.info(format!(
+                                "The {} service was successfully loaded",
+                                spec.ident
+                            ))?;
+                        }
+
+                        // Generate and save the new spec
+                        let new_composite_spec = CompositeSpec::from_package_install(
+                            source.as_ref(),
+                            &installed_package,
+                        )?;
+                        save_composite_spec_for(&mgr.cfg, &new_composite_spec)?;
+                        req.info(format!(
+                            "The {} composite was successfully loaded",
+                            new_composite_spec.ident()
+                        ))?;
+                    }
+                }
+            }
+        }
+    }
+    req.reply_complete(net::ok());
+    Ok(())
+}
+
+pub fn service_unload(
+    mgr: &ManagerState,
+    req: &mut CtlRequest,
+    opts: protocol::ctl::SvcUnload,
+) -> NetResult<()> {
+    let ident: PackageIdent = opts.ident.ok_or(err_update_client())?.into();
+    // Gather up the paths to all the spec files we care about,
+    // along with their corresponding idents (we do this to ensure
+    // we emit a proper "unloading X" message for each member of a
+    // composite).
+    //
+    // This includes all service specs as well as any composite
+    // spec.
+    let path_ident_pairs = match existing_specs_for_ident(&mgr.cfg, &ident)? {
+        Some(Spec::Service(spec)) => vec![(spec_path_for(&mgr.cfg, &spec), ident)],
+        Some(Spec::Composite(composite_spec, specs)) => {
+            let mut paths = Vec::with_capacity(specs.len() + 1);
+            for spec in specs.iter() {
+                paths.push((spec_path_for(&mgr.cfg, spec), spec.ident.clone()));
+            }
+            paths.push((composite_path_for(&mgr.cfg, &composite_spec), ident));
+            paths
+        }
+        None => vec![],
+    };
+
+    for (file, ident) in path_ident_pairs {
+        if let Err(err) = fs::remove_file(&file) {
+            return Err(net::err(
+                ErrCode::Internal,
+                format!("{}", sup_error!(Error::ServiceSpecFileIO(file, err))),
+            ));
+        };
+        // JW TODO: Change this to unloaded from unloading when the Supervisor waits for
+        // the work to complete.
+        req.info(format!("Unloading {}", ident))?;
+    }
+    req.reply_complete(net::ok());
+    Ok(())
+}
+
+pub fn service_start(
+    mgr: &ManagerState,
+    req: &mut CtlRequest,
+    opts: protocol::ctl::SvcStart,
+) -> NetResult<()> {
+    let ident = opts.ident.ok_or(err_update_client())?.into();
+    let updated_specs = match existing_specs_for_ident(&mgr.cfg, &ident)? {
+        Some(Spec::Service(mut spec)) => {
+            let mut updated_specs = vec![];
+            if spec.desired_state == DesiredState::Down {
+                spec.desired_state = DesiredState::Up;
+                updated_specs.push(spec);
+            }
+            updated_specs
+        }
+        Some(Spec::Composite(_, service_specs)) => {
+            let mut updated_specs = vec![];
+            for mut spec in service_specs {
+                if spec.desired_state == DesiredState::Down {
+                    spec.desired_state = DesiredState::Up;
+                    updated_specs.push(spec);
+                }
+            }
+            updated_specs
+        }
+        None => {
+            return Err(net::err(
+                ErrCode::NotFound,
+                format!("Service not loaded, {}", &ident),
+            ));
+        }
+    };
+    let specs_changed = updated_specs.len() > 0;
+    for spec in updated_specs.iter() {
+        save_spec_for(&mgr.cfg, spec)?;
+    }
+    if specs_changed {
+        // JW TODO: Change the language of the message below to "started" when we actually
+        // synchronously control services from the ctl gateway.
+        req.info(format!(
+            "Supervisor starting {}. See the Supervisor output for more details.",
+            &ident
+        ))?;
+    }
+    req.reply_complete(net::ok());
+    Ok(())
+}
+
+pub fn service_stop(
+    mgr: &ManagerState,
+    req: &mut CtlRequest,
+    opts: protocol::ctl::SvcStop,
+) -> NetResult<()> {
+    let ident: PackageIdent = opts.ident.ok_or(err_update_client())?.into();
+    let updated_specs = match existing_specs_for_ident(&mgr.cfg, &ident)? {
+        Some(Spec::Service(mut spec)) => {
+            let mut updated_specs = vec![];
+            if spec.desired_state == DesiredState::Up {
+                spec.desired_state = DesiredState::Down;
+                updated_specs.push(spec);
+            }
+            updated_specs
+        }
+        Some(Spec::Composite(_, service_specs)) => {
+            let mut updated_specs = vec![];
+            for mut spec in service_specs {
+                if spec.desired_state == DesiredState::Up {
+                    spec.desired_state = DesiredState::Down;
+                    updated_specs.push(spec);
+                }
+            }
+            updated_specs
+        }
+        None => {
+            return Err(net::err(
+                ErrCode::NotFound,
+                format!("Service not loaded, {}", &ident),
+            ));
+        }
+    };
+    let specs_changed = updated_specs.len() > 0;
+    for spec in updated_specs.iter() {
+        save_spec_for(&mgr.cfg, spec)?;
+    }
+    if specs_changed {
+        // JW TODO: Change the langauge of the message below to "stopped" when we actually
+        // synchronously control services from the ctl gateway.
+        req.info(format!(
+            "Supervisor stopping {}. See the Supervisor output for more details.",
+            &ident
+        ))?;
+    }
+    req.reply_complete(net::ok());
+    Ok(())
+}
+
+pub fn supervisor_depart(
+    mgr: &ManagerState,
+    req: &mut CtlRequest,
+    opts: protocol::ctl::SupDepart,
+) -> NetResult<()> {
+    let member_id = opts.member_id.ok_or(err_update_client())?;
+    let mut client = match butterfly::client::Client::new(
+        mgr.cfg.gossip_listen.local_addr(),
+        mgr.cfg.ring_key.clone(),
+    ) {
+        Ok(client) => client,
+        Err(err) => {
+            outputln!("Failed to connect to own gossip server, {}", err);
+            return Err(net::err(ErrCode::Internal, err.to_string()));
+        }
+    };
+    outputln!("Attempting to depart member: {}", member_id);
+    match client.send_departure(member_id) {
+        Ok(()) => {
+            req.reply_complete(net::ok());
+            Ok(())
+        }
+        Err(e) => Err(net::err(ErrCode::Internal, e.to_string())),
+    }
+}
+
+pub fn service_status(
+    mgr: &ManagerState,
+    req: &mut CtlRequest,
+    opts: protocol::ctl::SvcStatus,
+) -> NetResult<()> {
+    let services_data = &mgr
+        .gateway_state
+        .read()
+        .expect("GatewayState lock is poisoned")
+        .services_data;
+    let statuses: Vec<ServiceStatus> = serde_json::from_str(&services_data)
+        .map_err(|e| sup_error!(Error::ServiceDeserializationError(e)))?;
+
+    if let Some(ident) = opts.ident {
+        for status in statuses {
+            if status.pkg.ident.satisfies(&ident) {
+                let mut msg: protocol::types::ServiceStatus = status.into();
+                req.reply_complete(msg);
+                return Ok(());
+            }
+        }
+        return Err(net::err(
+            ErrCode::NotFound,
+            format!("Service not loaded, {}", ident),
+        ));
+    }
+
+    // We're not dealing with a single service, but with all of them.
+    if statuses.is_empty() {
+        req.reply_complete(net::ok());
+    } else {
+        let mut list = statuses.into_iter().peekable();
+        while let Some(status) = list.next() {
+            let mut msg: protocol::types::ServiceStatus = status.into();
+            if list.peek().is_some() {
+                req.reply_partial(msg);
+            } else {
+                req.reply_complete(msg);
+            }
+        }
+    }
+    Ok(())
+}
+
+////////////////////////////////////////////////////////////////////////
+// Private helper functions
+
+fn composites_path<T>(state_path: T) -> PathBuf
+where
+    T: AsRef<Path>,
+{
+    state_path.as_ref().join("composites")
+}
+
+fn err_update_client() -> net::NetErr {
+    net::err(ErrCode::UpdateClient, "client out of date")
+}
+
+fn composite_path_for(cfg: &ManagerConfig, spec: &CompositeSpec) -> PathBuf {
+    composites_path(cfg.sup_root()).join(spec.file_name())
+}
+
+fn save_composite_spec_for(cfg: &ManagerConfig, spec: &CompositeSpec) -> Result<()> {
+    spec.to_file(composite_path_for(cfg, spec))
+}
+
+fn spec_path_for(cfg: &ManagerConfig, spec: &ServiceSpec) -> PathBuf {
+    cfg.sup_root().join("specs").join(spec.file_name())
+}
+
+fn save_spec_for(cfg: &ManagerConfig, spec: &ServiceSpec) -> Result<()> {
+    spec.to_file(spec_path_for(cfg, spec))
+}
+
+fn composite_path_by_ident(cfg: &ManagerConfig, ident: &PackageIdent) -> PathBuf {
+    let mut p = composites_path(cfg.sup_root()).join(&ident.name);
+    p.set_extension("spec");
+    p
+}
+
+/// Given an installed package, generate a spec (or specs, in the case
+/// of composite packages!) from it and the arguments passed in on the
+/// command line.
+fn generate_new_specs_from_package(
+    package: &PackageInstall,
+    opts: &protocol::ctl::SvcLoad,
+) -> Result<Vec<ServiceSpec>> {
+    let specs = match package.pkg_type()? {
+        PackageType::Standalone => {
+            let mut spec = ServiceSpec::default();
+            opts.into_spec(&mut spec);
+            vec![spec]
+        }
+        PackageType::Composite => opts.into_composite_spec(
+            package.ident().name.clone(),
+            package.pkg_services()?,
+            package.bind_map()?,
+        ),
+    };
+    Ok(specs)
+}
+
+/// Given a `PackageIdent`, return current specs if they exist. If
+/// the package is a standalone service, only that spec will be
+/// returned, but if it is a composite, the composite spec as well as
+/// the specs for all the services in the composite will be returned.
+fn existing_specs_for_ident(cfg: &ManagerConfig, ident: &PackageIdent) -> Result<Option<Spec>> {
+    let default_spec = ServiceSpec::default_for(ident.clone());
+    let spec_file = spec_path_for(cfg, &default_spec);
+
+    // Try it as a service first
+    if let Ok(spec) = ServiceSpec::from_file(&spec_file) {
+        Ok(Some(Spec::Service(spec)))
+    } else {
+        // Try it as a composite next
+        let composite_spec_file = composite_path_by_ident(&cfg, ident);
+        match CompositeSpec::from_file(composite_spec_file) {
+            Ok(composite_spec) => {
+                let fs_root_path = Path::new(&*FS_ROOT_PATH);
+                let package =
+                    PackageInstall::load(composite_spec.package_ident(), Some(fs_root_path))?;
+                let mut specs = vec![];
+
+                let services = package.pkg_services()?;
+                for service in services {
+                    let spec = ServiceSpec::from_file(spec_path_for(
+                        cfg,
+                        &ServiceSpec::default_for(service),
+                    ))?;
+                    specs.push(spec);
+                }
+
+                Ok(Some(Spec::Composite(composite_spec, specs)))
+            }
+            // Looks like we have no specs for this thing at all
+            Err(_) => Ok(None),
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct ServiceStatus {
+    pkg: Pkg,
+    process: ProcessStatus,
+    service_group: ServiceGroup,
+    composite: Option<String>,
+    desired_state: DesiredState,
+}
+
+impl fmt::Display for ServiceStatus {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "{} ({}), {}, group:{}",
+            self.pkg.ident,
+            self.composite.as_ref().unwrap_or(&"standalone".to_string()),
+            self.process,
+            self.service_group,
+        )
+    }
+}
+
+impl From<ServiceStatus> for protocol::types::ServiceStatus {
+    fn from(other: ServiceStatus) -> Self {
+        let mut proto = protocol::types::ServiceStatus::default();
+        proto.ident = other.pkg.ident.into();
+        proto.process = Some(other.process.into());
+        proto.service_group = other.service_group.into();
+        if let Some(composite) = other.composite {
+            proto.composite = Some(composite);
+        }
+        proto.desired_state = Some(other.desired_state.into());
+        proto
+    }
+}
+
+#[derive(Deserialize)]
+struct ProcessStatus {
+    #[serde(
+        deserialize_with = "deserialize_time",
+        rename = "state_entered"
+    )]
+    elapsed: TimeDuration,
+    pid: Option<u32>,
+    state: ProcessState,
+}
+
+impl fmt::Display for ProcessStatus {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self.pid {
+            Some(pid) => write!(
+                f,
+                "state:{}, time:{}, pid:{}",
+                self.state, self.elapsed, pid
+            ),
+            None => write!(f, "state:{}, time:{}", self.state, self.elapsed),
+        }
+    }
+}
+
+impl From<ProcessStatus> for protocol::types::ProcessStatus {
+    fn from(other: ProcessStatus) -> Self {
+        let mut proto = protocol::types::ProcessStatus::default();
+        proto.elapsed = Some(other.elapsed.num_seconds());
+        proto.state = other.state.into();
+        if let Some(pid) = other.pid {
+            proto.pid = Some(pid);
+        }
+        proto
+    }
+}
+
+fn deserialize_time<'de, D>(d: D) -> result::Result<TimeDuration, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    struct FromTimespec;
+
+    impl<'de> serde::de::Visitor<'de> for FromTimespec {
+        type Value = TimeDuration;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("a i64 integer")
+        }
+
+        fn visit_u64<R>(self, value: u64) -> result::Result<TimeDuration, R>
+        where
+            R: serde::de::Error,
+        {
+            let tspec = Timespec {
+                sec: (value as i64),
+                nsec: 0,
+            };
+            Ok(time::get_time() - tspec)
+        }
+    }
+
+    d.deserialize_u64(FromTimespec)
+}

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -15,6 +15,7 @@
 pub mod service;
 #[macro_use]
 mod debug;
+pub mod commands;
 mod events;
 mod file_watcher;
 mod peer_watcher;
@@ -26,8 +27,7 @@ mod sys;
 mod user_config_watcher;
 
 use std;
-use std::collections::{HashMap, HashSet};
-use std::fmt;
+use std::collections::HashMap;
 use std::fs::{self, File, OpenOptions};
 use std::io::{BufRead, BufReader, Read, Write};
 use std::mem;
@@ -46,34 +46,27 @@ use butterfly;
 use butterfly::member::Member;
 use butterfly::server::{timing::Timing, ServerProxy, Suitability};
 use butterfly::trace::Trace;
-use common::command::package::install::InstallSource;
-use common::ui::UIWriter;
 use futures::prelude::*;
 use futures::sync::mpsc;
 use hcore::crypto::SymKey;
 use hcore::env;
-use hcore::fs::FS_ROOT_PATH;
 use hcore::os::process::{self, Pid, Signal};
 use hcore::os::signals::{self, SignalEvent};
-use hcore::package::metadata::PackageType;
-use hcore::package::{Identifiable, PackageIdent, PackageInstall, PackageTarget};
+use hcore::package::{Identifiable, PackageIdent, PackageInstall};
 use hcore::service::ServiceGroup;
 use launcher_client::{LauncherCli, LAUNCHER_LOCK_CLEAN_ENV, LAUNCHER_PID_ENV};
 use protocol;
-use protocol::net::{self, ErrCode, NetResult};
 use rustls::{internal::pemfile, NoClientAuth, ServerConfig};
-use serde;
 use serde_json;
 use time::{self, Duration as TimeDuration, Timespec};
 use tokio::{executor, runtime};
-use toml;
 
 use self::peer_watcher::PeerWatcher;
 use self::self_updater::{SelfUpdater, SUP_PKG_IDENT};
-use self::service::{health::HealthCheck, DesiredState, IntoServiceSpec, Pkg, ProcessState};
+use self::service::{health::HealthCheck, DesiredState};
 pub use self::service::{
-    CompositeSpec, ConfigRendering, Service, ServiceBind, ServiceProxy, ServiceSpec, Spec,
-    Topology, UpdateStrategy,
+    CompositeSpec, ConfigRendering, Service, ServiceProxy, ServiceSpec, Spec, Topology,
+    UpdateStrategy,
 };
 use self::service_updater::ServiceUpdater;
 use self::spec_watcher::{SpecWatcher, SpecWatcherEvent};
@@ -85,8 +78,6 @@ use config::{EnvConfig, GossipListenAddr};
 use ctl_gateway::{self, CtlRequest};
 use error::{Error, Result, SupError};
 use http_gateway;
-use manager::service::spec::DesiredState as SpecDesiredState;
-use util;
 use ShutdownReason;
 use VERSION;
 
@@ -116,11 +107,10 @@ impl FsCfg {
         T: Into<PathBuf>,
     {
         let sup_root = sup_root.into();
-        let data_path = sup_root.join("data");
         FsCfg {
             specs_path: sup_root.join("specs"),
+            data_path: sup_root.join("data"),
             composites_path: sup_root.join("composites"),
-            data_path: data_path,
             member_id_file: sup_root.join(MEMBER_ID_FILE),
             proc_lock_file: sup_root.join(PROC_LOCK_FILE),
             sup_root: sup_root,
@@ -238,78 +228,15 @@ impl Manager {
     /// run if available.
     pub fn load(cfg: ManagerConfig, launcher: LauncherCli) -> Result<Manager> {
         let state_path = cfg.sup_root();
-        Self::create_state_path_dirs(&state_path)?;
-        Self::clean_dirty_state(&state_path)?;
         let fs_cfg = FsCfg::new(state_path);
+        Self::create_state_path_dirs(&fs_cfg)?;
+        Self::clean_dirty_state(&fs_cfg)?;
         if env::var(LAUNCHER_LOCK_CLEAN_ENV).is_ok() {
             release_process_lock(&fs_cfg);
         }
         obtain_process_lock(&fs_cfg)?;
 
         Self::new(cfg, fs_cfg, launcher)
-    }
-
-    /// Given an installed package, generate a spec (or specs, in the case
-    /// of composite packages!) from it and the arguments passed in on the
-    /// command line.
-    pub fn generate_new_specs_from_package(
-        package: &PackageInstall,
-        opts: &protocol::ctl::SvcLoad,
-    ) -> Result<Vec<ServiceSpec>> {
-        let specs = match package.pkg_type()? {
-            PackageType::Standalone => {
-                let mut spec = ServiceSpec::default();
-                opts.into_spec(&mut spec);
-                vec![spec]
-            }
-            PackageType::Composite => opts.into_composite_spec(
-                package.ident().name.clone(),
-                package.pkg_services()?,
-                package.bind_map()?,
-            ),
-        };
-        Ok(specs)
-    }
-
-    pub fn service_status(
-        mgr: &ManagerState,
-        req: &mut CtlRequest,
-        opts: protocol::ctl::SvcStatus,
-    ) -> NetResult<()> {
-        let services_data = &mgr
-            .gateway_state
-            .read()
-            .expect("GatewayState lock is poisoned")
-            .services_data;
-        let statuses: Vec<ServiceStatus> = serde_json::from_str(&services_data)
-            .map_err(|e| sup_error!(Error::ServiceDeserializationError(e)))?;
-
-        if let Some(ident) = opts.ident {
-            for status in statuses {
-                if status.pkg.ident.satisfies(&ident) {
-                    let mut msg: protocol::types::ServiceStatus = status.into();
-                    req.reply_complete(msg);
-                    return Ok(());
-                }
-            }
-            return Err(net::err(
-                ErrCode::NotFound,
-                format!("Service not loaded, {}", ident),
-            ));
-        } else if statuses.is_empty() {
-            req.reply_complete(net::ok());
-        } else {
-            let mut list = statuses.into_iter().peekable();
-            while let Some(status) = list.next() {
-                let mut msg: protocol::types::ServiceStatus = status.into();
-                if list.peek().is_some() {
-                    req.reply_partial(msg);
-                } else {
-                    req.reply_complete(msg);
-                }
-            }
-        }
-        Ok(())
     }
 
     pub fn term(cfg: &ManagerConfig) -> Result<()> {
@@ -475,75 +402,8 @@ impl Manager {
         Ok(member)
     }
 
-    pub fn spec_path_for(cfg: &ManagerConfig, spec: &ServiceSpec) -> PathBuf {
-        Self::specs_path(cfg.sup_root()).join(spec.file_name())
-    }
-
-    pub fn composite_path_for(cfg: &ManagerConfig, spec: &CompositeSpec) -> PathBuf {
-        Self::composites_path(cfg.sup_root()).join(spec.file_name())
-    }
-
-    // TODO (CM): BAAAAARF
-    pub fn composite_path_by_ident(cfg: &ManagerConfig, ident: &PackageIdent) -> PathBuf {
-        let mut p = Self::composites_path(cfg.sup_root()).join(&ident.name);
-        p.set_extension("spec");
-        p
-    }
-
-    /// Given a `PackageIdent`, return current specs if they exist. If
-    /// the package is a standalone service, only that spec will be
-    /// returned, but if it is a composite, the composite spec as well as
-    /// the specs for all the services in the composite will be returned.
-    pub fn existing_specs_for_ident(
-        cfg: &ManagerConfig,
-        ident: &PackageIdent,
-    ) -> Result<Option<Spec>> {
-        let default_spec = ServiceSpec::default_for(ident.clone());
-        let spec_file = Self::spec_path_for(cfg, &default_spec);
-
-        // Try it as a service first
-        if let Ok(spec) = ServiceSpec::from_file(&spec_file) {
-            Ok(Some(Spec::Service(spec)))
-        } else {
-            // Try it as a composite next
-            let composite_spec_file = Self::composite_path_by_ident(&cfg, ident);
-            match CompositeSpec::from_file(composite_spec_file) {
-                Ok(composite_spec) => {
-                    let fs_root_path = Path::new(&*FS_ROOT_PATH);
-                    let package =
-                        PackageInstall::load(composite_spec.package_ident(), Some(fs_root_path))?;
-                    let mut specs = vec![];
-
-                    let services = package.pkg_services()?;
-                    for service in services {
-                        let spec = ServiceSpec::from_file(Manager::spec_path_for(
-                            cfg,
-                            &ServiceSpec::default_for(service),
-                        ))?;
-                        specs.push(spec);
-                    }
-
-                    Ok(Some(Spec::Composite(composite_spec, specs)))
-                }
-                // Looks like we have no specs for this thing at all
-                Err(_) => Ok(None),
-            }
-        }
-    }
-
-    pub fn save_spec_for(cfg: &ManagerConfig, spec: &ServiceSpec) -> Result<()> {
-        spec.to_file(Self::spec_path_for(cfg, spec))
-    }
-
-    pub fn save_composite_spec_for(cfg: &ManagerConfig, spec: &CompositeSpec) -> Result<()> {
-        spec.to_file(Self::composite_path_for(cfg, spec))
-    }
-
-    fn clean_dirty_state<T>(state_path: T) -> Result<()>
-    where
-        T: AsRef<Path>,
-    {
-        let data_path = Self::data_path(&state_path);
+    fn clean_dirty_state(fs_cfg: &FsCfg) -> Result<()> {
+        let data_path = &fs_cfg.data_path;
         debug!("Cleaning cached health checks");
         match fs::read_dir(&data_path) {
             Ok(entries) => {
@@ -561,59 +421,35 @@ impl Manager {
                 }
                 Ok(())
             }
-            Err(err) => Err(sup_error!(Error::BadDataPath(data_path, err))),
+            Err(err) => Err(sup_error!(Error::BadDataPath(data_path.clone(), err))),
         }
     }
 
-    fn create_state_path_dirs<T>(state_path: T) -> Result<()>
-    where
-        T: AsRef<Path>,
-    {
-        let data_path = Self::data_path(&state_path);
+    fn create_state_path_dirs(fs_cfg: &FsCfg) -> Result<()> {
+        let data_path = &fs_cfg.data_path;
         debug!("Creating data directory: {}", data_path.display());
         if let Some(err) = fs::create_dir_all(&data_path).err() {
-            return Err(sup_error!(Error::BadDataPath(data_path, err)));
+            return Err(sup_error!(Error::BadDataPath(data_path.clone(), err)));
         }
-        let specs_path = Self::specs_path(&state_path);
+        let specs_path = &fs_cfg.specs_path;
         debug!("Creating specs directory: {}", specs_path.display());
         if let Some(err) = fs::create_dir_all(&specs_path).err() {
-            return Err(sup_error!(Error::BadSpecsPath(specs_path, err)));
+            return Err(sup_error!(Error::BadSpecsPath(specs_path.clone(), err)));
         }
 
-        let composites_path = Self::composites_path(&state_path);
+        let composites_path = &fs_cfg.composites_path;
         debug!(
             "Creating composites directory: {}",
             composites_path.display()
         );
         if let Some(err) = fs::create_dir_all(&composites_path).err() {
-            return Err(sup_error!(Error::BadCompositesPath(composites_path, err)));
+            return Err(sup_error!(Error::BadCompositesPath(
+                composites_path.clone(),
+                err
+            )));
         }
 
         Ok(())
-    }
-
-    #[inline]
-    fn data_path<T>(state_path: T) -> PathBuf
-    where
-        T: AsRef<Path>,
-    {
-        state_path.as_ref().join("data")
-    }
-
-    #[inline]
-    fn specs_path<T>(state_path: T) -> PathBuf
-    where
-        T: AsRef<Path>,
-    {
-        state_path.as_ref().join("specs")
-    }
-
-    #[inline]
-    fn composites_path<T>(state_path: T) -> PathBuf
-    where
-        T: AsRef<Path>,
-    {
-        state_path.as_ref().join("composites")
     }
 
     fn add_service(&mut self, spec: ServiceSpec) {
@@ -692,7 +528,7 @@ impl Manager {
         runtime.spawn(ctl_handler);
 
         if let Some(svc_load) = svc {
-            Self::service_load(&self.state, &mut CtlRequest::default(), svc_load)?;
+            commands::service_load(&self.state, &mut CtlRequest::default(), svc_load)?;
         }
         self.start_initial_services_from_spec_watcher()?;
 
@@ -894,533 +730,6 @@ impl Manager {
                 let time_to_wait = next_check - now;
                 thread::sleep(time_to_wait.to_std().unwrap());
             }
-        }
-    }
-
-    pub fn service_cfg(
-        mgr: &ManagerState,
-        req: &mut CtlRequest,
-        opts: protocol::ctl::SvcGetDefaultCfg,
-    ) -> NetResult<()> {
-        let ident: PackageIdent = opts.ident.ok_or(err_update_client())?.into();
-        let mut msg = protocol::types::ServiceCfg {
-            format: Some(protocol::types::service_cfg::Format::Toml as i32),
-            default: None,
-        };
-        for service in mgr
-            .services
-            .read()
-            .expect("Services lock is poisoned")
-            .values()
-        {
-            if service.pkg.ident.satisfies(&ident) {
-                if let Some(ref cfg) = service.cfg.default {
-                    msg.default = Some(
-                        toml::to_string_pretty(&toml::value::Value::Table(cfg.clone())).unwrap(),
-                    );
-                    req.reply_complete(msg);
-                }
-                return Ok(());
-            }
-        }
-        Err(net::err(
-            ErrCode::NotFound,
-            format!("Service not loaded, {}", ident),
-        ))
-    }
-
-    pub fn service_cfg_validate(
-        _mgr: &ManagerState,
-        req: &mut CtlRequest,
-        opts: protocol::ctl::SvcValidateCfg,
-    ) -> NetResult<()> {
-        let cfg = opts.cfg.ok_or(err_update_client())?;
-        let format = opts
-            .format
-            .and_then(protocol::types::service_cfg::Format::from_i32)
-            .unwrap_or_default();
-        if cfg.len() > protocol::butterfly::MAX_SVC_CFG_SIZE {
-            return Err(net::err(
-                ErrCode::EntityTooLarge,
-                "Configuration too large.",
-            ));
-        }
-        if format != protocol::types::service_cfg::Format::Toml {
-            return Err(net::err(
-                ErrCode::NotSupported,
-                format!("Configuration format {} not available.", format),
-            ));
-        }
-        let _new_cfg: toml::value::Table = toml::from_slice(&cfg).map_err(|e| {
-            net::err(
-                ErrCode::BadPayload,
-                format!("Unable to decode configuration as {}, {}", format, e),
-            )
-        })?;
-        req.reply_complete(net::ok());
-        Ok(())
-        // JW TODO: Hold off on validation until we can validate services which aren't currently
-        // loaded in the Supervisor but are known through rumor propagation.
-        // let service_group: ServiceGroup = opts.service_group.into();
-        // for service in mgr.services.read().unwrap().iter() {
-        //     if service.service_group != service_group {
-        //         continue;
-        //     }
-        //     if let Some(interface) = service.cfg.interface() {
-        //         match Cfg::validate(interface, &new_cfg) {
-        //             None => req.reply_complete(net::ok()),
-        //             Some(errors) => {
-        //                 for error in errors {
-        //                     req.reply_partial(net::err(ErrCode::InvalidPayload, error));
-        //                 }
-        //                 req.reply_complete(net::ok());
-        //             }
-        //         }
-        //         return Ok(());
-        //     } else {
-        //         // No interface, this service can't be configured.
-        //         return Err(net::err(
-        //             ErrCode::NotFound,
-        //             "Service has no configurable attributes.",
-        //         ));
-        //     }
-        // }
-        // Err(net::err(
-        //     ErrCode::NotFound,
-        //     format!("Service not loaded, {}", service_group),
-        // ))
-    }
-
-    pub fn service_cfg_set(
-        mgr: &ManagerState,
-        req: &mut CtlRequest,
-        opts: protocol::ctl::SvcSetCfg,
-    ) -> NetResult<()> {
-        let cfg = opts.cfg.ok_or(err_update_client())?;
-        let is_encrypted = opts.is_encrypted.unwrap_or(false);
-        let version = opts.version.ok_or(err_update_client())?;
-        let service_group: ServiceGroup = opts.service_group.ok_or(err_update_client())?.into();
-        if cfg.len() > protocol::butterfly::MAX_SVC_CFG_SIZE {
-            return Err(net::err(
-                ErrCode::EntityTooLarge,
-                "Configuration too large.",
-            ));
-        }
-        outputln!(
-            "Setting new configuration version {} for {}",
-            version,
-            service_group,
-        );
-        let mut client = match butterfly::client::Client::new(
-            mgr.cfg.gossip_listen.local_addr(),
-            mgr.cfg.ring_key.clone(),
-        ) {
-            Ok(client) => client,
-            Err(err) => {
-                outputln!("Failed to connect to own gossip server, {}", err);
-                return Err(net::err(ErrCode::Internal, err.to_string()));
-            }
-        };
-        match client.send_service_config(service_group, version, cfg, is_encrypted) {
-            Ok(()) => {
-                req.reply_complete(net::ok());
-                return Ok(());
-            }
-            Err(e) => return Err(net::err(ErrCode::Internal, e.to_string())),
-        }
-    }
-
-    pub fn service_file_put(
-        mgr: &ManagerState,
-        req: &mut CtlRequest,
-        opts: protocol::ctl::SvcFilePut,
-    ) -> NetResult<()> {
-        let content = opts.content.ok_or(err_update_client())?;
-        let filename = opts.filename.ok_or(err_update_client())?;
-        let is_encrypted = opts.is_encrypted.unwrap_or(false);
-        let version = opts.version.ok_or(err_update_client())?;
-        let service_group: ServiceGroup = opts.service_group.ok_or(err_update_client())?.into();
-        if content.len() > protocol::butterfly::MAX_FILE_PUT_SIZE_BYTES {
-            return Err(net::err(ErrCode::EntityTooLarge, "File content too large."));
-        }
-        outputln!(
-            "Receiving new version {} of file {} for {}",
-            version,
-            filename,
-            service_group,
-        );
-        let mut client = match butterfly::client::Client::new(
-            mgr.cfg.gossip_listen.local_addr(),
-            mgr.cfg.ring_key.clone(),
-        ) {
-            Ok(client) => client,
-            Err(err) => {
-                outputln!("Failed to connect to own gossip server, {}", err);
-                return Err(net::err(ErrCode::Internal, err.to_string()));
-            }
-        };
-        match client.send_service_file(service_group, filename, version, content, is_encrypted) {
-            Ok(()) => {
-                req.reply_complete(net::ok());
-                return Ok(());
-            }
-            Err(e) => return Err(net::err(ErrCode::Internal, e.to_string())),
-        }
-    }
-
-    pub fn service_load(
-        mgr: &ManagerState,
-        req: &mut CtlRequest,
-        opts: protocol::ctl::SvcLoad,
-    ) -> NetResult<()> {
-        let ident: PackageIdent = opts.ident.clone().ok_or(err_update_client())?.into();
-        let bldr_url = opts
-            .bldr_url
-            .clone()
-            .unwrap_or(protocol::DEFAULT_BLDR_URL.to_string());
-        let bldr_channel = opts
-            .bldr_channel
-            .clone()
-            .unwrap_or(protocol::DEFAULT_BLDR_CHANNEL.to_string());
-        let force = opts.force.clone().unwrap_or(false);
-        let source = InstallSource::Ident(ident.clone(), *PackageTarget::active_target());
-        match Self::existing_specs_for_ident(&mgr.cfg, source.as_ref())? {
-            None => {
-                // We don't have any record of this thing; let's set it up!
-                //
-                // If a package exists on disk that satisfies the
-                // desired package identifier, it will be used;
-                // otherwise, we'll install the latest suitable
-                // version from the specified Builder channel.
-                let installed =
-                    util::pkg::satisfy_or_install(req, &source, &bldr_url, &bldr_channel)?;
-
-                let mut specs = Self::generate_new_specs_from_package(&installed, &opts)?;
-
-                for spec in specs.iter_mut() {
-                    Self::save_spec_for(&mgr.cfg, spec)?;
-                    req.info(format!(
-                        "The {} service was successfully loaded",
-                        spec.ident
-                    ))?;
-                }
-
-                // Only saves a composite spec if it's, well, a composite
-                if let Ok(composite_spec) =
-                    CompositeSpec::from_package_install(source.as_ref(), &installed)
-                {
-                    Self::save_composite_spec_for(&mgr.cfg, &composite_spec)?;
-                    req.info(format!(
-                        "The {} composite was successfully loaded",
-                        composite_spec.ident()
-                    ))?;
-                }
-            }
-            Some(spec) => {
-                // We've seen this service / composite before. Thus `load`
-                // basically acts as a way to edit spec files on the
-                // command line. As a result, we a) check that you
-                // *really* meant to change an existing spec, and b) DO
-                // NOT download a potentially new version of the package
-                // in question
-
-                if !force {
-                    // TODO (CM): make this error reflect composites
-                    return Err(net::err(
-                        ErrCode::Conflict,
-                        format!("Service already loaded, unload '{}' and try again", ident),
-                    ));
-                }
-
-                match spec {
-                    Spec::Service(mut service_spec) => {
-                        opts.into_spec(&mut service_spec);
-
-                        // Only install if we don't have something
-                        // locally; otherwise you could potentially
-                        // upgrade each time you load.
-                        //
-                        // Also make sure you're pulling from where you're
-                        // supposed to be pulling from!
-                        util::pkg::satisfy_or_install(
-                            req,
-                            &source,
-                            &service_spec.bldr_url,
-                            &service_spec.channel,
-                        )?;
-
-                        Self::save_spec_for(&mgr.cfg, &service_spec)?;
-                        req.info(format!(
-                            "The {} service was successfully loaded",
-                            service_spec.ident
-                        ))?;
-                    }
-                    Spec::Composite(composite_spec, mut existing_service_specs) => {
-                        if source.as_ref() == composite_spec.ident() {
-                            let mut bind_map =
-                                match util::pkg::installed(composite_spec.package_ident()) {
-                                    Some(package) => package.bind_map()?,
-                                    // TODO (CM): this should be a proper error
-                                    None => unreachable!(),
-                                };
-
-                            for mut service_spec in existing_service_specs.iter_mut() {
-                                opts.update_composite(&mut bind_map, &mut service_spec);
-                                Self::save_spec_for(&mgr.cfg, service_spec)?;
-                                req.info(format!(
-                                    "The {} service was successfully loaded",
-                                    service_spec.ident
-                                ))?;
-                            }
-                            req.info(format!(
-                                "The {} composite was successfully loaded",
-                                composite_spec.ident()
-                            ))?;
-                        } else {
-                            // It changed!
-                            // OK, here's the deal.
-                            //
-                            // We're going to install a new composite if
-                            // we need to in order to satisfy the spec
-                            // we've now got. That also means that the
-                            // services that are currently running may get
-                            // unloaded (because they are no longer in the
-                            // composite), and new services may start
-                            // (because they were added to the composite).
-
-                            let installed_package = util::pkg::satisfy_or_install(
-                                req,
-                                &source,
-                                // This (updating from the command-line
-                                // args) is a difference from
-                                // force-loading a spec, because
-                                // composites don't auto-update themselves
-                                // like services can.
-                                &bldr_url,
-                                &bldr_channel,
-                            )?;
-
-                            // Generate new specs from the new composite package and
-                            // CLI inputs
-                            let new_service_specs =
-                                Self::generate_new_specs_from_package(&installed_package, &opts)?;
-
-                            // Delete any specs that are not in the new
-                            // composite
-                            let mut old_spec_names = HashSet::new();
-                            for s in existing_service_specs.iter() {
-                                old_spec_names.insert(s.ident.name.clone());
-                            }
-                            let mut new_spec_names = HashSet::new();
-                            for s in new_service_specs.iter() {
-                                new_spec_names.insert(s.ident.name.clone());
-                            }
-
-                            let specs_to_delete: HashSet<_> =
-                                old_spec_names.difference(&new_spec_names).collect();
-                            for spec in existing_service_specs.iter() {
-                                if specs_to_delete.contains(&spec.ident.name) {
-                                    let file = Manager::spec_path_for(&mgr.cfg, spec);
-                                    req.info(format!("Unloading {:?}", file))?;
-                                    std::fs::remove_file(&file).map_err(|err| {
-                                        sup_error!(Error::ServiceSpecFileIO(file, err))
-                                    })?;
-                                }
-                            }
-                            // <-- end of deletion
-
-                            // Save all the new specs. If there are
-                            // services that exist in both composites,
-                            // their service spec files will have the same
-                            // name, so they'll be taken care of here (we
-                            // don't need to treat them differently)
-                            for spec in new_service_specs.iter() {
-                                Self::save_spec_for(&mgr.cfg, spec)?;
-                                req.info(format!(
-                                    "The {} service was successfully loaded",
-                                    spec.ident
-                                ))?;
-                            }
-
-                            // Generate and save the new spec
-                            let new_composite_spec = CompositeSpec::from_package_install(
-                                source.as_ref(),
-                                &installed_package,
-                            )?;
-                            Self::save_composite_spec_for(&mgr.cfg, &new_composite_spec)?;
-                            req.info(format!(
-                                "The {} composite was successfully loaded",
-                                new_composite_spec.ident()
-                            ))?;
-                        }
-                    }
-                }
-            }
-        }
-        req.reply_complete(net::ok());
-        Ok(())
-    }
-
-    pub fn service_unload(
-        mgr: &ManagerState,
-        req: &mut CtlRequest,
-        opts: protocol::ctl::SvcUnload,
-    ) -> NetResult<()> {
-        let ident: PackageIdent = opts.ident.ok_or(err_update_client())?.into();
-        // Gather up the paths to all the spec files we care about,
-        // along with their corresponding idents (we do this to ensure
-        // we emit a proper "unloading X" message for each member of a
-        // composite).
-        //
-        // This includes all service specs as well as any composite
-        // spec.
-        let path_ident_pairs = match Self::existing_specs_for_ident(&mgr.cfg, &ident)? {
-            Some(Spec::Service(spec)) => vec![(Self::spec_path_for(&mgr.cfg, &spec), ident)],
-            Some(Spec::Composite(composite_spec, specs)) => {
-                let mut paths = Vec::with_capacity(specs.len() + 1);
-                for spec in specs.iter() {
-                    paths.push((Self::spec_path_for(&mgr.cfg, spec), spec.ident.clone()));
-                }
-                paths.push((Self::composite_path_for(&mgr.cfg, &composite_spec), ident));
-                paths
-            }
-            None => vec![],
-        };
-
-        for (file, ident) in path_ident_pairs {
-            if let Err(err) = std::fs::remove_file(&file) {
-                return Err(net::err(
-                    ErrCode::Internal,
-                    format!("{}", sup_error!(Error::ServiceSpecFileIO(file, err))),
-                ));
-            };
-            // JW TODO: Change this to unloaded from unloading when the Supervisor waits for
-            // the work to complete.
-            req.info(format!("Unloading {}", ident))?;
-        }
-        req.reply_complete(net::ok());
-        Ok(())
-    }
-
-    pub fn service_start(
-        mgr: &ManagerState,
-        req: &mut CtlRequest,
-        opts: protocol::ctl::SvcStart,
-    ) -> NetResult<()> {
-        let ident = opts.ident.ok_or(err_update_client())?.into();
-        let updated_specs = match Self::existing_specs_for_ident(&mgr.cfg, &ident)? {
-            Some(Spec::Service(mut spec)) => {
-                let mut updated_specs = vec![];
-                if spec.desired_state == DesiredState::Down {
-                    spec.desired_state = DesiredState::Up;
-                    updated_specs.push(spec);
-                }
-                updated_specs
-            }
-            Some(Spec::Composite(_, service_specs)) => {
-                let mut updated_specs = vec![];
-                for mut spec in service_specs {
-                    if spec.desired_state == DesiredState::Down {
-                        spec.desired_state = DesiredState::Up;
-                        updated_specs.push(spec);
-                    }
-                }
-                updated_specs
-            }
-            None => {
-                return Err(net::err(
-                    ErrCode::NotFound,
-                    format!("Service not loaded, {}", &ident),
-                ));
-            }
-        };
-        let specs_changed = updated_specs.len() > 0;
-        for spec in updated_specs.iter() {
-            Self::save_spec_for(&mgr.cfg, spec)?;
-        }
-        if specs_changed {
-            // JW TODO: Change the language of the message below to "started" when we actually
-            // synchronously control services from the ctl gateway.
-            req.info(format!(
-                "Supervisor starting {}. See the Supervisor output for more details.",
-                &ident
-            ))?;
-        }
-        req.reply_complete(net::ok());
-        Ok(())
-    }
-
-    pub fn service_stop(
-        mgr: &ManagerState,
-        req: &mut CtlRequest,
-        opts: protocol::ctl::SvcStop,
-    ) -> NetResult<()> {
-        let ident: PackageIdent = opts.ident.ok_or(err_update_client())?.into();
-        let updated_specs = match Self::existing_specs_for_ident(&mgr.cfg, &ident)? {
-            Some(Spec::Service(mut spec)) => {
-                let mut updated_specs = vec![];
-                if spec.desired_state == DesiredState::Up {
-                    spec.desired_state = DesiredState::Down;
-                    updated_specs.push(spec);
-                }
-                updated_specs
-            }
-            Some(Spec::Composite(_, service_specs)) => {
-                let mut updated_specs = vec![];
-                for mut spec in service_specs {
-                    if spec.desired_state == DesiredState::Up {
-                        spec.desired_state = DesiredState::Down;
-                        updated_specs.push(spec);
-                    }
-                }
-                updated_specs
-            }
-            None => {
-                return Err(net::err(
-                    ErrCode::NotFound,
-                    format!("Service not loaded, {}", &ident),
-                ));
-            }
-        };
-        let specs_changed = updated_specs.len() > 0;
-        for spec in updated_specs.iter() {
-            Self::save_spec_for(&mgr.cfg, spec)?;
-        }
-        if specs_changed {
-            // JW TODO: Change the langauge of the message below to "stopped" when we actually
-            // synchronously control services from the ctl gateway.
-            req.info(format!(
-                "Supervisor stopping {}. See the Supervisor output for more details.",
-                &ident
-            ))?;
-        }
-        req.reply_complete(net::ok());
-        Ok(())
-    }
-
-    pub fn supervisor_depart(
-        mgr: &ManagerState,
-        req: &mut CtlRequest,
-        opts: protocol::ctl::SupDepart,
-    ) -> NetResult<()> {
-        let member_id = opts.member_id.ok_or(err_update_client())?;
-        let mut client = match butterfly::client::Client::new(
-            mgr.cfg.gossip_listen.local_addr(),
-            mgr.cfg.ring_key.clone(),
-        ) {
-            Ok(client) => client,
-            Err(err) => {
-                outputln!("Failed to connect to own gossip server, {}", err);
-                return Err(net::err(ErrCode::Internal, err.to_string()));
-            }
-        };
-        outputln!("Attempting to depart member: {}", member_id);
-        match client.send_departure(member_id) {
-            Ok(()) => {
-                req.reply_complete(net::ok());
-                Ok(())
-            }
-            Err(e) => Err(net::err(ErrCode::Internal, e.to_string())),
         }
     }
 
@@ -1841,52 +1150,6 @@ impl Into<usize> for TokioThreadCount {
     }
 }
 
-#[derive(Deserialize)]
-pub struct ProcessStatus {
-    #[serde(
-        deserialize_with = "deserialize_time",
-        rename = "state_entered"
-    )]
-    pub elapsed: TimeDuration,
-    pub pid: Option<u32>,
-    pub state: ProcessState,
-}
-
-impl fmt::Display for ProcessStatus {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self.pid {
-            Some(pid) => write!(
-                f,
-                "state:{}, time:{}, pid:{}",
-                self.state, self.elapsed, pid
-            ),
-            None => write!(f, "state:{}, time:{}", self.state, self.elapsed),
-        }
-    }
-}
-
-#[derive(Deserialize)]
-pub struct ServiceStatus {
-    pub pkg: Pkg,
-    pub process: ProcessStatus,
-    pub service_group: ServiceGroup,
-    pub composite: Option<String>,
-    pub desired_state: DesiredState,
-}
-
-impl fmt::Display for ServiceStatus {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "{} ({}), {}, group:{}",
-            self.pkg.ident,
-            self.composite.as_ref().unwrap_or(&"standalone".to_string()),
-            self.process,
-            self.service_group,
-        )
-    }
-}
-
 #[derive(Debug)]
 struct SuitabilityLookup(Arc<RwLock<HashMap<PackageIdent, Service>>>);
 
@@ -1900,38 +1163,6 @@ impl Suitability for SuitabilityLookup {
             .and_then(|s| s.suitability())
             .unwrap_or(u64::min_value())
     }
-}
-
-fn err_update_client() -> net::NetErr {
-    net::err(ErrCode::UpdateClient, "client out of date")
-}
-
-fn deserialize_time<'de, D>(d: D) -> result::Result<TimeDuration, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    struct FromTimespec;
-
-    impl<'de> serde::de::Visitor<'de> for FromTimespec {
-        type Value = TimeDuration;
-
-        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-            formatter.write_str("a i64 integer")
-        }
-
-        fn visit_u64<R>(self, value: u64) -> result::Result<TimeDuration, R>
-        where
-            R: serde::de::Error,
-        {
-            let tspec = Timespec {
-                sec: (value as i64),
-                nsec: 0,
-            };
-            Ok(time::get_time() - tspec)
-        }
-    }
-
-    d.deserialize_u64(FromTimespec)
 }
 
 fn obtain_process_lock(fs_cfg: &FsCfg) -> Result<()> {
@@ -2077,60 +1308,6 @@ impl Future for CtlHandler {
             }
         }
         Ok(Async::Ready(()))
-    }
-}
-
-impl From<ProcessStatus> for protocol::types::ProcessStatus {
-    fn from(other: ProcessStatus) -> Self {
-        let mut proto = protocol::types::ProcessStatus::default();
-        proto.elapsed = Some(other.elapsed.num_seconds());
-        proto.state = other.state.into();
-        if let Some(pid) = other.pid {
-            proto.pid = Some(pid);
-        }
-        proto
-    }
-}
-
-impl From<service::ServiceBind> for protocol::types::ServiceBind {
-    fn from(bind: service::ServiceBind) -> Self {
-        let mut proto = protocol::types::ServiceBind::default();
-        proto.name = bind.name;
-        proto.service_group = bind.service_group.into();
-        proto
-    }
-}
-
-impl From<ServiceStatus> for protocol::types::ServiceStatus {
-    fn from(other: ServiceStatus) -> Self {
-        let mut proto = protocol::types::ServiceStatus::default();
-        proto.ident = other.pkg.ident.into();
-        proto.process = Some(other.process.into());
-        proto.service_group = other.service_group.into();
-        if let Some(composite) = other.composite {
-            proto.composite = Some(composite);
-        }
-        proto.desired_state = Some(other.desired_state.into());
-        proto
-    }
-}
-
-impl Into<service::ServiceBind> for protocol::types::ServiceBind {
-    fn into(self) -> service::ServiceBind {
-        service::ServiceBind {
-            name: self.name,
-            service_group: self.service_group.into(),
-            service_name: self.service_name,
-        }
-    }
-}
-
-impl From<SpecDesiredState> for i32 {
-    fn from(other: SpecDesiredState) -> Self {
-        match other {
-            DesiredState::Down => 0,
-            DesiredState::Up => 1,
-        }
     }
 }
 

--- a/components/sup/src/manager/service/spec.rs
+++ b/components/sup/src/manager/service/spec.rs
@@ -77,6 +77,15 @@ impl FromStr for DesiredState {
     }
 }
 
+impl From<DesiredState> for i32 {
+    fn from(other: DesiredState) -> Self {
+        match other {
+            DesiredState::Down => 0,
+            DesiredState::Up => 1,
+        }
+    }
+}
+
 pub enum Spec {
     Service(ServiceSpec),
     Composite(CompositeSpec, Vec<ServiceSpec>),
@@ -492,6 +501,25 @@ impl serde::Serialize for ServiceBind {
         S: serde::Serializer,
     {
         serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl From<ServiceBind> for protocol::types::ServiceBind {
+    fn from(bind: ServiceBind) -> Self {
+        let mut proto = protocol::types::ServiceBind::default();
+        proto.name = bind.name;
+        proto.service_group = bind.service_group.into();
+        proto
+    }
+}
+
+impl Into<ServiceBind> for protocol::types::ServiceBind {
+    fn into(self) -> ServiceBind {
+        ServiceBind {
+            name: self.name,
+            service_group: self.service_group.into(),
+            service_name: self.service_name,
+        }
     }
 }
 


### PR DESCRIPTION
The `manager` module, as well as the `Manager` struct itself, has
grown bloated, making it difficult to work with. A closer reading of
the code revealed lots of code that was not directly related to
managing the Supervisor's "main loop"; this code was moved to more
appropriate places.

In particular:

- All functions that implement the various `hab sup` commands were
  moved into a new `commands` module. All of these were static methods
  on the `Manager` struct, making it easy to completely remove them.

- A few accessory structs (`ProcessStatus` and `ServiceStatus`) were
  moved into this `commands` module, since they are only needed for
  the command functions.

- A number of accessory functions for dealing with specs that were
  only used in the commands were also extracted into `commands`.

- A few trait implementations for `ServiceBind` and `DesiredState`
  that existed in the `manager` module, instead of the `spec` module
  where the structs themselves are defined, were moved.

- The `clean_dirty_state` and `clean_state_path_dirs` functions were
  slightly reworked to pull information from `FsCfg`, which provided the
  same information as some static path functions, allowing the deletion
  of the latter.

  It should be noted that there remains a bit of duplication around
  the creation of these filesystem paths (see `FsCfg` and the
  `commands` module). Further exploration reveals that our filesystem
  path logic is actually split up across several modules across the
  project. Consolidation of all that should be a follow-on PR.

Signed-off-by: Christopher Maier <cmaier@chef.io>