### PR TITLE
The --no-tty and --non-interactive flags were removed.

### DIFF
--- a/support/ci/build_component.ps1
+++ b/support/ci/build_component.ps1
@@ -18,6 +18,6 @@ Write-Host "--- :key: Generating fake origin key"
 hab origin key generate
 Write-Host "--- :hab: Running hab pkg build for $Component"
 
-hab studio build -D --no-tty --non-interactive components/$Component
+hab studio build -D components/$Component
 
 exit $LASTEXITCODE


### PR DESCRIPTION
The docker exporter should auto-detect ttys now.  See also https://github.com/habitat-sh/habitat/pull/6476

![](https://media.giphy.com/media/3oEjHVzZsvDfkdO7kc/giphy.gif)

Signed-off-by: Josh Black <raskchanky@gmail.com>