### PR TITLE
Check for missing cache key path when entering dockerized studio

### DIFF
--- a/components/hab/src/command/studio/docker.rs
+++ b/components/hab/src/command/studio/docker.rs
@@ -57,13 +57,11 @@ pub fn start_docker_studio(_ui: &mut UI, args: &[OsString]) -> Result<()> {
         Err(_) => cache_key_path(None::<PathBuf>),
     };
     if !local_cache_key_path.exists() {
-        return Err(Error::FileNotFound(
-            format!(
-                "{}\nRun `hab setup` to create an origin or \
-                use `hab origin key` to configure your keys.",
-                local_cache_key_path.display()
-            )
-        ));
+        return Err(Error::FileNotFound(format!("{}\nRun `hab setup` to \
+                                                create an origin or use \
+                                                `hab origin key` to \
+                                                configure your keys.",
+                                               local_cache_key_path.display())));
     }
 
     let mut volumes = vec![format!("{}:{}{}",

--- a/components/hab/src/command/studio/docker.rs
+++ b/components/hab/src/command/studio/docker.rs
@@ -61,7 +61,7 @@ pub fn start_docker_studio(_ui: &mut UI, args: &[OsString]) -> Result<()> {
             format!(
                 "{}\nRun `hab setup` to create an origin or \
                 use `hab origin key` to configure your keys.",
-                local_cache_key_path.to_string_lossy().into_owned()
+                local_cache_key_path.display()
             )
         ));
     }
@@ -71,7 +71,7 @@ pub fn start_docker_studio(_ui: &mut UI, args: &[OsString]) -> Result<()> {
                                    mnt_prefix,
                                    "/src"),
                            format!("{}:{}/{}",
-                                   local_cache_key_path.to_string_lossy(),
+                                   local_cache_key_path.display(),
                                    mnt_prefix,
                                    CACHE_KEY_PATH),];
     if let Ok(cache_artifact_path) = henv::var(ARTIFACT_PATH_ENVVAR) {

--- a/components/hab/src/command/studio/docker.rs
+++ b/components/hab/src/command/studio/docker.rs
@@ -50,12 +50,24 @@ pub fn start_docker_studio(_ui: &mut UI, args: &[OsString]) -> Result<()> {
     } else {
         ""
     };
+
+    let local_cache_key_path = default_cache_key_path(None);
+    if !local_cache_key_path.exists() {
+        return Err(Error::FileNotFound(
+            format!(
+                "{}\nRun `hab setup` to create an origin or \
+                use `hab origin key` to configure your keys.",
+                local_cache_key_path.to_string_lossy().into_owned()
+            )
+        ));
+    }
+
     let mut volumes = vec![format!("{}:{}{}",
                                    env::current_dir().unwrap().to_string_lossy(),
                                    mnt_prefix,
                                    "/src"),
                            format!("{}:{}/{}",
-                                   default_cache_key_path(None).to_string_lossy(),
+                                   local_cache_key_path.to_string_lossy(),
                                    mnt_prefix,
                                    CACHE_KEY_PATH),];
     if let Ok(cache_artifact_path) = henv::var(ARTIFACT_PATH_ENVVAR) {

--- a/components/hab/src/command/studio/docker.rs
+++ b/components/hab/src/command/studio/docker.rs
@@ -2,9 +2,10 @@ use crate::{command::studio::enter::ARTIFACT_PATH_ENVVAR,
             common::ui::UI,
             error::{Error,
                     Result},
-            hcore::{crypto::default_cache_key_path,
+            hcore::{crypto::CACHE_KEY_PATH_ENV_VAR,
                     env as henv,
-                    fs::{find_command,
+                    fs::{cache_key_path,
+                         find_command,
                          CACHE_ARTIFACT_PATH,
                          CACHE_KEY_PATH},
                     os::process,
@@ -51,7 +52,10 @@ pub fn start_docker_studio(_ui: &mut UI, args: &[OsString]) -> Result<()> {
         ""
     };
 
-    let local_cache_key_path = default_cache_key_path(None);
+    let local_cache_key_path = match henv::var(CACHE_KEY_PATH_ENV_VAR) {
+        Ok(val) => PathBuf::from(val),
+        Err(_) => cache_key_path(None::<PathBuf>),
+    };
     if !local_cache_key_path.exists() {
         return Err(Error::FileNotFound(
             format!(


### PR DESCRIPTION
Resolves https://github.com/habitat-sh/habitat/issues/5025

I ran into issue https://github.com/habitat-sh/habitat/issues/5025 when setting up Habitat on my Windows machine, so I figured I would submit a pull request along the lines of the solution suggested by @mwrock.

`Error::FileNotFound()` felt the closest to this error, but I am happy to switch it to something else or add a new enum element.

I know issue https://github.com/habitat-sh/habitat/issues/6314 also exists which intends to touch this code, but from what I can tell, a check would still be good here even if the way the path arrives in this method changes.

Lastly, I had started writing a test for this, but noticed the verification pipeline does not run any tests for studio and only checks to ensure it builds. It looks like I'd have to change the pipeline in order for any tests I write to be run, and I don't know what you all think about that.

Edit: I forgot to note that I needed to make the change to `build_component.ps1` in order to run the build test locally. The comment above the `pkg build` line made it seem like this change should have been made a little bit ago.