### PR TITLE
Add buildkite based verification pipeline

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -32,3 +32,8 @@ github:
     - release_forever:
         # This version constraint is also arbitrary and will be used for a test branch
         version_constraint: 42*
+
+pipelines:
+  - verify:
+      # Adding a comment to do a thing
+      description: Pull Request validation tests

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -213,7 +213,7 @@ steps:
       - ./test/run_cargo_test.ps1 butterfly -Features "ignore_inconsistent_tests" -TestOptions "--test-threads=1"
     agents:
       queue: 'windows-default'
-    timeout_in_minutes: 30
+    timeout_in_minutes: 35
     retry:
       automatic:
         limit: 1
@@ -223,7 +223,7 @@ steps:
       - ./test/run_cargo_test.ps1 butterfly -TestOptions "--test-threads=1"
     agents:
       queue: 'windows-default'
-    timeout_in_minutes: 30
+    timeout_in_minutes: 35
     retry:
       automatic:
         limit: 10

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -145,7 +145,7 @@ steps:
 
   - label: "[unit] :linux: sup"
     command:
-      - ./test/run_cargo_test.sh --features "inconsistent_tests integration_tests"  sup
+      - ./test/run_cargo_test.sh --features "ignore_inconsistent_tests ignore_integration_tests"  sup
     agents:
       queue: 'docker-privileged'
     plugins:
@@ -155,6 +155,19 @@ steps:
     retry:
       automatic:
         limit: 1
+
+  - label: "[unit][inconsistent] :linux: sup"
+    command:
+      - ./test/run_cargo_test.sh --features "ignore_integration_tests"  sup
+    agents:
+      queue: 'docker-privileged'
+    plugins:
+      docker#v2.1.0:
+        image: "chefes/buildkite"
+    timeout_in_minutes: 10
+    retry:
+      automatic:
+        limit: 10
 
   - label: "[unit] :linux: sup-client"
     command:
@@ -197,13 +210,23 @@ steps:
 
   - label: "[unit] :windows: butterfly"
     command:
-      - ./test/run_cargo_test.ps1 butterfly -Features "inconsistent_tests" -TestOptions "--test-threads=1"
+      - ./test/run_cargo_test.ps1 butterfly -Features "ignore_inconsistent_tests" -TestOptions "--test-threads=1"
     agents:
       queue: 'windows-default'
     timeout_in_minutes: 30
     retry:
       automatic:
         limit: 1
+
+  - label: "[unit][inconsistent] :windows: butterfly"
+    command:
+      - ./test/run_cargo_test.ps1 butterfly -TestOptions "--test-threads=1"
+    agents:
+      queue: 'windows-default'
+    timeout_in_minutes: 30
+    retry:
+      automatic:
+        limit: 10
 
   - label: "[unit] :windows: common"
     command:

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -1,9 +1,297 @@
 steps:
-  - label: "Dummy Step! YAY!"
+  - label: "Shellcheck :linux: :bash:"
+    skip: "Need to update the tests to pass"
     command:
-      - echo "YAY!"
+      - ./test/shellcheck.sh
     agents:
       queue: 'docker-privileged'
     plugins:
       docker#v2.1.0:
         image: "chefes/buildkite"
