### PR TITLE
Run health checks asynchronously

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1267,6 +1267,7 @@ dependencies = [
  "tokio 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "valico 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/sup/Cargo.toml
+++ b/components/sup/Cargo.toml
@@ -65,6 +65,7 @@ toml = { version = "*", default-features = false }
 tokio = "*"
 tokio-core = "*"
 tokio-codec = "*"
+tokio-timer = "*"
 url = "*"
 valico = "*"
 

--- a/components/sup/src/http_gateway.rs
+++ b/components/sup/src/http_gateway.rs
@@ -1,8 +1,8 @@
 use crate::{error::{Result,
                     SupError},
             manager::{self,
-                      service::{HealthCheck,
-                                HealthCheckHook}}};
+                      service::{HealthCheckHook,
+                                HealthCheckResult}}};
 use actix;
 use actix_web::{http::{self,
                        StatusCode},
@@ -149,12 +149,12 @@ struct HealthCheckBody {
     stderr: String,
 }
 
-impl Into<StatusCode> for HealthCheck {
+impl Into<StatusCode> for HealthCheckResult {
     fn into(self) -> StatusCode {
         match self {
-            HealthCheck::Ok | HealthCheck::Warning => StatusCode::OK,
-            HealthCheck::Critical => StatusCode::SERVICE_UNAVAILABLE,
-            HealthCheck::Unknown => StatusCode::INTERNAL_SERVER_ERROR,
+            HealthCheckResult::Ok | HealthCheckResult::Warning => StatusCode::OK,
+            HealthCheckResult::Critical => StatusCode::SERVICE_UNAVAILABLE,
+            HealthCheckResult::Unknown => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
 }

--- a/components/sup/src/lib.rs
+++ b/components/sup/src/lib.rs
@@ -76,6 +76,7 @@ pub mod error;
 mod event;
 pub mod http_gateway;
 pub mod manager;
+mod sup_futures;
 mod sys;
 #[cfg(test)]
 pub mod test_helpers;

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -962,7 +962,7 @@ impl Manager {
                 // this var goes out of scope
                 #[allow(unused_variables)]
                 let service_timer = service_hist.start_timer();
-                if service.tick(&self.census_ring, &self.launcher) {
+                if service.tick(&self.census_ring, &self.launcher, &runtime.executor()) {
                     self.gossip_latest_service_rumor(&service);
                 }
             }

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -20,7 +20,7 @@ use self::{action::{ShutdownSpec,
                           SUP_PKG_IDENT},
            service::{ConfigRendering,
                      DesiredState,
-                     HealthCheck,
+                     HealthCheckResult,
                      Service,
                      ServiceProxy,
                      ServiceSpec,
@@ -337,7 +337,7 @@ pub struct GatewayState {
     pub services_data: String,
     /// Data returned by /services/<SERVICE_NAME>/<GROUP_NAME>/health
     /// endpoint
-    pub health_check_data: HashMap<ServiceGroup, HealthCheck>,
+    pub health_check_data: HashMap<ServiceGroup, HealthCheckResult>,
 }
 
 pub struct Manager {

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -1254,7 +1254,7 @@ impl Manager {
     }
 
     /// Remove the given service from the manager.
-    fn service_stop_future(service: Service,
+    fn service_stop_future(mut service: Service,
                            shutdown_spec: ShutdownSpec,
                            user_config_watcher: Arc<RwLock<UserConfigWatcher>>,
                            updater: Arc<Mutex<ServiceUpdater>>,

--- a/components/sup/src/manager/service/health.rs
+++ b/components/sup/src/manager/service/health.rs
@@ -121,7 +121,7 @@ impl State {
 
         // Use an Arc to avoid having to have full clones everywhere. :/
         let service_group = Arc::new(service_group);
-        let service_group_copy = service_group.clone();
+        let service_group_ref = Arc::clone(&service_group);
 
         if let Some(hook) = hook {
             let hr = hook_runner::HookRunner::new(hook,
@@ -140,7 +140,7 @@ impl State {
             Either::B(lazy(move || Ok(status)))
         }.map_err(move |e| {
              error!("Error running health check hook for {}: {:?}",
-                    service_group_copy, e)
+                    service_group_ref, e)
          })
          .and_then(move |check_result| {
              debug!("Caching HealthCheck = '{}' for '{}'",

--- a/components/sup/src/manager/service/health.rs
+++ b/components/sup/src/manager/service/health.rs
@@ -193,19 +193,16 @@ impl State {
             // it.
             let service_group = state.service_group.clone();
             state.clone().single_iteration().then(move |res| {
-                                                match res {
-                                                    Ok(_) => {
-                                                        trace!("Health check future for {} \
-                                                                succeeded; continuing loop",
-                                                               service_group);
-                                                        Ok(Loop::Continue(state))
-                                                    }
-                                                    Err(_) => {
-                                                        trace!("Health check future for {} \
-                                                                failed failed; continuing loop.",
-                                                               service_group);
-                                                        Ok(Loop::Continue(state))
-                                                    }
+                                                if res.is_ok() {
+                                                    trace!("Health check future for {} \
+                                                            succeeded; continuing loop",
+                                                           service_group);
+                                                    Ok(Loop::Continue(state))
+                                                } else {
+                                                    trace!("Health check future for {} failed \
+                                                            failed; continuing loop.",
+                                                           service_group);
+                                                    Ok(Loop::Continue(state))
                                                 }
                                             })
         })

--- a/components/sup/src/manager/service/health.rs
+++ b/components/sup/src/manager/service/health.rs
@@ -1,5 +1,24 @@
-use std::fmt;
+use crate::manager::{service::{hook_runner,
+                               hooks::HealthCheckHook,
+                               supervisor::Supervisor},
+                     GatewayState};
+use futures::{future::{self,
+                       lazy,
+                       Either,
+                       Future,
+                       Loop},
+              IntoFuture};
+use habitat_common::templating::package::Pkg;
+use habitat_core::service::{HealthCheckInterval,
+                            ServiceGroup};
+use std::{fmt,
+          ops::Deref,
+          sync::{Arc,
+                 Mutex,
+                 RwLock},
+          time::Instant};
 
+/// The possible results of running a health check hook.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize)]
 pub enum HealthCheck {
     Ok,
@@ -12,6 +31,7 @@ impl Default for HealthCheck {
     fn default() -> HealthCheck { HealthCheck::Unknown }
 }
 
+/// Convert health check hook exit codes into `HealthCheck` statuses.
 impl From<i8> for HealthCheck {
     fn from(value: i8) -> HealthCheck {
         match value {
@@ -33,5 +53,162 @@ impl fmt::Display for HealthCheck {
             HealthCheck::Unknown => "UNKNOWN",
         };
         write!(f, "{}", msg)
+    }
+}
+
+/// All state needed for checking the health of a service over time.
+#[derive(Clone)]
+pub struct State {
+    // All hooks currently need these
+    hook:                   Option<Arc<HealthCheckHook>>,
+    service_group:          ServiceGroup,
+    package:                Pkg,
+    svc_encrypted_password: Option<String>,
+
+    /// A reference to the process supervisor for the service. This is
+    /// used to create a "proxy health check" for services that do not
+    /// provide their own health check hook.
+    supervisor: Arc<Mutex<Supervisor>>,
+
+    /// The configured interval at which to run health checks for this
+    /// service. The interval actually used may differ based on the
+    /// previous health check result.
+    configured_interval: HealthCheckInterval,
+
+    /// A reference to the service's current health check status. We
+    /// store the result of the health check here.
+    service_health_result: Arc<Mutex<HealthCheck>>,
+
+    /// A reference to the Supervisor's gateway state. We also store
+    /// the status in here for making it available via the HTTP
+    /// gateway.
+    gateway_state: Arc<RwLock<GatewayState>>,
+}
+
+impl State {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(hook: Option<Arc<HealthCheckHook>>,
+               service_group: ServiceGroup,
+               package: Pkg,
+               svc_encrypted_password: Option<String>,
+               supervisor: Arc<Mutex<Supervisor>>,
+               configured_interval: HealthCheckInterval,
+               service_health_result: Arc<Mutex<HealthCheck>>,
+               gateway_state: Arc<RwLock<GatewayState>>)
+               -> Self {
+        State { hook,
+                service_group,
+                package,
+                svc_encrypted_password,
+                supervisor,
+                configured_interval,
+                service_health_result,
+                gateway_state }
+    }
+
+    /// Creates a future that runs the health check and then waits for
+    /// a suitable interval. Multiple such iterations will then be
+    /// chained together for an unending stream of health checks.
+    fn single_iteration(self) -> impl Future<Item = (), Error = ()> {
+        let State { hook,
+                    service_group,
+                    package,
+                    svc_encrypted_password,
+                    supervisor,
+
+                    configured_interval,
+                    service_health_result,
+                    gateway_state, } = self;
+
+        // Use an Arc to avoid having to have full clones everywhere. :/
+        let service_group = Arc::new(service_group);
+        let service_group_copy = service_group.clone();
+
+        if let Some(hook) = hook {
+            let hr = hook_runner::HookRunner::new(hook,
+                                                  service_group.deref().clone(),
+                                                  package,
+                                                  svc_encrypted_password);
+            Either::A(hr.into_future())
+        } else {
+            let status = match supervisor.lock()
+                                         .expect("couldn't unlock supervisor")
+                                         .status()
+            {
+                (true, _) => HealthCheck::Ok,
+                (false, _) => HealthCheck::Critical,
+            };
+            Either::B(lazy(move || Ok(status)))
+        }.map_err(move |e| {
+             error!("Error running health check hook for {}: {:?}",
+                    service_group_copy, e)
+         })
+         .and_then(move |check_result| {
+             debug!("Caching HealthCheck = '{}' for '{}'",
+                    check_result, service_group);
+
+             *service_health_result.lock()
+                                   .expect("Could not unlock service_health_result") = check_result;
+             gateway_state.write()
+                          .expect("GatewayState lock is poisoned")
+                          .health_check_data
+                          .insert(service_group.deref().clone(), check_result);
+
+             let interval = if check_result == HealthCheck::Ok {
+                 // routine health check
+                 configured_interval
+             } else {
+                 // special health check interval
+                 HealthCheckInterval::default()
+             };
+
+             trace!("Next health check for {} in {}", service_group, interval);
+
+             let instant =
+                 Instant::now().checked_add(interval.into())
+                               .expect("This should never happen with normal health check \
+                                        interval sizes");
+             tokio_timer::timer::Handle::current().delay(instant)
+                                                  .map_err(move |timer_error| {
+                                                      if timer_error.is_shutdown() {
+                                                          warn!("Timer for {} health check shut \
+                                                                 down!",
+                                                                service_group);
+                                                      }
+                                                      if timer_error.is_at_capacity() {
+                                                          warn!("Timer for {} health check is at \
+                                                                 capacity!",
+                                                                service_group);
+                                                      }
+                                                  })
+         })
+    }
+
+    /// Repeatedly runs a health check, followed by an appropriate
+    /// delay, forever.
+    pub fn check_repeatedly(self) -> impl Future<Item = (), Error = ()> {
+        future::loop_fn(self, move |state| {
+            // TODO (CM): If we wanted to keep track of how many times
+            // a health check has failed in the past X executions, or
+            // do similar historical tracking, here's where we'd do
+            // it.
+            let service_group = state.service_group.clone();
+            state.clone().single_iteration().then(move |res| {
+                                                match res {
+                                                    Ok(_) => {
+                                                        trace!("Health check future for {} \
+                                                                succeeded; continuing loop",
+                                                               service_group);
+                                                        Ok(Loop::Continue(state))
+                                                    }
+                                                    Err(_) => {
+                                                        trace!("Health check future for {} \
+                                                                failed failed; continuing loop.",
+                                                               service_group);
+                                                        Ok(Loop::Continue(state))
+                                                    }
+                                                }
+                                            })
+        })
     }
 }

--- a/components/sup/src/manager/service/health.rs
+++ b/components/sup/src/manager/service/health.rs
@@ -73,7 +73,7 @@ pub struct State {
     /// The configured interval at which to run health checks for this
     /// service. The interval actually used may differ based on the
     /// previous health check result.
-    configured_interval: HealthCheckInterval,
+    nominal_interval: HealthCheckInterval,
 
     /// A reference to the service's current health check status. We
     /// store the result of the health check here.
@@ -92,7 +92,7 @@ impl State {
                package: Pkg,
                svc_encrypted_password: Option<String>,
                supervisor: Arc<Mutex<Supervisor>>,
-               configured_interval: HealthCheckInterval,
+               nominal_interval: HealthCheckInterval,
                service_health_result: Arc<Mutex<HealthCheck>>,
                gateway_state: Arc<RwLock<GatewayState>>)
                -> Self {
@@ -101,7 +101,7 @@ impl State {
                 package,
                 svc_encrypted_password,
                 supervisor,
-                configured_interval,
+                nominal_interval,
                 service_health_result,
                 gateway_state }
     }
@@ -115,7 +115,7 @@ impl State {
                     package,
                     svc_encrypted_password,
                     supervisor,
-                    configured_interval,
+                    nominal_interval,
                     service_health_result,
                     gateway_state, } = self;
 
@@ -155,7 +155,7 @@ impl State {
 
              let interval = if check_result == HealthCheck::Ok {
                  // routine health check
-                 configured_interval
+                 nominal_interval
              } else {
                  // special health check interval
                  HealthCheckInterval::default()

--- a/components/sup/src/manager/service/health.rs
+++ b/components/sup/src/manager/service/health.rs
@@ -115,7 +115,6 @@ impl State {
                     package,
                     svc_encrypted_password,
                     supervisor,
-
                     configured_interval,
                     service_health_result,
                     gateway_state, } = self;

--- a/components/sup/src/manager/service/hooks.rs
+++ b/components/sup/src/manager/service/hooks.rs
@@ -418,9 +418,11 @@ impl Hook for PostStopHook {
     fn stderr_log_path(&self) -> &Path { &self.stderr_log_path }
 }
 
+// Hooks wrapped in Arcs represent a possibly-temporary state while we
+// refactor hooks to be able to run asynchronously.
 #[derive(Debug, Default, Serialize)]
 pub struct HookTable {
-    pub health_check: Option<HealthCheckHook>,
+    pub health_check: Option<Arc<HealthCheckHook>>,
     pub init:         Option<InitHook>,
     pub file_updated: Option<FileUpdatedHook>,
     pub reload:       Option<ReloadHook>,
@@ -428,9 +430,7 @@ pub struct HookTable {
     pub suitability:  Option<SuitabilityHook>,
     pub run:          Option<RunHook>,
     pub post_run:     Option<PostRunHook>,
-    // This Arc<> business is a possibly-temporary state while
-    // we refactor hooks to be able to run asynchronously.
-    pub post_stop: Option<Arc<PostStopHook>>,
+    pub post_stop:    Option<Arc<PostStopHook>>,
 }
 
 impl HookTable {
@@ -443,7 +443,8 @@ impl HookTable {
         if let Ok(meta) = std::fs::metadata(templates.as_ref()) {
             if meta.is_dir() {
                 table.file_updated = FileUpdatedHook::load(package_name, &hooks_path, &templates);
-                table.health_check = HealthCheckHook::load(package_name, &hooks_path, &templates);
+                table.health_check =
+                    HealthCheckHook::load(package_name, &hooks_path, &templates).map(Arc::new);
                 table.suitability = SuitabilityHook::load(package_name, &hooks_path, &templates);
                 table.init = InitHook::load(package_name, &hooks_path, &templates);
                 table.reload = ReloadHook::load(package_name, &hooks_path, &templates);
@@ -474,7 +475,7 @@ impl HookTable {
             changed |= self.compile_one(hook, service_group, ctx);
         }
         if let Some(ref hook) = self.health_check {
-            changed |= self.compile_one(hook, service_group, ctx);
+            changed |= self.compile_one(hook.as_ref(), service_group, ctx);
         }
         if let Some(ref hook) = self.init {
             changed |= self.compile_one(hook, service_group, ctx);

--- a/components/sup/src/manager/service/hooks.rs
+++ b/components/sup/src/manager/service/hooks.rs
@@ -59,7 +59,7 @@ pub struct HealthCheckHook {
 }
 
 impl Hook for HealthCheckHook {
-    type ExitValue = health::HealthCheck;
+    type ExitValue = health::HealthCheckResult;
 
     fn file_name() -> &'static str { "health-check" }
 
@@ -72,18 +72,18 @@ impl Hook for HealthCheckHook {
     fn handle_exit<'a>(&self, pkg: &Pkg, _: &'a HookOutput, status: ExitStatus) -> Self::ExitValue {
         let pkg_name = &pkg.name;
         match status.code() {
-            Some(0) => health::HealthCheck::Ok,
-            Some(1) => health::HealthCheck::Warning,
-            Some(2) => health::HealthCheck::Critical,
-            Some(3) => health::HealthCheck::Unknown,
+            Some(0) => health::HealthCheckResult::Ok,
+            Some(1) => health::HealthCheckResult::Warning,
+            Some(2) => health::HealthCheckResult::Critical,
+            Some(3) => health::HealthCheckResult::Unknown,
             Some(code) => {
                 outputln!(preamble pkg_name,
                     "Health check exited with an unknown status code, {}", code);
-                health::HealthCheck::default()
+                health::HealthCheckResult::default()
             }
             None => {
                 Self::output_termination_message(pkg_name, status);
-                health::HealthCheck::default()
+                health::HealthCheckResult::default()
             }
         }
     }

--- a/components/sup/src/manager/service/mod.rs
+++ b/components/sup/src/manager/service/mod.rs
@@ -142,6 +142,10 @@ pub struct Service {
     // *also* storing the health check result directly (see
     // manager::GatewayState#health_check_data), but because of how
     // the data is currently rendered, this is a little complicated.
+    //
+    // In order to access this field in an asynchronous health check
+    // hook, we need to wrap some Arc<Mutex<_>> protection around it
+    // :(
     health_check_result: Arc<Mutex<HealthCheck>>,
     last_election_status: ElectionStatus,
     needs_reload: bool,
@@ -213,7 +217,7 @@ impl Service {
                      bldr_url: spec.bldr_url,
                      channel: spec.channel,
                      desired_state: spec.desired_state,
-                     health_check_result: HealthCheck::default(),
+                     health_check_result: Arc::new(Mutex::new(HealthCheck::default())),
                      hooks: HookTable::load(&pkg.name,
                                             &hooks_root,
                                             svc_hooks_path(&service_group.service())),
@@ -972,7 +976,10 @@ impl Service {
                    self.spec_ident, check_result);
             self.schedule_special_health_check();
         }
-        self.health_check_result = check_result;
+        *self.health_check_result
+             .lock()
+             .expect("Could not unlock health_check_result") = check_result;
+
         self.cache_health_check(check_result);
     }
 

--- a/components/sup/src/manager/service/mod.rs
+++ b/components/sup/src/manager/service/mod.rs
@@ -20,7 +20,7 @@ mod terminator;
 use self::{context::RenderContext,
            hooks::HookTable,
            supervisor::Supervisor};
-pub use self::{health::HealthCheck,
+pub use self::{health::HealthCheckResult,
                hooks::HealthCheckHook,
                spec::{DesiredState,
                       IntoServiceSpec,
@@ -147,7 +147,7 @@ pub struct Service {
     // In order to access this field in an asynchronous health check
     // hook, we need to wrap some Arc<Mutex<_>> protection around it
     // :(
-    health_check_result: Arc<Mutex<HealthCheck>>,
+    health_check_result: Arc<Mutex<HealthCheckResult>>,
     last_election_status: ElectionStatus,
     needs_reload: bool,
     needs_reconfiguration: bool,
@@ -222,7 +222,7 @@ impl Service {
                      bldr_url: spec.bldr_url,
                      channel: spec.channel,
                      desired_state: spec.desired_state,
-                     health_check_result: Arc::new(Mutex::new(HealthCheck::default())),
+                     health_check_result: Default::default(),
                      hooks: HookTable::load(&pkg.name,
                                             &hooks_root,
                                             svc_hooks_path(&service_group.service())),

--- a/components/sup/src/manager/service/mod.rs
+++ b/components/sup/src/manager/service/mod.rs
@@ -374,7 +374,7 @@ impl Service {
         let f = self.supervisor
                     .lock()
                     .expect("Couldn't lock supervisor")
-                    .stop()
+                    .stop(shutdown_spec)
                     .and_then(move |_| {
                         gs.write()
                           .expect("GatewayState lock is poisoned")

--- a/components/sup/src/sup_futures.rs
+++ b/components/sup/src/sup_futures.rs
@@ -14,7 +14,7 @@ pub struct FutureHandle(oneshot::Sender<()>);
 impl FutureHandle {
     /// A more explicit way to cancel a future instead of relying on
     /// dropping the handle.
-    pub fn terminate(self) { let _ = self.0.send(()); }
+    pub fn terminate(self) { self.0.send(()).ok(); }
 }
 
 // TODO (CM): I'm not super thrilled with the error type being

--- a/components/sup/src/sup_futures.rs
+++ b/components/sup/src/sup_futures.rs
@@ -1,0 +1,48 @@
+//! Custom futures used throughout the Supervisor.
+
+use futures::{future::Either,
+              sync::oneshot,
+              Future,
+              IntoFuture};
+
+/// A handle attached to a future generated using
+/// `cancelable_future`. That future will be dropped when this handle
+/// is dropped.
+#[derive(Debug)]
+pub struct FutureHandle(oneshot::Sender<()>);
+
+impl FutureHandle {
+    /// A more explicit way to cancel a future instead of relying on
+    /// dropping the handle.
+    pub fn terminate(self) { let _ = self.0.send(()); }
+}
+
+// TODO (CM): I'm not super thrilled with the error type being
+// Option<E> here, but it should be "fine" for now.
+/// Wrap a future in another future which allows the entire thing to
+/// be dropped if a `Handle` to the future is dropped.
+///
+/// This is useful for retaining control of long-running futures.
+pub fn cancelable_future<F, I, E>(fut: F)
+                                  -> (FutureHandle, impl Future<Item = I, Error = Option<E>>)
+    where F: IntoFuture<Item = I, Error = E>
+{
+    let (tx, rx) = oneshot::channel();
+    let cancelable =
+        fut.into_future().select2(rx).then(|res| {
+                                         match res {
+                                             Ok(Either::A((f_ok, _rx))) => Ok(f_ok),
+                                             Err(Either::A((f_err, _rx))) => Err(Some(f_err)),
+                                             Ok(Either::B((..))) => {
+                                                 trace!("Handle signalled; canceling future");
+                                                 Err(None)
+                                             }
+                                             Err(Either::B((..))) => {
+                                                 trace!("Handle dropped; canceling future");
+                                                 Err(None)
+                                             }
+                                         }
+                                     });
+
+    (FutureHandle(tx), cancelable)
+}


### PR DESCRIPTION
Previously, health check hooks were run synchronously by the
Supervisor, with logic for managing the scheduling of the next
invocation at some time in the future. Each time through the service's
"tick", we would have to determine whether or not to run a health
check based on this. Not only does this add complexity, but it also
ends up blocking the Supervisor if a health check hook takes any
appreciable amount of time.

Here, we reformulate health checking to happen in an endlessly
repeating future that runs asynchronously. Rather than tracking when
the next time to run a hook is, this is now baked into the logic of
the future itself, giving us less to explicitly manage.

Now, when we start a service, we spawn the health checking future. It
executes the health check, then waits for the appropriate amount of
time; these two steps constitute a single iteration of the overall
health checking process. This iteration is then repeated endlessly.

The future is constructed such that we retain a "handle" to it, which
can be used to terminate the future when, e.g., the service shuts
down. This handle is the only explicit "state" that the Service itself
needs to keep track of, and even then, all it really has to do is just
maintain ownership of it.

In order to make this approach work with how Services are currently
constructed, we needed to wrap the `HealthCheckHook` itself in an
`Arc`, as well as the service's process supervisor and health check
result fields. As we continue to move toward a more asynchronous
internal architecture, we hope to be able to eliminate this shared
state.

![tenor-203861434](https://user-images.githubusercontent.com/207178/56830247-df456a80-6833-11e9-953b-957687291977.gif)
