### PR TITLE
Manually trigger an election (exploratory, unfinshed feature in development)

### DIFF
--- a/components/butterfly/src/server/mod.rs
+++ b/components/butterfly/src/server/mod.rs
@@ -27,38 +27,6 @@ mod pull;
 mod push;
 pub mod timing;
 
-use std::{collections::{HashMap,
-                        HashSet},
-          fmt::{self,
-                Debug},
-          fs,
-          io,
-          net::{SocketAddr,
-                ToSocketAddrs,
-                UdpSocket},
-          path::{Path,
-                 PathBuf},
-          result,
-          sync::{atomic::{AtomicBool,
-                          AtomicIsize,
-                          Ordering},
-                 mpsc::{self,
-                        channel},
-                 Arc,
-                 Mutex,
-                 RwLock},
-          thread,
-          time::{Duration,
-                 Instant}};
-
-use habitat_core::crypto::SymKey;
-use prometheus::{HistogramTimer,
-                 HistogramVec,
-                 IntGauge};
-use serde::{ser::SerializeStruct,
-            Serialize,
-            Serializer};
-
 use self::incarnation_store::IncarnationStore;
 use crate::{error::{Error,
                     Result},
@@ -85,6 +53,37 @@ use crate::{error::{Error,
             swim::Ack,
             trace::{Trace,
                     TraceKind}};
+use habitat_common::FeatureFlag;
+use habitat_core::crypto::SymKey;
+use prometheus::{HistogramTimer,
+                 HistogramVec,
+                 IntGauge};
+use serde::{ser::SerializeStruct,
+            Serialize,
+            Serializer};
+use std::{collections::{HashMap,
+                        HashSet},
+          fmt::{self,
+                Debug},
+          fs,
+          io,
+          net::{SocketAddr,
+                ToSocketAddrs,
+                UdpSocket},
+          path::{Path,
+                 PathBuf},
+          result,
+          sync::{atomic::{AtomicBool,
+                          AtomicIsize,
+                          Ordering},
+                 mpsc::{self,
+                        channel},
+                 Arc,
+                 Mutex,
+                 RwLock},
+          thread,
+          time::{Duration,
+                 Instant}};
 
 /// The maximum number of other members we should notify when we shut
 /// down and leave the ring.

--- a/components/butterfly/tests/rumor/election.rs
+++ b/components/butterfly/tests/rumor/election.rs
@@ -14,6 +14,7 @@
 
 use habitat_butterfly::{member::Health,
                         rumor::election::ElectionStatus};
+use habitat_common::FeatureFlag;
 
 use crate::btest;
 
@@ -75,9 +76,9 @@ fn five_members_elect_a_new_leader_when_the_old_one_dies() {
     let paused_id = net[paused].member_id();
     assert_wait_for_health_of!(net, paused, Health::Confirmed);
     if paused == 0 {
-        net[1].restart_elections();
+        net[1].restart_elections(FeatureFlag::empty());
     } else {
-        net[0].restart_elections();
+        net[0].restart_elections(FeatureFlag::empty());
     }
 
     for i in 0..5 {
@@ -143,8 +144,8 @@ fn five_members_elect_a_new_leader_when_they_are_quorum_partitioned() {
     let mut new_leader_id = String::from("");
     net.partition(0..2, 2..5);
     assert_wait_for_health_of!(net, [0..2, 2..5], Health::Confirmed);
-    net[0].restart_elections();
-    net[4].restart_elections();
+    net[0].restart_elections(FeatureFlag::empty());
+    net[4].restart_elections(FeatureFlag::empty());
     assert_wait_for_election_status!(net, 0, "witcher.prod", ElectionStatus::NoQuorum);
     assert_wait_for_election_status!(net, 1, "witcher.prod", ElectionStatus::NoQuorum);
     assert_wait_for_election_status!(net, 2, "witcher.prod", ElectionStatus::Finished);

--- a/components/common/src/lib.rs
+++ b/components/common/src/lib.rs
@@ -90,15 +90,16 @@ bitflags::bitflags! {
     /// environment variable to which it corresponds in the `ENV_VARS`
     /// map below.
     pub struct FeatureFlag: u32 {
-        const LIST            = 0b0000_0000_0001;
-        const TEST_EXIT       = 0b0000_0000_0010;
-        const TEST_BOOT_FAIL  = 0b0000_0000_0100;
-        const REDACT_HTTP     = 0b0000_0000_1000;
-        const IGNORE_SIGNALS  = 0b0000_0001_0000;
-        const INSTALL_HOOK    = 0b0000_0010_0000;
-        const OFFLINE_INSTALL = 0b0000_0100_0000;
-        const IGNORE_LOCAL    = 0b0000_1000_0000;
-        const EVENT_STREAM    = 0b0001_0000_0000;
+        const LIST             = 0b0000_0000_0001;
+        const TEST_EXIT        = 0b0000_0000_0010;
+        const TEST_BOOT_FAIL   = 0b0000_0000_0100;
+        const REDACT_HTTP      = 0b0000_0000_1000;
+        const IGNORE_SIGNALS   = 0b0000_0001_0000;
+        const INSTALL_HOOK     = 0b0000_0010_0000;
+        const OFFLINE_INSTALL  = 0b0000_0100_0000;
+        const IGNORE_LOCAL     = 0b0000_1000_0000;
+        const EVENT_STREAM     = 0b0001_0000_0000;
+        const TRIGGER_ELECTION = 0b0010_0000_0000;
     }
 }
 
@@ -112,7 +113,8 @@ lazy_static! {
                            (FeatureFlag::INSTALL_HOOK, "HAB_FEAT_INSTALL_HOOK"),
                            (FeatureFlag::OFFLINE_INSTALL, "HAB_FEAT_OFFLINE_INSTALL"),
                            (FeatureFlag::IGNORE_LOCAL, "HAB_FEAT_IGNORE_LOCAL"),
-                           (FeatureFlag::EVENT_STREAM, "HAB_FEAT_EVENT_STREAM")];
+                           (FeatureFlag::EVENT_STREAM, "HAB_FEAT_EVENT_STREAM"),
+                           (FeatureFlag::TRIGGER_ELECTION, "HAB_FEAT_TRIGGER_ELECTION")];
         HashMap::from_iter(mapping)
     };
 }

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -870,7 +870,7 @@ impl Manager {
                 runtime.spawn(f);
             }
 
-            self.restart_elections();
+            self.restart_elections(self.feature_flags);
             self.census_ring
                 .update_from_rumors(&self.state.cfg.cache_key_path,
                                     &self.butterfly.service_store,
@@ -1153,7 +1153,9 @@ impl Manager {
     }
 
     /// Check if any elections need restarting.
-    fn restart_elections(&mut self) { self.butterfly.restart_elections(); }
+    fn restart_elections(&mut self, feature_flags: FeatureFlag) {
+        self.butterfly.restart_elections(feature_flags);
+    }
 
     /// Create a future for stopping a Service. The Service is assumed
     /// to have been removed from the internal list of active services


### PR DESCRIPTION
To help work around some issues in elections, as well as to help
investigate them further, this commit introduces the beginnings of a
potential feature for allowing operators to manually trigger a service
election.

The current incarnation relies on the `HAB_FEAT_TRIGGER_ELECTION`
feature flag. A Supervisor operating with this flag enabled will
initiate a new election for a service group if a special sentinel file
for that group is found on disk.

To trigger a new election for the service group `foo.default`, for
example, create the file

   /hab/sup/default/data/trigger_foo.default_election

(That is, a file with the name `trigger_${SERVICE_GROUP_NAME}_election`.)

This should be done on a Supervisor that is actually running the
`foo.default` service group.

As the Supervisor's main loop executes, it will respond to the
presence of such a file by initiating a new election. The sentinel
file is also deleted, to prevent endless cycles of elections. If the
file is created in such a way that the Supervisor cannot delete it, no
election is triggered.

To monitor this feature in logs, add
`habitat_butterfly::server::election_trigger=trace` to your `RUST_LOG`
environment variable (or use `info` for less noisy log output).

cc: @irvingpop @dmccown 