### PR TITLE
[sup] Add `core/make` as a build dependency.

### DIFF
--- a/components/sup/habitat/plan.sh
+++ b/components/sup/habitat/plan.sh
@@ -14,6 +14,7 @@ pkg_deps=(core/busybox-static
           core/zeromq)
 pkg_build_deps=(core/coreutils
                 core/cacerts
+                core/make
                 core/rust
                 core/gcc
                 core/raml2html)


### PR DESCRIPTION
This is now required because the `jemallocator` crate will source
compile a vendored version of jemalloc which requires the `make` program
on PATH.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>