### PR TITLE
Adds service update started event

### DIFF
--- a/components/sup/Cargo.toml
+++ b/components/sup/Cargo.toml
@@ -51,7 +51,7 @@ prost = "*"
 prost-derive = "*"
 prost-types = "0.5.0" # This is current stable, but for some reason gets pulled in as 0.4.0 if we use "*" (2019-03-28)
 rand = "*"
-ratsio = "*"
+ratsio = "^0.2"
 regex = "*"
 rustls = "*"
 serde = { version = "*", features = ["rc"] }

--- a/components/sup/Cargo.toml
+++ b/components/sup/Cargo.toml
@@ -51,7 +51,7 @@ prost = "*"
 prost-derive = "*"
 prost-types = "0.5.0" # This is current stable, but for some reason gets pulled in as 0.4.0 if we use "*" (2019-03-28)
 rand = "*"
-ratsio = "^0.2"
+ratsio = "*"
 regex = "*"
 rustls = "*"
 serde = { version = "*", features = ["rc"] }

--- a/components/sup/protocols/event.proto
+++ b/components/sup/protocols/event.proto
@@ -72,6 +72,48 @@ message ServiceStoppedEvent {
   ServiceMetadata service_metadata = 2;
 }
 
+message ServiceUpdateStartedEvent {
+  EventMetadata event_metadata = 1;
+  ServiceMetadata service_metadata = 2;
+  // Details of the service pkg to which 
+  // we're attempting to update.These
+  // are implemented as strings for now,
+  // but at some point we'll likely want
+  // to create a type for this set of
+  // attributes (PackageIdent)
+  string update_origin = 3;
+  string update_name = 4;
+  string update_version = 5;
+  string update_release = 6;
+}
+
+message ServiceUpdateCompleteEvent {
+  EventMetadata event_metadata = 1;
+  ServiceMetadata service_metadata = 2;
+  // Details of the service pkg to
+  // which we've successfully updated.
+  // These are implemented as strings for now,
+  // but at some point we'll likely want
+  // to create a type for this set of
+  // attributes (PackageIdent)
+  string update_origin = 3;
+  string update_name = 4;
+  string update_version = 5;
+  string update_release = 6;
+}
+
+message FailureDetail {}
+
+message ServiceUpdateFailedEvent {
+  EventMetadata event_metadata = 1;
+  ServiceMetadata service_metadata = 2;
+  // Details of the service pkg to
+  // which we've failed to update
+  ServiceMetadata update_metadata = 3;
+  // service update failure detail
+  FailureDetail failure_detail = 4;
+}
+
 message HealthCheckEvent {
   EventMetadata event_metadata = 1;
   ServiceMetadata service_metadata = 2;

--- a/components/sup/protocols/event.proto
+++ b/components/sup/protocols/event.proto
@@ -87,33 +87,6 @@ message ServiceUpdateStartedEvent {
   string update_release = 6;
 }
 
-message ServiceUpdateCompleteEvent {
-  EventMetadata event_metadata = 1;
-  ServiceMetadata service_metadata = 2;
-  // Details of the service pkg to
-  // which we've successfully updated.
-  // These are implemented as strings for now,
-  // but at some point we'll likely want
-  // to create a type for this set of
-  // attributes (PackageIdent)
-  string update_origin = 3;
-  string update_name = 4;
-  string update_version = 5;
-  string update_release = 6;
-}
-
-message FailureDetail {}
-
-message ServiceUpdateFailedEvent {
-  EventMetadata event_metadata = 1;
-  ServiceMetadata service_metadata = 2;
-  // Details of the service pkg to
-  // which we've failed to update
-  ServiceMetadata update_metadata = 3;
-  // service update failure detail
-  FailureDetail failure_detail = 4;
-}
-
 message HealthCheckEvent {
   EventMetadata event_metadata = 1;
   ServiceMetadata service_metadata = 2;

--- a/components/sup/protocols/event.proto
+++ b/components/sup/protocols/event.proto
@@ -76,15 +76,12 @@ message ServiceUpdateStartedEvent {
   EventMetadata event_metadata = 1;
   ServiceMetadata service_metadata = 2;
   // Details of the service pkg to which 
-  // we're attempting to update.These
-  // are implemented as strings for now,
-  // but at some point we'll likely want
+  // we're attempting to update.This is
+  // implemented as a string for now,
+  // but at some point we'll may want
   // to create a type for this set of
-  // attributes (PackageIdent)
-  string update_origin = 3;
-  string update_name = 4;
-  string update_version = 5;
-  string update_release = 6;
+  // attributes (FullyQualifiedPackageIdent)
+  string update_package_ident = 3;
 }
 
 message HealthCheckEvent {

--- a/components/sup/src/event.rs
+++ b/components/sup/src/event.rs
@@ -185,7 +185,7 @@ pub fn service_update_started(service: &Service, update: &PackageIdent) {
         publish(ServiceUpdateStartedEvent { event_metadata:       None,
                                             service_metadata:
                                                 Some(service.to_service_metadata()),
-                                            update_package_ident: format!("{}", update.clone()), });
+                                            update_package_ident: update.clone().to_string(), });
     }
 }
 

