### PR TITLE
Add the license env var in the old way for now

### DIFF
--- a/.buildkite/abort_release_pipeline.yaml
+++ b/.buildkite/abort_release_pipeline.yaml
@@ -1,5 +1,6 @@
 env:
   HAB_LICENSE: "accept-no-persist"
+  HAB_STUDIO_SECRET_HAB_LICENSE: "accept-no-persist"
 
 steps:
   - label: ":crying_cat_face: :boom: Destroy release channel"

--- a/.buildkite/finish_release_pipeline.yaml
+++ b/.buildkite/finish_release_pipeline.yaml
@@ -1,5 +1,6 @@
 env:
   HAB_LICENSE: "accept-no-persist"
+  HAB_STUDIO_SECRET_HAB_LICENSE: "accept-no-persist"
 
 steps:
   - label: ":right-facing_fist: :boom: :left-facing_fist: Promote Release for consumption by Builder"

--- a/.buildkite/launcher_build_steps.yaml
+++ b/.buildkite/launcher_build_steps.yaml
@@ -1,5 +1,6 @@
 env:
   HAB_LICENSE: "accept-no-persist"
+  HAB_STUDIO_SECRET_HAB_LICENSE: "accept-no-persist"
 
 steps:
   - label: ":linux: :habicat: core/hab-launcher"

--- a/.buildkite/release_pipeline.yaml
+++ b/.buildkite/release_pipeline.yaml
@@ -1,5 +1,6 @@
 env:
   HAB_LICENSE: "accept-no-persist"
+  HAB_STUDIO_SECRET_HAB_LICENSE: "accept-no-persist"
 
 steps:
 


### PR DESCRIPTION
After 0.80.0 releases, we can pull this change out and it should work, but for now, I think we need to use this mechanism to get the `HAB_LICENSE` env var into the studio.

Signed-off-by: Josh Black <raskchanky@gmail.com>