### PR TITLE
Platform-specific UserInfo proof of concept

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -954,6 +954,7 @@ name = "habitat-launcher-protocol"
 version = "0.0.0"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "habitat_common 0.0.0",
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-build 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/common/src/types/mod.rs
+++ b/components/common/src/types/mod.rs
@@ -25,14 +25,19 @@ pub use self::listen_ctl_addr::ListenCtlAddr;
 /// On Windows, all but `username` will be `None`. On Linux,
 /// `username` and `groupname` may legitimately be `None`, but `uid`
 /// and `gid` should always be `Some`.
-#[derive(Debug, Default)]
+#[cfg(unix)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct UserInfo {
-    /// Windows required, Linux optional
     pub username: Option<String>,
     /// Linux preferred
-    pub uid: Option<u32>,
-    /// Linux optional
+    pub uid: u32,
     pub groupname: Option<String>,
     /// Linux preferred
-    pub gid: Option<u32>,
+    pub gid: u32,
+}
+
+#[cfg(windows)]
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct UserInfo {
+    pub username: String,
 }

--- a/components/launcher-client/src/client.rs
+++ b/components/launcher-client/src/client.rs
@@ -151,13 +151,13 @@ impl LauncherCli {
         // used; names are only for backward compatibility with older
         // Launchers.
         let msg = protocol::Spawn { binary: bin.to_string_lossy().into_owned(),
-                                    svc_user: username,
-                                    svc_group: groupname,
-                                    svc_user_id: uid,
-                                    svc_group_id: gid,
                                     svc_password: password.map(str::to_string),
                                     env,
-                                    id: id.to_string() };
+                                    id: id.to_string(),
+                                    user_info: UserInfo { username,
+                                                          uid,
+                                                          groupname,
+                                                          gid } };
 
         Self::send(&self.tx, &msg)?;
         let reply = Self::recv::<protocol::SpawnOk>(&self.rx)?;

--- a/components/launcher-protocol/Cargo.toml
+++ b/components/launcher-protocol/Cargo.toml
@@ -8,6 +8,7 @@ workspace = "../../"
 
 [dependencies]
 bytes = "*"
+habitat_common = { path = "../common" }
 prost = "*"
 prost-derive = "*"
 serde = "*"

--- a/components/launcher-protocol/protocols/launcher.proto
+++ b/components/launcher-protocol/protocols/launcher.proto
@@ -10,6 +10,7 @@ message Restart {
   optional int64 pid = 1;
 }
 
