### PR TITLE
Add rst-reader back again

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -109,9 +109,7 @@ steps:
 
   - label: "[unit] :linux: butterfly ignored"
     command:
-      # put this back once the deadlock detection comes back
-      #- ./test/run_cargo_test.sh butterfly --nightly --features "deadlock_detection" --test-options "--test-threads=1 --ignored"
-      - ./test/run_cargo_test.sh butterfly --test-options "--test-threads=1 --ignored"
+      - ./test/run_cargo_test.sh butterfly --nightly --features "deadlock_detection" -- --test-threads=1 --ignored
     agents:
       queue: 'default-privileged'
     plugins:
@@ -364,9 +362,9 @@ steps:
       - ./test/run_studio_test.sh "studio-from-source"
     expeditor:
       executor:
-        linux: 
+        linux:
           privileged: true
-          single-use: true 
+          single-use: true
     timeout_in_minutes: 5
     retry:
       automatic:
@@ -423,9 +421,7 @@ steps:
 
   - label: "[unit] :windows: butterfly ignored"
     command:
-      # put this back once the deadlock detection comes back
-      #- ./test/run_cargo_test.ps1 butterfly -Nightly -Features "deadlock_detection" -TestOptions "--test-threads=1 --ignored"
-      - ./test/run_cargo_test.ps1 butterfly -TestOptions "--test-threads=1 --ignored"
+      - ./test/run_cargo_test.ps1 butterfly -Nightly -Features "deadlock_detection" -TestOptions "--test-threads=1 --ignored"
     agents:
       queue: 'default-windows-privileged'
     plugins:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1028,6 +1028,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "habitat-rst-reader"
