### PR TITLE
split sections by custom token when generating cli docs

### DIFF
--- a/www/scripts/generate-cli-docs.js
+++ b/www/scripts/generate-cli-docs.js
@@ -21,8 +21,10 @@ function runCommand(command, args) {
 }
 
 function parseOutput(command, output) {
+  const sectionToken = '\^/--IMATOKEN--\^/';
+
   const lines = output.split('\n');
-  const sections = output.split('\n\n');
+  const sections = output.replace(/\n\n(.+):\n/g, sectionToken + '$1:').split(sectionToken);
 
   let result = {
     name: lines[0].trim(),

--- a/www/scripts/generate-cli-docs.js
+++ b/www/scripts/generate-cli-docs.js
@@ -2,7 +2,7 @@ const { spawnSync } = require('child_process');
 const { platform } = require('os');
 
 function getHelp(command, sub) {
-  const proc = runCommand(command, ['--help']);
+  const proc = runCommand(command, ['-h']);
 
   function render(data) {
     parsed = parseOutput(command, data.replace(/`/g, ''));

--- a/www/scripts/generate-cli-docs.js
+++ b/www/scripts/generate-cli-docs.js
@@ -24,6 +24,7 @@ function parseOutput(command, output) {
   const sectionToken = '\^/--IMATOKEN--\^/';
 
   const lines = output.split('\n');
+  // TODO: Fix spacing issues when options include a line break between the option name and description.
   const sections = output.replace(/\n\n(.+):\n/g, sectionToken + '$1:').split(sectionToken);
 
   let result = {


### PR DESCRIPTION
We were assuming that sections were separated by two newlines, but that isn't always the case. When commands have long argument/option names the help output wraps and adds multiple newlines. This adds a custom token before each section heading and then splits on that token. There are still some issues with spacing on commands with long argument/option names, but at least everything shows up.

Fixes #6035 

Signed-off-by: Matthew Peck <mpeck@chef.io>