### PR TITLE
Update to Rust 1.35.0

### DIFF
--- a/.buildkite/env
+++ b/.buildkite/env
@@ -8,7 +8,7 @@ set -euo pipefail
 # Use this to specify a toolchain for Rustup on platforms where that's
 # how we get Rust (e.g., macOS)
 if [[ -z "${RUST_TOOLCHAIN:-}" ]]; then
-    export RUST_TOOLCHAIN="1.34.0"
+    export RUST_TOOLCHAIN="1.35.0"
 else
     echo "--- :warning: Using RUST_TOOLCHAIN=\"${RUST_TOOLCHAIN}\", previously set in the environment"
 fi

--- a/test/denied_lints.txt
+++ b/test/denied_lints.txt
@@ -9,6 +9,7 @@ clippy::collapsible_if
 clippy::const_static_lifetime
 clippy::correctness
 clippy::deref_addrof
+clippy::drop_bounds
 clippy::expect_fun_call
 clippy::for_kv_map
 clippy::get_unwrap
@@ -37,6 +38,7 @@ clippy::println_empty_string
 clippy::ptr_arg
 clippy::question_mark
 clippy::redundant_closure
+clippy::redundant_closure_for_method_calls
 clippy::redundant_field_names
 clippy::redundant_pattern_matching
 clippy::single_char_pattern

--- a/test/lints_to_fix.txt
+++ b/test/lints_to_fix.txt
@@ -1,1 +1,1 @@
-clippy::cyclomatic_complexity
+clippy::cognitive_complexity


### PR DESCRIPTION
This fixes some clippy issues with Rust 1.35.0, although not all of them.  https://github.com/habitat-sh/habitat/pull/6610 also fixes 1.35.0 related clippy issues, and that PR should merge before this one does in order for CI on this one to pass.

![](https://media.giphy.com/media/xUOxf4YpQNlEtssg8g/giphy.gif)