### PR TITLE
ensure install hooks do not run from cli if feature is not enabled

### DIFF
--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -668,11 +668,12 @@ fn sub_pkg_install(ui: &mut UI, m: &ArgMatches<'_>) -> Result<()> {
         LocalPackageUsage::default()
     };
 
-    let install_hook_mode = if m.is_present("IGNORE_INSTALL_HOOK") {
-        InstallHookMode::Ignore
-    } else {
-        InstallHookMode::default()
-    };
+    let install_hook_mode =
+        if !feat::is_enabled(feat::InstallHook) || m.is_present("IGNORE_INSTALL_HOOK") {
+            InstallHookMode::Ignore
+        } else {
+            InstallHookMode::default()
+        };
 
     init();
 


### PR DESCRIPTION
This was something that was in my original PR and removed after some code review comments. I just noticed looking at the windows worker builds that the install hooks are running in their studios even though the feature is not enabled. I now recall why this conditional is important.

Signed-off-by: mwrock <matt@mattwrock.com>