### PR TITLE
Fix clippy::redundant_field_names needless_update and add to DENIED_LINTS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -203,7 +203,6 @@ LINTS_TO_FIX = clippy::cyclomatic_complexity \
                clippy::large_enum_variant \
                clippy::needless_pass_by_value \
                clippy::needless_return \
-               clippy::redundant_field_names \
                clippy::too_many_arguments \
                clippy::trivially_copy_pass_by_ref \
                clippy::wrong_self_convention
@@ -236,6 +235,7 @@ DENIED_LINTS = clippy::assign_op_pattern \
                clippy::needless_bool \
                clippy::needless_collect \
                clippy::needless_range_loop \
+               clippy::needless_update \
                clippy::ok_expect \
                clippy::op_ref \
                clippy::option_map_unit_fn \
@@ -244,6 +244,7 @@ DENIED_LINTS = clippy::assign_op_pattern \
                clippy::ptr_arg \
                clippy::question_mark \
                clippy::redundant_closure \
+               clippy::redundant_field_names \
                clippy::redundant_pattern_matching \
                clippy::single_char_pattern \
                clippy::single_match \

--- a/components/launcher-client/src/client.rs
+++ b/components/launcher-client/src/client.rs
@@ -168,7 +168,6 @@ impl LauncherCli {
             svc_password: password.map(|p| p.to_string()),
             env,
             id: id.to_string(),
-            ..Default::default()
         };
 
         Self::send(&self.tx, &msg)?;


### PR DESCRIPTION
All the instances of [`redundant_field_names`](https://rust-lang.github.io/rust-clippy/master/#redundant_field_names) had already been fixed (thanks @raskchanky), but this moves that lint to the category that makes new instances an error. Additionally, this fixes the one instance of [`needless_update`](https://rust-lang.github.io/rust-clippy/master/#needless_update) and adds it to the error-causing category as well.