### PR TITLE
refactor ctl_gateway and launcher to leverage windows color friendly StructuredOutput

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -872,6 +872,7 @@ version = "0.0.0"
 dependencies = [
  "env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat-launcher-protocol 0.0.0",
+ "habitat_common 0.0.0",
  "habitat_core 0.0.0 (git+https://github.com/habitat-sh/core.git)",
  "ipc-channel 0.9.0 (git+https://github.com/habitat-sh/ipc-channel?branch=hbt-windows)",
  "libc 0.2.49 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1047,9 +1048,8 @@ dependencies = [
 [[package]]
 name = "habitat_core"
 version = "0.0.0"
-source = "git+https://github.com/habitat-sh/core.git#873de50fdc0bf2d63f0fc211b0dd2516517014e2"
+source = "git+https://github.com/habitat-sh/core.git#f9ab5b649067a409b77b2cd9aea823115ae17679"
 dependencies = [
- "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "caps 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ctrlc 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1084,7 +1084,7 @@ dependencies = [
 [[package]]
 name = "habitat_http_client"
 version = "0.0.0"
-source = "git+https://github.com/habitat-sh/core.git#873de50fdc0bf2d63f0fc211b0dd2516517014e2"
+source = "git+https://github.com/habitat-sh/core.git#f9ab5b649067a409b77b2cd9aea823115ae17679"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat_core 0.0.0 (git+https://github.com/habitat-sh/core.git)",
@@ -1245,11 +1245,11 @@ dependencies = [
 [[package]]
 name = "habitat_win_users"
 version = "0.0.0"
-source = "git+https://github.com/habitat-sh/core.git#873de50fdc0bf2d63f0fc211b0dd2516517014e2"
+source = "git+https://github.com/habitat-sh/core.git#f9ab5b649067a409b77b2cd9aea823115ae17679"
 dependencies = [
  "gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "widestring 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "widestring 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/components/common/src/lib.rs
+++ b/components/common/src/lib.rs
@@ -19,14 +19,11 @@ extern crate json;
 extern crate log;
 #[macro_use]
 extern crate lazy_static;
-
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;
-
 #[cfg_attr(test, macro_use)]
 extern crate serde_json;
-
 #[cfg(windows)]
 extern crate winapi;
 
@@ -37,8 +34,21 @@ pub mod cli_defaults;
 pub mod command;
 pub mod error;
 pub mod locked_env_var;
+pub mod output;
 pub mod package_graph;
 pub mod templating;
 pub mod types;
 pub mod ui;
 pub mod util;
+
+lazy_static::lazy_static! {
+    pub static ref PROGRAM_NAME: String = {
+        match std::env::current_exe() {
+            Ok(path) => path.file_stem().and_then(|p| p.to_str()).unwrap().to_string(),
+            Err(e) => {
+                error!("Error getting path of current_exe: {}", e);
+                String::from("hab-?")
+            }
+        }
+    };
+}

--- a/components/common/src/output.rs
+++ b/components/common/src/output.rs
@@ -1,0 +1,499 @@
+// Copyright (c) 2016-2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Formats user-visible output for the Supervisor.
+//!
+//! Most of this module is used via the `outputln!` and
+//! `output_format!` macros. They create a `StructuredOutput` struct,
+//! which includes the line number, file name, and column it was
+//! called on. Additionally, it uses a standard constant called
+//! `LOGKEY` as a short hint as to where the output was generated
+//! within the Supervisor. Also supported is a `preamble`, which is
+//! used to denote when output comes from a running service rather
+//! than the Supervisor itself.
+//!
+//! The `StructuredOutput` struct supports three global options -
+//! dealing with verbosity, coloring, and structured JSON output. If
+//! verbose is turned on, then every line printed is annotated with
+//! its preamble, logkey, and precise location; without verbose, it
+//! prints simply the preamble and logkey. Coloring does what it says
+//! on the tin :) JSON-formatted output emits this information as a
+//! JSON object. It ignores the coloring option, and does _not_ ever log
+//! with ANSI color codes, but does honor the verbose flag.
+
+use crate::PROGRAM_NAME;
+use serde::{ser::SerializeMap,
+            Serialize,
+            Serializer};
+use serde_json;
+use std::{fmt,
+          io::{self,
+               Write},
+          result,
+          sync::{atomic::{AtomicBool,
+                          Ordering,
+                          ATOMIC_BOOL_INIT},
+                 Mutex}};
+use termcolor::{BufferWriter,
+                Color,
+                ColorChoice,
+                ColorSpec,
+                WriteColor};
+
+static VERBOSITY: AtomicBool = ATOMIC_BOOL_INIT;
+
+lazy_static! {
+    static ref FORMAT: Mutex<OutputFormat> = Mutex::new(OutputFormat::Color);
+}
+
+/// Get the OutputFormat for which content is to be rendered
+pub fn get_format() -> OutputFormat { *FORMAT.lock().expect("FORMAT lock poisoned") }
+
+/// Set the OutputFormat for which content is to be rendered
+pub fn set_format(format: OutputFormat) { *FORMAT.lock().expect("FORMAT lock poisoned") = format }
+
+/// Get the OutputVerbosity for which content is to be rendered
+pub fn get_verbosity() -> OutputVerbosity {
+    if VERBOSITY.load(Ordering::Relaxed) {
+        OutputVerbosity::Verbose
+    } else {
+        OutputVerbosity::Normal
+    }
+}
+
+/// Set the OutputVerbosity for which content is to be rendered
+pub fn set_verbosity(format: OutputVerbosity) {
+    VERBOSITY.store(match format {
+                        OutputVerbosity::Verbose => true,
+                        OutputVerbosity::Normal => false,
+                    },
+                    Ordering::Relaxed)
+}
+
+/// Adds structure to printed output. Stores a preamble, a logkey, line, file, column, and content
+/// to print.
+pub struct StructuredOutput<'a> {
+    preamble: &'a str,
+    logkey: &'static str,
+    content: &'a str,
+    /// The verbosity level of rendered content
+    verbosity: OutputVerbosityInternal,
+    /// How should output be formatted
+    format: OutputFormat,
+    /// Color and styling to use for content.
+    color_spec: ColorSpec,
+}
+
+impl<'a> StructuredOutput<'a> {
+    /// Return a new StructuredOutput struct.
+    pub fn new(preamble: &'a str,
+               logkey: &'static str,
+               line: u32,
+               file: &'static str,
+               column: u32,
+               format: OutputFormat,
+               verbosity: OutputVerbosity,
+               content: &'a str)
+               -> StructuredOutput<'a> {
+        let verbosity = match verbosity {
+            OutputVerbosity::Normal => OutputVerbosityInternal::Normal,
+            OutputVerbosity::Verbose => OutputVerbosityInternal::Verbose { line, file, column },
+        };
+        StructuredOutput { preamble,
+                           logkey,
+                           content,
+                           verbosity,
+                           format,
+                           color_spec: ColorSpec::new() }
+    }
+
+    pub fn colored(preamble: &'a str,
+                   logkey: &'static str,
+                   line: u32,
+                   file: &'static str,
+                   column: u32,
+                   verbosity: OutputVerbosity,
+                   content: &'a str,
+                   color_spec: ColorSpec)
+                   -> StructuredOutput<'a> {
+        let verbosity = match verbosity {
+            OutputVerbosity::Normal => OutputVerbosityInternal::Normal,
+            OutputVerbosity::Verbose => OutputVerbosityInternal::Verbose { line, file, column },
+        };
+        StructuredOutput { preamble,
+                           logkey,
+                           content,
+                           verbosity,
+                           format: OutputFormat::Color,
+                           color_spec }
+    }
+
+    pub fn succinct(preamble: &'a str,
+                    logkey: &'static str,
+                    format: OutputFormat,
+                    content: &'a str)
+                    -> StructuredOutput<'a> {
+        StructuredOutput { preamble,
+                           logkey,
+                           content,
+                           verbosity: OutputVerbosityInternal::Normal,
+                           format,
+                           color_spec: ColorSpec::new() }
+    }
+
+    pub fn print(&self) -> io::Result<()> {
+        self.print_to_writer(&BufferWriter::stdout(self.color_choice()))
+    }
+
+    pub fn eprint(&self) -> io::Result<()> {
+        self.print_to_writer(&BufferWriter::stderr(self.color_choice()))
+    }
+
+    pub fn println(&self) -> io::Result<()> {
+        self.println_to_writer(&BufferWriter::stdout(self.color_choice()))
+    }
+
+    pub fn eprintln(&self) -> io::Result<()> {
+        self.println_to_writer(&BufferWriter::stderr(self.color_choice()))
+    }
+
+    fn print_to_writer(&self, writer: &BufferWriter) -> io::Result<()> {
+        let mut buffer = writer.buffer();
+        self.format(&mut buffer)?;
+        writer.print(&buffer)
+    }
+
+    fn println_to_writer(&self, writer: &BufferWriter) -> io::Result<()> {
+        let mut buffer = writer.buffer();
+        self.format(&mut buffer)?;
+        buffer.write_all(b"\n")?;
+        buffer.flush()?;
+        writer.print(&buffer)
+    }
+
+    fn color_choice(&self) -> ColorChoice {
+        match self.format {
+            OutputFormat::Color => ColorChoice::Auto,
+            OutputFormat::NoColor | OutputFormat::JSON => ColorChoice::Never,
+        }
+    }
+
+    // If we ever want to create multiple output formats in the future, we would do it here -
+    // essentially create a flag we check to see what output you want, then call a different
+    // formatting function. Viola!
+    fn format(&self, writer: &mut WriteColor) -> io::Result<()> {
+        writer.reset()?;
+        match self.format {
+            OutputFormat::JSON => {
+                // Our JSON serialization handles verbosity itself, and
+                // color is ignored anyway, so there's no reason to check
+                // those settings here.
+
+                // unwrap is safe, as we control the inputs
+                let as_json = serde_json::to_string(&self).unwrap();
+                write!(writer, "{}", as_json)
+            }
+            _ => {
+                let preamble_color = if self.preamble == PROGRAM_NAME.as_str() {
+                    Color::Cyan
+                } else {
+                    Color::Green
+                };
+
+                writer.set_color(ColorSpec::new().set_fg(Some(preamble_color)))?;
+                writer.write_all(self.preamble.as_bytes())?;
+                writer.reset()?;
+                writer.write_all(b"(")?;
+                writer.set_color(ColorSpec::new().set_fg(Some(Color::White)).set_bold(true))?;
+                writer.write_all(self.logkey.as_bytes())?;
+                writer.reset()?;
+                writer.write_all(b")")?;
+                if let OutputVerbosityInternal::Verbose { line, file, column } = self.verbosity {
+                    writer.write_all(b"[")?;
+                    writer.set_color(ColorSpec::new().set_fg(Some(Color::White))
+                                                     .set_underline(true))?;
+                    write!(writer, "{}:{}:{}", file, line, column)?;
+                    writer.reset()?;
+                    writer.write_all(b"]")?;
+                }
+                writer.write_all(b": ")?;
+                writer.set_color(&self.color_spec)?;
+                writer.write_all(self.content.as_bytes())?;
+                writer.reset()?;
+                writer.flush()
+            }
+        }
+    }
+}
+
+// Custom implementation of Serialize to ensure that we can
+// appropriately represent both verbose and non-verbose output, a
+// behavior which isn't otherwise possible to derive.
+impl<'a> Serialize for StructuredOutput<'a> {
+    fn serialize<S>(&self, serializer: S) -> result::Result<S::Ok, S::Error>
+        where S: Serializer
+    {
+        // Focused on JSON serialization right now, so the length hint
+        // isn't needed; it might be later if we target other formats.
+        let mut map = serializer.serialize_map(None)?;
+
+        map.serialize_entry("preamble", &self.preamble)?;
+        map.serialize_entry("logkey", &self.logkey)?;
+        if let OutputVerbosityInternal::Verbose { line, file, column } = self.verbosity {
+            map.serialize_entry("file", &file)?;
+            map.serialize_entry("line", &line)?;
+            map.serialize_entry("column", &column)?;
+        }
+        map.serialize_entry("content", &self.content)?;
+
+        map.end()
+    }
+}
+
+impl<'a> fmt::Display for StructuredOutput<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let bufwtr = BufferWriter::stdout(self.color_choice());
+        let mut buffer = bufwtr.buffer();
+        match self.format(&mut buffer) {
+            Ok(_) => {
+                f.write_str(std::str::from_utf8(buffer.as_slice()).expect("termcolor buffer \
+                                                                           valid utf8"))
+            }
+            Err(e) => write!(f, "Error formatting StructuredOutput: {}", e),
+        }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq)]
+pub enum OutputFormat {
+    Color,
+    NoColor,
+    JSON,
+}
+
+#[derive(Clone, Copy, PartialEq)]
+pub enum OutputVerbosity {
+    Normal,
+    Verbose,
+}
+
+#[derive(Clone, Copy)]
+enum OutputVerbosityInternal {
+    Normal,
+    Verbose {
+        line:   u32,
+        file:   &'static str,
+        column: u32,
+    },
+}
+
+#[macro_export]
+/// Works the same as println!, but uses our structured output formatter.
+macro_rules! outputln {
+    ($content: expr) => {
+        {
+            use $crate::output::{get_format, get_verbosity, StructuredOutput};
+            use $crate::PROGRAM_NAME;
+            StructuredOutput::new(PROGRAM_NAME.as_str(),
+                                           LOGKEY,
+                                           line!(),
+                                           file!(),
+                                           column!(),
+                                           get_format(),
+                                           get_verbosity(),
+                                           $content).println().expect("failed to write output to stdout");
+        }
+    };
+    (preamble $preamble:expr, $content: expr) => {
+        {
+            use $crate::output::{get_format, get_verbosity, StructuredOutput};
+            StructuredOutput::new(&$preamble,
+                                           LOGKEY,
+                                           line!(),
+                                           file!(),
+                                           column!(),
+                                           get_format(),
+                                           get_verbosity(),
+                                           $content).println().expect("failed to write output to stdout");
+        }
+    };
+    ($content: expr, $($arg:tt)*) => {
+        {
+            use $crate::output::{get_format, get_verbosity, StructuredOutput};
+            use $crate::PROGRAM_NAME;
+            let content = format!($content, $($arg)*);
+            StructuredOutput::new(PROGRAM_NAME.as_str(),
+                                           LOGKEY,
+                                           line!(),
+                                           file!(),
+                                           column!(),
+                                           get_format(),
+                                           get_verbosity(),
+                                           &content).println().expect("failed to write output to stdout");
+        }
+    };
+    (preamble $preamble: expr, $content: expr, $($arg:tt)*) => {
+        {
+            use $crate::output::{get_format, get_verbosity, StructuredOutput};
+            let content = format!($content, $($arg)*);
+            StructuredOutput::new(&$preamble,
+                                           LOGKEY,
+                                           line!(),
+                                           file!(),
+                                           column!(),
+                                           get_format(),
+                                           get_verbosity(),
+                                           &content).println().expect("failed to write output to stdout");
+        }
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+
+    use super::{OutputFormat,
+                OutputVerbosity,
+                StructuredOutput};
+    use serde_json;
+    use termcolor::{BufferWriter,
+                    Color,
+                    ColorChoice,
+                    ColorSpec,
+                    WriteColor};
+
+    use crate::PROGRAM_NAME;
+
+    static LOGKEY: &'static str = "SOT";
+
+    fn so<'a>(preamble: &'a str,
+              content: &'a str,
+              format: OutputFormat,
+              verbosity: OutputVerbosity)
+              -> StructuredOutput<'a> {
+        StructuredOutput::new(preamble, LOGKEY, 1, file!(), 2, format, verbosity, content)
+    }
+
+    #[test]
+    fn new() {
+        let so = so("soup",
+                    "opeth is amazing",
+                    OutputFormat::NoColor,
+                    OutputVerbosity::Normal);
+        assert_eq!(so.logkey, "SOT");
+        assert_eq!(so.preamble, "soup");
+        assert_eq!(so.content, "opeth is amazing");
+    }
+
+    #[test]
+    fn format() {
+        let so = so("soup",
+                    "opeth is amazing",
+                    OutputFormat::NoColor,
+                    OutputVerbosity::Normal);
+        assert_eq!(format!("{}", so), "soup(SOT): opeth is amazing");
+    }
+
+    #[test]
+    fn format_color() {
+        let progname = PROGRAM_NAME.as_str();
+        let content = "opeth is amazing";
+        let mut cs = ColorSpec::new();
+        cs.set_underline(true);
+        let so = StructuredOutput::colored(progname,
+                                           LOGKEY,
+                                           1,
+                                           file!(),
+                                           2,
+                                           OutputVerbosity::Normal,
+                                           content,
+                                           cs.clone());
+        let writer = BufferWriter::stdout(ColorChoice::Auto);
+        let mut buffer = writer.buffer();
+        buffer.reset().unwrap();
+        buffer.set_color(ColorSpec::new().set_fg(Some(Color::Cyan)))
+              .unwrap();
+        buffer.write_all(progname.as_bytes()).unwrap();
+        buffer.reset().unwrap();
+        buffer.write_all(b"(").unwrap();
+        buffer.set_color(ColorSpec::new().set_fg(Some(Color::White)).set_bold(true))
+              .unwrap();
+        buffer.write_all(b"SOT").unwrap();
+        buffer.reset().unwrap();
+        buffer.write_all(b"): ").unwrap();
+        buffer.set_color(&cs).unwrap();
+        buffer.write_all(content.as_bytes()).unwrap();
+        buffer.reset().unwrap();
+        assert_eq!(format!("{}", so),
+                   String::from_utf8_lossy(buffer.as_slice()));
+    }
+
+    #[test]
+    fn json_formatting() {
+        let so = so("monkeys",
+                    "I love monkeys",
+                    OutputFormat::JSON,
+                    OutputVerbosity::Normal);
+
+        let actual: serde_json::Value =
+            serde_json::from_str(&(format!("{}", so))).expect("Couldn't parse from JSON");
+
+        assert_eq!(actual,
+                   serde_json::json!({
+                       "preamble": "monkeys",
+                       "logkey": LOGKEY,
+                       "content": "I love monkeys"
+                   }));
+    }
+
+    #[test]
+    fn verbose_json_formatting() {
+        let so = so("monkeys",
+                    "I love verbose monkeys",
+                    OutputFormat::JSON,
+                    OutputVerbosity::Verbose);
+
+        let actual: serde_json::Value =
+            serde_json::from_str(&(format!("{}", so))).expect("Couldn't parse from JSON");
+
+        assert_eq!(actual,
+                   serde_json::json!({
+                       "preamble": "monkeys",
+                       "logkey": LOGKEY,
+                       "line": 1,
+                       "file": file!(),
+                       "column": 2,
+                       "content": "I love verbose monkeys"
+                   }));
+    }
+
+    #[test]
+    fn json_formatting_ignores_color() {
+        let with_color = so("monkeys",
+                            "I love drab monkeys",
+                            OutputFormat::JSON,
+                            OutputVerbosity::Normal);
+
+        let actual: serde_json::Value =
+            serde_json::from_str(&(format!("{}", with_color))).expect("Couldn't parse from JSON");
+
+        assert_eq!(actual,
+                   serde_json::json!({
+                       "preamble": "monkeys",
+                       "logkey": LOGKEY,
+                       "content": "I love drab monkeys"
+                   }),
+                   "JSON output shouldn't have color, even if the colorized flag was set");
+    }
+}

--- a/components/common/src/templating/config.rs
+++ b/components/common/src/templating/config.rs
@@ -13,13 +13,13 @@
 // limitations under the License.
 
 /// Collect all the configuration data that is exposed to users, and render it.
-use crate::error::{Error,
-                   Result};
-use crate::{hcore::{self,
+use crate::{error::{Error,
+                    Result},
+            hcore::{self,
                     crypto,
                     fs::{self,
-                         USER_CONFIG_FILE},
-                    outputln},
+                         USER_CONFIG_FILE}},
+            outputln,
             templating::{package::Pkg,
                          TemplateRenderer}};
 use serde::{Serialize,

--- a/components/common/src/templating/hooks.rs
+++ b/components/common/src/templating/hooks.rs
@@ -14,14 +14,14 @@
 
 use super::{package::Pkg,
             TemplateRenderer};
-use crate::error::{Error,
-                   Result};
+use crate::{error::{Error,
+                    Result},
+            outputln};
 #[cfg(windows)]
 use habitat_core::os::process::windows_child::{Child,
                                                ExitStatus};
 use habitat_core::{crypto,
-                   fs,
-                   outputln};
+                   fs};
 use serde::{Serialize,
             Serializer};
 #[cfg(unix)]

--- a/components/common/src/util/path.rs
+++ b/components/common/src/util/path.rs
@@ -12,20 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{env,
-          fs::File,
-          io::{prelude::*,
-               BufReader},
-          path::PathBuf,
-          str::FromStr};
-
 use crate::{command::package::install::{self,
                                         InstallHookMode,
                                         InstallMode,
                                         LocalPackageUsage},
             error::{Error,
                     Result},
-            ui};
+            ui,
+            PROGRAM_NAME};
 use habitat_core::{fs::{cache_artifact_path,
                         find_command,
                         FS_ROOT_PATH},
@@ -33,8 +27,13 @@ use habitat_core::{fs::{cache_artifact_path,
                              PackageInstall,
                              PackageTarget},
                    url::default_bldr_url,
-                   ChannelIdent,
-                   PROGRAM_NAME};
+                   ChannelIdent};
+use std::{env,
+          fs::File,
+          io::{prelude::*,
+               BufReader},
+          path::PathBuf,
+          str::FromStr};
 
 /// The package identifier for the OS specific interpreter which the Supervisor is built with,
 /// or which may be independently installed

