### PR TITLE
Move deadlock error to trace - stop spam

### DIFF
--- a/components/common/src/lib.rs
+++ b/components/common/src/lib.rs
@@ -199,7 +199,7 @@ pub mod sync {
         let heartbeats = &THREAD_HEARTBEATS.lock()
                                            .expect("THREAD_HEARTBEATS poisoned");
         for (name, last_heartbeat) in threads_missing_heartbeat(heartbeats, threshold) {
-            error!("No heartbeat from {} in {} seconds; deadlock likely",
+            warn!("No heartbeat from {} in {} seconds; deadlock likely",
                    name.unwrap_or_else(|| { "unnamed thread".to_string() }),
                    last_heartbeat.elapsed().as_secs());
         }


### PR DESCRIPTION
This error is continuously spamming Builder and making it very hard to debug anything else.

Signed-off-by: Salim Alam <salam@chef.io>