### PR TITLE
Replace `busybox mount` with direct read of /proc/mounts

### DIFF
--- a/components/studio/bin/hab-studio.sh
+++ b/components/studio/bin/hab-studio.sh
@@ -1015,7 +1015,7 @@ is_fs_mounted() {
   # scenario.  
 
   # NOTE(SM): This makes this studio implementation Linux specific. 
-  $bb cut -d' ' -f2 /proc/mounts | $bb grep -q "$_mount_point" 
+  $bb cut -d' ' -f2 /proc/mounts | $bb grep -q -x "$_mount_point" 
 }
 
 # **Internal** Unmounts file system mounts if mounted. The order of file system

--- a/components/studio/bin/hab-studio.sh
+++ b/components/studio/bin/hab-studio.sh
@@ -1004,8 +1004,18 @@ persisted. Check that the filesystem is no longer in the mounted using \
 # if true and non-zero otherwise.
 is_fs_mounted() {
   _mount_point="${1:?}"
+  
+  # Work around bug in musl's implementation of getmntent_r. 
+  # https://github.com/habitat-sh/habitat/issues/6591#issuecomment-498292168 
+  #$bb mount | $bb grep -q "on $_mount_point type"
 
-  $bb mount | $bb grep -q "on $_mount_point type"
+  # NOTE(SM): There is still a chance for failure here. Mount points with a 
+  # space in their name will not be detected. However, given that we control
+  # the name of all mount points, it is unlikely that we will encounter this 
+  # scenario.  
+
+  # NOTE(SM): This makes this studio implementation Linux specific. 
+  $bb cut -d' ' -f2 /proc/mounts | $bb grep -q "$_mount_point" 
 }
 
 # **Internal** Unmounts file system mounts if mounted. The order of file system

--- a/components/studio/test/shared/studio-enter.exp
+++ b/components/studio/test/shared/studio-enter.exp
@@ -1,8 +1,8 @@
 #!/usr/bin/env expect
 
 set env(HAB_NOCOLORING) true
