### PR TITLE
Auto detect ttys for docker studios

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -877,6 +877,7 @@ dependencies = [
 name = "hab"
 version = "0.0.0"
 dependencies = [
+ "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/hab/Cargo.toml
+++ b/components/hab/Cargo.toml
@@ -38,6 +38,7 @@ walkdir = "*"
 tar = "*"
 flate2 = "*"
 chrono = "*"
+atty = "*"
 
 [dependencies.clap]
 version = "*"

--- a/components/studio/bin/hab-studio.sh
+++ b/components/studio/bin/hab-studio.sh
@@ -86,9 +86,6 @@ COMMON FLAGS:
     -V  Prints version information
     -D  Use a Docker Studio instead of a chroot Studio
 
-    --no-tty           Disable the --tty default (Docker Studio only)
-    --non-interactive  Disable the --interactive default (Docker Studio only)
-
 COMMON OPTIONS:
     -a <ARTIFACT_PATH>    Sets the source artifact cache path (default: /hab/cache/artifacts)
     -k <HAB_ORIGIN_KEYS>  Installs secret origin keys (default:\$HAB_ORIGIN )


### PR DESCRIPTION
This eliminates the awkward `--no-tty` and `--non-interactive` flags that were added in https://github.com/habitat-sh/habitat/pull/6295 in favor of automatically detecting TTYs and passing the appropriate flags to docker.

In theory, this means that docker studios should always just do the right thing, whether they're run in a TTY or a headless environment.

![](https://media.giphy.com/media/Osmo5A1vwU41i/giphy.gif)

Closes https://github.com/habitat-sh/habitat/issues/6403
Signed-off-by: Josh Black <raskchanky@gmail.com>