### PR TITLE
Load config variables from cli.toml when entering hab-studio

### DIFF
--- a/components/hab/src/command/studio/enter.rs
+++ b/components/hab/src/command/studio/enter.rs
@@ -13,25 +13,44 @@ use crate::{config,
 
 pub const ARTIFACT_PATH_ENVVAR: &str = "ARTIFACT_PATH";
 
-const ORIGIN_ENVVAR: &str = "HAB_ORIGIN";
 const AUTH_TOKEN_ENVVAR: &str = "HAB_AUTH_TOKEN";
+const BLDR_URL_ENVVAR: &str = "HAB_BLDR_URL";
+const CTL_SECRET_ENVVAR: &str= "HAB_CTL_SECRET";
+const ORIGIN_ENVVAR: &str = "HAB_ORIGIN";
 const STUDIO_CMD: &str = "hab-studio";
 const STUDIO_CMD_ENVVAR: &str = "HAB_STUDIO_BINARY";
 const STUDIO_PACKAGE_IDENT: &str = "core/hab-studio";
 
 pub fn start(ui: &mut UI, args: &[OsString]) -> Result<()> {
+    if henv::var(AUTH_TOKEN_ENVVAR).is_err() {
+        let config = config::load()?;
+        if let Some(auth_token) = config.auth_token {
+            debug!("Setting {}={} via config file", AUTH_TOKEN_ENVVAR, &auth_token);
+            env::set_var("HAB_AUTH_TOKEN", auth_token);
+        }
+    }
+
+    if henv::var(BLDR_URL_ENVVAR).is_err() {
+        let config = config::load()?;
+        if let Some(bldr_url) = config.bldr_url {
+            debug!("Setting {}={} via config file", BLDR_URL_ENVVAR, &bldr_url);
+            env::set_var("HAB_BLDR_URL", bldr_url);
+        }
+    }
+
+    if henv::var(CTL_SECRET_ENVVAR).is_err() {
+        let config = config::load()?;
+        if let Some(ctl_secret) = config.ctl_secret {
+            debug!("Setting {}={} via config file", CTL_SECRET_ENVVAR, &ctl_secret);
+            env::set_var("CTL_SECRET_ENVVAR", ctl_secret);
+        }
+    }
+
     if henv::var(ORIGIN_ENVVAR).is_err() {
         let config = config::load()?;
         if let Some(default_origin) = config.origin {
             debug!("Setting default origin {} via CLI config", &default_origin);
             env::set_var("HAB_ORIGIN", default_origin);
-        }
-    }
-    if henv::var(AUTH_TOKEN_ENVVAR).is_err() {
-        let config = config::load()?;
-        if let Some(auth_token) = config.auth_token {
-            debug!("Setting default origin {} via CLI config", &auth_token);
-            env::set_var("HAB_AUTH_TOKEN", auth_token);
         }
     }
 

--- a/components/hab/src/command/studio/enter.rs
+++ b/components/hab/src/command/studio/enter.rs
@@ -22,13 +22,17 @@ const STUDIO_CMD: &str = "hab-studio";
 const STUDIO_CMD_ENVVAR: &str = "HAB_STUDIO_BINARY";
 const STUDIO_PACKAGE_IDENT: &str = "core/hab-studio";
 
-fn set_env_var_from_config(env_var: &str, config_val: Option<String>, sensitive: bool) {
+enum Sensitivity {
+    PrintValue,
+    NoPrintValue,
+}
+
+fn set_env_var_from_config(env_var: &str, config_val: Option<String>, sensitive: Sensitivity) {
     if henv::var(env_var).is_err() {
         if let Some(val) = config_val {
-            if sensitive {
-                debug!("Setting {}=REDACTED (sensitive) via config file", env_var)
-            } else {
-                debug!("Setting {}={} via config file", env_var, val)
+            match sensitive {
+                Sensitivity::NoPrintValue =>  debug!("Setting {}=REDACTED (sensitive) via config file", env_var),
+                Sensitivity::PrintValue => debug!("Setting {}={} via config file", env_var, val),
             }
             env::set_var(env_var, val);
         }
@@ -38,10 +42,10 @@ fn set_env_var_from_config(env_var: &str, config_val: Option<String>, sensitive:
 pub fn start(ui: &mut UI, args: &[OsString]) -> Result<()> {
     let config = config::load()?;
 
-    set_env_var_from_config(AUTH_TOKEN_ENVVAR, config.auth_token, true);
-    set_env_var_from_config(BLDR_URL_ENVVAR, config.bldr_url, false);
-    set_env_var_from_config(CTL_SECRET_ENVVAR, config.ctl_secret, true);
-    set_env_var_from_config(ORIGIN_ENVVAR, config.origin, false);
+    set_env_var_from_config(AUTH_TOKEN_ENVVAR, config.auth_token, Sensitivity::NoPrintValue);
+    set_env_var_from_config(BLDR_URL_ENVVAR, config.bldr_url, Sensitivity::PrintValue);
+    set_env_var_from_config(CTL_SECRET_ENVVAR, config.ctl_secret, Sensitivity::NoPrintValue);
+    set_env_var_from_config(ORIGIN_ENVVAR, config.origin, Sensitivity::PrintValue);
 
     if henv::var(CACHE_KEY_PATH_ENV_VAR).is_err() {
         let path = fs::cache_key_path(None::<&str>);

--- a/components/hab/src/command/studio/enter.rs
+++ b/components/hab/src/command/studio/enter.rs
@@ -14,7 +14,7 @@ use crate::{config,
 pub const ARTIFACT_PATH_ENVVAR: &str = "ARTIFACT_PATH";
 
 const ORIGIN_ENVVAR: &str = "HAB_ORIGIN";
-const AUTH_TOKEN_ENVVAR: &str = "HAB_AUTH_TOKEN"
+const AUTH_TOKEN_ENVVAR: &str = "HAB_AUTH_TOKEN";
 const STUDIO_CMD: &str = "hab-studio";
 const STUDIO_CMD_ENVVAR: &str = "HAB_STUDIO_BINARY";
 const STUDIO_PACKAGE_IDENT: &str = "core/hab-studio";
@@ -31,7 +31,7 @@ pub fn start(ui: &mut UI, args: &[OsString]) -> Result<()> {
         let config = config::load()?;
         if let Some(auth_token) = config.auth_token {
             debug!("Setting default origin {} via CLI config", &auth_token);
-            env::set_var("HAB_AUTH_TOKEN", auth_token;
+            env::set_var("HAB_AUTH_TOKEN", auth_token);
         }
     }
 

--- a/components/hab/src/command/studio/enter.rs
+++ b/components/hab/src/command/studio/enter.rs
@@ -14,6 +14,7 @@ use crate::{config,
 pub const ARTIFACT_PATH_ENVVAR: &str = "ARTIFACT_PATH";
 
 const ORIGIN_ENVVAR: &str = "HAB_ORIGIN";
+const AUTH_TOKEN_ENVVAR: &str = "HAB_AUTH_TOKEN"
 const STUDIO_CMD: &str = "hab-studio";
 const STUDIO_CMD_ENVVAR: &str = "HAB_STUDIO_BINARY";
 const STUDIO_PACKAGE_IDENT: &str = "core/hab-studio";
@@ -24,6 +25,13 @@ pub fn start(ui: &mut UI, args: &[OsString]) -> Result<()> {
         if let Some(default_origin) = config.origin {
             debug!("Setting default origin {} via CLI config", &default_origin);
             env::set_var("HAB_ORIGIN", default_origin);
+        }
+    }
+    if henv::var(AUTH_TOKEN_ENVVAR).is_err() {
+        let config = config::load()?;
+        if let Some(auth_token) = config.auth_token {
+            debug!("Setting default origin {} via CLI config", &auth_token);
+            env::set_var("HAB_AUTH_TOKEN", auth_token;
         }
     }
 

--- a/components/hab/src/command/studio/enter.rs
+++ b/components/hab/src/command/studio/enter.rs
@@ -21,36 +21,47 @@ const STUDIO_CMD: &str = "hab-studio";
 const STUDIO_CMD_ENVVAR: &str = "HAB_STUDIO_BINARY";
 const STUDIO_PACKAGE_IDENT: &str = "core/hab-studio";
 
+// fn set_env_var(env_var: &str) -> Result<()> {
+//   let config = config::load()?;
+//   if henv::var(env_var).is_err() {
+//     if let Some(config_val) = match env_var {
+//       AUTH_TOKEN_ENVVAR => config.auth_token,
+//       _ => println!("uh oh, this shouldn't happen"),
+//     };
+//     println!("config var is: {}", config_val);
+//     env::set_var(env_var, config_val)
+//   }
+// }
+
+fn set_env_var(env_var: &str, val: String) -> Result<()> {
+    debug!("Setting {}={} via config file", env_var, &val);
+    env::set_var(env_var, val);
+    Ok(())
+}
+
 pub fn start(ui: &mut UI, args: &[OsString]) -> Result<()> {
+    let config = config::load()?;
     if henv::var(AUTH_TOKEN_ENVVAR).is_err() {
-        let config = config::load()?;
         if let Some(auth_token) = config.auth_token {
-            debug!("Setting {}={} via config file", AUTH_TOKEN_ENVVAR, &auth_token);
-            env::set_var("HAB_AUTH_TOKEN", auth_token);
+          set_env_var(AUTH_TOKEN_ENVVAR, auth_token)?;
         }
     }
 
     if henv::var(BLDR_URL_ENVVAR).is_err() {
-        let config = config::load()?;
         if let Some(bldr_url) = config.bldr_url {
-            debug!("Setting {}={} via config file", BLDR_URL_ENVVAR, &bldr_url);
-            env::set_var("HAB_BLDR_URL", bldr_url);
+            set_env_var(BLDR_URL_ENVVAR, bldr_url)?;
         }
     }
 
     if henv::var(CTL_SECRET_ENVVAR).is_err() {
-        let config = config::load()?;
         if let Some(ctl_secret) = config.ctl_secret {
-            debug!("Setting {}={} via config file", CTL_SECRET_ENVVAR, &ctl_secret);
-            env::set_var("CTL_SECRET_ENVVAR", ctl_secret);
+            set_env_var(CTL_SECRET_ENVVAR, ctl_secret)?;
         }
     }
 
     if henv::var(ORIGIN_ENVVAR).is_err() {
-        let config = config::load()?;
         if let Some(default_origin) = config.origin {
-            debug!("Setting default origin {} via CLI config", &default_origin);
-            env::set_var("HAB_ORIGIN", default_origin);
+            set_env_var(ORIGIN_ENVVAR, default_origin)?;
         }
     }
 

--- a/components/hab/src/command/studio/enter.rs
+++ b/components/hab/src/command/studio/enter.rs
@@ -21,10 +21,14 @@ const STUDIO_CMD: &str = "hab-studio";
 const STUDIO_CMD_ENVVAR: &str = "HAB_STUDIO_BINARY";
 const STUDIO_PACKAGE_IDENT: &str = "core/hab-studio";
 
-fn set_env_var_from_config(env_var: &str, config_val: Option<String>) {
+// fn set_env_var_from_config<T: Into<Option<bool>>>(env_var: &str, config_val: Option<String>, sensitive: T) {
+fn set_env_var_from_config(env_var: &str, config_val: Option<String>, sensitive: Option<bool>) {
     if henv::var(env_var).is_err() {
         if let Some(val) = config_val {
-            debug!("Setting {}={} via config file", env_var, val);
+            match sensitive {
+              Some(_) => debug!("Setting Sensitive value {} via config file", env_var),
+              None => debug!("Setting {}={} via config file", env_var, val),
+            }
             env::set_var(env_var, val);
         }
     }
@@ -33,10 +37,10 @@ fn set_env_var_from_config(env_var: &str, config_val: Option<String>) {
 pub fn start(ui: &mut UI, args: &[OsString]) -> Result<()> {
     let config = config::load()?;
 
-    set_env_var_from_config(AUTH_TOKEN_ENVVAR, config.auth_token);
-    set_env_var_from_config(BLDR_URL_ENVVAR, config.bldr_url);
-    set_env_var_from_config(CTL_SECRET_ENVVAR, config.ctl_secret);
-    set_env_var_from_config(ORIGIN_ENVVAR, config.origin);
+    set_env_var_from_config(AUTH_TOKEN_ENVVAR, config.auth_token, Some(true));
+    set_env_var_from_config(BLDR_URL_ENVVAR, config.bldr_url, None);
+    set_env_var_from_config(CTL_SECRET_ENVVAR, config.ctl_secret, Some(true));
+    set_env_var_from_config(ORIGIN_ENVVAR, config.origin, None);
 
     if henv::var(CACHE_KEY_PATH_ENV_VAR).is_err() {
         let path = fs::cache_key_path(None::<&str>);

--- a/components/hab/src/command/studio/enter.rs
+++ b/components/hab/src/command/studio/enter.rs
@@ -31,7 +31,9 @@ fn set_env_var_from_config(env_var: &str, config_val: Option<String>, sensitive:
     if henv::var(env_var).is_err() {
         if let Some(val) = config_val {
             match sensitive {
-                Sensitivity::NoPrintValue =>  debug!("Setting {}=REDACTED (sensitive) via config file", env_var),
+                Sensitivity::NoPrintValue => {
+                    debug!("Setting {}=REDACTED (sensitive) via config file", env_var)
+                }
                 Sensitivity::PrintValue => debug!("Setting {}={} via config file", env_var, val),
             }
             env::set_var(env_var, val);
@@ -42,9 +44,13 @@ fn set_env_var_from_config(env_var: &str, config_val: Option<String>, sensitive:
 pub fn start(ui: &mut UI, args: &[OsString]) -> Result<()> {
     let config = config::load()?;
 
-    set_env_var_from_config(AUTH_TOKEN_ENVVAR, config.auth_token, Sensitivity::NoPrintValue);
+    set_env_var_from_config(AUTH_TOKEN_ENVVAR,
+                            config.auth_token,
+                            Sensitivity::NoPrintValue);
     set_env_var_from_config(BLDR_URL_ENVVAR, config.bldr_url, Sensitivity::PrintValue);
-    set_env_var_from_config(CTL_SECRET_ENVVAR, config.ctl_secret, Sensitivity::NoPrintValue);
+    set_env_var_from_config(CTL_SECRET_ENVVAR,
+                            config.ctl_secret,
+                            Sensitivity::NoPrintValue);
     set_env_var_from_config(ORIGIN_ENVVAR, config.origin, Sensitivity::PrintValue);
 
     if henv::var(CACHE_KEY_PATH_ENV_VAR).is_err() {

--- a/components/hab/src/command/studio/enter.rs
+++ b/components/hab/src/command/studio/enter.rs
@@ -15,7 +15,7 @@ pub const ARTIFACT_PATH_ENVVAR: &str = "ARTIFACT_PATH";
 
 const AUTH_TOKEN_ENVVAR: &str = "HAB_AUTH_TOKEN";
 const BLDR_URL_ENVVAR: &str = "HAB_BLDR_URL";
-const CTL_SECRET_ENVVAR: &str= "HAB_CTL_SECRET";
+const CTL_SECRET_ENVVAR: &str = "HAB_CTL_SECRET";
 const ORIGIN_ENVVAR: &str = "HAB_ORIGIN";
 const STUDIO_CMD: &str = "hab-studio";
 const STUDIO_CMD_ENVVAR: &str = "HAB_STUDIO_BINARY";

--- a/components/hab/src/command/studio/enter.rs
+++ b/components/hab/src/command/studio/enter.rs
@@ -26,10 +26,9 @@ fn set_env_var_from_config(env_var: &str, config_val: Option<String>, sensitive:
     if henv::var(env_var).is_err() {
         if let Some(val) = config_val {
             if sensitive {
-              debug!("Setting {}=REDACTED (sensitive) via config file", env_var)
-            }
-            else {
-              debug!("Setting {}={} via config file", env_var, val)
+                debug!("Setting {}=REDACTED (sensitive) via config file", env_var)
+            } else {
+                debug!("Setting {}={} via config file", env_var, val)
             }
             env::set_var(env_var, val);
         }

--- a/components/hab/src/command/studio/enter.rs
+++ b/components/hab/src/command/studio/enter.rs
@@ -22,6 +22,7 @@ const STUDIO_CMD: &str = "hab-studio";
 const STUDIO_CMD_ENVVAR: &str = "HAB_STUDIO_BINARY";
 const STUDIO_PACKAGE_IDENT: &str = "core/hab-studio";
 
+#[derive(Clone, Copy)]
 enum Sensitivity {
     PrintValue,
     NoPrintValue,

--- a/components/hab/src/command/studio/enter.rs
+++ b/components/hab/src/command/studio/enter.rs
@@ -22,7 +22,6 @@ const STUDIO_CMD: &str = "hab-studio";
 const STUDIO_CMD_ENVVAR: &str = "HAB_STUDIO_BINARY";
 const STUDIO_PACKAGE_IDENT: &str = "core/hab-studio";
 
-// fn set_env_var_from_config<T: Into<Option<bool>>>(env_var: &str, config_val: Option<String>, sensitive: T) {
 fn set_env_var_from_config(env_var: &str, config_val: Option<String>, sensitive: bool) {
     if henv::var(env_var).is_err() {
         if let Some(val) = config_val {

--- a/components/hab/src/command/studio/enter.rs
+++ b/components/hab/src/command/studio/enter.rs
@@ -22,12 +22,14 @@ const STUDIO_CMD_ENVVAR: &str = "HAB_STUDIO_BINARY";
 const STUDIO_PACKAGE_IDENT: &str = "core/hab-studio";
 
 // fn set_env_var_from_config<T: Into<Option<bool>>>(env_var: &str, config_val: Option<String>, sensitive: T) {
-fn set_env_var_from_config(env_var: &str, config_val: Option<String>, sensitive: Option<bool>) {
+fn set_env_var_from_config(env_var: &str, config_val: Option<String>, sensitive: bool) {
     if henv::var(env_var).is_err() {
         if let Some(val) = config_val {
-            match sensitive {
-              Some(_) => debug!("Setting Sensitive value {} via config file", env_var),
-              None => debug!("Setting {}={} via config file", env_var, val),
+            if sensitive {
+              debug!("Setting Sensitive value {} via config file", env_var)
+            }
+            else {
+              debug!("Setting {}={} via config file", env_var, val)
             }
             env::set_var(env_var, val);
         }
@@ -37,10 +39,10 @@ fn set_env_var_from_config(env_var: &str, config_val: Option<String>, sensitive:
 pub fn start(ui: &mut UI, args: &[OsString]) -> Result<()> {
     let config = config::load()?;
 
-    set_env_var_from_config(AUTH_TOKEN_ENVVAR, config.auth_token, Some(true));
-    set_env_var_from_config(BLDR_URL_ENVVAR, config.bldr_url, None);
-    set_env_var_from_config(CTL_SECRET_ENVVAR, config.ctl_secret, Some(true));
-    set_env_var_from_config(ORIGIN_ENVVAR, config.origin, None);
+    set_env_var_from_config(AUTH_TOKEN_ENVVAR, config.auth_token, true);
+    set_env_var_from_config(BLDR_URL_ENVVAR, config.bldr_url, false);
+    set_env_var_from_config(CTL_SECRET_ENVVAR, config.ctl_secret, true);
+    set_env_var_from_config(ORIGIN_ENVVAR, config.origin, false);
 
     if henv::var(CACHE_KEY_PATH_ENV_VAR).is_err() {
         let path = fs::cache_key_path(None::<&str>);

--- a/components/hab/src/command/studio/enter.rs
+++ b/components/hab/src/command/studio/enter.rs
@@ -21,49 +21,22 @@ const STUDIO_CMD: &str = "hab-studio";
 const STUDIO_CMD_ENVVAR: &str = "HAB_STUDIO_BINARY";
 const STUDIO_PACKAGE_IDENT: &str = "core/hab-studio";
 
-// fn set_env_var(env_var: &str) -> Result<()> {
-//   let config = config::load()?;
-//   if henv::var(env_var).is_err() {
-//     if let Some(config_val) = match env_var {
-//       AUTH_TOKEN_ENVVAR => config.auth_token,
-//       _ => println!("uh oh, this shouldn't happen"),
-//     };
-//     println!("config var is: {}", config_val);
-//     env::set_var(env_var, config_val)
-//   }
-// }
-
-fn set_env_var(env_var: &str, val: String) -> Result<()> {
-    debug!("Setting {}={} via config file", env_var, &val);
-    env::set_var(env_var, val);
-    Ok(())
+fn set_env_var_from_config(env_var: &str, config_val: Option<String>) {
+    if henv::var(env_var).is_err() {
+        if let Some(val) = config_val {
+            debug!("Setting {}={} via config file", env_var, val);
+            env::set_var(env_var, val);
+        }
+    }
 }
 
 pub fn start(ui: &mut UI, args: &[OsString]) -> Result<()> {
     let config = config::load()?;
-    if henv::var(AUTH_TOKEN_ENVVAR).is_err() {
-        if let Some(auth_token) = config.auth_token {
-          set_env_var(AUTH_TOKEN_ENVVAR, auth_token)?;
-        }
-    }
 
-    if henv::var(BLDR_URL_ENVVAR).is_err() {
-        if let Some(bldr_url) = config.bldr_url {
-            set_env_var(BLDR_URL_ENVVAR, bldr_url)?;
-        }
-    }
-
-    if henv::var(CTL_SECRET_ENVVAR).is_err() {
-        if let Some(ctl_secret) = config.ctl_secret {
-            set_env_var(CTL_SECRET_ENVVAR, ctl_secret)?;
-        }
-    }
-
-    if henv::var(ORIGIN_ENVVAR).is_err() {
-        if let Some(default_origin) = config.origin {
-            set_env_var(ORIGIN_ENVVAR, default_origin)?;
-        }
-    }
+    set_env_var_from_config(AUTH_TOKEN_ENVVAR, config.auth_token);
+    set_env_var_from_config(BLDR_URL_ENVVAR, config.bldr_url);
+    set_env_var_from_config(CTL_SECRET_ENVVAR, config.ctl_secret);
+    set_env_var_from_config(ORIGIN_ENVVAR, config.origin);
 
     if henv::var(CACHE_KEY_PATH_ENV_VAR).is_err() {
         let path = fs::cache_key_path(None::<&str>);

--- a/components/hab/src/command/studio/enter.rs
+++ b/components/hab/src/command/studio/enter.rs
@@ -9,14 +9,15 @@ use crate::{common::ui::UI,
                     fs}};
 
 use crate::{config,
-            error::Result};
+            error::Result,
+            BLDR_URL_ENVVAR,
+            CTL_SECRET_ENVVAR,
+            ORIGIN_ENVVAR};
+
+use habitat_core::AUTH_TOKEN_ENVVAR;
 
 pub const ARTIFACT_PATH_ENVVAR: &str = "ARTIFACT_PATH";
 
-const AUTH_TOKEN_ENVVAR: &str = "HAB_AUTH_TOKEN";
-const BLDR_URL_ENVVAR: &str = "HAB_BLDR_URL";
-const CTL_SECRET_ENVVAR: &str = "HAB_CTL_SECRET";
-const ORIGIN_ENVVAR: &str = "HAB_ORIGIN";
 const STUDIO_CMD: &str = "hab-studio";
 const STUDIO_CMD_ENVVAR: &str = "HAB_STUDIO_BINARY";
 const STUDIO_PACKAGE_IDENT: &str = "core/hab-studio";
@@ -26,7 +27,7 @@ fn set_env_var_from_config(env_var: &str, config_val: Option<String>, sensitive:
     if henv::var(env_var).is_err() {
         if let Some(val) = config_val {
             if sensitive {
-              debug!("Setting Sensitive value {} via config file", env_var)
+              debug!("Setting {}=REDACTED (sensitive) via config file", env_var)
             }
             else {
               debug!("Setting {}={} via config file", env_var, val)


### PR DESCRIPTION
This commit loads from `cli.toml` and sets:

* HAB_AUTH_TOKEN
* HAB_BLDR_URL
* HAB_CTL_SECRET

If these variables are not set before `hab studio enter` is executed.

This resolves #4908