### PR TITLE
Downgrade clippy::cyclomatic_complexity from error to warning

### DIFF
--- a/components/butterfly/src/server/push.rs
+++ b/components/butterfly/src/server/push.rs
@@ -146,7 +146,6 @@ impl PushWorker {
     // simplify the redundant aspects and remove this allow(clippy::cyclomatic_complexity),
     // but changing it in the absence of other necessity seems like too much risk for the
     // expected reward.
-    #[allow(clippy::cyclomatic_complexity)]
     fn send_rumors(&self, member: &Member, rumors: &[RumorKey]) {
         let socket = (**ZMQ_CONTEXT).as_mut()
                                     .socket(zmq::PUSH)

--- a/components/butterfly/tests/rumor/election.rs
+++ b/components/butterfly/tests/rumor/election.rs
@@ -86,7 +86,6 @@ fn five_members_elect_a_new_leader_when_the_old_one_dies() {
 }
 
 #[test]
-#[allow(clippy::cyclomatic_complexity)]
 fn five_members_elect_a_new_leader_when_they_are_quorum_partitioned() {
     let mut net = btest::SwimNet::new_with_suitability(vec![1, 0, 0, 0, 0]);
     net[0].member

--- a/components/core/src/fs.rs
+++ b/components/core/src/fs.rs
@@ -517,6 +517,8 @@ pub fn find_command_in_pkg<T, U>(command: T,
     where T: AsRef<Path>,
           U: AsRef<Path>
 {
+    // Remove this once https://github.com/rust-lang/rust-clippy/issues/4133 is resolved
+    #[allow(clippy::identity_conversion)]
     for path in pkg_install.paths()? {
         let stripped =
             path.strip_prefix("/")

--- a/components/core/src/package/install.rs
+++ b/components/core/src/package/install.rs
@@ -501,6 +501,8 @@ impl PackageInstall {
         let mut paths = Vec::new();
         let mut seen = HashSet::new();
 
+        // Remove this once https://github.com/rust-lang/rust-clippy/issues/4133 is resolved
+        #[allow(clippy::identity_conversion)]
         for p in self.paths()? {
             if seen.contains(&p) {
                 continue;
@@ -513,6 +515,8 @@ impl PackageInstall {
                                .into_iter()
                                .chain(self.load_tdeps()?.into_iter());
         for pkg in ordered_pkgs {
+            // Remove this once https://github.com/rust-lang/rust-clippy/issues/4133 is resolved
+            #[allow(clippy::identity_conversion)]
             for p in pkg.paths()? {
                 if seen.contains(&p) {
                     continue;

--- a/components/hab/src/scaffolding.rs
+++ b/components/hab/src/scaffolding.rs
@@ -131,6 +131,8 @@ fn is_project_ruby<T>(path: T) -> bool
 
 fn project_uses_gb(dir: &Path) -> io::Result<bool> {
     if dir.is_dir() {
+        // Remove this once https://github.com/rust-lang/rust-clippy/issues/4133 is resolved
+        #[allow(clippy::identity_conversion)]
         for entry in fs::read_dir(dir)? {
             let entry = entry?;
             let path = entry.path();

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -674,7 +674,6 @@ impl Manager {
     // simplify the redundant aspects and remove this allow(clippy::cyclomatic_complexity),
     // but changing it in the absence of other necessity seems like too much risk for the
     // expected reward.
-    #[allow(clippy::cyclomatic_complexity)]
     pub fn run(mut self, svc: Option<habitat_sup_protocol::ctl::SvcLoad>) -> Result<()> {
         let main_hist = RUN_LOOP_DURATION.with_label_values(&["sup"]);
         let service_hist = RUN_LOOP_DURATION.with_label_values(&["service"]);

--- a/components/sup/src/manager/service_updater.rs
+++ b/components/sup/src/manager/service_updater.rs
@@ -154,7 +154,6 @@ impl ServiceUpdater {
     // simplify the redundant aspects and remove this allow(clippy::cyclomatic_complexity),
     // but changing it in the absence of other necessity seems like too much risk for the
     // expected reward.
-    #[allow(clippy::cyclomatic_complexity)]
     pub fn check_for_updated_package(&mut self,
                                      service: &Service,
                                      // TODO (CM): Strictly speaking, we don't need to pass

--- a/test/denied_lints.txt
+++ b/test/denied_lints.txt
@@ -8,7 +8,6 @@ clippy::cmp_owned
 clippy::collapsible_if
 clippy::const_static_lifetime
 clippy::correctness
-clippy::cyclomatic_complexity
 clippy::deref_addrof
 clippy::expect_fun_call
 clippy::for_kv_map

--- a/test/lints_to_fix.txt
+++ b/test/lints_to_fix.txt
@@ -1,0 +1,1 @@
+clippy::cyclomatic_complexity


### PR DESCRIPTION
`cyclomatic_complexity` was renamed to `cognitive_complexity` in rust 1.35,
but because our CI defaults to `stable`, this resulted in a situation
where linux and windows run CI against different versions, leading to a
mutually incompatible situation for this lint. This is a temporary fix
until we can fully address the toolchain versioning issue in CI.

See https://github.com/habitat-sh/habitat/pull/6593 for more.