### PR TITLE
Add build/publish of Windows Docker Studio to release pipeline

### DIFF
--- a/.buildkite/release_pipeline.yaml
+++ b/.buildkite/release_pipeline.yaml
@@ -361,6 +361,11 @@ steps:
     env:
       BUILD_PKG_TARGET: "x86_64-linux-kernel2"
 
+  - label: ":docker: :windows: Upload windows container to Bintray"
+    command: .buildkite/scripts/publish_docker_studio.ps1
+    agents:
+      queue: 'single-use-windows-privileged'
+
   # TODO Create a JFrog emoji
   - label: ":linux: Upload (but don't publish!) artifacts to Bintray"
     command: .buildkite/scripts/bintray_upload.sh

--- a/.buildkite/scripts/build_docker_image.ps1
+++ b/.buildkite/scripts/build_docker_image.ps1
@@ -1,0 +1,84 @@
+#!/usr/bin/env powershell
+
+#Requires -Version 5
+
+param (
+  # The builder channel to install packages from. Defaults to unstable
+  [string]$ReleaseChannel="unstable",
+  # The docker image name. Defaults to "habitat-docker-registry.bintray.io/win-studio-x86_64-windows
+  [string]$imageName = "habitat-docker-registry.bintray.io/win-studio-x86_64-windows"
+)
+
+$ErrorActionPreference = "Stop"
+
+$startDir="$pwd"
+$tmpRoot = mkdir (Join-Path $env:TEMP ([System.IO.Path]::GetRandomFileName()))
+Push-Location $tmpRoot
+try {
+    $env:FS_ROOT="$tmpRoot/rootfs"
+    # Ensure that no existing `HAB_BINLINK_DIR` environment variable is present,
+    # like it would if executed in a Studio instance.
+    $env:HAB_BINLINK_DIR = $null
+    
+    Write-Host "Installing and extracting initial Habitat packages"
+    $InstallHarts = @(
+        "core/hab-studio",
+        "core/hab-sup",
+        "core/windows-service"
+    )
+    $InstallHarts | % {
+        Invoke-Expression "hab pkg install $_ --channel=$ReleaseChannel"
+        if ($LASTEXITCODE -ne 0) {
+            Write-Error "hab install failed for $_, aborting"
+        }
+    }
+    $studioPath = hab pkg path core/hab-studio
+    if ($LASTEXITCODE -ne 0) {
+      Write-Error "core/hab-studio must be installed, aborting"
+    }
+    
+    Write-Host "Purging container hab cache"
+    Remove-Item "$env:FS_ROOT/hab/cache" -Recurse -Force
+    
+    $pathParts = $studioPath.Replace("\", "/").Split("/")
+    $ident = [String]::Join("/", $pathParts[-4..-1])
+    $shortVersion = $pathParts[-2]
+    $version = "$($pathParts[-2])-$($pathParts[-1])"
+    
+@"
+FROM microsoft/windowsservercore
+MAINTAINER The Habitat Maintainers <humans@habitat.sh>
+ADD rootfs /
+WORKDIR /src
+RUN /hab/pkgs/$ident/bin/hab/hab.exe pkg exec core/windows-service install
+ENTRYPOINT ["/hab/pkgs/$ident/bin/powershell/pwsh.exe", "-ExecutionPolicy", "bypass", "-NoLogo", "-file", "/hab/pkgs/$ident/bin/hab-studio.ps1"]
+"@ | Out-File "$tmpRoot/Dockerfile" -Encoding ascii
+    
+Write-Host "Building Docker image ${imageName}:$version'"
+docker build --no-cache -t ${imageName}:$version .
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "docker build failed, aborting"
+}
+
+Write-Host "Tagging latest image to ${imageName}:$version"
+docker tag ${imageName}:$version ${imageName}:latest
+
+Write-Host "Tagging latest image to ${imageName}:$shortVersion"
+docker tag ${imageName}:$version ${imageName}:$shortVersion
+
+# Ensure the results directory exists before writing to it
+New-Item -ItemType directory -Path "$startDir/results" -Force
+@"
+`$docker_image="$imageName"
+`$docker_image_version="$version"
+`$docker_image_short_version="$shortVersion"
+"@ | Out-File "$startDir/results/last_image.ps1" -Encoding ascii
+    
+    Write-Host "Docker Image: ${imageName}:$version"
+    Write-Host "Build Report: $startDir/results/last_image.ps1"
+}
+finally {
+    Pop-Location
+    $env:FS_ROOT = $null
+    Remove-Item $tmpRoot -Recurse -Force
+}

--- a/.buildkite/scripts/publish_docker_studio.ps1
+++ b/.buildkite/scripts/publish_docker_studio.ps1
@@ -1,0 +1,41 @@
+#!/usr/bin/env powershell
+
+#Requires -Version 5
+
+function is_fake_release() {
+  buildkite-agent meta-data exists fake-release
+  if($LastExitCode -eq 0) {
+    return $true
+  }
+  return $false
+}
+
+$ErrorActionPreference="stop" 
+$ReleaseChannel = & buildkite-agent meta-data get release-channel
+
+Write-Host "--- Building the Windows Docker Studio"
+
+& $PSScriptRoot/build_docker_image.ps1 -ReleaseChannel $ReleaseChannel
+
+Write-Host "--- Publishing the Windows Docker Studio"
+. ./results/last_image.ps1
+
+Write-Host "Logging in to Bintray Docker repo"
+docker login -u="$env:BINTRAY_USER" -p="$env:BINTRAY_KEY" habitat-docker-registry.bintray.io
+
+if(is_fake_release) {
+  Write-Host "This is a fake release."
+  Write-Host "Not uploading $docker_image"
+} else {
+  try {
+    Write-Host "Pushing ${docker_image}:$docker_image_version"
+    docker push "${docker_image}:$docker_image_version"
+    Write-Host "Pushing ${docker_image}:$docker_image_short_version tag for $docker_image_version"
+    docker push "${docker_image}:$docker_image_short_version"
+    Write-Host "Pushing latest tag for $docker_image_version"
+    docker push "${docker_image}:latest"
+  }
+  finally {
+      Remove-Item $HOME/.docker/config.json -Recurse -Force -ErrorAction SilentlyContinue
+  }
+}


### PR DESCRIPTION
This takes code from components/hab-bintray-publish and integrates it into the release pipeline.

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>