### PR TITLE
Add `--binlink-dir` argument to `hab pkg install`

### DIFF
--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -882,7 +882,7 @@ fn sub_pkg_install(feature_flags: FeatureFlag) -> App<'static, 'static> {
             "One or more Habitat package identifiers (ex: acme/redis) and/or filepaths \
             to a Habitat Artifact (ex: /home/acme-redis-3.0.7-21120102031201-x86_64-linux.hart)")
         (@arg BINLINK: -b --binlink
-            "Binlink all binaries from installed package(s)")
+            "Binlink all binaries from installed package(s) into BINLINK_DIR")
         (@arg BINLINK_DIR: --("binlink-dir") +takes_value {non_empty} env(BINLINK_DIR_ENVVAR)
             default_value(DEFAULT_BINLINK_DIR) "Binlink all binaries from installed package(s) into BINLINK_DIR")
         (@arg FORCE: -f --force "Overwrite existing binlinks")

--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -881,8 +881,10 @@ fn sub_pkg_install(feature_flags: FeatureFlag) -> App<'static, 'static> {
         (@arg PKG_IDENT_OR_ARTIFACT: +required +multiple
             "One or more Habitat package identifiers (ex: acme/redis) and/or filepaths \
             to a Habitat Artifact (ex: /home/acme-redis-3.0.7-21120102031201-x86_64-linux.hart)")
-        (@arg BINLINK: -b --binlink +takes_value {non_empty} env(BINLINK_DIR_ENVVAR)
-            default_value(DEFAULT_BINLINK_DIR) "Binlink all binaries from installed package(s)")
+        (@arg BINLINK: -b --binlink
+            "Binlink all binaries from installed package(s)")
+        (@arg BINLINK_DIR: --("binlink-dir") +takes_value {non_empty} env(BINLINK_DIR_ENVVAR)
+            default_value(DEFAULT_BINLINK_DIR) "Binlink all binaries from installed package(s) into BINLINK_DIR")
         (@arg FORCE: -f --force "Overwrite existing binlinks")
         (@arg AUTH_TOKEN: -z --auth +takes_value "Authentication token for Builder")
         (@arg IGNORE_INSTALL_HOOK: --("ignore-install-hook") "Do not run any install hooks")


### PR DESCRIPTION
Resolves https://github.com/habitat-sh/habitat/issues/6582

Also revert `--binlink` argument to its previous behavior as a flag; Specifying a non-default location for the links is now handled by the new `--binlink-dir` argument.

The best course of action would have to never have made `--binlink` a flag in the first place; it should always have taken an (optional) argument. But since we have that historical usage, this may be an improvement over breaking usages like:
```bash
$ hab pkg install --binlink core/redis
```
which previously worked. The tradeoff here is that the functionality is now confusingly split across two arguments: `--binlink` (a flag again) and `--binlink-dir` (an option which has a default value that can be overridden on the CLI or via environment variable). This makes the connection between `--binlink` and where the links are created less obvious in the CLI docs:
```
Installs a Habitat package from Builder or locally from a Habitat Artifact

USAGE:
    hab pkg install [FLAGS] [OPTIONS] <PKG_IDENT_OR_ARTIFACT>...

FLAGS:
    -b, --binlink                Binlink all binaries from installed package(s)
    -f, --force                  Overwrite existing binlinks
        --ignore-install-hook    Do not run any install hooks
    -h, --help                   Prints help information
    -V, --version                Prints version information

OPTIONS:
    -z, --auth <AUTH_TOKEN>            Authentication token for Builder
        --binlink-dir <BINLINK_DIR>    Binlink all binaries from installed package(s) into BINLINK_DIR [env:
                                       HAB_BINLINK_DIR=]  [default: /bin]
    -u, --url <BLDR_URL>               Specify an alternate Builder endpoint. If not specified, the value will be taken
                                       from the HAB_BLDR_URL environment variable if defined. (default:
                                       https://bldr.habitat.sh)
    -c, --channel <CHANNEL>            Install from the specified release channel [env: HAB_BLDR_CHANNEL=]  [default:
                                       stable]

ARGS:
    <PKG_IDENT_OR_ARTIFACT>...    One or more Habitat package identifiers (ex: acme/redis) and/or filepaths to a
                                  Habitat Artifact (ex: /home/acme-redis-3.0.7-21120102031201-x86_64-linux.hart)
```

So, which path forward is better:
1. Stick with the code we have now, which is clearer, but forces some changes in usage
1. Move to the approach in this PR, which supports old usage, but is more complicated/confusing

?