### PR TITLE
Two minor fixes for vagrant based bootstrap

### DIFF
--- a/support/linux/install_dev_9_linux.sh
+++ b/support/linux/install_dev_9_linux.sh
@@ -45,5 +45,5 @@ else
   sudo -E addgroup --system hab || true
 fi
 
-sudo "$(dirname -- "$0")/../../components/hab/install.sh"
-sudo hab install core/busybox-static core/hab-studio
+sudo "$(dirname -- "$0")/install.sh"
+sudo HAB_LICENSE="accept-no-persist" hab install core/busybox-static core/hab-studio


### PR DESCRIPTION
1) Pass accept license through sudo.

2) Fixup bad path for install.sh. This seems reasonable for the vagrant
environment, and the docker environment still seems to work for me. Tested this on MacOS and Ubuntu 18.10 hosts. This might need a bit more review because I'm not sure how wide ranging the usage of this script is.

Thanks to @smacfarlane for his help with this and getting my dev-env bootstrapped.

Signed-off-by: Mark Anderson <mark@chef.io>