### PR TITLE
Don't panic if CLI parameters for "sup run" are missing from "sup term"

### DIFF
--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -221,16 +221,16 @@ fn mgrcfg_from_matches(m: &ArgMatches) -> Result<ManagerConfig> {
         gossip_permanent: m.is_present("PERMANENT_PEER"),
         ring_key: get_ring_key(m)?,
         gossip_peers: get_peers(m)?,
-        gossip_listen: GossipListenAddr::from_str(
-            m.value_of("LISTEN_GOSSIP")
-                .expect("LISTEN_GOSSIP should always have a value."),
-        )?,
-        http_listen: http_gateway::ListenAddr::from_str(
-            m.value_of("LISTEN_HTTP")
-                .expect("LISTEN_HTTP should always have a value"),
-        )?,
         ..Default::default()
     };
+
+    if let Some(addr_str) = m.value_of("LISTEN_GOSSIP") {
+        cfg.gossip_listen = GossipListenAddr::from_str(addr_str)?;
+    }
+
+    if let Some(addr_str) = m.value_of("LISTEN_HTTP") {
+        cfg.http_listen = http_gateway::ListenAddr::from_str(addr_str)?;
+    }
 
     if let Some(addr_str) = m.value_of("LISTEN_CTL") {
         cfg.ctl_listen = SocketAddr::from_str(addr_str)?;


### PR DESCRIPTION
Both "sup run" and "sup term" use mgrcfg_from_matches, but only the former
guarantees a value (possibly default) for LISTEN_GOSSIP and LISTEN_HTTP.
