### PR TITLE
Bump verify pipeline timeouts for single-use Windows queue

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -282,7 +282,7 @@ steps:
       - ./test/run_cargo_test.ps1 builder-api-client
     agents:
       queue: 'single-use-windows-privileged'
-    timeout_in_minutes: 15
+    timeout_in_minutes: 20
     retry:
       automatic:
         limit: 1
@@ -292,7 +292,7 @@ steps:
       - ./test/run_cargo_test.ps1 butterfly -Features "ignore_inconsistent_tests" -TestOptions "--test-threads=1"
     agents:
       queue: 'single-use-windows-privileged'
-    timeout_in_minutes: 15
+    timeout_in_minutes: 20
     retry:
       automatic:
         limit: 1
@@ -302,7 +302,7 @@ steps:
       - ./test/run_cargo_test.ps1 butterfly -TestOptions "--test-threads=1"
     agents:
       queue: 'single-use-windows-privileged'
-    timeout_in_minutes: 15
+    timeout_in_minutes: 20
     retry:
       automatic:
         limit: 10


### PR DESCRIPTION
We're regularly bumping up against our 15 minute timeout, particularly
on our Butterfly tests.

For now, we'll try 20 minutes instead and see how that goes.

Signed-off-by: Christopher Maier <cmaier@chef.io>