### PR TITLE
Modify script so we can use pipeline upload in the job

### DIFF
--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -28,7 +28,7 @@ if [[ "${FAKE_RELEASE_TAG:-}" || "${BUILDKITE_TAG}" ]]; then
     version=$(cat VERSION)
     set_version "${version}"
 
-    buildkite-agent pipeline upload .buildkite/release_pipeline.yaml
+    cat .buildkite/release_pipeline.yaml
 else
     echo "--- :sparkles: Preparing for a CI run! :sparkles:"
     echo "TODO"


### PR DESCRIPTION
Signed-off-by: Scott Hain <shain@chef.io>

The other half of this fix will be changing the buildkite job setup from
`.buildkite/pipeline.sh`
to
`.buildkite/pipeline.sh | buildkite-agent pipeline upload`