### PR TITLE
Be explicit when dealing with feature flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -726,14 +726,6 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "features"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "field-offset"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -883,7 +875,6 @@ dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "features 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat-sup-client 0.0.0",
@@ -1069,6 +1060,7 @@ name = "habitat_common"
 version = "0.0.0"
 dependencies = [
  "bimap 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "habitat_api_client 0.0.0",
@@ -1252,7 +1244,6 @@ dependencies = [
  "cpu-time 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ctrlc 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "features 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hab 0.0.0",
@@ -3854,7 +3845,6 @@ dependencies = [
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
-"checksum features 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "45d496bf4d9e25b7509388b3ba8abe3af35b78b39f0f32e326253856eb11f5bc"
 "checksum field-offset 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "64e9bc339e426139e02601fa69d101e96a92aee71b58bc01697ec2a63a5c9e68"
 "checksum filetime 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a2df5c1a8c4be27e7707789dc42ae65976e60b394afd293d1419ab915833e646"
 "checksum fixedbitset 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "86d4de0081402f5e88cdac65c8dcdcc73118c1a7a465e2a05f0da05843a8ea33"

--- a/components/common/Cargo.toml
+++ b/components/common/Cargo.toml
@@ -8,6 +8,7 @@ workspace = "../../"
 
 [dependencies]
 bimap = "*"
+bitflags = "*"
 clap = { version = "*", features = [ "suggestions", "color", "unstable" ] }
 glob = "*"
 # The handlebars crate has a few issues that require us to lock at 0.28.3

--- a/components/common/src/lib.rs
+++ b/components/common/src/lib.rs
@@ -12,8 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::ui::{UIWriter,
+                UI};
 use habitat_api_client as api_client;
 use habitat_core as hcore;
+use habitat_core::env as henv;
+use lazy_static::lazy_static;
+use std::{collections::HashMap,
+          iter::FromIterator};
+
 extern crate json;
 #[macro_use]
 extern crate log;
@@ -51,4 +58,98 @@ lazy_static::lazy_static! {
             }
         }
     };
+}
+
+// TODO (CM): It would be nice to come up with a way to more
+// programmatically manage these flags. It's a bit of a pain to define
+// the flag, and then define the environment variables
+// separately. Nothing statically guarantees that you've specified an
+// variable for a flag.
+
+// TODO (CM): It'd be great to have a built-in way to document them,
+// too.
+
+// TODO (CM): Part of that documentation might be *when* a flag was
+// added. In general, long-lived flags are a code-smell.
+
+// TODO (CM): It may also be useful to break out features by area of
+// concern. We can have any number of bitflags-generated structs.
+
+bitflags::bitflags! {
+    /// All the feature flags that are recogized by Habitat.
+    ///
+    /// In general, feature flags are enabled by setting the corresponding
+    /// environment variable.
+    ///
+    /// Your binary should call `FeatureFlag::from_env` to get a set
+    /// of flags to use.
+    ///
+    /// To add a new feature flag, you will need to add the bit mask
+    /// constant here, as well as a mapping from the feature to the
+    /// environment variable to which it corresponds in the `ENV_VARS`
+    /// map below.
+    pub struct FeatureFlag: u32 {
+        const LIST            = 0b0000_0000_0001;
+        const TEST_EXIT       = 0b0000_0000_0010;
+        const TEST_BOOT_FAIL  = 0b0000_0000_0100;
+        const REDACT_HTTP     = 0b0000_0000_1000;
+        const IGNORE_SIGNALS  = 0b0000_0001_0000;
+        const INSTALL_HOOK    = 0b0000_0010_0000;
+        const OFFLINE_INSTALL = 0b0000_0100_0000;
+        const IGNORE_LOCAL    = 0b0000_1000_0000;
+        const EVENT_STREAM    = 0b0001_0000_0000;
+    }
+}
+
+lazy_static! {
+    static ref ENV_VARS: HashMap<FeatureFlag, &'static str> = {
+        let mapping = vec![(FeatureFlag::LIST, "HAB_FEAT_LIST"),
+                           (FeatureFlag::TEST_EXIT, "HAB_FEAT_TEST_EXIT"),
+                           (FeatureFlag::TEST_BOOT_FAIL, "HAB_FEAT_BOOT_FAIL"),
+                           (FeatureFlag::REDACT_HTTP, "HAB_FEAT_REDACT_HTTP"),
+                           (FeatureFlag::IGNORE_SIGNALS, "HAB_FEAT_IGNORE_SIGNALS"),
+                           (FeatureFlag::INSTALL_HOOK, "HAB_FEAT_INSTALL_HOOK"),
+                           (FeatureFlag::OFFLINE_INSTALL, "HAB_FEAT_OFFLINE_INSTALL"),
+                           (FeatureFlag::IGNORE_LOCAL, "HAB_FEAT_IGNORE_LOCAL"),
+                           (FeatureFlag::EVENT_STREAM, "HAB_FEAT_EVENT_STREAM")];
+        HashMap::from_iter(mapping)
+    };
+}
+
+impl FeatureFlag {
+    /// If the environment variable for a flag is set to _anything_ but
+    /// the empty string, it is activated.
+    pub fn from_env(ui: &mut UI) -> Self {
+        let mut flags = FeatureFlag::empty();
+
+        for (feature, env_var) in ENV_VARS.iter() {
+            if henv::var(env_var).is_ok() {
+                flags.insert(*feature);
+                ui.warn(&format!("Enabling feature: {:?}", feature))
+                  .unwrap();
+            }
+        }
+
+        // TODO (CM): Once the other TODOs above are done (especially the
+        // documentation bits), it would be nice to extract this logic
+        // into an actual discoverable CLI subcommand; it's a little weird
+        // that you have to know how to enable a feature flag before you
+        // can even find out that there *are* feature flags to enable.
+        //
+        // There's no reason why "list feature flags" should itself be a
+        // feature-flag.
+        if flags.contains(FeatureFlag::LIST) {
+            ui.warn("Listing feature flags environment variables:")
+              .unwrap();
+            for (feature, env_var) in ENV_VARS.iter() {
+                ui.warn(&format!("  * {:?}: {}={}",
+                                 feature,
+                                 env_var,
+                                 henv::var(env_var).unwrap_or_default()))
+                  .unwrap();
+            }
+        }
+
+        flags
+    }
 }

