### PR TITLE
Improve member health interface

### DIFF
--- a/components/butterfly/src/member.rs
+++ b/components/butterfly/src/member.rs
@@ -636,19 +636,6 @@ impl MemberList {
         }
     }
 
-    pub fn check_in_voting_population_by_id(&self, member_id: &str) -> bool {
-        match self
-            .health
-            .read()
-            .expect("Health lock is poisoned")
-            .get(member_id)
-        {
-            Some(&Health::Alive) | Some(&Health::Suspect) | Some(&Health::Confirmed) => true,
-            Some(&Health::Departed) => false,
-            None => false,
-        }
-    }
-
     /// Returns true if the members health is the same as `health`. False otherwise.
     pub fn check_health_of(&self, member: &Member, health: Health) -> bool {
         match self

--- a/components/butterfly/src/member.rs
+++ b/components/butterfly/src/member.rs
@@ -1055,7 +1055,7 @@ mod tests {
                 };
 
                 assert!(
-                    ml.insert(member.clone(), from_health.clone()),
+                    ml.insert(member.clone(), from_health),
                     "Could not insert member into list initially"
                 );
 
@@ -1068,7 +1068,7 @@ mod tests {
 
                 assert_eq!(
                     ml.health_of(&member),
-                    Some(from_health.clone()),
+                    Some(from_health),
                     "Member should have had health {:?}, but didn't",
                     from_health
                 );
@@ -1091,7 +1091,7 @@ mod tests {
                 "Update counter should not have been incremented after trying to insert a lower-incarnation-number rumor"
             );
                 assert_eq!(
-                ml.health_of(&member), Some(from_health.clone()),
+                ml.health_of(&member), Some(from_health),
                 "Member should have still have health {:?} following attempt to insert lower-incarnation-number rumor, but didn't",
                 from_health
             );
@@ -1143,7 +1143,7 @@ mod tests {
                 };
 
                 assert!(
-                    ml.insert(member.clone(), from_health.clone()),
+                    ml.insert(member.clone(), from_health),
                     "Could not insert member into list initially"
                 );
 
@@ -1156,7 +1156,7 @@ mod tests {
 
                 assert_eq!(
                     ml.health_of(&member),
-                    Some(from_health.clone()),
+                    Some(from_health),
                     "Member should have had health {:?}, but didn't",
                     from_health
                 );
@@ -1179,7 +1179,7 @@ mod tests {
                 "Update counter should increment by 1 when inserting a higher-incarnation-number rumor"
             );
                 assert_eq!(
-                ml.health_of(&member), Some(to_health.clone()),
+                ml.health_of(&member), Some(to_health),
                 "Member should have health {:?} following insertion of higher-incarnation-number rumor",
                 to_health
             );
@@ -1231,7 +1231,7 @@ mod tests {
                 };
 
                 assert!(
-                    ml.insert(member.clone(), from_health.clone()),
+                    ml.insert(member.clone(), from_health),
                     "Could not insert member into list initially"
                 );
 
@@ -1244,7 +1244,7 @@ mod tests {
 
                 assert_eq!(
                     ml.health_of(&member),
-                    Some(from_health.clone()),
+                    Some(from_health),
                     "Member should have had health {:?}, but didn't",
                     from_health
                 );
@@ -1264,7 +1264,7 @@ mod tests {
                     "Update counter should increment by 1 when inserting a same-incarnation-number rumor with worse health"
                 );
                     assert_eq!(
-                    ml.health_of(&member), Some(to_health.clone()),
+                    ml.health_of(&member), Some(to_health),
                     "Member should have health {:?} following insertion of same-incarnation-number rumor with worse health",
                     to_health
                 );
@@ -1281,7 +1281,7 @@ mod tests {
                     "Update counter should not increment when inserting a same-incarnation-number rumor without worse health"
                 );
                     assert_eq!(
-                    ml.health_of(&member), Some(from_health.clone()),
+                    ml.health_of(&member), Some(from_health),
                     "Member should still have health {:?} following insertion of same-incarnation-number rumor without worse health",
                     from_health
                 );
@@ -1333,7 +1333,7 @@ mod tests {
                 let member_one = Member::default();
 
                 assert!(
-                    ml.insert_health_by_id(&member_one.id, from_health.clone()),
+                    ml.insert_health_by_id(&member_one.id, from_health),
                     "Should be able to insert initial health of {:?} into empty MemberList",
                     from_health
                 );
@@ -1390,7 +1390,7 @@ mod tests {
 
                 if from_health == to_health {
                     assert!(
-                        !ml.insert_health_by_id(&member_one.id, to_health.clone()),
+                        !ml.insert_health_by_id(&member_one.id, to_health),
                         "Transitioning from {:?} to {:?} (i.e., no change) should be a no-op",
                         from_health,
                         to_health
@@ -1409,7 +1409,7 @@ mod tests {
                     );
                 } else {
                     assert!(
-                    ml.insert_health_by_id(&member_one.id, to_health.clone()),
+                    ml.insert_health_by_id(&member_one.id, to_health),
                     "Transitioning from {:?} to {:?} (i.e., different health) should NOT be a no-op",
                     from_health,
                     to_health

--- a/components/butterfly/src/server/mod.rs
+++ b/components/butterfly/src/server/mod.rs
@@ -622,7 +622,7 @@ impl Server {
         // with it as best we can, with our head held high.
         let member_id = member.id.clone();
         let trace_incarnation = member.incarnation;
-        let trace_health = health.clone();
+        let trace_health = health;
         if self.member_list.insert(member, health) {
             trace_it!(
                 MEMBERSHIP: self,
@@ -715,7 +715,7 @@ impl Server {
         // on, knowing life is still worth living.
         let member_id = member.id.clone();
         let trace_incarnation = member.incarnation;
-        let trace_health = health.clone();
+        let trace_health = health;
 
         if self.member_list.insert(member, health) || incremented_incarnation {
             trace_it!(

--- a/components/butterfly/src/server/mod.rs
+++ b/components/butterfly/src/server/mod.rs
@@ -743,9 +743,8 @@ impl Server {
         if !self.service_store.contains_rumor(&rk.key, &rk.id) {
             let mut service_entries: Vec<Service> = Vec::new();
             self.service_store.with_rumors(&rk.key, |service_rumor| {
-                if self
-                    .member_list
-                    .check_health_of_by_id(&service_rumor.member_id, Health::Confirmed)
+                if self.member_list.health_of_by_id(&service_rumor.member_id)
+                    == Some(Health::Confirmed)
                 {
                     service_entries.push(service_rumor.clone());
                 }
@@ -817,10 +816,7 @@ impl Server {
     fn get_electorate(&self, key: &str) -> Vec<String> {
         let mut electorate = vec![];
         self.service_store.with_rumors(key, |s| {
-            if self
-                .member_list
-                .check_health_of_by_id(&s.member_id, Health::Alive)
-            {
+            if self.member_list.health_of_by_id(&s.member_id) == Some(Health::Alive) {
                 electorate.push(s.member_id.clone());
             }
         });


### PR DESCRIPTION
1. Move check for being in voting population to more appropriate location
   Also, make the function private, since all the callers are in the module its now moved to.

2. Remove `check_health_of` and `check_health_of_by_id`
   The interface of these functions was prone to subtle errors (see https://github.com/habitat-sh/habitat/pull/5859). Specifically, returning a `bool` made it easy to overlook the case where the member's health was unknown. Checking for equality with `health_of_by_id` is nearly as ergonomic, and considerably less likely to overlook handling this case correctly. Additionally, it makes for more understandable test output.