### PR TITLE
Remove txn_id from Launcher protocol

### DIFF
--- a/components/launcher-protocol/protocols/net.proto
+++ b/components/launcher-protocol/protocols/net.proto
@@ -3,7 +3,9 @@ syntax = "proto2";
 package launcher.net;
 
 message Envelope {
+  reserved 3;
+  reserved "txn_id";
+
   optional string message_id = 1;
   optional bytes payload = 2;
-  optional uint64 txn_id = 3;
 }

--- a/components/launcher-protocol/src/lib.rs
+++ b/components/launcher-protocol/src/lib.rs
@@ -46,9 +46,10 @@ impl NetTxn {
     where
         T: LauncherMessage,
     {
-        let mut env = Envelope::default();
-        env.message_id = T::MESSAGE_ID.to_string();
-        env.payload = message.to_bytes()?;
+        let env = Envelope {
+            message_id: T::MESSAGE_ID.to_string(),
+            payload: message.to_bytes()?,
+        };
         Ok(NetTxn(env))
     }
 

--- a/components/launcher-protocol/src/lib.rs
+++ b/components/launcher-protocol/src/lib.rs
@@ -65,9 +65,7 @@ impl NetTxn {
     where
         T: LauncherMessage,
     {
-        let mut env = Self::build(message)?;
-        env.0.txn_id = self.0.txn_id;
-        Ok(env)
+        Ok(Self::build(message)?)
     }
 
     pub fn decode<T>(&self) -> Result<T>
@@ -89,29 +87,5 @@ where
     NetErr {
         msg: err.to_string(),
         code: err.into(),
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn envelopes_should_always_have_a_txn_id() {
-        let msg = NetOk::default();
-        let txn = NetTxn::build(&msg).unwrap();
-        assert_eq!(txn.0.txn_id, 0);
-    }
-
-    #[test]
-    fn decoded_envelopes_should_also_have_a_txn_id() {
-        let msg = NetOk::default();
-        let txn = NetTxn::build(&msg).unwrap();
-        let bytes = txn.to_bytes().unwrap();
-        let decoded = NetTxn::from_bytes(&bytes).unwrap();
-        let decoded_payload = decoded.decode::<NetOk>().unwrap();
-        assert_eq!(decoded.message_id(), "NetOk");
-        assert_eq!(decoded.0.txn_id, 0);
-        assert_eq!(decoded_payload, msg);
     }
 }

--- a/components/launcher-protocol/src/lib.rs
+++ b/components/launcher-protocol/src/lib.rs
@@ -62,13 +62,6 @@ impl NetTxn {
         self.0.clone().to_bytes()
     }
 
-    pub fn build_reply<T>(&self, message: &T) -> Result<Self>
-    where
-        T: LauncherMessage,
-    {
-        Ok(Self::build(message)?)
-    }
-
     pub fn decode<T>(&self) -> Result<T>
     where
         T: LauncherMessage,

--- a/components/launcher-protocol/src/types.rs
+++ b/components/launcher-protocol/src/types.rs
@@ -291,7 +291,6 @@ impl From<TerminateOk> for generated::TerminateOk {
 pub struct Envelope {
     pub message_id: String,
     pub payload: Vec<u8>,
-    pub txn_id: u64,
 }
 
 impl LauncherMessage for Envelope {
@@ -304,7 +303,6 @@ impl LauncherMessage for Envelope {
                 .message_id
                 .ok_or(Error::ProtocolMismatch("message_id"))?,
             payload: proto.payload.ok_or(Error::ProtocolMismatch("payload"))?,
-            txn_id: proto.txn_id.ok_or(Error::ProtocolMismatch("txn_id"))?,
         })
     }
 }
@@ -314,7 +312,6 @@ impl From<Envelope> for generated::Envelope {
         generated::Envelope {
             message_id: Some(value.message_id),
             payload: Some(value.payload),
-            txn_id: Some(value.txn_id),
         }
     }
 }

--- a/components/launcher/src/server/handlers/mod.rs
+++ b/components/launcher/src/server/handlers/mod.rs
@@ -43,12 +43,12 @@ pub trait Handler {
         trace!("{}, {:?}, {:?}", txn.message_id(), msg, services);
         match Self::handle(msg, services) {
             Ok(reply) => {
-                if let Err(err) = super::reply(tx, &txn, &reply) {
+                if let Err(err) = super::send(tx, &reply) {
                     error!("{}: replying, {}", txn.message_id(), err);
                 }
             }
             Err(reply) => {
-                if let Err(err) = super::reply(tx, &txn, &reply) {
+                if let Err(err) = super::send(tx, &reply) {
                     error!("{}: replying, {}", txn.message_id(), err);
                 }
             }

--- a/components/launcher/src/server/mod.rs
+++ b/components/launcher/src/server/mod.rs
@@ -415,16 +415,6 @@ impl ServiceTable {
 // Public Func
 //
 
-pub fn reply<T>(tx: &Sender, txn: &protocol::NetTxn, msg: &T) -> Result<()>
-where
-    T: protocol::LauncherMessage,
-{
-    let reply = txn.build_reply(msg)?;
-    let bytes = reply.to_bytes()?;
-    tx.send(bytes).map_err(Error::Send)?;
-    Ok(())
-}
-
 pub fn run(args: Vec<String>) -> Result<i32> {
     let mut server = Server::new(args)?;
     signals::init();


### PR DESCRIPTION
TL;DR - this field was never used, so we're getting rid of it.

Read individual commit messages for further details.