### PR TITLE
[sup] Enable client-authentication with TLS

### DIFF
--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -918,6 +918,9 @@ pub fn sub_sup_run() -> App<'static, 'static> {
         "Used for enabling TLS for the HTTP gateway. Read server certificates from CERT_FILE. \
          This should contain PEM-format certificates in the right order (the first certificate \
          should certify KEY_FILE, the last should be a root CA).")
+    (@arg CA_CERT_FILE: --("ca-certs") +takes_value {file_exists} requires[CERT_FILE] requires[KEY_FILE]
+        "Used for enabling client-authentication with TLS for the HTTP gateway. Read CA certificate from CA_CERT_FILE. \
+         This should contain PEM-format certificate that can be used to validate client requests.")
     // === Optional arguments to additionally load an initial service for the Supervisor
     (@arg PKG_IDENT_OR_ARTIFACT: +takes_value "Load the given Habitat package as part of \
         the Supervisor startup specified by a package identifier \

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -80,7 +80,8 @@ use crate::sup::{cli::cli,
                          SupError},
                  feat,
                  manager::{Manager,
-                           ManagerConfig},
+                           ManagerConfig,
+                           TLSConfig},
                  util};
 
 #[cfg(test)]
@@ -278,14 +279,17 @@ fn mgrcfg_from_sup_run_matches(m: &ArgMatches) -> Result<ManagerConfig> {
             },
             |v| v.parse(),
         )?,
-        tls_files: m.value_of("KEY_FILE").and_then(|kf| {
-            Some((
-                PathBuf::from(kf),
-                PathBuf::from(
-                    m.value_of("CERT_FILE")
-                        .expect("CERT_FILE should always have a value if KEY_FILE has a value."),
-                ),
-            ))
+        tls_config: m.value_of("KEY_FILE").map(|kf| {
+            let cert_path = m
+                .value_of("CERT_FILE")
+                .map(PathBuf::from)
+                .expect("CERT_FILE should always have a value if KEY_FILE has a value.");
+            let ca_cert_path = m.value_of("CA_CERT_FILE").map(PathBuf::from);
+            TLSConfig {
+                key_path: PathBuf::from(kf),
+                cert_path,
+                ca_cert_path,
+            }
         }),
         // default is only included here for the custom_state_path field which will ideally
         // eventually be removed, it only exists to manipulate test data.

--- a/www/source/docs/habitat-cli.html.md
+++ b/www/source/docs/habitat-cli.html.md
@@ -2217,6 +2217,7 @@ hab sup run [FLAGS] [OPTIONS] [--] [PKG_IDENT_OR_ARTIFACT]
     --bind <BIND>...                                   One or more service groups to bind to a configuration
     --binding-mode <BINDING_MODE> Governs how the presence or absence of binds affects service startup. strict blocks startup until all binds are present. [default: strict] [values: relaxed, strict]
 -u, --url <BLDR_URL> Specify an alternate Builder endpoint. If not specified, the value will be taken from the HAB_BLDR_URL environment variable if defined. (default: https://bldr.habitat.sh)
+    --ca-certs <CA_CERT_FILE> Used for enabling client-authentication with TLS for the HTTP gateway. Read CA certificate from CA_CERT_FILE. This should contain PEM-format certificate that can be used to validate client requests.
     --certs <CERT_FILE> Used for enabling TLS for the HTTP gateway. Read server certificates from CERT_FILE. This should contain PEM-format certificates in the right order (the first certificate should certify KEY_FILE, the last should be a root CA).
     --channel <CHANNEL> Receive Supervisor updates from the specified release channel [default: stable]
 


### PR DESCRIPTION
TLS allows clients to also provide a certificate when initiating a
connection. This certifcate can be used to authenticate clients as an
alternative to other HTTP authentication schems such as basic auth.

I've factored out the TLS configuration into a struct because passing
around `Option<(PathBuf, PathBuf, Option<PathBuf>)>` felt like it
would become a bit error prone and hard to extend.

Signed-off-by: Steven Danna <steve@chef.io>