### PR TITLE
Put integration tests behind cargo feature flag

### DIFF
--- a/components/butterfly/Cargo.toml
+++ b/components/butterfly/Cargo.toml
@@ -46,3 +46,4 @@ tempfile = "*"
 [features]
 default = ["protocols"]
 protocols = []
+integration_tests = []

--- a/components/butterfly/tests/encryption/mod.rs
+++ b/components/butterfly/tests/encryption/mod.rs
@@ -18,6 +18,7 @@ use habitat_core::crypto::keys::sym_key::SymKey;
 use crate::btest;
 
 #[test]
+#[cfg_attr(not(feature = "integration_tests"), ignore)]
 fn symmetric_encryption_of_wire_payloads() {
     let ring_key = SymKey::generate_pair_for_ring("wolverine")
         .expect("Failed to generate an in memory symkey");

--- a/components/butterfly/tests/integration.rs
+++ b/components/butterfly/tests/integration.rs
@@ -23,6 +23,7 @@ mod rumor;
 use habitat_butterfly::member::Health;
 
 #[test]
+#[cfg_attr(not(feature = "integration_tests"), ignore)]
 fn two_members_meshed_confirm_one_member() {
     let mut net = btest::SwimNet::new(2);
     net.mesh();
@@ -36,6 +37,7 @@ fn two_members_meshed_confirm_one_member() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "integration_tests"), ignore)]
 fn six_members_meshed_confirm_one_member() {
     let mut net = btest::SwimNet::new(6);
     net.mesh();
@@ -45,6 +47,7 @@ fn six_members_meshed_confirm_one_member() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "integration_tests"), ignore)]
 fn six_members_meshed_partition_one_node_from_another_node_remains_alive() {
     let mut net = btest::SwimNet::new(6);
     trace_it!(TEST_NET: net, "Mesh");
@@ -55,6 +58,7 @@ fn six_members_meshed_partition_one_node_from_another_node_remains_alive() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "integration_tests"), ignore)]
 fn six_members_meshed_partition_half_of_nodes_from_each_other_both_sides_confirmed() {
     let mut net = btest::SwimNet::new(6);
     net.mesh();
@@ -64,6 +68,7 @@ fn six_members_meshed_partition_half_of_nodes_from_each_other_both_sides_confirm
 }
 
 #[test]
