### PR TITLE
use console api instead of ansi codes on windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -827,7 +827,6 @@ dependencies = [
 name = "hab"
 version = "0.0.0"
 dependencies = [
- "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -857,6 +856,7 @@ dependencies = [
  "tabwriter 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tar 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -870,7 +870,6 @@ dependencies = [
 name = "habitat-launcher"
 version = "0.0.0"
 dependencies = [
- "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat-launcher-protocol 0.0.0",
  "habitat_core 0.0.0 (git+https://github.com/habitat-sh/core.git)",
@@ -921,6 +920,7 @@ dependencies = [
  "prost 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protoc 1.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "protoc-rust 1.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1016,7 +1016,6 @@ dependencies = [
 name = "habitat_common"
 version = "0.0.0"
 dependencies = [
- "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bimap 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat_api_client 0.0.0",
@@ -1037,7 +1036,7 @@ dependencies = [
  "serde_json 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.8.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "term 0.5.1 (git+https://github.com/habitat-sh/term)",
+ "termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1121,6 +1120,7 @@ dependencies = [
  "serde 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1192,7 +1192,6 @@ version = "0.0.0"
 dependencies = [
  "actix 0.7.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-web 0.7.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "caps 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1232,6 +1231,7 @@ dependencies = [
  "serde_json 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.8.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2808,16 +2808,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "term"
-version = "0.5.1"
-source = "git+https://github.com/habitat-sh/term#1b646454f859178295e7fdf41c8205add8003131"
-dependencies = [
- "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "dirs 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "termcolor"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3850,7 +3840,6 @@ dependencies = [
 "checksum tee 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "37c12559dba7383625faaff75be24becf35bfc885044375bcab931111799a3da"
 "checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
 "checksum tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "b86c784c88d98c801132806dadd3819ed29d8600836c4088e855cdf3e178ed8a"
-"checksum term 0.5.1 (git+https://github.com/habitat-sh/term)" = "<none>"
 "checksum termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4096add70612622289f2fdcdbd5086dc81c1e2675e6ae58d6c4f62a16c6d7f2f"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum textwrap 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "307686869c93e71f94da64286f9a9524c0f308a9e1c87a583de8e9c9039ad3f6"

--- a/components/common/Cargo.toml
+++ b/components/common/Cargo.toml
@@ -7,7 +7,6 @@ build = "../build-habitat.rs"
 workspace = "../../"
 
 [dependencies]
-ansi_term = "*"
 bimap = "*"
 glob = "*"
 # The handlebars crate has a few issues that require us to lock at 0.28.3
@@ -36,7 +35,7 @@ serde-transcode = "*"
 serde_yaml = "*"
 tempfile = "*"
 retry = "*"
-term = { git = "https://github.com/habitat-sh/term" }
+termcolor = "*"
 time = "*"
 toml = { version = "*", default-features = false }
 uuid = { version = "*", features = ["v4"] }

--- a/components/common/src/error.rs
+++ b/components/common/src/error.rs
@@ -35,6 +35,7 @@ pub enum Error {
     ArtifactIdentMismatch((String, String, String)),
     /// Occurs when there is no valid toml of json in the environment variable
     BadEnvConfig(String),
+    BadWeight(String),
     CantUploadGossipToml,
     ChannelNotFound,
     CryptoKeyError(String),
@@ -93,6 +94,9 @@ impl fmt::Display for Error {
             ),
             Error::BadEnvConfig(ref varname) => {
                 format!("Unable to find valid TOML or JSON in {} ENVVAR", varname)
+            }
+            Error::BadWeight(ref varname) => {
+                format!("Unable to parse Weight value from {}", varname)
             }
             Error::CantUploadGossipToml => {
                 "Can't upload gossip.toml, it's a reserved file name".to_string()
@@ -161,6 +165,7 @@ impl error::Error for Error {
             Error::APIClient(ref err) => err.description(),
             Error::ArtifactIdentMismatch((..)) => "Artifact ident does not match expected ident",
             Error::BadEnvConfig(_) => "Unknown syntax in Env Configuration",
+            Error::BadWeight(_) => "Unable to parse Weight value",
             Error::CantUploadGossipToml => "Can't upload gossip.toml, it's a reserved filename",
             Error::ChannelNotFound => "Channel not found",
             Error::CryptoKeyError(_) => "Missing or invalid key",

--- a/components/common/src/error.rs
+++ b/components/common/src/error.rs
@@ -35,7 +35,6 @@ pub enum Error {
     ArtifactIdentMismatch((String, String, String)),
     /// Occurs when there is no valid toml of json in the environment variable
     BadEnvConfig(String),
-    BadWeight(String),
     CantUploadGossipToml,
     ChannelNotFound,
     CryptoKeyError(String),
@@ -94,9 +93,6 @@ impl fmt::Display for Error {
             ),
             Error::BadEnvConfig(ref varname) => {
                 format!("Unable to find valid TOML or JSON in {} ENVVAR", varname)
-            }
-            Error::BadWeight(ref varname) => {
-                format!("Unable to parse Weight value from {}", varname)
             }
             Error::CantUploadGossipToml => {
                 "Can't upload gossip.toml, it's a reserved file name".to_string()
@@ -165,7 +161,6 @@ impl error::Error for Error {
             Error::APIClient(ref err) => err.description(),
             Error::ArtifactIdentMismatch((..)) => "Artifact ident does not match expected ident",
             Error::BadEnvConfig(_) => "Unknown syntax in Env Configuration",
-            Error::BadWeight(_) => "Unable to parse Weight value",
             Error::CantUploadGossipToml => "Can't upload gossip.toml, it's a reserved filename",
             Error::ChannelNotFound => "Channel not found",
             Error::CryptoKeyError(_) => "Missing or invalid key",

--- a/components/common/src/ui.rs
+++ b/components/common/src/ui.rs
@@ -186,7 +186,7 @@ pub trait UIWriter {
             format!("{} {}", symbol, status_str).as_bytes(),
             ColorSpec::new().set_fg(Some(color)).set_bold(true),
         )?;
-        self.out().write(format!(" {}\n", message).as_bytes())?;
+        self.out().write_all(format!(" {}\n", message).as_bytes())?;
         self.out().flush()
     }
 
@@ -195,7 +195,7 @@ pub trait UIWriter {
     where
         T: fmt::Display,
     {
-        self.out().write(format!("{}\n", text).as_bytes())?;
+        self.out().write_all(format!("{}\n", text).as_bytes())?;
         self.out().flush()
     }
 
@@ -270,7 +270,7 @@ pub trait UIWriter {
 
     /// Write a line break message`.
     fn br(&mut self) -> io::Result<()> {
-        self.out().write(b"\n")?;
+        self.out().write_all(b"\n")?;
         self.out().flush()
     }
 }
@@ -433,7 +433,7 @@ impl UIReader for UI {
                 question.as_bytes(),
                 ColorSpec::new().set_fg(Some(Color::Cyan)),
             )?;
-            stream.write(b": ")?;
+            stream.write_all(b": ")?;
             if let Some(d) = default {
                 print(
                     stream,
@@ -447,7 +447,7 @@ impl UIReader for UI {
                 )?;
                 print(stream, b"]", ColorSpec::new().set_fg(Some(Color::White)))?;
             }
-            stream.write(b" ")?;
+            stream.write_all(b" ")?;
             stream.flush()?;
             let mut response = String::new();
             {
@@ -784,7 +784,7 @@ where
         for word in line.split_whitespace() {
             let wl = word.chars().count();
             if (width + wl + 1) > (wrap_width - left_indent) {
-                stream.write(
+                stream.write_all(
                     format!("{:<width$}{}\n", " ", buffer, width = left_indent).as_bytes(),
                 )?;
                 buffer.clear();
@@ -795,9 +795,11 @@ where
             buffer.push(' ');
         }
         if !buffer.is_empty() {
-            stream.write(format!("{:<width$}{}\n", " ", buffer, width = left_indent).as_bytes())?;
+            stream.write_all(
+                format!("{:<width$}{}\n", " ", buffer, width = left_indent).as_bytes(),
+            )?;
         }
-        stream.write(b"\n")?;
+        stream.write_all(b"\n")?;
     }
     stream.flush()
 }
@@ -812,6 +814,6 @@ pub fn print(writer: &mut WriteColor, buf: &[u8], color_spec: &ColorSpec) -> io:
 
 pub fn println(writer: &mut WriteColor, buf: &[u8], color_spec: &ColorSpec) -> io::Result<()> {
     print(writer, buf, color_spec)?;
-    writer.write(b"\n")?;
+    writer.write_all(b"\n")?;
     writer.flush()
 }

--- a/components/common/src/ui.rs
+++ b/components/common/src/ui.rs
@@ -158,8 +158,7 @@ pub trait UIWriter {
         print(
             self.out(),
             format!("{} {}\n", symbol, message).as_bytes(),
-            Some(Color::Yellow),
-            Weight::Bold,
+            ColorSpec::new().set_fg(Some(Color::Yellow)).set_bold(true),
         )
     }
 
@@ -172,8 +171,7 @@ pub trait UIWriter {
         print(
             self.out(),
             format!("{} {}\n", symbol, message).as_bytes(),
-            Some(Color::Magenta),
-            Weight::Bold,
+            ColorSpec::new().set_fg(Some(Color::Magenta)).set_bold(true),
         )
     }
 
@@ -186,14 +184,12 @@ pub trait UIWriter {
         print(
             self.out(),
             format!("{} {}", symbol, status_str).as_bytes(),
-            Some(color),
-            Weight::Bold,
+            ColorSpec::new().set_fg(Some(color)).set_bold(true),
         )?;
         print(
             self.out(),
             format!(" {}\n", message).as_bytes(),
-            None,
-            Weight::Normal,
+            &ColorSpec::new(),
         )
     }
 
@@ -205,8 +201,7 @@ pub trait UIWriter {
         print(
             self.out(),
             format!("{}\n", text).as_bytes(),
-            None,
-            Weight::Normal,
+            &ColorSpec::new(),
         )
     }
 
@@ -218,8 +213,7 @@ pub trait UIWriter {
         print(
             self.err(),
             format!("∅ {}\n", message).as_bytes(),
-            Some(Color::Yellow),
-            Weight::Bold,
+            ColorSpec::new().set_fg(Some(Color::Yellow)).set_bold(true),
         )
     }
 
@@ -231,22 +225,19 @@ pub trait UIWriter {
         print(
             self.err(),
             "✗✗✗\n".as_bytes(),
-            Some(Color::Red),
-            Weight::Bold,
+            ColorSpec::new().set_fg(Some(Color::Red)).set_bold(true),
         )?;
         for line in message.to_string().lines() {
             print(
                 self.err(),
                 format!("✗✗✗ {}\n", line).as_bytes(),
-                Some(Color::Red),
-                Weight::Bold,
+                ColorSpec::new().set_fg(Some(Color::Red)).set_bold(true),
             )?;
         }
         print(
             self.err(),
             "✗✗✗\n".as_bytes(),
-            Some(Color::Red),
-            Weight::Bold,
+            ColorSpec::new().set_fg(Some(Color::Red)).set_bold(true),
         )
     }
 
@@ -264,8 +255,7 @@ pub trait UIWriter {
                 width = text.as_ref().chars().count()
             )
             .as_bytes(),
-            Some(Color::Green),
-            Weight::Bold,
+            ColorSpec::new().set_fg(Some(Color::Green)).set_bold(true),
         )
     }
 
@@ -277,8 +267,7 @@ pub trait UIWriter {
         print(
             self.out(),
             format!("{}\n\n", text.as_ref()).as_bytes(),
-            Some(Color::Green),
-            Weight::Bold,
+            ColorSpec::new().set_fg(Some(Color::Green)).set_bold(true),
         )
     }
 
@@ -286,7 +275,7 @@ pub trait UIWriter {
     fn para(&mut self, text: &str) -> io::Result<()> { print_wrapped(self.out(), text, 75, 2) }
 
     /// Write a line break message`.
-    fn br(&mut self) -> io::Result<()> { print(self.out(), b"\n", None, Weight::Normal) }
+    fn br(&mut self) -> io::Result<()> { print(self.out(), b"\n", &ColorSpec::new()) }
 }
 
 /// Console (shell) backed UI.
@@ -404,26 +393,22 @@ impl UIReader for UI {
             print(
                 stream,
                 question.as_bytes(),
-                Some(Color::Cyan),
-                Weight::Normal,
+                ColorSpec::new().set_fg(Some(Color::Cyan)),
             )?;
             print(
                 stream,
                 format!(" {}", prefix).as_bytes(),
-                Some(Color::White),
-                Weight::Normal,
+                ColorSpec::new().set_fg(Some(Color::White)),
             )?;
             print(
                 stream,
                 default_text.as_bytes(),
-                Some(Color::White),
-                Weight::Bold,
+                ColorSpec::new().set_fg(Some(Color::White)).set_bold(true),
             )?;
             print(
                 stream,
                 format!("{} ", suffix).as_bytes(),
-                Some(Color::White),
-                Weight::Normal,
+                ColorSpec::new().set_fg(Some(Color::White)),
             )?;
             let mut response = String::new();
             {
@@ -449,16 +434,23 @@ impl UIReader for UI {
             print(
                 stream,
                 question.as_bytes(),
-                Some(Color::Cyan),
-                Weight::Normal,
+                ColorSpec::new().set_fg(Some(Color::Cyan)),
             )?;
-            print(stream, b": ", None, Weight::Normal)?;
+            print(stream, b": ", &ColorSpec::new())?;
             if let Some(d) = default {
-                print(stream, b"[default: ", Some(Color::White), Weight::Normal)?;
-                print(stream, d.as_bytes(), Some(Color::White), Weight::Bold)?;
-                print(stream, b"]", Some(Color::White), Weight::Normal)?;
+                print(
+                    stream,
+                    b"[default: ",
+                    ColorSpec::new().set_fg(Some(Color::White)),
+                )?;
+                print(
+                    stream,
+                    d.as_bytes(),
+                    ColorSpec::new().set_fg(Some(Color::White)).set_bold(true),
+                )?;
+                print(stream, b"]", ColorSpec::new().set_fg(Some(Color::White)))?;
             }
-            print(stream, b" ", None, Weight::Normal)?;
+            print(stream, b" ", &ColorSpec::new())?;
             let mut response = String::new();
             {
                 let reference = self.shell.input.by_ref();
@@ -538,22 +530,6 @@ impl Shell {
 
 impl Default for Shell {
     fn default() -> Self { Shell::default_with(ColorChoice::Auto, None) }
-}
-
-#[derive(Copy, Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
-pub enum Weight {
-    Normal,
-    Bold,
-}
-
-impl Weight {
-    pub fn from_i32(value: i32) -> Result<Self> {
-        match value {
-            0 => Ok(Weight::Normal),
-            1 => Ok(Weight::Bold),
-            _ => Err(Error::BadWeight(value.to_string())),
-        }
-    }
 }
 
 pub struct InputStream {
@@ -813,8 +789,7 @@ where
                 print(
                     stream,
                     format!("{:<width$}{}\n", " ", buffer, width = left_indent).as_bytes(),
-                    None,
-                    Weight::Normal,
+                    &ColorSpec::new(),
                 )?;
                 buffer.clear();
                 width = 0;
@@ -827,27 +802,17 @@ where
             print(
                 stream,
                 format!("{:<width$}{}\n", " ", buffer, width = left_indent).as_bytes(),
-                None,
-                Weight::Normal,
+                &ColorSpec::new(),
             )?;
         }
-        print(stream, b"\n", None, Weight::Normal)?;
+        print(stream, b"\n", &ColorSpec::new())?;
     }
     Ok(())
 }
 
-pub fn print(
-    writer: &mut WriteColor,
-    buf: &[u8],
-    color: Option<Color>,
-    weight: Weight,
-) -> io::Result<()> {
+pub fn print(writer: &mut WriteColor, buf: &[u8], color_spec: &ColorSpec) -> io::Result<()> {
     writer.reset()?;
-    writer.set_color(
-        ColorSpec::new()
-            .set_bold(weight == Weight::Bold)
-            .set_fg(color),
-    )?;
+    writer.set_color(color_spec)?;
     writer.write_all(buf)?;
     writer.flush()?;
     writer.reset()

--- a/components/common/src/ui.rs
+++ b/components/common/src/ui.rs
@@ -12,20 +12,32 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{
-    env, fmt,
-    fs::{self, File},
-    io::{self, BufRead, BufReader, Read, Stdout, Write},
-    process::{self, Command},
-};
+use std::{env,
+          fmt,
+          fs::{self,
+               File},
+          io::{self,
+               BufRead,
+               BufReader,
+               Read,
+               Stdout,
+               Write},
+          process::{self,
+                    Command}};
 use uuid::Uuid;
 
 use crate::api_client::DisplayProgress;
 use pbr;
-use termcolor::{self, Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
+use termcolor::{self,
+                Color,
+                ColorChoice,
+                ColorSpec,
+                StandardStream,
+                WriteColor};
 
 use self::tty::StdStream;
-use crate::error::{Error, Result};
+use crate::error::{Error,
+                   Result};
 
 pub const NONINTERACTIVE_ENVVAR: &str = "HAB_NONINTERACTIVE";
 
@@ -216,8 +228,7 @@ pub trait UIWriter {
                 true,
             )?;
         }
-        self.err()
-            .print("✗✗✗\n".as_bytes(), Some(Color::Red), true)
+        self.err().print("✗✗✗\n".as_bytes(), Some(Color::Red), true)
     }
 
     /// Write a message formatted with `title`.
@@ -251,14 +262,10 @@ pub trait UIWriter {
     }
 
     /// Write a message formatted with `para`.
-    fn para(&mut self, text: &str) -> io::Result<()> {
-        print_wrapped(self.out(), text, 75, 2)
-    }
+    fn para(&mut self, text: &str) -> io::Result<()> { print_wrapped(self.out(), text, 75, 2) }
 
     /// Write a line break message`.
-    fn br(&mut self) -> io::Result<()> {
-        self.out().print(b"\n", None, false)
-    }
+    fn br(&mut self) -> io::Result<()> { self.out().print(b"\n", None, false) }
 }
 
 /// Console (shell) backed UI.
@@ -269,9 +276,7 @@ pub struct UI {
 
 impl UI {
     /// Creates a new `UI` from a `Shell`.
-    pub fn new(shell: Shell) -> Self {
-        UI { shell }
-    }
+    pub fn new(shell: Shell) -> Self { UI { shell } }
 
     /// Creates a new default `UI` with a coloring strategy and tty hinting.
     pub fn default_with(coloring: ColorChoice, isatty: Option<bool>) -> Self {
@@ -339,29 +344,19 @@ impl UI {
 }
 
 impl Default for UI {
-    fn default() -> Self {
-        UI::default_with(ColorChoice::Auto, None)
-    }
+    fn default() -> Self { UI::default_with(ColorChoice::Auto, None) }
 }
 
 impl UIWriter for UI {
     type ProgressBar = ConsoleProgressBar;
 
-    fn out(&mut self) -> &mut dyn ColorPrinter {
-        &mut self.shell.out
-    }
+    fn out(&mut self) -> &mut dyn ColorPrinter { &mut self.shell.out }
 
-    fn err(&mut self) -> &mut dyn ColorPrinter {
-        &mut self.shell.err
-    }
+    fn err(&mut self) -> &mut dyn ColorPrinter { &mut self.shell.err }
 
-    fn is_out_a_terminal(&self) -> bool {
-        self.shell.out.is_a_terminal()
-    }
+    fn is_out_a_terminal(&self) -> bool { self.shell.out.is_a_terminal() }
 
-    fn is_err_a_terminal(&self) -> bool {
-        self.shell.err.is_a_terminal()
-    }
+    fn is_err_a_terminal(&self) -> bool { self.shell.err.is_a_terminal() }
 
     fn progress(&self) -> Option<Self::ProgressBar> {
         if self.is_out_a_terminal() {
@@ -488,23 +483,15 @@ impl Shell {
         Shell::new(stdin, stdout, stderr)
     }
 
-    pub fn input(&mut self) -> &mut InputStream {
-        &mut self.input
-    }
+    pub fn input(&mut self) -> &mut InputStream { &mut self.input }
 
-    pub fn out(&mut self) -> &mut OutputStream {
-        &mut self.out
-    }
+    pub fn out(&mut self) -> &mut OutputStream { &mut self.out }
 
-    pub fn err(&mut self) -> &mut OutputStream {
-        &mut self.err
-    }
+    pub fn err(&mut self) -> &mut OutputStream { &mut self.err }
 }
 
 impl Default for Shell {
-    fn default() -> Self {
-        Shell::default_with(ColorChoice::Auto, None)
-    }
+    fn default() -> Self { Shell::default_with(ColorChoice::Auto, None) }
 }
 
 pub struct InputStream {
@@ -513,9 +500,7 @@ pub struct InputStream {
 }
 
 impl InputStream {
-    pub fn new(inner: Box<dyn Read + Send>, isatty: bool) -> Self {
-        InputStream { inner, isatty }
-    }
+    pub fn new(inner: Box<dyn Read + Send>, isatty: bool) -> Self { InputStream { inner, isatty } }
 
     pub fn from_stdin(isatty: Option<bool>) -> Self {
         Self::new(
@@ -527,15 +512,11 @@ impl InputStream {
         )
     }
 
-    pub fn is_a_terminal(&self) -> bool {
-        self.isatty
-    }
+    pub fn is_a_terminal(&self) -> bool { self.isatty }
 }
 
 impl Read for InputStream {
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        self.inner.read(buf)
-    }
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> { self.inner.read(buf) }
 }
 
 impl fmt::Debug for InputStream {
@@ -581,9 +562,7 @@ impl OutputStream {
         )
     }
 
-    pub fn is_a_terminal(&self) -> bool {
-        self.isatty
-    }
+    pub fn is_a_terminal(&self) -> bool { self.isatty }
 }
 
 impl ColorPrinter for OutputStream {
@@ -661,7 +640,9 @@ mod tty {
     }
     #[cfg(windows)]
     pub fn isatty(output: StdStream) -> bool {
-        use winapi::um::{consoleapi, processenv, winbase};
+        use winapi::um::{consoleapi,
+                         processenv,
+                         winbase};
 
         let handle = match output {
             StdStream::Stdin => winbase::STD_INPUT_HANDLE,
@@ -728,9 +709,7 @@ impl Write for ConsoleProgressBar {
         }
     }
 
-    fn flush(&mut self) -> io::Result<()> {
-        self.bar.flush()
-    }
+    fn flush(&mut self) -> io::Result<()> { self.bar.flush() }
 }
 
 pub fn print_wrapped<U>(

--- a/components/hab/Cargo.toml
+++ b/components/hab/Cargo.toml
@@ -13,7 +13,6 @@ doc = false
 [dependencies]
 bitflags = "*"
 base64 = "*"
-ansi_term = "*"
 dirs = "*"
 env_logger = "*"
 features = "*"
@@ -34,6 +33,7 @@ serde = "*"
 serde_json = "*"
 serde_derive = "*"
 tabwriter = "*"
+termcolor = "*"
 toml = { version = "*", default-features = false }
 url = "*"
 walkdir = "*"

--- a/components/hab/src/command/bldr/job/promote.rs
+++ b/components/hab/src/command/bldr/job/promote.rs
@@ -183,6 +183,7 @@ mod test {
                    Write},
               sync::{Arc,
                      RwLock}};
+    use termcolor::ColorChoice;
 
     use super::get_ident_list;
     use crate::{api_client::{Project,
@@ -217,7 +218,7 @@ mod test {
             Box::new(io::empty()),
             || Box::new(stdout_buf.clone()),
             || Box::new(stderr_buf.clone()),
-            Coloring::Never,
+            ColorChoice::Never,
             false,
         );
 

--- a/components/hab/src/command/bldr/job/promote.rs
+++ b/components/hab/src/command/bldr/job/promote.rs
@@ -188,8 +188,7 @@ mod test {
     use super::get_ident_list;
     use crate::{api_client::{Project,
                              SchedulerResponse},
-                common::ui::{Coloring,
-                             UI}};
+                common::ui::UI};
 
     fn sample_project_list() -> Vec<Project> {
         let project1 = Project {

--- a/components/hab/src/command/pkg/binlink.rs
+++ b/components/hab/src/command/pkg/binlink.rs
@@ -277,6 +277,7 @@ mod test {
                     FromStr},
               sync::{Arc,
                      RwLock}};
+    use termcolor::ColorChoice;
 
     use crate::{common::ui::{Coloring,
                              UI},
@@ -492,7 +493,7 @@ mod test {
             Box::new(io::empty()),
             || Box::new(stdout_buf.clone()),
             || Box::new(stderr_buf.clone()),
-            Coloring::Never,
+            ColorChoice::Never,
             false,
         );
 

--- a/components/hab/src/command/pkg/binlink.rs
+++ b/components/hab/src/command/pkg/binlink.rs
@@ -279,8 +279,7 @@ mod test {
                      RwLock}};
     use termcolor::ColorChoice;
 
-    use crate::{common::ui::{Coloring,
-                             UI},
+    use crate::{common::ui::UI,
                 hcore::{self,
                         package::{PackageIdent,
                                   PackageTarget}}};

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -29,60 +29,81 @@ extern crate lazy_static;
 extern crate log;
 use pbr;
 
-use std::{
-    env,
-    ffi::OsString,
-    fs::File,
-    io::{self, prelude::*, Read},
-    net::ToSocketAddrs,
-    path::{Path, PathBuf},
-    process, result,
-    str::FromStr,
-    thread,
-};
-use termcolor::{self, Color, ColorChoice};
+use std::{env,
+          ffi::OsString,
+          fs::File,
+          io::{self,
+               prelude::*,
+               Read},
+          net::ToSocketAddrs,
+          path::{Path,
+                 PathBuf},
+          process,
+          result,
+          str::FromStr,
+          thread};
+use termcolor::{self,
+                Color,
+                ColorChoice};
 
 #[cfg(windows)]
 use crate::hcore::crypto::dpapi::encrypt;
-use crate::{
-    common::{
-        command::package::install::{
-            InstallHookMode, InstallMode, InstallSource, LocalPackageUsage,
-        },
-        types::ListenCtlAddr,
-        ui::{Status, UIWriter, NONINTERACTIVE_ENVVAR, UI},
-    },
-    hcore::{
-        binlink::default_binlink_dir,
-        crypto::{default_cache_key_path, init, keys::PairType, BoxKeyPair, SigKeyPair},
-        env as henv,
-        env::Config as EnvConfig,
-        fs::{cache_analytics_path, cache_artifact_path, cache_key_path, launcher_root_path},
-        package::{PackageIdent, PackageTarget},
-        ChannelIdent,
-    },
-};
-use clap::{ArgMatches, Shell};
+use crate::{common::{command::package::install::{InstallHookMode,
+                                                 InstallMode,
+                                                 InstallSource,
+                                                 LocalPackageUsage},
+                     types::ListenCtlAddr,
+                     ui::{Status,
+                          UIWriter,
+                          NONINTERACTIVE_ENVVAR,
+                          UI}},
+            hcore::{binlink::default_binlink_dir,
+                    crypto::{default_cache_key_path,
+                             init,
+                             keys::PairType,
+                             BoxKeyPair,
+                             SigKeyPair},
+                    env as henv,
+                    env::Config as EnvConfig,
+                    fs::{cache_analytics_path,
+                         cache_artifact_path,
+                         cache_key_path,
+                         launcher_root_path},
+                    package::{PackageIdent,
+                              PackageTarget},
+                    ChannelIdent}};
+use clap::{ArgMatches,
+           Shell};
 use futures::prelude::*;
 
-use crate::{
-    hcore::{
-        service::{HealthCheckInterval, ServiceGroup},
-        url::{bldr_url_from_env, default_bldr_url},
-    },
-    protocol::{codec::*, ctl::ServiceBindList, net::ErrCode, types::*},
-    sup_client::{SrvClient, SrvClientError},
-};
+use crate::{hcore::{service::{HealthCheckInterval,
+                              ServiceGroup},
+                    url::{bldr_url_from_env,
+                          default_bldr_url}},
+            protocol::{codec::*,
+                       ctl::ServiceBindList,
+                       net::ErrCode,
+                       types::*},
+            sup_client::{SrvClient,
+                         SrvClientError}};
 use tabwriter::TabWriter;
 
-use hab::{
-    analytics, cli,
-    command::{self, pkg::list::ListingType},
-    config::{self, Config},
-    error::{Error, Result},
-    feat, scaffolding, AUTH_TOKEN_ENVVAR, BLDR_URL_ENVVAR, CTL_SECRET_ENVVAR, ORIGIN_ENVVAR,
-    PRODUCT, VERSION,
-};
+use hab::{analytics,
+          cli,
+          command::{self,
+                    pkg::list::ListingType},
+          config::{self,
+                   Config},
+          error::{Error,
+                  Result},
+          feat,
+          scaffolding,
+          AUTH_TOKEN_ENVVAR,
+          BLDR_URL_ENVVAR,
+          CTL_SECRET_ENVVAR,
+          ORIGIN_ENVVAR,
+          PRODUCT,
+          VERSION};
 
 /// Makes the --org CLI param optional when this env var is set
 const HABITAT_ORG_ENVVAR: &str = "HAB_ORG";
@@ -1696,9 +1717,7 @@ fn get_password_from_input(m: &ArgMatches) -> Result<Option<String>> {
 }
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
-fn get_password_from_input(_m: &ArgMatches<'_>) -> Result<Option<String>> {
-    Ok(None)
-}
+fn get_password_from_input(_m: &ArgMatches<'_>) -> Result<Option<String>> { Ok(None) }
 
 fn get_topology_from_input(m: &ArgMatches<'_>) -> Option<Topology> {
     m.value_of("TOPOLOGY")

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -55,6 +55,7 @@ use crate::{common::{command::package::install::{InstallHookMode,
                      types::ListenCtlAddr,
                      ui::{Status,
                           UIWriter,
+                          Weight,
                           NONINTERACTIVE_ENVVAR,
                           UI}},
             hcore::{binlink::default_binlink_dir,
@@ -1513,9 +1514,12 @@ fn handle_ctl_reply(reply: SrvMessage) -> result::Result<(), SrvClientError> {
                 Some(color) => Some(Color::from_str(&color)?),
                 None => None,
             };
-            UI::default_with_env()
-                .out()
-                .print(m.line.as_bytes(), c, m.bold)?;
+            common::ui::print(
+                UI::default_with_env().out(),
+                m.line.as_bytes(),
+                c,
+                Weight::from_i32(m.weight)?,
+            )?;
         }
         "NetProgress" => {
             let m = reply

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -29,79 +29,60 @@ extern crate lazy_static;
 extern crate log;
 use pbr;
 
-use std::{env,
-          ffi::OsString,
-          fs::File,
-          io::{self,
-               prelude::*,
-               Read},
-          net::ToSocketAddrs,
-          path::{Path,
-                 PathBuf},
-          process,
-          result,
-          str::FromStr,
-          thread};
+use std::{
+    env,
+    ffi::OsString,
+    fs::File,
+    io::{self, prelude::*, Read},
+    net::ToSocketAddrs,
+    path::{Path, PathBuf},
+    process, result,
+    str::FromStr,
+    thread,
+};
 use termcolor::{self, Color, ColorChoice};
 
 #[cfg(windows)]
 use crate::hcore::crypto::dpapi::encrypt;
-use crate::{common::{command::package::install::{InstallHookMode,
-                                                 InstallMode,
-                                                 InstallSource,
-                                                 LocalPackageUsage},
-                     types::ListenCtlAddr,
-                     ui::{Status,
-                          UIWriter,
-                          NONINTERACTIVE_ENVVAR,
-                          UI}},
-            hcore::{binlink::default_binlink_dir,
-                    crypto::{default_cache_key_path,
-                             init,
-                             keys::PairType,
-                             BoxKeyPair,
-                             SigKeyPair},
-                    env as henv,
-                    env::Config as EnvConfig,
-                    fs::{cache_analytics_path,
-                         cache_artifact_path,
-                         cache_key_path,
-                         launcher_root_path},
-                    package::{PackageIdent,
-                              PackageTarget},
-                    ChannelIdent}};
-use clap::{ArgMatches,
-           Shell};
+use crate::{
+    common::{
+        command::package::install::{
+            InstallHookMode, InstallMode, InstallSource, LocalPackageUsage,
+        },
+        types::ListenCtlAddr,
+        ui::{Status, UIWriter, NONINTERACTIVE_ENVVAR, UI},
+    },
+    hcore::{
+        binlink::default_binlink_dir,
+        crypto::{default_cache_key_path, init, keys::PairType, BoxKeyPair, SigKeyPair},
+        env as henv,
+        env::Config as EnvConfig,
+        fs::{cache_analytics_path, cache_artifact_path, cache_key_path, launcher_root_path},
+        package::{PackageIdent, PackageTarget},
+        ChannelIdent,
+    },
+};
+use clap::{ArgMatches, Shell};
 use futures::prelude::*;
 
-use crate::{hcore::{service::{HealthCheckInterval,
-                              ServiceGroup},
-                    url::{bldr_url_from_env,
-                          default_bldr_url}},
-            protocol::{codec::*,
-                       ctl::ServiceBindList,
-                       net::ErrCode,
-                       types::*},
-            sup_client::{SrvClient,
-                         SrvClientError}};
+use crate::{
+    hcore::{
+        service::{HealthCheckInterval, ServiceGroup},
+        url::{bldr_url_from_env, default_bldr_url},
+    },
+    protocol::{codec::*, ctl::ServiceBindList, net::ErrCode, types::*},
+    sup_client::{SrvClient, SrvClientError},
+};
 use tabwriter::TabWriter;
 
-use hab::{analytics,
-          cli,
-          command::{self,
-                    pkg::list::ListingType},
-          config::{self,
-                   Config},
-          error::{Error,
-                  Result},
-          feat,
-          scaffolding,
-          AUTH_TOKEN_ENVVAR,
-          BLDR_URL_ENVVAR,
-          CTL_SECRET_ENVVAR,
-          ORIGIN_ENVVAR,
-          PRODUCT,
-          VERSION};
+use hab::{
+    analytics, cli,
+    command::{self, pkg::list::ListingType},
+    config::{self, Config},
+    error::{Error, Result},
+    feat, scaffolding, AUTH_TOKEN_ENVVAR, BLDR_URL_ENVVAR, CTL_SECRET_ENVVAR, ORIGIN_ENVVAR,
+    PRODUCT, VERSION,
+};
 
 /// Makes the --org CLI param optional when this env var is set
 const HABITAT_ORG_ENVVAR: &str = "HAB_ORG";
@@ -1511,7 +1492,9 @@ fn handle_ctl_reply(reply: SrvMessage) -> result::Result<(), SrvClientError> {
                 Some(color) => Some(Color::from_str(&color)?),
                 None => None,
             };
-            UI::default_with_env().out().print(m.line.as_bytes(), c, m.bold)?;
+            UI::default_with_env()
+                .out()
+                .print(m.line.as_bytes(), c, m.bold)?;
         }
         "NetProgress" => {
             let m = reply
@@ -1713,7 +1696,9 @@ fn get_password_from_input(m: &ArgMatches) -> Result<Option<String>> {
 }
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
-fn get_password_from_input(_m: &ArgMatches<'_>) -> Result<Option<String>> { Ok(None) }
+fn get_password_from_input(_m: &ArgMatches<'_>) -> Result<Option<String>> {
+    Ok(None)
+}
 
 fn get_topology_from_input(m: &ArgMatches<'_>) -> Option<Topology> {
     m.value_of("TOPOLOGY")

--- a/components/launcher/Cargo.toml
+++ b/components/launcher/Cargo.toml
@@ -11,7 +11,6 @@ path = "src/main.rs"
 doc = false
 
 [dependencies]
-ansi_term = "*"
 env_logger = "*"
 # JW TODO: core has external deps that we don't want, libarchive/libsodium. We should either
 # put these things behind a feature flag so we can statically compile the launcher.

--- a/components/pkg-export-docker/Cargo.toml
+++ b/components/pkg-export-docker/Cargo.toml
@@ -32,6 +32,7 @@ rusoto_ecr = "*"
 serde = { version = "*", features = ["rc"] }
 serde_json = "*"
 tempfile = "*"
+termcolor = "*"
 url = "*"
 failure = "*"
 failure_derive = "*"

--- a/components/pkg-export-docker/src/build.rs
+++ b/components/pkg-export-docker/src/build.rs
@@ -914,8 +914,7 @@ mod test {
                          RwLock}};
         use termcolor::ColorChoice;
 
-        use crate::{common::ui::{Coloring,
-                                 UI},
+        use crate::{common::ui::UI,
                     hcore};
 
         use tempfile::TempDir;

--- a/components/pkg-export-docker/src/build.rs
+++ b/components/pkg-export-docker/src/build.rs
@@ -912,6 +912,7 @@ mod test {
                        Write},
                   sync::{Arc,
                          RwLock}};
+        use termcolor::ColorChoice;
 
         use crate::{common::ui::{Coloring,
                                  UI},
@@ -1003,7 +1004,7 @@ mod test {
                 Box::new(io::empty()),
                 || Box::new(stdout_buf.clone()),
                 || Box::new(stderr_buf.clone()),
-                Coloring::Never,
+                ColorChoice::Never,
                 false,
             );
 

--- a/components/sup-client/Cargo.toml
+++ b/components/sup-client/Cargo.toml
@@ -11,6 +11,7 @@ habitat-sup-protocol = { path = "../sup-protocol", default-features = false }
 habitat_common = { path = "../common" }
 log = "*"
 prost = "*"
+termcolor = "*"
 tokio = "*"
 tokio-core = "*"
 tokio-codec = "*"

--- a/components/sup-client/src/lib.rs
+++ b/components/sup-client/src/lib.rs
@@ -45,10 +45,15 @@ use habitat_sup_protocol as protocol;
 extern crate log;
 use habitat_common as common;
 
-use std::{error, fmt, io, path::PathBuf};
+use std::{error,
+          fmt,
+          io,
+          path::PathBuf};
 
-use crate::protocol::{codec::*, net::NetErr};
-use futures::{prelude::*, sink};
+use crate::protocol::{codec::*,
+                      net::NetErr};
+use futures::{prelude::*,
+              sink};
 use tokio::net::TcpStream;
 use tokio_codec::Framed;
 
@@ -112,27 +117,19 @@ impl fmt::Display for SrvClientError {
 }
 
 impl From<NetErr> for SrvClientError {
-    fn from(err: NetErr) -> Self {
-        SrvClientError::NetErr(err)
-    }
+    fn from(err: NetErr) -> Self { SrvClientError::NetErr(err) }
 }
 
 impl From<io::Error> for SrvClientError {
-    fn from(err: io::Error) -> Self {
-        SrvClientError::Io(err)
-    }
+    fn from(err: io::Error) -> Self { SrvClientError::Io(err) }
 }
 
 impl From<prost::DecodeError> for SrvClientError {
-    fn from(err: prost::DecodeError) -> Self {
-        SrvClientError::Decode(err)
-    }
+    fn from(err: prost::DecodeError) -> Self { SrvClientError::Decode(err) }
 }
 
 impl From<termcolor::ParseColorError> for SrvClientError {
-    fn from(err: termcolor::ParseColorError) -> Self {
-        SrvClientError::ParseColor(err)
-    }
+    fn from(err: termcolor::ParseColorError) -> Self { SrvClientError::ParseColor(err) }
 }
 
 /// Client for connecting and communicating with a server listener which speaks SrvProtocol.

--- a/components/sup-client/src/lib.rs
+++ b/components/sup-client/src/lib.rs
@@ -45,15 +45,10 @@ use habitat_sup_protocol as protocol;
 extern crate log;
 use habitat_common as common;
 
-use std::{error,
-          fmt,
-          io,
-          path::PathBuf};
+use std::{error, fmt, io, path::PathBuf};
 
-use crate::protocol::{codec::*,
-                      net::NetErr};
-use futures::{prelude::*,
-              sink};
+use crate::protocol::{codec::*, net::NetErr};
+use futures::{prelude::*, sink};
 use tokio::net::TcpStream;
 use tokio_codec::Framed;
 
@@ -117,15 +112,21 @@ impl fmt::Display for SrvClientError {
 }
 
 impl From<NetErr> for SrvClientError {
-    fn from(err: NetErr) -> Self { SrvClientError::NetErr(err) }
+    fn from(err: NetErr) -> Self {
+        SrvClientError::NetErr(err)
+    }
 }
 
 impl From<io::Error> for SrvClientError {
-    fn from(err: io::Error) -> Self { SrvClientError::Io(err) }
+    fn from(err: io::Error) -> Self {
+        SrvClientError::Io(err)
+    }
 }
 
 impl From<prost::DecodeError> for SrvClientError {
-    fn from(err: prost::DecodeError) -> Self { SrvClientError::Decode(err) }
+    fn from(err: prost::DecodeError) -> Self {
+        SrvClientError::Decode(err)
+    }
 }
 
 impl From<termcolor::ParseColorError> for SrvClientError {

--- a/components/sup-client/src/lib.rs
+++ b/components/sup-client/src/lib.rs
@@ -64,8 +64,6 @@ pub type SrvSend = sink::Send<SrvStream>;
 /// Error types returned by a [`SrvClient`].
 #[derive(Debug)]
 pub enum SrvClientError {
-    // An error from the common crate
-    CommonError(habitat_common::error::Error),
     /// The remote server unexpectedly closed the connection.
     ConnectionClosed,
     /// Unable to locate a secret key on disk.
@@ -83,7 +81,6 @@ pub enum SrvClientError {
 impl error::Error for SrvClientError {
     fn description(&self) -> &str {
         match *self {
-            SrvClientError::CommonError(ref err) => err.description(),
             SrvClientError::ConnectionClosed => "Connection closed",
             SrvClientError::CtlSecretNotFound(_) => "Ctl secret key not found",
             SrvClientError::Decode(ref err) => err.description(),
@@ -97,7 +94,6 @@ impl error::Error for SrvClientError {
 impl fmt::Display for SrvClientError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let content = match *self {
-            SrvClientError::CommonError(ref err) => format!("{}", err),
             SrvClientError::ConnectionClosed => "Connection closed".to_string(),
             SrvClientError::CtlSecretNotFound(ref path) => format!(
                 "No Supervisor CtlGateway secret set in `cli.toml` or found at {}. Run `hab \
@@ -134,10 +130,6 @@ impl From<prost::DecodeError> for SrvClientError {
 
 impl From<termcolor::ParseColorError> for SrvClientError {
     fn from(err: termcolor::ParseColorError) -> Self { SrvClientError::ParseColor(err) }
-}
-
-impl From<habitat_common::error::Error> for SrvClientError {
-    fn from(err: habitat_common::error::Error) -> Self { SrvClientError::CommonError(err) }
 }
 
 /// Client for connecting and communicating with a server listener which speaks SrvProtocol.

--- a/components/sup-client/src/lib.rs
+++ b/components/sup-client/src/lib.rs
@@ -74,6 +74,8 @@ pub enum SrvClientError {
     Io(io::Error),
     /// An RPC call to the remote was received but failed.
     NetErr(NetErr),
+    /// A parse error from an Invalid Color string
+    ParseColor(termcolor::ParseColorError),
 }
 
 impl error::Error for SrvClientError {
@@ -84,6 +86,7 @@ impl error::Error for SrvClientError {
             SrvClientError::Decode(ref err) => err.description(),
             SrvClientError::Io(ref err) => err.description(),
             SrvClientError::NetErr(ref err) => err.description(),
+            SrvClientError::ParseColor(ref err) => err.description(),
         }
     }
 }
@@ -107,6 +110,7 @@ impl fmt::Display for SrvClientError {
                 err
             ),
             SrvClientError::NetErr(ref err) => format!("{}", err),
+            SrvClientError::ParseColor(ref err) => format!("{}", err),
         };
         write!(f, "{}", content)
     }
@@ -122,6 +126,12 @@ impl From<io::Error> for SrvClientError {
 
 impl From<prost::DecodeError> for SrvClientError {
     fn from(err: prost::DecodeError) -> Self { SrvClientError::Decode(err) }
+}
+
+impl From<termcolor::ParseColorError> for SrvClientError {
+    fn from(err: termcolor::ParseColorError) -> Self {
+        SrvClientError::ParseColor(err)
+    }
 }
 
 /// Client for connecting and communicating with a server listener which speaks SrvProtocol.

--- a/components/sup-protocol/protocols/ctl.proto
+++ b/components/sup-protocol/protocols/ctl.proto
@@ -123,15 +123,9 @@ message SvcStatus {
   optional sup.types.PackageIdent ident = 1;
 }
 
-enum Weight {
-  // The weight of rendered text
-  Normal = 0;
-  Bold = 1;
-}
-
 // A reply to various requests which contains a pre-formatted console line.
 message ConsoleLine {
   required string line = 1;
   optional string color = 2;
-  required Weight weight = 3;
+  required bool bold = 3;
 }

--- a/components/sup-protocol/protocols/ctl.proto
+++ b/components/sup-protocol/protocols/ctl.proto
@@ -123,9 +123,15 @@ message SvcStatus {
   optional sup.types.PackageIdent ident = 1;
 }
 
+enum Weight {
+  // The weight of rendered text
+  Normal = 0;
+  Bold = 1;
+}
+
 // A reply to various requests which contains a pre-formatted console line.
 message ConsoleLine {
   required string line = 1;
   optional string color = 2;
-  required bool bold = 3;
+  required Weight weight = 3;
 }

--- a/components/sup-protocol/protocols/ctl.proto
+++ b/components/sup-protocol/protocols/ctl.proto
@@ -126,5 +126,6 @@ message SvcStatus {
 // A reply to various requests which contains a pre-formatted console line.
 message ConsoleLine {
   required string line = 1;
+  optional string color = 2;
+  required bool bold = 3;
 }
-

--- a/components/sup-protocol/src/generated/sup.ctl.rs
+++ b/components/sup-protocol/src/generated/sup.ctl.rs
@@ -190,4 +190,8 @@ pub struct SvcStatus {
 pub struct ConsoleLine {
     #[prost(string, required, tag="1")]
     pub line: String,
+    #[prost(string, optional, tag="2")]
+    pub color: ::std::option::Option<String>,
+    #[prost(bool, required, tag="3")]
+    pub bold: bool,
 }

--- a/components/sup-protocol/src/generated/sup.ctl.rs
+++ b/components/sup-protocol/src/generated/sup.ctl.rs
@@ -192,6 +192,14 @@ pub struct ConsoleLine {
     pub line: String,
     #[prost(string, optional, tag="2")]
     pub color: ::std::option::Option<String>,
-    #[prost(bool, required, tag="3")]
-    pub bold: bool,
+    #[prost(enumeration="Weight", required, tag="3")]
+    pub weight: i32,
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Enumeration)]
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Weight {
+    /// The weight of rendered text
+    Normal = 0,
+    Bold = 1,
 }

--- a/components/sup-protocol/src/generated/sup.ctl.rs
+++ b/components/sup-protocol/src/generated/sup.ctl.rs
@@ -192,14 +192,6 @@ pub struct ConsoleLine {
     pub line: String,
     #[prost(string, optional, tag="2")]
     pub color: ::std::option::Option<String>,
-    #[prost(enumeration="Weight", required, tag="3")]
-    pub weight: i32,
-}
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Enumeration)]
-#[derive(Serialize, Deserialize)]
-#[serde(rename_all = "kebab-case")]
-pub enum Weight {
-    /// The weight of rendered text
-    Normal = 0,
-    Bold = 1,
+    #[prost(bool, required, tag="3")]
+    pub bold: bool,
 }

--- a/components/sup/Cargo.toml
+++ b/components/sup/Cargo.toml
@@ -17,7 +17,6 @@ doc = false
 [dependencies]
 actix = "*"
 actix-web = { version = "*", default-features = false, features = [ "rust-tls" ] }
-ansi_term = "*"
 bitflags = "*"
 byteorder = "*"
 clap = { version = "*", features = [ "suggestions", "color", "unstable" ] }
@@ -50,6 +49,7 @@ serde_json = "*"
 serde_yaml = "*"
 serde-transcode = "*"
 tempfile = "*"
+termcolor = "*"
 time = "*"
 toml = { version = "*", default-features = false }
 tokio = "*"

--- a/components/sup/src/ctl_gateway/mod.rs
+++ b/components/sup/src/ctl_gateway/mod.rs
@@ -22,26 +22,30 @@
 
 pub mod server;
 
-use std::{
-    borrow::Cow,
-    fmt,
-    fs::{self, File},
-    io::{self, Write},
-    path::Path,
-};
+use std::{borrow::Cow,
+          fmt,
+          fs::{self,
+               File},
+          io::{self,
+               Write},
+          path::Path};
 
 use regex::Regex;
-use termcolor::{Buffer, Color, ColorSpec, WriteColor};
+use termcolor::{Buffer,
+                Color,
+                ColorSpec,
+                WriteColor};
 
-use crate::{
-    api_client::DisplayProgress,
-    common::ui::{ColorPrinter, UIWriter},
-    hcore::{self, output},
-    protocol,
-};
+use crate::{api_client::DisplayProgress,
+            common::ui::{ColorPrinter,
+                         UIWriter},
+            hcore::{self,
+                    output},
+            protocol};
 use futures::prelude::*;
 
-use crate::error::{Error, Result};
+use crate::error::{Error,
+                   Result};
 
 lazy_static! {
     /// Shamelessly stolen from https://github.com/chalk/ansi-regex/blob/master/index.js
@@ -106,9 +110,7 @@ impl CtlRequest {
     }
 
     /// Returns true if the request is transactional and false if not.
-    pub fn transactional(&self) -> bool {
-        self.transaction.is_some() && self.tx.is_some()
-    }
+    pub fn transactional(&self) -> bool { self.transaction.is_some() && self.tx.is_some() }
 
     fn send_msg<T>(&mut self, msg: T, complete: bool)
     where
@@ -130,21 +132,13 @@ impl CtlRequest {
 impl UIWriter for CtlRequest {
     type ProgressBar = NetProgressBar;
 
-    fn out(&mut self) -> &mut dyn ColorPrinter {
-        self
-    }
+    fn out(&mut self) -> &mut dyn ColorPrinter { self }
 
-    fn err(&mut self) -> &mut dyn ColorPrinter {
-        self
-    }
+    fn err(&mut self) -> &mut dyn ColorPrinter { self }
 
-    fn is_out_a_terminal(&self) -> bool {
-        true
-    }
+    fn is_out_a_terminal(&self) -> bool { true }
 
-    fn is_err_a_terminal(&self) -> bool {
-        true
-    }
+    fn is_err_a_terminal(&self) -> bool { true }
 
     fn progress(&self) -> Option<Self::ProgressBar> {
         if self.is_out_a_terminal() {
@@ -227,9 +221,7 @@ impl NetProgressBar {
 }
 
 impl DisplayProgress for NetProgressBar {
-    fn size(&mut self, size: u64) {
-        self.inner.total = size;
-    }
+    fn size(&mut self, size: u64) { self.inner.total = size; }
 
     fn finish(&mut self) {}
 }
@@ -241,9 +233,7 @@ impl io::Write for NetProgressBar {
         Ok(buf.len())
     }
 
-    fn flush(&mut self) -> io::Result<()> {
-        Ok(())
-    }
+    fn flush(&mut self) -> io::Result<()> { Ok(()) }
 }
 
 /// First attempts to read the secret key used to authenticate with the `CtlGateway` from disk

--- a/components/sup/src/ctl_gateway/mod.rs
+++ b/components/sup/src/ctl_gateway/mod.rs
@@ -37,8 +37,7 @@ use termcolor::{Buffer,
                 WriteColor};
 
 use crate::{api_client::DisplayProgress,
-            common::ui::{UIWriter,
-                         Weight},
+            common::ui::UIWriter,
             hcore::{self,
                     output},
             protocol};
@@ -181,14 +180,11 @@ impl Write for CtlRequest {
         match self.current_color_spec {
             Some(ref spec) => {
                 msg.color = color_to_string(spec.fg());
-                msg.weight = match spec.bold() {
-                    true => Weight::Bold as i32,
-                    false => Weight::Normal as i32,
-                }
+                msg.bold = spec.bold();
             }
             None => {
                 msg.color = None;
-                msg.weight = Weight::Normal as i32;
+                msg.bold = false;
             }
         }
         self.reply_partial(msg);

--- a/components/sup/src/ctl_gateway/mod.rs
+++ b/components/sup/src/ctl_gateway/mod.rs
@@ -173,7 +173,7 @@ impl ColorPrinter for CtlRequest {
         // that CtlRequest is sending output to two destinations with
         // different formatting requirements complicates things a bit.
         //
-        // TODO (MW): For `han sup run` scenarios, it would be nice to
+        // TODO (MW): For `hab sup run` scenarios, it would be nice to
         // support color on older versions of Windows. We could refactor
         // outputln! to support a cross platform ColorWriter similar to
         // what we use in common::UI.

--- a/components/sup/src/ctl_gateway/mod.rs
+++ b/components/sup/src/ctl_gateway/mod.rs
@@ -22,27 +22,26 @@
 
 pub mod server;
 
-use std::{borrow::Cow,
-          fmt,
-          fs::{self,
-               File},
-          io::{self,
-               Write},
-          path::Path};
+use std::{
+    borrow::Cow,
+    fmt,
+    fs::{self, File},
+    io::{self, Write},
+    path::Path,
+};
 
 use regex::Regex;
 use termcolor::{Buffer, Color, ColorSpec, WriteColor};
 
-use crate::{api_client::DisplayProgress,
-            common::ui::{ColorPrinter,
-                         UIWriter},
-            hcore::{self,
-                    output},
-            protocol};
+use crate::{
+    api_client::DisplayProgress,
+    common::ui::{ColorPrinter, UIWriter},
+    hcore::{self, output},
+    protocol,
+};
 use futures::prelude::*;
 
-use crate::error::{Error,
-                   Result};
+use crate::error::{Error, Result};
 
 lazy_static! {
     /// Shamelessly stolen from https://github.com/chalk/ansi-regex/blob/master/index.js
@@ -107,7 +106,9 @@ impl CtlRequest {
     }
 
     /// Returns true if the request is transactional and false if not.
-    pub fn transactional(&self) -> bool { self.transaction.is_some() && self.tx.is_some() }
+    pub fn transactional(&self) -> bool {
+        self.transaction.is_some() && self.tx.is_some()
+    }
 
     fn send_msg<T>(&mut self, msg: T, complete: bool)
     where
@@ -129,13 +130,21 @@ impl CtlRequest {
 impl UIWriter for CtlRequest {
     type ProgressBar = NetProgressBar;
 
-    fn out(&mut self) -> &mut dyn ColorPrinter { self }
+    fn out(&mut self) -> &mut dyn ColorPrinter {
+        self
+    }
 
-    fn err(&mut self) -> &mut dyn ColorPrinter { self }
+    fn err(&mut self) -> &mut dyn ColorPrinter {
+        self
+    }
 
-    fn is_out_a_terminal(&self) -> bool { true }
+    fn is_out_a_terminal(&self) -> bool {
+        true
+    }
 
-    fn is_err_a_terminal(&self) -> bool { true }
+    fn is_err_a_terminal(&self) -> bool {
+        true
+    }
 
     fn progress(&self) -> Option<Self::ProgressBar> {
         if self.is_out_a_terminal() {
@@ -218,7 +227,9 @@ impl NetProgressBar {
 }
 
 impl DisplayProgress for NetProgressBar {
-    fn size(&mut self, size: u64) { self.inner.total = size; }
+    fn size(&mut self, size: u64) {
+        self.inner.total = size;
+    }
 
     fn finish(&mut self) {}
 }
@@ -230,7 +241,9 @@ impl io::Write for NetProgressBar {
         Ok(buf.len())
     }
 
-    fn flush(&mut self) -> io::Result<()> { Ok(()) }
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
 }
 
 /// First attempts to read the secret key used to authenticate with the `CtlGateway` from disk

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-extern crate ansi_term;
 extern crate clap;
 extern crate env_logger;
 extern crate hab;
@@ -48,11 +47,11 @@ use std::{env,
           process,
           str::{self,
                 FromStr}};
+use termcolor::ColorChoice;
 
 use crate::{common::{cli_defaults::GOSSIP_DEFAULT_PORT,
                      command::package::install::InstallSource,
-                     ui::{Coloring,
-                          NONINTERACTIVE_ENVVAR,
+                     ui::{NONINTERACTIVE_ENVVAR,
                           UI}},
             hcore::{crypto::{self,
                              default_cache_key_path,
@@ -491,9 +490,9 @@ fn set_supervisor_logging_options(m: &ArgMatches) {
 // the scope of change contained.
 fn ui() -> UI {
     let coloring = if hcore::output::is_color() {
-        Coloring::Auto
+        ColorChoice::Auto
     } else {
-        Coloring::Never
+        ColorChoice::Never
     };
     let isatty = if env::var(NONINTERACTIVE_ENVVAR)
         .map(|val| val == "1" || val == "true")


### PR DESCRIPTION
Versions of Windows prior to Windows 10 and server 2016 do not support ANSI color control codes and render them as "gibberish" test. This means that on many "not so legacy" windows environments, Habitat output looks very unsightly.

Server 2012 R2:
![image](https://user-images.githubusercontent.com/655165/53280415-c521cb80-36ce-11e9-93b5-0d4edd56f3f1.png)

![image](https://user-images.githubusercontent.com/655165/53280424-e1be0380-36ce-11e9-9ef4-7165cad6cdb0.png)

The ubiquitous way to do color in a windows terminal has been to leverage the `SetConsoleMode` API.

The `termcolor` crate leverages that API on Windows providing cross platform terminal color support for all of the versions of Windows that Habitat supports.

This PR refactors our `common::UI` struct to use this crate and discards the `term` and `ansi_term` crates. The `term` crate is no longer supported and so this has the added benefit of moving us off of that crate. This also replaces `Blue` with `Magenta` in our `UIWriter.end` function because `blue` is virtually invisible with the default windows console backgrounds.

Here is the same output above with the changes in this PR:

![image](https://user-images.githubusercontent.com/655165/53280546-29915a80-36d0-11e9-853c-81e699a0ff55.png)

![image](https://user-images.githubusercontent.com/655165/53280555-42017500-36d0-11e9-8d73-0276ab860eba.png)



Signed-off-by: mwrock <matt@mattwrock.com>