### PR TITLE
Work in progress: studio CLI parsing in rust

### DIFF
--- a/components/common/src/cli.rs
+++ b/components/common/src/cli.rs
@@ -30,9 +30,6 @@ lazy_static! {
     pub static ref GOSSIP_DEFAULT_ADDR: String =
         { format!("{}:{}", GOSSIP_DEFAULT_IP, GOSSIP_DEFAULT_PORT) };
 }
-pub const GOSSIP_LISTEN_ADDRESS_ENVVAR: &str = "HAB_LISTEN_GOSSIP";
-pub const RING_ENVVAR: &str = "HAB_RING";
-pub const RING_KEY_ENVVAR: &str = "HAB_RING_KEY";
 
 pub const LISTEN_HTTP_DEFAULT_PORT: u16 = 9631;
 pub const LISTEN_HTTP_DEFAULT_IP: &str = "0.0.0.0";
@@ -40,7 +37,6 @@ lazy_static! {
     pub static ref LISTEN_HTTP_DEFAULT_ADDR: String =
         { format!("{}:{}", LISTEN_HTTP_DEFAULT_IP, LISTEN_HTTP_DEFAULT_PORT) };
 }
-pub const LISTEN_HTTP_ADDRESS_ENVVAR: &str = "HAB_LISTEN_HTTP";
 
 const SYSTEMDRIVE_ENVVAR: &str = "SYSTEMDRIVE";
 
@@ -71,7 +67,36 @@ lazy_static! {
     };
 }
 
-pub const BINLINK_DIR_ENVVAR: &str = "HAB_BINLINK_DIR";
+/// The environment variables used in CLI arg overrides
+// TODO: Collect the rest of the *_ENVVAR values here
+pub mod env_var {
+    pub const BINLINK_DIR: &str = "HAB_BINLINK_DIR";
+    pub const CACHE_KEY_PATH: &str = "HAB_CACHE_KEY_PATH"; // TODO: Remove duplicate habitat_core::crypto::CACHE_KEY_PATH_ENV_VAR
+    pub const GLYPH_STYLE: &str = "HAB_GLYPH_STYLE";
+    pub const GOSSIP_LISTEN_ADDRESS: &str = "HAB_LISTEN_GOSSIP";
+    pub const LISTEN_HTTP_ADDRESS: &str = "HAB_LISTEN_HTTP";
+    pub const NONINTERACTIVE: &str = "HAB_NONINTERACTIVE";
+    pub const NOCOLORING: &str = "HAB_NOCOLORING";
+    pub const NOSTUDIORC: &str = "HAB_STUDIO_NOSTUDIORC";
+    pub const ORIGIN: &str = "HAB_ORIGIN";
+    pub const ORIGIN_KEYS: &str = "HAB_ORIGIN_KEYS";
+    pub const RING: &str = "HAB_RING";
+    pub const RING_KEY: &str = "HAB_RING_KEY";
+    pub const STUDIOS_HOME: &str = "HAB_STUDIOS_HOME";
+    pub const STUDIO_ROOT: &str = "HAB_STUDIO_ROOT";
+    pub const STUDIO_SUP: &str = "HAB_STUDIO_SUP";
+    // These should be deprecated in favor of names of the form "HAB_*"
+    pub const ARTIFACT_PATH: &str = "ARTIFACT_PATH";
+    pub const HTTPS_PROXY: &str = "https_proxy";
+    pub const HTTP_PROXY: &str = "http_proxy";
+    pub const NO_ARTIFACT_PATH: &str = "NO_ARTIFACT_PATH";
+    pub const NO_PROXY: &str = "no_proxy";
+    pub const NO_SRC_PATH: &str = "NO_SRC_PATH";
+    pub const QUIET: &str = "QUIET";
+    pub const STUDIO_TYPE: &str = "STUDIO_TYPE";
+    pub const VERBOSE: &str = "VERBOSE";
+    // End to deprecate
+}
 
 /// Default Binlink Dir
 #[cfg(target_os = "windows")]
@@ -80,6 +105,8 @@ pub const DEFAULT_BINLINK_DIR: &str = "/hab/bin";
 pub const DEFAULT_BINLINK_DIR: &str = "/bin";
 #[cfg(target_os = "macos")]
 pub const DEFAULT_BINLINK_DIR: &str = "/usr/local/bin";
+
+pub const CACHE_KEY_PATH_ARG: &str = "cache-key-path";
 
 /// We require the value at the clap layer (see cli::arg_cache_key_path),
 /// so we can safely unwrap, but we need some additional logic to calculate