+#[cfg_attr(not(feature = "integration_tests"), ignore)]
 fn six_members_unmeshed_become_fully_meshed_via_gossip() {
     let mut net = btest::SwimNet::new(6);
     net.connect(0, 1);
@@ -75,6 +80,7 @@ fn six_members_unmeshed_become_fully_meshed_via_gossip() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "integration_tests"), ignore)]
 fn six_members_unmeshed_confirm_one_member() {
     let mut net = btest::SwimNet::new(6);
     net.connect(0, 1);
@@ -88,6 +94,7 @@ fn six_members_unmeshed_confirm_one_member() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "integration_tests"), ignore)]
 fn six_members_unmeshed_partition_and_rejoin_no_persistent_peers() {
     let mut net = btest::SwimNet::new(6);
     net.connect(0, 1);
@@ -103,6 +110,7 @@ fn six_members_unmeshed_partition_and_rejoin_no_persistent_peers() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "integration_tests"), ignore)]
 fn six_members_unmeshed_partition_and_rejoin_persistent_peers() {
     let mut net = btest::SwimNet::new(6);
     net[0]
@@ -128,6 +136,7 @@ fn six_members_unmeshed_partition_and_rejoin_persistent_peers() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "integration_tests"), ignore)]
 fn six_members_unmeshed_allows_graceful_departure() {
     let mut net = btest::SwimNet::new(6);
     net.connect(0, 1);
@@ -144,6 +153,7 @@ fn six_members_unmeshed_allows_graceful_departure() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "integration_tests"), ignore)]
 fn fifty_members_meshed_confirm_one_member() {
     let mut net = btest::SwimNet::new(50);
     net.mesh();

--- a/components/butterfly/tests/rumor/departure.rs
+++ b/components/butterfly/tests/rumor/departure.rs
@@ -17,6 +17,7 @@ use habitat_butterfly::client::Client;
 use habitat_butterfly::member::Health;
 
 #[test]
+#[cfg_attr(not(feature = "integration_tests"), ignore)]
 fn two_members_share_departures() {
     let mut net = btest::SwimNet::new(2);
     net.mesh();
@@ -28,6 +29,7 @@ fn two_members_share_departures() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "integration_tests"), ignore)]
 #[ignore]
 fn departure_via_client() {
     let mut net = btest::SwimNet::new(3);

--- a/components/butterfly/tests/rumor/election.rs
+++ b/components/butterfly/tests/rumor/election.rs
@@ -18,6 +18,7 @@ use habitat_butterfly::rumor::election::ElectionStatus;
 use crate::btest;
 
 #[test]
+#[cfg_attr(not(feature = "integration_tests"), ignore)]
 fn three_members_run_election() {
     let mut net = btest::SwimNet::new(3);
     net.mesh();
@@ -34,6 +35,7 @@ fn three_members_run_election() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "integration_tests"), ignore)]
 fn three_members_run_election_from_one_starting_rumor() {
     let mut net = btest::SwimNet::new(3);
     net.mesh();
@@ -46,6 +48,7 @@ fn three_members_run_election_from_one_starting_rumor() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "integration_tests"), ignore)]
 #[ignore]
 fn five_members_elect_a_new_leader_when_the_old_one_dies() {
     let mut net = btest::SwimNet::new(5);
@@ -111,6 +114,7 @@ fn five_members_elect_a_new_leader_when_the_old_one_dies() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "integration_tests"), ignore)]
 fn five_members_elect_a_new_leader_when_they_are_quorum_partitioned() {
     let mut net = btest::SwimNet::new_with_suitability(vec![1, 0, 0, 0, 0]);
     net[0]

--- a/components/butterfly/tests/rumor/service.rs
+++ b/components/butterfly/tests/rumor/service.rs
@@ -15,6 +15,7 @@
 use crate::btest;
 
 #[test]
+#[cfg_attr(not(feature = "integration_tests"), ignore)]
 fn two_members_share_services() {
     let mut net = btest::SwimNet::new(2);
     net.mesh();

--- a/components/butterfly/tests/rumor/service_config.rs
+++ b/components/butterfly/tests/rumor/service_config.rs
@@ -17,6 +17,7 @@ use habitat_butterfly::client::Client;
 use habitat_core::service::ServiceGroup;
 
 #[test]
+#[cfg_attr(not(feature = "integration_tests"), ignore)]
 fn two_members_share_service_config() {
     let mut net = btest::SwimNet::new(2);
     net.mesh();
@@ -28,6 +29,7 @@ fn two_members_share_service_config() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "integration_tests"), ignore)]
 fn service_config_via_client() {
     let mut net = btest::SwimNet::new(2);
     net.mesh();

--- a/components/butterfly/tests/rumor/service_file.rs
+++ b/components/butterfly/tests/rumor/service_file.rs
@@ -17,6 +17,7 @@ use habitat_butterfly::client::Client;
 use habitat_core::service::ServiceGroup;
 
 #[test]
+#[cfg_attr(not(feature = "integration_tests"), ignore)]
 fn two_members_share_service_files() {
     let mut net = btest::SwimNet::new(2);
     net.mesh();
@@ -33,6 +34,7 @@ fn two_members_share_service_files() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "integration_tests"), ignore)]
 fn service_file_via_client() {
     let mut net = btest::SwimNet::new(2);
     net.mesh();

--- a/components/sup/Cargo.toml
+++ b/components/sup/Cargo.toml
@@ -85,4 +85,4 @@ git = "https://github.com/habitat-sh/core.git"
 [features]
 default = []
 apidocs = []
-
+integration_tests = []

--- a/components/sup/tests/compilation.rs
+++ b/components/sup/tests/compilation.rs
@@ -31,6 +31,7 @@ lazy_static! {
 }
 
 #[test]
+#[cfg_attr(not(feature = "integration_tests"), ignore)]
 fn config_only_packages_restart_on_config_application() {
     let hab_root = utils::HabRoot::new("config_only_packages_restart_on_config_application");
 
@@ -70,6 +71,7 @@ fn config_only_packages_restart_on_config_application() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "integration_tests"), ignore)]
 fn hook_only_packages_restart_on_config_application() {
     let hab_root = utils::HabRoot::new("hook_only_packages_restart_on_config_application");
 
@@ -109,6 +111,7 @@ fn hook_only_packages_restart_on_config_application() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "integration_tests"), ignore)]
 fn config_files_change_but_hooks_do_not_still_restarts() {
     let hab_root = utils::HabRoot::new("config_files_change_but_hooks_do_not_still_restarts");
 
@@ -156,6 +159,7 @@ hook_value = "default"
 }
 
 #[test]
+#[cfg_attr(not(feature = "integration_tests"), ignore)]
 fn hooks_change_but_config_files_do_not_still_restarts() {
     let hab_root = utils::HabRoot::new("hooks_change_but_config_files_do_not_still_restarts");
 
@@ -203,6 +207,7 @@ hook_value = "applied"
 }
 
 #[test]
+#[cfg_attr(not(feature = "integration_tests"), ignore)]
 fn applying_identical_configuration_results_in_no_changes_and_no_restart() {
     let hab_root = utils::HabRoot::new(
         "applying_identical_configuration_results_in_no_changes_and_no_restart",


### PR DESCRIPTION
Signed-off-by: Scott Hain <shain@chef.io>

⚠️ This will effectively disable these tests from running on every PR, which we may not want to do at this point in time. The tests can be run with `cargo test --feature integration_tests` which should be run prior to release but not necessarily during verification. (This also may be a good time to discuss the value/risk and the line between verification/unit and integration tests)