### PR TITLE
implement platform specific UI symbols

### DIFF
--- a/components/common/src/error.rs
+++ b/components/common/src/error.rs
@@ -35,6 +35,7 @@ pub enum Error {
     ArtifactIdentMismatch((String, String, String)),
     /// Occurs when there is no valid toml of json in the environment variable
     BadEnvConfig(String),
+    BadGlyphStyle(String),
     CantUploadGossipToml,
     ChannelNotFound,
     CryptoKeyError(String),
@@ -95,6 +96,7 @@ impl fmt::Display for Error {
             Error::BadEnvConfig(ref varname) => {
                 format!("Unable to find valid TOML or JSON in {} ENVVAR", varname)
             }
+            Error::BadGlyphStyle(ref style) => format!("Unknown symbol style '{}'", style),
             Error::CantUploadGossipToml => {
                 "Can't upload gossip.toml, it's a reserved file name".to_string()
             }
@@ -162,6 +164,7 @@ impl error::Error for Error {
             Error::APIClient(ref err) => err.description(),
             Error::ArtifactIdentMismatch((..)) => "Artifact ident does not match expected ident",
             Error::BadEnvConfig(_) => "Unknown syntax in Env Configuration",
+            Error::BadGlyphStyle(_) => "Unknown symbol style",
             Error::CantUploadGossipToml => "Can't upload gossip.toml, it's a reserved filename",
             Error::ChannelNotFound => "Channel not found",
             Error::CryptoKeyError(_) => "Missing or invalid key",

--- a/components/pkg-export-docker/src/build.rs
+++ b/components/pkg-export-docker/src/build.rs
@@ -291,9 +291,10 @@ impl<'a> BuildSpec<'a> {
         where P: AsRef<Path>
     {
         use crate::chmod;
+        use habitat_common::ui::Glyph;
 
         let target = rootfs.as_ref().join("hab");
-        ui.status(Status::Custom('✓', "Changing permissions on".into()),
+        ui.status(Status::Custom(Glyph::CheckMark, "Changing permissions on".into()),
                   format!("{:?}", target))?;
         chmod::recursive_g_equal_u(target)
     }

--- a/components/pkg-export-kubernetes/src/lib.rs
+++ b/components/pkg-export-kubernetes/src/lib.rs
@@ -28,7 +28,8 @@ use std::{fs::File,
           io::{self,
                prelude::*}};
 
-use crate::common::ui::{Status,
+use crate::common::ui::{Glyph,
+                        Status,
                         UIWriter,
                         UI};
 
@@ -60,7 +61,7 @@ pub fn export_for_cli_matches(ui: &mut UI, matches: &clap::ArgMatches<'_>) -> Re
     let image = if !matches.is_present("NO_DOCKER_IMAGE") {
         export_docker::export_for_cli_matches(ui, &matches)?
     } else {
-        ui.status(Status::Custom('☛', String::from("Skipping")),
+        ui.status(Status::Custom(Glyph::FingerPoint, String::from("Skipping")),
                   "Docker image generation")?;
         None
     };
@@ -76,7 +77,7 @@ pub fn export_for_cli_matches(ui: &mut UI, matches: &clap::ArgMatches<'_>) -> Re
         }
         _ => {
             let stdout = Box::new(io::stdout());
-            ui.status(Status::Custom('→', String::from("Writing")),
+            ui.status(Status::Custom(Glyph::RightArrow, String::from("Writing")),
                       "Kubernetes manifest to stdout")?;
 
             stdout

--- a/components/studio/bin/hab-studio.ps1
+++ b/components/studio/bin/hab-studio.ps1
@@ -290,6 +290,13 @@ function Enter-Studio {
     mkdir $HAB_STUDIO_ROOT | Out-Null
   }
   $env:HAB_STUDIO_ENTER_ROOT = Resolve-Path $HAB_STUDIO_ROOT
+  if (Test-InContainer) {
+    # The Windows Docker TTY does not render non standard
+    # characters. Each is rendered as a '?'. So we are going
+    # to just render standard ascii symbols. No pretty clouds
+    # or check marks.
+    $env:HAB_GLYPH_STYLE="ascii"
+  }
   New-Studio
   Write-HabInfo "Entering Studio at $HAB_STUDIO_ROOT"
   $env:STUDIO_SCRIPT_ROOT = $PSScriptRoot
@@ -348,6 +355,9 @@ function Enter-Studio {
     } else {
       $habSvc = Get-Service Habitat -ErrorAction SilentlyContinue
       if(!$habSvc -or ($habSvc.Status -eq "Stopped")) {
+        # Set console encoding to UTF-8 so that any redirected glyphs
+        # from the supervisor log are propperly encoded
+        [System.Console]::OutputEncoding = [System.Text.Encoding]::UTF8
         $pr = New-Object System.Diagnostics.Process
         $pr.StartInfo.UseShellExecute = $false
         $pr.StartInfo.CreateNoWindow = $true
@@ -356,10 +366,10 @@ function Enter-Studio {
         $pr.StartInfo.FileName = "hab.exe"
         $pr.StartInfo.Arguments = "sup run"
         Register-ObjectEvent -InputObject $pr -EventName OutputDataReceived -action {
-          $Event.SourceEventArgs.Data | Out-File $env:HAB_STUDIO_ENTER_ROOT\hab\sup\default\out.log -Append -Encoding ascii
+          $Event.SourceEventArgs.Data | Out-File $env:HAB_STUDIO_ENTER_ROOT\hab\sup\default\out.log -Append
         } | Out-Null
         Register-ObjectEvent -InputObject $pr -EventName ErrorDataReceived -action {
-          $Event.SourceEventArgs.Data | Out-File $env:HAB_STUDIO_ENTER_ROOT\hab\sup\default\out.log -Append -Encoding ascii
+          $Event.SourceEventArgs.Data | Out-File $env:HAB_STUDIO_ENTER_ROOT\hab\sup\default\out.log -Append
         } | Out-Null
         $pr.start() | Out-Null
         $pr.BeginErrorReadLine()

--- a/components/windows-service/HabService.cs
+++ b/components/windows-service/HabService.cs
@@ -75,6 +75,13 @@ namespace HabService
             {
                 ConfigureDebug();
                 ConfigureSupSignal();
+
+                // DataReceivedEventArgs.Data will return text in the default system
+                // locale. We can change that via System.Console.OutputEncoding for a console
+                // but not here because there is no actual console. To prevent a larger refactor
+                // and research excercise, we will just emit our glyphs in ascii.
+                Environment.SetEnvironmentVariable("HAB_GLYPH_STYLE", "ascii");
+                
                 proc = new Process();
                 proc.StartInfo.UseShellExecute = false;
                 proc.StartInfo.CreateNoWindow = true;

--- a/www/source/partials/docs/_reference-environment-vars.html.md.erb
+++ b/www/source/partials/docs/_reference-environment-vars.html.md.erb
@@ -28,6 +28,7 @@ This is a list of all environment variables that can be used to modify the opera
 | `HAB_STUDIO_ROOT` | build system | no default | Root of the current Studio under `$HAB_STUDIOS_HOME`. Infrequently overridden. |
 | `HAB_STUDIO_NOSTUDIORC` | build system | no default | When set to a non-empty value, a `.studiorc` will not be sourced when entering an interactive Studio via `hab studio enter`. |
 | `HAB_STUDIO_SUP` | build system | no default | Used to customize the arguments passed to an automatically launched Supervisor, or to disable the automatic launching by setting it to `false`, `no`, or `0`. |
+| `HAB_GLYPH_STYLE` | build system | `full` (`limited` on Windows) | Used to customize the rendering of unicode glyphs in UI messages. Valid values are `full`, `limited`, or `ascii`. |
 | `HAB_UPDATE_STRATEGY_FREQUENCY_MS` | Supervisor | 60000 | Frequency of milliseconds to check for updates when running with an [update strategy](/docs/using-habitat#using-updates) |
 | `HAB_USER` | Supervisor | no default | User key to use when running with [service group encryption](/docs/using-habitat#using-encryption) |
 | `http_proxy` | build system, Supervisor | no default | A URL for a local HTTP proxy server optionally supporting basic authentication |


### PR DESCRIPTION
Our symbols in the UI module like `☁` and `☑` do not render in most Windows use cases. They should render fine in a console like ConEmu or cygwin but not in a standard Windows console (`cmd.exe` or `powershell.exe`). They also do not render in a Docker TTY (which is what a Docker studio uses) even if inside of a "friendly" console like ConEmu.

The standard Windows consoles can only render a subset of our symbols depending on the font that the console is set to. More modern console's have the concept of a fallback font so that they can find a font that supports a unicode character even if the primary font has no representation of the character to be rendered. It is possible to install a font on Windows that provides characters for all the symbols we use, but we do not want to be in the business of distributing fonts. So instead we will support multiple `UISymbolStyle`s: `full`, `limited` and `ascii`.

By default on non-Windows systems, `full` will be the default and it provides all the symbols we currently use today. On Windows, `limited` is the default which supports most of these symbols and substitutes others for the few that the default console fonts do not support.

The Docker TTY uses an ANSI code parser that filters out any non standard ascii character and replaces them with `?`. Thus, an `ascii` style will only render standard ascii characters instead of unicode glyphs. This style will be used in the Docker Windows studio.

The `UISymbolStyle` can be set via the `HAB_SYMBOL_STYLE` environment variable.

We also no longer force `ascii` encoding when redirecting the supervisor log in a local windows studio. This used to be necessary in beta versions of Powershell code but now Powershell uses a bomless UTF-8 default encoder and this will not strip out our symbols.

When running headless in a Windows service, we will always set the style to `ascii` because output is redirected through the default system locale which will distort the glyph encoding.

Finally, this PR also abstracts the colors to a `UIColor` enum as requested in the review of https://github.com/habitat-sh/habitat/pull/6256. This will allow us to more easily adjust colors used based on platform or user preference.

Signed-off-by: mwrock <matt@mattwrock.com>