### PR TITLE
Update the default allocator to jemalloc.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -880,6 +880,7 @@ dependencies = [
  "habitat_http_client 0.0.0",
  "handlebars 0.29.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.10.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jemallocator 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/hab/Cargo.toml
+++ b/components/hab/Cargo.toml
@@ -60,6 +60,9 @@ widestring = "*"
 winapi = { version = "*", features = ["winuser", "windef"] }
 winreg = "*"
 
+[target.'cfg(target_family = "unix")'.dependencies]
+jemallocator = "*"
+
 [dev-dependencies]
 tempfile = "*"
 

--- a/components/hab/habitat/plan.sh
+++ b/components/hab/habitat/plan.sh
@@ -7,7 +7,9 @@ pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 # The result is a portable, static binary in a zero-dependency package.
 pkg_deps=()
-pkg_build_deps=(core/musl
+pkg_build_deps=(core/make
+                core/jemalloc-musl
+                core/musl
                 core/zlib-musl
                 core/xz-musl
                 core/bzip2-musl
@@ -72,6 +74,10 @@ do_prepare() {
   # package proper--it won't find its way into the final binaries.
   export LD_LIBRARY_PATH=$(pkg_path_for gcc)/lib
   build_line "Setting LD_LIBRARY_PATH=$LD_LIBRARY_PATH"
+
+  # Credit to @smacfarlane for discovering this gem
+  export JEMALLOC_OVERRIDE="$(pkg_path_for jemalloc-musl)/lib/libjemalloc.a"
+  export JEMALLOC_STATIC="true"
 }
 
 do_build() {

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -2,6 +2,8 @@
 
 #[macro_use]
 extern crate clap;
+#[cfg(unix)]
+extern crate jemallocator;
 #[macro_use]
 extern crate lazy_static;
 #[macro_use]
@@ -104,6 +106,10 @@ lazy_static! {
              "group",]
     };
 }
+
+#[cfg(unix)]
+#[global_allocator]
+static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 fn main() {
     env_logger::init();


### PR DESCRIPTION
Part of this is just to be consistent with hab-sup, which uses jemalloc
because it allows the gathering of metrics with regards to allocations.
The other part is to try and solve some strange hanging issues where
'hab pkg path' will peg the CPU at 100% and never return. Attaching gdb
to a hung process and inspecting stack frames shows malloc as the
culprit, so this is an attempt to fix that bug.

![](https://media.giphy.com/media/z6ccg9ZZzWT2E/giphy.gif)

Closes https://github.com/habitat-sh/habitat/issues/6252
Signed-off-by: Josh Black <raskchanky@gmail.com>