### PR TITLE
Fix "uncontroversial" clippy lints and start making them errors in TravisCI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -199,67 +199,22 @@ unit-sup: build-launcher-for-supervisor-tests
 .PHONY: build-launcher-for-supervisor-tests
 
 # Lints we need to work through and decide as a team whether to allow or fix
-UNEXAMINED_LINTS = clippy::assign_op_pattern \
-                   clippy::blacklisted_name \
-                   clippy::block_in_if_condition_stmt \
-                   clippy::bool_comparison \
-                   clippy::cast_lossless \
-                   clippy::clone_on_copy \
-                   clippy::cmp_owned \
-                   clippy::collapsible_if \
-                   clippy::const_static_lifetime \
-                   clippy::cyclomatic_complexity \
-                   clippy::deref_addrof \
-                   clippy::expect_fun_call \
-                   clippy::for_kv_map \
-                   clippy::get_unwrap \
-                   clippy::identity_conversion \
-                   clippy::if_let_some_result \
+UNEXAMINED_LINTS = clippy::cyclomatic_complexity \
                    clippy::large_enum_variant \
                    clippy::len_without_is_empty \
-                   clippy::len_zero \
-                   clippy::let_and_return \
-                   clippy::let_unit_value \
-                   clippy::map_clone \
-                   clippy::match_bool \
-                   clippy::match_ref_pats \
                    clippy::module_inception \
-                   clippy::needless_bool \
-                   clippy::needless_collect \
                    clippy::needless_pass_by_value \
-                   clippy::needless_range_loop \
                    clippy::needless_return \
                    clippy::new_ret_no_self \
                    clippy::new_without_default \
                    clippy::new_without_default_derive \
-                   clippy::ok_expect \
-                   clippy::op_ref \
-                   clippy::option_map_unit_fn \
-                   clippy::or_fun_call \
-                   clippy::println_empty_string \
-                   clippy::ptr_arg \
                    clippy::question_mark \
-                   clippy::redundant_closure \
                    clippy::redundant_field_names \
-                   clippy::redundant_pattern_matching \
-                   clippy::single_char_pattern \
-                   clippy::single_match \
-                   clippy::string_lit_as_bytes \
                    clippy::too_many_arguments \
-                   clippy::toplevel_ref_arg \
                    clippy::trivially_copy_pass_by_ref \
-                   clippy::unit_arg \
-                   clippy::unnecessary_operation \
-                   clippy::unreadable_literal \
-                   clippy::unused_label \
-                   clippy::unused_unit \
-                   clippy::useless_asref \
-                   clippy::useless_format \
-                   clippy::useless_let_if_seq \
-                   clippy::useless_vec \
-                   clippy::write_with_newline \
                    clippy::wrong_self_convention \
-                   renamed_and_removed_lints
+                   renamed_and_removed_lints # Move to DENIED_LINTS after eventsrv is removed
+                                             # See https://github.com/habitat-sh/habitat/issues/5962
 
 # Lints we disagree with and choose to keep in our code with no warning
 ALLOWED_LINTS =
@@ -269,7 +224,53 @@ LINTS_TO_FIX =
 
 # Lints we don't expect to have in our code at all and want to avoid adding
 # even at the cost of failing the build
-DENIED_LINTS = clippy::correctness
+DENIED_LINTS = clippy::assign_op_pattern \
+               clippy::blacklisted_name \
+               clippy::block_in_if_condition_stmt \
+               clippy::bool_comparison \
+               clippy::cast_lossless \
+               clippy::clone_on_copy \
+               clippy::cmp_owned \
+               clippy::collapsible_if \
+               clippy::const_static_lifetime \
+               clippy::correctness \
+               clippy::deref_addrof \
+               clippy::expect_fun_call \
+               clippy::for_kv_map \
+               clippy::get_unwrap \
+               clippy::identity_conversion \
+               clippy::if_let_some_result \
+               clippy::len_zero \
+               clippy::let_and_return \
+               clippy::let_unit_value \
+               clippy::map_clone \
+               clippy::match_bool \
+               clippy::match_ref_pats \
+               clippy::needless_bool \
+               clippy::needless_collect \
+               clippy::needless_range_loop \
+               clippy::ok_expect \
+               clippy::op_ref \
+               clippy::option_map_unit_fn \
+               clippy::or_fun_call \
+               clippy::println_empty_string \
+               clippy::ptr_arg \
+               clippy::redundant_closure \
+               clippy::redundant_pattern_matching \
+               clippy::single_char_pattern \
+               clippy::single_match \
+               clippy::string_lit_as_bytes \
+               clippy::toplevel_ref_arg \
+               clippy::unit_arg \
+               clippy::unnecessary_operation \
+               clippy::unreadable_literal \
+               clippy::unused_label \
+               clippy::unused_unit \
+               clippy::useless_asref \
+               clippy::useless_format \
+               clippy::useless_let_if_seq \
+               clippy::useless_vec \
+               clippy::write_with_newline
 
 define LINT
 lint-$1: image ## executes the $1 component's linter checks

--- a/components/builder-api-client/src/error.rs
+++ b/components/builder-api-client/src/error.rs
@@ -51,7 +51,7 @@ pub enum Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let msg = match *self {
-            Error::APIError(ref c, ref m) if m.len() > 0 => format!("[{}] {}", c, m),
+            Error::APIError(ref c, ref m) if !m.is_empty() => format!("[{}] {}", c, m),
             Error::APIError(ref c, _) => format!("[{}]", c),
             Error::BadResponseBody(ref e) => format!("Failed to read response body, {}", e),
             Error::DownloadWrite(ref p, ref e) => format!("Failed to write contents of builder response, {}, {}", p.display(), e),
@@ -61,25 +61,13 @@ impl fmt::Display for Error {
             Error::IO(ref e) => format!("{}", e),
             Error::Json(ref e) => format!("{}", e),
             Error::KeyReadError(ref p, ref e) => format!("Failed to read origin key, {}, {}", p.display(), e),
-            Error::NoFilePart => {
-                format!(
-                    "An invalid path was passed - we needed a filename, and this path does \
-                         not have one"
-                )
-            }
+            Error::NoFilePart => "An invalid path was passed - we needed a filename, and this path does not have one".to_string(),
             Error::PackageReadError(ref p, ref e) => format!("Failed to read package artifact, {}, {}", p.display(), e),
             Error::ParseIntError(ref err) => format!("{}", err),
-            Error::IdentNotFullyQualified => {
-                format!(
-                    "Cannot perform the specified operation. \
-                    Specify a fully qualifed package identifier (ex: core/busybox-static/1.42.2/20170513215502)"
-                )
-            }
+            Error::IdentNotFullyQualified => "Cannot perform the specified operation. Specify a fully qualifed package identifier (ex: core/busybox-static/1.42.2/20170513215502)".to_string(),
             Error::UploadFailed(ref s) => format!("Upload failed: {}", s),
             Error::UrlParseError(ref e) => format!("{}", e),
-            Error::WriteSyncFailed => {
-                format!("Could not write to destination; perhaps the disk is full?")
-            }
+            Error::WriteSyncFailed => "Could not write to destination; perhaps the disk is full?".to_string(),
         };
         write!(f, "{}", msg)
     }

