### PR TITLE
Use curl to upload packages rather than pkg upload

### DIFF
--- a/.buildkite/scripts/build_component.sh
+++ b/.buildkite/scripts/build_component.sh
@@ -79,14 +79,20 @@ echo "--- :habicat: Uploading ${pkg_ident} to Builder in the '${channel}' channe
 #     --channel="${channel}" \
 #     --auth="${HAB_AUTH_TOKEN}" \
 #     "results/${pkg_artifact}"
+#
+# ${hab_binary} pkg promote \
+#     --auth="${HAB_AUTH_TOKEN}" \
+#     "${pkg_ident}" "${channel}" "${pkg_target}"
 
 curl -v -X POST \
     -H "Accept: application/json" \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer $HAB_AUTH_TOKEN" \
     --data-binary "@results/${pkg_artifact}.hart" \
-    "http://bldr.habitat.sh:9636/v1/depot/pkgs/${pkg_ident}?checksum=${pkg_blake2bsum:?}&target=${pkg_target}"
+    "http://bldr.habitat.sh/v1/depot/pkgs/${pkg_ident}?checksum=${pkg_blake2bsum:?}&target=${pkg_target}"
 
-${hab_binary} pkg promote \
-    --auth="${HAB_AUTH_TOKEN}" \
-    "${pkg_ident}" "${channel}"
+curl -v -X PUT \
+    -H "Accept: application/json" \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $HAB_AUTH_TOKEN" \
+    "http://bldr.habitat.sh/v1/depot/channels/${pkg_origin:?}/pkgs/${pkg_name:?}/${pkg_version:?}/${pkg_release}/promote?&target=${pkg_target}"

--- a/.buildkite/scripts/build_component.sh
+++ b/.buildkite/scripts/build_component.sh
@@ -84,4 +84,5 @@ curl -v -X POST \
     -H "Accept: application/json" \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer $HAB_AUTH_TOKEN" \
-    --data-binary "@/hab/cache/artifacts/${pkg_artifact}.hart" "http://bldr.habitat.sh:9636/v1/depot/pkgs/${pkg_ident}\?checksum=${pkg_sha256sum}\?target=${pkg_target}"
+    --data-binary "@results/${pkg_artifact}.hart" \
+    "http://bldr.habitat.sh:9636/v1/depot/pkgs/${pkg_ident}\?checksum=${pkg_sha256sum:?}\&target=${pkg_target}"

--- a/.buildkite/scripts/build_component.sh
+++ b/.buildkite/scripts/build_component.sh
@@ -85,4 +85,4 @@ curl -v -X POST \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer $HAB_AUTH_TOKEN" \
     --data-binary "@results/${pkg_artifact}.hart" \
-    "http://bldr.habitat.sh:9636/v1/depot/pkgs/${pkg_ident}\?checksum=${pkg_sha256sum:?}\&target=${pkg_target}"
+    "http://bldr.habitat.sh:9636/v1/depot/pkgs/${pkg_ident}\?checksum=${pkg_blake2bsum:?}\&target=${pkg_target}"

--- a/.buildkite/scripts/build_component.sh
+++ b/.buildkite/scripts/build_component.sh
@@ -73,7 +73,15 @@ esac
 echo "<br>* ${pkg_ident:?} (${pkg_target:?})" | buildkite-agent annotate --append --context "release-manifest"
 
 echo "--- :habicat: Uploading ${pkg_ident} to Builder in the '${channel}' channel"
-${hab_binary} pkg upload \
-    --channel="${channel}" \
-    --auth="${HAB_AUTH_TOKEN}" \
-    "results/${pkg_artifact}"
+# TODO: after 0.79.0 we can reenable this. We are explicitly using curl to upload
+# due to this bug: https://github.com/habitat-sh/builder/issues/940
+# ${hab_binary} pkg upload \
+#     --channel="${channel}" \
+#     --auth="${HAB_AUTH_TOKEN}" \
+#     "results/${pkg_artifact}"
+
+curl -v -X POST \
+    -H "Accept: application/json" \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $HAB_AUTH_TOKEN" \
+    --data-binary "@/hab/cache/artifacts/${pkg_artifact}.hart" "http://bldr.habitat.sh:9636/v1/depot/pkgs/${pkg_ident}\?checksum=${pkg_sha256sum}\?target=${pkg_target}"

--- a/.buildkite/scripts/build_component.sh
+++ b/.buildkite/scripts/build_component.sh
@@ -85,4 +85,8 @@ curl -v -X POST \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer $HAB_AUTH_TOKEN" \
     --data-binary "@results/${pkg_artifact}.hart" \
-    "http://bldr.habitat.sh:9636/v1/depot/pkgs/${pkg_ident}\?checksum=${pkg_blake2bsum:?}\&target=${pkg_target}"
+    "http://bldr.habitat.sh:9636/v1/depot/pkgs/${pkg_ident}?checksum=${pkg_blake2bsum:?}&target=${pkg_target}"
+
+${hab_binary} pkg promote \
+    --auth="${HAB_AUTH_TOKEN}" \
+    "${pkg_ident}" "${channel}"


### PR DESCRIPTION
Signed-off-by: Scott Hain <shain@chef.io>

this is a temporary fix until https://github.com/habitat-sh/builder/issues/940 gets resolved (which is underway)