### PR TITLE
macOS still needs --interactive and --tty set

### DIFF
--- a/components/hab/src/command/studio/enter.rs
+++ b/components/hab/src/command/studio/enter.rs
@@ -66,13 +66,12 @@ pub fn start(ui: &mut UI, args: Vec<OsString>) -> Result<()> {
 
 #[cfg(target_os = "linux")]
 mod inner {
-    use std::{env,
-              ffi::OsString,
-              path::PathBuf,
-              str::FromStr};
-
-    use crate::{common::ui::{UIWriter,
+    use crate::{command::studio::docker,
+                common::ui::{UIWriter,
                              UI},
+                error::{Error,
+                        Result},
+                exec,
                 hcore::{crypto::{default_cache_key_path,
                                  init},
                         env as henv,
@@ -80,14 +79,12 @@ mod inner {
                              find_command},
                         os::process,
                         package::PackageIdent,
-                        users::linux as group}};
-
-    use crate::{error::{Error,
-                        Result},
-                exec,
+                        users::linux as group},
                 VERSION};
-
-    use crate::command::studio::docker;
+    use std::{env,
+              ffi::OsString,
+              path::PathBuf,
+              str::FromStr};
 
     const SUDO_CMD: &str = "sudo";
 
@@ -174,23 +171,21 @@ mod inner {
 
 #[cfg(not(target_os = "linux"))]
 mod inner {
-    use std::{ffi::OsString,
-              path::PathBuf,
-              str::FromStr};
-
-    use crate::{common::ui::UI,
+    use crate::{command::studio::docker,
+                common::ui::UI,
+                error::{Error,
+                        Result},
+                exec,
                 hcore::{crypto::{default_cache_key_path,
                                  init},
                         env as henv,
                         fs::find_command,
                         os::process,
-                        package::PackageIdent}};
-
-    use crate::{command::studio::docker,
-                error::{Error,
-                        Result},
-                exec,
+                        package::PackageIdent},
                 VERSION};
+    use std::{ffi::OsString,
+              path::PathBuf,
+              str::FromStr};
 
     pub fn start(_ui: &mut UI, args: Vec<OsString>) -> Result<()> {
         if is_windows_studio(&args) {

--- a/components/studio/bin/hab-studio.sh
+++ b/components/studio/bin/hab-studio.sh
@@ -86,6 +86,9 @@ COMMON FLAGS:
     -V  Prints version information
     -D  Use a Docker Studio instead of a chroot Studio
 
+    --no-tty           Disable the --tty default (Docker Studio only)
+    --non-interactive  Disable the --interactive default (Docker Studio only)
+
 COMMON OPTIONS:
     -a <ARTIFACT_PATH>    Sets the source artifact cache path (default: /hab/cache/artifacts)
     -k <HAB_ORIGIN_KEYS>  Installs secret origin keys (default:\$HAB_ORIGIN )
@@ -104,24 +107,24 @@ SUBCOMMANDS:
     version   Prints version information
 
 ENVIRONMENT VARIABLES:
-    ARTIFACT_PATH       Sets the source artifact cache path (\`-a' option overrides)
-    HAB_NOCOLORING      Disables text coloring mode despite TERM capabilities
-    HAB_NONINTERACTIVE  Disables interactive progress bars despite tty
-    HAB_ORIGIN          Propagates this variable into any studios
-    HAB_ORIGIN_KEYS     Installs secret keys (\`-k' option overrides)
-    HAB_STUDIOS_HOME    Sets a home path for all Studios (default: /hab/studios)
-    HAB_STUDIO_NOSTUDIORC Disables sourcing a \`.studiorc' in \`studio enter'
-    HAB_STUDIO_ROOT     Sets a Studio root (\`-r' option overrides)
-    HAB_STUDIO_SUP      Sets args for a Supervisor in \`studio enter'
-    NO_ARTIFACT_PATH    If set, do not mount the source artifact cache path (\`-N' flag overrides)
-    NO_SRC_PATH         If set, do not mount the source path (\`-n' flag overrides)
-    QUIET               Prints less output (\`-q' flag overrides)
-    SRC_PATH            Sets the source path (\`-s' option overrides)
-    STUDIO_TYPE         Sets a Studio type when creating (\`-t' option overrides)
-    VERBOSE             Prints more verbose output (\`-v' flag overrides)
-    http_proxy          Sets an http_proxy environment variable inside the Studio
-    https_proxy         Sets an https_proxy environment variable inside the Studio
-    no_proxy            Sets a no_proxy environment variable inside the Studio
+    ARTIFACT_PATH          Sets the source artifact cache path (\`-a' option overrides)
+    HAB_NOCOLORING         Disables text coloring mode despite TERM capabilities
+    HAB_NONINTERACTIVE     Disables interactive progress bars despite tty
+    HAB_ORIGIN             Propagates this variable into any studios
+    HAB_ORIGIN_KEYS        Installs secret keys (\`-k' option overrides)
+    HAB_STUDIOS_HOME       Sets a home path for all Studios (default: /hab/studios)
+    HAB_STUDIO_NOSTUDIORC  Disables sourcing a \`.studiorc' in \`studio enter'
+    HAB_STUDIO_ROOT        Sets a Studio root (\`-r' option overrides)
+    HAB_STUDIO_SUP         Sets args for a Supervisor in \`studio enter'
+    NO_ARTIFACT_PATH       If set, do not mount the source artifact cache path (\`-N' flag overrides)
+    NO_SRC_PATH            If set, do not mount the source path (\`-n' flag overrides)
+    QUIET                  Prints less output (\`-q' flag overrides)
+    SRC_PATH               Sets the source path (\`-s' option overrides)
+    STUDIO_TYPE            Sets a Studio type when creating (\`-t' option overrides)
+    VERBOSE                Prints more verbose output (\`-v' flag overrides)
+    http_proxy             Sets an http_proxy environment variable inside the Studio
+    https_proxy            Sets an https_proxy environment variable inside the Studio
+    no_proxy               Sets a no_proxy environment variable inside the Studio
 
 SUBCOMMAND HELP:
     $program <SUBCOMMAND> -h


### PR DESCRIPTION
It turns out that on macOS, `--interactive` and `--tty` weren't getting passed when doing a `hab studio run` or `hab studio build`, which meant that coloring was no longer active and you couldn't ctrl+c to kill the process.  This fixes that breakage, and adds some new lines so the code is easier to read.

![](https://media.giphy.com/media/yoJC2Olx0ekMy2nX7W/giphy.gif)

Fixes https://github.com/habitat-sh/habitat/issues/5661
Signed-off-by: Josh Black <raskchanky@gmail.com>