### PR TITLE
Clean up some workarounds to the release process

### DIFF
--- a/.buildkite/scripts/build_component.ps1
+++ b/.buildkite/scripts/build_component.ps1
@@ -46,9 +46,6 @@ Push-Location "C:\build"
     Write-Host "Running hab pkg upload for $Component to channel $ReleaseChannel"
     Invoke-Expression "$baseHabExe pkg upload results\$pkg_artifact --channel=$ReleaseChannel"
 
-    # Temporary workaround until 0.79.0 goes out
-    Invoke-Expression "buildkite-agent meta-data set ${pkg_ident}-x86_64-windows true"
-
     If ($Component -eq 'hab') {
         Write-Host "--- :buildkite: Recording metadata $pkg_ident"
         Invoke-Expression "buildkite-agent meta-data set 'hab-version-x86_64-windows' '$pkg_ident'"

--- a/.buildkite/scripts/build_component.sh
+++ b/.buildkite/scripts/build_component.sh
@@ -47,10 +47,6 @@ ${hab_binary} pkg upload \
     --auth="${HAB_AUTH_TOKEN}" \
     "results/${pkg_artifact}"
 
-${hab_binary} pkg promote \
-    --auth="${HAB_AUTH_TOKEN}" \
-    "${pkg_ident}" "${channel}" "${pkg_target}"
-
 echo "--- :writing_hand: Recording Build Metadata"
 case "${component}" in
     "hab")

--- a/.buildkite/scripts/build_component.sh
+++ b/.buildkite/scripts/build_component.sh
@@ -41,11 +41,18 @@ else
 fi
 source results/last_build.env
 
-echo "--- :habicat: Uploading ${pkg_ident} to Builder in the '${channel}' channel"
+# TODO (SM): The 0.59.0 hab cli that we rely on for x86_64-linux builds 
+# doesn't emit pkg_target. Until we've sufficiently bootstrapped ourselves
+# we need to set it. This can be removed when studio-ci-common pulls 0.63.0 
+# or newer. This is safe to do because the x86_64-linux-kernel2 builds will
+# already have this value set.
+: "${pkg_target:=x86_64-linux}"
+
+echo "--- :habicat: Uploading ${pkg_ident:-} to Builder in the '${channel}' channel"
 ${hab_binary} pkg upload \
     --channel="${channel}" \
     --auth="${HAB_AUTH_TOKEN}" \
-    "results/${pkg_artifact}"
+    "results/${pkg_artifact:-}"
 
 echo "--- :writing_hand: Recording Build Metadata"
 case "${component}" in

--- a/.buildkite/scripts/build_component.sh
+++ b/.buildkite/scripts/build_component.sh
@@ -41,14 +41,6 @@ else
 fi
 source results/last_build.env
 
-# TODO (SM): The 0.59.0 hab cli that we rely on for x86_64-linux builds 
-# doesn't emit pkg_target. Until we've sufficiently bootstrapped ourselves
-# we need to set it. This can be removed when studio-ci-common pulls 0.63.0 
-# or newer. This is safe to do because the x86_64-linux-kernel2 builds will
-# already have this value set.
-: "${pkg_target:=x86_64-linux}"
-
-
 echo "--- :habicat: Uploading ${pkg_ident} to Builder in the '${channel}' channel"
 ${hab_binary} pkg upload \
     --channel="${channel}" \

--- a/.buildkite/scripts/build_component.sh
+++ b/.buildkite/scripts/build_component.sh
@@ -51,8 +51,6 @@ ${hab_binary} pkg promote \
     --auth="${HAB_AUTH_TOKEN}" \
     "${pkg_ident}" "${channel}" "${pkg_target}"
 
-set_target_metadata "${pkg_ident}" "${pkg_target}"
-
 echo "--- :writing_hand: Recording Build Metadata"
 case "${component}" in
     "hab")

--- a/.buildkite/scripts/build_component.sh
+++ b/.buildkite/scripts/build_component.sh
@@ -49,28 +49,16 @@ source results/last_build.env
 : "${pkg_target:=x86_64-linux}"
 
 
