### PR TITLE
Add target param to pkg related APIs

### DIFF
--- a/components/builder-api-client/src/lib.rs
+++ b/components/builder-api-client/src/lib.rs
@@ -339,8 +339,7 @@ impl Client {
     /// * Key cannot be found
     /// * Remote Builder is not available
     pub fn schedule_job(&self,
-                        ident: &PackageIdent,
-                        target: PackageTarget,
+                        (ident, target): (&PackageIdent, PackageTarget),
                         package_only: bool,
                         token: &str)
                         -> Result<(String)> {
@@ -372,7 +371,9 @@ impl Client {
     /// # Failures
     ///
     /// * Remote API Server is not available
-    pub fn fetch_rdeps(&self, ident: &PackageIdent, target: PackageTarget) -> Result<Vec<String>> {
+    pub fn fetch_rdeps(&self,
+                       (ident, target): (&PackageIdent, PackageTarget))
+                       -> Result<Vec<String>> {
         debug!("Fetching the reverse dependencies for {}", ident);
 
         let url = format!("rdeps/{}", ident);
@@ -635,8 +636,7 @@ impl Client {
     /// * Remote Builder is not available
     /// * Package does not exist
     pub fn package_channels(&self,
-                            ident: &PackageIdent,
-                            target: PackageTarget,
+                            (ident, target): (&PackageIdent, PackageTarget),
                             token: Option<&str>)
                             -> Result<Vec<String>> {
         if !ident.fully_qualified() {
@@ -791,8 +791,7 @@ impl Client {
     /// * Remote Builder is not available
     /// * File cannot be created and written to
     pub fn fetch_package<D, P>(&self,
-                               ident: &PackageIdent,
-                               target: PackageTarget,
+                               (ident, target): (&PackageIdent, PackageTarget),
                                token: Option<&str>,
                                dst_path: &P,
                                progress: Option<D>)
@@ -828,8 +827,7 @@ impl Client {
     /// * Package cannot be found
     /// * Remote Builder is not available
     pub fn show_package(&self,
-                        package: &PackageIdent,
-                        target: PackageTarget,
+                        (package, target): (&PackageIdent, PackageTarget),
                         channel: &ChannelIdent,
                         token: Option<&str>)
                         -> Result<PackageIdent> {
@@ -953,8 +951,7 @@ impl Client {
     /// * If the package does not qualify for deletion
     /// * Authorization token was not set on client
     pub fn delete_package(&self,
-                          ident: &PackageIdent,
-                          target: PackageTarget,
+                          (ident, target): (&PackageIdent, PackageTarget),
                           token: &str)
                           -> Result<()> {
         let path = package_path(ident);
@@ -986,8 +983,7 @@ impl Client {
     /// * If package does not exist in Builder
     /// * Authorization token was not set on client
     pub fn promote_package(&self,
-                           ident: &PackageIdent,
-                           target: PackageTarget,
+                           (ident, target): (&PackageIdent, PackageTarget),
                            channel: &ChannelIdent,
                            token: &str)
                            -> Result<()> {
@@ -1023,8 +1019,7 @@ impl Client {
     /// * If package does not exist in Builder
     /// * Authorization token was not set on client
     pub fn demote_package(&self,
-                          ident: &PackageIdent,
-                          target: PackageTarget,
+                          (ident, target): (&PackageIdent, PackageTarget),
                           channel: &ChannelIdent,
                           token: &str)
                           -> Result<()> {

--- a/components/common/src/cli.rs
+++ b/components/common/src/cli.rs
@@ -42,6 +42,8 @@ lazy_static! {
 }
 pub const LISTEN_HTTP_ADDRESS_ENVVAR: &str = "HAB_LISTEN_HTTP";
 
+pub const PACKAGE_TARGET_ENVVAR: &str = "HAB_PACKAGE_TARGET";
+
 const SYSTEMDRIVE_ENVVAR: &str = "SYSTEMDRIVE";
 
 lazy_static! {

--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -24,6 +24,7 @@ use habitat_common::{cli::{BINLINK_DIR_ENVVAR,
                            LISTEN_CTL_DEFAULT_ADDR_STRING,
                            LISTEN_HTTP_ADDRESS_ENVVAR,
                            LISTEN_HTTP_DEFAULT_ADDR,
+                           PACKAGE_TARGET_ENVVAR,
                            RING_ENVVAR,
                            RING_KEY_ENVVAR},
                      types::ListenCtlAddr};
@@ -122,8 +123,7 @@ pub fn get() -> App<'static, 'static> {
                     (aliases: &["s", "st", "sta", "star"])
                     (@arg PKG_IDENT: +required +takes_value {valid_ident}
                         "The origin and name of the package to schedule a job for (eg: core/redis)")
-                    (@arg PKG_TARGET: +takes_value {valid_target}
-                        "A package target (ex: x86_64-windows) (default: x86_64-linux)")
+                    (arg: arg_target())
                     (@arg BLDR_URL: -u --url +takes_value {valid_url}
                         "Specify an alternate Builder endpoint. If not specified, the value will \
                          be taken from the cli.toml or HAB_BLDR_URL environment variable if defined. \
@@ -535,6 +535,7 @@ pub fn get() -> App<'static, 'static> {
                     environment variable if defined. (default: https://bldr.habitat.sh)")
                 (@arg PKG_IDENT: +required +takes_value {valid_fully_qualified_ident} "A fully qualified package identifier \
                     (ex: core/busybox-static/1.42.2/20170513215502)")
+                (arg: arg_target())
                 (@arg AUTH_TOKEN: -z --auth +takes_value "Authentication token for Builder")
             )
             (@subcommand promote =>
@@ -545,6 +546,7 @@ pub fn get() -> App<'static, 'static> {
                     environment variable if defined. (default: https://bldr.habitat.sh)")
                 (@arg PKG_IDENT: +required +takes_value {valid_fully_qualified_ident} "A fully qualified package identifier \
                     (ex: core/busybox-static/1.42.2/20170513215502)")
+                (arg: arg_target())
                 (@arg CHANNEL: +required +takes_value "Promote to the specified release channel")
                 (@arg AUTH_TOKEN: -z --auth +takes_value "Authentication token for Builder")
             )
@@ -556,6 +558,7 @@ pub fn get() -> App<'static, 'static> {
                     environment variable if defined. (default: https://bldr.habitat.sh)")
                 (@arg PKG_IDENT: +required +takes_value {valid_fully_qualified_ident} "A fully qualified package identifier \
                     (ex: core/busybox-static/1.42.2/20170513215502)")
+                (arg: arg_target())
                 (@arg CHANNEL: +required +takes_value "Demote from the specified release channel")
                 (@arg AUTH_TOKEN: -z --auth +takes_value "Authentication token for Builder")
             )
@@ -567,6 +570,7 @@ pub fn get() -> App<'static, 'static> {
                     environment variable if defined. (default: https://bldr.habitat.sh)")
                 (@arg PKG_IDENT: +required +takes_value {valid_fully_qualified_ident} "A fully qualified package identifier \
                     (ex: core/busybox-static/1.42.2/20170513215502)")
+                (arg: arg_target())
                 (@arg AUTH_TOKEN: -z --auth +takes_value "Authentication token for Builder")
             )
             (@subcommand verify =>
@@ -834,6 +838,16 @@ fn arg_cache_key_path(help_text: &'static str) -> Arg<'static, 'static> {
                                     .default_value(CACHE_KEY_PATH)
                                     .hide_default_value(true)
                                     .help(&help_text)
+}
+
+fn arg_target() -> Arg<'static, 'static> {
+    Arg::with_name("PKG_TARGET").required(false)
+                                .takes_value(true)
+                                .validator(valid_target)
+                                .env(PACKAGE_TARGET_ENVVAR)
+                                .hide_default_value(true)
+                                .help("A package target (ex: x86_64-windows) (default: system \
+                                       appropriate target")
 }
 
 fn sub_pkg_build() -> App<'static, 'static> {

--- a/components/hab/src/command/bldr/job/start.rs
+++ b/components/hab/src/command/bldr/job/start.rs
@@ -27,15 +27,14 @@ use crate::{error::{Error,
 
 pub fn start(ui: &mut UI,
              bldr_url: &str,
-             ident: &PackageIdent,
-             target: PackageTarget,
+             (ident, target): (&PackageIdent, PackageTarget),
              token: &str,
              group: bool)
              -> Result<()> {
     let api_client = Client::new(bldr_url, PRODUCT, VERSION, None).map_err(Error::APIClient)?;
 
     if group {
-        let rdeps = api_client.fetch_rdeps(ident, target)
+        let rdeps = api_client.fetch_rdeps((ident, target))
                               .map_err(Error::APIClient)?;
         if !rdeps.is_empty() {
             ui.warn("Found the following reverse dependencies:")?;
@@ -57,7 +56,7 @@ pub fn start(ui: &mut UI,
     ui.status(Status::Creating,
               format!("build job for {} ({})", ident, target))?;
 
-    let id = api_client.schedule_job(ident, target, !group, token)
+    let id = api_client.schedule_job((ident, target), !group, token)
                        .map_err(Error::APIClient)?;
 
     ui.status(Status::Created, format!("build job. The id is {}", id))?;

--- a/components/hab/src/command/pkg/channels.rs
+++ b/components/hab/src/command/pkg/channels.rs
@@ -43,14 +43,13 @@ use crate::{error::Result,
 /// * Fails if it cannot find the specified package in Builder.
 pub fn start(ui: &mut UI,
              bldr_url: &str,
-             ident: &PackageIdent,
-             target: PackageTarget,
+             (ident, target): (&PackageIdent, PackageTarget),
              token: Option<&str>)
              -> Result<()> {
     let api_client = Client::new(bldr_url, PRODUCT, VERSION, None)?;
 
     ui.begin(format!("Retrieving channels for {} ({})", ident, target))?;
-    let channels = api_client.package_channels(ident, target, token)?;
+    let channels = api_client.package_channels((ident, target), token)?;
     for channel in &channels {
         println!("{}", channel);
     }

--- a/components/hab/src/command/pkg/channels.rs
+++ b/components/hab/src/command/pkg/channels.rs
@@ -25,12 +25,12 @@
 //! Notes:
 //!    The package should already have been uploaded to Builder.
 //!    If the specified package does not exist, this will fail.
-//!
 
 use crate::{api_client::Client,
             common::ui::{UIWriter,
                          UI},
-            hcore::package::PackageIdent};
+            hcore::package::{PackageIdent,
+                             PackageTarget}};
 
 use crate::{error::Result,
             PRODUCT,
@@ -41,11 +41,16 @@ use crate::{error::Result,
 /// # Failures
 ///
 /// * Fails if it cannot find the specified package in Builder.
-pub fn start(ui: &mut UI, bldr_url: &str, ident: &PackageIdent, token: Option<&str>) -> Result<()> {
+pub fn start(ui: &mut UI,
+             bldr_url: &str,
+             ident: &PackageIdent,
+             target: PackageTarget,
+             token: Option<&str>)
+             -> Result<()> {
     let api_client = Client::new(bldr_url, PRODUCT, VERSION, None)?;
 
-    ui.begin(format!("Retrieving channels for {}", ident))?;
-    let channels = api_client.package_channels(ident, token)?;
+    ui.begin(format!("Retrieving channels for {} ({})", ident, target))?;
+    let channels = api_client.package_channels(ident, target, token)?;
     for channel in &channels {
         println!("{}", channel);
     }

--- a/components/hab/src/command/pkg/delete.rs
+++ b/components/hab/src/command/pkg/delete.rs
@@ -18,7 +18,8 @@ use crate::{api_client::Client,
                          UI},
             error::{Error,
                     Result},
-            hcore::package::PackageIdent,
+            hcore::package::{PackageIdent,
+                             PackageTarget},
             PRODUCT,
             VERSION};
 
@@ -27,17 +28,22 @@ use crate::{api_client::Client,
 /// # Failures
 ///
 /// * Fails if it cannot find the specified package in Builder
-pub fn start(ui: &mut UI, bldr_url: &str, ident: &PackageIdent, token: &str) -> Result<()> {
+pub fn start(ui: &mut UI,
+             bldr_url: &str,
+             ident: &PackageIdent,
+             target: PackageTarget,
+             token: &str)
+             -> Result<()> {
     let api_client = Client::new(bldr_url, PRODUCT, VERSION, None)?;
 
-    ui.begin(format!("Deleting {} from Builder", ident))?;
+    ui.begin(format!("Deleting {} ({}) from Builder", ident, target))?;
 
-    if let Err(err) = api_client.delete_package(ident, token) {
+    if let Err(err) = api_client.delete_package(ident, target, token) {
         println!("Failed to delete '{}': {:?}", ident, err);
         return Err(Error::from(err));
     }
 
-    ui.status(Status::Deleted, ident)?;
+    ui.status(Status::Deleted, format!("{} ({})", ident, target))?;
 
     Ok(())
 }

--- a/components/hab/src/command/pkg/delete.rs
+++ b/components/hab/src/command/pkg/delete.rs
@@ -30,15 +30,14 @@ use crate::{api_client::Client,
 /// * Fails if it cannot find the specified package in Builder
 pub fn start(ui: &mut UI,
              bldr_url: &str,
-             ident: &PackageIdent,
-             target: PackageTarget,
+             (ident, target): (&PackageIdent, PackageTarget),
              token: &str)
              -> Result<()> {
     let api_client = Client::new(bldr_url, PRODUCT, VERSION, None)?;
 
     ui.begin(format!("Deleting {} ({}) from Builder", ident, target))?;
 
-    if let Err(err) = api_client.delete_package(ident, target, token) {
+    if let Err(err) = api_client.delete_package((ident, target), token) {
         println!("Failed to delete '{}': {:?}", ident, err);
         return Err(Error::from(err));
     }

--- a/components/hab/src/command/pkg/demote.rs
+++ b/components/hab/src/command/pkg/demote.rs
@@ -24,13 +24,13 @@
 //! Notes:
 //!    The package should already have been uploaded to Builder.
 //!    If the specified channel does not exist, this will fail.
-//!
 
 use crate::{api_client::Client,
             common::ui::{Status,
                          UIWriter,
                          UI},
-            hcore::{package::PackageIdent,
+            hcore::{package::{PackageIdent,
+                              PackageTarget},
                     ChannelIdent}};
 
 use crate::{error::{Error,
@@ -48,18 +48,19 @@ use crate::{error::{Error,
 pub fn start(ui: &mut UI,
              bldr_url: &str,
              ident: &PackageIdent,
+             target: PackageTarget,
              channel: &ChannelIdent,
              token: &str)
              -> Result<()> {
     let api_client = Client::new(bldr_url, PRODUCT, VERSION, None)?;
 
-    ui.begin(format!("Demoting {} from {}", ident, channel))?;
+    ui.begin(format!("Demoting {} ({}) from {}", ident, target, channel))?;
 
     if channel == &ChannelIdent::unstable() {
         return Err(Error::CannotRemoveFromChannel((ident.to_string(), channel.to_string())));
     }
 
-    match api_client.demote_package(ident, channel, token) {
+    match api_client.demote_package(ident, target, channel, token) {
         Ok(_) => (),
         Err(e) => {
             println!("Failed to demote '{}': {:?}", ident, e);
@@ -67,7 +68,7 @@ pub fn start(ui: &mut UI,
         }
     }
 
-    ui.status(Status::Demoted, ident)?;
+    ui.status(Status::Demoted, format!("{} ({})", ident, target))?;
 
     Ok(())
 }

--- a/components/hab/src/command/pkg/demote.rs
+++ b/components/hab/src/command/pkg/demote.rs
@@ -47,8 +47,7 @@ use crate::{error::{Error,
 /// * Fails if "unstable" is the channel specified.
 pub fn start(ui: &mut UI,
              bldr_url: &str,
-             ident: &PackageIdent,
-             target: PackageTarget,
+             (ident, target): (&PackageIdent, PackageTarget),
              channel: &ChannelIdent,
              token: &str)
              -> Result<()> {
@@ -60,7 +59,7 @@ pub fn start(ui: &mut UI,
         return Err(Error::CannotRemoveFromChannel((ident.to_string(), channel.to_string())));
     }
 
-    match api_client.demote_package(ident, target, channel, token) {
+    match api_client.demote_package((ident, target), channel, token) {
         Ok(_) => (),
         Err(e) => {
             println!("Failed to demote '{}': {:?}", ident, e);

--- a/components/hab/src/command/pkg/promote.rs
+++ b/components/hab/src/command/pkg/promote.rs
@@ -24,14 +24,14 @@
 //! Notes:
 //!    The package should already have been uploaded to Builder.
 //!    If the specified channel does not exist, it will be created.
-//!
 
 use crate::{api_client::{self,
                          Client},
             common::ui::{Status,
                          UIWriter,
                          UI},
-            hcore::{package::PackageIdent,
+            hcore::{package::{PackageIdent,
+                              PackageTarget},
                     ChannelIdent}};
 use hyper::status::StatusCode;
 
@@ -48,12 +48,13 @@ use crate::{error::{Error,
 pub fn start(ui: &mut UI,
              bldr_url: &str,
              ident: &PackageIdent,
+             target: PackageTarget,
              channel: &ChannelIdent,
              token: &str)
              -> Result<()> {
     let api_client = Client::new(bldr_url, PRODUCT, VERSION, None)?;
 
-    ui.begin(format!("Promoting {} to channel '{}'", ident, channel))?;
+    ui.begin(format!("Promoting {} ({}) to channel '{}'", ident, target, channel))?;
 
     if channel != &ChannelIdent::stable() && channel != &ChannelIdent::unstable() {
         match api_client.create_channel(&ident.origin, channel, token) {
@@ -66,7 +67,7 @@ pub fn start(ui: &mut UI,
         };
     }
 
-    match api_client.promote_package(ident, channel, token) {
+    match api_client.promote_package(ident, target, channel, token) {
         Ok(_) => (),
         Err(e) => {
             println!("Failed to promote '{}': {:?}", ident, e);
@@ -74,7 +75,7 @@ pub fn start(ui: &mut UI,
         }
     }
 
-    ui.status(Status::Promoted, ident)?;
+    ui.status(Status::Promoted, format!("{} ({})", ident, target))?;
 
     Ok(())
 }

--- a/components/hab/src/command/pkg/promote.rs
+++ b/components/hab/src/command/pkg/promote.rs
@@ -47,8 +47,7 @@ use crate::{error::{Error,
 /// * Fails if it cannot find the specified package in Builder
 pub fn start(ui: &mut UI,
              bldr_url: &str,
-             ident: &PackageIdent,
-             target: PackageTarget,
+             (ident, target): (&PackageIdent, PackageTarget),
              channel: &ChannelIdent,
              token: &str)
              -> Result<()> {
@@ -67,7 +66,7 @@ pub fn start(ui: &mut UI,
         };
     }
 
-    match api_client.promote_package(ident, target, channel, token) {
+    match api_client.promote_package((ident, target), channel, token) {
         Ok(_) => (),
         Err(e) => {
             println!("Failed to promote '{}': {:?}", ident, e);

--- a/components/hab/src/command/pkg/upload.rs
+++ b/components/hab/src/command/pkg/upload.rs
@@ -125,6 +125,7 @@ pub fn start(ui: &mut UI,
                                   &api_client,
                                   token,
                                   &ident,
+                                  target,
                                   additional_release_channel,
                                   force_upload,
                                   &mut archive)
@@ -153,6 +154,7 @@ fn upload_into_depot(ui: &mut UI,
                      api_client: &Client,
                      token: &str,
                      ident: &PackageIdent,
+                     target: PackageTarget,
                      additional_release_channel: &Option<ChannelIdent>,
                      force_upload: bool,
                      mut archive: &mut PackageArchive)
@@ -197,7 +199,7 @@ fn upload_into_depot(ui: &mut UI,
             };
         }
 
-        match api_client.promote_package(ident, &channel, token) {
+        match api_client.promote_package(ident, target, &channel, token) {
             Ok(_) => (),
             Err(e) => return Err(Error::from(e)),
         };
@@ -226,6 +228,7 @@ fn attempt_upload_dep(ui: &mut UI,
                           api_client,
                           token,
                           ident,
+                          target,
                           additional_release_channel,
                           false,
                           &mut archive)

--- a/components/hab/src/command/pkg/upload.rs
+++ b/components/hab/src/command/pkg/upload.rs
@@ -81,14 +81,16 @@ pub fn start(ui: &mut UI,
     let ident = archive.ident()?;
     let target = archive.target()?;
 
-    match api_client.show_package(&ident, target, &ChannelIdent::unstable(), Some(token)) {
+    match api_client.show_package((&ident, target), &ChannelIdent::unstable(), Some(token)) {
         Ok(_) if !force_upload => {
             ui.status(Status::Using, format!("existing {}", &ident))?;
             Ok(())
         }
         Err(api_client::Error::APIError(StatusCode::NotFound, _)) | Ok(_) => {
             for dep in tdeps.into_iter() {
-                match api_client.show_package(&dep, target, &ChannelIdent::unstable(), Some(token))
+                match api_client.show_package((&dep, target),
+                                              &ChannelIdent::unstable(),
+                                              Some(token))
                 {
                     Ok(_) => ui.status(Status::Using, format!("existing {}", &dep))?,
                     Err(api_client::Error::APIError(StatusCode::NotFound, _)) => {
@@ -100,8 +102,7 @@ pub fn start(ui: &mut UI,
                             attempt_upload_dep(ui,
                                                &api_client,
                                                token,
-                                               &dep,
-                                               target,
+                                               (&dep, target),
                                                additional_release_channel,
                                                &candidate_path,
                                                key_path)
@@ -124,8 +125,7 @@ pub fn start(ui: &mut UI,
                 upload_into_depot(ui,
                                   &api_client,
                                   token,
-                                  &ident,
-                                  target,
+                                  (&ident, target),
                                   additional_release_channel,
                                   force_upload,
                                   &mut archive)
@@ -153,8 +153,7 @@ pub fn start(ui: &mut UI,
 fn upload_into_depot(ui: &mut UI,
                      api_client: &Client,
                      token: &str,
-                     ident: &PackageIdent,
-                     target: PackageTarget,
+                     (ident, target): (&PackageIdent, PackageTarget),
                      additional_release_channel: &Option<ChannelIdent>,
                      force_upload: bool,
                      mut archive: &mut PackageArchive)
@@ -199,7 +198,7 @@ fn upload_into_depot(ui: &mut UI,
             };
         }
 
-        match api_client.promote_package(ident, target, &channel, token) {
+        match api_client.promote_package((ident, target), &channel, token) {
             Ok(_) => (),
             Err(e) => return Err(Error::from(e)),
         };
@@ -213,8 +212,7 @@ fn upload_into_depot(ui: &mut UI,
 fn attempt_upload_dep(ui: &mut UI,
                       api_client: &Client,
                       token: &str,
-                      ident: &PackageIdent,
-                      target: PackageTarget,
+                      (ident, target): (&PackageIdent, PackageTarget),
                       additional_release_channel: &Option<ChannelIdent>,
                       archives_dir: &PathBuf,
                       key_path: &Path)
@@ -227,8 +225,7 @@ fn attempt_upload_dep(ui: &mut UI,
         upload_into_depot(ui,
                           api_client,
                           token,
-                          ident,
-                          target,
+                          (ident, target),
                           additional_release_channel,
                           false,
                           &mut archive)

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -958,7 +958,7 @@ fn sub_svc_set(m: &ArgMatches<'_>) -> Result<()> {
     // SrvClient from a for_each iterator so we can chain upon a successful stream but I don't
     // know if it's possible with this version of futures.
     SrvClient::connect(&listen_ctl_addr, &secret_key).and_then(|conn| {
-        conn.call(set).for_each(|reply| {
+                                                         conn.call(set).for_each(|reply| {
                           match reply.message_id() {
                 "NetOk" => Ok(()),
                 "NetErr" => {
@@ -972,8 +972,8 @@ fn sub_svc_set(m: &ArgMatches<'_>) -> Result<()> {
                 ))),
             }
                       })
-    })
-    .wait()?;
+                                                     })
+                                                     .wait()?;
     ui.end("Applied configuration")?;
     Ok(())
 }
@@ -986,7 +986,7 @@ fn sub_svc_config(m: &ArgMatches<'_>) -> Result<()> {
     let mut msg = protocol::ctl::SvcGetDefaultCfg::default();
     msg.ident = Some(ident.into());
     SrvClient::connect(&listen_ctl_addr, &secret_key).and_then(|conn| {
-        conn.call(msg).for_each(|reply| {
+                                                         conn.call(msg).for_each(|reply| {
                           match reply.message_id() {
                 "ServiceCfg" => {
                     let m = reply
@@ -1006,8 +1006,8 @@ fn sub_svc_config(m: &ArgMatches<'_>) -> Result<()> {
                 ))),
             }
                       })
-    })
-    .wait()?;
+                                                     })
+                                                     .wait()?;
     Ok(())
 }
 
@@ -1156,9 +1156,11 @@ fn sub_file_put(m: &ArgMatches<'_>) -> Result<()> {
         _ => msg.content = Some(buf.to_vec()),
     }
     SrvClient::connect(&listen_ctl_addr, &secret_key).and_then(|conn| {
-        ui.status(Status::Applying, format!("via peer {}", listen_ctl_addr))
-          .unwrap();
-        conn.call(msg).for_each(|reply| {
+                                                         ui.status(Status::Applying,
+                                                                   format!("via peer {}",
+                                                                           listen_ctl_addr))
+                                                           .unwrap();
+                                                         conn.call(msg).for_each(|reply| {
                           match reply.message_id() {
                 "NetOk" => Ok(()),
                 "NetErr" => {
@@ -1178,8 +1180,8 @@ fn sub_file_put(m: &ArgMatches<'_>) -> Result<()> {
                 ))),
             }
                       })
-    })
-    .wait()?;
+                                                     })
+                                                     .wait()?;
     ui.end("Uploaded file")?;
     Ok(())
 }
@@ -1636,7 +1638,7 @@ fn supervisor_services() -> Result<Vec<PackageIdent>> {
 
     let mut out: Vec<PackageIdent> = vec![];
     SrvClient::connect(&listen_ctl_addr, &secret_key).and_then(|conn| {
-        conn.call(msg).for_each(|reply| {
+                                                         conn.call(msg).for_each(|reply| {
                           match reply.message_id() {
                               "ServiceStatus" => {
                                   let m = reply.parse::<protocol::types::ServiceStatus>()
@@ -1656,8 +1658,8 @@ fn supervisor_services() -> Result<Vec<PackageIdent>> {
                               }
                           }
                       })
-    })
-    .wait()?;
+                                                     })
+                                                     .wait()?;
     Ok(out)
 }
 

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -606,7 +606,7 @@ fn sub_bldr_job_start(ui: &mut UI, m: &ArgMatches<'_>) -> Result<()> {
     let target = target_from_matches(m)?;
     let group = m.is_present("GROUP");
     let token = auth_token_param_or_env(&m)?;
-    command::bldr::job::start::start(ui, &url, &ident, target, &token, group)
+    command::bldr::job::start::start(ui, &url, (&ident, target), &token, group)
 }
 
 fn sub_bldr_job_cancel(ui: &mut UI, m: &ArgMatches<'_>) -> Result<()> {
@@ -827,7 +827,7 @@ fn sub_pkg_delete(ui: &mut UI, m: &ArgMatches<'_>) -> Result<()> {
     let ident = PackageIdent::from_str(m.value_of("PKG_IDENT").unwrap())?;
     let target = target_from_matches(m)?;
 
-    command::pkg::delete::start(ui, &url, &ident, target, &token)?;
+    command::pkg::delete::start(ui, &url, (&ident, target), &token)?;
 
     Ok(())
 }
@@ -861,7 +861,7 @@ fn sub_pkg_promote(ui: &mut UI, m: &ArgMatches<'_>) -> Result<()> {
     let token = auth_token_param_or_env(&m)?;
     let target = target_from_matches(m)?;
     let ident = PackageIdent::from_str(m.value_of("PKG_IDENT").unwrap())?; // Required via clap
-    command::pkg::promote::start(ui, &url, &ident, target, &channel, &token)
+    command::pkg::promote::start(ui, &url, (&ident, target), &channel, &token)
 }
 
 fn sub_pkg_demote(ui: &mut UI, m: &ArgMatches<'_>) -> Result<()> {
@@ -870,7 +870,7 @@ fn sub_pkg_demote(ui: &mut UI, m: &ArgMatches<'_>) -> Result<()> {
     let token = auth_token_param_or_env(&m)?;
     let target = target_from_matches(m)?;
     let ident = PackageIdent::from_str(m.value_of("PKG_IDENT").unwrap())?; // Required via clap
-    command::pkg::demote::start(ui, &url, &ident, target, &channel, &token)
+    command::pkg::demote::start(ui, &url, (&ident, target), &channel, &token)
 }
 
 fn sub_pkg_channels(ui: &mut UI, m: &ArgMatches<'_>) -> Result<()> {
@@ -879,7 +879,10 @@ fn sub_pkg_channels(ui: &mut UI, m: &ArgMatches<'_>) -> Result<()> {
     let token = maybe_auth_token(&m);
     let target = target_from_matches(m)?;
 
-    command::pkg::channels::start(ui, &url, &ident, target, token.as_ref().map(String::as_str))
+    command::pkg::channels::start(ui,
+                                  &url,
+                                  (&ident, target),
+                                  token.as_ref().map(String::as_str))
 }
 
 fn sub_svc_set(m: &ArgMatches<'_>) -> Result<()> {


### PR DESCRIPTION
This adds a package target param to hab cli commands that were missing them : promote, demote, delete and channels.  If the param is not specified, the target defaults to ~~x86_64-linux~~ a sane system appropriate default.

NOTE: This change will require a corresponding Builder backend change. Until the Builder change is rolled out, this change will be a no-op.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-11376684](https://user-images.githubusercontent.com/13542112/55443355-39218000-5567-11e9-8945-2d467c5d169c.gif)
