### PR TITLE
Fix error runining install.sh/Dockerfile

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -21,7 +21,6 @@ cd habitat
 Then, run the system preparation scripts
 
 ```
-cp components/hab/install.sh /tmp/
 sh support/linux/install_dev_0_ubuntu_latest.sh
 sh support/linux/install_dev_9_linux.sh
 ```
@@ -58,6 +57,13 @@ The binaries will be in `habitat/target/debug` and can be run directly, or you c
 cd components/sup
 cargo run -- --help
 cargo run -- status
+```
+
+Or from the habitat directory:
+
+```
+cargo run -p hab plan --help
+cargo run -p hab sup --help
 ```
 
 ## Compiling launcher
@@ -248,7 +254,6 @@ cd habitat
 Then, run the system preparation scripts and try to compile the project:
 
 ```
-cp components/hab/install.sh /tmp/
 sh support/linux/install_dev_0_ubuntu_14.04.sh
 sh support/linux/install_dev_9_linux.sh
 . ~/.profile
@@ -278,7 +283,6 @@ cd habitat
 Then, run the system preparation scripts and try to compile the project:
 
 ```
-cp components/hab/install.sh /tmp/
 sh support/linux/install_dev_0_centos_7.sh
 sh support/linux/install_dev_9_linux.sh
 . ~/.profile
@@ -314,7 +318,6 @@ cd habitat
 Then, run the system preparation scripts and try to compile the project:
 
 ```
-cp components/hab/install.sh /tmp/
 sh support/linux/install_dev_0_arch.sh
 sh support/linux/install_dev_9_linux.sh
 . ~/.profile

--- a/support/linux/install_dev_9_linux.sh
+++ b/support/linux/install_dev_9_linux.sh
@@ -45,6 +45,6 @@ else
   sudo -E addgroup --system hab || true
 fi
 
-sudo sh /tmp/install.sh
+sudo bash /tmp/install.sh
 sudo hab install core/busybox-static core/hab-studio
 sudo rm -rf /tmp/install.sh

--- a/support/linux/install_dev_9_linux.sh
+++ b/support/linux/install_dev_9_linux.sh
@@ -45,6 +45,5 @@ else
   sudo -E addgroup --system hab || true
 fi
 
-sudo bash /tmp/install.sh
+sudo "$(dirname -- "$0")/../../components/hab/install.sh"
 sudo hab install core/busybox-static core/hab-studio
-sudo rm -rf /tmp/install.sh


### PR DESCRIPTION
For some reason, even though the shbang line is set to `/bin/bash` `sh` executes `/tmp/install.sh` which fails at line [202](https://github.com/habitat-sh/habitat/blob/master/components/hab/install.sh#L202)

Since we expect `bash` anyway, I changed the invocation of the install script to `bash /tmp/install.sh` instead, (although, why isn't this just executed from `components/hab/install.sh`?) which allows the install script and Dockerfile to complete successfully.