### PR TITLE
Only start services that are runnable

### DIFF
--- a/components/sup/src/error.rs
+++ b/components/sup/src/error.rs
@@ -155,6 +155,7 @@ pub enum Error {
     NotifyError(notify::Error),
     NulError(ffi::NulError),
     PackageNotFound(package::PackageIdent),
+    PackageNotRunnable(package::PackageIdent),
     Permissions(String),
     PidFileCorrupt(PathBuf),
     PidFileIO(PathBuf, io::Error),
@@ -295,6 +296,7 @@ impl fmt::Display for SupError {
                     format!("Cannot find a release of package: {}", pkg)
                 }
             }
+            Error::PackageNotRunnable(ref pkg) => format!("Package is not runnable: {}", pkg),
             Error::PidFileCorrupt(ref path) => {
                 format!("Unable to decode contents of PID file, {}", path.display())
             }
@@ -427,6 +429,7 @@ impl error::Error for SupError {
                 "An attempt was made to build a CString with a null byte inside it"
             }
             Error::PackageNotFound(_) => "Cannot find a package",
+            Error::PackageNotRunnable(_) => "The package is not runnable",
             Error::Permissions(_) => "File system permissions error",
             Error::PidFileCorrupt(_) => "Unable to decode contents of PID file",
             Error::PidFileIO(_, _) => "Unable to read or write to PID file",

--- a/components/sup/src/manager/commands.rs
+++ b/components/sup/src/manager/commands.rs
@@ -244,7 +244,8 @@ pub fn service_load(
             // desired package identifier, it will be used;
             // otherwise, we'll install the latest suitable
             // version from the specified Builder channel.
-            let installed = util::pkg::satisfy_or_install(req, &source, &bldr_url, &bldr_channel)?;
+            let installed =
+                util::pkg::satisfy_or_install(req, &source, &bldr_url, &bldr_channel, true)?;
 
             let mut specs = generate_new_specs_from_package(&installed, &opts)?;
 
@@ -298,6 +299,7 @@ pub fn service_load(
                         &source,
                         &service_spec.bldr_url,
                         &service_spec.channel,
+                        true,
                     )?;
 
                     save_spec_for(&mgr.cfg, &service_spec)?;
@@ -349,6 +351,7 @@ pub fn service_load(
                             // like services can.
                             &bldr_url,
                             &bldr_channel,
+                            false,
                         )?;
 
                         // Generate new specs from the new composite package and

--- a/components/sup/src/util/pkg.rs
+++ b/components/sup/src/util/pkg.rs
@@ -73,6 +73,11 @@ where
 ///
 /// Return the PackageInstall corresponding to the package that was
 /// installed, or was pre-existing.
+///
+/// JC: TODO: When composites are removed, we can remove the
+/// `must_be_runnable` parameter as then all invokers of this
+/// function will require runnable packages
+///
 pub fn satisfy_or_install<T>(
     ui: &mut T,
     install_source: &InstallSource,


### PR DESCRIPTION
Fixes #3468 

Before writing out new service spec files check that the service is
actually runnable. We do the checks in `manager::command` so we
never actually trigger an attempt to start the service (which gives
unhelpful user messages).

We still need to install the package and it's dependencies in order
to check if it's runnable.  We don't clean up those packages

NOTE:  This code doesn't cover the code paths covering the composite
use cases as they're going to be removed.

Signed-off-by: James Casey <james@chef.io>