### PR TITLE
[ci/mac] Upgrade to macOS 10.12 for build workers.

### DIFF
--- a/.buildkite/release_pipeline.yaml
+++ b/.buildkite/release_pipeline.yaml
@@ -59,7 +59,7 @@ steps:
       # they're also not being used by anyone else.
       queue: omnibus
       os: Darwin
-      "os:version": 10.11 # Build statically on the oldest thing we can
+      "os:version": 10.12 # Build statically on the oldest thing we can
 
   - wait
 


### PR DESCRIPTION
This change will cause all builds of `core/hab` on macOS to use version
10.12. Prior to this change 10.11 was used but this infrastructure was
retired within the last couple of weeks.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>