### PR TITLE
remove assert for no events in spec watcher tests after adding files to be watched

### DIFF
--- a/components/sup/src/manager/spec_watcher.rs
+++ b/components/sup/src/manager/spec_watcher.rs
@@ -184,9 +184,6 @@ mod tests {
 
         file_with_content(&dir, "foo.spec", "fooooooo").expect("couldn't create file");
 
-        assert!(!sw.has_events(),
-                "Need to allow for the debounce interval to pass before you can expect events");
-
         while !sw.has_events() {
             wait_for_debounce_interval();
         }
@@ -216,9 +213,6 @@ mod tests {
 
         file_with_content(&dir, "foo.abc123xyz", "fooooooo").expect("couldn't create file");
 
-        assert!(!sw.has_events(),
-                "Need to allow for the debounce interval to pass before you can expect events");
-
         while !sw.has_events() {
             wait_for_debounce_interval();
         }
@@ -246,9 +240,6 @@ mod tests {
         assert!(!sw.has_events(), "There should be no events to start");
 
         file_with_content(&dir, "foo.spec", "fooooooo").expect("couldn't create file");
-
-        assert!(!sw.has_events(),
-                "Need to allow for the debounce interval to pass before you can expect events");
 
         while !sw.has_events() {
             wait_for_debounce_interval();


### PR DESCRIPTION
These tests have been pandomly failing recently. Likely since we just switched windows tests to docker.

All these tesst had this pattern:

```
        let sw = SpecWatcher::run(&spec_dir).expect("Couldn't create a SpecWatcher!");
        assert!(!sw.has_events(), "There should be no events to start");
        file_with_content(&dir, "foo.spec", "fooooooo").expect("couldn't create file");
        assert!(!sw.has_events(),
                "Need to allow for the debounce interval to pass before you can expect events");
        while !sw.has_events() {
            wait_for_debounce_interval();
        }
```

This assumes that the time it takes to get from `run` to the 2nd `assert!` will be shorter than the debounce period. Probably a sensible assumption in most cases but absolutely no guarantee and changing infra like we did with the move to docker could absolutely impact this.

At a closer glance, this second assert seems unnecesary. These tests are primarily concerned with if the events are getting registered at all so removing the assert should make the tests more reliable and keep them valid.

Signed-off-by: mwrock <matt@mattwrock.com>