+    timeout_in_minutes: 10
+    retry:
+      automatic:
+        limit: 1
+
+  - label: "[unit] :linux: builder-api-client"
+    command:
+      - ./test/run_cargo_test.sh builder-api-client
+    agents:
+      queue: 'docker-privileged'
+    plugins:
+      docker#v2.1.0:
+        image: "chefes/buildkite"
+    timeout_in_minutes: 20
+    retry:
+      automatic:
+        limit: 1
+
+  - label: "[unit] :linux: butterfly"
+    command:
+      - ./test/run_cargo_test.sh --test-options "--test-threads=1" butterfly
+    agents:
+      queue: 'docker-privileged'
+    plugins:
+      docker#v2.1.0:
+        image: "chefes/buildkite"
+    timeout_in_minutes: 10
+    retry:
+      automatic:
+        limit: 1
+
+  - label: "[unit] :linux: common"
+    command:
+      - ./test/run_cargo_test.sh common
+    agents:
+      queue: 'docker-privileged'
+    plugins:
+      docker#v2.1.0:
+        image: "chefes/buildkite"
+    timeout_in_minutes: 10
+    retry:
+      automatic:
+        limit: 1
+
+  - label: "[unit] :linux: hab"
+    command:
+      - ./test/run_cargo_test.sh hab
+    agents:
+      queue: 'docker-privileged'
+    plugins:
+      docker#v2.1.0:
+        image: "chefes/buildkite"
+    timeout_in_minutes: 10
+    retry:
+      automatic:
+        limit: 1
+
+  - label: "[unit] :linux: launcher-client"
+    command:
+      - ./test/run_cargo_test.sh launcher-client
+    agents:
+      queue: 'docker-privileged'
+    plugins:
+      docker#v2.1.0:
+        image: "chefes/buildkite"
+    timeout_in_minutes: 10
+    retry:
+      automatic:
+        limit: 1
+
+  - label: "[unit] :linux: launcher-protocol"
+    command:
+      - ./test/run_cargo_test.sh launcher-protocol
+    agents:
+      queue: 'docker-privileged'
+    plugins:
+      docker#v2.1.0:
+        image: "chefes/buildkite"
+    timeout_in_minutes: 10
+    retry:
+      automatic:
+        limit: 1
+
+  - label: "[unit] :linux: pkg-export-docker"
+    command:
+      - ./test/run_cargo_test.sh pkg-export-docker
+    agents:
+      queue: 'docker-privileged'
+    plugins:
+      docker#v2.1.0:
+        image: "chefes/buildkite"
+    timeout_in_minutes: 10
+    retry:
+      automatic:
+        limit: 1
+
+  - label: "[unit] :linux: pkg-export-helm"
+    command:
+      - ./test/run_cargo_test.sh pkg-export-helm
+    agents:
+      queue: 'docker-privileged'
+    plugins:
+      docker#v2.1.0:
+        image: "chefes/buildkite"
+    timeout_in_minutes: 10
+    retry:
+      automatic:
+        limit: 1
+
+  - label: "[unit] :linux: pkg-export-kubernetes"
+    command:
+      - ./test/run_cargo_test.sh pkg-export-kubernetes
+    agents:
+      queue: 'docker-privileged'
+    plugins:
+      docker#v2.1.0:
+        image: "chefes/buildkite"
+    timeout_in_minutes: 10
+    retry:
+      automatic:
+        limit: 1
+
+  - label: "[unit] :linux: pkg-export-tar"
+    command:
+      - ./test/run_cargo_test.sh pkg-export-tar
+    agents:
+      queue: 'docker-privileged'
+    plugins:
+      docker#v2.1.0:
+        image: "chefes/buildkite"
+    timeout_in_minutes: 10
+    retry:
+      automatic:
+        limit: 1
+
+  - label: "[unit] :linux: sup"
+    command:
+      - ./test/run_cargo_test.sh --features "inconsistent_tests integration_tests"  sup
+    agents:
+      queue: 'docker-privileged'
+    plugins:
+      docker#v2.1.0:
+        image: "chefes/buildkite"
+    timeout_in_minutes: 10
+    retry:
+      automatic:
+        limit: 1
+
+  - label: "[unit] :linux: sup-client"
+    command:
+      - ./test/run_cargo_test.sh sup-client
+    agents:
+      queue: 'docker-privileged'
+    plugins:
+      docker#v2.1.0:
+        image: "chefes/buildkite"
+    timeout_in_minutes: 10
+    retry:
+      automatic:
+        limit: 1
+
+  - label: "[unit] :linux: sup-protocol"
+    command:
+      - ./test/run_cargo_test.sh sup-protocol
+    agents:
+      queue: 'docker-privileged'
+    plugins:
+      docker#v2.1.0:
+        image: "chefes/buildkite"
+    timeout_in_minutes: 10
+    retry:
+      automatic:
+        limit: 1
+
+ #################################################################
+
+
+  - label: "[unit] :windows: builder-api-client"
+    command:
+      - ./test/run_cargo_test.ps1 builder-api-client
+    agents:
+      queue: 'windows-default'
+    timeout_in_minutes: 15
+    retry:
+      automatic:
+        limit: 1
+
+  - label: "[unit] :windows: butterfly"
+    command:
+      - ./test/run_cargo_test.ps1 butterfly -Features "inconsistent_tests" -TestOptions "--test-threads=1"
+    agents:
+      queue: 'windows-default'
+    timeout_in_minutes: 30
+    retry:
+      automatic:
+        limit: 1
+
+  - label: "[unit] :windows: common"
+    command:
+      - ./test/run_cargo_test.ps1 common -TestOptions "--test-threads=1"
+    agents:
+      queue: 'windows-default'
+    timeout_in_minutes: 20
+    retry:
+      automatic:
+        limit: 1
+
+  - label: "[unit] :windows: hab"
+    command:
+      - ./test/run_cargo_test.ps1 hab
+    agents:
+      queue: 'windows-default'
+    timeout_in_minutes: 20
+    retry:
+      automatic:
+        limit: 1
+
+  - label: "[unit] :windows: launcher-client"
+    command:
+      - ./test/run_cargo_test.ps1 launcher-client
+    agents:
+      queue: 'windows-default'
+    timeout_in_minutes: 10
+    retry:
+      automatic:
+        limit: 1
+
+  - label: "[unit] :windows: launcher-protocol"
+    command:
+      - ./test/run_cargo_test.ps1 launcher-protocol
+    agents:
+      queue: 'windows-default'
+    timeout_in_minutes: 10
+    retry:
+      automatic:
+        limit: 1
+
+  - label: "[unit] :windows: pkg-export-docker"
+    command:
+      - ./test/run_cargo_test.ps1 pkg-export-docker
+    agents:
+      queue: 'windows-default'
+    timeout_in_minutes: 20
+    retry:
+      automatic:
+        limit: 1
+
+  - label: "[unit] :windows: pkg-export-tar"
+    command:
+      - ./test/run_cargo_test.ps1 pkg-export-tar
+    agents:
+      queue: 'windows-default'
+    timeout_in_minutes: 20
+    retry:
+      automatic:
+        limit: 1
+
+  - label: "[unit] :windows: sup"
+    command:
+      # This test has test (not code) concurrency issues and will fail if we don't limit it
+      - ./test/run_cargo_test.ps1 sup -TestOptions "--test-threads=1"
+    agents:
+      queue: 'windows-default'
+    timeout_in_minutes: 35
+    retry:
+      automatic:
+        limit: 1
+
+  - label: "[unit] :windows: sup-client"
+    command:
+      - ./test/run_cargo_test.ps1 sup-client
+    agents:
+      queue: 'windows-default'
+    timeout_in_minutes: 20
+    retry:
+      automatic:
+        limit: 1
+
+  - label: "[unit] :windows: sup-protocol"
+    command:
+      - ./test/run_cargo_test.ps1 sup-protocol
+    agents:
+      queue: 'windows-default' 
+    timeout_in_minutes: 20
+    retry:
+      automatic:
+        limit: 1

