### PR TITLE
adding HAB_CRYPTO_KEY to hab build

### DIFF
--- a/.buildkite/release_pipeline.yaml
+++ b/.buildkite/release_pipeline.yaml
@@ -50,6 +50,7 @@ steps:
           environment:
             - HAB_BLDR_CHANNEL
             - HAB_AUTH_TOKEN
+            - HAB_CRYPTO_KEY
             - BUILDKITE_JOB_ID
             - BUILDKITE_AGENT_ACCESS_TOKEN
 


### PR DESCRIPTION
Also added coment to https://github.com/habitat-sh/habitat/pull/6163 to have it added for the launcher

This should fix passing password to `hab svc load` and having it decrypted by the launcher.

Signed-off-by: mwrock <matt@mattwrock.com>