### PR TITLE
Add a CI step to run `ignore`d tests but not fail entire run

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -87,6 +87,20 @@ steps:
       automatic:
         limit: 1
 
+  - label: "[unit] :linux: butterfly ignored"
+    command:
+      - ./test/run_cargo_test.sh --nightly --features "deadlock_detection" --test-options "--test-threads=1 --ignored" butterfly
+    agents:
+      queue: 'default-privileged'
+    plugins:
+      docker#v3.0.1:
+        always-pull: true
+        user: "buildkite-agent"
+        group: "buildkite-agent"
+        image: "chefes/buildkite"
+    timeout_in_minutes: 20
+    soft_fail: true
+
   - label: "[unit] :linux: common"
     command:
       - ./test/run_cargo_test.sh common
@@ -317,6 +331,14 @@ steps:
     retry:
       automatic:
         limit: 1
+
+  - label: "[unit] :windows: butterfly ignored"
+    command:
+      - ./test/run_cargo_test.ps1 butterfly -Nightly -Features "deadlock_detection" -TestOptions "--test-threads=1 --ignored"
+    agents:
+      queue: 'default-windows-privileged'
+    timeout_in_minutes: 20
+    soft_fail: true
 
   - label: "[unit] :windows: common"
     command:


### PR DESCRIPTION
This serves as a reminder that there are ignored tests which should either be fixed or removed entirely.