-# TODO: after 0.79.0 we can reenable this. We are explicitly using curl to upload
-# due to this bug: https://github.com/habitat-sh/builder/issues/940
-# echo "--- :habicat: Uploading ${pkg_ident} to Builder in the '${channel}' channel"
-# ${hab_binary} pkg upload \
-#     --channel="${channel}" \
-#     --auth="${HAB_AUTH_TOKEN}" \
-#     "results/${pkg_artifact}"
-#
-# ${hab_binary} pkg promote \
-#     --auth="${HAB_AUTH_TOKEN}" \
-#     "${pkg_ident}" "${channel}" "${pkg_target}"
+echo "--- :habicat: Uploading ${pkg_ident} to Builder in the '${channel}' channel"
+${hab_binary} pkg upload \
+    --channel="${channel}" \
+    --auth="${HAB_AUTH_TOKEN}" \
+    "results/${pkg_artifact}"
 
-echo "--- :partyparrot: Manually uploading '${pkg_ident:?}' (${pkg_target}) to Builder"
-curl --request POST \
-     --header "Content-Type: application/octet-stream" \
-     --header "Authorization: Bearer $HAB_AUTH_TOKEN" \
-     --data-binary "@results/${pkg_artifact:?}" \
-     --fail \
-     --verbose \
-    "https://bldr.habitat.sh/v1/depot/pkgs/${pkg_ident}?checksum=${pkg_blake2bsum:?}&target=${pkg_target}"
+${hab_binary} pkg promote \
+    --auth="${HAB_AUTH_TOKEN}" \
+    "${pkg_ident}" "${channel}" "${pkg_target}"
 
-promote "${pkg_ident}" "${pkg_target}" "${channel}"
 set_target_metadata "${pkg_ident}" "${pkg_target}"
 
 echo "--- :writing_hand: Recording Build Metadata"

