### PR TITLE
Add Builder provider interface

### DIFF
--- a/components/builder-api-client/src/builder.rs
+++ b/components/builder-api-client/src/builder.rs
@@ -1,0 +1,1145 @@
+use std::{fmt,
+          fs::{self,
+               File},
+          io::{self,
+               Read},
+          path::{Path,
+                 PathBuf},
+          string::ToString};
+
+use broadcast::BroadcastWriter;
+use hyper::{client::{Body,
+                     IntoUrl,
+                     RequestBuilder,
+                     Response},
+            header::{Accept,
+                     Authorization,
+                     Bearer,
+                     ContentType},
+            status::StatusCode,
+            Url};
+use tee::TeeReader;
+use url::percent_encoding::{percent_encode,
+                            PATH_SEGMENT_ENCODE_SET};
+
+use crate::{error::{Error,
+                    Result},
+            hab_core::{crypto::keys::box_key_pair::WrappedSealedBox,
+                       fs::AtomicWriter,
+                       package::{Identifiable,
+                                 PackageArchive,
+                                 PackageIdent,
+                                 PackageTarget},
+                       ChannelIdent},
+            hab_http::{util::decoded_response,
+                       ApiClient},
+            BuilderAPIProvider,
+            DisplayProgress,
+            OriginKeyIdent,
+            OriginSecret,
+            ReverseDependencies,
+            SchedulerResponse};
+
+header! { (XFileName, "X-Filename") => [String] }
+header! { (ETag, "ETag") => [String] }
+
+const DEFAULT_API_PATH: &str = "/v1";
+
+#[derive(Clone, Deserialize)]
+#[serde(rename = "error")]
+pub struct NetError {
+    pub code: i32,
+    pub msg:  String,
+}
+
+impl fmt::Display for NetError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "[err: {:?}, msg: {}]", self.code, self.msg)
+    }
+}
+
+/// Custom conversion logic to allow `serde` to successfully
+/// round-trip `u64` datatypes through JSON serialization.
+///
+/// To use it, add `#[serde(with = "json_u64")]` to any `u64`-typed struct
+/// fields.
+mod json_u64 {
+    use serde::{self,
+                Deserialize,
+                Deserializer,
+                Serializer};
+
+    #[allow(clippy::trivially_copy_pass_by_ref)]
+    pub fn serialize<S>(num: &u64, serializer: S) -> Result<S::Ok, S::Error>
+        where S: Serializer
+    {
+        let s = format!("{}", num);
+        serializer.serialize_str(&s)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<u64, D::Error>
+        where D: Deserializer<'de>
+    {
+        let s = String::deserialize(deserializer)?;
+        s.parse::<u64>().map_err(serde::de::Error::custom)
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug)]
+pub struct OriginPrivateSigningKey {
+    #[serde(with = "json_u64")]
+    pub id: u64,
+    #[serde(with = "json_u64")]
+    pub origin_id: u64,
+    pub name: String,
+    pub revision: String,
+    pub body: Vec<u8>,
+    #[serde(with = "json_u64")]
+    pub owner_id: u64,
+}
+
+mod json {
+    #[derive(Clone, Deserialize)]
+    pub struct Package {
+        pub ident:    PackageIdent,
+        pub checksum: String,
+        pub manifest: String,
+        pub deps:     Vec<PackageIdent>,
+        pub tdeps:    Vec<PackageIdent>,
+        pub exposes:  Vec<u32>,
+        pub config:   String,
+    }
+
+    #[derive(Clone, Deserialize)]
+    pub struct PackageIdent {
+        pub origin:  String,
+        pub name:    String,
+        pub version: String,
+        pub release: String,
+    }
+
+    impl From<PackageIdent> for super::PackageIdent {
+        fn from(ident: PackageIdent) -> Self {
+            super::PackageIdent { origin:  ident.origin,
+                                  name:    ident.name,
+                                  version: Some(ident.version),
+                                  release: Some(ident.release), }
+        }
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct PackageResults<T> {
+    pub range_start: isize,
+    pub range_end:   isize,
+    pub total_count: isize,
+    pub data:        Vec<T>,
+}
+
+#[derive(Clone, Deserialize)]
+pub struct OriginChannelIdent {
+    pub name: String,
+}
+
+pub struct BuilderAPIClient(ApiClient);
+
+impl BuilderAPIClient {
+    pub fn new<U>(endpoint: U,
+                  product: &str,
+                  version: &str,
+                  fs_root_path: Option<&Path>)
+                  -> Result<Self>
+        where U: IntoUrl
+    {
+        let mut endpoint = endpoint.into_url().map_err(Error::UrlParseError)?;
+        if !endpoint.cannot_be_a_base() && endpoint.path() == "/" {
+            endpoint.set_path(DEFAULT_API_PATH);
+        }
+        Ok(BuilderAPIClient(
+            ApiClient::new(endpoint, product, version, fs_root_path)
+                .map_err(Error::HabitatHttpClient)?,
+        ))
+    }
+
+    fn maybe_add_authz<'a>(&'a self,
+                           rb: RequestBuilder<'a>,
+                           token: Option<&str>)
+                           -> RequestBuilder<'_> {
+        if token.is_some() {
+            rb.header(Authorization(Bearer { token: token.unwrap().to_string(), }))
+        } else {
+            rb
+        }
+    }
+
+    fn add_authz<'a>(&'a self, rb: RequestBuilder<'a>, token: &str) -> RequestBuilder<'_> {
+        rb.header(Authorization(Bearer { token: token.to_string(), }))
+    }
+
+    fn download<'a>(&'a self,
+                    rb: RequestBuilder<'a>,
+                    dst_path: &Path,
+                    token: Option<&str>,
+                    progress: Option<<BuilderAPIClient as BuilderAPIProvider>::Progress>)
+                    -> Result<PathBuf> {
+        let mut res = self.maybe_add_authz(rb, token).send()?;
+
+        debug!("Response: {:?}", res);
+
+        if res.status != hyper::status::StatusCode::Ok {
+            return Err(err_from_response(res));
+        }
+
+        fs::create_dir_all(&dst_path)?;
+
+        let file_name = res.headers
+                           .get::<XFileName>()
+                           .expect("XFileName missing from response")
+                           .to_string();
+        let dst_file_path = dst_path.join(file_name);
+        let w = AtomicWriter::new(&dst_file_path)?;
+        w.with_writer(|mut f| {
+             match progress {
+                 Some(mut progress) => {
+                     let size: u64 = res.headers
+                                        .get::<hyper::header::ContentLength>()
+                                        .map_or(0, |v| **v);
+                     progress.size(size);
+                     let mut writer = BroadcastWriter::new(&mut f, progress);
+                     io::copy(&mut res, &mut writer)
+                 }
+                 None => io::copy(&mut res, &mut f),
+             }
+         })
+         .map_err(Error::BadResponseBody)?;
+        Ok(dst_file_path)
+    }
+}
+
+impl BuilderAPIProvider for BuilderAPIClient {
+    type Progress = Box<dyn DisplayProgress>;
+
+    /// Retrieves the status of every group job in an origin
+    ///
+    /// # Failures
+    ///
+    /// * Remote Builder is not available
+    fn get_origin_schedule(&self, origin: &str, limit: usize) -> Result<Vec<SchedulerResponse>> {
+        debug!("Retrieving status for job groups in the {} origin", origin);
+
+        let path = format!("depot/pkgs/schedule/{}/status", origin);
+
+        let custom = |url: &mut Url| {
+            url.query_pairs_mut()
+               .append_pair("limit", &limit.to_string());
+        };
+
+        let res = self.0.get_with_custom_url(&path, custom).send()?;
+
+        if res.status != StatusCode::Ok {
+            return Err(err_from_response(res));
+        }
+
+        let sr: Vec<SchedulerResponse> = decoded_response(res)?;
+        Ok(sr)
+    }
+
+    /// Retrieves the status of a group job
+    ///
+    /// # Failures
+    ///
+    /// * Remote Builder is not available
+    fn get_schedule(&self, group_id: i64, include_projects: bool) -> Result<SchedulerResponse> {
+        debug!("Retrieving schedule for job group {}", group_id);
+
+        let path = format!("depot/pkgs/schedule/{}", group_id);
+
+        let custom = |url: &mut Url| {
+            url.query_pairs_mut()
+               .append_pair("include_projects", &include_projects.to_string());
+        };
+
+        let res = self.0.get_with_custom_url(&path, custom).send()?;
+
+        if res.status != StatusCode::Ok {
+            return Err(err_from_response(res));
+        }
+
+        let sr: SchedulerResponse = decoded_response(res)?;
+        Ok(sr)
+    }
+
+    /// Schedules a job for a package ident
+    ///
+    /// # Failures
+    ///
+    /// * Key cannot be found
+    /// * Remote Builder is not available
+    fn schedule_job(&self,
+                    (ident, target): (&PackageIdent, PackageTarget),
+                    package_only: bool,
+                    token: &str)
+                    -> Result<(String)> {
+        let path = format!("depot/pkgs/schedule/{}/{}", ident.origin(), ident.name());
+
+        let custom = |url: &mut Url| {
+            url.query_pairs_mut()
+               .append_pair("package_only", &package_only.to_string())
+               .append_pair("target", &target.to_string());
+        };
+
+        match self.add_authz(self.0.post_with_custom_url(&path, custom), token)
+                  .send()
+        {
+            Ok(response) => {
+                if response.status == StatusCode::Created || response.status == StatusCode::Ok {
+                    let sr: SchedulerResponse = decoded_response(response)?;
+                    Ok(sr.id)
+                } else {
+                    Err(err_from_response(response))
+                }
+            }
+            Err(e) => Err(Error::from(e)),
+        }
+    }
+
+    /// Fetch the reverse dependencies for a package
+    ///
+    /// # Failures
+    ///
+    /// * Remote API Server is not available
+    fn fetch_rdeps(&self, (ident, target): (&PackageIdent, PackageTarget)) -> Result<Vec<String>> {
+        debug!("Fetching the reverse dependencies for {}", ident);
+
+        let url = format!("rdeps/{}", ident);
+
+        let mut res = self.0
+                          .get_with_custom_url(&url, |u| {
+                              u.set_query(Some(&format!("target={}", &target.to_string())))
+                          })
+                          .send()
+                          .map_err(Error::HyperError)?;
+
+        if res.status != StatusCode::Ok {
+            return Err(err_from_response(res));
+        }
+
+        let mut encoded = String::new();
+        res.read_to_string(&mut encoded).map_err(Error::IO)?;
+        debug!("Body: {:?}", encoded);
+        let rd: ReverseDependencies = serde_json::from_str(&encoded).map_err(Error::Json)?;
+        Ok(rd.rdeps.to_vec())
+    }
+
+    /// Promote/Demote a job group to/from a channel
+    ///
+    /// # Failures
+    ///
+    /// * Remote API Server is not available
+    fn job_group_promote_or_demote(&self,
+                                   group_id: u64,
+                                   idents: &[String],
+                                   channel: &ChannelIdent,
+                                   token: &str,
+                                   promote: bool)
+                                   -> Result<()> {
+        let json_idents = json!(idents);
+        let body = json!({ "idents": json_idents });
+        let sbody = serde_json::to_string(&body).unwrap();
+        let url = format!("jobs/group/{}/{}/{}",
+                          group_id,
+                          if promote { "promote" } else { "demote" },
+                          channel);
+        let res = self.add_authz(self.0.post(&url), token)
+                      .body(&sbody)
+                      .header(Accept::json())
+                      .header(ContentType::json())
+                      .send()
+                      .map_err(Error::HyperError)?;
+
+        if res.status != StatusCode::NoContent {
+            debug!("Failed to {} group, status: {:?}",
+                   if promote { "promote" } else { "demote" },
+                   res.status);
+            return Err(err_from_response(res));
+        }
+
+        Ok(())
+    }
+
+    /// Cancel a job group
+    ///
+    /// # Failures
+    ///
+    /// * Remote API Server is not available
+    fn job_group_cancel(&self, group_id: u64, token: &str) -> Result<()> {
+        let url = format!("jobs/group/{}/cancel", group_id);
+        let res = self.add_authz(self.0.post(&url), token)
+                      .send()
+                      .map_err(Error::HyperError)?;
+
+        if res.status != StatusCode::NoContent {
+            debug!("Failed to cancel group, status: {:?}", res.status);
+            return Err(err_from_response(res));
+        }
+
+        Ok(())
+    }
+
+    /// Download a public encryption key from a remote Builder to the given filepath.
+    ///
+    /// # Failures
+    ///
+    /// * Key cannot be found
+    /// * Remote Builder is not available
+    /// * File cannot be created and written to
+    fn fetch_origin_public_encryption_key(&self,
+                                          origin: &str,
+                                          token: &str,
+                                          dst_path: &Path,
+                                          progress: Option<Self::Progress>)
+                                          -> Result<PathBuf> {
+        self.download(self.0
+                          .get(&format!("depot/origins/{}/encryption_key", origin)),
+                      dst_path.as_ref(),
+                      Some(token),
+                      progress)
+    }
+
+    /// Create secret for an origin
+    ///
+    /// # Failures
+    ///
+    /// * Remote Builder is not available
+    fn create_origin_secret(&self,
+                            origin: &str,
+                            token: &str,
+                            key: &str,
+                            secret: &WrappedSealedBox)
+                            -> Result<()> {
+        let path = format!("depot/origins/{}/secret", origin);
+        let body = json!({
+            "name": key,
+            "value": secret
+        });
+
+        let sbody = serde_json::to_string(&body)?;
+        let res = self.add_authz(self.0.post(&path), token)
+                      .body(&sbody)
+                      .header(Accept::json())
+                      .header(ContentType::json())
+                      .send()?;
+
+        if res.status != StatusCode::Created {
+            return Err(err_from_response(res));
+        }
+
+        Ok(())
+    }
+
+    /// Delete a secret for an origin
+    ///
+    /// # Failures
+    ///
+    /// * Remote Builder is not available
+    fn delete_origin_secret(&self, origin: &str, token: &str, key: &str) -> Result<()> {
+        let path = format!("depot/origins/{}/secret/{}", origin, key);
+
+        let res = self.add_authz(self.0.delete(&path), token).send()?;
+
+        // We expect NoContent, because the origin must be empty to delete
+        if res.status == StatusCode::NoContent {
+            Ok(())
+        } else {
+            Err(err_from_response(res))
+        }
+    }
+
+    /// Delete an origin
+    ///
+    ///  # Failures
+    ///
+    ///  * Remote builder is not available
+    ///  * Origin is populated with > 0 packages
+    ///  * Submitted Origin is not found
+    fn delete_origin(&self, origin: &str, token: &str) -> Result<()> {
+        let path = format!("depot/origins/{}", origin);
+
+        let res = self.add_authz(self.0.delete(&path), token).send()?;
+
+        if res.status != StatusCode::NoContent {
+            return Err(err_from_response(res));
+        }
+
+        Ok(())
+    }
+
+    /// List all secrets keys for an origin
+    ///
+    /// # Failures
+    ///
+    /// * Remote Builder is not available
+    fn list_origin_secrets(&self, origin: &str, token: &str) -> Result<Vec<String>> {
+        let path = format!("depot/origins/{}/secret", origin);
+
+        let mut res = self.add_authz(self.0.get(&path), token).send()?;
+
+        if res.status != StatusCode::Ok {
+            return Err(err_from_response(res));
+        }
+
+        let mut encoded = String::new();
+        res.read_to_string(&mut encoded)
+           .map_err(Error::BadResponseBody)?;
+        debug!("Response body: {:?}", encoded);
+        let secret_keys: Vec<String> =
+            serde_json::from_str::<Vec<OriginSecret>>(&encoded)?.into_iter()
+                                                                .map(|s| s.name)
+                                                                .collect();
+        Ok(secret_keys)
+    }
+
+    /// Download a public key from a remote Builder to the given filepath.
+    ///
+    /// # Failures
+    ///
+    /// * Key cannot be found
+    /// * Remote Builder is not available
+    /// * File cannot be created and written to
+    fn fetch_origin_key(&self,
+                        origin: &str,
+                        revision: &str,
+                        dst_path: &Path,
+                        progress: Option<Self::Progress>)
+                        -> Result<PathBuf> {
+        self.download(self.0
+                          .get(&format!("depot/origins/{}/keys/{}", origin, revision)),
+                      dst_path.as_ref(),
+                      None,
+                      progress)
+    }
+
+    /// Download a secret key from a remote Builder to the given filepath.
+    ///
+    /// # Failures
+    ///
+    /// * Key cannot be found
+    /// * Remote Builder is not available
+    /// * File cannot be created and written to
+    fn fetch_secret_origin_key(&self,
+                               origin: &str,
+                               token: &str,
+                               dst_path: &Path,
+                               progress: Option<Self::Progress>)
+                               -> Result<PathBuf> {
+        self.download(self.0
+                          .get(&format!("depot/origins/{}/secret_keys/latest", origin)),
+                      dst_path.as_ref(),
+                      Some(token),
+                      progress)
+    }
+
+    fn show_origin_keys(&self, origin: &str) -> Result<Vec<OriginKeyIdent>> {
+        let mut res = self.0.get(&origin_keys_path(origin)).send()?;
+        debug!("Response: {:?}", res);
+
+        if res.status != StatusCode::Ok {
+            return Err(err_from_response(res));
+        };
+
+        let mut encoded = String::new();
+        res.read_to_string(&mut encoded)
+           .map_err(Error::BadResponseBody)?;
+        debug!("Response body: {:?}", encoded);
+        let revisions: Vec<OriginKeyIdent> = serde_json::from_str::<Vec<OriginKeyIdent>>(&encoded)?;
+        Ok(revisions)
+    }
+
+    /// Return a list of channels for a given package
+    ///
+    /// # Failures
+    ///
+    /// * Remote Builder is not available
+    /// * Package does not exist
+    fn package_channels(&self,
+                        (ident, target): (&PackageIdent, PackageTarget),
+                        token: Option<&str>)
+                        -> Result<Vec<String>> {
+        if !ident.fully_qualified() {
+            return Err(Error::IdentNotFullyQualified);
+        }
+
+        let path = package_channels_path(ident);
+        debug!("Retrieving channels for {}, target {}", ident, target);
+
+        let custom = |url: &mut Url| {
+            url.query_pairs_mut()
+               .append_pair("target", &target.to_string());
+        };
+
+        let mut res = self.maybe_add_authz(self.0.get_with_custom_url(&path, custom), token)
+                          .send()?;
+
+        if res.status != StatusCode::Ok {
+            return Err(err_from_response(res));
+        }
+
+        let mut encoded = String::new();
+        res.read_to_string(&mut encoded)
+           .map_err(Error::BadResponseBody)?;
+        debug!("Response body: {:?}", encoded);
+        let channels: Vec<String> = serde_json::from_str::<Vec<String>>(&encoded)?.into_iter()
+                                                                                  .collect();
+        Ok(channels)
+    }
+
+    /// Upload a public origin key to a remote Builder.
+    ///
+    /// # Failures
+    ///
+    /// * Remote Builder is not available
+    /// * File cannot be read
+    ///
+    /// # Panics
+    ///
+    /// * Authorization token was not set on client
+    fn put_origin_key(&self,
+                      origin: &str,
+                      revision: &str,
+                      src_path: &Path,
+                      token: &str,
+                      progress: Option<Self::Progress>)
+                      -> Result<()> {
+        let path = format!("depot/origins/{}/keys/{}", &origin, &revision);
+        let mut file =
+            File::open(src_path).map_err(|e| Error::KeyReadError(src_path.to_path_buf(), e))?;
+        let file_size = file.metadata()
+                            .map_err(|e| Error::KeyReadError(src_path.to_path_buf(), e))?
+                            .len();
+
+        let result = if let Some(mut progress) = progress {
+            progress.size(file_size);
+            let mut reader = TeeReader::new(file, progress);
+            self.add_authz(self.0.post(&path), token)
+                .body(Body::SizedBody(&mut reader, file_size))
+                .send()
+        } else {
+            self.add_authz(self.0.post(&path), token)
+                .body(Body::SizedBody(&mut file, file_size))
+                .send()
+        };
+        match result {
+            Ok(Response { status: StatusCode::Created,
+                          .. }) => Ok(()),
+            Ok(response) => Err(err_from_response(response)),
+            Err(e) => Err(Error::from(e)),
+        }
+    }
+
+    /// Upload a secret origin key to a remote Builder.
+    ///
+    /// # Failures
+    ///
+    /// * Remote Builder is not available
+    /// * File cannot be read
+    ///
+    /// # Panics
+    ///
+    /// * Authorization token was not set on client
+    fn put_origin_secret_key(&self,
+                             origin: &str,
+                             revision: &str,
+                             src_path: &Path,
+                             token: &str,
+                             progress: Option<Self::Progress>)
+                             -> Result<()> {
+        let path = format!("depot/origins/{}/secret_keys/{}", &origin, &revision);
+        let mut file =
+            File::open(src_path).map_err(|e| Error::KeyReadError(src_path.to_path_buf(), e))?;
+        let file_size = file.metadata()
+                            .map_err(|e| Error::KeyReadError(src_path.to_path_buf(), e))?
+                            .len();
+
+        let result = if let Some(mut progress) = progress {
+            progress.size(file_size);
+            let mut reader = TeeReader::new(file, progress);
+            self.add_authz(self.0.post(&path), token)
+                .body(Body::SizedBody(&mut reader, file_size))
+                .send()
+        } else {
+            self.add_authz(self.0.post(&path), token)
+                .body(Body::SizedBody(&mut file, file_size))
+                .send()
+        };
+        match result {
+            Ok(Response { status: StatusCode::Created,
+                          .. }) => Ok(()),
+            Ok(response) => Err(err_from_response(response)),
+            Err(e) => Err(Error::from(e)),
+        }
+    }
+
+    /// Download the latest release of a package.
+    ///
+    /// By the time this function is called, the ident must be fully qualified. The download URL in
+    /// the depot requires a fully qualified ident to work. If you want the latest version of
+    /// a package, e.g. core/redis, you can display package details for that via a different URL,
+    /// e.g. /pkgs/core/redis/latest but that only _shows_ you the details - it doesn't download
+    /// the package.
+    ///
+    /// # Failures
+    ///
+    /// * Package cannot be found
+    /// * Remote Builder is not available
+    /// * File cannot be created and written to
+    fn fetch_package(&self,
+                     (ident, target): (&PackageIdent, PackageTarget),
+                     token: Option<&str>,
+                     dst_path: &Path,
+                     progress: Option<Self::Progress>)
+                     -> Result<PackageArchive> {
+        // Ensure ident is fully qualified.
+        //
+        // TODO fn: this will be removed when we can describe a fully qualified ident by type as a
+        // param to this function
+        if !ident.fully_qualified() {
+            return Err(Error::IdentNotFullyQualified);
+        }
+
+        let req_builder = self.0.get_with_custom_url(&package_download(ident), |u| {
+                                    u.set_query(Some(&format!("target={}", target)))
+                                });
+
+        match self.download(req_builder, dst_path.as_ref(), token, progress) {
+            Ok(file) => Ok(PackageArchive::new(file)),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Returns a package struct for the latest package.
+    ///
+    /// An optional version can be specified which will scope the release returned to the latest
+    /// release of that package.
+    ///
+    /// # Failures
+    ///
+    /// * Package cannot be found
+    /// * Remote Builder is not available
+    fn show_package(&self,
+                    (package, target): (&PackageIdent, PackageTarget),
+                    channel: &ChannelIdent,
+                    token: Option<&str>)
+                    -> Result<PackageIdent> {
+        let mut url = channel_package_path(channel, package);
+
+        if !package.fully_qualified() {
+            url.push_str("/latest");
+        }
+
+        let mut res = self.maybe_add_authz(self.0
+                                               .get_with_custom_url(&url, |u| {
+                                                   u.set_query(Some(&format!("target={}", target)))
+                                               }),
+                                           token)
+                          .send()?;
+
+        if res.status != StatusCode::Ok {
+            return Err(err_from_response(res));
+        }
+
+        let mut encoded = String::new();
+        res.read_to_string(&mut encoded)
+           .map_err(Error::BadResponseBody)?;
+        debug!("Body: {:?}", encoded);
+        let package: json::Package = serde_json::from_str::<json::Package>(&encoded)?;
+        Ok(package.ident.into())
+    }
+
+    /// Upload a package to a remote Builder.
+    ///
+    /// # Failures
+    ///
+    /// * Remote Builder is not available
+    /// * File cannot be read
+    ///
+    /// # Panics
+    ///
+    /// * Authorization token was not set on client
+    fn put_package(&self,
+                   pa: &mut PackageArchive,
+                   token: &str,
+                   force_upload: bool,
+                   progress: Option<Self::Progress>)
+                   -> Result<()> {
+        let checksum = pa.checksum()?;
+        let ident = pa.ident()?;
+        let target = pa.target()?;
+
+        let file = File::open(&pa.path).map_err(|e| Error::PackageReadError(pa.path.clone(), e))?;
+        let file_size = file.metadata()
+                            .map_err(|e| Error::PackageReadError(pa.path.clone(), e))?
+                            .len();
+
+        let path = package_path(&ident);
+
+        let custom = |url: &mut Url| {
+            url.query_pairs_mut()
+               .append_pair("checksum", &checksum)
+               .append_pair("target", &target.to_string())
+               .append_pair("forced", &force_upload.to_string());
+        };
+        debug!("Reading from {}", &pa.path.display());
+
+        let mut reader: Box<dyn Read> = if let Some(mut progress) = progress {
+            progress.size(file_size);
+            Box::new(TeeReader::new(file, progress))
+        } else {
+            Box::new(file)
+        };
+
+        let result = self.add_authz(self.0.post_with_custom_url(&path, custom), token)
+                         .body(Body::SizedBody(&mut reader, file_size))
+                         .send();
+
+        match result {
+            Ok(Response { status: StatusCode::Created,
+                          .. }) => Ok(()),
+            Ok(response) => Err(err_from_response(response)),
+            Err(e) => Err(Error::from(e)),
+        }
+    }
+
+    fn x_put_package(&self, pa: &mut PackageArchive, token: &str) -> Result<()> {
+        let checksum = pa.checksum()?;
+        let ident = pa.ident()?;
+        let target = pa.target()?;
+
+        let mut file =
+            File::open(&pa.path).map_err(|e| Error::PackageReadError(pa.path.clone(), e))?;
+        let file_size = file.metadata()
+                            .map_err(|e| Error::PackageReadError(pa.path.clone(), e))?
+                            .len();
+        let path = package_path(&ident);
+        let custom = |url: &mut Url| {
+            url.query_pairs_mut()
+               .append_pair("checksum", &checksum)
+               .append_pair("target", &target.to_string())
+               .append_pair("builder", "");
+        };
+        debug!("Reading from {}", &pa.path.display());
+
+        let result = self.add_authz(self.0.post_with_custom_url(&path, custom), token)
+                         .body(Body::SizedBody(&mut file, file_size))
+                         .send();
+        match result {
+            Ok(Response { status: StatusCode::Created,
+                          .. }) => Ok(()),
+            Ok(response) => Err(err_from_response(response)),
+            Err(e) => Err(Error::from(e)),
+        }
+    }
+
+    /// Delete a package from Builder
+    ///
+    /// # Failures
+    ///
+    /// * Remote Builder is not available
+    /// * If package does not exist in Builder
+    /// * If the package does not qualify for deletion
+    /// * Authorization token was not set on client
+    fn delete_package(&self,
+                      (ident, target): (&PackageIdent, PackageTarget),
+                      token: &str)
+                      -> Result<()> {
+        let path = package_path(ident);
+        debug!("Deleting package {}, target {}", ident, target);
+
+        let custom = |url: &mut Url| {
+            url.query_pairs_mut()
+               .append_pair("target", &target.to_string());
+        };
+
+        let res = self.add_authz(self.0.delete_with_custom_url(&path, custom), token)
+                      .send()?;
+
+        if res.status != StatusCode::NoContent {
+            return Err(err_from_response(res));
+        };
+
+        Ok(())
+    }
+
+    /// Promote a package to a given channel
+    ///
+    /// # Failures
+    ///
+    /// * Remote Builder is not available
+    ///
+    /// # Panics
+    ///
+    /// * If package does not exist in Builder
+    /// * Authorization token was not set on client
+    fn promote_package(&self,
+                       (ident, target): (&PackageIdent, PackageTarget),
+                       channel: &ChannelIdent,
+                       token: &str)
+                       -> Result<()> {
+        if !ident.fully_qualified() {
+            return Err(Error::IdentNotFullyQualified);
+        }
+        let path = channel_package_promote(channel, ident);
+        debug!("Promoting package {}, target {}", ident, target);
+
+        let custom = |url: &mut Url| {
+            url.query_pairs_mut()
+               .append_pair("target", &target.to_string());
+        };
+
+        let res = self.add_authz(self.0.put_with_custom_url(&path, custom), token)
+                      .send()?;
+
+        if res.status != StatusCode::Ok {
+            return Err(err_from_response(res));
+        };
+
+        Ok(())
+    }
+
+    /// Demote a package from a given channel
+    ///
+    /// # Failures
+    ///
+    /// * Remote Builder is not available
+    ///
+    /// # Panics
+    ///
+    /// * If package does not exist in Builder
+    /// * Authorization token was not set on client
+    fn demote_package(&self,
+                      (ident, target): (&PackageIdent, PackageTarget),
+                      channel: &ChannelIdent,
+                      token: &str)
+                      -> Result<()> {
+        if !ident.fully_qualified() {
+            return Err(Error::IdentNotFullyQualified);
+        }
+        let path = channel_package_demote(channel, ident);
+        debug!("Demoting package {}, target {}", ident, target);
+
+        let custom = |url: &mut Url| {
+            url.query_pairs_mut()
+               .append_pair("target", &target.to_string());
+        };
+
+        let res = self.add_authz(self.0.put_with_custom_url(&path, custom), token)
+                      .send()?;
+
+        if res.status != StatusCode::Ok {
+            return Err(err_from_response(res));
+        };
+
+        Ok(())
+    }
+
+    /// Create a custom channel
+    ///
+    /// # Failures
+    ///
+    /// * Remote Builder is not available
+    fn create_channel(&self, origin: &str, channel: &ChannelIdent, token: &str) -> Result<()> {
+        let path = format!("depot/channels/{}/{}", origin, channel);
+        debug!("Creating channel, path: {:?}", path);
+
+        let res = self.add_authz(self.0.post(&path), token).send()?;
+
+        if res.status != StatusCode::Created {
+            return Err(err_from_response(res));
+        };
+
+        Ok(())
+    }
+
+    /// Delete a custom channel
+    ///
+    /// # Failures
+    ///
+    /// * Remote Builder is not available
+    fn delete_channel(&self, origin: &str, channel: &ChannelIdent, token: &str) -> Result<()> {
+        let path = format!("depot/channels/{}/{}", origin, channel);
+        debug!("Deleting channel, path: {:?}", path);
+
+        let res = self.add_authz(self.0.delete(&path), token).send()?;
+
+        if res.status != StatusCode::Ok {
+            return Err(err_from_response(res));
+        };
+
+        Ok(())
+    }
+
+    /// Returns a vector of PackageIdent structs
+    ///
+    /// # Failures
+    ///
+    /// * Remote depot unavailable
+    fn search_package(&self,
+                      search_term: &str,
+                      token: Option<&str>)
+                      -> Result<(Vec<PackageIdent>, bool)> {
+        let mut res = self.maybe_add_authz(self.0.get(&package_search(search_term)), token)
+                          .send()?;
+        match res.status {
+            StatusCode::Ok | StatusCode::PartialContent => {
+                let mut encoded = String::new();
+                res.read_to_string(&mut encoded)
+                   .map_err(Error::BadResponseBody)?;
+                let package_results: PackageResults<PackageIdent> = serde_json::from_str(&encoded)?;
+                let packages: Vec<PackageIdent> = package_results.data;
+                Ok((packages, res.status == StatusCode::PartialContent))
+            }
+            _ => Err(err_from_response(res)),
+        }
+    }
+
+    /// Return a list of channels for a given origin
+    ///
+    /// # Failures
+    /// * Remote Builder is not available
+    /// * Authorization token was not set on client
+    fn list_channels(&self, origin: &str, include_sandbox_channels: bool) -> Result<Vec<String>> {
+        let path = format!("depot/channels/{}", origin);
+        let mut res = if include_sandbox_channels {
+            self.0
+                .get_with_custom_url(&path, |url| url.set_query(Some("sandbox=true")))
+                .send()?
+        } else {
+            self.0.get(&path).send()?
+        };
+
+        match res.status {
+            StatusCode::Ok | StatusCode::PartialContent => {
+                let mut encoded = String::new();
+                res.read_to_string(&mut encoded)
+                   .map_err(Error::BadResponseBody)?;
+                let results: Vec<OriginChannelIdent> = serde_json::from_str(&encoded)?;
+                let channels = results.into_iter().map(|o| o.name).collect();
+                Ok(channels)
+            }
+            _ => Err(err_from_response(res)),
+        }
+    }
+}
+
+fn err_from_response(mut response: hyper::client::Response) -> Error {
+    if response.status == StatusCode::Unauthorized {
+        return Error::APIError(response.status,
+                               "Please check that you have specified a valid Personal Access \
+                                Token."
+                                       .to_string());
+    }
+
+    let mut buff = String::new();
+    match response.read_to_string(&mut buff) {
+        Ok(_) => {
+            match serde_json::from_str::<NetError>(&buff) {
+                Ok(err) => Error::APIError(response.status, err.to_string()),
+                Err(_) => Error::APIError(response.status, buff),
+            }
+        }
+        Err(_) => {
+            buff.truncate(0);
+            Error::APIError(response.status, buff)
+        }
+    }
+}
+
+fn origin_keys_path(origin: &str) -> String { format!("depot/origins/{}/keys", origin) }
+
+fn package_download(package: &PackageIdent) -> String {
+    format!("{}/download", package_path(package))
+}
+
+fn package_path(package: &PackageIdent) -> String { format!("depot/pkgs/{}", package) }
+
+fn package_search(term: &str) -> String {
+    let encoded_term = percent_encode(term.as_bytes(), PATH_SEGMENT_ENCODE_SET);
+    format!("depot/pkgs/search/{}", encoded_term)
+}
+
+fn channel_package_path(channel: &ChannelIdent, package: &PackageIdent) -> String {
+    let mut path = format!("depot/channels/{}/{}/pkgs/{}",
+                           package.origin(),
+                           channel,
+                           package.name());
+    if let Some(version) = package.version() {
+        path.push_str("/");
+        path.push_str(version);
+        if let Some(release) = package.release() {
+            path.push_str("/");
+            path.push_str(release);
+        }
+    }
+    path
+}
+
+fn package_channels_path(package: &PackageIdent) -> String {
+    format!("depot/pkgs/{}/{}/{}/{}/channels",
+            package.origin(),
+            package.name(),
+            package.version().unwrap(),
+            package.release().unwrap())
+}
+
+fn channel_package_promote(channel: &ChannelIdent, package: &PackageIdent) -> String {
+    format!("depot/channels/{}/{}/pkgs/{}/{}/{}/promote",
+            package.origin(),
+            channel,
+            package.name(),
+            package.version().unwrap(),
+            package.release().unwrap())
+}
+
+fn channel_package_demote(channel: &ChannelIdent, package: &PackageIdent) -> String {
+    format!("depot/channels/{}/{}/pkgs/{}/{}/{}/demote",
+            package.origin(),
+            channel,
+            package.name(),
+            package.version().unwrap(),
+            package.release().unwrap())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json;
+
+    #[test]
+    fn json_round_trip_u64_fields() {
+        let pre = OriginPrivateSigningKey { id:        705_705_315_793_903_646,
+                                            origin_id: 705_705_305_031_319_582,
+                                            name:      "core".to_string(),
+                                            revision:  "20160810182414".to_string(),
+                                            body:      vec![1, 2, 3],
+                                            owner_id:  0, };
+
+        let as_json = serde_json::to_value(&pre).unwrap();
+        let expected = json!({
+            "id": "705705315793903646",
+            "origin_id": "705705305031319582",
+            "name": "core",
+            "revision": "20160810182414",
+            "body": [
+                1,
+                2,
+                3
+            ],
+            "owner_id": "0"
+        });
+        assert_eq!(as_json, expected);
+
+        let post: OriginPrivateSigningKey = serde_json::from_value(as_json).unwrap();
+        assert_eq!(pre.id, post.id);
+        assert_eq!(pre.origin_id, post.origin_id);
+        assert_eq!(pre.owner_id, post.owner_id);
+    }
+}

--- a/components/builder-api-client/src/lib.rs
+++ b/components/builder-api-client/src/lib.rs
@@ -6,56 +6,42 @@ extern crate hyper;
 #[macro_use]
 extern crate log;
 
-use serde;
 #[macro_use]
 extern crate serde_derive;
 #[allow(unused_imports)]
 #[macro_use]
 extern crate serde_json;
 
+pub mod builder;
 pub mod error;
+
+use std::{fmt,
+          io::Write,
+          path::{Path,
+                 PathBuf}};
+
+use chrono::DateTime;
+use hyper::client::IntoUrl;
+
 pub use crate::error::{Error,
                        Result};
 
-use std::{fmt,
-          fs::{self,
-               File},
-          io::{self,
-               Read,
-               Write},
-          path::{Path,
-                 PathBuf},
-          string::ToString};
-
-use crate::{hab_core::{crypto::keys::box_key_pair::WrappedSealedBox,
-                       fs::AtomicWriter,
-                       package::{Identifiable,
-                                 PackageArchive,
+use crate::{builder::BuilderAPIClient,
+            hab_core::{crypto::keys::box_key_pair::WrappedSealedBox,
+                       package::{PackageArchive,
                                  PackageIdent,
                                  PackageTarget},
-                       ChannelIdent},
-            hab_http::{util::decoded_response,
-                       ApiClient}};
-use broadcast::BroadcastWriter;
-use chrono::DateTime;
-use hyper::{client::{Body,
-                     IntoUrl,
-                     RequestBuilder,
-                     Response},
-            header::{Accept,
-                     Authorization,
-                     Bearer,
-                     ContentType},
-            status::StatusCode,
-            Url};
-use tee::TeeReader;
-use url::percent_encoding::{percent_encode,
-                            PATH_SEGMENT_ENCODE_SET};
+                       ChannelIdent}};
 
 header! { (XFileName, "X-Filename") => [String] }
 header! { (ETag, "ETag") => [String] }
 
 const DEFAULT_API_PATH: &str = "/v1";
+
+pub trait DisplayProgress: Write {
+    fn size(&mut self, size: u64);
+    fn finish(&mut self);
+}
 
 #[derive(Clone, Deserialize)]
 #[serde(rename = "error")]
@@ -70,13 +56,6 @@ impl fmt::Display for NetError {
     }
 }
 
-#[derive(Clone, Deserialize)]
-pub struct OriginKeyIdent {
-    pub origin:   String,
-    pub revision: String,
-    pub location: String,
-}
-
 #[derive(Clone, Default, Deserialize)]
 pub struct Project {
     pub name:   String,
@@ -84,14 +63,6 @@ pub struct Project {
     pub state:  String,
     pub job_id: String,
     pub target: String,
-}
-
-#[derive(Clone, Deserialize)]
-pub struct OriginSecret {
-    pub id:        String,
-    pub origin_id: String,
-    pub name:      String,
-    pub value:     String,
 }
 
 impl fmt::Display for Project {
@@ -142,19 +113,6 @@ impl fmt::Display for SchedulerResponse {
 
         write!(f, "{}", output.join("\n"))
     }
-}
-
-#[derive(Deserialize)]
-pub struct ReverseDependencies {
-    pub origin: String,
-    pub name:   String,
-    pub rdeps:  Vec<String>,
-}
-
-#[derive(Default, Deserialize)]
-pub struct JobGroupPromoteResponse {
-    pub group_id:     String,
-    pub not_promoted: Vec<PackageIdent>,
 }
 
 /// Custom conversion logic to allow `serde` to successfully
@@ -240,1047 +198,182 @@ pub struct OriginChannelIdent {
     pub name: String,
 }
 
-pub trait DisplayProgress: Write {
-    fn size(&mut self, size: u64);
-    fn finish(&mut self);
+#[derive(Clone, Deserialize)]
+pub struct OriginSecret {
+    pub id:        String,
+    pub origin_id: String,
+    pub name:      String,
+    pub value:     String,
 }
 
-pub struct Client(ApiClient);
+#[derive(Clone, Deserialize)]
+pub struct OriginKeyIdent {
+    pub origin:   String,
+    pub revision: String,
+    pub location: String,
+}
+
+#[derive(Deserialize)]
+pub struct ReverseDependencies {
+    pub origin: String,
+    pub name:   String,
+    pub rdeps:  Vec<String>,
+}
+
+pub trait BuilderAPIProvider: Sync + Send {
+    type Progress;
+
+    fn get_origin_schedule(&self, origin: &str, limit: usize) -> Result<Vec<SchedulerResponse>>;
+
+    fn get_schedule(&self, group_id: i64, include_projects: bool) -> Result<SchedulerResponse>;
+
+    fn schedule_job(&self,
+                    ident_and_target: (&PackageIdent, PackageTarget),
+                    package_only: bool,
+                    token: &str)
+                    -> Result<(String)>;
+
+    fn fetch_rdeps(&self, ident_and_target: (&PackageIdent, PackageTarget)) -> Result<Vec<String>>;
+
+    fn job_group_promote_or_demote(&self,
+                                   group_id: u64,
+                                   idents: &[String],
+                                   channel: &ChannelIdent,
+                                   token: &str,
+                                   promote: bool)
+                                   -> Result<()>;
+
+    fn job_group_cancel(&self, group_id: u64, token: &str) -> Result<()>;
+
+    fn fetch_origin_public_encryption_key(&self,
+                                          origin: &str,
+                                          token: &str,
+                                          dst_path: &Path,
+                                          progress: Option<Self::Progress>)
+                                          -> Result<PathBuf>;
+
+    fn create_origin_secret(&self,
+                            origin: &str,
+                            token: &str,
+                            key: &str,
+                            secret: &WrappedSealedBox)
+                            -> Result<()>;
+
+    fn delete_origin_secret(&self, origin: &str, token: &str, key: &str) -> Result<()>;
+
+    fn delete_origin(&self, origin: &str, token: &str) -> Result<()>;
+
+    fn list_origin_secrets(&self, origin: &str, token: &str) -> Result<Vec<String>>;
+
+    fn put_package(&self,
+                   pa: &mut PackageArchive,
+                   token: &str,
+                   force_upload: bool,
+                   progress: Option<Self::Progress>)
+                   -> Result<()>;
+
+    fn x_put_package(&self, pa: &mut PackageArchive, token: &str) -> Result<()>;
+
+    fn fetch_package(&self,
+                     ident_and_target: (&PackageIdent, PackageTarget),
+                     token: Option<&str>,
+                     dst_path: &Path,
+                     progress: Option<Self::Progress>)
+                     -> Result<PackageArchive>;
+
+    fn show_package(&self,
+                    ident_and_target: (&PackageIdent, PackageTarget),
+                    channel: &ChannelIdent,
+                    token: Option<&str>)
+                    -> Result<PackageIdent>;
+
+    fn delete_package(&self,
+                      ident_and_target: (&PackageIdent, PackageTarget),
+                      token: &str)
+                      -> Result<()>;
+
+    fn search_package(&self,
+                      search_term: &str,
+                      token: Option<&str>)
+                      -> Result<(Vec<PackageIdent>, bool)>;
+
+    fn create_channel(&self, origin: &str, channel: &ChannelIdent, token: &str) -> Result<()>;
+
+    fn delete_channel(&self, origin: &str, channel: &ChannelIdent, token: &str) -> Result<()>;
+
+    fn list_channels(&self, origin: &str, include_sandbox_channels: bool) -> Result<Vec<String>>;
+
+    fn promote_package(&self,
+                       ident_and_target: (&PackageIdent, PackageTarget),
+                       channel: &ChannelIdent,
+                       token: &str)
+                       -> Result<()>;
+
+    fn demote_package(&self,
+                      ident_and_target: (&PackageIdent, PackageTarget),
+                      channel: &ChannelIdent,
+                      token: &str)
+                      -> Result<()>;
+
+    fn put_origin_key(&self,
+                      origin: &str,
+                      revision: &str,
+                      src_path: &Path,
+                      token: &str,
+                      progress: Option<Self::Progress>)
+                      -> Result<()>;
+
+    fn fetch_origin_key(&self,
+                        origin: &str,
+                        revision: &str,
+                        dst_path: &Path,
+                        progress: Option<Self::Progress>)
+                        -> Result<PathBuf>;
+
+    fn put_origin_secret_key(&self,
+                             origin: &str,
+                             revision: &str,
+                             src_path: &Path,
+                             token: &str,
+                             progress: Option<Self::Progress>)
+                             -> Result<()>;
+
+    fn fetch_secret_origin_key(&self,
+                               origin: &str,
+                               token: &str,
+                               dst_path: &Path,
+                               progress: Option<Self::Progress>)
+                               -> Result<PathBuf>;
+
+    fn show_origin_keys(&self, origin: &str) -> Result<Vec<OriginKeyIdent>>;
+
+    fn package_channels(&self,
+                        ident_and_target: (&PackageIdent, PackageTarget),
+                        token: Option<&str>)
+                        -> Result<Vec<String>>;
+}
+
+pub struct Client;
+pub type BoxedClient = Box<BuilderAPIProvider<Progress = Box<dyn DisplayProgress>>>;
 
 impl Client {
+    #[allow(clippy::new_ret_no_self)]
     pub fn new<U>(endpoint: U,
                   product: &str,
                   version: &str,
                   fs_root_path: Option<&Path>)
-                  -> Result<Self>
+                  -> Result<BoxedClient>
         where U: IntoUrl
     {
         let mut endpoint = endpoint.into_url().map_err(Error::UrlParseError)?;
         if !endpoint.cannot_be_a_base() && endpoint.path() == "/" {
             endpoint.set_path(DEFAULT_API_PATH);
         }
-        Ok(Client(
-            ApiClient::new(endpoint, product, version, fs_root_path)
-                .map_err(Error::HabitatHttpClient)?,
-        ))
+
+        let client = BuilderAPIClient::new(endpoint, product, version, fs_root_path)?;
+
+        Ok(Box::new(client))
     }
-
-    /// Retrieves the status of every group job in an origin
-    ///
-    /// # Failures
-    ///
-    /// * Remote Builder is not available
-    pub fn get_origin_schedule(&self,
-                               origin: &str,
-                               limit: usize)
-                               -> Result<Vec<SchedulerResponse>> {
-        debug!("Retrieving status for job groups in the {} origin", origin);
-
-        let path = format!("depot/pkgs/schedule/{}/status", origin);
-
-        let custom = |url: &mut Url| {
-            url.query_pairs_mut()
-               .append_pair("limit", &limit.to_string());
-        };
-
-        let res = self.0.get_with_custom_url(&path, custom).send()?;
-
-        if res.status != StatusCode::Ok {
-            return Err(err_from_response(res));
-        }
-
-        let sr: Vec<SchedulerResponse> = decoded_response(res)?;
-        Ok(sr)
-    }
-
-    /// Retrieves the status of a group job
-    ///
-    /// # Failures
-    ///
-    /// * Remote Builder is not available
-    pub fn get_schedule(&self, group_id: i64, include_projects: bool) -> Result<SchedulerResponse> {
-        debug!("Retrieving schedule for job group {}", group_id);
-
-        let path = format!("depot/pkgs/schedule/{}", group_id);
-
-        let custom = |url: &mut Url| {
-            url.query_pairs_mut()
-               .append_pair("include_projects", &include_projects.to_string());
-        };
-
-        let res = self.0.get_with_custom_url(&path, custom).send()?;
-
-        if res.status != StatusCode::Ok {
-            return Err(err_from_response(res));
-        }
-
-        let sr: SchedulerResponse = decoded_response(res)?;
-        Ok(sr)
-    }
-
-    /// Schedules a job for a package ident
-    ///
-    /// # Failures
-    ///
-    /// * Key cannot be found
-    /// * Remote Builder is not available
-    pub fn schedule_job(&self,
-                        (ident, target): (&PackageIdent, PackageTarget),
-                        package_only: bool,
-                        token: &str)
-                        -> Result<(String)> {
-        let path = format!("depot/pkgs/schedule/{}/{}", ident.origin(), ident.name());
-
-        let custom = |url: &mut Url| {
-            url.query_pairs_mut()
-               .append_pair("package_only", &package_only.to_string())
-               .append_pair("target", &target.to_string());
-        };
-
-        match self.add_authz(self.0.post_with_custom_url(&path, custom), token)
-                  .send()
-        {
-            Ok(response) => {
-                if response.status == StatusCode::Created || response.status == StatusCode::Ok {
-                    let sr: SchedulerResponse = decoded_response(response)?;
-                    Ok(sr.id)
-                } else {
-                    Err(err_from_response(response))
-                }
-            }
-            Err(e) => Err(Error::from(e)),
-        }
-    }
-
-    /// Fetch the reverse dependencies for a package
-    ///
-    /// # Failures
-    ///
-    /// * Remote API Server is not available
-    pub fn fetch_rdeps(&self,
-                       (ident, target): (&PackageIdent, PackageTarget))
-                       -> Result<Vec<String>> {
-        debug!("Fetching the reverse dependencies for {}", ident);
-
-        let url = format!("rdeps/{}", ident);
-
-        let mut res = self.0
-                          .get_with_custom_url(&url, |u| {
-                              u.set_query(Some(&format!("target={}", &target.to_string())))
-                          })
-                          .send()
-                          .map_err(Error::HyperError)?;
-
-        if res.status != StatusCode::Ok {
-            return Err(err_from_response(res));
-        }
-
-        let mut encoded = String::new();
-        res.read_to_string(&mut encoded).map_err(Error::IO)?;
-        debug!("Body: {:?}", encoded);
-        let rd: ReverseDependencies = serde_json::from_str(&encoded).map_err(Error::Json)?;
-        Ok(rd.rdeps.to_vec())
-    }
-
-    /// Promote/Demote a job group to/from a channel
-    ///
-    /// # Failures
-    ///
-    /// * Remote API Server is not available
-    pub fn job_group_promote_or_demote<T: AsRef<str> + serde::Serialize>(&self,
-                                                                         group_id: u64,
-                                                                         idents: &[T],
-                                                                         channel: &ChannelIdent,
-                                                                         token: &str,
-                                                                         promote: bool)
-                                                                         -> Result<()> {
-        let json_idents = json!(idents);
-        let body = json!({ "idents": json_idents });
-        let sbody = serde_json::to_string(&body).unwrap();
-        let url = format!("jobs/group/{}/{}/{}",
-                          group_id,
-                          if promote { "promote" } else { "demote" },
-                          channel);
-        let res = self.add_authz(self.0.post(&url), token)
-                      .body(&sbody)
-                      .header(Accept::json())
-                      .header(ContentType::json())
-                      .send()
-                      .map_err(Error::HyperError)?;
-
-        if res.status != StatusCode::NoContent {
-            debug!("Failed to {} group, status: {:?}",
-                   if promote { "promote" } else { "demote" },
-                   res.status);
-            return Err(err_from_response(res));
-        }
-
-        Ok(())
-    }
-
-    /// Cancel a job group
-    ///
-    /// # Failures
-    ///
-    /// * Remote API Server is not available
-    pub fn job_group_cancel(&self, group_id: u64, token: &str) -> Result<()> {
-        let url = format!("jobs/group/{}/cancel", group_id);
-        let res = self.add_authz(self.0.post(&url), token)
-                      .send()
-                      .map_err(Error::HyperError)?;
-
-        if res.status != StatusCode::NoContent {
-            debug!("Failed to cancel group, status: {:?}", res.status);
-            return Err(err_from_response(res));
-        }
-
-        Ok(())
-    }
-
-    /// Download a public encryption key from a remote Builder to the given filepath.
-    ///
-    /// # Failures
-    ///
-    /// * Key cannot be found
-    /// * Remote Builder is not available
-    /// * File cannot be created and written to
-    pub fn fetch_origin_public_encryption_key<D, P: ?Sized>(&self,
-                                                            origin: &str,
-                                                            token: &str,
-                                                            dst_path: &P,
-                                                            progress: Option<D>)
-                                                            -> Result<PathBuf>
-        where P: AsRef<Path>,
-              D: DisplayProgress + Sized
-    {
-        self.download(self.0
-                          .get(&format!("depot/origins/{}/encryption_key", origin)),
-                      dst_path.as_ref(),
-                      Some(token),
-                      progress)
-    }
-
-    /// Create secret for an origin
-    ///
-    /// # Failures
-    ///
-    /// * Remote Builder is not available
-    pub fn create_origin_secret(&self,
-                                origin: &str,
-                                token: &str,
-                                key: &str,
-                                secret: &WrappedSealedBox)
-                                -> Result<()> {
-        let path = format!("depot/origins/{}/secret", origin);
-        let body = json!({
-            "name": key,
-            "value": secret
-        });
-
-        let sbody = serde_json::to_string(&body)?;
-        let res = self.add_authz(self.0.post(&path), token)
-                      .body(&sbody)
-                      .header(Accept::json())
-                      .header(ContentType::json())
-                      .send()?;
-
-        if res.status != StatusCode::Created {
-            return Err(err_from_response(res));
-        }
-
-        Ok(())
-    }
-
-    /// Delete a secret for an origin
-    ///
-    /// # Failures
-    ///
-    /// * Remote Builder is not available
-    pub fn delete_origin_secret(&self, origin: &str, token: &str, key: &str) -> Result<()> {
-        let path = format!("depot/origins/{}/secret/{}", origin, key);
-
-        let res = self.add_authz(self.0.delete(&path), token).send()?;
-
-        // We expect NoContent, because the origin must be empty to delete
-        if res.status == StatusCode::NoContent {
-            Ok(())
-        } else {
-            Err(err_from_response(res))
-        }
-    }
-
-    /// Delete an origin
-    ///
-    ///  # Failures
-    ///
-    ///  * Remote builder is not available
-    ///  * Origin is populated with > 0 packages
-    ///  * Submitted Origin is not found
-    pub fn delete_origin(&self, origin: &str, token: &str) -> Result<()> {
-        let path = format!("depot/origins/{}", origin);
-
-        let res = self.add_authz(self.0.delete(&path), token).send()?;
-
-        if res.status != StatusCode::NoContent {
-            return Err(err_from_response(res));
-        }
-
-        Ok(())
-    }
-
-    /// List all secrets keys for an origin
-    ///
-    /// # Failures
-    ///
-    /// * Remote Builder is not available
-    pub fn list_origin_secrets(&self, origin: &str, token: &str) -> Result<Vec<String>> {
-        let path = format!("depot/origins/{}/secret", origin);
-
-        let mut res = self.add_authz(self.0.get(&path), token).send()?;
-
-        if res.status != StatusCode::Ok {
-            return Err(err_from_response(res));
-        }
-
-        let mut encoded = String::new();
-        res.read_to_string(&mut encoded)
-           .map_err(Error::BadResponseBody)?;
-        debug!("Response body: {:?}", encoded);
-        let secret_keys: Vec<String> =
-            serde_json::from_str::<Vec<OriginSecret>>(&encoded)?.into_iter()
-                                                                .map(|s| s.name)
-                                                                .collect();
-        Ok(secret_keys)
-    }
-
-    /// Download a public key from a remote Builder to the given filepath.
-    ///
-    /// # Failures
-    ///
-    /// * Key cannot be found
-    /// * Remote Builder is not available
-    /// * File cannot be created and written to
-    pub fn fetch_origin_key<D, P: ?Sized>(&self,
-                                          origin: &str,
-                                          revision: &str,
-                                          dst_path: &P,
-                                          progress: Option<D>)
-                                          -> Result<PathBuf>
-        where P: AsRef<Path>,
-              D: DisplayProgress + Sized
-    {
-        self.download(self.0
-                          .get(&format!("depot/origins/{}/keys/{}", origin, revision)),
-                      dst_path.as_ref(),
-                      None,
-                      progress)
-    }
-
-    /// Download a secret key from a remote Builder to the given filepath.
-    ///
-    /// # Failures
-    ///
-    /// * Key cannot be found
-    /// * Remote Builder is not available
-    /// * File cannot be created and written to
-    pub fn fetch_secret_origin_key<D, P: ?Sized>(&self,
-                                                 origin: &str,
-                                                 token: &str,
-                                                 dst_path: &P,
-                                                 progress: Option<D>)
-                                                 -> Result<PathBuf>
-        where P: AsRef<Path>,
-              D: DisplayProgress + Sized
-    {
-        self.download(self.0
-                          .get(&format!("depot/origins/{}/secret_keys/latest", origin)),
-                      dst_path.as_ref(),
-                      Some(token),
-                      progress)
-    }
-
-    pub fn show_origin_keys(&self, origin: &str) -> Result<Vec<OriginKeyIdent>> {
-        let mut res = self.0.get(&origin_keys_path(origin)).send()?;
-        debug!("Response: {:?}", res);
-
-        if res.status != StatusCode::Ok {
-            return Err(err_from_response(res));
-        };
-
-        let mut encoded = String::new();
-        res.read_to_string(&mut encoded)
-           .map_err(Error::BadResponseBody)?;
-        debug!("Response body: {:?}", encoded);
-        let revisions: Vec<OriginKeyIdent> = serde_json::from_str::<Vec<OriginKeyIdent>>(&encoded)?;
-        Ok(revisions)
-    }
-
-    /// Return a list of channels for a given package
-    ///
-    /// # Failures
-    ///
-    /// * Remote Builder is not available
-    /// * Package does not exist
-    pub fn package_channels(&self,
-                            (ident, target): (&PackageIdent, PackageTarget),
-                            token: Option<&str>)
-                            -> Result<Vec<String>> {
-        if !ident.fully_qualified() {
-            return Err(Error::IdentNotFullyQualified);
-        }
-
-        let path = package_channels_path(ident);
-        debug!("Retrieving channels for {}, target {}", ident, target);
-
-        let custom = |url: &mut Url| {
-            url.query_pairs_mut()
-               .append_pair("target", &target.to_string());
-        };
-
-        let mut res = self.maybe_add_authz(self.0.get_with_custom_url(&path, custom), token)
-                          .send()?;
-
-        if res.status != StatusCode::Ok {
-            return Err(err_from_response(res));
-        }
-
-        let mut encoded = String::new();
-        res.read_to_string(&mut encoded)
-           .map_err(Error::BadResponseBody)?;
-        debug!("Response body: {:?}", encoded);
-        let channels: Vec<String> = serde_json::from_str::<Vec<String>>(&encoded)?.into_iter()
-                                                                                  .collect();
-        Ok(channels)
-    }
-
-    /// Upload a public origin key to a remote Builder.
-    ///
-    /// # Failures
-    ///
-    /// * Remote Builder is not available
-    /// * File cannot be read
-    ///
-    /// # Panics
-    ///
-    /// * Authorization token was not set on client
-    pub fn put_origin_key<D>(&self,
-                             origin: &str,
-                             revision: &str,
-                             src_path: &Path,
-                             token: &str,
-                             progress: Option<D>)
-                             -> Result<()>
-        where D: DisplayProgress + Sized
-    {
-        let path = format!("depot/origins/{}/keys/{}", &origin, &revision);
-        let mut file =
-            File::open(src_path).map_err(|e| Error::KeyReadError(src_path.to_path_buf(), e))?;
-        let file_size = file.metadata()
-                            .map_err(|e| Error::KeyReadError(src_path.to_path_buf(), e))?
-                            .len();
-
-        let result = if let Some(mut progress) = progress {
-            progress.size(file_size);
-            let mut reader = TeeReader::new(file, progress);
-            self.add_authz(self.0.post(&path), token)
-                .body(Body::SizedBody(&mut reader, file_size))
-                .send()
-        } else {
-            self.add_authz(self.0.post(&path), token)
-                .body(Body::SizedBody(&mut file, file_size))
-                .send()
-        };
-        match result {
-            Ok(Response { status: StatusCode::Created,
-                          .. }) => Ok(()),
-            Ok(response) => Err(err_from_response(response)),
-            Err(e) => Err(Error::from(e)),
-        }
-    }
-
-    /// Download a secret key from a remote Builder to the given filepath.
-    ///
-    /// # Failures
-    ///
-    /// * Remote Builder is not available
-    /// * File cannot be read
-    ///
-    /// # Panics
-    ///
-    /// * Authorization token was not set on client
-    pub fn fetch_origin_secret_key<P>(&self,
-                                      origin: &str,
-                                      token: &str,
-                                      dst_path: P)
-                                      -> Result<PathBuf>
-        where P: AsRef<Path>
-    {
-        self.x_download(&origin_secret_keys_latest(origin), dst_path.as_ref(), token)
-    }
-
-    /// Upload a secret origin key to a remote Builder.
-    ///
-    /// # Failures
-    ///
-    /// * Remote Builder is not available
-    /// * File cannot be read
-    ///
-    /// # Panics
-    ///
-    /// * Authorization token was not set on client
-    pub fn put_origin_secret_key<D>(&self,
-                                    origin: &str,
-                                    revision: &str,
-                                    src_path: &Path,
-                                    token: &str,
-                                    progress: Option<D>)
-                                    -> Result<()>
-        where D: DisplayProgress + Sized
-    {
-        let path = format!("depot/origins/{}/secret_keys/{}", &origin, &revision);
-        let mut file =
-            File::open(src_path).map_err(|e| Error::KeyReadError(src_path.to_path_buf(), e))?;
-        let file_size = file.metadata()
-                            .map_err(|e| Error::KeyReadError(src_path.to_path_buf(), e))?
-                            .len();
-
-        let result = if let Some(mut progress) = progress {
-            progress.size(file_size);
-            let mut reader = TeeReader::new(file, progress);
-            self.add_authz(self.0.post(&path), token)
-                .body(Body::SizedBody(&mut reader, file_size))
-                .send()
-        } else {
-            self.add_authz(self.0.post(&path), token)
-                .body(Body::SizedBody(&mut file, file_size))
-                .send()
-        };
-        match result {
-            Ok(Response { status: StatusCode::Created,
-                          .. }) => Ok(()),
-            Ok(response) => Err(err_from_response(response)),
-            Err(e) => Err(Error::from(e)),
-        }
-    }
-
-    /// Download the latest release of a package.
-    ///
-    /// By the time this function is called, the ident must be fully qualified. The download URL in
-    /// the depot requires a fully qualified ident to work. If you want the latest version of
-    /// a package, e.g. core/redis, you can display package details for that via a different URL,
-    /// e.g. /pkgs/core/redis/latest but that only _shows_ you the details - it doesn't download
-    /// the package.
-    ///
-    /// # Failures
-    ///
-    /// * Package cannot be found
-    /// * Remote Builder is not available
-    /// * File cannot be created and written to
-    pub fn fetch_package<D, P>(&self,
-                               (ident, target): (&PackageIdent, PackageTarget),
-                               token: Option<&str>,
-                               dst_path: &P,
-                               progress: Option<D>)
-                               -> Result<PackageArchive>
-        where P: AsRef<Path> + ?Sized,
-              D: DisplayProgress + Sized
-    {
-        // Ensure ident is fully qualified.
-        //
-        // TODO fn: this will be removed when we can describe a fully qualified ident by type as a
-        // param to this function
-        if !ident.fully_qualified() {
-            return Err(Error::IdentNotFullyQualified);
-        }
-
-        let req_builder = self.0.get_with_custom_url(&package_download(ident), |u| {
-                                    u.set_query(Some(&format!("target={}", target)))
-                                });
-
-        match self.download(req_builder, dst_path.as_ref(), token, progress) {
-            Ok(file) => Ok(PackageArchive::new(file)),
-            Err(e) => Err(e),
-        }
-    }
-
-    /// Returns a package struct for the latest package.
-    ///
-    /// An optional version can be specified which will scope the release returned to the latest
-    /// release of that package.
-    ///
-    /// # Failures
-    ///
-    /// * Package cannot be found
-    /// * Remote Builder is not available
-    pub fn show_package(&self,
-                        (package, target): (&PackageIdent, PackageTarget),
-                        channel: &ChannelIdent,
-                        token: Option<&str>)
-                        -> Result<PackageIdent> {
-        let mut url = channel_package_path(channel, package);
-
-        if !package.fully_qualified() {
-            url.push_str("/latest");
-        }
-
-        let mut res = self.maybe_add_authz(self.0
-                                               .get_with_custom_url(&url, |u| {
-                                                   u.set_query(Some(&format!("target={}", target)))
-                                               }),
-                                           token)
-                          .send()?;
-
-        if res.status != StatusCode::Ok {
-            return Err(err_from_response(res));
-        }
-
-        let mut encoded = String::new();
-        res.read_to_string(&mut encoded)
-           .map_err(Error::BadResponseBody)?;
-        debug!("Body: {:?}", encoded);
-        let package: json::Package = serde_json::from_str::<json::Package>(&encoded)?;
-        Ok(package.ident.into())
-    }
-
-    /// Upload a package to a remote Builder.
-    ///
-    /// # Failures
-    ///
-    /// * Remote Builder is not available
-    /// * File cannot be read
-    ///
-    /// # Panics
-    ///
-    /// * Authorization token was not set on client
-    pub fn put_package<D>(&self,
-                          pa: &mut PackageArchive,
-                          token: &str,
-                          force_upload: bool,
-                          progress: Option<D>)
-                          -> Result<()>
-        where D: DisplayProgress + Sized
-    {
-        let checksum = pa.checksum()?;
-        let ident = pa.ident()?;
-        let target = pa.target()?;
-
-        let file = File::open(&pa.path).map_err(|e| Error::PackageReadError(pa.path.clone(), e))?;
-        let file_size = file.metadata()
-                            .map_err(|e| Error::PackageReadError(pa.path.clone(), e))?
-                            .len();
-
-        let path = package_path(&ident);
-
-        let custom = |url: &mut Url| {
-            url.query_pairs_mut()
-               .append_pair("checksum", &checksum)
-               .append_pair("target", &target.to_string())
-               .append_pair("forced", &force_upload.to_string());
-        };
-        debug!("Reading from {}", &pa.path.display());
-
-        let mut reader: Box<dyn Read> = if let Some(mut progress) = progress {
-            progress.size(file_size);
-            Box::new(TeeReader::new(file, progress))
-        } else {
-            Box::new(file)
-        };
-
-        let result = self.add_authz(self.0.post_with_custom_url(&path, custom), token)
-                         .body(Body::SizedBody(&mut reader, file_size))
-                         .send();
-
-        match result {
-            Ok(Response { status: StatusCode::Created,
-                          .. }) => Ok(()),
-            Ok(response) => Err(err_from_response(response)),
-            Err(e) => Err(Error::from(e)),
-        }
-    }
-
-    pub fn x_put_package(&self, pa: &mut PackageArchive, token: &str) -> Result<()> {
-        let checksum = pa.checksum()?;
-        let ident = pa.ident()?;
-        let target = pa.target()?;
-
-        let mut file =
-            File::open(&pa.path).map_err(|e| Error::PackageReadError(pa.path.clone(), e))?;
-        let file_size = file.metadata()
-                            .map_err(|e| Error::PackageReadError(pa.path.clone(), e))?
-                            .len();
-        let path = package_path(&ident);
-        let custom = |url: &mut Url| {
-            url.query_pairs_mut()
-               .append_pair("checksum", &checksum)
-               .append_pair("target", &target.to_string())
-               .append_pair("builder", "");
-        };
-        debug!("Reading from {}", &pa.path.display());
-
-        let result = self.add_authz(self.0.post_with_custom_url(&path, custom), token)
-                         .body(Body::SizedBody(&mut file, file_size))
-                         .send();
-        match result {
-            Ok(Response { status: StatusCode::Created,
-                          .. }) => Ok(()),
-            Ok(response) => Err(err_from_response(response)),
-            Err(e) => Err(Error::from(e)),
-        }
-    }
-
-    /// Delete a package from Builder
-    ///
-    /// # Failures
-    ///
-    /// * Remote Builder is not available
-    /// * If package does not exist in Builder
-    /// * If the package does not qualify for deletion
-    /// * Authorization token was not set on client
-    pub fn delete_package(&self,
-                          (ident, target): (&PackageIdent, PackageTarget),
-                          token: &str)
-                          -> Result<()> {
-        let path = package_path(ident);
-        debug!("Deleting package {}, target {}", ident, target);
-
-        let custom = |url: &mut Url| {
-            url.query_pairs_mut()
-               .append_pair("target", &target.to_string());
-        };
-
-        let res = self.add_authz(self.0.delete_with_custom_url(&path, custom), token)
-                      .send()?;
-
-        if res.status != StatusCode::NoContent {
-            return Err(err_from_response(res));
-        };
-
-        Ok(())
-    }
-
-    /// Promote a package to a given channel
-    ///
-    /// # Failures
-    ///
-    /// * Remote Builder is not available
-    ///
-    /// # Panics
-    ///
-    /// * If package does not exist in Builder
-    /// * Authorization token was not set on client
-    pub fn promote_package(&self,
-                           (ident, target): (&PackageIdent, PackageTarget),
-                           channel: &ChannelIdent,
-                           token: &str)
-                           -> Result<()> {
-        if !ident.fully_qualified() {
-            return Err(Error::IdentNotFullyQualified);
-        }
-        let path = channel_package_promote(channel, ident);
-        debug!("Promoting package {}, target {}", ident, target);
-
-        let custom = |url: &mut Url| {
-            url.query_pairs_mut()
-               .append_pair("target", &target.to_string());
-        };
-
-        let res = self.add_authz(self.0.put_with_custom_url(&path, custom), token)
-                      .send()?;
-
-        if res.status != StatusCode::Ok {
-            return Err(err_from_response(res));
-        };
-
-        Ok(())
-    }
-
-    /// Demote a package from a given channel
-    ///
-    /// # Failures
-    ///
-    /// * Remote Builder is not available
-    ///
-    /// # Panics
-    ///
-    /// * If package does not exist in Builder
-    /// * Authorization token was not set on client
-    pub fn demote_package(&self,
-                          (ident, target): (&PackageIdent, PackageTarget),
-                          channel: &ChannelIdent,
-                          token: &str)
-                          -> Result<()> {
-        if !ident.fully_qualified() {
-            return Err(Error::IdentNotFullyQualified);
-        }
-        let path = channel_package_demote(channel, ident);
-        debug!("Demoting package {}, target {}", ident, target);
-
-        let custom = |url: &mut Url| {
-            url.query_pairs_mut()
-               .append_pair("target", &target.to_string());
-        };
-
-        let res = self.add_authz(self.0.put_with_custom_url(&path, custom), token)
-                      .send()?;
-
-        if res.status != StatusCode::Ok {
-            return Err(err_from_response(res));
-        };
-
-        Ok(())
-    }
-
-    /// Create a custom channel
-    ///
-    /// # Failures
-    ///
-    /// * Remote Builder is not available
-    pub fn create_channel(&self, origin: &str, channel: &ChannelIdent, token: &str) -> Result<()> {
-        let path = format!("depot/channels/{}/{}", origin, channel);
-        debug!("Creating channel, path: {:?}", path);
-
-        let res = self.add_authz(self.0.post(&path), token).send()?;
-
-        if res.status != StatusCode::Created {
-            return Err(err_from_response(res));
-        };
-
-        Ok(())
-    }
-
-    /// Delete a custom channel
-    ///
-    /// # Failures
-    ///
-    /// * Remote Builder is not available
-    pub fn delete_channel(&self, origin: &str, channel: &ChannelIdent, token: &str) -> Result<()> {
-        let path = format!("depot/channels/{}/{}", origin, channel);
-        debug!("Deleting channel, path: {:?}", path);
-
-        let res = self.add_authz(self.0.delete(&path), token).send()?;
-
-        if res.status != StatusCode::Ok {
-            return Err(err_from_response(res));
-        };
-
-        Ok(())
-    }
-
-    /// Return a list of channels for a given origin
-    ///
-    /// # Failures
-    /// * Remote Builder is not available
-    /// * Authorization token was not set on client
-    pub fn list_channels(&self,
-                         origin: &str,
-                         include_sandbox_channels: bool)
-                         -> Result<Vec<String>> {
-        let path = format!("depot/channels/{}", origin);
-        let mut res = if include_sandbox_channels {
-            self.0
-                .get_with_custom_url(&path, |url| url.set_query(Some("sandbox=true")))
-                .send()?
-        } else {
-            self.0.get(&path).send()?
-        };
-
-        match res.status {
-            StatusCode::Ok | StatusCode::PartialContent => {
-                let mut encoded = String::new();
-                res.read_to_string(&mut encoded)
-                   .map_err(Error::BadResponseBody)?;
-                let results: Vec<OriginChannelIdent> = serde_json::from_str(&encoded)?;
-                let channels = results.into_iter().map(|o| o.name).collect();
-                Ok(channels)
-            }
-            _ => Err(err_from_response(res)),
-        }
-    }
-
-    /// Returns a vector of PackageIdent structs
-    ///
-    /// # Failures
-    ///
-    /// * Remote depot unavailable
-    pub fn search_package(&self,
-                          search_term: &str,
-                          token: Option<&str>)
-                          -> Result<(Vec<PackageIdent>, bool)> {
-        let mut res = self.maybe_add_authz(self.0.get(&package_search(search_term)), token)
-                          .send()?;
-        match res.status {
-            StatusCode::Ok | StatusCode::PartialContent => {
-                let mut encoded = String::new();
-                res.read_to_string(&mut encoded)
-                   .map_err(Error::BadResponseBody)?;
-                let package_results: PackageResults<PackageIdent> = serde_json::from_str(&encoded)?;
-                let packages: Vec<PackageIdent> = package_results.data;
-                Ok((packages, res.status == StatusCode::PartialContent))
-            }
-            _ => Err(err_from_response(res)),
-        }
-    }
-
-    fn maybe_add_authz<'a>(&'a self,
-                           rb: RequestBuilder<'a>,
-                           token: Option<&str>)
-                           -> RequestBuilder<'_> {
-        if token.is_some() {
-            rb.header(Authorization(Bearer { token: token.unwrap().to_string(), }))
-        } else {
-            rb
-        }
-    }
-
-    fn add_authz<'a>(&'a self, rb: RequestBuilder<'a>, token: &str) -> RequestBuilder<'_> {
-        rb.header(Authorization(Bearer { token: token.to_string(), }))
-    }
-
-    fn download<'a, D>(&'a self,
-                       rb: RequestBuilder<'a>,
-                       dst_path: &Path,
-                       token: Option<&str>,
-                       progress: Option<D>)
-                       -> Result<PathBuf>
-        where D: DisplayProgress + Sized
-    {
-        let mut res = self.maybe_add_authz(rb, token).send()?;
-
-        debug!("Response: {:?}", res);
-
-        if res.status != hyper::status::StatusCode::Ok {
-            return Err(err_from_response(res));
-        }
-
-        fs::create_dir_all(&dst_path)?;
-
-        let file_name = res.headers
-                           .get::<XFileName>()
-                           .expect("XFileName missing from response")
-                           .to_string();
-        let dst_file_path = dst_path.join(file_name);
-        let w = AtomicWriter::new(&dst_file_path)?;
-        w.with_writer(|mut f| {
-             match progress {
-                 Some(mut progress) => {
-                     let size: u64 = res.headers
-                                        .get::<hyper::header::ContentLength>()
-                                        .map_or(0, |v| **v);
-                     progress.size(size);
-                     let mut writer = BroadcastWriter::new(&mut f, progress);
-                     io::copy(&mut res, &mut writer)
-                 }
-                 None => io::copy(&mut res, &mut f),
-             }
-         })
-         .map_err(Error::BadResponseBody)?;
-        Ok(dst_file_path)
-    }
-
-    // TODO: Ideally we would have a single download function that can support
-    // both progress and non-progress versions, however the Rust compiler cannot
-    // infer the type for a None for a Display + Sized trait, and makes this task
-    // much more difficult than it should be. Fix later.
-    fn x_download(&self, path: &str, dst_path: &Path, token: &str) -> Result<PathBuf> {
-        let mut res = self.add_authz(self.0.get(path), token).send()?;
-        debug!("Response: {:?}", res);
-
-        if res.status != hyper::status::StatusCode::Ok {
-            return Err(err_from_response(res));
-        }
-        fs::create_dir_all(&dst_path)?;
-
-        let file_name = res.headers
-                           .get::<XFileName>()
-                           .expect("XFileName missing from response")
-                           .to_string();
-        let dst_file_path = dst_path.join(file_name);
-        let w = AtomicWriter::new(&dst_file_path)?;
-        w.with_writer(|mut w| io::copy(&mut res, &mut w).map_err(Error::BadResponseBody))?;
-        Ok(dst_file_path)
-    }
-}
-
-fn err_from_response(mut response: hyper::client::Response) -> Error {
-    if response.status == StatusCode::Unauthorized {
-        return Error::APIError(response.status,
-                               "Please check that you have specified a valid Personal Access \
-                                Token."
-                                       .to_string());
-    }
-
-    let mut buff = String::new();
-    match response.read_to_string(&mut buff) {
-        Ok(_) => {
-            match serde_json::from_str::<NetError>(&buff) {
-                Ok(err) => Error::APIError(response.status, err.to_string()),
-                Err(_) => Error::APIError(response.status, buff),
-            }
-        }
-        Err(_) => {
-            buff.truncate(0);
-            Error::APIError(response.status, buff)
-        }
-    }
-}
-
-fn origin_keys_path(origin: &str) -> String { format!("depot/origins/{}/keys", origin) }
-
-fn origin_secret_keys_latest(origin: &str) -> String {
-    format!("depot/origins/{}/secret_keys/latest", origin)
-}
-
-fn package_download(package: &PackageIdent) -> String {
-    format!("{}/download", package_path(package))
-}
-
-fn package_path(package: &PackageIdent) -> String { format!("depot/pkgs/{}", package) }
-
-fn package_search(term: &str) -> String {
-    let encoded_term = percent_encode(term.as_bytes(), PATH_SEGMENT_ENCODE_SET);
-    format!("depot/pkgs/search/{}", encoded_term)
-}
-
-fn channel_package_path(channel: &ChannelIdent, package: &PackageIdent) -> String {
-    let mut path = format!("depot/channels/{}/{}/pkgs/{}",
-                           package.origin(),
-                           channel,
-                           package.name());
-    if let Some(version) = package.version() {
-        path.push_str("/");
-        path.push_str(version);
-        if let Some(release) = package.release() {
-            path.push_str("/");
-            path.push_str(release);
-        }
-    }
-    path
-}
-
-fn package_channels_path(package: &PackageIdent) -> String {
-    format!("depot/pkgs/{}/{}/{}/{}/channels",
-            package.origin(),
-            package.name(),
-            package.version().unwrap(),
-            package.release().unwrap())
-}
-
-fn channel_package_promote(channel: &ChannelIdent, package: &PackageIdent) -> String {
-    format!("depot/channels/{}/{}/pkgs/{}/{}/{}/promote",
-            package.origin(),
-            channel,
-            package.name(),
-            package.version().unwrap(),
-            package.release().unwrap())
-}
-
-fn channel_package_demote(channel: &ChannelIdent, package: &PackageIdent) -> String {
-    format!("depot/channels/{}/{}/pkgs/{}/{}/{}/demote",
-            package.origin(),
-            channel,
-            package.name(),
-            package.version().unwrap(),
-            package.release().unwrap())
 }
 
 #[cfg(test)]

--- a/components/common/src/command/package/install.rs
+++ b/components/common/src/command/package/install.rs
@@ -33,6 +33,7 @@ use std::{borrow::Cow,
           str::FromStr};
 
 use crate::{api_client::{self,
+                         BoxedClient,
                          Client,
                          Error::APIError},
             hcore::{self,
@@ -415,7 +416,7 @@ fn run_install_hook<T>(ui: &mut T, package: &PackageInstall) -> Result<()>
 struct InstallTask<'a> {
     install_mode: &'a InstallMode,
     local_package_usage: &'a LocalPackageUsage,
-    api_client: Client,
+    api_client: BoxedClient,
     channel: &'a ChannelIdent,
     fs_root_path: &'a Path,
     /// The path to the local artifact cache (e.g., /hab/cache/artifacts)
@@ -626,8 +627,7 @@ impl<'a> InstallTask<'a> {
             } else {
                 artifacts_to_install.push(self.get_cached_artifact(
                     ui,
-                    (&FullyQualifiedPackageIdent::from(dependency)?,
-                                        target),
+                    (&FullyQualifiedPackageIdent::from(dependency)?, target),
                     token,
                 )?);
             }

--- a/components/common/src/ui.rs
+++ b/components/common/src/ui.rs
@@ -293,7 +293,7 @@ pub trait UIWriter {
     /// Messages sent to the error IO stream will be formatted for a terminal if true.
     fn is_err_a_terminal(&self) -> bool;
     /// Returns a progress bar widget implementation for writing operation's progress to.
-    fn progress(&self) -> Option<Self::ProgressBar>;
+    fn progress(&self) -> Option<Box<dyn DisplayProgress>>;
 
     /// Write a message formatted with `begin`.
     fn begin<T>(&mut self, message: T) -> io::Result<()>
@@ -487,9 +487,9 @@ impl UIWriter for UI {
 
     fn is_err_a_terminal(&self) -> bool { self.shell.err.is_a_terminal() }
 
-    fn progress(&self) -> Option<Self::ProgressBar> {
+    fn progress(&self) -> Option<Box<dyn DisplayProgress>> {
         if self.is_out_a_terminal() {
-            Some(Self::ProgressBar::default())
+            Some(Box::new(Self::ProgressBar::default()))
         } else {
             None
         }

--- a/components/hab/src/command/bldr/job/status.rs
+++ b/components/hab/src/command/bldr/job/status.rs
@@ -31,7 +31,7 @@ pub fn start(ui: &mut UI,
 }
 
 fn do_job_group_status(ui: &mut UI,
-                       api_client: &api_client::Client,
+                       api_client: &api_client::BoxedClient,
                        group_id: &str,
                        show_jobs: bool)
                        -> Result<()> {
@@ -78,7 +78,7 @@ fn do_job_group_status(ui: &mut UI,
 }
 
 fn do_origin_status(ui: &mut UI,
-                    api_client: &api_client::Client,
+                    api_client: &api_client::BoxedClient,
                     origin: &str,
                     limit: usize)
                     -> Result<()> {

--- a/components/hab/src/command/origin/key/download.rs
+++ b/components/hab/src/command/origin/key/download.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
-use crate::{api_client::Client,
+use crate::{api_client::{BoxedClient,
+                         Client},
             common::{self,
                      command::package::install::{RETRIES,
                                                  RETRY_WAIT},
@@ -38,7 +39,7 @@ pub fn start(ui: &mut UI,
 }
 
 fn handle_public(ui: &mut UI,
-                 api_client: &Client,
+                 api_client: &BoxedClient,
                  origin: &str,
                  revision: Option<&str>,
                  cache: &Path)
@@ -78,7 +79,7 @@ fn handle_public(ui: &mut UI,
 }
 
 fn handle_secret(ui: &mut UI,
-                 api_client: &Client,
+                 api_client: &BoxedClient,
                  origin: &str,
                  token: Option<&str>,
                  cache: &Path)
@@ -95,7 +96,7 @@ fn handle_secret(ui: &mut UI,
 }
 
 fn handle_encryption(ui: &mut UI,
-                     api_client: &Client,
+                     api_client: &BoxedClient,
                      origin: &str,
                      token: Option<&str>,
                      cache: &Path)
@@ -112,7 +113,7 @@ fn handle_encryption(ui: &mut UI,
 }
 
 pub fn download_public_encryption_key(ui: &mut UI,
-                                      api_client: &Client,
+                                      api_client: &BoxedClient,
                                       name: &str,
                                       token: &str,
                                       cache: &Path)
@@ -137,7 +138,7 @@ pub fn download_public_encryption_key(ui: &mut UI,
 }
 
 fn download_secret_key(ui: &mut UI,
-                       api_client: &Client,
+                       api_client: &BoxedClient,
                        name: &str,
                        token: &str,
                        cache: &Path)
@@ -161,7 +162,7 @@ fn download_secret_key(ui: &mut UI,
 }
 
 fn download_key(ui: &mut UI,
-                api_client: &Client,
+                api_client: &BoxedClient,
                 nwr: &str,
                 name: &str,
                 rev: &str,

--- a/components/hab/src/command/pkg/upload.rs
+++ b/components/hab/src/command/pkg/upload.rs
@@ -24,6 +24,7 @@ use retry::retry;
 
 // Local Dependencies
 use crate::{api_client::{self,
+                         BoxedClient,
                          Client},
             common::{command::package::install::{RETRIES,
                                                  RETRY_WAIT},
@@ -137,7 +138,7 @@ pub fn start(ui: &mut UI,
 /// `additional_release_channel` is provided, packages will be
 /// promoted to that channel as well.
 fn upload_into_depot(ui: &mut UI,
-                     api_client: &Client,
+                     api_client: &BoxedClient,
                      token: &str,
                      (ident, target): (&PackageIdent, PackageTarget),
                      additional_release_channel: &Option<ChannelIdent>,
@@ -196,7 +197,7 @@ fn upload_into_depot(ui: &mut UI,
 
 #[allow(clippy::too_many_arguments)]
 fn attempt_upload_dep(ui: &mut UI,
-                      api_client: &Client,
+                      api_client: &BoxedClient,
                       token: &str,
                       (ident, target): (&PackageIdent, PackageTarget),
                       additional_release_channel: &Option<ChannelIdent>,
@@ -230,7 +231,7 @@ fn attempt_upload_dep(ui: &mut UI,
 
 fn upload_public_key(ui: &mut UI,
                      token: &str,
-                     api_client: &Client,
+                     api_client: &BoxedClient,
                      archive: &mut PackageArchive,
                      key_path: &Path)
                      -> Result<()> {

--- a/components/sup/src/ctl_gateway/mod.rs
+++ b/components/sup/src/ctl_gateway/mod.rs
@@ -126,9 +126,9 @@ impl UIWriter for CtlRequest {
 
     fn is_err_a_terminal(&self) -> bool { true }
 
-    fn progress(&self) -> Option<Self::ProgressBar> {
+    fn progress(&self) -> Option<Box<dyn DisplayProgress>> {
         if self.is_out_a_terminal() {
-            Some(Self::ProgressBar::new(self.clone()))
+            Some(Box::new(Self::ProgressBar::new(self.clone())))
         } else {
             None
         }


### PR DESCRIPTION
This change abstracts out the Builder API into a provider model, in readiness for adding a new API provider in the builder-api-client crate. Functionality wise, it is a no-op. There's a bit of change that spills out from the builder-api-client due to managing the DisplayProgress trait in the provider, but its fairly minor.

Signed-off-by: Salim Alam <salam@chef.io>

![tenor-96156703](https://user-images.githubusercontent.com/13542112/59045996-fb2a2c00-8835-11e9-964a-132023c6c08c.gif)