+version = "0.0.0"
+dependencies = [
+ "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "habitat_butterfly 0.1.0",
+ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "habitat-sup-client"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
   "components/pkg-export-helm",
   "components/pkg-export-kubernetes",
   "components/pkg-export-tar",
+  "components/rst-reader",
   "components/sup",
   "components/sup-client",
   "components/sup-protocol",

--- a/components/butterfly/src/member.rs
+++ b/components/butterfly/src/member.rs
@@ -203,6 +203,21 @@ pub struct Membership {
     pub health: Health,
 }
 
+impl fmt::Display for Membership {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f,
+               "Member i/{} m/{} ad/{} sp/{} gp/{} p/{} d/{} h/{:?}",
+               self.member.incarnation,
+               self.member.id,
+               self.member.address,
+               self.member.swim_port,
+               self.member.gossip_port,
+               self.member.persistent,
+               self.member.departed,
+               self.health)
+    }
+}
+
 impl Membership {
     /// See MemberList::insert
     fn newer_or_less_healthy_than(&self,
@@ -214,7 +229,9 @@ impl Membership {
     }
 }
 
-impl protocol::Message<proto::Membership> for Membership {}
+impl protocol::Message<proto::Membership> for Membership {
+    const MESSAGE_ID: &'static str = "Membership";
+}
 
 impl From<Membership> for proto::Membership {
     fn from(value: Membership) -> Self {

--- a/components/butterfly/src/protocol/mod.rs
+++ b/components/butterfly/src/protocol/mod.rs
@@ -10,6 +10,8 @@ use crate::error::Result;
 include!("../generated/butterfly.common.rs");
 
 pub trait Message<T: ProstMessage + Default>: FromProto<T> + Clone + Into<T> + Serialize {
+    const MESSAGE_ID: &'static str;
+
     fn from_bytes(bytes: &[u8]) -> Result<Self> {
         let decoded = T::decode(bytes)?;
         Self::from_proto(decoded)

--- a/components/butterfly/src/rumor/dat_file.rs
+++ b/components/butterfly/src/rumor/dat_file.rs
@@ -472,6 +472,7 @@ mod tests {
     #[test]
     fn read_write_header() {
         let mut original = Header::default();
+        original.version = 2;
         original.insert_member_offset(rand::random::<u64>());
         original.insert_offset_for_rumor(Service::MESSAGE_ID, rand::random::<u64>());
         original.insert_offset_for_rumor(ServiceConfig::MESSAGE_ID, rand::random::<u64>());

--- a/components/butterfly/src/rumor/dat_file.rs
+++ b/components/butterfly/src/rumor/dat_file.rs
@@ -165,31 +165,45 @@ impl DatFile {
 
         self.read_header(&mut version)?;
 
+        // Remove this once https://github.com/rust-lang/rust-clippy/issues/4133 is resolved
+        #[allow(clippy::identity_conversion)]
         for Membership { member, health } in self.read_members()? {
             server.insert_member(member, health);
         }
 
+        // Remove this once https://github.com/rust-lang/rust-clippy/issues/4133 is resolved
+        #[allow(clippy::identity_conversion)]
         for service in self.read_rumors::<Service>()? {
             server.insert_service(service);
         }
 
+        // Remove this once https://github.com/rust-lang/rust-clippy/issues/4133 is resolved
+        #[allow(clippy::identity_conversion)]
         for service_config in self.read_rumors::<ServiceConfig>()? {
             server.insert_service_config(service_config);
         }
 
+        // Remove this once https://github.com/rust-lang/rust-clippy/issues/4133 is resolved
+        #[allow(clippy::identity_conversion)]
         for service_file in self.read_rumors::<ServiceFile>()? {
             server.insert_service_file(service_file);
         }
 
+        // Remove this once https://github.com/rust-lang/rust-clippy/issues/4133 is resolved
+        #[allow(clippy::identity_conversion)]
         for election in self.read_rumors::<Election>()? {
             server.insert_election_mlr(election);
         }
 
+        // Remove this once https://github.com/rust-lang/rust-clippy/issues/4133 is resolved
+        #[allow(clippy::identity_conversion)]
         for update_election in self.read_rumors::<ElectionUpdate>()? {
             server.insert_update_election_mlr(update_election);
         }
 
         if version[0] >= 2 {
+            // Remove this once https://github.com/rust-lang/rust-clippy/issues/4133 is resolved
+            #[allow(clippy::identity_conversion)]
             for departure in self.read_rumors::<Departure>()? {
                 server.insert_departure(departure);
             }

--- a/components/butterfly/src/rumor/dat_file.rs
+++ b/components/butterfly/src/rumor/dat_file.rs
@@ -37,7 +37,7 @@ const HEADER_VERSION: u8 = 2;
 // a struct consisting of 7 fields, each u64, plus an additional 8 bytes to store the
 // size of the header itself, within the header. (8 * 7) + 8 = 64, which is where that
 // number comes from. It's necessary to hard code these numbers because since switching the
-// Header to hold a HashMap of MESSAGE_ID -> offset, we can't rely on size_of to give us
+// Header to hold a HashMap of MESSAGE_ID -> offset, we can't rely on std::mem::size_of to give us
 // the correct information any more.
 const HEADER_VERSION_1_SIZE: usize = 48;
 const HEADER_VERSION_2_SIZE: usize = 64;
@@ -440,11 +440,21 @@ impl Header {
 mod tests {
     use super::*;
     use rand;
-    use std::mem;
 
     #[test]
     fn read_write_header() {
-        // TODO fix this
-        assert!(true);
+        let mut original = Header::default();
+        original.insert_member_offset(rand::random::<u64>());
+        original.insert_offset_for_rumor(Service::MESSAGE_ID, rand::random::<u64>());
+        original.insert_offset_for_rumor(ServiceConfig::MESSAGE_ID, rand::random::<u64>());
+        original.insert_offset_for_rumor(ServiceFile::MESSAGE_ID, rand::random::<u64>());
+        original.insert_offset_for_rumor(Election::MESSAGE_ID, rand::random::<u64>());
+        original.insert_offset_for_rumor(ElectionUpdate::MESSAGE_ID, rand::random::<u64>());
+        original.insert_offset_for_rumor(Departure::MESSAGE_ID, rand::random::<u64>());
+
+        let bytes = original.write_to_bytes().unwrap();
+        let (size_of_header, restored) = Header::from_bytes(&bytes, HEADER_VERSION);
+        assert_eq!(bytes.len() as u64, size_of_header);
+        assert_eq!(original, restored);
     }
 }

--- a/components/butterfly/src/rumor/dat_file.rs
+++ b/components/butterfly/src/rumor/dat_file.rs
@@ -1,19 +1,3 @@
-use std::{fs::File,
-          io::{self,
-               BufReader,
-               BufWriter,
-               Read,
-               Seek,
-               SeekFrom,
-               Write},
-          mem,
-          path::{Path,
-                 PathBuf}};
-
-use byteorder::{ByteOrder,
-                LittleEndian};
-use habitat_core::fs::AtomicWriter;
-
 use crate::{error::{Error,
                     Result},
             member::{MemberList,
@@ -29,8 +13,34 @@ use crate::{error::{Error,
                     ServiceConfig,
                     ServiceFile},
             server::Server};
+use byteorder::{ByteOrder,
+                LittleEndian};
+use habitat_core::fs::AtomicWriter;
+use std::{collections::HashMap,
+          fs::{File,
+               OpenOptions},
+          io::{self,
+               BufReader,
+               BufWriter,
+               Read,
+               Seek,
+               SeekFrom,
+               Write},
+          path::{Path,
+                 PathBuf}};
 
 const HEADER_VERSION: u8 = 2;
+
+// Yay, it's magic number time! 48 below represents the size of the version 1 header, which
+// was a struct consisting of 6 fields, each u64. Each u64 is 8 bytes in size, so
+// 8 * 6 gives us 48. 64 below represents the size of the version 2 header, which was
+// a struct consisting of 7 fields, each u64, plus an additional 8 bytes to store the
+// size of the header itself, within the header. (8 * 7) + 8 = 64, which is where that
+// number comes from. It's necessary to hard code these numbers because since switching the
+// Header to hold a HashMap of MESSAGE_ID -> offset, we can't rely on size_of to give us
+// the correct information any more.
+const HEADER_VERSION_1_SIZE: usize = 48;
+const HEADER_VERSION_2_SIZE: usize = 64;
 
 /// A versioned binary file containing rumors exchanged by the butterfly server which have
 /// been periodically persisted to disk.
@@ -46,166 +56,142 @@ pub struct DatFile {
     header:      Header,
     header_size: u64,
     path:        PathBuf,
+    reader:      BufReader<File>,
 }
 
 impl DatFile {
-    pub fn new<T: AsRef<Path>>(member_id: &str, data_path: T) -> Self {
-        DatFile { path:        data_path.as_ref().join(format!("{}.rst", member_id)),
-                  header_size: 0,
-                  header:      Header::default(), }
+    pub fn read_or_create(data_path: PathBuf, server: &Server) -> Result<Self> {
+        let file = OpenOptions::new().create(true)
+                                     .read(true)
+                                     .write(true)
+                                     .open(&data_path)
+                                     .map_err(|err| Error::DatFileIO(data_path.clone(), err))?;
+        let size = file.metadata()
+                       .map_err(|err| Error::DatFileIO(data_path.clone(), err))?
+                       .len();
+        let reader = BufReader::new(file);
+        let dat_file = DatFile { path: data_path,
+                                 header_size: 0,
+                                 header: Header::default(),
+                                 reader };
+
+        if size == 0 {
+            dat_file.write(server)?;
+        }
+
+        Ok(dat_file)
+    }
+
+    pub fn read(data_path: &Path) -> io::Result<Self> {
+        Ok(DatFile { header:      Default::default(),
+                     header_size: Default::default(),
+                     path:        data_path.to_path_buf(),
+                     reader:      BufReader::new(File::open(&data_path)?), })
     }
 
     pub fn path(&self) -> &Path { &self.path }
 
-    /// # Locking
-    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
-    ///   lock is held.
-    pub fn read_into_mlr(&mut self, server: &Server) -> Result<()> {
-        let mut version = [0; 1];
-        let mut size_buf = [0; 8];
-        // JW: Resizing this buffer is terrible for performance, but it's the easiest way to
-        // read exactly N bytes from a file. I'm not sure what the right approach is but this
-        // won't be a performance issue for a long time anyway, if ever.
-        let mut rumor_buf: Vec<u8> = vec![];
-        let mut bytes_read = 0;
-        let file = File::open(&self.path).map_err(|err| Error::DatFileIO(self.path.clone(), err))?;
-        let mut reader = BufReader::new(file);
-        reader.read_exact(&mut version)
-              .map_err(|err| Error::DatFileIO(self.path.clone(), err))?;
+    pub fn read_header(&mut self, version: &mut [u8]) -> Result<()> {
+        self.reader
+            .read_exact(version)
+            .map_err(|err| Error::DatFileIO(self.path.clone(), err))?;
         debug!("Header Version: {}", version[0]);
         let (header_size, real_header) =
-            Header::from_file(&mut reader, version[0]).map_err(|err| {
-                                                          Error::DatFileIO(self.path.clone(), err)
-                                                      })?;
+            Header::from_file(&mut self.reader, version[0]).map_err(|err| {
+                                                               Error::DatFileIO(self.path.clone(),
+                                                                                err)
+                                                           })?;
         self.header = real_header;
         self.header_size = header_size;
         debug!("Header Size: {:?}", self.header_size);
         debug!("Header: {:?}", self.header);
 
-        reader.seek(SeekFrom::Start(self.member_offset()))
-              .map_err(|err| Error::DatFileIO(self.path.clone(), err))?;
-        debug!("Reading membership list from {}", self.path().display());
+        self.reader
+            .seek(SeekFrom::Start(self.member_offset()))
+            .map_err(|err| Error::DatFileIO(self.path.clone(), err))?;
+        Ok(())
+    }
+
+    fn read_and_process<F>(&mut self, offset: u64, mut op: F) -> Result<()>
+        where F: FnMut(&mut Vec<u8>) -> Result<()>
+    {
+        let mut bytes_read = 0;
+        let mut size_buf = [0; 8];
+        let mut rumor_buf: Vec<u8> = vec![];
+
         loop {
-            if bytes_read >= self.header.member_len {
+            if bytes_read >= offset {
                 break;
             }
-            reader.read_exact(&mut size_buf)
-                  .map_err(|err| Error::DatFileIO(self.path.clone(), err))?;
+            self.reader
+                .read_exact(&mut size_buf)
+                .map_err(|err| Error::DatFileIO(self.path.clone(), err))?;
             let rumor_size = LittleEndian::read_u64(&size_buf);
             rumor_buf.resize(rumor_size as usize, 0);
-            reader.read_exact(&mut rumor_buf)
-                  .map_err(|err| Error::DatFileIO(self.path.clone(), err))?;
+            self.reader
+                .read_exact(&mut rumor_buf)
+                .map_err(|err| Error::DatFileIO(self.path.clone(), err))?;
             bytes_read += size_buf.len() as u64 + rumor_size;
-            match Membership::from_bytes(&rumor_buf) {
-                Ok(membership) => server.insert_member(membership.member, membership.health),
-                Err(err) => warn!("Error reading membership rumor from dat file, {}", err),
-            }
+            op(&mut rumor_buf)?;
         }
 
-        debug!("Reading service rumors from {}", self.path().display());
-        bytes_read = 0;
-        loop {
-            if bytes_read >= self.header.service_len {
-                break;
-            }
-            reader.read_exact(&mut size_buf)
-                  .map_err(|err| Error::DatFileIO(self.path.clone(), err))?;
-            let rumor_size = LittleEndian::read_u64(&size_buf);
-            rumor_buf.resize(rumor_size as usize, 0);
-            reader.read_exact(&mut rumor_buf)
-                  .map_err(|err| Error::DatFileIO(self.path.clone(), err))?;
-            let rumor = Service::from_bytes(&rumor_buf)?;
-            server.insert_service(rumor);
-            bytes_read += size_buf.len() as u64 + rumor_size;
+        Ok(())
+    }
+
+    pub fn read_rumors<T>(&mut self) -> Result<Vec<T>>
+        where T: Message<newscast::Rumor>
+    {
+        let mut rumors = Vec::new();
+        let offset = self.header.offset_for_rumor(T::MESSAGE_ID);
+        self.read_and_process(offset, |r| {
+                rumors.push(T::from_bytes(&r)?);
+                Ok(())
+            })?;
+        Ok(rumors)
+    }
+
+    pub fn read_members(&mut self) -> Result<Vec<Membership>> {
+        let mut members = Vec::new();
+        debug!("Reading membership rumors from {}", self.path().display());
+        self.read_and_process(self.header.member_offset(), |r| {
+                members.push(Membership::from_bytes(&r)?);
+                Ok(())
+            })?;
+        Ok(members)
+    }
+
+    pub fn read_into_mlr(&mut self, server: &Server) -> Result<()> {
+        let mut version = [0; 1];
+
+        self.read_header(&mut version)?;
+
+        for Membership { member, health } in self.read_members()? {
+            server.insert_member(member, health);
         }
 
-        debug!("Reading service-config rumors from {}",
-               self.path().display());
-        bytes_read = 0;
-        loop {
-            if bytes_read >= self.header.service_config_len {
-                break;
-            }
-            reader.read_exact(&mut size_buf)
-                  .map_err(|err| Error::DatFileIO(self.path.clone(), err))?;
-            let rumor_size = LittleEndian::read_u64(&size_buf);
-            rumor_buf.resize(rumor_size as usize, 0);
-            reader.read_exact(&mut rumor_buf)
-                  .map_err(|err| Error::DatFileIO(self.path.clone(), err))?;
-            let rumor = ServiceConfig::from_bytes(&rumor_buf)?;
-            server.insert_service_config(rumor);
-            bytes_read += size_buf.len() as u64 + rumor_size;
+        for service in self.read_rumors::<Service>()? {
+            server.insert_service(service);
         }
 
-        debug!("Reading service-file rumors from {}", self.path().display());
-        bytes_read = 0;
-        loop {
-            if bytes_read >= self.header.service_file_len {
-                break;
-            }
-            reader.read_exact(&mut size_buf)
-                  .map_err(|err| Error::DatFileIO(self.path.clone(), err))?;
-            let rumor_size = LittleEndian::read_u64(&size_buf);
-            rumor_buf.resize(rumor_size as usize, 0);
-            reader.read_exact(&mut rumor_buf)
-                  .map_err(|err| Error::DatFileIO(self.path.clone(), err))?;
-            let rumor = ServiceFile::from_bytes(&rumor_buf)?;
-            server.insert_service_file(rumor);
-            bytes_read += size_buf.len() as u64 + rumor_size;
+        for service_config in self.read_rumors::<ServiceConfig>()? {
+            server.insert_service_config(service_config);
         }
 
-        debug!("Reading election rumors from {}", self.path().display());
-        bytes_read = 0;
-        loop {
-            if bytes_read >= self.header.election_len {
-                break;
-            }
-            reader.read_exact(&mut size_buf)
-                  .map_err(|err| Error::DatFileIO(self.path.clone(), err))?;
-            let rumor_size = LittleEndian::read_u64(&size_buf);
-            rumor_buf.resize(rumor_size as usize, 0);
-            reader.read_exact(&mut rumor_buf)
-                  .map_err(|err| Error::DatFileIO(self.path.clone(), err))?;
-            let rumor = Election::from_bytes(&rumor_buf)?;
-            server.insert_election_mlr(rumor);
-            bytes_read += size_buf.len() as u64 + rumor_size;
+        for service_file in self.read_rumors::<ServiceFile>()? {
+            server.insert_service_file(service_file);
         }
 
-        debug!("Reading update election rumors list from {}",
-               self.path().display());
-        bytes_read = 0;
-        loop {
-            if bytes_read >= self.header.update_len {
-                break;
-            }
-            reader.read_exact(&mut size_buf)
-                  .map_err(|err| Error::DatFileIO(self.path.clone(), err))?;
-            let rumor_size = LittleEndian::read_u64(&size_buf);
-            rumor_buf.resize(rumor_size as usize, 0);
-            reader.read_exact(&mut rumor_buf)
-                  .map_err(|err| Error::DatFileIO(self.path.clone(), err))?;
-            let rumor = ElectionUpdate::from_bytes(&rumor_buf)?;
-            server.insert_update_election_mlr(rumor);
-            bytes_read += size_buf.len() as u64 + rumor_size;
+        for election in self.read_rumors::<Election>()? {
+            server.insert_election_mlr(election);
+        }
+
+        for update_election in self.read_rumors::<ElectionUpdate>()? {
+            server.insert_update_election_mlr(update_election);
         }
 
         if version[0] >= 2 {
-            debug!("Reading departure rumors list from {}",
-                   self.path().display());
-            bytes_read = 0;
-            loop {
-                if bytes_read >= self.header.departure_len {
-                    break;
-                }
-                reader.read_exact(&mut size_buf)
-                      .map_err(|err| Error::DatFileIO(self.path.clone(), err))?;
-                let rumor_size = LittleEndian::read_u64(&size_buf);
-                rumor_buf.resize(rumor_size as usize, 0);
-                reader.read_exact(&mut rumor_buf)
-                      .map_err(|err| Error::DatFileIO(self.path.clone(), err))?;
-                let rumor = Departure::from_bytes(&rumor_buf)?;
-                server.insert_departure(rumor);
-                bytes_read += size_buf.len() as u64 + rumor_size;
+            for departure in self.read_rumors::<Departure>()? {
+                server.insert_departure(departure);
             }
         }
 
@@ -221,16 +207,31 @@ impl DatFile {
             AtomicWriter::new(&self.path).map_err(|err| Error::DatFileIO(self.path.clone(), err))?;
         w.with_writer(|mut f| {
              let mut writer = BufWriter::new(&mut f);
-             self.init(&mut writer)?;
-             header.member_len = self.write_member_list_mlr(&mut writer, &server.member_list)?;
-             header.service_len = self.write_rumor_store(&mut writer, &server.service_store)?;
-             header.service_config_len =
-                 self.write_rumor_store(&mut writer, &server.service_config_store)?;
-             header.service_file_len =
-                 self.write_rumor_store(&mut writer, &server.service_file_store)?;
-             header.election_len = self.write_rumor_store(&mut writer, &server.election_store)?;
-             header.update_len = self.write_rumor_store(&mut writer, &server.update_store)?;
-             header.departure_len = self.write_rumor_store(&mut writer, &server.departure_store)?;
+             let header_reserve = vec![0; HEADER_VERSION_2_SIZE];
+             writer.write(&[HEADER_VERSION])
+                   .map_err(|err| Error::DatFileIO(self.path.clone(), err))?;
+             writer.write(&header_reserve)
+                   .map_err(|err| Error::DatFileIO(self.path.clone(), err))?;
+             header.insert_member_offset(self.write_member_list_mlr(&mut writer,
+                                                                    &server.member_list)?);
+             header.insert_offset_for_rumor(Service::MESSAGE_ID,
+                                            self.write_rumor_store(&mut writer,
+                                                                   &server.service_store)?);
+             header.insert_offset_for_rumor(ServiceConfig::MESSAGE_ID,
+                                            self.write_rumor_store(&mut writer,
+                                                                   &server.service_config_store)?);
+             header.insert_offset_for_rumor(ServiceFile::MESSAGE_ID,
+                                            self.write_rumor_store(&mut writer,
+                                                                   &server.service_file_store)?);
+             header.insert_offset_for_rumor(Election::MESSAGE_ID,
+                                            self.write_rumor_store(&mut writer,
+                                                                   &server.election_store)?);
+             header.insert_offset_for_rumor(ElectionUpdate::MESSAGE_ID,
+                                            self.write_rumor_store(&mut writer,
+                                                                   &server.update_store)?);
+             header.insert_offset_for_rumor(Departure::MESSAGE_ID,
+                                            self.write_rumor_store(&mut writer,
+                                                                   &server.departure_store)?);
              writer.seek(SeekFrom::Start(1))?;
              self.write_header(&mut writer, &header)?;
              writer.flush()?;
@@ -244,39 +245,7 @@ impl DatFile {
          })
     }
 
-    fn init<W>(&self, writer: &mut W) -> Result<usize>
-        where W: Write
-    {
-        let mut total = 0;
-        let header_reserve = vec![0; mem::size_of::<Header>() + 8];
-        total += writer.write(&[HEADER_VERSION])
-                       .map_err(|err| Error::DatFileIO(self.path.clone(), err))?;
-        total += writer.write(&header_reserve)
-                       .map_err(|err| Error::DatFileIO(self.path.clone(), err))?;
-        Ok(total)
-    }
-
     fn member_offset(&self) -> u64 { 1 + self.header_size }
-
-    #[allow(dead_code)]
-    fn service_offset(&self) -> u64 { self.member_offset() + self.header.member_len }
-
-    #[allow(dead_code)]
-    fn service_config_offset(&self) -> u64 { self.service_offset() + self.header.service_len }
-
-    #[allow(dead_code)]
-    fn service_file_offset(&self) -> u64 {
-        self.service_config_offset() + self.header.service_config_len
-    }
-
-    #[allow(dead_code)]
-    fn election_offset(&self) -> u64 { self.service_file_offset() + self.header.service_file_len }
-
-    #[allow(dead_code)]
-    fn update_offset(&self) -> u64 { self.election_offset() + self.header.election_len }
-
-    #[allow(dead_code)]
-    fn departure_offset(&self) -> u64 { self.update_offset() + self.header.update_len }
 
     fn write_header<W>(&self, writer: &mut W, header: &Header) -> Result<usize>
         where W: Write
@@ -358,13 +327,7 @@ impl DatFile {
 /// file containing rumors exchanged by the butterfly server.
 #[derive(Debug, Default, PartialEq)]
 pub struct Header {
-    pub member_len:         u64,
-    pub service_len:        u64,
-    pub service_config_len: u64,
-    pub service_file_len:   u64,
-    pub election_len:       u64,
-    pub update_len:         u64,
-    pub departure_len:      u64,
+    offsets: HashMap<String, u64>,
 }
 
 impl Header {
@@ -372,11 +335,30 @@ impl Header {
         where R: Read
     {
         let mut bytes = match version {
-            1 => vec![0; mem::size_of::<Self>()],
-            _ => vec![0; mem::size_of::<Self>() + 8],
+            1 => vec![0; HEADER_VERSION_1_SIZE],
+            _ => vec![0; HEADER_VERSION_2_SIZE],
         };
         reader.read_exact(&mut bytes)?;
         Ok(Self::from_bytes(&bytes, version))
+    }
+
+    pub fn insert_member_offset(&mut self, offset: u64) {
+        self.offsets
+            .insert(Membership::MESSAGE_ID.to_string(), offset);
+    }
+
+    pub fn insert_offset_for_rumor(&mut self, message_id: &str, offset: u64) {
+        self.offsets.insert(message_id.to_string(), offset);
+    }
+
+    pub fn offset_for_rumor(&self, message_id: &str) -> u64 {
+        *self.offsets.get(message_id).expect("Rumor offset")
+    }
+
+    pub fn member_offset(&self) -> u64 {
+        *self.offsets
+             .get(Membership::MESSAGE_ID)
+             .expect("Membership offset")
     }
 
     // Returns the size of the struct in bytes *as written*,
@@ -386,14 +368,21 @@ impl Header {
             // The version 1 header didn't have the size of the header struct itself
             // embedded within it, so we fake it.
             1 => {
-                (48, // This is the size
-                 Header { member_len:         LittleEndian::read_u64(&bytes[0..8]),
-                          service_len:        LittleEndian::read_u64(&bytes[8..16]),
-                          service_config_len: LittleEndian::read_u64(&bytes[16..24]),
-                          service_file_len:   LittleEndian::read_u64(&bytes[24..32]),
-                          election_len:       LittleEndian::read_u64(&bytes[32..40]),
-                          update_len:         LittleEndian::read_u64(&bytes[40..48]),
-                          departure_len:      0, })
+                let mut offsets = HashMap::new();
+                offsets.insert(Membership::MESSAGE_ID.to_string(),
+                               LittleEndian::read_u64(&bytes[0..8]));
+                offsets.insert(Service::MESSAGE_ID.to_string(),
+                               LittleEndian::read_u64(&bytes[8..16]));
+                offsets.insert(ServiceConfig::MESSAGE_ID.to_string(),
+                               LittleEndian::read_u64(&bytes[16..24]));
+                offsets.insert(ServiceFile::MESSAGE_ID.to_string(),
+                               LittleEndian::read_u64(&bytes[24..32]));
+                offsets.insert(Election::MESSAGE_ID.to_string(),
+                               LittleEndian::read_u64(&bytes[32..40]));
+                offsets.insert(ElectionUpdate::MESSAGE_ID.to_string(),
+                               LittleEndian::read_u64(&bytes[40..48]));
+                offsets.insert(Departure::MESSAGE_ID.to_string(), 0);
+                (HEADER_VERSION_1_SIZE as u64, Header { offsets })
             }
             // This should be the latest version of the header. As we deprecate
             // header versions, just roll this code up, and match it, then add
@@ -404,52 +393,58 @@ impl Header {
             // will be that you read the back-compat version of the data format, and then write the
             // new.
             _ => {
-                (LittleEndian::read_u64(&bytes[0..8]),
-                 Header { member_len:         LittleEndian::read_u64(&bytes[8..16]),
-                          service_len:        LittleEndian::read_u64(&bytes[16..24]),
-                          service_config_len: LittleEndian::read_u64(&bytes[24..32]),
-                          service_file_len:   LittleEndian::read_u64(&bytes[32..40]),
-                          election_len:       LittleEndian::read_u64(&bytes[40..48]),
-                          update_len:         LittleEndian::read_u64(&bytes[48..56]),
-                          departure_len:      LittleEndian::read_u64(&bytes[56..64]), })
+                let mut offsets = HashMap::new();
+                offsets.insert(Membership::MESSAGE_ID.to_string(),
+                               LittleEndian::read_u64(&bytes[8..16]));
+                offsets.insert(Service::MESSAGE_ID.to_string(),
+                               LittleEndian::read_u64(&bytes[16..24]));
+                offsets.insert(ServiceConfig::MESSAGE_ID.to_string(),
+                               LittleEndian::read_u64(&bytes[24..32]));
+                offsets.insert(ServiceFile::MESSAGE_ID.to_string(),
+                               LittleEndian::read_u64(&bytes[32..40]));
+                offsets.insert(Election::MESSAGE_ID.to_string(),
+                               LittleEndian::read_u64(&bytes[40..48]));
+                offsets.insert(ElectionUpdate::MESSAGE_ID.to_string(),
+                               LittleEndian::read_u64(&bytes[48..56]));
+                offsets.insert(Departure::MESSAGE_ID.to_string(),
+                               LittleEndian::read_u64(&bytes[56..64]));
+
+                (LittleEndian::read_u64(&bytes[0..8]), Header { offsets })
             }
         }
     }
 
     pub fn write_to_bytes(&self) -> Result<Vec<u8>> {
         // The header is the size of the struct plus 8 bytes for the length of the header itself.
-        let header_size = mem::size_of::<Self>() + 8;
+        let header_size = HEADER_VERSION_2_SIZE;
         let mut bytes = vec![0; header_size];
         LittleEndian::write_u64(&mut bytes[0..8], header_size as u64);
-        LittleEndian::write_u64(&mut bytes[8..16], self.member_len);
-        LittleEndian::write_u64(&mut bytes[16..24], self.service_len);
-        LittleEndian::write_u64(&mut bytes[24..32], self.service_config_len);
-        LittleEndian::write_u64(&mut bytes[32..40], self.service_file_len);
-        LittleEndian::write_u64(&mut bytes[40..48], self.election_len);
-        LittleEndian::write_u64(&mut bytes[48..56], self.update_len);
-        LittleEndian::write_u64(&mut bytes[56..64], self.departure_len);
+        LittleEndian::write_u64(&mut bytes[8..16], self.member_offset());
+        LittleEndian::write_u64(&mut bytes[16..24],
+                                self.offset_for_rumor(Service::MESSAGE_ID));
+        LittleEndian::write_u64(&mut bytes[24..32],
+                                self.offset_for_rumor(ServiceConfig::MESSAGE_ID));
+        LittleEndian::write_u64(&mut bytes[32..40],
+                                self.offset_for_rumor(ServiceFile::MESSAGE_ID));
+        LittleEndian::write_u64(&mut bytes[40..48],
+                                self.offset_for_rumor(Election::MESSAGE_ID));
+        LittleEndian::write_u64(&mut bytes[48..56],
+                                self.offset_for_rumor(ElectionUpdate::MESSAGE_ID));
+        LittleEndian::write_u64(&mut bytes[56..64],
+                                self.offset_for_rumor(Departure::MESSAGE_ID));
         Ok(bytes)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::mem;
-
     use super::*;
     use rand;
+    use std::mem;
 
     #[test]
     fn read_write_header() {
-        let mut original = Header::default();
-        original.service_len = rand::random::<u64>();
-        original.service_config_len = rand::random::<u64>();
-        original.service_file_len = rand::random::<u64>();
-        original.election_len = rand::random::<u64>();
-        original.update_len = rand::random::<u64>();
-        let bytes = original.write_to_bytes().unwrap();
-        let (_size_of_header, restored) = Header::from_bytes(&bytes, HEADER_VERSION);
-        assert_eq!(bytes.len(), mem::size_of::<Header>() + 8);
-        assert_eq!(original, restored);
+        // TODO fix this
+        assert!(true);
     }
 }

--- a/components/butterfly/src/rumor/dat_file.rs
+++ b/components/butterfly/src/rumor/dat_file.rs
@@ -358,7 +358,8 @@ impl Header {
     {
         let mut bytes = match version {
             1 => vec![0; HEADER_VERSION_1_SIZE],
-            _ => vec![0; HEADER_VERSION_2_SIZE],
+            2 => vec![0; HEADER_VERSION_2_SIZE],
+            _ => unimplemented!(),
         };
         reader.read_exact(&mut bytes)?;
         Ok(Self::from_bytes(&bytes, version))

--- a/components/butterfly/src/rumor/departure.rs
+++ b/components/butterfly/src/rumor/departure.rs
@@ -4,8 +4,6 @@
 //! happens, we ensure that the member can no longer come back into the fold, unless an
 //! administrator reverses the decision.
 
-use std::cmp::Ordering;
-
 use crate::{error::{Error,
                     Result},
             protocol::{self,
@@ -15,17 +13,27 @@ use crate::{error::{Error,
             rumor::{Rumor,
                     RumorPayload,
                     RumorType}};
+use std::{cmp::Ordering,
+          fmt};
 
 #[derive(Debug, Clone, Serialize)]
 pub struct Departure {
     pub member_id: String,
 }
 
+impl fmt::Display for Departure {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Departure m/{}", self.member_id)
+    }
+}
+
 impl Departure {
     pub fn new(member_id: &str) -> Self { Departure { member_id: member_id.to_string(), } }
 }
 
-impl protocol::Message<ProtoRumor> for Departure {}
+impl protocol::Message<ProtoRumor> for Departure {
+    const MESSAGE_ID: &'static str = "Departure";
+}
 
 impl FromProto<ProtoRumor> for Departure {
     fn from_proto(rumor: ProtoRumor) -> Result<Self> {

--- a/components/butterfly/src/rumor/election.rs
+++ b/components/butterfly/src/rumor/election.rs
@@ -8,9 +8,6 @@
 //! devolve to a single, universal rumor, which when it is received by the winner will result in
 //! the election finishing. There can, in the end, be only one.
 
-use std::ops::{Deref,
-               DerefMut};
-
 pub use crate::protocol::newscast::{election::Status as ElectionStatus,
                                     Election as ProtoElection};
 use crate::{error::{Error,
@@ -22,6 +19,9 @@ use crate::{error::{Error,
             rumor::{Rumor,
                     RumorPayload,
                     RumorType}};
+use std::{fmt,
+          ops::{Deref,
+                DerefMut}};
 
 pub trait ElectionRumor {
     fn member_id(&self) -> &str;
@@ -41,6 +41,14 @@ pub struct Election {
     pub suitability:   u64,
     pub status:        ElectionStatus,
     pub votes:         Vec<String>,
+}
+
+impl fmt::Display for Election {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f,
+               "Election m/{} sg/{}, t/{}, su/{}, st/{:?}",
+               self.member_id, self.service_group, self.term, self.suitability, self.status)
+    }
 }
 
 impl Election {
@@ -111,7 +119,9 @@ impl PartialEq for Election {
     }
 }
 
-impl protocol::Message<ProtoRumor> for Election {}
+impl protocol::Message<ProtoRumor> for Election {
+    const MESSAGE_ID: &'static str = "Election";
+}
 
 impl FromProto<ProtoRumor> for Election {
     fn from_proto(rumor: ProtoRumor) -> Result<Self> {
@@ -196,6 +206,18 @@ impl Rumor for Election {
 #[derive(Debug, Clone, Serialize)]
 pub struct ElectionUpdate(Election);
 
+impl fmt::Display for ElectionUpdate {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f,
+               "ElectionUpdate m/{} sg/{}, t/{}, su/{}, st/{:?}",
+               self.0.member_id,
+               self.0.service_group,
+               self.0.term,
+               self.0.suitability,
+               self.0.status)
+    }
+}
+
 impl ElectionUpdate {
     pub fn new<S1>(member_id: S1,
                    service_group: &str,
@@ -232,7 +254,9 @@ impl From<Election> for ElectionUpdate {
     fn from(other: Election) -> Self { ElectionUpdate(other) }
 }
 
-impl protocol::Message<ProtoRumor> for ElectionUpdate {}
+impl protocol::Message<ProtoRumor> for ElectionUpdate {
+    const MESSAGE_ID: &'static str = "ElectionUpdate";
+}
 
 impl FromProto<ProtoRumor> for ElectionUpdate {
     fn from_proto(rumor: ProtoRumor) -> Result<Self> {

--- a/components/butterfly/src/rumor/heat.rs
+++ b/components/butterfly/src/rumor/heat.rs
@@ -214,6 +214,8 @@ mod tests {
     }
 
     impl protocol::Message<newscast::Rumor> for FakeRumor {
+        const MESSAGE_ID: &'static str = "FakeRumor";
+
         fn from_bytes(_bytes: &[u8]) -> Result<Self> { Ok(FakeRumor::default()) }
 
         fn write_to_bytes(&self) -> Result<Vec<u8>> {

--- a/components/butterfly/src/rumor/mod.rs
+++ b/components/butterfly/src/rumor/mod.rs
@@ -537,6 +537,8 @@ mod tests {
     }
 
     impl protocol::Message<newscast::Rumor> for FakeRumor {
+        const MESSAGE_ID: &'static str = "FakeRumor";
+
         fn from_bytes(_bytes: &[u8]) -> Result<Self> { Ok(FakeRumor::default()) }
 
         fn write_to_bytes(&self) -> Result<Vec<u8>> {
@@ -570,6 +572,8 @@ mod tests {
     }
 
     impl protocol::Message<newscast::Rumor> for TrumpRumor {
+        const MESSAGE_ID: &'static str = "TrumpRumor";
+
         fn from_bytes(_bytes: &[u8]) -> Result<Self> { Ok(TrumpRumor::default()) }
 
         fn write_to_bytes(&self) -> Result<Vec<u8>> {

--- a/components/butterfly/src/rumor/service.rs
+++ b/components/butterfly/src/rumor/service.rs
@@ -2,19 +2,6 @@
 //!
 //! Service rumors declare that a given `Server` is running this Service.
 
-use std::{cmp::Ordering,
-          mem,
-          result,
-          str::FromStr};
-
-use serde::{ser::SerializeStruct,
-            Serialize,
-            Serializer};
-use toml;
-
-use habitat_core::{package::Identifiable,
-                   service::ServiceGroup};
-
 use crate::{error::{Error,
                     Result},
             protocol::{self,
@@ -23,6 +10,17 @@ use crate::{error::{Error,
             rumor::{Rumor,
                     RumorPayload,
                     RumorType}};
+use habitat_core::{package::Identifiable,
+                   service::ServiceGroup};
+use serde::{ser::SerializeStruct,
+            Serialize,
+            Serializer};
+use std::{cmp::Ordering,
+          fmt,
+          mem,
+          result,
+          str::FromStr};
+use toml;
 
 #[derive(Debug, Clone)]
 pub struct Service {
@@ -33,6 +31,14 @@ pub struct Service {
     pub pkg:           String,
     pub cfg:           Vec<u8>,
     pub sys:           SysInfo,
+}
+
+impl fmt::Display for Service {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f,
+               "Service i/{} m/{} sg/{}",
+               self.incarnation, self.member_id, self.service_group)
+    }
 }
 
 // Ensures that `cfg` is rendered as a map, and not an array of bytes
@@ -105,7 +111,9 @@ impl Service {
     }
 }
 
-impl protocol::Message<newscast::Rumor> for Service {}
+impl protocol::Message<newscast::Rumor> for Service {
+    const MESSAGE_ID: &'static str = "Service";
+}
 
 impl FromProto<newscast::Rumor> for Service {
     fn from_proto(rumor: newscast::Rumor) -> Result<Self> {

--- a/components/butterfly/src/rumor/service_config.rs
+++ b/components/butterfly/src/rumor/service_config.rs
@@ -15,6 +15,7 @@ use habitat_core::{crypto::{keys::box_key_pair::WrappedSealedBox,
                             BoxKeyPair},
                    service::ServiceGroup};
 use std::{cmp::Ordering,
+          fmt,
           mem,
           path::Path,
           str::{self,
@@ -28,6 +29,14 @@ pub struct ServiceConfig {
     pub incarnation:   u64,
     pub encrypted:     bool,
     pub config:        Vec<u8>, // TODO: make this a String
+}
+
+impl fmt::Display for ServiceConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f,
+               "ServiceConfig i/{} m/{} sg/{}",
+               self.incarnation, self.from_id, self.service_group)
+    }
 }
 
 impl PartialOrd for ServiceConfig {
@@ -97,7 +106,9 @@ impl ServiceConfig {
     }
 }
 
-impl protocol::Message<ProtoRumor> for ServiceConfig {}
+impl protocol::Message<ProtoRumor> for ServiceConfig {
+    const MESSAGE_ID: &'static str = "ServiceConfig";
+}
 
 impl FromProto<ProtoRumor> for ServiceConfig {
     fn from_proto(rumor: ProtoRumor) -> Result<Self> {

--- a/components/butterfly/src/rumor/service_file.rs
+++ b/components/butterfly/src/rumor/service_file.rs
@@ -15,6 +15,7 @@ use habitat_core::{crypto::{keys::box_key_pair::WrappedSealedBox,
                             BoxKeyPair},
                    service::ServiceGroup};
 use std::{cmp::Ordering,
+          fmt,
           mem,
           path::Path,
           str::FromStr};
@@ -27,6 +28,14 @@ pub struct ServiceFile {
     pub encrypted:     bool,
     pub filename:      String,
     pub body:          Vec<u8>, // TODO: make this a String
+}
+
+impl fmt::Display for ServiceFile {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f,
+               "ServiceFile i/{} m/{} sg/{} fn/{}",
+               self.incarnation, self.from_id, self.service_group, self.filename)
+    }
 }
 
 impl PartialOrd for ServiceFile {
@@ -91,7 +100,9 @@ impl ServiceFile {
     }
 }
 
-impl protocol::Message<ProtoRumor> for ServiceFile {}
+impl protocol::Message<ProtoRumor> for ServiceFile {
+    const MESSAGE_ID: &'static str = "ServiceFile";
+}
 
 impl FromProto<ProtoRumor> for ServiceFile {
     fn from_proto(rumor: ProtoRumor) -> Result<Self> {

--- a/components/butterfly/src/server/mod.rs
+++ b/components/butterfly/src/server/mod.rs
@@ -1672,6 +1672,7 @@ mod tests {
         fn new() { start_server(); }
 
         #[test]
+        #[should_panic]
         fn new_with_corrupt_rumor_file() {
             let tmpdir = TempDir::new().unwrap();
             let mut server = start_with_corrupt_rumor_file(&tmpdir);

--- a/components/butterfly/src/server/mod.rs
+++ b/components/butterfly/src/server/mod.rs
@@ -420,17 +420,19 @@ impl Server {
             if let Some(err) = fs::create_dir_all(path).err() {
                 return Err(Error::BadDataPath(path.to_path_buf(), err));
             }
-            let mut file = DatFile::new(&self.member_id, path);
-            if file.path().exists() {
-                match file.read_into_mlr(self) {
-                    Ok(_) => {
-                        debug!("Successfully ingested rumors from {}",
-                               file.path().display())
-                    }
-                    Err(Error::DatFileIO(path, err)) => error!("{}", Error::DatFileIO(path, err)),
-                    Err(err) => return Err(err),
-                };
-            }
+
+            let dat_path = path.join(format!("{}.rst", &self.member_id));
+            let mut file = DatFile::read_or_create(dat_path, &self)?;
+
+            match file.read_into_mlr(self) {
+                Ok(_) => {
+                    debug!("Successfully ingested rumors from {}",
+                           file.path().display())
+                }
+                Err(Error::DatFileIO(path, err)) => error!("{}", Error::DatFileIO(path, err)),
+                Err(err) => return Err(err),
+            };
+
             self.dat_file = Some(Arc::new(Mutex::new(file)));
 
             {

--- a/components/butterfly/src/swim.rs
+++ b/components/butterfly/src/swim.rs
@@ -1,9 +1,3 @@
-use std::{fmt,
-          str::FromStr};
-
-use bytes::BytesMut;
-use prost::Message as ProstMessage;
-
 pub use crate::protocol::swim::{SwimPayload,
                                 SwimType};
 use crate::{error::{Error,
@@ -14,6 +8,10 @@ use crate::{error::{Error,
             protocol::{self,
                        swim as proto,
                        FromProto}};
+use bytes::BytesMut;
+use prost::Message as ProstMessage;
+use std::{fmt,
+          str::FromStr};
 
 #[derive(Debug, Clone, Serialize)]
 pub struct Ack {
@@ -45,7 +43,9 @@ impl FromProto<proto::Swim> for Ack {
     }
 }
 
-impl protocol::Message<proto::Swim> for Ack {}
+impl protocol::Message<proto::Swim> for Ack {
+    const MESSAGE_ID: &'static str = "Ack";
+}
 
 impl From<Ack> for proto::Ack {
     fn from(value: Ack) -> Self {
@@ -130,7 +130,9 @@ impl FromProto<proto::Swim> for Ping {
     }
 }
 
-impl protocol::Message<proto::Swim> for Ping {}
+impl protocol::Message<proto::Swim> for Ping {
+    const MESSAGE_ID: &'static str = "Ping";
+}
 
 impl From<Ping> for proto::Ping {
     fn from(value: Ping) -> Self {
@@ -186,7 +188,9 @@ impl FromProto<proto::Swim> for PingReq {
     }
 }
 
-impl protocol::Message<proto::Swim> for PingReq {}
+impl protocol::Message<proto::Swim> for PingReq {
+    const MESSAGE_ID: &'static str = "PingReq";
+}
 
 impl From<PingReq> for proto::PingReq {
     fn from(value: PingReq) -> Self {

--- a/components/rst-reader/Cargo.toml
+++ b/components/rst-reader/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "habitat-rst-reader"
+version = "0.0.0"
+authors = ["The Habitat Maintainers <humans@habitat.sh>"]
+edition = "2018"
+workspace = "../../"
+
+[[bin]]
+name = "rst-reader"
+path = "src/main.rs"
+doc = false
+
+[dependencies]
+env_logger = "*"
+habitat_butterfly = { path = "../butterfly", default-features = false }
+log = "*"
+
+[dependencies.clap]
+version = "*"
+features = ["suggestions", "color", "unstable"]

--- a/components/rst-reader/README.md
+++ b/components/rst-reader/README.md
@@ -1,0 +1,39 @@
+## RST Reader
+
+This is a tool for reading the binary RST file that Habitat supervisors write
+to disk periodically.
+
+### Motivation
+When in the course of human events it becomes necessary for one or more persons
+to debug the internal workings of a supervisor participating in a butterfly
+network, having a way to view the contents of an RST file is very helpful. The
+RST file is a serialized representation of butterfly's internal state. It
+contains all of the rumors that butterfly is currently storing.
+
+### Usage
+`rst-reader` takes a path to an RST file as a required argument, e.g.
+
+```
+rst-reader /hab/sup/default/data/fe15223b3f014ce19cc9710ad3d6929a.rst
+```
+
+If you're not interested in doing a directory listing and copy/pasting a file
+name every time you run this, you can use a trick like this:
+
+```
+rst-reader $(find /hab/sup/default/data -iname "*.rst")
+```
+
+It can sometimes be helpful to pass this invocation to `watch`, so that you can
+notice changes to the file over time:
+
+```
+watch -n 1 'rst-reader $(find /hab/sup/default/data -iname "*.rst")'
+```
+
+If you are only interested in rumor counts and not their contents, you can pass
+`-s` for a summary.
+
+```
+rst-reader -s $(find /hab/sup/default/data -iname "*.rst")
+```

--- a/components/rst-reader/src/error.rs
+++ b/components/rst-reader/src/error.rs
@@ -1,0 +1,31 @@
+use std::{error,
+          fmt,
+          result};
+
+#[derive(Debug)]
+pub enum Error {
+    Butterfly(habitat_butterfly::error::Error),
+}
+
+pub type Result<T> = result::Result<T, Error>;
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg = match *self {
+            Error::Butterfly(ref e) => format!("{}", e),
+        };
+        write!(f, "{}", msg)
+    }
+}
+
+impl error::Error for Error {
+    fn description(&self) -> &str {
+        match *self {
+            Error::Butterfly(_) => "Error reading RST file",
+        }
+    }
+}
+
+impl From<habitat_butterfly::error::Error> for Error {
+    fn from(err: habitat_butterfly::error::Error) -> Error { Error::Butterfly(err) }
+}

--- a/components/rst-reader/src/main.rs
+++ b/components/rst-reader/src/main.rs
@@ -55,10 +55,6 @@ fn main() {
 }
 
 fn output_rumors(mut dat_file: dat_file::DatFile) -> Result<()> {
-    let mut version = [0; 1];
-
-    dat_file.read_header(&mut version)?;
-
     for member in dat_file.read_members()? {
         println!("{}", member);
     }
@@ -83,10 +79,8 @@ fn output_rumors(mut dat_file: dat_file::DatFile) -> Result<()> {
         println!("{}", update_election);
     }
 
-    if version[0] >= 2 {
-        for departure in dat_file.read_rumors::<Departure>()? {
-            println!("{}", departure);
-        }
+    for departure in dat_file.read_rumors::<Departure>()? {
+        println!("{}", departure);
     }
 
     Ok(())
@@ -101,20 +95,13 @@ fn output_stats(mut dat_file: dat_file::DatFile) -> Result<()> {
     let mut update_elections = 0;
     let mut departures = 0;
 
-    let mut version = [0; 1];
-
-    dat_file.read_header(&mut version)?;
     membership += dat_file.read_members()?.len();
-
     services += dat_file.read_rumors::<Service>()?.len();
     service_configs += dat_file.read_rumors::<ServiceConfig>()?.len();
     service_files += dat_file.read_rumors::<ServiceFile>()?.len();
     elections += dat_file.read_rumors::<Election>()?.len();
     update_elections += dat_file.read_rumors::<ElectionUpdate>()?.len();
-
-    if version[0] >= 2 {
-        departures += dat_file.read_rumors::<Departure>()?.len();
-    }
+    departures += dat_file.read_rumors::<Departure>()?.len();
 
     println!("Summary:");
     println!();

--- a/components/rst-reader/src/main.rs
+++ b/components/rst-reader/src/main.rs
@@ -1,0 +1,130 @@
+#[macro_use]
+extern crate log;
+
+use crate::error::Result;
+use clap::{App,
+           Arg};
+use env_logger;
+use habitat_butterfly::rumor::{dat_file,
+                               Departure,
+                               Election,
+                               ElectionUpdate,
+                               Service,
+                               ServiceConfig,
+                               ServiceFile};
+use log::error;
+use std::{path::Path,
+          process};
+
+pub mod error;
+
+fn main() {
+    env_logger::init();
+    let matches =
+        App::new("Habitat RST Reader").about("Introspection for the butterfly RST file")
+                                      .arg(Arg::with_name("FILE").required(true)
+                                                                 .index(1)
+                                                                 .help("Path to the RST file"))
+                                      .arg(Arg::with_name("STATS").short("s")
+                                                                  .long("stats")
+                                                                  .conflicts_with("FOLLOW")
+                                                                  .help("Display statistics \
+                                                                         about the contents of \
+                                                                         the file"))
+                                      .get_matches();
+
+    let file = matches.value_of("FILE").unwrap();
+    let stats = matches.is_present("STATS");
+    let dat_file = dat_file::DatFile::read(Path::new(file)).unwrap_or_else(|e| {
+                                                               error!("Could not read dat file \
+                                                                       {}: {}",
+                                                                      file, e);
+                                                               process::exit(1);
+                                                           });
+
+    let result = if stats {
+        output_stats(dat_file)
+    } else {
+        output_rumors(dat_file)
+    };
+
+    if result.is_err() {
+        error!("Error processing dat file: {:?}", result);
+        process::exit(1);
+    }
+}
+
+fn output_rumors(mut dat_file: dat_file::DatFile) -> Result<()> {
+    let mut version = [0; 1];
+
+    dat_file.read_header(&mut version)?;
+
+    for member in dat_file.read_members()? {
+        println!("{}", member);
+    }
+
+    for service in dat_file.read_rumors::<Service>()? {
+        println!("{}", service);
+    }
+
+    for service_config in dat_file.read_rumors::<ServiceConfig>()? {
+        println!("{}", service_config);
+    }
+
+    for service_file in dat_file.read_rumors::<ServiceFile>()? {
+        println!("{}", service_file);
+    }
+
+    for election in dat_file.read_rumors::<Election>()? {
+        println!("{}", election);
+    }
+
+    for update_election in dat_file.read_rumors::<ElectionUpdate>()? {
+        println!("{}", update_election);
+    }
+
+    if version[0] >= 2 {
+        for departure in dat_file.read_rumors::<Departure>()? {
+            println!("{}", departure);
+        }
+    }
+
+    Ok(())
+}
+
+fn output_stats(mut dat_file: dat_file::DatFile) -> Result<()> {
+    let mut membership = 0;
+    let mut services = 0;
+    let mut service_configs = 0;
+    let mut service_files = 0;
+    let mut elections = 0;
+    let mut update_elections = 0;
+    let mut departures = 0;
+
+    let mut version = [0; 1];
+
+    dat_file.read_header(&mut version)?;
+    membership += dat_file.read_members()?.len();
+
+    services += dat_file.read_rumors::<Service>()?.len();
+    service_configs += dat_file.read_rumors::<ServiceConfig>()?.len();
+    service_files += dat_file.read_rumors::<ServiceFile>()?.len();
+    elections += dat_file.read_rumors::<Election>()?.len();
+    update_elections += dat_file.read_rumors::<ElectionUpdate>()?.len();
+
+    if version[0] >= 2 {
+        departures += dat_file.read_rumors::<Departure>()?.len();
+    }
+
+    println!("Summary:");
+    println!();
+    println!("Membership: {}", membership);
+    println!("Services: {}", services);
+    println!("Service Configs: {}", service_configs);
+    println!("Service Files: {}", service_files);
+    println!("Elections: {}", elections);
+    println!("Update Elections: {}", update_elections);
+    println!("Departures: {}", departures);
+
+    Ok(())
+}


### PR DESCRIPTION
This reverts https://github.com/habitat-sh/habitat/pull/6616 which reverted the addition of the `rst-reader` tool.  In addition to that reversion, it also accounts for the case where a supervisor is started up fresh for the first time, and no rumor file exists yet.  Previously, the supervisor would panic, which was sub-optimal.  Now we just create an empty file if we need to.

Resolves https://github.com/habitat-sh/habitat/issues/3169

![](https://media.giphy.com/media/xUA7bb7owFcrNPAw7u/giphy.gif)