### PR TITLE
Remove minimum 3 member requirement from quorum check

### DIFF
--- a/components/butterfly/src/server/mod.rs
+++ b/components/butterfly/src/server/mod.rs
@@ -850,17 +850,19 @@ impl Server {
         let service_group_members = self.get_total_population(key);
         let total_population = service_group_members.len();
         let alive_population = electorate.len();
+        let has_quorum = alive_population > total_population / 2;
 
         trace!(
-            "check_quorum({}): {}/{} alive/total, electorate: {:?}, service_group: {:?}",
+            "check_quorum({}): {}/{} alive/total => {}, electorate: {:?}, service_group: {:?}",
             key,
             alive_population,
             total_population,
+            has_quorum,
             electorate,
             service_group_members
         );
 
-        alive_population >= ((total_population / 2) + 1)
+        has_quorum
     }
 
     /// Start an election for the given service group, declaring this members suitability and the

--- a/components/butterfly/src/server/mod.rs
+++ b/components/butterfly/src/server/mod.rs
@@ -859,13 +859,6 @@ impl Server {
             electorate,
             service_group_members
         );
-        if total_population < 3 {
-            trace!(
-                "Quorum size: {}/3 - election cannot complete",
-                total_population
-            );
-            return false;
-        }
 
         alive_population >= ((total_population / 2) + 1)
     }

--- a/components/butterfly/tests/rumor/election.rs
+++ b/components/butterfly/tests/rumor/election.rs
@@ -46,34 +46,6 @@ fn three_members_run_election_from_one_starting_rumor() {
 }
 
 #[test]
-fn two_members_fail_to_find_quorum() {
-    let mut net = btest::SwimNet::new(2);
-    net.mesh();
-    net.add_service(0, "core/witcher/1.2.3/20161208121212");
-    net.add_service(1, "core/witcher/1.2.3/20161208121212");
-    net.add_election(0, "witcher");
-    assert_wait_for_equal_election!(net, [0..2, 0..2], "witcher.prod");
-    assert_wait_for_election_status!(net, [0..2], "witcher.prod", ElectionStatus::NoQuorum);
-}
-
-#[test]
-fn two_members_find_quorum_when_a_third_comes() {
-    let mut net = btest::SwimNet::new(2);
-    net.mesh();
-    net.add_service(0, "core/witcher/1.2.3/20161208121212");
-    net.add_service(1, "core/witcher/1.2.3/20161208121212");
-    net.add_election(0, "witcher");
-    assert_wait_for_equal_election!(net, [0..2, 0..2], "witcher.prod");
-    assert_wait_for_election_status!(net, [0..2], "witcher.prod", ElectionStatus::NoQuorum);
-
-    net.members.push(btest::start_server("2", None, 0));
-    net.add_service(2, "core/witcher/1.2.3/20161208121212");
-    net.connect(2, 0);
-    assert_wait_for_election_status!(net, [0..2], "witcher.prod", ElectionStatus::Finished);
-    assert_wait_for_equal_election!(net, [0..3, 0..3], "witcher.prod");
-}
-
-#[test]
 #[ignore]
 fn five_members_elect_a_new_leader_when_the_old_one_dies() {
     let mut net = btest::SwimNet::new(5);


### PR DESCRIPTION
Resolves https://github.com/habitat-sh/habitat/issues/4759

The purpose of quorum is to prevent multiple elections occurring on different sides of a network partition leading to split-brain. This doesn't require a minimum of 3 members to work. Also, there's no risk of a tie in the election process, since the merge operation breaks ties with the member
ID, which is guaranteed to be unique (or else the consequences would be much worse than split brain).