### PR TITLE
Remove usage of habitat_core::binlink::default_binlink_dir

### DIFF
--- a/components/common/src/cli_defaults.rs
+++ b/components/common/src/cli_defaults.rs
@@ -41,3 +41,13 @@ lazy_static! {
     pub static ref LISTEN_CTL_DEFAULT_ADDR_STRING: String =
         { ListenCtlAddr::default().to_string() };
 }
+
+pub const BINLINK_DIR_ENVVAR: &str = "HAB_BINLINK_DIR";
+
+/// Default Binlink Dir
+#[cfg(target_os = "windows")]
+pub const DEFAULT_BINLINK_DIR: &str = "/hab/bin";
+#[cfg(target_os = "linux")]
+pub const DEFAULT_BINLINK_DIR: &str = "/bin";
+#[cfg(target_os = "macos")]
+pub const DEFAULT_BINLINK_DIR: &str = "/usr/local/bin";

--- a/components/common/src/cli_defaults.rs
+++ b/components/common/src/cli_defaults.rs
@@ -18,6 +18,8 @@
 //! need a spot to consolidate those values and help simplify some of the logic around them.
 
 use crate::types::ListenCtlAddr;
+use habitat_core::env as henv;
+use std::path::PathBuf;
 
 pub const GOSSIP_DEFAULT_IP: &str = "0.0.0.0";
 pub const GOSSIP_DEFAULT_PORT: u16 = 9638;
@@ -37,9 +39,33 @@ lazy_static! {
 }
 pub const LISTEN_HTTP_ADDRESS_ENVVAR: &str = "HAB_LISTEN_HTTP";
 
+const SYSTEMDRIVE_ENVVAR: &str = "SYSTEMDRIVE";
+
 lazy_static! {
     pub static ref LISTEN_CTL_DEFAULT_ADDR_STRING: String =
         { ListenCtlAddr::default().to_string() };
+
+    /// The default filesystem root path to base all commands from. This is lazily generated on
+    /// first call and reflects on the presence and value of the environment variable keyed as
+    /// `FS_ROOT_ENVVAR`.
+    pub static ref FS_ROOT: PathBuf = {
+        use crate::hcore::fs::FS_ROOT_ENVVAR;
+
+        if cfg!(target_os = "windows") {
+            match (henv::var(FS_ROOT_ENVVAR), henv::var(SYSTEMDRIVE_ENVVAR)) {
+                (Ok(path), _) => PathBuf::from(path),
+                (Err(_), Ok(system_drive)) => PathBuf::from(format!("{}{}", system_drive, "\\")),
+                (Err(_), Err(_)) => unreachable!(
+                    "Windows should always have a SYSTEMDRIVE \
+                    environment variable."
+                ),
+            }
+        } else if let Ok(root) = henv::var(FS_ROOT_ENVVAR) {
+            PathBuf::from(root)
+        } else {
+            PathBuf::from("/")
+        }
+    };
 }
 
 pub const BINLINK_DIR_ENVVAR: &str = "HAB_BINLINK_DIR";

