### PR TITLE
 allow dots in package names

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -87,7 +87,7 @@ function Invoke-Build([string]$Path, [switch]$Clean, [string]$Command, [switch]$
             Install-RustToolchain $toolchain
             rustup component add --toolchain $Toolchain rustfmt
             Setup-Environment
-            Invoke-Expression "cargo +$ToolChain $Command --all -- --check"
+            Invoke-Expression "cargo +$ToolChain $Command --all"
             break
         }
         "clippy" {
@@ -109,7 +109,12 @@ function Invoke-Build([string]$Path, [switch]$Clean, [string]$Command, [switch]$
         "build" {
             Install-Rustup $toolchain
             Install-RustToolchain $toolchain
-            rustup component add --toolchain $Toolchain rustfmt
+            Setup-Environment
+            Invoke-Expression "cargo +$ToolChain $Command $(if ($Release) { '--release' }) $FeatureString"
+        }
+        "check" {
+            Install-Rustup $toolchain
+            Install-RustToolchain $toolchain
             Setup-Environment
             Invoke-Expression "cargo +$ToolChain $Command $(if ($Release) { '--release' }) $FeatureString"
         }

--- a/components/core/src/error.rs
+++ b/components/core/src/error.rs
@@ -85,6 +85,8 @@ pub enum Error {
     InvalidApplicationEnvironment(String),
     /// Occurs when a service binding cannot be successfully parsed.
     InvalidBinding(String),
+    /// Occurs when a group is in an invalid format.
+    InvalidGroupName(String),
     /// Occurs when a package identifier string cannot be successfully parsed.
     InvalidPackageIdent(String),
     /// Occurs when a package target string cannot be successfully parsed.
@@ -263,6 +265,7 @@ impl fmt::Display for Error {
                          <NAME> is a service name, and <SERVICE_GROUP> is a valid service group",
                         binding)
             }
+            Error::InvalidGroupName(ref e) => format!("Invalid group: {}.", e),
             Error::InvalidPackageIdent(ref e) => {
                 format!("Invalid package identifier: {:?}. A valid identifier is in the form \
                          origin/name (example: acme/redis)",
@@ -429,6 +432,7 @@ impl error::Error for Error {
                 "Service Bind strings must be in name:service_group format (example \
                  cache:redis.cache@organization)."
             }
+            Error::InvalidGroupName(_) => "Service group name must not contain a '.'",
             Error::InvalidPackageIdent(_) => {
                 "Package identifiers must be in origin/name format (example: acme/redis)"
             }

--- a/components/core/src/error.rs
+++ b/components/core/src/error.rs
@@ -75,6 +75,8 @@ pub enum Error {
     CryptProtectDataFailed(String),
     /// Occurs when a call to CryptUnprotectData fails
     CryptUnprotectDataFailed(String),
+    /// Occurs when a group has a period in it.
+    DotInGroupName(String),
     /// Occurs when a file that should exist does not or could not be read.
     FileNotFound(String),
     /// Occurs when a fully-qualified package identifier is required,
@@ -85,8 +87,6 @@ pub enum Error {
     InvalidApplicationEnvironment(String),
     /// Occurs when a service binding cannot be successfully parsed.
     InvalidBinding(String),
-    /// Occurs when a group is in an invalid format.
-    InvalidGroupName(String),
     /// Occurs when a package identifier string cannot be successfully parsed.
     InvalidPackageIdent(String),
     /// Occurs when a package target string cannot be successfully parsed.
@@ -250,6 +250,9 @@ impl fmt::Display for Error {
             Error::CryptoError(ref e) => format!("Crypto error: {}", e),
             Error::CryptProtectDataFailed(ref e) => e.to_string(),
             Error::CryptUnprotectDataFailed(ref e) => e.to_string(),
+            Error::DotInGroupName(ref e) => {
+                format!("Service group name must not contain a '.': {}.", e)
+            }
             Error::FileNotFound(ref e) => format!("File not found at: {}", e),
             Error::FullyQualifiedPackageIdentRequired(ref ident) => {
                 format!("Fully-qualified package identifier was expected, but found: {:?}",
@@ -265,7 +268,6 @@ impl fmt::Display for Error {
                          <NAME> is a service name, and <SERVICE_GROUP> is a valid service group",
                         binding)
             }
-            Error::InvalidGroupName(ref e) => format!("Invalid group: {}.", e),
             Error::InvalidPackageIdent(ref e) => {
                 format!("Invalid package identifier: {:?}. A valid identifier is in the form \
                          origin/name (example: acme/redis)",
@@ -420,6 +422,7 @@ impl error::Error for Error {
             Error::CryptoError(_) => "Crypto error",
             Error::CryptProtectDataFailed(_) => "CryptProtectData failed",
             Error::CryptUnprotectDataFailed(_) => "CryptUnprotectData failed",
+            Error::DotInGroupName(_) => "Service group name must not contain a '.'",
             Error::FileNotFound(_) => "File not found",
             Error::FullyQualifiedPackageIdentRequired(_) => {
                 "A fully-qualified package identifier was expected"
@@ -432,7 +435,6 @@ impl error::Error for Error {
                 "Service Bind strings must be in name:service_group format (example \
                  cache:redis.cache@organization)."
             }
-            Error::InvalidGroupName(_) => "Service group name must not contain a '.'",
             Error::InvalidPackageIdent(_) => {
                 "Package identifiers must be in origin/name format (example: acme/redis)"
             }

--- a/components/core/src/package/ident.rs
+++ b/components/core/src/package/ident.rs
@@ -13,7 +13,7 @@ use std::{borrow::Cow,
 
 lazy_static::lazy_static! {
     static ref ORIGIN_NAME_RE: Regex =
-        Regex::new(r"\A[a-z0-9][a-z0-9_-]*\z").expect("Unable to compile regex");
+        Regex::new(r"\A[a-z0-9][a-z0-9_\.-]*\z").expect("Unable to compile regex");
 }
 
 #[derive(Deserialize, Serialize, Eq, PartialEq, Debug, Clone, Hash)]
@@ -33,7 +33,7 @@ pub trait Identifiable: fmt::Display + Into<PackageIdent> {
     fn fully_qualified(&self) -> bool { self.version().is_some() && self.release().is_some() }
 
     fn valid(&self) -> bool {
-        let re = Regex::new(r"^[A-Za-z0-9_-]+$").unwrap();
+        let re = Regex::new(r"^[A-Za-z0-9_\.-]+$").unwrap();
         re.is_match(self.name())
     }
 
@@ -641,15 +641,15 @@ mod tests {
         let valid2 = PackageIdent::new("acme", "rocket-one", Some("1.2.3"), Some("1234"));
         let valid3 = PackageIdent::new("acme", "rocket_one", Some("1.2.3"), Some("1234"));
         let valid4 = PackageIdent::new("acme", "rocket_one", Some("foo-bar"), Some("1234"));
-        let invalid1 = PackageIdent::new("acme", "rocket.one", Some("1.2.3"), Some("1234"));
-        let invalid2 = PackageIdent::new("acme", "rocket%one", Some("1.2.3"), Some("1234"));
+        let valid5 = PackageIdent::new("acme", "rocket.one", Some("1.2.3"), Some("1234"));
+        let invalid1 = PackageIdent::new("acme", "rocket%one", Some("1.2.3"), Some("1234"));
 
         assert!(valid1.valid());
         assert!(valid2.valid());
         assert!(valid3.valid());
         assert!(valid4.valid());
+        assert!(valid5.valid());
         assert!(!invalid1.valid());
-        assert!(!invalid2.valid());
     }
 
     #[test]
@@ -657,6 +657,7 @@ mod tests {
         assert!(super::is_valid_origin_name("foo"));
         assert!(super::is_valid_origin_name("foo_bar"));
         assert!(super::is_valid_origin_name("foo-bar"));
+        assert!(super::is_valid_origin_name("foo.bar"));
         assert!(super::is_valid_origin_name("0xdeadbeef"));
 
         assert!(!super::is_valid_origin_name("Core"));

--- a/components/core/src/package/ident.rs
+++ b/components/core/src/package/ident.rs
@@ -13,7 +13,7 @@ use std::{borrow::Cow,
 
 lazy_static::lazy_static! {
     static ref ORIGIN_NAME_RE: Regex =
-        Regex::new(r"\A[a-z0-9][a-z0-9_\.-]*\z").expect("Unable to compile regex");
+        Regex::new(r"\A[a-z0-9][a-z0-9_-]*\z").expect("Unable to compile regex");
 }
 
 #[derive(Deserialize, Serialize, Eq, PartialEq, Debug, Clone, Hash)]
@@ -657,7 +657,6 @@ mod tests {
         assert!(super::is_valid_origin_name("foo"));
         assert!(super::is_valid_origin_name("foo_bar"));
         assert!(super::is_valid_origin_name("foo-bar"));
-        assert!(super::is_valid_origin_name("foo.bar"));
         assert!(super::is_valid_origin_name("0xdeadbeef"));
 
         assert!(!super::is_valid_origin_name("Core"));

--- a/components/core/src/package/ident.rs
+++ b/components/core/src/package/ident.rs
@@ -33,7 +33,8 @@ pub trait Identifiable: fmt::Display + Into<PackageIdent> {
     fn fully_qualified(&self) -> bool { self.version().is_some() && self.release().is_some() }
 
     fn valid(&self) -> bool {
-        let re = Regex::new(r"^[A-Za-z0-9_.-]+$").unwrap();
+        // allow periods in ident name but not at start or end
+        let re = Regex::new(r"^[A-Za-z0-9_-]+([A-Za-z0-9_.-]+[A-Za-z0-9_-]+)?$").unwrap();
         re.is_match(self.name())
     }
 
@@ -642,14 +643,20 @@ mod tests {
         let valid3 = PackageIdent::new("acme", "rocket_one", Some("1.2.3"), Some("1234"));
         let valid4 = PackageIdent::new("acme", "rocket_one", Some("foo-bar"), Some("1234"));
         let valid5 = PackageIdent::new("acme", "rocket.one", Some("1.2.3"), Some("1234"));
+        let valid6 = PackageIdent::new("acme", "rocket.one.two", Some("1.2.3"), Some("1234"));
         let invalid1 = PackageIdent::new("acme", "rocket%one", Some("1.2.3"), Some("1234"));
-
+        let invalid2 = PackageIdent::new("acme", ".rocketone", Some("1.2.3"), Some("1234"));
+        let invalid3 = PackageIdent::new("acme", "rocket.", Some("1.2.3"), Some("1234"));
+        
         assert!(valid1.valid());
         assert!(valid2.valid());
         assert!(valid3.valid());
         assert!(valid4.valid());
         assert!(valid5.valid());
+        assert!(valid6.valid());
         assert!(!invalid1.valid());
+        assert!(!invalid2.valid());
+        assert!(!invalid3.valid());
     }
 
     #[test]

--- a/components/core/src/package/ident.rs
+++ b/components/core/src/package/ident.rs
@@ -11,6 +11,9 @@ use std::{borrow::Cow,
           result,
           str::FromStr};
 
+// allow periods in package name but not at start or end
+pub const PACKAGE_NAME_RE_STR: &str = r"[A-Za-z0-9_-]+(?:[A-Za-z0-9_.-]+[A-Za-z0-9_-]+)?";
+
 lazy_static::lazy_static! {
     static ref ORIGIN_NAME_RE: Regex =
         Regex::new(r"\A[a-z0-9][a-z0-9_-]*\z").expect("Unable to compile regex");
@@ -33,9 +36,8 @@ pub trait Identifiable: fmt::Display + Into<PackageIdent> {
     fn fully_qualified(&self) -> bool { self.version().is_some() && self.release().is_some() }
 
     fn valid(&self) -> bool {
-        // allow periods in ident name but not at start or end
-        let re = Regex::new(r"^[A-Za-z0-9_-]+([A-Za-z0-9_.-]+[A-Za-z0-9_-]+)?$").unwrap();
-        re.is_match(self.name())
+        Regex::new(&format!("^{}$", PACKAGE_NAME_RE_STR)).unwrap()
+                                                         .is_match(self.name())
     }
 
     fn satisfies<I: Identifiable>(&self, other: &I) -> bool {

--- a/components/core/src/package/ident.rs
+++ b/components/core/src/package/ident.rs
@@ -33,7 +33,7 @@ pub trait Identifiable: fmt::Display + Into<PackageIdent> {
     fn fully_qualified(&self) -> bool { self.version().is_some() && self.release().is_some() }
 
     fn valid(&self) -> bool {
-        let re = Regex::new(r"^[A-Za-z0-9_\.-]+$").unwrap();
+        let re = Regex::new(r"^[A-Za-z0-9_.-]+$").unwrap();
         re.is_match(self.name())
     }
 

--- a/components/core/src/package/ident.rs
+++ b/components/core/src/package/ident.rs
@@ -647,7 +647,7 @@ mod tests {
         let invalid1 = PackageIdent::new("acme", "rocket%one", Some("1.2.3"), Some("1234"));
         let invalid2 = PackageIdent::new("acme", ".rocketone", Some("1.2.3"), Some("1234"));
         let invalid3 = PackageIdent::new("acme", "rocket.", Some("1.2.3"), Some("1234"));
-        
+
         assert!(valid1.valid());
         assert!(valid2.valid());
         assert!(valid3.valid());

--- a/components/core/src/service.rs
+++ b/components/core/src/service.rs
@@ -486,10 +486,12 @@ mod test {
 
     #[test]
     fn service_group_from_str_with_period_in_service() {
-        let x = ServiceGroup::from_str("svc.one.group").unwrap();
+        let x = ServiceGroup::from_str("oz.prod#svc.one.group@baz").unwrap();
+        assert_eq!(x.application_environment(),
+                   Some(ApplicationEnvironment::from_str("oz.prod").unwrap()));
         assert_eq!(x.service(), "svc.one");
         assert_eq!(x.group(), "group");
-        assert!(x.org().is_none());
+        assert_eq!(x.org(), Some("baz"));
     }
 
     #[test]

--- a/components/core/src/service.rs
+++ b/components/core/src/service.rs
@@ -1,5 +1,6 @@
-use crate::error::{Error,
-                   Result};
+use crate::{error::{Error,
+                    Result},
+            package::ident::PACKAGE_NAME_RE_STR};
 use regex::Regex;
 use serde_derive::{Deserialize,
                    Serialize};
@@ -12,17 +13,15 @@ use std::{fmt,
           time::Duration};
 
 lazy_static::lazy_static! {
-    static ref SG_FROM_STR_RE: Regex =
-        Regex::new(r"(?x)\A(
-        (?P<application_environment>[^\#@]+)
-        \#)?
-        # allow periods in service name but not at start or end
-        (?P<service>[A-Za-z0-9_-]+([A-Za-z0-9_.-]+[A-Za-z0-9_-]+)?)
-        \.
-        (?P<group>[^\#@.]+)
-        (@
-        (?P<organization>[^\#@.]+)
-        )?\z").unwrap();
+    static ref SG_FROM_STR_RE: Regex = {
+        let svc_capture = format!("(?P<service>{})", PACKAGE_NAME_RE_STR);
+        let regex_str = format!(r"\A({}#)?{}\.{}(@{})?\z",
+        "(?P<application_environment>[^#@]+)",
+        svc_capture,
+        "(?P<group>[^#@.]+)",
+        "(?P<organization>[^#@.]+)");
+        Regex::new(&regex_str).unwrap()
+    };
 
     static ref AE_FROM_STR_RE: Regex =
         Regex::new(r"(?x)\A

--- a/components/core/src/service.rs
+++ b/components/core/src/service.rs
@@ -13,10 +13,22 @@ use std::{fmt,
 
 lazy_static::lazy_static! {
     static ref SG_FROM_STR_RE: Regex =
-        Regex::new(r"\A((?P<application_environment>[^#@]+)#)?(?P<service>[^#@]+)\.(?P<group>[^#@.]+)(@(?P<organization>[^#@.]+))?\z").unwrap();
+        Regex::new(r"(?x)\A(
+        (?P<application_environment>[^\#@]+)
+        \#)?
+        (?P<service>[^\#@]+)
+        \.
+        (?P<group>[^\#@.]+)
+        (@
+        (?P<organization>[^\#@.]+)
+        )?\z").unwrap();
 
     static ref AE_FROM_STR_RE: Regex =
-        Regex::new(r"\A(?P<application>[^#.@]+)\.(?P<environment>[^#.@]+)\z").unwrap();
+        Regex::new(r"(?x)\A
+        (?P<application>[^\#.@]+)
+        \.
+        (?P<environment>[^\#.@]+)
+        \z").unwrap();
 }
 
 /// Determines how the presence of bound service groups affects the

--- a/components/core/src/service.rs
+++ b/components/core/src/service.rs
@@ -151,7 +151,7 @@ impl ServiceGroup {
               S2: AsRef<str>
     {
         if group.as_ref().contains('.') {
-            return Err(Error::InvalidGroupName(group.as_ref().to_string()));
+            return Err(Error::DotInGroupName(group.as_ref().to_string()));
         }
         let formatted = Self::format(app_env, service, group, organization);
         Self::validate(&formatted)?;
@@ -543,7 +543,7 @@ mod test {
         match ServiceGroup::new(None, service, group, None) {
             Err(e) => {
                 match e {
-                    Error::InvalidGroupName(val) => assert_eq!(group, val),
+                    Error::DotInGroupName(val) => assert_eq!(group, val),
                     wrong => panic!("Unexpected error returned: {:?}", wrong),
                 }
             }

--- a/components/plan-build-ps1/bin/hab-plan-build.ps1
+++ b/components/plan-build-ps1/bin/hab-plan-build.ps1
@@ -2154,10 +2154,11 @@ try {
     }
 
     # Test to ensure package name and origin contain only valid characters
-    foreach ($var in @("pkg_name", "pkg_origin")) {
-      if (-Not ((Get-Content Variable:\$var) -match '^[A-Za-z0-9_\.-]+$')) {
-          _Exit-With "Failed to build. Package '$var' contains invalid characters." 1
-      }
+    if (-Not ($pkg_origin -match '^[A-Za-z0-9_-]+$')) {
+        _Exit-With "Failed to build. Origin '$pkg_origin' contains invalid characters." 1
+    }
+    if (-Not ($pkg_name -match '^[A-Za-z0-9_\.-]+$')) {
+        _Exit-With "Failed to build. Package '$pkg_name' contains invalid characters." 1
     }
 
     # Pass over `$pkg_svc_run` to replace any `$pkg_name` placeholder tokens

--- a/components/plan-build-ps1/bin/hab-plan-build.ps1
+++ b/components/plan-build-ps1/bin/hab-plan-build.ps1
@@ -2155,7 +2155,7 @@ try {
 
     # Test to ensure package name and origin contain only valid characters
     foreach ($var in @("pkg_name", "pkg_origin")) {
-      if (-Not ((Get-Content Variable:\$var) -match '^[A-Za-z0-9_-]+$')) {
+      if (-Not ((Get-Content Variable:\$var) -match '^[A-Za-z0-9_\.-]+$')) {
           _Exit-With "Failed to build. Package '$var' contains invalid characters." 1
       }
     }

--- a/components/plan-build-ps1/bin/hab-plan-build.ps1
+++ b/components/plan-build-ps1/bin/hab-plan-build.ps1
@@ -2157,7 +2157,7 @@ try {
     if (-Not ($pkg_origin -match '^[A-Za-z0-9_-]+$')) {
         _Exit-With "Failed to build. Origin '$pkg_origin' contains invalid characters." 1
     }
-    if (-Not ($pkg_name -match '^[A-Za-z0-9_\.-]+$')) {
+    if (-Not ($pkg_name -match '^[A-Za-z0-9_.-]+$')) {
         _Exit-With "Failed to build. Package '$pkg_name' contains invalid characters." 1
     }
 

--- a/components/plan-build-ps1/bin/hab-plan-build.ps1
+++ b/components/plan-build-ps1/bin/hab-plan-build.ps1
@@ -2158,7 +2158,7 @@ try {
         _Exit-With "Failed to build. Origin '$pkg_origin' contains invalid characters." 1
     }
     # Name can include periods but cannot begin or end with one
-    if (-Not ($pkg_name -match '^[A-Za-z0-9_-]+([A-Za-z0-9_.-]+[A-Za-z0-9_-]+)?$')) {
+    if (-Not ($pkg_name -match '^[A-Za-z0-9_-]+(?:[A-Za-z0-9_.-]+[A-Za-z0-9_-]+)?$')) {
         _Exit-With "Failed to build. Package '$pkg_name' contains invalid characters." 1
     }
 

--- a/components/plan-build-ps1/bin/hab-plan-build.ps1
+++ b/components/plan-build-ps1/bin/hab-plan-build.ps1
@@ -2157,7 +2157,8 @@ try {
     if (-Not ($pkg_origin -match '^[A-Za-z0-9_-]+$')) {
         _Exit-With "Failed to build. Origin '$pkg_origin' contains invalid characters." 1
     }
-    if (-Not ($pkg_name -match '^[A-Za-z0-9_.-]+$')) {
+    # Name can include periods but cannot begin or end with one
+    if (-Not ($pkg_name -match '^[A-Za-z0-9_-]+([A-Za-z0-9_.-]+[A-Za-z0-9_-]+)?$')) {
         _Exit-With "Failed to build. Package '$pkg_name' contains invalid characters." 1
     }
 

--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -2466,12 +2466,14 @@ do
 done
 
 # Test to ensure package name contains only valid characters
-for var in pkg_name pkg_origin; do
-  if [[ ! "${!var}" =~ ^[A-Za-z0-9_\.-]+$ ]];
-  then
-    exit_with "Failed to build. Package $var '${!var}' contains invalid characters." 1
-  fi
-done
+if [[ ! "$pkg_origin" =~ ^[A-Za-z0-9_-]+$ ]];
+then
+  exit_with "Failed to build. Origin $var '$pkg_origin' contains invalid characters." 1
+fi
+if [[ ! "$pkg_name" =~ ^[A-Za-z0-9_\.-]+$ ]];
+then
+  exit_with "Failed to build. Package $var '$pkg_name' contains invalid characters." 1
+fi
 
 # Pass over `$pkg_svc_run` to replace any `$pkg_name` placeholder tokens
 # from prior pkg_svc_* variables that were set before the Plan was loaded.

--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -2467,7 +2467,7 @@ done
 
 # Test to ensure package name contains only valid characters
 for var in pkg_name pkg_origin; do
-  if [[ ! "${!var}" =~ ^[A-Za-z0-9_-]+$ ]];
+  if [[ ! "${!var}" =~ ^[A-Za-z0-9_\.-]+$ ]];
   then
     exit_with "Failed to build. Package $var '${!var}' contains invalid characters." 1
   fi

--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -2470,7 +2470,7 @@ if [[ ! "$pkg_origin" =~ ^[A-Za-z0-9_-]+$ ]];
 then
   exit_with "Failed to build. Origin $var '$pkg_origin' contains invalid characters." 1
 fi
-if [[ ! "$pkg_name" =~ ^[A-Za-z0-9_\.-]+$ ]];
+if [[ ! "$pkg_name" =~ ^[A-Za-z0-9_.-]+$ ]];
 then
   exit_with "Failed to build. Package $var '$pkg_name' contains invalid characters." 1
 fi

--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -2471,7 +2471,7 @@ then
   exit_with "Failed to build. Origin $var '$pkg_origin' contains invalid characters." 1
 fi
 # Name can include periods but cannot begin or end with one
-if [[ ! "$pkg_name" =~ ^[A-Za-z0-9_-]+([A-Za-z0-9_.-]+[A-Za-z0-9_-]+)?$ ]];
+if [[ ! "$pkg_name" =~ ^[A-Za-z0-9_-]+(?:[A-Za-z0-9_.-]+[A-Za-z0-9_-]+)?$ ]];
 then
   exit_with "Failed to build. Package $var '$pkg_name' contains invalid characters." 1
 fi

--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -2470,7 +2470,8 @@ if [[ ! "$pkg_origin" =~ ^[A-Za-z0-9_-]+$ ]];
 then
   exit_with "Failed to build. Origin $var '$pkg_origin' contains invalid characters." 1
 fi
-if [[ ! "$pkg_name" =~ ^[A-Za-z0-9_.-]+$ ]];
+# Name can include periods but cannot begin or end with one
+if [[ ! "$pkg_name" =~ ^[A-Za-z0-9_-]+([A-Za-z0-9_.-]+[A-Za-z0-9_-]+)?$ ]];
 then
   exit_with "Failed to build. Package $var '$pkg_name' contains invalid characters." 1
 fi


### PR DESCRIPTION
resolves #6434

This allows `.`s in a package name. It looks as though the reason why we have banned the presence of dots is due to the dot notation we use in service groups of `service.group`. What this change does is allow dots in package names when building packages and then enforcing at `svc load` that there are no dots in `--group`. Thus a "service group" with multiple dots will parse the group name as the string after the last dot.

I have tested running a package with a dot in it in a supervisor with these changes and the service runs succesfully and I have also tested that groups with dots are rejected.