--- a/components/sup/src/event.rs
+++ b/components/sup/src/event.rs
@@ -27,7 +27,8 @@ use self::types::{EventMessage,
                   EventMetadata,
                   HealthCheckEvent,
                   ServiceStartedEvent,
-                  ServiceStoppedEvent};
+                  ServiceStoppedEvent,
+                  ServiceUpdateStartedEvent};
 use crate::manager::{service::{HealthCheckResult,
                                Service},
                      sys::Sys};
@@ -37,7 +38,8 @@ pub use error::{Error,
 use futures::sync::mpsc::UnboundedSender;
 use habitat_common::types::{AutomateAuthToken,
                             EventStreamMetadata};
-use habitat_core::env::Config as EnvConfig;
+use habitat_core::{env::Config as EnvConfig,
+                   package::ident::PackageIdent};
 use state::Container;
 use std::{net::SocketAddr,
           num::ParseIntError,
@@ -177,6 +179,22 @@ pub fn service_stopped(service: &Service) {
     }
 }
 
+/// Send an event at the start of a Service update.
+pub fn service_update_started(service: &Service, update: &PackageIdent) {
+    if stream_initialized() {
+        publish(ServiceUpdateStartedEvent { event_metadata:   None,
+                                            service_metadata: Some(service.to_service_metadata()),
+                                            update_origin:    update.origin.clone(),
+                                            update_name:      update.name.clone(),
+                                            update_version:   update.version
+                                                                    .clone()
+                                                                    .unwrap_or_default(),
+                                            update_release:   update.release
+                                                                    .clone()
+                                                                    .unwrap_or_default(), });
+    }
+}
+
 // Takes metadata directly, rather than a `&Service` like other event
 // functions, because of how the asynchronous health checking
 // currently works. Revisit when async/await + Pin is all stabilized.
@@ -219,6 +237,7 @@ fn publish(mut event: impl EventMessage) {
         // one.
         //
         // The ugliness is at least contained, though.
+        debug!("Publishing to event stream: event {:?} ", event);
         event.event_metadata(EventMetadata { occurred_at:
                                                  Some(std::time::SystemTime::now().into()),
                                              ..EVENT_CORE.get::<EventCore>().to_event_metadata() });

--- a/components/sup/src/event.rs
+++ b/components/sup/src/event.rs
@@ -186,12 +186,16 @@ pub fn service_update_started(service: &Service, update: &PackageIdent) {
                                             service_metadata: Some(service.to_service_metadata()),
                                             update_origin:    update.origin.clone(),
                                             update_name:      update.name.clone(),
-                                            update_version:   update.version
-                                                                    .clone()
-                                                                    .unwrap_or_default(),
-                                            update_release:   update.release
-                                                                    .clone()
-                                                                    .unwrap_or_default(), });
+                                            update_version:
+                                                update.version
+                                                      .clone()
+                                                      .expect("Can't send service update started \
+                                                               event; invalid update version"),
+                                            update_release:
+                                                update.release
+                                                      .clone()
+                                                      .expect("Can't send service update started \
+                                                               event; invalid update release"), });
     }
 }
 

--- a/components/sup/src/event.rs
+++ b/components/sup/src/event.rs
@@ -182,20 +182,10 @@ pub fn service_stopped(service: &Service) {
 /// Send an event at the start of a Service update.
 pub fn service_update_started(service: &Service, update: &PackageIdent) {
     if stream_initialized() {
-        publish(ServiceUpdateStartedEvent { event_metadata:   None,
-                                            service_metadata: Some(service.to_service_metadata()),
-                                            update_origin:    update.origin.clone(),
-                                            update_name:      update.name.clone(),
-                                            update_version:
-                                                update.version
-                                                      .clone()
-                                                      .expect("Can't send service update started \
-                                                               event; invalid update version"),
-                                            update_release:
-                                                update.release
-                                                      .clone()
-                                                      .expect("Can't send service update started \
-                                                               event; invalid update release"), });
+        publish(ServiceUpdateStartedEvent { event_metadata:       None,
+                                            service_metadata:
+                                                Some(service.to_service_metadata()),
+                                            update_package_ident: format!("{}", update.clone()), });
     }
 }
 

--- a/components/sup/src/event/types.rs
+++ b/components/sup/src/event/types.rs
@@ -91,18 +91,16 @@ pub trait EventMessage: Message + Sized {
 }
 
 macro_rules! event_msg_impl {
-    ($($t:ty)*) => {$(
+    ($t:ty) => {
         impl EventMessage for $t {
             fn event_metadata(&mut self, event_metadata: EventMetadata) {
                 self.event_metadata = Some(event_metadata);
             }
         }
-    )*};
+    };
 }
 
-event_msg_impl! (
-    ServiceStartedEvent
-    ServiceStoppedEvent
-    ServiceUpdateStartedEvent
-    HealthCheckEvent
-);
+event_msg_impl!(ServiceStartedEvent);
+event_msg_impl!(ServiceStoppedEvent);
+event_msg_impl!(ServiceUpdateStartedEvent);
+event_msg_impl!(HealthCheckEvent);

--- a/components/sup/src/event/types.rs
+++ b/components/sup/src/event/types.rs
@@ -90,29 +90,19 @@ pub trait EventMessage: Message + Sized {
     }
 }
 
