### PR TITLE
Make studio backline dependency explicit

### DIFF
--- a/components/hab/src/command/studio/enter.rs
+++ b/components/hab/src/command/studio/enter.rs
@@ -63,7 +63,8 @@ mod inner {
                         fs::{am_i_root,
                              find_command},
                         os::process,
-                        package::{PackageIdent,PackageInstall},
+                        package::{PackageIdent,
+                                  PackageInstall},
                         users::linux as group},
                 VERSION};
     use std::{env,
@@ -86,9 +87,10 @@ mod inner {
                     let ident = PackageIdent::from_str(&format!("{}/{}",
                                                                 super::STUDIO_PACKAGE_IDENT,
                                                                 version[0]))?;
-                    // TODO(SM): This is the minimum change needed to allow the studio to specify
-                    // its dependencies. This is a duplicate of the code in `hab pkg exec` and
-                    // should be refactored.
+                    // This is a duplicate of the code in `hab pkg exec` and
+                    // should be refactored as part of or after:
+                    // https://github.com/habitat-sh/habitat/issues/6633
+                    // https://github.com/habitat-sh/habitat/issues/6634
                     let pkg_install = PackageInstall::load(&ident, None)?;
                     let cmd_env = pkg_install.environment_for_command()?;
                     for (key, value) in cmd_env.into_iter() {

--- a/components/studio/habitat/plan.sh
+++ b/components/studio/habitat/plan.sh
@@ -4,7 +4,9 @@ pkg_origin=core
 pkg_version=$(cat "$SRC_PATH/../../VERSION")
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
-pkg_deps=()
+pkg_deps=(
+  core/hab-backline/$pkg_version
+)
 pkg_build_deps=(core/coreutils
                 core/tar
                 core/xz
@@ -12,6 +14,10 @@ pkg_build_deps=(core/coreutils
                 core/busybox-static
                 core/hab)
 pkg_bin_dirs=(bin)
+
+do_prepare() {
+  set_runtime_env "HAB_STUDIO_BACKLINE_PKG" "$(< $(pkg_path_for core/hab-backline)/IDENT)"
+}
 
 do_build() {
   cp -v "$SRC_PATH"/bin/hab-studio.sh hab-studio

--- a/components/studio/habitat/plan.sh
+++ b/components/studio/habitat/plan.sh
@@ -5,7 +5,7 @@ pkg_version=$(cat "$SRC_PATH/../../VERSION")
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_deps=(
-  core/hab-backline/$pkg_version
+  core/hab-backline
 )
 pkg_build_deps=(core/coreutils
                 core/tar
@@ -16,7 +16,7 @@ pkg_build_deps=(core/coreutils
 pkg_bin_dirs=(bin)
 
 do_prepare() {
-  set_runtime_env "HAB_STUDIO_BACKLINE_PKG" "$(< $(pkg_path_for core/hab-backline)/IDENT)"
+  set_runtime_env "HAB_STUDIO_BACKLINE_PKG" "$(< "$(pkg_path_for core/hab-backline)"/IDENT)"
 }
 
 do_build() {

--- a/components/studio/libexec/hab-studio-type-default.sh
+++ b/components/studio/libexec/hab-studio-type-default.sh
@@ -23,6 +23,7 @@ finish_setup() {
     # will use the outside cache key path, whereas the `_hab` function has
     # the `$FS_ROOT` set for the inside of the Studio. We're copying from
     # the outside in, using `hab` twice. I love my job.
+    # shellcheck disable=SC2154
     for key in $(echo "$HAB_ORIGIN_KEYS" | $bb tr ',' ' '); do
       # Import the secret origin key, required for signing packages
       info "Importing '$key' secret origin key"
@@ -85,7 +86,7 @@ finish_setup() {
   # (This is also why we're not using HAB_BLDR_CHANNEL for this and
   # replicating the fallback logic from hab-plan-build; it'd be too
   # easy to create an unstable studio.)
-  _hab install $HAB_STUDIO_BACKLINE_PKG
+  _hab install "$HAB_STUDIO_BACKLINE_PKG"
 
   bash_path=$(_pkgpath_for core/bash)
   coreutils_path=$(_pkgpath_for core/coreutils)

--- a/components/studio/libexec/hab-studio-type-default.sh
+++ b/components/studio/libexec/hab-studio-type-default.sh
@@ -14,9 +14,6 @@ studio_build_command="_record_build $HAB_ROOT_PATH/bin/build"
 studio_run_environment=
 studio_run_command="$HAB_ROOT_PATH/bin/hab pkg exec core/hab-backline bash --login"
 
-pkgs="${HAB_STUDIO_BACKLINE_PKG:-core/hab-backline/$(
-  echo "$version" | $bb cut -d / -f 1)}"
-
 run_user="hab"
 run_group="$run_user"
 
@@ -88,17 +85,7 @@ finish_setup() {
   # (This is also why we're not using HAB_BLDR_CHANNEL for this and
   # replicating the fallback logic from hab-plan-build; it'd be too
   # easy to create an unstable studio.)
-  for pkg in $pkgs; do
-    if [ -n "${CI_OVERRIDE_CHANNEL:-}" ]; then
-      info "Override channel set; retrieving ${pkg} from ${CI_OVERRIDE_CHANNEL}"
-      _hab install --channel="${CI_OVERRIDE_CHANNEL}" "${pkg}" || {
-        info "Package not found in ${CI_OVERRIDE_CHANNEL}; falling back to stable"
-        _hab install "${pkg}"
-      }
-    else
-      _hab install "$pkg"
-    fi
-  done
+  _hab install $HAB_STUDIO_BACKLINE_PKG
 
   bash_path=$(_pkgpath_for core/bash)
   coreutils_path=$(_pkgpath_for core/coreutils)


### PR DESCRIPTION
Ref: #6509 

This is initial set of work to make studio dependencies explicit, starting with backline.  

In order for the studio to rely on the RUNTIME_ENVIRONMENT in the package metadata, we need to treat the `studio enter` command the same way we run `hab pkg exec`.  This  is currently a copy/paste from `hab pkg exec` and will need to be refactored in the future. When I started investigating the possibility of doing that work in this PR, it ended up being a much a much larger slice of work that I felt should be captured in its own PR. 

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>