--- a/components/butterfly/src/client.rs
+++ b/components/butterfly/src/client.rs
@@ -81,10 +81,10 @@ impl Client {
         &mut self,
         service_group: ServiceGroup,
         incarnation: u64,
-        config: Vec<u8>,
+        config: &[u8],
         encrypted: bool,
     ) -> Result<()> {
-        let mut sc = ServiceConfig::new("butterflyclient", service_group, config);
+        let mut sc = ServiceConfig::new("butterflyclient", service_group, config.to_vec());
         sc.incarnation = incarnation;
         sc.encrypted = encrypted;
         self.send(sc)
@@ -96,13 +96,13 @@ impl Client {
         service_group: ServiceGroup,
         filename: S,
         incarnation: u64,
-        body: Vec<u8>,
+        body: &[u8],
         encrypted: bool,
     ) -> Result<()>
     where
         S: Into<String>,
     {
-        let mut sf = ServiceFile::new("butterflyclient", service_group, filename, body);
+        let mut sf = ServiceFile::new("butterflyclient", service_group, filename, body.to_vec());
         sf.incarnation = incarnation;
         sf.encrypted = encrypted;
         self.send(sf)

--- a/components/butterfly/src/error.rs
+++ b/components/butterfly/src/error.rs
@@ -83,11 +83,12 @@ impl fmt::Display for Error {
                 path.display(),
                 err
             ),
-            Error::InvalidIncarnationSynchronization => format!(
+            Error::InvalidIncarnationSynchronization => {
                 "Tried to synchronize own member incarnation from non-existent incarnation store"
-            ),
+                    .to_string()
+            }
             Error::InvalidRumorShareLimit => {
-                format!("Rumor share limit should be a positive integer")
+                "Rumor share limit should be a positive integer".to_string()
             }
             Error::NonExistentRumor(ref member_id, ref rumor_id) => format!(
                 "Non existent rumor asked to be written to bytes: {} {}",
@@ -103,7 +104,7 @@ impl fmt::Display for Error {
             Error::ServiceConfigNotUtf8(ref sg, ref err) => {
                 format!("Cannot read service configuration: group={}, {}", sg, err)
             }
-            Error::SocketCloneError => format!("Cannot clone the underlying UDP socket"),
+            Error::SocketCloneError => "Cannot clone the underlying UDP socket".to_string(),
             Error::SocketSetReadTimeout(ref err) => {
                 format!("Cannot set UDP socket read timeout: {}", err)
             }

--- a/components/butterfly/src/main.rs
+++ b/components/butterfly/src/main.rs
@@ -42,7 +42,7 @@ fn main() {
 
     let bind_to_addr = bind_to.parse::<SocketAddr>().unwrap();
     let bind_port = bind_to_addr.port();
-    let mut gossip_bind_addr = bind_to_addr.clone();
+    let mut gossip_bind_addr = bind_to_addr;
     let gport = bind_port + 1;
     gossip_bind_addr.set_port(gport);
 

--- a/components/butterfly/src/member.rs
+++ b/components/butterfly/src/member.rs
@@ -297,7 +297,7 @@ impl FromProto<proto::Member> for Member {
             // a value of `None`. We ultimately need to either _not_
             // generate meaningless default values, or tease apart the
             // two uses of our Member protobuf, or both.
-            address: proto.address.unwrap_or("".to_string()),
+            address: proto.address.unwrap_or_default(),
 
             swim_port: proto
                 .swim_port
@@ -1307,7 +1307,7 @@ mod tests {
                     );
                 } else {
                     assert!(
-                        ml.insert(member_one.clone(), to_health) == false,
+                        !ml.insert(member_one.clone(), to_health),
                         "Transitioning from {:?} to {:?} (i.e., no worse health) should be a no-op",
                         from_health,
                         to_health

--- a/components/butterfly/src/rumor/dat_file.rs
+++ b/components/butterfly/src/rumor/dat_file.rs
@@ -283,10 +283,12 @@ impl DatFile {
     /// On windows this function does nothing.
     #[cfg(unix)]
     fn sync_parent_dir(&self) -> Result<()> {
-        let parent = self.path.parent().ok_or(Error::DatFileIO(
-            self.path.clone(),
-            io::Error::new(io::ErrorKind::Other, "Dat file has no parent directory"),
-        ))?;
+        let parent = self.path.parent().ok_or_else(|| {
+            Error::DatFileIO(
+                self.path.clone(),
+                io::Error::new(io::ErrorKind::Other, "Dat file has no parent directory"),
+            )
+        })?;
         fs::File::open(parent)
             .and_then(|f| f.sync_all())
             .map_err(|err| Error::DatFileIO(parent.to_path_buf(), err))?;

--- a/components/butterfly/src/rumor/departure.rs
+++ b/components/butterfly/src/rumor/departure.rs
@@ -66,11 +66,7 @@ impl From<Departure> for newscast::Departure {
 
 impl Rumor for Departure {
     fn merge(&mut self, other: Departure) -> bool {
-        if *self >= other {
-            false
-        } else {
-            true
-        }
+        *self < other
     }
 
     fn kind(&self) -> RumorType {

--- a/components/butterfly/src/rumor/election.rs
+++ b/components/butterfly/src/rumor/election.rs
@@ -201,17 +201,15 @@ impl Rumor for Election {
             other.steal_votes(self);
             *self = other;
             true
+        } else if self.member_id >= other.member_id {
+            debug!("stored rumor wins tie-breaker; take received rumor's votes and share");
+            self.steal_votes(&mut other);
+            true
         } else {
-            if self.member_id >= other.member_id {
-                debug!("stored rumor wins tie-breaker; take received rumor's votes and share");
-                self.steal_votes(&mut other);
-                true
-            } else {
-                debug!("received rumor wins tie-breaker; take stored rumor's votes, replace stored and share");
-                other.steal_votes(self);
-                *self = other;
-                true
-            }
+            debug!("received rumor wins tie-breaker; take stored rumor's votes, replace stored and share");
+            other.steal_votes(self);
+            *self = other;
+            true
         }
     }
 

--- a/components/butterfly/src/rumor/heat.rs
+++ b/components/butterfly/src/rumor/heat.rs
@@ -123,7 +123,7 @@ impl RumorHeat {
             .read()
             .expect("RumorHeat lock poisoned")
             .iter()
-            .map(|(k, heat_map)| (k.clone(), heat_map.get(id).unwrap_or(&0).clone()))
+            .map(|(k, heat_map)| (k.clone(), *heat_map.get(id).unwrap_or(&0)))
             .filter(|&(_, heat)| heat < RumorShareLimit::configured_value().0)
             .collect();
 
@@ -144,9 +144,9 @@ impl RumorHeat {
     /// **NOTE**: "cool" in the name of the function is a *verb*; you're
     /// not going to get a list of cool rumors from this.
     pub fn cool_rumors(&self, id: &str, rumors: &[RumorKey]) {
-        if rumors.len() > 0 {
+        if !rumors.is_empty() {
             let mut rumor_map = self.0.write().expect("RumorHeat lock poisoned");
-            for ref rk in rumors {
+            for rk in rumors {
                 if rumor_map.contains_key(&rk) {
                     let heat_map = rumor_map.get_mut(&rk).unwrap();
                     if heat_map.contains_key(id) {

--- a/components/butterfly/src/rumor/service.rs
+++ b/components/butterfly/src/rumor/service.rs
@@ -50,7 +50,7 @@ impl Serialize for Service {
         S: Serializer,
     {
         let mut strukt = serializer.serialize_struct("service", 7)?;
-        let cfg = toml::from_slice(&self.cfg).unwrap_or(toml::value::Table::default());
+        let cfg: toml::value::Table = toml::from_slice(&self.cfg).unwrap_or_default();
         strukt.serialize_field("member_id", &self.member_id)?;
         strukt.serialize_field("service_group", &self.service_group)?;
         strukt.serialize_field("package", &self.pkg)?;

--- a/components/butterfly/src/server/outbound.rs
+++ b/components/butterfly/src/server/outbound.rs
@@ -46,8 +46,8 @@ enum AckFrom {
 impl fmt::Display for AckFrom {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            &AckFrom::Ping => write!(f, "Ping"),
-            &AckFrom::PingReq => write!(f, "PingReq"),
+            AckFrom::Ping => write!(f, "Ping"),
+            AckFrom::PingReq => write!(f, "PingReq"),
         }
     }
 }
@@ -266,7 +266,7 @@ pub fn populate_membership_rumors(server: &Server, target: &Member, swim: &mut S
         .take(5) // TODO (CM): magic number!
         .collect();
 
-    for ref rkey in rumors.iter() {
+    for rkey in rumors.iter() {
         if let Some(member) = server.member_list.membership_for(&rkey.key()) {
             swim.membership.push(member);
         }

--- a/components/butterfly/src/server/push.rs
+++ b/components/butterfly/src/server/push.rs
@@ -54,7 +54,7 @@ impl Push {
     /// all FANOUT targets faster than `Timing::GOSSIP_PERIOD_DEFAULT_MS`, we will block until we
     /// exceed that time.
     pub fn run(&mut self) {
-        'send: loop {
+        loop {
             if self.server.pause.load(Ordering::Relaxed) {
                 thread::sleep(Duration::from_millis(100));
                 continue;
@@ -67,7 +67,7 @@ impl Push {
 
             'fanout: loop {
                 let mut thread_list = Vec::with_capacity(FANOUT);
-                if check_list.len() == 0 {
+                if check_list.is_empty() {
                     break 'fanout;
                 }
                 let drain_length = if check_list.len() >= FANOUT {
@@ -89,7 +89,7 @@ impl Push {
                         && !self.server.member_list.persistent_and_confirmed(&member)
                     {
                         let rumors = self.server.rumor_heat.currently_hot_rumors(&member.id);
-                        if rumors.len() > 0 {
+                        if !rumors.is_empty() {
                             let sc = self.server.clone();
 
                             let guard = match thread::Builder::new()
@@ -173,7 +173,7 @@ impl PushWorker {
                 return;
             }
         }
-        'rumorlist: for ref rumor_key in rumors.iter() {
+        'rumorlist: for rumor_key in rumors.iter() {
             let rumor_as_bytes = match rumor_key.kind {
                 RumorType::Member => {
                     let send_rumor = match self.create_member_rumor(&rumor_key) {

--- a/components/butterfly/src/server/timing.rs
+++ b/components/butterfly/src/server/timing.rs
@@ -24,7 +24,7 @@ const SUSPICION_TIMEOUT_DEFAULT_PROTOCOL_PERIODS: i64 = 3;
 const GOSSIP_PERIOD_DEFAULT_MS: i64 = 1000;
 /// How long before we set a confirmed member to a departed member, removing them from quorums
 ///   just for your own sanity - this is 3 days.
-const DEPARTURE_TIMEOUT_DEFAULT_MS: i64 = 259200000;
+const DEPARTURE_TIMEOUT_DEFAULT_MS: i64 = 259_200_000;
 
 /// The timing of the outbound threads.
 #[derive(Debug, Clone)]

--- a/components/butterfly/src/trace.rs
+++ b/components/butterfly/src/trace.rs
@@ -137,7 +137,7 @@ impl<'a> fmt::Display for TraceWrite<'a> {
         write!(f, "^{}", self.to_addr.unwrap_or(""))?;
         write!(f, "^{}", self.swim.unwrap_or(""))?;
         write!(f, "^{}", self.rumor.unwrap_or(""))?;
-        write!(f, "\n")
+        writeln!(f)
     }
 }
 

--- a/components/butterfly/tests/rumor/service_config.rs
+++ b/components/butterfly/tests/rumor/service_config.rs
@@ -35,7 +35,7 @@ fn service_config_via_client() {
     net.wait_for_gossip_rounds(1);
     let mut client =
         Client::new(net[0].gossip_addr(), None).expect("Cannot create Butterfly Client");
-    let payload = Vec::from("I want to get lost in you, tokyo".as_bytes());
+    let payload = b"I want to get lost in you, tokyo";
     client
         .send_service_config(
             ServiceGroup::new(None, "witcher", "prod", None).unwrap(),

--- a/components/butterfly/tests/rumor/service_file.rs
+++ b/components/butterfly/tests/rumor/service_file.rs
@@ -40,7 +40,7 @@ fn service_file_via_client() {
     net.wait_for_gossip_rounds(1);
     let mut client =
         Client::new(net[0].gossip_addr(), None).expect("Cannot create Butterfly Client");
-    let payload = Vec::from("I want to get lost in you, tokyo".as_bytes());
+    let payload = b"I want to get lost in you, tokyo";
     client
         .send_service_file(
             ServiceGroup::new(None, "witcher", "prod", None).unwrap(),

--- a/components/common/src/error.rs
+++ b/components/common/src/error.rs
@@ -64,17 +64,17 @@ impl fmt::Display for Error {
                 ai, a, i
             ),
             Error::CantUploadGossipToml => {
-                format!("Can't upload gossip.toml, it's a reserved file name")
+                "Can't upload gossip.toml, it's a reserved file name".to_string()
             }
-            Error::ChannelNotFound => format!("Channel not found"),
+            Error::ChannelNotFound => "Channel not found".to_string(),
             Error::CryptoKeyError(ref s) => format!("Missing or invalid key: {}", s),
             Error::GossipFileRelativePath(ref s) => format!(
                 "Path for gossip file cannot have relative components (eg: ..): {}",
                 s
             ),
-            Error::DownloadFailed(ref msg) => format!("{}", msg),
-            Error::EditStatus => format!("Failed edit text command"),
-            Error::FileNameError => format!("Failed to extract a filename"),
+            Error::DownloadFailed(ref msg) => msg.to_string(),
+            Error::EditStatus => "Failed edit text command".to_string(),
+            Error::FileNameError => "Failed to extract a filename".to_string(),
             Error::HabitatCore(ref e) => format!("{}", e),
             Error::IO(ref err) => format!("{}", err),
             Error::NetParseError(ref err) => format!("{}", err),

--- a/components/common/src/locked_env_var.rs
+++ b/components/common/src/locked_env_var.rs
@@ -218,7 +218,7 @@ mod tests {
         // Poison the lock
         let _ = thread::Builder::new()
             .name("testing-locked-env-var-panic".into())
-            .spawn(move || -> () {
+            .spawn(move || {
                 let _lock = lock_var();
                 panic!("This is an intentional panic; it's OK");
             })

--- a/components/common/src/package_graph.rs
+++ b/components/common/src/package_graph.rs
@@ -83,7 +83,7 @@ impl PackageGraph {
     }
 
     /// Extend a graph by adding in dependencies for a package
-    fn extend(&mut self, package: &PackageIdent, deps: &Vec<PackageIdent>) -> (usize, usize) {
+    fn extend(&mut self, package: &PackageIdent, deps: &[PackageIdent]) -> (usize, usize) {
         let idx = self.node_idx(package);
 
         for dep in deps {
@@ -97,8 +97,6 @@ impl PackageGraph {
     }
 
     /// Return the dependencies of a given Package Identifier
-    ///
-    /// Returns `None` if the package identifier is not in the graph
     pub fn ordered_deps(&self, package: &PackageIdent) -> Vec<&PackageIdent> {
         self.nodes
             .get_by_left(package)
@@ -107,19 +105,15 @@ impl PackageGraph {
                 // `skip` it here so it's not in the result Vec
                 let bfs = Bfs::new(&self.graph, idx).iter(&self.graph).skip(1);
 
-                bfs.into_iter()
-                    .map(|child| self.graph.node_weight(child).unwrap())
+                bfs.map(|child| self.graph.node_weight(child).unwrap())
                     .collect()
             })
-            .unwrap_or(vec![])
+            .unwrap_or_default()
     }
 
     /// Return the dependencies of a given Package Identifier as `PackageIdent`s. This
     /// allows you to modify the underlying graph (via `PackageGraph::remove`) while traversing the
     /// dependencies
-    ///
-    /// Returns `None` if the package identifier is not in the graph
-
     pub fn owned_ordered_deps(&self, package: &PackageIdent) -> Vec<PackageIdent> {
         self.ordered_deps(&package)
             .iter()
@@ -127,8 +121,6 @@ impl PackageGraph {
             .collect()
     }
     /// Return the reverse dependencies of a given Package Identifier
-    ///
-    /// Returns `None` if the package identifier is not in the graph
     pub fn ordered_reverse_deps(&self, package: &PackageIdent) -> Vec<&PackageIdent> {
         self.nodes
             .get_by_left(package)
@@ -139,11 +131,10 @@ impl PackageGraph {
                     .iter(Reversed(&self.graph))
                     .skip(1);
 
-                bfs.into_iter()
-                    .map(|child| self.graph.node_weight(child).unwrap())
+                bfs.map(|child| self.graph.node_weight(child).unwrap())
                     .collect()
             })
-            .unwrap_or(vec![])
+            .unwrap_or_default()
     }
 
     /// Remove a package from a graph
@@ -212,7 +203,7 @@ impl PackageGraph {
                     .map(|n| self.nodes.get_by_right(&n).unwrap()) //  unwrap here is ok as we have consistency between `self.graph` and `self.nodes`
                     .collect()
             })
-            .unwrap_or(vec![])
+            .unwrap_or_default()
     }
 
     /// Returns the direct dependencies for a package.
@@ -274,7 +265,7 @@ mod test {
         }
     }
 
-    fn package_deps(ident: PackageIdent, deps: &Vec<PackageIdent>) -> PackageDeps {
+    fn package_deps(ident: PackageIdent, deps: &[PackageIdent]) -> PackageDeps {
         PackageDeps {
             ident: ident,
             deps: deps.to_vec(),
@@ -312,7 +303,7 @@ mod test {
         let b = PackageIdent::from_str("core/foo/1.0/20180704142702").unwrap();
         let packages = vec![
             empty_package_deps(a.clone()),
-            package_deps(b.clone(), &vec![a.clone()]),
+            package_deps(b.clone(), &[a.clone()]),
         ];
 
         let graph = build(packages);
@@ -345,9 +336,9 @@ mod test {
         let d = PackageIdent::from_str("core/bar/1.0/20180704142805").unwrap();
         let packages = vec![
             empty_package_deps(a.clone()),
-            package_deps(b.clone(), &vec![a.clone()]),
-            package_deps(c.clone(), &vec![a.clone()]),
-            package_deps(d.clone(), &vec![b.clone(), c.clone()]),
+            package_deps(b.clone(), &[a.clone()]),
+            package_deps(c.clone(), &[a.clone()]),
+            package_deps(d.clone(), &[b.clone(), c.clone()]),
         ];
 
         let graph = build(packages);
@@ -367,9 +358,9 @@ mod test {
         let d = PackageIdent::from_str("core/bar/1.0/20180704142805").unwrap();
         let packages = vec![
             empty_package_deps(a.clone()),
-            package_deps(b.clone(), &vec![a.clone()]),
-            package_deps(c.clone(), &vec![a.clone()]),
-            package_deps(d.clone(), &vec![b.clone(), c.clone()]),
+            package_deps(b.clone(), &[a.clone()]),
+            package_deps(c.clone(), &[a.clone()]),
+            package_deps(d.clone(), &[b.clone(), c.clone()]),
         ];
 
         let graph = build(packages);
@@ -390,9 +381,9 @@ mod test {
         let d = PackageIdent::from_str("core/bar/1.0/20180704142805").unwrap();
         let packages = vec![
             empty_package_deps(a.clone()),
-            package_deps(b.clone(), &vec![a.clone()]),
-            package_deps(c.clone(), &vec![a.clone()]),
-            package_deps(d.clone(), &vec![b.clone(), c.clone()]),
+            package_deps(b.clone(), &[a.clone()]),
+            package_deps(c.clone(), &[a.clone()]),
+            package_deps(d.clone(), &[b.clone(), c.clone()]),
         ];
 
         let graph = build(packages);
@@ -415,9 +406,9 @@ mod test {
         let d = PackageIdent::from_str("core/bar/1.0/20180704142805").unwrap();
         let packages = vec![
             empty_package_deps(a.clone()),
-            package_deps(b.clone(), &vec![a.clone()]),
-            package_deps(c.clone(), &vec![a.clone()]),
-            package_deps(d.clone(), &vec![b.clone(), c.clone()]),
+            package_deps(b.clone(), &[a.clone()]),
+            package_deps(c.clone(), &[a.clone()]),
+            package_deps(d.clone(), &[b.clone(), c.clone()]),
         ];
 
         let graph = build(packages);
@@ -438,9 +429,9 @@ mod test {
         let d = PackageIdent::from_str("core/bar/1.0/20180704142805").unwrap();
         let packages = vec![
             empty_package_deps(a.clone()),
-            package_deps(b.clone(), &vec![a.clone()]),
-            package_deps(c.clone(), &vec![a.clone()]),
-            package_deps(d.clone(), &vec![b.clone(), c.clone()]),
+            package_deps(b.clone(), &[a.clone()]),
+            package_deps(c.clone(), &[a.clone()]),
+            package_deps(d.clone(), &[b.clone(), c.clone()]),
         ];
 
         let graph = build(packages);
@@ -463,9 +454,9 @@ mod test {
         let d = PackageIdent::from_str("core/bar/1.0/20180704142805").unwrap();
         let packages = vec![
             empty_package_deps(a.clone()),
-            package_deps(b.clone(), &vec![a.clone()]),
-            package_deps(c.clone(), &vec![a.clone()]),
-            package_deps(d.clone(), &vec![b.clone(), c.clone()]),
+            package_deps(b.clone(), &[a.clone()]),
+            package_deps(c.clone(), &[a.clone()]),
+            package_deps(d.clone(), &[b.clone(), c.clone()]),
         ];
 
         let mut graph = build(packages);
@@ -490,7 +481,7 @@ mod test {
         let b = PackageIdent::from_str("core/foo/1.0/20180704142702").unwrap();
         let packages = vec![
             empty_package_deps(a.clone()),
-            package_deps(b.clone(), &vec![a.clone()]),
+            package_deps(b.clone(), &[a.clone()]),
         ];
 
         let mut graph = build(packages);
@@ -524,9 +515,9 @@ mod test {
         let d = PackageIdent::from_str("core/bar/1.0/20180704142805").unwrap();
         let packages = vec![
             empty_package_deps(a.clone()),
-            package_deps(b.clone(), &vec![a.clone()]),
-            package_deps(c.clone(), &vec![a.clone()]),
-            package_deps(d.clone(), &vec![b.clone(), c.clone()]),
+            package_deps(b.clone(), &[a.clone()]),
+            package_deps(c.clone(), &[a.clone()]),
+            package_deps(d.clone(), &[b.clone(), c.clone()]),
         ];
 
         let graph = build(packages);
@@ -546,9 +537,9 @@ mod test {
         let d = PackageIdent::from_str("core/baz/1.0/20180704142805").unwrap();
         let packages = vec![
             empty_package_deps(a.clone()),
-            package_deps(b.clone(), &vec![a.clone()]),
-            package_deps(c.clone(), &vec![b.clone()]),
-            package_deps(d.clone(), &vec![c.clone()]),
+            package_deps(b.clone(), &[a.clone()]),
+            package_deps(c.clone(), &[b.clone()]),
+            package_deps(d.clone(), &[c.clone()]),
         ];
 
         let graph = build(packages);
@@ -568,9 +559,9 @@ mod test {
         let d = PackageIdent::from_str("core/baz/1.0/20180704142805").unwrap();
         let packages = vec![
             empty_package_deps(a.clone()),
-            package_deps(b.clone(), &vec![a.clone()]),
-            package_deps(c.clone(), &vec![b.clone()]),
-            package_deps(d.clone(), &vec![c.clone()]),
+            package_deps(b.clone(), &[a.clone()]),
+            package_deps(c.clone(), &[b.clone()]),
+            package_deps(d.clone(), &[c.clone()]),
         ];
 
         let graph = build(packages);
@@ -602,9 +593,9 @@ mod test {
         let d = PackageIdent::from_str("core/baz/1.0/20180704142805").unwrap();
         let packages = vec![
             empty_package_deps(a.clone()),
-            package_deps(b.clone(), &vec![a.clone()]),
-            package_deps(c.clone(), &vec![b.clone()]),
-            package_deps(d.clone(), &vec![c.clone()]),
+            package_deps(b.clone(), &[a.clone()]),
+            package_deps(c.clone(), &[b.clone()]),
+            package_deps(d.clone(), &[c.clone()]),
         ];
 
         let graph = build(packages);

--- a/components/hab/src/analytics.rs
+++ b/components/hab/src/analytics.rs
@@ -204,23 +204,23 @@ use crate::error::Result;
 /// The Google Analytics [Tracking
 /// ID](https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#tid)
 /// which represents this product.
-const GOOGLE_ANALYTICS_ID: &'static str = "UA-6369228-7";
+const GOOGLE_ANALYTICS_ID: &str = "UA-6369228-7";
 /// The Google Analytics [URL endpoint][g].
 ///
 /// [g]: https://developers.google.com/analytics/devguides/collection/protocol/v1/reference#endpoint
-const GOOGLE_ANALYTICS_URL: &'static str = "https://www.google-analytics.com/collect";
+const GOOGLE_ANALYTICS_URL: &str = "https://www.google-analytics.com/collect";
 /// The product name for this application.
-const PRODUCT: &'static str = "hab";
+const PRODUCT: &str = "hab";
 /// A representation of the source of the analytics data.
-const DATA_SOURCE: &'static str = "cli--hab";
+const DATA_SOURCE: &str = "cli--hab";
 /// The filename containing a randomly generated [Client
 /// ID](https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#cid).
-const CLIENT_ID_METAFILE: &'static str = "CLIENT_ID";
+const CLIENT_ID_METAFILE: &str = "CLIENT_ID";
 /// The filename which represents a program which has opted in to analytics
-const OPTED_IN_METAFILE: &'static str = "OPTED_IN";
+const OPTED_IN_METAFILE: &str = "OPTED_IN";
 /// The filename which represents a program which has explicitly opted out to analytics. Note that
 /// the default is opted out.
-const OPTED_OUT_METAFILE: &'static str = "OPTED_OUT";
+const OPTED_OUT_METAFILE: &str = "OPTED_OUT";
 
 /// Different kinds of analytic events.
 enum Event {

--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -1120,9 +1120,9 @@ fn file_exists_or_stdin(val: String) -> result::Result<(), String> {
 fn valid_socket_addr(val: String) -> result::Result<(), String> {
     match SocketAddr::from_str(&val) {
         Ok(_) => Ok(()),
-        Err(_) => Err(format!(
-            "Socket address should include both IP and port, eg: '0.0.0.0:9700'"
-        )),
+        Err(_) => {
+            Err("Socket address should include both IP and port, eg: '0.0.0.0:9700'".to_string())
+        }
     }
 }
 

--- a/components/hab/src/command/bldr/job/promote.rs
+++ b/components/hab/src/command/bldr/job/promote.rs
@@ -49,7 +49,7 @@ pub fn get_ident_list(
         .map(|p| p.ident)
         .collect();
 
-    if idents.len() == 0 || !interactive {
+    if idents.is_empty() || !interactive {
         return Ok(idents);
     }
 
@@ -64,9 +64,9 @@ pub fn get_ident_list(
 
     Ok(ui
         .edit(&idents)?
-        .split("\n")
+        .split('\n')
         .filter(|s| is_ident(s))
-        .map(|s: &str| s.to_string())
+        .map(str::to_string)
         .collect())
 }
 
@@ -76,7 +76,7 @@ fn get_group_status(bldr_url: &str, group_id: u64) -> Result<api_client::Schedul
 
     let group_status = api_client
         .get_schedule(group_id as i64, true)
-        .map_err(|e| Error::ScheduleStatus(e))?;
+        .map_err(Error::ScheduleStatus)?;
 
     Ok(group_status)
 }
@@ -124,7 +124,7 @@ pub fn start(
     let group_status = get_group_status(bldr_url, gid)?;
     let idents = get_ident_list(ui, &group_status, origin, interactive)?;
 
-    if idents.len() == 0 {
+    if idents.is_empty() {
         ui.warn("No matching packages found")?;
         return Ok(());
     }

--- a/components/hab/src/command/bldr/job/start.rs
+++ b/components/hab/src/command/bldr/job/start.rs
@@ -30,11 +30,11 @@ pub fn start(
 
     if group {
         let rdeps = api_client.fetch_rdeps(ident).map_err(Error::APIClient)?;
-        if rdeps.len() > 0 {
+        if !rdeps.is_empty() {
             ui.warn("Found the following reverse dependencies:")?;
 
             for rdep in rdeps {
-                ui.warn(format!("{}", rdep))?;
+                ui.warn(rdep.to_string())?;
             }
 
             let question = "If you choose to start a group build for this package, \

--- a/components/hab/src/command/bldr/job/status.rs
+++ b/components/hab/src/command/bldr/job/status.rs
@@ -63,10 +63,10 @@ fn do_job_group_status(
     match api_client.get_schedule(gid, show_jobs) {
         Ok(sr) => {
             let mut tw = TabWriter::new(vec![]);
-            write!(&mut tw, "CREATED AT\tGROUP ID\tSTATUS\tIDENT\n").unwrap();
-            write!(
+            writeln!(&mut tw, "CREATED AT\tGROUP ID\tSTATUS\tIDENT").unwrap();
+            writeln!(
                 &mut tw,
-                "{}\t{}\t{}\t{}\n",
+                "{}\t{}\t{}\t{}",
                 sr.created_at, sr.id, sr.state, sr.project_name,
             )
             .unwrap();
@@ -76,17 +76,12 @@ fn do_job_group_status(
 
             if show_jobs && !sr.projects.is_empty() {
                 tw = TabWriter::new(vec![]);
-                write!(&mut tw, "NAME\tSTATUS\tJOB ID\tIDENT\n").unwrap();
+                writeln!(&mut tw, "NAME\tSTATUS\tJOB ID\tIDENT").unwrap();
                 for p in sr.projects {
                     // Don't show ident if the build did not succeed
                     // TODO: This will be fixed at the API level eventually
                     let ident = if p.state == "Success" { &p.ident } else { "" };
-                    write!(
-                        &mut tw,
-                        "{}\t{}\t{}\t{}\n",
-                        p.name, p.state, p.job_id, ident,
-                    )
-                    .unwrap();
+                    writeln!(&mut tw, "{}\t{}\t{}\t{}", p.name, p.state, p.job_id, ident,).unwrap();
                 }
                 written = String::from_utf8(tw.into_inner().unwrap()).unwrap();
                 println!("{}", written);
@@ -111,11 +106,11 @@ fn do_origin_status(
     match api_client.get_origin_schedule(origin, limit) {
         Ok(sr) => {
             let mut tw = TabWriter::new(vec![]);
-            write!(&mut tw, "CREATED AT\tGROUP ID\tSTATUS\tIDENT\n").unwrap();
+            writeln!(&mut tw, "CREATED AT\tGROUP ID\tSTATUS\tIDENT").unwrap();
             for s in sr.iter() {
-                write!(
+                writeln!(
                     &mut tw,
-                    "{}\t{}\t{}\t{}\n",
+                    "{}\t{}\t{}\t{}",
                     s.created_at, s.id, s.state, s.project_name,
                 )
                 .unwrap();

--- a/components/hab/src/command/cli/setup.rs
+++ b/components/hab/src/command/cli/setup.rs
@@ -111,11 +111,11 @@ pub fn start(
              publicly, we recommend that you select one that is not already in use \
              on the Habitat build service found at https://bldr.habitat.sh/.",
         )?;
-        ui.para(&format!(
+        ui.para(
             "Origins must begin with a lowercase letter or number. \
              Allowed characters include lowercase letters, numbers, _, -. \
-             No more than 255 characters."
-        ))?;
+             No more than 255 characters.",
+        )?;
         let mut origin = prompt_origin(ui)?;
 
         while !ident::is_valid_origin_name(&origin) {
@@ -326,7 +326,7 @@ fn prompt_origin(ui: &mut UI) -> Result<String> {
             ))?;
             Some(o)
         }
-        None => henv::var(ORIGIN_ENVVAR).or(henv::var("USER")).ok(),
+        None => henv::var(ORIGIN_ENVVAR).or_else(|_| henv::var("USER")).ok(),
     };
     Ok(ui.prompt_ask("Default origin name", default.as_ref().map(|x| &**x))?)
 }

--- a/components/hab/src/command/launcher.rs
+++ b/components/hab/src/command/launcher.rs
@@ -40,14 +40,14 @@ mod inner {
     use crate::exec;
     use crate::VERSION;
 
-    const LAUNCH_CMD: &'static str = "hab-launch";
-    const LAUNCH_CMD_ENVVAR: &'static str = "HAB_LAUNCH_BINARY";
-    const LAUNCH_PKG_IDENT: &'static str = "core/hab-launcher";
+    const LAUNCH_CMD: &str = "hab-launch";
+    const LAUNCH_CMD_ENVVAR: &str = "HAB_LAUNCH_BINARY";
+    const LAUNCH_PKG_IDENT: &str = "core/hab-launcher";
 
     pub fn start(ui: &mut UI, args: Vec<OsString>) -> Result<()> {
         init();
         if henv::var(SUP_CMD_ENVVAR).is_err() {
-            let version: Vec<&str> = VERSION.split("/").collect();
+            let version: Vec<&str> = VERSION.split('/').collect();
             exec::command_from_min_pkg(
                 ui,
                 SUP_CMD,
@@ -60,18 +60,18 @@ mod inner {
             Ok(command) => PathBuf::from(command),
             Err(_) => {
                 init();
-                let cmd = exec::command_from_min_pkg(
+                exec::command_from_min_pkg(
                     ui,
                     LAUNCH_CMD,
                     &PackageIdent::from_str(LAUNCH_PKG_IDENT)?,
                     &default_cache_key_path(None),
                     0,
-                )?;
-                PathBuf::from(cmd)
+                )?
             }
         };
         if let Some(cmd) = find_command(&command) {
-            Ok(process::become_command(cmd, args)?)
+            process::become_command(cmd, args)?;
+            Ok(())
         } else {
             Err(Error::ExecCommandNotFound(command))
         }

--- a/components/hab/src/command/origin/key/download.rs
+++ b/components/hab/src/command/origin/key/download.rs
@@ -69,7 +69,7 @@ fn handle_public(
         None => {
             ui.begin(format!("Downloading public origin keys for {}", origin))?;
             match api_client.show_origin_keys(origin) {
-                Ok(ref keys) if keys.len() == 0 => {
+                Ok(ref keys) if keys.is_empty() => {
                     ui.end(format!("No public keys for {}.", origin))?;
                     Ok(())
                 }
@@ -98,9 +98,7 @@ fn handle_secret(
     cache: &Path,
 ) -> Result<()> {
     if token.is_none() {
-        ui.end(format!(
-            "No auth token found. You must pass a token to download secret keys."
-        ))?;
+        ui.end("No auth token found. You must pass a token to download secret keys.")?;
         return Ok(());
     }
 
@@ -121,9 +119,7 @@ fn handle_encryption(
     cache: &Path,
 ) -> Result<()> {
     if token.is_none() {
-        ui.end(format!(
-            "No auth token found. You must pass a token to download secret keys."
-        ))?;
+        ui.end("No auth token found. You must pass a token to download secret keys.")?;
         return Ok(());
     }
 

--- a/components/hab/src/command/origin/key/generate.rs
+++ b/components/hab/src/command/origin/key/generate.rs
@@ -22,17 +22,16 @@ use crate::hcore::Error::InvalidOrigin;
 use crate::error::{Error, Result};
 
 pub fn start(ui: &mut UI, origin: &str, cache: &Path) -> Result<()> {
-    match ident::is_valid_origin_name(origin) {
-        false => Err(Error::from(InvalidOrigin(origin.to_string()))),
-        true => {
-            ui.begin(format!("Generating origin key for {}", &origin))?;
-            let pair = SigKeyPair::generate_pair_for_origin(origin)?;
-            pair.to_pair_files(cache)?;
-            ui.end(format!(
-                "Generated origin key pair {}.",
-                &pair.name_with_rev()
-            ))?;
-            Ok(())
-        }
+    if ident::is_valid_origin_name(origin) {
+        ui.begin(format!("Generating origin key for {}", &origin))?;
+        let pair = SigKeyPair::generate_pair_for_origin(origin)?;
+        pair.to_pair_files(cache)?;
+        ui.end(format!(
+            "Generated origin key pair {}.",
+            &pair.name_with_rev()
+        ))?;
+        Ok(())
+    } else {
+        Err(Error::from(InvalidOrigin(origin.to_string())))
     }
 }

--- a/components/hab/src/command/origin/key/mod.rs
+++ b/components/hab/src/command/origin/key/mod.rs
@@ -31,20 +31,19 @@ fn get_name_with_rev(keyfile: &Path, expected_vsn: &str) -> Result<String> {
     let f = File::open(&keyfile)?;
     let f = BufReader::new(f);
     let mut lines = f.lines();
-    let _ = match lines.next() {
+    match lines.next() {
         Some(val) => {
             let val = val?;
-            if &val != expected_vsn {
+            if val != expected_vsn {
                 let msg = format!("Unsupported version: {}", &val);
                 return Err(Error::HabitatCore(hcore::Error::CryptoError(msg)));
             }
-            ()
         }
         None => {
             let msg = "Corrupt key file, can't read file version".to_string();
             return Err(Error::HabitatCore(hcore::Error::CryptoError(msg)));
         }
-    };
+    }
     let name_with_rev = match lines.next() {
         Some(val) => val?,
         None => {

--- a/components/hab/src/command/origin/key/upload.rs
+++ b/components/hab/src/command/origin/key/upload.rs
@@ -103,9 +103,7 @@ pub fn start(
                     ))?;
                     Ok(())
                 }
-                Err(e) => {
-                    return Err(Error::APIClient(e));
-                }
+                Err(e) => Err(Error::APIClient(e)),
             }
         };
 

--- a/components/hab/src/command/pkg/exec.rs
+++ b/components/hab/src/command/pkg/exec.rs
@@ -44,5 +44,6 @@ where
         display_args.push_str(arg.to_string_lossy().as_ref());
     }
     debug!("Running: {}", display_args);
-    Ok(process::become_command(command, args)?)
+    process::become_command(command, args)?;
+    Ok(())
 }

--- a/components/hab/src/command/pkg/export/cf.rs
+++ b/components/hab/src/command/pkg/export/cf.rs
@@ -18,10 +18,10 @@ use crate::common::ui::UI;
 
 use crate::error::Result;
 
-const EXPORT_CMD: &'static str = "hab-pkg-cfize";
-const EXPORT_CMD_ENVVAR: &'static str = "HAB_PKG_CFIZE_BINARY";
-const EXPORT_PKG_IDENT: &'static str = "core/hab-pkg-cfize";
-const EXPORT_PKG_IDENT_ENVVAR: &'static str = "HAB_PKG_CFIZE_PKG_IDENT";
+const EXPORT_CMD: &str = "hab-pkg-cfize";
+const EXPORT_CMD_ENVVAR: &str = "HAB_PKG_CFIZE_BINARY";
+const EXPORT_PKG_IDENT: &str = "core/hab-pkg-cfize";
+const EXPORT_PKG_IDENT_ENVVAR: &str = "HAB_PKG_CFIZE_PKG_IDENT";
 
 pub fn start(ui: &mut UI, args: Vec<OsString>) -> Result<()> {
     crate::command::pkg::export::export_common::start(

--- a/components/hab/src/command/pkg/export/docker.rs
+++ b/components/hab/src/command/pkg/export/docker.rs
@@ -18,10 +18,10 @@ use crate::common::ui::UI;
 
 use crate::error::Result;
 
-const EXPORT_CMD: &'static str = "hab-pkg-export-docker";
-const EXPORT_CMD_ENVVAR: &'static str = "HAB_PKG_EXPORT_DOCKER_BINARY";
-const EXPORT_PKG_IDENT: &'static str = "core/hab-pkg-export-docker";
-const EXPORT_PKG_IDENT_ENVVAR: &'static str = "HAB_PKG_EXPORT_DOCKER_PKG_IDENT";
+const EXPORT_CMD: &str = "hab-pkg-export-docker";
+const EXPORT_CMD_ENVVAR: &str = "HAB_PKG_EXPORT_DOCKER_BINARY";
+const EXPORT_PKG_IDENT: &str = "core/hab-pkg-export-docker";
+const EXPORT_PKG_IDENT_ENVVAR: &str = "HAB_PKG_EXPORT_DOCKER_PKG_IDENT";
 
 pub fn start(ui: &mut UI, args: Vec<OsString>) -> Result<()> {
     crate::command::pkg::export::export_common::start(

--- a/components/hab/src/command/pkg/export/export_common.rs
+++ b/components/hab/src/command/pkg/export/export_common.rs
@@ -68,22 +68,22 @@ mod inner {
                 let ident = match henv::var(export_pkg_ident_envvar) {
                     Ok(ref ident_str) => PackageIdent::from_str(ident_str)?,
                     Err(_) => {
-                        let version: Vec<&str> = VERSION.split("/").collect();
+                        let version: Vec<&str> = VERSION.split('/').collect();
                         PackageIdent::from_str(&format!("{}/{}", export_pkg_ident, version[0]))?
                     }
                 };
-                let cmd = exec::command_from_min_pkg(
+                exec::command_from_min_pkg(
                     ui,
                     export_cmd,
                     &ident,
                     &default_cache_key_path(None),
                     0,
-                )?;
-                PathBuf::from(cmd)
+                )?
             }
         };
         if let Some(cmd) = find_command(&command) {
-            Ok(process::become_command(cmd, args)?)
+            process::become_command(cmd, args)?;
+            Ok(())
         } else {
             Err(Error::ExecCommandNotFound(command))
         }

--- a/components/hab/src/command/pkg/export/helm.rs
+++ b/components/hab/src/command/pkg/export/helm.rs
@@ -18,10 +18,10 @@ use crate::common::ui::UI;
 
 use crate::error::Result;
 
-const EXPORT_CMD: &'static str = "hab-pkg-export-helm";
-const EXPORT_CMD_ENVVAR: &'static str = "HAB_PKG_EXPORT_HELM_BINARY";
-const EXPORT_PKG_IDENT: &'static str = "core/hab-pkg-export-helm";
-const EXPORT_PKG_IDENT_ENVVAR: &'static str = "HAB_PKG_EXPORT_HELM_PKG_IDENT";
+const EXPORT_CMD: &str = "hab-pkg-export-helm";
+const EXPORT_CMD_ENVVAR: &str = "HAB_PKG_EXPORT_HELM_BINARY";
+const EXPORT_PKG_IDENT: &str = "core/hab-pkg-export-helm";
+const EXPORT_PKG_IDENT_ENVVAR: &str = "HAB_PKG_EXPORT_HELM_PKG_IDENT";
 
 pub fn start(ui: &mut UI, args: Vec<OsString>) -> Result<()> {
     crate::command::pkg::export::export_common::start(

--- a/components/hab/src/command/pkg/export/kubernetes.rs
+++ b/components/hab/src/command/pkg/export/kubernetes.rs
@@ -18,10 +18,10 @@ use crate::common::ui::UI;
 
 use crate::error::Result;
 
-const EXPORT_CMD: &'static str = "hab-pkg-export-kubernetes";
-const EXPORT_CMD_ENVVAR: &'static str = "HAB_PKG_EXPORT_KUBERNETES_BINARY";
-const EXPORT_PKG_IDENT: &'static str = "core/hab-pkg-export-kubernetes";
-const EXPORT_PKG_IDENT_ENVVAR: &'static str = "HAB_PKG_EXPORT_KUBERNETES_PKG_IDENT";
+const EXPORT_CMD: &str = "hab-pkg-export-kubernetes";
+const EXPORT_CMD_ENVVAR: &str = "HAB_PKG_EXPORT_KUBERNETES_BINARY";
+const EXPORT_PKG_IDENT: &str = "core/hab-pkg-export-kubernetes";
+const EXPORT_PKG_IDENT_ENVVAR: &str = "HAB_PKG_EXPORT_KUBERNETES_PKG_IDENT";
 
 pub fn start(ui: &mut UI, args: Vec<OsString>) -> Result<()> {
     crate::command::pkg::export::export_common::start(

--- a/components/hab/src/command/pkg/export/mod.rs
+++ b/components/hab/src/command/pkg/export/mod.rs
@@ -76,7 +76,7 @@ mod inner {
     use crate::VERSION;
 
     pub fn format_for(_ui: &mut UI, value: &str) -> Result<ExportFormat> {
-        let version: Vec<_> = VERSION.split("/").collect();
+        let version: Vec<_> = VERSION.split('/').collect();
         match value {
             "aci" => {
                 let format = ExportFormat {

--- a/components/hab/src/command/pkg/export/tar.rs
+++ b/components/hab/src/command/pkg/export/tar.rs
@@ -18,7 +18,7 @@ use crate::common::ui::UI;
 
 use crate::error::Result;
 
-const EXPORT_CMD: &'static str = "hab-pkg-export-tar";
+const EXPORT_CMD: &str = "hab-pkg-export-tar";
 
 pub fn start(ui: &mut UI, args: Vec<OsString>) -> Result<()> {
     inner::start(ui, args)
@@ -42,9 +42,9 @@ mod inner {
     use crate::exec;
     use crate::VERSION;
 
-    const EXPORT_CMD_ENVVAR: &'static str = "HAB_PKG_EXPORT_TAR_BINARY";
-    const EXPORT_PKG_IDENT: &'static str = "core/hab-pkg-export-tar";
-    const EXPORT_PKG_IDENT_ENVVAR: &'static str = "HAB_PKG_EXPORT_TAR_PKG_IDENT";
+    const EXPORT_CMD_ENVVAR: &str = "HAB_PKG_EXPORT_TAR_BINARY";
+    const EXPORT_PKG_IDENT: &str = "core/hab-pkg-export-tar";
+    const EXPORT_PKG_IDENT_ENVVAR: &str = "HAB_PKG_EXPORT_TAR_PKG_IDENT";
 
     pub fn start(ui: &mut UI, args: Vec<OsString>) -> Result<()> {
         let command = match henv::var(EXPORT_CMD_ENVVAR) {
@@ -54,22 +54,22 @@ mod inner {
                 let ident = match henv::var(EXPORT_PKG_IDENT_ENVVAR) {
                     Ok(ref ident_str) => PackageIdent::from_str(ident_str)?,
                     Err(_) => {
-                        let version: Vec<&str> = VERSION.split("/").collect();
+                        let version: Vec<&str> = VERSION.split('/').collect();
                         PackageIdent::from_str(&format!("{}/{}", EXPORT_PKG_IDENT, version[0]))?
                     }
                 };
-                let cmd = exec::command_from_min_pkg(
+                exec::command_from_min_pkg(
                     ui,
                     EXPORT_CMD,
                     &ident,
                     &default_cache_key_path(None),
                     0,
-                )?;
-                PathBuf::from(cmd)
+                )?
             }
         };
         if let Some(cmd) = find_command(&command) {
-            Ok(process::become_command(cmd, args)?)
+            process::become_command(cmd, args)?;
+            Ok(())
         } else {
             Err(Error::ExecCommandNotFound(command))
         }

--- a/components/hab/src/command/pkg/provides.rs
+++ b/components/hab/src/command/pkg/provides.rs
@@ -45,7 +45,7 @@ pub fn start(
                 // skip prefix_count segments of the path
                 let _ = comps
                     .nth(prefix_count)
-                    .ok_or(Error::FileNotFound(f.to_string()))?;
+                    .ok_or_else(|| Error::FileNotFound(f.to_string()))?;
 
                 let segments = if full_releases {
                     // take all 4 segments of the path

--- a/components/hab/src/command/pkg/uninstall.rs
+++ b/components/hab/src/command/pkg/uninstall.rs
@@ -128,7 +128,7 @@ pub fn start(
                         )?;
 
                         graph.remove(&p);
-                        count = count + 1;
+                        count += 1;
                     }
                     Some(c) => {
                         ui.status(
@@ -169,8 +169,8 @@ fn maybe_delete(
     fs_root_path: &Path,
     install: &PackageInstall,
     strategy: &ExecutionStrategy,
-    excludes: &Vec<PackageIdent>,
-    services: &Vec<PackageIdent>,
+    excludes: &[PackageIdent],
+    services: &[PackageIdent],
 ) -> Result<bool> {
     let ident = install.ident();
     let pkg_root_path = hfs::pkg_root_path(Some(fs_root_path));
@@ -237,7 +237,7 @@ fn do_clean_delete(pkg_root_path: &Path, real_install_path: &Path) -> Result<boo
                 match p.read_dir() {
                     Ok(contents) => {
                         // This will calculate the amount of items in the directory
-                        match contents.collect::<Vec<_>>().len() {
+                        match contents.count() {
                             0 => fs::remove_dir(&p)?,
                             _ => break,
                         }

--- a/components/hab/src/command/sup.rs
+++ b/components/hab/src/command/sup.rs
@@ -18,9 +18,9 @@ use crate::common::ui::UI;
 
 use crate::error::Result;
 
-pub const SUP_CMD: &'static str = "hab-sup";
-pub const SUP_CMD_ENVVAR: &'static str = "HAB_SUP_BINARY";
-pub const SUP_PKG_IDENT: &'static str = "core/hab-sup";
+pub const SUP_CMD: &str = "hab-sup";
+pub const SUP_CMD_ENVVAR: &str = "HAB_SUP_BINARY";
+pub const SUP_PKG_IDENT: &str = "core/hab-sup";
 
 pub fn start(ui: &mut UI, args: Vec<OsString>) -> Result<()> {
     inner::start(ui, args)
@@ -49,19 +49,19 @@ mod inner {
             Ok(command) => PathBuf::from(command),
             Err(_) => {
                 init();
-                let version: Vec<&str> = VERSION.split("/").collect();
-                let cmd = exec::command_from_min_pkg(
+                let version: Vec<&str> = VERSION.split('/').collect();
+                exec::command_from_min_pkg(
                     ui,
                     SUP_CMD,
                     &PackageIdent::from_str(&format!("{}/{}", SUP_PKG_IDENT, version[0]))?,
                     &default_cache_key_path(None),
                     0,
-                )?;
-                PathBuf::from(cmd)
+                )?
             }
         };
         if let Some(cmd) = find_command(&command) {
-            Ok(process::become_command(cmd, args)?)
+            process::become_command(cmd, args)?;
+            Ok(())
         } else {
             Err(Error::ExecCommandNotFound(command))
         }

--- a/components/hab/src/command/supportbundle.rs
+++ b/components/hab/src/command/supportbundle.rs
@@ -70,16 +70,13 @@ pub fn start(ui: &mut UI) -> Result<()> {
             Status::Adding,
             format!("files from {}", &sup_root.display()),
         )?;
-        match tar.append_dir_all(format!("hab{}sup", MAIN_SEPARATOR), &sup_root) {
-            Err(why) => {
-                ui.fatal(format!(
-                    "Failed to add all files into the tarball: {:?}",
-                    why.description()
-                ))?;
-                fs::remove_file(&tarball_name)?;
-                process::exit(1)
-            }
-            Ok(_) => {}
+        if let Err(why) = tar.append_dir_all(format!("hab{}sup", MAIN_SEPARATOR), &sup_root) {
+            ui.fatal(format!(
+                "Failed to add all files into the tarball: {:?}",
+                why.description()
+            ))?;
+            fs::remove_file(&tarball_name)?;
+            process::exit(1);
         }
     } else {
         ui.fatal(format!(

--- a/components/hab/src/config.rs
+++ b/components/hab/src/config.rs
@@ -24,7 +24,7 @@ use toml;
 
 use crate::error::{Error, Result};
 
-const CLI_CONFIG_PATH: &'static str = "hab/etc/cli.toml";
+const CLI_CONFIG_PATH: &str = "hab/etc/cli.toml";
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct Config {

--- a/components/hab/src/error.rs
+++ b/components/hab/src/error.rs
@@ -55,7 +55,8 @@ pub enum Error {
     FileNotFound(String),
     HabitatCommon(common::Error),
     HabitatCore(hcore::Error),
-    HandlebarsRenderError(handlebars::TemplateRenderError),
+    // Boxed because https://rust-lang-nursery.github.io/rust-clippy/master/index.html#large_enum_variant
+    HandlebarsRenderError(Box<handlebars::TemplateRenderError>),
     IO(io::Error),
     JobGroupPromoteOrDemote(api_client::Error, bool /* promote */),
     JobGroupCancel(api_client::Error),
@@ -79,9 +80,9 @@ pub enum Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let msg = match *self {
-            Error::APIClient(ref err) => format!("{}", err),
-            Error::ArgumentError(ref e) => format!("{}", e),
-            Error::ButterflyError(ref e) => format!("{}", e),
+            Error::APIClient(ref e) => e.to_string(),
+            Error::ArgumentError(ref e) => e.to_string(),
+            Error::ButterflyError(ref e) => e.to_string(),
             Error::CannotParseBinlinkBinaryName(ref p) => {
                 format!("Cannot parse binlink binary name from {}.", p.display())
             }
@@ -89,7 +90,7 @@ impl fmt::Display for Error {
                 format!("Cannot parse binlink source path from {}.", p.display())
             }
             Error::CannotRemoveDockerStudio => {
-                format!("Docker Studios are not persistent and cannot be removed")
+                "Docker Studios are not persistent and cannot be removed".to_string()
             }
             Error::CannotRemoveFromChannel((ref p, ref c)) => {
                 format!("{} cannot be removed from the {} channel.", p, c)
@@ -102,22 +103,24 @@ impl fmt::Display for Error {
                 "`{}' was not found under any 'PATH' directories in the {} package",
                 c, p
             ),
-            Error::CryptoCLI(ref e) => format!("{}", e),
-            Error::CtlClient(ref e) => format!("{}", e),
+            Error::CryptoCLI(ref e) => e.to_string(),
+            Error::CtlClient(ref e) => e.to_string(),
             Error::DockerDaemonDown => {
-                format!("Can not connect to Docker. Is the Docker daemon running?")
+                "Can not connect to Docker. Is the Docker daemon running?".to_string()
             }
             #[cfg(not(windows))]
-            Error::DockerFileSharingNotEnabled => format!(
+            Error::DockerFileSharingNotEnabled => {
                 "File Sharing must be enabled in order to enter a studio.\nPlease enable \
                  it in the Docker preferences and share (at a minimum) your home \
                  directory."
-            ),
+                    .to_string()
+            }
             #[cfg(windows)]
-            Error::DockerFileSharingNotEnabled => format!(
+            Error::DockerFileSharingNotEnabled => {
                 "File Sharing must be enabled in order to enter a studio.\nPlease select \
                  a drive to share in the Docker preferences."
-            ),
+                    .to_string()
+            }
             Error::DockerImageNotFound(ref e) => format!(
                 "The Docker image {} was not found in the docker registry.\nYou can \
                  specify your own Docker image using the HAB_DOCKER_STUDIO_IMAGE \
@@ -136,11 +139,11 @@ impl fmt::Display for Error {
                 "`{}' was not found on the filesystem or in PATH",
                 c.display()
             ),
-            Error::FFINulError(ref e) => format!("{}", e),
+            Error::FFINulError(ref e) => e.to_string(),
             Error::FileNotFound(ref e) => format!("File not found at: {}", e),
-            Error::HabitatCommon(ref e) => format!("{}", e),
-            Error::HabitatCore(ref e) => format!("{}", e),
-            Error::HandlebarsRenderError(ref e) => format!("{}", e),
+            Error::HabitatCommon(ref e) => e.to_string(),
+            Error::HabitatCore(ref e) => e.to_string(),
+            Error::HandlebarsRenderError(ref e) => e.to_string(),
             Error::IO(ref err) => format!("{}", err),
             Error::JobGroupPromoteOrDemoteUnprocessable(true) => {
                 "Failed to promote job group, the build job is still in progress".to_string()
@@ -154,8 +157,8 @@ impl fmt::Display for Error {
                 e
             ),
             Error::JobGroupCancel(ref e) => format!("Failed to cancel job group: {:?}", e),
-            Error::NameLookup => format!("Error resolving a name or IP address"),
-            Error::NetErr(ref e) => format!("{}", e),
+            Error::NameLookup => "Error resolving a name or IP address".to_string(),
+            Error::NetErr(ref e) => e.to_string(),
             Error::PackageArchiveMalformed(ref e) => format!(
                 "Package archive was unreadable or contained unexpected contents: {:?}",
                 e
@@ -275,7 +278,7 @@ impl From<hcore::Error> for Error {
 
 impl From<handlebars::TemplateRenderError> for Error {
     fn from(err: handlebars::TemplateRenderError) -> Error {
-        Error::HandlebarsRenderError(err)
+        Error::HandlebarsRenderError(Box::new(err))
     }
 }
 

--- a/components/hab/src/exec.rs
+++ b/components/hab/src/exec.rs
@@ -27,7 +27,7 @@ use crate::error::{Error, Result};
 use crate::{PRODUCT, VERSION};
 
 const MAX_RETRIES: u8 = 4;
-const INTERNAL_TOOLING_CHANNEL_ENVVAR: &'static str = "HAB_INTERNAL_BLDR_CHANNEL";
+const INTERNAL_TOOLING_CHANNEL_ENVVAR: &str = "HAB_INTERNAL_BLDR_CHANNEL";
 
 /// Returns the absolute path to the given command from a package no
 /// older than the given package identifier.

--- a/components/hab/src/lib.rs
+++ b/components/hab/src/lib.rs
@@ -51,18 +51,18 @@ pub mod error;
 mod exec;
 pub mod scaffolding;
 
-pub const PRODUCT: &'static str = "hab";
-pub const VERSION: &'static str = include_str!(concat!(env!("OUT_DIR"), "/VERSION"));
-pub const CTL_SECRET_ENVVAR: &'static str = "HAB_CTL_SECRET";
-pub const ORIGIN_ENVVAR: &'static str = "HAB_ORIGIN";
-pub const BLDR_URL_ENVVAR: &'static str = "HAB_BLDR_URL";
+pub const PRODUCT: &str = "hab";
+pub const VERSION: &str = include_str!(concat!(env!("OUT_DIR"), "/VERSION"));
+pub const CTL_SECRET_ENVVAR: &str = "HAB_CTL_SECRET";
+pub const ORIGIN_ENVVAR: &str = "HAB_ORIGIN";
+pub const BLDR_URL_ENVVAR: &str = "HAB_BLDR_URL";
 
 pub use crate::hcore::AUTH_TOKEN_ENVVAR;
 
 features! {
     pub mod feat {
-        const List = 0b00000001,
-        const OfflineInstall = 0b00000010,
-        const IgnoreLocal = 0b00000100
+        const List           = 0b0000_0001,
+        const OfflineInstall = 0b0000_0010,
+        const IgnoreLocal    = 0b0000_0100
     }
 }

--- a/components/hab/src/scaffolding.rs
+++ b/components/hab/src/scaffolding.rs
@@ -22,10 +22,10 @@ use crate::common::ui::{Status, UIWriter, UI};
 use crate::hcore::crypto::init;
 use crate::hcore::package::PackageIdent;
 
-const SCAFFOLDING_GO_IDENT: &'static str = "core/scaffolding-go";
-const SCAFFOLDING_GRADLE_IDENT: &'static str = "core/scaffolding-gradle";
-const SCAFFOLDING_NODE_IDENT: &'static str = "core/scaffolding-node";
-const SCAFFOLDING_RUBY_IDENT: &'static str = "core/scaffolding-ruby";
+const SCAFFOLDING_GO_IDENT: &str = "core/scaffolding-go";
+const SCAFFOLDING_GRADLE_IDENT: &str = "core/scaffolding-gradle";
+const SCAFFOLDING_NODE_IDENT: &str = "core/scaffolding-node";
+const SCAFFOLDING_RUBY_IDENT: &str = "core/scaffolding-ruby";
 
 // Check to see if the --scaffolding passed matches available core scaffolding
 // If not check if we've been given a pkg ident for a custom scaffolding
@@ -120,47 +120,32 @@ fn is_project_go<T>(path: T) -> bool
 where
     T: AsRef<Path>,
 {
-    if path.as_ref().join("main.go").is_file()
+    path.as_ref().join("main.go").is_file()
         || path.as_ref().join("Godeps/Godeps.json").is_file()
         || path.as_ref().join("vendor/vendor.json").is_file()
         || path.as_ref().join("glide.yaml").is_file()
         || project_uses_gb(path.as_ref()).unwrap_or(false)
-    {
-        return true;
-    }
-    return false;
 }
 
 fn is_project_gradle<T>(path: T) -> bool
 where
     T: AsRef<Path>,
 {
-    if path.as_ref().join("build.gradle").is_file()
-        || path.as_ref().join("settings.gradle").is_file()
-    {
-        return true;
-    }
-    return false;
+    path.as_ref().join("build.gradle").is_file() || path.as_ref().join("settings.gradle").is_file()
 }
 
 fn is_project_node<T>(path: T) -> bool
 where
     T: AsRef<Path>,
 {
-    if path.as_ref().join("package.json").is_file() {
-        return true;
-    }
-    return false;
+    path.as_ref().join("package.json").is_file()
 }
 
 fn is_project_ruby<T>(path: T) -> bool
 where
     T: AsRef<Path>,
 {
-    if path.as_ref().join("Gemfile").is_file() {
-        return true;
-    }
-    return false;
+    path.as_ref().join("Gemfile").is_file()
 }
 
 fn project_uses_gb(dir: &Path) -> io::Result<bool> {
@@ -181,5 +166,5 @@ fn project_uses_gb(dir: &Path) -> io::Result<bool> {
             }
         }
     }
-    return Ok(false);
+    Ok(false)
 }

--- a/components/launcher-client/src/error.rs
+++ b/components/launcher-client/src/error.rs
@@ -39,7 +39,7 @@ pub type Result<T> = result::Result<T, Error>;
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let msg = match *self {
-            Error::AcceptConn => format!("Unable to accept connection from Launcher"),
+            Error::AcceptConn => "Unable to accept connection from Launcher".to_string(),
             Error::BadPipe(ref e) => format!("Unable to open pipe to Launcher, {}", e),
             Error::Connect(ref e) => format!("Unable to connect to Launcher's pipe, {}", e),
             Error::Deserialize(ref e) => {

--- a/components/launcher-protocol/src/lib.rs
+++ b/components/launcher-protocol/src/lib.rs
@@ -23,11 +23,11 @@ pub use crate::message::launcher::*;
 use crate::message::net::*;
 pub use crate::message::supervisor::*;
 
-pub const LAUNCHER_PIPE_ENV: &'static str = "HAB_LAUNCHER_PIPE";
-pub const LAUNCHER_PID_ENV: &'static str = "HAB_LAUNCHER_PID";
+pub const LAUNCHER_PIPE_ENV: &str = "HAB_LAUNCHER_PIPE";
+pub const LAUNCHER_PID_ENV: &str = "HAB_LAUNCHER_PID";
 // Set to instruct the Supervisor to clean the Launcher's process LOCK on startup. This is useful
 // when restarting a Supervisor which terminated normally.
-pub const LAUNCHER_LOCK_CLEAN_ENV: &'static str = "HAB_LAUNCHER_LOCK_CLEAN";
+pub const LAUNCHER_LOCK_CLEAN_ENV: &str = "HAB_LAUNCHER_LOCK_CLEAN";
 /// Process exit code from Supervisor which indicates to Launcher that the Supervisor
 /// ran to completion with a successful result. The Launcher should not attempt to restart
 /// the Supervisor and should exit immediately with a successful exit code.

--- a/components/launcher/src/lib.rs
+++ b/components/launcher/src/lib.rs
@@ -26,5 +26,5 @@ pub mod server;
 pub mod service;
 mod sys;
 
-pub const SUP_CMD: &'static str = "hab-sup";
-pub const SUP_PACKAGE_IDENT: &'static str = "core/hab-sup";
+pub const SUP_CMD: &str = "hab-sup";
+pub const SUP_PACKAGE_IDENT: &str = "core/hab-sup";

--- a/components/launcher/src/server/mod.rs
+++ b/components/launcher/src/server/mod.rs
@@ -46,16 +46,16 @@ use crate::error::{Error, Result};
 use crate::service::Service;
 use crate::{SUP_CMD, SUP_PACKAGE_IDENT};
 
-const IPC_CONNECT_TIMEOUT_SECS: &'static str = "HAB_LAUNCH_SUP_CONNECT_TIMEOUT_SECS";
+const IPC_CONNECT_TIMEOUT_SECS: &str = "HAB_LAUNCH_SUP_CONNECT_TIMEOUT_SECS";
 const DEFAULT_IPC_CONNECT_TIMEOUT_SECS: u64 = 5;
-const SUP_CMD_ENVVAR: &'static str = "HAB_SUP_BINARY";
+const SUP_CMD_ENVVAR: &str = "HAB_SUP_BINARY";
 static LOGKEY: &'static str = "SV";
 
-const SUP_VERSION_CHECK_DISABLE: &'static str = "HAB_LAUNCH_NO_SUP_VERSION_CHECK";
+const SUP_VERSION_CHECK_DISABLE: &str = "HAB_LAUNCH_NO_SUP_VERSION_CHECK";
 // Version 0.56 is somewhat arbitrary. This functionality is for when we make
 // changes to the launcher that depend on supervisor behavior that hasn't
 // always existed such as https://github.com/habitat-sh/habitat/issues/5380
-const SUP_VERSION_REQ: &'static str = ">= 0.56";
+const SUP_VERSION_REQ: &str = ">= 0.56";
 
 type Receiver = IpcReceiver<Vec<u8>>;
 type Sender = IpcSender<Vec<u8>>;

--- a/components/libbuild.rs
+++ b/components/libbuild.rs
@@ -1,5 +1,5 @@
 #[allow(dead_code)]
-const VERSION_ENVVAR: &'static str = "PLAN_VERSION";
+const VERSION_ENVVAR: &str = "PLAN_VERSION";
 
 #[allow(dead_code)]
 mod builder {
@@ -81,7 +81,8 @@ mod util {
         let mut f = File::create(
             Path::new(&env::var("OUT_DIR").expect("Failed to read OUT_DIR environment variable"))
                 .join(filename),
-        ).expect("Failed to create OUT_DIR file");
+        )
+        .expect("Failed to create OUT_DIR file");
         f.write_all(content.as_ref().trim().as_bytes())
             .expect("Failed to write to OUT_DIR file");
     }

--- a/components/pkg-export-docker/src/cli.rs
+++ b/components/pkg-export-docker/src/cli.rs
@@ -23,7 +23,7 @@ use url::Url;
 use crate::RegistryType;
 
 /// The version of this library and program when built.
-pub const VERSION: &'static str = include_str!(concat!(env!("OUT_DIR"), "/VERSION"));
+pub const VERSION: &str = include_str!(concat!(env!("OUT_DIR"), "/VERSION"));
 
 /// A Docker-specific clap:App wrapper
 #[derive(Clone)]

--- a/components/pkg-export-docker/src/docker.rs
+++ b/components/pkg-export-docker/src/docker.rs
@@ -31,11 +31,11 @@ use serde_json;
 
 /// The `Dockerfile` template.
 #[cfg(unix)]
-const DOCKERFILE: &'static str = include_str!("../defaults/Dockerfile.hbs");
+const DOCKERFILE: &str = include_str!("../defaults/Dockerfile.hbs");
 #[cfg(windows)]
-const DOCKERFILE: &'static str = include_str!("../defaults/Dockerfile_win.hbs");
+const DOCKERFILE: &str = include_str!("../defaults/Dockerfile_win.hbs");
 /// The build report template.
-const BUILD_REPORT: &'static str = include_str!("../defaults/last_docker_export.env.hbs");
+const BUILD_REPORT: &str = include_str!("../defaults/last_docker_export.env.hbs");
 
 lazy_static! {
     /// Absolute path to the Docker program
@@ -402,7 +402,7 @@ impl DockerBuildRoot {
                     Status::Creating,
                     format!("user '{}' in /{}", user.name, &file),
                 )?;
-                write!(f, "{}\n", user)?;
+                writeln!(f, "{}", user)?;
             }
         }
         {
@@ -415,7 +415,7 @@ impl DockerBuildRoot {
                     Status::Creating,
                     format!("group '{}' in /{}", group.name, &file),
                 )?;
-                write!(f, "{}\n", group)?;
+                writeln!(f, "{}", group)?;
             }
         }
         Ok(())
@@ -426,7 +426,7 @@ impl DockerBuildRoot {
         use crate::hcore::util::posix_perm;
 
         /// The entrypoint script template.
-        const INIT_SH: &'static str = include_str!("../defaults/init.sh.hbs");
+        const INIT_SH: &str = include_str!("../defaults/init.sh.hbs");
 
         ui.status(Status::Creating, "entrypoint script")?;
         let ctx = self.0.ctx();

--- a/components/pkg-export-docker/src/lib.rs
+++ b/components/pkg-export-docker/src/lib.rs
@@ -63,12 +63,12 @@ pub use crate::docker::{DockerBuildRoot, DockerImage};
 pub use crate::error::{Error, Result};
 
 /// The version of this library and program when built.
-pub const VERSION: &'static str = include_str!(concat!(env!("OUT_DIR"), "/VERSION"));
+pub const VERSION: &str = include_str!(concat!(env!("OUT_DIR"), "/VERSION"));
 
 /// The Habitat Package Identifier string for a Busybox package.
-const BUSYBOX_IDENT: &'static str = "core/busybox-static";
+const BUSYBOX_IDENT: &str = "core/busybox-static";
 /// The Habitat Package Identifier string for SSL certificate authorities (CA) certificates package.
-const CACERTS_IDENT: &'static str = "core/cacerts";
+const CACERTS_IDENT: &str = "core/cacerts";
 
 /// An image naming policy.
 ///
@@ -171,7 +171,7 @@ impl Credentials {
                 let token = client
                     .get_authorization_token(auth_token_req)
                     .sync()
-                    .map_err(|e| Error::TokenFetchFailed(e))
+                    .map_err(Error::TokenFetchFailed)
                     .and_then(|resp| {
                         resp.authorization_data
                             .ok_or(Error::NoECRTokensReturned)

--- a/components/pkg-export-docker/src/rootfs.rs
+++ b/components/pkg-export-docker/src/rootfs.rs
@@ -21,13 +21,13 @@ use crate::error::Result;
 use crate::util::write_file;
 
 /// The default password file contents.
-const ETC_PASSWD: &'static str = include_str!("../defaults/etc/passwd");
+const ETC_PASSWD: &str = include_str!("../defaults/etc/passwd");
 /// The default group file contents.
-const ETC_GROUP: &'static str = include_str!("../defaults/etc/group");
+const ETC_GROUP: &str = include_str!("../defaults/etc/group");
 /// The default `resolv.conf` contents.
-const ETC_RESOLV_CONF: &'static str = include_str!("../defaults/etc/resolv.conf");
+const ETC_RESOLV_CONF: &str = include_str!("../defaults/etc/resolv.conf");
 /// The default `nsswitch.conf` contents.
-const ETC_NSSWITCH_CONF: &'static str = include_str!("../defaults/etc/nsswitch.conf");
+const ETC_NSSWITCH_CONF: &str = include_str!("../defaults/etc/nsswitch.conf");
 
 /// Creates a root file system under the given path.
 ///

--- a/components/pkg-export-docker/src/util.rs
+++ b/components/pkg-export-docker/src/util.rs
@@ -20,7 +20,7 @@ use crate::hcore::package::{PackageIdent, PackageInstall};
 
 use crate::error::Result;
 
-const BIN_PATH: &'static str = "/bin";
+const BIN_PATH: &str = "/bin";
 
 /// Returns the `bin` path used for symlinking programs.
 pub fn bin_path() -> &'static Path {

--- a/components/pkg-export-helm/src/chartfile.rs
+++ b/components/pkg-export-helm/src/chartfile.rs
@@ -22,10 +22,10 @@ use crate::hcore::package::PackageIdent;
 
 use crate::maintainer::Maintainer;
 
-pub const DEFAULT_VERSION: &'static str = "0.0.1";
+pub const DEFAULT_VERSION: &str = "0.0.1";
 
 // Helm chart file template
-const CHARTFILE: &'static str = include_str!("../defaults/HelmChartFile.hbs");
+const CHARTFILE: &str = include_str!("../defaults/HelmChartFile.hbs");
 
 pub struct ChartFile {
     pub name: String,

--- a/components/pkg-export-helm/src/deps.rs
+++ b/components/pkg-export-helm/src/deps.rs
@@ -23,12 +23,12 @@ use crate::common::ui::{Status, UIWriter, UI};
 use crate::error::Error;
 use crate::export_docker::Result;
 
-pub const DEFAULT_OPERATOR_VERSION: &'static str = "0.6.1";
-pub const OPERATOR_REPO_URL: &'static str = "https://habitat-sh.github.io/\
-                                             habitat-operator/helm/charts/stable/";
+pub const DEFAULT_OPERATOR_VERSION: &str = "0.6.1";
+pub const OPERATOR_REPO_URL: &str = "https://habitat-sh.github.io/\
+                                     habitat-operator/helm/charts/stable/";
 
 // Helm requirements.yaml template
-const DEPSFILE: &'static str = include_str!("../defaults/HelmDeps.hbs");
+const DEPSFILE: &str = include_str!("../defaults/HelmDeps.hbs");
 
 pub struct Deps {
     operator_version: String,

--- a/components/pkg-export-kubernetes/src/hb.rs
+++ b/components/pkg-export-kubernetes/src/hb.rs
@@ -17,7 +17,7 @@ use serde::Serialize;
 use std::result::Result;
 
 // Kubernetes manifest template
-const MANIFESTFILE: &'static str = include_str!("../defaults/KubernetesManifest.hbs");
+const MANIFESTFILE: &str = include_str!("../defaults/KubernetesManifest.hbs");
 
 #[derive(Clone, Copy)]
 pub struct QuoteHelper;

--- a/components/pkg-export-kubernetes/src/lib.rs
+++ b/components/pkg-export-kubernetes/src/lib.rs
@@ -52,7 +52,7 @@ pub use crate::manifestjson::ManifestJson;
 pub use crate::storage::PersistentStorage;
 
 // Synced with the version of the Habitat operator.
-pub const VERSION: &'static str = "0.1.0";
+pub const VERSION: &str = "0.1.0";
 
 /// Convenient do-it-all function. You give it the CLI arguments from the user and it generates the
 /// Kubernetes manifest. If user passed an `--output` argument with a value that is not "`-`", the

--- a/components/pkg-export-kubernetes/src/manifest.rs
+++ b/components/pkg-export-kubernetes/src/manifest.rs
@@ -74,7 +74,7 @@ impl Manifest {
             .value_of("TOPOLOGY")
             .unwrap_or("standalone")
             .parse()
-            .unwrap_or(Default::default());
+            .unwrap_or_default();
         let group = matches.value_of("GROUP").map(|s| s.to_string());
         let config_file = matches.value_of("CONFIG");
         let ring_secret_name = matches.value_of("RING_SECRET_NAME").map(|s| s.to_string());
@@ -95,7 +95,7 @@ impl Manifest {
                 .release
                 .as_ref()
                 .map(|r| format!("{}-{}", v, r))
-                .unwrap_or(v.to_string()),
+                .unwrap_or_else(|| v.to_string()),
             None => "latest".to_owned(),
         };
         let name = matches
@@ -134,7 +134,7 @@ impl Manifest {
                 let mut contents = String::new();
                 File::open(name)?.read_to_string(&mut contents)?;
 
-                Some(base64::encode(&format!("{}", contents)))
+                Some(base64::encode(&contents))
             }
         };
 
@@ -175,7 +175,7 @@ mod tests {
             count: 3,
             service_topology: Default::default(),
             service_group: Some("group1".to_owned()),
-            config: Some(base64::encode(&format!("{}", "port = 4444"))),
+            config: Some(base64::encode(&"port = 4444")),
             ring_secret_name: Some("deltaechofoxtrot".to_owned()),
             binds: vec![],
             persistent_storage: None,

--- a/components/pkg-export-tar/src/build.rs
+++ b/components/pkg-export-tar/src/build.rs
@@ -36,9 +36,9 @@ use crate::rootfs;
 // from the Docker exporter. This needs to be abstacted out in
 // the future for use with further exporters.
 // https://github.com/habitat-sh/habitat/issues/4522
-const DEFAULT_HAB_IDENT: &'static str = "core/hab";
-const DEFAULT_LAUNCHER_IDENT: &'static str = "core/hab-launcher";
-const DEFAULT_SUP_IDENT: &'static str = "core/hab-sup";
+const DEFAULT_HAB_IDENT: &str = "core/hab";
+const DEFAULT_LAUNCHER_IDENT: &str = "core/hab-launcher";
+const DEFAULT_SUP_IDENT: &str = "core/hab-sup";
 
 /// The specification for creating a temporary file system build root, based on Habitat packages.
 ///

--- a/components/pkg-export-tar/src/cli.rs
+++ b/components/pkg-export-tar/src/cli.rs
@@ -6,7 +6,7 @@ use crate::common::command::package::install::InstallSource;
 use url::Url;
 
 /// The version of this library and program when built.
-pub const VERSION: &'static str = include_str!(concat!(env!("OUT_DIR"), "/VERSION"));
+pub const VERSION: &str = include_str!(concat!(env!("OUT_DIR"), "/VERSION"));
 
 #[derive(Clone)]
 pub struct Cli<'a, 'b>

--- a/components/pkg-export-tar/src/lib.rs
+++ b/components/pkg-export-tar/src/lib.rs
@@ -30,9 +30,9 @@ use tar::Builder;
 pub use crate::build::BuildSpec;
 
 /// The version of this library and program when built.
-pub const VERSION: &'static str = include_str!(concat!(env!("OUT_DIR"), "/VERSION"));
+pub const VERSION: &str = include_str!(concat!(env!("OUT_DIR"), "/VERSION"));
 /// The Habitat Package Identifier string for a Busybox package.
-const BUSYBOX_IDENT: &'static str = "core/busybox-static";
+const BUSYBOX_IDENT: &str = "core/busybox-static";
 
 pub fn export_for_cli_matches(ui: &mut UI, matches: &clap::ArgMatches<'_>) -> Result<()> {
     let default_channel = channel::default();

--- a/components/sup-client/src/lib.rs
+++ b/components/sup-client/src/lib.rs
@@ -91,7 +91,7 @@ impl error::Error for SrvClientError {
 impl fmt::Display for SrvClientError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let content = match *self {
-            SrvClientError::ConnectionClosed => format!("Connection closed"),
+            SrvClientError::ConnectionClosed => "Connection closed".to_string(),
             SrvClientError::CtlSecretNotFound(ref path) => format!(
                 "No Supervisor CtlGateway secret set in `cli.toml` or found at {}. Run \
                  `hab setup` or run the Supervisor for the first time before attempting to \

--- a/components/sup-protocol/src/lib.rs
+++ b/components/sup-protocol/src/lib.rs
@@ -71,7 +71,7 @@ use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 
 // Name of file containing the CtlGateway secret key.
-const CTL_SECRET_FILENAME: &'static str = "CTL_SECRET";
+const CTL_SECRET_FILENAME: &str = "CTL_SECRET";
 /// Length of characters in CtlGateway secret key.
 const CTL_SECRET_LEN: usize = 64;
 
@@ -162,7 +162,7 @@ where
 /// If the Environment variable is empty or unparseable, returns the default as passed in.
 pub fn socket_addr_env_or_default(env_var: &str, default: SocketAddr) -> SocketAddr {
     henv::var(env_var)
-        .unwrap_or("".into())
+        .unwrap_or_default()
         .parse()
         .unwrap_or(default)
 }
@@ -190,7 +190,7 @@ mod ctl_secret {
         let tmpdir = TempDir::new().unwrap();
         let file_path = tmpdir.path().to_owned().join("CTL_SECRET");
         let mut secret_file = File::create(file_path).unwrap();
-        write!(secret_file, "w9TuoqTk4Ixaht8ZpJpHQlmPRbvpgz13GaGnvxunJy8iOhZcS7qGqEA7jogq/Itfu4HOdQGmLRY9G5fRUcuw/w==\n").unwrap();
+        writeln!(secret_file, "w9TuoqTk4Ixaht8ZpJpHQlmPRbvpgz13GaGnvxunJy8iOhZcS7qGqEA7jogq/Itfu4HOdQGmLRY9G5fRUcuw/w==").unwrap();
         let mut out = String::new();
         assert_eq!(read_secret_key(tmpdir, &mut out), Ok(true));
         assert_eq!(out, "w9TuoqTk4Ixaht8ZpJpHQlmPRbvpgz13GaGnvxunJy8iOhZcS7qGqEA7jogq/Itfu4HOdQGmLRY9G5fRUcuw/w==");
@@ -201,7 +201,7 @@ mod ctl_secret {
         let tmpdir = TempDir::new().unwrap();
         let file_path = tmpdir.path().to_owned().join("CTL_SECRET");
         let mut secret_file = File::create(file_path).unwrap();
-        write!(secret_file, "w9TuoqTk4Ixaht8ZpJpHQlmPRbvpgz13GaGnvxunJy8iOhZcS7qGqEA7jogq/Itfu4HOdQGmLRY9G5fRUcuw/w==\r\n").unwrap();
+        writeln!(secret_file, "w9TuoqTk4Ixaht8ZpJpHQlmPRbvpgz13GaGnvxunJy8iOhZcS7qGqEA7jogq/Itfu4HOdQGmLRY9G5fRUcuw/w==\r").unwrap();
         let mut out = String::new();
         assert_eq!(read_secret_key(tmpdir, &mut out), Ok(true));
         assert_eq!(out, "w9TuoqTk4Ixaht8ZpJpHQlmPRbvpgz13GaGnvxunJy8iOhZcS7qGqEA7jogq/Itfu4HOdQGmLRY9G5fRUcuw/w==");

--- a/components/sup/src/cli_test_helpers.rs
+++ b/components/sup/src/cli_test_helpers.rs
@@ -41,7 +41,7 @@ impl fmt::Display for CliTestError {
             ),
             CliTestError::MissingFlag(flag) => format!("Expected {} flag was missing.", flag),
             CliTestError::MissingSubcmd() => {
-                format!("Expected a subcommand, but none was specified")
+                "Expected a subcommand, but none was specified".to_string()
             }
             CliTestError::ClapError(err) => format!(
                 r#"
@@ -97,7 +97,7 @@ fn assert_matches(
         match expected_value {
             Value(expected) => match matches.value_of(flag) {
                 Some(actual) => {
-                    if actual != expected.to_string() {
+                    if actual != expected {
                         errs.push(CliTestError::ValueMismatch(
                             flag.to_string(),
                             expected.to_string(),

--- a/components/sup/src/ctl_gateway/mod.rs
+++ b/components/sup/src/ctl_gateway/mod.rs
@@ -237,14 +237,12 @@ impl DisplayProgress for NetProgressBar {
         self.inner.total = size;
     }
 
-    fn finish(&mut self) {
-        ()
-    }
+    fn finish(&mut self) {}
 }
 
 impl io::Write for NetProgressBar {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.inner.position = self.inner.position + buf.len() as u64;
+        self.inner.position += buf.len() as u64;
         self.req.reply_partial(self.inner.clone());
         Ok(buf.len())
     }

--- a/components/sup/src/ctl_gateway/server.rs
+++ b/components/sup/src/ctl_gateway/server.rs
@@ -230,7 +230,7 @@ impl Client {
                         io::ErrorKind::TimedOut,
                         "client timed out",
                     ))),
-                    Err(Either::A((err, _))) => future::err(HandlerError::from(err)),
+                    Err(Either::A((err, _))) => future::err(err),
                     Err(Either::B((err, _))) => future::err(HandlerError::from(err)),
                 }),
         )

--- a/components/sup/src/error.rs
+++ b/components/sup/src/error.rs
@@ -190,14 +190,14 @@ impl fmt::Display for SupError {
     // verbose on, and print it.
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let content = match self.err {
-            Error::APIClient(ref err) => format!("{}", err),
+            Error::APIClient(ref err) => err.to_string(),
             Error::BadAddress(ref err) => format!("Unable to bind to address {}.", err),
             Error::BadCompositesPath(ref path, ref err) => format!(
                 "Unable to create the composites directory '{}' ({})",
                 path.display(),
                 err
             ),
-            Error::Departed => format!(
+            Error::Departed => {
                 "This Supervisor has been manually departed.\n\nFor the safety of the system, \
                  this Supervisor cannot be started (if we did, we would risk the services on \
                  this machine behaving badly without our knowledge.) If you know that the \
@@ -206,7 +206,8 @@ impl fmt::Display for SupError {
                  This will cause the Supervisor to join the ring as a new member.\n\n \
                  If you are in doubt, it is better to consider the services managed by this \
                  Supervisor as unsafe to run."
-            ),
+                    .to_string()
+            }
             Error::BadDataFile(ref path, ref err) => format!(
                 "Unable to read or write to data file, {}, {}",
                 path.display(),
@@ -232,8 +233,8 @@ impl fmt::Display for SupError {
                 format!("Unable to find valid TOML or JSON in {} ENVVAR", varname)
             }
             Error::BindTimeout(ref err) => format!("Timeout waiting to bind to {}", err),
-            Error::LockPoisoned => format!("A mutex or read/write lock has failed."),
-            Error::TestBootFail => format!("Simulated boot failure"),
+            Error::LockPoisoned => "A mutex or read/write lock has failed.".to_string(),
+            Error::TestBootFail => "Simulated boot failure".to_string(),
             Error::ButterflyError(ref err) => format!("Butterfly error: {}", err),
             Error::CtlSecretIo(ref path, ref err) => format!(
                 "IoError while reading or writing ctl secret, {}, {}",
@@ -243,14 +244,14 @@ impl fmt::Display for SupError {
             Error::ExecCommandNotFound(ref c) => {
                 format!("`{}' was not found on the filesystem or in PATH", c)
             }
-            Error::Permissions(ref err) => format!("{}", err),
-            Error::HabitatCommon(ref err) => format!("{}", err),
-            Error::HabitatCore(ref err) => format!("{}", err),
+            Error::Permissions(ref err) => err.to_string(),
+            Error::HabitatCommon(ref err) => err.to_string(),
+            Error::HabitatCore(ref err) => err.to_string(),
             Error::TemplateFileError(ref err) => format!("{:?}", err),
-            Error::TemplateRenderError(ref err) => format!("{}", err),
-            Error::EnvJoinPathsError(ref err) => format!("{}", err),
+            Error::TemplateRenderError(ref err) => err.to_string(),
+            Error::EnvJoinPathsError(ref err) => err.to_string(),
             Error::FileNotFound(ref e) => format!("File not found at: {}", e),
-            Error::FileWatcherFileIsRoot => format!("Watched file is root"),
+            Error::FileWatcherFileIsRoot => "Watched file is root".to_string(),
             Error::GroupNotFound(ref e) => format!("No GID for group '{}' could be found", e),
             Error::InvalidBinding(ref binding) => format!(
                 "Invalid binding \"{}\", must be of the form <NAME>:<SERVICE_GROUP> or \
@@ -265,30 +266,30 @@ impl fmt::Display for SupError {
             Error::InvalidKeyParameter(ref e) => {
                 format!("Invalid parameter for key generation: {:?}", e)
             }
-            Error::InvalidPidFile => format!("Invalid child process PID file"),
+            Error::InvalidPidFile => "Invalid child process PID file".to_string(),
             Error::InvalidTokioThreadCount => {
-                format!("Tokio thread count should be a positive integer")
+                "Tokio thread count should be a positive integer".to_string()
             }
             Error::InvalidTopology(ref t) => format!("Invalid topology: {}", t),
             Error::InvalidUpdateStrategy(ref s) => format!("Invalid update strategy: {}", s),
-            Error::Io(ref err) => format!("{}", err),
-            Error::IPFailed => format!("Failed to discover this hosts outbound IP address"),
-            Error::Launcher(ref err) => format!("{}", err),
+            Error::Io(ref err) => err.to_string(),
+            Error::IPFailed => "Failed to discover this hosts outbound IP address".to_string(),
+            Error::Launcher(ref err) => err.to_string(),
             Error::MissingRequiredBind(ref e) => {
                 format!("Missing required bind(s), {}", e.join(", "))
             }
             Error::MissingRequiredIdent => {
-                format!("Missing required ident field: (example: ident = \"core/redis\")")
+                "Missing required ident field: (example: ident = \"core/redis\")".to_string()
             }
             Error::NameLookup(ref e) => format!("Error resolving a name or IP address: {}", e),
-            Error::NetErr(ref err) => format!("{}", err),
+            Error::NetErr(ref err) => err.to_string(),
             Error::NetParseError(ref e) => format!("Can't parse ip:port: {}", e),
             Error::NoActiveMembers(ref g) => format!("No active members in service group {}", g),
-            Error::NoLauncher => format!("Supervisor must be run from `hab-launch`"),
+            Error::NoLauncher => "Supervisor must be run from `hab-launch`".to_string(),
             Error::NoSuchBind(ref b) => format!("No such bind: {}", b),
             Error::NotifyCreateError(ref e) => format!("Notify create error: {}", e),
             Error::NotifyError(ref e) => format!("Notify error: {}", e),
-            Error::NulError(ref e) => format!("{}", e),
+            Error::NulError(ref e) => e.to_string(),
             Error::PackageNotFound(ref pkg) => {
                 if pkg.fully_qualified() {
                     format!("Cannot find package: {}", pkg)
@@ -303,7 +304,7 @@ impl fmt::Display for SupError {
             Error::PidFileIO(ref path, ref err) => {
                 format!("Unable to read PID file, {}, {}", path.display(), err)
             }
-            Error::ProcessLockCorrupt => format!("Unable to decode contents of process lock"),
+            Error::ProcessLockCorrupt => "Unable to decode contents of process lock".to_string(),
             Error::ProcessLocked(ref pid) => format!(
                 "Unable to start Habitat Supervisor because another instance is already \
                  running with the pid {}.",
@@ -315,7 +316,7 @@ impl fmt::Display for SupError {
                 path.display(),
                 err
             ),
-            Error::RecvError(ref err) => format!("{}", err),
+            Error::RecvError(ref err) => err.to_string(),
             Error::RenderContextSerialization(ref e) => {
                 format!("Unable to serialize rendering context, {}", e)
             }
@@ -337,21 +338,21 @@ impl fmt::Display for SupError {
             Error::ServiceSpecRender(ref err) => {
                 format!("Service spec could not be rendered successfully: {}", err)
             }
-            Error::SignalFailed => format!("Failed to send a signal to the child process"),
-            Error::SpecWatcherNotCreated => format!("Failed to create a SpecWatcher"),
+            Error::SignalFailed => "Failed to send a signal to the child process".to_string(),
+            Error::SpecWatcherNotCreated => "Failed to create a SpecWatcher".to_string(),
             Error::SpecDirNotFound(ref path) => format!(
                 "Spec directory '{}' not created or is not a directory",
                 path
             ),
-            Error::SpecWatcherGlob(ref e) => format!("{}", e),
-            Error::StrFromUtf8Error(ref e) => format!("{}", e),
-            Error::StringFromUtf8Error(ref e) => format!("{}", e),
-            Error::TLSError(ref e) => format!("{}", e),
+            Error::SpecWatcherGlob(ref e) => e.to_string(),
+            Error::StrFromUtf8Error(ref e) => e.to_string(),
+            Error::StringFromUtf8Error(ref e) => e.to_string(),
+            Error::TLSError(ref e) => e.to_string(),
             Error::TomlEncode(ref e) => format!("Failed to encode TOML: {}", e),
             Error::TomlMergeError(ref e) => format!("Failed to merge TOML: {}", e),
             Error::TomlParser(ref err) => format!("Failed to parse TOML: {}", err),
-            Error::TryRecvError(ref err) => format!("{}", err),
-            Error::UnpackFailed => format!("Failed to unpack a package"),
+            Error::TryRecvError(ref err) => err.to_string(),
+            Error::UnpackFailed => "Failed to unpack a package".to_string(),
             Error::UserNotFound(ref e) => format!("No UID for user '{}' could be found", e),
         };
         let progname = PROGRAM_NAME.as_str();

--- a/components/sup/src/http_gateway.rs
+++ b/components/sup/src/http_gateway.rs
@@ -46,8 +46,8 @@ use crate::manager::service::HealthCheck;
 
 use crate::feat;
 
-const APIDOCS: &'static str = include_str!(concat!(env!("OUT_DIR"), "/api.html"));
-pub const HTTP_THREADS_ENVVAR: &'static str = "HAB_SUP_HTTP_THREADS";
+const APIDOCS: &str = include_str!(concat!(env!("OUT_DIR"), "/api.html"));
+pub const HTTP_THREADS_ENVVAR: &str = "HAB_SUP_HTTP_THREADS";
 pub const HTTP_THREAD_COUNT: usize = 2;
 
 /// Default listening port for the HTTPGateway listener.
@@ -494,10 +494,10 @@ mod tests {
             .join("http-gateway")
             .join(name);
 
-        let mut f = File::open(path).expect(&format!("could not open {}", &name));
+        let mut f = File::open(path).unwrap_or_else(|_| panic!("could not open {}", &name));
         let mut json = String::new();
         f.read_to_string(&mut json)
-            .expect(&format!("could not read {}", &name));
+            .unwrap_or_else(|_| panic!("could not read {}", &name));
 
         assert_valid(&json, schema);
     }

--- a/components/sup/src/lib.rs
+++ b/components/sup/src/lib.rs
@@ -110,7 +110,7 @@ use std::path::PathBuf;
 
 lazy_static! {
     pub static ref PROGRAM_NAME: String = {
-        let arg0 = env::args().next().map(|p| PathBuf::from(p));
+        let arg0 = env::args().next().map(PathBuf::from);
         arg0.as_ref()
             .and_then(|p| p.file_stem())
             .and_then(|p| p.to_str())
@@ -125,16 +125,16 @@ lazy_static! {
 /// Search for feat::is_enabled(feat::FeatureName) to learn more
 features! {
     pub mod feat {
-        const List          = 0b00000001,
-        const TestExit      = 0b00000010,
-        const TestBootFail  = 0b00000100,
-        const RedactHTTP    = 0b00001000,
-        const IgnoreSignals = 0b00010000
+        const List          = 0b0000_0001,
+        const TestExit      = 0b0000_0010,
+        const TestBootFail  = 0b0000_0100,
+        const RedactHTTP    = 0b0000_1000,
+        const IgnoreSignals = 0b0001_0000
     }
 }
 
-pub const PRODUCT: &'static str = "hab-sup";
-pub const VERSION: &'static str = include_str!(concat!(env!("OUT_DIR"), "/VERSION"));
+pub const PRODUCT: &str = "hab-sup";
+pub const VERSION: &str = include_str!(concat!(env!("OUT_DIR"), "/VERSION"));
 
 #[derive(Copy, Clone)]
 pub enum ShutdownReason {

--- a/components/sup/src/manager/debug.rs
+++ b/components/sup/src/manager/debug.rs
@@ -109,8 +109,8 @@ impl IndentedToString for OsString {
 impl<T: IndentedToString> IndentedToString for Option<T> {
     fn indented_to_string(&self, spaces: &str, repeat: usize) -> String {
         match self {
-            &Some(ref v) => format!("Some({})", its!(v, spaces, repeat)),
-            &None => "None".to_string(),
+            Some(ref v) => format!("Some({})", its!(v, spaces, repeat)),
+            None => "None".to_string(),
         }
     }
 }

--- a/components/sup/src/manager/events.rs
+++ b/components/sup/src/manager/events.rs
@@ -70,7 +70,7 @@ impl EventsCli {
         if let Some(cg) = census.census_group_for(&self.group) {
             // JW TODO: We're over allocating here. We should determine who we are already
             // connected to before we generate an addr list.
-            let addrs = cg.members().iter().map(|m| eventsrv_addr(&m)).collect();
+            let addrs = cg.members().map(|m| eventsrv_addr(&m)).collect();
             self.tx.send(Command::TryConnect(addrs)).unwrap();
         }
     }
@@ -126,18 +126,8 @@ impl EventsMgr {
 fn eventsrv_addr(member: &CensusMember) -> EventSrvAddr {
     let mut addr = EventSrvAddr::default();
     addr.host = IpAddr::from_str(&member.sys.ip).unwrap();
-    addr.consumer_port = member
-        .cfg
-        .get("consumer_port")
-        .unwrap()
-        .as_integer()
-        .unwrap() as u16;
-    addr.producer_port = member
-        .cfg
-        .get("producer_port")
-        .unwrap()
-        .as_integer()
-        .unwrap() as u16;
+    addr.consumer_port = member.cfg["consumer_port"].as_integer().unwrap() as u16;
+    addr.producer_port = member.cfg["producer_port"].as_integer().unwrap() as u16;
     addr
 }
 

--- a/components/sup/src/manager/file_watcher.rs
+++ b/components/sup/src/manager/file_watcher.rs
@@ -66,7 +66,7 @@ pub trait Callbacks {
     // Keep the variable name for documentation purposes, so silence
     // compiler's complaints about unused variable.
     #[allow(unused_variables)]
-    fn event_in_directories(&mut self, paths: &Vec<PathBuf>) {}
+    fn event_in_directories(&mut self, paths: &[PathBuf]) {}
 }
 
 // Essentially a pair of dirname and basename.
@@ -122,9 +122,8 @@ struct SplitPath {
 
 impl SplitPath {
     fn push(&mut self, path: OsString) -> DirFileName {
-        match self.file_name {
-            Some(ref file_name) => self.directory.push(file_name),
-            None => (),
+        if let Some(ref file_name) = self.file_name {
+            self.directory.push(file_name);
         }
         self.file_name = Some(path.clone());
 
@@ -423,21 +422,21 @@ enum WatchedFile {
 impl WatchedFile {
     fn get_common(&self) -> &Common {
         match self {
-            &WatchedFile::Regular(ref c)
-            | &WatchedFile::MissingRegular(ref c)
-            | &WatchedFile::Symlink(ref c)
-            | &WatchedFile::Directory(ref c)
-            | &WatchedFile::MissingDirectory(ref c) => c,
+            WatchedFile::Regular(ref c)
+            | WatchedFile::MissingRegular(ref c)
+            | WatchedFile::Symlink(ref c)
+            | WatchedFile::Directory(ref c)
+            | WatchedFile::MissingDirectory(ref c) => c,
         }
     }
 
     fn get_mut_common(&mut self) -> &mut Common {
         match self {
-            &mut WatchedFile::Regular(ref mut c)
-            | &mut WatchedFile::MissingRegular(ref mut c)
-            | &mut WatchedFile::Symlink(ref mut c)
-            | &mut WatchedFile::Directory(ref mut c)
-            | &mut WatchedFile::MissingDirectory(ref mut c) => c,
+            WatchedFile::Regular(ref mut c)
+            | WatchedFile::MissingRegular(ref mut c)
+            | WatchedFile::Symlink(ref mut c)
+            | WatchedFile::Directory(ref mut c)
+            | WatchedFile::MissingDirectory(ref mut c) => c,
         }
     }
 
@@ -455,11 +454,11 @@ impl WatchedFile {
 impl IndentedToString for WatchedFile {
     fn indented_to_string(&self, spaces: &str, repeat: usize) -> String {
         let name = match self {
-            &WatchedFile::Regular(_) => "Regular",
-            &WatchedFile::MissingRegular(_) => "MissingRegular",
-            &WatchedFile::Symlink(_) => "Symlink",
-            &WatchedFile::Directory(_) => "Directory",
-            &WatchedFile::MissingDirectory(_) => "MissingDirectory",
+            WatchedFile::Regular(_) => "Regular",
+            WatchedFile::MissingRegular(_) => "MissingRegular",
+            WatchedFile::Symlink(_) => "Symlink",
+            WatchedFile::Directory(_) => "Directory",
+            WatchedFile::MissingDirectory(_) => "MissingDirectory",
         };
         format!("{}({})", name, its!(self.get_common(), spaces, repeat))
     }
@@ -515,28 +514,28 @@ enum EventAction {
 impl IndentedToString for EventAction {
     fn indented_to_string(&self, spaces: &str, repeat: usize) -> String {
         match self {
-            &EventAction::Ignore => "Ignore".to_string(),
-            &EventAction::PlainChange(ref p) => format!("PlainChange({})", its!(p, spaces, repeat)),
-            &EventAction::RestartWatching => "RestartWatching".to_string(),
-            &EventAction::AddRegular(ref pad) => {
+            EventAction::Ignore => "Ignore".to_string(),
+            EventAction::PlainChange(ref p) => format!("PlainChange({})", its!(p, spaces, repeat)),
+            EventAction::RestartWatching => "RestartWatching".to_string(),
+            EventAction::AddRegular(ref pad) => {
                 format!("AddRegular({})", its!(pad, spaces, repeat))
             }
-            &EventAction::DropRegular(ref pad) => {
+            EventAction::DropRegular(ref pad) => {
                 format!("DropRegular({})", its!(pad, spaces, repeat))
             }
-            &EventAction::AddDirectory(ref pad) => {
+            EventAction::AddDirectory(ref pad) => {
                 format!("AddDirectory({})", its!(pad, spaces, repeat))
             }
-            &EventAction::DropDirectory(ref pad) => {
+            EventAction::DropDirectory(ref pad) => {
                 format!("DropDirectory({})", its!(pad, spaces, repeat))
             }
-            &EventAction::RewireSymlink(ref pad) => {
+            EventAction::RewireSymlink(ref pad) => {
                 format!("RewireSymlink({})", its!(pad, spaces, repeat))
             }
-            &EventAction::DropSymlink(ref pad) => {
+            EventAction::DropSymlink(ref pad) => {
                 format!("DropSymlink({})", its!(pad, spaces, repeat))
             }
-            &EventAction::SettlePath(ref p) => format!("SettlePath({})", its!(p, spaces, repeat)),
+            EventAction::SettlePath(ref p) => format!("SettlePath({})", its!(p, spaces, repeat)),
         }
     }
 }
@@ -557,26 +556,26 @@ enum PathsAction {
 impl IndentedToString for PathsAction {
     fn indented_to_string(&self, spaces: &str, repeat: usize) -> String {
         match self {
-            &PathsAction::NotifyFileAppeared(ref p) => {
+            PathsAction::NotifyFileAppeared(ref p) => {
                 format!("NotifyFileAppeared({})", its!(p, spaces, repeat + 1))
             }
-            &PathsAction::NotifyFileModified(ref p) => {
+            PathsAction::NotifyFileModified(ref p) => {
                 format!("NotifyFileModified({})", its!(p, spaces, repeat + 1))
             }
-            &PathsAction::NotifyFileDisappeared(ref p) => {
+            PathsAction::NotifyFileDisappeared(ref p) => {
                 format!("NotifyFileDisappeared({})", its!(p, spaces, repeat + 1))
             }
-            &PathsAction::DropWatch(ref p) => format!("DropWatch({})", its!(p, spaces, repeat + 1)),
-            &PathsAction::AddPathToSettle(ref p) => {
+            PathsAction::DropWatch(ref p) => format!("DropWatch({})", its!(p, spaces, repeat + 1)),
+            PathsAction::AddPathToSettle(ref p) => {
                 format!("AddPathToSettle({})", its!(p, spaces, repeat + 1))
             }
-            &PathsAction::SettlePath(ref p) => {
+            PathsAction::SettlePath(ref p) => {
                 format!("SettlePath({})", its!(p, spaces, repeat + 1))
             }
-            &PathsAction::ProcessPathAfterSettle(ref a) => {
+            PathsAction::ProcessPathAfterSettle(ref a) => {
                 format!("ProcessPathAfterSettle({})", its!(a, spaces, repeat + 1))
             }
-            &PathsAction::RestartWatching => "RestartWatching".to_string(),
+            PathsAction::RestartWatching => "RestartWatching".to_string(),
         }
     }
 }
@@ -600,11 +599,11 @@ enum BranchResult {
 impl IndentedToString for BranchResult {
     fn indented_to_string(&self, spaces: &str, repeat: usize) -> String {
         match self {
-            &BranchResult::AlreadyExists => "AlreadyExists".to_string(),
-            &BranchResult::NewInOldDirectory(ref i) => {
+            BranchResult::AlreadyExists => "AlreadyExists".to_string(),
+            BranchResult::NewInOldDirectory(ref i) => {
                 format!("NewInOldDirectory({})", its!(i, spaces, repeat))
             }
-            &BranchResult::NewInNewDirectory(ref i, ref p) => format!(
+            BranchResult::NewInNewDirectory(ref i, ref p) => format!(
                 "NewInNewDirectory({}, {})",
                 its!(i, spaces, repeat),
                 p.to_string_lossy()
@@ -624,10 +623,10 @@ enum LeafResult {
 impl IndentedToString for LeafResult {
     fn indented_to_string(&self, spaces: &str, repeat: usize) -> String {
         match self {
-            &LeafResult::NewInOldDirectory(ref i) => {
+            LeafResult::NewInOldDirectory(ref i) => {
                 format!("NewInOldDirectory({})", its!(i, spaces, repeat))
             }
-            &LeafResult::NewInNewDirectory(ref i, ref p) => format!(
+            LeafResult::NewInNewDirectory(ref i, ref p) => format!(
                 "NewInNewDirectory({}, {})",
                 its!(i, spaces, repeat),
                 p.to_string_lossy()
@@ -1435,17 +1434,17 @@ impl<C: Callbacks, W: Watcher> FileWatcher<C, W> {
 
     fn emit_directories_for_event(&mut self, event: &DebouncedEvent) {
         let paths = match event {
-            &DebouncedEvent::NoticeWrite(ref p)
-            | &DebouncedEvent::Write(ref p)
-            | &DebouncedEvent::Chmod(ref p)
-            | &DebouncedEvent::NoticeRemove(ref p)
-            | &DebouncedEvent::Remove(ref p)
-            | &DebouncedEvent::Create(ref p) => vec![p],
-            &DebouncedEvent::Rename(ref from, ref to) => vec![from, to],
-            &DebouncedEvent::Rescan => vec![],
-            &DebouncedEvent::Error(_, ref o) => match o {
-                &Some(ref p) => vec![p],
-                &None => vec![],
+            DebouncedEvent::NoticeWrite(ref p)
+            | DebouncedEvent::Write(ref p)
+            | DebouncedEvent::Chmod(ref p)
+            | DebouncedEvent::NoticeRemove(ref p)
+            | DebouncedEvent::Remove(ref p)
+            | DebouncedEvent::Create(ref p) => vec![p],
+            DebouncedEvent::Rename(ref from, ref to) => vec![from, to],
+            DebouncedEvent::Rescan => vec![],
+            DebouncedEvent::Error(_, ref o) => match o {
+                Some(ref p) => vec![p],
+                None => vec![],
             },
         };
         let mut dirs = vec![];
@@ -2730,7 +2729,7 @@ mod tests {
     }
 
     impl TestCallbacks {
-        fn new(ignored_dirs: &Vec<PathBuf>) -> Self {
+        fn new(ignored_dirs: &[PathBuf]) -> Self {
             let mut cb = Self::default();
             cb.ignored_dirs.extend(ignored_dirs.iter().cloned());
             cb
@@ -2753,7 +2752,7 @@ mod tests {
                 .push(NotifyEvent::disappeared(real_path.to_owned()));
         }
 
-        fn event_in_directories(&mut self, paths: &Vec<PathBuf>) {
+        fn event_in_directories(&mut self, paths: &[PathBuf]) {
             for path in paths {
                 if self.ignored_dirs.contains(path) {
                     debug!("got event in ignored dirs");
@@ -2797,10 +2796,9 @@ mod tests {
                     path.as_ref().display(),
                 );
             }
-            match mode {
-                RecursiveMode::Recursive => panic!("Recursive watch should not ever happen"),
-                _ => (),
-            };
+            if mode == RecursiveMode::Recursive {
+                panic!("Recursive watch should not ever happen");
+            }
             self.real_watcher.watch(path, mode)
         }
 
@@ -2845,10 +2843,10 @@ mod tests {
 
     impl Display for DebugInfo {
         fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
-            write!(f, "----------------\n")?;
+            writeln!(f, "----------------")?;
             for level_logs in &self.logs_per_level {
                 for entry in level_logs {
-                    write!(f, "{}\n----------------\n", entry)?;
+                    writeln!(f, "{}\n----------------", entry)?;
                 }
             }
             Ok(())
@@ -2876,12 +2874,14 @@ mod tests {
             } else {
                 target.clone()
             };
-            unix_fs::symlink(&tt, &pp).expect(&format!(
-                "could not create symlink at {} pointing to {}, debug info:\n{}",
-                pp.display(),
-                tt.display(),
-                self.debug_info,
-            ));
+            unix_fs::symlink(&tt, &pp).unwrap_or_else(|_| {
+                panic!(
+                    "could not create symlink at {} pointing to {}, debug info:\n{}",
+                    pp.display(),
+                    tt.display(),
+                    self.debug_info,
+                )
+            });
             if self.parent_is_watched(&pp) {
                 // One event - create.
                 1
@@ -2916,20 +2916,24 @@ mod tests {
         }
 
         fn real_mkdir(&self, real_path: &PathBuf) {
-            fs::create_dir_all(&real_path).expect(&format!(
-                "could not create directories up to {}, debug info:\n{}",
-                real_path.display(),
-                self.debug_info,
-            ));
+            fs::create_dir_all(&real_path).unwrap_or_else(|_| {
+                panic!(
+                    "could not create directories up to {}, debug info:\n{}",
+                    real_path.display(),
+                    self.debug_info,
+                )
+            });
         }
 
         fn touch(&self, path: &PathBuf) -> u32 {
             let pp = self.prepend_root(&path);
-            File::create(&pp).expect(&format!(
-                "could not create file {}, debug info:\n{}",
-                pp.display(),
-                self.debug_info,
-            ));
+            File::create(&pp).unwrap_or_else(|_| {
+                panic!(
+                    "could not create file {}, debug info:\n{}",
+                    pp.display(),
+                    self.debug_info,
+                )
+            });
             if self.parent_is_watched(&pp) {
                 // One event - create.
                 1
@@ -2942,12 +2946,14 @@ mod tests {
         fn mv(&self, from: &PathBuf, to: &PathBuf) -> u32 {
             let ff = self.prepend_root(&from);
             let tt = self.prepend_root(&to);
-            fs::rename(&ff, &tt).expect(&format!(
-                "could not move from {} to {}, debug info:\n{}",
-                ff.display(),
-                tt.display(),
-                self.debug_info,
-            ));
+            fs::rename(&ff, &tt).unwrap_or_else(|_| {
+                panic!(
+                    "could not move from {} to {}, debug info:\n{}",
+                    ff.display(),
+                    tt.display(),
+                    self.debug_info,
+                )
+            });
             match (self.parent_is_watched(&ff), self.parent_is_watched(&tt)) {
                 (true, true) | (true, false) => {
                     if self.path_is_watched(&ff) {
@@ -3076,11 +3082,13 @@ mod tests {
 
         fn get_parent(&self, path: &PathBuf) -> PathBuf {
             path.parent()
-                .expect(&format!(
-                    "path {} has no parent, debug info:\n{}",
-                    path.display(),
-                    self.debug_info
-                ))
+                .unwrap_or_else(|| {
+                    panic!(
+                        "path {} has no parent, debug info:\n{}",
+                        path.display(),
+                        self.debug_info
+                    )
+                })
                 .to_owned()
         }
 
@@ -3100,7 +3108,8 @@ mod tests {
 
     impl TestCaseRunner {
         fn new() -> Self {
-            let tmp_dir = TempDir::new().expect(&format!("couldn't create temporary directory",));
+            let tmp_dir =
+                TempDir::new().unwrap_or_else(|_| panic!("couldn't create temporary directory",));
             let root = tmp_dir.path().to_owned();
             Self {
                 debug_info: DebugInfo::new(),
@@ -3109,17 +3118,17 @@ mod tests {
             }
         }
 
-        fn run_init_commands(&mut self, commands: &Vec<InitCommand>) {
+        fn run_init_commands(&mut self, commands: &[InitCommand]) {
             let fs_ops = self.get_fs_ops();
             for command in commands {
                 match command {
-                    &InitCommand::MkdirP(ref path) => {
+                    InitCommand::MkdirP(ref path) => {
                         fs_ops.mkdir_p(path);
                     }
-                    &InitCommand::Touch(ref path) => {
+                    InitCommand::Touch(ref path) => {
                         fs_ops.touch(path);
                     }
-                    &InitCommand::LnS(ref target, ref path) => {
+                    InitCommand::LnS(ref target, ref path) => {
                         fs_ops.ln_s(target, path);
                     }
                 }
@@ -3127,15 +3136,14 @@ mod tests {
         }
 
         fn prepare_watcher(&mut self, tc_init_path: &Option<PathBuf>) -> WatcherSetup {
-            let init_path = tc_init_path.clone().unwrap_or(pb!("/a/b/c/d/e/f"));
+            let init_path = tc_init_path.clone().unwrap_or_else(|| pb!("/a/b/c/d/e/f"));
             let additional_dirs = self.get_additional_directories_from_root();
             let callbacks = TestCallbacks::new(&additional_dirs);
             let watcher =
                 FileWatcher::<_, TestWatcher>::create(self.prepend_root(&init_path), callbacks)
-                    .expect(&format!(
-                        "failed to create watcher, debug info:\n{}",
-                        self.debug_info,
-                    ));
+                    .unwrap_or_else(|_| {
+                        panic!("failed to create watcher, debug info:\n{}", self.debug_info,)
+                    });
             WatcherSetup {
                 init_path: init_path,
                 watcher: watcher,
@@ -3146,7 +3154,7 @@ mod tests {
             &mut self,
             mut setup: WatcherSetup,
             tc_initial_file: &Option<PathBuf>,
-            steps: &Vec<Step>,
+            steps: &[Step],
         ) {
             let mut initial_file = tc_initial_file.clone();
             let mut actual_initial_file = setup.watcher.initial_real_file.clone();
@@ -3176,12 +3184,12 @@ mod tests {
                 let tw = setup.watcher.get_mut_underlying_watcher();
                 let mut fs_ops = self.get_fs_ops_with_dirs(&tw.watched_dirs);
                 match action {
-                    &StepAction::LnS(ref target, ref path) => fs_ops.ln_s(target, path),
-                    &StepAction::MkdirP(ref path) => fs_ops.mkdir_p(path),
-                    &StepAction::Touch(ref path) => fs_ops.touch(path),
-                    &StepAction::Mv(ref from, ref to) => fs_ops.mv(from, to),
-                    &StepAction::RmRF(ref path) => fs_ops.rm_rf(path),
-                    &StepAction::Nop => 0,
+                    StepAction::LnS(ref target, ref path) => fs_ops.ln_s(target, path),
+                    StepAction::MkdirP(ref path) => fs_ops.mkdir_p(path),
+                    StepAction::Touch(ref path) => fs_ops.touch(path),
+                    StepAction::Mv(ref from, ref to) => fs_ops.mv(from, to),
+                    StepAction::RmRF(ref path) => fs_ops.rm_rf(path),
+                    StepAction::Nop => 0,
                 }
             };
             self.debug_info
@@ -3197,10 +3205,9 @@ mod tests {
             thread::sleep(Duration::from_secs(3));
 
             while iteration < iterations {
-                setup.watcher.single_iteration().expect(&format!(
-                    "iteration failed, debug info:\n{}",
-                    self.debug_info,
-                ));
+                setup.watcher.single_iteration().unwrap_or_else(|_| {
+                    panic!("iteration failed, debug info:\n{}", self.debug_info,)
+                });
                 let cb = setup.watcher.get_mut_callbacks();
                 if cb.ignore {
                     debug!("got event below tmpdir, not increasing the iteration counter");
@@ -3268,7 +3275,7 @@ mod tests {
         fn test_events(
             &mut self,
             real_initial_file: Option<PathBuf>,
-            step_events: &Vec<NotifyEvent>,
+            step_events: &[NotifyEvent],
             actual_events: &mut Vec<NotifyEvent>,
         ) {
             let expected_events = self.fixup_expected_events(&step_events, real_initial_file);
@@ -3350,7 +3357,7 @@ mod tests {
                 &real_first_expected,
                 // The existence of this path in the map is checked in
                 // get_real_first_expected_path.
-                expected_paths.get(&real_first_expected).unwrap(),
+                &expected_paths[&real_first_expected],
             );
 
             self.link_expected_paths_with_additional_ones(
@@ -3385,7 +3392,7 @@ mod tests {
 
         fn fixup_expected_events(
             &self,
-            events: &Vec<NotifyEvent>,
+            events: &[NotifyEvent],
             real_initial_file: Option<PathBuf>,
         ) -> Vec<NotifyEvent> {
             let mut expected_events = match real_initial_file {
@@ -3413,12 +3420,12 @@ mod tests {
                             kind: s.kind,
                             path_rest: s.path_rest.clone(),
                             prev: match &s.prev {
-                                &Some(ref p) => Some(self.prepend_root(&p)),
-                                &None => None,
+                                Some(ref p) => Some(self.prepend_root(&p)),
+                                None => None,
                             },
                             next: match &s.next {
-                                &Some(ref p) => Some(self.prepend_root(&p)),
-                                &None => None,
+                                Some(ref p) => Some(self.prepend_root(&p)),
+                                None => None,
                             },
                         },
                     )
@@ -3433,11 +3440,13 @@ mod tests {
         ) -> PathBuf {
             let first_expected = get_first_item(&init_path);
             let real_first_expected = self.prepend_root(&first_expected);
-            let first_item = expected_paths.get(&real_first_expected).expect(&format!(
-                "expected watched item for {} (real: {}), it is an error in the test case",
-                first_expected.display(),
-                real_first_expected.display(),
-            ));
+            let first_item = expected_paths.get(&real_first_expected).unwrap_or_else(|| {
+                panic!(
+                    "expected watched item for {} (real: {}), it is an error in the test case",
+                    first_expected.display(),
+                    real_first_expected.display(),
+                )
+            });
 
             assert_eq!(
                 first_item.prev,
@@ -3483,8 +3492,8 @@ mod tests {
             }
             // Fill path rests in additional path states.
             let real_first_expected_path_rest = to_path_rest(&real_first_expected);
-            for idx in 0..ap_len {
-                let path_rest = &mut ap_vec[idx].1.path_rest;
+            for (idx, ap_vec_item) in ap_vec.iter_mut().enumerate() {
+                let path_rest = &mut ap_vec_item.1.path_rest;
                 // If root/temporary directory is `/tmp/foo/bar` then
                 // `/tmp` will have path rest `[foo, bar, <rest from
                 // the first item>]`, `/tmp/foo` - `[bar, <rest from
@@ -3542,11 +3551,11 @@ mod tests {
         ) {
             let common = watched_file.get_common();
             let expected_kind = match watched_file {
-                &WatchedFile::Regular(_) => PathKind::Regular,
-                &WatchedFile::MissingRegular(_) => PathKind::MissingRegular,
-                &WatchedFile::Symlink(_) => PathKind::Symlink,
-                &WatchedFile::Directory(_) => PathKind::Directory,
-                &WatchedFile::MissingDirectory(_) => PathKind::MissingDirectory,
+                WatchedFile::Regular(_) => PathKind::Regular,
+                WatchedFile::MissingRegular(_) => PathKind::MissingRegular,
+                WatchedFile::Symlink(_) => PathKind::Symlink,
+                WatchedFile::Directory(_) => PathKind::Directory,
+                WatchedFile::MissingDirectory(_) => PathKind::MissingDirectory,
             };
             let path_rest: Vec<OsString> = common.path_rest.iter().cloned().collect();
 

--- a/components/sup/src/manager/self_updater.rs
+++ b/components/sup/src/manager/self_updater.rs
@@ -27,9 +27,9 @@ use crate::env;
 use crate::hcore::package::{PackageIdent, PackageInstall};
 use crate::util;
 
-pub const SUP_PKG_IDENT: &'static str = "core/hab-sup";
+pub const SUP_PKG_IDENT: &str = "core/hab-sup";
 const DEFAULT_FREQUENCY: i64 = 60_000;
-const FREQUENCY_ENVVAR: &'static str = "HAB_SUP_UPDATE_MS";
+const FREQUENCY_ENVVAR: &str = "HAB_SUP_UPDATE_MS";
 
 pub struct SelfUpdater {
     rx: Receiver<PackageInstall>,

--- a/components/sup/src/manager/service/composite_spec.rs
+++ b/components/sup/src/manager/service/composite_spec.rs
@@ -32,9 +32,9 @@ use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};
 use toml;
 
-const SPEC_FILE_EXT: &'static str = "spec";
+const SPEC_FILE_EXT: &str = "spec";
 
-static LOGKEY: &'static str = "CS";
+static LOGKEY: &str = "CS";
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(default)]

--- a/components/sup/src/manager/service/hooks.rs
+++ b/components/sup/src/manager/service/hooks.rs
@@ -77,7 +77,7 @@ pub trait Hook: fmt::Debug + Sized {
         T: AsRef<Path>,
     {
         let file_name = Self::file_name();
-        let deprecated_file_name = if Self::file_name().contains("-") {
+        let deprecated_file_name = if Self::file_name().contains('-') {
             Some(Self::file_name().replace("-", "_"))
         } else {
             None
@@ -788,7 +788,7 @@ where
     T: AsRef<Path>,
 {
     if path.as_ref().exists() {
-        crypto::hash::hash_file(path).map_err(|e| SupError::from(e))
+        crypto::hash::hash_file(path).map_err(SupError::from)
     } else {
         Ok(String::new())
     }
@@ -831,7 +831,7 @@ impl HookTable {
         T: AsRef<Path>,
     {
         let mut table = HookTable::default();
-        if let Some(meta) = std::fs::metadata(templates.as_ref()).ok() {
+        if let Ok(meta) = std::fs::metadata(templates.as_ref()) {
             if meta.is_dir() {
                 table.file_updated = FileUpdatedHook::load(service_group, &hooks_path, &templates);
                 table.health_check = HealthCheckHook::load(service_group, &hooks_path, &templates);
@@ -982,7 +982,7 @@ impl<'a> HookOutput<'a> {
         let preamble_str = self.stream_preamble::<H>(service_group);
         if let Some(ref mut stdout) = process.stdout {
             for line in BufReader::new(stdout).lines() {
-                if let Some(ref l) = line.ok() {
+                if let Ok(ref l) = line {
                     outputln!(preamble preamble_str, l);
                     stdout_log
                         .write_fmt(format_args!("{}\n", l))
@@ -992,7 +992,7 @@ impl<'a> HookOutput<'a> {
         }
         if let Some(ref mut stderr) = process.stderr {
             for line in BufReader::new(stderr).lines() {
-                if let Some(ref l) = line.ok() {
+                if let Ok(ref l) = line {
                     outputln!(preamble preamble_str, l);
                     stderr_log
                         .write_fmt(format_args!("{}\n", l))

--- a/components/sup/src/manager/service/package.rs
+++ b/components/sup/src/manager/service/package.rs
@@ -28,11 +28,11 @@ use crate::error::{Error, Result};
 use crate::fs;
 use crate::util;
 
-const DEFAULT_USER: &'static str = "hab";
-const DEFAULT_GROUP: &'static str = "hab";
+const DEFAULT_USER: &str = "hab";
+const DEFAULT_GROUP: &str = "hab";
 
-const PATH_KEY: &'static str = "PATH";
-static LOGKEY: &'static str = "PK";
+const PATH_KEY: &str = "PATH";
+static LOGKEY: &str = "PK";
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Env(HashMap<String, String>);

--- a/components/sup/src/manager/service/spec.rs
+++ b/components/sup/src/manager/service/spec.rs
@@ -38,9 +38,9 @@ use super::composite_spec::CompositeSpec;
 use super::{BindingMode, Topology, UpdateStrategy};
 use crate::error::{Error, Result, SupError};
 
-static LOGKEY: &'static str = "SS";
-static DEFAULT_GROUP: &'static str = "default";
-const SPEC_FILE_EXT: &'static str = "spec";
+static LOGKEY: &str = "SS";
+static DEFAULT_GROUP: &str = "default";
+const SPEC_FILE_EXT: &str = "spec";
 
 pub type BindMap = HashMap<PackageIdent, Vec<BindMapping>>;
 
@@ -95,8 +95,8 @@ pub enum Spec {
 impl Spec {
     pub fn ident(&self) -> &PackageIdent {
         match self {
-            &Spec::Composite(ref s, _) => s.ident(),
-            &Spec::Service(ref s) => s.ident.as_ref(),
+            Spec::Composite(ref s, _) => s.ident(),
+            Spec::Service(ref s) => s.ident.as_ref(),
         }
     }
 }
@@ -136,7 +136,10 @@ pub trait IntoServiceSpec {
 impl IntoServiceSpec for protocol::ctl::SvcLoad {
     fn into_spec(&self, spec: &mut ServiceSpec) {
         spec.ident = self.ident.clone().unwrap().into();
-        spec.group = self.group.clone().unwrap_or(DEFAULT_GROUP.to_string());
+        spec.group = self
+            .group
+            .clone()
+            .unwrap_or_else(|| DEFAULT_GROUP.to_string());
         if let Some(ref app_env) = self.application_environment {
             spec.application_environment = Some(app_env.clone().into());
         }
@@ -544,7 +547,7 @@ impl Into<ServiceBind> for protocol::types::ServiceBind {
 ///
 /// * bind_map: output of package.bind_map()
 /// * cli_binds: per-service overrides given on the CLI
-fn set_composite_binds(spec: &mut ServiceSpec, bind_map: &mut BindMap, binds: &Vec<ServiceBind>) {
+fn set_composite_binds(spec: &mut ServiceSpec, bind_map: &mut BindMap, binds: &[ServiceBind]) {
     // We'll be layering bind specifications from the composite
     // with any additional ones from the CLI. We'll store them here,
     // keyed to the bind name

--- a/components/sup/src/manager/service/supervisor.rs
+++ b/components/sup/src/manager/service/supervisor.rs
@@ -134,8 +134,7 @@ impl Supervisor {
             let gid = users::get_effective_gid();
 
             let name_for_logging = username
-                .as_ref()
-                .map(|name| name.clone())
+                .clone()
                 .unwrap_or_else(|| format!("anonymous [UID={}]", uid));
             outputln!(preamble self.preamble, "Current user ({}) lacks sufficient capabilites to \
                 run services as a different user; running as self!", name_for_logging);

--- a/components/sup/src/manager/spec_dir.rs
+++ b/components/sup/src/manager/spec_dir.rs
@@ -9,9 +9,9 @@ use glob;
 use super::service::spec::ServiceSpec;
 use crate::error::{Error, Result};
 
-static LOGKEY: &'static str = "SD";
-const SPEC_FILE_EXT: &'static str = "spec";
-const SPEC_FILE_GLOB: &'static str = "*.spec";
+static LOGKEY: &str = "SD";
+const SPEC_FILE_EXT: &str = "spec";
+const SPEC_FILE_GLOB: &str = "*.spec";
 
 #[derive(Debug, Clone)]
 pub struct SpecDir(PathBuf);

--- a/components/sup/src/manager/sys.rs
+++ b/components/sup/src/manager/sys.rs
@@ -84,11 +84,11 @@ impl Sys {
         sys_info.ip = self.ip.to_string();
         sys_info.hostname = self.hostname.clone();
         sys_info.gossip_ip = self.gossip_ip.to_string();
-        sys_info.gossip_port = self.gossip_port as u32;
+        sys_info.gossip_port = u32::from(self.gossip_port);
         sys_info.ctl_gateway_ip = self.ctl_gateway_ip.to_string();
-        sys_info.ctl_gateway_port = self.ctl_gateway_port as u32;
+        sys_info.ctl_gateway_port = u32::from(self.ctl_gateway_port);
         sys_info.http_gateway_ip = self.http_gateway_ip.to_string();
-        sys_info.http_gateway_port = self.http_gateway_port as u32;
+        sys_info.http_gateway_port = u32::from(self.http_gateway_port);
         sys_info
     }
 

--- a/components/sup/src/manager/user_config_watcher.rs
+++ b/components/sup/src/manager/user_config_watcher.rs
@@ -101,8 +101,8 @@ impl UserConfigWatcher {
         let mut states = self.states.lock().expect("states lock was poisoned");
         if states.get(service.name()).is_none() {
             let user_toml_path = match service.user_config_path() {
-                &UserConfigPath::Recommended(ref p) => p.join(USER_CONFIG_FILE),
-                &UserConfigPath::Deprecated(ref p) => {
+                UserConfigPath::Recommended(ref p) => p.join(USER_CONFIG_FILE),
+                UserConfigPath::Deprecated(ref p) => {
                     outputln!(
                         preamble service.service_group(),
                         "Not watching {}, because it is located in deprecated path ({}).",
@@ -362,7 +362,6 @@ mod tests {
                 }
                 Err(TryRecvError::Empty) => {
                     println!("Received nothing on the start_watching channel. Returning ().");
-                    ()
                 }
                 Err(TryRecvError::Disconnected) => {
                     println!("The start_watching channel was disconnected. Returning false.");

--- a/components/sup/src/templating/helpers/each_alive.rs
+++ b/components/sup/src/templating/helpers/each_alive.rs
@@ -48,7 +48,7 @@ impl HelperDef for EachAliveHelper {
                         })
                         .collect();
                     let len = alive_members.len();
-                    for i in 0..len {
+                    for (i, alive_member) in alive_members.iter().enumerate() {
                         let mut local_rc = rc.derive();
                         local_rc.set_local_var("@first".to_string(), to_json(&(i == 0usize)));
                         local_rc.set_local_var("@last".to_string(), to_json(&(i == len - 1)));
@@ -56,7 +56,7 @@ impl HelperDef for EachAliveHelper {
 
                         if let Some(block_param) = h.block_param() {
                             let mut map = BTreeMap::new();
-                            map.insert(block_param.to_string(), to_json(&alive_members[i]));
+                            map.insert(block_param.to_string(), to_json(alive_member));
                             local_rc.push_block_context(&map)?;
                         }
 

--- a/components/sup/src/templating/helpers/mod.rs
+++ b/components/sup/src/templating/helpers/mod.rs
@@ -49,9 +49,9 @@ impl JsonTruthy for Json {
             Json::Bool(ref i) => *i,
             Json::Number(ref n) => n.as_f64().map(|f| f.is_normal()).unwrap_or(false),
             Json::Null => false,
-            Json::String(ref i) => i.len() > 0,
-            Json::Array(ref i) => i.len() > 0,
-            Json::Object(ref i) => i.len() > 0,
+            Json::String(ref i) => !i.is_empty(),
+            Json::Array(ref i) => !i.is_empty(),
+            Json::Object(ref i) => !i.is_empty(),
         }
     }
 }

--- a/components/sup/src/templating/helpers/pkg_path_for.rs
+++ b/components/sup/src/templating/helpers/pkg_path_for.rs
@@ -44,7 +44,7 @@ impl HelperDef for PkgPathForHelper {
                         .into_owned(),
                 )
             })
-            .unwrap_or("".to_string());
+            .unwrap_or_default();
         rc.writer.write_all(target_pkg.into_bytes().as_ref())?;
         Ok(())
     }

--- a/components/sup/src/templating/mod.rs
+++ b/components/sup/src/templating/mod.rs
@@ -122,8 +122,7 @@ mod test {
         let mut config = String::new();
         let _ = file.read_to_string(&mut config).unwrap();
         let toml = toml::de::from_str(&config).unwrap();
-        let data = convert::toml_to_json(toml::Value::Table(toml));
-        data
+        convert::toml_to_json(toml::Value::Table(toml))
     }
 
     #[test]
@@ -253,7 +252,7 @@ test: something"#
         let rendered = renderer.render("t", &data).unwrap();
         assert_eq!(
             PathBuf::from(rendered),
-            PathBuf::from((&*FS_ROOT_PATH).join("/hab/pkgs/core/acl/2.2.52/20161208223311",))
+            (&*FS_ROOT_PATH).join("/hab/pkgs/core/acl/2.2.52/20161208223311",)
         );
     }
 

--- a/components/sup/src/util/convert.rs
+++ b/components/sup/src/util/convert.rs
@@ -19,7 +19,7 @@ use toml;
 
 pub fn toml_to_json(value: toml::Value) -> serde_json::Value {
     match value {
-        toml::Value::String(s) => serde_json::Value::String(format!("{}", s)),
+        toml::Value::String(s) => serde_json::Value::String(s),
         toml::Value::Integer(i) => serde_json::Value::from(i as i64),
         toml::Value::Float(i) => serde_json::Value::from(i as f64),
         toml::Value::Boolean(b) => serde_json::Value::Bool(b),
@@ -41,7 +41,7 @@ fn toml_vec_to_json(toml: Vec<toml::Value>) -> serde_json::Value {
 fn toml_table_to_json(toml: BTreeMap<String, toml::Value>) -> serde_json::Value {
     let mut map = serde_json::Map::with_capacity(toml.len());
     for (key, value) in toml.iter() {
-        map.insert(format!("{}", key), toml_to_json(value.clone()));
+        map.insert(key.to_string(), toml_to_json(value.clone()));
     }
     serde_json::Value::Object(map)
 }

--- a/components/sup/src/util/path.rs
+++ b/components/sup/src/util/path.rs
@@ -29,14 +29,14 @@ static LOGKEY: &'static str = "PT";
 /// The package identifier for the OS specific interpreter which the Supervisor is built with,
 /// or which may be independently installed
 #[cfg(any(target_os = "linux", target_os = "macos"))]
-const INTERPRETER_IDENT: &'static str = "core/busybox-static";
+const INTERPRETER_IDENT: &str = "core/busybox-static";
 #[cfg(any(target_os = "linux", target_os = "macos"))]
-const INTERPRETER_COMMAND: &'static str = "busybox";
+const INTERPRETER_COMMAND: &str = "busybox";
 
 #[cfg(target_os = "windows")]
-const INTERPRETER_IDENT: &'static str = "core/powershell";
+const INTERPRETER_IDENT: &str = "core/powershell";
 #[cfg(target_os = "windows")]
-const INTERPRETER_COMMAND: &'static str = "powershell";
+const INTERPRETER_COMMAND: &str = "powershell";
 
 /// Returns a list of path entries, one of which should contain the interpreter binary.
 ///

--- a/components/sup/tests/utils/hab_root.rs
+++ b/components/sup/tests/utils/hab_root.rs
@@ -46,7 +46,7 @@ impl HabRoot {
         let t = Builder::new()
             .prefix(&s)
             .tempdir()
-            .expect(format!("Could not create temporary directory {}", s).as_str());
+            .unwrap_or_else(|_| panic!("Could not create temporary directory {}", s));
         HabRoot(t)
     }
 
@@ -180,9 +180,9 @@ impl HabRoot {
     {
         let mut buffer = String::new();
         let p = path.as_ref();
-        let mut f = File::open(&p).expect(format!("Couldn't open file {:?}", p).as_str());
+        let mut f = File::open(&p).unwrap_or_else(|_| panic!("Couldn't open file {:?}", p));
         f.read_to_string(&mut buffer)
-            .expect(format!("Couldn't read file {:?}", p).as_str());
+            .unwrap_or_else(|_| panic!("Couldn't read file {:?}", p));
         buffer
     }
 }

--- a/components/sup/tests/utils/mod.rs
+++ b/components/sup/tests/utils/mod.rs
@@ -67,7 +67,7 @@ pub fn setup_package_files<O, P, S>(
         format!("Missing a spec file at {:?}", spec_source)
     );
     fs::copy(&spec_source, &spec_destination)
-        .expect(format!("Could not copy {:?} to {:?}", spec_source, spec_destination).as_str());
+        .unwrap_or_else(|_| panic!("Could not copy {:?} to {:?}", spec_source, spec_destination));
 
     // Copy the expanded package directory over
     let expanded_fixture_dir = fixture_root.expanded_package_dir(&package_name);
@@ -94,10 +94,10 @@ where
     let dest_dir = dest_dir.as_ref().to_path_buf();
 
     fs::create_dir_all(&dest_dir)
-        .expect(format!("Could not create directory {:?}", dest_dir).as_str());
+        .unwrap_or_else(|_| panic!("Could not create directory {:?}", dest_dir));
 
     let source_dir_entries = fs::read_dir(&source_dir)
-        .expect(format!("Could not read entries in {:?}", source_dir).as_str());
+        .unwrap_or_else(|_| panic!("Could not read entries in {:?}", source_dir));
 
     for entry in source_dir_entries {
         let source = entry.unwrap().path();
@@ -105,7 +105,7 @@ where
 
         if source.is_file() {
             fs::copy(&source, &destination)
-                .expect(format!("could not copy {:?} to {:?}", source, destination).as_str());
+                .unwrap_or_else(|_| panic!("could not copy {:?} to {:?}", source, destination));
         } else if source.is_dir() {
             copy_dir(&source, &destination);
         }
@@ -151,12 +151,11 @@ where
     P: AsRef<Path>,
 {
     let mut f = File::create(&metafile)
-        .expect(format!("Could not create metafile {}", metafile.as_ref().display()).as_str());
-    f.write_all(content.as_bytes()).expect(
-        format!(
+        .unwrap_or_else(|_| panic!("Could not create metafile {}", metafile.as_ref().display()));
+    f.write_all(content.as_bytes()).unwrap_or_else(|_| {
+        panic!(
             "Could not write file contents to metafile {}",
             metafile.as_ref().display()
         )
-        .as_str(),
-    );
+    });
 }

--- a/components/sup/tests/utils/test_butterfly.rs
+++ b/components/sup/tests/utils/test_butterfly.rs
@@ -64,20 +64,19 @@ impl Client {
         T: ToString,
     {
         let config = config.to_string();
+        let config = config.as_bytes();
 
         // Validate the TOML, to save you from typos in your tests
-        if let Err(err) = self::toml::de::from_slice::<self::toml::value::Value>(&config.as_bytes())
-        {
+        if let Err(err) = self::toml::de::from_slice::<self::toml::value::Value>(&config) {
             panic!("Invalid TOML! {:?} ==> {:?}", config, err);
         }
 
-        let payload = Vec::from(config.as_bytes());
         let incarnation = Self::new_incarnation();
         self.butterfly_client
             .send_service_config(
                 ServiceGroup::new(None, &self.package_name, &self.service_group, None).unwrap(),
                 incarnation,
-                payload,
+                config,
                 false,
             )
             .expect("Cannot send the service configuration");


### PR DESCRIPTION
Which lints are clearly ones we should fix (and fail on in the future) is subjective, but this is a first cut at making things better, so that we can be more idiomatic, consistent and performant going forward and clippy can help let us know when we stray off the path.

Deciding what to do about the remaining lints in the `UNEXAMINED_LINTS` category in the [Makefile](https://github.com/habitat-sh/habitat/blob/master/Makefile) will be an exercise for another PR.

This is a longer PR than ideal, but since so many of the changes are totally mechanical, I hope it's not totally unworkable. I've tried to call out any changes that are not totally automatic so they can be appropriately scrutinized.

I **highly** recommend viewing this [with whitespace changes hidden](https://github.com/habitat-sh/habitat/pull/6065/files?utf8=✓&diff=split&w=1).

Some changes that occur a lot that might benefit from some explanation:

## Avoiding unnecessary execution
```rust
.expect(&format!(…))
```
→
```rust
.unwrap_or_else(|_| panic!(…))
```
avoids unconditionally evaluating the contents of the `format` macro, and allocating a `String`. The alternative only runs in the case we're panicking. The same goes for constructs like changing `unwrap_or(function_call())` → `unwrap_or_else(|| function_call())` or `unwrap_or(Foo::default())` → `unwrap_or_default()`.

## Avoiding passing unit values
```rust
Ok(result_or_result_returning_func?)
```
→
```rust
result_or_result_returning_func?;
Ok()
```
This isn't terrible on it's own, though it is a bit weird. The real reason it fix it is that it trips the [unit_arg](https://rust-lang-nursery.github.io/rust-clippy/master/index.html#unit_arg) lint, which is something fairly useful. Plus, I think the meaning of:
```rust
Ok(process::become_command(cmd, args)?)
```
is less obvious than
```rust
process::become_command(cmd, args)?;
Ok(())
```