### PR TITLE
Add a tool for simulating a supervisor network

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ test/builder-api/built/*
 test/builder-api/node_modules
 test/builder-api/services.log
 tmp/
+CTL_SECRET

--- a/tools/sup-network/Dockerfile
+++ b/tools/sup-network/Dockerfile
@@ -1,0 +1,15 @@
+FROM ubuntu:18.04
+
+RUN apt-get update
+
+RUN apt-get install -y \
+            libarchive-dev \
+            libczmq-dev \
+            libsodium-dev \
+            libssl-dev
+
+RUN apt-get install -y \
+            jq \
+            curl
+
+RUN useradd --user-group hab

--- a/tools/sup-network/Makefile
+++ b/tools/sup-network/Makefile
@@ -1,0 +1,50 @@
+ifneq (${HAB_SUP_TEST_NETWORK_LOG_SERVICE},)
+	log_service := ${HAB_SUP_TEST_NETWORK_LOG_SERVICE}
+else
+	log_service := rando
+endif
+
+ifneq (${HAB_SUP_TEST_NETWORK_SIZE},)
+	peers := ${HAB_SUP_TEST_NETWORK_SIZE}
+else
+	peers := 3
+endif
+
+HAB_SUP_TEST_NETWORK_PEER_NAME ?= rando_1
+
+up: build CTL_SECRET
+	@docker build -t hab-sup-network .
+	@docker-compose up -d --scale rando=${peers}
+
+down:
+	@docker-compose down
+	@rm -f CTL_SECRET
+
+start:
+	@docker-compose start
+
+stop:
+	@docker-compose stop
+
+logs:
+	@docker-compose logs -f ${log_service}
+
+console:
+	@docker exec -it $$(docker ps -aqf name=${HAB_SUP_TEST_NETWORK_PEER_NAME}) /bin/bash
+
+# Kill the specified container to simulate a departure
+kill:
+	@docker stop $$(docker ps -aqf name=${HAB_SUP_TEST_NETWORK_PEER_NAME})
+
+# This gets the IP address of one of the containers that you specify. This is
+# useful if you need to e.g. hab svc load --remote-sup=X.X.X.X core/redis
+ip:
+	@docker network inspect $$(docker network ls -qf name=supnetwork) | jq ".[].Containers | to_entries | map(select(.value.Name == \"supnetwork_${HAB_SUP_TEST_NETWORK_PEER_NAME}_1\")) | .[0].value.IPv4Address" | tr -d '"' | cut -d '/' -f 1
+
+CTL_SECRET:
+	@hab sup secret generate > CTL_SECRET
+
+build:
+	@cargo build -p habitat-launcher
+	@cargo build -p habitat_sup
+	@cargo build -p hab

--- a/tools/sup-network/Makefile
+++ b/tools/sup-network/Makefile
@@ -1,50 +1,40 @@
-ifneq (${HAB_SUP_TEST_NETWORK_LOG_SERVICE},)
-	log_service := ${HAB_SUP_TEST_NETWORK_LOG_SERVICE}
-else
-	log_service := rando
-endif
-
-ifneq (${HAB_SUP_TEST_NETWORK_SIZE},)
-	peers := ${HAB_SUP_TEST_NETWORK_SIZE}
-else
-	peers := 3
-endif
-
-HAB_SUP_TEST_NETWORK_PEER_NAME ?= rando_1
+HAB_SUP_TEST_NETWORK_LOG_SERVICE := rando
+HAB_SUP_TEST_NETWORK_SIZE := 3
+HAB_SUP_TEST_NETWORK_PEER_NAME := rando_1
 
 up: build CTL_SECRET
-	@docker build -t hab-sup-network .
-	@docker-compose up -d --scale rando=${peers}
+	docker build -t hab-sup-network .
+	docker-compose up -d --scale rando=${HAB_SUP_TEST_NETWORK_SIZE}
 
 down:
-	@docker-compose down
-	@rm -f CTL_SECRET
+	docker-compose down
+	rm -f CTL_SECRET
 
 start:
-	@docker-compose start
+	docker-compose start
 
 stop:
-	@docker-compose stop
+	docker-compose stop
 
 logs:
-	@docker-compose logs -f ${log_service}
+	docker-compose logs -f ${HAB_SUP_TEST_NETWORK_LOG_SERVICE}
 
 console:
-	@docker exec -it $$(docker ps -aqf name=${HAB_SUP_TEST_NETWORK_PEER_NAME}) /bin/bash
+	docker exec -it $$(docker ps -aqf name=${HAB_SUP_TEST_NETWORK_PEER_NAME}) /bin/bash
 
 # Kill the specified container to simulate a departure
 kill:
-	@docker stop $$(docker ps -aqf name=${HAB_SUP_TEST_NETWORK_PEER_NAME})
+	docker stop $$(docker ps -aqf name=${HAB_SUP_TEST_NETWORK_PEER_NAME})
 
 # This gets the IP address of one of the containers that you specify. This is
 # useful if you need to e.g. hab svc load --remote-sup=X.X.X.X core/redis
 ip:
-	@docker network inspect $$(docker network ls -qf name=supnetwork) | jq ".[].Containers | to_entries | map(select(.value.Name == \"supnetwork_${HAB_SUP_TEST_NETWORK_PEER_NAME}_1\")) | .[0].value.IPv4Address" | tr -d '"' | cut -d '/' -f 1
+	docker network inspect $(shell docker network ls -qf name=supnetwork) | jq ".[].Containers | to_entries | map(select(.value.Name == \"supnetwork_${HAB_SUP_TEST_NETWORK_PEER_NAME}\")) | .[0].value.IPv4Address" | tr -d '"' | cut -d '/' -f 1
 
 CTL_SECRET:
-	@hab sup secret generate > CTL_SECRET
+	hab sup secret generate > CTL_SECRET
 
 build:
-	@cargo build -p habitat-launcher
-	@cargo build -p habitat_sup
-	@cargo build -p hab
+	cargo build -p habitat-launcher
+	cargo build -p habitat_sup
+	cargo build -p hab

--- a/tools/sup-network/README.md
+++ b/tools/sup-network/README.md
@@ -15,8 +15,11 @@ I had just made with a minimum of hassle and fuss. That's why I made this.
 To start the network, run `make up`. This will build `hab`, `hab-launch`, and
 `hab-sup`, write out a `CTL_SECRET` file, and start the network. By default it
 will start 1 bastion node and 3 peer nodes. The number of peer nodes that are
-started can be controlled via the `HAB_SUP_TEST_NETWORK_SIZE` environment
-variable.
+started can be controlled via `HAB_SUP_TEST_NETWORK_SIZE`.
+
+```
+make up HAB_SUP_TEST_NETWORK_SIZE=5
+```
 
 To stop the network, run `make down`. This not only stops the network and all
 the containers, but also removes them, as well as removes the `CTL_SECRET`
@@ -26,13 +29,21 @@ file. If you want to just stop containers, without removing them, you can run
 Nodes are started up in detached mode. Presumably, you'd like to look at the
 logs for a service at some point. You can do that via `make logs`. This shows
 the logs for the `rando` service by default but you can display the logs of the
-bastion service by setting the `HAB_SUP_TEST_NETWORK_LOG_SERVICE` environment
-variable to `bastion`.
+bastion service by setting the `HAB_SUP_TEST_NETWORK_LOG_SERVICE` variable to
+`bastion`.
+
+```
+make logs HAB_SUP_TEST_NETWORK_LOG_SERVICE=bastion
+```
 
 If you would like to get a shell prompt into one of the containers, you can run
 `make console`. This will get you into the `rando_1` container by default. You
 can specify a different container using the `HAB_SUP_TEST_NETWORK_PEER_NAME`
-environment variable.
+variable.
+
+```
+make console HAB_SUP_TEST_NETWORK_PEER_NAME=rando_2
+```
 
 If you wish to simulate a departure, you can kill a container using `make
 kill`. Which container is killed works the same as `make console`.

--- a/tools/sup-network/README.md
+++ b/tools/sup-network/README.md
@@ -1,0 +1,43 @@
+## sup-network
+
+This is a tool designed to simulate a supervisor network using docker-compose.
+It takes much inspiration from
+[Terrarium](https://github.com/christophermaier/terrarium).
+
+### Rationale
+I wanted a tool that I could use to get a network of Habitat supervisors up and
+running quickly. More than that though, I specifically wanted to be able to
+test supervisors that were under active development. I wanted to run `cargo
+build` on the `sup` crate and then immediately be able to test the changes
+I had just made with a minimum of hassle and fuss. That's why I made this.
+
+### Usage
+To start the network, run `make up`. This will build `hab`, `hab-launch`, and
+`hab-sup`, write out a `CTL_SECRET` file, and start the network. By default it
+will start 1 bastion node and 3 peer nodes. The number of peer nodes that are
+started can be controlled via the `HAB_SUP_TEST_NETWORK_SIZE` environment
+variable.
+
+To stop the network, run `make down`. This not only stops the network and all
+the containers, but also removes them, as well as removes the `CTL_SECRET`
+file. If you want to just stop containers, without removing them, you can run
+`make stop`. `make start` will start them back up from a stopped state.
+
+Nodes are started up in detached mode. Presumably, you'd like to look at the
+logs for a service at some point. You can do that via `make logs`. This shows
+the logs for the `rando` service by default but you can display the logs of the
+bastion service by setting the `HAB_SUP_TEST_NETWORK_LOG_SERVICE` environment
+variable to `bastion`.
+
+If you would like to get a shell prompt into one of the containers, you can run
+`make console`. This will get you into the `rando_1` container by default. You
+can specify a different container using the `HAB_SUP_TEST_NETWORK_PEER_NAME`
+environment variable.
+
+If you wish to simulate a departure, you can kill a container using `make
+kill`. Which container is killed works the same as `make console`.
+
+Sometimes you may want the IP address of one of the containers, perhaps to do
+a service load on a remote supervisor, or perhaps to satisfy your own
+curiosity. `make ip` will get you that. Specifying the container works the same
+as `make console`.

--- a/tools/sup-network/docker-compose.yml
+++ b/tools/sup-network/docker-compose.yml
@@ -1,0 +1,65 @@
+version: "3.4"
+
+x-service: &srv
+  image: hab-sup-network
+  volumes:
+    - type: bind
+      source: ./CTL_SECRET
+      target: /hab/sup/default/CTL_SECRET
+      read_only: false
+    - type: bind
+      source: /hab/cache
+      target: /hab/cache
+      read_only: false
+    - type: bind
+      source: /hab/pkgs
+      target: /hab/pkgs
+      read_only: false
+    - type: bind
+      source: "${PWD}/../../target/debug/hab"
+      target: /bin/hab
+      read_only: false
+    - type: bind
+      source: "${PWD}/../../target/debug/hab-sup"
+      target: /bin/hab-sup
+      read_only: false
+    - type: bind
+      source: "${PWD}/../../target/debug/hab-launch"
+      target: /bin/hab-launch
+      read_only: false
+  environment:
+    - HAB_NONINTERACTIVE=1
+    - HAB_SUP_BINARY=/bin/hab-sup
+    - HAB_LAUNCH_BINARY=/bin/hab-launch
+    - HAB_LAUNCH_NO_SUP_VERSION_CHECK=1
+    - HAB_LICENSE=accept-no-persist
+    - RUST_LOG=info,rustc_metadata=error,cargo=error,jobserver=error,rustc_trans=error,rustc_driver=error,rustc_mir=error,rustc=error,tokio_core=info
+    - PATH=/bin:/usr/bin
+  entrypoint: /bin/hab
+
+services:
+  bastion:
+    <<: *srv
+    hostname: bastion
+    networks:
+      sup:
+        aliases:
+          - bastion
+    command:
+      - "run"
+      - "--listen-ctl=0.0.0.0:9632"
+      - "--permanent-peer"
+
+  rando:
+    <<: *srv
+    networks:
+      sup:
+    command:
+      - "run"
+      - "--listen-ctl=0.0.0.0:9632"
+      - "--peer=bastion"
+    depends_on:
+      - bastion
+
+networks:
+  sup:


### PR DESCRIPTION
This tool uses a slightly modified Ubuntu 18.04 image and docker-compose
to start up a supervisor network using 1 permanent peer and a dynamic
number of other peers.

I originally created this for the work on rumor garbage collection, but it feels generally useful, and I'm in the middle of restructuring that work, so I thought it made sense to PR this separately.

![](https://media.giphy.com/media/goOxvsigLIh6U/giphy.gif)

Signed-off-by: Josh Black <raskchanky@gmail.com>