### PR TITLE
Update tutorials with license acceptance information

### DIFF
--- a/www/source/demo/build-system/steps/10.html.slim
+++ b/www/source/demo/build-system/steps/10.html.slim
@@ -43,7 +43,7 @@ classes: demo_step
         = code(:shell) do
           | $ docker pull your-docker-org/your-docker-repo
         = code(:shell) do
-          | $ docker run -it -p 8000:8000 your-docker-org/your-docker-repo
+          | $ docker run --env HAB_LICENSE="accept-no-persist" -it -p 8000:8000 your-docker-org/your-docker-repo
         h3="Preview the application in your browser"
         p
           ' With the container runnning, visit

--- a/www/source/demo/build-system/steps/9.html.slim
+++ b/www/source/demo/build-system/steps/9.html.slim
@@ -28,7 +28,7 @@ classes: demo_step
         = code(:shell) do
           | $ docker pull your-docker-org/your-docker-repo
         = code(:shell) do
-          | $ docker run -it -p 8000:8000 your-docker-org/your-docker-repo
+          | $ docker run --env HAB_LICENSE="accept-no-persist" -it -p 8000:8000 your-docker-org/your-docker-repo
 
         h3="Preview the application in your browser"
         p

--- a/www/source/demo/packaging-system/steps/6.html.slim
+++ b/www/source/demo/packaging-system/steps/6.html.slim
@@ -32,7 +32,7 @@ classes: demo_step
           | [1][default:/src:0]# exit
 
         = code(:shell) do
-          | $ docker run -it -p 8000:8000 yourorigin/sample-node-app
+          | $ docker run --env HAB_LICENSE="accept-no-persist" -it -p 8000:8000 yourorigin/sample-node-app
 
         .footnote
           p.mb-0

--- a/www/source/demo/windows/steps/8.html.slim
+++ b/www/source/demo/windows/steps/8.html.slim
@@ -73,7 +73,7 @@ section
  p The following example shows how to start the Docker container running your Habitat package.
 
  = code(:shell) do
-   | PS C:\contosouniversity> docker run -it myorigin/contosouniversity
+   | PS C:\contosouniversity> docker run --env HAB_LICENSE="accept-no-persist" -it myorigin/contosouniversity
 
  p For more information on using the Habitat Studio, see #{link_to 'Plan Builds', '/docs/developing-packages#plan-builds'}.
 

--- a/www/source/demo/windows/steps/9.html.slim
+++ b/www/source/demo/windows/steps/9.html.slim
@@ -141,9 +141,9 @@ section
 
  = code(:shell) do
    |
-    PS C:\contosouniversity> $sql = docker run -d --memory 2GB core/sqlserver
+    PS C:\contosouniversity> $sql = docker run --env HAB_LICENSE="accept-no-persist" -d --memory 2GB core/sqlserver
     PS C:\contosouniversity> $ip = docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $sql
-    PS C:\contosouniversity> docker run -it -p 80:8099 myorigin/contosouniversity --peer $ip --bind database:sqlserver.default
+    PS C:\contosouniversity> docker run --env HAB_LICENSE="accept-no-persist" -it -p 80:8099 myorigin/contosouniversity --peer $ip --bind database:sqlserver.default
 
  p You should now be able to access the web application and receive a <code>200 OK</code> response:
 

--- a/www/source/partials/demo/_install_the_tools.html.slim
+++ b/www/source/partials/demo/_install_the_tools.html.slim
@@ -2,8 +2,8 @@
   p
     | In order to start packaging applications with Habitat, you'll need two bits of software on your workstation:
   ol
-    li The Habitat CLI tool
-    li Docker*
+    li The Habitat CLI tool*
+    li Docker**
   p
     ' Instructions for
     a.link-external target="_bank" href="https://www.habitat.sh/docs/install-habitat/" installing Habitat and Docker
@@ -12,8 +12,16 @@
   = code(:shell) do
     | $ hab --version
 
+  .footnote 
+    p.mb-0
+      span.asterisk * 
+      | The first time you run Habitat, you will be asked to accept the License Agreement. 
+      |  More details about the license can be found 
+      a href="https://docs.chef.io/chef_license.html" here.
+
   .footnote
     p.mb-0
+      span.asterisk *
       span.asterisk *
       | Habitat uses Docker to create a clean build room environment known as the Habitat Studio.
       |  You'll learn more about the Studio later in this demo.


### PR DESCRIPTION
This adds information on how to accept the license when running the exported docker containers.  It also adds a notice about the license on install with a link to our licenseing page. 

I haven't verified the Windows docker export lines are correct yet, but the docker docs indicate that `--env` behaves exactly the same as it does on Linux. 

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>