### PR TITLE
Classify the remaining unfixed clippy lints as ones to fix versus ignore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,18 +194,18 @@ UNEXAMINED_LINTS =
 
 # Lints we disagree with and choose to keep in our code with no warning
 ALLOWED_LINTS = clippy::module_inception \
-                clippy::needless_return \
                 clippy::new_ret_no_self \
                 clippy::new_without_default \
-                clippy::new_without_default_derive \
-                clippy::redundant_field_names
+                clippy::new_without_default_derive
 
 # Known failing lints we want to receive warnings for, but not fail the build
 LINTS_TO_FIX = clippy::cyclomatic_complexity \
                clippy::large_enum_variant \
                clippy::len_without_is_empty \
                clippy::needless_pass_by_value \
+               clippy::needless_return \
                clippy::question_mark \
+               clippy::redundant_field_names \
                clippy::too_many_arguments \
                clippy::trivially_copy_pass_by_ref \
                clippy::wrong_self_convention

--- a/Makefile
+++ b/Makefile
@@ -190,26 +190,25 @@ unit-sup: build-launcher-for-supervisor-tests
 .PHONY: build-launcher-for-supervisor-tests
 
 # Lints we need to work through and decide as a team whether to allow or fix
-UNEXAMINED_LINTS = clippy::cyclomatic_complexity \
-                   clippy::large_enum_variant \
-                   clippy::len_without_is_empty \
-                   clippy::module_inception \
-                   clippy::needless_pass_by_value \
-                   clippy::needless_return \
-                   clippy::new_ret_no_self \
-                   clippy::new_without_default \
-                   clippy::new_without_default_derive \
-                   clippy::question_mark \
-                   clippy::redundant_field_names \
-                   clippy::too_many_arguments \
-                   clippy::trivially_copy_pass_by_ref \
-                   clippy::wrong_self_convention
+UNEXAMINED_LINTS =
 
 # Lints we disagree with and choose to keep in our code with no warning
-ALLOWED_LINTS =
+ALLOWED_LINTS = clippy::module_inception \
+                clippy::needless_return \
+                clippy::new_ret_no_self \
+                clippy::new_without_default \
+                clippy::new_without_default_derive \
+                clippy::redundant_field_names
 
 # Known failing lints we want to receive warnings for, but not fail the build
-LINTS_TO_FIX =
+LINTS_TO_FIX = clippy::cyclomatic_complexity \
+               clippy::large_enum_variant \
+               clippy::len_without_is_empty \
+               clippy::needless_pass_by_value \
+               clippy::question_mark \
+               clippy::too_many_arguments \
+               clippy::trivially_copy_pass_by_ref \
+               clippy::wrong_self_convention
 
 # Lints we don't expect to have in our code at all and want to avoid adding
 # even at the cost of failing the build


### PR DESCRIPTION
No code changes here, this is just to confirm our consensus about what our goals and expectations are. For each lint I'm proposing to classify, I've provided an argument.

For the ones in `ALLOWED_LINTS`, I'm explaining why I don't think they're worth fixing. If you agree, give it a 👍. If instead you think we *should* fix the lint, give it a 👎 and give some reasoning.

For the ones in `LINTS_TO_FIX`, it's the opposite. If you agree we should fix them, give it a 👍. If you think it's not worth the effort, please 👎 and say why. The intent is that once all the instances of a given lint in `LINTS_TO_FIX` and fixed (or suppressed with a case-by-case `#[allow(…)]`, we can move them to `DENIED_LINTS`, which will cause them to fail CI.