--- a/components/common/src/ui.rs
+++ b/components/common/src/ui.rs
@@ -12,6 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use self::tty::StdStream;
+use crate::{api_client::DisplayProgress,
+            cli::env_var,
+            error::{Error,
+                    Result}};
+use pbr;
 use std::{env,
           fmt,
           fs::{self,
@@ -25,25 +31,12 @@ use std::{env,
           process::{self,
                     Command},
           str::FromStr};
-use uuid::Uuid;
-
-use crate::api_client::DisplayProgress;
-use pbr;
 use termcolor::{self,
                 ColorChoice,
                 ColorSpec,
                 StandardStream,
                 WriteColor};
-
-use self::tty::StdStream;
-use crate::error::{Error,
-                   Result};
-
-pub const NONINTERACTIVE_ENVVAR: &str = "HAB_NONINTERACTIVE";
-
-pub const NOCOLORING_ENVVAR: &str = "HAB_NOCOLORING";
-
-pub const GLYPH_STYLE_ENVVAR: &str = "HAB_GLYPH_STYLE";
+use uuid::Uuid;
 
 #[derive(Clone, Copy)]
 pub enum Color {
@@ -128,7 +121,7 @@ pub enum Glyph {
 
 impl Glyph {
     pub fn to_str(&self) -> &str {
-        let style = if let Ok(s) = env::var(GLYPH_STYLE_ENVVAR) {
+        let style = if let Ok(s) = env::var(env_var::GLYPH_STYLE) {
             match GlyphStyle::from_str(&s) {
                 Ok(style) => style,
                 Err(e) => {
@@ -431,7 +424,7 @@ impl UI {
 
     /// Creates a new default `UI` with a coloring strategy and tty hinting.
     pub fn default_with_env() -> Self {
-        let isatty = if env::var(NONINTERACTIVE_ENVVAR)
+        let isatty = if env::var(env_var::NONINTERACTIVE)
             // Keep string boolean for backwards-compatibility
             .map(|val| val == "1" || val == "true")
             .unwrap_or(false)
@@ -440,8 +433,8 @@ impl UI {
         } else {
             None
         };
-        let coloring = if env::var(NOCOLORING_ENVVAR).map(|val| val == "1" || val == "true")
-                                                     .unwrap_or(false)
+        let coloring = if env::var(env_var::NOCOLORING).map(|val| val == "1" || val == "true")
+                                                       .unwrap_or(false)
         {
             ColorChoice::Never
         } else {

--- a/components/hab/src/command/cli/setup.rs
+++ b/components/hab/src/command/cli/setup.rs
@@ -13,11 +13,6 @@
 // limitations under the License.
 
 #[cfg(windows)]
-use std::env;
-use std::{path::Path,
-          result};
-
-#[cfg(windows)]
 use crate::common::cli::{DEFAULT_BINLINK_DIR,
                          FS_ROOT};
 use crate::{common::ui::{UIReader,
@@ -27,8 +22,13 @@ use crate::{common::ui::{UIReader,
                     env as henv,
                     package::ident,
                     Error::InvalidOrigin}};
+use habitat_common::cli::env_var;
+#[cfg(windows)]
+use std::env;
 #[cfg(windows)]
 use std::ptr;
+use std::{path::Path,
+          result};
 use url::Url;
 #[cfg(windows)]
 use widestring::WideCString;
@@ -52,8 +52,7 @@ use crate::{analytics,
             error::Result,
             AUTH_TOKEN_ENVVAR,
             BLDR_URL_ENVVAR,
-            CTL_SECRET_ENVVAR,
-            ORIGIN_ENVVAR};
+            CTL_SECRET_ENVVAR};
 
 pub fn start(ui: &mut UI, cache_path: &Path, analytics_path: &Path) -> Result<()> {
     let mut generated_origin = false;
@@ -278,7 +277,10 @@ fn prompt_origin(ui: &mut UI) -> Result<String> {
                              &o))?;
             Some(o)
         }
-        None => henv::var(ORIGIN_ENVVAR).or_else(|_| henv::var("USER")).ok(),
+        None => {
+            henv::var(env_var::ORIGIN).or_else(|_| henv::var("USER"))
+                                      .ok()
+        }
     };
     Ok(ui.prompt_ask("Default origin name", default.as_ref().map(|x| &**x))?)
 }

--- a/components/hab/src/command/pkg/build.rs
+++ b/components/hab/src/command/pkg/build.rs
@@ -12,16 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::ffi::OsString;
-
-use crate::common::ui::UI;
-
 use crate::{command::studio,
+            common::ui::UI,
             error::Result};
+use std::{ffi::OsString,
+          path::Path};
 
 #[allow(clippy::too_many_arguments)]
 pub fn start(ui: &mut UI,
              plan_context: &str,
+             cache_key_path: &Path,
              root: Option<&str>,
              src: Option<&str>,
              keys: Option<&str>,
@@ -53,5 +53,5 @@ pub fn start(ui: &mut UI,
     if studio::native_studio_support() && docker {
         args.push("-D".into());
     }
-    studio::enter::start(ui, &args)
+    studio::enter::start(ui, cache_key_path, &args)
 }

--- a/components/hab/src/command/studio/docker.rs
+++ b/components/hab/src/command/studio/docker.rs
@@ -12,6 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::{common::cli::env_var,
+            error::{Error,
+                    Result},
+            hcore::{env as henv,
+                    fs::{find_command,
+                         CACHE_ARTIFACT_PATH,
+                         CACHE_KEY_PATH},
+                    os::process,
+                    package::target},
+            VERSION};
 use std::{env,
           ffi::{OsStr,
                 OsString},
@@ -19,20 +29,6 @@ use std::{env,
                  PathBuf},
           process::{Command,
                     Stdio}};
-
-use crate::{command::studio::enter::ARTIFACT_PATH_ENVVAR,
-            common::ui::UI,
-            hcore::{crypto::default_cache_key_path,
-                    env as henv,
-                    fs::{find_command,
-                         CACHE_ARTIFACT_PATH,
-                         CACHE_KEY_PATH},
-                    os::process,
-                    package::target}};
-
-use crate::{error::{Error,
-                    Result},
-            VERSION};
 
 const DOCKER_CMD: &str = "docker";
 const DOCKER_CMD_ENVVAR: &str = "HAB_DOCKER_BINARY";
@@ -44,7 +40,7 @@ const DOCKER_OPTS_ENVVAR: &str = "HAB_DOCKER_OPTS";
 const DOCKER_SOCKET: &str = "/var/run/docker.sock";
 const HAB_STUDIO_SECRET: &str = "HAB_STUDIO_SECRET_";
 
-pub fn start_docker_studio(_ui: &mut UI, args: &[OsString]) -> Result<()> {
+pub fn start_docker_studio(cache_key_path: &Path, args: &[OsString]) -> Result<()> {
     let mut args = args.to_vec();
     if args.get(0) == Some(&OsString::from("rm")) {
         return Err(Error::CannotRemoveDockerStudio);
@@ -69,10 +65,10 @@ pub fn start_docker_studio(_ui: &mut UI, args: &[OsString]) -> Result<()> {
                                    mnt_prefix,
                                    "/src"),
                            format!("{}:{}/{}",
-                                   default_cache_key_path(None).to_string_lossy(),
+                                   cache_key_path.to_string_lossy(),
                                    mnt_prefix,
                                    CACHE_KEY_PATH),];
-    if let Ok(cache_artifact_path) = henv::var(ARTIFACT_PATH_ENVVAR) {
+    if let Ok(cache_artifact_path) = henv::var(env_var::ARTIFACT_PATH) {
         volumes.push(format!("{}:{}/{}",
                              cache_artifact_path, mnt_prefix, CACHE_ARTIFACT_PATH));
     }

--- a/components/hab/src/error.rs
+++ b/components/hab/src/error.rs
@@ -12,6 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::{api_client,
+            common,
+            hcore,
+            protocol::net,
+            sup_client::SrvClientError};
+use handlebars;
 use std::{env,
           error,
           ffi,
@@ -21,13 +27,6 @@ use std::{env,
           path::{self,
                  PathBuf},
           result};
-
-use crate::{api_client,
-            common,
-            hcore,
-            protocol::net,
-            sup_client::SrvClientError};
-use handlebars;
 use toml;
 
 pub type Result<T> = result::Result<T, Error>;

--- a/components/hab/src/lib.rs
+++ b/components/hab/src/lib.rs
@@ -56,7 +56,6 @@ pub mod scaffolding;
 pub const PRODUCT: &str = "hab";
 pub const VERSION: &str = include_str!(concat!(env!("OUT_DIR"), "/VERSION"));
 pub const CTL_SECRET_ENVVAR: &str = "HAB_CTL_SECRET";
-pub const ORIGIN_ENVVAR: &str = "HAB_ORIGIN";
 pub const BLDR_URL_ENVVAR: &str = "HAB_BLDR_URL";
 
 pub use crate::hcore::AUTH_TOKEN_ENVVAR;

--- a/components/studio/bin/hab-studio.ps1
+++ b/components/studio/bin/hab-studio.ps1
@@ -68,8 +68,6 @@ COMMON FLAGS:
     -q  Prints less output for better use in scripts
     -v  Prints more verbose output
     -D  Use a Docker Studio instead of a native Studio
-DEPRECATED FLAG:
-    -w  Use a local Windows studio instead of a Docker Studio
 
 COMMON OPTIONS:
     -k <HAB_ORIGIN_KEYS>  Installs secret origin keys (default:\$HAB_ORIGIN )

--- a/components/sup/src/config.rs
+++ b/components/sup/src/config.rs
@@ -20,9 +20,9 @@
 //!
 //! See the [Config](struct.Config.html) struct for the specific options available.
 
-use habitat_common::cli::{GOSSIP_DEFAULT_IP,
-                          GOSSIP_DEFAULT_PORT,
-                          GOSSIP_LISTEN_ADDRESS_ENVVAR};
+use habitat_common::cli::{env_var,
+                          GOSSIP_DEFAULT_IP,
+                          GOSSIP_DEFAULT_PORT};
 use habitat_core::env::Config as EnvConfig;
 use std::{fmt,
           io,
@@ -74,7 +74,7 @@ impl Default for GossipListenAddr {
 }
 
 impl EnvConfig for GossipListenAddr {
-    const ENVVAR: &'static str = GOSSIP_LISTEN_ADDRESS_ENVVAR;
+    const ENVVAR: &'static str = env_var::GOSSIP_LISTEN_ADDRESS;
 }
 
 impl Deref for GossipListenAddr {

--- a/components/sup/src/http_gateway.rs
+++ b/components/sup/src/http_gateway.rs
@@ -32,7 +32,7 @@ use actix_web::{http::{self,
                 HttpResponse,
                 Path,
                 Request};
-use habitat_common::{cli::{LISTEN_HTTP_ADDRESS_ENVVAR,
+use habitat_common::{cli::{env_var,
                            LISTEN_HTTP_DEFAULT_IP,
                            LISTEN_HTTP_DEFAULT_PORT},
                      templating::hooks};
@@ -106,7 +106,7 @@ impl Default for ListenAddr {
 }
 
 impl EnvConfig for ListenAddr {
-    const ENVVAR: &'static str = LISTEN_HTTP_ADDRESS_ENVVAR;
+    const ENVVAR: &'static str = env_var::LISTEN_HTTP_ADDRESS;
 }
 
 impl Deref for ListenAddr {

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -45,14 +45,14 @@ use crate::sup::{cli::cli,
                  util};
 use clap::ArgMatches;
 use habitat_common::{cli::{cache_key_path_from_matches,
+                           env_var,
                            GOSSIP_DEFAULT_PORT},
                      command::package::install::InstallSource,
                      output::{self,
                               OutputFormat,
                               OutputVerbosity},
                      outputln,
-                     ui::{NONINTERACTIVE_ENVVAR,
-                          UI}};
+                     ui::UI};
 #[cfg(windows)]
 use habitat_core::crypto::dpapi::encrypt;
 use habitat_core::{crypto::{self,
@@ -493,8 +493,8 @@ fn set_supervisor_logging_options(m: &ArgMatches) {
 // function wouldn't be necessary. In the meantime, though, it'll keep
 // the scope of change contained.
 fn ui() -> UI {
-    let isatty = if env::var(NONINTERACTIVE_ENVVAR).map(|val| val == "1" || val == "true")
-                                                   .unwrap_or(false)
+    let isatty = if env::var(env_var::NONINTERACTIVE).map(|val| val == "1" || val == "true")
+                                                     .unwrap_or(false)
     {
         Some(false)
     } else {


### PR DESCRIPTION
See https://github.com/habitat-sh/habitat/issues/6314

To fully eliminate `default_cache_key_path`, we need to have proper CLI arguments for each command that needs a key cache path. That allows the env var override to be checked appropriately.

Unfortunately, the studio (in the docker case) needs this value, but the CLI parsing for the `hab studio …` commands is mostly deferred to `hab-studio.{sh,ps1}`, meaning either we need to add the validation in the scripts, do it ad-hoc in rust (not clap) in `studio::enter::start`, or pull the CLI parsing into our standard clap-based approach. The last option seems the best, so this is a start down that road.

Still to do are implementing the rest of the `hab studio …` subcommands in clap and possibly further refactoring of `studio::enter::start` to completely remove the `args: &[OsString]` argument. Finally, it likely makes sense to completely remove the argument parsing code from the `hab-studio` scripts once this is in place, but that approach needs more thought first.

Refactoring out the rest of the ad-hoc arg parsing in `exec_subcommand_if_called` is probably a good idea, but that can be in a follow-up PR.

For comparison, see how `hab studio --help` renders with the [new, clap-based approach](https://github.com/habitat-sh/habitat/files/3010744/clap.txt) versus [the old shell-based one](https://github.com/habitat-sh/habitat/files/3010749/clap.txt).