### PR TITLE
Remove default_cache_key_path calls around command_from_min_pkg

### DIFF
--- a/components/hab/src/command/launcher.rs
+++ b/components/hab/src/command/launcher.rs
@@ -27,8 +27,7 @@ mod inner {
               str::FromStr};
 
     use crate::{common::ui::UI,
-                hcore::{crypto::{default_cache_key_path,
-                                 init},
+                hcore::{crypto::init,
                         env as henv,
                         fs::find_command,
                         os::process,
@@ -54,9 +53,7 @@ mod inner {
                                        SUP_CMD,
                                        &PackageIdent::from_str(&format!("{}/{}",
                                                                         SUP_PKG_IDENT,
-                                                                        version[0]))?,
-                                       &default_cache_key_path(None),
-                                       0)?;
+                                                                        version[0]))?)?;
         }
         let command = match henv::var(LAUNCH_CMD_ENVVAR) {
             Ok(command) => PathBuf::from(command),
@@ -64,9 +61,7 @@ mod inner {
                 init();
                 exec::command_from_min_pkg(ui,
                                            LAUNCH_CMD,
-                                           &PackageIdent::from_str(LAUNCH_PKG_IDENT)?,
-                                           &default_cache_key_path(None),
-                                           0)?
+                                           &PackageIdent::from_str(LAUNCH_PKG_IDENT)?)?
             }
         };
         if let Some(cmd) = find_command(&command) {

--- a/components/hab/src/command/pkg/export/export_common.rs
+++ b/components/hab/src/command/pkg/export/export_common.rs
@@ -40,8 +40,7 @@ mod inner {
               str::FromStr};
 
     use crate::{common::ui::UI,
-                hcore::{crypto::{default_cache_key_path,
-                                 init},
+                hcore::{crypto::init,
                         env as henv,
                         fs::find_command,
                         os::process,
@@ -70,11 +69,7 @@ mod inner {
                         PackageIdent::from_str(&format!("{}/{}", export_pkg_ident, version[0]))?
                     }
                 };
-                exec::command_from_min_pkg(ui,
-                                           export_cmd,
-                                           &ident,
-                                           &default_cache_key_path(None),
-                                           0)?
+                exec::command_from_min_pkg(ui, export_cmd, &ident)?
             }
         };
         if let Some(cmd) = find_command(&command) {

--- a/components/hab/src/command/pkg/export/mod.rs
+++ b/components/hab/src/command/pkg/export/mod.rs
@@ -56,8 +56,7 @@ mod inner {
               str::FromStr};
 
     use crate::{common::ui::UI,
-                hcore::{crypto::{default_cache_key_path,
-                                 init},
+                hcore::{crypto::init,
                         env::Config,
                         fs::find_command,
                         package::PackageIdent,
@@ -101,11 +100,7 @@ mod inner {
                  format: &ExportFormat)
                  -> Result<()> {
         init();
-        let command = exec::command_from_min_pkg(ui,
-                                                 format.cmd(),
-                                                 format.pkg_ident(),
-                                                 &default_cache_key_path(None),
-                                                 0)?;
+        let command = exec::command_from_min_pkg(ui, format.cmd(), format.pkg_ident())?;
 
         if let Some(cmd) = find_command(command.to_string_lossy().as_ref()) {
             let pkg_arg = OsString::from(&ident.to_string());

--- a/components/hab/src/command/pkg/export/tar.rs
+++ b/components/hab/src/command/pkg/export/tar.rs
@@ -29,8 +29,7 @@ mod inner {
               str::FromStr};
 
     use crate::{common::ui::UI,
-                hcore::{crypto::{default_cache_key_path,
-                                 init},
+                hcore::{crypto::init,
                         env as henv,
                         fs::find_command,
                         os::process,
@@ -58,11 +57,7 @@ mod inner {
                         PackageIdent::from_str(&format!("{}/{}", EXPORT_PKG_IDENT, version[0]))?
                     }
                 };
-                exec::command_from_min_pkg(ui,
-                                           EXPORT_CMD,
-                                           &ident,
-                                           &default_cache_key_path(None),
-                                           0)?
+                exec::command_from_min_pkg(ui, EXPORT_CMD, &ident)?
             }
         };
         if let Some(cmd) = find_command(&command) {

--- a/components/hab/src/command/studio/enter.rs
+++ b/components/hab/src/command/studio/enter.rs
@@ -72,8 +72,7 @@ mod inner {
                 error::{Error,
                         Result},
                 exec,
-                hcore::{crypto::{default_cache_key_path,
-                                 init},
+                hcore::{crypto::init,
                         env as henv,
                         fs::{am_i_root,
                              find_command},
@@ -101,11 +100,7 @@ mod inner {
                     let ident = PackageIdent::from_str(&format!("{}/{}",
                                                                 super::STUDIO_PACKAGE_IDENT,
                                                                 version[0]))?;
-                    exec::command_from_min_pkg(ui,
-                                               super::STUDIO_CMD,
-                                               &ident,
-                                               &default_cache_key_path(None),
-                                               0)?
+                    exec::command_from_min_pkg(ui, super::STUDIO_CMD, &ident)?
                 }
             };
 
@@ -176,8 +171,7 @@ mod inner {
                 error::{Error,
                         Result},
                 exec,
-                hcore::{crypto::{default_cache_key_path,
-                                 init},
+                hcore::{crypto::init,
                         env as henv,
                         fs::find_command,
                         os::process,
@@ -204,11 +198,7 @@ mod inner {
                 let ident = PackageIdent::from_str(&format!("{}/{}",
                                                             super::STUDIO_PACKAGE_IDENT,
                                                             version[0]))?;
-                exec::command_from_min_pkg(ui,
-                                           super::STUDIO_CMD,
-                                           &ident,
-                                           &default_cache_key_path(None),
-                                           0)?
+                exec::command_from_min_pkg(ui, super::STUDIO_CMD, &ident)?
             }
         };
 

--- a/components/hab/src/command/sup.rs
+++ b/components/hab/src/command/sup.rs
@@ -31,8 +31,7 @@ mod inner {
               str::FromStr};
 
     use crate::{common::ui::UI,
-                hcore::{crypto::{default_cache_key_path,
-                                 init},
+                hcore::{crypto::init,
                         env as henv,
                         fs::find_command,
                         os::process,
@@ -56,9 +55,7 @@ mod inner {
                                            SUP_CMD,
                                            &PackageIdent::from_str(&format!("{}/{}",
                                                                             SUP_PKG_IDENT,
-                                                                            version[0]))?,
-                                           &default_cache_key_path(None),
-                                           0)?
+                                                                            version[0]))?)?
             }
         };
         if let Some(cmd) = find_command(&command) {


### PR DESCRIPTION
The cache_key_path argument wasn't being used anyway, so this gets us one step closer to eliminating default_cache_key_path altogether.

Additionally, fix up some issues with `command_from_min_pkg`:
- [Argument position impl syntax](https://github.com/habitat-sh/habitat/pull/6329/files#diff-adee662cab12990beb3cbb40956a005aR74) is a bit [clearer than generics](https://github.com/habitat-sh/habitat/pull/6329/files#diff-adee662cab12990beb3cbb40956a005aL76)
- [Separate the recursion](https://github.com/habitat-sh/habitat/pull/6329/files#diff-adee662cab12990beb3cbb40956a005aR80) so callers don't have to add [a 0 arg](https://github.com/habitat-sh/habitat/pull/6329/files#diff-5bf1fa8787bf57a51ea27f8f121ef7c1L69)
- Avoid [the possibility of overflow](https://github.com/habitat-sh/habitat/pull/6329/files#diff-adee662cab12990beb3cbb40956a005aR120) on the retry check
