### PR TITLE
Update plan-build default_strip behavior

### DIFF
--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -2046,7 +2046,7 @@ do_strip() {
 }
 
 # Default implementation for the `do_strip()` phase.
-# TODO(SM): Previous versions of the `find` utility reported x-pie-exectuable
+# TODO(SM): Previous versions of the `file` utility reported x-pie-exectuable
 # as x-sharedlib. This means that while the intent was to `--strip-all` for 
 # x-executable, in reality we have been running `--strip-unneeded`. In order to 
 # be consistant with past behavior we will pass `--strip-unneeded` when stripping

--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -2046,12 +2046,21 @@ do_strip() {
 }
 
 # Default implementation for the `do_strip()` phase.
+# TODO(SM): Previous versions of the `find` utility reported x-pie-exectuable
+# as x-sharedlib. This means that while the intent was to `--strip-all` for 
+# x-executable, in reality we have been running `--strip-unneeded`. In order to 
+# be consistant with past behavior we will pass `--strip-unneeded` when stripping
+# x-pie-executable. In the future, we will need to make a decision as to the behavior 
+# we want and introduce it at an appropriate time, such as a core-plans refresh.
+# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=81498
+# https://bugs.launchpad.net/ubuntu/+source/file/+bug/1747711
 do_default_strip() {
   build_line "Stripping unneeded symbols from binaries and libraries"
   find "$pkg_prefix" -type f -perm -u+w -print0 2> /dev/null \
     | while read -rd '' f; do
       case "$(file -bi "$f")" in
         *application/x-executable*) strip --strip-all "$f";;
+        *application/x-pie-executable*) strip --strip-unneeded "$f";;
         *application/x-sharedlib*) strip --strip-unneeded "$f";;
         *application/x-archive*) strip --strip-debug "$f";;
         *) continue;;


### PR DESCRIPTION
Closes #6186 

In the recent [core-plans refresh](https://github.com/habitat-sh/core-plans/pull/1767) we updated `file` from 5.32 to 5.34.  In between those two releases was a fix to the `file` command to correctly report modern PIE executables as `application/x-pie-executable` instead of the previously incorrect `application/x-sharedlib`.    

https://gcc.gnu.org/bugzilla/show_bug.cgi?id=81498
https://bugs.launchpad.net/ubuntu/+source/file/+bug/1747711

This resulted files that were previously misreported as `x-sharedlib` to no longer match a [branch of the case statement](https://github.com/habitat-sh/habitat/blob/0.75.0/components/plan-build/bin/hab-plan-build.sh#L2053-L2057) in `do_default_strip` and were therefore no longer stripped of debug symbols leading to the bloated file sizes reported in #6186.

This PR adds an additional branch to the case statement in do_default_strip, to give `application/x-pie-executable` the previous `strip --strip-unneeded` behavior of `application/x-sharedlib`.  While the original intent was to `strip --strip-all` for executable files,  that hasn't been the behavior for an unknown period of time, possibly the lifetime of the project.  While `--strip-all` is probably the desired behavior, I think we should introduce that change after evaluating the impact across the ecosystem.  

Building the Habitat supervisor with these changes results in a reduction in file size in line with previous values:

```
3816853 core-hab-sup-0.73.0-20190115010906-x86_64-linux.hart
46022649 core-hab-sup-0.74.0-20190204225911-x86_64-linux.hart
43047381 core-hab-sup-0.75.0-20190220000453-x86_64-linux.hart
3937420 smacfarlane-hab-sup-0.76.0-dev-20190220210136-x86_64-linux.hart
```

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>