--- a/VERIFICATION_TESTING.md
+++ b/VERIFICATION_TESTING.md
@@ -1,0 +1,22 @@
+## PR Verification Testing
+
+All components of habitat are tested when PRs are created. The helper scripts are designed to run against a single component (such as `common`), in an environment that has habitat and rust preinstalled.
+
+#### Linux
+```
+./test/run_cargo_test.sh <component>
+```
+*Parameters:*
+`--test-options` - allows you to pass options such as `--test-threads=1` to the cargo test command.
+`--features` - allows you to enable specific features when running tests.
+
+#### Windows (powershell 5+)
+```
+./test/run_cargo_test.ps1 <component>
+```
+*Parameters:*
+`--TestOptions` - allows you to pass options such as `--test-threads=1` to the cargo test command.
+`--Features` - allows you to enable specific features when running tests.
+
+####Examples
+See [verify.pipeline.yml](.expeditor/verify.pipeline.yml) for a full list of what is run in the CI pipeline, and what parameters are used.

--- a/components/butterfly/Cargo.toml
+++ b/components/butterfly/Cargo.toml
@@ -47,4 +47,4 @@ tempfile = "*"
 [features]
 default = ["protocols"]
 protocols = []
-inconsistent_tests = []
+ignore_inconsistent_tests = []

--- a/components/butterfly/Cargo.toml
+++ b/components/butterfly/Cargo.toml
@@ -47,3 +47,4 @@ tempfile = "*"
 [features]
 default = ["protocols"]
 protocols = []
+inconsistent_tests = []

