### PR TITLE
Remove recusive memberlist locking

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -657,7 +657,7 @@ steps:
         shell: [ "powershell", "-Command" ]
         always-pull: true
         propagate-environment: true
-    timeout_in_minutes: 5
+    timeout_in_minutes: 20
     retry:
       automatic:
         limit: 1

--- a/components/butterfly/src/main.rs
+++ b/components/butterfly/src/main.rs
@@ -55,7 +55,7 @@ fn main() {
         server.member_list.add_initial_member_imlw(member);
     }
 
-    server.start_mlr(server::timing::Timing::default())
+    server.start_mlr(&server::timing::Timing::default())
           .expect("Cannot start server");
     loop {
         println!("{:#?}", server.member_list);

--- a/components/butterfly/src/main.rs
+++ b/components/butterfly/src/main.rs
@@ -52,10 +52,10 @@ fn main() {
         member.address = format!("{}", addr.ip());
         member.swim_port = addr.port();
         member.gossip_port = addr.port();
-        server.member_list.add_initial_member(member);
+        server.member_list.add_initial_member_imlw(member);
     }
 
-    server.start(server::timing::Timing::default())
+    server.start_mlr(server::timing::Timing::default())
           .expect("Cannot start server");
     loop {
         println!("{:#?}", server.member_list);

--- a/components/butterfly/src/member.rs
+++ b/components/butterfly/src/member.rs
@@ -983,7 +983,7 @@ mod tests {
         #[test]
         fn health_of_with_memberships() {
             let ml = populated_member_list(1);
-            ml.with_memberships_mlr(|Membership { member: _, health }| {
+            ml.with_memberships_mlr(|Membership { health, .. }| {
                   assert_eq!(health, Health::Alive);
                   Ok(0)
               })

--- a/components/butterfly/src/member.rs
+++ b/components/butterfly/src/member.rs
@@ -713,30 +713,6 @@ impl MemberList {
             .map(|member_list::Entry { member, .. }| member.clone())
     }
 
-    /// Calls a function whose argument is a reference to a membership entry matching the given ID.
-    ///
-    /// # Locking
-    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
-    ///   lock is held. Additionally `with_closure` is called with this lock held, so the closure
-    ///   must not call any functions which take this lock.
-    pub fn with_member_mlr(&self, member_id: &str, with_closure: impl Fn(Option<&Member>)) {
-        with_closure(self.read_entries()
-                         .get(member_id)
-                         .map(|member_list::Entry { member, .. }| member));
-    }
-
-    /// Iterates over the member list, calling the function for each member.
-    ///
-    /// # Locking
-    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
-    ///   lock is held. Additionally `with_closure` is called with this lock held, so the closure
-    ///   must not call any functions which take this lock.
-    pub fn with_members_mlr(&self, mut with_closure: impl FnMut(&Member)) {
-        for member_list::Entry { member, .. } in self.read_entries().values() {
-            with_closure(member);
-        }
-    }
-
     /// Iterates over the memberships list, calling the function for each membership.
     /// This could be return Result<T> instead, but there's only the one caller now.
     ///

--- a/components/butterfly/src/member.rs
+++ b/components/butterfly/src/member.rs
@@ -956,6 +956,16 @@ mod tests {
         }
 
         #[test]
+        fn health_of_with_memberships() {
+            let ml = populated_member_list(1);
+            ml.with_memberships(|Membership { member: _, health }| {
+                  assert_eq!(health, Health::Alive);
+                  Ok(0)
+              })
+              .ok();
+        }
+
+        #[test]
         fn pingreq_targets() {
             let ml = populated_member_list(10);
             ml.with_member_iter(|mut i| {

--- a/components/butterfly/src/server/expire.rs
+++ b/components/butterfly/src/server/expire.rs
@@ -14,11 +14,11 @@ const LOOP_DELAY_MS: u64 = 500;
 
 pub fn spawn_thread(name: String, server: Server, timing: Timing) -> std::io::Result<()> {
     thread::Builder::new().name(name)
-                          .spawn(|| run_loop(server, timing))
+                          .spawn(move || run_loop(&server, &timing))
                           .map(|_| ())
 }
 
-fn run_loop(server: Server, timing: Timing) -> ! {
+fn run_loop(server: &Server, timing: &Timing) -> ! {
     loop {
         habitat_common::sync::mark_thread_alive();
 

--- a/components/butterfly/src/server/expire.rs
+++ b/components/butterfly/src/server/expire.rs
@@ -12,42 +12,35 @@ use crate::{rumor::{RumorKey,
 
 const LOOP_DELAY_MS: u64 = 500;
 
-pub struct Expire {
-    pub server: Server,
-    pub timing: Timing,
+pub fn spawn_thread(name: String, server: Server, timing: Timing) -> std::io::Result<()> {
+    thread::Builder::new().name(name)
+                          .spawn(|| run_loop(server, timing))
+                          .map(|_| ())
 }
 
-impl Expire {
-    pub fn new(server: Server, timing: Timing) -> Expire { Expire { server, timing } }
+fn run_loop(server: Server, timing: Timing) -> ! {
+    loop {
+        habitat_common::sync::mark_thread_alive();
 
-    pub fn run(&self) {
-        loop {
-            habitat_common::sync::mark_thread_alive();
+        let newly_confirmed_members =
+            server.member_list
+                  .members_expired_to_confirmed_mlw(timing.suspicion_timeout_duration());
 
-            let newly_confirmed_members =
-                self.server
-                    .member_list
-                    .members_expired_to_confirmed(self.timing.suspicion_timeout_duration());
-
-            for id in newly_confirmed_members {
-                self.server
-                    .rumor_heat
-                    .start_hot_rumor(RumorKey::new(RumorType::Member, &id, ""));
-            }
-
-            let newly_departed_members =
-                self.server
-                    .member_list
-                    .members_expired_to_departed(self.timing.departure_timeout_duration());
-
-            for id in newly_departed_members {
-                self.server.rumor_heat.purge(&id);
-                self.server
-                    .rumor_heat
-                    .start_hot_rumor(RumorKey::new(RumorType::Member, &id, ""));
-            }
-
-            thread::sleep(Duration::from_millis(LOOP_DELAY_MS));
+        for id in newly_confirmed_members {
+            server.rumor_heat
+                  .start_hot_rumor(RumorKey::new(RumorType::Member, &id, ""));
         }
+
+        let newly_departed_members =
+            server.member_list
+                  .members_expired_to_departed_mlw(timing.departure_timeout_duration());
+
+        for id in newly_departed_members {
+            server.rumor_heat.purge(&id);
+            server.rumor_heat
+                  .start_hot_rumor(RumorKey::new(RumorType::Member, &id, ""));
+        }
+
+        thread::sleep(Duration::from_millis(LOOP_DELAY_MS));
     }
 }

--- a/components/butterfly/src/server/inbound.rs
+++ b/components/butterfly/src/server/inbound.rs
@@ -33,198 +33,204 @@ lazy_static! {
                                 &["type", "mode"]).unwrap();
 }
 
-/// Takes the Server and a channel to send received Acks to the outbound thread.
-pub struct Inbound {
-    pub server:      Server,
-    pub socket:      UdpSocket,
-    pub tx_outbound: AckSender,
+pub fn spawn_thread(name: String,
+                    server: Server,
+                    socket: UdpSocket,
+                    tx_outbound: AckSender)
+                    -> std::io::Result<()> {
+    thread::Builder::new().name(name)
+                          .spawn(|| run_loop(server, socket, tx_outbound))
+                          .map(|_| ())
 }
 
-impl Inbound {
-    /// Create a new Inbound.
-    pub fn new(server: Server, socket: UdpSocket, tx_outbound: AckSender) -> Inbound {
-        Inbound { server,
-                  socket,
-                  tx_outbound }
-    }
+/// Run the thread. Listens for messages up to 1k in size, and then processes them accordingly.
+/// Takes the Server and a channel to send received Acks to the outbound thread.
+///
+/// # Locking
+/// * `MemberList::entries` (read) This method must not be called while any MemberList::entries lock
+///   is held.
+pub fn run_loop(server: Server, socket: UdpSocket, tx_outbound: AckSender) -> ! {
+    let mut recv_buffer: Vec<u8> = vec![0; 1024];
 
-    /// Run the thread. Listens for messages up to 1k in size, and then processes them accordingly.
-    pub fn run(&self) {
-        let mut recv_buffer: Vec<u8> = vec![0; 1024];
+    loop {
+        habitat_common::sync::mark_thread_alive();
 
-        loop {
-            habitat_common::sync::mark_thread_alive();
-
-            if self.server.paused() {
-                thread::sleep(Duration::from_millis(100));
-                continue;
-            }
-
-            match self.socket.recv_from(&mut recv_buffer[..]) {
-                Ok((length, addr)) => {
-                    let swim_payload = match self.server.unwrap_wire(&recv_buffer[0..length]) {
-                        Ok(swim_payload) => swim_payload,
-                        Err(e) => {
-                            // NOTE: In the future, we might want to block people who send us
-                            // garbage all the time.
-                            error!("Error unwrapping protocol message, {}", e);
-                            let label_values = &["unwrap_wire", "failure"];
-                            SWIM_BYTES_RECEIVED.with_label_values(label_values)
-                                               .set(length.to_i64());
-                            SWIM_MESSAGES_RECEIVED.with_label_values(label_values).inc();
-                            continue;
-                        }
-                    };
-
-                    let bytes_received = swim_payload.len();
-                    let msg = match Swim::decode(&swim_payload) {
-                        Ok(msg) => msg,
-                        Err(e) => {
-                            // NOTE: In the future, we might want to block people who send us
-                            // garbage all the time.
-                            error!("Error decoding protocol message, {}", e);
-                            let label_values = &["undecodable", "failure"];
-                            SWIM_BYTES_RECEIVED.with_label_values(label_values)
-                                               .set(bytes_received.to_i64());
-                            SWIM_MESSAGES_RECEIVED.with_label_values(label_values).inc();
-                            continue;
-                        }
-                    };
-
-                    // Setting a label_values variable here throws errors about moving borrowed
-                    // content that I couldn't solve w/o clones. Leaving this for now. I'm sure
-                    // there's a better way.
-                    SWIM_BYTES_RECEIVED.with_label_values(&[msg.kind.as_str(), "success"])
-                                       .set(bytes_received.to_i64());
-                    SWIM_MESSAGES_RECEIVED.with_label_values(&[msg.kind.as_str(), "success"])
-                                          .inc();
-
-                    trace!("SWIM Message: {:?}", msg);
-                    match msg.kind {
-                        SwimKind::Ping(ping) => {
-                            if self.server.is_member_blocked(&ping.from.id) {
-                                debug!("Not processing message from {} - it is blocked",
-                                       ping.from.id);
-                                continue;
-                            }
-                            self.process_ping(addr, ping);
-                        }
-                        SwimKind::Ack(ack) => {
-                            if self.server.is_member_blocked(&ack.from.id)
-                               && ack.forward_to.is_none()
-                            {
-                                debug!("Not processing message from {} - it is blocked",
-                                       ack.from.id);
-                                continue;
-                            }
-                            self.process_ack(addr, ack);
-                        }
-                        SwimKind::PingReq(pingreq) => {
-                            if self.server.is_member_blocked(&pingreq.from.id) {
-                                debug!("Not processing message from {} - it is blocked",
-                                       pingreq.from.id);
-                                continue;
-                            }
-                            self.process_pingreq(addr, pingreq);
-                        }
-                    }
-                }
-                Err(e) => {
-                    // TODO: We can't use magic numbers here because the Supervisor runs on more
-                    // than one platform. I'm sure these were added as specific OS errors for Linux
-                    // but we need to also handle Windows & Mac.
-                    match e.raw_os_error() {
-                        Some(35) | Some(11) | Some(10035) | Some(10060) => {
-                            // This is the normal non-blocking result, or a timeout
-                        }
-                        Some(_) => {
-                            error!("UDP Receive error: {}", e);
-                            debug!("UDP Receive error debug: {:?}", e);
-                        }
-                        None => {
-                            error!("UDP Receive error: {}", e);
-                        }
-                    }
-                }
-            }
+        if server.paused() {
+            thread::sleep(Duration::from_millis(100));
+            continue;
         }
-    }
 
-    /// Process pingreq messages.
-    fn process_pingreq(&self, addr: SocketAddr, mut msg: PingReq) {
-        trace_it!(SWIM: &self.server, TraceKind::RecvPingReq, &msg.from.id, addr, &msg);
-        msg.from.address = addr.ip().to_string();
-        let id = msg.target.id.clone(); // TODO: see if we can eliminate this clone
-        self.server.member_list.with_member(&id, |target| {
-                                   if let Some(target) = target {
-                                       // Set the route-back address to the one we received the
-                                       // pingreq from
-                                       outbound::ping(&self.server,
-                                                      &self.socket,
-                                                      target,
-                                                      target.swim_socket_address(),
-                                                      Some(&msg.from));
-                                   } else {
-                                       error!("PingReq request {:?} for invalid target", msg);
-                                   }
-                               });
-    }
-
-    /// Process ack messages; forwards to the outbound thread.
-    fn process_ack(&self, addr: SocketAddr, mut msg: Ack) {
-        trace_it!(SWIM: &self.server, TraceKind::RecvAck, &msg.from.id, addr, &msg);
-        trace!("Ack from {}@{}", msg.from.id, addr);
-        if msg.forward_to.is_some() && *self.server.member_id != msg.forward_to.as_ref().unwrap().id
-        {
-            let (forward_to_addr, from_addr) = {
-                let forward_to = msg.forward_to.as_ref().unwrap();
-                let forward_addr_str = format!("{}:{}", forward_to.address, forward_to.swim_port);
-                let forward_to_addr = match forward_addr_str.parse() {
-                    Ok(addr) => addr,
+        match socket.recv_from(&mut recv_buffer[..]) {
+            Ok((length, addr)) => {
+                let swim_payload = match server.unwrap_wire(&recv_buffer[0..length]) {
+                    Ok(swim_payload) => swim_payload,
                     Err(e) => {
-                        error!("Abandoning Ack forward: cannot parse member address: {}:{}, {}",
-                               forward_to.address, forward_to.swim_port, e);
-                        return;
+                        // NOTE: In the future, we might want to block people who send us
+                        // garbage all the time.
+                        error!("Error unwrapping protocol message, {}", e);
+                        let label_values = &["unwrap_wire", "failure"];
+                        SWIM_BYTES_RECEIVED.with_label_values(label_values)
+                                           .set(length.to_i64());
+                        SWIM_MESSAGES_RECEIVED.with_label_values(label_values).inc();
+                        continue;
                     }
                 };
-                trace!("Forwarding Ack from {}@{} to {}@{}",
-                       msg.from.id,
-                       addr,
-                       forward_to.id,
-                       forward_to.address,);
-                (forward_to_addr, addr.ip().to_string())
-            };
-            msg.from.address = from_addr;
-            outbound::forward_ack(&self.server, &self.socket, forward_to_addr, msg);
-            return;
-        }
-        let memberships = msg.membership.clone();
-        match self.tx_outbound.send((addr, msg)) {
-            Ok(()) => {
-                for membership in memberships {
-                    self.server
-                        .insert_member_from_rumor(membership.member, membership.health);
+
+                let bytes_received = swim_payload.len();
+                let msg = match Swim::decode(&swim_payload) {
+                    Ok(msg) => msg,
+                    Err(e) => {
+                        // NOTE: In the future, we might want to block people who send us
+                        // garbage all the time.
+                        error!("Error decoding protocol message, {}", e);
+                        let label_values = &["undecodable", "failure"];
+                        SWIM_BYTES_RECEIVED.with_label_values(label_values)
+                                           .set(bytes_received.to_i64());
+                        SWIM_MESSAGES_RECEIVED.with_label_values(label_values).inc();
+                        continue;
+                    }
+                };
+
+                // Setting a label_values variable here throws errors about moving borrowed
+                // content that I couldn't solve w/o clones. Leaving this for now. I'm sure
+                // there's a better way.
+                SWIM_BYTES_RECEIVED.with_label_values(&[msg.kind.as_str(), "success"])
+                                   .set(bytes_received.to_i64());
+                SWIM_MESSAGES_RECEIVED.with_label_values(&[msg.kind.as_str(), "success"])
+                                      .inc();
+
+                trace!("SWIM Message: {:?}", msg);
+                match msg.kind {
+                    SwimKind::Ping(ping) => {
+                        if server.is_member_blocked(&ping.from.id) {
+                            debug!("Not processing message from {} - it is blocked",
+                                   ping.from.id);
+                            continue;
+                        }
+                        process_ping(&server, &socket, addr, ping);
+                    }
+                    SwimKind::Ack(ack) => {
+                        if server.is_member_blocked(&ack.from.id) && ack.forward_to.is_none() {
+                            debug!("Not processing message from {} - it is blocked",
+                                   ack.from.id);
+                            continue;
+                        }
+                        process_ack(&server, &socket, &tx_outbound, addr, ack);
+                    }
+                    SwimKind::PingReq(pingreq) => {
+                        if server.is_member_blocked(&pingreq.from.id) {
+                            debug!("Not processing message from {} - it is blocked",
+                                   pingreq.from.id);
+                            continue;
+                        }
+                        process_pingreq_mlr(&server, &socket, addr, pingreq);
+                    }
                 }
             }
-            Err(e) => panic!("Outbound thread has died - this shouldn't happen: #{:?}", e),
+            Err(e) => {
+                // TODO: We can't use magic numbers here because the Supervisor runs on more
+                // than one platform. I'm sure these were added as specific OS errors for Linux
+                // but we need to also handle Windows & Mac.
+                match e.raw_os_error() {
+                    Some(35) | Some(11) | Some(10035) | Some(10060) => {
+                        // This is the normal non-blocking result, or a timeout
+                    }
+                    Some(_) => {
+                        error!("UDP Receive error: {}", e);
+                        debug!("UDP Receive error debug: {:?}", e);
+                    }
+                    None => {
+                        error!("UDP Receive error: {}", e);
+                    }
+                }
+            }
         }
     }
+}
 
-    /// Process ping messages.
-    fn process_ping(&self, addr: SocketAddr, mut msg: Ping) {
-        trace_it!(SWIM: &self.server, TraceKind::RecvPing, &msg.from.id, addr, &msg);
-        outbound::ack(&self.server, &self.socket, &msg.from, addr, msg.forward_to);
-        // Populate the member for this sender with its remote address
-        msg.from.address = addr.ip().to_string();
-        trace!("Ping from {}@{}", msg.from.id, addr);
-        if msg.from.departed {
-            self.server.insert_member(msg.from, Health::Departed);
-        } else {
-            self.server.insert_member(msg.from, Health::Alive);
+/// Process pingreq messages.
+///
+/// # Locking
+/// * `MemberList::entries` (read) This method must not be called while any MemberList::entries lock
+///   is held.
+fn process_pingreq_mlr(server: &Server, socket: &UdpSocket, addr: SocketAddr, mut msg: PingReq) {
+    trace_it!(SWIM: server,
+              TraceKind::RecvPingReq,
+              &msg.from.id,
+              addr,
+              &msg);
+    msg.from.address = addr.ip().to_string();
+    let id = msg.target.id.clone(); // TODO: see if we can eliminate this clone
+    server.member_list.with_member_mlr(&id, |target| {
+                          if let Some(target) = target {
+                              // Set the route-back address to the one we received the
+                              // pingreq from
+                              // XXX Recursive lock!
+                              outbound::ping_mlr(server,
+                                                 socket,
+                                                 target,
+                                                 target.swim_socket_address(),
+                                                 Some(&msg.from));
+                          } else {
+                              error!("PingReq request {:?} for invalid target", msg);
+                          }
+                      });
+}
+
+/// Process ack messages; forwards to the outbound thread.
+fn process_ack(server: &Server,
+               socket: &UdpSocket,
+               tx_outbound: &AckSender,
+               addr: SocketAddr,
+               mut msg: Ack) {
+    trace_it!(SWIM: server, TraceKind::RecvAck, &msg.from.id, addr, &msg);
+    trace!("Ack from {}@{}", msg.from.id, addr);
+    if msg.forward_to.is_some() && *server.member_id != msg.forward_to.as_ref().unwrap().id {
+        let (forward_to_addr, from_addr) = {
+            let forward_to = msg.forward_to.as_ref().unwrap();
+            let forward_addr_str = format!("{}:{}", forward_to.address, forward_to.swim_port);
+            let forward_to_addr = match forward_addr_str.parse() {
+                Ok(addr) => addr,
+                Err(e) => {
+                    error!("Abandoning Ack forward: cannot parse member address: {}:{}, {}",
+                           forward_to.address, forward_to.swim_port, e);
+                    return;
+                }
+            };
+            trace!("Forwarding Ack from {}@{} to {}@{}",
+                   msg.from.id,
+                   addr,
+                   forward_to.id,
+                   forward_to.address,);
+            (forward_to_addr, addr.ip().to_string())
+        };
+        msg.from.address = from_addr;
+        outbound::forward_ack(server, socket, forward_to_addr, msg);
+        return;
+    }
+    let memberships = msg.membership.clone();
+    match tx_outbound.send((addr, msg)) {
+        Ok(()) => {
+            for membership in memberships {
+                server.insert_member_from_rumor(membership.member, membership.health);
+            }
         }
-        for membership in msg.membership {
-            self.server
-                .insert_member_from_rumor(membership.member, membership.health);
-        }
+        Err(e) => panic!("Outbound thread has died - this shouldn't happen: #{:?}", e),
+    }
+}
+
+fn process_ping(server: &Server, socket: &UdpSocket, addr: SocketAddr, mut msg: Ping) {
+    trace_it!(SWIM: server, TraceKind::RecvPing, &msg.from.id, addr, &msg);
+    outbound::ack(server, socket, &msg.from, addr, msg.forward_to);
+    // Populate the member for this sender with its remote address
+    msg.from.address = addr.ip().to_string();
+    trace!("Ping from {}@{}", msg.from.id, addr);
+    if msg.from.departed {
+        server.insert_member(msg.from, Health::Departed);
+    } else {
+        server.insert_member(msg.from, Health::Alive);
+    }
+    for membership in msg.membership {
+        server.insert_member_from_rumor(membership.member, membership.health);
     }
 }

--- a/components/butterfly/src/server/mod.rs
+++ b/components/butterfly/src/server/mod.rs
@@ -413,7 +413,7 @@ impl Server {
     /// * Returns `Error::CannotBind` if the socket cannot be bound
     /// * Returns `Error::SocketSetReadTimeout` if the socket read timeout cannot be set
     /// * Returns `Error::SocketSetWriteTimeout` if the socket write timeout cannot be set
-    pub fn start_mlr(&mut self, timing: timing::Timing) -> Result<()> {
+    pub fn start_mlr(&mut self, timing: &timing::Timing) -> Result<()> {
         debug!("entering habitat_butterfly::server::Server::start");
         let (tx_outbound, rx_inbound) = channel();
         if let Some(ref path) = self.data_path {
@@ -1176,11 +1176,11 @@ impl fmt::Display for Server {
 
 fn spawn_persist_thread(name: String, server: Server) -> std::io::Result<()> {
     thread::Builder::new().name(name)
-                          .spawn(|| persist_loop(server))
+                          .spawn(move || persist_loop(&server))
                           .map(|_| ())
 }
 
-fn persist_loop(server: Server) -> ! {
+fn persist_loop(server: &Server) -> ! {
     habitat_core::env_config_duration!(PersistLoopPeriod,
                                        HAB_PERSIST_LOOP_PERIOD_SECS => from_secs,
                                        Duration::from_secs(30));
@@ -1673,14 +1673,14 @@ mod tests {
         fn new_with_corrupt_rumor_file() {
             let tmpdir = TempDir::new().unwrap();
             let mut server = start_with_corrupt_rumor_file(&tmpdir);
-            server.start_mlr(Timing::default())
+            server.start_mlr(&Timing::default())
                   .expect("Server failed to start");
         }
 
         #[test]
         fn start_listener() {
             let mut server = start_server();
-            server.start_mlr(Timing::default())
+            server.start_mlr(&Timing::default())
                   .expect("Server failed to start");
         }
     }

--- a/components/butterfly/src/server/mod.rs
+++ b/components/butterfly/src/server/mod.rs
@@ -1443,7 +1443,7 @@ mod tests {
                                     &rumor_heat,
                                     check_quorum_returns(false));
 
-        assert_eq!(member_list.health_of(&confirmed_member),
+        assert_eq!(member_list.health_of_mlr(&confirmed_member),
                    Some(Health::Confirmed));
 
         Server::insert_service_impl(alive_member_service_rumor.clone(),
@@ -1452,7 +1452,7 @@ mod tests {
                                     &rumor_heat,
                                     check_quorum_returns(false));
 
-        assert_eq!(member_list.health_of(&confirmed_member),
+        assert_eq!(member_list.health_of_mlr(&confirmed_member),
                    Some(Health::Departed));
     }
 
@@ -1493,7 +1493,7 @@ mod tests {
                                     &rumor_heat,
                                     check_quorum_returns(false));
 
-        assert_eq!(member_list.health_of(&confirmed_member),
+        assert_eq!(member_list.health_of_mlr(&confirmed_member),
                    Some(Health::Confirmed));
     }
 
@@ -1516,7 +1516,7 @@ mod tests {
                                     &rumor_heat,
                                     check_quorum_returns(true));
 
-        assert_eq!(member_list.health_of(&confirmed_member),
+        assert_eq!(member_list.health_of_mlr(&confirmed_member),
                    Some(Health::Confirmed));
 
         Server::insert_service_impl(alive_member_service_rumor.clone(),
@@ -1525,7 +1525,7 @@ mod tests {
                                     &rumor_heat,
                                     check_quorum_returns(true));
 
-        assert_eq!(member_list.health_of(&confirmed_member),
+        assert_eq!(member_list.health_of_mlr(&confirmed_member),
                    Some(Health::Confirmed));
     }
     mod myself {

--- a/components/butterfly/src/server/mod.rs
+++ b/components/butterfly/src/server/mod.rs
@@ -404,12 +404,16 @@ impl Server {
     /// Start the server, along with a `Timing` for outbound connections. Spawns the `inbound`,
     /// `outbound`, and `expire` threads.
     ///
+    /// # Locking
+    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
+    ///   lock is held.
+    ///
     /// # Errors
     ///
     /// * Returns `Error::CannotBind` if the socket cannot be bound
     /// * Returns `Error::SocketSetReadTimeout` if the socket read timeout cannot be set
     /// * Returns `Error::SocketSetWriteTimeout` if the socket write timeout cannot be set
-    pub fn start(&mut self, timing: timing::Timing) -> Result<()> {
+    pub fn start_mlr(&mut self, timing: timing::Timing) -> Result<()> {
         debug!("entering habitat_butterfly::server::Server::start");
         let (tx_outbound, rx_inbound) = channel();
         if let Some(ref path) = self.data_path {
@@ -418,7 +422,7 @@ impl Server {
             }
             let mut file = DatFile::new(&self.member_id, path);
             if file.path().exists() {
-                match file.read_into(self) {
+                match file.read_into_mlr(self) {
                     Ok(_) => {
                         debug!("Successfully ingested rumors from {}",
                                file.path().display())
@@ -442,81 +446,47 @@ impl Server {
             }
         }
 
-        let socket = match UdpSocket::bind(self.swim_addr) {
-            Ok(socket) => socket,
-            Err(e) => return Err(Error::CannotBind(e)),
-        };
+        let socket = UdpSocket::bind(self.swim_addr)?;
         socket.set_read_timeout(Some(Duration::from_millis(1000)))
               .map_err(Error::SocketSetReadTimeout)?;
         socket.set_write_timeout(Some(Duration::from_millis(1000)))
               .map_err(Error::SocketSetReadTimeout)?;
 
-        let server_a = self.clone();
-        let socket_a = match socket.try_clone() {
-            Ok(socket_a) => socket_a,
-            Err(_) => return Err(Error::SocketCloneError),
-        };
-        let socket_expire = match socket.try_clone() {
-            Ok(socket_expire) => socket_expire,
-            Err(_) => return Err(Error::SocketCloneError),
-        };
-        self.socket = Some(socket_expire);
+        self.socket = Some(socket.try_clone()?);
 
-        let _ =
-            thread::Builder::new().name(format!("inbound-{}", self.name()))
-                                  .spawn(move || {
-                                      inbound::Inbound::new(server_a, socket_a, tx_outbound).run();
-                                      panic!("You should never, ever get here, judy");
-                                  });
+        inbound::spawn_thread(format!("inbound-{}", self.name()),
+                              self.clone(),
+                              socket.try_clone()?,
+                              tx_outbound)?;
 
-        let server_b = self.clone();
-        let socket_b = match socket.try_clone() {
-            Ok(socket_b) => socket_b,
-            Err(_) => return Err(Error::SocketCloneError),
-        };
-        let timing_b = timing.clone();
-        let _ = thread::Builder::new().name(format!("outbound-{}", self.name()))
-                                      .spawn(move || {
-                                          outbound::Outbound::new(server_b, socket_b, rx_inbound,
-                                                                  timing_b).run();
-                                          panic!("You should never, ever get here, bob");
-                                      });
+        outbound::spawn_thread(format!("outbound-{}", self.name()),
+                               self.clone(),
+                               socket,
+                               rx_inbound,
+                               timing.clone())?;
 
-        let server_c = self.clone();
-        let timing_c = timing.clone();
-        let _ = thread::Builder::new().name(format!("expire-{}", self.name()))
-                                      .spawn(move || {
-                                          expire::Expire::new(server_c, timing_c).run();
-                                          panic!("You should never, ever get here, frank");
-                                      });
+        expire::spawn_thread(format!("expire-{}", self.name()),
+                             self.clone(),
+                             timing.clone())?;
 
-        let server_d = self.clone();
-        let _ = thread::Builder::new().name(format!("pull-{}", self.name()))
-                                      .spawn(move || {
-                                          pull::Pull::new(server_d).run();
-                                          panic!("You should never, ever get here, davey");
-                                      });
+        pull::spawn_thread(format!("pull-{}", self.name()), self.clone())?;
 
-        let server_e = self.clone();
-        let _ = thread::Builder::new().name(format!("push-{}", self.name()))
-                                      .spawn(move || {
-                                          push::Push::new(server_e, timing).run();
-                                          panic!("You should never, ever get here, liu");
-                                      });
+        push::spawn_thread(format!("push-{}", self.name()),
+                           self.clone(),
+                           timing.clone())?;
 
         if self.dat_file.is_some() {
-            let server_f = self.clone();
-            let _ = thread::Builder::new().name(format!("persist-{}", self.name()))
-                                          .spawn(move || {
-                                              persist_loop(&server_f);
-                                              panic!("Data persistence loop unexpectedly quit!");
-                                          });
+            spawn_persist_thread(format!("persist-{}", self.name()), self.clone())?;
         }
 
         Ok(())
     }
 
-    pub fn need_peer_seeding(&self) -> bool { self.member_list.is_empty() }
+    /// # Locking
+    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
+    ///   lock is held. Additionally `with_closure` is called with this lock held, so the closure
+    ///   must not call any functions which take this lock.
+    pub fn need_peer_seeding_mlr(&self) -> bool { self.member_list.is_empty_mlr() }
 
     /// Persistently block a given address, causing no traffic to be seen.
     pub fn add_to_block_list(&self, member_id: String) {
@@ -567,6 +537,10 @@ impl Server {
     pub fn name(&self) -> &str { &self.name }
 
     /// Insert a member to the `MemberList`, and update its `RumorKey` appropriately.
+    ///
+    /// # Locking
+    /// * `MemberList::entries` (write) This method must not be called while any MemberList::entries
+    ///   lock is held.
     pub fn insert_member(&self, member: Member, health: Health) {
         let rk: RumorKey = RumorKey::from(&member);
         // NOTE: This sucks so much right here. Check out how we allocate no matter what, because
@@ -575,7 +549,7 @@ impl Server {
         let member_id = member.id.clone();
         let trace_incarnation = member.incarnation;
         let trace_health = health;
-        if self.member_list.insert(member, health) {
+        if self.member_list.insert_mlw(member, health) {
             trace_it!(MEMBERSHIP: self,
                       TraceKind::MemberUpdate,
                       member_id,
@@ -596,7 +570,11 @@ impl Server {
 
     /// Set our member to departed, then send up to 10 out of order ack messages to other
     /// members to seed our status.
-    pub fn set_departed(&self) {
+    ///
+    /// # Locking
+    /// * `MemberList::entries` (write) This method must not be called while any MemberList::entries
+    ///   lock is held.
+    pub fn set_departed_mlw(&self) {
         if self.socket.is_some() {
             {
                 let mut me = self.member.write().expect("Member lock is poisoned");
@@ -605,7 +583,7 @@ impl Server {
                 // actually needed.
                 me.mark_departed();
 
-                self.member_list.set_departed(&self.member_id);
+                self.member_list.set_departed_mlw(&self.member_id);
                 trace_it!(MEMBERSHIP: self,
                           TraceKind::MemberUpdate,
                           self.member_id.clone(),
@@ -622,7 +600,7 @@ impl Server {
             self.rumor_heat
                 .start_hot_rumor(RumorKey::new(RumorType::Member, &self.member_id, ""));
 
-            let check_list = self.member_list.check_list(&self.member_id);
+            let check_list = self.member_list.check_list_mlr(&self.member_id);
 
             // TODO (CM): Even though we marked the rumor as hot
             // above, when we gossip, we send out the 5 "coolest but
@@ -641,6 +619,10 @@ impl Server {
     }
 
     /// Given a membership record and some health, insert it into the Member List.
+    ///
+    /// # Locking
+    /// * `MemberList::entries` (write) This method must not be called while any MemberList::entries
+    ///   lock is held.
     fn insert_member_from_rumor(&self, member: Member, mut health: Health) {
         let rk: RumorKey = RumorKey::from(&member);
         if member.id == self.member_id() && health != Health::Alive {
@@ -657,7 +639,7 @@ impl Server {
         let trace_incarnation = member.incarnation;
         let trace_health = health;
 
-        if self.member_list.insert(member, health) {
+        if self.member_list.insert_mlw(member, health) {
             trace_it!(MEMBERSHIP: self,
                       TraceKind::MemberUpdate,
                       member_id,
@@ -682,6 +664,10 @@ impl Server {
     ///
     /// See https://github.com/habitat-sh/habitat/issues/1994
     /// See Server::check_quorum
+    ///
+    /// # Locking
+    /// * `MemberList::entries` (write) This method must not be called while any MemberList::entries
+    ///   lock is held.
     pub fn insert_service(&self, service: Service) {
         Self::insert_service_impl(service,
                                   &self.service_store,
@@ -707,10 +693,10 @@ impl Server {
             if inserting_new_group_member && !check_quorum(service_group) {
                 if let Some(member_id_to_depart) =
                     service_store.min_member_id_with(service_group, |id| {
-                                     member_list.health_of_by_id(id) == Some(Health::Confirmed)
+                                     member_list.health_of_by_id_mlr(id) == Some(Health::Confirmed)
                                  })
                 {
-                    member_list.set_departed(&member_id_to_depart);
+                    member_list.set_departed_mlw(&member_id_to_depart);
                     rumor_heat.purge(&member_id_to_depart);
                     rumor_heat.start_hot_rumor(RumorKey::new(RumorType::Member,
                                                              &member_id_to_depart,
@@ -738,6 +724,10 @@ impl Server {
     }
 
     /// Insert a departure rumor into the departure store.
+    ///
+    /// # Locking
+    /// * `MemberList::entries` (write) This method must not be called while any MemberList::entries
+    ///   lock is held.
     pub fn insert_departure(&self, departure: Departure) {
         let rk = RumorKey::from(&departure);
         if *self.member_id == departure.member_id {
@@ -745,7 +735,7 @@ impl Server {
                 .compare_and_swap(false, true, Ordering::Relaxed);
         }
 
-        self.member_list.set_departed(&departure.member_id);
+        self.member_list.set_departed_mlw(&departure.member_id);
 
         self.rumor_heat.purge(&departure.member_id);
         self.rumor_heat
@@ -758,10 +748,14 @@ impl Server {
 
     /// Get all the Member ID's who are present in a given service group, and eligible to vote
     /// (alive)
-    fn get_electorate(&self, key: &str) -> Vec<String> {
+    ///
+    /// # Locking
+    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
+    ///   lock is held.
+    fn get_electorate_mlr(&self, key: &str) -> Vec<String> {
         let mut electorate = vec![];
         self.service_store.with_rumors(key, |s| {
-                              if self.member_list.health_of_by_id(&s.member_id)
+                              if self.member_list.health_of_by_id_mlr(&s.member_id)
                                  == Some(Health::Alive)
                               {
                                   electorate.push(s.member_id.clone());
@@ -770,18 +764,25 @@ impl Server {
         electorate
     }
 
-    fn check_in_voting_population_by_id(&self, member_id: &str) -> bool {
-        match self.member_list.health_of_by_id(member_id) {
+    /// # Locking
+    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
+    ///   lock is held.
+    fn check_in_voting_population_by_id_mlr(&self, member_id: &str) -> bool {
+        match self.member_list.health_of_by_id_mlr(member_id) {
             Some(Health::Alive) | Some(Health::Suspect) | Some(Health::Confirmed) => true,
             Some(Health::Departed) | None => false,
         }
     }
 
     /// Get all the Member ID's who are present in a given service group, and count towards quorum.
-    fn get_total_population(&self, key: &str) -> Vec<String> {
+    ///
+    /// # Locking
+    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
+    ///   lock is held.
+    fn get_total_population_mlr(&self, key: &str) -> Vec<String> {
         let mut total_pop = vec![];
         self.service_store.with_rumors(key, |s| {
-                              if self.check_in_voting_population_by_id(&s.member_id) {
+                              if self.check_in_voting_population_by_id_mlr(&s.member_id) {
                                   total_pop.push(s.member_id.clone());
                               }
                           });
@@ -791,9 +792,13 @@ impl Server {
     /// Check if a given service group has quorum to run an election.
     ///
     /// A group has quorum if a majority of its non-departed members are alive.
+    ///
+    /// # Locking
+    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
+    ///   lock is held.
     fn check_quorum(&self, key: &str) -> bool {
-        let electorate = self.get_electorate(key);
-        let service_group_members = self.get_total_population(key);
+        let electorate = self.get_electorate_mlr(key);
+        let service_group_members = self.get_total_population_mlr(key);
         let total_population = service_group_members.len();
         let alive_population = electorate.len();
         let has_quorum = alive_population > total_population / 2;
@@ -842,10 +847,13 @@ impl Server {
         self.update_store.insert(e);
     }
 
-    fn elections_to_restart<T>(&self,
-                               elections: &RumorStore<T>,
-                               feature_flags: FeatureFlag)
-                               -> Vec<(String, u64)>
+    /// # Locking
+    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
+    ///   lock is held.
+    fn elections_to_restart_mlr<T>(&self,
+                                   elections: &RumorStore<T>,
+                                   feature_flags: FeatureFlag)
+                                   -> Vec<(String, u64)>
         where T: Rumor + ElectionRumor + Debug
     {
         Self::elections_to_restart_impl(elections,
@@ -857,6 +865,9 @@ impl Server {
                                         &self.data_path)
     }
 
+    /// # Locking
+    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
+    ///   lock is held.
     fn elections_to_restart_impl<T>(elections: &RumorStore<T>,
                                     service_store: &RumorStore<Service>,
                                     myself_member_id: &str,
@@ -905,7 +916,7 @@ impl Server {
                                  }
                              } else if election.is_finished() {
                                  let leader_health =
-                                     member_list.health_of_by_id(election.member_id())
+                                     member_list.health_of_by_id_mlr(election.member_id())
                                                 .unwrap_or_else(|| {
                                                     debug!("No health information for {}; \
                                                             treating as Departed",
@@ -931,15 +942,20 @@ impl Server {
     ///
     /// a) We are the leader, and we have lost quorum with the rest of the group.
     /// b) We are not the leader, and we have detected that the leader is confirmed dead.
-    pub fn restart_elections(&self, feature_flags: FeatureFlag) {
-        let elections_to_restart = self.elections_to_restart(&self.election_store, feature_flags);
+    ///
+    /// # Locking
+    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
+    ///   lock is held.
+    pub fn restart_elections_mlr(&self, feature_flags: FeatureFlag) {
+        let elections_to_restart =
+            self.elections_to_restart_mlr(&self.election_store, feature_flags);
 
         // TODO (CM): not currently triggering update elections!
         // There's only one kind of sentinel file at the moment, and
         // that's for non-update elections. If that file existed,
         // it'll be gone by the time we get here.
         let update_elections_to_restart =
-            self.elections_to_restart(&self.update_store, feature_flags);
+            self.elections_to_restart_mlr(&self.update_store, feature_flags);
 
         for (service_group, old_term) in elections_to_restart {
             let term = old_term + 1;
@@ -959,7 +975,11 @@ impl Server {
     /// Insert an election into the election store. Handles creating a new election rumor for this
     /// member on receipt of an election rumor for a service this server cares about. Also handles
     /// stopping the election if we are the winner and we have enough votes.
-    pub fn insert_election(&self, mut election: Election) {
+    ///
+    /// # Locking
+    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
+    ///   lock is held.
+    pub fn insert_election_mlr(&self, mut election: Election) {
         debug!("insert_election: {:?}", election);
         let rk = RumorKey::from(&election);
 
@@ -989,7 +1009,7 @@ impl Server {
                 // election is over! If it is, mark this election as final before you process it.
                 if self.member_id() == election.member_id {
                     if self.check_quorum(election.key()) {
-                        let electorate = self.get_electorate(election.key());
+                        let electorate = self.get_electorate_mlr(election.key());
                         let mut num_votes = 0;
                         for vote in election.votes.iter() {
                             if electorate.contains(vote) {
@@ -1049,7 +1069,10 @@ impl Server {
         }
     }
 
-    pub fn insert_update_election(&self, mut election: ElectionUpdate) {
+    /// # Locking
+    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
+    ///   lock is held.
+    pub fn insert_update_election_mlr(&self, mut election: ElectionUpdate) {
         debug!("insert_update_election: {:?}", election);
         let rk = RumorKey::from(&election);
 
@@ -1079,7 +1102,7 @@ impl Server {
                 // election is over! If it is, mark this election as final before you process it.
                 if self.member_id() == election.member_id {
                     if self.check_quorum(election.key()) {
-                        let electorate = self.get_electorate(election.key());
+                        let electorate = self.get_electorate_mlr(election.key());
                         let mut num_votes = 0;
                         for vote in election.votes.iter() {
                             if electorate.contains(vote) {
@@ -1141,22 +1164,6 @@ impl Server {
     pub fn is_departed(&self) -> bool { self.departed.load(Ordering::Relaxed) }
 }
 
-impl Serialize for Server {
-    fn serialize<S>(&self, serializer: S) -> result::Result<S::Ok, S::Error>
-        where S: Serializer
-    {
-        let mut strukt = serializer.serialize_struct("butterfly", 7)?;
-        strukt.serialize_field("member", &self.member_list)?;
-        strukt.serialize_field("service", &self.service_store)?;
-        strukt.serialize_field("service_config", &self.service_config_store)?;
-        strukt.serialize_field("service_file", &self.service_file_store)?;
-        strukt.serialize_field("election", &self.election_store)?;
-        strukt.serialize_field("election_update", &self.update_store)?;
-        strukt.serialize_field("departure", &self.departure_store)?;
-        strukt.end()
-    }
-}
-
 impl fmt::Display for Server {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f,
@@ -1167,7 +1174,13 @@ impl fmt::Display for Server {
     }
 }
 
-fn persist_loop(server: &Server) {
+fn spawn_persist_thread(name: String, server: Server) -> std::io::Result<()> {
+    thread::Builder::new().name(name)
+                          .spawn(|| persist_loop(server))
+                          .map(|_| ())
+}
+
+fn persist_loop(server: Server) -> ! {
     habitat_core::env_config_duration!(PersistLoopPeriod,
                                        HAB_PERSIST_LOOP_PERIOD_SECS => from_secs,
                                        Duration::from_secs(30));
@@ -1202,6 +1215,9 @@ impl<'a> ServerProxy<'a> {
 }
 
 impl<'a> Serialize for ServerProxy<'a> {
+    /// # Locking
+    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
+    ///   lock is held.
     fn serialize<S>(&self, serializer: S) -> result::Result<S::Ok, S::Error>
         where S: Serializer
     {
@@ -1369,7 +1385,7 @@ mod tests {
 
         service_store.insert(service.clone());
 
-        member_list.insert(departed_leader, Health::Departed);
+        member_list.insert_mlw(departed_leader, Health::Departed);
 
         let to_restart = Server::elections_to_restart_impl(&elections,
                                                            &service_store,
@@ -1418,8 +1434,8 @@ mod tests {
         let member_list = MemberList::new();
         let rumor_heat = RumorHeat::default();
 
-        member_list.insert(alive_member.clone(), Health::Alive);
-        member_list.insert(confirmed_member.clone(), Health::Confirmed);
+        member_list.insert_mlw(alive_member.clone(), Health::Alive);
+        member_list.insert_mlw(confirmed_member.clone(), Health::Confirmed);
 
         Server::insert_service_impl(confirmed_member_service_rumor.clone(),
                                     &service_store,
@@ -1450,10 +1466,10 @@ mod tests {
         let member_list = MemberList::new();
         let rumor_heat = RumorHeat::default();
 
-        member_list.insert(alive_member.clone(), Health::Alive);
+        member_list.insert_mlw(alive_member.clone(), Health::Alive);
         // This member will become confirmed later. If it's already Confirmed
         // when inserted, it could be departed immediately
-        member_list.insert(confirmed_member.clone(), Health::Alive);
+        member_list.insert_mlw(confirmed_member.clone(), Health::Alive);
 
         Server::insert_service_impl(alive_member_service_rumor.clone(),
                                     &service_store,
@@ -1467,7 +1483,7 @@ mod tests {
                                     &rumor_heat,
                                     check_quorum_returns(false));
 
-        member_list.insert(confirmed_member.clone(), Health::Confirmed);
+        member_list.insert_mlw(confirmed_member.clone(), Health::Confirmed);
 
         Server::insert_service_impl(Service { incarnation: alive_member_service_rumor.incarnation
                                                            + 1,
@@ -1491,8 +1507,8 @@ mod tests {
         let member_list = MemberList::new();
         let rumor_heat = RumorHeat::default();
 
-        member_list.insert(alive_member.clone(), Health::Alive);
-        member_list.insert(confirmed_member.clone(), Health::Confirmed);
+        member_list.insert_mlw(alive_member.clone(), Health::Alive);
+        member_list.insert_mlw(confirmed_member.clone(), Health::Confirmed);
 
         Server::insert_service_impl(confirmed_member_service_rumor.clone(),
                                     &service_store,
@@ -1657,14 +1673,14 @@ mod tests {
         fn new_with_corrupt_rumor_file() {
             let tmpdir = TempDir::new().unwrap();
             let mut server = start_with_corrupt_rumor_file(&tmpdir);
-            server.start(Timing::default())
+            server.start_mlr(Timing::default())
                   .expect("Server failed to start");
         }
 
         #[test]
         fn start_listener() {
             let mut server = start_server();
-            server.start(Timing::default())
+            server.start_mlr(Timing::default())
                   .expect("Server failed to start");
         }
     }

--- a/components/butterfly/src/server/outbound.rs
+++ b/components/butterfly/src/server/outbound.rs
@@ -73,7 +73,7 @@ pub fn spawn_thread(name: String,
                     timing: Timing)
                     -> std::io::Result<()> {
     thread::Builder::new().name(name)
-                          .spawn(|| run_loop(server, socket, rx_inbound, timing))
+                          .spawn(move || run_loop(&server, &socket, &rx_inbound, &timing))
                           .map(|_| ())
 }
 
@@ -88,7 +88,7 @@ pub fn spawn_thread(name: String,
 ///   is held.
 /// * `MemberList::intitial_entries` (read) This method must not be called while any
 ///   MemberList::intitial_entries lock is held.
-fn run_loop(server: Server, socket: UdpSocket, rx_inbound: AckReceiver, timing: Timing) -> ! {
+fn run_loop(server: &Server, socket: &UdpSocket, rx_inbound: &AckReceiver, timing: &Timing) -> ! {
     let mut have_members = false;
     loop {
         habitat_common::sync::mark_thread_alive();

--- a/components/butterfly/src/server/outbound.rs
+++ b/components/butterfly/src/server/outbound.rs
@@ -82,12 +82,6 @@ pub fn spawn_thread(name: String,
 ///
 /// If the probe completes before the next protocol period is scheduled, waits for the protocol
 /// period to finish before starting the next probe.
-///
-/// # Locking
-/// * `MemberList::entries` (read) This method must not be called while any MemberList::entries lock
-///   is held.
-/// * `MemberList::intitial_entries` (read) This method must not be called while any
-///   MemberList::intitial_entries lock is held.
 fn run_loop(server: &Server, socket: &UdpSocket, rx_inbound: &AckReceiver, timing: &Timing) -> ! {
     let mut have_members = false;
     loop {
@@ -125,7 +119,7 @@ fn run_loop(server: &Server, socket: &UdpSocket, rx_inbound: &AckReceiver, timin
         let check_list = server.member_list.check_list_mlr(&server.member_id);
 
         for member in check_list {
-            if server.member_list.pingable(&member) {
+            if server.member_list.pingable_mlr(&member) {
                 // This is the timeout for the next protocol period - if we
                 // complete faster than this, we want to wait in the end
                 // until this timer expires.
@@ -313,7 +307,7 @@ pub fn populate_membership_rumors_mlr(server: &Server, target: &Member, swim: &m
     // We don't want to update the heat for rumors that we know we are sending to a target that is
     // confirmed dead; the odds are, they won't receive them. Lets spam them a little harder with
     // rumors.
-    if !server.member_list.persistent_and_confirmed(target) {
+    if !server.member_list.persistent_and_confirmed_mlr(target) {
         server.rumor_heat.cool_rumors(&target.id, &rumors);
     }
 }

--- a/components/butterfly/src/server/pull.rs
+++ b/components/butterfly/src/server/pull.rs
@@ -27,120 +27,116 @@ lazy_static! {
                                 &["type", "mode", "blocked"]).unwrap();
 }
 
-/// Takes a reference to the server itself
-pub struct Pull {
-    pub server: Server,
+pub fn spawn_thread(name: String, server: Server) -> std::io::Result<()> {
+    thread::Builder::new().name(name)
+                          .spawn(|| run_loop(server))
+                          .map(|_| ())
 }
 
-impl Pull {
-    /// Create a new Pull
-    pub fn new(server: Server) -> Pull { Pull { server } }
+fn run_loop(server: Server) -> ! {
+    habitat_core::env_config_int!(RecvTimeoutMillis, i32, HAB_PULL_RECV_TIMEOUT_MS, 5_000);
 
-    /// Run this thread. Creates a socket, binds to the `gossip_addr`, then processes messages as
-    /// they are received. Uses a ZMQ pull socket, so inbound messages are fair-queued.
-    pub fn run(&mut self) {
-        habitat_core::env_config_int!(RecvTimeoutMillis, i32, HAB_PULL_RECV_TIMEOUT_MS, 5_000);
+    let socket = (**ZMQ_CONTEXT).as_mut()
+                                .socket(zmq::PULL)
+                                .expect("Failure to create the ZMQ pull socket");
+    socket.set_linger(0)
+          .expect("Failure to set the ZMQ Pull socket to not linger");
+    socket.set_tcp_keepalive(0)
+          .expect("Failure to set the ZMQ Pull socket to not use keepalive");
+    socket.set_rcvtimeo(RecvTimeoutMillis::configured_value().into())
+          .expect("Failure to set the ZMQ Pull socket receive timeout");
+    socket.bind(&format!("tcp://{}", server.gossip_addr()))
+          .expect("Failure to bind the ZMQ Pull socket to the port");
+    'recv: loop {
+        if let Ok(-1) = socket.get_rcvtimeo() {
+            trace!("Skipping thread liveliness checks due to infinite recv timeout");
+        } else {
+            habitat_common::sync::mark_thread_alive();
+        }
 
-        let socket = (**ZMQ_CONTEXT).as_mut()
-                                    .socket(zmq::PULL)
-                                    .expect("Failure to create the ZMQ pull socket");
-        socket.set_linger(0)
-              .expect("Failure to set the ZMQ Pull socket to not linger");
-        socket.set_tcp_keepalive(0)
-              .expect("Failure to set the ZMQ Pull socket to not use keepalive");
-        socket.set_rcvtimeo(RecvTimeoutMillis::configured_value().into())
-              .expect("Failure to set the ZMQ Pull socket receive timeout");
-        socket.bind(&format!("tcp://{}", self.server.gossip_addr()))
-              .expect("Failure to bind the ZMQ Pull socket to the port");
-        'recv: loop {
-            if let Ok(-1) = socket.get_rcvtimeo() {
-                trace!("Skipping thread liveliness checks due to infinite recv timeout");
-            } else {
-                habitat_common::sync::mark_thread_alive();
-            }
+        if server.paused() {
+            thread::sleep(Duration::from_millis(100));
+            continue;
+        }
 
-            if self.server.paused() {
-                thread::sleep(Duration::from_millis(100));
-                continue;
-            }
-
-            let msg = match socket.recv_msg(0) {
-                Ok(msg) => msg,
-                Err(e) => {
-                    // We intentionally set a timeout above so that `mark_thread_alive` can be
-                    // used to show this thread is alive even when there's no data to receive.
-                    if e != zmq::Error::EAGAIN {
-                        error!("Error receiving message: {:?}", e);
-                    }
-                    continue 'recv;
+        let msg = match socket.recv_msg(0) {
+            Ok(msg) => msg,
+            Err(e) => {
+                // We intentionally set a timeout above so that `mark_thread_alive` can be
+                // used to show this thread is alive even when there's no data to receive.
+                if e != zmq::Error::EAGAIN {
+                    error!("Error receiving message: {:?}", e);
                 }
-            };
-
-            let payload = match self.server.unwrap_wire(&msg) {
-                Ok(payload) => payload,
-                Err(e) => {
-                    // NOTE: In the future, we might want to block people who send us
-                    // garbage all the time.
-                    error!("Error parsing protocol message: {:?}", e);
-                    let label_values = &["unwrap_wire", "failure", "unknown"];
-                    GOSSIP_BYTES_RECEIVED.with_label_values(label_values)
-                                         .set(msg.len().to_i64());
-                    GOSSIP_MESSAGES_RECEIVED.with_label_values(label_values)
-                                            .inc();
-                    continue;
-                }
-            };
-
-            let proto = match RumorEnvelope::decode(&payload) {
-                Ok(proto) => proto,
-                Err(e) => {
-                    error!("Error parsing protocol message: {:?}", e);
-                    let label_values = &["undecodable", "failure", "unknown"];
-                    GOSSIP_BYTES_RECEIVED.with_label_values(label_values)
-                                         .set(payload.len().to_i64());
-                    GOSSIP_MESSAGES_RECEIVED.with_label_values(label_values)
-                                            .inc();
-                    continue 'recv;
-                }
-            };
-
-            let blocked = self.server.is_member_blocked(&proto.from_id);
-            let blocked_label = if blocked { "true" } else { "false" };
-            let label_values = &[&proto.r#type.to_string(), "success", blocked_label];
-
-            GOSSIP_MESSAGES_RECEIVED.with_label_values(label_values)
-                                    .inc();
-            GOSSIP_BYTES_RECEIVED.with_label_values(label_values)
-                                 .set(payload.len().to_i64());
-
-            if blocked {
-                warn!("Not processing message from {} - it is blocked",
-                      proto.from_id);
                 continue 'recv;
             }
+        };
 
-            trace_it!(GOSSIP: &self.server, TraceKind::RecvRumor, &proto.from_id, &proto);
-            match proto.kind {
-                RumorKind::Membership(membership) => {
-                    self.server
-                        .insert_member_from_rumor(membership.member, membership.health);
-                }
-                RumorKind::Service(service) => self.server.insert_service(*service),
-                RumorKind::ServiceConfig(service_config) => {
-                    self.server.insert_service_config(service_config);
-                }
-                RumorKind::ServiceFile(service_file) => {
-                    self.server.insert_service_file(service_file);
-                }
-                RumorKind::Election(election) => {
-                    self.server.insert_election(election);
-                }
-                RumorKind::ElectionUpdate(election) => {
-                    self.server.insert_update_election(election);
-                }
-                RumorKind::Departure(departure) => {
-                    self.server.insert_departure(departure);
-                }
+        let payload = match server.unwrap_wire(&msg) {
+            Ok(payload) => payload,
+            Err(e) => {
+                // NOTE: In the future, we might want to block people who send us
+                // garbage all the time.
+                error!("Error parsing protocol message: {:?}", e);
+                let label_values = &["unwrap_wire", "failure", "unknown"];
+                GOSSIP_BYTES_RECEIVED.with_label_values(label_values)
+                                     .set(msg.len().to_i64());
+                GOSSIP_MESSAGES_RECEIVED.with_label_values(label_values)
+                                        .inc();
+                continue;
+            }
+        };
+
+        let proto = match RumorEnvelope::decode(&payload) {
+            Ok(proto) => proto,
+            Err(e) => {
+                error!("Error parsing protocol message: {:?}", e);
+                let label_values = &["undecodable", "failure", "unknown"];
+                GOSSIP_BYTES_RECEIVED.with_label_values(label_values)
+                                     .set(payload.len().to_i64());
+                GOSSIP_MESSAGES_RECEIVED.with_label_values(label_values)
+                                        .inc();
+                continue 'recv;
+            }
+        };
+
+        let blocked = server.is_member_blocked(&proto.from_id);
+        let blocked_label = if blocked { "true" } else { "false" };
+        let label_values = &[&proto.r#type.to_string(), "success", blocked_label];
+
+        GOSSIP_MESSAGES_RECEIVED.with_label_values(label_values)
+                                .inc();
+        GOSSIP_BYTES_RECEIVED.with_label_values(label_values)
+                             .set(payload.len().to_i64());
+
+        if blocked {
+            warn!("Not processing message from {} - it is blocked",
+                  proto.from_id);
+            continue 'recv;
+        }
+
+        trace_it!(GOSSIP: &server,
+                  TraceKind::RecvRumor,
+                  &proto.from_id,
+                  &proto);
+        match proto.kind {
+            RumorKind::Membership(membership) => {
+                server.insert_member_from_rumor(membership.member, membership.health);
+            }
+            RumorKind::Service(service) => server.insert_service(*service),
+            RumorKind::ServiceConfig(service_config) => {
+                server.insert_service_config(service_config);
+            }
+            RumorKind::ServiceFile(service_file) => {
+                server.insert_service_file(service_file);
+            }
+            RumorKind::Election(election) => {
+                server.insert_election_mlr(election);
+            }
+            RumorKind::ElectionUpdate(election) => {
+                server.insert_update_election_mlr(election);
+            }
+            RumorKind::Departure(departure) => {
+                server.insert_departure(departure);
             }
         }
     }

--- a/components/butterfly/src/server/pull.rs
+++ b/components/butterfly/src/server/pull.rs
@@ -29,11 +29,11 @@ lazy_static! {
 
 pub fn spawn_thread(name: String, server: Server) -> std::io::Result<()> {
     thread::Builder::new().name(name)
-                          .spawn(|| run_loop(server))
+                          .spawn(move || run_loop(&server))
                           .map(|_| ())
 }
 
-fn run_loop(server: Server) -> ! {
+fn run_loop(server: &Server) -> ! {
     habitat_core::env_config_int!(RecvTimeoutMillis, i32, HAB_PULL_RECV_TIMEOUT_MS, 5_000);
 
     let socket = (**ZMQ_CONTEXT).as_mut()
@@ -114,10 +114,7 @@ fn run_loop(server: Server) -> ! {
             continue 'recv;
         }
 
-        trace_it!(GOSSIP: &server,
-                  TraceKind::RecvRumor,
-                  &proto.from_id,
-                  &proto);
+        trace_it!(GOSSIP: server, TraceKind::RecvRumor, &proto.from_id, &proto);
         match proto.kind {
             RumorKind::Membership(membership) => {
                 server.insert_member_from_rumor(membership.member, membership.health);

--- a/components/butterfly/src/server/push.rs
+++ b/components/butterfly/src/server/push.rs
@@ -36,330 +36,305 @@ lazy_static! {
                                 &["type", "mode"]).unwrap();
 }
 
-/// The Push server
-#[derive(Debug)]
-pub struct Push {
-    pub server: Server,
-    pub timing: Timing,
+pub fn spawn_thread(name: String, server: Server, timing: Timing) -> std::io::Result<()> {
+    thread::Builder::new().name(name)
+                          .spawn(|| run_loop(server, timing))
+                          .map(|_| ())
 }
 
-impl Push {
-    /// Creates a new Push instance from a Server and Timing
-    pub fn new(server: Server, timing: Timing) -> Push { Push { server, timing } }
+/// Executes the Push thread. Gets a list of members to talk to that are not Confirmed; then
+/// proceeds to process the list in `FANOUT` sized chunks. If we finish sending the messages to
+/// all FANOUT targets faster than `Timing::GOSSIP_PERIOD_DEFAULT_MS`, we will block until we
+/// exceed that time.
+fn run_loop(server: Server, timing: Timing) -> ! {
+    loop {
+        habitat_common::sync::mark_thread_alive();
 
-    /// Executes the Push thread. Gets a list of members to talk to that are not Confirmed; then
-    /// proceeds to process the list in `FANOUT` sized chunks. If we finish sending the messages to
-    /// all FANOUT targets faster than `Timing::GOSSIP_PERIOD_DEFAULT_MS`, we will block until we
-    /// exceed that time.
-    pub fn run(&mut self) {
-        loop {
-            habitat_common::sync::mark_thread_alive();
+        if server.paused() {
+            thread::sleep(Duration::from_millis(100));
+            continue;
+        }
 
-            if self.server.paused() {
-                thread::sleep(Duration::from_millis(100));
-                continue;
+        server.update_gossip_round();
+
+        let mut check_list = server.member_list.check_list_mlr(server.member_id());
+        let long_wait = timing.gossip_timeout();
+
+        'fanout: loop {
+            let mut thread_list = Vec::with_capacity(FANOUT);
+            if check_list.is_empty() {
+                break 'fanout;
             }
+            let drain_length = if check_list.len() >= FANOUT {
+                FANOUT
+            } else {
+                check_list.len()
+            };
+            let next_gossip = timing.gossip_timeout();
+            for member in check_list.drain(0..drain_length) {
+                if server.is_member_blocked(&member.id) {
+                    debug!("Not sending rumors to {} - it is blocked", member.id);
 
-            self.server.update_gossip_round();
-
-            let mut check_list = self.server.member_list.check_list(self.server.member_id());
-            let long_wait = self.timing.gossip_timeout();
-
-            'fanout: loop {
-                let mut thread_list = Vec::with_capacity(FANOUT);
-                if check_list.is_empty() {
-                    break 'fanout;
+                    continue;
                 }
-                let drain_length = if check_list.len() >= FANOUT {
-                    FANOUT
-                } else {
-                    check_list.len()
-                };
-                let next_gossip = self.timing.gossip_timeout();
-                for member in check_list.drain(0..drain_length) {
-                    if self.server.is_member_blocked(&member.id) {
-                        debug!("Not sending rumors to {} - it is blocked", member.id);
-
-                        continue;
-                    }
-                    // Unlike the SWIM mechanism, we don't actually want to send gossip traffic to
-                    // persistent members that are confirmed dead. When the failure detector thread
-                    // finds them alive again, we'll go ahead and get back to the business at hand.
-                    if self.server.member_list.pingable(&member)
-                       && !self.server.member_list.persistent_and_confirmed(&member)
-                    {
-                        let rumors = self.server.rumor_heat.currently_hot_rumors(&member.id);
-                        if !rumors.is_empty() {
-                            let sc = self.server.clone();
-
-                            let guard = match thread::Builder::new()
-                                .name(String::from("push-worker"))
-                                .spawn(move || {
-                                    PushWorker::new(sc).send_rumors(&member, &rumors);
-                                }) {
-                                Ok(guard) => guard,
-                                Err(e) => {
-                                    error!("Could not spawn thread: {}", e);
-                                    continue;
-                                }
-                            };
-                            thread_list.push(guard);
-                        }
-                    }
-                }
-                let num_threads = thread_list.len();
-                for guard in thread_list.drain(0..num_threads) {
-                    let _ = guard.join()
-                                 .map_err(|e| error!("Push worker died: {:?}", e));
-                }
-                if SteadyTime::now() < next_gossip {
-                    let wait_time = (next_gossip - SteadyTime::now()).num_milliseconds();
-                    if wait_time > 0 {
-                        thread::sleep(Duration::from_millis(wait_time as u64));
+                // Unlike the SWIM mechanism, we don't actually want to send gossip traffic to
+                // persistent members that are confirmed dead. When the failure detector thread
+                // finds them alive again, we'll go ahead and get back to the business at hand.
+                if server.member_list.pingable(&member)
+                   && !server.member_list.persistent_and_confirmed(&member)
+                {
+                    let rumors = server.rumor_heat.currently_hot_rumors(&member.id);
+                    if !rumors.is_empty() {
+                        let sc = server.clone();
+                        let guard = match thread::Builder::new().name(String::from("push-worker"))
+                                                                .spawn(move || {
+                                                                    send_rumors(sc, &member,
+                                                                                &rumors)
+                                                                }) {
+                            Ok(guard) => guard,
+                            Err(e) => {
+                                error!("Could not spawn thread: {}", e);
+                                continue;
+                            }
+                        };
+                        thread_list.push(guard);
                     }
                 }
             }
-            if SteadyTime::now() < long_wait {
-                let wait_time = (long_wait - SteadyTime::now()).num_milliseconds();
+            let num_threads = thread_list.len();
+            for guard in thread_list.drain(0..num_threads) {
+                let _ = guard.join()
+                             .map_err(|e| error!("Push worker died: {:?}", e));
+            }
+            if SteadyTime::now() < next_gossip {
+                let wait_time = (next_gossip - SteadyTime::now()).num_milliseconds();
                 if wait_time > 0 {
                     thread::sleep(Duration::from_millis(wait_time as u64));
                 }
             }
         }
+        if SteadyTime::now() < long_wait {
+            let wait_time = (long_wait - SteadyTime::now()).num_milliseconds();
+            if wait_time > 0 {
+                thread::sleep(Duration::from_millis(wait_time as u64));
+            }
+        }
     }
 }
 
-/// A worker thread for pushing messages to a target
-struct PushWorker {
-    pub server: Server,
-}
-
-impl PushWorker {
-    /// Create a new PushWorker.
-    pub fn new(server: Server) -> PushWorker { PushWorker { server } }
-
-    /// Send the list of rumors to a given member. This method creates an outbound socket and then
-    /// closes the connection as soon as we are done sending rumors. ZeroMQ may choose to keep the
-    /// connection and socket open for 1 second longer - so it is possible, but unlikely, that this
-    /// method can lose messages.
-    // If we ever need to modify this function, it would be an excellent opportunity to
-    // simplify the redundant aspects and remove this allow(clippy::cognitive_complexity),
-    // but changing it in the absence of other necessity seems like too much risk for the
-    // expected reward.
-    #[allow(clippy::cognitive_complexity)]
-    fn send_rumors(&self, member: &Member, rumors: &[RumorKey]) {
-        let socket = (**ZMQ_CONTEXT).as_mut()
-                                    .socket(zmq::PUSH)
-                                    .expect("Failure to create the ZMQ push socket");
-        socket.set_linger(1000)
-              .expect("Failure to set the ZMQ push socket to not linger");
-        socket.set_tcp_keepalive(0)
-              .expect("Failure to set the ZMQ push socket to not use keepalive");
-        socket.set_immediate(true)
-              .expect("Failure to set the ZMQ push socket to immediate");
-        socket.set_sndhwm(1000)
-              .expect("Failure to set the ZMQ push socket hwm");
-        socket.set_sndtimeo(500)
-              .expect("Failure to set the ZMQ send timeout");
-        let to_addr = format!("{}:{}", member.address, member.gossip_port);
-        match socket.connect(&format!("tcp://{}", to_addr)) {
-            Ok(()) => debug!("Connected push socket to {:?}", member),
+/// Send the list of rumors to a given member. This method creates an outbound socket and then
+/// closes the connection as soon as we are done sending rumors. ZeroMQ may choose to keep the
+/// connection and socket open for 1 second longer - so it is possible, but unlikely, that this
+/// method can lose messages.
+///
+/// # Locking
+/// * `MemberList::entries` (read) This method must not be called while any MemberList::entries lock
+///   is held.
+// If we ever need to modify this function, it would be an excellent opportunity to
+// simplify the redundant aspects and remove this allow(clippy::cognitive_complexity),
+// but changing it in the absence of other necessity seems like too much risk for the
+// expected reward.
+#[allow(clippy::cognitive_complexity)]
+fn send_rumors(server: Server, member: &Member, rumors: &[RumorKey]) {
+    let socket = (**ZMQ_CONTEXT).as_mut()
+                                .socket(zmq::PUSH)
+                                .expect("Failure to create the ZMQ push socket");
+    socket.set_linger(1000)
+          .expect("Failure to set the ZMQ push socket to not linger");
+    socket.set_tcp_keepalive(0)
+          .expect("Failure to set the ZMQ push socket to not use keepalive");
+    socket.set_immediate(true)
+          .expect("Failure to set the ZMQ push socket to immediate");
+    socket.set_sndhwm(1000)
+          .expect("Failure to set the ZMQ push socket hwm");
+    socket.set_sndtimeo(500)
+          .expect("Failure to set the ZMQ send timeout");
+    let to_addr = format!("{}:{}", member.address, member.gossip_port);
+    match socket.connect(&format!("tcp://{}", to_addr)) {
+        Ok(()) => debug!("Connected push socket to {:?}", member),
+        Err(e) => {
+            error!("Cannot connect push socket to {:?}: {:?}", member, e);
+            let label_values = &["socket_connect", "failure"];
+            GOSSIP_MESSAGES_SENT.with_label_values(label_values).inc();
+            GOSSIP_BYTES_SENT.with_label_values(label_values).set(0);
+            return;
+        }
+    }
+    'rumorlist: for rumor_key in rumors.iter() {
+        let rumor_as_bytes = match rumor_key.kind {
+            RumorType::Member => {
+                let send_rumor = match create_member_rumor_mlr(&server, &rumor_key) {
+                    Some(rumor) => rumor,
+                    None => continue 'rumorlist,
+                };
+                trace_it!(GOSSIP: &server,
+                          TraceKind::SendRumor,
+                          &member.id,
+                          &send_rumor);
+                match send_rumor.encode() {
+                    Ok(bytes) => bytes,
+                    Err(e) => {
+                        error!("Could not write our own rumor to bytes; abandoning sending \
+                                rumor: {:?}",
+                               e);
+                        let label_values = &["member_rumor_encode", "failure"];
+                        GOSSIP_MESSAGES_SENT.with_label_values(label_values).inc();
+                        GOSSIP_BYTES_SENT.with_label_values(label_values).set(0);
+                        continue 'rumorlist;
+                    }
+                }
+            }
+            RumorType::Service => {
+                // trace_it!(GOSSIP: &server,
+                //           TraceKind::SendRumor,
+                //           &member.id,
+                //           &send_rumor);
+                match server.service_store.encode(&rumor_key.key, &rumor_key.id) {
+                    Ok(bytes) => bytes,
+                    Err(e) => {
+                        error!("Could not write our own rumor to bytes; abandoning sending \
+                                rumor: {:?}",
+                               e);
+                        let label_values = &["service_rumor_encode", "failure"];
+                        GOSSIP_MESSAGES_SENT.with_label_values(label_values).inc();
+                        GOSSIP_BYTES_SENT.with_label_values(label_values).set(0);
+                        continue 'rumorlist;
+                    }
+                }
+            }
+            RumorType::ServiceConfig => {
+                // trace_it!(GOSSIP: &server,
+                //           TraceKind::SendRumor,
+                //           &member.id,
+                //           &send_rumor);
+                match server.service_config_store
+                            .encode(&rumor_key.key, &rumor_key.id)
+                {
+                    Ok(bytes) => bytes,
+                    Err(e) => {
+                        error!("Could not write our own rumor to bytes; abandoning sending \
+                                rumor: {:?}",
+                               e);
+                        let label_values = &["service_config_rumor_encode", "failure"];
+                        GOSSIP_MESSAGES_SENT.with_label_values(label_values).inc();
+                        GOSSIP_BYTES_SENT.with_label_values(label_values).set(0);
+                        continue 'rumorlist;
+                    }
+                }
+            }
+            RumorType::ServiceFile => {
+                // trace_it!(GOSSIP: &server,
+                //           TraceKind::SendRumor,
+                //           &member.id,
+                //           &send_rumor);
+                match server.service_file_store
+                            .encode(&rumor_key.key, &rumor_key.id)
+                {
+                    Ok(bytes) => bytes,
+                    Err(e) => {
+                        error!("Could not write our own rumor to bytes; abandoning sending \
+                                rumor: {:?}",
+                               e);
+                        let label_values = &["service_file_rumor_encode", "failure"];
+                        GOSSIP_MESSAGES_SENT.with_label_values(label_values).inc();
+                        GOSSIP_BYTES_SENT.with_label_values(label_values).set(0);
+                        continue 'rumorlist;
+                    }
+                }
+            }
+            RumorType::Departure => {
+                match server.departure_store.encode(&rumor_key.key, &rumor_key.id) {
+                    Ok(bytes) => bytes,
+                    Err(e) => {
+                        error!("Could not write our own rumor to bytes; abandoning sending \
+                                rumor: {:?}",
+                               e);
+                        let label_values = &["departure_rumor_encode", "failure"];
+                        GOSSIP_MESSAGES_SENT.with_label_values(label_values).inc();
+                        GOSSIP_BYTES_SENT.with_label_values(label_values).set(0);
+                        continue 'rumorlist;
+                    }
+                }
+            }
+            RumorType::Election => {
+                // trace_it!(GOSSIP: &server,
+                //           TraceKind::SendRumor,
+                //           &member.id,
+                //           &send_rumor);
+                match server.election_store.encode(&rumor_key.key, &rumor_key.id) {
+                    Ok(bytes) => bytes,
+                    Err(e) => {
+                        error!("Could not write our own rumor to bytes; abandoning sending \
+                                rumor: {:?}",
+                               e);
+                        let label_values = &["election_rumor_encode", "failure"];
+                        GOSSIP_MESSAGES_SENT.with_label_values(label_values).inc();
+                        GOSSIP_BYTES_SENT.with_label_values(label_values).set(0);
+                        continue 'rumorlist;
+                    }
+                }
+            }
+            RumorType::ElectionUpdate => {
+                match server.update_store.encode(&rumor_key.key, &rumor_key.id) {
+                    Ok(bytes) => bytes,
+                    Err(e) => {
+                        error!("Could not write our own rumor to bytes; abandoning sending \
+                                rumor: {:?}",
+                               e);
+                        let label_values = &["election_update_rumor_encode", "failure"];
+                        GOSSIP_MESSAGES_SENT.with_label_values(label_values).inc();
+                        GOSSIP_BYTES_SENT.with_label_values(label_values).set(0);
+                        continue 'rumorlist;
+                    }
+                }
+            }
+            RumorType::Fake | RumorType::Fake2 => {
+                debug!("You have fake rumors; how odd!");
+                continue 'rumorlist;
+            }
+        };
+        let rumor_len = rumor_as_bytes.len().to_i64();
+        let payload = match server.generate_wire(rumor_as_bytes) {
+            Ok(payload) => payload,
             Err(e) => {
-                error!("Cannot connect push socket to {:?}: {:?}", member, e);
-                let label_values = &["socket_connect", "failure"];
+                error!("Generating protobuf failed: {}", e);
+                let label_values = &["generate_wire", "failure"];
                 GOSSIP_MESSAGES_SENT.with_label_values(label_values).inc();
-                GOSSIP_BYTES_SENT.with_label_values(label_values).set(0);
-                return;
+                GOSSIP_BYTES_SENT.with_label_values(label_values)
+                                 .set(rumor_len);
+                continue 'rumorlist;
+            }
+        };
+        match socket.send(&payload, 0) {
+            Ok(()) => {
+                GOSSIP_MESSAGES_SENT.with_label_values(&[&rumor_key.kind.to_string(), "success"])
+                                    .inc();
+                GOSSIP_BYTES_SENT.with_label_values(&[&rumor_key.kind.to_string(), "success"])
+                                 .set(payload.len().to_i64());
+                debug!("Sent rumor {:?} to {:?}", rumor_key, member);
+            }
+            Err(e) => {
+                warn!("Could not send rumor to {:?} @ {:?}; ZMQ said: {:?}",
+                      member.id, to_addr, e)
             }
         }
-        'rumorlist: for rumor_key in rumors.iter() {
-            let rumor_as_bytes = match rumor_key.kind {
-                RumorType::Member => {
-                    let send_rumor = match self.create_member_rumor(&rumor_key) {
-                        Some(rumor) => rumor,
-                        None => continue 'rumorlist,
-                    };
-                    trace_it!(GOSSIP: &self.server,
-                              TraceKind::SendRumor,
-                              &member.id,
-                              &send_rumor);
-                    match send_rumor.encode() {
-                        Ok(bytes) => bytes,
-                        Err(e) => {
-                            error!("Could not write our own rumor to bytes; abandoning sending \
-                                    rumor: {:?}",
-                                   e);
-                            let label_values = &["member_rumor_encode", "failure"];
-                            GOSSIP_MESSAGES_SENT.with_label_values(label_values).inc();
-                            GOSSIP_BYTES_SENT.with_label_values(label_values).set(0);
-                            continue 'rumorlist;
-                        }
-                    }
-                }
-                RumorType::Service => {
-                    // trace_it!(GOSSIP: &self.server,
-                    //           TraceKind::SendRumor,
-                    //           &member.id,
-                    //           &send_rumor);
-                    match self.server
-                              .service_store
-                              .encode(&rumor_key.key, &rumor_key.id)
-                    {
-                        Ok(bytes) => bytes,
-                        Err(e) => {
-                            error!("Could not write our own rumor to bytes; abandoning sending \
-                                    rumor: {:?}",
-                                   e);
-                            let label_values = &["service_rumor_encode", "failure"];
-                            GOSSIP_MESSAGES_SENT.with_label_values(label_values).inc();
-                            GOSSIP_BYTES_SENT.with_label_values(label_values).set(0);
-                            continue 'rumorlist;
-                        }
-                    }
-                }
-                RumorType::ServiceConfig => {
-                    // trace_it!(GOSSIP: &self.server,
-                    //           TraceKind::SendRumor,
-                    //           &member.id,
-                    //           &send_rumor);
-                    match self.server
-                              .service_config_store
-                              .encode(&rumor_key.key, &rumor_key.id)
-                    {
-                        Ok(bytes) => bytes,
-                        Err(e) => {
-                            error!("Could not write our own rumor to bytes; abandoning sending \
-                                    rumor: {:?}",
-                                   e);
-                            let label_values = &["service_config_rumor_encode", "failure"];
-                            GOSSIP_MESSAGES_SENT.with_label_values(label_values).inc();
-                            GOSSIP_BYTES_SENT.with_label_values(label_values).set(0);
-                            continue 'rumorlist;
-                        }
-                    }
-                }
-                RumorType::ServiceFile => {
-                    // trace_it!(GOSSIP: &self.server,
-                    //           TraceKind::SendRumor,
-                    //           &member.id,
-                    //           &send_rumor);
-                    match self.server
-                              .service_file_store
-                              .encode(&rumor_key.key, &rumor_key.id)
-                    {
-                        Ok(bytes) => bytes,
-                        Err(e) => {
-                            error!("Could not write our own rumor to bytes; abandoning sending \
-                                    rumor: {:?}",
-                                   e);
-                            let label_values = &["service_file_rumor_encode", "failure"];
-                            GOSSIP_MESSAGES_SENT.with_label_values(label_values).inc();
-                            GOSSIP_BYTES_SENT.with_label_values(label_values).set(0);
-                            continue 'rumorlist;
-                        }
-                    }
-                }
-                RumorType::Departure => {
-                    match self.server
-                              .departure_store
-                              .encode(&rumor_key.key, &rumor_key.id)
-                    {
-                        Ok(bytes) => bytes,
-                        Err(e) => {
-                            error!("Could not write our own rumor to bytes; abandoning sending \
-                                    rumor: {:?}",
-                                   e);
-                            let label_values = &["departure_rumor_encode", "failure"];
-                            GOSSIP_MESSAGES_SENT.with_label_values(label_values).inc();
-                            GOSSIP_BYTES_SENT.with_label_values(label_values).set(0);
-                            continue 'rumorlist;
-                        }
-                    }
-                }
-                RumorType::Election => {
-                    // trace_it!(GOSSIP: &self.server,
-                    //           TraceKind::SendRumor,
-                    //           &member.id,
-                    //           &send_rumor);
-                    match self.server
-                              .election_store
-                              .encode(&rumor_key.key, &rumor_key.id)
-                    {
-                        Ok(bytes) => bytes,
-                        Err(e) => {
-                            error!("Could not write our own rumor to bytes; abandoning sending \
-                                    rumor: {:?}",
-                                   e);
-                            let label_values = &["election_rumor_encode", "failure"];
-                            GOSSIP_MESSAGES_SENT.with_label_values(label_values).inc();
-                            GOSSIP_BYTES_SENT.with_label_values(label_values).set(0);
-                            continue 'rumorlist;
-                        }
-                    }
-                }
-                RumorType::ElectionUpdate => {
-                    match self.server
-                              .update_store
-                              .encode(&rumor_key.key, &rumor_key.id)
-                    {
-                        Ok(bytes) => bytes,
-                        Err(e) => {
-                            error!("Could not write our own rumor to bytes; abandoning sending \
-                                    rumor: {:?}",
-                                   e);
-                            let label_values = &["election_update_rumor_encode", "failure"];
-                            GOSSIP_MESSAGES_SENT.with_label_values(label_values).inc();
-                            GOSSIP_BYTES_SENT.with_label_values(label_values).set(0);
-                            continue 'rumorlist;
-                        }
-                    }
-                }
-                RumorType::Fake | RumorType::Fake2 => {
-                    debug!("You have fake rumors; how odd!");
-                    continue 'rumorlist;
-                }
-            };
-            let rumor_len = rumor_as_bytes.len().to_i64();
-            let payload = match self.server.generate_wire(rumor_as_bytes) {
-                Ok(payload) => payload,
-                Err(e) => {
-                    error!("Generating protobuf failed: {}", e);
-                    let label_values = &["generate_wire", "failure"];
-                    GOSSIP_MESSAGES_SENT.with_label_values(label_values).inc();
-                    GOSSIP_BYTES_SENT.with_label_values(label_values)
-                                     .set(rumor_len);
-                    continue 'rumorlist;
-                }
-            };
-            match socket.send(&payload, 0) {
-                Ok(()) => {
-                    GOSSIP_MESSAGES_SENT.with_label_values(&[&rumor_key.kind.to_string(),
-                                                             "success"])
-                                        .inc();
-                    GOSSIP_BYTES_SENT.with_label_values(&[&rumor_key.kind.to_string(), "success"])
-                                     .set(payload.len().to_i64());
-                    debug!("Sent rumor {:?} to {:?}", rumor_key, member);
-                }
-                Err(e) => {
-                    warn!("Could not send rumor to {:?} @ {:?}; ZMQ said: {:?}",
-                          member.id, to_addr, e)
-                }
-            }
-        }
-        self.server.rumor_heat.cool_rumors(&member.id, &rumors);
     }
+    server.rumor_heat.cool_rumors(&member.id, &rumors);
+}
 
-    /// Given a rumorkey, creates a protobuf rumor for sharing.
-    fn create_member_rumor(&self, rumor_key: &RumorKey) -> Option<RumorEnvelope> {
-        let member = self.server.member_list.get_cloned(&rumor_key.key())?;
-        let payload = Membership { member,
-                                   health: self.server
-                                               .member_list
-                                               .health_of_by_id(&rumor_key.key())
-                                               .unwrap() };
-        let rumor = RumorEnvelope { r#type:  RumorType::Member,
-                                    from_id: self.server.member_id().to_string(),
-                                    kind:    RumorKind::Membership(payload), };
-        Some(rumor)
-    }
+/// Given a rumorkey, creates a protobuf rumor for sharing.
+///
+/// # Locking
+/// * `MemberList::entries` (read) This method must not be called while any MemberList::entries lock
+///   is held.
+fn create_member_rumor_mlr(server: &Server, rumor_key: &RumorKey) -> Option<RumorEnvelope> {
+    let member = server.member_list.get_cloned_mlr(&rumor_key.key())?;
+    let payload = Membership { member,
+                               health: server.member_list
+                                             .health_of_by_id_mlr(&rumor_key.key())
+                                             .unwrap() };
+    let rumor = RumorEnvelope { r#type:  RumorType::Member,
+                                from_id: server.member_id().to_string(),
+                                kind:    RumorKind::Membership(payload), };
+    Some(rumor)
 }

--- a/components/butterfly/src/server/push.rs
+++ b/components/butterfly/src/server/push.rs
@@ -80,8 +80,8 @@ fn run_loop(server: &Server, timing: &Timing) -> ! {
                 // Unlike the SWIM mechanism, we don't actually want to send gossip traffic to
                 // persistent members that are confirmed dead. When the failure detector thread
                 // finds them alive again, we'll go ahead and get back to the business at hand.
-                if server.member_list.pingable(&member)
-                   && !server.member_list.persistent_and_confirmed(&member)
+                if server.member_list.pingable_mlr(&member)
+                   && !server.member_list.persistent_and_confirmed_mlr(&member)
                 {
                     let rumors = server.rumor_heat.currently_hot_rumors(&member.id);
                     if !rumors.is_empty() {

--- a/components/butterfly/tests/common/mod.rs
+++ b/components/butterfly/tests/common/mod.rs
@@ -166,7 +166,10 @@ impl SwimNet {
         from.remove_from_block_list(to.member_id());
     }
 
-    pub fn health_of(&self, from_entry: usize, to_entry: usize) -> Option<Health> {
+    /// # Locking
+    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
+    ///   lock is held.
+    pub fn health_of_mlr(&self, from_entry: usize, to_entry: usize) -> Option<Health> {
         /// To avoid deadlocking in a test, we use `health_of_by_id_with_timeout` rather than
         /// `health_of_by_id`.
         const HEALTH_OF_TIMEOUT: Duration = Duration::from_secs(5);
@@ -180,7 +183,7 @@ impl SwimNet {
                      .expect("Asked for a network member who is out of bounds");
 
         match from.member_list
-                  .health_of_by_id_with_timeout(to.member_id(), HEALTH_OF_TIMEOUT)
+                  .health_of_by_id_with_timeout_mlr(to.member_id(), HEALTH_OF_TIMEOUT)
         {
             Ok(health) => Some(health),
             Err(Error::UnknownMember(_)) => None,
@@ -195,14 +198,17 @@ impl SwimNet {
         }
     }
 
-    pub fn network_health_of(&self, to_check: usize) -> Vec<Option<Health>> {
+    /// # Locking
+    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
+    ///   lock is held.
+    pub fn network_health_of_mlr(&self, to_check: usize) -> Vec<Option<Health>> {
         let mut health_summary = Vec::with_capacity(self.members.len() - 1);
         let length = self.members.len();
         for x in 0..length {
             if x == to_check {
                 continue;
             }
-            health_summary.push(self.health_of(x, to_check));
+            health_summary.push(self.health_of_mlr(x, to_check));
         }
         health_summary
     }
@@ -352,10 +358,17 @@ impl SwimNet {
         }
     }
 
-    pub fn wait_for_health_of(&self, from_entry: usize, to_check: usize, health: Health) -> bool {
+    /// # Locking
+    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
+    ///   lock is held.
+    pub fn wait_for_health_of_mlr(&self,
+                                  from_entry: usize,
+                                  to_check: usize,
+                                  health: Health)
+                                  -> bool {
         let rounds_in = self.rounds_in(self.max_rounds());
         loop {
-            if let Some(real_health) = self.health_of(from_entry, to_check) {
+            if let Some(real_health) = self.health_of_mlr(from_entry, to_check) {
                 if real_health == health {
                     trace_it!(TEST: &self.members[from_entry], format!("Health {} {} as {}", self.members[to_check].name(), self.members[to_check].member_id(), health));
                     return true;
@@ -371,10 +384,13 @@ impl SwimNet {
         }
     }
 
-    pub fn wait_for_network_health_of(&self, to_check: usize, health: Health) -> bool {
+    /// # Locking
+    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
+    ///   lock is held.
+    pub fn wait_for_network_health_of_mlr(&self, to_check: usize, health: Health) -> bool {
         let rounds_in = self.rounds_in(self.max_rounds());
         loop {
-            let network_health = self.network_health_of(to_check);
+            let network_health = self.network_health_of_mlr(to_check);
             if network_health.iter().all(|&x| x == Some(health)) {
                 trace_it!(TEST_NET: self,
                           format!("Health {} {} as {}",
@@ -453,7 +469,7 @@ impl SwimNet {
 #[macro_export]
 macro_rules! assert_health_of {
     ($network:expr, $to:expr, $health:expr) => {
-        assert!($network.network_health_of($to)
+        assert!($network.network_health_of_mlr($to)
                         .into_iter()
                         .all(|x| x == $health),
                 "Member {} does not always have health {}",
@@ -470,7 +486,7 @@ macro_rules! assert_health_of {
 }
 
 #[macro_export]
-macro_rules! assert_wait_for_health_of {
+macro_rules! assert_wait_for_health_of_mlr {
     ($network:expr,[$from:expr, $to:expr], $health:expr) => {
         let left: Vec<usize> = $from.collect();
         let right: Vec<usize> = $to.collect();
@@ -479,12 +495,12 @@ macro_rules! assert_wait_for_health_of {
                 if l == r {
                     continue;
                 }
-                assert!($network.wait_for_health_of(*l, *r, $health),
+                assert!($network.wait_for_health_of_mlr(*l, *r, $health),
                         "Member {} does not see {} as {}",
                         l,
                         r,
                         $health);
-                assert!($network.wait_for_health_of(*r, *l, $health),
+                assert!($network.wait_for_health_of_mlr(*r, *l, $health),
                         "Member {} does not see {} as {}",
                         r,
                         l,
@@ -493,13 +509,13 @@ macro_rules! assert_wait_for_health_of {
         }
     };
     ($network:expr, $to:expr, $health:expr) => {
-        assert!($network.wait_for_network_health_of($to, $health),
+        assert!($network.wait_for_network_health_of_mlr($to, $health),
                 "Member {} does not always have health {}",
                 $to,
                 $health);
     };
     ($network:expr, $from:expr, $to:expr, $health:expr) => {
-        assert!($network.wait_for_health_of($from, $to, $health),
+        assert!($network.wait_for_health_of_mlr($from, $to, $health),
                 "Member {} does not see {} as {}",
                 $from,
                 $to,

--- a/components/butterfly/tests/common/mod.rs
+++ b/components/butterfly/tests/common/mod.rs
@@ -61,7 +61,7 @@ pub fn start_server(name: &str, ring_key: Option<SymKey>, suitability: u64) -> S
                                  Some(String::from(name)),
                                  None,
                                  Box::new(NSuitability(suitability))).unwrap();
-    server.start(Timing::default())
+    server.start_mlr(Timing::default())
           .expect("Cannot start server");
     server
 }

--- a/components/butterfly/tests/common/mod.rs
+++ b/components/butterfly/tests/common/mod.rs
@@ -61,7 +61,7 @@ pub fn start_server(name: &str, ring_key: Option<SymKey>, suitability: u64) -> S
                                  Some(String::from(name)),
                                  None,
                                  Box::new(NSuitability(suitability))).unwrap();
-    server.start_mlr(Timing::default())
+    server.start_mlr(&Timing::default())
           .expect("Cannot start server");
     server
 }

--- a/components/butterfly/tests/encryption/mod.rs
+++ b/components/butterfly/tests/encryption/mod.rs
@@ -9,7 +9,7 @@ fn symmetric_encryption_of_wire_payloads() {
                                                                        memory symkey");
     let mut net = btest::SwimNet::new_ring_encryption(2, &ring_key);
     net.connect(0, 1);
-    assert_wait_for_health_of!(net, [0..2, 0..2], Health::Alive);
+    assert_wait_for_health_of_mlr!(net, [0..2, 0..2], Health::Alive);
     net.add_service(0, "core/beast/1.2.3/20161208121212");
     net.wait_for_gossip_rounds(2);
     assert!(net[1].service_store

--- a/components/butterfly/tests/integration.rs
+++ b/components/butterfly/tests/integration.rs
@@ -12,13 +12,13 @@ use habitat_butterfly::{self,
 fn two_members_meshed_confirm_one_member() {
     let mut net = btest::SwimNet::new(2);
     net.mesh();
-    assert_wait_for_health_of!(net, 0, 1, Health::Alive);
-    assert_wait_for_health_of!(net, 1, 0, Health::Alive);
+    assert_wait_for_health_of_mlr!(net, 0, 1, Health::Alive);
+    assert_wait_for_health_of_mlr!(net, 1, 0, Health::Alive);
 
     trace_it!(TEST: &net[0], "Paused");
     net[0].pause();
-    assert_wait_for_health_of!(net, 1, 0, Health::Suspect);
-    assert_wait_for_health_of!(net, 1, 0, Health::Confirmed);
+    assert_wait_for_health_of_mlr!(net, 1, 0, Health::Suspect);
+    assert_wait_for_health_of_mlr!(net, 1, 0, Health::Confirmed);
 }
 
 #[test]
@@ -27,7 +27,7 @@ fn six_members_meshed_confirm_one_member() {
     net.mesh();
     trace_it!(TEST: &net[0], "Paused");
     net[0].pause();
-    assert_wait_for_health_of!(net, 0, Health::Confirmed);
+    assert_wait_for_health_of_mlr!(net, 0, Health::Confirmed);
 }
 
 #[test]
@@ -37,16 +37,16 @@ fn six_members_meshed_partition_one_node_from_another_node_remains_alive() {
     net.mesh();
     net.block(0, 1);
     net.wait_for_rounds(2);
-    assert_wait_for_health_of!(net, 1, Health::Alive);
+    assert_wait_for_health_of_mlr!(net, 1, Health::Alive);
 }
 
 #[test]
 fn six_members_meshed_partition_half_of_nodes_from_each_other_both_sides_confirmed() {
     let mut net = btest::SwimNet::new(6);
     net.mesh();
-    assert_wait_for_health_of!(net, 0, Health::Alive);
+    assert_wait_for_health_of_mlr!(net, 0, Health::Alive);
     net.partition(0..3, 3..6);
-    assert_wait_for_health_of!(net, [0..3, 3..6], Health::Confirmed);
+    assert_wait_for_health_of_mlr!(net, [0..3, 3..6], Health::Confirmed);
 }
 
 #[test]
@@ -57,7 +57,7 @@ fn six_members_unmeshed_become_fully_meshed_via_gossip() {
     net.connect(2, 3);
     net.connect(3, 4);
     net.connect(4, 5);
-    assert_wait_for_health_of!(net, [0..6, 0..6], Health::Alive);
+    assert_wait_for_health_of_mlr!(net, [0..6, 0..6], Health::Alive);
 }
 
 #[test]
@@ -68,9 +68,9 @@ fn six_members_unmeshed_confirm_one_member() {
     net.connect(2, 3);
     net.connect(3, 4);
     net.connect(4, 5);
-    assert_wait_for_health_of!(net, [0..6, 0..6], Health::Alive);
+    assert_wait_for_health_of_mlr!(net, [0..6, 0..6], Health::Alive);
     net[0].pause();
-    assert_wait_for_health_of!(net, 0, Health::Confirmed);
+    assert_wait_for_health_of_mlr!(net, 0, Health::Confirmed);
 }
 
 #[test]
@@ -81,11 +81,11 @@ fn six_members_unmeshed_partition_and_rejoin_no_persistent_peers() {
     net.connect(2, 3);
     net.connect(3, 4);
     net.connect(4, 5);
-    assert_wait_for_health_of!(net, [0..6, 0..6], Health::Alive);
+    assert_wait_for_health_of_mlr!(net, [0..6, 0..6], Health::Alive);
     net.partition(0..3, 3..6);
-    assert_wait_for_health_of!(net, [0..3, 3..6], Health::Confirmed);
+    assert_wait_for_health_of_mlr!(net, [0..3, 3..6], Health::Confirmed);
     net.unpartition(0..3, 3..6);
-    assert_wait_for_health_of!(net, [0..3, 3..6], Health::Confirmed);
+    assert_wait_for_health_of_mlr!(net, [0..3, 3..6], Health::Confirmed);
 }
 
 #[test]
@@ -104,11 +104,11 @@ fn six_members_unmeshed_partition_and_rejoin_persistent_peers() {
     net.connect(2, 3);
     net.connect(3, 4);
     net.connect(4, 5);
-    assert_wait_for_health_of!(net, [0..6, 0..6], Health::Alive);
+    assert_wait_for_health_of_mlr!(net, [0..6, 0..6], Health::Alive);
     net.partition(0..3, 3..6);
-    assert_wait_for_health_of!(net, [0..3, 3..6], Health::Confirmed);
+    assert_wait_for_health_of_mlr!(net, [0..3, 3..6], Health::Confirmed);
     net.unpartition(0..3, 3..6);
-    assert_wait_for_health_of!(net, [0..3, 3..6], Health::Alive);
+    assert_wait_for_health_of_mlr!(net, [0..3, 3..6], Health::Alive);
 }
 
 #[test]
@@ -119,12 +119,12 @@ fn six_members_unmeshed_allows_graceful_departure() {
     net.connect(2, 3);
     net.connect(3, 4);
     net.connect(4, 5);
-    assert_wait_for_health_of!(net, [0..6, 0..6], Health::Alive);
+    assert_wait_for_health_of_mlr!(net, [0..6, 0..6], Health::Alive);
     trace_it!(TEST: &net[0], "Departing");
     net[0].set_departed_mlw();
     trace_it!(TEST: &net[0], "Paused");
     net[0].pause();
-    assert_wait_for_health_of!(net, 0, Health::Departed);
+    assert_wait_for_health_of_mlr!(net, 0, Health::Departed);
 }
 
 #[test]
@@ -132,5 +132,5 @@ fn ten_members_meshed_confirm_one_member() {
     let mut net = btest::SwimNet::new(10);
     net.mesh();
     net[0].pause();
-    assert_wait_for_health_of!(net, 0, Health::Confirmed);
+    assert_wait_for_health_of_mlr!(net, 0, Health::Confirmed);
 }

--- a/components/butterfly/tests/integration.rs
+++ b/components/butterfly/tests/integration.rs
@@ -121,7 +121,7 @@ fn six_members_unmeshed_allows_graceful_departure() {
     net.connect(4, 5);
     assert_wait_for_health_of!(net, [0..6, 0..6], Health::Alive);
     trace_it!(TEST: &net[0], "Departing");
-    net[0].set_departed();
+    net[0].set_departed_mlw();
     trace_it!(TEST: &net[0], "Paused");
     net[0].pause();
     assert_wait_for_health_of!(net, 0, Health::Departed);

--- a/components/butterfly/tests/rumor/departure.rs
+++ b/components/butterfly/tests/rumor/departure.rs
@@ -27,5 +27,5 @@ fn departure_via_client() {
     net.wait_for_gossip_rounds(1);
     assert!(net[2].departure_store
                   .contains_rumor("departure", net[1].member_id()));
-    assert_wait_for_health_of!(net, 1, Health::Departed);
+    assert_wait_for_health_of_mlr!(net, 1, Health::Departed);
 }

--- a/components/butterfly/tests/rumor/election.rs
+++ b/components/butterfly/tests/rumor/election.rs
@@ -60,7 +60,7 @@ fn five_members_elect_a_new_leader_when_the_old_one_dies() {
     }
     net[paused].pause();
     let paused_id = net[paused].member_id();
-    assert_wait_for_health_of!(net, paused, Health::Confirmed);
+    assert_wait_for_health_of_mlr!(net, paused, Health::Confirmed);
     if paused == 0 {
         net[1].restart_elections_mlr(FeatureFlag::empty());
     } else {
@@ -107,7 +107,7 @@ fn five_members_elect_a_new_leader_when_they_are_quorum_partitioned() {
     net.connect(1, 2);
     net.connect(2, 3);
     net.connect(3, 4);
-    assert_wait_for_health_of!(net, [0..5, 0..5], Health::Alive);
+    assert_wait_for_health_of_mlr!(net, [0..5, 0..5], Health::Alive);
     assert_wait_for_election_status!(net, [0..5], "witcher.prod", ElectionStatus::Finished);
     assert_wait_for_equal_election!(net, [0..5, 0..5], "witcher.prod");
 
@@ -129,7 +129,7 @@ fn five_members_elect_a_new_leader_when_they_are_quorum_partitioned() {
 
     let mut new_leader_id = String::from("");
     net.partition(0..2, 2..5);
-    assert_wait_for_health_of!(net, [0..2, 2..5], Health::Confirmed);
+    assert_wait_for_health_of_mlr!(net, [0..2, 2..5], Health::Confirmed);
     net[0].restart_elections_mlr(FeatureFlag::empty());
     net[4].restart_elections_mlr(FeatureFlag::empty());
     assert_wait_for_election_status!(net, 0, "witcher.prod", ElectionStatus::NoQuorum);
@@ -150,7 +150,7 @@ fn five_members_elect_a_new_leader_when_they_are_quorum_partitioned() {
     assert!(leader_id != new_leader_id);
     println!("Leader {} New {}", leader_id, new_leader_id);
     net.unpartition(0..2, 2..5);
-    assert_wait_for_health_of!(net, [0..5, 0..5], Health::Alive);
+    assert_wait_for_health_of_mlr!(net, [0..5, 0..5], Health::Alive);
     assert_wait_for_election_status!(net, 0, "witcher.prod", ElectionStatus::Finished);
     assert_wait_for_election_status!(net, 1, "witcher.prod", ElectionStatus::Finished);
 

--- a/components/butterfly/tests/rumor/election.rs
+++ b/components/butterfly/tests/rumor/election.rs
@@ -62,9 +62,9 @@ fn five_members_elect_a_new_leader_when_the_old_one_dies() {
     let paused_id = net[paused].member_id();
     assert_wait_for_health_of!(net, paused, Health::Confirmed);
     if paused == 0 {
-        net[1].restart_elections(FeatureFlag::empty());
+        net[1].restart_elections_mlr(FeatureFlag::empty());
     } else {
-        net[0].restart_elections(FeatureFlag::empty());
+        net[0].restart_elections_mlr(FeatureFlag::empty());
     }
 
     for i in 0..5 {
@@ -130,8 +130,8 @@ fn five_members_elect_a_new_leader_when_they_are_quorum_partitioned() {
     let mut new_leader_id = String::from("");
     net.partition(0..2, 2..5);
     assert_wait_for_health_of!(net, [0..2, 2..5], Health::Confirmed);
-    net[0].restart_elections(FeatureFlag::empty());
-    net[4].restart_elections(FeatureFlag::empty());
+    net[0].restart_elections_mlr(FeatureFlag::empty());
+    net[4].restart_elections_mlr(FeatureFlag::empty());
     assert_wait_for_election_status!(net, 0, "witcher.prod", ElectionStatus::NoQuorum);
     assert_wait_for_election_status!(net, 1, "witcher.prod", ElectionStatus::NoQuorum);
     assert_wait_for_election_status!(net, 2, "witcher.prod", ElectionStatus::Finished);

--- a/components/core/src/os/process/windows_child.rs
+++ b/components/core/src/os/process/windows_child.rs
@@ -1133,7 +1133,7 @@ fn null_stdio_handle() -> Result<Handle> {
     Ok(File::open(Path::new("NUL"), &opts).map(File::into_handle)?)
 }
 
-unsafe fn read_to_end_uninitialized(r: &mut Read, buf: &mut Vec<u8>) -> io::Result<usize> {
+unsafe fn read_to_end_uninitialized(r: &mut impl Read, buf: &mut Vec<u8>) -> io::Result<usize> {
     let start_len = buf.len();
     buf.reserve(16);
 

--- a/components/sup/src/census.rs
+++ b/components/sup/src/census.rs
@@ -112,6 +112,10 @@ impl CensusRing {
     ///
     /// (Butterfly provides the health, the ServiceRumors provide the
     /// rest).
+    ///
+    /// # Locking
+    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
+    ///   lock is held.
     fn populate_census(&mut self,
                        service_rumors: &RumorStore<ServiceRumor>,
                        member_list: &MemberList) {
@@ -136,7 +140,7 @@ impl CensusRing {
                           }
                       });
 
-        member_list.with_members(|member| {
+        member_list.with_members_mlr(|member| {
                        let health = member_list.health_of(&member).unwrap();
                        for group in self.census_groups.values_mut() {
                            if let Some(census_member) = group.find_member_mut(&member.id) {

--- a/components/sup/src/census.rs
+++ b/components/sup/src/census.rs
@@ -141,7 +141,8 @@ impl CensusRing {
                       });
 
         member_list.with_members_mlr(|member| {
-                       let health = member_list.health_of(&member).unwrap();
+                       // XXX Recursive lock!
+                       let health = member_list.health_of_mlr(&member).unwrap();
                        for group in self.census_groups.values_mut() {
                            if let Some(census_member) = group.find_member_mut(&member.id) {
                                census_member.update_from_member(&member);

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -759,7 +759,7 @@ impl Manager {
 
         outputln!("Starting gossip-listener on {}",
                   self.butterfly.gossip_addr());
-        self.butterfly.start_mlr(Timing::default())?;
+        self.butterfly.start_mlr(&Timing::default())?;
         debug!("gossip-listener started");
         self.persist_state_mlr();
         let http_listen_addr = self.sys.http_listen();


### PR DESCRIPTION
Since RwLocks can't be both fair and recursive (and recursive locking is very hard to reason about), let's eliminate the recursive locking of the locks in `MemberList`. See the individual commit messages for more explanation.

See https://github.com/habitat-sh/habitat/issues/6435