### PR TITLE
Fix clippy::large_enum_variant and add to DENIED_LINTS

### DIFF
--- a/components/butterfly/build.rs
+++ b/components/butterfly/build.rs
@@ -14,6 +14,8 @@ fn main() {
 
 fn generate_protocols() {
     let mut config = prost_build::Config::new();
+    config.type_attribute(".butterfly.newscast.Rumor.payload",
+                          "#[allow(clippy::large_enum_variant)]");
     config.type_attribute(".", "#[derive(Serialize, Deserialize)]");
     config.compile_protos(&protocol_files(), &protocol_includes())
           .expect("Error compiling protobuf definitions");

--- a/components/butterfly/src/generated/butterfly.newscast.rs
+++ b/components/butterfly/src/generated/butterfly.newscast.rs
@@ -122,6 +122,7 @@ pub mod rumor {
         Departure = 9,
     }
     #[derive(Clone, PartialEq, ::prost::Oneof)]
+    #[allow(clippy::large_enum_variant)]
     #[derive(Serialize, Deserialize)]
     pub enum Payload {
         #[prost(message, tag="4")]

--- a/components/butterfly/src/rumor/mod.rs
+++ b/components/butterfly/src/rumor/mod.rs
@@ -75,7 +75,7 @@ pub enum RumorKind {
     Election(Election),
     ElectionUpdate(ElectionUpdate),
     Membership(Membership),
-    Service(Service),
+    Service(Box<Service>), // Boxed due to clippy::large_enum_variant
     ServiceConfig(ServiceConfig),
     ServiceFile(ServiceFile),
 }
@@ -87,7 +87,7 @@ impl From<RumorKind> for RumorPayload {
             RumorKind::Election(election) => RumorPayload::Election(election.into()),
             RumorKind::ElectionUpdate(election) => RumorPayload::Election(election.into()),
             RumorKind::Membership(membership) => RumorPayload::Member(membership.into()),
-            RumorKind::Service(service) => RumorPayload::Service(service.into()),
+            RumorKind::Service(service) => RumorPayload::Service((*service).into()),
             RumorKind::ServiceConfig(service_config) => {
                 RumorPayload::ServiceConfig(service_config.into())
             }
@@ -475,7 +475,7 @@ impl RumorEnvelope {
                 RumorKind::ElectionUpdate(ElectionUpdate::from_proto(proto)?)
             }
             RumorType::Member => RumorKind::Membership(Membership::from_proto(proto)?),
-            RumorType::Service => RumorKind::Service(Service::from_proto(proto)?),
+            RumorType::Service => RumorKind::Service(Box::new(Service::from_proto(proto)?)),
             RumorType::ServiceConfig => RumorKind::ServiceConfig(ServiceConfig::from_proto(proto)?),
             RumorType::ServiceFile => RumorKind::ServiceFile(ServiceFile::from_proto(proto)?),
             RumorType::Fake | RumorType::Fake2 => panic!("fake rumor"),

--- a/components/butterfly/src/server/pull.rs
+++ b/components/butterfly/src/server/pull.rs
@@ -125,7 +125,7 @@ impl Pull {
                     self.server
                         .insert_member_from_rumor(membership.member, membership.health);
                 }
-                RumorKind::Service(service) => self.server.insert_service(service),
+                RumorKind::Service(service) => self.server.insert_service(*service),
                 RumorKind::ServiceConfig(service_config) => {
                     self.server.insert_service_config(service_config);
                 }

--- a/components/common/src/error.rs
+++ b/components/common/src/error.rs
@@ -66,7 +66,8 @@ pub enum Error {
     StrFromUtf8Error(str::Utf8Error),
     StringFromUtf8Error(string::FromUtf8Error),
     /// When an error occurs registering template file
-    TemplateFileError(handlebars::TemplateFileError),
+    // Boxed due to clippy::large_enum_variant
+    TemplateFileError(Box<handlebars::TemplateFileError>),
     /// When an error occurs rendering template
     /// The error is constructed with a handlebars::RenderError's format string instead
     /// of the handlebars::RenderError itself because the cause field of the
@@ -207,7 +208,7 @@ impl From<api_client::Error> for Error {
 }
 
 impl From<handlebars::TemplateFileError> for Error {
-    fn from(err: handlebars::TemplateFileError) -> Self { Error::TemplateFileError(err) }
+    fn from(err: handlebars::TemplateFileError) -> Self { Error::TemplateFileError(Box::new(err)) }
 }
 
 impl From<hcore::Error> for Error {

--- a/components/common/src/templating/config.rs
+++ b/components/common/src/templating/config.rs
@@ -575,7 +575,7 @@ fn load_templates(dir: &Path,
             Ok(file_type) if file_type.is_file() => {
                 // JW TODO: This error needs improvement. TemplateFileError is too generic.
                 template.register_template_file(&relative_path.to_string_lossy(), &entry.path())
-                        .map_err(Error::TemplateFileError)?;
+                        .map_err(|e| Error::TemplateFileError(Box::new(e)))?;
             }
             Ok(file_type) if file_type.is_dir() => {
                 template = load_templates(&entry.path(), &relative_path, template)?

--- a/components/hab/src/error.rs
+++ b/components/hab/src/error.rs
@@ -56,7 +56,7 @@ pub enum Error {
     FileNotFound(String),
     HabitatCommon(common::Error),
     HabitatCore(hcore::Error),
-    // Boxed because https://rust-lang-nursery.github.io/rust-clippy/master/index.html#large_enum_variant
+    // Boxed due to clippy::large_enum_variant
     HandlebarsRenderError(Box<handlebars::TemplateRenderError>),
     IO(io::Error),
     JobGroupPromoteOrDemote(api_client::Error, bool /* promote */),

--- a/components/launcher/src/server/mod.rs
+++ b/components/launcher/src/server/mod.rs
@@ -232,7 +232,7 @@ impl Server {
         match self.supervisor.try_wait() {
             Ok(Some(status)) => debug!("Supervisor exited with: {}", status),
             Err(e) => error!("Error waiting on supervisor: {:?}", e),
-            __ => unreachable!(),
+            _ => unreachable!(),
         }
 
         // TODO (CM): Eventually this can go away... but we need to

--- a/components/sup/src/cli.rs
+++ b/components/sup/src/cli.rs
@@ -8,7 +8,6 @@ pub fn cli<'a, 'b>() -> App<'a, 'b> { sup_commands() }
 mod test {
     use super::cli;
     use clap::ErrorKind;
-    use std::iter::FromIterator;
 
     macro_rules! assert_cli_cmd {
         ($test:ident, $cmd:expr, $( $key:expr => $value:tt ),+) => {
@@ -29,6 +28,7 @@ mod test {
 
     mod sup_run {
         use super::*;
+        use std::iter::FromIterator as _;
 
         assert_cli_cmd!(should_handle_multiple_peer_flags,
                         "hab-sup run --peer 1.1.1.1 --peer 2.2.2.2",

--- a/components/sup/src/error.rs
+++ b/components/sup/src/error.rs
@@ -48,8 +48,7 @@ use habitat_common::{self,
 use habitat_core::{self,
                    os::process::Pid,
                    package::{self,
-                             Identifiable,
-                             PackageInstall}};
+                             Identifiable}};
 use habitat_launcher_client;
 use habitat_sup_protocol;
 use notify;

--- a/components/sup/src/error.rs
+++ b/components/sup/src/error.rs
@@ -110,7 +110,6 @@ pub enum Error {
     BadDataPath(PathBuf, io::Error),
     BadDesiredState(String),
     BadElectionStatus(String),
-    BadPackage(PackageInstall, habitat_core::error::Error),
     BadSpecsPath(PathBuf, io::Error),
     BadStartStyle(String),
     BindTimeout(String),
@@ -208,7 +207,6 @@ impl fmt::Display for SupError {
                 format!("Unknown service desired state style '{}'", state)
             }
             Error::BadElectionStatus(ref status) => format!("Unknown election status '{}'", status),
-            Error::BadPackage(ref pkg, ref err) => format!("Bad package, {}, {}", pkg, err),
             Error::BadSpecsPath(ref path, ref err) => {
                 format!("Unable to create the specs directory '{}' ({})",
                         path.display(),
@@ -348,7 +346,6 @@ impl error::Error for SupError {
             Error::BadDataPath(..) => "Unable to read or write to data directory",
             Error::BadElectionStatus(_) => "Unknown election status",
             Error::BadDesiredState(_) => "Unknown desired state in service spec",
-            Error::BadPackage(..) => "Package was malformed or contained malformed contents",
             Error::BadSpecsPath(..) => "Unable to create the specs directory",
             Error::BadStartStyle(_) => "Unknown start style in service spec",
             Error::BindTimeout(_) => "Timeout waiting to bind to an address",

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -154,7 +154,8 @@ lazy_static! {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ServiceOperation {
+#[allow(clippy::large_enum_variant)]
+enum ServiceOperation {
     Start(ServiceSpec),
     Stop(ServiceSpec),
     Restart {

--- a/components/sup/src/manager/spec_watcher.rs
+++ b/components/sup/src/manager/spec_watcher.rs
@@ -194,7 +194,9 @@ mod tests {
     /// few milliseconds more, just to be certain our filesystem
     /// events have had plenty of time to process.
     fn wait_for_debounce_interval() {
-        thread::sleep(SpecWatcherDelay::configured_value().0 + Duration::from_millis(2));
+        let wait_duration = SpecWatcherDelay::configured_value().0 + Duration::from_millis(2);
+        trace!("wait_for_debounce_interval: waiting {:?}", wait_duration);
+        thread::sleep(wait_duration);
     }
 
     #[test]
@@ -237,6 +239,8 @@ mod tests {
     /// to their final `*.spec` form.
     #[test]
     fn can_get_events_for_non_spec_files() {
+        env_logger::try_init().ok();
+        debug!("can_get_events_for_non_spec_files starting");
         let _delay = lock_delay_var();
 
         let dir = TempDir::new().expect("Could not create directory");
@@ -250,11 +254,14 @@ mod tests {
         assert!(!sw.has_events(),
                 "Need to allow for the debounce interval to pass before you can expect events");
 
-        wait_for_debounce_interval();
+        while !sw.has_events() {
+            wait_for_debounce_interval();
+        }
 
-        assert!(sw.has_events(), "There should be an event now");
+        // assert!(sw.has_events(), "There should be an event now");
         assert!(!sw.has_events(),
                 "Should be no more events after you've checked");
+        debug!("can_get_events_for_non_spec_files done");
     }
 
     #[test]

--- a/components/sup/src/manager/spec_watcher.rs
+++ b/components/sup/src/manager/spec_watcher.rs
@@ -211,6 +211,8 @@ mod tests {
 
     #[test]
     fn can_get_events_for_spec_files() {
+        env_logger::try_init().ok();
+        debug!("can_get_events_for_spec_files starting");
         let _delay = lock_delay_var();
 
         let dir = TempDir::new().expect("Could not create directory");
@@ -224,11 +226,14 @@ mod tests {
         assert!(!sw.has_events(),
                 "Need to allow for the debounce interval to pass before you can expect events");
 
-        wait_for_debounce_interval();
+        while !sw.has_events() {
+            wait_for_debounce_interval();
+        }
 
-        assert!(sw.has_events(), "There should be an event now");
+        // assert!(sw.has_events(), "There should be an event now");
         assert!(!sw.has_events(),
                 "Should be no more events after you've checked");
+        debug!("can_get_events_for_spec_files done");
     }
 
     /// Currently, the spec watcher will respond to changes to any
@@ -266,6 +271,8 @@ mod tests {
 
     #[test]
     fn short_debounce_delays_also_work() {
+        env_logger::try_init().ok();
+        debug!("short_debounce_delays_also_work starting");
         let delay = lock_delay_var();
         delay.set("1");
 
@@ -284,10 +291,13 @@ mod tests {
         assert!(!sw.has_events(),
                 "Need to allow for the debounce interval to pass before you can expect events");
 
-        wait_for_debounce_interval();
+        while !sw.has_events() {
+            wait_for_debounce_interval();
+        }
 
-        assert!(sw.has_events(), "There should be an event now");
+        // assert!(sw.has_events(), "There should be an event now");
         assert!(!sw.has_events(),
                 "Should be no more events after you've checked");
+        debug!("short_debounce_delays_also_work starting");
     }
 }

--- a/components/sup/src/manager/spec_watcher.rs
+++ b/components/sup/src/manager/spec_watcher.rs
@@ -195,7 +195,7 @@ mod tests {
     /// events have had plenty of time to process.
     fn wait_for_debounce_interval() {
         let wait_duration = SpecWatcherDelay::configured_value().0 + Duration::from_millis(2);
-        trace!("wait_for_debounce_interval: waiting {:?}", wait_duration);
+        error!("wait_for_debounce_interval: waiting {:?}", wait_duration);
         thread::sleep(wait_duration);
     }
 
@@ -212,7 +212,7 @@ mod tests {
     #[test]
     fn can_get_events_for_spec_files() {
         env_logger::try_init().ok();
-        debug!("can_get_events_for_spec_files starting");
+        error!("can_get_events_for_spec_files starting");
         let _delay = lock_delay_var();
 
         let dir = TempDir::new().expect("Could not create directory");
@@ -230,10 +230,9 @@ mod tests {
             wait_for_debounce_interval();
         }
 
-        // assert!(sw.has_events(), "There should be an event now");
         assert!(!sw.has_events(),
                 "Should be no more events after you've checked");
-        debug!("can_get_events_for_spec_files done");
+        error!("can_get_events_for_spec_files done");
     }
 
     /// Currently, the spec watcher will respond to changes to any
@@ -245,7 +244,7 @@ mod tests {
     #[test]
     fn can_get_events_for_non_spec_files() {
         env_logger::try_init().ok();
-        debug!("can_get_events_for_non_spec_files starting");
+        error!("can_get_events_for_non_spec_files starting");
         let _delay = lock_delay_var();
 
         let dir = TempDir::new().expect("Could not create directory");
@@ -263,16 +262,15 @@ mod tests {
             wait_for_debounce_interval();
         }
 
-        // assert!(sw.has_events(), "There should be an event now");
         assert!(!sw.has_events(),
                 "Should be no more events after you've checked");
-        debug!("can_get_events_for_non_spec_files done");
+        error!("can_get_events_for_non_spec_files done");
     }
 
     #[test]
     fn short_debounce_delays_also_work() {
         env_logger::try_init().ok();
-        debug!("short_debounce_delays_also_work starting");
+        error!("short_debounce_delays_also_work starting");
         let delay = lock_delay_var();
         delay.set("1");
 
@@ -295,9 +293,8 @@ mod tests {
             wait_for_debounce_interval();
         }
 
-        // assert!(sw.has_events(), "There should be an event now");
         assert!(!sw.has_events(),
                 "Should be no more events after you've checked");
-        debug!("short_debounce_delays_also_work starting");
+        error!("short_debounce_delays_also_work starting");
     }
 }

--- a/test/run_clippy.sh
+++ b/test/run_clippy.sh
@@ -43,7 +43,6 @@ allowed_lints=(clippy::module_inception \
 
 # Known failing lints we want to receive warnings for, but not fail the build
 lints_to_fix=(clippy::cyclomatic_complexity \
-               clippy::large_enum_variant \
                clippy::needless_return \
                clippy::too_many_arguments)
 
@@ -66,6 +65,7 @@ denied_lints=(clippy::assign_op_pattern \
                clippy::identity_conversion \
                clippy::if_let_some_result \
                clippy::just_underscores_and_digits \
+               clippy::large_enum_variant \
                clippy::len_without_is_empty \
                clippy::len_zero \
                clippy::let_and_return \

--- a/test/run_clippy.sh
+++ b/test/run_clippy.sh
@@ -39,8 +39,7 @@ unexamined_lints=()
 # Lints we disagree with and choose to keep in our code with no warning
 allowed_lints=(clippy::module_inception \
                clippy::new_ret_no_self \
-               clippy::new_without_default \
-               clippy::new_without_default_derive)
+               clippy::new_without_default)
 
 # Known failing lints we want to receive warnings for, but not fail the build
 lints_to_fix=(clippy::cyclomatic_complexity \

--- a/test/run_clippy.sh
+++ b/test/run_clippy.sh
@@ -66,6 +66,7 @@ denied_lints=(clippy::assign_op_pattern \
                clippy::get_unwrap \
                clippy::identity_conversion \
                clippy::if_let_some_result \
+               clippy::just_underscores_and_digits \
                clippy::len_without_is_empty \
                clippy::len_zero \
                clippy::let_and_return \


### PR DESCRIPTION
See https://rust-lang.github.io/rust-clippy/master/#large_enum_variant

Some related fixes as well, view by commit for full explanation.

Clippy tracking issue: https://github.com/habitat-sh/habitat/issues/6213

