### PR TITLE
Refactor the date logic for nightly rust in CI

### DIFF
--- a/components/hab/src/command/pkg/export/mod.rs
+++ b/components/hab/src/command/pkg/export/mod.rs
@@ -147,9 +147,8 @@ mod inner {
 
     pub fn format_for(ui: &mut UI, value: &str) -> Result<ExportFormat> {
         ui.warn(format!(
-            "∅ Exporting {} packages from this operating system is not yet \
-             supported. Try running this command again on a 64-bit Linux \
-             operating system.\n",
+            "∅ Exporting {} packages from this operating system is not yet supported. Try running \
+             this command again on a 64-bit Linux operating system.\n",
             value
         ))?;
         ui.br()?;

--- a/components/sup-protocol/src/lib.rs
+++ b/components/sup-protocol/src/lib.rs
@@ -177,10 +177,19 @@ mod ctl_secret {
         let tmpdir = TempDir::new().unwrap();
         let file_path = tmpdir.path().to_owned().join("CTL_SECRET");
         let mut secret_file = File::create(file_path).unwrap();
-        write!(secret_file, "w9TuoqTk4Ixaht8ZpJpHQlmPRbvpgz13GaGnvxunJy8iOhZcS7qGqEA7jogq/Itfu4HOdQGmLRY9G5fRUcuw/w==").unwrap();
+        write!(
+            secret_file,
+            "w9TuoqTk4Ixaht8ZpJpHQlmPRbvpgz13GaGnvxunJy8iOhZcS7qGqEA7jogq/Itfu4HOdQGmLRY9G5fRUcuw/\
+             w=="
+        )
+        .unwrap();
         let mut out = String::new();
         assert_eq!(read_secret_key(tmpdir, &mut out), Ok(true));
-        assert_eq!(out, "w9TuoqTk4Ixaht8ZpJpHQlmPRbvpgz13GaGnvxunJy8iOhZcS7qGqEA7jogq/Itfu4HOdQGmLRY9G5fRUcuw/w==");
+        assert_eq!(
+            out,
+            "w9TuoqTk4Ixaht8ZpJpHQlmPRbvpgz13GaGnvxunJy8iOhZcS7qGqEA7jogq/Itfu4HOdQGmLRY9G5fRUcuw/\
+             w=="
+        );
     }
 
     #[test]
@@ -188,10 +197,19 @@ mod ctl_secret {
         let tmpdir = TempDir::new().unwrap();
         let file_path = tmpdir.path().to_owned().join("CTL_SECRET");
         let mut secret_file = File::create(file_path).unwrap();
-        writeln!(secret_file, "w9TuoqTk4Ixaht8ZpJpHQlmPRbvpgz13GaGnvxunJy8iOhZcS7qGqEA7jogq/Itfu4HOdQGmLRY9G5fRUcuw/w==").unwrap();
+        writeln!(
+            secret_file,
+            "w9TuoqTk4Ixaht8ZpJpHQlmPRbvpgz13GaGnvxunJy8iOhZcS7qGqEA7jogq/Itfu4HOdQGmLRY9G5fRUcuw/\
+             w=="
+        )
+        .unwrap();
         let mut out = String::new();
         assert_eq!(read_secret_key(tmpdir, &mut out), Ok(true));
-        assert_eq!(out, "w9TuoqTk4Ixaht8ZpJpHQlmPRbvpgz13GaGnvxunJy8iOhZcS7qGqEA7jogq/Itfu4HOdQGmLRY9G5fRUcuw/w==");
+        assert_eq!(
+            out,
+            "w9TuoqTk4Ixaht8ZpJpHQlmPRbvpgz13GaGnvxunJy8iOhZcS7qGqEA7jogq/Itfu4HOdQGmLRY9G5fRUcuw/\
+             w=="
+        );
     }
 
     #[test]
@@ -199,10 +217,19 @@ mod ctl_secret {
         let tmpdir = TempDir::new().unwrap();
         let file_path = tmpdir.path().to_owned().join("CTL_SECRET");
         let mut secret_file = File::create(file_path).unwrap();
-        writeln!(secret_file, "w9TuoqTk4Ixaht8ZpJpHQlmPRbvpgz13GaGnvxunJy8iOhZcS7qGqEA7jogq/Itfu4HOdQGmLRY9G5fRUcuw/w==\r").unwrap();
+        writeln!(
+            secret_file,
+            "w9TuoqTk4Ixaht8ZpJpHQlmPRbvpgz13GaGnvxunJy8iOhZcS7qGqEA7jogq/Itfu4HOdQGmLRY9G5fRUcuw/\
+             w==\r"
+        )
+        .unwrap();
         let mut out = String::new();
         assert_eq!(read_secret_key(tmpdir, &mut out), Ok(true));
-        assert_eq!(out, "w9TuoqTk4Ixaht8ZpJpHQlmPRbvpgz13GaGnvxunJy8iOhZcS7qGqEA7jogq/Itfu4HOdQGmLRY9G5fRUcuw/w==");
+        assert_eq!(
+            out,
+            "w9TuoqTk4Ixaht8ZpJpHQlmPRbvpgz13GaGnvxunJy8iOhZcS7qGqEA7jogq/Itfu4HOdQGmLRY9G5fRUcuw/\
+             w=="
+        );
     }
 
     #[test]


### PR DESCRIPTION
@baumanj rightly pointed out that using a range loop instead of an infinite one is a better idea when doing something X times. This makes that change for our nightly rust calculations in CI.

![](https://media.giphy.com/media/fkE8aXHMceFQQ/giphy.gif)

Signed-off-by: Josh Black <raskchanky@gmail.com>