### PR TITLE
Separate running rustfmt from installing it.

### DIFF
--- a/support/ci/install-nightly-rustfmt.sh
+++ b/support/ci/install-nightly-rustfmt.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# This script can be run standalone, but it can also be sourced from rustfmt.sh.
+# If it's sourced, then $rustup is already defined for us. If it's not, we need
+# to make sure we have it.
+: "${rustup:=$(command -v rustup)}"
+
+# Due to the nature of nightly rust, sometimes changes will break rustfmt's
+# usage of rustc. If this happens, nightly rust won't include rustfmt,
+# and we need to automatically fall back to a version that does include it.
+# Note that we begin with 1 day ago, since nightly packages can sometimes not
+# exist when this script runs if we leave it at 0.
+max_days=90
+
+for days_ago in $(seq 1 1 $max_days)
+do
+  date=$(date -d "$days_ago days ago" +%Y-%m-%d)
+  toolchain="nightly-$date"
+  echo "Installing rust $toolchain"
+  sudo -E "$rustup" toolchain install "$toolchain"
+
+  if sudo -E "$rustup" component add --toolchain "$toolchain" rustfmt; then
+    if [ "${BASH_SOURCE[0]}" != "${0}" ]; then
+      # If we made it here, this script is being sourced from rustfmt.sh, so do the check
+      cargo_fmt="$rustup run $toolchain cargo fmt --all -- --check"
+      echo "Running cargo fmt command: $cargo_fmt"
+      $cargo_fmt
+    fi
+
+    exit
+  else
+    next_days=$((days_ago + 1))
+    echo "Rust $toolchain did not include rustfmt. Let's try $next_days day(s) ago."
+  fi
+done
+
+echo "We couldn't find a release of nightly rust in the past $max_days days that includes rustfmt. Giving up entirely."
+exit 1

--- a/support/ci/rustfmt.sh
+++ b/support/ci/rustfmt.sh
@@ -11,30 +11,4 @@ rustup="/opt/rust/bin/rustup"
 # NOTE: this line should be deleted after the Docker container gets updated
 sudo chown -R buildkite-agent /home/buildkite-agent
 
-# Due to the nature of nightly rust, sometimes changes will break rustfmt's
-# usage of rustc. If this happens, nightly rust won't include rustfmt,
-# and we need to automatically fall back to a version that does include it.
-# Note that we begin with 1 day ago, since nightly packages can sometimes not
-# exist when this script runs if we leave it at 0.
-max_days=90
-
-for days_ago in $(seq 1 1 $max_days)
-do
-  date=$(date -d "$days_ago days ago" +%Y-%m-%d)
-  toolchain="nightly-$date"
-  echo "Installing rust $toolchain"
-  sudo -E $rustup toolchain install "$toolchain"
-
-  if sudo -E $rustup component add --toolchain "$toolchain" rustfmt; then
-    cargo_fmt="$rustup run $toolchain cargo fmt --all -- --check"
-    echo "Running cargo fmt command: $cargo_fmt"
-    $cargo_fmt
-    exit
-  else
-    next_days=$((days_ago + 1))
-    echo "Rust $toolchain did not include rustfmt. Let's try $next_days day(s) ago."
-  fi
-done
-
-echo "We couldn't find a release of nightly rust in the past $max_days days that includes rustfmt. Giving up entirely."
-exit 1
+source ./install-nightly-rustfmt.sh


### PR DESCRIPTION
If someone discovers that CI fails because their code wasn't formatted
properly, it'd be nice to have an easy way to install the same version
of rust nightly that CI is using. The existing script for doing this is
tightly married to BuildKite, so this separates the installation logic
from the BuildKite logic to allow developers to run
install-nightly-rustfmt.sh on their workstations.

![](https://media.giphy.com/media/5eF8reUP0IdvgdpO6A/giphy.gif)

Signed-off-by: Josh Black <raskchanky@gmail.com>