### PR TITLE
[plan-build] Avoid reading a newline delimited value to array

### DIFF
--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -961,7 +961,7 @@ _resolve_scaffolding_dependencies() {
     scaff_build_deps_resolved+=("$resolved")
     # Add each (fully qualified) direct run dependency of the scaffolding
     # package.
-    read -r -a sdeps <<< "$(_get_deps_for "$resolved")"
+    mapfile -t sdeps < <(_get_deps_for "$resolved")
     for sdep in "${sdeps[@]}"; do
       scaff_build_deps+=("$sdep")
       scaff_build_deps_resolved+=("$HAB_PKG_PATH/$sdep")
@@ -1035,7 +1035,7 @@ _set_build_tdeps_resolved() {
   # dependency could pull in `acme/binutils` for us, as an example. Any
   # duplicate entries are dropped to produce a proper set.
   for dep in "${pkg_build_deps_resolved[@]}"; do
-    read -r -a tdeps <<< "$(_get_tdeps_for "$dep")"
+    mapfile -t tdeps < <(_get_tdeps_for "$dep")
     for tdep in "${tdeps[@]}"; do
       tdep="$HAB_PKG_PATH/$tdep"
       read -r -a pkg_build_tdeps_resolved <<< "$(_return_or_append_to_set "$tdep" "${pkg_build_tdeps_resolved[@]}")"
@@ -1100,7 +1100,7 @@ _resolve_run_dependencies() {
   # Append all non-direct (transitive) run dependencies for each direct run
   # dependency. Any duplicate entries are dropped to produce a proper set.
   for dep in "${pkg_deps_resolved[@]}"; do
-    read -r -a tdeps <<< "$(_get_tdeps_for "$dep")"
+    mapfile -t tdeps < <(_get_tdeps_for "$dep")
     for tdep in "${tdeps[@]}"; do
       tdep="$HAB_PKG_PATH/$tdep"
       read -r -a pkg_tdeps_resolved <<< "$(_return_or_append_to_set "$tdep" "${pkg_tdeps_resolved[@]}")"


### PR DESCRIPTION
Despite my sincerest efforts, some combination of the build environment
is making reading newline delimited output to array not workable. I
tried several combinations of `read` with delimiters and IFS variables
and could not get it to work properly.

This resolves and issue where wrapper scaffolding dependencies were not
resolving because we only read the first dependency.

Signed-off-by: Ryan Cragun <ryan@chef.io>