### PR TITLE
First pass at test framework to validate studio changes

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -339,6 +339,19 @@ steps:
       automatic:
         limit: 1
 
+  - label: "[unit] :linux: studio"
+    command:
+      - ./test/run_studio_test.sh "studio-from-source"
+    expeditor:
+      executor:
+        linux: 
+          privileged: true
+          single-use: true 
+    timeout_in_minutes: 10
+    retry:
+      automatic:
+        limit: 1
+
  #################################################################
 
 
@@ -493,6 +506,16 @@ steps:
   - label: "[unit] :windows: sup-protocol"
     command:
       - ./test/run_cargo_test.ps1 sup-protocol
+    agents:
+      queue: 'default-windows-privileged'
+    timeout_in_minutes: 20
+    retry:
+      automatic:
+        limit: 1
+
+  - label: "[unit] :windows: studio"
+    command:
+      - ./test/run_studio_test.ps1 "studio-from-source"
     agents:
       queue: 'default-windows-privileged'
     timeout_in_minutes: 20
@@ -684,6 +707,7 @@ steps:
     retry:
       automatic:
         limit: 1
+
 
 #######################################################################
 # Things that have no tests but should be built to make sure they

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -347,7 +347,7 @@ steps:
         linux: 
           privileged: true
           single-use: true 
-    timeout_in_minutes: 10
+    timeout_in_minutes: 5
     retry:
       automatic:
         limit: 1
@@ -518,7 +518,7 @@ steps:
       - ./test/run_studio_test.ps1 "studio-from-source"
     agents:
       queue: 'default-windows-privileged'
-    timeout_in_minutes: 20
+    timeout_in_minutes: 5
     retry:
       automatic:
         limit: 1

--- a/components/studio/Makefile
+++ b/components/studio/Makefile
@@ -1,0 +1,15 @@
+HAB_BLDR_CHANNEL ?= stable
+
+export HAB_INTERNAL_BLDR_CHANNEL = ${HAB_BLDR_CHANNEL}
+export CI_OVERRIDE_CHANNEL = ${HAB_BLDR_CHANNEL}
+export HAB_STUDIO_SECRET_HAB_INTERNAL_BLDR_CHANNEL = ${HAB_BLDR_CHANNEL}
+export HAB_STUDIO_SECRET_CI_OVERRIDE_CHANNEL = ${HAB_BLDR_CHANNEL}
+
+test: studio-from-package studio-from-source
+
+studio-from-package:
+	test/studio-from-package/test.sh 
+
+studio-from-source: 
+	test/studio-from-source/test.sh
+

--- a/components/studio/test/fixtures/empty-plan/plan.ps1
+++ b/components/studio/test/fixtures/empty-plan/plan.ps1
@@ -1,0 +1,6 @@
+$pkg_name="empty-plan"
+$pkg_origin="ci"
+$pkg_version="0.0.1"
+
+function Invoke-Build {}
+function Invoke-Install {}

--- a/components/studio/test/fixtures/empty-plan/plan.sh
+++ b/components/studio/test/fixtures/empty-plan/plan.sh
@@ -1,0 +1,6 @@
+pkg_name="empty-plan"
+pkg_origin="ci"
+pkg_version="0.0.1"
+
+do_build() { :; }
+do_install() { :; }

