### PR TITLE
Remove uses of default_cache_key_path

### DIFF
--- a/components/common/Cargo.toml
+++ b/components/common/Cargo.toml
@@ -8,6 +8,7 @@ workspace = "../../"
 
 [dependencies]
 bimap = "*"
+clap = { version = "*", features = [ "suggestions", "color", "unstable" ] }
 glob = "*"
 # The handlebars crate has a few issues that require us to lock at 0.28.3
 # until further notice.

--- a/components/common/src/cli.rs
+++ b/components/common/src/cli.rs
@@ -18,7 +18,10 @@
 //! need a spot to consolidate those values and help simplify some of the logic around them.
 
 use crate::types::ListenCtlAddr;
-use habitat_core::env as henv;
+use clap::ArgMatches;
+use habitat_core::{env as henv,
+                   fs::{cache_key_path,
+                        CACHE_KEY_PATH}};
 use std::path::PathBuf;
 
 pub const GOSSIP_DEFAULT_IP: &str = "0.0.0.0";
@@ -77,3 +80,14 @@ pub const DEFAULT_BINLINK_DIR: &str = "/hab/bin";
 pub const DEFAULT_BINLINK_DIR: &str = "/bin";
 #[cfg(target_os = "macos")]
 pub const DEFAULT_BINLINK_DIR: &str = "/usr/local/bin";
+
+/// We require the value at the clap layer (see cli::arg_cache_key_path),
+/// so we can safely unwrap, but we need some additional logic to calculate
+// the dynamic "default" value if the argument has the default signifier value:
+/// CACHE_KEY_PATH. An empty value can't stand for default since it is invalid.
+pub fn cache_key_path_from_matches(matches: &ArgMatches<'_>) -> PathBuf {
+    match matches.value_of("CACHE_KEY_PATH").unwrap() {
+        CACHE_KEY_PATH => cache_key_path(Some(&*FS_ROOT)),
+        val => PathBuf::from(val),
+    }
+}

--- a/components/common/src/lib.rs
+++ b/components/common/src/lib.rs
@@ -30,7 +30,7 @@ extern crate winapi;
 pub use self::error::{Error,
                       Result};
 
-pub mod cli_defaults;
+pub mod cli;
 pub mod command;
 pub mod error;
 pub mod locked_env_var;

