### PR TITLE
Consolidate feature flag operations.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -734,14 +734,6 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "features"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "field-offset"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -886,12 +878,10 @@ name = "hab"
 version = "0.0.0"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "features 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat-sup-client 0.0.0",
@@ -1077,6 +1067,7 @@ name = "habitat_common"
 version = "0.0.0"
 dependencies = [
  "bimap 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat_api_client 0.0.0",
@@ -1252,7 +1243,6 @@ version = "0.0.0"
 dependencies = [
  "actix 0.7.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-web 0.7.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "caps 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1260,7 +1250,6 @@ dependencies = [
  "cpu-time 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ctrlc 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "features 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hab 0.0.0",
@@ -3857,7 +3846,6 @@ dependencies = [
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
-"checksum features 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "45d496bf4d9e25b7509388b3ba8abe3af35b78b39f0f32e326253856eb11f5bc"
 "checksum field-offset 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "64e9bc339e426139e02601fa69d101e96a92aee71b58bc01697ec2a63a5c9e68"
 "checksum filetime 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a2df5c1a8c4be27e7707789dc42ae65976e60b394afd293d1419ab915833e646"
 "checksum fixedbitset 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "86d4de0081402f5e88cdac65c8dcdcc73118c1a7a465e2a05f0da05843a8ea33"

--- a/components/common/Cargo.toml
+++ b/components/common/Cargo.toml
@@ -8,6 +8,7 @@ workspace = "../../"
 
 [dependencies]
 bimap = "*"
+bitflags = "*"
 clap = { version = "*", features = [ "suggestions", "color", "unstable" ] }
 glob = "*"
 # The handlebars crate has a few issues that require us to lock at 0.28.3

--- a/components/common/src/lib.rs
+++ b/components/common/src/lib.rs
@@ -12,8 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::ui::{UIWriter,
+                UI};
 use habitat_api_client as api_client;
 use habitat_core as hcore;
+use lazy_static::lazy_static;
+use std::{collections::HashMap,
+          env,
+          iter::FromIterator};
+
 extern crate json;
 #[macro_use]
 extern crate log;
@@ -43,7 +50,7 @@ pub mod util;
 
 lazy_static::lazy_static! {
     pub static ref PROGRAM_NAME: String = {
-        match std::env::current_exe() {
+        match env::current_exe() {
             Ok(path) => path.file_stem().and_then(|p| p.to_str()).unwrap().to_string(),
             Err(e) => {
                 error!("Error getting path of current_exe: {}", e);
@@ -51,4 +58,100 @@ lazy_static::lazy_static! {
             }
         }
     };
+}
+
+// TODO (CM): It would be nice to come up with a way to more
+// programmatically manage these flags. It's a bit of a pain to define
+// the flag, and then define the environment variables
+// separately. Nothing statically guarantees that you've specified an
+// variable for a flag.
+
+// TODO (CM): It'd be great to have a built-in way to document them,
+// too.
+
+// TODO (CM): Part of that documentation might be *when* a flag was
+// added. In general, long-lived flags are a code-smell.
+
+// TODO (CM): It may also be useful to break out features by area of
+// concern. We can have any number of bitflags-generated structs.
+
+bitflags::bitflags! {
+    /// All the feature flags that are recogized by Habitat.
+    ///
+    /// In general, feature flags are enabled by setting the corresponding
+    /// environment variable.
+    ///
+    /// Your binary should call `FeatureFlag::from_env` to get a set
+    /// of flags to use.
+    ///
+    /// To add a new feature flag, you will need to add the bit mask
+    /// constant here, as well as a mapping from the feature to the
+    /// environment variable to which it corresponds in the `ENV_VARS`
+    /// map below.
+    pub struct FeatureFlag: u32 {
+        const LIST            = 0b0000_0000_0001;
+        const TEST_EXIT       = 0b0000_0000_0010;
+        const TEST_BOOT_FAIL  = 0b0000_0000_0100;
+        const REDACT_HTTP     = 0b0000_0000_1000;
+        const IGNORE_SIGNALS  = 0b0000_0001_0000;
+        const INSTALL_HOOK    = 0b0000_0010_0000;
+        const OFFLINE_INSTALL = 0b0000_0100_0000;
+        const IGNORE_LOCAL    = 0b0000_1000_0000;
+        const EVENT_STREAM    = 0b0001_0000_0000;
+    }
+}
+
+lazy_static! {
+    static ref ENV_VARS: HashMap<FeatureFlag, &'static str> = {
+        let mapping = vec![(FeatureFlag::LIST, "HAB_FEAT_LIST"),
+                           (FeatureFlag::TEST_EXIT, "HAB_FEAT_TEST_EXIT"),
+                           (FeatureFlag::TEST_BOOT_FAIL, "HAB_FEAT_BOOT_FAIL"),
+                           (FeatureFlag::REDACT_HTTP, "HAB_FEAT_REDACT_HTTP"),
+                           (FeatureFlag::IGNORE_SIGNALS, "HAB_FEAT_IGNORE_SIGNALS"),
+                           (FeatureFlag::INSTALL_HOOK, "HAB_FEAT_INSTALL_HOOK"),
+                           (FeatureFlag::OFFLINE_INSTALL, "HAB_FEAT_OFFLINE_INSTALL"),
+                           (FeatureFlag::IGNORE_LOCAL, "HAB_FEAT_IGNORE_LOCAL"),
+                           (FeatureFlag::EVENT_STREAM, "HAB_FEAT_EVENT_STREAM")];
+        HashMap::from_iter(mapping)
+    };
+}
+
+impl FeatureFlag {
+    /// If the environment variable for a flag is set to _anything_ but
+    /// the empty string, it is activated.
+    pub fn from_env(ui: &mut UI) -> Self {
+        let mut flags = FeatureFlag::empty();
+
+        for (feature, env_var) in ENV_VARS.iter() {
+            if let Some(val) = env::var_os(env_var) {
+                if !val.is_empty() {
+                    flags.insert(*feature);
+                    ui.warn(&format!("Enabling feature: {:?}", feature))
+                      .unwrap();
+                }
+            }
+        }
+
+        // TODO (CM): Once the other TODOs above are done (especially the
+        // documentation bits), it would be nice to extract this logic
+        // into an actual discoverable CLI subcommand; it's a little weird
+        // that you have to know how to enable a feature flag before you
+        // can even find out that there *are* feature flags to enable.
+        //
+        // There's no reason why "list feature flags" should itself be a
+        // feature-flag.
+        if flags.contains(FeatureFlag::LIST) {
+            ui.warn("Listing feature flags environment variables:")
+              .unwrap();
+            for (feature, env_var) in ENV_VARS.iter() {
+                ui.warn(&format!("  * {:?}: {}={:?}",
+                                 feature,
+                                 env_var,
+                                 env::var_os(env_var).unwrap_or_default()))
+                  .unwrap();
+            }
+        }
+
+        flags
+    }
 }

--- a/components/hab/Cargo.toml
+++ b/components/hab/Cargo.toml
@@ -11,11 +11,9 @@ name = "hab"
 doc = false
 
 [dependencies]
-bitflags = "*"
 base64 = "*"
 dirs = "*"
 env_logger = "*"
-features = "*"
 futures = "*"
 # Pending upgrade activities in https://github.com/habitat-sh/core/issues/72
 hyper = "0.10"

--- a/components/hab/src/lib.rs
+++ b/components/hab/src/lib.rs
@@ -22,13 +22,7 @@ use habitat_sup_client as sup_client;
 use habitat_sup_protocol as protocol;
 
 #[macro_use]
-extern crate bitflags;
-
-#[macro_use]
 extern crate clap;
-
-#[macro_use]
-extern crate features;
 
 #[macro_use]
 extern crate log;
@@ -60,12 +54,3 @@ pub const ORIGIN_ENVVAR: &str = "HAB_ORIGIN";
 pub const BLDR_URL_ENVVAR: &str = "HAB_BLDR_URL";
 
 pub use crate::hcore::AUTH_TOKEN_ENVVAR;
-
-features! {
-    pub mod feat {
-        const List           = 0b0000_0001,
-        const OfflineInstall = 0b0000_0010,
-        const IgnoreLocal    = 0b0000_0100,
-        const InstallHook    = 0b0000_1000
-    }
-}

--- a/components/sup/Cargo.toml
+++ b/components/sup/Cargo.toml
@@ -25,12 +25,10 @@ bytes = "*"
 # This is temporary, until this is merged to the mainline
 nitox = { git = "https://github.com/YellowInnovation/nitox", branch="feature/nats-server" }
 actix-web = { version = "*", default-features = false, features = [ "rust-tls" ] }
-bitflags = "*"
 byteorder = "*"
 clap = { version = "*", features = [ "suggestions", "color", "unstable" ] }
 cpu-time = "*"
 env_logger = "*"
-features = "*"
 futures = "*"
 glob = "*"
 hab = { path = "../hab" }

--- a/components/sup/src/cli.rs
+++ b/components/sup/src/cli.rs
@@ -1,5 +1,4 @@
 use clap::App;
-
 use hab::cli::sup_commands;
 
 pub fn cli<'a, 'b>() -> App<'a, 'b> { sup_commands() }

--- a/components/sup/src/lib.rs
+++ b/components/sup/src/lib.rs
@@ -39,17 +39,12 @@
 //! * [The Habitat Command Line Reference](command)
 //! * [The Habitat Supervisor Sidecar; http interface to promises](sidecar)
 
-#[macro_use]
-extern crate bitflags;
-
 #[cfg(target_os = "linux")]
 extern crate caps;
 extern crate clap;
 extern crate cpu_time;
 #[cfg(windows)]
 extern crate ctrlc;
-#[macro_use]
-extern crate features;
 #[macro_use]
 extern crate lazy_static;
 #[macro_use]
@@ -103,22 +98,6 @@ pub mod test_helpers;
 pub mod util;
 
 use std::env;
-
-/// List enables printing out the list features which can be dynamically enabled
-/// TestExit enables triggering an abrupt exit to simulate failures
-/// TestBootFail exits with a fatal error before even calling boot()
-/// Search for feat::is_enabled(feat::FeatureName) to learn more
-features! {
-    pub mod feat {
-        const List          = 0b0000_0001,
-        const TestExit      = 0b0000_0010,
-        const TestBootFail  = 0b0000_0100,
-        const RedactHTTP    = 0b0000_1000,
-        const IgnoreSignals = 0b0001_0000,
-        const InstallHook   = 0b0010_0000,
-        const EventStream   = 0b0100_0000
-    }
-}
 
 pub const PRODUCT: &str = "hab-sup";
 pub const VERSION: &str = include_str!(concat!(env!("OUT_DIR"), "/VERSION"));

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -37,7 +37,6 @@ use crate::sup::{cli::cli,
                  error::{Error,
                          Result,
                          SupError},
-                 feat,
                  manager::{Manager,
                            ManagerConfig,
                            TLSConfig,
@@ -52,12 +51,12 @@ use habitat_common::{cli::{cache_key_path_from_matches,
                               OutputVerbosity},
                      outputln,
                      ui::{NONINTERACTIVE_ENVVAR,
-                          UI}};
+                          UI},
+                     FeatureFlag};
 #[cfg(windows)]
 use habitat_core::crypto::dpapi::encrypt;
 use habitat_core::{crypto::{self,
                             SymKey},
-                   env as henv,
                    url::{bldr_url_from_env,
                          default_bldr_url},
                    ChannelIdent};
@@ -92,8 +91,9 @@ static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 fn main() {
     env_logger::init();
-    enable_features_from_env();
-    let result = start();
+    let mut ui = UI::default_with_env();
+    let flags = FeatureFlag::from_env(&mut ui);
+    let result = start(flags);
     let exit_code = match result {
         Ok(_) => 0,
         Err(ref err) => {
@@ -124,8 +124,8 @@ fn boot() -> Option<LauncherCli> {
     }
 }
 
-fn start() -> Result<()> {
-    if feat::is_enabled(feat::TestBootFail) {
+fn start(feature_flags: FeatureFlag) -> Result<()> {
+    if feature_flags.contains(FeatureFlag::TEST_BOOT_FAIL) {
         outputln!("Simulating boot failure");
         return Err(sup_error!(Error::TestBootFail));
     }
@@ -153,7 +153,7 @@ fn start() -> Result<()> {
         ("bash", Some(_)) => sub_bash(),
         ("run", Some(m)) => {
             let launcher = launcher.ok_or(sup_error!(Error::NoLauncher))?;
-            sub_run(m, launcher)
+            sub_run(m, launcher, feature_flags)
         }
         ("sh", Some(_)) => sub_sh(),
         ("term", Some(_)) => sub_term(),
@@ -163,10 +163,10 @@ fn start() -> Result<()> {
 
 fn sub_bash() -> Result<()> { command::shell::bash() }
 
-fn sub_run(m: &ArgMatches, launcher: LauncherCli) -> Result<()> {
+fn sub_run(m: &ArgMatches, launcher: LauncherCli, feature_flags: FeatureFlag) -> Result<()> {
     set_supervisor_logging_options(m);
 
-    let cfg = mgrcfg_from_sup_run_matches(m)?;
+    let cfg = mgrcfg_from_sup_run_matches(m, feature_flags)?;
     let manager = Manager::load(cfg, launcher)?;
 
     // We need to determine if we have an initial service to start
@@ -225,8 +225,11 @@ fn sub_term() -> Result<()> {
 // Internal Implementation Details
 ////////////////////////////////////////////////////////////////////////
 
-fn mgrcfg_from_sup_run_matches(m: &ArgMatches) -> Result<ManagerConfig> {
+fn mgrcfg_from_sup_run_matches(m: &ArgMatches,
+                               feature_flags: FeatureFlag)
+                               -> Result<ManagerConfig> {
     let cache_key_path = cache_key_path_from_matches(m);
+
     let cfg = ManagerConfig {
         auto_update: m.is_present("AUTO_UPDATE"),
         custom_state_path: None, // remove entirely?
@@ -291,6 +294,7 @@ fn mgrcfg_from_sup_run_matches(m: &ArgMatches) -> Result<ManagerConfig> {
                 ca_cert_path,
             }
         }),
+        feature_flags
     };
 
     Ok(cfg)
@@ -444,36 +448,6 @@ fn get_password_from_input(m: &ArgMatches) -> Result<Option<String>> {
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 fn get_password_from_input(_m: &ArgMatches) -> Result<Option<String>> { Ok(None) }
 
-fn enable_features_from_env() {
-    let features = vec![(feat::List, "LIST"),
-                        (feat::TestExit, "TEST_EXIT"),
-                        (feat::TestBootFail, "BOOT_FAIL"),
-                        (feat::RedactHTTP, "REDACT_HTTP"),
-                        (feat::IgnoreSignals, "IGNORE_SIGNALS"),
-                        (feat::InstallHook, "INSTALL_HOOK"),
-                        (feat::EventStream, "EVENT_STREAM"),];
-
-    // If the environment variable for a flag is set to _anything_ but
-    // the empty string, it is activated.
-    for feature in &features {
-        if henv::var(format!("HAB_FEAT_{}", feature.1)).is_ok() {
-            feat::enable(feature.0);
-            outputln!("Enabling feature: {:?}", feature.0);
-        }
-    }
-
-    if feat::is_enabled(feat::List) {
-        outputln!("Listing feature flags environment variables:");
-        for feature in &features {
-            outputln!("     * {:?}: HAB_FEAT_{}={}",
-                      feature.0,
-                      feature.1,
-                      henv::var(format!("HAB_FEAT_{}", feature.1)).unwrap_or_default());
-        }
-        outputln!("The Supervisor will start now, enjoy!");
-    }
-}
-
 fn set_supervisor_logging_options(m: &ArgMatches) {
     if m.is_present("VERBOSE") {
         output::set_verbosity(OutputVerbosity::Verbose);
@@ -532,6 +506,8 @@ mod test {
     use habitat_common::{locked_env_var,
                          types::ListenCtlAddr};
 
+    fn no_feature_flags() -> FeatureFlag { FeatureFlag::empty() }
+
     mod manager_config {
 
         use super::*;
@@ -552,7 +528,8 @@ mod test {
             let (_, sub_matches) = matches.subcommand();
             let sub_matches = sub_matches.expect("Error getting sub command matches");
 
-            mgrcfg_from_sup_run_matches(&sub_matches).expect("Could not get config")
+            mgrcfg_from_sup_run_matches(&sub_matches, no_feature_flags()).expect("Could not get \
+                                                                                  config")
         }
 
         #[test]


### PR DESCRIPTION
Previously, feature flags were defined in both the `hab` and
`habitat_sup` crates. This was problematic because it required far too
much setup in order to create a feature flag.

Additionally, if you wanted to create a feature flag that is mainly
used in the Supervisor, but conditionally adds additional CLI options,
you were out of luck. Because of underlying code, as well as the fact
`hab` and `hab-sup` are entirely separate binaries, the feature flags
enabled in `hab` wouldn't necessarily be enabled in `hab-sup`.

This refactoring moves *all* feature flags into the common
crate. Additionally, we dispense with the use of the `features` crate,
in favor of using the underlying `bitflags` abstraction directly.

This means that we no longer rely on recording which feature flags are
currently enabled in global state, but in immutable data that we
explicitly thread through function calls.

This also means that functionality that differs based on feature flag
state can be more easily unit tested (otherwise, we have to contend
with the sharing of global state, which is always tricky).

Signed-off-by: Christopher Maier <cmaier@chef.io>