### PR TITLE
Use POSIX `unset` rather than Busybox `env -u` for HAB_STUDIO_BINARY

### DIFF
--- a/components/studio/bin/hab-studio.sh
+++ b/components/studio/bin/hab-studio.sh
@@ -1146,8 +1146,8 @@ set_libexec_path() {
   fi
 
   if [ -n "${HAB_STUDIO_BINARY:-}" ]; then
-    version=$($bb env -u HAB_STUDIO_BINARY hab studio version | $bb cut -d ' ' -f 2)
-    libexec_path="$($bb env -u HAB_STUDIO_BINARY hab pkg path core/hab-studio)/libexec"
+    version="$(unset HAB_STUDIO_BINARY; hab studio version | $bb cut -d ' ' -f 2)"
+    libexec_path="$(unset HAB_STUDIO_BINARY; hab pkg path core/hab-studio)/libexec"
     studio_binary_libexec_path="$($bb dirname "$HAB_STUDIO_BINARY")/../libexec"
   else
     p=$($bb dirname "$0")


### PR DESCRIPTION
On my Ubuntu 18.10 machine, overriding `HAB_STUDIO_BINARY` leads these
lines to fail with the following:

```
env: invalid number 'HAB_STUDIO_BINARY'
env: invalid number 'HAB_STUDIO_BINARY'
```

It appears to be something similar to this bug report:

http://lists.busybox.net/pipermail/busybox/2017-December/086002.html

To circumvent this, we'll just use `unset` to remove the variable from
the command environment (taking place in a subshell)

As an aside, `HAB_STUDIO_BINARY` seems to expect the given binary to
exist in a Habitat package, rather than being a bare script on the
workstation.

Signed-off-by: Christopher Maier <cmaier@chef.io>