--- a/components/hab/Cargo.toml
+++ b/components/hab/Cargo.toml
@@ -15,7 +15,6 @@ bitflags = "*"
 base64 = "*"
 dirs = "*"
 env_logger = "*"
-features = "*"
 futures = "*"
 # Pending upgrade activities in https://github.com/habitat-sh/core/issues/72
 hyper = "0.10"

--- a/components/hab/src/lib.rs
+++ b/components/hab/src/lib.rs
@@ -22,13 +22,7 @@ use habitat_sup_client as sup_client;
 use habitat_sup_protocol as protocol;
 
 #[macro_use]
-extern crate bitflags;
-
-#[macro_use]
 extern crate clap;
-
-#[macro_use]
-extern crate features;
 
 #[macro_use]
 extern crate log;
@@ -60,12 +54,3 @@ pub const ORIGIN_ENVVAR: &str = "HAB_ORIGIN";
 pub const BLDR_URL_ENVVAR: &str = "HAB_BLDR_URL";
 
 pub use crate::hcore::AUTH_TOKEN_ENVVAR;
-
-features! {
-    pub mod feat {
-        const List           = 0b0000_0001,
-        const OfflineInstall = 0b0000_0010,
-        const IgnoreLocal    = 0b0000_0100,
-        const InstallHook    = 0b0000_1000
-    }
-}

--- a/components/sup/Cargo.toml
+++ b/components/sup/Cargo.toml
@@ -30,7 +30,6 @@ byteorder = "*"
 clap = { version = "*", features = [ "suggestions", "color", "unstable" ] }
 cpu-time = "*"
 env_logger = "*"
-features = "*"
 futures = "*"
 glob = "*"
 hab = { path = "../hab" }

--- a/components/sup/src/cli.rs
+++ b/components/sup/src/cli.rs
@@ -1,5 +1,4 @@
 use clap::App;
-
 use hab::cli::sup_commands;
 
 pub fn cli<'a, 'b>() -> App<'a, 'b> { sup_commands() }

--- a/components/sup/src/lib.rs
+++ b/components/sup/src/lib.rs
@@ -39,17 +39,12 @@
 //! * [The Habitat Command Line Reference](command)
 //! * [The Habitat Supervisor Sidecar; http interface to promises](sidecar)
 
-#[macro_use]
-extern crate bitflags;
-
 #[cfg(target_os = "linux")]
 extern crate caps;
 extern crate clap;
 extern crate cpu_time;
 #[cfg(windows)]
 extern crate ctrlc;
-#[macro_use]
-extern crate features;
 #[macro_use]
 extern crate lazy_static;
 #[macro_use]
@@ -103,22 +98,6 @@ pub mod test_helpers;
 pub mod util;
 
 use std::env;
-
-/// List enables printing out the list features which can be dynamically enabled
-/// TestExit enables triggering an abrupt exit to simulate failures
-/// TestBootFail exits with a fatal error before even calling boot()
-/// Search for feat::is_enabled(feat::FeatureName) to learn more
-features! {
-    pub mod feat {
-        const List          = 0b0000_0001,
-        const TestExit      = 0b0000_0010,
-        const TestBootFail  = 0b0000_0100,
-        const RedactHTTP    = 0b0000_1000,
-        const IgnoreSignals = 0b0001_0000,
-        const InstallHook   = 0b0010_0000,
-        const EventStream   = 0b0100_0000
-    }
-}
 
 pub const PRODUCT: &str = "hab-sup";
 pub const VERSION: &str = include_str!(concat!(env!("OUT_DIR"), "/VERSION"));


### PR DESCRIPTION
Here, we dispense with the use of the `features` crate, in favor of
using the underlying `bitflags` abstraction directly.

This means that we no longer rely on recording which feature flags are
currently enabled in global state, but in immutable data that we
explicitly thread through function calls.

This also means that functionality that differs based on feature flag
state can be more easily unit tested (otherwise, we have to contend
with the sharing of global state, which is always tricky).

Signed-off-by: Christopher Maier <cmaier@chef.io>