### PR TITLE
Update docs for 0.82.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,7 @@
 
 <!-- latest_release -->
 
-## [0.82.0](https://github.com/habitat-sh/habitat/tree/0.82.0) (2019-06-03)
-
-#### Merged Pull Requests
-- Release 0.82.0 [#6613](https://github.com/habitat-sh/habitat/pull/6613) ([smacfarlane](https://github.com/smacfarlane))
-
- ## [0.82.0](https://github.com/habitat-sh/habitat/tree/0.82.0) (2019-05-06)
+ ## [0.82.0](https://github.com/habitat-sh/habitat/tree/0.82.0) (2019-06-06)
  [Full Changelog](https://github.com/habitat-sh/habitat/compare/0.81.0...0.82.0)
 
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -183,10 +183,7 @@ make cli_docs
 make template_reference
 ```
 
-Verify the diff looks reasonable and matches the newly released version, then submit your PR. Until
-https://github.com/habitat-sh/habitat/issues/5948 is fixed, this may require some manual fixup. In particular,
-make sure that https://github.com/habitat-sh/habitat/blob/master/www/source/partials/docs/_reference-template-data.html.md.erb doesn't remove the `sys` section. If https://github.com/habitat-sh/habitat/issues/5948 is fixed,
-update these instructions.
+Verify the diff looks reasonable and matches the newly released version, then submit your PR.
 
 ## Verify the Docs
 

--- a/www/Makefile
+++ b/www/Makefile
@@ -33,16 +33,16 @@ cli_docs:
 	hab studio run "hab pkg install core/hab-studio && \
 	hab pkg install core/hab-sup && \
 	hab pkg install core/hab-launcher && \
-	hab pkg install core/node --binlink /bin && \
+	hab pkg install core/node && \
+	hab pkg binlink core/node --dest=/bin && \
 	/bin/node scripts/generate-cli-docs > source/docs/habitat-cli.html.md"
 
-node_modules/json-schema-ref-parser:
-	npm install json-schema-ref-parser@6.1.0
-
-template_reference: node_modules/json-schema-ref-parser
+template_reference:
 	mkdir tmp
 	cp ../components/sup/doc/* tmp/
-	hab studio run "hab pkg install core/node --binlink /bin && \
+	hab studio run "hab pkg install core/node && \
+	hab pkg binlink core/node --dest=/bin && \
+	npm install json-schema-ref-parser@6.1.0 && \
 	/bin/node scripts/generate-template-reference.js tmp/render_context_schema.json > ./source/partials/docs/_reference-template-data.html.md.erb"
 	rm -rf tmp
 

--- a/www/source/docs/habitat-cli.html.md
+++ b/www/source/docs/habitat-cli.html.md
@@ -10,7 +10,7 @@ The commands for the Habitat CLI (`hab`) are listed below.
 
 | Applies to Version | Last Updated |
 | ------- | ------------ |
-| hab 0.81.0/20190507225645 (linux) | 8 May 2019 |
+| hab 0.82.0/20190605214032 (linux) | 6 Jun 2019 |
 
 ## hab
 
@@ -1223,7 +1223,7 @@ hab pkg binlink [FLAGS] [OPTIONS] <PKG_IDENT> [BINARY]
 **OPTIONS**
 
 ```
--d, --dest <DEST_DIR>    Sets the destination directory [env: HAB_BINLINK_DIR=/hab/bin]  [default: /bin]
+-d, --dest <DEST_DIR>    Sets the destination directory [env: HAB_BINLINK_DIR=]  [default: /bin]
 ```
 
 **ARGS**
@@ -1602,6 +1602,7 @@ hab pkg install [FLAGS] [OPTIONS] <PKG_IDENT_OR_ARTIFACT>...
 **FLAGS**
 
 ```
+-b, --binlink                Binlink all binaries from installed package(s) into BINLINK_DIR
 -f, --force                  Overwrite existing binlinks
     --ignore-install-hook    Do not run any install hooks
 -h, --help                   Prints help information
@@ -1611,10 +1612,10 @@ hab pkg install [FLAGS] [OPTIONS] <PKG_IDENT_OR_ARTIFACT>...
 **OPTIONS**
 
 ```
--z, --auth <AUTH_TOKEN>    Authentication token for Builder
--b, --binlink <BINLINK>    Binlink all binaries from installed package(s) [env: HAB_BINLINK_DIR=/hab/bin]  [default: bin]
--u, --url <BLDR_URL>       Specify an alternate Builder endpoint. If not specified, the value will be taken from the HAB_BLDR_URL environment variable if defined. (default: https://bldr.habitat.sh)
--c, --channel <CHANNEL>    Install from the specified release channel [env: HAB_BLDR_CHANNEL=]  [default: stable]
+-z, --auth <AUTH_TOKEN>            Authentication token for Builder
+    --binlink-dir <BINLINK_DIR>    Binlink all binaries from installed package(s) into BINLINK_DIR [env: HAB_BINLINK_DIR=]  [default: /bin]
+-u, --url <BLDR_URL>               Specify an alternate Builder endpoint. If not specified, the value will be taken from the HAB_BLDR_URL environment variable if defined. (default: https://bldr.habitat.sh)
+-c, --channel <CHANNEL>            Install from the specified release channel [env: HAB_BLDR_CHANNEL=]  [default: stable]
 ```
 
 **ARGS**
@@ -1970,15 +1971,16 @@ hab plan init [FLAGS] [OPTIONS] [PKG_NAME]
 **FLAGS**
 
 ```
--h, --help              Prints help information
--V, --version           Prints version information
+-m, --min            Create a minimal plan file
+-s, --scaffolding    Specify explicit Scaffolding for your app (ex: node, ruby)
+-h, --help           Prints help information
+-V, --version        Prints version information
 ```
 
 **OPTIONS**
 
 ```
--o, --origin <ORIGIN>              Origin for the new app
--s, --scaffolding <SCAFFOLDING>    Specify explicit Scaffolding for your app (ex: node, ruby)
+-o, --origin <ORIGIN>    Origin for the new app
 ```
 
 **ARGS**


### PR DESCRIPTION
Update the cli docs for the 0.82.0 release.

This also includes fixes to the Makefile for generating the docs, as well as updating the documentation for generating the docs. 