### PR TITLE
Add --transitive option to hab pkg dependencies

### DIFF
--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -533,8 +533,10 @@ pub fn get() -> App<'static, 'static> {
                     (ex: /home/acme-redis-3.0.7-21120102031201-x86_64-linux.hart)")
             )
             (@subcommand dependencies =>
-                (about: "Returns the Habitat Artifact dependencies")
+                (about: "Returns the Habitat Artifact dependencies. By default it will return \
+                    the direct dependencies of the package")
                 (aliases: &["dep", "deps"])
+                (@arg TRANSITIVE: -t --transitive "Show transitive dependencies")
                 (@arg PKG_IDENT: +required +takes_value {valid_ident}
                     "A package identifier (ex: core/redis, core/busybox-static/1.42.2)")
             )

--- a/components/hab/src/command/pkg/dependencies.rs
+++ b/components/hab/src/command/pkg/dependencies.rs
@@ -14,14 +14,18 @@
 
 use std::path::Path;
 
+use super::Scope;
 use hcore::package::{PackageIdent, PackageInstall};
 
 use error::Result;
 
-pub fn start(ident: &PackageIdent, fs_root_path: &Path) -> Result<()> {
+pub fn start(ident: &PackageIdent, scope: &Scope, fs_root_path: &Path) -> Result<()> {
     let pkg_install = PackageInstall::load(ident, Some(fs_root_path))?;
 
-    let deps = pkg_install.tdeps()?;
+    let deps = match &scope {
+        Scope::Package => pkg_install.deps()?,
+        Scope::PackageAndDependencies => pkg_install.tdeps()?,
+    };
 
     for dep in &deps {
         println!("{}", dep);

--- a/components/hab/src/command/pkg/mod.rs
+++ b/components/hab/src/command/pkg/mod.rs
@@ -43,7 +43,7 @@ pub enum ExecutionStrategy {
 }
 
 /// Used in `hab pkg` commands to choose where to apply the command to just a package
-/// or the package and it's dependencies
+/// or the package and its dependencies
 pub enum Scope {
     Package,
     PackageAndDependencies,

--- a/components/hab/src/command/pkg/mod.rs
+++ b/components/hab/src/command/pkg/mod.rs
@@ -42,7 +42,7 @@ pub enum ExecutionStrategy {
     Run,
 }
 
-/// Used in `hab pkg uninstall` to choose where to iterate over just a package
+/// Used in `hab pkg` commands to choose where to apply the command to just a package
 /// or the package and it's dependencies
 pub enum Scope {
     Package,

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -469,9 +469,10 @@ fn sub_pkg_binds(m: &ArgMatches) -> Result<()> {
 
 fn sub_pkg_dependencies(m: &ArgMatches) -> Result<()> {
     let ident = PackageIdent::from_str(m.value_of("PKG_IDENT").unwrap())?;
-    let scope = match m.is_present("TRANSITIVE") {
-        true => command::pkg::Scope::PackageAndDependencies,
-        false => command::pkg::Scope::Package,
+    let scope = if m.is_present("TRANSITIVE") {
+        command::pkg::Scope::PackageAndDependencies
+    } else {
+        command::pkg::Scope::Package
     };
 
     command::pkg::dependencies::start(&ident, &scope, &*FS_ROOT)

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -469,7 +469,12 @@ fn sub_pkg_binds(m: &ArgMatches) -> Result<()> {
 
 fn sub_pkg_dependencies(m: &ArgMatches) -> Result<()> {
     let ident = PackageIdent::from_str(m.value_of("PKG_IDENT").unwrap())?;
-    command::pkg::dependencies::start(&ident, &*FS_ROOT)
+    let scope = match m.is_present("TRANSITIVE") {
+        true => command::pkg::Scope::PackageAndDependencies,
+        false => command::pkg::Scope::Package,
+    };
+
+    command::pkg::dependencies::start(&ident, &scope, &*FS_ROOT)
 }
 
 fn sub_pkg_env(m: &ArgMatches) -> Result<()> {


### PR DESCRIPTION
After UX review it was suggested that we should either show direct
dependencies or all recursive dependencies with a -t/--transitive command

NOTE: There is a breaking change in how --transitive works. The default (with no options) used to show transitive dependencies, now it will only show direct dependencies. This was done after walking through the UX with @mpeck and considering this would be the most understandable behaviour for the user.

Signed-off-by: James Casey <james@chef.io>

