### PR TITLE
Add target param to bldr job start command

### DIFF
--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -18,7 +18,7 @@ use std::result;
 use std::str::FromStr;
 
 use crate::hcore::package::ident;
-use crate::hcore::package::{Identifiable, PackageIdent};
+use crate::hcore::package::{Identifiable, PackageIdent, PackageTarget};
 use crate::hcore::{crypto::keys::PairType, service::HealthCheckInterval, service::ServiceGroup};
 use crate::protocol;
 use clap::{App, AppSettings, Arg};
@@ -111,6 +111,8 @@ pub fn get() -> App<'static, 'static> {
                     (aliases: &["s", "st", "sta", "star"])
                     (@arg PKG_IDENT: +required +takes_value {valid_ident}
                         "The origin and name of the package to schedule a job for (eg: core/redis)")
+                    (@arg PKG_TARGET: +takes_value {valid_target}
+                        "A package target (ex: x86_64-windows) (default: x86_64-linux)")
                     (@arg BLDR_URL: -u --url +takes_value {valid_url}
                         "Specify an alternate Builder endpoint. If not specified, the value will \
                          be taken from the cli.toml or HAB_BLDR_URL environment variable if defined. \
@@ -1169,6 +1171,13 @@ fn valid_ident(val: String) -> result::Result<(), String> {
             "'{}' is not valid. Package identifiers have the form origin/name[/version[/release]]",
             &val
         )),
+    }
+}
+
+fn valid_target(val: String) -> result::Result<(), String> {
+    match PackageTarget::from_str(&val) {
+        Ok(_) => Ok(()),
+        Err(_) => Err(format!("'{}' is not valid. A valid target is in the form architecture-platform (example: x86_64-linux)", &val)),
     }
 }
 

--- a/components/hab/src/command/bldr/job/start.rs
+++ b/components/hab/src/command/bldr/job/start.rs
@@ -14,7 +14,7 @@
 
 use crate::api_client::Client;
 use crate::common::ui::{Status, UIReader, UIWriter, UI};
-use crate::hcore::package::PackageIdent;
+use crate::hcore::package::{PackageIdent, PackageTarget};
 
 use crate::error::{Error, Result};
 use crate::{PRODUCT, VERSION};
@@ -23,6 +23,7 @@ pub fn start(
     ui: &mut UI,
     bldr_url: &str,
     ident: &PackageIdent,
+    target: &PackageTarget,
     token: &str,
     group: bool,
 ) -> Result<()> {
@@ -47,10 +48,13 @@ pub fn start(
         }
     }
 
-    ui.status(Status::Creating, format!("build job for {}", ident))?;
+    ui.status(
+        Status::Creating,
+        format!("build job for {} ({})", ident, target),
+    )?;
 
     let id = api_client
-        .schedule_job(ident, !group, token)
+        .schedule_job(ident, target, !group, token)
         .map_err(Error::APIClient)?;
 
     ui.status(Status::Created, format!("build job. The id is {}", id))?;


### PR DESCRIPTION
This change adds a PKG_TARGET param to the 'hab bldr job start' command. It will allow us to request builds for new build targets such as Windows.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-46709735](https://user-images.githubusercontent.com/13542112/51716871-71e72b00-1ff3-11e9-8ac3-62bf32a1a5b3.gif)

