### PR TITLE
Use previous release to build Release Candidate

### DIFF
--- a/.buildkite/launcher_build_steps.yaml
+++ b/.buildkite/launcher_build_steps.yaml
@@ -31,6 +31,7 @@ steps:
             - HAB_BLDR_CHANNEL
             - HAB_AUTH_TOKEN
             - HAB_CRYPTO_KEY
+            - HAB_LICENSE
             - BUILDKITE_JOB_ID
             - BUILDKITE_AGENT_ACCESS_TOKEN
 
@@ -48,5 +49,6 @@ steps:
           environment:
             - HAB_BLDR_CHANNEL
             - HAB_AUTH_TOKEN
+            - HAB_LICENSE
             - BUILDKITE_JOB_ID
             - BUILDKITE_AGENT_ACCESS_TOKEN

--- a/.buildkite/release_pipeline.yaml
+++ b/.buildkite/release_pipeline.yaml
@@ -85,6 +85,7 @@ steps:
             - HAB_BLDR_CHANNEL
             - HAB_AUTH_TOKEN
             - HAB_CRYPTO_KEY
+            - HAB_LICENSE
             - BUILDKITE_JOB_ID
             - BUILDKITE_AGENT_ACCESS_TOKEN
 
@@ -134,6 +135,7 @@ steps:
           environment:
             - HAB_BLDR_CHANNEL
             - HAB_AUTH_TOKEN
+            - HAB_LICENSE
             - BUILDKITE_JOB_ID
             - BUILDKITE_AGENT_ACCESS_TOKEN
 
@@ -199,6 +201,7 @@ steps:
           environment:
             - HAB_BLDR_CHANNEL
             - HAB_AUTH_TOKEN
+            - HAB_LICENSE
             - BUILDKITE_JOB_ID
             - BUILDKITE_AGENT_ACCESS_TOKEN
 
@@ -231,6 +234,7 @@ steps:
           environment:
             - HAB_BLDR_CHANNEL
             - HAB_AUTH_TOKEN
+            - HAB_LICENSE
             - BUILDKITE_JOB_ID
             - BUILDKITE_AGENT_ACCESS_TOKEN
 
@@ -266,6 +270,7 @@ steps:
           environment:
             - HAB_BLDR_CHANNEL
             - HAB_AUTH_TOKEN
+            - HAB_LICENSE
             - BUILDKITE_JOB_ID
             - BUILDKITE_AGENT_ACCESS_TOKEN
 
@@ -312,6 +317,7 @@ steps:
           environment:
             - HAB_BLDR_CHANNEL
             - HAB_AUTH_TOKEN
+            - HAB_LICENSE
             - BUILDKITE_JOB_ID
             - BUILDKITE_AGENT_ACCESS_TOKEN
 

--- a/.buildkite/scripts/bintray_upload_macos.sh
+++ b/.buildkite/scripts/bintray_upload_macos.sh
@@ -19,7 +19,8 @@ channel=$(get_release_channel)
 # use it here
 
 echo "--- :habicat: Installing core/hab-bintray-publish from '${channel}' channel"
-sudo hab pkg install \
+sudo HAB_LICENSE="${HAB_LICENSE}" \
+     hab pkg install \
      --channel="${channel}" \
      core/hab-bintray-publish
 
@@ -39,6 +40,7 @@ sudo HAB_BLDR_CHANNEL="${channel}" \
      BINTRAY_USER="${BINTRAY_USER}" \
      BINTRAY_KEY="${BINTRAY_KEY}" \
      BINTRAY_PASSPHRASE="${BINTRAY_PASSPHRASE}" \
+     HAB_LICENSE="${HAB_LICENSE}"
      hab pkg exec core/hab-bintray-publish \
          publish-hab \
          -s \

--- a/.buildkite/scripts/bintray_upload_macos.sh
+++ b/.buildkite/scripts/bintray_upload_macos.sh
@@ -40,7 +40,7 @@ sudo HAB_BLDR_CHANNEL="${channel}" \
      BINTRAY_USER="${BINTRAY_USER}" \
      BINTRAY_KEY="${BINTRAY_KEY}" \
      BINTRAY_PASSPHRASE="${BINTRAY_PASSPHRASE}" \
