### PR TITLE
Use subshells and unset to actually unset environment variables

### DIFF
--- a/components/studio/libexec/hab-studio-type-bare.sh
+++ b/components/studio/libexec/hab-studio-type-bare.sh
@@ -114,10 +114,10 @@ EOT
   studio_env_command="$busybox_path/bin/env"
 }
 
-_hab() {
-  # shellcheck disable=2154
-  $bb env FS_ROOT="$HAB_STUDIO_ROOT" HAB_CACHE_KEY_PATH= "$hab" "$@"
-}
+_hab() (
+    unset HAB_CACHE_KEY_PATH
+    $bb env FS_ROOT="$HAB_STUDIO_ROOT" "$hab" "$@"
+)
 
 _pkgpath_for() {
   _hab pkg path "$1" | $bb sed -e "s,^$HAB_STUDIO_ROOT,,g"

--- a/components/studio/libexec/hab-studio-type-bare.sh
+++ b/components/studio/libexec/hab-studio-type-bare.sh
@@ -118,6 +118,7 @@ EOT
 # caller's environment.
 _hab() (
     unset HAB_CACHE_KEY_PATH
+    # shellcheck disable=2154
     $bb env FS_ROOT="$HAB_STUDIO_ROOT" "$hab" "$@"
 )
 

--- a/components/studio/libexec/hab-studio-type-bare.sh
+++ b/components/studio/libexec/hab-studio-type-bare.sh
@@ -114,6 +114,8 @@ EOT
   studio_env_command="$busybox_path/bin/env"
 }
 
+# Intentionally using a subshell here so `unset` doesn't affect the
+# caller's environment.
 _hab() (
     unset HAB_CACHE_KEY_PATH
     $bb env FS_ROOT="$HAB_STUDIO_ROOT" "$hab" "$@"

--- a/components/studio/libexec/hab-studio-type-baseimage.sh
+++ b/components/studio/libexec/hab-studio-type-baseimage.sh
@@ -141,10 +141,11 @@ EOT
   studio_env_command="$busybox_path/bin/env"
 }
 
-_hab() {
-  # shellcheck disable=2154
-  $bb env FS_ROOT="$HAB_STUDIO_ROOT" HAB_CACHE_KEY_PATH= "$hab" "$@"
-}
+
+_hab() (
+    unset HAB_CACHE_KEY_PATH
+    $bb env FS_ROOT="$HAB_STUDIO_ROOT" "$hab" "$@"
+)
 
 _pkgpath_for() {
   _hab pkg path "$1" | $bb sed -e "s,^$HAB_STUDIO_ROOT,,g"

--- a/components/studio/libexec/hab-studio-type-baseimage.sh
+++ b/components/studio/libexec/hab-studio-type-baseimage.sh
@@ -141,7 +141,8 @@ EOT
   studio_env_command="$busybox_path/bin/env"
 }
 
-
+# Intentionally using a subshell here so `unset` doesn't affect the
+# caller's environment.
 _hab() (
     unset HAB_CACHE_KEY_PATH
     $bb env FS_ROOT="$HAB_STUDIO_ROOT" "$hab" "$@"

--- a/components/studio/libexec/hab-studio-type-baseimage.sh
+++ b/components/studio/libexec/hab-studio-type-baseimage.sh
@@ -145,6 +145,7 @@ EOT
 # caller's environment.
 _hab() (
     unset HAB_CACHE_KEY_PATH
+    # shellcheck disable=2154
     $bb env FS_ROOT="$HAB_STUDIO_ROOT" "$hab" "$@"
 )
 

--- a/components/studio/libexec/hab-studio-type-default.sh
+++ b/components/studio/libexec/hab-studio-type-default.sh
@@ -232,6 +232,8 @@ PROFILE_ENTER
   studio_env_command="$coreutils_path/bin/env"
 }
 
+# Intentionally using a subshell here so `unset` doesn't affect the
+# caller's environment.
 _hab() (
     # We remove a couple of env vars we do not want for this instance of the studio
     unset HAB_CACHE_KEY_PATH

--- a/components/studio/libexec/hab-studio-type-default.sh
+++ b/components/studio/libexec/hab-studio-type-default.sh
@@ -232,10 +232,12 @@ PROFILE_ENTER
   studio_env_command="$coreutils_path/bin/env"
 }
 
-_hab() {
-  # We remove a couple of env vars we do not want for this instance of the studio
-  $bb env FS_ROOT="$HAB_STUDIO_ROOT" HAB_CACHE_KEY_PATH= HAB_BLDR_CHANNEL= "$hab" "$@"
-}
+_hab() (
+    # We remove a couple of env vars we do not want for this instance of the studio
+    unset HAB_CACHE_KEY_PATH
+    unset HAB_BLDR_CHANNEL
+    $bb env FS_ROOT="$HAB_STUDIO_ROOT" "$hab" "$@"
+)
 
 _pkgpath_for() {
   _hab pkg path "$1" | $bb sed -e "s,^$HAB_STUDIO_ROOT,,g"

--- a/components/studio/libexec/hab-studio-type-stage1.sh
+++ b/components/studio/libexec/hab-studio-type-stage1.sh
@@ -115,6 +115,8 @@ alias fgrep='fgrep --color=auto'
 PROFILE
 }
 
+# Intentionally using a subshell here so `unset` doesn't affect the
+# caller's environment.
 _hab() (
     unset HAB_CACHE_KEY_PATH
     $bb env FS_ROOT="$HAB_STUDIO_ROOT" "$hab" "$@"

--- a/components/studio/libexec/hab-studio-type-stage1.sh
+++ b/components/studio/libexec/hab-studio-type-stage1.sh
@@ -115,6 +115,7 @@ alias fgrep='fgrep --color=auto'
 PROFILE
 }
 
-_hab() {
-  $bb env FS_ROOT="$HAB_STUDIO_ROOT" HAB_CACHE_KEY_PATH= "$hab" "$@"
-}
+_hab() (
+    unset HAB_CACHE_KEY_PATH
+    $bb env FS_ROOT="$HAB_STUDIO_ROOT" "$hab" "$@"
+)


### PR DESCRIPTION
https://github.com/habitat-sh/habitat/pull/6278 made a change to
environment variable handling around the channel that `hab` uses to
install packages. As part of this, we no longer treated an empty
string as being synonymous with "unset".

This, in turn, revealed places in our shell code where the intention
was to unset environment variables, but in practice, they were set to
empty strings.

This PR changes our `_hab` wrapper function in our various studio
implementations to run in a subshell, using POSIX `unset` to remove
variables from the environment completely. Busybox's `env` also
supports the `-u` syntax, which we could have used, but we've opted to
keep with POSIX whenever possible.

Big thanks to @baumanj for this solution.

Signed-off-by: Christopher Maier <cmaier@chef.io>