### PR TITLE
Fix clippy::needless_pass_by_value and add to DENIED_LINTS

### DIFF
--- a/components/butterfly-test/src/lib.rs
+++ b/components/butterfly-test/src/lib.rs
@@ -21,7 +21,6 @@ extern crate lazy_static;
 use std::{ops::{Deref,
                 DerefMut,
                 Range},
-          path::PathBuf,
           str::FromStr,
           sync::Mutex,
           thread,
@@ -78,7 +77,7 @@ pub fn start_server(name: &str, ring_key: Option<SymKey>, suitability: u64) -> S
         Trace::default(),
         ring_key,
         Some(String::from(name)),
-        None::<PathBuf>,
+        None,
         Box::new(NSuitability(suitability)),
     )
     .unwrap();
@@ -136,11 +135,11 @@ impl SwimNet {
         SwimNet::new_with_suitability(suitabilities)
     }
 
-    pub fn new_ring_encryption(count: usize, ring_key: Option<SymKey>) -> SwimNet {
+    pub fn new_ring_encryption(count: usize, ring_key: &SymKey) -> SwimNet {
         let mut members = Vec::with_capacity(count);
         for x in 0..count {
             let rk = ring_key.clone();
-            members.push(start_server(&format!("{}", x), rk, 0));
+            members.push(start_server(&format!("{}", x), Some(rk), 0));
         }
         SwimNet { members }
     }

--- a/components/butterfly/src/main.rs
+++ b/components/butterfly/src/main.rs
@@ -16,7 +16,6 @@ use env_logger;
 
 use std::{env,
           net::SocketAddr,
-          path::PathBuf,
           thread,
           time::Duration};
 
@@ -57,7 +56,7 @@ fn main() {
         trace::Trace::default(),
         None,
         None,
-        None::<PathBuf>,
+        None,
         Box::new(ZeroSuitability),
     )
     .unwrap();

--- a/components/butterfly/src/rumor/departure.rs
+++ b/components/butterfly/src/rumor/departure.rs
@@ -36,10 +36,7 @@ pub struct Departure {
 }
 
 impl Departure {
-    pub fn new<U>(member_id: U) -> Self
-    where
-        U: ToString,
-    {
+    pub fn new(member_id: &str) -> Self {
         Departure {
             member_id: member_id.to_string(),
         }

--- a/components/butterfly/src/rumor/mod.rs
+++ b/components/butterfly/src/rumor/mod.rs
@@ -107,11 +107,7 @@ pub struct RumorKey {
 }
 
 impl RumorKey {
-    pub fn new<A, B>(kind: RumorType, id: A, key: B) -> RumorKey
-    where
-        A: ToString,
-        B: ToString,
-    {
+    pub fn new(kind: RumorType, id: &str, key: &str) -> RumorKey {
         RumorKey {
             kind,
             id: id.to_string(),
@@ -641,11 +637,7 @@ mod tests {
 
     #[test]
     fn rumor_keys_kind_can_be_represented_as_a_string() {
-        let r = RumorKey::new(
-            RumorType::Member,
-            String::from("my-sweet-id"),
-            String::from("my-sweet-key"),
-        );
+        let r = RumorKey::new(RumorType::Member, "my-sweet-id", "my-sweet-key");
         assert_eq!(r.kind.to_string(), "member");
     }
 

--- a/components/butterfly/src/server/expire.rs
+++ b/components/butterfly/src/server/expire.rs
@@ -44,7 +44,7 @@ impl Expire {
             for id in newly_confirmed_members {
                 self.server
                     .rumor_heat
-                    .start_hot_rumor(RumorKey::new(RumorType::Member, id, ""));
+                    .start_hot_rumor(RumorKey::new(RumorType::Member, &id, ""));
             }
 
             let newly_departed_members = self
@@ -56,7 +56,7 @@ impl Expire {
                 self.server.rumor_heat.purge(&id);
                 self.server
                     .rumor_heat
-                    .start_hot_rumor(RumorKey::new(RumorType::Member, id, ""));
+                    .start_hot_rumor(RumorKey::new(RumorType::Member, &id, ""));
             }
 
             thread::sleep(Duration::from_millis(LOOP_DELAY_MS));

--- a/components/butterfly/src/server/outbound.rs
+++ b/components/butterfly/src/server/outbound.rs
@@ -73,8 +73,7 @@ lazy_static! {
     .unwrap();
 }
 
-/// Where an Ack came from; either Ping or PingReq.
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 enum AckFrom {
     Ping,
     PingReq,

--- a/components/butterfly/src/server/push.rs
+++ b/components/butterfly/src/server/push.rs
@@ -111,7 +111,7 @@ impl Push {
                             let guard = match thread::Builder::new()
                                 .name(String::from("push-worker"))
                                 .spawn(move || {
-                                    PushWorker::new(sc).send_rumors(member, rumors);
+                                    PushWorker::new(sc).send_rumors(&member, &rumors);
                                 }) {
                                 Ok(guard) => guard,
                                 Err(e) => {
@@ -159,7 +159,7 @@ impl PushWorker {
     /// closes the connection as soon as we are done sending rumors. ZeroMQ may choose to keep the
     /// connection and socket open for 1 second longer - so it is possible, but unlikely, that this
     /// method can lose messages.
-    fn send_rumors(&self, member: Member, rumors: Vec<RumorKey>) {
+    fn send_rumors(&self, member: &Member, rumors: &[RumorKey]) {
         let socket = (**ZMQ_CONTEXT)
             .as_mut()
             .socket(zmq::PUSH)

--- a/components/butterfly/src/trace.rs
+++ b/components/butterfly/src/trace.rs
@@ -193,7 +193,7 @@ impl Trace {
     }
 
     /// Write a line to the trace file.
-    pub fn write(&mut self, trace_write: TraceWrite<'_>) {
+    pub fn write(&mut self, trace_write: &TraceWrite<'_>) {
         let dump = format!("{:#?}", self);
         match self.file.as_mut() {
             Some(file) => match write!(file, "{}", trace_write) {
@@ -231,7 +231,7 @@ macro_rules! trace_it {
             tw.server_name = Some(&server_name);
             tw.member_id = Some(member_id);
             tw.rumor = Some(&payload);
-            trace.write(tw);
+            trace.write(&tw);
         }
     }};
 
@@ -255,7 +255,7 @@ macro_rules! trace_it {
                 tw.server_name = Some(&server_name);
                 tw.member_id = Some(member_id);
                 tw.rumor = Some(&payload);
-                trace.write(tw);
+                trace.write(&tw);
             }
         }
     }};
@@ -276,7 +276,7 @@ macro_rules! trace_it {
             tw.server_name = Some(&server_name);
             tw.member_id = Some(member_id);
             tw.rumor = Some(&rumor_text);
-            trace.write(tw);
+            trace.write(&tw);
         }
     }};
 
@@ -301,7 +301,7 @@ macro_rules! trace_it {
             tw.to_addr = Some(&to_addr);
             tw.swim = None;
             tw.rumor = None;
-            trace.write(tw);
+            trace.write(&tw);
         }
     }};
     (SWIM: $server:expr, $msg_type:expr, $to_member_id:expr, $to_addr:expr, $payload:expr) => {{
@@ -332,7 +332,7 @@ macro_rules! trace_it {
             tw.to_addr = Some(&to_addr);
             tw.swim = Some(&swim_str);
             tw.rumor = None;
-            trace.write(tw);
+            trace.write(&tw);
         }
     }};
     (GOSSIP: $server:expr, $msg_type:expr, $to_member_id:expr, $payload:expr) => {{
@@ -397,7 +397,7 @@ macro_rules! trace_it {
             tw.listening = Some(&listening);
             tw.swim = None;
             tw.rumor = Some(&rp);
-            trace.write(tw);
+            trace.write(&tw);
         }
     }};
 }

--- a/components/butterfly/tests/encryption/mod.rs
+++ b/components/butterfly/tests/encryption/mod.rs
@@ -21,7 +21,7 @@ use crate::btest;
 fn symmetric_encryption_of_wire_payloads() {
     let ring_key = SymKey::generate_pair_for_ring("wolverine")
         .expect("Failed to generate an in memory symkey");
-    let mut net = btest::SwimNet::new_ring_encryption(2, Some(ring_key));
+    let mut net = btest::SwimNet::new_ring_encryption(2, &ring_key);
     net.connect(0, 1);
     assert_wait_for_health_of!(net, [0..2, 0..2], Health::Alive);
     net.add_service(0, "core/beast/1.2.3/20161208121212");

--- a/components/butterfly/tests/rumor/departure.rs
+++ b/components/butterfly/tests/rumor/departure.rs
@@ -34,10 +34,10 @@ fn departure_via_client() {
     net.mesh();
 
     net.wait_for_gossip_rounds(1);
-    let mut client =
-        Client::new(net[0].gossip_addr(), None).expect("Cannot create Butterfly Client");
+    let mut client = Client::new(&net[0].gossip_addr().to_string(), None)
+        .expect("Cannot create Butterfly Client");
     client
-        .send_departure(String::from(net[1].member_id()))
+        .send_departure(&net[1].member_id())
         .expect("Cannot send the departure");
     net.wait_for_gossip_rounds(1);
     assert!(net[2]

--- a/components/butterfly/tests/rumor/service_config.rs
+++ b/components/butterfly/tests/rumor/service_config.rs
@@ -33,8 +33,8 @@ fn service_config_via_client() {
     net.mesh();
 
     net.wait_for_gossip_rounds(1);
-    let mut client =
-        Client::new(net[0].gossip_addr(), None).expect("Cannot create Butterfly Client");
+    let mut client = Client::new(&net[0].gossip_addr().to_string(), None)
+        .expect("Cannot create Butterfly Client");
     let payload = b"I want to get lost in you, tokyo";
     client
         .send_service_config(

--- a/components/butterfly/tests/rumor/service_file.rs
+++ b/components/butterfly/tests/rumor/service_file.rs
@@ -38,8 +38,8 @@ fn service_file_via_client() {
     net.mesh();
 
     net.wait_for_gossip_rounds(1);
-    let mut client =
-        Client::new(net[0].gossip_addr(), None).expect("Cannot create Butterfly Client");
+    let mut client = Client::new(&net[0].gossip_addr().to_string(), None)
+        .expect("Cannot create Butterfly Client");
     let payload = b"I want to get lost in you, tokyo";
     client
         .send_service_file(

--- a/components/common/src/package_graph.rs
+++ b/components/common/src/package_graph.rs
@@ -245,9 +245,9 @@ mod test {
         deps: Vec<PackageIdent>,
     }
 
-    fn build(packages: Vec<PackageDeps>) -> PackageGraph {
+    fn build(packages: &[PackageDeps]) -> PackageGraph {
         let mut graph = PackageGraph::empty();
-        for p in &packages {
+        for p in packages.iter() {
             graph.extend(&p.ident, &p.deps);
         }
         graph
@@ -273,7 +273,7 @@ mod test {
     fn empty_graph() {
         let packages = Vec::new();
 
-        let graph = build(packages);
+        let graph = build(&packages);
         assert_eq!(graph.node_count(), 0);
         assert_eq!(graph.edge_count(), 0);
     }
@@ -285,7 +285,7 @@ mod test {
             empty_package_deps(PackageIdent::from_str("core/foo/1.0/20180704142702").unwrap()),
         ];
 
-        let graph = build(packages);
+        let graph = build(&packages);
         assert_eq!(graph.node_count(), 2);
         assert_eq!(graph.edge_count(), 0);
     }
@@ -299,7 +299,7 @@ mod test {
             package_deps(b.clone(), &[a.clone()]),
         ];
 
-        let graph = build(packages);
+        let graph = build(&packages);
         assert!(graph.has_package(&a));
         assert!(graph.has_package(&b));
 
@@ -316,7 +316,7 @@ mod test {
             empty_package_deps(PackageIdent::from_str("mine/redis/2.1.0/20180704142101").unwrap()),
         ];
 
-        let graph = build(packages);
+        let graph = build(&packages);
         assert_eq!(graph.node_count(), 2);
         assert_eq!(graph.edge_count(), 0);
     }
@@ -334,7 +334,7 @@ mod test {
             package_deps(d.clone(), &[b.clone(), c.clone()]),
         ];
 
-        let graph = build(packages);
+        let graph = build(&packages);
         assert_eq!(graph.node_count(), 4);
         assert_eq!(graph.edge_count(), 4);
 
@@ -356,7 +356,7 @@ mod test {
             package_deps(d.clone(), &[b.clone(), c.clone()]),
         ];
 
-        let graph = build(packages);
+        let graph = build(&packages);
         assert_eq!(graph.node_count(), 4);
         assert_eq!(graph.edge_count(), 4);
 
@@ -379,7 +379,7 @@ mod test {
             package_deps(d.clone(), &[b.clone(), c.clone()]),
         ];
 
-        let graph = build(packages);
+        let graph = build(&packages);
         assert_eq!(graph.node_count(), 4);
         assert_eq!(graph.edge_count(), 4);
 
@@ -404,7 +404,7 @@ mod test {
             package_deps(d.clone(), &[b.clone(), c.clone()]),
         ];
 
-        let graph = build(packages);
+        let graph = build(&packages);
         assert_eq!(graph.node_count(), 4);
         assert_eq!(graph.edge_count(), 4);
 
@@ -427,7 +427,7 @@ mod test {
             package_deps(d.clone(), &[b.clone(), c.clone()]),
         ];
 
-        let graph = build(packages);
+        let graph = build(&packages);
         assert_eq!(graph.node_count(), 4);
         assert_eq!(graph.edge_count(), 4);
 
@@ -452,7 +452,7 @@ mod test {
             package_deps(d.clone(), &[b.clone(), c.clone()]),
         ];
 
-        let mut graph = build(packages);
+        let mut graph = build(&packages);
         assert_eq!(graph.node_count(), 4);
         assert_eq!(graph.edge_count(), 4);
 
@@ -477,7 +477,7 @@ mod test {
             package_deps(b.clone(), &[a.clone()]),
         ];
 
-        let mut graph = build(packages);
+        let mut graph = build(&packages);
         assert_eq!(graph.node_count(), 2);
         assert_eq!(graph.edge_count(), 1);
 
@@ -492,7 +492,7 @@ mod test {
         let a = PackageIdent::from_str("core/redis/2.1.0/20180704142101").unwrap();
         let packages = vec![empty_package_deps(a.clone())];
 
-        let graph = build(packages);
+        let graph = build(&packages);
         assert_eq!(graph.node_count(), 1);
         assert_eq!(graph.edge_count(), 0);
 
@@ -513,7 +513,7 @@ mod test {
             package_deps(d.clone(), &[b.clone(), c.clone()]),
         ];
 
-        let graph = build(packages);
+        let graph = build(&packages);
         assert_eq!(graph.node_count(), 4);
         assert_eq!(graph.edge_count(), 4);
 
@@ -535,7 +535,7 @@ mod test {
             package_deps(d.clone(), &[c.clone()]),
         ];
 
-        let graph = build(packages);
+        let graph = build(&packages);
         assert_eq!(graph.node_count(), 4);
         assert_eq!(graph.edge_count(), 3);
 
@@ -557,7 +557,7 @@ mod test {
             package_deps(d.clone(), &[c.clone()]),
         ];
 
-        let graph = build(packages);
+        let graph = build(&packages);
         assert_eq!(graph.node_count(), 4);
         assert_eq!(graph.edge_count(), 3);
 
@@ -570,7 +570,7 @@ mod test {
         let a = PackageIdent::from_str("core/redis/2.1.0/20180704142101").unwrap();
         let packages = vec![empty_package_deps(a.clone())];
 
-        let graph = build(packages);
+        let graph = build(&packages);
         assert_eq!(graph.node_count(), 1);
         assert_eq!(graph.edge_count(), 0);
 
@@ -591,7 +591,7 @@ mod test {
             package_deps(d.clone(), &[c.clone()]),
         ];
 
-        let graph = build(packages);
+        let graph = build(&packages);
         assert_eq!(graph.node_count(), 4);
         assert_eq!(graph.edge_count(), 3);
 

--- a/components/common/src/templating/config.rs
+++ b/components/common/src/templating/config.rs
@@ -1222,14 +1222,14 @@ mod test {
             pkg_dir.clone(),
         );
         let toml_path = pkg_dir.join("default.toml");
-        create_with_content(toml_path, &String::from("message = \"Hello\""));
+        create_with_content(toml_path, "message = \"Hello\"");
 
         let config_dir = pkg_dir.join("config");
         let deep_config_dir = config_dir.join("dir_a").join("dir_b");
         fs::create_dir_all(&deep_config_dir).expect("create config/dir_a/dir_b");
         create_with_content(
             deep_config_dir.join("config.txt"),
-            &String::from("config message is {{cfg.message}}"),
+            "config message is {{cfg.message}}",
         );
 
         // Setup context for loading and compiling templates

--- a/components/common/src/templating/hooks.rs
+++ b/components/common/src/templating/hooks.rs
@@ -755,7 +755,7 @@ echo "The message is Hola Mundo"
 
         // This is gross, but it actually works
         let cfg_path = concrete_path.as_ref().join("default.toml");
-        create_with_content(cfg_path, &String::from("message = \"Hello\""));
+        create_with_content(cfg_path, "message = \"Hello\"");
 
         let cfg = Cfg::new(&pkg, Some(&concrete_path.as_ref().to_path_buf()))
             .expect("Could not create config");

--- a/components/common/src/templating/mod.rs
+++ b/components/common/src/templating/mod.rs
@@ -378,18 +378,18 @@ test: something"#
             PackageInstall::new_from_parts(pg_id.clone(), root.clone(), root.clone(), root.clone());
 
         let toml_path = root.join("default.toml");
-        create_with_content(toml_path, &String::from("message = \"Hello\""));
+        create_with_content(toml_path, "message = \"Hello\"");
         let hooks_path = root.join("hooks");
         std::fs::create_dir_all(&hooks_path).unwrap();
         create_with_content(
             hooks_path.join("install"),
-            &String::from("install message is {{cfg.message}}"),
+            "install message is {{cfg.message}}",
         );
         let config_path = root.join("config_install");
         std::fs::create_dir_all(&config_path).unwrap();
         create_with_content(
             config_path.join("config.txt"),
-            &String::from("config message is {{cfg.message}}"),
+            "config message is {{cfg.message}}",
         );
 
         compile_for_package_install(&pkg_install).expect("compile package");

--- a/components/common/src/templating/test_helpers.rs
+++ b/components/common/src/templating/test_helpers.rs
@@ -22,13 +22,12 @@ use crate::json;
 use serde_json;
 use valico::json_schema;
 
-pub fn create_with_content<P, C>(path: P, content: C)
+pub fn create_with_content<P>(path: P, content: &str)
 where
     P: AsRef<Path>,
-    C: ToString,
 {
     let mut file = File::create(path).expect("Cannot create file");
-    file.write_all(content.to_string().as_bytes())
+    file.write_all(content.as_bytes())
         .expect("Cannot write to file");
 }
 

--- a/components/common/src/types/listen_ctl_addr.rs
+++ b/components/common/src/types/listen_ctl_addr.rs
@@ -23,10 +23,6 @@ use std::{fmt,
           result,
           str::FromStr};
 
-use super::env_config::EnvConfig;
-use crate::error::{Error,
-                   Result};
-
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub struct ListenCtlAddr(SocketAddr);
 

--- a/components/common/src/types/listen_ctl_addr.rs
+++ b/components/common/src/types/listen_ctl_addr.rs
@@ -23,7 +23,11 @@ use std::{fmt,
           result,
           str::FromStr};
 
-#[derive(Clone, PartialEq, Eq, Debug)]
+use super::env_config::EnvConfig;
+use crate::error::{Error,
+                   Result};
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub struct ListenCtlAddr(SocketAddr);
 
 impl ListenCtlAddr {

--- a/components/common/src/ui.rs
+++ b/components/common/src/ui.rs
@@ -677,6 +677,7 @@ impl WriteStream {
 }
 
 mod tty {
+    #[derive(Clone, Copy)]
     pub enum StdStream {
         Stdin,
         Stdout,

--- a/components/hab/src/analytics.rs
+++ b/components/hab/src/analytics.rs
@@ -229,6 +229,7 @@ const OPTED_IN_METAFILE: &str = "OPTED_IN";
 const OPTED_OUT_METAFILE: &str = "OPTED_OUT";
 
 /// Different kinds of analytic events.
+#[derive(Clone, Copy)]
 enum Event {
     /// Occurs when a CLI error occurs, such as when a required argument is missing, an invalid
     /// subcommand is invoked, etc.

--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -1106,6 +1106,8 @@ fn sub_svc_load() -> App<'static, 'static> {
 
 // CLAP Validation Functions
 ////////////////////////////////////////////////////////////////////////
+
+#[allow(clippy::needless_pass_by_value)] // Signature required by CLAP
 fn valid_binding_mode(val: String) -> result::Result<(), String> {
     match habitat_sup_protocol::types::BindingMode::from_str(&val) {
         Ok(_) => Ok(()),
@@ -1113,6 +1115,7 @@ fn valid_binding_mode(val: String) -> result::Result<(), String> {
     }
 }
 
+#[allow(clippy::needless_pass_by_value)] // Signature required by CLAP
 fn valid_pair_type(val: String) -> result::Result<(), String> {
     match PairType::from_str(&val) {
         Ok(_) => Ok(()),
@@ -1123,10 +1126,12 @@ fn valid_pair_type(val: String) -> result::Result<(), String> {
     }
 }
 
+#[allow(clippy::needless_pass_by_value)] // Signature required by CLAP
 fn valid_service_group(val: String) -> result::Result<(), String> {
     ServiceGroup::validate(&val).map_err(|e| e.to_string())
 }
 
+#[allow(clippy::needless_pass_by_value)] // Signature required by CLAP
 fn dir_exists(val: String) -> result::Result<(), String> {
     if Path::new(&val).is_dir() {
         Ok(())
@@ -1135,6 +1140,7 @@ fn dir_exists(val: String) -> result::Result<(), String> {
     }
 }
 
+#[allow(clippy::needless_pass_by_value)] // Signature required by CLAP
 fn file_exists(val: String) -> result::Result<(), String> {
     if Path::new(&val).is_file() {
         Ok(())
@@ -1151,6 +1157,7 @@ fn file_exists_or_stdin(val: String) -> result::Result<(), String> {
     }
 }
 
+#[allow(clippy::needless_pass_by_value)] // Signature required by CLAP
 fn valid_socket_addr(val: String) -> result::Result<(), String> {
     match SocketAddr::from_str(&val) {
         Ok(_) => Ok(()),
@@ -1160,6 +1167,7 @@ fn valid_socket_addr(val: String) -> result::Result<(), String> {
     }
 }
 
+#[allow(clippy::needless_pass_by_value)] // Signature required by CLAP
 fn valid_url(val: String) -> result::Result<(), String> {
     match Url::parse(&val) {
         Ok(_) => Ok(()),
@@ -1167,6 +1175,7 @@ fn valid_url(val: String) -> result::Result<(), String> {
     }
 }
 
+#[allow(clippy::needless_pass_by_value)] // Signature required by CLAP
 fn valid_numeric<T: FromStr>(val: String) -> result::Result<(), String> {
     match val.parse::<T>() {
         Ok(_) => Ok(()),
@@ -1174,6 +1183,7 @@ fn valid_numeric<T: FromStr>(val: String) -> result::Result<(), String> {
     }
 }
 
+#[allow(clippy::needless_pass_by_value)] // Signature required by CLAP
 fn valid_health_check_interval(val: String) -> result::Result<(), String> {
     match HealthCheckInterval::from_str(&val) {
         Ok(_) => Ok(()),
@@ -1184,6 +1194,7 @@ fn valid_health_check_interval(val: String) -> result::Result<(), String> {
     }
 }
 
+#[allow(clippy::needless_pass_by_value)] // Signature required by CLAP
 fn valid_update_strategy(val: String) -> result::Result<(), String> {
     match habitat_sup_protocol::types::UpdateStrategy::from_str(&val) {
         Ok(_) => Ok(()),
@@ -1191,6 +1202,7 @@ fn valid_update_strategy(val: String) -> result::Result<(), String> {
     }
 }
 
+#[allow(clippy::needless_pass_by_value)] // Signature required by CLAP
 fn valid_ident(val: String) -> result::Result<(), String> {
     match PackageIdent::from_str(&val) {
         Ok(_) => Ok(()),
@@ -1201,6 +1213,7 @@ fn valid_ident(val: String) -> result::Result<(), String> {
     }
 }
 
+#[allow(clippy::needless_pass_by_value)] // Signature required by CLAP
 fn valid_target(val: String) -> result::Result<(), String> {
     match PackageTarget::from_str(&val) {
         Ok(_) => Ok(()),
@@ -1212,6 +1225,7 @@ fn valid_target(val: String) -> result::Result<(), String> {
     }
 }
 
+#[allow(clippy::needless_pass_by_value)] // Signature required by CLAP
 fn valid_fully_qualified_ident(val: String) -> result::Result<(), String> {
     match PackageIdent::from_str(&val) {
         Ok(ref ident) if ident.fully_qualified() => Ok(()),
@@ -1223,6 +1237,7 @@ fn valid_fully_qualified_ident(val: String) -> result::Result<(), String> {
     }
 }
 
+#[allow(clippy::needless_pass_by_value)] // Signature required by CLAP
 fn valid_origin(val: String) -> result::Result<(), String> {
     if ident::is_valid_origin_name(&val) {
         Ok(())

--- a/components/hab/src/command/cli/setup.rs
+++ b/components/hab/src/command/cli/setup.rs
@@ -193,7 +193,7 @@ pub fn start(
         ui.br()?;
         ui.para("Enter your Habitat Personal Access Token.")?;
         let auth_token = prompt_auth_token(ui)?;
-        write_cli_config_auth_token(auth_token)?;
+        write_cli_config_auth_token(&auth_token)?;
     } else {
         ui.para("Okay, maybe another time.")?;
     }
@@ -201,7 +201,7 @@ pub fn start(
         ui.br()?;
         ui.para("Enter your Habitat Supervisor CtlGateway secret.")?;
         let ctl_secret = prompt_ctl_secret(ui)?;
-        write_cli_config_ctl_secret(ctl_secret)?;
+        write_cli_config_ctl_secret(&ctl_secret)?;
     } else {
         ui.para("Okay, maybe another time.")?;
     }
@@ -266,37 +266,25 @@ fn ask_create_origin(ui: &mut UI, origin: &str) -> Result<bool> {
     )?)
 }
 
-fn write_cli_config_origin<T>(origin: T) -> Result<()>
-where
-    T: ToString,
-{
+fn write_cli_config_origin(origin: &str) -> Result<()> {
     let mut config = config::load()?;
     config.origin = Some(origin.to_string());
     config::save(&config)
 }
 
-fn write_cli_config_bldr_url<T>(url: T) -> Result<()>
-where
-    T: ToString,
-{
+fn write_cli_config_bldr_url(url: &str) -> Result<()> {
     let mut config = config::load()?;
     config.bldr_url = Some(url.to_string());
     config::save(&config)
 }
 
-fn write_cli_config_auth_token<T>(auth_token: T) -> Result<()>
-where
-    T: ToString,
-{
+fn write_cli_config_auth_token(auth_token: &str) -> Result<()> {
     let mut config = config::load()?;
     config.auth_token = Some(auth_token.to_string());
     config::save(&config)
 }
 
-fn write_cli_config_ctl_secret<T>(value: T) -> Result<()>
-where
-    T: ToString,
-{
+fn write_cli_config_ctl_secret(value: &str) -> Result<()> {
     let mut config = config::load()?;
     config.ctl_secret = Some(value.to_string());
     config::save(&config)

--- a/components/hab/src/command/origin/key/export.rs
+++ b/components/hab/src/command/origin/key/export.rs
@@ -21,6 +21,7 @@ use crate::hcore::crypto::{keys::PairType,
 
 use crate::error::Result;
 
+#[warn(clippy::needless_pass_by_value)] // Remove after making `PairType` Copy
 pub fn start(origin: &str, pair_type: PairType, cache: &Path) -> Result<()> {
     let latest = SigKeyPair::get_latest_pair_for(origin, cache, Some(&pair_type))?;
     let path = match pair_type {

--- a/components/hab/src/command/pkg/dependencies.rs
+++ b/components/hab/src/command/pkg/dependencies.rs
@@ -27,8 +27,8 @@ use crate::{common::package_graph::PackageGraph,
 /// the provided identifier
 pub fn start(
     ident: &PackageIdent,
-    scope: &Scope,
-    direction: &DependencyRelation,
+    scope: Scope,
+    direction: DependencyRelation,
     fs_root_path: &Path,
 ) -> Result<()> {
     let pkg_install = PackageInstall::load(ident, Some(fs_root_path))?;

--- a/components/hab/src/command/pkg/mod.rs
+++ b/components/hab/src/command/pkg/mod.rs
@@ -34,6 +34,7 @@ pub mod upload;
 pub mod verify;
 
 /// Used in commands like uninstall which provide a --dry-run option
+#[derive(Clone, Copy)]
 pub enum ExecutionStrategy {
     /// Don't actually run commands that mutate the state of the system,
     /// simply print their output
@@ -44,6 +45,7 @@ pub enum ExecutionStrategy {
 
 /// Used in `hab pkg` commands to choose where to apply the command to just a package
 /// or the package and its dependencies
+#[derive(Clone, Copy)]
 pub enum Scope {
     Package,
     PackageAndDependencies,
@@ -52,6 +54,7 @@ pub enum Scope {
 /// Express the relationship between two packages
 /// `Requires`: a dependency from a package to one it depends on
 /// `Supports`: a dependency from a package to one that depends on it
+#[derive(Clone, Copy)]
 pub enum DependencyRelation {
     Requires,
     Supports,

--- a/components/hab/src/command/pkg/uninstall.rs
+++ b/components/hab/src/command/pkg/uninstall.rs
@@ -57,8 +57,8 @@ pub fn start(
     fs_root_path: &Path,
     execution_strategy: ExecutionStrategy,
     scope: Scope,
-    excludes: Vec<PackageIdent>,
-    services: Vec<PackageIdent>,
+    excludes: &[PackageIdent],
+    services: &[PackageIdent],
 ) -> Result<()> {
     // 1.
     let pkg_install = PackageInstall::load(ident, Some(fs_root_path))?;
@@ -70,7 +70,7 @@ pub fn start(
             Status::Determining,
             "list of running services in supervisor",
         )?;
-        for s in &services {
+        for s in services.iter() {
             ui.status(Status::Found, format!("running service {}", s))?;
         }
     }
@@ -99,7 +99,7 @@ pub fn start(
                 ui,
                 &fs_root_path,
                 &pkg_install,
-                &execution_strategy,
+                execution_strategy,
                 &excludes,
                 &services,
             )?;
@@ -137,7 +137,7 @@ pub fn start(
                             ui,
                             &fs_root_path,
                             &install,
-                            &execution_strategy,
+                            execution_strategy,
                             &excludes,
                             &services,
                         )?;
@@ -183,7 +183,7 @@ fn maybe_delete(
     ui: &mut UI,
     fs_root_path: &Path,
     install: &PackageInstall,
-    strategy: &ExecutionStrategy,
+    strategy: ExecutionStrategy,
     excludes: &[PackageIdent],
     services: &[PackageIdent],
 ) -> Result<bool> {

--- a/components/hab/src/command/studio/docker.rs
+++ b/components/hab/src/command/studio/docker.rs
@@ -126,7 +126,7 @@ pub fn start_docker_studio(_ui: &mut UI, mut args: Vec<OsString>) -> Result<()> 
     if !is_serving_windows_containers(&docker_cmd) {
         check_mounts(&docker_cmd, volumes.iter())?;
     }
-    run_container(docker_cmd, args, volumes.iter(), env_vars.iter())
+    run_container(docker_cmd, &args, volumes.iter(), env_vars.iter())
 }
 
 fn find_docker_cmd() -> Result<PathBuf> {
@@ -230,7 +230,7 @@ where
 
 fn run_container<I, J, S, T>(
     docker_cmd: PathBuf,
-    args: Vec<OsString>,
+    args: &[OsString],
     volumes: I,
     env_vars: J,
 ) -> Result<()>
@@ -280,7 +280,7 @@ where
         cmd_args.push(vol.as_ref().into());
     }
     cmd_args.push(image.into());
-    cmd_args.extend_from_slice(args.as_slice());
+    cmd_args.extend_from_slice(args);
     if using_windows_containers {
         cmd_args.push("-n".into());
         cmd_args.push("-o".into());

--- a/components/pkg-export-docker/src/accounts.rs
+++ b/components/pkg-export-docker/src/accounts.rs
@@ -28,10 +28,7 @@ pub struct EtcPasswdEntry {
 }
 
 impl EtcPasswdEntry {
-    pub fn new<S>(name: S, uid: u32, gid: u32) -> Self
-    where
-        S: ToString,
-    {
+    pub fn new(name: &str, uid: u32, gid: u32) -> Self {
         Self {
             name: name.to_string(),
             uid,
@@ -61,17 +58,13 @@ pub struct EtcGroupEntry {
 }
 
 impl EtcGroupEntry {
-    pub fn empty_group<S>(name: S, gid: u32) -> Self
-    where
-        S: ToString,
-    {
+    pub fn empty_group(name: &str, gid: u32) -> Self {
         let users: Vec<String> = vec![];
-        Self::group_with_users(name, gid, users)
+        Self::group_with_users(name, gid, &users)
     }
 
-    pub fn group_with_users<S, U>(name: S, gid: u32, users: Vec<U>) -> Self
+    pub fn group_with_users<U>(name: &str, gid: u32, users: &[U]) -> Self
     where
-        S: ToString,
         U: ToString,
     {
         Self {
@@ -108,7 +101,7 @@ mod test {
 
     #[test]
     fn etc_group_entry_with_users_renders_correctly() {
-        let entry = EtcGroupEntry::group_with_users("my_group", 456, vec!["larry", "moe", "curly"]);
+        let entry = EtcGroupEntry::group_with_users("my_group", 456, &["larry", "moe", "curly"]);
         let rendered = format!("{}", entry);
 
         assert_eq!(rendered, "my_group:x:456:larry,moe,curly");

--- a/components/pkg-export-docker/src/chmod.rs
+++ b/components/pkg-export-docker/src/chmod.rs
@@ -54,19 +54,19 @@ where
     if filetype.is_symlink() {
         // skip
     } else if filetype.is_dir() {
-        set_g_equal_u(&path, permissions)?;
+        set_g_equal_u(&path, &permissions)?;
         for entry in fs::read_dir(&path)? {
             let entry = entry.unwrap().path();
             recursive_g_equal_u(entry)?;
         }
     } else if filetype.is_file() {
-        set_g_equal_u(&path, permissions)?;
+        set_g_equal_u(&path, &permissions)?;
     }
     Ok(())
 }
 
 /// Set the group permissions of `path` equal to the user permissions.
-fn set_g_equal_u<P, Q>(path: P, permissions: Q) -> Result<()>
+fn set_g_equal_u<P, Q>(path: P, permissions: &Q) -> Result<()>
 where
     P: AsRef<Path>,
     Q: PermissionsExt,

--- a/components/pkg-export-docker/src/cli.rs
+++ b/components/pkg-export-docker/src/cli.rs
@@ -35,6 +35,7 @@ where
     pub app: App<'a, 'b>,
 }
 
+#[derive(Clone, Copy)]
 pub struct PkgIdentArgOptions {
     pub multiple: bool,
 }
@@ -299,6 +300,7 @@ impl<'a, 'b> Cli<'a, 'b> {
     }
 }
 
+#[allow(clippy::needless_pass_by_value)] // Signature required by CLAP
 fn valid_ident_or_hart(val: String) -> result::Result<(), String> {
     if Path::new(&val).is_file() {
         Ok(())
@@ -312,6 +314,7 @@ fn valid_ident_or_hart(val: String) -> result::Result<(), String> {
     }
 }
 
+#[allow(clippy::needless_pass_by_value)] // Signature required by CLAP
 fn valid_url(val: String) -> result::Result<(), String> {
     match Url::parse(&val) {
         Ok(_) => Ok(()),

--- a/components/pkg-export-docker/src/lib.rs
+++ b/components/pkg-export-docker/src/lib.rs
@@ -119,7 +119,7 @@ impl<'a> Naming<'a> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub enum RegistryType {
     Amazon,
     Azure,

--- a/components/pkg-export-helm/src/chart.rs
+++ b/components/pkg-export-helm/src/chart.rs
@@ -57,12 +57,12 @@ impl<'a> Chart<'a> {
         chartdir.push(&chartfile.name);
 
         Ok(Self::new_for_manifest(
-            manifest, chartdir, chartfile, deps, ui,
+            &manifest, chartdir, chartfile, deps, ui,
         ))
     }
 
     fn new_for_manifest(
-        manifest: Manifest,
+        manifest: &Manifest,
         chartdir: PathBuf,
         chartfile: ChartFile,
         deps: Deps,

--- a/components/pkg-export-helm/src/main.rs
+++ b/components/pkg-export-helm/src/main.rs
@@ -178,6 +178,7 @@ fn cli<'a, 'b>() -> clap::App<'a, 'b> {
         ))
 }
 
+#[allow(clippy::needless_pass_by_value)] // Signature required by CLAP
 fn valid_version(val: String) -> result::Result<(), String> {
     let split: Vec<&str> = val.split('.').collect();
     if split.len() != 3 {
@@ -195,6 +196,7 @@ fn valid_version(val: String) -> result::Result<(), String> {
     Ok(())
 }
 
+#[allow(clippy::needless_pass_by_value)] // Signature required by CLAP
 fn valid_url(val: String) -> result::Result<(), String> {
     match Url::parse(&val) {
         Ok(_) => Ok(()),
@@ -202,6 +204,7 @@ fn valid_url(val: String) -> result::Result<(), String> {
     }
 }
 
+#[allow(clippy::needless_pass_by_value)] // Signature required by CLAP
 fn valid_maintainer(val: String) -> result::Result<(), String> {
     maintainer::Maintainer::from_str(&val)
         .map(|_| ())

--- a/components/pkg-export-kubernetes/src/cli.rs
+++ b/components/pkg-export-kubernetes/src/cli.rs
@@ -201,6 +201,7 @@ impl<'a, 'b> Cli<'a, 'b> {
     }
 }
 
+#[allow(clippy::needless_pass_by_value)] // Signature required by CLAP
 fn valid_natural_number(val: String) -> result::Result<(), String> {
     match val.parse::<u32>() {
         Ok(_) => Ok(()),
@@ -210,6 +211,7 @@ fn valid_natural_number(val: String) -> result::Result<(), String> {
 
 // TODO (JC) This might be worth moving to core if it could be used
 // elsewhere.  `ServiceGroup` already has a similar `validate` fn
+#[allow(clippy::needless_pass_by_value)] // Signature required by CLAP
 fn valid_bind(val: String) -> result::Result<(), String> {
     if let Err(e) = ServiceBind::from_str(&val) {
         Err(e.to_string())

--- a/components/pkg-export-tar/src/cli.rs
+++ b/components/pkg-export-tar/src/cli.rs
@@ -130,6 +130,7 @@ impl<'a, 'b> Cli<'a, 'b> {
     }
 }
 
+#[allow(clippy::needless_pass_by_value)] // Signature required by CLAP
 fn valid_ident_or_hart(val: String) -> result::Result<(), String> {
     match InstallSource::from_str(&val) {
         Ok(_) => Ok(()),
@@ -137,6 +138,7 @@ fn valid_ident_or_hart(val: String) -> result::Result<(), String> {
     }
 }
 
+#[allow(clippy::needless_pass_by_value)] // Signature required by CLAP
 fn valid_url(val: String) -> result::Result<(), String> {
     match Url::parse(&val) {
         Ok(_) => Ok(()),

--- a/components/pkg-export-tar/src/lib.rs
+++ b/components/pkg-export-tar/src/lib.rs
@@ -77,7 +77,7 @@ fn tar_command(temp_dir_path: &Path, pkg_ident: PackageIdent, hab_pkg: &str) {
     tar_builder.append_dir_all("hab", hab_pkgs_path);
 
     // Find the path to the hab binary
-    let mut hab_pkg_binary_path = hab_install_path(hab_package_ident(hab_pkg), root_fs);
+    let mut hab_pkg_binary_path = hab_install_path(&hab_package_ident(hab_pkg), &root_fs);
     hab_pkg_binary_path.push("bin");
 
     // Append the hab binary to the tar ball
@@ -96,7 +96,7 @@ fn format_tar_name(ident: PackageIdent) -> String {
 
 fn hab_package_ident(hab_pkg: &str) -> PackageIdent { PackageIdent::from_str(hab_pkg).unwrap() }
 
-fn hab_install_path(hab_ident: PackageIdent, root_fs_path: PathBuf) -> PathBuf {
+fn hab_install_path(hab_ident: &PackageIdent, root_fs_path: &Path) -> PathBuf {
     let root_fs_path = Path::new(&root_fs_path);
     PackageInstall::load(&hab_ident, Some(root_fs_path))
         .unwrap()

--- a/components/sup-client/src/lib.rs
+++ b/components/sup-client/src/lib.rs
@@ -152,13 +152,10 @@ pub struct SrvClient {
 
 impl SrvClient {
     /// Connect to the given remote server and authenticate with the given secret_key.
-    pub fn connect<S>(
+    pub fn connect(
         addr: &ListenCtlAddr,
-        secret_key: S,
-    ) -> Box<dyn Future<Item = SrvClient, Error = SrvClientError> + 'static>
-    where
-        S: ToString,
-    {
+        secret_key: &str,
+    ) -> Box<dyn Future<Item = SrvClient, Error = SrvClientError> + 'static> {
         let secret_key = secret_key.to_string();
         let conn = TcpStream::connect(addr.as_ref())
             .map_err(SrvClientError::from)
@@ -186,7 +183,7 @@ impl SrvClient {
 
     pub fn read_secret_key() -> Result<String, SrvClientError> {
         let mut buf = String::new();
-        protocol::read_secret_key(protocol::sup_root(None::<String>), &mut buf)
+        protocol::read_secret_key(protocol::sup_root(None), &mut buf)
             .map_err(SrvClientError::from)?;
         Ok(buf)
     }

--- a/components/sup-protocol/src/lib.rs
+++ b/components/sup-protocol/src/lib.rs
@@ -140,12 +140,9 @@ where
     sup_root.as_ref().join(CTL_SECRET_FILENAME)
 }
 
-pub fn sup_root<U>(custom_state_path: Option<U>) -> PathBuf
-where
-    U: AsRef<Path>,
-{
+pub fn sup_root(custom_state_path: Option<&PathBuf>) -> PathBuf {
     match custom_state_path {
-        Some(ref custom) => custom.as_ref().to_path_buf(),
+        Some(custom) => custom.to_path_buf(),
         // TODO: /hab/sup/default is legacy from when we allowed multiple
         // supervisors on the same host with --override-name. The sup dir
         // should really be /hab/sup now, but it would be an awkward change

--- a/components/sup/src/config.rs
+++ b/components/sup/src/config.rs
@@ -20,6 +20,11 @@
 //!
 //! See the [Config](struct.Config.html) struct for the specific options available.
 
+use crate::{common::cli_defaults::{GOSSIP_DEFAULT_IP,
+                                   GOSSIP_DEFAULT_PORT,
+                                   GOSSIP_LISTEN_ADDRESS_ENVVAR},
+            error::{Result,
+                    SupError}};
 use habitat_core::env::Config as EnvConfig;
 use std::{fmt,
           io,
@@ -34,13 +39,7 @@ use std::{fmt,
           result,
           str::FromStr};
 
-use crate::{common::cli_defaults::{GOSSIP_DEFAULT_IP,
-                                   GOSSIP_DEFAULT_PORT,
-                                   GOSSIP_LISTEN_ADDRESS_ENVVAR},
-            error::{Result,
-                    SupError}};
-
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub struct GossipListenAddr(SocketAddr);
 
 impl GossipListenAddr {
@@ -55,7 +54,7 @@ impl GossipListenAddr {
     /// `192.168.1.1` should be contacted via `127.0.0.1` in the
     /// former case, but `192.168.1.1` in the latter.
     pub fn local_addr(&self) -> Self {
-        let mut addr = self.clone();
+        let mut addr = *self;
         if addr.0.ip().is_unspecified() {
             // TODO (CM): Use Ipv4Addr::loopback() when it's no longer experimental
             // TODO (CM): Support IPV6, once we do that more broadly

--- a/components/sup/src/ctl_gateway/server.rs
+++ b/components/sup/src/ctl_gateway/server.rs
@@ -355,7 +355,7 @@ impl Future for SrvHandler {
                                 CtlCommand::new(
                                     Some(self.tx.clone()),
                                     msg.transaction(),
-                                    move |state, req| commands::service_load(state, req, m.clone()),
+                                    move |state, req| commands::service_load(state, req, &m),
                                 )
                             }
                             "SvcUnload" => {

--- a/components/sup/src/http_gateway.rs
+++ b/components/sup/src/http_gateway.rs
@@ -91,7 +91,7 @@ lazy_static! {
     .unwrap();
 }
 
-#[derive(PartialEq, Eq, Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone, Copy)]
 pub struct ListenAddr(SocketAddr);
 
 impl ListenAddr {
@@ -662,7 +662,7 @@ mod tests {
                 Trace::default(),
                 None,
                 None,
-                None::<PathBuf>,
+                None,
                 Box::new(ZeroSuitability),
             )
             .unwrap()

--- a/components/sup/src/manager/commands.rs
+++ b/components/sup/src/manager/commands.rs
@@ -164,7 +164,7 @@ pub fn service_cfg_set(
         service_group,
     );
     let mut client = match butterfly::client::Client::new(
-        mgr.cfg.gossip_listen.local_addr(),
+        &mgr.cfg.gossip_listen.local_addr().to_string(),
         mgr.cfg.ring_key.clone(),
     ) {
         Ok(client) => client,
@@ -202,7 +202,7 @@ pub fn service_file_put(
         service_group,
     );
     let mut client = match butterfly::client::Client::new(
-        mgr.cfg.gossip_listen.local_addr(),
+        &mgr.cfg.gossip_listen.local_addr().to_string(),
         mgr.cfg.ring_key.clone(),
     ) {
         Ok(client) => client,
@@ -223,7 +223,7 @@ pub fn service_file_put(
 pub fn service_load(
     mgr: &ManagerState,
     req: &mut CtlRequest,
-    opts: protocol::ctl::SvcLoad,
+    opts: &protocol::ctl::SvcLoad,
 ) -> NetResult<()> {
     let ident: PackageIdent = opts.ident.clone().ok_or_else(err_update_client)?.into();
     let bldr_url = opts
@@ -385,7 +385,7 @@ pub fn supervisor_depart(
 ) -> NetResult<()> {
     let member_id = opts.member_id.ok_or_else(err_update_client)?;
     let mut client = match butterfly::client::Client::new(
-        mgr.cfg.gossip_listen.local_addr(),
+        &mgr.cfg.gossip_listen.local_addr().to_string(),
         mgr.cfg.ring_key.clone(),
     ) {
         Ok(client) => client,
@@ -395,7 +395,7 @@ pub fn supervisor_depart(
         }
     };
     outputln!("Attempting to depart member: {}", member_id);
-    match client.send_departure(member_id) {
+    match client.send_departure(&member_id) {
         Ok(()) => {
             req.reply_complete(net::ok());
             Ok(())

--- a/components/sup/src/manager/file_watcher.rs
+++ b/components/sup/src/manager/file_watcher.rs
@@ -1128,7 +1128,7 @@ impl Paths {
 
     fn add_path_to_settle(&mut self, path: PathBuf) { self.paths_to_settle.insert(path); }
 
-    fn settle_path(&mut self, path: PathBuf) { self.paths_to_settle.remove(&path); }
+    fn settle_path(&mut self, path: &Path) { self.paths_to_settle.remove(path); }
 
     fn set_process_args(&mut self, args: ProcessPathArgs) {
         if match self.process_args_after_settle {
@@ -1388,7 +1388,7 @@ impl<C: Callbacks, W: Watcher> FileWatcher<C, W> {
                     self.paths.add_path_to_settle(p);
                 }
                 PathsAction::SettlePath(p) => {
-                    self.paths.settle_path(p);
+                    self.paths.settle_path(&p);
                     actions.extend(self.handle_process_path()?);
                 }
                 PathsAction::ProcessPathAfterSettle(args) => {

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -594,7 +594,7 @@ impl Manager {
         Ok(())
     }
 
-    fn add_service(&mut self, spec: ServiceSpec) {
+    fn add_service(&mut self, spec: &ServiceSpec) {
         // JW TODO: This clone sucks, but our data structures are a bit messy here. What we really
         // want is the service to hold the spec and, on failure, return an error with the spec
         // back to us. Since we consume and deconstruct the spec in `Service::new()` which
@@ -700,7 +700,7 @@ impl Manager {
         runtime.spawn(ctl_handler);
 
         if let Some(svc_load) = svc {
-            commands::service_load(&self.state, &mut CtlRequest::default(), svc_load)?;
+            commands::service_load(&self.state, &mut CtlRequest::default(), &svc_load)?;
         }
 
         // This serves to start up any services that need starting
@@ -746,7 +746,7 @@ impl Manager {
 
             outputln!("Starting http-gateway on {}", &http_listen_addr);
             http_gateway::Server::run(
-                http_listen_addr.clone(),
+                http_listen_addr,
                 tls_server_config,
                 self.state.gateway_state.clone(),
                 pair.clone(),

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -1347,7 +1347,7 @@ impl Manager {
                         f
                     }
                     ServiceOperation::Start(spec) => {
-                        self.add_service(spec);
+                        self.add_service(&spec);
                         None // No future to return (currently synchronous!)
                     }
                 }

--- a/components/sup/src/manager/self_updater.rs
+++ b/components/sup/src/manager/self_updater.rs
@@ -67,16 +67,16 @@ impl SelfUpdater {
         let (tx, rx) = sync_channel(0);
         thread::Builder::new()
             .name("self-updater".to_string())
-            .spawn(move || Self::run(tx, current, update_url, update_channel))
+            .spawn(move || Self::run(&tx, &current, &update_url, &update_channel))
             .expect("Unable to start self-updater thread");
         rx
     }
 
     fn run(
-        sender: SyncSender<PackageInstall>,
-        current: PackageIdent,
-        builder_url: String,
-        channel: ChannelIdent,
+        sender: &SyncSender<PackageInstall>,
+        current: &PackageIdent,
+        builder_url: &str,
+        channel: &ChannelIdent,
     ) {
         debug!("Self updater current package, {}", current);
         // SUP_PKG_IDENT will always parse as a valid PackageIdent,
@@ -88,12 +88,12 @@ impl SelfUpdater {
             match util::pkg::install(
                 // We don't want anything in here to print
                 &mut UI::with_sinks(),
-                &builder_url,
+                builder_url,
                 &install_source,
-                &channel,
+                channel,
             ) {
                 Ok(package) => {
-                    if current < *package.ident() {
+                    if current < package.ident() {
                         debug!(
                             "Self updater installing newer Supervisor, {}",
                             package.ident()

--- a/components/sup/src/manager/service/hooks.rs
+++ b/components/sup/src/manager/service/hooks.rs
@@ -667,7 +667,7 @@ mod tests {
 
         // This is gross, but it actually works
         let cfg_path = &concrete_path.as_path().join("default.toml");
-        create_with_content(cfg_path, &String::from("message = \"Hello\""));
+        create_with_content(cfg_path, "message = \"Hello\"");
 
         let cfg = Cfg::new(&pkg, Some(&concrete_path.as_path().to_path_buf()))
             .expect("Could not create config");

--- a/components/sup/src/manager/service/mod.rs
+++ b/components/sup/src/manager/service/mod.rs
@@ -199,7 +199,7 @@ pub struct Service {
 impl Service {
     fn new(
         sys: Arc<Sys>,
-        package: PackageInstall,
+        package: &PackageInstall,
         spec: ServiceSpec,
         manager_fs_cfg: Arc<FsCfg>,
         organization: Option<&str>,
@@ -284,7 +284,7 @@ impl Service {
         let package = PackageInstall::load(&spec.ident, Some(fs_root_path))?;
         Ok(Self::new(
             sys,
-            package,
+            &package,
             spec,
             manager_fs_cfg,
             organization,
@@ -1249,7 +1249,7 @@ mod tests {
         let afs = Arc::new(fscfg);
 
         let gs = Arc::new(RwLock::new(GatewayState::default()));
-        Service::new(asys, install, spec, afs, Some("haha"), gs)
+        Service::new(asys, &install, spec, afs, Some("haha"), gs)
             .expect("I wanted a service to load, but it didn't")
     }
 

--- a/components/sup/src/manager/service_updater.rs
+++ b/components/sup/src/manager/service_updater.rs
@@ -434,8 +434,8 @@ impl Worker {
         thread::Builder::new()
             .name(format!("SU-{}", sg))
             .spawn(move || match ident {
-                Some(latest) => self.run_once(tx, latest, kill_rx),
-                None => self.run_poll(tx, kill_rx),
+                Some(latest) => self.run_once(&tx, latest, &kill_rx),
+                None => self.run_poll(&tx, &kill_rx),
             })
             .expect("unable to start service-updater thread");
         rx
@@ -466,9 +466,9 @@ impl Worker {
     /// the function exits.
     fn run_once(
         &mut self,
-        sender: Sender<PackageInstall>,
+        sender: &Sender<PackageInstall>,
         ident: PackageIdent,
-        kill_rx: Receiver<()>,
+        kill_rx: &Receiver<()>,
     ) {
         // Fairly certain that this only gets called in a rolling update
         // scenario, where `ident` is always a fully-qualified identifier
@@ -514,7 +514,7 @@ impl Worker {
 
     /// Continually poll for a new version of a package, installing it
     /// when found.
-    fn run_poll(&mut self, sender: Sender<PackageInstall>, kill_rx: Receiver<()>) {
+    fn run_poll(&mut self, sender: &Sender<PackageInstall>, kill_rx: &Receiver<()>) {
         let install_source = (self.spec_ident.clone(), *PackageTarget::active_target()).into();
         let mut next_time = SteadyTime::now();
 

--- a/components/sup/tests/utils/fixture_root.rs
+++ b/components/sup/tests/utils/fixture_root.rs
@@ -75,10 +75,7 @@ impl FixtureRoot {
     }
 
     /// There should be a spec file in the root of the fixture directory
-    pub fn spec_path<P>(&self, package_name: P) -> PathBuf
-    where
-        P: ToString,
-    {
+    pub fn spec_path(&self, package_name: &str) -> PathBuf {
         self.0
             .to_path_buf()
             .join(format!("{}.spec", &package_name.to_string()))

--- a/components/sup/tests/utils/hab_root.rs
+++ b/components/sup/tests/utils/hab_root.rs
@@ -41,10 +41,7 @@ use tempfile::{Builder,
 pub struct HabRoot(TempDir);
 
 impl HabRoot {
-    pub fn new<S>(name: S) -> HabRoot
-    where
-        S: ToString,
-    {
+    pub fn new(name: &str) -> HabRoot {
         let s = name.to_string();
         let t = Builder::new()
             .prefix(&s)
@@ -127,9 +124,8 @@ impl HabRoot {
 
     /// The path to which a spec file should be written for a given
     /// package name.
-    pub fn spec_path<P, S>(&self, pkg_name: P, service_group: S) -> PathBuf
+    pub fn spec_path<S>(&self, pkg_name: &str, service_group: S) -> PathBuf
     where
-        P: ToString,
         S: AsRef<Path>,
     {
         self.spec_dir(service_group)

--- a/components/sup/tests/utils/mod.rs
+++ b/components/sup/tests/utils/mod.rs
@@ -40,17 +40,13 @@ pub fn sleep_seconds(seconds: u64) { thread::sleep(Duration::from_secs(seconds))
 
 /// Copy fixture package files from `fixture_root` over to `hab_root`
 /// in the appropriate places for the Supervisor to find them.
-pub fn setup_package_files<O, P, S>(
-    origin_name: O,
-    package_name: P,
-    service_group: S,
+pub fn setup_package_files(
+    origin_name: &str,
+    package_name: &str,
+    service_group: &str,
     fixture_root: &FixtureRoot,
     hab_root: &HabRoot,
-) where
-    O: ToString,
-    P: ToString,
-    S: ToString,
-{
+) {
     let origin_name = origin_name.to_string();
     let package_name = package_name.to_string();
     let service_group = service_group.to_string();

--- a/components/sup/tests/utils/test_butterfly.rs
+++ b/components/sup/tests/utils/test_butterfly.rs
@@ -37,15 +37,11 @@ pub struct Client {
 }
 
 impl Client {
-    pub fn new<T, U>(package_name: T, service_group: U, port: u16) -> Client
-    where
-        T: ToString,
-        U: ToString,
-    {
+    pub fn new(package_name: &str, service_group: &str, port: u16) -> Client {
         let gossip_addr = format!("127.0.0.1:{}", port)
             .parse::<SocketAddr>()
             .expect("Could not parse Butterfly gossip address!");
-        let c = ButterflyClient::new(&gossip_addr, None)
+        let c = ButterflyClient::new(&gossip_addr.to_string(), None)
             .expect("Could not create Butterfly Client for test!");
         Client {
             butterfly_client: c,
@@ -60,10 +56,7 @@ impl Client {
     ///
     /// A time-based incarnation value is automatically used,
     /// resulting in less clutter in your tests.
-    pub fn apply<T>(&mut self, config: T)
-    where
-        T: ToString,
-    {
+    pub fn apply(&mut self, config: &str) {
         let config = config.to_string();
         let config = config.as_bytes();
 

--- a/components/sup/tests/utils/test_sup.rs
+++ b/components/sup/tests/utils/test_sup.rs
@@ -161,17 +161,14 @@ impl TestSup {
     /// parallel don't step on each other.
     ///
     /// See also `new`.
-    pub fn new_with_random_ports<R, O, P, S>(
+    pub fn new_with_random_ports<R>(
         fs_root: R,
-        origin: O,
-        pkg_name: P,
-        service_group: S,
+        origin: &str,
+        pkg_name: &str,
+        service_group: &str,
     ) -> TestSup
     where
         R: AsRef<Path>,
-        O: ToString,
-        P: ToString,
-        S: ToString,
     {
         // We'll give 10 tries to find a free port number
         let http_port = unclaimed_port(10);
@@ -207,20 +204,17 @@ impl TestSup {
     ///
     /// (No HTTP interaction with the Supervisor is currently called
     /// for, so we don't have a HTTP client.)
-    pub fn new<R, O, P, S>(
+    pub fn new<R>(
         fs_root: R,
-        origin: O,
-        pkg_name: P,
-        service_group: S,
+        origin: &str,
+        pkg_name: &str,
+        service_group: &str,
         http_port: u16,
         butterfly_port: u16,
         control_port: u16,
     ) -> TestSup
     where
         R: AsRef<Path>,
-        O: ToString,
-        P: ToString,
-        S: ToString,
     {
         let sup_exe = find_exe("hab-sup");
         let launcher_exe = find_exe("hab-launch");
@@ -292,12 +286,7 @@ impl TestSup {
 
     /// The equivalent of performing `hab apply` with the given
     /// configuration.
-    pub fn apply_config<T>(&mut self, toml_config: T)
-    where
-        T: ToString,
-    {
-        self.butterfly_client.apply(toml_config.to_string())
-    }
+    pub fn apply_config(&mut self, toml_config: &str) { self.butterfly_client.apply(toml_config) }
 }
 
 // We kill the Supervisor so you don't have to! We also free up the

--- a/test/run_clippy.sh
+++ b/test/run_clippy.sh
@@ -45,7 +45,6 @@ allowed_lints=(clippy::module_inception \
 # Known failing lints we want to receive warnings for, but not fail the build
 lints_to_fix=(clippy::cyclomatic_complexity \
                clippy::large_enum_variant \
-               clippy::needless_pass_by_value \
                clippy::needless_return \
                clippy::too_many_arguments)
 
@@ -76,6 +75,7 @@ denied_lints=(clippy::assign_op_pattern \
                clippy::match_ref_pats \
                clippy::needless_bool \
                clippy::needless_collect \
+               clippy::needless_pass_by_value \
                clippy::needless_range_loop \
                clippy::needless_update \
                clippy::ok_expect \


### PR DESCRIPTION
See https://rust-lang.github.io/rust-clippy/master/#needless_pass_by_value

One config override warning is left in pending the conversion of [`PairType` in `core`](https://github.com/habitat-sh/core/blob/f18341e369c441ca9303a1e03b60c4ffbe4556af/components/core/src/crypto/keys/mod.rs#L64) to a `Copy` type.

`T-DO-NOT-MERGE` because this is based on the `fix-clippy-trivially_copy_pass_by_ref ` and needs to be rebased to `master` first.

