### PR TITLE
Remove the catch-all code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,3 @@
-* @christophermaier @raskchanky
 .buildkite @christophermaier @scotthain
 components/backline @baumanj
 components/builder-api-client @chefsalim @raskchanky


### PR DESCRIPTION
Nobody is truly a code owner for the entire repo, so this allows us better visibility during triage to find areas of the code in need of explicit ownership.
