### PR TITLE
Enable local installation of latest rustfmt

### DIFF
--- a/support/ci/install-latest-rustfmt.sh
+++ b/support/ci/install-latest-rustfmt.sh
@@ -5,4 +5,4 @@ set -euo pipefail
 d=$(dirname "${BASH_SOURCE[0]}")
 source "$d/shared.sh"
 
-install_rustfmt
+maybe_install_rustfmt

--- a/support/ci/install-latest-rustfmt.sh
+++ b/support/ci/install-latest-rustfmt.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-set -euo pipefail
-
-d=$(dirname "${BASH_SOURCE[0]}")
-source "$d/shared.sh"
-
-maybe_install_rustfmt

--- a/support/ci/install-latest-rustfmt.sh
+++ b/support/ci/install-latest-rustfmt.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -euo pipefail
+
+d=$(dirname "${BASH_SOURCE[0]}")
+source "$d/shared.sh"
+
+install_rustfmt

--- a/support/ci/install-nightly-rustfmt.sh
+++ b/support/ci/install-nightly-rustfmt.sh
@@ -7,8 +7,4 @@ dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 source "$dir/shared.sh"
 toolchain=$(get_current_toolchain)
 
-install_rustup
 install_rustfmt "$toolchain"
-cargo_fmt="cargo +$toolchain fmt --all -- --check"
-echo "--- :rust: Running cargo fmt command: $cargo_fmt"
-$cargo_fmt

--- a/support/ci/rustfmt.sh
+++ b/support/ci/rustfmt.sh
@@ -2,31 +2,11 @@
 
 set -euo pipefail
 
-source ./support/ci/shared.sh
+d=$(dirname "${BASH_SOURCE[0]}")
+source "$d/shared.sh"
 
-# Due to the nature of nightly rust, sometimes changes will break rustfmt's
-# usage of rustc. If this happens, nightly rust won't include rustfmt,
-# and we need to automatically fall back to a version that does include it.
-# Note that we begin with 1 day ago, since nightly packages can sometimes not
-# exist when this script runs if we leave it at 0.
-max_days=90
-
-for days_ago in $(seq 1 1 $max_days)
-do
-  date=$(date -d "$days_ago days ago" +%Y-%m-%d)
-  echo "Installing rust nightly-$date"
-  install_rust_toolchain "nightly-$date"
-
-  if rustup component add --toolchain "$toolchain" rustfmt; then
-    cargo_fmt="cargo +$toolchain fmt --all -- --check"
-    echo "Running cargo fmt command: $cargo_fmt"
-    $cargo_fmt
-    exit
-  else
-    next_days=$((days_ago + 1))
-    echo "Rust $toolchain did not include rustfmt. Let's try $next_days day(s) ago."
-  fi
-done
-
-echo "We couldn't find a release of nightly rust in the past $max_days days that includes rustfmt. Giving up entirely."
-exit 1
+maybe_install_rustup
+install_rustfmt
+cargo_fmt="cargo +$toolchain fmt --all -- --check"
+echo "--- :rust: Running cargo fmt command: $cargo_fmt"
+$cargo_fmt

--- a/support/ci/rustfmt.sh
+++ b/support/ci/rustfmt.sh
@@ -5,6 +5,11 @@ set -euo pipefail
 d=$(dirname "${BASH_SOURCE[0]}")
 source "$d/shared.sh"
 
+# Thanks to the magic of global variables, this value will get overwritten when
+# install_rustfmt runs. But, if we don't declare it up front here, shellcheck
+# errors on the cargo_fmt statement below.
+toolchain="stable"
+
 maybe_install_rustup
 install_rustfmt
 cargo_fmt="cargo +$toolchain fmt --all -- --check"

--- a/support/ci/rustfmt.sh
+++ b/support/ci/rustfmt.sh
@@ -11,7 +11,7 @@ source "$d/shared.sh"
 toolchain="stable"
 
 maybe_install_rustup
-install_rustfmt
+maybe_install_rustfmt
 cargo_fmt="cargo +$toolchain fmt --all -- --check"
 echo "--- :rust: Running cargo fmt command: $cargo_fmt"
 $cargo_fmt