--- a/components/studio/test/shared/README.md
+++ b/components/studio/test/shared/README.md
@@ -1,0 +1,8 @@
+### Linux
+
+We use [expect](https://core.tcl.tk/expect/index) in order to test the internal behavior of the Studio. We use `spawn` to create a studio, and then `send` to interact with it. With `send` we're unable to use return codes from the commands run, so all tests must emit `[PASS]` or `[FAIL]` before exiting. An automatic timeout is scheduled, such that a test will Fail if it doesn't emit either `[PASS]` or `[FAIL]`.
+
+
+### Windows
+
+We use the [Await module](https://www.powershellgallery.com/packages/Await/0.8) to test the internal behavior of the studio. Like expect, we're unable to use return codes from the tests and all tests must emit `[PASS]` or `[FAIL]`.  Unlike expect, we're unable to timeout a test, so we rely on the default timeout for CI in order to fail the test. 

--- a/components/studio/test/shared/studio-enter.exp
+++ b/components/studio/test/shared/studio-enter.exp
@@ -1,0 +1,40 @@
+#!/usr/bin/env expect
+
+set env(HAB_NOCOLORING) true
+set studio_enter_command $::env(STUDIO_ENTER_COMMAND)
+set studio_test [lindex $argv 0]
+# Print out some helpful tracing messages in the test output.
+
+proc log {message} {
+    puts "LOG >>> $message"
+}
+
+# Cleanup after the test
+exit -onexit {
+    exec hab studio rm
+}
+
+# Installing packages can take time
+set timeout 30
+
+# {*} Syntax explanation:
+# https://www.tcl.tk/man/tcl/TclCmd/Tcl.htm [5] Argument Expansion
+spawn {*}$studio_enter_command
+expect {
+  {\[default:/src:0]#} { 
+    log "Studio entered successfully -alpha "
+  }
+  eof {
+    error "Unable to enter studio"
+  }
+  timeout {
+    error "Timeout entering studio"
+  } 
+}
+
+send "$studio_test\n"
+expect {
+  {\[PASS]} { }
+  {\[FAIL]} { error "Studio internals tests failed" }
+  timeout { error "Studio internals tests timed out" }
+}

--- a/components/studio/test/shared/studio-enter.exp
+++ b/components/studio/test/shared/studio-enter.exp
@@ -22,7 +22,7 @@ set timeout 30
 spawn {*}$studio_enter_command
 expect {
   {\[default:/src:0]#} { 
-    log "Studio entered successfully -alpha "
+    log "Studio entered successfully"
   }
   eof {
     error "Unable to enter studio"

--- a/components/studio/test/shared/studio-enter.ps1
+++ b/components/studio/test/shared/studio-enter.ps1
@@ -1,0 +1,41 @@
+# Depends on https://www.powershellgallery.com/packages/Await/0.8
+param(
+    [String]$studio_command,
+    [String]$test_case
+)
+
+$env:HAB_NOCOLORING = "true"
+# Await has trouble parsing non-ascii glyphs
+$env:HAB_GLYPH_STYLE = "ascii"  
+$exit_code = 0
+
+try { 
+    Start-AwaitSession 
+    Send-AwaitCommand "$studio_command enter" 
+    $prompt = Wait-AwaitResponse "[HAB-STUDIO] Habitat:\src>"
+    Write-Host $prompt
+
+    Send-AwaitCommand "$test_case" 
+    $result = Wait-AwaitResponse "test finished"
+
+    Write-Host $result
+    if($result -match "\[FAIL\]") {
+        $exit_code = 1
+    }
+
+} finally { 
+    Write-Host "Cleaning up"
+    Send-AwaitCommand "exit"
+    
+    # Await won't block on "Waiting for supervisor to finish..." 
+    # and there's no output to match afterwords to wait on.
+    # This sleep is required to give the studio a chance to finish 
+    # exiting before we issue the `rm`.
+    sleep 10
+
+    Send-AwaitCommand "$studio_command rm"
+    sleep 2
+    Stop-AwaitSession
+}
+
+exit $exit_code

--- a/components/studio/test/shared/studio-enter.ps1
+++ b/components/studio/test/shared/studio-enter.ps1
@@ -8,10 +8,10 @@ $env:HAB_NOCOLORING = "true"
 # Await has trouble parsing non-ascii glyphs
 $env:HAB_GLYPH_STYLE = "ascii"  
 $exit_code = 0
-
+$studio_name = "/hab/studios/studio-internals-test"
 try { 
     Start-AwaitSession 
-    Send-AwaitCommand "$studio_command enter" 
+    Send-AwaitCommand "$studio_command enter -o $studio_name" 
     $prompt = Wait-AwaitResponse "[HAB-STUDIO] Habitat:\src>"
     Write-Host $prompt
 
@@ -28,13 +28,25 @@ try {
     Send-AwaitCommand "exit"
     
     # Await won't block on "Waiting for supervisor to finish..." 
-    # and there's no output to match afterwords to wait on.
-    # This sleep is required to give the studio a chance to finish 
-    # exiting before we issue the `rm`.
-    sleep 10
+    # Copy the studio shutdown behavior and block for a bit until the supervisor has finished
+    $retry = 0
+    while(($retry -lt 5) -and (Test-Path "$studio_name\hab\sup\default\LOCK")) {
+      $retry += 1
+      Write-Host "Waiting for Supervisor to finish..."
+      Start-Sleep -Seconds 5
+    }
 
     Send-AwaitCommand "$studio_command rm"
-    sleep 2
+    
+    # Add the same behavior for `hab studio rm` to ensure that the studio is fully cleaned up before 
+    # stopping the Await session.
+    $retry = 0
+    while(($retry -lt 5) -and (Test-Path "$studio_name")) {
+      $retry += 1
+      Write-Host "Waiting for Studio to exit..."
+      Start-Sleep -Seconds 2
+    }
+
     Stop-AwaitSession
 }
 

--- a/components/studio/test/shared/studio-internals/test-studio-build.ps1
+++ b/components/studio/test/shared/studio-internals/test-studio-build.ps1
@@ -1,0 +1,19 @@
+$env:HAB_ORIGIN="ci"
+
+$exit_code = 1
+try { 
+    hab origin key generate $HAB_ORIGIN
+
+    build test/fixtures/empty-plan
+
+    $exit_code = $LASTEXITCODE
+} finally { 
+    if($exit_code -eq 0) {
+        Write-Host "[PASS]"
+    } else {
+        Write-Host "[FAIL]"
+    }
+    Write-Host "test finished"
+}
+
+exit $exit_code

--- a/components/studio/test/shared/studio-internals/test-studio-build.sh
+++ b/components/studio/test/shared/studio-internals/test-studio-build.sh
@@ -1,0 +1,14 @@
+#!/bin/bash 
+
+set -euo pipefail 
+
+export HAB_ORIGIN=ci
+hab origin key generate $HAB_ORIGIN
+
+if build test/fixtures/empty-plan; then 
+  echo "[PASS] - test finished"
+else 
+  echo "[FAIL] - test finished"
+  exit 1
+fi
+

--- a/components/studio/test/shared/studio-internals/test-studio-metadata.sh
+++ b/components/studio/test/shared/studio-internals/test-studio-metadata.sh
@@ -1,0 +1,34 @@
+#!/bin/bash 
+
+set -euo pipefail
+
+exit_code=0
+
+check_dot_studio_for() {
+  if ! grep -q "$1" /.studio; then
+    echo "Expected '$1' not found in .studio"
+    exit_code=1
+  fi
+}
+
+if [ ! -f /.studio ]; then 
+  echo "Unable to find .studio metadata"
+  exit_code=1
+fi
+
+
+check_dot_studio_for 'studio_type="default"' 
+check_dot_studio_for 'studio_path="/hab/bin"'
+check_dot_studio_for 'studio_build_environment=""'
+check_dot_studio_for 'studio_enter_command="/hab/bin/hab pkg exec core/hab-backline bash --login +h"'
+check_dot_studio_for 'studio_build_command="_record_build /hab/bin/build"'
+check_dot_studio_for 'studio_run_environment=""'
+
+
+if [[ $exit_code -eq 0 ]]; then 
+  echo "[PASS] - Studio metadata present"
+else 
+  echo "[FAIL] - Studio metadata incorrect"
+fi
+
+exit "$exit_code"

--- a/components/studio/test/shared/test-all.ps1
+++ b/components/studio/test/shared/test-all.ps1
@@ -1,0 +1,12 @@
+param( 
+    [String]$studio_command
+)
+
+$ErrorActionPreference = "Stop"
+
+$studio_internals="./test/shared/studio-internals"
+
+foreach($test_case in Get-ChildItem test/shared/studio-internals -Filter "test-studio-*.ps1") {
+  Write-Host "--- Running $test_case"
+  & ./test/shared/studio-enter.ps1 -studio_command "$studio_command" -test_case "$studio_internals/$test_case"
+}

--- a/components/studio/test/shared/test-all.sh
+++ b/components/studio/test/shared/test-all.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -euo pipefail
+
+for t in test/shared/studio-internals/test-studio-*.sh; do 
+  test_case="$(basename "$t")"
+  echo "--- Running $test_case"
+  hab studio rm 
+  if ! expect test/shared/studio-enter.exp "$t"; then 
+    exit 1
+  fi
+done

--- a/components/studio/test/studio-from-package/test.ps1
+++ b/components/studio/test/studio-from-package/test.ps1
@@ -1,0 +1,9 @@
+$ErrorActionPreference = "Stop"
+
+$env:HAB_LICENSE = "accept-no-persist"
+
+hab studio rm
+
+& test/shared/test-all.ps1 -studio_command "hab studio"
+
+exit $LASTEXITCODE

--- a/components/studio/test/studio-from-package/test.sh
+++ b/components/studio/test/studio-from-package/test.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -euo pipefail 
+
+export HAB_LICENSE="accept-no-persist"
+
+hab studio rm
+
+export STUDIO_ENTER_COMMAND="hab studio enter"
+
+./test/shared/test-all.sh
+

--- a/components/studio/test/studio-from-source/test.ps1
+++ b/components/studio/test/studio-from-source/test.ps1
@@ -1,0 +1,34 @@
+$ErrorActionPreference = "Stop"
+
+$env:HAB_LICENSE = "accept-no-persist"
+
+$env:studio_command = "bin/hab-studio.ps1"
+
+hab pkg install core/powershell
+hab pkg install core/7zip
+hab pkg install core/hab 
+hab pkg install core/hab-plan-build-ps1 
+
+mkdir "bin/powershell" | Out-Null
+mkdir "bin/hab" | Out-Null
+mkdir "bin/7zip" | Out-Null
+
+Copy-Item "$(hab pkg path core/powershell)/bin/*" "bin/powershell" -Recurse
+Copy-Item "$(hab pkg path core/hab)/bin/*" "bin/hab"
+Copy-Item "$(hab pkg path core/7zip)/bin/*" "bin/7zip"
+Copy-Item "$(hab pkg path core/hab-plan-build-ps1)/bin/*" "bin/"
+
+try {
+    & test/shared/test-all.ps1 -studio_command "bin/hab-studio.ps1"
+    $exit_code = $LASTEXITCODE
+} finally {
+    # The tests can exit before the Studio or Await have closed all open 
+    # handles to the following files/directories. This sleep gives those 
+    # processes a chance to finish.  
+    sleep 5
+    Remove-Item "bin/7zip" -Recurse
+    Remove-Item "bin/powershell" -Recurse
+    Remove-Item "bin/hab" -Recurse
+    Remove-Item "bin/hab-plan-build.ps1"
+}
+exit $exit_code

--- a/components/studio/test/studio-from-source/test.sh
+++ b/components/studio/test/studio-from-source/test.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+export HAB_LICENSE="accept-no-persist"
+
+sudo hab pkg install core/busybox-static core/hab core/hab-backline
+
+# Current studio has the expectation that busybox and hab live in the libexec directroy
+# These two lines should be removed at a later date to validate this is no longer a requirement
+# While not explicily mentioned, resolving habitat-sh/habitat#6509 will likely remove this 
+# explicit requirement.
+cp "$(hab pkg path core/busybox-static)"/bin/busybox libexec/busybox
+cp "$(hab pkg path core/hab)"/bin/hab libexec/hab
+
+HAB_STUDIO_BACKLINE_PKG="$(< "$(hab pkg path core/hab-backline)"/IDENT)"
+
+export HAB_STUDIO_BACKLINE_PKG
+export STUDIO_ENTER_COMMAND="sudo --preserve-env bin/hab-studio.sh enter"
+
+./test/shared/test-all.sh
+
+rm libexec/hab
+rm libexec/busybox

--- a/test/run_studio_test.ps1
+++ b/test/run_studio_test.ps1
@@ -1,0 +1,21 @@
+#Requires -Version 5
+
+param (
+    [string]$studio_type
+)
+
+$ErrorActionPreference="stop"
+
+if(!(Get-Module Await -ListAvailable)) {
+  Write-Host "Installing Await PS Module..."
+  Install-Module Await -Force | Out-Null
+}
+
+Push-Location "components/studio"
+try {
+ & test/$studio_type/test.ps1
+}
+finally { Pop-Location }
+
+if ($LASTEXITCODE -ne 0) {exit $LASTEXITCODE}
+

--- a/test/run_studio_test.sh
+++ b/test/run_studio_test.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -eou pipefail
+
+studio_type=${1?studio type argument required}
+
+sudo hab pkg install core/expect
+sudo hab pkg binlink core/expect expect 
+
+pushd components/studio
+
+test/"$studio_type"/test.sh


### PR DESCRIPTION
As we investigate #6509 we will be making changes to the studio.  This is a first pass at adding some tests to verify that the behavior of the studio doesn't change as we make those modifications. 

There's currently no straightforward way to specify a studio package, as `hab studio enter` will use the latest `core/hab-studio` package that shares the same version as the `hab` command, so the `studio-from-package` tests assume that the `hab` cli matches the version of the studio you wish to test. 

I've also include a POC for Windows, though it depends on a powershell module that appears unmaintained.  

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>