### PR TITLE
Propagate host license acceptance into docker containers

### DIFF
--- a/components/hab/src/license.rs
+++ b/components/hab/src/license.rs
@@ -68,8 +68,16 @@ impl LicenseData {
     }
 }
 
-pub fn check_for_license_acceptance_and_prompt(ui: &mut UI) -> Result<()> {
+pub fn check_for_license_acceptance() -> Result<bool> {
     if license_exists() || env_var_present()? {
+        return Ok(true);
+    }
+
+    Ok(false)
+}
+
+pub fn check_for_license_acceptance_and_prompt(ui: &mut UI) -> Result<()> {
+    if check_for_license_acceptance()? {
         return Ok(());
     }
 

--- a/components/pkg-export-docker/src/docker.rs
+++ b/components/pkg-export-docker/src/docker.rs
@@ -1,38 +1,22 @@
-// Copyright (c) 2016-2017 Chef Software Inc. and/or applicable contributors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
+use super::{Credentials,
+            Naming};
+use crate::{build::BuildRoot,
+            common::ui::{Status,
+                         UIWriter,
+                         UI},
+            error::{Error,
+                    Result},
+            hcore::{fs as hfs,
+                    package::PackageIdent},
+            util};
+use failure::SyncFailure;
+use handlebars::Handlebars;
+use serde_json;
 use std::{fs,
           path::{Path,
                  PathBuf},
           process::Command,
           str::FromStr};
-
-use crate::{common::ui::{Status,
-                         UIWriter,
-                         UI},
-            hcore::{fs as hfs,
-                    package::PackageIdent}};
-use failure::SyncFailure;
-use handlebars::Handlebars;
-
-use super::{Credentials,
-            Naming};
-use crate::{build::BuildRoot,
-            error::{Error,
-                    Result},
-            util};
-use serde_json;
 
 /// The `Dockerfile` template.
 #[cfg(unix)]


### PR DESCRIPTION
Without this change, docker containers that have been exported on a system where the license has been accepted will not run, but will fail at a license acceptance prompt.

![](https://media.giphy.com/media/9giteJR0GnI6Q/giphy.gif)

Signed-off-by: Josh Black <raskchanky@gmail.com>