### PR TITLE
Some code cleanups after #5866

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 UNAME_S := $(shell uname -s)
 HAS_DOCKER := $(shell command -v docker 2> /dev/null)
+TESTING_FS_ROOT := $(shell mktemp -d /tmp/testing-fs-root-XXXXXX)
 ifneq (${IN_DOCKER},)
 	IN_DOCKER := ${IN_DOCKER}
 else ifeq ($(UNAME_S),Darwin)
@@ -186,7 +187,7 @@ $(foreach component,$(ALL),$(eval $(call BUILD,$(component))))
 
 define UNIT
 unit-$1: image ## executes the $1 component's unit test suite
-	$(run) sh -c 'cd components/$1 && cargo test $(CARGO_FLAGS)'
+	$(run) sh -c 'cd components/$1 && TESTING_FS_ROOT=$(TESTING_FS_ROOT) cargo test $(CARGO_FLAGS)'
 .PHONY: unit-$1
 endef
 $(foreach component,$(ALL),$(eval $(call UNIT,$(component))))

--- a/components/common/src/templating/mod.rs
+++ b/components/common/src/templating/mod.rs
@@ -118,6 +118,10 @@ fn never_escape(data: &str) -> String {
 
 #[cfg(test)]
 mod test {
+    use super::*;
+    use crate::hcore::fs::{pkg_root_path, FS_ROOT_PATH};
+    use crate::hcore::package::PackageIdent;
+    use crate::templating::test_helpers::*;
     use serde_json;
     use std::collections::BTreeMap;
     use std::env;
@@ -126,12 +130,6 @@ mod test {
     use std::path::PathBuf;
     use tempfile::TempDir;
     use toml;
-
-    use crate::hcore::fs::FS_ROOT_PATH;
-    use crate::hcore::package::PackageIdent;
-
-    use super::*;
-    use crate::templating::test_helpers::*;
 
     pub fn root() -> PathBuf {
         PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests")
@@ -309,7 +307,7 @@ test: something"#
         let rendered = renderer.render("t", &data).unwrap();
         assert_eq!(
             PathBuf::from(rendered),
-            (&*FS_ROOT_PATH).join("/hab/pkgs/core/acl/2.2.52/20161208223311",)
+            pkg_root_path(Some(&*FS_ROOT_PATH)).join("core/acl/2.2.52/20161208223311",)
         );
     }
 

--- a/components/pkg-export-kubernetes/src/lib.rs
+++ b/components/pkg-export-kubernetes/src/lib.rs
@@ -12,12 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use base64;
 use clap;
 use habitat_common as common;
 use habitat_core as hcore;
 use habitat_pkg_export_docker as export_docker;
-use handlebars;
 
 #[macro_use]
 extern crate serde_json;

--- a/components/sup-protocol/src/lib.rs
+++ b/components/sup-protocol/src/lib.rs
@@ -45,7 +45,6 @@ use habitat_core as core;
 extern crate lazy_static;
 #[macro_use]
 extern crate log;
-use prost;
 #[macro_use]
 extern crate prost_derive;
 

--- a/components/sup/tests/integration.rs
+++ b/components/sup/tests/integration.rs
@@ -20,7 +20,6 @@ extern crate habitat_core as hcore;
 
 #[macro_use]
 extern crate lazy_static;
-use rand;
 
 mod utils;
 

--- a/support/ci/rust_tests.sh
+++ b/support/ci/rust_tests.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-sudo mkdir -p /hab
-sudo chmod o+w /hab
-
 git log HEAD~1..HEAD | grep -q '!!! Temporary Commit !!!'
 is_tmp_commit=$?
 


### PR DESCRIPTION
These are some misc cleanups after #5866 was merged

* Delete unneeded file
* remove some unused exports
* Update Makefile so tests have `TESTING_FS_ROOT` set.  This stops the tests writing to `/hab/svc/test` during a unit test run (or failing if there is no permission to write there)