### PR TITLE
Fix release promotion

### DIFF
--- a/.buildkite/finish_release_pipeline.yaml
+++ b/.buildkite/finish_release_pipeline.yaml
@@ -7,6 +7,8 @@ steps:
     command: .buildkite/scripts/promote_release_channel.sh builder-live
     agents:
       queue: habitat-release
+    env:
+      BUILD_PKG_TARGET: "x86_64-linux"
 
   - block: ":habicat: Ensure that Builder is stable on the new release"
     prompt: |
@@ -22,6 +24,8 @@ steps:
     command: .buildkite/scripts/promote_release_channel.sh stable
     agents:
       queue: habitat-release
+    env:
+      BUILD_PKG_TARGET: "x86_64-linux"
 
   - wait
 

--- a/.buildkite/release_pipeline.yaml
+++ b/.buildkite/release_pipeline.yaml
@@ -52,6 +52,8 @@ steps:
     command: .buildkite/scripts/resolve_launcher_actions.sh
     agents:
       queue: habitat-release
+    env:
+      BUILD_PKG_TARGET: "x86_64-linux"
 
   # New Launcher build steps are automatically added here, if applicable.
 

--- a/.buildkite/scripts/build_component.ps1
+++ b/.buildkite/scripts/build_component.ps1
@@ -44,6 +44,9 @@ Push-Location "C:\build"
 
     Write-Host "Running hab pkg upload for $Component to channel $ReleaseChannel"
     Invoke-Expression "$baseHabExe pkg upload results\$pkg_artifact --channel=$ReleaseChannel"
+    Invoke-Expression "buildkite-agent meta-data set ${pkg_ident}-x86_64-windows true"
+
+
 
     If ($Component -eq 'hab') {
         Write-Host "--- :buildkite: Recording metadata $pkg_ident"

--- a/.buildkite/scripts/build_component.sh
+++ b/.buildkite/scripts/build_component.sh
@@ -54,6 +54,8 @@ ${hab_binary} pkg upload \
     --auth="${HAB_AUTH_TOKEN}" \
     "results/${pkg_artifact:-}"
 
+set_target_metadata "${pkg_ident}" "${pkg_target}"
+
 echo "--- :writing_hand: Recording Build Metadata"
 case "${component}" in
     "hab")

--- a/.buildkite/scripts/shared.sh
+++ b/.buildkite/scripts/shared.sh
@@ -246,3 +246,29 @@ set_version() {
     local version=$1
     buildkite-agent meta-data set "version" "${version}"
 }
+
+# Until we can reliably deal with packages that have the same
+# identifier, but different target, we'll track the information in
+# Buildkite metadata.
+#
+# Each time we put a package into our release channel, we'll record
+# what target it was built for.
+set_target_metadata() {
+    package_ident="${1}"
+    target="${2}"
+
+    echo "--- :partyparrot: Setting target metadata for '${package_ident}' (${target})"
+    buildkite-agent meta-data set "${package_ident}-${target}" "true"
+}
+
+# When we do the final promotions, we need to know the target of each
+# package in order to properly get the promotion done. If Buildkite metadata for
+# an ident/target pair exists, then that means that's a valid
+# combination, and we can use the target in the promotion call.
+ident_has_target() {
+    package_ident="${1}"
+    target="${2}"
+
+    echo "--- :partyparrot: Checking target metadata for '${package_ident}' (${target})"
+    buildkite-agent meta-data exists "${package_ident}-${target}"
+}


### PR DESCRIPTION
This re-adds the package target metadata captured in order to promote packages that may share fully qualified identifiers. 

It also installs the latest hab cli in a couple places we were calling `hab` directly, as `pkg_target` isn't a valid parameter to some sub-commands in versions prior to 0.81.0.