### PR TITLE
Plumb in target into rdeps API

### DIFF
--- a/components/builder-api-client/src/lib.rs
+++ b/components/builder-api-client/src/lib.rs
@@ -362,11 +362,15 @@ impl Client {
     /// # Failures
     ///
     /// * Remote API Server is not available
-    pub fn fetch_rdeps(&self, ident: &PackageIdent) -> Result<Vec<String>> {
+    pub fn fetch_rdeps(&self, ident: &PackageIdent, target: &PackageTarget) -> Result<Vec<String>> {
         debug!("Fetching the reverse dependencies for {}", ident);
 
         let url = format!("rdeps/{}", ident);
-        let mut res = self.0.get(&url).send().map_err(Error::HyperError)?;
+
+        let mut res = self.0.get_with_custom_url(&url, |u| {
+            u.set_query(Some(&format!("target={}", &target.to_string())))
+        }).send().map_err(Error::HyperError)?;
+
         if res.status != StatusCode::Ok {
             return Err(err_from_response(res));
         }

--- a/components/hab/src/command/bldr/job/start.rs
+++ b/components/hab/src/command/bldr/job/start.rs
@@ -30,7 +30,9 @@ pub fn start(
     let api_client = Client::new(bldr_url, PRODUCT, VERSION, None).map_err(Error::APIClient)?;
 
     if group {
-        let rdeps = api_client.fetch_rdeps(ident).map_err(Error::APIClient)?;
+        let rdeps = api_client
+            .fetch_rdeps(ident, target)
+            .map_err(Error::APIClient)?;
         if !rdeps.is_empty() {
             ui.warn("Found the following reverse dependencies:")?;
 


### PR DESCRIPTION
This change updates the rdeps API to take a target param. This fixes a bug with 'hab bldr job start' failing in some cases.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-234381747](https://user-images.githubusercontent.com/13542112/52238499-fc941980-2880-11e9-88aa-1a3de91e745c.gif)
