### PR TITLE
Add limit option to hab pkg search

### DIFF
--- a/components/builder-api-client/src/builder.rs
+++ b/components/builder-api-client/src/builder.rs
@@ -1258,7 +1258,6 @@ mod tests {
         assert_eq!(r.1, 0);
     }
 
-    #[ignore]
     #[test]
     fn package_search_large() {
         let client = BuilderAPIClient::new("http://test.com", "", "", None).expect("valid client");

--- a/components/builder-api-client/src/lib.rs
+++ b/components/builder-api-client/src/lib.rs
@@ -294,8 +294,9 @@ pub trait BuilderAPIProvider: Sync + Send {
 
     fn search_package(&self,
                       search_term: &str,
+                      limit: usize,
                       token: Option<&str>)
-                      -> Result<(Vec<PackageIdent>, bool)>;
+                      -> Result<(Vec<PackageIdent>, usize)>;
 
     fn create_channel(&self, origin: &str, channel: &ChannelIdent, token: &str) -> Result<()>;
 

--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -474,6 +474,8 @@ pub fn get(feature_flags: FeatureFlag) -> App<'static, 'static> {
                     endpoint. If not specified, the value will be taken from the HAB_BLDR_URL \
                     environment variable if defined. (default: https://bldr.habitat.sh)")
                 (@arg AUTH_TOKEN: -z --auth +takes_value "Authentication token for Builder")
+                (@arg LIMIT: -l --limit +takes_value default_value("50") {valid_numeric::<usize>}
+                    "Limit how many packages to retrieve (default: 50)")
             )
             (@subcommand sign =>
                 (about: "Signs an archive with an origin key, generating a Habitat Artifact")

--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -475,7 +475,7 @@ pub fn get(feature_flags: FeatureFlag) -> App<'static, 'static> {
                     environment variable if defined. (default: https://bldr.habitat.sh)")
                 (@arg AUTH_TOKEN: -z --auth +takes_value "Authentication token for Builder")
                 (@arg LIMIT: -l --limit +takes_value default_value("50") {valid_numeric::<usize>}
-                    "Limit how many packages to retrieve (default: 50)")
+                    "Limit how many packages to retrieve")
             )
             (@subcommand sign =>
                 (about: "Signs an archive with an origin key, generating a Habitat Artifact")

--- a/components/hab/src/command/pkg/search.rs
+++ b/components/hab/src/command/pkg/search.rs
@@ -3,11 +3,11 @@ use crate::{api_client::Client,
             PRODUCT,
             VERSION};
 
-pub fn start(st: &str, bldr_url: &str, token: Option<&str>) -> Result<()> {
+pub fn start(st: &str, bldr_url: &str, limit: usize, token: Option<&str>) -> Result<()> {
     let api_client = Client::new(bldr_url, PRODUCT, VERSION, None)?;
-    let (packages, more) = api_client.search_package(st, token)?;
+    let (packages, total) = api_client.search_package(st, limit, token)?;
     match packages.len() {
-        0 => println!("No packages found that match '{}'", st),
+        0 => eprintln!("No packages found that match '{}'", st),
         _ => {
             for p in &packages {
                 if let (&Some(ref version), &Some(ref release)) = (&p.version, &p.release) {
@@ -16,9 +16,10 @@ pub fn start(st: &str, bldr_url: &str, token: Option<&str>) -> Result<()> {
                     println!("{}/{}", p.origin, p.name);
                 }
             }
-            if more {
-                println!("Search returned too many items, only showing the first {}",
-                         packages.len());
+            if packages.len() != total as usize {
+                eprintln!("Search returned too many items, only showing the first {} of {}",
+                          packages.len(),
+                          total);
             }
         }
     }

--- a/components/hab/src/command/pkg/search.rs
+++ b/components/hab/src/command/pkg/search.rs
@@ -16,7 +16,7 @@ pub fn start(st: &str, bldr_url: &str, limit: usize, token: Option<&str>) -> Res
                     println!("{}/{}", p.origin, p.name);
                 }
             }
-            if packages.len() != total as usize {
+            if packages.len() < total {
                 eprintln!("Search returned too many items, only showing the first {} of {}",
                           packages.len(),
                           total);

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -784,8 +784,12 @@ fn sub_pkg_provides(m: &ArgMatches<'_>) -> Result<()> {
 fn sub_pkg_search(m: &ArgMatches<'_>) -> Result<()> {
     let url = bldr_url_from_matches(&m)?;
     let search_term = m.value_of("SEARCH_TERM").unwrap(); // Required via clap
+    let limit = m.value_of("LIMIT").unwrap().parse().unwrap(); // Required via clap
     let token = maybe_auth_token(&m);
-    command::pkg::search::start(&search_term, &url, token.as_ref().map(String::as_str))
+    command::pkg::search::start(&search_term,
+                                &url,
+                                limit,
+                                token.as_ref().map(String::as_str))
 }
 
 fn sub_pkg_sign(ui: &mut UI, m: &ArgMatches<'_>) -> Result<()> {

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -783,8 +783,11 @@ fn sub_pkg_provides(m: &ArgMatches<'_>) -> Result<()> {
 
 fn sub_pkg_search(m: &ArgMatches<'_>) -> Result<()> {
     let url = bldr_url_from_matches(&m)?;
-    let search_term = m.value_of("SEARCH_TERM").unwrap(); // Required via clap
-    let limit = m.value_of("LIMIT").unwrap().parse().unwrap(); // Required via clap
+    let search_term = m.value_of("SEARCH_TERM").expect("required opt SEARCH_TERM");
+    let limit = m.value_of("LIMIT")
+                 .expect("required opt LIMIT")
+                 .parse()
+                 .expect("valid LIMIT");
     let token = maybe_auth_token(&m);
     command::pkg::search::start(&search_term,
                                 &url,


### PR DESCRIPTION
This adds a `--limit` option to `hab pkg search` that lets users set an arbitrary limit when searching for packages. Before it was restricted to 50. 

This uses the existing builder api. Future work could improve the builder api cleaning up the logic of the cli. For example, it is currently necessary to do multiple http requests to get the results.

I also made output that is not directly printing package idents pipe to stderr instead of stdout. I have found this makes tools easier to use in conjunction with other command line utilities.

Resolves [#56](https://github.com/habitat-sh/builder/issues/56)