### PR TITLE
Make clippy use single-use queues and no retries

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -42,19 +42,14 @@ steps:
     agents:
       queue: 'single-use-privileged'
     timeout_in_minutes: 10
-    retry:
-      automatic:
-        limit: 1
+
 
   - label: "[lint] :windows: :paperclip: clippy!"
     command:
       - .\test\run_clippy.ps1 stable .\test\unexamined_lints.txt .\test\allowed_lints.txt .\test\lints_to_fix.txt .\test\denied_lints.txt
     agents:
-      queue: 'default-windows-privileged'
+      queue: 'single-use-windows-privileged'
     timeout_in_minutes: 25
-    retry:
-      automatic:
-        limit: 1
 
 #######################################################################
 # Unit Tests - Linux!


### PR DESCRIPTION
There's no need to retry clippy commands, they should be deterministic, so retries would tend to make the CI run take longer to generate an actionable result. Additionally, re-using a container may cause us to get false positives due to https://github.com/rust-lang/rust-clippy/issues/2604. This change should help us avoid that.
