### PR TITLE
Upload backline to acceptance

### DIFF
--- a/.buildkite/finish_release_pipeline.yaml
+++ b/.buildkite/finish_release_pipeline.yaml
@@ -43,10 +43,19 @@ steps:
     agents:
       queue: habitat-release
 
-  - label: "Add core/backline to Acceptance Environment"
+  - label: ":linux: Add core/backline to Acceptance Environment"
     command: .buildkite/scripts/upload_backline_to_acceptance.sh
     agents:
       queue: habitat-release
+    env:
+      BUILD_PKG_TARGET: "x86_64-linux"
+
+  - label: ":linux: :two: Add core/backline to Acceptance Environment"
+    command: .buildkite/scripts/upload_backline_to_acceptance.sh
+    agents:
+      queue: habitat-release
+    env:
+      BUILD_PKG_TARGET: "x86_64-linux-kernel2"
 
   - label: "Rebuild and promote the worker"
     command: /bin/true

--- a/.buildkite/finish_release_pipeline.yaml
+++ b/.buildkite/finish_release_pipeline.yaml
@@ -44,8 +44,7 @@ steps:
       queue: habitat-release
 
   - label: "Add core/backline to Acceptance Environment"
-    command: /bin/true
-    skip: Not implemented yet
+    command: .buildkite/scripts/upload_backline_to_acceptance.sh
     agents:
       queue: habitat-release
 

--- a/.buildkite/scripts/build_component.sh
+++ b/.buildkite/scripts/build_component.sh
@@ -62,6 +62,11 @@ case "${component}" in
         # buildkite-agent artifact upload "results/${pkg_artifact}"
         set_studio_ident "${pkg_target:?}" "${pkg_ident:?}"
         ;;
+    "backline")
+        echo "--- :buildkite: Recording metadata for ${pkg_ident}"
+        set_backline_ident "${pkg_target}" "${pkg_ident}"
+        set_backline_artifact "${pkg_target}" "${pkg_artifact}"
+        ;;
     *)
         ;;
 esac

--- a/.buildkite/scripts/shared.sh
+++ b/.buildkite/scripts/shared.sh
@@ -200,6 +200,28 @@ set_studio_ident() {
     buildkite-agent meta-data set "studio-ident-${target}" "${ident}"
 }
 
+get_backline_ident() {
+    local target=$1
+    buildkite-agent meta-data get "backline-ident-${target}"
+}
+
+set_backline_ident() {
+    local target=$1
+    local ident=$2
+    buildkite-agent meta-data set "backline-ident-${target}" "${ident}"
+}
+
+get_backline_artifact() {
+    local target=$1
+    buildkite-agent meta-data get "backline-artifact-${target}"
+}
+
+set_backline_artifact() {
+    local target=$1
+    local ident=$2
+    buildkite-agent meta-data set "backline-artifact-${target}" "${ident}"
+}
+
 get_release_channel() {
     buildkite-agent meta-data get "release-channel"
 }

--- a/.buildkite/scripts/upload_backline_to_acceptance.sh
+++ b/.buildkite/scripts/upload_backline_to_acceptance.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source .buildkite/scripts/shared.sh
+
+echo "--- :drum_with_drumsticks: Uploading hab-backline to acceptance" 
+
+acceptance_channel() {
+  if is_fake_release; then
+    echo "$(get_release_channel)"
+  else
+    echo "stable"
+  fi
+}
+
+backline_ident="$(get_backline_ident x86_64-linux)"
+backline_artifact="$(get_backline_artifact x86_64-linux)"
+
+# Ensure we have the package in our local artifact cache
+hab pkg install "$backline_ident"
+
+# The above pkg install is executed in the context of the buildkite user
+# so the artifact (and public signing keys) will be cached in the users
+# home, rather than the system cache (/hab). If the below breaks with a:
+#
+# Invalid value for '<HART_FILE>...': File: 'XXXX.hart' cannot be found, 
+#
+# then it is likely that something has changed with how Hab caches files,
+# or the user this is executed as.
+hab pkg upload -u https://bldr.acceptance.habitat.sh -c "$(acceptance_channel)" \
+  ~/.hab/cache/artifacts/"$backline_artifact"

--- a/.buildkite/scripts/upload_backline_to_acceptance.sh
+++ b/.buildkite/scripts/upload_backline_to_acceptance.sh
@@ -4,21 +4,23 @@ set -euo pipefail
 
 source .buildkite/scripts/shared.sh
 
+set_hab_binary
+
 echo "--- :drum_with_drumsticks: Uploading hab-backline to acceptance" 
 
 acceptance_channel() {
   if is_fake_release; then
-    echo "$(get_release_channel)"
+    get_release_channel
   else
     echo "stable"
   fi
 }
 
-backline_ident="$(get_backline_ident x86_64-linux)"
-backline_artifact="$(get_backline_artifact x86_64-linux)"
+backline_ident="$(get_backline_ident "$BUILD_PKG_TARGET")"
+backline_artifact="$(get_backline_artifact "$BUILD_PKG_TARGET")"
 
 # Ensure we have the package in our local artifact cache
-hab pkg install "$backline_ident"
+"${hab_binary}" pkg install "$backline_ident"
 
 # The above pkg install is executed in the context of the buildkite user
 # so the artifact (and public signing keys) will be cached in the users
@@ -28,5 +30,7 @@ hab pkg install "$backline_ident"
 #
 # then it is likely that something has changed with how Hab caches files,
 # or the user this is executed as.
-hab pkg upload -u https://bldr.acceptance.habitat.sh -c "$(acceptance_channel)" \
+"${hab_binary}" pkg upload \
+  --url https://bldr.acceptance.habitat.sh \
+  --channel "$(acceptance_channel)" \
   ~/.hab/cache/artifacts/"$backline_artifact"

--- a/.buildkite/scripts/upload_backline_to_acceptance.sh
+++ b/.buildkite/scripts/upload_backline_to_acceptance.sh
@@ -33,4 +33,5 @@ backline_artifact="$(get_backline_artifact "$BUILD_PKG_TARGET")"
 "${hab_binary}" pkg upload \
   --url https://bldr.acceptance.habitat.sh \
   --channel "$(acceptance_channel)" \
+  --auth "${HAB_AUTH_TOKEN}" \
   ~/.hab/cache/artifacts/"$backline_artifact"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -202,20 +202,7 @@ to make sure it is successful and looks correct.
 
 ## Update the Acceptance environment with the new hab-backline
 
-After the new hab is released and there is a new hab-backline in stable, the acceptance environment will also need to be updated. In order to do this, (from a Linux machine):
-
-```
-./update-hab-backline.sh stable $(< VERSION)
-```
-
-If your auth token isn't specified in your environment, you can add `-z <AUTH_TOKEN>`
-(or any other arguments to pass to the `hab pkg upload` command) to the
-`update-hab-backline.sh` script after the channel and version arguments.
-
-Make sure the commands from the trace output look correct when the script executes:
-1. The version is the version being released (no `-dev` suffix)
-1. The install is from the `stable` channel
-1. The upload is to the `stable` channel
+This step is handled by buildkite. If it is necessary to do manually, you can find instructions in [a previous release of this file.](https://github.com/habitat-sh/habitat/blob/bebf0fdfb738e1304ea201717fb6054733b17939/RELEASE.md#update-the-acceptance-environment-with-the-new-hab-backline)
 
 ## Update the Docs
 


### PR DESCRIPTION
This automates the upload of the released hab-backline to the acceptance environment.  

Ref #5228 