### PR TITLE
Undo clippy disparate rust toolchain workaround

### DIFF
--- a/components/butterfly/src/server/push.rs
+++ b/components/butterfly/src/server/push.rs
@@ -146,6 +146,7 @@ impl PushWorker {
     // simplify the redundant aspects and remove this allow(clippy::cyclomatic_complexity),
     // but changing it in the absence of other necessity seems like too much risk for the
     // expected reward.
+    #[allow(clippy::cyclomatic_complexity)]
     fn send_rumors(&self, member: &Member, rumors: &[RumorKey]) {
         let socket = (**ZMQ_CONTEXT).as_mut()
                                     .socket(zmq::PUSH)

--- a/components/butterfly/src/server/push.rs
+++ b/components/butterfly/src/server/push.rs
@@ -143,10 +143,10 @@ impl PushWorker {
     /// connection and socket open for 1 second longer - so it is possible, but unlikely, that this
     /// method can lose messages.
     // If we ever need to modify this function, it would be an excellent opportunity to
-    // simplify the redundant aspects and remove this allow(clippy::cyclomatic_complexity),
+    // simplify the redundant aspects and remove this allow(clippy::cognitive_complexity),
     // but changing it in the absence of other necessity seems like too much risk for the
     // expected reward.
-    #[allow(clippy::cyclomatic_complexity)]
+    #[allow(clippy::cognitive_complexity)]
     fn send_rumors(&self, member: &Member, rumors: &[RumorKey]) {
         let socket = (**ZMQ_CONTEXT).as_mut()
                                     .socket(zmq::PUSH)

--- a/components/butterfly/tests/rumor/election.rs
+++ b/components/butterfly/tests/rumor/election.rs
@@ -86,7 +86,7 @@ fn five_members_elect_a_new_leader_when_the_old_one_dies() {
 }
 
 #[test]
-#[allow(clippy::cyclomatic_complexity)]
+#[allow(clippy::cognitive_complexity)]
 fn five_members_elect_a_new_leader_when_they_are_quorum_partitioned() {
     let mut net = btest::SwimNet::new_with_suitability(vec![1, 0, 0, 0, 0]);
     net[0].member

--- a/components/butterfly/tests/rumor/election.rs
+++ b/components/butterfly/tests/rumor/election.rs
@@ -86,6 +86,7 @@ fn five_members_elect_a_new_leader_when_the_old_one_dies() {
 }
 
 #[test]
+#[allow(clippy::cyclomatic_complexity)]
 fn five_members_elect_a_new_leader_when_they_are_quorum_partitioned() {
     let mut net = btest::SwimNet::new_with_suitability(vec![1, 0, 0, 0, 0]);
     net[0].member

--- a/components/hab/src/command/bldr/job/promote.rs
+++ b/components/hab/src/command/bldr/job/promote.rs
@@ -142,8 +142,7 @@ pub fn start(ui: &mut UI,
 
 #[cfg(test)]
 mod test {
-    use std::{env,
-              io::{self,
+    use std::{io::{self,
                    Cursor,
                    Write},
               sync::{Arc,

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -672,6 +672,7 @@ impl Manager {
     // simplify the redundant aspects and remove this allow(clippy::cyclomatic_complexity),
     // but changing it in the absence of other necessity seems like too much risk for the
     // expected reward.
+    #[allow(clippy::cyclomatic_complexity)]
     pub fn run(mut self, svc: Option<habitat_sup_protocol::ctl::SvcLoad>) -> Result<()> {
         let main_hist = RUN_LOOP_DURATION.with_label_values(&["sup"]);
         let service_hist = RUN_LOOP_DURATION.with_label_values(&["service"]);

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -669,10 +669,10 @@ impl Manager {
     }
 
     // If we ever need to modify this function, it would be an excellent opportunity to
-    // simplify the redundant aspects and remove this allow(clippy::cyclomatic_complexity),
+    // simplify the redundant aspects and remove this allow(clippy::cognitive_complexity),
     // but changing it in the absence of other necessity seems like too much risk for the
     // expected reward.
-    #[allow(clippy::cyclomatic_complexity)]
+    #[allow(clippy::cognitive_complexity)]
     pub fn run(mut self, svc: Option<habitat_sup_protocol::ctl::SvcLoad>) -> Result<()> {
         let main_hist = RUN_LOOP_DURATION.with_label_values(&["sup"]);
         let service_hist = RUN_LOOP_DURATION.with_label_values(&["service"]);

--- a/components/sup/src/manager/service_updater.rs
+++ b/components/sup/src/manager/service_updater.rs
@@ -154,6 +154,7 @@ impl ServiceUpdater {
     // simplify the redundant aspects and remove this allow(clippy::cyclomatic_complexity),
     // but changing it in the absence of other necessity seems like too much risk for the
     // expected reward.
+    #[allow(clippy::cyclomatic_complexity)]
     pub fn check_for_updated_package(&mut self,
                                      service: &Service,
                                      // TODO (CM): Strictly speaking, we don't need to pass

--- a/components/sup/src/manager/service_updater.rs
+++ b/components/sup/src/manager/service_updater.rs
@@ -151,10 +151,10 @@ impl ServiceUpdater {
     /// of the newly-updated service if a new version was installed,
     /// thus signalling that the service should be restarted.
     // If we ever need to modify this function, it would be an excellent opportunity to
-    // simplify the redundant aspects and remove this allow(clippy::cyclomatic_complexity),
+    // simplify the redundant aspects and remove this allow(clippy::cognitive_complexity),
     // but changing it in the absence of other necessity seems like too much risk for the
     // expected reward.
-    #[allow(clippy::cyclomatic_complexity)]
+    #[allow(clippy::cognitive_complexity)]
     pub fn check_for_updated_package(&mut self,
                                      service: &Service,
                                      // TODO (CM): Strictly speaking, we don't need to pass

--- a/test/denied_lints.txt
+++ b/test/denied_lints.txt
@@ -8,6 +8,7 @@ clippy::cmp_owned
 clippy::collapsible_if
 clippy::const_static_lifetime
 clippy::correctness
+clippy::cyclomatic_complexity
 clippy::deref_addrof
 clippy::drop_bounds
 clippy::expect_fun_call

--- a/test/denied_lints.txt
+++ b/test/denied_lints.txt
@@ -8,7 +8,7 @@ clippy::cmp_owned
 clippy::collapsible_if
 clippy::const_static_lifetime
 clippy::correctness
-clippy::cyclomatic_complexity
+clippy::cognitive_complexity
 clippy::deref_addrof
 clippy::drop_bounds
 clippy::expect_fun_call

--- a/test/lints_to_fix.txt
+++ b/test/lints_to_fix.txt
@@ -1,1 +1,0 @@
-clippy::cognitive_complexity


### PR DESCRIPTION
Basically, revert the workaround from https://github.com/habitat-sh/habitat/pull/6600