### PR TITLE
Generate protobuf code in Supervisor and Launcher package builds

### DIFF
--- a/components/launcher/habitat/plan.sh
+++ b/components/launcher/habitat/plan.sh
@@ -12,7 +12,8 @@ pkg_deps=(core/glibc
 pkg_build_deps=(core/coreutils
                 core/rust
                 core/gcc
-                core/git)
+                core/git
+                core/protobuf)
 pkg_bin_dirs=(bin)
 bin="hab-launch"
 
@@ -25,7 +26,15 @@ do_prepare() {
   export OPENSSL_LIB_DIR=$(pkg_path_for openssl)/lib
   export OPENSSL_INCLUDE_DIR=$(pkg_path_for openssl)/include
   export SODIUM_LIB_DIR=$(pkg_path_for libsodium)/lib
-  
+
+  # Prost (our Rust protobuf library) embeds a `protoc` binary, but
+  # it's dynamically linked, which means it won't work in a
+  # Studio. Prost does allow us to override that, though, so we can
+  # just use our Habitat package by setting these two environment
+  # variables.
+  export PROTOC="$(pkg_path_for protobuf)/bin/protoc"
+  export PROTOC_INCLUDE="$(pkg_path_for protobuf)/include"
+
   # Used to set the active package target for the binaries at build time
   export PLAN_PACKAGE_TARGET="$pkg_target"
   build_line "Setting PLAN_PACKAGE_TARGET=$PLAN_PACKAGE_TARGET"

--- a/components/sup/habitat/plan.sh
+++ b/components/sup/habitat/plan.sh
@@ -17,7 +17,8 @@ pkg_build_deps=(core/coreutils
                 core/make
                 core/rust
                 core/gcc
-                core/raml2html)
+                core/raml2html
+                core/protobuf)
 pkg_bin_dirs=(bin)
 
 bin=$_pkg_distname
@@ -73,6 +74,15 @@ do_prepare() {
   # this used only at build time, we will use the version found in the gcc
   # package proper--it won't find its way into the final binaries.
   export LD_LIBRARY_PATH=$(pkg_path_for gcc)/lib
+
+  # Prost (our Rust protobuf library) embeds a `protoc` binary, but
+  # it's dynamically linked, which means it won't work in a
+  # Studio. Prost does allow us to override that, though, so we can
+  # just use our Habitat package by setting these two environment
+  # variables.
+  export PROTOC="$(pkg_path_for protobuf)/bin/protoc"
+  export PROTOC_INCLUDE="$(pkg_path_for protobuf)/include"
+
   build_line "Setting LD_LIBRARY_PATH=$LD_LIBRARY_PATH"
 }
 


### PR DESCRIPTION
With the transition to always-compiled Protobuf code in our launcher protocol crate (see #6105), we need to add the Protobuf compiler to our package build process.

I suspect this works unmodified on Windows because the Habitat build process is necessarily less of a "clean room" affair. The `prost_build` crate includes a `protoc` binary that it can use, but this doesn't work in our Linux builds because it's linked to non-Habitat libraries.

Signed-off-by: Christopher Maier <cmaier@chef.io>