### PR TITLE
Switch to log4rs in the Supervisor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1304,7 +1304,6 @@ dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cpu-time 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ctrlc 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hab 0.0.0",
@@ -1321,6 +1320,7 @@ dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log4rs 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "nitox 0.1.10 (git+https://github.com/habitat-sh/nitox?branch=feature/nats-server)",
  "notify 4.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1786,6 +1786,36 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "log-mdc"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "log4rs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "antidote 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arc-swap 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flate2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.54 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log-mdc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde-value 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_yaml 0.8.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread-id 3.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typemap 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2162,6 +2192,14 @@ dependencies = [
  "libc 0.2.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "vcpkg 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ordered-float"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2965,6 +3003,15 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde-value"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ordered-float 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4171,6 +4218,8 @@ dependencies = [
 "checksum lock_api 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ed946d4529956a20f2d63ebe1b69996d5a2137c91913fe3ebbeff957f5bca7ff"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
+"checksum log-mdc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a94d21414c1f4a51209ad204c1776a3d0765002c76c6abcb602a6f09f1e881c7"
+"checksum log4rs 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)" = "100052474df98158c0738a7d3f4249c99978490178b5f9f68cd835ac57adbd1b"
 "checksum lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
 "checksum mach 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "86dd2487cdfea56def77b88438a2c915fb45113c5319bfe7e14306ca4cd0b0e1"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
@@ -4210,6 +4259,7 @@ dependencies = [
 "checksum openssl 0.9.24 (registry+https://github.com/rust-lang/crates.io-index)" = "a3605c298474a3aa69de92d21139fb5e2a81688d308262359d85cdd0d12a7985"
 "checksum openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 "checksum openssl-sys 0.9.47 (registry+https://github.com/rust-lang/crates.io-index)" = "75bdd6dbbb4958d38e47a1d2348847ad1eb4dc205dc5d37473ae504391865acc"
+"checksum ordered-float 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "18869315e81473c951eb56ad5558bbc56978562d3ecfb87abb7a1e944cea4518"
 "checksum ordermap 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a86ed3f5f244b372d6b1a00b72ef7f8876d0bc6a78a4c9985c53614041512063"
 "checksum owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13"
 "checksum palaver 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "506302e99b606a2e34473b24570e4461ade973842ffd57de665f1a9bece98510"
@@ -4294,6 +4344,7 @@ dependencies = [
 "checksum serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)" = "32746bf0f26eab52f06af0d0aa1984f641341d06d8d673c693871da2d188c9be"
 "checksum serde-transcode 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97528f0dfcf8ce2d51d995cb513a103b9cd301dc3f387a9cae5ef974381d4e1c"
 "checksum serde_derive 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)" = "46a3223d0c9ba936b61c0d2e3e559e3217dbfb8d65d06d26e8b3c25de38bae3e"
+"checksum serde-value 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7a663f873dedc4eac1a559d4c6bc0d0b2c34dc5ac4702e105014b8281489e44f"
 "checksum serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)" = "5a23aa71d4a4d43fdbfaac00eff68ba8a06a51759a89ac3304323e800c4dd40d"
 "checksum serde_urlencoded 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "642dd69105886af2efd227f75a520ec9b44a820d65bc133a9131f7d229fd165a"
 "checksum serde_yaml 0.8.9 (registry+https://github.com/rust-lang/crates.io-index)" = "38b08a9a90e5260fe01c6480ec7c811606df6d3a660415808c3c3fa8ed95b582"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1786,7 +1786,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1808,9 +1808,9 @@ dependencies = [
  "libc 0.2.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "log-mdc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-value 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.8.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread-id 3.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2199,7 +2199,7 @@ name = "ordered-float"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3011,7 +3011,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ordered-float 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4343,8 +4343,8 @@ dependencies = [
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)" = "32746bf0f26eab52f06af0d0aa1984f641341d06d8d673c693871da2d188c9be"
 "checksum serde-transcode 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97528f0dfcf8ce2d51d995cb513a103b9cd301dc3f387a9cae5ef974381d4e1c"
-"checksum serde_derive 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)" = "46a3223d0c9ba936b61c0d2e3e559e3217dbfb8d65d06d26e8b3c25de38bae3e"
 "checksum serde-value 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7a663f873dedc4eac1a559d4c6bc0d0b2c34dc5ac4702e105014b8281489e44f"
+"checksum serde_derive 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)" = "46a3223d0c9ba936b61c0d2e3e559e3217dbfb8d65d06d26e8b3c25de38bae3e"
 "checksum serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)" = "5a23aa71d4a4d43fdbfaac00eff68ba8a06a51759a89ac3304323e800c4dd40d"
 "checksum serde_urlencoded 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "642dd69105886af2efd227f75a520ec9b44a820d65bc133a9131f7d229fd165a"
 "checksum serde_yaml 0.8.9 (registry+https://github.com/rust-lang/crates.io-index)" = "38b08a9a90e5260fe01c6480ec7c811606df6d3a660415808c3c3fa8ed95b582"

--- a/components/core/src/env.rs
+++ b/components/core/src/env.rs
@@ -152,8 +152,8 @@ macro_rules! env_config {
 /// ```
 #[macro_export]
 macro_rules! env_config_duration {
-    ($wrapping_type:ident, $env_var:ident => $from_str_fn:ident, $default_value:expr) => {
-        $crate::env_config!(#[derive(Debug)]
+    ($(#[$attr:meta])* $wrapping_type:ident, $env_var:ident => $from_str_fn:ident, $default_value:expr) => {
+        $crate::env_config!($(#[$attr])*
                             $wrapping_type,
                             std::time::Duration,
                             $env_var,

--- a/components/sup/Cargo.toml
+++ b/components/sup/Cargo.toml
@@ -33,7 +33,6 @@ actix-web = { version = "= 0.7.19", default-features = false, features = [ "rust
 byteorder = "*"
 clap = { version = "*", features = [ "suggestions", "color", "unstable" ] }
 cpu-time = "*"
-env_logger = "*"
 futures = "*"
 glob = "*"
 hab = { path = "../hab" }
@@ -50,6 +49,7 @@ lazy_static = "*"
 # and https://github.com/alecmocatta/palaver/pull/16 merged is made.
 libc = "= 0.2.54" 
 log = "*"
+log4rs = "*"
 notify = "*"
 num_cpus = "*"
 prometheus = "*"

--- a/components/sup/src/lib.rs
+++ b/components/sup/src/lib.rs
@@ -64,6 +64,7 @@ pub mod ctl_gateway;
 pub mod error;
 pub mod event;
 pub mod http_gateway;
+pub mod logger; // must be pub if used in the `hab-sup` binary
 pub mod manager;
 mod sup_futures;
 mod sys;

--- a/components/sup/src/logger.rs
+++ b/components/sup/src/logger.rs
@@ -1,0 +1,96 @@
+use log::LevelFilter;
+use log4rs::{append::console::ConsoleAppender,
+             config::{Appender,
+                      Config,
+                      Root},
+             encode::pattern::PatternEncoder,
+             file::Deserializers};
+use std::path::PathBuf;
+
+mod env_logger_compatibility;
+
+/// A `log4rs`
+/// [PatternEncoder](https://docs.rs/log4rs/0.8.3/log4rs/encode/pattern/index.html)
+/// format to mimic that of out-of-the-box `env_logger`.
+const DEFAULT_PATTERN: &str = "[{d(%Y-%m-%dT%H:%M:%SZ)(utc)} {l} {module}] {message}{n}";
+
+/// Initialize a log4rs-based logging system.
+///
+/// Absent any other configuration, a basic logging configuration will
+/// be used. Users can also specify configuration using a YAML
+/// configuration file (see
+/// https://docs.rs/log4rs/0.8.3/log4rs/#configuration).
+///
+/// We also provide a migration path from our previous
+/// `env_logger`-based implementation. If a configuration file is
+/// absent, but `RUST_LOG` is present in the environment, we will
+/// coerce a `log4rs` configuration from that `env_logger`
+/// configuration string.
+pub fn init() {
+    let file = configuration_file();
+    if file.exists() {
+        if let Err(e) = log4rs::init_file(&file, Deserializers::default()) {
+            eprintln!("Logging configuration file '{}' not valid: {}; using default logging \
+                       configuration",
+                      file.display(),
+                      e);
+            log4rs::init_config(default_config()).expect("Tried setting the log configuration, \
+                                                          but the global logger had already been \
+                                                          set!");
+        }
+    } else {
+        let config = env_logger_compatibility::from_env().unwrap_or_else(|| {
+                                                             eprintln!("Logging configuration \
+                                                                        file '{}' not found; \
+                                                                        using default logging \
+                                                                        configuration",
+                                                                       file.display());
+                                                             default_config()
+                                                         });
+
+        log4rs::init_config(config).expect("Tried setting the log configuration, but the global \
+                                            logger had already been set!");
+    }
+}
+
+/// The logging configuration that will be used if a configuration
+/// file is not found when the Supervisor is started.
+///
+/// Logs everything at ERROR and above to standard output. This is
+/// kept deliberately "bare bones" (for now), since `log4rs` allows for so much
+/// flexibility to end users via its configuration file.
+///
+/// As we move forward to consolidate more of our output under a
+/// unified logging interface (see
+/// https://github.com/habitat-sh/habitat/issues/6587, but
+/// particularly https://github.com/habitat-sh/habitat/issues/6584),
+/// we _may_ want to further customize this default configuration, in
+/// order to more closely adhere to our existing non-log-based output
+/// (at that point, though, it may be better to define the default in
+/// a YAML file and `include!` it here for readability)
+fn default_config() -> Config {
+    let stdout = ConsoleAppender::builder().encoder(Box::new(PatternEncoder::new(DEFAULT_PATTERN)))
+                                           .build();
+    // Calling `expect()` is OK because we have full control over this
+    // configuration. It can only fail if we create an inconsistent
+    // one (e.g., referred to an appender that we didn't
+    // create). Also, see the test below.
+    Config::builder().appender(Appender::builder().build("stdout", Box::new(stdout)))
+                     .build(Root::builder().appender("stdout").build(LevelFilter::Error))
+                     .expect("Default log4rs configuration should always be valid")
+}
+
+fn configuration_file() -> PathBuf {
+    habitat_sup_protocol::sup_root(None).join("config")
+                                        .join("log.yml")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// This saves us from accidentally creating an inconsistent default
+    /// configuration.
+    #[test]
+    fn default_configuration_does_not_fail() { default_config(); }
+}

--- a/components/sup/src/logger/env_logger_compatibility.rs
+++ b/components/sup/src/logger/env_logger_compatibility.rs
@@ -1,0 +1,246 @@
+//! Transition code to bridge users from `env_logger` to `log4rs`.
+//!
+//! Takes a configuration string (e.g., the content of the environment
+//! variable `RUST_LOG`) for configuring `env_logger` and transforms
+//! it (as much as possible) into a valid `log4rs` configuration.
+//!
+//! An important difference is in how module targeting works. With
+//! `env_logger`, you could do something like this:
+//!
+//! ```text
+//! RUST_LOG=debug,tokio=error
+//! ```
+//!
+//! This would ensure that all `debug` and higher severity messages
+//! were logged, but every module path that started with the string
+//! "tokio" would only log for `error` and higher (Tokio can be rather
+//! verbose at the lower logging levels).
+//!
+//! The `log4rs` library treats this target slightly differently; it
+//! *must* be a Rust module path. That is, the same "tokio=error"
+//! targeting string would match the module `tokio`, as well as
+//! `tokio::foo`, `tokio::foo::bar`, etc. However, for this particular
+//! example, there isn't actually a `tokio` module at the root;
+//! instead you have things like `tokio_reactor`, `tokio_threadpool`,
+//! etc. In `log4rs`, "tokio" will _not_ match `tokio_reactor` or
+//! `tokio_threadpool`; thus, you would see debug-level messages from
+//! these modules! To filter these in `log4rs`, you would need to
+//! explicitly list the module prefixes, like so:
+//!
+//! ```text
+//! RUST_LOG=debug,tokio_reactor=error,tokio_threadpool=error
+//! ```
+//!
+//! In other words, `log4rs` is much stricter in its notion of
+//! what qualifies as a module prefix (indeed, it actually _is_ a
+//! module prefix, rather than a simple string prefix).
+//!
+//! Another notable difference is that while `env_logger` permits the
+//! addition of a regular expression filter (e.g., only print messages
+//! that match the expression "foo*"), we do *not*. Any filter that is
+//! present will be ignored.
+//!
+//! We also don't honor the `RUST_LOG_STYLE` variable; no output is
+//! colored at all.
+//!
+//! See https://docs.rs/env_logger/0.6.1/env_logger/ for more details.
+use log::LevelFilter;
+use log4rs::{append::console::ConsoleAppender,
+             config::{Appender,
+                      Config,
+                      Logger,
+                      Root},
+             encode::pattern::PatternEncoder};
+use std::{collections::HashMap,
+          str::FromStr};
+
+pub(super) fn from_env() -> Option<Config> {
+    std::env::var("RUST_LOG").ok().map(|env_var| {
+                                      eprintln!("RUST_LOG environment variable found; using it \
+                                                 to configure log4rs");
+                                      env_var.parse::<EnvLogConfig>()
+                                             .expect("RUST_LOG parsing can't fail")
+                                             .into()
+                                  })
+}
+
+/// Encapsulates the relevant parts of an `env_logger` configuration
+/// string that we care to replicate.
+#[derive(Eq, PartialEq, Clone, Debug)]
+struct EnvLogConfig {
+    /// The base filtering level. Messages of lower severity than
+    /// this will not be printed.
+    root_level: LevelFilter,
+    /// Optional filtering customizations on a per-module basis.
+    module_filters: HashMap<String, LevelFilter>,
+}
+
+impl Default for EnvLogConfig {
+    /// This is the same unsetting `RUST_LOG` (or, alternatively,
+    /// `RUST_LOG=error`).
+    fn default() -> Self {
+        EnvLogConfig { root_level:     LevelFilter::Error,
+                       module_filters: HashMap::new(), }
+    }
+}
+
+impl Into<Config> for EnvLogConfig {
+    /// Actually create a `log4rs` configuration. This is
+    /// infallible because we'll always create something valid.
+    fn into(self: Self) -> Config {
+        let stdout = ConsoleAppender::builder().encoder(Box::new(PatternEncoder::new(super::DEFAULT_PATTERN)))
+                                               .build();
+        let loggers = self.module_filters
+                          .into_iter()
+                          .map(|(module, filter)| Logger::builder().build(module, filter));
+        Config::builder().appender(Appender::builder().build("stdout", Box::new(stdout)))
+                         .loggers(loggers)
+                         .build(Root::builder().appender("stdout").build(self.root_level))
+                         .expect("Should always generate a valid log4rs configuration")
+    }
+}
+
+impl FromStr for EnvLogConfig {
+    // We skip over any "bad" parts of the string and always end up
+    // returning a valid `EnvLogConfig`.
+    type Err = std::convert::Infallible;
+
+    // Copied in large part (with appropriate modifications) from
+    // [env_logger::filter::parse_spec](https://github.com/sebasmagri/env_logger/blob/811db3240831049788c5500ab9ed1b481d79476f/src/filter/mod.rs#L302).
+    //
+    // It's not necessarily how I would have written it from scratch,
+    // but I felt like keeping the code as similar as possible to the
+    // original would be better, both for comparison purposes, as well
+    // as for adhering as closely as possible to the behavior we're
+    // trying to emulate.
+    fn from_str(spec: &str) -> Result<Self, Self::Err> {
+        let mut config = EnvLogConfig::default();
+
+        let mut parts = spec.split('/');
+        let mods = parts.next();
+        if parts.next().is_some() {
+            eprintln!("Ignoring regex filter; not supported in log4rs");
+        }
+        if parts.next().is_some() {
+            eprintln!("warning: invalid logging spec '{}', ignoring it (too many '/'s)",
+                      spec);
+            return Ok(config);
+        }
+
+        if let Some(m) = mods {
+            for s in m.split(',') {
+                if s.is_empty() {
+                    continue;
+                }
+                let mut parts = s.split('=');
+                let (log_level, name) =
+                    match (parts.next(), parts.next().map(str::trim), parts.next()) {
+                        (Some(part0), None, None) => {
+                            // if the single argument is a log-level string or number,
+                            // treat that as a global fallback
+                            match part0.parse() {
+                                Ok(num) => (num, None),
+                                Err(_) => (LevelFilter::max(), Some(part0)),
+                            }
+                        }
+                        (Some(part0), Some(""), None) => (LevelFilter::max(), Some(part0)),
+                        (Some(part0), Some(part1), None) => {
+                            match part1.parse() {
+                                Ok(num) => (num, Some(part0)),
+                                _ => {
+                                    eprintln!("warning: invalid logging spec '{}', ignoring it",
+                                              part1);
+                                    continue;
+                                }
+                            }
+                        }
+                        _ => {
+                            eprintln!("warning: invalid logging spec '{}', ignoring it", s);
+                            continue;
+                        }
+                    };
+                if let Some(target) = name {
+                    config.module_filters.insert(target.to_string(), log_level);
+                } else {
+                    config.root_level = log_level
+                };
+            }
+        };
+
+        Ok(config)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Helper function for creating an `EnvLogConfig` struct with a
+    /// minimum of boilerplate.
+    fn config(root_level: LevelFilter, filters: Vec<(&str, LevelFilter)>) -> EnvLogConfig {
+        EnvLogConfig { root_level,
+                       module_filters: filters.into_iter()
+                                              .map(|(m, f)| (m.to_string(), f))
+                                              .collect() }
+    }
+
+    #[test]
+    fn bare_module_name_gets_converted_to_maximum_filter_level() {
+        assert_eq!("my::cool::module".parse::<EnvLogConfig>().unwrap(),
+                   config(LevelFilter::Error,
+                          vec![("my::cool::module", LevelFilter::Trace)]));
+
+        assert_eq!("my::cool::module,another::nifty::module,snazzy".parse::<EnvLogConfig>()
+                                                                   .unwrap(),
+                   config(LevelFilter::Error,
+                          vec![("my::cool::module", LevelFilter::Trace),
+                               ("another::nifty::module", LevelFilter::Trace),
+                               ("snazzy", LevelFilter::Trace)]));
+    }
+
+    #[test]
+    fn can_disable_logging() {
+        assert_eq!("off".parse::<EnvLogConfig>().unwrap(),
+                   config(LevelFilter::Off, vec![]));
+
+        assert_eq!("debug,my::chatty::module=off".parse::<EnvLogConfig>()
+                                                 .unwrap(),
+                   config(LevelFilter::Debug,
+                          vec![("my::chatty::module", LevelFilter::Off)]));
+    }
+
+    #[test]
+    fn parse_the_spec() {
+        assert_eq!("debug".parse::<EnvLogConfig>().unwrap(),
+                   config(LevelFilter::Debug, vec![]));
+
+        assert_eq!("debug,foo::bar::baz=trace".parse::<EnvLogConfig>().unwrap(),
+                   config(LevelFilter::Debug,
+                          vec![("foo::bar::baz", LevelFilter::Trace)]));
+
+        assert_eq!("monkeys,foo::bar::baz=trace".parse::<EnvLogConfig>()
+                                                .unwrap(),
+                   config(LevelFilter::Error,
+                          vec![("monkeys", LevelFilter::Trace),
+                               ("foo::bar::baz", LevelFilter::Trace)]));
+    }
+
+    #[test]
+    fn regexes_are_ignored() {
+        assert_eq!("debug/foo".parse::<EnvLogConfig>().unwrap(),
+                   config(LevelFilter::Debug, vec![]));
+        assert_eq!("debug,foo::bar::baz=trace/foo".parse::<EnvLogConfig>()
+                                                  .unwrap(),
+                   config(LevelFilter::Debug,
+                          vec![("foo::bar::baz", LevelFilter::Trace)]));
+    }
+
+    #[test]
+    fn bad_stuff_is_ignored() {
+        assert_eq!("debug/foo/foo".parse::<EnvLogConfig>().unwrap(),
+                   EnvLogConfig::default());
+        assert_eq!("debug/foo,foo::bar::baz=trace/foo".parse::<EnvLogConfig>()
+                                                      .unwrap(),
+                   EnvLogConfig::default());
+    }
+}

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -1,5 +1,4 @@
 extern crate clap;
-extern crate env_logger;
 extern crate habitat_sup as sup;
 #[cfg(unix)]
 extern crate jemalloc_ctl;
@@ -20,6 +19,7 @@ use crate::sup::{cli::cli,
                  error::{Error,
                          Result},
                  event::EventStreamConfig,
+                 logger,
                  manager::{Manager,
                            ManagerConfig,
                            TLSConfig,
@@ -72,7 +72,7 @@ static LOGKEY: &'static str = "MN";
 static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 fn main() {
-    env_logger::init();
+    logger::init();
     let mut ui = UI::default_with_env();
     let flags = FeatureFlag::from_env(&mut ui);
     let result = start(flags);

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -1586,8 +1586,8 @@ fn tls_config(config: &TLSConfig) -> Result<rustls::ServerConfig> {
     Ok(server_config)
 }
 
-/// Represents how many threads to start for our main Tokio runtime
-habitat_core::env_config_int!(#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Eq)]
+habitat_core::env_config_int!(/// Represents how many threads to start for our main Tokio runtime
+                              #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Eq)]
                               TokioThreadCount,
                               usize,
                               HAB_TOKIO_THREAD_COUNT,

--- a/components/sup/src/manager/service_updater.rs
+++ b/components/sup/src/manager/service_updater.rs
@@ -333,13 +333,14 @@ impl ServiceUpdater {
     }
 }
 
-/// Represents how far apart checks for updates to individual services
-/// are, in milliseconds.
-habitat_core::env_config_duration!(ServiceUpdatePeriod,
-                                   // TODO (CM): Yes, the variable value should be "period" and not
-                                   // "frequency"... we need to fix that.
-                                   HAB_UPDATE_STRATEGY_FREQUENCY_MS => from_millis,
-                                   ServiceUpdatePeriod::MIN_ALLOWED);
+habitat_core::env_config_duration!(
+    /// Represents how far apart checks for updates to individual services
+    /// are, in milliseconds.
+    ServiceUpdatePeriod,
+    // TODO (CM): Yes, the variable value should be "period" and not
+    // "frequency"... we need to fix that.
+    HAB_UPDATE_STRATEGY_FREQUENCY_MS => from_millis,
+    ServiceUpdatePeriod::MIN_ALLOWED);
 
 impl ServiceUpdatePeriod {
     const MIN_ALLOWED: Duration = Duration::from_secs(60);

--- a/components/sup/src/manager/spec_watcher.rs
+++ b/components/sup/src/manager/spec_watcher.rs
@@ -172,8 +172,6 @@ mod tests {
 
     #[test]
     fn can_get_events_for_spec_files() {
-        env_logger::try_init().ok();
-        error!("can_get_events_for_spec_files starting");
         let _delay = lock_delay_var();
 
         let dir = TempDir::new().expect("Could not create directory");
@@ -193,7 +191,6 @@ mod tests {
 
         assert!(!sw.has_events(),
                 "Should be no more events after you've checked");
-        error!("can_get_events_for_spec_files done");
     }
 
     /// Currently, the spec watcher will respond to changes to any
@@ -204,8 +201,6 @@ mod tests {
     /// to their final `*.spec` form.
     #[test]
     fn can_get_events_for_non_spec_files() {
-        env_logger::try_init().ok();
-        error!("can_get_events_for_non_spec_files starting");
         let _delay = lock_delay_var();
 
         let dir = TempDir::new().expect("Could not create directory");
@@ -225,13 +220,10 @@ mod tests {
 
         assert!(!sw.has_events(),
                 "Should be no more events after you've checked");
-        error!("can_get_events_for_non_spec_files done");
     }
 
     #[test]
     fn short_debounce_delays_also_work() {
-        env_logger::try_init().ok();
-        error!("short_debounce_delays_also_work starting");
         let delay = lock_delay_var();
         delay.set("1");
 
@@ -256,6 +248,5 @@ mod tests {
 
         assert!(!sw.has_events(),
                 "Should be no more events after you've checked");
-        error!("short_debounce_delays_also_work starting");
     }
 }

--- a/components/sup/src/manager/spec_watcher.rs
+++ b/components/sup/src/manager/spec_watcher.rs
@@ -13,23 +13,24 @@ use std::{sync::mpsc,
           thread::Builder,
           time::Duration};
 
-/// How long should we wait to consolidate filesystem events?
-///
-/// This should strike a balance between responsiveness and
-/// too-granular a series of events.
-///
-/// See https://docs.rs/notify/4.0.6/notify/trait.Watcher.html#tymethod.new
-habitat_core::env_config_duration!(SpecWatcherDelay,
-                                   HAB_SPEC_WATCHER_DELAY_MS => from_millis,
-                                   // There's nothing particularly magical about 2s, particularly
-                                   // since we're monitoring at such a coarse level ("something
-                                   // happened in this directory").
-                                   //
-                                   // Smaller is probably fine, but you wouldn't want to go much
-                                   // higher, as this could extend the amount of time you'd need
-                                   // to wait before realizing you need to take action on a
-                                   // service.
-                                   Duration::from_secs(2));
+habitat_core::env_config_duration!(
+    /// How long should we wait to consolidate filesystem events?
+    ///
+    /// This should strike a balance between responsiveness and
+    /// too-granular a series of events.
+    ///
+    /// See https://docs.rs/notify/4.0.6/notify/trait.Watcher.html#tymethod.new
+    SpecWatcherDelay,
+    HAB_SPEC_WATCHER_DELAY_MS => from_millis,
+    // There's nothing particularly magical about 2s, particularly
+    // since we're monitoring at such a coarse level ("something
+    // happened in this directory").
+    //
+    // Smaller is probably fine, but you wouldn't want to go much
+    // higher, as this could extend the amount of time you'd need
+    // to wait before realizing you need to take action on a
+    // service.
+    Duration::from_secs(2));
 
 // TODO (CM): A strong argument could be made for folding the
 // SpecWatcher functionality into SpecDir itself.


### PR DESCRIPTION
By switching away from `env_logger` to `log4rs`, we gain a lot of
configurability, including _dynamic_ configuration changes, allowing
us to selectively toggle log verbosity at runtime.

Out of the box, and without any additional configuration, logging will
behave largely as it does now. We will even honor `RUST_LOG`
environment variable-based configuration strings as a way to
transition users to the new logging system.

However, by adding a `/hab/sup/default/config/log.yml` configuration
file (whose format is detailed at
https://docs.rs/log4rs/0.8.3/log4rs/#configuration), users will be
able to greatly influence how logging is done.

A key feature to notice is that if the file contains a `refresh_rate`
key, then the file will be monitored for changes at runtime. There is
a caveat in the current default implementation, however; if the
Supervisor starts with a configuration file that does _not_ have a
`refresh_rate` key, then it will _never_ update the active
configuration based on changes to the file. Similarly, if you later
update the file and _remove_ the `refresh_rate` key, then monitoring
will _stop_ altogether. For now, if you want runtime monitoring, just
always have a `refresh_rate` present. We can change this in the
future, though; follow #6588 for details.

A basic, refreshing configuration file would look like this:

```yaml
refresh_rate: 5 seconds

appenders:
  stdout:
    kind: console
    encoder:
      pattern: "[{d(%Y-%m-%dT%H:%M:%SZ)(utc)} {l} {module}] {message}{n}"

root:
  level: error
  appenders:
    - stdout
```

To selectively filter on modules, add some `loggers` to that, like so:

```yaml
loggers:
  tokio_threadpool:
    level: trace
  habitat_sup::manager::service_updater:
    level: debug
```

Be sure to read the code comments for further details.

Fixes #6500
Fixes #6583

Signed-off-by: Christopher Maier <cmaier@chef.io>