### PR TITLE
Add windows builder-worker promotion step to release

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -31,7 +31,8 @@ Here are all the steps for the release process. Create a new issue at the beginn
 - [ ] [Update docs](https://github.com/habitat-sh/habitat/blob/master/RELEASE.md#update-the-docs)
 - [ ] [Bump version](https://github.com/habitat-sh/habitat/blob/master/RELEASE.md#bump-version) to new `-dev` version
 - [ ] [Update `hab-backline` to new `-dev` version in acceptance environment](https://github.com/habitat-sh/habitat/blob/master/RELEASE.md#update-the-acceptance-environment-with-the-new-hab-backline-1)
-- [ ] [Promote builder worker](https://github.com/habitat-sh/habitat/blob/master/RELEASE.md#promote-the-builder-worker) and confrm build uses new version
+- [ ] [Promote Linux builder worker](https://github.com/habitat-sh/habitat/blob/master/RELEASE.md#promote-the-builder-worker) and confirm build uses new version
+- [ ] [Promote Windows builder worker](https://github.com/habitat-sh/habitat/blob/master/RELEASE.md#promote-the-builder-worker) and confirm build uses new version
 - [ ] Post announcement in [Chef discourse](https://discourse.chef.io/c/habitat)
 - [ ] Post announcement in [Habitat forums](https://forums.habitat.sh/c/announcements)
 - [ ] Tweet announcement from `@habitatsh`

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -261,6 +261,8 @@ Now that the release is stable, we need to build a new version of builder-worker
 If it is, just wait for it to finish and promote it. If it's not, click the
 `Build Latest Version` button to kick off a build, and promote when it's done.  Wait for a few minutes so that supervisors on all the workers can update to the newly promoted version, then perform a test build. Check the build log for the test build to confirm that the version of the Habitat client being used is the desired version.
 
+With the addition of Windows builder workers, you will also need to build and promote the builder-worker package for x86_64-windows.  In order to build the Windows package, you will need to use the hab cli and issue `hab bldr job start habitat/builder-worker x86_64-windows` in order to create the package.  
+
 # Release Notification
 
 1. Create new posts in [Habitat Announcements](https://discourse.chef.io/c/habitat) on the Chef discourse as well as [Announcements](https://forums.habitat.sh/c/announcements) in the Habitat forums.


### PR DESCRIPTION
This documents the new requirement of building and promoting Windows workers for Builder to the release process.  


Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>