-     HAB_LICENSE="${HAB_LICENSE}"
+     HAB_LICENSE="${HAB_LICENSE}" \
      hab pkg exec core/hab-bintray-publish \
          publish-hab \
          -s \

--- a/.buildkite/scripts/build_component.ps1
+++ b/.buildkite/scripts/build_component.ps1
@@ -38,7 +38,7 @@ Push-Location "C:\build"
     $ReleaseChannel = & buildkite-agent meta-data get release-channel
     Write-Host "--- Setting HAB_BLDR_CHANNEL channel to $ReleaseChannel"
     $Env:HAB_BLDR_CHANNEL="$ReleaseChannel"
-
+    Write-Host "--- HAB_LICENSE is $Env:HAB_LICENSE"
     Write-Host "--- Running hab pkg build for $Component"
     Invoke-Expression "$baseHabExe pkg build components\$Component --keys core"
     . "results\last_build.ps1"

--- a/.buildkite/scripts/build_component.ps1
+++ b/.buildkite/scripts/build_component.ps1
@@ -45,9 +45,6 @@ Push-Location "C:\build"
     Write-Host "Running hab pkg upload for $Component to channel $ReleaseChannel"
     Invoke-Expression "$baseHabExe pkg upload results\$pkg_artifact --channel=$ReleaseChannel"
 
-    # Temporary workaround until 0.79.0 goes out
-    Invoke-Expression "buildkite-agent meta-data set ${pkg_ident}-x86_64-windows true"
-
     If ($Component -eq 'hab') {
         Write-Host "--- :buildkite: Recording metadata $pkg_ident"
         Invoke-Expression "buildkite-agent meta-data set 'hab-version-x86_64-windows' '$pkg_ident'"

--- a/.buildkite/scripts/build_component.ps1
+++ b/.buildkite/scripts/build_component.ps1
@@ -38,7 +38,6 @@ Push-Location "C:\build"
     $ReleaseChannel = & buildkite-agent meta-data get release-channel
     Write-Host "--- Setting HAB_BLDR_CHANNEL channel to $ReleaseChannel"
     $Env:HAB_BLDR_CHANNEL="$ReleaseChannel"
-    Write-Host "--- HAB_LICENSE is $Env:HAB_LICENSE"
     Write-Host "--- Running hab pkg build for $Component"
     Invoke-Expression "$baseHabExe pkg build components\$Component --keys core"
     . "results\last_build.ps1"

--- a/.buildkite/scripts/build_component.sh
+++ b/.buildkite/scripts/build_component.sh
@@ -41,14 +41,6 @@ else
 fi
 source results/last_build.env
 
-# TODO (SM): The 0.59.0 hab cli that we rely on for x86_64-linux builds 
-# doesn't emit pkg_target. Until we've sufficiently bootstrapped ourselves
-# we need to set it. This can be removed when studio-ci-common pulls 0.63.0 
-# or newer. This is safe to do because the x86_64-linux-kernel2 builds will
-# already have this value set.
-: "${pkg_target:=x86_64-linux}"
-
-
 echo "--- :habicat: Uploading ${pkg_ident} to Builder in the '${channel}' channel"
 ${hab_binary} pkg upload \
     --channel="${channel}" \

--- a/.buildkite/scripts/build_component.sh
+++ b/.buildkite/scripts/build_component.sh
@@ -51,8 +51,6 @@ ${hab_binary} pkg promote \
     --auth="${HAB_AUTH_TOKEN}" \
     "${pkg_ident}" "${channel}" "${pkg_target}"
 
-set_target_metadata "${pkg_ident}" "${pkg_target}"
-
 echo "--- :writing_hand: Recording Build Metadata"
 case "${component}" in
     "hab")

--- a/.buildkite/scripts/build_component.sh
+++ b/.buildkite/scripts/build_component.sh
@@ -49,28 +49,16 @@ source results/last_build.env
 : "${pkg_target:=x86_64-linux}"
 
 
