### PR TITLE
if the studio is rooted immediately under the system drive, do not try to delete it

### DIFF
--- a/components/studio/bin/hab-studio.ps1
+++ b/components/studio/bin/hab-studio.ps1
@@ -419,9 +419,14 @@ function Remove-Studio {
     Write-RmHelp
     return
   }
-  Write-HabInfo "Destroying Studio at $HAB_STUDIO_ROOT"
-
-  if(Test-Path $HAB_STUDIO_ROOT) { Remove-Item $HAB_STUDIO_ROOT -Recurse -Force }
+  if ($HAB_STUDIO_ROOT -eq "$env:SystemDrive\") {
+    Write-HabInfo "Studio is rooted in system drive. Skipping Studio removal."
+  } else {
+    if(Test-Path $HAB_STUDIO_ROOT) {
+      Write-HabInfo "Destroying Studio at $HAB_STUDIO_ROOT"
+      Remove-Item $HAB_STUDIO_ROOT -Recurse -Force
+    }
+  }
 }
 
 function Test-InContainer {


### PR DESCRIPTION
This address a specific scenario where `hab pkg build . -D` breaks on windows containers because the docker studio roots the studio right in `c:\` which you cannot delete. To work around this today, you must pass `-R` to "persist" the studio.

Of course you would not want to delete `c:\` in any scenario whatsoever so this avoids such a removal and emits a message stating that it is not going to remove the system drive.

Signed-off-by: mwrock <matt@mattwrock.com>