--- a/components/butterfly/tests/integration.rs
+++ b/components/butterfly/tests/integration.rs
@@ -144,7 +144,7 @@ fn six_members_unmeshed_allows_graceful_departure() {
 }
 
 #[test]
-#[cfg_attr(feature = "inconsistent_tests", ignore)]
+#[cfg_attr(feature = "ignore_inconsistent_tests", ignore)]
 fn fifty_members_meshed_confirm_one_member() {
     let mut net = btest::SwimNet::new(50);
     net.mesh();

--- a/components/butterfly/tests/integration.rs
+++ b/components/butterfly/tests/integration.rs
@@ -144,6 +144,7 @@ fn six_members_unmeshed_allows_graceful_departure() {
 }
 
 #[test]
+#[cfg_attr(feature = "inconsistent_tests", ignore)]
 fn fifty_members_meshed_confirm_one_member() {
     let mut net = btest::SwimNet::new(50);
     net.mesh();

--- a/components/butterfly/tests/rumor/election.rs
+++ b/components/butterfly/tests/rumor/election.rs
@@ -111,7 +111,7 @@ fn five_members_elect_a_new_leader_when_the_old_one_dies() {
 }
 
 #[test]
-#[cfg_attr(feature = "inconsistent_tests", ignore)]
+#[cfg_attr(feature = "ignore_inconsistent_tests", ignore)]
 fn five_members_elect_a_new_leader_when_they_are_quorum_partitioned() {
     let mut net = btest::SwimNet::new_with_suitability(vec![1, 0, 0, 0, 0]);
     net[0]

--- a/components/butterfly/tests/rumor/election.rs
+++ b/components/butterfly/tests/rumor/election.rs
@@ -111,6 +111,7 @@ fn five_members_elect_a_new_leader_when_the_old_one_dies() {
 }
 
 #[test]
+#[cfg_attr(feature = "inconsistent_tests", ignore)]
 fn five_members_elect_a_new_leader_when_they_are_quorum_partitioned() {
     let mut net = btest::SwimNet::new_with_suitability(vec![1, 0, 0, 0, 0]);
     net[0]

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -1705,12 +1705,15 @@ fn resolve_listen_ctl_addr(input: &str) -> Result<ListenCtlAddr> {
     listen_ctl_addr
         .to_socket_addrs()
         .and_then(|mut addrs| {
-            addrs.next().ok_or_else(|| {
-                io::Error::new(
-                    io::ErrorKind::AddrNotAvailable,
-                    "Address could not be resolved.",
-                )
-            })
+            addrs
+                .filter(std::net::SocketAddr::is_ipv4)
+                .next()
+                .ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::AddrNotAvailable,
+                        "Address could not be resolved.",
+                    )
+                })
         })
         .map(ListenCtlAddr::from)
         .map_err(|e| Error::RemoteSupResolutionError(listen_ctl_addr, e))

--- a/components/sup/Cargo.toml
+++ b/components/sup/Cargo.toml
@@ -81,5 +81,5 @@ git = "https://github.com/habitat-sh/core.git"
 [features]
 default = []
 apidocs = []
-inconsistent_tests = []
-integration_tests = []
+ignore_inconsistent_tests = []
+ignore_integration_tests = []

--- a/components/sup/Cargo.toml
+++ b/components/sup/Cargo.toml
@@ -81,4 +81,5 @@ git = "https://github.com/habitat-sh/core.git"
 [features]
 default = []
 apidocs = []
-
+inconsistent_tests = []
+integration_tests = []

--- a/components/sup/tests/integration.rs
+++ b/components/sup/tests/integration.rs
@@ -30,6 +30,7 @@ lazy_static! {
 }
 
 #[test]
+#[cfg_attr(feature = "inconsistent_tests", ignore)]
 fn config_only_packages_restart_on_config_application() {
     let hab_root = utils::HabRoot::new("config_only_packages_restart_on_config_application");
 
@@ -69,6 +70,7 @@ fn config_only_packages_restart_on_config_application() {
 }
 
 #[test]
+#[cfg_attr(feature = "inconsistent_tests", ignore)]
 fn hook_only_packages_restart_on_config_application() {
     let hab_root = utils::HabRoot::new("hook_only_packages_restart_on_config_application");
 
@@ -108,6 +110,7 @@ fn hook_only_packages_restart_on_config_application() {
 }
 
 #[test]
+#[cfg_attr(feature = "inconsistent_tests", ignore)]
 fn config_files_change_but_hooks_do_not_still_restarts() {
     let hab_root = utils::HabRoot::new("config_files_change_but_hooks_do_not_still_restarts");
 
@@ -155,6 +158,7 @@ hook_value = "default"
 }
 
 #[test]
+#[cfg_attr(feature = "inconsistent_tests", ignore)]
 fn hooks_change_but_config_files_do_not_still_restarts() {
     let hab_root = utils::HabRoot::new("hooks_change_but_config_files_do_not_still_restarts");
 
@@ -202,6 +206,7 @@ hook_value = "applied"
 }
 
 #[test]
+#[cfg_attr(feature = "inconsistent_tests", ignore)]
 fn applying_identical_configuration_results_in_no_changes_and_no_restart() {
     let hab_root = utils::HabRoot::new(
         "applying_identical_configuration_results_in_no_changes_and_no_restart",
@@ -251,6 +256,7 @@ hook_value = "default"
 }
 
 #[test]
+#[cfg_attr(feature = "integration_tests", ignore)]
 fn install_hook_success() {
     let hab_root = utils::HabRoot::new("install_hook_success");
 
@@ -292,6 +298,7 @@ fn install_hook_success() {
 }
 
 #[test]
+#[cfg_attr(feature = "integration_tests", ignore)]
 fn package_with_successful_install_hook_in_dependency_is_loaded() {
     let hab_root =
         utils::HabRoot::new("package_with_successful_install_hook_in_dependency_is_loaded");
@@ -335,6 +342,7 @@ fn package_with_successful_install_hook_in_dependency_is_loaded() {
 }
 
 #[test]
+#[cfg_attr(feature = "integration_tests", ignore)]
 fn install_hook_fails() {
     let hab_root = utils::HabRoot::new("install_hook_fails");
 
@@ -377,6 +385,7 @@ fn install_hook_fails() {
 }
 
 #[test]
+#[cfg_attr(feature = "integration_tests", ignore)]
 fn package_with_failing_install_hook_in_dependency_is_not_loaded() {
     let hab_root =
         utils::HabRoot::new("package_with_failing_install_hook_in_dependency_is_not_loaded");

--- a/components/sup/tests/integration.rs
+++ b/components/sup/tests/integration.rs
@@ -30,7 +30,7 @@ lazy_static! {
 }
 
 #[test]
-#[cfg_attr(feature = "inconsistent_tests", ignore)]
+#[cfg_attr(feature = "ignore_integration_tests", ignore)]
 fn config_only_packages_restart_on_config_application() {
     let hab_root = utils::HabRoot::new("config_only_packages_restart_on_config_application");
 
@@ -70,7 +70,7 @@ fn config_only_packages_restart_on_config_application() {
 }
 
 #[test]
-#[cfg_attr(feature = "inconsistent_tests", ignore)]
+#[cfg_attr(feature = "ignore_integration_tests", ignore)]
 fn hook_only_packages_restart_on_config_application() {
     let hab_root = utils::HabRoot::new("hook_only_packages_restart_on_config_application");
 
@@ -110,7 +110,7 @@ fn hook_only_packages_restart_on_config_application() {
 }
 
 #[test]
-#[cfg_attr(feature = "inconsistent_tests", ignore)]
+#[cfg_attr(feature = "ignore_integration_tests", ignore)]
 fn config_files_change_but_hooks_do_not_still_restarts() {
     let hab_root = utils::HabRoot::new("config_files_change_but_hooks_do_not_still_restarts");
 
@@ -158,7 +158,7 @@ hook_value = "default"
 }
 
 #[test]
-#[cfg_attr(feature = "inconsistent_tests", ignore)]
+#[cfg_attr(feature = "ignore_integration_tests", ignore)]
 fn hooks_change_but_config_files_do_not_still_restarts() {
     let hab_root = utils::HabRoot::new("hooks_change_but_config_files_do_not_still_restarts");
 
@@ -206,7 +206,7 @@ hook_value = "applied"
 }
 
 #[test]
-#[cfg_attr(feature = "inconsistent_tests", ignore)]
+#[cfg_attr(feature = "ignore_integration_tests", ignore)]
 fn applying_identical_configuration_results_in_no_changes_and_no_restart() {
     let hab_root = utils::HabRoot::new(
         "applying_identical_configuration_results_in_no_changes_and_no_restart",
@@ -256,7 +256,7 @@ hook_value = "default"
 }
 
 #[test]
-#[cfg_attr(feature = "integration_tests", ignore)]
+#[cfg_attr(feature = "ignore_integration_tests", ignore)]
 fn install_hook_success() {
     let hab_root = utils::HabRoot::new("install_hook_success");
 
@@ -298,7 +298,7 @@ fn install_hook_success() {
 }
 
 #[test]
-#[cfg_attr(feature = "integration_tests", ignore)]
+#[cfg_attr(feature = "ignore_integration_tests", ignore)]
 fn package_with_successful_install_hook_in_dependency_is_loaded() {
     let hab_root =
         utils::HabRoot::new("package_with_successful_install_hook_in_dependency_is_loaded");
@@ -342,7 +342,7 @@ fn package_with_successful_install_hook_in_dependency_is_loaded() {
 }
 
 #[test]
-#[cfg_attr(feature = "integration_tests", ignore)]
+#[cfg_attr(feature = "ignore_integration_tests", ignore)]
 fn install_hook_fails() {
     let hab_root = utils::HabRoot::new("install_hook_fails");
 
@@ -385,7 +385,7 @@ fn install_hook_fails() {
 }
 
 #[test]
-#[cfg_attr(feature = "integration_tests", ignore)]
+#[cfg_attr(feature = "ignore_integration_tests", ignore)]
 fn package_with_failing_install_hook_in_dependency_is_not_loaded() {
     let hab_root =
         utils::HabRoot::new("package_with_failing_install_hook_in_dependency_is_not_loaded");

--- a/test/run_cargo_test.ps1
+++ b/test/run_cargo_test.ps1
@@ -1,0 +1,71 @@
+#!/usr/bin/env powershell
+
+#Requires -Version 5
+
+param (
+    # The name of the component to be built. Defaults to none
+    [string]$Component,
+    # Features to pass to cargo
+    [string]$Features,
+    # Options to pass to the cargo test command
+    [string]$TestOptions
+)
+
+$ErrorActionPreference="stop"
+$env:RUSTUP_HOME="C:\rust\.rustup"
+$env:CARGO_HOME="C:\rust\.cargo"
+$env:Path="$env:Path;$env:CARGO_HOME\bin"
+
+If($Features) {
+    $FeatureString = "--features $Features"
+} Else {
+    $FeatureString = ""
+}
+
+# Set cargo test invocation
+$CargoTestCommand = "cargo test $FeatureString -- --nocapture $TestOptions"
+
+choco install habitat -y
+
+Write-Host "--- Installing required prerequisites"
+hab pkg install core/cacerts
+hab pkg install core/libarchive
+hab pkg install core/libsodium
+hab pkg install core/openssl
+hab pkg install core/protobuf
+hab pkg install core/xz
+hab pkg install core/zeromq
+hab pkg install core/zlib
+
+# Set up some path variables for ease of use later
+$cacertsDir     = & hab pkg path core/cacerts
+$libarchiveDir  = & hab pkg path core/libarchive
+$libsodiumDir   = & hab pkg path core/libsodium
+$opensslDir     = & hab pkg path core/openssl
+$protobufDir    = & hab pkg path core/protobuf
+$xzDir          = & hab pkg path core/xz
+$zeromqDir      = & hab pkg path core/zeromq
+$zlibDir        = & hab pkg path core/zlib
+
+# Set some required variables
+$env:SODIUM_LIB_DIR             = "$libsodiumDir\lib"
+$env:LIBARCHIVE_INCLUDE_DIR     = "$libarchiveDir\include"
+$env:LIBARCHIVE_LIB_DIR         = "$libarchiveDir\lib"
+$env:OPENSSL_LIBS               = 'ssleay32:libeay32'
+$env:OPENSSL_LIB_DIR            = "$opensslDir\lib"
+$env:OPENSSL_INCLUDE_DIR        = "$opensslDir\include"
+$env:LIBZMQ_PREFIX              = "$zeromqDir"
+$env:SSL_CERT_FILE              = "$cacertsDir\ssl\certs\cacert.pem"
+$env:SODIUM_STATIC              = "true"
+$env:OPENSSL_STATIC             = "true"
+$env:LD_LIBRARY_PATH            = "$env:LIBZMQ_PREFIX\lib;$env:SODIUM_LIB_DIR;$zlibDir\lib;$xzDir\lib"
+
+# Make sure protoc is on the path, we also need to make sure the DLLs (in \bin) are on the path,
+# because windows library pathing is weird and terrifying.
+$env:Path="$env:Path;$protobufDir\bin;$zeromqDir\bin;$libarchiveDir\bin;$libsodiumDir\bin;$zlibDir\bin;$xzDir\bin;$opensslDir\bin"
+
+Write-Host "--- Running cargo test on $Component with command: '$CargoTestCommand'"
+cd components/$Component
+Invoke-Expression $CargoTestCommand
+
+if ($LASTEXITCODE -ne 0) {exit $LASTEXITCODE}

--- a/test/run_cargo_test.sh
+++ b/test/run_cargo_test.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+set -eou pipefail
+
+while [[ $# -gt 1 ]]; do
+  case $1 in
+    -f | --features )       shift
+                            features=$1
+                            ;;
+    -t | --test-options )   shift
+                            test_options=$1
+                            ;;
+    * )                     echo "FAIL SCHOONER"
+                            exit 1
+  esac
+  shift
+done
+
+# set the features string if needed
+[ -z "${features:-}" ] && features_string="" || features_string="--features ${features}"
+
+component=${1?component argument required}
+cargo_test_command="cargo test ${features_string} -- --nocapture ${test_options:-}"
+
+hab pkg install core/bzip2
+hab pkg install core/libarchive
+hab pkg install core/libsodium
+hab pkg install core/openssl
+hab pkg install core/xz
+hab pkg install core/zeromq
+hab pkg install core/protobuf --binlink
+export SODIUM_STATIC=true # so the libarchive crate links to sodium statically
+export LIBARCHIVE_STATIC=true # so the libarchive crate *builds* statically
+export OPENSSL_DIR # so the openssl crate knows what to build against
+OPENSSL_DIR="$(hab pkg path core/openssl)"
+export OPENSSL_STATIC=true # so the openssl crate builds statically
+export LIBZMQ_PREFIX
+LIBZMQ_PREFIX=$(hab pkg path core/zeromq)
+# now include openssl and zeromq so thney exists in the runtime library path when cargo test is run
+export LD_LIBRARY_PATH
+LD_LIBRARY_PATH="$(hab pkg path core/libsodium)/lib:$(hab pkg path core/zeromq)/lib"
+# include these so that the cargo tests can bind to libarchive (which dynamically binds to xz, bzip, etc), openssl, and sodium at *runtime*
+export LIBRARY_PATH
+LIBRARY_PATH="$(hab pkg path core/bzip2)/lib:$(hab pkg path core/libsodium)/lib:$(hab pkg path core/openssl)/lib:$(hab pkg path core/xz)/lib"
+# setup pkgconfig so the libarchive crate can use pkg-config to fine bzip2 and xz at *build* time
+export PKG_CONFIG_PATH
+PKG_CONFIG_PATH="$(hab pkg path core/libarchive)/lib/pkgconfig:$(hab pkg path core/libsodium)/lib/pkgconfig:$(hab pkg path core/openssl)/lib/pkgconfig"
+
+echo "--- Running cargo test on $component with command: '$cargo_test_command'"
+ cd "components/$component"
+$cargo_test_command


### PR DESCRIPTION
Signed-off-by: Scott Hain <shain@chef.io>

(I would have had these 3 things in separate commits but I accidentally squashed too much)

I've also added two (initial) features that represent `inconsistent_tests` and `integration_tests` - these currently do not function correctly in buildkite and need to be addressed.

~In addition to that, I've modified some of the hook tests slightly to match on the specific text, rather than the entire explicit file contents. This was done to avoid issues with `\n` vs `\r\n` on linux vs windows. (credit to @christophermaier and @raskchanky for help on this fix!)~ This is no longer needed due to the fix mwrock pointed out.

Finally, I've modified the `resolve_listen_ctl_addr` function to explicitly filter for ipv4 addresses. (credit to @baumanj for the actual code and explaining the rust to me!) This was causing issues on windows when ipv4 and ipv6 were both enabled. Since hab doesn't currently support ipv6, we're now explicitly setting ipv4 in this section.