### PR TITLE
Make --binlink take an value (or env var) for `hab pkg install`

### DIFF
--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -900,7 +900,8 @@ fn sub_pkg_install(feature_flags: FeatureFlag) -> App<'static, 'static> {
         (@arg PKG_IDENT_OR_ARTIFACT: +required +multiple
             "One or more Habitat package identifiers (ex: acme/redis) and/or filepaths \
             to a Habitat Artifact (ex: /home/acme-redis-3.0.7-21120102031201-x86_64-linux.hart)")
-        (@arg BINLINK: -b --binlink "Binlink all binaries from installed package(s)")
+        (@arg BINLINK: -b --binlink +takes_value {non_empty} env(BINLINK_DIR_ENVVAR)
+            default_value(DEFAULT_BINLINK_DIR) "Binlink all binaries from installed package(s)")
         (@arg FORCE: -f --force "Overwrite existing binlinks")
         (@arg AUTH_TOKEN: -z --auth +takes_value "Authentication token for Builder")
     );


### PR DESCRIPTION
Resolves https://github.com/habitat-sh/habitat/issues/6418

Commit 6232c6728f29f825b4324b81ff7c77b7eec95d79 removed `binlink_dest_dir_from_matches`, which applied the value in the HAB_BINLINK_DIR env var to choose the destination when the `--binlink` flag was provided. This resulted in a bug where the binlinks weren't in the expected location in a new studio.

This commit changes `--binlink` from a flag to a option that takes a value. That value has platform-specific defaults, allowing the existing use case of `--binlink` without a value to work with either the default, or with a value supplied by the `HAB_BINLINK_DIR` env var.

One notable change is that since `--binlink` now takes a value, it must be placed *after* the `<PKG_IDENT_OR_ARTIFACT>` positional argument if the default value is desired. Otherwise, something like `hab pkg install --binlink core/redis` would interpret `core/redis` as
the binlink path. Fortunately, this would be caught by clap since the command appears to lack the required `<PKG_IDENT_OR_ARTIFACT>` positional argument, yielding the error:
```
error: The following required arguments were not provided:
    <PKG_IDENT_OR_ARTIFACT>...

USAGE:
    hab pkg install <PKG_IDENT_OR_ARTIFACT>... --binlink <BINLINK> --channel <CHANNEL>
```