### PR TITLE
Add `cargo test` runs on Linux for core repository crates

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -103,6 +103,38 @@ steps:
       automatic:
         limit: 1
 
+  - label: "[unit] :linux: core"
+    command:
+      - ./test/run_cargo_test.sh core
+    agents:
+      queue: 'default-privileged'
+    plugins:
+      docker#v3.0.1:
+        always-pull: true
+        user: "buildkite-agent"
+        group: "buildkite-agent"
+        image: "chefes/buildkite"
+    timeout_in_minutes: 10
+    retry:
+      automatic:
+        limit: 1
+
+  - label: "[unit] :linux: http-client"
+    command:
+      - ./test/run_cargo_test.sh http-client
+    agents:
+      queue: 'default-privileged'
+    plugins:
+      docker#v3.0.1:
+        always-pull: true
+        user: "buildkite-agent"
+        group: "buildkite-agent"
+        image: "chefes/buildkite"
+    timeout_in_minutes: 10
+    retry:
+      automatic:
+        limit: 1
+
   - label: "[unit] :linux: hab"
     command:
       - ./test/run_cargo_test.sh hab


### PR DESCRIPTION
Adds `cargo test` runs for the `core` and `http-client` crates on Linux.

@mwrock will add the corresponding Windows tests, as well as ones for the `win-users` crate, in his refactoring work already underway in #6466.

Signed-off-by: Christopher Maier <cmaier@chef.io>