--- a/components/launcher/Cargo.toml
+++ b/components/launcher/Cargo.toml
@@ -12,6 +12,7 @@ doc = false
 
 [dependencies]
 env_logger = "*"
+habitat_common = { path = "../common" }
 # JW TODO: core has external deps that we don't want, libarchive/libsodium. We should either
 # put these things behind a feature flag so we can statically compile the launcher.
 habitat_core = { git = "https://github.com/habitat-sh/core.git" }

--- a/components/launcher/src/lib.rs
+++ b/components/launcher/src/lib.rs
@@ -12,12 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[macro_use]
 extern crate habitat_core as core;
 use habitat_launcher_protocol as protocol;
 #[macro_use]
 extern crate log;
-
 #[cfg(windows)]
 extern crate winapi;
 

--- a/components/launcher/src/main.rs
+++ b/components/launcher/src/main.rs
@@ -13,15 +13,13 @@
 // limitations under the License.
 
 use env_logger;
-use habitat_core as core;
-use habitat_launcher as launcher;
-#[macro_use]
-extern crate log;
-
+use habitat_common::output::{self,
+                             OutputFormat,
+                             OutputVerbosity};
+use habitat_launcher::server;
+use log::error;
 use std::{env,
           process};
-
-use crate::launcher::server;
 
 fn main() {
     env_logger::init();
@@ -58,12 +56,12 @@ fn set_global_logging_options(args: &[String]) {
     // Note that each of these options has only one form, so we don't
     // have to check for long _and_ short options, for example.
     if args.contains(&String::from("--no-color")) {
-        core::output::set_no_color(true);
+        output::set_format(OutputFormat::NoColor)
     }
     if args.contains(&String::from("--json-logging")) {
-        core::output::set_json(true);
+        output::set_format(OutputFormat::JSON)
     }
     if args.contains(&String::from("-v")) {
-        core::output::set_verbose(true);
+        output::set_verbosity(OutputVerbosity::Verbose);
     }
 }

--- a/components/launcher/src/server/mod.rs
+++ b/components/launcher/src/server/mod.rs
@@ -14,25 +14,6 @@
 
 mod handlers;
 
-use std::{collections::HashMap,
-          fs,
-          io::Write,
-          path::PathBuf,
-          process::{Child,
-                    Command,
-                    Stdio},
-          str::FromStr,
-          sync::{Arc,
-                 Condvar,
-                 Mutex},
-          thread,
-          time::Duration};
-
-#[cfg(unix)]
-use std::os::unix::process::ExitStatusExt;
-#[cfg(unix)]
-use std::process::ExitStatus;
-
 use crate::{core::{self,
                    fs::{launcher_root_path,
                         FS_ROOT_PATH},
@@ -52,6 +33,7 @@ use crate::{core::{self,
             service::Service,
             SUP_CMD,
             SUP_PACKAGE_IDENT};
+use habitat_common::outputln;
 use ipc_channel::ipc::{IpcOneShotServer,
                        IpcReceiver,
                        IpcSender};
@@ -59,6 +41,23 @@ use ipc_channel::ipc::{IpcOneShotServer,
 use libc;
 use semver::{Version,
              VersionReq};
+#[cfg(unix)]
+use std::os::unix::process::ExitStatusExt;
+#[cfg(unix)]
+use std::process::ExitStatus;
+use std::{collections::HashMap,
+          fs,
+          io::Write,
+          path::PathBuf,
+          process::{Child,
+                    Command,
+                    Stdio},
+          str::FromStr,
+          sync::{Arc,
+                 Condvar,
+                 Mutex},
+          thread,
+          time::Duration};
 
 const IPC_CONNECT_TIMEOUT_SECS: &str = "HAB_LAUNCH_SUP_CONNECT_TIMEOUT_SECS";
 const DEFAULT_IPC_CONNECT_TIMEOUT_SECS: u64 = 5;

--- a/components/pkg-export-docker/src/lib.rs
+++ b/components/pkg-export-docker/src/lib.rs
@@ -42,24 +42,11 @@ mod error;
 pub mod rootfs;
 mod util;
 
-use std::{env,
-          fmt,
-          result,
-          str::FromStr};
-
-use crate::{common::ui::{UIWriter,
-                         UI},
-            hcore::{url as hurl,
-                    PROGRAM_NAME}};
-
-use crate::aws_creds::StaticProvider;
-use clap::App;
-use rusoto_core::{request::*,
-                  Region};
-use rusoto_ecr::{Ecr,
-                 EcrClient,
-                 GetAuthorizationTokenRequest};
-
+use crate::{aws_creds::StaticProvider,
+            common::{ui::{UIWriter,
+                          UI},
+                     PROGRAM_NAME},
+            hcore::url as hurl};
 pub use crate::{build::BuildSpec,
                 cli::{Cli,
                       PkgIdentArgOptions},
@@ -67,6 +54,16 @@ pub use crate::{build::BuildSpec,
                          DockerImage},
                 error::{Error,
                         Result}};
+use clap::App;
+use rusoto_core::{request::*,
+                  Region};
+use rusoto_ecr::{Ecr,
+                 EcrClient,
+                 GetAuthorizationTokenRequest};
+use std::{env,
+          fmt,
+          result,
+          str::FromStr};
 
 /// The version of this library and program when built.
 pub const VERSION: &str = include_str!(concat!(env!("OUT_DIR"), "/VERSION"));

--- a/components/pkg-export-helm/src/main.rs
+++ b/components/pkg-export-helm/src/main.rs
@@ -37,19 +37,17 @@ mod error;
 mod maintainer;
 mod values;
 
+use clap::Arg;
 use std::{result,
           str::FromStr};
 
-use clap::Arg;
-
-use crate::{common::ui::{UIWriter,
-                         UI},
+use crate::{chart::Chart,
+            common::{ui::{UIWriter,
+                          UI},
+                     PROGRAM_NAME},
             export_docker::Result,
-            export_k8s::Cli,
-            hcore::PROGRAM_NAME};
+            export_k8s::Cli};
 use url::Url;
-
-use crate::chart::Chart;
 
 fn main() {
     env_logger::init();

--- a/components/pkg-export-kubernetes/src/main.rs
+++ b/components/pkg-export-kubernetes/src/main.rs
@@ -14,16 +14,11 @@
 
 use clap;
 use env_logger;
-use habitat_common as common;
-use habitat_core as hcore;
-
+use habitat_common::{ui::{UIWriter,
+                          UI},
+                     PROGRAM_NAME};
 use habitat_pkg_export_kubernetes as export_k8s;
-#[macro_use]
-extern crate log;
-
-use crate::{common::ui::{UIWriter,
-                         UI},
-            hcore::PROGRAM_NAME};
+use log::debug;
 
 fn main() {
     env_logger::init();

--- a/components/pkg-export-tar/src/build.rs
+++ b/components/pkg-export-tar/src/build.rs
@@ -19,15 +19,15 @@ use crate::{common::{self,
                                                  LocalPackageUsage},
                      ui::{Status,
                           UIWriter,
-                          UI}},
+                          UI},
+                     PROGRAM_NAME},
             error::Result,
             hcore::{fs::{cache_artifact_path,
                          cache_key_path,
                          CACHE_ARTIFACT_PATH,
                          CACHE_KEY_PATH},
                     package::PackageIdent,
-                    ChannelIdent,
-                    PROGRAM_NAME}};
+                    ChannelIdent}};
 use clap;
 #[cfg(unix)]
 use std::os::unix::fs::symlink;

--- a/components/pkg-export-tar/src/main.rs
+++ b/components/pkg-export-tar/src/main.rs
@@ -1,15 +1,14 @@
 use env_logger;
 use habitat_common as common;
-use habitat_core as hcore;
 use habitat_pkg_export_tar as export_tar;
 #[macro_use]
 extern crate log;
 
-use crate::{common::ui::{UIWriter,
-                         UI},
+use crate::{common::{ui::{UIWriter,
+                          UI},
+                     PROGRAM_NAME},
             export_tar::{Cli,
-                         Result},
-            hcore::PROGRAM_NAME};
+                         Result}};
 use clap::App;
 
 fn main() {

--- a/components/sup/src/census.rs
+++ b/components/sup/src/census.rs
@@ -12,15 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{borrow::Cow,
-          collections::{BTreeMap,
-                        HashMap,
-                        HashSet},
-          fmt,
-          result,
-          str::FromStr};
-
-use crate::{butterfly::{member::{Health,
+use crate::error::{Error,
+                   SupError};
+use habitat_butterfly::{member::{Health,
                                  Member,
                                  MemberList},
                         rumor::{election::{Election as ElectionRumor,
@@ -30,17 +24,22 @@ use crate::{butterfly::{member::{Health,
                                           SysInfo},
                                 service_config::ServiceConfig as ServiceConfigRumor,
                                 service_file::ServiceFile as ServiceFileRumor,
-                                RumorStore}},
-            hcore::{self,
-                    package::PackageIdent,
-                    service::ServiceGroup}};
+                                RumorStore}};
+use habitat_common::outputln;
+use habitat_core::{self,
+                   package::PackageIdent,
+                   service::ServiceGroup};
 use serde::{ser::SerializeStruct,
             Serialize,
             Serializer};
+use std::{borrow::Cow,
+          collections::{BTreeMap,
+                        HashMap,
+                        HashSet},
+          fmt,
+          result,
+          str::FromStr};
 use toml;
-
-use crate::error::{Error,
-                   SupError};
 
 static LOGKEY: &'static str = "CE";
 
@@ -713,7 +712,7 @@ impl<'a> Serialize for CensusMemberProxy<'a> {
     }
 }
 
-fn service_group_from_str(sg: &str) -> Result<ServiceGroup, hcore::Error> {
+fn service_group_from_str(sg: &str) -> Result<ServiceGroup, habitat_core::Error> {
     ServiceGroup::from_str(sg).map_err(|e| {
                                   outputln!("Malformed service group; cannot populate \
                                              configuration data. Aborting.: {}",
@@ -728,7 +727,7 @@ mod tests {
 
     use serde_json;
 
-    use crate::{butterfly::{member::{Health,
+    use habitat_butterfly::{member::{Health,
                                      MemberList},
                             rumor::{election::{self,
                                                Election as ElectionRumor,
@@ -737,10 +736,11 @@ mod tests {
                                               SysInfo},
                                     service_config::ServiceConfig as ServiceConfigRumor,
                                     service_file::ServiceFile as ServiceFileRumor,
-                                    RumorStore}},
-                hcore::{package::ident::PackageIdent,
-                        service::ServiceGroup},
-                test_helpers::*};
+                                    RumorStore}};
+    use habitat_core::{package::ident::PackageIdent,
+                       service::ServiceGroup};
+
+    use crate::test_helpers::*;
 
     #[test]
     fn update_from_rumors() {

--- a/components/sup/src/command/shell.rs
+++ b/components/sup/src/command/shell.rs
@@ -12,17 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::error::{Error,
+                   Result};
+use habitat_common::{outputln,
+                     util::path};
+use habitat_core::fs::find_command;
+use libc;
 use std::{env,
           ffi::CString,
           path::PathBuf,
           ptr};
-
-use crate::hcore::fs::find_command;
-use libc;
-
-use crate::{common::util::path,
-            error::{Error,
-                    Result}};
 
 /// Our output key
 static LOGKEY: &'static str = "SH";

--- a/components/sup/src/config.rs
+++ b/components/sup/src/config.rs
@@ -20,11 +20,9 @@
 //!
 //! See the [Config](struct.Config.html) struct for the specific options available.
 
-use crate::{common::cli_defaults::{GOSSIP_DEFAULT_IP,
+use habitat_common::cli_defaults::{GOSSIP_DEFAULT_IP,
                                    GOSSIP_DEFAULT_PORT,
-                                   GOSSIP_LISTEN_ADDRESS_ENVVAR},
-            error::{Result,
-                    SupError}};
+                                   GOSSIP_LISTEN_ADDRESS_ENVVAR};
 use habitat_core::env::Config as EnvConfig;
 use std::{fmt,
           io,
@@ -38,6 +36,9 @@ use std::{fmt,
           option,
           result,
           str::FromStr};
+
+use crate::error::{Result,
+                   SupError};
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub struct GossipListenAddr(SocketAddr);

--- a/components/sup/src/lib.rs
+++ b/components/sup/src/lib.rs
@@ -50,14 +50,6 @@ extern crate cpu_time;
 extern crate ctrlc;
 #[macro_use]
 extern crate features;
-
-use habitat_butterfly as butterfly;
-use habitat_common as common;
-#[macro_use]
-extern crate habitat_core as hcore;
-use habitat_api_client as api_client;
-use habitat_launcher_client as launcher_client;
-use habitat_sup_protocol as protocol;
 #[macro_use]
 extern crate lazy_static;
 #[macro_use]
@@ -109,19 +101,7 @@ mod sys;
 pub mod test_helpers;
 pub mod util;
 
-use std::{env,
-          path::PathBuf};
-
-lazy_static! {
-    pub static ref PROGRAM_NAME: String = {
-        let arg0 = env::args().next().map(PathBuf::from);
-        arg0.as_ref()
-            .and_then(|p| p.file_stem())
-            .and_then(|p| p.to_str())
-            .unwrap()
-            .to_string()
-    };
-}
+use std::env;
 
 /// List enables printing out the list features which can be dynamically enabled
 /// TestExit enables triggering an abrupt exit to simulate failures

--- a/components/sup/src/manager/commands.rs
+++ b/components/sup/src/manager/commands.rs
@@ -27,9 +27,9 @@ use crate::{ctl_gateway::CtlRequest,
             util};
 use habitat_butterfly as butterfly;
 use habitat_common::{command::package::install::InstallSource,
+                     outputln,
                      ui::UIWriter};
-use habitat_core::{outputln,
-                   package::{Identifiable,
+use habitat_core::{package::{Identifiable,
                              PackageIdent,
                              PackageTarget},
                    service::ServiceGroup,

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -62,7 +62,8 @@ use habitat_butterfly::{member::Member,
                                  ServerProxy,
                                  Suitability},
                         trace::Trace};
-use habitat_common::types::ListenCtlAddr;
+use habitat_common::{outputln,
+                     types::ListenCtlAddr};
 use habitat_core::{crypto::SymKey,
                    env::{self,
                          Config},
@@ -72,7 +73,6 @@ use habitat_core::{crypto::SymKey,
                                   Signal},
                         signals::{self,
                                   SignalEvent}},
-                   outputln,
                    package::{Identifiable,
                              PackageIdent,
                              PackageInstall},

--- a/components/sup/src/manager/peer_watcher.rs
+++ b/components/sup/src/manager/peer_watcher.rs
@@ -12,6 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::{error::{Error,
+                    Result},
+            manager::file_watcher::{default_file_watcher,
+                                    Callbacks}};
+use habitat_butterfly::member::Member;
+use habitat_common::{cli_defaults::GOSSIP_DEFAULT_PORT,
+                     outputln};
 use std::{fs::File,
           io::{BufRead,
                BufReader},
@@ -23,13 +30,6 @@ use std::{fs::File,
                           Ordering},
                  Arc},
           thread::Builder as ThreadBuilder};
-
-use crate::{butterfly::member::Member,
-            common::cli_defaults::GOSSIP_DEFAULT_PORT,
-            error::{Error,
-                    Result},
-            manager::file_watcher::{default_file_watcher,
-                                    Callbacks}};
 
 static LOGKEY: &'static str = "PW";
 
@@ -151,8 +151,8 @@ impl PeerWatcher {
 #[cfg(test)]
 mod tests {
     use super::PeerWatcher;
-    use crate::{butterfly::member::Member,
-                common::cli_defaults::GOSSIP_DEFAULT_PORT};
+    use habitat_butterfly::member::Member;
+    use habitat_common::cli_defaults::GOSSIP_DEFAULT_PORT;
     use std::{fs::{File,
                    OpenOptions},
               io::Write};

--- a/components/sup/src/manager/self_updater.rs
+++ b/components/sup/src/manager/self_updater.rs
@@ -22,16 +22,15 @@ use std::{sync::mpsc::{sync_channel,
           thread,
           time::Duration};
 
+use crate::{env,
+            util};
+use habitat_common::{command::package::install::InstallSource,
+                     ui::UI};
+use habitat_core::{package::{PackageIdent,
+                             PackageInstall},
+                   ChannelIdent};
 use time::{Duration as TimeDuration,
            SteadyTime};
-
-use crate::{common::{command::package::install::InstallSource,
-                     ui::UI},
-            env,
-            hcore::{package::{PackageIdent,
-                              PackageInstall},
-                    ChannelIdent},
-            util};
 
 pub const SUP_PKG_IDENT: &str = "core/hab-sup";
 const DEFAULT_FREQUENCY: i64 = 60_000;

--- a/components/sup/src/manager/service/context.rs
+++ b/components/sup/src/manager/service/context.rs
@@ -47,31 +47,28 @@
 //! their focused and single-use purpose; they shouldn't be used for
 //! anything else, and so, they _can't_ be used for anything else.
 
-use std::{borrow::Cow,
-          collections::HashMap,
-          net::IpAddr,
-          path::PathBuf,
-          result};
-
-use serde::{ser::SerializeMap,
-            Serialize,
-            Serializer};
-use toml;
-
-use crate::{butterfly::rumor::service::SysInfo,
-            common::templating::{config::Cfg,
-                                 package::{Env,
-                                           Pkg}},
-            hcore::{package::PackageIdent,
-                    service::{ServiceBind,
-                              ServiceGroup}}};
-
 use crate::{census::{CensusGroup,
                      CensusMember,
                      CensusRing,
                      ElectionStatus,
                      MemberId},
             manager::Sys};
+use habitat_butterfly::rumor::service::SysInfo;
+use habitat_common::templating::{config::Cfg,
+                                 package::{Env,
+                                           Pkg}};
+use habitat_core::{package::PackageIdent,
+                   service::{ServiceBind,
+                             ServiceGroup}};
+use serde::{ser::SerializeMap,
+            Serialize,
+            Serializer};
+use std::{borrow::Cow,
+          collections::HashMap,
+          net::IpAddr,
+          path::PathBuf,
+          result};
+use toml;
 
 /// The context of a rendering call, exposing information on the
 /// currently-running Supervisor and service, its service group, and
@@ -574,10 +571,10 @@ mod tests {
     use serde_json;
     use tempfile::TempDir;
 
-    use crate::{butterfly::rumor::service::SysInfo,
-                common::templating::{config::PackageConfigPaths,
-                                     TemplateRenderer},
-                hcore::package::PackageIdent};
+    use habitat_butterfly::rumor::service::SysInfo;
+    use habitat_common::templating::{config::PackageConfigPaths,
+                                     TemplateRenderer};
+    use habitat_core::package::PackageIdent;
 
     use crate::{manager::service::Cfg,
                 test_helpers::*};

--- a/components/sup/src/manager/service/hooks.rs
+++ b/components/sup/src/manager/service/hooks.rs
@@ -13,16 +13,16 @@
 // limitations under the License.
 
 use super::health;
+use habitat_common::{outputln,
+                     templating::{hooks::{self,
+                                          ExitCode,
+                                          Hook,
+                                          HookOutput,
+                                          RenderPair},
+                                  package::Pkg,
+                                  TemplateRenderer}};
 #[cfg(windows)]
-use crate::hcore::os::process::windows_child::ExitStatus;
-use habitat_common::templating::{hooks::{self,
-                                         ExitCode,
-                                         Hook,
-                                         HookOutput,
-                                         RenderPair},
-                                 package::Pkg,
-                                 TemplateRenderer};
-use habitat_core::outputln;
+use habitat_core::os::process::windows_child::ExitStatus;
 use serde::Serialize;
 #[cfg(not(windows))]
 use std::process::ExitStatus;
@@ -533,8 +533,9 @@ impl HookTable {
 mod tests {
     use std::{fs,
               iter};
+    use tempfile::TempDir;
 
-    use crate::{butterfly::{member::MemberList,
+    use habitat_butterfly::{member::MemberList,
                             rumor::{election::{self,
                                                Election as ElectionRumor,
                                                ElectionUpdate as ElectionUpdateRumor},
@@ -542,20 +543,19 @@ mod tests {
                                               SysInfo},
                                     service_config::ServiceConfig as ServiceConfigRumor,
                                     service_file::ServiceFile as ServiceFileRumor,
-                                    RumorStore}},
-                common::templating::{config::Cfg,
-                                     package::Pkg,
-                                     test_helpers::*},
-                hcore::{package::{PackageIdent,
-                                  PackageInstall},
-                        service::{ServiceBind,
-                                  ServiceGroup}}};
-    use tempfile::TempDir;
+                                    RumorStore}};
+    use habitat_common::{templating::{config::Cfg,
+                                      package::Pkg,
+                                      test_helpers::*},
+                         types::ListenCtlAddr};
+    use habitat_core::{package::{PackageIdent,
+                                 PackageInstall},
+                       service::{ServiceBind,
+                                 ServiceGroup}};
 
     use super::{super::RenderContext,
                 *};
     use crate::{census::CensusRing,
-                common::types::ListenCtlAddr,
                 config::GossipListenAddr,
                 http_gateway,
                 manager::sys::Sys};

--- a/components/sup/src/manager/service/mod.rs
+++ b/components/sup/src/manager/service/mod.rs
@@ -53,13 +53,14 @@ use futures::{future,
               Future,
               IntoFuture};
 use habitat_butterfly::rumor::service::Service as ServiceRumor;
-use habitat_common::templating::{config::CfgRenderer,
-                                 hooks::Hook};
 pub use habitat_common::templating::{config::{Cfg,
                                               UserConfigPath},
                                      package::{Env,
                                                Pkg,
                                                PkgProxy}};
+use habitat_common::{outputln,
+                     templating::{config::CfgRenderer,
+                                  hooks::Hook}};
 use habitat_core::{crypto::hash,
                    fs::{atomic_write,
                         svc_hooks_path,
@@ -819,16 +820,16 @@ impl Service {
     }
 
     #[cfg(not(windows))]
-    fn set_hook_permissions<T: AsRef<Path>>(path: T) -> hcore::error::Result<()> {
-        use crate::{common::templating::hooks::HOOK_PERMISSIONS,
-                    hcore::util::posix_perm};
+    fn set_hook_permissions<T: AsRef<Path>>(path: T) -> habitat_core::error::Result<()> {
+        use habitat_common::templating::hooks::HOOK_PERMISSIONS;
+        use habitat_core::util::posix_perm;
 
         posix_perm::set_permissions(path.as_ref(), HOOK_PERMISSIONS)
     }
 
     #[cfg(windows)]
-    fn set_hook_permissions<T: AsRef<Path>>(path: T) -> hcore::error::Result<()> {
-        use hcore::util::win_perm;
+    fn set_hook_permissions<T: AsRef<Path>>(path: T) -> habitat_core::error::Result<()> {
+        use habitat_core::util::win_perm;
 
         win_perm::harden_path(path.as_ref())
     }
@@ -1017,7 +1018,7 @@ impl Service {
 
     #[cfg(not(windows))]
     fn set_gossip_permissions<T: AsRef<Path>>(&self, path: T) -> bool {
-        use crate::hcore::{os::users,
+        use habitat_core::{os::users,
                            util::posix_perm};
 
         if users::can_run_services_as_svc_user() {
@@ -1042,7 +1043,7 @@ impl Service {
 
     #[cfg(windows)]
     fn set_gossip_permissions<T: AsRef<Path>>(&self, path: T) -> bool {
-        use hcore::util::win_perm;
+        use habitat_core::util::win_perm;
 
         if let Err(e) = win_perm::harden_path(path.as_ref()) {
             outputln!(preamble self.service_group,

--- a/components/sup/src/manager/service/spec.rs
+++ b/components/sup/src/manager/service/spec.rs
@@ -15,20 +15,20 @@
 use super::{BindingMode,
             Topology,
             UpdateStrategy};
-use crate::{error::{Error,
-                    Result,
-                    SupError},
-            hcore::{fs::atomic_write,
-                    package::{PackageIdent,
-                              PackageInstall},
-                    service::{ApplicationEnvironment,
-                              HealthCheckInterval,
-                              ServiceBind},
-                    url::DEFAULT_BLDR_URL,
-                    util::{deserialize_using_from_str,
-                           serialize_using_to_string},
-                    ChannelIdent},
-            protocol};
+use crate::error::{Error,
+                   Result,
+                   SupError};
+use habitat_core::{fs::atomic_write,
+                   package::{PackageIdent,
+                             PackageInstall},
+                   service::{ApplicationEnvironment,
+                             HealthCheckInterval,
+                             ServiceBind},
+                   url::DEFAULT_BLDR_URL,
+                   util::{deserialize_using_from_str,
+                          serialize_using_to_string},
+                   ChannelIdent};
+use habitat_sup_protocol;
 use serde::{self,
             Deserialize};
 use std::{collections::HashSet,
@@ -107,7 +107,7 @@ pub trait IntoServiceSpec {
     fn into_spec(&self, spec: &mut ServiceSpec);
 }
 
-impl IntoServiceSpec for protocol::ctl::SvcLoad {
+impl IntoServiceSpec for habitat_sup_protocol::ctl::SvcLoad {
     fn into_spec(&self, spec: &mut ServiceSpec) {
         spec.ident = self.ident.clone().unwrap().into();
         spec.group = self.group
@@ -129,13 +129,14 @@ impl IntoServiceSpec for protocol::ctl::SvcLoad {
             spec.update_strategy = UpdateStrategy::from_i32(update_strategy).unwrap_or_default();
         }
         if let Some(ref list) = self.binds {
-            spec.binds = list.binds
-                             .iter()
-                             .map(|pb: &habitat_sup_protocol::types::ServiceBind| {
-                                 hcore::service::ServiceBind::new(&pb.name,
-                                                                  pb.service_group.clone().into())
-                             })
-                             .collect();
+            spec.binds =
+                list.binds
+                    .iter()
+                    .map(|pb: &habitat_sup_protocol::types::ServiceBind| {
+                        habitat_core::service::ServiceBind::new(&pb.name,
+                                                                pb.service_group.clone().into())
+                    })
+                    .collect();
         }
         if let Some(binding_mode) = self.binding_mode {
             spec.binding_mode = BindingMode::from_i32(binding_mode).unwrap_or_default();
@@ -313,11 +314,11 @@ mod test {
               path::{Path,
                      PathBuf},
               str::FromStr};
+    use tempfile::TempDir;
 
-    use crate::hcore::{package::PackageIdent,
+    use habitat_core::{package::PackageIdent,
                        service::{ApplicationEnvironment,
                                  HealthCheckInterval}};
-    use tempfile::TempDir;
 
     use super::*;
     use crate::error::Error::*;

--- a/components/sup/src/manager/service/supervisor.rs
+++ b/components/sup/src/manager/service/supervisor.rs
@@ -24,13 +24,13 @@ use crate::error::{Error,
                    SupError};
 use futures::{future,
               Future};
-use habitat_common::templating::package::Pkg;
+use habitat_common::{outputln,
+                     templating::package::Pkg};
 #[cfg(unix)]
 use habitat_core::os::users;
 use habitat_core::{fs,
                    os::process::{self,
                                  Pid},
-                   outputln,
                    service::ServiceGroup};
 use habitat_launcher_client::LauncherCli;
 use serde::{ser::SerializeStruct,

--- a/components/sup/src/manager/service/terminator.rs
+++ b/components/sup/src/manager/service/terminator.rs
@@ -16,8 +16,8 @@ use super::spawned_future::SpawnedFuture;
 use crate::sys::{service,
                  ShutdownMethod};
 use futures::sync::oneshot;
-use habitat_core::{os::process::Pid,
-                   outputln};
+use habitat_common::outputln;
+use habitat_core::os::process::Pid;
 use std::thread;
 
 static LOGKEY: &str = "ST"; // "Service Terminator"

--- a/components/sup/src/manager/service_updater.rs
+++ b/components/sup/src/manager/service_updater.rs
@@ -19,10 +19,10 @@ use crate::{census::CensusRing,
                                 UpdateStrategy}},
             util};
 use habitat_butterfly;
-use habitat_common::ui::UI;
+use habitat_common::{outputln,
+                     ui::UI};
 use habitat_core::{env as henv,
                    env::Config as EnvConfig,
-                   outputln,
                    package::{PackageIdent,
                              PackageInstall,
                              PackageTarget},

--- a/components/sup/src/manager/spec_dir.rs
+++ b/components/sup/src/manager/spec_dir.rs
@@ -1,14 +1,13 @@
+use super::service::spec::ServiceSpec;
+use crate::error::{Error,
+                   Result};
+use glob;
+use habitat_common::outputln;
 use std::{error::Error as StdErr,
           ffi::OsStr,
           iter::IntoIterator,
           path::{Path,
                  PathBuf}};
-
-use glob;
-
-use super::service::spec::ServiceSpec;
-use crate::error::{Error,
-                   Result};
 
 static LOGKEY: &str = "SD";
 const SPEC_FILE_EXT: &str = "spec";

--- a/components/sup/src/manager/sys.rs
+++ b/components/sup/src/manager/sys.rs
@@ -12,20 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{net::{IpAddr,
-                Ipv4Addr,
-                SocketAddr},
-          str};
-
-use crate::{butterfly::rumor::service::SysInfo,
-            hcore};
-
-use crate::{common::types::ListenCtlAddr,
-            config::GossipListenAddr,
+use crate::{config::GossipListenAddr,
             error::{Error,
                     Result},
             http_gateway,
             VERSION};
+use habitat_butterfly::rumor::service::SysInfo;
+use habitat_common::{outputln,
+                     types::ListenCtlAddr};
+use habitat_core;
+use std::{net::{IpAddr,
+                Ipv4Addr,
+                SocketAddr},
+          str};
 
 static LOGKEY: &'static str = "SY";
 
@@ -104,14 +103,14 @@ impl Sys {
 }
 
 pub fn lookup_ip() -> Result<IpAddr> {
-    match hcore::util::sys::ip() {
+    match habitat_core::util::sys::ip() {
         Ok(s) => Ok(s),
         Err(e) => Err(sup_error!(Error::HabitatCore(e))),
     }
 }
 
 pub fn lookup_hostname() -> Result<String> {
-    match hcore::os::net::hostname() {
+    match habitat_core::os::net::hostname() {
         Ok(hostname) => Ok(hostname),
         Err(_) => Err(sup_error!(Error::IPFailed)),
     }

--- a/components/sup/src/manager/user_config_watcher.rs
+++ b/components/sup/src/manager/user_config_watcher.rs
@@ -15,7 +15,8 @@
 use super::file_watcher::{default_file_watcher_with_no_initial_event,
                           Callbacks};
 use crate::manager::service::Service;
-use habitat_common::templating::config::UserConfigPath;
+use habitat_common::{outputln,
+                     templating::config::UserConfigPath};
 use habitat_core::{fs::USER_CONFIG_FILE,
                    service::ServiceGroup};
 use std::{collections::HashMap,

--- a/components/sup/src/util/pkg.rs
+++ b/components/sup/src/util/pkg.rs
@@ -12,27 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::path::Path;
-
-use crate::{common::{self,
-                     command::package::install::{InstallHookMode,
-                                                 InstallMode,
-                                                 InstallSource,
-                                                 LocalPackageUsage},
-                     ui::UIWriter},
-            hcore::{env as henv,
-                    fs::{self,
-                         FS_ROOT_PATH},
-                    package::{PackageIdent,
-                              PackageInstall},
-                    ChannelIdent,
-                    AUTH_TOKEN_ENVVAR}};
-
 use crate::{error::{Error,
                     Result,
                     SupError},
             PRODUCT,
             VERSION};
+use habitat_common::{self,
+                     command::package::install::{InstallHookMode,
+                                                 InstallMode,
+                                                 InstallSource,
+                                                 LocalPackageUsage},
+                     outputln,
+                     ui::UIWriter};
+use habitat_core::{env as henv,
+                   fs::{self,
+                        FS_ROOT_PATH},
+                   package::{PackageIdent,
+                             PackageInstall},
+                   ChannelIdent,
+                   AUTH_TOKEN_ENVVAR};
+use std::path::Path;
 
 static LOGKEY: &'static str = "UT";
 
@@ -51,7 +50,7 @@ pub fn install<T>(ui: &mut T,
         Err(_) => None,
     };
 
-    common::command::package::install::start(ui,
+    habitat_common::command::package::install::start(ui,
                                              url,
                                              // We currently need this to be an option due to how
                                              // the depot


### PR DESCRIPTION
This leverages https://github.com/habitat-sh/core/pull/126 and should not be merged until that is merged.

This focuses on 2 areas of output:

1. The launcher emitting the output of spawned processes
2. Output T'd from the ctrl_gateway

The ctrl_gateway implementation is a bit whacky because instead or receiving whole "chunks" of output (think of the output emitted when loading a new service that must be downloaded and installed), it now receives output piecemeal, separated when styling changes and so we can't blissfully send the entire chunk as a line of StructuredOutput. We only want the structured output header if this is either the beginning of a line or if we are emitting json.

Signed-off-by: mwrock <matt@mattwrock.com>