### PR TITLE
Changes for clippy lint fixes from core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -970,7 +970,7 @@ dependencies = [
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "mktemp 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mktemp 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "prometheus 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1033,7 +1033,7 @@ dependencies = [
 [[package]]
 name = "habitat_core"
 version = "0.0.0"
-source = "git+https://github.com/habitat-sh/core.git#e9aba7b7732fa5c8682ef941a7164aa27c13788b"
+source = "git+https://github.com/habitat-sh/core.git#ffbd4d486d61a1017bbf49309010eb9bf339cf0e"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "caps 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1060,7 +1060,7 @@ dependencies = [
  "toml 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "typemap 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "users 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "users 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "widestring 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "windows-acl 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1069,7 +1069,7 @@ dependencies = [
 [[package]]
 name = "habitat_http_client"
 version = "0.0.0"
-source = "git+https://github.com/habitat-sh/core.git#e9aba7b7732fa5c8682ef941a7164aa27c13788b"
+source = "git+https://github.com/habitat-sh/core.git#ffbd4d486d61a1017bbf49309010eb9bf339cf0e"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat_core 0.0.0 (git+https://github.com/habitat-sh/core.git)",
@@ -1163,7 +1163,7 @@ dependencies = [
  "handlebars 0.29.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "mktemp 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mktemp 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "tar 0.4.22 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1230,7 +1230,7 @@ dependencies = [
 [[package]]
 name = "habitat_win_users"
 version = "0.0.0"
-source = "git+https://github.com/habitat-sh/core.git#e9aba7b7732fa5c8682ef941a7164aa27c13788b"
+source = "git+https://github.com/habitat-sh/core.git#ffbd4d486d61a1017bbf49309010eb9bf339cf0e"
 dependencies = [
  "gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1799,10 +1799,10 @@ dependencies = [
 
 [[package]]
 name = "mktemp"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "uuid 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3301,7 +3301,7 @@ dependencies = [
 
 [[package]]
 name = "users"
-version = "0.8.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3311,15 +3311,6 @@ dependencies = [
 name = "utf8-ranges"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "uuid"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "rand 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "uuid"
@@ -3756,7 +3747,7 @@ dependencies = [
 "checksum mio-uds 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "966257a94e196b11bb43aca423754d87429960a768de9414f3691d6957abf125"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
 "checksum miow 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "396aa0f2003d7df8395cb93e09871561ccc3e785f0acb369170e8cc74ddf9226"
-"checksum mktemp 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "77001ceb9eed65439f3dc2a2543f9ba1417d912686bf224a7738d0966e6dcd69"
+"checksum mktemp 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "edf4fc746c5c977923b802d86fc9a95ca79a27d8c487613f68830d68d07c7b27"
 "checksum multimap 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2eb04b9f127583ed176e163fb9ec6f3e793b87e21deedd5734a69386a18a0151"
 "checksum native-tls 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ff8e08de0070bbf4c31f452ea2a70db092f36f6f2e4d897adf5674477d488fb2"
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
@@ -3916,9 +3907,8 @@ dependencies = [
 "checksum unsafe-any 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f30360d7979f5e9c6e6cea48af192ea8fab4afb3cf72597154b8f08935bc9c7f"
 "checksum untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "55cd1f4b4e96b46aeb8d4855db4a7a9bd96eeeb5c6a1ab54593328761642ce2f"
 "checksum url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
-"checksum users 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7fed7d0912567d35f88010c23dbaf865e9da8b5227295e8dc0f2fdd109155ab7"
+"checksum users 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c72f4267aea0c3ec6d07eaabea6ead7c5ddacfafc5e22bcf8d186706851fb4cf"
 "checksum utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737"
-"checksum uuid 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "78c590b5bd79ed10aad8fb75f078a59d8db445af6c743e55c4a53227fc01c13f"
 "checksum uuid 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bcc7e3b898aa6f6c08e5295b6c89258d1331e9ac578cc992fb818759951bdc22"
 "checksum uuid 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0238db0c5b605dd1cf51de0f21766f97fba2645897024461d6a00c036819a768"
 "checksum v_escape 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c8b50688edb86f4c092a1a9fe8bda004b0faa3197100897653809e97e09a2814"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1033,7 +1033,7 @@ dependencies = [
 [[package]]
 name = "habitat_core"
 version = "0.0.0"
-source = "git+https://github.com/habitat-sh/core.git#e6312bf6d4fe1033526783000cbc5c0fcde91ebe"
+source = "git+https://github.com/habitat-sh/core.git#e9aba7b7732fa5c8682ef941a7164aa27c13788b"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "caps 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1069,7 +1069,7 @@ dependencies = [
 [[package]]
 name = "habitat_http_client"
 version = "0.0.0"
-source = "git+https://github.com/habitat-sh/core.git#e6312bf6d4fe1033526783000cbc5c0fcde91ebe"
+source = "git+https://github.com/habitat-sh/core.git#e9aba7b7732fa5c8682ef941a7164aa27c13788b"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat_core 0.0.0 (git+https://github.com/habitat-sh/core.git)",
@@ -1230,7 +1230,7 @@ dependencies = [
 [[package]]
 name = "habitat_win_users"
 version = "0.0.0"
-source = "git+https://github.com/habitat-sh/core.git#e6312bf6d4fe1033526783000cbc5c0fcde91ebe"
+source = "git+https://github.com/habitat-sh/core.git#e9aba7b7732fa5c8682ef941a7164aa27c13788b"
 dependencies = [
  "gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/common/src/command/package/install.rs
+++ b/components/common/src/command/package/install.rs
@@ -167,7 +167,7 @@ impl FromStr for InstallSource {
                 // one string, such as `"x86_64-linux::core/redis"` (or similar). As there is
                 // currently no such representation, I'd argue that this `FromStr` is no longer
                 // reasonable. However, it's doing the job for now and we can proceed with caution.
-                Ok(ident) => Ok(InstallSource::Ident(ident, *PackageTarget::active_target())),
+                Ok(ident) => Ok(InstallSource::Ident(ident, PackageTarget::active_target())),
                 Err(e) => Err(e),
             }
         }
@@ -990,9 +990,9 @@ impl<'a> InstallTask<'a> {
         // system. Until we have better ideas, this implementation preserves past behavior.
         let artifact_target = artifact.target()?;
         let active_target = PackageTarget::active_target();
-        if active_target != &artifact_target {
+        if active_target != artifact_target {
             return Err(Error::HabitatCore(hcore::Error::WrongActivePackageTarget(
-                *active_target,
+                active_target,
                 artifact_target,
             )));
         }

--- a/components/common/src/util/path.rs
+++ b/components/common/src/util/path.rs
@@ -134,7 +134,7 @@ pub fn interpreter_paths() -> Result<Vec<PathBuf>> {
                                 &mut ui::UI::default_with_env(),
                                 &default_bldr_url(),
                                 &ChannelIdent::stable(),
-                                &(ident.clone(), *PackageTarget::active_target()).into(),
+                                &(ident.clone(), PackageTarget::active_target()).into(),
                                 &*PROGRAM_NAME,
                                 VERSION,
                                 FS_ROOT_PATH.as_path(),

--- a/components/hab/src/command/launcher.rs
+++ b/components/hab/src/command/launcher.rs
@@ -18,7 +18,7 @@ use crate::common::ui::UI;
 
 use crate::error::Result;
 
-pub fn start(ui: &mut UI, args: Vec<OsString>) -> Result<()> { inner::start(ui, args) }
+pub fn start(ui: &mut UI, args: &[OsString]) -> Result<()> { inner::start(ui, args) }
 
 #[cfg(not(target_os = "macos"))]
 mod inner {
@@ -46,7 +46,7 @@ mod inner {
     const LAUNCH_CMD_ENVVAR: &str = "HAB_LAUNCH_BINARY";
     const LAUNCH_PKG_IDENT: &str = "core/hab-launcher";
 
-    pub fn start(ui: &mut UI, args: Vec<OsString>) -> Result<()> {
+    pub fn start(ui: &mut UI, args: &[OsString]) -> Result<()> {
         init();
         if henv::var(SUP_CMD_ENVVAR).is_err() {
             let version: Vec<&str> = VERSION.split('/').collect();
@@ -89,7 +89,7 @@ mod inner {
     use crate::error::{Error,
                        Result};
 
-    pub fn start(ui: &mut UI, _args: Vec<OsString>) -> Result<()> {
+    pub fn start(ui: &mut UI, _args: &[OsString]) -> Result<()> {
         let subcmd = env::args().nth(1).unwrap_or("<unknown>".to_string());
         ui.warn("Launching a native Supervisor on this operating system is not yet supported. \
                  Try running this command again on 64-bit Linux or Windows.")?;

--- a/components/hab/src/command/origin/key/export.rs
+++ b/components/hab/src/command/origin/key/export.rs
@@ -21,7 +21,6 @@ use crate::hcore::crypto::{keys::PairType,
 
 use crate::error::Result;
 
-#[warn(clippy::needless_pass_by_value)] // Remove after making `PairType` Copy
 pub fn start(origin: &str, pair_type: PairType, cache: &Path) -> Result<()> {
     let latest = SigKeyPair::get_latest_pair_for(origin, cache, Some(&pair_type))?;
     let path = match pair_type {

--- a/components/hab/src/command/pkg/binlink.rs
+++ b/components/hab/src/command/pkg/binlink.rs
@@ -455,7 +455,7 @@ mod test {
         }
         let prefix = hcore::fs::pkg_install_path(&ident, Some(rootfs));
         write_file(prefix.join("IDENT"), &ident.to_string());
-        write_file(prefix.join("TARGET"), PackageTarget::active_target());
+        write_file(prefix.join("TARGET"), &PackageTarget::active_target());
         let mut paths = Vec::new();
         for (path, bins) in binaries {
             let abspath = hcore::fs::pkg_install_path(&ident, None::<&Path>).join(path);

--- a/components/hab/src/command/pkg/build.rs
+++ b/components/hab/src/command/pkg/build.rs
@@ -52,5 +52,5 @@ pub fn start(ui: &mut UI,
     if studio::native_studio_support() && docker {
         args.push("-D".into());
     }
-    studio::enter::start(ui, args)
+    studio::enter::start(ui, &args)
 }

--- a/components/hab/src/command/pkg/exec.rs
+++ b/components/hab/src/command/pkg/exec.rs
@@ -25,7 +25,7 @@ use crate::hcore::{fs::{find_command,
 use crate::error::{Error,
                    Result};
 
-pub fn start<T>(ident: &PackageIdent, command: T, args: Vec<OsString>) -> Result<()>
+pub fn start<T>(ident: &PackageIdent, command: T, args: &[OsString]) -> Result<()>
     where T: Into<PathBuf>
 {
     let command = command.into();
@@ -41,7 +41,7 @@ pub fn start<T>(ident: &PackageIdent, command: T, args: Vec<OsString>) -> Result
         None => return Err(Error::ExecCommandNotFound(command)),
     };
     let mut display_args = command.to_string_lossy().into_owned();
-    for arg in &args {
+    for arg in args {
         display_args.push(' ');
         display_args.push_str(arg.to_string_lossy().as_ref());
     }

--- a/components/hab/src/command/pkg/export/cf.rs
+++ b/components/hab/src/command/pkg/export/cf.rs
@@ -23,7 +23,7 @@ const EXPORT_CMD_ENVVAR: &str = "HAB_PKG_CFIZE_BINARY";
 const EXPORT_PKG_IDENT: &str = "core/hab-pkg-cfize";
 const EXPORT_PKG_IDENT_ENVVAR: &str = "HAB_PKG_CFIZE_PKG_IDENT";
 
-pub fn start(ui: &mut UI, args: Vec<OsString>) -> Result<()> {
+pub fn start(ui: &mut UI, args: &[OsString]) -> Result<()> {
     crate::command::pkg::export::export_common::start(ui,
                                                       args,
                                                       EXPORT_CMD,

--- a/components/hab/src/command/pkg/export/docker.rs
+++ b/components/hab/src/command/pkg/export/docker.rs
@@ -23,7 +23,7 @@ const EXPORT_CMD_ENVVAR: &str = "HAB_PKG_EXPORT_DOCKER_BINARY";
 const EXPORT_PKG_IDENT: &str = "core/hab-pkg-export-docker";
 const EXPORT_PKG_IDENT_ENVVAR: &str = "HAB_PKG_EXPORT_DOCKER_PKG_IDENT";
 
-pub fn start(ui: &mut UI, args: Vec<OsString>) -> Result<()> {
+pub fn start(ui: &mut UI, args: &[OsString]) -> Result<()> {
     crate::command::pkg::export::export_common::start(ui,
                                                       args,
                                                       EXPORT_CMD,

--- a/components/hab/src/command/pkg/export/export_common.rs
+++ b/components/hab/src/command/pkg/export/export_common.rs
@@ -19,7 +19,7 @@ use crate::common::ui::UI;
 use crate::error::Result;
 
 pub fn start(ui: &mut UI,
-             args: Vec<OsString>,
+             args: &[OsString],
              export_cmd: &str,
              export_cmd_envvar: &str,
              export_pkg_ident: &str,
@@ -53,7 +53,7 @@ mod inner {
                 VERSION};
 
     pub fn start(ui: &mut UI,
-                 args: Vec<OsString>,
+                 args: &[OsString],
                  export_cmd: &str,
                  export_cmd_envvar: &str,
                  export_pkg_ident: &str,
@@ -97,7 +97,7 @@ mod inner {
                        Result};
 
     pub fn start(ui: &mut UI,
-                 _args: Vec<OsString>,
+                 _args: &[OsString],
                  export_cmd: &str,
                  _export_cmd_envvar: &str,
                  _export_pkg_ident: &str,

--- a/components/hab/src/command/pkg/export/helm.rs
+++ b/components/hab/src/command/pkg/export/helm.rs
@@ -23,7 +23,7 @@ const EXPORT_CMD_ENVVAR: &str = "HAB_PKG_EXPORT_HELM_BINARY";
 const EXPORT_PKG_IDENT: &str = "core/hab-pkg-export-helm";
 const EXPORT_PKG_IDENT_ENVVAR: &str = "HAB_PKG_EXPORT_HELM_PKG_IDENT";
 
-pub fn start(ui: &mut UI, args: Vec<OsString>) -> Result<()> {
+pub fn start(ui: &mut UI, args: &[OsString]) -> Result<()> {
     crate::command::pkg::export::export_common::start(ui,
                                                       args,
                                                       EXPORT_CMD,

--- a/components/hab/src/command/pkg/export/kubernetes.rs
+++ b/components/hab/src/command/pkg/export/kubernetes.rs
@@ -23,7 +23,7 @@ const EXPORT_CMD_ENVVAR: &str = "HAB_PKG_EXPORT_KUBERNETES_BINARY";
 const EXPORT_PKG_IDENT: &str = "core/hab-pkg-export-kubernetes";
 const EXPORT_PKG_IDENT_ENVVAR: &str = "HAB_PKG_EXPORT_KUBERNETES_PKG_IDENT";
 
-pub fn start(ui: &mut UI, args: Vec<OsString>) -> Result<()> {
+pub fn start(ui: &mut UI, args: &[OsString]) -> Result<()> {
     crate::command::pkg::export::export_common::start(ui,
                                                       args,
                                                       EXPORT_CMD,

--- a/components/hab/src/command/pkg/export/mod.rs
+++ b/components/hab/src/command/pkg/export/mod.rs
@@ -115,7 +115,7 @@ mod inner {
             // dependent programs such as `docker` on `$PATH`. This is not ideal and we should be
             // using `hcore::os::process::become_command` but for the moment we'll continue to use
             // the behavior of the `pkg exec` subcommand.
-            command::pkg::exec::start(format.pkg_ident(), cmd, vec![pkg_arg])
+            command::pkg::exec::start(format.pkg_ident(), cmd, &[pkg_arg])
         } else {
             Err(Error::ExecCommandNotFound(command))
         }

--- a/components/hab/src/command/pkg/export/tar.rs
+++ b/components/hab/src/command/pkg/export/tar.rs
@@ -20,7 +20,7 @@ use crate::error::Result;
 
 const EXPORT_CMD: &str = "hab-pkg-export-tar";
 
-pub fn start(ui: &mut UI, args: Vec<OsString>) -> Result<()> { inner::start(ui, args) }
+pub fn start(ui: &mut UI, args: &[OsString]) -> Result<()> { inner::start(ui, args) }
 
 #[cfg(not(target_os = "macos"))]
 mod inner {
@@ -46,7 +46,7 @@ mod inner {
     const EXPORT_PKG_IDENT: &str = "core/hab-pkg-export-tar";
     const EXPORT_PKG_IDENT_ENVVAR: &str = "HAB_PKG_EXPORT_TAR_PKG_IDENT";
 
-    pub fn start(ui: &mut UI, args: Vec<OsString>) -> Result<()> {
+    pub fn start(ui: &mut UI, args: &[OsString]) -> Result<()> {
         let command = match henv::var(EXPORT_CMD_ENVVAR) {
             Ok(command) => PathBuf::from(command),
             Err(_) => {
@@ -85,7 +85,7 @@ mod inner {
     use crate::error::{Error,
                        Result};
 
-    pub fn start(ui: &mut UI, _args: Vec<OsString>) -> Result<()> {
+    pub fn start(ui: &mut UI, _args: &[OsString]) -> Result<()> {
         let cmd = EXPORT_CMD.replace("hab", "").replace("-", " ");
         ui.warn(format!("Running 'hab {}' on this operating system is not yet supported. Try \
                          running this command again on 64-bit Linux.",

--- a/components/hab/src/command/pkg/upload.rs
+++ b/components/hab/src/command/pkg/upload.rs
@@ -223,7 +223,7 @@ fn attempt_upload_dep<T>(ui: &mut UI,
                          -> Result<()>
     where T: AsRef<Path>
 {
-    let candidate_path = archives_dir.join(ident.archive_name_with_target(&target).unwrap());
+    let candidate_path = archives_dir.join(ident.archive_name_with_target(target).unwrap());
 
     if candidate_path.is_file() {
         let mut archive = PackageArchive::new(candidate_path);
@@ -236,7 +236,7 @@ fn attempt_upload_dep<T>(ui: &mut UI,
                           false,
                           &mut archive)
     } else {
-        let archive_name = ident.archive_name_with_target(&target).unwrap();
+        let archive_name = ident.archive_name_with_target(target).unwrap();
 
         ui.status(Status::Missing,
                   format!("artifact {}. It was not found in {}. Please make sure that all the \

--- a/components/hab/src/command/studio/docker.rs
+++ b/components/hab/src/command/studio/docker.rs
@@ -44,7 +44,8 @@ const DOCKER_OPTS_ENVVAR: &str = "HAB_DOCKER_OPTS";
 const DOCKER_SOCKET: &str = "/var/run/docker.sock";
 const HAB_STUDIO_SECRET: &str = "HAB_STUDIO_SECRET_";
 
-pub fn start_docker_studio(_ui: &mut UI, mut args: Vec<OsString>) -> Result<()> {
+pub fn start_docker_studio(_ui: &mut UI, args: &[OsString]) -> Result<()> {
+    let mut args = args.to_vec();
     if args.get(0) == Some(&OsString::from("rm")) {
         return Err(Error::CannotRemoveDockerStudio);
     }
@@ -292,7 +293,7 @@ fn run_container<I, J, S, T>(docker_cmd: PathBuf,
     }
 
     unset_proxy_env_vars();
-    process::become_command(docker_cmd, cmd_args)?;
+    process::become_command(docker_cmd, &cmd_args)?;
     Ok(())
 }
 
@@ -307,7 +308,7 @@ fn unset_proxy_env_vars() {
 
 fn image_identifier_for_active_target(docker_cmd: &Path) -> String {
     image_identifier(is_serving_windows_containers(docker_cmd),
-                     *target::PackageTarget::active_target())
+                     target::PackageTarget::active_target())
 }
 
 /// Returns the Docker Studio image with tag for the desired version which corresponds to the

--- a/components/hab/src/command/studio/enter.rs
+++ b/components/hab/src/command/studio/enter.rs
@@ -142,7 +142,7 @@ mod inner {
     fn rerun_with_sudo_if_needed(ui: &mut UI, args: &[OsString]) -> Result<()> {
         // If I have root permissions or if I am executing a docker studio
         // and have the appropriate group - early return, we are done.
-        if am_i_root() || (is_docker_studio(&args) && has_docker_group()) {
+        if am_i_root() || (is_docker_studio(args) && has_docker_group()) {
             return Ok(());
         }
 

--- a/components/hab/src/command/studio/enter.rs
+++ b/components/hab/src/command/studio/enter.rs
@@ -32,7 +32,7 @@ const STUDIO_CMD: &str = "hab-studio";
 const STUDIO_CMD_ENVVAR: &str = "HAB_STUDIO_BINARY";
 const STUDIO_PACKAGE_IDENT: &str = "core/hab-studio";
 
-pub fn start(ui: &mut UI, args: Vec<OsString>) -> Result<()> {
+pub fn start(ui: &mut UI, args: &[OsString]) -> Result<()> {
     if henv::var(ORIGIN_ENVVAR).is_err() {
         let config = config::load()?;
         if let Some(default_origin) = config.origin {
@@ -88,7 +88,7 @@ mod inner {
 
     const SUDO_CMD: &str = "sudo";
 
-    pub fn start(ui: &mut UI, args: Vec<OsString>) -> Result<()> {
+    pub fn start(ui: &mut UI, args: &[OsString]) -> Result<()> {
         rerun_with_sudo_if_needed(ui, &args)?;
         if is_docker_studio(&args) {
             docker::start_docker_studio(ui, args)
@@ -153,7 +153,7 @@ mod inner {
                                                    "[sudo hab-studio] password for %u: ".into(),
                                                    "-E".into(),];
                 args.append(&mut env::args_os().collect());
-                process::become_command(sudo_prog, args)?;
+                process::become_command(sudo_prog, &args)?;
                 Ok(())
             }
             None => {
@@ -187,7 +187,7 @@ mod inner {
               path::PathBuf,
               str::FromStr};
 
-    pub fn start(_ui: &mut UI, args: Vec<OsString>) -> Result<()> {
+    pub fn start(_ui: &mut UI, args: &[OsString]) -> Result<()> {
         if is_windows_studio(&args) {
             start_windows_studio(_ui, args)
         } else {
@@ -195,7 +195,7 @@ mod inner {
         }
     }
 
-    pub fn start_windows_studio(ui: &mut UI, args: Vec<OsString>) -> Result<()> {
+    pub fn start_windows_studio(ui: &mut UI, args: &[OsString]) -> Result<()> {
         let command = match henv::var(super::STUDIO_CMD_ENVVAR) {
             Ok(command) => PathBuf::from(command),
             Err(_) => {
@@ -220,7 +220,7 @@ mod inner {
         Ok(())
     }
 
-    fn is_windows_studio(args: &Vec<OsString>) -> bool {
+    fn is_windows_studio(args: &[OsString]) -> bool {
         if cfg!(not(target_os = "windows")) {
             return false;
         }

--- a/components/hab/src/command/sup.rs
+++ b/components/hab/src/command/sup.rs
@@ -22,7 +22,7 @@ pub const SUP_CMD: &str = "hab-sup";
 pub const SUP_CMD_ENVVAR: &str = "HAB_SUP_BINARY";
 pub const SUP_PKG_IDENT: &str = "core/hab-sup";
 
-pub fn start(ui: &mut UI, args: Vec<OsString>) -> Result<()> { inner::start(ui, args) }
+pub fn start(ui: &mut UI, args: &[OsString]) -> Result<()> { inner::start(ui, args) }
 
 #[cfg(not(target_os = "macos"))]
 mod inner {
@@ -46,7 +46,7 @@ mod inner {
                 exec,
                 VERSION};
 
-    pub fn start(ui: &mut UI, args: Vec<OsString>) -> Result<()> {
+    pub fn start(ui: &mut UI, args: &[OsString]) -> Result<()> {
         let command = match henv::var(SUP_CMD_ENVVAR) {
             Ok(command) => PathBuf::from(command),
             Err(_) => {
@@ -81,7 +81,7 @@ mod inner {
     use crate::error::{Error,
                        Result};
 
-    pub fn start(ui: &mut UI, _args: Vec<OsString>) -> Result<()> {
+    pub fn start(ui: &mut UI, _args: &[OsString]) -> Result<()> {
         let subcmd = env::args().nth(1).unwrap_or("<unknown>".to_string());
         ui.warn("Launching a native Supervisor on this operating system is not yet supported. \
                  Try running this command again on 64-bit Linux or Windows.")?;

--- a/components/hab/src/exec.rs
+++ b/components/hab/src/exec.rs
@@ -101,8 +101,8 @@ pub fn command_from_min_pkg<T>(ui: &mut UI,
                                                      &default_bldr_url(),
                                                      &internal_tooling_channel(),
                                                      &(ident.clone(),
-                                                       *PackageTarget::active_target())
-                                                                                       .into(),
+                                                       PackageTarget::active_target())
+                                                                                      .into(),
                                                      PRODUCT,
                                                      VERSION,
                                                      fs_root_path,

--- a/components/pkg-export-docker/src/build.rs
+++ b/components/pkg-export-docker/src/build.rs
@@ -821,7 +821,7 @@ mod test {
             }
             let prefix = hcore::fs::pkg_install_path(&ident, Some(self.rootfs.as_path()));
             util::write_file(prefix.join("IDENT"), &ident.to_string()).unwrap();
-            util::write_file(prefix.join("TARGET"), PackageTarget::active_target()).unwrap();
+            util::write_file(prefix.join("TARGET"), &PackageTarget::active_target()).unwrap();
 
             util::write_file(prefix.join("SVC_USER"), &self.svc_user).unwrap();
             util::write_file(prefix.join("SVC_GROUP"), &self.svc_group).unwrap();

--- a/components/sup/src/manager/commands.rs
+++ b/components/sup/src/manager/commands.rs
@@ -213,7 +213,7 @@ pub fn service_load(mgr: &ManagerState,
                            .map(ChannelIdent::from)
                            .unwrap_or_default();
     let force = opts.force.unwrap_or(false);
-    let source = InstallSource::Ident(ident.clone(), *PackageTarget::active_target());
+    let source = InstallSource::Ident(ident.clone(), PackageTarget::active_target());
     match spec_for_ident(&mgr.cfg, source.as_ref()) {
         None => {
             let mut spec = ServiceSpec::default();

--- a/components/sup/src/manager/service_updater.rs
+++ b/components/sup/src/manager/service_updater.rs
@@ -472,7 +472,7 @@ impl Worker {
         // Fairly certain that this only gets called in a rolling update
         // scenario, where `ident` is always a fully-qualified identifier
         outputln!("Updating from {} to {}", self.current, ident);
-        let install_source = (ident, *PackageTarget::active_target()).into();
+        let install_source = (ident, PackageTarget::active_target()).into();
         let mut next_time = SteadyTime::now();
 
         loop {
@@ -513,7 +513,7 @@ impl Worker {
     /// Continually poll for a new version of a package, installing it
     /// when found.
     fn run_poll(&mut self, sender: &Sender<PackageInstall>, kill_rx: &Receiver<()>) {
-        let install_source = (self.spec_ident.clone(), *PackageTarget::active_target()).into();
+        let install_source = (self.spec_ident.clone(), PackageTarget::active_target()).into();
         let mut next_time = SteadyTime::now();
 
         loop {


### PR DESCRIPTION
Fixing the clippy lints in `core` requires some downstream changes to consumer code.

Now that https://github.com/habitat-sh/core/pull/135 has merged, these fixes need to merge along with the `cargo update` that pulls in the new `core` code.