### PR TITLE
Make Linux Kernel 2 validation just a little bit easier

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -137,6 +137,10 @@ When testing the linux studio, you will need to `export CI_OVERRIDE_CHANNEL` to 
 
 For this PackageTarget it is important that you perform validation on a Linux system running a 2.6 series kernel. CentOS 6 is recommended because it ships with a kernel of the appropriate age,  but any distro with a Kernel between 2.6.32 and 3.0.0 can be used. Included in the `support/validation/x86_64-linux-kernel2` directory in this repository is a Vagrantfile that will create a CentOS-6 VM to perform the validation. You can also run a VM in EC2.
 
+The Vagrantfile is configured to grab the [core-plans](https://github.com/habitat-sh/core-plans) repository (to give you something to build), as well as grab the secret key for your `HAB_ORIGIN` (using the `HAB_ORIGIN` and `HAB_AUTH_TOKEN` variables in your environment). You'll need to manually install the release-candidate `hab` binary and set your various channel overrides, but other than that you should have all you need to test things out.
+
+As an example, immediately after provisioning you can SSH into the machine and run `HAB_ORIGIN=<my_origin> hab pkg build core-plans/redis`.
+
 ### Addressing issues with a Release
 
 If you find issues when validating the release binaries that must be fixed before promoting the release, you will need to fix those issues and then have Buildkite and AppVeyor rerun the deployment. After you merge the necessary PRs to fix the release issues:

--- a/support/validation/x86_64-linux-kernel2/Vagrantfile
+++ b/support/validation/x86_64-linux-kernel2/Vagrantfile
@@ -9,6 +9,21 @@ Vagrant.configure("2") do |config|
   end
 
   config.vm.provision "shell", inline: <<-SHELL
-    yum install -y wget curl 
+    yum install -y wget curl git
+
+    # You'll need this for running most services
+    adduser hab
+
+    # You'll want this if you want to build a plan
+    git clone https://github.com/habitat-sh/core-plans.git
+
+    # You'll also want the keys for building for whatever origin you
+    # choose.
+    #
+    # It expects you to have HAB_ORIGIN and HAB_AUTH_TOKEN set in your
+    # environment when you provision the VM.
+    curl https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh -o install.sh
+    bash install.sh -t x86_64-linux-kernel2
+    sudo -u vagrant hab origin key download #{ENV['HAB_ORIGIN']} --secret --auth=#{ENV['HAB_AUTH_TOKEN']}
   SHELL
 end


### PR DESCRIPTION
To validate `x86_64-linux-kernel2` target releases, we need a Linux
system with an old enough kernel. We have a `Vagrantfile` that does a
basic setup of a CentOS 6 machine, but there are extra steps you need
to take to run services, build plans, and so on.

This PR adds a bit more automation to help with some of that. There
are still manual steps (namely, getting a release candidate `hab`
binary on the box), but this change makes things a lot easier.

The changes are:

* Add a `hab` user and group

  If you want to run a service to test things out, you're probably
  going to need to have those anyway.

* Check out the core-plans repository

  If you want to build a package, you're going to need some plans!

* Install secret keys

  When you want to build a package, you'll need signing keys. When
  provisioning the VM, we'll grab the secret key that corresponds to
  the values of `HAB_ORIGIN` and `HAB_AUTH_TOKEN` in your
  workstation's environment. When you build in the VM, just set
  `HAB_ORIGIN` in the environment of the `hab pkg build` call.

  To do this, we also install the current stable `hab` binary. When
  validating a release candidate, you'll still need to manually get
  _that_ binary on disk. Having the stable binary around helps make
  this a more self-contained system, and also makes this VM a bit more
  useful outside of pure release candidate validation purposes.

* Added some additional documentation around all this.

  Because who doesn't love documentation?

Signed-off-by: Christopher Maier <cmaier@chef.io>