### PR TITLE
fix cargo check in windows build script

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -113,7 +113,12 @@ function Invoke-Build([string]$Path, [switch]$Clean, [string]$Command, [switch]$
         "build" {
             Install-Rustup $toolchain
             Install-RustToolchain $toolchain
-            rustup component add --toolchain $Toolchain rustfmt
+            Setup-Environment
+            Invoke-Expression "cargo +$ToolChain $Command $(if ($Release) { '--release' }) $FeatureString"
+        }
+        "check" {
+            Install-Rustup $toolchain
+            Install-RustToolchain $toolchain
             Setup-Environment
             Invoke-Expression "cargo +$ToolChain $Command $(if ($Release) { '--release' }) $FeatureString"
         }


### PR DESCRIPTION
This broke in a recent change to build.ps1 where `check` was inadvertently removed.

Signed-off-by: mwrock <matt@mattwrock.com>