-# TODO: after 0.79.0 we can reenable this. We are explicitly using curl to upload
-# due to this bug: https://github.com/habitat-sh/builder/issues/940
-# echo "--- :habicat: Uploading ${pkg_ident} to Builder in the '${channel}' channel"
-# ${hab_binary} pkg upload \
-#     --channel="${channel}" \
-#     --auth="${HAB_AUTH_TOKEN}" \
-#     "results/${pkg_artifact}"
-#
-# ${hab_binary} pkg promote \
-#     --auth="${HAB_AUTH_TOKEN}" \
-#     "${pkg_ident}" "${channel}" "${pkg_target}"
+echo "--- :habicat: Uploading ${pkg_ident} to Builder in the '${channel}' channel"
+${hab_binary} pkg upload \
+    --channel="${channel}" \
+    --auth="${HAB_AUTH_TOKEN}" \
+    "results/${pkg_artifact}"
 
-echo "--- :partyparrot: Manually uploading '${pkg_ident:?}' (${pkg_target}) to Builder"
-curl --request POST \
-     --header "Content-Type: application/octet-stream" \
-     --header "Authorization: Bearer $HAB_AUTH_TOKEN" \
-     --data-binary "@results/${pkg_artifact:?}" \
-     --fail \
-     --verbose \
-    "https://bldr.habitat.sh/v1/depot/pkgs/${pkg_ident}?checksum=${pkg_blake2bsum:?}&target=${pkg_target}"
+${hab_binary} pkg promote \
+    --auth="${HAB_AUTH_TOKEN}" \
+    "${pkg_ident}" "${channel}" "${pkg_target}"
 
-promote "${pkg_ident}" "${pkg_target}" "${channel}"
 set_target_metadata "${pkg_ident}" "${pkg_target}"
 
 echo "--- :writing_hand: Recording Build Metadata"

--- a/.buildkite/scripts/dockerhub_upload.sh
+++ b/.buildkite/scripts/dockerhub_upload.sh
@@ -26,7 +26,14 @@ trap 'rm -f $HOME/.docker/config.json' INT TERM EXIT
 
 pushd ./components/rootless_studio >/dev/null
 docker build --build-arg PACKAGE_TARGET="${target}" -t "habitat-${target}:hab-base" .
-docker build --build-arg BLDR_CHANNEL="${channel}" --build-arg PACKAGE_TARGET="${target}" --no-cache --tag "${image_name_with_tag}" ./default
+docker build \
+  --build-arg HAB_LICENSE="${HAB_LICENSE}" \
+  --build-arg BLDR_CHANNEL="${channel}" \
+  --build-arg PACKAGE_TARGET="${target}" \
+  --no-cache \
+  --tag "${image_name_with_tag}" \
+  ./default
+
 docker push "${image_name_with_tag}"
 popd >/dev/null
 

