### PR TITLE
make sure all build prereqs exist on windows, run cargo test against core/rust and use a local studio for builds

### DIFF
--- a/support/ci/build_component.ps1
+++ b/support/ci/build_component.ps1
@@ -7,6 +7,9 @@ param (
     [string]$Component
 )
 
+. $PSScriptRoot\shared.ps1
+Install-Habitat
+
 # Since we are only verifying we don't have build failures, make everything
 # temp!
 $env:HAB_ORIGIN="throwaway"
@@ -18,6 +21,6 @@ Write-Host "--- :key: Generating fake origin key"
 hab origin key generate
 Write-Host "--- :hab: Running hab pkg build for $Component"
 
-hab studio build -D --no-tty --non-interactive components/$Component
+hab studio build components/$Component -R
 
 exit $LASTEXITCODE


### PR DESCRIPTION
This will install the hab cli, visual studio tools and rustup if they are not present. This will also run `cargo test` against the latest core/rust instead of whatever toolchain was installed with rustup. Finally this moves to using a local studio instead of a docker studio for the CI component builds. Because we control the host and our builds do not impact machine state, we don't get value from a dockerized studio and we should also get faster build times and less resource consumption with local builds.

Signed-off-by: mwrock <matt@mattwrock.com>