### PR TITLE
eliminate false error noise from windows launcher

### DIFF
--- a/components/launcher/src/main.rs
+++ b/components/launcher/src/main.rs
@@ -17,7 +17,9 @@ use habitat_common::output::{self,
                              OutputFormat,
                              OutputVerbosity};
 use habitat_launcher::server;
-use log::error;
+use log::{error,
+          log,
+          Level};
 use std::{env,
           process};
 
@@ -33,7 +35,8 @@ fn main() {
             process::exit(1);
         }
         Ok(code) => {
-            error!("Launcher exiting with code {}", code);
+            let level = if code == 0 { Level::Info } else { Level::Error };
+            log!(level, "Launcher exiting with code {}", code);
             process::exit(code);
         }
     }

--- a/components/launcher/src/server/mod.rs
+++ b/components/launcher/src/server/mod.rs
@@ -91,6 +91,7 @@ pub struct Server {
 impl Drop for Server {
     fn drop(&mut self) {
         fs::remove_file(&self.pid_file_path).ok();
+        #[cfg(not(windows))]
         self.remove_pipe();
     }
 }
@@ -125,6 +126,7 @@ impl Server {
         Ok((ipc_channel, supervisor, pipe))
     }
 
+    #[cfg(not(windows))]
     fn remove_pipe(&self) {
         if fs::remove_file(&self.pipe).is_err() {
             error!("Could not remove old pipe to supervisor {}", self.pipe);
@@ -143,6 +145,7 @@ impl Server {
         self.supervisor = supervisor;
         // We're connecting to a new supervisor instance, so we need to remove
         // the socket files for the old pipe to avoid https://github.com/habitat-sh/habitat/issues/4673
+        #[cfg(not(windows))]
         self.remove_pipe();
         self.pipe = pipe;
         Ok(())


### PR DESCRIPTION
This fixes #6148. When the launcher terminates, it attempts to remove the IPC pipe files. This is absolutely the right thing to do on *nix but on Windows the file is not user deletable and is saved to the NPFS (Named Pipe File System). It is automatically deleted when all handles to the named pipe are freed. The ipc-channel crate wraps the named pipe in a `WinHandle` struct which calls `CloseHandle` on its handle in its `drop` implementation.

So the attempt to delete the named pipe file on windows results in an error that is sent to the supervisor output and can give the perception that bad things are happening at worst and is just noisy at best.

This pr will only remove the file on `unix` it also changes the `error!` log in the launcher's `main.rs` to an `info!` if the launcher server exits `0`.

Signed-off-by: mwrock <matt@mattwrock.com>