--- a/.buildkite/scripts/promote_release_channel.sh
+++ b/.buildkite/scripts/promote_release_channel.sh
@@ -94,29 +94,13 @@ targets=("x86_64-linux"
 
 for pkg in "${non_supervisor_packages[@]}"; do
     echo "--- :habicat: Promoting '$pkg' to '$to_channel'"
-    # hab pkg promote --auth="${HAB_AUTH_TOKEN}" "${pkg}" "${to_channel}"
-    for target in "${targets[@]}"; do
-        if ident_has_target "${pkg}" "${target}"; then
-            echo "--- :star: Found a match: ${pkg} is for ${target}"
-            promote "${pkg}" "${target}" "${to_channel}"
-        else
-            echo "--- :thumbsdown: not a match"
-        fi
-    done
+    hab pkg promote --auth="${HAB_AUTH_TOKEN}" "${pkg}" "${to_channel}" "${pkg_target}"
 done
 
 echo "--- :warning: PROMOTING SUPERVISORS TO '$to_channel' :warning:"
 for pkg in "${supervisor_packages[@]}"; do
     echo "--- :habicat: Promoting $pkg to $to_channel"
-    # hab pkg promote --auth="${HAB_AUTH_TOKEN}" "${pkg}" "${to_channel}"
-    for target in "${targets[@]}"; do
-        if ident_has_target "${pkg}" "${target}"; then
-            echo "--- :star: Found a match: ${pkg} is for ${target}"
-            promote "${pkg}" "${target}" "${to_channel}"
-        else
-            echo "--- :thumbsdown: not a match"
-        fi
-    done
+    hab pkg promote --auth="${HAB_AUTH_TOKEN}" "${pkg}" "${to_channel}" "${pkg_target}"
 done
 
 buildkite-agent annotate --style="success" --context="release-manifest"

--- a/.buildkite/scripts/resolve_launcher_actions.sh
+++ b/.buildkite/scripts/resolve_launcher_actions.sh
@@ -18,7 +18,7 @@ promote_from_one_channel_to_another() {
 
     artifact="$(latest_from_builder "${target}" "${from_channel}" "${package_name}")"
     echo "--- Promoting ${artifact} (${target}) to ${to_channel}"
-    hab pkg promote --auth="${HAB_AUTH_TOKEN}" "${artifact}" "${to_channel}" "${pkg_target}"
+    hab pkg promote --auth="${HAB_AUTH_TOKEN}" "${artifact}" "${to_channel}" "${target}"
 }
 
 launcher_action=$(buildkite-agent meta-data get "launcher-action");

--- a/.buildkite/scripts/resolve_launcher_actions.sh
+++ b/.buildkite/scripts/resolve_launcher_actions.sh
@@ -18,11 +18,7 @@ promote_from_one_channel_to_another() {
 
     artifact="$(latest_from_builder "${target}" "${from_channel}" "${package_name}")"
     echo "--- Promoting ${artifact} (${target}) to ${to_channel}"
-    # TODO: after 0.79.0 we can reenable this. We are explicitly using curl to upload
-    # due to this bug: https://github.com/habitat-sh/builder/issues/940
-    # hab pkg promote --auth="${HAB_AUTH_TOKEN}" "${artifact}" "${to_channel}"
-    promote "${artifact}" "${target}" "${to_channel}"
-    set_target_metadata "${artifact}" "${target}"
+    hab pkg promote --auth="${HAB_AUTH_TOKEN}" "${artifact}" "${to_channel}" "${pkg_target}"
 }
 
 launcher_action=$(buildkite-agent meta-data get "launcher-action");

--- a/.buildkite/scripts/shared.sh
+++ b/.buildkite/scripts/shared.sh
@@ -237,34 +237,6 @@ set_version() {
     buildkite-agent meta-data set "version" "${version}"
 }
 
-# curl-based promotion function to work around https://github.com/habitat-sh/builder/issues/940
-# Remove after 0.79.0
-promote() {
-    package_ident="${1}"
-    target="${2}"
-    to_channel="${3}"
-
-    # Extract the individual bits of the fully-qualified identifier
-    IFS="/" read -r origin package version release <<< "${package_ident}"
-
-    # Create the channel, if necessary.
-    #
-    # Don't use --fail here, because trying to create a channel that
-    # already exists returns a 409, and we don't want to fail in that case.
-    echo "--- :partyparrot: Manually creating '${to_channel}' channel (if it doesn't exist already)"
-    curl --request POST \
-         --header "Authorization: Bearer $HAB_AUTH_TOKEN" \
-         --verbose \
-         "https://bldr.habitat.sh/v1/depot/channels/${origin}/${to_channel}"
-
-    echo "--- :partyparrot: Manually promoting '${package_ident}' (${target}) to the '${to_channel}' channel"
-    curl --request PUT \
-         --header "Authorization: Bearer $HAB_AUTH_TOKEN" \
-         --fail \
-         --verbose \
-         "https://bldr.habitat.sh/v1/depot/channels/${origin}/${to_channel}/pkgs/${package}/${version}/${release}/promote?&target=${target}"
-}
-
 # Until we can reliably deal with packages that have the same
 # identifier, but different target, we'll track the information in
 # Buildkite metadata.

--- a/.buildkite/scripts/shared.sh
+++ b/.buildkite/scripts/shared.sh
@@ -116,8 +116,8 @@ set_hab_binary() {
         # Note that we are explicitly not binlinking here; this is to
         # prevent accidentally polluting the builder for any future
         # runs that may take place on it.
-        sudo "${hab_binary:?}" pkg install "${hab_ident}"
-        sudo "${hab_binary:?}" pkg install "$(get_studio_ident $pkg_target)"
+        sudo env HAB_LICENSE="${HAB_LICENSE}" "${hab_binary:?}" pkg install "${hab_ident}"
+        sudo env HAB_LICENSE="${HAB_LICENSE}" "${hab_binary:?}" pkg install "$(get_studio_ident $pkg_target)"
         hab_binary="/hab/pkgs/${hab_ident}/bin/hab"
         declare -g new_studio=1
     else
@@ -127,6 +127,7 @@ set_hab_binary() {
     echo "--- :habicat: Using $(${hab_binary} --version)"
 }
 
+
 # Use the install.sh script which lives in this repository to download the latest version of Habitat
 install_hab_binary() {
     local target install_path
@@ -134,9 +135,8 @@ install_hab_binary() {
     target="$1"
     install_path="$2"
 
-    #sudo env HAB_BINLINK_DIR="$install_path" ./components/hab/install.sh -t "$target"
-    sudo ./components/hab/install.sh -t "$target"
-    sudo /bin/hab pkg binlink core/hab hab -d $install_path 
+    sudo env HAB_LICENSE="${HAB_LICENSE}" ./components/hab/install.sh -t "$target"
+    sudo env HAB_LICENSE="${HAB_LICENSE}" /bin/hab pkg binlink core/hab hab -d $install_path 
 }
 
 # The following get/set functions abstract the meta-data key

--- a/.buildkite/scripts/shared.sh
+++ b/.buildkite/scripts/shared.sh
@@ -236,29 +236,3 @@ set_version() {
     local version=$1
     buildkite-agent meta-data set "version" "${version}"
 }
-
-# Until we can reliably deal with packages that have the same
-# identifier, but different target, we'll track the information in
-# Buildkite metadata.
-#
-# Each time we put a package into our release channel, we'll record
-# what target it was built for.
-set_target_metadata() {
-    package_ident="${1}"
-    target="${2}"
-
-    echo "--- :partyparrot: Setting target metadata for '${package_ident}' (${target})"
-    buildkite-agent meta-data set "${package_ident}-${target}" "true"
-}
-
-# When we do the final promotions, we need to know the target of each
-# package in order to properly get the promotion done. If Buildkite metadata for
-# an ident/target pair exists, then that means that's a valid
-# combination, and we can use the target in the promotion call.
-ident_has_target() {
-    package_ident="${1}"
-    target="${2}"
-
-    echo "--- :partyparrot: Checking target metadata for '${package_ident}' (${target})"
-    buildkite-agent meta-data exists "${package_ident}-${target}"
-}

--- a/components/rootless_studio/default/Dockerfile
+++ b/components/rootless_studio/default/Dockerfile
@@ -2,6 +2,7 @@ ARG PACKAGE_TARGET
 FROM habitat-${PACKAGE_TARGET}:hab-base as hab
 ENV PATH=${PATH}:/hab/bin
 ARG BLDR_CHANNEL=stable
+ARG HAB_LICENSE=no-accept
 RUN hab pkg install -c ${BLDR_CHANNEL} core/hab-backline \
   && hab pkg binlink core/bash -d /hab/bin \
   && hab pkg binlink core/hab -d /hab/bin


### PR DESCRIPTION
In the current release process, we use the Habitat version available on the build infrastructure in order to build the initial set of RC packages (launcher, hab, backline, plan-build, studio) on Linux and the previous release on Windows

This change updates Linux build process to always install the previous release of Habitat until we have sufficiently build the RC packages, giving us parity with the Windows build process. 

As part of this change, it was discovered that we had missed a handful of locations where `HAB_LICENSE` isn't plumbed through, such as in Windows containers and use of `sudo`. 

I've also incorporated the work from #6493. There is work in that PR that is needed for this to pass a "fake release" and this work is required for #6593 to pass a "fake release"

![tenor-70829672](https://user-images.githubusercontent.com/36851/58648625-f8bc5500-82be-11e9-9b84-c799152a605c.gif)


