### PR TITLE
Identify launcher-protocol message files as auto generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 components/sup-protocol/src/generated/*.rs linguist-generated
 components/butterfly/src/generated/*.rs linguist-generated
+components/launcher-protocol/src/message/*.rs linguist-generated


### PR DESCRIPTION
This will make diffs to these files collapsed by default

Signed-off-by: Jon Bauman <5906042+baumanj@users.noreply.github.com>