### PR TITLE
Update to bundler 2 to fix website deploy

### DIFF
--- a/www/Makefile
+++ b/www/Makefile
@@ -1,4 +1,5 @@
 build: clean
+	gem install bundler
 	bundle install
 	bundle exec middleman build --no-parallel
 .PHONY: build

--- a/www/README.md
+++ b/www/README.md
@@ -4,7 +4,7 @@ Static site content for www.habitat.sh
 
 ## Setup
 
-1. Install Ruby 2.3.1 or greater
+1. Install Ruby 2.3.3 or greater
 1. Install Bundler
 
     ```


### PR DESCRIPTION
Hopefully this will address https://travis-ci.org/habitat-sh/habitat/builds/518862256
which failed with:
```
You must use Bundler 2 or greater with this lockfile.
```