--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -17,7 +17,9 @@ use crate::{command::studio,
 use clap::{App,
            AppSettings,
            Arg};
-use habitat_common::{cli_defaults::{GOSSIP_DEFAULT_ADDR,
+use habitat_common::{cli_defaults::{BINLINK_DIR_ENVVAR,
+                                    DEFAULT_BINLINK_DIR,
+                                    GOSSIP_DEFAULT_ADDR,
                                     GOSSIP_LISTEN_ADDRESS_ENVVAR,
                                     LISTEN_CTL_DEFAULT_ADDR_STRING,
                                     LISTEN_HTTP_ADDRESS_ENVVAR,
@@ -369,8 +371,8 @@ pub fn get() -> App<'static, 'static> {
                     "A package identifier (ex: core/redis, core/busybox-static/1.42.2)")
                 (@arg BINARY: +takes_value
                     "The command to binlink (ex: bash)")
-                (@arg DEST_DIR: -d --dest +takes_value
-                    "Sets the destination directory (default: /bin)")
+                (@arg DEST_DIR: -d --dest +takes_value {non_empty} env(BINLINK_DIR_ENVVAR) default_value(DEFAULT_BINLINK_DIR)
+                    "Sets the destination directory")
                 (@arg FORCE: -f --force "Overwrite existing binlinks")
             )
             (@subcommand config =>
@@ -1236,6 +1238,15 @@ fn valid_origin(val: String) -> result::Result<(), String> {
         Err(format!("'{}' is not valid. A valid origin contains a-z, \
                      0-9, and _ or - after the first character",
                     &val))
+    }
+}
+
+#[allow(clippy::needless_pass_by_value)] // Signature required by CLAP
+fn non_empty(val: String) -> result::Result<(), String> {
+    if val.is_empty() {
+        Err("must not be empty".to_string())
+    } else {
+        Ok(())
     }
 }
 

--- a/components/hab/src/command/cli/setup.rs
+++ b/components/hab/src/command/cli/setup.rs
@@ -53,11 +53,7 @@ use crate::{analytics,
             CTL_SECRET_ENVVAR,
             ORIGIN_ENVVAR};
 
-pub fn start(ui: &mut UI,
-             cache_path: &Path,
-             analytics_path: &Path,
-             binlink_path: &Path)
-             -> Result<()> {
+pub fn start(ui: &mut UI, cache_path: &Path, analytics_path: &Path) -> Result<()> {
     let mut generated_origin = false;
 
     ui.br()?;
@@ -177,7 +173,8 @@ pub fn start(ui: &mut UI,
     } else {
         ui.para("Okay, maybe another time.")?;
     }
-    if cfg!(windows) {
+    #[cfg(windows)]
+    {
         ui.heading("Habitat Binlink Path")?;
         ui.para("The `hab` command-line tool can create binlinks for package binaries in the \
                  'PATH' when using the 'pkg binlink' or 'pkg install --binlink' commands. By \
@@ -383,7 +380,10 @@ fn binlink_is_on_path(binlink_path: &Path) -> bool {
 /// the path of this process. These are maintained
 /// in the Windows registry
 #[cfg(windows)]
-fn set_binlink_path(binlink_path: &Path) -> Result<()> {
+fn set_binlink_path() -> Result<()> {
+    let binlink_path =
+        &Path::new(&*FS_ROOT).join(Path::new(DEFAULT_BINLINK_DIR).strip_prefix("/").unwrap());
+
     if !binlink_is_on_path(binlink_path) {
         let hklm = RegKey::predef(HKEY_LOCAL_MACHINE);
         let env = hklm.open_subkey_with_flags(
@@ -411,6 +411,3 @@ fn set_binlink_path(binlink_path: &Path) -> Result<()> {
     }
     Ok(())
 }
-
-#[cfg(not(windows))]
-fn set_binlink_path(_binlink_path: &Path) -> Result<()> { unreachable!() }

--- a/components/hab/src/command/pkg/binlink.rs
+++ b/components/hab/src/command/pkg/binlink.rs
@@ -99,17 +99,12 @@ pub fn start(ui: &mut UI,
     Ok(())
 }
 
-pub fn binlink_all_in_pkg<F, D>(ui: &mut UI,
-                                pkg_ident: &PackageIdent,
-                                dest_path: D,
-                                fs_root_path: F,
-                                force: bool)
-                                -> Result<()>
-    where D: AsRef<Path>,
-          F: AsRef<Path>
-{
-    let fs_root_path = fs_root_path.as_ref();
-
+pub fn binlink_all_in_pkg(ui: &mut UI,
+                          pkg_ident: &PackageIdent,
+                          dest_path: &Path,
+                          fs_root_path: &Path,
+                          force: bool)
+                          -> Result<()> {
     let pkg_path = PackageInstall::load(&pkg_ident, Some(fs_root_path))?;
     for bin_path in pkg_path.paths()? {
         for bin in fs::read_dir(fs_root_path.join(bin_path.strip_prefix("/")?))? {
@@ -148,12 +143,7 @@ pub fn binlink_all_in_pkg<F, D>(ui: &mut UI,
                     continue;
                 }
             };
-            self::start(ui,
-                        &pkg_ident,
-                        &bin_name,
-                        dest_path.as_ref(),
-                        &fs_root_path,
-                        force)?;
+            self::start(ui, &pkg_ident, &bin_name, dest_path, &fs_root_path, force)?;
         }
     }
     Ok(())

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -23,7 +23,8 @@ extern crate log;
 
 #[cfg(windows)]
 use crate::hcore::crypto::dpapi::encrypt;
-use crate::{common::{cli_defaults::DEFAULT_BINLINK_DIR,
+use crate::{common::{cli_defaults::{DEFAULT_BINLINK_DIR,
+                                    FS_ROOT},
                      command::package::install::{InstallHookMode,
                                                  InstallMode,
                                                  InstallSource,
@@ -91,8 +92,7 @@ use std::{env,
                prelude::*,
                Read},
           net::ToSocketAddrs,
-          path::{Path,
-                 PathBuf},
+          path::Path,
           process,
           result,
           str::FromStr,
@@ -107,41 +107,16 @@ use termcolor::{self,
 const HABITAT_ORG_ENVVAR: &str = "HAB_ORG";
 /// Makes the --user CLI param optional when this env var is set
 const HABITAT_USER_ENVVAR: &str = "HAB_USER";
-const SYSTEMDRIVE_ENVVAR: &str = "SYSTEMDRIVE";
 
 lazy_static! {
     static ref STATUS_HEADER: Vec<&'static str> = {
-        vec![
-            "package",
-            "type",
-            "desired",
-            "state",
-            "elapsed (s)",
-            "pid",
-            "group",
-        ]
-    };
-
-    /// The default filesystem root path to base all commands from. This is lazily generated on
-    /// first call and reflects on the presence and value of the environment variable keyed as
-    /// `FS_ROOT_ENVVAR`.
-    static ref FS_ROOT: PathBuf = {
-        use crate::hcore::fs::FS_ROOT_ENVVAR;
-
-        if cfg!(target_os = "windows") {
-            match (henv::var(FS_ROOT_ENVVAR), henv::var(SYSTEMDRIVE_ENVVAR)) {
-                (Ok(path), _) => PathBuf::from(path),
-                (Err(_), Ok(system_drive)) => PathBuf::from(format!("{}{}", system_drive, "\\")),
-                (Err(_), Err(_)) => unreachable!(
-                    "Windows should always have a SYSTEMDRIVE \
-                    environment variable."
-                ),
-            }
-        } else if let Ok(root) = henv::var(FS_ROOT_ENVVAR) {
-            PathBuf::from(root)
-        } else {
-            PathBuf::from("/")
-        }
+        vec!["package",
+             "type",
+             "desired",
+             "state",
+             "elapsed (s)",
+             "pid",
+             "group",]
     };
 }
 


### PR DESCRIPTION
See https://github.com/habitat-sh/habitat/issues/6314

Since only habitat used it, we can move the necessary logic of `habitat_core::binlink::default_binlink_dir` into `habitat` itself. While doing so, we switch to using the standard [clap](https://clap.rs) approach to environment variable overrides, and add validation that the binlink dir is not set to the empty string.

After this merges, we should remove the `binlink` module from `core`.