### PR TITLE
Add thread heartbeats to log errors for likely deadlocks

### DIFF
--- a/components/butterfly/src/server/expire.rs
+++ b/components/butterfly/src/server/expire.rs
@@ -22,6 +22,8 @@ impl Expire {
 
     pub fn run(&self) {
         loop {
+            habitat_common::sync::mark_thread_alive();
+
             let newly_confirmed_members =
                 self.server
                     .member_list

--- a/components/butterfly/src/server/inbound.rs
+++ b/components/butterfly/src/server/inbound.rs
@@ -53,6 +53,8 @@ impl Inbound {
         let mut recv_buffer: Vec<u8> = vec![0; 1024];
 
         loop {
+            habitat_common::sync::mark_thread_alive();
+
             if self.server.paused() {
                 thread::sleep(Duration::from_millis(100));
                 continue;

--- a/components/butterfly/src/server/mod.rs
+++ b/components/butterfly/src/server/mod.rs
@@ -40,8 +40,7 @@ use crate::{error::{Error,
             trace::{Trace,
                     TraceKind}};
 use habitat_common::FeatureFlag;
-use habitat_core::{crypto::SymKey,
-                   env::Config as EnvConfig};
+use habitat_core::crypto::SymKey;
 use prometheus::{HistogramTimer,
                  HistogramVec,
                  IntGauge};
@@ -1173,7 +1172,7 @@ fn persist_loop(server: &Server) {
                                        HAB_PERSIST_LOOP_PERIOD_SECS,
                                        Duration::from_secs(30));
 
-    let min_loop_period = PersistLoopPeriod::configured_value().0;
+    let min_loop_period: Duration = PersistLoopPeriod::configured_value().into();
 
     loop {
         habitat_common::sync::mark_thread_alive();

--- a/components/butterfly/src/server/outbound.rs
+++ b/components/butterfly/src/server/outbound.rs
@@ -95,6 +95,8 @@ impl Outbound {
     pub fn run(&mut self) {
         let mut have_members = false;
         loop {
+            habitat_common::sync::mark_thread_alive();
+
             if !have_members {
                 let num_initial = self.server.member_list.len_initial_members();
                 if num_initial != 0 {

--- a/components/butterfly/src/server/pull.rs
+++ b/components/butterfly/src/server/pull.rs
@@ -49,6 +49,8 @@ impl Pull {
         socket.bind(&format!("tcp://{}", self.server.gossip_addr()))
               .expect("Failure to bind the ZMQ Pull socket to the port");
         'recv: loop {
+            habitat_common::sync::mark_thread_alive();
+
             if self.server.paused() {
                 thread::sleep(Duration::from_millis(100));
                 continue;

--- a/components/butterfly/src/server/push.rs
+++ b/components/butterfly/src/server/push.rs
@@ -53,6 +53,8 @@ impl Push {
     /// exceed that time.
     pub fn run(&mut self) {
         loop {
+            habitat_common::sync::mark_thread_alive();
+
             if self.server.paused() {
                 thread::sleep(Duration::from_millis(100));
                 continue;

--- a/components/common/src/lib.rs
+++ b/components/common/src/lib.rs
@@ -218,7 +218,7 @@ pub mod sync {
                       if time_since_last_heartbeat < threshold {
                           None
                       } else {
-                          Some((thread_name.clone(), last_heartbeat.clone()))
+                          Some((thread_name.clone(), *last_heartbeat))
                       }
                   })
                   .collect::<Vec<_>>()

--- a/components/common/src/lib.rs
+++ b/components/common/src/lib.rs
@@ -146,7 +146,6 @@ impl FeatureFlag {
 }
 
 pub mod sync {
-    use habitat_core::env::Config as EnvConfig;
     use std::{collections::HashMap,
               sync::Mutex,
               thread::{self,
@@ -186,8 +185,8 @@ pub mod sync {
     pub fn spawn_thread_alive_checker() {
         thread::Builder::new().name("thread-alive-check".to_string())
                               .spawn(|| {
-                                  let delay = ThreadAliveCheckDelay::configured_value().0;
-                                  let threshold = ThreadAliveThreshold::configured_value().0;
+                                  let delay = ThreadAliveCheckDelay::configured_value().into();
+                                  let threshold = ThreadAliveThreshold::configured_value().into();
                                   loop {
                                       check_thread_heartbeats(threshold);
                                       thread::sleep(delay);

--- a/components/core/src/env.rs
+++ b/components/core/src/env.rs
@@ -142,6 +142,7 @@ macro_rules! env_config {
 ///
 /// Example usage:
 /// ```
+/// use std::time::Duration;
 /// habitat_core::env_config_duration!(PersistLoopPeriod,
 ///                                    HAB_PERSIST_LOOP_PERIOD_SECS,
 ///                                    Duration::from_secs(30));
@@ -166,6 +167,7 @@ macro_rules! env_config_duration {
 ///
 /// Example usage:
 /// ```
+/// use std::time::Duration;
 /// habitat_core::env_config_duration!(ThreadAliveThreshold,
 ///                                    HAB_THREAD_ALIVE_THRESHOLD_SECS,
 ///                                    Duration::from_secs(5 * 60));

--- a/components/core/src/env.rs
+++ b/components/core/src/env.rs
@@ -128,6 +128,19 @@ macro_rules! env_config_duration {
     };
 }
 
+#[macro_export]
+macro_rules! env_config_int {
+    ($wrapping_type:ident, $type:ty, $env_var:ident, $default_value:expr) => {
+        $crate::env_config!($wrapping_type,
+                            $type,
+                            $env_var,
+                            $default_value,
+                            std::num::ParseIntError,
+                            s,
+                            Ok(Self((s.parse()?))));
+    };
+}
+
 /// Enable the creation of a value based on an environment variable
 /// that can be supplied at runtime by the user.
 pub trait Config: Default + FromStr {

--- a/components/core/src/env.rs
+++ b/components/core/src/env.rs
@@ -83,16 +83,18 @@ macro_rules! env_config {
         $from_str_input:ident,
         $from_str_return:expr
     ) => {
+        use $crate::env::Config as _;
+
         struct $wrapping_type($wrapped_type);
         // A little trickery to avoid env var name collisions:
         // This enum can't ever be instantiated, but the compiler will give
-        // an error if two invocations in a namespace give the same env_var
+        // an error if two invocations in a namespace give the same env_var.
         // It'd be nice to make this work globally, but I don't see a good way
         #[allow(non_camel_case_types, dead_code)]
         enum $env_var {}
 
         impl $crate::env::Config for $wrapping_type {
-            const ENVVAR: &'static str = "$env_var";
+            const ENVVAR: &'static str = stringify!($env_var);
         }
 
         impl Default for $wrapping_type {
@@ -105,6 +107,10 @@ macro_rules! env_config {
             fn from_str($from_str_input: &str) -> std::result::Result<Self, Self::Err> {
                 $from_str_return
             }
+        }
+
+        impl std::convert::From<$wrapping_type> for $wrapped_type {
+            fn from(x: $wrapping_type) -> $wrapped_type { x.0 }
         }
     };
 }

--- a/components/launcher/src/server/mod.rs
+++ b/components/launcher/src/server/mod.rs
@@ -418,6 +418,8 @@ pub fn run(args: Vec<String>) -> Result<i32> {
     let mut server = Server::new(args)?;
     signals::init();
     loop {
+        habitat_common::sync::mark_thread_alive();
+
         match server.tick() {
             Ok(TickState::Continue) => thread::sleep(Duration::from_millis(100)),
             Ok(TickState::Exit(code)) => {

--- a/components/sup/src/ctl_gateway/server.rs
+++ b/components/sup/src/ctl_gateway/server.rs
@@ -375,6 +375,8 @@ impl Future for SrvHandler {
 
     fn poll(&mut self) -> Poll<(), Self::Error> {
         loop {
+            habitat_common::sync::mark_thread_alive();
+
             match self.state {
                 SrvHandlerState::Receiving => {
                     match try_ready!(self.io.poll()) {

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -114,6 +114,7 @@ fn start(feature_flags: FeatureFlag) -> Result<()> {
         outputln!("Simulating boot failure");
         return Err(sup_error!(Error::TestBootFail));
     }
+    habitat_common::sync::spawn_thread_alive_checker();
     let launcher = boot();
     let app_matches = match cli().get_matches_safe() {
         Ok(matches) => matches,

--- a/components/sup/src/manager/file_watcher.rs
+++ b/components/sup/src/manager/file_watcher.rs
@@ -1263,6 +1263,7 @@ impl<C: Callbacks, W: Watcher> FileWatcher<C, W> {
 
     pub fn run(&mut self) -> Result<()> {
         loop {
+            habitat_common::sync::mark_thread_alive();
             self.single_iteration()?;
             thread::sleep(Duration::from_secs(1));
         }

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -802,6 +802,8 @@ impl Manager {
         // errors or panics generated in this loop and performing some
         // kind of controlled shutdown.
         let shutdown_mode = loop {
+            habitat_common::sync::mark_thread_alive();
+
             // time will be recorded automatically by HistogramTimer's drop implementation when
             // this var goes out of scope
             #[allow(unused_variables)]

--- a/components/sup/src/manager/peer_watcher.rs
+++ b/components/sup/src/manager/peer_watcher.rs
@@ -52,6 +52,8 @@ impl PeerWatcher {
 
         ThreadBuilder::new().name(format!("peer-watcher-[{}]", path.display()))
                             .spawn(move || {
+                                habitat_common::sync::mark_thread_alive();
+
                                 // debug!("PeerWatcher({}) thread starting", abs_path.display());
                                 loop {
                                     let have_events_for_loop = Arc::clone(&have_events_for_thread);

--- a/components/sup/src/manager/self_updater.rs
+++ b/components/sup/src/manager/self_updater.rs
@@ -62,6 +62,8 @@ impl SelfUpdater {
         // and thus a valid InstallSource
         let install_source: InstallSource = SUP_PKG_IDENT.parse().unwrap();
         loop {
+            habitat_common::sync::mark_thread_alive();
+
             let next_check = SteadyTime::now() + TimeDuration::milliseconds(update_frequency());
 
             match util::pkg::install(// We don't want anything in here to print

--- a/components/sup/src/manager/service_updater.rs
+++ b/components/sup/src/manager/service_updater.rs
@@ -508,6 +508,8 @@ impl Worker {
         let mut next_time = SteadyTime::now();
 
         loop {
+            habitat_common::sync::mark_thread_alive();
+
             match kill_rx.try_recv() {
                 Ok(_) => {
                     info!("Received some data on the kill channel. Letting this thread die.");

--- a/components/sup/src/manager/user_config_watcher.rs
+++ b/components/sup/src/manager/user_config_watcher.rs
@@ -209,6 +209,8 @@ impl Worker {
                                 let _ = started_watching.try_send(());
 
                                 loop {
+                                    habitat_common::sync::mark_thread_alive();
+
                                     match stop_running.try_recv() {
                                         // As long as the `stop_running` channel is
                                         // empty, this branch will execute on every


### PR DESCRIPTION
The 0.80.0 release incident showed that deadlock scenarios can be very confusing to debug in production, so this adds calls to the various threads which run a continuous work loop to indicate that they are still processing and adds a new thread which checks the heartbeats and logs an error indicating the thread which is likely deadlocked if one does not occur for too long a period.

`ThreadAliveThreshold` (how long a heartbeat must go missing before an error is logged, default 5 minutes) and `ThreadAliveCheckDelay` (how frequently the checker thread looks for updated heartbeats, default 1 minute) can be configured with the `HAB_THREAD_ALIVE_THRESHOLD_SECS`
and `HAB_THREAD_ALIVE_THRESHOLD_SECS` environment variables.