### PR TITLE
Don't use TESTING_FS_ROOT as an environment variable.

### DIFF
--- a/components/common/src/templating/mod.rs
+++ b/components/common/src/templating/mod.rs
@@ -356,6 +356,8 @@ test: something"#
     fn render_package_install() {
         let root = TempDir::new().expect("create temp dir").into_path();
         env::set_var(fs::FS_ROOT_ENVVAR, &root);
+        // Override the default / filesystem root for this test
+        env::set_var("TESTING_FS_ROOT", &root);
         let pg_id = PackageIdent::new("testing", "test", Some("1.0.0"), Some("20170712000000"));
 
         let pkg_install =

--- a/components/common/src/templating/mod.rs
+++ b/components/common/src/templating/mod.rs
@@ -119,7 +119,7 @@ mod test {
                              FS_ROOT_PATH},
                         package::PackageIdent},
                 templating::test_helpers::*};
-    use crate::{locked_env_var};
+    // use crate::{locked_env_var};
     use serde_json;
     use std::{collections::BTreeMap,
               env,
@@ -353,15 +353,15 @@ test: something"#
         assert_eq!(each_alive_render, each_if_render);
     }
 
-    locked_env_var!(TESTING_FS_ROOT, lock_var);
+    // locked_env_var!(TESTING_FS_ROOT, lock_var);
 
     #[test]
     fn render_package_install() {
         let root = TempDir::new().expect("create temp dir").into_path();
         env::set_var(fs::FS_ROOT_ENVVAR, &root);
         // Override the default / filesystem root for this test
-        let lock = lock_var();
-        lock.set(&root);
+        // let lock = lock_var();
+        // lock.set(&root);
         env::set_var("TESTING_FS_ROOT", &root);
         let pg_id = PackageIdent::new("testing", "test", Some("1.0.0"), Some("20170712000000"));
 

--- a/components/common/src/templating/mod.rs
+++ b/components/common/src/templating/mod.rs
@@ -119,6 +119,7 @@ mod test {
                              FS_ROOT_PATH},
                         package::PackageIdent},
                 templating::test_helpers::*};
+    use crate::{locked_env_var};
     use serde_json;
     use std::{collections::BTreeMap,
               env,
@@ -352,11 +353,15 @@ test: something"#
         assert_eq!(each_alive_render, each_if_render);
     }
 
