### PR TITLE
Update generated CLI docs for 0.72.0 release

### DIFF
--- a/www/source/docs/habitat-cli.html.md
+++ b/www/source/docs/habitat-cli.html.md
@@ -9,7 +9,7 @@ The commands for the Habitat CLI (`hab`) are listed below.
 
 | Applies to Version | Last Updated |
 | ------- | ------------ |
-| hab 0.71.0/20181218014130 (linux) | 19 Dec 2018 |
+| hab 0.72.0/20190103231731 (linux) | 4 Jan 2019 |
 
 ## hab
 
@@ -1974,7 +1974,7 @@ hab ring key import
 
 ## hab studio
 
-[1;33m» Installing core/hab-studio/0.71.0[0m
+
 
 **USAGE**
 
@@ -2212,26 +2212,12 @@ hab sup run [FLAGS] [OPTIONS] [--] [PKG_IDENT_OR_ARTIFACT]
 **OPTIONS**
 
 ```
--a, --application <APPLICATION>            Application name; [default: not set].
-    --bind <BIND>...                       One or more service groups to bind to a configuration
-    --binding-mode <BINDING_MODE>          Governs how the presence or absence of binds affects service startup. strict blocks startup until all binds are present. [default: strict] values: relaxed, strict]
--u, --url <BLDR_URL>                       Specify an alternate Builder endpoint. If not specified, the value will be taken from the HAB_BLDR_URL environment variable if defined. (default: https://bldr.habitat.sh)
-    --certs <CERT_FILE>                    Used for enabling TLS for the HTTP gateway. Read server certificates from CERT_FILE. This should contain PEM-format certificates in the right order the first certificate should certify KEY_FILE, the last should be a root CA).
-    --channel <CHANNEL>                    Receive Supervisor updates from the specified release channel [default: stable]
-    --config-from <CONFIG_DIR>             Use package config from this path, rather than the package itself
--e, --environment <ENVIRONMENT>            Environment name; [default: not set].
--n, --events <EVENTS>                      Name of the service group running a Habitat EventSrv to forward Supervisor and service event data to
-    --group <GROUP>                        The service group; shared config and topology [default: default].
-    --key <KEY_FILE>                       Used for enabling TLS for the HTTP gateway. Read private key from KEY_FILE. This should be a RSA private key or PKCS8-encoded private key, in PEM format.
-    --listen-ctl <LISTEN_CTL>              The listen address for the Control Gateway. If not specified, the value will be taken from the HAB_LISTEN_CTL environment variable if defined. default: 127.0.0.1:9632]
-    --listen-gossip <LISTEN_GOSSIP>        The listen address for the Gossip System Gateway. [env: HAB_LISTEN_GOSSIP=]  [default: 0.0.0.0:9638]
-    --listen-http <LISTEN_HTTP>            The listen address for the HTTP Gateway. [env: HAB_LISTEN_HTTP=] default: 0.0.0.0:9631]
-    --org <ORGANIZATION>                   The organization that the Supervisor and its subsequent services are part of.
-    --peer <PEER>...                       The listen address of one or more initial peers (IP[:PORT])
-    --peer-watch-file <PEER_WATCH_FILE>    Watch this file for connecting to the ring
--r, --ring <RING>                          The name of the ring used by the Supervisor when running with wire encryption. (ex: hab sup run --ring myring) [env: HAB_RING=]
--s, --strategy <STRATEGY>                  The update strategy; [default: none] [values: none, at-once, rolling]
--t, --topology <TOPOLOGY>                  Service topology; [default: none] [possible values: standalone, leader]
+-a, --application <APPLICATION>                        Application name; [default: not set].
+    --bind <BIND>...                                   One or more service groups to bind to a configuration
+    --binding-mode <BINDING_MODE> Governs how the presence or absence of binds affects service startup. strict blocks startup until all binds are present. [default: strict] [values: relaxed, strict]
+-u, --url <BLDR_URL> Specify an alternate Builder endpoint. If not specified, the value will be taken from the HAB_BLDR_URL environment variable if defined. (default: https://bldr.habitat.sh)
+    --certs <CERT_FILE> Used for enabling TLS for the HTTP gateway. Read server certificates from CERT_FILE. This should contain PEM-format certificates in the right order (the first certificate should certify KEY_FILE, the last should be a root CA).
+    --channel <CHANNEL> Receive Supervisor updates from the specified release channel [default: stable]
 ```
 
 **ARGS**
@@ -2501,16 +2487,11 @@ hab svc load [FLAGS] [OPTIONS] <PKG_IDENT>
 **OPTIONS**
 
 ```
--a, --application <APPLICATION>      Application name; [default: not set].
-    --bind <BIND>...                 One or more service groups to bind to a configuration
-    --binding-mode <BINDING_MODE>    Governs how the presence or absence of binds affects service startup. strict blocks startup until all binds are present. [default: strict] [values: relaxed, strict]
--u, --url <BLDR_URL>                 Specify an alternate Builder endpoint. If not specified, the value will be taken from the HAB_BLDR_URL environment variable if defined. (default: https://bldr.habitat.sh)
-    --channel <CHANNEL>              Receive package updates from the specified release channel [default: stable]
--e, --environment <ENVIRONMENT>      Environment name; [default: not set].
-    --group <GROUP>                  The service group; shared config and topology [default: default].
--r, --remote-sup <REMOTE_SUP>        Address to a remote Supervisor's Control Gateway [default: 127.0.0.1:9632]
--s, --strategy <STRATEGY>            The update strategy; [default: none] [values: none, at-once, rolling]
--t, --topology <TOPOLOGY>            Service topology; [default: none] [possible values: standalone, leader]
+-a, --application <APPLICATION>                        Application name; [default: not set].
+    --bind <BIND>...                                   One or more service groups to bind to a configuration
+    --binding-mode <BINDING_MODE> Governs how the presence or absence of binds affects service startup. strict blocks startup until all binds are present. [default: strict] [values: relaxed, strict]
+-u, --url <BLDR_URL> Specify an alternate Builder endpoint. If not specified, the value will be taken from the HAB_BLDR_URL environment variable if defined. (default: https://bldr.habitat.sh)
+    --channel <CHANNEL> Receive package updates from the specified release channel [default: stable]
 ```
 
 **ARGS**

--- a/www/source/partials/docs/_reference-template-data.html.md.erb
+++ b/www/source/partials/docs/_reference-template-data.html.md.erb
@@ -6,21 +6,7 @@ These configuration settings are referenced using the [Handlebars.js](https://gi
 
 ## sys
 
-Describes the details of how this specific Supervisor was started
 
-| Property | Type | Description |
-| -------- | ---- | ----------- |
-| version | string | Version of the Habitat Supervisor, e.g., `0.54.0/20180221023448` |
-| member_id | string | The member's Supervisor ID, e.g., `3d1e73ff19464a27aea3cdc5c2243f74` |
-| ip | string | The IP address of the running service. |
-| hostname | string | The hostname of the running service. Defaults to `localhost` |
-| gossip_ip | string | Listening address for Supervisor's gossip connection. |
-| gossip_port | integer | Listening port for Supervisor's gossip connection. |
-| http_gateway_ip | string | Listening address for Supervisor's HTTP gateway. |
-| http_gateway_port | integer | Listening port for Supervisor's HTTP gateway. |
-| ctl_gateway_ip | string | Listening address for Supervisor's Control Gateway. |
-| ctl_gateway_port | integer | Listening port for Supervisor's Control Gateway. |
-| permanent | boolean | Set to true if a Supervisor is being used as a permanent peer, to increase Ring network traffic stability. |
 
 ## pkg
 


### PR DESCRIPTION
This auto generated output seems kind of wrong. For instance, a bunch of options from `hab sup run` seem to be missing, despite them being present when I run `hab sup run --help` on the Mac that I did the docs generation on:

```
➤ hab sup run --help
hab-sup-run 
Run the Habitat Supervisor

USAGE:
    hab sup run [FLAGS] [OPTIONS] [--] [PKG_IDENT_OR_ARTIFACT]

FLAGS:
    -A, --auto-update       Enable automatic updates for the Supervisor itself
    -D, --http-disable      Disable the HTTP Gateway completely [default: false]
        --json-logging      Use structured JSON logging for the Supervisor. Implies NO_COLOR
        --no-color          Turn ANSI color off
    -I, --permanent-peer    If this Supervisor is a permanent peer
    -v                      Verbose output; shows file and line/column numbers
    -h, --help              Prints help information

OPTIONS:
    -a, --application <APPLICATION>                        Application name; [default: not set].
        --bind <BIND>...                                   One or more service groups to bind to a configuration
        --binding-mode <BINDING_MODE>
            Governs how the presence or absence of binds affects service startup. `strict` blocks startup until all
            binds are present. [default: strict] [values: relaxed, strict]
    -u, --url <BLDR_URL>
            Specify an alternate Builder endpoint. If not specified, the value will be taken from the HAB_BLDR_URL
            environment variable if defined. (default: https://bldr.habitat.sh)
        --certs <CERT_FILE>
            Used for enabling TLS for the HTTP gateway. Read server certificates from CERT_FILE. This should contain
            PEM-format certificates in the right order (the first certificate should certify KEY_FILE, the last should
            be a root CA).
        --channel <CHANNEL>
            Receive Supervisor updates from the specified release channel [default: stable]

        --config-from <CONFIG_DIR>
            Use package config from this path, rather than the package itself

    -e, --environment <ENVIRONMENT>                        Environment name; [default: not set].
    -n, --events <EVENTS>
            Name of the service group running a Habitat EventSrv to forward Supervisor and service event data to

        --group <GROUP>
            The service group; shared config and topology [default: default].

    -i, --health-check-interval <HEALTH_CHECK_INTERVAL>
            The interval (seconds) on which to run health checks [default: 30]

        --key <KEY_FILE>
            Used for enabling TLS for the HTTP gateway. Read private key from KEY_FILE. This should be a RSA private key
            or PKCS8-encoded private key, in PEM format.
        --listen-ctl <LISTEN_CTL>
            The listen address for the Control Gateway. If not specified, the value will be taken from the
            HAB_LISTEN_CTL environment variable if defined. [default: 127.0.0.1:9632]
        --listen-gossip <LISTEN_GOSSIP>
            The listen address for the Gossip System Gateway. [env: HAB_LISTEN_GOSSIP=]  [default: 0.0.0.0:9638]

        --listen-http <LISTEN_HTTP>
            The listen address for the HTTP Gateway. [env: HAB_LISTEN_HTTP=]  [default: 0.0.0.0:9631]

        --org <ORGANIZATION>
            The organization that the Supervisor and its subsequent services are part of.

        --peer <PEER>...                                   The listen address of one or more initial peers (IP[:PORT])
        --peer-watch-file <PEER_WATCH_FILE>                Watch this file for connecting to the ring
    -r, --ring <RING>
            The name of the ring used by the Supervisor when running with wire encryption. (ex: hab sup run --ring
            myring) [env: HAB_RING=]
    -s, --strategy <STRATEGY>
            The update strategy; [default: none] [values: none, at-once, rolling]

    -t, --topology <TOPOLOGY>
            Service topology; [default: none] [possible values: standalone, leader]


ARGS:
    <PKG_IDENT_OR_ARTIFACT>    Load the given Habitat package as part of the Supervisor startup specified by a
                               package identifier (ex: core/redis) or filepath to a Habitat Artifact (ex:
                               /home/core-redis-3.0.7-21120102031201-x86_64-linux.hart).
```