### PR TITLE
Follow $refs in generate-template-reference

### DIFF
--- a/www/.gitignore
+++ b/www/.gitignore
@@ -14,5 +14,8 @@
 /.sass-cache
 /.cache
 
+# Ignore node_modules
+node_modules/
+
 # Ignore .DS_store file
 .DS_Store

--- a/www/Makefile
+++ b/www/Makefile
@@ -36,11 +36,15 @@ cli_docs:
 	hab pkg install core/node --binlink && \
 	node scripts/generate-cli-docs > source/docs/habitat-cli.html.md"
 
-template_reference:
-	cp ../components/sup/doc/render_context_schema.json scripts/schema.json.tmp
+node_modules/json-schema-ref-parser:
+	npm install json-schema-ref-parser@6.1.0
+
+template_reference: node_modules/json-schema-ref-parser
+	mkdir tmp
+	cp ../components/sup/doc/* tmp/
 	hab studio run "hab pkg install core/node --binlink && \
-	cat scripts/schema.json.tmp | node scripts/generate-template-reference.js > ./source/partials/docs/_reference-template-data.html.md.erb"
-	rm -f scripts/schema.json.tmp
+	node scripts/generate-template-reference.js tmp/render_context_schema.json > ./source/partials/docs/_reference-template-data.html.md.erb"
+	rm -rf tmp
 
 check-env:
 ifndef AWS_ACCESS_KEY_ID

--- a/www/scripts/generate-template-reference.js
+++ b/www/scripts/generate-template-reference.js
@@ -1,6 +1,5 @@
-const stdin = process.stdin;
+let $RefParser = require('json-schema-ref-parser');
 const stdout = process.stdout;
-let input = [];
 let lines = [];
 
 function writeHeader() {
@@ -92,14 +91,11 @@ function getType(prop) {
   return '--';
 }
 
-stdin.on('data', d => {
-  input.push(d);
-});
-
-stdin.on('end', () => {
-  schema = JSON.parse(input.join());
-  writeHeader();
-  writeProperties();
-  writeDefinitions();
-  stdout.write(lines.join('\n'));
+$RefParser.bundle(process.argv[2]).then(function(deref_schema) {
+    console.log("ARGV", process.argv[2]);
+    schema = deref_schema;
+    writeHeader();
+    writeProperties();
+    writeDefinitions();
+    stdout.write(lines.join('\n'));
 });


### PR DESCRIPTION
Uses the json schema $ref parser https://apidevtools.org/json-schema-ref-parser/ to follow refs when generating data documentation with generate-template-reference.js. resolves #5948 