+    locked_env_var!(TESTING_FS_ROOT, lock_var);
+
     #[test]
     fn render_package_install() {
         let root = TempDir::new().expect("create temp dir").into_path();
         env::set_var(fs::FS_ROOT_ENVVAR, &root);
         // Override the default / filesystem root for this test
+        let lock = lock_var();
+        lock.set(&root);
         env::set_var("TESTING_FS_ROOT", &root);
         let pg_id = PackageIdent::new("testing", "test", Some("1.0.0"), Some("20170712000000"));
 

--- a/test/run_cargo_test.sh
+++ b/test/run_cargo_test.sh
@@ -29,6 +29,7 @@ sudo chown -R buildkite-agent /home/buildkite-agent
 sudo hab pkg install core/rust
 
 rust_path=$(hab pkg path core/rust)
+export PATH=$rust_path/bin:$PATH
 
 component=${1?component argument required}
 cargo_test_command="$rust_path/bin/cargo test ${features_string} -- --nocapture ${test_options:-}"

--- a/test/run_cargo_test.sh
+++ b/test/run_cargo_test.sh
@@ -19,15 +19,21 @@ done
 # set the features string if needed
 [ -z "${features:-}" ] && features_string="" || features_string="--features ${features}"
 
-component=${1?component argument required}
-cargo_test_command="cargo test ${features_string} -- --nocapture ${test_options:-}"
-
-# TODO: fix this upstream so it's already on the path and set up
-export RUSTUP_HOME=/opt/rust
-export CARGO_HOME=/home/buildkite-agent/.cargo
-export PATH=/opt/rust/bin:$PATH
+# # TODO: fix this upstream so it's already on the path and set up
+# export RUSTUP_HOME=/opt/rust
+# export CARGO_HOME=/home/buildkite-agent/.cargo
+# export PATH=/opt/rust/bin:$PATH
 # TODO: fix this upstream, it looks like it's not saving correctly.
 sudo chown -R buildkite-agent /home/buildkite-agent
+
+sudo hab pkg install core/rust
+
+rust_path=$(hab pkg path core/rust)
+
+component=${1?component argument required}
+cargo_test_command="$rust_path/bin/cargo test ${features_string} -- --nocapture ${test_options:-}"
+
+
 
 # TODO: these should be in a shared script?
 sudo hab pkg install core/bzip2
@@ -54,6 +60,9 @@ LIBRARY_PATH="$(hab pkg path core/bzip2)/lib:$(hab pkg path core/libsodium)/lib:
 # setup pkgconfig so the libarchive crate can use pkg-config to fine bzip2 and xz at *build* time
 export PKG_CONFIG_PATH
 PKG_CONFIG_PATH="$(hab pkg path core/libarchive)/lib/pkgconfig:$(hab pkg path core/libsodium)/lib/pkgconfig:$(hab pkg path core/openssl)/lib/pkgconfig"
+
+export TESTING_FS_ROOT
+TESTING_FS_ROOT=/tmp/foo
 
 echo "--- Running cargo test on $component with command: '$cargo_test_command'"
 cd "components/$component"

--- a/test/run_cargo_test.sh
+++ b/test/run_cargo_test.sh
@@ -26,13 +26,15 @@ done
 # TODO: fix this upstream, it looks like it's not saving correctly.
 sudo chown -R buildkite-agent /home/buildkite-agent
 
-sudo hab pkg install core/rust
+sudo rm -rf /opt/rust
 
-rust_path=$(hab pkg path core/rust)
-export PATH=$rust_path/bin:$PATH
+sudo hab pkg install core/rust --binlink
+
+# rust_path=$(hab pkg path core/rust)
+# export PATH=$rust_path/bin:$PATH
 
 component=${1?component argument required}
-cargo_test_command="$rust_path/bin/cargo test ${features_string} -- --nocapture ${test_options:-}"
+cargo_test_command="cargo test ${features_string} -- --nocapture ${test_options:-}"
 
 
 
@@ -64,6 +66,8 @@ PKG_CONFIG_PATH="$(hab pkg path core/libarchive)/lib/pkgconfig:$(hab pkg path co
 
 export TESTING_FS_ROOT
 TESTING_FS_ROOT=/tmp/foo
+
+which cargo
 
 echo "--- Running cargo test on $component with command: '$cargo_test_command'"
 cd "components/$component"

--- a/test/run_cargo_test.sh
+++ b/test/run_cargo_test.sh
@@ -37,6 +37,7 @@ sudo hab pkg install core/openssl
 sudo hab pkg install core/xz
 sudo hab pkg install core/zeromq
 sudo hab pkg install core/protobuf --binlink
+
 export SODIUM_STATIC=true # so the libarchive crate links to sodium statically
 export LIBARCHIVE_STATIC=true # so the libarchive crate *builds* statically
 export OPENSSL_DIR # so the openssl crate knows what to build against
@@ -54,9 +55,6 @@ LIBRARY_PATH="$(hab pkg path core/bzip2)/lib:$(hab pkg path core/libsodium)/lib:
 export PKG_CONFIG_PATH
 PKG_CONFIG_PATH="$(hab pkg path core/libarchive)/lib/pkgconfig:$(hab pkg path core/libsodium)/lib/pkgconfig:$(hab pkg path core/openssl)/lib/pkgconfig"
 
-# Set testing filesystem root
-export TESTING_FS_ROOT
-TESTING_FS_ROOT=$(mktemp -d /tmp/testing-fs-root-XXXXXX)
 echo "--- Running cargo test on $component with command: '$cargo_test_command'"
 cd "components/$component"
 $cargo_test_command


### PR DESCRIPTION
Rather than run all the tests in a seperate FS_ROOT, which can cause pathing and other issues,
run tests normally, except for the one test that needs to lay down a template file and verify
it. This seems like a reasonable use of TESTING_FS_ROOT.

Signed-off-by: Scott Hain <shain@chef.io>