### PR TITLE
Fix a buglet in stable launcher promotion during a release

### DIFF
--- a/.buildkite/scripts/resolve_launcher_actions.sh
+++ b/.buildkite/scripts/resolve_launcher_actions.sh
@@ -16,7 +16,7 @@ promote_from_one_channel_to_another() {
     from_channel="${3}" # e.g. "stable"
     to_channel="${4}"   # e.g. "rc-0.75.0"
 
-    artifact="$(latest_from_builder "${target}" $"{from_channel}" "${package_name}")"
+    artifact="$(latest_from_builder "${target}" "${from_channel}" "${package_name}")"
     echo "--- Promoting ${artifact} (${target}) to ${to_channel}"
     hab pkg promote --auth="${HAB_AUTH_TOKEN}" "${artifact}" "${to_channel}"
 }


### PR DESCRIPTION
Turns out there's a very important difference between `$"{from_channel}"` and`"${from_channel}"`.

![tenor-181284286](https://user-images.githubusercontent.com/207178/53425738-94ce7b80-39b3-11e9-8976-6287da1b7090.gif)

Normally, Shellcheck would catch this as [SC2034](https://github.com/koalaman/shellcheck/wiki/SC2034), but we don't currently check for this due to excessive false positive rates.

Signed-off-by: Christopher Maier <cmaier@chef.io>