### PR TITLE
Fix detection of emacs in studio

### DIFF
--- a/components/rootless_studio/default/profile
+++ b/components/rootless_studio/default/profile
@@ -42,9 +42,9 @@ TERMINFO=$(hab pkg path core/ncurses)/share/terminfo
 
 emacs() {
   if type -P emacs > /dev/null; then
-    "$(type -P emacs)" "$@";
+    "$(type -P emacs)" "$@"
   else
-    mg "$@";
+    mg "$@"
   fi
 }
 

--- a/components/rootless_studio/default/profile
+++ b/components/rootless_studio/default/profile
@@ -41,10 +41,10 @@ export TERMINFO
 TERMINFO=$(hab pkg path core/ncurses)/share/terminfo
 
 emacs() {
-  if command -v emacs > /dev/null; then
-    emacs "$@"
+  if type -P emacs > /dev/null; then
+    "$(type -P emacs)" "$@";
   else
-    mg "$@"
+    mg "$@";
   fi
 }
 

--- a/components/rootless_studio/default/profile
+++ b/components/rootless_studio/default/profile
@@ -42,7 +42,7 @@ TERMINFO=$(hab pkg path core/ncurses)/share/terminfo
 
 emacs() {
   if type -P emacs > /dev/null; then
-    "$(type -P emacs)" "$@"
+    command emacs "$@"
   else
     mg "$@"
   fi

--- a/components/studio/libexec/hab-studio-type-default.sh
+++ b/components/studio/libexec/hab-studio-type-default.sh
@@ -145,9 +145,9 @@ TERMINFO=$(_pkgpath_for core/ncurses)/share/terminfo
 
 emacs() {
   if type -P emacs > /dev/null; then
-    "$(type -P emacs)" "$@"
+    "$(type -P emacs)" "\$@"
   else
-    mg "$@"
+    mg "\$@"
   fi
 }
 

--- a/components/studio/libexec/hab-studio-type-default.sh
+++ b/components/studio/libexec/hab-studio-type-default.sh
@@ -145,9 +145,9 @@ TERMINFO=$(_pkgpath_for core/ncurses)/share/terminfo
 
 emacs() {
   if type -P emacs > /dev/null; then
-    "$(type -P emacs)" "$@";
+    "$(type -P emacs)" "$@"
   else
-    mg "$@";
+    mg "$@"
   fi
 }
 

--- a/components/studio/libexec/hab-studio-type-default.sh
+++ b/components/studio/libexec/hab-studio-type-default.sh
@@ -144,10 +144,10 @@ export TERMINFO
 TERMINFO=$(_pkgpath_for core/ncurses)/share/terminfo
 
 emacs() {
-  if command -v emacs > /dev/null; then
-    emacs "\$@"
+  if type -P emacs > /dev/null; then
+    "$(type -P emacs)" "$@";
   else
-    mg "\$@"
+    mg "$@";
   fi
 }
 

--- a/components/studio/libexec/hab-studio-type-default.sh
+++ b/components/studio/libexec/hab-studio-type-default.sh
@@ -145,7 +145,7 @@ TERMINFO=$(_pkgpath_for core/ncurses)/share/terminfo
 
 emacs() {
   if type -P emacs > /dev/null; then
-    "$(type -P emacs)" "\$@"
+    command emacs "\$@"
   else
     mg "\$@"
   fi


### PR DESCRIPTION
`command -v` includes functions in its search, resulting in an endless loop followed by a segmentation fault (#6370).

This updates the function to use `type -P` which preserves the original intended behavior while forcing a PATH search preventing the segfault.  

```
type: type [-afptP] name [name ...]
      -P	force a PATH search for each NAME, even if it is an alias,
    		builtin, or function, and returns the name of the disk file
    		that would be executed
```

I tested this by modifying the function in a studio and executing the following sequence of commands: 

```
[3][default:/src:0]# type -a emacs
emacs is a function
emacs ()
{
    if type -P emacs > /dev/null; then
        "$(type -P emacs)" "$@";
    else
        mg "$@";
    fi
}
[4][default:/src:0]# emacs
... mg opens ... 
[5][default:/src:0]# hab pkg install ssd/emacs
[6][default:/src:0]# hab pkg binlink ssd/emacs emacs -d /bin
[7][default:/src:0]# emacs
... emacs opens ... 
```

Closes #6370 

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>