### PR TITLE
Simplify hooks test to look for appropriate change

### DIFF
--- a/components/common/src/templating/hooks.rs
+++ b/components/common/src/templating/hooks.rs
@@ -756,11 +756,7 @@ echo "The message is Hola Mundo"
         assert_eq!(hook.compile(&service_group, &ctx).unwrap(), true);
 
         let post_change_content = file_content(&hook);
-        let expected = r#"#!/bin/bash
-
-echo "The message is Hello"
-"#;
-        assert_eq!(post_change_content, expected);
+        assert!(post_change_content.contains("The message is Hello"));
 
         // Compiling again should result in no changes
         assert_eq!(hook.compile(&service_group, &ctx).unwrap(), false);


### PR DESCRIPTION
...rather than full text. This allows us to avoid any issues we may run into with line endings on windows vs unix

Signed-off-by: Scott Hain <shain@chef.io>