### PR TITLE
Fix clippy::len_without_is_empty lint and add to DENIED_LINTS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -201,7 +201,6 @@ ALLOWED_LINTS = clippy::module_inception \
 # Known failing lints we want to receive warnings for, but not fail the build
 LINTS_TO_FIX = clippy::cyclomatic_complexity \
                clippy::large_enum_variant \
-               clippy::len_without_is_empty \
                clippy::needless_pass_by_value \
                clippy::needless_return \
                clippy::question_mark \
@@ -228,6 +227,7 @@ DENIED_LINTS = clippy::assign_op_pattern \
                clippy::get_unwrap \
                clippy::identity_conversion \
                clippy::if_let_some_result \
+               clippy::len_without_is_empty \
                clippy::len_zero \
                clippy::let_and_return \
                clippy::let_unit_value \

--- a/components/butterfly/src/member.rs
+++ b/components/butterfly/src/member.rs
@@ -656,6 +656,10 @@ impl MemberList {
         self.read_entries().len()
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.read_entries().is_empty()
+    }
+
     /// A randomized list of members to check.
     pub fn check_list(&self, exclude_id: &str) -> Vec<Member> {
         let mut members: Vec<_> = self
@@ -923,7 +927,7 @@ mod tests {
         #[test]
         fn new() {
             let ml = MemberList::new();
-            assert_eq!(ml.len(), 0);
+            assert!(ml.is_empty());
         }
 
         #[test]

--- a/components/butterfly/src/rumor/mod.rs
+++ b/components/butterfly/src/rumor/mod.rs
@@ -368,16 +368,6 @@ where
         self.update_counter.load(Ordering::Relaxed)
     }
 
-    /// Returns the count of all rumors in this RumorStore.
-    pub fn len(&self) -> usize {
-        self.list
-            .read()
-            .expect("Rumor store lock poisoned")
-            .values()
-            .map(|member| member.len())
-            .sum()
-    }
-
     /// Returns the count of all rumors in the rumor store for the given member's key.
     pub fn len_for_key(&self, key: &str) -> usize {
         let list = self.list.read().expect("Rumor store lock poisoned");

--- a/components/butterfly/src/server/mod.rs
+++ b/components/butterfly/src/server/mod.rs
@@ -554,7 +554,7 @@ impl Server {
     }
 
     pub fn need_peer_seeding(&self) -> bool {
-        self.member_list.len() == 0
+        self.member_list.is_empty()
     }
 
     /// Persistently block a given address, causing no traffic to be seen.

--- a/components/hab/src/command/pkg/export/mod.rs
+++ b/components/hab/src/command/pkg/export/mod.rs
@@ -147,9 +147,8 @@ mod inner {
 
     pub fn format_for(ui: &mut UI, value: &str) -> Result<ExportFormat> {
         ui.warn(format!(
-            "∅ Exporting {} packages from this operating system is not yet \
-             supported. Try running this command again on a 64-bit Linux \
-             operating system.\n",
+            "∅ Exporting {} packages from this operating system is not yet supported. Try running \
+             this command again on a 64-bit Linux operating system.\n",
             value
         ))?;
         ui.br()?;

--- a/components/sup-protocol/src/lib.rs
+++ b/components/sup-protocol/src/lib.rs
@@ -177,10 +177,19 @@ mod ctl_secret {
         let tmpdir = TempDir::new().unwrap();
         let file_path = tmpdir.path().to_owned().join("CTL_SECRET");
         let mut secret_file = File::create(file_path).unwrap();
-        write!(secret_file, "w9TuoqTk4Ixaht8ZpJpHQlmPRbvpgz13GaGnvxunJy8iOhZcS7qGqEA7jogq/Itfu4HOdQGmLRY9G5fRUcuw/w==").unwrap();
+        write!(
+            secret_file,
+            "w9TuoqTk4Ixaht8ZpJpHQlmPRbvpgz13GaGnvxunJy8iOhZcS7qGqEA7jogq/Itfu4HOdQGmLRY9G5fRUcuw/\
+             w=="
+        )
+        .unwrap();
         let mut out = String::new();
         assert_eq!(read_secret_key(tmpdir, &mut out), Ok(true));
-        assert_eq!(out, "w9TuoqTk4Ixaht8ZpJpHQlmPRbvpgz13GaGnvxunJy8iOhZcS7qGqEA7jogq/Itfu4HOdQGmLRY9G5fRUcuw/w==");
+        assert_eq!(
+            out,
+            "w9TuoqTk4Ixaht8ZpJpHQlmPRbvpgz13GaGnvxunJy8iOhZcS7qGqEA7jogq/Itfu4HOdQGmLRY9G5fRUcuw/\
+             w=="
+        );
     }
 
     #[test]
@@ -188,10 +197,19 @@ mod ctl_secret {
         let tmpdir = TempDir::new().unwrap();
         let file_path = tmpdir.path().to_owned().join("CTL_SECRET");
         let mut secret_file = File::create(file_path).unwrap();
-        writeln!(secret_file, "w9TuoqTk4Ixaht8ZpJpHQlmPRbvpgz13GaGnvxunJy8iOhZcS7qGqEA7jogq/Itfu4HOdQGmLRY9G5fRUcuw/w==").unwrap();
+        writeln!(
+            secret_file,
+            "w9TuoqTk4Ixaht8ZpJpHQlmPRbvpgz13GaGnvxunJy8iOhZcS7qGqEA7jogq/Itfu4HOdQGmLRY9G5fRUcuw/\
+             w=="
+        )
+        .unwrap();
         let mut out = String::new();
         assert_eq!(read_secret_key(tmpdir, &mut out), Ok(true));
-        assert_eq!(out, "w9TuoqTk4Ixaht8ZpJpHQlmPRbvpgz13GaGnvxunJy8iOhZcS7qGqEA7jogq/Itfu4HOdQGmLRY9G5fRUcuw/w==");
+        assert_eq!(
+            out,
+            "w9TuoqTk4Ixaht8ZpJpHQlmPRbvpgz13GaGnvxunJy8iOhZcS7qGqEA7jogq/Itfu4HOdQGmLRY9G5fRUcuw/\
+             w=="
+        );
     }
 
     #[test]
@@ -199,10 +217,19 @@ mod ctl_secret {
         let tmpdir = TempDir::new().unwrap();
         let file_path = tmpdir.path().to_owned().join("CTL_SECRET");
         let mut secret_file = File::create(file_path).unwrap();
-        writeln!(secret_file, "w9TuoqTk4Ixaht8ZpJpHQlmPRbvpgz13GaGnvxunJy8iOhZcS7qGqEA7jogq/Itfu4HOdQGmLRY9G5fRUcuw/w==\r").unwrap();
+        writeln!(
+            secret_file,
+            "w9TuoqTk4Ixaht8ZpJpHQlmPRbvpgz13GaGnvxunJy8iOhZcS7qGqEA7jogq/Itfu4HOdQGmLRY9G5fRUcuw/\
+             w==\r"
+        )
+        .unwrap();
         let mut out = String::new();
         assert_eq!(read_secret_key(tmpdir, &mut out), Ok(true));
-        assert_eq!(out, "w9TuoqTk4Ixaht8ZpJpHQlmPRbvpgz13GaGnvxunJy8iOhZcS7qGqEA7jogq/Itfu4HOdQGmLRY9G5fRUcuw/w==");
+        assert_eq!(
+            out,
+            "w9TuoqTk4Ixaht8ZpJpHQlmPRbvpgz13GaGnvxunJy8iOhZcS7qGqEA7jogq/Itfu4HOdQGmLRY9G5fRUcuw/\
+             w=="
+        );
     }
 
     #[test]


### PR DESCRIPTION
See https://rust-lang.github.io/rust-clippy/master/#len_without_is_empty

Also updated callers to use is_empty when appropriate

[1 down, 9 to go](https://github.com/habitat-sh/habitat/blob/master/Makefile#L202)…