### PR TITLE
Rename windows queue for launcher steps

### DIFF
--- a/.buildkite/launcher_build_steps.yaml
+++ b/.buildkite/launcher_build_steps.yaml
@@ -16,7 +16,7 @@ steps:
   - label: ":windows: :habicat: core/hab-launcher"
     command: .buildkite/scripts/build_component.ps1 -Component launcher
     agents:
-      queue: windows-docker
+      queue: default-windows-privileged
     env:
       HAB_BLDR_CHANNEL: unstable
     plugins:
@@ -34,7 +34,7 @@ steps:
   - label: ":windows: Build windows service"
     command: .buildkite/scripts/build_component.ps1 -Component windows-service 
     agents:
-      queue: windows-docker
+      queue: default-windows-privileged
     env:
       HAB_BLDR_CHANNEL: unstable
     plugins:


### PR DESCRIPTION
This updates the windows queue names in the launcher pipeline steps to match the updated queue names provided by our build infrastructure.  


Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>