### PR TITLE
allow windows service to set arbitrary environment variables

### DIFF
--- a/components/windows-service/App.config
+++ b/components/windows-service/App.config
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
+    <!--
+    The 'debug' setting is deprecated and may not work as desired in a future release
+    of the windows-service. Use the 'ENV_RUST_LOG' setting instead and set it to 'debug'.
+    -->
     <add key="debug" value="false" />
-    <add key="HAB_FEAT_IGNORE_SIGNALS" value="true" />
+    <add key="ENV_HAB_FEAT_IGNORE_SIGNALS" value="true" />
     <add key="launcherArgs" value="--no-color" />
   </appSettings>
 </configuration>

--- a/components/windows-service/HabService.cs
+++ b/components/windows-service/HabService.cs
@@ -74,7 +74,7 @@ namespace HabService
             try
             {
                 ConfigureDebug();
-                ConfigureSupSignal();
+                ConfigureEnvironment();
 
                 // DataReceivedEventArgs.Data will return text in the default system
                 // locale. We can change that via System.Console.OutputEncoding for a console
@@ -108,6 +108,17 @@ namespace HabService
             }
         }
 
+        private static void ConfigureEnvironment()
+        {
+            var envPrefix = "ENV_";
+            foreach(var key in ConfigurationManager.AppSettings.AllKeys) {
+                var i = key.Trim().ToUpper();
+                if (i.StartsWith(envPrefix)) {
+                    Environment.SetEnvironmentVariable(i.Substring(envPrefix.Length), ConfigurationManager.AppSettings[key]);
+                }
+            }
+        }
+
         private static void ConfigureDebug()
         {
             if (ConfigurationManager.AppSettings["debug"] != null)
@@ -124,25 +135,6 @@ namespace HabService
             else
             {
                 Environment.SetEnvironmentVariable("RUST_LOG", null);
-            }
-        }
-
-        private static void ConfigureSupSignal()
-        {
-            if (ConfigurationManager.AppSettings["HAB_FEAT_IGNORE_SIGNALS"] != null)
-            {
-                if (ConfigurationManager.AppSettings["HAB_FEAT_IGNORE_SIGNALS"].ToLower() != "false")
-                {
-                    Environment.SetEnvironmentVariable("HAB_FEAT_IGNORE_SIGNALS", "true");
-                }
-                else
-                {
-                    Environment.SetEnvironmentVariable("HAB_FEAT_IGNORE_SIGNALS", null);
-                }
-            }
-            else
-            {
-                Environment.SetEnvironmentVariable("HAB_FEAT_IGNORE_SIGNALS", null);
             }
         }
 

--- a/components/windows-service/plan.ps1
+++ b/components/windows-service/plan.ps1
@@ -1,6 +1,6 @@
 $pkg_name="windows-service"
 $pkg_origin="core"
-$pkg_version="0.4.0"
+$pkg_version="0.5.0"
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_license=@('Apache-2.0')
 $pkg_description="A Windows Service for runnung the Habitat Supervisor"


### PR DESCRIPTION
fixes #6647 

Now users can create any application setting prefixed with `ENV_` and that setting (sans the `ENV_`) will be added to the environment of the service.

This also deprecates the debug setting which we will remove in a future release.

Signed-off-by: mwrock <matt@mattwrock.com>