### PR TITLE
Increase timing threshold for sync module tests

### DIFF
--- a/components/common/src/lib.rs
+++ b/components/common/src/lib.rs
@@ -231,7 +231,7 @@ pub mod sync {
                                  Ordering},
                         Arc};
 
-        const TEST_THRESHOLD: Duration = Duration::from_millis(10);
+        const TEST_THRESHOLD: Duration = Duration::from_secs(1);
 
         #[test]
         fn no_tracking_without_mark_thread_alive() {


### PR DESCRIPTION
There has been an inconsistent, inexplicable failure in `sync::test::one_dead_one_alive`. After failures to reproduce locally or in CI with additional logging, I can only assume it's a timing issue due to the less responsive CI environment. Hopefully increasing the threshold should eliminate this error.

See https://buildkite.com/chef/habitat-sh-habitat-master-verify/builds/2238#4f98424b-10b2-47fa-a40a-a4e8a8473d8f/238-740

