### PR TITLE
build_component.ps1 should enter a non interactive container and forward exit code

### DIFF
--- a/support/ci/build_component.ps1
+++ b/support/ci/build_component.ps1
@@ -17,8 +17,7 @@ $env:HAB_CACHE_KEY_PATH="$job_temp_root/keys"
 Write-Host "--- :key: Generating fake origin key"
 hab origin key generate
 Write-Host "--- :hab: Running hab pkg build for $Component"
-# REMOVE -R AFTER 0.75.0
-hab pkg build -D -R components/$Component
 
+hab studio build -D --no-tty --non-interactive components/$Component
 
-if($LASTEXITCODE -ne 0) { Write-Error "Failed to build package!" }
+exit $LASTEXITCODE


### PR DESCRIPTION
Just noticed all the windows builds are reporting success but are actually failing. This should fix the docker error:

```
the input device is not a TTY.  If you are using mintty, try prefixing the command with 'winpty'
```

and also make sure the exitcode from docker gets forwarded to buildkite.

Signed-off-by: mwrock <matt@mattwrock.com>