### PR TITLE
Add rst-reader to assist in debugging butterfly.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1003,6 +1003,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "habitat-rst-reader"
+version = "0.0.0"
+dependencies = [
+ "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "habitat_butterfly 0.1.0",
+ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "habitat-sup-client"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
   "components/pkg-export-helm",
   "components/pkg-export-kubernetes",
   "components/pkg-export-tar",
+  "components/rst-reader",
   "components/sup",
   "components/sup-client",
   "components/sup-protocol",

--- a/components/butterfly/src/member.rs
+++ b/components/butterfly/src/member.rs
@@ -203,6 +203,21 @@ pub struct Membership {
     pub health: Health,
 }
 
+impl fmt::Display for Membership {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f,
+               "Member i/{} m/{} ad/{} sp/{} gp/{} p/{} d/{} h/{:?}",
+               self.member.incarnation,
+               self.member.id,
+               self.member.address,
+               self.member.swim_port,
+               self.member.gossip_port,
+               self.member.persistent,
+               self.member.departed,
+               self.health)
+    }
+}
+
 impl Membership {
     /// See MemberList::insert
     fn newer_or_less_healthy_than(&self,

--- a/components/butterfly/src/rumor/dat_file.rs
+++ b/components/butterfly/src/rumor/dat_file.rs
@@ -60,17 +60,14 @@ impl DatFile {
         Ok(BufReader::new(file))
     }
 
-    pub fn read_header(&mut self,
-                       mut version: &mut [u8],
-                       mut reader: &mut BufReader<File>)
-                       -> Result<()> {
-        reader.read_exact(&mut version)
+    pub fn read_header(&mut self, version: &mut [u8], reader: &mut BufReader<File>) -> Result<()> {
+        reader.read_exact(version)
               .map_err(|err| Error::DatFileIO(self.path.clone(), err))?;
         debug!("Header Version: {}", version[0]);
         let (header_size, real_header) =
-            Header::from_file(&mut reader, version[0]).map_err(|err| {
-                                                          Error::DatFileIO(self.path.clone(), err)
-                                                      })?;
+            Header::from_file(reader, version[0]).map_err(|err| {
+                                                     Error::DatFileIO(self.path.clone(), err)
+                                                 })?;
         self.header = real_header;
         self.header_size = header_size;
         debug!("Header Size: {:?}", self.header_size);

--- a/components/butterfly/src/rumor/departure.rs
+++ b/components/butterfly/src/rumor/departure.rs
@@ -4,8 +4,6 @@
 //! happens, we ensure that the member can no longer come back into the fold, unless an
 //! administrator reverses the decision.
 
-use std::cmp::Ordering;
-
 use crate::{error::{Error,
                     Result},
             protocol::{self,
@@ -15,10 +13,18 @@ use crate::{error::{Error,
             rumor::{Rumor,
                     RumorPayload,
                     RumorType}};
+use std::{cmp::Ordering,
+          fmt};
 
 #[derive(Debug, Clone, Serialize)]
 pub struct Departure {
     pub member_id: String,
+}
+
+impl fmt::Display for Departure {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Departure m/{}", self.member_id)
+    }
 }
 
 impl Departure {

--- a/components/butterfly/src/rumor/election.rs
+++ b/components/butterfly/src/rumor/election.rs
@@ -8,9 +8,6 @@
 //! devolve to a single, universal rumor, which when it is received by the winner will result in
 //! the election finishing. There can, in the end, be only one.
 
-use std::ops::{Deref,
-               DerefMut};
-
 pub use crate::protocol::newscast::{election::Status as ElectionStatus,
                                     Election as ProtoElection};
 use crate::{error::{Error,
@@ -22,6 +19,9 @@ use crate::{error::{Error,
             rumor::{Rumor,
                     RumorPayload,
                     RumorType}};
+use std::{fmt,
+          ops::{Deref,
+                DerefMut}};
 
 pub trait ElectionRumor {
     fn member_id(&self) -> &str;
@@ -41,6 +41,14 @@ pub struct Election {
     pub suitability:   u64,
     pub status:        ElectionStatus,
     pub votes:         Vec<String>,
+}
+
+impl fmt::Display for Election {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f,
+               "Election m/{} sg/{}, t/{}, su/{}, st/{:?}",
+               self.member_id, self.service_group, self.term, self.suitability, self.status)
+    }
 }
 
 impl Election {
@@ -195,6 +203,18 @@ impl Rumor for Election {
 
 #[derive(Debug, Clone, Serialize)]
 pub struct ElectionUpdate(Election);
+
+impl fmt::Display for ElectionUpdate {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f,
+               "ElectionUpdate m/{} sg/{}, t/{}, su/{}, st/{:?}",
+               self.0.member_id,
+               self.0.service_group,
+               self.0.term,
+               self.0.suitability,
+               self.0.status)
+    }
+}
 
 impl ElectionUpdate {
     pub fn new<S1>(member_id: S1,

--- a/components/butterfly/src/rumor/service.rs
+++ b/components/butterfly/src/rumor/service.rs
@@ -2,19 +2,6 @@
 //!
 //! Service rumors declare that a given `Server` is running this Service.
 
-use std::{cmp::Ordering,
-          mem,
-          result,
-          str::FromStr};
-
-use serde::{ser::SerializeStruct,
-            Serialize,
-            Serializer};
-use toml;
-
-use habitat_core::{package::Identifiable,
-                   service::ServiceGroup};
-
 use crate::{error::{Error,
                     Result},
             protocol::{self,
@@ -23,6 +10,17 @@ use crate::{error::{Error,
             rumor::{Rumor,
                     RumorPayload,
                     RumorType}};
+use habitat_core::{package::Identifiable,
+                   service::ServiceGroup};
+use serde::{ser::SerializeStruct,
+            Serialize,
+            Serializer};
+use std::{cmp::Ordering,
+          fmt,
+          mem,
+          result,
+          str::FromStr};
+use toml;
 
 #[derive(Debug, Clone)]
 pub struct Service {
@@ -33,6 +31,14 @@ pub struct Service {
     pub pkg:           String,
     pub cfg:           Vec<u8>,
     pub sys:           SysInfo,
+}
+
+impl fmt::Display for Service {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f,
+               "Service i/{} m/{} sg/{}",
+               self.incarnation, self.member_id, self.service_group)
+    }
 }
 
 // Ensures that `cfg` is rendered as a map, and not an array of bytes

--- a/components/butterfly/src/rumor/service_config.rs
+++ b/components/butterfly/src/rumor/service_config.rs
@@ -15,6 +15,7 @@ use habitat_core::{crypto::{keys::box_key_pair::WrappedSealedBox,
                             BoxKeyPair},
                    service::ServiceGroup};
 use std::{cmp::Ordering,
+          fmt,
           mem,
           path::Path,
           str::{self,
@@ -28,6 +29,14 @@ pub struct ServiceConfig {
     pub incarnation:   u64,
     pub encrypted:     bool,
     pub config:        Vec<u8>, // TODO: make this a String
+}
+
+impl fmt::Display for ServiceConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f,
+               "ServiceConfig i/{} m/{} sg/{}",
+               self.incarnation, self.from_id, self.service_group)
+    }
 }
 
 impl PartialOrd for ServiceConfig {

--- a/components/butterfly/src/rumor/service_file.rs
+++ b/components/butterfly/src/rumor/service_file.rs
@@ -15,6 +15,7 @@ use habitat_core::{crypto::{keys::box_key_pair::WrappedSealedBox,
                             BoxKeyPair},
                    service::ServiceGroup};
 use std::{cmp::Ordering,
+          fmt,
           mem,
           path::Path,
           str::FromStr};
@@ -27,6 +28,14 @@ pub struct ServiceFile {
     pub encrypted:     bool,
     pub filename:      String,
     pub body:          Vec<u8>, // TODO: make this a String
+}
+
+impl fmt::Display for ServiceFile {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f,
+               "ServiceFile i/{} m/{} sg/{} fn/{}",
+               self.incarnation, self.from_id, self.service_group, self.filename)
+    }
 }
 
 impl PartialOrd for ServiceFile {

--- a/components/butterfly/src/server/mod.rs
+++ b/components/butterfly/src/server/mod.rs
@@ -417,7 +417,8 @@ impl Server {
                 return Err(Error::BadDataPath(path.to_path_buf(), err));
             }
             let dat_path = path.join(format!("{}.rst", &self.member_id));
-            let mut file = DatFile::new(dat_path);
+            let mut file = DatFile::new(dat_path)?;
+
             if file.path().exists() {
                 match file.read_into(self) {
                     Ok(_) => {
@@ -428,6 +429,7 @@ impl Server {
                     Err(err) => return Err(err),
                 };
             }
+
             self.dat_file = Some(Arc::new(Mutex::new(file)));
 
             {

--- a/components/butterfly/src/server/mod.rs
+++ b/components/butterfly/src/server/mod.rs
@@ -416,7 +416,8 @@ impl Server {
             if let Some(err) = fs::create_dir_all(path).err() {
                 return Err(Error::BadDataPath(path.to_path_buf(), err));
             }
-            let mut file = DatFile::new(&self.member_id, path);
+            let dat_path = path.join(format!("{}.rst", &self.member_id));
+            let mut file = DatFile::new(dat_path);
             if file.path().exists() {
                 match file.read_into(self) {
                     Ok(_) => {

--- a/components/rst-reader/Cargo.toml
+++ b/components/rst-reader/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "habitat-rst-reader"
+version = "0.0.0"
+authors = ["The Habitat Maintainers <humans@habitat.sh>"]
+edition = "2018"
+workspace = "../../"
+
+[[bin]]
+name = "rst-reader"
+path = "src/main.rs"
+doc = false
+
+[dependencies]
+env_logger = "*"
+habitat_butterfly = { path = "../butterfly", default-features = false }
+log = "*"
+
+[dependencies.clap]
+version = "*"
+features = ["suggestions", "color", "unstable"]

--- a/components/rst-reader/README.md
+++ b/components/rst-reader/README.md
@@ -1,0 +1,39 @@
+## RST Reader
+
+This is a tool for reading the binary RST file that Habitat supervisors write
+to disk periodically.
+
+### Motivation
+When in the course of human events it becomes necessary for one or more persons
+to debug the internal workings of a supervisor participating in a butterfly
+network, having a way to view the contents of an RST file is very helpful. The
+RST file is a serialized representation of butterfly's internal state. It
+contains all of the rumors that butterfly is currently storing.
+
+### Usage
+`rst-reader` takes a path to an RST file as a required argument, e.g.
+
+```
+rst-reader /hab/sup/default/data/fe15223b3f014ce19cc9710ad3d6929a.rst
+```
+
+If you're not interested in doing a directory listing and copy/pasting a file
+name every time you run this, you can use a trick like this:
+
+```
+rst-reader $(find /hab/sup/default/data -iname "*.rst")
+```
+
+It can sometimes be helpful to pass this invocation to `watch`, so that you can
+notice changes to the file over time:
+
+```
+watch -n 1 'rst-reader $(find /hab/sup/default/data -iname "*.rst")'
+```
+
+If you are only interested in rumor counts and not their contents, you can pass
+`-s` for a summary.
+
+```
+rst-reader -s $(find /hab/sup/default/data -iname "*.rst")
+```

--- a/components/rst-reader/src/error.rs
+++ b/components/rst-reader/src/error.rs
@@ -1,0 +1,31 @@
+use std::{error,
+          fmt,
+          result};
+
+#[derive(Debug)]
+pub enum Error {
+    Butterfly(habitat_butterfly::error::Error),
+}
+
+pub type Result<T> = result::Result<T, Error>;
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg = match *self {
+            Error::Butterfly(ref e) => format!("{}", e),
+        };
+        write!(f, "{}", msg)
+    }
+}
+
+impl error::Error for Error {
+    fn description(&self) -> &str {
+        match *self {
+            Error::Butterfly(_) => "Error reading RST file",
+        }
+    }
+}
+
+impl From<habitat_butterfly::error::Error> for Error {
+    fn from(err: habitat_butterfly::error::Error) -> Error { Error::Butterfly(err) }
+}

--- a/components/rst-reader/src/main.rs
+++ b/components/rst-reader/src/main.rs
@@ -1,0 +1,182 @@
+#[macro_use]
+extern crate log;
+
+use crate::error::Result;
+use clap::{App,
+           Arg};
+use env_logger;
+use habitat_butterfly::{member::Membership,
+                        protocol::Message,
+                        rumor::{dat_file,
+                                Departure,
+                                Election,
+                                ElectionUpdate,
+                                Service,
+                                ServiceConfig,
+                                ServiceFile}};
+use log::error;
+use std::{path::Path,
+          process};
+
+pub mod error;
+
+fn main() {
+    env_logger::init();
+    let matches =
+        App::new("Habitat RST Reader").about("Introspection for the butterfly RST file")
+                                      .arg(Arg::with_name("FILE").required(true)
+                                                                 .index(1)
+                                                                 .help("Path to the RST file"))
+                                      .arg(Arg::with_name("STATS").short("s")
+                                                                  .long("stats")
+                                                                  .conflicts_with("FOLLOW")
+                                                                  .help("Display statistics \
+                                                                         about the contents of \
+                                                                         the file"))
+                                      .get_matches();
+
+    let file = matches.value_of("FILE").unwrap();
+    let stats = matches.is_present("STATS");
+
+    let path = Path::new(file);
+    let dat_file = dat_file::DatFile::new(path.to_path_buf());
+
+    let result = if stats {
+        output_stats(dat_file)
+    } else {
+        output_rumors(dat_file)
+    };
+
+    if result.is_err() {
+        error!("Error processing dat file: {:?}", result);
+        process::exit(1);
+    }
+}
+
+fn output_rumors(mut dat_file: dat_file::DatFile) -> Result<()> {
+    let mut version = [0; 1];
+    let mut reader = dat_file.reader_for_file()?;
+
+    dat_file.read_header(&mut version, &mut reader)?;
+    dat_file.read_members(&mut reader, |r| {
+                match Membership::from_bytes(&r) {
+                    Ok(m) => println!("{}", m),
+                    Err(err) => warn!("Error reading membership rumor from dat file, {}", err),
+                }
+
+                Ok(())
+            })?;
+
+    dat_file.read_services(&mut reader, |r| {
+                let rumor = Service::from_bytes(&r)?;
+                println!("{}", rumor);
+                Ok(())
+            })?;
+
+    dat_file.read_service_configs(&mut reader, |r| {
+                let rumor = ServiceConfig::from_bytes(&r)?;
+                println!("{}", rumor);
+                Ok(())
+            })?;
+
+    dat_file.read_service_files(&mut reader, |r| {
+                let rumor = ServiceFile::from_bytes(&r)?;
+                println!("{}", rumor);
+                Ok(())
+            })?;
+
+    dat_file.read_elections(&mut reader, |r| {
+                let rumor = Election::from_bytes(&r)?;
+                println!("{}", rumor);
+                Ok(())
+            })?;
+
+    dat_file.read_update_elections(&mut reader, |r| {
+                let rumor = ElectionUpdate::from_bytes(&r)?;
+                println!("{}", rumor);
+                Ok(())
+            })?;
+
+    if version[0] >= 2 {
+        dat_file.read_departures(&mut reader, |r| {
+                    let rumor = Departure::from_bytes(&r)?;
+                    println!("{}", rumor);
+                    Ok(())
+                })?;
+    }
+
+    Ok(())
+}
+
+fn output_stats(mut dat_file: dat_file::DatFile) -> Result<()> {
+    let mut membership = 0;
+    let mut services = 0;
+    let mut service_configs = 0;
+    let mut service_files = 0;
+    let mut elections = 0;
+    let mut update_elections = 0;
+    let mut departures = 0;
+
+    let mut version = [0; 1];
+    let mut reader = dat_file.reader_for_file()?;
+
+    dat_file.read_header(&mut version, &mut reader)?;
+    dat_file.read_members(&mut reader, |r| {
+                match Membership::from_bytes(&r) {
+                    Ok(_) => membership += 1,
+                    Err(err) => warn!("Error reading membership rumor from dat file, {}", err),
+                }
+
+                Ok(())
+            })?;
+
+    dat_file.read_services(&mut reader, |r| {
+                let _ = Service::from_bytes(&r)?;
+                services += 1;
+                Ok(())
+            })?;
+
+    dat_file.read_service_configs(&mut reader, |r| {
+                let _ = ServiceConfig::from_bytes(&r)?;
+                service_configs += 1;
+                Ok(())
+            })?;
+
+    dat_file.read_service_files(&mut reader, |r| {
+                let _ = ServiceFile::from_bytes(&r)?;
+                service_files += 1;
+                Ok(())
+            })?;
+
+    dat_file.read_elections(&mut reader, |r| {
+                let _ = Election::from_bytes(&r)?;
+                elections += 1;
+                Ok(())
+            })?;
+
+    dat_file.read_update_elections(&mut reader, |r| {
+                let _ = ElectionUpdate::from_bytes(&r)?;
+                update_elections += 1;
+                Ok(())
+            })?;
+
+    if version[0] >= 2 {
+        dat_file.read_departures(&mut reader, |r| {
+                    let _ = Departure::from_bytes(&r)?;
+                    departures += 1;
+                    Ok(())
+                })?;
+    }
+
+    println!("Summary:");
+    println!("");
+    println!("Membership: {}", membership);
+    println!("Services: {}", services);
+    println!("Service Configs: {}", service_configs);
+    println!("Service Files: {}", service_files);
+    println!("Elections: {}", elections);
+    println!("Update Elections: {}", update_elections);
+    println!("Departures: {}", departures);
+
+    Ok(())
+}

--- a/components/rst-reader/src/main.rs
+++ b/components/rst-reader/src/main.rs
@@ -126,7 +126,7 @@ fn output_stats(mut dat_file: dat_file::DatFile) -> Result<()> {
     }
 
     println!("Summary:");
-    println!("");
+    println!();
     println!("Membership: {}", membership);
     println!("Services: {}", services);
     println!("Service Configs: {}", service_configs);


### PR DESCRIPTION
This is a tool for reading the binary RST file that supervisor's periodically write to disk. The README.md contains motivation and usage instructions. This was written as part of my rumor garbage collection work, but I'm in the middle of restructuring that branch, and felt this was useful enough to PR separately.

There's 3 main things happening in this PR:
1. I implemented `Display` for all the rumors, so there would be something meaningful to write out. Note that the representation I chose was intentionally terse. I tried hard to get everything to fit onto one line and display the maximum amount of useful information with the least number of characters. End users should never be using this tool, so this felt like a reasonable tradeoff.
1. I refactored the inner workings of `dat_file.rs` to remove a lot of duplication, as well as make it possible to use some of those functions in a setting other than the butterfly server.
1. `rst-reader` itself is added, which is a very thin shim around the newly refactored functions in `dat_file.rs` - just enough to grab the information and output it.

![](https://media.giphy.com/media/wJ9WoVan2Z3ri/giphy.gif)

Closes https://github.com/habitat-sh/habitat/issues/3169
Signed-off-by: Josh Black <raskchanky@gmail.com>