### PR TITLE
Revert "remove old content" feature

### DIFF
--- a/components/sup/src/manager/service/mod.rs
+++ b/components/sup/src/manager/service/mod.rs
@@ -282,9 +282,7 @@ impl Service {
     /// Create the service path for this package.
     pub fn create_svc_path(&self) -> Result<()> {
         debug!("{}, Creating svc paths", self.service_group);
-        let svc_dir = SvcDir::new(&self.pkg.name, &self.pkg.svc_user, &self.pkg.svc_group);
-        svc_dir.create()?;
-        svc_dir.purge_templated_content()?;
+        SvcDir::new(&self.pkg.name, &self.pkg.svc_user, &self.pkg.svc_group).create()?;
         Ok(())
     }
 


### PR DESCRIPTION
This reverts PR #6269, which attempted to address issue #4925.

This reverts commit bad5824a9bd741f137aa1a98a24c6993f420c862, reversing
changes made to cd011db827c6e1054dfeef4523fc23ebbfb73d2b.

Sending a `SIGHUP` signal to either the Launcher or Supervisor
processes will allow the Supervisor to restart itself, while leaving
the supervised processes intact and unaffected.

The reverted change breaks this functionality by effectively causing
all supervised services to restart anyway once the Supervisor comes
back up again and rewrites the templated content.

This would also happen when a Supervisor restarts as a result of
automatically updating itself.

We're reverting for the time being, pending a deeper rethinking of how
the Supervisor "reattaches" to existing processes.

Signed-off-by: Christopher Maier <cmaier@chef.io>