### PR TITLE
Add flag to skip startup of the supervisors gossip layer

### DIFF
--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -946,6 +946,7 @@ pub fn sub_sup_run() -> App<'static, 'static> {
         Implies NO_COLOR")
     (@arg HEALTH_CHECK_INTERVAL: --("health-check-interval") -i +takes_value {valid_health_check_interval}
         "The interval (seconds) on which to run health checks [default: 30]")
+    (@arg NO_LISTEN_GOSSIP: --("no-listen-gossip") "Don't startup the gossip listener.")
     )
 }
 

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -221,6 +221,7 @@ fn sub_term() -> Result<()> {
 fn mgrcfg_from_sup_run_matches(m: &ArgMatches) -> Result<ManagerConfig> {
     let cfg = ManagerConfig {
         auto_update: m.is_present("AUTO_UPDATE"),
+        no_listen_gossip: m.is_present("NO_LISTEN_GOSSIP"),
         update_url: bldr_url(m),
         update_channel: channel(m),
         http_disable: m.is_present("HTTP_DISABLE"),


### PR DESCRIPTION
Adds a new flag to the cli `--no-listen-gossip` that causes the supervisor to skip startup of the gossip layer. 

To test just start up the supervisor with the `--no-listen-gossip` flag and then try to connect to it with either `telnet` or `netcat` in another terminal.

`hab sup run --no-listen-gossip`

In another terminal
`telnet 127.0.0.1 9638` or `nc 127.0.0.1 9638`

If it's doing what it's supposed to you should **NOT** be successful in connecting.