### PR TITLE
turn off supervisor log coloring in local windows studio if ANSI is not supported

### DIFF
--- a/components/studio/bin/hab-studio.ps1
+++ b/components/studio/bin/hab-studio.ps1
@@ -364,7 +364,21 @@ function Enter-Studio {
         $pr.StartInfo.RedirectStandardOutput = $true
         $pr.StartInfo.RedirectStandardError = $true
         $pr.StartInfo.FileName = "hab.exe"
-        $pr.StartInfo.Arguments = "sup run"
+        
+        # We if the termcolor crate cannot find a console, which it will not
+        # since we launch the supervisor in the background, it will fall back
+        # to ANSI codes on Windows unless we explicitly turn off color. Lets
+        # do that if on a windows version that does not support ANSI codes in
+        # its console
+        $ansi_min_supported_version = [Version]::new(10, 0, 10586)
+        $osVersion = [Version]::new((Get-CimInstance -ClassName Win32_OperatingSystem).Version)
+        if ($osVersion -ge $ansi_min_supported_version) {
+          $pr.StartInfo.Arguments = "sup run"
+        } else {
+          $pr.StartInfo.Arguments = "sup run --no-color"
+          $pr.StartInfo.EnvironmentVariables["HAB_NOCOLORING"] = "1"
+        }
+
         Register-ObjectEvent -InputObject $pr -EventName OutputDataReceived -action {
           $Event.SourceEventArgs.Data | Out-File $env:HAB_STUDIO_ENTER_ROOT\hab\sup\default\out.log -Append
         } | Out-Null


### PR DESCRIPTION
On Windows versions prior to 10.0.10586(TH2), the standard windows console did not understand ANSI code sequences. While we have adopted the `termcolor` crate to use console APIs instead of ANSI sequences on Windows, `termcolor` will fall back to ansi if it cannot find a console. This will happen if habitat is running in a headless environment like a windows service or in a local studio where we launch it in the background.

We already specify `--no-color` as a default parameter in the `windows-service` but the local studio should turn off color if runing in a older version of windows like 2012R2 or even an earlier 2016 build.

This sniffs the OS version and adds `--no-color` and also sets `HAB_NOCOLORING` on non ANSI supporting versions:

BEFORE:
![image](https://user-images.githubusercontent.com/655165/54469274-2f201480-4753-11e9-940c-2c3aa57e06c5.png)

AFTER:
![image](https://user-images.githubusercontent.com/655165/54469228-99848500-4752-11e9-861b-8beabe635112.png)


Signed-off-by: mwrock <matt@mattwrock.com>