### PR TITLE
Generate a unique NATS client id for event msgs

### DIFF
--- a/components/sup/src/event.rs
+++ b/components/sup/src/event.rs
@@ -66,8 +66,8 @@ pub fn init_stream(config: EventStreamConfig, event_core: EventCore) -> Result<(
     let mut return_value: Result<()> = Ok(());
 
     INIT.call_once(|| {
-            let conn_info = EventConnectionInfo::new(config.token, config.url,
-                                                     event_core.supervisor_id.clone());
+            let conn_info =
+                EventConnectionInfo::new(config.token, config.url, &event_core.supervisor_id);
             match stream_impl::init_stream(conn_info) {
                 Ok(event_stream) => {
                     EVENT_STREAM.set(event_stream);
@@ -120,7 +120,7 @@ pub struct EventConnectionInfo {
 }
 
 impl EventConnectionInfo {
-    pub fn new(auth_token: AutomateAuthToken, cluster_uri: String, supervisor_id: String) -> Self {
+    pub fn new(auth_token: AutomateAuthToken, cluster_uri: String, supervisor_id: &str) -> Self {
         EventConnectionInfo { name: format!("hab_client_{}", supervisor_id),
                               verbose: true,
                               cluster_uri,

--- a/components/sup/src/event.rs
+++ b/components/sup/src/event.rs
@@ -66,7 +66,8 @@ pub fn init_stream(config: EventStreamConfig, event_core: EventCore) -> Result<(
     let mut return_value: Result<()> = Ok(());
 
     INIT.call_once(|| {
-            let conn_info = EventConnectionInfo::new(config.token, config.url);
+            let conn_info = EventConnectionInfo::new(config.token, config.url,
+                                                     event_core.supervisor_id.clone());
             match stream_impl::init_stream(conn_info) {
                 Ok(event_stream) => {
                     EVENT_STREAM.set(event_stream);
@@ -119,8 +120,8 @@ pub struct EventConnectionInfo {
 }
 
 impl EventConnectionInfo {
-    pub fn new(auth_token: AutomateAuthToken, cluster_uri: String) -> Self {
-        EventConnectionInfo { name: "hab_client".to_string(),
+    pub fn new(auth_token: AutomateAuthToken, cluster_uri: String, supervisor_id: String) -> Self {
+        EventConnectionInfo { name: format!("hab_client_{}", supervisor_id),
                               verbose: true,
                               cluster_uri,
                               cluster_id: "event-service".to_string(),


### PR DESCRIPTION
After connecting one Habitat supervisor to Automate, all subsequent
connection attempts from Habitat fail with:
```
[2019-06-05T17:09:34Z ERROR ratsio::nats_client::client] NATS Server - Error - Permissions Violation for Publish to ".habitat"
```

This is happening because we hardcoded the client identifier used
to connect to the NATS Streaming server inside the Automate server.

From the NATS Streaming server [documentation](https://github.com/nats-io/nats-streaming-server#client-connections):
>As described, clients are not directly connected to the streaming
server. Instead, they send connection requests. The request includes
a client ID which is used by the server to uniquely identify, and
restrict, a given client. That is, no two connections with the same
client ID will be able to run concurrently.

This change is generating a unique client id composed by the keyword
**"hab_client_"** plus the supervisor id.

New client id example: `hab_client_4a5cb023f9274a8d9418bf5f974bdb52`

Related resource: https://chefio.atlassian.net/browse/A2-860

Signed-off-by: Salim Afiune <afiune@chef.io>