--- a/.buildkite/scripts/promote_release_channel.sh
+++ b/.buildkite/scripts/promote_release_channel.sh
@@ -94,29 +94,13 @@ targets=("x86_64-linux"
 
 for pkg in "${non_supervisor_packages[@]}"; do
     echo "--- :habicat: Promoting '$pkg' to '$to_channel'"
-    # hab pkg promote --auth="${HAB_AUTH_TOKEN}" "${pkg}" "${to_channel}"
-    for target in "${targets[@]}"; do
-        if ident_has_target "${pkg}" "${target}"; then
-            echo "--- :star: Found a match: ${pkg} is for ${target}"
-            promote "${pkg}" "${target}" "${to_channel}"
-        else
-            echo "--- :thumbsdown: not a match"
-        fi
-    done
+    hab pkg promote --auth="${HAB_AUTH_TOKEN}" "${pkg}" "${to_channel}" "${pkg_target}"
 done
 
 echo "--- :warning: PROMOTING SUPERVISORS TO '$to_channel' :warning:"
 for pkg in "${supervisor_packages[@]}"; do
     echo "--- :habicat: Promoting $pkg to $to_channel"
-    # hab pkg promote --auth="${HAB_AUTH_TOKEN}" "${pkg}" "${to_channel}"
-    for target in "${targets[@]}"; do
-        if ident_has_target "${pkg}" "${target}"; then
-            echo "--- :star: Found a match: ${pkg} is for ${target}"
-            promote "${pkg}" "${target}" "${to_channel}"
-        else
-            echo "--- :thumbsdown: not a match"
-        fi
-    done
+    hab pkg promote --auth="${HAB_AUTH_TOKEN}" "${pkg}" "${to_channel}" "${pkg_target}"
 done
 
 buildkite-agent annotate --style="success" --context="release-manifest"

--- a/.buildkite/scripts/resolve_launcher_actions.sh
+++ b/.buildkite/scripts/resolve_launcher_actions.sh
@@ -18,7 +18,7 @@ promote_from_one_channel_to_another() {
 
     artifact="$(latest_from_builder "${target}" "${from_channel}" "${package_name}")"
     echo "--- Promoting ${artifact} (${target}) to ${to_channel}"
-    hab pkg promote --auth="${HAB_AUTH_TOKEN}" "${artifact}" "${to_channel}" "${pkg_target}"
+    hab pkg promote --auth="${HAB_AUTH_TOKEN}" "${artifact}" "${to_channel}" "${target}"
 }
 
 launcher_action=$(buildkite-agent meta-data get "launcher-action");

--- a/.buildkite/scripts/resolve_launcher_actions.sh
+++ b/.buildkite/scripts/resolve_launcher_actions.sh
@@ -18,11 +18,7 @@ promote_from_one_channel_to_another() {
 
     artifact="$(latest_from_builder "${target}" "${from_channel}" "${package_name}")"
     echo "--- Promoting ${artifact} (${target}) to ${to_channel}"
-    # TODO: after 0.79.0 we can reenable this. We are explicitly using curl to upload
-    # due to this bug: https://github.com/habitat-sh/builder/issues/940
-    # hab pkg promote --auth="${HAB_AUTH_TOKEN}" "${artifact}" "${to_channel}"
-    promote "${artifact}" "${target}" "${to_channel}"
-    set_target_metadata "${artifact}" "${target}"
+    hab pkg promote --auth="${HAB_AUTH_TOKEN}" "${artifact}" "${to_channel}" "${pkg_target}"
 }
 
 launcher_action=$(buildkite-agent meta-data get "launcher-action");

--- a/.buildkite/scripts/shared.sh
+++ b/.buildkite/scripts/shared.sh
@@ -242,34 +242,6 @@ set_version() {
     buildkite-agent meta-data set "version" "${version}"
 }
 
-# curl-based promotion function to work around https://github.com/habitat-sh/builder/issues/940
-# Remove after 0.79.0
-promote() {
-    package_ident="${1}"
-    target="${2}"
-    to_channel="${3}"
-
-    # Extract the individual bits of the fully-qualified identifier
-    IFS="/" read -r origin package version release <<< "${package_ident}"
-
-    # Create the channel, if necessary.
-    #
-    # Don't use --fail here, because trying to create a channel that
-    # already exists returns a 409, and we don't want to fail in that case.
-    echo "--- :partyparrot: Manually creating '${to_channel}' channel (if it doesn't exist already)"
-    curl --request POST \
-         --header "Authorization: Bearer $HAB_AUTH_TOKEN" \
-         --verbose \
-         "https://bldr.habitat.sh/v1/depot/channels/${origin}/${to_channel}"
-
-    echo "--- :partyparrot: Manually promoting '${package_ident}' (${target}) to the '${to_channel}' channel"
-    curl --request PUT \
-         --header "Authorization: Bearer $HAB_AUTH_TOKEN" \
-         --fail \
-         --verbose \
-         "https://bldr.habitat.sh/v1/depot/channels/${origin}/${to_channel}/pkgs/${package}/${version}/${release}/promote?&target=${target}"
-}
-
 # Until we can reliably deal with packages that have the same
 # identifier, but different target, we'll track the information in
 # Buildkite metadata.

--- a/.buildkite/scripts/shared.sh
+++ b/.buildkite/scripts/shared.sh
@@ -241,29 +241,3 @@ set_version() {
     local version=$1
     buildkite-agent meta-data set "version" "${version}"
 }
-
-# Until we can reliably deal with packages that have the same
-# identifier, but different target, we'll track the information in
-# Buildkite metadata.
-#
-# Each time we put a package into our release channel, we'll record
-# what target it was built for.
-set_target_metadata() {
-    package_ident="${1}"
-    target="${2}"
-
-    echo "--- :partyparrot: Setting target metadata for '${package_ident}' (${target})"
-    buildkite-agent meta-data set "${package_ident}-${target}" "true"
-}
-
-# When we do the final promotions, we need to know the target of each
-# package in order to properly get the promotion done. If Buildkite metadata for
-# an ident/target pair exists, then that means that's a valid
-# combination, and we can use the target in the promotion call.
-ident_has_target() {
-    package_ident="${1}"
-    target="${2}"
-
-    echo "--- :partyparrot: Checking target metadata for '${package_ident}' (${target})"
-    buildkite-agent meta-data exists "${package_ident}-${target}"
-}


### PR DESCRIPTION
This removes some workarounds regarding promotion of artifacts with different package targets. This requires 0.80.0.