### PR TITLE
remove trailing space from env vars set in export docker build

### DIFF
--- a/components/pkg-export-docker/defaults/Dockerfile_win.hbs
+++ b/components/pkg-export-docker/defaults/Dockerfile_win.hbs
@@ -5,7 +5,7 @@ EXPOSE 9631 {{exposes}}
 RUN SET HAB_FEAT_OFFLINE_INSTALL=ON && \
     {{~ #if environment}}
     {{~ #each environment}}
-        SET {{@key}}={{{this}}} && \
+        SET {{@key}}={{{this}}}&& \
     {{~ /each}}
     {{~ /if}}
     {{hab_path}} pkg install {{installed_primary_svc_ident}}


### PR DESCRIPTION
This fixes broken docker export on windows. I've definitely used this before without issue and perhaps we should also `trim` the `HAB_LICENSE` to protect against these kinds of scenarios.

Signed-off-by: mwrock <matt@mattwrock.com>