+// Make this SpawnUnix
 message Spawn {
   optional string id = 1;
   optional string binary = 2;
@@ -17,8 +18,12 @@ message Spawn {
   optional string svc_group = 4;
   optional string svc_password = 5;
   map<string, string> env = 6;
-  optional uint32 svc_user_id = 7;
-  optional uint32 svc_group_id = 8;
+  required uint32 svc_user_id = 7;
+  required uint32 svc_group_id = 8;
+}
+
+message SpawnWindows {
+  required string svc_user = 3;
 }
 
 message SpawnOk {

--- a/components/launcher-protocol/src/types.rs
+++ b/components/launcher-protocol/src/types.rs
@@ -15,6 +15,7 @@
 use crate::{error::{Error,
                     Result},
             generated};
+use habitat_common::types::UserInfo;
 use prost::{self,
             Message};
 use std::{collections::HashMap,
@@ -149,12 +150,9 @@ impl From<Restart> for generated::Restart {
 pub struct Spawn {
     pub id:           String,
     pub binary:       String,
-    pub svc_user:     Option<String>,
-    pub svc_group:    Option<String>,
     pub svc_password: Option<String>,
     pub env:          HashMap<String, String>,
-    pub svc_user_id:  Option<u32>,
-    pub svc_group_id: Option<u32>,
+    pub user_info:    UserInfo,
 }
 
 impl LauncherMessage for Spawn {
@@ -165,12 +163,12 @@ impl LauncherMessage for Spawn {
     fn from_proto(proto: generated::Spawn) -> Result<Self> {
         Ok(Spawn { id:           proto.id.ok_or(Error::ProtocolMismatch("id"))?,
                    binary:       proto.binary.ok_or(Error::ProtocolMismatch("binary"))?,
-                   svc_user:     proto.svc_user,
-                   svc_group:    proto.svc_group,
                    svc_password: proto.svc_password,
                    env:          proto.env,
-                   svc_user_id:  proto.svc_user_id,
-                   svc_group_id: proto.svc_group_id, })
+                   user_info:    UserInfo { username:  proto.svc_user,
+                                            uid:       proto.svc_user_id,
+                                            groupname: proto.svc_group,
+                                            gid:       proto.svc_group_id, }, })
     }
 }
 
@@ -178,12 +176,12 @@ impl From<Spawn> for generated::Spawn {
     fn from(value: Spawn) -> Self {
         generated::Spawn { id:           Some(value.id),
                            binary:       Some(value.binary),
-                           svc_user:     value.svc_user,
-                           svc_group:    value.svc_group,
+                           svc_user:     value.user_info.username,
+                           svc_group:    value.user_info.groupname,
                            svc_password: value.svc_password,
                            env:          value.env,
-                           svc_user_id:  value.svc_user_id,
-                           svc_group_id: value.svc_group_id, }
+                           svc_user_id:  value.user_info.uid,
+                           svc_group_id: value.user_info.gid, }
     }
 }
 

--- a/components/launcher/src/sys/unix/service.rs
+++ b/components/launcher/src/sys/unix/service.rs
@@ -21,9 +21,8 @@ use std::{io,
                     Stdio},
           result};
 
-use crate::{core::os::{self,
-                       process::{signal,
-                                 Signal}},
+use crate::{core::os::process::{signal,
+                                Signal},
             protocol::{self,
                        ShutdownMethod}};
 use libc;
@@ -85,35 +84,15 @@ impl Process {
 
 pub fn run(msg: protocol::Spawn) -> Result<Service> {
     debug!("launcher is spawning {}", msg.binary);
-    let mut cmd = Command::new(&msg.binary);
-
-    // Favor explicitly set UID/GID over names when present
-    let uid = if let Some(suid) = msg.svc_user_id {
-        suid
-    } else if let Some(suser) = &msg.svc_user {
-        os::users::get_uid_by_name(&suser).ok_or_else(|| Error::UserNotFound(suser.to_string()))?
-    } else {
-        return Err(Error::UserNotFound(String::from("")));
-    };
-
-    let gid = if let Some(sgid) = msg.svc_group_id {
-        sgid
-    } else if let Some(sgroup) = &msg.svc_group {
-        os::users::get_gid_by_name(&sgroup).ok_or_else(|| Error::GroupNotFound(sgroup.to_string()))?
-    } else {
-        return Err(Error::GroupNotFound(String::from("")));
-    };
-
-    cmd.before_exec(owned_pgid);
-    cmd.stdin(Stdio::null())
-       .stdout(Stdio::piped())
-       .stderr(Stdio::piped())
-       .uid(uid)
-       .gid(gid);
-    for (key, val) in msg.env.iter() {
-        cmd.env(key, val);
-    }
-    let mut child = cmd.spawn().map_err(Error::Spawn)?;
+    let mut child = Command::new(&msg.binary).before_exec(owned_pgid)
+                                             .stdin(Stdio::null())
+                                             .stdout(Stdio::piped())
+                                             .stderr(Stdio::piped())
+                                             .uid(msg.user_info.uid)
+                                             .gid(msg.user_info.gid)
+                                             .envs(msg.env.iter())
+                                             .spawn()
+                                             .map_err(Error::Spawn)?;
     let stdout = child.stdout.take();
     let stderr = child.stderr.take();
     let process = Process(child);

--- a/components/sup/src/manager/service/supervisor.rs
+++ b/components/sup/src/manager/service/supervisor.rs
@@ -104,10 +104,10 @@ impl Supervisor {
             let gid = users::get_gid_by_name(&pkg.svc_group)
                 .ok_or(sup_error!(Error::GroupNotFound(pkg.svc_group.to_string(),)))?;
 
-            Ok(UserInfo { username:  Some(pkg.svc_user.clone()),
-                          uid:       Some(uid),
+            Ok(UserInfo { username: Some(pkg.svc_user.clone()),
+                          uid,
                           groupname: Some(pkg.svc_group.clone()),
-                          gid:       Some(gid), })
+                          gid })
         } else {
             // We DO NOT have the ability to run as other users!  Also
             // note that we legitimately may not have a username or
@@ -123,9 +123,9 @@ impl Supervisor {
                 run services as a different user; running as self!", name_for_logging);
 
             Ok(UserInfo { username,
-                          uid: Some(uid),
+                          uid,
                           groupname,
-                          gid: Some(gid) })
+                          gid })
         }
     }
 


### PR DESCRIPTION
See https://github.com/habitat-sh/habitat/pull/6305#discussion_r267052477 for more context.

I don't think this is worth going forward with because adding `required` types to launcher.proto shackles the launcher and supervisor together in an undesirable way. But if we keep our protobuf-generated structs with optional types, we are stuck with the decision between `unwrap` during the infallible conversion from `generated::Spawn` -> `Spawn`, or we can't really eliminate the Option<_>`s in UserInfo.

