### PR TITLE
Fix shellcheck ignores

### DIFF
--- a/test/shellcheck.sh
+++ b/test/shellcheck.sh
@@ -25,9 +25,10 @@ shellcheck --version
 find . -type f \
   -and \( -name "*.*sh" \
       -or -exec sh -c 'file -b "$1" | grep -q "shell script"' -- {} \; \) \
-  -and \! -path "*_template_plan.sh" \
   -and \! -path "*.sample" \
   -and \! -path "*.ps1" \
+  -and \! -path "./components/hab/static/template_plan.sh" \
+  -and \! -path "./target/*" \
   -and \! -path "./test/integration/helpers.bash" \
   -and \! -path "./test/integration/test_helper/bats-assert/*" \
   -and \! -path "./test/integration/test_helper/bats-file/*" \


### PR DESCRIPTION
Ignore handlebars template that was renamed to `template_plan.sh`.
Ignore cargo's `target` directory.

Is there a reason we would want to check the `target` directory?

