### PR TITLE
[Studio][Tests] Use absolute drive path for windows studio name

### DIFF
--- a/components/studio/test/shared/studio-enter.ps1
+++ b/components/studio/test/shared/studio-enter.ps1
@@ -8,7 +8,7 @@ $env:HAB_NOCOLORING = "true"
 # Await has trouble parsing non-ascii glyphs
 $env:HAB_GLYPH_STYLE = "ascii"  
 $exit_code = 0
-$studio_name = "/hab/studios/studio-internals-test"
+$studio_name = "c:\hab\studios\studio-internals-test"
 try { 
     Start-AwaitSession 
     Send-AwaitCommand "$studio_command enter -o $studio_name" 
@@ -25,8 +25,10 @@ try {
 
 } finally { 
     Write-Host "Cleaning up"
-    Send-AwaitCommand "exit"
     
+    Send-AwaitCommand "exit"
+    Receive-AwaitResponse
+
     # Await won't block on "Waiting for supervisor to finish..." 
     # Copy the studio shutdown behavior and block for a bit until the supervisor has finished
     $retry = 0
@@ -36,12 +38,13 @@ try {
       Start-Sleep -Seconds 5
     }
 
-    Send-AwaitCommand "$studio_command rm"
-    
+    Send-AwaitCommand "$studio_command rm -o $studio_name"
+    Receive-AwaitResponse -Stream
+
     # Add the same behavior for `hab studio rm` to ensure that the studio is fully cleaned up before 
     # stopping the Await session.
     $retry = 0
-    while(($retry -lt 10) -and (Test-Path "$studio_name")) {
+    while(($retry -lt 5) -and (Test-Path "$studio_name")) {
       $retry += 1
       Write-Host "Waiting for Studio to exit..."
       Start-Sleep -Seconds 5

--- a/components/studio/test/shared/studio-enter.ps1
+++ b/components/studio/test/shared/studio-enter.ps1
@@ -8,7 +8,7 @@ $env:HAB_NOCOLORING = "true"
 # Await has trouble parsing non-ascii glyphs
 $env:HAB_GLYPH_STYLE = "ascii"  
 $exit_code = 0
-$studio_name = "c:\hab\studios\studio-internals-test"
+$studio_name = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath("/hab/studios/studio-internals-test")
 try { 
     Start-AwaitSession 
     Send-AwaitCommand "$studio_command enter -o $studio_name" 
@@ -44,7 +44,7 @@ try {
     # Add the same behavior for `hab studio rm` to ensure that the studio is fully cleaned up before 
     # stopping the Await session.
     $retry = 0
-    while(($retry -lt 5) -and (Test-Path "$studio_name")) {
+    while(($retry -lt 10) -and (Test-Path "$studio_name")) {
       $retry += 1
       Write-Host "Waiting for Studio to exit..."
       Start-Sleep -Seconds 5


### PR DESCRIPTION
When exiting the studio inside an Await session, the CWD would remain at the `[Habitat]` junction location.  This caused the Linux style path of `/hab/studios/studio-internals-test` to not be resolvable and the studio rm would fail, resulting in a failing test.  

This changes the studio name to use Windows-style drive letter paths, allowing the `hab studio rm` to behave as expected. 

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>