### PR TITLE
include HAB_FEAT_INSTALL_HOOK in docker studio env_vars

### DIFF
--- a/components/hab/src/command/studio/docker.rs
+++ b/components/hab/src/command/studio/docker.rs
@@ -89,6 +89,7 @@ pub fn start_docker_studio(_ui: &mut UI, mut args: Vec<OsString>) -> Result<()> 
         String::from("HAB_AUTH_TOKEN"),
         String::from("HAB_BLDR_URL"),
         String::from("HAB_BLDR_CHANNEL"),
+        String::from("HAB_FEAT_INSTALL_HOOK"),
         String::from("HAB_NOCOLORING"),
         String::from("HAB_ORIGIN"),
         String::from("HAB_ORIGIN_KEYS"),


### PR DESCRIPTION
fixes #6128 

Signed-off-by: mwrock <matt@mattwrock.com>