### PR TITLE
Cleanup lifecycle restarts and remove reload hook

### DIFF
--- a/components/common/src/templating/hooks.rs
+++ b/components/common/src/templating/hooks.rs
@@ -82,6 +82,11 @@ pub trait Hook: fmt::Debug + Sized + Send {
         let has_template = template.exists();
         let has_deprecated_template = deprecated_template.as_ref().map_or(false, |t| t.exists());
 
+        if has_template && file_name == "reload" {
+            outputln!(preamble package_name, "The '{}' hook has been deprecated. You should use the 'reconfigure' hook instead.",
+                file_name);
+        }
+
         let template_to_use = if has_template {
             if has_deprecated_template {
                 outputln!(preamble package_name,

--- a/components/sup/doc/http_gateway_services_schema.json
+++ b/components/sup/doc/http_gateway_services_schema.json
@@ -332,14 +332,6 @@
         ],
         "type": "object"
       },
-      "needs_reconfiguration": {
-        "description": "Does this service need to be reconfigured",
-        "type": "boolean"
-      },
-      "needs_reload": {
-        "description": "Does this service need to be reloaded",
-        "type": "boolean"
-      },
       "pkg": {
         "description": "The habitat package that this service was spawned from",
         "properties": {
@@ -560,8 +552,6 @@
       "initialized",
       "last_election_status",
       "manager_fs_cfg",
-      "needs_reconfiguration",
-      "needs_reload",
       "pkg",
       "process",
       "service_group",

--- a/components/sup/src/manager/service.rs
+++ b/components/sup/src/manager/service.rs
@@ -136,12 +136,12 @@ impl TemplateUpdate {
     }
 
     fn needs_restart(&self) -> bool {
-        self.hooks.run_changed
-        || self.hooks.post_run_changed
+        self.hooks.run_changed()
+        || self.hooks.post_run_changed()
         || (!self.have_reconfigure_hook && self.config_changed)
     }
 
-    fn needs_reconfigure(&self) -> bool { self.config_changed || self.hooks.reconfigure_changed }
+    fn needs_reconfigure(&self) -> bool { self.config_changed || self.hooks.reconfigure_changed() }
 
     fn changed(&self) -> bool { self.hooks.changed() || self.config_changed }
 }

--- a/components/sup/src/manager/service.rs
+++ b/components/sup/src/manager/service.rs
@@ -120,7 +120,7 @@ enum BindStatus<'a> {
     Unknown(Error),
 }
 
-/// Encapsulate changes to /hooks or /config.
+/// Encapsulate changes to `/hooks` and `/config`.
 #[derive(Default)]
 struct TemplateUpdate {
     hooks:                 HookCompileTable,
@@ -135,14 +135,24 @@ impl TemplateUpdate {
                have_reconfigure_hook }
     }
 
+    /// Returns `true` if the service needs to be restarted.
+    ///
+    /// A restart is needed under the following conditions:
+    /// 1. the `run` or `post-run` hooks have changed. A restart is limited to these hooks
+    /// because they are the only hooks that can impact the execution of the service.
+    /// 2. `/config` changed and there is no `reconfigure` hook
     fn needs_restart(&self) -> bool {
         self.hooks.run_changed()
         || self.hooks.post_run_changed()
         || (!self.have_reconfigure_hook && self.config_changed)
     }
 
+    /// Returns `true` if the service needs to be reconfigured.
+    ///
+    /// A reconfigure is needed if `/config` or the `reconfigure` hook changed.
     fn needs_reconfigure(&self) -> bool { self.config_changed || self.hooks.reconfigure_changed() }
 
+    /// Returns `true` if there was a change to `/hooks` or `/config`
     fn changed(&self) -> bool { self.hooks.changed() || self.config_changed }
 }
 

--- a/components/sup/src/manager/service.rs
+++ b/components/sup/src/manager/service.rs
@@ -457,7 +457,7 @@ impl Service {
 
     /// Performs updates and executes hooks.
     ///
-    /// Returns `true` if the service was restarted or reconfigured.
+    /// Returns `true` if the service was marked to be restarted or reconfigured.
     pub fn tick(&mut self,
                 census_ring: &CensusRing,
                 launcher: &LauncherCli,
@@ -926,7 +926,7 @@ impl Service {
         win_perm::harden_path(path.as_ref())
     }
 
-    /// Returns `true` if the service was restarted or reconfigured.
+    /// Returns `true` if the service was marked to be restarted or reconfigured.
     fn execute_hooks(&mut self,
                      launcher: &LauncherCli,
                      executor: &TaskExecutor,

--- a/components/sup/src/manager/service.rs
+++ b/components/sup/src/manager/service.rs
@@ -162,7 +162,9 @@ pub struct Service {
     pub initialized:         bool,
     pub user_config_updated: bool,
     pub shutdown_timeout:    Option<ShutdownTimeout>,
-    pub needs_restart:       bool,
+    // TODO (DM): This flag is a temporary hack to signal to the `Manager` that this service needs
+    // to be restarted. As we continue refactoring lifecycle hooks this flag should be removed.
+    pub needs_restart: bool,
 
     config_renderer: CfgRenderer,
     // Note: This field is really only needed for serializing a

--- a/components/sup/src/manager/service/hooks.rs
+++ b/components/sup/src/manager/service/hooks.rs
@@ -223,49 +223,6 @@ impl Hook for PostRunHook {
 }
 
 #[derive(Debug, Serialize)]
-pub struct ReloadHook {
-    render_pair:     RenderPair,
-    stdout_log_path: PathBuf,
-    stderr_log_path: PathBuf,
-}
-
-impl Hook for ReloadHook {
-    type ExitValue = ExitCode;
-
-    fn file_name() -> &'static str { "reload" }
-
-    fn new(package_name: &str, pair: RenderPair) -> Self {
-        ReloadHook { render_pair:     pair,
-                     stdout_log_path: hooks::stdout_log_path::<Self>(package_name),
-                     stderr_log_path: hooks::stderr_log_path::<Self>(package_name), }
-    }
-
-    fn handle_exit<'a>(&self, pkg: &Pkg, _: &'a HookOutput, status: ExitStatus) -> Self::ExitValue {
-        let pkg_name = &pkg.name;
-        match status.code() {
-            Some(0) => ExitCode(0),
-            Some(code) => {
-                outputln!(preamble pkg_name, "Reload failed! '{}' exited with \
-                    status code {}", Self::file_name(), code);
-                ExitCode(code)
-            }
-            None => {
-                Self::output_termination_message(pkg_name, status);
-                ExitCode::default()
-            }
-        }
-    }
-
-    fn path(&self) -> &Path { &self.render_pair.path }
-
-    fn renderer(&self) -> &TemplateRenderer { &self.render_pair.renderer }
-
-    fn stdout_log_path(&self) -> &Path { &self.stdout_log_path }
-
-    fn stderr_log_path(&self) -> &Path { &self.stderr_log_path }
-}
-
-#[derive(Debug, Serialize)]
 pub struct ReconfigureHook {
     render_pair:     RenderPair,
     stdout_log_path: PathBuf,
@@ -418,6 +375,44 @@ impl Hook for PostStopHook {
     fn stderr_log_path(&self) -> &Path { &self.stderr_log_path }
 }
 
+#[derive(Clone, Copy, Default)]
+pub struct HookChangeTable {
+    pub health_check: bool,
+    pub init:         bool,
+    pub file_updated: bool,
+    pub reconfigure:  bool,
+    pub suitability:  bool,
+    pub run:          bool,
+    pub post_run:     bool,
+    pub post_stop:    bool,
+}
+
+impl HookChangeTable {
+    pub fn new() -> Self { Self::default() }
+
+    pub fn changed(self) -> bool {
+        match self {
+            Self { health_check,
+                   init,
+                   file_updated,
+                   reconfigure,
+                   suitability,
+                   run,
+                   post_run,
+                   post_stop, } => {
+                health_check
+                || init
+                || file_updated
+                || reconfigure
+                || suitability
+                || run
+                || post_run
+                || post_stop
+            }
+        }
+    }
+}
+
 // Hooks wrapped in Arcs represent a possibly-temporary state while we
 // refactor hooks to be able to run asynchronously.
 #[derive(Debug, Default, Serialize)]
@@ -425,7 +420,6 @@ pub struct HookTable {
     pub health_check: Option<Arc<HealthCheckHook>>,
     pub init:         Option<InitHook>,
     pub file_updated: Option<FileUpdatedHook>,
-    pub reload:       Option<ReloadHook>,
     pub reconfigure:  Option<ReconfigureHook>,
     pub suitability:  Option<SuitabilityHook>,
     pub run:          Option<RunHook>,
@@ -447,7 +441,6 @@ impl HookTable {
                     HealthCheckHook::load(package_name, &hooks_path, &templates).map(Arc::new);
                 table.suitability = SuitabilityHook::load(package_name, &hooks_path, &templates);
                 table.init = InitHook::load(package_name, &hooks_path, &templates);
-                table.reload = ReloadHook::load(package_name, &hooks_path, &templates);
                 table.reconfigure = ReconfigureHook::load(package_name, &hooks_path, &templates);
                 table.run = RunHook::load(package_name, &hooks_path, &templates);
                 table.post_run = PostRunHook::load(package_name, &hooks_path, &templates);
@@ -464,39 +457,36 @@ impl HookTable {
 
     /// Compile all loaded hooks from the table into their destination service directory.
     ///
-    /// Returns `true` if compiling any of the hooks resulted in new
-    /// content being written to the hook scripts on disk.
-    pub fn compile<T>(&self, service_group: &str, ctx: &T) -> bool
+    /// Returns a `HookChangeTable` with the hook set to true if compiling the hook resulted
+    /// in new content being written to the hook script on disk.
+    pub fn compile<T>(&self, service_group: &str, ctx: &T) -> HookChangeTable
         where T: Serialize
     {
         debug!("{:?}", self);
-        let mut changed = false;
+        let mut changed = HookChangeTable::new();
         if let Some(ref hook) = self.file_updated {
-            changed |= self.compile_one(hook, service_group, ctx);
+            changed.file_updated = self.compile_one(hook, service_group, ctx);
         }
         if let Some(ref hook) = self.health_check {
-            changed |= self.compile_one(hook.as_ref(), service_group, ctx);
+            changed.health_check = self.compile_one(hook.as_ref(), service_group, ctx);
         }
         if let Some(ref hook) = self.init {
-            changed |= self.compile_one(hook, service_group, ctx);
-        }
-        if let Some(ref hook) = self.reload {
-            changed |= self.compile_one(hook, service_group, ctx);
+            changed.init = self.compile_one(hook, service_group, ctx);
         }
         if let Some(ref hook) = self.reconfigure {
-            changed |= self.compile_one(hook, service_group, ctx);
+            changed.reconfigure = self.compile_one(hook, service_group, ctx);
         }
         if let Some(ref hook) = self.suitability {
-            changed |= self.compile_one(hook, service_group, ctx);
+            changed.suitability = self.compile_one(hook, service_group, ctx);
         }
         if let Some(ref hook) = self.run {
-            changed |= self.compile_one(hook, service_group, ctx);
+            changed.run = self.compile_one(hook, service_group, ctx);
         }
         if let Some(ref hook) = self.post_run {
-            changed |= self.compile_one(hook, service_group, ctx);
+            changed.post_run = self.compile_one(hook, service_group, ctx);
         }
         if let Some(ref hook) = self.post_stop {
-            changed |= self.compile_one(hook.as_ref(), service_group, ctx);
+            changed.post_stop = self.compile_one(hook.as_ref(), service_group, ctx);
         }
         changed
     }
@@ -566,7 +556,6 @@ mod tests {
                       InitHook
                       PostRunHook
                       ReconfigureHook
-                      ReloadHook
                       RunHook
                       SuitabilityHook
                       PostStopHook);
@@ -673,7 +662,7 @@ mod tests {
         ////////////////////////////////////////////////////////////////////////
 
         let hook_table = HookTable::load(&service_group, &template_path, &hooks_path);
-        assert_eq!(hook_table.compile(&service_group, &ctx), true);
+        assert!(hook_table.compile(&service_group, &ctx).changed(), true);
 
         // Verify init hook
         let init_hook_content = file_content(&hook_table.init.as_ref().expect("no init hook??"));
@@ -686,7 +675,7 @@ mod tests {
         assert_eq!(run_hook_content, expected_run_hook);
 
         // Recompiling again results in no changes
-        assert_eq!(hook_table.compile(&service_group, &ctx), false);
+        assert!(!hook_table.compile(&service_group, &ctx).changed());
 
         // Re-Verify init hook
         let init_hook_content = file_content(&hook_table.init.as_ref().expect("no init hook??"));

--- a/components/sup/src/manager/service/hooks.rs
+++ b/components/sup/src/manager/service/hooks.rs
@@ -378,37 +378,43 @@ impl Hook for PostStopHook {
 /// A lookup of hooks that have changed after compilation.
 #[derive(Default)]
 pub struct HookCompileTable {
-    pub health_check_changed: bool,
-    pub init_changed:         bool,
-    pub file_updated_changed: bool,
-    pub reconfigure_changed:  bool,
-    pub suitability_changed:  bool,
-    pub run_changed:          bool,
-    pub post_run_changed:     bool,
-    pub post_stop_changed:    bool,
+    health_check: bool,
+    init:         bool,
+    file_updated: bool,
+    reconfigure:  bool,
+    suitability:  bool,
+    run:          bool,
+    post_run:     bool,
+    post_stop:    bool,
 }
 
 impl HookCompileTable {
     pub fn new() -> Self { Self::default() }
 
+    pub fn reconfigure_changed(&self) -> bool { self.reconfigure }
+
+    pub fn run_changed(&self) -> bool { self.run }
+
+    pub fn post_run_changed(&self) -> bool { self.post_run }
+
     pub fn changed(&self) -> bool {
         match self {
-            Self { health_check_changed,
-                   init_changed,
-                   file_updated_changed,
-                   reconfigure_changed,
-                   suitability_changed,
-                   run_changed,
-                   post_run_changed,
-                   post_stop_changed, } => {
-                *health_check_changed
-                || *init_changed
-                || *file_updated_changed
-                || *reconfigure_changed
-                || *suitability_changed
-                || *run_changed
-                || *post_run_changed
-                || *post_stop_changed
+            Self { health_check,
+                   init,
+                   file_updated,
+                   reconfigure,
+                   suitability,
+                   run,
+                   post_run,
+                   post_stop, } => {
+                *health_check
+                || *init
+                || *file_updated
+                || *reconfigure
+                || *suitability
+                || *run
+                || *post_run
+                || *post_stop
             }
         }
     }
@@ -463,28 +469,28 @@ impl HookTable {
         debug!("{:?}", self);
         let mut changed = HookCompileTable::new();
         if let Some(ref hook) = self.file_updated {
-            changed.file_updated_changed = self.compile_one(hook, service_group, ctx);
+            changed.file_updated = self.compile_one(hook, service_group, ctx);
         }
         if let Some(ref hook) = self.health_check {
-            changed.health_check_changed = self.compile_one(hook.as_ref(), service_group, ctx);
+            changed.health_check = self.compile_one(hook.as_ref(), service_group, ctx);
         }
         if let Some(ref hook) = self.init {
-            changed.init_changed = self.compile_one(hook, service_group, ctx);
+            changed.init = self.compile_one(hook, service_group, ctx);
         }
         if let Some(ref hook) = self.reconfigure {
-            changed.reconfigure_changed = self.compile_one(hook, service_group, ctx);
+            changed.reconfigure = self.compile_one(hook, service_group, ctx);
         }
         if let Some(ref hook) = self.suitability {
-            changed.suitability_changed = self.compile_one(hook, service_group, ctx);
+            changed.suitability = self.compile_one(hook, service_group, ctx);
         }
         if let Some(ref hook) = self.run {
-            changed.run_changed = self.compile_one(hook, service_group, ctx);
+            changed.run = self.compile_one(hook, service_group, ctx);
         }
         if let Some(ref hook) = self.post_run {
-            changed.post_run_changed = self.compile_one(hook, service_group, ctx);
+            changed.post_run = self.compile_one(hook, service_group, ctx);
         }
         if let Some(ref hook) = self.post_stop {
-            changed.post_stop_changed = self.compile_one(hook.as_ref(), service_group, ctx);
+            changed.post_stop = self.compile_one(hook.as_ref(), service_group, ctx);
         }
         changed
     }

--- a/components/sup/src/manager/service/supervisor.rs
+++ b/components/sup/src/manager/service/supervisor.rs
@@ -207,32 +207,6 @@ impl Supervisor {
         }
     }
 
-    pub fn restart(&mut self,
-                   pkg: &Pkg,
-                   group: &ServiceGroup,
-                   launcher: &LauncherCli,
-                   svc_password: Option<&str>)
-                   -> Result<()> {
-        match self.pid {
-            Some(pid) => {
-                match launcher.restart(pid) {
-                    Ok(pid) => {
-                        self.pid = Some(pid);
-                        self.create_pidfile()?;
-                        self.change_state(ProcessState::Up);
-                        Ok(())
-                    }
-                    Err(err) => {
-                        self.cleanup_pidfile();
-                        self.change_state(ProcessState::Down);
-                        Err(Error::Launcher(err))
-                    }
-                }
-            }
-            None => self.start(pkg, group, launcher, svc_password),
-        }
-    }
-
     /// Create a PID file for a running service
     fn create_pidfile(&self) -> Result<()> {
         match self.pid {

--- a/components/sup/tests/fixtures/http-gateway/sample-services-with-cfg-output.json
+++ b/components/sup/tests/fixtures/http-gateway/sample-services-with-cfg-output.json
@@ -85,8 +85,6 @@
       "specs_path": "/hab/sup/default/specs",
       "sup_root": "/hab/sup/default"
     },
-    "needs_reconfiguration": false,
-    "needs_reload": false,
     "pkg": {
       "deps": [
         {

--- a/components/sup/tests/fixtures/http-gateway/sample-services-without-cfg-output.json
+++ b/components/sup/tests/fixtures/http-gateway/sample-services-without-cfg-output.json
@@ -41,8 +41,6 @@
       "specs_path": "/hab/sup/default/specs",
       "sup_root": "/hab/sup/default"
     },
-    "needs_reconfiguration": false,
-    "needs_reload": false,
     "pkg": {
       "deps": [
         {

--- a/www/source/partials/docs/_reference-hooks.html.md.erb
+++ b/www/source/partials/docs/_reference-hooks.html.md.erb
@@ -80,11 +80,11 @@ An `install` hook, unlike other hooks, will not have access to any census data e
 ###reconfigure
 File location: `<plan>/hooks/reconfigure`
 
-A `reconfigure` hook can be written for processes that can respond to changes in `<plan>/config` without requiring a restart. This hook will execute **instead** of the default behaviour of restarting the process. `{{pkg.svc_pid_file}}` can be used to get a handle on the `PID` of the service.
+A `reconfigure` hook can be written for services that can respond to changes in `<plan>/config` without requiring a restart. This hook will execute **instead** of the default behavior of restarting the process. `{{pkg.svc_pid_file}}` can be used to get the `PID` of the service.
 
-The `reconfigure` hook is not necessarily run on every change to `<plan>/config`. The `reconfigure` hook will not be run if the service restarts before the `reconfigure` hook has run. The restart is considered sufficient for reconfiguring the service. For example, when applying a configuration that changes both the `run` hook and `<plan>/config`, the change to the `run` hook will trigger a restart and therefore the `reconfigure` hook will not be run. 
+Habitat does not support changing the `PID` of the underlying service in any lifecycle hook. If part of a service's reconfiguration relies on changing the `PID`, you should not provide a `reconfigure` hook, and instead, use the default behavior of restarting the service for reconfiguration.
 
-Habitat does not support changing the `PID` of the underlying process in any lifecycle hook. If part of a service's reconfiguration relies on changing the `PID`, you should not provide a `reconfigure` hook and rely on the default behaviour of restarting the service.
+The `reconfigure` hook is not necessarily run on every change to `<plan>/config`. The `reconfigure` hook will not be run if the service restarts before the `reconfigure` hook has run. The restart is considered sufficient for reconfiguring the service. For example, when applying a configuration that changes both the `run` hook and `<plan>/config`, the change to the `run` hook will trigger a restart. Therefore, the `reconfigure` hook will not be run. To put it another way, the `reconfigure` hook will only respond to changes in `<plan>/config` after the service has started.
 
 ###suitability
 File location: `<plan>/hooks/suitability`

--- a/www/source/partials/docs/_reference-hooks.html.md.erb
+++ b/www/source/partials/docs/_reference-hooks.html.md.erb
@@ -3,6 +3,8 @@ Each plan can specify lifecycle event handlers, or hooks, to perform certain act
 
 To define a hook, simply create a bash file of the same name in `/my_plan_name/hooks/`, for example, `/postgresql/hooks/health-check`.
 
+When applying a new configuration, modification to the `run` or `post-run` hooks will restart the service.
+
 > **Important** You cannot block the thread in a hook unless it is in the `run` hook. Never call `hab` or `sleep` in a hook that is not the `run` hook.
 
 # Related article: Runtime settings
@@ -15,7 +17,6 @@ To define a hook, simply create a bash file of the same name in `/my_plan_name/h
 * [health-check](#health-check)
 * [init](#init)
 * [install](#install)
-* [reload](#reload)
 * [reconfigure](#reconfigure)
 * [suitability](#suitability)
 * [run](#run)
@@ -30,7 +31,7 @@ This hook is run whenever a configuration file that is not related to a user or 
 ###health-check
 File location: `<plan>/hooks/health-check`
 
-This hook is run when the Chef Habitat HTTP API receives a request at `/health`.
+This hook is run periodically on a configurable interval.
 
 The `health-check` script must return a valid exit code from the list below.
 
@@ -76,15 +77,14 @@ The exit code returned from an `install` hook will be "remembered". If a previou
 
 An `install` hook, unlike other hooks, will not have access to any census data exposed via binds or the `svc` namespace. Also, configuration in `svc_config_path` is not accesible to an `install` hook. If an `install` hook needs to utilize templated configuration files, templates located in the `svc_config_install_path` may be referenced. This location will contain rendered templates in a package's `config_install` folder. Finally, any configuration updates made during a service's runtime that would alter an `install` hook or any configuration template in `svc_config_install_path` will not cause a service to reload.
 
-###reload
-File location: `<plan>/hooks/reload`
-
-For processes that can update their configuration without requiring a restart a `reload` hook can be written. This hook will execute instead of the default behaviour of restarting the process. `{{pkg.svc_pid_file}}` can be used to get a handle on the `PID` of the service.
-
 ###reconfigure
 File location: `<plan>/hooks/reconfigure`
 
-This hook is run when service configuration has changed due to updates coming from the gossip protocol or from the `user.toml` file. Before the `reconfigure` hook the config files are re-rendered and the process is either restarted or the `reload` hook is called if present.
+A `reconfigure` hook can be written for processes that can respond to changes in `<plan>/config` without requiring a restart. This hook will execute **instead** of the default behaviour of restarting the process. `{{pkg.svc_pid_file}}` can be used to get a handle on the `PID` of the service.
+
+The `reconfigure` hook is not necessarily run on every change to `<plan>/config`. The `reconfigure` hook will not be run if the service restarts before the `reconfigure` hook has run. The restart is considered sufficient for reconfiguring the service. For example, when applying a configuration that changes both the `run` hook and `<plan>/config`, the change to the `run` hook will trigger a restart and therefore the `reconfigure` hook will not be run. 
+
+Habitat does not support changing the `PID` of the underlying process in any lifecycle hook. If part of a service's reconfiguration relies on changing the `PID`, you should not provide a `reconfigure` hook and rely on the default behaviour of restarting the service.
 
 ###suitability
 File location: `<plan>/hooks/suitability`


### PR DESCRIPTION
Resolves #1838  #5305 #5306 #5307

The following issues must be addressed before merging:
- [ ] The two TODOs in the code
- [ ] Document the change
- [ ] Update core plans to reflect the change to the `reload` hook

Signed-off-by: David McNeil <mcneil.david2@gmail.com>