### PR TITLE
Fix scaffolding detection for windows.

### DIFF
--- a/components/plan-build-ps1/bin/hab-plan-build.ps1
+++ b/components/plan-build-ps1/bin/hab-plan-build.ps1
@@ -782,20 +782,30 @@ function _Resolve-ScaffoldingDependencies {
   Write-BuildLine "Resolving scaffolding dependencies"
   $scaff_build_deps = @()
   $scaff_build_deps_resolved = @()
-  _install-dependency $pkg_scaffolding
-  # Add scaffolding package to the list of scaffolding build deps
-  $scaff_build_deps += $pkg_scaffolding
-  if($resolved=(_resolve-dependency $pkg_scaffolding)) {
-    Write-BuildLine "Resolved scaffolding dependency '$pkg_scaffolding' to $resolved"
-    $scaff_build_deps_resolved+=($resolved)
-    $sdeps=(@(_Get-DepsFor $resolved) + @(_Get-BuildDepsFor $resolved))
-    foreach($sdep in $sdeps) {
-        $scaff_build_deps += $sdep
-        $scaff_build_deps_resolved+=(Resolve-Path "$HAB_PKG_PATH/$sdep").Path
+  
+  if($pkg_scaffolding.count -gt 0) {
+    $dep = $pkg_scaffolding[0]
+     _install-dependency $dep
+      # Add scaffolding package to the list of scaffolding build deps
+     $scaff_build_deps += $dep
+     if($resolved=(_resolve-dependency $dep)) {
+       Write-BuildLine "Resolved scaffolding dependency '$dep' to $resolved"
+        $scaff_build_deps_resolved+=($resolved)
+        $sdeps=(@(_Get-DepsFor $resolved) + @(_Get-BuildDepsFor $resolved))
+      foreach($sdep in $sdeps) {
+            $scaff_build_deps += $sdep
+            $scaff_build_deps_resolved+=(Resolve-Path "$HAB_PKG_PATH/$sdep").Path
+        }
+     }
+     else {
+        _Exit-With "Resolving '$dep' failed, should this be built first?" 1
     }
   }
+  elseif($pkg_scaffolding.count -gt 1) {
+    _Exit-With "More than one scaffolding detected. Please specify only one" 1
+  }
   else {
-    _Exit-With "Resolving '$pkg_scaffolding' failed, should this be built first?" 1
+    Write-BuildLine "No scaffolding present"
   }
 
   # Add all of the ordered scaffolding dependencies to the start of


### PR DESCRIPTION
We only allow one scaffolding, this ensures that is detected and gives useful feedback in the event there are more than one.

Signed-off-by: Scott Hain <shain@chef.io>