### PR TITLE
Only execute the RumorStore::with_rumor closure if there's actually a rumor

### DIFF
--- a/components/butterfly-test/src/lib.rs
+++ b/components/butterfly-test/src/lib.rs
@@ -306,7 +306,7 @@ impl SwimNet {
                 .get(e_num)
                 .expect("Asked for a network member who is out of bounds");
             server.election_store.with_rumor(key, "election", |e| {
-                if e.is_some() && e.unwrap().status == status {
+                if e.status == status {
                     result = true;
                 }
             });
@@ -341,7 +341,7 @@ impl SwimNet {
                 right_server
                     .election_store
                     .with_rumor(key, "election", |r| {
-                        result = l.is_some() && r.is_some() && l.unwrap() == r.unwrap();
+                        result = l == r;
                     });
             });
             if result {

--- a/components/butterfly/src/server/mod.rs
+++ b/components/butterfly/src/server/mod.rs
@@ -1040,7 +1040,7 @@ impl Server {
                 self.election_store
                     .with_rumor(election.key(), election.id(), |ce| {
                         trace!("election_store already contains {:?}", ce);
-                        new_term = election.term > ce.unwrap().term
+                        new_term = election.term > ce.term
                     });
                 if new_term {
                     debug!("removing old rumor and starting new election");
@@ -1139,7 +1139,7 @@ impl Server {
                 self.update_store
                     .with_rumor(election.key(), election.id(), |ce| {
                         trace!("election_store already contains {:?}", ce);
-                        new_term = election.term > ce.unwrap().term
+                        new_term = election.term > ce.term
                     });
                 if new_term {
                     debug!("removing old rumor and starting new election");

--- a/components/butterfly/tests/encryption/mod.rs
+++ b/components/butterfly/tests/encryption/mod.rs
@@ -26,7 +26,7 @@ fn symmetric_encryption_of_wire_payloads() {
     assert_wait_for_health_of!(net, [0..2, 0..2], Health::Alive);
     net.add_service(0, "core/beast/1.2.3/20161208121212");
     net.wait_for_gossip_rounds(2);
-    net[1]
+    assert!(net[1]
         .service_store
-        .with_rumor("beast.prod", net[0].member_id(), |u| assert!(u.is_some()));
+        .contains_rumor("beast.prod", net[0].member_id()));
 }

--- a/components/butterfly/tests/rumor/departure.rs
+++ b/components/butterfly/tests/rumor/departure.rs
@@ -22,9 +22,9 @@ fn two_members_share_departures() {
     net.mesh();
     net.add_departure(0);
     net.wait_for_gossip_rounds(1);
-    net[1]
+    assert!(net[1]
         .departure_store
-        .with_rumor("departure", net[0].member_id(), |u| assert!(u.is_some()));
+        .contains_rumor("departure", net[0].member_id()));
 }
 
 #[test]
@@ -40,8 +40,8 @@ fn departure_via_client() {
         .send_departure(String::from(net[1].member_id()))
         .expect("Cannot send the departure");
     net.wait_for_gossip_rounds(1);
-    net[2]
+    assert!(net[2]
         .departure_store
-        .with_rumor("departure", net[1].member_id(), |u| assert!(u.is_some()));
+        .contains_rumor("departure", net[1].member_id()));
     assert_wait_for_health_of!(net, 1, Health::Departed);
 }

--- a/components/butterfly/tests/rumor/election.rs
+++ b/components/butterfly/tests/rumor/election.rs
@@ -63,7 +63,7 @@ fn five_members_elect_a_new_leader_when_the_old_one_dies() {
     net[0]
         .election_store
         .with_rumor("witcher.prod", "election", |e| {
-            leader_id = e.unwrap().member_id.to_string();
+            leader_id = e.member_id.to_string();
         });
 
     let mut paused = 0;
@@ -93,21 +93,11 @@ fn five_members_elect_a_new_leader_when_the_old_one_dies() {
         }
     }
 
-    if paused == 0 {
-        net[1]
-            .election_store
-            .with_rumor("witcher.prod", "election", |e| {
-                assert!(e.unwrap().term == 1);
-                assert!(e.unwrap().member_id != paused_id);
-            });
-    } else {
-        net[0]
-            .election_store
-            .with_rumor("witcher.prod", "election", |e| {
-                assert!(e.unwrap().term == 1);
-                assert!(e.unwrap().member_id != paused_id);
-            });
-    }
+    net[if paused == 0 { 1 } else { 0 }]
+        .election_store
+        .assert_rumor_is("witcher.prod", "election", |e| {
+            e.term == 1 && e.member_id != paused_id
+        });
 }
 
 #[test]
@@ -141,7 +131,7 @@ fn five_members_elect_a_new_leader_when_they_are_quorum_partitioned() {
     net[0]
         .election_store
         .with_rumor("witcher.prod", "election", |e| {
-            leader_id = e.unwrap().member_id.to_string();
+            leader_id = e.member_id.to_string();
         });
 
     assert_eq!(leader_id, net[0].member_id());
@@ -168,13 +158,13 @@ fn five_members_elect_a_new_leader_when_they_are_quorum_partitioned() {
         .election_store
         .with_rumor("witcher.prod", "election", |e| {
             println!("OLD: {:#?}", e);
-            new_leader_id = e.unwrap().member_id.to_string();
+            new_leader_id = e.member_id.to_string();
         });
     net[2]
         .election_store
         .with_rumor("witcher.prod", "election", |e| {
             println!("NEW: {:#?}", e);
-            new_leader_id = e.unwrap().member_id.to_string();
+            new_leader_id = e.member_id.to_string();
         });
     assert!(leader_id != new_leader_id);
     println!("Leader {} New {}", leader_id, new_leader_id);
@@ -191,8 +181,8 @@ fn five_members_elect_a_new_leader_when_they_are_quorum_partitioned() {
 
     net[0]
         .election_store
-        .with_rumor("witcher.prod", "election", |e| {
+        .assert_rumor_is("witcher.prod", "election", |e| {
             println!("MINORITY: {:#?}", e);
-            assert_eq!(new_leader_id, e.unwrap().member_id.to_string());
+            new_leader_id == e.member_id
         });
 }

--- a/components/butterfly/tests/rumor/service.rs
+++ b/components/butterfly/tests/rumor/service.rs
@@ -20,7 +20,7 @@ fn two_members_share_services() {
     net.mesh();
     net.add_service(0, "core/witcher/1.2.3/20161208121212");
     net.wait_for_rounds(2);
-    net[1]
+    assert!(net[1]
         .service_store
-        .with_rumor("witcher.prod", net[0].member_id(), |u| assert!(u.is_some()));
+        .contains_rumor("witcher.prod", net[0].member_id()));
 }

--- a/components/butterfly/tests/rumor/service_config.rs
+++ b/components/butterfly/tests/rumor/service_config.rs
@@ -22,9 +22,9 @@ fn two_members_share_service_config() {
     net.mesh();
     net.add_service_config(0, "witcher", "tcp-backlog = 128");
     net.wait_for_gossip_rounds(1);
-    net[1]
+    assert!(net[1]
         .service_config_store
-        .with_rumor("witcher.prod", "service_config", |u| assert!(u.is_some()));
+        .contains_rumor("witcher.prod", "service_config"));
 }
 
 #[test]
@@ -45,7 +45,7 @@ fn service_config_via_client() {
         )
         .expect("Cannot send the service configuration");
     net.wait_for_gossip_rounds(1);
-    net[1]
+    assert!(net[1]
         .service_config_store
-        .with_rumor("witcher.prod", "service_config", |u| assert!(u.is_some()));
+        .contains_rumor("witcher.prod", "service_config"));
 }

--- a/components/butterfly/tests/rumor/service_file.rs
+++ b/components/butterfly/tests/rumor/service_file.rs
@@ -27,9 +27,9 @@ fn two_members_share_service_files() {
         "I like to have contents in my file",
     );
     net.wait_for_gossip_rounds(1);
-    net[1]
+    assert!(net[1]
         .service_file_store
-        .with_rumor("witcher.prod", "yeppers", |u| assert!(u.is_some()));
+        .contains_rumor("witcher.prod", "yeppers"));
 }
 
 #[test]
@@ -51,9 +51,7 @@ fn service_file_via_client() {
         )
         .expect("Cannot send the service file");
     net.wait_for_gossip_rounds(1);
-    net[1]
+    assert!(net[1]
         .service_file_store
-        .with_rumor("witcher.prod", "devil-wears-prada.txt", |u| {
-            assert!(u.is_some())
-        });
+        .contains_rumor("witcher.prod", "devil-wears-prada.txt"));
 }


### PR DESCRIPTION
This eliminates the need for a lot of unwraps and makes the code clearer. The tradeoff is that we now need `RumorStore::assert_rumor_is`, but only for tests, and that function will provide both more ergonomic calls as well as more informative test output.

