### PR TITLE
Update error handling for origin deletion

### DIFF
--- a/components/hab/src/command/origin/delete.rs
+++ b/components/hab/src/command/origin/delete.rs
@@ -1,21 +1,34 @@
-use crate::{api_client::Client,
+use crate::{api_client::{self,
+                         Client},
             common::ui::{Status,
                          UIWriter,
-                         UI}};
-
-use crate::{error::{Error,
+                         UI},
+            error::{Error,
                     Result},
             PRODUCT,
             VERSION};
+use hyper::status::StatusCode;
 
 pub fn start(ui: &mut UI, bldr_url: &str, token: &str, origin: &str) -> Result<()> {
     let api_client = Client::new(bldr_url, PRODUCT, VERSION, None).map_err(Error::APIClient)?;
 
     ui.status(Status::Deleting, format!("origin {}.", origin))?;
 
-    api_client.delete_origin(origin, token)
-              .map_err(Error::APIClient)?;
-
-    ui.status(Status::Deleted, format!("origin {}.", origin))
-      .map_err(Into::into)
+    match api_client.delete_origin(origin, token) {
+        Ok(_) => {
+            ui.status(Status::Deleted, format!("origin {}.", origin))
+              .map_err(Into::into)
+        }
+        Err(api_client::Error::APIError(StatusCode::Conflict, msg)) => {
+            ui.fatal(format!("Unable to delete origin {}", origin))?;
+            ui.fatal(format!("Origins may only be deleted if they have no packages, linked \
+                              projects"))?;
+            ui.fatal("or other dependencies. Please check your origin and try again.")?;
+            Err(Error::APIClient(api_client::Error::APIError(StatusCode::Conflict, msg)))
+        }
+        Err(e) => {
+            ui.fatal(format!("Failed to delete origin {}, {:?}", origin, e))?;
+            Err(Error::from(e))
+        }
+    }
 }


### PR DESCRIPTION
This change adds some explanatory text for origin deletion failure.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-11595829](https://user-images.githubusercontent.com/13542112/56438072-88b9b880-6296-11e9-888a-1f7f78f0e2bf.gif)