--- a/support/ci/shared.sh
+++ b/support/ci/shared.sh
@@ -12,7 +12,7 @@ maybe_install_rustup() {
   fi
 }
 
-install_rust_toolchain() {
+maybe_install_rust_toolchain() {
   local toolchain="${1?toolchain argument required}"
 
   if rustup component list --toolchain "$toolchain" >/dev/null 2>&1; then
@@ -26,7 +26,7 @@ install_rust_toolchain() {
 # Due to the nature of nightly rust, sometimes changes will break rustfmt's
 # usage of rustc. If this happens, nightly rust won't include rustfmt,
 # and we need to automatically fall back to a version that does include it.
-install_rustfmt() {
+maybe_install_rustfmt() {
   local max_days=90
 
   for days_ago in $(seq 0 1 $max_days)
@@ -35,7 +35,7 @@ install_rustfmt() {
     date=$(date -d "$days_ago days ago" +%Y-%m-%d)
     toolchain="nightly-$date"
 
-    if install_rust_toolchain "$toolchain"; then
+    if maybe_install_rust_toolchain "$toolchain"; then
       echo "--- :rust: Installation of $toolchain succeeded, or it was already installed."
     else
       next_days=$((days_ago + 1))

--- a/support/ci/shared.sh
+++ b/support/ci/shared.sh
@@ -1,17 +1,57 @@
 #!/bin/bash
 
-set -eou pipefail
+set -euo pipefail
 
-#
-# Install core rust toolchain
-# defaults to "stable"
-#
+maybe_install_rustup() {
+  if command -v rustup >/dev/null 2>&1; then
+    echo "--- :rust: rustup is currently installed."
+  else
+    echo "--- :rust: Installing rustup."
+    curl https://sh.rustup.rs -sSf | sh -s -- --no-modify-path -y
+    source "$HOME"/.cargo/env
+  fi
+}
+
 install_rust_toolchain() {
-  toolchain="${1?toolchain argument required}"
+  local toolchain="${1?toolchain argument required}"
 
-  echo "--- :rust: Installing rustup"
-  curl https://sh.rustup.rs -sSf | sh -s -- --no-modify-path -y
-  source "$HOME"/.cargo/env
-  echo "--- :rust: Installing rust $toolchain"
-  rustup toolchain install "$toolchain"  
+  if rustup component list --toolchain "$toolchain" >/dev/null 2>&1; then
+    echo "--- :rust: Rust $toolchain is already installed."
+  else
+    echo "--- :rust: Installing rust $toolchain."
+    rustup toolchain install "$toolchain"
+  fi
+}
+
+# Due to the nature of nightly rust, sometimes changes will break rustfmt's
+# usage of rustc. If this happens, nightly rust won't include rustfmt,
+# and we need to automatically fall back to a version that does include it.
+install_rustfmt() {
+  local max_days=90
+
+  for days_ago in $(seq 0 1 $max_days)
+  do
+    local date
+    date=$(date -d "$days_ago days ago" +%Y-%m-%d)
+    toolchain="nightly-$date"
+
+    if install_rust_toolchain "$toolchain"; then
+      echo "--- :rust: Installation of $toolchain succeeded, or it was already installed."
+    else
+      next_days=$((days_ago + 1))
+      echo "--- :rust: Rust $toolchain doesn't exist. Let's try $next_days days(s) ago."
+      continue
+    fi
+
+    if rustup component add --toolchain "$toolchain" rustfmt; then
+      echo "--- :rust: Installation of rustfmt for $toolchain succeeded, or it was already up to date."
+      return
+    else
+      next_days=$((days_ago + 1))
+      echo "--- :rust: Rust $toolchain did not include rustfmt. Let's try $next_days day(s) ago."
+    fi
+  done
+
+  echo "We couldn't find a release of nightly rust in the past $max_days days that includes rustfmt. Giving up entirely."
+  exit 1
 }

--- a/support/ci/shared.sh
+++ b/support/ci/shared.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 maybe_install_rustup() {
-  if command -v rustup >/dev/null 2>&1; then
+  if command -v rustup && command -v cargo &>/dev/null; then
     echo "--- :rust: rustup is currently installed."
   else
     echo "--- :rust: Installing rustup."

--- a/support/ci/shared.sh
+++ b/support/ci/shared.sh
@@ -55,3 +55,15 @@ maybe_install_rustfmt() {
   echo "We couldn't find a release of nightly rust in the past $max_days days that includes rustfmt. Giving up entirely."
   exit 1
 }
+
+install_hab_pkg() {
+  for ident; do
+    installed_pkgs=$(hab pkg list "$ident")
+
+    if [[ -z $installed_pkgs ]]; then
+      sudo hab pkg install "$ident"
+    else
+      echo "$ident already installed"
+    fi
+  done
+}

--- a/test/run_clippy.sh
+++ b/test/run_clippy.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 
-set -eou pipefail
+set -euo pipefail
 
+# This is problematic if you want to be able to run this script from anywhere other than the root of the project,
+# but changing it to an idiom like we have in rustfmt.sh breaks BK, so I dunno?
 source ./support/ci/shared.sh
 
 toolchain="${1:-stable}"
-maybe_install_rustup
+install_rustup
 install_rust_toolchain "$toolchain"
 
 # TODO: these should be in a shared script?

--- a/test/run_clippy.sh
+++ b/test/run_clippy.sh
@@ -9,13 +9,7 @@ maybe_install_rustup
 install_rust_toolchain "$toolchain"
 
 # TODO: these should be in a shared script?
-sudo hab pkg install core/bzip2
-sudo hab pkg install core/libarchive
-sudo hab pkg install core/libsodium
-sudo hab pkg install core/openssl
-sudo hab pkg install core/xz
-sudo hab pkg install core/zeromq
-sudo hab pkg install core/protobuf
+install_hab_pkg core/bzip2 core/libarchive core/libsodium core/openssl core/xz core/zeromq core/protobuf
 export SODIUM_STATIC=true # so the libarchive crate links to sodium statically
 export LIBARCHIVE_STATIC=true # so the libarchive crate *builds* statically
 export OPENSSL_DIR # so the openssl crate knows what to build against

--- a/test/run_clippy.sh
+++ b/test/run_clippy.sh
@@ -9,13 +9,13 @@ maybe_install_rustup
 install_rust_toolchain "$toolchain"
 
 # TODO: these should be in a shared script?
-hab pkg install core/bzip2
-hab pkg install core/libarchive
-hab pkg install core/libsodium
-hab pkg install core/openssl
-hab pkg install core/xz
-hab pkg install core/zeromq
-hab pkg install core/protobuf
+sudo hab pkg install core/bzip2
+sudo hab pkg install core/libarchive
+sudo hab pkg install core/libsodium
+sudo hab pkg install core/openssl
+sudo hab pkg install core/xz
+sudo hab pkg install core/zeromq
+sudo hab pkg install core/protobuf
 export SODIUM_STATIC=true # so the libarchive crate links to sodium statically
 export LIBARCHIVE_STATIC=true # so the libarchive crate *builds* statically
 export OPENSSL_DIR # so the openssl crate knows what to build against

--- a/test/run_clippy.sh
+++ b/test/run_clippy.sh
@@ -5,6 +5,7 @@ set -eou pipefail
 source ./support/ci/shared.sh
 
 toolchain="${1:-stable}"
+maybe_install_rustup
 install_rust_toolchain "$toolchain"
 
 # TODO: these should be in a shared script?


### PR DESCRIPTION
When I see that a PR of mine has failed CI because I didn't format it using the latest nightly `rustfmt`, I'd like a way to install said version quickly, with a minimum of hassle.

This PR refactors our CI scripts slightly such that:
* network calls are avoided if they can be
* running `install-latest-rustfmt.sh` will put the same version of `rustfmt` on your dev machine that is running in CI.
* the actual formatting check is only run in CI

---
# Update
After some discussion with @baumanj, we decided to pin the nightly version of rust that we're using for performing `rustfmt` checks and update it with our biweekly release cadence. I left a longer comment explaining the rationale for this in detail in `shared.sh`.

![](https://media.giphy.com/media/qxqEBcunJ67HW/giphy.gif)

Signed-off-by: Josh Black <raskchanky@gmail.com>