### PR TITLE
Remove old templated content when adding a service

### DIFF
--- a/components/sup/src/manager/service/mod.rs
+++ b/components/sup/src/manager/service/mod.rs
@@ -282,7 +282,9 @@ impl Service {
     /// Create the service path for this package.
     pub fn create_svc_path(&self) -> Result<()> {
         debug!("{}, Creating svc paths", self.service_group);
-        SvcDir::new(&self.pkg.name, &self.pkg.svc_user, &self.pkg.svc_group).create()?;
+        let svc_dir = SvcDir::new(&self.pkg.name, &self.pkg.svc_user, &self.pkg.svc_group);
+        svc_dir.create()?;
+        svc_dir.purge_templated_content()?;
         Ok(())
     }
 


### PR DESCRIPTION
This ensures that config and hook files from a previous version of the service that are not present in the currently-running version are removed and cannot cause conflicts.

Fixes #4925

Signed-off-by: Christopher Maier <cmaier@chef.io>