### PR TITLE
Don't copy the entire member list when choosing PingReq values

### DIFF
--- a/components/butterfly/src/server/outbound.rs
+++ b/components/butterfly/src/server/outbound.rs
@@ -224,7 +224,7 @@ impl Outbound {
                         .with_label_values(&["pingreq/ack"])
                         .start_timer(),
                 );
-                pingreq(&self.server, &self.socket, &pingreq_target, &member);
+                pingreq(&self.server, &self.socket, pingreq_target, &member);
             },
         );
 


### PR DESCRIPTION
When choosing PingReq targets for SWIM, we want to randomly choose 5 members which are:
1. Alive
2. Not the the member doing the sending

Previously we cloned the entire member list, shuffled it, filtered out the members that didn't satisfy (1) or (2), and then took the first 5 values.

To avoid unnecessary allocation and copying, we can instead use [rand::seq::IteratorRandom::choose_multiple](https://rust-random.github.io/rand/rand/seq/trait.IteratorRandom.html#method.choose_multiple) to allocate space for and copy only the 5 values we need to return. Additionally, we can return member references rather than owned values to further reduce overhead.