### PR TITLE
Refactor CensusGroup::previous_peer

### DIFF
--- a/components/sup/src/census.rs
+++ b/components/sup/src/census.rs
@@ -405,22 +405,19 @@ impl CensusGroup {
         me: Option<&CensusMember>,
     ) -> Option<&'a CensusMember> {
         let alive_members: Vec<&CensusMember> = members.filter(|cm| cm.alive()).collect();
-        if alive_members.len() <= 1 || me.is_none() {
+
+        if alive_members.len() < 2 || me.is_none() {
             return None;
         }
-        match alive_members
+
+        alive_members
             .iter()
             .position(|cm| cm.member_id == me.unwrap().member_id)
-        {
-            Some(idx) => {
-                if idx == 0 {
-                    Some(alive_members[alive_members.len() - 1])
-                } else {
-                    Some(alive_members[idx - 1])
-                }
-            }
-            None => None,
-        }
+            .and_then(|idx| match idx {
+                0 => alive_members.last(),
+                idx => alive_members.get(idx - 1),
+            })
+            .map(|&reference| reference)
     }
 
     fn update_from_service_rumors(&mut self, rumors: &HashMap<String, ServiceRumor>) {

--- a/components/sup/src/census.rs
+++ b/components/sup/src/census.rs
@@ -405,20 +405,18 @@ impl CensusGroup {
         members: impl Iterator<Item = &'a CensusMember>,
         me: &CensusMember,
     ) -> Option<&'a CensusMember> {
-        let alive_members: Vec<&CensusMember> = members.filter(|cm| cm.alive()).collect();
+        let mut alive_members = members.filter(|cm| cm.alive());
+        let mut previous = None;
 
-        if alive_members.len() < 2 {
-            return None;
+        for member in alive_members.by_ref() {
+            if member.member_id == me.member_id {
+                return previous.or_else(|| alive_members.last());
+            } else {
+                previous = Some(member);
+            }
         }
 
-        alive_members
-            .iter()
-            .position(|cm| cm.member_id == me.member_id)
-            .and_then(|idx| match idx {
-                0 => alive_members.last(),
-                idx => alive_members.get(idx - 1),
-            })
-            .map(|&reference| reference)
+        None
     }
 
     fn update_from_service_rumors(&mut self, rumors: &HashMap<String, ServiceRumor>) {


### PR DESCRIPTION
This function is untested and a bit awkward, so we aim to remedy both