### PR TITLE
Use --strip-debug for hab, sup, and launcher

### DIFF
--- a/components/hab/habitat/plan.sh
+++ b/components/hab/habitat/plan.sh
@@ -87,6 +87,6 @@ do_install() {
 
 do_strip() {
   if [[ "$build_type" != "--debug" ]]; then
-    do_default_strip
+    strip --strip-debug "$pkg_prefix"/bin/$bin
   fi
 }

--- a/components/launcher/habitat/plan.sh
+++ b/components/launcher/habitat/plan.sh
@@ -50,3 +50,7 @@ do_install() {
   install -v -D "$CARGO_TARGET_DIR"/"$rustc_target"/"${builder_build_type#--}"/$bin \
     "$pkg_prefix"/bin/$bin
 }
+
+do_strip() {
+  strip --strip-debug "$pkg_prefix"/bin/$bin
+}

--- a/components/sup/habitat/plan.sh
+++ b/components/sup/habitat/plan.sh
@@ -102,6 +102,6 @@ do_install() {
 
 do_strip() {
   if [[ "$build_type" != "--debug" ]]; then
-    do_default_strip
+    strip --strip-debug "$pkg_prefix"/bin/$bin
   fi
 }


### PR DESCRIPTION
`--strip-all` is too harsh . It makes things next to impossible to debug.
If we do `--strip-debug`, we'll at least get some hints at what is going
on if we ever try to debug something running in production or analyze a
core dump.

More discussion at https://github.com/habitat-sh/habitat/pull/6259