### PR TITLE
Fix clippy::question_mark and add to DENIED_LINTS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -203,7 +203,6 @@ LINTS_TO_FIX = clippy::cyclomatic_complexity \
                clippy::large_enum_variant \
                clippy::needless_pass_by_value \
                clippy::needless_return \
-               clippy::question_mark \
                clippy::redundant_field_names \
                clippy::too_many_arguments \
                clippy::trivially_copy_pass_by_ref \
@@ -243,6 +242,7 @@ DENIED_LINTS = clippy::assign_op_pattern \
                clippy::or_fun_call \
                clippy::println_empty_string \
                clippy::ptr_arg \
+               clippy::question_mark \
                clippy::redundant_closure \
                clippy::redundant_pattern_matching \
                clippy::single_char_pattern \

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -1717,16 +1717,13 @@ fn resolve_listen_ctl_addr(input: &str) -> Result<ListenCtlAddr> {
 
     listen_ctl_addr
         .to_socket_addrs()
-        .and_then(|addrs| {
-            addrs
-                .filter(std::net::SocketAddr::is_ipv4)
-                .next()
-                .ok_or_else(|| {
-                    io::Error::new(
-                        io::ErrorKind::AddrNotAvailable,
-                        "Address could not be resolved.",
-                    )
-                })
+        .and_then(|mut addrs| {
+            addrs.find(std::net::SocketAddr::is_ipv4).ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::AddrNotAvailable,
+                    "Address could not be resolved.",
+                )
+            })
         })
         .map(ListenCtlAddr::from)
         .map_err(|e| Error::RemoteSupResolutionError(listen_ctl_addr, e))

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -1411,7 +1411,7 @@ fn required_channel_from_matches(matches: &ArgMatches<'_>) -> ChannelIdent {
 /// Resolve a channel. Taken from the environment or from CLI args, if
 /// given or return the default channel value.
 fn channel_from_matches_or_default(matches: &ArgMatches<'_>) -> ChannelIdent {
-    channel_from_matches(matches).unwrap_or_else(|| ChannelIdent::configured_value())
+    channel_from_matches(matches).unwrap_or_else(ChannelIdent::configured_value)
 }
 
 /// Resolve a target. Default to x86_64-linux if none specified


### PR DESCRIPTION
Ironically we didn't have any code that failed [`question_mark`](https://rust-lang.github.io/rust-clippy/master/#question_mark) at this point, but this moves it to DENIED_LINTS and fixes some other lints.