### PR TITLE
Tests for hab sup run cli behavior

### DIFF
--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -943,14 +943,14 @@ pub fn sub_sup_run() -> App<'static, 'static> {
     (@arg GROUP: --group default_value("default")
         "The service group; shared config and topology.")
     (@arg TOPOLOGY: --topology -t +takes_value possible_value[standalone leader]
-        "Service topology; [default: none]")
-    (@arg STRATEGY: --strategy -s default_value("none") {valid_update_strategy}
-        "The update strategy; [values: none, at-once, rolling]")
+        "Service topology.")
+    (@arg STRATEGY: --strategy -s possible_value("none") possible_value("at-once") possible_value("rolling") default_value("none")
+        "The update strategy.")
     (@arg BIND: --bind +takes_value +multiple
         "One or more service groups to bind to a configuration")
-    (@arg BINDING_MODE: --("binding-mode") default_value("strict") {valid_binding_mode}
+    (@arg BINDING_MODE: --("binding-mode") default_value("strict") possible_value[relaxed strict]
         "Governs how the presence or absence of binds affects service startup. `strict` blocks \
-         startup until all binds are present. [values: relaxed, strict]")
+         startup until all binds are present.")
     (@arg VERBOSE: -v "Verbose output; shows file and line/column numbers")
     (@arg NO_COLOR: --("no-color") "Turn ANSI color off")
     (@arg JSON: --("json-logging") "Use structured JSON logging for the Supervisor. \

--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -888,21 +888,20 @@ pub fn sub_sup_run() -> App<'static, 'static> {
     // is displayed confusingly as `hab-sup`
     // see: https://github.com/kbknapp/clap-rs/blob/2724ec5399c500b12a1a24d356f4090f4816f5e2/src/app/mod.rs#L373-L394
     (usage: "hab sup run [FLAGS] [OPTIONS] [--] [PKG_IDENT_OR_ARTIFACT]")
-          (@arg LISTEN_GOSSIP: --("listen-gossip") env(GOSSIP_LISTEN_ADDRESS_ENVVAR) default_value(&GOSSIP_DEFAULT_ADDR) {valid_socket_addr}
+    (@arg LISTEN_GOSSIP: --("listen-gossip") env(GOSSIP_LISTEN_ADDRESS_ENVVAR) default_value(&GOSSIP_DEFAULT_ADDR) {valid_socket_addr}
         "The listen address for the Gossip System Gateway.")
     (@arg LISTEN_HTTP: --("listen-http") env(LISTEN_HTTP_ADDRESS_ENVVAR) default_value(&LISTEN_HTTP_DEFAULT_ADDR) {valid_socket_addr}
         "The listen address for the HTTP Gateway.")
     (@arg HTTP_DISABLE: --("http-disable") -D
         "Disable the HTTP Gateway completely [default: false]")
     (@arg LISTEN_CTL: --("listen-ctl") env(ListenCtlAddr::ENVVAR) default_value(&LISTEN_CTL_DEFAULT_ADDR_STRING) {valid_socket_addr}
-        "The listen address for the Control Gateway. If not specified, the value will \
-        be taken from the HAB_LISTEN_CTL environment variable if defined. [default: 127.0.0.1:9632]")
+        "The listen address for the Control Gateway.")
     (@arg ORGANIZATION: --org +takes_value
         "The organization that the Supervisor and its subsequent services are part of.")
     (@arg PEER: --peer +takes_value +multiple
         "The listen address of one or more initial peers (IP[:PORT])")
     (@arg PERMANENT_PEER: --("permanent-peer") -I "If this Supervisor is a permanent peer")
-    (@arg PEER_WATCH_FILE: --("peer-watch-file") +takes_value conflicts_with[peer]
+    (@arg PEER_WATCH_FILE: --("peer-watch-file") +takes_value conflicts_with("PEER")
         "Watch this file for connecting to the ring"
     )
     (@arg RING: --ring -r env(RING_ENVVAR) conflicts_with("RING_KEY")
@@ -917,10 +916,9 @@ pub fn sub_sup_run() -> App<'static, 'static> {
                   GCrBOW6CCN75LMl0j2V5QqQ6nNzWm6and9hkKBSUFPI=')")
     (@arg CHANNEL: --channel +takes_value
         "Receive Supervisor updates from the specified release channel [default: stable]")
-    (@arg BLDR_URL: -u --url +takes_value {valid_url}
+    (@arg BLDR_URL: -u --url default_value("https://bldr.habitat.sh") {valid_url}
         "Specify an alternate Builder endpoint. If not specified, the value will \
-         be taken from the HAB_BLDR_URL environment variable if defined. (default: \
-         https://bldr.habitat.sh)")
+         be taken from the HAB_BLDR_URL environment variable if defined.")
 
     (@arg CONFIG_DIR: --("config-from") +takes_value {dir_exists}
         "Use package config from this path, rather than the package itself")
@@ -942,23 +940,23 @@ pub fn sub_sup_run() -> App<'static, 'static> {
         "Application name; [default: not set].")
     (@arg ENVIRONMENT: --environment -e +takes_value requires[APPLICATION]
         "Environment name; [default: not set].")
-    (@arg GROUP: --group +takes_value
-        "The service group; shared config and topology [default: default].")
+    (@arg GROUP: --group default_value("default")
+        "The service group; shared config and topology.")
     (@arg TOPOLOGY: --topology -t +takes_value possible_value[standalone leader]
         "Service topology; [default: none]")
-    (@arg STRATEGY: --strategy -s +takes_value {valid_update_strategy}
-        "The update strategy; [default: none] [values: none, at-once, rolling]")
+    (@arg STRATEGY: --strategy -s default_value("none") {valid_update_strategy}
+        "The update strategy; [values: none, at-once, rolling]")
     (@arg BIND: --bind +takes_value +multiple
         "One or more service groups to bind to a configuration")
-    (@arg BINDING_MODE: --("binding-mode") +takes_value {valid_binding_mode}
+    (@arg BINDING_MODE: --("binding-mode") default_value("strict") {valid_binding_mode}
         "Governs how the presence or absence of binds affects service startup. `strict` blocks \
-         startup until all binds are present. [default: strict] [values: relaxed, strict]")
+         startup until all binds are present. [values: relaxed, strict]")
     (@arg VERBOSE: -v "Verbose output; shows file and line/column numbers")
     (@arg NO_COLOR: --("no-color") "Turn ANSI color off")
     (@arg JSON: --("json-logging") "Use structured JSON logging for the Supervisor. \
         Implies NO_COLOR")
-    (@arg HEALTH_CHECK_INTERVAL: --("health-check-interval") -i +takes_value {valid_health_check_interval}
-        "The interval (seconds) on which to run health checks [default: 30]")
+    (@arg HEALTH_CHECK_INTERVAL: --("health-check-interval") -i default_value("30") {valid_health_check_interval}
+        "The interval (seconds) on which to run health checks.")
     )
 }
 

--- a/components/sup/src/cli.rs
+++ b/components/sup/src/cli.rs
@@ -36,6 +36,8 @@ mod test {
         use std::iter::FromIterator;
         use tempfile::{NamedTempFile, TempDir};
 
+        const BAD_ADDRS: [&str; 3] = ["1.1.1:1111", "1.1.1.256:1111", "1.1.1.1.1:1111"];
+
         assert_cli_cmd!(should_handle_listen_gossip_with_value,
                         "hab-sup run --listen-gossip 1.1.1.1:1111",
                         "LISTEN_GOSSIP" => "1.1.1.1:1111");
@@ -46,9 +48,11 @@ mod test {
 
         #[test]
         fn invalid_listen_gossip_address_should_fail() {
-            let cmd_vec =
-                Vec::from_iter("hab-sup run --listen-gossip bad-address".split_whitespace());
-            assert!(cli().get_matches_from_safe(cmd_vec).is_err());
+            for addr in BAD_ADDRS.iter() {
+                let cmd_str = format!("hab-sup run --listen-gossip {}", addr);
+                let cmd_vec = Vec::from_iter(cmd_str.split_whitespace());
+                assert!(cli().get_matches_from_safe(cmd_vec).is_err());
+            }
         }
 
         assert_cli_cmd!(should_handle_listen_http,
@@ -61,9 +65,11 @@ mod test {
 
         #[test]
         fn invalid_listen_http_address_should_fail() {
-            let cmd_vec =
-                Vec::from_iter("hab-sup run --listen-http bad-address".split_whitespace());
-            assert!(cli().get_matches_from_safe(cmd_vec).is_err());
+            for addr in BAD_ADDRS.iter() {
+                let cmd_str = format!("hab-sup run --listen-http {}", addr);
+                let cmd_vec = Vec::from_iter(cmd_str.split_whitespace());
+                assert!(cli().get_matches_from_safe(cmd_vec).is_err());
+            }
         }
 
         assert_cli_cmd!(should_handle_http_disable,
@@ -84,8 +90,11 @@ mod test {
 
         #[test]
         fn invalid_listen_ctl_address_should_fail() {
-            let cmd_vec = Vec::from_iter("hab-sup run --listen-ctl bad-address".split_whitespace());
-            assert!(cli().get_matches_from_safe(cmd_vec).is_err());
+            for addr in BAD_ADDRS.iter() {
+                let cmd_str = format!("hab-sup run --listen-ctl {}", addr);
+                let cmd_vec = Vec::from_iter(cmd_str.split_whitespace());
+                assert!(cli().get_matches_from_safe(cmd_vec).is_err());
+            }
         }
 
         assert_cli_cmd!(should_handle_org,
@@ -293,8 +302,11 @@ mod test {
 
         #[test]
         fn topology_should_fail_when_a_bad_value_is_passed() {
-            let cmd_vec = Vec::from_iter("hab-sup run --topology foobar".split_whitespace());
-            assert!(cli().get_matches_from_safe(cmd_vec).is_err());
+            for bad_topo in ["none", "at-once", "rolling", "foobar"].iter() {
+                let cmd_str = format!("hab-sup run --topology {}", bad_topo);
+                let cmd_vec = Vec::from_iter(cmd_str.split_whitespace());
+                assert!(cli().get_matches_from_safe(cmd_vec).is_err());
+            }
         }
 
         assert_cli_cmd!(should_handle_none_strategy,
@@ -319,8 +331,11 @@ mod test {
 
         #[test]
         fn strategy_should_fail_when_a_bad_value_is_passed() {
-            let cmd_vec = Vec::from_iter("hab-sup run --strategy foobar".split_whitespace());
-            assert!(cli().get_matches_from_safe(cmd_vec).is_err());
+            for bad_strat in ["standalone", "leader", "foobar"].iter() {
+                let cmd_str = format!("hab-sup run --strategy {}", bad_strat);
+                let cmd_vec = Vec::from_iter(cmd_str.split_whitespace());
+                assert!(cli().get_matches_from_safe(cmd_vec).is_err());
+            }
         }
 
         assert_cli_cmd!(should_handle_multiple_bind_flags,

--- a/components/sup/src/cli.rs
+++ b/components/sup/src/cli.rs
@@ -30,6 +30,66 @@ mod test {
 
     mod sup_run {
         use super::*;
+        use crate::common::cli_defaults::{
+            GOSSIP_DEFAULT_ADDR, LISTEN_CTL_DEFAULT_ADDR_STRING, LISTEN_HTTP_DEFAULT_ADDR,
+        };
+        use std::iter::FromIterator;
+
+        assert_cli_cmd!(should_handle_listen_gossip_with_value,
+                        "hab-sup run --listen-gossip 1.1.1.1:1111",
+                        "LISTEN_GOSSIP" => "1.1.1.1:1111");
+
+        assert_cli_cmd!(listen_gossip_should_have_default_value,
+                        "hab-sup run",
+                        "LISTEN_GOSSIP" => (&GOSSIP_DEFAULT_ADDR));
+
+        #[test]
+        fn invalid_listen_gossip_address_should_fail() {
+            let cmd_vec =
+                Vec::from_iter("hab-sup run --listen-gossip bad-address".split_whitespace());
+            assert!(cli().get_matches_from_safe(cmd_vec).is_err());
+        }
+
+        assert_cli_cmd!(should_handle_listen_http,
+                        "hab-sup run --listen-http 1.1.1.1:1111",
+                        "LISTEN_HTTP" => "1.1.1.1:1111");
+
+        assert_cli_cmd!(listen_http_should_have_default_value,
+                        "hab-sup run",
+                        "LISTEN_HTTP" => (&LISTEN_HTTP_DEFAULT_ADDR));
+
+        #[test]
+        fn invalid_listen_http_address_should_fail() {
+            let cmd_vec =
+                Vec::from_iter("hab-sup run --listen-http bad-address".split_whitespace());
+            assert!(cli().get_matches_from_safe(cmd_vec).is_err());
+        }
+
+        assert_cli_cmd!(should_handle_http_disable,
+                        "hab-sup run --http-disable",
+                        "HTTP_DISABLE" => true);
+
+        assert_cli_cmd!(http_disable_should_have_short_flag,
+                        "hab-sup run -D",
+                        "HTTP_DISABLE" => true);
+
+        assert_cli_cmd!(should_handle_listen_ctl,
+                        "hab-sup run --listen-ctl 1.1.1.1:1111",
+                        "LISTEN_CTL" => "1.1.1.1:1111");
+
+        assert_cli_cmd!(listen_ctl_should_have_a_default_value,
+                        "hab-sup run",
+                        "LISTEN_CTL" => (&LISTEN_CTL_DEFAULT_ADDR_STRING));
+
+        #[test]
+        fn invalid_listen_ctl_address_should_fail() {
+            let cmd_vec = Vec::from_iter("hab-sup run --listen-ctl bad-address".split_whitespace());
+            assert!(cli().get_matches_from_safe(cmd_vec).is_err());
+        }
+
+        assert_cli_cmd!(should_handle_org,
+                        "hab-sup run --org monkeypants",
+                        "ORGANIZATION" => "monkeypants");
 
         assert_cli_cmd!(should_handle_multiple_peer_flags,
                         "hab-sup run --peer 1.1.1.1 --peer 2.2.2.2",
@@ -44,6 +104,163 @@ mod test {
                         "PEER" => ["1.1.1.1", "2.2.2.2"],
                         "PKG_IDENT_OR_ARTIFACT" => "core/redis");
 
+        assert_cli_cmd!(should_handle_permanent_peer,
+                        "hab-sup run --permanent-peer",
+                        "PERMANENT_PEER" => true);
+
+        assert_cli_cmd!(permanent_peer_should_have_short_flag,
+                        "hab-sup run -I",
+                        "PERMANENT_PEER" => true);
+
+        assert_cli_cmd!(should_handle_peer_watch_file,
+                        "hab-sup run --peer-watch-file foobar",
+                        "PEER_WATCH_FILE" => "foobar");
+
+        #[test]
+        fn peer_watch_file_conflicts_with_peer() {
+            let cmd_vec = Vec::from_iter(
+                "hab-sup run --peer-watch-file foobar --peer 1.1.1.1:1111".split_whitespace(),
+            );
+            assert!(cli().get_matches_from_safe(cmd_vec).is_err());
+        }
+
+        assert_cli_cmd!(should_handle_ring,
+                        "hab-sup run --ring fizbang",
+                        "RING" => "fizbang");
+
+        assert_cli_cmd!(ring_should_have_short_flag,
+                        "hab-sup run -r flippitygibbit",
+                        "RING" => "flippitygibbit");
+
+        #[test]
+        fn ring_conflicts_with_ring_key() {
+            let cmd_vec =
+                Vec::from_iter("hab-sup run --ring myring --ring-key foobar".split_whitespace());
+            assert!(cli().get_matches_from_safe(cmd_vec).is_err());
+        }
+
+        assert_cli_cmd!(should_handle_ring_key,
+                        "hab-sup run --ring-key secrit",
+                        "RING_KEY" => "secrit");
+
+        assert_cli_cmd!(should_handle_channel,
+                        "hab-sup run --channel dev",
+                        "CHANNEL" => "dev");
+
+        assert_cli_cmd!(should_handle_bldr_url,
+                        "hab-sup run --url http://not.a.real.com",
+                        "BLDR_URL" => "http://not.a.real.com");
+
+        assert_cli_cmd!(bldr_url_should_have_a_short_flag,
+                        "hab-sup run -u http://not.a.real.com",
+                        "BLDR_URL" => "http://not.a.real.com");
+
+        assert_cli_cmd!(bldr_url_should_have_a_default_value,
+                        "hab-sup run",
+                        "BLDR_URL" => "https://bldr.habitat.sh");
+
+        #[test]
+        fn invalid_bldr_url_should_fail() {
+            let cmd_vec = Vec::from_iter("hab-sup run -u bad-url".split_whitespace());
+            assert!(cli().get_matches_from_safe(cmd_vec).is_err());
+        }
+
+        // TODO: config dir test
+
+        // TODO: bad config dir test
+
+        assert_cli_cmd!(should_handle_auto_update,
+                        "hab-sup run --auto-update",
+                        "AUTO_UPDATE" => true);
+
+        assert_cli_cmd!(auto_update_should_have_a_short_flag,
+                        "hab-sup run -A",
+                        "AUTO_UPDATE" => true);
+
+        // TODO: key file cert file test
+
+        // TODO: key file requires test
+
+        // TODO: cert file requires test
+
+        assert_cli_cmd!(should_take_pkg_or_artifact_as_arg,
+                        "hab-sup run core/redis",
+                        "PKG_IDENT_OR_ARTIFACT" => "core/redis");
+
+        assert_cli_cmd!(should_handle_application_and_environment,
+                        "hab-sup run --application foobar --environment fizbang",
+                        "APPLICATION" => "foobar",
+                        "ENVIRONMENT" => "fizbang");
+
+        assert_cli_cmd!(application_and_environment_should_have_short_flags,
+                        "hab-sup run -a foobar -e fizbang",
+                        "APPLICATION" => "foobar",
+                        "ENVIRONMENT" => "fizbang");
+
+        #[test]
+        fn application_requires_environment() {
+            let cmd_vec = Vec::from_iter("hab-sup run -a foobar".split_whitespace());
+            assert!(cli().get_matches_from_safe(cmd_vec).is_err());
+        }
+
+        #[test]
+        fn environment_requires_application() {
+            let cmd_vec = Vec::from_iter("hab-sup run -e fizbang".split_whitespace());
+            assert!(cli().get_matches_from_safe(cmd_vec).is_err());
+        }
+
+        assert_cli_cmd!(should_handle_group,
+                        "hab-sup run --group groupy",
+                        "GROUP" => "groupy");
+
+        assert_cli_cmd!(group_should_have_default_value,
+                        "hab-sup run",
+                        "GROUP" => "default");
+
+        assert_cli_cmd!(should_handle_standalone_topology,
+                        "hab-sup run --topology standalone",
+                        "TOPOLOGY" => "standalone");
+
+        assert_cli_cmd!(should_handle_leader_topology,
+                        "hab-sup run --topology leader",
+                        "TOPOLOGY" => "leader");
+
+        assert_cli_cmd!(topology_should_have_a_short_flag,
+                        "hab-sup run -t standalone",
+                        "TOPOLOGY" => "standalone");
+
+        #[test]
+        fn topology_should_fail_when_a_bad_value_is_passed() {
+            let cmd_vec = Vec::from_iter("hab-sup run --topology foobar".split_whitespace());
+            assert!(cli().get_matches_from_safe(cmd_vec).is_err());
+        }
+
+        assert_cli_cmd!(should_handle_none_strategy,
+                        "hab-sup run --strategy none",
+                        "STRATEGY" => "none");
+
+        assert_cli_cmd!(should_handle_at_once_strategy,
+                        "hab-sup run --strategy at-once",
+                        "STRATEGY" => "at-once");
+
+        assert_cli_cmd!(should_handle_rolling_strategy,
+                        "hab-sup run --strategy rolling",
+                        "STRATEGY" => "rolling");
+
+        assert_cli_cmd!(strategy_should_have_short_flag,
+                        "hab-sup run -s rolling",
+                        "STRATEGY" => "rolling");
+
+        assert_cli_cmd!(strategy_should_have_a_default_value,
+                        "hab-sup run",
+                        "STRATEGY" => "none");
+
+        #[test]
+        fn strategy_should_fail_when_a_bad_value_is_passed() {
+            let cmd_vec = Vec::from_iter("hab-sup run --strategy foobar".split_whitespace());
+            assert!(cli().get_matches_from_safe(cmd_vec).is_err());
+        }
+
         assert_cli_cmd!(should_handle_multiple_bind_flags,
                         "hab-sup run --bind service.group1 --bind service.group2",
                         "BIND" => ["service.group1", "service.group2"]);
@@ -56,6 +273,48 @@ mod test {
                         "hab-sup run --bind service.group1 service.group2 -- core/redis",
                         "BIND" => ["service.group1", "service.group2"],
                         "PKG_IDENT_OR_ARTIFACT" => "core/redis");
+
+        assert_cli_cmd!(should_handle_strict_binding_mode,
+                        "hab-sup run --binding-mode strict",
+                        "BINDING_MODE" => "strict");
+
+        assert_cli_cmd!(should_handle_relaxed_binding_mode,
+                        "hab-sup run --binding-mode relaxed",
+                        "BINDING_MODE" => "relaxed");
+
+        assert_cli_cmd!(binding_mode_should_have_default_value,
+                        "hab-sup run",
+                        "BINDING_MODE" => "strict");
+
+        #[test]
+        fn binding_mode_should_fail_when_a_bad_value_is_passed() {
+            let cmd_vec = Vec::from_iter("hab-sup run --binding-mode foobar".split_whitespace());
+            assert!(cli().get_matches_from_safe(cmd_vec).is_err());
+        }
+
+        assert_cli_cmd!(should_handle_verbose,
+                        "hab-sup run -v",
+                        "VERBOSE" => true);
+
+        assert_cli_cmd!(should_handle_no_color,
+                        "hab-sup run --no-color",
+                        "NO_COLOR" => true);
+
+        assert_cli_cmd!(should_handle_json_logging,
+                        "hab-sup run --json-logging",
+                        "JSON" => true);
+
+        assert_cli_cmd!(should_handle_health_check_interval,
+                        "hab-sup run --health-check-interval 10",
+                        "HEALTH_CHECK_INTERVAL" => "10");
+
+        assert_cli_cmd!(health_check_interval_should_have_short_flag,
+                        "hab-sup run -i 10",
+                        "HEALTH_CHECK_INTERVAL" => "10");
+
+        assert_cli_cmd!(health_check_interval_should_have_a_default_value,
+                        "hab-sup run",
+                        "HEALTH_CHECK_INTERVAL" => "30");
 
     }
 

--- a/components/sup/src/cli.rs
+++ b/components/sup/src/cli.rs
@@ -38,10 +38,6 @@ mod test {
 
         const BAD_ADDRS: [&str; 3] = ["1.1.1:1111", "1.1.1.256:1111", "1.1.1.1.1:1111"];
 
-        assert_cli_cmd!(should_handle_listen_gossip_with_value,
-                        "hab-sup run --listen-gossip 1.1.1.1:1111",
-                        "LISTEN_GOSSIP" => "1.1.1.1:1111");
-
         assert_cli_cmd!(listen_gossip_should_have_default_value,
                         "hab-sup run",
                         "LISTEN_GOSSIP" => (&GOSSIP_DEFAULT_ADDR));
@@ -54,10 +50,6 @@ mod test {
                 assert!(cli().get_matches_from_safe(cmd_vec).is_err());
             }
         }
-
-        assert_cli_cmd!(should_handle_listen_http,
-                        "hab-sup run --listen-http 1.1.1.1:1111",
-                        "LISTEN_HTTP" => "1.1.1.1:1111");
 
         assert_cli_cmd!(listen_http_should_have_default_value,
                         "hab-sup run",
@@ -72,18 +64,6 @@ mod test {
             }
         }
 
-        assert_cli_cmd!(should_handle_http_disable,
-                        "hab-sup run --http-disable",
-                        "HTTP_DISABLE" => true);
-
-        assert_cli_cmd!(http_disable_should_have_short_flag,
-                        "hab-sup run -D",
-                        "HTTP_DISABLE" => true);
-
-        assert_cli_cmd!(should_handle_listen_ctl,
-                        "hab-sup run --listen-ctl 1.1.1.1:1111",
-                        "LISTEN_CTL" => "1.1.1.1:1111");
-
         assert_cli_cmd!(listen_ctl_should_have_a_default_value,
                         "hab-sup run",
                         "LISTEN_CTL" => (&LISTEN_CTL_DEFAULT_ADDR_STRING));
@@ -96,10 +76,6 @@ mod test {
                 assert!(cli().get_matches_from_safe(cmd_vec).is_err());
             }
         }
-
-        assert_cli_cmd!(should_handle_org,
-                        "hab-sup run --org monkeypants",
-                        "ORGANIZATION" => "monkeypants");
 
         assert_cli_cmd!(should_handle_multiple_peer_flags,
                         "hab-sup run --peer 1.1.1.1 --peer 2.2.2.2",
@@ -114,18 +90,6 @@ mod test {
                         "PEER" => ["1.1.1.1", "2.2.2.2"],
                         "PKG_IDENT_OR_ARTIFACT" => "core/redis");
 
-        assert_cli_cmd!(should_handle_permanent_peer,
-                        "hab-sup run --permanent-peer",
-                        "PERMANENT_PEER" => true);
-
-        assert_cli_cmd!(permanent_peer_should_have_short_flag,
-                        "hab-sup run -I",
-                        "PERMANENT_PEER" => true);
-
-        assert_cli_cmd!(should_handle_peer_watch_file,
-                        "hab-sup run --peer-watch-file foobar",
-                        "PEER_WATCH_FILE" => "foobar");
-
         #[test]
         fn peer_watch_file_conflicts_with_peer() {
             let cmd_vec = Vec::from_iter(
@@ -134,36 +98,12 @@ mod test {
             assert!(cli().get_matches_from_safe(cmd_vec).is_err());
         }
 
-        assert_cli_cmd!(should_handle_ring,
-                        "hab-sup run --ring fizbang",
-                        "RING" => "fizbang");
-
-        assert_cli_cmd!(ring_should_have_short_flag,
-                        "hab-sup run -r flippitygibbit",
-                        "RING" => "flippitygibbit");
-
         #[test]
         fn ring_conflicts_with_ring_key() {
             let cmd_vec =
                 Vec::from_iter("hab-sup run --ring myring --ring-key foobar".split_whitespace());
             assert!(cli().get_matches_from_safe(cmd_vec).is_err());
         }
-
-        assert_cli_cmd!(should_handle_ring_key,
-                        "hab-sup run --ring-key secrit",
-                        "RING_KEY" => "secrit");
-
-        assert_cli_cmd!(should_handle_channel,
-                        "hab-sup run --channel dev",
-                        "CHANNEL" => "dev");
-
-        assert_cli_cmd!(should_handle_bldr_url,
-                        "hab-sup run --url http://not.a.real.com",
-                        "BLDR_URL" => "http://not.a.real.com");
-
-        assert_cli_cmd!(bldr_url_should_have_a_short_flag,
-                        "hab-sup run -u http://not.a.real.com",
-                        "BLDR_URL" => "http://not.a.real.com");
 
         assert_cli_cmd!(bldr_url_should_have_a_default_value,
                         "hab-sup run",
@@ -258,16 +198,6 @@ mod test {
                         "hab-sup run core/redis",
                         "PKG_IDENT_OR_ARTIFACT" => "core/redis");
 
-        assert_cli_cmd!(should_handle_application_and_environment,
-                        "hab-sup run --application foobar --environment fizbang",
-                        "APPLICATION" => "foobar",
-                        "ENVIRONMENT" => "fizbang");
-
-        assert_cli_cmd!(application_and_environment_should_have_short_flags,
-                        "hab-sup run -a foobar -e fizbang",
-                        "APPLICATION" => "foobar",
-                        "ENVIRONMENT" => "fizbang");
-
         #[test]
         fn application_requires_environment() {
             let cmd_vec = Vec::from_iter("hab-sup run -a foobar".split_whitespace());
@@ -280,10 +210,6 @@ mod test {
             assert!(cli().get_matches_from_safe(cmd_vec).is_err());
         }
 
-        assert_cli_cmd!(should_handle_group,
-                        "hab-sup run --group groupy",
-                        "GROUP" => "groupy");
-
         assert_cli_cmd!(group_should_have_default_value,
                         "hab-sup run",
                         "GROUP" => "default");
@@ -295,10 +221,6 @@ mod test {
         assert_cli_cmd!(should_handle_leader_topology,
                         "hab-sup run --topology leader",
                         "TOPOLOGY" => "leader");
-
-        assert_cli_cmd!(topology_should_have_a_short_flag,
-                        "hab-sup run -t standalone",
-                        "TOPOLOGY" => "standalone");
 
         #[test]
         fn topology_should_fail_when_a_bad_value_is_passed() {
@@ -319,10 +241,6 @@ mod test {
 
         assert_cli_cmd!(should_handle_rolling_strategy,
                         "hab-sup run --strategy rolling",
-                        "STRATEGY" => "rolling");
-
-        assert_cli_cmd!(strategy_should_have_short_flag,
-                        "hab-sup run -s rolling",
                         "STRATEGY" => "rolling");
 
         assert_cli_cmd!(strategy_should_have_a_default_value,
@@ -368,26 +286,6 @@ mod test {
             let cmd_vec = Vec::from_iter("hab-sup run --binding-mode foobar".split_whitespace());
             assert!(cli().get_matches_from_safe(cmd_vec).is_err());
         }
-
-        assert_cli_cmd!(should_handle_verbose,
-                        "hab-sup run -v",
-                        "VERBOSE" => true);
-
-        assert_cli_cmd!(should_handle_no_color,
-                        "hab-sup run --no-color",
-                        "NO_COLOR" => true);
-
-        assert_cli_cmd!(should_handle_json_logging,
-                        "hab-sup run --json-logging",
-                        "JSON" => true);
-
-        assert_cli_cmd!(should_handle_health_check_interval,
-                        "hab-sup run --health-check-interval 10",
-                        "HEALTH_CHECK_INTERVAL" => "10");
-
-        assert_cli_cmd!(health_check_interval_should_have_short_flag,
-                        "hab-sup run -i 10",
-                        "HEALTH_CHECK_INTERVAL" => "10");
 
         assert_cli_cmd!(health_check_interval_should_have_a_default_value,
                         "hab-sup run",


### PR DESCRIPTION
Here are some tests and tweaks for the `hab sup run` cli command. I'm trying to capture the existing behavior here in preparation of switching away from the macro when defining the cli. I tried to not change much of the existing behavior, but I did make a couple tweaks around default values and I fixed one bug.

The reason for making this change is to get some functionality that does not seem to work when using the macro syntax; `default_value_if` specifically (https://docs.rs/clap/2.32.0/clap/struct.Arg.html#method.default_value_if). Also, I'm not a fan of the macro syntax :|