### PR TITLE
Migrate to habitat rust rather than system rust

### DIFF
--- a/test/run_cargo_test.sh
+++ b/test/run_cargo_test.sh
@@ -22,10 +22,6 @@ done
 component=${1?component argument required}
 cargo_test_command="cargo test ${features_string} -- --nocapture ${test_options:-}"
 
-# TODO: fix this upstream so it's already on the path and set up
-export RUSTUP_HOME=/opt/rust
-export CARGO_HOME=/home/buildkite-agent/.cargo
-export PATH=/opt/rust/bin:$PATH
 # TODO: fix this upstream, it looks like it's not saving correctly.
 sudo chown -R buildkite-agent /home/buildkite-agent
 
@@ -37,6 +33,7 @@ sudo hab pkg install core/openssl
 sudo hab pkg install core/xz
 sudo hab pkg install core/zeromq
 sudo hab pkg install core/protobuf --binlink
+sudo hab pkg install core/rust --binlink
 export SODIUM_STATIC=true # so the libarchive crate links to sodium statically
 export LIBARCHIVE_STATIC=true # so the libarchive crate *builds* statically
 export OPENSSL_DIR # so the openssl crate knows what to build against


### PR DESCRIPTION
Signed-off-by: Scott Hain <shain@chef.io>

This is step 1 and will replace https://github.com/habitat-sh/habitat/pull/6338

After digging through with @baumanj - it looks like there may be a feature gap that was causing the issues I was seeing when using `TESTING_FS_ROOT` that caused the rabbithole in 6338.

Note - we will still be using the system rust until I remove it from the base build image, which will come shortly.