### PR TITLE
add studio powershell directory to path on studio creation so it is propogated to supervisor

### DIFF
--- a/components/studio/bin/hab-studio.ps1
+++ b/components/studio/bin/hab-studio.ps1
@@ -243,6 +243,7 @@ function New-Studio {
   }
 
   $pathArray = @(
+    "$PSScriptRoot\powershell",
     "$PSScriptRoot\hab",
     "$PSScriptRoot\7zip",
     "$PSScriptRoot",


### PR DESCRIPTION
The 0.79.0 release included a bug where the supervisor launched in a local studio is unable to locate pwsh.exe and therefore unable to spawn hooks. There are 2 issues at play here:

1. The supervisor is looking for powershell in `/hab/pkgs/core/powershell` and not the `FS_ROOT`ed location. This is the deeper problem but also looks like this has been the case for a while. We should absolutely fix soon but it is more involved than this fix.
2. When you enter the studio, we explicitly set several directories on the `PATH` and then launch a nested `pwsh` session to host the interactive studio. Powershell will add the path of its own binary to the path. Until 0.79.0, we would launch the supervisor in the background from this interactive session so the supervisor would inherit the running powershell path and then successfully find `pwsh.exe`. In 0.79.0 we launch it before entering the interactive session (for good reason) so it does not get the powershell directory on its path.

This simply add's the studio's own powershell directory to the list of directories we set for the `PATH` upon creating the studio before the supervisor is launched.

I have manually added this line to a clean environment and validated that it fixes this issue.

Signed-off-by: mwrock <matt@mattwrock.com>