### PR TITLE
Remove uses of core's default_cache_key_path

### DIFF
--- a/components/hab/src/command/origin/key/download.rs
+++ b/components/hab/src/command/origin/key/download.rs
@@ -182,12 +182,12 @@ fn download_key(ui: &mut UI,
                 cache: &Path)
                 -> Result<()> {
     match SigKeyPair::get_public_key_path(&nwr, &cache) {
-        Ok(_) => ui.status(Status::Using, &nwr)?,
+        Ok(_) => ui.status(Status::Using, &format!("{} in {}", nwr, cache.display()))?,
         Err(_) => {
             let download_fn = || -> Result<()> {
                 ui.status(Status::Downloading, &nwr)?;
                 api_client.fetch_origin_key(name, rev, cache, ui.progress())?;
-                ui.status(Status::Cached, &nwr)?;
+                ui.status(Status::Cached, &format!("{} to {}", nwr, cache.display()))?;
                 Ok(())
             };
 


### PR DESCRIPTION
See https://github.com/habitat-sh/habitat/issues/6314 for why.

This removes basically all the calls in the core hab CLI processing. All of which are of the form:

```rust
    default_cache_key_path(Some(&*FS_ROOT))
```

and replaces them with `cache_key_path_from_matches`, which instead of calling core's nonstandard `env::var` implementation, accesses values which have been validated by clap. To facilitate this, and improve discoverability, all the CLI commands which previously relied on `default_cache_key_path` now have a `--cache-key-path`, which is documented and overridable with the `HAB_CACHE_KEY_PATH` environment variable, but in a safe way, where an empty-string value generates an informative error.

Previously, empty-string values would be treated as specifying the current working directory as the search root. This is no longer legal, as it is too likely to be the result of an erroneous attempt to unset
the override environment variable. If this behavior is desired, the use of the more explicit `.` with either the `HAB_CACHE_KEY_PATH` env var or `--cache-key-path` argument will achieve the same effect more clearly.

Additional uses of default_cache_key_path exist and will be addressed in a subsequent commit.
