### PR TITLE
Properly pass CLI args to `hab origin key import`

### DIFF
--- a/components/common/src/cli.rs
+++ b/components/common/src/cli.rs
@@ -86,7 +86,9 @@ pub const DEFAULT_BINLINK_DIR: &str = "/usr/local/bin";
 // the dynamic "default" value if the argument has the default signifier value:
 /// CACHE_KEY_PATH. An empty value can't stand for default since it is invalid.
 pub fn cache_key_path_from_matches(matches: &ArgMatches<'_>) -> PathBuf {
-    match matches.value_of("CACHE_KEY_PATH").unwrap() {
+    match matches.value_of("CACHE_KEY_PATH")
+                 .expect("CACHE_KEY_PATH required")
+    {
         CACHE_KEY_PATH => cache_key_path(Some(&*FS_ROOT)),
         val => PathBuf::from(val),
     }

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -180,7 +180,7 @@ fn start(ui: &mut UI) -> Result<()> {
                         ("download", Some(sc)) => sub_origin_key_download(ui, sc)?,
                         ("export", Some(sc)) => sub_origin_key_export(sc)?,
                         ("generate", Some(sc)) => sub_origin_key_generate(ui, sc)?,
-                        ("import", Some(_)) => sub_origin_key_import(ui, m)?,
+                        ("import", Some(sc)) => sub_origin_key_import(ui, sc)?,
                         ("upload", Some(sc)) => sub_origin_key_upload(ui, sc)?,
                         _ => unreachable!(),
                     }
@@ -371,9 +371,9 @@ fn sub_origin_key_generate(ui: &mut UI, m: &ArgMatches<'_>) -> Result<()> {
 
 fn sub_origin_key_import(ui: &mut UI, m: &ArgMatches<'_>) -> Result<()> {
     let mut content = String::new();
-    io::stdin().read_to_string(&mut content)?;
     let cache_key_path = cache_key_path_from_matches(&m);
     init();
+    io::stdin().read_to_string(&mut content)?;
 
     // Trim the content to lose line feeds added by Powershell pipeline
     command::origin::key::import::start(ui, content.trim(), &cache_key_path)
@@ -1248,9 +1248,9 @@ fn sub_ring_key_generate(ui: &mut UI, m: &ArgMatches<'_>) -> Result<()> {
 
 fn sub_ring_key_import(ui: &mut UI, m: &ArgMatches<'_>) -> Result<()> {
     let mut content = String::new();
-    io::stdin().read_to_string(&mut content)?;
     let cache_key_path = cache_key_path_from_matches(&m);
     init();
+    io::stdin().read_to_string(&mut content)?;
 
     // Trim the content to lose line feeds added by Powershell pipeline
     command::ring::key::import::start(ui, content.trim(), &cache_key_path)


### PR DESCRIPTION
The argument matches for the `key` supercommand rather than the `import` subcommand were passed to sub_origin_key_import, causing the unwrap of the required `CACHE_KEY_PATH` argument to fail.

Fix this, plus change the unwrap to an expect (this is best even when you don't expect there's any way to fail) and move the read of stdinto after the arg parsing so this can be more easily triggered.
