### PR TITLE
Fix plan build regression in 0.76.0 release

### DIFF
--- a/components/hab/src/command/origin/delete.rs
+++ b/components/hab/src/command/origin/delete.rs
@@ -12,11 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::api_client::Client;
-use crate::common::ui::{Status, UIWriter, UI};
+use crate::{api_client::Client,
+            common::ui::{Status,
+                         UIWriter,
+                         UI}};
 
-use crate::error::{Error, Result};
-use crate::{PRODUCT, VERSION};
+use crate::{error::{Error,
+                    Result},
+            PRODUCT,
+            VERSION};
 
 pub fn start(ui: &mut UI, bldr_url: &str, token: &str, origin: &str) -> Result<()> {
     let api_client = Client::new(bldr_url, PRODUCT, VERSION, None).map_err(Error::APIClient)?;

--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -758,9 +758,9 @@ _install_dependency() {
 
 # **Internal** Returns (on stdout) the `TDEPS` file contents of another locally
 # installed package which contain the set of all direct and transitive run
-# dependencies. An empty set could be returned as whitespace and/or newlines.
-# The lack of a `TDEPS` file in the desired package will be considered an
-# unset, or empty set.
+# dependencies. An empty set generates no output. The lack of a `TDEPS` file or
+# a TDEPS file of zero bytes in the desired package will be considered an unset,
+# or empty set.
 #
 # ```
 # _get_tdeps_for /hab/pkgs/acme/a/4.2.2/20160113044458
@@ -774,20 +774,17 @@ _install_dependency() {
 #
 # Will return 0 in any case and the contents of `TDEPS` if the file exists.
 _get_tdeps_for() {
-  local pkg_path="$1"
-  if [[ -f "$pkg_path/TDEPS" ]]; then
+  local pkg_path="${1?_get_tdeps_for requires a pkg_path argument}"
+  if [[ -s "$pkg_path/TDEPS" ]]; then
     cat "$pkg_path"/TDEPS
-  else
-    # No file, meaning an empty set
-    echo
   fi
-  return 0
 }
 
 # **Internal** Returns (on stdout) the `DEPS` file contents of another locally
 # installed package which contain the set of all direct run dependencies. An
-# empty set could be returned as whitespace and/or newlines.  The lack of a
-# `DEPS` file in the desired package will be considered an unset, or empty set.
+# empty set could be returned as whitespace and/or newlines. An empty set
+# generates no output. The lack of a `DEPS` file or a DEPS file of zero bytes in
+# the desired package will be considered an unset, or empty set.
 #
 # ```
 # _get_deps_for /hab/pkgs/acme/a/4.2.2/20160113044458
@@ -801,14 +798,10 @@ _get_tdeps_for() {
 #
 # Will return 0 in any case and the contents of `DEPS` if the file exists.
 _get_deps_for() {
-  local pkg_path="$1"
-  if [[ -f "$pkg_path/DEPS" ]]; then
+  local pkg_path="${1?_get_deps_for requires a pkg_path argument}"
+  if [[ -s "$pkg_path/DEPS" ]]; then
     cat "$pkg_path"/DEPS
-  else
-    # No file, meaning an empty set
-    echo
   fi
-  return 0
 }
 
 # **Internal** Appends an entry to the given array only if the entry is not

--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -961,7 +961,7 @@ _resolve_scaffolding_dependencies() {
     scaff_build_deps_resolved+=("$resolved")
     # Add each (fully qualified) direct run dependency of the scaffolding
     # package.
-    read -r -a sdeps <<< "$(_get_deps_for "$resolved")"
+    mapfile -t sdeps < <(_get_deps_for "$resolved")
     for sdep in "${sdeps[@]}"; do
       scaff_build_deps+=("$sdep")
       scaff_build_deps_resolved+=("$HAB_PKG_PATH/$sdep")
@@ -1035,7 +1035,7 @@ _set_build_tdeps_resolved() {
   # dependency could pull in `acme/binutils` for us, as an example. Any
   # duplicate entries are dropped to produce a proper set.
   for dep in "${pkg_build_deps_resolved[@]}"; do
-    read -r -a tdeps <<< "$(_get_tdeps_for "$dep")"
+    mapfile -t tdeps < <(_get_tdeps_for "$dep")
     for tdep in "${tdeps[@]}"; do
       tdep="$HAB_PKG_PATH/$tdep"
       read -r -a pkg_build_tdeps_resolved <<< "$(_return_or_append_to_set "$tdep" "${pkg_build_tdeps_resolved[@]}")"
@@ -1100,7 +1100,7 @@ _resolve_run_dependencies() {
   # Append all non-direct (transitive) run dependencies for each direct run
   # dependency. Any duplicate entries are dropped to produce a proper set.
   for dep in "${pkg_deps_resolved[@]}"; do
-    read -r -a tdeps <<< "$(_get_tdeps_for "$dep")"
+    mapfile -t tdeps < <(_get_tdeps_for "$dep")
     for tdep in "${tdeps[@]}"; do
       tdep="$HAB_PKG_PATH/$tdep"
       read -r -a pkg_tdeps_resolved <<< "$(_return_or_append_to_set "$tdep" "${pkg_tdeps_resolved[@]}")"

--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -570,7 +570,7 @@ _assemble_runtime_path() {
       data="$(cat "$dep_prefix/PATH")"
       data="$(trim "$data")"
       while read -r entry; do
-        paths=($(_return_or_append_to_set "$entry" "${paths[@]}"))
+        read -r -a paths <<< "$(_return_or_append_to_set "$entry" "${paths[@]}")"
       done <<< "$(echo "$data" | tr ':' '\n' | grep "^$dep_prefix")"
     fi
   done
@@ -953,30 +953,27 @@ _resolve_scaffolding_dependencies() {
   scaff_build_deps=()
   scaff_build_deps_resolved=()
 
-  # shellcheck disable=2066
-  for dep in "${pkg_scaffolding}"; do
-    _install_dependency "$dep"
-    # Add scaffolding package to the list of scaffolding build deps
-    scaff_build_deps+=($dep)
-    if resolved="$(_resolve_dependency "$dep")"; then
-      build_line "Resolved scaffolding dependency '$dep' to $resolved"
-      scaff_build_deps_resolved+=($resolved)
-      # Add each (fully qualified) direct run dependency of the scaffolding
-      # package.
-      sdeps=($(_get_deps_for "$resolved"))
-      for sdep in "${sdeps[@]}"; do
-        scaff_build_deps+=($sdep)
-        scaff_build_deps_resolved+=($HAB_PKG_PATH/$sdep)
-      done
-    else
-      exit_with "Resolving '$dep' failed, should this be built first?" 1
-    fi
-  done
+  _install_dependency "$pkg_scaffolding"
+  # Add scaffolding package to the list of scaffolding build deps
+  scaff_build_deps+=("$pkg_scaffolding")
+  if resolved="$(_resolve_dependency "$pkg_scaffolding")"; then
+    build_line "Resolved scaffolding dependency '$pkg_scaffolding' to $resolved"
+    scaff_build_deps_resolved+=("$resolved")
+    # Add each (fully qualified) direct run dependency of the scaffolding
+    # package.
+    read -r -a sdeps <<< "$(_get_deps_for "$resolved")"
+    for sdep in "${sdeps[@]}"; do
+      scaff_build_deps+=("$sdep")
+      scaff_build_deps_resolved+=("$HAB_PKG_PATH/$sdep")
+    done
+  else
+    exit_with "Resolving '$pkg_scaffolding' failed, should this be built first?" 1
+  fi
 
   # Add all of the ordered scaffolding dependencies to the start of
   # `${pkg_build_deps[@]}` to make sure they could be overridden by a Plan
   # author if required.
-  pkg_build_deps=(${scaff_build_deps[@]} ${pkg_build_deps[@]})
+  pkg_build_deps=("${scaff_build_deps[@]}" "${pkg_build_deps[@]}")
   debug "Updating pkg_build_deps=(${pkg_build_deps[*]}) from Scaffolding deps"
 
   # Set `pkg_build_deps_resolved[@]}` to all resolved scaffolding dependencies.
@@ -1016,7 +1013,7 @@ _resolve_build_dependencies() {
     _install_dependency "$dep"
     if resolved="$(_resolve_dependency "$dep")"; then
       build_line "Resolved build dependency '$dep' to $resolved"
-      pkg_build_deps_resolved+=($resolved)
+      pkg_build_deps_resolved+=("$resolved")
     else
       exit_with "Resolving '$dep' failed, should this be built first?" 1
     fi
@@ -1038,12 +1035,10 @@ _set_build_tdeps_resolved() {
   # dependency could pull in `acme/binutils` for us, as an example. Any
   # duplicate entries are dropped to produce a proper set.
   for dep in "${pkg_build_deps_resolved[@]}"; do
-    tdeps=($(_get_tdeps_for "$dep"))
+    read -r -a tdeps <<< "$(_get_tdeps_for "$dep")"
     for tdep in "${tdeps[@]}"; do
       tdep="$HAB_PKG_PATH/$tdep"
-      pkg_build_tdeps_resolved=(
-        $(_return_or_append_to_set "$tdep" "${pkg_build_tdeps_resolved[@]}")
-      )
+      read -r -a pkg_build_tdeps_resolved <<< "$(_return_or_append_to_set "$tdep" "${pkg_build_tdeps_resolved[@]}")"
     done
   done
 }
@@ -1091,7 +1086,7 @@ _resolve_run_dependencies() {
     fi
     if resolved="$(_resolve_dependency "$dep")"; then
       build_line "Resolved dependency '$dep' to $resolved"
-      pkg_deps_resolved+=($resolved)
+      pkg_deps_resolved+=("$resolved")
     else
       exit_with "Resolving '$dep' failed, should this be built first?" 1
     fi
@@ -1105,12 +1100,10 @@ _resolve_run_dependencies() {
   # Append all non-direct (transitive) run dependencies for each direct run
   # dependency. Any duplicate entries are dropped to produce a proper set.
   for dep in "${pkg_deps_resolved[@]}"; do
-    tdeps=($(_get_tdeps_for "$dep"))
+    read -r -a tdeps <<< "$(_get_tdeps_for "$dep")"
     for tdep in "${tdeps[@]}"; do
       tdep="$HAB_PKG_PATH/$tdep"
-      pkg_tdeps_resolved=(
-        $(_return_or_append_to_set "$tdep" "${pkg_tdeps_resolved[@]}")
-      )
+      read -r -a pkg_tdeps_resolved <<< "$(_return_or_append_to_set "$tdep" "${pkg_tdeps_resolved[@]}")"
     done
   done
 }
@@ -1141,9 +1134,7 @@ _populate_dependency_arrays() {
     "${pkg_build_deps_resolved[@]}"
   )
   for dep in "${pkg_tdeps_resolved[@]}" "${pkg_build_tdeps_resolved[@]}"; do
-    pkg_all_tdeps_resolved=(
-      $(_return_or_append_to_set "$dep" "${pkg_all_tdeps_resolved[@]}")
-    )
+    read -r -a pkg_all_tdeps_resolved <<< "$(_return_or_append_to_set "$dep" "${pkg_all_tdeps_resolved[@]}")"
   done
 }
 
@@ -1486,7 +1477,7 @@ _set_build_path() {
       data="$(cat "$dep_prefix/PATH")"
       data="$(trim "$data")"
       while read -r entry; do
-        paths=($(_return_or_append_to_set "$entry" "${paths[@]}"))
+        read -r -a paths <<< "$(_return_or_append_to_set "$entry" "${paths[@]}")"
       done <<< "$(echo "$data" | tr ':' '\n' | grep "^$dep_prefix")"
     fi
   done


### PR DESCRIPTION
**tl;dr** see the fix in https://github.com/habitat-sh/habitat/pull/6257/commits/05d362304504770424ed076805dca570d938a669

# Full Details

Reverts habitat-sh/habitat#6248
Resolves https://github.com/habitat-sh/habitat/issues/6250

Now that we understand the nature of this error, we can re-implement that shellcheck fixes that we previously reverted and add the necessary fix to the problem they uncovered.

**The Bugs**

1. In `_resolve_scaffolding_dependencies` (and other similar usages), changing the code that collects the transitive dependencies from
    ```bash
    sdeps=($(_get_deps_for "$resolved"))
    ```
    to
    ```bash
    read -r -a sdeps <<< "$(_get_deps_for "$resolved")"
    ```
    as part of https://github.com/habitat-sh/habitat/pull/6160 to address `shellcheck` lint [SC2207](https://github.com/koalaman/shellcheck/wiki/SC2207#prefer-mapfile-or-read--a-to-split-command-output-or-quote-to-avoid-splitting). This resulted in a defect where because only the first dependency from `_get_deps_for` was added to `sdeps`, scaffolding-based builds failed. https://github.com/habitat-sh/habitat/pull/6240 was submitted to fix the issue.

1. The fix in https://github.com/habitat-sh/habitat/pull/6240 was correct. It changed
    ```bash
    read -r -a sdeps <<< "$(_get_deps_for "$resolved")"
    ```
    to
    ```bash
    mapfile -t sdeps < <(_get_deps_for "$resolved")
    ```
    The first command is for populating an array from a single line of input, with entries separated by whitespace. The second command is for populating an array from multiple lines of input, with entries separate by newlines (which is what `_get_deps_for` does).

    However, a different bug was discovered: unexpected newlines were appearing at the beginning of the `TDEPS` files for some packages, causing breakages. Eventually, the difference in behavior between
    ```bash
    sdeps=($(_get_deps_for "$resolved"))
    ```
    and
    ```bash
    mapfile -t sdeps < <(_get_deps_for "$resolved")
    ```
    was traced back to `_get_deps_for`:
    ```bash
    # **Internal** Returns (on stdout) the `TDEPS` file contents of another locally
    # installed package which contain the set of all direct and transitive run
    # dependencies. An empty set could be returned as whitespace and/or newlines.
    # The lack of a `TDEPS` file in the desired package will be considered an
    # unset, or empty set.
    #
    # ```
    # _get_tdeps_for /hab/pkgs/acme/a/4.2.2/20160113044458
    # # /hab/pkgs/acme/dep-b/1.2.3/20160113033619
    # # /hab/pkgs/acme/dep-c/5.0.1/20160113033507
    # # /hab/pkgs/acme/dep-d/2.0.0/20160113033539
    # # /hab/pkgs/acme/dep-e/10.0.1/20160113033453
    # # /hab/pkgs/acme/dep-f/4.2.2/20160113033338
    # # /hab/pkgs/acme/dep-g/4.2.2/20160113033319
    # ```
    #
    # Will return 0 in any case and the contents of `TDEPS` if the file exists.
    _get_tdeps_for() {
      local pkg_path="$1"
      if [[ -f "$pkg_path/TDEPS" ]]; then
        cat "$pkg_path"/TDEPS
      else
        # No file, meaning an empty set
        echo
      fi
      return 0
    }
    ```
    Because `_get_tdeps_for` returned a newline (rather than nothing) in the case of an absent `TDEPS` file (which is normal, some packages have no transitive dependencies), the `mapfile` version of the code interpreted this as a single element array, containing an empty string. This was eventually rendered into the subsequent `TDEPS` file as an empty line.

    Essentially, the previous code depended upon ["the shell's sloppy word splitting and glob expansion" that `shellcheck` warns against](https://github.com/koalaman/shellcheck/wiki/SC2207#prefer-mapfile-or-read--a-to-split-command-output-or-quote-to-avoid-splitting). Updating `_get_tdeps_for` (and similarly `_get_deps_for`) to output nothing in the case of an empty set (and omitting the superfluous `return`):
    ```bash
    _get_tdeps_for() {
      local pkg_path="$1"
      if [[ -f "$pkg_path/TDEPS" ]]; then
        cat "$pkg_path"/TDEPS
      fi
    }
    ```
    fixes the issue.

This PR makes some additional improvements to `_get_[t]deps_for`; see https://github.com/habitat-sh/habitat/pull/6257/commits/05d362304504770424ed076805dca570d938a669.