### PR TITLE
docker windows studio should read the sup log from the new path

### DIFF
--- a/components/studio/bin/hab-studio.ps1
+++ b/components/studio/bin/hab-studio.ps1
@@ -320,8 +320,8 @@ function Enter-Studio {
         # Container studios run habitat as a service which logs to a 
         # configured file location
         $svcPath = Join-Path $env:SystemDrive "hab\svc\windows-service"
-        [xml]$configXml = Get-Content (Join-Path $svcPath HabService.exe.config)
-        $logPath = Join-Path $svcPath $configXml.configuration.log4net.appender.file.value
+        [xml]$configXml = Get-Content (Join-Path $svcPath log4net.xml)
+        $logPath = (Resolve-Path $configXml.log4net.appender.file.value).Path
 
         Get-Content $logPath -Tail 100 -Wait
       }


### PR DESCRIPTION
Related to https://github.com/habitat-sh/windows-service/pull/6

The new Habitat `windows-service` which runs the Supervisor inside the Docker Studio now runs under .Net Core and the path of the configuration file where we set the location of the supervisor log is now different and holds an absolute path.

Signed-off-by: mwrock <matt@mattwrock.com>