### PR TITLE
Ensure backline upload to acceptance can happen.

### DIFF
--- a/.buildkite/scripts/upload_backline_to_acceptance.sh
+++ b/.buildkite/scripts/upload_backline_to_acceptance.sh
@@ -6,8 +6,6 @@ source .buildkite/scripts/shared.sh
 
 set_hab_binary
 
-echo "--- :drum_with_drumsticks: Uploading hab-backline to acceptance" 
-
 acceptance_channel() {
   if is_fake_release; then
     get_release_channel
@@ -16,22 +14,16 @@ acceptance_channel() {
   fi
 }
 
-backline_ident="$(get_backline_ident "$BUILD_PKG_TARGET")"
-backline_artifact="$(get_backline_artifact "$BUILD_PKG_TARGET")"
+backline_ident="$(get_backline_ident "${BUILD_PKG_TARGET}")"
+backline_artifact="$(get_backline_artifact "${BUILD_PKG_TARGET}")"
 
 # Ensure we have the package in our local artifact cache
-"${hab_binary}" pkg install "$backline_ident"
+echo "--- :drum_with_drumsticks: Downloading ${backline_ident} locally"
+sudo "${hab_binary}" pkg install "${backline_ident}"
 
-# The above pkg install is executed in the context of the buildkite user
-# so the artifact (and public signing keys) will be cached in the users
-# home, rather than the system cache (/hab). If the below breaks with a:
-#
-# Invalid value for '<HART_FILE>...': File: 'XXXX.hart' cannot be found, 
-#
-# then it is likely that something has changed with how Hab caches files,
-# or the user this is executed as.
-"${hab_binary}" pkg upload \
+echo "--- :drum_with_drumsticks: Uploading ${backline_ident} to acceptance"
+sudo "${hab_binary}" pkg upload \
   --url https://bldr.acceptance.habitat.sh \
   --channel "$(acceptance_channel)" \
   --auth "${HAB_AUTH_TOKEN}" \
-  ~/.hab/cache/artifacts/"$backline_artifact"
+  /hab/cache/artifacts/"${backline_artifact}"


### PR DESCRIPTION
Recent changes to our release engineering infrastructure require
`sudo` for `hab` commands, so that was added here.

Additionally, some extra logging was added, along with some shell
formatting tweaks.

Signed-off-by: Christopher Maier <cmaier@chef.io>