### PR TITLE
Remove the ProdPad and GH project tracker content.

### DIFF
--- a/www/source/community.html.slim
+++ b/www/source/community.html.slim
@@ -49,36 +49,7 @@ section.community--roadmap
   .row
     .columns.medium-12
       .community--roadmap--content
-        h2 Product Roadmap
-        a.button.cta href="https://portal.prodpad.com/24539" Request New Features
-        a.button.outline.contrast href="https://ext.prodpad.com/ext/roadmap/d2938aed0d0ad1dd62669583e108357efd53b3a6" View Complete Roadmap
-        .row.roadmap-headings
-          .columns.medium-4
-            h5 Current
-          .columns.medium-4
-            h5 Near Term
-          .columns.medium-4
-            h5 Future
-        .row
-          <iframe src="https://ext.prodpad.com/ext/roadmap/0fe93038ea3ea1f8f4589ada044eaf0898658a83" height="900" width="100%"></iframe>
-
-section.community--tracker
-  .row
-    .columns.medium-12
-      .foreground-github
-        img[src="/images/graphics/graphic-github-mountain-cats.png"]
-      .community--tracker--content
-        .callout-box.columns.medium-6.medium-push-3
-          h2 GitHub Project Tracker
-          p
-            | We use GitHub project tracker to track and share our engineering progress. Check it out now to see all the work currently in flight.
-          .row
-            .columns.medium-12
-              ul.no-bullet
-                li
-                  a.button.cta href="/docs/contribute/" target="_blank" Become a Contributor
-                li
-                  a.button.outline.contrast href="https://github.com/habitat-sh/habitat/projects/1" View Tracker on GitHub
+        h2 Stay tuned. We're revamping our roadmap!
 
 section.community--cta
   .row


### PR DESCRIPTION
That stuff isn't currently in use.

![](https://media.giphy.com/media/l2JI1JzL6YS8z5KUM/giphy.gif)

Closes https://github.com/habitat-sh/habitat/issues/6031
Signed-off-by: Josh Black <raskchanky@gmail.com>