### PR TITLE
fix and clarify release issues found in 0.72.0 release

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -14,12 +14,13 @@ Here are all the steps for the release process. Create a new issue at the beginn
 - [ ] Fix up any miscategorization in [CHANGELOG.md](https://github.com/habitat-sh/habitat/blob/master/CHANGELOG.md) and add to PR updating [`VERSION`](https://github.com/habitat-sh/habitat/blob/master/VERSION)
 - [ ] [Merge PR](https://github.com/habitat-sh/habitat/blob/master/RELEASE.md#prepare-master-branch-for-release) to update [`VERSION`](https://github.com/habitat-sh/habitat/blob/master/VERSION)
 - [ ] [Create blog announcement PR](https://github.com/habitat-sh/habitat/blob/master/RELEASE.md#submit-a-release-notes-blog-post-pr) and solicit team member input
-- [ ] AppVeyor run success
 - [ ] [Buildkite](https://buildkite.com/chef/habitat-sh-habitat-master-release) run success
+- [ ] [Build Windows Docker Studio](https://github.com/habitat-sh/habitat/blob/master/RELEASE.md#build-the-windows-docker-studio-image)
 - [ ] [Validate](https://github.com/habitat-sh/habitat/blob/master/RELEASE.md#validate-the-release) [darwin binaries](https://bintray.com/habitat/stable/hab-x86_64-darwin)
 - [ ] [Validate](https://github.com/habitat-sh/habitat/blob/master/RELEASE.md#validate-the-release) [linux binaries](https://bintray.com/habitat/stable/hab-x86_64-linux)
 - [ ] [Validate](https://github.com/habitat-sh/habitat/blob/master/RELEASE.md#validate-the-release) [linux-kernel2 binaries](https://bintray.com/habitat/stable/hab-x86_64-linux-kernel2)
 - [ ] [Validate](https://github.com/habitat-sh/habitat/blob/master/RELEASE.md#validate-the-release) [windows binaries](https://bintray.com/habitat/stable/hab-x86_64-windows)
+- [ ] Confirm validation in Buildkite to complete promotion
 - [ ] Declare merge thaw and update slack status
 - [ ] Merge blog announcement PR
 - [ ] [Update builder bootstrap bundle](https://github.com/habitat-sh/habitat/blob/master/RELEASE.md#update-builder-bootstrap-bundle)
@@ -34,7 +35,7 @@ Here are all the steps for the release process. Create a new issue at the beginn
 - [ ] Post announcement in [Chef discourse](https://discourse.chef.io/c/habitat)
 - [ ] Post announcement in [Habitat forums](https://forums.habitat.sh/c/announcements)
 - [ ] Tweet announcement from `@habitatsh`
-- [ ] [Update `Cargo.lock`](https://github.com/habitat-sh/habitat/blob/master/RELEASE.md#update-cargolock) for [`habitat`](https://github.com/habitat-sh/habitat)
 - [ ] [Update `Cargo.lock`](https://github.com/habitat-sh/habitat/blob/master/RELEASE.md#update-cargolock) for [`core`](https://github.com/habitat-sh/core)
+- [ ] [Update `Cargo.lock`](https://github.com/habitat-sh/habitat/blob/master/RELEASE.md#update-cargolock) for [`habitat`](https://github.com/habitat-sh/habitat)
 - [ ] [Update `Cargo.lock`](https://github.com/habitat-sh/habitat/blob/master/RELEASE.md#update-cargolock) for [`builder`](https://github.com/habitat-sh/builder)
 - [ ] Review release automation and/or [`RELEASE.md`](https://github.com/habitat-sh/habitat/blob/master/RELEASE.md) and add necessary fixes

--- a/support/ci/choco_push.ps1
+++ b/support/ci/choco_push.ps1
@@ -1,0 +1,24 @@
+param (
+    [string]$Version,
+    [string]$Release,
+    [string]$Checksum,
+    [string]$ApiKey
+)
+
+function Get-RepoRoot {
+    (Resolve-Path "$PSScriptRoot\..\..\").Path
+}
+
+$versionStamp = "$Version-$Release"
+$choco_install = "$(Get-RepoRoot)/components/hab/win/chocolateyinstall.ps1"
+
+(Get-Content $choco_install) |
+    % {$_.Replace('$version$', $versionStamp) } |
+    Set-Content $choco_install
+
+(Get-Content $choco_install) |
+    % {$_.Replace('$checksum$', $Checksum) } |
+    Set-Content $choco_install
+
+choco pack "$(Get-RepoRoot)/components/hab/win/habitat.nuspec" --version $Version 
+choco push habitat.$Version.nupkg -k $ApiKey --timeout 600

--- a/update-hab-backline.sh
+++ b/update-hab-backline.sh
@@ -5,6 +5,7 @@ set -eoux pipefail
 CHANNEL=$1
 VERSION=$2
 
+shift 2
 sudo hab pkg install -c "$CHANNEL" core/hab-backline/"$VERSION"
 hab pkg upload -u https://bldr.acceptance.habitat.sh -c stable "$@" \
     /hab/cache/artifacts/core-hab-backline-"$VERSION"-*-x86_64-linux.hart


### PR DESCRIPTION
closes #6028 

This covers a few issues encountered in the 0.72.0 release:

* Add instructions for publishing the Windows Docker Studio and the Chocolatey package as well as a script that performs the latter until these are assimilated by Buildkite
* Remove the checklist item for watching appveyor
* Add checklist item for unblocking Buildkite after validation
* Move the `core` cargo update before `builder` and `habitat` since they should pull in the update from core
* Small fix to `update-hab-backline` to fix issue with the `channel` and `version` args getting added to the upload command

Signed-off-by: mwrock <matt@mattwrock.com>