-// TODO (CM): these are repetitive, and will only get more so as we
-// add events. Consider implementing via macro instead.
-
-impl EventMessage for ServiceStartedEvent {
-    fn event_metadata(&mut self, event_metadata: EventMetadata) {
-        self.event_metadata = Some(event_metadata);
-    }
+macro_rules! event_msg_impl {
+    ($($t:ty)*) => {$(
+        impl EventMessage for $t {
+            fn event_metadata(&mut self, event_metadata: EventMetadata) {
+                self.event_metadata = Some(event_metadata);
+            }
+        }
+    )*};
 }
 
-impl EventMessage for ServiceStoppedEvent {
-    fn event_metadata(&mut self, event_metadata: EventMetadata) {
-        self.event_metadata = Some(event_metadata);
-    }
-}
-
-impl EventMessage for ServiceUpdateStartedEvent {
-    fn event_metadata(&mut self, event_metadata: EventMetadata) {
-        self.event_metadata = Some(event_metadata);
-    }
-}
-
-impl EventMessage for HealthCheckEvent {
-    fn event_metadata(&mut self, event_metadata: EventMetadata) {
-        self.event_metadata = Some(event_metadata);
-    }
-}
+event_msg_impl! (
+    ServiceStartedEvent
+    ServiceStoppedEvent
+    ServiceUpdateStartedEvent
+    HealthCheckEvent
+);

--- a/components/sup/src/event/types.rs
+++ b/components/sup/src/event/types.rs
@@ -105,6 +105,12 @@ impl EventMessage for ServiceStoppedEvent {
     }
 }
 
+impl EventMessage for ServiceUpdateStartedEvent {
+    fn event_metadata(&mut self, event_metadata: EventMetadata) {
+        self.event_metadata = Some(event_metadata);
+    }
+}
+
 impl EventMessage for HealthCheckEvent {
     fn event_metadata(&mut self, event_metadata: EventMetadata) {
         self.event_metadata = Some(event_metadata);

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -1065,6 +1065,7 @@ impl Manager {
                     updater.check_for_updated_package(&service, &self.census_ring)
                 {
                     outputln!("Updating from {} to {}", current_ident, new_ident);
+                    event::service_update_started(&service, &new_ident);
                     Some(current_ident.clone())
                 } else {
                     trace!("No update found for {}", current_ident);


### PR DESCRIPTION
This PR fires a service update started event when the supervisor sees that a new hab package is available and thus starts the package update process. Automate uses this event to help determine and display the deployment status of a service.

Note: there's work in progress to refactor the supervisor to perform certain operations, including starting packages, asynchronously. Until this work is done, providing additional deployment events (service update completed, service update failed) is awkward because we don't have a concrete handle on when these events occur without adding more state as a stopgap. I'm thinking it might be best to let Automate derive completed and failure states on its side until we get the supervisor refactored and can implement additional events in the correct way. One possible way Automate might accomplish this would be to compare the update fully-qualified package identifier from the service update started event with the fully-qualified package identifier  from the most recent service started event for a given service. If they match, Automate could assume a successful update. If this is not the case (and a specified period of time has passed), Automate could assume an update failure.

There are nuances to this we'd need to discuss, e.g., multiple entities trying to update the same service. Additionally, depending upon the level of effort on the Automate side, we may wish to revisit adding state on the Habitat side, bumping up the priority of the supervisor work, etc. Another option would be just using the service update started event on the Automate side without trying to derive any additional information. This needs discussion with the Automate team and Product.

Shake 'n' Bake!
![image](https://user-images.githubusercontent.com/12157155/58993803-71318300-87a3-11e9-95d5-747ae6f33ea0.png)
 
Signed-off-by: Gina Peers <gpeers@chef.io>