### PR TITLE
install interpreter if not already installed

### DIFF
--- a/components/common/Cargo.toml
+++ b/components/common/Cargo.toml
@@ -3,6 +3,7 @@ name = "habitat_common"
 version = "0.0.0"
 edition = "2018"
 authors = ["Adam Jacob <adam@chef.io>", "Jamie Winsor <reset@chef.io>", "Fletcher Nichol <fnichol@chef.io>", "Joshua Timberman <joshua@chef.io>", "Dave Parfitt <dparfitt@chef.io>"]
+build = "../build-habitat.rs"
 workspace = "../../"
 
 [dependencies]


### PR DESCRIPTION
This installs the interpreter if it is not installed and addresses a bug found when executing an install hook on a fresh hab install where powershell or busybox is not installed.

Signed-off-by: mwrock <matt@mattwrock.com>