--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -17,15 +17,15 @@ use crate::{command::studio,
 use clap::{App,
            AppSettings,
            Arg};
-use habitat_common::{cli_defaults::{BINLINK_DIR_ENVVAR,
-                                    DEFAULT_BINLINK_DIR,
-                                    GOSSIP_DEFAULT_ADDR,
-                                    GOSSIP_LISTEN_ADDRESS_ENVVAR,
-                                    LISTEN_CTL_DEFAULT_ADDR_STRING,
-                                    LISTEN_HTTP_ADDRESS_ENVVAR,
-                                    LISTEN_HTTP_DEFAULT_ADDR,
-                                    RING_ENVVAR,
-                                    RING_KEY_ENVVAR},
+use habitat_common::{cli::{BINLINK_DIR_ENVVAR,
+                           DEFAULT_BINLINK_DIR,
+                           GOSSIP_DEFAULT_ADDR,
+                           GOSSIP_LISTEN_ADDRESS_ENVVAR,
+                           LISTEN_CTL_DEFAULT_ADDR_STRING,
+                           LISTEN_HTTP_ADDRESS_ENVVAR,
+                           LISTEN_HTTP_DEFAULT_ADDR,
+                           RING_ENVVAR,
+                           RING_KEY_ENVVAR},
                      types::ListenCtlAddr};
 use habitat_core::{crypto::{keys::PairType,
                             CACHE_KEY_PATH_ENV_VAR},
@@ -975,10 +975,13 @@ pub fn sub_sup_run() -> App<'static, 'static> {
     (@arg PEER_WATCH_FILE: --("peer-watch-file") +takes_value conflicts_with("PEER")
         "Watch this file for connecting to the ring"
     )
-    (@arg RING: --ring -r env(RING_ENVVAR) conflicts_with("RING_KEY")
+    (arg: arg_cache_key_path("Path to search for encryption keys. \
+        Default value is hab/cache/keys if root and .hab/cache/keys under the home \
+        directory otherwise."))
+    (@arg RING: --ring -r env(RING_ENVVAR) conflicts_with("RING_KEY") {non_empty}
         "The name of the ring used by the Supervisor when running with wire encryption. \
          (ex: hab sup run --ring myring)")
-    (@arg RING_KEY: --("ring-key") env(RING_KEY_ENVVAR) conflicts_with("RING") +hidden
+    (@arg RING_KEY: --("ring-key") env(RING_KEY_ENVVAR) conflicts_with("RING") +hidden {non_empty}
         "The contents of the ring key when running with wire encryption. \
              (Note: This option is explicitly undocumented and for testing purposes only. Do not use it in a production system. Use the corresponding environment variable instead.)
              (ex: hab sup run --ring-key 'SYM-SEC-1 \
@@ -1282,7 +1285,7 @@ fn valid_origin(val: String) -> result::Result<(), String> {
 #[allow(clippy::needless_pass_by_value)] // Signature required by CLAP
 fn non_empty(val: String) -> result::Result<(), String> {
     if val.is_empty() {
-        Err("must not be empty".to_string())
+        Err("must not be empty (check env overrides)".to_string())
     } else {
         Ok(())
     }

--- a/components/hab/src/command/cli/setup.rs
+++ b/components/hab/src/command/cli/setup.rs
@@ -18,8 +18,8 @@ use std::{path::Path,
           result};
 
 #[cfg(windows)]
-use crate::common::cli_defaults::{DEFAULT_BINLINK_DIR,
-                                  FS_ROOT};
+use crate::common::cli::{DEFAULT_BINLINK_DIR,
+                         FS_ROOT};
 use crate::{common::ui::{UIReader,
                          UIWriter,
                          UI},

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -23,8 +23,9 @@ extern crate log;
 
 #[cfg(windows)]
 use crate::hcore::crypto::dpapi::encrypt;
-use crate::{common::{cli_defaults::{DEFAULT_BINLINK_DIR,
-                                    FS_ROOT},
+use crate::{common::{cli::{cache_key_path_from_matches,
+                           DEFAULT_BINLINK_DIR,
+                           FS_ROOT},
                      command::package::install::{InstallHookMode,
                                                  InstallMode,
                                                  InstallSource,
@@ -43,9 +44,7 @@ use crate::{common::{cli_defaults::{DEFAULT_BINLINK_DIR,
                     env::Config as EnvConfig,
                     fs::{cache_analytics_path,
                          cache_artifact_path,
-                         cache_key_path,
-                         launcher_root_path,
-                         CACHE_KEY_PATH},
+                         launcher_root_path},
                     package::{PackageIdent,
                               PackageTarget},
                     service::{HealthCheckInterval,
@@ -91,8 +90,7 @@ use std::{env,
                prelude::*,
                Read},
           net::ToSocketAddrs,
-          path::{Path,
-                 PathBuf},
+          path::Path,
           process,
           result,
           str::FromStr,
@@ -1464,17 +1462,6 @@ fn excludes_from_matches(matches: &ArgMatches<'_>) -> Vec<PackageIdent> {
         .unwrap_or_default()
         .map(|i| PackageIdent::from_str(i).unwrap()) // unwrap safe as we've validated the input
         .collect()
-}
-
-/// We require the value at the clap layer (see cli::arg_cache_key_path),
-/// so we can safely unwrap, but we need some additional logic to calculate
-// the dynamic "default" value if the argument has the default signifier value:
-/// CACHE_KEY_PATH. An empty value can't stand for default since it is invalid.
-fn cache_key_path_from_matches(matches: &ArgMatches<'_>) -> PathBuf {
-    match matches.value_of("CACHE_KEY_PATH").unwrap() {
-        CACHE_KEY_PATH => cache_key_path(Some(&*FS_ROOT)),
-        val => PathBuf::from(val),
-    }
 }
 
 fn enable_features_from_env(ui: &mut UI) {

--- a/components/sup/src/census.rs
+++ b/components/sup/src/census.rs
@@ -78,6 +78,7 @@ impl CensusRing {
                      last_service_file_counter: 0, }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn update_from_rumors(&mut self,
                               cache_key_path: &Path,
                               service_rumors: &RumorStore<ServiceRumor>,

--- a/components/sup/src/config.rs
+++ b/components/sup/src/config.rs
@@ -20,9 +20,9 @@
 //!
 //! See the [Config](struct.Config.html) struct for the specific options available.
 
-use habitat_common::cli_defaults::{GOSSIP_DEFAULT_IP,
-                                   GOSSIP_DEFAULT_PORT,
-                                   GOSSIP_LISTEN_ADDRESS_ENVVAR};
+use habitat_common::cli::{GOSSIP_DEFAULT_IP,
+                          GOSSIP_DEFAULT_PORT,
+                          GOSSIP_LISTEN_ADDRESS_ENVVAR};
 use habitat_core::env::Config as EnvConfig;
 use std::{fmt,
           io,

--- a/components/sup/src/http_gateway.rs
+++ b/components/sup/src/http_gateway.rs
@@ -32,9 +32,9 @@ use actix_web::{http::{self,
                 HttpResponse,
                 Path,
                 Request};
-use habitat_common::{cli_defaults::{LISTEN_HTTP_ADDRESS_ENVVAR,
-                                    LISTEN_HTTP_DEFAULT_IP,
-                                    LISTEN_HTTP_DEFAULT_PORT},
+use habitat_common::{cli::{LISTEN_HTTP_ADDRESS_ENVVAR,
+                           LISTEN_HTTP_DEFAULT_IP,
+                           LISTEN_HTTP_DEFAULT_PORT},
                      templating::hooks};
 use habitat_core::{crypto,
                    env as henv,

--- a/components/sup/src/manager/peer_watcher.rs
+++ b/components/sup/src/manager/peer_watcher.rs
@@ -17,7 +17,7 @@ use crate::{error::{Error,
             manager::file_watcher::{default_file_watcher,
                                     Callbacks}};
 use habitat_butterfly::member::Member;
-use habitat_common::{cli_defaults::GOSSIP_DEFAULT_PORT,
+use habitat_common::{cli::GOSSIP_DEFAULT_PORT,
                      outputln};
 use std::{fs::File,
           io::{BufRead,
@@ -152,7 +152,7 @@ impl PeerWatcher {
 mod tests {
     use super::PeerWatcher;
     use habitat_butterfly::member::Member;
-    use habitat_common::cli_defaults::GOSSIP_DEFAULT_PORT;
+    use habitat_common::cli::GOSSIP_DEFAULT_PORT;
     use std::{fs::{File,
                    OpenOptions},
               io::Write};

--- a/components/sup/src/manager/service/hooks.rs
+++ b/components/sup/src/manager/service/hooks.rs
@@ -531,10 +531,12 @@ impl HookTable {
 
 #[cfg(test)]
 mod tests {
-    use std::{fs,
-              iter};
-    use tempfile::TempDir;
-
+    use super::{super::RenderContext,
+                *};
+    use crate::{census::CensusRing,
+                config::GossipListenAddr,
+                http_gateway,
+                manager::sys::Sys};
     use habitat_butterfly::{member::MemberList,
                             rumor::{election::{self,
                                                Election as ElectionRumor,
@@ -544,21 +546,19 @@ mod tests {
                                     service_config::ServiceConfig as ServiceConfigRumor,
                                     service_file::ServiceFile as ServiceFileRumor,
                                     RumorStore}};
-    use habitat_common::{templating::{config::Cfg,
+    use habitat_common::{cli::FS_ROOT,
+                         templating::{config::Cfg,
                                       package::Pkg,
                                       test_helpers::*},
                          types::ListenCtlAddr};
-    use habitat_core::{package::{PackageIdent,
+    use habitat_core::{fs::cache_key_path,
+                       package::{PackageIdent,
                                  PackageInstall},
                        service::{ServiceBind,
                                  ServiceGroup}};
-
-    use super::{super::RenderContext,
-                *};
-    use crate::{census::CensusRing,
-                config::GossipListenAddr,
-                http_gateway,
-                manager::sys::Sys};
+    use std::{fs,
+              iter};
+    use tempfile::TempDir;
 
     // Turns out it's useful for Hooks to implement AsRef<Path>, at
     // least for these tests. Ideally, this would be useful to use
@@ -670,7 +670,8 @@ mod tests {
         let service_file_store: RumorStore<ServiceFileRumor> = RumorStore::default();
 
         let mut ring = CensusRing::new("member-a");
-        ring.update_from_rumors(&service_store,
+        ring.update_from_rumors(&cache_key_path(Some(&*FS_ROOT)),
+                                &service_store,
                                 &election_store,
                                 &election_update_store,
                                 &member_list,


### PR DESCRIPTION
See https://github.com/habitat-sh/habitat/issues/6314 for why

There are some associated changes and cleanup, but most of this is just plumbing what were previous environment variable overrides and making them proper CLI argument (with the option for override).