### PR TITLE
Refactor MemberList

### DIFF
--- a/components/butterfly/Cargo.toml
+++ b/components/butterfly/Cargo.toml
@@ -21,7 +21,7 @@ lazy_static = "*"
 prost = "*"
 prost-derive = "*"
 rand = "*"
-serde = "*"
+serde = { version = "*", features = ["rc"] }
 serde_derive = "*"
 serde_json = "*"
 tempfile = "*"

--- a/components/butterfly/src/member.rs
+++ b/components/butterfly/src/member.rs
@@ -330,7 +330,7 @@ impl FromProto<newscast::Rumor> for Membership {
 /// suspect or confirmed.
 #[derive(Debug)]
 pub struct MemberList {
-    pub members: RwLock<HashMap<UuidSimple, Member>>,
+    members: RwLock<HashMap<UuidSimple, Member>>,
     pub health: RwLock<HashMap<UuidSimple, Health>>,
     /// Records timestamps of when Members are marked `Suspect`. This
     /// supports automatically transitioning them to `Confirmed` after
@@ -713,8 +713,11 @@ impl MemberList {
 
     /// Takes a function whose argument is a `HashMap::Values` iterator, with the ID and Membership
     /// entry.
-    pub fn with_member_iter(&self, mut with_closure: impl FnMut(hash_map::Values<String, Member>)) {
-        with_closure(self.members_read().values());
+    pub fn with_member_iter<T>(
+        &self,
+        mut with_closure: impl FnMut(hash_map::Values<String, Member>) -> T,
+    ) -> T {
+        with_closure(self.members_read().values())
     }
 
     /// Calls a function whose argument is a reference to a membership entry matching the given ID.

--- a/components/butterfly/src/member.rs
+++ b/components/butterfly/src/member.rs
@@ -331,7 +331,7 @@ impl FromProto<newscast::Rumor> for Membership {
 #[derive(Debug)]
 pub struct MemberList {
     members: RwLock<HashMap<UuidSimple, Member>>,
-    pub health: RwLock<HashMap<UuidSimple, Health>>,
+    health: RwLock<HashMap<UuidSimple, Health>>,
     /// Records timestamps of when Members are marked `Suspect`. This
     /// supports automatically transitioning them to `Confirmed` after
     /// an appropriate amount of time.
@@ -609,28 +609,16 @@ impl MemberList {
 
     /// Returns the health of the member, if the member exists.
     pub fn health_of(&self, member: &Member) -> Option<Health> {
-        match self
-            .health
-            .read()
-            .expect("Health lock is poisoned")
-            .get(&member.id)
-        {
-            Some(health) => Some(*health),
-            None => None,
-        }
+        self.health_of_by_id(&member.id)
     }
 
     /// Returns the health of the member, if the member exists.
     pub fn health_of_by_id(&self, member_id: &str) -> Option<Health> {
-        match self
-            .health
+        self.health
             .read()
             .expect("Health lock is poisoned")
             .get(member_id)
-        {
-            Some(health) => Some(*health),
-            None => None,
-        }
+            .cloned() // this is cheap since Health is a Copy type
     }
 
     /// Returns true if the member is alive, suspect, or persistent; used during the target

--- a/components/butterfly/src/member.rs
+++ b/components/butterfly/src/member.rs
@@ -339,9 +339,6 @@ mod member_list {
 #[derive(Debug)]
 pub struct MemberList {
     entries: RwLock<HashMap<UuidSimple, member_list::Entry>>,
-    /// Records timestamps of when Members are marked `Suspect`. This
-    /// supports automatically transitioning them to `Confirmed` after
-    /// an appropriate amount of time.
     initial_members: RwLock<Vec<Member>>,
     update_counter: AtomicUsize,
 }

--- a/components/butterfly/src/member.rs
+++ b/components/butterfly/src/member.rs
@@ -24,7 +24,7 @@ use std::ops::Add;
 use std::result;
 use std::str::FromStr;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Arc, RwLock};
+use std::sync::RwLock;
 
 use rand::{seq::SliceRandom, thread_rng};
 use serde::{
@@ -328,20 +328,20 @@ impl FromProto<newscast::Rumor> for Membership {
 
 /// Tracks lists of members, their health, and how long they have been
 /// suspect or confirmed.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct MemberList {
-    pub members: Arc<RwLock<HashMap<UuidSimple, Member>>>,
-    pub health: Arc<RwLock<HashMap<UuidSimple, Health>>>,
+    pub members: RwLock<HashMap<UuidSimple, Member>>,
+    pub health: RwLock<HashMap<UuidSimple, Health>>,
     /// Records timestamps of when Members are marked `Suspect`. This
     /// supports automatically transitioning them to `Confirmed` after
     /// an appropriate amount of time.
-    aging_suspects: Arc<RwLock<HashMap<UuidSimple, SteadyTime>>>,
+    aging_suspects: RwLock<HashMap<UuidSimple, SteadyTime>>,
     /// Records timestamps of when Members are marked
     /// `Confirmed`. This supports automatically transitioning them to
     /// `Departed` after an appropriate amount of time.
-    aging_confirmed: Arc<RwLock<HashMap<UuidSimple, SteadyTime>>>,
-    initial_members: Arc<RwLock<Vec<Member>>>,
-    update_counter: Arc<AtomicUsize>,
+    aging_confirmed: RwLock<HashMap<UuidSimple, SteadyTime>>,
+    initial_members: RwLock<Vec<Member>>,
+    update_counter: AtomicUsize,
 }
 
 impl Serialize for MemberList {
@@ -372,12 +372,12 @@ impl MemberList {
     /// Creates a new, empty, MemberList.
     pub fn new() -> MemberList {
         MemberList {
-            members: Arc::new(RwLock::new(HashMap::new())),
-            health: Arc::new(RwLock::new(HashMap::new())),
-            aging_suspects: Arc::new(RwLock::new(HashMap::new())),
-            aging_confirmed: Arc::new(RwLock::new(HashMap::new())),
-            initial_members: Arc::new(RwLock::new(Vec::new())),
-            update_counter: Arc::new(AtomicUsize::new(0)),
+            members: RwLock::new(HashMap::new()),
+            health: RwLock::new(HashMap::new()),
+            aging_suspects: RwLock::new(HashMap::new()),
+            aging_confirmed: RwLock::new(HashMap::new()),
+            initial_members: RwLock::new(Vec::new()),
+            update_counter: AtomicUsize::new(0),
         }
     }
 

--- a/components/butterfly/src/rumor/dat_file.rs
+++ b/components/butterfly/src/rumor/dat_file.rs
@@ -363,24 +363,8 @@ impl DatFile {
         W: Write,
     {
         let mut total = 0;
-        member_list.with_member_iter(|members| {
-            for member in members {
-                // we do not call membership_for here since that would recursively enter
-                // the members read lock that we are currently in now. One would assume that
-                // is acceptable but this has proven to potentially deadlock Windows threads
-                // in some scenarios. Windows uses a Slim Reader/Writer lock (SRW) and
-                // recursively acquiring locks may result in "undefined behavior" (see
-                // https://blogs.msdn.microsoft.com/oldnewthing/20160819-00/?p=94125)
-                if let Some(health) = member_list.health_of(member) {
-                    total += self.write_member(
-                        writer,
-                        &Membership {
-                            health: health,
-                            member: member.clone(),
-                        },
-                    )?;
-                }
-            }
+        member_list.with_memberships(|membership| {
+            total += self.write_member(writer, &membership)?;
             Ok(total)
         })
     }

--- a/components/butterfly/src/server/mod.rs
+++ b/components/butterfly/src/server/mod.rs
@@ -212,7 +212,7 @@ pub struct Server {
     // TODO (CM): This is currently public because butterfly-test
     // depends on it being so. Refactor so it can be private.
     pub member: Arc<RwLock<Myself>>,
-    pub member_list: MemberList,
+    pub member_list: Arc<MemberList>,
     ring_key: Arc<Option<SymKey>>,
     rumor_heat: RumorHeat,
     pub service_store: RumorStore<Service>,
@@ -312,7 +312,7 @@ impl Server {
                     // on member, if we have a better type
                     member_id: Arc::new(member_id),
                     member: Arc::new(RwLock::new(myself)),
-                    member_list: MemberList::new(),
+                    member_list: Arc::new(MemberList::new()),
                     ring_key: Arc::new(ring_key),
                     rumor_heat: RumorHeat::default(),
                     service_store: RumorStore::default(),

--- a/components/butterfly/src/server/mod.rs
+++ b/components/butterfly/src/server/mod.rs
@@ -819,16 +819,9 @@ impl Server {
     }
 
     fn check_in_voting_population_by_id(&self, member_id: &str) -> bool {
-        match self
-            .member_list
-            .health
-            .read()
-            .expect("Health lock is poisoned")
-            .get(member_id)
-        {
-            Some(&Health::Alive) | Some(&Health::Suspect) | Some(&Health::Confirmed) => true,
-            Some(&Health::Departed) => false,
-            None => false,
+        match self.member_list.health_of_by_id(member_id) {
+            Some(Health::Alive) | Some(Health::Suspect) | Some(Health::Confirmed) => true,
+            Some(Health::Departed) | None => false,
         }
     }
 

--- a/components/butterfly/src/server/mod.rs
+++ b/components/butterfly/src/server/mod.rs
@@ -528,12 +528,7 @@ impl Server {
     }
 
     pub fn need_peer_seeding(&self) -> bool {
-        let m = self
-            .member_list
-            .members
-            .read()
-            .expect("Members lock is poisoned");
-        m.is_empty()
+        self.member_list.len() == 0
     }
 
     /// Persistently block a given address, causing no traffic to be seen.

--- a/components/butterfly/src/server/mod.rs
+++ b/components/butterfly/src/server/mod.rs
@@ -692,7 +692,6 @@ impl Server {
 
     /// Given a membership record and some health, insert it into the Member List.
     fn insert_member_from_rumor(&self, member: Member, mut health: Health) {
-        let mut incremented_incarnation = false;
         let rk: RumorKey = RumorKey::from(&member);
         if member.id == self.member_id() {
             if health != Health::Alive {
@@ -700,7 +699,6 @@ impl Server {
                 if member.incarnation >= me.incarnation() {
                     me.refute_incarnation(member.incarnation);
                     health = Health::Alive;
-                    incremented_incarnation = true;
                 }
             }
         }
@@ -711,7 +709,7 @@ impl Server {
         let trace_incarnation = member.incarnation;
         let trace_health = health;
 
-        if self.member_list.insert(member, health) || incremented_incarnation {
+        if self.member_list.insert(member, health) {
             trace_it!(
                 MEMBERSHIP: self,
                 TraceKind::MemberUpdate,


### PR DESCRIPTION
The structure of `MemberList` lends itself to inconsistency, and that has led to panics in situations where a given member is present in the `members` map, but not the `health` map. This work should make that impossible by restructuring into a single collection that associates the needed metadata with the `Member` struct and improving modularity by privatizing the public fields and providing a proper interface to consumers.