-set studio_command $::env(STUDIO_COMMAND)
-set studio_test [lindex $argv 0]
+set studio_command [lindex $argv 0]
+set studio_test [lindex $argv 1]
 # Print out some helpful tracing messages in the test output.
 
 proc log {message} {

--- a/components/studio/test/shared/studio-enter.exp
+++ b/components/studio/test/shared/studio-enter.exp
@@ -1,7 +1,7 @@
 #!/usr/bin/env expect
 
 set env(HAB_NOCOLORING) true
-set studio_enter_command $::env(STUDIO_ENTER_COMMAND)
+set studio_command $::env(STUDIO_COMMAND)
 set studio_test [lindex $argv 0]
 # Print out some helpful tracing messages in the test output.
 
@@ -11,7 +11,7 @@ proc log {message} {
 
 # Cleanup after the test
 exit -onexit {
-    exec hab studio rm
+    exec $studio_command rm
 }
 
 # Installing packages can take time
@@ -19,7 +19,7 @@ set timeout 30
 
 # {*} Syntax explanation:
 # https://www.tcl.tk/man/tcl/TclCmd/Tcl.htm [5] Argument Expansion
-spawn {*}$studio_enter_command
+spawn {*}$studio_command enter
 expect {
   {\[default:/src:0]#} { 
     log "Studio entered successfully"

--- a/components/studio/test/shared/studio-exit/test-studio-umount-long-fs.sh
+++ b/components/studio/test/shared/studio-exit/test-studio-umount-long-fs.sh
@@ -1,0 +1,39 @@
+#!/bin/bash 
+
+set -euo pipefail 
+
+sudo hab pkg install core/e2fsprogs
+
+# Maximum directory name length is 255 characters so we need to create
+# a nested set of directories to have a mount point with > 1024 characters. 
+tmpdir=$(mktemp -d -p /tmp hab-studio-XXXXXXX)
+directory="$(printf "a%.0s" {1..100})"
+mnt_path="/mnt/$(printf "$directory/%.0s" {1..10})"
+
+cleanup() { 
+  sudo umount "$mnt_path" || true
+  sudo rm -rf "$mnt_path"
+  ( cd "$tmpdir"/studio && $STUDIO_COMMAND rm )
+  rm -rf "$tmpdir" 
+}
+
+trap cleanup EXIT
+
+(
+  cd "$tmpdir"
+
+  # Create a tiny filesystem and mount it as a loopback device before we 
+  # create our studio. It is important that this happens before we create the 
+  # studio so that it appears first in /proc/mounts. The specific bug this is 
+  # intended to detect (https://github.com/habitat-sh/habitat/issues/6591) 
+  # won't be triggered if the studio mount entries are first. 
+  dd if=/dev/zero of=empty-fs.img bs=10M count=1 
+  hab pkg exec core/e2fsprogs mkfs.ext4 empty-fs.img
+  sudo mkdir -p "$mnt_path"
+  sudo mount -o loop "$tmpdir"/empty-fs.img "$mnt_path"
+
+  mkdir studio 
+  cd studio
+  $STUDIO_COMMAND new 
+  $STUDIO_COMMAND rm 
+)

--- a/components/studio/test/shared/studio-exit/test-studio-umount-long-fs.sh
+++ b/components/studio/test/shared/studio-exit/test-studio-umount-long-fs.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail 
 
+studio_command="${1}"
+
 sudo hab pkg install core/e2fsprogs
 
 # Maximum directory name length is 255 characters so we need to create
@@ -13,7 +15,7 @@ mnt_path="/mnt/$(printf "$directory/%.0s" {1..10})"
 cleanup() { 
   sudo umount "$mnt_path" || true
   sudo rm -rf "$mnt_path"
-  ( cd "$tmpdir"/studio && $STUDIO_COMMAND rm )
+  ( cd "$tmpdir"/studio && $studio_command rm )
   rm -rf "$tmpdir" 
 }
 
@@ -34,6 +36,8 @@ trap cleanup EXIT
 
   mkdir studio 
   cd studio
-  $STUDIO_COMMAND new 
-  $STUDIO_COMMAND rm 
+  $studio_command new 
+  # Print out the mount table using the system tools before removing it
+  mount 
+  $studio_command rm 
 )

--- a/components/studio/test/shared/test-all.sh
+++ b/components/studio/test/shared/test-all.sh
@@ -2,11 +2,13 @@
 
 set -euo pipefail
 
+studio_command="${1}"
+
 for t in test/shared/studio-internals/test-studio-*.sh; do 
   test_case="$(basename "$t")"
   echo "--- Running $test_case"
   hab studio rm 
-  if ! expect test/shared/studio-enter.exp "$t"; then 
+  if ! expect test/shared/studio-enter.exp "${studio_command}" "$t"; then 
     exit 1
   fi
 done
@@ -14,5 +16,5 @@ done
 for t in test/shared/studio-exit/test-studio-*.sh; do
   test_case="$(basename "$t")"
   echo "--- Running $test_case"
-  $t
+  $t "${studio_command}"
 done

--- a/components/studio/test/shared/test-all.sh
+++ b/components/studio/test/shared/test-all.sh
@@ -10,3 +10,9 @@ for t in test/shared/studio-internals/test-studio-*.sh; do
     exit 1
   fi
 done
+
+for t in test/shared/studio-exit/test-studio-*.sh; do
+  test_case="$(basename "$t")"
+  echo "--- Running $test_case"
+  $t
+done

--- a/components/studio/test/studio-from-package/test.sh
+++ b/components/studio/test/studio-from-package/test.sh
@@ -6,7 +6,7 @@ export HAB_LICENSE="accept-no-persist"
 
 hab studio rm
 
-export STUDIO_ENTER_COMMAND="hab studio enter"
+export STUDIO_COMMAND="hab studio"
 
 ./test/shared/test-all.sh
 

--- a/components/studio/test/studio-from-package/test.sh
+++ b/components/studio/test/studio-from-package/test.sh
@@ -6,7 +6,7 @@ export HAB_LICENSE="accept-no-persist"
 
 hab studio rm
 
-export STUDIO_COMMAND="hab studio"
+studio_command="hab studio"
 
-./test/shared/test-all.sh
+./test/shared/test-all.sh "${studio_command}"
 

--- a/components/studio/test/studio-from-source/test.sh
+++ b/components/studio/test/studio-from-source/test.sh
@@ -14,11 +14,11 @@ cp "$(hab pkg path core/busybox-static)"/bin/busybox libexec/busybox
 cp "$(hab pkg path core/hab)"/bin/hab libexec/hab
 
 HAB_STUDIO_BACKLINE_PKG="$(< "$(hab pkg path core/hab-backline)"/IDENT)"
+studio_command="sudo --preserve-env $(realpath bin/hab-studio.sh)"
 
 export HAB_STUDIO_BACKLINE_PKG
-export STUDIO_COMMAND="sudo --preserve-env $(realpath bin/hab-studio.sh)"
 
-./test/shared/test-all.sh
+./test/shared/test-all.sh "${studio_command}"
 
 
 rm libexec/hab

--- a/components/studio/test/studio-from-source/test.sh
+++ b/components/studio/test/studio-from-source/test.sh
@@ -16,9 +16,10 @@ cp "$(hab pkg path core/hab)"/bin/hab libexec/hab
 HAB_STUDIO_BACKLINE_PKG="$(< "$(hab pkg path core/hab-backline)"/IDENT)"
 
 export HAB_STUDIO_BACKLINE_PKG
-export STUDIO_ENTER_COMMAND="sudo --preserve-env bin/hab-studio.sh enter"
+export STUDIO_COMMAND="sudo --preserve-env $(realpath bin/hab-studio.sh)"
 
 ./test/shared/test-all.sh
+
 
 rm libexec/hab
 rm libexec/busybox


### PR DESCRIPTION
Closes #6591 
Closes #6577 

This replaces `$bb mount` with a direct read of /proc/mounts to check if a filesystem is mounted.  See #6591 for details. 
