### PR TITLE
add windows docker studio build to buildkite

### DIFF
--- a/.buildkite/scripts/bintray_upload.ps1
+++ b/.buildkite/scripts/bintray_upload.ps1
@@ -39,7 +39,7 @@ $Env:HAB_BLDR_CHANNEL="$SourceChannel"
 $Env:BINTRAY_USER="$Env:HABITAT_BINTRAY_USER"
 $Env:BINTRAY_KEY="$Env:HABITAT_BINTRAY_KEY"
 $Env:BINTRAY_PASSPHRASE="$Env:HABITAT_BINTRAY_PASSPHRASE"
+Invoke-Expression "$baseHabExe pkg exec core/hab-bintray-publish publish-studio"
+if($LASTEXITCODE -ne 0) { Write-Error "publishing studio container failed!" } 
 Invoke-Expression "$baseHabExe pkg exec core/hab-bintray-publish publish-hab -s -r $TargetChannel C:\hab\cache\artifacts\$HabArtifact"
-
-
-if($LASTEXITCODE -ne 0) { Write-Error "Something mysterious and unexpected happened!" } 
+if($LASTEXITCODE -ne 0) { Write-Error "publishing hab components failed!" } 


### PR DESCRIPTION
This should fix the windows docker studio in buildkite.

Signed-off-by: mwrock <matt@mattwrock.com>